### PR TITLE
fix: improve prune mode to remove panics

### DIFF
--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -30,7 +30,7 @@ use crate::{
         OutboundNodeCommsInterface,
     },
     blocks::{block_header::BlockHeader, Block, NewBlock, NewBlockTemplate},
-    chain_storage::{async_db::AsyncBlockchainDb, BlockAddResult, BlockchainBackend, ChainBlock},
+    chain_storage::{async_db::AsyncBlockchainDb, BlockAddResult, BlockchainBackend, ChainBlock, PrunedOutput},
     consensus::{ConsensusConstants, ConsensusManager},
     mempool::{async_mempool, Mempool},
     proof_of_work::{Difficulty, PowAlgorithm},
@@ -224,12 +224,14 @@ where T: BlockchainBackend + 'static
             },
             NodeCommsRequest::FetchMatchingUtxos(utxo_hashes) => {
                 let mut res = Vec::with_capacity(utxo_hashes.len());
-                for (output, spent) in (self.blockchain_db.fetch_utxos(utxo_hashes).await?)
+                for (pruned_output, spent) in (self.blockchain_db.fetch_utxos(utxo_hashes).await?)
                     .into_iter()
                     .flatten()
                 {
-                    if !spent {
-                        res.push(output);
+                    if let PrunedOutput::NotPruned { output } = pruned_output {
+                        if !spent {
+                            res.push(output);
+                        }
                     }
                 }
                 Ok(NodeCommsResponse::TransactionOutputs(res))
@@ -240,7 +242,10 @@ where T: BlockchainBackend + 'static
                     .fetch_utxos(hashes)
                     .await?
                     .into_iter()
-                    .filter_map(|opt| opt.map(|(output, _)| output))
+                    .filter_map(|opt| match opt {
+                        Some((PrunedOutput::NotPruned { output }, _)) => Some(output),
+                        _ => None,
+                    })
                     .collect();
                 Ok(NodeCommsResponse::TransactionOutputs(res))
             },

--- a/base_layer/core/src/base_node/comms_interface/local_interface.rs
+++ b/base_layer/core/src/base_node/comms_interface/local_interface.rs
@@ -32,7 +32,7 @@ use crate::{
     chain_storage::HistoricalBlock,
     proof_of_work::PowAlgorithm,
     transactions::{
-        transaction::{TransactionKernel, TransactionOutput},
+        transaction::TransactionKernel,
         types::{Commitment, HashOutput, Signature},
     },
 };
@@ -43,7 +43,10 @@ use tokio::sync::broadcast;
 
 pub type BlockEventSender = broadcast::Sender<Arc<BlockEvent>>;
 pub type BlockEventReceiver = broadcast::Receiver<Arc<BlockEvent>>;
-use crate::base_node::comms_interface::comms_request::GetNewBlockTemplateRequest;
+use crate::{
+    base_node::comms_interface::comms_request::GetNewBlockTemplateRequest,
+    transactions::transaction::TransactionOutput,
+};
 
 /// The InboundNodeCommsInterface provides an interface to request information from the current local node by other
 /// internal services.

--- a/base_layer/core/src/chain_storage/async_db.rs
+++ b/base_layer/core/src/chain_storage/async_db.rs
@@ -139,9 +139,9 @@ impl<B: BlockchainBackend + 'static> AsyncBlockchainDb<B> {
     make_async_fn!(fetch_horizon_data() -> Option<HorizonData>, "fetch_horizon_data");
 
     //---------------------------------- TXO --------------------------------------------//
-    make_async_fn!(fetch_utxo(hash: HashOutput) -> Option<TransactionOutput>, "fetch_utxo");
+    make_async_fn!(fetch_utxo(hash: HashOutput) -> Option<PrunedOutput>, "fetch_utxo");
 
-    make_async_fn!(fetch_utxos(hashes: Vec<HashOutput>) -> Vec<Option<(TransactionOutput, bool)>>, "fetch_utxos");
+    make_async_fn!(fetch_utxos(hashes: Vec<HashOutput>) -> Vec<Option<(PrunedOutput, bool)>>, "fetch_utxos");
 
     make_async_fn!(fetch_utxos_by_mmr_position(start: u64, end: u64, deleted: Arc<Bitmap>) -> (Vec<PrunedOutput>, Bitmap), "fetch_utxos_by_mmr_position");
 

--- a/base_layer/core/src/chain_storage/blockchain_backend.rs
+++ b/base_layer/core/src/chain_storage/blockchain_backend.rs
@@ -15,7 +15,7 @@ use crate::{
         MmrTree,
     },
     transactions::{
-        transaction::{TransactionInput, TransactionKernel, TransactionOutput},
+        transaction::{TransactionInput, TransactionKernel},
         types::{HashOutput, Signature},
     },
 };
