### PR TITLE
feat(mining_node): mining worker name for tari_mining_node

### DIFF
--- a/applications/tari_mining_node/src/config.rs
+++ b/applications/tari_mining_node/src/config.rs
@@ -51,6 +51,7 @@ pub struct MinerConfig {
     pub validate_tip_timeout_sec: u64,
     pub mining_pool_address: String,
     pub mining_wallet_address: String,
+    pub mining_worker_name: String,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -75,6 +76,7 @@ impl Default for MinerConfig {
             validate_tip_timeout_sec: 30,
             mining_pool_address: "".to_string(),
             mining_wallet_address: "".to_string(),
+            mining_worker_name: "".to_string(),
         }
     }
 }

--- a/applications/tari_mining_node/src/main.rs
+++ b/applications/tari_mining_node/src/main.rs
@@ -73,12 +73,16 @@ async fn main_inner() -> Result<(), ExitCodes> {
     config.mine_on_tip_only = global.mine_on_tip_only;
     config.num_mining_threads = global.num_mining_threads;
     config.validate_tip_timeout_sec = global.validate_tip_timeout_sec;
+    config.mining_worker_name = global.mining_worker_name.clone();
     debug!("{:?}", bootstrap);
     debug!("{:?}", config);
 
     if !config.mining_wallet_address.is_empty() && !config.mining_pool_address.is_empty() {
         let url = config.mining_pool_address.clone();
-        let miner_address = config.mining_wallet_address.clone();
+        let mut miner_address = config.mining_wallet_address.clone();
+        if !config.mining_worker_name.is_empty() {
+            miner_address += &format!("{}{}", ".", &config.mining_worker_name);
+        }
         let mut mc = Controller::new().unwrap_or_else(|e| {
             panic!("Error loading mining controller: {}", e);
         });

--- a/applications/tari_mining_node/src/stratum/controller.rs
+++ b/applications/tari_mining_node/src/stratum/controller.rs
@@ -297,7 +297,7 @@ impl Controller {
                         self.stream = None;
                     } else {
                         let status = format!("Connection Status: Connected to server at {}.", self.server_url);
-                        warn!("{}", status);
+                        info!("{}", status);
                     }
                     next_server_retry = time::get_time().sec + server_retry_interval;
                     if self.stream.is_none() {

--- a/common/config/presets/tari_config_example.toml
+++ b/common/config/presets/tari_config_example.toml
@@ -523,3 +523,4 @@ transcoder_host_address = "127.0.0.1:7879"
 # Stratum Mode configuration
 # mining_pool_address = "miningcore.tarilabs.com:3052"
 # mining_wallet_address = "YOUR_WALLET_PUBLIC_KEY"
+# mining_worker_name = "worker1"

--- a/common/src/configuration/global.rs
+++ b/common/src/configuration/global.rs
@@ -133,6 +133,7 @@ pub struct GlobalConfig {
     pub validate_tip_timeout_sec: u64,
     pub mining_pool_address: String,
     pub mining_wallet_address: String,
+    pub mining_worker_name: String,
 }
 
 impl GlobalConfig {
@@ -674,6 +675,13 @@ fn convert_node_config(
     let mining_pool_address = cfg.get_str(&key).unwrap_or_else(|_| "".to_string());
     let key = "mining_node.mining_wallet_address";
     let mining_wallet_address = cfg.get_str(&key).unwrap_or_else(|_| "".to_string());
+    let key = "mining_node.mining_worker_name";
+    let mining_worker_name = cfg
+        .get_str(&key)
+        .unwrap_or_else(|_| "".to_string())
+        .chars()
+        .filter(|c| c.is_alphanumeric())
+        .collect::<String>();
 
     Ok(GlobalConfig {
         autoupdate_check_interval,
@@ -757,6 +765,7 @@ fn convert_node_config(
         validate_tip_timeout_sec,
         mining_pool_address,
         mining_wallet_address,
+        mining_worker_name,
     })
 }
 


### PR DESCRIPTION
## Description
Adds optional field to config for tari_mining_node to allow the miner to be named when using the stratum configuration.

Updated successful server connection status from warn to info.

## Motivation and Context


## How Has This Been Tested?
Manually

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I have squashed my commits into a single commit.
