### PR TITLE
refactor!: mapping for deleted mmr position to height/hash for perf

### DIFF
--- a/applications/tari_app_utilities/src/utilities.rs
+++ b/applications/tari_app_utilities/src/utilities.rs
@@ -76,6 +76,8 @@ pub enum ExitCodes {
     NoPassword,
     #[error("Tor connection is offline")]
     TorOffline,
+    #[error("Database is in inconsistent state: {0}")]
+    DbInconsistentState(String),
 }
 
 impl ExitCodes {
@@ -94,6 +96,29 @@ impl ExitCodes {
             Self::ConversionError(_) => 111,
             Self::IncorrectPassword | Self::NoPassword => 112,
             Self::TorOffline => 113,
+            Self::DbInconsistentState(_) => 115,
+        }
+    }
+
+    pub fn eprint_details(&self) {
+        use ExitCodes::*;
+        match self {
+            TorOffline => {
+                eprintln!("Unable to connect to the Tor control port.");
+                eprintln!(
+                    "Please check that you have the Tor proxy running and that access to the Tor control port is \
+                     turned on.",
+                );
+                eprintln!("If you are unsure of what to do, use the following command to start the Tor proxy:");
+                eprintln!(
+                    "tor --allow-missing-torrc --ignore-missing-torrc --clientonly 1 --socksport 9050 --controlport \
+                     127.0.0.1:9051 --log \"notice stdout\" --clientuseipv6 1",
+                );
+            },
+
+            e => {
+                eprintln!("{}", e);
+            },
         }
     }
 }

--- a/applications/tari_base_node/src/main.rs
+++ b/applications/tari_base_node/src/main.rs
@@ -115,6 +115,7 @@ use tari_app_utilities::{
 };
 use tari_common::{configuration::bootstrap::ApplicationType, ConfigBootstrap, GlobalConfig};
 use tari_comms::{peer_manager::PeerFeatures, tor::HiddenServiceControllerError};
