### PR TITLE
refactor: misc minor improvements + add MissTickBehaviour to all timeouts

### DIFF
--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb.rs
@@ -78,31 +78,28 @@ where
 {
     let val_buf = serialize(val)?;
     trace!(target: LOG_TARGET, "LMDB: {} bytes inserted", val_buf.len());
-    txn.access().put(&db, key, &val_buf, put::NOOVERWRITE).map_err(|e| {
-        error!(
-            target: LOG_TARGET,
-            "Could not insert value into lmdb {} ({}/{:?}): {:?}",
+    match txn.access().put(&db, key, &val_buf, put::NOOVERWRITE) {
+        Ok(_) => Ok(()),
+        Err(lmdb_zero::Error::Code(lmdb_zero::error::KEYEXIST)) => Err(ChainStorageError::KeyExists {
             table_name,
-            to_hex(key.as_lmdb_bytes()),
-            val,
-            e,
-        );
-        if let lmdb_zero::Error::Code(code) = &e {
-            if *code == lmdb_zero::error::KEYEXIST {
-                return ChainStorageError::KeyExists {
-                    table_name,
-                    key: to_hex(key.as_lmdb_bytes()),
-                };
-            }
-            if *code == lmdb_zero::error::MAP_FULL {
-                return ChainStorageError::DbResizeRequired;
-            }
-        }
-        ChainStorageError::InsertError {
-            table: table_name,
-            error: e.to_string(),
-        }
-    })
+            key: to_hex(key.as_lmdb_bytes()),
+        }),
+        Err(lmdb_zero::Error::Code(lmdb_zero::error::MAP_FULL)) => Err(ChainStorageError::DbResizeRequired),
+        Err(e) => {
+            error!(
+                target: LOG_TARGET,
+                "Could not insert value into lmdb {} ({}/{:?}): {:?}",
+                table_name,
+                to_hex(key.as_lmdb_bytes()),
+                val,
+                e,
+            );
+            Err(ChainStorageError::InsertError {
+                table: table_name,
+                error: e.to_string(),
+            })
+        },
+    }
 }
 
 /// Note that calling this on a table that does not allow duplicates will replace it

--- a/base_layer/p2p/src/services/liveness/service.rs
+++ b/base_layer/p2p/src/services/liveness/service.rs
@@ -48,7 +48,7 @@ use tari_comms_dht::{
 };
 use tari_service_framework::reply_channel::RequestContext;
 use tari_shutdown::ShutdownSignal;
-use tokio::time;
+use tokio::{time, time::MissedTickBehavior};
 use tokio_stream::wrappers;
 
 /// Service responsible for testing Liveness of Peers.
@@ -101,10 +101,11 @@ where
         pin_mut!(request_stream);
 
         let mut ping_tick = match self.config.auto_ping_interval {
-            Some(interval) => Either::Left(wrappers::IntervalStream::new(time::interval_at(
-                (Instant::now() + interval).into(),
-                interval,
-            ))),
+            Some(interval) => {
+                let mut interval = time::interval_at((Instant::now() + interval).into(), interval);
+                interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+                Either::Left(wrappers::IntervalStream::new(interval))
+            },
             None => Either::Right(futures::stream::iter(iter::empty())),
         };
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -21,7 +21,7 @@ serde_json = "1.0.51"
 dirs-next = "1.0.2"
 get_if_addrs = "0.5.3"
 log = "0.4.8"
-log4rs = { version = "1.0.0", default_features= false, features = ["config_parsing", "threshold_filter"]}
+log4rs = { version = "1.0.0", default_features= false, features = ["config_parsing", "threshold_filter", "yaml_format"]}
 multiaddr={version = "0.13.0"}
 sha2 = "0.9.5"
 path-clean = "0.1.0"

