### PR TITLE
feat: custom_base_node in config

### DIFF
--- a/applications/tari_app_utilities/src/initialization.rs
+++ b/applications/tari_app_utilities/src/initialization.rs
@@ -75,6 +75,10 @@ pub fn init_configuration(
         global_config.grpc_console_wallet_address = grpc_address;
     }
 
+    if let Some(str) = bootstrap.custom_base_node.clone() {
+        global_config.wallet_custom_base_node = Some(str);
+    }
+
     check_file_paths(&mut global_config, &bootstrap);
 
     Ok((bootstrap, global_config, cfg))

--- a/applications/tari_console_wallet/src/automation/commands.rs
+++ b/applications/tari_console_wallet/src/automation/commands.rs
@@ -289,6 +289,7 @@ async fn wait_for_comms(connectivity_requester: &ConnectivityRequester) -> Resul
         }
     }
 }
+
 async fn set_base_node_peer(
     mut wallet: WalletSqlite,
     args: &[ParsedArgument],
@@ -308,7 +309,6 @@ async fn set_base_node_peer(
     wallet
         .set_base_node_peer(public_key.clone(), net_address.to_string())
         .await?;
-
     Ok((public_key, net_address))
 }
 

--- a/applications/tari_console_wallet/src/init/mod.rs
+++ b/applications/tari_console_wallet/src/init/mod.rs
@@ -153,7 +153,18 @@ pub async fn get_base_node_peer_config(
     wallet: &mut WalletSqlite,
 ) -> Result<PeerConfig, ExitCodes> {
     // custom
-    let base_node_custom = get_custom_base_node_peer_from_db(wallet).await;
+    let mut base_node_custom = get_custom_base_node_peer_from_db(wallet).await;
+
+    if let Some(custom) = config.wallet_custom_base_node.clone() {
+        match SeedPeer::from_str(&custom) {
+            Ok(node) => {
+                base_node_custom = Some(Peer::from(node));
+            },
+            Err(err) => {
+                return Err(ExitCodes::ConfigError(format!("Malformed custom base node: {}", err)));
+            },
+        }
+    }
 
     // config
     let base_node_peers = config

--- a/applications/tari_console_wallet/src/ui/state/app_state.rs
+++ b/applications/tari_console_wallet/src/ui/state/app_state.rs
@@ -804,7 +804,6 @@ impl AppStateInner {
                 peer.addresses.first().ok_or(UiError::NoAddress)?.to_string(),
             )
             .await?;
-
         info!(
             target: LOG_TARGET,
             "Setting custom base node peer for wallet: {}::{}",

--- a/applications/tari_console_wallet/src/wallet_modes.rs
+++ b/applications/tari_console_wallet/src/wallet_modes.rs
@@ -224,7 +224,7 @@ fn wallet_or_exit(config: WalletModeConfig, wallet: WalletSqlite) -> Result<(), 
 
 pub fn tui_mode(config: WalletModeConfig, mut wallet: WalletSqlite) -> Result<(), ExitCodes> {
     let WalletModeConfig {
-        mut base_node_config,
+        base_node_config,
         mut base_node_selected,
         global_config,
         handle,
@@ -236,10 +236,9 @@ pub fn tui_mode(config: WalletModeConfig, mut wallet: WalletSqlite) -> Result<()
 
     let notifier = Notifier::new(notify_script, handle.clone(), wallet.clone());
 
-    // update the selected/custom base node since it may have been changed by script/command mode
-    let base_node_custom = handle.block_on(get_custom_base_node_peer_from_db(&mut wallet));
-    base_node_config.base_node_custom = base_node_custom.clone();
-    if let Some(peer) = base_node_custom {
+    if let Some(peer) = base_node_config.base_node_custom.clone() {
+        base_node_selected = peer;
+    } else if let Some(peer) = handle.block_on(get_custom_base_node_peer_from_db(&mut wallet)) {
         base_node_selected = peer;
     } else if let Some(peer) = handle.block_on(wallet.get_base_node_peer()) {
         base_node_selected = peer;

--- a/common/src/configuration/bootstrap.rs
+++ b/common/src/configuration/bootstrap.rs
@@ -164,6 +164,8 @@ pub struct ConfigBootstrap {
     /// Metrics push endpoint (prometheus push)
     #[structopt(long)]
     pub metrics_push_endpoint: Option<String>,
+    #[structopt(long, alias = "custom_base_node")]
+    pub custom_base_node: Option<String>,
 }
 
 fn normalize_path(path: PathBuf) -> PathBuf {
@@ -203,6 +205,7 @@ impl Default for ConfigBootstrap {
             wallet_grpc_address: None,
             metrics_server_bind_addr: None,
             metrics_push_endpoint: None,
+            custom_base_node: None,
         }
     }
 }

--- a/common/src/configuration/global.rs
+++ b/common/src/configuration/global.rs
@@ -117,6 +117,7 @@ pub struct GlobalConfig {
     pub wallet_command_send_wait_stage: String,
     pub wallet_command_send_wait_timeout: u64,
     pub wallet_base_node_service_peers: Vec<String>,
+    pub wallet_custom_base_node: Option<String>,
     pub wallet_base_node_service_refresh_interval: u64,
     pub wallet_base_node_service_request_max_age: u64,
     pub wallet_balance_enquiry_cooldown_period: u64,
@@ -526,6 +527,13 @@ fn convert_node_config(
         },
     };
 
+    let key = config_string("wallet", net_str, "custom_base_node");
+    let custom_peer: Option<String> = match cfg.get_int(&key) {
+        Ok(peer) => Some(peer.to_string()),
+        Err(ConfigError::NotFound(_)) => None,
+        Err(e) => return Err(ConfigurationError::new(&key, &e.to_string())),
+    };
+
     let key = "wallet.password";
     let console_wallet_password = optional(cfg.get_str(key))?;
 
@@ -795,6 +803,7 @@ fn convert_node_config(
         wallet_command_send_wait_stage,
         wallet_command_send_wait_timeout,
         wallet_base_node_service_peers,
+        wallet_custom_base_node: custom_peer,
         wallet_base_node_service_refresh_interval,
         wallet_base_node_service_request_max_age,
         wallet_balance_enquiry_cooldown_period,


### PR DESCRIPTION
Description
---
This PR allows the custom_base_node_peer to be set via the config, env, or via the command line

Motivation and Context
---
Usability

How Has This Been Tested?
---
cargo test --all
nvm use 12.22.6 && node_modules/.bin/cucumber-js --profile "ci" --tags "not @long-running and not @broken"
manually
