### PR TITLE
fix: auto update continuously checks auto_update_check_interval is disabled

### DIFF
--- a/base_layer/p2p/src/auto_update/dns.rs
+++ b/base_layer/p2p/src/auto_update/dns.rs
@@ -32,7 +32,7 @@ use std::{
 use tari_common::configuration::bootstrap::ApplicationType;
 use tari_utilities::hex::{from_hex, Hex};
 
-const LOG_TARGET: &str = "p2p::auto-update:dns";
+const LOG_TARGET: &str = "p2p::auto_update::dns";
 
 pub struct DnsSoftwareUpdate {
     client: DnsClient,

--- a/base_layer/p2p/src/auto_update/mod.rs
+++ b/base_layer/p2p/src/auto_update/mod.rs
@@ -46,7 +46,7 @@ use std::{
 use tari_common::configuration::bootstrap::ApplicationType;
 use tari_utilities::hex::Hex;
 
-const LOG_TARGET: &str = "p2p::auto-update";
+const LOG_TARGET: &str = "p2p::auto_update";
 
 #[derive(Debug, Clone)]
 pub struct AutoUpdateConfig {
@@ -56,6 +56,12 @@ pub struct AutoUpdateConfig {
     pub download_base_url: String,
     pub hashes_url: String,
     pub hashes_sig_url: String,
+}
+
+impl AutoUpdateConfig {
+    pub fn is_update_enabled(&self) -> bool {
+        !self.update_uris.is_empty()
+    }
 }
 
 pub async fn check_for_updates(


### PR DESCRIPTION
Description
---
Continuously checks for updates when auto_update_check_interval is disabled.

Thanks @mikethetike. for finding it and for the fix 

Add check to if no auto update URIs are configured 

Motivation and Context
---
Bug fix

When check_interval is disabled, stream::empty() is used to disable the update checking, however it
returns None continuously when polled, causing the update to continuously be checked.

Also sets MissedTickBehaviour::Skip - which will prevent bursts of checks if intervals are missed

How Has This Been Tested?
---
Ran base node with auto_update_check_interval = 0 (or equivalently without this setting set)
