### PR TITLE
feat: implement multiple read single write for sqlite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1213,6 +1213,7 @@ dependencies = [
  "num-bigint 0.2.6",
  "num-integer",
  "num-traits 0.2.14",
+ "r2d2",
  "serde_json",
 ]
 
@@ -3277,6 +3278,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "r2d2"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "545c5bc2b880973c9c10e4067418407a0ccaa3091781d1671d46eb35107cb26f"
+dependencies = [
+ "log",
+ "parking_lot 0.11.2",
+ "scheduled-thread-pool",
+]
+
+[[package]]
 name = "radix_trie"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3737,6 +3749,15 @@ checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
 dependencies = [
  "lazy_static 1.4.0",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "scheduled-thread-pool"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6f74fd1204073fa02d5d5d68bec8021be4c38690b61264b2fdb48083d0e7d7"
+dependencies = [
+ "parking_lot 0.11.2",
 ]
 
 [[package]]
@@ -4330,7 +4351,7 @@ dependencies = [
  "config",
  "either",
  "futures 0.3.17",
- "log 0.4.14",
+ "log",
  "log-mdc",
  "num_cpus",
  "opentelemetry",
@@ -4410,6 +4431,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tari_common_sqlite"
+version = "0.21.0"
+dependencies = [
+ "diesel",
+ "log",
+ "thiserror",
+]
+
+[[package]]
 name = "tari_common_types"
 version = "0.21.0"
 dependencies = [
@@ -4441,7 +4471,7 @@ dependencies = [
  "futures 0.3.17",
  "lazy_static 1.4.0",
  "lmdb-zero",
- "log 0.4.14",
+ "log",
  "log-mdc",
  "multiaddr",
  "nom 5.1.2",
@@ -4493,7 +4523,7 @@ dependencies = [
  "lazy_static 1.4.0",
  "libsqlite3-sys",
  "lmdb-zero",
- "log 0.4.14",
+ "log",
  "log-mdc",
  "petgraph",
  "pin-project 0.4.28",
@@ -4599,7 +4629,7 @@ dependencies = [
  "integer-encoding 3.0.2",
  "lazy_static 1.4.0",
  "lmdb-zero",
- "log 0.4.14",
+ "log",
  "log-mdc",
  "monero",
  "newtype-ops",
@@ -4975,6 +5005,7 @@ dependencies = [
  "serde 1.0.130",
  "serde_json",
  "tari_common",
+ "tari_common_sqlite",
  "tari_common_types",
  "tari_comms",
  "tari_comms_dht",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "comms",
     "comms/dht",
     "comms/rpc_macros",
+    "common_sqlite",
     "infrastructure/shutdown",
     "infrastructure/storage",
     "infrastructure/test_utils",

--- a/applications/tari_console_wallet/src/init/mod.rs
+++ b/applications/tari_console_wallet/src/init/mod.rs
@@ -272,7 +272,7 @@ pub async fn init_wallet(
     // test encryption by initializing with no passphrase...
     let db_path = config.console_wallet_db_file.clone();
 
-    let result = initialize_sqlite_database_backends(db_path.clone(), None);
+    let result = initialize_sqlite_database_backends(db_path.clone(), None, config.wallet_connection_manager_pool_size);
     let (backends, wallet_encrypted) = match result {
         Ok(backends) => {
             // wallet is not encrypted
@@ -281,7 +281,8 @@ pub async fn init_wallet(
         Err(WalletStorageError::NoPasswordError) => {
             // get supplied or prompt password
             let passphrase = get_or_prompt_password(arg_password.clone(), config.console_wallet_password.clone())?;
-            let backends = initialize_sqlite_database_backends(db_path, passphrase)?;
+            let backends =
+                initialize_sqlite_database_backends(db_path, passphrase, config.wallet_connection_manager_pool_size)?;
 
             (backends, true)
         },

--- a/base_layer/wallet/Cargo.toml
+++ b/base_layer/wallet/Cargo.toml
@@ -17,6 +17,7 @@ tari_p2p = { version = "^0.21", path = "../p2p", features = ["auto-update"] }
 tari_service_framework = { version = "^0.21", path = "../service_framework" }
 tari_shutdown = { version = "^0.21", path = "../../infrastructure/shutdown" }
 tari_storage = { version = "^0.21", path = "../../infrastructure/storage" }
+tari_common_sqlite = { path = "../../common_sqlite" }
 
 aes-gcm = "^0.8"
 async-trait = "0.1.50"

--- a/base_layer/wallet/src/contacts_service/error.rs
+++ b/base_layer/wallet/src/contacts_service/error.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::contacts_service::storage::database::DbKey;
+use crate::{contacts_service::storage::database::DbKey, error::WalletStorageError};
 use diesel::result::Error as DieselError;
 use tari_service_framework::reply_channel::TransportChannelError;
 use thiserror::Error;
@@ -50,8 +50,8 @@ pub enum ContactsServiceStorageError {
     ValueNotFound(DbKey),
     #[error("Unexpected result error: `{0}`")]
     UnexpectedResult(String),
-    #[error("R2d2 error")]
-    R2d2Error,
+    #[error("Diesel R2d2 error: `{0}`")]
+    DieselR2d2Error(#[from] WalletStorageError),
     #[error("Diesel error: `{0}`")]
     DieselError(#[from] DieselError),
     #[error("Diesel connection error: `{0}`")]

--- a/base_layer/wallet/src/contacts_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/contacts_service/storage/sqlite_db.rs
@@ -20,19 +20,22 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use std::convert::TryFrom;
+
+use diesel::{prelude::*, result::Error as DieselError, SqliteConnection};
+use tari_crypto::tari_utilities::ByteArray;
+
+use tari_common_types::types::PublicKey;
+
 use crate::{
     contacts_service::{
         error::ContactsServiceStorageError,
         storage::database::{Contact, ContactsBackend, DbKey, DbKeyValuePair, DbValue, WriteOperation},
     },
     schema::contacts,
-    storage::sqlite_utilities::WalletDbConnection,
+    storage::sqlite_utilities::wallet_db_connection::WalletDbConnection,
     util::diesel_ext::ExpectedRowsExtension,
 };
-use diesel::{prelude::*, result::Error as DieselError, SqliteConnection};
-use std::convert::TryFrom;
-use tari_common_types::types::PublicKey;
-use tari_crypto::tari_utilities::ByteArray;
 
 /// A Sqlite backend for the Output Manager Service. The Backend is accessed via a connection pool to the Sqlite file.
 #[derive(Clone)]
@@ -47,10 +50,10 @@ impl ContactsServiceSqliteDatabase {
 
 impl ContactsBackend for ContactsServiceSqliteDatabase {
     fn fetch(&self, key: &DbKey) -> Result<Option<DbValue>, ContactsServiceStorageError> {
-        let conn = self.database_connection.acquire_lock();
+        let conn = self.database_connection.get_pooled_connection()?;
 
         let result = match key {
-            DbKey::Contact(pk) => match ContactSql::find(&pk.to_vec(), &(*conn)) {
+            DbKey::Contact(pk) => match ContactSql::find(&pk.to_vec(), &conn) {
                 Ok(c) => Some(DbValue::Contact(Box::new(Contact::try_from(c)?))),
                 Err(ContactsServiceStorageError::DieselError(DieselError::NotFound)) => None,
                 Err(e) => return Err(e),
@@ -67,13 +70,13 @@ impl ContactsBackend for ContactsServiceSqliteDatabase {
     }
 
     fn write(&self, op: WriteOperation) -> Result<Option<DbValue>, ContactsServiceStorageError> {
-        let conn = self.database_connection.acquire_lock();
+        let conn = self.database_connection.get_pooled_connection()?;
 
         match op {
             WriteOperation::Upsert(kvp) => match kvp {
-                DbKeyValuePair::Contact(k, c) => match ContactSql::find(&k.to_vec(), &(*conn)) {
+                DbKeyValuePair::Contact(k, c) => match ContactSql::find(&k.to_vec(), &conn) {
                     Ok(found_c) => {
-                        let _ = found_c.update(UpdateContact { alias: Some(c.alias) }, &(*conn))?;
+                        let _ = found_c.update(UpdateContact { alias: Some(c.alias) }, &conn)?;
                     },
                     Err(_) => {
                         ContactSql::from(c).commit(&conn)?;
@@ -81,7 +84,7 @@ impl ContactsBackend for ContactsServiceSqliteDatabase {
                 },
             },
             WriteOperation::Remove(k) => match k {
-                DbKey::Contact(k) => match ContactSql::find(&k.to_vec(), &(*conn)) {
+                DbKey::Contact(k) => match ContactSql::find(&k.to_vec(), &conn) {
                     Ok(c) => {
                         c.delete(&conn)?;
                         return Ok(Some(DbValue::Contact(Box::new(Contact::try_from(c)?))));
@@ -181,19 +184,22 @@ pub struct UpdateContact {
 
 #[cfg(test)]
 mod test {
-    use crate::contacts_service::storage::{
-        database::Contact,
-        sqlite_db::{ContactSql, UpdateContact},
-    };
+    use std::convert::TryFrom;
+
     use diesel::{Connection, SqliteConnection};
     use rand::rngs::OsRng;
-    use std::convert::TryFrom;
-    use tari_common_types::types::{PrivateKey, PublicKey};
     use tari_crypto::{
         keys::{PublicKey as PublicKeyTrait, SecretKey as SecretKeyTrait},
         tari_utilities::ByteArray,
     };
+
+    use tari_common_types::types::{PrivateKey, PublicKey};
     use tari_test_utils::{paths::with_temp_dir, random::string};
+
+    use crate::contacts_service::storage::{
+        database::Contact,
+        sqlite_db::{ContactSql, UpdateContact},
+    };
 
     #[test]
     fn test_crud() {

--- a/base_layer/wallet/src/error.rs
+++ b/base_layer/wallet/src/error.rs
@@ -32,6 +32,7 @@ use diesel::result::Error as DieselError;
 use log::SetLoggerError;
 use serde_json::Error as SerdeJsonError;
 use tari_common::exit_codes::ExitCodes;
+use tari_common_sqlite::error::SqliteStorageError;
 use tari_comms::{
     connectivity::ConnectivityError,
     multiaddr,
@@ -113,8 +114,8 @@ pub enum WalletStorageError {
     DbPathDoesNotExist,
     #[error("Serde json error: `{0}`")]
     SerdeJsonError(#[from] SerdeJsonError),
-    #[error("R2d2 error")]
-    R2d2Error,
+    #[error("Diesel R2d2 error: `{0}`")]
+    DieselR2d2Error(#[from] SqliteStorageError),
     #[error("Diesel error: `{0}`")]
     DieselError(#[from] DieselError),
     #[error("Diesel connection error: `{0}`")]
@@ -167,5 +168,11 @@ impl From<WalletStorageError> for ExitCodes {
             InvalidPassphrase => ExitCodes::IncorrectPassword,
             e => ExitCodes::WalletError(e.to_string()),
         }
+    }
+}
+
+impl PartialEq for WalletStorageError {
+    fn eq(&self, other: &Self) -> bool {
+        self == other
     }
 }

--- a/base_layer/wallet/src/output_manager_service/error.rs
+++ b/base_layer/wallet/src/output_manager_service/error.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::base_node_service::error::BaseNodeServiceError;
+use crate::{base_node_service::error::BaseNodeServiceError, error::WalletStorageError};
 use diesel::result::Error as DieselError;
 use tari_common::exit_codes::ExitCodes;
 use tari_comms::{connectivity::ConnectivityError, peer_manager::node_id::NodeIdError, protocol::rpc::RpcError};
@@ -142,8 +142,8 @@ pub enum OutputManagerStorageError {
     OutputAlreadySpent,
     #[error("Key Manager not initialized")]
     KeyManagerNotInitialized,
-    #[error("R2d2 error")]
-    R2d2Error,
+    #[error("Diesel R2d2 error: `{0}`")]
+    DieselR2d2Error(#[from] WalletStorageError),
     #[error("Transaction error: `{0}`")]
     TransactionError(#[from] TransactionError),
     #[error("Diesel error: `{0}`")]

--- a/base_layer/wallet/src/output_manager_service/storage/sqlite_db/mod.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/sqlite_db/mod.rs
@@ -20,6 +20,34 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use std::{
+    convert::{TryFrom, TryInto},
+    str::from_utf8,
+    sync::{Arc, RwLock},
+};
+
+use aes_gcm::Aes256Gcm;
+use chrono::{NaiveDateTime, Utc};
+use diesel::{prelude::*, result::Error as DieselError, SqliteConnection};
+use log::*;
+use tari_crypto::{
+    script::{ExecutionStack, TariScript},
+    tari_utilities::{
+        hex::{from_hex, Hex},
+        ByteArray,
+    },
+};
+use tokio::time::Instant;
+
+pub use new_output_sql::NewOutputSql;
+pub use output_sql::OutputSql;
+use tari_common_types::{
+    transaction::TxId,
+    types::{Commitment, PrivateKey},
+};
+use tari_core::transactions::transaction::TransactionOutput;
+use tari_key_manager::cipher_seed::CipherSeed;
+
 use crate::{
     output_manager_service::{
         error::OutputManagerStorageError,
@@ -30,39 +58,15 @@ use crate::{
         },
     },
     schema::{key_manager_states, known_one_sided_payment_scripts, outputs},
-    storage::sqlite_utilities::WalletDbConnection,
+    storage::sqlite_utilities::wallet_db_connection::WalletDbConnection,
     util::{
         diesel_ext::ExpectedRowsExtension,
         encryption::{decrypt_bytes_integral_nonce, encrypt_bytes_integral_nonce, Encryptable},
     },
 };
-use aes_gcm::Aes256Gcm;
-use chrono::{NaiveDateTime, Utc};
-use diesel::{prelude::*, result::Error as DieselError, SqliteConnection};
-use log::*;
-use std::{
-    convert::{TryFrom, TryInto},
-    str::from_utf8,
-    sync::{Arc, RwLock},
-};
-use tari_common_types::{
-    transaction::TxId,
-    types::{Commitment, PrivateKey},
-};
-use tari_core::transactions::transaction::TransactionOutput;
-use tari_crypto::{
-    script::{ExecutionStack, TariScript},
-    tari_utilities::{
-        hex::{from_hex, Hex},
-        ByteArray,
-    },
-};
-use tari_key_manager::cipher_seed::CipherSeed;
-use tokio::time::Instant;
+
 mod new_output_sql;
-pub use new_output_sql::NewOutputSql;
 mod output_sql;
-pub use output_sql::OutputSql;
 
 const LOG_TARGET: &str = "wallet::output_manager_service::database::sqlite_db";
 
@@ -102,23 +106,23 @@ impl OutputManagerSqliteDatabase {
     fn insert(&self, key_value_pair: DbKeyValuePair, conn: &SqliteConnection) -> Result<(), OutputManagerStorageError> {
         match key_value_pair {
             DbKeyValuePair::UnspentOutput(c, o) => {
-                if OutputSql::find_by_commitment_and_cancelled(&c.to_vec(), false, &(*conn)).is_ok() {
+                if OutputSql::find_by_commitment_and_cancelled(&c.to_vec(), false, conn).is_ok() {
                     return Err(OutputManagerStorageError::DuplicateOutput);
                 }
                 let mut new_output = NewOutputSql::new(*o, OutputStatus::Unspent, None, None)?;
                 self.encrypt_if_necessary(&mut new_output)?;
-                new_output.commit(&(*conn))?
+                new_output.commit(conn)?
             },
             DbKeyValuePair::UnspentOutputWithTxId(c, (tx_id, o)) => {
-                if OutputSql::find_by_commitment_and_cancelled(&c.to_vec(), false, &(*conn)).is_ok() {
+                if OutputSql::find_by_commitment_and_cancelled(&c.to_vec(), false, conn).is_ok() {
                     return Err(OutputManagerStorageError::DuplicateOutput);
                 }
                 let mut new_output = NewOutputSql::new(*o, OutputStatus::Unspent, Some(tx_id), None)?;
                 self.encrypt_if_necessary(&mut new_output)?;
-                new_output.commit(&(*conn))?
+                new_output.commit(conn)?
             },
             DbKeyValuePair::OutputToBeReceived(c, (tx_id, o, coinbase_block_height)) => {
-                if OutputSql::find_by_commitment_and_cancelled(&c.to_vec(), false, &(*conn)).is_ok() {
+                if OutputSql::find_by_commitment_and_cancelled(&c.to_vec(), false, conn).is_ok() {
                     return Err(OutputManagerStorageError::DuplicateOutput);
                 }
                 let mut new_output = NewOutputSql::new(
@@ -128,17 +132,17 @@ impl OutputManagerSqliteDatabase {
                     coinbase_block_height,
                 )?;
                 self.encrypt_if_necessary(&mut new_output)?;
-                new_output.commit(&(*conn))?
+                new_output.commit(conn)?
             },
             DbKeyValuePair::KeyManagerState(km) => {
                 let mut km_sql = NewKeyManagerStateSql::from(km);
                 self.encrypt_if_necessary(&mut km_sql)?;
-                km_sql.commit(&(*conn))?
+                km_sql.commit(conn)?
             },
             DbKeyValuePair::KnownOneSidedPaymentScripts(script) => {
                 let mut script_sql = KnownOneSidedPaymentScriptSql::from(script);
                 self.encrypt_if_necessary(&mut script_sql)?;
-                script_sql.commit(&(*conn))?
+                script_sql.commit(conn)?
             },
         }
         Ok(())
@@ -149,11 +153,11 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
     #[allow(clippy::cognitive_complexity)]
     fn fetch(&self, key: &DbKey) -> Result<Option<DbValue>, OutputManagerStorageError> {
         let start = Instant::now();
-        let conn = self.database_connection.acquire_lock();
+        let conn = self.database_connection.get_pooled_connection()?;
         let acquire_lock = start.elapsed();
 
         let result = match key {
-            DbKey::SpentOutput(k) => match OutputSql::find_status(&k.to_vec(), OutputStatus::Spent, &(*conn)) {
+            DbKey::SpentOutput(k) => match OutputSql::find_status(&k.to_vec(), OutputStatus::Spent, &conn) {
                 Ok(mut o) => {
                     self.decrypt_if_necessary(&mut o)?;
                     Some(DbValue::SpentOutput(Box::new(DbUnblindedOutput::try_from(o)?)))
@@ -166,7 +170,7 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
                     None
                 },
             },
-            DbKey::UnspentOutput(k) => match OutputSql::find_status(&k.to_vec(), OutputStatus::Unspent, &(*conn)) {
+            DbKey::UnspentOutput(k) => match OutputSql::find_status(&k.to_vec(), OutputStatus::Unspent, &conn) {
                 Ok(mut o) => {
                     self.decrypt_if_necessary(&mut o)?;
                     Some(DbValue::UnspentOutput(Box::new(DbUnblindedOutput::try_from(o)?)))
@@ -180,7 +184,7 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
                 },
             },
             DbKey::AnyOutputByCommitment(commitment) => {
-                match OutputSql::find_by_commitment(&commitment.to_vec(), &(*conn)) {
+                match OutputSql::find_by_commitment(&commitment.to_vec(), &conn) {
                     Ok(mut o) => {
                         self.decrypt_if_necessary(&mut o)?;
                         Some(DbValue::SpentOutput(Box::new(DbUnblindedOutput::try_from(o)?)))
@@ -195,7 +199,7 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
                 }
             },
             DbKey::OutputsByTxIdAndStatus(tx_id, status) => {
-                let mut outputs = OutputSql::find_by_tx_id_and_status(*tx_id, *status, &(*conn))?;
+                let mut outputs = OutputSql::find_by_tx_id_and_status(*tx_id, *status, &conn)?;
                 for o in outputs.iter_mut() {
                     self.decrypt_if_necessary(o)?;
                 }
@@ -207,7 +211,7 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
                 ))
             },
             DbKey::UnspentOutputs => {
-                let mut outputs = OutputSql::index_status(OutputStatus::Unspent, &(*conn))?;
+                let mut outputs = OutputSql::index_status(OutputStatus::Unspent, &conn)?;
                 for o in outputs.iter_mut() {
                     self.decrypt_if_necessary(o)?;
                 }
@@ -220,7 +224,7 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
                 ))
             },
             DbKey::SpentOutputs => {
-                let mut outputs = OutputSql::index_status(OutputStatus::Spent, &(*conn))?;
+                let mut outputs = OutputSql::index_status(OutputStatus::Spent, &conn)?;
                 for o in outputs.iter_mut() {
                     self.decrypt_if_necessary(o)?;
                 }
@@ -233,7 +237,7 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
                 ))
             },
             DbKey::TimeLockedUnspentOutputs(tip) => {
-                let mut outputs = OutputSql::index_time_locked(*tip, &(*conn))?;
+                let mut outputs = OutputSql::index_time_locked(*tip, &conn)?;
                 for o in outputs.iter_mut() {
                     self.decrypt_if_necessary(o)?;
                 }
@@ -246,7 +250,7 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
                 ))
             },
             DbKey::KeyManagerState => {
-                match KeyManagerStateSql::get_state(&(*conn)).ok() {
+                match KeyManagerStateSql::get_state(&conn).ok() {
                     None => None,
                     Some(mut km) => {
                         self.decrypt_if_necessary(&mut km)?;
@@ -260,7 +264,7 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
                 }
             },
             DbKey::InvalidOutputs => {
-                let mut outputs = OutputSql::index_status(OutputStatus::Invalid, &(*conn))?;
+                let mut outputs = OutputSql::index_status(OutputStatus::Invalid, &conn)?;
                 for o in outputs.iter_mut() {
                     self.decrypt_if_necessary(o)?;
                 }
@@ -273,7 +277,7 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
                 ))
             },
             DbKey::KnownOneSidedPaymentScripts => {
-                let mut known_one_sided_payment_scripts = KnownOneSidedPaymentScriptSql::index(&(*conn))?;
+                let mut known_one_sided_payment_scripts = KnownOneSidedPaymentScriptSql::index(&conn)?;
                 for script in known_one_sided_payment_scripts.iter_mut() {
                     self.decrypt_if_necessary(script)?;
                 }
@@ -286,33 +290,37 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
                 ))
             },
         };
-        trace!(
-            target: LOG_TARGET,
-            "sqlite profile - fetch '{}': lock {} + db_op {} = {} ms",
-            key,
-            acquire_lock.as_millis(),
-            (start.elapsed() - acquire_lock).as_millis(),
-            start.elapsed().as_millis()
-        );
+        if start.elapsed().as_millis() > 0 {
+            trace!(
+                target: LOG_TARGET,
+                "sqlite profile - fetch '{}': lock {} + db_op {} = {} ms",
+                key,
+                acquire_lock.as_millis(),
+                (start.elapsed() - acquire_lock).as_millis(),
+                start.elapsed().as_millis()
+            );
+        }
 
         Ok(result)
     }
 
     fn fetch_mined_unspent_outputs(&self) -> Result<Vec<DbUnblindedOutput>, OutputManagerStorageError> {
         let start = Instant::now();
-        let conn = self.database_connection.acquire_lock();
+        let conn = self.database_connection.get_pooled_connection()?;
         let acquire_lock = start.elapsed();
-        let mut outputs = OutputSql::index_marked_deleted_in_block_is_null(&(*conn))?;
+        let mut outputs = OutputSql::index_marked_deleted_in_block_is_null(&conn)?;
         for output in outputs.iter_mut() {
             self.decrypt_if_necessary(output)?;
         }
-        trace!(
-            target: LOG_TARGET,
-            "sqlite profile - fetch_mined_unspent_outputs: lock {} + db_op {} = {} ms",
-            acquire_lock.as_millis(),
-            (start.elapsed() - acquire_lock).as_millis(),
-            start.elapsed().as_millis()
-        );
+        if start.elapsed().as_millis() > 0 {
+            trace!(
+                target: LOG_TARGET,
+                "sqlite profile - fetch_mined_unspent_outputs: lock {} + db_op {} = {} ms",
+                acquire_lock.as_millis(),
+                (start.elapsed() - acquire_lock).as_millis(),
+                start.elapsed().as_millis()
+            );
+        }
 
         outputs
             .into_iter()
@@ -322,19 +330,21 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
 
     fn fetch_unconfirmed_outputs(&self) -> Result<Vec<DbUnblindedOutput>, OutputManagerStorageError> {
         let start = Instant::now();
-        let conn = self.database_connection.acquire_lock();
+        let conn = self.database_connection.get_pooled_connection()?;
         let acquire_lock = start.elapsed();
-        let mut outputs = OutputSql::index_unconfirmed(&(*conn))?;
+        let mut outputs = OutputSql::index_unconfirmed(&conn)?;
         for output in outputs.iter_mut() {
             self.decrypt_if_necessary(output)?;
         }
-        trace!(
-            target: LOG_TARGET,
-            "sqlite profile - fetch_unconfirmed_outputs: lock {} + db_op {} = {} ms",
-            acquire_lock.as_millis(),
-            (start.elapsed() - acquire_lock).as_millis(),
-            start.elapsed().as_millis()
-        );
+        if start.elapsed().as_millis() > 0 {
+            trace!(
+                target: LOG_TARGET,
+                "sqlite profile - fetch_unconfirmed_outputs: lock {} + db_op {} = {} ms",
+                acquire_lock.as_millis(),
+                (start.elapsed() - acquire_lock).as_millis(),
+                start.elapsed().as_millis()
+            );
+        }
 
         outputs
             .into_iter()
@@ -344,7 +354,7 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
 
     fn write(&self, op: WriteOperation) -> Result<Option<DbValue>, OutputManagerStorageError> {
         let start = Instant::now();
-        let conn = self.database_connection.acquire_lock();
+        let conn = self.database_connection.get_pooled_connection()?;
         let acquire_lock = start.elapsed();
 
         match op {
@@ -352,17 +362,19 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
             WriteOperation::Remove(k) => match k {
                 DbKey::AnyOutputByCommitment(commitment) => {
                     // Used by coinbase when mining.
-                    match OutputSql::find_by_commitment(&commitment.to_vec(), &(*conn)) {
+                    match OutputSql::find_by_commitment(&commitment.to_vec(), &conn) {
                         Ok(mut o) => {
-                            o.delete(&(*conn))?;
+                            o.delete(&conn)?;
                             self.decrypt_if_necessary(&mut o)?;
-                            trace!(
-                                target: LOG_TARGET,
-                                "sqlite profile - write Remove: lock {} + db_op {} = {} ms",
-                                acquire_lock.as_millis(),
-                                (start.elapsed() - acquire_lock).as_millis(),
-                                start.elapsed().as_millis()
-                            );
+                            if start.elapsed().as_millis() > 0 {
+                                trace!(
+                                    target: LOG_TARGET,
+                                    "sqlite profile - write Remove: lock {} + db_op {} = {} ms",
+                                    acquire_lock.as_millis(),
+                                    (start.elapsed() - acquire_lock).as_millis(),
+                                    start.elapsed().as_millis()
+                                );
+                            }
                             return Ok(Some(DbValue::AnyOutput(Box::new(DbUnblindedOutput::try_from(o)?))));
                         },
                         Err(e) => {
@@ -384,20 +396,22 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
                 DbKey::OutputsByTxIdAndStatus(_, _) => return Err(OutputManagerStorageError::OperationNotSupported),
             },
         }
-        trace!(
-            target: LOG_TARGET,
-            "sqlite profile - write Insert: lock {} + db_op {} = {} ms",
-            acquire_lock.as_millis(),
-            (start.elapsed() - acquire_lock).as_millis(),
-            start.elapsed().as_millis()
-        );
+        if start.elapsed().as_millis() > 0 {
+            trace!(
+                target: LOG_TARGET,
+                "sqlite profile - write Insert: lock {} + db_op {} = {} ms",
+                acquire_lock.as_millis(),
+                (start.elapsed() - acquire_lock).as_millis(),
+                start.elapsed().as_millis()
+            );
+        }
 
         Ok(None)
     }
 
     fn fetch_pending_incoming_outputs(&self) -> Result<Vec<DbUnblindedOutput>, OutputManagerStorageError> {
         let start = Instant::now();
-        let conn = self.database_connection.acquire_lock();
+        let conn = self.database_connection.get_pooled_connection()?;
         let acquire_lock = start.elapsed();
 
         let mut outputs = OutputSql::index_status(OutputStatus::EncumberedToBeReceived, &conn)?;
@@ -409,13 +423,15 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
         for o in outputs.iter_mut() {
             self.decrypt_if_necessary(o)?;
         }
-        trace!(
-            target: LOG_TARGET,
-            "sqlite profile - fetch_pending_incoming_outputs: lock {} + db_op {} = {} ms",
-            acquire_lock.as_millis(),
-            (start.elapsed() - acquire_lock).as_millis(),
-            start.elapsed().as_millis()
-        );
+        if start.elapsed().as_millis() > 0 {
+            trace!(
+                target: LOG_TARGET,
+                "sqlite profile - fetch_pending_incoming_outputs: lock {} + db_op {} = {} ms",
+                acquire_lock.as_millis(),
+                (start.elapsed() - acquire_lock).as_millis(),
+                start.elapsed().as_millis()
+            );
+        }
         outputs
             .iter()
             .map(|o| DbUnblindedOutput::try_from(o.clone()))
@@ -431,7 +447,7 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
         confirmed: bool,
     ) -> Result<(), OutputManagerStorageError> {
         let start = Instant::now();
-        let conn = self.database_connection.acquire_lock();
+        let conn = self.database_connection.get_pooled_connection()?;
         let acquire_lock = start.elapsed();
         let status = if confirmed {
             OutputStatus::Unspent as i32
@@ -450,22 +466,24 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
                 outputs::mined_mmr_position.eq(mmr_position as i64),
                 outputs::status.eq(status),
             ))
-            .execute(&(*conn))
+            .execute(&conn)
             .num_rows_affected_or_not_found(1)?;
-        trace!(
-            target: LOG_TARGET,
-            "sqlite profile - set_received_output_mined_height: lock {} + db_op {} = {} ms",
-            acquire_lock.as_millis(),
-            (start.elapsed() - acquire_lock).as_millis(),
-            start.elapsed().as_millis()
-        );
+        if start.elapsed().as_millis() > 0 {
+            trace!(
+                target: LOG_TARGET,
+                "sqlite profile - set_received_output_mined_height: lock {} + db_op {} = {} ms",
+                acquire_lock.as_millis(),
+                (start.elapsed() - acquire_lock).as_millis(),
+                start.elapsed().as_millis()
+            );
+        }
 
         Ok(())
     }
 
     fn set_output_to_unmined(&self, hash: Vec<u8>) -> Result<(), OutputManagerStorageError> {
         let start = Instant::now();
-        let conn = self.database_connection.acquire_lock();
+        let conn = self.database_connection.get_pooled_connection()?;
         let acquire_lock = start.elapsed();
         // Only allow updating of non-deleted utxos
         diesel::update(outputs::table.filter(outputs::hash.eq(hash).and(outputs::marked_deleted_at_height.is_null())))
@@ -475,22 +493,24 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
                 outputs::mined_mmr_position.eq::<Option<i64>>(None),
                 outputs::status.eq(OutputStatus::Invalid as i32),
             ))
-            .execute(&(*conn))
+            .execute(&conn)
             .num_rows_affected_or_not_found(1)?;
-        trace!(
-            target: LOG_TARGET,
-            "sqlite profile - set_output_to_unmined: lock {} + db_op {} = {} ms",
-            acquire_lock.as_millis(),
-            (start.elapsed() - acquire_lock).as_millis(),
-            start.elapsed().as_millis()
-        );
+        if start.elapsed().as_millis() > 0 {
+            trace!(
+                target: LOG_TARGET,
+                "sqlite profile - set_output_to_unmined: lock {} + db_op {} = {} ms",
+                acquire_lock.as_millis(),
+                (start.elapsed() - acquire_lock).as_millis(),
+                start.elapsed().as_millis()
+            );
+        }
 
         Ok(())
     }
 
     fn set_outputs_to_be_revalidated(&self) -> Result<(), OutputManagerStorageError> {
         let start = Instant::now();
-        let conn = self.database_connection.acquire_lock();
+        let conn = self.database_connection.get_pooled_connection()?;
         let acquire_lock = start.elapsed();
         // Only update non-deleted utxos
         let result = diesel::update(outputs::table.filter(outputs::marked_deleted_at_height.is_null()))
@@ -499,16 +519,18 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
                 outputs::mined_in_block.eq::<Option<Vec<u8>>>(None),
                 outputs::mined_mmr_position.eq::<Option<i64>>(None),
             ))
-            .execute(&(*conn))?;
+            .execute(&conn)?;
 
         trace!(target: LOG_TARGET, "rows updated: {:?}", result);
-        trace!(
-            target: LOG_TARGET,
-            "sqlite profile - set_outputs_to_be_revalidated: lock {} + db_op {} = {} ms",
-            acquire_lock.as_millis(),
-            (start.elapsed() - acquire_lock).as_millis(),
-            start.elapsed().as_millis()
-        );
+        if start.elapsed().as_millis() > 0 {
+            trace!(
+                target: LOG_TARGET,
+                "sqlite profile - set_outputs_to_be_revalidated: lock {} + db_op {} = {} ms",
+                acquire_lock.as_millis(),
+                (start.elapsed() - acquire_lock).as_millis(),
+                start.elapsed().as_millis()
+            );
+        }
 
         Ok(())
     }
@@ -521,7 +543,7 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
         confirmed: bool,
     ) -> Result<(), OutputManagerStorageError> {
         let start = Instant::now();
-        let conn = self.database_connection.acquire_lock();
+        let conn = self.database_connection.get_pooled_connection()?;
         let acquire_lock = start.elapsed();
         let status = if confirmed {
             OutputStatus::Spent as i32
@@ -543,22 +565,24 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
             outputs::marked_deleted_in_block.eq(mark_deleted_in_block),
             outputs::status.eq(status),
         ))
-        .execute(&(*conn))
+        .execute(&conn)
         .num_rows_affected_or_not_found(1)?;
-        trace!(
-            target: LOG_TARGET,
-            "sqlite profile - mark_output_as_spent: lock {} + db_op {} = {} ms",
-            acquire_lock.as_millis(),
-            (start.elapsed() - acquire_lock).as_millis(),
-            start.elapsed().as_millis()
-        );
+        if start.elapsed().as_millis() > 0 {
+            trace!(
+                target: LOG_TARGET,
+                "sqlite profile - mark_output_as_spent: lock {} + db_op {} = {} ms",
+                acquire_lock.as_millis(),
+                (start.elapsed() - acquire_lock).as_millis(),
+                start.elapsed().as_millis()
+            );
+        }
 
         Ok(())
     }
 
     fn mark_output_as_unspent(&self, hash: Vec<u8>) -> Result<(), OutputManagerStorageError> {
         let start = Instant::now();
-        let conn = self.database_connection.acquire_lock();
+        let conn = self.database_connection.get_pooled_connection()?;
         let acquire_lock = start.elapsed();
 
         debug!(target: LOG_TARGET, "mark_output_as_unspent({})", hash.to_hex());
@@ -575,15 +599,17 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
             outputs::marked_deleted_in_block.eq::<Option<Vec<u8>>>(None),
             outputs::status.eq(OutputStatus::Unspent as i32),
         ))
-        .execute(&(*conn))
+        .execute(&conn)
         .num_rows_affected_or_not_found(1)?;
-        trace!(
-            target: LOG_TARGET,
-            "sqlite profile - mark_output_as_unspent: lock {} + db_op {} = {} ms",
-            acquire_lock.as_millis(),
-            (start.elapsed() - acquire_lock).as_millis(),
-            start.elapsed().as_millis()
-        );
+        if start.elapsed().as_millis() > 0 {
+            trace!(
+                target: LOG_TARGET,
+                "sqlite profile - mark_output_as_unspent: lock {} + db_op {} = {} ms",
+                acquire_lock.as_millis(),
+                (start.elapsed() - acquire_lock).as_millis(),
+                start.elapsed().as_millis()
+            );
+        }
 
         Ok(())
     }
@@ -595,12 +621,12 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
         outputs_to_receive: &[DbUnblindedOutput],
     ) -> Result<(), OutputManagerStorageError> {
         let start = Instant::now();
-        let conn = self.database_connection.acquire_lock();
+        let conn = self.database_connection.get_pooled_connection()?;
         let acquire_lock = start.elapsed();
 
         let mut outputs_to_be_spent = Vec::with_capacity(outputs_to_send.len());
         for i in outputs_to_send {
-            let output = OutputSql::find_by_commitment_and_cancelled(i.commitment.as_bytes(), false, &(*conn))?;
+            let output = OutputSql::find_by_commitment_and_cancelled(i.commitment.as_bytes(), false, &conn)?;
             if output.status != (OutputStatus::Unspent as i32) {
                 return Err(OutputManagerStorageError::OutputAlreadySpent);
             }
@@ -614,7 +640,7 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
                     spent_in_tx_id: Some(Some(tx_id)),
                     ..Default::default()
                 },
-                &(*conn),
+                &conn,
             )?;
         }
 
@@ -626,22 +652,24 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
                 None,
             )?;
             self.encrypt_if_necessary(&mut new_output)?;
-            new_output.commit(&(*conn))?;
+            new_output.commit(&conn)?;
         }
-        trace!(
-            target: LOG_TARGET,
-            "sqlite profile - short_term_encumber_outputs: lock {} + db_op {} = {} ms",
-            acquire_lock.as_millis(),
-            (start.elapsed() - acquire_lock).as_millis(),
-            start.elapsed().as_millis()
-        );
+        if start.elapsed().as_millis() > 0 {
+            trace!(
+                target: LOG_TARGET,
+                "sqlite profile - short_term_encumber_outputs: lock {} + db_op {} = {} ms",
+                acquire_lock.as_millis(),
+                (start.elapsed() - acquire_lock).as_millis(),
+                start.elapsed().as_millis()
+            );
+        }
 
         Ok(())
     }
 
     fn confirm_encumbered_outputs(&self, tx_id: TxId) -> Result<(), OutputManagerStorageError> {
         let start = Instant::now();
-        let conn = self.database_connection.acquire_lock();
+        let conn = self.database_connection.get_pooled_connection()?;
         let acquire_lock = start.elapsed();
 
         let outputs_to_be_received =
@@ -652,7 +680,7 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
                     status: Some(OutputStatus::EncumberedToBeReceived),
                     ..Default::default()
                 },
-                &(*conn),
+                &conn,
             )?;
         }
 
@@ -664,23 +692,25 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
                     status: Some(OutputStatus::EncumberedToBeSpent),
                     ..Default::default()
                 },
-                &(*conn),
+                &conn,
             )?;
         }
-        trace!(
-            target: LOG_TARGET,
-            "sqlite profile - confirm_encumbered_outputs: lock {} + db_op {} = {} ms",
-            acquire_lock.as_millis(),
-            (start.elapsed() - acquire_lock).as_millis(),
-            start.elapsed().as_millis()
-        );
+        if start.elapsed().as_millis() > 0 {
+            trace!(
+                target: LOG_TARGET,
+                "sqlite profile - confirm_encumbered_outputs: lock {} + db_op {} = {} ms",
+                acquire_lock.as_millis(),
+                (start.elapsed() - acquire_lock).as_millis(),
+                start.elapsed().as_millis()
+            );
+        }
 
         Ok(())
     }
 
     fn clear_short_term_encumberances(&self) -> Result<(), OutputManagerStorageError> {
         let start = Instant::now();
-        let conn = self.database_connection.acquire_lock();
+        let conn = self.database_connection.get_pooled_connection()?;
         let acquire_lock = start.elapsed();
 
         let outputs_to_be_received = OutputSql::index_status(OutputStatus::ShortTermEncumberedToBeReceived, &conn)?;
@@ -690,7 +720,7 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
                     status: Some(OutputStatus::CancelledInbound),
                     ..Default::default()
                 },
-                &(*conn),
+                &conn,
             )?;
         }
 
@@ -701,33 +731,37 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
                     status: Some(OutputStatus::Unspent),
                     ..Default::default()
                 },
-                &(*conn),
+                &conn,
             )?;
         }
-        trace!(
-            target: LOG_TARGET,
-            "sqlite profile - clear_short_term_encumberances: lock {} + db_op {} = {} ms",
-            acquire_lock.as_millis(),
-            (start.elapsed() - acquire_lock).as_millis(),
-            start.elapsed().as_millis()
-        );
+        if start.elapsed().as_millis() > 0 {
+            trace!(
+                target: LOG_TARGET,
+                "sqlite profile - clear_short_term_encumberances: lock {} + db_op {} = {} ms",
+                acquire_lock.as_millis(),
+                (start.elapsed() - acquire_lock).as_millis(),
+                start.elapsed().as_millis()
+            );
+        }
 
         Ok(())
     }
 
     fn get_last_mined_output(&self) -> Result<Option<DbUnblindedOutput>, OutputManagerStorageError> {
         let start = Instant::now();
-        let conn = self.database_connection.acquire_lock();
+        let conn = self.database_connection.get_pooled_connection()?;
         let acquire_lock = start.elapsed();
 
-        let output = OutputSql::first_by_mined_height_desc(&(*conn))?;
-        trace!(
-            target: LOG_TARGET,
-            "sqlite profile - get_last_mined_output: lock {} + db_op {} = {} ms",
-            acquire_lock.as_millis(),
-            (start.elapsed() - acquire_lock).as_millis(),
-            start.elapsed().as_millis()
-        );
+        let output = OutputSql::first_by_mined_height_desc(&conn)?;
+        if start.elapsed().as_millis() > 0 {
+            trace!(
+                target: LOG_TARGET,
+                "sqlite profile - get_last_mined_output: lock {} + db_op {} = {} ms",
+                acquire_lock.as_millis(),
+                (start.elapsed() - acquire_lock).as_millis(),
+                start.elapsed().as_millis()
+            );
+        }
         match output {
             Some(mut o) => {
                 self.decrypt_if_necessary(&mut o)?;
@@ -739,17 +773,19 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
 
     fn get_last_spent_output(&self) -> Result<Option<DbUnblindedOutput>, OutputManagerStorageError> {
         let start = Instant::now();
-        let conn = self.database_connection.acquire_lock();
+        let conn = self.database_connection.get_pooled_connection()?;
         let acquire_lock = start.elapsed();
 
-        let output = OutputSql::first_by_marked_deleted_height_desc(&(*conn))?;
-        trace!(
-            target: LOG_TARGET,
-            "sqlite profile - get_last_spent_output: lock {} + db_op {} = {} ms",
-            acquire_lock.as_millis(),
-            (start.elapsed() - acquire_lock).as_millis(),
-            start.elapsed().as_millis()
-        );
+        let output = OutputSql::first_by_marked_deleted_height_desc(&conn)?;
+        if start.elapsed().as_millis() > 0 {
+            trace!(
+                target: LOG_TARGET,
+                "sqlite profile - get_last_spent_output: lock {} + db_op {} = {} ms",
+                acquire_lock.as_millis(),
+                (start.elapsed() - acquire_lock).as_millis(),
+                start.elapsed().as_millis()
+            );
+        }
         match output {
             Some(mut o) => {
                 self.decrypt_if_necessary(&mut o)?;
@@ -764,23 +800,25 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
         current_tip_for_time_lock_calculation: Option<u64>,
     ) -> Result<Balance, OutputManagerStorageError> {
         let start = Instant::now();
-        let conn = self.database_connection.acquire_lock();
+        let conn = self.database_connection.get_pooled_connection()?;
         let acquire_lock = start.elapsed();
 
-        let result = OutputSql::get_balance(current_tip_for_time_lock_calculation, &(*conn));
-        trace!(
-            target: LOG_TARGET,
-            "sqlite profile - get_balance: lock {} + db_op {} = {} ms",
-            acquire_lock.as_millis(),
-            (start.elapsed() - acquire_lock).as_millis(),
-            start.elapsed().as_millis()
-        );
+        let result = OutputSql::get_balance(current_tip_for_time_lock_calculation, &conn);
+        if start.elapsed().as_millis() > 0 {
+            trace!(
+                target: LOG_TARGET,
+                "sqlite profile - get_balance: lock {} + db_op {} = {} ms",
+                acquire_lock.as_millis(),
+                (start.elapsed() - acquire_lock).as_millis(),
+                start.elapsed().as_millis()
+            );
+        }
         result
     }
 
     fn cancel_pending_transaction(&self, tx_id: TxId) -> Result<(), OutputManagerStorageError> {
         let start = Instant::now();
-        let conn = self.database_connection.acquire_lock();
+        let conn = self.database_connection.get_pooled_connection()?;
         let acquire_lock = start.elapsed();
 
         let outputs = OutputSql::find_by_tx_id_and_encumbered(tx_id, &conn)?;
@@ -796,7 +834,7 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
                         status: Some(OutputStatus::CancelledInbound),
                         ..Default::default()
                     },
-                    &(*conn),
+                    &conn,
                 )?;
             } else if output.spent_in_tx_id == Some(tx_id as i64) {
                 output.update(
@@ -805,58 +843,64 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
                         spent_in_tx_id: Some(None),
                         ..Default::default()
                     },
-                    &(*conn),
+                    &conn,
                 )?;
             }
         }
-        trace!(
-            target: LOG_TARGET,
-            "sqlite profile - cancel_pending_transaction: lock {} + db_op {} = {} ms",
-            acquire_lock.as_millis(),
-            (start.elapsed() - acquire_lock).as_millis(),
-            start.elapsed().as_millis()
-        );
+        if start.elapsed().as_millis() > 0 {
+            trace!(
+                target: LOG_TARGET,
+                "sqlite profile - cancel_pending_transaction: lock {} + db_op {} = {} ms",
+                acquire_lock.as_millis(),
+                (start.elapsed() - acquire_lock).as_millis(),
+                start.elapsed().as_millis()
+            );
+        }
 
         Ok(())
     }
 
     fn increment_key_index(&self) -> Result<(), OutputManagerStorageError> {
         let start = Instant::now();
-        let conn = self.database_connection.acquire_lock();
+        let conn = self.database_connection.get_pooled_connection()?;
         let acquire_lock = start.elapsed();
 
-        KeyManagerStateSql::increment_index(&(*conn))?;
-        trace!(
-            target: LOG_TARGET,
-            "sqlite profile - increment_key_index: lock {} + db_op {} = {} ms",
-            acquire_lock.as_millis(),
-            (start.elapsed() - acquire_lock).as_millis(),
-            start.elapsed().as_millis()
-        );
+        KeyManagerStateSql::increment_index(&conn)?;
+        if start.elapsed().as_millis() > 0 {
+            trace!(
+                target: LOG_TARGET,
+                "sqlite profile - increment_key_index: lock {} + db_op {} = {} ms",
+                acquire_lock.as_millis(),
+                (start.elapsed() - acquire_lock).as_millis(),
+                start.elapsed().as_millis()
+            );
+        }
 
         Ok(())
     }
 
     fn set_key_index(&self, index: u64) -> Result<(), OutputManagerStorageError> {
         let start = Instant::now();
-        let conn = self.database_connection.acquire_lock();
+        let conn = self.database_connection.get_pooled_connection()?;
         let acquire_lock = start.elapsed();
 
-        KeyManagerStateSql::set_index(index, &(*conn))?;
-        trace!(
-            target: LOG_TARGET,
-            "sqlite profile - set_key_index: lock {} + db_op {} = {} ms",
-            acquire_lock.as_millis(),
-            (start.elapsed() - acquire_lock).as_millis(),
-            start.elapsed().as_millis()
-        );
+        KeyManagerStateSql::set_index(index, &conn)?;
+        if start.elapsed().as_millis() > 0 {
+            trace!(
+                target: LOG_TARGET,
+                "sqlite profile - set_key_index: lock {} + db_op {} = {} ms",
+                acquire_lock.as_millis(),
+                (start.elapsed() - acquire_lock).as_millis(),
+                start.elapsed().as_millis()
+            );
+        }
 
         Ok(())
     }
 
     fn update_output_metadata_signature(&self, output: &TransactionOutput) -> Result<(), OutputManagerStorageError> {
         let start = Instant::now();
-        let conn = self.database_connection.acquire_lock();
+        let conn = self.database_connection.get_pooled_connection()?;
         let acquire_lock = start.elapsed();
         let db_output = OutputSql::find_by_commitment_and_cancelled(&output.commitment.to_vec(), false, &conn)?;
         db_output.update(
@@ -865,22 +909,24 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
                 metadata_signature_u_key: Some(output.metadata_signature.u().to_vec()),
                 ..Default::default()
             },
-            &(*conn),
+            &conn,
         )?;
-        trace!(
-            target: LOG_TARGET,
-            "sqlite profile - update_output_metadata_signature: lock {} + db_op {} = {} ms",
-            acquire_lock.as_millis(),
-            (start.elapsed() - acquire_lock).as_millis(),
-            start.elapsed().as_millis()
-        );
+        if start.elapsed().as_millis() > 0 {
+            trace!(
+                target: LOG_TARGET,
+                "sqlite profile - update_output_metadata_signature: lock {} + db_op {} = {} ms",
+                acquire_lock.as_millis(),
+                (start.elapsed() - acquire_lock).as_millis(),
+                start.elapsed().as_millis()
+            );
+        }
 
         Ok(())
     }
 
     fn revalidate_unspent_output(&self, commitment: &Commitment) -> Result<(), OutputManagerStorageError> {
         let start = Instant::now();
-        let conn = self.database_connection.acquire_lock();
+        let conn = self.database_connection.get_pooled_connection()?;
         let acquire_lock = start.elapsed();
         let output = OutputSql::find_by_commitment_and_cancelled(&commitment.to_vec(), false, &conn)?;
 
@@ -892,15 +938,17 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
                 status: Some(OutputStatus::Unspent),
                 ..Default::default()
             },
-            &(*conn),
+            &conn,
         )?;
-        trace!(
-            target: LOG_TARGET,
-            "sqlite profile - revalidate_unspent_output: lock {} + db_op {} = {} ms",
-            acquire_lock.as_millis(),
-            (start.elapsed() - acquire_lock).as_millis(),
-            start.elapsed().as_millis()
-        );
+        if start.elapsed().as_millis() > 0 {
+            trace!(
+                target: LOG_TARGET,
+                "sqlite profile - revalidate_unspent_output: lock {} + db_op {} = {} ms",
+                acquire_lock.as_millis(),
+                (start.elapsed() - acquire_lock).as_millis(),
+                start.elapsed().as_millis()
+            );
+        }
         Ok(())
     }
 
@@ -912,7 +960,7 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
         }
 
         let start = Instant::now();
-        let conn = self.database_connection.acquire_lock();
+        let conn = self.database_connection.get_pooled_connection()?;
         let acquire_lock = start.elapsed();
         let mut outputs = OutputSql::index(&conn)?;
 
@@ -963,13 +1011,15 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
         }
 
         (*current_cipher) = Some(cipher);
-        trace!(
-            target: LOG_TARGET,
-            "sqlite profile - apply_encryption: lock {} + db_op {} = {} ms",
-            acquire_lock.as_millis(),
-            (start.elapsed() - acquire_lock).as_millis(),
-            start.elapsed().as_millis()
-        );
+        if start.elapsed().as_millis() > 0 {
+            trace!(
+                target: LOG_TARGET,
+                "sqlite profile - apply_encryption: lock {} + db_op {} = {} ms",
+                acquire_lock.as_millis(),
+                (start.elapsed() - acquire_lock).as_millis(),
+                start.elapsed().as_millis()
+            );
+        }
 
         Ok(())
     }
@@ -982,7 +1032,7 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
             return Ok(());
         };
         let start = Instant::now();
-        let conn = self.database_connection.acquire_lock();
+        let conn = self.database_connection.get_pooled_connection()?;
         let acquire_lock = start.elapsed();
         let mut outputs = OutputSql::index(&conn)?;
 
@@ -1009,13 +1059,15 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
 
         // Now that all the decryption has been completed we can safely remove the cipher fully
         let _ = (*current_cipher).take();
-        trace!(
-            target: LOG_TARGET,
-            "sqlite profile - remove_encryption: lock {} + db_op {} = {} ms",
-            acquire_lock.as_millis(),
-            (start.elapsed() - acquire_lock).as_millis(),
-            start.elapsed().as_millis()
-        );
+        if start.elapsed().as_millis() > 0 {
+            trace!(
+                target: LOG_TARGET,
+                "sqlite profile - remove_encryption: lock {} + db_op {} = {} ms",
+                acquire_lock.as_millis(),
+                (start.elapsed() - acquire_lock).as_millis(),
+                start.elapsed().as_millis()
+            );
+        }
         Ok(())
     }
 
@@ -1024,26 +1076,28 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
         block_height: u64,
     ) -> Result<(), OutputManagerStorageError> {
         let start = Instant::now();
-        let conn = self.database_connection.acquire_lock();
+        let conn = self.database_connection.get_pooled_connection()?;
         let acquire_lock = start.elapsed();
 
         let output = OutputSql::find_pending_coinbase_at_block_height(block_height, &conn)?;
 
         output.delete(&conn)?;
-        trace!(
-            target: LOG_TARGET,
-            "sqlite profile - clear_pending_coinbase_transaction_at_block_height: lock {} + db_op {} = {} ms",
-            acquire_lock.as_millis(),
-            (start.elapsed() - acquire_lock).as_millis(),
-            start.elapsed().as_millis()
-        );
+        if start.elapsed().as_millis() > 0 {
+            trace!(
+                target: LOG_TARGET,
+                "sqlite profile - clear_pending_coinbase_transaction_at_block_height: lock {} + db_op {} = {} ms",
+                acquire_lock.as_millis(),
+                (start.elapsed() - acquire_lock).as_millis(),
+                start.elapsed().as_millis()
+            );
+        }
 
         Ok(())
     }
 
     fn set_coinbase_abandoned(&self, tx_id: TxId, abandoned: bool) -> Result<(), OutputManagerStorageError> {
         let start = Instant::now();
-        let conn = self.database_connection.acquire_lock();
+        let conn = self.database_connection.get_pooled_connection()?;
         let acquire_lock = start.elapsed();
 
         if abandoned {
@@ -1059,7 +1113,7 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
                 ),
             )
             .set((outputs::status.eq(OutputStatus::AbandonedCoinbase as i32),))
-            .execute(&(*conn))
+            .execute(&conn)
             .num_rows_affected_or_not_found(1)?;
         } else {
             let output = OutputSql::find_by_tx_id_and_status(tx_id, OutputStatus::AbandonedCoinbase, &conn)?;
@@ -1073,20 +1127,22 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
                 )?;
             }
         };
-        trace!(
-            target: LOG_TARGET,
-            "sqlite profile - set_coinbase_abandoned: lock {} + db_op {} = {} ms",
-            acquire_lock.as_millis(),
-            (start.elapsed() - acquire_lock).as_millis(),
-            start.elapsed().as_millis()
-        );
+        if start.elapsed().as_millis() > 0 {
+            trace!(
+                target: LOG_TARGET,
+                "sqlite profile - set_coinbase_abandoned: lock {} + db_op {} = {} ms",
+                acquire_lock.as_millis(),
+                (start.elapsed() - acquire_lock).as_millis(),
+                start.elapsed().as_millis()
+            );
+        }
 
         Ok(())
     }
 
     fn reinstate_cancelled_inbound_output(&self, tx_id: TxId) -> Result<(), OutputManagerStorageError> {
         let start = Instant::now();
-        let conn = self.database_connection.acquire_lock();
+        let conn = self.database_connection.get_pooled_connection()?;
         let acquire_lock = start.elapsed();
         let outputs = OutputSql::find_by_tx_id_and_status(tx_id, OutputStatus::CancelledInbound, &conn)?;
 
@@ -1096,16 +1152,18 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
                     status: Some(OutputStatus::EncumberedToBeReceived),
                     ..Default::default()
                 },
-                &(*conn),
+                &conn,
             )?;
         }
-        trace!(
-            target: LOG_TARGET,
-            "sqlite profile - reinstate_cancelled_inbound_output: lock {} + db_op {} = {} ms",
-            acquire_lock.as_millis(),
-            (start.elapsed() - acquire_lock).as_millis(),
-            start.elapsed().as_millis()
-        );
+        if start.elapsed().as_millis() > 0 {
+            trace!(
+                target: LOG_TARGET,
+                "sqlite profile - reinstate_cancelled_inbound_output: lock {} + db_op {} = {} ms",
+                acquire_lock.as_millis(),
+                (start.elapsed() - acquire_lock).as_millis(),
+                start.elapsed().as_millis()
+            );
+        }
         Ok(())
     }
 }
@@ -1493,27 +1551,6 @@ impl Encryptable<Aes256Gcm> for KnownOneSidedPaymentScriptSql {
 
 #[cfg(test)]
 mod test {
-    use std::convert::TryFrom;
-
-    use aes_gcm::{
-        aead::{generic_array::GenericArray, NewAead},
-        Aes256Gcm,
-    };
-    use diesel::{Connection, SqliteConnection};
-    use rand::{rngs::OsRng, RngCore};
-    use tari_crypto::script;
-    use tempfile::tempdir;
-
-    use tari_common_types::types::CommitmentFactory;
-    use tari_core::transactions::{
-        tari_amount::MicroTari,
-        test_helpers::{create_unblinded_output, TestParams as TestParamsHelpers},
-        transaction::{OutputFeatures, TransactionInput, UnblindedOutput},
-        CryptoFactories,
-    };
-    use tari_key_manager::cipher_seed::CipherSeed;
-    use tari_test_utils::random;
-
     use crate::{
         output_manager_service::storage::{
             database::{DbKey, KeyManagerState, OutputManagerBackend},
@@ -1528,9 +1565,28 @@ mod test {
                 UpdateOutput,
             },
         },
-        storage::sqlite_utilities::WalletDbConnection,
+        storage::sqlite_utilities::wallet_db_connection::WalletDbConnection,
         util::encryption::Encryptable,
     };
+    use aes_gcm::{
+        aead::{generic_array::GenericArray, NewAead},
+        Aes256Gcm,
+    };
+    use diesel::{Connection, SqliteConnection};
+    use rand::{rngs::OsRng, RngCore};
+    use std::{convert::TryFrom, time::Duration};
+    use tari_common_sqlite::sqlite_connection_pool::SqliteConnectionPool;
+    use tari_common_types::types::CommitmentFactory;
+    use tari_core::transactions::{
+        tari_amount::MicroTari,
+        test_helpers::{create_unblinded_output, TestParams as TestParamsHelpers},
+        transaction::{OutputFeatures, TransactionInput, UnblindedOutput},
+        CryptoFactories,
+    };
+    use tari_crypto::script;
+    use tari_key_manager::cipher_seed::CipherSeed;
+    use tari_test_utils::random;
+    use tempfile::tempdir;
 
     pub fn make_input(val: MicroTari) -> (TransactionInput, UnblindedOutput) {
         let test_params = TestParamsHelpers::new();
@@ -1784,33 +1840,42 @@ mod test {
         let db_path = format!("{}{}", db_folder, db_name);
 
         embed_migrations!("./migrations");
-        let conn = SqliteConnection::establish(&db_path).unwrap_or_else(|_| panic!("Error connecting to {}", db_path));
+        let mut pool = SqliteConnectionPool::new(db_path.clone(), 1, true, true, Duration::from_secs(60));
+        pool.create_pool()
+            .unwrap_or_else(|_| panic!("Error connecting to {}", db_path));
+        // Note: For this test the connection pool is setup with a pool size of one; the pooled connection must go out
+        // of scope to be released once obtained otherwise subsequent calls to obtain a pooled connection will fail .
+        {
+            let conn = pool
+                .get_pooled_connection()
+                .unwrap_or_else(|_| panic!("Error connecting to {}", db_path));
 
-        embedded_migrations::run_with_output(&conn, &mut std::io::stdout()).expect("Migration failed");
-        let factories = CryptoFactories::default();
+            embedded_migrations::run_with_output(&conn, &mut std::io::stdout()).expect("Migration failed");
+            let factories = CryptoFactories::default();
 
-        let starting_state = KeyManagerState {
-            seed: CipherSeed::new(),
-            branch_seed: "boop boop".to_string(),
-            primary_key_index: 1,
-        };
+            let starting_state = KeyManagerState {
+                seed: CipherSeed::new(),
+                branch_seed: "boop boop".to_string(),
+                primary_key_index: 1,
+            };
 
-        let _state_sql = NewKeyManagerStateSql::from(starting_state).commit(&conn).unwrap();
+            let _state_sql = NewKeyManagerStateSql::from(starting_state).commit(&conn).unwrap();
 
-        let (_, uo) = make_input(MicroTari::from(100 + OsRng.next_u64() % 1000));
-        let uo = DbUnblindedOutput::from_unblinded_output(uo, &factories).unwrap();
-        let output = NewOutputSql::new(uo, OutputStatus::Unspent, None, None).unwrap();
-        output.commit(&conn).unwrap();
+            let (_, uo) = make_input(MicroTari::from(100 + OsRng.next_u64() % 1000));
+            let uo = DbUnblindedOutput::from_unblinded_output(uo, &factories).unwrap();
+            let output = NewOutputSql::new(uo, OutputStatus::Unspent, None, None).unwrap();
+            output.commit(&conn).unwrap();
 
-        let (_, uo2) = make_input(MicroTari::from(100 + OsRng.next_u64() % 1000));
-        let uo2 = DbUnblindedOutput::from_unblinded_output(uo2, &factories).unwrap();
-        let output2 = NewOutputSql::new(uo2, OutputStatus::Unspent, None, None).unwrap();
-        output2.commit(&conn).unwrap();
+            let (_, uo2) = make_input(MicroTari::from(100 + OsRng.next_u64() % 1000));
+            let uo2 = DbUnblindedOutput::from_unblinded_output(uo2, &factories).unwrap();
+            let output2 = NewOutputSql::new(uo2, OutputStatus::Unspent, None, None).unwrap();
+            output2.commit(&conn).unwrap();
+        }
 
         let key = GenericArray::from_slice(b"an example very very secret key.");
         let cipher = Aes256Gcm::new(key);
 
-        let connection = WalletDbConnection::new(conn, None);
+        let connection = WalletDbConnection::new(pool, None);
 
         let db1 = OutputManagerSqliteDatabase::new(connection.clone(), Some(cipher.clone()));
         assert!(db1.apply_encryption(cipher.clone()).is_err());

--- a/base_layer/wallet/src/storage/database.rs
+++ b/base_layer/wallet/src/storage/database.rs
@@ -373,7 +373,7 @@ mod test {
 
         let db_name = format!("{}.sqlite3", string(8).as_str());
         let db_folder = tempdir().unwrap().path().to_str().unwrap().to_string();
-        let connection = run_migration_and_create_sqlite_connection(&format!("{}{}", db_folder, db_name)).unwrap();
+        let connection = run_migration_and_create_sqlite_connection(&format!("{}{}", db_folder, db_name), 16).unwrap();
 
         let db = WalletDatabase::new(WalletSqliteDatabase::new(connection, None).unwrap());
 

--- a/base_layer/wallet/src/storage/sqlite_utilities/wallet_db_connection.rs
+++ b/base_layer/wallet/src/storage/sqlite_utilities/wallet_db_connection.rs
@@ -1,4 +1,4 @@
-// Copyright 2019. The Tari Project
+// Copyright 2020. The Tari Project
 //
 // Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
 // following conditions are met:
@@ -20,37 +20,34 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::path::PathBuf;
-use tari_test_utils::random;
-use tari_wallet::storage::sqlite_utilities::{run_migration_and_create_sqlite_connection, WalletDbConnection};
-use tempfile::{tempdir, TempDir};
+use std::{fs::File, sync::Arc};
 
-pub fn get_path(name: Option<&str>) -> String {
-    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    path.push("tests/data");
-    path.push(name.unwrap_or(""));
-    path.to_str().unwrap().to_string()
+use crate::error::WalletStorageError;
+use diesel::{
+    r2d2::{ConnectionManager, PooledConnection},
+    SqliteConnection,
+};
+use tari_common_sqlite::sqlite_connection_pool::SqliteConnectionPool;
+
+#[derive(Clone)]
+pub struct WalletDbConnection {
+    pool: SqliteConnectionPool,
+    _file_lock: Arc<Option<File>>,
 }
 
-pub fn clean_up_sql_database(name: &str) {
-    if std::fs::metadata(get_path(Some(name))).is_ok() {
-        std::fs::remove_file(get_path(Some(name))).unwrap();
+impl WalletDbConnection {
+    pub fn new(pool: SqliteConnectionPool, file_lock: Option<File>) -> Self {
+        Self {
+            pool,
+            _file_lock: Arc::new(file_lock),
+        }
     }
-}
 
-pub fn init_sql_database(name: &str) {
-    clean_up_sql_database(name);
-    let path = get_path(None);
-    let _ = std::fs::create_dir(&path).unwrap_or_default();
-}
-
-pub fn get_temp_sqlite_database_connection() -> (WalletDbConnection, TempDir) {
-    let db_name = format!("{}.sqlite3", random::string(8).as_str());
-    let db_tempdir = tempdir().unwrap();
-    let db_folder = db_tempdir.path().to_str().unwrap().to_string();
-    let db_path = format!("{}/{}", db_folder, db_name);
-    // let db_path = "/tmp/test.sqlite3".to_string();
-    let connection = run_migration_and_create_sqlite_connection(&db_path, 16).unwrap();
-
-    (connection, db_tempdir)
+    pub fn get_pooled_connection(
+        &self,
+    ) -> Result<PooledConnection<ConnectionManager<SqliteConnection>>, WalletStorageError> {
+        self.pool
+            .get_pooled_connection()
+            .map_err(WalletStorageError::DieselR2d2Error)
+    }
 }

--- a/base_layer/wallet/src/test_utils.rs
+++ b/base_layer/wallet/src/test_utils.rs
@@ -20,13 +20,19 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::storage::sqlite_utilities::{run_migration_and_create_sqlite_connection, WalletDbConnection};
 use core::iter;
-use rand::{distributions::Alphanumeric, rngs::OsRng, Rng};
 use std::path::Path;
+
+use rand::{distributions::Alphanumeric, rngs::OsRng, Rng};
+use tempfile::{tempdir, TempDir};
+
 use tari_common::configuration::Network;
 use tari_core::consensus::{ConsensusConstants, ConsensusManager};
-use tempfile::{tempdir, TempDir};
+
+use crate::storage::sqlite_utilities::{
+    run_migration_and_create_sqlite_connection,
+    wallet_db_connection::WalletDbConnection,
+};
 
 pub fn random_string(len: usize) -> String {
     iter::repeat(())
@@ -49,7 +55,8 @@ pub fn make_wallet_database_connection(path: Option<String>) -> (WalletDbConnect
     let db_path = Path::new(&path_string).join(db_name);
 
     let connection =
-        run_migration_and_create_sqlite_connection(&db_path.to_str().expect("Should be able to make path")).unwrap();
+        run_migration_and_create_sqlite_connection(&db_path.to_str().expect("Should be able to make path"), 16)
+            .unwrap();
     (connection, temp_dir)
 }
 

--- a/base_layer/wallet/src/transaction_service/error.rs
+++ b/base_layer/wallet/src/transaction_service/error.rs
@@ -200,8 +200,8 @@ pub enum TransactionStorageError {
     CompletedConversionError(#[from] CompletedTransactionConversionError),
     #[error("Serde json error: `{0}`")]
     SerdeJsonError(#[from] SerdeJsonError),
-    #[error("R2d2 error")]
-    R2d2Error,
+    #[error("Diesel R2d2 error: `{0}`")]
+    DieselR2d2Error(#[from] WalletStorageError),
     #[error("Diesel error: `{0}`")]
     DieselError(#[from] DieselError),
     #[error("Diesel connection error: `{0}`")]

--- a/base_layer/wallet/tests/output_manager_service/service.rs
+++ b/base_layer/wallet/tests/output_manager_service/service.rs
@@ -60,7 +60,7 @@ use tari_crypto::{
 };
 use tari_key_manager::{cipher_seed::CipherSeed, mnemonic::Mnemonic};
 use tari_p2p::Network;
-use tari_service_framework::{reply_channel, reply_channel::SenderService};
+use tari_service_framework::reply_channel;
 use tari_shutdown::Shutdown;
 use tari_wallet::{
     base_node_service::{

--- a/base_layer/wallet/tests/transaction_service/storage.rs
+++ b/base_layer/wallet/tests/transaction_service/storage.rs
@@ -552,7 +552,7 @@ pub fn test_transaction_service_sqlite_db() {
     let db_tempdir = tempdir().unwrap();
     let db_folder = db_tempdir.path().to_str().unwrap().to_string();
     let db_path = format!("{}/{}", db_folder, db_name);
-    let connection = run_migration_and_create_sqlite_connection(&db_path).unwrap();
+    let connection = run_migration_and_create_sqlite_connection(&db_path, 16).unwrap();
 
     test_db_backend(TransactionServiceSqliteDatabase::new(connection, None));
 }
@@ -563,7 +563,7 @@ pub fn test_transaction_service_sqlite_db_encrypted() {
     let db_tempdir = tempdir().unwrap();
     let db_folder = db_tempdir.path().to_str().unwrap().to_string();
     let db_path = format!("{}/{}", db_folder, db_name);
-    let connection = run_migration_and_create_sqlite_connection(&db_path).unwrap();
+    let connection = run_migration_and_create_sqlite_connection(&db_path, 16).unwrap();
 
     let key = GenericArray::from_slice(b"an example very very secret key.");
     let cipher = Aes256Gcm::new(key);

--- a/base_layer/wallet/tests/transaction_service/transaction_protocols.rs
+++ b/base_layer/wallet/tests/transaction_service/transaction_protocols.rs
@@ -134,7 +134,7 @@ pub async fn setup(
     let db_name = format!("{}.sqlite3", random::string(8).as_str());
     let temp_dir = tempdir().unwrap();
     let db_folder = temp_dir.path().to_str().unwrap().to_string();
-    let db_connection = run_migration_and_create_sqlite_connection(&format!("{}/{}", db_folder, db_name)).unwrap();
+    let db_connection = run_migration_and_create_sqlite_connection(&format!("{}/{}", db_folder, db_name), 16).unwrap();
 
     let db = TransactionDatabase::new(TransactionServiceSqliteDatabase::new(db_connection, None));
 

--- a/base_layer/wallet/tests/wallet/mod.rs
+++ b/base_layer/wallet/tests/wallet/mod.rs
@@ -136,7 +136,7 @@ async fn create_wallet(
         .with_extension("sqlite3");
 
     let (wallet_backend, transaction_backend, output_manager_backend, contacts_backend) =
-        initialize_sqlite_database_backends(sql_database_path, passphrase).unwrap();
+        initialize_sqlite_database_backends(sql_database_path, passphrase, 16).unwrap();
 
     let transaction_service_config = TransactionServiceConfig {
         resend_response_cooldown: Duration::from_secs(1),
@@ -312,7 +312,7 @@ async fn test_wallet() {
     alice_wallet.wait_until_shutdown().await;
 
     let connection =
-        run_migration_and_create_sqlite_connection(&current_wallet_path).expect("Could not open Sqlite db");
+        run_migration_and_create_sqlite_connection(&current_wallet_path, 16).expect("Could not open Sqlite db");
 
     if WalletSqliteDatabase::new(connection.clone(), None).is_ok() {
         panic!("Should not be able to instantiate encrypted wallet without cipher");
@@ -348,7 +348,7 @@ async fn test_wallet() {
     alice_wallet.wait_until_shutdown().await;
 
     let connection =
-        run_migration_and_create_sqlite_connection(&current_wallet_path).expect("Could not open Sqlite db");
+        run_migration_and_create_sqlite_connection(&current_wallet_path, 16).expect("Could not open Sqlite db");
     let db = WalletSqliteDatabase::new(connection, None).expect(
         "Should be able to instantiate db with
     cipher",
@@ -386,12 +386,12 @@ async fn test_wallet() {
         .unwrap();
 
     let connection =
-        run_migration_and_create_sqlite_connection(&current_wallet_path).expect("Could not open Sqlite db");
+        run_migration_and_create_sqlite_connection(&current_wallet_path, 16).expect("Could not open Sqlite db");
     let wallet_db = WalletDatabase::new(WalletSqliteDatabase::new(connection.clone(), None).unwrap());
     let master_seed = wallet_db.get_master_seed().await.unwrap();
     assert!(master_seed.is_some());
     // Checking that the backup has had its Comms Private Key is cleared.
-    let connection = run_migration_and_create_sqlite_connection(&backup_wallet_path).expect(
+    let connection = run_migration_and_create_sqlite_connection(&backup_wallet_path, 16).expect(
         "Could not open Sqlite
     db",
     );
@@ -764,14 +764,14 @@ fn test_db_file_locking() {
     let db_tempdir = tempdir().unwrap();
     let wallet_path = db_tempdir.path().join("alice_db").with_extension("sqlite3");
 
-    let connection = run_migration_and_create_sqlite_connection(&wallet_path).expect("Could not open Sqlite db");
+    let connection = run_migration_and_create_sqlite_connection(&wallet_path, 16).expect("Could not open Sqlite db");
 
-    match run_migration_and_create_sqlite_connection(&wallet_path) {
+    match run_migration_and_create_sqlite_connection(&wallet_path, 16) {
         Err(WalletStorageError::CannotAcquireFileLock) => {},
         _ => panic!("Should not be able to acquire file lock"),
     }
 
     drop(connection);
 
-    assert!(run_migration_and_create_sqlite_connection(&wallet_path).is_ok());
+    assert!(run_migration_and_create_sqlite_connection(&wallet_path, 16).is_ok());
 }

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -2933,7 +2933,7 @@ pub unsafe extern "C" fn wallet_create(
 
     debug!(target: LOG_TARGET, "Running Wallet database migrations");
     let (wallet_backend, transaction_backend, output_manager_backend, contacts_backend) =
-        match initialize_sqlite_database_backends(sql_database_path, passphrase_option) {
+        match initialize_sqlite_database_backends(sql_database_path, passphrase_option, 16) {
             Ok((w, t, o, c)) => (w, t, o, c),
             Err(e) => {
                 error = LibWalletError::from(WalletError::WalletStorageError(e)).code;
@@ -5781,7 +5781,7 @@ mod test {
             let runtime = Runtime::new().unwrap();
 
             let connection =
-                run_migration_and_create_sqlite_connection(&sql_database_path).expect("Could not open Sqlite db");
+                run_migration_and_create_sqlite_connection(&sql_database_path, 16).expect("Could not open Sqlite db");
             let wallet_backend = WalletDatabase::new(WalletSqliteDatabase::new(connection, None).unwrap());
 
             let stored_seed = runtime.block_on(wallet_backend.get_master_seed()).unwrap();
@@ -5816,7 +5816,7 @@ mod test {
             wallet_destroy(alice_wallet);
 
             let connection =
-                run_migration_and_create_sqlite_connection(&sql_database_path).expect("Could not open Sqlite db");
+                run_migration_and_create_sqlite_connection(&sql_database_path, 16).expect("Could not open Sqlite db");
             let wallet_backend = WalletDatabase::new(WalletSqliteDatabase::new(connection, None).unwrap());
 
             let stored_seed1 = runtime.block_on(wallet_backend.get_master_seed()).unwrap().unwrap();
@@ -5853,7 +5853,7 @@ mod test {
             wallet_destroy(alice_wallet2);
 
             let connection =
-                run_migration_and_create_sqlite_connection(&sql_database_path).expect("Could not open Sqlite db");
+                run_migration_and_create_sqlite_connection(&sql_database_path, 16).expect("Could not open Sqlite db");
             let wallet_backend = WalletDatabase::new(WalletSqliteDatabase::new(connection, None).unwrap());
 
             let stored_seed2 = runtime.block_on(wallet_backend.get_master_seed()).unwrap().unwrap();
@@ -5872,7 +5872,7 @@ mod test {
 
             let sql_database_path = alice_temp_dir.path().join("backup").with_extension("sqlite3");
             let connection =
-                run_migration_and_create_sqlite_connection(&sql_database_path).expect("Could not open Sqlite db");
+                run_migration_and_create_sqlite_connection(&sql_database_path, 16).expect("Could not open Sqlite db");
             let wallet_backend = WalletDatabase::new(WalletSqliteDatabase::new(connection, None).unwrap());
 
             let stored_seed = runtime.block_on(wallet_backend.get_master_seed()).unwrap();

--- a/common/src/configuration/global.rs
+++ b/common/src/configuration/global.rs
@@ -112,6 +112,7 @@ pub struct GlobalConfig {
     pub transaction_event_channel_size: usize,
     pub base_node_event_channel_size: usize,
     pub output_manager_event_channel_size: usize,
+    pub wallet_connection_manager_pool_size: usize,
     pub console_wallet_password: Option<String>,
     pub wallet_command_send_wait_stage: String,
     pub wallet_command_send_wait_timeout: u64,
@@ -486,6 +487,9 @@ fn convert_node_config(
     let key = "wallet.base_node_event_channel_size";
     let base_node_event_channel_size = optional(cfg.get_int(key))?.unwrap_or(250) as usize;
 
+    let key = "wallet.connection_manager_pool_size";
+    let wallet_connection_manager_pool_size = optional(cfg.get_int(key))?.unwrap_or(16) as usize;
+
     let key = "wallet.output_manager_event_channel_size";
     let output_manager_event_channel_size = optional(cfg.get_int(key))?.unwrap_or(250) as usize;
 
@@ -759,6 +763,7 @@ fn convert_node_config(
         transaction_num_confirmations_required,
         transaction_event_channel_size,
         base_node_event_channel_size,
+        wallet_connection_manager_pool_size,
         output_manager_event_channel_size,
         console_wallet_password,
         wallet_command_send_wait_stage,

--- a/common_sqlite/Cargo.toml
+++ b/common_sqlite/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "tari_common_sqlite"
+authors = ["The Tari Development Community"]
+description = "Tari cryptocurrency wallet library"
+license = "BSD-3-Clause"
+version = "0.21.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+diesel = { version = "1.4.7", features = ["sqlite", "r2d2"] }
+log = "0.4.6"
+thiserror = "1.0.26"

--- a/common_sqlite/src/connection_options.rs
+++ b/common_sqlite/src/connection_options.rs
@@ -1,4 +1,4 @@
-// Copyright 2019. The Tari Project
+// Copyright 2020. The Tari Project
 //
 // Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
 // following conditions are met:
@@ -20,37 +20,44 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::path::PathBuf;
-use tari_test_utils::random;
-use tari_wallet::storage::sqlite_utilities::{run_migration_and_create_sqlite_connection, WalletDbConnection};
-use tempfile::{tempdir, TempDir};
+use core::{
+    option::{Option, Option::Some},
+    result::{Result, Result::Ok},
+    time::Duration,
+};
+use diesel::{connection::SimpleConnection, SqliteConnection};
 
-pub fn get_path(name: Option<&str>) -> String {
-    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    path.push("tests/data");
-    path.push(name.unwrap_or(""));
-    path.to_str().unwrap().to_string()
+#[derive(Debug, Clone)]
+pub struct ConnectionOptions {
+    enable_wal: bool,
+    enable_foreign_keys: bool,
+    busy_timeout: Option<Duration>,
 }
 
-pub fn clean_up_sql_database(name: &str) {
-    if std::fs::metadata(get_path(Some(name))).is_ok() {
-        std::fs::remove_file(get_path(Some(name))).unwrap();
+impl ConnectionOptions {
+    pub fn new(enable_wal: bool, enable_foreign_keys: bool, busy_timeout: Duration) -> Self {
+        Self {
+            enable_wal,
+            enable_foreign_keys,
+            busy_timeout: Some(busy_timeout),
+        }
     }
 }
 
-pub fn init_sql_database(name: &str) {
-    clean_up_sql_database(name);
-    let path = get_path(None);
-    let _ = std::fs::create_dir(&path).unwrap_or_default();
-}
-
-pub fn get_temp_sqlite_database_connection() -> (WalletDbConnection, TempDir) {
-    let db_name = format!("{}.sqlite3", random::string(8).as_str());
-    let db_tempdir = tempdir().unwrap();
-    let db_folder = db_tempdir.path().to_str().unwrap().to_string();
-    let db_path = format!("{}/{}", db_folder, db_name);
-    // let db_path = "/tmp/test.sqlite3".to_string();
-    let connection = run_migration_and_create_sqlite_connection(&db_path, 16).unwrap();
-
-    (connection, db_tempdir)
+impl diesel::r2d2::CustomizeConnection<SqliteConnection, diesel::r2d2::Error> for ConnectionOptions {
+    fn on_acquire(&self, conn: &mut SqliteConnection) -> Result<(), diesel::r2d2::Error> {
+        (|| {
+            if self.enable_wal {
+                conn.batch_execute("PRAGMA journal_mode = WAL; PRAGMA synchronous = NORMAL;")?;
+            }
+            if self.enable_foreign_keys {
+                conn.batch_execute("PRAGMA foreign_keys = ON;")?;
+            }
+            if let Some(d) = self.busy_timeout {
+                conn.batch_execute(&format!("PRAGMA busy_timeout = {};", d.as_millis()))?;
+            }
+            Ok(())
+        })()
+        .map_err(diesel::r2d2::Error::QueryError)
+    }
 }

--- a/common_sqlite/src/error.rs
+++ b/common_sqlite/src/error.rs
@@ -20,37 +20,16 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::path::PathBuf;
-use tari_test_utils::random;
-use tari_wallet::storage::sqlite_utilities::{run_migration_and_create_sqlite_connection, WalletDbConnection};
-use tempfile::{tempdir, TempDir};
+use thiserror::Error;
 
-pub fn get_path(name: Option<&str>) -> String {
-    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    path.push("tests/data");
-    path.push(name.unwrap_or(""));
-    path.to_str().unwrap().to_string()
+#[derive(Debug, Error)]
+pub enum SqliteStorageError {
+    #[error("Diesel R2d2 error")]
+    DieselR2d2Error(String),
 }
 
-pub fn clean_up_sql_database(name: &str) {
-    if std::fs::metadata(get_path(Some(name))).is_ok() {
-        std::fs::remove_file(get_path(Some(name))).unwrap();
+impl PartialEq for SqliteStorageError {
+    fn eq(&self, other: &Self) -> bool {
+        self == other
     }
-}
-
-pub fn init_sql_database(name: &str) {
-    clean_up_sql_database(name);
-    let path = get_path(None);
-    let _ = std::fs::create_dir(&path).unwrap_or_default();
-}
-
-pub fn get_temp_sqlite_database_connection() -> (WalletDbConnection, TempDir) {
-    let db_name = format!("{}.sqlite3", random::string(8).as_str());
-    let db_tempdir = tempdir().unwrap();
-    let db_folder = db_tempdir.path().to_str().unwrap().to_string();
-    let db_path = format!("{}/{}", db_folder, db_name);
-    // let db_path = "/tmp/test.sqlite3".to_string();
-    let connection = run_migration_and_create_sqlite_connection(&db_path, 16).unwrap();
-
-    (connection, db_tempdir)
 }

--- a/common_sqlite/src/lib.rs
+++ b/common_sqlite/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019. The Tari Project
+// Copyright 2020. The Tari Project
 //
 // Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
 // following conditions are met:
@@ -20,37 +20,6 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::path::PathBuf;
-use tari_test_utils::random;
-use tari_wallet::storage::sqlite_utilities::{run_migration_and_create_sqlite_connection, WalletDbConnection};
-use tempfile::{tempdir, TempDir};
-
-pub fn get_path(name: Option<&str>) -> String {
-    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    path.push("tests/data");
-    path.push(name.unwrap_or(""));
-    path.to_str().unwrap().to_string()
-}
-
-pub fn clean_up_sql_database(name: &str) {
-    if std::fs::metadata(get_path(Some(name))).is_ok() {
-        std::fs::remove_file(get_path(Some(name))).unwrap();
-    }
-}
-
-pub fn init_sql_database(name: &str) {
-    clean_up_sql_database(name);
-    let path = get_path(None);
-    let _ = std::fs::create_dir(&path).unwrap_or_default();
-}
-
-pub fn get_temp_sqlite_database_connection() -> (WalletDbConnection, TempDir) {
-    let db_name = format!("{}.sqlite3", random::string(8).as_str());
-    let db_tempdir = tempdir().unwrap();
-    let db_folder = db_tempdir.path().to_str().unwrap().to_string();
-    let db_path = format!("{}/{}", db_folder, db_name);
-    // let db_path = "/tmp/test.sqlite3".to_string();
-    let connection = run_migration_and_create_sqlite_connection(&db_path, 16).unwrap();
-
-    (connection, db_tempdir)
-}
+mod connection_options;
+pub mod error;
+pub mod sqlite_connection_pool;

--- a/common_sqlite/src/sqlite_connection_pool.rs
+++ b/common_sqlite/src/sqlite_connection_pool.rs
@@ -1,0 +1,142 @@
+// Copyright 2020. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::{connection_options::ConnectionOptions, error::SqliteStorageError};
+use core::{
+    option::Option::{None, Some},
+    result::{
+        Result,
+        Result::{Err, Ok},
+    },
+    time::Duration,
+};
+use diesel::{
+    r2d2::{ConnectionManager, Pool, PooledConnection},
+    SqliteConnection,
+};
+use log::*;
+
+const LOG_TARGET: &str = "common_sqlite::sqlite_connection_pool";
+
+#[derive(Clone)]
+pub struct SqliteConnectionPool {
+    pool: Option<Pool<ConnectionManager<SqliteConnection>>>,
+    db_path: String,
+    pool_size: usize,
+    connection_options: ConnectionOptions,
+}
+
+impl SqliteConnectionPool {
+    pub fn new(
+        db_path: String,
+        pool_size: usize,
+        enable_wal: bool,
+        enable_foreign_keys: bool,
+        busy_timeout: Duration,
+    ) -> Self {
+        Self {
+            pool: None,
+            db_path,
+            pool_size,
+            connection_options: ConnectionOptions::new(enable_wal, enable_foreign_keys, busy_timeout),
+        }
+    }
+
+    /// Create an sqlite connection pool managed by the pool connection manager
+    pub fn create_pool(&mut self) -> Result<(), SqliteStorageError> {
+        if self.pool.is_none() {
+            let pool = Pool::builder()
+                .max_size(self.pool_size as u32)
+                .connection_customizer(Box::new(self.connection_options.clone()))
+                .build(ConnectionManager::<SqliteConnection>::new(self.db_path.as_str()))
+                .map_err(|e| SqliteStorageError::DieselR2d2Error(e.to_string()));
+            self.pool = Some(pool?);
+        } else {
+            warn!(
+                target: LOG_TARGET,
+                "Connection pool for {} already exists", self.db_path
+            );
+        }
+        Ok(())
+    }
+
+    /// Return a pooled sqlite connection managed by the pool connection manager, waits for at most the configured
+    /// connection timeout before returning an error.
+    pub fn get_pooled_connection(
+        &self,
+    ) -> Result<PooledConnection<ConnectionManager<SqliteConnection>>, SqliteStorageError> {
+        if let Some(pool) = self.pool.clone() {
+            pool.get().map_err(|e| {
+                warn!(
+                    target: LOG_TARGET,
+                    "Connection pool state {:?}: {}",
+                    pool.state(),
+                    e.to_string()
+                );
+                SqliteStorageError::DieselR2d2Error(e.to_string())
+            })
+        } else {
+            Err(SqliteStorageError::DieselR2d2Error("Pool does not exist".to_string()))
+        }
+    }
+
+    /// Return a pooled sqlite connection managed by the pool connection manager, waits for at most supplied
+    /// connection timeout before returning an error.
+    pub fn get_pooled_connection_timeout(
+        &self,
+        timeout: Duration,
+    ) -> Result<PooledConnection<ConnectionManager<SqliteConnection>>, SqliteStorageError> {
+        if let Some(pool) = self.pool.clone() {
+            pool.get_timeout(timeout).map_err(|e| {
+                warn!(
+                    target: LOG_TARGET,
+                    "Connection pool state {:?}: {}",
+                    pool.state(),
+                    e.to_string()
+                );
+                SqliteStorageError::DieselR2d2Error(e.to_string())
+            })
+        } else {
+            Err(SqliteStorageError::DieselR2d2Error("Pool does not exist".to_string()))
+        }
+    }
+
+    /// Return a pooled sqlite connection managed by the pool connection manager, returns None if there are no idle
+    /// connections available in the pool. This method will not block waiting to establish a new connection.
+    pub fn try_get_pooled_connection(
+        &self,
+    ) -> Result<Option<PooledConnection<ConnectionManager<SqliteConnection>>>, SqliteStorageError> {
+        if let Some(pool) = self.pool.clone() {
+            let connection = pool.try_get();
+            if connection.is_none() {
+                warn!(
+                    target: LOG_TARGET,
+                    "No connections available, pool state {:?}",
+                    pool.state()
+                );
+            };
+            Ok(connection)
+        } else {
+            Err(SqliteStorageError::DieselR2d2Error("Pool does not exist".to_string()))
+        }
+    }
+}


### PR DESCRIPTION
Description
---
- Implemented a generic system-wide pool connection manager for diesel SQLite connections that uses the modern Write-ahead Log (WAL) SQLite3 database mode to speed up database operations  (_see https://www.sqlite.org/wal.html_) with a configurable pool size.
- Changed the Wallet's SQLite database connection to make use of the pool connection manager.
- Refined SQLite profiling trace logs to only log an entry if the total time is > 1ms - this cut down on noisy entries as most database calls are now < 1ms.
- Notable SQLite pragma settings:
  - [PRAGMA schema.journal_mode](https://www.sqlite.org/pragma.html#pragma_journal_mode) = `WAL`
  - [PRAGMA schema.locking_mode](https://www.sqlite.org/pragma.html#pragma_locking_mode) = `NORMAL `
  - [PRAGMA schema.synchronous](https://www.sqlite.org/pragma.html#pragma_synchronous) = `| 2 | FULL`
  - [PRAGMA wal_autocheckpoint](https://www.sqlite.org/pragma.html#pragma_wal_autocheckpoint) = `1000` (the default)

Motivation and Context
---
The wallet's database connection was not optimal.

How Has This Been Tested?
---
- Unit tests
- Cucumber tests (`npm test -- --tags "not @long-running and not @broken"`)
- System-level tests with positive results all around (see discussion):
  - Configuration: Base node + console wallet + merge mining proxy + XMRig -> Mining
  - Test 1: Moderate coin split (22 transactions producing 3124 outputs)
  - Test 2: Moderate stress test (2x simultaneous `make-it-rain` transactions from one sender to two receiving wallets of 250 transactions each)

The graphs below show the SQLite WAL mode profiling for the above two tests (sender wallet only) with a pool size of 16 for all read and write database operations where the total time (acquire lock time + db operation time) was larger than 1ms. The wallet in question had a communications breakdown to its connected base node for a while after all transactions were completed and when it eventually gained an RPC connection validation protocols for all 500 transactions queried the base node as fast as possible, which panned out in some of those protocols waiting for a pooled connection. The actual time db operations will wait for a write operation to conclude is managed by SQLite and bunched within the `db op time` measurement.

![image](https://user-images.githubusercontent.com/39146854/141734409-34b268d1-0b6c-4cc9-91d1-6933b244ee3d.png)

![image](https://user-images.githubusercontent.com/39146854/141733462-583eb0eb-e7ed-4c8c-bfb3-48e3acd4e800.png)

