### PR TITLE
fix: fix console wallet buffer size bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5000,7 +5000,7 @@ dependencies = [
 
 [[package]]
 name = "tari_wallet_ffi"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "chrono",
  "env_logger 0.7.1",

--- a/applications/tari_console_wallet/src/init/mod.rs
+++ b/applications/tari_console_wallet/src/init/mod.rs
@@ -352,7 +352,7 @@ pub async fn init_wallet(
     );
 
     let factories = CryptoFactories::default();
-    let mut wallet_config = WalletConfig::new(
+    let wallet_config = WalletConfig::new(
         comms_config.clone(),
         factories,
         Some(TransactionServiceConfig {
@@ -376,11 +376,13 @@ pub async fn init_wallet(
         }),
         config.network.into(),
         Some(base_node_service_config),
-        Some(config.buffer_size_console_wallet),
+        Some(std::cmp::max(
+            BASE_NODE_BUFFER_MIN_SIZE,
+            config.buffer_size_console_wallet,
+        )),
         Some(config.buffer_rate_limit_console_wallet),
         Some(config.scan_for_utxo_interval),
     );
-    wallet_config.buffer_size = std::cmp::max(BASE_NODE_BUFFER_MIN_SIZE, config.buffer_size_base_node);
 
     let mut wallet = Wallet::start(
         wallet_config,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixed a bug where the wrong configuration parameter was assigned to the console wallet buffer size.

## Motivation and Context
See above

## How Has This Been Tested?
System-level test

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I have squashed my commits into a single commit.
