### PR TITLE
fix: improve p2p RPC robustness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4486,6 +4486,7 @@ dependencies = [
  "serde_json",
  "snow",
  "tari_common",
+ "tari_comms_rpc_macros",
  "tari_crypto",
  "tari_shutdown",
  "tari_storage",

--- a/base_layer/wallet/src/connectivity_service/handle.rs
+++ b/base_layer/wallet/src/connectivity_service/handle.rs
@@ -66,7 +66,7 @@ impl WalletConnectivityHandle {
     /// Obtain a BaseNodeWalletRpcClient.
     ///
     /// This can be relied on to obtain a pooled BaseNodeWalletRpcClient rpc session from a currently selected base
-    /// node/nodes. It will be block until this is happens. The ONLY other time it will return is if the node is
+    /// node/nodes. It will block until this happens. The ONLY other time it will return is if the node is
     /// shutting down, where it will return None. Use this function whenever no work can be done without a
     /// BaseNodeWalletRpcClient RPC session.
     pub async fn obtain_base_node_wallet_rpc_client(&mut self) -> Option<RpcClientLease<BaseNodeWalletRpcClient>> {
@@ -89,7 +89,7 @@ impl WalletConnectivityHandle {
     /// Obtain a BaseNodeSyncRpcClient.
     ///
     /// This can be relied on to obtain a pooled BaseNodeSyncRpcClient rpc session from a currently selected base
-    /// node/nodes. It will be block until this is happens. The ONLY other time it will return is if the node is
+    /// node/nodes. It will block until this happens. The ONLY other time it will return is if the node is
     /// shutting down, where it will return None. Use this function whenever no work can be done without a
     /// BaseNodeSyncRpcClient RPC session.
     pub async fn obtain_base_node_sync_rpc_client(&mut self) -> Option<RpcClientLease<BaseNodeSyncRpcClient>> {

--- a/base_layer/wallet/src/connectivity_service/service.rs
+++ b/base_layer/wallet/src/connectivity_service/service.rs
@@ -242,8 +242,10 @@ impl WalletConnectivityService {
             conn.peer_node_id()
         );
         self.pools = Some(ClientPoolContainer {
-            base_node_sync_rpc_client: conn.create_rpc_client_pool(self.config.base_node_rpc_pool_size),
-            base_node_wallet_rpc_client: conn.create_rpc_client_pool(self.config.base_node_rpc_pool_size),
+            base_node_sync_rpc_client: conn
+                .create_rpc_client_pool(self.config.base_node_rpc_pool_size, Default::default()),
+            base_node_wallet_rpc_client: conn
+                .create_rpc_client_pool(self.config.base_node_rpc_pool_size, Default::default()),
         });
         self.notify_pending_requests().await?;
         debug!(

--- a/base_layer/wallet/tests/output_manager_service/service.rs
+++ b/base_layer/wallet/tests/output_manager_service/service.rs
@@ -1816,14 +1816,14 @@ fn test_txo_validation_rpc_timeout() {
         .unwrap();
 
     runtime.block_on(async {
-        let mut delay = delay_for(Duration::from_secs(60)).fuse();
+        let mut delay = delay_for(Duration::from_secs(100)).fuse();
         let mut failed = 0;
         loop {
             futures::select! {
                 event = event_stream.select_next_some() => {
                     if let Ok(msg) = event {
                          if let OutputManagerEvent::TxoValidationFailure(_,_) = (*msg).clone() {
-                         failed+=1;
+                             failed+=1;
                         }
                     }
 

--- a/comms/Cargo.toml
+++ b/comms/Cargo.toml
@@ -48,6 +48,7 @@ anyhow = "1.0.32"
 
 [dev-dependencies]
 tari_test_utils = {version="^0.9", path="../infrastructure/test_utils"}
+tari_comms_rpc_macros = {version="*", path="./rpc_macros"}
 
 env_logger = "0.7.0"
 serde_json = "1.0.39"

--- a/comms/src/builder/error.rs
+++ b/comms/src/builder/error.rs
@@ -36,7 +36,7 @@ pub enum CommsBuilderError {
     ConnectionManagerError(#[from] ConnectionManagerError),
     #[error("Node identity not set. Call `with_node_identity(node_identity)` on [CommsBuilder]")]
     NodeIdentityNotSet,
-    #[error("Shutdown signa not set. Call `with_shutdown_signal(shutdown_signal)` on [CommsBuilder]")]
+    #[error("Shutdown signal not set. Call `with_shutdown_signal(shutdown_signal)` on [CommsBuilder]")]
     ShutdownSignalNotSet,
     #[error("The PeerStorage was not provided to the CommsBuilder. Use `with_peer_storage` to set it.")]
     PeerStorageNotProvided,

--- a/comms/src/connection_manager/peer_connection.rs
+++ b/comms/src/connection_manager/peer_connection.rs
@@ -233,9 +233,15 @@ impl PeerConnection {
     /// Creates a new RpcClientPool that can be shared between tasks. The client pool will lazily establish up to
     /// `max_sessions` sessions and provides client session that is least used.
     #[cfg(feature = "rpc")]
-    pub fn create_rpc_client_pool<T>(&self, max_sessions: usize) -> RpcClientPool<T>
-    where T: RpcPoolClient + From<RpcClient> + NamedProtocolService + Clone {
-        RpcClientPool::new(self.clone(), max_sessions)
+    pub fn create_rpc_client_pool<T>(
+        &self,
+        max_sessions: usize,
+        client_config: RpcClientBuilder<T>,
+    ) -> RpcClientPool<T>
+    where
+        T: RpcPoolClient + From<RpcClient> + NamedProtocolService + Clone,
+    {
+        RpcClientPool::new(self.clone(), max_sessions, client_config)
     }
 
     /// Immediately disconnects the peer connection. This can only fail if the peer connection worker

--- a/comms/src/connectivity/manager.rs
+++ b/comms/src/connectivity/manager.rs
@@ -228,7 +228,7 @@ impl ConnectivityManagerActor {
                 _ => {
                     debug!(
                         target: LOG_TARGET,
-                        "No existing connection found for peer `{}`. Dialling...",
+                        "No existing connection found for peer `{}`. Dialing...",
                         node_id.short_str()
                     );
                     if let Err(err) = self.connection_manager.send_dial_peer(node_id, reply).await {
@@ -528,7 +528,7 @@ impl ConnectivityManagerActor {
                 num_failed
             );
             if self.peer_manager.set_offline(node_id, true).await? {
-                warn!(
+                debug!(
                     target: LOG_TARGET,
                     "Peer `{}` was marked as offline but was already offline.", node_id
                 );

--- a/comms/src/protocol/rpc/context.rs
+++ b/comms/src/protocol/rpc/context.rs
@@ -77,17 +77,26 @@ impl RpcCommsProvider for RpcCommsBackend {
 }
 
 pub struct RequestContext {
+    request_id: u32,
     backend: Box<dyn RpcCommsProvider>,
     node_id: NodeId,
 }
 
 impl RequestContext {
-    pub(super) fn new(node_id: NodeId, backend: Box<dyn RpcCommsProvider>) -> Self {
-        Self { backend, node_id }
+    pub(super) fn new(request_id: u32, node_id: NodeId, backend: Box<dyn RpcCommsProvider>) -> Self {
+        Self {
+            request_id,
+            backend,
+            node_id,
+        }
     }
 
     pub fn peer_node_id(&self) -> &NodeId {
         &self.node_id
+    }
+
+    pub fn request_id(&self) -> u32 {
+        self.request_id
     }
 
     pub(crate) async fn fetch_peer(&self) -> Result<Peer, RpcError> {

--- a/comms/src/protocol/rpc/error.rs
+++ b/comms/src/protocol/rpc/error.rs
@@ -45,6 +45,8 @@ pub enum RpcError {
     ServerClosedRequest,
     #[error("Request cancelled")]
     RequestCancelled,
+    #[error("Response did not match the request ID (expected {expected} actual {actual})")]
+    ResponseIdDidNotMatchRequest { expected: u16, actual: u16 },
     #[error("Client internal error: {0}")]
     ClientInternalError(String),
     #[error("Handshake error: {0}")]

--- a/comms/src/protocol/rpc/message.rs
+++ b/comms/src/protocol/rpc/message.rs
@@ -242,6 +242,10 @@ impl proto::rpc::RpcResponse {
     pub fn flags(&self) -> RpcMessageFlags {
         RpcMessageFlags::from_bits_truncate(self.flags as u8)
     }
+
+    pub fn is_fin(&self) -> bool {
+        self.flags as u8 & RpcMessageFlags::FIN.bits() != 0
+    }
 }
 
 impl fmt::Display for proto::rpc::RpcResponse {

--- a/comms/src/protocol/rpc/server/mock.rs
+++ b/comms/src/protocol/rpc/server/mock.rs
@@ -80,7 +80,7 @@ impl RpcRequestMock {
     }
 
     pub fn request_with_context<T>(&self, node_id: NodeId, msg: T) -> Request<T> {
-        let context = RequestContext::new(node_id, Box::new(self.comms_provider.clone()));
+        let context = RequestContext::new(0, node_id, Box::new(self.comms_provider.clone()));
         Request::with_context(context, 0.into(), msg)
     }
 

--- a/comms/src/protocol/rpc/status.rs
+++ b/comms/src/protocol/rpc/status.rs
@@ -36,21 +36,21 @@ pub struct RpcStatus {
 
 impl RpcStatus {
     pub fn ok() -> Self {
-        RpcStatus {
+        Self {
             code: RpcStatusCode::Ok,
             details: Default::default(),
         }
     }
 
     pub fn unsupported_method<T: ToString>(details: T) -> Self {
-        RpcStatus {
+        Self {
             code: RpcStatusCode::UnsupportedMethod,
             details: details.to_string(),
         }
     }
 
     pub fn not_implemented<T: ToString>(details: T) -> Self {
-        RpcStatus {
+        Self {
             code: RpcStatusCode::NotImplemented,
             details: details.to_string(),
         }
@@ -96,6 +96,13 @@ impl RpcStatus {
         move |err| {
             log::error!(target: target, "Internal error: {}", err);
             Self::general_default()
+        }
+    }
+
+    pub(super) fn protocol_error<T: ToString>(details: T) -> Self {
+        Self {
+            code: RpcStatusCode::ProtocolError,
+            details: details.to_string(),
         }
     }
 
@@ -177,6 +184,8 @@ pub enum RpcStatusCode {
     General = 6,
     /// Entity not found
     NotFound = 7,
+    /// RPC protocol error
+    ProtocolError = 8,
     // The following status represents anything that is not recognised (i.e not one of the above codes).
     /// Unrecognised RPC status code
     InvalidRpcStatusCode,

--- a/comms/tests/greeting_service.rs
+++ b/comms/tests/greeting_service.rs
@@ -1,0 +1,166 @@
+//  Copyright 2021, The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#![allow(dead_code)]
+#![cfg(feature = "rpc")]
+
+use core::iter;
+use futures::{channel::mpsc, stream, SinkExt, StreamExt};
+use std::{cmp, time::Duration};
+use tari_comms::{
+    async_trait,
+    protocol::rpc::{Request, Response, RpcStatus, Streaming},
+};
+use tari_comms_rpc_macros::tari_rpc;
+use tokio::{task, time};
+
+#[tari_rpc(protocol_name = b"t/greeting/1", server_struct = GreetingServer, client_struct = GreetingClient)]
+pub trait GreetingRpc: Send + Sync + 'static {
+    #[rpc(method = 1)]
+    async fn say_hello(&self, request: Request<SayHelloRequest>) -> Result<Response<SayHelloResponse>, RpcStatus>;
+    #[rpc(method = 2)]
+    async fn get_greetings(&self, request: Request<u32>) -> Result<Streaming<String>, RpcStatus>;
+    #[rpc(method = 3)]
+    async fn reply_with_msg_of_size(&self, request: Request<u64>) -> Result<Response<Vec<u8>>, RpcStatus>;
+    #[rpc(method = 4)]
+    async fn stream_large_items(
+        &self,
+        request: Request<StreamLargeItemsRequest>,
+    ) -> Result<Streaming<Vec<u8>>, RpcStatus>;
+    #[rpc(method = 5)]
+    async fn slow_response(&self, request: Request<u64>) -> Result<Response<()>, RpcStatus>;
+}
+
+pub struct GreetingService {
+    greetings: Vec<String>,
+}
+
+impl GreetingService {
+    pub const DEFAULT_GREETINGS: &'static [&'static str] =
+        &["Sawubona", "Jambo", "Bonjour", "Hello", "Molo", "Olá", "سلام", "你好"];
+
+    pub fn new(greetings: &[&str]) -> Self {
+        Self {
+            greetings: greetings.iter().map(ToString::to_string).collect(),
+        }
+    }
+}
+
+impl Default for GreetingService {
+    fn default() -> Self {
+        Self::new(Self::DEFAULT_GREETINGS)
+    }
+}
+
+#[async_trait]
+impl GreetingRpc for GreetingService {
+    async fn say_hello(&self, request: Request<SayHelloRequest>) -> Result<Response<SayHelloResponse>, RpcStatus> {
+        let msg = request.message();
+        let greeting = self
+            .greetings
+            .get(msg.language as usize)
+            .ok_or_else(|| RpcStatus::bad_request(format!("{} is not a valid language identifier", msg.language)))?;
+
+        let greeting = format!("{} {}", greeting, msg.name);
+        Ok(Response::new(SayHelloResponse { greeting }))
+    }
+
+    async fn get_greetings(&self, request: Request<u32>) -> Result<Streaming<String>, RpcStatus> {
+        let num = *request.message();
+        let (mut tx, rx) = mpsc::channel(num as usize);
+        let greetings = self.greetings[..cmp::min(num as usize + 1, self.greetings.len())].to_vec();
+        task::spawn(async move {
+            let iter = greetings.into_iter().map(Ok);
+            let mut stream = stream::iter(iter)
+                // "Extra" Result::Ok is to satisfy send_all
+                .map(Ok);
+            tx.send_all(&mut stream).await.unwrap();
+        });
+
+        Ok(Streaming::new(rx))
+    }
+
+    async fn reply_with_msg_of_size(&self, request: Request<u64>) -> Result<Response<Vec<u8>>, RpcStatus> {
+        let size = request.into_message() as usize;
+        Ok(Response::new(iter::repeat(0).take(size).collect()))
+    }
+
+    async fn stream_large_items(
+        &self,
+        request: Request<StreamLargeItemsRequest>,
+    ) -> Result<Streaming<Vec<u8>>, RpcStatus> {
+        let req_id = request.context().request_id();
+        let StreamLargeItemsRequest {
+            id,
+            item_size,
+            num_items,
+        } = request.into_message();
+        let (mut tx, rx) = mpsc::channel(10);
+        let t = std::time::Instant::now();
+        task::spawn(async move {
+            let item = iter::repeat(0u8).take(item_size as usize).collect::<Vec<_>>();
+            for (i, item) in iter::repeat_with(|| Ok(item.clone()))
+                .take(num_items as usize)
+                .enumerate()
+            {
+                tx.send(item).await.unwrap();
+                log::info!(
+                    "[{}] reqid: {} t={:.2?} sent {}/{}",
+                    id,
+                    req_id,
+                    t.elapsed(),
+                    i + 1,
+                    num_items
+                );
+            }
+        });
+        Ok(Streaming::new(rx))
+    }
+
+    async fn slow_response(&self, request: Request<u64>) -> Result<Response<()>, RpcStatus> {
+        time::delay_for(Duration::from_secs(request.into_message())).await;
+        Ok(Response::new(()))
+    }
+}
+
+#[derive(prost::Message)]
+pub struct SayHelloRequest {
+    #[prost(string, tag = "1")]
+    pub name: String,
+    #[prost(uint32, tag = "2")]
+    pub language: u32,
+}
+
+#[derive(prost::Message)]
+pub struct SayHelloResponse {
+    #[prost(string, tag = "1")]
+    pub greeting: String,
+}
+
+#[derive(prost::Message)]
+pub struct StreamLargeItemsRequest {
+    #[prost(uint64, tag = "1")]
+    pub id: u64,
+    #[prost(uint64, tag = "2")]
+    pub num_items: u64,
+    #[prost(uint64, tag = "3")]
+    pub item_size: u64,
+}

--- a/comms/tests/helpers.rs
+++ b/comms/tests/helpers.rs
@@ -1,0 +1,62 @@
+//  Copyright 2021, The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use rand::rngs::OsRng;
+use std::sync::Arc;
+use tari_comms::{peer_manager::PeerFeatures, types::CommsDatabase, CommsBuilder, NodeIdentity, UnspawnedCommsNode};
+use tari_shutdown::ShutdownSignal;
+use tari_storage::{
+    lmdb_store::{LMDBBuilder, LMDBConfig},
+    LMDBWrapper,
+};
+use tari_test_utils::{paths::create_temporary_data_path, random};
+
+pub fn create_peer_storage() -> CommsDatabase {
+    let database_name = random::string(8);
+    let datastore = LMDBBuilder::new()
+        .set_path(create_temporary_data_path())
+        .set_env_config(LMDBConfig::default())
+        .set_max_number_of_databases(1)
+        .add_database(&database_name, lmdb_zero::db::CREATE)
+        .build()
+        .unwrap();
+
+    let peer_database = datastore.get_handle(&database_name).unwrap();
+    LMDBWrapper::new(Arc::new(peer_database))
+}
+
+pub fn create_comms(signal: ShutdownSignal) -> UnspawnedCommsNode {
+    let node_identity = Arc::new(NodeIdentity::random(
+        &mut OsRng,
+        "/ip4/127.0.0.1/tcp/0".parse().unwrap(),
+        PeerFeatures::COMMUNICATION_NODE,
+    ));
+
+    CommsBuilder::new()
+        .allow_test_addresses()
+        .with_listener_address("/ip4/127.0.0.1/tcp/0".parse().unwrap())
+        .with_node_identity(node_identity)
+        .with_peer_storage(create_peer_storage(), None)
+        .with_shutdown_signal(signal)
+        .build()
+        .unwrap()
+}

--- a/comms/tests/rpc_stress.rs
+++ b/comms/tests/rpc_stress.rs
@@ -1,0 +1,290 @@
+//  Copyright 2021, The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#![cfg(feature = "rpc")]
+
+// Run as normal, --nocapture for some extra output
+// cargo test --package tari_comms --test rpc_stress run  --all-features --release -- --exact --nocapture
+
+mod greeting_service;
+use greeting_service::{GreetingClient, GreetingServer, GreetingService, StreamLargeItemsRequest};
+
+mod helpers;
+use helpers::create_comms;
+
+use futures::{future, StreamExt};
+use std::{env, future::Future, time::Duration};
+use tari_comms::{
+    protocol::rpc::{RpcClientBuilder, RpcServer},
+    transports::TcpTransport,
+    CommsNode,
+};
+use tari_shutdown::{Shutdown, ShutdownSignal};
+use tokio::{task, time::Instant};
+
+pub async fn spawn_node(signal: ShutdownSignal) -> CommsNode {
+    let rpc_server = RpcServer::builder()
+        .with_unlimited_simultaneous_sessions()
+        .finish()
+        .add_service(GreetingServer::new(GreetingService::default()));
+
+    let comms = create_comms(signal)
+        .add_rpc_server(rpc_server)
+        .spawn_with_transport(TcpTransport::new())
+        .await
+        .unwrap();
+
+    comms
+        .node_identity()
+        .set_public_address(comms.listening_address().clone());
+    comms
+}
+
+async fn run_stress_test(test_params: Params) {
+    let Params {
+        num_tasks,
+        num_concurrent_sessions,
+        deadline,
+        payload_size,
+        num_items,
+    } = test_params;
+
+    let time = Instant::now();
+    assert!(
+        num_tasks >= num_concurrent_sessions,
+        "concurrent tasks must be more than concurrent sessions, otherwise the (lazy) pool wont make the given number \
+         of sessions"
+    );
+    println!(
+        "RPC stress test will transfer a total of {} MiB of data",
+        (num_tasks * payload_size * num_items) / (1024 * 1024)
+    );
+    log::info!(
+        "RPC stress test will transfer a total of {} MiB of data",
+        (num_tasks * payload_size * num_items) / (1024 * 1024)
+    );
+
+    let shutdown = Shutdown::new();
+    let node1 = spawn_node(shutdown.to_signal()).await;
+    let node2 = spawn_node(shutdown.to_signal()).await;
+
+    node1
+        .peer_manager()
+        .add_peer(node2.node_identity().to_peer())
+        .await
+        .unwrap();
+
+    let conn1_2 = node1
+        .connectivity()
+        .dial_peer(node2.node_identity().node_id().clone())
+        .await
+        .unwrap();
+
+    let client_pool = conn1_2.create_rpc_client_pool::<GreetingClient>(
+        num_concurrent_sessions,
+        RpcClientBuilder::new().with_deadline(deadline),
+    );
+
+    let mut tasks = Vec::with_capacity(num_tasks);
+    for i in 0..num_tasks {
+        let pool = client_pool.clone();
+        tasks.push(task::spawn(async move {
+            let mut client = pool.get().await.unwrap();
+            // let mut stream = client
+            //     .get_greetings(GreetingService::DEFAULT_GREETINGS.len() as u32)
+            //     .await
+            //     .unwrap();
+            // let mut count = 0;
+            // while let Some(Ok(_)) = stream.next().await {
+            //     count += 1;
+            // }
+            // assert_eq!(count, GreetingService::DEFAULT_GREETINGS.len());
+
+            // let err = client.slow_response(5).await.unwrap_err();
+            // unpack_enum!(RpcError::RequestFailed(err) = err);
+            // assert_eq!(err.status_code(), RpcStatusCode::Timeout);
+
+            // let msg = client.reply_with_msg_of_size(1024).await.unwrap();
+            // assert_eq!(msg.len(), 1024);
+
+            let time = std::time::Instant::now();
+            log::info!("[{}] start {:.2?}", i, time.elapsed(),);
+            let mut stream = client
+                .stream_large_items(StreamLargeItemsRequest {
+                    id: i as u64,
+                    num_items: num_items as u64,
+                    item_size: payload_size as u64,
+                })
+                .await
+                .unwrap();
+
+            log::info!("[{}] got stream {:.2?}", i, time.elapsed());
+            let mut count = 0;
+            while let Some(r) = stream.next().await {
+                count += 1;
+                log::info!(
+                    "[{}] (count = {}) consuming stream {:.2?} : {}",
+                    i,
+                    count,
+                    time.elapsed(),
+                    r.as_ref().err().map(ToString::to_string).unwrap_or_else(String::new)
+                );
+
+                let _ = r.unwrap();
+            }
+            assert_eq!(count, num_items);
+        }));
+    }
+
+    future::join_all(tasks).await.into_iter().for_each(Result::unwrap);
+    log::info!("Stress test took {:.2?}", time.elapsed());
+}
+
+struct Params {
+    pub num_tasks: usize,
+    pub num_concurrent_sessions: usize,
+    pub deadline: Duration,
+    pub payload_size: usize,
+    pub num_items: usize,
+}
+
+async fn quick() {
+    run_stress_test(Params {
+        num_tasks: 10,
+        num_concurrent_sessions: 10,
+        deadline: Duration::from_secs(5),
+        payload_size: 1024,
+        num_items: 10,
+    })
+    .await;
+}
+
+async fn basic() {
+    run_stress_test(Params {
+        num_tasks: 10,
+        num_concurrent_sessions: 5,
+        deadline: Duration::from_secs(15),
+        payload_size: 1024 * 1024,
+        num_items: 4,
+    })
+    .await;
+}
+
+#[allow(dead_code)]
+async fn many_small_messages() {
+    run_stress_test(Params {
+        num_tasks: 10,
+        num_concurrent_sessions: 10,
+        deadline: Duration::from_secs(5),
+        payload_size: 1024,
+        num_items: 10 * 1024,
+    })
+    .await;
+}
+
+async fn few_large_messages() {
+    run_stress_test(Params {
+        num_tasks: 10,
+        num_concurrent_sessions: 10,
+        deadline: Duration::from_secs(5),
+        payload_size: 1024 * 1024,
+        num_items: 10,
+    })
+    .await;
+}
+
+async fn payload_limit() {
+    run_stress_test(Params {
+        num_tasks: 50,
+        num_concurrent_sessions: 10,
+        deadline: Duration::from_secs(20),
+        payload_size: 4 * 1024 * 1024 - 100,
+        num_items: 2,
+    })
+    .await;
+}
+
+async fn high_contention() {
+    run_stress_test(Params {
+        num_tasks: 1000,
+        num_concurrent_sessions: 10,
+        deadline: Duration::from_secs(15),
+        payload_size: 1024 * 1024,
+        num_items: 4,
+    })
+    .await;
+}
+
+async fn high_concurrency() {
+    run_stress_test(Params {
+        num_tasks: 1000,
+        num_concurrent_sessions: 1000,
+        deadline: Duration::from_secs(15),
+        payload_size: 1024 * 1024,
+        num_items: 4,
+    })
+    .await;
+}
+
+async fn high_contention_high_concurrency() {
+    run_stress_test(Params {
+        num_tasks: 2000,
+        num_concurrent_sessions: 1000,
+        deadline: Duration::from_secs(15),
+        payload_size: 1024 * 1024,
+        num_items: 4,
+    })
+    .await;
+}
+
+#[tokio_macros::test]
+async fn run_ci() {
+    log_timing("quick", quick()).await;
+    log_timing("basic", basic()).await;
+    log_timing("many_small_messages", many_small_messages()).await;
+    log_timing("few_large_messages", few_large_messages()).await;
+}
+
+#[tokio_macros::test]
+async fn run() {
+    if env::var("CI").is_ok() {
+        println!("Skipping the stress test on CI");
+        return;
+    }
+    // let _ = env_logger::try_init();
+    log_timing("quick", quick()).await;
+    log_timing("basic", basic()).await;
+    log_timing("many_small_messages", many_small_messages()).await;
+    log_timing("few_large_messages", few_large_messages()).await;
+    log_timing("payload_limit", payload_limit()).await;
+    log_timing("high_contention", high_contention()).await;
+    log_timing("high_concurrency", high_concurrency()).await;
+    log_timing("high_contention_high_concurrency", high_contention_high_concurrency()).await;
+}
+
+async fn log_timing<R, F: Future<Output = R>>(name: &str, fut: F) -> R {
+    let t = Instant::now();
+    println!("'{}' is running...", name);
+    let ret = fut.await;
+    let elapsed = t.elapsed();
+    println!("'{}' completed in {:.2}s", name, elapsed.as_secs_f32());
+    ret
+}

--- a/comms/tests/substream_stress.rs
+++ b/comms/tests/substream_stress.rs
@@ -1,0 +1,160 @@
+//  Copyright 2021, The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+mod helpers;
+use helpers::create_comms;
+
+use futures::{channel::mpsc, future, SinkExt, StreamExt};
+use std::time::Duration;
+use tari_comms::{
+    framing,
+    protocol::{ProtocolEvent, ProtocolId, ProtocolNotificationRx},
+    transports::TcpTransport,
+    BytesMut,
+    CommsNode,
+    Substream,
+};
+use tari_shutdown::{Shutdown, ShutdownSignal};
+use tari_test_utils::unpack_enum;
+use tokio::{task, time::Instant};
+
+const PROTOCOL_NAME: &[u8] = b"test/dummy/protocol";
+
+pub async fn spawn_node(signal: ShutdownSignal) -> (CommsNode, ProtocolNotificationRx<Substream>) {
+    let (notif_tx, notif_rx) = mpsc::channel(1);
+    let comms = create_comms(signal)
+        .add_protocol(&[ProtocolId::from_static(PROTOCOL_NAME)], notif_tx)
+        .spawn_with_transport(TcpTransport::new())
+        .await
+        .unwrap();
+
+    comms
+        .node_identity()
+        .set_public_address(comms.listening_address().clone());
+    (comms, notif_rx)
+}
+
+async fn run_stress_test(num_substreams: usize, num_iterations: usize, payload_size: usize, frame_size: usize) {
+    let shutdown = Shutdown::new();
+    let (node1, _) = spawn_node(shutdown.to_signal()).await;
+    let (node2, mut notif_rx) = spawn_node(shutdown.to_signal()).await;
+
+    node1
+        .peer_manager()
+        .add_peer(node2.node_identity().to_peer())
+        .await
+        .unwrap();
+
+    let mut conn = node1
+        .connectivity()
+        .dial_peer(node2.node_identity().node_id().clone())
+        .await
+        .unwrap();
+
+    let sample = {
+        let mut buf = BytesMut::with_capacity(payload_size);
+        buf.fill(1);
+        buf.freeze()
+    };
+
+    task::spawn({
+        let sample = sample.clone();
+        async move {
+            while let Some(event) = notif_rx.next().await {
+                unpack_enum!(ProtocolEvent::NewInboundSubstream(_n, remote_substream) = event.event);
+                let mut remote_substream = framing::canonical(remote_substream, frame_size);
+
+                task::spawn({
+                    let sample = sample.clone();
+                    async move {
+                        let mut count = 0;
+                        while let Some(r) = remote_substream.next().await {
+                            r.unwrap();
+                            count += 1;
+                            remote_substream.send(sample.clone()).await.unwrap();
+
+                            if count == num_iterations {
+                                break;
+                            }
+                        }
+
+                        assert_eq!(count, num_iterations);
+                    }
+                });
+            }
+        }
+    });
+
+    let mut substreams = Vec::with_capacity(num_substreams);
+    for _ in 0..num_substreams {
+        let substream = conn
+            .open_framed_substream(&ProtocolId::from_static(PROTOCOL_NAME), frame_size)
+            .await
+            .unwrap();
+        substreams.push(substream);
+    }
+
+    let tasks = substreams
+        .into_iter()
+        .enumerate()
+        .map(|(id, mut substream)| {
+            let sample = sample.clone();
+            task::spawn(async move {
+                let mut count = 1;
+                // Send first to get the ball rolling
+                substream.send(sample.clone()).await.unwrap();
+                let mut total_time = Duration::from_secs(0);
+                while let Some(r) = substream.next().await {
+                    r.unwrap();
+                    count += 1;
+                    let t = Instant::now();
+                    substream.send(sample.clone()).await.unwrap();
+                    total_time += t.elapsed();
+                    if count == num_iterations {
+                        break;
+                    }
+                }
+
+                println!("[task {}] send time = {:.2?}", id, total_time,);
+                assert_eq!(count, num_iterations);
+                total_time
+            })
+        })
+        .collect::<Vec<_>>();
+
+    let send_latencies = future::join_all(tasks)
+        .await
+        .into_iter()
+        .map(Result::unwrap)
+        .collect::<Vec<_>>();
+    let avg = send_latencies.iter().sum::<Duration>().as_millis() / send_latencies.len() as u128;
+    println!("avg t = {}ms", avg);
+}
+
+#[tokio_macros::test]
+async fn many_at_frame_limit() {
+    const NUM_SUBSTREAMS: usize = 20;
+    const NUM_ITERATIONS_PER_STREAM: usize = 100;
+    const MAX_FRAME_SIZE: usize = 4 * 1024 * 1024;
+    const PAYLOAD_SIZE: usize = 4 * 1024 * 1024;
+    run_stress_test(NUM_SUBSTREAMS, NUM_ITERATIONS_PER_STREAM, PAYLOAD_SIZE, MAX_FRAME_SIZE).await;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Correctly handles edge case where the client can receive a response after
  the deadline + grace period has expired due to extreme latency. 
- Minor code simplifications
- Adds substream and RPC stress tests to comms
- Increase client-side deadline grace period. This is needed because at
  any point we could be transferring a lot of data, causing delays,
  which the client must tolerate.
- Minor performance optimisations (e.g removed usage of `.split()` which uses a BiLock)
- Change `was marked as offline but was already offline` to debug message

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Part of investigating RPC timeouts and RPC "getting into a bad state".

**Summary**

Basically what we're seeing is the limits of what the transport sockets (tor/tcp + noise + yamux) are able to provide.
I believe that the amount of data transferred often during DHT peer exchange + wallet UTXO sync + messaging + whatever else results in large delays that result in timeouts. The delays can result in the server sending a response before the deadline and the client receiving the response after the deadline + grace period - so I've increased the grace period. IMO we need to look at how we can reduce data transmission, possible prime targets are UTXO sync and reducing the data usage of DHT network discovery (less peers transferred, less often, optimal set reconciliation etc). Other potential optimisations may exist in the noise protocol implementation and yamux.

**Stress tests observations**

- Streaming ~100Mb over a local connection, the server can take many seconds (1s-15s) to transmit the data when with some contention. There is nothing unexpected about this, however I set a 4 second timeout with 200ms grace period and some contention over the socket, and so was seeing timeouts that I erroneously did not expect.
- ~~Reliability and performance appears better with many small messages than with fewer large payloads~~ 
- Performance is many times better in release mode, this is most likely because of the cryptography used in stream cipher of the noise protocol

```
running 1 test
'quick' is running...
'quick' completed in 0.01s
'basic' is running...
'basic' completed in 0.27s
'many_small_messages' is running...
'many_small_messages' completed in 1.69s
'few_large_messages' is running...
'few_large_messages' completed in 0.63s
'payload_limit' is running...
'payload_limit' completed in 3.15s
'high_contention' is running...
'high_contention' completed in 25.45s
'high_concurrency' is running...
'high_concurrency' completed in 41.70s
'high_contention_high_concurrency' is running...
'high_contention_high_concurrency' completed in 82.73s
test run ... ok
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Stress tests test noise protocol + muxer + rpc performance

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I have squashed my commits into a single commit.
