### PR TITLE
test: add more wallet ffi testing

### DIFF
--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -150,7 +150,7 @@ struct TariPublicKey *emoji_id_to_public_key(const char *emoji, int *error_out);
 struct TariPrivateKey *private_key_create(struct ByteVector *bytes, int *error_out);
 
 // Generates a TariPrivateKey
-struct TariPrivateKey *private_key_generate(void);
+struct TariPrivateKey *private_key_generate();
 
 // Creates a ByteVector from a TariPrivateKey
 struct ByteVector *private_key_get_bytes(struct TariPrivateKey *private_key, int *error_out);
@@ -385,13 +385,13 @@ void pending_inbound_transactions_destroy(struct TariPendingInboundTransactions 
 // Creates a TariCommsConfig
 // Valid values for network are: ridcully, stibbons, weatherwax, localnet, mainnet
 struct TariCommsConfig *comms_config_create(const char *public_address,
-                                     struct TariTransportType *transport,
-                                     const char *database_name,
-                                     const char *datastore_path,
-                                     unsigned long long discovery_timeout_in_secs,
-                                     unsigned long long saf_message_duration_in_secs,
-                                     const char *network,
-                                     int* error_out);
+                                            struct TariTransportType *transport,
+                                            const char *database_name,
+                                            const char *datastore_path,
+                                            unsigned long long discovery_timeout_in_secs,
+                                            unsigned long long saf_message_duration_in_secs,
+                                            const char *network,
+                                            int *error_out);
 
 // Frees memory for a TariCommsConfig
 void comms_config_destroy(struct TariCommsConfig *wc);
@@ -717,7 +717,7 @@ void file_partial_backup(const char *original_file_path, const char *backup_file
 /// This function will log the provided string at debug level. To be used to have a client log messages to the LibWallet
 void log_debug_message(const char *msg);
 
-struct EmojiSet *get_emoji_set(void);
+struct EmojiSet *get_emoji_set();
 
 void emoji_set_destroy(struct EmojiSet *emoji_set);
 

--- a/integration_tests/features/WalletFFI.feature
+++ b/integration_tests/features/WalletFFI.feature
@@ -1,6 +1,71 @@
 Feature: Wallet FFI
 
-    Scenario: I want to get public key and emoji id
-        Given I have a ffi wallet Wallet
-        Then I want to get public key of ffi wallet Wallet
-        And I want to get emoji id of ffi wallet Wallet
+    Scenario: As a client I want to send Tari to a Public Key
+    # It's a subtest of "As a client I want to retrieve a list of transactions I have made and received"
+
+    Scenario: As a client I want to specify a custom fee when I send tari
+    # It's a subtest of "As a client I want to retrieve a list of transactions I have made and received"
+
+    Scenario: As a client I want to receive Tari via my Public Key while I am online
+    # It's a subtest of "As a client I want to retrieve a list of transactions I have made and received"
+
+    Scenario: As a client I want to receive Tari via my Public Key sent while I am offline when I come back online
+
+    @long-running
+    Scenario: As a client I want to retrieve a list of transactions I have made and received
+        Given I have a base node BASE
+        And I have wallet SENDER connected to base node BASE
+        And I have mining node MINER connected to base node BASE and wallet SENDER
+        And mining node MINER mines 4 blocks
+        Then I wait for wallet SENDER to have at least 1000000 uT
+        And I have a ffi wallet FFI_WALLET connected to base node BASE
+        And I send 2000000 uT from wallet SENDER to wallet FFI_WALLET at fee 100
+        And wallet SENDER detects all transactions are at least Broadcast
+        And mining node MINER mines 10 blocks
+        Then I wait for ffi wallet FFI_WALLET to have at least 1000000 uT
+        And I have wallet RECEIVER connected to base node BASE
+        And I send 1000000 uT from ffi wallet FFI_WALLET to wallet RECEIVER at fee 100
+        And ffi wallet FFI_WALLET has 1 broadcast transaction
+        And mining node MINER mines 4 blocks
+        Then I wait for wallet RECEIVER to have at least 1000000 uT
+        And I have 1 received and 1 send transaction in ffi wallet FFI_WALLET
+
+    # It's just calling the encrypt function, we don't test if it's actually encrypted
+    Scenario: As a client I want to be able to protect my wallet with a passphrase
+        Given I have a base node BASE
+        And I have a ffi wallet FFI_WALLET connected to base node BASE
+        And I set passphrase PASSPHRASE of ffi wallet FFI_WALLET
+
+    Scenario: As a client I want to manage contacts
+        Given I have a base node BASE
+        And I have a ffi wallet FFI_WALLET connected to base node BASE
+        And I have wallet WALLET connected to base node BASE
+        And I add contact with alias ALIAS and pubkey WALLET to ffi wallet FFI_WALLET
+        Then I have contact with alias ALIAS and pubkey WALLET in ffi wallet FFI_WALLET
+        When I remove contact with alias ALIAS from ffi wallet FFI_WALLET
+        Then I don't have contact with alias ALIAS in ffi wallet FFI_WALLET
+
+    Scenario: As a client I want to set the base node (should be persisted)
+
+    Scenario: As a client I want to see my public_key, emoji ID, address (whoami)
+        Given I have a base node BASE
+        And I have a ffi wallet FFI_WALLET connected to base node BASE
+        Then I want to get public key of ffi wallet FFI_WALLET
+        And I want to get emoji id of ffi wallet FFI_WALLET
+
+    Scenario: As a client I want to get my balance
+    # It's a subtest of "As a client I want to retrieve a list of transactions I have made and received"
+
+    Scenario: As a client I want to cancel a transaction
+
+    Scenario: As a client I want to be able to restore my wallet from seed words
+
+    Scenario: AS a client I want to be able to initiate TXO and TX validation with the specifed base node.
+
+    Scenario: As a client I want async feedback about the progress of sending and receiving a transaction
+
+    Scenario: As a client I want async feedback about my connection status to the specifed Base Node
+
+    Scenario: As a client I want async feedback about the wallet restoration process
+
+    Scenario: As a client I want async feedback about TXO and TX validation processes

--- a/integration_tests/features/support/world.js
+++ b/integration_tests/features/support/world.js
@@ -106,10 +106,12 @@ class CustomWorld {
     this.walletPubkeys[name] = walletInfo.public_key;
   }
 
-  async ffiCreateWallet(name) {
+  async createAndAddFFIWallet(name) {
     const wallet = new WalletFFIClient(name);
     await wallet.startNew();
     this.walletsFFI[name] = wallet;
+    this.walletPubkeys[name] = await wallet.getPublicKey();
+    return wallet;
   }
 
   addWallet(name, process) {

--- a/integration_tests/helpers/walletFFI.js
+++ b/integration_tests/helpers/walletFFI.js
@@ -1,10 +1,5 @@
 /**
- * Goal of this library is to provide all the functions inside the ffi library.
- * All the functions that returns error, should throw error instead. So the
- * outside code can use this as a regular javascript library (with nice code
- * completion,  * and parameter names, instead of big unknown), and not to take
- * care of the ffi stuff that's going on in here. This way, anyone doing new
- * test can avoid this ffi importing, declaration, etc... And just use it.
+ * This library was AUTO-GENERATED. Do not modify manually!
  */
 
 const { expect } = require("chai");
@@ -13,7 +8,6 @@ const ref = require("ref-napi");
 const dateFormat = require("dateformat");
 const { spawn } = require("child_process");
 const fs = require("fs");
-
 class WalletFFI {
   static byte_vector = ref.types.void;
   static byte_vector_ptr = ref.refType(this.byte_vector);
@@ -23,8 +17,6 @@ class WalletFFI {
   static tari_private_key_ptr = ref.refType(this.tari_private_key);
   static tari_wallet = ref.types.void;
   static tari_wallet_ptr = ref.refType(this.tari_wallet);
-  static tari_wallet_config = ref.types.void;
-  static tari_wallet_config_ptr = ref.refType(this.tari_wallet_config);
   static tari_public_key = ref.types.void;
   static tari_public_key_ptr = ref.refType(this.tari_public_key);
   static tari_contacts = ref.types.void;
@@ -75,6 +67,32 @@ class WalletFFI {
   static NULL = ref.NULL;
   static #loaded = false;
   static #ps = null;
+
+  // Callbacks
+  static #callback_received_transaction;
+  static #callback_received_transaction_reply;
+  static #callback_received_finalized_transaction;
+  static #callback_transaction_broadcast;
+  static #callback_transaction_mined;
+  static #callback_transaction_mined_unconfirmed;
+  static #callback_direct_send_result;
+  static #callback_store_and_forward_send_result;
+  static #callback_transaction_cancellation;
+  static #callback_utxo_validation_complete;
+  static #callback_stxo_validation_complete;
+  static #callback_invalid_txo_validation_complete;
+  static #callback_transaction_validation_complete;
+  static #callback_saf_message_received;
+  static #recovery_progress_callback;
+
+  static checkAsyncRes(resolve, reject, error_name) {
+    return (err, res) => {
+      if (err) reject(err);
+      expect(this.error.deref()).to.equal(0, `Error in ${error_name}`);
+      resolve(res);
+    };
+  }
+
   static compile() {
     return new Promise((resolve, _reject) => {
       const cmd = "cargo";
@@ -124,11 +142,113 @@ class WalletFFI {
     const outputProcess = `${process.cwd()}/temp/out/${
       process.platform === "win32" ? "" : "lib"
     }tari_wallet_ffi`;
-    console.log(outputProcess);
 
+    // Init callbacks
+    // TODO: Add callback support for wallets
+
+    this.#callback_received_transaction = ffi.Callback(
+      "void",
+      [this.tari_pending_inbound_transaction_ptr],
+      function (_pending_inbound_transaction) {
+        console.log("callback_received_transaction");
+      }
+    );
+    this.#callback_received_transaction_reply = ffi.Callback(
+      "void",
+      [this.tari_completed_transaction_ptr],
+      function (_completed_transaction) {
+        console.log("callback_received_transaction_reply");
+      }
+    );
+    this.#callback_received_finalized_transaction = ffi.Callback(
+      "void",
+      [this.tari_completed_transaction_ptr],
+      function (_completed_transaction) {
+        console.log("callback_received_finalized_transaction");
+      }
+    );
+    this.#callback_transaction_broadcast = ffi.Callback(
+      "void",
+      [this.tari_completed_transaction_ptr],
+      function (_completed_transaction) {
+        console.log("callback_transaction_broadcast");
+      }
+    );
+    this.#callback_transaction_mined = ffi.Callback(
+      "void",
+      [this.tari_completed_transaction_ptr],
+      function (_completed_transaction) {
+        console.log("callback_transaction_mined");
+      }
+    );
+    this.#callback_transaction_mined_unconfirmed = ffi.Callback(
+      "void",
+      [this.tari_completed_transaction_ptr, "ulong long"],
+      function (_completed_transaction, _b) {
+        console.log("callback_transaction_mined_unconfirmed");
+      }
+    );
+    this.#callback_direct_send_result = ffi.Callback(
+      "void",
+      ["ulong long", "bool"],
+      function (_a, _b) {
+        console.log("callback_direct_send_result");
+      }
+    );
+    this.#callback_store_and_forward_send_result = ffi.Callback(
+      "void",
+      ["ulong long", "bool"],
+      function (_a, _b) {
+        console.log("callback_store_and_forward_send_result");
+      }
+    );
+    this.#callback_transaction_cancellation = ffi.Callback(
+      "void",
+      [this.tari_completed_transaction_ptr],
+      function (_completed_transaction) {
+        console.log("callback_transaction_cancellation");
+      }
+    );
+    this.#callback_utxo_validation_complete = ffi.Callback(
+      "void",
+      ["ulong long", "uchar"],
+      function (_a, _b) {
+        console.log("callback_utxo_validation_complete");
+      }
+    );
+    this.#callback_stxo_validation_complete = ffi.Callback(
+      "void",
+      ["ulong long", "uchar"],
+      function (_a, _b) {
+        console.log("callback_stxo_validation_complete");
+      }
+    );
+    this.#callback_invalid_txo_validation_complete = ffi.Callback(
+      "void",
+      ["ulong long", "uchar"],
+      function (_a, _b) {
+        console.log("callback_invalid_txo_validation_complete");
+      }
+    );
+    this.#callback_transaction_validation_complete = ffi.Callback(
+      "void",
+      ["ulong long", "uchar"],
+      function (_a, _b) {
+        console.log("callback_transaction_validation_complete");
+      }
+    );
+    this.#callback_saf_message_received = ffi.Callback("void", [], function () {
+      console.log("callback_saf_message_received");
+    });
+    this.#recovery_progress_callback = ffi.Callback(
+      "void",
+      ["uchar", "ulong long", "ulong long"],
+      function (_a, _b, _c) {
+        console.log("recovery_progress_callback");
+      }
+    );
     // Load the library
     this.#fn = ffi.Library(outputProcess, {
