### PR TITLE
fix: fix median timestamp index

### DIFF
--- a/base_layer/core/src/validation/header_validator.rs
+++ b/base_layer/core/src/validation/header_validator.rs
@@ -35,7 +35,7 @@ impl HeaderValidator {
         }
 
         let height = block_header.height - 1;
-        let min_height = height.saturating_sub(
+        let min_height = block_header.height.saturating_sub(
             self.rules
                 .consensus_constants(block_header.height)
                 .get_median_timestamp_count() as u64,

--- a/base_layer/core/src/validation/helpers.rs
+++ b/base_layer/core/src/validation/helpers.rs
@@ -87,6 +87,12 @@ pub fn calc_median_timestamp(timestamps: &[EpochTime]) -> EpochTime {
 
     let mid_index = timestamps.len() / 2;
     let median_timestamp = if timestamps.len() % 2 == 0 {
+        trace!(
+            target: LOG_TARGET,
+            "No median timestamp available, estimating median as avg of [{}] and [{}]",
+            timestamps[mid_index - 1],
+            timestamps[mid_index],
+        );
         (timestamps[mid_index - 1] + timestamps[mid_index]) / 2
     } else {
         timestamps[mid_index]


### PR DESCRIPTION
Description
---
The current code will ask for the last 12 block heights and not 11. This code fixes it to only work on the last 11

Motivation and Context
---
The consensus rules are stated to work on the last 11 blocks and not 12. The current code incorrectly includes a second index.

How Has This Been Tested?
---
Unit tests
