### PR TITLE
chore: remove fee from SubmitTransaction

### DIFF
--- a/applications/tari_console_wallet/src/automation/commands.rs
+++ b/applications/tari_console_wallet/src/automation/commands.rs
@@ -170,11 +170,11 @@ pub async fn coin_split(
         _ => Err(CommandError::Argument),
     }?;
 
-    let (tx_id, tx, fee, amount) = output_service
+    let (tx_id, tx, amount) = output_service
         .create_coin_split(amount_per_split, num_splits as usize, MicroTari(100), None)
         .await?;
     transaction_service
-        .submit_transaction(tx_id, tx, fee, amount, "Coin split".into())
+        .submit_transaction(tx_id, tx, amount, "Coin split".into())
         .await?;
 
     Ok(tx_id)
@@ -694,9 +694,8 @@ pub async fn command_runner(
                 let message = format!("Register asset: {}", name);
                 let mut manager = wallet.asset_manager.clone();
                 let (tx_id, transaction) = manager.create_registration_transaction(name).await?;
-                let fee = transaction.body.get_total_fee();
                 let _result = transaction_service
-                    .submit_transaction(tx_id, transaction, fee, 0.into(), message)
+                    .submit_transaction(tx_id, transaction, 0.into(), message)
                     .await?;
             },
             MintTokens => {
@@ -728,9 +727,8 @@ pub async fn command_runner(
                 let (tx_id, transaction) = asset_manager
                     .create_minting_transaction(&public_key, asset.owner_commitment(), unique_ids)
                     .await?;
-                let fee = transaction.body.get_total_fee();
                 let _result = transaction_service
-                    .submit_transaction(tx_id, transaction, fee, 0.into(), message)
+                    .submit_transaction(tx_id, transaction, 0.into(), message)
                     .await?;
             },
             CreateInitialCheckpoint => {
@@ -759,12 +757,10 @@ pub async fn command_runner(
                 let (tx_id, transaction) = asset_manager
                     .create_initial_asset_checkpoint(&public_key, &merkle_root)
                     .await?;
-                let fee = transaction.body.get_total_fee();
                 let _result = transaction_service
                     .submit_transaction(
                         tx_id,
                         transaction,
-                        fee,
                         0.into(),
                         "test initial asset checkpoint transaction".to_string(),
                     )

--- a/applications/tari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/tari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -377,7 +377,6 @@ impl wallet_server::Wallet for WalletGrpcServer {
             .create_minting_transaction(&asset_public_key, asset.owner_commitment(), message.unique_ids)
             .await
             .map_err(|e| Status::internal(e.to_string()))?;
-        let fee = transaction.body.get_total_fee();
 
         let owner_commitments = transaction
             .body
@@ -386,7 +385,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
             .filter_map(|o| o.features.unique_id.as_ref().map(|_| o.commitment.to_vec()))
             .collect();
         let _result = transaction_service
-            .submit_transaction(tx_id, transaction, fee, 0.into(), "test mint transaction".to_string())
+            .submit_transaction(tx_id, transaction, 0.into(), "test mint transaction".to_string())
             .await
             .map_err(|e| Status::internal(e.to_string()))?;
 

--- a/base_layer/wallet/src/output_manager_service/handle.rs
+++ b/base_layer/wallet/src/output_manager_service/handle.rs
@@ -189,7 +189,7 @@ pub enum OutputManagerResponse {
     SeedWords(Vec<String>),
     BaseNodePublicKeySet,
     UtxoValidationStarted(u64),
-    Transaction((TxId, Transaction, MicroTari, MicroTari)),
+    Transaction((TxId, Transaction, MicroTari)),
     EncryptionApplied,
     EncryptionRemoved,
     PublicRewindKeys(Box<PublicRewindKeys>),
@@ -557,7 +557,7 @@ impl OutputManagerHandle {
         split_count: usize,
         fee_per_gram: MicroTari,
         lock_height: Option<u64>,
-    ) -> Result<(TxId, Transaction, MicroTari, MicroTari), OutputManagerError> {
+    ) -> Result<(TxId, Transaction, MicroTari), OutputManagerError> {
         match self
             .handle
             .call(OutputManagerRequest::CreateCoinSplit((

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -1316,7 +1316,7 @@ where TBackend: OutputManagerBackend + 'static
         split_count: usize,
         fee_per_gram: MicroTari,
         lock_height: Option<u64>,
-    ) -> Result<(TxId, Transaction, MicroTari, MicroTari), OutputManagerError> {
+    ) -> Result<(TxId, Transaction, MicroTari), OutputManagerError> {
         trace!(
             target: LOG_TARGET,
             "Select UTXOs and estimate coin split transaction fee."
@@ -1425,7 +1425,7 @@ where TBackend: OutputManagerBackend + 'static
         trace!(target: LOG_TARGET, "Finalize coin split transaction ({}).", tx_id);
         stp.finalize(KernelFeatures::empty(), &factories)?;
         let tx = stp.take_transaction()?;
-        Ok((tx_id, tx, fee, utxos_total_value))
+        Ok((tx_id, tx, utxos_total_value))
     }
 
     /// Persist a one-sided payment script for a Comms Public/Private key. These are the scripts that this wallet knows

--- a/base_layer/wallet/src/transaction_service/handle.rs
+++ b/base_layer/wallet/src/transaction_service/handle.rs
@@ -493,10 +493,10 @@ impl TransactionServiceHandle {
         &mut self,
         tx_id: TxId,
         tx: Transaction,
-        fee: MicroTari,
         amount: MicroTari,
         message: String,
     ) -> Result<(), TransactionServiceError> {
+        let fee = tx.body.get_total_fee();
         match self
             .handle
             .call(TransactionServiceRequest::SubmitSelfSendTransaction(

--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -499,10 +499,10 @@ where
             .await;
 
         match coin_split_tx {
-            Ok((tx_id, split_tx, amount, fee)) => {
+            Ok((tx_id, split_tx, amount)) => {
                 let coin_tx = self
                     .transaction_service
-                    .submit_transaction(tx_id, split_tx, fee, amount, message)
+                    .submit_transaction(tx_id, split_tx, amount, message)
                     .await;
                 match coin_tx {
                     Ok(_) => Ok(tx_id),


### PR DESCRIPTION
Description
---
Remove fee from `SubmitTransaction`, it's already stored in `tx.body.get_total_fee()`.

Motivation and Context
---
Simplify the code.

How Has This Been Tested?
---
`cargo test` on development branch after removing the fee from `coin_split`

