### PR TITLE
feat: add asset definition to asset manage

### DIFF
--- a/applications/tari_collectibles/README.md
+++ b/applications/tari_collectibles/README.md
@@ -6,13 +6,12 @@
 
 # then in `tari_collectibles/web-app/`
 npm i
-npm start
 
 # in `tari_collectibles/`
 cargo install tauri-cli --version "^1.0.0-beta"
 npm i
 
-npm run tauri dev
+npm start # npm run tauri dev
 
 # dev cycle: https://tauri.studio/en/docs/usage/development/development
 ```

--- a/applications/tari_collectibles/package.json
+++ b/applications/tari_collectibles/package.json
@@ -1,5 +1,6 @@
 {
   "scripts": {
+    "start": "tauri dev",
     "tauri": "tauri"
   },
   "name": "tari_collectibles",

--- a/applications/tari_collectibles/web-app/src/AssetManager.js
+++ b/applications/tari_collectibles/web-app/src/AssetManager.js
@@ -127,7 +127,7 @@ const AssetDefinition = (props) => {
   return (
     <div>
       <p>Asset Definition</p>
-      <p>Use this asset definition json file for your validator node</p>
+      <p>Use this asset definition json file for your validator nodes</p>
       <pre>{contents}</pre>
       <Button id="download" onClick={save}>
         Save asset definition file

--- a/applications/tari_collectibles/web-app/src/AssetManager.js
+++ b/applications/tari_collectibles/web-app/src/AssetManager.js
@@ -20,74 +20,130 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import React from "react";
-import {Box, Button, Container, TextField, Typography} from "@mui/material";
-import {useParams, withRouter} from "react-router-dom";
+import React, { useState } from "react";
+import { Box, Button, Container, TextField, Typography } from "@mui/material";
+import { useParams, withRouter } from "react-router-dom";
 import PropTypes from "prop-types";
 import binding from "./binding";
-
+import { fs, path } from "@tauri-apps/api";
 
 class AssetManagerContent extends React.Component {
-    constructor(props) {
-        super(props);
+  constructor(props) {
+    super(props);
 
-        this.state = {
-            error: "",
-            loading: true,
-            saving: false,
-            numTokens: 0
-        }
+    this.state = {
+      error: "",
+      loading: true,
+      saving: false,
+      numTokens: 0,
+    };
 
-        this.onNumTokensToIssueChanged = this.onNumTokensToIssueChanged.bind(this);
-        this.onIssueTokens = this.onIssueTokens.bind(this);
+    this.onNumTokensToIssueChanged = this.onNumTokensToIssueChanged.bind(this);
+    this.onIssueTokens = this.onIssueTokens.bind(this);
+  }
+
+  async componentDidMount() {
+    this.setState({ loading: false });
+  }
+
+  onNumTokensToIssueChanged(e) {
+    this.setState({ numTokens: e.target.value });
+  }
+
+  async onIssueTokens() {
+    console.log("About to issue tokens");
+    this.setState({ saving: true, error: "" });
+    // Issue
+
+    try {
+      let res = await binding.command_asset_issue_simple_tokens(
+        this.props.assetPubKey,
+        parseInt(this.state.numTokens)
+      );
+      console.log(res);
+    } catch (e) {
+      this.setState({ error: "Could not issue tokens:" + e });
     }
 
-    async componentDidMount() {
+    this.setState({ saving: false });
+  }
 
-        this.setState({loading: false});
-
-    }
-
-    onNumTokensToIssueChanged(e) {
-        this.setState({numTokens: e.target.value});
-    }
-
-    async onIssueTokens() {
-        console.log("About to issue tokens");
-        this.setState({saving: true, error: ""});
-        // Issue
-
-        try {
-            let res = await binding.command_asset_issue_simple_tokens(this.props.assetPubKey, parseInt(this.state.numTokens));
-            console.log(res);
-        }
-        catch(e)
-        {
-            this.setState({error: "Could not issue tokens:" + e})
-        }
-
-        this.setState({saving: false});
-    }
-
-    render() {
-        return (<Container maxWidth="lg" sx={{mt: 4, mb: 4, py: 8}}>
-            <Typography>Asset: {this.props.assetPubKey}</Typography>
-            <Box>
-                <TextField id="numTokens" onChange={this.onNumTokensToIssueChanged} value={this.state.numTokens} type="number"
-                           disabled={this.state.saving}></TextField>
-                <Button id="issueTokens" onClick={this.onIssueTokens} disabled={this.state.saving}>Issue Tokens</Button>
-            </Box>
-        </Container>)
-    }
+  render() {
+    return (
+      <Container maxWidth="lg" sx={{ mt: 4, mb: 4, py: 8 }}>
+        <Typography>Asset: {this.props.assetPubKey}</Typography>
+        <Box>
+          <TextField
+            id="numTokens"
+            onChange={this.onNumTokensToIssueChanged}
+            value={this.state.numTokens}
+            type="number"
+            disabled={this.state.saving}
+          ></TextField>
+          <Button
+            id="issueTokens"
+            onClick={this.onIssueTokens}
+            disabled={this.state.saving}
+          >
+            Issue Tokens
+          </Button>
+        </Box>
+        <Box>
+          <AssetDefinition assetPubKey={this.props.assetPubKey} />
+        </Box>
+      </Container>
+    );
+  }
 }
+
+const AssetDefinition = (props) => {
+  const { assetPubKey } = props;
+  const [msg, setMsg] = useState("");
+
+  const asset = {
+    publicKey: assetPubKey,
+    phaseTimeout: 10,
+    initialCommittee: [],
+    baseLayerConfirmationTime: 5,
+    checkpointUniqueId: [],
+    templates: [],
+  };
+  const contents = JSON.stringify(asset);
+  async function save() {
+    const filename = `${assetPubKey}.json`;
+    try {
+      const home = await path.homeDir();
+      const filePath = `${home}${filename}`;
+      await fs.writeFile({
+        contents,
+        path: filePath,
+      });
+      setMsg(`Asset definition file written to: ${filePath}`);
+    } catch (e) {
+      setMsg(`Error: ${e}`);
+    }
+  }
+
+  return (
+    <div>
+      <p>Asset Definition</p>
+      <p>Use this asset definition json file for your validator node</p>
+      <pre>{contents}</pre>
+      <Button id="download" onClick={save}>
+        Save asset definition file
+      </Button>
+      <p>{msg}</p>
+    </div>
+  );
+};
 
 AssetManagerContent.propTypes = {
-    assetPubKey: PropTypes.string
-}
+  assetPubKey: PropTypes.string,
+};
 
 function AssetManager() {
-    let {assetPubKey} = useParams();
-    return <AssetManagerContent assetPubKey={assetPubKey}/>
+  const { assetPubKey } = useParams();
+  return <AssetManagerContent assetPubKey={assetPubKey} />;
 }
 
 export default withRouter(AssetManager);

--- a/applications/tari_collectibles/web-app/src/Create.js
+++ b/applications/tari_collectibles/web-app/src/Create.js
@@ -251,7 +251,7 @@ class Create extends React.Component {
               })}
             </List>
             <TextField
-              label="New public key"
+              label="Validator node public key"
               id="newCommitteePubKey"
               value={this.state.newCommitteePubKey}
               onChange={this.onNewCommitteePubKeyChanged}

--- a/applications/tari_collectibles/web-app/src/Create.js
+++ b/applications/tari_collectibles/web-app/src/Create.js
@@ -22,13 +22,10 @@
 import React from "react";
 import {
   Alert,
-  Box,
   Button,
   Container,
-  FormControl,
   FormControlLabel,
   FormGroup,
-  Grid,
   List,
   ListItem,
   ListItemText,
@@ -38,7 +35,7 @@ import {
   Typography,
 } from "@mui/material";
 import binding from "./binding";
-import {withRouter} from "react-router-dom";
+import { withRouter } from "react-router-dom";
 
 class Create extends React.Component {
   constructor(props) {
@@ -87,9 +84,9 @@ class Create extends React.Component {
 
       if (this.state.contract721 || this.state.contract100) {
         let res = await binding.command_asset_issue_simple_tokens(
-            publicKey,
-            parseInt(this.state.numberInitialTokens),
-            this.state.committee
+          publicKey,
+          parseInt(this.state.numberInitialTokens),
+          this.state.committee
         );
 
         console.log(res);
@@ -150,7 +147,7 @@ class Create extends React.Component {
 
   onDeleteCommitteeMember(index) {
     let committee = this.state.committee.filter(function (_, i, arr) {
-      return i != index;
+      return i !== parseInt(index);
     });
 
     this.setState({ committee });
@@ -277,5 +274,4 @@ class Create extends React.Component {
   }
 }
 
-export default withRouter(Create)
-
+export default withRouter(Create);

--- a/applications/tari_collectibles/web-app/src/Manage.js
+++ b/applications/tari_collectibles/web-app/src/Manage.js
@@ -22,7 +22,6 @@
 import React from "react";
 import {
   Alert,
-  Button,
   Card,
   CardActions,
   CardContent,
@@ -32,7 +31,7 @@ import {
   Typography,
 } from "@mui/material";
 import binding from "./binding";
-import {Link, withRouter} from "react-router-dom";
+import { Link, withRouter } from "react-router-dom";
 
 var cardStyle = {
   width: "20vw",

--- a/applications/tari_collectibles/web-app/src/Manage.js
+++ b/applications/tari_collectibles/web-app/src/Manage.js
@@ -59,7 +59,7 @@ class Manage extends React.Component {
     this.setState({ error: "" });
     try {
       let assets = await binding.command_assets_list();
-      console.log(assets);
+      // console.log(assets);
       this.setState({
         ownedAssets: assets,
       });
@@ -77,17 +77,19 @@ class Manage extends React.Component {
         ) : (
           ""
         )}
-        <Typography variant="h3">Assets I've Issued</Typography>
+        <Typography variant="h3">Assets Issued</Typography>
         <Grid container spacing={4}>
           {this.state.ownedAssets.map((asset) => (
-            <Grid item key={asset} xs={12} sm={6} md={4} lg={4}>
+            <Grid item key={asset.public_key} xs={12} sm={6} md={4} lg={4}>
               <Card style={cardStyle}>
-                <CardMedia
-                  component="img"
-                  sx={{ pb: "5%", height: "20vw", width: "20vw" }}
-                  image={asset.image}
-                  alt="random"
-                ></CardMedia>
+                <Link to={`/assets/manage/${asset.public_key}`}>
+                  <CardMedia
+                    component="img"
+                    sx={{ pb: "5%", height: "20vw", width: "20vw" }}
+                    image={asset.image}
+                    alt="random"
+                  ></CardMedia>
+                </Link>
                 <CardContent>
                   <Typography gutterBottom variant="h5" component="h2">
                     {asset.name}

--- a/applications/tari_collectibles/web-app/src/binding.js
+++ b/applications/tari_collectibles/web-app/src/binding.js
@@ -19,23 +19,32 @@
 //  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-import {invoke} from '@tauri-apps/api/tauri'
+import { invoke } from "@tauri-apps/api/tauri";
 
 async function command_assets_create(name, description, image) {
-    return await invoke('assets_create', {name, description, image});
+  return await invoke("assets_create", { name, description, image });
 }
 
 async function command_assets_list() {
-    return await invoke('assets_list', {});
+  return await invoke("assets_list", {});
 }
 
-
-async function command_asset_issue_simple_tokens(assetPubKey, numTokens, committee) {
-    return await invoke("assets_issue_simple_tokens", {assetPubKey, numTokens, committee});
+async function command_asset_issue_simple_tokens(
+  assetPubKey,
+  numTokens,
+  committee
+) {
+  return await invoke("assets_issue_simple_tokens", {
+    assetPubKey,
+    numTokens,
+    committee,
+  });
 }
 
-export default {
-    command_assets_create,
-    command_assets_list,
-    command_asset_issue_simple_tokens
+const commands = {
+  command_assets_create,
+  command_assets_list,
+  command_asset_issue_simple_tokens,
 };
+
+export default commands;

--- a/applications/tari_validator_node/src/dan_layer/workers/consensus_worker.rs
+++ b/applications/tari_validator_node/src/dan_layer/workers/consensus_worker.rs
@@ -336,6 +336,9 @@ where
             (PreCommit, PreCommitted) => Commit,
             (Commit, Committed) => Decide,
             (Decide, Decided) => NextView,
+            (Starting, BaseLayerCheckpointNotFound) => {
+                unimplemented!("Base layer checkpoint not found!")
+            },
             (s, e) => {
                 dbg!(&s);
                 dbg!(&e);


### PR DESCRIPTION
Description
---

Adds the asset definition json to the asset manage page, with a button to write it to disk. 
Cleaned up some JS warnings. Prettier auto formatted some files. 

![Screenshot 2021-10-27 at 14 42 39](https://user-images.githubusercontent.com/351403/139068004-2eb50ba3-b0c4-4027-b089-c5a1c545a8e1.png)


