### PR TITLE
fix: update message on finding a valid share in tari_mining_node

### DIFF
--- a/applications/tari_mining_node/src/stratum/stratum_miner/miner.rs
+++ b/applications/tari_mining_node/src/stratum/stratum_miner/miner.rs
@@ -132,13 +132,13 @@ impl StratumMiner {
                     if difficulty >= target_difficulty {
                         let block_header: BlockHeader = BlockHeader::try_from(hasher.into_header()).unwrap();
                         info!(
-                            "Miner found block header with hash {}, nonce {} and difficulty {:?}",
+                            "Miner found share with hash {}, nonce {} and difficulty {:?}",
                             block_header.hash().to_hex(),
                             solver.current_nonce,
                             difficulty
                         );
                         debug!(
-                            "Miner found block header with hash {}, difficulty {:?} and data {:?}",
+                            "Miner found share with hash {}, difficulty {:?} and data {:?}",
                             block_header.hash().to_hex(),
                             difficulty,
                             block_header


### PR DESCRIPTION
Description
---
When pool mining, the miner finds shares (valid solutions to a block that meets the minimum difficulty of the pool and may or may not meet the minimum difficulty to be included on the chain). The miner is also only rewarded for these shares by the pool based on the rewards system the pool uses.

Motivation and Context
---
Prevents confusion between finding a block when solo mining and finding a share when pool mining. 

How Has This Been Tested?
---
N/A

