### PR TITLE
test: fix cucumber console wallet startup

### DIFF
--- a/applications/tari_console_wallet/src/wallet_modes.rs
+++ b/applications/tari_console_wallet/src/wallet_modes.rs
@@ -337,7 +337,7 @@ async fn run_grpc(grpc: WalletGrpcServer, grpc_console_wallet_address: Multiaddr
         .serve(socket)
         .await
         .map_err(|e| format!("GRPC server returned error:{}", e))?;
-    
+
     // Do not remove this println!
     const CUCUMBER_TEST_MARKER_B: &str = "Tari Console Wallet running... (gRPC mode completed)";
     println!("{}", CUCUMBER_TEST_MARKER_B);

--- a/applications/tari_console_wallet/src/wallet_modes.rs
+++ b/applications/tari_console_wallet/src/wallet_modes.rs
@@ -132,8 +132,17 @@ pub fn command_mode(config: WalletModeConfig, wallet: WalletSqlite, command: Str
         global_config, handle, ..
     } = config.clone();
     let commands = vec![parse_command(&command)?];
+
+    // Do not remove this println!
+    const CUCUMBER_TEST_MARKER_A: &str = "Tari Console Wallet running... (Command mode started)";
+    println!("{}", CUCUMBER_TEST_MARKER_A);
+
     info!(target: LOG_TARGET, "Starting wallet command mode");
     handle.block_on(command_runner(commands, wallet.clone(), global_config))?;
+
+    // Do not remove this println!
+    const CUCUMBER_TEST_MARKER_B: &str = "Tari Console Wallet running... (Command mode completed)";
+    println!("{}", CUCUMBER_TEST_MARKER_B);
 
     info!(target: LOG_TARGET, "Completed wallet command mode");
 
@@ -164,8 +173,16 @@ pub fn script_mode(config: WalletModeConfig, wallet: WalletSqlite, path: PathBuf
     }
     println!("{} commands parsed successfully.", commands.len());
 
+    // Do not remove this println!
+    const CUCUMBER_TEST_MARKER_A: &str = "Tari Console Wallet running... (Script mode started)";
+    println!("{}", CUCUMBER_TEST_MARKER_A);
+
     println!("Starting the command runner!");
     handle.block_on(command_runner(commands, wallet.clone(), global_config))?;
+
+    // Do not remove this println!
+    const CUCUMBER_TEST_MARKER_B: &str = "Tari Console Wallet running... (Script mode completed)";
+    println!("{}", CUCUMBER_TEST_MARKER_B);
 
     info!(target: LOG_TARGET, "Completed wallet script mode");
 
@@ -238,6 +255,10 @@ pub fn tui_mode(config: WalletModeConfig, mut wallet: WalletSqlite) -> Result<()
 
     info!(target: LOG_TARGET, "Starting app");
 
+    // Do not remove this println!
+    const CUCUMBER_TEST_MARKER: &str = "Tari Console Wallet running... (TUI mode started)";
+    println!("{}", CUCUMBER_TEST_MARKER);
+
     {
         let _enter = handle.enter();
         ui::run(app)?;
@@ -258,6 +279,11 @@ pub fn recovery_mode(config: WalletModeConfig, wallet: WalletSqlite) -> Result<(
         wallet_mode,
         ..
     } = config.clone();
+
+    // Do not remove this println!
+    const CUCUMBER_TEST_MARKER_A: &str = "Tari Console Wallet running... (Recovery mode started)";
+    println!("{}", CUCUMBER_TEST_MARKER_A);
+
     println!("Starting recovery...");
     match handle.block_on(wallet_recovery(&wallet, &base_node_config)) {
         Ok(_) => println!("Wallet recovered!"),
@@ -271,6 +297,10 @@ pub fn recovery_mode(config: WalletModeConfig, wallet: WalletSqlite) -> Result<(
             return Err(e);
         },
     }
+
+    // Do not remove this println!
+    const CUCUMBER_TEST_MARKER_B: &str = "Tari Console Wallet running... (Recovery mode completed)";
+    println!("{}", CUCUMBER_TEST_MARKER_B);
 
     println!("Starting TUI.");
 
@@ -287,6 +317,7 @@ pub fn grpc_mode(config: WalletModeConfig, wallet: WalletSqlite) -> Result<(), E
     } = config;
     info!(target: LOG_TARGET, "Starting grpc server");
     let grpc = WalletGrpcServer::new(wallet);
+
     handle
         .block_on(run_grpc(grpc, global_config.grpc_console_wallet_address))
         .map_err(ExitCodes::GrpcError)?;
@@ -295,6 +326,10 @@ pub fn grpc_mode(config: WalletModeConfig, wallet: WalletSqlite) -> Result<(), E
 }
 
 async fn run_grpc(grpc: WalletGrpcServer, grpc_console_wallet_address: Multiaddr) -> Result<(), String> {
+    // Do not remove this println!
+    const CUCUMBER_TEST_MARKER_A: &str = "Tari Console Wallet running... (gRPC mode started)";
+    println!("{}", CUCUMBER_TEST_MARKER_A);
+
     info!(target: LOG_TARGET, "Starting GRPC on {}", grpc_console_wallet_address);
     let socket = multiaddr_to_socketaddr(&grpc_console_wallet_address).map_err(|e| e.to_string())?;
     Server::builder()
@@ -302,6 +337,11 @@ async fn run_grpc(grpc: WalletGrpcServer, grpc_console_wallet_address: Multiaddr
         .serve(socket)
         .await
         .map_err(|e| format!("GRPC server returned error:{}", e))?;
+    
+    // Do not remove this println!
+    const CUCUMBER_TEST_MARKER_B: &str = "Tari Console Wallet running... (gRPC mode completed)";
+    println!("{}", CUCUMBER_TEST_MARKER_B);
+
     info!(target: LOG_TARGET, "Stopping GRPC");
     Ok(())
 }

--- a/integration_tests/features/WalletCli.feature
+++ b/integration_tests/features/WalletCli.feature
@@ -126,9 +126,9 @@ Feature: Wallet CLI
     @flaky
     Scenario: As a user I want to discover-peer via command line
         Given I have a seed node SEED
+        And I have wallet WALLET connected to seed node SEED
         And I have a base node BASE1 connected to seed SEED
         And I have a base node BASE2 connected to seed SEED
-        And I have wallet WALLET connected to base node BASE1
         And I discover peer BASE2 on wallet WALLET via command line
         Then WALLET is connected to BASE2
 

--- a/integration_tests/features/support/steps.js
+++ b/integration_tests/features/support/steps.js
@@ -3512,7 +3512,7 @@ async function wallet_run_command(
       return true;
     },
     true,
-      timeOutSeconds * 1000,
+    timeOutSeconds * 1000,
     5 * 1000,
     5
   );
