### PR TITLE
feat: add GRPC call to search for utxo via commitment hex

### DIFF
--- a/applications/tari_app_grpc/proto/base_node.proto
+++ b/applications/tari_app_grpc/proto/base_node.proto
@@ -68,6 +68,8 @@ service BaseNode {
     rpc GetTipInfo(Empty) returns (TipInfoResponse);
     // Search for blocks containing the specified kernels
     rpc SearchKernels(SearchKernelsRequest) returns (stream HistoricalBlock);
+    // Search for blocks containing the specified commitments
+    rpc SearchUtxos(SearchUtxosRequest) returns (stream HistoricalBlock);
     // Fetch any utxos that exist in the main chain
     rpc FetchMatchingUtxos(FetchMatchingUtxosRequest) returns (stream FetchMatchingUtxosResponse);
     // get all peers from the base node
@@ -287,6 +289,11 @@ message MinerData{
 // This is the request type for the Search Kernels rpc
 message SearchKernelsRequest{
     repeated Signature signatures = 1;
+}
+
+// This is the request type for the Search Utxo rpc
+message SearchUtxosRequest{
+    repeated bytes commitments = 1;
 }
 
 message FetchMatchingUtxosRequest {

--- a/applications/tari_base_node/src/command_handler.rs
+++ b/applications/tari_base_node/src/command_handler.rs
@@ -335,10 +335,7 @@ impl CommandHandler {
                 },
                 Ok(mut data) => match data.pop() {
                     Some(v) => println!("{}", v.block()),
-                    _ => println!(
-                        "Block not found for utxo commitment {}",
-                        commitment.to_hex()
-                    ),
+                    _ => println!("Block not found for utxo commitment {}", commitment.to_hex()),
                 },
             };
         });

--- a/applications/tari_base_node/src/command_handler.rs
+++ b/applications/tari_base_node/src/command_handler.rs
@@ -336,7 +336,7 @@ impl CommandHandler {
                 Ok(mut data) => match data.pop() {
                     Some(v) => println!("{}", v.block()),
                     _ => println!(
-                        "Pruned node: utxo found, but block not found for utxo commitment {}",
+                        "Block not found for utxo commitment {}",
                         commitment.to_hex()
                     ),
                 },

--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -292,24 +292,25 @@ where T: BlockchainBackend + 'static
                 }
                 Ok(NodeCommsResponse::HistoricalBlocks(blocks))
             },
-            NodeCommsRequest::FetchBlocksWithUtxos(hashes) => {
-                let mut blocks = Vec::with_capacity(hashes.len());
-                for hash in hashes {
-                    let hash_hex = hash.to_hex();
+            NodeCommsRequest::FetchBlocksWithUtxos(commitments) => {
+                let mut blocks = Vec::with_capacity(commitments.len());
+                for commitment in commitments {
+                    let commitment_hex = commitment.to_hex();
                     debug!(
                         target: LOG_TARGET,
-                        "A peer has requested a block with hash {}", hash_hex,
+                        "A peer has requested a block with commitment {}", commitment_hex,
                     );
-                    match self.blockchain_db.fetch_block_with_utxo(hash).await {
+                    match self.blockchain_db.fetch_block_with_utxo(commitment).await {
                         Ok(Some(block)) => blocks.push(block),
                         Ok(None) => warn!(
                             target: LOG_TARGET,
-                            "Could not provide requested block {} to peer because not stored", hash_hex,
+                            "Could not provide requested block with commitment {} to peer because not stored",
+                            commitment_hex,
                         ),
                         Err(e) => warn!(
                             target: LOG_TARGET,
-                            "Could not provide requested block {} to peer because: {}",
-                            hash_hex,
+                            "Could not provide requested block with commitment {} to peer because: {}",
+                            commitment_hex,
                             e.to_string()
                         ),
                     }


### PR DESCRIPTION
Description
---
Added a GRPC call to search for the block a UTXO was mined in via the commitment.  UI command already exists, this adds a GPRC mapping to the same command. 


This fixes a UI bug that when a commitment is not found, says the the node is pruned and that the utxo was found. 