### PR TITLE
chore: upgrade to tokio 1.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1673,7 +1673,7 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio 1.10.1",
+ "tokio 1.11.0",
  "tokio-util",
  "tracing",
 ]
@@ -1800,7 +1800,7 @@ dependencies = [
  "itoa",
  "pin-project-lite 0.2.7",
  "socket2",
- "tokio 1.10.1",
+ "tokio 1.11.0",
  "tower-service",
  "tracing",
  "want",
@@ -1814,7 +1814,7 @@ checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
  "hyper 0.14.12",
  "pin-project-lite 0.2.7",
- "tokio 1.10.1",
+ "tokio 1.11.0",
  "tokio-io-timeout",
 ]
 
@@ -1827,7 +1827,7 @@ dependencies = [
  "bytes 1.1.0",
  "hyper 0.14.12",
  "native-tls",
- "tokio 1.10.1",
+ "tokio 1.11.0",
  "tokio-native-tls",
 ]
 
@@ -2738,7 +2738,7 @@ dependencies = [
  "pin-project 1.0.8",
  "rand 0.8.4",
  "thiserror",
- "tokio 1.10.1",
+ "tokio 1.11.0",
  "tokio-stream",
 ]
 
@@ -2754,7 +2754,7 @@ dependencies = [
  "opentelemetry-semantic-conventions",
  "thiserror",
  "thrift",
- "tokio 1.10.1",
+ "tokio 1.11.0",
 ]
 
 [[package]]
