### PR TITLE
fix: handle receiver cancelling an inbound transaction that is later received

### DIFF
--- a/applications/tari_app_grpc/proto/wallet.proto
+++ b/applications/tari_app_grpc/proto/wallet.proto
@@ -50,6 +50,8 @@ service Wallet {
     rpc GetNetworkStatus(Empty) returns (NetworkStatusResponse);
     // List currently connected peers
     rpc ListConnectedPeers(Empty) returns (ListConnectedPeersResponse);
+    // Cancel pending transaction
+    rpc CancelTransaction (CancelTransactionRequest) returns (CancelTransactionResponse);
 }
 
 message GetVersionRequest { }
@@ -185,3 +187,11 @@ message ImportUtxosResponse {
     repeated uint64 tx_ids = 1;
 }
 
+message CancelTransactionRequest {
+    uint64 tx_id = 1;
+}
+
+message CancelTransactionResponse {
+    bool is_success = 1;
+    string failure_message = 2;
+}

--- a/applications/tari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/tari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -393,6 +393,33 @@ impl wallet_server::Wallet for WalletGrpcServer {
 
         Ok(Response::new(resp))
     }
+
+    async fn cancel_transaction(
+        &self,
+        request: Request<tari_rpc::CancelTransactionRequest>,
+    ) -> Result<Response<tari_rpc::CancelTransactionResponse>, Status> {
+        let message = request.into_inner();
+        debug!(
+            target: LOG_TARGET,
+            "Incoming gRPC request to Cancel Transaction (TxId: {})", message.tx_id,
+        );
+        let mut transaction_service = self.get_transaction_service();
+
+        match transaction_service.cancel_transaction(message.tx_id).await {
+            Ok(_) => {
+                return Ok(Response::new(tari_rpc::CancelTransactionResponse {
+                    is_success: true,
+                    failure_message: "".to_string(),
+                }))
+            },
+            Err(e) => {
+                return Ok(Response::new(tari_rpc::CancelTransactionResponse {
+                    is_success: false,
+                    failure_message: e.to_string(),
+                }))
+            },
+        }
+    }
 }
 
 fn convert_wallet_transaction_into_transaction_info(

--- a/base_layer/wallet/src/output_manager_service/storage/database.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/database.rs
@@ -23,7 +23,7 @@
 use crate::output_manager_service::{
     error::OutputManagerStorageError,
     service::Balance,
-    storage::models::{DbUnblindedOutput, KnownOneSidedPaymentScript},
+    storage::models::{DbUnblindedOutput, KnownOneSidedPaymentScript, OutputStatus},
     TxId,
 };
 use aes_gcm::Aes256Gcm;
@@ -135,6 +135,7 @@ pub enum DbKey {
     KeyManagerState,
     InvalidOutputs,
     KnownOneSidedPaymentScripts,
+    OutputsByTxIdAndStatus(TxId, OutputStatus),
 }
 
 #[derive(Debug)]
@@ -149,6 +150,7 @@ pub enum DbValue {
     KeyManagerState(KeyManagerState),
     KnownOneSidedPaymentScripts(Vec<KnownOneSidedPaymentScript>),
     AnyOutput(Box<DbUnblindedOutput>),
+    AnyOutputs(Vec<DbUnblindedOutput>),
 }
 
 pub enum DbKeyValuePair {
@@ -158,6 +160,7 @@ pub enum DbKeyValuePair {
     PendingTransactionOutputs(TxId, Box<PendingTransactionOutputs>),
     KeyManagerState(KeyManagerState),
     KnownOneSidedPaymentScripts(KnownOneSidedPaymentScript),
+    UpdateOutputStatus(Commitment, OutputStatus),
 }
 
 pub enum WriteOperation {
@@ -710,6 +713,48 @@ where T: OutputManagerBackend + 'static
         .map_err(|err| OutputManagerStorageError::BlockingTaskSpawnError(err.to_string()))??;
         Ok(())
     }
+
+    /// Check if a single cancelled inbound output exists that matches this TxID, if it does then return its status to
+    /// EncumberedToBeReceived
+    pub async fn reinstate_inbound_output(&self, tx_id: TxId) -> Result<(), OutputManagerStorageError> {
+        let db_clone = self.db.clone();
+        let outputs = tokio::task::spawn_blocking(move || {
+            match db_clone.fetch(&DbKey::OutputsByTxIdAndStatus(tx_id, OutputStatus::CancelledInbound)) {
+                Ok(None) => Err(OutputManagerStorageError::ValueNotFound),
+                Ok(Some(DbValue::AnyOutputs(o))) => Ok(o),
+                Ok(Some(other)) => unexpected_result(
+                    DbKey::OutputsByTxIdAndStatus(tx_id, OutputStatus::CancelledInbound),
+                    other,
+                ),
+                Err(e) => log_error(DbKey::OutputsByTxIdAndStatus(tx_id, OutputStatus::CancelledInbound), e),
+            }
+        })
+        .await
+        .map_err(|err| OutputManagerStorageError::BlockingTaskSpawnError(err.to_string()))
+        .and_then(|inner_result| inner_result)?;
+
+        if outputs.len() != 1 {
+            return Err(OutputManagerStorageError::UnexpectedResult(
+                "There should be only 1 output for a cancelled inbound transaction but more were found".to_string(),
+            ));
+        }
+        let db_clone2 = self.db.clone();
+
+        tokio::task::spawn_blocking(move || {
+            db_clone2.write(WriteOperation::Insert(DbKeyValuePair::UpdateOutputStatus(
+                outputs
+                    .first()
+                    .expect("Must be only one element in outputs")
+                    .commitment
+                    .clone(),
+                OutputStatus::EncumberedToBeReceived,
+            )))
+        })
+        .await
+        .map_err(|err| OutputManagerStorageError::BlockingTaskSpawnError(err.to_string()))??;
+
+        Ok(())
+    }
 }
 
 fn unexpected_result<T>(req: DbKey, res: DbValue) -> Result<T, OutputManagerStorageError> {
@@ -734,6 +779,7 @@ impl Display for DbKey {
             DbKey::TimeLockedUnspentOutputs(_t) => f.write_str(&"Timelocked Outputs"),
             DbKey::KnownOneSidedPaymentScripts => f.write_str(&"Known claiming scripts"),
             DbKey::AnyOutputByCommitment(_) => f.write_str(&"AnyOutputByCommitment"),
+            DbKey::OutputsByTxIdAndStatus(_, _) => f.write_str(&"OutputsByTxIdAndStatus"),
         }
     }
 }
