### PR TITLE
feat: prevent banning of connected base node in wallet

### DIFF
--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -294,6 +294,10 @@ where
 
         self.comms.peer_manager().add_peer(peer.clone()).await?;
         self.wallet_connectivity.set_base_node(peer);
+        self.comms
+            .connectivity()
+            .message_rate_immune_peer(NodeId::from_key(&public_key))
+            .await?;
 
         Ok(())
     }

--- a/common/src/configuration/utils.rs
+++ b/common/src/configuration/utils.rs
@@ -170,7 +170,7 @@ pub fn default_config(bootstrap: &ConfigBootstrap) -> Config {
     cfg.set_default("base_node.weatherwax.pruning_horizon", 0).unwrap();
     cfg.set_default("base_node.weatherwax.pruned_mode_cleanup_interval", 50)
         .unwrap();
-    cfg.set_default("base_node.weatherwax.flood_ban_max_msg_count", 1000)
+    cfg.set_default("base_node.weatherwax.flood_ban_max_msg_count", 10000)
         .unwrap();
     cfg.set_default("base_node.weatherwax.peer_seeds", Vec::<String>::new())
         .unwrap();
@@ -215,7 +215,8 @@ pub fn default_config(bootstrap: &ConfigBootstrap) -> Config {
     cfg.set_default("base_node.igor.pruning_horizon", 0).unwrap();
     cfg.set_default("base_node.igor.pruned_mode_cleanup_interval", 50)
         .unwrap();
-    cfg.set_default("base_node.igor.flood_ban_max_msg_count", 1000).unwrap();
+    cfg.set_default("base_node.igor.flood_ban_max_msg_count", 10000)
+        .unwrap();
     cfg.set_default("base_node.igor.grpc_enabled", false).unwrap();
     cfg.set_default("base_node.igor.grpc_base_node_address", "127.0.0.1:18142")
         .unwrap();

--- a/comms/src/connectivity/manager.rs
+++ b/comms/src/connectivity/manager.rs
@@ -274,6 +274,11 @@ impl ConnectivityManagerActor {
                     error!(target: LOG_TARGET, "Error when banning peer: {:?}", err);
                 }
             },
+            SetMessageRateImmuneNode(node_id) => {
+                if let Err(err) = self.message_rate_immune_peer(&node_id).await {
+                    error!(target: LOG_TARGET, "Error when excluding peer from banning: {:?}", err);
+                }
+            },
             GetActiveConnections(reply) => {
                 let _ = reply.send(
                     self.pool
@@ -746,6 +751,13 @@ impl ConnectivityManagerActor {
                 "Disconnected banned peer {}. The peer connection status is {}", node_id, status
             );
         }
+        Ok(())
+    }
+
+    async fn message_rate_immune_peer(&mut self, node_id: &NodeId) -> Result<(), ConnectivityError> {
+        info!(target: LOG_TARGET, "Excluding peer {} from banning", node_id);
+        self.publish_event(ConnectivityEvent::SetMessageRateImmuneNode(node_id.clone()));
+
         Ok(())
     }
 }

--- a/comms/src/test_utils/mocks/connectivity_manager.rs
+++ b/comms/src/test_utils/mocks/connectivity_manager.rs
@@ -258,6 +258,7 @@ impl ConnectivityManagerMock {
             },
             GetAllConnectionStates(_) => unimplemented!(),
             BanPeer(_, _, _) => {},
+            SetMessageRateImmuneNode(_) => {},
             GetActiveConnections(reply) => {
                 self.state
                     .with_state(|state| reply.send(state.active_conns.values().cloned().collect()).unwrap())


### PR DESCRIPTION
Description
---
This PR excludes the connected base node in the wallet from being banned.

Motivation and Context
---
Usability

How Has This Been Tested?
---
cargo test --all
nvm use 12.22.6 && node_modules/.bin/cucumber-js --profile "ci" --tags "not @long-running and not @broken"
