### PR TITLE
feat: bad block list for invalid blocks after sync

### DIFF
--- a/base_layer/core/src/base_node/sync/block_sync/error.rs
+++ b/base_layer/core/src/base_node/sync/block_sync/error.rs
@@ -34,8 +34,6 @@ pub enum BlockSyncError {
     RpcRequestError(#[from] RpcStatus),
     #[error("Chain storage error: {0}")]
     ChainStorageError(#[from] ChainStorageError),
-    #[error("Peer sent invalid block body: {0}")]
-    ReceivedInvalidBlockBody(String),
     #[error("Peer sent a block that did not form a chain. Expected hash = {expected}, got = {got}")]
     PeerSentBlockThatDidNotFormAChain { expected: String, got: String },
     #[error("Connectivity Error: {0}")]
@@ -48,4 +46,6 @@ pub enum BlockSyncError {
     FailedToBan(ConnectivityError),
     #[error("Failed to construct valid chain block")]
     FailedToConstructChainBlock,
+    #[error("Peer violated the block sync protocol: {0}")]
+    ProtocolViolation(String),
 }

--- a/base_layer/core/src/base_node/sync/block_sync/synchronizer.rs
+++ b/base_layer/core/src/base_node/sync/block_sync/synchronizer.rs
@@ -26,12 +26,12 @@ use crate::{
         sync::{hooks::Hooks, rpc, SyncPeer},
         BlockSyncConfig,
     },
-    blocks::{Block, ChainBlock},
+    blocks::{Block, BlockValidationError, ChainBlock},
     chain_storage::{async_db::AsyncBlockchainDb, BlockchainBackend},
     proto::base_node::SyncBlocksRequest,
     tari_utilities::{hex::Hex, Hashable},
     transactions::aggregated_body::AggregateBody,
-    validation::BlockSyncBodyValidation,
+    validation::{BlockSyncBodyValidation, ValidationError},
 };
 use futures::StreamExt;
 use log::*;
@@ -96,7 +96,29 @@ impl<B: BlockchainBackend + 'static> BlockSynchronizer<B> {
                 self.db.cleanup_orphans().await?;
                 Ok(())
             },
-            Err(err @ BlockSyncError::ValidationError(_)) | Err(err @ BlockSyncError::ReceivedInvalidBlockBody(_)) => {
+            Err(BlockSyncError::ValidationError(err)) => {
+                match &err {
+                    ValidationError::BlockHeaderError(_) => {},
+                    ValidationError::BlockError(BlockValidationError::MismatchedMmrRoots) |
+                    ValidationError::BadBlockFound { .. } |
+                    ValidationError::BlockError(BlockValidationError::MismatchedMmrSize { .. }) => {
+                        let num_cleared = self.db.clear_all_pending_headers().await?;
+                        warn!(
+                            target: LOG_TARGET,
+                            "Cleared {} incomplete headers from bad chain", num_cleared
+                        );
+                    },
+                    _ => {},
+                }
+                warn!(
+                    target: LOG_TARGET,
+                    "Banning peer because provided block failed validation: {}", err
+                );
+                self.ban_peer(node_id, &err).await?;
+                Err(err.into())
+            },
+            Err(err @ BlockSyncError::ProtocolViolation(_)) => {
+                warn!(target: LOG_TARGET, "Banning peer: {}", err);
                 self.ban_peer(node_id, &err).await?;
                 Err(err)
             },
@@ -166,9 +188,10 @@ impl<B: BlockchainBackend + 'static> BlockSynchronizer<B> {
                 .fetch_chain_header_by_block_hash(block.hash.clone())
                 .await?
                 .ok_or_else(|| {
-                    BlockSyncError::ReceivedInvalidBlockBody("Peer sent hash for block header we do not have".into())
+                    BlockSyncError::ProtocolViolation("Peer sent hash for block header we do not have".into())
                 })?;
 
+            let current_height = header.height();
             let header_hash = header.hash().clone();
 
             if header.header().prev_hash != prev_hash {
@@ -183,13 +206,13 @@ impl<B: BlockchainBackend + 'static> BlockSynchronizer<B> {
             let body = block
                 .body
                 .map(AggregateBody::try_from)
-                .ok_or_else(|| BlockSyncError::ReceivedInvalidBlockBody("Block body was empty".to_string()))?
-                .map_err(BlockSyncError::ReceivedInvalidBlockBody)?;
+                .ok_or_else(|| BlockSyncError::ProtocolViolation("Block body was empty".to_string()))?
+                .map_err(BlockSyncError::ProtocolViolation)?;
 
             debug!(
                 target: LOG_TARGET,
                 "Validating block body #{} (PoW = {}, {})",
-                header.height(),
+                current_height,
                 header.header().pow_algo(),
                 body.to_counts_string(),
             );
@@ -197,7 +220,26 @@ impl<B: BlockchainBackend + 'static> BlockSynchronizer<B> {
             let timer = Instant::now();
             let (header, header_accum_data) = header.into_parts();
 
-            let block = self.block_validator.validate_body(Block::new(header, body)).await?;
+            let block = match self.block_validator.validate_body(Block::new(header, body)).await {
+                Ok(block) => block,
+                Err(err @ ValidationError::BadBlockFound { .. }) |
+                Err(err @ ValidationError::FatalStorageError(_)) |
+                Err(err @ ValidationError::AsyncTaskFailed(_)) |
+                Err(err @ ValidationError::CustomError(_)) => return Err(err.into()),
+                Err(err) => {
+                    // Add to bad blocks
+                    if let Err(err) = self
+                        .db
+                        .write_transaction()
+                        .insert_bad_block(header_hash, current_height)
+                        .commit()
+                        .await
+                    {
+                        error!(target: LOG_TARGET, "Failed to insert bad block: {}", err);
+                    }
+                    return Err(err.into());
+                },
+            };
 
             let block = ChainBlock::try_construct(Arc::new(block), header_accum_data)
                 .map(Arc::new)

--- a/base_layer/core/src/chain_storage/async_db.rs
+++ b/base_layer/core/src/chain_storage/async_db.rs
@@ -207,6 +207,8 @@ impl<B: BlockchainBackend + 'static> AsyncBlockchainDb<B> {
 
     make_async_fn!(fetch_last_header() -> BlockHeader, "fetch_last_header");
 
+    make_async_fn!(clear_all_pending_headers() -> usize, "clear_all_pending_headers");
+
     make_async_fn!(fetch_last_chain_header() -> ChainHeader, "fetch_last_chain_header");
 
     make_async_fn!(fetch_tip_header() -> ChainHeader, "fetch_tip_header");
@@ -221,6 +223,8 @@ impl<B: BlockchainBackend + 'static> AsyncBlockchainDb<B> {
     make_async_fn!(cleanup_all_orphans() -> (), "cleanup_all_orphans");
 
     make_async_fn!(block_exists(block_hash: BlockHash) -> bool, "block_exists");
+
+    make_async_fn!(bad_block_exists(block_hash: BlockHash) -> bool, "bad_block_exists");
 
     make_async_fn!(fetch_block(height: u64) -> HistoricalBlock, "fetch_block");
 
@@ -373,6 +377,11 @@ impl<'a, B: BlockchainBackend + 'static> AsyncDbTransaction<'a, B> {
 
     pub fn insert_block_body(&mut self, block: Arc<ChainBlock>) -> &mut Self {
         self.transaction.insert_block_body(block);
+        self
+    }
+
+    pub fn insert_bad_block(&mut self, hash: HashOutput, height: u64) -> &mut Self {
+        self.transaction.insert_bad_block(hash, height);
         self
     }
 

--- a/base_layer/core/src/chain_storage/blockchain_backend.rs
+++ b/base_layer/core/src/chain_storage/blockchain_backend.rs
@@ -135,6 +135,10 @@ pub trait BlockchainBackend: Send + Sync {
     fn orphan_count(&self) -> Result<usize, ChainStorageError>;
     /// Returns the stored header with the highest corresponding height.
     fn fetch_last_header(&self) -> Result<BlockHeader, ChainStorageError>;
+
+    /// Clear all headers that are beyond the current height of longest chain, returning the number of headers that were
+    /// deleted.
+    fn clear_all_pending_headers(&self) -> Result<usize, ChainStorageError>;
     /// Returns the stored header and accumulated data with the highest height.
     fn fetch_last_chain_header(&self) -> Result<ChainHeader, ChainStorageError>;
     /// Returns the stored header with the highest corresponding height.
@@ -181,4 +185,7 @@ pub trait BlockchainBackend: Send + Sync {
         &self,
         mmr_positions: Vec<u32>,
     ) -> Result<Vec<Option<(u64, HashOutput)>>, ChainStorageError>;
+
+    /// Check if a block hash is in the bad block list
+    fn bad_block_exists(&self, block_hash: HashOutput) -> Result<bool, ChainStorageError>;
 }

--- a/base_layer/core/src/chain_storage/db_transaction.rs
+++ b/base_layer/core/src/chain_storage/db_transaction.rs
@@ -190,6 +190,15 @@ impl DbTransaction {
         self
     }
 
+    /// Inserts a block hash into the bad block list
+    pub fn insert_bad_block(&mut self, block_hash: HashOutput, height: u64) -> &mut Self {
+        self.operations.push(WriteOperation::InsertBadBlock {
+            hash: block_hash,
+            height,
+        });
+        self
+    }
+
     /// Stores an orphan block. No checks are made as to whether this is actually an orphan. That responsibility lies
     /// with the calling function.
     /// The transaction will rollback and write will return an error if the orphan already exists.
@@ -297,6 +306,10 @@ pub enum WriteOperation {
         output_hash: HashOutput,
         witness_hash: HashOutput,
         mmr_position: u32,
+    },
+    InsertBadBlock {
+        hash: HashOutput,
+        height: u64,
     },
     DeleteHeader(u64),
     DeleteOrphan(HashOutput),
@@ -440,6 +453,7 @@ impl fmt::Display for WriteOperation {
             SetPrunedHeight { height, .. } => write!(f, "Set pruned height to {}", height),
             DeleteHeader(height) => write!(f, "Delete header at height: {}", height),
             DeleteOrphan(hash) => write!(f, "Delete orphan with hash: {}", hash.to_hex()),
+            InsertBadBlock { hash, height } => write!(f, "Insert bad block #{} {}", height, hash.to_hex()),
         }
     }
 }

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -57,6 +57,7 @@ use crate::{
             lmdb::{
                 fetch_db_entry_sizes,
                 lmdb_delete,
+                lmdb_delete_each_where,
                 lmdb_delete_key_value,
                 lmdb_delete_keys_starting_with,
                 lmdb_exists,
@@ -119,6 +120,7 @@ const LMDB_DB_MONERO_SEED_HEIGHT: &str = "monero_seed_height";
 const LMDB_DB_ORPHAN_HEADER_ACCUMULATED_DATA: &str = "orphan_accumulated_data";
 const LMDB_DB_ORPHAN_CHAIN_TIPS: &str = "orphan_chain_tips";
 const LMDB_DB_ORPHAN_PARENT_MAP_INDEX: &str = "orphan_parent_map_index";
+const LMDB_DB_BAD_BLOCK_LIST: &str = "bad_blocks";
 
 pub fn create_lmdb_database<P: AsRef<Path>>(path: P, config: LMDBConfig) -> Result<LMDBDatabase, ChainStorageError> {
     let flags = db::CREATE;
@@ -130,7 +132,7 @@ pub fn create_lmdb_database<P: AsRef<Path>>(path: P, config: LMDBConfig) -> Resu
     let lmdb_store = LMDBBuilder::new()
         .set_path(path)
         .set_env_config(config)
-        .set_max_number_of_databases(20)
+        .set_max_number_of_databases(40)
         .add_database(LMDB_DB_METADATA, flags | db::INTEGERKEY)
         .add_database(LMDB_DB_HEADERS, flags | db::INTEGERKEY)
         .add_database(LMDB_DB_HEADER_ACCUMULATED_DATA, flags | db::INTEGERKEY)
@@ -151,6 +153,7 @@ pub fn create_lmdb_database<P: AsRef<Path>>(path: P, config: LMDBConfig) -> Resu
         .add_database(LMDB_DB_MONERO_SEED_HEIGHT, flags)
         .add_database(LMDB_DB_ORPHAN_CHAIN_TIPS, flags)
         .add_database(LMDB_DB_ORPHAN_PARENT_MAP_INDEX, flags | db::DUPSORT)
+        .add_database(LMDB_DB_BAD_BLOCK_LIST, flags)
         .build()
         .map_err(|err| ChainStorageError::CriticalError(format!("Could not create LMDB store:{}", err)))?;
     debug!(target: LOG_TARGET, "LMDB database creation successful");
@@ -181,6 +184,7 @@ pub struct LMDBDatabase {
     orphan_header_accumulated_data_db: DatabaseRef,
     orphan_chain_tips_db: DatabaseRef,
     orphan_parent_map_index: DatabaseRef,
+    bad_blocks: DatabaseRef,
     _file_lock: Arc<File>,
 }
 
@@ -212,6 +216,7 @@ impl LMDBDatabase {
             monero_seed_height_db: get_database(&store, LMDB_DB_MONERO_SEED_HEIGHT)?,
             orphan_chain_tips_db: get_database(&store, LMDB_DB_ORPHAN_CHAIN_TIPS)?,
             orphan_parent_map_index: get_database(&store, LMDB_DB_ORPHAN_PARENT_MAP_INDEX)?,
+            bad_blocks: get_database(&store, LMDB_DB_BAD_BLOCK_LIST)?,
             env,
             env_config: store.env_config(),
             _file_lock: Arc::new(file_lock),
@@ -413,6 +418,9 @@ impl LMDBDatabase {
                         MetadataValue::HorizonData(HorizonData::new(kernel_sum.clone(), utxo_sum.clone())),
                     )?;
                 },
+                InsertBadBlock { hash, height } => {
+                    self.insert_bad_block_and_cleanup(&write_txn, hash, *height)?;
+                },
             }
         }
         write_txn.commit()?;
@@ -420,7 +428,7 @@ impl LMDBDatabase {
         Ok(())
     }
 
-    fn all_dbs(&self) -> [(&'static str, &DatabaseRef); 20] {
+    fn all_dbs(&self) -> [(&'static str, &DatabaseRef); 21] {
         [
             ("metadata_db", &self.metadata_db),
             ("headers_db", &self.headers_db),
@@ -448,6 +456,7 @@ impl LMDBDatabase {
             ("monero_seed_height_db", &self.monero_seed_height_db),
             ("orphan_chain_tips_db", &self.orphan_chain_tips_db),
             ("orphan_parent_map_index", &self.orphan_parent_map_index),
+            ("bad_blocks", &self.bad_blocks),
         ]
     }
 
@@ -1316,6 +1325,31 @@ impl LMDBDatabase {
 
     fn fetch_last_header_in_txn(&self, txn: &ConstTransaction<'_>) -> Result<Option<BlockHeader>, ChainStorageError> {
         lmdb_last(txn, &self.headers_db)
+    }
+
+    fn insert_bad_block_and_cleanup(
+        &self,
+        txn: &WriteTransaction<'_>,
+        hash: &HashOutput,
+        height: u64,
+    ) -> Result<(), ChainStorageError> {
+        const CLEAN_BAD_BLOCKS_BEFORE_REL_HEIGHT: u64 = 10000;
+
+        lmdb_replace(txn, &self.bad_blocks, hash, &height)?;
+        // Clean up bad blocks that are far from the tip
+        let metadata = fetch_metadata(&*txn, &self.metadata_db)?;
+        let deleted_before_height = metadata
+            .height_of_longest_chain()
+            .saturating_sub(CLEAN_BAD_BLOCKS_BEFORE_REL_HEIGHT);
+        if deleted_before_height == 0 {
+            return Ok(());
+        }
+
+        let num_deleted =
+            lmdb_delete_each_where::<[u8], u64, _>(txn, &self.bad_blocks, |_, v| Some(v < deleted_before_height))?;
+        debug!(target: LOG_TARGET, "Cleaned out {} stale bad blocks", num_deleted);
+
+        Ok(())
     }
 }
 
@@ -2200,6 +2234,37 @@ impl BlockchainBackend for LMDBDatabase {
                 })
             })
             .collect()
+    }
+
+    fn bad_block_exists(&self, block_hash: HashOutput) -> Result<bool, ChainStorageError> {
+        let txn = self.read_transaction()?;
+        lmdb_exists(&txn, &self.bad_blocks, &block_hash)
+    }
+
+    fn clear_all_pending_headers(&self) -> Result<usize, ChainStorageError> {
+        let txn = self.write_transaction()?;
+        let last_header = match self.fetch_last_header_in_txn(&txn)? {
+            Some(h) => h,
+            None => {
+                return Ok(0);
+            },
+        };
+        let metadata = fetch_metadata(&txn, &self.metadata_db)?;
+
+        if metadata.height_of_longest_chain() == last_header.height {
+            return Ok(0);
+        }
+
+        let start = metadata.height_of_longest_chain() + 1;
+        let end = last_header.height;
+
+        let mut num_deleted = 0;
+        for h in (start..=end).rev() {
+            self.delete_header(&txn, h)?;
+            num_deleted += 1;
+        }
+        txn.commit()?;
+        Ok(num_deleted)
     }
 }
 

--- a/base_layer/core/src/chain_storage/tests/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/tests/blockchain_database.rs
@@ -441,10 +441,9 @@ mod fetch_total_size_stats {
         let db = setup();
         let _ = add_many_chained_blocks(2, &db);
         let stats = db.fetch_total_size_stats().unwrap();
-        // Returns one per db
         assert_eq!(
-            stats.sizes().iter().find(|s| s.name == "utxo_db").unwrap().num_entries,
-            2
+            stats.sizes().iter().find(|s| s.name == "utxos_db").unwrap().num_entries,
+            4003
         );
     }
 }

