### PR TITLE
chore: update toolchain to nightly-2021-09-18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 defaults:
-  rust_image: &rust_image quay.io/tarilabs/rust_tari-build-with-deps:nightly-2021-08-18
+  rust_image: &rust_image quay.io/tarilabs/rust_tari-build-with-deps:nightly-2021-09-18
 
 commands:
   test:
@@ -76,13 +76,13 @@ commands:
       - run:
           name: Cargo fmt
           command: |
-            TOOLCHAIN=$(cat rust-toolchain)
+            TOOLCHAIN=$(awk '/channel = /{print $NF}' rust-toolchain.toml)
             rustup component add --toolchain $TOOLCHAIN rustfmt
             cargo fmt --all -- --check
       - run:
           name: Run clippy (main source)
           command: |
-            TOOLCHAIN=$(cat rust-toolchain)
+            TOOLCHAIN=$(awk '/channel = /{print $NF}' rust-toolchain.toml)
             rustup component add --toolchain $TOOLCHAIN clippy
             cargo clippy -- -D warnings -W clippy::cognitive_complexity
       - run:

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -7,7 +7,7 @@ jobs:
   security_audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions-rs/audit-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/base_node_binaries.yml
+++ b/.github/workflows/base_node_binaries.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2021-08-18
+          toolchain: nightly-2021-09-18
           components: rustfmt
           override: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,11 @@ on:
     types: [opened, synchronize, reopened]
 
 name: CI
+
 env:
-  toolchain: nightly-2021-08-18
+  CARGO_HTTP_MULTIPLEXING: false
+  toolchain: nightly-2021-09-18
+
 jobs:
   clippy:
     name: clippy

--- a/.github/workflows/libwallet.yml
+++ b/.github/workflows/libwallet.yml
@@ -48,13 +48,13 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2021-08-18
+          toolchain: nightly-2021-09-18
           target: aarch64-apple-ios
           components: rustfmt
           override: true
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2021-08-18
+          toolchain: nightly-2021-09-18
           target: x86_64-apple-ios
           components: rustfmt
           override: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,9 +132,9 @@ checksum = "34fde25430d87a9388dadbe6e34d7f72a462c8b43ac8d309b42b0a8505d7e2a5"
 
 [[package]]
 name = "anyhow"
-version = "1.0.43"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28ae2b3dec75a406790005a200b1bd89785afc02517a00ca99ecfe093ee9e6cf"
+checksum = "61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1"
 
 [[package]]
 name = "arc-swap"
