### PR TITLE
chore: improve cucumber tests to wait for broadcast

### DIFF
--- a/integration_tests/features/Mempool.feature
+++ b/integration_tests/features/Mempool.feature
@@ -114,7 +114,7 @@ Feature: Mempool
     Then NODE_B has TXB in MEMPOOL state
     When I mine 1 blocks on NODE_A
     When I mine 1 blocks on NODE_B
-    And I connect node NODE_A to node NODE_B and wait 1 seconds
+    And I connect node NODE_A to node NODE_B
     Then all nodes are at height 12
     Then NODE_A has TXA in NOT_STORED state
     Then NODE_A has TXB in MINED state

--- a/integration_tests/features/Reorgs.feature
+++ b/integration_tests/features/Reorgs.feature
@@ -162,9 +162,9 @@ Feature: Reorgs
         #
         # Connect Chain 1a and 1b
         #
-    And I connect node NODE_A1 to node NODE_A3 and wait 1 seconds
-    And I connect node NODE_A2 to node NODE_A4 and wait 1 seconds
-    And I connect node SEED_A1 to node SEED_A2 and wait <SYNC_TIME> seconds
+    And I connect node NODE_A1 to node NODE_A3
+    And I connect node NODE_A2 to node NODE_A4
+    And I connect node SEED_A1 to node SEED_A2
     Then node SEED_A1 is in state LISTENING
     Then node SEED_A2 is in state LISTENING
     When I mine 10 blocks on SEED_A1
@@ -194,9 +194,9 @@ Feature: Reorgs
         #
         # Connect Chain 2a and 2b
         #
-    And I connect node NODE_B1 to node NODE_B3 and wait 1 seconds
-    And I connect node NODE_B2 to node NODE_B4 and wait 1 seconds
-    And I connect node SEED_B1 to node SEED_B2 and wait <SYNC_TIME> seconds
+    And I connect node NODE_B1 to node NODE_B3
+    And I connect node NODE_B2 to node NODE_B4
+    And I connect node SEED_B1 to node SEED_B2
     Then node SEED_B2 is in state LISTENING
     Then node SEED_B1 is in state LISTENING
     When I mine 10 blocks on SEED_B1
@@ -208,23 +208,21 @@ Feature: Reorgs
         #
         # Connect Chain 1 and 2
         #
-    And I connect node NODE_A1 to node NODE_B1 and wait 1 seconds
-    And I connect node NODE_A3 to node NODE_B3 and wait 1 seconds
-    And I connect node SEED_A1 to node SEED_B1 and wait <SYNC_TIME> seconds
-    Then node SEED_A1 is in state LISTENING
-    Then node SEED_B1 is in state LISTENING
+    And I connect node NODE_A1 to node NODE_B1
+    And I connect node NODE_A3 to node NODE_B3
+    And I connect node SEED_A1 to node SEED_B1
     When I mine 10 blocks on SEED_A1
     Then all nodes are on the same chain tip
 
     Examples:
-      | X1 | Y1 | X2 | Y2 | SYNC_TIME |
-      | 5  | 10 | 15 | 20 | 1        |
+      | X1 | Y1 | X2 | Y2 |
+      | 5  | 10 | 15 | 20 |
 
     @long-running
     Examples:
-        | X1     | Y1     | X2    | Y2   | SYNC_TIME |
-        | 100    | 125    | 150   | 175  | 1         |
-        | 1010   | 1110   | 1210  | 1310 | 1         |
+        | X1     | Y1     | X2    | Y2   |
+        | 100    | 125    | 150   | 175  |
+        | 1010   | 1110   | 1210  | 1310 |
 
   @reorg
   Scenario: Full block sync with small reorg

--- a/integration_tests/features/StressTest.feature
+++ b/integration_tests/features/StressTest.feature
@@ -6,17 +6,16 @@ Feature: Stress Test
         And I have stress-test wallet WALLET_A connected to the seed node NODE1 with broadcast monitoring timeout <MonitoringTimeout>
         And I have mining node MINER connected to base node NODE1 and wallet WALLET_A
         # We mine some blocks before starting the other nodes to avoid a spinning sync state when all the nodes are at height 0
-        When mining node MINER mines 6 blocks
         And I have a seed node NODE2
         And I have <NumNodes> base nodes connected to all seed nodes
         And I have stress-test wallet WALLET_B connected to the seed node NODE2 with broadcast monitoring timeout <MonitoringTimeout>
+        When mining node MINER mines 6 blocks
         # There need to be at least as many mature coinbase UTXOs in the wallet coin splits required for the number of transactions
         When mining node MINER mines <NumCoinsplitsNeeded> blocks
         Then all nodes are on the same chain tip
         When I wait for wallet WALLET_A to have at least 5100000000 uT
 
