### PR TITLE
fix(comms): ensure signature challenge is constructed consistently

### DIFF
--- a/comms/dht/src/network_discovery/error.rs
+++ b/comms/dht/src/network_discovery/error.rs
@@ -34,6 +34,6 @@ pub enum NetworkDiscoveryError {
     ConnectivityError(#[from] ConnectivityError),
     #[error("No sync peers available")]
     NoSyncPeers,
-    #[error("Sync peer sent invalid peer")]
+    #[error("Sync peer sent invalid peer: {0}")]
     PeerValidationError(#[from] PeerValidatorError),
 }

--- a/comms/dht/src/proto/mod.rs
+++ b/comms/dht/src/proto/mod.rs
@@ -25,7 +25,7 @@ use std::{
     fmt,
 };
 
-use chrono::NaiveDateTime;
+use chrono::{DateTime, NaiveDateTime, Utc};
 use rand::{rngs::OsRng, RngCore};
 use tari_comms::{
     multiaddr::Multiaddr,
@@ -144,6 +144,7 @@ impl TryFrom<common::IdentitySignature> for IdentitySignature {
         let signature = CommsSecretKey::from_bytes(&value.signature)?;
         let updated_at = NaiveDateTime::from_timestamp_opt(value.updated_at, 0)
             .ok_or_else(|| anyhow::anyhow!("updated_at overflowed"))?;
+        let updated_at = DateTime::<Utc>::from_utc(updated_at, Utc);
 
         Ok(Self::new(version, Signature::new(public_nonce, signature), updated_at))
     }

--- a/comms/src/net_address/mutliaddresses_with_stats.rs
+++ b/comms/src/net_address/mutliaddresses_with_stats.rs
@@ -73,12 +73,12 @@ impl MultiaddressesWithStats {
             .collect();
 
         let to_add = addresses
-            .iter()
-            .filter(|addr| !self.addresses.iter().any(|a| a.address == **addr))
+            .into_iter()
+            .filter(|addr| !self.addresses.iter().any(|a| a.address == *addr))
             .collect::<Vec<_>>();
 
         for address in to_add {
-            self.addresses.push(address.clone().into());
+            self.addresses.push(address.into());
         }
 
         self.addresses.sort();
@@ -88,6 +88,16 @@ impl MultiaddressesWithStats {
     /// connections and latency.
     pub fn iter(&self) -> impl Iterator<Item = &Multiaddr> {
         self.addresses.iter().map(|addr| &addr.address)
+    }
+
+    pub fn to_lexicographically_sorted(&self) -> Vec<Multiaddr> {
+        let mut addresses = self.iter().cloned().collect::<Vec<_>>();
+        addresses.sort_by(|a, b| {
+            let bytes_a = a.as_ref();
+            let bytes_b = b.as_ref();
+            bytes_a.cmp(bytes_b)
+        });
+        addresses
     }
 
     /// Finds the specified address in the set and allow updating of its variables such as its usage stats

--- a/comms/src/peer_manager/migrations.rs
+++ b/comms/src/peer_manager/migrations.rs
@@ -20,8 +20,8 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-mod v4;
 mod v5;
+mod v6;
 
 use log::*;
 use tari_storage::lmdb_store::{LMDBDatabase, LMDBError};
@@ -32,7 +32,7 @@ pub(super) const MIGRATION_VERSION_KEY: u64 = u64::MAX;
 
 pub fn migrate(database: &LMDBDatabase) -> Result<(), LMDBError> {
     // Add migrations here in version order
-    let migrations = vec![v4::Migration.boxed(), v5::Migration.boxed()];
+    let migrations = vec![v5::Migration.boxed(), v6::Migration.boxed()];
     if migrations.is_empty() {
         return Ok(());
     }

--- a/comms/src/peer_manager/node_identity.rs
+++ b/comms/src/peer_manager/node_identity.rs
@@ -165,7 +165,7 @@ impl NodeIdentity {
             self.secret_key(),
             self.features,
             Some(&*acquire_read_lock!(self.public_address)),
-            Utc::now().naive_utc(),
+            Utc::now(),
         );
 
         *acquire_write_lock!(self.identity_signature) = Some(identity_sig);

--- a/comms/src/stream_id.rs
+++ b/comms/src/stream_id.rs
@@ -41,6 +41,6 @@ impl Id {
 
 impl fmt::Display for Id {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.0)
+        write!(f, "{}", self.as_u32())
     }
 }


### PR DESCRIPTION
Description
---
- Ensure timestamp is timezone independent
- Ensure multiple addresses are lexicographically ordered for the signature challenge
- Add extra info in peer validation errors 
- migration that clears out all signatures (allowing new ones to take their place if provided)

Motivation and Context
---
Some base nodes are being banned for propagating invalid peer signatures - it is still not clear how this happens but
since peer signatures are checked before being committed it must be an inconsistency between base nodes in how the challenge is being constructed. Two possible but unconfirmed issues are that the integer timestamp from the naive date-time is effected by timezones (this PR replaces with `DateTime<Utc>`) and/or the addresses were not ordered consistently (doubtful because all peers currently only ever advertise one address, this PR sorts them lexicographically)  

How Has This Been Tested?
---

Manually: ban still occurs, but it seems as if only the same few nodes somehow accepted an invalid signature, this PR will clear the invalid signatures and we can monitor from there.