### PR TITLE
fix: pressing b key should not clear existing base node in console wallet

### DIFF
--- a/applications/tari_console_wallet/src/ui/components/network_tab.rs
+++ b/applications/tari_console_wallet/src/ui/components/network_tab.rs
@@ -416,15 +416,13 @@ impl<B: Backend> Component<B> for NetworkTab {
                 }
             },
             'b' => {
-                if app_state.get_custom_base_node().is_some() {
-                    self.confirmation_dialog = true;
-                } else {
-                    self.base_node_list_state
-                        .set_num_items(app_state.get_base_node_list().len());
-                    self.base_node_edit_mode = BaseNodeInputMode::Selection;
-                    self.base_node_list_state.select(Some(0));
-                    self.detailed_base_node = app_state.get_base_node_list().get(0).map(|(_, peer)| peer.clone());
-                }
+                self.base_node_list_state
+                    .set_num_items(app_state.get_base_node_list().len());
+                self.base_node_edit_mode = BaseNodeInputMode::Selection;
+                self.base_node_list_state.select_first();
+                if let Some(index) = self.base_node_list_state.selected() {
+                    self.detailed_base_node = app_state.get_base_node_list().get(index).map(|(_, peer)| peer.clone());
+                };
             },
             's' => {
                 // set the currently selected base node as a custom base node


### PR DESCRIPTION
Description
---
Pressing b key should not clear existing base node, it should only activate the selection.
Additional check for selected().

Motivation and Context
---

How Has This Been Tested?
---
Manually