### PR TITLE
feat!: expose reason for transaction cancellation for callback in wallet_ffi

### DIFF
--- a/applications/tari_console_wallet/src/ui/state/wallet_event_monitor.rs
+++ b/applications/tari_console_wallet/src/ui/state/wallet_event_monitor.rs
@@ -100,7 +100,7 @@ impl WalletEventMonitor {
                                         self.trigger_balance_refresh();
                                         notifier.transaction_mined(tx_id);
                                     },
-                                    TransactionEvent::TransactionCancelled(tx_id) => {
+                                    TransactionEvent::TransactionCancelled(tx_id, _) => {
                                         self.trigger_tx_state_refresh(tx_id).await;
                                         self.trigger_balance_refresh();
                                         notifier.transaction_cancelled(tx_id);

--- a/base_layer/p2p/src/services/liveness/state.rs
+++ b/base_layer/p2p/src/services/liveness/state.rs
@@ -152,7 +152,7 @@ impl LivenessState {
             self.failed_pings
                 .entry(node_id)
                 .and_modify(|v| {
-                    *v = *v + 1;
+                    *v += 1;
                 })
                 .or_insert(1);
         }
@@ -167,7 +167,7 @@ impl LivenessState {
     /// a latency sample is added and calculated. The given `peer` must match the recorded peer
     pub fn record_pong(&mut self, nonce: u64, sent_by: &NodeId) -> Option<u32> {
         self.inc_pongs_received();
-        self.failed_pings.remove_entry(&sent_by);
+        self.failed_pings.remove_entry(sent_by);
 
         let (node_id, _) = self.inflight_pings.get(&nonce)?;
         if node_id == sent_by {

--- a/base_layer/wallet/src/transaction_service/handle.rs
+++ b/base_layer/wallet/src/transaction_service/handle.rs
@@ -36,6 +36,7 @@ use tari_service_framework::reply_channel::SenderService;
 
 use crate::transaction_service::{
     error::TransactionServiceError,
+    protocols::TxRejection,
     storage::models::{CompletedTransaction, InboundTransaction, OutboundTransaction, WalletTransaction},
 };
 
@@ -150,7 +151,7 @@ pub enum TransactionEvent {
     TransactionDirectSendResult(TxId, bool),
     TransactionCompletedImmediately(TxId),
     TransactionStoreForwardSendResult(TxId, bool),
-    TransactionCancelled(TxId),
+    TransactionCancelled(TxId, TxRejection),
     TransactionBroadcast(TxId),
     TransactionImported(TxId),
     TransactionMined {

--- a/base_layer/wallet/src/transaction_service/protocols/mod.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/mod.rs
@@ -20,6 +20,17 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum TxRejection {
+    Unknown,            // 0
+    UserCancelled,      // 1
+    Timeout,            // 2
+    DoubleSpend,        // 3
+    Orphan,             // 4
+    TimeLocked,         // 5
+    InvalidTransaction, // 6
+}
+
 pub mod transaction_broadcast_protocol;
 pub mod transaction_receive_protocol;
 pub mod transaction_send_protocol;

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_broadcast_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_broadcast_protocol.rs
@@ -48,6 +48,7 @@ use crate::{
     transaction_service::{
         error::{TransactionServiceError, TransactionServiceProtocolError},
         handle::TransactionEvent,
+        protocols::TxRejection,
         service::TransactionServiceResources,
         storage::{database::TransactionBackend, models::CompletedTransaction},
     },
@@ -215,19 +216,6 @@ where
 
             self.cancel_transaction().await;
 
-            let _ = self
-                .resources
-                .event_publisher
-                .send(Arc::new(TransactionEvent::TransactionCancelled(self.tx_id)))
-                .map_err(|e| {
-                    trace!(
-                        target: LOG_TARGET,
-                        "Error sending event because there are no subscribers: {:?}",
-                        e
-                    );
-                    e
-                });
-
             let reason = match response.rejection_reason {
                 TxSubmissionRejectionReason::None | TxSubmissionRejectionReason::ValidationFailed => {
                     TransactionServiceError::MempoolRejectionInvalidTransaction
@@ -237,6 +225,31 @@ where
                 TxSubmissionRejectionReason::TimeLocked => TransactionServiceError::MempoolRejectionTimeLocked,
                 _ => TransactionServiceError::UnexpectedBaseNodeResponse,
             };
+
+            let cancellation_event_reason = match reason {
+                TransactionServiceError::MempoolRejectionInvalidTransaction => TxRejection::InvalidTransaction,
+                TransactionServiceError::MempoolRejectionDoubleSpend => TxRejection::DoubleSpend,
+                TransactionServiceError::MempoolRejectionOrphan => TxRejection::Orphan,
+                TransactionServiceError::MempoolRejectionTimeLocked => TxRejection::TimeLocked,
+                _ => TxRejection::Unknown,
+            };
+
+            let _ = self
+                .resources
+                .event_publisher
+                .send(Arc::new(TransactionEvent::TransactionCancelled(
+                    self.tx_id,
+                    cancellation_event_reason,
+                )))
+                .map_err(|e| {
+                    trace!(
+                        target: LOG_TARGET,
+                        "Error sending event because there are no subscribers: {:?}",
+                        e
+                    );
+                    e
+                });
+
             return Err(TransactionServiceProtocolError::new(self.tx_id, reason));
         } else if response.rejection_reason == TxSubmissionRejectionReason::AlreadyMined {
             info!(
@@ -342,7 +355,10 @@ where
                 let _ = self
                     .resources
                     .event_publisher
-                    .send(Arc::new(TransactionEvent::TransactionCancelled(self.tx_id)))
+                    .send(Arc::new(TransactionEvent::TransactionCancelled(
+                        self.tx_id,
+                        TxRejection::InvalidTransaction,
+                    )))
                     .map_err(|e| {
                         trace!(
                             target: LOG_TARGET,

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_receive_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_receive_protocol.rs
@@ -39,7 +39,7 @@ use tari_common_types::transaction::{TransactionDirection, TransactionStatus, Tx
 use tari_comms::types::CommsPublicKey;
 use tokio::sync::{mpsc, oneshot};
 
-use crate::connectivity_service::WalletConnectivityInterface;
+use crate::{connectivity_service::WalletConnectivityInterface, transaction_service::protocols::TxRejection};
 use tari_common_types::types::HashOutput;
 use tari_core::transactions::{
     transaction_entities::Transaction,
@@ -504,7 +504,10 @@ where
         let _ = self
             .resources
             .event_publisher
-            .send(Arc::new(TransactionEvent::TransactionCancelled(self.id)))
+            .send(Arc::new(TransactionEvent::TransactionCancelled(
+                self.id,
+                TxRejection::Timeout,
+            )))
             .map_err(|e| {
                 trace!(
                     target: LOG_TARGET,

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_send_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_send_protocol.rs
@@ -26,6 +26,7 @@ use crate::{
         config::TransactionRoutingMechanism,
         error::{TransactionServiceError, TransactionServiceProtocolError},
         handle::{TransactionEvent, TransactionServiceResponse},
+        protocols::TxRejection,
         service::TransactionServiceResources,
         storage::{
             database::TransactionBackend,
@@ -826,7 +827,10 @@ where
         let _ = self
             .resources
             .event_publisher
-            .send(Arc::new(TransactionEvent::TransactionCancelled(self.id)))
+            .send(Arc::new(TransactionEvent::TransactionCancelled(
+                self.id,
+                TxRejection::Timeout,
+            )))
             .map_err(|e| {
                 trace!(
                     target: LOG_TARGET,

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_validation_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_validation_protocol.rs
@@ -64,6 +64,7 @@ pub struct TransactionValidationProtocol<TTransactionBackend, TWalletConnectivit
     event_publisher: TransactionEventSender,
     output_manager_handle: OutputManagerHandle,
 }
+use crate::transaction_service::protocols::TxRejection;
 use tari_common_types::types::Signature;
 
 #[allow(unused_variables)]
@@ -416,7 +417,7 @@ where
             );
         };
 
-        self.publish_event(TransactionEvent::TransactionCancelled(tx_id));
+        self.publish_event(TransactionEvent::TransactionCancelled(tx_id, TxRejection::Orphan));
 
         Ok(())
     }

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -34,6 +34,7 @@ use crate::{
             transaction_receive_protocol::{TransactionReceiveProtocol, TransactionReceiveProtocolStage},
             transaction_send_protocol::{TransactionSendProtocol, TransactionSendProtocolStage},
             transaction_validation_protocol::TransactionValidationProtocol,
+            TxRejection,
         },
         storage::{
             database::{TransactionBackend, TransactionDatabase},
@@ -1301,7 +1302,10 @@ where
 
         let _ = self
             .event_publisher
-            .send(Arc::new(TransactionEvent::TransactionCancelled(tx_id)))
+            .send(Arc::new(TransactionEvent::TransactionCancelled(
+                tx_id,
+                TxRejection::UserCancelled,
+            )))
             .map_err(|e| {
                 trace!(
                     target: LOG_TARGET,

--- a/base_layer/wallet/tests/transaction_service/service.rs
+++ b/base_layer/wallet/tests/transaction_service/service.rs
@@ -2184,7 +2184,7 @@ fn test_transaction_cancellation() {
         loop {
             tokio::select! {
                 event = alice_event_stream.recv() => {
-                    if let TransactionEvent::TransactionCancelled(_) = &*event.unwrap() {
+                    if let TransactionEvent::TransactionCancelled(..) = &*event.unwrap() {
                        cancelled = true;
                        break;
                     }
@@ -2380,7 +2380,7 @@ fn test_transaction_cancellation() {
         loop {
             tokio::select! {
                 event = alice_event_stream.recv() => {
-                    if let TransactionEvent::TransactionCancelled(_) = &*event.unwrap() {
+                    if let TransactionEvent::TransactionCancelled(..) = &*event.unwrap() {
                        cancelled = true;
                        break;
                     }
@@ -3524,7 +3524,7 @@ fn test_coinbase_abandoned() {
         loop {
             tokio::select! {
                 event = alice_event_stream.recv() => {
-                    if let TransactionEvent::TransactionCancelled(tx_id) = &*event.unwrap() {
+                    if let TransactionEvent::TransactionCancelled(tx_id, _) = &*event.unwrap() {
                         if tx_id == &tx_id1  {
                             count += 1;
                         }
@@ -3684,7 +3684,7 @@ fn test_coinbase_abandoned() {
                                 count += 1;
                             }
                         },
-                        TransactionEvent::TransactionCancelled(tx_id) => {
+                        TransactionEvent::TransactionCancelled(tx_id, _) => {
                              if tx_id == &tx_id2  {
                                 count += 1;
                             }
@@ -3771,7 +3771,7 @@ fn test_coinbase_abandoned() {
                                 count += 1;
                             }
                         },
-                        TransactionEvent::TransactionCancelled(tx_id) => {
+                        TransactionEvent::TransactionCancelled(tx_id, _) => {
                              if tx_id == &tx_id1  {
                                 count += 1;
                             }
@@ -4755,7 +4755,7 @@ fn test_transaction_timeout_cancellation() {
         loop {
             tokio::select! {
                 event = carol_event_stream.recv() => {
-                     if let TransactionEvent::TransactionCancelled(t) = &*event.unwrap() {
+                     if let TransactionEvent::TransactionCancelled(t, _) = &*event.unwrap() {
                         if t == &tx_id {
                             transaction_cancelled = true;
                             break;
@@ -5074,7 +5074,7 @@ fn transaction_service_tx_broadcast() {
         loop {
             tokio::select! {
                 event = alice_event_stream.recv() => {
-                     if let TransactionEvent::TransactionCancelled(tx_id) = &*event.unwrap(){
+                     if let TransactionEvent::TransactionCancelled(tx_id, _) = &*event.unwrap(){
                         if tx_id == &tx_id2 {
                             tx2_cancelled = true;
                             break;

--- a/base_layer/wallet/tests/transaction_service/transaction_protocols.rs
+++ b/base_layer/wallet/tests/transaction_service/transaction_protocols.rs
@@ -370,7 +370,7 @@ async fn tx_broadcast_protocol_submit_rejection() {
     loop {
         tokio::select! {
             event = event_stream.recv() => {
-                if let TransactionEvent::TransactionCancelled(_) = &*event.unwrap() {
+                if let TransactionEvent::TransactionCancelled(..) = &*event.unwrap() {
                     cancelled = true;
                 }
             },
@@ -547,7 +547,7 @@ async fn tx_broadcast_protocol_submit_success_followed_by_rejection() {
     loop {
         tokio::select! {
             event = event_stream.recv() => {
-                if let TransactionEvent::TransactionCancelled(_) = &*event.unwrap() {
+                if let TransactionEvent::TransactionCancelled(..) = &*event.unwrap() {
                 cancelled = true;
                 }
             },

--- a/base_layer/wallet/tests/wallet/mod.rs
+++ b/base_layer/wallet/tests/wallet/mod.rs
@@ -632,7 +632,7 @@ fn test_store_and_forward_send_tx() {
                 event = carol_event_stream.recv() => {
                     match &*event.unwrap() {
                         TransactionEvent::ReceivedTransaction(_) => tx_recv = true,
-                        TransactionEvent::TransactionCancelled(_) => tx_cancelled = true,
+                        TransactionEvent::TransactionCancelled(..) => tx_cancelled = true,
                         _ => (),
                     }
                     if tx_recv && tx_cancelled {

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -423,9 +423,22 @@ void comms_config_destroy(struct TariCommsConfig *wc);
 /// when a Broadcast transaction is detected as mined AND confirmed.
 /// `callback_transaction_mined_unconfirmed` - The callback function pointer matching the function signature. This will
 /// be called  when a Broadcast transaction is detected as mined but not yet confirmed.
-/// `callback_discovery_process_complete` - The callback function pointer matching the function signature. This will be
-/// called when a `send_transacion(..)` call is made to a peer whose address is not known and a discovery process must
-/// be conducted. The outcome of the discovery process is relayed via this callback
+/// `callback_direct_send_result` - The callback function pointer matching the function signature. This is called
+/// when a direct send is completed. The first parameter is the transaction id and the second is whether if was successful or not.
+/// `callback_store_and_forward_send_result` - The callback function pointer matching the function signature. This is called
+/// when a direct send is completed. The first parameter is the transaction id and the second is whether if was successful or not.
+/// `callback_transaction_cancellation` - The callback function pointer matching the function signature. This is called
+/// when a transaction is cancelled. The first parameter is a pointer to the cancelled transaction, the second is a reason as to
+/// why said transaction failed that is mapped to the `TxRejection` enum:
+/// pub enum TxRejection {
+///     Unknown,                // 0
+///     UserCancelled,          // 1
+///     Timeout,                // 2
+///     DoubleSpend,            // 3
+///     Orphan,                 // 4
+///     TimeLocked,             // 5
+///     InvalidTransaction,     // 6
+/// }
 /// `callback_txo_validation_complete` - The callback function pointer matching the function signature. This is called
 /// when a TXO validation process is completed. The request_key is used to identify which request this
 /// callback references and the second parameter is a u8 that represent the CallbackValidationResults enum.
@@ -469,7 +482,7 @@ struct TariWallet *wallet_create(struct TariCommsConfig *config,
                                  void (*callback_transaction_mined_unconfirmed)(struct TariCompletedTransaction *, unsigned long long),
                                  void (*callback_direct_send_result)(unsigned long long, bool),
                                  void (*callback_store_and_forward_send_result)(unsigned long long, bool),
-                                 void (*callback_transaction_cancellation)(struct TariCompletedTransaction *),
+                                 void (*callback_transaction_cancellation)(struct TariCompletedTransaction *, unsigned long long),
                                  void (*callback_txo_validation_complete)(unsigned long long, unsigned char),
                                  void (*callback_balance_updated)(struct TariBalance *),
                                  void (*callback_transaction_validation_complete)(unsigned long long, unsigned char),

--- a/integration_tests/helpers/ffi/ffiInterface.js
+++ b/integration_tests/helpers/ffi/ffiInterface.js
@@ -1129,7 +1129,7 @@ class InterfaceFFI {
   }
 
   static createCallbackTransactionCancellation(fn) {
-    return ffi.Callback(this.void, [this.ptr], fn);
+    return ffi.Callback(this.void, [this.ptr, this.ulonglong], fn);
   }
   static createCallbackTxoValidationComplete(fn) {
     return ffi.Callback(this.void, [this.ulonglong, this.uchar], fn);

--- a/integration_tests/helpers/ffi/wallet.js
+++ b/integration_tests/helpers/ffi/wallet.js
@@ -245,11 +245,11 @@ class Wallet {
     this.minedunconfirmed += 1;
   };
 
-  onTransactionCancellation = (ptr) => {
+  onTransactionCancellation = (ptr, reason) => {
     let tx = new CompletedTransaction();
     tx.pointerAssign(ptr);
     console.log(
-      `${new Date().toISOString()} Transaction with txID ${tx.getTransactionID()} was cancelled`
+      `${new Date().toISOString()} Transaction with txID ${tx.getTransactionID()} was cancelled with reason code ${reason}.`
     );
     tx.destroy();
     this.cancelled += 1;


### PR DESCRIPTION
Description
---
Exposes reason for transaction cancellation to wallet_ffi via the transaction cancellation callback.

Additionally removes outdated docs and fixes Clippy errors.

Motivation and Context
---

How Has This Been Tested?
---
cargo test --all
