### PR TITLE
chore: update tokio to 1.10 and add config section

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4861,7 +4861,8 @@ dependencies = [
  "tari_shutdown",
  "tari_test_utils 0.8.1",
  "thiserror",
- "tokio 0.2.25",
+ "tokio 1.11.0",
+ "tokio-stream",
  "tonic",
  "tonic-build",
 ]
@@ -5407,7 +5408,6 @@ dependencies = [
  "num_cpus",
  "pin-project-lite 0.1.12",
  "slab",
- "tokio-macros 0.2.6",
 ]
 
 [[package]]
@@ -5425,7 +5425,7 @@ dependencies = [
  "once_cell",
  "pin-project-lite 0.2.7",
  "signal-hook-registry",
- "tokio-macros 1.3.0",
+ "tokio-macros",
  "winapi 0.3.9",
 ]
 
@@ -5437,17 +5437,6 @@ checksum = "90c49f106be240de154571dd31fbe48acb10ba6c6dd6f6517ad603abffa42de9"
 dependencies = [
  "pin-project-lite 0.2.7",
  "tokio 1.11.0",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a"
-dependencies = [
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "syn 1.0.75",
 ]
 
 [[package]]

--- a/applications/tari_dan_node/Cargo.toml
+++ b/applications/tari_dan_node/Cargo.toml
@@ -22,7 +22,8 @@ tari_mmr = {path = "../../base_layer/mmr"}
 thiserror = "^1.0.20"
 log = { version = "0.4.8", features = ["std"] }
 anyhow = "1.0.32"
-tokio = { version="0.2.10", features = ["macros", "sync", "time"]}
+tokio = { version="1.10", features = ["macros", "time"]}
+tokio-stream = { version = "0.1.7", features = ["sync"] }
 tonic = "0.5.2"
 prost = "0.8"
 prost-types = "0.8"

--- a/applications/tari_dan_node/proto/dan_node.proto
+++ b/applications/tari_dan_node/proto/dan_node.proto
@@ -41,7 +41,7 @@ message ExecuteInstructionRequest{
     bytes asset_public_key =1;
     string method =2;
     repeated bytes args = 3;
-    bytes from = 4;
+    bytes token_id = 4;
     bytes signature = 5;
     uint64 id = 6;
 }

--- a/applications/tari_dan_node/src/dan_layer/workers/states/commit_state.rs
+++ b/applications/tari_dan_node/src/dan_layer/workers/states/commit_state.rs
@@ -41,7 +41,7 @@ use crate::{
     digital_assets_error::DigitalAssetError,
 };
 use std::{any::Any, collections::HashMap, marker::PhantomData, time::Instant};
-use tokio::time::{delay_for, Duration};
+use tokio::time::{sleep, Duration};
 
 // TODO: This is very similar to pre-commit state
 pub struct CommitState<TAddr, TPayload, TInboundConnectionService, TOutboundService, TSigningService>
@@ -121,7 +121,7 @@ where
                               }
 
                               }
-                      _ = delay_for(timeout.saturating_sub(Instant::now() - started)) =>  {
+                      _ = sleep(timeout.saturating_sub(Instant::now() - started)) =>  {
                                     // TODO: perhaps this should be from the time the state was entered
                                     next_event_result = ConsensusWorkerStateEvent::TimedOut;
                                     break;

--- a/applications/tari_dan_node/src/dan_layer/workers/states/decide_state.rs
+++ b/applications/tari_dan_node/src/dan_layer/workers/states/decide_state.rs
@@ -42,7 +42,7 @@ use crate::{
     digital_assets_error::DigitalAssetError,
 };
 use std::{any::Any, collections::HashMap, marker::PhantomData, time::Instant};
-use tokio::time::{delay_for, Duration};
+use tokio::time::{sleep, Duration};
 
 // TODO: This is very similar to pre-commit, and commit state
 pub struct DecideState<TAddr, TPayload, TInboundConnectionService, TOutboundService, TSigningService, TPayloadProcessor>
@@ -127,7 +127,7 @@ where
                               }
 
                               }
