### PR TITLE
feat(wallet): import utxo’s as EncumberedToBeReceived rather than Unspent

### DIFF
--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -373,7 +373,7 @@ where
             .await?;
 
         self.output_manager_service
-            .add_output_with_tx_id(tx_id, unblinded_output.clone())
+            .add_unvalidated_output(tx_id, unblinded_output.clone())
             .await?;
 
         info!(

--- a/base_layer/wallet/tests/wallet/mod.rs
+++ b/base_layer/wallet/tests/wallet/mod.rs
@@ -744,7 +744,7 @@ async fn test_import_utxo() {
 
     let balance = alice_wallet.output_manager_service.get_balance().await.unwrap();
 
-    assert_eq!(balance.available_balance, 20000 * uT);
+    assert_eq!(balance.pending_incoming_balance, 20000 * uT);
 
     let completed_tx = alice_wallet
         .transaction_service
@@ -755,8 +755,6 @@ async fn test_import_utxo() {
         .expect("Tx should be in collection");
 
     assert_eq!(completed_tx.amount, 20000 * uT);
-    let stored_utxo = alice_wallet.output_manager_service.get_unspent_outputs().await.unwrap()[0].clone();
-    assert_eq!(stored_utxo, utxo);
 }
 
 #[test]

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -4392,7 +4392,25 @@ pub unsafe extern "C" fn wallet_import_utxo(
         &(*spending_key).clone(),
         &Default::default(),
     )) {
-        Ok(tx_id) => tx_id,
+        Ok(tx_id) => {
+            if let Err(e) = (*wallet)
+                .runtime
+                .block_on((*wallet).wallet.output_manager_service.validate_txos())
+            {
+                error = LibWalletError::from(WalletError::OutputManagerError(e)).code;
+                ptr::swap(error_out, &mut error as *mut c_int);
+                return 0;
+            }
+            if let Err(e) = (*wallet)
+                .runtime
+                .block_on((*wallet).wallet.transaction_service.validate_transactions())
+            {
+                error = LibWalletError::from(WalletError::TransactionServiceError(e)).code;
+                ptr::swap(error_out, &mut error as *mut c_int);
+                return 0;
+            }
+            tx_id
+        },
         Err(e) => {
             error = LibWalletError::from(e).code;
             ptr::swap(error_out, &mut error as *mut c_int);


### PR DESCRIPTION
Description
---

When the Wallet imports a UTXO it would set its status to Unspent making it immediately spendable.  However, imported outputs are missing a number of pieces of data from the chain that a traditionally received output would have. Completing a validation cycle fills in this data.

However, this caused some issues in the mobile clients when importing a UTXO and quickly spending it before the first validation was complete. There were unintended edge cases when a validation completed during an active transaction negotiation.

This PR solves this problem by importing utxo’s into the wallet via the Wallet.import_utxo(…) method in the EncumberedToBeReceived status and triggering a new validation immediately. This stops the output from being selected for a transaction before the validation completes which should happen quickly if the wallet is connected to a base node.


How Has This Been Tested?
---
cargo test
