### PR TITLE
feat: send token

### DIFF
--- a/applications/tari_console_wallet/src/ui/components/send_tab.rs
+++ b/applications/tari_console_wallet/src/ui/components/send_tab.rs
@@ -1,21 +1,21 @@
 use crate::{
     ui::{
-        components::{balance::Balance, Component, KeyHandled},
+        components::{balance::Balance, styles, Component, KeyHandled},
         state::{AppState, UiTransactionSendStatus},
         widgets::{centered_rect_absolute, draw_dialog, MultiColumnList, WindowedListState},
         MAX_WIDTH,
     },
     utils::formatting::display_compressed_string,
 };
-use tari_core::transactions::tari_amount::MicroTari;
-use tari_wallet::types::DEFAULT_FEE_PER_GRAM;
+use tari_core::{tari_utilities::hex::Hex, transactions::tari_amount::MicroTari};
+use tari_wallet::{tokens::Token, types::DEFAULT_FEE_PER_GRAM};
 use tokio::{runtime::Handle, sync::watch};
 use tui::{
     backend::Backend,
     layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Span, Spans},
-    widgets::{Block, Borders, Clear, ListItem, Paragraph, Wrap},
+    widgets::{Block, Borders, Clear, ListItem, Paragraph, Row, Table, TableState, Wrap},
     Frame,
 };
 use unicode_width::UnicodeWidthStr;
@@ -37,6 +37,8 @@ pub struct SendTab {
     contacts_list_state: WindowedListState,
     send_result_watch: Option<watch::Receiver<UiTransactionSendStatus>>,
     confirmation_dialog: Option<ConfirmationDialogType>,
+    selected_unique_id: Option<Vec<u8>>,
+    table_state: TableState,
 }
 
 impl SendTab {
@@ -58,6 +60,8 @@ impl SendTab {
             contacts_list_state: WindowedListState::new(),
             send_result_watch: None,
             confirmation_dialog: None,
+            selected_unique_id: None,
+            table_state: TableState::default(),
         }
     }
 