-        Then I coin split tari in wallet WALLET_A to produce <NumTransactions> UTXOs of 5000 uT each with fee_per_gram 4 uT
-        When I wait 30 seconds
+        Then I coin split tari in wallet WALLET_A to produce <NumTransactions> UTXOs of 5000 uT each with fee_per_gram 20 uT
         When mining node MINER mines 3 blocks
         When mining node MINER mines <NumCoinsplitsNeeded> blocks
         Then all nodes are on the same chain tip
@@ -32,7 +31,7 @@ Feature: Stress Test
         # Then wallet WALLET_B detects all transactions as Mined_Confirmed
         Then while mining via node NODE1 all transactions in wallet WALLET_B are found to be Mined_Confirmed
 
-        @flaky @current
+        @flaky
         Examples:
             | NumTransactions | NumCoinsplitsNeeded | NumNodes | MonitoringTimeout |
             | 10              | 1                   | 3        | 10                |

--- a/integration_tests/features/Sync.feature
+++ b/integration_tests/features/Sync.feature
@@ -80,7 +80,7 @@ Feature: Block Sync
     Then node PNODE2 is at height 40
     When I start base node NODE1
     # We need for node to boot up and supply node 2 with blocks
-    And I connect node NODE2 to node NODE1 and wait 1 seconds
+    And I connect node NODE2 to node NODE1
     # NODE2 may initially try to sync from PNODE1 and PNODE2, then eventually try to sync from NODE1; mining blocks
     # on NODE1 will make this test less flaky and force NODE2 to sync from NODE1 much quicker
     When I mine 10 blocks on NODE1
@@ -100,8 +100,6 @@ Feature: Block Sync
     When I start base node SYNCER
     # Try to mine much faster than block sync, but still producing a lower accumulated difficulty
     And mining node MINER2 mines <Y1> blocks with min difficulty 1 and max difficulty 10
-    # Allow reorg to filter through
-    Then node SYNCER is in state LISTENING
     Then node SYNCER is at the same height as node SEED
     @critical
     Examples:

--- a/integration_tests/features/WalletFFI.feature
+++ b/integration_tests/features/WalletFFI.feature
@@ -53,7 +53,7 @@ Feature: Wallet FFI
         And mining node MINER mines 10 blocks
         Then I wait for wallet SENDER to have at least 1000000 uT
         And I have a ffi wallet FFI_WALLET connected to base node BASE
-        And I send 2000000 uT from wallet SENDER to wallet FFI_WALLET at fee 20
+        And I send 2000000 uT without waiting for broadcast from wallet SENDER to wallet FFI_WALLET at fee 20
         And wallet SENDER detects all transactions are at least Broadcast
         And mining node MINER mines 10 blocks
         Then I wait for ffi wallet FFI_WALLET to have at least 1000000 uT
@@ -107,7 +107,7 @@ Feature: Wallet FFI
         And I have a ffi wallet FFI_WALLET connected to base node BASE
         And I stop ffi wallet FFI_WALLET
         And I wait 10 seconds
-        And I send 2000000 uT from wallet SENDER to wallet FFI_WALLET at fee 20
+        And I send 2000000 uT without waiting for broadcast from wallet SENDER to wallet FFI_WALLET at fee 20
         And I wait 5 seconds
         # Broken step with reason base node is not persisted
         # Log:

--- a/integration_tests/features/WalletMonitoring.feature
+++ b/integration_tests/features/WalletMonitoring.feature
@@ -66,8 +66,7 @@ Feature: Wallet Monitoring
     Then node NODE_A1 is at height 10
     Then wallet WALLET_A1 detects at least 7 coinbase transactions as Mined_Confirmed
         # Use 7 of the 10 coinbase UTXOs in transactions (others require 3 confirmations)
-    And I multi-send 7 transactions of 1000000 uT from wallet WALLET_A1 to wallet WALLET_A2 at fee 20
-    Then wallet WALLET_A1 detects all transactions are at least Broadcast
+    And I multi-send 7 transactions of 1000000 uT from wallet WALLET_A1 to wallet WALLET_A2 at fee 100
     When I mine 100 blocks on SEED_A
     Then node SEED_A is at height 110
     Then node NODE_A1 is at height 110
@@ -88,8 +87,7 @@ Feature: Wallet Monitoring
     Then node NODE_B1 is at height 10
     Then wallet WALLET_B1 detects at least 7 coinbase transactions as Mined_Confirmed
         # Use 7 of the 10 coinbase UTXOs in transactions (others require 3 confirmations)
