### PR TITLE
feat: add caching and clippy annotations to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,8 @@ on:
     types: [opened, synchronize, reopened]
 
 name: CI
-
+env:
+  toolchain: nightly-2021-08-18
 jobs:
   clippy:
     name: clippy
@@ -19,31 +20,41 @@ jobs:
       - name: toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2021-08-18
+          toolchain: ${{ env.toolchain }}
           components: clippy, rustfmt
           override: true
+      - name: Caching
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-${{ runner.cpu-model }}-${{ env.toolchain }}-${{ hashFiles('**/Cargo.lock') }}
       - name: cargo fmt
         uses: actions-rs/cargo@v1
         with:
           command: fmt
           args: --all -- --check
-      - name: cargo clippy
-        uses: actions-rs/cargo@v1
+      - name: Clippy check
+        uses: actions-rs/clippy-check@v1
         with:
-          command: clippy
-          args: -- -D warnings -W clippy::cognitive_complexity
-      - name: cargo clippy --all-targets
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-targets -- -D warnings
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-features
   test:
     name: test
     runs-on: ubuntu-18.04
     steps:
       - name: checkout
         uses: actions/checkout@v2
-
+      - name: Caching
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-${{ runner.cpu-model }}-${{ env.toolchain }}-${{ hashFiles('**/Cargo.lock') }}
       - name: ubuntu dependencies
         if: startsWith(matrix.os,'ubuntu')
         run: |
@@ -64,7 +75,7 @@ jobs:
       - name: toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2021-08-18
+          toolchain: ${{ env.toolchain }}
           components: clippy, rustfmt
           override: true
 


### PR DESCRIPTION
* Adds caching to the standard CI flow; this should drastically reduce build times when pushing small fixes to PRs by 90% or more.
* Introduce clippy-check that puts annotations in the PR for identifying clippy warnings.
  * The motivation for this is that recent changes to clippy make warnings into hard errors, which shouldn't break an entire PR build (e.g. `missing impl Default` warning).
  * Fixing clippy errors are always "Good first issues", and having annotations in the code makes it clear where first-time contributors need to focus.