@@ -751,6 +797,7 @@ impl Display for DbValue {
             DbValue::InvalidOutputs(_) => f.write_str("Invalid Outputs"),
             DbValue::KnownOneSidedPaymentScripts(_) => f.write_str(&"Known claiming scripts"),
             DbValue::AnyOutput(_) => f.write_str(&"Any Output"),
+            DbValue::AnyOutputs(_) => f.write_str(&"Any Outputs"),
         }
     }
 }

--- a/base_layer/wallet/src/output_manager_service/storage/models.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/models.rs
@@ -105,3 +105,14 @@ impl PartialEq for KnownOneSidedPaymentScript {
         self.script_hash == other.script_hash
     }
 }
+
+/// The status of a given output
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum OutputStatus {
+    Unspent,
+    Spent,
+    EncumberedToBeReceived,
+    EncumberedToBeSpent,
+    Invalid,
+    CancelledInbound,
+}

--- a/base_layer/wallet/src/output_manager_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/sqlite_db.rs
@@ -33,7 +33,7 @@ use crate::{
                 PendingTransactionOutputs,
                 WriteOperation,
             },
-            models::{DbUnblindedOutput, KnownOneSidedPaymentScript},
+            models::{DbUnblindedOutput, KnownOneSidedPaymentScript, OutputStatus},
         },
         TxId,
     },