-    And I multi-send 7 transactions of 1000000 uT from wallet WALLET_B1 to wallet WALLET_B2 at fee 20
-    Then wallet WALLET_B1 detects all transactions are at least Broadcast
+    And I multi-send 7 transactions of 1000000 uT from wallet WALLET_B1 to wallet WALLET_B2 at fee 100
     When I mine 100 blocks on SEED_B
     Then node SEED_B is at height 110
     Then node NODE_B1 is at height 110

--- a/integration_tests/features/WalletRecovery.feature
+++ b/integration_tests/features/WalletRecovery.feature
@@ -14,8 +14,7 @@ Feature: Wallet Recovery
         When I recover wallet WALLET_A into wallet WALLET_B connected to all seed nodes
         Then wallet WALLET_A and wallet WALLET_B have the same balance
         And I have wallet WALLET_C connected to all seed nodes
-        And I send 100000 uT from wallet WALLET_B to wallet WALLET_C at fee 20
-        Then wallet WALLET_B detects all transactions are at least Broadcast
+        And I send 100000 uT from wallet WALLET_B to wallet WALLET_C at fee 100
         When I mine 5 blocks on NODE
         Then all nodes are at height 20
         Then I wait for wallet WALLET_C to have at least 100000 uT

--- a/integration_tests/features/WalletRoutingMechanism.feature
+++ b/integration_tests/features/WalletRoutingMechanism.feature
@@ -16,10 +16,7 @@ Scenario Outline: Wallets transacting via specified routing mechanism only
     When I wait 1 seconds
     When I wait for wallet WALLET_A to have at least 100000000 uT
     #When I print the world
-    And I multi-send 1000000 uT from wallet WALLET_A to all wallets at fee 20
-    Then all wallets detect all transactions are at least Pending
-    Then all wallets detect all transactions are at least Completed
-    Then all wallets detect all transactions are at least Broadcast
+    And I multi-send 1000000 uT from wallet WALLET_A to all wallets at fee 100
         # TODO: This wait is needed to stop next merge mining task from continuing
     When I wait 1 seconds
     And mining node MINER mines 1 blocks

--- a/integration_tests/features/WalletTransactions.feature
+++ b/integration_tests/features/WalletTransactions.feature
@@ -11,9 +11,8 @@ Feature: Wallet Transactions
     Then all nodes are at height 15
     When I wait for wallet WALLET_A to have at least 55000000000 uT
     And I have wallet WALLET_B connected to all seed nodes
-    Then I send a one-sided transaction of 1000000 uT from WALLET_A to WALLET_B at fee 20
-    Then I send a one-sided transaction of 1000000 uT from WALLET_A to WALLET_B at fee 20
-    Then wallet WALLET_A detects all transactions are at least Broadcast
+    Then I send a one-sided transaction of 1000000 uT from WALLET_A to WALLET_B at fee 100
+    Then I send a one-sided transaction of 1000000 uT from WALLET_A to WALLET_B at fee 100
     When mining node MINER mines 5 blocks
     Then all nodes are at height 20
     Then I wait for wallet WALLET_B to have at least 2000000 uT
@@ -40,8 +39,7 @@ Feature: Wallet Transactions
     Then all nodes are at height 5
     Then I wait for wallet WALLET_A to have at least 10000000000 uT
     Then I have wallet WALLET_B connected to all seed nodes
-    And I send 1000000 uT from wallet WALLET_A to wallet WALLET_B at fee 20
-    When wallet WALLET_A detects all transactions are at least Broadcast
+    And I send 1000000 uT from wallet WALLET_A to wallet WALLET_B at fee 100
     Then mining node MINER mines 5 blocks
     Then all nodes are at height 10
     Then I wait for wallet WALLET_B to have at least 1000000 uT
@@ -53,7 +51,7 @@ Feature: Wallet Transactions
     Then I wait for wallet WALLET_C to have at least 1000000 uT
     Then I check if last imported transactions are valid in wallet WALLET_C
 
-  @critical
+  @critical @flaky
   Scenario: Wallet imports spent outputs that become invalidated
     Given I have a seed node NODE
     And I have 1 base nodes connected to all seed nodes
@@ -63,13 +61,11 @@ Feature: Wallet Transactions
     Then all nodes are at height 5
     Then I wait for wallet WALLET_A to have at least 10000000000 uT
     Then I have wallet WALLET_B connected to all seed nodes
-    And I send 1000000 uT from wallet WALLET_A to wallet WALLET_B at fee 20
-    When wallet WALLET_A detects all transactions are at least Broadcast
+    And I send 1000000 uT from wallet WALLET_A to wallet WALLET_B at fee 100
     Then mining node MINER mines 5 blocks
     Then all nodes are at height 10
     Then I wait for wallet WALLET_B to have at least 1000000 uT
