### PR TITLE
test: reset cucumber timeouts to practical limits

### DIFF
--- a/integration_tests/features/WalletCli.feature
+++ b/integration_tests/features/WalletCli.feature
@@ -76,7 +76,7 @@ Feature: Wallet CLI
         And I have wallet RECEIVER connected to base node BASE
         And I have mining node MINE connected to base node BASE and wallet SENDER
         And mining node MINE mines 15 blocks
-        Then wallets SENDER should have 12 spendable coinbase outputs
+        Then wallets SENDER should have exactly 12 spendable coinbase outputs
         # TODO: Remove this wait when the wallet CLI commands involving transactions will only commence with a valid
         # TODO: base node connection.
         And I wait 30 seconds

--- a/integration_tests/features/WalletMonitoring.feature
+++ b/integration_tests/features/WalletMonitoring.feature
@@ -61,17 +61,18 @@ Feature: Wallet Monitoring
     And I have wallet WALLET_A1 connected to seed node SEED_A
     And I have wallet WALLET_A2 connected to seed node SEED_A
     And I have mining node MINING_A connected to base node SEED_A and wallet WALLET_A1
-    And mining node MINING_A mines 10 blocks
+    When mining node MINING_A mines 10 blocks with min difficulty 100 and max difficulty 9999999999
     Then node SEED_A is at height 10
     Then node NODE_A1 is at height 10
-    Then wallet WALLET_A1 detects at least 7 coinbase transactions as Mined_Confirmed
+    Then wallet WALLET_A1 detects exactly 7 coinbase transactions as Mined_Confirmed
         # Use 7 of the 10 coinbase UTXOs in transactions (others require 3 confirmations)
     And I multi-send 7 transactions of 1000000 uT from wallet WALLET_A1 to wallet WALLET_A2 at fee 100
-    When I mine 100 blocks on SEED_A
-    Then node SEED_A is at height 110
-    Then node NODE_A1 is at height 110
+    When mining node MINING_A mines 10 blocks with min difficulty 100 and max difficulty 9999999999
+    Then node SEED_A is at height 20
+    Then node NODE_A1 is at height 20
     Then wallet WALLET_A2 detects all transactions as Mined_Confirmed
     Then all NORMAL transactions for wallet WALLET_A1 are valid
+    Then wallet WALLET_A1 detects exactly 17 coinbase transactions as Mined_Confirmed
         #
         # Chain 2:
         #   Collects 10 coinbases into one wallet, send 7 transactions
@@ -82,25 +83,28 @@ Feature: Wallet Monitoring
     And I have wallet WALLET_B1 connected to seed node SEED_B
     And I have wallet WALLET_B2 connected to seed node SEED_B
     And I have mining node MINING_B connected to base node SEED_B and wallet WALLET_B1
-    And mining node MINING_B mines 10 blocks
+    When mining node MINING_B mines 10 blocks with min difficulty 1 and max difficulty 2
     Then node SEED_B is at height 10
     Then node NODE_B1 is at height 10
-    Then wallet WALLET_B1 detects at least 7 coinbase transactions as Mined_Confirmed
+    Then wallet WALLET_B1 detects exactly 7 coinbase transactions as Mined_Confirmed
         # Use 7 of the 10 coinbase UTXOs in transactions (others require 3 confirmations)
     And I multi-send 7 transactions of 1000000 uT from wallet WALLET_B1 to wallet WALLET_B2 at fee 100
-    When I mine 100 blocks on SEED_B
-    Then node SEED_B is at height 110
-    Then node NODE_B1 is at height 110
+    When mining node MINING_B mines 10 blocks with min difficulty 1 and max difficulty 2
+    Then node SEED_B is at height 20
+    Then node NODE_B1 is at height 20
     Then wallet WALLET_B2 detects all transactions as Mined_Confirmed
     Then all NORMAL transactions for wallet WALLET_B1 are valid
+    Then wallet WALLET_B1 detects exactly 17 coinbase transactions as Mined_Confirmed
         #
         # Connect Chain 1 and 2
         #
     And I have a SHA3 miner NODE_C connected to all seed nodes
-    Then all nodes are at height 110
+    Then all nodes are at height 20
         # When tip advances past required confirmations, invalid coinbases still being monitored will be cancelled.
     And mining node NODE_C mines 6 blocks
-    Then all nodes are at height 116
+    Then all nodes are at height 26
+    Then wallet WALLET_A1 detects exactly 20 coinbase transactions as Mined_Confirmed
+    Then wallet WALLET_B1 detects exactly 17 coinbase transactions as Mined_Confirmed
     And I list all NORMAL transactions for wallet WALLET_A1
     And I list all NORMAL transactions for wallet WALLET_B1
     # TODO: Uncomment this step when wallets can handle reorg
@@ -130,7 +134,7 @@ Feature: Wallet Monitoring
     Then all nodes are on the same chain at height <endBlocks>
 
     When I wait 1 seconds
-    Then wallets WALLET1,WALLET2 should have <numBlocks> spendable coinbase outputs
+    Then wallets WALLET1,WALLET2 should have exactly <numBlocks> spendable coinbase outputs
 
     @flaky
     Examples:

--- a/integration_tests/features/support/steps.js
+++ b/integration_tests/features/support/steps.js
@@ -28,11 +28,11 @@ const AUTOUPDATE_HASHES_TXT_SIG_URL =
 const AUTOUPDATE_HASHES_TXT_BAD_SIG_URL =
   "https://raw.githubusercontent.com/tari-project/tari/development/meta/hashes.txt.bad.sig";
 
