### PR TITLE
ci: fix macos installer

### DIFF
--- a/buildtools/create_osx_install_zip.sh
+++ b/buildtools/create_osx_install_zip.sh
@@ -43,8 +43,8 @@ else
 fi
 
 # One click miner
-cp -f -P "${app_dir}/tari_base_node/osx/start_all" "${tarball_folder}/start_all"
-cp -f "${app_dir}/tari_base_node/osx/runtime/start_all.sh" "${tarball_folder}/runtime/start_all.sh"
+# cp -f -P "${app_dir}/tari_base_node/osx/start_all" "${tarball_folder}/start_all"
+# cp -f "${app_dir}/tari_base_node/osx/runtime/start_all.sh" "${tarball_folder}/runtime/start_all.sh"
 
 # Base Node
 cp -f -P "${app_dir}/tari_base_node/osx/start_tari_base_node" "${tarball_folder}/start_tari_base_node"
@@ -69,6 +69,14 @@ cp -f -P "${app_dir}/tari_merge_mining_proxy/osx/start_xmrig" "${tarball_folder}
 cp -f "${app_dir}/tari_merge_mining_proxy/osx/runtime/start_tari_merge_mining_proxy.sh" "${tarball_folder}/runtime/start_tari_merge_mining_proxy.sh"
 cp -f "${app_dir}/tari_merge_mining_proxy/osx/runtime/start_xmrig.sh" "${tarball_folder}/runtime/start_xmrig.sh"
 cp -f "${project_dir}/target/release/tari_merge_mining_proxy" "${tarball_folder}/runtime/tari_merge_mining_proxy"
+
+# Collectibles
+cp -f "${project_dir}/target/release/tari_collectibles" "${tarball_folder}/runtime/tari_collectibles"
+
+# Validator node
+cp -f "${project_dir}/target/release/tari_validator_node" "${tarball_folder}/runtime/tari_validator_node"
+
+# todo: launchpad
 
 # 3rd party install
 cp -f "${local_dir}/install_xmrig.sh" "${tarball_folder}/runtime/install_xmrig.sh"

--- a/buildtools/osx_postinstall.sh
+++ b/buildtools/osx_postinstall.sh
@@ -1,12 +1,27 @@
 #! /bin/bash
 
 # logs are in /var/log/install.log
-whoami
-echo "$HOME"
-echo "$USER"
+TARI_LOG=/tmp/tari.log
+TARI_DIR="$HOME/.tari/"
+
+date >$TARI_LOG
+if [ -d "$TARI_DIR" ]; then
+    echo "removing ~/.tari" >>$TARI_LOG
+    rm -rf "$TARI_DIR"
+fi
+echo "creating ~/.tari" >>$TARI_LOG
 mkdir "$HOME"/.tari/ || exit 1
+{
+    echo "whoami: $(whoami)"
+    echo "home dir: $HOME"
+    echo "user: $USER"
+    echo "copy /tmp/tari/ to ~/.tari"
+} >>$TARI_LOG
 cp -R /tmp/tari/ "$HOME"/.tari/ || exit 1
+echo "chown" >>$TARI_LOG
 chown -R "$USER":staff "$HOME"/.tari/ || exit 1
+echo "rm scripts" >>$TARI_LOG
 rm -rf "$HOME"/.tari/scripts/ || exit 1
 
+echo "done! exiting" >>$TARI_LOG
 exit 0


### PR DESCRIPTION
Description
---

The macos post install script was failing if the `.tari` directory in the user home dir already existed. 