--- a/base_layer/core/src/chain_storage/tests/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/tests/blockchain_database.rs
@@ -437,11 +437,15 @@ mod fetch_total_size_stats {
     use super::*;
 
     #[test]
-    fn it_works_when_db_is_empty() {
+    fn it_measures_the_number_of_entries() {
         let db = setup();
+        let _ = add_many_chained_blocks(2, &db);
         let stats = db.fetch_total_size_stats().unwrap();
         // Returns one per db
-        assert_eq!(stats.sizes().len(), 20);
+        assert_eq!(
+            stats.sizes().iter().find(|s| s.name == "utxo_db").unwrap().num_entries,
+            2
+        );
     }
 }
 

--- a/base_layer/core/src/test_helpers/blockchain.rs
+++ b/base_layer/core/src/test_helpers/blockchain.rs
@@ -322,6 +322,10 @@ impl BlockchainBackend for TempDatabase {
         self.db.as_ref().unwrap().fetch_last_header()
     }
 
+    fn clear_all_pending_headers(&self) -> Result<usize, ChainStorageError> {
+        self.db.as_ref().unwrap().clear_all_pending_headers()
+    }
+
     fn fetch_last_chain_header(&self) -> Result<ChainHeader, ChainStorageError> {
         self.db.as_ref().unwrap().fetch_last_chain_header()
     }
@@ -393,6 +397,10 @@ impl BlockchainBackend for TempDatabase {
             .as_ref()
             .unwrap()
             .fetch_header_hash_by_deleted_mmr_positions(mmr_positions)
+    }
+
+    fn bad_block_exists(&self, block_hash: HashOutput) -> Result<bool, ChainStorageError> {
+        self.db.as_ref().unwrap().bad_block_exists(block_hash)
     }
 }
 