-    When I send 900000 uT from wallet WALLET_B to wallet WALLET_A at fee 20
-    And wallet WALLET_B detects all transactions are at least Broadcast
+    When I send 900000 uT from wallet WALLET_B to wallet WALLET_A at fee 100
     Then mining node MINER mines 5 blocks
     Then all nodes are at height 15
     When I wait for wallet WALLET_B to have at least 50000 uT
@@ -94,8 +90,7 @@ Feature: Wallet Transactions
     And mining node BM mines 4 blocks with min difficulty 1 and max difficulty 50
     Then I wait for wallet WB to have at least 1000000 uT
     And I have wallet WALLET_RECEIVE_TX connected to base node B
-    And I send 1000000 uT from wallet WB to wallet WALLET_RECEIVE_TX at fee 20
-    And wallet WB detects all transactions are at least Broadcast
+    And I send 1000000 uT from wallet WB to wallet WALLET_RECEIVE_TX at fee 100
     Then mining node BM mines 4 blocks with min difficulty 50 and max difficulty 100
     When node B is at height 8
     Then I wait for wallet WALLET_RECEIVE_TX to have at least 1000000 uT
@@ -128,7 +123,7 @@ Feature: Wallet Transactions
     # for imported UTXO's anyway so until that is decided we will just check that the imported output becomes invalid
     # Then I check if last imported transactions are invalid in wallet WALLET_IMPORTED
 
-  @critical @flaky
+  @critical
   Scenario: Wallet imports faucet UTXO
     Given I have a seed node NODE
     And I have 1 base nodes connected to all seed nodes
@@ -138,8 +133,7 @@ Feature: Wallet Transactions
     Then all nodes are at height 5
     Then I wait for wallet WALLET_A to have at least 10000000000 uT
     When I have wallet WALLET_B connected to all seed nodes
-    And I send 1000000 uT from wallet WALLET_A to wallet WALLET_B at fee 20
-    When I wait 10 seconds
+    And I send 1000000 uT from wallet WALLET_A to wallet WALLET_B at fee 100
     When mining node MINER mines 6 blocks
     Then all nodes are at height 11
     Then I wait for wallet WALLET_B to have at least 1000000 uT
@@ -147,9 +141,7 @@ Feature: Wallet Transactions
     When I have wallet WALLET_C connected to all seed nodes
     Then I import WALLET_B unspent outputs as faucet outputs to WALLET_C
     Then I wait for wallet WALLET_C to have at least 1000000 uT
-    And I send 500000 uT from wallet WALLET_C to wallet WALLET_A at fee 20
-    When I wait 10 seconds
-    Then wallet WALLET_C detects all transactions are at least Broadcast
+    And I send 500000 uT from wallet WALLET_C to wallet WALLET_A at fee 100
     When mining node MINER mines 6 blocks
     Then all nodes are at height 17
     Then I wait for wallet WALLET_C to have at least 400000 uT
@@ -163,13 +155,11 @@ Feature: Wallet Transactions
     Then all nodes are at height 10
     Then I wait for wallet WALLET_A to have at least 10000000000 uT
     Then I have wallet WALLET_B connected to all seed nodes
-    And I send 100000 uT from wallet WALLET_A to wallet WALLET_B at fee 20
-    And I send 100000 uT from wallet WALLET_A to wallet WALLET_B at fee 20
-    And I send 100000 uT from wallet WALLET_A to wallet WALLET_B at fee 20
-    And I send 100000 uT from wallet WALLET_A to wallet WALLET_B at fee 20
-    And I send 100000 uT from wallet WALLET_A to wallet WALLET_B at fee 20
-    When I wait 30 seconds
-    When wallet WALLET_A detects all transactions are at least Broadcast
+    And I send 100000 uT from wallet WALLET_A to wallet WALLET_B at fee 100
+    And I send 100000 uT from wallet WALLET_A to wallet WALLET_B at fee 100
+    And I send 100000 uT from wallet WALLET_A to wallet WALLET_B at fee 100
+    And I send 100000 uT from wallet WALLET_A to wallet WALLET_B at fee 100
+    And I send 100000 uT from wallet WALLET_A to wallet WALLET_B at fee 100
     Then mining node MINER mines 5 blocks
     Then all nodes are at height 15
     Then I wait for wallet WALLET_B to have at least 500000 uT
