### PR TITLE
feat: add atomic swap refund transaction handling

### DIFF
--- a/applications/tari_app_grpc/proto/types.proto
+++ b/applications/tari_app_grpc/proto/types.proto
@@ -288,6 +288,8 @@ message UnblindedOutput {
     bytes sender_offset_public_key = 8;
     // UTXO signature with the script offset private key, k_O
     ComSignature metadata_signature = 9;
+    // The minimum height the script allows this output to be spent
+    uint64 script_lock_height = 10;
 }
 
 // ----------------------------- Network Types ----------------------------- //

--- a/applications/tari_app_grpc/proto/wallet.proto
+++ b/applications/tari_app_grpc/proto/wallet.proto
@@ -54,12 +54,14 @@ service Wallet {
     rpc ListConnectedPeers(Empty) returns (ListConnectedPeersResponse);
     // Cancel pending transaction
     rpc CancelTransaction (CancelTransactionRequest) returns (CancelTransactionResponse);
-    // Will triggger a complete revalidation of all wallet outputs.
+    // Will trigger a complete revalidation of all wallet outputs.
     rpc RevalidateAllTransactions (RevalidateRequest) returns (RevalidateResponse);
     // This will send a XTR SHA Atomic swap transaction
     rpc SendShaAtomicSwapTransaction(SendShaAtomicSwapRequest) returns (SendShaAtomicSwapResponse);
     // This will claim a XTR SHA Atomic swap transaction
     rpc ClaimShaAtomicSwapTransaction(ClaimShaAtomicSwapRequest) returns (ClaimShaAtomicSwapResponse);
+    // This will claim a HTLC refund transaction
+    rpc ClaimHtlcRefundTransaction(ClaimHtlcRefundRequest) returns (ClaimHtlcRefundResponse);
 }
 
 message GetVersionRequest { }
@@ -122,6 +124,15 @@ message ClaimShaAtomicSwapRequest{
 }
 
 message ClaimShaAtomicSwapResponse {
+    TransferResult results = 1;
+}
+
+message ClaimHtlcRefundRequest{
+    string output_hash = 1;
+    uint64 fee_per_gram = 2;
+}
+
+message ClaimHtlcRefundResponse {
     TransferResult results = 1;
 }
 

--- a/applications/tari_app_grpc/src/conversions/unblinded_output.rs
+++ b/applications/tari_app_grpc/src/conversions/unblinded_output.rs
@@ -49,6 +49,7 @@ impl From<UnblindedOutput> for grpc::UnblindedOutput {
                 signature_u: Vec::from(output.metadata_signature.u().as_bytes()),
                 signature_v: Vec::from(output.metadata_signature.v().as_bytes()),
             }),
+            script_lock_height: output.script_lock_height,
         }
     }
 }
@@ -91,6 +92,7 @@ impl TryFrom<grpc::UnblindedOutput> for UnblindedOutput {
             script_private_key,
             sender_offset_public_key,
             metadata_signature,
+            script_lock_height: output.script_lock_height,
         })
     }
 }

--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -246,6 +246,7 @@ async fn build_node_context(
         Box::new(TxInternalConsistencyValidator::new(
             factories.clone(),
             config.base_node_bypass_range_proof_verification,
+            blockchain_db.clone(),
         )),
         Box::new(TxInputAndMaturityValidator::new(blockchain_db.clone())),
         Box::new(TxConsensusValidator::new(blockchain_db.clone())),

--- a/applications/tari_console_wallet/src/automation/command_parser.rs
+++ b/applications/tari_console_wallet/src/automation/command_parser.rs
@@ -59,6 +59,7 @@ impl Display for ParsedCommand {
             ClearCustomBaseNode => "clear-custom-base-node",
             InitShaAtomicSwap => "init-sha-atomic-swap",
             FinaliseShaAtomicSwap => "finalise-sha-atomic-swap",
+            ClaimShaAtomicSwapRefund => "claim-sha-atomic-swap-refund",
         };
 
         let args = self
@@ -130,6 +131,7 @@ pub fn parse_command(command: &str) -> Result<ParsedCommand, ParseError> {
         ClearCustomBaseNode => Vec::new(),
         InitShaAtomicSwap => parse_init_sha_atomic_swap(args)?,
         FinaliseShaAtomicSwap => parse_finalise_sha_atomic_swap(args)?,
+        ClaimShaAtomicSwapRefund => parse_claim_htlc_refund_refund(args)?,
     };
 
     Ok(ParsedCommand { command, args })
@@ -215,6 +217,18 @@ fn parse_finalise_sha_atomic_swap(mut args: SplitWhitespace) -> Result<Vec<Parse
     let pre_image = args.next().ok_or_else(|| ParseError::Empty("public key".to_string()))?;
     let pre_image = parse_emoji_id_or_public_key(pre_image).ok_or(ParseError::PublicKey)?;
     parsed_args.push(ParsedArgument::PublicKey(pre_image));
+
+    Ok(parsed_args)
+}
+
+fn parse_claim_htlc_refund_refund(mut args: SplitWhitespace) -> Result<Vec<ParsedArgument>, ParseError> {
+    let mut parsed_args = Vec::new();
+    // hash
+    let hash = args
+        .next()
+        .ok_or_else(|| ParseError::Empty("Output hash".to_string()))?;
+    let hash = parse_hash(hash).ok_or(ParseError::Hash)?;
+    parsed_args.push(ParsedArgument::Hash(hash));
 
     Ok(parsed_args)
 }

--- a/base_layer/core/src/mempool/unconfirmed_pool/unconfirmed_pool.rs
+++ b/base_layer/core/src/mempool/unconfirmed_pool/unconfirmed_pool.rs
@@ -596,8 +596,12 @@ mod test {
             .unwrap();
 
         let factories = CryptoFactories::default();
-        let mut stx_protocol = stx_builder.build::<HashDigest>(&factories).unwrap();
-        stx_protocol.finalize(KernelFeatures::empty(), &factories).unwrap();
+        let mut stx_protocol = stx_builder
+            .build::<HashDigest>(&factories, None, Some(u64::MAX))
+            .unwrap();
+        stx_protocol
+            .finalize(KernelFeatures::empty(), &factories, None, Some(u64::MAX))
+            .unwrap();
 
         let tx3 = stx_protocol.get_transaction().unwrap().clone();
 

--- a/base_layer/core/src/transactions/coinbase_builder.rs
+++ b/base_layer/core/src/transactions/coinbase_builder.rs
@@ -208,6 +208,7 @@ impl CoinbaseBuilder {
             script_private_key,
             sender_offset_public_key,
             metadata_sig,
+            0,
         );
         let output = if let Some(rewind_data) = self.rewind_data.as_ref() {
             unblinded_output
@@ -235,7 +236,7 @@ impl CoinbaseBuilder {
             .with_reward(total_reward)
             .with_kernel(kernel);
         let tx = builder
-            .build(&self.factories)
+            .build(&self.factories, None, Some(height))
             .map_err(|e| CoinbaseBuildError::BuildError(e.to_string()))?;
         Ok((tx, unblinded_output))
     }
@@ -525,7 +526,9 @@ mod test {
                 &PrivateKey::default(),
                 false,
                 block_reward,
-                &factories
+                &factories,
+                None,
+                Some(u64::MAX)
             ),
             Ok(())
         );

--- a/base_layer/core/src/transactions/test_helpers.rs
+++ b/base_layer/core/src/transactions/test_helpers.rs
@@ -155,6 +155,7 @@ impl TestParams {
             self.script_private_key.clone(),
             self.sender_offset_public_key.clone(),
             metadata_signature,
+            0,
         )
     }
 
@@ -444,8 +445,10 @@ pub fn create_transaction_with(
         stx_builder.with_output(utxo, script_offset_pvt_key).unwrap();
     });
 
-    let mut stx_protocol = stx_builder.build::<Blake256>(&factories).unwrap();
-    stx_protocol.finalize(KernelFeatures::empty(), &factories).unwrap();
+    let mut stx_protocol = stx_builder.build::<Blake256>(&factories, None, Some(u64::MAX)).unwrap();
+    stx_protocol
+        .finalize(KernelFeatures::empty(), &factories, None, Some(u64::MAX))
+        .unwrap();
     stx_protocol.take_transaction().unwrap()
 }
 
@@ -513,7 +516,7 @@ pub fn spend_utxos(schema: TransactionSchema) -> (Transaction, Vec<UnblindedOutp
             .unwrap();
     }
 
-    let mut stx_protocol = stx_builder.build::<Blake256>(&factories).unwrap();
+    let mut stx_protocol = stx_builder.build::<Blake256>(&factories, None, Some(u64::MAX)).unwrap();
     let change = stx_protocol.get_change_amount().unwrap();
     // The change output is assigned its own random script offset private key
     let change_sender_offset_public_key = stx_protocol.get_change_sender_offset_public_key().unwrap().unwrap();
@@ -539,9 +542,12 @@ pub fn spend_utxos(schema: TransactionSchema) -> (Transaction, Vec<UnblindedOutp
         test_params_change_and_txn.script_private_key.clone(),
         change_sender_offset_public_key,
         metadata_sig,
+        0,
     );
     outputs.push(change_output);
-    stx_protocol.finalize(KernelFeatures::empty(), &factories).unwrap();
+    stx_protocol
+        .finalize(KernelFeatures::empty(), &factories, None, Some(u64::MAX))
+        .unwrap();
     let txn = stx_protocol.get_transaction().unwrap().clone();
     (txn, outputs, test_params_change_and_txn)
 }

--- a/base_layer/core/src/transactions/transaction_protocol/transaction_initializer.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/transaction_initializer.rs
@@ -49,7 +49,7 @@ use std::{
     collections::HashMap,
     fmt::{Debug, Error, Formatter},
 };
