### PR TITLE
feat: validator node shows its public key on startup

### DIFF
--- a/applications/tari_collectibles/web-app/.gitignore
+++ b/applications/tari_collectibles/web-app/.gitignore
@@ -20,4 +20,5 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
-build
+build/*
+!build/.gitkeep

--- a/applications/tari_validator_node/src/main.rs
+++ b/applications/tari_validator_node/src/main.rs
@@ -99,6 +99,7 @@ async fn run_node(config: GlobalConfig, create_id: bool) -> Result<(), ExitCodes
     )?;
     let db_factory = SqliteDbFactory::new(&config);
     let mempool_service = MempoolServiceHandle::default();
+
     info!(
         target: LOG_TARGET,
         "Node starting with pub key: {}, node_id: {}",
@@ -133,6 +134,8 @@ async fn run_node(config: GlobalConfig, create_id: bool) -> Result<(), ExitCodes
     let grpc_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 18144);
 
     task::spawn(run_grpc(grpc_server, grpc_addr, shutdown.to_signal()));
+    println!("🚀 Validator node started!");
+    println!("{}", node_identity);
     run_dan_node(
         shutdown.to_signal(),
         config,

--- a/comms/src/peer_manager/node_identity.rs
+++ b/comms/src/peer_manager/node_identity.rs
@@ -112,10 +112,19 @@ impl NodeIdentity {
         acquire_read_lock!(self.public_address).clone()
     }
 
-    /// Modify the public address. The account signature will be invalid
+    /// Modify the public address.
     pub fn set_public_address(&self, address: Multiaddr) {
-        *acquire_write_lock!(self.public_address) = address;
-        self.sign()
+        let mut must_sign = false;
+        {
+            let mut lock = acquire_write_lock!(self.public_address);
+            if *lock != address {
+                *lock = address;
+                must_sign = true;
+            }
+        }
+        if must_sign {
+            self.sign()
+        }
     }
 
     /// This returns a random NodeIdentity for testing purposes. This function can panic. If public_address


### PR DESCRIPTION
Description
---

- Displays the validator node network identity information on startup 
- Only resign the node identity if the public address has changed.

Motivation and Context
---
Previously, you would have to look in the logs to obtain this public key 

How Has This Been Tested?
---
Manually

```
🚀 Validator node started!
Public Key: aefbe6559c06bb4a7f7f04307651e9263c15a7f0be3a19a4f59e2c928d5ec333
Node ID: 1bdaf4a679ce426c3178460e7a
Public Address: /onion3/fsag2su6pao5cbosz3wqy6x73x3yb7cinpsqzubrajhhn4emqrzxgvqd:18141
Features: NONE | COMMUNICATION_CLIENT
```