@@ -3540,7 +3540,7 @@ When(
     await wallet_run_command(
       wallet,
       `send-tari ${amount} ${dest_pubkey} test message`,
-        180
+      180
     );
     // await wallet.sendTari(dest_pubkey, amount, "test message");
   }
@@ -3555,7 +3555,7 @@ When(
     await wallet_run_command(
       wallet,
       `send-one-sided ${amount} ${dest_pubkey} test message`,
-        180
+      180
     );
     // await wallet.sendOneSided(dest_pubkey, amount, "test message");
   }
@@ -3570,7 +3570,7 @@ Then(
     await wallet_run_command(
       wallet,
       `make-it-rain ${freq} ${duration} ${amount} ${amount_inc} now ${dest_pubkey} negotiated test message`,
-        300
+      300
     );
   }
 );
@@ -3594,7 +3594,7 @@ When(
     await wallet_run_command(
       wallet,
       `coin-split ${amount_per_coin} ${number_of_coins}`,
-        180
+      180
     );
   }
 );

--- a/integration_tests/features/support/steps.js
+++ b/integration_tests/features/support/steps.js
@@ -3490,6 +3490,7 @@ Given(
 async function wallet_run_command(
   wallet,
   command,
+  timeOutSeconds = 15,
   message = "",
   printMessage = true
 ) {
@@ -3511,7 +3512,7 @@ async function wallet_run_command(
       return true;
     },
     true,
-    45 * 1000,
+      timeOutSeconds * 1000,
     5 * 1000,
     5
   );
@@ -3523,7 +3524,7 @@ Then(
   { timeout: 180 * 1000 },
   async function (name, amount) {
     let wallet = this.getWallet(name);
-    let output = await wallet_run_command(wallet, "get-balance");
+    let output = await wallet_run_command(wallet, "get-balance", 180);
     let parse = output.buffer.match(/Available balance: (\d*.\d*) T/);
     expect(parse, "Parsing the output buffer failed").to.not.be.null;
     expect(parseFloat(parse[1])).to.be.greaterThanOrEqual(amount / 1000000);
@@ -3538,7 +3539,8 @@ When(
     let dest_pubkey = this.getWalletPubkey(receiver);
     await wallet_run_command(
       wallet,
-      `send-tari ${amount} ${dest_pubkey} test message`
+      `send-tari ${amount} ${dest_pubkey} test message`,
+        180
     );
     // await wallet.sendTari(dest_pubkey, amount, "test message");
   }
@@ -3552,7 +3554,8 @@ When(
     let dest_pubkey = this.getWalletPubkey(receiver);
     await wallet_run_command(
       wallet,
-      `send-one-sided ${amount} ${dest_pubkey} test message`
+      `send-one-sided ${amount} ${dest_pubkey} test message`,
+        180
     );
     // await wallet.sendOneSided(dest_pubkey, amount, "test message");
   }
@@ -3566,7 +3569,8 @@ Then(
     let dest_pubkey = this.getWalletPubkey(receiver);
     await wallet_run_command(
       wallet,
-      `make-it-rain ${freq} ${duration} ${amount} ${amount_inc} now ${dest_pubkey} negotiated test message`
+      `make-it-rain ${freq} ${duration} ${amount} ${amount_inc} now ${dest_pubkey} negotiated test message`,
+        300
     );
   }
 );
@@ -3589,7 +3593,8 @@ When(
     let wallet = this.getWallet(name);
     await wallet_run_command(
       wallet,
-      `coin-split ${amount_per_coin} ${number_of_coins}`
+      `coin-split ${amount_per_coin} ${number_of_coins}`,
+        180
     );
   }
 );
@@ -3600,7 +3605,7 @@ When(
   async function (node, name) {
     let wallet = this.getWallet(name);
     let peer = this.getNode(node).peerAddress().split("::")[0];
-    let output = await wallet_run_command(wallet, `discover-peer ${peer}`);
+    let output = await wallet_run_command(wallet, `discover-peer ${peer}`, 120);
     let parse = output.buffer.match(/Discovery succeeded/);
     expect(parse, "Parsing the output buffer failed").to.not.be.null;
   }
@@ -3613,7 +3618,7 @@ When(
     await sleep(5000);
     let wallet = this.getWallet(name);
     let pubkey = this.getNode(who).peerAddress().split("::")[0];
-    let output = await wallet_run_command(wallet, `whois ${pubkey}`);
+    let output = await wallet_run_command(wallet, `whois ${pubkey}`, 20);
     let parse = output.buffer.match(/Public Key: (.+)\n/);
     expect(parse, "Parsing the output buffer failed").to.not.be.null;
     expect(parse[1]).to.be.equal(pubkey);

--- a/integration_tests/helpers/walletProcess.js
+++ b/integration_tests/helpers/walletProcess.js
@@ -59,7 +59,7 @@ class WalletProcess {
     this.peerSeeds = addresses;
   }
 
-  run(cmd, args, saveFile, input_buffer, output) {
+  run(cmd, args, saveFile, input_buffer, output, waitForCommand) {
     let thePromise = new Promise((resolve, reject) => {
       if (!fs.existsSync(this.baseDir)) {
         fs.mkdirSync(this.baseDir, { recursive: true });
@@ -110,16 +110,20 @@ class WalletProcess {
         ps.stdin.write(input_buffer);
       }
       ps.stdout.on("data", (data) => {
-        //console.log(`stdout: ${data}`);
+        //console.log(`\nstdout: ${data}`);
         if (output !== undefined && output.buffer !== undefined) {
           output.buffer += data;
         }
         fs.appendFileSync(`${this.baseDir}/log/stdout.log`, data.toString());
         if (
-          (!this.recoverWallet &&
-            data.toString().match(/Starting grpc server/)) ||
-          (this.recoverWallet &&
-            data.toString().match(/Initializing logging according/))
+          (!waitForCommand &&
+            data.toString().match(/Tari Console Wallet running/i)) ||
+          (waitForCommand &&
+            data
+              .toString()
+              .match(
+                /(?=.*Tari Console Wallet running)(?=.*Command mode completed)/gim
+              ))
         ) {
           resolve(ps);
         }
@@ -144,7 +148,6 @@ class WalletProcess {
       });
       expect(ps.error).to.be.undefined;
       this.ps = ps;
-      resolve(ps);
     });
     return thePromise;
   }
@@ -244,7 +247,7 @@ class WalletProcess {
     }
     let output = { buffer: "" };
     // In case we killed the wallet fast send enter. Because it will ask for the logs again (e.g. whois test)
-    await this.run(await this.compile(), args, true, "\n", output);
+    await this.run(await this.compile(), args, true, "\n", output, true);
     return output;
   }
 


### PR DESCRIPTION
Description
---
- Fixed an issue with the wallet startup promise not resolving consistently (_... a broken fix introduced by me in #3534_).
- Added explicit startup markers (`Tari Console Wallet running...`) in the console wallet that will print to stdout for the sake of cucumber tests. These are scraped to indicate the wallet startup state.
- Improved flaky test `Scenario: As a user I want to discover-peer via command line`
- Added variable time out settings for `wallet.runCommand(command)` for the different `As a user I ... via command line` steps according to the higher-level logic.

Motivation and Context
---
Cucumber tests were not running successfully.

How Has This Been Tested?
---
Cucumber:
- `npm test -- --profile ci --name "via command line"`
- `npm test -- --tags "not @long-running and not @broken"`

Sample stdout output:
``` rust
Installing new config file at C:\Users\pluto\Documents\Code\@tari-project\integration_tests\temp\base_nodes\202111121208\Wallet5529-WALLET\config\config.toml
Initializing logging according to "C:\\Users\\pluto\\Documents\\Code\\@tari-project\\integration_tests\\log4rs\\wallet.yml"
Tari Console Wallet running... (gRPC mode started)
Initializing logging according to "C:\\Users\\pluto\\Documents\\Code\\@tari-project\\integration_tests\\log4rs\\wallet.yml"
Tari Console Wallet running... (Command mode started)
==============
Command Runner
==============

1. discover-peer e88343a9b0d734a0ed98e0e3b558493d91220216599b676de12c76a2ce7ef369

Waiting for connectivity... ✅
🌎 Peer discovery started.
⚡️ Discovery succeeded in 77ms.
[05696c85b9a0ab4b] PK=e88343a9b0d734a0ed98e0e3b558493d91220216599b676de12c76a2ce7ef369 (/ip4/127.0.0.1/tcp/5537) - . Type: BASE_NODE. User agent: tari/basenode/0.21.0. Last connected at 2021-11-12 10:08:51.
Tari Console Wallet running... (Command mode completed)
Tari Console Wallet running... (gRPC mode started)
>>>> End of ./temp/base_nodes/202111121208/Wallet5529-WALLET/log/stdout.log
```
``` rust
Installing new config file at C:\Users\pluto\Documents\Code\@tari-project\integration_tests\temp\base_nodes\202111121210\Wallet5586-WALLET\config\config.toml
Initializing logging according to "C:\\Users\\pluto\\Documents\\Code\\@tari-project\\integration_tests\\log4rs\\wallet.yml"
Tari Console Wallet running... (gRPC mode started)
Initializing logging according to "C:\\Users\\pluto\\Documents\\Code\\@tari-project\\integration_tests\\log4rs\\wallet.yml"
Tari Console Wallet running... (Command mode started)
==============
Command Runner
==============

1. set-custom-base-node a637ce92c0e07ff9fc39a023a1b6530d1873be782cc27e258995af27bb5d3101 /ip4/127.0.0.1/tcp/5581

Setting base node peer...
a637ce92c0e07ff9fc39a023a1b6530d1873be782cc27e258995af27bb5d3101::/ip4/127.0.0.1/tcp/5581
Custom base node peer saved in wallet database.
Tari Console Wallet running... (Command mode completed)
Tari Console Wallet running... (gRPC mode started)
Initializing logging according to "C:\\Users\\pluto\\Documents\\Code\\@tari-project\\integration_tests\\log4rs\\wallet.yml"
Tari Console Wallet running... (Command mode started)
==============
Command Runner
==============

1. clear-custom-base-node 

Custom base node peer cleared from wallet database.
Tari Console Wallet running... (Command mode completed)
Tari Console Wallet running... (gRPC mode started)
>>>> End of ./temp/base_nodes/202111121210/Wallet5586-WALLET/log/stdout.log
```
