### PR TITLE
test: improve cucumber with wallets

### DIFF
--- a/integration_tests/features/WalletRecovery.feature
+++ b/integration_tests/features/WalletRecovery.feature
@@ -6,6 +6,7 @@ Feature: Wallet Recovery
         Given I have a seed node NODE
         And I have 1 base nodes connected to all seed nodes
         And I have wallet WALLET_A connected to all seed nodes
+        And I have wallet WALLET_C connected to all seed nodes
         And I have mining node MINER connected to base node NODE and wallet WALLET_A
         When mining node MINER mines 10 blocks
         When I mine 5 blocks on NODE
@@ -13,7 +14,6 @@ Feature: Wallet Recovery
         Then all nodes are at height 15
         When I recover wallet WALLET_A into wallet WALLET_B connected to all seed nodes
         Then wallet WALLET_A and wallet WALLET_B have the same balance
-        And I have wallet WALLET_C connected to all seed nodes
         And I send 100000 uT from wallet WALLET_B to wallet WALLET_C at fee 100
         When I mine 5 blocks on NODE
         Then all nodes are at height 20
@@ -47,10 +47,10 @@ Feature: Wallet Recovery
         Given I have a seed node NODE
         And I have 1 base nodes connected to all seed nodes
         And I have wallet WALLET_A connected to all seed nodes
+        And I have wallet WALLET_B connected to all seed nodes
         And I have mining node MINER connected to base node NODE and wallet WALLET_A
         When mining node MINER mines 10 blocks
         Then all nodes are at height 10
-        And I have wallet WALLET_B connected to all seed nodes
         And I stop wallet WALLET_B
         # Send 2 one-sided payments to WALLET_B so it can spend them in two cases
         Then I send a one-sided transaction of 1000000 uT from WALLET_A to WALLET_B at fee 20

--- a/integration_tests/features/WalletTransactions.feature
+++ b/integration_tests/features/WalletTransactions.feature
@@ -6,11 +6,12 @@ Feature: Wallet Transactions
     Given I have a seed node NODE
     And I have 1 base nodes connected to all seed nodes
     And I have wallet WALLET_A connected to all seed nodes
+    And I have wallet WALLET_B connected to all seed nodes
+    And I have wallet WALLET_C connected to all seed nodes
     And I have mining node MINER connected to base node NODE and wallet WALLET_A
     When mining node MINER mines 15 blocks
     Then all nodes are at height 15
     When I wait for wallet WALLET_A to have at least 55000000000 uT
-    And I have wallet WALLET_B connected to all seed nodes
     Then I send a one-sided transaction of 1000000 uT from WALLET_A to WALLET_B at fee 100
     Then I send a one-sided transaction of 1000000 uT from WALLET_A to WALLET_B at fee 100
     When mining node MINER mines 5 blocks
@@ -23,7 +24,6 @@ Feature: Wallet Transactions
     Then all nodes are at height 25
     Then I wait for wallet WALLET_B to have at least 1900000 uT
     # Make a one-sided payment to a new wallet that is big enough to ensure the second recovered output is spent
-    And I have wallet WALLET_C connected to all seed nodes
     Then I send a one-sided transaction of 1500000 uT from WALLET_B to WALLET_C at fee 20
     Then I wait for wallet WALLET_B to have less than 1000000 uT
     When mining node MINER mines 5 blocks
@@ -34,17 +34,17 @@ Feature: Wallet Transactions
     Given I have a seed node NODE
     And I have 1 base nodes connected to all seed nodes
     And I have wallet WALLET_A connected to all seed nodes
+    And I have wallet WALLET_B connected to all seed nodes
+    And I have wallet WALLET_C connected to all seed nodes
     And I have mining node MINER connected to base node NODE and wallet WALLET_A
     When mining node MINER mines 5 blocks
     Then all nodes are at height 5
     Then I wait for wallet WALLET_A to have at least 10000000000 uT
-    Then I have wallet WALLET_B connected to all seed nodes
     And I send 1000000 uT from wallet WALLET_A to wallet WALLET_B at fee 100
     Then mining node MINER mines 5 blocks
     Then all nodes are at height 10
     Then I wait for wallet WALLET_B to have at least 1000000 uT
     Then I stop wallet WALLET_B
-    When I have wallet WALLET_C connected to all seed nodes
     Then I import WALLET_B unspent outputs to WALLET_C
     Then I wait for wallet WALLET_C to have at least 1000000 uT
     Then I restart wallet WALLET_C
@@ -56,11 +56,12 @@ Feature: Wallet Transactions
     Given I have a seed node NODE
     And I have 1 base nodes connected to all seed nodes
     And I have wallet WALLET_A connected to all seed nodes
