### PR TITLE
fix: ban peer when Merkle roots mismatch

### DIFF
--- a/base_layer/core/src/base_node/state_machine_service/states/block_sync.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/block_sync.rs
@@ -58,6 +58,7 @@ impl BlockSync {
         shared: &mut BaseNodeStateMachine<B>,
     ) -> StateEvent {
         let mut synchronizer = BlockSynchronizer::new(
+            shared.config.block_sync_config.clone(),
             shared.db.clone(),
             shared.connectivity.clone(),
             self.sync_peer.take(),

--- a/base_layer/core/src/base_node/sync/block_sync/error.rs
+++ b/base_layer/core/src/base_node/sync/block_sync/error.rs
@@ -20,7 +20,7 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::{chain_storage::ChainStorageError, proof_of_work::PowError, validation::ValidationError};
+use crate::{chain_storage::ChainStorageError, validation::ValidationError};
 use tari_comms::{
     connectivity::ConnectivityError,
     protocol::rpc::{RpcError, RpcStatus},
@@ -42,10 +42,8 @@ pub enum BlockSyncError {
     ConnectivityError(#[from] ConnectivityError),
     #[error("No sync peers available")]
     NoSyncPeers,
-    #[error("Error fetching PoW: {0}")]
-    PowError(#[from] PowError),
-    //#[error("Expected to find header at height {0} however the header did not exist")]
-    // ExpectedHeaderNotFound(u64),
     #[error("Block validation failed: {0}")]
     ValidationError(#[from] ValidationError),
+    #[error("Failed to ban peer: {0}")]
+    FailedToBan(ConnectivityError),
 }

--- a/base_layer/core/src/base_node/sync/config.rs
+++ b/base_layer/core/src/base_node/sync/config.rs
@@ -25,9 +25,6 @@ use tari_comms::peer_manager::NodeId;
 
 #[derive(Debug, Clone)]
 pub struct BlockSyncConfig {
-    pub max_sync_peers: usize,
-    pub num_tip_hashes: usize,
-    pub num_proof_headers: usize,
     pub ban_period: Duration,
     pub short_ban_period: Duration,
     pub sync_peers: Vec<NodeId>,
@@ -36,9 +33,6 @@ pub struct BlockSyncConfig {
 impl Default for BlockSyncConfig {
     fn default() -> Self {
         Self {
-            max_sync_peers: 10,
-            num_tip_hashes: 500,
-            num_proof_headers: 100,
             ban_period: Duration::from_secs(30 * 60),
             short_ban_period: Duration::from_secs(60),
             sync_peers: Default::default(),

--- a/base_layer/core/src/base_node/sync/header_sync/synchronizer.rs
+++ b/base_layer/core/src/base_node/sync/header_sync/synchronizer.rs
@@ -110,28 +110,28 @@ impl<'a, B: BlockchainBackend + 'static> HeaderSynchronizer<'a, B> {
                 Ok(()) => return Ok(peer_conn),
                 // Try another peer
                 Err(err @ BlockHeaderSyncError::NotInSync) => {
-                    debug!(target: LOG_TARGET, "{}", err);
+                    warn!(target: LOG_TARGET, "{}", err);
                 },
 
                 Err(err @ BlockHeaderSyncError::RpcError(RpcError::HandshakeError(RpcHandshakeError::TimedOut))) => {
-                    debug!(target: LOG_TARGET, "{}", err);
+                    warn!(target: LOG_TARGET, "{}", err);
                     self.ban_peer_short(node_id, BanReason::RpcNegotiationTimedOut).await?;
                 },
                 Err(BlockHeaderSyncError::ValidationFailed(err)) => {
-                    debug!(target: LOG_TARGET, "Block header validation failed: {}", err);
+                    warn!(target: LOG_TARGET, "Block header validation failed: {}", err);
                     self.ban_peer_long(node_id, err.into()).await?;
                 },
                 Err(BlockHeaderSyncError::ChainSplitNotFound(peer)) => {
-                    debug!(target: LOG_TARGET, "Chain split not found for peer {}.", peer);
+                    warn!(target: LOG_TARGET, "Chain split not found for peer {}.", peer);
                     self.ban_peer_long(peer, BanReason::ChainSplitNotFound).await?;
                 },
                 Err(err @ BlockHeaderSyncError::InvalidBlockHeight { .. }) => {
-                    debug!(target: LOG_TARGET, "{}", err);
+                    warn!(target: LOG_TARGET, "{}", err);
                     self.ban_peer_long(node_id, BanReason::GeneralHeaderSyncFailure(err))
                         .await?;
                 },
                 Err(err) => {
-                    debug!(
+                    error!(
                         target: LOG_TARGET,
                         "Failed to synchronize headers from peer `{}`: {}", node_id, err
                     );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Ban peer if block validation fails during block body sync

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When this error is encountered, the peer sent an invalid block body given the current header chain.  
`DEBUG Block sync failed: Block validation failed: Block validation error: Mismatched MMR roots`
The node should ban the peer. Previously, the node would encounter this, then retry the same peer,
rinse and repeat - preventing the node from syncing.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Not explicitly tested - fairly basic change.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I have squashed my commits into a single commit.
