### PR TITLE
perf: reduce memory usage in service framework

### DIFF
--- a/base_layer/core/src/base_node/chain_metadata_service/service.rs
+++ b/base_layer/core/src/base_node/chain_metadata_service/service.rs
@@ -298,8 +298,8 @@ mod test {
         LocalNodeCommsInterface,
         reply_channel::TryReceiver<NodeCommsRequest, NodeCommsResponse, CommsInterfaceError>,
     ) {
-        let (base_node_sender, base_node_receiver) = reply_channel::unbounded();
-        let (block_sender, _block_receiver) = reply_channel::unbounded();
+        let (base_node_sender, base_node_receiver) = reply_channel::channel();
+        let (block_sender, _block_receiver) = reply_channel::channel();
         let (block_event_sender, _) = broadcast::channel(50);
         let base_node = LocalNodeCommsInterface::new(base_node_sender, block_sender, block_event_sender);
 

--- a/base_layer/core/src/base_node/service/initializer.rs
+++ b/base_layer/core/src/base_node/service/initializer.rs
@@ -152,10 +152,10 @@ where T: BlockchainBackend + 'static
         let inbound_response_stream = self.inbound_response_stream();
         let inbound_block_stream = self.inbound_block_stream();
         // Connect InboundNodeCommsInterface and OutboundNodeCommsInterface to BaseNodeService
-        let (outbound_request_sender_service, outbound_request_stream) = reply_channel::unbounded();
+        let (outbound_request_sender_service, outbound_request_stream) = reply_channel::channel();
         let (outbound_block_sender_service, outbound_block_stream) = mpsc::unbounded_channel();
-        let (local_request_sender_service, local_request_stream) = reply_channel::unbounded();
-        let (local_block_sender_service, local_block_stream) = reply_channel::unbounded();
+        let (local_request_sender_service, local_request_stream) = reply_channel::channel();
+        let (local_block_sender_service, local_block_stream) = reply_channel::channel();
         let outbound_nci =
             OutboundNodeCommsInterface::new(outbound_request_sender_service, outbound_block_sender_service);
         let (block_event_sender, _) = broadcast::channel(50);

--- a/base_layer/core/src/base_node/sync/rpc/tests.rs
+++ b/base_layer/core/src/base_node/sync/rpc/tests.rs
@@ -49,8 +49,8 @@ fn setup() -> (
     let request_mock = RpcRequestMock::new(peer_manager);
 
     let db = create_new_blockchain();
-    let (req_tx, _) = reply_channel::unbounded();
-    let (block_tx, _) = reply_channel::unbounded();
+    let (req_tx, _) = reply_channel::channel();
+    let (block_tx, _) = reply_channel::channel();
     let (block_event_tx, _) = broadcast::channel(1);
     let service = BaseNodeSyncRpcService::new(
         db.clone().into(),

--- a/base_layer/core/src/mempool/service/initializer.rs
+++ b/base_layer/core/src/mempool/service/initializer.rs
@@ -146,13 +146,13 @@ impl ServiceInitializer for MempoolServiceInitializer {
         let inbound_transaction_stream = self.inbound_transaction_stream();
 
         // Connect MempoolOutboundServiceHandle to MempoolService
-        let (request_sender, request_receiver) = reply_channel::unbounded();
+        let (request_sender, request_receiver) = reply_channel::channel();
         let mempool_handle = MempoolHandle::new(request_sender);
         context.register_handle(mempool_handle);
 
         let (outbound_tx_sender, outbound_tx_stream) = mpsc::unbounded_channel();
-        let (outbound_request_sender_service, outbound_request_stream) = reply_channel::unbounded();
-        let (local_request_sender_service, local_request_stream) = reply_channel::unbounded();
+        let (outbound_request_sender_service, outbound_request_stream) = reply_channel::channel();
+        let (local_request_sender_service, local_request_stream) = reply_channel::channel();
         let outbound_mp_interface =
             OutboundMempoolServiceInterface::new(outbound_request_sender_service, outbound_tx_sender);
         let local_mp_interface = LocalMempoolService::new(local_request_sender_service);

--- a/base_layer/core/src/mempool/service/local_service.rs
+++ b/base_layer/core/src/mempool/service/local_service.rs
@@ -105,7 +105,7 @@ impl LocalMempoolService {
 #[cfg(test)]
 mod test {
     use futures::StreamExt;
-    use tari_service_framework::reply_channel::{unbounded, Receiver};
+    use tari_service_framework::reply_channel::{channel, Receiver};
     use tokio::task;
 
     use crate::mempool::{
@@ -138,7 +138,7 @@ mod test {
 
     #[tokio::test]
     async fn mempool_stats() {
-        let (tx, rx) = unbounded();
+        let (tx, rx) = channel();
         let mut service = LocalMempoolService::new(tx);
         task::spawn(mock_handler(rx));
         let stats = service.get_mempool_stats().await;
@@ -148,7 +148,7 @@ mod test {
 
     #[tokio::test]
     async fn mempool_stats_from_multiple() {
-        let (tx, rx) = unbounded();
+        let (tx, rx) = channel();
         let mut service = LocalMempoolService::new(tx);
         let mut service2 = service.clone();
         task::spawn(mock_handler(rx));

--- a/base_layer/core/src/mempool/test_utils/mock.rs
+++ b/base_layer/core/src/mempool/test_utils/mock.rs
@@ -38,7 +38,7 @@ use crate::mempool::{
 };
 
 pub fn create_mempool_service_mock() -> (MempoolHandle, MempoolMockState) {
-    let (tx, rx) = reply_channel::unbounded();
+    let (tx, rx) = reply_channel::channel();
     let mock = MempoolServiceMock::new(rx);
     let state = mock.get_shared_state();
     task::spawn(mock.run());

--- a/base_layer/core/tests/base_node_rpc.rs
+++ b/base_layer/core/tests/base_node_rpc.rs
@@ -107,8 +107,8 @@ async fn setup() -> (
         base_node.mempool_handle.clone(),
         base_node.state_machine_handle.clone(),
     );
-    let (req_tx, _) = reply_channel::unbounded();
-    let (block_tx, _) = reply_channel::unbounded();
+    let (req_tx, _) = reply_channel::channel();
+    let (block_tx, _) = reply_channel::channel();
     let (block_event_tx, _) = broadcast::channel(1);
     let local_nci = LocalNodeCommsInterface::new(req_tx, block_tx, block_event_tx);
     let base_node_service = BaseNodeSyncRpcService::new(base_node.blockchain_db.clone().into(), local_nci);

--- a/base_layer/core/tests/node_comms_interface.rs
+++ b/base_layer/core/tests/node_comms_interface.rs
@@ -74,7 +74,7 @@ async fn inbound_get_metadata() {
     let network = Network::LocalNet;
     let consensus_manager = ConsensusManager::builder(network).build();
     let (block_event_sender, _) = broadcast::channel(50);
-    let (request_sender, _) = reply_channel::unbounded();
+    let (request_sender, _) = reply_channel::channel();
     let (block_sender, _) = mpsc::unbounded_channel();
     let outbound_nci = OutboundNodeCommsInterface::new(request_sender, block_sender.clone());
     let inbound_nch = InboundNodeCommsHandlers::new(
@@ -105,7 +105,7 @@ async fn inbound_fetch_kernel_by_excess_sig() {
     let network = Network::LocalNet;
     let consensus_manager = ConsensusManager::builder(network).build();
     let (block_event_sender, _) = broadcast::channel(50);
-    let (request_sender, _) = reply_channel::unbounded();
+    let (request_sender, _) = reply_channel::channel();
     let (block_sender, _) = mpsc::unbounded_channel();
     let outbound_nci = OutboundNodeCommsInterface::new(request_sender, block_sender.clone());
     let inbound_nch = InboundNodeCommsHandlers::new(
@@ -136,7 +136,7 @@ async fn inbound_fetch_headers() {
     let network = Network::LocalNet;
     let consensus_manager = ConsensusManager::builder(network).build();
     let (block_event_sender, _) = broadcast::channel(50);
-    let (request_sender, _) = reply_channel::unbounded();
+    let (request_sender, _) = reply_channel::channel();
     let (block_sender, _) = mpsc::unbounded_channel();
     let outbound_nci = OutboundNodeCommsInterface::new(request_sender, block_sender);
     let inbound_nch = InboundNodeCommsHandlers::new(
@@ -167,7 +167,7 @@ async fn inbound_fetch_utxos() {
     let network = Network::LocalNet;
     let consensus_manager = ConsensusManager::builder(network).build();
     let (block_event_sender, _) = broadcast::channel(50);
-    let (request_sender, _) = reply_channel::unbounded();
+    let (request_sender, _) = reply_channel::channel();
     let (block_sender, _) = mpsc::unbounded_channel();
     let outbound_nci = OutboundNodeCommsInterface::new(request_sender, block_sender);
     let inbound_nch = InboundNodeCommsHandlers::new(
@@ -210,7 +210,7 @@ async fn inbound_fetch_txos() {
     let (block_event_sender, _) = broadcast::channel(50);
     let network = Network::LocalNet;
     let consensus_manager = ConsensusManager::builder(network).build();
-    let (request_sender, _) = reply_channel::unbounded();
+    let (request_sender, _) = reply_channel::channel();
     let (block_sender, _) = mpsc::unbounded_channel();
     let outbound_nci = OutboundNodeCommsInterface::new(request_sender, block_sender);
     let inbound_nch = InboundNodeCommsHandlers::new(
@@ -282,7 +282,7 @@ async fn inbound_fetch_blocks() {
     let (block_event_sender, _) = broadcast::channel(50);
     let network = Network::LocalNet;
     let consensus_manager = ConsensusManager::builder(network).build();
-    let (request_sender, _) = reply_channel::unbounded();
+    let (request_sender, _) = reply_channel::channel();
     let (block_sender, _) = mpsc::unbounded_channel();
     let outbound_nci = OutboundNodeCommsInterface::new(request_sender, block_sender);
     let inbound_nch = InboundNodeCommsHandlers::new(
@@ -330,7 +330,7 @@ async fn inbound_fetch_blocks_before_horizon_height() {
         Box::new(mempool_validator),
     );
     let (block_event_sender, _) = broadcast::channel(50);
-    let (request_sender, _) = reply_channel::unbounded();
+    let (request_sender, _) = reply_channel::channel();
     let (block_sender, _) = mpsc::unbounded_channel();
     let outbound_nci = OutboundNodeCommsInterface::new(request_sender, block_sender);
     let inbound_nch = InboundNodeCommsHandlers::new(

--- a/base_layer/p2p/src/services/liveness/mock.rs
+++ b/base_layer/p2p/src/services/liveness/mock.rs
@@ -44,7 +44,7 @@ use crate::services::liveness::{
 const LOG_TARGET: &str = "p2p::liveness_mock";
 
 pub fn create_p2p_liveness_mock(buf_size: usize) -> (LivenessHandle, LivenessMock, LivenessEventSender) {
-    let (sender, receiver) = reply_channel::unbounded();
+    let (sender, receiver) = reply_channel::channel();
     let (publisher, _) = broadcast::channel(buf_size);
     (
         LivenessHandle::new(sender, publisher.clone()),

--- a/base_layer/p2p/src/services/liveness/mod.rs
+++ b/base_layer/p2p/src/services/liveness/mod.rs
@@ -118,7 +118,7 @@ impl LivenessInitializer {
 #[async_trait]
 impl ServiceInitializer for LivenessInitializer {
     async fn initialize(&mut self, context: ServiceInitializerContext) -> Result<(), ServiceInitializationError> {
-        let (sender, receiver) = reply_channel::unbounded();
+        let (sender, receiver) = reply_channel::channel();
 
         let (publisher, _) = broadcast::channel(200);
 

--- a/base_layer/p2p/src/services/liveness/service.rs
+++ b/base_layer/p2p/src/services/liveness/service.rs
@@ -376,7 +376,7 @@ mod test {
         let outbound_messaging = OutboundMessageRequester::new(outbound_tx);
 
         // Setup liveness service
-        let (sender_service, receiver) = reply_channel::unbounded();
+        let (sender_service, receiver) = reply_channel::channel();
         let (publisher, _) = broadcast::channel(200);
 
         let mut liveness_handle = LivenessHandle::new(sender_service, publisher.clone());
@@ -412,7 +412,7 @@ mod test {
         let outbound_messaging = OutboundMessageRequester::new(outbound_tx);
 
         // Setup liveness service
-        let (sender_service, receiver) = reply_channel::unbounded();
+        let (sender_service, receiver) = reply_channel::channel();
         let (publisher, _) = broadcast::channel(200);
         let mut liveness_handle = LivenessHandle::new(sender_service, publisher.clone());
 

--- a/base_layer/service_framework/Cargo.toml
+++ b/base_layer/service_framework/Cargo.toml
@@ -25,4 +25,4 @@ tari_test_utils = { version = "^0.23", path = "../../infrastructure/test_utils" 
 
 tokio = { version = "1.14", features = ["rt-multi-thread", "macros", "time"] }
 futures-test = { version = "0.3.3" }
-tower = "0.4"
+tower = { version = "0.4", features = ["util"] }

--- a/base_layer/service_framework/examples/services/service_a.rs
+++ b/base_layer/service_framework/examples/services/service_a.rs
@@ -122,7 +122,7 @@ impl ServiceAInitializer {
 #[async_trait]
 impl ServiceInitializer for ServiceAInitializer {
     async fn initialize(&mut self, context: ServiceInitializerContext) -> Result<(), ServiceInitializationError> {
-        let (sender, receiver) = reply_channel::unbounded();
+        let (sender, receiver) = reply_channel::channel();
 
         let service_a_handle = ServiceAHandle::new(sender);
 

--- a/base_layer/service_framework/examples/services/service_b.rs
+++ b/base_layer/service_framework/examples/services/service_b.rs
@@ -116,7 +116,7 @@ impl ServiceBInitializer {
 #[async_trait]
 impl ServiceInitializer for ServiceBInitializer {
     async fn initialize(&mut self, context: ServiceInitializerContext) -> Result<(), ServiceInitializationError> {
-        let (sender, receiver) = reply_channel::unbounded();
+        let (sender, receiver) = reply_channel::channel();
 
         let service_b_handle = ServiceBHandle::new(sender);
 

--- a/base_layer/service_framework/src/lib.rs
+++ b/base_layer/service_framework/src/lib.rs
@@ -48,7 +48,7 @@
 //! use tari_service_framework::{reply_channel, tower::ServiceExt};
 //!
 //! block_on(async {
-//!     let (mut sender, mut receiver) = reply_channel::unbounded();
+//!     let (mut sender, mut receiver) = reply_channel::channel();
 //!
 //!     let (result, _) = futures::join!(
 //!         // Make the request and make progress on the resulting future

--- a/base_layer/wallet/src/assets/infrastructure/initializer.rs
+++ b/base_layer/wallet/src/assets/infrastructure/initializer.rs
@@ -56,7 +56,7 @@ impl<T> ServiceInitializer for AssetManagerServiceInitializer<T>
 where T: OutputManagerBackend + 'static
 {
     async fn initialize(&mut self, context: ServiceInitializerContext) -> Result<(), ServiceInitializationError> {
-        let (sender, receiver) = reply_channel::unbounded();
+        let (sender, receiver) = reply_channel::channel();
 
         let handle = AssetManagerHandle::new(sender);
         context.register_handle(handle);

--- a/base_layer/wallet/src/base_node_service/mod.rs
+++ b/base_layer/wallet/src/base_node_service/mod.rs
@@ -68,7 +68,7 @@ where T: WalletBackend + 'static
     async fn initialize(&mut self, context: ServiceInitializerContext) -> Result<(), ServiceInitializationError> {
         info!(target: LOG_TARGET, "Wallet base node service initializing.");
 
-        let (sender, request_stream) = reply_channel::unbounded();
+        let (sender, request_stream) = reply_channel::channel();
 
         let (event_publisher, _) = broadcast::channel(self.config.event_channel_size);
 

--- a/base_layer/wallet/src/contacts_service/mod.rs
+++ b/base_layer/wallet/src/contacts_service/mod.rs
@@ -62,7 +62,7 @@ impl<T> ServiceInitializer for ContactsServiceInitializer<T>
 where T: ContactsBackend + 'static
 {
     async fn initialize(&mut self, context: ServiceInitializerContext) -> Result<(), ServiceInitializationError> {
-        let (sender, receiver) = reply_channel::unbounded();
+        let (sender, receiver) = reply_channel::channel();
 
         let contacts_handle = ContactsServiceHandle::new(sender);
 

--- a/base_layer/wallet/src/output_manager_service/mod.rs
+++ b/base_layer/wallet/src/output_manager_service/mod.rs
@@ -104,7 +104,7 @@ where T: OutputManagerBackend + 'static
             self.config.base_node_query_timeout.as_secs()
         );
 
-        let (sender, receiver) = reply_channel::unbounded();
+        let (sender, receiver) = reply_channel::channel();
         let (publisher, _) = broadcast::channel(self.config.event_channel_size);
 
         // Register handle before waiting for handles to be ready

--- a/base_layer/wallet/src/tokens/infrastructure/initializer.rs
+++ b/base_layer/wallet/src/tokens/infrastructure/initializer.rs
@@ -56,7 +56,7 @@ impl<T> ServiceInitializer for TokenManagerServiceInitializer<T>
 where T: OutputManagerBackend + 'static
 {
     async fn initialize(&mut self, context: ServiceInitializerContext) -> Result<(), ServiceInitializationError> {
-        let (sender, receiver) = reply_channel::unbounded();
+        let (sender, receiver) = reply_channel::channel();
 
         let handle = TokenManagerHandle::new(sender);
         context.register_handle(handle);

--- a/base_layer/wallet/src/transaction_service/mod.rs
+++ b/base_layer/wallet/src/transaction_service/mod.rs
@@ -180,7 +180,7 @@ where
     W: WalletBackend + 'static,
 {
     async fn initialize(&mut self, context: ServiceInitializerContext) -> Result<(), ServiceInitializationError> {
-        let (sender, receiver) = reply_channel::unbounded();
+        let (sender, receiver) = reply_channel::channel();
         let transaction_stream = self.transaction_stream();
         let transaction_reply_stream = self.transaction_reply_stream();
         let transaction_finalized_stream = self.transaction_finalized_stream();

--- a/base_layer/wallet/tests/output_manager_service_tests/service.rs
+++ b/base_layer/wallet/tests/output_manager_service_tests/service.rs
@@ -117,16 +117,16 @@ async fn setup_output_manager_service<T: OutputManagerBackend + 'static>(
     let shutdown = Shutdown::new();
     let factories = CryptoFactories::default();
 
-    let (oms_request_sender, oms_request_receiver) = reply_channel::unbounded();
+    let (oms_request_sender, oms_request_receiver) = reply_channel::channel();
     let (oms_event_publisher, _) = broadcast::channel(200);
 
-    let (ts_request_sender, _ts_request_receiver) = reply_channel::unbounded();
+    let (ts_request_sender, _ts_request_receiver) = reply_channel::channel();
     let (event_publisher, _) = channel(100);
     let ts_handle = TransactionServiceHandle::new(ts_request_sender, event_publisher);
 
     let constants = create_consensus_constants(0);
 
-    let (sender, receiver_bns) = reply_channel::unbounded();
+    let (sender, receiver_bns) = reply_channel::channel();
     let (event_publisher_bns, _) = broadcast::channel(100);
     let basenode_service_handle = BaseNodeServiceHandle::new(sender, event_publisher_bns.clone());
     let mut mock_base_node_service = MockBaseNodeService::new(receiver_bns, shutdown.to_signal());
@@ -237,16 +237,16 @@ pub async fn setup_oms_with_bn_state<T: OutputManagerBackend + 'static>(
     let shutdown = Shutdown::new();
     let factories = CryptoFactories::default();
 
-    let (oms_request_sender, oms_request_receiver) = reply_channel::unbounded();
+    let (oms_request_sender, oms_request_receiver) = reply_channel::channel();
     let (oms_event_publisher, _) = broadcast::channel(200);
 
-    let (ts_request_sender, _ts_request_receiver) = reply_channel::unbounded();
+    let (ts_request_sender, _ts_request_receiver) = reply_channel::channel();
     let (event_publisher, _) = channel(100);
     let ts_handle = TransactionServiceHandle::new(ts_request_sender, event_publisher);
 
     let constants = create_consensus_constants(0);
 
-    let (sender, receiver_bns) = reply_channel::unbounded();
+    let (sender, receiver_bns) = reply_channel::channel();
     let (event_publisher_bns, _) = broadcast::channel(100);
 
     let base_node_service_handle = BaseNodeServiceHandle::new(sender, event_publisher_bns.clone());
@@ -1812,11 +1812,11 @@ async fn test_txo_revalidation() {
 async fn test_oms_key_manager_discrepancy() {
     let shutdown = Shutdown::new();
     let factories = CryptoFactories::default();
-    let (_oms_request_sender, oms_request_receiver) = reply_channel::unbounded();
+    let (_oms_request_sender, oms_request_receiver) = reply_channel::channel();
 
     let (oms_event_publisher, _) = broadcast::channel(200);
     let constants = ConsensusConstantsBuilder::new(Network::Weatherwax).build();
-    let (sender, receiver_bns) = reply_channel::unbounded();
+    let (sender, receiver_bns) = reply_channel::channel();
     let (event_publisher_bns, _) = broadcast::channel(100);
 
     let basenode_service_handle = BaseNodeServiceHandle::new(sender, event_publisher_bns);
@@ -1850,7 +1850,7 @@ async fn test_oms_key_manager_discrepancy() {
 
     drop(output_manager_service);
 
-    let (_oms_request_sender2, oms_request_receiver2) = reply_channel::unbounded();
+    let (_oms_request_sender2, oms_request_receiver2) = reply_channel::channel();
 
     let server_node_identity2 = build_node_identity(PeerFeatures::COMMUNICATION_NODE);
     let output_manager_service2 = OutputManagerService::new(
@@ -1870,7 +1870,7 @@ async fn test_oms_key_manager_discrepancy() {
     .expect("Should be able to make a new OMS with same master key");
     drop(output_manager_service2);
 
-    let (_oms_request_sender3, oms_request_receiver3) = reply_channel::unbounded();
+    let (_oms_request_sender3, oms_request_receiver3) = reply_channel::channel();
     let master_seed2 = CipherSeed::new();
     let server_node_identity3 = build_node_identity(PeerFeatures::COMMUNICATION_NODE);
     let output_manager_service3 = OutputManagerService::new(

--- a/base_layer/wallet/tests/support/output_manager_service_mock.rs
+++ b/base_layer/wallet/tests/support/output_manager_service_mock.rs
@@ -38,7 +38,7 @@ const LOG_TARGET: &str = "wallet::output_manager_service_mock";
 pub fn make_output_manager_service_mock(
     shutdown_signal: ShutdownSignal,
 ) -> (OutputManagerServiceMock, OutputManagerHandle) {
-    let (sender, receiver) = reply_channel::unbounded();
+    let (sender, receiver) = reply_channel::channel();
     let (publisher, _) = broadcast::channel(100);
     let output_manager_handle = OutputManagerHandle::new(sender, publisher.clone());
     let mock = OutputManagerServiceMock::new(publisher, receiver, shutdown_signal);

--- a/base_layer/wallet/tests/support/transaction_service_mock.rs
+++ b/base_layer/wallet/tests/support/transaction_service_mock.rs
@@ -38,7 +38,7 @@ const LOG_TARGET: &str = "wallet::transaction_service_mock";
 pub fn make_transaction_service_mock(
     shutdown_signal: ShutdownSignal,
 ) -> (TransactionServiceMock, TransactionServiceHandle) {
-    let (sender, receiver) = reply_channel::unbounded();
+    let (sender, receiver) = reply_channel::channel();
     let (publisher, _) = broadcast::channel(100);
     let transaction_handle = TransactionServiceHandle::new(sender, publisher.clone());
     let mock = TransactionServiceMock::new(publisher, receiver, shutdown_signal);

--- a/base_layer/wallet/tests/transaction_service_tests/service.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/service.rs
@@ -276,12 +276,12 @@ pub fn setup_transaction_service_no_comms(
     db_connection: WalletDbConnection,
     config: Option<TransactionServiceConfig>,
 ) -> TransactionServiceNoCommsInterface {
-    let (oms_request_sender, oms_request_receiver) = reply_channel::unbounded();
+    let (oms_request_sender, oms_request_receiver) = reply_channel::channel();
 
     let (output_manager_service_event_publisher, _) = broadcast::channel(200);
     let (outbound_message_requester, mock_outbound_service) = create_outbound_service_mock(100);
 
-    let (ts_request_sender, ts_request_receiver) = reply_channel::unbounded();
+    let (ts_request_sender, ts_request_receiver) = reply_channel::channel();
     let (event_publisher, _) = channel(100);
     let transaction_service_handle = TransactionServiceHandle::new(ts_request_sender, event_publisher.clone());
     let (transaction_send_message_channel, tx_receiver) = mpsc::channel(20);
@@ -328,7 +328,7 @@ pub fn setup_transaction_service_no_comms(
 
     let shutdown = Shutdown::new();
 
-    let (sender, receiver_bns) = reply_channel::unbounded();
+    let (sender, receiver_bns) = reply_channel::channel();
     let (base_node_service_event_publisher, _) = broadcast::channel(100);
 
     let base_node_service_handle = BaseNodeServiceHandle::new(sender, base_node_service_event_publisher);

--- a/base_layer/wallet/tests/transaction_service_tests/transaction_protocols.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/transaction_protocols.rs
@@ -129,7 +129,7 @@ pub async fn setup() -> (
 
     let db = TransactionDatabase::new(TransactionServiceSqliteDatabase::new(db_connection, None));
 
-    let (oms_request_sender, oms_request_receiver) = reply_channel::unbounded();
+    let (oms_request_sender, oms_request_receiver) = reply_channel::channel();
     task::spawn(oms_reply_channel_task(oms_request_receiver));
 
     let (oms_event_publisher, _) = broadcast::channel(200);

--- a/base_layer/wallet/tests/utxo_scanner.rs
+++ b/base_layer/wallet/tests/utxo_scanner.rs
@@ -97,7 +97,7 @@ async fn setup(
     let factories = CryptoFactories::default();
 
     // Base Node Service Mock
-    let (sender, receiver_bns) = reply_channel::unbounded();
+    let (sender, receiver_bns) = reply_channel::channel();
     let (event_publisher_bns, _) = broadcast::channel(100);
     let base_node_service_handle = BaseNodeServiceHandle::new(sender, event_publisher_bns.clone());
     let mut mock_base_node_service = MockBaseNodeService::new(receiver_bns, shutdown.to_signal());

--- a/base_layer/wallet_ffi/src/callback_handler_tests.rs
+++ b/base_layer/wallet_ffi/src/callback_handler_tests.rs
@@ -280,7 +280,7 @@ mod test {
         let (oms_event_sender, oms_event_receiver) = broadcast::channel(20);
         let (dht_event_sender, dht_event_receiver) = broadcast::channel(20);
 
-        let (oms_request_sender, oms_request_receiver) = reply_channel::unbounded();
+        let (oms_request_sender, oms_request_receiver) = reply_channel::channel();
         let mut oms_handle = OutputManagerHandle::new(oms_request_sender, oms_event_sender.clone());
 
         let shutdown_signal = Shutdown::new();

--- a/infrastructure/test_utils/Cargo.toml
+++ b/infrastructure/test_utils/Cargo.toml
@@ -13,7 +13,7 @@ tari_shutdown = { version = "*", path = "../shutdown" }
 
 futures = { version = "^0.3.1" }
 rand = "0.8"
-tokio = { version = "1.11", features = ["rt-multi-thread", "time"] }
+tokio = { version = "1.11", features = ["rt-multi-thread", "time", "sync", "macros"] }
 tempfile = "3.1.0"
 
 [dev-dependencies]


### PR DESCRIPTION
Description
---

- replace unbounded channel with single element bounded channel

Motivation and Context
---
The reply channel sends a single message and waits for a response. This means that buffering up many requests
in an unbounded channel is pointless as the waiting occurs in any case (whether sending on a full channel or waiting for a reply). No performance change observed, however, this will prevent any extra memory allocations esp in stress test conditions where many internal messages are buffered. It is unclear when, if ever, unbounded channels release that memory.

How Has This Been Tested?
---
Existing tests pass
Manually
