### PR TITLE
fix: fix cucumber transaction builder reliability

### DIFF
--- a/integration_tests/helpers/transactionBuilder.js
+++ b/integration_tests/helpers/transactionBuilder.js
@@ -169,7 +169,7 @@ class TransactionBuilder {
     };
     let key = Math.floor(Math.random() * 500 + 1);
     let privateKey = Buffer.from(toLittleEndian(key, 256)).toString("hex");
-    let scriptKey = Math.floor(Math.random() * 500 + 1);
+    let scriptKey = Math.floor(Math.random() * 500000000000 + 1);
     let scriptPrivateKey = Buffer.from(toLittleEndian(scriptKey, 256)).toString(
       "hex"
     );
@@ -339,7 +339,9 @@ class TransactionBuilder {
       flags: 1,
       maturity: lockHeight,
     };
-    let scriptOffsetPrivateKeyNum = Math.floor(Math.random() * 500 + 1);
+    let scriptOffsetPrivateKeyNum = Math.floor(
+      Math.random() * 500000000000 + 1
+    );
     let scriptOffsetPrivateKey = Buffer.from(
       toLittleEndian(scriptOffsetPrivateKeyNum, 256)
     ).toString("hex");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
We sometimes find that transactions created by the cucumber transaction builder fail lmdb insertion by duplicate excess. 
This increases the private key range for the private keys increasing the range of the excess. This should decrease duplicate entries. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I have squashed my commits into a single commit.
