### PR TITLE
fix: iOS linker error workaround

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,8 @@ jobs:
           sudo apt-get update && \
           sudo apt-get -y install \
             libssl-dev \
+            openssl \
+            libsqlite3-dev \
             clang-10 \
             pkg-config \
             git \
@@ -119,6 +121,8 @@ jobs:
           sudo apt-get update && \
           sudo apt-get -y install \
             libssl-dev \
+            openssl \
+            libsqlite3-dev \
             pkg-config \
             git \
             cmake \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1883,7 +1883,7 @@ dependencies = [
  "byteorder",
  "color_quant",
  "num-iter",
- "num-rational 0.3.2",
+ "num-rational",
  "num-traits 0.2.14",
 ]
 
@@ -2497,24 +2497,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b7a8e9be5e039e2ff869df49155f1c06bd01ade2117ec783e56ab0932b67a8f"
 dependencies = [
  "num-bigint 0.3.2",
- "num-complex 0.3.1",
+ "num-complex",
  "num-integer",
  "num-iter",
- "num-rational 0.3.2",
- "num-traits 0.2.14",
-]
-
-[[package]]
-name = "num"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
-dependencies = [
- "num-bigint 0.4.1",
- "num-complex 0.4.0",
- "num-integer",
- "num-iter",
- "num-rational 0.4.0",
+ "num-rational",
  "num-traits 0.2.14",
 ]
 
