### PR TITLE
test: create cucumber test directory if necessary

### DIFF
--- a/integration_tests/run-tests.sh
+++ b/integration_tests/run-tests.sh
@@ -1,2 +1,5 @@
+ if [ ! -d cucumber_output ]; then
+   mkdir cucumber_output
+ fi
 ./node_modules/.bin/cucumber-js -f ./node_modules/cucumber-pretty -f json:cucumber_output/tests.cucumber "$@"
 node ./generate_report.js


### PR DESCRIPTION
The `run-tests.sh` script fails on a fresh install because the cucumber
output folder doesn't exist. This PR simple checks and creates the
folder if necessary.

