### PR TITLE
test: fix metadata signature in cucumber

### DIFF
--- a/integration_tests/helpers/transactionBuilder.js
+++ b/integration_tests/helpers/transactionBuilder.js
@@ -44,14 +44,10 @@ class TransactionBuilder {
     const context = blake2bInit(OUTPUT_LENGTH, KEY);
     const buff_nonce = Buffer.from(publicNonce, "hex");
     const buff_key = Buffer.from(scriptOffsetPublicKey, "hex");
-    let flags = Buffer.alloc(1);
-    flags[0] = features.flags;
     let features_buffer = Buffer.concat([
-      flags,
-      toLittleEndian(parseInt(features.maturity), 64),
-      toLittleEndian(features.metadata.length, 64),
-      new Uint8Array(features.metadata),
-      new Uint8Array([0, 0, 0, 0, 0]),
+      Buffer.from([0]), // base_layer\core\src\transactions\transaction\output_features.rs:64 CONSENSUS_ENCODING_VERSION : u8 = 0
+      Buffer.from([parseInt(features.maturity)]),
+      Buffer.from([features.flags]),
     ]);
     blake2bUpdate(context, buff_nonce);
     blake2bUpdate(context, script);
@@ -87,11 +83,10 @@ class TransactionBuilder {
     var KEY = null; // optional key
     var OUTPUT_LENGTH = 32; // bytes
     var context = blake2bInit(OUTPUT_LENGTH, KEY);
-    let flags = Buffer.alloc(1);
-    flags[0] = features.flags;
     let features_buffer = Buffer.concat([
-      flags,
-      toLittleEndian(parseInt(features.maturity), 64),
+      Buffer.from([0]), // base_layer\core\src\transactions\transaction\output_features.rs:64 CONSENSUS_ENCODING_VERSION : u8 = 0
+      Buffer.from([parseInt(features.maturity)]),
+      Buffer.from([features.flags]),
     ]);
     blake2bUpdate(context, features_buffer);
     blake2bUpdate(context, commitment);

--- a/integration_tests/helpers/validatorNodeProcess.js
+++ b/integration_tests/helpers/validatorNodeProcess.js
@@ -6,6 +6,7 @@ const ValidatorNodeClient = require("./validatorNodeClient");
 const { getFreePort } = require("./util");
 const dateFormat = require("dateformat");
 const { createEnv } = require("./config");
+const JSON5 = require("json5");
 
 let outputProcess;
 class ValidatorNodeProcess {
@@ -79,7 +80,7 @@ class ValidatorNodeProcess {
       }
     }
 
-    this.nodeInfo = JSON.parse(
+    this.nodeInfo = JSON5.parse(
       fs.readFileSync(this.baseDir + "/" + this.nodeFile, "utf8")
     );
   }


### PR DESCRIPTION
Description
---
Fix metadata signature in cucumber test.
Change json to json5 for validator node. Because we use comments then json read fails.

How Has This Been Tested?
---
Running the failing test.
