### PR TITLE
fix: use of branch seed in key manager

### DIFF
--- a/base_layer/key_manager/src/key_manager.rs
+++ b/base_layer/key_manager/src/key_manager.rs
@@ -77,7 +77,12 @@ where
 
     /// Derive a new private key from master key: derived_key=SHA256(master_key||branch_seed||index)
     pub fn derive_key(&self, key_index: u64) -> Result<DerivedKey<K>, ByteArrayError> {
-        let concatenated = format!("{}{}", self.seed.entropy().to_vec().to_hex(), key_index);
+        let concatenated = format!(
+            "{}{}{}",
+            self.seed.entropy().to_vec().to_hex(),
+            self.branch_seed,
+            key_index
+        );
         match K::from_bytes(D::digest(&concatenated.into_bytes()).as_slice()) {
             Ok(k) => Ok(DerivedKey { k, key_index }),
             Err(e) => Err(e),
@@ -165,5 +170,15 @@ mod test {
         assert_eq!(next_key2.k, derived_key2.k);
         assert_eq!(next_key1.key_index, desired_key_index1);
         assert_eq!(next_key2.key_index, desired_key_index2);
+    }
+
+    #[test]
+    fn test_use_of_branch_seed() {
+        let x = CipherSeed::new();
+        let mut km1 = KeyManager::<RistrettoSecretKey, Sha256>::from(x.clone(), "some".to_string(), 0);
+        let mut km2 = KeyManager::<RistrettoSecretKey, Sha256>::from(x, "other".to_string(), 0);
+        let next_key1 = km1.next_key().unwrap();
+        let next_key2 = km2.next_key().unwrap();
+        assert_ne!(next_key1.k, next_key2.k);
     }
 }


### PR DESCRIPTION
Description
---
The branch seed was not used (even if it was mentioned in the comment).

Motivation and Context
---
Problem with doubling the tokens in collectibles because of the pub keys for asset and tokens were the same.

How Has This Been Tested?
---
Manually (fixed the double problem in collectibles)
Added new cargo test for the use of the branch seed.