-      // Transport Types
       transport_memory_create: [this.tari_transport_type_ptr, []],
       transport_tcp_create: [this.tari_transport_type_ptr, ["string", "int*"]],
       transport_tor_create: [
@@ -136,18 +256,15 @@ class WalletFFI {
         ["string", this.byte_vector_ptr, "ushort", "string", "string", "int*"],
       ],
       transport_memory_get_address: [
-        "string",
+        "char*",
         [this.tari_transport_type_ptr, "int*"],
       ],
       transport_type_destroy: ["void", [this.tari_transport_type_ptr]],
-      // Strings
       string_destroy: ["void", ["string"]],
-      // ByteVector
       byte_vector_create: [this.byte_vector_ptr, ["uchar*", "uint", "int*"]],
       byte_vector_get_at: ["uchar", [this.byte_vector_ptr, "uint", "int*"]],
       byte_vector_get_length: ["uint", [this.byte_vector_ptr, "int*"]],
       byte_vector_destroy: ["void", [this.byte_vector_ptr]],
-      // TariPublicKey
       public_key_create: [
         this.tari_public_key_ptr,
         [this.byte_vector_ptr, "int*"],
@@ -162,9 +279,8 @@ class WalletFFI {
       ],
       public_key_from_hex: [this.tari_public_key_ptr, ["string", "int*"]],
       public_key_destroy: ["void", [this.tari_public_key_ptr]],
-      public_key_to_emoji_id: ["string", [this.tari_public_key_ptr, "int*"]],
+      public_key_to_emoji_id: ["char*", [this.tari_public_key_ptr, "int*"]],
       emoji_id_to_public_key: [this.tari_public_key_ptr, ["string", "int*"]],
-      // TariPrivateKey
       private_key_create: [
         this.tari_private_key_ptr,
         [this.byte_vector_ptr, "int*"],
@@ -176,34 +292,30 @@ class WalletFFI {
       ],
       private_key_from_hex: [this.tari_private_key_ptr, ["string", "int*"]],
       private_key_destroy: ["void", [this.tari_private_key_ptr]],
-      // Seed Words
       seed_words_create: [this.tari_seed_words_ptr, []],
       seed_words_get_length: ["uint", [this.tari_seed_words_ptr, "int*"]],
-      seed_words_get_at: ["string", [this.tari_seed_words_ptr, "uint", "int*"]],
+      seed_words_get_at: ["char*", [this.tari_seed_words_ptr, "uint", "int*"]],
       seed_words_push_word: [
         "uchar",
         [this.tari_seed_words_ptr, "string", "int*"],
       ],
       seed_words_destroy: ["void", [this.tari_seed_words_ptr]],
-      // Contact
       contact_create: [
         this.tari_contact_ptr,
         ["string", this.tari_public_key_ptr, "int*"],
       ],
-      contact_get_alias: ["string", [this.tari_contact_ptr, "int*"]],
+      contact_get_alias: ["char*", [this.tari_contact_ptr, "int*"]],
       contact_get_public_key: [
         this.tari_public_key_ptr,
         [this.tari_contact_ptr, "int*"],
       ],
       contact_destroy: ["void", [this.tari_contact_ptr]],
-      // Contacts
       contacts_get_length: ["uint", [this.tari_contacts_ptr, "int*"]],
       contacts_get_at: [
         this.tari_contact_ptr,
         [this.tari_contacts_ptr, "uint", "int*"],
       ],
       contacts_destroy: ["void", [this.tari_contacts_ptr]],
-      // CompletedTransaction
       completed_transaction_get_destination_public_key: [
         this.tari_public_key_ptr,
         [this.tari_completed_transaction_ptr, "int*"],
@@ -221,12 +333,12 @@ class WalletFFI {
         [this.tari_completed_transaction_ptr, "int*"],
       ],
       completed_transaction_get_message: [
-        "string",
+        "char*",
         [this.tari_completed_transaction_ptr, "int*"],
       ],
       completed_transaction_get_status: [
         "int",
-        [this.tari_completed_transaction, "int*"],
+        [this.tari_completed_transaction_ptr, "int*"],
       ],
       completed_transaction_get_transaction_id: [
         "ulong long",
@@ -267,7 +379,6 @@ class WalletFFI {
       excess_destroy: ["void", [this.tari_excess_ptr]],
       nonce_destroy: ["void", [this.tari_excess_public_nonce_ptr]],
       signature_destroy: ["void", [this.tari_excess_signature_ptr]],
-      // CompletedTransactions
       completed_transactions_get_length: [
         "uint",
         [this.tari_completed_transactions_ptr, "int*"],
@@ -280,7 +391,6 @@ class WalletFFI {
         "void",
         [this.tari_completed_transactions_ptr],
       ],
-      // OutboundTransaction
       pending_outbound_transaction_get_transaction_id: [
         "ulong long",
         [this.tari_pending_outbound_transaction_ptr, "int*"],
@@ -298,7 +408,7 @@ class WalletFFI {
         [this.tari_pending_outbound_transaction_ptr, "int*"],
       ],
       pending_outbound_transaction_get_message: [
-        "string",
+        "char*",
         [this.tari_pending_outbound_transaction_ptr, "int*"],
       ],
       pending_outbound_transaction_get_timestamp: [
@@ -313,7 +423,6 @@ class WalletFFI {
         "void",
         [this.tari_pending_outbound_transaction_ptr],
       ],
-      // OutboundTransactions
       pending_outbound_transactions_get_length: [
         "uint",
         [this.tari_pending_outbound_transactions_ptr, "int*"],
@@ -326,7 +435,6 @@ class WalletFFI {
         "void",
         [this.tari_pending_outbound_transactions_ptr],
       ],
-      // InboundTransaction
       pending_inbound_transaction_get_transaction_id: [
         "ulong long",
         [this.tari_pending_inbound_transaction_ptr, "int*"],
@@ -336,7 +444,7 @@ class WalletFFI {
         [this.tari_pending_inbound_transaction_ptr, "int*"],
       ],
       pending_inbound_transaction_get_message: [
-        "string",
+        "char*",
         [this.tari_pending_inbound_transaction_ptr, "int*"],
       ],
       pending_inbound_transaction_get_amount: [
@@ -355,7 +463,6 @@ class WalletFFI {
         "void",
         [this.tari_pending_inbound_transaction_ptr],
       ],
-      // InboundTransactions
       pending_inbound_transactions_get_length: [
         "uint",
         [this.tari_pending_inbound_transactions_ptr, "int*"],
@@ -368,7 +475,6 @@ class WalletFFI {
         "void",
         [this.tari_pending_inbound_transactions_ptr],
       ],
-      // TariCommsConfig
       comms_config_create: [
         this.tari_comms_config_ptr,
         [
@@ -378,15 +484,15 @@ class WalletFFI {
           "string",
           "ulong long",
           "ulong long",
+          "string",
           "int*",
         ],
       ],
       comms_config_destroy: ["void", [this.tari_comms_config_ptr]],
-      // TariWallet
       wallet_create: [
         this.tari_wallet_ptr,
         [
-          this.tari_wallet_config_ptr,
+          this.tari_comms_config_ptr,
           "string",
           "uint",
           "uint",
@@ -409,7 +515,7 @@ class WalletFFI {
           "int*",
         ],
       ],
-      wallet_sign_message: ["string", [this.tari_wallet_ptr, "string", "int*"]],
+      wallet_sign_message: ["char*", [this.tari_wallet_ptr, "string", "int*"]],
       wallet_verify_message_signature: [
         "bool",
         [
@@ -461,10 +567,10 @@ class WalletFFI {
       ],
       wallet_set_num_confirmations_required: [
         "void",
-        [this.tari_wallet_ptr, "long long", "int*"],
+        [this.tari_wallet_ptr, "ulong long", "int*"],
       ],
       wallet_send_transaction: [
-        "long long",
+        "ulong long",
         [
           this.tari_wallet_ptr,
           this.tari_public_key_ptr,
@@ -504,15 +610,15 @@ class WalletFFI {
       ],
       wallet_get_pending_outbound_transaction_by_id: [
         this.tari_pending_outbound_transaction_ptr,
-        [this.tari_wallet_ptr, "uint", "int*"],
+        [this.tari_wallet_ptr, "ulong long", "int*"],
       ],
       wallet_get_pending_inbound_transaction_by_id: [
-        this.tari_pending_outbound_transaction_ptr,
-        [this.tari_wallet_ptr, "uint", "int*"],
+        this.tari_pending_inbound_transaction_ptr,
+        [this.tari_wallet_ptr, "ulong long", "int*"],
       ],
       wallet_get_cancelled_transaction_by_id: [
         this.tari_completed_transaction_ptr,
-        [this.tari_wallet_ptr, "int", "int*"],
+        [this.tari_wallet_ptr, "ulong long", "int*"],
       ],
       wallet_import_utxo: [
         "ulong long",
@@ -576,7 +682,7 @@ class WalletFFI {
         "bool",
         [this.tari_wallet_ptr, "string", "string", "int*"],
       ],
-      wallet_get_value: ["string", [this.tari_wallet_ptr, "string", "int*"]],
+      wallet_get_value: ["char*", [this.tari_wallet_ptr, "string", "int*"]],
       wallet_clear_value: ["bool", [this.tari_wallet_ptr, "string", "int*"]],
       wallet_is_recovery_in_progress: ["bool", [this.tari_wallet_ptr, "int*"]],
       wallet_start_recovery: [
@@ -596,18 +702,22 @@ class WalletFFI {
     });
   }
 
-  static checkError(text) {
-    expect(this.error.deref()).to.equal(0, `Error in ${text}`);
+  static transportMemoryCreate() {
+    return new Promise((resolve, reject) =>
+      this.#fn.transport_memory_create.async(
+        this.checkAsyncRes(resolve, reject, "transportMemoryCreate")
+      )
+    );
   }
-
-  /// -------------------------------- Transport Types ----------------------------------------------- ///
-
   static transportTcpCreate(listener_address) {
-    let tcp = this.#fn.transport_tcp_create(listener_address, this.error);
-    this.checkError("transportTcpCreate");
-    return tcp;
+    return new Promise((resolve, reject) =>
+      this.#fn.transport_tcp_create.async(
+        listener_address,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "transportTcpCreate")
+      )
+    );
   }
-
   static transportTorCreate(
     control_server_address,
     tor_cookie,
@@ -615,256 +725,1300 @@ class WalletFFI {
     socks_username,
     socks_password
   ) {
-    let tor = this.#fn.transport_tor_create(
-      control_server_address,
-      tor_cookie,
-      tor_port,
-      socks_username,
-      socks_password,
-      this.error
+    return new Promise((resolve, reject) =>
+      this.#fn.transport_tor_create.async(
+        control_server_address,
+        tor_cookie,
+        tor_port,
+        socks_username,
+        socks_password,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "transportTorCreate")
+      )
     );
-    this.checkError("transportTorCreate");
-    return tor;
   }
-
   static transportMemoryGetAddress(transport) {
-    let address = this.#fn.transport_memory_get_address(transport, this.error);
-    this.checkError("transportMemoryGetAddress");
-    return address;
-  }
-
-  static transportTypeDestroy(transport) {
-    this.#fn.transport_type_destroy(transport);
-  }
-
-  /// -------------------------------- Strings ----------------------------------------------- ///
-
-  static stringDestroy(string) {
-    this.#fn.string_destroy(string);
-  }
-
-  /// -------------------------------- ByteVector ----------------------------------------------- ///
-
-  static byteVectorCreate(byte_array, element_count) {
-    const byte_vector = this.#fn.byte_vector_create(
-      byte_array,
-      element_count,
-      this.error
+    return new Promise((resolve, reject) =>
+      this.#fn.transport_memory_get_address.async(
+        transport,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "transportMemoryGetAddress")
+      )
     );
-    this.checkError("byteVectorCreate");
-    /// -------------------------------- TariWallet ----------------------------------------------- //
-    return byte_vector;
   }
-
-  static byteVectorGetAt(byte_array, i) {
-    const byte = this.#fn.byte_vector_get_at(byte_array, i, this.error);
-    this.checkError("byteVectorGetAt");
-    return byte;
+  static transportTypeDestroy(transport) {
+    return new Promise((resolve, reject) =>
+      this.#fn.transport_type_destroy.async(
+        transport,
+        this.checkAsyncRes(resolve, reject, "transportTypeDestroy")
+      )
+    );
   }
-
-  static byteVectorGetLength(byte_array) {
-    const length = this.#fn.byte_vector_get_length(byte_array, this.error);
-    this.checkError("byteVectorGetLength");
-    return length;
+  static stringDestroy(s) {
+    return new Promise((resolve, reject) =>
+      this.#fn.string_destroy.async(
+        s,
+        this.checkAsyncRes(resolve, reject, "stringDestroy")
+      )
+    );
   }
-
-  static byteVectorDestroy(byte_array) {
-    this.#fn.byte_vector_destroy(byte_array);
+  static byteVectorCreate(byte_array, element_count) {
+    return new Promise((resolve, reject) =>
+      this.#fn.byte_vector_create.async(
+        byte_array,
+        element_count,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "byteVectorCreate")
+      )
+    );
   }
-
-  /// -------------------------------- TariPublicKey ----------------------------------------------- ///
-
+  static byteVectorGetAt(ptr, i) {
+    return new Promise((resolve, reject) =>
+      this.#fn.byte_vector_get_at.async(
+        ptr,
+        i,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "byteVectorGetAt")
+      )
+    );
+  }
+  static byteVectorGetLength(vec) {
+    return new Promise((resolve, reject) =>
+      this.#fn.byte_vector_get_length.async(
+        vec,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "byteVectorGetLength")
+      )
+    );
+  }
+  static byteVectorDestroy(bytes) {
+    return new Promise((resolve, reject) =>
+      this.#fn.byte_vector_destroy.async(
+        bytes,
+        this.checkAsyncRes(resolve, reject, "byteVectorDestroy")
+      )
+    );
+  }
+  static publicKeyCreate(bytes) {
+    return new Promise((resolve, reject) =>
+      this.#fn.public_key_create.async(
+        bytes,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "publicKeyCreate")
+      )
+    );
+  }
   static publicKeyGetBytes(public_key) {
-    let bytes = this.#fn.public_key_get_bytes(public_key, this.error);
-    this.checkError("publicKeyGetBytes");
-    return bytes;
+    return new Promise((resolve, reject) =>
+      this.#fn.public_key_get_bytes.async(
+        public_key,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "publicKeyGetBytes")
+      )
+    );
   }
-
-  static publicKeyDestroy(public_key) {
-    this.#fn.public_key_destroy(public_key);
+  static publicKeyFromPrivateKey(secret_key) {
+    return new Promise((resolve, reject) =>
+      this.#fn.public_key_from_private_key.async(
+        secret_key,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "publicKeyFromPrivateKey")
+      )
+    );
   }
-
-  static publicKeyToEmojiId(public_key) {
-    let emoji_id = this.#fn.public_key_to_emoji_id(public_key, this.error);
-    this.checkError("publicKeyToEmojiId");
-    return emoji_id;
+  static publicKeyFromHex(hex) {
+    return new Promise((resolve, reject) =>
+      this.#fn.public_key_from_hex.async(
+        hex,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "publicKeyFromHex")
+      )
+    );
   }
-  /// -------------------------------- TariPrivateKey ----------------------------------------------- ///
-  /// -------------------------------- Seed Words  -------------------------------------------------- ///
-  /// -------------------------------- Contact ------------------------------------------------------ ///
-  /// -------------------------------- Contacts ------------------------------------------------------ ///
-  /// -------------------------------- CompletedTransaction ------------------------------------------------------ ///
-  /// -------------------------------- CompletedTransactions ------------------------------------------------------ ///
-  /// -------------------------------- OutboundTransaction ------------------------------------------------------ ///
-  /// -------------------------------- OutboundTransactions ------------------------------------------------------ ///
-  /// -------------------------------- InboundTransaction ------------------------------------------------------ ///
-  /// -------------------------------- InboundTransactions ------------------------------------------------------ ///
-  /// -------------------------------- TariCommsConfig ----------------------------------------------- ///
-
+  static publicKeyDestroy(pk) {
+    return new Promise((resolve, reject) =>
+      this.#fn.public_key_destroy.async(
+        pk,
+        this.checkAsyncRes(resolve, reject, "publicKeyDestroy")
+      )
+    );
+  }
+  static publicKeyToEmojiId(pk) {
+    return new Promise((resolve, reject) =>
+      this.#fn.public_key_to_emoji_id.async(
+        pk,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "publicKeyToEmojiId")
+      )
+    );
+  }
+  static emojiIdToPublicKey(emoji) {
+    return new Promise((resolve, reject) =>
+      this.#fn.emoji_id_to_public_key.async(
+        emoji,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "emojiIdToPublicKey")
+      )
+    );
+  }
+  static privateKeyCreate(bytes) {
+    return new Promise((resolve, reject) =>
+      this.#fn.private_key_create.async(
+        bytes,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "privateKeyCreate")
+      )
+    );
+  }
+  static privateKeyGenerate() {
+    return new Promise((resolve, reject) =>
+      this.#fn.private_key_generate.async(
+        this.checkAsyncRes(resolve, reject, "privateKeyGenerate")
+      )
+    );
+  }
+  static privateKeyGetBytes(private_key) {
+    return new Promise((resolve, reject) =>
+      this.#fn.private_key_get_bytes.async(
+        private_key,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "privateKeyGetBytes")
+      )
+    );
+  }
+  static privateKeyFromHex(hex) {
+    return new Promise((resolve, reject) =>
+      this.#fn.private_key_from_hex.async(
+        hex,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "privateKeyFromHex")
+      )
+    );
+  }
+  static privateKeyDestroy(pk) {
+    return new Promise((resolve, reject) =>
+      this.#fn.private_key_destroy.async(
+        pk,
+        this.checkAsyncRes(resolve, reject, "privateKeyDestroy")
+      )
+    );
+  }
+  static seedWordsCreate() {
+    return new Promise((resolve, reject) =>
+      this.#fn.seed_words_create.async(
+        this.checkAsyncRes(resolve, reject, "seedWordsCreate")
+      )
+    );
+  }
+  static seedWordsGetLength(seed_words) {
+    return new Promise((resolve, reject) =>
+      this.#fn.seed_words_get_length.async(
+        seed_words,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "seedWordsGetLength")
+      )
+    );
+  }
+  static seedWordsGetAt(seed_words, position) {
+    return new Promise((resolve, reject) =>
+      this.#fn.seed_words_get_at.async(
+        seed_words,
+        position,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "seedWordsGetAt")
+      )
+    );
+  }
+  static seedWordsPushWord(seed_words, word) {
+    return new Promise((resolve, reject) =>
+      this.#fn.seed_words_push_word.async(
+        seed_words,
+        word,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "seedWordsPushWord")
+      )
+    );
+  }
+  static seedWordsDestroy(seed_words) {
+    return new Promise((resolve, reject) =>
+      this.#fn.seed_words_destroy.async(
+        seed_words,
+        this.checkAsyncRes(resolve, reject, "seedWordsDestroy")
+      )
+    );
+  }
+  static contactCreate(alias, public_key) {
+    return new Promise((resolve, reject) =>
+      this.#fn.contact_create.async(
+        alias,
+        public_key,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "contactCreate")
+      )
+    );
+  }
+  static contactGetAlias(contact) {
+    return new Promise((resolve, reject) =>
+      this.#fn.contact_get_alias.async(
+        contact,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "contactGetAlias")
+      )
+    );
+  }
+  static contactGetPublicKey(contact) {
+    return new Promise((resolve, reject) =>
+      this.#fn.contact_get_public_key.async(
+        contact,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "contactGetPublicKey")
+      )
+    );
+  }
+  static contactDestroy(contact) {
+    return new Promise((resolve, reject) =>
+      this.#fn.contact_destroy.async(
+        contact,
+        this.checkAsyncRes(resolve, reject, "contactDestroy")
+      )
+    );
+  }
+  static contactsGetLength(contacts) {
+    return new Promise((resolve, reject) =>
+      this.#fn.contacts_get_length.async(
+        contacts,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "contactsGetLength")
+      )
+    );
+  }
+  static contactsGetAt(contacts, position) {
+    return new Promise((resolve, reject) =>
+      this.#fn.contacts_get_at.async(
+        contacts,
+        position,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "contactsGetAt")
+      )
+    );
+  }
+  static contactsDestroy(contacts) {
+    return new Promise((resolve, reject) =>
+      this.#fn.contacts_destroy.async(
+        contacts,
+        this.checkAsyncRes(resolve, reject, "contactsDestroy")
+      )
+    );
+  }
+  static completedTransactionGetDestinationPublicKey(transaction) {
+    return new Promise((resolve, reject) =>
+      this.#fn.completed_transaction_get_destination_public_key.async(
+        transaction,
+        this.error,
+        this.checkAsyncRes(
+          resolve,
+          reject,
+          "completedTransactionGetDestinationPublicKey"
+        )
+      )
+    );
+  }
+  static completedTransactionGetSourcePublicKey(transaction) {
+    return new Promise((resolve, reject) =>
+      this.#fn.completed_transaction_get_source_public_key.async(
+        transaction,
+        this.error,
+        this.checkAsyncRes(
+          resolve,
+          reject,
+          "completedTransactionGetSourcePublicKey"
+        )
+      )
+    );
+  }
+  static completedTransactionGetAmount(transaction) {
+    return new Promise((resolve, reject) =>
+      this.#fn.completed_transaction_get_amount.async(
+        transaction,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "completedTransactionGetAmount")
+      )
+    );
+  }
+  static completedTransactionGetFee(transaction) {
+    return new Promise((resolve, reject) =>
+      this.#fn.completed_transaction_get_fee.async(
+        transaction,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "completedTransactionGetFee")
+      )
+    );
+  }
+  static completedTransactionGetMessage(transaction) {
+    return new Promise((resolve, reject) =>
+      this.#fn.completed_transaction_get_message.async(
+        transaction,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "completedTransactionGetMessage")
+      )
+    );
+  }
+  static completedTransactionGetStatus(transaction) {
+    return new Promise((resolve, reject) =>
+      this.#fn.completed_transaction_get_status.async(
+        transaction,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "completedTransactionGetStatus")
+      )
+    );
+  }
+  static completedTransactionGetTransactionId(transaction) {
+    return new Promise((resolve, reject) =>
+      this.#fn.completed_transaction_get_transaction_id.async(
+        transaction,
+        this.error,
+        this.checkAsyncRes(
+          resolve,
+          reject,
+          "completedTransactionGetTransactionId"
+        )
+      )
+    );
+  }
+  static completedTransactionGetTimestamp(transaction) {
+    return new Promise((resolve, reject) =>
+      this.#fn.completed_transaction_get_timestamp.async(
+        transaction,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "completedTransactionGetTimestamp")
+      )
+    );
+  }
+  static completedTransactionIsValid(tx) {
+    return new Promise((resolve, reject) =>
+      this.#fn.completed_transaction_is_valid.async(
+        tx,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "completedTransactionIsValid")
+      )
+    );
+  }
+  static completedTransactionIsOutbound(tx) {
+    return new Promise((resolve, reject) =>
+      this.#fn.completed_transaction_is_outbound.async(
+        tx,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "completedTransactionIsOutbound")
+      )
+    );
+  }
+  static completedTransactionGetConfirmations(transaction) {
+    return new Promise((resolve, reject) =>
+      this.#fn.completed_transaction_get_confirmations.async(
+        transaction,
+        this.error,
+        this.checkAsyncRes(
+          resolve,
+          reject,
+          "completedTransactionGetConfirmations"
+        )
+      )
+    );
+  }
+  static completedTransactionDestroy(transaction) {
+    return new Promise((resolve, reject) =>
+      this.#fn.completed_transaction_destroy.async(
+        transaction,
+        this.checkAsyncRes(resolve, reject, "completedTransactionDestroy")
+      )
+    );
+  }
+  static completedTransactionGetExcess(transaction) {
+    return new Promise((resolve, reject) =>
+      this.#fn.completed_transaction_get_excess.async(
+        transaction,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "completedTransactionGetExcess")
+      )
+    );
+  }
+  static completedTransactionGetPublicNonce(transaction) {
+    return new Promise((resolve, reject) =>
+      this.#fn.completed_transaction_get_public_nonce.async(
+        transaction,
+        this.error,
+        this.checkAsyncRes(
+          resolve,
+          reject,
+          "completedTransactionGetPublicNonce"
+        )
+      )
+    );
+  }
+  static completedTransactionGetSignature(transaction) {
+    return new Promise((resolve, reject) =>
+      this.#fn.completed_transaction_get_signature.async(
+        transaction,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "completedTransactionGetSignature")
+      )
+    );
+  }
+  static excessDestroy(excess) {
+    return new Promise((resolve, reject) =>
+      this.#fn.excess_destroy.async(
+        excess,
+        this.checkAsyncRes(resolve, reject, "excessDestroy")
+      )
+    );
+  }
+  static nonceDestroy(nonce) {
+    return new Promise((resolve, reject) =>
+      this.#fn.nonce_destroy.async(
+        nonce,
+        this.checkAsyncRes(resolve, reject, "nonceDestroy")
+      )
+    );
+  }
+  static signatureDestroy(signature) {
+    return new Promise((resolve, reject) =>
+      this.#fn.signature_destroy.async(
+        signature,
+        this.checkAsyncRes(resolve, reject, "signatureDestroy")
+      )
+    );
+  }
+  static completedTransactionsGetLength(transactions) {
+    return new Promise((resolve, reject) =>
+      this.#fn.completed_transactions_get_length.async(
+        transactions,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "completedTransactionsGetLength")
+      )
+    );
+  }
+  static completedTransactionsGetAt(transactions, position) {
+    return new Promise((resolve, reject) =>
+      this.#fn.completed_transactions_get_at.async(
+        transactions,
+        position,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "completedTransactionsGetAt")
+      )
+    );
+  }
+  static completedTransactionsDestroy(transactions) {
+    return new Promise((resolve, reject) =>
+      this.#fn.completed_transactions_destroy.async(
+        transactions,
+        this.checkAsyncRes(resolve, reject, "completedTransactionsDestroy")
+      )
+    );
+  }
+  static pendingOutboundTransactionGetTransactionId(transaction) {
+    return new Promise((resolve, reject) =>
+      this.#fn.pending_outbound_transaction_get_transaction_id.async(
+        transaction,
+        this.error,
+        this.checkAsyncRes(
+          resolve,
+          reject,
+          "pendingOutboundTransactionGetTransactionId"
+        )
+      )
+    );
+  }
+  static pendingOutboundTransactionGetDestinationPublicKey(transaction) {
+    return new Promise((resolve, reject) =>
+      this.#fn.pending_outbound_transaction_get_destination_public_key.async(
+        transaction,
+        this.error,
+        this.checkAsyncRes(
+          resolve,
+          reject,
+          "pendingOutboundTransactionGetDestinationPublicKey"
+        )
+      )
+    );
+  }
+  static pendingOutboundTransactionGetAmount(transaction) {
+    return new Promise((resolve, reject) =>
+      this.#fn.pending_outbound_transaction_get_amount.async(
+        transaction,
+        this.error,
+        this.checkAsyncRes(
+          resolve,
+          reject,
+          "pendingOutboundTransactionGetAmount"
+        )
+      )
+    );
+  }
+  static pendingOutboundTransactionGetFee(transaction) {
+    return new Promise((resolve, reject) =>
+      this.#fn.pending_outbound_transaction_get_fee.async(
+        transaction,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "pendingOutboundTransactionGetFee")
+      )
+    );
+  }
+  static pendingOutboundTransactionGetMessage(transaction) {
+    return new Promise((resolve, reject) =>
+      this.#fn.pending_outbound_transaction_get_message.async(
+        transaction,
+        this.error,
+        this.checkAsyncRes(
+          resolve,
+          reject,
+          "pendingOutboundTransactionGetMessage"
+        )
+      )
+    );
+  }
+  static pendingOutboundTransactionGetTimestamp(transaction) {
+    return new Promise((resolve, reject) =>
+      this.#fn.pending_outbound_transaction_get_timestamp.async(
+        transaction,
+        this.error,
+        this.checkAsyncRes(
+          resolve,
+          reject,
+          "pendingOutboundTransactionGetTimestamp"
+        )
+      )
+    );
+  }
+  static pendingOutboundTransactionGetStatus(transaction) {
+    return new Promise((resolve, reject) =>
+      this.#fn.pending_outbound_transaction_get_status.async(
+        transaction,
+        this.error,
+        this.checkAsyncRes(
+          resolve,
+          reject,
+          "pendingOutboundTransactionGetStatus"
+        )
+      )
+    );
+  }
+  static pendingOutboundTransactionDestroy(transaction) {
+    return new Promise((resolve, reject) =>
+      this.#fn.pending_outbound_transaction_destroy.async(
+        transaction,
+        this.checkAsyncRes(resolve, reject, "pendingOutboundTransactionDestroy")
+      )
+    );
+  }
+  static pendingOutboundTransactionsGetLength(transactions) {
+    return new Promise((resolve, reject) =>
+      this.#fn.pending_outbound_transactions_get_length.async(
+        transactions,
+        this.error,
+        this.checkAsyncRes(
+          resolve,
+          reject,
+          "pendingOutboundTransactionsGetLength"
+        )
+      )
+    );
+  }
+  static pendingOutboundTransactionsGetAt(transactions, position) {
+    return new Promise((resolve, reject) =>
+      this.#fn.pending_outbound_transactions_get_at.async(
+        transactions,
+        position,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "pendingOutboundTransactionsGetAt")
+      )
+    );
+  }
+  static pendingOutboundTransactionsDestroy(transactions) {
+    return new Promise((resolve, reject) =>
+      this.#fn.pending_outbound_transactions_destroy.async(
+        transactions,
+        this.checkAsyncRes(
+          resolve,
+          reject,
+          "pendingOutboundTransactionsDestroy"
+        )
+      )
+    );
+  }
+  static pendingInboundTransactionGetTransactionId(transaction) {
+    return new Promise((resolve, reject) =>
+      this.#fn.pending_inbound_transaction_get_transaction_id.async(
+        transaction,
+        this.error,
+        this.checkAsyncRes(
+          resolve,
+          reject,
+          "pendingInboundTransactionGetTransactionId"
+        )
+      )
+    );
+  }
+  static pendingInboundTransactionGetSourcePublicKey(transaction) {
+    return new Promise((resolve, reject) =>
+      this.#fn.pending_inbound_transaction_get_source_public_key.async(
+        transaction,
+        this.error,
+        this.checkAsyncRes(
+          resolve,
+          reject,
+          "pendingInboundTransactionGetSourcePublicKey"
+        )
+      )
+    );
+  }
+  static pendingInboundTransactionGetMessage(transaction) {
+    return new Promise((resolve, reject) =>
+      this.#fn.pending_inbound_transaction_get_message.async(
+        transaction,
+        this.error,
+        this.checkAsyncRes(
+          resolve,
+          reject,
+          "pendingInboundTransactionGetMessage"
+        )
+      )
+    );
+  }
+  static pendingInboundTransactionGetAmount(transaction) {
+    return new Promise((resolve, reject) =>
+      this.#fn.pending_inbound_transaction_get_amount.async(
+        transaction,
+        this.error,
+        this.checkAsyncRes(
+          resolve,
+          reject,
+          "pendingInboundTransactionGetAmount"
+        )
+      )
+    );
+  }
+  static pendingInboundTransactionGetTimestamp(transaction) {
+    return new Promise((resolve, reject) =>
+      this.#fn.pending_inbound_transaction_get_timestamp.async(
+        transaction,
+        this.error,
+        this.checkAsyncRes(
+          resolve,
+          reject,
+          "pendingInboundTransactionGetTimestamp"
+        )
+      )
+    );
+  }
+  static pendingInboundTransactionGetStatus(transaction) {
+    return new Promise((resolve, reject) =>
+      this.#fn.pending_inbound_transaction_get_status.async(
+        transaction,
+        this.error,
+        this.checkAsyncRes(
+          resolve,
+          reject,
+          "pendingInboundTransactionGetStatus"
+        )
+      )
+    );
+  }
+  static pendingInboundTransactionDestroy(transaction) {
+    return new Promise((resolve, reject) =>
+      this.#fn.pending_inbound_transaction_destroy.async(
+        transaction,
+        this.checkAsyncRes(resolve, reject, "pendingInboundTransactionDestroy")
+      )
+    );
+  }
+  static pendingInboundTransactionsGetLength(transactions) {
+    return new Promise((resolve, reject) =>
+      this.#fn.pending_inbound_transactions_get_length.async(
+        transactions,
+        this.error,
+        this.checkAsyncRes(
+          resolve,
+          reject,
+          "pendingInboundTransactionsGetLength"
+        )
+      )
+    );
+  }
+  static pendingInboundTransactionsGetAt(transactions, position) {
+    return new Promise((resolve, reject) =>
+      this.#fn.pending_inbound_transactions_get_at.async(
+        transactions,
+        position,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "pendingInboundTransactionsGetAt")
+      )
+    );
+  }
+  static pendingInboundTransactionsDestroy(transactions) {
+    return new Promise((resolve, reject) =>
+      this.#fn.pending_inbound_transactions_destroy.async(
+        transactions,
+        this.checkAsyncRes(resolve, reject, "pendingInboundTransactionsDestroy")
+      )
+    );
+  }
   static commsConfigCreate(
     public_address,
     transport,
     database_name,
     datastore_path,
     discovery_timeout_in_secs,
-    saf_message_duration_in_secs
+    saf_message_duration_in_secs,
+    network
   ) {
-    let comms_config = this.#fn.comms_config_create(
-      public_address,
-      transport,
-      database_name,
-      datastore_path,
-      discovery_timeout_in_secs,
-      saf_message_duration_in_secs,
-      this.error
+    return new Promise((resolve, reject) =>
+      this.#fn.comms_config_create.async(
+        public_address,
+        transport,
+        database_name,
+        datastore_path,
+        discovery_timeout_in_secs,
+        saf_message_duration_in_secs,
+        network,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "commsConfigCreate")
+      )
     );
