### PR TITLE
chore: add network to Base Node status line

### DIFF
--- a/applications/tari_base_node/src/command_handler.rs
+++ b/applications/tari_base_node/src/command_handler.rs
@@ -116,7 +116,8 @@ impl CommandHandler {
             let mut status_line = StatusLine::new();
             let version = format!("v{}", consts::APP_VERSION_NUMBER);
             status_line.add_field("", version);
-
+            let network = format!("{}", config.network);
+            status_line.add_field("", network);
             status_line.add_field("State", state_info.borrow().state_info.short_desc());
 
             let metadata = node.get_metadata().await.unwrap();


### PR DESCRIPTION
Description
---
We want to see the network in the base node status line.

How Has This Been Tested?
---
manually