@@ -105,6 +105,7 @@ impl OutputManagerSqliteDatabase {
     }
 }
 impl OutputManagerBackend for OutputManagerSqliteDatabase {
+    #[allow(clippy::cognitive_complexity)]
     fn fetch(&self, key: &DbKey) -> Result<Option<DbValue>, OutputManagerStorageError> {
         let conn = self.database_connection.acquire_lock();
 
@@ -135,6 +136,7 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
                     None
                 },
             },
+
             DbKey::AnyOutputByCommitment(commitment) => {
                 match OutputSql::find_by_commitment(&commitment.to_vec(), &(*conn)) {
                     Ok(mut o) => {
@@ -172,6 +174,18 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
                     };
                     None
                 },
+            },
+            DbKey::OutputsByTxIdAndStatus(tx_id, status) => {
+                let mut outputs = OutputSql::find_by_tx_id_and_status(*tx_id, *status, &(*conn))?;
+                for o in outputs.iter_mut() {
+                    self.decrypt_if_necessary(o)?;
+                }
+                Some(DbValue::AnyOutputs(
+                    outputs
+                        .iter()
+                        .map(|o| DbUnblindedOutput::try_from(o.clone()))
+                        .collect::<Result<Vec<_>, _>>()?,
+                ))
             },
             DbKey::UnspentOutputs => {
                 let mut outputs = OutputSql::index_status(OutputStatus::Unspent, &(*conn))?;
@@ -273,6 +287,7 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
         Ok(result)
     }
 
+    #[allow(clippy::cognitive_complexity)]
     fn write(&self, op: WriteOperation) -> Result<Option<DbValue>, OutputManagerStorageError> {
         let conn = self.database_connection.acquire_lock();
 
@@ -336,6 +351,20 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
                     let mut script_sql = KnownOneSidedPaymentScriptSql::from(script);
                     self.encrypt_if_necessary(&mut script_sql)?;
                     script_sql.commit(&(*conn))?
+                },
+                DbKeyValuePair::UpdateOutputStatus(commitment, status) => {
+                    let output = OutputSql::find_by_commitment(&commitment.to_vec(), &(*conn))?;
+                    output.update(
+                        UpdateOutput {
+                            status: Some(status),
+                            tx_id: None,
+                            spending_key: None,
+                            script_private_key: None,
+                            metadata_signature_nonce: None,
+                            metadata_signature_u_key: None,
+                        },
+                        &(*conn),
+                    )?;
                 },
             },
             WriteOperation::Remove(k) => match k {
@@ -409,6 +438,7 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
                 DbKey::InvalidOutputs => return Err(OutputManagerStorageError::OperationNotSupported),
                 DbKey::TimeLockedUnspentOutputs(_) => return Err(OutputManagerStorageError::OperationNotSupported),
                 DbKey::KnownOneSidedPaymentScripts => return Err(OutputManagerStorageError::OperationNotSupported),
+                DbKey::OutputsByTxIdAndStatus(_, _) => return Err(OutputManagerStorageError::OperationNotSupported),
             },
         }
 
@@ -840,17 +870,6 @@ fn pending_transaction_outputs_from_sql_outputs(
     })
 }
 
-/// The status of a given output
-#[derive(PartialEq)]
-enum OutputStatus {
-    Unspent,
-    Spent,
-    EncumberedToBeReceived,
-    EncumberedToBeSpent,
-    Invalid,
-    CancelledInbound,
-}
-
 impl TryFrom<i32> for OutputStatus {
     type Error = OutputManagerStorageError;
 
@@ -1009,6 +1028,17 @@ impl OutputSql {
         };
 
         Ok(request.first::<OutputSql>(conn)?)
+    }
+
+    pub fn find_by_tx_id_and_status(
+        tx_id: TxId,
+        status: OutputStatus,
+        conn: &SqliteConnection,
+    ) -> Result<Vec<OutputSql>, OutputManagerStorageError> {
+        Ok(outputs::table
+            .filter(outputs::tx_id.eq(Some(tx_id as i64)))
+            .filter(outputs::status.eq(status as i32))
+            .load(conn)?)
     }
 
     /// Find outputs via tx_id that are encumbered. Any outputs that are encumbered cannot be marked as spent.

