### PR TITLE
fix: update transaction and block validator to use full deleted map

### DIFF
--- a/applications/tari_base_node/src/command_handler.rs
+++ b/applications/tari_base_node/src/command_handler.rs
@@ -304,7 +304,7 @@ impl CommandHandler {
                 Ok(mut data) => match data.pop() {
                     Some(v) => println!("{}", v.block()),
                     _ => println!(
-                        "Pruned node: utxo found, but lock not found for utxo commitment {}",
+                        "Pruned node: utxo found, but block not found for utxo commitment {}",
                         commitment.to_hex()
                     ),
                 },

--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -362,7 +362,13 @@ where T: BlockchainBackend + 'static
                     .await?
                     .into_iter()
                     .map(|tx| Arc::try_unwrap(tx).unwrap_or_else(|tx| (*tx).clone()))
-                    .collect();
+                    .collect::<Vec<_>>();
+
+                debug!(
+                    target: LOG_TARGET,
+                    "Adding {} transaction(s) to new block template",
+                    transactions.len()
+                );
 
                 let prev_hash = header.prev_hash.clone();
                 let height = header.height;

--- a/base_layer/core/src/chain_storage/async_db.rs
+++ b/base_layer/core/src/chain_storage/async_db.rs
@@ -32,6 +32,7 @@ use crate::{
         ChainHeader,
         ChainStorageError,
         DbTransaction,
+        DeletedBitmap,
         HistoricalBlock,
         HorizonData,
         MmrTree,
@@ -215,6 +216,8 @@ impl<B: BlockchainBackend + 'static> AsyncBlockchainDb<B> {
     make_async_fn!(fetch_block_accumulated_data_by_height(height: u64) -> BlockAccumulatedData, "fetch_block_accumulated_data_by_height");
 
     //---------------------------------- Misc. --------------------------------------------//
+    make_async_fn!(fetch_deleted_bitmap() -> DeletedBitmap, "fetch_deleted_bitmap");
+
     make_async_fn!(fetch_block_timestamps(start_hash: HashOutput) -> RollingVec<EpochTime>, "fetch_block_timestamps");
 
     make_async_fn!(fetch_target_difficulty_for_next_block(pow_algo: PowAlgorithm, current_block_hash: HashOutput) -> TargetDifficultyWindow, "fetch_target_difficulty");

--- a/base_layer/core/src/chain_storage/error.rs
+++ b/base_layer/core/src/chain_storage/error.rs
@@ -85,8 +85,8 @@ pub enum ChainStorageError {
     },
     #[error("The MMR root for {0} in the provided block header did not match the MMR root in the database")]
     MismatchedMmrRoot(MmrTree),
-    #[error("An invalid block was submitted to the database")]
-    InvalidBlock,
+    #[error("An invalid block was submitted to the database: {0}")]
+    InvalidBlock(String),
     #[error("Blocking task spawn error: {0}")]
     BlockingTaskSpawnError(String),
     #[error("A request was out of range")]

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -1755,7 +1755,6 @@ impl BlockchainBackend for LMDBDatabase {
 
     fn kernel_count(&self) -> Result<usize, ChainStorageError> {
         let txn = self.read_transaction()?;
-
         lmdb_len(&txn, &self.kernels_db)
     }
 

--- a/base_layer/core/src/chain_storage/pruned_output.rs
+++ b/base_layer/core/src/chain_storage/pruned_output.rs
@@ -31,6 +31,7 @@ pub enum PrunedOutput {
         output: TransactionOutput,
     },
 }
+
 impl PrunedOutput {
     pub fn is_pruned(&self) -> bool {
         matches!(self, PrunedOutput::Pruned { .. })

--- a/base_layer/core/src/validation/block_validators.rs
+++ b/base_layer/core/src/validation/block_validators.rs
@@ -22,7 +22,7 @@
 use crate::{
     blocks::{Block, BlockValidationError},
     chain_storage,
-    chain_storage::{BlockchainBackend, ChainBlock, MmrTree},
+    chain_storage::{BlockchainBackend, ChainBlock, DeletedBitmap, MmrTree},
     consensus::ConsensusManager,
     transactions::{
         aggregated_body::AggregateBody,
@@ -39,6 +39,7 @@ use crate::{
 };
 use log::*;
 use std::marker::PhantomData;
+use tari_common_types::chain_metadata::ChainMetadata;
 use tari_crypto::{
     commitment::HomomorphicCommitmentFactory,
     tari_utilities::{hash::Hashable, hex::Hex},
@@ -124,10 +125,29 @@ impl<B: BlockchainBackend> PostOrphanBodyValidation<B> for BodyOnlyValidator {
     /// 1. Are all inputs currently in the UTXO set?
     /// 1. Are all inputs and outputs not in the STXO set?
     /// 1. Are the block header MMR roots valid?
-    fn validate_body_for_valid_orphan(&self, block: &ChainBlock, backend: &B) -> Result<(), ValidationError> {
+    fn validate_body_for_valid_orphan(
+        &self,
+        block: &ChainBlock,
+        backend: &B,
+        metadata: &ChainMetadata,
+        deleted_bitmap: &DeletedBitmap,
+    ) -> Result<(), ValidationError> {
+        if block.header().height != metadata.height_of_longest_chain() + 1 {
+            return Err(ValidationError::IncorrectNextTipHeight {
+                expected: metadata.height_of_longest_chain() + 1,
+                block_height: block.height(),
+            });
+        }
+        if block.header().prev_hash != *metadata.best_block() {
+            return Err(ValidationError::IncorrectPreviousHash {
+                expected: metadata.best_block().to_hex(),
+                block_hash: block.hash().to_hex(),
+            });
+        }
+
         let block_id = format!("block #{} ({})", block.header().height, block.hash().to_hex());
-        check_inputs_are_utxos(&block.block(), backend)?;
-        check_not_duplicate_txos(&block.block(), backend)?;
+        check_inputs_are_utxos(block.block(), backend, deleted_bitmap)?;
+        check_not_duplicate_txos(block.block(), backend)?;
         trace!(
             target: LOG_TARGET,
             "Block validation: All inputs and outputs are valid for {}",
@@ -157,14 +177,14 @@ fn check_sorting_and_duplicates(body: &AggregateBody) -> Result<(), ValidationEr
 }
 
 /// This function checks that all inputs in the blocks are valid UTXO's to be spend
-fn check_inputs_are_utxos<B: BlockchainBackend>(block: &Block, db: &B) -> Result<(), ValidationError> {
-    let data = db
-        .fetch_block_accumulated_data(&block.header.prev_hash)?
-        .ok_or(ValidationError::PreviousHashNotFound)?;
-
+fn check_inputs_are_utxos<B: BlockchainBackend>(
+    block: &Block,
+    db: &B,
+    deleted: &DeletedBitmap,
+) -> Result<(), ValidationError> {
     for input in block.body.inputs() {
         if let Some((_, index, _height)) = db.fetch_output(&input.output_hash())? {
-            if data.deleted().contains(index) {
+            if deleted.bitmap().contains(index) {
                 warn!(
                     target: LOG_TARGET,
                     "Block validation failed due to already spent input: {}", input

--- a/base_layer/core/src/validation/error.rs
+++ b/base_layer/core/src/validation/error.rs
@@ -81,6 +81,10 @@ pub enum ValidationError {
     MaxTransactionWeightExceeded,
     #[error("End of time: {0}")]
     EndOfTimeError(String),
+    #[error("Expected block height to be {expected}, but was {block_height}")]
+    IncorrectNextTipHeight { expected: u64, block_height: u64 },
+    #[error("Expected block previous hash to be {expected}, but was {block_hash}")]
+    IncorrectPreviousHash { expected: String, block_hash: String },
 }
 
 // ChainStorageError has a ValidationError variant, so to prevent a cyclic dependency we use a string representation in

--- a/base_layer/core/src/validation/mocks.rs
+++ b/base_layer/core/src/validation/mocks.rs
@@ -22,7 +22,7 @@
 
 use crate::{
     blocks::{Block, BlockHeader},
-    chain_storage::{BlockchainBackend, ChainBlock},
+    chain_storage::{BlockchainBackend, ChainBlock, DeletedBitmap},
     proof_of_work::{sha3_difficulty, AchievedTargetDifficulty, Difficulty, PowAlgorithm},
     transactions::{transaction::Transaction, types::Commitment},
     validation::{
@@ -40,6 +40,7 @@ use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc,
 };
+use tari_common_types::chain_metadata::ChainMetadata;
 
 #[derive(Clone)]
 pub struct MockValidator {
@@ -79,7 +80,13 @@ impl<B: BlockchainBackend> CandidateBlockBodyValidation<B> for MockValidator {
 }
 
 impl<B: BlockchainBackend> PostOrphanBodyValidation<B> for MockValidator {
-    fn validate_body_for_valid_orphan(&self, _item: &ChainBlock, _db: &B) -> Result<(), ValidationError> {
+    fn validate_body_for_valid_orphan(
+        &self,
+        _: &ChainBlock,
+        _: &B,
+        _: &ChainMetadata,
+        _: &DeletedBitmap,
+    ) -> Result<(), ValidationError> {
         if self.is_valid.load(Ordering::SeqCst) {
             Ok(())
         } else {

--- a/base_layer/core/src/validation/traits.rs
+++ b/base_layer/core/src/validation/traits.rs
@@ -22,11 +22,12 @@
 
 use crate::{
     blocks::{Block, BlockHeader},
-    chain_storage::{BlockchainBackend, ChainBlock},
+    chain_storage::{BlockchainBackend, ChainBlock, DeletedBitmap},
     proof_of_work::AchievedTargetDifficulty,
     transactions::{transaction::Transaction, types::Commitment},
     validation::{error::ValidationError, DifficultyCalculator},
 };
+use tari_common_types::chain_metadata::ChainMetadata;
 
 /// A validator that determines if a block body is valid, assuming that the header has already been
 /// validated
@@ -36,7 +37,13 @@ pub trait CandidateBlockBodyValidation<B: BlockchainBackend>: Send + Sync {
 
 /// A validator that validates a body after it has been determined to be a valid orphan
 pub trait PostOrphanBodyValidation<B>: Send + Sync {
-    fn validate_body_for_valid_orphan(&self, block: &ChainBlock, backend: &B) -> Result<(), ValidationError>;
+    fn validate_body_for_valid_orphan(
+        &self,
+        block: &ChainBlock,
+        backend: &B,
+        metadata: &ChainMetadata,
+        deleted_bitmap: &DeletedBitmap,
+    ) -> Result<(), ValidationError>;
 }
 
 pub trait MempoolTransactionValidation: Send + Sync {

--- a/base_layer/core/tests/helpers/block_builders.rs
+++ b/base_layer/core/tests/helpers/block_builders.rs
@@ -289,6 +289,7 @@ pub fn chain_block_with_new_coinbase(
         height + consensus_manager.consensus_constants(0).coinbase_lock_height(),
     );
     let mut header = BlockHeader::from_previous(&prev_block.header());
+    header.height = height;
     header.version = consensus_manager
         .consensus_constants(header.height)
         .blockchain_version();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Prevent double spends from being added to the mempool. This bug
was introduced by the blockchain deleted bitmap storage changes
in #3109. A new block template contained already spent transactions
which would then fail a double spend check in `calculate_mmr_roots`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes:
```
"Chain storage error: You tried to execute an invalid Database operation: Could not delete index 141535 from the output MMR (length is 94741)" 
```

This error incorrectly attributes the failed deletion to an index that is larger than the total length. 
There are two corrections in this PR:
1. `output_mmr.len() != output_mmr.get_leaf_count()` - length is the number of remaining  unspent txos (`leaf_count - cardinality(deleted_bitmap)`).
2. The delete also can fail if the index is already added. The correct error is emitted in this case.

Expect to see many occurrences of ` WARN  Validation failed due to already spent output` in logs until double spends are cleared

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Archival Sync current chain 
Mining non-empty blocks.
Cucumber tests pass (in 
progress)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I have squashed my commits into a single commit.
