### PR TITLE
fix: ban header sync peer if no headers provided

### DIFF
--- a/base_layer/core/src/base_node/sync/header_sync/error.rs
+++ b/base_layer/core/src/base_node/sync/header_sync/error.rs
@@ -63,4 +63,6 @@ pub enum BlockHeaderSyncError {
     InvalidProtocolResponse(String),
     #[error("Headers did not form a chain. Expected {actual} to equal the previous hash {expected}")]
     ChainLinkBroken { actual: String, expected: String },
+    #[error("Invalid remote peer behaviour: {0}")]
+    InvalidRemotePeerBehaviour(String),
 }


### PR DESCRIPTION

Description
---
Adds ban in header sync if peer has indicated that they have a better chain but is unable to provide headers 

Motivation and Context
---
A peer can advertise a higher chain metadata and then return no
headers. This case is likely malicious. In this PR, this is handled
by banning the peer allowing the node to attempt a sync with another peer.

How Has This Been Tested?
---
Manually
