### PR TITLE
feat: improve wallet responsiveness

### DIFF
--- a/applications/tari_console_wallet/src/ui/state/wallet_event_monitor.rs
+++ b/applications/tari_console_wallet/src/ui/state/wallet_event_monitor.rs
@@ -119,7 +119,7 @@ impl WalletEventMonitor {
                                         self.trigger_balance_refresh();
                                         notifier.transaction_sent(tx_id);
                                     },
-                                    TransactionEvent::TransactionValidationSuccess(_) => {
+                                    TransactionEvent::TransactionValidationStateChanged(_) => {
                                         self.trigger_full_tx_state_refresh().await;
                                         self.trigger_balance_refresh();
                                     },

--- a/base_layer/wallet/src/transaction_service/handle.rs
+++ b/base_layer/wallet/src/transaction_service/handle.rs
@@ -166,7 +166,7 @@ pub enum TransactionEvent {
         is_valid: bool,
     },
     TransactionValidationTimedOut(u64),
-    TransactionValidationSuccess(u64),
+    TransactionValidationStateChanged(u64),
     TransactionValidationFailure(u64),
     TransactionValidationAborted(u64),
     TransactionValidationDelayed(u64),

--- a/base_layer/wallet_ffi/src/callback_handler.rs
+++ b/base_layer/wallet_ffi/src/callback_handler.rs
@@ -258,7 +258,7 @@ where TBackend: TransactionBackend + 'static
                                     self.receive_transaction_mined_unconfirmed_event(tx_id, num_confirmations).await;
                                     self.trigger_balance_refresh().await;
                                 },
-                                TransactionEvent::TransactionValidationSuccess(tx_id)  => {
+                                TransactionEvent::TransactionValidationStateChanged(tx_id)  => {
                                     self.transaction_validation_complete_event(tx_id, CallbackValidationResults::Success);
                                     self.trigger_balance_refresh().await;
                                 },

--- a/base_layer/wallet_ffi/src/callback_handler_tests.rs
+++ b/base_layer/wallet_ffi/src/callback_handler_tests.rs
@@ -476,7 +476,7 @@ mod test {
         assert_eq!(callback_balance_updated, 5);
 
         transaction_event_sender
-            .send(Arc::new(TransactionEvent::TransactionValidationSuccess(1u64)))
+            .send(Arc::new(TransactionEvent::TransactionValidationStateChanged(1u64)))
             .unwrap();
 
         oms_event_sender


### PR DESCRIPTION

Description
---
Improved wallet responsiveness by cutting down on unnecessary wallet database calls:
- `TransactionEvent::TransactionValidationSuccess` was published regardless of any state change in the wallet database, which resulted in many unnecessary `fetch 'All Complete Transactions'` calls to the wallet database. This issue was optimized to only send the event when a state change was affected.
- A missing event was added when state changed due to reorgs.
- This should have a slight positive impact on mobile wallet battery usage.

Motivation and Context
---
Unnecessary wallet database calls to fetch all completed transactions were made each time the transaction validation protocol was run, especially when nothing changed in the database. This effect grew linearly with the amount of transactions in the database,

How Has This Been Tested?
---
- Unit tests
- Cucumber tests (`npm test -- --tags "not @long-running and not @broken"`)
- System level tests

