### PR TITLE
fix: stop MTP attack

### DIFF
--- a/applications/tari_mining_node/src/difficulty.rs
+++ b/applications/tari_mining_node/src/difficulty.rs
@@ -75,8 +75,14 @@ impl BlockHeaderSha3 {
             .chain(self.header.total_script_offset.as_bytes())
     }
 
-    pub fn set_timestamp(&mut self, timestamp: u64) {
-        self.timestamp = timestamp;
+    /// This function will update the timestamp of the header, but only if the new timestamp is greater than the current
+    /// one.
+    pub fn set_forward_timestamp(&mut self, timestamp: u64) {
+        // if the timestamp has been advanced by the base_node due to the median time we should not reverse it but we
+        // should only change the timestamp if we move it forward.
+        if timestamp > self.timestamp {
+            self.timestamp = timestamp;
+        }
     }
 
     pub fn random_nonce(&mut self) {
@@ -171,7 +177,7 @@ pub mod test {
             );
             timestamp = timestamp.increase(1);
             core_header.timestamp = timestamp;
-            hasher.set_timestamp(timestamp.as_u64());
+            hasher.set_forward_timestamp(timestamp.as_u64());
         }
     }
 }

--- a/applications/tari_mining_node/src/miner.rs
+++ b/applications/tari_mining_node/src/miner.rs
@@ -209,7 +209,7 @@ pub fn mining_task(
                 info!("Mining thread {} disconnected", miner);
                 return;
             }
-            hasher.set_timestamp(timestamp().seconds as u64);
+            hasher.set_forward_timestamp(timestamp().seconds as u64);
         }
         hasher.inc_nonce();
     }

