### PR TITLE
fix: prevent immediate run of wallet recovery on cron script

### DIFF
--- a/applications/daily_tests/automatic_recovery_test.js
+++ b/applications/daily_tests/automatic_recovery_test.js
@@ -81,17 +81,17 @@ async function run(options = {}) {
       process: wallet.ps,
       outputStream: logfile,
       onData: (data) => {
-        let successLog = data.match(RECOVERY_COMPLETE_REGEXP);
-        let recoveredAmount = data.match(RECOVERY_WORTH_REGEXP);
-        if (successLog && recoveredAmount) {
-          let recoveredAmount = parseInt(recoveredAmount[1]);
-          if (recoveredAmount[2] === "T") {
+        let scannedMatch = data.match(RECOVERY_COMPLETE_REGEXP);
+        let recoveredAmountMatch = data.match(RECOVERY_WORTH_REGEXP);
+        if (scannedMatch && recoveredAmountMatch) {
+          let recoveredAmount = parseInt(recoveredAmountMatch[1]);
+          if (recoveredAmountMatch[2] === "T") {
             // convert to micro tari
             recoveredAmount *= 1000000;
           }
           return {
-            height: parseInt(height[1]),
-            recoveredAmount: parseInt(recoveredAmount[1]),
+            numScanned: parseInt(scannedMatch[1]),
+            recoveredAmount,
           };
         }
 
@@ -114,13 +114,13 @@ async function run(options = {}) {
 
     await wallet.stop();
 
-    const block_rate = recoveryResult.height / timeDiffMinutes;
+    const scannedRate = recoveryResult.numScanned / timeDiffMinutes;
 
     return {
       identity: id,
-      height: recoveryResult.height,
+      numScanned: recoveryResult.numScanned,
       timeDiffMinutes,
-      blockRate: block_rate.toFixed(2),
+      scannedRate: scannedRate.toFixed(2),
       recoveredAmount: recoveryResult.recoveredAmount,
     };
   } catch (err) {

--- a/applications/daily_tests/cron_jobs.js
+++ b/applications/daily_tests/cron_jobs.js
@@ -44,23 +44,28 @@ async function runWalletRecoveryTest(instances) {
   await emptyFile(LOG_FILE);
 
   try {
-    const { identity, timeDiffMinutes, height, blockRate, recoveredAmount } =
-      await walletRecoveryTest({
-        seedWords:
-          "spare man patrol essay divide hollow trip visual actress sadness country hungry toy blouse body club depend capital sleep aim high recycle crystal abandon",
-        log: LOG_FILE,
-        numWallets: instances,
-      });
+    const {
+      identity,
+      timeDiffMinutes,
+      numScanned,
+      scannedRate,
+      recoveredAmount,
+    } = await walletRecoveryTest({
+      seedWords:
+        "spare man patrol essay divide hollow trip visual actress sadness country hungry toy blouse body club depend capital sleep aim high recycle crystal abandon",
+      log: LOG_FILE,
+      numWallets: instances,
+    });
 
     notify(
       "🙌 Wallet (Pubkey:",
       identity.public_key,
       ") recovered to a block height of",
-      height,
+      numScanned,
       "completed in",
       timeDiffMinutes,
       "minutes (",
-      blockRate,
+      scannedRate,
       "blocks/min).",
       recoveredAmount,
       "µT recovered for ",
@@ -121,8 +126,8 @@ ${logLines.join("\n")}
 }
 
 // ------------------------- CRON ------------------------- //
-new CronJob("0 7 * * *", runWalletRecoveryTest(1)).start();
-new CronJob("0 7 * * *", runWalletRecoveryTest(5)).start();
+new CronJob("0 7 * * *", () => runWalletRecoveryTest(1)).start();
+new CronJob("30 7 * * *", () => runWalletRecoveryTest(5)).start();
 new CronJob("0 6 * * *", () => runBaseNodeSyncTest(SyncType.Archival)).start();
 new CronJob("30 6 * * *", () => runBaseNodeSyncTest(SyncType.Pruned)).start();
 


### PR DESCRIPTION

Description
---
When running cron, the two wallet recovery tests would run immediately
and not be awaited (Promises are eager in js)

Motivation and Context
---
Minor fix

How Has This Been Tested?
---
Script run and tests did not immediately start
