### PR TITLE
fix: disable P2P transaction negotiation while recovery is in progress

### DIFF
--- a/base_layer/wallet/src/test_utils.rs
+++ b/base_layer/wallet/src/test_utils.rs
@@ -20,12 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::{
-    contacts_service::storage::sqlite_db::ContactsServiceSqliteDatabase,
-    output_manager_service::storage::sqlite_db::OutputManagerSqliteDatabase,
-    storage::{sqlite_db::WalletSqliteDatabase, sqlite_utilities::run_migration_and_create_sqlite_connection},
-    transaction_service::storage::sqlite_db::TransactionServiceSqliteDatabase,
-};
+use crate::storage::sqlite_utilities::{run_migration_and_create_sqlite_connection, WalletDbConnection};
 use core::iter;
 use rand::{distributions::Alphanumeric, rngs::OsRng, Rng};
 use std::path::Path;
@@ -39,15 +34,7 @@ pub fn random_string(len: usize) -> String {
 }
 
 /// A test helper to create a temporary wallet service databases
-pub fn make_wallet_databases(
-    path: Option<String>,
-) -> (
-    WalletSqliteDatabase,
-    TransactionServiceSqliteDatabase,
-    OutputManagerSqliteDatabase,
-    ContactsServiceSqliteDatabase,
-    Option<TempDir>,
-) {
+pub fn make_wallet_database_connection(path: Option<String>) -> (WalletDbConnection, Option<TempDir>) {
     let (path_string, temp_dir): (String, Option<TempDir>) = if let Some(p) = path {
         (p, None)
     } else {
@@ -61,11 +48,5 @@ pub fn make_wallet_databases(
 
     let connection =
         run_migration_and_create_sqlite_connection(&db_path.to_str().expect("Should be able to make path")).unwrap();
-    (
-        WalletSqliteDatabase::new(connection.clone(), None).expect("Should be able to create wallet database"),
-        TransactionServiceSqliteDatabase::new(connection.clone(), None),
-        OutputManagerSqliteDatabase::new(connection.clone(), None),
-        ContactsServiceSqliteDatabase::new(connection),
-        temp_dir,
-    )
+    (connection, temp_dir)
 }

--- a/base_layer/wallet/src/transaction_service/error.rs
+++ b/base_layer/wallet/src/transaction_service/error.rs
@@ -21,6 +21,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{
+    error::WalletStorageError,
     output_manager_service::{error::OutputManagerError, TxId},
     transaction_service::storage::database::DbKey,
 };
@@ -100,6 +101,8 @@ pub enum TransactionServiceError {
     TransportChannelError(#[from] TransportChannelError),
     #[error("Transaction storage error: `{0}`")]
     TransactionStorageError(#[from] TransactionStorageError),
+    #[error("Wallet storage error: `{0}`")]
+    WalletStorageError(#[from] WalletStorageError),
     #[error("Invalid message error: `{0}`")]
     InvalidMessageError(String),
     #[error("Transaction error: `{0}`")]
@@ -140,6 +143,8 @@ pub enum TransactionServiceError {
     ByteArrayError(#[from] tari_crypto::tari_utilities::ByteArrayError),
     #[error("Transaction Service Error: `{0}`")]
     ServiceError(String),
+    #[error("Wallet Recovery in progress so Transaction Service Messaging Requests ignored")]
+    WalletRecoveryInProgress,
 }
 
 #[derive(Debug, Error)]

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -20,47 +20,9 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{
-    collections::{HashMap, HashSet},
-    convert::TryInto,
-    sync::Arc,
-    time::{Duration, Instant},
-};
-
-use chrono::{NaiveDateTime, Utc};
-use digest::Digest;
-use futures::{pin_mut, stream::FuturesUnordered, Stream, StreamExt};
-use log::*;
-use rand::{rngs::OsRng, RngCore};
-use tari_crypto::{keys::DiffieHellmanSharedSecret, script, tari_utilities::ByteArray};
-use tokio::{sync::broadcast, task::JoinHandle};
-
-use tari_common_types::types::PrivateKey;
-use tari_comms::{connectivity::ConnectivityRequester, peer_manager::NodeIdentity, types::CommsPublicKey};
-use tari_comms_dht::outbound::OutboundMessageRequester;
-use tari_core::{
-    crypto::keys::SecretKey,
-    proto::base_node as base_node_proto,
-    transactions::{
-        tari_amount::MicroTari,
-        transaction::{KernelFeatures, OutputFeatures, Transaction},
-        transaction_protocol::{
-            proto,
-            recipient::RecipientSignedMessage,
-            sender::TransactionSenderMessage,
-            RewindData,
-        },
-        CryptoFactories,
-        ReceiverTransactionProtocol,
-    },
-};
-use tari_p2p::domain_message::DomainMessage;
-use tari_service_framework::{reply_channel, reply_channel::Receiver};
-use tari_shutdown::ShutdownSignal;
-use tokio::sync::{mpsc, mpsc::Sender, oneshot};
-
 use crate::{
     output_manager_service::{handle::OutputManagerHandle, TxId},
+    storage::database::{WalletBackend, WalletDatabase},
     transaction_service::{
         config::TransactionServiceConfig,
         error::{TransactionServiceError, TransactionServiceProtocolError},
@@ -83,6 +45,45 @@ use crate::{
         },
     },
     types::{HashDigest, ValidationRetryStrategy},
+    utxo_scanner_service::utxo_scanning::RECOVERY_KEY,
+};
+use chrono::{NaiveDateTime, Utc};
+use digest::Digest;
+use futures::{pin_mut, stream::FuturesUnordered, Stream, StreamExt};
+use log::*;
+use rand::{rngs::OsRng, RngCore};
+use std::{
+    collections::{HashMap, HashSet},
+    convert::TryInto,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+use tari_common_types::types::PrivateKey;
+use tari_comms::{connectivity::ConnectivityRequester, peer_manager::NodeIdentity, types::CommsPublicKey};
+use tari_comms_dht::outbound::OutboundMessageRequester;
+use tari_core::{
+    crypto::keys::SecretKey,
+    proto::base_node as base_node_proto,
+    transactions::{
+        tari_amount::MicroTari,
+        transaction::{KernelFeatures, OutputFeatures, Transaction},
+        transaction_protocol::{
+            proto,
+            recipient::RecipientSignedMessage,
+            sender::TransactionSenderMessage,
+            RewindData,
+        },
+        CryptoFactories,
+        ReceiverTransactionProtocol,
+    },
+};
+use tari_crypto::{keys::DiffieHellmanSharedSecret, script, tari_utilities::ByteArray};
+use tari_p2p::domain_message::DomainMessage;
+use tari_service_framework::{reply_channel, reply_channel::Receiver};
+use tari_shutdown::ShutdownSignal;
+use tokio::{
+    sync::{broadcast, mpsc, mpsc::Sender, oneshot},
+    task::JoinHandle,
 };
 
 const LOG_TARGET: &str = "wallet::transaction_service::service";
@@ -107,7 +108,10 @@ pub struct TransactionService<
     BNResponseStream,
     TBackend,
     TTxCancelledStream,
-> where TBackend: TransactionBackend + 'static
+    WBackend,
+> where
+    TBackend: TransactionBackend + 'static,
+    WBackend: WalletBackend + 'static,
 {
     config: TransactionServiceConfig,
     db: TransactionDatabase<TBackend>,
@@ -134,11 +138,20 @@ pub struct TransactionService<
     timeout_update_publisher: broadcast::Sender<Duration>,
     base_node_update_publisher: broadcast::Sender<CommsPublicKey>,
     power_mode: PowerMode,
+    wallet_db: WalletDatabase<WBackend>,
 }
 
 #[allow(clippy::too_many_arguments)]
-impl<TTxStream, TTxReplyStream, TTxFinalizedStream, BNResponseStream, TBackend, TTxCancelledStream>
-    TransactionService<TTxStream, TTxReplyStream, TTxFinalizedStream, BNResponseStream, TBackend, TTxCancelledStream>
+impl<TTxStream, TTxReplyStream, TTxFinalizedStream, BNResponseStream, TBackend, TTxCancelledStream, WBackend>
+    TransactionService<
+        TTxStream,
+        TTxReplyStream,
+        TTxFinalizedStream,
+        BNResponseStream,
+        TBackend,
+        TTxCancelledStream,
+        WBackend,
+    >
 where
     TTxStream: Stream<Item = DomainMessage<proto::TransactionSenderMessage>>,
     TTxReplyStream: Stream<Item = DomainMessage<proto::RecipientSignedMessage>>,
@@ -146,10 +159,12 @@ where
     BNResponseStream: Stream<Item = DomainMessage<base_node_proto::BaseNodeServiceResponse>>,
     TTxCancelledStream: Stream<Item = DomainMessage<proto::TransactionCancelledMessage>>,
     TBackend: TransactionBackend + 'static,
+    WBackend: WalletBackend + 'static,
 {
     pub fn new(
         config: TransactionServiceConfig,
         db: TransactionDatabase<TBackend>,
+        wallet_db: WalletDatabase<WBackend>,
         request_stream: Receiver<
             TransactionServiceRequest,
             Result<TransactionServiceResponse, TransactionServiceError>,
@@ -208,6 +223,7 @@ where
             timeout_update_publisher,
             base_node_update_publisher,
             power_mode: PowerMode::Normal,
+            wallet_db,
         }
     }
 
@@ -316,7 +332,7 @@ where
                             msg.dht_header.message_tag);
                         }
                         Err(e) => {
-                            warn!(target: LOG_TARGET, "Failed to handle incoming Transaction message: {:?} for NodeID: {}, Trace: {}",
+                            warn!(target: LOG_TARGET, "Failed to handle incoming Transaction message: {} for NodeID: {}, Trace: {}",
                                 e, self.node_identity.node_id().short_str(), msg.dht_header.message_tag);
                             let _ = self.event_publisher.send(Arc::new(TransactionEvent::Error(format!("Error handling \
                                 Transaction Sender message: {:?}", e).to_string())));
@@ -346,7 +362,7 @@ where
                             msg.dht_header.message_tag);
                         },
                         Err(e) => {
-                            warn!(target: LOG_TARGET, "Failed to handle incoming Transaction Reply message: {:?} \
+                            warn!(target: LOG_TARGET, "Failed to handle incoming Transaction Reply message: {} \
                             for NodeId: {}, Trace: {}", e, self.node_identity.node_id().short_str(),
                             msg.dht_header.message_tag);
                             let _ = self.event_publisher.send(Arc::new(TransactionEvent::Error("Error handling \
@@ -384,7 +400,7 @@ where
                             msg.dht_header.message_tag);
                         },
                        Err(e) => {
-                            warn!(target: LOG_TARGET, "Failed to handle incoming Transaction Finalized message: {:?} \
+                            warn!(target: LOG_TARGET, "Failed to handle incoming Transaction Finalized message: {} \
                             for NodeID: {}, Trace: {}", e , self.node_identity.node_id().short_str(),
                             msg.dht_header.message_tag.as_value());
                             let _ = self.event_publisher.send(Arc::new(TransactionEvent::Error("Error handling Transaction \
@@ -879,6 +895,9 @@ where
         source_pubkey: CommsPublicKey,
         recipient_reply: proto::RecipientSignedMessage,
     ) -> Result<(), TransactionServiceError> {
+        // Check if a wallet recovery is in progress, if it is we will ignore this request
+        self.check_recovery_status().await?;
+
         let recipient_reply: RecipientSignedMessage = recipient_reply
             .try_into()
             .map_err(TransactionServiceError::InvalidMessageError)?;
@@ -1181,6 +1200,9 @@ where
         traced_message_tag: u64,
         join_handles: &mut FuturesUnordered<JoinHandle<Result<u64, TransactionServiceProtocolError>>>,
     ) -> Result<(), TransactionServiceError> {
+        // Check if a wallet recovery is in progress, if it is we will ignore this request
+        self.check_recovery_status().await?;
+
         let sender_message: TransactionSenderMessage = sender_message
             .try_into()
             .map_err(TransactionServiceError::InvalidMessageError)?;
@@ -1289,6 +1311,9 @@ where
         finalized_transaction: proto::TransactionFinalizedMessage,
         join_handles: &mut FuturesUnordered<JoinHandle<Result<u64, TransactionServiceProtocolError>>>,
     ) -> Result<(), TransactionServiceError> {
+        // Check if a wallet recovery is in progress, if it is we will ignore this request
+        self.check_recovery_status().await?;
+
         let tx_id = finalized_transaction.tx_id;
         let transaction: Transaction = finalized_transaction
             .transaction
@@ -2024,6 +2049,16 @@ where
         }
 
         Ok(())
+    }
+
+    /// Check if a Recovery Status is currently stored in the databse, this indicates that a wallet recovery is in
+    /// progress
+    async fn check_recovery_status(&self) -> Result<(), TransactionServiceError> {
+        let value = self.wallet_db.get_client_key_value(RECOVERY_KEY.to_owned()).await?;
+        match value {
+            None => Ok(()),
+            Some(_) => Err(TransactionServiceError::WalletRecoveryInProgress),
+        }
     }
 }
 

--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -187,6 +187,7 @@ where
                 transaction_backend,
                 node_identity.clone(),
                 factories.clone(),
+                wallet_database.clone(),
             ))
             .add_initializer(ContactsServiceInitializer::new(contacts_backend))
             .add_initializer(BaseNodeServiceInitializer::new(

--- a/base_layer/wallet_ffi/src/callback_handler.rs
+++ b/base_layer/wallet_ffi/src/callback_handler.rs
@@ -598,7 +598,7 @@ mod test {
     use tari_shutdown::Shutdown;
     use tari_wallet::{
         output_manager_service::{handle::OutputManagerEvent, TxoValidationType},
-        test_utils::make_wallet_databases,
+        test_utils::make_wallet_database_connection,
         transaction_service::{
             handle::TransactionEvent,
             storage::{
@@ -610,6 +610,7 @@ mod test {
                     TransactionDirection,
                     TransactionStatus,
                 },
+                sqlite_db::TransactionServiceSqliteDatabase,
             },
         },
     };
@@ -770,8 +771,8 @@ mod test {
     fn test_callback_handler() {
         let runtime = Runtime::new().unwrap();
 
-        let (_wallet_backend, backend, _oms_backend, _, _tempdir) = make_wallet_databases(None);
-        let db = TransactionDatabase::new(backend);
+        let (connection, _tempdir) = make_wallet_database_connection(None);
+        let db = TransactionDatabase::new(TransactionServiceSqliteDatabase::new(connection, None));
         let rtp = ReceiverTransactionProtocol::new_placeholder();
         let inbound_tx = InboundTransaction::new(
             1u64,


### PR DESCRIPTION
Description
---
Some weird behaviour was observed when a wallet would be busy with recovery and then receive transaction negotiation messages, either directly or via SAF.

The Recovery process is updating the Key Manager Indices and looking for commitments on the blockchain so to allow transaction negotiation during this time is dangerous as it might put duplicate commitments into the db and reuse spending keys.

This PR checks for the db key/value used to indicate Recovery progress before handling a transaction negotiation p2p message and if it is there the message is ignored with a log.

How Has This Been Tested?
---
Manual test