@@ -103,10 +103,7 @@ pub trait BlockchainBackend: Send + Sync {
     ) -> Result<(Vec<PrunedOutput>, Bitmap), ChainStorageError>;
 
     /// Fetch a specific output. Returns the output and the leaf index in the output MMR
-    fn fetch_output(
-        &self,
-        output_hash: &HashOutput,
-    ) -> Result<Option<(TransactionOutput, u32, u64)>, ChainStorageError>;
+    fn fetch_output(&self, output_hash: &HashOutput) -> Result<Option<(PrunedOutput, u32, u64)>, ChainStorageError>;
 
     /// Fetch all outputs in a block
     fn fetch_outputs_in_block(&self, header_hash: &HashOutput) -> Result<Vec<PrunedOutput>, ChainStorageError>;

--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -47,7 +47,7 @@ use crate::{
     proof_of_work::{monero_rx::MoneroPowData, PowAlgorithm, TargetDifficultyWindow},
     tari_utilities::epoch_time::EpochTime,
     transactions::{
-        transaction::{TransactionKernel, TransactionOutput},
+        transaction::TransactionKernel,
         types::{Commitment, HashDigest, HashOutput, Signature},
     },
     validation::{DifficultyCalculator, HeaderValidation, OrphanValidation, PostOrphanBodyValidation, ValidationError},
@@ -284,7 +284,7 @@ where B: BlockchainBackend
     }
 
     // Fetch the utxo
