### PR TITLE
fix: remove explicit panic from rpc handshake on io error

### DIFF
--- a/comms/src/protocol/rpc/handshake.rs
+++ b/comms/src/protocol/rpc/handshake.rs
@@ -148,7 +148,6 @@ where T: AsyncRead + AsyncWrite + Unpin
                 target: LOG_TARGET,
                 "IO error when sending new session handshake to peer: {}", err
             );
-            panic!();
         }
         self.framed.flush().await?;
         match self.recv_next_frame().await {


### PR DESCRIPTION
Description
---
Remove mistaken explicit panic

Motivation and Context
---
Forgot to remove panic while developing

How Has This Been Tested?
---
N/A
