### PR TITLE
feat(ffi)!: add features, metadata_signature and sender_offset_public_key to import_utxo

### DIFF
--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -53,6 +53,10 @@ struct TariPublicKey;
 
 struct TariPublicKeys;
 
+struct TariCommitmentSignature;
+
+struct TariOutputFeatures;
+
 struct TariContacts;
 
 struct TariContact;
@@ -573,7 +577,17 @@ struct TariCompletedTransaction *wallet_get_cancelled_transaction_by_id(struct T
 
 // Import a UTXO into the wallet. This will add a spendable UTXO and create a faux completed transaction to record the
 // event.
-unsigned long long wallet_import_utxo(struct TariWallet *wallet, unsigned long long amount, struct TariPrivateKey *spending_key, struct TariPublicKey *source_public_key, const char *message, int *error_out);
+unsigned long long wallet_import_utxo(
+    struct TariWallet *wallet,
+    unsigned long long amount,
+    struct TariPrivateKey *spending_key,
+    struct TariPublicKey *source_public_key,
+    struct TariOutputFeatures *features,
+    struct TariCommitmentSignature *metadata_signature,
+    struct TariPublicKey *sender_offset_public_key,
+    const char *message,
+    int *error_out
+);
 
 // This function will tell the wallet to query the set base node to confirm the status of unspent transaction outputs (UTXOs).
 unsigned long long wallet_start_txo_validation(struct TariWallet *wallet, int *error_out);

--- a/integration_tests/helpers/ffi/ffiInterface.js
+++ b/integration_tests/helpers/ffi/ffiInterface.js
@@ -380,6 +380,11 @@ class InterfaceFFI {
           this.ulonglong,
           this.ptr,
           this.ptr,
+          this.ptr,
+          this.ptr,
+          this.ptr,
+          this.ptr,
+          this.ptr,
           this.string,
           this.intPtr,
         ],
@@ -1440,6 +1445,9 @@ class InterfaceFFI {
     amount,
     spending_key_ptr,
     source_public_key_ptr,
+    features_ptr,
+    metadata_signature_ptr,
+    sender_offset_public_key_ptr,
     message
   ) {
     let error = this.initError();
@@ -1448,6 +1456,13 @@ class InterfaceFFI {
       amount,
       spending_key_ptr,
       source_public_key_ptr,
+      features_ptr,
+      metadata_signature_ptr,
+      sender_offset_public_key_ptr,
+      // script_private_key
+      spending_key_ptr,
+      // default Covenant
+      null,
       message,
       error
     );


### PR DESCRIPTION
Description
---
- adds two arguments to `wallet_import_utxo` (features, metadata_signature and sender_offset_public_key)

Motivation and Context
---
Allows faucet utxos to be imported to the wallet db correctly

How Has This Been Tested?
---

