### PR TITLE
test: improve cucumber scenario robustness

### DIFF
--- a/integration_tests/helpers/walletProcess.js
+++ b/integration_tests/helpers/walletProcess.js
@@ -252,6 +252,7 @@ class WalletProcess {
   }
 
   async exportSpentOutputs() {
+    await this.stop();
     const args = [
       "--init",
       "--base-path",
@@ -262,11 +263,13 @@ class WalletProcess {
       "--command",
       "export-spent-utxos --csv-file exported_outputs.csv",
     ];
+    let output = { buffer: "" };
     outputProcess = __dirname + "/../temp/out/tari_console_wallet";
-    await this.run(outputProcess, args, true);
+    await this.run(outputProcess, args, true, "\n", output, true);
   }
 
   async exportUnspentOutputs() {
+    await this.stop();
     const args = [
       "--init",
       "--base-path",
@@ -277,8 +280,9 @@ class WalletProcess {
       "--command",
       "export-utxos --csv-file exported_outputs.csv",
     ];
+    let output = { buffer: "" };
     outputProcess = __dirname + "/../temp/out/tari_console_wallet";
-    await this.run(outputProcess, args, true);
+    await this.run(outputProcess, args, true, "\n", output, true);
   }
 
   async readExportedOutputs() {


### PR DESCRIPTION

Description
---
Improved cucumber scenario robustness by explicitly waiting on the command mode to finish before proceeding with the next step for:
- `Scenario: Wallet imports spent outputs that become invalidated`
- `Scenario: Wallet imports reorged outputs that become invalidated`

Motivation and Context
---
The above-mentioned tests failed now and again, at least 1 in 10.

How Has This Been Tested?
---
Repeatedly running these tests 10 times on two different computers.
- `npm test -- --name "Wallet imports spent outputs that become invalidated"`
- `npm test -- --name "Wallet imports reorged outputs that become invalidated"`

