### PR TITLE
fix: off-by-one causing "no further headers to download" bug

### DIFF
--- a/base_layer/core/src/base_node/sync/header_sync/validator.rs
+++ b/base_layer/core/src/base_node/sync/header_sync/validator.rs
@@ -115,6 +115,10 @@ impl<B: BlockchainBackend + 'static> BlockHeaderSyncValidator<B> {
         Ok(())
     }
 
+    pub fn current_valid_chain_tip_header(&self) -> Option<&ChainHeader> {
+        self.valid_headers().last()
+    }
+
     pub fn validate(&mut self, header: BlockHeader) -> Result<(), BlockHeaderSyncError> {
         let state = self.state();
         let expected_height = state.current_height + 1;


### PR DESCRIPTION
Description
---
When entering the `synchonize_headers` function, a chain of headers has
been downloaded and validated but not committed. If there less than
1000 (not equal to as before), the function can exit without streaming
more as there are no more to send.

This PR correctly handles the case where the node is exactly 1000 headers behind
by: (1) correcting the off-by-one "no further headers to download" conditional and
(2) commiting headers before starting streaming if the PoW is stronger,
in case no further headers would be streamed.

Motivation and Context
---
Header sync ends prematurely when receiving exactly 1000 "pre-sync" headers.

How Has This Been Tested?
---
Manually - Sync from scratch.
