### PR TITLE
test: remove @broken keyword from working tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5049,7 +5049,7 @@ dependencies = [
 
 [[package]]
 name = "tari_wallet_ffi"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "chrono",
  "env_logger 0.7.1",

--- a/integration_tests/features/Mempool.feature
+++ b/integration_tests/features/Mempool.feature
@@ -60,7 +60,7 @@ Feature: Mempool
     Then SENDER has TX3 in MINED state
 
 
-  @critical @broken
+  @critical @long-running
   Scenario: Double spend
     Given I have 1 seed nodes
     And I have a base node SENDER connected to all seed nodes
@@ -171,23 +171,23 @@ Feature: Mempool
     Then SENDER has TX12 in MINED state
     Then SENDER has TX13 in MINED state
 
-    @critical
-    Scenario: Mempool unconfirmed transactions
-      Given I have 1 seed nodes
-      And I have a base node BN1 connected to all seed nodes
-      When I mine a block on BN1 with coinbase CB1
-      When I mine 5 blocks on BN1
-      When I create a custom fee transaction TX1 spending CB1 to UTX1 with fee 80
-      When I create a custom fee transaction TX2 spending CB1 to UTX1 with fee 80
-      When I create a custom fee transaction TX3 spending CB1 to UTX1 with fee 80
-      When I create a custom fee transaction TX4 spending CB1 to UTX1 with fee 80
-      When I create a custom fee transaction TX5 spending CB1 to UTX1 with fee 80
-      When I submit transaction TX1 to BN1
-      When I submit transaction TX2 to BN1
-      When I submit transaction TX3 to BN1
-      When I submit transaction TX4 to BN1
-      When I submit transaction TX5 to BN1
-      Then I wait until base node BN1 has 5 unconfirmed transactions in its mempool
+  @critical
+  Scenario: Mempool unconfirmed transactions
+    Given I have 1 seed nodes
+    And I have a base node BN1 connected to all seed nodes
+    When I mine a block on BN1 with coinbase CB1
+    When I mine 5 blocks on BN1
+    When I create a custom fee transaction TX1 spending CB1 to UTX1 with fee 80
+    When I create a custom fee transaction TX2 spending CB1 to UTX1 with fee 80
+    When I create a custom fee transaction TX3 spending CB1 to UTX1 with fee 80
+    When I create a custom fee transaction TX4 spending CB1 to UTX1 with fee 80
+    When I create a custom fee transaction TX5 spending CB1 to UTX1 with fee 80
+    When I submit transaction TX1 to BN1
+    When I submit transaction TX2 to BN1
+    When I submit transaction TX3 to BN1
+    When I submit transaction TX4 to BN1
+    When I submit transaction TX5 to BN1
+    Then I wait until base node BN1 has 5 unconfirmed transactions in its mempool
 
   @critical
   Scenario: Mempool unconfirmed transaction to mined transaction

--- a/integration_tests/features/Sync.feature
+++ b/integration_tests/features/Sync.feature
@@ -148,12 +148,8 @@ Feature: Block Sync
       | X1   | Y1 | SYNC_TIME |
       | 501  | 50 | 20        |
       | 999  | 50 | 60        |
-      | 1001 | 50 | 60        |
-
-    @critical @long-running @broken
-    Examples:
-      | X1   | Y1 | SYNC_TIME |
       | 1000 | 50 | 60        |
+      | 1001 | 50 | 60        |
 
   Scenario: Pruned mode network only
     Given I have a base node NODE1 connected to all seed nodes
@@ -185,9 +181,9 @@ Feature: Block Sync
       | 5     | 100    | 0             | 30        |
       | 10    | 100    | 0             | 30        |
       | 20    | 100    | 0             | 30        |
-      | 5     | 1001   | 0             | 60        |
-      | 10    | 1001   | 0             | 60        |
+      | 5     | 999    | 0             | 60        |
+      | 10    | 1000   | 0             | 60        |
       | 20    | 1001   | 0             | 60        |
-      | 5     | 1001   | 100           | 90        |
-      | 10    | 1001   | 100           | 90        |
+      | 5     | 999    | 100           | 90        |
+      | 10    | 1000   | 100           | 90        |
       | 20    | 1001   | 100           | 90        |


### PR DESCRIPTION
Description
---
These two tests are fine (manually tested on my PC).

How Has This Been Tested?
---
npm test -- --name "Double spend"
npm test -- --name "Syncing node while also mining before tip sync"