-    this.checkError("commsConfigCreate");
-    return comms_config;
   }
-
-  /// -------------------------------- TariWallet ----------------------------------------------- //
-
+  static commsConfigDestroy(wc) {
+    return new Promise((resolve, reject) =>
+      this.#fn.comms_config_destroy.async(
+        wc,
+        this.checkAsyncRes(resolve, reject, "commsConfigDestroy")
+      )
+    );
+  }
   static walletCreate(
-    comms_config,
+    config,
     log_path,
     num_rolling_log_files,
     size_per_log_file_bytes,
     passphrase,
     seed_words
-    // callback_received_transaction
   ) {
-    let callback_received_transaction = ffi.Callback(
-      "void",
-      [this.tari_pending_inbound_transaction_ptr],
-      function (_pending_inbound_transcation) {
-        console.log("callback_received_transaction");
-      }
+    return new Promise((resolve, reject) =>
+      this.#fn.wallet_create.async(
+        config,
+        log_path,
+        num_rolling_log_files,
+        size_per_log_file_bytes,
+        passphrase,
+        seed_words,
+        this.#callback_received_transaction,
+        this.#callback_received_transaction_reply,
+        this.#callback_received_finalized_transaction,
+        this.#callback_transaction_broadcast,
+        this.#callback_transaction_mined,
+        this.#callback_transaction_mined_unconfirmed,
+        this.#callback_direct_send_result,
+        this.#callback_store_and_forward_send_result,
+        this.#callback_transaction_cancellation,
+        this.#callback_utxo_validation_complete,
+        this.#callback_stxo_validation_complete,
+        this.#callback_invalid_txo_validation_complete,
+        this.#callback_transaction_validation_complete,
+        this.#callback_saf_message_received,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "walletCreate")
+      )
     );
-    let callback_received_transaction_reply = ffi.Callback(
-      "void",
-      [this.tari_completed_transaction_ptr],
-      function (_completed_transaction) {
-        console.log("callback_received_transaction_reply");
-      }
-    );
-    let callback_received_finalized_transaction = ffi.Callback(
-      "void",
-      [this.tari_completed_transaction_ptr],
-      function (_completed_transaction) {
-        console.log("callback_received_finalized_transaction");
-      }
-    );
-    let callback_transaction_broadcast = ffi.Callback(
-      "void",
-      [this.tari_completed_transaction_ptr],
-      function (_completed_transaction) {
-        console.log("callback_transaction_broadcast");
-      }
-    );
-    let callback_transaction_mined = ffi.Callback(
-      "void",
-      [this.tari_completed_transaction_ptr],
-      function (_completed_transaction) {
-        console.log("callback_transaction_mined");
-      }
-    );
-    let callback_transaction_mined_unconfirmed = ffi.Callback(
-      "void",
-      [this.tari_completed_transaction_ptr, "long long"],
-      function (_completed_transaction, x) {
-        console.log("callback_transaction_mined_unconfirmed", x);
-      }
-    );
-    let callback_direct_send_result = ffi.Callback(
-      "void",
-      ["long long", "bool"],
-      function (x, y) {
-        console.log("callback_direct_send_result", x, y);
-      }
-    );
-    let callback_store_and_forward_send_result = ffi.Callback(
-      "void",
-      ["long long", "bool"],
-      function (x, y) {
-        console.log("callback_store_and_forward_send_result", x, y);
-      }
-    );
-    let callback_transaction_cancellation = ffi.Callback(
-      "void",
-      [this.tari_completed_transaction_ptr],
-      function (_completed_transaction) {
-        console.log("callback_transaction_cancellation");
-      }
-    );
-    let callback_utxo_validation_complete = ffi.Callback(
-      "void",
-      ["long long", "char"],
-      function (x, y) {
-        console.log("callback_utxo_validation_complete", x, y);
-      }
-    );
-    let callback_stxo_validation_complete = ffi.Callback(
-      "void",
-      ["long long", "char"],
-      function (x, y) {
-        console.log("callback_stxo_validation_complete", x, y);
-      }
-    );
-    let callback_invalid_txo_validation_complete = ffi.Callback(
-      "void",
-      ["long long", "char"],
-      function (x, y) {
-        console.log("callback_invalid_txo_validation_complete", x, y);
-      }
-    );
-    let callback_transaction_validation_complete = ffi.Callback(
-      "void",
-      ["long long", "char"],
-      function (x, y) {
-        console.log("callback_transaction_validation_complete", x, y);
-      }
-    );
-    let callback_saf_message_received = ffi.Callback("void", [], function () {
-      console.log("callback_saf_message_received");
-    });
-
-    let wallet = this.#fn.wallet_create(
-      comms_config,
-      log_path,
-      num_rolling_log_files,
-      size_per_log_file_bytes,
-      passphrase,
-      seed_words,
-      callback_received_transaction,
-      callback_received_transaction_reply,
-      callback_received_finalized_transaction,
-      callback_transaction_broadcast,
-      callback_transaction_mined,
-      callback_transaction_mined_unconfirmed,
-      callback_direct_send_result,
-      callback_store_and_forward_send_result,
-      callback_transaction_cancellation,
-      callback_utxo_validation_complete,
-      callback_stxo_validation_complete,
-      callback_invalid_txo_validation_complete,
-      callback_transaction_validation_complete,
-      callback_saf_message_received,
-      this.error
-    );
-
-    this.checkError("walletCreate");
-    return wallet;
   }
