### PR TITLE
fix(wallet_ffi)add null check for `transport_type` in `create_comms_config` FFI function

### DIFF
--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -2600,6 +2600,12 @@ pub unsafe extern "C" fn comms_config_create(
     }
     let datastore_path = PathBuf::from(datastore_path_string);
 
+    if transport_type.is_null() {
+        error = LibWalletError::from(InterfaceError::NullError("transport_type".to_string())).code;
+        ptr::swap(error_out, &mut error as *mut c_int);
+        return ptr::null_mut();
+    }
+
     let dht_database_path = datastore_path.join("dht.db");
 
     let public_address = public_address_str.parse::<Multiaddr>();


### PR DESCRIPTION
## Description
The `transport_type` argument is not checked is it null before it is used in this method. This PR adds the check and appropriate error response.

## How Has This Been Tested?
Not tested

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I have squashed my commits into a single commit.
