### PR TITLE
feat: wallet connectivity service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4932,6 +4932,7 @@ dependencies = [
  "futures-test",
  "lazy_static 1.4.0",
  "rand 0.8.4",
+ "tari_shutdown",
  "tempfile",
  "tokio 0.2.25",
 ]

--- a/applications/tari_console_wallet/src/ui/components/base_node.rs
+++ b/applications/tari_console_wallet/src/ui/components/base_node.rs
@@ -21,7 +21,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::ui::{components::Component, state::AppState};
-use tari_wallet::base_node_service::service::OnlineState;
+use tari_wallet::connectivity_service::OnlineStatus;
 use tui::{
     backend::Backend,
     layout::Rect,
@@ -45,17 +45,17 @@ impl<B: Backend> Component<B> for BaseNode {
         let base_node_state = app_state.get_base_node_state();
 
         let chain_info = match base_node_state.online {
-            OnlineState::Connecting => Spans::from(vec![
+            OnlineStatus::Connecting => Spans::from(vec![
                 Span::styled("Chain Tip:", Style::default().fg(Color::Magenta)),
                 Span::raw(" "),
                 Span::styled("Connecting...", Style::default().fg(Color::Reset)),
             ]),
-            OnlineState::Offline => Spans::from(vec![
+            OnlineStatus::Offline => Spans::from(vec![
                 Span::styled("Chain Tip:", Style::default().fg(Color::Magenta)),
                 Span::raw(" "),
                 Span::styled("Offline", Style::default().fg(Color::Red)),
             ]),
-            OnlineState::Online => {
+            OnlineStatus::Online => {
                 if let Some(metadata) = base_node_state.clone().chain_metadata {
                     let tip = metadata.height_of_longest_chain();
 

--- a/applications/tari_console_wallet/src/utils/crossterm_events.rs
+++ b/applications/tari_console_wallet/src/utils/crossterm_events.rs
@@ -70,7 +70,9 @@ impl CrosstermEvents {
                 ) {
                     Ok(true) => {
                         if let Ok(CEvent::Key(key)) = event::read() {
-                            tx.send(Event::Input(key)).unwrap();
+                            if let Err(e) = tx.send(Event::Input(key)) {
+                                warn!(target: LOG_TARGET, "Error sending Tick event on MPSC channel: {}", e);
+                            }
                         }
                     },
                     Ok(false) => {},

--- a/base_layer/wallet/src/base_node_service/config.rs
+++ b/base_layer/wallet/src/base_node_service/config.rs
@@ -28,6 +28,7 @@ const LOG_TARGET: &str = "wallet::base_node_service::config";
 #[derive(Clone, Debug)]
 pub struct BaseNodeServiceConfig {
     pub base_node_monitor_refresh_interval: Duration,
+    pub base_node_rpc_pool_size: usize,
     pub request_max_age: Duration,
 }
 
@@ -35,6 +36,7 @@ impl Default for BaseNodeServiceConfig {
     fn default() -> Self {
         Self {
             base_node_monitor_refresh_interval: Duration::from_secs(5),
+            base_node_rpc_pool_size: 10,
             request_max_age: Duration::from_secs(60),
         }
     }
@@ -51,6 +53,7 @@ impl BaseNodeServiceConfig {
         Self {
             base_node_monitor_refresh_interval: Duration::from_secs(refresh_interval),
             request_max_age: Duration::from_secs(request_max_age),
+            ..Default::default()
         }
     }
 }

--- a/base_layer/wallet/src/base_node_service/error.rs
+++ b/base_layer/wallet/src/base_node_service/error.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::error::WalletStorageError;
+use crate::{connectivity_service::WalletConnectivityError, error::WalletStorageError};
 use tari_comms::{connectivity::ConnectivityError, protocol::rpc::RpcError};
 use tari_comms_dht::outbound::DhtOutboundError;
 use tari_service_framework::reply_channel::TransportChannelError;
@@ -46,4 +46,6 @@ pub enum BaseNodeServiceError {
     InvalidBaseNodeResponse(String),
     #[error("Wallet storage error: `{0}`")]
     WalletStorageError(#[from] WalletStorageError),
+    #[error("Wallet connectivity error: `{0}`")]
+    WalletConnectivityError(#[from] WalletConnectivityError),
 }

--- a/base_layer/wallet/src/base_node_service/handle.rs
+++ b/base_layer/wallet/src/base_node_service/handle.rs
@@ -22,11 +22,9 @@
 
 use super::{error::BaseNodeServiceError, service::BaseNodeState};
 use futures::{stream::Fuse, StreamExt};
-use std::sync::Arc;
-use tari_comms::peer_manager::Peer;
-
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 use tari_common_types::chain_metadata::ChainMetadata;
+use tari_comms::peer_manager::Peer;
 use tari_service_framework::reply_channel::SenderService;
 use tokio::sync::broadcast;
 use tower::Service;

--- a/base_layer/wallet/src/base_node_service/mock_base_node_service.rs
+++ b/base_layer/wallet/src/base_node_service/mock_base_node_service.rs
@@ -20,10 +20,13 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::base_node_service::{
-    error::BaseNodeServiceError,
-    handle::{BaseNodeServiceRequest, BaseNodeServiceResponse},
-    service::{BaseNodeState, OnlineState},
+use crate::{
+    base_node_service::{
+        error::BaseNodeServiceError,
+        handle::{BaseNodeServiceRequest, BaseNodeServiceResponse},
+        service::BaseNodeState,
+    },
+    connectivity_service::OnlineStatus,
 };
 use futures::StreamExt;
 use tari_common_types::chain_metadata::ChainMetadata;
@@ -81,9 +84,9 @@ impl MockBaseNodeService {
         let (chain_metadata, is_synced, online) = match height {
             Some(height) => {
                 let metadata = ChainMetadata::new(height, Vec::new(), 0, 0, 0);
-                (Some(metadata), Some(true), OnlineState::Online)
+                (Some(metadata), Some(true), OnlineStatus::Online)
             },
-            None => (None, None, OnlineState::Offline),
+            None => (None, None, OnlineStatus::Offline),
         };
         self.state = BaseNodeState {
             chain_metadata,
@@ -102,7 +105,7 @@ impl MockBaseNodeService {
             is_synced: Some(true),
             updated: None,
             latency: None,
-            online: OnlineState::Online,
+            online: OnlineStatus::Online,
             base_node_peer: None,
         }
     }

--- a/base_layer/wallet/src/base_node_service/mod.rs
+++ b/base_layer/wallet/src/base_node_service/mod.rs
@@ -30,10 +30,10 @@ mod monitor;
 
 use crate::{
     base_node_service::{config::BaseNodeServiceConfig, handle::BaseNodeServiceHandle, service::BaseNodeService},
+    connectivity_service::WalletConnectivityHandle,
     storage::database::{WalletBackend, WalletDatabase},
 };
 use log::*;
-use tari_comms::connectivity::ConnectivityRequester;
 use tari_service_framework::{
     async_trait,
     reply_channel,
@@ -80,12 +80,12 @@ where T: WalletBackend + 'static
         let db = self.db.clone();
 
         context.spawn_when_ready(move |handles| async move {
-            let connectivity_manager = handles.expect_handle::<ConnectivityRequester>();
+            let wallet_connectivity = handles.expect_handle::<WalletConnectivityHandle>();
 
             let service = BaseNodeService::new(
                 config,
                 request_stream,
-                connectivity_manager,
+                wallet_connectivity,
                 event_publisher,
                 handles.get_shutdown_signal(),
                 db,

--- a/base_layer/wallet/src/connectivity_service/error.rs
+++ b/base_layer/wallet/src/connectivity_service/error.rs
@@ -1,0 +1,45 @@
+//  Copyright 2021, The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use futures::channel::{mpsc, oneshot};
+use tari_comms::connectivity::ConnectivityError;
+
+#[derive(Debug, thiserror::Error)]
+pub enum WalletConnectivityError {
+    #[error("Base node has not been set")]
+    BaseNodeNotSet,
+    #[error("Connectivity error: {0}")]
+    ConnectivityError(#[from] ConnectivityError),
+    #[error("Service is terminated and can no longer response to requests")]
+    ServiceTerminated,
+}
+
+impl From<mpsc::SendError> for WalletConnectivityError {
+    fn from(_: mpsc::SendError) -> Self {
+        WalletConnectivityError::ServiceTerminated
+    }
+}
+impl From<oneshot::Canceled> for WalletConnectivityError {
+    fn from(_: oneshot::Canceled) -> Self {
+        WalletConnectivityError::ServiceTerminated
+    }
+}

--- a/base_layer/wallet/src/connectivity_service/handle.rs
+++ b/base_layer/wallet/src/connectivity_service/handle.rs
@@ -1,0 +1,99 @@
+//  Copyright 2021, The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use super::service::OnlineStatus;
+use crate::connectivity_service::error::WalletConnectivityError;
+use futures::{
+    channel::{mpsc, oneshot},
+    SinkExt,
+};
+use tari_comms::{peer_manager::NodeId, protocol::rpc::RpcClientLease};
+use tari_core::base_node::rpc;
+use tokio::sync::watch;
+
+pub enum WalletConnectivityRequest {
+    ObtainBaseNodeWalletRpcClient(oneshot::Sender<RpcClientLease<rpc::BaseNodeWalletRpcClient>>),
+    SetBaseNode(NodeId),
+}
+
+#[derive(Clone)]
+pub struct WalletConnectivityHandle {
+    sender: mpsc::Sender<WalletConnectivityRequest>,
+    base_node_watch_rx: watch::Receiver<Option<NodeId>>,
+    online_status_rx: watch::Receiver<OnlineStatus>,
+}
+
+impl WalletConnectivityHandle {
+    pub(super) fn new(
+        sender: mpsc::Sender<WalletConnectivityRequest>,
+        base_node_watch_rx: watch::Receiver<Option<NodeId>>,
+        online_status_rx: watch::Receiver<OnlineStatus>,
+    ) -> Self {
+        Self {
+            sender,
+            base_node_watch_rx,
+            online_status_rx,
+        }
+    }
+
+    pub async fn set_base_node(&mut self, base_node_peer: NodeId) -> Result<(), WalletConnectivityError> {
+        self.sender
+            .send(WalletConnectivityRequest::SetBaseNode(base_node_peer))
+            .await?;
+        Ok(())
+    }
+
+    /// Obtain a BaseNodeWalletRpcClient.
+    ///
+    /// This can be relied on to obtain a pooled BaseNodeWalletRpcClient rpc session from a currently selected base
+    /// node/nodes. It will be block until this is happens. The ONLY other time it will return is if the node is
+    /// shutting down, where it will return None. Use this function whenever no work can be done without a
+    /// BaseNodeWalletRpcClient RPC session.
+    pub async fn obtain_base_node_rpc_client(&mut self) -> Option<RpcClientLease<rpc::BaseNodeWalletRpcClient>> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        // Under what conditions do the (1) mpsc channel and (2) oneshot channel error?
+        // (1) when the receiver has been dropped
+        // (2) when the sender has been dropped
+        // When can this happen?
+        // Only when the service is shutdown (or there is a bug in the service that should be fixed)
+        // None is returned in these cases, which we say means that you will never ever get a client connection
+        // because the node is shutting down.
+        self.sender
+            .send(WalletConnectivityRequest::ObtainBaseNodeWalletRpcClient(reply_tx))
+            .await
+            .ok()?;
+
+        reply_rx.await.ok()
+    }
+
+    pub async fn get_connectivity_status(&mut self) -> OnlineStatus {
+        self.online_status_rx.recv().await.unwrap_or(OnlineStatus::Offline)
+    }
+
+    pub fn get_connectivity_status_watcher(&self) -> watch::Receiver<OnlineStatus> {
+        self.online_status_rx.clone()
+    }
+
+    pub fn get_current_base_node(&self) -> Option<NodeId> {
+        self.base_node_watch_rx.borrow().clone()
+    }
+}

--- a/base_layer/wallet/src/connectivity_service/initializer.rs
+++ b/base_layer/wallet/src/connectivity_service/initializer.rs
@@ -1,0 +1,69 @@
+//  Copyright 2021, The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use super::{handle::WalletConnectivityHandle, service::WalletConnectivityService, watch::Watch};
+use crate::{base_node_service::config::BaseNodeServiceConfig, connectivity_service::service::OnlineStatus};
+use futures::channel::mpsc;
+use tari_service_framework::{async_trait, ServiceInitializationError, ServiceInitializer, ServiceInitializerContext};
+
+pub struct WalletConnectivityInitializer {
+    config: BaseNodeServiceConfig,
+}
+
+impl WalletConnectivityInitializer {
+    pub fn new(config: BaseNodeServiceConfig) -> Self {
+        Self { config }
+    }
+}
+
+#[async_trait]
+impl ServiceInitializer for WalletConnectivityInitializer {
+    async fn initialize(&mut self, context: ServiceInitializerContext) -> Result<(), ServiceInitializationError> {
+        let (sender, receiver) = mpsc::channel(5);
+        let base_node_watch = Watch::new(None);
+        let online_status_watch = Watch::new(OnlineStatus::Offline);
+        context.register_handle(WalletConnectivityHandle::new(
+            sender,
+            base_node_watch.get_receiver(),
+            online_status_watch.get_receiver(),
+        ));
+
+        let config = self.config.clone();
+
+        context.spawn_until_shutdown(move |handles| {
+            let connectivity = handles.expect_handle();
+            let service =
+                WalletConnectivityService::new(config, receiver, base_node_watch, online_status_watch, connectivity);
+            service.start()
+        });
+
+        Ok(())
+    }
+}

--- a/base_layer/wallet/src/connectivity_service/mod.rs
+++ b/base_layer/wallet/src/connectivity_service/mod.rs
@@ -1,0 +1,38 @@
+//  Copyright 2021, The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+mod error;
+pub use error::WalletConnectivityError;
+
+mod handle;
+pub use handle::WalletConnectivityHandle;
+
+mod initializer;
+pub use initializer::WalletConnectivityInitializer;
+
+mod service;
+pub use service::OnlineStatus;
+
+mod watch;
+
+#[cfg(test)]
+mod test;

--- a/base_layer/wallet/src/connectivity_service/service.rs
+++ b/base_layer/wallet/src/connectivity_service/service.rs
@@ -1,0 +1,219 @@
+//  Copyright 2021, The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::{
+    base_node_service::config::BaseNodeServiceConfig,
+    connectivity_service::{error::WalletConnectivityError, handle::WalletConnectivityRequest, watch::Watch},
+};
+use core::mem;
+use futures::{
+    channel::{mpsc, oneshot},
+    stream::Fuse,
+    StreamExt,
+};
+use log::*;
+use tari_comms::{
+    connectivity::ConnectivityRequester,
+    peer_manager::NodeId,
+    protocol::rpc::{RpcClientLease, RpcClientPool},
+};
+use tari_core::base_node::rpc;
+use tokio::time;
+
+const LOG_TARGET: &str = "wallet::connectivity";
+
+/// Connection status of the Base Node
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum OnlineStatus {
+    Connecting,
+    Online,
+    Offline,
+}
+
+pub struct WalletConnectivityService {
+    config: BaseNodeServiceConfig,
+    request_stream: Fuse<mpsc::Receiver<WalletConnectivityRequest>>,
+    connectivity: ConnectivityRequester,
+    base_node_watch: Watch<Option<NodeId>>,
+    base_node_wallet_rpc_client_pool: Option<RpcClientPool<rpc::BaseNodeWalletRpcClient>>,
+    online_status_watch: Watch<OnlineStatus>,
+    pending_base_node_rpc_requests: Vec<oneshot::Sender<RpcClientLease<rpc::BaseNodeWalletRpcClient>>>,
+}
+
+impl WalletConnectivityService {
+    pub(super) fn new(
+        config: BaseNodeServiceConfig,
+        request_stream: mpsc::Receiver<WalletConnectivityRequest>,
+        base_node_watch: Watch<Option<NodeId>>,
+        online_status_watch: Watch<OnlineStatus>,
+        connectivity: ConnectivityRequester,
+    ) -> Self {
+        Self {
+            config,
+            request_stream: request_stream.fuse(),
+            connectivity,
+            base_node_watch,
+            base_node_wallet_rpc_client_pool: None,
+            pending_base_node_rpc_requests: Vec::new(),
+            online_status_watch,
+        }
+    }
+
+    pub async fn start(mut self) {
+        debug!(target: LOG_TARGET, "Wallet connectivity service has started.");
+        let mut base_node_watch_rx = self.base_node_watch.get_receiver().fuse();
+        loop {
+            futures::select! {
+                req = self.request_stream.select_next_some() => {
+                    self.handle_request(req).await;
+                },
+                peer = base_node_watch_rx.select_next_some() => {
+                    if let Some(peer) = peer {
+                        // This will block the rest until the connection is established. This is what we want.
+                        self.setup_base_node_connection(peer).await;
+                    }
+                }
+            }
+        }
+    }
+
+    async fn handle_request(&mut self, request: WalletConnectivityRequest) {
+        use WalletConnectivityRequest::*;
+        match request {
+            ObtainBaseNodeWalletRpcClient(reply) => {
+                self.handle_get_base_node_wallet_rpc_client(reply).await;
+            },
+
+            SetBaseNode(peer) => {
+                self.set_base_node_peer(peer);
+            },
+        }
+    }
+
+    async fn handle_get_base_node_wallet_rpc_client(
+        &mut self,
+        reply: oneshot::Sender<RpcClientLease<rpc::BaseNodeWalletRpcClient>>,
+    ) {
+        match self.base_node_wallet_rpc_client_pool {
+            Some(ref pool) => match pool.get().await {
+                Ok(client) => {
+                    let _ = reply.send(client);
+                },
+                Err(e) => {
+                    warn!(
+                        target: LOG_TARGET,
+                        "Base node connection failed: {}. Reconnecting...", e
+                    );
+                    self.trigger_reconnect();
+                    self.pending_base_node_rpc_requests.push(reply);
+                },
+            },
+            None => {
+                self.pending_base_node_rpc_requests.push(reply);
+                if self.base_node_watch.borrow().is_none() {
+                    warn!(
+                        target: LOG_TARGET,
+                        "{} requests are waiting for base node to be set",
+                        self.pending_base_node_rpc_requests.len()
+                    );
+                }
+            },
+        }
+    }
+
+    fn trigger_reconnect(&mut self) {
+        let peer = self
+            .base_node_watch
+            .borrow()
+            .clone()
+            .expect("trigger_reconnect called before base node is set");
+        // Trigger the watch so that a peer connection is reinitiated
+        self.set_base_node_peer(peer);
+    }
+
+    fn set_base_node_peer(&mut self, peer: NodeId) {
+        self.base_node_wallet_rpc_client_pool = None;
+        self.base_node_watch.broadcast(Some(peer));
+    }
+
+    async fn setup_base_node_connection(&mut self, peer: NodeId) {
+        self.base_node_wallet_rpc_client_pool = None;
+        loop {
+            debug!(
+                target: LOG_TARGET,
+                "Attempting to connect to base node peer {}...", peer
+            );
+            self.set_online_status(OnlineStatus::Connecting);
+            match self.try_setup_rpc_pool(peer.clone()).await {
+                Ok(_) => {
+                    self.set_online_status(OnlineStatus::Online);
+                    debug!(
+                        target: LOG_TARGET,
+                        "Wallet is ONLINE and connected to base node {}", peer
+                    );
+                    break;
+                },
+                Err(e) => {
+                    self.set_online_status(OnlineStatus::Offline);
+                    error!(target: LOG_TARGET, "{}", e);
+                    time::delay_for(self.config.base_node_monitor_refresh_interval).await;
+                    continue;
+                },
+            }
+        }
+    }
+
+    fn set_online_status(&self, status: OnlineStatus) {
+        let _ = self.online_status_watch.broadcast(status);
+    }
+
+    async fn try_setup_rpc_pool(&mut self, peer: NodeId) -> Result<(), WalletConnectivityError> {
+        self.connectivity.add_managed_peers(vec![peer.clone()]).await?;
+        let conn = self.connectivity.dial_peer(peer).await?;
+        debug!(
+            target: LOG_TARGET,
+            "Successfully established peer connection to base node {}",
+            conn.peer_node_id()
+        );
+        let pool = conn.create_rpc_client_pool(self.config.base_node_rpc_pool_size);
+        self.base_node_wallet_rpc_client_pool = Some(pool);
+        self.notify_pending_requests().await?;
+        debug!(
+            target: LOG_TARGET,
+            "Successfully established RPC connection {}",
+            conn.peer_node_id()
+        );
+        Ok(())
+    }
+
+    async fn notify_pending_requests(&mut self) -> Result<(), WalletConnectivityError> {
+        let current_pending = mem::take(&mut self.pending_base_node_rpc_requests);
+        for reply in current_pending {
+            if reply.is_canceled() {
+                continue;
+            }
+
+            self.handle_get_base_node_wallet_rpc_client(reply).await;
+        }
+        Ok(())
+    }
+}

--- a/base_layer/wallet/src/connectivity_service/test.rs
+++ b/base_layer/wallet/src/connectivity_service/test.rs
@@ -1,0 +1,234 @@
+//  Copyright 2021, The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use super::service::WalletConnectivityService;
+use crate::connectivity_service::{watch::Watch, OnlineStatus, WalletConnectivityHandle};
+use core::convert;
+use futures::{channel::mpsc, future};
+use std::{iter, sync::Arc};
+use tari_comms::{
+    peer_manager::PeerFeatures,
+    protocol::rpc::{
+        mock::{MockRpcImpl, MockRpcServer},
+        RpcPoolClient,
+    },
+    test_utils::{
+        mocks::{create_connectivity_mock, ConnectivityManagerMockState},
+        node_identity::build_node_identity,
+    },
+    Substream,
+};
+use tari_shutdown::Shutdown;
+use tari_test_utils::runtime::spawn_until_shutdown;
+use tokio::{sync::Barrier, task};
+
+async fn setup() -> (
+    WalletConnectivityHandle,
+    MockRpcServer<MockRpcImpl, Substream>,
+    ConnectivityManagerMockState,
+    Shutdown,
+) {
+    let (tx, rx) = mpsc::channel(1);
+    let base_node_watch = Watch::new(None);
+    let online_status_watch = Watch::new(OnlineStatus::Offline);
+    let handle = WalletConnectivityHandle::new(tx, base_node_watch.get_receiver(), online_status_watch.get_receiver());
+    let (connectivity, mock) = create_connectivity_mock();
+    let mock_state = mock.spawn();
+    let service = WalletConnectivityService::new(
+        Default::default(),
+        rx,
+        base_node_watch,
+        online_status_watch,
+        connectivity,
+    );
+    let shutdown = spawn_until_shutdown(service.start());
+
+    let mock_svc = MockRpcImpl::new();
+    let mut mock_server = MockRpcServer::new(mock_svc, build_node_identity(PeerFeatures::COMMUNICATION_NODE));
+    mock_server.serve();
+
+    (handle, mock_server, mock_state, shutdown)
+}
+
+#[tokio_macros::test]
+async fn it_dials_peer_when_base_node_is_set() {
+    let (mut handle, mock_server, mock_state, _shutdown) = setup().await;
+    let base_node_peer = build_node_identity(PeerFeatures::COMMUNICATION_NODE);
+    let conn = mock_server.create_mockimpl_connection(base_node_peer.to_peer()).await;
+
+    // Set the mock to defer returning a result for the peer connection
+    mock_state.set_pending_connection(base_node_peer.node_id()).await;
+    // Initiate a connection to the base node
+    handle.set_base_node(base_node_peer.node_id().clone()).await.unwrap();
+
+    // Wait for connection request
+    mock_state.await_call_count(1).await;
+    mock_state.expect_dial_peer(base_node_peer.node_id()).await;
+
+    // Now a connection will given to the service
+    mock_state.add_active_connection(conn).await;
+
+    let rpc_client = handle.obtain_base_node_rpc_client().await.unwrap();
+    assert!(rpc_client.is_connected());
+}
+
+#[tokio_macros::test]
+async fn it_resolves_many_pending_rpc_session_requests() {
+    let (mut handle, mock_server, mock_state, _shutdown) = setup().await;
+    let base_node_peer = build_node_identity(PeerFeatures::COMMUNICATION_NODE);
+    let conn = mock_server.create_mockimpl_connection(base_node_peer.to_peer()).await;
+
+    // Set the mock to defer returning a result for the peer connection
+    mock_state.set_pending_connection(base_node_peer.node_id()).await;
+
+    // Initiate a connection to the base node
+    handle.set_base_node(base_node_peer.node_id().clone()).await.unwrap();
+
+    let pending_requests = iter::repeat_with(|| {
+        let mut handle = handle.clone();
+        task::spawn(async move {
+            let rpc_client = handle.obtain_base_node_rpc_client().await.unwrap();
+            rpc_client.is_connected()
+        })
+    })
+    .take(10)
+    // Eagerly call `obtain_base_node_rpc_client`
+    .collect::<Vec<_>>();
+
+    // Now a connection will given to the service
+    mock_state.add_active_connection(conn).await;
+
+    let results = future::join_all(pending_requests).await;
+    assert!(results.into_iter().map(Result::unwrap).all(convert::identity));
+}
+
+#[tokio_macros::test]
+async fn it_changes_to_a_new_base_node() {
+    let (mut handle, mock_server, mock_state, _shutdown) = setup().await;
+    let base_node_peer1 = build_node_identity(PeerFeatures::COMMUNICATION_NODE);
+    let conn1 = mock_server.create_mockimpl_connection(base_node_peer1.to_peer()).await;
+    let base_node_peer2 = build_node_identity(PeerFeatures::COMMUNICATION_NODE);
+    let conn2 = mock_server.create_mockimpl_connection(base_node_peer2.to_peer()).await;
+
+    mock_state.add_active_connection(conn1).await;
+    mock_state.add_active_connection(conn2).await;
+
+    // Initiate a connection to the base node
+    handle.set_base_node(base_node_peer1.node_id().clone()).await.unwrap();
+
+    mock_state.await_call_count(2).await;
+    mock_state.expect_dial_peer(base_node_peer1.node_id()).await;
+    assert_eq!(mock_state.count_calls_containing("AddManagedPeer").await, 1);
+    let _ = mock_state.take_calls().await;
+
+    let rpc_client = handle.obtain_base_node_rpc_client().await.unwrap();
+    assert!(rpc_client.is_connected());
+
+    // Initiate a connection to the base node
+    handle.set_base_node(base_node_peer2.node_id().clone()).await.unwrap();
+
+    mock_state.await_call_count(2).await;
+    mock_state.expect_dial_peer(base_node_peer2.node_id()).await;
+    assert_eq!(mock_state.count_calls_containing("AddManagedPeer").await, 1);
+
+    let rpc_client = handle.obtain_base_node_rpc_client().await.unwrap();
+    assert!(rpc_client.is_connected());
+}
+
+#[tokio_macros::test]
+async fn it_gracefully_handles_connect_fail_reconnect() {
+    let (mut handle, mock_server, mock_state, _shutdown) = setup().await;
+    let base_node_peer = build_node_identity(PeerFeatures::COMMUNICATION_NODE);
+    let mut conn = mock_server.create_mockimpl_connection(base_node_peer.to_peer()).await;
+
+    // Set the mock to defer returning a result for the peer connection
+    mock_state.set_pending_connection(base_node_peer.node_id()).await;
+
+    // Initiate a connection to the base node
+    handle.set_base_node(base_node_peer.node_id().clone()).await.unwrap();
+
+    // Now a connection will given to the service
+    mock_state.add_active_connection(conn.clone()).await;
+    // Empty out all the calls
+    let _ = mock_state.take_calls().await;
+    conn.disconnect().await.unwrap();
+
+    let barrier = Arc::new(Barrier::new(2));
+    let pending_request = task::spawn({
+        let mut handle = handle.clone();
+        let barrier = barrier.clone();
+        async move {
+            barrier.wait().await;
+            let rpc_client = handle.obtain_base_node_rpc_client().await.unwrap();
+            assert!(rpc_client.is_connected());
+        }
+    });
+
+    mock_state.await_call_count(2).await;
+    mock_state.expect_dial_peer(base_node_peer.node_id()).await;
+
+    // Make sure that the task has actually started before continuing, otherwise we may not be testing the client asking
+    // for a client session before a connection is made
+    barrier.wait().await;
+
+    // "Establish" a new connections
+    let conn = mock_server.create_mockimpl_connection(base_node_peer.to_peer()).await;
+    mock_state.add_active_connection(conn).await;
+
+    pending_request.await.unwrap();
+}
+
+#[tokio_macros::test]
+async fn it_gracefully_handles_multiple_connection_failures() {
+    let (mut handle, mock_server, mock_state, _shutdown) = setup().await;
+    let base_node_peer = build_node_identity(PeerFeatures::COMMUNICATION_NODE);
+    let conn = mock_server.create_mockimpl_connection(base_node_peer.to_peer()).await;
+
+    // Initiate a connection to the base node
+    handle.set_base_node(base_node_peer.node_id().clone()).await.unwrap();
+
+    // Now a connection will given to the service
+    mock_state.add_active_connection(conn.clone()).await;
+    let barrier = Arc::new(Barrier::new(2));
+
+    let pending_request = task::spawn({
+        let mut handle = handle.clone();
+        let barrier = barrier.clone();
+        async move {
+            barrier.wait().await;
+            let rpc_client = handle.obtain_base_node_rpc_client().await.unwrap();
+            assert!(rpc_client.is_connected());
+        }
+    });
+
+    mock_state.await_call_count(2).await;
+    mock_state.expect_dial_peer(base_node_peer.node_id()).await;
+
+    barrier.wait().await;
+
+    // Peer has failed up until this point, but finally the base node "comes online"
+    let conn = mock_server.create_mockimpl_connection(base_node_peer.to_peer()).await;
+    mock_state.add_active_connection(conn).await;
+
+    // Still able to get a base node rpc client
+    pending_request.await.unwrap();
+}

--- a/base_layer/wallet/src/connectivity_service/watch.rs
+++ b/base_layer/wallet/src/connectivity_service/watch.rs
@@ -1,0 +1,67 @@
+//  Copyright 2021, The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::sync::Arc;
+use tokio::sync::watch;
+
+#[derive(Clone)]
+pub struct Watch<T>(Arc<watch::Sender<T>>, watch::Receiver<T>);
+
+impl<T: Clone> Watch<T> {
+    pub fn new(initial: T) -> Self {
+        let (tx, rx) = watch::channel(initial);
+        Self(Arc::new(tx), rx)
+    }
+
+    #[allow(dead_code)]
+    pub async fn recv(&mut self) -> Option<T> {
+        self.receiver_mut().recv().await
+    }
+
+    pub fn borrow(&mut self) -> watch::Ref<'_, T> {
+        self.receiver().borrow()
+    }
+
+    pub fn broadcast(&self, item: T) {
+        // SAFETY: broadcast becomes infallible because the receiver is owned in Watch and so has the same lifetime
+        if self.sender().broadcast(item).is_err() {
+            // Result::expect requires E: fmt::Debug and `watch::SendError<T>` is not, this is equivalent
+            panic!("watch internal receiver is dropped");
+        }
+    }
+
+    fn sender(&self) -> &watch::Sender<T> {
+        &self.0
+    }
+
+    fn receiver_mut(&mut self) -> &mut watch::Receiver<T> {
+        &mut self.1
+    }
+
+    pub fn receiver(&self) -> &watch::Receiver<T> {
+        &self.1
+    }
+
+    pub fn get_receiver(&self) -> watch::Receiver<T> {
+        self.receiver().clone()
+    }
+}

--- a/base_layer/wallet/src/lib.rs
+++ b/base_layer/wallet/src/lib.rs
@@ -6,11 +6,11 @@
 #![deny(unreachable_patterns)]
 #![deny(unknown_lints)]
 #![recursion_limit = "2048"]
-#![feature(drain_filter)]
 
 #[macro_use]
 mod macros;
 pub mod base_node_service;
+pub mod connectivity_service;
 pub mod contacts_service;
 pub mod error;
 pub mod output_manager_service;

--- a/base_layer/wallet/tests/transaction_service/service.rs
+++ b/base_layer/wallet/tests/transaction_service/service.rs
@@ -99,6 +99,7 @@ use tari_wallet::{
         mock_base_node_service::MockBaseNodeService,
         BaseNodeServiceInitializer,
     },
+    connectivity_service::WalletConnectivityInitializer,
     output_manager_service::{
         config::OutputManagerServiceConfig,
         handle::OutputManagerHandle,
@@ -211,6 +212,7 @@ pub fn setup_transaction_service<
             factories,
         ))
         .add_initializer(BaseNodeServiceInitializer::new(BaseNodeServiceConfig::default(), db))
+        .add_initializer(WalletConnectivityInitializer::new(BaseNodeServiceConfig::default()))
         .build();
 
     let handles = runtime.block_on(fut).expect("Service initialization failed");

--- a/comms/src/connection_manager/error.rs
+++ b/comms/src/connection_manager/error.rs
@@ -27,6 +27,7 @@ use crate::{
 };
 use futures::channel::mpsc;
 use thiserror::Error;
+use tokio::{time, time::Elapsed};
 
 #[derive(Debug, Error, Clone)]
 pub enum ConnectionManagerError {
@@ -110,4 +111,12 @@ pub enum PeerConnectionError {
     InternalRequestSendFailed(#[from] mpsc::SendError),
     #[error("Protocol error: {0}")]
     ProtocolError(#[from] ProtocolError),
+    #[error("Protocol negotiation timeout")]
+    ProtocolNegotiationTimeout,
+}
+
+impl From<time::Elapsed> for PeerConnectionError {
+    fn from(_: Elapsed) -> Self {
+        PeerConnectionError::ProtocolNegotiationTimeout
+    }
 }

--- a/comms/src/connectivity/manager.rs
+++ b/comms/src/connectivity/manager.rs
@@ -124,6 +124,12 @@ impl ConnectivityStatus {
     }
 }
 
+impl Default for ConnectivityStatus {
+    fn default() -> Self {
+        ConnectivityStatus::Initializing
+    }
+}
+
 impl fmt::Display for ConnectivityStatus {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:?}", self)

--- a/comms/src/connectivity/requester.rs
+++ b/comms/src/connectivity/requester.rs
@@ -137,7 +137,7 @@ impl ConnectivityRequester {
                 Err(err @ ConnectionManagerError::DialCancelled) => {
                     num_cancels += 1;
                     // Due to simultaneous dialing, it's possible for the dial to be cancelled. However, typically if
-                    // dial is called right after, the resolved connection will be returned.
+                    // dial is called again right after, the resolved connection will be returned.
                     if num_cancels == 1 {
                         continue;
                     }

--- a/comms/src/protocol/rpc/server/mock.rs
+++ b/comms/src/protocol/rpc/server/mock.rs
@@ -28,6 +28,7 @@ use crate::{
             context::{RequestContext, RpcCommsBackend, RpcCommsProvider},
             server::{handle::RpcServerRequest, PeerRpcServer, RpcServerError},
             Body,
+            NamedProtocolService,
             Request,
             Response,
             RpcError,
@@ -48,9 +49,17 @@ use crate::{
 };
 use async_trait::async_trait;
 use bytes::Bytes;
-use futures::{channel::mpsc, stream, SinkExt};
-use std::sync::Arc;
-use tokio::{sync::RwLock, task};
+use futures::{channel::mpsc, future::BoxFuture, stream, SinkExt};
+use std::{
+    collections::HashMap,
+    future,
+    sync::Arc,
+    task::{Context, Poll},
+};
+use tokio::{
+    sync::{Mutex, RwLock},
+    task,
+};
 use tower::Service;
 use tower_make::MakeService;
 
@@ -242,5 +251,71 @@ where
     pub fn serve(&mut self) -> task::JoinHandle<Result<(), RpcServerError>> {
         let inner = self.inner.take().expect("can only call `serve` once");
         task::spawn(inner.serve())
+    }
+}
+
+impl MockRpcServer<MockRpcImpl, Substream> {
+    pub async fn create_mockimpl_connection(&self, peer: Peer) -> PeerConnection {
+        // MockRpcImpl accepts any protocol
+        self.create_connection(peer, ProtocolId::new()).await
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct MockRpcImpl {
+    state: Arc<Mutex<State>>,
+}
+
+#[derive(Default)]
+struct State {
+    accepted_calls: HashMap<u32, Response<Bytes>>,
+}
+
+impl MockRpcImpl {
+    pub fn new() -> Self {
+        Default::default()
+    }
+}
+
+impl Service<Request<Bytes>> for MockRpcImpl {
+    type Error = RpcStatus;
+    type Future = BoxFuture<'static, Result<Response<Body>, RpcStatus>>;
+    type Response = Response<Body>;
+
+    fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: Request<Bytes>) -> Self::Future {
+        let state = self.state.clone();
+        Box::pin(async move {
+            let method_id = req.method().id();
+            match state.lock().await.accepted_calls.get(&method_id) {
+                Some(resp) => Ok(resp.clone().map(Body::single)),
+                None => Err(RpcStatus::unsupported_method(format!(
+                    "Method identifier `{}` is not recognised or supported",
+                    method_id
+                ))),
+            }
+        })
+    }
+}
+
+impl NamedProtocolService for MockRpcImpl {
+    const PROTOCOL_NAME: &'static [u8] = b"mock-service";
+}
+
+/// A service maker for GreetingServer
+impl Service<ProtocolId> for MockRpcImpl {
+    type Error = RpcServerError;
+    type Future = future::Ready<Result<Self::Response, Self::Error>>;
+    type Response = Self;
+
+    fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, _: ProtocolId) -> Self::Future {
+        future::ready(Ok(self.clone()))
     }
 }

--- a/comms/src/test_utils/mocks/connectivity_manager.rs
+++ b/comms/src/test_utils/mocks/connectivity_manager.rs
@@ -26,9 +26,14 @@ use crate::{
     peer_manager::NodeId,
     runtime::task,
 };
-use futures::{channel::mpsc, lock::Mutex, stream::Fuse, StreamExt};
-use std::{collections::HashMap, sync::Arc};
-use tokio::sync::broadcast;
+use futures::{
+    channel::{mpsc, oneshot},
+    lock::Mutex,
+    stream::Fuse,
+    StreamExt,
+};
+use std::{collections::HashMap, sync::Arc, time::Duration};
+use tokio::{sync::broadcast, time};
 
 pub fn create_connectivity_mock() -> (ConnectivityRequester, ConnectivityManagerMock) {
     let (tx, rx) = mpsc::channel(10);
@@ -41,66 +46,125 @@ pub fn create_connectivity_mock() -> (ConnectivityRequester, ConnectivityManager
 
 #[derive(Debug, Clone)]
 pub struct ConnectivityManagerMockState {
-    calls: Arc<Mutex<Vec<String>>>,
-    active_conns: Arc<Mutex<HashMap<NodeId, PeerConnection>>>,
-    selected_connections: Arc<Mutex<Vec<PeerConnection>>>,
-    managed_peers: Arc<Mutex<Vec<NodeId>>>,
+    inner: Arc<Mutex<State>>,
     event_tx: broadcast::Sender<Arc<ConnectivityEvent>>,
-    connectivity_status: Arc<Mutex<ConnectivityStatus>>,
+}
+
+#[derive(Debug, Default)]
+struct State {
+    calls: Vec<String>,
+    active_conns: HashMap<NodeId, PeerConnection>,
+    pending_conns: HashMap<NodeId, Vec<oneshot::Sender<Result<PeerConnection, ConnectionManagerError>>>>,
+    selected_connections: Vec<PeerConnection>,
+    managed_peers: Vec<NodeId>,
+    connectivity_status: ConnectivityStatus,
 }
 
 impl ConnectivityManagerMockState {
     pub fn new(event_tx: broadcast::Sender<Arc<ConnectivityEvent>>) -> Self {
         Self {
-            calls: Arc::new(Mutex::new(Vec::new())),
             event_tx,
-            selected_connections: Arc::new(Mutex::new(Vec::new())),
-            managed_peers: Arc::new(Mutex::new(Vec::new())),
-            active_conns: Arc::new(Mutex::new(HashMap::new())),
-            connectivity_status: Arc::new(Mutex::new(ConnectivityStatus::Initializing)),
+            inner: Default::default(),
         }
     }
 
     async fn add_call(&self, call_str: String) {
-        self.calls.lock().await.push(call_str);
+        self.with_state(|state| state.calls.push(call_str)).await
     }
 
     pub async fn take_calls(&self) -> Vec<String> {
-        self.calls.lock().await.drain(..).collect()
+        self.with_state(|state| state.calls.drain(..).collect()).await
     }
 
     pub async fn count_calls_containing(&self, pat: &str) -> usize {
-        self.calls.lock().await.iter().filter(|s| s.contains(pat)).count()
+        self.with_state(|state| state.calls.iter().filter(|s| s.contains(pat)).count())
+            .await
     }
 
     pub async fn get_selected_connections(&self) -> Vec<PeerConnection> {
-        self.selected_connections.lock().await.clone()
+        self.with_state(|state| state.selected_connections.clone()).await
     }
 
     pub async fn set_selected_connections(&self, conns: Vec<PeerConnection>) {
-        *self.selected_connections.lock().await = conns;
+        self.with_state(|state| {
+            state.selected_connections = conns;
+        })
+        .await
     }
 
     pub async fn set_connectivity_status(&self, status: ConnectivityStatus) {
-        *self.connectivity_status.lock().await = status;
+        self.with_state(|state| {
+            state.connectivity_status = status;
+        })
+        .await
     }
 
     pub async fn get_managed_peers(&self) -> Vec<NodeId> {
-        self.managed_peers.lock().await.clone()
+        self.with_state(|state| state.managed_peers.clone()).await
     }
 
     #[allow(dead_code)]
     pub async fn call_count(&self) -> usize {
-        self.calls.lock().await.len()
+        self.with_state(|state| state.calls.len()).await
+    }
+
+    pub async fn expect_dial_peer(&self, peer: &NodeId) {
+        let is_found = self
+            .with_state(|state| {
+                let peer_str = peer.to_string();
+                state
+                    .calls
+                    .iter()
+                    .any(|s| s.contains("DialPeer") && s.contains(&peer_str))
+            })
+            .await;
+
+        assert!(is_found, "expected call to dial peer {} but no dial was found", peer);
+    }
+
+    pub async fn await_call_count(&self, count: usize) {
+        let mut attempts = 0;
+        while self.call_count().await < count {
+            attempts += 1;
+            assert!(
+                attempts <= 10,
+                "expected call count to equal {} within 1 second but it was {}",
+                count,
+                self.call_count().await
+            );
+            time::delay_for(Duration::from_millis(100)).await;
+        }
     }
 
     pub async fn add_active_connection(&self, conn: PeerConnection) {
-        self.active_conns.lock().await.insert(conn.peer_node_id().clone(), conn);
+        self.with_state(|state| {
+            let peer = conn.peer_node_id();
+            state.active_conns.insert(peer.clone(), conn.clone());
+            if let Some(replies) = state.pending_conns.remove(&peer) {
+                replies.into_iter().for_each(|reply| {
+                    reply.send(Ok(conn.clone())).unwrap();
+                });
+            }
+        })
+        .await
+    }
+
+    pub async fn set_pending_connection(&self, peer: &NodeId) {
+        self.with_state(|state| {
+            state.pending_conns.entry(peer.clone()).or_default();
+        })
+        .await
     }
 
     #[allow(dead_code)]
     pub fn publish_event(&self, event: ConnectivityEvent) {
         self.event_tx.send(Arc::new(event)).unwrap();
+    }
+
+    pub(self) async fn with_state<F, R>(&self, f: F) -> R
+    where F: FnOnce(&mut State) -> R {
+        let mut lock = self.inner.lock().await;
+        (f)(&mut *lock)
     }
 }
 
@@ -124,8 +188,10 @@ impl ConnectivityManagerMock {
         self.state.clone()
     }
 
-    pub fn spawn(self) {
+    pub fn spawn(self) -> ConnectivityManagerMockState {
+        let state = self.get_shared_state();
         task::spawn(Self::run(self));
+        state
     }
 
     pub async fn run(mut self) {
@@ -140,51 +206,71 @@ impl ConnectivityManagerMock {
         match req {
             DialPeer(node_id, reply) => {
                 // Send Ok(conn) if we have an active connection, otherwise Err(DialConnectFailedAllAddresses)
-                let _ = reply.send(
-                    self.state
-                        .active_conns
-                        .lock()
-                        .await
-                        .get(&node_id)
-                        .cloned()
-                        .ok_or(ConnectionManagerError::DialConnectFailedAllAddresses)
-                        .map_err(Into::into),
-                );
+                self.state
+                    .with_state(|state| match state.pending_conns.get_mut(&node_id) {
+                        Some(replies) => {
+                            replies.push(reply);
+                        },
+                        None => {
+                            let _ = reply.send(
+                                state
+                                    .active_conns
+                                    .get(&node_id)
+                                    .cloned()
+                                    .ok_or(ConnectionManagerError::DialConnectFailedAllAddresses)
+                                    .map_err(Into::into),
+                            );
+                        },
+                    })
+                    .await;
             },
             GetConnectivityStatus(reply) => {
-                reply.send(*self.state.connectivity_status.lock().await).unwrap();
+                self.state
+                    .with_state(|state| {
+                        reply.send(state.connectivity_status).unwrap();
+                    })
+                    .await;
             },
             AddManagedPeers(peers) => {
                 // TODO: we should not have to implement behaviour of the actor in the mock
                 //       but should rather have a _good_ way to check the call to the mock
                 //       was made with the correct arguments.
-                let mut lock = self.state.managed_peers.lock().await;
-                for peer in peers {
-                    if !lock.contains(&peer) {
-                        lock.push(peer.clone());
-                    }
-                }
+                self.state
+                    .with_state(|state| {
+                        let managed_peers = &mut state.managed_peers;
+                        for peer in peers {
+                            if !managed_peers.contains(&peer) {
+                                managed_peers.push(peer.clone());
+                            }
+                        }
+                    })
+                    .await
             },
             RemovePeer(node_id) => {
-                let mut lock = self.state.managed_peers.lock().await;
-                if let Some(pos) = lock.iter().position(|n| n == &node_id) {
-                    lock.remove(pos);
-                }
+                self.state
+                    .with_state(|state| {
+                        if let Some(pos) = state.managed_peers.iter().position(|n| n == &node_id) {
+                            state.managed_peers.remove(pos);
+                        }
+                    })
+                    .await;
             },
             SelectConnections(_, reply) => {
                 reply.send(Ok(self.state.get_selected_connections().await)).unwrap();
             },
             GetConnection(node_id, reply) => {
-                reply
-                    .send(self.state.active_conns.lock().await.get(&node_id).cloned())
-                    .unwrap();
+                self.state
+                    .with_state(|state| {
+                        reply.send(state.active_conns.get(&node_id).cloned()).unwrap();
+                    })
+                    .await
             },
             GetAllConnectionStates(_) => unimplemented!(),
             BanPeer(_, _, _) => {},
             GetActiveConnections(reply) => {
-                reply
-                    .send(self.state.active_conns.lock().await.values().cloned().collect())
-                    .unwrap();
+                self.state
+                    .with_state(|state| reply.send(state.active_conns.values().cloned().collect()).unwrap())
+                    .await;
             },
             WaitStarted(reply) => reply.send(()).unwrap(),
         }

--- a/infrastructure/test_utils/Cargo.toml
+++ b/infrastructure/test_utils/Cargo.toml
@@ -9,6 +9,7 @@ license = "BSD-3-Clause"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+tari_shutdown = {version="*", path="../shutdown"}
 futures-test = { version = "^0.3.1" }
 futures = {version= "^0.3.1"}
 rand = "0.8"

--- a/infrastructure/test_utils/src/futures/async_assert_eventually.rs
+++ b/infrastructure/test_utils/src/futures/async_assert_eventually.rs
@@ -85,4 +85,11 @@ macro_rules! async_assert {
             tokio::time::delay_for($interval).await;
         }
     }};
+    ($check_expr:expr$(,)?) => {{
+        async_assert!(
+            $check_expr,
+            max_attempts = 10,
+            interval = std::time::Duration::from_millis(100)
+        )
+    }};
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds a service responsible for wallet connectivity. This service
is responsible for and abstracts any complexity in the management of
the base node connections and RPC session management.

This PR makes use of this service in the base node montoring service but
does not "plumb" the WalletConenctivityService into the protocols. This
is left as a TODO, but we should expect this to remove many lines of
code and greaty simplify these protocols by removing the budren of
connection management in the various wallet components.

A number of simplifications on the peer connection and substream code,
debatably reducing places that bugs could hide.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Follow on from #3152, making use of the pool in the wallet base node monitoring. The rest of the protocols should follow. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Extensive service unit tests
Existing tests pass

Washing machine test on local wallet, with the broadcast protocol modified to use the wallet connectivity 
Base node RPC sessions max out at 10 each (2 wallets connected to same base node) even when pushing through 426 transactions.
![image](https://user-images.githubusercontent.com/1057902/128175630-52617736-f71f-4865-a915-6d6c9b00e8d5.png)

Manually tested wallet connectivity states (Connecting -> Online | Connecting -> Offline | Connecting -> Online -> Offline -> Connecting -> Online)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I have squashed my commits into a single commit.