@@ -89,7 +93,7 @@ impl SendTab {
                 Span::raw(" field, "),
                 Span::styled("A", Style::default().add_modifier(Modifier::BOLD)),
                 Span::raw(" to edit "),
-                Span::styled("Amount", Style::default().add_modifier(Modifier::BOLD)),
+                Span::styled("Amount/Token", Style::default().add_modifier(Modifier::BOLD)),
                 Span::raw(", "),
                 Span::styled("F", Style::default().add_modifier(Modifier::BOLD)),
                 Span::raw(" to edit "),
@@ -127,12 +131,19 @@ impl SendTab {
             .constraints([Constraint::Percentage(50), Constraint::Percentage(50)].as_ref())
             .split(vert_chunks[2]);
 
-        let amount_input = Paragraph::new(self.amount_field.as_ref())
-            .style(match self.send_input_mode {
-                SendInputMode::Amount => Style::default().fg(Color::Magenta),
-                _ => Style::default(),
-            })
-            .block(Block::default().borders(Borders::ALL).title("(A)mount (uT or T):"));
+        let amount_input = Paragraph::new(match &self.selected_unique_id {
+            Some(token) => format!("Token selected : {}", token.to_hex()),
+            None => format!("{}", self.amount_field),
+        })
+        .style(match self.send_input_mode {
+            SendInputMode::Amount => Style::default().fg(Color::Magenta),
+            _ => Style::default(),
+        })
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title("(A)mount (uT or T) or select Token:"),
+        );
         f.render_widget(amount_input, amount_fee_layout[0]);
 
         let fee_input = Paragraph::new(self.fee_field.as_ref())
@@ -159,12 +170,16 @@ impl SendTab {
                 // Move one line down, from the border to the input line
                 vert_chunks[1].y + 1,
             ),
-            SendInputMode::Amount => f.set_cursor(
-                // Put cursor past the end of the input text
-                amount_fee_layout[0].x + self.amount_field.width() as u16 + 1,
-                // Move one line down, from the border to the input line
-                amount_fee_layout[0].y + 1,
-            ),
+            SendInputMode::Amount => {
+                if self.selected_unique_id.is_none() {
+                    f.set_cursor(
+                        // Put cursor past the end of the input text
+                        amount_fee_layout[0].x + self.amount_field.width() as u16 + 1,
+                        // Move one line down, from the border to the input line
+                        amount_fee_layout[0].y + 1,
+                    )
+                }
+            },
             SendInputMode::Fee => f.set_cursor(
                 // Put cursor past the end of the input text
                 amount_fee_layout[1].x + self.fee_field.width() as u16 + 1,
@@ -301,6 +316,50 @@ impl SendTab {
         }
     }
 
+    fn draw_tokens<B>(&mut self, f: &mut Frame<B>, area: Rect, app_state: &AppState)
+    where B: Backend {
+        let tokens = app_state.get_owned_tokens();
+
+        let tokens: Vec<_> = tokens
+            .iter()
+            .filter(|&token| token.output_status() == "Unspent")
+            .map(|r| {
+                (
+                    r.name().to_string(),
+                    r.output_status().to_string(),
+                    r.asset_public_key().to_hex(),
+                    Vec::from(r.unique_id()).to_hex(),
+                    r.owner_commitment().to_hex(),
+                )
+            })
+            .collect();
+        let rows: Vec<_> = tokens
+            .iter()
+            .map(|v| {
+                Row::new(vec![
+                    v.0.as_str(),
+                    v.1.as_str(),
+                    v.2.as_str(),
+                    v.3.as_str(),
+                    v.4.as_str(),
+                ])
+            })
+            .collect();
+        let table = Table::new(rows)
+            .header(Row::new(vec!["Name", "Status", "Asset Pub Key", "Unique ID", "Owner"]).style(styles::header_row()))
+            .block(Block::default().title("Tokens").borders(Borders::ALL))
+            .widths(&[
+                Constraint::Length(30),
+                Constraint::Length(20),
+                Constraint::Length(32),
+                Constraint::Length(32),
+                Constraint::Length(64),
+            ])
+            .highlight_style(styles::highlight())
+            .highlight_symbol(">>");
+        f.render_stateful_widget(table, area, &mut self.table_state)
+    }
+
     fn on_key_confirmation_dialog(&mut self, c: char, app_state: &mut AppState) -> KeyHandled {
         if self.confirmation_dialog.is_some() {
             if 'n' == c {
@@ -319,9 +378,12 @@ impl SendTab {
                             let amount = if let Ok(v) = self.amount_field.parse::<MicroTari>() {
                                 v
                             } else {
-                                self.error_message =
-                                    Some("Amount should be an integer\nPress Enter to continue.".to_string());
-                                return KeyHandled::Handled;
+                                if self.selected_unique_id.is_none() {
+                                    self.error_message =
+                                        Some("Amount should be an integer\nPress Enter to continue.".to_string());
+                                    return KeyHandled::Handled;
+                                }
+                                MicroTari::from(0)
                             };
 
                             let fee_per_gram = if let Ok(v) = self.fee_field.parse::<u64>() {
@@ -339,6 +401,7 @@ impl SendTab {
                                 match Handle::current().block_on(app_state.send_one_sided_transaction(
                                     self.to_field.clone(),
                                     amount.into(),
+                                    self.selected_unique_id.clone(),
                                     fee_per_gram,
                                     self.message_field.clone(),
                                     tx,
@@ -355,6 +418,7 @@ impl SendTab {
                                 match Handle::current().block_on(app_state.send_transaction(
                                     self.to_field.clone(),
                                     amount.into(),
+                                    self.selected_unique_id.clone(),
                                     fee_per_gram,
                                     self.message_field.clone(),
                                     tx,
@@ -371,6 +435,7 @@ impl SendTab {
                             if reset_fields {
                                 self.to_field = "".to_string();
                                 self.amount_field = "".to_string();
+                                self.selected_unique_id = None;
                                 self.fee_field = u64::from(DEFAULT_FEE_PER_GRAM).to_string();
                                 self.message_field = "".to_string();
                                 self.send_input_mode = SendInputMode::None;
@@ -409,20 +474,25 @@ impl SendTab {
             match self.send_input_mode {
                 SendInputMode::None => (),
                 SendInputMode::To => match c {
-                    '\n' => {
-                        self.send_input_mode = SendInputMode::Amount;
-                    },
+                    '\n' => self.send_input_mode = SendInputMode::Amount,
                     c => {
                         self.to_field.push(c);
                         return KeyHandled::Handled;
                     },
                 },
                 SendInputMode::Amount => match c {
-                    '\n' => self.send_input_mode = SendInputMode::Message,
+                    '\n' => {
+                        if self.selected_unique_id.is_some() {
+                            self.amount_field = "".to_string();
+                        }
+                        self.send_input_mode = SendInputMode::Message
+                    },
                     c => {
-                        let symbols = &['t', 'T', 'u', 'U'];
-                        if c.is_numeric() || symbols.contains(&c) {
-                            self.amount_field.push(c);
+                        if self.selected_unique_id.is_none() {
+                            let symbols = &['t', 'T', 'u', 'U'];
+                            if c.is_numeric() || symbols.contains(&c) {
+                                self.amount_field.push(c);
+                            }
                         }
                         return KeyHandled::Handled;
                     },
@@ -546,6 +616,10 @@ impl<B: Backend> Component<B> for SendTab {
                 self.draw_edit_contact(f, area, app_state);
             }
         };
+
+        if self.send_input_mode == SendInputMode::Amount {
+            self.draw_tokens(f, areas[2], app_state);
+        }
 
         let rx_option = self.send_result_watch.take();
         if let Some(rx) = rx_option {
@@ -672,7 +746,6 @@ impl<B: Backend> Component<B> for SendTab {
                     self.send_input_mode = SendInputMode::None;
                 }
             },
-
             'e' => {
                 if let Some(c) = self
                     .contacts_list_state
@@ -688,21 +761,25 @@ impl<B: Backend> Component<B> for SendTab {
                 }
             },
             't' => self.send_input_mode = SendInputMode::To,
-            'a' => self.send_input_mode = SendInputMode::Amount,
+            'a' => {
+                self.send_input_mode = SendInputMode::Amount;
+            },
             'f' => self.send_input_mode = SendInputMode::Fee,
             'm' => self.send_input_mode = SendInputMode::Message,
             's' | 'o' => {
-                if self.amount_field.is_empty() || self.to_field.is_empty() {
-                    self.error_message = Some(
-                        "Destination Public Key/Emoji ID and Amount required\nPress Enter to continue.".to_string(),
-                    );
+                if self.to_field.is_empty() {
+                    self.error_message = Some("Destination Public Key/Emoji ID\nPress Enter to continue.".to_string());
                     return;
                 }
-                if self.amount_field.parse::<MicroTari>().is_err() {
+                if self.amount_field.is_empty() && self.selected_unique_id.is_none() {
+                    self.error_message = Some("Amount or token required\nPress Enter to continue.".to_string());
+                    return;
+                }
+                if self.amount_field.parse::<MicroTari>().is_err() && self.selected_unique_id.is_none() {
                     self.error_message =
                         Some("Amount should be a valid amount of Tari\nPress Enter to continue.".to_string());
                     return;
-                };
+                }
 
                 if matches!(c, 'o') {
                     self.confirmation_dialog = Some(ConfirmationDialogType::ConfirmOneSidedSend);
@@ -715,13 +792,45 @@ impl<B: Backend> Component<B> for SendTab {
     }
 
     fn on_up(&mut self, app_state: &mut AppState) {
-        self.contacts_list_state.set_num_items(app_state.get_contacts().len());
-        self.contacts_list_state.previous();
+        if self.show_contacts {
+            self.contacts_list_state.set_num_items(app_state.get_contacts().len());
+            self.contacts_list_state.previous();
+        } else if self.send_input_mode == SendInputMode::Amount {
+            let index = self.table_state.selected().unwrap_or_default();
+            if index == 0 {
+                self.table_state.select(None);
+                self.selected_unique_id = None;
+            } else {
+                let tokens: Vec<&Token> = app_state
+                    .get_owned_tokens()
+                    .into_iter()
+                    .filter(|&token| token.output_status() == "Unspent")
+                    .collect();
+                self.selected_unique_id = Some(Vec::from(tokens[index - 1].unique_id()));
+                self.table_state.select(Some(index - 1));
+            }
+        }
     }
 
     fn on_down(&mut self, app_state: &mut AppState) {
-        self.contacts_list_state.set_num_items(app_state.get_contacts().len());
-        self.contacts_list_state.next();
+        if self.show_contacts {
+            self.contacts_list_state.set_num_items(app_state.get_contacts().len());
+            self.contacts_list_state.next();
+        } else if self.send_input_mode == SendInputMode::Amount {
+            let index = self.table_state.selected().map(|s| s + 1).unwrap_or_default();
+            let tokens: Vec<&Token> = app_state
+                .get_owned_tokens()
+                .into_iter()
+                .filter(|&token| token.output_status() == "Unspent")
+                .collect();
+            if index > tokens.len().saturating_sub(1) {
+                self.table_state.select(None);
+                self.selected_unique_id = None;
+            } else {
+                self.selected_unique_id = Some(Vec::from(tokens[index].unique_id()));
+                self.table_state.select(Some(index));
+            }
+        }
     }
 
     fn on_esc(&mut self, _: &mut AppState) {
@@ -737,7 +846,9 @@ impl<B: Backend> Component<B> for SendTab {
                 let _ = self.to_field.pop();
             },
             SendInputMode::Amount => {
-                let _ = self.amount_field.pop();
+                if self.selected_unique_id.is_none() {
+                    let _ = self.amount_field.pop();
+                }
             },
             SendInputMode::Fee => {
                 let _ = self.fee_field.pop();

--- a/applications/tari_console_wallet/src/ui/components/transactions_tab.rs
+++ b/applications/tari_console_wallet/src/ui/components/transactions_tab.rs
@@ -106,7 +106,13 @@ impl TransactionsTab {
                 } else {
                     Style::default().fg(Color::Red)
                 };
-                column1_items.push(ListItem::new(Span::styled(format!("{}", t.amount), amount_style)));
+                match t.get_unique_id() {
+                    Some(unique_id) => column1_items.push(ListItem::new(Span::styled(
+                        format!("Token : {}", unique_id),
+                        amount_style,
+                    ))),
+                    None => column1_items.push(ListItem::new(Span::styled(format!("{}", t.amount), amount_style))),
+                }
             } else {
                 column0_items.push(ListItem::new(Span::styled(
                     app_state.get_alias(&t.source_public_key),
@@ -117,7 +123,13 @@ impl TransactionsTab {
                 } else {
                     Style::default().fg(Color::Green)
                 };
-                column1_items.push(ListItem::new(Span::styled(format!("{}", t.amount), amount_style)));
+                match t.get_unique_id() {
+                    Some(unique_id) => column1_items.push(ListItem::new(Span::styled(
+                        format!("Token : {}", unique_id),
+                        amount_style,
+                    ))),
+                    None => column1_items.push(ListItem::new(Span::styled(format!("{}", t.amount), amount_style))),
+                }
             }
             let local_time = DateTime::<Local>::from_utc(t.timestamp, Local::now().offset().to_owned());
             column2_items.push(ListItem::new(Span::styled(
@@ -135,7 +147,7 @@ impl TransactionsTab {
             .heading_style(styles::header_row())
             .max_width(MAX_WIDTH)
             .add_column(Some("Source/Destination Public Key"), Some(67), column0_items)
-            .add_column(Some("Amount"), Some(18), column1_items)
+            .add_column(Some("Amount/Token"), Some(18), column1_items)
             .add_column(Some("Local Date/Time"), Some(20), column2_items)
             .add_column(Some("Message"), None, column3_items);
         column_list.render(f, area, &mut pending_list_state);
@@ -191,7 +203,13 @@ impl TransactionsTab {
                 } else {
                     Style::default().fg(Color::Red)
                 };
-                column1_items.push(ListItem::new(Span::styled(format!("{}", t.amount), amount_style)));
+                match t.get_unique_id() {
+                    Some(unique_id) => column1_items.push(ListItem::new(Span::styled(
+                        format!("Token : {}", unique_id),
+                        amount_style,
+                    ))),
+                    None => column1_items.push(ListItem::new(Span::styled(format!("{}", t.amount), amount_style))),
+                }
             } else {
                 column0_items.push(ListItem::new(Span::styled(
                     app_state.get_alias(&t.source_public_key),
@@ -211,7 +229,13 @@ impl TransactionsTab {
                     _ => Color::Green,
                 };
                 let amount_style = Style::default().fg(color);
-                column1_items.push(ListItem::new(Span::styled(format!("{}", t.amount), amount_style)));
+                match t.get_unique_id() {
+                    Some(unique_id) => column1_items.push(ListItem::new(Span::styled(
+                        format!("Token : {}", unique_id),
+                        amount_style,
+                    ))),
+                    None => column1_items.push(ListItem::new(Span::styled(format!("{}", t.amount), amount_style))),
+                }
             }
             let local_time = DateTime::<Local>::from_utc(t.timestamp, Local::now().offset().to_owned());
             column2_items.push(ListItem::new(Span::styled(
@@ -235,7 +259,7 @@ impl TransactionsTab {
             .heading_style(Style::default().fg(Color::Magenta))
             .max_width(MAX_WIDTH)
             .add_column(Some("Source/Destination Public Key"), Some(67), column0_items)
-            .add_column(Some("Amount"), Some(18), column1_items)
+            .add_column(Some("Amount/Token"), Some(18), column1_items)
             .add_column(Some("Local Date/Time"), Some(20), column2_items)
             .add_column(Some("Status"), None, column3_items);
 
@@ -264,7 +288,16 @@ impl TransactionsTab {
         let source_public_key = Span::styled("Source Public Key:", Style::default().fg(Color::Magenta));
         let destination_public_key = Span::styled("Destination Public Key:", Style::default().fg(Color::Magenta));
         let direction = Span::styled("Direction:", Style::default().fg(Color::Magenta));
-        let amount = Span::styled("Amount:", Style::default().fg(Color::Magenta));
+        let amount = Span::styled(
+            match self.detailed_transaction.as_ref() {
+                Some(tx) => match tx.get_unique_id() {
+                    Some(_unique_id) => "Token:",
+                    None => "Amount",
+                },
+                None => "Amount/Token:",
+            },
+            Style::default().fg(Color::Magenta),
+        );
         let fee = Span::styled("Fee:", Style::default().fg(Color::Magenta));
         let status = Span::styled("Status:", Style::default().fg(Color::Magenta));
         let message = Span::styled("Message:", Style::default().fg(Color::Magenta));
@@ -325,7 +358,13 @@ impl TransactionsTab {
                     )
                 };
             let direction = Span::styled(format!("{}", tx.direction), Style::default().fg(Color::White));
-            let amount = Span::styled(format!("{}", tx.amount), Style::default().fg(Color::White));
+            let amount = Span::styled(
+                format!("{}", match tx.get_unique_id() {
+                    Some(unique_id) => unique_id,
+                    None => tx.amount.to_string(),
+                }),
+                Style::default().fg(Color::White),
+            );
             let fee = Span::styled(format!("{}", tx.fee), Style::default().fg(Color::White));
             let status_msg = if tx.cancelled {
                 "Cancelled".to_string()

--- a/applications/tari_console_wallet/src/ui/state/app_state.rs
+++ b/applications/tari_console_wallet/src/ui/state/app_state.rs
@@ -238,6 +238,7 @@ impl AppState {
         &mut self,
         public_key: String,
         amount: u64,
+        unique_id: Option<Vec<u8>>,
         fee_per_gram: u64,
         message: String,
         result_tx: watch::Sender<UiTransactionSendStatus>,
@@ -253,6 +254,7 @@ impl AppState {
         tokio::spawn(send_transaction_task(
             public_key,
             MicroTari::from(amount),
+            unique_id,
             message,
             fee_per_gram,
             tx_service_handle,
@@ -266,6 +268,7 @@ impl AppState {
         &mut self,
         public_key: String,
         amount: u64,
+        unique_id: Option<Vec<u8>>,
         fee_per_gram: u64,
         message: String,
         result_tx: watch::Sender<UiTransactionSendStatus>,
@@ -281,6 +284,7 @@ impl AppState {
         tokio::spawn(send_one_sided_transaction_task(
             public_key,
             MicroTari::from(amount),
+            unique_id,
             message,
             fee_per_gram,
             tx_service_handle,

--- a/applications/tari_console_wallet/src/ui/state/tasks.rs
+++ b/applications/tari_console_wallet/src/ui/state/tasks.rs
@@ -31,6 +31,7 @@ const LOG_TARGET: &str = "wallet::console_wallet::tasks ";
 pub async fn send_transaction_task(
     public_key: CommsPublicKey,
     amount: MicroTari,
+    unique_id: Option<Vec<u8>>,
     message: String,
     fee_per_gram: MicroTari,
     mut transaction_service_handle: TransactionServiceHandle,
@@ -41,7 +42,7 @@ pub async fn send_transaction_task(
     let mut send_direct_received_result = (false, false);
     let mut send_saf_received_result = (false, false);
     match transaction_service_handle
-        .send_transaction(public_key, amount, None, fee_per_gram, message)
+        .send_transaction(public_key, amount, unique_id, fee_per_gram, message)
         .await
     {
         Err(e) => {
@@ -106,6 +107,7 @@ pub async fn send_transaction_task(
 pub async fn send_one_sided_transaction_task(
     public_key: CommsPublicKey,
     amount: MicroTari,
+    unique_id: Option<Vec<u8>>,
     message: String,
     fee_per_gram: MicroTari,
     mut transaction_service_handle: TransactionServiceHandle,
@@ -114,7 +116,7 @@ pub async fn send_one_sided_transaction_task(
     let _ = result_tx.send(UiTransactionSendStatus::Initiated);
     let mut event_stream = transaction_service_handle.get_event_stream();
     match transaction_service_handle
-        .send_one_sided_transaction(public_key, amount, None, fee_per_gram, message)
+        .send_one_sided_transaction(public_key, amount, unique_id, fee_per_gram, message)
         .await
     {
         Err(e) => {

--- a/base_layer/core/src/transactions/transaction_protocol/sender.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/sender.rs
@@ -98,7 +98,6 @@ pub(super) struct RawTransactionInfo {
     pub recipient_info: RecipientInfo,
     pub signatures: Vec<Signature>,
     pub message: String,
-    pub unique_id: Option<Vec<u8>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]

--- a/base_layer/core/src/transactions/transaction_protocol/single_receiver.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/single_receiver.rs
@@ -80,7 +80,7 @@ impl SingleReceiverTransactionProtocol {
 
     /// Validates the sender info
     fn validate_sender_data(sender_info: &SD) -> Result<(), TPE> {
-        if sender_info.amount == 0.into() {
+        if sender_info.amount == 0.into() && sender_info.features.unique_id.is_none() {
             return Err(TPE::ValidationError("Cannot send zero microTari".into()));
         }
         Ok(())

--- a/base_layer/wallet/src/output_manager_service/error.rs
+++ b/base_layer/wallet/src/output_manager_service/error.rs
@@ -109,6 +109,8 @@ pub enum OutputManagerError {
     MasterSecretKeyMismatch,
     #[error("Private Key is not found in the current Key Chain")]
     KeyNotFoundInKeyChain,
+    #[error("Token with unique id not found")]
+    TokenUniqueIdNotFound,
 }
 
 #[derive(Debug, Error, PartialEq)]

--- a/base_layer/wallet/src/output_manager_service/storage/sqlite_db/new_output_sql.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/sqlite_db/new_output_sql.rs
@@ -52,6 +52,8 @@ pub struct NewOutputSql {
     script_private_key: Vec<u8>,
     metadata: Option<Vec<u8>>,
     features_asset_public_key: Option<Vec<u8>>,
+    features_mint_asset_public_key: Option<Vec<u8>>,
+    features_mint_asset_owner_commitment: Option<Vec<u8>>,
     features_parent_public_key: Option<Vec<u8>>,
     features_unique_id: Option<Vec<u8>>,
     sender_offset_public_key: Vec<u8>,
@@ -76,6 +78,17 @@ impl NewOutputSql {
             script_private_key: output.unblinded_output.script_private_key.to_vec(),
             metadata: Some(output.unblinded_output.features.metadata),
             features_asset_public_key: output.unblinded_output.features.asset.map(|a| a.public_key.to_vec()),
+            features_mint_asset_public_key: output
+                .unblinded_output
+                .features
+                .mint_non_fungible
+                .clone()
+                .map(|a| a.asset_public_key.to_vec()),
+            features_mint_asset_owner_commitment: output
+                .unblinded_output
+                .features
+                .mint_non_fungible
+                .map(|a| a.asset_owner_commitment.to_vec()),
             features_parent_public_key: output.unblinded_output.features.parent_public_key.map(|a| a.to_vec()),
             features_unique_id: output.unblinded_output.features.unique_id,
             sender_offset_public_key: output.unblinded_output.sender_offset_public_key.to_vec(),

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_send_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_send_protocol.rs
@@ -72,6 +72,7 @@ where TBackend: TransactionBackend + 'static
     id: TxId,
     dest_pubkey: CommsPublicKey,
     amount: MicroTari,
+    unique_id: Option<Vec<u8>>,
     fee_per_gram: MicroTari,
     message: String,
     service_request_reply_channel: Option<oneshot::Sender<Result<TransactionServiceResponse, TransactionServiceError>>>,
@@ -92,6 +93,7 @@ where TBackend: TransactionBackend + 'static
         cancellation_receiver: oneshot::Receiver<()>,
         dest_pubkey: CommsPublicKey,
         amount: MicroTari,
+        unique_id: Option<Vec<u8>>,
         fee_per_gram: MicroTari,
         message: String,
         service_request_reply_channel: Option<
@@ -106,6 +108,7 @@ where TBackend: TransactionBackend + 'static
             cancellation_receiver: Some(cancellation_receiver),
             dest_pubkey,
             amount,
+            unique_id,
             fee_per_gram,
             message,
             service_request_reply_channel,
@@ -155,7 +158,7 @@ where TBackend: TransactionBackend + 'static
             .prepare_transaction_to_send(
                 self.id,
                 self.amount,
-                None, // TODO: is this supposed to be populated?
+                self.unique_id.clone(),
                 self.fee_per_gram,
                 None,
                 self.message.clone(),

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -742,6 +742,7 @@ where
             cancellation_receiver,
             dest_pubkey,
             amount,
+            unique_id,
             fee_per_gram,
             message,
             Some(reply_channel),
@@ -1175,6 +1176,7 @@ where
                     cancellation_receiver,
                     tx.destination_public_key,
                     tx.amount,
+                    None, // TODO: Fill this ?
                     tx.fee,
                     tx.message,
                     None,

--- a/base_layer/wallet/src/transaction_service/storage/models.rs
+++ b/base_layer/wallet/src/transaction_service/storage/models.rs
@@ -29,12 +29,15 @@ use std::{
 };
 use tari_common_types::types::PrivateKey;
 use tari_comms::types::CommsPublicKey;
-use tari_core::transactions::{
-    tari_amount::MicroTari,
-    transaction::Transaction,
-    transaction_protocol::TxId,
-    ReceiverTransactionProtocol,
-    SenderTransactionProtocol,
+use tari_core::{
+    tari_utilities::hex::Hex,
+    transactions::{
+        tari_amount::MicroTari,
+        transaction::Transaction,
+        transaction_protocol::TxId,
+        ReceiverTransactionProtocol,
+        SenderTransactionProtocol,
+    },
 };
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -238,6 +241,23 @@ impl CompletedTransaction {
             confirmations: None,
             mined_height: None,
         }
+    }
+
+    pub fn get_unique_id(&self) -> Option<String> {
+        let body = self.transaction.get_body();
+        for tx_input in body.inputs() {
+            match tx_input.features.unique_id {
+                Some(ref unique_id) => return Some(unique_id.to_hex()),
+                _ => {},
+            }
+        }
+        for tx_output in body.outputs() {
+            match tx_output.features.unique_id {
+                Some(ref unique_id) => return Some(unique_id.to_hex()),
+                _ => {},
+            }
+        }
+        None
     }
 }
 


### PR DESCRIPTION
Description
---
When you are changing the amount, you can select token instead. I think the UI is very intuitive. Please do comment if you have better idea for the UI.

Motivation and Context
---

How Has This Been Tested?
---
Manually. After the transactions is mined, you need to recover the wallet to change the state of the token to unspent (the same behavior as with mint tokens and registering asset).