### PR TITLE
fix: ensure that features are set when syncing peers

### DIFF
--- a/base_layer/p2p/src/peer_seeds.rs
+++ b/base_layer/p2p/src/peer_seeds.rs
@@ -81,7 +81,7 @@ pub struct SeedPeer {
 
 impl SeedPeer {
     #[inline]
-    pub fn get_node_id(&self) -> NodeId {
+    pub fn derive_node_id(&self) -> NodeId {
         NodeId::from_public_key(&self.public_key)
     }
 }
@@ -105,8 +105,8 @@ impl FromStr for SeedPeer {
 
 impl From<SeedPeer> for Peer {
     fn from(seed: SeedPeer) -> Self {
-        let node_id = seed.get_node_id();
-        Self::new(
+        let node_id = seed.derive_node_id();
+        Peer::new(
             seed.public_key,
             node_id,
             seed.addresses.into(),

--- a/comms/dht/src/peer_validator.rs
+++ b/comms/dht/src/peer_validator.rs
@@ -103,9 +103,13 @@ impl<'a> PeerValidator<'a> {
                 }
 
                 debug!(target: LOG_TARGET, "Updating peer `{}`", new_peer.node_id);
-                current_peer.addresses.update_addresses(new_peer.addresses.into_vec());
-                current_peer.identity_signature = new_peer.identity_signature;
-                current_peer.set_offline(false);
+                current_peer
+                    .update_addresses(new_peer.addresses.into_vec())
+                    .set_features(new_peer.features)
+                    .set_offline(false);
+                if let Some(sig) = new_peer.identity_signature {
+                    current_peer.set_valid_identity_signature(sig);
+                }
                 self.peer_manager.add_peer(current_peer).await?;
 
                 Ok(false)


### PR DESCRIPTION
Description
---

- updates features in peer sync when a signature is valid
- invalidates the identity signature of a peer if addresses/features are changed

Motivation and Context
---
If a peer somehow is created with incorrect peer features (say, by adding a wallet to peer_seeds list), and that same peer is later synced with a valid signature but without updating the erroneous features in the existing peer, the peer will have an invalid state and signature in its database causing it to be banned by other nodes.

How Has This Been Tested?
---
Manually, added a wallet to my peer seeds and didnt get banned
