### PR TITLE
fix: update cucumber tests for walletffi.feature

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,9 +127,15 @@ commands:
           name: Generate report
           command: cd integration_tests && node ./generate_report.js
           when: always
+      #- run:
+      #    name: Set the correct Node version for wallet FFI tests
+      #    shell: bash -l {0}
+      #    command: nvm install v12.22.6 && nvm use v12.22.6 && cd integration_tests && npm install
+      #    when: always
       - run:
-          name: Run ffi cucumber scenarios
+          name: Run FFI wallet library cucumber scenarios
           command: cd integration_tests && mkdir -p cucumber_output && node_modules/.bin/cucumber-js --tags "not @long-running and not @broken and not @flaky and @wallet-ffi" --format json:cucumber_output/tests_ffi.cucumber --exit
+          when: always
       - run:
           name: Generate report (ffi)
           command: cd integration_tests && node ./generate_report.js "cucumber_output/tests_ffi.cucumber" "temp/reports/cucumber_ffi_report.html"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5049,7 +5049,7 @@ dependencies = [
 
 [[package]]
 name = "tari_wallet_ffi"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "chrono",
  "env_logger 0.7.1",

--- a/integration_tests/features/support/steps.js
+++ b/integration_tests/features/support/steps.js
@@ -13,6 +13,7 @@ const {
   consoleLogBalance,
   consoleLogTransactionDetails,
   withTimeout,
+  waitForIterate,
 } = require("../../helpers/util");
 const { ConnectivityStatus, PaymentType } = require("../../helpers/types");
 const TransactionBuilder = require("../../helpers/transactionBuilder");
@@ -3539,19 +3540,6 @@ When(
 );
 
 Then(
-  "I want to get public key of ffi wallet {word}",
-  { timeout: 20 * 1000 },
-  function (name) {
-    let wallet = this.getWallet(name);
-    let public_key = wallet.identify();
-    expect(public_key.length).to.be.equal(
-      64,
-      `Public key has wrong length : ${public_key}`
-    );
-  }
-);
-
-Then(
   "I want to get emoji id of ffi wallet {word}",
   { timeout: 20 * 1000 },
   async function (name) {
@@ -3826,14 +3814,13 @@ Then(
       "Waiting for " + wallet_name + " to receive " + amount + " transaction(s)"
     );
 
-    await waitFor(
-      async () => {
+    await waitForIterate(
+      () => {
         return wallet.getCounters().received >= amount;
       },
       true,
-      700 * 1000,
-      5 * 1000,
-      5
+      1000,
+      700
     );
 
     if (!(wallet.getCounters().received >= amount)) {
@@ -3860,14 +3847,13 @@ Then(
         " transaction finalization(s)"
     );
 
-    await waitFor(
-      async () => {
+    await waitForIterate(
+      () => {
         return wallet.getCounters().finalized >= amount;
       },
       true,
-      700 * 1000,
-      5 * 1000,
-      5
+      1000,
+      700
     );
 
     if (!(wallet.getCounters().finalized >= amount)) {
@@ -3880,7 +3866,7 @@ Then(
 );
 
 Then(
-  /I wait for ffi wallet (.*) to receive (.*) SAF message/,
+  /I wait for ffi wallet (.*) to receive (.*) broadcast/,
   { timeout: 710 * 1000 },
   async function (wallet_name, amount) {
     let wallet = this.getWallet(wallet_name);
@@ -3891,17 +3877,82 @@ Then(
         wallet_name +
         " to receive " +
         amount +
+        " transaction broadcast(s)"
+    );
+
+    await waitForIterate(
+      () => {
+        return wallet.getCounters().broadcast >= amount;
+      },
+      true,
+      1000,
+      700
+    );
+
+    if (!(wallet.getCounters().broadcast >= amount)) {
+      console.log("Counter not adequate!");
+    } else {
+      console.log(wallet.getCounters());
+    }
+    expect(wallet.getCounters().broadcast >= amount).to.equal(true);
+  }
+);
+
+Then(
+  /I wait for ffi wallet (.*) to receive (.*) mined/,
+  { timeout: 710 * 1000 },
+  async function (wallet_name, amount) {
+    let wallet = this.getWallet(wallet_name);
+
+    console.log("\n");
+    console.log(
+      "Waiting for " +
+        wallet_name +
+        " to receive " +
+        amount +
+        " transaction mined"
+    );
+
+    await waitForIterate(
+      () => {
+        return wallet.getCounters().mined >= amount;
+      },
+      true,
+      1000,
+      700
+    );
+
+    if (!(wallet.getCounters().mined >= amount)) {
+      console.log("Counter not adequate!");
+    } else {
+      console.log(wallet.getCounters());
+    }
+    expect(wallet.getCounters().mined >= amount).to.equal(true);
+  }
+);
+
+Then(
+  /I wait for ffi wallet (.*) to receive at least (.*) SAF message/,
+  { timeout: 710 * 1000 },
+  async function (wallet_name, amount) {
+    let wallet = this.getWallet(wallet_name);
+
+    console.log("\n");
+    console.log(
+      "Waiting for " +
+        wallet_name +
+        " to receive at least " +
+        amount +
         " SAF messages(s)"
     );
 
-    await waitFor(
-      async () => {
+    await waitForIterate(
+      () => {
         return wallet.getCounters().saf >= amount;
       },
       true,
-      700 * 1000,
-      5 * 1000,
-      5
+      1000,
+      700
     );
 
     if (!(wallet.getCounters().saf >= amount)) {
@@ -3924,23 +3975,21 @@ Then(
       "Waiting for " + wallet_name + " balance to be at least " + amount + " uT"
     );
 
-    let count = 0;
-
-    while (!(wallet.getBalance().available >= amount)) {
-      await sleep(1000);
-      count++;
-      if (count > 700) {
-        break;
-      }
-    }
+    await waitForIterate(
+      () => {
+        return wallet.getBalance().available >= amount;
+      },
+      true,
+      1000,
+      700
+    );
 
     let balance = wallet.getBalance().available;
 
     if (!(balance >= amount)) {
       console.log("Balance not adequate!");
-    } else {
-      console.log(wallet.getBalance());
     }
+
     expect(balance >= amount).to.equal(true);
   }
 );
@@ -3961,10 +4010,28 @@ When(/I start ffi wallet (.*)/, async function (walletName) {
   await wallet.startNew(null, null);
 });
 
-When(/I restart ffi wallet (.*)/, async function (walletName) {
-  let wallet = this.getWallet(walletName);
-  await wallet.restart();
-});
+When(
+  /I restart ffi wallet (.*) connected to base node (.*)/,
+  async function (walletName, node) {
+    let wallet = this.getWallet(walletName);
+    await wallet.restart();
+    let peer = this.nodes[node].peerAddress().split("::");
+    wallet.addBaseNodePeer(peer[0], peer[1]);
+  }
+);
+
+Then(
+  "I want to get public key of ffi wallet {word}",
+  { timeout: 20 * 1000 },
+  function (name) {
+    let wallet = this.getWallet(name);
+    let public_key = wallet.identify();
+    expect(public_key.length).to.be.equal(
+      64,
+      `Public key has wrong length : ${public_key}`
+    );
+  }
+);
 
 When(/I stop ffi wallet (.*)/, function (walletName) {
   let wallet = this.getWallet(walletName);

--- a/integration_tests/features/support/world.js
+++ b/integration_tests/features/support/world.js
@@ -9,6 +9,8 @@ const TransactionBuilder = require("../../helpers/transactionBuilder");
 const glob = require("glob");
 const fs = require("fs");
 const archiver = require("archiver");
+const InterfaceFFI = require("../../helpers/ffi/ffiInterface");
+
 class CustomWorld {
   constructor({ attach, parameters }) {
     // this.variable = 0;
@@ -381,7 +383,8 @@ BeforeAll({ timeout: 1200000 }, async function () {
   await miningNode.compile();
 
   console.log("Compiling wallet FFI...");
-  await WalletFFIClient.Init();
+  await InterfaceFFI.compile();
+  await InterfaceFFI.init();
   console.log("Finished compilation.");
 });
 

--- a/integration_tests/helpers/ffi/byteVector.js
+++ b/integration_tests/helpers/ffi/byteVector.js
@@ -1,15 +1,15 @@
 const InterfaceFFI = require("./ffiInterface");
 
 class ByteVector {
-  #byte_vector_ptr;
+  ptr;
 
   pointerAssign(ptr) {
     // Prevent pointer from being leaked in case of re-assignment
-    if (this.#byte_vector_ptr) {
+    if (this.ptr) {
       this.destroy();
-      this.#byte_vector_ptr = ptr;
+      this.ptr = ptr;
     } else {
-      this.#byte_vector_ptr = ptr;
+      this.ptr = ptr;
     }
   }
 
@@ -30,21 +30,21 @@ class ByteVector {
   }
 
   getLength() {
-    return InterfaceFFI.byteVectorGetLength(this.#byte_vector_ptr);
+    return InterfaceFFI.byteVectorGetLength(this.ptr);
   }
 
   getAt(position) {
-    return InterfaceFFI.byteVectorGetAt(this.#byte_vector_ptr, position);
+    return InterfaceFFI.byteVectorGetAt(this.ptr, position);
   }
 
   getPtr() {
-    return this.#byte_vector_ptr;
+    return this.ptr;
   }
 
   destroy() {
-    if (this.#byte_vector_ptr) {
-      InterfaceFFI.byteVectorDestroy(this.#byte_vector_ptr);
-      this.#byte_vector_ptr = undefined; //prevent double free segfault
+    if (this.ptr) {
+      InterfaceFFI.byteVectorDestroy(this.ptr);
+      this.ptr = undefined; //prevent double free segfault
     }
   }
 }

--- a/integration_tests/helpers/ffi/commsConfig.js
+++ b/integration_tests/helpers/ffi/commsConfig.js
@@ -2,7 +2,7 @@ const InterfaceFFI = require("./ffiInterface");
 const utf8 = require("utf8");
 
 class CommsConfig {
-  #comms_config_ptr;
+  ptr;
 
   constructor(
     public_address,
@@ -17,7 +17,7 @@ class CommsConfig {
     let sanitize_db_name = utf8.encode(database_name);
     let sanitize_db_path = utf8.encode(datastore_path);
     let sanitize_network = utf8.encode(network);
-    this.#comms_config_ptr = InterfaceFFI.commsConfigCreate(
+    this.ptr = InterfaceFFI.commsConfigCreate(
       sanitize_address,
       transport_ptr,
       sanitize_db_name,
@@ -29,13 +29,13 @@ class CommsConfig {
   }
 
   getPtr() {
-    return this.#comms_config_ptr;
+    return this.ptr;
   }
 
   destroy() {
-    if (this.#comms_config_ptr) {
-      InterfaceFFI.commsConfigDestroy(this.#comms_config_ptr);
-      this.#comms_config_ptr = undefined; //prevent double free segfault
+    if (this.ptr) {
+      InterfaceFFI.commsConfigDestroy(this.ptr);
+      this.ptr = undefined; //prevent double free segfault
     }
   }
 }

--- a/integration_tests/helpers/ffi/completedTransaction.js
+++ b/integration_tests/helpers/ffi/completedTransaction.js
@@ -2,33 +2,29 @@ const InterfaceFFI = require("./ffiInterface");
 const PublicKey = require("./publicKey");
 
 class CompletedTransaction {
-  #tari_completed_transaction_ptr;
+  ptr;
 
   pointerAssign(ptr) {
-    if (this.#tari_completed_transaction_ptr) {
+    if (this.ptr) {
       this.destroy();
-      this.#tari_completed_transaction_ptr = ptr;
+      this.ptr = ptr;
     } else {
-      this.#tari_completed_transaction_ptr = ptr;
+      this.ptr = ptr;
     }
   }
 
   getPtr() {
-    return this.#tari_completed_transaction_ptr;
+    return this.ptr;
   }
 
   isOutbound() {
-    return InterfaceFFI.completedTransactionIsOutbound(
-      this.#tari_completed_transaction_ptr
-    );
+    return InterfaceFFI.completedTransactionIsOutbound(this.ptr);
   }
 
   getDestinationPublicKey() {
     let result = new PublicKey();
     result.pointerAssign(
-      InterfaceFFI.completedTransactionGetDestinationPublicKey(
-        this.#tari_completed_transaction_ptr
-      )
+      InterfaceFFI.completedTransactionGetDestinationPublicKey(this.ptr)
     );
     return result;
   }
@@ -36,67 +32,47 @@ class CompletedTransaction {
   getSourcePublicKey() {
     let result = new PublicKey();
     result.pointerAssign(
-      InterfaceFFI.completedTransactionGetSourcePublicKey(
-        this.#tari_completed_transaction_ptr
-      )
+      InterfaceFFI.completedTransactionGetSourcePublicKey(this.ptr)
     );
     return result;
   }
 
   getAmount() {
-    return InterfaceFFI.completedTransactionGetAmount(
-      this.#tari_completed_transaction_ptr
-    );
+    return InterfaceFFI.completedTransactionGetAmount(this.ptr);
   }
 
   getFee() {
-    return InterfaceFFI.completedTransactionGetFee(
-      this.#tari_completed_transaction_ptr
-    );
+    return InterfaceFFI.completedTransactionGetFee(this.ptr);
   }
 
   getMessage() {
-    return InterfaceFFI.completedTransactionGetMessage(
-      this.#tari_completed_transaction_ptr
-    );
+    return InterfaceFFI.completedTransactionGetMessage(this.ptr);
   }
 
   getStatus() {
-    return InterfaceFFI.completedTransactionGetStatus(
-      this.#tari_completed_transaction_ptr
-    );
+    return InterfaceFFI.completedTransactionGetStatus(this.ptr);
   }
 
   getTransactionID() {
-    return InterfaceFFI.completedTransactionGetTransactionId(
-      this.#tari_completed_transaction_ptr
-    );
+    return InterfaceFFI.completedTransactionGetTransactionId(this.ptr);
   }
 
   getTimestamp() {
-    return InterfaceFFI.completedTransactionGetTimestamp(
-      this.#tari_completed_transaction_ptr
-    );
+    return InterfaceFFI.completedTransactionGetTimestamp(this.ptr);
   }
 
   isValid() {
-    return InterfaceFFI.completedTransactionIsValid(
-      this.#tari_completed_transaction_ptr
-    );
+    return InterfaceFFI.completedTransactionIsValid(this.ptr);
   }
 
   getConfirmations() {
-    return InterfaceFFI.completedTransactionGetConfirmations(
-      this.#tari_completed_transaction_ptr
-    );
+    return InterfaceFFI.completedTransactionGetConfirmations(this.ptr);
   }
 
   destroy() {
-    if (this.#tari_completed_transaction_ptr) {
-      InterfaceFFI.completedTransactionDestroy(
-        this.#tari_completed_transaction_ptr
-      );
-      this.#tari_completed_transaction_ptr = undefined; //prevent double free segfault
+    if (this.ptr) {
+      InterfaceFFI.completedTransactionDestroy(this.ptr);
+      this.ptr = undefined; //prevent double free segfault
     }
   }
 }

--- a/integration_tests/helpers/ffi/completedTransactions.js
+++ b/integration_tests/helpers/ffi/completedTransactions.js
@@ -2,35 +2,28 @@ const CompletedTransaction = require("./completedTransaction");
 const InterfaceFFI = require("./ffiInterface");
 
 class CompletedTransactions {
-  #tari_completed_transactions_ptr;
+  ptr;
 
   constructor(ptr) {
-    this.#tari_completed_transactions_ptr = ptr;
+    this.ptr = ptr;
   }
 
   getLength() {
-    return InterfaceFFI.completedTransactionsGetLength(
-      this.#tari_completed_transactions_ptr
-    );
+    return InterfaceFFI.completedTransactionsGetLength(this.ptr);
   }
 
   getAt(position) {
     let result = new CompletedTransaction();
     result.pointerAssign(
-      InterfaceFFI.completedTransactionsGetAt(
-        this.#tari_completed_transactions_ptr,
-        position
-      )
+      InterfaceFFI.completedTransactionsGetAt(this.ptr, position)
     );
     return result;
   }
 
   destroy() {
-    if (this.#tari_completed_transactions_ptr) {
-      InterfaceFFI.completedTransactionsDestroy(
-        this.#tari_completed_transactions_ptr
-      );
-      this.#tari_completed_transactions_ptr = undefined; //prevent double free segfault
+    if (this.ptr) {
+      InterfaceFFI.completedTransactionsDestroy(this.ptr);
+      this.ptr = undefined; //prevent double free segfault
     }
   }
 }

--- a/integration_tests/helpers/ffi/contact.js
+++ b/integration_tests/helpers/ffi/contact.js
@@ -2,50 +2,48 @@ const PublicKey = require("./publicKey");
 const InterfaceFFI = require("./ffiInterface");
 
 class Contact {
-  #tari_contact_ptr;
+  ptr;
 
   pointerAssign(ptr) {
     // Prevent pointer from being leaked in case of re-assignment
-    if (this.#tari_contact_ptr) {
+    if (this.ptr) {
       this.destroy();
-      this.#tari_contact_ptr = ptr;
+      this.ptr = ptr;
     } else {
-      this.#tari_contact_ptr = ptr;
+      this.ptr = ptr;
     }
   }
 
   getPtr() {
-    return this.#tari_contact_ptr;
+    return this.ptr;
   }
 
   getAlias() {
-    const alias = InterfaceFFI.contactGetAlias(this.#tari_contact_ptr);
-    const result = alias.readCString();
+    let alias = InterfaceFFI.contactGetAlias(this.ptr);
+    let result = alias.readCString();
     InterfaceFFI.stringDestroy(alias);
     return result;
   }
 
   getPubkey() {
     let result = new PublicKey();
-    result.pointerAssign(
-      InterfaceFFI.contactGetPublicKey(this.#tari_contact_ptr)
-    );
+    result.pointerAssign(InterfaceFFI.contactGetPublicKey(this.ptr));
     return result;
   }
 
   getPubkeyHex() {
     let result = "";
     let pk = new PublicKey();
-    pk.pointerAssign(InterfaceFFI.contactGetPublicKey(this.#tari_contact_ptr));
+    pk.pointerAssign(InterfaceFFI.contactGetPublicKey(this.ptr));
     result = pk.getHex();
     pk.destroy();
     return result;
   }
 
   destroy() {
-    if (this.#tari_contact_ptr) {
-      InterfaceFFI.contactDestroy(this.#tari_contact_ptr);
-      this.#tari_contact_ptr = undefined; //prevent double free segfault
+    if (this.ptr) {
+      InterfaceFFI.contactDestroy(this.ptr);
+      this.ptr = undefined; //prevent double free segfault
     }
   }
 }

--- a/integration_tests/helpers/ffi/contacts.js
+++ b/integration_tests/helpers/ffi/contacts.js
@@ -2,28 +2,26 @@ const Contact = require("./contact");
 const InterfaceFFI = require("./ffiInterface");
 
 class Contacts {
-  #tari_contacts_ptr;
+  ptr;
 
   constructor(ptr) {
-    this.#tari_contacts_ptr = ptr;
+    this.ptr = ptr;
   }
 
   getLength() {
-    return InterfaceFFI.contactsGetLength(this.#tari_contacts_ptr);
+    return InterfaceFFI.contactsGetLength(this.ptr);
   }
 
   getAt(position) {
     let result = new Contact();
-    result.pointerAssign(
-      InterfaceFFI.contactsGetAt(this.#tari_contacts_ptr, position)
-    );
+    result.pointerAssign(InterfaceFFI.contactsGetAt(this.ptr, position));
     return result;
   }
 
   destroy() {
-    if (this.#tari_contacts_ptr) {
-      InterfaceFFI.contactsDestroy(this.#tari_contacts_ptr);
-      this.#tari_contacts_ptr = undefined; //prevent double free segfault
+    if (this.ptr) {
+      InterfaceFFI.contactsDestroy(this.ptr);
+      this.ptr = undefined; //prevent double free segfault
     }
   }
 }

--- a/integration_tests/helpers/ffi/emojiSet.js
+++ b/integration_tests/helpers/ffi/emojiSet.js
@@ -1,18 +1,18 @@
 const InterfaceFFI = require("./ffiInterface");
 
 class EmojiSet {
-  #emoji_set_ptr;
+  ptr;
 
   constructor() {
-    this.#emoji_set_ptr = InterfaceFFI.getEmojiSet();
+    this.ptr = InterfaceFFI.getEmojiSet();
   }
 
   getLength() {
-    return InterfaceFFI.emojiSetGetLength(this.#emoji_set_ptr);
+    return InterfaceFFI.emojiSetGetLength(this.ptr);
   }
 
   getAt(position) {
-    return InterfaceFFI.emojiSetGetAt(this.#emoji_set_ptr, position);
+    return InterfaceFFI.emojiSetGetAt(this.ptr, position);
   }
 
   list() {
@@ -26,9 +26,9 @@ class EmojiSet {
   }
 
   destroy() {
-    if (this.#emoji_set_ptr) {
-      InterfaceFFI.byteVectorDestroy(this.#emoji_set_ptr);
-      this.#emoji_set_ptr = undefined; //prevent double free segfault
+    if (this.ptr) {
+      InterfaceFFI.byteVectorDestroy(this.ptr);
+      this.ptr = undefined; //prevent double free segfault
     }
   }
 }

--- a/integration_tests/helpers/ffi/ffiInterface.js
+++ b/integration_tests/helpers/ffi/ffiInterface.js
@@ -1,6 +1,6 @@
 /**
- * This library was AUTO-GENERATED. Do not modify manually!
- */
+ * NB!: Modify with caution.
+ **/
 
 const { expect } = require("chai");
 const ffi = require("ffi-napi");
@@ -10,6 +10,20 @@ const { spawn } = require("child_process");
 const fs = require("fs");
 
 class InterfaceFFI {
+  static void = ref.types.void;
+  static bool = ref.types.bool;
+  static int = ref.types.int;
+  static ulonglong = ref.types.ulonglong;
+  static uchar = ref.types.uchar;
+  static uint = ref.types.uint;
+  static string = ref.types.CString;
+  static ucharPtr = ref.refType(this.uchar); // uchar*
+  static ptr = ref.refType(this.void); //pointer is opaque
+  static stringPtr = ref.refType(this.string);
+  static intPtr = ref.refType(this.int); // int*
+  static boolPtr = ref.refType(this.bool); // bool*
+  static ushort = ref.types.ushort;
+
   //region Compile
   static compile() {
     return new Promise((resolve, _reject) => {
@@ -46,279 +60,386 @@ class InterfaceFFI {
         console.log("error : ", error.toString());
       });
       expect(ps.error).to.be.an("undefined");
-      this.#ps = ps;
+      this.ps = ps;
     });
   }
   //endregion
 
   //region Interface
-  static #fn;
+  static fn;
 
-  static #loaded = false;
-  static #ps = null;
+  static loaded = false;
+  static ps = null;
+  static library = null;
 
-  static async Init() {
-    if (this.#loaded) {
-      return;
-    }
-
-    this.#loaded = true;
-    await this.compile();
-    const outputProcess = `${process.cwd()}/temp/out/${
+  static async init() {
+    this.library = `${process.cwd()}/temp/out/${
       process.platform === "win32" ? "" : "lib"
     }tari_wallet_ffi`;
-
     // Load the library
-    this.#fn = ffi.Library(outputProcess, {
-      transport_memory_create: ["pointer", ["void"]],
-      transport_tcp_create: ["pointer", ["string", "int*"]],
+    this.fn = ffi.Library(this.loaded ? null : this.library, {
+      transport_memory_create: [this.ptr, []],
+      transport_tcp_create: [this.ptr, [this.string, this.intPtr]],
       transport_tor_create: [
-        "pointer",
-        ["string", "pointer", "ushort", "string", "string", "int*"],
+        this.ptr,
+        [
+          this.string,
+          this.ptr,
+          this.ushort,
+          this.string,
+          this.string,
+          this.intPtr,
+        ],
       ],
-      transport_memory_get_address: ["char*", ["pointer", "int*"]],
-      transport_type_destroy: ["void", ["pointer"]],
-      string_destroy: ["void", ["string"]],
-      byte_vector_create: ["pointer", ["uchar*", "uint", "int*"]],
-      byte_vector_get_at: ["uchar", ["pointer", "uint", "int*"]],
-      byte_vector_get_length: ["uint", ["pointer", "int*"]],
-      byte_vector_destroy: ["void", ["pointer"]],
-      public_key_create: ["pointer", ["pointer", "int*"]],
-      public_key_get_bytes: ["pointer", ["pointer", "int*"]],
-      public_key_from_private_key: ["pointer", ["pointer", "int*"]],
-      public_key_from_hex: ["pointer", ["string", "int*"]],
-      public_key_destroy: ["void", ["pointer"]],
-      public_key_to_emoji_id: ["char*", ["pointer", "int*"]],
-      emoji_id_to_public_key: ["pointer", ["string", "int*"]],
-      private_key_create: ["pointer", ["pointer", "int*"]],
-      private_key_generate: ["pointer", ["void"]],
-      private_key_get_bytes: ["pointer", ["pointer", "int*"]],
-      private_key_from_hex: ["pointer", ["string", "int*"]],
-      private_key_destroy: ["void", ["pointer"]],
-      seed_words_create: ["pointer", ["void"]],
-      seed_words_get_length: ["uint", ["pointer", "int*"]],
-      seed_words_get_at: ["char*", ["pointer", "uint", "int*"]],
-      seed_words_push_word: ["uchar", ["pointer", "string", "int*"]],
-      seed_words_destroy: ["void", ["pointer"]],
-      contact_create: ["pointer", ["string", "pointer", "int*"]],
-      contact_get_alias: ["char*", ["pointer", "int*"]],
-      contact_get_public_key: ["pointer", ["pointer", "int*"]],
-      contact_destroy: ["void", ["pointer"]],
-      contacts_get_length: ["uint", ["pointer", "int*"]],
-      contacts_get_at: ["pointer", ["pointer", "uint", "int*"]],
-      contacts_destroy: ["void", ["pointer"]],
+      transport_memory_get_address: [this.stringPtr, [this.ptr, this.intPtr]],
+      transport_type_destroy: [this.void, [this.ptr]],
+      string_destroy: [this.void, [this.string]],
+      byte_vector_create: [this.ptr, [this.ucharPtr, this.uint, this.intPtr]],
+      byte_vector_get_at: [this.uchar, [this.ptr, this.uint, this.intPtr]],
+      byte_vector_get_length: [this.uint, [this.ptr, this.intPtr]],
+      byte_vector_destroy: [this.void, [this.ptr]],
+      public_key_create: [this.ptr, [this.ptr, this.intPtr]],
+      public_key_get_bytes: [this.ptr, [this.ptr, this.intPtr]],
+      public_key_from_private_key: [this.ptr, [this.ptr, this.intPtr]],
+      public_key_from_hex: [this.ptr, [this.string, this.intPtr]],
+      public_key_destroy: [this.void, [this.ptr]],
+      public_key_to_emoji_id: [this.stringPtr, [this.ptr, this.intPtr]],
+      emoji_id_to_public_key: [this.ptr, [this.string, this.intPtr]],
+      private_key_create: [this.ptr, [this.ptr, this.intPtr]],
+      private_key_generate: [this.ptr, []],
+      private_key_get_bytes: [this.ptr, [this.ptr, this.intPtr]],
+      private_key_from_hex: [this.ptr, [this.string, this.intPtr]],
+      private_key_destroy: [this.void, [this.ptr]],
+      seed_words_create: [this.ptr, []],
+      seed_words_get_length: [this.uint, [this.ptr, this.intPtr]],
+      seed_words_get_at: [this.stringPtr, [this.ptr, this.uint, this.intPtr]],
+      seed_words_push_word: [this.uchar, [this.ptr, this.string, this.intPtr]],
+      seed_words_destroy: [this.void, [this.ptr]],
+      contact_create: [this.ptr, [this.string, this.ptr, this.intPtr]],
+      contact_get_alias: [this.stringPtr, [this.ptr, this.intPtr]],
+      contact_get_public_key: [this.ptr, [this.ptr, this.intPtr]],
+      contact_destroy: [this.void, [this.ptr]],
+      contacts_get_length: [this.uint, [this.ptr, this.intPtr]],
+      contacts_get_at: [this.ptr, [this.ptr, this.uint, this.intPtr]],
+      contacts_destroy: [this.void, [this.ptr]],
       completed_transaction_get_destination_public_key: [
-        "pointer",
-        ["pointer", "int*"],
+        this.ptr,
+        [this.ptr, this.intPtr],
       ],
       completed_transaction_get_source_public_key: [
-        "pointer",
-        ["pointer", "int*"],
+        this.ptr,
+        [this.ptr, this.intPtr],
       ],
-      completed_transaction_get_amount: ["uint64", ["pointer", "int*"]],
-      completed_transaction_get_fee: ["uint64", ["pointer", "int*"]],
-      completed_transaction_get_message: ["char*", ["pointer", "int*"]],
-      completed_transaction_get_status: ["int", ["pointer", "int*"]],
-      completed_transaction_get_transaction_id: ["uint64", ["pointer", "int*"]],
-      completed_transaction_get_timestamp: ["uint64", ["pointer", "int*"]],
-      completed_transaction_is_valid: ["bool", ["pointer", "int*"]],
-      completed_transaction_is_outbound: ["bool", ["pointer", "int*"]],
-      completed_transaction_get_confirmations: ["uint64", ["pointer", "int*"]],
-      completed_transaction_destroy: ["void", ["pointer"]],
+      completed_transaction_get_amount: [
+        this.ulonglong,
+        [this.ptr, this.intPtr],
+      ],
+      completed_transaction_get_fee: [this.ulonglong, [this.ptr, this.intPtr]],
+      completed_transaction_get_message: [
+        this.stringPtr,
+        [this.ptr, this.intPtr],
+      ],
+      completed_transaction_get_status: [this.int, [this.ptr, this.intPtr]],
+      completed_transaction_get_transaction_id: [
+        this.ulonglong,
+        [this.ptr, this.intPtr],
+      ],
+      completed_transaction_get_timestamp: [
+        this.ulonglong,
+        [this.ptr, this.intPtr],
+      ],
+      completed_transaction_is_valid: [this.bool, [this.ptr, this.intPtr]],
+      completed_transaction_is_outbound: [this.bool, [this.ptr, this.intPtr]],
+      completed_transaction_get_confirmations: [
+        this.ulonglong,
+        [this.ptr, this.intPtr],
+      ],
+      completed_transaction_destroy: [this.void, [this.ptr]],
       //completed_transaction_get_excess: [
       //this.tari_excess_ptr,
-      //  [this.tari_completed_transaction_ptr, "int*"],
+      //  [this.tari_completed_transaction_ptr, this.intPtr],
       //],
       //completed_transaction_get_public_nonce: [
       // this.tari_excess_public_nonce_ptr,
-      //  [this.tari_completed_transaction_ptr, "int*"],
+      //  [this.tari_completed_transaction_ptr, this.intPtr],
       //],
       //completed_transaction_get_signature: [
       //  this.tari_excess_signature_ptr,
-      //  [this.tari_completed_transaction_ptr, "int*"],
+      //  [this.tari_completed_transaction_ptr, this.intPtr],
       //],
-      // excess_destroy: ["void", [this.tari_excess_ptr]],
-      // nonce_destroy: ["void", [this.tari_excess_public_nonce_ptr]],
-      // signature_destroy: ["void", [this.tari_excess_signature_ptr]],
-      completed_transactions_get_length: ["uint", ["pointer", "int*"]],
-      completed_transactions_get_at: ["pointer", ["pointer", "uint", "int*"]],
-      completed_transactions_destroy: ["void", ["pointer"]],
+      // excess_destroy: [this.void, [this.tari_excess_ptr]],
+      // nonce_destroy: [this.void, [this.tari_excess_public_nonce_ptr]],
+      // signature_destroy: [this.void, [this.tari_excess_signature_ptr]],
+      completed_transactions_get_length: [this.uint, [this.ptr, this.intPtr]],
+      completed_transactions_get_at: [
+        this.ptr,
+        [this.ptr, this.uint, this.intPtr],
+      ],
+      completed_transactions_destroy: [this.void, [this.ptr]],
       pending_outbound_transaction_get_transaction_id: [
-        "uint64",
-        ["pointer", "int*"],
+        this.ulonglong,
+        [this.ptr, this.intPtr],
       ],
       pending_outbound_transaction_get_destination_public_key: [
-        "pointer",
-        ["pointer", "int*"],
+        this.ptr,
+        [this.ptr, this.intPtr],
       ],
-      pending_outbound_transaction_get_amount: ["uint64", ["pointer", "int*"]],
-      pending_outbound_transaction_get_fee: ["uint64", ["pointer", "int*"]],
-      pending_outbound_transaction_get_message: ["char*", ["pointer", "int*"]],
+      pending_outbound_transaction_get_amount: [
+        this.ulonglong,
+        [this.ptr, this.intPtr],
+      ],
+      pending_outbound_transaction_get_fee: [
+        this.ulonglong,
+        [this.ptr, this.intPtr],
+      ],
+      pending_outbound_transaction_get_message: [
+        this.stringPtr,
+        [this.ptr, this.intPtr],
+      ],
       pending_outbound_transaction_get_timestamp: [
-        "uint64",
-        ["pointer", "int*"],
+        this.ulonglong,
+        [this.ptr, this.intPtr],
       ],
-      pending_outbound_transaction_get_status: ["int", ["pointer", "int*"]],
-      pending_outbound_transaction_destroy: ["void", ["pointer"]],
-      pending_outbound_transactions_get_length: ["uint", ["pointer", "int*"]],
+      pending_outbound_transaction_get_status: [
+        this.int,
+        [this.ptr, this.intPtr],
+      ],
+      pending_outbound_transaction_destroy: [this.void, [this.ptr]],
+      pending_outbound_transactions_get_length: [
+        this.uint,
+        [this.ptr, this.intPtr],
+      ],
       pending_outbound_transactions_get_at: [
-        "pointer",
-        ["pointer", "uint", "int*"],
+        this.ptr,
+        [this.ptr, this.uint, this.intPtr],
       ],
-      pending_outbound_transactions_destroy: ["void", ["pointer"]],
+      pending_outbound_transactions_destroy: [this.void, [this.ptr]],
       pending_inbound_transaction_get_transaction_id: [
-        "uint64",
-        ["pointer", "int*"],
+        this.ulonglong,
+        [this.ptr, this.intPtr],
       ],
       pending_inbound_transaction_get_source_public_key: [
-        "pointer",
-        ["pointer", "int*"],
+        this.ptr,
+        [this.ptr, this.intPtr],
       ],
-      pending_inbound_transaction_get_message: ["char*", ["pointer", "int*"]],
-      pending_inbound_transaction_get_amount: ["uint64", ["pointer", "int*"]],
+      pending_inbound_transaction_get_message: [
+        this.stringPtr,
+        [this.ptr, this.intPtr],
+      ],
+      pending_inbound_transaction_get_amount: [
+        this.ulonglong,
+        [this.ptr, this.intPtr],
+      ],
       pending_inbound_transaction_get_timestamp: [
-        "uint64",
-        ["pointer", "int*"],
+        this.ulonglong,
+        [this.ptr, this.intPtr],
       ],
-      pending_inbound_transaction_get_status: ["int", ["pointer", "int*"]],
-      pending_inbound_transaction_destroy: ["void", ["pointer"]],
-      pending_inbound_transactions_get_length: ["uint", ["pointer", "int*"]],
+      pending_inbound_transaction_get_status: [
+        this.int,
+        [this.ptr, this.intPtr],
+      ],
+      pending_inbound_transaction_destroy: [this.void, [this.ptr]],
+      pending_inbound_transactions_get_length: [
+        this.uint,
+        [this.ptr, this.intPtr],
+      ],
       pending_inbound_transactions_get_at: [
-        "pointer",
-        ["pointer", "uint", "int*"],
+        this.ptr,
+        [this.ptr, this.uint, this.intPtr],
       ],
-      pending_inbound_transactions_destroy: ["void", ["pointer"]],
+      pending_inbound_transactions_destroy: [this.void, [this.ptr]],
       comms_config_create: [
-        "pointer",
+        this.ptr,
         [
-          "string",
-          "pointer",
-          "string",
-          "string",
-          "uint64",
-          "uint64",
-          "string",
-          "int*",
+          this.string,
+          this.ptr,
+          this.string,
+          this.string,
+          this.ulonglong,
+          this.ulonglong,
+          this.string,
+          this.intPtr,
         ],
       ],
-      comms_config_destroy: ["void", ["pointer"]],
+      comms_config_destroy: [this.void, [this.ptr]],
       wallet_create: [
-        "pointer",
+        this.ptr,
         [
-          "pointer",
-          "string",
-          "uint",
-          "uint",
-          "string",
-          "pointer",
-          "pointer",
-          "pointer",
-          "pointer",
-          "pointer",
-          "pointer",
-          "pointer",
-          "pointer",
-          "pointer",
-          "pointer",
-          "pointer",
-          "pointer",
-          "pointer",
-          "pointer",
-          "pointer",
-          "bool*",
-          "int*",
+          this.ptr,
+          this.string,
+          this.uint,
+          this.uint,
+          this.string,
+          this.ptr,
+          this.ptr,
+          this.ptr,
+          this.ptr,
+          this.ptr,
+          this.ptr,
+          this.ptr,
+          this.ptr,
+          this.ptr,
+          this.ptr,
+          this.ptr,
+          this.ptr,
+          this.ptr,
+          this.ptr,
+          this.ptr,
+          this.boolPtr,
+          this.intPtr,
         ],
       ],
-      wallet_sign_message: ["char*", ["pointer", "string", "int*"]],
+      wallet_sign_message: [
+        this.stringPtr,
+        [this.ptr, this.string, this.intPtr],
+      ],
       wallet_verify_message_signature: [
-        "bool",
-        ["pointer", "pointer", "string", "string", "int*"],
+        this.bool,
+        [this.ptr, this.ptr, this.string, this.string, this.intPtr],
       ],
       wallet_add_base_node_peer: [
-        "bool",
-        ["pointer", "pointer", "string", "int*"],
+        this.bool,
+        [this.ptr, this.ptr, this.string, this.intPtr],
       ],
-      wallet_upsert_contact: ["bool", ["pointer", "pointer", "int*"]],
-      wallet_remove_contact: ["bool", ["pointer", "pointer", "int*"]],
-      wallet_get_available_balance: ["uint64", ["pointer", "int*"]],
-      wallet_get_pending_incoming_balance: ["uint64", ["pointer", "int*"]],
-      wallet_get_pending_outgoing_balance: ["uint64", ["pointer", "int*"]],
+      wallet_upsert_contact: [this.bool, [this.ptr, this.ptr, this.intPtr]],
+      wallet_remove_contact: [this.bool, [this.ptr, this.ptr, this.intPtr]],
+      wallet_get_available_balance: [this.ulonglong, [this.ptr, this.intPtr]],
+      wallet_get_pending_incoming_balance: [
+        this.ulonglong,
+        [this.ptr, this.intPtr],
+      ],
+      wallet_get_pending_outgoing_balance: [
+        this.ulonglong,
+        [this.ptr, this.intPtr],
+      ],
       wallet_get_fee_estimate: [
-        "uint64",
-        ["pointer", "uint64", "uint64", "uint64", "uint64", "int*"],
+        this.ulonglong,
+        [
+          this.ptr,
+          this.ulonglong,
+          this.ulonglong,
+          this.ulonglong,
+          this.ulonglong,
+          this.intPtr,
+        ],
       ],
-      wallet_get_num_confirmations_required: ["uint64", ["pointer", "int*"]],
+      wallet_get_num_confirmations_required: [
+        this.ulonglong,
+        [this.ptr, this.intPtr],
+      ],
       wallet_set_num_confirmations_required: [
-        "void",
-        ["pointer", "uint64", "int*"],
+        this.void,
+        [this.ptr, this.ulonglong, this.intPtr],
       ],
       wallet_send_transaction: [
-        "uint64",
-        ["pointer", "pointer", "uint64", "uint64", "string", "int*"],
+        this.ulonglong,
+        [
+          this.ptr,
+          this.ptr,
+          this.ulonglong,
+          this.ulonglong,
+          this.string,
+          this.intPtr,
+        ],
       ],
-      wallet_get_contacts: ["pointer", ["pointer", "int*"]],
-      wallet_get_completed_transactions: ["pointer", ["pointer", "int*"]],
+      wallet_get_contacts: [this.ptr, [this.ptr, this.intPtr]],
+      wallet_get_completed_transactions: [this.ptr, [this.ptr, this.intPtr]],
       wallet_get_pending_outbound_transactions: [
-        "pointer",
-        ["pointer", "int*"],
+        this.ptr,
+        [this.ptr, this.intPtr],
       ],
-      wallet_get_public_key: ["pointer", ["pointer", "int*"]],
-      wallet_get_pending_inbound_transactions: ["pointer", ["pointer", "int*"]],
-      wallet_get_cancelled_transactions: ["pointer", ["pointer", "int*"]],
+      wallet_get_public_key: [this.ptr, [this.ptr, this.intPtr]],
+      wallet_get_pending_inbound_transactions: [
+        this.ptr,
+        [this.ptr, this.intPtr],
+      ],
+      wallet_get_cancelled_transactions: [this.ptr, [this.ptr, this.intPtr]],
       wallet_get_completed_transaction_by_id: [
-        "pointer",
-        ["pointer", "uint64", "int*"],
+        this.ptr,
+        [this.ptr, this.ulonglong, this.intPtr],
       ],
       wallet_get_pending_outbound_transaction_by_id: [
-        "pointer",
-        ["pointer", "uint64", "int*"],
+        this.ptr,
+        [this.ptr, this.ulonglong, this.intPtr],
       ],
       wallet_get_pending_inbound_transaction_by_id: [
-        "pointer",
-        ["pointer", "uint64", "int*"],
+        this.ptr,
+        [this.ptr, this.ulonglong, this.intPtr],
       ],
       wallet_get_cancelled_transaction_by_id: [
-        "pointer",
-        ["pointer", "uint64", "int*"],
+        this.ptr,
+        [this.ptr, this.ulonglong, this.intPtr],
       ],
       wallet_import_utxo: [
-        "uint64",
-        ["pointer", "uint64", "pointer", "pointer", "string", "int*"],
+        this.ulonglong,
+        [
+          this.ptr,
+          this.ulonglong,
+          this.ptr,
+          this.ptr,
+          this.string,
+          this.intPtr,
+        ],
       ],
-      wallet_start_utxo_validation: ["uint64", ["pointer", "int*"]],
-      wallet_start_stxo_validation: ["uint64", ["pointer", "int*"]],
-      wallet_start_invalid_txo_validation: ["uint64", ["pointer", "int*"]],
-      wallet_start_transaction_validation: ["uint64", ["pointer", "int*"]],
-      wallet_restart_transaction_broadcast: ["bool", ["pointer", "int*"]],
-      wallet_set_low_power_mode: ["void", ["pointer", "int*"]],
-      wallet_set_normal_power_mode: ["void", ["pointer", "int*"]],
+      wallet_start_utxo_validation: [this.ulonglong, [this.ptr, this.intPtr]],
+      wallet_start_stxo_validation: [this.ulonglong, [this.ptr, this.intPtr]],
+      wallet_start_invalid_txo_validation: [
+        this.ulonglong,
+        [this.ptr, this.intPtr],
+      ],
+      wallet_start_transaction_validation: [
+        this.ulonglong,
+        [this.ptr, this.intPtr],
+      ],
+      wallet_restart_transaction_broadcast: [
+        this.bool,
+        [this.ptr, this.intPtr],
+      ],
+      wallet_set_low_power_mode: [this.void, [this.ptr, this.intPtr]],
+      wallet_set_normal_power_mode: [this.void, [this.ptr, this.intPtr]],
       wallet_cancel_pending_transaction: [
-        "bool",
-        ["pointer", "uint64", "int*"],
+        this.bool,
+        [this.ptr, this.ulonglong, this.intPtr],
       ],
       wallet_coin_split: [
-        "uint64",
-        ["pointer", "uint64", "uint64", "uint64", "string", "uint64", "int*"],
+        this.ulonglong,
+        [
+          this.ptr,
+          this.ulonglong,
+          this.ulonglong,
+          this.ulonglong,
+          this.string,
+          this.ulonglong,
+          this.intPtr,
+        ],
       ],
-      wallet_get_seed_words: ["pointer", ["pointer", "int*"]],
-      wallet_apply_encryption: ["void", ["pointer", "string", "int*"]],
-      wallet_remove_encryption: ["void", ["pointer", "int*"]],
-      wallet_set_key_value: ["bool", ["pointer", "string", "string", "int*"]],
-      wallet_get_value: ["char*", ["pointer", "string", "int*"]],
-      wallet_clear_value: ["bool", ["pointer", "string", "int*"]],
-      wallet_is_recovery_in_progress: ["bool", ["pointer", "int*"]],
+      wallet_get_seed_words: [this.ptr, [this.ptr, this.intPtr]],
+      wallet_apply_encryption: [
+        this.void,
+        [this.ptr, this.string, this.intPtr],
+      ],
+      wallet_remove_encryption: [this.void, [this.ptr, this.intPtr]],
+      wallet_set_key_value: [
+        this.bool,
+        [this.ptr, this.string, this.string, this.intPtr],
+      ],
+      wallet_get_value: [this.stringPtr, [this.ptr, this.string, this.intPtr]],
+      wallet_clear_value: [this.bool, [this.ptr, this.string, this.intPtr]],
+      wallet_is_recovery_in_progress: [this.bool, [this.ptr, this.intPtr]],
       wallet_start_recovery: [
-        "bool",
-        ["pointer", "pointer", "pointer", "int*"],
+        this.bool,
+        [this.ptr, this.ptr, this.ptr, this.intPtr],
       ],
-      wallet_destroy: ["void", ["pointer"]],
-      file_partial_backup: ["void", ["string", "string", "int*"]],
-      log_debug_message: ["void", ["string"]],
-      get_emoji_set: ["pointer", ["void"]],
-      emoji_set_destroy: ["void", ["pointer"]],
-      emoji_set_get_at: ["pointer", ["pointer", "uint", "int*"]],
-      emoji_set_get_length: ["uint", ["pointer", "int*"]],
+      wallet_destroy: [this.void, [this.ptr]],
+      file_partial_backup: [this.void, [this.string, this.string, this.intPtr]],
+      log_debug_message: [this.void, [this.string]],
+      get_emoji_set: [this.ptr, []],
+      emoji_set_destroy: [this.void, [this.ptr]],
+      emoji_set_get_at: [this.ptr, [this.ptr, this.uint, this.intPtr]],
+      emoji_set_get_length: [this.uint, [this.ptr, this.intPtr]],
     });
+
+    this.loaded = true;
   }
   //endregion
 
@@ -328,9 +449,7 @@ class InterfaceFFI {
 
   //region Helpers
   static initError() {
-    let error = Buffer.alloc(4);
-    error.writeInt32LE(-1, 0);
-    error.type = ref.types.int;
+    let error = ref.alloc(ref.types.int);
     return error;
   }
 
@@ -341,7 +460,7 @@ class InterfaceFFI {
 
   static filePartialBackup(original_file_path, backup_file_path) {
     let error = this.initError();
-    let result = this.#fn.file_partial_backup(
+    let result = this.fn.file_partial_backup(
       original_file_path,
       backup_file_path,
       error
@@ -351,71 +470,71 @@ class InterfaceFFI {
   }
 
   static logDebugMessage(msg) {
-    this.#fn.log_debug_message(msg);
+    this.fn.log_debug_message(msg);
   }
   //endregion
 
   //region String
   static stringDestroy(s) {
-    this.#fn.string_destroy(s);
+    this.fn.string_destroy(s);
   }
   //endregion
 
   // region ByteVector
   static byteVectorCreate(byte_array, element_count) {
     let error = this.initError();
-    let result = this.#fn.byte_vector_create(byte_array, element_count, error);
+    let result = this.fn.byte_vector_create(byte_array, element_count, error);
     this.checkErrorResult(error, `byteVectorCreate`);
     return result;
   }
 
   static byteVectorGetAt(ptr, i) {
     let error = this.initError();
-    let result = this.#fn.byte_vector_get_at(ptr, i, error);
+    let result = this.fn.byte_vector_get_at(ptr, i, error);
     this.checkErrorResult(error, `byteVectorGetAt`);
     return result;
   }
 
   static byteVectorGetLength(ptr) {
     let error = this.initError();
-    let result = this.#fn.byte_vector_get_length(ptr, error);
+    let result = this.fn.byte_vector_get_length(ptr, error);
     this.checkErrorResult(error, `byteVectorGetLength`);
     return result;
   }
 
   static byteVectorDestroy(ptr) {
-    this.#fn.byte_vector_destroy(ptr);
+    this.fn.byte_vector_destroy(ptr);
   }
   //endregion
 
   //region PrivateKey
   static privateKeyCreate(ptr) {
     let error = this.initError();
-    let result = this.#fn.private_key_create(ptr, error);
+    let result = this.fn.private_key_create(ptr, error);
     this.checkErrorResult(error, `privateKeyCreate`);
     return result;
   }
 
   static privateKeyGenerate() {
-    return this.#fn.private_key_generate();
+    return this.fn.private_key_generate();
   }
 
   static privateKeyGetBytes(ptr) {
     let error = this.initError();
-    let result = this.#fn.private_key_get_bytes(ptr, error);
+    let result = this.fn.private_key_get_bytes(ptr, error);
     this.checkErrorResult(error, "privateKeyGetBytes");
     return result;
   }
 
   static privateKeyFromHex(hex) {
     let error = this.initError();
-    let result = this.#fn.private_key_from_hex(hex, error);
+    let result = this.fn.private_key_from_hex(hex, error);
     this.checkErrorResult(error, "privateKeyFromHex");
     return result;
   }
 
   static privateKeyDestroy(ptr) {
-    this.#fn.private_key_destroy(ptr);
+    this.fn.private_key_destroy(ptr);
   }
 
   //endregion
@@ -423,59 +542,59 @@ class InterfaceFFI {
   //region PublicKey
   static publicKeyCreate(ptr) {
     let error = this.initError();
-    let result = this.#fn.public_key_create(ptr, error);
+    let result = this.fn.public_key_create(ptr, error);
     this.checkErrorResult(error, `publicKeyCreate`);
     return result;
   }
 
   static publicKeyGetBytes(ptr) {
     let error = this.initError();
-    let result = this.#fn.public_key_get_bytes(ptr, error);
+    let result = this.fn.public_key_get_bytes(ptr, error);
     this.checkErrorResult(error, `publicKeyGetBytes`);
     return result;
   }
 
   static publicKeyFromPrivateKey(ptr) {
     let error = this.initError();
-    let result = this.#fn.public_key_from_private_key(ptr, error);
+    let result = this.fn.public_key_from_private_key(ptr, error);
     this.checkErrorResult(error, `publicKeyFromPrivateKey`);
     return result;
   }
 
   static publicKeyFromHex(hex) {
     let error = this.initError();
-    let result = this.#fn.public_key_from_hex(hex, error);
+    let result = this.fn.public_key_from_hex(hex, error);
     this.checkErrorResult(error, `publicKeyFromHex`);
     return result;
   }
 
   static emojiIdToPublicKey(emoji) {
     let error = this.initError();
-    let result = this.#fn.emoji_id_to_public_key(emoji, error);
+    let result = this.fn.emoji_id_to_public_key(emoji, error);
     this.checkErrorResult(error, `emojiIdToPublicKey`);
     return result;
   }
 
   static publicKeyToEmojiId(ptr) {
     let error = this.initError();
-    let result = this.#fn.public_key_to_emoji_id(ptr, error);
+    let result = this.fn.public_key_to_emoji_id(ptr, error);
     this.checkErrorResult(error, `publicKeyToEmojiId`);
     return result;
   }
 
   static publicKeyDestroy(ptr) {
-    this.#fn.public_key_destroy(ptr);
+    this.fn.public_key_destroy(ptr);
   }
   //endregion
 
   //region TransportType
   static transportMemoryCreate() {
-    return this.#fn.transport_memory_create();
+    return this.fn.transport_memory_create();
   }
 
   static transportTcpCreate(listener_address) {
     let error = this.initError();
-    let result = this.#fn.transport_tcp_create(listener_address, error);
+    let result = this.fn.transport_tcp_create(listener_address, error);
     this.checkErrorResult(error, `transportTcpCreate`);
     return result;
   }
@@ -488,7 +607,7 @@ class InterfaceFFI {
     socks_password
   ) {
     let error = this.initError();
-    let result = this.#fn.transport_tor_create(
+    let result = this.fn.transport_tor_create(
       control_server_address,
       tor_cookie,
       tor_port,
@@ -502,35 +621,35 @@ class InterfaceFFI {
 
   static transportMemoryGetAddress(transport) {
     let error = this.initError();
-    let result = this.#fn.transport_memory_get_address(transport, error);
+    let result = this.fn.transport_memory_get_address(transport, error);
     this.checkErrorResult(error, `transportMemoryGetAddress`);
     return result;
   }
 
   static transportTypeDestroy(transport) {
-    this.#fn.transport_type_destroy(transport);
+    this.fn.transport_type_destroy(transport);
   }
   //endregion
 
   //region EmojiSet
   static getEmojiSet() {
-    return this.#fn.this.#fn.get_emoji_set();
+    return this.fn.this.fn.get_emoji_set();
   }
 
   static emojiSetDestroy(ptr) {
-    this.#fn.emoji_set_destroy(ptr);
+    this.fn.emoji_set_destroy(ptr);
   }
 
   static emojiSetGetAt(ptr, position) {
     let error = this.initError();
-    let result = this.#fn.emoji_set_get_at(ptr, position, error);
+    let result = this.fn.emoji_set_get_at(ptr, position, error);
     this.checkErrorResult(error, `emojiSetGetAt`);
     return result;
   }
 
   static emojiSetGetLength(ptr) {
     let error = this.initError();
-    let result = this.#fn.emoji_set_get_length(ptr, error);
+    let result = this.fn.emoji_set_get_length(ptr, error);
     this.checkErrorResult(error, `emojiSetGetLength`);
     return result;
   }
@@ -538,32 +657,32 @@ class InterfaceFFI {
 
   //region SeedWords
   static seedWordsCreate() {
-    return this.#fn.seed_words_create();
+    return this.fn.seed_words_create();
   }
 
   static seedWordsGetLength(ptr) {
     let error = this.initError();
-    let result = this.#fn.seed_words_get_length(ptr, error);
+    let result = this.fn.seed_words_get_length(ptr, error);
     this.checkErrorResult(error, `emojiSetGetLength`);
     return result;
   }
 
   static seedWordsGetAt(ptr, position) {
     let error = this.initError();
-    let result = this.#fn.seed_words_get_at(ptr, position, error);
+    let result = this.fn.seed_words_get_at(ptr, position, error);
     this.checkErrorResult(error, `seedWordsGetAt`);
     return result;
   }
 
   static seedWordsPushWord(ptr, word) {
     let error = this.initError();
-    let result = this.#fn.seed_words_push_word(ptr, word, error);
+    let result = this.fn.seed_words_push_word(ptr, word, error);
     this.checkErrorResult(error, `seedWordsPushWord`);
     return result;
   }
 
   static seedWordsDestroy(ptr) {
-    this.#fn.seed_words_destroy(ptr);
+    this.fn.seed_words_destroy(ptr);
   }
   //endregion
 
@@ -578,7 +697,7 @@ class InterfaceFFI {
     network
   ) {
     let error = this.initError();
-    let result = this.#fn.comms_config_create(
+    let result = this.fn.comms_config_create(
       public_address,
       transport,
       database_name,
@@ -593,61 +712,61 @@ class InterfaceFFI {
   }
 
   static commsConfigDestroy(ptr) {
-    this.#fn.comms_config_destroy(ptr);
+    this.fn.comms_config_destroy(ptr);
   }
   //endregion
 
   //region Contact
   static contactCreate(alias, public_key) {
     let error = this.initError();
-    let result = this.#fn.contact_create(alias, public_key, error);
+    let result = this.fn.contact_create(alias, public_key, error);
     this.checkErrorResult(error, `contactCreate`);
     return result;
   }
 
   static contactGetAlias(ptr) {
     let error = this.initError();
-    let result = this.#fn.contact_get_alias(ptr, error);
+    let result = this.fn.contact_get_alias(ptr, error);
     this.checkErrorResult(error, `contactGetAlias`);
     return result;
   }
 
   static contactGetPublicKey(ptr) {
     let error = this.initError();
-    let result = this.#fn.contact_get_public_key(ptr, error);
+    let result = this.fn.contact_get_public_key(ptr, error);
     this.checkErrorResult(error, `contactGetPublicKey`);
     return result;
   }
 
   static contactDestroy(ptr) {
-    this.#fn.contact_destroy(ptr);
+    this.fn.contact_destroy(ptr);
   }
   //endregion
 
   //region Contacts (List)
   static contactsGetLength(ptr) {
     let error = this.initError();
-    let result = this.#fn.contacts_get_length(ptr, error);
+    let result = this.fn.contacts_get_length(ptr, error);
     this.checkErrorResult(error, `contactsGetLength`);
     return result;
   }
 
   static contactsGetAt(ptr, position) {
     let error = this.initError();
-    let result = this.#fn.contacts_get_at(ptr, position, error);
+    let result = this.fn.contacts_get_at(ptr, position, error);
     this.checkErrorResult(error, `contactsGetAt`);
     return result;
   }
 
   static contactsDestroy(ptr) {
-    this.#fn.contacts_destroy(ptr);
+    this.fn.contacts_destroy(ptr);
   }
   //endregion
 
   //region CompletedTransaction
   static completedTransactionGetDestinationPublicKey(ptr) {
     let error = this.initError();
-    let result = this.#fn.completed_transaction_get_destination_public_key(
+    let result = this.fn.completed_transaction_get_destination_public_key(
       ptr,
       error
     );
@@ -657,7 +776,7 @@ class InterfaceFFI {
 
   static completedTransactionGetSourcePublicKey(ptr) {
     let error = this.initError();
-    let result = this.#fn.completed_transaction_get_source_public_key(
+    let result = this.fn.completed_transaction_get_source_public_key(
       ptr,
       error
     );
@@ -667,69 +786,69 @@ class InterfaceFFI {
 
   static completedTransactionGetAmount(ptr) {
     let error = this.initError();
-    let result = this.#fn.completed_transaction_get_amount(ptr, error);
+    let result = this.fn.completed_transaction_get_amount(ptr, error);
     this.checkErrorResult(error, `completedTransactionGetAmount`);
     return result;
   }
 
   static completedTransactionGetFee(ptr) {
     let error = this.initError();
-    let result = this.#fn.completed_transaction_get_fee(ptr, error);
+    let result = this.fn.completed_transaction_get_fee(ptr, error);
     this.checkErrorResult(error, `completedTransactionGetFee`);
     return result;
   }
 
   static completedTransactionGetMessage(ptr) {
     let error = this.initError();
-    let result = this.#fn.completed_transaction_get_message(ptr, error);
+    let result = this.fn.completed_transaction_get_message(ptr, error);
     this.checkErrorResult(error, `completedTransactionGetMessage`);
     return result;
   }
 
   static completedTransactionGetStatus(ptr) {
     let error = this.initError();
-    let result = this.#fn.completed_transaction_get_status(ptr, error);
+    let result = this.fn.completed_transaction_get_status(ptr, error);
     this.checkErrorResult(error, `completedTransactionGetStatus`);
     return result;
   }
 
   static completedTransactionGetTransactionId(ptr) {
     let error = this.initError();
-    let result = this.#fn.completed_transaction_get_transaction_id(ptr, error);
+    let result = this.fn.completed_transaction_get_transaction_id(ptr, error);
     this.checkErrorResult(error, `completedTransactionGetTransactionId`);
     return result;
   }
 
   static completedTransactionGetTimestamp(ptr) {
     let error = this.initError();
-    let result = this.#fn.completed_transaction_get_timestamp(ptr, error);
+    let result = this.fn.completed_transaction_get_timestamp(ptr, error);
     this.checkErrorResult(error, `completedTransactionGetTimestamp`);
     return result;
   }
 
   static completedTransactionIsValid(ptr) {
     let error = this.initError();
-    let result = this.#fn.completed_transaction_is_valid(ptr, error);
+    let result = this.fn.completed_transaction_is_valid(ptr, error);
     this.checkErrorResult(error, `completedTransactionIsValid`);
     return result;
   }
 
   static completedTransactionIsOutbound(ptr) {
     let error = this.initError();
-    let result = this.#fn.completed_transaction_is_outbound(ptr, error);
+    let result = this.fn.completed_transaction_is_outbound(ptr, error);
     this.checkErrorResult(error, `completedTransactionGetConfirmations`);
     return result;
   }
 
   static completedTransactionGetConfirmations(ptr) {
     let error = this.initError();
-    let result = this.#fn.completed_transaction_get_confirmations(ptr, error);
+    let result = this.fn.completed_transaction_get_confirmations(ptr, error);
     this.checkErrorResult(error, `completedTransactionGetConfirmations`);
     return result;
   }
 
   static completedTransactionDestroy(ptr) {
-    this.#fn.completed_transaction_destroy(ptr);
+    this.fn.completed_transaction_destroy(ptr);
   }
 
   //endregion
@@ -739,7 +858,7 @@ class InterfaceFFI {
 
   static completedTransactionGetExcess(transaction) {
     return new Promise((resolve, reject) =>
-      this.#fn.completed_transaction_get_excess.async(
+      this.fn.completed_transaction_get_excess.async(
         transaction,
         this.error,
         this.checkAsyncRes(resolve, reject, "completedTransactionGetExcess")
@@ -749,7 +868,7 @@ class InterfaceFFI {
 
   static completedTransactionGetPublicNonce(transaction) {
     return new Promise((resolve, reject) =>
-      this.#fn.completed_transaction_get_public_nonce.async(
+      this.fn.completed_transaction_get_public_nonce.async(
         transaction,
         this.error,
         this.checkAsyncRes(
@@ -763,7 +882,7 @@ class InterfaceFFI {
 
   static completedTransactionGetSignature(transaction) {
     return new Promise((resolve, reject) =>
-      this.#fn.completed_transaction_get_signature.async(
+      this.fn.completed_transaction_get_signature.async(
         transaction,
         this.error,
         this.checkAsyncRes(resolve, reject, "completedTransactionGetSignature")
@@ -773,7 +892,7 @@ class InterfaceFFI {
 
   static excessDestroy(excess) {
     return new Promise((resolve, reject) =>
-      this.#fn.excess_destroy.async(
+      this.fn.excess_destroy.async(
         excess,
         this.checkAsyncRes(resolve, reject, "excessDestroy")
       )
@@ -782,7 +901,7 @@ class InterfaceFFI {
 
   static nonceDestroy(nonce) {
     return new Promise((resolve, reject) =>
-      this.#fn.nonce_destroy.async(
+      this.fn.nonce_destroy.async(
         nonce,
         this.checkAsyncRes(resolve, reject, "nonceDestroy")
       )
@@ -791,7 +910,7 @@ class InterfaceFFI {
 
   static signatureDestroy(signature) {
     return new Promise((resolve, reject) =>
-      this.#fn.signature_destroy.async(
+      this.fn.signature_destroy.async(
         signature,
         this.checkAsyncRes(resolve, reject, "signatureDestroy")
       )
@@ -802,27 +921,27 @@ class InterfaceFFI {
   //region CompletedTransactions (List)
   static completedTransactionsGetLength(ptr) {
     let error = this.initError();
-    let result = this.#fn.completed_transactions_get_length(ptr, error);
+    let result = this.fn.completed_transactions_get_length(ptr, error);
     this.checkErrorResult(error, `contactsGetAt`);
     return result;
   }
 
   static completedTransactionsGetAt(ptr, position) {
     let error = this.initError();
-    let result = this.#fn.completed_transactions_get_at(ptr, position, error);
+    let result = this.fn.completed_transactions_get_at(ptr, position, error);
     this.checkErrorResult(error, `contactsGetAt`);
     return result;
   }
 
   static completedTransactionsDestroy(transactions) {
-    this.#fn.completed_transactions_destroy(transactions);
+    this.fn.completed_transactions_destroy(transactions);
   }
   //endregion
 
   //region PendingOutboundTransaction
   static pendingOutboundTransactionGetTransactionId(ptr) {
     let error = this.initError();
-    let result = this.#fn.pending_outbound_transaction_get_transaction_id(
+    let result = this.fn.pending_outbound_transaction_get_transaction_id(
       ptr,
       error
     );
@@ -833,7 +952,7 @@ class InterfaceFFI {
   static pendingOutboundTransactionGetDestinationPublicKey(ptr) {
     let error = this.initError();
     let result =
-      this.#fn.pending_outbound_transaction_get_destination_public_key(
+      this.fn.pending_outbound_transaction_get_destination_public_key(
         ptr,
         error
       );
@@ -846,58 +965,55 @@ class InterfaceFFI {
 
   static pendingOutboundTransactionGetAmount(ptr) {
     let error = this.initError();
-    let result = this.#fn.pending_outbound_transaction_get_amount(ptr, error);
+    let result = this.fn.pending_outbound_transaction_get_amount(ptr, error);
     this.checkErrorResult(error, `pendingOutboundTransactionGetAmount`);
     return result;
   }
 
   static pendingOutboundTransactionGetFee(ptr) {
     let error = this.initError();
-    let result = this.#fn.pending_outbound_transaction_get_fee(ptr, error);
+    let result = this.fn.pending_outbound_transaction_get_fee(ptr, error);
     this.checkErrorResult(error, `pendingOutboundTransactionGetFee`);
     return result;
   }
 
   static pendingOutboundTransactionGetMessage(ptr) {
     let error = this.initError();
-    let result = this.#fn.pending_outbound_transaction_get_message(ptr, error);
+    let result = this.fn.pending_outbound_transaction_get_message(ptr, error);
     this.checkErrorResult(error, `pendingOutboundTransactionGetMessage`);
     return result;
   }
 
   static pendingOutboundTransactionGetTimestamp(ptr) {
     let error = this.initError();
-    let result = this.#fn.pending_outbound_transaction_get_timestamp(
-      ptr,
-      error
-    );
+    let result = this.fn.pending_outbound_transaction_get_timestamp(ptr, error);
     this.checkErrorResult(error, `pendingOutboundTransactionGetTimestamp`);
     return result;
   }
 
   static pendingOutboundTransactionGetStatus(ptr) {
     let error = this.initError();
-    let result = this.#fn.pending_outbound_transaction_get_status(ptr, error);
+    let result = this.fn.pending_outbound_transaction_get_status(ptr, error);
     this.checkErrorResult(error, `pendingOutboundTransactionGetStatus`);
     return result;
   }
 
   static pendingOutboundTransactionDestroy(ptr) {
-    this.#fn.pending_outbound_transaction_destroy(ptr);
+    this.fn.pending_outbound_transaction_destroy(ptr);
   }
   //endregion
 
   //region PendingOutboundTransactions (List)
   static pendingOutboundTransactionsGetLength(ptr) {
     let error = this.initError();
-    let result = this.#fn.pending_outbound_transactions_get_length(ptr, error);
+    let result = this.fn.pending_outbound_transactions_get_length(ptr, error);
     this.checkErrorResult(error, `pendingOutboundTransactionsGetLength`);
     return result;
   }
 
   static pendingOutboundTransactionsGetAt(ptr, position) {
     let error = this.initError();
-    let result = this.#fn.pending_outbound_transactions_get_at(
+    let result = this.fn.pending_outbound_transactions_get_at(
       ptr,
       position,
       error
@@ -907,14 +1023,14 @@ class InterfaceFFI {
   }
 
   static pendingOutboundTransactionsDestroy(ptr) {
-    this.#fn.pending_outbound_transactions_destroy(ptr);
+    this.fn.pending_outbound_transactions_destroy(ptr);
   }
   //endregion
 
   //region PendingInboundTransaction
   static pendingInboundTransactionGetTransactionId(ptr) {
     let error = this.initError();
-    let result = this.#fn.pending_inbound_transaction_get_transaction_id(
+    let result = this.fn.pending_inbound_transaction_get_transaction_id(
       ptr,
       error
     );
@@ -924,7 +1040,7 @@ class InterfaceFFI {
 
   static pendingInboundTransactionGetSourcePublicKey(ptr) {
     let error = this.initError();
-    let result = this.#fn.pending_inbound_transaction_get_source_public_key(
+    let result = this.fn.pending_inbound_transaction_get_source_public_key(
       ptr,
       error
     );
@@ -934,48 +1050,48 @@ class InterfaceFFI {
 
   static pendingInboundTransactionGetMessage(ptr) {
     let error = this.initError();
-    let result = this.#fn.pending_inbound_transaction_get_message(ptr, error);
+    let result = this.fn.pending_inbound_transaction_get_message(ptr, error);
     this.checkErrorResult(error, `pendingInboundTransactionGetMessage`);
     return result;
   }
 
   static pendingInboundTransactionGetAmount(ptr) {
     let error = this.initError();
-    let result = this.#fn.pending_inbound_transaction_get_amount(ptr, error);
+    let result = this.fn.pending_inbound_transaction_get_amount(ptr, error);
     this.checkErrorResult(error, `pendingInboundTransactionGetAmount`);
     return result;
   }
 
   static pendingInboundTransactionGetTimestamp(ptr) {
     let error = this.initError();
-    let result = this.#fn.pending_inbound_transaction_get_timestamp(ptr, error);
+    let result = this.fn.pending_inbound_transaction_get_timestamp(ptr, error);
     this.checkErrorResult(error, `pendingInboundTransactionGetTimestamp`);
     return result;
   }
 
   static pendingInboundTransactionGetStatus(ptr) {
     let error = this.initError();
-    let result = this.#fn.pending_inbound_transaction_get_status(ptr, error);
+    let result = this.fn.pending_inbound_transaction_get_status(ptr, error);
     this.checkErrorResult(error, `pendingInboundTransactionGetStatus`);
     return result;
   }
 
   static pendingInboundTransactionDestroy(ptr) {
-    this.#fn.pending_inbound_transaction_destroy(ptr);
+    this.fn.pending_inbound_transaction_destroy(ptr);
   }
   //endregion
 
   //region PendingInboundTransactions (List)
   static pendingInboundTransactionsGetLength(ptr) {
     let error = this.initError();
-    let result = this.#fn.pending_inbound_transactions_get_length(ptr, error);
+    let result = this.fn.pending_inbound_transactions_get_length(ptr, error);
     this.checkErrorResult(error, `pendingInboundTransactionsGetLength`);
     return result;
   }
 
   static pendingInboundTransactionsGetAt(ptr, position) {
     let error = this.initError();
-    let result = this.#fn.pending_inbound_transactions_get_at(
+    let result = this.fn.pending_inbound_transactions_get_at(
       ptr,
       position,
       error
@@ -985,7 +1101,7 @@ class InterfaceFFI {
   }
 
   static pendingInboundTransactionsDestroy(ptr) {
-    this.#fn.pending_inbound_transactions_destroy(ptr);
+    this.fn.pending_inbound_transactions_destroy(ptr);
   }
   //endregion
 
@@ -993,57 +1109,61 @@ class InterfaceFFI {
 
   //region Callbacks
   static createCallbackReceivedTransaction(fn) {
-    return ffi.Callback("void", ["pointer"], fn);
+    return ffi.Callback(this.void, [this.ptr], fn);
   }
 
   static createCallbackReceivedTransactionReply(fn) {
-    return ffi.Callback("void", ["pointer"], fn);
+    return ffi.Callback(this.void, [this.ptr], fn);
   }
 
   static createCallbackReceivedFinalizedTransaction(fn) {
-    return ffi.Callback("void", ["pointer"], fn);
+    return ffi.Callback(this.void, [this.ptr], fn);
   }
 
   static createCallbackTransactionBroadcast(fn) {
-    return ffi.Callback("void", ["pointer"], fn);
+    return ffi.Callback(this.void, [this.ptr], fn);
   }
 
   static createCallbackTransactionMined(fn) {
-    return ffi.Callback("void", ["pointer"], fn);
+    return ffi.Callback(this.void, [this.ptr], fn);
   }
 
   static createCallbackTransactionMinedUnconfirmed(fn) {
-    return ffi.Callback("void", ["pointer", "uint64"], fn);
+    return ffi.Callback(this.void, [this.ptr, this.ulonglong], fn);
   }
 
   static createCallbackDirectSendResult(fn) {
-    return ffi.Callback("void", ["uint64", "bool"], fn);
+    return ffi.Callback(this.void, [this.ulonglong, this.bool], fn);
   }
 
   static createCallbackStoreAndForwardSendResult(fn) {
-    return ffi.Callback("void", ["uint64", "bool"], fn);
+    return ffi.Callback(this.void, [this.ulonglong, this.bool], fn);
   }
 
   static createCallbackTransactionCancellation(fn) {
-    return ffi.Callback("void", ["pointer"], fn);
+    return ffi.Callback(this.void, [this.ptr], fn);
   }
   static createCallbackUtxoValidationComplete(fn) {
-    return ffi.Callback("void", ["uint64", "uchar"], fn);
+    return ffi.Callback(this.void, [this.ulonglong, this.uchar], fn);
   }
   static createCallbackStxoValidationComplete(fn) {
-    return ffi.Callback("void", ["uint64", "uchar"], fn);
+    return ffi.Callback(this.void, [this.ulonglong, this.uchar], fn);
   }
   static createCallbackInvalidTxoValidationComplete(fn) {
-    return ffi.Callback("void", ["uint64", "uchar"], fn);
+    return ffi.Callback(this.void, [this.ulonglong, this.uchar], fn);
   }
   static createCallbackTransactionValidationComplete(fn) {
-    return ffi.Callback("void", ["uint64", "uchar"], fn);
+    return ffi.Callback(this.void, [this.ulonglong, this.uchar], fn);
   }
   static createCallbackSafMessageReceived(fn) {
-    return ffi.Callback("void", ["void"], fn);
+    return ffi.Callback(this.void, [], fn);
   }
   static createRecoveryProgressCallback(fn) {
-    return ffi.Callback("void", ["uchar", "uint64", "uint64"], fn);
+    return ffi.Callback(
+      this.void,
+      [this.uchar, this.ulonglong, this.ulonglong],
+      fn
+    );
   }
   //endregion
 
@@ -1072,7 +1192,7 @@ class InterfaceFFI {
     let error = this.initError();
     let recovery_in_progress = this.initBool();
 
-    let result = this.#fn.wallet_create(
+    let result = this.fn.wallet_create(
       config,
       log_path,
       num_rolling_log_files,
@@ -1097,29 +1217,26 @@ class InterfaceFFI {
       error
     );
     this.checkErrorResult(error, `walletCreate`);
-    if (recovery_in_progress) {
-      console.log("Wallet recovery is in progress");
-    }
     return result;
   }
 
   static walletGetPublicKey(ptr) {
     let error = this.initError();
-    let result = this.#fn.wallet_get_public_key(ptr, error);
+    let result = this.fn.wallet_get_public_key(ptr, error);
     this.checkErrorResult(error, `walletGetPublicKey`);
     return result;
   }
 
   static walletSignMessage(ptr, msg) {
     let error = this.initError();
-    let result = this.#fn.wallet_sign_message(ptr, msg, error);
+    let result = this.fn.wallet_sign_message(ptr, msg, error);
     this.checkErrorResult(error, `walletSignMessage`);
     return result;
   }
 
   static walletVerifyMessageSignature(ptr, public_key_ptr, hex_sig_nonce, msg) {
     let error = this.initError();
-    let result = this.#fn.wallet_verify_message_signature(
+    let result = this.fn.wallet_verify_message_signature(
       ptr,
       public_key_ptr,
       hex_sig_nonce,
@@ -1132,7 +1249,7 @@ class InterfaceFFI {
 
   static walletAddBaseNodePeer(ptr, public_key_ptr, address) {
     let error = this.initError();
-    let result = this.#fn.wallet_add_base_node_peer(
+    let result = this.fn.wallet_add_base_node_peer(
       ptr,
       public_key_ptr,
       address,
@@ -1144,35 +1261,35 @@ class InterfaceFFI {
 
   static walletUpsertContact(ptr, contact_ptr) {
     let error = this.initError();
-    let result = this.#fn.wallet_upsert_contact(ptr, contact_ptr, error);
+    let result = this.fn.wallet_upsert_contact(ptr, contact_ptr, error);
     this.checkErrorResult(error, `walletUpsertContact`);
     return result;
   }
 
   static walletRemoveContact(ptr, contact_ptr) {
     let error = this.initError();
-    let result = this.#fn.wallet_remove_contact(ptr, contact_ptr, error);
+    let result = this.fn.wallet_remove_contact(ptr, contact_ptr, error);
     this.checkErrorResult(error, `walletRemoveContact`);
     return result;
   }
 
   static walletGetAvailableBalance(ptr) {
     let error = this.initError();
-    let result = this.#fn.wallet_get_available_balance(ptr, error);
+    let result = this.fn.wallet_get_available_balance(ptr, error);
     this.checkErrorResult(error, `walletGetAvailableBalance`);
     return result;
   }
 
   static walletGetPendingIncomingBalance(ptr) {
     let error = this.initError();
-    let result = this.#fn.wallet_get_pending_incoming_balance(ptr, error);
+    let result = this.fn.wallet_get_pending_incoming_balance(ptr, error);
     this.checkErrorResult(error, `walletGetPendingIncomingBalance`);
     return result;
   }
 
   static walletGetPendingOutgoingBalance(ptr) {
     let error = this.initError();
-    let result = this.#fn.wallet_get_pending_outgoing_balance(ptr, error);
+    let result = this.fn.wallet_get_pending_outgoing_balance(ptr, error);
     this.checkErrorResult(error, `walletGetPendingOutgoingBalance`);
     return result;
   }
@@ -1185,7 +1302,7 @@ class InterfaceFFI {
     num_outputs
   ) {
     let error = this.initError();
-    let result = this.#fn.wallet_get_fee_estimate(
+    let result = this.fn.wallet_get_fee_estimate(
       ptr,
       amount,
       fee_per_gram,
@@ -1199,14 +1316,14 @@ class InterfaceFFI {
 
   static walletGetNumConfirmationsRequired(ptr) {
     let error = this.initError();
-    let result = this.#fn.wallet_get_num_confirmations_required(ptr, error);
+    let result = this.fn.wallet_get_num_confirmations_required(ptr, error);
     this.checkErrorResult(error, `walletGetNumConfirmationsRequired`);
     return result;
   }
 
   static walletSetNumConfirmationsRequired(ptr, num) {
     let error = this.initError();
-    this.#fn.wallet_set_num_confirmations_required(ptr, num, error);
+    this.fn.wallet_set_num_confirmations_required(ptr, num, error);
     this.checkErrorResult(error, `walletSetNumConfirmationsRequired`);
   }
 
@@ -1218,7 +1335,7 @@ class InterfaceFFI {
     message
   ) {
     let error = this.initError();
-    let result = this.#fn.wallet_send_transaction(
+    let result = this.fn.wallet_send_transaction(
       ptr,
       destination,
       amount,
@@ -1232,42 +1349,42 @@ class InterfaceFFI {
 
   static walletGetContacts(ptr) {
     let error = this.initError();
-    let result = this.#fn.wallet_get_contacts(ptr, error);
+    let result = this.fn.wallet_get_contacts(ptr, error);
     this.checkErrorResult(error, `walletGetContacts`);
     return result;
   }
 
   static walletGetCompletedTransactions(ptr) {
     let error = this.initError();
-    let result = this.#fn.wallet_get_completed_transactions(ptr, error);
+    let result = this.fn.wallet_get_completed_transactions(ptr, error);
     this.checkErrorResult(error, `walletGetCompletedTransactions`);
     return result;
   }
 
   static walletGetPendingOutboundTransactions(ptr) {
     let error = this.initError();
-    let result = this.#fn.wallet_get_pending_outbound_transactions(ptr, error);
+    let result = this.fn.wallet_get_pending_outbound_transactions(ptr, error);
     this.checkErrorResult(error, `walletGetPendingOutboundTransactions`);
     return result;
   }
 
   static walletGetPendingInboundTransactions(ptr) {
     let error = this.initError();
-    let result = this.#fn.wallet_get_pending_inbound_transactions(ptr, error);
+    let result = this.fn.wallet_get_pending_inbound_transactions(ptr, error);
     this.checkErrorResult(error, `walletGetPendingInboundTransactions`);
     return result;
   }
 
   static walletGetCancelledTransactions(ptr) {
     let error = this.initError();
-    let result = this.#fn.wallet_get_cancelled_transactions(ptr, error);
+    let result = this.fn.wallet_get_cancelled_transactions(ptr, error);
     this.checkErrorResult(error, `walletGetCancelledTransactions`);
     return result;
   }
 
   static walletGetCompletedTransactionById(ptr, transaction_id) {
     let error = this.initError();
-    let result = this.#fn.wallet_get_completed_transaction_by_id(
+    let result = this.fn.wallet_get_completed_transaction_by_id(
       ptr,
       transaction_id,
       error
@@ -1278,7 +1395,7 @@ class InterfaceFFI {
 
   static walletGetPendingOutboundTransactionById(ptr, transaction_id) {
     let error = this.initError();
-    let result = this.#fn.wallet_get_pending_outbound_transaction_by_id(
+    let result = this.fn.wallet_get_pending_outbound_transaction_by_id(
       ptr,
       transaction_id,
       error
@@ -1289,7 +1406,7 @@ class InterfaceFFI {
 
   static walletGetPendingInboundTransactionById(ptr, transaction_id) {
     let error = this.initError();
-    let result = this.#fn.wallet_get_pending_inbound_transaction_by_id(
+    let result = this.fn.wallet_get_pending_inbound_transaction_by_id(
       ptr,
       transaction_id,
       error
@@ -1300,7 +1417,7 @@ class InterfaceFFI {
 
   static walletGetCancelledTransactionById(ptr, transaction_id) {
     let error = this.initError();
-    let result = this.#fn.wallet_get_cancelled_transaction_by_id(
+    let result = this.fn.wallet_get_cancelled_transaction_by_id(
       ptr,
       transaction_id,
       error
@@ -1317,7 +1434,7 @@ class InterfaceFFI {
     message
   ) {
     let error = this.initError();
-    let result = this.#fn.wallet_import_utxo(
+    let result = this.fn.wallet_import_utxo(
       ptr,
       amount,
       spending_key_ptr,
@@ -1331,54 +1448,54 @@ class InterfaceFFI {
 
   static walletStartUtxoValidation(ptr) {
     let error = this.initError();
-    let result = this.#fn.wallet_start_utxo_validation(ptr, error);
+    let result = this.fn.wallet_start_utxo_validation(ptr, error);
     this.checkErrorResult(error, `walletStartUtxoValidation`);
     return result;
   }
 
   static walletStartStxoValidation(ptr) {
     let error = this.initError();
-    let result = this.#fn.wallet_start_stxo_validation(ptr, error);
+    let result = this.fn.wallet_start_stxo_validation(ptr, error);
     this.checkErrorResult(error, `walletStartStxoValidation`);
     return result;
   }
 
   static walletStartInvalidTxoValidation(ptr) {
     let error = this.initError();
-    let result = this.#fn.wallet_start_invalid_txo_validation(ptr, error);
+    let result = this.fn.wallet_start_invalid_txo_validation(ptr, error);
     this.checkErrorResult(error, `walletStartInvalidUtxoValidation`);
     return result;
   }
 
   static walletStartTransactionValidation(ptr) {
     let error = this.initError();
-    let result = this.#fn.wallet_start_transaction_validation(ptr, error);
+    let result = this.fn.wallet_start_transaction_validation(ptr, error);
     this.checkErrorResult(error, `walletStartTransactionValidation`);
     return result;
   }
 
   static walletRestartTransactionBroadcast(ptr) {
     let error = this.initError();
-    let result = this.#fn.wallet_restart_transaction_broadcast(ptr, error);
+    let result = this.fn.wallet_restart_transaction_broadcast(ptr, error);
     this.checkErrorResult(error, `walletRestartTransactionBroadcast`);
     return result;
   }
 
   static walletSetLowPowerMode(ptr) {
     let error = this.initError();
-    this.#fn.wallet_set_low_power_mode(ptr, error);
+    this.fn.wallet_set_low_power_mode(ptr, error);
     this.checkErrorResult(error, `walletSetLowPowerMode`);
   }
 
   static walletSetNormalPowerMode(ptr) {
     let error = this.initError();
-    this.#fn.wallet_set_normal_power_mode(ptr, error);
+    this.fn.wallet_set_normal_power_mode(ptr, error);
     this.checkErrorResult(error, `walletSetNormalPowerMode`);
   }
 
   static walletCancelPendingTransaction(ptr, transaction_id) {
     let error = this.initError();
-    let result = this.#fn.wallet_cancel_pending_transaction(
+    let result = this.fn.wallet_cancel_pending_transaction(
       ptr,
       transaction_id,
       error
@@ -1389,7 +1506,7 @@ class InterfaceFFI {
 
   static walletCoinSplit(ptr, amount, count, fee, msg, lock_height) {
     let error = this.initError();
-    let result = this.#fn.wallet_coin_split(
+    let result = this.fn.wallet_coin_split(
       ptr,
       amount,
       count,
@@ -1404,47 +1521,47 @@ class InterfaceFFI {
 
   static walletGetSeedWords(ptr) {
     let error = this.initError();
-    let result = this.#fn.wallet_get_seed_words(ptr, error);
+    let result = this.fn.wallet_get_seed_words(ptr, error);
     this.checkErrorResult(error, `walletGetSeedWords`);
     return result;
   }
 
   static walletApplyEncryption(ptr, passphrase) {
     let error = this.initError();
-    this.#fn.wallet_apply_encryption(ptr, passphrase, error);
+    this.fn.wallet_apply_encryption(ptr, passphrase, error);
     this.checkErrorResult(error, `walletApplyEncryption`);
   }
 
   static walletRemoveEncryption(ptr) {
     let error = this.initError();
-    this.#fn.wallet_remove_encryption(ptr, error);
+    this.fn.wallet_remove_encryption(ptr, error);
     this.checkErrorResult(error, `walletRemoveEncryption`);
   }
 
   static walletSetKeyValue(ptr, key_ptr, value) {
     let error = this.initError();
-    let result = this.#fn.wallet_set_key_value(ptr, key_ptr, value, error);
+    let result = this.fn.wallet_set_key_value(ptr, key_ptr, value, error);
     this.checkErrorResult(error, `walletSetKeyValue`);
     return result;
   }
 
   static walletGetValue(ptr, key_ptr) {
     let error = this.initError();
-    let result = this.#fn.wallet_get_value(ptr, key_ptr, error);
+    let result = this.fn.wallet_get_value(ptr, key_ptr, error);
     this.checkErrorResult(error, `walletGetValue`);
     return result;
   }
 
   static walletClearValue(ptr, key_ptr) {
     let error = this.initError();
-    let result = this.#fn.wallet_clear_value(ptr, key_ptr, error);
+    let result = this.fn.wallet_clear_value(ptr, key_ptr, error);
     this.checkErrorResult(error, `walletClearValue`);
     return result;
   }
 
   static walletIsRecoveryInProgress(ptr) {
     let error = this.initError();
-    let result = this.#fn.wallet_is_recovery_in_progress(ptr, error);
+    let result = this.fn.wallet_is_recovery_in_progress(ptr, error);
     this.checkErrorResult(error, `walletIsRecoveryInProgress`);
     return result;
   }
@@ -1455,7 +1572,7 @@ class InterfaceFFI {
     recovery_progress_callback
   ) {
     let error = this.initError();
-    let result = this.#fn.wallet_start_recovery(
+    let result = this.fn.wallet_start_recovery(
       ptr,
       base_node_public_key_ptr,
       recovery_progress_callback,
@@ -1466,7 +1583,7 @@ class InterfaceFFI {
   }
 
   static walletDestroy(ptr) {
-    this.#fn.wallet_destroy(ptr);
+    this.fn.wallet_destroy(ptr);
   }
   //endregion
 }

--- a/integration_tests/helpers/ffi/pendingInboundTransaction.js
+++ b/integration_tests/helpers/ffi/pendingInboundTransaction.js
@@ -2,67 +2,53 @@ const InterfaceFFI = require("./ffiInterface");
 const PublicKey = require("./publicKey");
 
 class PendingInboundTransaction {
-  #tari_pending_inbound_transaction_ptr;
+  ptr;
 
   pointerAssign(ptr) {
-    if (this.#tari_pending_inbound_transaction_ptr) {
+    if (this.ptr) {
       this.destroy();
-      this.#tari_pending_inbound_transaction_ptr = ptr;
+      this.ptr = ptr;
     } else {
-      this.#tari_pending_inbound_transaction_ptr = ptr;
+      this.ptr = ptr;
     }
   }
 
   getPtr() {
-    return this.#tari_pending_inbound_transaction_ptr;
+    return this.ptr;
   }
 
   getSourcePublicKey() {
     let result = new PublicKey();
     result.pointerAssign(
-      InterfaceFFI.pendingInboundTransactionGetSourcePublicKey(
-        this.#tari_pending_inbound_transaction_ptr
-      )
+      InterfaceFFI.pendingInboundTransactionGetSourcePublicKey(this.ptr)
     );
     return result;
   }
 
   getAmount() {
-    return InterfaceFFI.pendingInboundTransactionGetAmount(
-      this.#tari_pending_inbound_transaction_ptr
-    );
+    return InterfaceFFI.pendingInboundTransactionGetAmount(this.ptr);
   }
 
   getMessage() {
-    return InterfaceFFI.pendingInboundTransactionGetMessage(
-      this.#tari_pending_inbound_transaction_ptr
-    );
+    return InterfaceFFI.pendingInboundTransactionGetMessage(this.ptr);
   }
 
   getStatus() {
-    return InterfaceFFI.pendingInboundTransactionGetStatus(
-      this.#tari_pending_inbound_transaction_ptr
-    );
+    return InterfaceFFI.pendingInboundTransactionGetStatus(this.ptr);
   }
 
   getTransactionID() {
-    return InterfaceFFI.pendingInboundTransactionGetTransactionId(
-      this.#tari_pending_inbound_transaction_ptr
-    );
+    return InterfaceFFI.pendingInboundTransactionGetTransactionId(this.ptr);
   }
 
   getTimestamp() {
-    return InterfaceFFI.pendingInboundTransactionGetTimestamp(
-      this.#tari_pending_inbound_transaction_ptr
-    );
+    return InterfaceFFI.pendingInboundTransactionGetTimestamp(this.ptr);
   }
 
   destroy() {
-    if (this.#tari_pending_inbound_transaction_ptr) {
-      InterfaceFFI.pendingInboundTransactionDestroy(
-        this.#tari_pending_inbound_transaction_ptr
-      );
-      this.#tari_pending_inbound_transaction_ptr = undefined; //prevent double free segfault
+    if (this.ptr) {
+      InterfaceFFI.pendingInboundTransactionDestroy(this.ptr);
+      this.ptr = undefined; //prevent double free segfault
     }
   }
 }

--- a/integration_tests/helpers/ffi/pendingInboundTransactions.js
+++ b/integration_tests/helpers/ffi/pendingInboundTransactions.js
@@ -2,35 +2,28 @@ const PendingInboundTransaction = require("./pendingInboundTransaction");
 const InterfaceFFI = require("./ffiInterface");
 
 class PendingInboundTransactions {
-  #tari_pending_inbound_transactions_ptr;
+  ptr;
 
   constructor(ptr) {
-    this.#tari_pending_inbound_transactions_ptr = ptr;
+    this.ptr = ptr;
   }
 
   getLength() {
-    return InterfaceFFI.pendingInboundTransactionsGetLength(
-      this.#tari_pending_inbound_transactions_ptr
-    );
+    return InterfaceFFI.pendingInboundTransactionsGetLength(this.ptr);
   }
 
   getAt(position) {
     let result = new PendingInboundTransaction();
     result.pointerAssign(
-      InterfaceFFI.pendingInboundTransactionsGetAt(
-        this.#tari_pending_inbound_transactions_ptr,
-        position
-      )
+      InterfaceFFI.pendingInboundTransactionsGetAt(this.ptr, position)
     );
     return result;
   }
 
   destroy() {
-    if (this.#tari_pending_inbound_transactions_ptr) {
-      InterfaceFFI.pendingInboundTransactionsDestroy(
-        this.#tari_pending_inbound_transactions_ptr
-      );
-      this.#tari_pending_inbound_transactions_ptr = undefined; //prevent double free segfault
+    if (this.ptr) {
+      InterfaceFFI.pendingInboundTransactionsDestroy(this.ptr);
+      this.ptr = undefined; //prevent double free segfault
     }
   }
 }

--- a/integration_tests/helpers/ffi/pendingOutboundTransaction.js
+++ b/integration_tests/helpers/ffi/pendingOutboundTransaction.js
@@ -2,73 +2,57 @@ const InterfaceFFI = require("./ffiInterface");
 const PublicKey = require("./publicKey");
 
 class PendingOutboundTransaction {
-  #tari_pending_outbound_transaction_ptr;
+  ptr;
 
   pointerAssign(ptr) {
-    if (this.#tari_pending_outbound_transaction_ptr) {
-      this.#tari_pending_outbound_transaction_ptr = ptr;
+    if (this.ptr) {
+      this.ptr = ptr;
       this.destroy();
     } else {
-      this.#tari_pending_outbound_transaction_ptr = ptr;
+      this.ptr = ptr;
     }
   }
 
   getPtr() {
-    return this.#tari_pending_outbound_transaction_ptr;
+    return this.ptr;
   }
 
   getDestinationPublicKey() {
     let result = new PublicKey();
     result.pointerAssign(
-      InterfaceFFI.pendingOutboundTransactionGetDestinationPublicKey(
-        this.#tari_pending_outbound_transaction_ptr
-      )
+      InterfaceFFI.pendingOutboundTransactionGetDestinationPublicKey(this.ptr)
     );
     return result;
   }
 
   getAmount() {
-    return InterfaceFFI.pendingOutboundTransactionGetAmount(
-      this.#tari_pending_outbound_transaction_ptr
-    );
+    return InterfaceFFI.pendingOutboundTransactionGetAmount(this.ptr);
   }
 
   getFee() {
-    return InterfaceFFI.pendingOutboundTransactionGetFee(
-      this.#tari_pending_outbound_transaction_ptr
-    );
+    return InterfaceFFI.pendingOutboundTransactionGetFee(this.ptr);
   }
 
   getMessage() {
-    return InterfaceFFI.pendingOutboundTransactionGetMessage(
-      this.#tari_pending_outbound_transaction_ptr
-    );
+    return InterfaceFFI.pendingOutboundTransactionGetMessage(this.ptr);
   }
 
   getStatus() {
-    return InterfaceFFI.pendingOutboundTransactionGetStatus(
-      this.#tari_pending_outbound_transaction_ptr
-    );
+    return InterfaceFFI.pendingOutboundTransactionGetStatus(this.ptr);
   }
 
   getTransactionID() {
-    return InterfaceFFI.pendingOutboundTransactionGetTransactionId(
-      this.#tari_pending_outbound_transaction_ptr
-    );
+    return InterfaceFFI.pendingOutboundTransactionGetTransactionId(this.ptr);
   }
 
   getTimestamp() {
-    return InterfaceFFI.pendingOutboundTransactionGetTimestamp(
-      this.#tari_pending_outbound_transaction_ptr
-    );
+    return InterfaceFFI.pendingOutboundTransactionGetTimestamp(this.ptr);
   }
 
   destroy() {
-    if (this.#tari_pending_outbound_transaction_ptr) {
-      InterfaceFFI.pendingOutboundTransactionDestroy(
-        this.#tari_pending_outbound_transaction_ptr
-      );
-      this.#tari_pending_outbound_transaction_ptr = undefined; //prevent double free segfault
+    if (this.ptr) {
+      InterfaceFFI.pendingOutboundTransactionDestroy(this.ptr);
+      this.ptr = undefined; //prevent double free segfault
     }
   }
 }

--- a/integration_tests/helpers/ffi/pendingOutboundTransactions.js
+++ b/integration_tests/helpers/ffi/pendingOutboundTransactions.js
@@ -2,35 +2,28 @@ const PendingOutboundTransaction = require("./pendingOutboundTransaction");
 const InterfaceFFI = require("./ffiInterface");
 
 class PendingOutboundTransactions {
-  #tari_pending_outbound_transactions_ptr;
+  ptr = undefined;
 
   constructor(ptr) {
-    this.#tari_pending_outbound_transactions_ptr = ptr;
+    this.ptr = ptr;
   }
 
   getLength() {
-    return InterfaceFFI.pendingOutboundTransactionsGetLength(
-      this.#tari_pending_outbound_transactions_ptr
-    );
+    return InterfaceFFI.pendingOutboundTransactionsGetLength(this.ptr);
   }
 
   getAt(position) {
     let result = new PendingOutboundTransaction();
     result.pointerAssign(
-      InterfaceFFI.pendingOutboundTransactionsGetAt(
-        this.#tari_pending_outbound_transactions_ptr,
-        position
-      )
+      InterfaceFFI.pendingOutboundTransactionsGetAt(this.ptr, position)
     );
     return result;
   }
 
   destroy() {
-    if (this.#tari_pending_outbound_transactions_ptr) {
-      InterfaceFFI.pendingOutboundTransactionsDestroy(
-        this.#tari_pending_outbound_transactions_ptr
-      );
-      this.#tari_pending_outbound_transactions_ptr = undefined; //prevent double free segfault
+    if (this.ptr) {
+      InterfaceFFI.pendingOutboundTransactionsDestroy(this.ptr);
+      this.ptr = undefined; //prevent double free segfault
     }
   }
 }

--- a/integration_tests/helpers/ffi/privateKey.js
+++ b/integration_tests/helpers/ffi/privateKey.js
@@ -3,20 +3,19 @@ const ByteVector = require("./byteVector");
 const utf8 = require("utf8");
 
 class PrivateKey {
-  #tari_private_key_ptr;
-
+  ptr;
   pointerAssign(ptr) {
     // Prevent pointer from being leaked in case of re-assignment
-    if (this.#tari_private_key_ptr) {
-      this.#tari_private_key_ptr = ptr;
+    if (this.ptr) {
+      this.ptr = ptr;
       this.destroy();
     } else {
-      this.#tari_private_key_ptr = ptr;
+      this.ptr = ptr;
     }
   }
 
   generate() {
-    this.#tari_private_key_ptr = InterfaceFFI.privateKeyGenerate();
+    this.ptr = InterfaceFFI.privateKeyGenerate();
   }
 
   fromHexString(hex) {
@@ -33,14 +32,12 @@ class PrivateKey {
   }
 
   getPtr() {
-    return this.#tari_private_key_ptr;
+    return this.ptr;
   }
 
   getBytes() {
     let result = new ByteVector();
-    result.pointerAssign(
-      InterfaceFFI.privateKeyGetBytes(this.#tari_private_key_ptr)
-    );
+    result.pointerAssign(InterfaceFFI.privateKeyGetBytes(this.ptr));
     return result;
   }
 
@@ -57,9 +54,9 @@ class PrivateKey {
   }
 
   destroy() {
-    if (this.#tari_private_key_ptr) {
-      InterfaceFFI.privateKeyDestroy(this.#tari_private_key_ptr);
-      this.#tari_private_key_ptr = undefined; //prevent double free segfault
+    if (this.ptr) {
+      InterfaceFFI.privateKeyDestroy(this.ptr);
+      this.ptr = undefined; //prevent double free segfault
     }
   }
 }

--- a/integration_tests/helpers/ffi/publicKey.js
+++ b/integration_tests/helpers/ffi/publicKey.js
@@ -3,15 +3,15 @@ const ByteVector = require("./byteVector");
 const utf8 = require("utf8");
 
 class PublicKey {
-  #tari_public_key_ptr;
+  ptr;
 
   pointerAssign(ptr) {
     // Prevent pointer from being leaked in case of re-assignment
-    if (this.#tari_public_key_ptr) {
+    if (this.ptr) {
       this.destroy();
-      this.#tari_public_key_ptr = ptr;
+      this.ptr = ptr;
     } else {
-      this.#tari_public_key_ptr = ptr;
+      this.ptr = ptr;
     }
   }
 
@@ -42,14 +42,12 @@ class PublicKey {
   }
 
   getPtr() {
-    return this.#tari_public_key_ptr;
+    return this.ptr;
   }
 
   getBytes() {
     let result = new ByteVector();
-    result.pointerAssign(
-      InterfaceFFI.publicKeyGetBytes(this.#tari_public_key_ptr)
-    );
+    result.pointerAssign(InterfaceFFI.publicKeyGetBytes(this.ptr));
     return result;
   }
 
@@ -66,16 +64,16 @@ class PublicKey {
   }
 
   getEmojiId() {
-    const emoji_id = InterfaceFFI.publicKeyToEmojiId(this.#tari_public_key_ptr);
-    const result = emoji_id.readCString();
+    let emoji_id = InterfaceFFI.publicKeyToEmojiId(this.ptr);
+    let result = emoji_id.readCString();
     InterfaceFFI.stringDestroy(emoji_id);
     return result;
   }
 
   destroy() {
-    if (this.#tari_public_key_ptr) {
-      InterfaceFFI.publicKeyDestroy(this.#tari_public_key_ptr);
-      this.#tari_public_key_ptr = undefined; //prevent double free segfault
+    if (this.ptr) {
+      InterfaceFFI.publicKeyDestroy(this.ptr);
+      this.ptr = undefined; //prevent double free segfault
     }
   }
 }

--- a/integration_tests/helpers/ffi/seedWords.js
+++ b/integration_tests/helpers/ffi/seedWords.js
@@ -2,15 +2,15 @@ const InterfaceFFI = require("./ffiInterface");
 const utf8 = require("utf8");
 
 class SeedWords {
-  #tari_seed_words_ptr;
+  ptr;
 
   pointerAssign(ptr) {
     // Prevent pointer from being leaked in case of re-assignment
-    if (this.#tari_seed_words_ptr) {
+    if (this.ptr) {
       this.destroy();
-      this.#tari_seed_words_ptr = ptr;
+      this.ptr = ptr;
     } else {
-      this.#tari_seed_words_ptr = ptr;
+      this.ptr = ptr;
     }
   }
 
@@ -28,27 +28,24 @@ class SeedWords {
   }
 
   getLength() {
-    return InterfaceFFI.seedWordsGetLength(this.#tari_seed_words_ptr);
+    return InterfaceFFI.seedWordsGetLength(this.ptr);
   }
 
   getPtr() {
-    return this.#tari_seed_words_ptr;
+    return this.ptr;
   }
 
   getAt(position) {
-    const seed_word = InterfaceFFI.seedWordsGetAt(
-      this.#tari_seed_words_ptr,
-      position
-    );
-    const result = seed_word.readCString();
+    let seed_word = InterfaceFFI.seedWordsGetAt(this.ptr, position);
+    let result = seed_word.readCString();
     InterfaceFFI.stringDestroy(seed_word);
     return result;
   }
 
   destroy() {
-    if (this.#tari_seed_words_ptr) {
-      InterfaceFFI.seedWordsDestroy(this.#tari_seed_words_ptr);
-      this.#tari_seed_words_ptr = undefined; //prevent double free segfault
+    if (this.ptr) {
+      InterfaceFFI.seedWordsDestroy(this.ptr);
+      this.ptr = undefined; //prevent double free segfault
     }
   }
 }

--- a/integration_tests/helpers/ffi/transportType.js
+++ b/integration_tests/helpers/ffi/transportType.js
@@ -2,27 +2,27 @@ const InterfaceFFI = require("./ffiInterface");
 const utf8 = require("utf8");
 
 class TransportType {
-  #tari_transport_type_ptr;
-  #type = "None";
+  ptr;
+  type = "None";
 
   pointerAssign(ptr, type) {
     // Prevent pointer from being leaked in case of re-assignment
-    if (this.#tari_transport_type_ptr) {
+    if (this.ptr) {
       this.destroy();
-      this.#tari_transport_type_ptr = ptr;
-      this.#type = type;
+      this.ptr = ptr;
+      this.type = type;
     } else {
-      this.#tari_transport_type_ptr = ptr;
-      this.#type = type;
+      this.ptr = ptr;
+      this.type = type;
     }
   }
 
   getPtr() {
-    return this.#tari_transport_type_ptr;
+    return this.ptr;
   }
 
   getType() {
-    return this.#type;
+    return this.type;
   }
 
   static createMemory() {
@@ -63,7 +63,7 @@ class TransportType {
   }
 
   getAddress() {
-    if (this.#type === "Memory") {
+    if (this.type === "Memory") {
       let c_address = InterfaceFFI.transportMemoryGetAddress(this.getPtr());
       let result = c_address.readCString();
       InterfaceFFI.stringDestroy(c_address);
@@ -74,10 +74,10 @@ class TransportType {
   }
 
   destroy() {
-    this.#type = "None";
-    if (this.#tari_transport_type_ptr) {
-      InterfaceFFI.transportTypeDestroy(this.#tari_transport_type_ptr);
-      this.#tari_transport_type_ptr = undefined; //prevent double free segfault
+    this.type = "None";
+    if (this.ptr) {
+      InterfaceFFI.transportTypeDestroy(this.ptr);
+      this.ptr = undefined; //prevent double free segfault
     }
   }
 }

--- a/integration_tests/helpers/util.js
+++ b/integration_tests/helpers/util.js
@@ -107,6 +107,19 @@ async function waitFor(
   }
 }
 
+async function waitForIterate(testFn, toBe, sleepMs, maxIterations = 500) {
+  let count = 0;
+  let val = testFn();
+  while (!(val === toBe)) {
+    val = testFn();
+    if (count >= maxIterations) {
+      break;
+    }
+    count++;
+    await sleep(sleepMs);
+  }
+}
+
 async function waitForPredicate(predicate, timeOut, sleep_ms = 500) {
   const now = new Date();
   while (new Date() - now < timeOut) {
@@ -280,6 +293,6 @@ module.exports = {
   combineTwoTariKeys,
   byteArrayToHex,
   waitForPredicate,
-
+  waitForIterate,
   NO_CONNECTION,
 };

--- a/integration_tests/helpers/walletFFIClient.js
+++ b/integration_tests/helpers/walletFFIClient.js
@@ -4,136 +4,131 @@ const CommsConfig = require("./ffi/commsConfig");
 const Wallet = require("./ffi/wallet");
 const { getFreePort } = require("./util");
 const dateFormat = require("dateformat");
-const InterfaceFFI = require("./ffi/ffiInterface");
 
 class WalletFFIClient {
-  #name;
-  #wallet;
-  #comms_config;
-  #transport;
-  #seed_words;
-  #pass_phrase;
-  #port;
+  name;
+  wallet;
+  comms_config;
+  transport;
+  seed_words;
+  pass_phrase;
+  port;
   baseDir = "";
 
   constructor(name) {
-    this.#name = name;
-  }
-
-  static async Init() {
-    await InterfaceFFI.Init();
+    this.name = name;
   }
 
   async startNew(seed_words_text, pass_phrase) {
-    this.#port = await getFreePort(19000, 25000);
-    const name = `WalletFFI${this.#port}-${this.#name}`;
+    this.port = await getFreePort(19000, 25000);
+    const name = `WalletFFI${this.port}-${this.name}`;
     this.baseDir = `./temp/base_nodes/${dateFormat(
       new Date(),
       "yyyymmddHHMM"
     )}/${name}`;
-    this.#transport = TransportType.createTCP(`/ip4/0.0.0.0/tcp/${this.#port}`);
-    this.#comms_config = new CommsConfig(
-      `/ip4/0.0.0.0/tcp/${this.#port}`,
-      this.#transport.getPtr(),
+    this.transport = TransportType.createTCP(`/ip4/0.0.0.0/tcp/${this.port}`);
+    this.comms_config = new CommsConfig(
+      `/ip4/0.0.0.0/tcp/${this.port}`,
+      this.transport.getPtr(),
       "wallet.dat",
       this.baseDir,
       30,
       600,
       "localnet"
     );
-    this.#start(seed_words_text, pass_phrase);
+    this.start(seed_words_text, pass_phrase);
   }
 
   async restart(seed_words_text, pass_phrase) {
-    this.#transport = TransportType.createTCP(`/ip4/0.0.0.0/tcp/${this.#port}`);
-    this.#comms_config = new CommsConfig(
-      `/ip4/0.0.0.0/tcp/${this.#port}`,
-      this.#transport.getPtr(),
+    this.transport = TransportType.createTCP(`/ip4/0.0.0.0/tcp/${this.port}`);
+    this.comms_config = new CommsConfig(
+      `/ip4/0.0.0.0/tcp/${this.port}`,
+      this.transport.getPtr(),
       "wallet.dat",
       this.baseDir,
       30,
       600,
       "localnet"
     );
-    this.#start(seed_words_text, pass_phrase);
+    this.start(seed_words_text, pass_phrase);
   }
 
   getStxoValidationStatus() {
-    return this.#wallet.getStxoValidationStatus();
+    return this.wallet.getStxoValidationStatus();
   }
 
   getUtxoValidationStatus() {
-    return this.#wallet.getUtxoValidationStatus();
+    return this.wallet.getUtxoValidationStatus();
   }
   identify() {
-    return this.#wallet.getPublicKey();
+    return this.wallet.getPublicKey();
   }
 
   identifyEmoji() {
-    return this.#wallet.getEmojiId();
+    return this.wallet.getEmojiId();
   }
 
   getBalance() {
-    return this.#wallet.getBalance();
+    return this.wallet.getBalance();
   }
 
   addBaseNodePeer(public_key_hex, address) {
-    return this.#wallet.addBaseNodePeer(public_key_hex, address);
+    return this.wallet.addBaseNodePeer(public_key_hex, address);
   }
 
   addContact(alias, pubkey_hex) {
-    return this.#wallet.addContact(alias, pubkey_hex);
+    return this.wallet.addContact(alias, pubkey_hex);
   }
 
   getContactList() {
-    return this.#wallet.getContacts();
+    return this.wallet.getContacts();
   }
 
   getCompletedTxs() {
-    return this.#wallet.getCompletedTransactions();
+    return this.wallet.getCompletedTransactions();
   }
 
   getInboundTxs() {
-    return this.#wallet.getInboundTransactions();
+    return this.wallet.getInboundTransactions();
   }
 
   getOutboundTxs() {
-    return this.#wallet.getOutboundTransactions();
+    return this.wallet.getOutboundTransactions();
   }
 
   removeContact(contact) {
-    return this.#wallet.removeContact(contact);
+    return this.wallet.removeContact(contact);
   }
 
   startRecovery(base_node_pubkey) {
-    this.#wallet.startRecovery(base_node_pubkey);
+    this.wallet.startRecovery(base_node_pubkey);
   }
 
   checkRecoveryInProgress() {
-    return this.#wallet.recoveryInProgress();
+    return this.wallet.recoveryInProgress();
   }
 
   applyEncryption(passphrase) {
-    this.#wallet.applyEncryption(passphrase);
+    this.wallet.applyEncryption(passphrase);
   }
 
   startStxoValidation() {
-    this.#wallet.startStxoValidation();
+    this.wallet.startStxoValidation();
   }
 
   startUtxoValidation() {
-    this.#wallet.startUtxoValidation();
+    this.wallet.startUtxoValidation();
   }
 
   getCounters() {
-    return this.#wallet.getCounters();
+    return this.wallet.getCounters();
   }
   resetCounters() {
-    this.#wallet.clearCallbackCounters();
+    this.wallet.clearCallbackCounters();
   }
 
   sendTransaction(destination, amount, fee_per_gram, message) {
-    return this.#wallet.sendTransaction(
+    return this.wallet.sendTransaction(
       destination,
       amount,
       fee_per_gram,
@@ -141,46 +136,49 @@ class WalletFFIClient {
     );
   }
 
-  #start(
+  start(
     seed_words_text,
     pass_phrase,
     rolling_log_files = 50,
     byte_size_per_log = 102400
   ) {
-    this.#pass_phrase = pass_phrase;
+    this.pass_phrase = pass_phrase;
     if (seed_words_text) {
       let seed_words = SeedWords.fromText(seed_words_text);
-      this.#seed_words = seed_words;
+      this.seed_words = seed_words;
     }
 
     let log_path = `${this.baseDir}/log/wallet.log`;
-    this.#wallet = new Wallet(
-      this.#comms_config.getPtr(),
+    this.wallet = new Wallet(
+      this.comms_config.getPtr(),
       log_path,
-      this.#pass_phrase,
-      this.#seed_words ? this.#seed_words.getPtr() : null,
+      this.pass_phrase,
+      this.seed_words ? this.seed_words.getPtr() : null,
       rolling_log_files,
       byte_size_per_log
     );
   }
 
   getOutboundTransactions() {
-    return this.#wallet.getOutboundTransactions();
+    return this.wallet.getOutboundTransactions();
   }
 
   cancelPendingTransaction(tx_id) {
-    return this.#wallet.cancelPendingTransaction(tx_id);
+    return this.wallet.cancelPendingTransaction(tx_id);
   }
 
   stop() {
-    if (this.#wallet) {
-      this.#wallet.destroy();
+    if (this.wallet) {
+      this.wallet.destroy();
     }
-    if (this.#comms_config) {
-      this.#comms_config.destroy();
+    if (this.comms_config) {
+      this.comms_config.destroy();
     }
-    if (this.#seed_words) {
-      this.#seed_words.destroy();
+    if (this.transport) {
+      this.transport.destroy();
+    }
+    if (this.seed_words) {
+      this.seed_words.destroy();
     }
   }
 }


### PR DESCRIPTION
Description
Made types more explicit for ffi interface and easier to maintain going forwards.
Initialized InterfaceFFI in world rather than WalletFFIClient.
Updated steps in WalletFFI.feature
Updated some const variables in wrapper classes to be let.
Better handling of callback function pointer variables in wallet.
Added additional steps to tests.
Downgrade code to be compatible with nodejs v12.

Motivation and Context


How Has This Been Tested?
nvm use v12.22.6 && ./node_modules/.bin/cucumber-js features/WalletFFI.feature

Run log:
[run.log](https://github.com/tari-project/tari/files/7097096/run.log)


NodeJS version downgrade:
https://github.com/tari-labs/docker/pull/16