### PR TITLE
chore: update to cucumber test to use sydney seed monero url address

### DIFF
--- a/integration_tests/helpers/mergeMiningProxyProcess.js
+++ b/integration_tests/helpers/mergeMiningProxyProcess.js
@@ -65,6 +65,8 @@ class MergeMiningProxyProcess {
       const extraEnvs = {
         TARI_MERGE_MINING_PROXY__LOCALNET__PROXY_SUBMIT_TO_ORIGIN:
           this.submitOrigin,
+        TARI_MERGE_MINING_PROXY__LOCALNET__monerod_url:
+          "http://3.104.4.129:18081",
       };
       const completeEnvs = { ...envs, ...extraEnvs };
       const ps = spawn(cmd, args, {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Changed the monero URL address used by the cucumber test from: `http://monero-stagenet.exan.tech:38081` to `http://3.104.4.129:18081/`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I'm merging against the `development` branch.
* [ ] I have squashed my commits into a single commit.
