### PR TITLE
fix: wait couple rounds for no pings to send an event

### DIFF
--- a/base_layer/core/src/base_node/chain_metadata_service/handle.rs
+++ b/base_layer/core/src/base_node/chain_metadata_service/handle.rs
@@ -53,6 +53,7 @@ impl Display for PeerChainMetadata {
 #[derive(Debug)]
 pub enum ChainMetadataEvent {
     PeerChainMetadataReceived(Vec<PeerChainMetadata>),
+    NetworkSilence,
 }
 
 #[derive(Clone)]

--- a/base_layer/core/src/base_node/state_machine_service/states/listening.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/listening.rs
@@ -120,6 +120,14 @@ impl Listening {
         loop {
             let metadata_event = shared.metadata_event_stream.recv().await;
             match metadata_event.as_ref().map(|v| v.deref()) {
+                Ok(ChainMetadataEvent::NetworkSilence) => {
+                    debug!("NetworkSilence event received");
+                    if !self.is_synced {
+                        self.is_synced = true;
+                        shared.set_state_info(StateInfo::Listening(ListeningInfo::new(true)));
+                        debug!(target: LOG_TARGET, "Initial sync achieved");
+                    }
+                },
                 Ok(ChainMetadataEvent::PeerChainMetadataReceived(peer_metadata_list)) => {
                     let mut peer_metadata_list = peer_metadata_list.clone();
 

--- a/integration_tests/features/Reorgs.feature
+++ b/integration_tests/features/Reorgs.feature
@@ -39,7 +39,7 @@ Feature: Reorgs
     And I mine a block on B at height 4 with an invalid MMR
     Then node B is at tip BTip1
 
-  @critical @reorg @broken
+  @critical @reorg
   Scenario: Pruned mode reorg simple
     Given I have a base node NODE1 connected to all seed nodes
     And I have wallet WALLET1 connected to base node NODE1
@@ -63,7 +63,7 @@ Feature: Reorgs
     When I start base node NODE1
     Then all nodes are at height 20
 
-  @critical @reorg @broken
+  @critical @reorg
   Scenario: Pruned mode reorg past horizon
     Given I have a base node NODE1 connected to all seed nodes
     And I have wallet WALLET1 connected to base node NODE1

--- a/integration_tests/features/Sync.feature
+++ b/integration_tests/features/Sync.feature
@@ -45,7 +45,7 @@ Feature: Block Sync
     Then NODE1 should have 11 peers
     Then NODE2 should have 11 peers
 
-  @critical @reorg @broken
+  @critical @reorg
   Scenario: Full block sync with small reorg
     Given I have a base node NODE1
     And I have wallet WALLET1 connected to base node NODE1


### PR DESCRIPTION
Description
---
Wait couple rounds of `no ping` before sending the event.

How Has This Been Tested?
---
npm test -- --name "Full block sync with small reorg"
npm test -- --name "Pruned mode reorg simple"
npm test -- --name "Pruned mode reorg past horizon"