### PR TITLE
fix: allow bullet proof value only rewinding in atomic swaps

### DIFF
--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -1230,8 +1230,8 @@ where
             )
             .as_bytes(),
         )?;
-        let rewind_key = PrivateKey::from_bytes(&hash_secret_key(&spending_key))?;
-        let blinding_key = PrivateKey::from_bytes(&hash_secret_key(&rewind_key))?;
+        let blinding_key = PrivateKey::from_bytes(&hash_secret_key(&spending_key))?;
+        let rewind_key = PrivateKey::from_bytes(&hash_secret_key(&blinding_key))?;
         let rewound =
             output.full_rewind_range_proof(&self.resources.factories.range_proof, &rewind_key, &blinding_key)?;
 

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -859,8 +859,9 @@ where
         .map_err(|e| TransactionServiceProtocolError::new(tx_id, e.into()))?;
 
         let sender_message = TransactionSenderMessage::new_single_round_message(stp.get_single_round_message()?);
-        let rewind_key = PrivateKey::from_bytes(&hash_secret_key(&spend_key))?;
-        let blinding_key = PrivateKey::from_bytes(&hash_secret_key(&rewind_key))?;
+        let blinding_key = PrivateKey::from_bytes(&hash_secret_key(&spend_key))?;
+        let rewind_key = PrivateKey::from_bytes(&hash_secret_key(&blinding_key))?;
+
         let rewind_data = RewindData {
             rewind_key: rewind_key.clone(),
             rewind_blinding_key: blinding_key.clone(),


### PR DESCRIPTION
Description
---
This PR allows us to do bulletproof value-only rewinding on HTLC atomic swap utxo.

Motivation and Context
---
Currently it is not possible to do bulletproof rewinding on the value only on an HTLC atomic swap utxo due to the way the commitment blinding factor and bulletproof rewinding keys are created. 
Currently, the two bulletproof rewinding keys are created as:
```
 let rewind_key = PrivateKey::from_bytes(&hash_secret_key(&commitment_blinding_factor))?;
 let blinding_key = PrivateKey::from_bytes(&hash_secret_key(&rewind_key))?;
```
This means that if you share the rewind key, which is used to do value only rewinding, that a person can calculate the blinding key which is used to do full rewinding and expose the commitment blinding factor.  by changing the calculation order we prevent this and only allow full rewinding by something who needs to be able to do this. 

```
 let rewind_key = PrivateKey::from_bytes(&hash_secret_key(&blinding_key ))?;
 let blinding_key = PrivateKey::from_bytes(&hash_secret_key(&commitment_blinding_factor))?;
```

How Has This Been Tested?
---

All current test pass
