### PR TITLE
fix: ensure peers are added to peer list before recovery starts

### DIFF
--- a/applications/tari_app_utilities/src/utilities.rs
+++ b/applications/tari_app_utilities/src/utilities.rs
@@ -26,7 +26,7 @@ use log::*;
 use tari_common::{CommsTransport, GlobalConfig, SocksAuthentication, TorControlAuthentication};
 use tari_comms::{
     connectivity::ConnectivityError,
-    peer_manager::NodeId,
+    peer_manager::{NodeId, PeerManagerError},
     protocol::rpc::RpcError,
     socks,
     tor,
@@ -143,6 +143,12 @@ impl From<WalletStorageError> for ExitCodes {
             IncorrectPassword => ExitCodes::IncorrectPassword,
             e => ExitCodes::WalletError(e.to_string()),
         }
+    }
+}
+
+impl From<PeerManagerError> for ExitCodes {
+    fn from(err: PeerManagerError) -> Self {
+        ExitCodes::NetworkError(err.to_string())
     }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds peers before recovery starts

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Recovery tests fails `. Base node connection error to 6ff2c71b55a9c808480a0344d1 (retries 0 of 10: ConnectionFailed: Peer manager error: The requested peer does not exist)`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Successful recovery test

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I have squashed my commits into a single commit.
