### PR TITLE
fix: fix attempting to validate faux transaction

### DIFF
--- a/base_layer/wallet/src/transaction_service/protocols/transaction_validation_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_validation_protocol.rs
@@ -252,7 +252,7 @@ where
                         .kernels()
                         .first()
                         .map(|k| k.excess.to_hex())
-                        .unwrap_or("{No Kernel found}".to_string()),
+                        .unwrap_or_else(|| "{No Kernel found}".to_string()),
                     self.operation_id
                 );
                 self.update_transaction_as_unmined(last_mined_transaction.tx_id, &last_mined_transaction.status)

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_validation_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_validation_protocol.rs
@@ -252,7 +252,7 @@ where
                         .kernels()
                         .first()
                         .map(|k| k.excess.to_hex())
-                        .unwrap(),
+                        .unwrap_or("{No Kernel found}".to_string()),
                     self.operation_id
                 );
                 self.update_transaction_as_unmined(last_mined_transaction.tx_id, &last_mined_transaction.status)

--- a/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
@@ -1049,6 +1049,7 @@ impl TransactionBackend for TransactionServiceSqliteDatabase {
         let acquire_lock = start.elapsed();
         let tx = completed_transactions::table
             .filter(completed_transactions::mined_height.is_not_null())
+            .filter(completed_transactions::mined_height.gt(0))
             .order_by(completed_transactions::mined_height.desc())
             .first::<CompletedTransactionSql>(&*conn)
             .optional()?;


### PR DESCRIPTION
Description
---
Found a panic where the tx validation will try validate a faux transaction and then panic when it doesn’t have a kernel to display.

Filtered out Imported transactions and fixed the unwrap to be handled gracefully.

