### PR TITLE
fix: enforce unique commitments in utxo set

### DIFF
--- a/applications/test_faucet/src/main.rs
+++ b/applications/test_faucet/src/main.rs
@@ -63,7 +63,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         task::spawn(async move {
             let result = task::spawn_blocking(move || {
                 let script = script!(Nop);
-                let (utxo, key, _) = helpers::create_utxo(value, &fc, Some(feature), &script);
+                let (utxo, key, _) = helpers::create_utxo(value, &fc, feature, &script);
                 print!(".");
                 (utxo, key, value)
             })

--- a/base_layer/core/src/chain_storage/blockchain_backend.rs
+++ b/base_layer/core/src/chain_storage/blockchain_backend.rs
@@ -16,7 +16,7 @@ use crate::{
     },
     transactions::{
         transaction::{TransactionInput, TransactionKernel},
-        types::{HashOutput, Signature},
+        types::{Commitment, HashOutput, Signature},
     },
 };
 use croaring::Bitmap;
@@ -105,6 +105,12 @@ pub trait BlockchainBackend: Send + Sync {
     /// Fetch a specific output. Returns the output and the leaf index in the output MMR
     fn fetch_output(&self, output_hash: &HashOutput) -> Result<Option<(PrunedOutput, u32, u64)>, ChainStorageError>;
 
+    /// Returns the unspent TransactionOutput output that matches the given commitment if it exists in the current UTXO
+    /// set, otherwise None is returned.
+    fn fetch_unspent_output_hash_by_commitment(
+        &self,
+        commitment: &Commitment,
+    ) -> Result<Option<HashOutput>, ChainStorageError>;
     /// Fetch all outputs in a block
     fn fetch_outputs_in_block(&self, header_hash: &HashOutput) -> Result<Vec<PrunedOutput>, ChainStorageError>;
 

--- a/base_layer/core/src/chain_storage/db_transaction.rs
+++ b/base_layer/core/src/chain_storage/db_transaction.rs
@@ -23,7 +23,7 @@ use crate::{
     blocks::{Block, BlockHeader},
     chain_storage::{error::ChainStorageError, ChainBlock, ChainHeader, MmrTree},
     transactions::{
-        transaction::{TransactionInput, TransactionKernel, TransactionOutput},
+        transaction::{TransactionKernel, TransactionOutput},
         types::{Commitment, HashOutput},
     },
 };
@@ -140,15 +140,6 @@ impl DbTransaction {
             header_height,
             output_hash,
             witness_hash,
-            mmr_position: mmr_leaf_index,
-        });
-        self
-    }
-
-    pub fn insert_input(&mut self, input: TransactionInput, header_hash: HashOutput, mmr_leaf_index: u32) -> &mut Self {
-        self.operations.push(WriteOperation::InsertInput {
-            header_hash,
-            input: Box::new(input),
             mmr_position: mmr_leaf_index,
         });
         self
@@ -283,11 +274,6 @@ pub enum WriteOperation {
     InsertBlockBody {
         block: Arc<ChainBlock>,
     },
-    InsertInput {
-        header_hash: HashOutput,
-        input: Box<TransactionInput>,
-        mmr_position: u32,
-    },
     InsertKernel {
         header_hash: HashOutput,
         kernel: Box<TransactionKernel>,
@@ -387,17 +373,6 @@ impl fmt::Display for WriteOperation {
                 output.hash().to_hex(),
                 header_hash.to_hex(),
                 header_height,
-                mmr_position
-            ),
-            InsertInput {
-                header_hash,
-                input,
-                mmr_position,
-            } => write!(
-                f,
-                "Insert input {} in block: {} position: {}",
-                input.output_hash().to_hex(),
-                header_hash.to_hex(),
                 mmr_position
             ),
             DeleteOrphanChainTip(hash) => write!(f, "DeleteOrphanChainTip({})", hash.to_hex()),

--- a/base_layer/core/src/chain_storage/error.rs
+++ b/base_layer/core/src/chain_storage/error.rs
@@ -107,11 +107,17 @@ pub enum ChainStorageError {
     IoError(#[from] std::io::Error),
     #[error("Cannot calculate MMR roots for block that does not form a chain with the current tip. {0}")]
     CannotCalculateNonTipMmr(String),
+    #[error("Key {key} in {table_name} already exists")]
+    KeyExists { table_name: &'static str, key: String },
 }
 
 impl ChainStorageError {
     pub fn is_value_not_found(&self) -> bool {
         matches!(self, ChainStorageError::ValueNotFound { .. })
+    }
+
+    pub fn is_key_exist_error(&self) -> bool {
+        matches!(self, ChainStorageError::KeyExists { .. })
     }
 }
 

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb.rs
@@ -86,6 +86,16 @@ where
             val,
             e,
         );
+
+        if let lmdb_zero::Error::Code(code) = &e {
+            if *code == lmdb_zero::error::KEYEXIST {
+                return ChainStorageError::KeyExists {
+                    table_name,
+                    key: to_hex(key.as_lmdb_bytes()),
+                };
+            }
+        }
+
         ChainStorageError::InsertError {
             table: table_name,
             error: e.to_string(),

--- a/base_layer/core/src/chain_storage/lmdb_db/mod.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/mod.rs
@@ -44,6 +44,7 @@ pub const LMDB_DB_KERNEL_EXCESS_INDEX: &str = "kernel_excess_index";
 pub const LMDB_DB_KERNEL_EXCESS_SIG_INDEX: &str = "kernel_excess_sig_index";
 pub const LMDB_DB_KERNEL_MMR_SIZE_INDEX: &str = "kernel_mmr_size_index";
 pub const LMDB_DB_UTXO_MMR_SIZE_INDEX: &str = "utxo_mmr_size_index";
+pub const LMDB_DB_UTXO_COMMITMENT_INDEX: &str = "utxo_commitment_index";
 pub const LMDB_DB_ORPHANS: &str = "orphans";
 pub const LMDB_DB_MONERO_SEED_HEIGHT: &str = "monero_seed_height";
 pub const LMDB_DB_ORPHAN_HEADER_ACCUMULATED_DATA: &str = "orphan_accumulated_data";

--- a/base_layer/core/src/test_helpers/blockchain.rs
+++ b/base_layer/core/src/test_helpers/blockchain.rs
@@ -45,7 +45,7 @@ use crate::{
     consensus::{chain_strength_comparer::ChainStrengthComparerBuilder, ConsensusConstantsBuilder, ConsensusManager},
     transactions::{
         transaction::{TransactionInput, TransactionKernel},
-        types::{CryptoFactories, HashOutput, Signature},
+        types::{Commitment, CryptoFactories, HashOutput, Signature},
     },
     validation::{
         block_validators::{BodyOnlyValidator, OrphanBlockValidator},
@@ -246,6 +246,13 @@ impl BlockchainBackend for TempDatabase {
 
     fn fetch_output(&self, output_hash: &HashOutput) -> Result<Option<(PrunedOutput, u32, u64)>, ChainStorageError> {
         self.db.fetch_output(output_hash)
+    }
+
+    fn fetch_unspent_output_hash_by_commitment(
+        &self,
+        commitment: &Commitment,
+    ) -> Result<Option<HashOutput>, ChainStorageError> {
+        self.db.fetch_unspent_output_hash_by_commitment(commitment)
     }
 
     fn fetch_outputs_in_block(&self, header_hash: &HashOutput) -> Result<Vec<PrunedOutput>, ChainStorageError> {

--- a/base_layer/core/src/transactions/coinbase_builder.rs
+++ b/base_layer/core/src/transactions/coinbase_builder.rs
@@ -200,7 +200,7 @@ impl CoinbaseBuilder {
         let unblinded_output = UnblindedOutput::new(
             total_reward,
             spending_key,
-            Some(output_features),
+            output_features,
             script,
             inputs!(PublicKey::from_secret_key(&script_private_key)),
             script_private_key,

--- a/base_layer/core/src/transactions/transaction.rs
+++ b/base_layer/core/src/transactions/transaction.rs
@@ -225,7 +225,7 @@ impl UnblindedOutput {
     pub fn new(
         value: MicroTari,
         spending_key: BlindingFactor,
-        features: Option<OutputFeatures>,
+        features: OutputFeatures,
         script: TariScript,
         input_data: ExecutionStack,
         script_private_key: PrivateKey,
@@ -235,7 +235,7 @@ impl UnblindedOutput {
         UnblindedOutput {
             value,
             spending_key,
-            features: features.unwrap_or_default(),
+            features,
             script,
             input_data,
             script_private_key,

--- a/base_layer/core/src/transactions/transaction_protocol/transaction_initializer.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/transaction_initializer.rs
@@ -314,7 +314,7 @@ impl SenderTransactionInitializer {
                         let change_unblinded_output = UnblindedOutput::new(
                             v,
                             change_key.clone(),
-                            Some(output_features),
+                            output_features,
                             script,
                             self.change_input_data
                                 .as_ref()

--- a/base_layer/core/src/validation/error.rs
+++ b/base_layer/core/src/validation/error.rs
@@ -53,6 +53,8 @@ pub enum ValidationError {
     ContainsSTxO,
     #[error("Transaction contains already outputs that already exist")]
     ContainsTxO,
+    #[error("Transaction contains an output commitment that already exists")]
+    ContainsDuplicateUtxoCommitment,
     #[error("Final state validation failed: The UTXO set did not balance with the expected emission at height {0}")]
     ChainBalanceValidationFailed(u64),
     #[error("Proof of work error: {0}")]

--- a/base_layer/core/src/validation/mocks.rs
+++ b/base_layer/core/src/validation/mocks.rs
@@ -22,7 +22,7 @@
 
 use crate::{
     blocks::{Block, BlockHeader},
-    chain_storage::{BlockchainBackend, ChainBlock, DeletedBitmap},
+    chain_storage::{BlockchainBackend, ChainBlock},
     proof_of_work::{sha3_difficulty, AchievedTargetDifficulty, Difficulty, PowAlgorithm},
     transactions::{transaction::Transaction, types::Commitment},
     validation::{
@@ -80,13 +80,7 @@ impl<B: BlockchainBackend> CandidateBlockBodyValidation<B> for MockValidator {
 }
 
 impl<B: BlockchainBackend> PostOrphanBodyValidation<B> for MockValidator {
-    fn validate_body_for_valid_orphan(
-        &self,
-        _: &ChainBlock,
-        _: &B,
-        _: &ChainMetadata,
-        _: &DeletedBitmap,
-    ) -> Result<(), ValidationError> {
+    fn validate_body_for_valid_orphan(&self, _: &ChainBlock, _: &B, _: &ChainMetadata) -> Result<(), ValidationError> {
         if self.is_valid.load(Ordering::SeqCst) {
             Ok(())
         } else {

--- a/base_layer/core/src/validation/traits.rs
+++ b/base_layer/core/src/validation/traits.rs
@@ -22,7 +22,7 @@
 
 use crate::{
     blocks::{Block, BlockHeader},
-    chain_storage::{BlockchainBackend, ChainBlock, DeletedBitmap},
+    chain_storage::{BlockchainBackend, ChainBlock},
     proof_of_work::AchievedTargetDifficulty,
     transactions::{transaction::Transaction, types::Commitment},
     validation::{error::ValidationError, DifficultyCalculator},
@@ -42,7 +42,6 @@ pub trait PostOrphanBodyValidation<B>: Send + Sync {
         block: &ChainBlock,
         backend: &B,
         metadata: &ChainMetadata,
-        deleted_bitmap: &DeletedBitmap,
     ) -> Result<(), ValidationError>;
 }
 

--- a/base_layer/core/tests/helpers/block_builders.rs
+++ b/base_layer/core/tests/helpers/block_builders.rs
@@ -63,7 +63,6 @@ use tari_core::{
 use tari_crypto::{
     keys::PublicKey as PublicKeyTrait,
     script,
-    script::TariScript,
     tari_utilities::{hash::Hashable, hex::Hex},
 };
 use tari_mmr::MutableMmr;
@@ -114,8 +113,7 @@ pub fn _create_act_gen_block() {
     let factories = CryptoFactories::default();
     let mut header = BlockHeader::new(consensus_manager.consensus_constants(0).blockchain_version());
     let value = consensus_manager.emission_schedule().block_reward(0);
-    let (mut utxo, key, _) = create_utxo(value, &factories, None, &TariScript::default());
-    utxo.features = OutputFeatures::create_coinbase(1);
+    let (utxo, key, _) = create_utxo(value, &factories, OutputFeatures::create_coinbase(1), &script![Nop]);
     let (pk, sig) = create_random_signature_from_s_key(key.clone(), 0.into(), 0);
     let excess = Commitment::from_public_key(&pk);
     let kernel = KernelBuilder::new()

--- a/base_layer/core/tests/mempool.rs
+++ b/base_layer/core/tests/mempool.rs
@@ -268,10 +268,10 @@ fn test_retrieve() {
         txn_schema!(from: vec![outputs[1][4].clone()], to: vec![], fee: 20*uT, lock: 2, features: OutputFeatures::default()),
         txn_schema!(from: vec![outputs[1][5].clone()], to: vec![], fee: 20*uT, lock: 3, features: OutputFeatures::default()),
         // Will be time locked when a tx is added to mempool with this as an input:
-        txn_schema!(from: vec![outputs[1][6].clone()], to: vec![800_000*uT], fee: 60*uT, lock: 0, 
+        txn_schema!(from: vec![outputs[1][6].clone()], to: vec![800_000*uT], fee: 60*uT, lock: 0,
         features: OutputFeatures::with_maturity(4)),
         // Will be time locked when a tx is added to mempool with this as an input:
-        txn_schema!(from: vec![outputs[1][7].clone()], to: vec![800_000*uT], fee: 25*uT, lock: 0, 
+        txn_schema!(from: vec![outputs[1][7].clone()], to: vec![800_000*uT], fee: 25*uT, lock: 0,
         features: OutputFeatures::with_maturity(3)),
     ];
     let (tx, utxos) = schema_to_transaction(&txs);

--- a/base_layer/core/tests/node_comms_interface.rs
+++ b/base_layer/core/tests/node_comms_interface.rs
@@ -204,7 +204,12 @@ async fn outbound_fetch_utxos() {
     let (block_sender, _) = mpsc::unbounded();
     let mut outbound_nci = OutboundNodeCommsInterface::new(request_sender, block_sender);
 
-    let (utxo, _, _) = create_utxo(MicroTari(10_000), &factories, None, &TariScript::default());
+    let (utxo, _, _) = create_utxo(
+        MicroTari(10_000),
+        &factories,
+        Default::default(),
+        &TariScript::default(),
+    );
     let hash = utxo.hash();
     let utxo_response = NodeCommsResponse::TransactionOutputs(vec![utxo.clone()]);
     let (received_utxos, _) = futures::join!(
@@ -239,7 +244,12 @@ async fn inbound_fetch_utxos() {
     let utxo_1 = block.body.outputs()[0].clone();
     let hash_1 = utxo_1.hash();
 
-    let (utxo_2, _, _) = create_utxo(MicroTari(10_000), &factories, None, &TariScript::default());
+    let (utxo_2, _, _) = create_utxo(
+        MicroTari(10_000),
+        &factories,
+        Default::default(),
+        &TariScript::default(),
+    );
     let hash_2 = utxo_2.hash();
 
     // Only retrieve a subset of the actual hashes, including a fake hash in the list
@@ -261,8 +271,18 @@ async fn outbound_fetch_txos() {
     let (block_sender, _) = mpsc::unbounded();
     let mut outbound_nci = OutboundNodeCommsInterface::new(request_sender, block_sender);
 
-    let (txo1, _, _) = create_utxo(MicroTari(10_000), &factories, None, &TariScript::default());
-    let (txo2, _, _) = create_utxo(MicroTari(15_000), &factories, None, &TariScript::default());
+    let (txo1, _, _) = create_utxo(
+        MicroTari(10_000),
+        &factories,
+        Default::default(),
+        &TariScript::default(),
+    );
+    let (txo2, _, _) = create_utxo(
+        MicroTari(15_000),
+        &factories,
+        Default::default(),
+        &TariScript::default(),
+    );
     let hash1 = txo1.hash();
     let hash2 = txo2.hash();
     let txo_response = NodeCommsResponse::TransactionOutputs(vec![txo1.clone(), txo2.clone()]);
@@ -295,9 +315,24 @@ async fn inbound_fetch_txos() {
         outbound_nci,
     );
 
-    let (utxo, _, _) = create_utxo(MicroTari(10_000), &factories, None, &TariScript::default());
-    let (pruned_utxo, _, _) = create_utxo(MicroTari(10_000), &factories, None, &TariScript::default());
-    let (stxo, _, _) = create_utxo(MicroTari(10_000), &factories, None, &TariScript::default());
+    let (utxo, _, _) = create_utxo(
+        MicroTari(10_000),
+        &factories,
+        Default::default(),
+        &TariScript::default(),
+    );
+    let (pruned_utxo, _, _) = create_utxo(
+        MicroTari(10_000),
+        &factories,
+        Default::default(),
+        &TariScript::default(),
+    );
+    let (stxo, _, _) = create_utxo(
+        MicroTari(10_000),
+        &factories,
+        Default::default(),
+        &TariScript::default(),
+    );
     let utxo_hash = utxo.hash();
     let stxo_hash = stxo.hash();
     let pruned_utxo_hash = pruned_utxo.hash();
@@ -412,7 +447,7 @@ async fn inbound_fetch_blocks_before_horizon_height() {
         outbound_nci,
     );
     let script = script!(Nop);
-    let (utxo, key, offset) = create_utxo(MicroTari(10_000), &factories, None, &script);
+    let (utxo, key, offset) = create_utxo(MicroTari(10_000), &factories, Default::default(), &script);
     let metadata_signature = TransactionOutput::create_final_metadata_signature(
         &MicroTari(10_000),
         &key,
@@ -424,7 +459,7 @@ async fn inbound_fetch_blocks_before_horizon_height() {
     let unblinded_output = UnblindedOutput::new(
         MicroTari(10_000),
         key.clone(),
-        None,
+        Default::default(),
         script,
         inputs!(PublicKey::from_secret_key(&key)),
         key,

--- a/base_layer/core/tests/node_service.rs
+++ b/base_layer/core/tests/node_service.rs
@@ -643,7 +643,7 @@ fn local_get_new_block_template_and_get_new_block() {
         assert_eq!(block.header.height, 1);
         assert_eq!(block.body, block_template.body);
 
-        assert!(node.blockchain_db.add_block(block.clone().into()).is_ok());
+        node.blockchain_db.add_block(block.clone().into()).unwrap();
 
         node.shutdown().await;
     });
@@ -722,7 +722,7 @@ fn local_get_new_block_with_zero_conf() {
         assert_eq!(block.body, block_template.body);
         assert_eq!(block_template.body.kernels().len(), 5);
 
-        assert!(node.blockchain_db.add_block(block.clone().into()).is_ok());
+        node.blockchain_db.add_block(block.clone().into()).unwrap();
 
         node.shutdown().await;
     });
@@ -796,7 +796,7 @@ fn local_get_new_block_with_combined_transaction() {
         assert_eq!(block.body, block_template.body);
         assert_eq!(block_template.body.kernels().len(), 5);
 
-        assert!(node.blockchain_db.add_block(block.clone().into()).is_ok());
+        node.blockchain_db.add_block(block.clone().into()).unwrap();
 
         node.shutdown().await;
     });

--- a/base_layer/wallet/src/output_manager_service/recovery/standard_outputs_recoverer.rs
+++ b/base_layer/wallet/src/output_manager_service/recovery/standard_outputs_recoverer.rs
@@ -90,7 +90,7 @@ where TBackend: OutputManagerBackend + 'static
                     UnblindedOutput::new(
                         output.committed_value,
                         output.blinding_factor.clone(),
-                        Some(features),
+                        features,
                         script,
                         inputs!(PublicKey::from_secret_key(&output.blinding_factor)),
                         output.blinding_factor,

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -442,7 +442,7 @@ where TBackend: OutputManagerBackend + 'static
             UnblindedOutput::new(
                 single_round_sender_data.amount,
                 spending_key.clone(),
-                Some(single_round_sender_data.features.clone()),
+                single_round_sender_data.features.clone(),
                 single_round_sender_data.script.clone(),
                 // TODO: The input data should be variable; this will only work for a Nop script
                 inputs!(PublicKey::from_secret_key(&script_private_key)),
@@ -766,7 +766,7 @@ where TBackend: OutputManagerBackend + 'static
             UnblindedOutput::new(
                 amount,
                 spending_key.clone(),
-                Some(output_features),
+                output_features,
                 script,
                 inputs!(PublicKey::from_secret_key(&script_private_key)),
                 script_private_key,
@@ -1155,7 +1155,7 @@ where TBackend: OutputManagerBackend + 'static
                 UnblindedOutput::new(
                     output_amount,
                     spending_key.clone(),
-                    Some(output_features),
+                    output_features,
                     script,
                     inputs!(PublicKey::from_secret_key(&script_private_key)),
                     script_private_key,
@@ -1237,7 +1237,7 @@ where TBackend: OutputManagerBackend + 'static
                     let rewound_output = UnblindedOutput::new(
                         rewound_result.committed_value,
                         rewound_result.blinding_factor.clone(),
-                        Some(output.features),
+                        output.features,
                         known_one_sided_payment_scripts[i].script.clone(),
                         known_one_sided_payment_scripts[i].input.clone(),
                         known_one_sided_payment_scripts[i].private_key.clone(),

--- a/base_layer/wallet/src/output_manager_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/sqlite_db.rs
@@ -1117,10 +1117,10 @@ impl TryFrom<OutputSql> for DbUnblindedOutput {
                 );
                 OutputManagerStorageError::ConversionError
             })?,
-            Some(OutputFeatures {
+            OutputFeatures {
                 flags: OutputFlags::from_bits(o.flags as u8).ok_or(OutputManagerStorageError::ConversionError)?,
                 maturity: o.maturity as u64,
-            }),
+            },
             TariScript::from_bytes(o.script.as_slice())?,
             ExecutionStack::from_bytes(o.input_data.as_slice())?,
             PrivateKey::from_vec(&o.script_private_key).map_err(|_| {

--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -324,7 +324,7 @@ where
         let unblinded_output = UnblindedOutput::new(
             amount,
             spending_key.clone(),
-            Some(features.clone()),
+            features.clone(),
             script,
             input_data,
             script_private_key.clone(),

--- a/infrastructure/test_utils/src/enums.rs
+++ b/infrastructure/test_utils/src/enums.rs
@@ -58,13 +58,20 @@ macro_rules! unpack_enum {
             v => panic!("Unexpected enum variant '{:?}' given to unpack_enum", v),
         }
     };
-    ($($enum_key:ident)::+ { $($idents:tt),* } = $enum:expr) => {
+    ($($enum_key:ident)::+ { $($idents:ident),+ ,.. } = $enum:expr) => {
         let ($(mut $idents),+) =  match $enum {
-            $($enum_key)::+{$($idents),+} => ($($idents),+),
+            $($enum_key)::+{$($idents),+, .. } => ($($idents),+),
             v => panic!("Unexpected enum variant '{:?}' given to unpack_enum", v),
         };
     };
-    ($($enum_key:ident)::+ ( $($idents:tt),* ) = $enum:expr) => {
+    ($($enum_key:ident)::+ { $($idents:ident),+ } = $enum:expr) => {
+        let ($(mut $idents),+) =  match $enum {
+            $($enum_key)::+{$($idents),+ } => ($($idents),+),
+            v => panic!("Unexpected enum variant '{:?}' given to unpack_enum", v),
+        };
+    };
+
+    ($($enum_key:ident)::+ ( $($idents:ident),* ) = $enum:expr) => {
         let ($(mut $idents),+) =  match $enum {
             $($enum_key)::+($($idents),+) => ($($idents),+),
             v => panic!("Unexpected enum variant '{:?}' given to unpack_enum", v),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Adds a unique commitment db index for the UTXO set as well as unique
commitment check in the block validator.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Prevents the a consensus disagreement between pruned and unpruned nodes by
reusing a commitment.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- New unit test that tests adding a UTXO with the same commitment, but with different maturity to avoid a hash collision.
After that UTXO is spent, the duplicate UTXO is allowed to be included in a block.
- Archival sync 
- Pruned sync
- Sent a number of transactions
- Mined some blocks
- `rewind-blockchain` command

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I have squashed my commits into a single commit.
