### PR TITLE
feat: add get-db-stats command

### DIFF
--- a/applications/tari_base_node/src/parser.rs
+++ b/applications/tari_base_node/src/parser.rs
@@ -53,6 +53,7 @@ pub enum BaseNodeCommand {
     CheckForUpdates,
     Status,
     GetChainMetadata,
+    GetDbStats,
     GetPeer,
     ListPeers,
     DialPeer,
@@ -184,6 +185,9 @@ impl Parser {
             GetChainMetadata => {
                 self.command_handler.get_chain_meta();
             },
+            GetDbStats => {
+                self.command_handler.get_blockchain_db_stats();
+            },
             DialPeer => {
                 self.process_dial_peer(args);
             },
@@ -284,6 +288,9 @@ impl Parser {
             },
             GetChainMetadata => {
                 println!("Gets your base node chain meta data");
+            },
+            GetDbStats => {
+                println!("Gets your base node database stats");
             },
             DialPeer => {
                 println!("Attempt to connect to a known peer");

--- a/base_layer/core/src/chain_storage/async_db.rs
+++ b/base_layer/core/src/chain_storage/async_db.rs
@@ -32,6 +32,8 @@ use crate::{
         ChainHeader,
         ChainStorageError,
         CompleteDeletedBitmap,
+        DbBasicStats,
+        DbTotalSizeStats,
         DbTransaction,
         HistoricalBlock,
         HorizonData,
@@ -226,6 +228,10 @@ impl<B: BlockchainBackend + 'static> AsyncBlockchainDb<B> {
     make_async_fn!(fetch_block_hashes_from_header_tip(n: usize, offset: usize) -> Vec<HashOutput>, "fetch_block_hashes_from_header_tip");
 
     make_async_fn!(fetch_complete_deleted_bitmap_at(hash: HashOutput) -> CompleteDeletedBitmap, "fetch_deleted_bitmap");
+
+    make_async_fn!(get_stats() -> DbBasicStats, "get_stats");
+
+    make_async_fn!(fetch_total_size_stats() -> DbTotalSizeStats, "fetch_total_size_stats");
 }
 
 impl<B: BlockchainBackend + 'static> From<BlockchainDatabase<B>> for AsyncBlockchainDb<B> {

--- a/base_layer/core/src/chain_storage/blockchain_backend.rs
+++ b/base_layer/core/src/chain_storage/blockchain_backend.rs
@@ -8,7 +8,9 @@ use crate::{
         ChainBlock,
         ChainHeader,
         ChainStorageError,
+        DbBasicStats,
         DbKey,
+        DbTotalSizeStats,
         DbTransaction,
         DbValue,
         HorizonData,
@@ -158,4 +160,11 @@ pub trait BlockchainBackend: Send + Sync {
     fn fetch_monero_seed_first_seen_height(&self, seed: &[u8]) -> Result<u64, ChainStorageError>;
 
     fn fetch_horizon_data(&self) -> Result<Option<HorizonData>, ChainStorageError>;
+
+    /// Returns basic database stats for each internal database, such as number of entries and page sizes. This call may
+    /// not apply to every database implementation.
+    fn get_stats(&self) -> Result<DbBasicStats, ChainStorageError>;
+    /// Returns total size information about each internal database. This call may be very slow and will obtain a read
+    /// lock for the duration.
+    fn fetch_total_size_stats(&self) -> Result<DbTotalSizeStats, ChainStorageError>;
 }

--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -35,6 +35,8 @@ use crate::{
         BlockchainBackend,
         ChainBlock,
         ChainHeader,
+        DbBasicStats,
+        DbTotalSizeStats,
         HistoricalBlock,
         HorizonData,
         MmrTree,
@@ -902,6 +904,18 @@ where B: BlockchainBackend
             height,
             chain_metadata.best_block().clone(),
         ))
+    }
+
+    pub fn get_stats(&self) -> Result<DbBasicStats, ChainStorageError> {
+        let lock = self.db_read_access()?;
+        lock.get_stats()
+    }
+
+    /// Returns total size information about each internal database. This call may be very slow and will obtain a read
+    /// lock for the duration.
+    pub fn fetch_total_size_stats(&self) -> Result<DbTotalSizeStats, ChainStorageError> {
+        let lock = self.db_read_access()?;
+        lock.fetch_total_size_stats()
     }
 }
 

--- a/base_layer/core/src/chain_storage/db_transaction.rs
+++ b/base_layer/core/src/chain_storage/db_transaction.rs
@@ -255,10 +255,6 @@ impl DbTransaction {
         &self.operations
     }
 
-    pub(crate) fn into_operations(self) -> Vec<WriteOperation> {
-        self.operations
-    }
-
     /// This will store the seed key with the height. This is called when a block is accepted into the main chain.
     /// This will only update the hieght of the seed, if its lower then currently stored.
     pub fn insert_monero_seed_height(&mut self, monero_seed: Vec<u8>, height: u64) {

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb.rs
@@ -77,6 +77,7 @@ where
     V: Serialize + Debug,
 {
     let val_buf = serialize(val)?;
+    trace!(target: LOG_TARGET, "LMDB: {} bytes inserted", val_buf.len());
     txn.access().put(&db, key, &val_buf, put::NOOVERWRITE).map_err(|e| {
         error!(
             target: LOG_TARGET,
@@ -386,4 +387,20 @@ where
         }
     }
     Ok(result)
+}
+
+/// Fetches all the size of all key/values in the given DB. Returns the number of entries, the total size of all the
+/// keys and values in bytes.
+pub fn fetch_db_entry_sizes(txn: &ConstTransaction<'_>, db: &Database) -> Result<(u64, u64, u64), ChainStorageError> {
+    let access = txn.access();
+    let mut cursor = txn.cursor(db)?;
+    let mut num_entries = 0;
+    let mut total_key_size = 0;
+    let mut total_value_size = 0;
+    while let Some((key, value)) = cursor.next::<[u8], [u8]>(&access).to_opt()? {
+        num_entries += 1;
+        total_key_size += key.len() as u64;
+        total_value_size += value.len() as u64;
+    }
+    Ok((num_entries, total_key_size, total_value_size))
 }

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb.rs
@@ -87,7 +87,6 @@ where
             val,
             e,
         );
-
         if let lmdb_zero::Error::Code(code) = &e {
             if *code == lmdb_zero::error::KEYEXIST {
                 return ChainStorageError::KeyExists {
@@ -95,8 +94,10 @@ where
                     key: to_hex(key.as_lmdb_bytes()),
                 };
             }
+            if *code == lmdb_zero::error::MAP_FULL {
+                return ChainStorageError::DbResizeRequired;
+            }
         }
-
         ChainStorageError::InsertError {
             table: table_name,
             error: e.to_string(),
@@ -121,6 +122,11 @@ where
             target: LOG_TARGET,
             "Could not insert value into lmdb transaction: {:?}", e
         );
+        if let lmdb_zero::Error::Code(code) = &e {
+            if *code == lmdb_zero::error::MAP_FULL {
+                return ChainStorageError::DbResizeRequired;
+            }
+        }
         ChainStorageError::AccessError(e.to_string())
     })
 }