--- a/clients/wallet_grpc_client/index.js
+++ b/clients/wallet_grpc_client/index.js
@@ -39,6 +39,7 @@ function Client(address) {
     "importUtxos",
     "listConnectedPeers",
     "getNetworkStatus",
+    "cancelTransaction",
   ];
 
   this.waitForReady = (...args) => {

--- a/integration_tests/features/Propagation.feature
+++ b/integration_tests/features/Propagation.feature
@@ -81,7 +81,7 @@ Feature: Block Propagation
     When I wait 10 seconds
     And mining node MINER mines 5 blocks
     When I wait 100 seconds
-    When I start LAG1
+    When I start base node LAG1
         # Wait for node to so start and get into listening mode
     When I wait 100 seconds
     Then node MINER is at height 6

--- a/integration_tests/features/Reorgs.feature
+++ b/integration_tests/features/Reorgs.feature
@@ -57,10 +57,10 @@ Feature: Reorgs
     When mining node MINING1 mines 3 blocks with min difficulty 1 and max difficulty 20
     And node NODE1 is at height 17
     And I stop node NODE1
-    And I start PNODE2
+    And I start base node PNODE2
     When mining node MINING2 mines 6 blocks with min difficulty 20 and max difficulty 1000000
     And node PNODE2 is at height 20
-    When I start NODE1
+    When I start base node NODE1
     Then all nodes are at height 20
 
   @critical @reorg
@@ -77,7 +77,7 @@ Feature: Reorgs
     And mining node MINING2 mines 19 blocks with min difficulty 20 and max difficulty 1000000
     And node NODE2 is at height 20
     And I stop node NODE2
-    When I start NODE1
+    When I start base node NODE1
     And mining node MINING1 mines 3 blocks with min difficulty 1 and max difficulty 20
     And node NODE1 is at height 4
     When I create a transaction TX1 spending CB1 to UTX1
@@ -87,7 +87,7 @@ Feature: Reorgs
     And node NODE1 is at height 10
     Given I have a pruned node PNODE1 connected to node NODE1 with pruning horizon set to 5
     Then node PNODE1 is at height 10
-    When I start NODE2
+    When I start base node NODE2
     Then all nodes are at height 20
         # Because TX1 should have been re_orged out we should be able to spend CB1 again
     When I create a transaction TX2 spending CB1 to UTX2

--- a/integration_tests/features/Sync.feature
+++ b/integration_tests/features/Sync.feature
@@ -59,10 +59,10 @@ Feature: Block Sync
     And mining node MINER1 mines 5 blocks with min difficulty 1 and max difficulty 1
     Then node NODE1 is at height 10
     Given I stop node NODE1
-    And I start NODE2
+    And I start base node NODE2
     And mining node MINER2 mines 7 blocks with min difficulty 11 and max difficulty 100000
     Then node NODE2 is at height 12
-    When I start NODE1
+    When I start base node NODE1
     Then all nodes are on the same chain at height 12
 
   @critical @reorg @long-running
@@ -79,10 +79,10 @@ Feature: Block Sync
     And mining node MINER1 mines 1001 blocks with min difficulty 1 and max difficulty 10
     Then node NODE1 is at height 1006
     Given I stop node NODE1
-    And I start NODE2
+    And I start base node NODE2
     And mining node MINER2 mines 1500 blocks with min difficulty 11 and max difficulty 100000
     Then node NODE2 is at height 1505
-    When I start NODE1
+    When I start base node NODE1
     Then all nodes are on the same chain at height 1505
 
   @critical
@@ -114,7 +114,7 @@ Feature: Block Sync
     When I mine 5 blocks on NODE2
     Then node NODE2 is at height 5
     Then node PNODE2 is at height 40
-    When I start NODE1
+    When I start base node NODE1
     # We need for node to boot up and supply node 2 with blocks
     And I connect node NODE2 to node NODE1 and wait 60 seconds
     Then all nodes are at height 40
@@ -129,7 +129,7 @@ Feature: Block Sync
     And I stop node SYNCER
     When mining node MINER mines <X1> blocks with min difficulty 1 and max difficulty 9999999999
     Then node SEED is at height <X1>
-    When I start SYNCER
+    When I start base node SYNCER
     # Try to mine much faster than block sync, but still producing a lower accumulated difficulty
     And mining node MINER2 mines <Y1> blocks with min difficulty 1 and max difficulty 10
     # Allow reorg to filter through

--- a/integration_tests/features/support/world.js
+++ b/integration_tests/features/support/world.js
@@ -90,8 +90,13 @@ class CustomWorld {
     this.proxies[name] = process;
   }
 
-  async createAndAddWallet(name, nodeAddresses) {
-    const wallet = new WalletProcess(name, false, {}, this.logFilePathWallet);
+  async createAndAddWallet(name, nodeAddresses, options = {}) {
+    const wallet = new WalletProcess(
+      name,
+      false,
+      options,
+      this.logFilePathWallet
+    );
     wallet.setPeerSeeds([nodeAddresses]);
     await wallet.startNew();
 
@@ -109,6 +114,10 @@ class CustomWorld {
 
   addWallet(name, process) {
     this.wallets[name] = process;
+  }
+
+  addWalletPubkey(name, pubkey) {
+    this.walletPubkeys[name] = pubkey;
   }
 
   addOutput(name, output) {

--- a/integration_tests/helpers/walletClient.js
+++ b/integration_tests/helpers/walletClient.js
@@ -222,6 +222,25 @@ class WalletClient {
     }
   }
 
+  async isTransactionPending(tx_id) {
+    try {
+      const txnDetails = await this.getTransactionInfo({
+        transaction_ids: [tx_id.toString()],
+      });
+      if (
+        transactionStatus().indexOf(txnDetails.transactions[0].status) == 2 &&
+        txnDetails.transactions[0].valid
+      ) {
+        return true;
+      } else {
+        return false;
+      }
+    } catch (err) {
+      // Any error here must be treated as if the required status was not achieved
+      return false;
+    }
+  }
+
   async isTransactionAtLeastCompleted(tx_id) {
     try {
       const txnDetails = await this.getTransactionInfo({
@@ -351,6 +370,22 @@ class WalletClient {
       ...resp,
       num_node_connections: +resp.num_node_connections,
     };
+  }
+  async cancelTransaction(tx_id) {
+    try {
+      const result = await this.client.cancelTransaction({
+        tx_id: tx_id,
+      });
+      return {
+        success: result.is_success,
+        failure_message: result.failure_message,
+      };
+    } catch (err) {
+      return {
+        success: false,
+        failure_message: err,
+      };
+    }
   }
 }
 


### PR DESCRIPTION
## Description
This PR addresses the following scenario spotted by @sdbondi :

- NodeA sends to nodeB(offline) 
- NodeA goes offline 
- NodeB receives tx, and cancels it (weird I know) 
- NodeA comes online and broadcasts the transaction 
- NodeB is not aware of the transaction, transaction complete for NodeA

This is handled by adding logic that if a FinalizedTransaction is received with no active Receive Protocols that the database is checked if there is a matching cancelled inbound transaction from the same pubkey. If there is the receiver might as well restart that protocol and accept the finalized transaction.

This required adding in functionality to the Transaction and Output Manager services to reinstate a cancelled inbound transaction

## How Has This Been Tested?
A cucumber test is provided to test this case.

Unit tests provided for new functionality in the Output Manager and Transaction Services

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I have squashed my commits into a single commit.
