### PR TITLE
feat: fix reinstating CancelledInbound outputs and fix tests

### DIFF
--- a/base_layer/wallet/migrations/2021-10-01-053552_clear_mined_height/down.sql
+++ b/base_layer/wallet/migrations/2021-10-01-053552_clear_mined_height/down.sql
@@ -1,0 +1,1 @@
+-- This file should undo anything in `up.sql`

--- a/base_layer/wallet/migrations/2021-10-01-053552_clear_mined_height/up.sql
+++ b/base_layer/wallet/migrations/2021-10-01-053552_clear_mined_height/up.sql
@@ -1,0 +1,5 @@
+-- mined_height and mined_in_block should always be set together, since mined_in_block is NULL we set mined_height to NULL
+-- so that the transactions can be revalidated.
+UPDATE completed_transactions
+SET mined_height = NULL
+WHERE mined_height IS NOT NULL AND mined_in_block IS NULL;

--- a/base_layer/wallet/src/output_manager_service/handle.rs
+++ b/base_layer/wallet/src/output_manager_service/handle.rs
@@ -480,7 +480,10 @@ impl OutputManagerHandle {
         }
     }
 
-    pub async fn reinstate_cancelled_inbound_transaction(&mut self, tx_id: TxId) -> Result<(), OutputManagerError> {
+    pub async fn reinstate_cancelled_inbound_transaction_outputs(
+        &mut self,
+        tx_id: TxId,
+    ) -> Result<(), OutputManagerError> {
         match self
             .handle
             .call(OutputManagerRequest::ReinstateCancelledInboundTx(tx_id))

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -320,7 +320,7 @@ where
                 .await
                 .map(|_| OutputManagerResponse::AddKnownOneSidedPaymentScript),
             OutputManagerRequest::ReinstateCancelledInboundTx(tx_id) => self
-                .reinstate_cancelled_inbound_transaction(tx_id)
+                .reinstate_cancelled_inbound_transaction_outputs(tx_id)
                 .await
                 .map(|_| OutputManagerResponse::ReinstatedCancelledInboundTx),
             OutputManagerRequest::SetCoinbaseAbandoned(tx_id, abandoned) => self
@@ -816,25 +816,10 @@ where
 
     /// Restore the pending transaction encumberance and output for an inbound transaction that was previously
     /// cancelled.
-    async fn reinstate_cancelled_inbound_transaction(&mut self, _tx_id: TxId) -> Result<(), OutputManagerError> {
-        // TODO: is this still needed?
-        unimplemented!("Still needed?");
-        // self.resources.db.reinstate_inbound_output(tx_id).await?;
-        //
-        // self.resources
-        //     .db
-        //     .add_pending_transaction_outputs(PendingTransactionOutputs {
-        //         tx_id,
-        //         outputs_to_be_spent: Vec::new(),
-        //         outputs_to_be_received: Vec::new(),
-        //         timestamp: Utc::now().naive_utc(),
-        //         coinbase_block_height: None,
-        //     })
-        //     .await?;
-        //
-        // self.confirm_encumberance(tx_id).await?;
+    async fn reinstate_cancelled_inbound_transaction_outputs(&mut self, tx_id: TxId) -> Result<(), OutputManagerError> {
+        self.resources.db.reinstate_cancelled_inbound_output(tx_id).await?;
 
-        // Ok(())
+        Ok(())
     }
 
     /// Select which unspent transaction outputs to use to send a transaction of the specified amount. Use the specified

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_broadcast_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_broadcast_protocol.rs
@@ -125,10 +125,12 @@ where
             loop {
                 tokio::select! {
                     _ = current_base_node_watcher.changed() => {
-                             info!(
-                                target: LOG_TARGET,
-                                "Transaction Broadcast protocol (TxId: {}) Base Node Public key updated to {:?}", self.tx_id, current_base_node_watcher.borrow()
-                            );
+                            if let Some(peer) = &*current_base_node_watcher.borrow() {
+                                info!(
+                                    target: LOG_TARGET,
+                                    "Transaction Broadcast protocol (TxId: {}) Base Node Public key updated to {} (NodeID: {})", self.tx_id, peer.public_key, peer.node_id
+                                );
+                            }
                             self.last_rejection = None;
                             continue;
                     },

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -1384,7 +1384,7 @@ where
                         );
                         self.db.uncancel_pending_transaction(tx_id).await?;
                         self.output_manager_service
-                            .reinstate_cancelled_inbound_transaction(tx_id)
+                            .reinstate_cancelled_inbound_transaction_outputs(tx_id)
                             .await?;
 
                         self.restart_receive_transaction_protocol(tx_id, source_pubkey.clone(), join_handles);

--- a/base_layer/wallet/tests/transaction_service/mod.rs
+++ b/base_layer/wallet/tests/transaction_service/mod.rs
@@ -20,8 +20,6 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-// TODO: These tests need to be rewritten to either be full integration tests (i.e. using the real wallet connectivity
-//       service) or changed to only test the component without building a full service stack
-// pub mod service;
+pub mod service;
 pub mod storage;
 pub mod transaction_protocols;

--- a/comms/src/protocol/rpc/handshake.rs
+++ b/comms/src/protocol/rpc/handshake.rs
@@ -87,7 +87,7 @@ where T: AsyncRead + AsyncWrite + Unpin
                     .find(|v| msg.supported_versions.contains(v));
                 if let Some(version) = version {
                     event!(Level::INFO, version = version, "Server accepted version");
-                    debug!(target: LOG_TARGET, "Server accepted version {}", version);
+                    debug!(target: LOG_TARGET, "Server accepted version: {}", version);
                     let reply = proto::rpc::RpcSessionReply {
                         session_result: Some(proto::rpc::rpc_session_reply::SessionResult::AcceptedVersion(*version)),
                         ..Default::default()


### PR DESCRIPTION
Description
---
This PR adds back the ability to reinstate a CancelledInbound transaction outputs in the case that a cancelled inbound transaction gets a reply via SAF after its been cancelled.

The majority of this PR is actually fixing transaction service tests in the `tx-validation2` branch.

It also adds an extra db migration to clear existing `mined_height` values from the `completed_transaction` table to have all completed transactions get fully revalidated after a migration from an old db schema.

How Has This Been Tested?
---
tests provided and fixed
