### PR TITLE
fix: prevent tari_mining_node from being able to start without a valid address for pool mining

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4560,7 +4560,7 @@ dependencies = [
 
 [[package]]
 name = "tari_mining_node"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "bufstream",
  "chrono",

--- a/applications/tari_mining_node/Cargo.toml
+++ b/applications/tari_mining_node/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "The tari mining node implementation"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2018"
 
 [dependencies]
@@ -12,7 +12,7 @@ tari_core = { path = "../../base_layer/core",  default-features = false }
 tari_common = {  path = "../../common" }
 tari_app_utilities = { path = "../tari_app_utilities"}
 tari_app_grpc = {  path = "../tari_app_grpc" }
-
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", branch = "main" }
 crossbeam = "0.8"
 futures = "0.3"
 log = { version = "0.4", features = ["std"] }
@@ -34,6 +34,5 @@ chrono = "0.4"
 hex = "0.4.2"
 
 [dev-dependencies]
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", branch = "main" }
 prost-types = "0.8"
 chrono = "0.4"

--- a/applications/tari_mining_node/src/main.rs
+++ b/applications/tari_mining_node/src/main.rs
@@ -47,9 +47,13 @@ use std::{
     time::Instant,
 };
 use tari_app_grpc::tari_rpc::{base_node_client::BaseNodeClient, wallet_client::WalletClient};
-use tari_app_utilities::{initialization::init_configuration, utilities::ExitCodes};
+use tari_app_utilities::{
+    initialization::init_configuration,
+    utilities::{ExitCodes, ExitCodes::ConfigError},
+};
 use tari_common::{configuration::bootstrap::ApplicationType, ConfigBootstrap, DefaultConfigLoader, GlobalConfig};
 use tari_core::blocks::BlockHeader;
+use tari_crypto::{ristretto::RistrettoPublicKey, tari_utilities::hex::Hex};
 use tokio::{runtime::Runtime, time::sleep};
 use tonic::transport::Channel;
 use utils::{coinbase_request, extract_outputs_and_kernels};
@@ -82,6 +86,8 @@ async fn main_inner() -> Result<(), ExitCodes> {
     if !config.mining_wallet_address.is_empty() && !config.mining_pool_address.is_empty() {
         let url = config.mining_pool_address.clone();
         let mut miner_address = config.mining_wallet_address.clone();
+        let _ = RistrettoPublicKey::from_hex(&miner_address)
+            .map_err(|_| ConfigError("Miner is not configured with a valid wallet address.".to_string()))?;
         if !config.mining_worker_name.is_empty() {
             miner_address += &format!("{}{}", ".", &config.mining_worker_name);
         }


### PR DESCRIPTION

Description
---
Prevent tari_mining_node from starting without a valid address.

Motivation and Context
---
Use should be informed that the configuration is invalid as soon as possible.

How Has This Been Tested?
---
Manually
