### PR TITLE
test: increase timeout in cucumber

### DIFF
--- a/integration_tests/features/support/steps.js
+++ b/integration_tests/features/support/steps.js
@@ -650,6 +650,7 @@ Given(
 
 Given(
   /I have a merge mining proxy (.*) connected to (.*) and (.*) with origin submission disabled/,
+  { timeout: 120 * 1000 }, // The timeout must make provision for testing the monerod URL /get_height response
   async function (mmProxy, node, wallet) {
     const baseNode = this.getNode(node);
     const walletNode = this.getWallet(wallet);
@@ -668,6 +669,7 @@ Given(
 
 Given(
   /I have a merge mining proxy (.*) connected to (.*) and (.*) with origin submission enabled/,
+  { timeout: 120 * 1000 }, // The timeout must make provision for testing the monerod URL /get_height response
   async function (mmProxy, node, wallet) {
     const baseNode = this.getNode(node);
     const walletNode = this.getWallet(wallet);


### PR DESCRIPTION
Description
---
Increased the timeout to obtain a merge mining proxy process, which includes the time for testing the monerod URL `/get_height` response.

Motivation and Context
---
Some tests dependent on merge mining timed out in cucumber before a suitable `monerod` server could be find.

How Has This Been Tested?
---
Cucumber
