### PR TITLE
test: fix flaky unit test sending_transaction_and_confirmation

### DIFF
--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -1007,7 +1007,7 @@ where TBackend: OutputManagerBackend + 'static
                 break;
             }
             fee_with_change = Fee::calculate(fee_per_gram, 1, utxos.len(), output_count + 1);
-            if utxos_total_value >= amount + fee_with_change {
+            if utxos_total_value > amount + fee_with_change {
                 require_change_output = true;
                 break;
             }

--- a/base_layer/wallet/tests/output_manager_service/service.rs
+++ b/base_layer/wallet/tests/output_manager_service/service.rs
@@ -626,7 +626,12 @@ fn sending_transaction_and_confirmation() {
     );
 
     if let DbValue::KeyManagerState(km) = backend.fetch(&DbKey::KeyManagerState).unwrap().unwrap() {
-        assert_eq!(km.primary_key_index, 1);
+        // if we dont have change, we did not move the index forward
+        if tx.body.outputs().len() > 1 {
+            assert_eq!(km.primary_key_index, 1);
+        } else {
+            assert_eq!(km.primary_key_index, 0);
+        }
     } else {
         panic!("No Key Manager set");
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The unit test had 2 edge cases:

1. When the transaction had no change, the master_key index should be 0 and not 1. 
2. Inside of the builder we had an edge case of one check being `>=` while the next check being `>` which resulted in the tx builder thinking it did not have enough funds

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I have squashed my commits into a single commit.
