### PR TITLE
refactor: clean up unwraps in wallet_ffi

### DIFF
--- a/base_layer/wallet_ffi/src/error.rs
+++ b/base_layer/wallet_ffi/src/error.rs
@@ -41,6 +41,8 @@ const LOG_TARGET: &str = "wallet_ffi::error";
 pub enum InterfaceError {
     #[error("An error has occurred due to one of the parameters being null: `{0}`")]
     NullError(String),
+    #[error("An invalid pointer was passed into the function")]
+    PointerError(String),
     #[error("An error has occurred when checking the length of the allocated object")]
     AllocationError,
     #[error("An error because the supplied position was out of range")]
@@ -100,6 +102,10 @@ impl From<InterfaceError> for LibWalletError {
             InterfaceError::BalanceError => Self {
                 code: 8,
                 message: "Balance Unavailable".to_string(),
+            },
+            InterfaceError::PointerError(ref p) => Self {
+                code: 9,
+                message: format!("Pointer error on {}:{:?}", p, v),
             },
         }
     }

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -716,7 +716,7 @@ void balance_destroy(struct TariBalance *balance);
 void file_partial_backup(const char *original_file_path, const char *backup_file_path, int *error_out);
 
 /// This function will log the provided string at debug level. To be used to have a client log messages to the LibWallet
-void log_debug_message(const char *msg);
+void log_debug_message(const char *msg, int *error_out);
 
 struct EmojiSet *get_emoji_set();
 


### PR DESCRIPTION
Description
---
Remove unwrap() in functions of wallet_ffi, code is considered best-effort to try to prevent a panic since the nature of handling invalid pointers or invalidly cast pointers passed in results in undefined behavior.

The function signature of log_debug_message() was modified to take into account an error occurring. PR is a breaking change due to this.

Fixed potential panic when unwrapping parse() for MultiAddr.

Fixed missing documentation for init_logging().

Motivation and Context
---
Removal of calls to unwrap() and bug fixes.

How Has This Been Tested?
---
cargo test --all
