### PR TITLE
test: add wallet ffi testing

### DIFF
--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -38,8 +38,8 @@
 extern "C" {
 #endif
 
-#include <stdio.h>
 #include <stdbool.h>
+#include <stdio.h>
 
 struct ByteVector;
 
@@ -48,8 +48,6 @@ struct TariCommsConfig;
 struct TariPrivateKey;
 
 struct TariWallet;
-
-struct TariWalletConfig;
 
 struct TariPublicKey;
 
@@ -87,7 +85,7 @@ struct TariExcessSignature;
 struct TariTransportType *transport_memory_create();
 
 // Creates a tcp transport type
-struct TariTransportType *transport_tcp_create(const char *listener_address,int* error_out);
+struct TariTransportType *transport_tcp_create(const char *listener_address, int *error_out);
 
 // Creates a tor transport type
 struct TariTransportType *transport_tor_create(
@@ -96,10 +94,10 @@ struct TariTransportType *transport_tor_create(
     unsigned short tor_port,
     const char *socks_username,
     const char *socks_password,
-    int* error_out);
+    int *error_out);
 
 // Gets the address from a memory transport type
-char *transport_memory_get_address(struct TariTransportType *transport,int* error_out);
+char *transport_memory_get_address(struct TariTransportType *transport, int *error_out);
 
 // Frees memory for a transport type
 void transport_type_destroy(struct TariTransportType *transport);
@@ -112,13 +110,13 @@ void string_destroy(char *s);
 /// -------------------------------- ByteVector ----------------------------------------------- ///
 
 // Creates a ByteVector
-struct ByteVector *byte_vector_create(const unsigned char *byte_array, unsigned int element_count, int* error_out);
+struct ByteVector *byte_vector_create(const unsigned char *byte_array, unsigned int element_count, int *error_out);
 
 // Gets a char from a ByteVector
-unsigned char byte_vector_get_at(struct ByteVector *ptr, unsigned int i, int* error_out);
+unsigned char byte_vector_get_at(struct ByteVector *ptr, unsigned int i, int *error_out);
 
 // Returns the number of elements in a ByteVector
-unsigned int byte_vector_get_length(const struct ByteVector *vec, int* error_out);
+unsigned int byte_vector_get_length(const struct ByteVector *vec, int *error_out);
 
 // Frees memory for a ByteVector pointer
 void byte_vector_destroy(struct ByteVector *bytes);
@@ -126,39 +124,39 @@ void byte_vector_destroy(struct ByteVector *bytes);
 /// -------------------------------- TariPublicKey ----------------------------------------------- ///
 
 // Creates a TariPublicKey from a ByteVector
-struct TariPublicKey *public_key_create(struct ByteVector *bytes,int* error_out);
+struct TariPublicKey *public_key_create(struct ByteVector *bytes, int *error_out);
 
 // Gets a ByteVector from a TariPublicKey
-struct ByteVector *public_key_get_bytes(struct TariPublicKey *public_key,int* error_out);
+struct ByteVector *public_key_get_bytes(struct TariPublicKey *public_key, int *error_out);
 
 // Creates a TariPublicKey from a TariPrivateKey
-struct TariPublicKey *public_key_from_private_key(struct TariPrivateKey *secret_key,int* error_out);
+struct TariPublicKey *public_key_from_private_key(struct TariPrivateKey *secret_key, int *error_out);
 
 // Creates a TariPublicKey from a const char* filled with hexadecimal characters
-struct TariPublicKey *public_key_from_hex(const char *hex,int* error_out);
+struct TariPublicKey *public_key_from_hex(const char *hex, int *error_out);
 
 // Frees memory for a TariPublicKey pointer
 void public_key_destroy(struct TariPublicKey *pk);
 
 //Converts a TariPublicKey to char array in emoji format
-char *public_key_to_emoji_id(struct TariPublicKey *pk, int* error_out);
+char *public_key_to_emoji_id(struct TariPublicKey *pk, int *error_out);
 
 // Converts a char array in emoji format to a public key
-struct TariPublicKey *emoji_id_to_public_key(const char *emoji,  int* error_out);
+struct TariPublicKey *emoji_id_to_public_key(const char *emoji, int *error_out);
 
 /// -------------------------------- TariPrivateKey ----------------------------------------------- ///
 
 // Creates a TariPrivateKey from a ByteVector
-struct TariPrivateKey *private_key_create(struct ByteVector *bytes,int* error_out);
+struct TariPrivateKey *private_key_create(struct ByteVector *bytes, int *error_out);
 
 // Generates a TariPrivateKey
 struct TariPrivateKey *private_key_generate(void);
 
 // Creates a ByteVector from a TariPrivateKey
-struct ByteVector *private_key_get_bytes(struct TariPrivateKey *private_key,int* error_out);
+struct ByteVector *private_key_get_bytes(struct TariPrivateKey *private_key, int *error_out);
 
 // Creates a TariPrivateKey from a const char* filled with hexadecimal characters
-struct TariPrivateKey *private_key_from_hex(const char *hex,int* error_out);
+struct TariPrivateKey *private_key_from_hex(const char *hex, int *error_out);
 
 // Frees memory for a TariPrivateKey
 void private_key_destroy(struct TariPrivateKey *pk);
@@ -168,10 +166,10 @@ void private_key_destroy(struct TariPrivateKey *pk);
 struct TariSeedWords *seed_words_create();
 
 // Get the number of seed words in the provided collection
-unsigned int seed_words_get_length(struct TariSeedWords *seed_words, int* error_out);
+unsigned int seed_words_get_length(struct TariSeedWords *seed_words, int *error_out);
 
 // Get a seed word from the provided collection at the specified position
-char *seed_words_get_at(struct TariSeedWords *seed_words, unsigned int position, int* error_out);
+char *seed_words_get_at(struct TariSeedWords *seed_words, unsigned int position, int *error_out);
 
 /// Add a word to the provided TariSeedWords instance
 ///
@@ -190,7 +188,7 @@ char *seed_words_get_at(struct TariSeedWords *seed_words, unsigned int position,
 ///     '3' -> InvalidSeedPhrase
 /// # Safety
 /// The ```string_destroy``` method must be called when finished with a string from rust to prevent a memory leak
-unsigned char seed_words_push_word(struct TariSeedWords *seed_words,  const char *word, int* error_out);
+unsigned char seed_words_push_word(struct TariSeedWords *seed_words, const char *word, int *error_out);
 
 // Frees the memory for a TariSeedWords collection
 void seed_words_destroy(struct TariSeedWords *seed_words);
@@ -198,13 +196,13 @@ void seed_words_destroy(struct TariSeedWords *seed_words);
 /// -------------------------------- Contact ------------------------------------------------------ ///
 
 // Creates a TariContact
-struct TariContact *contact_create(const char *alias, struct TariPublicKey *public_key,int* error_out);
+struct TariContact *contact_create(const char *alias, struct TariPublicKey *public_key, int *error_out);
 
 // Gets the alias of the TariContact
-char *contact_get_alias(struct TariContact *contact,int* error_out);
+char *contact_get_alias(struct TariContact *contact, int *error_out);
 
 /// Gets the TariPublicKey of the TariContact
-struct TariPublicKey *contact_get_public_key(struct TariContact *contact, int* error_out);
+struct TariPublicKey *contact_get_public_key(struct TariContact *contact, int *error_out);
 
 // Frees memory for a TariContact
 void contact_destroy(struct TariContact *contact);
@@ -212,10 +210,10 @@ void contact_destroy(struct TariContact *contact);
 /// -------------------------------- Contacts ------------------------------------------------------ ///
 
 // Gets the number of elements of TariContacts
-unsigned int contacts_get_length(struct TariContacts *contacts,int* error_out);
+unsigned int contacts_get_length(struct TariContacts *contacts, int *error_out);
 
 // Gets a TariContact from TariContacts at position
-struct TariContact *contacts_get_at(struct TariContacts *contacts, unsigned int position,int* error_out);
+struct TariContact *contacts_get_at(struct TariContacts *contacts, unsigned int position, int *error_out);
 
 // Frees memory for TariContacts
 void contacts_destroy(struct TariContacts *contacts);
@@ -223,19 +221,19 @@ void contacts_destroy(struct TariContacts *contacts);
 /// -------------------------------- CompletedTransaction ------------------------------------------------------ ///
 
 // Gets the destination TariPublicKey of a TariCompletedTransaction
-struct TariPublicKey *completed_transaction_get_destination_public_key(struct TariCompletedTransaction *transaction,int* error_out);
+struct TariPublicKey *completed_transaction_get_destination_public_key(struct TariCompletedTransaction *transaction, int *error_out);
 
 // Gets the source TariPublicKey of a TariCompletedTransaction
-struct TariPublicKey *completed_transaction_get_source_public_key(struct TariCompletedTransaction *transaction,int* error_out);
+struct TariPublicKey *completed_transaction_get_source_public_key(struct TariCompletedTransaction *transaction, int *error_out);
 
 // Gets the amount of a TariCompletedTransaction
-unsigned long long completed_transaction_get_amount(struct TariCompletedTransaction *transaction,int* error_out);
+unsigned long long completed_transaction_get_amount(struct TariCompletedTransaction *transaction, int *error_out);
 
 // Gets the fee of a TariCompletedTransaction
-unsigned long long completed_transaction_get_fee(struct TariCompletedTransaction *transaction,int* error_out);
+unsigned long long completed_transaction_get_fee(struct TariCompletedTransaction *transaction, int *error_out);
 
 // Gets the message of a TariCompletedTransaction
-const char *completed_transaction_get_message(struct TariCompletedTransaction *transaction,int* error_out);
+const char *completed_transaction_get_message(struct TariCompletedTransaction *transaction, int *error_out);
 
 // Gets the status of a TariCompletedTransaction
 // | Value | Interpretation |
@@ -246,35 +244,35 @@ const char *completed_transaction_get_message(struct TariCompletedTransaction *t
 // |   2 | Mined       |
 // |   3 | Imported    |
 // |   4 | Pending     |
-int completed_transaction_get_status(struct TariCompletedTransaction *transaction,int* error_out);
+int completed_transaction_get_status(struct TariCompletedTransaction *transaction, int *error_out);
 
 // Gets the TransactionID of a TariCompletedTransaction
-unsigned long long completed_transaction_get_transaction_id(struct TariCompletedTransaction *transaction,int* error_out);
+unsigned long long completed_transaction_get_transaction_id(struct TariCompletedTransaction *transaction, int *error_out);
 
 // Gets the timestamp of a TariCompletedTransaction
-unsigned long long completed_transaction_get_timestamp(struct TariCompletedTransaction *transaction,int* error_out);
+unsigned long long completed_transaction_get_timestamp(struct TariCompletedTransaction *transaction, int *error_out);
 
 // Check if a TariCompletedTransaction is Valid or not
-bool completed_transaction_is_valid(struct TariCompletedTransaction *tx,int* error_out);
+bool completed_transaction_is_valid(struct TariCompletedTransaction *tx, int *error_out);
 
 // Checks if a TariCompletedTransaction was originally a TariPendingOutboundTransaction,
 // i.e the transaction was originally sent from the wallet
-bool completed_transaction_is_outbound(struct TariCompletedTransaction *tx,int* error_out);
+bool completed_transaction_is_outbound(struct TariCompletedTransaction *tx, int *error_out);
 
 /// Gets the number of confirmations of a TariCompletedTransaction
-unsigned long long completed_transaction_get_confirmations(struct TariCompletedTransaction *transaction,int* error_out);
+unsigned long long completed_transaction_get_confirmations(struct TariCompletedTransaction *transaction, int *error_out);
 
 // Frees memory for a TariCompletedTransaction
 void completed_transaction_destroy(struct TariCompletedTransaction *transaction);
 
 // Gets the TariExcess of a TariCompletedTransaction
-struct TariExcess *completed_transaction_get_excess(struct TariCompletedTransaction *transaction,int* error_out);
+struct TariExcess *completed_transaction_get_excess(struct TariCompletedTransaction *transaction, int *error_out);
 
 // Gets the TariExcessPublicNonce of a TariCompletedTransaction
-struct TariExcessPublicNonce *completed_transaction_get_public_nonce(struct TariCompletedTransaction *transaction,int* error_out);
+struct TariExcessPublicNonce *completed_transaction_get_public_nonce(struct TariCompletedTransaction *transaction, int *error_out);
 
 // Gets the TariExcessSignature of a TariCompletedTransaction
-struct TariExcessSignature *completed_transaction_get_signature(struct TariCompletedTransaction *transaction,int* error_out);
+struct TariExcessSignature *completed_transaction_get_signature(struct TariCompletedTransaction *transaction, int *error_out);
 
 // Frees memory for a TariExcess
 void excess_destroy(struct TariExcess *excess);
@@ -288,10 +286,10 @@ void signature_destroy(struct TariExcessSignature *signature);
 /// -------------------------------- CompletedTransactions ------------------------------------------------------ ///
 
 // Gets number of elements in TariCompletedTransactions
-unsigned int completed_transactions_get_length(struct TariCompletedTransactions *transactions,int* error_out);
+unsigned int completed_transactions_get_length(struct TariCompletedTransactions *transactions, int *error_out);
 
 // Gets a TariCompletedTransaction from a TariCompletedTransactions at position
-struct TariCompletedTransaction *completed_transactions_get_at(struct TariCompletedTransactions *transactions, unsigned int position,int* error_out);
+struct TariCompletedTransaction *completed_transactions_get_at(struct TariCompletedTransactions *transactions, unsigned int position, int *error_out);
 
 // Frees memory for a TariCompletedTransactions
 void completed_transactions_destroy(struct TariCompletedTransactions *transactions);
@@ -299,22 +297,22 @@ void completed_transactions_destroy(struct TariCompletedTransactions *transactio
 /// -------------------------------- OutboundTransaction ------------------------------------------------------ ///
 
 // Gets the TransactionId of a TariPendingOutboundTransaction
-unsigned long long pending_outbound_transaction_get_transaction_id(struct TariPendingOutboundTransaction *transaction,int* error_out);
+unsigned long long pending_outbound_transaction_get_transaction_id(struct TariPendingOutboundTransaction *transaction, int *error_out);
 
 // Gets the destination TariPublicKey of a TariPendingOutboundTransaction
-struct TariPublicKey *pending_outbound_transaction_get_destination_public_key(struct TariPendingOutboundTransaction *transaction,int* error_out);
+struct TariPublicKey *pending_outbound_transaction_get_destination_public_key(struct TariPendingOutboundTransaction *transaction, int *error_out);
 
 // Gets the amount of a TariPendingOutboundTransaction
-unsigned long long pending_outbound_transaction_get_amount(struct TariPendingOutboundTransaction *transaction,int* error_out);
+unsigned long long pending_outbound_transaction_get_amount(struct TariPendingOutboundTransaction *transaction, int *error_out);
 
 // Gets the fee of a TariPendingOutboundTransaction
-unsigned long long pending_outbound_transaction_get_fee(struct TariPendingOutboundTransaction *transaction,int* error_out);
+unsigned long long pending_outbound_transaction_get_fee(struct TariPendingOutboundTransaction *transaction, int *error_out);
 
 // Gets the message of a TariPendingOutboundTransaction
-const char *pending_outbound_transaction_get_message(struct TariPendingOutboundTransaction *transaction,int* error_out);
+const char *pending_outbound_transaction_get_message(struct TariPendingOutboundTransaction *transaction, int *error_out);
 
 // Gets the timestamp of a TariPendingOutboundTransaction
-unsigned long long pending_outbound_transaction_get_timestamp(struct TariPendingOutboundTransaction *transaction,int* error_out);
+unsigned long long pending_outbound_transaction_get_timestamp(struct TariPendingOutboundTransaction *transaction, int *error_out);
 
 // Gets the status of a TariPendingOutboundTransaction
 // | Value | Interpretation |
@@ -325,7 +323,7 @@ unsigned long long pending_outbound_transaction_get_timestamp(struct TariPending
 // |   2 | Mined       |
 // |   3 | Imported    |
 // |   4 | Pending     |
-int pending_outbound_transaction_get_status(struct TariPendingOutboundTransaction *transaction,int* error_out);
+int pending_outbound_transaction_get_status(struct TariPendingOutboundTransaction *transaction, int *error_out);
 
 // Frees memory for a TariPendingOutboundTactions
 void pending_outbound_transaction_destroy(struct TariPendingOutboundTransaction *transaction);
@@ -333,10 +331,10 @@ void pending_outbound_transaction_destroy(struct TariPendingOutboundTransaction 
 /// -------------------------------- OutboundTransactions ------------------------------------------------------ ///
 
 // Gets the number of elements in a TariPendingOutboundTactions
-unsigned int pending_outbound_transactions_get_length(struct TariPendingOutboundTransactions *transactions,int* error_out);
+unsigned int pending_outbound_transactions_get_length(struct TariPendingOutboundTransactions *transactions, int *error_out);
 
 // Gets a TariPendingOutboundTransaction of a TariPendingOutboundTransactions at position
-struct TariPendingOutboundTransaction *pending_outbound_transactions_get_at(struct TariPendingOutboundTransactions *transactions, unsigned int position,int* error_out);
+struct TariPendingOutboundTransaction *pending_outbound_transactions_get_at(struct TariPendingOutboundTransactions *transactions, unsigned int position, int *error_out);
 
 // Frees memory of a TariPendingOutboundTransactions
 void pending_outbound_transactions_destroy(struct TariPendingOutboundTransactions *transactions);
@@ -344,19 +342,19 @@ void pending_outbound_transactions_destroy(struct TariPendingOutboundTransaction
 /// -------------------------------- InboundTransaction ------------------------------------------------------ ///
 
 // Gets the TransactionId of a TariPendingInboundTransaction
-unsigned long long pending_inbound_transaction_get_transaction_id(struct TariPendingInboundTransaction *transaction,int* error_out);
+unsigned long long pending_inbound_transaction_get_transaction_id(struct TariPendingInboundTransaction *transaction, int *error_out);
 
 // Gets the source TariPublicKey of a TariPendingInboundTransaction
-struct TariPublicKey *pending_inbound_transaction_get_source_public_key(struct TariPendingInboundTransaction *transaction,int* error_out);
+struct TariPublicKey *pending_inbound_transaction_get_source_public_key(struct TariPendingInboundTransaction *transaction, int *error_out);
 
 // Gets the message of a TariPendingInboundTransaction
-const char *pending_inbound_transaction_get_message(struct TariPendingInboundTransaction *transaction,int* error_out);
+const char *pending_inbound_transaction_get_message(struct TariPendingInboundTransaction *transaction, int *error_out);
 
 // Gets the amount of a TariPendingInboundTransaction
-unsigned long long pending_inbound_transaction_get_amount(struct TariPendingInboundTransaction *transaction,int* error_out);
+unsigned long long pending_inbound_transaction_get_amount(struct TariPendingInboundTransaction *transaction, int *error_out);
 
 // Gets the timestamp of a TariPendingInboundTransaction
-unsigned long long pending_inbound_transaction_get_timestamp(struct TariPendingInboundTransaction *transaction,int* error_out);
+unsigned long long pending_inbound_transaction_get_timestamp(struct TariPendingInboundTransaction *transaction, int *error_out);
 
 // Gets the status of a TariPendingInboundTransaction
 // | Value | Interpretation |
@@ -367,7 +365,7 @@ unsigned long long pending_inbound_transaction_get_timestamp(struct TariPendingI
 // |   2 | Mined       |
 // |   3 | Imported    |
 // |   4 | Pending     |
-int pending_inbound_transaction_get_status(struct TariPendingInboundTransaction *transaction,int* error_out);
+int pending_inbound_transaction_get_status(struct TariPendingInboundTransaction *transaction, int *error_out);
 
 // Frees memory for a TariPendingInboundTransaction
 void pending_inbound_transaction_destroy(struct TariPendingInboundTransaction *transaction);
@@ -375,10 +373,10 @@ void pending_inbound_transaction_destroy(struct TariPendingInboundTransaction *t
 /// -------------------------------- InboundTransactions ------------------------------------------------------ ///
 
 // Gets the number of elements in a TariPendingInboundTransactions
-unsigned int pending_inbound_transactions_get_length(struct TariPendingInboundTransactions *transactions,int* error_out);
+unsigned int pending_inbound_transactions_get_length(struct TariPendingInboundTransactions *transactions, int *error_out);
 
 // Gets a TariPendingInboundTransaction of a TariPendingInboundTransactions at position
-struct TariPendingInboundTransaction *pending_inbound_transactions_get_at(struct TariPendingInboundTransactions *transactions, unsigned int position,int* error_out);
+struct TariPendingInboundTransaction *pending_inbound_transactions_get_at(struct TariPendingInboundTransactions *transactions, unsigned int position, int *error_out);
 
 // Frees memory of a TariPendingInboundTransaction
 void pending_inbound_transactions_destroy(struct TariPendingInboundTransactions *transactions);
@@ -386,12 +384,12 @@ void pending_inbound_transactions_destroy(struct TariPendingInboundTransactions 
 /// -------------------------------- TariCommsConfig ----------------------------------------------- ///
 // Creates a TariCommsConfig
 struct TariCommsConfig *comms_config_create(const char *public_address,
-                                     struct TariTransportType *transport,
-                                     const char *database_name,
-                                     const char *datastore_path,
-                                     unsigned long long discovery_timeout_in_secs,
-                                     unsigned long long saf_message_duration_in_secs,
-                                     int* error_out);
+                                            struct TariTransportType *transport,
+                                            const char *database_name,
+                                            const char *datastore_path,
+                                            unsigned long long discovery_timeout_in_secs,
+                                            unsigned long long saf_message_duration_in_secs,
+                                            int *error_out);
 
 // Frees memory for a TariCommsConfig
 void comms_config_destroy(struct TariCommsConfig *wc);
@@ -457,155 +455,154 @@ void comms_config_destroy(struct TariCommsConfig *wc);
 ///        Failure,           // 2
 ///        BaseNodeNotInSync, // 3
 ///    }
-struct TariWallet *wallet_create(struct TariWalletConfig *config,
-                                    const char *log_path,
-                                    unsigned int num_rolling_log_files,
-                                    unsigned int size_per_log_file_bytes,
-                                    const char *passphrase,
-                                    struct TariSeedWords *seed_words,
-                                    void (*callback_received_transaction)(struct TariPendingInboundTransaction*),
-                                    void (*callback_received_transaction_reply)(struct TariCompletedTransaction*),
-                                    void (*callback_received_finalized_transaction)(struct TariCompletedTransaction*),
-                                    void (*callback_transaction_broadcast)(struct TariCompletedTransaction*),
-                                    void (*callback_transaction_mined)(struct TariCompletedTransaction*),
-                                    void (*callback_transaction_mined_unconfirmed)(struct TariCompletedTransaction*, unsigned long long),
-                                    void (*callback_direct_send_result)(unsigned long long, bool),
-                                    void (*callback_store_and_forward_send_result)(unsigned long long, bool),
-                                    void (*callback_transaction_cancellation)(struct TariCompletedTransaction*),
-                                    void (*callback_utxo_validation_complete)(unsigned long long, unsigned char),
-                                    void (*callback_stxo_validation_complete)(unsigned long long, unsigned char),
-                                    void (*callback_invalid_txo_validation_complete)(unsigned long long, unsigned char),
-                                    void (*callback_transaction_validation_complete)(unsigned long long, unsigned char),
-                                    void (*callback_saf_message_received)(),
-                                    int* error_out);
+struct TariWallet *wallet_create(struct TariCommsConfig *config,
+                                 const char *log_path,
+                                 unsigned int num_rolling_log_files,
+                                 unsigned int size_per_log_file_bytes,
+                                 const char *passphrase,
+                                 struct TariSeedWords *seed_words,
+                                 void (*callback_received_transaction)(struct TariPendingInboundTransaction *),
+                                 void (*callback_received_transaction_reply)(struct TariCompletedTransaction *),
+                                 void (*callback_received_finalized_transaction)(struct TariCompletedTransaction *),
+                                 void (*callback_transaction_broadcast)(struct TariCompletedTransaction *),
+                                 void (*callback_transaction_mined)(struct TariCompletedTransaction *),
+                                 void (*callback_transaction_mined_unconfirmed)(struct TariCompletedTransaction *, unsigned long long),
+                                 void (*callback_direct_send_result)(unsigned long long, bool),
+                                 void (*callback_store_and_forward_send_result)(unsigned long long, bool),
+                                 void (*callback_transaction_cancellation)(struct TariCompletedTransaction *),
+                                 void (*callback_utxo_validation_complete)(unsigned long long, unsigned char),
+                                 void (*callback_stxo_validation_complete)(unsigned long long, unsigned char),
+                                 void (*callback_invalid_txo_validation_complete)(unsigned long long, unsigned char),
+                                 void (*callback_transaction_validation_complete)(unsigned long long, unsigned char),
+                                 void (*callback_saf_message_received)(),
+                                 int *error_out);
 
 // Signs a message
-char* wallet_sign_message(struct TariWallet *wallet, const char* msg, int* error_out);
+char *wallet_sign_message(struct TariWallet *wallet, const char *msg, int *error_out);
 
 // Verifies signature for a signed message
-bool wallet_verify_message_signature(struct TariWallet *wallet, struct TariPublicKey *public_key, const char* hex_sig_nonce, const char* msg, int* error_out);
+bool wallet_verify_message_signature(struct TariWallet *wallet, struct TariPublicKey *public_key, const char *hex_sig_nonce, const char *msg, int *error_out);
 
 /// Generates test data
-bool wallet_test_generate_data(struct TariWallet *wallet, const char *datastore_path,int* error_out);
+bool wallet_test_generate_data(struct TariWallet *wallet, const char *datastore_path, int *error_out);
 
 // Adds a base node peer to the TariWallet
-bool wallet_add_base_node_peer(struct TariWallet *wallet, struct TariPublicKey *public_key, const char *address,int* error_out);
+bool wallet_add_base_node_peer(struct TariWallet *wallet, struct TariPublicKey *public_key, const char *address, int *error_out);
 
 // Upserts a TariContact to the TariWallet, if the contact does not exist it is inserted and if it does the alias is updated
-bool wallet_upsert_contact(struct TariWallet *wallet, struct TariContact *contact,int* error_out);
+bool wallet_upsert_contact(struct TariWallet *wallet, struct TariContact *contact, int *error_out);
 
 // Removes a TariContact form the TariWallet
-bool wallet_remove_contact(struct TariWallet *wallet, struct TariContact *contact,int* error_out);
+bool wallet_remove_contact(struct TariWallet *wallet, struct TariContact *contact, int *error_out);
 
 // Gets the available balance from a TariWallet
-unsigned long long wallet_get_available_balance(struct TariWallet *wallet,int* error_out);
+unsigned long long wallet_get_available_balance(struct TariWallet *wallet, int *error_out);
 
 // Gets the incoming balance from a TariWallet
-unsigned long long wallet_get_pending_incoming_balance(struct TariWallet *wallet,int* error_out);
+unsigned long long wallet_get_pending_incoming_balance(struct TariWallet *wallet, int *error_out);
 
 // Gets the outgoing balance from a TariWallet
-unsigned long long wallet_get_pending_outgoing_balance(struct TariWallet *wallet,int* error_out);
+unsigned long long wallet_get_pending_outgoing_balance(struct TariWallet *wallet, int *error_out);
 
 // Get a fee estimate from a TariWallet for a given amount
-unsigned long long wallet_get_fee_estimate(struct TariWallet *wallet, unsigned long long amount, unsigned long long fee_per_gram, unsigned long long num_kernels, unsigned long long num_outputs, int* error_out);
+unsigned long long wallet_get_fee_estimate(struct TariWallet *wallet, unsigned long long amount, unsigned long long fee_per_gram, unsigned long long num_kernels, unsigned long long num_outputs, int *error_out);
 
 // Get the number of mining confirmations by the wallet transaction service
-unsigned long long wallet_get_num_confirmations_required(struct TariWallet *wallet, int* error_out);
+unsigned long long wallet_get_num_confirmations_required(struct TariWallet *wallet, int *error_out);
 
 // Set the number of mining confirmations by the wallet transaction service
-void wallet_set_num_confirmations_required(struct TariWallet *wallet, unsigned long long num, int* error_out);
-
+void wallet_set_num_confirmations_required(struct TariWallet *wallet, unsigned long long num, int *error_out);
 
 // Sends a TariPendingOutboundTransaction
-unsigned long long wallet_send_transaction(struct TariWallet *wallet, struct TariPublicKey *destination, unsigned long long amount, unsigned long long fee_per_gram,const char *message,int* error_out);
+unsigned long long wallet_send_transaction(struct TariWallet *wallet, struct TariPublicKey *destination, unsigned long long amount, unsigned long long fee_per_gram, const char *message, int *error_out);
 
 // Get the TariContacts from a TariWallet
-struct TariContacts *wallet_get_contacts(struct TariWallet *wallet,int* error_out);
+struct TariContacts *wallet_get_contacts(struct TariWallet *wallet, int *error_out);
 
 // Get the TariCompletedTransactions from a TariWallet
-struct TariCompletedTransactions *wallet_get_completed_transactions(struct TariWallet *wallet,int* error_out);
+struct TariCompletedTransactions *wallet_get_completed_transactions(struct TariWallet *wallet, int *error_out);
 
 // Get the TariPendingOutboundTransactions from a TariWallet
-struct TariPendingOutboundTransactions *wallet_get_pending_outbound_transactions(struct TariWallet *wallet,int* error_out);
+struct TariPendingOutboundTransactions *wallet_get_pending_outbound_transactions(struct TariWallet *wallet, int *error_out);
 
 // Get the TariPublicKey from a TariCommsConfig
-struct TariPublicKey *wallet_get_public_key(struct TariWallet *wallet,int* error_out);
+struct TariPublicKey *wallet_get_public_key(struct TariWallet *wallet, int *error_out);
 
 // Get the TariPendingInboundTransactions from a TariWallet
-struct TariPendingInboundTransactions *wallet_get_pending_inbound_transactions(struct TariWallet *wallet,int* error_out);
+struct TariPendingInboundTransactions *wallet_get_pending_inbound_transactions(struct TariWallet *wallet, int *error_out);
 
 // Get all cancelled transactions from a TariWallet
-struct TariCompletedTransactions *wallet_get_cancelled_transactions(struct TariWallet *wallet,int* error_out);
+struct TariCompletedTransactions *wallet_get_cancelled_transactions(struct TariWallet *wallet, int *error_out);
 
 // Get the TariCompletedTransaction from a TariWallet by its TransactionId
-struct TariCompletedTransaction *wallet_get_completed_transaction_by_id(struct TariWallet *wallet, unsigned long long transaction_id,int* error_out);
+struct TariCompletedTransaction *wallet_get_completed_transaction_by_id(struct TariWallet *wallet, unsigned long long transaction_id, int *error_out);
 
 // Get the TariPendingOutboundTransaction from a TariWallet by its TransactionId
-struct TariPendingOutboundTransaction *wallet_get_pending_outbound_transaction_by_id(struct TariWallet *wallet, unsigned long long transaction_id,int* error_out);
+struct TariPendingOutboundTransaction *wallet_get_pending_outbound_transaction_by_id(struct TariWallet *wallet, unsigned long long transaction_id, int *error_out);
 
 // Get the TariPendingInboundTransaction from a TariWallet by its TransactionId
-struct TariPendingInboundTransaction *wallet_get_pending_inbound_transaction_by_id(struct TariWallet *wallet, unsigned long long transaction_id,int* error_out);
+struct TariPendingInboundTransaction *wallet_get_pending_inbound_transaction_by_id(struct TariWallet *wallet, unsigned long long transaction_id, int *error_out);
 
 // Get a Cancelled transaction from a TariWallet by its TransactionId. Pending Inbound or Outbound transaction will be converted to a CompletedTransaction
-struct TariCompletedTransaction *wallet_get_cancelled_transaction_by_id(struct TariWallet *wallet, unsigned long long transaction_id, int* error_out);
+struct TariCompletedTransaction *wallet_get_cancelled_transaction_by_id(struct TariWallet *wallet, unsigned long long transaction_id, int *error_out);
 
 // Simulates completion of a TariPendingOutboundTransaction
-bool wallet_test_complete_sent_transaction(struct TariWallet *wallet, struct TariPendingOutboundTransaction *tx,int* error_out);
+bool wallet_test_complete_sent_transaction(struct TariWallet *wallet, struct TariPendingOutboundTransaction *tx, int *error_out);
 
 // Import a UTXO into the wallet. This will add a spendable UTXO and create a faux completed transaction to record the
 // event.
-unsigned long long wallet_import_utxo(struct TariWallet *wallet, unsigned long long amount, struct TariPrivateKey *spending_key, struct TariPublicKey *source_public_key, const char *message, int* error_out);
+unsigned long long wallet_import_utxo(struct TariWallet *wallet, unsigned long long amount, struct TariPrivateKey *spending_key, struct TariPublicKey *source_public_key, const char *message, int *error_out);
 
 // This function will tell the wallet to query the set base node to confirm the status of unspent transaction outputs (UTXOs).
-unsigned long long wallet_start_utxo_validation(struct TariWallet *wallet, int* error_out);
+unsigned long long wallet_start_utxo_validation(struct TariWallet *wallet, int *error_out);
 
 // This function will tell the wallet to query the set base node to confirm the status of spent transaction outputs (STXOs).
-unsigned long long wallet_start_stxo_validation(struct TariWallet *wallet, int* error_out);
+unsigned long long wallet_start_stxo_validation(struct TariWallet *wallet, int *error_out);
 
 // This function will tell the wallet to query the set base node to confirm the status of invalid transaction outputs.
-unsigned long long wallet_start_invalid_txo_validation(struct TariWallet *wallet, int* error_out);
+unsigned long long wallet_start_invalid_txo_validation(struct TariWallet *wallet, int *error_out);
 
 //This function will tell the wallet to query the set base node to confirm the status of mined transactions.
-unsigned long long wallet_start_transaction_validation(struct TariWallet *wallet, int* error_out);
+unsigned long long wallet_start_transaction_validation(struct TariWallet *wallet, int *error_out);
 
 //This function will tell the wallet retart any broadcast protocols for completed transactions. Ideally this should be
 // called after a successfuly Transaction Validation is complete
-bool wallet_restart_transaction_broadcast(struct TariWallet *wallet, int* error_out);
+bool wallet_restart_transaction_broadcast(struct TariWallet *wallet, int *error_out);
 
 // Set the power mode of the wallet to Low Power mode which will reduce the amount of network operations the wallet performs to conserve power
-void wallet_set_low_power_mode(struct TariWallet *wallet, int* error_out);
+void wallet_set_low_power_mode(struct TariWallet *wallet, int *error_out);
 
 // Set the power mode of the wallet to Normal Power mode which will then use the standard level of network traffic
-void wallet_set_normal_power_mode(struct TariWallet *wallet, int* error_out);
+void wallet_set_normal_power_mode(struct TariWallet *wallet, int *error_out);
 
 // Simulates the completion of a broadcasted TariPendingInboundTransaction
-bool wallet_test_broadcast_transaction(struct TariWallet *wallet, unsigned long long tx, int* error_out);
+bool wallet_test_broadcast_transaction(struct TariWallet *wallet, unsigned long long tx, int *error_out);
 
 // Simulates receiving the finalized version of a TariPendingInboundTransaction
-bool wallet_test_finalize_received_transaction(struct TariWallet *wallet, struct TariPendingInboundTransaction *tx, int* error_out);
+bool wallet_test_finalize_received_transaction(struct TariWallet *wallet, struct TariPendingInboundTransaction *tx, int *error_out);
 
 // Simulates a TariCompletedTransaction that has been mined
-bool wallet_test_mine_transaction(struct TariWallet *wallet, unsigned long long tx, int* error_out);
+bool wallet_test_mine_transaction(struct TariWallet *wallet, unsigned long long tx, int *error_out);
 
 // Simulates a TariPendingInboundtransaction being received
-bool wallet_test_receive_transaction(struct TariWallet *wallet,int* error_out);
+bool wallet_test_receive_transaction(struct TariWallet *wallet, int *error_out);
 
 /// Cancel a Pending Outbound Transaction
-bool wallet_cancel_pending_transaction(struct TariWallet *wallet, unsigned long long transaction_id, int* error_out);
+bool wallet_cancel_pending_transaction(struct TariWallet *wallet, unsigned long long transaction_id, int *error_out);
 
 /// Perform a coin split
-unsigned long long wallet_coin_split(struct TariWallet *wallet, unsigned long long amount, unsigned long long count, unsigned long long fee, const char* msg, unsigned long long lock_height, int* error_out);
+unsigned long long wallet_coin_split(struct TariWallet *wallet, unsigned long long amount, unsigned long long count, unsigned long long fee, const char *msg, unsigned long long lock_height, int *error_out);
 
 /// Get the seed words representing the seed private key of the provided TariWallet
-struct TariSeedWords *wallet_get_seed_words(struct TariWallet *wallet, int* error_out);
+struct TariSeedWords *wallet_get_seed_words(struct TariWallet *wallet, int *error_out);
 
 // Apply encryption to the databases used in this wallet using the provided passphrase. If the databases are already
 // encrypted this function will fail.
-void wallet_apply_encryption(struct TariWallet *wallet, const char *passphrase, int* error_out);
+void wallet_apply_encryption(struct TariWallet *wallet, const char *passphrase, int *error_out);
 
 // Remove encryption to the databases used in this wallet. If this wallet is currently encrypted this encryption will
 // be removed. If it is not encrypted then this function will still succeed to make the operation idempotent
-void wallet_remove_encryption(struct TariWallet *wallet, int* error_out);
+void wallet_remove_encryption(struct TariWallet *wallet, int *error_out);
 
 /// Set a Key Value in the Wallet storage used for Client Key Value store
 ///
@@ -622,7 +619,7 @@ void wallet_remove_encryption(struct TariWallet *wallet, int* error_out);
 ///
 /// # Safety
 /// None
-bool wallet_set_key_value(struct TariWallet *wallet, const char* key, const char* value, int* error_out);
+bool wallet_set_key_value(struct TariWallet *wallet, const char *key, const char *value, int *error_out);
 
 /// get a stored Value that was previously stored in the Wallet storage used for Client Key Value store
 ///
@@ -638,7 +635,7 @@ bool wallet_set_key_value(struct TariWallet *wallet, const char* key, const char
 ///
 /// # Safety
 /// The ```string_destroy``` method must be called when finished with a string from rust to prevent a memory leak
-const char *wallet_get_value(struct TariWallet *wallet, const char* key, int* error_out);
+const char *wallet_get_value(struct TariWallet *wallet, const char *key, int *error_out);
 
 /// Clears a Value for the provided Key Value in the Wallet storage used for Client Key Value store
 ///
@@ -654,7 +651,7 @@ const char *wallet_get_value(struct TariWallet *wallet, const char* key, int* er
 ///
 /// # Safety
 /// None
-bool wallet_clear_value(struct TariWallet *wallet, const char* key, int* error_out);
+bool wallet_clear_value(struct TariWallet *wallet, const char *key, int *error_out);
 
 /// Check if a Wallet has the data of an In Progress Recovery in its database.
 ///
@@ -669,7 +666,7 @@ bool wallet_clear_value(struct TariWallet *wallet, const char* key, int* error_o
 ///
 /// # Safety
 /// None
-bool wallet_is_recovery_in_progress(struct TariWallet *wallet, int* error_out);
+bool wallet_is_recovery_in_progress(struct TariWallet *wallet, int *error_out);
 
 /// Starts the Wallet recovery process.
 ///
@@ -723,7 +720,7 @@ bool wallet_is_recovery_in_progress(struct TariWallet *wallet, int* error_out);
 ///
 /// # Safety
 /// None
-bool wallet_start_recovery(struct TariWallet *wallet, struct TariPublicKey *base_node_public_key, void (*recovery_progress_callback)(unsigned char, unsigned long long, unsigned long long), int* error_out);
+bool wallet_start_recovery(struct TariWallet *wallet, struct TariPublicKey *base_node_public_key, void (*recovery_progress_callback)(unsigned char, unsigned long long, unsigned long long), int *error_out);
 
 // Frees memory for a TariWallet
 void wallet_destroy(struct TariWallet *wallet);
@@ -731,18 +728,18 @@ void wallet_destroy(struct TariWallet *wallet);
 // This function will produce a partial backup of the specified wallet database file (full file path must be provided.
 // This backup will be written to the provided file (full path must include the filename and extension) and will include
 // the full wallet db but will clear the sensitive Comms Private Key
-void file_partial_backup(const char *original_file_path, const char *backup_file_path, int* error_out);
+void file_partial_backup(const char *original_file_path, const char *backup_file_path, int *error_out);
 
 /// This function will log the provided string at debug level. To be used to have a client log messages to the LibWallet
-void log_debug_message(const char* msg);
+void log_debug_message(const char *msg);
 
 struct EmojiSet *get_emoji_set(void);
 
 void emoji_set_destroy(struct EmojiSet *emoji_set);
 
-struct ByteVector *emoji_set_get_at(struct EmojiSet *emoji_set, unsigned int position, int* error_out);
+struct ByteVector *emoji_set_get_at(struct EmojiSet *emoji_set, unsigned int position, int *error_out);
 
-unsigned int emoji_set_get_length(struct EmojiSet *emoji_set, int* error_out);
+unsigned int emoji_set_get_length(struct EmojiSet *emoji_set, int *error_out);
 
 #ifdef __cplusplus
 }

--- a/integration_tests/.eslintrc.json
+++ b/integration_tests/.eslintrc.json
@@ -1,11 +1,21 @@
 {
   "extends": ["eslint:recommended", "plugin:prettier/recommended"],
-  "plugins": ["prettier"],
+  "plugins": ["prettier", "@babel"],
   "env": {
     "browser": true,
     "commonjs": true,
     "node": true,
     "es2021": true
+  },
+  "parser": "@babel/eslint-parser", // He is where you communicate to ESLint that you want to use the @babel/eslint-parser.
+  "parserOptions": {
+    "ecmaVersion": 2021,
+    "sourceType": "module",
+    "allowImportExportEverywhere": false,
+    "ecmaFeatures": {
+      "globalReturn": false
+    },
+    "requireConfigFile": false
   },
   "rules": {
     "no-unused-vars": [

--- a/integration_tests/features/WalletFFI.feature
+++ b/integration_tests/features/WalletFFI.feature
@@ -1,0 +1,6 @@
+Feature: Wallet FFI
+
+    Scenario: I want to get public key and emoji id
+        Given I have a ffi wallet Wallet
+        Then I want to get public key of ffi wallet Wallet
+        And I want to get emoji id of ffi wallet Wallet

--- a/integration_tests/features/support/steps.js
+++ b/integration_tests/features/support/steps.js
@@ -3177,3 +3177,25 @@ When(
     }
   }
 );
+
+When("I have a ffi wallet {word}", async function (name) {
+  await this.ffiCreateWallet(name);
+});
+
+Then("I want to get public key of ffi wallet {word}", function (name) {
+  let wallet = this.getWallet(name);
+  let public_key = wallet.getPublicKey();
+  expect(public_key.length).to.be.equal(
+    32,
+    `Public key has wrong length : ${public_key}`
+  );
+});
+
+Then("I want to get emoji id of ffi wallet {word}", function (name) {
+  let wallet = this.getWallet(name);
+  let emoji_id = wallet.getEmojiId();
+  expect(emoji_id.length).to.be.equal(
+    22 * 3, // 22 emojis, 3 bytes per one emoji
+    `Emoji id has wrong length : ${emoji_id}`
+  );
+});

--- a/integration_tests/helpers/walletFFI.js
+++ b/integration_tests/helpers/walletFFI.js
@@ -1,0 +1,899 @@
+/**
+ * Goal of this library is to provide all the functions inside the ffi library.
+ * All the functions that returns error, should throw error instead. So the
+ * outside code can use this as a regular javascript library (with nice code
+ * completion,  * and parameter names, instead of big unknown), and not to take
+ * care of the ffi stuff that's going on in here. This way, anyone doing new
+ * test can avoid this ffi importing, declaration, etc... And just use it.
+ */
+
+const { expect } = require("chai");
+const ffi = require("ffi-napi");
+const ref = require("ref-napi");
+const dateFormat = require("dateformat");
+const { spawn } = require("child_process");
+const fs = require("fs");
+
+class WalletFFI {
+  static byte_vector = ref.types.void;
+  static byte_vector_ptr = ref.refType(this.byte_vector);
+  static tari_comms_config = ref.types.void;
+  static tari_comms_config_ptr = ref.refType(this.tari_comms_config);
+  static tari_private_key = ref.types.void;
+  static tari_private_key_ptr = ref.refType(this.tari_private_key);
+  static tari_wallet = ref.types.void;
+  static tari_wallet_ptr = ref.refType(this.tari_wallet);
+  static tari_wallet_config = ref.types.void;
+  static tari_wallet_config_ptr = ref.refType(this.tari_wallet_config);
+  static tari_public_key = ref.types.void;
+  static tari_public_key_ptr = ref.refType(this.tari_public_key);
+  static tari_contacts = ref.types.void;
+  static tari_contacts_ptr = ref.refType(this.tari_contacts);
+  static tari_contact = ref.types.void;
+  static tari_contact_ptr = ref.refType(this.tari_contact);
+  static tari_completed_transactions = ref.types.void;
+  static tari_completed_transactions_ptr = ref.refType(
+    this.tari_completed_transactions
+  );
+  static tari_completed_transaction = ref.types.void;
+  static tari_completed_transaction_ptr = ref.refType(
+    this.tari_completed_transaction
+  );
+  static tari_pending_outbound_transactions = ref.types.void;
+  static tari_pending_outbound_transactions_ptr = ref.refType(
+    this.tari_pending_outbound_transactions
+  );
+  static tari_pending_outbound_transaction = ref.types.void;
+  static tari_pending_outbound_transaction_ptr = ref.refType(
+    this.tari_pending_outbound_transaction
+  );
+  static tari_pending_inbound_transactions = ref.types.void;
+  static tari_pending_inbound_transactions_ptr = ref.refType(
+    this.tari_pending_inbound_transactions
+  );
+  static tari_pending_inbound_transaction = ref.types.void;
+  static tari_pending_inbound_transaction_ptr = ref.refType(
+    this.tari_pending_inbound_transaction
+  );
+  static tari_transport_type = ref.types.void;
+  static tari_transport_type_ptr = ref.refType(this.tari_transport_type);
+  static tari_seed_words = ref.types.void;
+  static tari_seed_words_ptr = ref.refType(this.tari_seed_words);
+  static emoji_set = ref.types.void;
+  static emoji_set_ptr = ref.refType(this.emoji_set);
+  static tari_excess = ref.types.void;
+  static tari_excess_ptr = ref.refType(this.tari_excess);
+  static tari_excess_public_nonce = ref.types.void;
+  static tari_excess_public_nonce_ptr = ref.refType(
+    this.tari_excess_public_nonce
+  );
+  static tari_excess_signature = ref.types.void;
+  static tari_excess_signature_ptr = ref.refType(this.tari_excess_signature);
+
+  static #fn;
+  static error = ref.alloc("int");
+  static NULL = ref.NULL;
+  static #loaded = false;
+  static #ps = null;
+  static compile() {
+    return new Promise((resolve, _reject) => {
+      const cmd = "cargo";
+      const args = [
+        "build",
+        "--release",
+        "--package",
+        "tari_wallet_ffi",
+        "-Z",
+        "unstable-options",
+        "--out-dir",
+        process.cwd() + "/temp/out",
+      ];
+      const baseDir = `./temp/base_nodes/${dateFormat(
+        new Date(),
+        "yyyymmddHHMM"
+      )}/WalletFFI-compile`;
+      if (!fs.existsSync(baseDir)) {
+        fs.mkdirSync(baseDir, { recursive: true });
+        fs.mkdirSync(baseDir + "/log", { recursive: true });
+      }
+      const ps = spawn(cmd, args, {
+        cwd: baseDir,
+        env: { ...process.env },
+      });
+      ps.on("close", (_code) => {
+        resolve(ps);
+      });
+      ps.stderr.on("data", (data) => {
+        console.log("stderr : ", data.toString());
+      });
+      ps.on("error", (error) => {
+        console.log("error : ", error.toString());
+      });
+      expect(ps.error).to.be.an("undefined");
+      this.#ps = ps;
+    });
+  }
+
+  static async Init() {
+    if (this.#loaded) {
+      return;
+    }
+
+    this.#loaded = true;
+    await this.compile();
+    const outputProcess = `${process.cwd()}/temp/out/${
+      process.platform === "win32" ? "" : "lib"
+    }tari_wallet_ffi`;
+    console.log(outputProcess);
+
+    // Load the library
+    this.#fn = ffi.Library(outputProcess, {
+      // Transport Types
+      transport_memory_create: [this.tari_transport_type_ptr, []],
+      transport_tcp_create: [this.tari_transport_type_ptr, ["string", "int*"]],
+      transport_tor_create: [
+        this.tari_transport_type_ptr,
+        ["string", this.byte_vector_ptr, "ushort", "string", "string", "int*"],
+      ],
+      transport_memory_get_address: [
+        "string",
+        [this.tari_transport_type_ptr, "int*"],
+      ],
+      transport_type_destroy: ["void", [this.tari_transport_type_ptr]],
+      // Strings
+      string_destroy: ["void", ["string"]],
+      // ByteVector
+      byte_vector_create: [this.byte_vector_ptr, ["uchar*", "uint", "int*"]],
+      byte_vector_get_at: ["uchar", [this.byte_vector_ptr, "uint", "int*"]],
+      byte_vector_get_length: ["uint", [this.byte_vector_ptr, "int*"]],
+      byte_vector_destroy: ["void", [this.byte_vector_ptr]],
+      // TariPublicKey
+      public_key_create: [
+        this.tari_public_key_ptr,
+        [this.byte_vector_ptr, "int*"],
+      ],
+      public_key_get_bytes: [
+        this.byte_vector_ptr,
+        [this.tari_public_key_ptr, "int*"],
+      ],
+      public_key_from_private_key: [
+        this.tari_public_key_ptr,
+        [this.tari_private_key_ptr, "int*"],
+      ],
+      public_key_from_hex: [this.tari_public_key_ptr, ["string", "int*"]],
+      public_key_destroy: ["void", [this.tari_public_key_ptr]],
+      public_key_to_emoji_id: ["string", [this.tari_public_key_ptr, "int*"]],
+      emoji_id_to_public_key: [this.tari_public_key_ptr, ["string", "int*"]],
+      // TariPrivateKey
+      private_key_create: [
+        this.tari_private_key_ptr,
+        [this.byte_vector_ptr, "int*"],
+      ],
+      private_key_generate: [this.tari_private_key_ptr, []],
+      private_key_get_bytes: [
+        this.byte_vector_ptr,
+        [this.tari_private_key_ptr, "int*"],
+      ],
+      private_key_from_hex: [this.tari_private_key_ptr, ["string", "int*"]],
+      private_key_destroy: ["void", [this.tari_private_key_ptr]],
+      // Seed Words
+      seed_words_create: [this.tari_seed_words_ptr, []],
+      seed_words_get_length: ["uint", [this.tari_seed_words_ptr, "int*"]],
+      seed_words_get_at: ["string", [this.tari_seed_words_ptr, "uint", "int*"]],
+      seed_words_push_word: [
+        "uchar",
+        [this.tari_seed_words_ptr, "string", "int*"],
+      ],
+      seed_words_destroy: ["void", [this.tari_seed_words_ptr]],
+      // Contact
+      contact_create: [
+        this.tari_contact_ptr,
+        ["string", this.tari_public_key_ptr, "int*"],
+      ],
+      contact_get_alias: ["string", [this.tari_contact_ptr, "int*"]],
+      contact_get_public_key: [
+        this.tari_public_key_ptr,
+        [this.tari_contact_ptr, "int*"],
+      ],
+      contact_destroy: ["void", [this.tari_contact_ptr]],
+      // Contacts
+      contacts_get_length: ["uint", [this.tari_contacts_ptr, "int*"]],
+      contacts_get_at: [
+        this.tari_contact_ptr,
+        [this.tari_contacts_ptr, "uint", "int*"],
+      ],
+      contacts_destroy: ["void", [this.tari_contacts_ptr]],
+      // CompletedTransaction
+      completed_transaction_get_destination_public_key: [
+        this.tari_public_key_ptr,
+        [this.tari_completed_transaction_ptr, "int*"],
+      ],
+      completed_transaction_get_source_public_key: [
+        this.tari_public_key_ptr,
+        [this.tari_completed_transaction_ptr, "int*"],
+      ],
+      completed_transaction_get_amount: [
+        "ulong long",
+        [this.tari_completed_transaction_ptr, "int*"],
+      ],
+      completed_transaction_get_fee: [
+        "ulong long",
+        [this.tari_completed_transaction_ptr, "int*"],
+      ],
+      completed_transaction_get_message: [
+        "string",
+        [this.tari_completed_transaction_ptr, "int*"],
+      ],
+      completed_transaction_get_status: [
+        "int",
+        [this.tari_completed_transaction, "int*"],
+      ],
+      completed_transaction_get_transaction_id: [
+        "ulong long",
+        [this.tari_completed_transaction_ptr, "int*"],
+      ],
+      completed_transaction_get_timestamp: [
+        "ulong long",
+        [this.tari_completed_transaction_ptr, "int*"],
+      ],
+      completed_transaction_is_valid: [
+        "bool",
+        [this.tari_completed_transaction_ptr, "int*"],
+      ],
+      completed_transaction_is_outbound: [
+        "bool",
+        [this.tari_completed_transaction_ptr, "int*"],
+      ],
+      completed_transaction_get_confirmations: [
+        "ulong long",
+        [this.tari_completed_transaction_ptr, "int*"],
+      ],
+      completed_transaction_destroy: [
+        "void",
+        [this.tari_completed_transaction_ptr],
+      ],
+      completed_transaction_get_excess: [
+        this.tari_excess_ptr,
+        [this.tari_completed_transaction_ptr, "int*"],
+      ],
+      completed_transaction_get_public_nonce: [
+        this.tari_excess_public_nonce_ptr,
+        [this.tari_completed_transaction_ptr, "int*"],
+      ],
+      completed_transaction_get_signature: [
+        this.tari_excess_signature_ptr,
+        [this.tari_completed_transaction_ptr, "int*"],
+      ],
+      excess_destroy: ["void", [this.tari_excess_ptr]],
+      nonce_destroy: ["void", [this.tari_excess_public_nonce_ptr]],
+      signature_destroy: ["void", [this.tari_excess_signature_ptr]],
+      // CompletedTransactions
+      completed_transactions_get_length: [
+        "uint",
+        [this.tari_completed_transactions_ptr, "int*"],
+      ],
+      completed_transactions_get_at: [
+        this.tari_completed_transaction_ptr,
+        [this.tari_completed_transactions_ptr, "uint", "int*"],
+      ],
+      completed_transactions_destroy: [
+        "void",
+        [this.tari_completed_transactions_ptr],
+      ],
+      // OutboundTransaction
+      pending_outbound_transaction_get_transaction_id: [
+        "ulong long",
+        [this.tari_pending_outbound_transaction_ptr, "int*"],
+      ],
+      pending_outbound_transaction_get_destination_public_key: [
+        this.tari_public_key_ptr,
+        [this.tari_pending_outbound_transaction_ptr, "int*"],
+      ],
+      pending_outbound_transaction_get_amount: [
+        "ulong long",
+        [this.tari_pending_outbound_transaction_ptr, "int*"],
+      ],
+      pending_outbound_transaction_get_fee: [
+        "ulong long",
+        [this.tari_pending_outbound_transaction_ptr, "int*"],
+      ],
+      pending_outbound_transaction_get_message: [
+        "string",
+        [this.tari_pending_outbound_transaction_ptr, "int*"],
+      ],
+      pending_outbound_transaction_get_timestamp: [
+        "ulong long",
+        [this.tari_pending_outbound_transaction_ptr, "int*"],
+      ],
+      pending_outbound_transaction_get_status: [
+        "int",
+        [this.tari_pending_outbound_transaction_ptr, "int*"],
+      ],
+      pending_outbound_transaction_destroy: [
+        "void",
+        [this.tari_pending_outbound_transaction_ptr],
+      ],
+      // OutboundTransactions
+      pending_outbound_transactions_get_length: [
+        "uint",
+        [this.tari_pending_outbound_transactions_ptr, "int*"],
+      ],
+      pending_outbound_transactions_get_at: [
+        this.tari_pending_outbound_transaction_ptr,
+        [this.tari_pending_outbound_transactions_ptr, "uint", "int*"],
+      ],
+      pending_outbound_transactions_destroy: [
+        "void",
+        [this.tari_pending_outbound_transactions_ptr],
+      ],
+      // InboundTransaction
+      pending_inbound_transaction_get_transaction_id: [
+        "ulong long",
+        [this.tari_pending_inbound_transaction_ptr, "int*"],
+      ],
+      pending_inbound_transaction_get_source_public_key: [
+        this.tari_public_key_ptr,
+        [this.tari_pending_inbound_transaction_ptr, "int*"],
+      ],
+      pending_inbound_transaction_get_message: [
+        "string",
+        [this.tari_pending_inbound_transaction_ptr, "int*"],
+      ],
+      pending_inbound_transaction_get_amount: [
+        "ulong long",
+        [this.tari_pending_inbound_transaction_ptr, "int*"],
+      ],
+      pending_inbound_transaction_get_timestamp: [
+        "ulong long",
+        [this.tari_pending_inbound_transaction_ptr, "int*"],
+      ],
+      pending_inbound_transaction_get_status: [
+        "int",
+        [this.tari_pending_inbound_transaction_ptr, "int*"],
+      ],
+      pending_inbound_transaction_destroy: [
+        "void",
+        [this.tari_pending_inbound_transaction_ptr],
+      ],
+      // InboundTransactions
+      pending_inbound_transactions_get_length: [
+        "uint",
+        [this.tari_pending_inbound_transactions_ptr, "int*"],
+      ],
+      pending_inbound_transactions_get_at: [
+        this.tari_pending_inbound_transaction_ptr,
+        [this.tari_pending_inbound_transactions_ptr, "uint", "int*"],
+      ],
+      pending_inbound_transactions_destroy: [
+        "void",
+        [this.tari_pending_inbound_transactions_ptr],
+      ],
+      // TariCommsConfig
+      comms_config_create: [
+        this.tari_comms_config_ptr,
+        [
+          "string",
+          this.tari_transport_type_ptr,
+          "string",
+          "string",
+          "ulong long",
+          "ulong long",
+          "int*",
+        ],
+      ],
+      comms_config_destroy: ["void", [this.tari_comms_config_ptr]],
+      // TariWallet
+      wallet_create: [
+        this.tari_wallet_ptr,
+        [
+          this.tari_wallet_config_ptr,
+          "string",
+          "uint",
+          "uint",
+          "string",
+          this.tari_seed_words_ptr,
+          "pointer",
+          "pointer",
+          "pointer",
+          "pointer",
+          "pointer",
+          "pointer",
+          "pointer",
+          "pointer",
+          "pointer",
+          "pointer",
+          "pointer",
+          "pointer",
+          "pointer",
+          "pointer",
+          "int*",
+        ],
+      ],
+      wallet_sign_message: ["string", [this.tari_wallet_ptr, "string", "int*"]],
+      wallet_verify_message_signature: [
+        "bool",
+        [
+          this.tari_wallet_ptr,
+          this.tari_public_key_ptr,
+          "string",
+          "string",
+          "int*",
+        ],
+      ],
+      wallet_test_generate_data: [
+        "bool",
+        [this.tari_wallet_ptr, "string", "int*"],
+      ],
+      wallet_add_base_node_peer: [
+        "bool",
+        [this.tari_wallet_ptr, this.tari_public_key_ptr, "string", "int*"],
+      ],
+      wallet_upsert_contact: [
+        "bool",
+        [this.tari_wallet_ptr, this.tari_contact_ptr, "int*"],
+      ],
+      wallet_remove_contact: [
+        "bool",
+        [this.tari_wallet_ptr, this.tari_contact_ptr, "int*"],
+      ],
+      wallet_get_available_balance: [
+        "ulong long",
+        [this.tari_wallet_ptr, "int*"],
+      ],
+      wallet_get_pending_incoming_balance: [
+        "ulong long",
+        [this.tari_wallet_ptr, "int*"],
+      ],
+      wallet_get_pending_outgoing_balance: [
+        "ulong long",
+        [this.tari_wallet_ptr, "int*"],
+      ],
+      wallet_get_fee_estimate: [
+        "ulong long",
+        [
+          this.tari_wallet_ptr,
+          "ulong long",
+          "ulong long",
+          "ulong long",
+          "ulong long",
+          "int*",
+        ],
+      ],
+      wallet_get_num_confirmations_required: [
+        "ulong long",
+        [this.tari_wallet_ptr, "int*"],
+      ],
+      wallet_set_num_confirmations_required: [
+        "void",
+        [this.tari_wallet_ptr, "long long", "int*"],
+      ],
+      wallet_send_transaction: [
+        "long long",
+        [
+          this.tari_wallet_ptr,
+          this.tari_public_key_ptr,
+          "ulong long",
+          "ulong long",
+          "string",
+          "int*",
+        ],
+      ],
+      wallet_get_contacts: [
+        this.tari_contacts_ptr,
+        [this.tari_wallet_ptr, "int*"],
+      ],
+      wallet_get_completed_transactions: [
+        this.tari_completed_transactions_ptr,
+        [this.tari_wallet_ptr, "int*"],
+      ],
+      wallet_get_pending_outbound_transactions: [
+        this.tari_pending_outbound_transactions_ptr,
+        [this.tari_wallet_ptr, "int*"],
+      ],
+      wallet_get_public_key: [
+        this.tari_public_key_ptr,
+        [this.tari_wallet_ptr, "int*"],
+      ],
+      wallet_get_pending_inbound_transactions: [
+        this.tari_pending_inbound_transactions_ptr,
+        [this.tari_wallet_ptr, "int*"],
+      ],
+      wallet_get_cancelled_transactions: [
+        this.tari_completed_transactions_ptr,
+        [this.tari_wallet_ptr, "int*"],
+      ],
+      wallet_get_completed_transaction_by_id: [
+        this.tari_completed_transaction_ptr,
+        [this.tari_wallet_ptr, "ulong long", "int*"],
+      ],
+      wallet_get_pending_outbound_transaction_by_id: [
+        this.tari_pending_outbound_transaction_ptr,
+        [this.tari_wallet_ptr, "uint", "int*"],
+      ],
+      wallet_get_pending_inbound_transaction_by_id: [
+        this.tari_pending_outbound_transaction_ptr,
+        [this.tari_wallet_ptr, "uint", "int*"],
+      ],
+      wallet_get_cancelled_transaction_by_id: [
+        this.tari_completed_transaction_ptr,
+        [this.tari_wallet_ptr, "int", "int*"],
+      ],
+      wallet_test_complete_sent_transaction: [
+        "bool",
+        [
+          this.tari_wallet_ptr,
+          this.tari_pending_outbound_transaction_ptr,
+          "int*",
+        ],
+      ],
+      wallet_import_utxo: [
+        "ulong long",
+        [
+          this.tari_wallet_ptr,
+          "ulong long",
+          this.tari_private_key_ptr,
+          this.tari_public_key_ptr,
+          "string",
+          "int*",
+        ],
+      ],
+      wallet_start_utxo_validation: [
+        "ulong long",
+        [this.tari_wallet_ptr, "int*"],
+      ],
+      wallet_start_stxo_validation: [
+        "ulong long",
+        [this.tari_wallet_ptr, "int*"],
+      ],
+      wallet_start_invalid_txo_validation: [
+        "ulong long",
+        [this.tari_wallet_ptr, "int*"],
+      ],
+      wallet_start_transaction_validation: [
+        "ulong long",
+        [this.tari_wallet_ptr, "int*"],
+      ],
+      wallet_restart_transaction_broadcast: [
+        "bool",
+        [this.tari_wallet_ptr, "int*"],
+      ],
+      wallet_set_low_power_mode: ["void", [this.tari_wallet_ptr, "int*"]],
+      wallet_set_normal_power_mode: ["void", [this.tari_wallet_ptr, "int*"]],
+      wallet_test_broadcast_transaction: [
+        "bool",
+        [this.tari_wallet_ptr, "uint", "int*"],
+      ],
+      wallet_test_finalize_received_transaction: [
+        "bool",
+        [
+          this.tari_wallet_ptr,
+          this.tari_pending_inbound_transaction_ptr,
+          "int*",
+        ],
+      ],
+      wallet_test_mine_transaction: [
+        "bool",
+        [this.tari_wallet_ptr, "ulong long", "int*"],
+      ],
+      wallet_test_receive_transaction: ["bool", [this.tari_wallet_ptr, "int*"]],
+      wallet_cancel_pending_transaction: [
+        "bool",
+        [this.tari_wallet_ptr, "ulong long", "int*"],
+      ],
+      wallet_coin_split: [
+        "ulong long",
+        [
+          this.tari_wallet_ptr,
+          "ulong long",
+          "ulong long",
+          "ulong long",
+          "string",
+          "ulong long",
+          "int*",
+        ],
+      ],
+      wallet_get_seed_words: [
+        this.tari_seed_words_ptr,
+        [this.tari_wallet_ptr, "int*"],
+      ],
+      wallet_apply_encryption: [
+        "void",
+        [this.tari_wallet_ptr, "string", "int*"],
+      ],
+      wallet_remove_encryption: ["void", [this.tari_wallet_ptr, "int*"]],
+      wallet_set_key_value: [
+        "bool",
+        [this.tari_wallet_ptr, "string", "string", "int*"],
+      ],
+      wallet_get_value: ["string", [this.tari_wallet_ptr, "string", "int*"]],
+      wallet_clear_value: ["bool", [this.tari_wallet_ptr, "string", "int*"]],
+      wallet_is_recovery_in_progress: ["bool", [this.tari_wallet_ptr, "int*"]],
+      wallet_start_recovery: [
+        "bool",
+        [this.tari_wallet_ptr, this.tari_public_key_ptr, "pointer", "int*"],
+      ],
+      wallet_destroy: ["void", [this.tari_wallet_ptr]],
+      file_partial_backup: ["void", ["string", "string", "int*"]],
+      log_debug_message: ["void", ["string"]],
+      get_emoji_set: [this.emoji_set_ptr, []],
+      emoji_set_destroy: ["void", [this.emoji_set_ptr]],
+      emoji_set_get_at: [
+        this.byte_vector_ptr,
+        [this.emoji_set_ptr, "uint", "int*"],
+      ],
+      emoji_set_get_length: ["uint", [this.emoji_set_ptr, "int*"]],
+    });
+  }
+
+  static checkError(text) {
+    expect(this.error.deref()).to.equal(0, `Error in ${text}`);
+  }
+
+  /// -------------------------------- Transport Types ----------------------------------------------- ///
+
+  static transportTcpCreate(listener_address) {
+    let tcp = this.#fn.transport_tcp_create(listener_address, this.error);
+    this.checkError("transportTcpCreate");
+    return tcp;
+  }
+
+  static transportTorCreate(
+    control_server_address,
+    tor_cookie,
+    tor_port,
+    socks_username,
+    socks_password
+  ) {
+    let tor = this.#fn.transport_tor_create(
+      control_server_address,
+      tor_cookie,
+      tor_port,
+      socks_username,
+      socks_password,
+      this.error
+    );
+    this.checkError("transportTorCreate");
+    return tor;
+  }
+
+  static transportMemoryGetAddress(transport) {
+    let address = this.#fn.transport_memory_get_address(transport, this.error);
+    this.checkError("transportMemoryGetAddress");
+    return address;
+  }
+
+  static transportTypeDestroy(transport) {
+    this.#fn.transport_type_destroy(transport);
+  }
+
+  /// -------------------------------- Strings ----------------------------------------------- ///
+
+  static stringDestroy(string) {
+    this.#fn.string_destroy(string);
+  }
+
+  /// -------------------------------- ByteVector ----------------------------------------------- ///
+
+  static byteVectorCreate(byte_array, element_count) {
+    const byte_vector = this.#fn.byte_vector_create(
+      byte_array,
+      element_count,
+      this.error
+    );
+    this.checkError("byteVectorCreate");
+    /// -------------------------------- TariWallet ----------------------------------------------- //
+    return byte_vector;
+  }
+
+  static byteVectorGetAt(byte_array, i) {
+    const byte = this.#fn.byte_vector_get_at(byte_array, i, this.error);
+    this.checkError("byteVectorGetAt");
+    return byte;
+  }
+
+  static byteVectorGetLength(byte_array) {
+    const length = this.#fn.byte_vector_get_length(byte_array, this.error);
+    this.checkError("byteVectorGetLength");
+    return length;
+  }
+
+  static byteVectorDestroy(byte_array) {
+    this.#fn.byte_vector_destroy(byte_array);
+  }
+
+  /// -------------------------------- TariPublicKey ----------------------------------------------- ///
+
+  static publicKeyGetBytes(public_key) {
+    let bytes = this.#fn.public_key_get_bytes(public_key, this.error);
+    this.checkError("publicKeyGetBytes");
+    return bytes;
+  }
+
+  static publicKeyDestroy(public_key) {
+    this.#fn.public_key_destroy(public_key);
+  }
+
+  static publicKeyToEmojiId(public_key) {
+    let emoji_id = this.#fn.public_key_to_emoji_id(public_key, this.error);
+    this.checkError("publicKeyToEmojiId");
+    return emoji_id;
+  }
+  /// -------------------------------- TariPrivateKey ----------------------------------------------- ///
+  /// -------------------------------- Seed Words  -------------------------------------------------- ///
+  /// -------------------------------- Contact ------------------------------------------------------ ///
+  /// -------------------------------- Contacts ------------------------------------------------------ ///
+  /// -------------------------------- CompletedTransaction ------------------------------------------------------ ///
+  /// -------------------------------- CompletedTransactions ------------------------------------------------------ ///
+  /// -------------------------------- OutboundTransaction ------------------------------------------------------ ///
+  /// -------------------------------- OutboundTransactions ------------------------------------------------------ ///
+  /// -------------------------------- InboundTransaction ------------------------------------------------------ ///
+  /// -------------------------------- InboundTransactions ------------------------------------------------------ ///
+  /// -------------------------------- TariCommsConfig ----------------------------------------------- ///
+
+  static commsConfigCreate(
+    public_address,
+    transport,
+    database_name,
+    datastore_path,
+    discovery_timeout_in_secs,
+    saf_message_duration_in_secs
+  ) {
+    let comms_config = this.#fn.comms_config_create(
+      public_address,
+      transport,
+      database_name,
+      datastore_path,
+      discovery_timeout_in_secs,
+      saf_message_duration_in_secs,
+      this.error
+    );
+    this.checkError("commsConfigCreate");
+    return comms_config;
+  }
+
+  /// -------------------------------- TariWallet ----------------------------------------------- //
+
+  static walletCreate(
+    comms_config,
+    log_path,
+    num_rolling_log_files,
+    size_per_log_file_bytes,
+    passphrase,
+    seed_words
+    // callback_received_transaction
+  ) {
+    let callback_received_transaction = ffi.Callback(
+      "void",
+      [this.tari_pending_inbound_transaction_ptr],
+      function (_pending_inbound_transcation) {
+        console.log("callback_received_transaction");
+      }
+    );
+    let callback_received_transaction_reply = ffi.Callback(
+      "void",
+      [this.tari_completed_transaction_ptr],
+      function (_completed_transaction) {
+        console.log("callback_received_transaction_reply");
+      }
+    );
+    let callback_received_finalized_transaction = ffi.Callback(
+      "void",
+      [this.tari_completed_transaction_ptr],
+      function (_completed_transaction) {
+        console.log("callback_received_finalized_transaction");
+      }
+    );
+    let callback_transaction_broadcast = ffi.Callback(
+      "void",
+      [this.tari_completed_transaction_ptr],
+      function (_completed_transaction) {
+        console.log("callback_transaction_broadcast");
+      }
+    );
+    let callback_transaction_mined = ffi.Callback(
+      "void",
+      [this.tari_completed_transaction_ptr],
+      function (_completed_transaction) {
+        console.log("callback_transaction_mined");
+      }
+    );
+    let callback_transaction_mined_unconfirmed = ffi.Callback(
+      "void",
+      [this.tari_completed_transaction_ptr, "long long"],
+      function (_completed_transaction, x) {
+        console.log("callback_transaction_mined_unconfirmed", x);
+      }
+    );
+    let callback_direct_send_result = ffi.Callback(
+      "void",
+      ["long long", "bool"],
+      function (x, y) {
+        console.log("callback_direct_send_result", x, y);
+      }
+    );
+    let callback_store_and_forward_send_result = ffi.Callback(
+      "void",
+      ["long long", "bool"],
+      function (x, y) {
+        console.log("callback_store_and_forward_send_result", x, y);
+      }
+    );
+    let callback_transaction_cancellation = ffi.Callback(
+      "void",
+      [this.tari_completed_transaction_ptr],
+      function (_completed_transaction) {
+        console.log("callback_transaction_cancellation");
+      }
+    );
+    let callback_utxo_validation_complete = ffi.Callback(
+      "void",
+      ["long long", "char"],
+      function (x, y) {
+        console.log("callback_utxo_validation_complete", x, y);
+      }
+    );
+    let callback_stxo_validation_complete = ffi.Callback(
+      "void",
+      ["long long", "char"],
+      function (x, y) {
+        console.log("callback_stxo_validation_complete", x, y);
+      }
+    );
+    let callback_invalid_txo_validation_complete = ffi.Callback(
+      "void",
+      ["long long", "char"],
+      function (x, y) {
+        console.log("callback_invalid_txo_validation_complete", x, y);
+      }
+    );
+    let callback_transaction_validation_complete = ffi.Callback(
+      "void",
+      ["long long", "char"],
+      function (x, y) {
+        console.log("callback_transaction_validation_complete", x, y);
+      }
+    );
+    let callback_saf_message_received = ffi.Callback("void", [], function () {
+      console.log("callback_saf_message_received");
+    });
+
+    let wallet = this.#fn.wallet_create(
+      comms_config,
+      log_path,
+      num_rolling_log_files,
+      size_per_log_file_bytes,
+      passphrase,
+      seed_words,
+      callback_received_transaction,
+      callback_received_transaction_reply,
+      callback_received_finalized_transaction,
+      callback_transaction_broadcast,
+      callback_transaction_mined,
+      callback_transaction_mined_unconfirmed,
+      callback_direct_send_result,
+      callback_store_and_forward_send_result,
+      callback_transaction_cancellation,
+      callback_utxo_validation_complete,
+      callback_stxo_validation_complete,
+      callback_invalid_txo_validation_complete,
+      callback_transaction_validation_complete,
+      callback_saf_message_received,
+      this.error
+    );
+
+    this.checkError("walletCreate");
+    return wallet;
+  }
+
+  static walletGetPublicKey(wallet) {
+    const public_key = this.#fn.wallet_get_public_key(wallet, this.error);
+    this.checkError("walletGetPublicKey");
+    return public_key;
+  }
+
+  static walletDestroy(wallet) {
+    this.#fn.wallet_destroy(wallet);
+  }
+}
+
+module.exports = WalletFFI;

--- a/integration_tests/helpers/walletFFIClient.js
+++ b/integration_tests/helpers/walletFFIClient.js
@@ -1,0 +1,70 @@
+const WalletFFI = require("./walletFFI");
+const { getFreePort } = require("./util");
+const dateFormat = require("dateformat");
+
+class WalletFFIClient {
+  #name;
+  #wallet;
+  #comms_config;
+  #port;
+
+  constructor(name) {
+    this.#wallet = null;
+    this.#name = name;
+  }
+
+  static async Init() {
+    await WalletFFI.Init();
+  }
+
+  async startNew() {
+    this.#port = await getFreePort(19000, 25000);
+    const name = `WalletFFI${this.#port}-${this.#name}`;
+    const baseDir = `./temp/base_nodes/${dateFormat(
+      new Date(),
+      "yyyymmddHHMM"
+    )}/${name}`;
+    const tcp = WalletFFI.transportTcpCreate(`/ip4/0.0.0.0/tcp/${this.#port}`);
+    this.#comms_config = WalletFFI.commsConfigCreate(
+      `/ip4/0.0.0.0/tcp/${this.#port}`,
+      tcp,
+      "wallet.dat",
+      baseDir,
+      30,
+      600
+    );
+    this.#wallet = WalletFFI.walletCreate(
+      this.#comms_config,
+      `${baseDir}/logs/wallet.log`,
+      5,
+      10240,
+      WalletFFI.NULL,
+      WalletFFI.NULL
+    );
+  }
+
+  stop() {
+    WalletFFI.walletDestroy(this.#wallet);
+  }
+
+  getPublicKey() {
+    const public_key = WalletFFI.walletGetPublicKey(this.#wallet);
+    const bytes = WalletFFI.publicKeyGetBytes(public_key);
+    const length = WalletFFI.byteVectorGetLength(bytes);
+    let public_key_array = Array(length)
+      .fill()
+      .map((_, i) => WalletFFI.byteVectorGetAt(bytes, i));
+    WalletFFI.byteVectorDestroy(bytes);
+    WalletFFI.publicKeyDestroy(public_key);
+    return public_key_array;
+  }
+
+  getEmojiId() {
+    const public_key = WalletFFI.walletGetPublicKey(this.#wallet);
+    let emoji_id = WalletFFI.publicKeyToEmojiId(public_key);
+    WalletFFI.publicKeyDestroy(public_key);
+    return emoji_id;
+  }
+}
+
+module.exports = WalletFFIClient;

--- a/integration_tests/package-lock.json
+++ b/integration_tests/package-lock.json
@@ -24,6 +24,9 @@
         "yargs": "^17.0.1"
       },
       "devDependencies": {
+        "@babel/core": "^7.15.0",
+        "@babel/eslint-parser": "^7.15.0",
+        "@babel/eslint-plugin": "^7.14.5",
         "@grpc/grpc-js": "^1.3.6",
         "@grpc/proto-loader": "^0.5.5",
         "blakejs": "^1.1.0",
@@ -38,9 +41,11 @@
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-prettier": "^3.4.0",
         "eslint-plugin-promise": "^4.3.1",
+        "ffi-napi": "^4.0.3",
         "grpc-promise": "^1.4.0",
         "husky": "^6.0.0",
-        "prettier": "^2.2.1"
+        "prettier": "^2.2.1",
+        "ref-napi": "^3.0.3"
       }
     },
     "../clients/wallet_grpc_client": {
@@ -169,10 +174,310 @@
         "@babel/highlight": "^7.10.4"
       }
     },
-    "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.14.5",
-      "integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
+    "node_modules/@babel/compat-data": {
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.15.0.tgz",
+      "integrity": "sha512-0NqAC1IJE0S0+lL1SWFMxMkz1pKCNCjI4tr2Zx4LJSXxCLAdr6KyArnY+sno5m3yH9g737ygOyPABDsnXkpxiA==",
       "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.0.tgz",
+      "integrity": "sha512-tXtmTminrze5HEUPn/a0JtOzzfp0nk+UEXQ/tqIJo3WDGypl/2OFQEMll/zSFU8f/lfmfLXvTaORHF3cfXIQMw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.14.5",
+        "@babel/generator": "^7.15.0",
+        "@babel/helper-compilation-targets": "^7.15.0",
+        "@babel/helper-module-transforms": "^7.15.0",
+        "@babel/helpers": "^7.14.8",
+        "@babel/parser": "^7.15.0",
+        "@babel/template": "^7.14.5",
+        "@babel/traverse": "^7.15.0",
+        "@babel/types": "^7.15.0",
+        "convert-source-map": "^1.7.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.1.2",
+        "semver": "^6.3.0",
+        "source-map": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/@babel/code-frame": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+      "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/highlight": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/eslint-parser": {
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.15.0.tgz",
+      "integrity": "sha512-+gSPtjSBxOZz4Uh8Ggqu7HbfpB8cT1LwW0DnVVLZEJvzXauiD0Di3zszcBkRmfGGrLdYeHUwcflG7i3tr9kQlw==",
+      "dev": true,
+      "dependencies": {
+        "eslint-scope": "^5.1.1",
+        "eslint-visitor-keys": "^2.1.0",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || >=14.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.11.0",
+        "eslint": ">=7.5.0"
+      }
+    },
+    "node_modules/@babel/eslint-parser/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/eslint-plugin": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-plugin/-/eslint-plugin-7.14.5.tgz",
+      "integrity": "sha512-nzt/YMnOOIRikvSn2hk9+W2omgJBy6U8TN0R+WTTmqapA+HnZTuviZaketdTE9W7/k/+E/DfZlt1ey1NSE39pg==",
+      "dev": true,
+      "dependencies": {
+        "eslint-rule-composer": "^0.3.0"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || >=14.0.0"
+      },
+      "peerDependencies": {
+        "@babel/eslint-parser": ">=7.11.0",
+        "eslint": ">=7.5.0"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.0.tgz",
+      "integrity": "sha512-eKl4XdMrbpYvuB505KTta4AV9g+wWzmVBW69tX0H2NwKVKd2YJbKgyK6M8j/rgLbmHOYJn6rUklV677nOyJrEQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.15.0",
+        "jsesc": "^2.5.1",
+        "source-map": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.15.0.tgz",
+      "integrity": "sha512-h+/9t0ncd4jfZ8wsdAsoIxSa61qhBYlycXiHWqJaQBCXAhDCMbPRSMTGnZIkkmt1u4ag+UQmuqcILwqKzZ4N2A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/compat-data": "^7.15.0",
+        "@babel/helper-validator-option": "^7.14.5",
+        "browserslist": "^4.16.6",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-function-name": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
+      "integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-get-function-arity": "^7.14.5",
+        "@babel/template": "^7.14.5",
+        "@babel/types": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-get-function-arity": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
+      "integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-hoist-variables": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz",
+      "integrity": "sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions": {
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.0.tgz",
+      "integrity": "sha512-Jq8H8U2kYiafuj2xMTPQwkTBnEEdGKpT35lJEQsRRjnG0LW3neucsaMWLgKcwu3OHKNeYugfw+Z20BXBSEs2Lg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.15.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz",
+      "integrity": "sha512-SwrNHu5QWS84XlHwGYPDtCxcA0hrSlL2yhWYLgeOc0w7ccOl2qv4s/nARI0aYZW+bSwAL5CukeXA47B/1NKcnQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.0.tgz",
+      "integrity": "sha512-RkGiW5Rer7fpXv9m1B3iHIFDZdItnO2/BLfWVW/9q7+KqQSDY5kUfQEbzdXM1MVhJGcugKV7kRrNVzNxmk7NBg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.14.5",
+        "@babel/helper-replace-supers": "^7.15.0",
+        "@babel/helper-simple-access": "^7.14.8",
+        "@babel/helper-split-export-declaration": "^7.14.5",
+        "@babel/helper-validator-identifier": "^7.14.9",
+        "@babel/template": "^7.14.5",
+        "@babel/traverse": "^7.15.0",
+        "@babel/types": "^7.15.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-optimise-call-expression": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.14.5.tgz",
+      "integrity": "sha512-IqiLIrODUOdnPU9/F8ib1Fx2ohlgDhxnIDU7OEVi+kAbEZcyiF7BLU8W6PfvPi9LzztjS7kcbzbmL7oG8kD6VA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-replace-supers": {
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.15.0.tgz",
+      "integrity": "sha512-6O+eWrhx+HEra/uJnifCwhwMd6Bp5+ZfZeJwbqUTuqkhIT6YcRhiZCOOFChRypOIe0cV46kFrRBlm+t5vHCEaA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-member-expression-to-functions": "^7.15.0",
+        "@babel/helper-optimise-call-expression": "^7.14.5",
+        "@babel/traverse": "^7.15.0",
+        "@babel/types": "^7.15.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-simple-access": {
+      "version": "7.14.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.14.8.tgz",
+      "integrity": "sha512-TrFN4RHh9gnWEU+s7JloIho2T76GPwRHhdzOWLqTrMnlas8T9O7ec+oEDNsRXndOmru9ymH9DFrEOxpzPoSbdg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.14.8"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-split-export-declaration": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
+      "integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.14.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+      "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
+      "integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.14.8",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.8.tgz",
+      "integrity": "sha512-ZRDmI56pnV+p1dH6d+UN6GINGz7Krps3+270qqI9UJ4wxYThfAIcI5i7j5vXC4FJ3Wap+S9qcebxeYiqn87DZw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/template": "^7.14.5",
+        "@babel/traverse": "^7.14.8",
+        "@babel/types": "^7.14.8"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -190,6 +495,18 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/parser": {
+      "version": "7.15.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.2.tgz",
+      "integrity": "sha512-bMJXql1Ss8lFnvr11TZDH4ArtwlAS5NG9qBmdiFW2UHHm6MVoR+GDc5XE2b9K938cyjc9O6/+vjjcffLDtfuDg==",
+      "dev": true,
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@babel/runtime-corejs3": {
       "version": "7.14.7",
       "integrity": "sha512-Wvzcw4mBYbTagyBVZpAJWI06auSIj033T/yNE0Zn1xcup83MieCddZA7ls3kme17L4NOGBrQ09Q+nKB41RLWBA==",
@@ -197,6 +514,86 @@
       "dependencies": {
         "core-js-pure": "^3.15.0",
         "regenerator-runtime": "^0.13.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
+      "integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.14.5",
+        "@babel/parser": "^7.14.5",
+        "@babel/types": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template/node_modules/@babel/code-frame": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+      "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/highlight": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.0.tgz",
+      "integrity": "sha512-392d8BN0C9eVxVWd8H6x9WfipgVH5IaIoLp23334Sc1vbKKWINnvwRpb4us0xtPaCumlwbTtIYNA0Dv/32sVFw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.14.5",
+        "@babel/generator": "^7.15.0",
+        "@babel/helper-function-name": "^7.14.5",
+        "@babel/helper-hoist-variables": "^7.14.5",
+        "@babel/helper-split-export-declaration": "^7.14.5",
+        "@babel/parser": "^7.15.0",
+        "@babel/types": "^7.15.0",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/@babel/code-frame": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+      "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/highlight": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
+      "integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.14.9",
+        "to-fast-properties": "^2.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -588,6 +985,29 @@
         "concat-map": "0.0.1"
       }
     },
+    "node_modules/browserslist": {
+      "version": "4.16.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.7.tgz",
+      "integrity": "sha512-7I4qVwqZltJ7j37wObBe3SoTz+nS8APaNcrBOlgoirb6/HbEU2XxW/LpUDTCngM6iauwFqmRTuOMfyKnFGY5JA==",
+      "dev": true,
+      "dependencies": {
+        "caniuse-lite": "^1.0.30001248",
+        "colorette": "^1.2.2",
+        "electron-to-chromium": "^1.3.793",
+        "escalade": "^3.1.1",
+        "node-releases": "^1.1.73"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/browserslist"
+      }
+    },
     "node_modules/buffer": {
       "version": "5.7.1",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
@@ -635,6 +1055,16 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001249",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001249.tgz",
+      "integrity": "sha512-vcX4U8lwVXPdqzPWi6cAJ3FnQaqXbBqy/GZseKNQzRj37J7qZdGcBtxq/QLFNLLlfsoXLUdHw8Iwenri86Tagw==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/browserslist"
       }
     },
     "node_modules/chai": {
@@ -767,6 +1197,12 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "node_modules/colorette": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
+      "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
+      "dev": true
+    },
     "node_modules/colors": {
       "version": "1.4.0",
       "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
@@ -796,6 +1232,15 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "node_modules/convert-source-map": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
+      "integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.1"
+      }
     },
     "node_modules/core-js-pure": {
       "version": "3.15.2",
@@ -1044,6 +1489,12 @@
         "d": "1",
         "es5-ext": "~0.10.46"
       }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.3.801",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.801.tgz",
+      "integrity": "sha512-xapG8ekC+IAHtJrGBMQSImNuN+dm+zl7UP1YbhvTkwQn8zf/yYuoxfTSAEiJ9VDD+kjvXaAhNDPSxJ+VImtAJA==",
+      "dev": true
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -1439,6 +1890,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/eslint-rule-composer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz",
+      "integrity": "sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "5.1.1",
       "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
@@ -1710,6 +2170,30 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "node_modules/ffi-napi": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/ffi-napi/-/ffi-napi-4.0.3.tgz",
+      "integrity": "sha512-PMdLCIvDY9mS32RxZ0XGb95sonPRal8aqRhLbeEtWKZTe2A87qRFG9HjOhvG8EX2UmQw5XNRMIOT+1MYlWmdeg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-uv-event-loop-napi-h": "^1.0.5",
+        "node-addon-api": "^3.0.0",
+        "node-gyp-build": "^4.2.1",
+        "ref-napi": "^2.0.1 || ^3.0.2",
+        "ref-struct-di": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ffi-napi/node_modules/node-addon-api": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
+      "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
+      "dev": true
+    },
     "node_modules/figures": {
       "version": "3.2.0",
       "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
@@ -1840,6 +2324,15 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
@@ -1866,6 +2359,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-symbol-from-current-process-h": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-symbol-from-current-process-h/-/get-symbol-from-current-process-h-1.0.2.tgz",
+      "integrity": "sha512-syloC6fsCt62ELLrr1VKBM1ggOpMdetX9hTrdW77UQdcApPHLmf7CI7OKcN1c9kYuNxKcDe4iJ4FY9sX3aw2xw==",
+      "dev": true
+    },
+    "node_modules/get-uv-event-loop-napi-h": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/get-uv-event-loop-napi-h/-/get-uv-event-loop-napi-h-1.0.6.tgz",
+      "integrity": "sha512-t5c9VNR84nRoF+eLiz6wFrEp1SE2Acg0wS+Ysa2zF0eROes+LzOfuTaVHxGy8AbS8rq7FHEJzjnCZo1BupwdJg==",
+      "dev": true,
+      "dependencies": {
+        "get-symbol-from-current-process-h": "^1.0.1"
       }
     },
     "node_modules/gherkin": {
@@ -2291,6 +2799,18 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true,
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/json-parse-better-errors": {
       "version": "1.0.2",
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
@@ -2566,6 +3086,23 @@
       "dependencies": {
         "lodash.toarray": "^4.4.0"
       }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
+      "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==",
+      "dev": true,
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "1.1.73",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.73.tgz",
+      "integrity": "sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg==",
+      "dev": true
     },
     "node_modules/normalize-package-data": {
       "version": "2.5.0",
@@ -2956,6 +3493,46 @@
       "integrity": "sha512-91/k1EzZwDx6HbERR+zucygRFfiPl2zkIYZtv3Jjr6Mn7SkKcVct8aVO+sSRiGMc6fLf72du3d92/uY63YPdEA==",
       "dependencies": {
         "minimatch": "^3.0.4"
+      }
+    },
+    "node_modules/ref-napi": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/ref-napi/-/ref-napi-3.0.3.tgz",
+      "integrity": "sha512-LiMq/XDGcgodTYOMppikEtJelWsKQERbLQsYm0IOOnzhwE9xYZC7x8txNnFC9wJNOkPferQI4vD4ZkC0mDyrOA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-symbol-from-current-process-h": "^1.0.2",
+        "node-addon-api": "^3.0.0",
+        "node-gyp-build": "^4.2.1"
+      },
+      "engines": {
+        "node": ">= 10.0"
+      }
+    },
+    "node_modules/ref-napi/node_modules/node-addon-api": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
+      "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
+      "dev": true
+    },
+    "node_modules/ref-struct-di": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ref-struct-di/-/ref-struct-di-1.1.1.tgz",
+      "integrity": "sha512-2Xyn/0Qgz89VT+++WP0sTosdm9oeowLP23wRJYhG4BFdMUrLj3jhwHZNEytYNYgtPKLNTP3KJX4HEgBvM1/Y2g==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^3.1.0"
+      }
+    },
+    "node_modules/ref-struct-di/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.1"
       }
     },
     "node_modules/regenerator-runtime": {
@@ -3491,6 +4068,15 @@
         "upper-case": "^1.0.3"
       }
     },
