### PR TITLE
feat: merge consensus breaking changes in #3195 #3193 with weatherwax compatibility

### DIFF
--- a/base_layer/core/src/blocks/block.rs
+++ b/base_layer/core/src/blocks/block.rs
@@ -81,6 +81,10 @@ impl Block {
         Self { header, body }
     }
 
+    pub fn version(&self) -> u16 {
+        self.header.version
+    }
+
     /// This function will calculate the total fees contained in a block
     pub fn calculate_fees(&self) -> MicroTari {
         self.body.kernels().iter().fold(0.into(), |sum, x| sum + x.fee)
@@ -239,7 +243,7 @@ impl BlockBuilder {
             header: self.header,
             body: AggregateBody::new(self.inputs, self.outputs, self.kernels),
         };
-        block.body.sort();
+        block.body.sort(block.header.version);
         block
     }
 }

--- a/base_layer/core/src/blocks/genesis_block.rs
+++ b/base_layer/core/src/blocks/genesis_block.rs
@@ -159,7 +159,7 @@ pub fn get_stibbons_genesis_block_raw() -> Block {
             excess_sig: sig,
         }],
     );
-    body.sort();
+    body.sort(1);
     Block {
         header: BlockHeader {
             version: 0,
@@ -226,7 +226,7 @@ pub fn get_weatherwax_genesis_block_raw() -> Block {
             excess_sig: sig,
         }],
     );
-    body.sort();
+    body.sort(1);
     // set genesis timestamp
     let genesis = DateTime::parse_from_rfc2822("07 Jul 2021 06:00:00 +0200").unwrap();
     let timestamp = genesis.timestamp() as u64;
@@ -336,7 +336,7 @@ pub fn get_ridcully_genesis_block_raw() -> Block {
             excess_sig: sig,
         }],
     );
-    body.sort();
+    body.sort(1);
     Block {
         header: BlockHeader {
             version: 0,
@@ -419,7 +419,7 @@ pub fn get_igor_genesis_block_raw() -> Block {
             excess_sig: sig,
         }],
     );
-    body.sort();
+    body.sort(2);
     // set genesis timestamp
     let genesis = DateTime::parse_from_rfc2822("27 Aug 2021 06:00:00 +0200").unwrap();
     let timestamp = genesis.timestamp() as u64;

--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -66,7 +66,7 @@ use std::{
     collections::VecDeque,
     convert::TryFrom,
     mem,
-    ops::Bound,
+    ops::{Bound, RangeBounds},
     sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard},
     time::Instant,
 };
@@ -75,8 +75,7 @@ use tari_common_types::{
     types::{BlockHash, Commitment, HashDigest, HashOutput, Signature},
 };
 use tari_crypto::tari_utilities::{hex::Hex, ByteArray, Hashable};
-use tari_mmr::{MerkleMountainRange, MutableMmr};
-use uint::static_assertions::_core::ops::RangeBounds;
+use tari_mmr::{pruned_hashset::PrunedHashSet, MerkleMountainRange, MutableMmr};
 
 const LOG_TARGET: &str = "c::cs::database";
 
@@ -995,7 +994,7 @@ pub fn calculate_mmr_roots<T: BlockchainBackend>(db: &T, block: &Block) -> Resul
     let mut kernel_mmr = MerkleMountainRange::<HashDigest, _>::new(kernels);
     let mut output_mmr = MutableMmr::<HashDigest, _>::new(outputs, deleted)?;
     let mut witness_mmr = MerkleMountainRange::<HashDigest, _>::new(range_proofs);
