### PR TITLE
fix: always grow database when asked to resize

### DIFF
--- a/base_layer/core/src/chain_storage/error.rs
+++ b/base_layer/core/src/chain_storage/error.rs
@@ -112,6 +112,8 @@ pub enum ChainStorageError {
     KeyExists { table_name: &'static str, key: String },
     #[error("Database resize required")]
     DbResizeRequired,
+    #[error("DB transaction was too large ({0} operations)")]
+    DbTransactionTooLarge(usize),
 }
 
 impl ChainStorageError {

--- a/infrastructure/storage/src/lmdb_store/store.rs
+++ b/infrastructure/storage/src/lmdb_store/store.rs
@@ -412,7 +412,7 @@ impl LMDBStore {
         );
 
         if size_left_bytes <= config.resize_threshold_bytes {
-            env.set_mapsize(env_info.mapsize + config.grow_size_bytes)?;
+            Self::resize(env, config)?;
             debug!(
                 target: LOG_TARGET,
                 "({}) LMDB size used {:?} MB, environment space left {:?} MB, increased by {:?} MB",
@@ -422,6 +422,31 @@ impl LMDBStore {
                 config.grow_size_bytes / BYTES_PER_MB,
             );
         }
+        Ok(())
+    }
+
+    /// Grows the LMDB environment by the configured amount
+    ///
+    /// # Safety
+    /// This may only be called if no write transactions are active in the current process. Note that the library does
+    /// not check for this condition, the caller must ensure it explicitly.
+    ///
+    /// http://www.lmdb.tech/doc/group__mdb.html#gaa2506ec8dab3d969b0e609cd82e619e5
+    pub unsafe fn resize(env: &Environment, config: &LMDBConfig) -> Result<(), LMDBError> {
+        let env_info = env.info()?;
+        let current_mapsize = env_info.mapsize;
+        env.set_mapsize(current_mapsize + config.grow_size_bytes)?;
+        let env_info = env.info()?;
+        let new_mapsize = env_info.mapsize;
+        debug!(
+            target: LOG_TARGET,
+            "({}) LMDB MB, mapsize was grown from {:?} MB to {:?} MB, increased by {:?} MB",
+            env.path()?.to_str()?,
+            current_mapsize / BYTES_PER_MB,
+            new_mapsize / BYTES_PER_MB,
+            config.grow_size_bytes / BYTES_PER_MB,
+        );
+
         Ok(())
     }
 }
@@ -442,8 +467,7 @@ impl LMDBDatabase {
         K: AsLmdbBytes + ?Sized,
         V: Serialize,
     {
-        const MAX_RESIZES: usize = 3;
-
+        const MAX_RESIZES: usize = 5;
         let value = LMDBWriteTransaction::convert_value(value)?;
         for _ in 0..MAX_RESIZES {
             match self.write(key, &value) {
@@ -456,7 +480,7 @@ impl LMDBDatabase {
                     // SAFETY: We know that there are no open transactions at this point because ...
                     // TODO: we don't guarantee this here but it works because the caller does this.
                     unsafe {
-                        LMDBStore::resize_if_required(&self.env, &self.env_config)?;
+                        LMDBStore::resize(&self.env, &self.env_config)?;
                     }
                 },
                 Err(e) => return Err(e.into()),


### PR DESCRIPTION

Description
---
When a resize is detected as needed, we no longer need to do threshold
checking. Simply grow the database by the configured amount.

Increase the number of MAX_RESIZES in a transaction to accomodate very
large transactions (interestingly, needed during rewind-blockchain for >
1000 blocks, depending on configured resize growth).

- Fix incorrect error log in lmdb helper functions.
- Check for MAP_FULL in lmdb_replace

Motivation and Context
---
Bug fixes

How Has This Been Tested?
---
using rewind-blockchain on base node
