### PR TITLE
fix: update LibWallet `wallet_import_utxo` method to include valid TariScript

### DIFF
--- a/integration_tests/features/WalletTransactions.feature
+++ b/integration_tests/features/WalletTransactions.feature
@@ -116,7 +116,31 @@ Feature: Wallet Transactions
     Then I wait for wallet WALLET_IMPORTED to have less than 1 uT
     Then I check if last imported transactions are invalid in wallet WALLET_IMPORTED
 
-Scenario: Wallet should display all transactions made
+    @critical
+    Scenario: Wallet imports faucet UTXO
+      Given I have a seed node NODE
+      And I have 1 base nodes connected to all seed nodes
+      And I have wallet WALLET_A connected to all seed nodes
+      And I have a merge mining proxy PROXY connected to NODE and WALLET_A with default config
+      When I merge mine 5 blocks via PROXY
+      Then all nodes are at height 5
+      Then I wait for wallet WALLET_A to have at least 10000000000 uT
+      When I have wallet WALLET_B connected to all seed nodes
+      And I send 1000000 uT from wallet WALLET_A to wallet WALLET_B at fee 100
+      When I merge mine 5 blocks via PROXY
+      Then all nodes are at height 10
+      Then I wait for wallet WALLET_B to have at least 1000000 uT
+      Then I stop wallet WALLET_B
+      When I have wallet WALLET_C connected to all seed nodes
+      Then I import WALLET_B unspent outputs as faucet outputs to WALLET_C
+      Then I wait for wallet WALLET_C to have at least 1000000 uT
+      And I send 500000 uT from wallet WALLET_C to wallet WALLET_A at fee 100
+      Then wallet WALLET_C detects all transactions are at least Broadcast
+      When I merge mine 5 blocks via PROXY
+      Then all nodes are at height 15
+      Then I wait for wallet WALLET_C to have at least 400000 uT
+
+  Scenario: Wallet should display all transactions made
     Given I have a seed node NODE
     And I have 1 base nodes connected to all seed nodes
     And I have wallet WALLET_A connected to all seed nodes

--- a/integration_tests/features/support/steps.js
+++ b/integration_tests/features/support/steps.js
@@ -454,6 +454,20 @@ When(
 );
 
 When(
+  /I import (.*) unspent outputs as faucet outputs to (.*)/,
+  async function (walletNameA, walletNameB) {
+    let walletA = this.getWallet(walletNameA);
+    let walletB = this.getWallet(walletNameB);
+    let clientB = walletB.getClient();
+
+    await walletA.exportUnspentOutputs();
+    let outputs = await walletA.readExportedOutputsAsFaucetOutputs();
+    let result = await clientB.importUtxos(outputs);
+    lastResult = result.tx_ids;
+  }
+);
+
+When(
   /I check if last imported transactions are invalid in wallet (.*)/,
   async function (walletName) {
     let wallet = this.getWallet(walletName);


### PR DESCRIPTION
## Description
The `wallet_import_utxo` FFI function in LibWallet just used defaults for a number of the new UTXO fields when importing a faucet UTXO. The Faucet UTXO provided by the client is just the spending key and amount. The `metadata_signature` and `sender_offset_public_key` can both remain as default values as they are not used in spending an UTXO.  A Nop script is assumed and the spending key is used as the `script_private_key`. The final update is that the `input_data` it set as the public key of the spending key.

To test that the base node is happy for an UTXO imported in this way to be spent a Cucumber test is provided which imports a UTXO into a wallet and zeroes out the `metadata_signature` and`sender_offset_public_key` and updates the `input_data` and `script_private_key` in the same way as described above. This imported Faucet utxo is then successfully spent to another wallet.

## How Has This Been Tested?
Cucumber test provided

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I have squashed my commits into a single commit.
