### PR TITLE
fix: upgrade rustyline dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -668,6 +668,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "clipboard-win"
+version = "4.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e4ea1881992efc993e4dc50a324cdbd03216e41bdc8385720ff47efc9bd2ca8"
+dependencies = [
+ "error-code",
+ "str-buf",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "cloudabi"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1204,6 +1215,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if 1.0.0",
+ "dirs-sys-next",
+]
+
+[[package]]
 name = "dirs-sys-next"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1316,6 +1337,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5115567ac25674e0043e472be13d14e537f37ea8aa4bdc4aef0c89add1db1ff"
+dependencies = [
+ "libc",
+ "str-buf",
+]
+
+[[package]]
 name = "ethnum"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1326,6 +1357,17 @@ name = "fast-float"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95765f67b4b18863968b4a1bd5bb576f732b29a4a28c7cd84c09fa3e2875f33c"
+
+[[package]]
+name = "fd-lock"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8806dd91a06a7a403a8e596f9bfbfb34e469efbc363fc9c9713e79e26472e36"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "fixed-hash"
@@ -2499,6 +2541,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf1e25ee6b412c2a1e3fcb6a4499a5c1bfe7f43e014bdce9a6b6666e5aa2d187"
+dependencies = [
+ "bitflags 1.3.2",
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
 name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3628,11 +3683,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f0d5e7b0219a3eadd5439498525d4765c59b7c993ef0c12244865cd2d988413"
 dependencies = [
  "cfg-if 0.1.10",
- "dirs-next",
+ "dirs-next 1.0.2",
  "libc",
  "log 0.4.14",
  "memchr",
- "nix",
+ "nix 0.18.0",
  "scopeguard",
  "unicode-segmentation",
  "unicode-width",
@@ -3641,10 +3696,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustyline-derive"
-version = "0.3.1"
+name = "rustyline"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a50e29610a5be68d4a586a5cce3bfb572ed2c2a74227e4168444b7bf4e5235"
+checksum = "790487c3881a63489ae77126f57048b42d62d3b2bafbf37453ea19eedb6340d6"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if 1.0.0",
+ "clipboard-win",
+ "dirs-next 2.0.0",
+ "fd-lock",
+ "libc",
+ "log 0.4.14",
+ "memchr",
+ "nix 0.22.0",
+ "radix_trie",
+ "scopeguard",
+ "smallvec",
+ "unicode-segmentation",
+ "unicode-width",
+ "utf8parse",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "rustyline-derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "688599bdab9f42105d0ae1494335a9ffafdeb7d36325e6b10fd4abc5829d6284"
 dependencies = [
  "quote 1.0.9",
  "syn 1.0.75",
@@ -4022,6 +4101,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "str-buf"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d44a3643b4ff9caf57abcee9c2c621d6c03d9135e0d8b589bd9afb5992cb176a"
+
+[[package]]
 name = "stream-cancel"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4200,7 +4285,7 @@ name = "tari_app_utilities"
 version = "0.11.0"
 dependencies = [
  "config",
- "dirs-next",
+ "dirs-next 1.0.2",
  "futures 0.3.16",
  "log 0.4.14",
  "qrcode",
@@ -4234,7 +4319,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-jaeger",
  "regex",
- "rustyline",
+ "rustyline 9.0.0",
  "rustyline-derive",
  "strum",
  "strum_macros 0.18.0",
@@ -4283,7 +4368,7 @@ version = "0.11.0"
 dependencies = [
  "anyhow",
  "config",
- "dirs-next",
+ "dirs-next 1.0.2",
  "get_if_addrs",
  "git2",
  "log 0.4.14",
@@ -4448,7 +4533,7 @@ dependencies = [
  "rand 0.8.4",
  "regex",
  "rpassword",
- "rustyline",
+ "rustyline 6.3.0",
  "strum",
  "strum_macros 0.19.4",
  "tari_app_grpc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2530,18 +2530,6 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83450fe6a6142ddd95fb064b746083fc4ef1705fe81f64a64e1d4b39f54a1055"
-dependencies = [
- "bitflags 1.3.2",
- "cc",
- "cfg-if 0.1.10",
- "libc",
-]
-
-[[package]]
-name = "nix"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1e25ee6b412c2a1e3fcb6a4499a5c1bfe7f43e014bdce9a6b6666e5aa2d187"
@@ -3678,25 +3666,6 @@ dependencies = [
 
 [[package]]
 name = "rustyline"
-version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0d5e7b0219a3eadd5439498525d4765c59b7c993ef0c12244865cd2d988413"
-dependencies = [
- "cfg-if 0.1.10",
- "dirs-next 1.0.2",
- "libc",
- "log 0.4.14",
- "memchr",
- "nix 0.18.0",
- "scopeguard",
- "unicode-segmentation",
- "unicode-width",
- "utf8parse",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "rustyline"
 version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790487c3881a63489ae77126f57048b42d62d3b2bafbf37453ea19eedb6340d6"
@@ -3709,7 +3678,7 @@ dependencies = [
  "libc",
  "log 0.4.14",
  "memchr",
- "nix 0.22.0",
+ "nix",
  "radix_trie",
  "scopeguard",
  "smallvec",
@@ -4319,7 +4288,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-jaeger",
  "regex",
- "rustyline 9.0.0",
+ "rustyline",
  "rustyline-derive",
  "strum",
  "strum_macros 0.18.0",
@@ -4533,7 +4502,7 @@ dependencies = [
  "rand 0.8.4",
  "regex",
  "rpassword",
- "rustyline 6.3.0",
+ "rustyline",
  "strum",
  "strum_macros 0.19.4",
  "tari_app_grpc",

--- a/applications/tari_base_node/Cargo.toml
+++ b/applications/tari_base_node/Cargo.toml
@@ -29,8 +29,8 @@ futures = { version = "^0.3.16", default-features = false, features = ["alloc"] 
 log = { version = "0.4.8", features = ["std"] }
 num_cpus = "1"
 regex = "1"
-rustyline = "6.0"
-rustyline-derive = "0.3"
+rustyline = "9.0"
+rustyline-derive = "0.5"
 strum = "^0.19"
 strum_macros = "0.18.0"
 thiserror = "^1.0.26"

--- a/applications/tari_base_node/src/parser.rs
+++ b/applications/tari_base_node/src/parser.rs
@@ -118,6 +118,8 @@ impl Completer for Parser {
 
 /// This allows us to make hints based on historic inputs
 impl Hinter for Parser {
+    type Hint = String;
+
     fn hint(&self, line: &str, pos: usize, ctx: &rustyline::Context<'_>) -> Option<String> {
         self.hinter.hint(line, pos, ctx)
     }

--- a/applications/tari_console_wallet/Cargo.toml
+++ b/applications/tari_console_wallet/Cargo.toml
@@ -29,7 +29,7 @@ log = { version = "0.4.8", features = ["std"] }
 qrcode = { version = "0.12" }
 regex = "1.5.4"
 rpassword = "5.0"
-rustyline = "6.0"
+rustyline = "9.0"
 strum = "^0.19"
 strum_macros = "^0.19"
 tokio = { version = "1.11", features = ["signal"] }


### PR DESCRIPTION
Description
---
Upgrades `rustyline` dependencies from 6.0 to 9.0.

Motivation and Context
---
There is a security issue in the `nix` crate used by the `rustyline` crate: https://github.com/tari-project/tari/issues/3441


How Has This Been Tested?
---
Standard unit tests and CI for basic compatibility checking.
And manual testing for checking the new version of `rustline` has no issues in a terminal.

