### PR TITLE
fix: invalid forced sync peer now returns configerror

### DIFF
--- a/applications/tari_base_node/src/bootstrap.rs
+++ b/applications/tari_base_node/src/bootstrap.rs
@@ -104,7 +104,8 @@ where B: BlockchainBackend + 'static
             .iter()
             .map(|s| SeedPeer::from_str(s))
             .map(|r| r.map(Peer::from).map(|p| p.node_id))
-            .collect::<Result<Vec<_>, _>>()?;
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| anyhow!("Invalid force sync peer: {:?}", e))?;
 
         debug!(target: LOG_TARGET, "{} sync peer(s) configured", sync_peers.len());
 

--- a/applications/tari_base_node/src/main.rs
+++ b/applications/tari_base_node/src/main.rs
@@ -204,7 +204,6 @@ async fn run_node(node_config: Arc<GlobalConfig>, bootstrap: ConfigBootstrap) ->
     )
     .await
     .map_err(|err| {
-        error!(target: LOG_TARGET, "{}", err);
         for boxed_error in err.chain() {
             if let Some(HiddenServiceControllerError::TorControlPortOffline) =
                 boxed_error.downcast_ref::<HiddenServiceControllerError>()
@@ -220,6 +219,12 @@ async fn run_node(node_config: Arc<GlobalConfig>, bootstrap: ConfigBootstrap) ->
                      127.0.0.1:9051 --log \"notice stdout\" --clientuseipv6 1",
                 );
                 return ExitCodes::TorOffline;
+            }
+
+            // todo: find a better way to do this
+            if boxed_error.to_string().contains("Invalid force sync peer") {
+                println!("Please check your force sync peers configuration");
+                return ExitCodes::ConfigError(boxed_error.to_string());
             }
         }
         ExitCodes::UnknownError


### PR DESCRIPTION
Description
---
Fixed bug which returned an UnknownError instead of a ConfigError for invalid force sync peers.
Remove double print of error.

Output:
```
Running `target\debug\tari_base_node.exe`
Initializing logging according to "C:\\Users\\DMStrider\\.tari\\config\\log4rs_base_node.yml"
Please check your force sync peers configuration
ConfigError("Invalid force sync peer: Invalid public key string")
14:43 ERROR Exiting with code (101): ConfigError("Invalid force sync peer: Invalid public key string")
```
Motivation and Context
---
Previously an UnknownError was reported for invalid force sync peers

How Has This Been Tested?
---
Configuration with invalid force_sync_peers.


