### PR TITLE
Add extra logging detail for wiremode warnings

### DIFF
--- a/comms/src/connection_manager/wire_mode.rs
+++ b/comms/src/connection_manager/wire_mode.rs
@@ -22,7 +22,7 @@
 
 use std::convert::TryFrom;
 
-const LIVENESS_WIRE_MODE: u8 = 0x46; // E
+pub(crate) const LIVENESS_WIRE_MODE: u8 = 0x46; // E
 
 pub enum WireMode {
     Comms(u8),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Minor log warning improvements for the case where a wire format byte is not received 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Adding more log info for some observed warnings 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Replaced existing base node and started syncing a new node successfully 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I have squashed my commits into a single commit.
