### PR TITLE
test: add logs on non-passing tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,7 +129,7 @@ commands:
       - run:
           name: Run cucumber scenarios
           no_output_timeout: 20m
-          command: cd integration_tests && mkdir -p cucumber_output && node_modules/.bin/cucumber-js --profile "ci" --tags "not @long-running and not @broken and not @wallet-ffi" --format json:cucumber_output/tests.cucumber --exit --retry 2 --retryTagFilter "@flaky and not @broken"
+          command: cd integration_tests && mkdir -p cucumber_output && node_modules/.bin/cucumber-js --profile "ci" --tags "not @long-running and not @broken and not @wallet-ffi" --format json:cucumber_output/tests.cucumber --exit --retry 3 --retry-tag-filter "@flaky and not @broken"
       - run:
           name: Generate report
           command: cd integration_tests && node ./generate_report.js
@@ -137,7 +137,7 @@ commands:
       # Below step requires NodeJS v12 to run correctly, see explanation in WalletFFI.feature
       - run:
           name: Run FFI wallet library cucumber scenarios
-          command: cd integration_tests && mkdir -p cucumber_output && node_modules/.bin/cucumber-js --profile "ci"  --tags "not @long-running and not @broken and not @flaky and @wallet-ffi" --format json:cucumber_output/tests_ffi.cucumber --exit
+          command: cd integration_tests && mkdir -p cucumber_output && node_modules/.bin/cucumber-js --profile "ci"  --tags "not @long-running and not @broken and @wallet-ffi" --format json:cucumber_output/tests_ffi.cucumber --exit --retry 3 --retry-tag-filter "@flaky and not @broken"
           when: always
       - run:
           name: Generate report (ffi)

--- a/integration_tests/features/support/world.js
+++ b/integration_tests/features/support/world.js
@@ -432,10 +432,15 @@ After(async function (testCase) {
 
 async function stopAndHandleLogs(objects, testCase, context) {
   for (const key in objects) {
-    if (testCase.result.status === "failed") {
-      await attachLogs(`${objects[key].baseDir}`, context);
+    try {
+      if (testCase.result.status !== "passed") {
+        await attachLogs(`${objects[key].baseDir}`, context);
+      }
+      await objects[key].stop();
+    } catch (e) {
+      console.log(e);
+      // Continue with others
     }
-    await objects[key].stop();
   }
 }
 


### PR DESCRIPTION
Description
---
Change the test to add logs from `=== 'failed'` to `!== 'passed'`. 

Motivation and Context
---
When a step would timeout, it would not trigger the step to add logs

How Has This Been Tested?
---
Checking on ci