+    "node_modules/to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/traverse-chain": {
       "version": "0.1.0",
       "integrity": "sha1-YdvC1Ttp/2CRoSoWj9fUMxB+QPE=",
@@ -3842,10 +4428,235 @@
         "@babel/highlight": "^7.10.4"
       }
     },
-    "@babel/helper-validator-identifier": {
-      "version": "7.14.5",
-      "integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
+    "@babel/compat-data": {
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.15.0.tgz",
+      "integrity": "sha512-0NqAC1IJE0S0+lL1SWFMxMkz1pKCNCjI4tr2Zx4LJSXxCLAdr6KyArnY+sno5m3yH9g737ygOyPABDsnXkpxiA==",
       "dev": true
+    },
+    "@babel/core": {
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.0.tgz",
+      "integrity": "sha512-tXtmTminrze5HEUPn/a0JtOzzfp0nk+UEXQ/tqIJo3WDGypl/2OFQEMll/zSFU8f/lfmfLXvTaORHF3cfXIQMw==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.14.5",
+        "@babel/generator": "^7.15.0",
+        "@babel/helper-compilation-targets": "^7.15.0",
+        "@babel/helper-module-transforms": "^7.15.0",
+        "@babel/helpers": "^7.14.8",
+        "@babel/parser": "^7.15.0",
+        "@babel/template": "^7.14.5",
+        "@babel/traverse": "^7.15.0",
+        "@babel/types": "^7.15.0",
+        "convert-source-map": "^1.7.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.1.2",
+        "semver": "^6.3.0",
+        "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+          "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.14.5"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/eslint-parser": {
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.15.0.tgz",
+      "integrity": "sha512-+gSPtjSBxOZz4Uh8Ggqu7HbfpB8cT1LwW0DnVVLZEJvzXauiD0Di3zszcBkRmfGGrLdYeHUwcflG7i3tr9kQlw==",
+      "dev": true,
+      "requires": {
+        "eslint-scope": "^5.1.1",
+        "eslint-visitor-keys": "^2.1.0",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/eslint-plugin": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-plugin/-/eslint-plugin-7.14.5.tgz",
+      "integrity": "sha512-nzt/YMnOOIRikvSn2hk9+W2omgJBy6U8TN0R+WTTmqapA+HnZTuviZaketdTE9W7/k/+E/DfZlt1ey1NSE39pg==",
+      "dev": true,
+      "requires": {
+        "eslint-rule-composer": "^0.3.0"
+      }
+    },
+    "@babel/generator": {
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.0.tgz",
+      "integrity": "sha512-eKl4XdMrbpYvuB505KTta4AV9g+wWzmVBW69tX0H2NwKVKd2YJbKgyK6M8j/rgLbmHOYJn6rUklV677nOyJrEQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.15.0",
+        "jsesc": "^2.5.1",
+        "source-map": "^0.5.0"
+      }
+    },
+    "@babel/helper-compilation-targets": {
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.15.0.tgz",
+      "integrity": "sha512-h+/9t0ncd4jfZ8wsdAsoIxSa61qhBYlycXiHWqJaQBCXAhDCMbPRSMTGnZIkkmt1u4ag+UQmuqcILwqKzZ4N2A==",
+      "dev": true,
+      "requires": {
+        "@babel/compat-data": "^7.15.0",
+        "@babel/helper-validator-option": "^7.14.5",
+        "browserslist": "^4.16.6",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
+      "integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.14.5",
+        "@babel/template": "^7.14.5",
+        "@babel/types": "^7.14.5"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
+      "integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.14.5"
+      }
+    },
+    "@babel/helper-hoist-variables": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz",
+      "integrity": "sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.14.5"
+      }
+    },
+    "@babel/helper-member-expression-to-functions": {
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.0.tgz",
+      "integrity": "sha512-Jq8H8U2kYiafuj2xMTPQwkTBnEEdGKpT35lJEQsRRjnG0LW3neucsaMWLgKcwu3OHKNeYugfw+Z20BXBSEs2Lg==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.15.0"
+      }
+    },
+    "@babel/helper-module-imports": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz",
+      "integrity": "sha512-SwrNHu5QWS84XlHwGYPDtCxcA0hrSlL2yhWYLgeOc0w7ccOl2qv4s/nARI0aYZW+bSwAL5CukeXA47B/1NKcnQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.14.5"
+      }
+    },
+    "@babel/helper-module-transforms": {
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.0.tgz",
+      "integrity": "sha512-RkGiW5Rer7fpXv9m1B3iHIFDZdItnO2/BLfWVW/9q7+KqQSDY5kUfQEbzdXM1MVhJGcugKV7kRrNVzNxmk7NBg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.14.5",
+        "@babel/helper-replace-supers": "^7.15.0",
+        "@babel/helper-simple-access": "^7.14.8",
+        "@babel/helper-split-export-declaration": "^7.14.5",
+        "@babel/helper-validator-identifier": "^7.14.9",
+        "@babel/template": "^7.14.5",
+        "@babel/traverse": "^7.15.0",
+        "@babel/types": "^7.15.0"
+      }
+    },
+    "@babel/helper-optimise-call-expression": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.14.5.tgz",
+      "integrity": "sha512-IqiLIrODUOdnPU9/F8ib1Fx2ohlgDhxnIDU7OEVi+kAbEZcyiF7BLU8W6PfvPi9LzztjS7kcbzbmL7oG8kD6VA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.14.5"
+      }
+    },
+    "@babel/helper-replace-supers": {
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.15.0.tgz",
+      "integrity": "sha512-6O+eWrhx+HEra/uJnifCwhwMd6Bp5+ZfZeJwbqUTuqkhIT6YcRhiZCOOFChRypOIe0cV46kFrRBlm+t5vHCEaA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-member-expression-to-functions": "^7.15.0",
+        "@babel/helper-optimise-call-expression": "^7.14.5",
+        "@babel/traverse": "^7.15.0",
+        "@babel/types": "^7.15.0"
+      }
+    },
+    "@babel/helper-simple-access": {
+      "version": "7.14.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.14.8.tgz",
+      "integrity": "sha512-TrFN4RHh9gnWEU+s7JloIho2T76GPwRHhdzOWLqTrMnlas8T9O7ec+oEDNsRXndOmru9ymH9DFrEOxpzPoSbdg==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.14.8"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
+      "integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.14.5"
+      }
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.14.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+      "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
+      "dev": true
+    },
+    "@babel/helper-validator-option": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
+      "integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==",
+      "dev": true
+    },
+    "@babel/helpers": {
+      "version": "7.14.8",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.8.tgz",
+      "integrity": "sha512-ZRDmI56pnV+p1dH6d+UN6GINGz7Krps3+270qqI9UJ4wxYThfAIcI5i7j5vXC4FJ3Wap+S9qcebxeYiqn87DZw==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.14.5",
+        "@babel/traverse": "^7.14.8",
+        "@babel/types": "^7.14.8"
+      }
     },
     "@babel/highlight": {
       "version": "7.14.5",
@@ -3857,6 +4668,12 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@babel/parser": {
+      "version": "7.15.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.2.tgz",
+      "integrity": "sha512-bMJXql1Ss8lFnvr11TZDH4ArtwlAS5NG9qBmdiFW2UHHm6MVoR+GDc5XE2b9K938cyjc9O6/+vjjcffLDtfuDg==",
+      "dev": true
+    },
     "@babel/runtime-corejs3": {
       "version": "7.14.7",
       "integrity": "sha512-Wvzcw4mBYbTagyBVZpAJWI06auSIj033T/yNE0Zn1xcup83MieCddZA7ls3kme17L4NOGBrQ09Q+nKB41RLWBA==",
@@ -3864,6 +4681,72 @@
       "requires": {
         "core-js-pure": "^3.15.0",
         "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "@babel/template": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
+      "integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.14.5",
+        "@babel/parser": "^7.14.5",
+        "@babel/types": "^7.14.5"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+          "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.14.5"
+          }
+        }
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.0.tgz",
+      "integrity": "sha512-392d8BN0C9eVxVWd8H6x9WfipgVH5IaIoLp23334Sc1vbKKWINnvwRpb4us0xtPaCumlwbTtIYNA0Dv/32sVFw==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.14.5",
+        "@babel/generator": "^7.15.0",
+        "@babel/helper-function-name": "^7.14.5",
+        "@babel/helper-hoist-variables": "^7.14.5",
+        "@babel/helper-split-export-declaration": "^7.14.5",
+        "@babel/parser": "^7.15.0",
+        "@babel/types": "^7.15.0",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+          "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.14.5"
+          }
+        },
+        "globals": {
+          "version": "11.12.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/types": {
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
+      "integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.14.9",
+        "to-fast-properties": "^2.0.0"
       }
     },
     "@eslint/eslintrc": {
@@ -4180,6 +5063,19 @@
         "concat-map": "0.0.1"
       }
     },
