### PR TITLE
feat: add specific LibWallet error code for “Fee is greater than amount”

### DIFF
--- a/base_layer/wallet_ffi/src/error.rs
+++ b/base_layer/wallet_ffi/src/error.rs
@@ -213,6 +213,12 @@ impl From<WalletError> for LibWalletError {
                 code: 204,
                 message: format!("{:?}", w),
             },
+            WalletError::TransactionServiceError(TransactionServiceError::OutputManagerError(
+                OutputManagerError::BuildError(ref s),
+            )) if s == &"Fee is greater than amount".to_string() => Self {
+                code: 212,
+                message: format!("{:?}", w),
+            },
             WalletError::TransactionServiceError(TransactionServiceError::OutputManagerError(_)) => Self {
                 code: 206,
                 message: format!("{:?}", w),
@@ -229,6 +235,7 @@ impl From<WalletError> for LibWalletError {
                 code: 211,
                 message: format!("{:?}", w),
             },
+
             // Comms Stack errors
             WalletError::MultiaddrError(_) => Self {
                 code: 301,


### PR DESCRIPTION
Description
---
Surfacing a specific error code for the “Fee is greater than amount” Transaction Build error in the LibWalletError for the FFI interface.

