### PR TITLE
fix: remove delay from last request latency call

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4513,8 +4513,6 @@ dependencies = [
  "log",
  "log4rs 1.0.0",
  "multiaddr",
- "opentelemetry",
- "opentelemetry-jaeger",
  "path-clean",
  "prost-build",
  "serde 1.0.130",
@@ -4527,8 +4525,6 @@ dependencies = [
  "thiserror",
  "toml 0.5.8",
  "tracing",
- "tracing-opentelemetry",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/base_layer/core/src/base_node/state_machine_service/states/horizon_state_sync/horizon_state_synchronization.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/horizon_state_sync/horizon_state_synchronization.rs
@@ -159,7 +159,7 @@ impl<'a, B: BlockchainBackend + 'static> HorizonStateSynchronization<'a, B> {
             remote_num_kernels - local_num_kernels,
         );
 
-        let latency = client.get_last_request_latency().await?;
+        let latency = client.get_last_request_latency();
         debug!(
             target: LOG_TARGET,
             "Initiating kernel sync with peer `{}` (latency = {}ms)",
@@ -287,7 +287,7 @@ impl<'a, B: BlockchainBackend + 'static> HorizonStateSynchronization<'a, B> {
         let end = remote_num_outputs;
         let end_hash = to_header.hash();
 
-        let latency = client.get_last_request_latency().await?;
+        let latency = client.get_last_request_latency();
         debug!(
             target: LOG_TARGET,
             "Initiating output sync with peer `{}` (latency = {}ms)",

--- a/base_layer/core/src/base_node/sync/header_sync/synchronizer.rs
+++ b/base_layer/core/src/base_node/sync/header_sync/synchronizer.rs
@@ -218,7 +218,7 @@ impl<'a, B: BlockchainBackend + 'static> HeaderSynchronizer<'a, B> {
         mut conn: PeerConnection,
     ) -> Result<(), BlockHeaderSyncError> {
         let mut client = conn.connect_rpc::<rpc::BaseNodeSyncRpcClient>().await?;
-        let latency = client.get_last_request_latency().await?;
+        let latency = client.get_last_request_latency();
         debug!(
             target: LOG_TARGET,
             "Initiating header sync with peer `{}` (sync latency = {}ms)",

--- a/base_layer/wallet/src/base_node_service/monitor.rs
+++ b/base_layer/wallet/src/base_node_service/monitor.rs
@@ -150,7 +150,7 @@ where
                 timer.elapsed().as_millis()
             );
 
-            let latency = match client.get_last_request_latency().await? {
+            let latency = match client.get_last_request_latency() {
                 Some(latency) => latency,
                 None => continue,
             };

--- a/base_layer/wallet/src/utxo_scanner_service/utxo_scanning.rs
+++ b/base_layer/wallet/src/utxo_scanner_service/utxo_scanning.rs
@@ -268,7 +268,7 @@ where TBackend: WalletBackend + 'static
             .connect_rpc_using_builder(BaseNodeSyncRpcClient::builder().with_deadline(Duration::from_secs(60)))
             .await?;
 
-        let latency = client.get_last_request_latency().await?;
+        let latency = client.get_last_request_latency();
         self.publish_event(UtxoScannerEvent::ConnectedToBaseNode(
             peer.clone(),
             latency.unwrap_or_default(),

--- a/base_layer/wallet/tests/transaction_service/service.rs
+++ b/base_layer/wallet/tests/transaction_service/service.rs
@@ -944,7 +944,7 @@ fn test_htlc_send_and_claim() {
     let bob_connection = run_migration_and_create_sqlite_connection(&bob_db_path, 16).unwrap();
 
     let shutdown = Shutdown::new();
-    let (alice_ts, alice_oms, _alice_comms, mut alice_connectivity) = setup_transaction_service(
+    let (mut alice_ts, mut alice_oms, _alice_comms, mut alice_connectivity) = setup_transaction_service(
         &mut runtime,
         alice_node_identity,
         vec![],
@@ -998,10 +998,8 @@ fn test_htlc_send_and_claim() {
             .expect("Alice sending HTLC transaction")
     });
 
-    let mut alice_ts_clone2 = alice_ts.clone();
-    let mut alice_oms_clone = alice_oms.clone();
     runtime.block_on(async move {
-        let completed_tx = alice_ts_clone2
+        let completed_tx = alice_ts
             .get_completed_transaction(tx_id)
             .await
             .expect("Could not find completed HTLC tx");
@@ -1009,7 +1007,7 @@ fn test_htlc_send_and_claim() {
         let fees = completed_tx.fee;
 
         assert_eq!(
-            alice_oms_clone.get_balance().await.unwrap().pending_incoming_balance,
+            alice_oms.get_balance().await.unwrap().pending_incoming_balance,
             initial_wallet_value - value - fees
         );
     });

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -27,12 +27,6 @@ sha2 = "0.9.5"
 path-clean = "0.1.0"
 tari_storage = { version = "^0.21", path = "../infrastructure/storage"}
 tracing = "0.1.26"
-tracing-opentelemetry = "0.15.0"
-tracing-subscriber = "0.2.20"
-
-# network tracing, rt-tokio for async batch export
-opentelemetry = { version = "0.16", default-features = false, features = ["trace","rt-tokio"] }
-opentelemetry-jaeger = { version="0.15", features=["rt-tokio"]}
 
 anyhow = { version = "1.0", optional = true }
 git2 = { version = "0.8", optional = true }

--- a/comms/rpc_macros/src/generator.rs
+++ b/comms/rpc_macros/src/generator.rs
@@ -208,8 +208,8 @@ impl RpcCodeGenerator {
 
             #client_methods
 
-            pub async fn get_last_request_latency(&mut self) -> Result<Option<std::time::Duration>, #dep_mod::RpcError> {
-                self.inner.get_last_request_latency().await
+            pub fn get_last_request_latency(&mut self) -> Option<std::time::Duration> {
+                self.inner.get_last_request_latency()
             }
 
             pub async fn ping(&mut self) -> Result<std::time::Duration, #dep_mod::RpcError> {

--- a/comms/src/protocol/rpc/test/greeting_service.rs
+++ b/comms/src/protocol/rpc/test/greeting_service.rs
@@ -447,8 +447,8 @@ impl GreetingClient {
         self.inner.server_streaming(request, 8).await
     }
 
-    pub async fn get_last_request_latency(&mut self) -> Result<Option<Duration>, RpcError> {
-        self.inner.get_last_request_latency().await
+    pub fn get_last_request_latency(&mut self) -> Option<Duration> {
+        self.inner.get_last_request_latency()
     }
 
     pub async fn ping(&mut self) -> Result<Duration, RpcError> {

--- a/comms/src/protocol/rpc/test/smoke.rs
+++ b/comms/src/protocol/rpc/test/smoke.rs
@@ -135,7 +135,7 @@ async fn request_response_errors_and_streaming() {
         .unwrap();
 
     // Latency is available "for free" as part of the connect protocol
-    assert!(client.get_last_request_latency().await.unwrap().is_some());
+    assert!(client.get_last_request_latency().is_some());
 
     let resp = client
         .say_hello(SayHelloRequest {


### PR DESCRIPTION
Description
---

- Allows the last_request_latency to be instantly queried even when a client is busy with another request. 

Motivation and Context
---
Ref #3577 

A delay could be experienced when calling get_last_request_latency because a single client runs on a single task and so can only handle one service request at a time.

How Has This Been Tested?
---
Added unit test
