### PR TITLE
test: add unique_id block validator tests

### DIFF
--- a/base_layer/core/src/blocks/genesis_block.rs
+++ b/base_layer/core/src/blocks/genesis_block.rs
@@ -39,6 +39,8 @@ use tari_crypto::{
     tari_utilities::{hash::Hashable, hex::*},
 };
 
+const LATEST_BLOCK_VERSION: u16 = 1;
+
 /// Returns the genesis block for the selected network.
 pub fn get_genesis_block(network: Network) -> ChainBlock {
     use Network::*;
@@ -47,7 +49,7 @@ pub fn get_genesis_block(network: Network) -> ChainBlock {
         Ridcully => get_ridcully_genesis_block(),
         Stibbons => unimplemented!(),
         Weatherwax => get_weatherwax_genesis_block(),
-        LocalNet => get_weatherwax_genesis_block(),
+        LocalNet => get_igor_genesis_block(),
         Igor => get_igor_genesis_block(),
         Dibbler => get_dibbler_genesis_block(),
     }
@@ -317,11 +319,11 @@ fn get_igor_genesis_block_raw() -> Block {
     );
     body.sort(1);
     // set genesis timestamp
-    let genesis = DateTime::parse_from_rfc2822("27 Aug 2021 06:00:00 +0200").unwrap();
+    let genesis = DateTime::parse_from_rfc2822("28 Oct 2021 06:00:00 +0200").unwrap();
     let timestamp = genesis.timestamp() as u64;
     Block {
         header: BlockHeader {
-            version: 0,
+            version: LATEST_BLOCK_VERSION,
             height: 0,
             prev_hash: vec![0; BLOCK_HASH_LENGTH],
             timestamp: timestamp.into(),
@@ -400,11 +402,11 @@ fn get_dibbler_genesis_block_raw() -> Block {
     );
     body.sort(2);
     // set genesis timestamp
-    let genesis = DateTime::parse_from_rfc2822("09 Sep 2021 00:00:00 +0200").unwrap();
+    let genesis = DateTime::parse_from_rfc2822("28 Oct 2021 00:00:00 +0200").unwrap();
     let timestamp = genesis.timestamp() as u64;
     Block {
         header: BlockHeader {
-            version: 0,
+            version: LATEST_BLOCK_VERSION,
             height: 0,
             prev_hash: vec![0; BLOCK_HASH_LENGTH],
             timestamp: timestamp.into(),

--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -235,7 +235,12 @@ where B: BlockchainBackend
     /// Returns a reference to the consensus cosntants at the current height
     pub fn consensus_constants(&self) -> Result<&ConsensusConstants, ChainStorageError> {
         let height = self.get_height()?;
-        Ok(self.consensus_manager.consensus_constants(height))
+        Ok(self.rules().consensus_constants(height))
+    }
+
+    /// Returns a reference to the consensus rules
+    pub fn rules(&self) -> &ConsensusManager {
+        &self.consensus_manager
     }
 
     // Be careful about making this method public. Rather use `db_and_metadata_read_access`

--- a/base_layer/core/src/test_helpers/block_spec.rs
+++ b/base_layer/core/src/test_helpers/block_spec.rs
@@ -97,6 +97,10 @@ macro_rules! block_spec {
         $spec = $spec.with_reward($reward.into());
         $crate::block_spec!(@ { spec } $($tail)*)
     };
+    (@ { $spec: ident } transactions: $transactions:expr, $($tail:tt)*) => {
+        $spec = $spec.with_transactions($transactions.into());
+        $crate::block_spec!(@ { spec } $($tail)*)
+    };
 
     (@ { $spec: ident } $k:ident: $v:expr $(,)?) => { $crate::block_spec!(@ { $spec } $k: $v,) };
 
@@ -153,7 +157,6 @@ macro_rules! block_specs {
 pub struct BlockSpec {
     pub name: &'static str,
     pub prev_block: &'static str,
-    pub version: u16,
     pub difficulty: Difficulty,
     pub block_time: u64,
     pub reward_override: Option<MicroTari>,
@@ -226,7 +229,6 @@ impl Default for BlockSpec {
         Self {
             name: "<unnamed>",
             prev_block: "",
-            version: 0,
             difficulty: 1.into(),
             block_time: 120,
             height_override: None,

--- a/base_layer/core/src/test_helpers/mod.rs
+++ b/base_layer/core/src/test_helpers/mod.rs
@@ -62,10 +62,10 @@ pub fn create_orphan_block(block_height: u64, transactions: Vec<Transaction>, co
 }
 
 pub fn create_block(rules: &ConsensusManager, prev_block: &Block, spec: BlockSpec) -> (Block, UnblindedOutput) {
-    let mut header = BlockHeader::new(spec.version);
+    let mut header = BlockHeader::from_previous(&prev_block.header);
     let block_height = spec.height_override.unwrap_or(prev_block.header.height + 1);
     header.height = block_height;
-    header.prev_hash = prev_block.hash();
+    // header.prev_hash = prev_block.hash();
     let reward = spec.reward_override.unwrap_or_else(|| {
         rules.calculate_coinbase_and_fees(
             header.height,

--- a/base_layer/core/src/transactions/test_helpers.rs
+++ b/base_layer/core/src/transactions/test_helpers.rs
@@ -297,7 +297,15 @@ macro_rules! txn_schema {
             features: $features
         )
     }};
-
+   (from: $input:expr, to: $outputs:expr, features: $features:expr) => {{
+        txn_schema!(
+            from: $input,
+            to:$outputs,
+            fee: 5.into(),
+            lock: 0,
+            features: $features
+        )
+    }};
     (from: $input:expr, to: $outputs:expr, fee: $fee:expr) => {
         txn_schema!(
             from: $input,

--- a/base_layer/core/src/validation/block_validators/async_validator.rs
+++ b/base_layer/core/src/validation/block_validators/async_validator.rs
@@ -27,7 +27,14 @@ use crate::{
     iterators::NonOverlappingIntegerPairIter,
     transactions::{
         aggregated_body::AggregateBody,
-        transaction::{KernelSum, TransactionError, TransactionInput, TransactionKernel, TransactionOutput},
+        transaction::{
+            KernelSum,
+            OutputFlags,
+            TransactionError,
+            TransactionInput,
+            TransactionKernel,
+            TransactionOutput,
+        },
         CryptoFactories,
     },
     validation::{
@@ -93,6 +100,22 @@ impl<B: BlockchainBackend + 'static> BlockValidator<B> {
         if !helpers::is_all_unique_and_sorted(&outputs) {
             return Err(ValidationError::UnsortedOrDuplicateOutput);
         }
+
+        // Check that unique_ids are unique in this block
+        let mut unique_ids = Vec::new();
+        for output in &outputs {
+            if output.features.flags.contains(OutputFlags::MINT_NON_FUNGIBLE) {
+                if let Some(unique_id) = output.features.unique_asset_id() {
+                    let parent_public_key = output.features.parent_public_key.as_ref();
+                    let asset_tuple = (parent_public_key, unique_id);
+                    if unique_ids.contains(&asset_tuple) {
+                        return Err(ValidationError::ContainsDuplicateUtxoUniqueID);
+                    }
+                    unique_ids.push(asset_tuple);
+                }
+            }
+        }
+
         let outputs_task = self.start_output_validation(&valid_header, outputs);
 
         // Wait for them to complete

--- a/base_layer/core/src/validation/block_validators/body_only.rs
+++ b/base_layer/core/src/validation/block_validators/body_only.rs
@@ -39,6 +39,12 @@ use tari_utilities::hex::Hex;
 #[derive(Default)]
 pub struct BodyOnlyValidator;
 
+impl BodyOnlyValidator {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
 impl<B: BlockchainBackend> PostOrphanBodyValidation<B> for BodyOnlyValidator {
     /// The consensus checks that are done (in order of cheapest to verify to most expensive):
     /// 1. Does the block satisfy the stateless checks?

--- a/base_layer/core/src/validation/block_validators/test.rs
+++ b/base_layer/core/src/validation/block_validators/test.rs
@@ -21,6 +21,7 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{
+    blocks::ChainBlock,
     consensus::{ConsensusConstantsBuilder, ConsensusManager},
     test_helpers::{
         blockchain::{TempDatabase, TestBlockchain},
@@ -29,8 +30,8 @@ use crate::{
     transactions::{
         aggregated_body::AggregateBody,
         tari_amount::T,
-        test_helpers::schema_to_transaction,
-        transaction::TransactionError,
+        test_helpers::{schema_to_transaction, TransactionSchema},
+        transaction::{OutputFeatures, OutputFlags, TransactionError, UnblindedOutput},
         CoinbaseBuilder,
         CryptoFactories,
     },
@@ -39,6 +40,7 @@ use crate::{
 };
 use std::sync::Arc;
 use tari_common::configuration::Network;
+use tari_common_types::types::PublicKey;
 use tari_test_utils::unpack_enum;
 
 fn setup_with_rules(rules: ConsensusManager) -> (TestBlockchain, BlockValidator<TempDatabase>) {
@@ -48,13 +50,20 @@ fn setup_with_rules(rules: ConsensusManager) -> (TestBlockchain, BlockValidator<
         rules,
         CryptoFactories::default(),
         false,
-        2,
+        6,
     );
     (blockchain, validator)
 }
 
 fn setup() -> (TestBlockchain, BlockValidator<TempDatabase>) {
-    setup_with_rules(ConsensusManager::builder(Network::LocalNet).build())
+    let rules = ConsensusManager::builder(Network::LocalNet)
+        .add_consensus_constants(
+            ConsensusConstantsBuilder::new(Network::LocalNet)
+                .with_coinbase_lockheight(0)
+                .build(),
+        )
+        .build();
+    setup_with_rules(rules)
 }
 
 #[tokio::test]
@@ -133,14 +142,7 @@ async fn it_checks_double_spends() {
 
 #[tokio::test]
 async fn it_checks_input_maturity() {
-    let rules = ConsensusManager::builder(Network::LocalNet)
-        .add_consensus_constants(
-            ConsensusConstantsBuilder::new(Network::LocalNet)
-                .with_coinbase_lockheight(0)
-                .build(),
-        )
-        .build();
-    let (mut blockchain, validator) = setup_with_rules(rules);
+    let (mut blockchain, validator) = setup();
 
     let (_, coinbase_a) = blockchain.add_next_tip("A", Default::default());
     let mut schema = txn_schema!(from: vec![coinbase_a], to: vec![50 * T]);
@@ -162,14 +164,7 @@ async fn it_checks_input_maturity() {
 
 #[tokio::test]
 async fn it_checks_txo_sort_order() {
-    let rules = ConsensusManager::builder(Network::LocalNet)
-        .add_consensus_constants(
-            ConsensusConstantsBuilder::new(Network::LocalNet)
-                .with_coinbase_lockheight(0)
-                .build(),
-        )
-        .build();
-    let (mut blockchain, validator) = setup_with_rules(rules);
+    let (mut blockchain, validator) = setup();
 
     let (_, coinbase_a) = blockchain.add_next_tip("A", Default::default());
 
@@ -186,4 +181,152 @@ async fn it_checks_txo_sort_order() {
 
     let err = validator.validate_block_body(block.block().clone()).await.unwrap_err();
     assert!(matches!(err, ValidationError::UnsortedOrDuplicateOutput));
+}
+
+mod unique_id {
+    use super::*;
+
+    pub fn create_block(
+        blockchain: &TestBlockchain,
+        parent_name: &'static str,
+        schema: TransactionSchema,
+    ) -> (Arc<ChainBlock>, UnblindedOutput) {
+        let (txs, outputs) = schema_to_transaction(&[schema]);
+        let txs = txs.into_iter().map(|t| Arc::try_unwrap(t).unwrap()).collect::<Vec<_>>();
+        let (block, _) = blockchain.create_chained_block(parent_name, BlockSpec::new().with_transactions(txs).finish());
+        let asset_output = outputs
+            .into_iter()
+            .find(|o| o.features.unique_asset_id().is_some())
+            .unwrap();
+        (block, asset_output)
+    }
+
+    #[tokio::test]
+    async fn it_checks_for_duplicate_unique_id_in_block() {
+        let (mut blockchain, validator) = setup();
+
+        let (_, coinbase_a) = blockchain.add_next_tip("1", Default::default());
+        let unique_id = vec![1; 3];
+        let parent_pk = PublicKey::default();
+
+        let features = OutputFeatures {
+            flags: OutputFlags::MINT_NON_FUNGIBLE,
+            parent_public_key: Some(parent_pk.clone()),
+            unique_id: Some(unique_id.clone()),
+            ..Default::default()
+        };
+
+        // Two outputs with same features
+        let schema =
+            txn_schema!(from: vec![coinbase_a], to: vec![5000 * T, 12 * T], fee: 5.into(), lock: 0, features: features);
+
+        let (block, _) = create_block(&blockchain, "1", schema);
+
+        let err = validator.validate_block_body(block.block().clone()).await.unwrap_err();
+        assert!(matches!(err, ValidationError::ContainsDuplicateUtxoUniqueID))
+    }
+
+    #[tokio::test]
+    async fn it_allows_spending_to_new_utxo() {
+        let (mut blockchain, validator) = setup();
+
+        let (_, coinbase_a) = blockchain.add_next_tip("1", Default::default());
+        let unique_id = vec![1; 3];
+        let parent_pk = PublicKey::default();
+
+        let features = OutputFeatures {
+            flags: OutputFlags::MINT_NON_FUNGIBLE,
+            parent_public_key: Some(parent_pk.clone()),
+            unique_id: Some(unique_id.clone()),
+            ..Default::default()
+        };
+
+        let schema =
+            txn_schema!(from: vec![coinbase_a], to: vec![5000 * T], fee: 5.into(), lock: 0, features: features);
+
+        let (block, asset_output) = create_block(&blockchain, "1", schema);
+        validator.validate_block_body(block.block().clone()).await.unwrap();
+        blockchain.append_block("2", block);
+
+        let features = OutputFeatures {
+            flags: OutputFlags::empty(),
+            parent_public_key: Some(parent_pk),
+            unique_id: Some(unique_id),
+            ..Default::default()
+        };
+
+        let schema = txn_schema!(from: vec![asset_output], to: vec![5 * T], fee: 5.into(), lock: 0, features: features);
+        let (block, _) = create_block(&blockchain, "2", schema);
+        validator.validate_block_body(block.block().clone()).await.unwrap();
+        blockchain.append_block("3", block);
+    }
+
+    #[tokio::test]
+    async fn it_checks_for_duplicate_unique_id_in_blockchain() {
+        let (mut blockchain, validator) = setup();
+
+        let (_, coinbase_a) = blockchain.add_next_tip("1", Default::default());
+        let unique_id = vec![1; 3];
+        let parent_pk = PublicKey::default();
+
+        let features = OutputFeatures {
+            flags: OutputFlags::MINT_NON_FUNGIBLE,
+            parent_public_key: Some(parent_pk.clone()),
+            unique_id: Some(unique_id.clone()),
+            ..Default::default()
+        };
+
+        let schema =
+            txn_schema!(from: vec![coinbase_a], to: vec![5000 * T], fee: 5.into(), lock: 0, features: features);
+
+        let (block, asset_output) = create_block(&blockchain, "1", schema);
+        validator.validate_block_body(block.block().clone()).await.unwrap();
+        blockchain.append_block("2", block);
+
+        let features = OutputFeatures {
+            flags: OutputFlags::MINT_NON_FUNGIBLE,
+            parent_public_key: Some(parent_pk),
+            unique_id: Some(unique_id),
+            ..Default::default()
+        };
+
+        let schema = txn_schema!(from: vec![asset_output], to: vec![5 * T], fee: 5.into(), lock: 0, features: features);
+        let (block, _) = create_block(&blockchain, "2", schema);
+        let err = validator.validate_block_body(block.block().clone()).await.unwrap_err();
+        assert!(matches!(err, ValidationError::ContainsDuplicateUtxoUniqueID))
+    }
+
+    #[tokio::test]
+    async fn it_allows_burn_flag() {
+        let (mut blockchain, validator) = setup();
+
+        let (_, coinbase_a) = blockchain.add_next_tip("1", Default::default());
+        let unique_id = vec![1; 3];
+        let parent_pk = PublicKey::default();
+
+        let features = OutputFeatures {
+            flags: OutputFlags::MINT_NON_FUNGIBLE,
+            parent_public_key: Some(parent_pk.clone()),
+            unique_id: Some(unique_id.clone()),
+            ..Default::default()
+        };
+
+        let schema =
+            txn_schema!(from: vec![coinbase_a], to: vec![5000 * T], fee: 5.into(), lock: 0, features: features);
+
+        let (block, asset_output) = create_block(&blockchain, "1", schema);
+        validator.validate_block_body(block.block().clone()).await.unwrap();
+        blockchain.append_block("2", block);
+
+        let features = OutputFeatures {
+            flags: OutputFlags::BURN_NON_FUNGIBLE,
+            parent_public_key: Some(parent_pk),
+            unique_id: Some(unique_id),
+            ..Default::default()
+        };
+
+        let schema = txn_schema!(from: vec![asset_output], to: vec![5 * T], fee: 5.into(), lock: 0, features: features);
+        let (block, _) = create_block(&blockchain, "2", schema);
+        validator.validate_block_body(block.block().clone()).await.unwrap();
+    }
 }

--- a/base_layer/core/src/validation/helpers.rs
+++ b/base_layer/core/src/validation/helpers.rs
@@ -339,7 +339,7 @@ pub fn check_inputs_are_utxos<B: BlockchainBackend>(db: &B, body: &AggregateBody
                 .features
                 .unique_id
                 .as_ref()
-                .map(|ui| (output.features.parent_public_key.clone(), ui.clone()))
+                .map(|ui| (output.features.parent_public_key.as_ref(), ui))
         })
         .collect::<Vec<_>>();
     for input in body.inputs() {
@@ -348,12 +348,12 @@ pub fn check_inputs_are_utxos<B: BlockchainBackend>(db: &B, body: &AggregateBody
             let exactly_one = output_unique_ids
                 .iter()
                 .filter(|(parent_public_key, output_unique_id)| {
-                    input.features.parent_public_key.as_ref() == parent_public_key.as_ref() &&
-                        unique_id == output_unique_id
+                    input.features.parent_public_key.as_ref() == *parent_public_key && unique_id == *output_unique_id
                 })
+                .take(2)
                 .collect::<Vec<_>>();
             // Unless a burn flag is present
-            if input.features.flags & OutputFlags::BURN_NON_FUNGIBLE == OutputFlags::BURN_NON_FUNGIBLE {
+            if input.features.flags.contains(OutputFlags::BURN_NON_FUNGIBLE) {
                 if !exactly_one.is_empty() {
                     return Err(ValidationError::UniqueIdBurnedButPresentInOutputs);
                 }


### PR DESCRIPTION
Description
---
- Add some tests for unique_id validation
- breaking change: Use version 1 blocks for localnet, igor and dibbler (kernel ordering, mmr without empty bitmap)
- Add mmr to test blocks in blockchain database so that concrete validation impls can be tested  

Motivation and Context
---
These are not complete as more work needs to happen to complete the validations

How Has This Been Tested?
---
Tests pass