--- a/common/src/configuration/bootstrap.rs
+++ b/common/src/configuration/bootstrap.rs
@@ -146,7 +146,7 @@ pub struct ConfigBootstrap {
     pub miner_min_diff: Option<u64>,
     #[structopt(long, alias = "max-difficulty")]
     pub miner_max_diff: Option<u64>,
-    #[structopt(long, alias = "tracing")]
+    #[structopt(long, aliases = &["tracing", "enable-tracing"])]
     pub tracing_enabled: bool,
     /// Supply a network (overrides existing configuration)
     #[structopt(long, alias = "network")]

--- a/comms/dht/src/actor.rs
+++ b/comms/dht/src/actor.rs
@@ -53,6 +53,7 @@ use tokio::{
     sync::{mpsc, oneshot},
     task,
     time,
+    time::MissedTickBehavior,
 };
 
 const LOG_TARGET: &str = "comms::dht::actor";
@@ -267,6 +268,7 @@ impl DhtActor {
         let mut pending_jobs = FuturesUnordered::new();
 
         let mut dedup_cache_trim_ticker = time::interval(self.config.dedup_cache_trim_interval);
+        dedup_cache_trim_ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
         loop {
             tokio::select! {

--- a/comms/dht/src/connectivity/mod.rs
+++ b/comms/dht/src/connectivity/mod.rs
@@ -38,7 +38,7 @@ use tari_comms::{
 };
 use tari_shutdown::ShutdownSignal;
 use thiserror::Error;
-use tokio::{sync::broadcast, task, task::JoinHandle, time};
+use tokio::{sync::broadcast, task, task::JoinHandle, time, time::MissedTickBehavior};
 
 const LOG_TARGET: &str = "comms::dht::connectivity";
 
@@ -135,6 +135,7 @@ impl DhtConnectivity {
         self.refresh_neighbour_pool().await?;
 
         let mut ticker = time::interval(self.config.connectivity_update_interval);
+        ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
         loop {
             tokio::select! {

--- a/comms/dht/src/store_forward/service.rs
+++ b/comms/dht/src/store_forward/service.rs
@@ -49,6 +49,7 @@ use tokio::{
     sync::{mpsc, oneshot},
     task,
     time,
+    time::MissedTickBehavior,
 };
 
 const LOG_TARGET: &str = "comms::dht::storeforward::actor";
@@ -212,6 +213,7 @@ impl StoreAndForwardService {
 
     async fn run(mut self) {
         let mut cleanup_ticker = time::interval(CLEANUP_INTERVAL);
+        cleanup_ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
         loop {
             tokio::select! {

--- a/comms/src/connection_manager/dial_state.rs
+++ b/comms/src/connection_manager/dial_state.rs
@@ -32,18 +32,18 @@ pub struct DialState {
     /// Number of dial attempts
     attempts: usize,
     /// This peer being dialed
-    pub peer: Box<Peer>,
+    peer: Box<Peer>,
     /// Cancel signal
     cancel_signal: ShutdownSignal,
     /// Reply channel for a connection result
-    pub reply_tx: oneshot::Sender<Result<PeerConnection, ConnectionManagerError>>,
+    reply_tx: Option<oneshot::Sender<Result<PeerConnection, ConnectionManagerError>>>,
 }
 
 impl DialState {
     /// Create a new DialState for the given NodeId
     pub fn new(
         peer: Box<Peer>,
-        reply_tx: oneshot::Sender<Result<PeerConnection, ConnectionManagerError>>,
+        reply_tx: Option<oneshot::Sender<Result<PeerConnection, ConnectionManagerError>>>,
         cancel_signal: ShutdownSignal,
     ) -> Self {
         Self {
@@ -67,5 +67,20 @@ impl DialState {
 
     pub fn num_attempts(&self) -> usize {
         self.attempts
+    }
+
+    pub fn send_reply(
+        &mut self,
+        result: Result<PeerConnection, ConnectionManagerError>,
+    ) -> Result<(), Result<PeerConnection, ConnectionManagerError>> {
+        if let Some(reply) = self.reply_tx.take() {
+            reply.send(result)?;
+            return Ok(());
+        }
+        Ok(())
+    }
+
+    pub fn peer(&self) -> &Peer {
+        &self.peer
     }
 }

--- a/comms/src/connection_manager/dialer.rs
+++ b/comms/src/connection_manager/dialer.rs
@@ -67,7 +67,7 @@ type DialFuturesUnordered =
 pub(crate) enum DialerRequest {
     Dial(
         Box<Peer>,
-        oneshot::Sender<Result<PeerConnection, ConnectionManagerError>>,
+        Option<oneshot::Sender<Result<PeerConnection, ConnectionManagerError>>>,
     ),
     CancelPendingDial(NodeId),
 }
@@ -189,27 +189,24 @@ where
 
     async fn handle_dial_result(
         &mut self,
-        dial_state: DialState,
+        mut dial_state: DialState,
         dial_result: Result<PeerConnection, ConnectionManagerError>,
     ) {
-        let DialState { peer, reply_tx, .. } = dial_state;
-
-        let node_id = peer.node_id.clone();
-        let peer_id_short_str = peer.node_id.short_str();
+        let node_id = dial_state.peer().node_id.clone();
 
         let removed = self.cancel_signals.remove(&node_id);
         drop(removed);
 
         match &dial_result {
             Ok(conn) => {
-                debug!(target: LOG_TARGET, "Successfully dialed peer '{}'", peer_id_short_str);
+                debug!(target: LOG_TARGET, "Successfully dialed peer '{}'", node_id);
                 self.notify_connection_manager(ConnectionManagerEvent::PeerConnected(conn.clone()))
                     .await
             },
             Err(err) => {
                 debug!(
                     target: LOG_TARGET,
-                    "Failed to dial peer '{}' because '{:?}'", peer_id_short_str, err
+                    "Failed to dial peer '{}' because '{:?}'", node_id, err
                 );
                 self.notify_connection_manager(ConnectionManagerEvent::PeerConnectFailed(
                     Box::new(node_id.clone()),
@@ -223,7 +220,12 @@ where
             self.reply_to_pending_requests(&node_id, dial_result.clone());
         }
 
-        let _ = reply_tx.send(dial_result);
+        if dial_state.send_reply(dial_result).is_err() {
+            warn!(
+                target: LOG_TARGET,
+                "Reply oneshot was closed before dial response for peer '{}' was sent", node_id
+            );
+        }
     }
 
     pub async fn notify_connection_manager(&mut self, event: ConnectionManagerEvent) {
@@ -259,11 +261,13 @@ where
         &mut self,
         pending_dials: &mut DialFuturesUnordered,
         peer: Box<Peer>,
-        reply_tx: oneshot::Sender<Result<PeerConnection, ConnectionManagerError>>,
+        reply_tx: Option<oneshot::Sender<Result<PeerConnection, ConnectionManagerError>>>,
     ) {
         if self.is_pending_dial(&peer.node_id) {
-            let entry = self.pending_dial_requests.entry(peer.node_id).or_insert_with(Vec::new);
-            entry.push(reply_tx);
+            if let Some(reply_tx) = reply_tx {
+                let entry = self.pending_dial_requests.entry(peer.node_id).or_insert_with(Vec::new);
+                entry.push(reply_tx);
+            }
             return;
         }
 
@@ -292,7 +296,7 @@ where
             match dial_result {
                 Ok((socket, addr)) => {
                     let authenticated_public_key =
-                        match Self::check_authenticated_public_key(&socket, &dial_state.peer.public_key) {
+                        match Self::check_authenticated_public_key(&socket, &dial_state.peer().public_key) {
                             Ok(pk) => pk,
                             Err(err) => {
                                 return (dial_state, Err(err));
@@ -443,17 +447,17 @@ where
                 target: LOG_TARGET,
                 "[Attempt {}] Will attempt connection to peer '{}' in {} second(s)",
                 current_state.num_attempts(),
-                current_state.peer.node_id.short_str(),
+                current_state.peer().node_id.short_str(),
                 backoff_duration.as_secs()
             );
             let delay = time::sleep(backoff_duration).fuse();
             let cancel_signal = current_state.get_cancel_signal();
             tokio::select! {
                 _ = delay => {
-                    debug!(target: LOG_TARGET, "[Attempt {}] Connecting to peer '{}'", current_state.num_attempts(), current_state.peer.node_id.short_str());
+                    debug!(target: LOG_TARGET, "[Attempt {}] Connecting to peer '{}'", current_state.num_attempts(), current_state.peer().node_id.short_str());
                     match Self::dial_peer(current_state, &noise_config, &current_transport, config.network_info.network_byte).await {
                         (state, Ok((socket, addr))) => {
-                            debug!(target: LOG_TARGET, "Dial succeeded for peer '{}' after {} attempt(s)", state.peer.node_id.short_str(), state.num_attempts());
+                            debug!(target: LOG_TARGET, "Dial succeeded for peer '{}' after {} attempt(s)", state.peer().node_id.short_str(), state.num_attempts());
                             break (state, Ok((socket, addr)));
                         },
                         // Inflight dial was cancelled
@@ -471,7 +475,7 @@ where
                 },
                 // Delayed dial was cancelled
                 _ = cancel_signal => {
-                    debug!(target: LOG_TARGET, "[Attempt {}] Connection attempt cancelled for peer '{}'", current_state.num_attempts(), current_state.peer.node_id.short_str());
+                    debug!(target: LOG_TARGET, "[Attempt {}] Connection attempt cancelled for peer '{}'", current_state.num_attempts(), current_state.peer().node_id.short_str());
                     break (current_state, Err(ConnectionManagerError::DialCancelled));
                 }
             }
@@ -490,7 +494,7 @@ where
         DialState,
         Result<(NoiseSocket<TTransport::Output>, Multiaddr), ConnectionManagerError>,
     ) {
-        let mut addr_iter = dial_state.peer.addresses.iter();
+        let mut addr_iter = dial_state.peer().addresses.iter();
         let cancel_signal = dial_state.get_cancel_signal();
         loop {
             let result = match addr_iter.next() {
@@ -499,7 +503,7 @@ where
                         target: LOG_TARGET,
                         "Attempting address '{}' for peer '{}'",
                         address,
-                        dial_state.peer.node_id.short_str()
+                        dial_state.peer().node_id.short_str()
                     );
 
                     let dial_fut = async move {
@@ -536,7 +540,7 @@ where
                                 "(Attempt {}) Dial failed on address '{}' for peer '{}' because '{}'",
                                 dial_state.num_attempts(),
                                 address,
-                                dial_state.peer.node_id.short_str(),
+                                dial_state.peer().node_id.short_str(),
                                 err,
                             );
                             // Try the next address
@@ -547,7 +551,7 @@ where
                             debug!(
                                 target: LOG_TARGET,
                                 "Dial for peer '{}' cancelled",
-                                dial_state.peer.node_id.short_str()
+                                dial_state.peer().node_id.short_str()
                             );
                             Err(ConnectionManagerError::DialCancelled)
                         },

--- a/comms/src/connection_manager/manager.rs
+++ b/comms/src/connection_manager/manager.rs
@@ -445,7 +445,7 @@ where
     async fn dial_peer(
         &mut self,
         node_id: NodeId,
-        reply: oneshot::Sender<Result<PeerConnection, ConnectionManagerError>>,
+        reply: Option<oneshot::Sender<Result<PeerConnection, ConnectionManagerError>>>,
     ) {
         match self.peer_manager.find_by_node_id(&node_id).await {
             Ok(peer) => {
@@ -454,7 +454,9 @@ where
             },
             Err(err) => {
                 warn!(target: LOG_TARGET, "Failed to fetch peer to dial because '{}'", err);
-                let _ = reply.send(Err(ConnectionManagerError::PeerManagerError(err)));
+                if let Some(reply) = reply {
+                    let _ = reply.send(Err(ConnectionManagerError::PeerManagerError(err)));
+                }
             },
         }
     }

--- a/comms/src/connection_manager/tests/listener_dialer.rs
+++ b/comms/src/connection_manager/tests/listener_dialer.rs
@@ -128,7 +128,7 @@ async fn smoke() {
 
     let (reply_tx, reply_rx) = oneshot::channel();
     request_tx
-        .send(DialerRequest::Dial(Box::new(peer), reply_tx))
+        .send(DialerRequest::Dial(Box::new(peer), Some(reply_tx)))
         .await
         .unwrap();
 
@@ -229,7 +229,7 @@ async fn banned() {
 
     let (reply_tx, reply_rx) = oneshot::channel();
     request_tx
-        .send(DialerRequest::Dial(Box::new(peer), reply_tx))
+        .send(DialerRequest::Dial(Box::new(peer), Some(reply_tx)))
         .await
         .unwrap();
 

--- a/comms/src/connectivity/manager.rs
+++ b/comms/src/connectivity/manager.rs
@@ -52,7 +52,7 @@ use std::{
     time::{Duration, Instant},
 };
 use tari_shutdown::ShutdownSignal;
-use tokio::{sync::mpsc, task::JoinHandle, time};
+use tokio::{sync::mpsc, task::JoinHandle, time, time::MissedTickBehavior};
 use tracing::{span, Instrument, Level};
 
 const LOG_TARGET: &str = "comms::connectivity::manager";
@@ -175,6 +175,7 @@ impl ConnectivityManagerActor {
                 .into(),
             interval,
         );
+        ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
         self.publish_event(ConnectivityEvent::ConnectivityStateInitialized);
 

--- a/comms/src/protocol/messaging/error.rs
+++ b/comms/src/protocol/messaging/error.rs
@@ -22,6 +22,7 @@
 
 use crate::{
     connection_manager::PeerConnectionError,
+    connectivity::ConnectivityError,
     message::OutboundMessage,
     peer_manager::PeerManagerError,
     protocol::ProtocolError,
@@ -46,8 +47,8 @@ pub enum MessagingProtocolError {
     ProtocolError(#[from] ProtocolError),
     #[error("PeerConnectionError: {0}")]
     PeerConnectionError(#[from] PeerConnectionError),
-    #[error("Failed to dial peer")]
-    PeerDialFailed,
+    #[error("Failed to dial peer: {0}")]
+    PeerDialFailed(ConnectivityError),
     #[error("IO Error: {0}")]
     Io(#[from] io::Error),
     #[error("Sender error: {0}")]

--- a/infrastructure/storage/tests/lmdb.rs
+++ b/infrastructure/storage/tests/lmdb.rs
@@ -338,7 +338,6 @@ fn lmdb_resize_on_create() {
 
 #[test]
 fn test_lmdb_resize_before_full() {
-    env_logger::init();
     let db_env_name = "resize_dynamic";
     {
         let path = get_path(&db_env_name);


### PR DESCRIPTION
Description
---
- Adds `MissedTickBehaviour` to every usage of `tokio::time::interval`
- Removes false error message saying failed to send dial reply, reply to dial is now optional, log error message will only occur if the reply is specified and then dropped
- Outbound messaging protocol inactivity case was incorrectly handled 
- Removes erroneous blockchain db error log when database is full and needs a resize

_Apologies for this PR being a bit miscellaneous_

Motivation and Context
---
- MissedTickBehaviour default is Burst. In most cases that we use interval, this is undesirable. `MissedTickBehaviour::Delay` or `Skip` are used as appropriate.
- When ConnectivityManager calls `dial_peer` it does not require a reply with the `PeerConnection`, changed the internal datastructures to allow this case. Previously the oneshot was created and immediately dropped to satisfy the API which cause the false error to log.
- Previously, an io::Error was returned when the stream was inactive for a certain length of time. An IO error was used just to satisfy the `stream.forward` combinator. A native MessagingProtocolError is now used, so the inactive case is now handled correctly.

How Has This Been Tested?
---
Existing tests + manually
