### PR TITLE
fix: put libtor behind optional feature flag

### DIFF
--- a/applications/tari_base_node/Cargo.toml
+++ b/applications/tari_base_node/Cargo.toml
@@ -57,5 +57,6 @@ default = ["metrics"]
 avx2 = ["tari_core/avx2", "tari_crypto/avx2", "tari_p2p/avx2", "tari_comms/avx2", "tari_comms_dht/avx2"]
 metrics = ["warp", "reqwest", "tari_metrics",  "tari_comms/metrics"]
 safe = []
+libtor = ["tari_common/libtor"]
 
 

--- a/applications/tari_base_node/src/main.rs
+++ b/applications/tari_base_node/src/main.rs
@@ -119,7 +119,7 @@ use tari_app_utilities::{
     utilities::setup_runtime,
 };
 use tari_common::{configuration::bootstrap::ApplicationType, exit_codes::ExitCodes, ConfigBootstrap, GlobalConfig};
-#[cfg(unix)]
+#[cfg(all(unix, feature = "libtor"))]
 use tari_common::{tor::Tor, CommsTransport};
 use tari_comms::{
     peer_manager::PeerFeatures,
@@ -192,7 +192,7 @@ fn main_inner() -> Result<(), ExitCodes> {
 
     // Run our own Tor instance, if configured
     // This is currently only possible on linux/macos
-    #[cfg(unix)]
+    #[cfg(all(unix, feature = "libtor"))]
     if config.base_node_use_libtor && matches!(config.comms_transport, CommsTransport::TorHiddenService { .. }) {
         let tor = Tor::initialize()?;
         config.comms_transport = tor.update_comms_transport(config.comms_transport)?;

--- a/applications/tari_console_wallet/Cargo.toml
+++ b/applications/tari_console_wallet/Cargo.toml
@@ -57,4 +57,5 @@ features = ["crossterm"]
 
 [features]
 avx2 = ["tari_core/avx2", "tari_crypto/avx2", "tari_wallet/avx2", "tari_comms/avx2", "tari_comms_dht/avx2", "tari_p2p/avx2", "tari_key_manager/avx2"]
+libtor = ["tari_common/libtor"]
 

--- a/applications/tari_console_wallet/src/main.rs
+++ b/applications/tari_console_wallet/src/main.rs
@@ -47,7 +47,7 @@ use opentelemetry::{self, global, KeyValue};
 use recovery::prompt_private_key_from_seed_words;
 use tari_app_utilities::{consts, initialization::init_configuration};
 use tari_common::{configuration::bootstrap::ApplicationType, exit_codes::ExitCodes, ConfigBootstrap};
-#[cfg(unix)]
+#[cfg(all(unix, feature = "libtor"))]
 use tari_common::{tor::Tor, CommsTransport};
 use tari_key_manager::cipher_seed::CipherSeed;
 use tari_shutdown::Shutdown;
@@ -137,7 +137,7 @@ fn main_inner() -> Result<(), ExitCodes> {
 
     // Run our own Tor instance, if configured
     // This is currently only possible on linux/macos
-    #[cfg(unix)]
+    #[cfg(all(unix, feature = "libtor"))]
     if global_config.console_wallet_use_libtor &&
         matches!(global_config.comms_transport, CommsTransport::TorHiddenService { .. })
     {

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -38,7 +38,7 @@ tempfile = "3.1.0"
 [target.'cfg(unix)'.dependencies]
 tari_shutdown = { version = "^0.24", path = "../infrastructure/shutdown"}
 
-libtor = "46.9"
+libtor = { version = "46.9.0", optional = true }
 rand = "0.8"
 tor-hash-passwd = "1.0.1"
 

--- a/common/config/presets/base_node.toml
+++ b/common/config/presets/base_node.toml
@@ -108,6 +108,7 @@ base_node_identity_file = "config/base_node_id.json"
 transport = "tor"
 
 # Spin up and use a built-in Tor instance. This only works on macos/linux and you must comment out tor_control_address below.
+# This requires that the base node was built with the optional "libtor" feature flag.
 #use_libtor = true
 
 # Address of the tor control server
@@ -285,6 +286,7 @@ console_wallet_identity_file = "config/console_wallet_id.json"
 transport = "tor"
 
 # Spin up and use a built-in Tor instance. This only works on macos/linux and you must comment out tor_control_address below.
+# This requires that the base node was built with the optional "libtor" feature flag.
 #use_libtor = true
 
 # Address of the tor control server

--- a/common/config/presets/console_wallet.toml
+++ b/common/config/presets/console_wallet.toml
@@ -122,6 +122,7 @@ base_node_service_request_max_age = 180
 transport = "tor"
 
 # Spin up and use a built-in Tor instance. This only works on macos/linux and you must comment out tor_control_address below.
+# This requires that the base node was built with the optional "libtor" feature flag.
 #use_libtor = true
 
 # Address of the tor control server
@@ -176,6 +177,7 @@ tor_control_address = "/ip4/127.0.0.1/tcp/9051"
 transport = "tor"
 
 # Spin up and use a built-in Tor instance. This only works on macos/linux and you must comment out tor_control_address below.
+# This requires that the wallet was built with the optional "libtor" feature flag.
 #use_libtor = true
 
 # Address of the tor control server

--- a/common/config/presets/console_wallet.toml
+++ b/common/config/presets/console_wallet.toml
@@ -122,7 +122,7 @@ base_node_service_request_max_age = 180
 transport = "tor"
 
 # Spin up and use a built-in Tor instance. This only works on macos/linux and you must comment out tor_control_address below.
-# This requires that the base node was built with the optional "libtor" feature flag.
+# This requires that the wallet was built with the optional "libtor" feature flag.
 #use_libtor = true
 
 # Address of the tor control server

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -81,7 +81,7 @@
 #[cfg(any(feature = "build", feature = "static-application-info"))]
 pub mod build;
 pub mod exit_codes;
-#[cfg(unix)]
+#[cfg(all(unix, feature = "libtor"))]
 pub mod tor;
 #[macro_use]
 mod logging;


### PR DESCRIPTION
Description
---

Make libtor fully optional behind `libtor` feature flag since we are hitting a compilation issue on macos. 

magicalbitcoin/libtor-sys#33