-
+  static walletSignMessage(wallet, msg) {
+    return new Promise((resolve, reject) =>
+      this.#fn.wallet_sign_message.async(
+        wallet,
+        msg,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "walletSignMessage")
+      )
+    );
+  }
+  static walletVerifyMessageSignature(wallet, public_key, hex_sig_nonce, msg) {
+    return new Promise((resolve, reject) =>
+      this.#fn.wallet_verify_message_signature.async(
+        wallet,
+        public_key,
+        hex_sig_nonce,
+        msg,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "walletVerifyMessageSignature")
+      )
+    );
+  }
+  static walletAddBaseNodePeer(wallet, public_key, address) {
+    return new Promise((resolve, reject) =>
+      this.#fn.wallet_add_base_node_peer.async(
+        wallet,
+        public_key,
+        address,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "walletAddBaseNodePeer")
+      )
+    );
+  }
+  static walletUpsertContact(wallet, contact) {
+    return new Promise((resolve, reject) =>
+      this.#fn.wallet_upsert_contact.async(
+        wallet,
+        contact,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "walletUpsertContact")
+      )
+    );
+  }
+  static walletRemoveContact(wallet, contact) {
+    return new Promise((resolve, reject) =>
+      this.#fn.wallet_remove_contact.async(
+        wallet,
+        contact,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "walletRemoveContact")
+      )
+    );
+  }
+  static walletGetAvailableBalance(wallet) {
+    return new Promise((resolve, reject) =>
+      this.#fn.wallet_get_available_balance.async(
+        wallet,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "walletGetAvailableBalance")
+      )
+    );
+  }
+  static walletGetPendingIncomingBalance(wallet) {
+    return new Promise((resolve, reject) =>
+      this.#fn.wallet_get_pending_incoming_balance.async(
+        wallet,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "walletGetPendingIncomingBalance")
+      )
+    );
+  }
+  static walletGetPendingOutgoingBalance(wallet) {
+    return new Promise((resolve, reject) =>
+      this.#fn.wallet_get_pending_outgoing_balance.async(
+        wallet,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "walletGetPendingOutgoingBalance")
+      )
+    );
+  }
+  static walletGetFeeEstimate(
+    wallet,
+    amount,
+    fee_per_gram,
+    num_kernels,
+    num_outputs
+  ) {
+    return new Promise((resolve, reject) =>
+      this.#fn.wallet_get_fee_estimate.async(
+        wallet,
+        amount,
+        fee_per_gram,
+        num_kernels,
+        num_outputs,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "walletGetFeeEstimate")
+      )
+    );
+  }
+  static walletGetNumConfirmationsRequired(wallet) {
+    return new Promise((resolve, reject) =>
+      this.#fn.wallet_get_num_confirmations_required.async(
+        wallet,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "walletGetNumConfirmationsRequired")
+      )
+    );
+  }
+  static walletSetNumConfirmationsRequired(wallet, num) {
+    return new Promise((resolve, reject) =>
+      this.#fn.wallet_set_num_confirmations_required.async(
+        wallet,
+        num,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "walletSetNumConfirmationsRequired")
+      )
+    );
+  }
+  static walletSendTransaction(
+    wallet,
+    destination,
+    amount,
+    fee_per_gram,
+    message
+  ) {
+    return new Promise((resolve, reject) =>
+      this.#fn.wallet_send_transaction.async(
+        wallet,
+        destination,
+        amount,
+        fee_per_gram,
+        message,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "walletSendTransaction")
+      )
+    );
+  }
+  static walletGetContacts(wallet) {
+    return new Promise((resolve, reject) =>
+      this.#fn.wallet_get_contacts.async(
+        wallet,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "walletGetContacts")
+      )
+    );
+  }
+  static walletGetCompletedTransactions(wallet) {
+    return new Promise((resolve, reject) =>
+      this.#fn.wallet_get_completed_transactions.async(
+        wallet,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "walletGetCompletedTransactions")
+      )
+    );
+  }
+  static walletGetPendingOutboundTransactions(wallet) {
+    return new Promise((resolve, reject) =>
+      this.#fn.wallet_get_pending_outbound_transactions.async(
+        wallet,
+        this.error,
+        this.checkAsyncRes(
+          resolve,
+          reject,
+          "walletGetPendingOutboundTransactions"
+        )
+      )
+    );
+  }
   static walletGetPublicKey(wallet) {
-    const public_key = this.#fn.wallet_get_public_key(wallet, this.error);
-    this.checkError("walletGetPublicKey");
-    return public_key;
+    return new Promise((resolve, reject) =>
+      this.#fn.wallet_get_public_key.async(
+        wallet,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "walletGetPublicKey")
+      )
+    );
   }