+    "browserslist": {
+      "version": "4.16.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.7.tgz",
+      "integrity": "sha512-7I4qVwqZltJ7j37wObBe3SoTz+nS8APaNcrBOlgoirb6/HbEU2XxW/LpUDTCngM6iauwFqmRTuOMfyKnFGY5JA==",
+      "dev": true,
+      "requires": {
+        "caniuse-lite": "^1.0.30001248",
+        "colorette": "^1.2.2",
+        "electron-to-chromium": "^1.3.793",
+        "escalade": "^3.1.1",
+        "node-releases": "^1.1.73"
+      }
+    },
     "buffer": {
       "version": "5.7.1",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
@@ -4204,6 +5100,12 @@
     "callsites": {
       "version": "3.1.0",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true
+    },
+    "caniuse-lite": {
+      "version": "1.0.30001249",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001249.tgz",
+      "integrity": "sha512-vcX4U8lwVXPdqzPWi6cAJ3FnQaqXbBqy/GZseKNQzRj37J7qZdGcBtxq/QLFNLLlfsoXLUdHw8Iwenri86Tagw==",
       "dev": true
     },
     "chai": {
@@ -4308,6 +5210,12 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "colorette": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
+      "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
+      "dev": true
+    },
     "colors": {
       "version": "1.4.0",
       "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
@@ -4331,6 +5239,15 @@
     "concat-map": {
       "version": "0.0.1",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "convert-source-map": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
+      "integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.1"
+      }
     },
     "core-js-pure": {
       "version": "3.15.2",
@@ -4519,6 +5436,12 @@
         "d": "1",
         "es5-ext": "~0.10.46"
       }
+    },
+    "electron-to-chromium": {
+      "version": "1.3.801",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.801.tgz",
+      "integrity": "sha512-xapG8ekC+IAHtJrGBMQSImNuN+dm+zl7UP1YbhvTkwQn8zf/yYuoxfTSAEiJ9VDD+kjvXaAhNDPSxJ+VImtAJA==",
+      "dev": true
     },
     "emoji-regex": {
       "version": "8.0.0",
@@ -4883,6 +5806,12 @@
       "integrity": "sha512-bY2sGqyptzFBDLh/GMbAxfdJC+b0f23ME63FOE4+Jao0oZ3E1LEwFtWJX/1pGMJLiTtrSSern2CRM/g+dfc0eQ==",
       "dev": true
     },
