### PR TITLE
test: change RPC connection issues log status

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5000,7 +5000,7 @@ dependencies = [
 
 [[package]]
 name = "tari_wallet_ffi"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "chrono",
  "env_logger 0.7.1",

--- a/base_layer/wallet/src/base_node_service/monitor.rs
+++ b/base_layer/wallet/src/base_node_service/monitor.rs
@@ -77,7 +77,7 @@ impl<T: WalletBackend + 'static> BaseNodeMonitor<T> {
                     break;
                 },
                 Err(e @ BaseNodeMonitorError::RpcFailed(_)) => {
-                    debug!(target: LOG_TARGET, "Connectivity failure to base node: {}", e);
+                    warn!(target: LOG_TARGET, "Connectivity failure to base node: {}", e);
                     debug!(target: LOG_TARGET, "Setting as OFFLINE and retrying...",);
 
                     self.set_offline().await;

--- a/comms/src/protocol/rpc/handshake.rs
+++ b/comms/src/protocol/rpc/handshake.rs
@@ -101,7 +101,7 @@ where T: AsyncRead + AsyncWrite + Unpin
     }
 
     pub async fn reject_with_reason(&mut self, reject_reason: HandshakeRejectReason) -> Result<(), RpcHandshakeError> {
-        debug!(target: LOG_TARGET, "Rejecting handshake because {}", reject_reason);
+        warn!(target: LOG_TARGET, "Rejecting handshake because {}", reject_reason);
         let reply = proto::rpc::RpcSessionReply {
             session_result: Some(proto::rpc::rpc_session_reply::SessionResult::Rejected(true)),
             reject_reason: reject_reason.as_i32(),
@@ -120,7 +120,7 @@ where T: AsyncRead + AsyncWrite + Unpin
         // anything. Rather than returning an IO error, let's ignore the send error and see if we can receive anything,
         // or return an IO error similarly to what send would have done.
         if let Err(err) = self.framed.send(msg.to_encoded_bytes().into()).await {
-            debug!(
+            warn!(
                 target: LOG_TARGET,
                 "IO error when sending new session handshake to peer: {}", err
             );


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Not all pertinent RPC connection issues were logged as warnings or errors. This PR changed some `debug` log messages to `warning`.

## Motivation and Context
See above.

## How Has This Been Tested?
NIT - not tested locally.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I have squashed my commits into a single commit.
