### PR TITLE
fix: fix console wallet tick events endless loop edge case at shutdown

### DIFF
--- a/applications/tari_console_wallet/src/utils/crossterm_events.rs
+++ b/applications/tari_console_wallet/src/utils/crossterm_events.rs
@@ -70,8 +70,10 @@ impl CrosstermEvents {
                 ) {
                     Ok(true) => {
                         if let Ok(CEvent::Key(key)) = event::read() {
-                            if let Err(e) = tx.send(Event::Input(key)) {
-                                warn!(target: LOG_TARGET, "Error sending Tick event on MPSC channel: {}", e);
+                            if tx.send(Event::Input(key)).is_err() {
+                                info!(target: LOG_TARGET, "Tick event channel shutting down");
+                                // A send operation can only fail if the receiving end of a channel is disconnected.
+                                break;
                             }
                         }
                     },
@@ -81,8 +83,10 @@ impl CrosstermEvents {
                     },
                 }
                 if last_tick.elapsed() >= config.tick_rate {
-                    if let Err(e) = tx.send(Event::Tick) {
-                        warn!(target: LOG_TARGET, "Error sending Tick event on MPSC channel: {}", e);
+                    if tx.send(Event::Tick).is_err() {
+                        info!(target: LOG_TARGET, "Tick event channel shutting down");
+                        // A send operation can only fail if the receiving end of a channel is disconnected.
+                        break;
                     }
                     last_tick = Instant::now();
                 }


### PR DESCRIPTION

Description
---
Fixed an edge case with console wallet shutdown where the tick events send loop will continue to send key or tick events after the receiver part of the channel has been closed. From the documentation: _"A send operation can only fail if the receiving end of a channel is disconnected."_ The tick event sending loop is now exited if the receiver channel has been closed.

Motivation and Context
---
It was found with system-level testing that with shutdown some times multiple key or tick events are being sent on a closed receiver channel and prevents the wallet from shutting down cleanly.

How Has This Been Tested?
---
System-level testing.