@@ -2534,17 +2520,6 @@ name = "num-bigint"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d0a3d5e207573f948a9e5376662aa743a2ea13f7c50a554d7af443a73fbfeba"
-dependencies = [
- "autocfg 1.0.1",
- "num-integer",
- "num-traits 0.2.14",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76e97c412795abf6c24ba30055a8f20642ea57ca12875220b854cfa501bf1e48"
 dependencies = [
  "autocfg 1.0.1",
  "num-integer",
@@ -2575,15 +2550,6 @@ name = "num-complex"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "747d632c0c558b87dbabbe6a82f3b4ae03720d0646ac5b7b4dae89394be5f2c5"
-dependencies = [
- "num-traits 0.2.14",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26873667bbbb7c5182d4a37c1add32cdf09f841af72da53318fdb81543c15085"
 dependencies = [
  "num-traits 0.2.14",
 ]
@@ -2638,18 +2604,6 @@ checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
 dependencies = [
  "autocfg 1.0.1",
  "num-bigint 0.3.2",
- "num-integer",
- "num-traits 0.2.14",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d41702bd167c2df5520b384281bc111a4b5efcf7fbc4c9c222c815b07e0a6a6a"
-dependencies = [
- "autocfg 1.0.1",
- "num-bigint 0.4.1",
  "num-integer",
  "num-traits 0.2.14",
 ]
@@ -3702,23 +3656,22 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.4.0"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b9bd29cdffb8875b04f71c51058f940cf4e390bbfd2ce669c4f22cd70b492a5"
+checksum = "525bc1abfda2e1998d152c45cf13e696f76d0a4972310b22fac1658b05df7c87"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
  "core-foundation-sys",
  "libc",
- "num 0.4.0",
  "security-framework-sys",
 ]
 
 [[package]]
 name = "security-framework-sys"
-version = "2.4.0"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19133a286e494cc3311c165c4676ccb1fd47bed45b55f9d71fbd784ad4cea6f8"
+checksum = "a9dd14d83160b528b7bfd66439110573efcfbe281b17fc2ca9f39f550d619c7e"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -4488,7 +4441,7 @@ dependencies = [
  "log 0.4.14",
  "monero",
  "newtype-ops",
- "num 0.3.1",
+ "num",
  "num-format",
  "prost",
  "prost-types",
@@ -4877,6 +4830,7 @@ dependencies = [
  "log 0.4.14",
  "log4rs 1.0.0",
  "rand 0.8.4",
+ "security-framework",
  "tari_common_types",
  "tari_comms",
  "tari_comms_dht",

--- a/base_layer/wallet/Cargo.toml
+++ b/base_layer/wallet/Cargo.toml
@@ -55,6 +55,6 @@ env_logger = "0.7.1"
 prost = "0.8.0"
 
 [features]
-default=["bundled_sqlite"]
+c_integration = []
 avx2 = ["tari_crypto/avx2", "tari_core/avx2"]
 bundled_sqlite = ["libsqlite3-sys"]

--- a/base_layer/wallet_ffi/Cargo.toml
+++ b/base_layer/wallet_ffi/Cargo.toml
@@ -7,13 +7,13 @@ version = "0.18.6"
 edition = "2018"
 
 [dependencies]
-tari_comms = { version = "^0.10", path = "../../comms" }
+tari_comms = { version = "^0.10", path = "../../comms", features = ["c_integration"]}
 tari_comms_dht = { version = "^0.10", path = "../../comms/dht", default-features = false }
 tari_common_types = {path="../common_types"}
 tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", branch = "main" }
 tari_key_manager = { version = "^0.10", path = "../key_manager" }
 tari_p2p = { version = "^0.10", path = "../p2p" }
-tari_wallet = { version = "^0.10", path = "../wallet", default-features = false }
+tari_wallet = { version = "^0.10", path = "../wallet", features = ["c_integration"]}
 tari_shutdown = { version = "^0.10", path = "../../infrastructure/shutdown" }
 tari_utilities = "^0.3"
 
@@ -26,6 +26,16 @@ rand = "0.8"
 thiserror = "1.0.26"
 tokio = "1.11"
 
+# <workaround>
+# Temporary workaround until crates utilizing openssl have been updated from security-framework 2.4.0
+# which is currently broken for iOS
+[target.x86_64-apple-ios.dependencies]
+security-framework = "2.4.2"
+
+[target.aarch64-apple-ios.dependencies]
+security-framework = "2.4.2"
+# </workaround>
+
 [dependencies.tari_core]
 path = "../../base_layer/core"
 version = "^0.10"
@@ -34,11 +44,6 @@ features = ["transactions"]
 
 [lib]
 crate-type = ["staticlib","cdylib"]
-
-[features]
-default = ["bundled_sqlite", "bundled_openssl"]
-bundled_openssl= [ "tari_comms/bundled_openssl"]
-bundled_sqlite = ["tari_wallet/bundled_sqlite"]
 
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/base_layer/wallet_ffi/mobile_build.sh
+++ b/base_layer/wallet_ffi/mobile_build.sh
@@ -79,13 +79,19 @@ if [ -n "${DEPENDENCIES}" ] && [ -n "${PKG_PATH}" ] && [ "${BUILD_IOS}" -eq 1 ] 
   export PKG_CONFIG_PATH=${PKG_PATH}
   # shellcheck disable=SC2028
   echo "\t${CYAN}Building Wallet FFI${NC}"
-  cargo-lipo lipo --release --no-default-features > "${IOS_LOG_PATH}/cargo.txt" 2>&1
+  cargo build --lib --release --target=x86_64-apple-ios > "${IOS_LOG_PATH}/cargo_ios_x86_64.txt" 2>&1
+  cargo build --lib --release --target=aarch64-apple-ios > "${IOS_LOG_PATH}/cargo_ios_aarch64.txt" 2>&1
   cd ../..
   cd target || exit
-  # Copy the fat library (which contains symbols for all built iOS architectures) created by the lipo tool
-  # XCode will select the relevant set of symbols to be included in the mobile application depending on which arch is built
+  mkdir -p universal/release
   cd universal || exit
   cd release || exit
+  # Create the fat library from the thin ones.
+  cp "../../x86_64-apple-ios/release/libtari_wallet_ffi.a" "${PWD}/libtari_wallet_ffi_x86_64.a"
+  cp "../../aarch64-apple-ios/release/libtari_wallet_ffi.a" "${PWD}/libtari_wallet_ffi_aarch64.a"
+  lipo -create libtari_wallet_ffi_x86_64.a libtari_wallet_ffi_aarch64.a -output libtari_wallet_ffi.a
+  # Copy the fat library (which contains symbols for all built iOS architectures) created by the lipo tool
+  # XCode will select the relevant set of symbols to be included in the mobile application depending on which arch is built
   cp libtari_wallet_ffi.a "${DEPENDENCIES}/MobileWallet/TariLib/"
   cd ../../.. || exit
   rm -rf target
@@ -392,9 +398,9 @@ EOF
       if [ "${MACHINE}" == "Mac" ]; then
         if [ "${MAC_MAIN_VERSION}" -le 10 ]; then
           if [ "${MAC_SUB_VERSION}" -ge 15 ]; then
-            cargo build --lib --release --no-default-features > "${ANDROID_LOG_PATH}/cargo_${PLATFORMABI}_${LEVEL}.txt" 2>&1
+            cargo build --lib --release > "${ANDROID_LOG_PATH}/cargo_${PLATFORMABI}_${LEVEL}.txt" 2>&1
           else
-            cargo ndk --target ${PLATFORMABI} --android-platform ${LEVEL} -- build --release --no-default-features > "${ANDROID_LOG_PATH}/cargo_${PLATFORMABI}_${LEVEL}.txt" 2>&1
+            cargo ndk --target ${PLATFORMABI} --android-platform ${LEVEL} -- build --release > "${ANDROID_LOG_PATH}/cargo_${PLATFORMABI}_${LEVEL}.txt" 2>&1
           fi
         else
           # Fix for lmdb-sys compilation for armv7 on Big Sur
@@ -405,7 +411,7 @@ EOF
             # shellcheck disable=SC2028
             echo "\t${CYAN}Extraction complete, continuing build ${NC}"
           fi
-          cargo build --lib --release --no-default-features > "${ANDROID_LOG_PATH}/cargo_${PLATFORMABI}_${LEVEL}.txt" 2>&1
+          cargo build --lib --release > "${ANDROID_LOG_PATH}/cargo_${PLATFORMABI}_${LEVEL}.txt" 2>&1
           if [ "${PLATFORMABI}" == "armv7-linux-androideabi" ]; then
             BACKTRACK=${PWD}
             # shellcheck disable=SC2028
@@ -416,7 +422,7 @@ EOF
           fi
         fi
       else
-        cargo ndk --target ${PLATFORMABI} --android-platform ${LEVEL} -- build --release --no-default-features > "${ANDROID_LOG_PATH}/cargo_${PLATFORMABI}_${LEVEL}.txt" 2>&1
+        cargo ndk --target ${PLATFORMABI} --android-platform ${LEVEL} -- build --release > "${ANDROID_LOG_PATH}/cargo_${PLATFORMABI}_${LEVEL}.txt" 2>&1
       fi
       cp wallet.h "${DEPENDENCIES}/"
       rm -rf .cargo

--- a/comms/Cargo.toml
+++ b/comms/Cargo.toml
@@ -65,6 +65,6 @@ tempfile = "3.1.0"
 tari_common = { version = "^0.10", path = "../common", features = ["build"] }
 
 [features]
-bundled_openssl = ["openssl-sys/vendored"]
+c_integration = []
 avx2 = ["tari_crypto/avx2"]
 rpc = ["tower-make"]


### PR DESCRIPTION
Description
---
revert bundle sqlite by default for tests (#3382)
workaround for  linker error for iOS framework
added dynamically linked dependencies to ci.yml for wallet_ffi tests

Motivation and Context
---
Resolves this linker error on iOS:
```
Undefined symbols for architecture arm64:
  "_SecTrustCopyAnchorCertificates", referenced from:
      security_framework::trust::SecTrust::copy_anchor_certificates::h87efeb6d9bd22eb2 in libtari_wallet_ffi.a
```

How Has This Been Tested?
---
Manually.