+    "eslint-rule-composer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz",
+      "integrity": "sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==",
+      "dev": true
+    },
     "eslint-scope": {
       "version": "5.1.1",
       "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
@@ -5018,6 +5947,28 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "ffi-napi": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/ffi-napi/-/ffi-napi-4.0.3.tgz",
+      "integrity": "sha512-PMdLCIvDY9mS32RxZ0XGb95sonPRal8aqRhLbeEtWKZTe2A87qRFG9HjOhvG8EX2UmQw5XNRMIOT+1MYlWmdeg==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "get-uv-event-loop-napi-h": "^1.0.5",
+        "node-addon-api": "^3.0.0",
+        "node-gyp-build": "^4.2.1",
+        "ref-napi": "^2.0.1 || ^3.0.2",
+        "ref-struct-di": "^1.1.0"
+      },
+      "dependencies": {
+        "node-addon-api": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
+          "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
+          "dev": true
+        }
+      }
+    },
     "figures": {
       "version": "3.2.0",
       "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
@@ -5117,6 +6068,12 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
+    "gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true
+    },
     "get-caller-file": {
       "version": "2.0.5",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
@@ -5134,6 +6091,21 @@
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
         "has-symbols": "^1.0.1"
+      }
+    },
+    "get-symbol-from-current-process-h": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-symbol-from-current-process-h/-/get-symbol-from-current-process-h-1.0.2.tgz",
+      "integrity": "sha512-syloC6fsCt62ELLrr1VKBM1ggOpMdetX9hTrdW77UQdcApPHLmf7CI7OKcN1c9kYuNxKcDe4iJ4FY9sX3aw2xw==",
+      "dev": true
+    },
+    "get-uv-event-loop-napi-h": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/get-uv-event-loop-napi-h/-/get-uv-event-loop-napi-h-1.0.6.tgz",
+      "integrity": "sha512-t5c9VNR84nRoF+eLiz6wFrEp1SE2Acg0wS+Ysa2zF0eROes+LzOfuTaVHxGy8AbS8rq7FHEJzjnCZo1BupwdJg==",
+      "dev": true,
+      "requires": {
+        "get-symbol-from-current-process-h": "^1.0.1"
       }
     },
     "gherkin": {
@@ -5406,6 +6378,12 @@
         "esprima": "^4.0.0"
       }
     },
