### PR TITLE
fix: fix GRPC GetTransactionInfo not found response

### DIFF
--- a/applications/tari_app_grpc/proto/wallet.proto
+++ b/applications/tari_app_grpc/proto/wallet.proto
@@ -114,7 +114,6 @@ message TransactionInfo {
     google.protobuf.Timestamp timestamp = 10;
     string message = 11;
     bool valid = 12;
-    bool is_found = 13;
 }
 
 enum TransactionDirection {
@@ -138,6 +137,8 @@ enum TransactionStatus {
     TRANSACTION_STATUS_COINBASE = 5;
     // This transaction is mined and confirmed at the current base node's height
     TRANSACTION_STATUS_MINED_CONFIRMED = 6;
+    // The transaction was not found by the wallet its in transaction database
+    TRANSACTION_STATUS_NOT_FOUND = 7;
 }
 
 message GetCompletedTransactionsRequest { }

--- a/applications/tari_app_grpc/src/conversions/transaction.rs
+++ b/applications/tari_app_grpc/src/conversions/transaction.rs
@@ -83,7 +83,7 @@ impl grpc::TransactionInfo {
     pub fn not_found(tx_id: TxId) -> Self {
         Self {
             tx_id,
-            is_found: false,
+            status: grpc::TransactionStatus::NotFound as i32,
             ..Default::default()
         }
     }

--- a/applications/tari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/tari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -266,7 +266,6 @@ impl wallet_server::Wallet for WalletGrpcServer {
                             .to_vec(),
                         message: txn.message,
                         valid: txn.valid,
-                        is_found: true,
                     }),
                 };
                 match sender.send(Ok(response)).await {
@@ -415,7 +414,6 @@ fn convert_wallet_transaction_into_transaction_info(
             timestamp: Some(naive_datetime_to_timestamp(tx.timestamp)),
             message: tx.message,
             valid: true,
-            is_found: true,
         },
         PendingOutbound(tx) => TransactionInfo {
             tx_id: tx.tx_id,
@@ -430,7 +428,6 @@ fn convert_wallet_transaction_into_transaction_info(
             timestamp: Some(naive_datetime_to_timestamp(tx.timestamp)),
             message: tx.message,
             valid: true,
-            is_found: true,
         },
         Completed(tx) => TransactionInfo {
             tx_id: tx.tx_id,
@@ -449,7 +446,6 @@ fn convert_wallet_transaction_into_transaction_info(
                 .unwrap_or_default(),
             message: tx.message,
             valid: tx.valid,
-            is_found: true,
         },
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When a transaction is not found on `GetTransactionInfo` the GRPC call will return a transaction with "junk" data including a status that is set to complete. But the not_found flag is set to false, which is also the default GRPC value for boolean. 

This removes the `not_found` flag and adds a status, `not found` to avoid confusion. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I have squashed my commits into a single commit.
