### PR TITLE
test: fix two cucumber tests to be less flaky

### DIFF
--- a/integration_tests/features/WalletTransactions.feature
+++ b/integration_tests/features/WalletTransactions.feature
@@ -12,6 +12,7 @@ Feature: Wallet Transactions
     And I have wallet WALLET_B connected to all seed nodes
     Then I send a one-sided transaction of 1000000 uT from WALLET_A to WALLET_B at fee 100
     Then I send a one-sided transaction of 1000000 uT from WALLET_A to WALLET_B at fee 100
+    Then wallet WALLET_A detects all transactions are at least Broadcast
     When I merge mine 5 blocks via PROXY
     Then all nodes are at height 20
     Then I wait for wallet WALLET_B to have at least 2000000 uT

--- a/integration_tests/features/support/steps.js
+++ b/integration_tests/features/support/steps.js
@@ -1673,6 +1673,12 @@ When(
         },
       ],
     });
+    expect(lastResult.results[0].is_success).to.equal(true);
+    const sourceInfo = await sourceClient.identify();
+    this.addTransaction(
+      sourceInfo.public_key,
+      lastResult.results[0].transaction_id
+    );
   }
 );
 
@@ -2630,13 +2636,27 @@ When(
     for (let i = 0; i < numberOfSplits; i++) {
       const splits = Math.min(499, splitsLeft);
       splitsLeft -= splits;
-      const result = await walletClient.coin_split({
-        amount_per_split: splitValue,
-        split_count: splits,
-        fee_per_gram: feePerGram,
-        message: "Cucumber coinsplit",
-        lockheight: 0,
-      });
+      let result;
+      await waitFor(
+        async () => {
+          try {
+            result = await walletClient.coin_split({
+              amount_per_split: splitValue,
+              split_count: splits,
+              fee_per_gram: feePerGram,
+              message: "Cucumber coinsplit",
+              lockheight: 0,
+            });
+          } catch (error) {
+            return false;
+          }
+          return true;
+        },
+        true,
+        4700 * 1000,
+        5 * 1000,
+        5
+      );
       console.log(
         "Coin split",
         i + 1,


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixed _"Ramped Stress Test"_ to be less flaky:
- A "FundsPending" error returned from the coin split step will now be handled gracefully and not stop the test

Fixed _"Wallet sending and receiving one-sided transactions"_ to be less flaky:
- Wallet A will monitor transactions to be at least broadcast when sending one-sided transactions to wallet B before mining will commence

## Motivation and Context
Cucumber tests were flaky.

## How Has This Been Tested?
Running the integration tests in question.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I have squashed my commits into a single commit.