-                      _ = delay_for(timeout.saturating_sub(Instant::now() - started)) =>  {
+                      _ = sleep(timeout.saturating_sub(Instant::now() - started)) =>  {
                                     // TODO: perhaps this should be from the time the state was entered
                                     next_event_result = ConsensusWorkerStateEvent::TimedOut;
                                     break;

--- a/applications/tari_dan_node/src/dan_layer/workers/states/pre_commit_state.rs
+++ b/applications/tari_dan_node/src/dan_layer/workers/states/pre_commit_state.rs
@@ -41,7 +41,7 @@ use crate::{
     digital_assets_error::DigitalAssetError,
 };
 use std::{any::Any, collections::HashMap, marker::PhantomData, time::Instant};
-use tokio::time::{delay_for, Duration};
+use tokio::time::{sleep, Duration};
 
 pub struct PreCommitState<TAddr, TPayload, TInboundConnectionService, TOutboundService, TSigningService>
 where
@@ -118,7 +118,7 @@ where
                               }
 
                               }
-                      _ = delay_for(timeout.saturating_sub(Instant::now() - started)) =>  {
+                      _ = sleep(timeout.saturating_sub(Instant::now() - started)) =>  {
                                     // TODO: perhaps this should be from the time the state was entered
                                     next_event_result = ConsensusWorkerStateEvent::TimedOut;
                                     break;

--- a/applications/tari_dan_node/src/dan_layer/workers/states/prepare.rs
+++ b/applications/tari_dan_node/src/dan_layer/workers/states/prepare.rs
@@ -56,7 +56,7 @@ use std::{
     time::Instant,
 };
 use tari_shutdown::{Shutdown, ShutdownSignal};
-use tokio::time::{delay_for, Duration};
+use tokio::time::{sleep, Duration};
 
 pub struct Prepare<TInboundConnectionService, TOutboundService, TAddr, TSigningService, TPayloadProvider, TPayload>
 where
@@ -135,7 +135,7 @@ where
                     }
 
                 },