--- a/base_layer/core/src/chain_storage/mod.rs
+++ b/base_layer/core/src/chain_storage/mod.rs
@@ -92,5 +92,8 @@ pub use lmdb_db::{
     LMDB_DB_UTXOS,
 };
 
+mod stats;
+pub use stats::{DbBasicStats, DbSize, DbStat, DbTotalSizeStats};
+
 mod target_difficulties;
 pub use target_difficulties::TargetDifficulties;

--- a/base_layer/core/src/chain_storage/stats.rs
+++ b/base_layer/core/src/chain_storage/stats.rs
@@ -1,0 +1,193 @@
+//  Copyright 2021, The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use lmdb_zero as lmdb;
+use std::{
+    fmt::{Display, Formatter},
+    iter::FromIterator,
+};
+
+#[derive(Debug, Clone)]
+pub struct DbBasicStats {
+    root: DbStat,
+    env_info: EnvInfo,
+    db_stats: Vec<DbStat>,
+}
+
+impl DbBasicStats {
+    pub(super) fn new<I: IntoIterator<Item = (&'static str, lmdb::Stat)>>(
+        global: lmdb::Stat,
+        env_info: lmdb::EnvInfo,
+        db_stats: I,
+    ) -> Self {
+        Self {
+            root: ("[root]", global).into(),
+            env_info: env_info.into(),
+            db_stats: db_stats.into_iter().map(Into::into).collect(),
+        }
+    }
+
+    pub fn root(&self) -> &DbStat {
+        &self.root
+    }
+
+    pub fn env_info(&self) -> &EnvInfo {
+        &self.env_info
+    }
+
+    pub fn db_stats(&self) -> &[DbStat] {
+        &self.db_stats
+    }
+}
+
+impl Display for DbBasicStats {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "Root: psize = {}, {}", self.root.psize, stat_to_string(&self.root))?;
+        for stat in &self.db_stats {
+            writeln!(f, "{}", stat_to_string(&stat))?;
+        }
+        Ok(())
+    }
+}
+
+fn stat_to_string(stat: &DbStat) -> String {
+    format!(
+        "name: {}, entries = {}, depth = {}, branch_pages = {}, leaf_pages = {}, overflow_pages = {}",
+        stat.name, stat.entries, stat.depth, stat.branch_pages, stat.leaf_pages, stat.overflow_pages
+    )
+}
+
+/// Statistics information about an environment.
+#[derive(Debug, Clone, Copy)]
+pub struct DbStat {
+    /// Name of the db
+    pub name: &'static str,
+    /// Size of a database page. This is currently the same for all databases.
+    pub psize: u32,
+    /// Depth (height) of the B-tree
+    pub depth: u32,
+    /// Number of internal (non-leaf) pages
+    pub branch_pages: usize,
+    /// Number of leaf pages
+    pub leaf_pages: usize,
+    /// Number of overflow pages
+    pub overflow_pages: usize,
+    /// Number of data items
+    pub entries: usize,
+}
+
+impl From<(&'static str, lmdb::Stat)> for DbStat {
+    fn from((name, stat): (&'static str, lmdb::Stat)) -> Self {
+        Self {
+            name,
+            psize: stat.psize,
+            depth: stat.depth,
+            branch_pages: stat.branch_pages,
+            leaf_pages: stat.leaf_pages,
+            overflow_pages: stat.overflow_pages,
+            entries: stat.entries,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DbTotalSizeStats {
+    sizes: Vec<DbSize>,
+}
+impl DbTotalSizeStats {
+    pub fn sizes(&self) -> &[DbSize] {
+        &self.sizes
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct DbSize {
+    pub name: &'static str,
+    pub num_entries: u64,
+    pub total_key_size: u64,
+    pub total_value_size: u64,
+}
+
+impl DbSize {
+    pub fn total(&self) -> u64 {
+        self.total_key_size.saturating_add(self.total_value_size)
+    }
+
+    pub fn avg_bytes_per_entry(&self) -> u64 {
+        if self.num_entries == 0 {
+            return 0;
+        }
+
+        self.total() / self.num_entries
+    }
+}
+
+impl From<Vec<DbSize>> for DbTotalSizeStats {
+    fn from(sizes: Vec<DbSize>) -> Self {
+        Self { sizes }
+    }
+}
+
+impl FromIterator<DbSize> for DbTotalSizeStats {
+    fn from_iter<T: IntoIterator<Item = DbSize>>(iter: T) -> Self {
+        Self {
+            sizes: iter.into_iter().collect(),
+        }
+    }
+}
+
+/// Configuration information about an environment.
+#[derive(Debug, Clone, Copy)]
+pub struct EnvInfo {
+    /// Size of the data memory map
+    pub mapsize: usize,
+    /// ID of the last used page
+    pub last_pgno: usize,
+    /// ID of the last committed transaction
+    pub last_txnid: usize,
+    /// max reader slots in the environment
+    pub maxreaders: u32,
+    /// max reader slots used in the environment
+    pub numreaders: u32,
+}
+
+impl From<lmdb::EnvInfo> for EnvInfo {
+    fn from(info: lmdb::EnvInfo) -> Self {
+        Self {
+            mapsize: info.mapsize,
+            last_pgno: info.last_pgno,
+            last_txnid: info.last_txnid,
+            maxreaders: info.maxreaders,
+            numreaders: info.numreaders,
+        }
+    }
+}
+
+impl Display for EnvInfo {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "mapsize: {}, last_pgno: {}, last_txnid: {}, maxreaders: {}, numreaders: {}",
+            self.mapsize, self.last_pgno, self.last_txnid, self.maxreaders, self.numreaders,
+        )
+    }
+}

--- a/base_layer/core/src/chain_storage/tests/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/tests/blockchain_database.rs
@@ -406,3 +406,26 @@ mod add_block {
         db.add_block(block).unwrap().assert_added();
     }
 }
+
+mod get_stats {
+    use super::*;
+
+    #[test]
+    fn it_works_when_db_is_empty() {
+        let db = setup();
+        let stats = db.get_stats().unwrap();
+        assert_eq!(stats.root().depth, 1);
+    }
+}
+
+mod fetch_total_size_stats {
+    use super::*;
+
+    #[test]
+    fn it_works_when_db_is_empty() {
+        let db = setup();
+        let stats = db.fetch_total_size_stats().unwrap();
+        // Returns one per db
+        assert_eq!(stats.sizes().len(), 19);
+    }
+}

--- a/base_layer/core/src/test_helpers/blockchain.rs
+++ b/base_layer/core/src/test_helpers/blockchain.rs
@@ -45,7 +45,9 @@ use crate::{
         ChainBlock,
         ChainHeader,
         ChainStorageError,
+        DbBasicStats,
         DbKey,
+        DbTotalSizeStats,
         DbTransaction,
         DbValue,
         DeletedBitmap,
@@ -329,5 +331,13 @@ impl BlockchainBackend for TempDatabase {
 
     fn fetch_horizon_data(&self) -> Result<Option<HorizonData>, ChainStorageError> {
         self.db.fetch_horizon_data()
+    }
+
+    fn get_stats(&self) -> Result<DbBasicStats, ChainStorageError> {
+        self.db.get_stats()
+    }
+
+    fn fetch_total_size_stats(&self) -> Result<DbTotalSizeStats, ChainStorageError> {
+        self.db.fetch_total_size_stats()
     }
 }

--- a/common/src/configuration/global.rs
+++ b/common/src/configuration/global.rs
@@ -41,12 +41,12 @@ use std::{
 use tari_storage::lmdb_store::LMDBConfig;
 
 const DB_INIT_DEFAULT_MB: usize = 1000;
-const DB_GROW_DEFAULT_MB: usize = 500;
-const DB_RESIZE_DEFAULT_MB: usize = 100;
+const DB_GROW_SIZE_DEFAULT_MB: usize = 500;
+const DB_RESIZE_THRESHOLD_DEFAULT_MB: usize = 100;
 
 const DB_INIT_MIN_MB: i64 = 100;
-const DB_GROW_MIN_MB: i64 = 20;
-const DB_RESIZE_MIN_MB: i64 = 10;
+const DB_GROW_SIZE_MIN_MB: i64 = 20;
+const DB_RESIZE_THRESHOLD_MIN_MB: i64 = 10;
 
 //-------------------------------------        Main Configuration Struct      --------------------------------------//
 
@@ -203,25 +203,28 @@ fn convert_node_config(
 
     let key = config_string("base_node", &net_str, "db_grow_size_mb");
     let grow_size_mb = match cfg.get_int(&key) {
-        Ok(mb) if mb < DB_GROW_MIN_MB => {
+        Ok(mb) if mb < DB_GROW_SIZE_MIN_MB => {
             return Err(ConfigurationError::new(
                 &key,
-                &format!("DB grow size must be at least {} MB.", DB_GROW_MIN_MB),
+                &format!("DB grow size must be at least {} MB.", DB_GROW_SIZE_MIN_MB),
             ))
         },
         Ok(mb) => mb as usize,
         Err(e) => match e {
-            ConfigError::NotFound(_) => DB_GROW_DEFAULT_MB, // default
+            ConfigError::NotFound(_) => DB_GROW_SIZE_DEFAULT_MB, // default
             other => return Err(ConfigurationError::new(&key, &other.to_string())),
         },
     };
 
     let key = config_string("base_node", &net_str, "db_resize_threshold_mb");
     let resize_threshold_mb = match cfg.get_int(&key) {
-        Ok(mb) if mb < DB_RESIZE_MIN_MB => {
+        Ok(mb) if mb < DB_RESIZE_THRESHOLD_MIN_MB => {
             return Err(ConfigurationError::new(
                 &key,
-                &format!("DB resize threshold must be at least {} MB.", DB_RESIZE_MIN_MB),
+                &format!(
+                    "DB resize threshold must be at least {} MB.",
+                    DB_RESIZE_THRESHOLD_MIN_MB
+                ),
             ))
         },
         Ok(mb) if mb as usize >= grow_size_mb => {
@@ -238,7 +241,7 @@ fn convert_node_config(
         },
         Ok(mb) => mb as usize,
         Err(e) => match e {
-            ConfigError::NotFound(_) => DB_RESIZE_DEFAULT_MB, // default
+            ConfigError::NotFound(_) => DB_RESIZE_THRESHOLD_DEFAULT_MB, // default
             other => return Err(ConfigurationError::new(&key, &other.to_string())),
         },
     };

--- a/infrastructure/storage/tests/lmdb.rs
+++ b/infrastructure/storage/tests/lmdb.rs
@@ -329,7 +329,7 @@ fn lmdb_resize_on_create() {
             let size_used_round_2 = env_stat.psize as usize * env_info.last_pgno;
             let space_remaining = env_info.mapsize - size_used_round_2;
             assert_eq!(size_used_round_1, size_used_round_2);
-            assert_eq!(space_remaining, PRESET_SIZE * 1024 * 1024);
+            assert!(space_remaining > PRESET_SIZE * 1024 * 1024);
             assert!(env_info.mapsize >= 2 * (PRESET_SIZE * 1024 * 1024));
         }
     }
@@ -338,6 +338,7 @@ fn lmdb_resize_on_create() {
 
 #[test]
 fn test_lmdb_resize_before_full() {
+    env_logger::init();
     let db_env_name = "resize_dynamic";
     {
         let path = get_path(&db_env_name);
@@ -360,10 +361,7 @@ fn test_lmdb_resize_before_full() {
             // our 1MB env size should be out of space
             // however the db should now be allocating additional space as it fills up
             for key in 0..32 {
-                if let Err(_e) = db.insert(&key, &value) {
-                    // println!("LMDBError {:#?}", _e);
-                    panic!("Failed to resize the LMDB store.");
-                }
+                db.insert(&key, &value).unwrap();
             }
             let env_info = store.env().info().unwrap();
             let psize = store.env().stat().unwrap().psize as usize;


### PR DESCRIPTION
Description
---
Adds `get-db-stats` command. This returns the LMDB entry stats and
the total entry sizes for each internal blockchain db.

Motivation and Context
---
Useful in debugging database sizes. At height 26215

```
>> get-db-stats
Name                              | Entries | Depth | Branch Pages | Leaf Pages | Overflow Pages
--------------------------------- | ------- | ----- | ------------ | ---------- | --------------
metadata_db                       | 5       | 1     | 0            | 1          | 23
headers_db                        | 26218   | 3     | 19           | 4057       | 0
header_accumulated_data_db        | 26218   | 3     | 6            | 1010       | 0
block_accumulated_data_db         | 26218   | 3     | 99           | 21775      | 1087
block_hashes_db                   | 26218   | 3     | 9            | 468        | 0
utxos_db                          | 747509  | 5     | 15022        | 373736     | 0
inputs_db                         | 560784  | 5     | 5928         | 99085      | 0
txos_hash_to_index_db             | 747509  | 4     | 533          | 35242      | 0
kernels_db                        | 262572  | 5     | 2556         | 39712      | 0
kernel_excess_index               | 262572  | 4     | 172          | 11999      | 0
kernel_excess_sig_index           | 262572  | 4     | 432          | 15393      | 0
kernel_mmr_size_index             | 26218   | 2     | 1            | 170        | 0
output_mmr_size_index             | 26218   | 3     | 3            | 438        | 0
utxo_commitment_index             | 186725  | 4     | 119          | 6889       | 0
orphans_db                        | 720     | 3     | 9            | 554        | 1674
orphan_header_accumulated_data_db | 718     | 2     | 1            | 47         | 0
monero_seed_height_db             | 1       | 1     | 0            | 1          | 0
orphan_chain_tips_db              | 16      | 1     | 0            | 1          | 0
orphan_parent_map_index           | 720     | 2     | 1            | 22         | 0

19 databases, page size: 4096 bytes

Totalling DB entry sizes. This may take a few seconds...

>>
Name                              | Entries | Total Size | Avg. Size/Entry | % of total
--------------------------------- | ------- | ---------- | --------------- | ----------
metadata_db                       | 5       | 0.09 MiB   | 18859 bytes     | 0.01%
headers_db                        | 26218   | 12.34 MiB  | 493 bytes       | 0.90%
header_accumulated_data_db        | 26218   | 3.40 MiB   | 136 bytes       | 0.25%
block_accumulated_data_db         | 26218   | 39.25 MiB  | 1569 bytes      | 2.86%
block_hashes_db                   | 26218   | 1.00 MiB   | 40 bytes        | 0.07%
utxos_db                          | 747509  | 789.72 MiB | 1107 bytes      | 57.51%
inputs_db                         | 560784  | 263.80 MiB | 493 bytes       | 19.21%
txos_hash_to_index_db             | 747509  | 84.83 MiB  | 119 bytes       | 6.18%
kernels_db                        | 262572  | 90.40 MiB  | 361 bytes       | 6.58%
kernel_excess_index               | 262572  | 29.05 MiB  | 116 bytes       | 2.12%
kernel_excess_sig_index           | 262572  | 37.06 MiB  | 148 bytes       | 2.70%
kernel_mmr_size_index             | 26218   | 0.40 MiB   | 16 bytes        | 0.03%
output_mmr_size_index             | 26218   | 1.40 MiB   | 56 bytes        | 0.10%
utxo_commitment_index             | 186725  | 12.82 MiB  | 72 bytes        | 0.93%
orphans_db                        | 720     | 7.51 MiB   | 10932 bytes     | 0.55%
orphan_header_accumulated_data_db | 718     | 0.11 MiB   | 160 bytes       | 0.01%
monero_seed_height_db             | 1       | 0.00 MiB   | 40 bytes        | 0.00%
orphan_chain_tips_db              | 16      | 0.00 MiB   | 72 bytes        | 0.00%
orphan_parent_map_index           | 720     | 0.05 MiB   | 72 bytes        | 0.00%

Total data size: 1373.23 MiB
```

How Has This Been Tested?
---
Manually by running `get-db-stats`
