### PR TITLE
feat: improve wallet connectivity status for console wallet

### DIFF
--- a/base_layer/wallet/src/base_node_service/monitor.rs
+++ b/base_layer/wallet/src/base_node_service/monitor.rs
@@ -144,29 +144,22 @@ where
                 .and_then(|metadata| {
                     ChainMetadata::try_from(metadata).map_err(BaseNodeMonitorError::InvalidBaseNodeResponse)
                 })?;
-            let latency = timer.elapsed();
-            trace!(target: LOG_TARGET, "Obtain tip info in {} ms", latency.as_millis());
+            trace!(
+                target: LOG_TARGET,
+                "Obtain tip info in {} ms",
+                timer.elapsed().as_millis()
+            );
 
-            // TODO: This method is usually free (<1ms), but can introduce huge delays obtaining latency when the
-            // TODO: wallet?/base node? gets busy - see below:
-            // TODO: - TRACE Obtain RPC client 160 ms
-            // TODO: - TRACE Obtain tip info in 572 ms
-            // TODO: - TRACE Obtain latency info in 0 ms
-            // TODO: - DEBUG Base node ece4c616a156c1e4fe34d94d8c Tip: 52127 (Synced) Latency: 572 ms
-            // TODO: - TRACE Obtain RPC client 0 ms
-            // TODO: - TRACE Obtain tip info in 111479 ms
-            // TODO: - TRACE Obtain latency info in 278823 ms
-            // TODO: - DEBUG Base node ece4c616a156c1e4fe34d94d8c Tip: 52127 (Synced) Latency: 11011 ms
-            // let timer = Instant::now();
-            // let latency = match client.get_last_request_latency().await? {
-            //     Some(latency) => latency,
-            //     None => continue,
-            // };
-            // trace!(
-            //     target: LOG_TARGET,
-            //     "Obtain latency info in {} ms",
-            //     timer.elapsed().as_millis()
-            // );
+            let timer = Instant::now();
+            let latency = match client.get_last_request_latency().await? {
+                Some(latency) => latency,
+                None => continue,
+            };
+            trace!(
+                target: LOG_TARGET,
+                "Obtain latency info in {} ms",
+                timer.elapsed().as_millis()
+            );
 
             self.db.set_chain_metadata(chain_metadata.clone()).await?;
 

--- a/base_layer/wallet/src/connectivity_service/service.rs
+++ b/base_layer/wallet/src/connectivity_service/service.rs
@@ -88,6 +88,7 @@ impl WalletConnectivityService {
         debug!(target: LOG_TARGET, "Wallet connectivity service has started.");
         let mut check_connection =
             time::interval_at(time::Instant::now() + Duration::from_secs(5), Duration::from_secs(5));
+        self.set_online_status(OnlineStatus::Offline);
         check_connection.set_missed_tick_behavior(MissedTickBehavior::Delay);
         loop {
             tokio::select! {
@@ -116,6 +117,7 @@ impl WalletConnectivityService {
         if let Some(pool) = self.pools.as_ref() {
             if !pool.base_node_wallet_rpc_client.is_connected().await {
                 debug!(target: LOG_TARGET, "Peer connection lost. Attempting to reconnect...");
+                self.set_online_status(OnlineStatus::Offline);
                 self.setup_base_node_connection().await;
             }
         }
@@ -155,6 +157,9 @@ impl WalletConnectivityService {
                         target: LOG_TARGET,
                         "Base node connection failed: {}. Reconnecting...", e
                     );
+                    if let Some(node_id) = self.current_base_node() {
+                        self.disconnect_base_node(node_id).await;
+                    };
                     self.pending_requests.push(reply.into());
                 },
             },
@@ -185,6 +190,9 @@ impl WalletConnectivityService {
                         target: LOG_TARGET,
                         "Base node connection failed: {}. Reconnecting...", e
                     );
+                    if let Some(node_id) = self.current_base_node() {
+                        self.disconnect_base_node(node_id).await;
+                    };
                     self.pending_requests.push(reply.into());
                 },
             },
