### PR TITLE
fix!: separate peer seeds to common.network

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ name: CI
 
 env:
   CARGO_HTTP_MULTIPLEXING: false
+  PROTOC: protoc
   toolchain: nightly-2021-09-18
 
 jobs:
@@ -18,6 +19,21 @@ jobs:
     name: clippy
     runs-on: ubuntu-18.04
     steps:
+      - name: ubuntu dependencies
+        run: |
+          sudo apt-get update && \
+          sudo apt-get -y install \
+            libssl-dev \
+            openssl \
+            libsqlite3-dev \
+            pkg-config \
+            git \
+            cmake \
+            zip \
+            libc++-dev \
+            libc++abi-dev \
+            libprotobuf-dev \
+            protobuf-compiler
       - name: checkout
         uses: actions/checkout@v2
       - name: toolchain
@@ -40,10 +56,10 @@ jobs:
           command: fmt
           args: --all -- --check
       - name: Clippy check
-        uses: actions-rs/clippy-check@v1
+        uses: actions-rs/cargo@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features
+          command: clippy
+          args: --all-targets -- -D warnings
   test:
     name: test
     runs-on: ubuntu-18.04
@@ -59,7 +75,6 @@ jobs:
             target
           key: ${{ runner.os }}-${{ runner.cpu-model }}-${{ env.toolchain }}-${{ hashFiles('**/Cargo.lock') }}
       - name: ubuntu dependencies
-        if: startsWith(matrix.os,'ubuntu')
         run: |
           sudo apt-get update && \
           sudo apt-get -y install \