+    "jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true
+    },
     "json-parse-better-errors": {
       "version": "1.0.2",
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
@@ -5656,6 +6634,18 @@
       "requires": {
         "lodash.toarray": "^4.4.0"
       }
+    },
+    "node-gyp-build": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
+      "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==",
+      "dev": true
+    },
+    "node-releases": {
+      "version": "1.1.73",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.73.tgz",
+      "integrity": "sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg==",
+      "dev": true
     },
     "normalize-package-data": {
       "version": "2.5.0",
@@ -5935,6 +6925,46 @@
       "integrity": "sha512-91/k1EzZwDx6HbERR+zucygRFfiPl2zkIYZtv3Jjr6Mn7SkKcVct8aVO+sSRiGMc6fLf72du3d92/uY63YPdEA==",
       "requires": {
         "minimatch": "^3.0.4"
+      }
+    },
+    "ref-napi": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/ref-napi/-/ref-napi-3.0.3.tgz",
+      "integrity": "sha512-LiMq/XDGcgodTYOMppikEtJelWsKQERbLQsYm0IOOnzhwE9xYZC7x8txNnFC9wJNOkPferQI4vD4ZkC0mDyrOA==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "get-symbol-from-current-process-h": "^1.0.2",
+        "node-addon-api": "^3.0.0",
+        "node-gyp-build": "^4.2.1"
+      },
+      "dependencies": {
+        "node-addon-api": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
+          "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
+          "dev": true
+        }
+      }
+    },
+    "ref-struct-di": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ref-struct-di/-/ref-struct-di-1.1.1.tgz",
+      "integrity": "sha512-2Xyn/0Qgz89VT+++WP0sTosdm9oeowLP23wRJYhG4BFdMUrLj3jhwHZNEytYNYgtPKLNTP3KJX4HEgBvM1/Y2g==",
+      "dev": true,
+      "requires": {
+        "debug": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
       }
     },
     "regenerator-runtime": {
@@ -6337,6 +7367,12 @@
         "no-case": "^2.2.0",
         "upper-case": "^1.0.3"
       }
