### PR TITLE
fix: relative paths for logs is now relative to data path instead of current execution directory

### DIFF
--- a/common/src/configuration/bootstrap.rs
+++ b/common/src/configuration/bootstrap.rs
@@ -309,7 +309,7 @@ impl ConfigBootstrap {
     /// Set up application-level logging using the Log4rs configuration file
     /// based on supplied CLI arguments
     pub fn initialize_logging(&self) -> Result<(), ConfigError> {
-        if initialize_logging(&self.log_config) {
+        if initialize_logging(&self.log_config, &self.base_path) {
             Ok(())
         } else {
             Err(ConfigError::new("Failed to initialize logging", None))
@@ -513,16 +513,6 @@ mod test {
         // Load and apply configuration file
         let cfg = load_configuration(&bootstrap);
 
-        // Change current dir to test dir so logging can be initialized there and test data can be cleaned up
-        let current_dir = std::env::current_dir().unwrap_or_default();
-        if std::env::set_current_dir(&dir).is_err() {
-            println!(
-                "Logging initialized in {}, could not initialize in {}.",
-                &current_dir.display(),
-                &dir.display()
-            );
-        };
-
         // Initialize logging
         let logging_initialized = bootstrap.initialize_logging().is_ok();
         let log_network_file_exists = std::path::Path::new(&bootstrap.base_path)
@@ -534,16 +524,6 @@ mod test {
         let log_other_file_exists = std::path::Path::new(&bootstrap.base_path)
             .join("log/base-node/other.log")
             .exists();
-
-        // Change back to current dir
-        if std::env::set_current_dir(&current_dir).is_err() {
-            println!(
-                "Working directory could not be changed back to {} after logging has been initialized. New working \
-                 directory is {}",
-                &current_dir.display(),
-                &std::env::current_dir().unwrap_or_default().display()
-            );
-        };
 
         // Cleanup test data
         if std::path::Path::new(&data_path.as_str()).exists() {

--- a/common/src/logging.rs
+++ b/common/src/logging.rs
@@ -26,16 +26,35 @@
 use std::{fs, fs::File, io::Write, path::Path};
 
 /// Set up application-level logging using the Log4rs configuration file specified in
-pub fn initialize_logging(config_file: &Path) -> bool {
+pub fn initialize_logging(config_file: &Path, base_path: &Path) -> bool {
     println!(
         "Initializing logging according to {:?}",
         config_file.to_str().unwrap_or("[??]")
     );
 
+    let current_working_dir = std::env::current_dir().unwrap_or_default();
+
+    if std::env::set_current_dir(&base_path).is_err() {
+        println!(
+            "Logging initialized in {}, could not initialize in {}.",
+            &current_working_dir.display(),
+            &base_path.display()
+        );
+    };
+
     if let Err(e) = log4rs::init_file(config_file, Default::default()) {
         println!("We couldn't load a logging configuration file. {}", e.to_string());
         return false;
     }
+
+    if std::env::set_current_dir(&current_working_dir).is_err() {
+        println!(
+            "Working directory could not be changed back to {} after logging has been initialized. New working \
+             directory is {}",
+            &current_working_dir.display(),
+            &std::env::current_dir().unwrap_or_default().display()
+        );
+    };
 
     // simplelog config - perhaps for future use
     // let config = ConfigBuilder::new()


### PR DESCRIPTION
Description
---
Relative paths for logs is now relative to data path instead of current execution directory

Motivation and Context
---
Logs are now stored in the expected location instead in the current working directory.

How Has This Been Tested?
---
Manually
