### PR TITLE
revert: fix ban header syn peer if no headers provided (#3297)

### DIFF
--- a/base_layer/core/src/base_node/sync/header_sync/error.rs
+++ b/base_layer/core/src/base_node/sync/header_sync/error.rs
@@ -63,6 +63,4 @@ pub enum BlockHeaderSyncError {
     InvalidProtocolResponse(String),
     #[error("Headers did not form a chain. Expected {actual} to equal the previous hash {expected}")]
     ChainLinkBroken { actual: String, expected: String },
-    #[error("Invalid remote peer behaviour: {0}")]
-    InvalidRemotePeerBehaviour(String),
 }

--- a/base_layer/core/src/base_node/sync/header_sync/synchronizer.rs
+++ b/base_layer/core/src/base_node/sync/header_sync/synchronizer.rs
@@ -127,11 +127,6 @@ impl<'a, B: BlockchainBackend + 'static> HeaderSynchronizer<'a, B> {
                     warn!(target: LOG_TARGET, "Chain split not found for peer {}.", peer);
                     self.ban_peer_long(peer, BanReason::ChainSplitNotFound).await?;
                 },
-                Err(err @ BlockHeaderSyncError::InvalidRemotePeerBehaviour(_)) => {
-                    warn!(target: LOG_TARGET, "{}", err);
-                    self.ban_peer_long(node_id, BanReason::PeerMisbehaviour(err.to_string()))
-                        .await?;
-                },
                 Err(err @ BlockHeaderSyncError::InvalidBlockHeight { .. }) => {
                     warn!(target: LOG_TARGET, "{}", err);
                     self.ban_peer_long(node_id, BanReason::GeneralHeaderSyncFailure(err))
@@ -386,13 +381,6 @@ impl<'a, B: BlockchainBackend + 'static> HeaderSynchronizer<'a, B> {
             headers.len(),
             peer
         );
-
-        if headers.is_empty() {
-            return Err(BlockHeaderSyncError::InvalidRemotePeerBehaviour(format!(
-                "Remote peer {} advertised a better chain but did not return headers",
-                peer
-            )));
-        }
 
         if fork_hash_index >= block_hashes.len() as u32 {
             let _ = self
@@ -689,8 +677,6 @@ enum BanReason {
     GeneralHeaderSyncFailure(BlockHeaderSyncError),
     #[error("Peer did not respond timeously during RPC negotiation")]
     RpcNegotiationTimedOut,
-    #[error("Peer misbehaviour: {0}")]
-    PeerMisbehaviour(String),
 }
 
 struct ChainSplitInfo {


### PR DESCRIPTION

Description
---
This reverts commit 570e2223b9443fd681f1c8395405e8aae8180d94.

Motivation and Context
---
https://github.com/tari-project/tari/pull/3297#issuecomment-913602494

Having thought about it a bit - header sync is designed to be self contained. It does not have the information required to ban a peer that "lied" in listening mode. 

Suggest that we pass through the chain metadata and peer that 'kicked' the base node into sync into header sync so 
that the peer can be banned if it fails to follow through. We should also not prevent mining when in header sync until a
split and better chain have been comfirmed by header sync.

How Has This Been Tested?
---
Existing tests pass
