### PR TITLE
fix: add display_currency_decimal method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -699,6 +699,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1058,6 +1064,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
 
 [[package]]
+name = "decimal-rs"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "628081e4b054b20bc00989885feca733c66f19d0e983bb4a3b81b6edcd0b70bc"
+dependencies = [
+ "ethnum",
+ "fast-float",
+ "stack-buf",
+ "thiserror",
+]
+
+[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1101,6 +1119,19 @@ dependencies = [
  "darling",
  "proc-macro2 1.0.28",
  "quote 1.0.9",
+ "syn 1.0.75",
+]
+
+[[package]]
+name = "derive_more"
+version = "0.99.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40eebddd2156ce1bb37b20bbe5151340a31828b1f2d22ba4141f3531710e38df"
+dependencies = [
+ "convert_case",
+ "proc-macro2 1.0.28",
+ "quote 1.0.9",
+ "rustc_version 0.3.3",
  "syn 1.0.75",
 ]
 
@@ -1283,6 +1314,18 @@ dependencies = [
  "regex",
  "termcolor",
 ]
+
+[[package]]
+name = "ethnum"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "887dc6b1e1f9ef25ac52649e19ce610a2520b4c55b48429030782b6c8a70e78a"
+
+[[package]]
+name = "fast-float"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95765f67b4b18863968b4a1bd5bb576f732b29a4a28c7cd84c09fa3e2875f33c"
 
 [[package]]
 name = "fixed-hash"
@@ -3961,6 +4004,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
+name = "stack-buf"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7386b49cb287f6fafbfd3bd604914bccb99fb8d53483f40e1ecfda5d45f3370"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4431,6 +4480,8 @@ dependencies = [
  "chrono",
  "config",
  "croaring",
+ "decimal-rs",
+ "derive_more",
  "digest",
  "env_logger 0.7.1",
  "fs2",

--- a/applications/tari_console_wallet/src/automation/commands.rs
+++ b/applications/tari_console_wallet/src/automation/commands.rs
@@ -23,6 +23,7 @@
 use super::error::CommandError;
 use log::*;
 use std::{
+    convert::TryFrom,
     fs::File,
     io::{LineWriter, Write},
     str::FromStr,
@@ -661,7 +662,7 @@ pub async fn command_runner(
                 }
                 if count > 0 {
                     let average = f64::from(sum) / count as f64;
-                    let average = Tari::from(average / 1_000_000f64);
+                    let average = Tari::try_from(average / 1_000_000f64)?;
                     println!("Average value UTXO   : {}", average);
                 }
                 if let Some(max) = values.iter().max() {

--- a/applications/tari_console_wallet/src/automation/error.rs
+++ b/applications/tari_console_wallet/src/automation/error.rs
@@ -26,7 +26,7 @@ use chrono_english::DateError;
 use log::*;
 use tari_app_utilities::utilities::ExitCodes;
 use tari_core::transactions::{
-    tari_amount::{MicroTariError, TariConvertError},
+    tari_amount::{MicroTariError, TariConversionError},
     transaction::TransactionError,
 };
 use tari_wallet::{
@@ -44,8 +44,8 @@ pub const LOG_TARGET: &str = "wallet::automation::error";
 pub enum CommandError {
     #[error("Argument error - were they in the right order?")]
     Argument,
-    #[error("Tari value convert error `{0}`")]
-    TariConvertError(#[from] TariConvertError),
+    #[error("Tari value conversion error `{0}`")]
+    TariConversionError(#[from] TariConversionError),
     #[error("Transaction service error `{0}`")]
     TransactionError(#[from] TransactionError),
     #[error("Transaction service error `{0}`")]

--- a/applications/tari_console_wallet/src/automation/error.rs
+++ b/applications/tari_console_wallet/src/automation/error.rs
@@ -25,7 +25,10 @@ use std::num::{ParseFloatError, ParseIntError};
 use chrono_english::DateError;
 use log::*;
 use tari_app_utilities::utilities::ExitCodes;
-use tari_core::transactions::{tari_amount::MicroTariError, transaction::TransactionError};
+use tari_core::transactions::{
+    tari_amount::{MicroTariError, TariConvertError},
+    transaction::TransactionError,
+};
 use tari_wallet::{
     error::{WalletError, WalletStorageError},
     output_manager_service::error::OutputManagerError,
@@ -41,6 +44,8 @@ pub const LOG_TARGET: &str = "wallet::automation::error";
 pub enum CommandError {
     #[error("Argument error - were they in the right order?")]
     Argument,
+    #[error("Tari value convert error `{0}`")]
+    TariConvertError(#[from] TariConvertError),
     #[error("Transaction service error `{0}`")]
     TransactionError(#[from] TransactionError),
     #[error("Transaction service error `{0}`")]

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -39,6 +39,7 @@ sha3 = "0.9"
 bytes = "0.5"
 chrono = { version = "0.4.6", features = ["serde"] }
 croaring = { version = "=0.4.5", optional = true }
+decimal-rs = "0.1.20"
 digest = "0.9.0"
 futures = { version = "^0.3.16", features = ["async-await"] }
 fs2 = "0.3.0"
@@ -64,6 +65,7 @@ num-format = "0.4.0"
 tracing = "0.1.26"
 tracing-futures = "*"
 tracing-attributes = "*"
+derive_more = "0.99.16"
 
 [dev-dependencies]
 tari_p2p = { version = "^0.11", path = "../../base_layer/p2p", features = ["test-mocks"] }

--- a/base_layer/core/src/transactions/helpers.rs
+++ b/base_layer/core/src/transactions/helpers.rs
@@ -561,6 +561,12 @@ pub fn schema_to_transaction(txns: &[TransactionSchema]) -> (Vec<Arc<Transaction
     (tx, utxos)
 }
 
+pub fn display_currency(value: f64, precision: usize, separator: &str) -> String {
+    let whole = value as u64;
+    let decimal = ((value - whole as f64) * pow(10_f64, precision)).round() as u64;
+    display_currency_decimal(whole, decimal, precision, separator)
+}
+
 /// Return a currency styled `String`
 /// # Examples
 ///
@@ -569,9 +575,7 @@ pub fn schema_to_transaction(txns: &[TransactionSchema]) -> (Vec<Arc<Transaction
 /// assert_eq!(String::from("12,345.12"), display_currency(12345.12, 2, ","));
 /// assert_eq!(String::from("12,345"), display_currency(12345.12, 0, ","));
 /// ```
-pub fn display_currency(value: f64, precision: usize, separator: &str) -> String {
-    let whole = value as usize;
-    let decimal = ((value - whole as f64) * pow(10_f64, precision)).round() as usize;
+pub fn display_currency_decimal(whole: u64, decimal: u64, precision: usize, separator: &str) -> String {
     let formatted_whole_value = whole
         .to_string()
         .chars()

--- a/base_layer/core/src/transactions/helpers.rs
+++ b/base_layer/core/src/transactions/helpers.rs
@@ -564,9 +564,9 @@ pub fn schema_to_transaction(txns: &[TransactionSchema]) -> (Vec<Arc<Transaction
 /// # Examples
 ///
 /// ```
-/// use tari_core::transactions::helpers::display_currency;
-/// assert_eq!(String::from("12,345.12"), display_currency(12345.12, 2, ","));
-/// assert_eq!(String::from("12,345"), display_currency(12345.12, 0, ","));
+/// use tari_core::transactions::helpers::format_currency;
+/// assert_eq!("12,345.12", format_currency("12345.12", ','));
+/// assert_eq!("12,345", format_currency("12345", ','));
 /// ```
 pub fn format_currency(value: &str, separator: char) -> String {
     let full_len = value.len();

--- a/base_layer/core/src/transactions/helpers.rs
+++ b/base_layer/core/src/transactions/helpers.rs
@@ -577,7 +577,7 @@ pub fn format_currency(value: &str, separator: char) -> String {
             let mut buffer = String::with_capacity(len / 3 + len);
             for (i, c) in whole.chars().rev().enumerate() {
                 buffer.push(c);
-                if i > 0 && i % 3 == 0 {
+                if i > 0 && i % 3 == 0 && i != len {
                     buffer.push(separator);
                 }
             }
@@ -593,18 +593,14 @@ pub fn format_currency(value: &str, separator: char) -> String {
 #[cfg(test)]
 #[allow(clippy::excessive_precision)]
 mod test {
+    use super::format_currency;
+
     #[test]
-    fn display_currency() {
-        assert_eq!(String::from("0.00"), super::display_currency(0.0f64, 2, ","));
-        assert_eq!(String::from("0.000000000000"), super::display_currency(0.0f64, 12, ","));
-        assert_eq!(
-            String::from("123,456.123456789"),
-            super::display_currency(123_456.123_456_789_012_f64, 9, ",")
-        );
-        assert_eq!(
-            String::from("123,456"),
-            super::display_currency(123_456.123_456_789_012_f64, 0, ",")
-        );
-        assert_eq!(String::from("1,234"), super::display_currency(1234.1f64, 0, ","));
+    fn test_format_currency() {
+        assert_eq!("0.00", format_currency("0.00", ','));
+        assert_eq!("0.000000000000", format_currency("0.000000000000", ','));
+        assert_eq!("123,456.123456789", format_currency("123456.123456789", ','));
+        assert_eq!("123,456", format_currency("123456", ','));
+        assert_eq!("123", format_currency("123", ','));
     }
 }

--- a/base_layer/core/src/transactions/tari_amount.rs
+++ b/base_layer/core/src/transactions/tari_amount.rs
@@ -23,7 +23,7 @@
 use newtype_ops::newtype_ops;
 use serde::{Deserialize, Serialize};
 
-use crate::transactions::helpers::display_currency;
+use crate::transactions::helpers;
 use std::{
     fmt::{Display, Error, Formatter},
     iter::Sum,
@@ -204,7 +204,7 @@ impl From<MicroTari> for FormattedMicroTari {
 
 impl Display for FormattedMicroTari {
     fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
-        write!(f, "{} µT", display_currency(self.0 as f64, 0, ","))
+        write!(f, "{} µT", helpers::display_currency_decimal(self.0, 0, 0, ","))
     }
 }
 
@@ -219,7 +219,7 @@ impl From<Tari> for FormattedTari {
 
 impl Display for FormattedTari {
     fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
-        write!(f, "{} T", display_currency(self.0, 2, ","))
+        write!(f, "{} T", helpers::display_currency(self.0, 2, ","))
     }
 }
 

--- a/base_layer/core/src/transactions/tari_amount.rs
+++ b/base_layer/core/src/transactions/tari_amount.rs
@@ -256,11 +256,11 @@ impl Display for Tari {
     }
 }
 
-pub type TariConvertError = DecimalConvertError;
+pub type TariConversionError = DecimalConvertError;
 
 // TODO: Remove `f64` completely! Using it is the bad idea in general.
 impl TryFrom<f64> for Tari {
-    type Error = TariConvertError;
+    type Error = TariConversionError;
 
     fn try_from(v: f64) -> Result<Self, Self::Error> {
         Decimal::try_from(v).map(Self)

--- a/base_layer/core/src/transactions/tari_amount.rs
+++ b/base_layer/core/src/transactions/tari_amount.rs
@@ -210,7 +210,11 @@ impl From<MicroTari> for FormattedMicroTari {
 
 impl Display for FormattedMicroTari {
     fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
-        write!(f, "{} µT", helpers::display_currency_decimal(self.0, 0, 0, ","))
+        let value = format!("{}", self.0);
+        let formatted = helpers::format_currency(&value, ',');
+        f.write_str(&formatted)?;
+        f.write_str(" µT")?;
+        Ok(())
     }
 }
 
@@ -225,7 +229,11 @@ impl From<Tari> for FormattedTari {
 
 impl Display for FormattedTari {
     fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
-        write!(f, "{} T", helpers::display_currency(self.0.into(), 2, ","))
+        let value = format!("{:.2}", self.0);
+        let formatted = helpers::format_currency(&value, ',');
+        f.write_str(&formatted)?;
+        f.write_str(" T")?;
+        Ok(())
     }
 }
 

--- a/base_layer/core/src/transactions/tari_amount.rs
+++ b/base_layer/core/src/transactions/tari_amount.rs
@@ -273,7 +273,8 @@ impl From<MicroTari> for Tari {
 #[cfg(test)]
 mod test {
     use super::{MicroTari, Tari};
-    use std::str::FromStr;
+    use std::{convert::TryFrom, str::FromStr};
+
     #[test]
     fn micro_tari_arithmetic() {
         let mut a = MicroTari::from(500);
@@ -310,7 +311,7 @@ mod test {
         let micro_tari = MicroTari::from(99_100_000);
         let s = format!("{}", micro_tari.formatted());
         assert_eq!(micro_tari, MicroTari::from_str(s.as_str()).unwrap());
-        let tari = Tari::from(1.12);
+        let tari = Tari::try_from(1.12).unwrap();
         let s = format!("{}", tari.formatted());
         assert_eq!(MicroTari::from(tari), MicroTari::from_str(s.as_str()).unwrap());
         assert_eq!(MicroTari::from(5_000_000), MicroTari::from_str("5000000").unwrap());
@@ -326,38 +327,38 @@ mod test {
     #[test]
     fn add_tari_and_microtari() {
         let a = MicroTari::from(100_000);
-        let b = Tari::from(0.23);
+        let b = Tari::try_from(0.23).unwrap();
         let sum: Tari = b + a.into();
-        assert_eq!(sum, Tari::from(0.33));
+        assert_eq!(sum, Tari::try_from(0.33).unwrap());
     }
 
     #[test]
     fn tari_arithmetic() {
-        let mut a = Tari::from(1.5);
-        let b = Tari::from(2.25);
-        assert_eq!(a + b, Tari::from(3.75));
-        assert_eq!(a - b, Tari::from(-0.75));
-        assert_eq!(a * 10.0, Tari::from(15.0));
-        assert_eq!(b / 2.0, Tari::from(1.125));
+        let mut a = Tari::try_from(1.5).unwrap();
+        let b = Tari::try_from(2.25).unwrap();
+        assert_eq!(a + b, Tari::try_from(3.75).unwrap());
+        assert_eq!(a - b, Tari::try_from(-0.75).unwrap());
+        assert_eq!(a * 10.0, Tari::try_from(15.0).unwrap());
+        assert_eq!(b / 2.0, Tari::try_from(1.125).unwrap());
         a += b;
-        assert_eq!(a, Tari::from(3.75));
-        a -= Tari::from(0.75);
-        assert_eq!(a, Tari::from(3.0));
+        assert_eq!(a, Tari::try_from(3.75).unwrap());
+        a -= Tari::try_from(0.75).unwrap();
+        assert_eq!(a, Tari::try_from(3.0).unwrap());
     }
 
     #[test]
     fn tari_display() {
-        let s = format!("{}", Tari::from(1.234));
+        let s = format!("{}", Tari::try_from(1.234).unwrap());
         assert_eq!(s, "1.234000 T");
-        let s = format!("{}", Tari::from(99.100));
+        let s = format!("{}", Tari::try_from(99.100).unwrap());
         assert_eq!(s, "99.100000 T");
     }
 
     #[test]
     fn formatted_tari_display() {
-        let s = format!("{}", Tari::from(1.234).formatted());
+        let s = format!("{}", Tari::try_from(1.234).unwrap().formatted());
         assert_eq!(s, "1.23 T");
-        let s = format!("{}", Tari::from(99999.100).formatted());
+        let s = format!("{}", Tari::try_from(99999.100).unwrap().formatted());
         assert_eq!(s, "99,999.10 T");
     }
 }


### PR DESCRIPTION
Description
---
The inner type of `Tari` changed from `f64` to `decimal_rs::Decimal`.
Also, `display_currency` method was replaced with `format_currency` that adds separators to formatted strings.

Motivation and Context
---
`display_currency` method forces us to use `f64` that is not accurate for finance calculations.

How Has This Been Tested?
---
Updated unit tests.
**TODO:** Smoke test: run the wallet and the node.