@@ -203,6 +211,14 @@ impl WalletConnectivityService {
 
     fn current_base_node(&self) -> Option<NodeId> {
         self.base_node_watch.borrow().as_ref().map(|p| p.node_id.clone())
+    }
+
+    async fn disconnect_base_node(&mut self, node_id: NodeId) {
+        if let Ok(Some(connection)) = self.connectivity.get_connection(node_id.clone()).await {
+            if connection.clone().disconnect().await.is_ok() {
+                debug!(target: LOG_TARGET, "Disconnected base node peer {}", node_id);
+            }
+        };
     }
 
     async fn setup_base_node_connection(&mut self) {
@@ -231,15 +247,18 @@ impl WalletConnectivityService {
                 },
                 Ok(false) => {
                     // Retry with updated peer
+                    self.disconnect_base_node(node_id).await;
+                    time::sleep(self.config.base_node_monitor_refresh_interval).await;
                     continue;
                 },
                 Err(e) => {
-                    if self.current_base_node() != Some(node_id) {
+                    if self.current_base_node() != Some(node_id.clone()) {
                         self.set_online_status(OnlineStatus::Connecting);
                     } else {
                         self.set_online_status(OnlineStatus::Offline);
                     }
                     warn!(target: LOG_TARGET, "{}", e);
+                    self.disconnect_base_node(node_id).await;
                     time::sleep(self.config.base_node_monitor_refresh_interval).await;
                     continue;
                 },
@@ -254,7 +273,10 @@ impl WalletConnectivityService {
     async fn try_setup_rpc_pool(&mut self, peer: NodeId) -> Result<bool, WalletConnectivityError> {
         let conn = match self.try_dial_peer(peer.clone()).await? {
             Some(c) => c,
-            None => return Ok(false),
+            None => {
+                warn!(target: LOG_TARGET, "Could not dial base node peer {}", peer);
+                return Ok(false);
+            },
         };
         debug!(
             target: LOG_TARGET,

--- a/base_layer/wallet/tests/transaction_service/service.rs
+++ b/base_layer/wallet/tests/transaction_service/service.rs
@@ -998,8 +998,8 @@ fn test_htlc_send_and_claim() {
             .expect("Alice sending HTLC transaction")
     });
 
-    let mut alice_ts_clone2 = alice_ts.clone();
-    let mut alice_oms_clone = alice_oms.clone();
+    let mut alice_ts_clone2 = alice_ts;
+    let mut alice_oms_clone = alice_oms;
     runtime.block_on(async move {
         let completed_tx = alice_ts_clone2
             .get_completed_transaction(tx_id)


### PR DESCRIPTION
Description
---
- Improved base node connection status feedback to the console wallet UI.
- Added disconnect logic for the wallet connectivity service to enable closing bad base node connections if RPC connections cannot be obtained, which will force the connection cycle to restart from scratch, rather than just waiting for the connection to become alive again.
- ~~Disabled obtaining latency information after obtaining tip information in the wallet's base node monitor, as it sometimes introduces huge additional delays.~~
~~_**Note:** Fixing this behaviour is marked for another PR._~~ _**(Fixed in PR #3579)**_

Motivation and Context
---
- Connectivity status was not always current in the console wallet under certain edge cases, observed when switching base nodes.
- Retrying to obtain an RPC connection from a bad base node connection is not efficient; this sometimes results in the base node staying offline for extended (> 30 minutes) durations.

How Has This Been Tested?
---
- System-level testing:
  - Switching base nodes and observing the connection status while (a) mining and (b) monitoring transactions to be mined.
  - Stress testing `make-it-rain`.
  - Stress testing `coin-split`.
  - Stress testing simaltaneous `make-it-rain` and `coin-split`.

See sample profiling measurements below depicting the added delay sometimes introduced by obtaining latency information, _**without the fix mentioned above**_:
``` rust
2021-11-16 14:18:07.490078500 [wallet::base_node_service::chain_metadata_monitor] TRACE Obtain RPC client 160 ms
2021-11-16 14:18:08.062610200 [wallet::base_node_service::chain_metadata_monitor] TRACE Obtain tip info in 572 ms
2021-11-16 14:18:08.062646600 [wallet::base_node_service::chain_metadata_monitor] TRACE Obtain latency info in 0 ms
2021-11-16 14:18:08.062944600 [wallet::base_node_service::chain_metadata_monitor] DEBUG Base node ece4c616a156c1e4fe34d94d8c Tip: 52127 (Synced) Latency: 572 ms
2021-11-16 14:18:37.491546100 [wallet::base_node_service::chain_metadata_monitor] TRACE Obtain RPC client 0 ms
2021-11-16 14:20:28.971178900 [wallet::base_node_service::chain_metadata_monitor] TRACE Obtain tip info in 111479 ms
2021-11-16 14:25:07.794774200 [wallet::base_node_service::chain_metadata_monitor] TRACE Obtain latency info in 278823 ms
2021-11-16 14:25:07.795167000 [wallet::base_node_service::chain_metadata_monitor] DEBUG Base node ece4c616a156c1e4fe34d94d8c Tip: 52127 (Synced) Latency: 11011 ms
2021-11-16 14:25:26.789903600 [wallet::base_node_service::chain_metadata_monitor] TRACE Obtain RPC client 0 ms
2021-11-16 14:30:35.914526200 [wallet::base_node_service::chain_metadata_monitor] TRACE Obtain tip info in 309124 ms
2021-11-16 14:34:04.569556900 [wallet::base_node_service::chain_metadata_monitor] TRACE Obtain latency info in 208654 ms
2021-11-16 14:34:04.569945400 [wallet::base_node_service::chain_metadata_monitor] DEBUG Base node ece4c616a156c1e4fe34d94d8c Tip: 52130 (Synced) Latency: 9699 ms
2021-11-16 14:34:24.885048300 [wallet::base_node_service::chain_metadata_monitor] TRACE Obtain RPC client 0 ms
2021-11-16 14:34:44.260586300 [wallet::base_node_service::chain_metadata_monitor] TRACE Obtain tip info in 19375 ms
2021-11-16 14:34:44.260734900 [wallet::base_node_service::chain_metadata_monitor] TRACE Obtain latency info in 0 ms
2021-11-16 14:34:44.261005000 [wallet::base_node_service::chain_metadata_monitor] DEBUG Base node ece4c616a156c1e4fe34d94d8c Tip: 52133 (Synced) Latency: 10712 ms
2021-11-16 14:35:03.552244200 [wallet::base_node_service::chain_metadata_monitor] TRACE Obtain RPC client 0 ms
2021-11-16 14:35:22.417825800 [wallet::base_node_service::chain_metadata_monitor] TRACE Obtain tip info in 18865 ms
2021-11-16 14:35:22.417869200 [wallet::base_node_service::chain_metadata_monitor] TRACE Obtain latency info in 0 ms
2021-11-16 14:35:22.418075300 [wallet::base_node_service::chain_metadata_monitor] DEBUG Base node ece4c616a156c1e4fe34d94d8c Tip: 52134 (Synced) Latency: 18865 ms
```