@@ -3467,7 +3467,7 @@ dependencies = [
  "serde 1.0.130",
  "serde_json",
  "serde_urlencoded",
- "tokio 1.10.1",
+ "tokio 1.11.0",
  "tokio-native-tls",
  "url 2.2.2",
  "wasm-bindgen",
@@ -4196,7 +4196,7 @@ dependencies = [
  "tari_p2p",
  "tari_wallet",
  "thiserror",
- "tokio 1.10.1",
+ "tokio 1.11.0",
  "tonic",
 ]
 
@@ -4230,7 +4230,7 @@ dependencies = [
  "tari_service_framework",
  "tari_shutdown",
  "thiserror",
- "tokio 1.10.1",
+ "tokio 1.11.0",
  "tonic",
  "tracing",
  "tracing-opentelemetry",
@@ -4296,7 +4296,7 @@ dependencies = [
  "rand 0.8.4",
  "serde 1.0.130",
  "tari_crypto",
- "tokio 1.10.1",
+ "tokio 1.11.0",
 ]
 
 [[package]]
@@ -4338,7 +4338,7 @@ dependencies = [
  "tari_test_utils",
  "tempfile",
  "thiserror",
- "tokio 1.10.1",
+ "tokio 1.11.0",
  "tokio-stream",
  "tokio-util",
  "tower 0.3.1",
@@ -4387,7 +4387,7 @@ dependencies = [
  "tari_utilities",
  "tempfile",
  "thiserror",
- "tokio 1.10.1",
+ "tokio 1.11.0",
  "tokio-stream",
  "tokio-test 0.4.2",
  "tower 0.3.1",
@@ -4406,7 +4406,7 @@ dependencies = [
  "syn 1.0.75",
  "tari_comms",
  "tari_test_utils",
- "tokio 1.10.1",
+ "tokio 1.11.0",
  "tower-service",
 ]
 
@@ -4442,7 +4442,7 @@ dependencies = [
  "tari_shutdown",
  "tari_wallet",
  "thiserror",
- "tokio 1.10.1",
+ "tokio 1.11.0",
  "tonic",
  "tracing",
  "tracing-opentelemetry",
@@ -4497,7 +4497,7 @@ dependencies = [
  "tari_test_utils",
  "tempfile",
  "thiserror",
- "tokio 1.10.1",
+ "tokio 1.11.0",
  "tracing",
  "tracing-attributes",
  "tracing-futures",
@@ -4583,7 +4583,7 @@ dependencies = [
  "tari_crypto",
  "tari_utilities",
  "thiserror",
- "tokio 1.10.1",
+ "tokio 1.11.0",
  "tonic",
  "tracing",
  "tracing-futures",
@@ -4617,7 +4617,7 @@ dependencies = [
  "tari_crypto",
  "thiserror",
  "time",
- "tokio 1.10.1",
+ "tokio 1.11.0",
  "tonic",
 ]
 
@@ -4675,7 +4675,7 @@ dependencies = [
  "tari_utilities",
  "tempfile",
  "thiserror",
- "tokio 1.10.1",
+ "tokio 1.11.0",
  "tokio-stream",
  "tower 0.3.1",
  "tower-service",
@@ -4694,7 +4694,7 @@ dependencies = [
  "tari_shutdown",
  "tari_test_utils",
  "thiserror",
- "tokio 1.10.1",
+ "tokio 1.11.0",
  "tower 0.3.1",
  "tower-service",
 ]
@@ -4704,7 +4704,7 @@ name = "tari_shutdown"
 version = "0.9.6"
 dependencies = [
  "futures 0.3.16",
- "tokio 1.10.1",
+ "tokio 1.11.0",
 ]
 
 [[package]]
@@ -4769,7 +4769,7 @@ dependencies = [
  "tari_crypto",
  "tari_utilities",
  "thiserror",
- "tokio 1.10.1",
+ "tokio 1.11.0",
  "tonic",
  "tonic-build",
  "tracing",
@@ -4788,7 +4788,7 @@ dependencies = [
  "rand 0.8.4",
  "tari_shutdown",
  "tempfile",
- "tokio 1.10.1",
+ "tokio 1.11.0",
 ]
 
 [[package]]
@@ -4847,7 +4847,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "time",
- "tokio 1.10.1",
+ "tokio 1.11.0",
  "tower 0.3.1",
 ]
 
@@ -4876,7 +4876,7 @@ dependencies = [
  "tari_wallet",
  "tempfile",
  "thiserror",
- "tokio 1.10.1",
+ "tokio 1.11.0",
 ]
 
 [[package]]
@@ -4913,7 +4913,7 @@ dependencies = [
  "tari_core",
  "tari_crypto",
  "tari_utilities",
- "tokio 1.10.1",
+ "tokio 1.11.0",
 ]
 
 [[package]]
@@ -5047,9 +5047,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92036be488bb6594459f2e03b60e42df6f937fe6ca5c5ffdcb539c6b84dc40f5"
+checksum = "b4efe6fc2395938c8155973d7be49fe8d03a843726e285e100a8a383cc0154ce"
 dependencies = [
  "autocfg 1.0.1",
  "bytes 1.1.0",
@@ -5071,7 +5071,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90c49f106be240de154571dd31fbe48acb10ba6c6dd6f6517ad603abffa42de9"
 dependencies = [
  "pin-project-lite 0.2.7",
- "tokio 1.10.1",
+ "tokio 1.11.0",
 ]
 
 [[package]]
@@ -5092,7 +5092,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
  "native-tls",
- "tokio 1.10.1",
+ "tokio 1.11.0",
 ]
 
 [[package]]
@@ -5102,7 +5102,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
 dependencies = [
  "rustls",
- "tokio 1.10.1",
+ "tokio 1.11.0",
  "webpki",
 ]
 
@@ -5114,7 +5114,7 @@ checksum = "7b2f3f698253f03119ac0102beaa64f67a67e08074d03a22d18784104543727f"
 dependencies = [
  "futures-core",
  "pin-project-lite 0.2.7",
- "tokio 1.10.1",
+ "tokio 1.11.0",
  "tokio-util",
 ]
 
@@ -5138,7 +5138,7 @@ dependencies = [
  "async-stream",
  "bytes 1.1.0",
  "futures-core",
- "tokio 1.10.1",
+ "tokio 1.11.0",
  "tokio-stream",
 ]
 
@@ -5154,7 +5154,7 @@ dependencies = [
  "futures-sink",
  "log 0.4.14",
  "pin-project-lite 0.2.7",
- "tokio 1.10.1",
+ "tokio 1.11.0",
 ]
 
 [[package]]
@@ -5196,7 +5196,7 @@ dependencies = [
  "pin-project 1.0.8",
  "prost",
  "prost-derive",
- "tokio 1.10.1",
+ "tokio 1.11.0",
  "tokio-stream",
  "tokio-util",
  "tower 0.4.8",
@@ -5248,7 +5248,7 @@ dependencies = [
  "pin-project 1.0.8",
  "rand 0.8.4",
  "slab",
- "tokio 1.10.1",
+ "tokio 1.11.0",
  "tokio-stream",
  "tokio-util",
  "tower-layer",
@@ -5516,7 +5516,7 @@ dependencies = [
  "ring",
  "rustls",
  "thiserror",
- "tokio 1.10.1",
+ "tokio 1.11.0",
  "trust-dns-proto",
  "webpki",
 ]
@@ -5544,7 +5544,7 @@ dependencies = [
  "smallvec",
  "thiserror",
  "tinyvec",
- "tokio 1.10.1",
+ "tokio 1.11.0",
  "tokio-rustls",
  "url 2.2.2",
  "webpki",

--- a/applications/tari_app_utilities/Cargo.toml
+++ b/applications/tari_app_utilities/Cargo.toml
@@ -5,21 +5,21 @@ authors = ["The Tari Development Community"]
 edition = "2018"
 
 [dependencies]
-tari_comms = { path = "../../comms"}
+tari_comms = { path = "../../comms" }
 tari_crypto = "0.11.1"
 tari_common = { path = "../../common" }
-tari_common_types ={ path ="../../base_layer/common_types"}
+tari_common_types = { path = "../../base_layer/common_types" }
 tari_p2p = { path = "../../base_layer/p2p", features = ["auto-update"] }
 tari_wallet = { path = "../../base_layer/wallet", optional = true }
 
 config = { version = "0.9.3" }
-futures = { version = "^0.3.16", default-features = false, features = ["alloc"]}
+futures = { version = "^0.3.16", default-features = false, features = ["alloc"] }
 qrcode = { version = "0.12" }
 dirs-next = "1.0.2"
 serde_json = "1.0"
 log = { version = "0.4.8", features = ["std"] }
 rand = "0.8"
-tokio = { version="^1.10", features = ["signal"] }
+tokio = { version = "1.11", features = ["signal"] }
 structopt = { version = "0.3.13", default_features = false }
 strum = "^0.19"
 strum_macros = "^0.19"
@@ -33,7 +33,7 @@ default-features = false
 features = ["transactions"]
 
 [build-dependencies]
-tari_common = {  path = "../../common", features = ["build", "static-application-info"] }
+tari_common = { path = "../../common", features = ["build", "static-application-info"] }
 
 [features]
 # TODO: This crate is supposed to hold common logic. Move code from this feature into the crate that is more specific to the wallet

--- a/applications/tari_base_node/Cargo.toml
+++ b/applications/tari_base_node/Cargo.toml
@@ -30,7 +30,7 @@ log = { version = "0.4.8", features = ["std"] }
 regex = "1"
 rustyline = "6.0"
 rustyline-derive = "0.3"
-tokio = { version = "^1.10", features = ["signal"] }
+tokio = { version = "1.11", features = ["signal"] }
 strum = "^0.19"
 strum_macros = "0.18.0"
 thiserror = "^1.0.26"

--- a/applications/tari_console_wallet/Cargo.toml
+++ b/applications/tari_console_wallet/Cargo.toml
@@ -5,23 +5,23 @@ authors = ["The Tari Development Community"]
 edition = "2018"
 
 [dependencies]
-tari_wallet = {  path = "../../base_layer/wallet", features=["bundled_sqlite"] }
+tari_wallet = { path = "../../base_layer/wallet", features = ["bundled_sqlite"] }
 tari_crypto = "0.11.1"
-tari_common = {  path = "../../common" }
-tari_app_utilities = { path = "../tari_app_utilities", features = ["wallet"]}
-tari_comms = {  path = "../../comms"}
-tari_comms_dht = {  path = "../../comms/dht"}
-tari_common_types = {path = "../../base_layer/common_types"}
-tari_p2p = {  path = "../../base_layer/p2p", features = ["auto-update"]  }
-tari_app_grpc = {  path = "../tari_app_grpc", features = ["wallet"] }
-tari_shutdown = {  path = "../../infrastructure/shutdown" }
-tari_key_manager = { path = "../../base_layer/key_manager"  }
+tari_common = { path = "../../common" }
+tari_app_utilities = { path = "../tari_app_utilities", features = ["wallet"] }
+tari_comms = { path = "../../comms" }
+tari_comms_dht = { path = "../../comms/dht" }
+tari_common_types = { path = "../../base_layer/common_types" }
+tari_p2p = { path = "../../base_layer/p2p", features = ["auto-update"] }
+tari_app_grpc = { path = "../tari_app_grpc", features = ["wallet"] }
+tari_shutdown = { path = "../../infrastructure/shutdown" }
+tari_key_manager = { path = "../../base_layer/key_manager" }
 
 bitflags = "1.2.1"
-chrono = { version = "0.4.6", features = ["serde"]}
+chrono = { version = "0.4.6", features = ["serde"] }
 chrono-english = "0.1"
-futures = { version = "^0.3.16", default-features = false, features = ["alloc"]}
-crossterm = { version = "0.17"}
+futures = { version = "^0.3.16", default-features = false, features = ["alloc"] }
+crossterm = { version = "0.17" }
 rand = "0.8"
 unicode-width = "0.1"
 unicode-segmentation = "1.6.0"
@@ -32,7 +32,7 @@ rpassword = "5.0"
 rustyline = "6.0"
 strum = "^0.19"
 strum_macros = "^0.19"
-tokio = { version="^1.10", features = ["signal"] }
+tokio = { version = "1.11", features = ["signal"] }
 thiserror = "1.0.26"
 tonic = "0.5.2"
 
@@ -41,8 +41,8 @@ tracing-opentelemetry = "0.15.0"
 tracing-subscriber = "0.2.20"
 
 # network tracing, rt-tokio for async batch export
-opentelemetry = { version = "0.16", default-features = false, features = ["trace","rt-tokio"] }
-opentelemetry-jaeger = { version="0.15", features=["rt-tokio"]}
+opentelemetry = { version = "0.16", default-features = false, features = ["trace", "rt-tokio"] }
+opentelemetry-jaeger = { version = "0.15", features = ["rt-tokio"] }
 
 [dependencies.tari_core]
 path = "../../base_layer/core"

--- a/applications/tari_merge_mining_proxy/Cargo.toml
+++ b/applications/tari_merge_mining_proxy/Cargo.toml
@@ -37,7 +37,7 @@ serde = { version = "1.0.106", features = ["derive"] }
 serde_json = "1.0.57"
 structopt = { version = "0.3.13", default_features = false }
 thiserror = "1.0.26"
-tokio = { version = "1.10", features = ["macros"] }
+tokio = { version = "1.11", features = ["macros"] }
 tonic = "0.5.2"
 tracing = "0.1"
 tracing-futures = "0.2"

--- a/applications/tari_mining_node/Cargo.toml
+++ b/applications/tari_mining_node/Cargo.toml
@@ -22,7 +22,7 @@ rand = "0.8"
 sha3 = "0.9"
 serde = { version = "1.0", default_features = false, features = ["derive"] }
 tonic = { version = "0.5.2", features = ["transport"] }
-tokio = { version = "1.10", default_features = false, features = ["rt-multi-thread"] }
+tokio = { version = "1.11", default_features = false, features = ["rt-multi-thread"] }
 thiserror = "1.0"
 jsonrpc = "0.11.0"
 reqwest = { version = "0.11", features = [ "json"] }

--- a/applications/tari_stratum_transcoder/Cargo.toml
+++ b/applications/tari_stratum_transcoder/Cargo.toml
@@ -35,7 +35,7 @@ serde = { version = "1.0.106", features = ["derive"] }
 serde_json = "1.0.57"
 structopt = { version = "0.3.13", default_features = false }
 thiserror = "1.0.26"
-tokio = { version = "^1.10", features = ["macros"] }
+tokio = { version = "1.11", features = ["macros"] }
 tonic = "0.5.2"
 tracing = "0.1"
 tracing-futures = "0.2"

--- a/base_layer/common_types/Cargo.toml
+++ b/base_layer/common_types/Cargo.toml
@@ -7,10 +7,10 @@ version = "0.9.6"
 edition = "2018"
 
 [dependencies]
-futures = {version = "^0.3.1", features = ["async-await"] }
+futures = { version = "^0.3.1", features = ["async-await"] }
 rand = "0.8"
 tari_crypto = "0.11.1"
 serde = { version = "1.0.106", features = ["derive"] }
-tokio = { version="^1.10", features = [ "time", "sync"] }
+tokio = { version = "1.11", features = ["time", "sync"] }
 lazy_static = "1.4.0"
 digest = "0.9.0"

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -18,15 +18,15 @@ base_node_proto = []
 avx2 = ["tari_crypto/avx2"]
 
 [dependencies]
-tari_common = { version = "^0.9", path = "../../common"}
-tari_common_types = { version = "^0.9", path = "../../base_layer/common_types"}
-tari_comms = { version = "^0.9", path = "../../comms"}
-tari_comms_dht = { version = "^0.9", path = "../../comms/dht"}
-tari_comms_rpc_macros = { version = "^0.9", path = "../../comms/rpc_macros"}
+tari_common = { version = "^0.9", path = "../../common" }
+tari_common_types = { version = "^0.9", path = "../../base_layer/common_types" }
+tari_comms = { version = "^0.9", path = "../../comms" }
+tari_comms_dht = { version = "^0.9", path = "../../comms/dht" }
+tari_comms_rpc_macros = { version = "^0.9", path = "../../comms/rpc_macros" }
 tari_crypto = "0.11.1"
 tari_mmr = { version = "^0.9", path = "../../base_layer/mmr", optional = true }
 tari_p2p = { version = "^0.9", path = "../../base_layer/p2p" }
-tari_service_framework = { version = "^0.9", path = "../service_framework"}
+tari_service_framework = { version = "^0.9", path = "../service_framework" }
 tari_shutdown = { version = "^0.9", path = "../../infrastructure/shutdown" }
 tari_storage = { version = "^0.9", path = "../../infrastructure/storage" }
 tari_test_utils = { version = "^0.9", path = "../../infrastructure/test_utils" }
@@ -36,16 +36,16 @@ bitflags = "1.0.4"
 blake2 = "^0.9.0"
 sha3 = "0.9"
 bytes = "0.5"
-chrono = { version = "0.4.6", features = ["serde"]}
+chrono = { version = "0.4.6", features = ["serde"] }
 croaring = { version = "=0.4.5", optional = true }
 digest = "0.9.0"
-futures = {version = "^0.3.16", features = ["async-await"] }
+futures = { version = "^0.3.16", features = ["async-await"] }
 fs2 = "0.3.0"
 hex = "0.4.2"
 lazy_static = "1.4.0"
 lmdb-zero = "0.4.4"
 log = "0.4"
-monero = { version = "^0.13.0", features= ["serde_support"], optional = true }
+monero = { version = "^0.13.0", features = ["serde_support"], optional = true }
 newtype-ops = "0.1.4"
 num = "0.3"
 prost = "0.8.0"
@@ -56,16 +56,16 @@ serde = { version = "1.0.106", features = ["derive"] }
 serde_json = "1.0"
 strum_macros = "0.17.1"
 thiserror = "1.0.26"
-tokio = { version="^1.10", features = [ "time", "sync", "macros"] }
+tokio = { version = "1.11", features = ["time", "sync", "macros"] }
 ttl_cache = "0.5.1"
 uint = { version = "0.9", default-features = false }
 num-format = "0.4.0"
 tracing = "0.1.26"
-tracing-futures="*"
-tracing-attributes="*"
+tracing-futures = "*"
+tracing-attributes = "*"
 
 [dev-dependencies]
-tari_p2p = { version = "^0.9", path = "../../base_layer/p2p", features=["test-mocks"]}
+tari_p2p = { version = "^0.9", path = "../../base_layer/p2p", features = ["test-mocks"] }
 tari_test_utils = { version = "^0.9", path = "../../infrastructure/test_utils" }
 
 config = { version = "0.9.3" }
@@ -73,4 +73,4 @@ env_logger = "0.7.0"
 tempfile = "3.1.0"
 
 [build-dependencies]
-tari_common = { version = "^0.9", path="../../common", features = ["build"]}
+tari_common = { version = "^0.9", path = "../../common", features = ["build"] }

--- a/base_layer/p2p/Cargo.toml
+++ b/base_layer/p2p/Cargo.toml
@@ -34,7 +34,7 @@ semver = "1.0.1"
 serde = "1.0.90"
 serde_derive = "1.0.90"
 thiserror = "1.0.26"
-tokio = { version = "1.10", features = ["macros"] }
+tokio = { version = "1.11", features = ["macros"] }
 tokio-stream = { version = "0.1.7", default-features = false, features = ["time"] }
 tower = "0.3.0-alpha.2"
 tower-service = { version = "0.3.0-alpha.2" }

--- a/base_layer/service_framework/Cargo.toml
+++ b/base_layer/service_framework/Cargo.toml
@@ -10,19 +10,19 @@ license = "BSD-3-Clause"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tari_shutdown = { version = "^0.9", path="../../infrastructure/shutdown" }
+tari_shutdown = { version = "^0.9", path = "../../infrastructure/shutdown" }
 
 anyhow = "1.0.32"
 async-trait = "0.1.50"
-futures = { version = "^0.3.16", features=["async-await"]}
+futures = { version = "^0.3.16", features = ["async-await"] }
 log = "0.4.8"
 thiserror = "1.0.26"
-tokio = {version="1.10", features=["rt"]}
-tower-service = { version="0.3.0" }
+tokio = { version = "1.11", features = ["rt"] }
+tower-service = { version = "0.3.0" }
 
 [dev-dependencies]
-tari_test_utils = { version = "^0.9", path="../../infrastructure/test_utils" }
+tari_test_utils = { version = "^0.9", path = "../../infrastructure/test_utils" }
 
-tokio = {version="1.10", features=["rt-multi-thread", "macros", "time"]}
+tokio = { version = "1.11", features = ["rt-multi-thread", "macros", "time"] }
 futures-test = { version = "0.3.3" }
 tower = "0.3.1"

--- a/base_layer/wallet/Cargo.toml
+++ b/base_layer/wallet/Cargo.toml
@@ -34,7 +34,7 @@ lmdb-zero = "0.4.4"
 rand = "0.8"
 serde = { version = "1.0.89", features = ["derive"] }
 serde_json = "1.0.39"
-tokio = { version = "1.10", features = ["sync", "macros"] }
+tokio = { version = "1.11", features = ["sync", "macros"] }
 tower = "0.3.0-alpha.2"
 tempfile = "3.1.0"
 time = { version = "0.1.39" }

--- a/base_layer/wallet_ffi/Cargo.toml
+++ b/base_layer/wallet_ffi/Cargo.toml
@@ -17,14 +17,14 @@ tari_wallet = { version = "^0.9", path = "../wallet", features = ["c_integration
 tari_shutdown = { version = "^0.9", path = "../../infrastructure/shutdown" }
 tari_utilities = "^0.3"
 
-futures =  { version = "^0.3.1", features =["compat", "std"]}
-tokio = "1.10.1"
-libc = "0.2.65"
-rand = "0.8"
 chrono = { version = "0.4.6", features = ["serde"]}
-thiserror = "1.0.26"
+futures =  { version = "^0.3.1", features =["compat", "std"]}
+libc = "0.2.65"
 log = "0.4.6"
 log4rs = {version = "1.0.0", features = ["console_appender", "file_appender", "yaml_format"]}
+rand = "0.8"
+thiserror = "1.0.26"
+tokio = "1.11"
 
 [dependencies.tari_core]
 path = "../../base_layer/core"

--- a/comms/Cargo.toml
+++ b/comms/Cargo.toml
@@ -38,7 +38,7 @@ serde = "1.0.119"
 serde_derive = "1.0.119"
 snow = { version = "=0.8.0", features = ["default-resolver"] }
 thiserror = "1.0.26"
-tokio = { version = "1.10", features = ["rt-multi-thread", "time", "sync", "signal", "net", "macros", "io-util"] }
+tokio = { version = "1.11", features = ["rt-multi-thread", "time", "sync", "signal", "net", "macros", "io-util"] }
 tokio-stream = { version = "0.1.7", features = ["sync"] }
 tokio-util = { version = "0.6.7", features = ["codec", "compat"] }
 tower = "0.3.1"
@@ -47,8 +47,8 @@ tracing-futures = "0.2.5"
 yamux = "=0.9.0"
 
 # network tracing, rt-tokio for async batch export
-opentelemetry = { version = "0.16", default-features = false, features = ["trace","rt-tokio"] }
-opentelemetry-jaeger = { version="0.15", features=["rt-tokio"]}
+opentelemetry = { version = "0.16", default-features = false, features = ["trace", "rt-tokio"] }
+opentelemetry-jaeger = { version = "0.15", features = ["rt-tokio"] }
 
 # RPC dependencies
 tower-make = { version = "0.3.0", optional = true }
@@ -59,7 +59,6 @@ tari_comms_rpc_macros = { version = "*", path = "./rpc_macros" }
 
 env_logger = "0.7.0"
 serde_json = "1.0.39"
-#tokio = {version="1.8", features=["macros"]}
 tempfile = "3.1.0"
 
 [build-dependencies]

--- a/comms/dht/Cargo.toml
+++ b/comms/dht/Cargo.toml
@@ -35,7 +35,7 @@ serde = "1.0.90"
 serde_derive = "1.0.90"
 serde_repr = "0.1.5"
 thiserror = "1.0.26"
-tokio = { version = "1.10", features = ["rt", "macros"] }
+tokio = { version = "1.11", features = ["rt", "macros"] }
 tower = "0.3.1"
 ttl_cache = "0.5.1"
 

--- a/comms/rpc_macros/Cargo.toml
+++ b/comms/rpc_macros/Cargo.toml
@@ -13,16 +13,16 @@ edition = "2018"
 proc-macro = true
 
 [dependencies]
-tari_comms = { version = "^0.9", path = "../", features = ["rpc"]}
+tari_comms = { version = "^0.9", path = "../", features = ["rpc"] }
 
 proc-macro2 = "1.0.24"
 quote = "1.0.7"
-syn = {version = "1.0.38", features = ["fold"]}
+syn = { version = "1.0.38", features = ["fold"] }
 
 [dev-dependencies]
-tari_test_utils = {version="^0.9", path="../../infrastructure/test_utils"}
+tari_test_utils = { version = "^0.9", path = "../../infrastructure/test_utils" }
 
 futures = "0.3.5"
 prost = "0.8.0"
-tokio = {version = "1", features = ["macros"]}
+tokio = { version = "1", features = ["macros"] }
 tower-service = "0.3.0"

--- a/infrastructure/shutdown/Cargo.toml
+++ b/infrastructure/shutdown/Cargo.toml
@@ -15,4 +15,4 @@ edition = "2018"
 futures = "^0.3"
 
 [dev-dependencies]
-tokio = {version="1", default-features = false, features = ["rt", "macros"]}
+tokio = { version = "1", default-features = false, features = ["rt", "macros"] }

--- a/infrastructure/test_utils/Cargo.toml
+++ b/infrastructure/test_utils/Cargo.toml
@@ -9,11 +9,11 @@ license = "BSD-3-Clause"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tari_shutdown = {version="*", path="../shutdown"}
+tari_shutdown = { version = "*", path = "../shutdown" }
 
 futures-test = { version = "^0.3.1" }
-futures = {version= "^0.3.1"}
+futures = { version = "^0.3.1" }
 rand = "0.8"
-tokio = {version= "1.10", features=["rt-multi-thread", "time"]}
+tokio = { version = "1.11", features = ["rt-multi-thread", "time"] }
 lazy_static = "1.3.0"
 tempfile = "3.1.0"


### PR DESCRIPTION
Description
---
https://github.com/tokio-rs/tokio/releases/tag/tokio-1.11.0
Formatted Cargo manifest files and made tokio includes consistent for easy future find and replace.

Motivation and Context
---
Keeping tokio up to date

How Has This Been Tested?
---
Existing tests pass