+    And I have wallet WALLET_B connected to all seed nodes
+    And I have wallet WALLET_C connected to all seed nodes
     And I have mining node MINER connected to base node NODE and wallet WALLET_A
     When mining node MINER mines 5 blocks
     Then all nodes are at height 5
     Then I wait for wallet WALLET_A to have at least 10000000000 uT
-    Then I have wallet WALLET_B connected to all seed nodes
     And I send 1000000 uT from wallet WALLET_A to wallet WALLET_B at fee 100
     Then mining node MINER mines 5 blocks
     Then all nodes are at height 10
@@ -70,7 +71,6 @@ Feature: Wallet Transactions
     Then all nodes are at height 15
     When I wait for wallet WALLET_B to have at least 50000 uT
     Then I stop wallet WALLET_B
-    When I have wallet WALLET_C connected to all seed nodes
     Then I import WALLET_B spent outputs to WALLET_C
     Then I wait for wallet WALLET_C to have at least 1000000 uT
     Then I restart wallet WALLET_C
@@ -86,16 +86,16 @@ Feature: Wallet Transactions
     Given I have a seed node SEED_B
     And I have a base node B connected to seed SEED_B
     And I have wallet WB connected to base node B
+    And I have wallet WALLET_RECEIVE_TX connected to base node B
+    And I have wallet WALLET_IMPORTED connected to base node B
     And I have mining node BM connected to base node B and wallet WB
     And mining node BM mines 4 blocks with min difficulty 1 and max difficulty 50
     Then I wait for wallet WB to have at least 1000000 uT
-    And I have wallet WALLET_RECEIVE_TX connected to base node B
     And I send 1000000 uT from wallet WB to wallet WALLET_RECEIVE_TX at fee 100
     Then mining node BM mines 4 blocks with min difficulty 50 and max difficulty 100
     When node B is at height 8
     Then I wait for wallet WALLET_RECEIVE_TX to have at least 1000000 uT
     Then I stop wallet WALLET_RECEIVE_TX
-    When I have wallet WALLET_IMPORTED connected to base node B
     Then I import WALLET_RECEIVE_TX unspent outputs to WALLET_IMPORTED
     Then I wait for wallet WALLET_IMPORTED to have at least 1000000 uT
     # This triggers a validation of the imported outputs
@@ -128,17 +128,17 @@ Feature: Wallet Transactions
     Given I have a seed node NODE
     And I have 1 base nodes connected to all seed nodes
     And I have wallet WALLET_A connected to all seed nodes
+    And I have wallet WALLET_B connected to all seed nodes
+    And I have wallet WALLET_C connected to all seed nodes
     And I have mining node MINER connected to base node NODE and wallet WALLET_A
     When mining node MINER mines 5 blocks
     Then all nodes are at height 5
     Then I wait for wallet WALLET_A to have at least 10000000000 uT
-    When I have wallet WALLET_B connected to all seed nodes
     And I send 1000000 uT from wallet WALLET_A to wallet WALLET_B at fee 100
     When mining node MINER mines 6 blocks
     Then all nodes are at height 11
     Then I wait for wallet WALLET_B to have at least 1000000 uT
     Then I stop wallet WALLET_B
-    When I have wallet WALLET_C connected to all seed nodes
     Then I import WALLET_B unspent outputs as faucet outputs to WALLET_C
     Then I wait for wallet WALLET_C to have at least 1000000 uT
     And I send 500000 uT from wallet WALLET_C to wallet WALLET_A at fee 100
@@ -275,6 +275,7 @@ Feature: Wallet Transactions
     Given I have a seed node NODE
     And I have 1 base nodes connected to all seed nodes
     And I have wallet WALLET_A connected to all seed nodes
+    And I have wallet WALLET_RECV connected to all seed nodes
     And I have mining node MINER connected to base node NODE and wallet WALLET_A
     And mining node MINER mines 5 blocks
     Then all nodes are at height 5
@@ -284,7 +285,6 @@ Feature: Wallet Transactions
     And mining node MINER mines 5 blocks
     Then all nodes are at height 10
     Then I wait for wallet WALLET_SENDER to have at least 100000000 uT
-    And I have wallet WALLET_RECV connected to all seed nodes
     And I stop wallet WALLET_RECV
     And I send 1000000 uT without waiting for broadcast from wallet WALLET_SENDER to wallet WALLET_RECV at fee 100
     When wallet WALLET_SENDER detects last transaction is Pending


### PR DESCRIPTION
Description
---
It is beneficial to start all wallets as soon as possible in a cucumber test if the test logic allows it to improve wallet discovery finishing within the set time out limits.

Motivation and Context
---
Flaky cucumber tests with CI.

How Has This Been Tested?
---
Running cucumber on CI