-    pub fn fetch_utxo(&self, hash: HashOutput) -> Result<Option<TransactionOutput>, ChainStorageError> {
+    pub fn fetch_utxo(&self, hash: HashOutput) -> Result<Option<PrunedOutput>, ChainStorageError> {
         let db = self.db_read_access()?;
         Ok(db.fetch_output(&hash)?.map(|(out, _index, _)| out))
     }
@@ -292,10 +292,7 @@ where B: BlockchainBackend
     /// Return a list of matching utxos, with each being `None` if not found. If found, the transaction
     /// output, and a boolean indicating if the UTXO was spent as of the block hash specified or the tip if not
     /// specified.
-    pub fn fetch_utxos(
-        &self,
-        hashes: Vec<HashOutput>,
-    ) -> Result<Vec<Option<(TransactionOutput, bool)>>, ChainStorageError> {
+    pub fn fetch_utxos(&self, hashes: Vec<HashOutput>) -> Result<Vec<Option<(PrunedOutput, bool)>>, ChainStorageError> {
         let db = self.db_read_access()?;
         let deleted = db.fetch_deleted_bitmap()?;
 

--- a/base_layer/core/src/chain_storage/pruned_output.rs
+++ b/base_layer/core/src/chain_storage/pruned_output.rs
@@ -22,6 +22,7 @@
 use crate::transactions::{transaction::TransactionOutput, types::HashOutput};
 
 #[allow(clippy::large_enum_variant)]
+#[derive(Debug, PartialEq)]
 pub enum PrunedOutput {
     Pruned {
         output_hash: HashOutput,

--- a/base_layer/core/src/test_helpers/blockchain.rs
+++ b/base_layer/core/src/test_helpers/blockchain.rs
@@ -44,7 +44,7 @@ use crate::{
     },
     consensus::{chain_strength_comparer::ChainStrengthComparerBuilder, ConsensusConstantsBuilder, ConsensusManager},
     transactions::{
-        transaction::{TransactionInput, TransactionKernel, TransactionOutput},
+        transaction::{TransactionInput, TransactionKernel},
         types::{CryptoFactories, HashOutput, Signature},
     },
     validation::{
@@ -244,10 +244,7 @@ impl BlockchainBackend for TempDatabase {
         self.db.fetch_utxos_by_mmr_position(start, end, deleted)
     }
 
-    fn fetch_output(
-        &self,
-        output_hash: &HashOutput,
-    ) -> Result<Option<(TransactionOutput, u32, u64)>, ChainStorageError> {
+    fn fetch_output(&self, output_hash: &HashOutput) -> Result<Option<(PrunedOutput, u32, u64)>, ChainStorageError> {
         self.db.fetch_output(output_hash)
     }
 

--- a/base_layer/core/tests/async_db.rs
+++ b/base_layer/core/tests/async_db.rs
@@ -33,7 +33,7 @@ use std::ops::Deref;
 use tari_common::configuration::Network;
 use tari_core::{
     blocks::Block,
-    chain_storage::{async_db::AsyncBlockchainDb, BlockAddResult},
+    chain_storage::{async_db::AsyncBlockchainDb, BlockAddResult, PrunedOutput},
     transactions::{
         helpers::schema_to_transaction,
         tari_amount::T,
@@ -103,11 +103,11 @@ fn fetch_async_utxo() {
         let db2 = AsyncBlockchainDb::new(adb);
         rt.spawn(async move {
             let utxo_check = db.fetch_utxo(utxo.hash()).await.unwrap().unwrap();
-            assert_eq!(utxo_check, utxo);
+            assert_eq!(utxo_check, PrunedOutput::NotPruned { output: utxo });
         });
         rt.spawn(async move {
             let stxo_check = db2.fetch_utxo(stxo.hash()).await.unwrap().unwrap();
-            assert_eq!(stxo_check, stxo);
+            assert_eq!(stxo_check, PrunedOutput::NotPruned { output: stxo });
         });
     });
 }

--- a/base_layer/core/tests/node_comms_interface.rs
+++ b/base_layer/core/tests/node_comms_interface.rs
@@ -22,7 +22,6 @@
 
 #[allow(dead_code)]
 mod helpers;
-
 use futures::{channel::mpsc, StreamExt};
 use helpers::block_builders::append_block;
 use std::sync::Arc;
@@ -39,10 +38,22 @@ use tari_core::{
     consensus::{ConsensusManager, NetworkConsensus},
     mempool::{Mempool, MempoolConfig},
     test_helpers::blockchain::{create_store_with_consensus_and_validators_and_config, create_test_blockchain_db},
-    transactions::{helpers::create_utxo, tari_amount::MicroTari, types::CryptoFactories},
+    transactions::{
+        helpers::{create_utxo, spend_utxos},
+        tari_amount::MicroTari,
+        transaction::{OutputFeatures, TransactionOutput, UnblindedOutput},
+        types::{CryptoFactories, PublicKey},
+    },
+    txn_schema,
     validation::{mocks::MockValidator, transaction_validators::TxInputAndMaturityValidator},
 };
-use tari_crypto::{script::TariScript, tari_utilities::hash::Hashable};
+use tari_crypto::{
+    inputs,
+    keys::PublicKey as PublicKeyTrait,
+    script,
+    script::TariScript,
+    tari_utilities::hash::Hashable,
+};
 use tari_service_framework::{reply_channel, reply_channel::Receiver};
 use tokio::sync::broadcast;
 // use crate::helpers::database::create_test_db;
@@ -285,21 +296,31 @@ async fn inbound_fetch_txos() {
     );
 
     let (utxo, _, _) = create_utxo(MicroTari(10_000), &factories, None, &TariScript::default());
+    let (pruned_utxo, _, _) = create_utxo(MicroTari(10_000), &factories, None, &TariScript::default());
     let (stxo, _, _) = create_utxo(MicroTari(10_000), &factories, None, &TariScript::default());
     let utxo_hash = utxo.hash();
     let stxo_hash = stxo.hash();
+    let pruned_utxo_hash = pruned_utxo.hash();
     let block = store.fetch_block(0).unwrap().block().clone();
     let header_hash = block.header.hash();
     let mut txn = DbTransaction::new();
     txn.insert_utxo(utxo.clone(), header_hash.clone(), block.header.height, 6000);
     txn.insert_utxo(stxo.clone(), header_hash.clone(), block.header.height, 6001);
+    txn.insert_pruned_utxo(
+        pruned_utxo_hash.clone(),
+        pruned_utxo.witness_hash(),
+        header_hash.clone(),
+        5,
+        6002,
+    );
     assert!(store.commit(txn).is_ok());
-    // let mut txn = DbTransaction::new();
-    // txn.insert_input(stxo.clone().into(), header_hash.clone(), 1);
-    // assert!(store.commit(txn).is_ok());
 
     if let Ok(NodeCommsResponse::TransactionOutputs(received_txos)) = inbound_nch
-        .handle_request(NodeCommsRequest::FetchMatchingTxos(vec![utxo_hash, stxo_hash]))
+        .handle_request(NodeCommsRequest::FetchMatchingTxos(vec![
+            utxo_hash,
+            stxo_hash,
+            pruned_utxo_hash,
+        ]))
         .await
     {
         assert_eq!(received_txos.len(), 2);
@@ -360,9 +381,9 @@ async fn inbound_fetch_blocks() {
 }
 
 #[tokio_macros::test]
-#[ignore]
 // Test needs to be updated to new pruned structure.
 async fn inbound_fetch_blocks_before_horizon_height() {
+    let factories = CryptoFactories::default();
     let network = Network::LocalNet;
     let consensus_manager = ConsensusManager::builder(network).build();
     let block0 = consensus_manager.get_genesis_block();
@@ -390,8 +411,36 @@ async fn inbound_fetch_blocks_before_horizon_height() {
         consensus_manager.clone(),
         outbound_nci,
     );
+    let script = script!(Nop);
+    let (utxo, key, offset) = create_utxo(MicroTari(10_000), &factories, None, &script);
+    let metadata_signature = TransactionOutput::create_final_metadata_signature(
+        &MicroTari(10_000),
+        &key,
+        &script,
+        &OutputFeatures::default(),
+        &offset,
+    )
+    .unwrap();
+    let unblinded_output = UnblindedOutput::new(
+        MicroTari(10_000),
+        key.clone(),
+        None,
+        script,
+        inputs!(PublicKey::from_secret_key(&key)),
+        key,
+        PublicKey::from_secret_key(&offset),
+        metadata_signature,
+    );
+    let mut txn = DbTransaction::new();
+    txn.insert_utxo(utxo.clone(), block0.hash().clone(), 0, 4002);
+    assert!(store.commit(txn).is_ok());
 
-    let block1 = append_block(&store, &block0, vec![], &consensus_manager, 1.into()).unwrap();
+    let txn = txn_schema!(
+        from: vec![unblinded_output],
+        to: vec![MicroTari(5_000), MicroTari(4_000)]
+    );
+    let (txn, _, _) = spend_utxos(txn);
+    let block1 = append_block(&store, &block0, vec![txn], &consensus_manager, 1.into()).unwrap();
     let block2 = append_block(&store, &block1, vec![], &consensus_manager, 1.into()).unwrap();
     let block3 = append_block(&store, &block2, vec![], &consensus_manager, 1.into()).unwrap();
     let block4 = append_block(&store, &block3, vec![], &consensus_manager, 1.into()).unwrap();
@@ -401,7 +450,8 @@ async fn inbound_fetch_blocks_before_horizon_height() {
         .handle_request(NodeCommsRequest::FetchMatchingBlocks(vec![1]))
         .await
     {
-        assert_eq!(received_blocks.len(), 0);
+        assert_eq!(received_blocks.len(), 1);
+        assert_eq!(received_blocks[0].pruned_outputs().len(), 1)
     } else {
         panic!();
     }

--- a/integration_tests/features/Sync.feature
+++ b/integration_tests/features/Sync.feature
@@ -103,6 +103,22 @@ Feature: Block Sync
     When I mine 15 blocks on PNODE2
     Then all nodes are at height 23
 
+    Scenario: Node should not sync from pruned node
+    Given I have a base node NODE1 connected to all seed nodes
+    Given I have a pruned node PNODE1 connected to node NODE1 with pruning horizon set to 5
+    When I mine 40 blocks on NODE1
+    Then all nodes are at height 40
+    When I stop node NODE1
+    Given I have a base node NODE2 connected to node PNODE1
+    Given I have a pruned node PNODE2 connected to node PNODE1 with pruning horizon set to 5
+    When I mine 5 blocks on NODE2
+    Then node NODE2 is at height 5
+    Then node PNODE2 is at height 40
+    When I start NODE1
+    # We need for node to boot up and supply node 2 with blocks
+    And I connect node NODE2 to node NODE1 and wait 60 seconds
+    Then all nodes are at height 40
+
   Scenario Outline: Syncing node while also mining before tip sync
     Given I have a seed node SEED
     And I have wallet WALLET1 connected to seed node SEED


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When requesting pruned data on base_node, the node would panic as it tried to provide pruned data. 
Removed this panic and changed requests for `TransactionOutputs` to `PrunedOutputs` so that callee functions can decide what to do with the data. 
Fixed ignored pruned unit test. 
Added in cucumber test to prove nodes cant sync from pruned nodes and neither panics. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I have squashed my commits into a single commit.