--- a/base_layer/core/src/validation/block_validators/body_only.rs
+++ b/base_layer/core/src/validation/block_validators/body_only.rs
@@ -74,6 +74,7 @@ impl<B: BlockchainBackend> PostOrphanBodyValidation<B> for BodyOnlyValidator {
         );
         let mmr_roots = chain_storage::calculate_mmr_roots(backend, block.block())?;
         helpers::check_mmr_roots(block.header(), &mmr_roots)?;
+        helpers::check_not_bad_block(backend, block.hash())?;
         trace!(
             target: LOG_TARGET,
             "Block validation: MMR roots are valid for {}",

--- a/base_layer/core/src/validation/error.rs
+++ b/base_layer/core/src/validation/error.rs
@@ -89,6 +89,8 @@ pub enum ValidationError {
     IncorrectPreviousHash { expected: String, block_hash: String },
     #[error("Async validation task failed: {0}")]
     AsyncTaskFailed(#[from] task::JoinError),
+    #[error("Bad block with hash {hash} found")]
+    BadBlockFound { hash: String },
 }
 
 // ChainStorageError has a ValidationError variant, so to prevent a cyclic dependency we use a string representation in


### PR DESCRIPTION
Description
---
Maintain a list of "bad blocks" that should never be accepted
Remove pending headers if block sync fails to validate the block body against the (now invalid) headers.

Motivation and Context
---
(Partially) valid headers may become invalid (MMR) once the block body is synced. This PR removes those headers and adds the offending block to a banned block list.

How Has This Been Tested?
---
Some new unit tests, basic manual test

