### PR TITLE
fix(core): reduce one block behind waiting period

### DIFF
--- a/base_layer/core/src/base_node/state_machine_service/states/listening.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/listening.rs
@@ -55,6 +55,9 @@ use crate::{
 
 const LOG_TARGET: &str = "c::bn::state_machine_service::states::listening";
 
+/// The length of time to wait for a propagated block when one block behind before proceeding to sync
+const ONE_BLOCK_BEHIND_WAIT_PERIOD: Duration = Duration::from_secs(20);
+
 /// This struct contains the info of the peer, and is used to serialised and deserialised.
 #[derive(Serialize, Deserialize)]
 pub struct PeerMetadata {
@@ -195,7 +198,7 @@ impl Listening {
                     if self.is_synced &&
                         best_metadata.height_of_longest_chain() == local.height_of_longest_chain() + 1 &&
                         time_since_better_block
-                            .map(|ts: Instant| ts.elapsed() < Duration::from_secs(60))
+                            .map(|ts: Instant| ts.elapsed() < ONE_BLOCK_BEHIND_WAIT_PERIOD)
                             .unwrap_or(true)
                     {
                         if time_since_better_block.is_none() {


### PR DESCRIPTION
Description
---
Reduces the time taken to switch to sync when one block behind (was 60s, now 20s)

Motivation and Context
---
With the improvement of block propagation, the time between detecting that a peer/s has progressed and receiving a new block is reduced, so it follows the "one block behind" waiting period should be reduced.

How Has This Been Tested?
---
Manually, minor change
