### PR TITLE
chore: update headers requests to use vec::with_capacity

### DIFF
--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -129,7 +129,7 @@ where T: BlockchainBackend + 'static
                 self.blockchain_db.get_chain_metadata().await?,
             )),
             NodeCommsRequest::FetchHeaders(block_nums) => {
-                let mut block_headers = Vec::<BlockHeader>::new();
+                let mut block_headers = Vec::<BlockHeader>::with_capacity(block_nums.len());
                 for block_num in block_nums {
                     match self.blockchain_db.fetch_header(block_num).await {
                         Ok(Some(block_header)) => {
@@ -145,7 +145,7 @@ where T: BlockchainBackend + 'static
                 Ok(NodeCommsResponse::BlockHeaders(block_headers))
             },
             NodeCommsRequest::FetchHeadersWithHashes(block_hashes) => {
-                let mut block_headers = Vec::<BlockHeader>::new();
+                let mut block_headers = Vec::<BlockHeader>::with_capacity(block_hashes.len());
                 for block_hash in block_hashes {
                     let block_hex = block_hash.to_hex();
                     match self.blockchain_db.fetch_header_by_block_hash(block_hash).await? {
@@ -196,7 +196,7 @@ where T: BlockchainBackend + 'static
                         .await?
                         .ok_or(CommsInterfaceError::BlockHeaderNotFound(0))?,
                 };
-                let mut headers = vec![];
+                let mut headers = Vec::with_capacity(MAX_HEADERS_PER_RESPONSE as usize);
                 for i in 1..MAX_HEADERS_PER_RESPONSE {
                     match self.blockchain_db.fetch_header(starting_block.height + i as u64).await {
                         Ok(header) => {


### PR DESCRIPTION
Description
All the current comms requests for headers just a `Vec::new()` rather then a `Vec::with_capacity()`

Motivation and Context
We know the size of the result or can make a calculated guess about the size of the result so we can avoid resizing the vector the whole time by just using with_capacity. 

How Has This Been Tested?
Run all unit tests. 

