### PR TITLE
feat!: add deleted height to unique_id index

### DIFF
--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -414,7 +414,7 @@ where T: BlockchainBackend + 'static
                     for id in unique_ids {
                         let output = self
                             .blockchain_db
-                            .fetch_utxo_by_unique_id(Some(asset_public_key.clone()), id)
+                            .fetch_utxo_by_unique_id(Some(asset_public_key.clone()), id, None)
                             .await?;
                         if let Some(out) = output {
                             match out.output {

--- a/base_layer/core/src/blocks/block_header.rs
+++ b/base_layer/core/src/blocks/block_header.rs
@@ -334,6 +334,7 @@ pub(crate) mod hash_serializer {
 mod test {
     use crate::blocks::BlockHeader;
     use tari_crypto::tari_utilities::Hashable;
+
     #[test]
     fn from_previous() {
         let mut h1 = crate::proof_of_work::sha3_test::get_header();

--- a/base_layer/core/src/chain_storage/async_db.rs
+++ b/base_layer/core/src/chain_storage/async_db.rs
@@ -160,7 +160,7 @@ impl<B: BlockchainBackend + 'static> AsyncBlockchainDb<B> {
 
     make_async_fn!(fetch_utxos_by_mmr_position(start: u64, end: u64, deleted: Arc<Bitmap>) -> (Vec<PrunedOutput>, Bitmap), "fetch_utxos_by_mmr_position");
 
-    make_async_fn!(fetch_utxo_by_unique_id(parent_public_key: Option<PublicKey>,unique_id: HashOutput) -> Option<UtxoMinedInfo>, "fetch_utxo_by_unique_id");
+    make_async_fn!(fetch_utxo_by_unique_id(parent_public_key: Option<PublicKey>,unique_id: HashOutput, deleted_at: Option<u64>) -> Option<UtxoMinedInfo>, "fetch_utxo_by_unique_id");
 
     make_async_fn!(fetch_all_unspent_by_parent_public_key(
         parent_public_key: PublicKey,

--- a/base_layer/core/src/chain_storage/blockchain_backend.rs
+++ b/base_layer/core/src/chain_storage/blockchain_backend.rs
@@ -119,12 +119,13 @@ pub trait BlockchainBackend: Send + Sync {
         commitment: &Commitment,
     ) -> Result<Option<HashOutput>, ChainStorageError>;
 
-    /// Returns the unspent TransactionOutput output that matches the given unique_id if it exists in the current UTXO
-    /// set, otherwise None is returned.
+    /// Returns the unspent TransactionOutput output that matches the given unique_id if it exists, otherwise None is
+    /// returned.
     fn fetch_utxo_by_unique_id(
         &self,
         parent_public_key: Option<&PublicKey>,
         unique_id: &[u8],
+        deleted_at: Option<u64>,
     ) -> Result<Option<UtxoMinedInfo>, ChainStorageError>;
 
     /// Returns all unspent outputs with a parent public key

--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -315,9 +315,10 @@ where B: BlockchainBackend
         &self,
         parent_public_key: Option<PublicKey>,
         unique_id: HashOutput,
+        deleted_at: Option<u64>,
     ) -> Result<Option<UtxoMinedInfo>, ChainStorageError> {
         let db = self.db_read_access()?;
-        db.fetch_utxo_by_unique_id(parent_public_key.as_ref(), &unique_id)
+        db.fetch_utxo_by_unique_id(parent_public_key.as_ref(), &unique_id, deleted_at)
     }
 
     pub fn fetch_all_unspent_by_parent_public_key(

--- a/base_layer/core/src/chain_storage/lmdb_db/key_prefix_cursor.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/key_prefix_cursor.rs
@@ -49,7 +49,7 @@ where V: DeserializeOwned
     /// Returns the item on or after the key prefix, progressing forwards until the key prefix no longer matches
     pub fn next(&mut self) -> Result<Option<(Vec<u8>, V)>, ChainStorageError> {
         if !self.has_seeked {
-            if let Some((k, val)) = self.seek_gte(&self.prefix_key)? {
+            if let Some((k, val)) = self.seek_gte(self.prefix_key)? {
                 return Ok(Some((k, val)));
             }
         }
@@ -86,7 +86,7 @@ where V: DeserializeOwned
             Some(r) => r,
             None => return Ok(None),
         };
-        Self::deserialize_if_matches(&key, k, v)
+        Self::deserialize_if_matches(key, k, v)
     }
 
     fn deserialize_if_matches(

--- a/base_layer/core/src/chain_storage/lmdb_db/key_prefix_cursor.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/key_prefix_cursor.rs
@@ -1,0 +1,104 @@
+//  Copyright 2021, The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::chain_storage::{lmdb_db::helpers::deserialize, ChainStorageError};
+use lmdb_zero::{ConstAccessor, Cursor, LmdbResultExt};
+use serde::de::DeserializeOwned;
+use std::marker::PhantomData;
+
+pub struct KeyPrefixCursor<'a, V> {
+    cursor: Cursor<'a, 'a>,
+    value_type: PhantomData<V>,
+    prefix_key: &'a [u8],
+    access: ConstAccessor<'a>,
+    has_seeked: bool,
+}
+
+impl<'a, V> KeyPrefixCursor<'a, V>
+where V: DeserializeOwned
+{
+    pub(super) fn new(cursor: Cursor<'a, 'a>, access: ConstAccessor<'a>, prefix_key: &'a [u8]) -> Self {
+        Self {
+            cursor,
+            access,
+            prefix_key,
+            value_type: PhantomData,
+            has_seeked: false,
+        }
+    }
+
+    /// Returns the item on or after the key prefix, progressing forwards until the key prefix no longer matches
+    pub fn next(&mut self) -> Result<Option<(Vec<u8>, V)>, ChainStorageError> {
+        if !self.has_seeked {
+            if let Some((k, val)) = self.seek_gte(&self.prefix_key)? {
+                return Ok(Some((k, val)));
+            }
+        }
+
+        match self.cursor.next(&self.access).to_opt()? {
+            Some((k, v)) => Self::deserialize_if_matches(self.prefix_key, k, v),
+            None => Ok(None),
+        }
+    }
+
+    /// Returns the item on or before the given seek key, progressing backwards until the key prefix no longer matches
+    pub fn prev(&mut self) -> Result<Option<(Vec<u8>, V)>, ChainStorageError> {
+        if !self.has_seeked {
+            let prefix_key = self.prefix_key;
+            if let Some((k, val)) = self.seek_gte(prefix_key)? {
+                // seek_range_k returns the greater key, so we only want to return the current value that was seeked to
+                // if it exactly matches the prefix_key
+                if k == prefix_key {
+                    return Ok(Some((k, val)));
+                }
+            }
+        }
+
+        match self.cursor.prev(&self.access).to_opt()? {
+            Some((k, v)) => Self::deserialize_if_matches(self.prefix_key, k, v),
+            None => Ok(None),
+        }
+    }
+
+    pub fn seek_gte(&mut self, key: &[u8]) -> Result<Option<(Vec<u8>, V)>, ChainStorageError> {
+        self.has_seeked = true;
+        let seek_result = self.cursor.seek_range_k(&self.access, key).to_opt()?;
+        let (k, v) = match seek_result {
+            Some(r) => r,
+            None => return Ok(None),
+        };
+        Self::deserialize_if_matches(&key, k, v)
+    }
+
+    fn deserialize_if_matches(
+        key_prefix: &[u8],
+        k: &[u8],
+        v: &[u8],
+    ) -> Result<Option<(Vec<u8>, V)>, ChainStorageError> {
+        let prefix_len = key_prefix.len();
+        if k.len() < prefix_len || k[..prefix_len] != *key_prefix {
+            return Ok(None);
+        }
+        let val = deserialize::<V>(v)?;
+        Ok(Some((k.to_vec(), val)))
+    }
+}

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -974,7 +974,7 @@ impl LMDBDatabase {
                     "utxo_commitment_index",
                 )?;
                 if let Some(unique_id) = output.features.unique_asset_id() {
-                    let mut key = UniqueIdIndexKey::new(output.features.parent_public_key.as_ref(), unique_id);
+                    let key = UniqueIdIndexKey::new(output.features.parent_public_key.as_ref(), unique_id);
                     lmdb_delete(txn, &self.unique_id_index, key.as_bytes(), "unique_id_index")?;
                 }
             }

--- a/base_layer/core/src/chain_storage/lmdb_db/mod.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/mod.rs
@@ -20,6 +20,8 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+mod helpers;
+mod key_prefix_cursor;
 mod lmdb;
 #[allow(clippy::module_inception)]
 mod lmdb_db;

--- a/base_layer/core/src/chain_storage/tests/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/tests/blockchain_database.rs
@@ -514,7 +514,7 @@ mod fetch_utxo_by_unique_id {
 
         // Height 2 - mint
         let (block, _) = create_next_block(blocks.last().unwrap(), txns);
-        assert!(db.add_block(block.clone()).unwrap().is_added());
+        assert!(db.add_block(block).unwrap().is_added());
 
         // Height 4
         let (blocks, _) = add_many_chained_blocks(2, &db);
@@ -548,7 +548,7 @@ mod fetch_utxo_by_unique_id {
         let asset_utxo2 = tx_outputs.iter().find(|o| o.features == features).unwrap();
 
         // Height 5 - spend
-        let (block, _) = create_next_block(&blocks.last().unwrap(), txns);
+        let (block, _) = create_next_block(blocks.last().unwrap(), txns);
         assert!(db.add_block(block).unwrap().is_added());
 
         // Height 10
@@ -592,22 +592,22 @@ mod fetch_utxo_by_unique_id {
             assert_utxo_not_found(Some(i));
         });
         (5..=10).for_each(|i| {
-            assert_utxo_found(&asset_utxo1, Some(i));
+            assert_utxo_found(asset_utxo1, Some(i));
         });
 
-        let (txns, _) = schema_to_transaction(&[txn_schema!(from: vec![asset_utxo2.clone()], to: vec![1 * T])]);
+        let (txns, _) = schema_to_transaction(&[txn_schema!(from: vec![asset_utxo2.clone()], to: vec![T])]);
 
         // Height 11 - burn
-        let (block, _) = create_next_block(&blocks.last().unwrap(), txns);
+        let (block, _) = create_next_block(blocks.last().unwrap(), txns);
         assert!(db.add_block(block).unwrap().is_added());
 
-        assert_utxo_found(&asset_utxo2, None);
+        assert_utxo_found(asset_utxo2, None);
         (0..=4).for_each(|i| {
             assert_utxo_not_found(Some(i));
         });
         (5..=10).for_each(|i| {
-            assert_utxo_found(&asset_utxo1, Some(i));
+            assert_utxo_found(asset_utxo1, Some(i));
         });
-        assert_utxo_found(&asset_utxo2, Some(11));
+        assert_utxo_found(asset_utxo2, Some(11));
     }
 }

--- a/base_layer/core/src/test_helpers/blockchain.rs
+++ b/base_layer/core/src/test_helpers/blockchain.rs
@@ -294,11 +294,12 @@ impl BlockchainBackend for TempDatabase {
         &self,
         parent_public_key: Option<&PublicKey>,
         unique_id: &[u8],
+        deleted_at: Option<u64>,
     ) -> Result<Option<UtxoMinedInfo>, ChainStorageError> {
         self.db
             .as_ref()
             .unwrap()
-            .fetch_utxo_by_unique_id(parent_public_key, unique_id)
+            .fetch_utxo_by_unique_id(parent_public_key, unique_id, deleted_at)
     }
 
     fn fetch_all_unspent_by_parent_public_key(

--- a/base_layer/core/src/transactions/test_helpers.rs
+++ b/base_layer/core/src/transactions/test_helpers.rs
@@ -282,7 +282,7 @@ macro_rules! txn_schema {
             to_outputs: vec![],
             fee: $fee,
             lock_height: $lock,
-            features: $features,
+            features: $features.clone(),
             script: tari_crypto::script![Nop],
             input_data: None,
         }
@@ -294,7 +294,7 @@ macro_rules! txn_schema {
             to:$outputs,
             fee:$fee,
             lock:$lock,
-            features: $features
+            features: $features.clone()
         )
     }};
 

--- a/base_layer/core/src/transactions/transaction.rs
+++ b/base_layer/core/src/transactions/transaction.rs
@@ -117,7 +117,7 @@ pub struct SideChainCheckpointFeatures {
 }
 
 /// Options for UTXO's
-#[derive(Debug, Clone, Hash, PartialEq, Deserialize, Serialize, Eq)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Deserialize, Serialize)]
 pub struct OutputFeatures {
     /// Flags are the feature flags that differentiate between outputs, eg Coinbase all of which has different rules
     pub flags: OutputFlags,

--- a/base_layer/core/src/validation/helpers.rs
+++ b/base_layer/core/src/validation/helpers.rs
@@ -419,7 +419,9 @@ pub fn check_input_is_utxo<B: BlockchainBackend>(db: &B, input: &TransactionInpu
     }
 
     if let Some(unique_id) = &input.features.unique_id {
-        if let Some(utxo_hash) = db.fetch_utxo_by_unique_id(input.features.parent_public_key.as_ref(), unique_id)? {
+        if let Some(utxo_hash) =
+            db.fetch_utxo_by_unique_id(input.features.parent_public_key.as_ref(), unique_id, None)?
+        {
             // Check that it is the same utxo in which the unique_id was created
             if utxo_hash.output.hash() == output_hash {
                 return Ok(());
@@ -461,7 +463,7 @@ pub fn check_not_duplicate_txos<B: BlockchainBackend>(db: &B, body: &AggregateBo
     Ok(())
 }
 
-/// This function checks that the outputs do not already exist in the UTxO set.
+/// This function checks that the outputs do not already exist in the TxO set.
 pub fn check_not_duplicate_txo<B: BlockchainBackend>(
     db: &B,
     output: &TransactionOutput,
@@ -487,7 +489,7 @@ pub fn check_not_duplicate_txo<B: BlockchainBackend>(
     if let Some(unique_id) = &output.features.unique_id {
         // Needs to have a mint flag
         if output.features.flags.contains(OutputFlags::MINT_NON_FUNGIBLE) &&
-            db.fetch_utxo_by_unique_id(output.features.parent_public_key.as_ref(), unique_id)?
+            db.fetch_utxo_by_unique_id(output.features.parent_public_key.as_ref(), unique_id, None)?
                 .is_some()
         {
             warn!(

--- a/base_layer/core/tests/chain_storage_tests/chain_storage.rs
+++ b/base_layer/core/tests/chain_storage_tests/chain_storage.rs
@@ -1074,7 +1074,7 @@ fn asset_unique_id() {
     // mint it to the chain
     let tx = txn_schema!(
         from: vec![outputs[1][0].clone()],
-        to: vec![0 * T], fee: 20.into(), lock: 0, features: features.clone()
+        to: vec![0 * T], fee: 20.into(), lock: 0, features: features
     );
 
     let result = generate_new_block(&mut db, &mut blocks, &mut outputs, vec![tx], &consensus_manager).unwrap();
@@ -1118,7 +1118,7 @@ fn asset_unique_id() {
     // mint unique_id2
     let tx = txn_schema!(
         from: vec![outputs[1][2].clone()],
-        to: vec![0 * T], fee: 20.into(), lock: 0, features: features.clone()
+        to: vec![0 * T], fee: 20.into(), lock: 0, features: features
     );
     let result = generate_new_block(&mut db, &mut blocks, &mut outputs, vec![tx], &consensus_manager).unwrap();
     assert!(result.is_added());
@@ -1150,7 +1150,7 @@ fn asset_unique_id() {
     // mint
     let tx = txn_schema!(
         from: vec![outputs[1][3].clone()],
-        to: vec![0 * T], fee: 20.into(), lock: 0, features: features.clone()
+        to: vec![0 * T], fee: 20.into(), lock: 0, features: features
     );
     let result = generate_new_block(&mut db, &mut blocks, &mut outputs, vec![tx], &consensus_manager).unwrap();
     assert!(result.is_added());

--- a/base_layer/core/tests/mempool.rs
+++ b/base_layer/core/tests/mempool.rs
@@ -1109,7 +1109,7 @@ async fn consensus_validation_unique_id() {
     };
     let txs = vec![txn_schema!(
         from: vec![outputs[1][0].clone()],
-        to: vec![0 * T], fee: 100.into(), lock: 0, features: features.clone()
+        to: vec![0 * T], fee: 100.into(), lock: 0, features: features
     )];
     generate_new_block(&mut store, &mut blocks, &mut outputs, txs, &consensus_manager).unwrap();
 


### PR DESCRIPTION

Description
---
- adds the spend/deleted height to the asset id index when a unique id
  UTXO is spent
- head unique_id (ie. <asset_pk, unique_id> in current UTXO set) has
  "special" key in unique_id_index
- handle reorg code to update unique_id_index
- replace hex string keys with byte keys in kernel and input dbs
- add test for fetch_utxo_by_unique_id with deleted height param

Motivation and Context
---
Allow fetch_utxo_by_unique_id to query the "head" UTXO that existed at any height

How Has This Been Tested?
---
Unit tests 
Some tests are failing but I suspect this was already the case before this PR