-                _ = delay_for(timeout.saturating_sub(Instant::now() - started)) =>  {
+                _ = sleep(timeout.saturating_sub(Instant::now() - started)) =>  {
                     // TODO: perhaps this should be from the time the state was entered
                     next_event_result = ConsensusWorkerStateEvent::TimedOut;
                     break;
@@ -265,7 +265,7 @@ where
         payload_provider: &TPayloadProvider,
     ) -> Result<HotStuffTreeNode<TPayload>, DigitalAssetError> {
         // TODO: Artificial delay here to set the block time
-        delay_for(Duration::from_secs(3)).await;
+        sleep(Duration::from_secs(3)).await;
 
         let payload = payload_provider.create_payload()?;
         dbg!(&payload);

--- a/applications/tari_dan_node/src/grpc/dan_grpc_server.rs
+++ b/applications/tari_dan_node/src/grpc/dan_grpc_server.rs
@@ -65,7 +65,7 @@ impl<TMempoolService: MempoolService + Clone + Sync + Send + 'static> dan_rpc::d
                 .map_err(|err| Status::invalid_argument("asset_public_key was not a valid public key"))?,
             request.method.clone(),
             request.args.clone(),
-            TokenId(request.from.clone()),
+            TokenId(request.token_id.clone()),
             // TODO: put signature in here
             ComSig::default()
             // create_com_sig_from_bytes(&request.signature)

--- a/applications/tari_dan_node/src/main.rs
+++ b/applications/tari_dan_node/src/main.rs
@@ -37,7 +37,8 @@ use std::{
 };
 use tari_shutdown::{Shutdown, ShutdownSignal};
 use thiserror::Error;
-use tokio::{runtime, stream::StreamExt, task};
+use tokio::{runtime, task};
+use tokio_stream::StreamExt;
 use tonic::transport::Server;
 
 use crate::{
@@ -97,12 +98,8 @@ async fn run_node(config: GlobalConfig) -> Result<(), ExitCodes> {
 }
 
 fn build_runtime() -> Result<Runtime, ExitCodes> {
-    let mut builder = runtime::Builder::new();
-    builder
-        .threaded_scheduler()
-        .enable_all()
-        .build()
-        .map_err(|e| ExitCodes::UnknownError)
+    let mut builder = runtime::Builder::new_multi_thread();
+    builder.enable_all().build().map_err(|e| ExitCodes::UnknownError)
 }
 
 async fn run_dan_node<TMempoolService: MempoolService + Clone + Send>(

--- a/common/config/presets/tari_config_example.toml
+++ b/common/config/presets/tari_config_example.toml
@@ -550,3 +550,8 @@ transcoder_host_address = "127.0.0.1:7879"
 # mining_pool_address = "miningcore.tarilabs.com:3052"
 # mining_wallet_address = "YOUR_WALLET_PUBLIC_KEY"
 # mining_worker_name = "worker1"
+
+[dan_node]
+# committee = ["pubkey_1", "pubkey_2"] # cannot be of zero size
+phase_timeout = 30
+template_id = "EditableMetadata"

--- a/common/config/presets/tari_config_example.toml
+++ b/common/config/presets/tari_config_example.toml
@@ -552,6 +552,10 @@ transcoder_host_address = "127.0.0.1:7879"
 # mining_worker_name = "worker1"
 
 [dan_node]
+# Override common.network for base node
+# network = "weatherwax"
+
+[dan_node.weatherwax]
 # committee = ["pubkey_1", "pubkey_2"] # cannot be of zero size
-phase_timeout = 30
-template_id = "EditableMetadata"
+# phase_timeout = 30
+# template_id = "EditableMetadata"

--- a/common/src/configuration/dan_config.rs
+++ b/common/src/configuration/dan_config.rs
@@ -32,6 +32,22 @@ pub struct DanNodeConfig {
 }
 
 impl DanNodeConfig {
+    pub fn new(
+        committee: Vec<String>,
+        phase_timeout: u64,
+        template_id: String,
+    ) -> Result<Option<DanNodeConfig>, ConfigurationError> {
+        if committee.len() == 0 {
+            Ok(None)
+        } else {
+            Ok(Some(DanNodeConfig {
+                committee,
+                phase_timeout,
+                template_id,
+            }))
+        }
+    }
+
     pub fn convert_if_present(cfg: Config) -> Result<Option<DanNodeConfig>, ConfigurationError> {
         let section: DanNodeConfig = match cfg.get("dan_node") {
             Ok(s) => s,

--- a/integration_tests/features/ValidatorNode.feature
+++ b/integration_tests/features/ValidatorNode.feature
@@ -1,0 +1,5 @@
+Feature: Validator Node
+    Scenario: Test committee
+        Given I have committee from 4 validator nodes connected
+        Then I send instruction successfully with metadata {"issuer" : {"num_clicks" : 1}}
+        Then At least 3 out of 4 validator nodes have filled asset data

--- a/integration_tests/features/support/steps.js
+++ b/integration_tests/features/support/steps.js
@@ -4096,4 +4096,72 @@ Then(
     }
   }
 );
+
+Given(
+  "I have committee from {int} validator nodes connected",
+  { timeout: 20 * 1000 },
+  async function (nodes_cnt) {
+    console.log(`Starting ${nodes_cnt} validator nodes`);
+    const promises = [];
+    for (let i = 0; i < nodes_cnt; i++) {
+      promises.push(this.createAndAddDanNode(`DanNode${i}`));
+    }
+    await Promise.all(promises);
+    let committee = Array(nodes_cnt)
+      .fill()
+      .map((_, i) => this.getNode(`DanNode${i}`).getPubKey());
+    let peers = Array(nodes_cnt)
+      .fill()
+      .map((_, i) => this.getNode(`DanNode${i}`).peerAddress());
+    for (let i = 0; i < nodes_cnt; ++i) {
+      let dan_node = this.getNode(`DanNode${i}`);
+      dan_node.setCommittee(committee);
+      dan_node.setPeerSeeds(peers.filter((_, j) => i != j));
+      promises.push(dan_node.start());
+    }
+    await Promise.all(promises);
+  }
+);
+
+Then(
+  /I send instruction successfully with metadata (.*)/,
+  { timeout: 20 * 1000 },
+  async function (metadata) {
+    console.log("metadata", metadata);
+    let dan_node = this.getNode("DanNode0"); // Only the first node has GRPC
+    let grpc_dan_node = await dan_node.createGrpcClient();
+    let response = await grpc_dan_node.executeInstruction(
+      "f665775dbbf4e428e5c8c2bb1c5e7d2e508e93c83250c495ac617a0a1fb2d76d", // asset
+      "update", // method
+      metadata,
+      "eee280877ef836f1026d8a848a5da3eb6364cd0343372235e6ca10e2a697fc6f" // token
+    );
+    expect(response?.status).to.be.equal("Accepted");
+  }
+);
+
+Then(
+  "At least {int} out of {int} validator nodes have filled asset data",
+  { timeout: 1200 * 1000 },
+  async function (at_least, total) {
+    let retries = 1;
+    let success = false;
+    let retries_limit = 239;
+    while (retries < retries_limit) {
+      let count = 0;
+      for (let i = 0; i < total; ++i) {
+        let node = this.getNode(`DanNode${i}`);
+        if (node.hasAssetData()) {
+          count += 1;
+        }
+      }
+      success = count >= at_least;
+      if (success) break;
+      ++retries;
+      await sleep(5000);
+    }
+    expect(success).to.be.true;
+  }
+);
+
 //endregion

--- a/integration_tests/helpers/config.js
+++ b/integration_tests/helpers/config.js
@@ -57,7 +57,7 @@ function mapEnvs(options) {
   return res;
 }
 
-function baseEnvs(peerSeeds = [], forceSyncPeers = []) {
+function baseEnvs(peerSeeds = [], forceSyncPeers = [], committee = []) {
   const envs = {
     RUST_BACKTRACE: 1,
     TARI_BASE_NODE__NETWORK: "localnet",
@@ -112,6 +112,9 @@ function baseEnvs(peerSeeds = [], forceSyncPeers = []) {
       "5cfcf17f41b01980eb4fa03cec5ea12edbd3783496a2b5dabf99e4bf6410f460::/ip4/10.0.0.50/tcp/1",
     ];
   }
+  if (committee.length != 0) {
+    envs.TARI_DAN_NODE__LOCALNET__COMMITTEE = committee;
+  }
 
   return envs;
 }
@@ -131,9 +134,10 @@ function createEnv(
   options,
   peerSeeds = [],
   _txnSendingMechanism = "DirectAndStoreAndForward",
-  forceSyncPeers = []
+  forceSyncPeers = [],
+  committee = []
 ) {
-  const envs = baseEnvs(peerSeeds, forceSyncPeers);
+  const envs = baseEnvs(peerSeeds, forceSyncPeers, committee);
   const network =
     options && options.network ? options.network.toUpperCase() : "LOCALNET";
 

--- a/integration_tests/helpers/danNodeClient.js
+++ b/integration_tests/helpers/danNodeClient.js
@@ -1,0 +1,62 @@
+const grpc = require("@grpc/grpc-js");
+const protoLoader = require("@grpc/proto-loader");
+const { tryConnect } = require("./util");
+const grpcPromise = require("grpc-promise");
+
+class DanNodeClient {
+  constructor() {
+    this.client = null;
+    this.blockTemplates = {};
+  }
+
+  async connect(port) {
+    const PROTO_PATH =
+      __dirname + "/../../applications/tari_dan_node/proto/dan_node.proto";
+    const packageDefinition = protoLoader.loadSync(PROTO_PATH, {
+      keepCase: true,
+      longs: String,
+      enums: String,
+      defaults: true,
+      oneofs: true,
+    });
+    const protoDescriptor = grpc.loadPackageDefinition(packageDefinition);
+    const tari = protoDescriptor.tari.dan.rpc;
+    this.client = await tryConnect(
+      () =>
+        new tari.DanNode("127.0.0.1:" + port, grpc.credentials.createInsecure())
+    );
+
+    grpcPromise.promisifyAll(this.client, {
+      metadata: new grpc.Metadata(),
+    });
+  }
+
+  static async create(port) {
+    const client = new DanNodeClient();
+    await client.connect(port);
+    return client;
+  }
+
+  executeInstruction(asset_public_key, method, metadata, token, signature, id) {
+    let convertHexStringToVec = (string) =>
+      string.match(/.{2}/g).map((x) => parseInt(x, 16));
+    let convertStringToVec = (string) =>
+      Array(string.length)
+        .fill()
+        .map((_, i) => string.charCodeAt(i));
+
+    console.log(
+      `Executing instruction for asset ${asset_public_key} / token ${token} via method ${method} with metadata ${metadata} `
+    );
+    return this.client.executeInstruction().sendMessage({
+      asset_public_key: convertHexStringToVec(asset_public_key),
+      method,
+      args: [convertStringToVec(metadata)],
+      token_id: convertHexStringToVec(token),
+      signature,
+      id,
+    });
+  }
+}
+
+module.exports = DanNodeClient;

--- a/integration_tests/helpers/danNodeProcess.js
+++ b/integration_tests/helpers/danNodeProcess.js
@@ -1,0 +1,225 @@
+const { spawn } = require("child_process");
+const { expect } = require("chai");
+const fs = require("fs");
+const path = require("path");
+const DanNodeClient = require("./danNodeClient");
+const { sleep, getFreePort } = require("./util");
+const dateFormat = require("dateformat");
+const { createEnv } = require("./config");
+
+let outputProcess;
+class DanNodeProcess {
+  constructor(name, excludeTestEnvars, options, logFilePath, nodeFile) {
+    this.name = name;
+    this.logFilePath = logFilePath ? path.resolve(logFilePath) : logFilePath;
+    this.nodeFile = nodeFile;
+    this.options = Object.assign(
+      {
+        baseDir: "./temp/base_nodes",
+      },
+      options || {}
+    );
+    this.excludeTestEnvars = excludeTestEnvars;
+  }
+
+  async init() {
+    this.port = await getFreePort();
+    this.grpcPort = 18080; // Currently it's constant
+    this.name = `DanNode${this.port}-${this.name}`;
+    this.nodeFile = this.nodeFile || "nodeid.json";
+
+    do {
+      this.baseDir = `${this.options.baseDir}/${dateFormat(
+        new Date(),
+        "yyyymmddHHMM"
+      )}/${this.name}`;
+      // Some tests failed during testing because the next base node process started in the previous process
+      // directory therefore using the previous blockchain database
+      if (fs.existsSync(this.baseDir)) {
+        sleep(1000);
+      }
+    } while (fs.existsSync(this.baseDir));
+    const args = ["--base-path", ".", "--init", "--create-id"];
+    if (this.logFilePath) {
+      args.push("--log-config", this.logFilePath);
+    }
+
+    await this.run(await this.compile(), args);
+  }
+
+  async compile() {
+    if (!outputProcess) {
+      await this.run("cargo", [
+        "build",
+        "--release",
+        "--bin",
+        "tari_dan_node",
+        "-Z",
+        "unstable-options",
+        "--out-dir",
+        process.cwd() + "/temp/out",
+      ]);
+      outputProcess = process.cwd() + "/temp/out/tari_dan_node";
+    }
+    console.log(outputProcess);
+    return outputProcess;
+  }
+
+  hasAssetData() {
+    return fs.existsSync(this.baseDir + "/localnet/asset_data");
+  }
+
+  ensureNodeInfo() {
+    for (;;) {
+      if (fs.existsSync(this.baseDir + "/" + this.nodeFile)) {
+        break;
+      }
+    }
+
+    this.nodeInfo = JSON.parse(
+      fs.readFileSync(this.baseDir + "/" + this.nodeFile, "utf8")
+    );
+  }
+
+  peerAddress() {
+    this.ensureNodeInfo();
+    const addr = this.nodeInfo.public_key + "::" + this.nodeInfo.public_address;
+    return addr;
+  }
+
+  getPubKey() {
+    this.ensureNodeInfo();
+    return this.nodeInfo.public_key;
+  }
+
+  setPeerSeeds(addresses) {
+    this.peerSeeds = addresses.join(",");
+  }
+
+  setForceSyncPeers(addresses) {
+    this.forceSyncPeers = addresses.join(",");
+  }
+
+  setCommittee(committee) {
+    this.committee = committee.join(",");
+  }
+
+  getGrpcAddress() {
+    const address = "127.0.0.1:" + this.grpcPort;
+    // console.log("Base Node GRPC Address:",address);
+    return address;
+  }
+
+  run(cmd, args) {
+    return new Promise((resolve, reject) => {
+      if (!fs.existsSync(this.baseDir)) {
+        fs.mkdirSync(this.baseDir, { recursive: true });
+        fs.mkdirSync(this.baseDir + "/log", { recursive: true });
+      }
+
+      let envs = [];
+      if (!this.excludeTestEnvars) {
+        envs = createEnv(
+          this.name,
+          false,
+          this.nodeFile,
+          "127.0.0.1",
+          "8082",
+          "8081",
+          "127.0.0.1",
+          this.grpcPort,
+          this.port,
+          "127.0.0.1:8080",
+          "127.0.0.1:8085",
+          this.options,
+          this.peerSeeds,
+          "DirectAndStoreAndForward",
+          this.forceSyncPeers,
+          this.committee
+        );
+      }
+      const ps = spawn(cmd, args, {
+        cwd: this.baseDir,
+        // shell: true,
+        env: { ...process.env, ...envs },
+      });
+
+      ps.stdout.on("data", (data) => {
+        //console.log(`stdout: ${data}`);
+        fs.appendFileSync(`${this.baseDir}/log/stdout.log`, data.toString());
+        if (
+          data
+            .toString()
+            .toUpperCase()
+            .match(/STATE CHANGED FROM STARTING TO PREPARE/)
+        ) {
+          resolve(ps);
+        }
+      });
+
+      ps.stderr.on("data", (data) => {
+        // console.error(`stderr: ${data}`);
+        fs.appendFileSync(`${this.baseDir}/log/stderr.log`, data.toString());
+      });
+
+      ps.on("close", (code) => {
+        const ps = this.ps;
+        this.ps = null;
+        if (code) {
+          if (code == 101) {
+            resolve(ps); // Validator node will fail, because of the missing committee section, but that's okay.
+          } else {
+            console.log(`child process exited with code ${code}`);
+            reject(`child process exited with code ${code}`);
+          }
+        } else {
+          resolve(ps);
+        }
+      });
+
+      expect(ps.error).to.be.an("undefined");
+      this.ps = ps;
+    });
+  }
+
+  async startNew() {
+    await this.init();
+    const start = await this.start();
+    return start;
+  }
+
+  async startAndConnect() {
+    await this.startNew();
+    return await this.createGrpcClient();
+  }
+
+  async start(opts = []) {
+    const args = ["--base-path", "."];
+    if (this.logFilePath) {
+      args.push("--log-config", this.logFilePath);
+    }
+    args.push(...opts);
+    return await this.run(await this.compile(), args);
+  }
+
+  stop() {
+    return new Promise((resolve) => {
+      if (!this.ps) {
+        return resolve();
+      }
+      this.ps.on("close", (code) => {
+        if (code) {
+          console.log(`child process exited with code ${code}`);
+        }
+        resolve();
+      });
+      this.ps.kill("SIGINT");
+    });
+  }
+
+  async createGrpcClient() {
+    return await DanNodeClient.create(this.grpcPort);
+  }
+}
+
+module.exports = DanNodeProcess;


### PR DESCRIPTION
Description
---

- I've upgraded the tokio to 1.10 
- Added the `dan_node` section to default config. With some default values, except the committee. Committee requires pubkeys, so I've added it but commented it out. 

Motivation and Context
---
Be able to compile and run the dan node.

How Has This Been Tested?
---
Manually running the dan node after setting up the committee.
