### PR TITLE
ci: fix clippy warning on generated proto module

### DIFF
--- a/base_layer/core/src/proto/mod.rs
+++ b/base_layer/core/src/proto/mod.rs
@@ -25,6 +25,7 @@
 pub mod transaction;
 mod types_impls;
 
+#[allow(clippy::large_enum_variant)]
 pub mod base_node {
     include!(concat!(env!("OUT_DIR"), "/tari.base_node.rs"));
 }


### PR DESCRIPTION
Description
---
Allow clippy lint for large enum variant on prost generated proto module for base node 

See tokio-rs/prost#379 for context 

