### PR TITLE
ci: improve caching by splitting clippy, build and test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,19 @@ jobs:
     name: clippy
     runs-on: ubuntu-18.04
     steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: caching
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-${{ runner.cpu-model }}-${{ env.toolchain }}-clippy-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.cpu-model }}-${{ env.toolchain }}-clippy-
+            ${{ runner.os }}-${{ runner.cpu-model }}-${{ env.toolchain }}-
       - name: ubuntu dependencies
         run: |
           sudo apt-get update && \
@@ -45,92 +58,44 @@ jobs:
           libappindicator3-dev \
           patchelf \
           librsvg2-dev
-      - name: checkout
-        uses: actions/checkout@v2
+      - name: Compile NPM
+        run: |
+          cd applications/launchpad/gui-vue
+          npm install
+          npm run build
       - name: toolchain
         uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ env.toolchain }}
           components: clippy, rustfmt
           override: true
-      - name: Caching
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: clippy-${{ runner.os }}-${{ runner.cpu-model }}-${{ env.toolchain }}-${{ hashFiles('**/Cargo.lock') }}
       - name: cargo fmt
         uses: actions-rs/cargo@v1
         with:
           command: fmt
           args: --all -- --check
-      - name: Compile NPM
-        run: |
-          cd applications/launchpad/gui-vue
-          npm install
-          npm run build
       - name: Clippy check
         uses: actions-rs/cargo@v1
         with:
           command: clippy
           args: --all-targets -- -D warnings
-  test:
-    name: test
-    runs-on: ubuntu-18.04
-    steps:
-      - name: checkout
-        uses: actions/checkout@v2
-      - name: Caching
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: release-${{ runner.os }}-${{ runner.cpu-model }}-${{ env.toolchain }}-${{ hashFiles('**/Cargo.lock') }}
-      - name: ubuntu dependencies
-        run: |
-          sudo apt-get update && \
-          sudo apt-get -y install \
-          build-essential \
-          libgtk-3-dev \
-          libwebkit2gtk-4.0-dev \
-          libsoup2.4-dev \
-          curl \
-          wget \
-          libappindicator3-dev \
-          patchelf \
-          librsvg2-dev \
-          libprotobuf-dev \
-          protobuf-compiler
-
-      - name: Compile NPM
-        run: |
-          cd applications/launchpad/gui-vue
-          npm install
-          npm run build
-
-      - name: toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ env.toolchain }}
-      - run: cargo test --release
   build:
     name: build
     runs-on: ubuntu-18.04
     steps:
       - name: checkout
         uses: actions/checkout@v2
-      - name: Caching
+      - name: caching
         uses: actions/cache@v2
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: release-${{ runner.os }}-${{ runner.cpu-model }}-${{ env.toolchain }}-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ runner.cpu-model }}-${{ env.toolchain }}-build-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.cpu-model }}-${{ env.toolchain }}-build-
+            ${{ runner.os }}-${{ runner.cpu-model }}-${{ env.toolchain }}-
       - name: ubuntu dependencies
         run: |
           sudo apt-get update && \
@@ -146,22 +111,66 @@ jobs:
           librsvg2-dev \
           libprotobuf-dev \
           protobuf-compiler
-
       - name: Compile NPM
         run: |
           cd applications/launchpad/gui-vue
           npm install
           npm run build
-
       - name: toolchain
         uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ env.toolchain }}
           components: clippy, rustfmt
           override: true
-
       - name: cargo build
         uses: actions-rs/cargo@v1
         with:
           command: check
           args: --release --all-targets
+  test:
+    name: test
+    needs: build
+    runs-on: ubuntu-18.04
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: caching
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-${{ runner.cpu-model }}-${{ env.toolchain }}-test-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.cpu-model }}-${{ env.toolchain }}-test-
+            ${{ runner.os }}-${{ runner.cpu-model }}-${{ env.toolchain }}-
+      - name: ubuntu dependencies
+        run: |
+          sudo apt-get update && \
+          sudo apt-get -y install \
+          build-essential \
+          libgtk-3-dev \
+          libwebkit2gtk-4.0-dev \
+          libsoup2.4-dev \
+          curl \
+          wget \
+          libappindicator3-dev \
+          patchelf \
+          librsvg2-dev \
+          libprotobuf-dev \
+          protobuf-compiler
+      - name: Compile NPM
+        run: |
+          cd applications/launchpad/gui-vue
+          npm install
+          npm run build
+      - name: toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env.toolchain }}
+      - name: cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --release


### PR DESCRIPTION
Description

CI improvement
Improve caching by splitting clippy, build and test jobs
Improve caching fallback to common caching base
Defer test job until build is complete and share cache

Rework clippy job to mimic other jobs closer

Motivation and Context
Clippy, Build and test times are reduce with more cache hits.

How Has This Been Tested?
All jobs build in GHA on my fork.

