### PR TITLE
fix: base node peer updates after being set

### DIFF
--- a/applications/tari_console_wallet/src/ui/components/network_tab.rs
+++ b/applications/tari_console_wallet/src/ui/components/network_tab.rs
@@ -303,32 +303,35 @@ impl NetworkTab {
                         return KeyHandled::Handled;
                     },
                 },
-                BaseNodeInputMode::Address => match c {
-                    '\n' => {
-                        match Handle::current().block_on(
-                            app_state.set_custom_base_node(self.public_key_field.clone(), self.address_field.clone()),
-                        ) {
-                            Ok(peer) => {
-                                self.previous_address_field = self.address_field.clone();
-                                self.previous_public_key_field = self.public_key_field.clone();
-                                self.detailed_base_node = Some(peer);
-                            },
-                            Err(e) => {
-                                warn!(target: LOG_TARGET, "Could not set custom base node peer: {}", e);
-                                self.error_message =
-                                    Some(format!("Error setting new Base Node Address:\n{}", e.to_string()));
-                                self.address_field = self.previous_address_field.clone();
-                                self.public_key_field = self.previous_public_key_field.clone();
-                            },
-                        }
+                BaseNodeInputMode::Address => {
+                    return match c {
+                        '\n' => {
+                            match Handle::current().block_on(
+                                app_state
+                                    .set_custom_base_node(self.public_key_field.clone(), self.address_field.clone()),
+                            ) {
+                                Ok(peer) => {
+                                    self.previous_address_field = self.address_field.clone();
+                                    self.previous_public_key_field = self.public_key_field.clone();
+                                    self.detailed_base_node = Some(peer);
+                                },
+                                Err(e) => {
+                                    warn!(target: LOG_TARGET, "Could not set custom base node peer: {}", e);
+                                    self.error_message =
+                                        Some(format!("Error setting new Base Node Address:\n{}", e.to_string()));
+                                    self.address_field = self.previous_address_field.clone();
+                                    self.public_key_field = self.previous_public_key_field.clone();
+                                },
+                            }
 
-                        self.base_node_edit_mode = BaseNodeInputMode::None;
-                        return KeyHandled::Handled;
-                    },
-                    c => {
-                        self.address_field.push(c);
-                        return KeyHandled::Handled;
-                    },
+                            self.base_node_edit_mode = BaseNodeInputMode::None;
+                            KeyHandled::Handled
+                        },
+                        c => {
+                            self.address_field.push(c);
+                            KeyHandled::Handled
+                        },
+                    }
                 },
                 BaseNodeInputMode::Selection => match c {
                     '\n' => {

--- a/applications/tari_console_wallet/src/ui/state/app_state.rs
+++ b/applications/tari_console_wallet/src/ui/state/app_state.rs
@@ -411,7 +411,7 @@ impl AppState {
     }
 
     pub fn get_required_confirmations(&self) -> u64 {
-        (&self.node_config.transaction_num_confirmations_required).to_owned()
+        self.node_config.transaction_num_confirmations_required
     }
 
     pub fn toggle_abandoned_coinbase_filter(&mut self) {
@@ -570,14 +570,14 @@ impl AppStateInner {
                 let tx = CompletedTransaction::from(tx);
                 if let Some(index) = self.data.pending_txs.iter().position(|i| i.tx_id == tx_id) {
                     if tx.status == TransactionStatus::Pending && !tx.cancelled {
-                        self.data.pending_txs[index] = tx;
+                        self.data.pending_txs[index] = tx.clone();
                         self.updated = true;
                         return Ok(());
                     } else {
                         let _ = self.data.pending_txs.remove(index);
                     }
                 } else if tx.status == TransactionStatus::Pending && !tx.cancelled {
-                    self.data.pending_txs.push(tx);
+                    self.data.pending_txs.push(tx.clone());
                     self.data.pending_txs.sort_by(|a, b| {
                         b.timestamp
                             .partial_cmp(&a.timestamp)
@@ -589,9 +589,9 @@ impl AppStateInner {
                 }
 
                 if let Some(index) = self.data.completed_txs.iter().position(|i| i.tx_id == tx_id) {
-                    self.data.completed_txs[index] = tx;
+                    self.data.completed_txs[index] = tx.clone();
                 } else {
-                    self.data.completed_txs.push(tx);
+                    self.data.completed_txs.push(tx.clone());
                 }
                 self.data.completed_txs.sort_by(|a, b| {
                     b.timestamp

--- a/base_layer/wallet/src/connectivity_service/handle.rs
+++ b/base_layer/wallet/src/connectivity_service/handle.rs
@@ -94,11 +94,10 @@ impl WalletConnectivityHandle {
             .send(WalletConnectivityRequest::ObtainBaseNodeSyncRpcClient(reply_tx))
             .await
             .ok()?;
-
         reply_rx.await.ok()
     }
 
-    pub fn get_connectivity_status(&mut self) -> OnlineStatus {
+    pub fn get_connectivity_status(&self) -> OnlineStatus {
         *self.online_status_rx.borrow()
     }
 
@@ -107,7 +106,7 @@ impl WalletConnectivityHandle {
     }
 
     pub fn get_current_base_node_peer(&self) -> Option<Peer> {
-        self.base_node_watch.borrow().clone()
+        self.base_node_watch.borrow().as_ref().cloned()
     }
 
     pub fn get_current_base_node_id(&self) -> Option<NodeId> {


### PR DESCRIPTION
Description
---
Fixed get_current_base_node_peer() cloning the watch instead of getting a reference to the watch and then cloning the peer.
Fixed some ownership nits in app_state.
Lifted return out of match in BaseNodeInputMode::Address.

Motivation and Context
---

How Has This Been Tested?
---
Manually

![set_base_node_peer](https://user-images.githubusercontent.com/51991544/134022433-83802888-05d0-45c8-8dbd-91f5ef9e3ece.png)

![set_base_node_peer_2](https://user-images.githubusercontent.com/51991544/134022450-fde5a1d5-7682-4a7e-afdd-086240612308.png)