--- a/applications/tari_app_utilities/src/initialization.rs
+++ b/applications/tari_app_utilities/src/initialization.rs
@@ -31,8 +31,7 @@ pub fn init_configuration(
     log::info!(target: LOG_TARGET, "{} ({})", application_type, consts::APP_VERSION);
 
     // Populate the configuration struct
-    let mut global_config = GlobalConfig::convert_from(application_type, cfg.clone())
-        .map_err(|err| ExitCodes::ConfigError(err.to_string()))?;
+    let mut global_config = GlobalConfig::convert_from(application_type, cfg.clone(), bootstrap.network.clone())?;
 
     if let Some(str) = bootstrap.network.clone() {
         log::info!(target: LOG_TARGET, "Network selection requested");
@@ -54,11 +53,9 @@ pub fn init_configuration(
                 global_config.wallet_peer_db_path = global_config.data_dir.join("wallet_peer_db");
                 global_config.console_wallet_peer_db_path = global_config.data_dir.join("console_wallet_peer_db");
             },
-            Err(_) => {
-                log::warn!(
-                    target: LOG_TARGET,
-                    "Network selection was invalid, continuing with default network."
-                );
+            Err(e) => {
+                log::error!(target: LOG_TARGET, "Network selection was invalid, exiting.");
+                return Err(e.into());
             },
         }
     }

--- a/applications/tari_stratum_transcoder/src/main.rs
+++ b/applications/tari_stratum_transcoder/src/main.rs
@@ -95,6 +95,6 @@ fn initialize() -> Result<GlobalConfig, StratumTranscoderProxyError> {
     #[cfg(not(feature = "envlog"))]
     bootstrap.initialize_logging()?;
 
-    let cfg = GlobalConfig::convert_from(application_type, cfg)?;
+    let cfg = GlobalConfig::convert_from(application_type, cfg, bootstrap.network)?;
     Ok(cfg)
 }

--- a/common/config/presets/common.toml
+++ b/common/config/presets/common.toml
@@ -10,40 +10,6 @@
 #   weatherwax - the Tari testnet
 network = "weatherwax"
 
-# When first logging onto the Tari network, you need to find a few peers to bootstrap the process. In the absence of
-# any servers, this is a little more challenging than usual. Our best strategy is just to try and connect to the peers
-# you knew about last time you ran the software. But what about when you run the software for the first time? That's
-# where this allowlist comes in. It's a list of known Tari nodes that are likely to be around for a long time and that
-# new nodes can use to introduce themselves to the network.
-# peer_seeds = ["public_key1::address1", "public_key2::address2",... ]
-peer_seeds = [
-    # weatherwax
-    "98bc76afc1c35ad4651bdc9ef57bbe0655a2ea3cd86c0e19b5fd5890546eb040::/onion3/33izgtjkrlxhxybj6luqowkpiy2wvte43osejnbqyieqtdfhovzghxad:18141", #jozi
-    "9a26e910288213d649b26f9a7a7ee51fe2b2a67ff7d42334523463bf4be94312::/onion3/56kq54ylttnbl5ikotqex3oqvtzlxdpn7zlx4v56rvzf4kq7eezlclid:18141", #london
-    "6afd5b3c7772ad7d4bb26e0c19668fe04f2d68f99de9e132bee50a6c1846946d::/onion3/may4ajbmcn4dlnzf6fanvqlklxzqiw6qwu6ywqwkjc3bb354rc2i5wid:18141", #ncal
-    "8e7beec9becdc44fe6015a00d97a77fa3dbafe65127dcc988df6326bd9fd040d::/onion3/3pise36l4imoopsbjic5rtw67adx7rms6w5pgjmccpdwiqx66j7oqcqd:18141", #nvir
-    "80bb590d943a46e63ae79af5dc2c7d35a3dcd7922c182b28f619dc4cfc366f44::/onion3/oaxwahri7r3h5qjlcdbveyjmg4jsttausik66bicmhixft73nmvecdad:18141", #oregon
-    "981cc8cd1e4fe2f99ea1bd3e0ab1e7821ca0bfab336a4967cfec053fee86254c::/onion3/7hxpnxrxycdfevirddau7ybofwedaamjrg2ijm57k2kevh5q46ixamid:18141", #seoul
-    "f2ce179fb733725961a5f7e1e45dacdd443dd43ba6237438d6abe344fb717058::/onion3/nvgdmjf4wucgatz7vemzvi2u4sw5o4gyzwuikagpepoj4w7mkii47zid:18141", #stockholm
-    "909c0160f4d8e815aba5c2bbccfcceb448877e7b38759fb160f3e9494484d515::/onion3/qw5uxv533sqdn2qoncfyqo35dgecy4rt4x27rexi2her6q6pcpxbm4qd:18141", #sydney
-    # igor
-    "8e7eb81e512f3d6347bf9b1ca9cd67d2c8e29f2836fc5bd608206505cc72af34::/onion3/l4wouomx42nezhzexjdzfh7pcou5l7df24ggmwgekuih7tkv2rsaokqd:18141",
-    "00b35047a341401bcd336b2a3d564280a72f6dc72ec4c739d30c502acce4e803::/onion3/ojhxd7z6ga7qrvjlr3px66u7eiwasmffnuklscbh5o7g6wrbysj45vid:18141",
-    "40a9d8573745072534bce7d0ecafe882b1c79570375a69841c08a98dee9ecb5f::/onion3/io37fylc2pupg4cte4siqlsmuszkeythgjsxs2i3prm6jyz2dtophaad:18141",
-    "126c7ee64f71aca36398b977dd31fbbe9f9dad615df96473fb655bef5709c540::/onion3/6ilmgndocop7ybgmcvivbdsetzr5ggj4hhsivievoa2dx2b43wqlrlid:18141",
-]
-
-# DNS seeds
-# The DNS records in these hostnames should provide TXT records as per https://github.com/tari-project/tari/pull/2319
-# Enter a domain name for the TXT records: seeds.tari.com
-dns_seeds =["seeds.weatherwax.tari.com"]
-# The name server used to resolve DNS seeds format: {socket address}/{tls sni dns name} (Default: cloudflare)
-# dns_seeds_name_server = "1.1.1.1:853/cloudfare-dns.com"
-# Servers addresses, majority of them have to agree.
-# autoupdate_dns_hosts = [#server1, #server2, ...]
-# Set to true to only accept DNS records that pass DNSSEC validation (Default: true)
-dns_seeds_use_dnssec = false
-
 # Tari is a 100% peer-to-peer network, so there are no servers to hold messages for you while you're offline.
 # Instead, we rely on our peers to hold messages for us while we're offline. This settings sets maximum size of the
 # message cache that for holding our peers' messages, in MB.
@@ -92,13 +58,60 @@ dedup_cache_capacity = 25000
 # sessions.
 rpc_max_simultaneous_sessions = 10000
 
+[common.weatherwax]
+# When first logging onto the Tari network, you need to find a few peers to bootstrap the process. In the absence of
+# any servers, this is a little more challenging than usual. Our best strategy is just to try and connect to the peers
+# you knew about last time you ran the software. But what about when you run the software for the first time? That's
+# where this allowlist comes in. It's a list of known Tari nodes that are likely to be around for a long time and that
+# new nodes can use to introduce themselves to the network.
+# peer_seeds = ["public_key1::address1", "public_key2::address2",... ]
+peer_seeds = [
+    # weatherwax
+    "98bc76afc1c35ad4651bdc9ef57bbe0655a2ea3cd86c0e19b5fd5890546eb040::/onion3/33izgtjkrlxhxybj6luqowkpiy2wvte43osejnbqyieqtdfhovzghxad:18141", #jozi
+    "9a26e910288213d649b26f9a7a7ee51fe2b2a67ff7d42334523463bf4be94312::/onion3/56kq54ylttnbl5ikotqex3oqvtzlxdpn7zlx4v56rvzf4kq7eezlclid:18141", #london
+    "6afd5b3c7772ad7d4bb26e0c19668fe04f2d68f99de9e132bee50a6c1846946d::/onion3/may4ajbmcn4dlnzf6fanvqlklxzqiw6qwu6ywqwkjc3bb354rc2i5wid:18141", #ncal
+    "8e7beec9becdc44fe6015a00d97a77fa3dbafe65127dcc988df6326bd9fd040d::/onion3/3pise36l4imoopsbjic5rtw67adx7rms6w5pgjmccpdwiqx66j7oqcqd:18141", #nvir
+    "80bb590d943a46e63ae79af5dc2c7d35a3dcd7922c182b28f619dc4cfc366f44::/onion3/oaxwahri7r3h5qjlcdbveyjmg4jsttausik66bicmhixft73nmvecdad:18141", #oregon
+    "981cc8cd1e4fe2f99ea1bd3e0ab1e7821ca0bfab336a4967cfec053fee86254c::/onion3/7hxpnxrxycdfevirddau7ybofwedaamjrg2ijm57k2kevh5q46ixamid:18141", #seoul
+    "f2ce179fb733725961a5f7e1e45dacdd443dd43ba6237438d6abe344fb717058::/onion3/nvgdmjf4wucgatz7vemzvi2u4sw5o4gyzwuikagpepoj4w7mkii47zid:18141", #stockholm
+    "909c0160f4d8e815aba5c2bbccfcceb448877e7b38759fb160f3e9494484d515::/onion3/qw5uxv533sqdn2qoncfyqo35dgecy4rt4x27rexi2her6q6pcpxbm4qd:18141", #sydney
+]
+
+# DNS seeds
+# The DNS records in these hostnames should provide TXT records as per https://github.com/tari-project/tari/pull/2319
+# Enter a domain name for the TXT records:
+dns_seeds =["seeds.weatherwax.tari.com"]
+# The name server used to resolve DNS seeds format: {socket address}/{tls sni dns name} (Default: cloudflare)
+# dns_seeds_name_server = "1.1.1.1:853/cloudfare-dns.com"
+# Servers addresses, majority of them have to agree.
+# autoupdate_dns_hosts = [#server1, #server2, ...]
+# Set to true to only accept DNS records that pass DNSSEC validation (Default: true)
+dns_seeds_use_dnssec = false
+
 # Auto Update
 #
 # This interval in seconds to check for software updates. Setting this to 0 disables checking.
 # auto_update.check_interval = 300
 # Customize the hosts that are used to check for updates. These hosts must contain update information in DNS TXT records.
-# auto_update.dns_hosts = ["updates.taripulse.com"]
+# "auto_update.dns_hosts" = ["updates.weatherwax.taripulse.com"]
 # Customize the location of the update SHA hashes and maintainer-signed signature.
-# auto_update.hashes_url = "https://<address>/hashes.txt"
-# auto_update.hashes_sig_url = "https://<address>/hashes.txt.sig"
+# "auto_update.hashes_url" = "https://<address>/hashes.txt"
+# "auto_update.hashes_sig_url" = "https://<address>/hashes.txt.sig"
 
+[common.igor]
+peer_seeds = [
+    # igor
+    "8e7eb81e512f3d6347bf9b1ca9cd67d2c8e29f2836fc5bd608206505cc72af34::/onion3/l4wouomx42nezhzexjdzfh7pcou5l7df24ggmwgekuih7tkv2rsaokqd:18141",
+    "00b35047a341401bcd336b2a3d564280a72f6dc72ec4c739d30c502acce4e803::/onion3/ojhxd7z6ga7qrvjlr3px66u7eiwasmffnuklscbh5o7g6wrbysj45vid:18141",
+    "40a9d8573745072534bce7d0ecafe882b1c79570375a69841c08a98dee9ecb5f::/onion3/io37fylc2pupg4cte4siqlsmuszkeythgjsxs2i3prm6jyz2dtophaad:18141",
+    "126c7ee64f71aca36398b977dd31fbbe9f9dad615df96473fb655bef5709c540::/onion3/6ilmgndocop7ybgmcvivbdsetzr5ggj4hhsivievoa2dx2b43wqlrlid:18141",
+]
+
+dns_seeds =["seeds.igor.tari.com"]
+# dns_seeds_name_server = "1.1.1.1:853/cloudfare-dns.com"
+dns_seeds_use_dnssec = false
+
+# auto_update.check_interval = 300
+# "auto_update.dns_hosts" = ["updates.igor.taripulse.com"]
+# "auto_update.hashes_url" = "https://<address>/hashes.txt"
+# "auto_update.hashes_sig_url" = "https://<address>/hashes.txt.sig"

--- a/common/config/presets/merge_mining_proxy.toml
+++ b/common/config/presets/merge_mining_proxy.toml
@@ -34,4 +34,3 @@ monerod_password = ""
 # or not. If merge mining starts before the base node has achieved initial sync, those Tari mined blocks will not be
 # accepted. (Default value = true; will wait for base node initial sync).
 #wait_for_initial_sync_at_startup = true
-

--- a/common/src/configuration/global.rs
+++ b/common/src/configuration/global.rs
@@ -145,27 +145,37 @@ pub struct GlobalConfig {
 }
 
 impl GlobalConfig {
-    pub fn convert_from(application: ApplicationType, mut cfg: Config) -> Result<Self, ConfigurationError> {
+    pub fn convert_from(
+        application: ApplicationType,
+        mut cfg: Config,
+        network: Option<String>,
+    ) -> Result<Self, ConfigurationError> {
         // Add in settings from the environment (with a prefix of TARI_NODE)
         // Eg.. `TARI_NODE_DEBUG=1 ./target/app` would set the `debug` key
         let env = Environment::with_prefix("tari").separator("__");
         cfg.merge(env)
             .map_err(|e| ConfigurationError::new("environment variable", &e.to_string()))?;
-        let network = one_of::<Network>(&cfg, &[
-            &format!("{}.network", application.as_config_str()),
-            "common.network",
-            // TODO: Remove this once some time has passed and folks have upgraded their configs
-            "base_node.network",
-        ])?;
 
-        convert_node_config(application, network, cfg)
+        // network override from command line
+        let network = match network {
+            Some(s) => Network::from_str(&s)?,
+            None => {
+                // otherwise specified from config
+                one_of::<Network>(&cfg, &[
+                    "common.network",
+                    &format!("{}.network", application.as_config_str()),
+                ])?
+            },
+        };
+
+        convert_node_config(application, cfg, network)
     }
 }
 
 fn convert_node_config(
     application: ApplicationType,
-    network: Network,
     cfg: Config,
+    network: Network,
 ) -> Result<GlobalConfig, ConfigurationError> {
     let net_str = network.as_str();
 
@@ -353,38 +363,35 @@ fn convert_node_config(
         .map(|addr| socket_or_multi(&addr).map_err(|e| ConfigurationError::new(key, &e.to_string())))??;
 
     // Peer and DNS seeds
-    let key = "common.peer_seeds";
+    let key = config_string("common", net_str, "peer_seeds");
     // Peer seeds can be an array or a comma separated list (e.g. in an ENVVAR)
-    let peer_seeds = match cfg.get_array(key) {
+    let peer_seeds = match cfg.get_array(&key) {
         Ok(seeds) => seeds.into_iter().map(|v| v.into_str().unwrap()).collect(),
-        Err(..) => optional(cfg.get_str(key))?
+        Err(..) => optional(cfg.get_str(&key))?
             .map(|s| s.split(',').map(|v| v.trim().to_string()).collect())
             .unwrap_or_default(),
     };
 
     // TODO: dns resolver presets e.g. "cloudflare", "quad9", "custom" (maybe just in toml) and
     //       add support for multiple addresses
-    let key = "common.dns_seeds_name_server";
+    let key = config_string("common", net_str, "dns_seeds_name_server");
     let dns_seeds_name_server = cfg
-        .get_str(key)
-        .map_err(|e| ConfigurationError::new(key, &e.to_string()))
+        .get_str(&key)
+        .map_err(|e| ConfigurationError::new(&key, &e.to_string()))
         .and_then(|s| {
             s.parse::<DnsNameServer>()
-                .map_err(|e| ConfigurationError::new(key, &e.to_string()))
+                .map_err(|e| ConfigurationError::new(&key, &e.to_string()))
         })?;
 
-    let key = config_string("base_node", net_str, "bypass_range_proof_verification");
-    let base_node_bypass_range_proof_verification = cfg.get_bool(&key).unwrap_or(false);
-
-    let key = "common.dns_seeds_use_dnssec";
+    let key = config_string("common", net_str, "dns_seeds_use_dnssec");
     let dns_seeds_use_dnssec = cfg
-        .get_bool(key)
-        .map_err(|e| ConfigurationError::new(key, &e.to_string()))?;
+        .get_bool(&key)
+        .map_err(|e| ConfigurationError::new(&key, &e.to_string()))?;
 
-    let key = "common.dns_seeds";
-    let dns_seeds = match cfg.get_array(key) {
+    let key = config_string("common", net_str, "dns_seeds");
+    let dns_seeds = match cfg.get_array(&key) {
         Ok(seeds) => seeds.into_iter().map(|v| v.into_str().unwrap()).collect(),
-        Err(..) => optional(cfg.get_str(key))?
+        Err(..) => optional(cfg.get_str(&key))?
             .map(|s| {
                 s.split(',')
                     .map(|v| v.trim().to_string())
@@ -393,6 +400,9 @@ fn convert_node_config(
             })
             .unwrap_or_default(),
     };
+
+    let key = config_string("base_node", net_str, "bypass_range_proof_verification");
+    let base_node_bypass_range_proof_verification = cfg.get_bool(&key).unwrap_or(false);
 
     // Peer DB path
     let peer_db_path = data_dir.join("peer_db");
@@ -668,8 +678,8 @@ fn convert_node_config(
     let validate_tip_timeout_sec = optional(cfg.get_int(key))?.unwrap_or(0) as u64;
 
     // Auto update
-    let key = "common.auto_update.check_interval";
-    let autoupdate_check_interval = optional(cfg.get_int(key))?.and_then(|secs| {
+    let key = config_string("common", net_str, "auto_update.check_interval");
+    let autoupdate_check_interval = optional(cfg.get_int(&key))?.and_then(|secs| {
         if secs > 0 {
             Some(Duration::from_secs(secs as u64))
         } else {
@@ -677,20 +687,20 @@ fn convert_node_config(
         }
     });
 
-    let key = "common.auto_update.dns_hosts";
+    let key = config_string("common", net_str, "auto_update.dns_hosts");
     let autoupdate_dns_hosts = cfg
-        .get_array(key)
+        .get_array(&key)
         .and_then(|arr| arr.into_iter().map(|s| s.into_str()).collect::<Result<Vec<_>, _>>())
         .or_else(|_| {
-            cfg.get_str(key)
+            cfg.get_str(&key)
                 .map(|s| s.split(',').map(ToString::to_string).collect())
         })?;
 
-    let key = "common.auto_update.hashes_url";
-    let autoupdate_hashes_url = cfg.get_str(key)?;
+    let key = config_string("common", net_str, "auto_update.hashes_url");
+    let autoupdate_hashes_url = cfg.get_str(&key)?;
 
-    let key = "common.auto_update.hashes_sig_url";
-    let autoupdate_hashes_sig_url = cfg.get_str(key)?;
+    let key = config_string("common", net_str, "auto_update.hashes_sig_url");
+    let autoupdate_hashes_sig_url = cfg.get_str(&key)?;
 
     let key = "mining_node.mining_pool_address";
     let mining_pool_address = cfg.get_str(key).unwrap_or_else(|_| "".to_string());

--- a/common/src/configuration/utils.rs
+++ b/common/src/configuration/utils.rs
@@ -81,25 +81,6 @@ pub fn default_config(bootstrap: &ConfigBootstrap) -> Config {
     cfg.set_default("common.fetch_utxos_timeout", 600).unwrap();
     cfg.set_default("common.service_request_timeout", 180).unwrap();
 
-    cfg.set_default("common.auto_update.dns_hosts", vec!["versions.tari.com"])
-        .unwrap();
-    // TODO: Change to a more permanent link
-    cfg.set_default(
-        "common.auto_update.hashes_url",
-        "https://raw.githubusercontent.com/tari-project/tari/development/meta/hashes.txt",
-    )
-    .unwrap();
-    cfg.set_default(
-        "common.auto_update.hashes_sig_url",
-        "https://raw.githubusercontent.com/tari-project/tari/development/meta/hashes.txt.sig",
-    )
-    .unwrap();
-    cfg.set_default("common.peer_seeds", Vec::<String>::new()).unwrap();
-    cfg.set_default("common.dns_seeds", Vec::<String>::new()).unwrap();
-    cfg.set_default("common.dns_seeds_name_server", "1.1.1.1:853/cloudflare-dns.com")
-        .unwrap();
-    cfg.set_default("common.dns_seeds_use_dnssec", true).unwrap();
-
     // Wallet settings
     cfg.set_default("wallet.grpc_enabled", false).unwrap();
     cfg.set_default("wallet.grpc_address", "127.0.0.1:18040").unwrap();
@@ -179,6 +160,26 @@ pub fn default_config(bootstrap: &ConfigBootstrap) -> Config {
     cfg.set_default("base_node.mainnet.flood_ban_max_msg_count", 10000)
         .unwrap();
 
+    cfg.set_default("common.mainnet.peer_seeds", Vec::<String>::new())
+        .unwrap();
+    cfg.set_default("common.mainnet.dns_seeds", Vec::<String>::new())
+        .unwrap();
+    cfg.set_default("common.mainnet.dns_seeds_name_server", "1.1.1.1:853/cloudflare-dns.com")
+        .unwrap();
+    cfg.set_default("common.mainnet.dns_seeds_use_dnssec", true).unwrap();
+    cfg.set_default("common.mainnet.auto_update.dns_hosts", vec!["versions.tari.com"])
+        .unwrap();
+    cfg.set_default(
+        "common.mainnet.auto_update.hashes_url",
+        "https://raw.githubusercontent.com/tari-project/tari/development/meta/hashes.txt",
+    )
+    .unwrap();
+    cfg.set_default(
+        "common.mainnet.auto_update.hashes_sig_url",
+        "https://raw.githubusercontent.com/tari-project/tari/development/meta/hashes.txt.sig",
+    )
+    .unwrap();
+
     //---------------------------------- Weatherwax Defaults --------------------------------------------//
 
     cfg.set_default("base_node.weatherwax.db_type", "lmdb").unwrap();
@@ -235,6 +236,29 @@ pub fn default_config(bootstrap: &ConfigBootstrap) -> Config {
 
     cfg.set_default("wallet.base_node_service_peers", Vec::<String>::new())
         .unwrap();
+
+    cfg.set_default("common.weatherwax.peer_seeds", Vec::<String>::new())
+        .unwrap();
+    cfg.set_default("common.weatherwax.dns_seeds", Vec::<String>::new())
+        .unwrap();
+    cfg.set_default(
+        "common.weatherwax.dns_seeds_name_server",
+        "1.1.1.1:853/cloudflare-dns.com",
+    )
+    .unwrap();
+    cfg.set_default("common.weatherwax.dns_seeds_use_dnssec", true).unwrap();
+    cfg.set_default("common.weatherwax.auto_update.dns_hosts", vec!["versions.tari.com"])
+        .unwrap();
+    cfg.set_default(
+        "common.weatherwax.auto_update.hashes_url",
+        "https://raw.githubusercontent.com/tari-project/tari/development/meta/hashes.txt",
+    )
+    .unwrap();
+    cfg.set_default(
+        "common.weatherwax.auto_update.hashes_sig_url",
+        "https://raw.githubusercontent.com/tari-project/tari/development/meta/hashes.txt.sig",
+    )
+    .unwrap();
     //---------------------------------- Igor Defaults --------------------------------------------//
 
     cfg.set_default("base_node.igor.db_type", "lmdb").unwrap();
@@ -252,6 +276,24 @@ pub fn default_config(bootstrap: &ConfigBootstrap) -> Config {
         .unwrap();
     cfg.set_default("base_node.igor.dns_seeds_use_dnssec", true).unwrap();
     cfg.set_default("base_node.igor.auto_ping_interval", 30).unwrap();
+
+    cfg.set_default("common.igor.peer_seeds", Vec::<String>::new()).unwrap();
+    cfg.set_default("common.igor.dns_seeds", Vec::<String>::new()).unwrap();
+    cfg.set_default("common.igor.dns_seeds_name_server", "1.1.1.1:853/cloudflare-dns.com")
+        .unwrap();
+    cfg.set_default("common.igor.dns_seeds_use_dnssec", true).unwrap();
+    cfg.set_default("common.igor.auto_update.dns_hosts", vec!["versions.tari.com"])
+        .unwrap();
+    cfg.set_default(
+        "common.igor.auto_update.hashes_url",
+        "https://raw.githubusercontent.com/tari-project/tari/development/meta/hashes.txt",
+    )
+    .unwrap();
+    cfg.set_default(
+        "common.igor.auto_update.hashes_sig_url",
+        "https://raw.githubusercontent.com/tari-project/tari/development/meta/hashes.txt.sig",
+    )
+    .unwrap();
 
     set_transport_defaults(&mut cfg).unwrap();
     set_merge_mining_defaults(&mut cfg);
@@ -306,6 +348,11 @@ fn set_merge_mining_defaults(cfg: &mut Config) {
         .unwrap();
     cfg.set_default("merge_mining_proxy.weatherwax.wait_for_initial_sync_at_startup", true)
         .unwrap();
+    cfg.set_default(
+        "merge_mining_proxy.igor.monerod_url",
+        "http://monero-stagenet.exan.tech:38081",
+    )
+    .unwrap();
     cfg.set_default("merge_mining_proxy.igor.proxy_host_address", "127.0.0.1:7878")
         .unwrap();
     cfg.set_default("merge_mining_proxy.igor.proxy_submit_to_origin", true)

--- a/common/src/configuration/utils.rs
+++ b/common/src/configuration/utils.rs
@@ -160,26 +160,6 @@ pub fn default_config(bootstrap: &ConfigBootstrap) -> Config {
     cfg.set_default("base_node.mainnet.flood_ban_max_msg_count", 10000)
         .unwrap();
 
-    cfg.set_default("common.mainnet.peer_seeds", Vec::<String>::new())
-        .unwrap();
-    cfg.set_default("common.mainnet.dns_seeds", Vec::<String>::new())
-        .unwrap();
-    cfg.set_default("common.mainnet.dns_seeds_name_server", "1.1.1.1:853/cloudflare-dns.com")
-        .unwrap();
-    cfg.set_default("common.mainnet.dns_seeds_use_dnssec", true).unwrap();
-    cfg.set_default("common.mainnet.auto_update.dns_hosts", vec!["versions.tari.com"])
-        .unwrap();
-    cfg.set_default(
-        "common.mainnet.auto_update.hashes_url",
-        "https://raw.githubusercontent.com/tari-project/tari/development/meta/hashes.txt",
-    )
-    .unwrap();
-    cfg.set_default(
-        "common.mainnet.auto_update.hashes_sig_url",
-        "https://raw.githubusercontent.com/tari-project/tari/development/meta/hashes.txt.sig",
-    )
-    .unwrap();
-
     //---------------------------------- Weatherwax Defaults --------------------------------------------//
 
     cfg.set_default("base_node.weatherwax.db_type", "lmdb").unwrap();
@@ -225,40 +205,7 @@ pub fn default_config(bootstrap: &ConfigBootstrap) -> Config {
     cfg.set_default("base_node.weatherwax.grpc_enabled", false).unwrap();
     cfg.set_default("base_node.weatherwax.grpc_base_node_address", "127.0.0.1:18142")
         .unwrap();
-    cfg.set_default(
-        "base_node.weatherwax.dns_seeds_name_server",
-        "1.1.1.1:853/cloudflare-dns.com",
-    )
-    .unwrap();
-    cfg.set_default("base_node.weatherwax.dns_seeds_use_dnssec", true)
-        .unwrap();
-    cfg.set_default("base_node.weatherwax.auto_ping_interval", 30).unwrap();
 
-    cfg.set_default("wallet.base_node_service_peers", Vec::<String>::new())
-        .unwrap();
-
-    cfg.set_default("common.weatherwax.peer_seeds", Vec::<String>::new())
-        .unwrap();
-    cfg.set_default("common.weatherwax.dns_seeds", Vec::<String>::new())
-        .unwrap();
-    cfg.set_default(
-        "common.weatherwax.dns_seeds_name_server",
-        "1.1.1.1:853/cloudflare-dns.com",
-    )
-    .unwrap();
-    cfg.set_default("common.weatherwax.dns_seeds_use_dnssec", true).unwrap();
-    cfg.set_default("common.weatherwax.auto_update.dns_hosts", vec!["versions.tari.com"])
-        .unwrap();
-    cfg.set_default(
-        "common.weatherwax.auto_update.hashes_url",
-        "https://raw.githubusercontent.com/tari-project/tari/development/meta/hashes.txt",
-    )
-    .unwrap();
-    cfg.set_default(
-        "common.weatherwax.auto_update.hashes_sig_url",
-        "https://raw.githubusercontent.com/tari-project/tari/development/meta/hashes.txt.sig",
-    )
-    .unwrap();
     //---------------------------------- Igor Defaults --------------------------------------------//
 
     cfg.set_default("base_node.igor.db_type", "lmdb").unwrap();
@@ -272,35 +219,56 @@ pub fn default_config(bootstrap: &ConfigBootstrap) -> Config {
     cfg.set_default("base_node.igor.grpc_enabled", false).unwrap();
     cfg.set_default("base_node.igor.grpc_base_node_address", "127.0.0.1:18142")
         .unwrap();
-    cfg.set_default("base_node.igor.dns_seeds_name_server", "1.1.1.1:853/cloudflare-dns.com")
-        .unwrap();
-    cfg.set_default("base_node.igor.dns_seeds_use_dnssec", true).unwrap();
-    cfg.set_default("base_node.igor.auto_ping_interval", 30).unwrap();
 
-    cfg.set_default("common.igor.peer_seeds", Vec::<String>::new()).unwrap();
-    cfg.set_default("common.igor.dns_seeds", Vec::<String>::new()).unwrap();
-    cfg.set_default("common.igor.dns_seeds_name_server", "1.1.1.1:853/cloudflare-dns.com")
-        .unwrap();
-    cfg.set_default("common.igor.dns_seeds_use_dnssec", true).unwrap();
-    cfg.set_default("common.igor.auto_update.dns_hosts", vec!["versions.tari.com"])
-        .unwrap();
-    cfg.set_default(
-        "common.igor.auto_update.hashes_url",
-        "https://raw.githubusercontent.com/tari-project/tari/development/meta/hashes.txt",
-    )
-    .unwrap();
-    cfg.set_default(
-        "common.igor.auto_update.hashes_sig_url",
-        "https://raw.githubusercontent.com/tari-project/tari/development/meta/hashes.txt.sig",
-    )
-    .unwrap();
-
+    set_common_network_defaults(&mut cfg);
     set_transport_defaults(&mut cfg).unwrap();
     set_merge_mining_defaults(&mut cfg);
     set_mining_node_defaults(&mut cfg);
     set_stratum_transcoder_defaults(&mut cfg);
 
     cfg
+}
+
+fn set_common_network_defaults(cfg: &mut Config) {
+    for network in ["mainnet", "weatherwax", "igor", "localnet"] {
+        let key = format!("base_node.{}.dns_seeds_name_server", network);
+        cfg.set_default(&key, "1.1.1.1:853/cloudflare-dns.com").unwrap();
+
+        let key = format!("base_node.{}.dns_seeds_use_dnssec", network);
+        cfg.set_default(&key, true).unwrap();
+
+        let key = format!("base_node.{}.auto_ping_interval", network);
+        cfg.set_default(&key, 30).unwrap();
+
+        let key = format!("common.{}.peer_seeds", network);
+        cfg.set_default(&key, Vec::<String>::new()).unwrap();
+
+        let key = format!("common.{}.dns_seeds", network);
+        cfg.set_default(&key, Vec::<String>::new()).unwrap();
+
+        let key = format!("common.{}.dns_seeds_name_server", network);
+        cfg.set_default(&key, "1.1.1.1:853/cloudflare-dns.com").unwrap();
+
+        let key = format!("common.{}.dns_seeds_use_dnssec", network);
+        cfg.set_default(&key, true).unwrap();
+
+        let key = format!("common.{}.auto_update.dns_hosts", network);
+        cfg.set_default(&key, vec!["versions.tari.com"]).unwrap();
+
+        let key = format!("common.{}.auto_update.hashes_url", network);
+        cfg.set_default(
+            &key,
+            "https://raw.githubusercontent.com/tari-project/tari/development/meta/hashes.txt",
+        )
+        .unwrap();
+
+        let key = format!("common.{}.auto_update.hashes_sig_url", network);
+        cfg.set_default(
+            &key,
+            "https://raw.githubusercontent.com/tari-project/tari/development/meta/hashes.txt.sig",
+        )
+        .unwrap();
+    }
 }
 
 fn set_stratum_transcoder_defaults(cfg: &mut Config) {

--- a/common/src/exit_codes.rs
+++ b/common/src/exit_codes.rs
@@ -86,6 +86,12 @@ impl From<super::ConfigError> for ExitCodes {
     }
 }
 
+impl From<crate::ConfigurationError> for ExitCodes {
+    fn from(err: crate::ConfigurationError) -> Self {
+        Self::ConfigError(err.to_string())
+    }
+}
+
 impl ExitCodes {
     pub fn grpc<M: std::fmt::Display>(err: M) -> Self {
         ExitCodes::GrpcError(format!("GRPC connection error: {}", err))

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -70,7 +70,7 @@
 //! # args.init = true;
 //! args.init_dirs(ApplicationType::BaseNode);
 //! let config = args.load_configuration().unwrap();
-//! let global = GlobalConfig::convert_from(ApplicationType::BaseNode, config).unwrap();
+//! let global = GlobalConfig::convert_from(ApplicationType::BaseNode, config, Some("weatherwax".into())).unwrap();
 //! assert_eq!(global.network, Network::Weatherwax);
 //! assert!(global.core_threads.is_none());
 //! # std::fs::remove_dir_all(temp_dir).unwrap();

--- a/integration_tests/Makefile
+++ b/integration_tests/Makefile
@@ -1,0 +1,14 @@
+.DEFAULT_GOAL := test
+
+.phony: build
+build:
+	cargo build --release --bin tari_base_node && \
+	cargo build --release --bin tari_console_wallet && \
+	cargo build --release --bin tari_mining_node && \
+	cargo build --release --bin tari_merge_mining_proxy && \
+	cargo build --release --bin tari_stratum_transcoder && \
+	cargo build --release --package tari_wallet_ffi
+
+.phony: test
+test: build
+	npm test -- --profile "ci" --tags "@critical and not @long-running and not @broken and not @wallet-ffi"

--- a/integration_tests/helpers/config.js
+++ b/integration_tests/helpers/config.js
@@ -40,21 +40,25 @@ function mapEnvs(options) {
   if (options.common && options.common.auto_update) {
     let { auto_update } = options.common;
     if (auto_update.enabled) {
-      res.TARI_COMMON__AUTO_UPDATE__ENABLED = auto_update.enabled
+      res.TARI_COMMON__LOCALNET__AUTO_UPDATE__ENABLED = auto_update.enabled
         ? "true"
         : "false";
     }
     if (auto_update.check_interval) {
-      res.TARI_COMMON__AUTO_UPDATE__CHECK_INTERVAL = auto_update.check_interval;
+      res.TARI_COMMON__LOCALNET__AUTO_UPDATE__CHECK_INTERVAL =
+        auto_update.check_interval;
     }
     if (auto_update.dns_hosts) {
-      res.TARI_COMMON__AUTO_UPDATE__DNS_HOSTS = auto_update.dns_hosts.join(",");
+      res.TARI_COMMON__LOCALNET__AUTO_UPDATE__DNS_HOSTS =
+        auto_update.dns_hosts.join(",");
     }
     if (auto_update.hashes_url) {
-      res.TARI_COMMON__AUTO_UPDATE__HASHES_URL = auto_update.hashes_url;
+      res.TARI_COMMON__LOCALNET__AUTO_UPDATE__HASHES_URL =
+        auto_update.hashes_url;
     }
     if (auto_update.hashes_sig_url) {
-      res.TARI_COMMON__AUTO_UPDATE__HASHES_SIG_URL = auto_update.hashes_sig_url;
+      res.TARI_COMMON__LOCALNET__AUTO_UPDATE__HASHES_SIG_URL =
+        auto_update.hashes_sig_url;
     }
   }
   return res;
@@ -83,8 +87,8 @@ function baseEnvs(peerSeeds = [], forceSyncPeers = []) {
     TARI_BASE_NODE__LOCALNET__ALLOW_TEST_ADDRESSES: true,
     TARI_BASE_NODE__LOCALNET__GRPC_ENABLED: true,
     TARI_BASE_NODE__LOCALNET__ENABLE_WALLET: false,
-    TARI_COMMON__DNS_SEEDS_USE_DNSSEC: "false",
-    TARI_COMMON__DNS_SEEDS: "",
+    TARI_COMMON__LOCALNET__DNS_SEEDS_USE_DNSSEC: "false",
+    TARI_COMMON__LOCALNET__DNS_SEEDS: "",
     TARI_BASE_NODE__LOCALNET__BLOCK_SYNC_STRATEGY: "ViaBestChainMetadata",
     TARI_BASE_NODE__LOCALNET__ORPHAN_DB_CLEAN_OUT_THRESHOLD: "0",
     TARI_BASE_NODE__LOCALNET__MAX_RANDOMX_VMS: "1",
@@ -107,7 +111,7 @@ function baseEnvs(peerSeeds = [], forceSyncPeers = []) {
     envs.TARI_BASE_NODE__LOCALNET__FORCE_SYNC_PEERS = forceSyncPeers.join(",");
   }
   if (peerSeeds.length > 0) {
-    envs.TARI_COMMON__PEER_SEEDS = peerSeeds.join(",");
+    envs.TARI_COMMON__LOCALNET__PEER_SEEDS = peerSeeds.join(",");
   }
 
   return envs;


### PR DESCRIPTION
Description
---

Separate some [common] configs to [common.network] 

- peer seeds 
- dns seeds 
- auto update settings 

Tested by starting base node sync on both weatherwax and igor and checking peer seeds are specific to network 

Update the clippy github action since the other version fails to run on forks.
Fix Linux build issue on github actions.