@@ -179,9 +179,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "648ed8c8d2ce5409ccd57453d9d1b214b342a0d69376a6feda1fd6cae3299308"
 dependencies = [
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "syn 1.0.75",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -190,9 +190,9 @@ version = "0.1.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44318e776df68115a881de9a8fd1b9e53368d7a4a5ce4cc48517da3393233a5e"
 dependencies = [
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "syn 1.0.75",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -220,9 +220,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "base58-monero"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465ba1f408efdef4d9379bdfa7340899b63e472d50c7fb666480ccfd5a893e53"
+checksum = "1df741a56140a4d26932fde3bd69ce8abec7f50d238f8c16351caa789a6d8fe9"
 dependencies = [
  "thiserror",
 ]
@@ -293,8 +293,8 @@ dependencies = [
  "lazycell",
  "log 0.4.14",
  "peeking_take_while",
- "proc-macro2 1.0.28",
- "quote 1.0.9",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
  "regex",
  "rustc-hash",
  "shlex",
@@ -321,9 +321,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitstring"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e54f7b7a46d7b183eb41e2d82965261fa8a1597c68b50aced268ee1fc70272d"
+checksum = "22a39c0db600cfe77ef1b6d9ea71173bdccf190722877969d526d380519b6ecc"
 
 [[package]]
 name = "blake2"
@@ -390,9 +390,9 @@ checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
 name = "bstr"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90682c8d613ad3373e66de8c6411e0ae2ab2571e879d2efbf73558cc66f21279"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
 dependencies = [
  "lazy_static 1.4.0",
  "memchr",
@@ -418,9 +418,9 @@ checksum = "40e38929add23cdf8a366df9b0e088953150724bcbe5fc330b0d8eb3b328eec8"
 
 [[package]]
 name = "bumpalo"
-version = "3.7.0"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
+checksum = "8f1e260c3a9040a7c19a12468758f4c16f31a81a1fe087482be9570ec864bb6c"
 
 [[package]]
 name = "bytemuck"
@@ -497,20 +497,20 @@ dependencies = [
  "heck",
  "indexmap",
  "log 0.4.14",
- "proc-macro2 1.0.28",
- "quote 1.0.9",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
  "serde 1.0.130",
  "serde_json",
- "syn 1.0.75",
+ "syn 1.0.81",
  "tempfile",
  "toml 0.5.8",
 ]
 
 [[package]]
 name = "cc"
-version = "1.0.69"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e70cc2f62c6ce1868963827bd677764c62d07c3d9a3e1fb1177ee1a9ab199eb2"
+checksum = "79c2681d6594606957bbb8631c4b90a7fcaaa72cdb714743a437b156d6a7eedd"
 
 [[package]]
 name = "cexpr"
@@ -634,9 +634,9 @@ checksum = "b0fc239e0f6cb375d2402d48afb92f76f5404fd1df208a41930ec81eda078bea"
 
 [[package]]
 name = "clang-sys"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cf2cc85830eae84823884db23c5306442a6c3d5bfd3beb2f2a2c829faa1816"
+checksum = "10612c0ec0e0a1ff0e97980647cb058a6e7aedb913d01d009c406b8b7d0b26ee"
 dependencies = [
  "glob",
  "libc",
@@ -669,9 +669,9 @@ dependencies = [
 
 [[package]]
 name = "clipboard-win"
-version = "4.2.1"
+version = "4.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4ea1881992efc993e4dc50a324cdbd03216e41bdc8385720ff47efc9bd2ca8"
+checksum = "3db8340083d28acb43451166543b98c838299b7e0863621be53a338adceea0ed"
 dependencies = [
  "error-code",
  "str-buf",
@@ -717,9 +717,9 @@ checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "core-foundation"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a89e2ae426ea83155dccf10c0fa6b1463ef6d5fcb44cee0b224a408fa640a62"
+checksum = "6888e10551bb93e424d8df1d07f1a8b4fceb0001a3a4b048bfc47554946f47b3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -727,9 +727,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cpufeatures"
@@ -991,9 +991,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.45+curl-7.78.0"
+version = "0.4.49+curl-7.79.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de9e5a72b1c744eb5dd20b2be4d7eb84625070bb5c4ab9b347b70464ab1e62eb"
+checksum = "e0f44960aea24a786a46907b8824ebc0e66ca06bf4e4978408c7499620343483"
 dependencies = [
  "cc",
  "libc",
@@ -1020,9 +1020,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek-ng"
-version = "4.1.0"
+version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2d05dbe571a5f832174d536b65101025c33693189830372032c005af68cbaec"
+checksum = "1c359b7249347e46fb28804470d071c921156ad62b3eef5d34e2ba867533dec8"
 dependencies = [
  "byteorder",
  "digest",
@@ -1051,10 +1051,10 @@ checksum = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.28",
- "quote 1.0.9",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
  "strsim 0.9.3",
- "syn 1.0.75",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -1064,8 +1064,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
 dependencies = [
  "darling_core",
- "quote 1.0.9",
- "syn 1.0.75",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -1076,9 +1076,9 @@ checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
 
 [[package]]
 name = "decimal-rs"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628081e4b054b20bc00989885feca733c66f19d0e983bb4a3b81b6edcd0b70bc"
+checksum = "783393e45feb78bb74819e3df984929325cba6c517d7de56f1f2303d8fcacd04"
 dependencies = [
  "ethnum",
  "fast-float",
@@ -1092,9 +1092,9 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "syn 1.0.75",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -1116,9 +1116,9 @@ checksum = "a2658621297f2cf68762a6f7dc0bb7e1ff2cfd6583daef8ee0fed6f7ec468ec0"
 dependencies = [
  "darling",
  "derive_builder_core",
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "syn 1.0.75",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -1128,9 +1128,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2791ea3e372c8495c0bc2033991d76b512cd799d07491fbd6890124db9458bef"
 dependencies = [
  "darling",
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "syn 1.0.75",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -1140,10 +1140,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40eebddd2156ce1bb37b20bbe5151340a31828b1f2d22ba4141f3531710e38df"
 dependencies = [
  "convert_case",
- "proc-macro2 1.0.28",
- "quote 1.0.9",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
  "rustc_version 0.3.3",
- "syn 1.0.75",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -1159,9 +1159,9 @@ dependencies = [
 
 [[package]]
 name = "diesel"
-version = "1.4.7"
+version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bba51ca66f57261fd17cadf8b73e4775cc307d0521d855de3f5de91a8f074e0e"
+checksum = "b28135ecf6b7d446b43e27e225622a038cc4e2930a1022f51cdb97ada19b8e4d"
 dependencies = [
  "bigdecimal",
  "byteorder",
@@ -1180,9 +1180,9 @@ version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45f5098f628d02a7a0f68ddba586fb61e80edec3bdc1be3b921f4ceec60858d3"
 dependencies = [
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "syn 1.0.75",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -1272,9 +1272,9 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.28"
+version = "0.8.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80df024fbc5ac80f87dfef0d9f5209a252f2a497f7f42944cff24d8253cac065"
+checksum = "a74ea89a0a1b98f6332de42c95baff457ada66d1cb4030f9ff151b2041a1c746"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -1292,9 +1292,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c5f0096a91d210159eceb2ff5e1c4da18388a170e1e3ce948aac9c8fdbbf595"
 dependencies = [
  "heck",
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "syn 1.0.75",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -1389,9 +1389,9 @@ checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
 name = "flate2"
-version = "1.0.20"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd3aec53de10fe96d7d8c565eb17f2c687bb5518a2ec453b5b1252964526abe0"
+checksum = "1e6988e897c1c9c485f43b47a529cef42fde0547f9d8d41a7062518f1d8fc53f"
 dependencies = [
  "cfg-if 1.0.0",
  "crc32fast",
@@ -1455,9 +1455,9 @@ checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
 
 [[package]]
 name = "futures"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1adc00f486adfc9ce99f77d717836f0c5aa84965eb0b4f051f4e83f7cab53f8b"
+checksum = "a12aa0eb539080d55c3f2d45a67c3b58b6b0773c1a3ca2dfec66d58c97fd66ca"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1470,9 +1470,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74ed2411805f6e4e3d9bc904c95d5d423b89b3b25dc0250aa74729de20629ff9"
+checksum = "5da6ba8c3bb3c165d3c7319fc1cc8304facf1fb8db99c5de877183c08a273888"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1490,9 +1490,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af51b1b4a7fdff033703db39de8802c673eb91855f2e0d47dcf3bf2c0ef01f99"
+checksum = "88d1c26957f23603395cd326b0ffe64124b818f4449552f960d815cfba83a53d"
 
 [[package]]
 name = "futures-core-preview"
@@ -1502,9 +1502,9 @@ checksum = "b35b6263fb1ef523c3056565fa67b1d16f0a8604ff12b11b08c25f28a734c60a"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d0d535a57b87e1ae31437b892713aee90cd2d7b0ee48727cd11fc72ef54761c"
+checksum = "45025be030969d763025784f7f355043dc6bc74093e4ecc5000ca4dc50d8745c"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1524,9 +1524,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b0e06c393068f3a6ef246c75cdca793d6a46347e75286933e5e75fd2fd11582"
+checksum = "522de2a0fe3e380f1bc577ba0474108faf3f6b18321dbf60b3b9c39a75073377"
 
 [[package]]
 name = "futures-io-preview"
@@ -1536,15 +1536,15 @@ checksum = "f4914ae450db1921a56c91bde97a27846287d062087d4a652efc09bb3a01ebda"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54913bae956fb8df7f4dc6fc90362aa72e69148e3f39041fbe8742d21e0ac57"
+checksum = "18e4a4b95cea4b4ccbcf1c5675ca7c4ee4e9e75eb79944d07defde18068f79bb"
 dependencies = [
  "autocfg 1.0.1",
  "proc-macro-hack",
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "syn 1.0.75",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -1563,9 +1563,9 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f30aaa67363d119812743aa5f33c201a7a66329f97d1a887022971feea4b53"
+checksum = "36ea153c13024fe480590b3e3d4cad89a0cfacecc24577b68f86c6ced9c2bc11"
 
 [[package]]
 name = "futures-sink-preview"
@@ -1575,15 +1575,15 @@ checksum = "86f148ef6b69f75bb610d4f9a2336d4fc88c4b5b67129d1a340dd0fd362efeec"
 
 [[package]]
 name = "futures-task"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe54a98670017f3be909561f6ad13e810d9a51f3f061b902062ca3da80799f2"
+checksum = "1d3d00f4eddb73e498a54394f228cd55853bdf059259e8e7bc6e69d408892e99"
 
 [[package]]
 name = "futures-test"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a5ac667be097531d74ff9fff9c9da7820dd63afd2312bb9c6f589211ae32080"
+checksum = "46b9f6d284a9595a613f881a7b08d46abaab1005995e6fe3ccfe2398f6aea492"
 dependencies = [
  "futures-core",
  "futures-executor",
@@ -1608,9 +1608,9 @@ dependencies = [
 
 [[package]]
 name = "futures-util"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eb846bfd58e44a8481a00049e82c43e0ccb5d61f8dc071057cb19249dd4d78"
+checksum = "36568465210a3a6ee45e1f165136d68671471a501e632e9a98d96872222b5481"
 dependencies = [
  "autocfg 1.0.1",
  "futures 0.1.31",
@@ -1746,9 +1746,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "h2"
-version = "0.3.4"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7f3675cfef6a30c8031cf9e6493ebdc3bb3272a3fea3923c4210d1830e6a472"
+checksum = "7fd819562fcebdac5afc5c113c3ec36f902840b70fd4fc458799c8ce4607ae55"
 dependencies = [
  "bytes 1.1.0",
  "fnv",
@@ -1758,7 +1758,7 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio 1.11.0",
+ "tokio 1.13.0",
  "tokio-util",
  "tracing",
 ]
@@ -1815,9 +1815,9 @@ checksum = "21e4590e13640f19f249fe3e4eca5113bc4289f2497710378190e7f4bd96f45b"
 
 [[package]]
 name = "http"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527e8c9ac747e28542699a951517aa9a6945af506cd1f2e1b53a576c17b6cc11"
+checksum = "1323096b05d41827dadeaee54c9981958c0f94e670bc94ed80037d1a7b8b186b"
 dependencies = [
  "bytes 1.1.0",
  "fnv",
@@ -1826,9 +1826,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "399c583b2979440c60be0821a6199eca73bc3c8dcd9d070d75ac726e2c6186e5"
+checksum = "1ff4f84919677303da5f147645dbea6b1881f368d03ac84e1dc09031ebd7b2c6"
 dependencies = [
  "bytes 1.1.0",
  "http",
@@ -1883,9 +1883,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.12"
+version = "0.14.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13f67199e765030fa08fe0bd581af683f0d5bc04ea09c2b1102012c5fb90e7fd"
+checksum = "2b91bb1f221b6ea1f1e4371216b70f40748774c2fb5971b450c07773fb92d26b"
 dependencies = [
  "bytes 1.1.0",
  "futures-channel",
@@ -1899,7 +1899,7 @@ dependencies = [
  "itoa",
  "pin-project-lite 0.2.7",
  "socket2",
- "tokio 1.11.0",
+ "tokio 1.13.0",
  "tower-service",
  "tracing",
  "want",
@@ -1911,9 +1911,9 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper 0.14.12",
+ "hyper 0.14.14",
  "pin-project-lite 0.2.7",
- "tokio 1.11.0",
+ "tokio 1.13.0",
  "tokio-io-timeout",
 ]
 
@@ -1924,9 +1924,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes 1.1.0",
- "hyper 0.14.12",
+ "hyper 0.14.14",
  "native-tls",
- "tokio 1.11.0",
+ "tokio 1.13.0",
  "tokio-native-tls",
 ]
 
@@ -1984,9 +1984,9 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.10"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee0328b1209d157ef001c94dd85b4f8f64139adb0eac2659f4b08382b2f474d"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -2035,9 +2035,9 @@ checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "js-sys"
-version = "0.3.53"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4bf49d50e2961077d9c99f4b7997d770a1114f087c3c2e0069b36c13fc2979d"
+checksum = "7cc9ffccd38c451a86bf13657df244e9c3f37493cce8e5e21e940963777acc84"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2099,9 +2099,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.101"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb00336871be5ed2c8ed44b60ae9959dc5b9f08539422ed43f09e34ecaeba21"
+checksum = "869d572136620d55835903746bcb5cdc54cb2851fd0aeec53220b4bb65ef3013"
 
 [[package]]
 name = "libgit2-sys"
@@ -2130,9 +2130,9 @@ dependencies = [
 
 [[package]]
 name = "libloading"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f84d96438c15fcd6c3f244c8fce01d1e2b9c6b5623e9c711dc9286d8fc92d6a"
+checksum = "c0cf036d15402bea3c5d4de17b3fce76b3e4a56ebc1f577be0e7a72f7c607cf0"
 dependencies = [
  "cfg-if 1.0.0",
  "winapi 0.3.9",
@@ -2163,9 +2163,9 @@ dependencies = [
 
 [[package]]
 name = "libssh2-sys"
-version = "0.2.21"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0186af0d8f171ae6b9c4c90ec51898bad5d08a2d5e470903a50d9ad8959cbee"
+checksum = "b094a36eb4b8b8c8a7b4b8ae43b2944502be3e59cd87687595cf6b0a71b3f4ca"
 dependencies = [
  "cc",
  "libc",
@@ -2377,9 +2377,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9753f12909fd8d923f75ae5c3258cae1ed3c8ec052e1b38c93c21a6d157f789c"
 dependencies = [
  "migrations_internals",
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "syn 1.0.75",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -2409,9 +2409,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c2bdb6314ec10835cd3293dd268473a835c02b7b352e788be788b3c6ca6bb16"
+checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
 dependencies = [
  "libc",
  "log 0.4.14",
@@ -2483,9 +2483,9 @@ checksum = "424f6e86263cd5294cbd7f1e95746b95aca0e0d66bff31e5a40d6baa87b4aa99"
 dependencies = [
  "proc-macro-crate",
  "proc-macro-error",
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "syn 1.0.75",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
  "synstructure",
 ]
 
@@ -2588,7 +2588,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b7a8e9be5e039e2ff869df49155f1c06bd01ade2117ec783e56ab0932b67a8f"
 dependencies = [
- "num-bigint 0.3.2",
+ "num-bigint 0.3.3",
  "num-complex",
  "num-integer",
  "num-iter",
@@ -2609,9 +2609,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d0a3d5e207573f948a9e5376662aa743a2ea13f7c50a554d7af443a73fbfeba"
+checksum = "5f6f7833f2cbf2360a6cfd58cd41a53aa7a90bd4c202f5b1c7dd2ed73c57b2c3"
 dependencies = [
  "autocfg 1.0.1",
  "num-integer",
@@ -2652,9 +2652,9 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "syn 1.0.75",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -2695,7 +2695,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
 dependencies = [
  "autocfg 1.0.1",
- "num-bigint 0.3.2",
+ "num-bigint 0.3.3",
  "num-integer",
  "num-traits 0.2.14",
 ]
@@ -2742,9 +2742,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.36"
+version = "0.10.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9facdb76fec0b73c406f125d44d86fdad818d66fef0531eec9233ca425ff4a"
+checksum = "2bc6b9e4403633698352880b22cbe2f0e45dd0177f6fabe4585536e56a3e4f75"
 dependencies = [
  "bitflags 1.3.2",
  "cfg-if 1.0.0",
@@ -2771,9 +2771,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.66"
+version = "0.9.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1996d2d305e561b70d1ee0c53f1542833f4e1ac6ce9a6708b6ff2738ca67dc82"
+checksum = "1c571f25d3f66dd427e417cebf73dbe2361d6125cf6e3a70d143fdf97c9f5150"
 dependencies = [
  "autocfg 1.0.1",
  "cc",
@@ -2791,14 +2791,14 @@ checksum = "e1cf9b1c4e9a6c4de793c632496fa490bdc0e1eea73f0c91394f7b6990935d22"
 dependencies = [
  "async-trait",
  "crossbeam-channel 0.5.1",
- "futures 0.3.16",
+ "futures 0.3.17",
  "js-sys",
  "lazy_static 1.4.0",
  "percent-encoding 2.1.0",
  "pin-project 1.0.8",
  "rand 0.8.4",
  "thiserror",
- "tokio 1.11.0",
+ "tokio 1.13.0",
  "tokio-stream",
 ]
 
@@ -2814,7 +2814,7 @@ dependencies = [
  "opentelemetry-semantic-conventions",
  "thiserror",
  "thrift",
- "tokio 1.11.0",
+ "tokio 1.13.0",
 ]
 
 [[package]]
@@ -2837,18 +2837,18 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "2.7.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "039f02eb0f69271f26abe3202189275d7aa2258b903cb0281b5de710a2570ff3"
+checksum = "97c9d06878b3a851e8026ef94bf7fef9ba93062cd412601da4d9cf369b1cc62d"
 dependencies = [
  "num-traits 0.2.14",
 ]
 
 [[package]]
 name = "packed_simd_2"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e64858a2d3733fdd61adfdd6da89aa202f7ff0e741d2fc7ed1e452ba9dc99d7"
+checksum = "71c0c06716cfc81616fa8e22b721ce92fecd594508bc0eb3d04ae3ef35ac10c5"
 dependencies = [
  "cfg-if 0.1.10",
  "libm 0.1.4",
@@ -3031,9 +3031,9 @@ version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be26700300be6d9d23264c73211d8190e755b6b5ca7a1b28230025511b52a5e"
 dependencies = [
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "syn 1.0.75",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -3042,9 +3042,9 @@ version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e8fe8163d14ce7f0cdac2e040116f22eac817edabff0be91e8aff7e9accf389"
 dependencies = [
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "syn 1.0.75",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -3067,9 +3067,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.19"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
+checksum = "12295df4f294471248581bc09bef3c38a5e46f1e36d6a37353621a0c6c357e1f"
 
 [[package]]
 name = "poly1305"
@@ -3107,15 +3107,15 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.10"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fdbd1df62156fbc5945f4762632564d7d038153091c3fcf1067f6aef7cff92"
+checksum = "1ebace6889caf889b4d3f76becee12e90353f2b8c7d875534a71e5742f8f6f83"
 dependencies = [
  "thiserror",
  "toml 0.5.8",
@@ -3128,9 +3128,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "syn 1.0.75",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
  "version_check 0.9.3",
 ]
 
@@ -3140,8 +3140,8 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.28",
- "quote 1.0.9",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
  "version_check 0.9.3",
 ]
 
@@ -3168,9 +3168,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.28"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
+checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
 dependencies = [
  "unicode-xid 0.2.2",
 ]
@@ -3211,9 +3211,9 @@ checksum = "600d2f334aa05acb02a755e217ef1ab6dea4d51b58b7846588b747edec04efba"
 dependencies = [
  "anyhow",
  "itertools 0.10.1",
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "syn 1.0.75",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -3259,11 +3259,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
 dependencies = [
- "proc-macro2 1.0.28",
+ "proc-macro2 1.0.32",
 ]
 
 [[package]]
@@ -3503,9 +3503,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.4"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "246e9f61b9bb77df069a947682be06e31ac43ea37862e244a69f177694ea6d22"
+checksum = "66d2927ca2f685faf0fc620ac4834690d29e7abb153add10f5812eef20b5e280"
 dependencies = [
  "base64 0.13.0",
  "bytes 1.1.0",
@@ -3514,7 +3514,7 @@ dependencies = [
  "futures-util",
  "http",
  "http-body",
- "hyper 0.14.12",
+ "hyper 0.14.14",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -3527,7 +3527,7 @@ dependencies = [
  "serde 1.0.130",
  "serde_json",
  "serde_urlencoded",
- "tokio 1.11.0",
+ "tokio 1.13.0",
  "tokio-native-tls",
  "url 2.2.2",
  "wasm-bindgen",
@@ -3694,8 +3694,8 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "688599bdab9f42105d0ae1494335a9ffafdeb7d36325e6b10fd4abc5829d6284"
 dependencies = [
- "quote 1.0.9",
- "syn 1.0.75",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -3852,7 +3852,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
 dependencies = [
- "ordered-float 2.7.0",
+ "ordered-float 2.8.0",
  "serde 1.0.130",
 ]
 
@@ -3862,16 +3862,16 @@ version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
 dependencies = [
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "syn 1.0.75",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.67"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f9e390c27c3c0ce8bc5d725f6e4d30a29d26659494aa4b17535f7522c5c950"
+checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
 dependencies = [
  "itoa",
  "ryu",
@@ -3884,9 +3884,9 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98d0516900518c29efa217c298fa1f4e6c6ffc85ae29fd7f4ee48f176e1a9ed5"
 dependencies = [
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "syn 1.0.75",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -3912,9 +3912,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad104641f3c958dab30eb3010e834c2622d1f3f4c530fef1dee20ad9485f3c09"
+checksum = "d8c608a35705a5d3cdc9fbe403147647ff34b921f8e833e49306df898f9b20af"
 dependencies = [
  "dtoa",
  "indexmap",
@@ -3962,9 +3962,9 @@ dependencies = [
 
 [[package]]
 name = "sharded-slab"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "740223c51853f3145fe7c90360d2d4232f2b62e3449489c207eccde818979982"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
 dependencies = [
  "lazy_static 1.4.0",
 ]
@@ -3997,9 +3997,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19772be3c4dd2ceaacf03cb41d5885f2a02c4d8804884918e3a258480803335"
+checksum = "02658e48d89f2bec991f9a78e69cfa4c316f8d6a6c4ec12fae1aeb263d486788"
 
 [[package]]
 name = "simple_asn1"
@@ -4014,15 +4014,15 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c307a32c1c5c437f38c7fd45d753050587732ba8628319fbdf12a7e289ccc590"
+checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
 
 [[package]]
 name = "smallvec"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
+checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
 
 [[package]]
 name = "snow"
@@ -4043,9 +4043,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "765f090f0e423d2b55843402a07915add955e7d60657db13707a159727326cad"
+checksum = "5dc90fe6c7be1a323296982db1836d1ea9e47b6839496dde9a541bc496df3516"
 dependencies = [
  "libc",
  "winapi 0.3.9",
@@ -4098,9 +4098,9 @@ checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
 name = "structopt"
-version = "0.3.22"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69b041cdcb67226aca307e6e7be44c8806423d83e018bd662360a93dabce4d71"
+checksum = "40b9788f4202aa75c240ecc9c15c65185e6a39ccdeb0fd5d008b98825464c87c"
 dependencies = [
  "clap",
  "lazy_static 1.4.0",
@@ -4109,15 +4109,15 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.15"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7813934aecf5f51a54775e00068c237de98489463968231a51746bbbc03f9c10"
+checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "syn 1.0.75",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -4133,9 +4133,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6e163a520367c465f59e0a61a23cfae3b10b6546d78b6f672a382be79f7110"
 dependencies = [
  "heck",
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "syn 1.0.75",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -4145,9 +4145,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87c85aa3f8ea653bfd3ddf25f7ee357ee4d204731f6aa9ad04002306f6e2774c"
 dependencies = [
  "heck",
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "syn 1.0.75",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -4157,9 +4157,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e61bb0be289045cb80bfce000512e32d09f8337e54c186725da381377ad1f8d5"
 dependencies = [
  "heck",
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "syn 1.0.75",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -4204,12 +4204,12 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.75"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f58f7e8eaa0009c5fec437aabf511bd9933e4b2d7407bd05273c01a8906ea7"
+checksum = "f2afee18b8beb5a596ecb4a2dce128c719b4ba399d34126b9e4396e3f9860966"
 dependencies = [
- "proc-macro2 1.0.28",
- "quote 1.0.9",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
  "unicode-xid 0.2.2",
 ]
 
@@ -4224,13 +4224,13 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.12.5"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "474aaa926faa1603c40b7885a9eaea29b444d1cb2850cb7c0e37bb1a4182f4fa"
+checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "syn 1.0.75",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
  "unicode-xid 0.2.2",
 ]
 
@@ -4255,7 +4255,7 @@ version = "0.12.0"
 dependencies = [
  "config",
  "dirs-next 1.0.2",
- "futures 0.3.16",
+ "futures 0.3.17",
  "log 0.4.14",
  "qrcode",
  "rand 0.8.4",
@@ -4270,7 +4270,7 @@ dependencies = [
  "tari_crypto",
  "tari_p2p",
  "thiserror",
- "tokio 1.11.0",
+ "tokio 1.13.0",
  "tonic",
 ]
 
@@ -4283,7 +4283,7 @@ dependencies = [
  "chrono",
  "config",
  "either",
- "futures 0.3.16",
+ "futures 0.3.17",
  "log 0.4.14",
  "num_cpus",
  "opentelemetry",
@@ -4306,7 +4306,7 @@ dependencies = [
  "tari_service_framework",
  "tari_shutdown",
  "thiserror",
- "tokio 1.11.0",
+ "tokio 1.13.0",
  "tonic",
  "tracing",
  "tracing-opentelemetry",
@@ -4367,13 +4367,13 @@ name = "tari_common_types"
 version = "0.12.0"
 dependencies = [
  "digest",
- "futures 0.3.16",
+ "futures 0.3.17",
  "lazy_static 1.4.0",
  "rand 0.8.4",
  "serde 1.0.130",
  "tari_crypto",
  "thiserror",
- "tokio 1.11.0",
+ "tokio 1.13.0",
 ]
 
 [[package]]
@@ -4391,7 +4391,7 @@ dependencies = [
  "data-encoding",
  "digest",
  "env_logger 0.7.1",
- "futures 0.3.16",
+ "futures 0.3.17",
  "lazy_static 1.4.0",
  "lmdb-zero",
  "log 0.4.14",
@@ -4415,7 +4415,7 @@ dependencies = [
  "tari_test_utils",
  "tempfile",
  "thiserror",
- "tokio 1.11.0",
+ "tokio 1.13.0",
  "tokio-stream",
  "tokio-util",
  "tower 0.3.1",
@@ -4439,7 +4439,7 @@ dependencies = [
  "diesel_migrations",
  "digest",
  "env_logger 0.7.1",
- "futures 0.3.16",
+ "futures 0.3.17",
  "futures-test",
  "futures-util",
  "lazy_static 1.4.0",
@@ -4464,10 +4464,10 @@ dependencies = [
  "tari_utilities",
  "tempfile",
  "thiserror",
- "tokio 1.11.0",
+ "tokio 1.13.0",
  "tokio-stream",
  "tokio-test 0.4.2",
- "tower 0.4.8",
+ "tower 0.4.10",
  "tower-test",
  "ttl_cache",
 ]
@@ -4476,14 +4476,14 @@ dependencies = [
 name = "tari_comms_rpc_macros"
 version = "0.12.0"
 dependencies = [
- "futures 0.3.16",
- "proc-macro2 1.0.28",
+ "futures 0.3.17",
+ "proc-macro2 1.0.32",
  "prost",
- "quote 1.0.9",
- "syn 1.0.75",
+ "quote 1.0.10",
+ "syn 1.0.81",
  "tari_comms",
  "tari_test_utils",
- "tokio 1.11.0",
+ "tokio 1.13.0",
  "tower-service",
 ]
 
@@ -4495,7 +4495,7 @@ dependencies = [
  "chrono",
  "chrono-english",
  "crossterm",
- "futures 0.3.16",
+ "futures 0.3.17",
  "log 0.4.14",
  "opentelemetry",
  "opentelemetry-jaeger",
@@ -4519,7 +4519,7 @@ dependencies = [
  "tari_shutdown",
  "tari_wallet",
  "thiserror",
- "tokio 1.11.0",
+ "tokio 1.13.0",
  "tonic",
  "tracing",
  "tracing-opentelemetry",
@@ -4546,7 +4546,7 @@ dependencies = [
  "digest",
  "env_logger 0.7.1",
  "fs2",
- "futures 0.3.16",
+ "futures 0.3.17",
  "hex",
  "integer-encoding 3.0.2",
  "lazy_static 1.4.0",
@@ -4578,7 +4578,7 @@ dependencies = [
  "tari_test_utils",
  "tempfile",
  "thiserror",
- "tokio 1.11.0",
+ "tokio 1.13.0",
  "tracing",
  "tracing-attributes",
  "tracing-futures",
@@ -4589,7 +4589,7 @@ dependencies = [
 [[package]]
 name = "tari_crypto"
 version = "0.11.2"
-source = "git+https://github.com/tari-project/tari-crypto.git?branch=main#75a6456a48d1f6dc36e58f49a215a3e9f0c465ab"
+source = "git+https://github.com/tari-project/tari-crypto.git?branch=main#a5defb77e4e212ca5f3fe5e8a1bfe57810efd83e"
 dependencies = [
  "base64 0.10.1",
  "blake2",
@@ -4645,10 +4645,10 @@ dependencies = [
  "config",
  "derive-error",
  "env_logger 0.7.1",
- "futures 0.3.16",
+ "futures 0.3.17",
  "futures-test",
  "hex",
- "hyper 0.14.12",
+ "hyper 0.14.14",
  "jsonrpc",
  "log 0.4.14",
  "rand 0.8.4",
@@ -4663,7 +4663,7 @@ dependencies = [
  "tari_crypto",
  "tari_utilities",
  "thiserror",
- "tokio 1.11.0",
+ "tokio 1.13.0",
  "tonic",
  "tracing",
  "tracing-futures",
@@ -4678,7 +4678,7 @@ dependencies = [
  "bufstream",
  "chrono",
  "crossbeam",
- "futures 0.3.16",
+ "futures 0.3.17",
  "hex",
  "jsonrpc",
  "log 0.4.14",
@@ -4697,7 +4697,7 @@ dependencies = [
  "tari_crypto",
  "thiserror",
  "time",
- "tokio 1.11.0",
+ "tokio 1.13.0",
  "tonic",
 ]
 
@@ -4730,7 +4730,7 @@ dependencies = [
  "clap",
  "env_logger 0.6.2",
  "fs2",
- "futures 0.3.16",
+ "futures 0.3.17",
  "futures-timer",
  "lazy_static 1.4.0",
  "lmdb-zero",
@@ -4755,7 +4755,7 @@ dependencies = [
  "tari_utilities",
  "tempfile",
  "thiserror",
- "tokio 1.11.0",
+ "tokio 1.13.0",
  "tokio-stream",
  "tower 0.3.1",
  "tower-service",
@@ -4768,13 +4768,13 @@ version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "futures 0.3.16",
+ "futures 0.3.17",
  "futures-test",
  "log 0.4.14",
  "tari_shutdown",
  "tari_test_utils",
  "thiserror",
- "tokio 1.11.0",
+ "tokio 1.13.0",
  "tower 0.3.1",
  "tower-service",
 ]
@@ -4783,8 +4783,8 @@ dependencies = [
 name = "tari_shutdown"
 version = "0.12.0"
 dependencies = [
- "futures 0.3.16",
- "tokio 1.11.0",
+ "futures 0.3.17",
+ "tokio 1.13.0",
 ]
 
 [[package]]
@@ -4832,10 +4832,10 @@ dependencies = [
  "config",
  "derive-error",
  "env_logger 0.7.1",
- "futures 0.3.16",
+ "futures 0.3.17",
  "futures-test",
  "hex",
- "hyper 0.14.12",
+ "hyper 0.14.14",
  "jsonrpc",
  "log 0.4.14",
  "rand 0.7.3",
@@ -4849,7 +4849,7 @@ dependencies = [
  "tari_crypto",
  "tari_utilities",
  "thiserror",
- "tokio 1.11.0",
+ "tokio 1.13.0",
  "tonic",
  "tonic-build",
  "tracing",
@@ -4862,13 +4862,13 @@ dependencies = [
 name = "tari_test_utils"
 version = "0.12.0"
 dependencies = [
- "futures 0.3.16",
+ "futures 0.3.17",
  "futures-test",
  "lazy_static 1.4.0",
  "rand 0.8.4",
  "tari_shutdown",
  "tempfile",
- "tokio 1.11.0",
+ "tokio 1.13.0",
 ]
 
 [[package]]
@@ -4904,7 +4904,7 @@ dependencies = [
  "digest",
  "env_logger 0.7.1",
  "fs2",
- "futures 0.3.16",
+ "futures 0.3.17",
  "libsqlite3-sys",
  "lmdb-zero",
  "log 0.4.14",
@@ -4928,7 +4928,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "time",
- "tokio 1.11.0",
+ "tokio 1.13.0",
  "tower 0.3.1",
 ]
 
@@ -4938,7 +4938,7 @@ version = "0.20.0"
 dependencies = [
  "chrono",
  "env_logger 0.7.1",
- "futures 0.3.16",
+ "futures 0.3.17",
  "lazy_static 1.4.0",
  "libc",
  "log 0.4.14",
@@ -4959,7 +4959,7 @@ dependencies = [
  "tari_wallet",
  "tempfile",
  "thiserror",
- "tokio 1.11.0",
+ "tokio 1.13.0",
 ]
 
 [[package]]
@@ -4996,7 +4996,7 @@ dependencies = [
  "tari_core",
  "tari_crypto",
  "tari_utilities",
- "tokio 1.11.0",
+ "tokio 1.13.0",
 ]
 
 [[package]]
@@ -5010,22 +5010,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.29"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "602eca064b2d83369e2b2f34b09c70b605402801927c65c11071ac911d299b88"
+checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.29"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bad553cc2c78e8de258400763a647e80e6d1b31ee237275d756f6836d204494c"
+checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
 dependencies = [
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "syn 1.0.75",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -5102,9 +5102,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.3.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "848a1e1181b9f6753b5e96a092749e29b11d19ede67dfbbd6c7dc7e0f49b5338"
+checksum = "f83b2a3d4d9091d0abd7eba4dc2710b1718583bd4d8992e2190720ea38f391f7"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -5130,9 +5130,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.11.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4efe6fc2395938c8155973d7be49fe8d03a843726e285e100a8a383cc0154ce"
+checksum = "588b2d10a336da58d877567cd8fb8a14b463e2104910f8132cd054b4b96e29ee"
 dependencies = [
  "autocfg 1.0.1",
  "bytes 1.1.0",
@@ -5154,18 +5154,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90c49f106be240de154571dd31fbe48acb10ba6c6dd6f6517ad603abffa42de9"
 dependencies = [
  "pin-project-lite 0.2.7",
- "tokio 1.11.0",
+ "tokio 1.13.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "1.3.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54473be61f4ebe4efd09cec9bd5d16fa51d70ea0192213d754d2d500457db110"
+checksum = "114383b041aa6212c579467afa0075fbbdd0718de036100bc0ba7961d8cb9095"
 dependencies = [
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "syn 1.0.75",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -5175,7 +5175,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
  "native-tls",
- "tokio 1.11.0",
+ "tokio 1.13.0",
 ]
 
 [[package]]
@@ -5185,19 +5185,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
 dependencies = [
  "rustls",
- "tokio 1.11.0",
+ "tokio 1.13.0",
  "webpki",
 ]
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b2f3f698253f03119ac0102beaa64f67a67e08074d03a22d18784104543727f"
+checksum = "50145484efff8818b5ccd256697f36863f587da82cf8b409c53adf1e840798e3"
 dependencies = [
  "futures-core",
  "pin-project-lite 0.2.7",
- "tokio 1.11.0",
+ "tokio 1.13.0",
  "tokio-util",
 ]
 
@@ -5221,15 +5221,15 @@ dependencies = [
  "async-stream",
  "bytes 1.1.0",
  "futures-core",
- "tokio 1.11.0",
+ "tokio 1.13.0",
  "tokio-stream",
 ]
 
 [[package]]
 name = "tokio-util"
-version = "0.6.7"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1caa0b0c8d94a049db56b5acf8cba99dc0623aab1b26d5b5f5e2d945846b3592"
+checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
 dependencies = [
  "bytes 1.1.0",
  "futures-core",
@@ -5237,7 +5237,7 @@ dependencies = [
  "futures-sink",
  "log 0.4.14",
  "pin-project-lite 0.2.7",
- "tokio 1.11.0",
+ "tokio 1.13.0",
 ]
 
 [[package]]
@@ -5273,16 +5273,16 @@ dependencies = [
  "h2",
  "http",
  "http-body",
- "hyper 0.14.12",
+ "hyper 0.14.14",
  "hyper-timeout",
  "percent-encoding 2.1.0",
  "pin-project 1.0.8",
  "prost",
  "prost-derive",
- "tokio 1.11.0",
+ "tokio 1.13.0",
  "tokio-stream",
  "tokio-util",
- "tower 0.4.8",
+ "tower 0.4.10",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -5295,10 +5295,10 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12b52d07035516c2b74337d2ac7746075e7dcae7643816c1b12c5ff8a7484c08"
 dependencies = [
- "proc-macro2 1.0.28",
+ "proc-macro2 1.0.32",
  "prost-build",
- "quote 1.0.9",
- "syn 1.0.75",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -5321,18 +5321,19 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.4.8"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60422bc7fefa2f3ec70359b8ff1caff59d785877eb70595904605bcc412470f"
+checksum = "c00e500fff5fa1131c866b246041a6bf96da9c965f8fe4128cb1421f23e93c00"
 dependencies = [
  "futures-core",
  "futures-util",
  "hdrhistogram",
  "indexmap",
  "pin-project 1.0.8",
+ "pin-project-lite 0.2.7",
  "rand 0.8.4",
  "slab",
- "tokio 1.11.0",
+ "tokio 1.13.0",
  "tokio-stream",
  "tokio-util",
  "tower-layer",
@@ -5479,9 +5480,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.26"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09adeb8c97449311ccd28a427f96fb563e7fd31aabf994189879d9da2394b89d"
+checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
 dependencies = [
  "cfg-if 1.0.0",
  "log 0.4.14",
@@ -5492,20 +5493,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.15"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42e6fa53307c8a17e4ccd4dc81cf5ec38db9209f59b222210375b54ee40d1e2"
+checksum = "f4f480b8f81512e825f337ad51e94c1eb5d3bbdf2b363dcd01e2b19a9ffe3f8e"
 dependencies = [
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "syn 1.0.75",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.19"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ca517f43f0fb96e0c3072ed5c275fe5eece87e8cb52f4a77b69226d3b1c9df8"
+checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
 dependencies = [
  "lazy_static 1.4.0",
 ]
@@ -5556,9 +5557,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.20"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9cbe87a2fa7e35900ce5de20220a582a9483a7063811defce79d7cbd59d4cfe"
+checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
 dependencies = [
  "ansi_term 0.12.1",
  "chrono",
@@ -5584,9 +5585,9 @@ checksum = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
 
 [[package]]
 name = "trust-dns-client"
-version = "0.21.0-alpha.2"
+version = "0.21.0-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edaa01dcab6aff8dbd2efa666c5b656729d2c04728c50e16e30117be07c764ac"
+checksum = "44bd50900d7796338807398681ed6d8de0c840d0d9aac65cff093b5635b22e57"
 dependencies = [
  "cfg-if 1.0.0",
  "chrono",
@@ -5600,16 +5601,16 @@ dependencies = [
  "ring",
  "rustls",
  "thiserror",
- "tokio 1.11.0",
+ "tokio 1.13.0",
  "trust-dns-proto",
  "webpki",
 ]
 
 [[package]]
 name = "trust-dns-proto"
-version = "0.21.0-alpha.2"
+version = "0.21.0-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09637dee9c56a62b9acd8ca59ab2ed9459d8430b005100d9063ea326a0a3590a"
+checksum = "d2e43c627e8301d45629cdfaf63e2e0c57305a07e9f1ea48208fd262ba2d87eb"
 dependencies = [
  "async-trait",
  "cfg-if 1.0.0",
@@ -5628,7 +5629,7 @@ dependencies = [
  "smallvec",
  "thiserror",
  "tinyvec",
- "tokio 1.11.0",
+ "tokio 1.13.0",
  "tokio-rustls",
  "url 2.2.2",
  "webpki",
@@ -5699,9 +5700,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
+checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
 
 [[package]]
 name = "ucd-trie"
@@ -5732,9 +5733,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "246f4c42e67e7a4e3c6106ff716a5d067d4132a642840b242e357e468a2a0085"
+checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
 
 [[package]]
 name = "unicode-normalization"
@@ -5753,9 +5754,9 @@ checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "unicode-xid"
@@ -5894,36 +5895,34 @@ checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.76"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce9b1b516211d33767048e5d47fa2a381ed8b76fc48d2ce4aa39877f9f183e0"
+checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
 dependencies = [
  "cfg-if 1.0.0",
- "serde 1.0.130",
- "serde_json",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.76"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe8dc78e2326ba5f845f4b5bf548401604fa20b1dd1d365fb73b6c1d6364041"
+checksum = "a317bf8f9fba2476b4b2c85ef4c4af8ff39c3c7f0cdfeed4f82c34a880aa837b"
 dependencies = [
  "bumpalo",
  "lazy_static 1.4.0",
  "log 0.4.14",
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "syn 1.0.75",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.26"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95fded345a6559c2cfee778d562300c581f7d4ff3edb9b0d230d69800d213972"
+checksum = "8e8d7523cb1f2a4c96c1317ca690031b714a51cc14e05f712446691f413f5d39"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -5933,38 +5932,38 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.76"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44468aa53335841d9d6b6c023eaab07c0cd4bddbcfdee3e2bb1e8d2cb8069fef"
+checksum = "d56146e7c495528bf6587663bea13a8eb588d39b36b679d83972e1a2dbbdacf9"
 dependencies = [
- "quote 1.0.9",
+ "quote 1.0.10",
  "wasm-bindgen-macro-support",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.76"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0195807922713af1e67dc66132c7328206ed9766af3858164fb583eedc25fbad"
+checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
 dependencies = [
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "syn 1.0.75",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.76"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acdb075a845574a1fa5f09fd77e43f7747599301ea3417a9fbffdeedfc1f4a29"
+checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
 
 [[package]]
 name = "web-sys"
-version = "0.3.53"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224b2f6b67919060055ef1a67807367c2066ed520c3862cc013d26cf893a783c"
+checksum = "38eb105f1c59d9eaa6b5cdc92b859d85b926e82cb2e0945cd0c9259faa6fe9fb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6054,9 +6053,9 @@ dependencies = [
 
 [[package]]
 name = "x25519-dalek"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a0c105152107e3b96f6a00a65e86ce82d9b125230e1c4302940eca58ff71f4f"
+checksum = "2392b6b94a576b4e2bf3c5b2757d63f10ada8020a2e4d08ac849ebcf6ea8e077"
 dependencies = [
  "curve25519-dalek",
  "rand_core 0.5.1",
@@ -6078,7 +6077,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7d9028f208dd5e63c614be69f115c1b53cacc1111437d4c765185856666c107"
 dependencies = [
- "futures 0.3.16",
+ "futures 0.3.17",
  "log 0.4.14",
  "nohash-hasher",
  "parking_lot 0.11.2",
@@ -6097,12 +6096,12 @@ dependencies = [
 
 [[package]]
 name = "zeroize_derive"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2c1e130bebaeab2f23886bf9acbaca14b092408c452543c857f66399cd6dab1"
+checksum = "bdff2024a851a322b08f179173ae2ba620445aef1e838f0c196820eade4ae0c7"
 dependencies = [
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "syn 1.0.75",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
  "synstructure",
 ]

--- a/applications/tari_console_wallet/src/automation/commands.rs
+++ b/applications/tari_console_wallet/src/automation/commands.rs
@@ -97,10 +97,7 @@ pub enum TransactionStage {
 }
 
 #[derive(Debug)]
-pub struct SentTransaction {
-    id: TxId,
-    stage: TransactionStage,
-}
+pub struct SentTransaction {}
 
 fn get_transaction_parameters(
     args: Vec<ParsedArgument>,
@@ -453,10 +450,7 @@ pub async fn monitor_transactions(
                         "tx direct send event for tx_id: {}, success: {}", *id, success
                     );
                     if wait_stage == TransactionStage::DirectSendOrSaf {
-                        results.push(SentTransaction {
-                            id: *id,
-                            stage: TransactionStage::DirectSendOrSaf,
-                        });
+                        results.push(SentTransaction {});
                         if results.len() == tx_ids.len() {
                             break;
                         }
@@ -468,10 +462,7 @@ pub async fn monitor_transactions(
                         "tx store and forward event for tx_id: {}, success: {}", *id, success
                     );
                     if wait_stage == TransactionStage::DirectSendOrSaf {
-                        results.push(SentTransaction {
-                            id: *id,
-                            stage: TransactionStage::DirectSendOrSaf,
-                        });
+                        results.push(SentTransaction {});
                         if results.len() == tx_ids.len() {
                             break;
                         }
@@ -480,10 +471,7 @@ pub async fn monitor_transactions(
                 TransactionEvent::ReceivedTransactionReply(id) if tx_ids.contains(id) => {
                     debug!(target: LOG_TARGET, "tx reply event for tx_id: {}", *id);
                     if wait_stage == TransactionStage::Negotiated {
-                        results.push(SentTransaction {
-                            id: *id,
-                            stage: TransactionStage::Negotiated,
-                        });
+                        results.push(SentTransaction {});
                         if results.len() == tx_ids.len() {
                             break;
                         }
@@ -492,10 +480,7 @@ pub async fn monitor_transactions(
                 TransactionEvent::TransactionBroadcast(id) if tx_ids.contains(id) => {
                     debug!(target: LOG_TARGET, "tx mempool broadcast event for tx_id: {}", *id);
                     if wait_stage == TransactionStage::Broadcast {
-                        results.push(SentTransaction {
-                            id: *id,
-                            stage: TransactionStage::Broadcast,
-                        });
+                        results.push(SentTransaction {});
                         if results.len() == tx_ids.len() {
                             break;
                         }
@@ -514,10 +499,7 @@ pub async fn monitor_transactions(
                         is_valid
                     );
                     if wait_stage == TransactionStage::MinedUnconfirmed {
-                        results.push(SentTransaction {
-                            id: *tx_id,
-                            stage: TransactionStage::MinedUnconfirmed,
-                        });
+                        results.push(SentTransaction {});
                         if results.len() == tx_ids.len() {
                             break;
                         }
@@ -529,10 +511,7 @@ pub async fn monitor_transactions(
                         "tx mined confirmed event for tx_id: {}, is_valid:{}", *tx_id, is_valid
                     );
                     if wait_stage == TransactionStage::Mined {
-                        results.push(SentTransaction {
-                            id: *tx_id,
-                            stage: TransactionStage::Mined,
-                        });
+                        results.push(SentTransaction {});
                         if results.len() == tx_ids.len() {
                             break;
                         }

--- a/applications/tari_console_wallet/src/ui/state/app_state.rs
+++ b/applications/tari_console_wallet/src/ui/state/app_state.rs
@@ -78,7 +78,6 @@ use crate::{
     utils::db::{CUSTOM_BASE_NODE_ADDRESS_KEY, CUSTOM_BASE_NODE_PUBLIC_KEY_KEY},
     wallet_modes::PeerConfig,
 };
-use tari_wallet::output_manager_service::handle::OutputManagerHandle;
 
 const LOG_TARGET: &str = "wallet::console_wallet::app_state";
 
@@ -91,7 +90,6 @@ pub struct AppState {
     node_config: GlobalConfig,
     config: AppStateConfig,
     wallet_connectivity: WalletConnectivityHandle,
-    output_manager_service: OutputManagerHandle,
     balance_enquiry_debouncer: BalanceEnquiryDebouncer,
 }
 
@@ -118,7 +116,6 @@ impl AppState {
             node_config: node_config.clone(),
             config: AppStateConfig::default(),
             wallet_connectivity,
-            output_manager_service: output_manager_service.clone(),
             balance_enquiry_debouncer: BalanceEnquiryDebouncer::new(
                 inner,
                 Duration::from_secs(node_config.wallet_balance_enquiry_cooldown_period),

--- a/applications/tari_stratum_transcoder/src/proxy.rs
+++ b/applications/tari_stratum_transcoder/src/proxy.rs
@@ -83,8 +83,8 @@ impl StratumTranscoderProxyService {
     ) -> Self {
         Self {
             inner: InnerService {
-                config,
-                http_client,
+                _config: config,
+                _http_client: http_client,
                 base_node_client,
                 wallet_client,
             },
@@ -129,8 +129,8 @@ impl Service<Request<Body>> for StratumTranscoderProxyService {
 
 #[derive(Debug, Clone)]
 struct InnerService {
-    config: StratumTranscoderProxyConfig,
-    http_client: reqwest::Client,
+    _config: StratumTranscoderProxyConfig,
+    _http_client: reqwest::Client,
     base_node_client: grpc::base_node_client::BaseNodeClient<tonic::transport::Channel>,
     wallet_client: grpc::wallet_client::WalletClient<tonic::transport::Channel>,
 }

--- a/base_layer/core/src/proof_of_work/randomx_factory.rs
+++ b/base_layer/core/src/proof_of_work/randomx_factory.rs
@@ -15,7 +15,7 @@ pub struct RandomXVMInstance {
     // The cache and dataset for the VM need to be stored together with it since they are not
     // mix and match.
     instance: Arc<Mutex<(RandomXVM, RandomXCache, Option<RandomXDataset>)>>,
-    flags: RandomXFlag,
+    _flags: RandomXFlag,
 }
 
 impl RandomXVMInstance {
@@ -48,7 +48,7 @@ impl RandomXVMInstance {
 
         Ok(Self {
             instance: Arc::new(Mutex::new((vm, cache, None))),
-            flags,
+            _flags: flags,
         })
     }
 

--- a/base_layer/core/src/transactions/transaction_protocol/transaction_initializer.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/transaction_initializer.rs
@@ -67,10 +67,9 @@ pub const LOG_TARGET: &str = "c::tx::tx_protocol::tx_initializer";
 /// SenderTransactionProtocol::new(1);
 /// ```
 /// which returns an instance of this builder. Once all the sender's information has been added via the builder
-/// methods, you can call `build()` which will return a
+/// methods, you can call `build()` which will return a [SenderTransactionProtocol]
 #[derive(Debug, Clone)]
 pub struct SenderTransactionInitializer {
-    consensus_constants: ConsensusConstants,
     num_recipients: usize,
     amounts: FixedSet<MicroTari>,
     lock_height: Option<u64>,
@@ -113,7 +112,6 @@ impl SenderTransactionInitializer {
     pub fn new(num_recipients: usize, consensus_constants: ConsensusConstants) -> Self {
         Self {
             fee: Fee::new(*consensus_constants.transaction_weight()),
-            consensus_constants,
             num_recipients,
             amounts: FixedSet::new(num_recipients),
             lock_height: None,

--- a/base_layer/p2p/src/comms_connector/pubsub.rs
+++ b/base_layer/p2p/src/comms_connector/pubsub.rs
@@ -179,37 +179,37 @@ mod test {
         #[derive(Debug, Clone)]
         struct Dummy {
             a: u32,
-            b: String,
+            _b: String,
         }
 
         let messages = vec![
             TopicPayload::new("Topic1", Dummy {
                 a: 1u32,
-                b: "one".to_string(),
+                _b: "one".to_string(),
             }),
             TopicPayload::new("Topic2", Dummy {
                 a: 2u32,
-                b: "two".to_string(),
+                _b: "two".to_string(),
             }),
             TopicPayload::new("Topic1", Dummy {
                 a: 3u32,
-                b: "three".to_string(),
+                _b: "three".to_string(),
             }),
             TopicPayload::new("Topic2", Dummy {
                 a: 4u32,
-                b: "four".to_string(),
+                _b: "four".to_string(),
             }),
             TopicPayload::new("Topic1", Dummy {
                 a: 5u32,
-                b: "five".to_string(),
+                _b: "five".to_string(),
             }),
             TopicPayload::new("Topic2", Dummy {
                 a: 6u32,
-                b: "size".to_string(),
+                _b: "size".to_string(),
             }),
             TopicPayload::new("Topic1", Dummy {
                 a: 7u32,
-                b: "seven".to_string(),
+                _b: "seven".to_string(),
             }),
         ];
 
@@ -231,15 +231,15 @@ mod test {
         let messages2 = vec![
             TopicPayload::new("Topic1", Dummy {
                 a: 11u32,
-                b: "one one".to_string(),
+                _b: "one one".to_string(),
             }),
             TopicPayload::new("Topic2", Dummy {
                 a: 22u32,
-                b: "two two".to_string(),
+                _b: "two two".to_string(),
             }),
             TopicPayload::new("Topic1", Dummy {
                 a: 33u32,
-                b: "three three".to_string(),
+                _b: "three three".to_string(),
             }),
         ];
 

--- a/base_layer/p2p/src/dns/client.rs
+++ b/base_layer/p2p/src/dns/client.rs
@@ -106,7 +106,7 @@ impl DnsClient {
 #[derive(Clone)]
 pub struct Client<C> {
     inner: C,
-    shutdown: Arc<Shutdown>,
+    _shutdown: Arc<Shutdown>,
 }
 
 impl Client<AsyncDnssecClient> {
@@ -121,7 +121,7 @@ impl Client<AsyncDnssecClient> {
 
         Ok(Self {
             inner: client,
-            shutdown: Arc::new(shutdown),
+            _shutdown: Arc::new(shutdown),
         })
     }
 }
@@ -135,7 +135,7 @@ impl Client<AsyncClient> {
 
         Ok(Self {
             inner: client,
-            shutdown: Arc::new(shutdown),
+            _shutdown: Arc::new(shutdown),
         })
     }
 }
@@ -165,7 +165,7 @@ mod mock {
             let client = MockClientHandle::mock(messages);
             Ok(Self {
                 inner: client,
-                shutdown: Arc::new(Shutdown::new()),
+                _shutdown: Arc::new(Shutdown::new()),
             })
         }
     }

--- a/base_layer/p2p/src/dns/mock.rs
+++ b/base_layer/p2p/src/dns/mock.rs
@@ -34,7 +34,7 @@ use trust_dns_client::{
 #[derive(Clone)]
 pub struct MockClientHandle<O: OnSend, E> {
     messages: Arc<Vec<Result<DnsResponse, E>>>,
-    on_send: O,
+    _on_send: O,
 }
 
 impl<E> MockClientHandle<DefaultOnSend, E> {
@@ -44,7 +44,7 @@ impl<E> MockClientHandle<DefaultOnSend, E> {
 
         MockClientHandle {
             messages: Arc::new(messages),
-            on_send: DefaultOnSend,
+            _on_send: DefaultOnSend,
         }
     }
 }

--- a/base_layer/p2p/src/services/liveness/state.rs
+++ b/base_layer/p2p/src/services/liveness/state.rs
@@ -74,7 +74,6 @@ pub struct LivenessState {
     pongs_received: usize,
     pings_sent: usize,
     pongs_sent: usize,
-    num_active_peers: usize,
 
     local_metadata: Metadata,
 }

--- a/base_layer/wallet/src/output_manager_service/mod.rs
+++ b/base_layer/wallet/src/output_manager_service/mod.rs
@@ -29,7 +29,6 @@ use crate::{
         service::OutputManagerService,
         storage::database::{OutputManagerBackend, OutputManagerDatabase},
     },
-    transaction_service::handle::TransactionServiceHandle,
 };
 use futures::future;
 use log::*;
@@ -114,13 +113,11 @@ where T: OutputManagerBackend + 'static
         let constants = self.network.create_consensus_constants().pop().unwrap();
         let master_secret_key = self.master_secret_key.clone();
         context.spawn_when_ready(move |handles| async move {
-            let transaction_service = handles.expect_handle::<TransactionServiceHandle>();
             let base_node_service_handle = handles.expect_handle::<BaseNodeServiceHandle>();
             let connectivity = handles.expect_handle::<WalletConnectivityHandle>();
 
             let service = OutputManagerService::new(
                 config,
-                transaction_service,
                 receiver,
                 OutputManagerDatabase::new(backend),
                 publisher,

--- a/base_layer/wallet/src/output_manager_service/resources.rs
+++ b/base_layer/wallet/src/output_manager_service/resources.rs
@@ -20,14 +20,11 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::{
-    output_manager_service::{
-        config::OutputManagerServiceConfig,
-        handle::OutputManagerEventSender,
-        storage::database::OutputManagerDatabase,
-        MasterKeyManager,
-    },
-    transaction_service::handle::TransactionServiceHandle,
+use crate::output_manager_service::{
+    config::OutputManagerServiceConfig,
+    handle::OutputManagerEventSender,
+    storage::database::OutputManagerDatabase,
+    MasterKeyManager,
 };
 use std::sync::Arc;
 use tari_core::{consensus::ConsensusConstants, transactions::CryptoFactories};
@@ -38,7 +35,6 @@ use tari_shutdown::ShutdownSignal;
 pub(crate) struct OutputManagerResources<TBackend, TWalletConnectivity> {
     pub config: OutputManagerServiceConfig,
     pub db: OutputManagerDatabase<TBackend>,
-    pub transaction_service: TransactionServiceHandle,
     pub factories: CryptoFactories,
     pub event_publisher: OutputManagerEventSender,
     pub master_key_manager: Arc<MasterKeyManager<TBackend>>,

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -36,7 +36,6 @@ use crate::{
         tasks::TxoValidationTask,
         MasterKeyManager,
     },
-    transaction_service::handle::TransactionServiceHandle,
     types::HashDigest,
 };
 use blake2::Digest;
@@ -95,7 +94,6 @@ where
     #[allow(clippy::too_many_arguments)]
     pub async fn new(
         config: OutputManagerServiceConfig,
-        transaction_service: TransactionServiceHandle,
         request_stream: reply_channel::Receiver<
             OutputManagerRequest,
             Result<OutputManagerResponse, OutputManagerError>,
@@ -118,7 +116,6 @@ where
         let resources = OutputManagerResources {
             config,
             db,
-            transaction_service,
             factories,
             connectivity,
             event_publisher,

--- a/base_layer/wallet/tests/transaction_service/service.rs
+++ b/base_layer/wallet/tests/transaction_service/service.rs
@@ -331,7 +331,6 @@ pub fn setup_transaction_service_no_comms(
     let output_manager_service = runtime
         .block_on(OutputManagerService::new(
             OutputManagerServiceConfig::default(),
-            ts_handle.clone(),
             oms_request_receiver,
             oms_db,
             oms_event_publisher.clone(),

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -22,7 +22,7 @@
 
 #![cfg_attr(not(debug_assertions), deny(unused_variables))]
 #![cfg_attr(not(debug_assertions), deny(unused_imports))]
-#![cfg_attr(not(debug_assertions), deny(dead_code))]
+#![warn(dead_code)]
 #![cfg_attr(not(debug_assertions), deny(unused_extern_crates))]
 #![deny(unused_must_use)]
 #![deny(unreachable_patterns)]

--- a/common/examples/base_node_init.rs
+++ b/common/examples/base_node_init.rs
@@ -7,7 +7,7 @@ use tari_common::{configuration::bootstrap::ApplicationType, ConfigBootstrap, De
 struct Arguments {
     /// Custom application parameters might eb specified as usual
     #[structopt(long, default_value = "any structopt options allowed")]
-    my_param: String,
+    _my_param: String,
     #[structopt(flatten)]
     bootstrap: ConfigBootstrap,
 }

--- a/comms/dht/src/network_discovery/discovering.rs
+++ b/comms/dht/src/network_discovery/discovering.rs
@@ -41,10 +41,8 @@ const LOG_TARGET: &str = "comms::dht::network_discovery";
 pub(super) struct Discovering {
     params: DiscoveryParams,
     context: NetworkDiscoveryContext,
-    candidate_peers: Vec<PeerConnection>,
     stats: DhtNetworkDiscoveryRoundInfo,
     neighbourhood_threshold: NodeDistance,
-    excluded_peers: Vec<NodeId>,
 }
 
 impl Discovering {
@@ -52,10 +50,8 @@ impl Discovering {
         Self {
             params,
             context,
-            candidate_peers: Vec::new(),
             stats: Default::default(),
             neighbourhood_threshold: NodeDistance::max_distance(),
-            excluded_peers: Vec::new(),
         }
     }
 

--- a/comms/src/multiplexing/yamux.rs
+++ b/comms/src/multiplexing/yamux.rs
@@ -144,7 +144,7 @@ impl Control {
         let stream = self.inner.open_stream().await?;
         Ok(Substream {
             stream: stream.compat(),
-            counter_guard,
+            _counter_guard: counter_guard,
         })
     }
 
@@ -193,7 +193,7 @@ impl Stream for IncomingSubstreams {
         match futures::ready!(Pin::new(&mut self.inner).poll_recv(cx)) {
             Some(stream) => Poll::Ready(Some(Substream {
                 stream: stream.compat(),
-                counter_guard: self.substream_counter.new_guard(),
+                _counter_guard: self.substream_counter.new_guard(),
             })),
             None => Poll::Ready(None),
         }
@@ -209,7 +209,7 @@ impl Drop for IncomingSubstreams {
 #[derive(Debug)]
 pub struct Substream {
     stream: Compat<yamux::Stream>,
-    counter_guard: AtomicRefCounterGuard,
+    _counter_guard: AtomicRefCounterGuard,
 }
 
 impl StreamId for Substream {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,4 +2,4 @@
 # and increment this number:
 # Hours spent updating the Rust Toolchain = 1
 [toolchain]
-channel = "nightly-2021-08-18"
+channel = "nightly-2021-09-18"


### PR DESCRIPTION
This seemingly innoucous update required several changes due to changes
in how the compiler interprets dead code.

* A few variables were renamed _x where it looked like x might be used
  in upcoming PRs. YAGNI maybe, but I gave the benefit of the doubt in
these cases.
* Some crates that had LOADS of dead code (wallet ffi crate I'm looking at
  you), I just changed the `deny(dead_code)` to `warn(dead_code)`
* And in some places, I just nuked the dead code, which tidied up some
  heavy code in the wallet in particular. Since the tests pass, I
presume this is fine and there isn't a weird new compiler bug that is
missing where the code is needed.