-
+  static walletGetPendingInboundTransactions(wallet) {
+    return new Promise((resolve, reject) =>
+      this.#fn.wallet_get_pending_inbound_transactions.async(
+        wallet,
+        this.error,
+        this.checkAsyncRes(
+          resolve,
+          reject,
+          "walletGetPendingInboundTransactions"
+        )
+      )
+    );
+  }
+  static walletGetCancelledTransactions(wallet) {
+    return new Promise((resolve, reject) =>
+      this.#fn.wallet_get_cancelled_transactions.async(
+        wallet,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "walletGetCancelledTransactions")
+      )
+    );
+  }
+  static walletGetCompletedTransactionById(wallet, transaction_id) {
+    return new Promise((resolve, reject) =>
+      this.#fn.wallet_get_completed_transaction_by_id.async(
+        wallet,
+        transaction_id,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "walletGetCompletedTransactionById")
+      )
+    );
+  }
+  static walletGetPendingOutboundTransactionById(wallet, transaction_id) {
+    return new Promise((resolve, reject) =>
+      this.#fn.wallet_get_pending_outbound_transaction_by_id.async(
+        wallet,
+        transaction_id,
+        this.error,
+        this.checkAsyncRes(
+          resolve,
+          reject,
+          "walletGetPendingOutboundTransactionById"
+        )
+      )
+    );
+  }
+  static walletGetPendingInboundTransactionById(wallet, transaction_id) {
+    return new Promise((resolve, reject) =>
+      this.#fn.wallet_get_pending_inbound_transaction_by_id.async(
+        wallet,
+        transaction_id,
+        this.error,
+        this.checkAsyncRes(
+          resolve,
+          reject,
+          "walletGetPendingInboundTransactionById"
+        )
+      )
+    );
+  }
+  static walletGetCancelledTransactionById(wallet, transaction_id) {
+    return new Promise((resolve, reject) =>
+      this.#fn.wallet_get_cancelled_transaction_by_id.async(
+        wallet,
+        transaction_id,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "walletGetCancelledTransactionById")
+      )
+    );
+  }
+  static walletImportUtxo(
+    wallet,
+    amount,
+    spending_key,
+    source_public_key,
+    message
+  ) {
+    return new Promise((resolve, reject) =>
+      this.#fn.wallet_import_utxo.async(
+        wallet,
+        amount,
+        spending_key,
+        source_public_key,
+        message,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "walletImportUtxo")
+      )
+    );
+  }
+  static walletStartUtxoValidation(wallet) {
+    return new Promise((resolve, reject) =>
+      this.#fn.wallet_start_utxo_validation.async(
+        wallet,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "walletStartUtxoValidation")
+      )
+    );
+  }
+  static walletStartStxoValidation(wallet) {
+    return new Promise((resolve, reject) =>
+      this.#fn.wallet_start_stxo_validation.async(
+        wallet,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "walletStartStxoValidation")
+      )
+    );
+  }
+  static walletStartInvalidTxoValidation(wallet) {
+    return new Promise((resolve, reject) =>
+      this.#fn.wallet_start_invalid_txo_validation.async(
+        wallet,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "walletStartInvalidTxoValidation")
+      )
+    );
+  }
+  static walletStartTransactionValidation(wallet) {
+    return new Promise((resolve, reject) =>
+      this.#fn.wallet_start_transaction_validation.async(
+        wallet,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "walletStartTransactionValidation")
+      )
+    );
+  }
+  static walletRestartTransactionBroadcast(wallet) {
+    return new Promise((resolve, reject) =>
+      this.#fn.wallet_restart_transaction_broadcast.async(
+        wallet,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "walletRestartTransactionBroadcast")
+      )
+    );
+  }
+  static walletSetLowPowerMode(wallet) {
+    return new Promise((resolve, reject) =>
+      this.#fn.wallet_set_low_power_mode.async(
+        wallet,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "walletSetLowPowerMode")
+      )
+    );
+  }
+  static walletSetNormalPowerMode(wallet) {
+    return new Promise((resolve, reject) =>
+      this.#fn.wallet_set_normal_power_mode.async(
+        wallet,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "walletSetNormalPowerMode")
+      )
+    );
+  }
+  static walletCancelPendingTransaction(wallet, transaction_id) {
+    return new Promise((resolve, reject) =>
+      this.#fn.wallet_cancel_pending_transaction.async(
+        wallet,
+        transaction_id,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "walletCancelPendingTransaction")
+      )
+    );
+  }
+  static walletCoinSplit(wallet, amount, count, fee, msg, lock_height) {
+    return new Promise((resolve, reject) =>
+      this.#fn.wallet_coin_split.async(
+        wallet,
+        amount,
+        count,
+        fee,
+        msg,
+        lock_height,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "walletCoinSplit")
+      )
+    );
+  }
+  static walletGetSeedWords(wallet) {
+    return new Promise((resolve, reject) =>
+      this.#fn.wallet_get_seed_words.async(
+        wallet,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "walletGetSeedWords")
+      )
+    );
+  }
+  static walletApplyEncryption(wallet, passphrase) {
+    return new Promise((resolve, reject) =>
+      this.#fn.wallet_apply_encryption.async(
+        wallet,
+        passphrase,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "walletApplyEncryption")
+      )
+    );
+  }
+  static walletRemoveEncryption(wallet) {
+    return new Promise((resolve, reject) =>
+      this.#fn.wallet_remove_encryption.async(
+        wallet,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "walletRemoveEncryption")
+      )
+    );
+  }
+  static walletSetKeyValue(wallet, key, value) {
+    return new Promise((resolve, reject) =>
+      this.#fn.wallet_set_key_value.async(
+        wallet,
+        key,
+        value,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "walletSetKeyValue")
+      )
+    );
+  }
+  static walletGetValue(wallet, key) {
+    return new Promise((resolve, reject) =>
+      this.#fn.wallet_get_value.async(
+        wallet,
+        key,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "walletGetValue")
+      )
+    );
+  }
+  static walletClearValue(wallet, key) {
+    return new Promise((resolve, reject) =>
+      this.#fn.wallet_clear_value.async(
+        wallet,
+        key,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "walletClearValue")
+      )
+    );
+  }
+  static walletIsRecoveryInProgress(wallet) {
+    return new Promise((resolve, reject) =>
+      this.#fn.wallet_is_recovery_in_progress.async(
+        wallet,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "walletIsRecoveryInProgress")
+      )
+    );
+  }
+  static walletStartRecovery(wallet, base_node_public_key) {
+    return new Promise((resolve, reject) =>
+      this.#fn.wallet_start_recovery.async(
+        wallet,
+        base_node_public_key,
+        this.#recovery_progress_callback,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "walletStartRecovery")
+      )
+    );
+  }
   static walletDestroy(wallet) {
-    this.#fn.wallet_destroy(wallet);
+    return new Promise((resolve, reject) =>
+      this.#fn.wallet_destroy.async(
+        wallet,
+        this.checkAsyncRes(resolve, reject, "walletDestroy")
+      )
+    );
+  }
+  static filePartialBackup(original_file_path, backup_file_path) {
+    return new Promise((resolve, reject) =>
+      this.#fn.file_partial_backup.async(
+        original_file_path,
+        backup_file_path,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "filePartialBackup")
+      )
+    );
+  }
+  static logDebugMessage(msg) {
+    return new Promise((resolve, reject) =>
+      this.#fn.log_debug_message.async(
+        msg,
+        this.checkAsyncRes(resolve, reject, "logDebugMessage")
+      )
+    );
+  }
+  static getEmojiSet() {
+    return new Promise((resolve, reject) =>
+      this.#fn.get_emoji_set.async(
+        this.checkAsyncRes(resolve, reject, "getEmojiSet")
+      )
+    );
+  }
+  static emojiSetDestroy(emoji_set) {
+    return new Promise((resolve, reject) =>
+      this.#fn.emoji_set_destroy.async(
+        emoji_set,
+        this.checkAsyncRes(resolve, reject, "emojiSetDestroy")
+      )
+    );
+  }
+  static emojiSetGetAt(emoji_set, position) {
+    return new Promise((resolve, reject) =>
+      this.#fn.emoji_set_get_at.async(
+        emoji_set,
+        position,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "emojiSetGetAt")
+      )
+    );
+  }
+  static emojiSetGetLength(emoji_set) {
+    return new Promise((resolve, reject) =>
+      this.#fn.emoji_set_get_length.async(
+        emoji_set,
+        this.error,
+        this.checkAsyncRes(resolve, reject, "emojiSetGetLength")
+      )
+    );
   }
 }
