### PR TITLE
feat: rpc response message chunking

### DIFF
--- a/applications/tari_base_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/tari_base_node/src/grpc/base_node_grpc_server.rs
@@ -1003,11 +1003,7 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
             .state_info
             .get_block_sync_info()
             .map(|info| {
-                let node_ids = info
-                    .sync_peers
-                    .iter()
-                    .map(|x| x.to_string().as_bytes().to_vec())
-                    .collect();
+                let node_ids = info.sync_peers.iter().map(|x| x.to_string().into_bytes()).collect();
                 tari_rpc::SyncInfoResponse {
                     tip_height: info.tip_height,
                     local_height: info.local_height,

--- a/applications/tari_base_node/src/main.rs
+++ b/applications/tari_base_node/src/main.rs
@@ -1,4 +1,3 @@
-#![recursion_limit = "1024"]
 // Copyright 2019. The Tari Project
 //
 // Redistribution and use in source and binary forms, with or without modification, are permitted provided that the

--- a/applications/tari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/tari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -98,9 +98,9 @@ impl wallet_server::Wallet for WalletGrpcServer {
     async fn identify(&self, _: Request<GetIdentityRequest>) -> Result<Response<GetIdentityResponse>, Status> {
         let identity = self.wallet.comms.node_identity();
         Ok(Response::new(GetIdentityResponse {
-            public_key: identity.public_key().to_string().as_bytes().to_vec(),
+            public_key: identity.public_key().to_string().into_bytes(),
             public_address: identity.public_address().to_string(),
-            node_id: identity.node_id().to_string().as_bytes().to_vec(),
+            node_id: identity.node_id().to_string().into_bytes(),
         }))
     }
 

--- a/base_layer/wallet/src/output_manager_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/sqlite_db.rs
@@ -1546,8 +1546,7 @@ struct KeyManagerStateUpdateSql {
 impl Encryptable<Aes256Gcm> for KeyManagerStateSql {
     fn encrypt(&mut self, cipher: &Aes256Gcm) -> Result<(), Error> {
         let encrypted_master_key = encrypt_bytes_integral_nonce(&cipher, self.master_key.clone())?;
-        let encrypted_branch_seed =
-            encrypt_bytes_integral_nonce(&cipher, self.branch_seed.clone().as_bytes().to_vec())?;
+        let encrypted_branch_seed = encrypt_bytes_integral_nonce(&cipher, self.branch_seed.clone().into_bytes())?;
         self.master_key = encrypted_master_key;
         self.branch_seed = encrypted_branch_seed.to_hex();
         Ok(())

--- a/base_layer/wallet/src/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/storage/sqlite_db.rs
@@ -588,7 +588,7 @@ impl ClientKeyValueSql {
 impl Encryptable<Aes256Gcm> for ClientKeyValueSql {
     #[allow(unused_assignments)]
     fn encrypt(&mut self, cipher: &Aes256Gcm) -> Result<(), AeadError> {
-        let encrypted_value = encrypt_bytes_integral_nonce(&cipher, self.clone().value.as_bytes().to_vec())?;
+        let encrypted_value = encrypt_bytes_integral_nonce(&cipher, self.value.as_bytes().to_vec())?;
         self.value = encrypted_value.to_hex();
         Ok(())
     }

--- a/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
@@ -1028,8 +1028,7 @@ impl InboundTransactionSql {
 
 impl Encryptable<Aes256Gcm> for InboundTransactionSql {
     fn encrypt(&mut self, cipher: &Aes256Gcm) -> Result<(), AeadError> {
-        let encrypted_protocol =
-            encrypt_bytes_integral_nonce(&cipher, self.receiver_protocol.clone().as_bytes().to_vec())?;
+        let encrypted_protocol = encrypt_bytes_integral_nonce(&cipher, self.receiver_protocol.as_bytes().to_vec())?;
         self.receiver_protocol = encrypted_protocol.to_hex();
         Ok(())
     }
@@ -1211,8 +1210,7 @@ impl OutboundTransactionSql {
 
 impl Encryptable<Aes256Gcm> for OutboundTransactionSql {
     fn encrypt(&mut self, cipher: &Aes256Gcm) -> Result<(), AeadError> {
-        let encrypted_protocol =
-            encrypt_bytes_integral_nonce(&cipher, self.sender_protocol.clone().as_bytes().to_vec())?;
+        let encrypted_protocol = encrypt_bytes_integral_nonce(&cipher, self.sender_protocol.as_bytes().to_vec())?;
         self.sender_protocol = encrypted_protocol.to_hex();
         Ok(())
     }
@@ -1534,8 +1532,7 @@ impl CompletedTransactionSql {
 
 impl Encryptable<Aes256Gcm> for CompletedTransactionSql {
     fn encrypt(&mut self, cipher: &Aes256Gcm) -> Result<(), AeadError> {
-        let encrypted_protocol =
-            encrypt_bytes_integral_nonce(&cipher, self.transaction_protocol.clone().as_bytes().to_vec())?;
+        let encrypted_protocol = encrypt_bytes_integral_nonce(&cipher, self.transaction_protocol.as_bytes().to_vec())?;
         self.transaction_protocol = encrypted_protocol.to_hex();
         Ok(())
     }

--- a/comms/dht/src/store_forward/saf_handler/task.rs
+++ b/comms/dht/src/store_forward/saf_handler/task.rs
@@ -599,7 +599,7 @@ mod test {
         dht_header: DhtMessageHeader,
         stored_at: NaiveDateTime,
     ) -> StoredMessage {
-        let body = message.as_bytes().to_vec();
+        let body = message.into_bytes();
         let body_hash = hex::to_hex(&Challenge::new().chain(body.clone()).finalize());
         StoredMessage {
             id: 1,

--- a/comms/src/proto/rpc.proto
+++ b/comms/src/proto/rpc.proto
@@ -16,7 +16,7 @@ message RpcRequest {
     uint64 deadline = 4;
 
     // The message payload
-    bytes message = 10;
+    bytes payload = 10;
 }
 
 // Message type for all RPC responses
@@ -29,7 +29,7 @@ message RpcResponse {
     uint32 flags = 3;
 
     // The message payload. If the status is non-zero, this contains additional error details.
-    bytes message = 10;
+    bytes payload = 10;
 }
 
 // Message sent by the client when negotiating an RPC session. A server may close the substream if it does

--- a/comms/src/protocol/rpc/body.rs
+++ b/comms/src/protocol/rpc/body.rs
@@ -177,6 +177,10 @@ impl BodyBytes {
     pub fn into_vec(self) -> Vec<u8> {
         self.0.map(|bytes| bytes.to_vec()).unwrap_or_else(Vec::new)
     }
+
+    pub fn into_bytes(self) -> Option<Bytes> {
+        self.0
+    }
 }
 
 #[allow(clippy::from_over_into)]
@@ -186,10 +190,9 @@ impl Into<Bytes> for BodyBytes {
     }
 }
 
-#[allow(clippy::from_over_into)]
-impl Into<Vec<u8>> for BodyBytes {
-    fn into(self) -> Vec<u8> {
-        self.into_vec()
+impl From<BodyBytes> for Vec<u8> {
+    fn from(body: BodyBytes) -> Self {
+        body.into_vec()
     }
 }
 

--- a/comms/src/protocol/rpc/error.rs
+++ b/comms/src/protocol/rpc/error.rs
@@ -65,6 +65,8 @@ pub enum RpcError {
     InvalidPingResponse,
     #[error("Unexpected ACK response. This is likely because of a previous ACK timeout")]
     UnexpectedAckResponse,
+    #[error("Attempted to send more than {expected} payload chunks")]
+    ExceededMaxChunkCount { expected: usize },
     #[error(transparent)]
     UnknownError(#[from] anyhow::Error),
 }

--- a/comms/src/protocol/rpc/mod.rs
+++ b/comms/src/protocol/rpc/mod.rs
@@ -26,6 +26,29 @@
 #[cfg(test)]
 mod test;
 
+/// Maximum frame size of each RPC message. This is enforced in tokio's length delimited codec.
+/// This can be thought of as the hard limit on message size.
+pub const RPC_MAX_FRAME_SIZE: usize = 2 * 1024 * 1024; // 2 MiB
+/// Maximum number of chunks into which a message can be broken up.
+const RPC_CHUNKING_MAX_CHUNKS: usize = 16; // 16 x 256 Kib = 4 MiB max combined message size
+const RPC_CHUNKING_THRESHOLD: usize = 256 * 1024;
+const RPC_CHUNKING_SIZE_LIMIT: usize = 384 * 1024;
+
+/// Convenience function that returns the maximum size for a single RPC message
+const fn max_message_size() -> usize {
+    RPC_CHUNKING_MAX_CHUNKS * RPC_CHUNKING_THRESHOLD
+}
+
+const fn max_payload_size() -> usize {
+    // RpcResponse overhead is:
+    // - 4 varint protobuf fields, each field ID is 1 byte
+    // - 3 u32 fields, VarInt(u32::MAX) is 5 bytes
+    // - 1 length varint for the payload, allow for 5 bytes to be safe (max_payload_size being technically too small is
+    //   fine, being too large isn't)
+    const MAX_HEADER_SIZE: usize = 4 + 4 * 5;
+    max_message_size() - MAX_HEADER_SIZE
+}
+
 mod body;
 pub use body::{Body, ClientStreaming, IntoBody, Streaming};
 
@@ -55,9 +78,6 @@ mod status;
 pub use status::{RpcStatus, RpcStatusCode};
 
 mod not_found;
-
-/// Maximum frame size of each RPC message. This is enforced in tokio's length delimited codec.
-pub const RPC_MAX_FRAME_SIZE: usize = 4 * 1024 * 1024; // 4 MiB
 
 // Re-exports used to keep things orderly in the #[tari_rpc] proc macro
 pub mod __macro_reexports {

--- a/comms/src/protocol/rpc/server/chunking.rs
+++ b/comms/src/protocol/rpc/server/chunking.rs
@@ -1,0 +1,259 @@
+//  Copyright 2021, The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use super::LOG_TARGET;
+use crate::{
+    proto,
+    protocol::{
+        rpc,
+        rpc::{
+            message::{RpcMessageFlags, RpcResponse},
+            RpcStatusCode,
+            RPC_CHUNKING_SIZE_LIMIT,
+            RPC_CHUNKING_THRESHOLD,
+        },
+    },
+};
+use bytes::Bytes;
+use log::*;
+use std::cmp;
+
+pub(super) struct ChunkedResponseIter {
+    message: RpcResponse,
+    initial_payload_size: usize,
+    has_emitted_once: bool,
+    num_chunks: usize,
+    total_chunks: usize,
+}
+
+fn calculate_total_chunk_count(payload_len: usize) -> usize {
+    let mut total_chunks = payload_len / RPC_CHUNKING_THRESHOLD;
+    let excess = (payload_len % RPC_CHUNKING_THRESHOLD) + RPC_CHUNKING_THRESHOLD;
+    if total_chunks == 0 || excess > RPC_CHUNKING_SIZE_LIMIT {
+        // If the chunk (threshold size) + excess cannot fit in the RPC_CHUNKING_SIZE_LIMIT, then we'll emit another
+        // frame smaller than threshold size
+        total_chunks += 1;
+    }
+
+    total_chunks
+}
+
+impl ChunkedResponseIter {
+    pub fn new(message: RpcResponse) -> Self {
+        let len = message.payload.len();
+        Self {
+            initial_payload_size: message.payload.len(),
+            message,
+            has_emitted_once: false,
+            num_chunks: 0,
+            total_chunks: calculate_total_chunk_count(len),
+        }
+    }
+
+    fn remaining(&self) -> usize {
+        self.message.payload.len()
+    }
+
+    fn payload_mut(&mut self) -> &mut Bytes {
+        &mut self.message.payload
+    }
+
+    fn payload(&self) -> &Bytes {
+        &self.message.payload
+    }
+
+    fn next_chunk(&mut self) -> Option<Bytes> {
+        let len = self.payload().len();
+        if len == 0 {
+            if self.num_chunks > 1 {
+                debug!(
+                    target: LOG_TARGET,
+                    "Emitted {} chunks ({} bytes)", self.num_chunks, self.initial_payload_size
+                );
+            }
+            return None;
+        }
+
+        // If the payload is within the maximum chunk size, simply return the rest of it
+        if len <= RPC_CHUNKING_SIZE_LIMIT {
+            let chunk = self.payload_mut().split_to(len);
+            self.num_chunks += 1;
+            trace!(
+                target: LOG_TARGET,
+                "Emitting chunk {}/{} ({} bytes)",
+                self.num_chunks,
+                self.total_chunks,
+                chunk.len()
+            );
+            return Some(chunk);
+        }
+
+        let chunk_size = cmp::min(len, RPC_CHUNKING_THRESHOLD);
+        let chunk = self.payload_mut().split_to(chunk_size);
+
+        self.num_chunks += 1;
+        trace!(
+            target: LOG_TARGET,
+            "Emitting chunk {}/{} ({} bytes)",
+            self.num_chunks,
+            self.total_chunks,
+            chunk.len()
+        );
+        Some(chunk)
+    }
+
+    fn is_last_chunk(&self) -> bool {
+        self.num_chunks == self.total_chunks
+    }
+
+    fn exceeded_message_size(&self) -> proto::rpc::RpcResponse {
+        const BYTES_PER_MB: f32 = 1024.0 * 1024.0;
+        let msg = format!(
+            "The response size exceeded the maximum allowed payload size. Max = {:.4} MiB, Got = {:.4} MiB",
+            rpc::max_payload_size() as f32 / BYTES_PER_MB,
+            self.message.payload.len() as f32 / BYTES_PER_MB,
+        );
+        warn!(target: LOG_TARGET, "{}", msg);
+        proto::rpc::RpcResponse {
+            request_id: self.message.request_id,
+            status: RpcStatusCode::MalformedResponse as u32,
+            flags: RpcMessageFlags::FIN.bits().into(),
+            payload: msg.into_bytes(),
+        }
+    }
+}
+
+impl Iterator for ChunkedResponseIter {
+    type Item = proto::rpc::RpcResponse;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // Edge case: the initial message has an empty payload.
+        if self.initial_payload_size == 0 {
+            if self.has_emitted_once {
+                return None;
+            }
+            self.has_emitted_once = true;
+            return Some(self.message.to_proto());
+        }
+
+        // Edge case: the total message size cannot fit into the maximum allowed chunks
+        if self.remaining() > rpc::max_payload_size() {
+            if self.has_emitted_once {
+                return None;
+            }
+            self.has_emitted_once = true;
+            return Some(self.exceeded_message_size());
+        }
+
+        let request_id = self.message.request_id;
+        let chunk = self.next_chunk()?;
+
+        // status MUST be set for the first chunked message, all subsequent chunk messages MUST have a status of 0
+        let mut status = 0;
+        if !self.has_emitted_once {
+            status = self.message.status as u32;
+        }
+        self.has_emitted_once = true;
+
+        let mut flags = self.message.flags;
+        if !self.is_last_chunk() {
+            // For all chunks except the last the MORE flag MUST be set
+            flags |= RpcMessageFlags::MORE;
+        }
+        let msg = proto::rpc::RpcResponse {
+            request_id,
+            status,
+            flags: flags.bits().into(),
+            payload: chunk.to_vec(),
+        };
+
+        Some(msg)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::iter;
+
+    fn create(size: usize) -> ChunkedResponseIter {
+        let msg = RpcResponse {
+            payload: iter::repeat(0).take(size).collect(),
+            ..Default::default()
+        };
+        ChunkedResponseIter::new(msg)
+    }
+
+    #[test]
+    fn it_emits_a_zero_size_message() {
+        let iter = create(0);
+        assert_eq!(iter.total_chunks, 1);
+        let msgs = iter.collect::<Vec<_>>();
+        assert_eq!(msgs.len(), 1);
+        assert!(!RpcMessageFlags::from_bits_truncate(msgs[0].flags as u8).is_more());
+    }
+
+    #[test]
+    fn it_emits_one_message_below_threshold() {
+        let iter = create(RPC_CHUNKING_THRESHOLD - 1);
+        assert_eq!(iter.total_chunks, 1);
+        let msgs = iter.collect::<Vec<_>>();
+        assert_eq!(msgs.len(), 1);
+        assert!(!RpcMessageFlags::from_bits_truncate(msgs[0].flags as u8).is_more());
+    }
+
+    #[test]
+    fn it_emits_a_single_message() {
+        let iter = create(RPC_CHUNKING_SIZE_LIMIT - 1);
+        let msgs = iter.collect::<Vec<_>>();
+        assert_eq!(msgs.len(), 1);
+
+        let iter = create(RPC_CHUNKING_SIZE_LIMIT);
+        let msgs = iter.collect::<Vec<_>>();
+        assert_eq!(msgs.len(), 1);
+    }
+
+    #[test]
+    fn it_emits_an_expected_number_of_chunks() {
+        let iter = create(RPC_CHUNKING_THRESHOLD * 2);
+        let msgs = iter.collect::<Vec<_>>();
+        assert_eq!(msgs.len(), 2);
+
+        let diff = RPC_CHUNKING_SIZE_LIMIT - RPC_CHUNKING_THRESHOLD;
+        let iter = create(RPC_CHUNKING_THRESHOLD * 2 + diff);
+        let msgs = iter.collect::<Vec<_>>();
+        assert_eq!(msgs.len(), 2);
+
+        let iter = create(RPC_CHUNKING_THRESHOLD * 2 + diff + 1);
+        let msgs = iter.collect::<Vec<_>>();
+        assert_eq!(msgs.len(), 3);
+    }
+
+    #[test]
+    fn it_sets_the_more_flag_except_last() {
+        let iter = create(RPC_CHUNKING_THRESHOLD * 3);
+        let msgs = iter.collect::<Vec<_>>();
+        assert!(RpcMessageFlags::from_bits_truncate(msgs[0].flags as u8).is_more());
+        assert!(RpcMessageFlags::from_bits_truncate(msgs[1].flags as u8).is_more());
+        assert!(!RpcMessageFlags::from_bits_truncate(msgs[2].flags as u8).is_more());
+    }
+}

--- a/comms/src/protocol/rpc/server/mod.rs
+++ b/comms/src/protocol/rpc/server/mod.rs
@@ -20,6 +20,9 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+mod chunking;
+use chunking::ChunkedResponseIter;
+
 mod error;
 pub use error::RpcServerError;
 
@@ -40,7 +43,6 @@ use super::{
     not_found::ProtocolServiceNotFound,
     status::RpcStatus,
     Handshake,
-    RpcStatusCode,
     RPC_MAX_FRAME_SIZE,
 };
 use crate::{
@@ -50,11 +52,17 @@ use crate::{
     message::MessageExt,
     peer_manager::NodeId,
     proto,
-    protocol::{ProtocolEvent, ProtocolId, ProtocolNotification, ProtocolNotificationRx},
+    protocol::{
+        rpc::{body::BodyBytes, message::RpcResponse},
+        ProtocolEvent,
+        ProtocolId,
+        ProtocolNotification,
+        ProtocolNotificationRx,
+    },
     Bytes,
     Substream,
 };
-use futures::SinkExt;
+use futures::{stream, SinkExt, StreamExt};
 use prost::Message;
 use std::{
     future::Future,
@@ -62,7 +70,6 @@ use std::{
     time::{Duration, Instant},
 };
 use tokio::{sync::mpsc, time};
-use tokio_stream::StreamExt;
 use tower::Service;
 use tower_make::MakeService;
 use tracing::{debug, error, instrument, span, trace, warn, Instrument, Level};
@@ -420,10 +427,6 @@ where
                 "({}) Rpc server exited with an error: {}", self.logging_context_string, err
             );
         }
-        debug!(
-            target: LOG_TARGET,
-            "({}) Rpc service shutdown", self.logging_context_string
-        );
     }
 
     async fn run(&mut self) -> Result<(), RpcServerError> {
@@ -431,8 +434,15 @@ where
             match result {
                 Ok(frame) => {
                     let start = Instant::now();
-                    if let Err(err) = self.handle(frame.freeze()).await {
-                        self.framed.close().await?;
+                    if let Err(err) = self.handle_request(frame.freeze()).await {
+                        if let Err(err) = self.framed.close().await {
+                            error!(
+                                target: LOG_TARGET,
+                                "({}) Failed to close substream after socket error: {}",
+                                self.logging_context_string,
+                                err
+                            );
+                        }
                         return Err(err);
                     }
                     let elapsed = start.elapsed();
@@ -460,8 +470,8 @@ where
         Ok(())
     }
 
-    #[instrument(name = "rpc::server::handle_req", skip(self), err)]
-    async fn handle(&mut self, mut request: Bytes) -> Result<(), RpcServerError> {
+    #[instrument(name = "rpc::server::handle_req", skip(self, request), err, fields(request_size = request.len()))]
+    async fn handle_request(&mut self, mut request: Bytes) -> Result<(), RpcServerError> {
         let decoded_msg = proto::rpc::RpcRequest::decode(&mut request)?;
 
         let request_id = decoded_msg.request_id;
@@ -483,7 +493,7 @@ where
                 request_id,
                 status: status.as_code(),
                 flags: RpcMessageFlags::FIN.bits().into(),
-                message: status.details_bytes(),
+                payload: status.to_details_bytes(),
             };
             self.framed.send(bad_request.to_encoded_bytes().into()).await?;
             return Ok(());
@@ -507,13 +517,13 @@ where
 
         debug!(
             target: LOG_TARGET,
-            "({}) Got request {}", self.logging_context_string, decoded_msg
+            "({}) Request: {}", self.logging_context_string, decoded_msg
         );
 
         let req = Request::with_context(
             self.create_request_context(request_id),
             method,
-            decoded_msg.message.into(),
+            decoded_msg.payload.into(),
         );
 
         let service_call = log_timing(
@@ -536,96 +546,7 @@ where
 
         match service_result {
             Ok(body) => {
-                // This is the most basic way we can push responses back to the peer. Keeping this here for reference
-                // and possible future evaluation
-                //
-                // body.into_message()
-                //     .map(|msg| match msg {
-                //         Ok(msg) => {
-                //             trace!(target: LOG_TARGET, "Sending body len = {}", msg.len());
-                //             let mut flags = RpcMessageFlags::empty();
-                //             if msg.is_finished() {
-                //                 flags |= RpcMessageFlags::FIN;
-                //             }
-                //             proto::rpc::RpcResponse {
-                //                 request_id,
-                //                 status: RpcStatus::ok().as_code(),
-                //                 flags: flags.bits().into(),
-                //                 message: msg.into(),
-                //             }
-                //         },
-                //         Err(err) => {
-                //             debug!(target: LOG_TARGET, "Body contained an error: {}", err);
-                //             proto::rpc::RpcResponse {
-                //                 request_id,
-                //                 status: err.as_code(),
-                //                 flags: RpcMessageFlags::FIN.bits().into(),
-                //                 message: err.details().as_bytes().to_vec(),
-                //             }
-                //         },
-                //     })
-                //     .map(|resp| Ok(resp.to_encoded_bytes().into()))
-                //     .forward(PreventClose::new(sink))
-                //     .await?;
-
-                let mut message = body.into_message();
-                loop {
-                    let msg_read = log_timing(
-                        self.logging_context_string.clone(),
-                        request_id,
-                        "message read",
-                        message.next(),
-                    );
-                    match time::timeout(deadline, msg_read).await {
-                        Ok(Some(msg)) => {
-                            let resp = match msg {
-                                Ok(msg) => {
-                                    trace!(target: LOG_TARGET, "Sending body len = {}", msg.len());
-                                    let mut flags = RpcMessageFlags::empty();
-                                    if msg.is_finished() {
-                                        flags |= RpcMessageFlags::FIN;
-                                    }
-                                    proto::rpc::RpcResponse {
-                                        request_id,
-                                        status: RpcStatus::ok().as_code(),
-                                        flags: flags.bits().into(),
-                                        message: msg.into(),
-                                    }
-                                },
-                                Err(err) => {
-                                    debug!(target: LOG_TARGET, "Body contained an error: {}", err);
-                                    proto::rpc::RpcResponse {
-                                        request_id,
-                                        status: err.as_code(),
-                                        flags: RpcMessageFlags::FIN.bits().into(),
-                                        message: err.details().as_bytes().to_vec(),
-                                    }
-                                },
-                            };
-
-                            let is_valid = log_timing(
-                                self.logging_context_string.clone(),
-                                request_id,
-                                "transmit",
-                                self.send_response(request_id, resp),
-                            )
-                            .await?;
-
-                            if !is_valid {
-                                break;
-                            }
-                        },
-                        Ok(None) => break,
-                        Err(_) => {
-                            debug!(
-                                target: LOG_TARGET,
-                                "Failed to return result within client deadline ({:.0?})", deadline
-                            );
-
-                            break;
-                        },
-                    }
-                } // end loop
+                self.process_body(request_id, deadline, body).await?;
             },
             Err(err) => {
                 debug!(target: LOG_TARGET, "Service returned an error: {}", err);
@@ -633,7 +554,7 @@ where
                     request_id,
                     status: err.as_code(),
                     flags: RpcMessageFlags::FIN.bits().into(),
-                    message: err.details_bytes(),
+                    payload: err.to_details_bytes(),
                 };
 
                 self.framed.send(resp.to_encoded_bytes().into()).await?;
@@ -643,38 +564,54 @@ where
         Ok(())
     }
 
-    /// Sends an RpcResponse on the given Sink. If the size of the message exceeds the RPC_MAX_FRAME_SIZE, an error is
-    /// returned to the client and false is returned from this function, otherwise the message is sent and true is
-    /// returned
-    async fn send_response(&mut self, request_id: u32, resp: proto::rpc::RpcResponse) -> Result<bool, RpcServerError> {
-        match resp.to_encoded_bytes() {
-            buf if buf.len() > RPC_MAX_FRAME_SIZE => {
-                let msg = format!(
-                    "This node tried to return a message that exceeds the maximum frame size. Max = {:.4} MiB, Got = \
-                     {:.4} MiB",
-                    RPC_MAX_FRAME_SIZE as f32 / (1024.0 * 1024.0),
-                    buf.len() as f32 / (1024.0 * 1024.0)
-                );
-                warn!(target: LOG_TARGET, "{}", msg);
-                self.framed
-                    .send(
-                        proto::rpc::RpcResponse {
-                            request_id,
-                            status: RpcStatusCode::MalformedResponse as u32,
-                            flags: RpcMessageFlags::FIN.bits().into(),
-                            message: msg.as_bytes().to_vec(),
-                        }
-                        .to_encoded_bytes()
-                        .into(),
-                    )
-                    .await?;
-                Ok(false)
-            },
-            buf => {
-                self.framed.send(buf.into()).await?;
-                Ok(true)
-            },
-        }
+    async fn process_body(
+        &mut self,
+        request_id: u32,
+        deadline: Duration,
+        body: Response<Body>,
+    ) -> Result<(), RpcServerError> {
+        trace!(target: LOG_TARGET, "Service call succeeded");
+        let mut stream = body
+            .into_message()
+            .map(|result| into_response(request_id, result))
+            .flat_map(|message| stream::iter(ChunkedResponseIter::new(message)))
+            .map(|resp| Bytes::from(resp.to_encoded_bytes()));
+
+        loop {
+            let next_item = log_timing(
+                self.logging_context_string.clone(),
+                request_id,
+                "message read",
+                stream.next(),
+            );
+            match time::timeout(deadline, next_item).await {
+                Ok(Some(msg)) => {
+                    trace!(
+                        target: LOG_TARGET,
+                        "({}) Sending body len = {}",
+                        self.logging_context_string,
+                        msg.len()
+                    );
+
+                    self.framed.send(msg).await?;
+                },
+                Ok(None) => {
+                    debug!(target: LOG_TARGET, "{} Request complete", self.logging_context_string,);
+                    break;
+                },
+                Err(_) => {
+                    debug!(
+                        target: LOG_TARGET,
+                        "({}) Failed to return result within client deadline ({:.0?})",
+                        self.logging_context_string,
+                        deadline
+                    );
+
+                    break;
+                },
+            }
+        } // end loop
+        Ok(())
     }
 
     fn create_request_context(&self, request_id: u32) -> RequestContext {
@@ -697,4 +634,32 @@ async fn log_timing<R, F: Future<Output = R>>(context_str: Arc<String>, request_
         if elapsed.as_secs() >= 5 { " (SLOW)" } else { "" }
     );
     ret
+}
+
+#[allow(clippy::cognitive_complexity)]
+fn into_response(request_id: u32, result: Result<BodyBytes, RpcStatus>) -> RpcResponse {
+    match result {
+        Ok(msg) => {
+            trace!(target: LOG_TARGET, "Sending body len = {}", msg.len());
+            let mut flags = RpcMessageFlags::empty();
+            if msg.is_finished() {
+                flags |= RpcMessageFlags::FIN;
+            }
+            RpcResponse {
+                request_id,
+                status: RpcStatus::ok().status_code(),
+                flags,
+                payload: msg.into_bytes().unwrap_or_else(Bytes::new),
+            }
+        },
+        Err(err) => {
+            debug!(target: LOG_TARGET, "Body contained an error: {}", err);
+            RpcResponse {
+                request_id,
+                status: err.status_code(),
+                flags: RpcMessageFlags::FIN,
+                payload: Bytes::from(err.to_details_bytes()),
+            }
+        },
+    }
 }

--- a/comms/src/protocol/rpc/status.rs
+++ b/comms/src/protocol/rpc/status.rs
@@ -118,7 +118,7 @@ impl RpcStatus {
         &self.details
     }
 
-    pub fn details_bytes(&self) -> Vec<u8> {
+    pub fn to_details_bytes(&self) -> Vec<u8> {
         self.details.as_bytes().to_vec()
     }
 
@@ -155,7 +155,7 @@ impl<'a> From<&'a proto::rpc::RpcResponse> for RpcStatus {
 
         RpcStatus {
             code: status_code,
-            details: String::from_utf8_lossy(&resp.message).to_string(),
+            details: String::from_utf8_lossy(&resp.payload).to_string(),
         }
     }
 }


### PR DESCRIPTION
Description
---
Adds server-side "chunking" protocol for large RPC responses.

Given a payload exceeding some threshold, comms RPC will split message payloads into a number (maximum 16) 
RPC messages and stream them to the client. The client will recombine the message payloads before emitting it to
the caller.  

BREAKING CHANGE: Backward compatible (client-side), an upgraded node may request from an older node and process
responses. Since an older node cannot process chunks, if a response contains any, the response will be invalid to the older node. Otherwise, if less than the payload threshold, the response is exactly as before. 

Motivation and Context
---
Large streamed message payloads (those seen in block sync) are often ~ 1.2 MiB over the wire. 
The [Bandwidth Delay product](https://www.wikiwand.com/en/Bandwidth-delay_product) is often low/very low for connections over tor resulting in large message frames will take many seconds to be completely received. 

This PR breaks message payloads into smaller chunks with less time between receiving a full frame on the client side. 

The algorithm for chunking is as follows:
```
THRESHOLD = 256kb 
SIZE_LIMIT = 384Kb
MAX_CHUNKS = 16
```
a. `payload <= THRESHOLD`: emit a single frame
b. `payload > THRESHOLD && payload <= SIZE_LIMIT `: emit a single frame containing the full payload
c. `payload > SIZE_LIMIT `: emit a one or more frames containing the next `SIZE_THRESHOLD` bytes, with the final frame either as per (a) or (b).

This is done to prevent an unnecessary/very small trailing chunk when a payload is only a handful of bytes over the threshold
e.g 256Kb (`THRESHOLD`) + 1 byte results in _one_ chunk not _two_.  384Kb (`SIZE_LIMIT`) + 1 kb results 
in 2 frames of 256Kb and 129Kb respectively. meaning each chunk has a maximum size of `SIZE_LIMIT` and the
trailing/last chunk has a minimum size of `SIZE_LIMIT - THRESHOLD  (128kb)`

How Has This Been Tested?
---

Some new unit tests, existing large message tests, manual archival sync using force sync 
