### PR TITLE
fix: handle stream read error case by explicitly closing the substream

### DIFF
--- a/applications/tari_base_node/src/command_handler.rs
+++ b/applications/tari_base_node/src/command_handler.rs
@@ -123,10 +123,8 @@ impl CommandHandler {
 
         self.executor.spawn(async move {
             let mut status_line = StatusLine::new();
-            let version = format!("v{}", consts::APP_VERSION_NUMBER);
-            status_line.add_field("", version);
-            let network = format!("{}", config.network);
-            status_line.add_field("", network);
+            status_line.add_field("", format!("v{}", consts::APP_VERSION_NUMBER));
+            status_line.add_field("", config.network);
             status_line.add_field("State", state_info.borrow().state_info.short_desc());
 
             let metadata = node.get_metadata().await.unwrap();

--- a/base_layer/wallet/src/connectivity_service/test.rs
+++ b/base_layer/wallet/src/connectivity_service/test.rs
@@ -35,7 +35,6 @@ use tari_comms::{
         mocks::{create_connectivity_mock, ConnectivityManagerMockState},
         node_identity::build_node_identity,
     },
-    Substream,
 };
 use tari_shutdown::Shutdown;
 use tari_test_utils::runtime::spawn_until_shutdown;
@@ -46,7 +45,7 @@ use tokio::{
 
 async fn setup() -> (
     WalletConnectivityHandle,
-    MockRpcServer<MockRpcImpl, Substream>,
+    MockRpcServer<MockRpcImpl>,
     ConnectivityManagerMockState,
     Shutdown,
 ) {

--- a/base_layer/wallet/tests/output_manager_service/service.rs
+++ b/base_layer/wallet/tests/output_manager_service/service.rs
@@ -36,7 +36,6 @@ use tari_comms::{
         node_identity::build_node_identity,
     },
     types::CommsSecretKey,
-    Substream,
 };
 use tari_core::{
     base_node::rpc::BaseNodeWalletRpcServer,
@@ -97,7 +96,7 @@ async fn setup_output_manager_service<T: OutputManagerBackend + 'static>(
     OutputManagerHandle,
     Shutdown,
     TransactionServiceHandle,
-    MockRpcServer<BaseNodeWalletRpcServer<BaseNodeWalletRpcMockService>, Substream>,
+    MockRpcServer<BaseNodeWalletRpcServer<BaseNodeWalletRpcMockService>>,
     Arc<NodeIdentity>,
     BaseNodeWalletRpcMockState,
     ConnectivityManagerMockState,

--- a/base_layer/wallet/tests/transaction_service/service.rs
+++ b/base_layer/wallet/tests/transaction_service/service.rs
@@ -72,7 +72,6 @@ use tari_comms::{
     },
     types::CommsSecretKey,
     CommsNode,
-    Substream,
 };
 use tari_comms_dht::outbound::mock::{
     create_outbound_service_mock,
@@ -244,7 +243,7 @@ pub fn setup_transaction_service_no_comms(
     Sender<DomainMessage<base_node_proto::BaseNodeServiceResponse>>,
     Sender<DomainMessage<proto::TransactionCancelledMessage>>,
     Shutdown,
-    MockRpcServer<BaseNodeWalletRpcServer<BaseNodeWalletRpcMockService>, Substream>,
+    MockRpcServer<BaseNodeWalletRpcServer<BaseNodeWalletRpcMockService>>,
     Arc<NodeIdentity>,
     BaseNodeWalletRpcMockState,
 ) {
@@ -268,7 +267,7 @@ pub fn setup_transaction_service_no_comms_and_oms_backend(
     Sender<DomainMessage<base_node_proto::BaseNodeServiceResponse>>,
     Sender<DomainMessage<proto::TransactionCancelledMessage>>,
     Shutdown,
-    MockRpcServer<BaseNodeWalletRpcServer<BaseNodeWalletRpcMockService>, Substream>,
+    MockRpcServer<BaseNodeWalletRpcServer<BaseNodeWalletRpcMockService>>,
     Arc<NodeIdentity>,
     BaseNodeWalletRpcMockState,
 ) {

--- a/base_layer/wallet/tests/transaction_service/transaction_protocols.rs
+++ b/base_layer/wallet/tests/transaction_service/transaction_protocols.rs
@@ -32,7 +32,6 @@ use tari_comms::{
     },
     types::CommsPublicKey,
     NodeIdentity,
-    Substream,
 };
 use tari_comms_dht::outbound::mock::{create_outbound_service_mock, OutboundServiceMockState};
 use tari_core::{
@@ -96,7 +95,7 @@ pub async fn setup(
     TransactionServiceResources<TransactionServiceSqliteDatabase>,
     ConnectivityManagerMockState,
     OutboundServiceMockState,
-    MockRpcServer<BaseNodeWalletRpcServer<BaseNodeWalletRpcMockService>, Substream>,
+    MockRpcServer<BaseNodeWalletRpcServer<BaseNodeWalletRpcMockService>>,
     Arc<NodeIdentity>,
     BaseNodeWalletRpcMockState,
     broadcast::Sender<Duration>,

--- a/comms/rpc_macros/src/generator.rs
+++ b/comms/rpc_macros/src/generator.rs
@@ -194,15 +194,15 @@ impl RpcCodeGenerator {
             .collect::<TokenStream>();
 
         let client_struct_body = quote! {
-            pub async fn connect<TSubstream>(framed: #dep_mod::CanonicalFraming<TSubstream>) -> Result<Self, #dep_mod::RpcError>
-              where TSubstream: #dep_mod::AsyncRead + #dep_mod::AsyncWrite + Unpin + Send + 'static {
+            pub async fn connect(framed: #dep_mod::CanonicalFraming<#dep_mod::Substream>) -> Result<Self, #dep_mod::RpcError> {
                 use #dep_mod::NamedProtocolService;
                 let inner = #dep_mod::RpcClient::connect(Default::default(), framed, Self::PROTOCOL_NAME.into()).await?;
                 Ok(Self { inner })
             }
 
             pub fn builder() -> #dep_mod::RpcClientBuilder<Self> {
-                #dep_mod::RpcClientBuilder::new()
+                use #dep_mod::NamedProtocolService;
+                #dep_mod::RpcClientBuilder::new().with_protocol_id(Self::PROTOCOL_NAME.into())
             }
 
             #client_methods

--- a/comms/rpc_macros/src/lib.rs
+++ b/comms/rpc_macros/src/lib.rs
@@ -12,7 +12,7 @@ mod options;
 ///
 /// Generates Tari RPC "harness code" for a given trait.
 ///
-/// ```no_run
+/// ```no_run,ignore
 /// # use tari_comms_rpc_macros::tari_rpc;
 /// # use tari_comms::protocol::rpc::{Request, Streaming, Response, RpcStatus, RpcServer};
 /// use tari_comms::{framing, memsocket::MemorySocket};

--- a/comms/src/multiplexing/yamux.rs
+++ b/comms/src/multiplexing/yamux.rs
@@ -166,7 +166,7 @@ pub struct IncomingSubstreams {
 }
 
 impl IncomingSubstreams {
-    pub fn new(inner: IncomingRx, substream_counter: SubstreamCounter, shutdown: Shutdown) -> Self {
+    pub(self) fn new(inner: IncomingRx, substream_counter: SubstreamCounter, shutdown: Shutdown) -> Self {
         Self {
             inner,
             substream_counter,
@@ -203,6 +203,12 @@ impl Drop for IncomingSubstreams {
 pub struct Substream {
     stream: Compat<yamux::Stream>,
     counter_guard: CounterGuard,
+}
+
+impl Substream {
+    pub fn id(&self) -> yamux::StreamId {
+        self.stream.get_ref().id()
+    }
 }
 
 impl tokio::io::AsyncRead for Substream {
@@ -242,13 +248,17 @@ where TSocket: futures::AsyncRead + futures::AsyncWrite + Unpin + Send + 'static
         }
     }
 
-    #[tracing::instrument(name = "yamux::incoming_worker::run", skip(self))]
+    #[tracing::instrument(name = "yamux::incoming_worker::run", skip(self), fields(connection = %self.connection))]
     pub async fn run(mut self) {
         loop {
             tokio::select! {
                 biased;
 
-                _ = &mut self.shutdown_signal => {
+                _ = self.shutdown_signal.wait() => {
+                     debug!(
+                        target: LOG_TARGET,
+                        "{} Yamux connection shutdown", self.connection
+                    );
                     let mut control = self.connection.control();
                     if let Err(err) = control.close().await {
                         error!(target: LOG_TARGET, "Failed to close yamux connection: {}", err);
@@ -259,11 +269,13 @@ where TSocket: futures::AsyncRead + futures::AsyncWrite + Unpin + Send + 'static
                 result = self.connection.next_stream() => {
                      match result {
                         Ok(Some(stream)) => {
-                            event!(Level::TRACE, "yamux::stream received {}", stream);if self.sender.send(stream).await.is_err() {
+                            event!(Level::TRACE, "yamux::incoming_worker::new_stream {}", stream);
+                            if self.sender.send(stream).await.is_err() {
                                 debug!(
                                     target: LOG_TARGET,
-                                    "Incoming peer substream task is shutting down because the internal stream sender channel \
-                                     was closed"
+                                    "{} Incoming peer substream task is shutting down because the internal stream sender channel \
+                                     was closed",
+                                    self.connection
                                 );
                                 break;
                             }
@@ -271,19 +283,23 @@ where TSocket: futures::AsyncRead + futures::AsyncWrite + Unpin + Send + 'static
                         Ok(None) =>{
                             debug!(
                                 target: LOG_TARGET,
-                                "Incoming peer substream completed. IncomingWorker exiting"
+                                "{} Incoming peer substream completed. IncomingWorker exiting",
+                                self.connection
                             );
                             break;
                         }
                         Err(err) => {
                             event!(
-                        Level::ERROR,
-                        "Incoming peer substream task received an error because '{}'",
-                        err
-                    );
-                    error!(
+                                Level::ERROR,
+                                "{} Incoming peer substream task received an error because '{}'",
+                                self.connection,
+                                err
+                            );
+                            error!(
                                 target: LOG_TARGET,
-                                "Incoming peer substream task received an error because '{}'", err
+                                "{} Incoming peer substream task received an error because '{}'",
+                                self.connection,
+                                err
                             );
                             break;
                         },

--- a/comms/src/protocol/rpc/mod.rs
+++ b/comms/src/protocol/rpc/mod.rs
@@ -63,6 +63,7 @@ pub const RPC_MAX_FRAME_SIZE: usize = 4 * 1024 * 1024; // 4 MiB
 pub mod __macro_reexports {
     pub use crate::{
         framing::CanonicalFraming,
+        multiplexing::Substream,
         protocol::{
             rpc::{
                 client_pool::RpcPoolClient,

--- a/comms/src/protocol/rpc/server/mock.rs
+++ b/comms/src/protocol/rpc/server/mock.rs
@@ -194,14 +194,14 @@ impl RpcCommsProvider for MockCommsProvider {
     }
 }
 
-pub struct MockRpcServer<TSvc, TSubstream> {
-    inner: Option<PeerRpcServer<TSvc, TSubstream, MockCommsProvider>>,
-    protocol_tx: ProtocolNotificationTx<TSubstream>,
+pub struct MockRpcServer<TSvc> {
+    inner: Option<PeerRpcServer<TSvc, MockCommsProvider>>,
+    protocol_tx: ProtocolNotificationTx<Substream>,
     our_node: Arc<NodeIdentity>,
     request_tx: mpsc::Sender<RpcServerRequest>,
 }
 
-impl<TSvc> MockRpcServer<TSvc, Substream>
+impl<TSvc> MockRpcServer<TSvc>
 where
     TSvc: MakeService<
             ProtocolId,
@@ -259,7 +259,7 @@ where
     }
 }
 
-impl MockRpcServer<MockRpcImpl, Substream> {
+impl MockRpcServer<MockRpcImpl> {
     pub async fn create_mockimpl_connection(&self, peer: Peer) -> PeerConnection {
         // MockRpcImpl accepts any protocol
         self.create_connection(peer, ProtocolId::new()).await

--- a/comms/src/protocol/rpc/server/router.rs
+++ b/comms/src/protocol/rpc/server/router.rs
@@ -42,6 +42,7 @@ use crate::{
     },
     runtime::task,
     Bytes,
+    Substream,
 };
 use futures::{
     future::BoxFuture,
@@ -49,10 +50,7 @@ use futures::{
     FutureExt,
 };
 use std::sync::Arc;
-use tokio::{
-    io::{AsyncRead, AsyncWrite},
-    sync::mpsc,
-};
+use tokio::sync::mpsc;
 use tower::Service;
 use tower_make::MakeService;
 
@@ -133,13 +131,12 @@ where
     <B::Service as Service<Request<Bytes>>>::Future: Send + 'static,
 {
     /// Start all services
-    pub(crate) async fn serve<TSubstream, TCommsProvider>(
+    pub(crate) async fn serve<TCommsProvider>(
         self,
-        protocol_notifications: ProtocolNotificationRx<TSubstream>,
+        protocol_notifications: ProtocolNotificationRx<Substream>,
         comms_provider: TCommsProvider,
     ) -> Result<(), RpcError>
     where
-        TSubstream: AsyncRead + AsyncWrite + Unpin + Send + 'static,
         TCommsProvider: RpcCommsProvider + Clone + Send + 'static,
     {
         self.server

--- a/comms/src/protocol/rpc/test/greeting_service.rs
+++ b/comms/src/protocol/rpc/test/greeting_service.rs
@@ -27,6 +27,7 @@ use crate::{
         ProtocolId,
     },
     utils,
+    Substream,
 };
 use core::iter;
 use std::{
@@ -393,14 +394,13 @@ impl __rpc_deps::NamedProtocolService for GreetingClient {
 }
 
 impl GreetingClient {
-    pub async fn connect<TSubstream>(framed: __rpc_deps::CanonicalFraming<TSubstream>) -> Result<Self, RpcError>
-    where TSubstream: __rpc_deps::AsyncRead + __rpc_deps::AsyncWrite + Unpin + Send + 'static {
+    pub async fn connect(framed: __rpc_deps::CanonicalFraming<Substream>) -> Result<Self, RpcError> {
         let inner = __rpc_deps::RpcClient::connect(Default::default(), framed, Self::PROTOCOL_NAME.into()).await?;
         Ok(Self { inner })
     }
 
     pub fn builder() -> __rpc_deps::RpcClientBuilder<Self> {
-        __rpc_deps::RpcClientBuilder::new()
+        __rpc_deps::RpcClientBuilder::new().with_protocol_id(Self::PROTOCOL_NAME.into())
     }
 
     pub async fn say_hello(&mut self, request: SayHelloRequest) -> Result<SayHelloResponse, RpcError> {


### PR DESCRIPTION

Description
---
- adds yamux stream id to logs to enrich rpc sesssion tracing info
- handle stream read error case by explicitly closing the substream
- updates rpc tests to use yamux

Motivation and Context
---
May allow us to diagnose where slowness in a RPC session/substream occurs 

How Has This Been Tested?
---
Tests updated

