### PR TITLE
chore: fix clippy warnings

### DIFF
--- a/applications/tari_base_node/src/main.rs
+++ b/applications/tari_base_node/src/main.rs
@@ -388,7 +388,7 @@ async fn cli_loop(parser: Parser, mut shutdown: Shutdown) {
             res = &mut read_command_fut => {
                 match res {
                     Ok((line, mut rustyline)) => {
-                        if let Some(p) = rustyline.helper_mut().as_deref_mut() {
+                        if let Some(p) = rustyline.helper_mut() {
                             p.handle_command(line.as_str(), &mut shutdown);
                         }
                         if !shutdown.is_triggered() {

--- a/applications/tari_mining_node/src/stratum/stratum_miner/job_shared_data.rs
+++ b/applications/tari_mining_node/src/stratum/stratum_miner/job_shared_data.rs
@@ -26,24 +26,13 @@ use tari_core::blocks::BlockHeader;
 
 pub type JobSharedDataType = Arc<RwLock<JobSharedData>>;
 
+#[derive(Default)]
 pub struct JobSharedData {
     pub job_id: u64,
     pub height: u64,
     pub header: Option<BlockHeader>,
     pub difficulty: u64,
     pub solutions: Vec<Solution>,
-}
-
-impl Default for JobSharedData {
-    fn default() -> JobSharedData {
-        JobSharedData {
-            job_id: 0,
-            height: 0,
-            header: None,
-            difficulty: 0,
-            solutions: Vec::new(),
-        }
-    }
 }
 
 impl JobSharedData {

--- a/applications/tari_mining_node/src/stratum/stratum_statistics/stats.rs
+++ b/applications/tari_mining_node/src/stratum/stratum_statistics/stats.rs
@@ -22,7 +22,7 @@
 //
 use std::time::Duration;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct SolutionStatistics {
     /// Total found
     pub found: u32,
@@ -30,13 +30,7 @@ pub struct SolutionStatistics {
     pub rejected: u32,
 }
 
-impl Default for SolutionStatistics {
-    fn default() -> SolutionStatistics {
-        SolutionStatistics { found: 0, rejected: 0 }
-    }
-}
-
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct MiningStatistics {
     /// Solutions per second
     sols: Vec<f64>,
@@ -46,17 +40,6 @@ pub struct MiningStatistics {
     pub solvers: usize,
     /// Solution statistics
     pub solution_stats: SolutionStatistics,
-}
-
-impl Default for MiningStatistics {
-    fn default() -> MiningStatistics {
-        MiningStatistics {
-            solvers: 0,
-            sols: vec![],
-            hashes: 0,
-            solution_stats: SolutionStatistics::default(),
-        }
-    }
 }
 
 impl MiningStatistics {
@@ -86,15 +69,7 @@ impl MiningStatistics {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct Statistics {
     pub mining_stats: MiningStatistics,
-}
-
-impl Default for Statistics {
-    fn default() -> Statistics {
-        Statistics {
-            mining_stats: MiningStatistics::default(),
-        }
-    }
 }

--- a/base_layer/core/src/mempool/config.rs
+++ b/base_layer/core/src/mempool/config.rs
@@ -26,19 +26,10 @@ use std::time::Duration;
 use tari_common::{configuration::seconds, NetworkConfigPath};
 
 /// Configuration for the Mempool.
-#[derive(Clone, Copy, Deserialize, Serialize)]
+#[derive(Clone, Copy, Deserialize, Serialize, Default)]
 pub struct MempoolConfig {
     pub unconfirmed_pool: UnconfirmedPoolConfig,
     pub reorg_pool: ReorgPoolConfig,
-}
-
-impl Default for MempoolConfig {
-    fn default() -> Self {
-        Self {
-            unconfirmed_pool: UnconfirmedPoolConfig::default(),
-            reorg_pool: ReorgPoolConfig::default(),
-        }
-    }
 }
 
 impl NetworkConfigPath for MempoolConfig {

--- a/base_layer/core/src/proof_of_work/monero_rx/fixed_array.rs
+++ b/base_layer/core/src/proof_of_work/monero_rx/fixed_array.rs
@@ -81,6 +81,7 @@ impl Deref for FixedByteArray {
     }
 }
 
+#[allow(clippy::derivable_impls)]
 impl Default for FixedByteArray {
     fn default() -> Self {
         Self {

--- a/base_layer/core/src/transactions/transaction_protocol/recipient.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/recipient.rs
@@ -65,6 +65,7 @@ pub(super) enum RecipientInfo {
     Multiple(HashMap<u64, MultiRecipientInfo>),
 }
 
+#[allow(clippy::derivable_impls)]
 impl Default for RecipientInfo {
     fn default() -> Self {
         RecipientInfo::Single(None)

--- a/base_layer/mmr/src/merkle_proof.rs
+++ b/base_layer/mmr/src/merkle_proof.rs
@@ -54,7 +54,7 @@ pub enum MerkleProofError {
 }
 
 /// A Merkle proof that proves a particular element at a particular position exists in an MMR.
-#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone, PartialOrd, Ord)]
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone, PartialOrd, Ord, Default)]
 pub struct MerkleProof {
     /// The size of the MMR at the time the proof was created.
     mmr_size: usize,
@@ -64,16 +64,6 @@ pub struct MerkleProof {
     /// The set of MMR peaks, not including the local peak for the candidate node
     #[serde(with = "serde_support::hash")]
     peaks: Vec<Hash>,
-}
-
-impl Default for MerkleProof {
-    fn default() -> MerkleProof {
-        MerkleProof {
-            mmr_size: 0,
-            path: Vec::default(),
-            peaks: Vec::default(),
-        }
-    }
 }
 
 impl MerkleProof {

--- a/base_layer/wallet/tests/output_manager_service/service.rs
+++ b/base_layer/wallet/tests/output_manager_service/service.rs
@@ -60,7 +60,7 @@ use tari_crypto::{
     script::TariScript,
 };
 use tari_p2p::Network;
-use tari_service_framework::{reply_channel, reply_channel::SenderService};
+use tari_service_framework::reply_channel;
 use tari_shutdown::Shutdown;
 use tari_wallet::{
     base_node_service::{

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -5292,6 +5292,7 @@ mod test {
         std::any::type_name::<T>().to_string()
     }
 
+    #[allow(dead_code)]
     #[derive(Debug)]
     struct CallbackState {
         pub received_tx_callback_called: bool,

--- a/comms/src/test_utils/factories/net_address.rs
+++ b/comms/src/test_utils/factories/net_address.rs
@@ -61,19 +61,10 @@ impl TestFactory for NetAddressesFactory {
 
 //---------------------------------- NetAddressFactory --------------------------------------------//
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct NetAddressFactory {
     port: Option<u16>,
     is_use_os_port: bool,
-}
-
-impl Default for NetAddressFactory {
-    fn default() -> Self {
-        Self {
-            port: None,
-            is_use_os_port: false,
-        }
-    }
 }
 
 impl NetAddressFactory {


### PR DESCRIPTION
Description
---
Fixed clippy warnings due to recent toolchain update.


Motivation and Context
---
See above

How Has This Been Tested?
---
Ran `cargo clippy --all-targets -- -D warnings` 