--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -392,7 +392,7 @@ where T: BlockchainBackend + 'static
                 Ok(NodeCommsResponse::NewBlockTemplate(block_template))
             },
             NodeCommsRequest::GetNewBlock(block_template) => {
-                let block = self.blockchain_db.prepare_block_merkle_roots(block_template).await?;
+                let block = self.blockchain_db.prepare_new_block(block_template).await?;
                 Ok(NodeCommsResponse::NewBlock {
                     success: true,
                     error: None,

--- a/base_layer/core/src/chain_storage/async_db.rs
+++ b/base_layer/core/src/chain_storage/async_db.rs
@@ -154,7 +154,7 @@ impl<B: BlockchainBackend + 'static> AsyncBlockchainDb<B> {
     make_async_fn!(fetch_kernels_by_mmr_position(start: u64, end: u64) -> Vec<TransactionKernel>, "fetch_kernels_by_mmr_position");
 
     //---------------------------------- MMR --------------------------------------------//
-    make_async_fn!(prepare_block_merkle_roots(template: NewBlockTemplate) -> Block, "prepare_block_merkle_roots");
+    make_async_fn!(prepare_new_block(template: NewBlockTemplate) -> Block, "prepare_new_block");
 
     make_async_fn!(fetch_mmr_size(tree: MmrTree) -> u64, "fetch_mmr_size");
 

--- a/base_layer/core/tests/async_db.rs
+++ b/base_layer/core/tests/async_db.rs
@@ -149,7 +149,7 @@ fn async_add_new_block() {
     )
     .0;
 
-    let new_block = db.prepare_block_merkle_roots(new_block).unwrap();
+    let new_block = db.prepare_new_block(new_block).unwrap();
 
     test_async(|rt| {
         let db = AsyncBlockchainDb::new(db);

--- a/base_layer/core/tests/base_node_rpc.rs
+++ b/base_layer/core/tests/base_node_rpc.rs
@@ -182,7 +182,7 @@ async fn test_base_node_wallet_rpc() {
     // Now submit a block with Tx1 in it so that Tx2 is no longer an orphan
     let block1 = base_node
         .blockchain_db
-        .prepare_block_merkle_roots(chain_block(&block0.block(), vec![tx1.clone()], &consensus_manager))
+        .prepare_new_block(chain_block(&block0.block(), vec![tx1.clone()], &consensus_manager))
         .unwrap();
 
     base_node
@@ -229,7 +229,7 @@ async fn test_base_node_wallet_rpc() {
     // Now we will Mine block 2 so that we can see 1 confirmation on tx1
     let mut block2 = base_node
         .blockchain_db
-        .prepare_block_merkle_roots(chain_block(&block1, vec![], &consensus_manager))
+        .prepare_new_block(chain_block(&block1, vec![], &consensus_manager))
         .unwrap();
 
     block2.header.output_mmr_size += 1;

--- a/base_layer/core/tests/chain_storage_tests/chain_storage.rs
+++ b/base_layer/core/tests/chain_storage_tests/chain_storage.rs
@@ -969,7 +969,7 @@ fn handle_reorg_failure_recovery() {
             orphan1_outputs.push(block_utxos);
 
             let template = chain_block(&orphan1_blocks.last().unwrap().block(), txns, &consensus_manager);
-            let mut block = orphan1_store.prepare_block_merkle_roots(template).unwrap();
+            let mut block = orphan1_store.prepare_new_block(template).unwrap();
             block.header.nonce = OsRng.next_u64();
             block.header.height += 1;
             find_header_with_achieved_difficulty(&mut block.header, Difficulty::from(2));

--- a/base_layer/core/tests/helpers/block_builders.rs
+++ b/base_layer/core/tests/helpers/block_builders.rs
@@ -346,7 +346,7 @@ pub fn append_block_with_coinbase<B: BlockchainBackend>(
         height + consensus_manager.consensus_constants(0).coinbase_lock_height(),
     );
     let template = chain_block_with_coinbase(prev_block, txns, coinbase_utxo, coinbase_kernel, consensus_manager);
-    let mut block = db.prepare_block_merkle_roots(template)?;
+    let mut block = db.prepare_new_block(template)?;
     block.header.nonce = OsRng.next_u64();
     find_header_with_achieved_difficulty(&mut block.header, achieved_difficulty);
     let res = db.add_block(Arc::new(block))?;
@@ -455,7 +455,7 @@ pub fn generate_block<B: BlockchainBackend>(
 ) -> Result<BlockAddResult, ChainStorageError> {
     let prev_block = blocks.last().unwrap();
     let template = chain_block_with_new_coinbase(prev_block, transactions, consensus, &CryptoFactories::default()).0;
-    let new_block = db.prepare_block_merkle_roots(template)?;
+    let new_block = db.prepare_new_block(template)?;
     let result = db.add_block(new_block.into());
     if let Ok(BlockAddResult::Ok(ref b)) = result {
         blocks.push(b.as_ref().clone());
@@ -478,7 +478,7 @@ pub fn generate_block_with_achieved_difficulty<B: BlockchainBackend>(
         &CryptoFactories::default(),
     )
     .0;
-    let mut new_block = db.prepare_block_merkle_roots(template)?;
+    let mut new_block = db.prepare_new_block(template)?;
     new_block.header.nonce = OsRng.next_u64();
     find_header_with_achieved_difficulty(&mut new_block.header, achieved_difficulty);
     let result = db.add_block(new_block.into());
@@ -505,7 +505,7 @@ pub fn generate_block_with_coinbase<B: BlockchainBackend>(
         coinbase_kernel,
         consensus,
     );
-    let new_block = db.prepare_block_merkle_roots(template)?;
+    let new_block = db.prepare_new_block(template)?;
     let result = db.add_block(new_block.into())?;
     if let BlockAddResult::Ok(ref b) = result {
         blocks.push(b.as_ref().clone());

--- a/base_layer/core/tests/helpers/pow_blockchain.rs
+++ b/base_layer/core/tests/helpers/pow_blockchain.rs
@@ -65,7 +65,7 @@ pub fn append_to_pow_blockchain<T: BlockchainBackend>(
     let mut prev_block = chain_tip;
     for pow_algo in pow_algos {
         let new_block = chain_block(&prev_block, Vec::new(), consensus_manager);
-        let mut new_block = db.prepare_block_merkle_roots(new_block).unwrap();
+        let mut new_block = db.prepare_new_block(new_block).unwrap();
         new_block.header.timestamp = prev_block.header.timestamp.increase(120);
         new_block.header.pow.pow_algo = pow_algo;
 

--- a/base_layer/core/tests/helpers/test_blockchain.rs
+++ b/base_layer/core/tests/helpers/test_blockchain.rs
@@ -94,7 +94,7 @@ impl TestBlockchain {
             &CryptoFactories::default(),
         );
 
-        let mut new_block = self.store.prepare_block_merkle_roots(template).unwrap();
+        let mut new_block = self.store.prepare_new_block(template).unwrap();
         new_block.header.nonce = OsRng.next_u64();
         find_header_with_achieved_difficulty(&mut new_block.header, block.difficulty.unwrap_or(1).into());
 

--- a/base_layer/core/tests/mempool.rs
+++ b/base_layer/core/tests/mempool.rs
@@ -694,7 +694,7 @@ async fn test_reorg() {
     db.rewind_to_height(2).unwrap();
 
     let template = chain_block(blocks[2].block(), vec![], &consensus_manager);
-    let reorg_block3 = db.prepare_block_merkle_roots(template).unwrap();
+    let reorg_block3 = db.prepare_new_block(template).unwrap();
 
     mempool
         .process_reorg(vec![blocks[3].to_arc_block()], vec![reorg_block3.into()])
@@ -706,7 +706,7 @@ async fn test_reorg() {
 
     // "Mine" block 4
     let template = chain_block(blocks[2].block(), vec![], &consensus_manager);
-    let reorg_block4 = db.prepare_block_merkle_roots(template).unwrap();
+    let reorg_block4 = db.prepare_new_block(template).unwrap();
 
     // test that process_reorg can handle the case when removed_blocks is empty
     // see https://github.com/tari-project/tari/issues/2101#issuecomment-680726940
@@ -1128,7 +1128,7 @@ async fn block_event_and_reorg_event_handling() {
     // These blocks are manually constructed to allow the block event system to be used.
     let empty_block = bob
         .blockchain_db
-        .prepare_block_merkle_roots(chain_block(block0.block(), vec![], &consensus_manager))
+        .prepare_new_block(chain_block(block0.block(), vec![], &consensus_manager))
         .unwrap();
 
     // Add one empty block, so the coinbase UTXO is no longer time-locked.
@@ -1146,7 +1146,7 @@ async fn block_event_and_reorg_event_handling() {
     bob.mempool.insert(Arc::new(tx1.clone())).unwrap();
     let mut block1 = bob
         .blockchain_db
-        .prepare_block_merkle_roots(chain_block(&empty_block, vec![tx1], &consensus_manager))
+        .prepare_new_block(chain_block(&empty_block, vec![tx1], &consensus_manager))
         .unwrap();
     find_header_with_achieved_difficulty(&mut block1.header, Difficulty::from(1));
     // Add Block1 - tx1 will be moved to the ReorgPool.
@@ -1172,13 +1172,13 @@ async fn block_event_and_reorg_event_handling() {
 
     let mut block2a = bob
         .blockchain_db
-        .prepare_block_merkle_roots(chain_block(&block1, vec![tx2a, tx3a], &consensus_manager))
+        .prepare_new_block(chain_block(&block1, vec![tx2a, tx3a], &consensus_manager))
         .unwrap();
     find_header_with_achieved_difficulty(&mut block2a.header, Difficulty::from(1));
     // Block2b also builds on Block1 but has a stronger PoW
     let mut block2b = bob
         .blockchain_db
-        .prepare_block_merkle_roots(chain_block(&block1, vec![tx2b, tx3b], &consensus_manager))
+        .prepare_new_block(chain_block(&block1, vec![tx2b, tx3b], &consensus_manager))
         .unwrap();
     find_header_with_achieved_difficulty(&mut block2b.header, Difficulty::from(10));
 

--- a/base_layer/core/tests/node_service.rs
+++ b/base_layer/core/tests/node_service.rs
@@ -811,7 +811,7 @@ async fn local_submit_block() {
     let mut event_stream = node.local_nci.get_block_event_stream();
     let block0 = db.fetch_block(0).unwrap().block().clone();
     let mut block1 = db
-        .prepare_block_merkle_roots(chain_block(&block0, vec![], &consensus_manager))
+        .prepare_new_block(chain_block(&block0, vec![], &consensus_manager))
         .unwrap();
     block1.header.kernel_mmr_size += 1;
     block1.header.output_mmr_size += 1;

--- a/base_layer/core/tests/node_state_machine.rs
+++ b/base_layer/core/tests/node_state_machine.rs
@@ -112,7 +112,7 @@ async fn test_listening_lagging() {
     let prev_block = append_block(&bob_db, &prev_block, vec![], &consensus_manager, 3.into()).unwrap();
     // Bob Block 2 - with block event and liveness service metadata update
     let mut prev_block = bob_db
-        .prepare_block_merkle_roots(chain_block(&prev_block.block(), vec![], &consensus_manager))
+        .prepare_new_block(chain_block(&prev_block.block(), vec![], &consensus_manager))
         .unwrap();
     prev_block.header.output_mmr_size += 1;
     prev_block.header.kernel_mmr_size += 1;


### PR DESCRIPTION
Description
---
This changes the timestamp of a new block template to be always greater than the median time past (MTP) of the past blocks as per consensus. 

Motivation and Context
---
It is possible for an attack to forward the median time to be greater than now, but less than the future time limit(FTL). This means that all valid blocks with the current timestamp will be rejected. This will ensure that ll newly created blocks always have a timestamp greater than the MTP. Due to consensus we also know that MTP will always be less than FTL. This ensures that all new block timestamps are `MTP < Timestamp < FTL`

For a description see: [Graft network](https://github.com/graft-project/GraftNetwork/pull/118#issuecomment-384599435)
and [MTP Attack (Jagernan)](https://github.com/zawy12/difficulty-algorithms/issues/30)


How Has This Been Tested?
---

All current unit tests pass. 
