### PR TITLE
ON_HOLD: fix: improve wallet's base node service connection, aka "console wallet being offline"

### DIFF
--- a/base_layer/core/src/base_node/sync/header_sync/synchronizer.rs
+++ b/base_layer/core/src/base_node/sync/header_sync/synchronizer.rs
@@ -114,7 +114,7 @@ impl<'a, B: BlockchainBackend + 'static> HeaderSynchronizer<'a, B> {
                 },
 
                 Err(err @ BlockHeaderSyncError::RpcError(RpcError::HandshakeError(RpcHandshakeError::TimedOut))) => {
-                    debug!(target: LOG_TARGET, "{}", err);
+                    warn!(target: LOG_TARGET, "{}", err);
                     self.ban_peer_short(node_id, BanReason::RpcNegotiationTimedOut).await?;
                 },
                 Err(BlockHeaderSyncError::ValidationFailed(err)) => {

--- a/comms/src/protocol/rpc/handshake.rs
+++ b/comms/src/protocol/rpc/handshake.rs
@@ -101,7 +101,7 @@ where T: AsyncRead + AsyncWrite + Unpin
     }
 
     pub async fn reject_with_reason(&mut self, reject_reason: HandshakeRejectReason) -> Result<(), RpcHandshakeError> {
-        debug!(target: LOG_TARGET, "Rejecting handshake because {}", reject_reason);
+        warn!(target: LOG_TARGET, "Rejecting handshake because {}", reject_reason);
         let reply = proto::rpc::RpcSessionReply {
             session_result: Some(proto::rpc::rpc_session_reply::SessionResult::Rejected(true)),
             reject_reason: reject_reason.as_i32(),
@@ -120,7 +120,7 @@ where T: AsyncRead + AsyncWrite + Unpin
         // anything. Rather than returning an IO error, let's ignore the send error and see if we can receive anything,
         // or return an IO error similarly to what send would have done.
         if let Err(err) = self.framed.send(msg.to_encoded_bytes().into()).await {
-            debug!(
+            warn!(
                 target: LOG_TARGET,
                 "IO error when sending new session handshake to peer: {}", err
             );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR made:
- the wallet's base node service connection (including obtaining RPC sessions) to be less flaky. i.e. recoverable more quickly;
- RPC connection errors to be recognized more explicitly as warnings in the logs.

_**Note:** This PR does not fix the root cause (maybe call it the root symptom?) of the problem, which was identified as a valid peer connection not always providing valid RPC sessions._

The major change brought about by this PR is to disconnect the connected base node whenever obtaining an RPC session gave an error so that a new connection could be established before retrying to obtain an RPC session. A minor change was to only re-dial the base node peer if the connection status is "not connected" for a slight efficiency improvement.

The attached logs show an 8 hour stretch for 7x base node - console wallet pairs that ran on 2x Windows 10 computers. The longest recorded "offline" times occurred in a stretch of ~27 minutes on two console wallets between 03:01 and 03:27, with intermittent successful connections in between those times, after which those two wallets' "online" status recovered. Previously, these wallets were measured as staying "offline" for hours (~5) on end.

As a point of interest, the internet connection was reset at ~07:53 for both computers, which can be seen in the logs as well.

[node_01.log](https://github.com/tari-project/tari/files/6922094/node_01.log)    |    [node_02.log](https://github.com/tari-project/tari/files/6922095/node_02.log)    |    [node_03.log](https://github.com/tari-project/tari/files/6922097/node_03.log)    |    [node_04.log](https://github.com/tari-project/tari/files/6922099/node_04.log)    |    [node_05.log](https://github.com/tari-project/tari/files/6922100/node_05.log)    |    [node_06.log](https://github.com/tari-project/tari/files/6922101/node_06.log)    |    [node_07.log](https://github.com/tari-project/tari/files/6922103/node_07.log)


## Motivation and Context
A new RPC session is created for each metadata request to the base node, whose result is used to display blockchain stats in the console wallet. On some systems (computers) the `wallet::base_node_service::chain_metadata_monitor` was not very robust resulting in console wallets being "offline" for extended periods. This was traced to a symptom with RPC sessions, where creating a new session on a valid peer connection would result in an RPC timeout time out without seemingly the ability to recover. 

## How Has This Been Tested?
Extended system-level testing with 7 base node - console wallet pairs on two Windows 10 computers where these "offline" symptoms were paramount.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I have squashed my commits into a single commit.
