### PR TITLE
fix: remove consensus breaking change in transaction input

### DIFF
--- a/base_layer/core/src/transactions/transaction.rs
+++ b/base_layer/core/src/transactions/transaction.rs
@@ -596,7 +596,7 @@ impl TransactionInput {
 impl Hashable for TransactionInput {
     fn hash(&self) -> Vec<u8> {
         HashDigest::new()
-            .chain(self.features.to_consensus_bytes())
+            .chain(self.features.to_v1_bytes())
             .chain(self.commitment.as_bytes())
             .chain(self.script.as_bytes())
             .chain(self.sender_offset_public_key.as_bytes())


### PR DESCRIPTION
Description
---

Remove consensus breaking change from #3411

Motivation and Context
---
Breaks consensus on weatherwax

How Has This Been Tested?
---
Synced base node
