### PR TITLE
fix: exit command and free up tokio thread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5060,7 +5060,7 @@ dependencies = [
 
 [[package]]
 name = "tari_wallet_ffi"
-version = "0.17.3"
+version = "0.17.4"
 dependencies = [
  "chrono",
  "env_logger 0.7.1",


### PR DESCRIPTION
Description
---
Exit command didn't exit the cli loop.
Rustyline was holding up a tokio thread - used a blocking thread instead

Motivation and Context
---
Bug

How Has This Been Tested?
---
Manually on base node