-    let mut input_mmr = MutableMmr::<HashDigest, _>::new(Vec::new(), Bitmap::create())?;
+    let mut input_mmr = MerkleMountainRange::<HashDigest, _>::new(PrunedHashSet::default());
 
     for kernel in body.kernels().iter() {
         kernel_mmr.push(kernel.hash())?;

--- a/base_layer/core/src/consensus/consensus_constants.rs
+++ b/base_layer/core/src/consensus/consensus_constants.rs
@@ -209,7 +209,7 @@ impl ConsensusConstants {
             emission_initial: 5_538_846_115 * uT,
             emission_decay: &EMISSION_DECAY,
             emission_tail: 100.into(),
-            max_randomx_seed_height: std::u64::MAX,
+            max_randomx_seed_height: u64::MAX,
             proof_of_work: algos,
             faucet_value: (5000 * 4000) * T,
         }]
@@ -218,7 +218,7 @@ impl ConsensusConstants {
     pub fn ridcully() -> Vec<Self> {
         let difficulty_block_window = 90;
         let mut algos = HashMap::new();
-        // seting sha3/monero to 40/60 split
+        // setting sha3/monero to 40/60 split
         algos.insert(PowAlgorithm::Sha3, PowAlgorithmConstants {
             max_target_time: 1800,
             min_difficulty: 60_000_000.into(),
@@ -242,7 +242,7 @@ impl ConsensusConstants {
             emission_initial: 5_538_846_115 * uT,
             emission_decay: &EMISSION_DECAY,
             emission_tail: 100.into(),
-            max_randomx_seed_height: std::u64::MAX,
+            max_randomx_seed_height: u64::MAX,
             proof_of_work: algos,
             faucet_value: (5000 * 4000) * T,
         }]
@@ -277,7 +277,7 @@ impl ConsensusConstants {
             target_time: 200,
         });
         let mut algos2 = HashMap::new();
-        // seting sha3/monero to 40/60 split
+        // setting sha3/monero to 40/60 split
         algos2.insert(PowAlgorithm::Sha3, PowAlgorithmConstants {
             max_target_time: 1800,
             min_difficulty: 60_000_000.into(),
@@ -302,7 +302,7 @@ impl ConsensusConstants {
                 emission_initial: 5_538_846_115 * uT,
                 emission_decay: &EMISSION_DECAY,
                 emission_tail: 100.into(),
-                max_randomx_seed_height: std::u64::MAX,
+                max_randomx_seed_height: u64::MAX,
                 proof_of_work: algos,
                 faucet_value: (5000 * 4000) * T,
             },
@@ -317,7 +317,7 @@ impl ConsensusConstants {
                 emission_initial: 5_538_846_115 * uT,
                 emission_decay: &EMISSION_DECAY,
                 emission_tail: 100.into(),
-                max_randomx_seed_height: std::u64::MAX,
+                max_randomx_seed_height: u64::MAX,
                 proof_of_work: algos2,
                 faucet_value: (5000 * 4000) * T,
             },
@@ -326,7 +326,7 @@ impl ConsensusConstants {
 
     pub fn weatherwax() -> Vec<Self> {
         let mut algos = HashMap::new();
-        // seting sha3/monero to 40/60 split
+        // setting sha3/monero to 40/60 split
         algos.insert(PowAlgorithm::Sha3, PowAlgorithmConstants {
             max_target_time: 1800,
             min_difficulty: 60_000_000.into(),
@@ -350,7 +350,7 @@ impl ConsensusConstants {
             emission_initial: 5_538_846_115 * uT,
             emission_decay: &EMISSION_DECAY,
             emission_tail: 100.into(),
-            max_randomx_seed_height: std::u64::MAX,
+            max_randomx_seed_height: u64::MAX,
             proof_of_work: algos,
             faucet_value: (5000 * 4000) * T,
         }]
@@ -358,7 +358,7 @@ impl ConsensusConstants {
 
     pub fn igor() -> Vec<Self> {
         let mut algos = HashMap::new();
-        // seting sha3/monero to 40/60 split
+        // setting sha3/monero to 40/60 split
         algos.insert(PowAlgorithm::Sha3, PowAlgorithmConstants {
             max_target_time: 1800,
             min_difficulty: 60_000_000.into(),
@@ -374,7 +374,7 @@ impl ConsensusConstants {
         vec![ConsensusConstants {
             effective_from_height: 0,
             coinbase_lock_height: 6,
-            blockchain_version: 1,
+            blockchain_version: 2,
             future_time_limit: 540,
             difficulty_block_window: 90,
             max_block_transaction_weight: 19500,
@@ -382,7 +382,7 @@ impl ConsensusConstants {
             emission_initial: 5_538_846_115 * uT,
             emission_decay: &EMISSION_DECAY,
             emission_tail: 100.into(),
-            max_randomx_seed_height: std::u64::MAX,
+            max_randomx_seed_height: u64::MAX,
             proof_of_work: algos,
             faucet_value: (5000 * 4000) * T,
         }]
@@ -415,7 +415,7 @@ impl ConsensusConstants {
             emission_initial: 10_000_000.into(),
             emission_decay: &EMISSION_DECAY,
             emission_tail: 100.into(),
-            max_randomx_seed_height: std::u64::MAX,
+            max_randomx_seed_height: u64::MAX,
             proof_of_work: algos,
             faucet_value: MicroTari::from(0),
         }]

--- a/base_layer/core/src/proto/transaction.rs
+++ b/base_layer/core/src/proto/transaction.rs
@@ -223,8 +223,7 @@ impl TryFrom<proto::types::AggregateBody> for AggregateBody {
         let inputs = try_convert_all(body.inputs)?;
         let outputs = try_convert_all(body.outputs)?;
         let kernels = try_convert_all(body.kernels)?;
-        let mut body = AggregateBody::new(inputs, outputs, kernels);
-        body.sort();
+        let body = AggregateBody::new(inputs, outputs, kernels);
         Ok(body)
     }
 }

--- a/base_layer/core/src/transactions/transaction.rs
+++ b/base_layer/core/src/transactions/transaction.rs
@@ -926,7 +926,7 @@ impl From<CryptoFullRewindResult<BlindingFactor>> for FullRewindResult {
 /// [Mimblewimble TLU post](https://tlu.tarilabs.com/protocols/mimblewimble-1/sources/PITCHME.link.html?highlight=mimblewimble#mimblewimble).
 /// The kernel also tracks other transaction metadata, such as the lock height for the transaction (i.e. the earliest
 /// this transaction can be mined) and the transaction fee, in cleartext.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TransactionKernel {
     /// Options for a kernel's structure or use
     pub features: KernelFeatures,
@@ -1069,6 +1069,18 @@ impl Display for TransactionKernel {
                 .unwrap_or_else(|_| "Failed to serialize signature".into()),
         );
         fmt.write_str(&msg)
+    }
+}
+
+impl PartialOrd for TransactionKernel {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.excess_sig.partial_cmp(&other.excess_sig)
+    }
+}
+
+impl Ord for TransactionKernel {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.excess_sig.cmp(&other.excess_sig)
     }
 }
 

--- a/base_layer/core/src/transactions/transaction.rs
+++ b/base_layer/core/src/transactions/transaction.rs
@@ -947,6 +947,77 @@ impl TransactionKernel {
     pub fn is_coinbase(&self) -> bool {
         self.features.contains(KernelFeatures::COINBASE_KERNEL)
     }
+
+    pub fn verify_signature(&self) -> Result<(), TransactionError> {
+        let excess = self.excess.as_public_key();
+        let r = self.excess_sig.get_public_nonce();
+        let m = TransactionMetadata {
+            lock_height: self.lock_height,
+            fee: self.fee,
+        };
+        let c = build_challenge(r, &m);
+        if self.excess_sig.verify_challenge(excess, &c) {
+            Ok(())
+        } else {
+            Err(TransactionError::InvalidSignatureError(
+                "Verifying kernel signature".to_string(),
+            ))
+        }
+    }
+
+    /// This method was used to sort kernels. It has been replaced, and will be removed in future
+    pub fn deprecated_cmp(&self, other: &Self) -> Ordering {
+        self.features
+            .cmp(&other.features)
+            .then(self.fee.cmp(&other.fee))
+            .then(self.lock_height.cmp(&other.lock_height))
+            .then(self.excess.cmp(&other.excess))
+            .then(self.excess_sig.cmp(&other.excess_sig))
+    }
+}
+
+impl Hashable for TransactionKernel {
+    /// Produce a canonical hash for a transaction kernel. The hash is given by
+    /// $$ H(feature_bits | fee | lock_height | P_excess | R_sum | s_sum)
+    fn hash(&self) -> Vec<u8> {
+        HashDigest::new()
+            .chain(&[self.features.bits])
+            .chain(u64::from(self.fee).to_le_bytes())
+            .chain(self.lock_height.to_le_bytes())
+            .chain(self.excess.as_bytes())
+            .chain(self.excess_sig.get_public_nonce().as_bytes())
+            .chain(self.excess_sig.get_signature().as_bytes())
+            .finalize()
+            .to_vec()
+    }
+}
+
+impl Display for TransactionKernel {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        let msg = format!(
+            "Fee: {}\nLock height: {}\nFeatures: {:?}\nExcess: {}\nExcess signature: {}\n",
+            self.fee,
+            self.lock_height,
+            self.features,
+            self.excess.to_hex(),
+            self.excess_sig
+                .to_json()
+                .unwrap_or_else(|_| "Failed to serialize signature".into()),
+        );
+        fmt.write_str(&msg)
+    }
+}
+
+impl PartialOrd for TransactionKernel {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.excess_sig.partial_cmp(&other.excess_sig)
+    }
+}
+
+impl Ord for TransactionKernel {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.excess_sig.cmp(&other.excess_sig)
+    }
 }
 
 /// A version of Transaction kernel with optional fields. This struct is only used in constructing transaction kernels
@@ -1021,69 +1092,6 @@ impl Default for KernelBuilder {
     }
 }
 
-impl TransactionKernel {
-    pub fn verify_signature(&self) -> Result<(), TransactionError> {
-        let excess = self.excess.as_public_key();
-        let r = self.excess_sig.get_public_nonce();
-        let m = TransactionMetadata {
-            lock_height: self.lock_height,
-            fee: self.fee,
-        };
-        let c = build_challenge(r, &m);
-        if self.excess_sig.verify_challenge(excess, &c) {
-            Ok(())
-        } else {
-            Err(TransactionError::InvalidSignatureError(
-                "Verifying kernel signature".to_string(),
-            ))
-        }
-    }
-}
-
-impl Hashable for TransactionKernel {
-    /// Produce a canonical hash for a transaction kernel. The hash is given by
-    /// $$ H(feature_bits | fee | lock_height | P_excess | R_sum | s_sum)
-    fn hash(&self) -> Vec<u8> {
-        HashDigest::new()
-            .chain(&[self.features.bits])
-            .chain(u64::from(self.fee).to_le_bytes())
-            .chain(self.lock_height.to_le_bytes())
-            .chain(self.excess.as_bytes())
-            .chain(self.excess_sig.get_public_nonce().as_bytes())
-            .chain(self.excess_sig.get_signature().as_bytes())
-            .finalize()
-            .to_vec()
-    }
-}
-
-impl Display for TransactionKernel {
-    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
-        let msg = format!(
-            "Fee: {}\nLock height: {}\nFeatures: {:?}\nExcess: {}\nExcess signature: {}\n",
-            self.fee,
-            self.lock_height,
-            self.features,
-            self.excess.to_hex(),
-            self.excess_sig
-                .to_json()
-                .unwrap_or_else(|_| "Failed to serialize signature".into()),
-        );
-        fmt.write_str(&msg)
-    }
-}
-
-impl PartialOrd for TransactionKernel {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.excess_sig.partial_cmp(&other.excess_sig)
-    }
-}
-
-impl Ord for TransactionKernel {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.excess_sig.cmp(&other.excess_sig)
-    }
-}
-
 /// This struct holds the result of calculating the sum of the kernels in a Transaction
 /// and returns the summed commitments and the total fees
 #[derive(Default)]
@@ -1119,12 +1127,10 @@ impl Transaction {
         kernels: Vec<TransactionKernel>,
         offset: BlindingFactor,
         script_offset: BlindingFactor,
-    ) -> Transaction {
-        let mut body = AggregateBody::new(inputs, outputs, kernels);
-        body.sort();
-        Transaction {
+    ) -> Self {
+        Self {
             offset,
-            body,
+            body: AggregateBody::new(inputs, outputs, kernels),
             script_offset,
         }
     }

--- a/base_layer/core/src/transactions/transaction_protocol/sender.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/sender.rs
@@ -20,17 +20,6 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::fmt;
-
-use digest::Digest;
-use serde::{Deserialize, Serialize};
-use tari_crypto::{
-    keys::PublicKey as PublicKeyTrait,
-    ristretto::pedersen::{PedersenCommitment, PedersenCommitmentFactory},
-    script::TariScript,
-    tari_utilities::ByteArray,
-};
-
 use crate::transactions::{
     crypto_factories::CryptoFactories,
     tari_amount::*,
@@ -55,7 +44,16 @@ use crate::transactions::{
         TransactionProtocolError as TPE,
     },
 };
+use digest::Digest;
+use serde::{Deserialize, Serialize};
+use std::fmt;
 use tari_common_types::types::{BlindingFactor, ComSignature, PrivateKey, PublicKey, RangeProofService, Signature};
+use tari_crypto::{
+    keys::PublicKey as PublicKeyTrait,
+    ristretto::pedersen::{PedersenCommitment, PedersenCommitmentFactory},
+    script::TariScript,
+    tari_utilities::ByteArray,
+};
 
 //----------------------------------------   Local Data types     ----------------------------------------------------//
 

--- a/base_layer/core/src/validation/block_validators/orphan.rs
+++ b/base_layer/core/src/validation/block_validators/orphan.rs
@@ -81,10 +81,10 @@ impl OrphanValidation for OrphanBlockValidator {
             "Checking duplicate inputs and outputs on {}",
             block_id
         );
-        check_sorting_and_duplicates(&block.body)?;
+        check_sorting_and_duplicates(&block)?;
         trace!(
             target: LOG_TARGET,
-            "SV - No duplicate inputs or outputs for {} ",
+            "SV - No duplicate inputs / outputs for {} ",
             &block_id
         );
 

--- a/base_layer/core/src/validation/error.rs
+++ b/base_layer/core/src/validation/error.rs
@@ -71,6 +71,8 @@ pub enum ValidationError {
     UnsortedOrDuplicateInput,
     #[error("Duplicate or unsorted output found in block body")]
     UnsortedOrDuplicateOutput,
+    #[error("Duplicate or unsorted kernel found in block body")]
+    UnsortedOrDuplicateKernel,
     #[error("Error in merge mine data:{0}")]
     MergeMineError(#[from] MergeMineError),
     #[error("Contains an input with an invalid mined-height in body")]

--- a/base_layer/core/tests/block_validation.rs
+++ b/base_layer/core/tests/block_validation.rs
@@ -482,7 +482,6 @@ OutputFeatures::default()),
         unblinded_utxo2.as_transaction_input(&factories.commitment).unwrap(),
     ];
     new_block.body = AggregateBody::new(inputs, template.body.outputs().clone(), template.body.kernels().clone());
-    new_block.body.sort();
     new_block.header.nonce = OsRng.next_u64();
 
     find_header_with_achieved_difficulty(&mut new_block.header, 10.into());
@@ -513,7 +512,6 @@ OutputFeatures::default()),
     // signatures.
     let inputs = vec![new_block.body.inputs()[0].clone(), new_block.body.inputs()[0].clone()];
     new_block.body = AggregateBody::new(inputs, template.body.outputs().clone(), template.body.kernels().clone());
-    new_block.body.sort();
     new_block.header.nonce = OsRng.next_u64();
 
     find_header_with_achieved_difficulty(&mut new_block.header, 10.into());
@@ -769,7 +767,6 @@ async fn test_block_sync_body_validator() {
         unblinded_utxo2.as_transaction_input(&factories.commitment).unwrap(),
     ];
     new_block.body = AggregateBody::new(inputs, template.body.outputs().clone(), template.body.kernels().clone());
-    new_block.body.sort();
     validator.validate_body(new_block).await.unwrap_err();
 
     // lets check duplicate txos
@@ -779,7 +776,6 @@ async fn test_block_sync_body_validator() {
     // signatures.
     let inputs = vec![new_block.body.inputs()[0].clone(), new_block.body.inputs()[0].clone()];
     new_block.body = AggregateBody::new(inputs, template.body.outputs().clone(), template.body.kernels().clone());
-    new_block.body.sort();
     validator.validate_body(new_block).await.unwrap_err();
 
     // let break coinbase value

--- a/base_layer/core/tests/helpers/block_builders.rs
+++ b/base_layer/core/tests/helpers/block_builders.rs
@@ -154,7 +154,7 @@ pub fn create_genesis_block(
 fn update_genesis_block_mmr_roots(template: NewBlockTemplate) -> Result<Block, ChainStorageError> {
     let NewBlockTemplate { header, mut body, .. } = template;
     // Make sure the body components are sorted. If they already are, this is a very cheap call.
-    body.sort();
+    body.sort(header.version);
     let kernel_hashes: Vec<HashOutput> = body.kernels().iter().map(|k| k.hash()).collect();
     let out_hashes: Vec<HashOutput> = body.outputs().iter().map(|out| out.hash()).collect();
     let rp_hashes: Vec<HashOutput> = body.outputs().iter().map(|out| out.witness_hash()).collect();

--- a/base_layer/core/tests/node_service.rs
+++ b/base_layer/core/tests/node_service.rs
@@ -716,7 +716,9 @@ async fn local_get_new_block_with_zero_conf() {
     );
     block_template.body.add_kernel(kernel);
     block_template.body.add_output(output);
-    block_template.body.sort();
+    block_template
+        .body
+        .sort(rules.consensus_constants(0).blockchain_version());
     let block = node.local_nci.get_new_block(block_template.clone()).await.unwrap();
     assert_eq!(block.header.height, 1);
     assert_eq!(block.body, block_template.body);
@@ -788,7 +790,9 @@ async fn local_get_new_block_with_combined_transaction() {
     );
     block_template.body.add_kernel(kernel);
     block_template.body.add_output(output);
-    block_template.body.sort();
+    block_template
+        .body
+        .sort(rules.consensus_constants(0).blockchain_version());
     let block = node.local_nci.get_new_block(block_template.clone()).await.unwrap();
     assert_eq!(block.header.height, 1);
     assert_eq!(block.body, block_template.body);


### PR DESCRIPTION
Description
---
Block v1 (compatible with weatherwax at all heights):
- Kernel ordering using every kernel field
- Input MR commits to empty serialization of bitmap

Block v2 (Igor, breaking change)
- Kernel ordering (#3193)
- Input MR uses input hashes only without extaneous empty bitmap bytes
  (#3195)

Misc

- Add missing kernel order block validation
- Removed unnecessary transaction body sorting in wallet, it (still) is the responsibility of the GetNewBlockTemplate to assemble a final sorted block body.

Motivation and Context
---
Allow consensus breaking code to be merged without hard forking weatherwax. 
Igor will have to be reset.

To follow in subsequent PR: network breaking changes from DHT header malleability fix (#3243 ) 

How Has This Been Tested?
---
Archival sync weatherwax node from scratch, received propagated blocks
Washing machine between two weatherwax wallets