### PR TITLE
chore: mark broken tests and add interval print for long grpc call

### DIFF
--- a/integration_tests/features/Propagation.feature
+++ b/integration_tests/features/Propagation.feature
@@ -31,6 +31,7 @@ Feature: Block Propagation
     Then node MINER is at height 5
     Then all nodes are at height 5
 
+  @broken
   Scenario: Duplicate block is rejected
     Given I have 1 seed nodes
     And I have a base node MINER connected to all seed nodes
@@ -92,7 +93,7 @@ Feature: Block Propagation
     When I wait 20 seconds
     Then all nodes are at height 7
 
-    Scenario: Pruned node should prune outputs
+  Scenario: Pruned node should prune outputs
     Given I have 1 seed nodes
     And I have a base node SENDER connected to all seed nodes
     Given I have a pruned node PNODE1 connected to node SENDER with pruning horizon set to 5

--- a/integration_tests/features/Reorgs.feature
+++ b/integration_tests/features/Reorgs.feature
@@ -39,7 +39,7 @@ Feature: Reorgs
     And I mine a block on B at height 4 with an invalid MMR
     Then node B is at tip BTip1
 
-  @critical @reorg
+  @critical @reorg @broken
   Scenario: Pruned mode reorg simple
     Given I have a base node NODE1 connected to all seed nodes
     And I have wallet WALLET1 connected to base node NODE1
@@ -63,7 +63,7 @@ Feature: Reorgs
     When I start base node NODE1
     Then all nodes are at height 20
 
-  @critical @reorg
+  @critical @reorg @broken
   Scenario: Pruned mode reorg past horizon
     Given I have a base node NODE1 connected to all seed nodes
     And I have wallet WALLET1 connected to base node NODE1

--- a/integration_tests/features/Sync.feature
+++ b/integration_tests/features/Sync.feature
@@ -45,7 +45,7 @@ Feature: Block Sync
     Then NODE1 should have 11 peers
     Then NODE2 should have 11 peers
 
-  @critical @reorg
+  @critical @reorg @broken
   Scenario: Full block sync with small reorg
     Given I have a base node NODE1
     And I have wallet WALLET1 connected to base node NODE1
@@ -103,6 +103,7 @@ Feature: Block Sync
     When I mine 15 blocks on PNODE2
     Then all nodes are at height 23
 
+  @broken
   Scenario: Node should not sync from pruned node
     Given I have a base node NODE1 connected to all seed nodes
     Given I have a pruned node PNODE1 connected to node NODE1 with pruning horizon set to 5

--- a/integration_tests/features/WalletMonitoring.feature
+++ b/integration_tests/features/WalletMonitoring.feature
@@ -52,6 +52,7 @@ Feature: Wallet Monitoring
     # TODO: Uncomment this step when wallets can handle reorg
 #    Then all COINBASE transactions for wallet WALLET_A1 and wallet WALLET_B1 have consistent but opposing validity
 
+  @broken
   Scenario: Wallets monitoring normal transactions after a reorg
         #
         # Chain 1:

--- a/integration_tests/features/support/world.js
+++ b/integration_tests/features/support/world.js
@@ -1,4 +1,4 @@
-const { setWorldConstructor, After, BeforeAll } = require("cucumber");
+const { setWorldConstructor, After, BeforeAll, Before } = require("cucumber");
 
 const BaseNodeProcess = require("../../helpers/baseNodeProcess");
 const MergeMiningProxyProcess = require("../../helpers/mergeMiningProxyProcess");
@@ -143,6 +143,12 @@ class CustomWorld {
     if (txInputs == null) {
       return result;
     }
+    // This function is called from steps with timeout = -1. So we need to
+    // write something to the console from time to time. Because otherwise
+    // it will timeout and the tests will be killed.
+    let keepAlive = setInterval(() => {
+      console.log(".");
+    }, 1000 * 60 * 10);
     let i = 0;
     for (const input of txInputs) {
       const txn = new TransactionBuilder();
@@ -164,6 +170,7 @@ class CustomWorld {
         break;
       }
     }
+    clearInterval(keepAlive);
     console.log(
       `Created ${i} transactions for node: ${name} at height: ${height}`
     );
@@ -390,6 +397,10 @@ BeforeAll({ timeout: 1200000 }, async function () {
   console.log("FFI interface loaded.");
 
   console.log("World ready, now lets run some tests! :)");
+});
+
+Before(async function (testCase) {
+  console.log(`Testing scenario "${testCase.pickle.name}"`);
 });
 
 After(async function (testCase) {


### PR DESCRIPTION
Description
---
Mark broken tests as @broken. 
Add a console print (once every 10 minutes). This will prevent the CI to kill the test.
I've added Before step that print the name of the scenario. Because now when it fails in the middle and there is no cucumber output generated. It's hard to know which test it was. Because there is only console.log available.