### PR TITLE
test: add tracing to comms via --tracing-enabled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2061,6 +2061,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "integer-encoding"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48dc51180a9b377fd75814d0cc02199c20f8e99433d6762f650d39cdbbd3b56f"
+
+[[package]]
 name = "iovec"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2888,6 +2894,49 @@ dependencies = [
  "openssl-src",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "opentelemetry"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf9b1c4e9a6c4de793c632496fa490bdc0e1eea73f0c91394f7b6990935d22"
+dependencies = [
+ "async-trait",
+ "crossbeam-channel 0.5.1",
+ "futures 0.3.15",
+ "js-sys",
+ "lazy_static 1.4.0",
+ "percent-encoding 2.1.0",
+ "pin-project 1.0.7",
+ "rand 0.8.4",
+ "thiserror",
+ "tokio 1.9.0",
+ "tokio-stream",
+]
+
+[[package]]
+name = "opentelemetry-jaeger"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db22f492873ea037bc267b35a0e8e4fb846340058cb7c864efe3d0bf23684593"
+dependencies = [
+ "async-trait",
+ "lazy_static 1.4.0",
+ "opentelemetry",
+ "opentelemetry-semantic-conventions",
+ "thiserror",
+ "thrift",
+ "tokio 1.9.0",
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffeac823339e8b0f27b961f4385057bf9f97f2863bc745bd015fd6091f2270e9"
+dependencies = [
+ "opentelemetry",
 ]
 
 [[package]]
@@ -4438,6 +4487,8 @@ dependencies = [
  "config",
  "futures 0.3.15",
  "log 0.4.14",
+ "opentelemetry",
+ "opentelemetry-jaeger",
  "regex",
  "rustyline",
  "rustyline-derive",
@@ -4458,6 +4509,9 @@ dependencies = [
  "thiserror",
  "tokio 0.2.25",
  "tonic",
+ "tracing",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -4491,6 +4545,8 @@ dependencies = [
  "git2",
  "log 0.4.14",
  "log4rs 1.0.0",
+ "opentelemetry",
+ "opentelemetry-jaeger",
  "parity-multiaddr",
  "path-clean",
  "prost-build",
@@ -4502,6 +4558,9 @@ dependencies = [
  "tari_test_utils",
  "tempfile",
  "toml 0.5.8",
+ "tracing",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -4536,6 +4595,8 @@ dependencies = [
  "log 0.4.14",
  "nom 5.1.2",
  "openssl",
+ "opentelemetry",
+ "opentelemetry-jaeger",
  "parity-multiaddr",
  "pin-project 0.4.28",
  "prost",
@@ -4554,9 +4615,11 @@ dependencies = [
  "thiserror",
  "tokio 0.2.25",
  "tokio-macros",
- "tokio-util 0.2.0",
+ "tokio-util 0.3.1",
  "tower",
  "tower-make",
+ "tracing",
+ "tracing-futures",
  "yamux",
 ]
 
@@ -4633,6 +4696,8 @@ dependencies = [
  "crossterm",
  "futures 0.3.15",
  "log 0.4.14",
+ "opentelemetry",
+ "opentelemetry-jaeger",
  "qrcode",
  "rand 0.8.4",
  "regex",
@@ -4654,6 +4719,9 @@ dependencies = [
  "thiserror",
  "tokio 0.2.25",
  "tonic",
+ "tracing",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
  "tui",
  "unicode-segmentation",
  "unicode-width",
@@ -4705,6 +4773,9 @@ dependencies = [
  "thiserror",
  "tokio 0.2.25",
  "tokio-macros",
+ "tracing",
+ "tracing-attributes",
+ "tracing-futures",
  "ttl_cache",
  "uint",
 ]
@@ -5173,6 +5244,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
+]
+
+[[package]]
+name = "thrift"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6d965454947cc7266d22716ebfd07b18d84ebaf35eec558586bbb2a8cb6b5b"
+dependencies = [
+ "byteorder",
+ "integer-encoding",
+ "log 0.4.14",
+ "ordered-float 1.1.1",
+ "threadpool",
+]
+
+[[package]]
 name = "time"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5278,6 +5371,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2f3f698253f03119ac0102beaa64f67a67e08074d03a22d18784104543727f"
+dependencies = [
+ "futures-core",
+ "pin-project-lite 0.2.7",
+ "tokio 1.9.0",
+]
+
+[[package]]
 name = "tokio-test"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5295,20 +5399,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a70f4fcd7b3b24fb194f837560168208f669ca8cb70d0c4b862944452396343"
 dependencies = [
  "native-tls",
- "tokio 0.2.25",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "571da51182ec208780505a32528fc5512a8fe1443ab960b3f2f3ef093cd16930"
-dependencies = [
- "bytes 0.5.6",
- "futures-core",
- "futures-sink",
- "log 0.4.14",
- "pin-project-lite 0.1.12",
  "tokio 0.2.25",
 ]
 
@@ -5647,6 +5737,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-opentelemetry"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "599f388ecb26b28d9c1b2e4437ae019a7b336018b45ed911458cd9ebf91129f6"
+dependencies = [
+ "opentelemetry",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-serde"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5658,9 +5761,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.19"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab69019741fca4d98be3c62d2b75254528b5432233fd8a4d2739fec20278de48"
+checksum = "b9cbe87a2fa7e35900ce5de20220a582a9483a7063811defce79d7cbd59d4cfe"
 dependencies = [
  "ansi_term 0.12.1",
  "chrono",

--- a/applications/tari_base_node/Cargo.toml
+++ b/applications/tari_base_node/Cargo.toml
@@ -35,6 +35,13 @@ strum = "^0.19"
 strum_macros = "0.18.0"
 thiserror = "^1.0.20"
 tonic = "0.2"
+tracing = "0.1.26"
+tracing-opentelemetry = "0.15.0"
+tracing-subscriber = "0.2.20"
+
+# network tracing, rt-tokio for async batch export
+opentelemetry = { version = "0.16", default-features = false, features = ["trace","rt-tokio"] }
+opentelemetry-jaeger = { version="0.15", features=["rt-tokio"]}
 
 [features]
 avx2 = ["tari_core/avx2", "tari_crypto/avx2", "tari_p2p/avx2", "tari_wallet/avx2", "tari_comms/avx2", "tari_comms_dht/avx2"]

--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -67,6 +67,7 @@ pub struct BaseNodeContext {
 impl BaseNodeContext {
     /// Starts the node container. This entails the base node state machine.
     /// This call consumes the NodeContainer instance.
+    #[tracing::instrument(name = "base_node::run", skip(self))]
     pub async fn run(self) {
         info!(target: LOG_TARGET, "Tari base node has STARTED");
 

--- a/applications/tari_console_wallet/Cargo.toml
+++ b/applications/tari_console_wallet/Cargo.toml
@@ -35,6 +35,15 @@ tokio = { version="0.2.10", features = ["signal"] }
 thiserror = "1.0.20"
 tonic = "0.2"
 
+tracing = "0.1.26"
+tracing-opentelemetry = "0.15.0"
+tracing-subscriber = "0.2.20"
+
+# network tracing, rt-tokio for async batch export
+opentelemetry = { version = "0.16", default-features = false, features = ["trace","rt-tokio"] }
+opentelemetry-jaeger = { version="0.15", features=["rt-tokio"]}
+
+
 [dependencies.tari_core]
 path = "../../base_layer/core"
 version = "^0.9"

--- a/applications/tari_console_wallet/src/main.rs
+++ b/applications/tari_console_wallet/src/main.rs
@@ -19,12 +19,14 @@ use init::{
     WalletBoot,
 };
 use log::*;
+use opentelemetry::{self, global, KeyValue};
 use recovery::prompt_private_key_from_seed_words;
-use std::process;
+use std::{env, process};
 use tari_app_utilities::{consts, initialization::init_configuration, utilities::ExitCodes};
 use tari_common::{configuration::bootstrap::ApplicationType, ConfigBootstrap};
 use tari_core::transactions::types::PrivateKey;
 use tari_shutdown::Shutdown;
+use tracing_subscriber::{layer::SubscriberExt, Registry};
 use wallet_modes::{command_mode, grpc_mode, recovery_mode, script_mode, tui_mode, WalletMode};
 
 pub const LOG_TARGET: &str = "wallet::console_wallet::main";
@@ -90,6 +92,7 @@ fn main_inner() -> Result<(), ExitCodes> {
         info!(target: LOG_TARGET, "Default configuration created. Done.");
     }
 
+    enable_tracing_if_specified(&bootstrap);
     // get command line password if provided
     let arg_password = bootstrap.password.clone();
     let seed_words_file_name = bootstrap.seed_words_file_name.clone();
@@ -183,5 +186,24 @@ fn get_recovery_master_key(
         Ok(Some(private_key))
     } else {
         Ok(None)
+    }
+}
+
+fn enable_tracing_if_specified(bootstrap: &ConfigBootstrap) {
+    if bootstrap.tracing_enabled {
+        // To run: docker run -d -p6831:6831/udp -p6832:6832/udp -p16686:16686 -p14268:14268 \
+        // jaegertracing/all-in-one:latest
+        global::set_text_map_propagator(opentelemetry_jaeger::Propagator::new());
+        let tracer = opentelemetry_jaeger::new_pipeline()
+            .with_service_name("tari::console_wallet")
+            .with_tags(vec![KeyValue::new("pid", process::id().to_string()), KeyValue::new("current_exe", env::current_exe().unwrap().to_str().unwrap_or_default().to_owned())])
+            // TODO: uncomment when using tokio 1
+            // .install_batch(opentelemetry::runtime::Tokio)
+            .install_simple()
+            .unwrap();
+        let telemetry = tracing_opentelemetry::layer().with_tracer(tracer);
+        let subscriber = Registry::default().with(telemetry);
+        tracing::subscriber::set_global_default(subscriber)
+            .expect("Tracing could not be set. Try running without `--tracing-enabled`");
     }
 }

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -59,6 +59,9 @@ tokio = { version="^0.2", features = ["blocking", "time", "sync"] }
 ttl_cache = "0.5.1"
 uint = { version = "0.9", default-features = false }
 num-format = "0.4.0"
+tracing = "0.1.26"
+tracing-futures="*"
+tracing-attributes="*"
 
 [dev-dependencies]
 tari_p2p = { version = "^0.9", path = "../../base_layer/p2p", features=["test-mocks"]}

--- a/base_layer/core/src/base_node/state_machine_service/states/block_sync.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/block_sync.rs
@@ -66,8 +66,12 @@ impl BlockSync {
         );
 
         let status_event_sender = shared.status_event_sender.clone();
-        let local_nci = shared.local_node_interface.clone();
         let bootstrapped = shared.is_bootstrapped();
+        let _ = status_event_sender.broadcast(StatusInfo {
+            bootstrapped,
+            state_info: StateInfo::BlockSyncStarting,
+        });
+        let local_nci = shared.local_node_interface.clone();
         synchronizer.on_progress(move |block, remote_tip_height, sync_peers| {
             let local_height = block.height();
             local_nci.publish_block_event(BlockEvent::ValidBlockAdded(

--- a/base_layer/core/src/base_node/state_machine_service/states/events_and_states.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/events_and_states.rs
@@ -162,6 +162,7 @@ pub enum StateInfo {
     StartUp,
     HeaderSync(BlockSyncInfo),
     HorizonSync(HorizonSyncInfo),
+    BlockSyncStarting,
     BlockSync(BlockSyncInfo),
     Listening(ListeningInfo),
 }
@@ -193,12 +194,17 @@ impl StateInfo {
                 HorizonSyncStatus::Finalizing => "Finalizing horizon sync".to_string(),
             },
             Self::BlockSync(info) => format!(
-                "Syncing blocks: {}/{} ({:.0}%)",
+                "Syncing blocks with {}: {}/{} ({:.0}%) ",
+                info.sync_peers
+                    .first()
+                    .map(|s| s.short_str())
+                    .unwrap_or_else(|| "".to_string()),
                 info.local_height,
                 info.tip_height,
                 info.local_height as f64 / info.tip_height as f64 * 100.0
             ),
             Self::Listening(_) => "Listening".to_string(),
+            Self::BlockSyncStarting => "Starting block sync".to_string(),
         }
     }
 
@@ -212,7 +218,7 @@ impl StateInfo {
     pub fn is_synced(&self) -> bool {
         use StateInfo::*;
         match self {
-            StartUp | HeaderSync(_) | HorizonSync(_) | BlockSync(_) => false,
+            StartUp | HeaderSync(_) | HorizonSync(_) | BlockSync(_) | BlockSyncStarting => false,
             Listening(info) => info.is_synced(),
         }
     }
@@ -226,6 +232,7 @@ impl Display for StateInfo {
             Self::HorizonSync(info) => write!(f, "Synchronizing horizon state: {}", info),
             Self::BlockSync(info) => write!(f, "Synchronizing blocks: {}", info),
             Self::Listening(info) => write!(f, "Listening: {}", info),
+            Self::BlockSyncStarting => write!(f, "Synchronizing blocks: Starting"),
         }
     }
 }

--- a/base_layer/core/src/base_node/sync/block_sync/synchronizer.rs
+++ b/base_layer/core/src/base_node/sync/block_sync/synchronizer.rs
@@ -46,6 +46,7 @@ use tari_comms::{
     PeerConnection,
 };
 use tokio::task;
+use tracing;
 
 const LOG_TARGET: &str = "c::bn::block_sync";
 
@@ -86,6 +87,7 @@ impl<B: BlockchainBackend + 'static> BlockSynchronizer<B> {
         self.hooks.add_on_complete_hook(hook);
     }
 
+    #[tracing::instrument(skip(self), err)]
     pub async fn synchronize(&mut self) -> Result<(), BlockSyncError> {
         let peer_conn = self.get_next_sync_peer().await?;
         let node_id = peer_conn.peer_node_id().clone();

--- a/base_layer/core/src/base_node/sync/header_sync/synchronizer.rs
+++ b/base_layer/core/src/base_node/sync/header_sync/synchronizer.rs
@@ -48,6 +48,7 @@ use tari_comms::{
     protocol::rpc::{RpcError, RpcHandshakeError},
     PeerConnection,
 };
+use tracing;
 
 const LOG_TARGET: &str = "c::bn::header_sync";
 
@@ -253,6 +254,7 @@ impl<'a, B: BlockchainBackend + 'static> HeaderSynchronizer<'a, B> {
         Ok(())
     }
 
+    #[tracing::instrument(skip(self, conn), err)]
     async fn attempt_sync(&mut self, mut conn: PeerConnection) -> Result<(), BlockHeaderSyncError> {
         let peer = conn.peer_node_id().clone();
         let mut client = conn.connect_rpc::<rpc::BaseNodeSyncRpcClient>().await?;

--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -1560,8 +1560,8 @@ fn handle_possible_reorg<T: BlockchainBackend>(
             }, // We want a warning if the number of removed blocks is at least 2.
             "Chain reorg required from {} to {} (accum_diff:{}, hash:{}) to (accum_diff:{}, hash:{}). Number of \
              blocks to remove: {}, to add: {}.",
-            tip_header.header(),
-            fork_header.header(),
+            tip_header.header().height,
+            fork_header.header().height,
             tip_header.accumulated_data().total_accumulated_difficulty,
             tip_header.accumulated_data().hash.to_hex(),
             fork_header.accumulated_data().total_accumulated_difficulty,

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -26,6 +26,13 @@ multiaddr={package="parity-multiaddr", version = "0.11.0"}
 sha2 = "0.9.5"
 path-clean = "0.1.0"
 tari_storage = { version = "^0.9", path = "../infrastructure/storage"}
+tracing = "0.1.26"
+tracing-opentelemetry = "0.15.0"
+tracing-subscriber = "0.2.20"
+
+# network tracing, rt-tokio for async batch export
+opentelemetry = { version = "0.16", default-features = false, features = ["trace","rt-tokio"] }
+opentelemetry-jaeger = { version="0.15", features=["rt-tokio"]}
 
 anyhow = { version = "1.0", optional = true }
 git2 = { version = "0.8", optional = true }

--- a/common/src/configuration/bootstrap.rs
+++ b/common/src/configuration/bootstrap.rs
@@ -146,6 +146,8 @@ pub struct ConfigBootstrap {
     pub miner_min_diff: Option<u64>,
     #[structopt(long, alias = "max-difficulty")]
     pub miner_max_diff: Option<u64>,
+    #[structopt(long, alias = "tracing")]
+    pub tracing_enabled: bool,
 }
 
 fn normalize_path(path: PathBuf) -> PathBuf {
@@ -180,6 +182,7 @@ impl Default for ConfigBootstrap {
             miner_max_blocks: None,
             miner_min_diff: None,
             miner_max_diff: None,
+            tracing_enabled: false,
         }
     }
 }

--- a/comms/Cargo.toml
+++ b/comms/Cargo.toml
@@ -38,9 +38,15 @@ serde_derive = "1.0.119"
 snow = {version="=0.8.0", features=["default-resolver"]}
 thiserror = "1.0.20"
 tokio = {version="~0.2.19", features=["blocking", "time", "tcp", "dns", "sync", "stream", "signal"]}
-tokio-util = {version="0.2.0", features=["codec"]}
+tokio-util = {version="0.3.1", features=["codec"]}
 tower= "0.3.1"
+tracing = "0.1.26"
+tracing-futures = "0.2.5"
 yamux = "=0.9.0"
+
+# network tracing, rt-tokio for async batch export
+opentelemetry = { version = "0.16", default-features = false, features = ["trace","rt-tokio"] }
+opentelemetry-jaeger = { version="0.15", features=["rt-tokio"]}
 
 # RPC dependencies
 tower-make = {version="0.3.0", optional=true}

--- a/comms/src/connection_manager/dialer.rs
+++ b/comms/src/connection_manager/dialer.rs
@@ -55,6 +55,7 @@ use log::*;
 use std::{collections::HashMap, sync::Arc, time::Duration};
 use tari_shutdown::{Shutdown, ShutdownSignal};
 use tokio::{task::JoinHandle, time};
+use tracing::{self, span, Instrument, Level};
 
 const LOG_TARGET: &str = "comms::connection_manager::dialer";
 
@@ -254,6 +255,7 @@ where
             });
     }
 
+    #[tracing::instrument(skip(self, pending_dials, reply_tx))]
     fn handle_dial_peer_request(
         &mut self,
         pending_dials: &mut DialFuturesUnordered,
@@ -281,6 +283,7 @@ where
         let noise_config = self.noise_config.clone();
         let config = self.config.clone();
 
+        let span = span!(Level::TRACE, "handle_dial_peer_request_inner1");
         let dial_fut = async move {
             let (dial_state, dial_result) =
                 Self::dial_peer_with_retry(dial_state, noise_config, transport, backoff, &config).await;
@@ -314,7 +317,8 @@ where
                 },
                 Err(err) => (dial_state, Err(err)),
             }
-        };
+        }
+        .instrument(span);
 
         pending_dials.push(dial_fut.boxed());
     }
@@ -335,6 +339,7 @@ where
     }
 
     #[allow(clippy::too_many_arguments)]
+    #[tracing::instrument(skip(peer_manager, socket, conn_man_notifier, config, cancel_signal), err)]
     async fn perform_socket_upgrade_procedure(
         peer_manager: Arc<PeerManager>,
         node_identity: Arc<NodeIdentity>,
@@ -419,6 +424,7 @@ where
         )
     }
 
+    #[tracing::instrument(skip(dial_state, noise_config, transport, backoff, config))]
     async fn dial_peer_with_retry(
         dial_state: DialState,
         noise_config: NoiseConfig,

--- a/comms/src/connection_manager/listener.rs
+++ b/comms/src/connection_manager/listener.rs
@@ -71,6 +71,7 @@ use std::{
 use tari_crypto::tari_utilities::hex::Hex;
 use tari_shutdown::ShutdownSignal;
 use tokio::time;
+use tracing::{span, Instrument, Level};
 
 const LOG_TARGET: &str = "comms::connection_manager::listener";
 
@@ -244,6 +245,7 @@ where
         let liveness_session_count = self.liveness_session_count.clone();
         let shutdown_signal = self.shutdown_signal.clone();
 
+        let span = span!(Level::TRACE, "connection_mann::listener::inbound_task",);
         let inbound_fut = async move {
             match Self::read_wire_format(&mut socket, config.time_to_first_byte).await {
                 Ok(WireMode::Comms(byte)) if byte == config.network_info.network_byte => {
@@ -331,7 +333,8 @@ where
                     );
                 },
             }
-        };
+        }
+        .instrument(span);
 
         // This will block (asynchronously) if we have reached the maximum simultaneous connections, creating
         // back-pressure on nodes connecting to this node

--- a/comms/src/connection_manager/manager.rs
+++ b/comms/src/connection_manager/manager.rs
@@ -50,6 +50,7 @@ use std::{fmt, sync::Arc};
 use tari_shutdown::{Shutdown, ShutdownSignal};
 use time::Duration;
 use tokio::{sync::broadcast, task, time};
+use tracing::{span, Instrument, Level};
 
 const LOG_TARGET: &str = "comms::connection_manager::manager";
 
@@ -121,7 +122,7 @@ impl Default for ConnectionManagerConfig {
                 .expect("DEFAULT_LISTENER_ADDRESS is malformed"),
             #[cfg(test)]
             listener_address: "/memory/0".parse().unwrap(),
-            max_dial_attempts: 3,
+            max_dial_attempts: 1,
             max_simultaneous_inbound_connects: 100,
             network_info: Default::default(),
             #[cfg(not(test))]
@@ -258,6 +259,8 @@ where
     }
 
     pub async fn run(mut self) {
+        let span = span!(Level::DEBUG, "comms::connection_manager::run");
+        let _enter = span.enter();
         let mut shutdown = self
             .shutdown_signal
             .take()
@@ -350,7 +353,16 @@ where
         use ConnectionManagerRequest::*;
         trace!(target: LOG_TARGET, "Connection manager got request: {:?}", request);
         match request {
-            DialPeer(node_id, reply) => self.dial_peer(node_id, reply).await,
+            DialPeer {
+                node_id,
+                reply_tx,
+                tracing_id: _tracing,
+            } => {
+                let span = span!(Level::TRACE, "connection_manager::handle_request");
+                // This causes a panic for some reason?
+                // span.follows_from(tracing_id);
+                self.dial_peer(node_id, reply_tx).instrument(span).await
+            },
             CancelDial(node_id) => {
                 if let Err(err) = self.dialer_tx.send(DialerRequest::CancelPendingDial(node_id)).await {
                     error!(
@@ -432,6 +444,7 @@ where
         let _ = self.connection_manager_events_tx.send(Arc::new(event));
     }
 
+    #[tracing::instrument(skip(self, reply))]
     async fn dial_peer(
         &mut self,
         node_id: NodeId,

--- a/comms/src/connectivity/requester.rs
+++ b/comms/src/connectivity/requester.rs
@@ -44,6 +44,7 @@ use std::{
 };
 use tokio::{sync::broadcast, time};
 const LOG_TARGET: &str = "comms::connectivity::requester";
+use tracing;
 
 pub type ConnectivityEventRx = broadcast::Receiver<Arc<ConnectivityEvent>>;
 pub type ConnectivityEventTx = broadcast::Sender<Arc<ConnectivityEvent>>;
@@ -90,7 +91,11 @@ impl fmt::Display for ConnectivityEvent {
 #[derive(Debug)]
 pub enum ConnectivityRequest {
     WaitStarted(oneshot::Sender<()>),
-    DialPeer(NodeId, oneshot::Sender<Result<PeerConnection, ConnectionManagerError>>),
+    DialPeer {
+        node_id: NodeId,
+        reply_tx: oneshot::Sender<Result<PeerConnection, ConnectionManagerError>>,
+        tracing_id: Option<tracing::span::Id>,
+    },
     GetConnectivityStatus(oneshot::Sender<ConnectivityStatus>),
     AddManagedPeers(Vec<NodeId>),
     RemovePeer(NodeId),
@@ -123,12 +128,17 @@ impl ConnectivityRequester {
         self.event_tx.clone()
     }
 
+    #[tracing::instrument(skip(self), err)]
     pub async fn dial_peer(&mut self, peer: NodeId) -> Result<PeerConnection, ConnectivityError> {
         let mut num_cancels = 0;
         loop {
             let (reply_tx, reply_rx) = oneshot::channel();
             self.sender
-                .send(ConnectivityRequest::DialPeer(peer.clone(), reply_tx))
+                .send(ConnectivityRequest::DialPeer {
+                    node_id: peer.clone(),
+                    reply_tx,
+                    tracing_id: tracing::Span::current().id(),
+                })
                 .await
                 .map_err(|_| ConnectivityError::ActorDisconnected)?;
 

--- a/comms/src/noise/config.rs
+++ b/comms/src/noise/config.rs
@@ -60,6 +60,7 @@ impl NoiseConfig {
 
     /// Upgrades the given socket to using the noise protocol. The upgraded socket and the peer's static key
     /// is returned.
+    #[tracing::instrument(name = "noise::upgrade_socket", skip(self, socket), err)]
     pub async fn upgrade_socket<TSocket>(
         &self,
         socket: TSocket,

--- a/comms/src/protocol/identity.rs
+++ b/comms/src/protocol/identity.rs
@@ -34,10 +34,12 @@ use std::{io, time::Duration};
 use thiserror::Error;
 use tokio::time;
 use tokio_util::codec::{Framed, LengthDelimitedCodec};
+use tracing;
 
 pub static IDENTITY_PROTOCOL: ProtocolId = ProtocolId::from_static(b"t/identity/1.0");
 const LOG_TARGET: &str = "comms::protocol::identity";
 
+#[tracing::instrument(skip(socket, our_supported_protocols), err)]
 pub async fn identity_exchange<'p, TSocket, P>(
     node_identity: &NodeIdentity,
     direction: ConnectionDirection,

--- a/comms/src/protocol/messaging/protocol.rs
+++ b/comms/src/protocol/messaging/protocol.rs
@@ -247,6 +247,7 @@ impl MessagingProtocol {
         Ok(())
     }
 
+    // #[tracing::instrument(skip(self, out_msg), err)]
     async fn send_message(&mut self, out_msg: OutboundMessage) -> Result<(), MessagingProtocolError> {
         let peer_node_id = out_msg.peer_node_id.clone();
         let sender = loop {

--- a/comms/src/protocol/rpc/handshake.rs
+++ b/comms/src/protocol/rpc/handshake.rs
@@ -23,10 +23,10 @@
 use crate::{framing::CanonicalFraming, message::MessageExt, proto, protocol::rpc::error::HandshakeRejectReason};
 use bytes::BytesMut;
 use futures::{AsyncRead, AsyncWrite, SinkExt, StreamExt};
-use log::*;
 use prost::{DecodeError, Message};
 use std::{io, time::Duration};
 use tokio::time;
+use tracing::{debug, error, event, span, warn, Instrument, Level};
 
 const LOG_TARGET: &str = "comms::rpc::handshake";
 
@@ -73,30 +73,48 @@ where T: AsyncRead + AsyncWrite + Unpin
     }
 
     /// Server-side handshake protocol
+    #[tracing::instrument(name = "rpc::server::perform_server_handshake", skip(self), err, fields(comms.direction="inbound"))]
     pub async fn perform_server_handshake(&mut self) -> Result<u32, RpcHandshakeError> {
         match self.recv_next_frame().await {
             Ok(Some(Ok(msg))) => {
+                event!(Level::DEBUG, "Handshake bytes received");
                 let msg = proto::rpc::RpcSession::decode(&mut msg.freeze())?;
                 let version = SUPPORTED_RPC_VERSIONS
                     .iter()
                     .find(|v| msg.supported_versions.contains(v));
                 if let Some(version) = version {
+                    event!(Level::INFO, version = version, "Server accepted version");
                     debug!(target: LOG_TARGET, "Server accepted version {}", version);
                     let reply = proto::rpc::RpcSessionReply {
                         session_result: Some(proto::rpc::rpc_session_reply::SessionResult::AcceptedVersion(*version)),
                         ..Default::default()
                     };
-                    self.framed.send(reply.to_encoded_bytes().into()).await?;
+                    let span = span!(Level::INFO, "rpc::server::handshake::send_accept_version_reply");
+                    self.framed
+                        .send(reply.to_encoded_bytes().into())
+                        .instrument(span)
+                        .await?;
                     return Ok(*version);
                 }
 
+                let span = span!(Level::INFO, "rpc::server::handshake::send_rejection");
                 self.reject_with_reason(HandshakeRejectReason::UnsupportedVersion)
+                    .instrument(span)
                     .await?;
                 Err(RpcHandshakeError::ClientNoSupportedVersion)
             },
-            Ok(Some(Err(err))) => Err(err.into()),
-            Ok(None) => Err(RpcHandshakeError::ClientClosed),
-            Err(_elapsed) => Err(RpcHandshakeError::TimedOut),
+            Ok(Some(Err(err))) => {
+                event!(Level::ERROR, "Error: {}", err);
+                Err(err.into())
+            },
+            Ok(None) => {
+                event!(Level::ERROR, "Client closed request");
+                Err(RpcHandshakeError::ClientClosed)
+            },
+            Err(_elapsed) => {
+                event!(Level::ERROR, "Timed out");
+                Err(RpcHandshakeError::TimedOut)
+            },
         }
     }
 
@@ -112,6 +130,7 @@ where T: AsyncRead + AsyncWrite + Unpin
     }
 
     /// Client-side handshake protocol
+    #[tracing::instrument(name = "rpc::client::perform_client_handshake", skip(self), err, fields(comms.direction="outbound"))]
     pub async fn perform_client_handshake(&mut self) -> Result<(), RpcHandshakeError> {
         let msg = proto::rpc::RpcSession {
             supported_versions: SUPPORTED_RPC_VERSIONS.to_vec(),
@@ -129,15 +148,26 @@ where T: AsyncRead + AsyncWrite + Unpin
             Ok(Some(Ok(msg))) => {
                 let msg = proto::rpc::RpcSessionReply::decode(&mut msg.freeze())?;
                 let version = msg.result()?;
+                event!(Level::INFO, "Server accepted version: {}", version);
                 debug!(target: LOG_TARGET, "Server accepted version {}", version);
                 Ok(())
             },
-            Ok(Some(Err(err))) => Err(err.into()),
-            Ok(None) => Err(RpcHandshakeError::ServerClosedRequest),
-            Err(_) => Err(RpcHandshakeError::TimedOut),
+            Ok(Some(Err(err))) => {
+                event!(Level::ERROR, "Error: {}", err);
+                Err(err.into())
+            },
+            Ok(None) => {
+                event!(Level::ERROR, "Server closed request");
+                Err(RpcHandshakeError::ServerClosedRequest)
+            },
+            Err(_) => {
+                event!(Level::ERROR, "Timed out");
+                Err(RpcHandshakeError::TimedOut)
+            },
         }
     }
 
+    #[tracing::instrument(name = "rpc::receive_handshake_reply", skip(self), err)]
     async fn recv_next_frame(&mut self) -> Result<Option<Result<BytesMut, io::Error>>, time::Elapsed> {
         match self.timeout {
             Some(timeout) => time::timeout(timeout, self.framed.next()).await,

--- a/comms/src/socks/client.rs
+++ b/comms/src/socks/client.rs
@@ -104,6 +104,7 @@ where TSocket: AsyncRead + AsyncWrite + Unpin
 
     /// Connects to a address through a SOCKS5 proxy and returns the 'upgraded' socket. This consumes the
     /// `Socks5Client` as once connected, the socks protocol does not recognise any further commands.
+    #[tracing::instrument(name = "socks::connect", skip(self), err)]
     pub async fn connect(mut self, address: &Multiaddr) -> Result<(TSocket, Multiaddr)> {
         let address = self.execute_command(Command::Connect, address).await?;
         Ok((self.protocol.socket, address))
@@ -111,6 +112,7 @@ where TSocket: AsyncRead + AsyncWrite + Unpin
 
     /// Requests the tor proxy to resolve a DNS address is resolved into an IP address.
     /// This operation only works with the tor SOCKS proxy.
+    #[tracing::instrument(name = "socks:tor_resolve", skip(self), err)]
     pub async fn tor_resolve(&mut self, address: &Multiaddr) -> Result<Multiaddr> {
         // Tor resolve does not return the port back
         let (dns, rest) = multiaddr_split_first(&address);
@@ -124,6 +126,7 @@ where TSocket: AsyncRead + AsyncWrite + Unpin
 
     /// Requests the tor proxy to reverse resolve an IP address into a DNS address if it is able.
     /// This operation only works with the tor SOCKS proxy.
+    #[tracing::instrument(name = "socks::tor_resolve_ptr", skip(self), err)]
     pub async fn tor_resolve_ptr(&mut self, address: &Multiaddr) -> Result<Multiaddr> {
         self.execute_command(Command::TorResolvePtr, address).await
     }

--- a/comms/src/test_utils/mocks/connection_manager.rs
+++ b/comms/src/test_utils/mocks/connection_manager.rs
@@ -131,7 +131,11 @@ impl ConnectionManagerMock {
         self.state.inc_call_count();
         self.state.add_call(format!("{:?}", req)).await;
         match req {
-            DialPeer(node_id, reply_tx) => {
+            DialPeer {
+                node_id,
+                reply_tx,
+                tracing_id: _,
+            } => {
                 // Send Ok(conn) if we have an active connection, otherwise Err(DialConnectFailedAllAddresses)
                 let _ = reply_tx.send(
                     self.state

--- a/comms/src/test_utils/mocks/connectivity_manager.rs
+++ b/comms/src/test_utils/mocks/connectivity_manager.rs
@@ -204,15 +204,19 @@ impl ConnectivityManagerMock {
         use ConnectivityRequest::*;
         self.state.add_call(format!("{:?}", req)).await;
         match req {
-            DialPeer(node_id, reply) => {
+            DialPeer {
+                node_id,
+                reply_tx,
+                tracing_id: _,
+            } => {
                 // Send Ok(conn) if we have an active connection, otherwise Err(DialConnectFailedAllAddresses)
                 self.state
                     .with_state(|state| match state.pending_conns.get_mut(&node_id) {
                         Some(replies) => {
-                            replies.push(reply);
+                            replies.push(reply_tx);
                         },
                         None => {
-                            let _ = reply.send(
+                            let _ = reply_tx.send(
                                 state
                                     .active_conns
                                     .get(&node_id)

--- a/comms/src/test_utils/mocks/peer_connection.rs
+++ b/comms/src/test_utils/mocks/peer_connection.rs
@@ -190,9 +190,16 @@ impl PeerConnectionMock {
         use PeerConnectionRequest::*;
         self.state.inc_call_count();
         match req {
-            OpenSubstream(protocol, reply_tx) => match self.state.open_substream().await {
+            OpenSubstream {
+                protocol_id,
+                reply_tx,
+                tracing_id: _,
+            } => match self.state.open_substream().await {
                 Ok(stream) => {
-                    let negotiated_substream = NegotiatedSubstream { protocol, stream };
+                    let negotiated_substream = NegotiatedSubstream {
+                        protocol: protocol_id,
+                        stream,
+                    };
                     reply_tx.send(Ok(negotiated_substream)).unwrap();
                 },
                 Err(err) => {


### PR DESCRIPTION
Description
---
Add tracing to comms to debug timings via the `--tracing-enabled` flag

Motivation and Context
---
It's currently difficult to understand the timings of network calls and errors in the application.

How Has This Been Tested?
---
Tested manually