+    },
+    "to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true
     },
     "traverse-chain": {
       "version": "0.1.0",

--- a/integration_tests/package.json
+++ b/integration_tests/package.json
@@ -14,6 +14,9 @@
   "author": "The Tari Project",
   "license": "ISC",
   "devDependencies": {
+    "@babel/core": "^7.15.0",
+    "@babel/eslint-parser": "^7.15.0",
+    "@babel/eslint-plugin": "^7.14.5",
     "@grpc/grpc-js": "^1.3.6",
     "@grpc/proto-loader": "^0.5.5",
     "blakejs": "^1.1.0",
@@ -28,9 +31,11 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^3.4.0",
     "eslint-plugin-promise": "^4.3.1",
+    "ffi-napi": "^4.0.3",
     "grpc-promise": "^1.4.0",
     "husky": "^6.0.0",
-    "prettier": "^2.2.1"
+    "prettier": "^2.2.1",
+    "ref-napi": "^3.0.3"
   },
   "dependencies": {
     "archiver": "^5.3.0",


### PR DESCRIPTION
## Description
Add testing possibilities of wallet ffi.
I've separated the logic of import of the dll into the WalletFFI.js. It's imports all the functions from the dll. But doesn't export (yet) all the javascript cover of these functions. My intentions is to export all the functions as a javascript regular functions to have nice code completion, parameter names etc. So anyone who import this doesn't have to do any ffi stuff.

The WalletFFIClient is responsible of holding the reference to ffi created wallet and calling functions on such wallet.

## Motivation and Context
I've added babel plugin, because the eslint doesn't support static/private methods/variables. 

## Checklist:
* [x] I'm merging against the `development` branch.
* [x] I have squashed my commits into a single commit.
