### PR TITLE
feat(base_node): base node keeps track of historical reorgs

### DIFF
--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -235,6 +235,7 @@ async fn build_node_context(
         orphan_storage_capacity: config.orphan_storage_capacity,
         pruning_horizon: config.pruning_horizon,
         pruning_interval: config.pruned_mode_cleanup_interval,
+        track_reorgs: config.blockchain_track_reorgs,
     };
     let blockchain_db = BlockchainDatabase::new(
         backend,

--- a/applications/tari_base_node/src/parser.rs
+++ b/applications/tari_base_node/src/parser.rs
@@ -79,6 +79,7 @@ pub enum BaseNodeCommand {
     HeaderStats,
     BlockTiming,
     CalcTiming,
+    ListReorgs,
     DiscoverPeer,
     GetBlock,
     SearchUtxo,
@@ -251,6 +252,9 @@ impl Parser {
             BlockTiming | CalcTiming => {
                 self.process_block_timing(args).await;
             },
+            ListReorgs => {
+                self.process_list_reorgs().await;
+            },
             GetBlock => {
                 self.process_get_block(args).await;
             },
@@ -380,6 +384,13 @@ impl Parser {
                 println!("Calculates the maximum, minimum, and average time taken to mine a given range of blocks.");
                 println!("block-timing [start height] [end height]");
                 println!("block-timing [number of blocks from chain tip]");
+            },
+            ListReorgs => {
+                println!("List tracked reorgs.");
+                println!(
+                    "This feature must be enabled by setting `track_reorgs = true` in the [base_node] section of your \
+                     config."
+                );
             },
             GetBlock => {
                 println!("Display a block by height or hash:");
@@ -730,5 +741,9 @@ impl Parser {
             .ok_or("new_height argument required")
             .and_then(|s| u64::from_str(s).map_err(|_| "new_height must be an integer.")));
         self.command_handler.lock().await.rewind_blockchain(new_height);
+    }
+
+    async fn process_list_reorgs(&self) {
+        self.command_handler.lock().await.list_reorgs();
     }
 }

--- a/applications/tari_base_node/src/recovery.rs
+++ b/applications/tari_base_node/src/recovery.rs
@@ -109,6 +109,7 @@ pub async fn run_recovery(node_config: &GlobalConfig) -> Result<(), anyhow::Erro
         orphan_storage_capacity: node_config.orphan_storage_capacity,
         pruning_horizon: node_config.pruning_horizon,
         pruning_interval: node_config.pruned_mode_cleanup_interval,
+        track_reorgs: false,
     };
     let db = BlockchainDatabase::new(
         main_db,

--- a/applications/tari_base_node/src/table.rs
+++ b/applications/tari_base_node/src/table.rs
@@ -27,6 +27,7 @@ pub struct Table<'t, 's> {
     titles: Option<Vec<&'t str>>,
     rows: Vec<Vec<String>>,
     delim_str: &'s str,
+    is_row_count_enabled: bool,
 }
 
 impl<'t, 's> Table<'t, 's> {
@@ -35,11 +36,17 @@ impl<'t, 's> Table<'t, 's> {
             titles: None,
             rows: Vec::new(),
             delim_str: "|",
+            is_row_count_enabled: false,
         }
     }
 
     pub fn set_titles(&mut self, titles: Vec<&'t str>) {
         self.titles = Some(titles);
+    }
+
+    pub fn enable_row_count(&mut self) -> &mut Self {
+        self.is_row_count_enabled = true;
+        self
     }
 
     pub fn add_row(&mut self, row: Vec<String>) {
@@ -55,11 +62,16 @@ impl<'t, 's> Table<'t, 's> {
             self.render_rows(out)?;
             out.write_all(b"\n")?;
         }
+        if self.is_row_count_enabled {
+            out.write_all(format!("\n{} row(s)\n", self.rows.len()).as_bytes())?;
+        }
         Ok(())
     }
 
     pub fn print_stdout(&self) {
-        self.render(&mut io::stdout()).unwrap();
+        let mut stdout = io::stdout();
+        self.render(&mut stdout).unwrap();
+        stdout.flush().unwrap();
     }
 
     fn col_width(&self, idx: usize) -> usize {

--- a/base_layer/core/src/chain_storage/blockchain_backend.rs
+++ b/base_layer/core/src/chain_storage/blockchain_backend.rs
@@ -27,6 +27,7 @@ use crate::{
         DbValue,
         HorizonData,
         MmrTree,
+        Reorg,
         UtxoMinedInfo,
     },
     transactions::transaction::{TransactionInput, TransactionKernel},
@@ -203,4 +204,7 @@ pub trait BlockchainBackend: Send + Sync {
 
     /// Check if a block hash is in the bad block list
     fn bad_block_exists(&self, block_hash: HashOutput) -> Result<bool, ChainStorageError>;
+
+    /// Fetches all tracked reorgs
+    fn fetch_all_reorgs(&self) -> Result<Vec<Reorg>, ChainStorageError>;
 }

--- a/base_layer/core/src/chain_storage/db_transaction.rs
+++ b/base_layer/core/src/chain_storage/db_transaction.rs
@@ -35,7 +35,7 @@ use tari_crypto::tari_utilities::{
 
 use crate::{
     blocks::{Block, BlockHeader, BlockHeaderAccumulatedData, ChainBlock, ChainHeader, UpdateBlockAccumulatedData},
-    chain_storage::{error::ChainStorageError, HorizonData},
+    chain_storage::{error::ChainStorageError, HorizonData, Reorg},
     transactions::transaction::{TransactionKernel, TransactionOutput},
 };
 
@@ -270,6 +270,16 @@ impl DbTransaction {
         self.operations
             .push(WriteOperation::InsertMoneroSeedHeight(monero_seed, height));
     }
+
+    pub fn insert_reorg(&mut self, reorg: Reorg) -> &mut Self {
+        self.operations.push(WriteOperation::InsertReorg { reorg });
+        self
+    }
+
+    pub fn clear_all_reorgs(&mut self) -> &mut Self {
+        self.operations.push(WriteOperation::ClearAllReorgs);
+        self
+    }
 }
 
 #[derive(Debug)]
@@ -338,6 +348,10 @@ pub enum WriteOperation {
     SetHorizonData {
         horizon_data: HorizonData,
     },
+    InsertReorg {
+        reorg: Reorg,
+    },
+    ClearAllReorgs,
 }
 
 impl fmt::Display for WriteOperation {
@@ -426,6 +440,8 @@ impl fmt::Display for WriteOperation {
             DeleteOrphan(hash) => write!(f, "Delete orphan with hash: {}", hash.to_hex()),
             InsertBadBlock { hash, height } => write!(f, "Insert bad block #{} {}", height, hash.to_hex()),
             SetHorizonData { .. } => write!(f, "Set horizon data"),
+            InsertReorg { .. } => write!(f, "Insert reorg"),
+            ClearAllReorgs => write!(f, "Clear all reorgs"),
         }
     }
 }

--- a/base_layer/core/src/chain_storage/mod.rs
+++ b/base_layer/core/src/chain_storage/mod.rs
@@ -33,6 +33,7 @@ pub mod async_db;
 
 mod block_add_result;
 pub use block_add_result::BlockAddResult;
+
 mod blockchain_database;
 pub use blockchain_database::{
     calculate_mmr_roots,
@@ -64,6 +65,9 @@ pub use horizon_data::HorizonData;
 
 mod pruned_output;
 pub use pruned_output::PrunedOutput;
+
+mod reorg;
+pub use reorg::Reorg;
 
 mod lmdb_db;
 pub use lmdb_db::{create_lmdb_database, create_recovery_lmdb_database, LMDBDatabase};

--- a/base_layer/core/src/chain_storage/reorg.rs
+++ b/base_layer/core/src/chain_storage/reorg.rs
@@ -1,0 +1,55 @@
+//  Copyright 2022, The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::{collections::VecDeque, sync::Arc};
+
+use chrono::{NaiveDateTime, Utc};
+use serde::{Deserialize, Serialize};
+use tari_common_types::types::HashOutput;
+
+use crate::blocks::ChainBlock;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Reorg {
+    pub new_height: u64,
+    pub new_hash: HashOutput,
+    pub prev_height: u64,
+    pub prev_hash: HashOutput,
+    pub num_blocks_added: u64,
+    pub num_blocks_removed: u64,
+    pub local_time: NaiveDateTime,
+}
+
+impl Reorg {
+    pub fn from_reorged_blocks(added: &VecDeque<Arc<ChainBlock>>, removed: &[Arc<ChainBlock>]) -> Self {
+        // Expects blocks to be ordered sequentially highest height to lowest (as in rewind_to_height)
+        Self {
+            new_height: added.get(0).map(|b| b.header().height).unwrap_or_default(),
+            new_hash: added.get(0).map(|b| b.hash().clone()).unwrap_or_default(),
+            prev_height: removed.first().map(|b| b.header().height).unwrap_or_default(),
+            prev_hash: removed.first().map(|b| b.hash().clone()).unwrap_or_default(),
+            num_blocks_added: added.len() as u64,
+            num_blocks_removed: removed.len() as u64,
+            local_time: Utc::now().naive_local(),
+        }
+    }
+}

--- a/base_layer/core/src/test_helpers/blockchain.rs
+++ b/base_layer/core/src/test_helpers/blockchain.rs
@@ -65,6 +65,7 @@ use crate::{
         LMDBDatabase,
         MmrTree,
         PrunedOutput,
+        Reorg,
         UtxoMinedInfo,
         Validators,
     },
@@ -425,6 +426,10 @@ impl BlockchainBackend for TempDatabase {
 
     fn bad_block_exists(&self, block_hash: HashOutput) -> Result<bool, ChainStorageError> {
         self.db.as_ref().unwrap().bad_block_exists(block_hash)
+    }
+
+    fn fetch_all_reorgs(&self) -> Result<Vec<Reorg>, ChainStorageError> {
+        self.db.as_ref().unwrap().fetch_all_reorgs()
     }
 }
 

--- a/base_layer/core/tests/chain_storage_tests/chain_storage.rs
+++ b/base_layer/core/tests/chain_storage_tests/chain_storage.rs
@@ -256,6 +256,7 @@ fn rewind_past_horizon_height() {
         orphan_storage_capacity: 3,
         pruning_horizon: 2,
         pruning_interval: 2,
+        ..Default::default()
     };
     let store = BlockchainDatabase::new(
         db,
@@ -1396,6 +1397,7 @@ fn orphan_cleanup_on_block_add() {
         orphan_storage_capacity: 3,
         pruning_horizon: 0,
         pruning_interval: 50,
+        ..Default::default()
     };
     let store = BlockchainDatabase::new(
         db,
@@ -1465,6 +1467,7 @@ fn horizon_height_orphan_cleanup() {
         orphan_storage_capacity: 3,
         pruning_horizon: 2,
         pruning_interval: 50,
+        ..Default::default()
     };
     let store = BlockchainDatabase::new(
         db,
@@ -1530,6 +1533,7 @@ fn orphan_cleanup_on_reorg() {
         orphan_storage_capacity: 3,
         pruning_horizon: 0,
         pruning_interval: 50,
+        ..Default::default()
     };
     let mut store = BlockchainDatabase::new(
         db,
@@ -1668,6 +1672,7 @@ fn orphan_cleanup_delete_all_orphans() {
         orphan_storage_capacity: 5,
         pruning_horizon: 0,
         pruning_interval: 50,
+        ..Default::default()
     };
     // Test cleanup during runtime
     {
@@ -1778,6 +1783,7 @@ fn fails_validation() {
         orphan_storage_capacity: 3,
         pruning_horizon: 0,
         pruning_interval: 50,
+        ..Default::default()
     };
     let mut store = BlockchainDatabase::new(
         db,
@@ -1823,6 +1829,7 @@ fn pruned_mode_cleanup_and_fetch_block() {
         orphan_storage_capacity: 3,
         pruning_horizon: 3,
         pruning_interval: 1,
+        ..Default::default()
     };
     let store = BlockchainDatabase::new(
         db,

--- a/common/config/presets/base_node.toml
+++ b/common/config/presets/base_node.toml
@@ -29,6 +29,9 @@ grpc_enabled = true
 # The socket to expose for the gRPC base node server. This value is ignored if grpc_enabled is false.
 grpc_address = "/ip4/127.0.0.1/tcp/18142"
 
+# Set to true to record all reorgs. Recorded reorgs can be viewed using the list-reorgs command.
+track_reorgs = false
+
 
 # Configuration options for testnet dibbler
 [base_node.dibbler]

--- a/common/src/configuration/global.rs
+++ b/common/src/configuration/global.rs
@@ -147,6 +147,7 @@ pub struct GlobalConfig {
     pub base_node_use_libtor: bool,
     pub console_wallet_use_libtor: bool,
     pub merge_mining_config: Option<MergeMiningConfig>,
+    pub blockchain_track_reorgs: bool,
 }
 
 impl GlobalConfig {
@@ -202,6 +203,11 @@ fn convert_node_config(
             &format!("Invalid option: {}", invalid_opt),
         )),
     }?;
+
+    let key = "base_node.track_reorgs";
+    let blockchain_track_reorgs = optional(cfg.get_bool(key))
+        .map_err(|_| ConfigurationError::new(key, None, "Invalid boolean"))?
+        .unwrap_or(false);
 
     let key = config_string("base_node", net_str, "db_init_size_mb");
     let init_size_mb = match cfg.get_int(&key) {
@@ -873,6 +879,7 @@ fn convert_node_config(
         base_node_use_libtor,
         console_wallet_use_libtor,
         merge_mining_config,
+        blockchain_track_reorgs,
     })
 }
 


### PR DESCRIPTION
Description
---

- Adds configuration `base_node.track_reorgs = true` to keep track of reorgs in the blockchain database
- Adds `list-reorgs` command

Motivation and Context
---
Allowing historical reorgs to be listed increases visibility into the state of the blockchain

How Has This Been Tested?
---
Manually, running list-reorgs after reorgs

```
# | New Tip                                                                 | Prev Tip                                                                | Depth              | Timestamp
- | ----------------------------------------------------------------------- | ----------------------------------------------------------------------- | ------------------ | --------------------------
0 | #386 (ccdd1480fa3e4565f2350174fe5ded250b9bbe78591ef9ace67dde382ab0a714) | #386 (a739e48089d64ada1381e2202b4a0f4a49e5a7984d6e1f19511482e1366612c8) | 1 added, 1 removed | 2022-01-19 13:24:43.962842
1 | #388 (b572e7463eb4a4404ad3e520ee849665bf11e42b9a18e110360ab418c714aa8c) | #388 (fbe474245a2f43fdb76fc9a2bb06bba7666189d50aaf214c37b1000ad65335a4) | 2 added, 1 removed | 2022-01-19 13:25:47.947690
2 | #387 (12e1eaee164cc3063f2af444ebb6538671b5176b203d4927788b92fac8d4f279) | #389 (4a89c54b8d37001b1e8df3a27e401842d032f879e1fb068044203fad6dc1f0d5) | 1 added, 3 removed | 2022-01-19 13:25:59.413194
```
