### PR TITLE
fix: use json 5 for tor identity (regression)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4539,7 +4539,7 @@ dependencies = [
  "log",
  "qrcode",
  "rand 0.8.4",
- "serde_json",
+ "serde 1.0.130",
  "structopt",
  "strum 0.19.5",
  "strum_macros 0.19.4",

--- a/applications/tari_app_utilities/Cargo.toml
+++ b/applications/tari_app_utilities/Cargo.toml
@@ -15,7 +15,7 @@ config = { version = "0.9.3" }
 futures = { version = "^0.3.16", default-features = false, features = ["alloc"] }
 qrcode = { version = "0.12" }
 dirs-next = "1.0.2"
-serde_json = "1.0"
+serde = "1.0.126"
 json5 = "0.2.2"
 log = { version = "0.4.8", features = ["std"] }
 rand = "0.8"


### PR DESCRIPTION
Description
---

Use json 5 for save/load identity functions 

Motivation and Context
---
Save and load identity were using older version of the json parser which coul not parse the json comments.
This causes a new tor identity and onion address to be created on each base node startup.

How Has This Been Tested?
---
Onion address does not change on base node restart
