### PR TITLE
fix: properly decrypt imported faux tx when reading from db

### DIFF
--- a/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
@@ -1217,7 +1217,12 @@ impl TransactionBackend for TransactionServiceSqliteDatabase {
         let conn = self.database_connection.get_pooled_connection()?;
         CompletedTransactionSql::index_by_status_and_cancelled(TransactionStatus::Imported, false, &conn)?
             .into_iter()
-            .map(|ct| CompletedTransaction::try_from(ct).map_err(TransactionStorageError::from))
+            .map(|mut ct: CompletedTransactionSql| {
+                if let Err(e) = self.decrypt_if_necessary(&mut ct) {
+                    return Err(e);
+                }
+                CompletedTransaction::try_from(ct).map_err(TransactionStorageError::from)
+            })
             .collect::<Result<Vec<CompletedTransaction>, TransactionStorageError>>()
     }
 }

--- a/base_layer/wallet/tests/transaction_service_tests/storage.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/storage.rs
@@ -619,7 +619,7 @@ async fn import_tx_and_read_it_from_db() {
     sqlite_db
         .write(WriteOperation::Insert(DbKeyValuePair::CompletedTransaction(
             TxId::from(1),
-            Box::new(transaction.clone()),
+            Box::new(transaction),
         )))
         .unwrap();
 

--- a/base_layer/wallet/tests/transaction_service_tests/storage.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/storage.rs
@@ -52,7 +52,7 @@ use tari_wallet::{
     storage::sqlite_utilities::run_migration_and_create_sqlite_connection,
     test_utils::create_consensus_constants,
     transaction_service::storage::{
-        database::{TransactionBackend, TransactionDatabase},
+        database::{DbKeyValuePair, TransactionBackend, TransactionDatabase, WriteOperation},
         models::{CompletedTransaction, InboundTransaction, OutboundTransaction, WalletTransaction},
         sqlite_db::TransactionServiceSqliteDatabase,
     },
@@ -582,4 +582,49 @@ pub fn test_transaction_service_sqlite_db_encrypted() {
     let cipher = Aes256Gcm::new(key);
 
     test_db_backend(TransactionServiceSqliteDatabase::new(connection, Some(cipher)));
+}
+
+#[tokio::test]
+async fn import_tx_and_read_it_from_db() {
+    let db_name = format!("{}.sqlite3", random::string(8));
+    let db_tempdir = tempdir().unwrap();
+    let db_folder = db_tempdir.path().to_str().unwrap().to_string();
+    let db_path = format!("{}/{}", db_folder, db_name);
+    let connection = run_migration_and_create_sqlite_connection(&db_path, 16).unwrap();
+
+    let key = GenericArray::from_slice(b"an example very very secret key.");
+    let cipher = Aes256Gcm::new(key);
+    let sqlite_db = TransactionServiceSqliteDatabase::new(connection, Some(cipher));
+
+    let transaction = CompletedTransaction::new(
+        TxId::from(1),
+        PublicKey::default(),
+        PublicKey::default(),
+        MicroTari::from(100000),
+        MicroTari::from(0),
+        Transaction::new(
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            PrivateKey::default(),
+            PrivateKey::default(),
+        ),
+        TransactionStatus::Imported,
+        "message".to_string(),
+        Utc::now().naive_utc(),
+        TransactionDirection::Inbound,
+        Some(0),
+    );
+
+    sqlite_db
+        .write(WriteOperation::Insert(DbKeyValuePair::CompletedTransaction(
+            TxId::from(1),
+            Box::new(transaction.clone()),
+        )))
+        .unwrap();
+
+    let db_tx = sqlite_db.fetch_imported_transactions().unwrap();
+
+    assert_eq!(db_tx.len(), 1);
+    assert_eq!(db_tx.first().unwrap().tx_id, TxId::from(1));
 }


### PR DESCRIPTION
Description
---
The function that read the imported transaction out of the database didn’t check if the data needed to be decrypted before deserialization. This PR fixes that.


How Has This Been Tested?
---
test provided
