### PR TITLE
chore: fix some broken cucumber tests

### DIFF
--- a/integration_tests/features/Sync.feature
+++ b/integration_tests/features/Sync.feature
@@ -103,7 +103,6 @@ Feature: Block Sync
     When I mine 15 blocks on PNODE2
     Then all nodes are at height 23
 
-  @broken
   Scenario: Node should not sync from pruned node
     Given I have a base node NODE1 connected to all seed nodes
     Given I have a pruned node PNODE1 connected to node NODE1 with pruning horizon set to 5
@@ -112,6 +111,7 @@ Feature: Block Sync
     When I stop node NODE1
     Given I have a base node NODE2 connected to node PNODE1
     Given I have a pruned node PNODE2 connected to node PNODE1 with pruning horizon set to 5
+    Given I do not expect all automated transactions to succeed
     When I mine 5 blocks on NODE2
     Then node NODE2 is at height 5
     Then node PNODE2 is at height 40
@@ -120,6 +120,7 @@ Feature: Block Sync
     And I connect node NODE2 to node NODE1 and wait 5 seconds
     # NODE2 may initially try to sync from PNODE1 and PNODE2, then eventually try to sync from NODE1; mining blocks
     # on NODE1 will make this test less flaky and force NODE2 to sync from NODE1 much quicker
+    Given I expect all automated transactions to succeed
     When I mine 10 blocks on NODE1
     Then all nodes are at height 50
 

--- a/integration_tests/features/WalletMonitoring.feature
+++ b/integration_tests/features/WalletMonitoring.feature
@@ -52,7 +52,6 @@ Feature: Wallet Monitoring
     # TODO: Uncomment this step when wallets can handle reorg
 #    Then all COINBASE transactions for wallet WALLET_A1 and wallet WALLET_B1 have consistent but opposing validity
 
-  @broken
   Scenario: Wallets monitoring normal transactions after a reorg
         #
         # Chain 1:
@@ -60,6 +59,7 @@ Feature: Wallet Monitoring
         #
     Given I have a seed node SEED_A
         # Add multiple base nodes to ensure more robust comms
+    Given I do not expect all automated transactions to succeed
     And I have a base node NODE_A1 connected to seed SEED_A
     And I have wallet WALLET_A1 connected to seed node SEED_A
     And I have wallet WALLET_A2 connected to seed node SEED_A

--- a/integration_tests/features/support/steps.js
+++ b/integration_tests/features/support/steps.js
@@ -1432,7 +1432,7 @@ When(
       null,
       (block) => {
         this.addTransactionOutput(
-          tipHeight + 2,
+          tipHeight + 1 + 2,
           block.originalTemplate.coinbase
         );
         this.saveBlock(blockName, block);


### PR DESCRIPTION
Description
---
This fixes some of the broken cucumber tests by adding in a disable and re-enable of the auto transactions

Motivation and Context
---

The cucumber test should all be fixed and running

How Has This Been Tested?
---
Run the broken tests and ensured that they passed. 
