### PR TITLE
chore: fix 3 cucumber tests

### DIFF
--- a/integration_tests/features/Propagation.feature
+++ b/integration_tests/features/Propagation.feature
@@ -31,7 +31,6 @@ Feature: Block Propagation
     Then node MINER is at height 5
     Then all nodes are at height 5
 
-  @broken
   Scenario: Duplicate block is rejected
     Given I have 1 seed nodes
     And I have a base node MINER connected to all seed nodes
@@ -39,9 +38,10 @@ Feature: Block Propagation
     When I submit block BLOCKA to MINER
     Then all nodes are at height 1
     When I submit block BLOCKA to MINER
+    # TODO: this step is not implemented.
     Then I receive an error containing 'Block exists'
     And all nodes are at height 1
-        # Check that the base node continues to accept blocks
+    # Check that the base node continues to accept blocks
     When I mine 1 blocks on MINER
     Then all nodes are at height 2
 
@@ -53,7 +53,7 @@ Feature: Block Propagation
     When I submit block BLOCKA to MINER
     Then I receive an error containing 'Orphan block'
     Then all nodes are at height 1
-        # Do it twice to be sure
+    # Do it twice to be sure
     When I submit block BLOCKA to MINER
     Then I receive an error containing 'Orphan block'
     And all nodes are at height 1
@@ -64,7 +64,7 @@ Feature: Block Propagation
     Given I have a SHA3 miner MINER connected to all seed nodes
     And I have a lagging delayed node LAG1 connected to node MINER with blocks_behind_before_considered_lagging 10000
     Given I have a lagging delayed node LAG2 connected to node MINER with blocks_behind_before_considered_lagging 10000
-        # Wait for node to so start and get into listening mode
+    # Wait for node to so start and get into listening mode
     When I wait 100 seconds
     When mining node MINER mines 5 blocks
     Then all nodes are at height 5
@@ -83,10 +83,10 @@ Feature: Block Propagation
     And mining node MINER mines 5 blocks
     When I wait 100 seconds
     When I start base node LAG1
-        # Wait for node to so start and get into listening mode
+    # Wait for node to so start and get into listening mode
     When I wait 100 seconds
     Then node MINER is at height 6
-        #node was shutdown, so it never received the propagation messages
+    #node was shutdown, so it never received the propagation messages
     Then node LAG1 is at height 1
     Given mining node MINER mines 1 blocks
     Then node MINER is at height 7

--- a/integration_tests/features/Sync.feature
+++ b/integration_tests/features/Sync.feature
@@ -103,15 +103,15 @@ Feature: Block Sync
     When I mine 15 blocks on PNODE2
     Then all nodes are at height 23
 
-  @broken
   Scenario: Node should not sync from pruned node
     Given I have a base node NODE1 connected to all seed nodes
-    Given I have a pruned node PNODE1 connected to node NODE1 with pruning horizon set to 5
+    And I have a pruned node PNODE1 connected to node NODE1 with pruning horizon set to 5
     When I mine 40 blocks on NODE1
     Then all nodes are at height 40
     When I stop node NODE1
     Given I have a base node NODE2 connected to node PNODE1
     Given I have a pruned node PNODE2 connected to node PNODE1 with pruning horizon set to 5
+    Given I do not expect all automated transactions to succeed
     When I mine 5 blocks on NODE2
     Then node NODE2 is at height 5
     Then node PNODE2 is at height 40
@@ -120,6 +120,7 @@ Feature: Block Sync
     And I connect node NODE2 to node NODE1 and wait 5 seconds
     # NODE2 may initially try to sync from PNODE1 and PNODE2, then eventually try to sync from NODE1; mining blocks
     # on NODE1 will make this test less flaky and force NODE2 to sync from NODE1 much quicker
+    Given I expect all automated transactions to succeed
     When I mine 10 blocks on NODE1
     Then all nodes are at height 50
 

--- a/integration_tests/features/WalletMonitoring.feature
+++ b/integration_tests/features/WalletMonitoring.feature
@@ -52,13 +52,13 @@ Feature: Wallet Monitoring
     # TODO: Uncomment this step when wallets can handle reorg
 #    Then all COINBASE transactions for wallet WALLET_A1 and wallet WALLET_B1 have consistent but opposing validity
 
-  @broken
   Scenario: Wallets monitoring normal transactions after a reorg
+    Given I do not expect all automated transactions to succeed
         #
         # Chain 1:
         #   Collects 10 coinbases into one wallet, send 7 transactions
         #
-    Given I have a seed node SEED_A
+    And I have a seed node SEED_A
         # Add multiple base nodes to ensure more robust comms
     And I have a base node NODE_A1 connected to seed SEED_A
     And I have wallet WALLET_A1 connected to seed node SEED_A

--- a/integration_tests/features/support/steps.js
+++ b/integration_tests/features/support/steps.js
@@ -1432,7 +1432,7 @@ When(
       null,
       (block) => {
         this.addTransactionOutput(
-          tipHeight + 2,
+          tipHeight + 1 + 2,
           block.originalTemplate.coinbase
         );
         this.saveBlock(blockName, block);

--- a/integration_tests/features/support/world.js
+++ b/integration_tests/features/support/world.js
@@ -160,6 +160,10 @@ class CustomWorld {
         completedTx
       );
       if (this.checkAutoTransactions && submitResult.result != "ACCEPTED") {
+        console.log(
+          "Automated transaction failed. If this is not intended add step :",
+          "`I do not expect all automated transactions to succeed` !"
+        );
         result = false;
       }
       if (submitResult.result == "ACCEPTED") {


### PR DESCRIPTION
Description
---
The test were failing, because the automated TXs were required, which should not be the case.

How Has This Been Tested?
---
npm test -- --name "Duplicate block is rejected"
npm test -- --name "Node should not sync from pruned node"
npm test -- --name "Wallets monitoring normal transactions after a reorg"