### PR TITLE
feat: add error codes to LibWallet for CipherSeed errors

### DIFF
--- a/base_layer/wallet_ffi/src/error.rs
+++ b/base_layer/wallet_ffi/src/error.rs
@@ -26,14 +26,13 @@ use tari_crypto::{
     signatures::SchnorrSignatureError,
     tari_utilities::{hex::HexError, ByteArrayError},
 };
-use tari_key_manager::error::MnemonicError;
+use tari_key_manager::error::{KeyManagerError, MnemonicError};
 use tari_wallet::{
     contacts_service::error::{ContactsServiceError, ContactsServiceStorageError},
     error::{WalletError, WalletStorageError},
     output_manager_service::error::{OutputManagerError, OutputManagerStorageError},
     transaction_service::error::{TransactionServiceError, TransactionStorageError},
 };
-
 use thiserror::Error;
 
 const LOG_TARGET: &str = "wallet_ffi::error";
@@ -284,6 +283,22 @@ impl From<WalletError> for LibWalletError {
             },
             WalletError::WalletStorageError(WalletStorageError::InvalidPassphrase) => Self {
                 code: 428,
+                message: format!("{:?}", w),
+            },
+            WalletError::KeyManagerError(KeyManagerError::InvalidData) => Self {
+                code: 429,
+                message: format!("{:?}", w),
+            },
+            WalletError::KeyManagerError(KeyManagerError::VersionMismatch) => Self {
+                code: 430,
+                message: format!("{:?}", w),
+            },
+            WalletError::KeyManagerError(KeyManagerError::DecryptionFailed) => Self {
+                code: 431,
+                message: format!("{:?}", w),
+            },
+            WalletError::KeyManagerError(KeyManagerError::CrcError) => Self {
+                code: 432,
                 message: format!("{:?}", w),
             },
             // This is the catch all error code. Any error that is not explicitly mapped above will be given this code

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -1071,7 +1071,8 @@ pub unsafe extern "C" fn seed_words_push_word(
         return if let Err(e) = CipherSeed::from_mnemonic(&(*seed_words).0, None) {
             log::error!(
                 target: LOG_TARGET,
-                "Problem building valid private seed from seed phrase: {}", e
+                "Problem building valid private seed from seed phrase: {}",
+                e
             );
             error = LibWalletError::from(WalletError::KeyManagerError(e)).code;
             ptr::swap(error_out, &mut error as *mut c_int);

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -1071,7 +1071,7 @@ pub unsafe extern "C" fn seed_words_push_word(
         return if let Err(e) = CipherSeed::from_mnemonic(&(*seed_words).0, None) {
             log::error!(
                 target: LOG_TARGET,
-                "Problem building valid private seed from seed phrase"
+                "Problem building valid private seed from seed phrase: {}", e
             );
             error = LibWalletError::from(WalletError::KeyManagerError(e)).code;
             ptr::swap(error_out, &mut error as *mut c_int);


### PR DESCRIPTION
Description
---
This PR adds explicit error codes to the LibWallet FFI interface to return the errors that can occur when invalid seed words are used during wallet recovery. 

The new error codes are:

- Code 429: KeyManagerError::InvalidData
- Code 430: KeyManagerError::VersionMismatch
- Code 431: KeyManagerError::DecryptionFailed
- Code 432: KeyManagerError::CrcError


How Has This Been Tested?
---
cargo test
