### PR TITLE
test: fix brokend test and remove @broken

### DIFF
--- a/integration_tests/features/StressTest.feature
+++ b/integration_tests/features/StressTest.feature
@@ -5,12 +5,12 @@ Feature: Stress Test
         Given I have a seed node NODE1
         And I have stress-test wallet WALLET_A connected to the seed node NODE1 with broadcast monitoring timeout <MonitoringTimeout>
         And I have a merge mining proxy PROXY connected to NODE1 and WALLET_A with default config
-            # We mine some blocks before starting the other nodes to avoid a spinning sync state when all the nodes are at height 0
+        # We mine some blocks before starting the other nodes to avoid a spinning sync state when all the nodes are at height 0
         When I merge mine 6 blocks via PROXY
         And I have a seed node NODE2
         And I have <NumNodes> base nodes connected to all seed nodes
         And I have stress-test wallet WALLET_B connected to the seed node NODE2 with broadcast monitoring timeout <MonitoringTimeout>
-            # There need to be at least as many mature coinbase UTXOs in the wallet coin splits required for the number of transactions
+        # There need to be at least as many mature coinbase UTXOs in the wallet coin splits required for the number of transactions
         When I merge mine <NumCoinsplitsNeeded> blocks via PROXY
         Then all nodes are on the same chain tip
         When I wait for wallet WALLET_A to have at least 5100000000 uT
@@ -21,29 +21,29 @@ Feature: Stress Test
         Then all nodes are on the same chain tip
         Then wallet WALLET_A detects all transactions as Mined_Confirmed
         When I send <NumTransactions> transactions of 1111 uT each from wallet WALLET_A to wallet WALLET_B at fee_per_gram 20
-            # Mine enough blocks for the first block of transactions to be confirmed.
+        # Mine enough blocks for the first block of transactions to be confirmed.
         When I merge mine 4 blocks via PROXY
         Then all nodes are on the same chain tip
-            # Now wait until all transactions are detected as confirmed in WALLET_A, continue to mine blocks if transactions
-            # are not found to be confirmed as sometimes the previous mining occurs faster than transactions are submitted
-            # to the mempool
+        # Now wait until all transactions are detected as confirmed in WALLET_A, continue to mine blocks if transactions
+        # are not found to be confirmed as sometimes the previous mining occurs faster than transactions are submitted
+        # to the mempool
         Then while merge mining via PROXY all transactions in wallet WALLET_A are found to be Mined_Confirmed
-            # Then wallet WALLET_B detects all transactions as Mined_Confirmed
+        # Then wallet WALLET_B detects all transactions as Mined_Confirmed
         Then while mining via NODE1 all transactions in wallet WALLET_B are found to be Mined_Confirmed
         Examples:
-            | NumTransactions   | NumCoinsplitsNeeded   | NumNodes  | MonitoringTimeout |
-            | 10                | 1                     | 3         | 10                |
-            | 100               | 1                     | 3         | 10                |
+            | NumTransactions | NumCoinsplitsNeeded | NumNodes | MonitoringTimeout |
+            | 10              | 1                   | 3        | 10                |
+            | 100             | 1                   | 3        | 10                |
 
         @long-running
         Examples:
-            | NumTransactions   | NumCoinsplitsNeeded   | NumNodes  | MonitoringTimeout |
-            | 1000              | 3                     | 3         | 60                |
+            | NumTransactions | NumCoinsplitsNeeded | NumNodes | MonitoringTimeout |
+            | 1000            | 3                   | 3        | 60                |
 
-        @long-running @broken
+        @long-running
         Examples:
-            | NumTransactions   | NumCoinsplitsNeeded   | NumNodes  | MonitoringTimeout |
-            | 10000             | 21                    | 3         | 300               |
+            | NumTransactions | NumCoinsplitsNeeded | NumNodes | MonitoringTimeout |
+            | 10000           | 21                  | 3        | 600               |
 
     @long-running
     Scenario: Simple Stress Test
@@ -54,26 +54,26 @@ Feature: Stress Test
         And I have a seed node NODE2
         And I have 1 base nodes connected to all seed nodes
         And I have stress-test wallet WALLET_B connected to the seed node NODE2 with broadcast monitoring timeout 60
-            # We need to ensure the coinbase lock heights are reached; mine enough blocks
-            # The following line is how you could mine directly on the node
+        # We need to ensure the coinbase lock heights are reached; mine enough blocks
+        # The following line is how you could mine directly on the node
         When I merge mine 8 blocks via PROXY
         Then all nodes are at current tip height
         When I wait for wallet WALLET_A to have at least 15100000000 uT
 
         Then I coin split tari in wallet WALLET_A to produce 2000 UTXOs of 5000 uT each with fee_per_gram 20 uT
 
-            # Make sure enough blocks are mined for the coin split transaction to be confirmed
+        # Make sure enough blocks are mined for the coin split transaction to be confirmed
         When I merge mine 8 blocks via PROXY
 
         Then all nodes are at current tip height
         Then wallet WALLET_A detects all transactions as Mined_Confirmed
         When I send 2000 transactions of 1111 uT each from wallet WALLET_A to wallet WALLET_B at fee_per_gram 20
-            # Mine enough blocks for the first block of transactions to be confirmed.
+        # Mine enough blocks for the first block of transactions to be confirmed.
         When I merge mine 4 blocks via PROXY
         Then all nodes are at current tip height
-            # Now wait until all transactions are detected as confirmed in WALLET_A, continue to mine blocks if transactions
-            # are not found to be confirmed as sometimes the previous mining occurs faster than transactions are submitted
-            # to the mempool
+        # Now wait until all transactions are detected as confirmed in WALLET_A, continue to mine blocks if transactions
+        # are not found to be confirmed as sometimes the previous mining occurs faster than transactions are submitted
+        # to the mempool
         Then while merge mining via PROXY all transactions in wallet WALLET_A are found to be Mined_Confirmed
-            # Then wallet WALLET_B detects all transactions as Mined_Confirmed
+        # Then wallet WALLET_B detects all transactions as Mined_Confirmed
         Then while mining via NODE1 all transactions in wallet WALLET_B are found to be Mined_Confirmed


### PR DESCRIPTION
Description
---
I've monitored the test and it was not stuck, it was just unlucky that one of the transaction was going to be processed last. Because they are not processed in the same order as we are checking them. I've doubled the timeout value.

How Has This Been Tested?
---
Manually.