-Given(/I have a seed node (.*)/, { timeout: 30 * 1000 }, async function (name) {
+Given(/I have a seed node (.*)/, { timeout: 20 * 1000 }, async function (name) {
   return await this.createSeedNode(name);
 });
 
-Given("I have {int} seed nodes", { timeout: 30 * 1000 }, async function (n) {
+Given("I have {int} seed nodes", { timeout: 20 * 1000 }, async function (n) {
   const promises = [];
   for (let i = 0; i < n; i++) {
     promises.push(this.createSeedNode(`SeedNode${i}`));
@@ -46,7 +46,7 @@ Then(/all transactions must have succeeded/, function () {
 
 Given(
   /I have a base node (.*) connected to all seed nodes/,
-  { timeout: 30 * 1000 },
+  { timeout: 20 * 1000 },
   async function (name) {
     await this.createAndAddNode(name, this.seedAddresses());
   }
@@ -54,7 +54,7 @@ Given(
 
 Given(
   /I have a base node (.*) connected to seed (.*)/,
-  { timeout: 30 * 1000 },
+  { timeout: 20 * 1000 },
   async function (name, seedNode) {
     await this.createAndAddNode(name, this.seeds[seedNode].peerAddress());
   }
@@ -62,7 +62,7 @@ Given(
 
 Given(
   /I have a base node (.*) connected to nodes (.*)/,
-  { timeout: 30 * 1000 },
+  { timeout: 20 * 1000 },
   async function (name, nodes) {
     const addresses = [];
     nodes = nodes.split(",");
@@ -75,7 +75,7 @@ Given(
 
 Given(
   /I have a node (.*) with auto update enabled/,
-  { timeout: 30 * 1000 },
+  { timeout: 20 * 1000 },
   async function (name) {
     const node = await this.createNode(name, {
       common: {
@@ -95,7 +95,7 @@ Given(
 
 Given(
   /I have a node (.*) with auto update configured with a bad signature/,
-  { timeout: 30 * 1000 },
+  { timeout: 20 * 1000 },
   async function (name) {
     const node = await this.createNode(name, {
       common: {
@@ -115,7 +115,7 @@ Given(
 
 Given(
   /I have a wallet (.*) with auto update enabled/,
-  { timeout: 30 * 1000 },
+  { timeout: 20 * 1000 },
   async function (name) {
     await this.createAndAddWallet(name, "", {
       common: {
@@ -133,7 +133,7 @@ Given(
 
 Given(
   /I have a wallet (.*) with auto update configured with a bad signature/,
-  { timeout: 30 * 1000 },
+  { timeout: 20 * 1000 },
   async function (name) {
     await this.createAndAddWallet(name, "", {
       common: {
@@ -151,7 +151,7 @@ Given(
 
 Given(
   /I have a base node (.*) connected to node (.*)/,
-  { timeout: 30 * 1000 },
+  { timeout: 20 * 1000 },
   async function (name, node) {
     await this.createAndAddNode(name, this.nodes[node].peerAddress());
   }
@@ -167,7 +167,7 @@ Given(
 
 Given(
   /I have a SHA3 miner (.*) connected to seed node (.*)/,
-  { timeout: 30 * 1000 },
+  { timeout: 20 * 1000 },
   async function (name, seed) {
     // add the base_node
     await this.createAndAddNode(name, this.seeds[seed].peerAddress(), this);
@@ -191,7 +191,7 @@ Given(
 
 Given(
   /I have a SHA3 miner (.*) connected to node (.*)/,
-  { timeout: 30 * 1000 },
+  { timeout: 20 * 1000 },
   async function (name, basenode) {
     // add the base_node
     await this.createAndAddNode(name, this.nodes[basenode].peerAddress(), this);
@@ -215,7 +215,7 @@ Given(
 
 Given(
   /I have a SHA3 miner (.*) connected to all seed nodes/,
-  { timeout: 30 * 1000 },
+  { timeout: 20 * 1000 },
   async function (name) {
     // add the base_node
     await this.createAndAddNode(name, this.seedAddresses(), this);
@@ -239,7 +239,7 @@ Given(
 
 Given(
   /I connect node (.*) to node (.*)/,
-  { timeout: 40 * 1000 },
+  { timeout: 20 * 1000 },
   async function (nodeNameA, nodeNameB) {
     console.log(
       "Connecting (add new peer seed, shut down, then start up)",
@@ -252,21 +252,12 @@ Given(
     nodeA.setPeerSeeds([nodeB.peerAddress()]);
     await this.stopNode(nodeNameA);
     await this.startNode(nodeNameA);
-    await waitFor(
-      async () => {
-        let node_a_result = (await nodeA.get_node_state()) === "LISTENING";
-        let node_b_result = (await nodeB.get_node_state()) === "LISTENING";
-        return node_a_result && node_b_result;
-      },
-      true,
-      30 * 1000
-    );
   }
 );
 
 Given(
   /I have a pruned node (.*) connected to node (.*) with pruning horizon set to (.*)/,
-  { timeout: 30 * 1000 },
+  { timeout: 20 * 1000 },
   async function (name, connected_to, horizon) {
     const node = this.createNode(name, { pruningHorizon: horizon });
     node.setPeerSeeds([this.nodes[connected_to].peerAddress()]);
@@ -277,7 +268,7 @@ Given(
 
 Given(
   /I have a lagging delayed node (.*) connected to node (.*) with blocks_behind_before_considered_lagging (\d+)/,
-  { timeout: 30 * 1000 },
+  { timeout: 20 * 1000 },
   async function (name, node, delay) {
     const miner = this.createNode(name, {
       blocks_behind_before_considered_lagging: delay,
@@ -300,7 +291,7 @@ Given(
 
 Given(
   "I have {int} base nodes connected to all seed nodes",
-  { timeout: 120 * 1000 },
+  { timeout: 20 * 1000 },
   async function (n) {
     const promises = [];
     for (let i = 0; i < n; i++) {
@@ -316,6 +307,7 @@ Given(
 
 Given(
   /I have stress-test wallet (.*) connected to the seed node (.*) with broadcast monitoring timeout (.*)/,
+  { timeout: 20 * 1000 },
   async function (walletName, seedName, timeout) {
     const wallet = new WalletProcess(
       walletName,
@@ -334,7 +326,7 @@ Given(
 
 Given(
   /I have stress-test wallet (.*) connected to all the seed nodes with broadcast monitoring timeout (.*)/,
-  { timeout: 30 * 1000 },
+  { timeout: 20 * 1000 },
   async function (name, timeout) {
     const wallet = new WalletProcess(
       name,
@@ -353,6 +345,7 @@ Given(
 
 Given(
   /I have wallet (.*) connected to seed node (.*)/,
+  { timeout: 20 * 1000 },
   async function (walletName, seedName) {
     await this.createAndAddWallet(
       walletName,
@@ -363,6 +356,7 @@ Given(
 
 Given(
   /I have wallet (.*) connected to base node (.*)/,
+  { timeout: 20 * 1000 },
   async function (walletName, nodeName) {
     await this.createAndAddWallet(
       walletName,
@@ -371,13 +365,15 @@ Given(
   }
 );
 
-Given(/I have wallet (.*) connected to all seed nodes/, async function (name) {
+Given(/I have wallet (.*) connected to all seed nodes/,
+  { timeout: 20 * 1000 },
+  async function (name) {
   await this.createAndAddWallet(name, this.seedAddresses());
 });
 
 Given(
   /I have non-default wallet (.*) connected to all seed nodes using (.*)/,
-  { timeout: 30 * 1000 },
+  { timeout: 20 * 1000 },
   async function (name, mechanism) {
     // mechanism: DirectOnly, StoreAndForwardOnly, DirectAndStoreAndForward
     const wallet = new WalletProcess(
@@ -445,6 +441,7 @@ Given(
 
 Given(
   /I recover wallet (.*) into (\d+) wallets connected to all seed nodes/,
+  { timeout: 30 * 1000 },
   async function (walletNameA, numwallets) {
     const seedWords = this.getWallet(walletNameA).getSeedWords();
     for (let i = 1; i <= numwallets; i++) {
@@ -475,6 +472,7 @@ Given(
 
 Then(
   /I wait for (\d+) wallets to have at least (\d+) uT/,
+  { timeout: 710 * 1000 },
   async function (numwallets, amount) {
     for (let i = 1; i <= numwallets; i++) {
       const walletClient = await this.getWallet(i.toString()).connectClient();
@@ -501,6 +499,7 @@ Then(
 
 Then(
   /Wallet (.*) and (\d+) wallets have the same balance/,
+  { timeout: 120 * 1000 },
   async function (wallet, numwallets) {
     const walletClient = await this.getWallet(wallet).connectClient();
     let balance = await walletClient.getBalance();
@@ -530,6 +529,7 @@ When(/I restart wallet (.*)/, async function (walletName) {
 
 When(
   /I import (.*) spent outputs to (.*)/,
+  { timeout: 20 * 1000 },
   async function (walletNameA, walletNameB) {
     let walletA = this.getWallet(walletNameA);
     let walletB = this.getWallet(walletNameB);
@@ -544,6 +544,7 @@ When(
 
 When(
   /I import (.*) unspent outputs to (.*)/,
+  { timeout: 20 * 1000 },
   async function (walletNameA, walletNameB) {
     let walletA = this.getWallet(walletNameA);
     let walletB = this.getWallet(walletNameB);
@@ -558,6 +559,7 @@ When(
 
 When(
   /I import (.*) unspent outputs as faucet outputs to (.*)/,
+  { timeout: 20 * 1000 },
   async function (walletNameA, walletNameB) {
     let walletA = this.getWallet(walletNameA);
     let walletB = this.getWallet(walletNameB);
@@ -628,6 +630,7 @@ When(
 
 Given(
   /I have a merge mining proxy (.*) connected to (.*) and (.*) with default config/,
+  { timeout: 20 * 1000 },
   async function (mmProxy, node, wallet) {
     const baseNode = this.getNode(node);
     const walletNode = this.getWallet(wallet);
@@ -646,6 +649,7 @@ Given(
 
 Given(
   /I have a merge mining proxy (.*) connected to (.*) and (.*) with origin submission disabled/,
+  { timeout: 20 * 1000 },
   async function (mmProxy, node, wallet) {
     const baseNode = this.getNode(node);
     const walletNode = this.getWallet(wallet);
@@ -664,6 +668,7 @@ Given(
 
 Given(
   /I have a merge mining proxy (.*) connected to (.*) and (.*) with origin submission enabled/,
+  { timeout: 20 * 1000 },
   async function (mmProxy, node, wallet) {
     const baseNode = this.getNode(node);
     const walletNode = this.getWallet(wallet);
@@ -682,6 +687,7 @@ Given(
 
 Given(
   /I have mining node (.*) connected to base node (.*) and wallet (.*)/,
+  { timeout: 20 * 1000 },
   async function (miner, node, wallet) {
     const baseNode = this.getNode(node);
     const walletNode = await this.getOrCreateWallet(wallet);
@@ -699,6 +705,7 @@ Given(
 
 Given(
   /I have mine-before-tip mining node (.*) connected to base node (.*) and wallet (.*)/,
+  { timeout: 20 * 1000 },
   function (miner, node, wallet) {
     const baseNode = this.getNode(node);
     const walletNode = this.getWallet(wallet);
@@ -800,7 +807,7 @@ Then("Proxy response for block header by hash is valid", function () {
   assert(lastResult.result.status, "OK");
 });
 
-When(/I start base node (.*)/, { timeout: 30 * 1000 }, async function (name) {
+When(/I start base node (.*)/, { timeout: 20 * 1000 }, async function (name) {
   await this.startNode(name);
 });
 
@@ -836,7 +843,9 @@ Then(
   }
 );
 
-Then(/node (.*) has a pruned height of (\d+)/, async function (name, height) {
+Then(/node (.*) has a pruned height of (\d+)/,
+  { timeout: 120 * 1000 },
+  async function (name, height) {
   const client = this.getClient(name);
   await waitFor(async () => await client.getPrunedHeight(), height, 115 * 1000);
   const currentHeight = await client.getPrunedHeight();
@@ -996,7 +1005,7 @@ Then(/node (.*) is in state (.*)/, async function (node, state) {
 
 Then(
   /(.*) does not have a new software update/,
-  { timeout: 1200 * 1000 },
+  { timeout: 65 * 1000 },
   async function (name) {
     let client = await this.getNodeOrWalletClient(name);
     await sleep(5000);
@@ -1014,7 +1023,7 @@ Then(
 
 Then(
   /(.+) has a new software update/,
-  { timeout: 1200 * 1000 },
+  { timeout: 65 * 1000 },
   async function (name) {
     let client = await this.getNodeOrWalletClient(name);
     await waitFor(
@@ -1178,7 +1187,9 @@ When(/I spend outputs (.*) via (.*)/, async function (inputs, node) {
   expect(this.lastResult.result).to.equal("ACCEPTED");
 });
 
-Then(/(.*) has (.*) in (.*) state/, async function (node, txn, pool) {
+Then(/(.*) has (.*) in (.*) state/,
+    { timeout: 120 * 1000 },
+  async function (node, txn, pool) {
   const client = this.getClient(node);
   const sig = this.transactions[txn].body.kernels[0].excess_sig;
   this.lastResult = await waitFor(
@@ -1188,8 +1199,7 @@ Then(/(.*) has (.*) in (.*) state/, async function (node, txn, pool) {
       return tx_result === pool;
     },
     true,
-    // TODO: Does it make sense to fix this timeout?
-    20 * 60 * 1000
+    115 * 1000
   );
   expect(this.lastResult).to.equal(true);
 });
@@ -1206,7 +1216,7 @@ Then(
         await waitFor(
           async () => await client.transactionStateResult(sig),
           pool,
-          20 * 60 * 1000
+          115 * 1000
         );
         this.lastResult = await client.transactionState(sig);
         console.log(`Node ${name} response is: ${this.lastResult.result}`);
@@ -1273,6 +1283,7 @@ When(
 
 When(
   /I mine (\d+) custom weight blocks on (.*) with weight (\d+)/,
+  { timeout: 120 * 1000 },
   async function (numBlocks, name, weight) {
     const tipHeight = await this.getClient(name).getTipHeight();
     for (let i = 0; i < numBlocks; i++) {
@@ -1283,7 +1294,7 @@ When(
       expect(autoTransactionResult).to.equal(true);
       // If a block cannot be mined quickly enough (or the process has frozen), timeout.
       await withTimeout(
-        2 * 60 * 1000,
+        115 * 1000,
         this.mineBlock(name, parseInt(weight), (candidate) => {
           this.addTransactionOutput(
             tipHeight + i + 1 + 2,
@@ -1358,7 +1369,7 @@ When(
 
 When(
   /I mine (\d+) blocks using wallet (.*) on (.*)/,
-  { timeout: 600 * 1000 },
+  { timeout: 120 * 1000 },
   async function (numBlocks, walletName, nodeName) {
     const nodeClient = this.getClient(nodeName);
     const walletClient = await this.getWallet(walletName).connectClient();
@@ -1583,7 +1594,7 @@ Then(
     await waitFor(
       async () => walletClient.isBalanceAtLeast(amount),
       true,
-      700 * 1000,
+      115 * 1000,
       5 * 1000,
       5
     );
@@ -1608,7 +1619,7 @@ Then(
     await waitFor(
       async () => walletClient.isBalanceLessThan(amount),
       true,
-      700 * 1000,
+      115 * 1000,
       5 * 1000,
       5
     );
@@ -1622,6 +1633,7 @@ Then(
 
 Then(
   /wallet (.*) and wallet (.*) have the same balance/,
+  { timeout: 120 * 1000 },
   async function (walletNameA, walletNameB) {
     const walletClientA = await this.getWallet(walletNameA).connectClient();
     var balanceA = await walletClientA.getBalance();
@@ -1789,7 +1801,7 @@ When(
 
 When(
   /I send(.*) uT without waiting for broadcast from wallet (.*) to wallet (.*) at fee (.*)/,
-  { timeout: 120 * 1000 },
+  { timeout: 20 * 1000 },
   async function (tariAmount, source, dest, feePerGram) {
     const sourceWallet = this.getWallet(source);
     const sourceClient = await sourceWallet.connectClient();
@@ -2023,7 +2035,7 @@ When(
 
 When(
   /I transfer (.*) uT to self from wallet (.*) at fee (.*)/,
-  { timeout: 30 * 1000 },
+  { timeout: 120 * 1000 },
   async function (tariAmount, source, feePerGram) {
     const sourceClient = await this.getWallet(source).connectClient();
     const sourceInfo = await sourceClient.identify();
@@ -2067,6 +2079,7 @@ When(
 
 When(
   /I transfer (.*) uT from (.*) to ([A-Za-z0-9,]+) at fee (.*)/,
+  { timeout: 120 * 1000 },
   async function (amount, source, dests, feePerGram) {
     const wallet = this.getWallet(source);
     const client = await wallet.connectClient();
@@ -2105,7 +2118,7 @@ When(
 
 When(
   /I send a one-sided transaction of (.*) uT from (.*) to (.*) at fee (.*)/,
-  { timeout: 30 * 1000 },
+  { timeout: 65 * 1000 },
   async function (amount, source, dest, feePerGram) {
     const sourceWallet = this.getWallet(source);
     const sourceClient = await sourceWallet.connectClient();
@@ -2148,7 +2161,7 @@ When(
 
 When(
   /I cancel last transaction in wallet (.*)/,
-  { timeout: 25 * 5 * 1000 },
+  { timeout: 20 * 1000 },
   async function (walletName) {
     const wallet = this.getWallet(walletName);
     const walletClient = await wallet.connectClient();
@@ -2459,7 +2472,7 @@ Then(
 
 Then(
   /wallet (.*) detects all transactions are at least Broadcast/,
-  { timeout: 150 * 1000 },
+  { timeout: 1200 * 1000 },
   async function (walletName) {
     // Pending -> Completed -> Broadcast -> Mined Unconfirmed -> Mined Confirmed
     const wallet = this.getWallet(walletName);
@@ -2784,7 +2797,7 @@ Then(
       await waitFor(
         async () => walletClient.isTransactionMinedConfirmed(txIds[i]),
         true,
-        600 * 1000,
+        115 * 1000,
         5 * 1000,
         5
       );
@@ -2797,6 +2810,7 @@ Then(
 
 Then(
   /while mining via node (.*) all transactions in wallet (.*) are found to be Mined_Confirmed/,
+  { timeout: 1200 * 1000 },
   async function (nodeName, walletName) {
     const wallet = this.getWallet(walletName);
     const walletClient = await wallet.connectClient();
@@ -2855,7 +2869,7 @@ Then(
 
 Then(
   /while mining via SHA3 miner (.*) all transactions in wallet (.*) are found to be Mined_Confirmed/,
-  { timeout: 120 * 1000 },
+  { timeout: 1200 * 1000 },
   async function (miner, walletName) {
     const wallet = this.getWallet(walletName);
     const walletClient = await wallet.connectClient();
@@ -3006,8 +3020,26 @@ Then(
     );
     const transactions =
       await walletClient.getAllSpendableCoinbaseTransactions();
-    expect(transactions.length >= count).to.equal(true);
+    expect(parseInt(transactions.length) >= parseInt(count)).to.equal(true);
   }
+);
+
+Then(
+    /wallet (.*) detects exactly (.*) coinbase transactions as Mined_Confirmed/,
+    { timeout: 120 * 1000 },
+    async function (walletName, count) {
+        const walletClient = await this.getWallet(walletName).connectClient();
+        await waitFor(
+            async () => walletClient.areCoinbasesConfirmedAtLeast(count),
+            true,
+            110 * 1000,
+            5 * 1000,
+            5
+        );
+        const transactions =
+            await walletClient.getAllSpendableCoinbaseTransactions();
+        expect(parseInt(transactions.length) === parseInt(count)).to.equal(true);
+    }
 );
 
 Then(
@@ -3205,7 +3237,7 @@ Then("difficulties are available", function () {
 
 When(
   /I coin split tari in wallet (.*) to produce (.*) UTXOs of (.*) uT each with fee_per_gram (.*) uT/,
-  { timeout: 300 * 1000 },
+  { timeout: 4800 * 1000 },
   async function (walletName, splitNum, splitValue, feePerGram) {
     console.log("\n");
     const numberOfSplits = Math.ceil(splitNum / 499);
@@ -3276,7 +3308,7 @@ When(
 
 When(
   /I send (.*) transactions of (.*) uT each from wallet (.*) to wallet (.*) at fee_per_gram (.*)/,
-  { timeout: 60 * 1000 },
+  { timeout: 120 * 1000 },
   async function (
     numTransactions,
     amount,
@@ -3375,6 +3407,7 @@ Then(
 
 When(
   /I wait for (.*) to connect to (.*)/,
+  { timeout: 60 * 1000 },
   async function (firstNode, secondNode) {
     const firstNodeClient = await this.getNodeOrWalletClient(firstNode);
     const secondNodeClient = await this.getNodeOrWalletClient(secondNode);
@@ -3397,6 +3430,7 @@ Then(/(.*) is connected to (.*)/, async function (firstNode, secondNode) {
 
 When(
   /I wait for (.*) to have (.*) connectivity/,
+  { timeout: 60 * 1000 },
   async function (nodeName, expectedStatus) {
     const node = await this.getNodeOrWalletClient(nodeName);
     const expected = ConnectivityStatus[expectedStatus.toUpperCase()];
@@ -3413,6 +3447,7 @@ When(
 
 When(
   /I wait for (.*) to have (\d+) node connections/,
+  { timeout: 60 * 1000 },
   async function (nodeName, numConnections) {
     const node = await this.getNodeOrWalletClient(nodeName);
     numConnections = +numConnections;
@@ -3561,7 +3596,7 @@ When(
 
 When(
   "I run whois {word} on wallet {word} via command line",
-  { timeout: 30 * 1000 },
+  { timeout: 20 * 1000 },
   async function (who, name) {
     await sleep(5000);
     let wallet = this.getWallet(name);
@@ -3619,6 +3654,7 @@ When(
 
 Then(
   /I wait until base node (.*) has (.*) unconfirmed transactions in its mempool/,
+  { timeout: 120 * 1000 },
   async function (baseNode, numTransactions) {
     const client = this.getClient(baseNode);
     await waitFor(
@@ -3627,7 +3663,7 @@ Then(
         return stats.unconfirmed_txs;
       },
       numTransactions,
-      120 * 1000
+      115 * 1000
     );
 
     let stats = await client.getMempoolStats();
@@ -3680,7 +3716,7 @@ Then(
 
 When(
   "I have {int} base nodes with pruning horizon {int} force syncing on node {word}",
-  { timeout: 30 * 1000 },
+  { timeout: 20 * 1000 },
   async function (nodes_count, horizon, force_sync_to) {
     const promises = [];
     const force_sync_address = this.getNode(force_sync_to).peerAddress();

--- a/integration_tests/features/support/steps.js
+++ b/integration_tests/features/support/steps.js
@@ -115,7 +115,7 @@ Given(
 
 Given(
   /I have a wallet (.*) with auto update enabled/,
-  { timeout: 20 * 1000 },
+  { timeout: 30 * 1000 },
   async function (name) {
     await this.createAndAddWallet(name, "", {
       common: {
@@ -133,7 +133,7 @@ Given(
 
 Given(
   /I have a wallet (.*) with auto update configured with a bad signature/,
-  { timeout: 20 * 1000 },
+  { timeout: 30 * 1000 },
   async function (name) {
     await this.createAndAddWallet(name, "", {
       common: {
@@ -151,7 +151,7 @@ Given(
 
 Given(
   /I have a base node (.*) connected to node (.*)/,
-  { timeout: 10 * 1000 },
+  { timeout: 30 * 1000 },
   async function (name, node) {
     await this.createAndAddNode(name, this.nodes[node].peerAddress());
   }
@@ -159,7 +159,7 @@ Given(
 
 Given(
   /I have a base node (\S+)$/,
-  { timeout: 10 * 1000 },
+  { timeout: 20 * 1000 },
   async function (name) {
     await this.createAndAddNode(name);
   }
@@ -167,7 +167,7 @@ Given(
 
 Given(
   /I have a SHA3 miner (.*) connected to seed node (.*)/,
-  { timeout: 10 * 1000 },
+  { timeout: 30 * 1000 },
   async function (name, seed) {
     // add the base_node
     await this.createAndAddNode(name, this.seeds[seed].peerAddress(), this);
@@ -191,7 +191,7 @@ Given(
 
 Given(
   /I have a SHA3 miner (.*) connected to node (.*)/,
-  { timeout: 10 * 1000 },
+  { timeout: 30 * 1000 },
   async function (name, basenode) {
     // add the base_node
     await this.createAndAddNode(name, this.nodes[basenode].peerAddress(), this);
@@ -215,7 +215,7 @@ Given(
 
 Given(
   /I have a SHA3 miner (.*) connected to all seed nodes/,
-  { timeout: 10 * 1000 },
+  { timeout: 30 * 1000 },
   async function (name) {
     // add the base_node
     await this.createAndAddNode(name, this.seedAddresses(), this);
@@ -266,7 +266,7 @@ Given(
 
 Given(
   /I have a pruned node (.*) connected to node (.*) with pruning horizon set to (.*)/,
-  { timeout: 20 * 1000 },
+  { timeout: 30 * 1000 },
   async function (name, connected_to, horizon) {
     const node = this.createNode(name, { pruningHorizon: horizon });
     node.setPeerSeeds([this.nodes[connected_to].peerAddress()]);
@@ -277,7 +277,7 @@ Given(
 
 Given(
   /I have a lagging delayed node (.*) connected to node (.*) with blocks_behind_before_considered_lagging (\d+)/,
-  { timeout: 20 * 1000 },
+  { timeout: 30 * 1000 },
   async function (name, node, delay) {
     const miner = this.createNode(name, {
       blocks_behind_before_considered_lagging: delay,
@@ -300,7 +300,7 @@ Given(
 
 Given(
   "I have {int} base nodes connected to all seed nodes",
-  { timeout: 20 * 1000 },
+  { timeout: 120 * 1000 },
   async function (n) {
     const promises = [];
     for (let i = 0; i < n; i++) {
@@ -334,7 +334,7 @@ Given(
 
 Given(
   /I have stress-test wallet (.*) connected to all the seed nodes with broadcast monitoring timeout (.*)/,
-  { timeout: 20 * 1000 },
+  { timeout: 30 * 1000 },
   async function (name, timeout) {
     const wallet = new WalletProcess(
       name,
@@ -377,7 +377,7 @@ Given(/I have wallet (.*) connected to all seed nodes/, async function (name) {
 
 Given(
   /I have non-default wallet (.*) connected to all seed nodes using (.*)/,
-  { timeout: 20 * 1000 },
+  { timeout: 30 * 1000 },
   async function (name, mechanism) {
     // mechanism: DirectOnly, StoreAndForwardOnly, DirectAndStoreAndForward
     const wallet = new WalletProcess(
@@ -416,6 +416,7 @@ Given(
 
 Given(
   /I recover wallet (.*) into wallet (.*) connected to all seed nodes/,
+  { timeout: 30 * 1000 },
   async function (walletNameA, walletNameB) {
     const seedWords = this.getWallet(walletNameA).getSeedWords();
     console.log(
@@ -799,7 +800,7 @@ Then("Proxy response for block header by hash is valid", function () {
   assert(lastResult.result.status, "OK");
 });
 
-When(/I start base node (.*)/, { timeout: 6 * 1000 }, async function (name) {
+When(/I start base node (.*)/, { timeout: 30 * 1000 }, async function (name) {
   await this.startNode(name);
 });
 
@@ -817,7 +818,7 @@ When(/I stop node (.*)/, async function (name) {
 
 Then(
   /node (.*) is at height (\d+)/,
-  { timeout: 15 * 1000 },
+  { timeout: 120 * 1000 },
   async function (name, height) {
     const client = this.getClient(name);
     const currentHeight = await waitForIterate(
@@ -849,7 +850,7 @@ Then(/node (.*) has a pruned height of (\d+)/, async function (name, height) {
 
 Then(
   /node (.*) is at the same height as node (.*)/,
-  { timeout: 20 * 1000 },
+  { timeout: 120 * 1000 },
   async function (nodeA, nodeB) {
     var expectedHeight, currentHeight;
     expectedHeight = parseInt(await this.getClient(nodeB).getTipHeight());
@@ -876,7 +877,7 @@ Then(
 
 Then(
   "all nodes are on the same chain at height {int}",
-  { timeout: 15 * 1000 },
+  { timeout: 120 * 1000 },
   async function (height) {
     let tipHash = null;
     await this.forEachClientAsync(async (client, name) => {
@@ -1197,6 +1198,7 @@ Then(/(.*) has (.*) in (.*) state/, async function (node, txn, pool) {
 // It's means at least 16 have to succeed.
 Then(
   /(.*) is in the (.*) of all nodes(, where (\d+)% can fail)?/,
+    { timeout: 120 * 1000 },
   async function (txn, pool, canFail) {
     const sig = this.transactions[txn].body.kernels[0].excess_sig;
     await this.forEachClientAsync(
@@ -1296,7 +1298,7 @@ When(
 
 When(
   /mining node (.*) mines (\d+) blocks with min difficulty (\d+) and max difficulty (\d+)/,
-  { timeout: 80 * 1000 },
+  { timeout: 120 * 1000 },
   async function (miner, numBlocks, min, max) {
     const miningNode = this.getMiningNode(miner);
     await miningNode.init(
@@ -1313,7 +1315,7 @@ When(
 
 When(
   /mining node (.*) mines (\d+) blocks$/,
-  { timeout: 20 * 1000 },
+  { timeout: 120 * 1000 },
   async function (miner, numBlocks) {
     const miningNode = this.getMiningNode(miner);
     // Don't wait for sync before mining
@@ -1331,7 +1333,7 @@ When(
 
 When(
   /I mine (\d+) blocks on (.*)/,
-  { timeout: 40 * 1000 },
+  { timeout: 120 * 1000 },
   async function (numBlocks, name) {
     const tipHeight = await this.getClient(name).getTipHeight();
     for (let i = 0; i < numBlocks; i++) {
@@ -1372,11 +1374,15 @@ When(
   }
 );
 
-When(/I merge mine (.*) blocks via (.*)/, async function (numBlocks, mmProxy) {
-  for (let i = 0; i < numBlocks; i++) {
-    await this.mergeMineBlock(mmProxy);
+When(
+  /I merge mine (.*) blocks via (.*)/,
+  { timeout: 120 * 1000 },
+  async function (numBlocks, mmProxy) {
+    for (let i = 0; i < numBlocks; i++) {
+      await this.mergeMineBlock(mmProxy);
+    }
   }
-});
+);
 
 // TODO: This step is still really flaky, rather use the co-mine with mining node step:
 //       Error: 13 INTERNAL:
@@ -1384,7 +1390,7 @@ When(/I merge mine (.*) blocks via (.*)/, async function (numBlocks, mmProxy) {
 //          header_hash:55545... in the database'
 When(
   /I co-mine (.*) blocks via merge mining proxy (.*) and base node (.*) with wallet (.*)/,
-  { timeout: 20 * 1000 },
+  { timeout: 120 * 1000 },
   async function (numBlocks, mmProxy, node, wallet) {
     let tipHeight = await this.getClient(node).getTipHeight();
     this.lastResult = tipHeight;
@@ -1566,7 +1572,7 @@ When("I print the world", function () {
 
 Then(
   /I wait for wallet (.*) to have at least (.*) uT/,
-  { timeout: 40 * 1000 },
+  { timeout: 120 * 1000 },
   async function (wallet, amount) {
     const walletClient = await this.getWallet(wallet).connectClient();
     console.log("\n");
@@ -1591,7 +1597,7 @@ Then(
 
 Then(
   /I wait for wallet (.*) to have less than (.*) uT/,
-  { timeout: 6 * 1000 },
+  { timeout: 120 * 1000 },
   async function (wallet, amount) {
     let walletClient = await this.getWallet(wallet).connectClient();
     console.log("\n");
@@ -1732,7 +1738,7 @@ async function send_tari(
 
 When(
   /I send (.*) uT from wallet (.*) to wallet (.*) at fee (.*)/,
-  { timeout: 60 * 1000 },
+  { timeout: 120 * 1000 },
   async function (tariAmount, source, dest, feePerGram) {
     const sourceWallet = this.getWallet(source);
     const sourceClient = await sourceWallet.connectClient();
@@ -1783,7 +1789,7 @@ When(
 
 When(
   /I send(.*) uT without waiting for broadcast from wallet (.*) to wallet (.*) at fee (.*)/,
-  { timeout: 40 * 1000 },
+  { timeout: 120 * 1000 },
   async function (tariAmount, source, dest, feePerGram) {
     const sourceWallet = this.getWallet(source);
     const sourceClient = await sourceWallet.connectClient();
@@ -1819,7 +1825,7 @@ When(
 
 When(
   /I multi-send (.*) transactions of (.*) uT from wallet (.*) to wallet (.*) at fee (.*)/,
-  { timeout: 10 * 1000 },
+  { timeout: 120 * 1000 },
   async function (number, tariAmount, source, dest, fee) {
     console.log("\n");
     const sourceClient = await this.getWallet(source).connectClient();
@@ -2017,7 +2023,7 @@ When(
 
 When(
   /I transfer (.*) uT to self from wallet (.*) at fee (.*)/,
-  { timeout: 7 * 1000 },
+  { timeout: 30 * 1000 },
   async function (tariAmount, source, feePerGram) {
     const sourceClient = await this.getWallet(source).connectClient();
     const sourceInfo = await sourceClient.identify();
@@ -2099,7 +2105,7 @@ When(
 
 When(
   /I send a one-sided transaction of (.*) uT from (.*) to (.*) at fee (.*)/,
-  { timeout: 8 * 1000 },
+  { timeout: 30 * 1000 },
   async function (amount, source, dest, feePerGram) {
     const sourceWallet = this.getWallet(source);
     const sourceClient = await sourceWallet.connectClient();
@@ -2173,6 +2179,7 @@ When(/I wait (.*) seconds/, { timeout: 600 * 1000 }, async function (int) {
 
 Then(
   /Batch transfer of (.*) transactions was a success from (.*) to ([A-Za-z0-9,]+)/,
+  { timeout: 30 * 1000 },
   async function (txCount, walletListStr) {
     const clients = await Promise.all(
       walletListStr.split(",").map((s) => {
@@ -2743,7 +2750,7 @@ Then(
 
 Then(
   /wallet (.*) detects all transactions as Mined_Confirmed/,
-  { timeout: 30 * 1000 },
+  { timeout: 120 * 1000 },
   async function (walletName) {
     // Pending -> Completed -> Broadcast -> Mined Unconfirmed -> Mined Confirmed
     const wallet = this.getWallet(walletName);
@@ -2848,7 +2855,7 @@ Then(
 
 Then(
   /while mining via SHA3 miner (.*) all transactions in wallet (.*) are found to be Mined_Confirmed/,
-  { timeout: 30 * 1000 },
+  { timeout: 120 * 1000 },
   async function (miner, walletName) {
     const wallet = this.getWallet(walletName);
     const walletClient = await wallet.connectClient();
@@ -2903,7 +2910,7 @@ Then(
 
 Then(
   /all wallets detect all transactions as Mined_Confirmed/,
-  { timeout: 40 * 1000 },
+  { timeout: 1200 * 1000 },
   async function () {
     // Pending -> Completed -> Broadcast -> Mined Unconfirmed -> Mined Confirmed
     for (const walletName in this.wallets) {
@@ -2987,13 +2994,13 @@ Then(
 
 Then(
   /wallet (.*) detects at least (.*) coinbase transactions as Mined_Confirmed/,
-  { timeout: 34 * 1000 },
+  { timeout: 120 * 1000 },
   async function (walletName, count) {
     const walletClient = await this.getWallet(walletName).connectClient();
     await waitFor(
       async () => walletClient.areCoinbasesConfirmedAtLeast(count),
       true,
-      600 * 1000,
+      110 * 1000,
       5 * 1000,
       5
     );
@@ -3198,7 +3205,7 @@ Then("difficulties are available", function () {
 
 When(
   /I coin split tari in wallet (.*) to produce (.*) UTXOs of (.*) uT each with fee_per_gram (.*) uT/,
-  { timeout: 7 * 1000 },
+  { timeout: 300 * 1000 },
   async function (walletName, splitNum, splitValue, feePerGram) {
     console.log("\n");
     const numberOfSplits = Math.ceil(splitNum / 499);
@@ -3269,7 +3276,7 @@ When(
 
 When(
   /I send (.*) transactions of (.*) uT each from wallet (.*) to wallet (.*) at fee_per_gram (.*)/,
-  { timeout: 7 * 1000 },
+  { timeout: 60 * 1000 },
   async function (
     numTransactions,
     amount,
@@ -3554,7 +3561,7 @@ When(
 
 When(
   "I run whois {word} on wallet {word} via command line",
-  { timeout: 6 * 1000 },
+  { timeout: 30 * 1000 },
   async function (who, name) {
     await sleep(5000);
     let wallet = this.getWallet(name);
@@ -3673,7 +3680,7 @@ Then(
 
 When(
   "I have {int} base nodes with pruning horizon {int} force syncing on node {word}",
-  { timeout: 7 * 1000 },
+  { timeout: 30 * 1000 },
   async function (nodes_count, horizon, force_sync_to) {
     const promises = [];
     const force_sync_address = this.getNode(force_sync_to).peerAddress();

--- a/integration_tests/features/support/world.js
+++ b/integration_tests/features/support/world.js
@@ -341,11 +341,13 @@ class CustomWorld {
   async stopNode(name) {
     const node = this.seeds[name] || this.nodes[name];
     await node.stop();
+    console.log("\n", name, "stopped\n")
   }
 
   async startNode(name, args) {
     const node = this.seeds[name] || this.nodes[name];
     await node.start(args);
+    console.log("\n", name, "started\n")
   }
 
   addTransaction(pubKey, txId) {


### PR DESCRIPTION

Description
---
Re-applied reasonable time outs to cucumber tests. It is not worthwhile
to have too stringent time outs as it makes the tests flaky on a slower
system and especially on CI.

Motivation and Context
---
Tests were flaky on slow and fast computers due to stringent time outs.

How Has This Been Tested?
---
Cucumber on slow and fast computers
