### PR TITLE
fix: updates to daily recovery test

### DIFF
--- a/applications/daily_tests/automatic_recovery_test.js
+++ b/applications/daily_tests/automatic_recovery_test.js
@@ -65,7 +65,7 @@ async function run(options = {}) {
       grpc_console_wallet_address: "127.0.0.1:18111",
       baseDir: options.baseDir || "./temp/base-nodes/",
     },
-    false,
+    "../../integration_tests/log4rs/wallet.yml",
     options.seedWords
   );
 
@@ -93,12 +93,6 @@ async function run(options = {}) {
             numScanned: parseInt(scannedMatch[1]),
             recoveredAmount,
           };
-        }
-
-        let errMatch = data.match(FAILURE_REGEXP);
-        // One extra attempt
-        if (errMatch && parseInt(errMatch[1]) > 1) {
-          throw new Error(data);
         }
 
         return null;

--- a/applications/daily_tests/cron_jobs.js
+++ b/applications/daily_tests/cron_jobs.js
@@ -52,10 +52,10 @@ async function runWalletRecoveryTest(instances) {
       scannedRate,
       recoveredAmount,
     } = await walletRecoveryTest({
-        seedWords:
-          "spare man patrol essay divide hollow trip visual actress sadness country hungry toy blouse body club depend capital sleep aim high recycle crystal abandon",
-        log: LOG_FILE,
-        numWallets: instances,
+      seedWords:
+        "spare man patrol essay divide hollow trip visual actress sadness country hungry toy blouse body club depend capital sleep aim high recycle crystal abandon",
+      log: LOG_FILE,
+      numWallets: instances,
       baseDir,
     });
 
@@ -136,7 +136,7 @@ async function main() {
 
   // ------------------------- CRON ------------------------- //
   new CronJob("0 7 * * *", () => runWalletRecoveryTest(1)).start();
-  new CronJob("30 7 * * *", () => runWalletRecoveryTest(5)).start();
+  //new CronJob("30 7 * * *", () => runWalletRecoveryTest(5)).start();
   new CronJob("0 6 * * *", () =>
     runBaseNodeSyncTest(SyncType.Archival)
   ).start();

--- a/applications/tari_console_wallet/src/recovery.rs
+++ b/applications/tari_console_wallet/src/recovery.rs
@@ -26,6 +26,7 @@ use log::*;
 use rustyline::Editor;
 use tari_app_utilities::utilities::ExitCodes;
 use tari_common_types::types::PrivateKey;
+use tari_crypto::tari_utilities::hex::Hex;
 use tari_key_manager::mnemonic::to_secretkey;
 use tari_shutdown::Shutdown;
 use tari_wallet::{
@@ -89,13 +90,19 @@ pub async fn wallet_recovery(wallet: &WalletSqlite, base_node_config: &PeerConfi
     let peer_manager = wallet.comms.peer_manager();
     let mut peer_public_keys = Vec::with_capacity(peers.len());
     for peer in peers {
+        debug!(
+            target: LOG_TARGET,
+            "Peer added: {} (NodeId: {})",
+            peer.public_key.to_hex(),
+            peer.node_id.to_hex()
+        );
         peer_public_keys.push(peer.public_key.clone());
         peer_manager.add_peer(peer).await?;
     }
 
     let mut recovery_task = UtxoScannerService::<WalletSqliteDatabase>::builder()
         .with_peers(peer_public_keys)
-        .with_retry_limit(10)
+        .with_retry_limit(3)
         .build_with_wallet(wallet, shutdown_signal);
 
     let mut event_stream = recovery_task.get_event_receiver();
@@ -106,7 +113,7 @@ pub async fn wallet_recovery(wallet: &WalletSqlite, base_node_config: &PeerConfi
     loop {
         match event_stream.recv().await {
             Ok(UtxoScannerEvent::ConnectingToBaseNode(peer)) => {
-                print!("Connecting to base node {}... ", peer);
+                println!("Connecting to base node {}... ", peer);
             },
             Ok(UtxoScannerEvent::ConnectedToBaseNode(_, latency)) => {
                 println!("OK (latency = {:.2?})", latency);

--- a/base_layer/wallet/src/utxo_scanner_service/utxo_scanning.rs
+++ b/base_layer/wallet/src/utxo_scanner_service/utxo_scanning.rs
@@ -724,8 +724,12 @@ where TBackend: WalletBackend + 'static
                 _ = self.resources.current_base_node_watcher.changed() => {
                     debug!(target: LOG_TARGET, "Base node change detected.");
                     let peer =  self.resources.current_base_node_watcher.borrow().as_ref().cloned();
-                    if let Some(peer) = peer {
-                        self.peer_seeds = vec![peer.public_key];
+
+                    // If we are recovering we will stick to the initially provided seeds
+                    if self.mode != UtxoScannerMode::Recovery {
+                        if let Some(peer) = peer {
+                            self.peer_seeds = vec![peer.public_key];
+                        }
                     }
 
                     self.is_running.store(false, Ordering::Relaxed);


### PR DESCRIPTION
Description
---
This PR provides some fixes to debug and hopefully fix the daily recovery test
- Use the debug logging config to produce more verbose logs
- Stop the Utxo Scanner from overriding the seed peers when doing a recovery
- Remove a weird javascript regex panic statement and just reduce the number of retries in the config
- Only run a single daily test to make the logs more readable


How Has This Been Tested?
---
This is to fix some tests
