### PR TITLE
fix: fix prune mode sync

### DIFF
--- a/base_layer/core/src/chain_storage/accumulated_data.rs
+++ b/base_layer/core/src/chain_storage/accumulated_data.rs
@@ -205,6 +205,32 @@ impl<'de> Visitor<'de> for DeletedBitmapVisitor {
     }
 }
 
+/// Wrapper struct to get a completed bitmap with the height it was created at
+#[derive(Debug, Clone)]
+pub struct CompleteDeletedBitmap {
+    deleted: Bitmap,
+    height: u64,
+    hash: HashOutput,
+}
+
+impl CompleteDeletedBitmap {
+    pub fn new(deleted: Bitmap, height: u64, hash: HashOutput) -> CompleteDeletedBitmap {
+        CompleteDeletedBitmap { deleted, height, hash }
+    }
+
+    pub fn into_bitmap(self) -> Bitmap {
+        self.deleted
+    }
+
+    pub fn bitmap(&self) -> &Bitmap {
+        &self.deleted
+    }
+
+    pub fn dissolve(self) -> (Bitmap, u64, HashOutput) {
+        (self.deleted, self.height, self.hash)
+    }
+}
+
 pub struct BlockHeaderAccumulatedDataBuilder<'a> {
     previous_accum: &'a BlockHeaderAccumulatedData,
     hash: Option<HashOutput>,

--- a/base_layer/core/src/chain_storage/async_db.rs
+++ b/base_layer/core/src/chain_storage/async_db.rs
@@ -31,8 +31,8 @@ use crate::{
         ChainBlock,
         ChainHeader,
         ChainStorageError,
+        CompleteDeletedBitmap,
         DbTransaction,
-        DeletedBitmap,
         HistoricalBlock,
         HorizonData,
         MmrTree,
@@ -143,7 +143,7 @@ impl<B: BlockchainBackend + 'static> AsyncBlockchainDb<B> {
 
     make_async_fn!(fetch_utxos(hashes: Vec<HashOutput>) -> Vec<Option<(TransactionOutput, bool)>>, "fetch_utxos");
 
-    make_async_fn!(fetch_utxos_by_mmr_position(start: u64, end: u64, end_header_hash: HashOutput) -> (Vec<PrunedOutput>, Bitmap), "fetch_utxos_by_mmr_position");
+    make_async_fn!(fetch_utxos_by_mmr_position(start: u64, end: u64, deleted: Arc<Bitmap>) -> (Vec<PrunedOutput>, Bitmap), "fetch_utxos_by_mmr_position");
 
     //---------------------------------- Kernel --------------------------------------------//
     make_async_fn!(fetch_kernel_by_excess_sig(excess_sig: Signature) -> Option<(TransactionKernel, HashOutput)>, "fetch_kernel_by_excess_sig");
@@ -216,7 +216,6 @@ impl<B: BlockchainBackend + 'static> AsyncBlockchainDb<B> {
     make_async_fn!(fetch_block_accumulated_data_by_height(height: u64) -> BlockAccumulatedData, "fetch_block_accumulated_data_by_height");
 
     //---------------------------------- Misc. --------------------------------------------//
-    make_async_fn!(fetch_deleted_bitmap() -> DeletedBitmap, "fetch_deleted_bitmap");
 
     make_async_fn!(fetch_block_timestamps(start_hash: HashOutput) -> RollingVec<EpochTime>, "fetch_block_timestamps");
 
@@ -225,6 +224,8 @@ impl<B: BlockchainBackend + 'static> AsyncBlockchainDb<B> {
     make_async_fn!(fetch_target_difficulties_for_next_block(current_block_hash: HashOutput) -> TargetDifficulties, "fetch_target_difficulties_for_next_block");
 
     make_async_fn!(fetch_block_hashes_from_header_tip(n: usize, offset: usize) -> Vec<HashOutput>, "fetch_block_hashes_from_header_tip");
+
+    make_async_fn!(fetch_complete_deleted_bitmap_at(hash: HashOutput) -> CompleteDeletedBitmap, "fetch_deleted_bitmap");
 }
 
 impl<B: BlockchainBackend + 'static> From<BlockchainDatabase<B>> for AsyncBlockchainDb<B> {

--- a/base_layer/core/src/chain_storage/mod.rs
+++ b/base_layer/core/src/chain_storage/mod.rs
@@ -36,6 +36,7 @@ pub use accumulated_data::{
     BlockHeaderAccumulatedDataBuilder,
     ChainBlock,
     ChainHeader,
+    CompleteDeletedBitmap,
     DeletedBitmap,
 };
 

--- a/integration_tests/features/Sync.feature
+++ b/integration_tests/features/Sync.feature
@@ -86,8 +86,9 @@ Feature: Block Sync
     Then all nodes are on the same chain at height 1505
 
   @critical
-  Scenario: Pruned mode
+  Scenario: Pruned mode sync test
     # TODO: Merge steps into single lines
+    Given I have a seed node SEED
     Given I have a base node NODE1 connected to all seed nodes
     When I mine a block on NODE1 with coinbase CB1
     When I mine a block on NODE1 with coinbase CB2
@@ -96,14 +97,9 @@ Feature: Block Sync
     When I mine a block on NODE1 with coinbase CB5
     Then all nodes are at height 5
     When I spend outputs CB1 via NODE1
-    #      When I spend outputs CB2 via NODE1
-    #      When I spend outputs CB3 via NODE1
     And I mine 3 blocks on NODE1
     Given I have a pruned node PNODE2 connected to node NODE1 with pruning horizon set to 5
     Then all nodes are at height 8
-    # Spend txns so that they are pruned when tip moves
-    #      When I spend outputs CB4 via PNODE2
-    #      When I spend outputs CB5 via PNODE2
     When I mine 15 blocks on PNODE2
     Then all nodes are at height 23
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This fixes prune mode sync to work again after the bitmap change. The bitmap saved in the accumulated block data is not the completed bitmap anymore but rather the diff for that block. This means when a bitmap is required to know what the spent state of the utxo set is, we need to build a new bitmap rather than ask the accumulated block data like we used to do. 

This PR lets the blockchain_database send a completed bitmap from the tip out, that can be used to reconstruct a bitmap at the desired height. 


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I have squashed my commits into a single commit.