-use tari_common_types::types::{BlindingFactor, PrivateKey, PublicKey};
+use tari_common_types::types::{BlindingFactor, HashOutput, PrivateKey, PublicKey};
 use tari_crypto::{
     commitment::HomomorphicCommitmentFactory,
     keys::{PublicKey as PublicKeyTrait, SecretKey},
@@ -381,6 +381,7 @@ impl SenderTransactionInitializer {
                                 .clone(),
                             PublicKey::from_secret_key(&change_sender_offset_private_key),
                             metadata_signature,
+                            0,
                         );
                         Ok((fee_with_change, v, Some(change_unblinded_output)))
                     },
@@ -421,7 +422,12 @@ impl SenderTransactionInitializer {
     /// error (so that you can continue building) along with a string listing the missing fields.
     /// If all the input data is present, but one or more fields are invalid, the function will return a
     /// `SenderTransactionProtocol` instance in the Failed state.
-    pub fn build<D: Digest>(mut self, factories: &CryptoFactories) -> Result<SenderTransactionProtocol, BuildError> {
+    pub fn build<D: Digest>(
+        mut self,
+        factories: &CryptoFactories,
+        prev_header: Option<HashOutput>,
+        height: Option<u64>,
+    ) -> Result<SenderTransactionProtocol, BuildError> {
         // Compile a list of all data that is missing
         let mut message = Vec::new();
         Self::check_value("Missing Lock Height", &self.lock_height, &mut message);
@@ -615,6 +621,8 @@ impl SenderTransactionInitializer {
             recipient_info,
             signatures: Vec::new(),
             message: self.message.unwrap_or_else(|| "".to_string()),
+            prev_header,
+            height,
         };
 
         let state = SenderState::Initializing(Box::new(sender_info));
@@ -662,7 +670,7 @@ mod test {
         let p = TestParams::new();
         // Start the builder
         let builder = SenderTransactionInitializer::new(0, create_consensus_constants(0));
-        let err = builder.build::<Blake256>(&factories).unwrap_err();
+        let err = builder.build::<Blake256>(&factories, None, Some(u64::MAX)).unwrap_err();
         let script = script!(Nop);
         // We should have a bunch of fields missing still, but we can recover and continue
         assert_eq!(
@@ -699,12 +707,12 @@ mod test {
             .with_change_script(script, ExecutionStack::default(), PrivateKey::default());
         let expected_fee = builder.fee().calculate(MicroTari(20), 1, 1, 2, 0);
         // We needed a change input, so this should fail
-        let err = builder.build::<Blake256>(&factories).unwrap_err();
+        let err = builder.build::<Blake256>(&factories, None, Some(u64::MAX)).unwrap_err();
         assert_eq!(err.message, "Change spending key was not provided");
         // Ok, give them a change output
         let mut builder = err.builder;
         builder.with_change_secret(p.change_spend_key);
-        let result = builder.build::<Blake256>(&factories).unwrap();
+        let result = builder.build::<Blake256>(&factories, None, Some(u64::MAX)).unwrap();
         // Peek inside and check the results
         if let SenderState::Finalizing(info) = result.into_state() {
             assert_eq!(info.num_recipients, 0, "Number of receivers");
@@ -746,7 +754,7 @@ mod test {
             .with_input(utxo, input)
             .with_fee_per_gram(MicroTari(4))
             .with_prevent_fee_gt_amount(false);
-        let result = builder.build::<Blake256>(&factories).unwrap();
+        let result = builder.build::<Blake256>(&factories, None, Some(u64::MAX)).unwrap();
         // Peek inside and check the results
         if let SenderState::Finalizing(info) = result.into_state() {
             assert_eq!(info.num_recipients, 0, "Number of receivers");
@@ -797,7 +805,7 @@ mod test {
             .with_input(utxo, input)
             .with_fee_per_gram(MicroTari(1))
             .with_prevent_fee_gt_amount(false);
-        let result = builder.build::<Blake256>(&factories).unwrap();
+        let result = builder.build::<Blake256>(&factories, None, Some(u64::MAX)).unwrap();
         // Peek inside and check the results
         if let SenderState::Finalizing(info) = result.into_state() {
             assert_eq!(info.num_recipients, 0, "Number of receivers");
@@ -839,7 +847,7 @@ mod test {
             let (utxo, input) = create_test_input(MicroTari(50), 0, &factories.commitment);
             builder.with_input(utxo, input);
         }
-        let err = builder.build::<Blake256>(&factories).unwrap_err();
+        let err = builder.build::<Blake256>(&factories, None, Some(u64::MAX)).unwrap_err();
         assert_eq!(err.message, "Too many inputs in transaction");
     }
 
@@ -872,7 +880,7 @@ mod test {
                 PrivateKey::random(&mut OsRng),
             );
         // .with_change_script(script, ExecutionStack::default(), PrivateKey::default());
-        let err = builder.build::<Blake256>(&factories).unwrap_err();
+        let err = builder.build::<Blake256>(&factories, None, Some(u64::MAX)).unwrap_err();
         assert_eq!(err.message, "Fee is less than the minimum");
     }
 
@@ -904,7 +912,7 @@ mod test {
                 PrivateKey::random(&mut OsRng),
             )
             .with_change_script(script, ExecutionStack::default(), PrivateKey::default());
-        let err = builder.build::<Blake256>(&factories).unwrap_err();
+        let err = builder.build::<Blake256>(&factories, None, Some(u64::MAX)).unwrap_err();
         assert_eq!(
             err.message,
             "You are spending (471 µT) more than you're providing (400 µT)."
@@ -948,7 +956,7 @@ mod test {
                 PrivateKey::random(&mut OsRng),
             )
             .with_change_script(script, ExecutionStack::default(), PrivateKey::default());
-        let result = builder.build::<Blake256>(&factories).unwrap();
+        let result = builder.build::<Blake256>(&factories, None, Some(u64::MAX)).unwrap();
         // Peek inside and check the results
         if let SenderState::Failed(TransactionProtocolError::UnsupportedError(s)) = result.into_state() {
             assert_eq!(s, "Multiple recipients are not supported yet")
@@ -996,7 +1004,7 @@ mod test {
                 PrivateKey::random(&mut OsRng),
             )
             .with_change_script(script, ExecutionStack::default(), PrivateKey::default());
-        let result = builder.build::<Blake256>(&factories).unwrap();
+        let result = builder.build::<Blake256>(&factories, None, Some(u64::MAX)).unwrap();
         // Peek inside and check the results
         if let SenderState::SingleRoundMessageReady(info) = result.into_state() {
             assert_eq!(info.num_recipients, 1, "Number of receivers");
@@ -1047,7 +1055,7 @@ mod test {
                 PrivateKey::random(&mut OsRng),
             )
             .with_change_script(script, ExecutionStack::default(), PrivateKey::default());
-        let result = builder.build::<Blake256>(&factories);
+        let result = builder.build::<Blake256>(&factories, None, Some(u64::MAX));
 
         match result {
             Ok(_) => panic!("Range proof should have failed to verify"),

--- a/base_layer/core/src/validation/block_validators/async_validator.rs
+++ b/base_layer/core/src/validation/block_validators/async_validator.rs
@@ -41,9 +41,9 @@ use crate::{
 use async_trait::async_trait;
 use futures::{stream::FuturesUnordered, StreamExt};
 use log::*;
-use std::{cmp, cmp::Ordering, thread, time::Instant};
+use std::{cmp, cmp::Ordering, convert::TryInto, thread, time::Instant};
 use tari_common_types::types::{Commitment, HashOutput, PublicKey};
-use tari_crypto::commitment::HomomorphicCommitmentFactory;
+use tari_crypto::{commitment::HomomorphicCommitmentFactory, script::ScriptContext};
 use tokio::task;
 
 /// This validator checks whether a block satisfies consensus rules.
@@ -229,12 +229,15 @@ impl<B: BlockchainBackend + 'static> BlockValidator<B> {
         let block_height = header.height;
         let commitment_factory = self.factories.commitment.clone();
         let db = self.db.inner().clone();
+        let prev_hash: [u8; 32] = header.prev_hash.as_slice().try_into().unwrap_or([0; 32]);
+        let height = header.height;
         task::spawn_blocking(move || {
             let timer = Instant::now();
             let mut aggregate_input_key = PublicKey::default();
             let mut commitment_sum = Commitment::default();
             let mut not_found_inputs = Vec::new();
             let db = db.db_read_access()?;
+
             for (i, input) in inputs.iter().enumerate() {
                 // Check for duplicates and/or incorrect sorting
                 if i > 0 && input <= &inputs[i - 1] {
@@ -268,8 +271,10 @@ impl<B: BlockchainBackend + 'static> BlockValidator<B> {
                 // Once we've found unknown inputs, the aggregate data will be discarded and there is no reason to run
                 // the tari script
                 if not_found_inputs.is_empty() {
+                    let context = ScriptContext::new(height, &prev_hash, &input.commitment);
                     // lets count up the input script public keys
-                    aggregate_input_key = aggregate_input_key + input.run_and_verify_script(&commitment_factory)?;
+                    aggregate_input_key =
+                        aggregate_input_key + input.run_and_verify_script(&commitment_factory, Some(context))?;
                     commitment_sum = &commitment_sum + &input.commitment;
                 }
             }

--- a/base_layer/core/src/validation/helpers.rs
+++ b/base_layer/core/src/validation/helpers.rs
@@ -233,6 +233,8 @@ pub fn check_accounting_balance(
             bypass_range_proof_verification,
             total_coinbase,
             factories,
+            Some(block.header.prev_hash.clone()),
+            Some(block.header.height),
         )
         .map_err(|err| {
             warn!(

--- a/base_layer/core/tests/mempool.rs
+++ b/base_layer/core/tests/mempool.rs
@@ -1066,7 +1066,9 @@ async fn consensus_validation_large_tx() {
 
     // make sure the tx was correctly made and is valid
     let factories = CryptoFactories::default();
-    assert!(tx.validate_internal_consistency(true, &factories, None).is_ok());
+    assert!(tx
+        .validate_internal_consistency(true, &factories, None, None, Some(u64::MAX))
+        .is_ok());
     let weighting = constants.transaction_weight();
     let weight = tx.calculate_weight(weighting);
 

--- a/base_layer/core/tests/node_comms_interface.rs
+++ b/base_layer/core/tests/node_comms_interface.rs
@@ -354,6 +354,7 @@ async fn inbound_fetch_blocks_before_horizon_height() {
         key,
         PublicKey::from_secret_key(&offset),
         metadata_signature,
+        0,
     );
     let mut txn = DbTransaction::new();
     txn.insert_utxo(utxo.clone(), block0.hash().clone(), 0, 4002);

--- a/base_layer/wallet/migrations/2021-11-11-094000_add_script_lock_height/up.sql
+++ b/base_layer/wallet/migrations/2021-11-11-094000_add_script_lock_height/up.sql
@@ -1,0 +1,31 @@
+--  Copyright 2021. The Tari Project
+--
+--  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+--  following conditions are met:
+--
+--  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+--  disclaimer.
+--
+--  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+--  following disclaimer in the documentation and/or other materials provided with the distribution.
+--
+--  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+--  products derived from this software without specific prior written permission.
+--
+--  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+--  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+--  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+--  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+--  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+--  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+--  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+ALTER TABLE outputs
+    ADD script_lock_height UNSIGNED BIGINT NOT NULL DEFAULT 0;
+
+ALTER TABLE outputs
+    ADD spending_priority UNSIGNED Integer NOT NULL DEFAULT 500;
+
+ALTER TABLE known_one_sided_payment_scripts
+    ADD script_lock_height UNSIGNED BIGINT NOT NULL DEFAULT 0;
+

--- a/base_layer/wallet/src/base_node_service/mock_base_node_service.rs
+++ b/base_layer/wallet/src/base_node_service/mock_base_node_service.rs
@@ -94,7 +94,7 @@ impl MockBaseNodeService {
     }
 
     pub fn set_default_base_node_state(&mut self) {
-        let metadata = ChainMetadata::new(u64::MAX, Vec::new(), 0, 0, 0);
+        let metadata = ChainMetadata::new(i64::MAX as u64, Vec::new(), 0, 0, 0);
         self.state = BaseNodeState {
             chain_metadata: Some(metadata),
             is_synced: Some(true),

--- a/base_layer/wallet/src/output_manager_service/handle.rs
+++ b/base_layer/wallet/src/output_manager_service/handle.rs
@@ -23,7 +23,7 @@
 use crate::output_manager_service::{
     error::OutputManagerError,
     service::Balance,
-    storage::models::KnownOneSidedPaymentScript,
+    storage::models::{KnownOneSidedPaymentScript, SpendingPriority},
 };
 use aes_gcm::Aes256Gcm;
 use std::{fmt, sync::Arc};
@@ -46,9 +46,9 @@ use tower::Service;
 /// API Request enum
 pub enum OutputManagerRequest {
     GetBalance,
-    AddOutput(Box<UnblindedOutput>),
-    AddOutputWithTxId((TxId, Box<UnblindedOutput>)),
-    AddUnvalidatedOutput((TxId, Box<UnblindedOutput>)),
+    AddOutput((Box<UnblindedOutput>, Option<SpendingPriority>)),
+    AddOutputWithTxId((TxId, Box<UnblindedOutput>, Option<SpendingPriority>)),
+    AddUnvalidatedOutput((TxId, Box<UnblindedOutput>, Option<SpendingPriority>)),
     UpdateOutputMetadataSignature(Box<TransactionOutput>),
     GetRecipientTransaction(TransactionSenderMessage),
     GetCoinbaseTransaction((u64, MicroTari, MicroTari, u64)),
@@ -78,6 +78,7 @@ pub enum OutputManagerRequest {
     ReinstateCancelledInboundTx(TxId),
     SetCoinbaseAbandoned(TxId, bool),
     CreateClaimShaAtomicSwapTransaction(HashOutput, PublicKey, MicroTari),
+    CreateHtlcRefundTransaction(HashOutput, MicroTari),
 }
 
 impl fmt::Display for OutputManagerRequest {
@@ -85,8 +86,11 @@ impl fmt::Display for OutputManagerRequest {
         use OutputManagerRequest::*;
         match self {
             GetBalance => write!(f, "GetBalance"),
-            AddOutput(v) => write!(f, "AddOutput ({})", v.value),
-            AddOutputWithTxId((t, v)) => write!(f, "AddOutputWithTxId ({}: {})", t, v.value),
+            AddOutput((v, _)) => write!(f, "AddOutput ({})", v.value),
+            AddOutputWithTxId((t, v, _)) => write!(f, "AddOutputWithTxId ({}: {})", t, v.value),
+            AddUnvalidatedOutput((t, v, _)) => {
+                write!(f, "AddUnvalidatedOutput ({}: {})", t, v.value)
+            },
             UpdateOutputMetadataSignature(v) => write!(
                 f,
                 "UpdateOutputMetadataSignature ({}, {}, {})",
@@ -132,9 +136,12 @@ impl fmt::Display for OutputManagerRequest {
                 pre_image,
                 fee_per_gram,
             ),
-            OutputManagerRequest::AddUnvalidatedOutput((t, v)) => {
-                write!(f, "AddUnvalidatedOutput ({}: {})", t, v.value)
-            },
+            CreateHtlcRefundTransaction(output, fee_per_gram) => write!(
+                f,
+                "CreateHtlcRefundTransaction(output hash: {}, , fee_per_gram: {} )",
+                output.to_hex(),
+                fee_per_gram,
+            ),
         }
     }
 }
@@ -168,7 +175,7 @@ pub enum OutputManagerResponse {
     AddKnownOneSidedPaymentScript,
     ReinstatedCancelledInboundTx,
     CoinbaseAbandonedSet,
-    ClaimShaAtomicSwapTransaction((u64, MicroTari, MicroTari, Transaction)),
+    ClaimHtlcTransaction((u64, MicroTari, MicroTari, Transaction)),
 }
 
 pub type OutputManagerEventSender = broadcast::Sender<Arc<OutputManagerEvent>>;
@@ -212,10 +219,14 @@ impl OutputManagerHandle {
         self.event_stream_sender.subscribe()
     }
 
-    pub async fn add_output(&mut self, output: UnblindedOutput) -> Result<(), OutputManagerError> {
+    pub async fn add_output(
+        &mut self,
+        output: UnblindedOutput,
+        spend_priority: Option<SpendingPriority>,
+    ) -> Result<(), OutputManagerError> {
         match self
             .handle
-            .call(OutputManagerRequest::AddOutput(Box::new(output)))
+            .call(OutputManagerRequest::AddOutput((Box::new(output), spend_priority)))
             .await??
         {
             OutputManagerResponse::OutputAdded => Ok(()),
@@ -227,10 +238,15 @@ impl OutputManagerHandle {
         &mut self,
         tx_id: TxId,
         output: UnblindedOutput,
+        spend_priority: Option<SpendingPriority>,
     ) -> Result<(), OutputManagerError> {
         match self
             .handle
-            .call(OutputManagerRequest::AddOutputWithTxId((tx_id, Box::new(output))))
+            .call(OutputManagerRequest::AddOutputWithTxId((
+                tx_id,
+                Box::new(output),
+                spend_priority,
+            )))
             .await??
         {
             OutputManagerResponse::OutputAdded => Ok(()),
@@ -242,10 +258,15 @@ impl OutputManagerHandle {
         &mut self,
         tx_id: TxId,
         output: UnblindedOutput,
+        spend_priority: Option<SpendingPriority>,
     ) -> Result<(), OutputManagerError> {
         match self
             .handle
-            .call(OutputManagerRequest::AddUnvalidatedOutput((tx_id, Box::new(output))))
+            .call(OutputManagerRequest::AddUnvalidatedOutput((
+                tx_id,
+                Box::new(output),
+                spend_priority,
+            )))
             .await??
         {
             OutputManagerResponse::OutputAdded => Ok(()),
@@ -456,6 +477,21 @@ impl OutputManagerHandle {
         }
     }
 
+    pub async fn create_htlc_refund_transaction(
+        &mut self,
+        output: HashOutput,
+        fee_per_gram: MicroTari,
+    ) -> Result<(u64, MicroTari, MicroTari, Transaction), OutputManagerError> {
+        match self
+            .handle
+            .call(OutputManagerRequest::CreateHtlcRefundTransaction(output, fee_per_gram))
+            .await??
+        {
+            OutputManagerResponse::ClaimHtlcTransaction(ct) => Ok(ct),
+            _ => Err(OutputManagerError::UnexpectedApiResponse),
+        }
+    }
+
     pub async fn create_claim_sha_atomic_swap_transaction(
         &mut self,
         output: HashOutput,
@@ -471,7 +507,7 @@ impl OutputManagerHandle {
             ))
             .await??
         {
-            OutputManagerResponse::ClaimShaAtomicSwapTransaction(ct) => Ok(ct),
+            OutputManagerResponse::ClaimHtlcTransaction(ct) => Ok(ct),
             _ => Err(OutputManagerError::UnexpectedApiResponse),
         }
     }

--- a/base_layer/wallet/src/output_manager_service/recovery/standard_outputs_recoverer.rs
+++ b/base_layer/wallet/src/output_manager_service/recovery/standard_outputs_recoverer.rs
@@ -93,6 +93,7 @@ where TBackend: OutputManagerBackend + 'static
                         )
                     })
             })
+            //Todo this needs some investigation. We assume Nop script here and recovery here might create an unspendable output if the script does not equal Nop.
             .map(
                 |(output, features, script, sender_offset_public_key, metadata_signature)| {
                     // Todo we need to look here that we might want to fail a specific output and not recover it as this
@@ -108,6 +109,7 @@ where TBackend: OutputManagerBackend + 'static
                         script_key,
                         sender_offset_public_key,
                         metadata_signature,
+                        0,
                     )
                 },
             )
@@ -117,7 +119,7 @@ where TBackend: OutputManagerBackend + 'static
             self.update_outputs_script_private_key_and_update_key_manager_index(output)
                 .await?;
 
-            let db_output = DbUnblindedOutput::from_unblinded_output(output.clone(), &self.factories)?;
+            let db_output = DbUnblindedOutput::from_unblinded_output(output.clone(), &self.factories, None)?;
             let output_hex = db_output.commitment.to_hex();
             if let Err(e) = self.db.add_unspent_output(db_output).await {
                 match e {

--- a/base_layer/wallet/src/output_manager_service/storage/database.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/database.rs
@@ -25,6 +25,9 @@ use crate::output_manager_service::{
     service::Balance,
     storage::models::{DbUnblindedOutput, KnownOneSidedPaymentScript, OutputStatus},
 };
+use tari_crypto::tari_utilities::hex::Hex;
+
+use crate::output_manager_service::service::UTXOSelectionStrategy;
 use aes_gcm::Aes256Gcm;
 use log::*;
 use std::{
@@ -35,7 +38,7 @@ use tari_common_types::{
     transaction::TxId,
     types::{BlindingFactor, Commitment, HashOutput},
 };
-use tari_core::transactions::transaction::TransactionOutput;
+use tari_core::transactions::{tari_amount::MicroTari, transaction::TransactionOutput};
 use tari_key_manager::cipher_seed::CipherSeed;
 
 const LOG_TARGET: &str = "wallet::output_manager_service::database";
@@ -130,6 +133,13 @@ pub trait OutputManagerBackend: Send + Sync + Clone {
     ) -> Result<Balance, OutputManagerStorageError>;
     /// Import unvalidated output
     fn add_unvalidated_output(&self, output: DbUnblindedOutput, tx_id: TxId) -> Result<(), OutputManagerStorageError>;
+
+    fn fetch_unspent_outputs_for_spending(
+        &self,
+        strategy: UTXOSelectionStrategy,
+        amount: u64,
+        current_tip_height: Option<u64>,
+    ) -> Result<Vec<DbUnblindedOutput>, OutputManagerStorageError>;
 }
 
 /// Holds the state of the KeyManager being used by the Output Manager Service
@@ -144,6 +154,7 @@ pub struct KeyManagerState {
 pub enum DbKey {
     SpentOutput(BlindingFactor),
     UnspentOutput(BlindingFactor),
+    UnspentOutputHash(HashOutput),
     AnyOutputByCommitment(Commitment),
     TimeLockedUnspentOutputs(u64),
     UnspentOutputs,
@@ -387,6 +398,22 @@ where T: OutputManagerBackend + 'static
         Ok(uo)
     }
 
+    /// Retrieves UTXOs than can be spent, sorted by priority, then value from smallest to largest.
+    pub async fn fetch_unspent_outputs_for_spending(
+        &self,
+        strategy: UTXOSelectionStrategy,
+        amount: MicroTari,
+        tip_height: Option<u64>,
+    ) -> Result<Vec<DbUnblindedOutput>, OutputManagerStorageError> {
+        let db_clone = self.db.clone();
+        let utxos = tokio::task::spawn_blocking(move || {
+            db_clone.fetch_unspent_outputs_for_spending(strategy, amount.as_u64(), tip_height)
+        })
+        .await
+        .map_err(|err| OutputManagerStorageError::BlockingTaskSpawnError(err.to_string()))??;
+        Ok(utxos)
+    }
+
     pub async fn fetch_spent_outputs(&self) -> Result<Vec<DbUnblindedOutput>, OutputManagerStorageError> {
         let db_clone = self.db.clone();
 
@@ -516,6 +543,27 @@ where T: OutputManagerBackend + 'static
         Ok(scripts)
     }
 
+    pub async fn get_unspent_output(&self, output: HashOutput) -> Result<DbUnblindedOutput, OutputManagerStorageError> {
+        let db_clone = self.db.clone();
+
+        let uo = tokio::task::spawn_blocking(
+            move || match db_clone.fetch(&DbKey::UnspentOutputHash(output.clone())) {
+                Ok(None) => log_error(
+                    DbKey::UnspentOutputHash(output.clone()),
+                    OutputManagerStorageError::UnexpectedResult(
+                        "Could not retrieve unspent output: ".to_string() + &output.to_hex(),
+                    ),
+                ),
+                Ok(Some(DbValue::UnspentOutput(uo))) => Ok(uo),
+                Ok(Some(other)) => unexpected_result(DbKey::UnspentOutputHash(output), other),
+                Err(e) => log_error(DbKey::UnspentOutputHash(output), e),
+            },
+        )
+        .await
+        .map_err(|err| OutputManagerStorageError::BlockingTaskSpawnError(err.to_string()))??;
+        Ok(*uo)
+    }
+
     pub async fn get_last_mined_output(&self) -> Result<Option<DbUnblindedOutput>, OutputManagerStorageError> {
         self.db.get_last_mined_output()
     }
@@ -630,6 +678,7 @@ impl Display for DbKey {
         match self {
             DbKey::SpentOutput(_) => f.write_str(&"Spent Output Key".to_string()),
             DbKey::UnspentOutput(_) => f.write_str(&"Unspent Output Key".to_string()),
+            DbKey::UnspentOutputHash(_) => f.write_str(&"Unspent Output Hash Key".to_string()),
             DbKey::UnspentOutputs => f.write_str(&"Unspent Outputs Key".to_string()),
             DbKey::SpentOutputs => f.write_str(&"Spent Outputs Key".to_string()),
             DbKey::KeyManagerState => f.write_str(&"Key Manager State".to_string()),

--- a/base_layer/wallet/src/output_manager_service/storage/models.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/models.rs
@@ -39,12 +39,14 @@ pub struct DbUnblindedOutput {
     pub mined_mmr_position: Option<u64>,
     pub marked_deleted_at_height: Option<u64>,
     pub marked_deleted_in_block: Option<BlockHash>,
+    pub spend_priority: SpendingPriority,
 }
 
 impl DbUnblindedOutput {
     pub fn from_unblinded_output(
         output: UnblindedOutput,
         factory: &CryptoFactories,
+        spend_priority: Option<SpendingPriority>,
     ) -> Result<DbUnblindedOutput, OutputManagerStorageError> {
         let tx_out = output.as_transaction_output(factory)?;
         Ok(DbUnblindedOutput {
@@ -56,6 +58,7 @@ impl DbUnblindedOutput {
             mined_mmr_position: None,
             marked_deleted_at_height: None,
             marked_deleted_in_block: None,
+            spend_priority: spend_priority.unwrap_or(SpendingPriority::Normal),
         })
     }
 
@@ -63,6 +66,7 @@ impl DbUnblindedOutput {
         output: UnblindedOutput,
         factory: &CryptoFactories,
         rewind_data: &RewindData,
+        spend_priority: Option<SpendingPriority>,
     ) -> Result<DbUnblindedOutput, OutputManagerStorageError> {
         let tx_out = output.as_rewindable_transaction_output(factory, rewind_data)?;
         Ok(DbUnblindedOutput {
@@ -74,6 +78,7 @@ impl DbUnblindedOutput {
             mined_mmr_position: None,
             marked_deleted_at_height: None,
             marked_deleted_in_block: None,
+            spend_priority: spend_priority.unwrap_or(SpendingPriority::Normal),
         })
     }
 }
@@ -105,11 +110,38 @@ impl Ord for DbUnblindedOutput {
 impl Eq for DbUnblindedOutput {}
 
 #[derive(Debug, Clone)]
+pub enum SpendingPriority {
+    Normal,
+    HtlcSpendAsap,
+    Unknown,
+}
+
+impl From<u32> for SpendingPriority {
+    fn from(value: u32) -> Self {
+        match value {
+            100 => SpendingPriority::HtlcSpendAsap,
+            500 => SpendingPriority::Normal,
+            _ => SpendingPriority::Unknown,
+        }
+    }
+}
+
+impl From<SpendingPriority> for u32 {
+    fn from(value: SpendingPriority) -> Self {
+        match value {
+            SpendingPriority::HtlcSpendAsap => 100,
+            SpendingPriority::Normal | SpendingPriority::Unknown => 500,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct KnownOneSidedPaymentScript {
     pub script_hash: Vec<u8>,
     pub private_key: PrivateKey,
     pub script: TariScript,
     pub input: ExecutionStack,
+    pub script_lock_height: u64,
 }
 
 impl PartialEq for KnownOneSidedPaymentScript {

--- a/base_layer/wallet/src/output_manager_service/storage/sqlite_db/mod.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/sqlite_db/mod.rs
@@ -51,7 +51,7 @@ use tari_key_manager::cipher_seed::CipherSeed;
 use crate::{
     output_manager_service::{
         error::OutputManagerStorageError,
-        service::Balance,
+        service::{Balance, UTXOSelectionStrategy},
         storage::{
             database::{DbKey, DbKeyValuePair, DbValue, KeyManagerState, OutputManagerBackend, WriteOperation},
             models::{DbUnblindedOutput, KnownOneSidedPaymentScript, OutputStatus},
@@ -171,6 +171,19 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
                 },
             },
             DbKey::UnspentOutput(k) => match OutputSql::find_status(&k.to_vec(), OutputStatus::Unspent, &conn) {
+                Ok(mut o) => {
+                    self.decrypt_if_necessary(&mut o)?;
+                    Some(DbValue::UnspentOutput(Box::new(DbUnblindedOutput::try_from(o)?)))
+                },
+                Err(e) => {
+                    match e {
+                        OutputManagerStorageError::DieselError(DieselError::NotFound) => (),
+                        e => return Err(e),
+                    };
+                    None
+                },
+            },
+            DbKey::UnspentOutputHash(hash) => match OutputSql::find_by_hash(hash, OutputStatus::Unspent, &(*conn)) {
                 Ok(mut o) => {
                     self.decrypt_if_necessary(&mut o)?;
                     Some(DbValue::UnspentOutput(Box::new(DbUnblindedOutput::try_from(o)?)))
@@ -386,6 +399,7 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
                     }
                 },
                 DbKey::SpentOutput(_s) => return Err(OutputManagerStorageError::OperationNotSupported),
+                DbKey::UnspentOutputHash(_h) => return Err(OutputManagerStorageError::OperationNotSupported),
                 DbKey::UnspentOutput(_k) => return Err(OutputManagerStorageError::OperationNotSupported),
                 DbKey::UnspentOutputs => return Err(OutputManagerStorageError::OperationNotSupported),
                 DbKey::SpentOutputs => return Err(OutputManagerStorageError::OperationNotSupported),
@@ -1190,6 +1204,37 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
         }
         Ok(())
     }
+
+    /// Retrieves UTXOs than can be spent, sorted by priority, then value from smallest to largest.
+    fn fetch_unspent_outputs_for_spending(
+        &self,
+        strategy: UTXOSelectionStrategy,
+        amount: u64,
+        tip_height: Option<u64>,
+    ) -> Result<Vec<DbUnblindedOutput>, OutputManagerStorageError> {
+        let start = Instant::now();
+        let conn = self.database_connection.get_pooled_connection()?;
+        let acquire_lock = start.elapsed();
+        let tip = match tip_height {
+            Some(v) => v as i64,
+            None => i64::MAX,
+        };
+        let mut outputs = OutputSql::fetch_unspent_outputs_for_spending(strategy, amount, tip, &conn)?;
+        for o in outputs.iter_mut() {
+            self.decrypt_if_necessary(o)?;
+        }
+        trace!(
+            target: LOG_TARGET,
+            "sqlite profile - fetch_unspent_outputs_for_spending: lock {} + db_op {} = {} ms",
+            acquire_lock.as_millis(),
+            (start.elapsed() - acquire_lock).as_millis(),
+            start.elapsed().as_millis()
+        );
+        outputs
+            .iter()
+            .map(|o| DbUnblindedOutput::try_from(o.clone()))
+            .collect::<Result<Vec<_>, _>>()
+    }
 }
 
 impl TryFrom<i32> for OutputStatus {
@@ -1436,6 +1481,7 @@ pub struct KnownOneSidedPaymentScriptSql {
     pub private_key: Vec<u8>,
     pub script: Vec<u8>,
     pub input: Vec<u8>,
+    pub script_lock_height: i64,
 }
 
 /// These are the fields that can be updated for an Output
@@ -1536,11 +1582,13 @@ impl TryFrom<KnownOneSidedPaymentScriptSql> for KnownOneSidedPaymentScript {
             error!(target: LOG_TARGET, "Could not create execution stack from stored bytes");
             OutputManagerStorageError::ConversionError
         })?;
+        let script_lock_height = o.script_lock_height as u64;
         Ok(KnownOneSidedPaymentScript {
             script_hash,
             private_key,
             script,
             input,
+            script_lock_height,
         })
     }
 }
@@ -1548,6 +1596,7 @@ impl TryFrom<KnownOneSidedPaymentScriptSql> for KnownOneSidedPaymentScript {
 /// Conversion from an KnownOneSidedPaymentScriptSQL to the datatype form
 impl From<KnownOneSidedPaymentScript> for KnownOneSidedPaymentScriptSql {
     fn from(known_script: KnownOneSidedPaymentScript) -> Self {
+        let script_lock_height = known_script.script_lock_height as i64;
         let script_hash = known_script.script_hash;
         let private_key = known_script.private_key.as_bytes().to_vec();
         let script = known_script.script.as_bytes().to_vec();
@@ -1557,6 +1606,7 @@ impl From<KnownOneSidedPaymentScript> for KnownOneSidedPaymentScriptSql {
             private_key,
             script,
             input,
+            script_lock_height,
         }
     }
 }
@@ -1644,7 +1694,7 @@ mod test {
 
         for _i in 0..2 {
             let (_, uo) = make_input(MicroTari::from(100 + OsRng.next_u64() % 1000));
-            let uo = DbUnblindedOutput::from_unblinded_output(uo, &factories).unwrap();
+            let uo = DbUnblindedOutput::from_unblinded_output(uo, &factories, None).unwrap();
             let o = NewOutputSql::new(uo, OutputStatus::Unspent, None, None).unwrap();
             outputs.push(o.clone());
             outputs_unspent.push(o.clone());
@@ -1653,7 +1703,7 @@ mod test {
 
         for _i in 0..3 {
             let (_, uo) = make_input(MicroTari::from(100 + OsRng.next_u64() % 1000));
-            let uo = DbUnblindedOutput::from_unblinded_output(uo, &factories).unwrap();
+            let uo = DbUnblindedOutput::from_unblinded_output(uo, &factories, None).unwrap();
             let o = NewOutputSql::new(uo, OutputStatus::Spent, None, None).unwrap();
             outputs.push(o.clone());
             outputs_spent.push(o.clone());
@@ -1768,7 +1818,7 @@ mod test {
         let factories = CryptoFactories::default();
 
         let (_, uo) = make_input(MicroTari::from(100 + OsRng.next_u64() % 1000));
-        let uo = DbUnblindedOutput::from_unblinded_output(uo, &factories).unwrap();
+        let uo = DbUnblindedOutput::from_unblinded_output(uo, &factories, None).unwrap();
         let output = NewOutputSql::new(uo, OutputStatus::Unspent, None, None).unwrap();
 
         let key = GenericArray::from_slice(b"an example very very secret key.");
@@ -1886,12 +1936,12 @@ mod test {
             let _state_sql = NewKeyManagerStateSql::from(starting_state).commit(&conn).unwrap();
 
             let (_, uo) = make_input(MicroTari::from(100 + OsRng.next_u64() % 1000));
-            let uo = DbUnblindedOutput::from_unblinded_output(uo, &factories).unwrap();
+            let uo = DbUnblindedOutput::from_unblinded_output(uo, &factories, None).unwrap();
             let output = NewOutputSql::new(uo, OutputStatus::Unspent, None, None).unwrap();
             output.commit(&conn).unwrap();
 
             let (_, uo2) = make_input(MicroTari::from(100 + OsRng.next_u64() % 1000));
-            let uo2 = DbUnblindedOutput::from_unblinded_output(uo2, &factories).unwrap();
+            let uo2 = DbUnblindedOutput::from_unblinded_output(uo2, &factories, None).unwrap();
             let output2 = NewOutputSql::new(uo2, OutputStatus::Unspent, None, None).unwrap();
             output2.commit(&conn).unwrap();
         }

--- a/base_layer/wallet/src/schema.rs
+++ b/base_layer/wallet/src/schema.rs
@@ -68,6 +68,7 @@ table! {
         private_key -> Binary,
         script -> Binary,
         input -> Binary,
+        script_lock_height -> BigInt,
     }
 }
 
@@ -112,6 +113,8 @@ table! {
         received_in_tx_id -> Nullable<BigInt>,
         spent_in_tx_id -> Nullable<BigInt>,
         coinbase_block_height -> Nullable<BigInt>,
+        script_lock_height -> BigInt,
+        spending_priority -> Integer,
     }
 }
 

--- a/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
@@ -2145,7 +2145,7 @@ mod test {
             )
             .with_change_script(script!(Nop), ExecutionStack::default(), PrivateKey::random(&mut OsRng));
 
-        let mut stp = builder.build::<HashDigest>(&factories).unwrap();
+        let mut stp = builder.build::<HashDigest>(&factories, None, Some(u64::MAX)).unwrap();
 
         let outbound_tx1 = OutboundTransaction {
             tx_id: 1u64,

--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -355,6 +355,7 @@ where
         metadata_signature: ComSignature,
         script_private_key: &PrivateKey,
         sender_offset_public_key: &PublicKey,
+        script_lock_height: u64,
     ) -> Result<TxId, WalletError> {
         let unblinded_output = UnblindedOutput::new(
             amount,
@@ -365,6 +366,7 @@ where
             script_private_key.clone(),
             sender_offset_public_key.clone(),
             metadata_signature,
+            script_lock_height,
         );
 
         let tx_id = self
@@ -373,7 +375,7 @@ where
             .await?;
 
         self.output_manager_service
-            .add_unvalidated_output(tx_id, unblinded_output.clone())
+            .add_unvalidated_output(tx_id, unblinded_output.clone(), None)
             .await?;
 
         info!(
@@ -408,7 +410,7 @@ where
             .await?;
 
         self.output_manager_service
-            .add_output_with_tx_id(tx_id, unblinded_output.clone())
+            .add_output_with_tx_id(tx_id, unblinded_output.clone(), None)
             .await?;
 
         info!(
@@ -559,6 +561,7 @@ pub async fn persist_one_sided_payment_script_for_node_identity(
         private_key: node_identity.secret_key().clone(),
         script,
         input: ExecutionStack::default(),
+        script_lock_height: 0,
     };
 
     output_manager_service.add_known_script(known_script).await?;

--- a/base_layer/wallet/tests/output_manager_service/storage.rs
+++ b/base_layer/wallet/tests/output_manager_service/storage.rs
@@ -55,7 +55,7 @@ pub fn test_db_backend<T: OutputManagerBackend + 'static>(backend: T) {
             MicroTari::from(100 + OsRng.next_u64() % 1000),
             &factories.commitment,
         );
-        let mut uo = DbUnblindedOutput::from_unblinded_output(uo, &factories).unwrap();
+        let mut uo = DbUnblindedOutput::from_unblinded_output(uo, &factories, None).unwrap();
         uo.unblinded_output.features.maturity = i;
         runtime.block_on(db.add_unspent_output(uo.clone())).unwrap();
         unspent_outputs.push(uo);
@@ -102,7 +102,7 @@ pub fn test_db_backend<T: OutputManagerBackend + 'static>(backend: T) {
                 MicroTari::from(100 + OsRng.next_u64() % 1000),
                 &factories.commitment,
             );
-            let uo = DbUnblindedOutput::from_unblinded_output(uo, &factories).unwrap();
+            let uo = DbUnblindedOutput::from_unblinded_output(uo, &factories, None).unwrap();
             runtime.block_on(db.add_unspent_output(uo.clone())).unwrap();
             pending_tx.outputs_to_be_spent.push(uo);
         }
@@ -112,7 +112,7 @@ pub fn test_db_backend<T: OutputManagerBackend + 'static>(backend: T) {
                 MicroTari::from(100 + OsRng.next_u64() % 1000),
                 &factories.commitment,
             );
-            let uo = DbUnblindedOutput::from_unblinded_output(uo, &factories).unwrap();
+            let uo = DbUnblindedOutput::from_unblinded_output(uo, &factories, None).unwrap();
             pending_tx.outputs_to_be_received.push(uo);
         }
         runtime
@@ -254,7 +254,7 @@ pub fn test_db_backend<T: OutputManagerBackend + 'static>(backend: T) {
         MicroTari::from(100 + OsRng.next_u64() % 1000),
         &factories.commitment,
     );
-    let output_to_be_received = DbUnblindedOutput::from_unblinded_output(uo, &factories).unwrap();
+    let output_to_be_received = DbUnblindedOutput::from_unblinded_output(uo, &factories, None).unwrap();
     runtime
         .block_on(db.add_output_to_be_received(11, output_to_be_received.clone(), None))
         .unwrap();
@@ -381,7 +381,7 @@ pub async fn test_short_term_encumberance() {
             MicroTari::from(100 + OsRng.next_u64() % 1000),
             &factories.commitment,
         );
-        let mut uo = DbUnblindedOutput::from_unblinded_output(uo, &factories).unwrap();
+        let mut uo = DbUnblindedOutput::from_unblinded_output(uo, &factories, None).unwrap();
         uo.unblinded_output.features.maturity = i;
         db.add_unspent_output(uo.clone()).await.unwrap();
         unspent_outputs.push(uo);
@@ -434,7 +434,7 @@ pub async fn test_no_duplicate_outputs() {
 
     // create an output
     let (_ti, uo) = make_input(&mut OsRng, MicroTari::from(1000), &factories.commitment);
-    let uo = DbUnblindedOutput::from_unblinded_output(uo, &factories).unwrap();
+    let uo = DbUnblindedOutput::from_unblinded_output(uo, &factories, None).unwrap();
 
     // add it to the database
     let result = db.add_unspent_output(uo.clone()).await;

--- a/base_layer/wallet/tests/support/comms_rpc.rs
+++ b/base_layer/wallet/tests/support/comms_rpc.rs
@@ -131,7 +131,7 @@ impl BaseNodeWalletRpcMockState {
             })),
             tip_info_response: Arc::new(Mutex::new(TipInfoResponse {
                 metadata: Some(ChainMetadataProto {
-                    height_of_longest_chain: Some(std::u64::MAX),
+                    height_of_longest_chain: Some(std::i64::MAX as u64),
                     best_block: Some(Vec::new()),
                     accumulated_difficulty: Vec::new(),
                     pruned_height: 0,

--- a/base_layer/wallet/tests/transaction_service/service.rs
+++ b/base_layer/wallet/tests/transaction_service/service.rs
@@ -20,14 +20,6 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{
-    collections::HashMap,
-    convert::{TryFrom, TryInto},
-    path::Path,
-    sync::Arc,
-    time::Duration,
-};
-
 use chrono::{Duration as ChronoDuration, Utc};
 use futures::{
     channel::{mpsc, mpsc::Sender},
@@ -36,6 +28,13 @@ use futures::{
 };
 use prost::Message;
 use rand::{rngs::OsRng, RngCore};
+use std::{
+    collections::HashMap,
+    convert::{TryFrom, TryInto},
+    path::Path,
+    sync::Arc,
+    time::Duration,
+};
 use tari_crypto::{
     commitment::HomomorphicCommitmentFactory,
     common::Blake256,
@@ -193,7 +192,7 @@ pub fn setup_transaction_service<P: AsRef<Path>>(
     ));
 
     let db = WalletDatabase::new(WalletSqliteDatabase::new(db_connection.clone(), None).unwrap());
-    let metadata = ChainMetadata::new(std::u64::MAX, Vec::new(), 0, 0, 0);
+    let metadata = ChainMetadata::new(std::i64::MAX as u64, Vec::new(), 0, 0, 0);
 
     runtime.block_on(db.set_chain_metadata(metadata)).unwrap();
 
@@ -540,7 +539,7 @@ fn manage_single_transaction() {
         ))
         .is_err());
 
-    runtime.block_on(alice_oms.add_output(uo1)).unwrap();
+    runtime.block_on(alice_oms.add_output(uo1, None)).unwrap();
     let message = "TAKE MAH MONEYS!".to_string();
     runtime
         .block_on(alice_ts.send_transaction(
@@ -655,7 +654,7 @@ fn single_transaction_to_self() {
         let initial_wallet_value = 2500.into();
         let (_utxo, uo1) = make_input(&mut OsRng, initial_wallet_value, &factories.commitment);
 
-        alice_oms.add_output(uo1).await.unwrap();
+        alice_oms.add_output(uo1, None).await.unwrap();
         let message = "TAKE MAH _OWN_ MONEYS!".to_string();
         let value = 1000.into();
         let tx_id = alice_ts
@@ -738,7 +737,7 @@ fn send_one_sided_transaction_to_other() {
     let initial_wallet_value = 2500.into();
     let (_utxo, uo1) = make_input(&mut OsRng, initial_wallet_value, &factories.commitment);
     let mut alice_oms_clone = alice_oms.clone();
-    runtime.block_on(async move { alice_oms_clone.add_output(uo1).await.unwrap() });
+    runtime.block_on(async move { alice_oms_clone.add_output(uo1, None).await.unwrap() });
 
     let message = "SEE IF YOU CAN CATCH THIS ONE..... SIDED TX!".to_string();
     let value = 1000.into();
@@ -860,6 +859,7 @@ fn recover_one_sided_transaction() {
         private_key: bob_node_identity.secret_key().clone(),
         script,
         input: ExecutionStack::default(),
+        script_lock_height: 0,
     };
     let mut cloned_bob_oms = bob_oms.clone();
     runtime.block_on(async move {
@@ -871,7 +871,7 @@ fn recover_one_sided_transaction() {
     let initial_wallet_value = 2500.into();
     let (_utxo, uo1) = make_input(&mut OsRng, initial_wallet_value, &factories.commitment);
     let mut alice_oms_clone = alice_oms;
-    runtime.block_on(async move { alice_oms_clone.add_output(uo1).await.unwrap() });
+    runtime.block_on(async move { alice_oms_clone.add_output(uo1, None).await.unwrap() });
 
     let message = "".to_string();
     let value = 1000.into();
@@ -944,7 +944,7 @@ fn test_htlc_send_and_claim() {
     let bob_connection = run_migration_and_create_sqlite_connection(&bob_db_path, 16).unwrap();
 
     let shutdown = Shutdown::new();
-    let (alice_ts, alice_oms, _alice_comms, mut alice_connectivity) = setup_transaction_service(
+    let (mut alice_ts, mut alice_oms, _alice_comms, mut alice_connectivity) = setup_transaction_service(
         &mut runtime,
         alice_node_identity,
         vec![],
@@ -985,7 +985,7 @@ fn test_htlc_send_and_claim() {
     let initial_wallet_value = 2500.into();
     let (_utxo, uo1) = make_input(&mut OsRng, initial_wallet_value, &factories.commitment);
     let mut alice_oms_clone = alice_oms.clone();
-    runtime.block_on(async move { alice_oms_clone.add_output(uo1).await.unwrap() });
+    runtime.block_on(async move { alice_oms_clone.add_output(uo1, None).await.unwrap() });
 
     let message = "".to_string();
     let value = 1000.into();
@@ -998,10 +998,8 @@ fn test_htlc_send_and_claim() {
             .expect("Alice sending HTLC transaction")
     });
 
-    let mut alice_ts_clone2 = alice_ts;
-    let mut alice_oms_clone = alice_oms;
     runtime.block_on(async move {
-        let completed_tx = alice_ts_clone2
+        let completed_tx = alice_ts
             .get_completed_transaction(tx_id)
             .await
             .expect("Could not find completed HTLC tx");
@@ -1009,7 +1007,7 @@ fn test_htlc_send_and_claim() {
         let fees = completed_tx.fee;
 
         assert_eq!(
-            alice_oms_clone.get_balance().await.unwrap().pending_incoming_balance,
+            alice_oms.get_balance().await.unwrap().pending_incoming_balance,
             initial_wallet_value - value - fees
         );
     });
@@ -1097,7 +1095,7 @@ fn send_one_sided_transaction_to_self() {
     let initial_wallet_value = 2500.into();
     let (_utxo, uo1) = make_input(&mut OsRng, initial_wallet_value, &factories.commitment);
     let mut alice_oms_clone = alice_oms;
-    runtime.block_on(async move { alice_oms_clone.add_output(uo1).await.unwrap() });
+    runtime.block_on(async move { alice_oms_clone.add_output(uo1, None).await.unwrap() });
 
     let message = "SEE IF YOU CAN CATCH THIS ONE..... SIDED TX!".to_string();
     let value = 1000.into();
@@ -1223,17 +1221,17 @@ fn manage_multiple_transactions() {
     );
 
     let (_utxo, uo2) = make_input(&mut OsRng, MicroTari(3500), &factories.commitment);
-    runtime.block_on(bob_oms.add_output(uo2)).unwrap();
+    runtime.block_on(bob_oms.add_output(uo2, None)).unwrap();
     let (_utxo, uo3) = make_input(&mut OsRng, MicroTari(4500), &factories.commitment);
-    runtime.block_on(carol_oms.add_output(uo3)).unwrap();
+    runtime.block_on(carol_oms.add_output(uo3, None)).unwrap();
 
     // Add some funds to Alices wallet
     let (_utxo, uo1a) = make_input(&mut OsRng, MicroTari(5500), &factories.commitment);
-    runtime.block_on(alice_oms.add_output(uo1a)).unwrap();
+    runtime.block_on(alice_oms.add_output(uo1a, None)).unwrap();
     let (_utxo, uo1b) = make_input(&mut OsRng, MicroTari(3000), &factories.commitment);
-    runtime.block_on(alice_oms.add_output(uo1b)).unwrap();
+    runtime.block_on(alice_oms.add_output(uo1b, None)).unwrap();
     let (_utxo, uo1c) = make_input(&mut OsRng, MicroTari(3000), &factories.commitment);
-    runtime.block_on(alice_oms.add_output(uo1c)).unwrap();
+    runtime.block_on(alice_oms.add_output(uo1c, None)).unwrap();
 
     // A series of interleaved transactions. First with Bob and Carol offline and then two with them online
     let value_a_to_b_1 = MicroTari::from(1000);
@@ -1412,7 +1410,7 @@ fn test_accepting_unknown_tx_id_and_malformed_reply() {
 
     let (_utxo, uo) = make_input(&mut OsRng, MicroTari(250000), &factories.commitment);
 
-    runtime.block_on(alice_output_manager.add_output(uo)).unwrap();
+    runtime.block_on(alice_output_manager.add_output(uo, None)).unwrap();
 
     runtime
         .block_on(alice_ts.send_transaction(
@@ -1537,7 +1535,7 @@ fn finalize_tx_with_incorrect_pubkey() {
     ) = setup_transaction_service_no_comms(&mut runtime, factories.clone(), connection_bob, None);
 
     let (_utxo, uo) = make_input(&mut OsRng, MicroTari(250000), &factories.commitment);
-    runtime.block_on(bob_output_manager.add_output(uo)).unwrap();
+    runtime.block_on(bob_output_manager.add_output(uo, None)).unwrap();
     let mut stp = runtime
         .block_on(bob_output_manager.prepare_transaction_to_send(
             OsRng.next_u64(),
@@ -1571,7 +1569,8 @@ fn finalize_tx_with_incorrect_pubkey() {
 
     stp.add_single_recipient_info(recipient_reply.clone(), &factories.range_proof)
         .unwrap();
-    stp.finalize(KernelFeatures::empty(), &factories).unwrap();
+    stp.finalize(KernelFeatures::empty(), &factories, None, Some(u64::MAX))
+        .unwrap();
     let tx = stp.get_transaction().unwrap();
 
     let finalized_transaction_message = proto::TransactionFinalizedMessage {
@@ -1666,7 +1665,7 @@ fn finalize_tx_with_missing_output() {
 
     let (_utxo, uo) = make_input(&mut OsRng, MicroTari(250000), &factories.commitment);
 
-    runtime.block_on(bob_output_manager.add_output(uo)).unwrap();
+    runtime.block_on(bob_output_manager.add_output(uo, None)).unwrap();
 
     let mut stp = runtime
         .block_on(bob_output_manager.prepare_transaction_to_send(
@@ -1701,7 +1700,8 @@ fn finalize_tx_with_missing_output() {
 
     stp.add_single_recipient_info(recipient_reply.clone(), &factories.range_proof)
         .unwrap();
-    stp.finalize(KernelFeatures::empty(), &factories).unwrap();
+    stp.finalize(KernelFeatures::empty(), &factories, None, Some(u64::MAX))
+        .unwrap();
 
     let finalized_transaction_message = proto::TransactionFinalizedMessage {
         tx_id: recipient_reply.tx_id,
@@ -1817,11 +1817,11 @@ fn discovery_async_return_test() {
     let mut alice_event_stream = alice_ts.get_event_stream();
 
     let (_utxo, uo1a) = make_input(&mut OsRng, MicroTari(5500), &factories.commitment);
-    runtime.block_on(alice_oms.add_output(uo1a)).unwrap();
+    runtime.block_on(alice_oms.add_output(uo1a, None)).unwrap();
     let (_utxo, uo1b) = make_input(&mut OsRng, MicroTari(3000), &factories.commitment);
-    runtime.block_on(alice_oms.add_output(uo1b)).unwrap();
+    runtime.block_on(alice_oms.add_output(uo1b, None)).unwrap();
     let (_utxo, uo1c) = make_input(&mut OsRng, MicroTari(3000), &factories.commitment);
-    runtime.block_on(alice_oms.add_output(uo1c)).unwrap();
+    runtime.block_on(alice_oms.add_output(uo1c, None)).unwrap();
 
     let initial_balance = runtime.block_on(alice_oms.get_balance()).unwrap();
 
@@ -2126,7 +2126,7 @@ fn test_transaction_cancellation() {
 
     let alice_total_available = 250000 * uT;
     let (_utxo, uo) = make_input(&mut OsRng, alice_total_available, &factories.commitment);
-    runtime.block_on(alice_output_manager.add_output(uo)).unwrap();
+    runtime.block_on(alice_output_manager.add_output(uo, None)).unwrap();
 
     let amount_sent = 10000 * uT;
 
@@ -2248,7 +2248,7 @@ fn test_transaction_cancellation() {
         )
         .with_change_script(script!(Nop), ExecutionStack::default(), PrivateKey::random(&mut OsRng));
 
-    let mut stp = builder.build::<HashDigest>(&factories).unwrap();
+    let mut stp = builder.build::<HashDigest>(&factories, None, Some(u64::MAX)).unwrap();
     let tx_sender_msg = stp.build_single_round_message().unwrap();
     let tx_id2 = tx_sender_msg.tx_id;
     let proto_message = proto::TransactionSenderMessage::single(tx_sender_msg.into());
@@ -2320,7 +2320,7 @@ fn test_transaction_cancellation() {
         )
         .with_change_script(script!(Nop), ExecutionStack::default(), PrivateKey::random(&mut OsRng));
 
-    let mut stp = builder.build::<HashDigest>(&factories).unwrap();
+    let mut stp = builder.build::<HashDigest>(&factories, None, Some(u64::MAX)).unwrap();
     let tx_sender_msg = stp.build_single_round_message().unwrap();
     let tx_id3 = tx_sender_msg.tx_id;
     let proto_message = proto::TransactionSenderMessage::single(tx_sender_msg.into());
@@ -2431,7 +2431,7 @@ fn test_direct_vs_saf_send_of_tx_reply_and_finalize() {
 
     let alice_total_available = 250000 * uT;
     let (_utxo, uo) = make_input(&mut OsRng, alice_total_available, &factories.commitment);
-    runtime.block_on(alice_output_manager.add_output(uo)).unwrap();
+    runtime.block_on(alice_output_manager.add_output(uo, None)).unwrap();
 
     let amount_sent = 10000 * uT;
 
@@ -2603,7 +2603,7 @@ fn test_direct_vs_saf_send_of_tx_reply_and_finalize() {
     // Now to repeat sending so we can test the SAF send of the finalize message
     let alice_total_available = 250000 * uT;
     let (_utxo, uo) = make_input(&mut OsRng, alice_total_available, &factories.commitment);
-    runtime.block_on(alice_output_manager.add_output(uo)).unwrap();
+    runtime.block_on(alice_output_manager.add_output(uo, None)).unwrap();
 
     let amount_sent = 20000 * uT;
 
@@ -2701,13 +2701,13 @@ fn test_tx_direct_send_behaviour() {
     let mut alice_event_stream = alice_ts.get_event_stream();
 
     let (_utxo, uo) = make_input(&mut OsRng, 1000000 * uT, &factories.commitment);
-    runtime.block_on(alice_output_manager.add_output(uo)).unwrap();
+    runtime.block_on(alice_output_manager.add_output(uo, None)).unwrap();
     let (_utxo, uo) = make_input(&mut OsRng, 1000000 * uT, &factories.commitment);
-    runtime.block_on(alice_output_manager.add_output(uo)).unwrap();
+    runtime.block_on(alice_output_manager.add_output(uo, None)).unwrap();
     let (_utxo, uo) = make_input(&mut OsRng, 1000000 * uT, &factories.commitment);
-    runtime.block_on(alice_output_manager.add_output(uo)).unwrap();
+    runtime.block_on(alice_output_manager.add_output(uo, None)).unwrap();
     let (_utxo, uo) = make_input(&mut OsRng, 1000000 * uT, &factories.commitment);
-    runtime.block_on(alice_output_manager.add_output(uo)).unwrap();
+    runtime.block_on(alice_output_manager.add_output(uo, None)).unwrap();
 
     let amount_sent = 10000 * uT;
 
@@ -2939,7 +2939,7 @@ fn test_restarting_transaction_protocols() {
             inputs!(PublicKey::from_secret_key(&script_private_key)),
             script_private_key,
         );
-    let mut bob_stp = builder.build::<Blake256>(&factories).unwrap();
+    let mut bob_stp = builder.build::<Blake256>(&factories, None, Some(u64::MAX)).unwrap();
     let msg = bob_stp.build_single_round_message().unwrap();
     let bob_pre_finalize = bob_stp.clone();
 
@@ -2960,7 +2960,7 @@ fn test_restarting_transaction_protocols() {
         .add_single_recipient_info(alice_reply.clone(), &factories.range_proof)
         .unwrap();
 
-    match bob_stp.finalize(KernelFeatures::empty(), &factories) {
+    match bob_stp.finalize(KernelFeatures::empty(), &factories, None, Some(u64::MAX)) {
         Ok(_) => (),
         Err(e) => panic!("Should be able to finalize tx: {}", e),
     };
@@ -3914,7 +3914,7 @@ fn test_transaction_resending() {
     // Send a transaction to Bob
     let alice_total_available = 250000 * uT;
     let (_utxo, uo) = make_input(&mut OsRng, alice_total_available, &factories.commitment);
-    runtime.block_on(alice_output_manager.add_output(uo)).unwrap();
+    runtime.block_on(alice_output_manager.add_output(uo, None)).unwrap();
 
     let amount_sent = 10000 * uT;
 
@@ -4112,7 +4112,7 @@ fn test_resend_on_startup() {
         )
         .with_change_script(script!(Nop), ExecutionStack::default(), PrivateKey::random(&mut OsRng));
 
-    let mut stp = builder.build::<HashDigest>(&factories).unwrap();
+    let mut stp = builder.build::<HashDigest>(&factories, None, Some(u64::MAX)).unwrap();
     let stp_msg = stp.build_single_round_message().unwrap();
     let tx_sender_msg = TransactionSenderMessage::Single(Box::new(stp_msg));
 
@@ -4410,7 +4410,7 @@ fn test_replying_to_cancelled_tx() {
     // Send a transaction to Bob
     let alice_total_available = 250000 * uT;
     let (_utxo, uo) = make_input(&mut OsRng, alice_total_available, &factories.commitment);
-    runtime.block_on(alice_output_manager.add_output(uo)).unwrap();
+    runtime.block_on(alice_output_manager.add_output(uo, None)).unwrap();
 
     let amount_sent = 10000 * uT;
 
@@ -4544,7 +4544,7 @@ fn test_transaction_timeout_cancellation() {
     // Send a transaction to Bob
     let alice_total_available = 250000 * uT;
     let (_utxo, uo) = make_input(&mut OsRng, alice_total_available, &factories.commitment);
-    runtime.block_on(alice_output_manager.add_output(uo)).unwrap();
+    runtime.block_on(alice_output_manager.add_output(uo, None)).unwrap();
 
     let amount_sent = 10000 * uT;
 
@@ -4619,7 +4619,7 @@ fn test_transaction_timeout_cancellation() {
         )
         .with_change_script(script!(Nop), ExecutionStack::default(), PrivateKey::random(&mut OsRng));
 
-    let mut stp = builder.build::<HashDigest>(&factories).unwrap();
+    let mut stp = builder.build::<HashDigest>(&factories, None, Some(u64::MAX)).unwrap();
     let stp_msg = stp.build_single_round_message().unwrap();
     let tx_sender_msg = TransactionSenderMessage::Single(Box::new(stp_msg));
 
@@ -4828,10 +4828,10 @@ fn transaction_service_tx_broadcast() {
     let alice_output_value = MicroTari(250000);
 
     let (_utxo, uo) = make_input(&mut OsRng, alice_output_value, &factories.commitment);
-    runtime.block_on(alice_output_manager.add_output(uo)).unwrap();
+    runtime.block_on(alice_output_manager.add_output(uo, None)).unwrap();
 
     let (_utxo, uo2) = make_input(&mut OsRng, alice_output_value, &factories.commitment);
-    runtime.block_on(alice_output_manager.add_output(uo2)).unwrap();
+    runtime.block_on(alice_output_manager.add_output(uo2, None)).unwrap();
 
     let amount_sent1 = 10000 * uT;
 

--- a/base_layer/wallet/tests/transaction_service/storage.rs
+++ b/base_layer/wallet/tests/transaction_service/storage.rs
@@ -93,7 +93,7 @@ pub fn test_db_backend<T: TransactionBackend + 'static>(backend: T) {
         )
         .with_change_script(script!(Nop), ExecutionStack::default(), PrivateKey::random(&mut OsRng));
 
-    let stp = builder.build::<HashDigest>(&factories).unwrap();
+    let stp = builder.build::<HashDigest>(&factories, None, Some(u64::MAX)).unwrap();
 
     let messages = vec!["Hey!".to_string(), "Yo!".to_string(), "Sup!".to_string()];
     let amounts = vec![MicroTari::from(10_000), MicroTari::from(23_000), MicroTari::from(5_000)];

--- a/base_layer/wallet/tests/wallet/mod.rs
+++ b/base_layer/wallet/tests/wallet/mod.rs
@@ -156,7 +156,7 @@ async fn create_wallet(
         None,
         None,
     );
-    let metadata = ChainMetadata::new(std::u64::MAX, Vec::new(), 0, 0, 0);
+    let metadata = ChainMetadata::new(std::i64::MAX as u64, Vec::new(), 0, 0, 0);
 
     let _ = wallet_backend.write(WriteOperation::Insert(DbKeyValuePair::BaseNodeChainMetadata(metadata)));
 
@@ -241,7 +241,7 @@ async fn test_wallet() {
     let value = MicroTari::from(1000);
     let (_utxo, uo1) = make_input(&mut OsRng, MicroTari(2500), &factories.commitment);
 
-    alice_wallet.output_manager_service.add_output(uo1).await.unwrap();
+    alice_wallet.output_manager_service.add_output(uo1, None).await.unwrap();
 
     alice_wallet
         .transaction_service
@@ -577,7 +577,7 @@ fn test_store_and_forward_send_tx() {
     let (_utxo, uo1) = make_input(&mut OsRng, MicroTari(2500), &factories.commitment);
 
     alice_runtime
-        .block_on(alice_wallet.output_manager_service.add_output(uo1))
+        .block_on(alice_wallet.output_manager_service.add_output(uo1, None))
         .unwrap();
 
     let tx_id = alice_runtime
@@ -738,6 +738,7 @@ async fn test_import_utxo() {
             utxo.metadata_signature.clone(),
             &p.script_private_key,
             &p.sender_offset_public_key,
+            0,
         )
         .await
         .unwrap();

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -4381,6 +4381,7 @@ pub unsafe extern "C" fn wallet_import_utxo(
     };
 
     let public_script_key = PublicKey::from_secret_key(&(*spending_key));
+    // Todo the script_lock_height can be something other than 0, for example an HTLC transaction
     match (*wallet).runtime.block_on((*wallet).wallet.import_utxo(
         MicroTari::from(amount),
         &(*spending_key).clone(),
@@ -4392,6 +4393,7 @@ pub unsafe extern "C" fn wallet_import_utxo(
         ComSignature::default(),
         &(*spending_key).clone(),
         &Default::default(),
+        0,
     )) {
         Ok(tx_id) => {
             if let Err(e) = (*wallet)

--- a/clients/wallet_grpc_client/index.js
+++ b/clients/wallet_grpc_client/index.js
@@ -44,6 +44,7 @@ function Client(address) {
     "revalidateAllTransactions",
     "SendShaAtomicSwapTransaction",
     "claimShaAtomicSwapTransaction",
+    "ClaimHtlcRefundTransaction",
   ];
 
   this.waitForReady = (...args) => {

--- a/integration_tests/features/WalletTransfer.feature
+++ b/integration_tests/features/WalletTransfer.feature
@@ -49,3 +49,21 @@ Feature: Wallet Transfer
     And I claim an HTLC transaction with wallet WALLET_B at fee 20
     And mining node MINER mines 6 blocks
     Then I wait for wallet WALLET_B to have at least 4000000000 uT
+
+  Scenario: As a wallet I want to claim a HTLC refund transaction
+    Given I have a seed node NODE
+    # Add a 2nd node otherwise initial sync will not succeed
+    And I have 1 base nodes connected to all seed nodes
+    And I have wallet WALLET_A connected to all seed nodes
+    And I have wallet WALLET_B connected to all seed nodes
+    And I have wallet WALLET_C connected to all seed nodes
+    And I have mining node MINER connected to base node NODE and wallet WALLET_A
+    And I have mining node MINER_2 connected to base node NODE and wallet WALLET_C
+    When mining node MINER mines 10 blocks
+    Then I wait for wallet WALLET_A to have at least 10000000000 uT
+    When I broadcast HTLC transaction with 5000000000 uT from wallet WALLET_A to wallet WALLET_B at fee 20
+    # atomic swaps are set at lock of 720 blocks
+    And mining node MINER_2 mines 720 blocks
+    And I claim an HTLC refund transaction with wallet WALLET_A at fee 20
+    And mining node MINER_2 mines 6 blocks
+    Then I wait for wallet WALLET_A to have at least 9000000000 uT

--- a/integration_tests/helpers/walletClient.js
+++ b/integration_tests/helpers/walletClient.js
@@ -156,6 +156,10 @@ class WalletClient {
     return await this.client.claimShaAtomicSwapTransaction(args);
   }
 
+  async claimHtlcRefund(args) {
+    return await this.client.ClaimHtlcRefundTransaction(args);
+  }
+
   async importUtxos(outputs) {
     return await this.client.importUtxos({
       outputs: outputs,


### PR DESCRIPTION
Description
---
This Pr adds the following things:
Atomic swap refund transactions
Proper handling of the script context
Transaction spend priority
SQL query for filtering locked outputs
Fix broken get_balance tests


Motivation and Context
---
One of the features that are required for atomic swaps is to be able to process refunds. This PR now allows atomic swap refunds to be processed after the time lock of the HTLC has passed. This can happen in a manual way where the user manually asks the console-wallet via the CLI, or if the time lock has passed the wallet will automatically spend this UTXO first. 

One of the missing features of TariScript is the `scriptContext`, which allows scripts to validate the blockchain state such as block height that is required in this case. This is now piped in anywhere where the script is validated if possible. If the state cannot be gathered, the state is filled in with default values which is how it operated up to now. 

This adds in a transaction spend priority that can allow UTXO to be given a priority to be spent. This is the case for high-risk UTXO such as HTLC which more than one party can claim. Manual claim for these transactions is still advised as they can be claimed as soon as possible, but this adds a second automated state where if you want to spend some UTXO at least pick the ones that you need to spend more urgently than the other ones. 

The current `select_utxos` function uses a rust function to filter the maturity of the UTXOs to only select UTXOs it can spend. This PR completely swaps out the selection to be based completely on SQL queries which should be much faster. 

All current get_balance tests are broken in where the available and time-locked balance is asserted to be the same. This is not due to the function being broken but rather the test and the testing code. What happened is that tests use a tip_height of `u64::MAX` but this is too large as the database uses `i64::MAX`. The problem comes when `u64::MAX` is cast as `i64` as this is equal to `-1` and when the query `FROM outputs WHERE status = ? AND maturity > ? AND script_lock_height > ?` is run, it select everything as the tip is now `-1`. This ensures that the testing tip is selected as `i64::MAX` to let the queries run correctly.

How Has This Been Tested?
---
Added new tests. 
