### PR TITLE
Expose `get_mempool_stats` via gRPC and add cucumber test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4329,7 +4329,7 @@ dependencies = [
 
 [[package]]
 name = "tari_app_grpc"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "chrono",
  "prost",
@@ -4345,7 +4345,7 @@ dependencies = [
 
 [[package]]
 name = "tari_app_utilities"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "config",
  "dirs-next",
@@ -4370,7 +4370,7 @@ dependencies = [
 
 [[package]]
 name = "tari_base_node"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4423,7 +4423,7 @@ dependencies = [
 
 [[package]]
 name = "tari_common"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "config",
@@ -4447,7 +4447,7 @@ dependencies = [
 
 [[package]]
 name = "tari_common_types"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "futures 0.3.15",
  "rand 0.8.4",
@@ -4458,7 +4458,7 @@ dependencies = [
 
 [[package]]
 name = "tari_comms"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4502,7 +4502,7 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_dht"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "bitflags 1.2.1",
@@ -4549,7 +4549,7 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_rpc_macros"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "futures 0.3.15",
  "proc-macro2 1.0.27",
@@ -4565,7 +4565,7 @@ dependencies = [
 
 [[package]]
 name = "tari_console_wallet"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "bitflags 1.2.1",
  "chrono",
@@ -4600,7 +4600,7 @@ dependencies = [
 
 [[package]]
 name = "tari_core"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "bincode",
  "bitflags 1.2.1",
@@ -4675,7 +4675,7 @@ dependencies = [
 
 [[package]]
 name = "tari_infra_derive"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "blake2",
  "proc-macro2 0.4.30",
@@ -4685,7 +4685,7 @@ dependencies = [
 
 [[package]]
 name = "tari_key_manager"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "digest",
  "rand 0.8.4",
@@ -4699,7 +4699,7 @@ dependencies = [
 
 [[package]]
 name = "tari_merge_mining_proxy"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4737,7 +4737,7 @@ dependencies = [
 
 [[package]]
 name = "tari_mining_node"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "bufstream",
  "chrono",
@@ -4767,7 +4767,7 @@ dependencies = [
 
 [[package]]
 name = "tari_mmr"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "bincode",
  "blake2",
@@ -4786,7 +4786,7 @@ dependencies = [
 
 [[package]]
 name = "tari_p2p"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "bytes 0.5.6",
@@ -4828,7 +4828,7 @@ dependencies = [
 
 [[package]]
 name = "tari_service_framework"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4846,7 +4846,7 @@ dependencies = [
 
 [[package]]
 name = "tari_shutdown"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "futures 0.3.15",
  "tokio 0.2.25",
@@ -4854,7 +4854,7 @@ dependencies = [
 
 [[package]]
 name = "tari_storage"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "bincode",
  "bytes 0.4.12",
@@ -4926,7 +4926,7 @@ dependencies = [
 
 [[package]]
 name = "tari_test_utils"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "futures 0.3.15",
  "futures-test",
@@ -4957,7 +4957,7 @@ dependencies = [
 
 [[package]]
 name = "tari_wallet"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "aes-gcm 0.8.0",
  "bincode",
@@ -5051,7 +5051,7 @@ dependencies = [
 
 [[package]]
 name = "test_faucet"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "rand 0.8.4",
  "serde 1.0.126",

--- a/applications/tari_app_grpc/proto/base_node.proto
+++ b/applications/tari_app_grpc/proto/base_node.proto
@@ -80,6 +80,8 @@ service BaseNode {
     rpc GetNetworkStatus(Empty) returns (NetworkStatusResponse);
     // List currently connected peers
     rpc ListConnectedPeers(Empty) returns (ListConnectedPeersResponse);
+    // Get mempool stats
+    rpc GetMempoolStats(Empty) returns (MempoolStatsResponse);
 }
 
 message SubmitBlockResponse {
@@ -336,4 +338,11 @@ message SoftwareUpdate {
     string version = 2;
     string sha = 3;
     string download_url = 4;
+}
+
+message MempoolStatsResponse {
+    uint64 total_txs = 1;
+    uint64 unconfirmed_txs = 2;
+    uint64 reorg_txs = 3;
+    uint64 total_weight = 4;
 }

--- a/applications/tari_base_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/tari_base_node/src/grpc/base_node_grpc_server.rs
@@ -1120,6 +1120,27 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
 
         Ok(Response::new(resp))
     }
+
+    async fn get_mempool_stats(
+        &self,
+        _: Request<tari_rpc::Empty>,
+    ) -> Result<Response<tari_rpc::MempoolStatsResponse>, Status> {
+        let mut mempool_handle = self.mempool_service.clone();
+
+        let mempool_stats = mempool_handle.get_mempool_stats().await.map_err(|e| {
+            error!(target: LOG_TARGET, "Error submitting query:{}", e);
+            Status::internal(e.to_string())
+        })?;
+
+        let response = tari_rpc::MempoolStatsResponse {
+            total_txs: mempool_stats.total_txs as u64,
+            unconfirmed_txs: mempool_stats.unconfirmed_txs as u64,
+            reorg_txs: mempool_stats.reorg_txs as u64,
+            total_weight: mempool_stats.total_weight,
+        };
+
+        Ok(Response::new(response))
+    }
 }
 
 enum BlockGroupType {

--- a/integration_tests/features/Mempool.feature
+++ b/integration_tests/features/Mempool.feature
@@ -169,3 +169,21 @@ Feature: Mempool
     Then SENDER has TX11 in MINED state
     Then SENDER has TX12 in MINED state
     Then SENDER has TX13 in MINED state
+
+    @critical
+    Scenario: Mempool unconfirmed transactions
+      Given I have 1 seed nodes
+      And I have a base node BN1 connected to all seed nodes
+      When I mine a block on BN1 with coinbase CB1
+      When I mine 5 blocks on BN1
+      When I create a custom fee transaction TX1 spending CB1 to UTX1 with fee 80
+      When I create a custom fee transaction TX2 spending CB1 to UTX1 with fee 80
+      When I create a custom fee transaction TX3 spending CB1 to UTX1 with fee 80
+      When I create a custom fee transaction TX4 spending CB1 to UTX1 with fee 80
+      When I create a custom fee transaction TX5 spending CB1 to UTX1 with fee 80
+      When I submit transaction TX1 to BN1
+      When I submit transaction TX2 to BN1
+      When I submit transaction TX3 to BN1
+      When I submit transaction TX4 to BN1
+      When I submit transaction TX5 to BN1
+      Then I wait until base node BN1 has 5 unconfirmed transactions in its mempool

--- a/integration_tests/features/support/steps.js
+++ b/integration_tests/features/support/steps.js
@@ -3306,3 +3306,29 @@ Then("I want to get emoji id of ffi wallet {word}", function (name) {
     `Emoji id has wrong length : ${emoji_id}`
   );
 });
+
+Then(
+  /I wait until base node (.*) has (.*) unconfirmed transactions in its mempool/,
+  { timeout: 180 * 1000 },
+  async function (baseNode, numTransactions) {
+    const client = this.getClient(baseNode);
+    await waitFor(
+      async () => {
+        let stats = await client.getMempoolStats();
+        return stats.unconfirmed_txs;
+      },
+      numTransactions,
+      120 * 1000
+    );
+
+    let stats = await client.getMempoolStats();
+    console.log(
+      "Base node",
+      baseNode,
+      "has ",
+      stats.unconfirmed_txs,
+      " unconfirmed transaction in its mempool"
+    );
+    expect(stats.unconfirmed_txs).to.equal(numTransactions);
+  }
+);

--- a/integration_tests/helpers/baseNodeClient.js
+++ b/integration_tests/helpers/baseNodeClient.js
@@ -433,6 +433,11 @@ class BaseNodeClient {
     await client.connect(port);
     return client;
   }
+
+  async getMempoolStats() {
+    const mempoolStats = await this.client.getMempoolStats().sendMessage({});
+    return mempoolStats;
+  }
 }
 
 module.exports = BaseNodeClient;


### PR DESCRIPTION
## Description
This PR exposes the `get_mempool_stats` method via the base node gRPC interface. It also adds a cucumber test to add 5 transactions to the mempool and tests that the base node reports the correct stats.

## How Has This Been Tested?
Cucumber test provided

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I have squashed my commits into a single commit.