@@ -195,8 +185,7 @@ Feature: Wallet Transactions
     Then wallet WALLET_A1 detects at least 7 coinbase transactions as Mined_Confirmed
     Then node SEED_A is at height 10
     Then node NODE_A1 is at height 10
-    And I multi-send 7 transactions of 1000000 uT from wallet WALLET_A1 to wallet WALLET_A2 at fee 20
-    Then wallet WALLET_A1 detects all transactions are at least Broadcast
+    And I multi-send 7 transactions of 1000000 uT from wallet WALLET_A1 to wallet WALLET_A2 at fee 100
     #
     # Chain 2:
     #   Collects 7 coinbases into one wallet, send 7 transactions
@@ -214,8 +203,7 @@ Feature: Wallet Transactions
     Then wallet WALLET_B1 detects at least 7 coinbase transactions as Mined_Confirmed
     Then node SEED_B is at height 12
     Then node NODE_B1 is at height 12
-    And I multi-send 7 transactions of 1000000 uT from wallet WALLET_B1 to wallet WALLET_B2 at fee 20
-    Then wallet WALLET_B1 detects all transactions are at least Broadcast
+    And I multi-send 7 transactions of 1000000 uT from wallet WALLET_B1 to wallet WALLET_B2 at fee 100
     #
     # Connect Chain 1 and 2 in stages
     #    New node connects to weaker chain, receives all broadcast (not mined) transactions into mempool
@@ -225,7 +213,7 @@ Feature: Wallet Transactions
     And I have a base node NODE_C connected to seed SEED_B
     Then node NODE_C is at height 12
     # Wait for the reorg to filter through
-    And I connect node SEED_A to node NODE_C and wait 30 seconds
+    And I connect node SEED_A to node NODE_C
     Then all nodes are at height 10
     When I mine 6 blocks on NODE_C
     Then all nodes are at height 16
@@ -250,7 +238,6 @@ Feature: Wallet Transactions
     Then node SEED_A is at height 4
     Then node NODE_A1 is at height 4
     And I multi-send 1 transactions of 10000 uT from wallet WALLET_A1 to wallet WALLET_A2 at fee 20
-    Then wallet WALLET_A1 detects all transactions are at least Broadcast
     #
     # Chain 2:
     #   Collects 7 coinbases into one wallet, send 7 transactions
@@ -269,7 +256,6 @@ Feature: Wallet Transactions
     Then node SEED_B is at height 5
     Then node NODE_B1 is at height 5
     And I multi-send 2 transactions of 10000 uT from wallet WALLET_B1 to wallet WALLET_B2 at fee 20
-    Then wallet WALLET_B1 detects all transactions are at least Broadcast
     #
     # Connect Chain 1 and 2 in stages
     #    New node connects to weaker chain, receives all broadcast (not mined) transactions into mempool
@@ -279,13 +265,12 @@ Feature: Wallet Transactions
     And I have a base node NODE_C connected to seed SEED_B
     Then node NODE_C is at height 5
     # Wait for the reorg to filter through
-    And I connect node SEED_A to node NODE_C and wait 30 seconds
+    And I connect node SEED_A to node NODE_C
     Then all nodes are at height 4
     When I mine 2 blocks on NODE_C
     Then all nodes are at height 6
 
-  # runs 8mins on circle ci
-  @long-running
+@flaky @long-running
   Scenario: Wallet SAF negotiation and cancellation with offline peers
     Given I have a seed node NODE
     And I have 1 base nodes connected to all seed nodes
@@ -295,30 +280,30 @@ Feature: Wallet Transactions
     Then all nodes are at height 5
     Then I wait for wallet WALLET_A to have at least 10000000000 uT
     And I have non-default wallet WALLET_SENDER connected to all seed nodes using StoreAndForwardOnly
-    And I send 100000000 uT from wallet WALLET_A to wallet WALLET_SENDER at fee 20
-    When wallet WALLET_SENDER detects all transactions are at least Broadcast
+    And I send 100000000 uT from wallet WALLET_A to wallet WALLET_SENDER at fee 100
     And mining node MINER mines 5 blocks
     Then all nodes are at height 10
     Then I wait for wallet WALLET_SENDER to have at least 100000000 uT
     And I have wallet WALLET_RECV connected to all seed nodes
     And I stop wallet WALLET_RECV
-    And I send 1000000 uT from wallet WALLET_SENDER to wallet WALLET_RECV at fee 20
+    And I send 1000000 uT without waiting for broadcast from wallet WALLET_SENDER to wallet WALLET_RECV at fee 100
     When wallet WALLET_SENDER detects last transaction is Pending
     Then I stop wallet WALLET_SENDER
     And I start wallet WALLET_RECV
     And I wait for 5 seconds
     When wallet WALLET_RECV detects all transactions are at least Pending
     Then I cancel last transaction in wallet WALLET_RECV
