### PR TITLE
refactor: reintroduce generic substream in client rpc

### DIFF
--- a/comms/src/lib.rs
+++ b/comms/src/lib.rs
@@ -39,6 +39,7 @@ pub use multiplexing::Substream;
 
 mod noise;
 mod proto;
+mod stream_id;
 
 pub mod backoff;
 pub mod bounded_executor;

--- a/comms/src/protocol/rpc/server/mod.rs
+++ b/comms/src/protocol/rpc/server/mod.rs
@@ -59,6 +59,7 @@ use crate::{
         ProtocolNotification,
         ProtocolNotificationRx,
     },
+    stream_id::StreamId,
     Bytes,
     Substream,
 };
@@ -402,7 +403,7 @@ where
         Self {
             logging_context_string: Arc::new(format!(
                 "stream_id: {}, peer: {}, protocol: {}",
-                framed.get_ref().id(),
+                framed.stream_id(),
                 node_id,
                 String::from_utf8_lossy(&protocol)
             )),

--- a/comms/src/stream_id.rs
+++ b/comms/src/stream_id.rs
@@ -1,4 +1,4 @@
-//  Copyright 2020, The Tari Project
+//  Copyright 2021, The Tari Project
 //
 //  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
 //  following conditions are met:
@@ -20,27 +20,27 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::stream_id::{Id, StreamId};
-use tokio::io::{AsyncRead, AsyncWrite};
-use tokio_util::codec::{Framed, LengthDelimitedCodec};
+use std::fmt;
 
-/// Tari comms canonical framing
-pub type CanonicalFraming<T> = Framed<T, LengthDelimitedCodec>;
-
-pub fn canonical<T>(stream: T, max_frame_len: usize) -> CanonicalFraming<T>
-where T: AsyncRead + AsyncWrite + Unpin {
-    Framed::new(
-        stream,
-        LengthDelimitedCodec::builder()
-            .max_frame_length(max_frame_len)
-            .new_codec(),
-    )
+pub trait StreamId {
+    fn stream_id(&self) -> Id;
 }
 
-impl<T> StreamId for CanonicalFraming<T>
-where T: StreamId
-{
-    fn stream_id(&self) -> Id {
-        self.get_ref().stream_id()
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Id(u32);
+
+impl Id {
+    pub fn new(val: u32) -> Self {
+        Self(val)
+    }
+
+    pub fn as_u32(self) -> u32 {
+        self.0
+    }
+}
+
+impl fmt::Display for Id {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
     }
 }


### PR DESCRIPTION
Description
---
Generic substream was removed in order to more closely test RPC/yamux
interaction but that was incorrect. The tests should have just been
updated without removing the generic + add new StreamId abstraction.
This PR reintroduces them so that an RPC client mock can more easily be created.

Motivation and Context
---
- Decouple RPC client from yamux
- Make mocking out RPC client easier

How Has This Been Tested?
---
Existing tests pass