+use tari_core::chain_storage::ChainStorageError;
 use tari_shutdown::{Shutdown, ShutdownSignal};
 use tokio::{
     runtime,
@@ -128,7 +129,7 @@ const LOG_TARGET: &str = "base_node::app";
 /// Application entry point
 fn main() {
     if let Err(exit_code) = main_inner() {
-        eprintln!("{:?}", exit_code);
+        exit_code.eprint_details();
         error!(
             target: LOG_TARGET,
             "Exiting with code ({}): {:?}",
@@ -205,20 +206,14 @@ async fn run_node(node_config: Arc<GlobalConfig>, bootstrap: ConfigBootstrap) ->
     .await
     .map_err(|err| {
         for boxed_error in err.chain() {
-            if let Some(HiddenServiceControllerError::TorControlPortOffline) =
-                boxed_error.downcast_ref::<HiddenServiceControllerError>()
-            {
-                println!("Unable to connect to the Tor control port.");
-                println!(
-                    "Please check that you have the Tor proxy running and that access to the Tor control port is \
-                     turned on.",
-                );
-                println!("If you are unsure of what to do, use the following command to start the Tor proxy:");
-                println!(
-                    "tor --allow-missing-torrc --ignore-missing-torrc --clientonly 1 --socksport 9050 --controlport \
-                     127.0.0.1:9051 --log \"notice stdout\" --clientuseipv6 1",
-                );
+            if let Some(HiddenServiceControllerError::TorControlPortOffline) = boxed_error.downcast_ref() {
                 return ExitCodes::TorOffline;
+            }
+            if let Some(ChainStorageError::DatabaseResyncRequired(reason)) = boxed_error.downcast_ref() {
+                return ExitCodes::DbInconsistentState(format!(
+                    "You may need to resync your database because {}",
+                    reason
+                ));
             }
 
             // todo: find a better way to do this

--- a/base_layer/core/src/chain_storage/async_db.rs
+++ b/base_layer/core/src/chain_storage/async_db.rs
@@ -37,6 +37,7 @@ use crate::{
         DbBasicStats,
         DbTotalSizeStats,
         DbTransaction,
+        DeletedBitmap,
         HistoricalBlock,
         HorizonData,
         MmrTree,
@@ -235,7 +236,9 @@ impl<B: BlockchainBackend + 'static> AsyncBlockchainDb<B> {
 
     make_async_fn!(fetch_complete_deleted_bitmap_at(hash: HashOutput) -> CompleteDeletedBitmap, "fetch_deleted_bitmap");
 
-    make_async_fn!(fetch_headers_of_deleted_positions(mmr_position: Vec<u64>) -> Vec<BlockHeader>, "fetch_headers_of_deleted_positions");
+    make_async_fn!(fetch_deleted_bitmap_at_tip() -> DeletedBitmap, "fetch_deleted_bitmap_at_tip");
+
+    make_async_fn!(fetch_header_hash_by_deleted_mmr_positions(mmr_positions: Vec<u32>) -> Vec<Option<(u64, HashOutput)>>, "fetch_headers_of_deleted_positions");
 
     make_async_fn!(get_stats() -> DbBasicStats, "get_stats");
 

--- a/base_layer/core/src/chain_storage/blockchain_backend.rs
+++ b/base_layer/core/src/chain_storage/blockchain_backend.rs
@@ -168,4 +168,10 @@ pub trait BlockchainBackend: Send + Sync {
     /// Returns total size information about each internal database. This call may be very slow and will obtain a read
     /// lock for the duration.
     fn fetch_total_size_stats(&self) -> Result<DbTotalSizeStats, ChainStorageError>;
+
+    /// Returns a (block height/hash) tuple for each mmr position of the height it was spent, or None if it is not spent
+    fn fetch_header_hash_by_deleted_mmr_positions(
+        &self,
+        mmr_positions: Vec<u32>,
+    ) -> Result<Vec<Option<(u64, HashOutput)>>, ChainStorageError>;
 }

--- a/base_layer/core/src/chain_storage/error.rs
+++ b/base_layer/core/src/chain_storage/error.rs
@@ -114,6 +114,8 @@ pub enum ChainStorageError {
     DbResizeRequired,
     #[error("DB transaction was too large ({0} operations)")]
     DbTransactionTooLarge(usize),
+    #[error("DB needs to be resynced: {0}")]
+    DatabaseResyncRequired(&'static str),
 }
 
 impl ChainStorageError {

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -51,25 +51,6 @@ use crate::{
             TransactionInputRowData,
             TransactionKernelRowData,
             TransactionOutputRowData,
-            LMDB_DB_BLOCK_ACCUMULATED_DATA,
-            LMDB_DB_BLOCK_HASHES,
-            LMDB_DB_HEADERS,
-            LMDB_DB_HEADER_ACCUMULATED_DATA,
-            LMDB_DB_INPUTS,
-            LMDB_DB_KERNELS,
-            LMDB_DB_KERNEL_EXCESS_INDEX,
-            LMDB_DB_KERNEL_EXCESS_SIG_INDEX,
-            LMDB_DB_KERNEL_MMR_SIZE_INDEX,
-            LMDB_DB_METADATA,
-            LMDB_DB_MONERO_SEED_HEIGHT,
-            LMDB_DB_ORPHANS,
-            LMDB_DB_ORPHAN_CHAIN_TIPS,
-            LMDB_DB_ORPHAN_HEADER_ACCUMULATED_DATA,
-            LMDB_DB_ORPHAN_PARENT_MAP_INDEX,
-            LMDB_DB_TXOS_HASH_TO_INDEX,
-            LMDB_DB_UTXOS,
-            LMDB_DB_UTXO_COMMITMENT_INDEX,
-            LMDB_DB_UTXO_MMR_SIZE_INDEX,
         },
         stats::DbTotalSizeStats,
         utxo_mined_info::UtxoMinedInfo,
@@ -106,22 +87,60 @@ type DatabaseRef = Arc<Database<'static>>;
 
 pub const LOG_TARGET: &str = "c::cs::lmdb_db::lmdb_db";
 
-struct OutputKey<'a> {
-    header_hash: &'a [u8],
-    mmr_position: u32,
-}
+const LMDB_DB_METADATA: &str = "metadata";
+const LMDB_DB_HEADERS: &str = "headers";
+const LMDB_DB_HEADER_ACCUMULATED_DATA: &str = "header_accumulated_data";
+const LMDB_DB_BLOCK_ACCUMULATED_DATA: &str = "mmr_peak_data";
+const LMDB_DB_BLOCK_HASHES: &str = "block_hashes";
+const LMDB_DB_UTXOS: &str = "utxos";
+const LMDB_DB_INPUTS: &str = "inputs";
+const LMDB_DB_TXOS_HASH_TO_INDEX: &str = "txos_hash_to_index";
+const LMDB_DB_KERNELS: &str = "kernels";
+const LMDB_DB_KERNEL_EXCESS_INDEX: &str = "kernel_excess_index";
+const LMDB_DB_KERNEL_EXCESS_SIG_INDEX: &str = "kernel_excess_sig_index";
+const LMDB_DB_KERNEL_MMR_SIZE_INDEX: &str = "kernel_mmr_size_index";
+const LMDB_DB_UTXO_MMR_SIZE_INDEX: &str = "utxo_mmr_size_index";
+const LMDB_DB_DELETED_TXO_MMR_POSITION_TO_HEIGHT_INDEX: &str = "deleted_txo_mmr_position_to_height_index";
+const LMDB_DB_UTXO_COMMITMENT_INDEX: &str = "utxo_commitment_index";
+const LMDB_DB_ORPHANS: &str = "orphans";
+const LMDB_DB_MONERO_SEED_HEIGHT: &str = "monero_seed_height";
+const LMDB_DB_ORPHAN_HEADER_ACCUMULATED_DATA: &str = "orphan_accumulated_data";
+const LMDB_DB_ORPHAN_CHAIN_TIPS: &str = "orphan_chain_tips";
+const LMDB_DB_ORPHAN_PARENT_MAP_INDEX: &str = "orphan_parent_map_index";
 
-impl<'a> OutputKey<'a> {
-    pub fn new(header_hash: &'a [u8], mmr_position: u32) -> OutputKey {
-        OutputKey {
-            header_hash,
-            mmr_position,
-        }
-    }
+pub fn create_lmdb_database<P: AsRef<Path>>(path: P, config: LMDBConfig) -> Result<LMDBDatabase, ChainStorageError> {
+    let flags = db::CREATE;
+    let _ = std::fs::create_dir_all(&path);
 
-    pub fn get_key(&self) -> String {
-        format!("{}-{:010}", to_hex(&self.header_hash), self.mmr_position)
-    }
+    let file_lock = acquire_exclusive_file_lock(&path.as_ref().to_path_buf())?;
+
+    let lmdb_store = LMDBBuilder::new()
+        .set_path(path)
+        .set_env_config(config)
+        .set_max_number_of_databases(20)
+        .add_database(LMDB_DB_METADATA, flags | db::INTEGERKEY)
+        .add_database(LMDB_DB_HEADERS, flags | db::INTEGERKEY)
+        .add_database(LMDB_DB_HEADER_ACCUMULATED_DATA, flags | db::INTEGERKEY)
+        .add_database(LMDB_DB_BLOCK_ACCUMULATED_DATA, flags | db::INTEGERKEY)
+        .add_database(LMDB_DB_BLOCK_HASHES, flags)
+        .add_database(LMDB_DB_UTXOS, flags)
+        .add_database(LMDB_DB_INPUTS, flags)
+        .add_database(LMDB_DB_TXOS_HASH_TO_INDEX, flags)
+        .add_database(LMDB_DB_KERNELS, flags)
+        .add_database(LMDB_DB_KERNEL_EXCESS_INDEX, flags)
+        .add_database(LMDB_DB_KERNEL_EXCESS_SIG_INDEX, flags)
+        .add_database(LMDB_DB_KERNEL_MMR_SIZE_INDEX, flags)
+        .add_database(LMDB_DB_UTXO_MMR_SIZE_INDEX, flags)
+        .add_database(LMDB_DB_UTXO_COMMITMENT_INDEX, flags)
+        .add_database(LMDB_DB_DELETED_TXO_MMR_POSITION_TO_HEIGHT_INDEX, flags | db::INTEGERKEY)
+        .add_database(LMDB_DB_ORPHANS, flags)
+        .add_database(LMDB_DB_ORPHAN_HEADER_ACCUMULATED_DATA, flags)
+        .add_database(LMDB_DB_MONERO_SEED_HEIGHT, flags)
+        .add_database(LMDB_DB_ORPHAN_CHAIN_TIPS, flags)
+        .add_database(LMDB_DB_ORPHAN_PARENT_MAP_INDEX, flags | db::DUPSORT)
+        .build()
+        .map_err(|err| ChainStorageError::CriticalError(format!("Could not create LMDB store:{}", err)))?;
+    LMDBDatabase::new(lmdb_store, file_lock)
 }
 
 /// This is a lmdb-based blockchain database for persistent storage of the chain state.
@@ -142,6 +161,7 @@ pub struct LMDBDatabase {
     kernel_mmr_size_index: DatabaseRef,
     output_mmr_size_index: DatabaseRef,
     utxo_commitment_index: DatabaseRef,
+    deleted_txo_mmr_position_to_height_index: DatabaseRef,
     orphans_db: DatabaseRef,
     monero_seed_height_db: DatabaseRef,
     orphan_header_accumulated_data_db: DatabaseRef,
@@ -154,7 +174,7 @@ impl LMDBDatabase {
     pub fn new(store: LMDBStore, file_lock: File) -> Result<Self, ChainStorageError> {
         let env = store.env();
 
-        let res = Self {
+        let db = Self {
             metadata_db: get_database(&store, LMDB_DB_METADATA)?,
             headers_db: get_database(&store, LMDB_DB_HEADERS)?,
             header_accumulated_data_db: get_database(&store, LMDB_DB_HEADER_ACCUMULATED_DATA)?,
@@ -169,6 +189,10 @@ impl LMDBDatabase {
             kernel_mmr_size_index: get_database(&store, LMDB_DB_KERNEL_MMR_SIZE_INDEX)?,
             output_mmr_size_index: get_database(&store, LMDB_DB_UTXO_MMR_SIZE_INDEX)?,
             utxo_commitment_index: get_database(&store, LMDB_DB_UTXO_COMMITMENT_INDEX)?,
+            deleted_txo_mmr_position_to_height_index: get_database(
+                &store,
+                LMDB_DB_DELETED_TXO_MMR_POSITION_TO_HEIGHT_INDEX,
+            )?,
             orphans_db: get_database(&store, LMDB_DB_ORPHANS)?,
             orphan_header_accumulated_data_db: get_database(&store, LMDB_DB_ORPHAN_HEADER_ACCUMULATED_DATA)?,
             monero_seed_height_db: get_database(&store, LMDB_DB_MONERO_SEED_HEIGHT)?,
@@ -179,7 +203,20 @@ impl LMDBDatabase {
             _file_lock: Arc::new(file_lock),
         };
 
-        Ok(res)
+        db.build_indexes()?;
+
+        Ok(db)
+    }
+
+    fn build_indexes(&self) -> Result<(), ChainStorageError> {
+        let txn = self.read_transaction()?;
+        if lmdb_len(&txn, &self.deleted_txo_mmr_position_to_height_index)? == 0 && lmdb_len(&txn, &self.inputs_db)? > 0
+        {
+            return Err(ChainStorageError::DatabaseResyncRequired(
+                "deleted_txo_mmr_position_to_height_index is needs to be built",
+            ));
+        }
+        Ok(())
     }
 
     /// Try to establish a read lock on the LMDB database. If an exclusive write lock has been previously acquired, this
@@ -377,7 +414,7 @@ impl LMDBDatabase {
         Ok(())
     }
 
-    fn all_dbs(&self) -> [(&'static str, &DatabaseRef); 19] {
+    fn all_dbs(&self) -> [(&'static str, &DatabaseRef); 20] {
         [
             ("metadata_db", &self.metadata_db),
             ("headers_db", &self.headers_db),
@@ -393,6 +430,10 @@ impl LMDBDatabase {
             ("kernel_mmr_size_index", &self.kernel_mmr_size_index),
             ("output_mmr_size_index", &self.output_mmr_size_index),
             ("utxo_commitment_index", &self.utxo_commitment_index),
+            (
+                "deleted_txo_mmr_position_to_height_index",
+                &self.deleted_txo_mmr_position_to_height_index,
+            ),
             ("orphans_db", &self.orphans_db),
             (
                 "orphan_header_accumulated_data_db",
@@ -529,7 +570,7 @@ impl LMDBDatabase {
             "kernel_excess_index",
         )?;
 
-        let mut excess_sig_key = Vec::<u8>::new();
+        let mut excess_sig_key = Vec::<u8>::with_capacity(32 * 2);
         excess_sig_key.extend(kernel.excess_sig.get_public_nonce().as_bytes());
         excess_sig_key.extend(kernel.excess_sig.get_signature().as_bytes());
         lmdb_insert(
@@ -557,6 +598,7 @@ impl LMDBDatabase {
     fn insert_input(
         &self,
         txn: &WriteTransaction<'_>,
+        height: u64,
         header_hash: HashOutput,
         input: TransactionInput,
         mmr_position: u32,
@@ -566,6 +608,13 @@ impl LMDBDatabase {
             &self.utxo_commitment_index,
             input.commitment().as_bytes(),
             "utxo_commitment_index",
+        )?;
+        lmdb_insert(
+            txn,
+            &self.deleted_txo_mmr_position_to_height_index,
+            &mmr_position,
+            &(height, &header_hash),
+            "deleted_txo_mmr_position_to_height_index",
         )?;
 
         let hash = input.hash();
@@ -860,6 +909,12 @@ impl LMDBDatabase {
                 &row.input.output_hash(),
                 "utxo_commitment_index",
             )?;
+            lmdb_delete(
+                txn,
+                &self.deleted_txo_mmr_position_to_height_index,
+                &row.mmr_position,
+                "deleted_txo_mmr_position_to_height_index",
+            )?;
         }
         Ok(())
     }
@@ -996,8 +1051,8 @@ impl LMDBDatabase {
                 })?
         };
 
-        let mut total_kernel_sum = Commitment::from_bytes(&[0u8; 32]).expect("Could not create commitment");
-        let mut total_utxo_sum = Commitment::from_bytes(&[0u8; 32]).expect("Could not create commitment");
+        let mut total_kernel_sum = Commitment::default();
+        let mut total_utxo_sum = Commitment::default();
         let BlockAccumulatedData {
             kernels: pruned_kernel_set,
             outputs: pruned_output_set,
@@ -1046,14 +1101,14 @@ impl LMDBDatabase {
                 )));
             }
             debug!(target: LOG_TARGET, "Inserting input `{}`", input.commitment.to_hex());
-            self.insert_input(txn, block_hash.clone(), input, index)?;
+            self.insert_input(txn, current_header_at_height.height, block_hash.clone(), input, index)?;
         }
 
         // Merge current deletions with the tip bitmap
-        let deleted = output_mmr.deleted().clone();
+        let deleted_at_current_height = output_mmr.deleted().clone();
         // Merge the new indexes with the blockchain deleted bitmap
         let mut deleted_bitmap = self.load_deleted_bitmap_model(txn)?;
-        deleted_bitmap.merge(&deleted)?;
+        deleted_bitmap.merge(&deleted_at_current_height)?;
 
         // Set the output MMR to the complete map so that the complete state can be committed to in the final MR
         output_mmr.set_deleted(deleted_bitmap.get().clone().into_bitmap());
@@ -1069,7 +1124,7 @@ impl LMDBDatabase {
                 kernel_mmr.get_pruned_hash_set()?,
                 output_mmr.mmr().get_pruned_hash_set()?,
                 witness_mmr.get_pruned_hash_set()?,
-                deleted,
+                deleted_at_current_height,
                 total_kernel_sum,
             ),
         )?;
@@ -1259,40 +1314,6 @@ impl LMDBDatabase {
     fn fetch_last_header_in_txn(&self, txn: &ConstTransaction<'_>) -> Result<Option<BlockHeader>, ChainStorageError> {
         lmdb_last(&txn, &self.headers_db)
     }
-}
-
-pub fn create_lmdb_database<P: AsRef<Path>>(path: P, config: LMDBConfig) -> Result<LMDBDatabase, ChainStorageError> {
-    let flags = db::CREATE;
-    let _ = std::fs::create_dir_all(&path);
-
-    let file_lock = acquire_exclusive_file_lock(&path.as_ref().to_path_buf())?;
-
-    let lmdb_store = LMDBBuilder::new()
-        .set_path(path)
-        .set_env_config(config)
-        .set_max_number_of_databases(20)
-        .add_database(LMDB_DB_METADATA, flags | db::INTEGERKEY)
-        .add_database(LMDB_DB_HEADERS, flags | db::INTEGERKEY)
-        .add_database(LMDB_DB_HEADER_ACCUMULATED_DATA, flags | db::INTEGERKEY)
-        .add_database(LMDB_DB_BLOCK_ACCUMULATED_DATA, flags | db::INTEGERKEY)
-        .add_database(LMDB_DB_BLOCK_HASHES, flags)
-        .add_database(LMDB_DB_UTXOS, flags)
-        .add_database(LMDB_DB_INPUTS, flags)
-        .add_database(LMDB_DB_TXOS_HASH_TO_INDEX, flags)
-        .add_database(LMDB_DB_KERNELS, flags)
-        .add_database(LMDB_DB_KERNEL_EXCESS_INDEX, flags)
-        .add_database(LMDB_DB_KERNEL_EXCESS_SIG_INDEX, flags)
-        .add_database(LMDB_DB_KERNEL_MMR_SIZE_INDEX, flags)
-        .add_database(LMDB_DB_UTXO_MMR_SIZE_INDEX, flags)
-        .add_database(LMDB_DB_UTXO_COMMITMENT_INDEX, flags)
-        .add_database(LMDB_DB_ORPHANS, flags)
-        .add_database(LMDB_DB_ORPHAN_HEADER_ACCUMULATED_DATA, flags)
-        .add_database(LMDB_DB_MONERO_SEED_HEIGHT, flags)
-        .add_database(LMDB_DB_ORPHAN_CHAIN_TIPS, flags)
-        .add_database(LMDB_DB_ORPHAN_PARENT_MAP_INDEX, flags | db::DUPSORT)
-        .build()
-        .map_err(|err| ChainStorageError::CriticalError(format!("Could not create LMDB store:{}", err)))?;
-    LMDBDatabase::new(lmdb_store, file_lock)
 }
 
 pub fn create_recovery_lmdb_database<P: AsRef<Path>>(path: P) -> Result<(), ChainStorageError> {
@@ -2056,6 +2077,18 @@ impl BlockchainBackend for LMDBDatabase {
         Ok(deleted_bitmap.get().clone())
     }
 
+    fn fetch_header_hash_by_deleted_mmr_positions(
+        &self,
+        mmr_positions: Vec<u32>,
+    ) -> Result<Vec<Option<(u64, HashOutput)>>, ChainStorageError> {
+        let txn = self.read_transaction()?;
+
+        mmr_positions
+            .iter()
+            .map(|pos| lmdb_get(&txn, &self.deleted_txo_mmr_position_to_height_index, pos))
+            .collect()
+    }
+
     fn delete_oldest_orphans(
         &mut self,
         horizon_height: u64,
@@ -2369,5 +2402,23 @@ impl<'a, 'b> DeletedBitmapModel<'a, WriteTransaction<'b>> {
             &MetadataValue::DeletedBitmap(self.bitmap),
         )?;
         Ok(())
+    }
+}
+
+struct OutputKey<'a> {
+    header_hash: &'a [u8],
+    mmr_position: u32,
+}
+
+impl<'a> OutputKey<'a> {
+    pub fn new(header_hash: &'a [u8], mmr_position: u32) -> OutputKey {
+        OutputKey {
+            header_hash,
+            mmr_position,
+        }
+    }
+
+    pub fn get_key(&self) -> String {
+        format!("{}-{:010}", to_hex(&self.header_hash), self.mmr_position)
     }
 }

--- a/base_layer/core/src/chain_storage/lmdb_db/mod.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/mod.rs
@@ -29,26 +29,6 @@ pub use lmdb_db::{create_lmdb_database, create_recovery_lmdb_database, LMDBDatab
 use serde::{Deserialize, Serialize};
 use tari_common_types::types::HashOutput;
 
-pub const LMDB_DB_METADATA: &str = "metadata";
-pub const LMDB_DB_HEADERS: &str = "headers";
-pub const LMDB_DB_HEADER_ACCUMULATED_DATA: &str = "header_accumulated_data";
-pub const LMDB_DB_BLOCK_ACCUMULATED_DATA: &str = "mmr_peak_data";
-pub const LMDB_DB_BLOCK_HASHES: &str = "block_hashes";
-pub const LMDB_DB_UTXOS: &str = "utxos";
-pub const LMDB_DB_INPUTS: &str = "inputs";
-pub const LMDB_DB_TXOS_HASH_TO_INDEX: &str = "txos_hash_to_index";
-pub const LMDB_DB_KERNELS: &str = "kernels";
-pub const LMDB_DB_KERNEL_EXCESS_INDEX: &str = "kernel_excess_index";
-pub const LMDB_DB_KERNEL_EXCESS_SIG_INDEX: &str = "kernel_excess_sig_index";
-pub const LMDB_DB_KERNEL_MMR_SIZE_INDEX: &str = "kernel_mmr_size_index";
-pub const LMDB_DB_UTXO_MMR_SIZE_INDEX: &str = "utxo_mmr_size_index";
-pub const LMDB_DB_UTXO_COMMITMENT_INDEX: &str = "utxo_commitment_index";
-pub const LMDB_DB_ORPHANS: &str = "orphans";
-pub const LMDB_DB_MONERO_SEED_HEIGHT: &str = "monero_seed_height";
-pub const LMDB_DB_ORPHAN_HEADER_ACCUMULATED_DATA: &str = "orphan_accumulated_data";
-pub const LMDB_DB_ORPHAN_CHAIN_TIPS: &str = "orphan_chain_tips";
-pub const LMDB_DB_ORPHAN_PARENT_MAP_INDEX: &str = "orphan_parent_map_index";
-
 #[derive(Serialize, Deserialize, Debug)]
 pub(crate) struct TransactionOutputRowData {
     pub output: Option<TransactionOutput>,

--- a/base_layer/core/src/chain_storage/mod.rs
+++ b/base_layer/core/src/chain_storage/mod.rs
@@ -80,18 +80,7 @@ mod pruned_output;
 pub use pruned_output::PrunedOutput;
 
 mod lmdb_db;
-pub use lmdb_db::{
-    create_lmdb_database,
-    create_recovery_lmdb_database,
-    LMDBDatabase,
-    LMDB_DB_BLOCK_HASHES,
-    LMDB_DB_HEADERS,
-    LMDB_DB_KERNELS,
-    LMDB_DB_METADATA,
-    LMDB_DB_MONERO_SEED_HEIGHT,
-    LMDB_DB_ORPHANS,
-    LMDB_DB_UTXOS,
-};
+pub use lmdb_db::{create_lmdb_database, create_recovery_lmdb_database, LMDBDatabase};
 
 mod stats;
 pub use stats::{DbBasicStats, DbSize, DbStat, DbTotalSizeStats};

--- a/base_layer/core/src/chain_storage/tests/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/tests/blockchain_database.rs
@@ -429,6 +429,6 @@ mod fetch_total_size_stats {
         let db = setup();
         let stats = db.fetch_total_size_stats().unwrap();
         // Returns one per db
-        assert_eq!(stats.sizes().len(), 19);
+        assert_eq!(stats.sizes().len(), 20);
     }
 }

--- a/base_layer/core/src/test_helpers/blockchain.rs
+++ b/base_layer/core/src/test_helpers/blockchain.rs
@@ -369,6 +369,16 @@ impl BlockchainBackend for TempDatabase {
     fn fetch_total_size_stats(&self) -> Result<DbTotalSizeStats, ChainStorageError> {
         self.db.as_ref().unwrap().fetch_total_size_stats()
     }
+
+    fn fetch_header_hash_by_deleted_mmr_positions(
+        &self,
+        mmr_positions: Vec<u32>,
+    ) -> Result<Vec<Option<(u64, HashOutput)>>, ChainStorageError> {
+        self.db
+            .as_ref()
+            .unwrap()
+            .fetch_header_hash_by_deleted_mmr_positions(mmr_positions)
+    }
 }
 
 pub fn create_chained_blocks(

--- a/base_layer/core/tests/chain_storage_tests/chain_storage.rs
+++ b/base_layer/core/tests/chain_storage_tests/chain_storage.rs
@@ -1771,60 +1771,65 @@ fn fetch_deleted_position_block_hash() {
         from: vec![outputs[0][0].clone()],
         to: vec![11 * T, 12 * T, 13 * T, 14 * T]
     )];
-    assert!(generate_new_block_with_achieved_difficulty(
+    generate_new_block_with_achieved_difficulty(
         &mut store,
         &mut blocks,
         &mut outputs,
         txs,
         Difficulty::from(1),
-        &consensus_manager
+        &consensus_manager,
     )
-    .is_ok());
+    .unwrap()
+    .assert_added();
     // Block 2
     let txs = vec![txn_schema!(from: vec![outputs[1][3].clone()], to: vec![6 * T])];
-    assert!(generate_new_block_with_achieved_difficulty(
+    generate_new_block_with_achieved_difficulty(
         &mut store,
         &mut blocks,
         &mut outputs,
         txs,
         Difficulty::from(3),
-        &consensus_manager
+        &consensus_manager,
     )
-    .is_ok());
+    .unwrap()
+    .assert_added();
     // Blocks 3 - 12 so we can test the search in the bottom and top half
     for i in 0..10 {
-        assert!(generate_new_block_with_achieved_difficulty(
+        generate_new_block_with_achieved_difficulty(
             &mut store,
             &mut blocks,
             &mut outputs,
             vec![],
             Difficulty::from(4 + i),
-            &consensus_manager
+            &consensus_manager,
         )
-        .is_ok());
+        .unwrap()
+        .assert_added();
     }
     // Block 13
     let txs = vec![txn_schema!(from: vec![outputs[2][0].clone()], to: vec![2 * T])];
-    assert!(generate_new_block_with_achieved_difficulty(
+    generate_new_block_with_achieved_difficulty(
         &mut store,
         &mut blocks,
         &mut outputs,
         txs,
         Difficulty::from(30),
-        &consensus_manager
+        &consensus_manager,
     )
-    .is_ok());
+    .unwrap()
+    .assert_added();
     // Block 14
     let txs = vec![txn_schema!(from: vec![outputs[13][0].clone()], to: vec![1 * T])];
-    assert!(generate_new_block_with_achieved_difficulty(
+    generate_new_block_with_achieved_difficulty(
         &mut store,
         &mut blocks,
         &mut outputs,
         txs,
         Difficulty::from(50),
-        &consensus_manager
+        &consensus_manager,
     )
-    .is_ok());
+    .unwrap()
+    .assert_added();
 
     let block1_hash = store.fetch_header(1).unwrap().unwrap().hash();
     let block2_hash = store.fetch_header(2).unwrap().unwrap().hash();
@@ -1838,11 +1843,13 @@ fn fetch_deleted_position_block_hash() {
         .to_vec();
 
     let headers = store
-        .fetch_headers_of_deleted_positions(deleted_positions.iter().map(|p| *p as u64).collect())
+        .fetch_header_hash_by_deleted_mmr_positions(deleted_positions)
         .unwrap();
+    let mut headers = headers.into_iter().map(Option::unwrap).collect::<Vec<_>>();
+    headers.sort_by(|(a, _), (b, _)| a.cmp(b));
 
-    assert_eq!(headers[0].hash(), block14_hash);
-    assert_eq!(headers[1].hash(), block13_hash);
-    assert_eq!(headers[2].hash(), block2_hash);
-    assert_eq!(headers[3].hash(), block1_hash);
+    assert_eq!(headers[3], (14, block14_hash));
+    assert_eq!(headers[2], (13, block13_hash));
+    assert_eq!(headers[1], (2, block2_hash));
+    assert_eq!(headers[0], (1, block1_hash));
 }


### PR DESCRIPTION
Description
---
- add index to optimise query for block height from deleted mmr position
- update query_deleted rpc call to use new call
- check if database should be resynced to avoid confusion around
  db errors resulting from this change
- exit code message showing help for a required db resync



Motivation and Context
---
Base node RPC call to `query_deleted` is slow
 
How Has This Been Tested?
---
Updated blockchain db unit test, manually

BREAKING CHANGE: blockchain database will need to be resynced