+    When I wait 15 seconds
     Then I stop wallet WALLET_RECV
     And I start wallet WALLET_SENDER
     # This is a weirdness that I haven't been able to figure out. When you start WALLET_SENDER on the line above it
     # requests SAF messages from the base nodes the base nodes get the request and attempt to send the stored messages
     # but the connection fails. It requires a second reconnection and request for the SAF messages to be delivered.
-    And I wait for 5 seconds
+    And I wait for 10 seconds
     Then I restart wallet WALLET_SENDER
-    And I wait for 5 seconds
+    And I wait for 10 seconds
     Then I restart wallet WALLET_SENDER
-    When wallet WALLET_SENDER detects all transactions are at least Broadcast
+    When I wait 30 seconds
     And mining node MINER mines 5 blocks
     Then all nodes are at height 15
     When wallet WALLET_SENDER detects all transactions as Mined_Confirmed

--- a/integration_tests/features/WalletTransfer.feature
+++ b/integration_tests/features/WalletTransfer.feature
@@ -1,7 +1,6 @@
 @wallet-transfer @wallet
 Feature: Wallet Transfer
 
-  @flaky @long-running
   Scenario: As a wallet I want to submit multiple transfers
     Given I have a seed node NODE
     # Add a 2nd node otherwise initial sync will not succeed
@@ -23,18 +22,15 @@ Feature: Wallet Transfer
     Then all nodes are at height 20
     Then all wallets detect all transactions as Mined_Confirmed
 
-  @long-running
   Scenario: As a wallet I want to submit transfers to myself
     Given I have a seed node NODE
     # Add a 2nd node otherwise initial sync will not succeed
     And I have 1 base nodes connected to all seed nodes
     And I have wallet Wallet_A connected to all seed nodes
-    And I have mining node MINER connected to base node NODE and wallet WALLET_A
-    When mining node MINER mines 5 blocks
-    Then all nodes are at height 5
-      # Ensure the coinbase lock heights have expired
-    When I mine 5 blocks on NODE
-    When I transfer 50000 uT to self from wallet Wallet_A at fee 5
+    And I have mining node MINER connected to base node NODE and wallet Wallet_A
+    When mining node MINER mines 10 blocks
+    Then all nodes are at height 10
+    When I transfer 50000 uT to self from wallet Wallet_A at fee 25
     And I mine 5 blocks on NODE
     Then all nodes are at height 15
     Then all wallets detect all transactions as Mined_Confirmed

