### PR TITLE
chore: script to keep .gitkeep file

### DIFF
--- a/applications/tari_collectibles/web-app/package.json
+++ b/applications/tari_collectibles/web-app/package.json
@@ -23,6 +23,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
+    "postbuild": "touch ./build/.gitkeep || type NUL > ./build/.gitkeep",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "lint": "eslint src/**/*.js"


### PR DESCRIPTION
Description
---
Added a step after build, that will recreate the `.gitkeep` file in the build directory.

Motivation and Context
---
We need to keep the `.gitkeep` file after the `npm run build`

How Has This Been Tested?
---
`npm run build` windows and wsl2(ubuntu) on windows