-
 module.exports = WalletFFI;

--- a/integration_tests/helpers/walletFFIClient.js
+++ b/integration_tests/helpers/walletFFIClient.js
@@ -1,6 +1,7 @@
 const WalletFFI = require("./walletFFI");
 const { getFreePort } = require("./util");
 const dateFormat = require("dateformat");
+const { expect } = require("chai");
 
 class WalletFFIClient {
   #name;
@@ -11,6 +12,23 @@ class WalletFFIClient {
   constructor(name) {
     this.#wallet = null;
     this.#name = name;
+    this.baseDir = "";
+  }
+
+  static async #convertPubkeyToHex(public_key) {
+    const bytes = await WalletFFI.publicKeyGetBytes(public_key);
+    const length = await WalletFFI.byteVectorGetLength(bytes);
+    const public_key_hex = (
+      await Promise.all(
+        Array(length)
+          .fill()
+          .map((_, i) => WalletFFI.byteVectorGetAt(bytes, i))
+      )
+    )
+      .map((byte) => byte.toString(16).padStart(2, "0"))
+      .join("");
+    await WalletFFI.byteVectorDestroy(bytes);
+    return public_key_hex;
   }
 
   static async Init() {
@@ -20,50 +38,163 @@ class WalletFFIClient {
   async startNew() {
     this.#port = await getFreePort(19000, 25000);
     const name = `WalletFFI${this.#port}-${this.#name}`;
-    const baseDir = `./temp/base_nodes/${dateFormat(
+    this.baseDir = `./temp/base_nodes/${dateFormat(
       new Date(),
       "yyyymmddHHMM"
     )}/${name}`;
-    const tcp = WalletFFI.transportTcpCreate(`/ip4/0.0.0.0/tcp/${this.#port}`);
-    this.#comms_config = WalletFFI.commsConfigCreate(
+    const tcp = await WalletFFI.transportTcpCreate(
+      `/ip4/0.0.0.0/tcp/${this.#port}`
+    );
+    this.#comms_config = await WalletFFI.commsConfigCreate(
       `/ip4/0.0.0.0/tcp/${this.#port}`,
       tcp,
       "wallet.dat",
-      baseDir,
+      this.baseDir,
       30,
-      600
+      600,
+      "localnet"
     );
-    this.#wallet = WalletFFI.walletCreate(
+    this.#wallet = await WalletFFI.walletCreate(
       this.#comms_config,
-      `${baseDir}/logs/wallet.log`,
-      5,
-      10240,
+      `${this.baseDir}/log/wallet.log`,
+      50,
+      102400,
       WalletFFI.NULL,
       WalletFFI.NULL
     );
   }
 
-  stop() {
-    WalletFFI.walletDestroy(this.#wallet);
+  async stop() {
+    await WalletFFI.walletDestroy(this.#wallet);
   }
 
-  getPublicKey() {
-    const public_key = WalletFFI.walletGetPublicKey(this.#wallet);
-    const bytes = WalletFFI.publicKeyGetBytes(public_key);
-    const length = WalletFFI.byteVectorGetLength(bytes);
-    let public_key_array = Array(length)
-      .fill()
-      .map((_, i) => WalletFFI.byteVectorGetAt(bytes, i));
-    WalletFFI.byteVectorDestroy(bytes);
-    WalletFFI.publicKeyDestroy(public_key);
-    return public_key_array;
+  async getPublicKey() {
+    const public_key = await WalletFFI.walletGetPublicKey(this.#wallet);
+    const pubkey_hex = await WalletFFIClient.#convertPubkeyToHex(public_key);
+    await WalletFFI.publicKeyDestroy(public_key);
+    return pubkey_hex;
   }
 
-  getEmojiId() {
-    const public_key = WalletFFI.walletGetPublicKey(this.#wallet);
-    let emoji_id = WalletFFI.publicKeyToEmojiId(public_key);
-    WalletFFI.publicKeyDestroy(public_key);
-    return emoji_id;
+  async getEmojiId() {
+    const public_key = await WalletFFI.walletGetPublicKey(this.#wallet);
+    const emoji_id = await WalletFFI.publicKeyToEmojiId(public_key);
+    const result = emoji_id.readCString();
+    await WalletFFI.stringDestroy(emoji_id);
+    await WalletFFI.publicKeyDestroy(public_key);
+    return result;
+  }
+
+  async getBalance() {
+    return await WalletFFI.walletGetAvailableBalance(this.#wallet);
+  }
+
+  async addBaseNodePeer(public_key_hex, address) {
+    const public_key = await WalletFFI.publicKeyFromHex(public_key_hex);
+    expect(
+      await WalletFFI.walletAddBaseNodePeer(this.#wallet, public_key, address)
+    ).to.be.true;
+    await WalletFFI.publicKeyDestroy(public_key);
+  }
+
+  async sendTransaction(destination, amount, fee_per_gram, message) {
+    const destinationPubkey = await WalletFFI.publicKeyFromHex(destination);
+    const result = await WalletFFI.walletSendTransaction(
+      this.#wallet,
+      destinationPubkey,
+      amount,
+      fee_per_gram,
+      message
+    );
+    await WalletFFI.publicKeyDestroy(destinationPubkey);
+    return result;
+  }
+
+  async applyEncryption(passphrase) {
+    await WalletFFI.walletApplyEncryption(this.#wallet, passphrase);
+  }
+
+  async getCompletedTransactions() {
+    const txs = await WalletFFI.walletGetCompletedTransactions(this.#wallet);
+    const length = await WalletFFI.completedTransactionsGetLength(txs);
+    let outbound = 0;
+    let inbound = 0;
+    for (let i = 0; i < length; ++i) {
+      const tx = await WalletFFI.completedTransactionsGetAt(txs, i);
+      if (await WalletFFI.completedTransactionIsOutbound(tx)) {
+        ++outbound;
+      } else {
+        ++inbound;
+      }
+      await WalletFFI.completedTransactionDestroy(tx);
+    }
+    await WalletFFI.completedTransactionsDestroy(txs);
+    return [outbound, inbound];
+  }
+
+  async getBroadcastTransactionsCount() {
+    let broadcast_tx_cnt = 0;
+    const txs = await WalletFFI.walletGetPendingOutboundTransactions(
+      this.#wallet
+    );
+    const length = await WalletFFI.pendingOutboundTransactionsGetLength(txs);
+    for (let i = 0; i < length; ++i) {
+      const tx = await WalletFFI.pendingOutboundTransactionsGetAt(txs, i);
+      const status = await WalletFFI.pendingOutboundTransactionGetStatus(tx);
+      await WalletFFI.pendingOutboundTransactionDestroy(tx);
+      if (status === 1) {
+        broadcast_tx_cnt += 1;
+      }
+    }
+    await WalletFFI.pendingOutboundTransactionsDestroy(txs);
+    return broadcast_tx_cnt;
+  }
+
+  async addContact(alias, pubkey_hex) {
+    const public_key = await WalletFFI.publicKeyFromHex(pubkey_hex);
+    const contact = await WalletFFI.contactCreate(alias, public_key);
+    await WalletFFI.publicKeyDestroy(public_key);
+    expect(await WalletFFI.walletUpsertContact(this.#wallet, contact)).to.be
+      .true;
+    await WalletFFI.contactDestroy(contact);
+  }
+
+  async #findContact(lookup_alias) {
+    const contacts = await WalletFFI.walletGetContacts(this.#wallet);
+    const length = await WalletFFI.contactsGetLength(contacts);
+    let contact;
+    for (let i = 0; i < length; ++i) {
+      contact = await WalletFFI.contactsGetAt(contacts, i);
+      const alias = await WalletFFI.contactGetAlias(contact);
+      const found = alias.readCString() === lookup_alias;
+      await WalletFFI.stringDestroy(alias);
+      if (found) {
+        break;
+      }
+      await WalletFFI.contactDestroy(contact);
+      contact = undefined;
+    }
+    await WalletFFI.contactsDestroy(contacts);
+    return contact;
+  }
+
+  async getContact(alias) {
+    const contact = await this.#findContact(alias);
+    if (contact) {
+      const pubkey = await WalletFFI.contactGetPublicKey(contact);
+      const pubkey_hex = await WalletFFIClient.#convertPubkeyToHex(pubkey);
+      await WalletFFI.publicKeyDestroy(pubkey);
+      await WalletFFI.contactDestroy(contact);
+      return pubkey_hex;
+    }
+  }
+
+  async removeContact(alias) {
+    const contact = await this.#findContact(alias);
+    if (contact) {
+      expect(await WalletFFI.walletRemoveContact(this.#wallet, contact)).to.be
+        .true;
+      await WalletFFI.contactDestroy(contact);
+    }
   }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adding more FFI test.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The ffi-napi is causing internal error (the pointers to the ffi functions gets invalidated) in nodejs when using the ffi destroy functions.
_v8::internal::Isolate::ArchiveSpacePerThread+4719_
The async calls is solving this (at least it looks like it from the tests I made).
The WalletFFI.js is now generated (the python code is not part of this PR, because it's a mess right now).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
npm test -- .\features\WalletFFI.feature

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I have squashed my commits into a single commit.
