### PR TITLE
fix: update daily test start times and seed phrase

### DIFF
--- a/applications/daily_tests/automatic_recovery_test.js
+++ b/applications/daily_tests/automatic_recovery_test.js
@@ -16,7 +16,7 @@ async function main() {
       description: "Seed words to use during recovery",
       type: "string",
       default:
-        "pigeon marble letter canal hard close kit cash coin still melt random require long shaft antenna tent turkey neck divert enrich iron analyst abandon",
+        "cactus pool fuel skull chair casino season disorder flat crash wrist whisper decorate narrow oxygen remember minor among happy cricket embark blue ship sick",
     })
     .option("log", {
       alias: "l",
@@ -34,19 +34,19 @@ async function main() {
     .alias("help", "h").argv;
 
   for (let i = 0; i < argv.numWallets; i++) {
-    let { identity, timeDiffMinutes, height, blockRate, recoveredAmount } =
+    let { identity, timeDiffMinutes, numOutputs, rate, recoveredAmount } =
       await run(argv);
 
     console.log(
       "Wallet (Pubkey:",
       identity.public_key,
-      ") recovered to a block height of",
-      height,
-      "completed in",
+      ") scanned",
+        numOutputs,
+      "outputs, completed in",
       timeDiffMinutes,
       "minutes (",
-      blockRate,
-      "blocks/min).",
+        rate,
+      "outputs/min).",
       recoveredAmount,
       "µT recovered for instance ",
       i,

--- a/applications/daily_tests/automatic_sync_test.js
+++ b/applications/daily_tests/automatic_sync_test.js
@@ -61,7 +61,7 @@ async function run(options) {
     "true";
   // Set pruning horizon in config file if `pruned` command line arg is present
   if (options.syncType === SyncType.Pruned) {
-    process.env[`TARI_BASE_NODE__${NETWORK}__PRUNING_HORIZON`] = 1000;
+    process.env[`TARI_BASE_NODE__${NETWORK}__PRUNING_HORIZON`] = 20;
   }
 
   if (options.forceSyncPeer) {

--- a/applications/daily_tests/cron_jobs.js
+++ b/applications/daily_tests/cron_jobs.js
@@ -53,7 +53,7 @@ async function runWalletRecoveryTest(instances) {
       recoveredAmount,
     } = await walletRecoveryTest({
       seedWords:
-        "abandon rely pave boil case broken volume bracket own false sketch ordinary gown bitter strong unhappy shoulder salad season student public will monkey inquiry",
+        "cactus pool fuel skull chair casino season disorder flat crash wrist whisper decorate narrow oxygen remember minor among happy cricket embark blue ship sick",
       log: LOG_FILE,
       numWallets: instances,
       baseDir,
@@ -126,13 +126,13 @@ async function main() {
   });
 
   // ------------------------- CRON ------------------------- //
-  new CronJob("0 7 * * *", () => runWalletRecoveryTest(1)).start();
+  new CronJob("0 2 * * *", () => runWalletRecoveryTest(1)).start();
   //new CronJob("30 7 * * *", () => runWalletRecoveryTest(5)).start();
-  new CronJob("0 6 * * *", () =>
+  new CronJob("0 1 * * *", () =>
     runBaseNodeSyncTest(SyncType.Archival)
   ).start();
-  new CronJob("30 6 * * *", () => runBaseNodeSyncTest(SyncType.Pruned)).start();
-  new CronJob("0 4 * * *", () =>
+  new CronJob("30 1 * * *", () => runBaseNodeSyncTest(SyncType.Pruned)).start();
+  new CronJob("0 0 * * *", () =>
     git.pull(__dirname).catch((err) => {
       failed("Failed to update git repo");
       console.error(err);


### PR DESCRIPTION
Description
---
- This PR updates the daily test star times to be from 1am so that the tests are done before standup.
- Updated the recovery seed phrase to a wallet with 1234567890uT for each spotting when recovery misses some outputs
- Updates the pruning horizon to 20.

How Has This Been Tested?
---
YOLO
