### PR TITLE
chore: bundle sqlite by default for tests

### DIFF
--- a/base_layer/wallet/Cargo.toml
+++ b/base_layer/wallet/Cargo.toml
@@ -55,6 +55,6 @@ env_logger = "0.7.1"
 prost = "0.8.0"
 
 [features]
-c_integration = []
+default=["bundled_sqlite"]
 avx2 = ["tari_crypto/avx2", "tari_core/avx2"]
 bundled_sqlite = ["libsqlite3-sys"]

--- a/base_layer/wallet_ffi/Cargo.toml
+++ b/base_layer/wallet_ffi/Cargo.toml
@@ -7,13 +7,13 @@ version = "0.18.6"
 edition = "2018"
 
 [dependencies]
-tari_comms = { version = "^0.10", path = "../../comms", features = ["c_integration"]}
+tari_comms = { version = "^0.10", path = "../../comms" }
 tari_comms_dht = { version = "^0.10", path = "../../comms/dht", default-features = false }
 tari_common_types = {path="../common_types"}
 tari_crypto = "0.11.1"
 tari_key_manager = { version = "^0.10", path = "../key_manager" }
 tari_p2p = { version = "^0.10", path = "../p2p" }
-tari_wallet = { version = "^0.10", path = "../wallet", features = ["c_integration"]}
+tari_wallet = { version = "^0.10", path = "../wallet", default-features = false }
 tari_shutdown = { version = "^0.10", path = "../../infrastructure/shutdown" }
 tari_utilities = "^0.3"
 
@@ -34,6 +34,11 @@ features = ["transactions"]
 
 [lib]
 crate-type = ["staticlib","cdylib"]
+
+[features]
+default = ["bundled_sqlite", "bundled_openssl"]
+bundled_openssl= [ "tari_comms/bundled_openssl"]
+bundled_sqlite = ["tari_wallet/bundled_sqlite"]
 
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/base_layer/wallet_ffi/mobile_build.sh
+++ b/base_layer/wallet_ffi/mobile_build.sh
@@ -79,7 +79,7 @@ if [ -n "${DEPENDENCIES}" ] && [ -n "${PKG_PATH}" ] && [ "${BUILD_IOS}" -eq 1 ] 
   export PKG_CONFIG_PATH=${PKG_PATH}
   # shellcheck disable=SC2028
   echo "\t${CYAN}Building Wallet FFI${NC}"
-  cargo-lipo lipo --release > "${IOS_LOG_PATH}/cargo.txt" 2>&1
+  cargo-lipo lipo --release --no-default-features > "${IOS_LOG_PATH}/cargo.txt" 2>&1
   cd ../..
   cd target || exit
   # Copy the fat library (which contains symbols for all built iOS architectures) created by the lipo tool
@@ -392,7 +392,7 @@ EOF
       if [ "${MACHINE}" == "Mac" ]; then
         if [ "${MAC_MAIN_VERSION}" -le 10 ]; then
           if [ "${MAC_SUB_VERSION}" -ge 15 ]; then
-            cargo build --lib --release > "${ANDROID_LOG_PATH}/cargo_${PLATFORMABI}_${LEVEL}.txt" 2>&1
+            cargo build --lib --release --no-default-features > "${ANDROID_LOG_PATH}/cargo_${PLATFORMABI}_${LEVEL}.txt" 2>&1
           else
             cargo ndk --target ${PLATFORMABI} --android-platform ${LEVEL} -- build --release > "${ANDROID_LOG_PATH}/cargo_${PLATFORMABI}_${LEVEL}.txt" 2>&1
           fi

--- a/base_layer/wallet_ffi/mobile_build.sh
+++ b/base_layer/wallet_ffi/mobile_build.sh
@@ -394,7 +394,7 @@ EOF
           if [ "${MAC_SUB_VERSION}" -ge 15 ]; then
             cargo build --lib --release --no-default-features > "${ANDROID_LOG_PATH}/cargo_${PLATFORMABI}_${LEVEL}.txt" 2>&1
           else
-            cargo ndk --target ${PLATFORMABI} --android-platform ${LEVEL} -- build --release > "${ANDROID_LOG_PATH}/cargo_${PLATFORMABI}_${LEVEL}.txt" 2>&1
+            cargo ndk --target ${PLATFORMABI} --android-platform ${LEVEL} -- build --release --no-default-features > "${ANDROID_LOG_PATH}/cargo_${PLATFORMABI}_${LEVEL}.txt" 2>&1
           fi
         else
           # Fix for lmdb-sys compilation for armv7 on Big Sur
@@ -405,7 +405,7 @@ EOF
             # shellcheck disable=SC2028
             echo "\t${CYAN}Extraction complete, continuing build ${NC}"
           fi
-          cargo build --lib --release > "${ANDROID_LOG_PATH}/cargo_${PLATFORMABI}_${LEVEL}.txt" 2>&1
+          cargo build --lib --release --no-default-features > "${ANDROID_LOG_PATH}/cargo_${PLATFORMABI}_${LEVEL}.txt" 2>&1
           if [ "${PLATFORMABI}" == "armv7-linux-androideabi" ]; then
             BACKTRACK=${PWD}
             # shellcheck disable=SC2028
@@ -416,7 +416,7 @@ EOF
           fi
         fi
       else
-        cargo ndk --target ${PLATFORMABI} --android-platform ${LEVEL} -- build --release > "${ANDROID_LOG_PATH}/cargo_${PLATFORMABI}_${LEVEL}.txt" 2>&1
+        cargo ndk --target ${PLATFORMABI} --android-platform ${LEVEL} -- build --release --no-default-features > "${ANDROID_LOG_PATH}/cargo_${PLATFORMABI}_${LEVEL}.txt" 2>&1
       fi
       cp wallet.h "${DEPENDENCIES}/"
       rm -rf .cargo

--- a/comms/Cargo.toml
+++ b/comms/Cargo.toml
@@ -65,6 +65,6 @@ tempfile = "3.1.0"
 tari_common = { version = "^0.10", path = "../common", features = ["build"] }
 
 [features]
-c_integration = []
+bundled_openssl = ["openssl-sys/vendored"]
 avx2 = ["tari_crypto/avx2"]
 rpc = ["tower-make"]


### PR DESCRIPTION
Description
---
Yet another attempt at bundling openssl and sqlite for easy debugging/testing on Windows

Motivation and Context
---
The current feature setup means that you cannot run `cargo test` in the `wallet_ffi` or any specific folder other than the root. I tried to follow the same way that other crates do this, but allowing a user to optionally specify whether a dependency is bundled or not, and not bundle it by default, but this makes running individual tests difficult. 

Since tests are run regularly, I made the default on wallet_ffi include the bundles, but then added `--no-default-features` to the mobile builds 

How Has This Been Tested?
---
Cargo test