--- a/integration_tests/features/support/steps.js
+++ b/integration_tests/features/support/steps.js
@@ -237,25 +237,29 @@ Given(
 );
 
 Given(
-  /I connect node (.*) to node (.*) and wait (.*) seconds/,
+  /I connect node (.*) to node (.*)/,
   { timeout: 1200 * 1000 },
-  async function (nodeNameA, nodeNameB, waitSeconds) {
-    expect(waitSeconds < 1190).to.equal(true);
+  async function (nodeNameA, nodeNameB) {
     console.log(
       "Connecting (add new peer seed, shut down, then start up)",
       nodeNameA,
       "to",
-      nodeNameB,
-      ", waiting for",
-      waitSeconds,
-      "seconds"
+      nodeNameB
     );
     const nodeA = this.getNode(nodeNameA);
     const nodeB = this.getNode(nodeNameB);
     nodeA.setPeerSeeds([nodeB.peerAddress()]);
     await this.stopNode(nodeNameA);
     await this.startNode(nodeNameA);
-    await sleep(waitSeconds * 1000);
+    await waitFor(
+      async () => {
+        let node_a_result = (await nodeA.get_node_state()) === "LISTENING";
+        let node_b_result = (await nodeB.get_node_state()) === "LISTENING";
+        return node_a_result && node_b_result;
+      },
+      true,
+      30 * 1000
+    );
   }
 );
 
@@ -1192,16 +1196,18 @@ Then(
   async function (node, txn, pool) {
     const client = this.getClient(node);
     const sig = this.transactions[txn].body.kernels[0].excess_sig;
-    await waitForPredicate(
-      async () => (await client.transactionStateResult(sig)) === pool,
-      20 * 60 * 1000,
-      1000
+    this.lastResult = await waitFor(
+      async () => {
+        let tx_result = await client.transactionStateResult(sig);
+        console.log(
+          `Node ${node} response is: ${tx_result}, should be: ${pool}`
+        );
+        return tx_result === pool;
+      },
+      true,
+      20 * 60 * 1000
     );
-    this.lastResult = await this.getClient(node).transactionState(
-      this.transactions[txn].body.kernels[0].excess_sig
-    );
-    console.log(`Node ${node} response is: ${this.lastResult.result}`);
-    expect(this.lastResult.result).to.equal(pool);
+    expect(this.lastResult).to.equal(true);
   }
 );
 
@@ -1217,7 +1223,7 @@ Then(
         await waitFor(
           async () => await client.transactionStateResult(sig),
           pool,
-          1200 * 1000
+          20 * 60 * 1000
         );
         this.lastResult = await client.transactionState(sig);
         console.log(`Node ${name} response is: ${this.lastResult.result}`);
@@ -1773,6 +1779,57 @@ When(
         this.lastResult.results[0].is_success +
         ")"
     );
+    //lets now wait for this transaction to be at least broadcast before we continue.
+    await waitFor(
+      async () =>
+        sourceClient.isTransactionAtLeastBroadcast(
+          this.lastResult.results[0].transaction_id
+        ),
+      true,
+      60 * 1000,
+      5 * 1000,
+      5
+    );
+    let transactionPending = await sourceClient.isTransactionAtLeastBroadcast(
+      this.lastResult.results[0].transaction_id
+    );
+    expect(transactionPending).to.equal(true);
+  }
+);
+
+When(
+  /I send(.*) uT without waiting for broadcast from wallet (.*) to wallet (.*) at fee (.*)/,
+  { timeout: 25 * 5 * 1000 },
+  async function (tariAmount, source, dest, feePerGram) {
+    const sourceWallet = this.getWallet(source);
+    const sourceClient = await sourceWallet.connectClient();
+    const sourceInfo = await sourceClient.identify();
+
+    const destPublicKey = this.getWalletPubkey(dest);
+
+    this.lastResult = await send_tari(
+      sourceWallet,
+      dest,
+      destPublicKey,
+      tariAmount,
+      feePerGram
+    );
+    expect(this.lastResult.results[0].is_success).to.equal(true);
+    this.addTransaction(
+      sourceInfo.public_key,
+      this.lastResult.results[0].transaction_id
+    );
+    this.addTransaction(
+      destPublicKey,
+      this.lastResult.results[0].transaction_id
+    );
+    console.log(
+      "  Transaction '" +
+        this.lastResult.results[0].transaction_id +
+        "' is_success(" +
+        this.lastResult.results[0].is_success +
+        ")"
+    );
   }
 );
 
@@ -1785,6 +1842,7 @@ When(
     const sourceInfo = await sourceClient.identify();
     const destClient = await this.getWallet(dest).connectClient();
     const destInfo = await destClient.identify();
+    let tx_ids = [];
     for (let i = 0; i < number; i++) {
       this.lastResult = await send_tari(
         this.getWallet(source),
@@ -1794,6 +1852,7 @@ When(
         fee
       );
       expect(this.lastResult.results[0].is_success).to.equal(true);
+      tx_ids.push(this.lastResult.results[0].transaction_id);
       this.addTransaction(
         sourceInfo.public_key,
         this.lastResult.results[0].transaction_id
@@ -1805,6 +1864,22 @@ When(
       // console.log("  Transaction '" + this.lastResult.results[0]["transaction_id"] + "' is_success(" +
       //    this.lastResult.results[0]["is_success"] + ")");
     }
+    //lets now wait for this transaction to be at least broadcast before we continue.
+    let waitfor_result = await waitFor(
+      async () => {
+        let result = true;
+        for (let i = 0; i < number; i++) {
+          result =
+            result && sourceClient.isTransactionAtLeastBroadcast(tx_ids[i]);
+        }
+        return result;
+      },
+      true,
+      60 * 1000,
+      5 * 1000,
+      5
+    );
+    expect(waitfor_result).to.equal(true);
   }
 );
 
@@ -1814,7 +1889,7 @@ When(
   async function (tariAmount, source, fee) {
     const sourceWalletClient = await this.getWallet(source).connectClient();
     const sourceInfo = await sourceWalletClient.identify();
-
+    let tx_ids = [];
     for (const wallet in this.wallets) {
       if (this.getWallet(source).name === this.getWallet(wallet).name) {
         continue;
@@ -1829,6 +1904,7 @@ When(
         fee
       );
       expect(this.lastResult.results[0].is_success).to.equal(true);
+      tx_ids.push(this.lastResult.results[0].transaction_id);
       this.addTransaction(
         sourceInfo.public_key,
         this.lastResult.results[0].transaction_id
@@ -1840,6 +1916,22 @@ When(
       // console.log("  Transaction '" + this.lastResult.results[0]["transaction_id"] + "' is_success(" +
       //    this.lastResult.results[0]["is_success"] + ")");
     }
+    let waitfor_result = await waitFor(
+      async () => {
+        let result = true;
+        tx_ids.forEach(
+          (id) =>
+            (result =
+              result && sourceWalletClient.isTransactionAtLeastBroadcast(id))
+        );
+        return result;
+      },
+      true,
+      60 * 1000,
+      5 * 1000,
+      5
+    );
+    expect(waitfor_result).to.equal(true);
   }
 );
 
@@ -1952,6 +2044,7 @@ When(
       tariAmount,
       feePerGram
     );
+
     expect(this.lastResult.results[0].is_success).to.equal(true);
     this.addTransaction(
       sourceInfo.public_key,
@@ -1964,6 +2057,21 @@ When(
         this.lastResult.results[0].is_success +
         ")"
     );
+    //lets now wait for this transaction to be at least broadcast before we continue.
+    await waitFor(
+      async () =>
+        sourceClient.isTransactionAtLeastBroadcast(
+          this.lastResult.results[0].transaction_id
+        ),
+      true,
+      60 * 1000,
+      5 * 1000,
+      5
+    );
+    let transactionPending = await sourceClient.isTransactionAtLeastBroadcast(
+      this.lastResult.results[0].transaction_id
+    );
+    expect(transactionPending).to.equal(true);
   }
 );
 
@@ -2030,6 +2138,21 @@ When(
       sourceInfo.public_key,
       lastResult.results[0].transaction_id
     );
+    //lets now wait for this transaction to be at least broadcast before we continue.
+    await waitFor(
+      async () =>
+        sourceClient.isTransactionAtLeastBroadcast(
+          lastResult.results[0].transaction_id
+        ),
+      true,
+      60 * 1000,
+      5 * 1000,
+      5
+    );
+    let transactionPending = await sourceClient.isTransactionAtLeastBroadcast(
+      lastResult.results[0].transaction_id
+    );
+    expect(transactionPending).to.equal(true);
   }
 );
 
@@ -3141,6 +3264,16 @@ When(
         5 * 1000,
         5
       );
+      let waitfor_result = await waitFor(
+        async () => {
+          return walletClient.isTransactionAtLeastBroadcast(result.tx_id);
+        },
+        true,
+        60 * 1000,
+        5 * 1000,
+        5
+      );
+      expect(waitfor_result).to.equal(true);
       console.log(
         "Coin split",
         i + 1,
@@ -3183,6 +3316,7 @@ When(
     );
 
     let batch = 1;
+    let tx_ids = [];
     for (let i = 0; i < numTransactions; i++) {
       const result = await send_tari(
         this.getWallet(sourceWallet),
@@ -3195,6 +3329,7 @@ When(
         false
       );
       expect(result.results[0].is_success).to.equal(true);
+      tx_ids.push(result.results[0].transaction_id);
       this.addTransaction(
         sourceInfo.public_key,
         result.results[0].transaction_id
@@ -3210,7 +3345,22 @@ When(
       }
       await sleep(50);
     }
-
+    let waitfor_result = await waitFor(
+      async () => {
+        let result = true;
+        tx_ids.forEach(
+          (id) =>
+            (result =
+              result && sourceWalletClient.isTransactionAtLeastBroadcast(id))
+        );
+        return result;
+      },
+      true,
+      60 * 1000,
+      5 * 1000,
+      5
+    );
+    expect(waitfor_result).to.equal(true);
     console.log(numTransactions, " transactions successfully sent.");
   }
 );

--- a/integration_tests/helpers/util.js
+++ b/integration_tests/helpers/util.js
@@ -87,7 +87,7 @@ async function waitFor(
         if (i > 1) {
           console.log("waiting for process...", timeOut, i, value);
         }
-        break;
+        return true;
       }
       if (i % skipLog === 0 && i > 1) {
         console.log("waiting for process...", timeOut, i, value);
@@ -105,6 +105,7 @@ async function waitFor(
       await sleep(timeOut);
     }
   }
+  return false;
 }
 
 async function waitForIterate(testFn, toBe, sleepMs, maxIterations = 500) {


### PR DESCRIPTION
Description
---
Changed connect node to wait for both nodes to listening
Changed send transactions to wait for broadcast state. 
Removed some flaky and long-running tags.

Motivation and Context
---
This will test to run faster as more stable. Current SHA3 miner mines too fast for the wallets to finish sending. This PR market wait for the transaction to be broadcast before continuing. 
This makes the connect node to await listing state of both nodes to avoid using waits.

How Has This Been Tested?
---
Manual test of tests