### PR TITLE
fix: don't display an error when there is no message to be read in tari_mining_node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4820,7 +4820,7 @@ dependencies = [
 
 [[package]]
 name = "tari_wallet_ffi"
-version = "0.18.7"
+version = "0.18.8"
 dependencies = [
  "chrono",
  "env_logger 0.7.1",

--- a/applications/tari_mining_node/src/stratum/controller.rs
+++ b/applications/tari_mining_node/src/stratum/controller.rs
@@ -349,12 +349,14 @@ impl Controller {
                                 error!("Error parsing message: {}", m)
                             }
                         },
+                        Ok(None) => {
+                            // noop, nothing to read for this interval
+                        },
                         Err(e) => {
                             error!("Error reading message: {:?}", e);
                             self.stream = None;
                             continue;
                         },
-                        _ => error!("Error reading message: None"),
                     }
                     next_server_read = time::get_time().sec + server_read_interval;
                 }


### PR DESCRIPTION
Description
---
Fixes a minor bug introduced by accident in PR#3396 causing terminal and logs to be peppered with errors for tari_mining_node (mining against a pool) where no action should be taken instead.

Motivation and Context
---
Prevents the following message from being incorrectly reported:
```
ERROR Error reading message: None
```

How Has This Been Tested?
---
Manually
