### PR TITLE
fix: bug that causes non p2p apps to panic on startup

### DIFF
--- a/common/src/configuration/global.rs
+++ b/common/src/configuration/global.rs
@@ -762,9 +762,17 @@ where
 
 fn network_transport_config(
     cfg: &Config,
-    application: ApplicationType,
+    mut application: ApplicationType,
     network: &str,
 ) -> Result<CommsTransport, ConfigurationError> {
+    const P2P_APPS: &[ApplicationType] = &[ApplicationType::BaseNode, ApplicationType::ConsoleWallet];
+    if !P2P_APPS.contains(&application) {
+        // TODO: If/when we split the configs by app, this hack can be removed
+        //       This removed the need to setup defaults for apps that dont use the network,
+        //       assuming base node has been set up
+        application = ApplicationType::BaseNode;
+    }
+
     let get_conf_str = |key| {
         cfg.get_str(key)
             .map_err(|err| ConfigurationError::new(key, &err.to_string()))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Exclude non p2p apps from needing comms configuration

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Bug fix

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Merge mining proxy and standalone miner starts successfully

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I have squashed my commits into a single commit.
