### PR TITLE
test: fix wallet CLI cucumber tests (child process exited with code 107)

### DIFF
--- a/base_layer/wallet/src/output_manager_service/storage/database.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/database.rs
@@ -700,10 +700,7 @@ where T: OutputManagerBackend + 'static
         let db_clone = self.db.clone();
         tokio::task::spawn_blocking(move || {
             match db_clone.write(WriteOperation::Remove(DbKey::AnyOutputByCommitment(commitment.clone()))) {
-                Ok(None) => log_error(
-                    DbKey::AnyOutputByCommitment(commitment.clone()),
-                    OutputManagerStorageError::ValueNotFound,
-                ),
+                Ok(None) => Ok(()),
                 Ok(Some(DbValue::AnyOutput(_))) => Ok(()),
                 Ok(Some(other)) => unexpected_result(DbKey::AnyOutputByCommitment(commitment.clone()), other),
                 Err(e) => log_error(DbKey::AnyOutputByCommitment(commitment), e),

--- a/base_layer/wallet/src/utxo_scanner_service/mod.rs
+++ b/base_layer/wallet/src/utxo_scanner_service/mod.rs
@@ -105,7 +105,7 @@ where T: WalletBackend + 'static
 
             let scanning_service = UtxoScannerService::<T>::builder()
                 .with_peers(vec![])
-                .with_retry_limit(10)
+                .with_retry_limit(2)
                 .with_scanning_interval(interval)
                 .with_mode(UtxoScannerMode::Scanning)
                 .build_with_resources(

--- a/base_layer/wallet/src/utxo_scanner_service/utxo_scanning.rs
+++ b/base_layer/wallet/src/utxo_scanner_service/utxo_scanning.rs
@@ -307,6 +307,11 @@ where TBackend: WalletBackend + 'static
             }
 
             let num_scanned = self.scan_utxos(&mut client, start_index, tip_header).await?;
+            if num_scanned == 0 {
+                return Err(UtxoScannerError::UtxoScanningError(
+                    "Peer returned 0 UTXOs to scan".to_string(),
+                ));
+            }
             debug!(
                 target: LOG_TARGET,
                 "Scanning round completed UTXO #{} in {:.2?} ({} scanned)",
@@ -679,7 +684,7 @@ where TBackend: WalletBackend + 'static
             event_sender: self.event_sender.clone(),
             retry_limit: self.retry_limit,
             peer_index: 0,
-            num_retries: 0,
+            num_retries: 1,
             mode: self.mode.clone(),
             run_flag: self.is_running.clone(),
         }

--- a/integration_tests/features/WalletCli.feature
+++ b/integration_tests/features/WalletCli.feature
@@ -4,19 +4,19 @@ Feature: Wallet CLI
         Given I have a base node NODE1 connected to all seed nodes
         And I have a base node NODE2 connected to all seed nodes
         And I have wallet WALLET connected to base node NODE1
-        Then I change base node of WALLET to NODE2
+        Then I change base node of WALLET to NODE2 via command line
 
     Scenario: As a user I want to set and clear custom base node for a wallet via command line
         Given I have a base node NODE1
         And I have a base node NODE2
         And I have wallet WALLET connected to base node NODE1
-        Then I set custom base node of WALLET to NODE2
-        And I clear custom base node of wallet WALLET
+        Then I set custom base node of WALLET to NODE2 via command line
+        And I clear custom base node of wallet WALLET via command line
 
     Scenario: As a user I want to change password via command line
         Given I have wallet WALLET connected to all seed nodes
         When I stop wallet WALLET
-        And I change the password of wallet WALLET to changedpwd
+        And I change the password of wallet WALLET to changedpwd via command line
         Then the password of wallet WALLET is not kensentme
         Then the password of wallet WALLET is changedpwd
 
@@ -27,62 +27,78 @@ Feature: Wallet CLI
         And mining node MINE mines 5 blocks
         Then I wait for wallet WALLET to have at least 1000000 uT
         And I stop wallet WALLET
-        Then I get balance via command line of wallet WALLET is at least 1000000 uT
+        Then I get balance of wallet WALLET is at least 1000000 uT via command line
 
     Scenario: As a user I want to send tari via command line
-        Given I have a base node BASE
+        Given I have a seed node SEED
+        And I have a base node BASE connected to seed SEED
         And I have wallet SENDER connected to base node BASE
         And I have wallet RECEIVER connected to base node BASE
         And I have mining node MINE connected to base node BASE and wallet SENDER
         And mining node MINE mines 5 blocks
-        Then I wait for wallet SENDER to have at least 1000000 uT
-        And I wait 5 seconds
+        Then I wait for wallet SENDER to have at least 1100000 uT
+        # TODO: Remove this wait when the wallet CLI commands involving transactions will only commence with a valid
+        # TODO: base node connection.
+        And I wait 30 seconds
         And I stop wallet SENDER
         And I send 1000000 uT from SENDER to RECEIVER via command line
+        Then wallet SENDER has at least 1 transactions that are all TRANSACTION_STATUS_BROADCAST and valid
+        Then wallet RECEIVER has at least 1 transactions that are all TRANSACTION_STATUS_BROADCAST and valid
         And mining node MINE mines 5 blocks
         Then I wait for wallet RECEIVER to have at least 1000000 uT
 
     Scenario: As a user I want to send one-sided via command line
-        Given I have a base node BASE
+        Given I have a seed node SEED
+        And I have a base node BASE connected to seed SEED
         And I have wallet SENDER connected to base node BASE
         And I have wallet RECEIVER connected to base node BASE
         And I have mining node MINE connected to base node BASE and wallet SENDER
         And mining node MINE mines 5 blocks
-        Then I wait for wallet SENDER to have at least 1000000 uT
-        And I wait 5 seconds
+        Then I wait for wallet SENDER to have at least 1100000 uT
+        # TODO: Remove this wait when the wallet CLI commands involving transactions will only commence with a valid
+        # TODO: base node connection.
+        And I wait 30 seconds
         And I stop wallet SENDER
         And I send one-sided 1000000 uT from SENDER to RECEIVER via command line
+        Then wallet SENDER has at least 1 transactions that are all TRANSACTION_STATUS_BROADCAST and valid
         And mining node MINE mines 5 blocks
         Then I wait for wallet RECEIVER to have at least 1000000 uT
 
     Scenario: As a user I want to make-it-rain via command line
-        Given I have a base node BASE
+        Given I have a seed node SEED
+        And I have a base node BASE connected to seed SEED
         And I have wallet SENDER connected to base node BASE
         And I have wallet RECEIVER connected to base node BASE
         And I have mining node MINE connected to base node BASE and wallet SENDER
         And mining node MINE mines 15 blocks
-        Then I wait for wallet SENDER to have at least 1000000 uT
-        And I wait 5 seconds
+        Then wallets SENDER should have 12 spendable coinbase outputs
+        # TODO: Remove this wait when the wallet CLI commands involving transactions will only commence with a valid
+        # TODO: base node connection.
+        And I wait 30 seconds
         And I stop wallet SENDER
-        And I make it rain from wallet SENDER 1 tx / sec 10 sec 8000 uT 100 increment to RECEIVER
-        And I wait 15 seconds
+        And I make it rain from wallet SENDER 1 tx / sec 10 sec 8000 uT 100 increment to RECEIVER via command line
+        Then wallet SENDER has at least 10 transactions that are all TRANSACTION_STATUS_BROADCAST and valid
+        Then wallet RECEIVER has at least 10 transactions that are all TRANSACTION_STATUS_BROADCAST and valid
         And mining node MINE mines 5 blocks
         Then I wait for wallet RECEIVER to have at least 84500 uT
 
     Scenario: As a user I want to coin-split via command line
-        Given I have a base node BASE
+        Given I have a seed node SEED
+        And I have a base node BASE connected to seed SEED
         And I have wallet WALLET connected to base node BASE
         And I have mining node MINE connected to base node BASE and wallet WALLET
         And mining node MINE mines 4 blocks
-        Then I wait for wallet WALLET to have at least 1000000 uT
-        And I wait 5 seconds
+        Then I wait for wallet WALLET to have at least 1100000 uT
+        # TODO: Remove this wait when the wallet CLI commands involving transactions will only commence with a valid
+        # TODO: base node connection.
+        And I wait 30 seconds
         And I stop wallet WALLET
-        And I do coin split on wallet WALLET to 10000 uT 10 coins
-        And I wait 5 seconds
+        And I do coin split on wallet WALLET to 10000 uT 10 coins via command line
+        Then wallet WALLET has at least 1 transactions that are all TRANSACTION_STATUS_BROADCAST and valid
         And mining node MINE mines 5 blocks
-        And I wait 5 seconds
+        Then wallet WALLET has at least 1 transactions that are all TRANSACTION_STATUS_MINED_CONFIRMED and valid
         And I stop wallet WALLET
-        Then I get count of utxos of wallet WALLET via command line and it's at least 10
+        Then I get count of utxos of wallet WALLET and it's at least 10 via command line
 
     Scenario: As a user I want to count utxos via command line
         Given I have a base node BASE
@@ -91,7 +107,7 @@ Feature: Wallet CLI
         And mining node MINE mines 4 blocks
         Then I wait for wallet WALLET to have at least 1000000 uT
         And I stop wallet WALLET
-        Then I get count of utxos of wallet WALLET via command line and it's at least 1
+        Then I get count of utxos of wallet WALLET and it's at least 1 via command line
 
     Scenario: As a user I want to export utxos via command line
         Given I have a base node BASE
@@ -112,4 +128,4 @@ Feature: Wallet CLI
     Scenario: As a user I want to run whois via command line
         Given I have a base node BASE
         And I have wallet WALLET connected to base node BASE
-        Then I run whois BASE on wallet WALLET
+        Then I run whois BASE on wallet WALLET via command line

--- a/integration_tests/helpers/util.js
+++ b/integration_tests/helpers/util.js
@@ -99,7 +99,7 @@ async function waitFor(
     } catch (e) {
       if (i > 1) {
         if (e && e.code && e.code === NO_CONNECTION) {
-          console.log("No connection yet (waitFor)...");
+          //console.log("No connection yet (waitFor)...");
         } else {
           console.error("Error in waitFor: ", e);
         }

--- a/integration_tests/helpers/walletClient.js
+++ b/integration_tests/helpers/walletClient.js
@@ -125,7 +125,7 @@ class WalletClient {
   }
 
   async getAllNormalTransactions() {
-    const data = this.getCompletedTransactions();
+    const data = await this.getCompletedTransactions();
     const transactions = [];
     for (let i = 0; i < data.length; i++) {
       if (

--- a/integration_tests/package-lock.json
+++ b/integration_tests/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "integration_tests",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
1. When using the wallet CLI mode in cucumber integration tests, the wallet is not always in the correct state to send transactions, depending on the last known metadata status from the previously connected base node. This PR introduces exception handling for wallet CLI commands so that it will automatically retry to execute the command if it fails. _A follow-up PR should let the wallet wait for a base node connection before it executes certain commands._
2. Added a new test step to explicitly test transaction statuses in the wallet.
3. Fixed the UTXO scanning service so it would not go into an infinite loop trying to scan UTXOs if the blockchain does not have any UTXOs yet.
4. Fixed an erroneous error return in the output manager service.

## Motivation and Context
Cucumber tests involving wallet CLI commands were failing.

## How Has This Been Tested?
Wallet CLI cucumber tests.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I have squashed my commits into a single commit.
