### PR TITLE
test: add network with only pruned nodes

### DIFF
--- a/integration_tests/features/Sync.feature
+++ b/integration_tests/features/Sync.feature
@@ -127,3 +127,19 @@ Feature: Block Sync
     Examples:
       | X1   | Y1 | SYNC_TIME |
       | 1000 | 50 | 60        |
+
+Scenario: Pruned mode network only
+    Given I have a base node NODE1 connected to all seed nodes
+    Given I have a pruned node PNODE1 connected to node NODE1 with pruning horizon set to 5
+    Given I have a pruned node PNODE2 connected to node PNODE1 with pruning horizon set to 5
+    When I mine a block on PNODE1 with coinbase CB1
+    When I mine 2 blocks on PNODE1
+    When I create a transaction TX1 spending CB1 to UTX1
+    When I submit transaction TX1 to PNODE1
+    When I mine 1 blocks on PNODE1
+    Then TX1 is in the MINED of all nodes
+    When I stop node NODE1
+    When I mine 16 blocks on PNODE1
+    Then node PNODE2 is at height 20
+    Given I have a pruned node PNODE3 connected to node PNODE1 with pruning horizon set to 5
+    Then node PNODE3 is at height 20


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This adds a cucumber test proving that a prune-only network can run and function.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It should be possible to run a network with only prune nodes and let prune nodes sync. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I have squashed my commits into a single commit.
