### PR TITLE
refactor: split `ErrorCodes` into the `ExitError` and `ExitCode` pair

### DIFF
--- a/applications/launchpad/backend/src/docker/error.rs
+++ b/applications/launchpad/backend/src/docker/error.rs
@@ -23,7 +23,7 @@
 
 use std::error::Error;
 
-use tari_app_utilities::common::exit_codes::ExitCodes;
+use tari_app_utilities::common::exit_codes::ExitError;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -43,7 +43,7 @@ pub enum DockerWrapperError {
     #[error("It should not be possible to be in this error state")]
     UnexpectedError,
     #[error("Could not create an identity file")]
-    IdentityError(#[from] ExitCodes),
+    IdentityError(#[from] ExitError),
     #[error("The specified image type is not supported")]
     InvalidImageType,
 }

--- a/applications/tari_app_utilities/src/identity_management.rs
+++ b/applications/tari_app_utilities/src/identity_management.rs
@@ -27,7 +27,7 @@ use rand::rngs::OsRng;
 use serde::{de::DeserializeOwned, Serialize};
 use tari_common::{
     configuration::{bootstrap::prompt, utils::get_local_ip},
-    exit_codes::ExitCodes,
+    exit_codes::{ExitCode, ExitError},
 };
 use tari_comms::{multiaddr::Multiaddr, peer_manager::PeerFeatures, NodeIdentity};
 use tari_crypto::tari_utilities::hex::Hex;
@@ -48,7 +48,7 @@ pub fn setup_node_identity<P: AsRef<Path>>(
     public_address: &Option<Multiaddr>,
     create_id: bool,
     peer_features: PeerFeatures,
-) -> Result<Arc<NodeIdentity>, ExitCodes> {
+) -> Result<Arc<NodeIdentity>, ExitError> {
     match load_identity(&identity_file) {
         Ok(id) => match public_address {
             Some(public_address) => {
@@ -69,12 +69,15 @@ pub fn setup_node_identity<P: AsRef<Path>>(
                          identity.",
                         e
                     );
-                    return Err(ExitCodes::ConfigError(format!(
-                        "Node identity information not found. {}. You can update the configuration file to point to a \
-                         valid node identity file, or re-run the node with the --create-id flag to create a new \
-                         identity.",
-                        e
-                    )));
+                    return Err(ExitError::new(
+                        ExitCode::ConfigError,
+                        format!(
+                            "Node identity information not found. {}. You can update the configuration file to point \
+                             to a valid node identity file, or re-run the node with the --create-id flag to create a \
+                             new identity.",
+                            e
+                        ),
+                    ));
                 };
             }
 
@@ -93,10 +96,10 @@ pub fn setup_node_identity<P: AsRef<Path>>(
                 },
                 Err(e) => {
                     error!(target: LOG_TARGET, "Could not create new node id. {:?}.", e);
-                    Err(ExitCodes::ConfigError(format!(
-                        "Could not create new node id. {:?}.",
-                        e
-                    )))
+                    Err(ExitError::new(
+                        ExitCode::ConfigError,
+                        format!("Could not create new node id. {:?}.", e),
+                    ))
                 },
             }
         },

--- a/applications/tari_app_utilities/src/initialization.rs
+++ b/applications/tari_app_utilities/src/initialization.rs
@@ -4,7 +4,7 @@ use config::Config;
 use structopt::StructOpt;
 use tari_common::{
     configuration::{bootstrap::ApplicationType, Network},
-    exit_codes::ExitCodes,
+    exit_codes::ExitError,
     ConfigBootstrap,
     DatabaseType,
     GlobalConfig,
@@ -16,7 +16,7 @@ pub const LOG_TARGET: &str = "tari::application";
 
 pub fn init_configuration(
     application_type: ApplicationType,
-) -> Result<(ConfigBootstrap, GlobalConfig, Config), ExitCodes> {
+) -> Result<(ConfigBootstrap, GlobalConfig, Config), ExitError> {
     // Parse and validate command-line arguments
     let mut bootstrap = ConfigBootstrap::from_args();
 

--- a/applications/tari_app_utilities/src/utilities.rs
+++ b/applications/tari_app_utilities/src/utilities.rs
@@ -24,7 +24,13 @@ use std::sync::Arc;
 
 use futures::future::Either;
 use log::*;
-use tari_common::{exit_codes::ExitCodes, CommsTransport, GlobalConfig, SocksAuthentication, TorControlAuthentication};
+use tari_common::{
+    exit_codes::{ExitCode, ExitError},
+    CommsTransport,
+    GlobalConfig,
+    SocksAuthentication,
+    TorControlAuthentication,
+};
 use tari_common_types::{emoji::EmojiId, types::BlockHash};
 use tari_comms::{
     peer_manager::NodeId,
@@ -145,7 +151,7 @@ pub fn convert_socks_authentication(auth: SocksAuthentication) -> socks::Authent
 ///
 /// ## Returns
 /// A result containing the runtime on success, string indicating the error on failure
-pub fn setup_runtime(config: &GlobalConfig) -> Result<Runtime, ExitCodes> {
+pub fn setup_runtime(config: &GlobalConfig) -> Result<Runtime, ExitError> {
     let mut builder = runtime::Builder::new_multi_thread();
 
     if let Some(core_threads) = config.core_threads {
@@ -163,7 +169,7 @@ pub fn setup_runtime(config: &GlobalConfig) -> Result<Runtime, ExitCodes> {
 
     builder.enable_all().build().map_err(|e| {
         let msg = format!("There was an error while building the node runtime. {}", e);
-        ExitCodes::UnknownError(msg)
+        ExitError::new(ExitCode::UnknownError, msg)
     })
 }
 

--- a/applications/tari_base_node/src/main.rs
+++ b/applications/tari_base_node/src/main.rs
@@ -248,7 +248,7 @@ async fn run_node(
         recovery::initiate_recover_db(&config)?;
         recovery::run_recovery(&config)
             .await
-            .map_err(|e| ExitError::new(ExitCode::RecoveryError, Some(e.to_string())))?;
+            .map_err(|e| ExitError::new(ExitCode::RecoveryError, e))?;
         return Ok(());
     };
 
@@ -263,30 +263,29 @@ async fn run_node(
     .map_err(|err| {
         for boxed_error in err.chain() {
             if let Some(HiddenServiceControllerError::TorControlPortOffline) = boxed_error.downcast_ref() {
-                return ExitError::new(ExitCode::TorOffline, None);
+                return ExitCode::TorOffline.into();
             }
             if let Some(ChainStorageError::DatabaseResyncRequired(reason)) = boxed_error.downcast_ref() {
                 return ExitError::new(
                     ExitCode::DbInconsistentState,
-                    Some(format!("You may need to resync your database because {}", reason)),
+                    format!("You may need to resync your database because {}", reason),
                 );
             }
 
             // todo: find a better way to do this
             if boxed_error.to_string().contains("Invalid force sync peer") {
                 println!("Please check your force sync peers configuration");
-                return ExitError::new(ExitCode::ConfigError, Some(boxed_error.to_string()));
+                return ExitError::new(ExitCode::ConfigError, boxed_error);
             }
         }
-        ExitError::new(ExitCode::UnknownError, Some(err.to_string()))
+        ExitError::new(ExitCode::UnknownError, err)
     })?;
 
     if let Some(ref base_node_config) = config.base_node_config {
         if let Some(ref address) = base_node_config.grpc_address {
             // Go, GRPC, go go
             let grpc = crate::grpc::base_node_grpc_server::BaseNodeGrpcServer::from_base_node_context(&ctx);
-            let socket_addr = multiaddr_to_socketaddr(address)
-                .map_err(|e| ExitError::new(ExitCode::ConfigError, Some(e.to_string())))?;
+            let socket_addr = multiaddr_to_socketaddr(address).map_err(|e| ExitError::new(ExitCode::ConfigError, e))?;
             task::spawn(run_grpc(grpc, socket_addr, shutdown.to_signal()));
         }
     }

--- a/applications/tari_base_node/src/main.rs
+++ b/applications/tari_base_node/src/main.rs
@@ -152,6 +152,7 @@ const LOG_TARGET: &str = "base_node::app";
 /// Application entry point
 fn main() {
     if let Err(err) = main_inner() {
+        eprintln!("{:?}", err);
         let exit_code = err.exit_code;
         eprintln!("{}", exit_code.hint());
         error!(

--- a/applications/tari_base_node/src/recovery.rs
+++ b/applications/tari_base_node/src/recovery.rs
@@ -30,7 +30,12 @@ use std::{
 
 use anyhow::anyhow;
 use log::*;
-use tari_common::{configuration::Network, exit_codes::ExitCodes, DatabaseType, GlobalConfig};
+use tari_common::{
+    configuration::Network,
+    exit_codes::{ExitCode, ExitError},
+    DatabaseType,
+    GlobalConfig,
+};
 use tari_core::{
     chain_storage::{
         async_db::AsyncBlockchainDb,
@@ -54,19 +59,19 @@ use tari_core::{
 
 pub const LOG_TARGET: &str = "base_node::app";
 
-pub fn initiate_recover_db(node_config: &GlobalConfig) -> Result<(), ExitCodes> {
+pub fn initiate_recover_db(node_config: &GlobalConfig) -> Result<(), ExitError> {
     // create recovery db
     match &node_config.db_type {
         DatabaseType::LMDB(p) => {
             let _backend = create_recovery_lmdb_database(&p).map_err(|err| {
                 error!(target: LOG_TARGET, "{}", err);
-                ExitCodes::UnknownError(err.to_string())
+                ExitError::new(ExitCode::UnknownError, err)
             })?;
         },
         _ => {
             const MSG: &str = "Recovery mode is only available for LMDB";
             error!(target: LOG_TARGET, "{}", MSG);
-            return Err(ExitCodes::UnknownError(MSG.to_string()));
+            return Err(ExitError::new(ExitCode::UnknownError, MSG));
         },
     };
     Ok(())

--- a/applications/tari_console_wallet/src/automation/error.rs
+++ b/applications/tari_console_wallet/src/automation/error.rs
@@ -23,7 +23,7 @@
 use std::num::{ParseFloatError, ParseIntError};
 
 use log::*;
-use tari_common::exit_codes::ExitCodes;
+use tari_common::exit_codes::{ExitCode, ExitError};
 use tari_core::transactions::{
     tari_amount::{MicroTariError, TariConversionError},
     transaction::TransactionError,
@@ -70,10 +70,10 @@ pub enum CommandError {
     ShaError(String),
 }
 
-impl From<CommandError> for ExitCodes {
+impl From<CommandError> for ExitError {
     fn from(err: CommandError) -> Self {
         error!(target: LOG_TARGET, "{}", err);
-        Self::CommandError(err.to_string())
+        Self::new(ExitCode::CommandError, err)
     }
 }
 
@@ -103,10 +103,10 @@ pub enum ParseError {
     Unimplemented(String),
 }
 
-impl From<ParseError> for ExitCodes {
+impl From<ParseError> for ExitError {
     fn from(err: ParseError) -> Self {
         error!(target: LOG_TARGET, "{}", err);
         let msg = format!("Failed to parse input file commands! {}", err);
-        Self::InputError(msg)
+        Self::new(ExitCode::InputError, msg)
     }
 }

--- a/applications/tari_console_wallet/src/main.rs
+++ b/applications/tari_console_wallet/src/main.rs
@@ -78,8 +78,8 @@ fn main() {
     match main_inner() {
         Ok(_) => process::exit(0),
         Err(err) => {
+            eprintln!("{:?}", err);
             let exit_code = err.exit_code;
-            eprintln!("{}", exit_code.hint());
             error!(
                 target: LOG_TARGET,
                 "Exiting with code ({}): {:?}", exit_code as i32, exit_code

--- a/applications/tari_console_wallet/src/ui/mod.rs
+++ b/applications/tari_console_wallet/src/ui/mod.rs
@@ -21,7 +21,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use log::error;
-use tari_common::exit_codes::ExitCodes;
+use tari_common::exit_codes::{ExitCode, ExitError};
 
 use crate::utils::crossterm_events::CrosstermEvents;
 
@@ -52,7 +52,7 @@ use crate::utils::events::{Event, EventStream};
 
 pub const MAX_WIDTH: u16 = 133;
 
-pub fn run(app: App<CrosstermBackend<Stdout>>) -> Result<(), ExitCodes> {
+pub fn run(app: App<CrosstermBackend<Stdout>>) -> Result<(), ExitError> {
     let mut app = app;
     Handle::current()
         .block_on(async {
@@ -74,42 +74,42 @@ pub fn run(app: App<CrosstermBackend<Stdout>>) -> Result<(), ExitCodes> {
             app.app_state.start_event_monitor(app.notifier.clone()).await;
             Result::<_, UiError>::Ok(())
         })
-        .map_err(|e| ExitCodes::WalletError(e.to_string()))?;
+        .map_err(|e| ExitError::new(ExitCode::WalletError, e))?;
     crossterm_loop(app)
 }
 /// This is the main loop of the application UI using Crossterm based events
-fn crossterm_loop(mut app: App<CrosstermBackend<Stdout>>) -> Result<(), ExitCodes> {
+fn crossterm_loop(mut app: App<CrosstermBackend<Stdout>>) -> Result<(), ExitError> {
     let events = CrosstermEvents::new();
     enable_raw_mode().map_err(|e| {
         error!(target: LOG_TARGET, "Error enabling Raw Mode {}", e);
-        ExitCodes::InterfaceError
+        ExitCode::InterfaceError
     })?;
     let mut stdout = stdout();
     execute!(stdout, EnterAlternateScreen).map_err(|e| {
         error!(target: LOG_TARGET, "Error creating stdout context. {}", e);
-        ExitCodes::InterfaceError
+        ExitCode::InterfaceError
     })?;
 
     let backend = CrosstermBackend::new(stdout);
 
     let mut terminal = Terminal::new(backend).map_err(|e| {
         error!(target: LOG_TARGET, "Error creating Terminal context. {}", e);
-        ExitCodes::InterfaceError
+        ExitCode::InterfaceError
     })?;
 
     terminal.clear().map_err(|e| {
         error!(target: LOG_TARGET, "Error clearing interface. {}", e);
-        ExitCodes::InterfaceError
+        ExitCode::InterfaceError
     })?;
 
     loop {
         terminal.draw(|f| app.draw(f)).map_err(|e| {
             error!(target: LOG_TARGET, "Error drawing interface. {}", e);
-            ExitCodes::InterfaceError
+            ExitCode::InterfaceError
         })?;
         match events.next().map_err(|e| {
             error!(target: LOG_TARGET, "Error reading input event: {}", e);
-            ExitCodes::InterfaceError
+            ExitCode::InterfaceError
         })? {
             Event::Input(event) => match (event.code, event.modifiers) {
                 (KeyCode::Char(c), KeyModifiers::CONTROL) => app.on_control_key(c),
@@ -137,20 +137,20 @@ fn crossterm_loop(mut app: App<CrosstermBackend<Stdout>>) -> Result<(), ExitCode
 
     terminal.clear().map_err(|e| {
         error!(target: LOG_TARGET, "Error clearing interface. {}", e);
-        ExitCodes::InterfaceError
+        ExitCode::InterfaceError
     })?;
 
     disable_raw_mode().map_err(|e| {
         error!(target: LOG_TARGET, "Error disabling Raw Mode {}", e);
-        ExitCodes::InterfaceError
+        ExitCode::InterfaceError
     })?;
     execute!(terminal.backend_mut(), LeaveAlternateScreen).map_err(|e| {
         error!(target: LOG_TARGET, "Error releasing stdout {}", e);
-        ExitCodes::InterfaceError
+        ExitCode::InterfaceError
     })?;
     terminal.show_cursor().map_err(|e| {
         error!(target: LOG_TARGET, "Error showing cursor: {}", e);
-        ExitCodes::InterfaceError
+        ExitCode::InterfaceError
     })?;
 
     Ok(())

--- a/applications/tari_validator_node/src/comms.rs
+++ b/applications/tari_validator_node/src/comms.rs
@@ -28,7 +28,12 @@ use tari_app_utilities::{
     identity_management::load_from_json,
     utilities::convert_socks_authentication,
 };
-use tari_common::{exit_codes::ExitCodes, CommsTransport, GlobalConfig, TorControlAuthentication};
+use tari_common::{
+    exit_codes::{ExitCode, ExitError},
+    CommsTransport,
+    GlobalConfig,
+    TorControlAuthentication,
+};
 use tari_comms::{
     protocol::rpc::RpcServer,
     socks,
@@ -61,7 +66,7 @@ pub async fn build_service_and_comms_stack(
     mempool: MempoolServiceHandle,
     db_factory: SqliteDbFactory,
     asset_processor: ConcreteAssetProcessor,
-) -> Result<(ServiceHandles, SubscriptionFactory), ExitCodes> {
+) -> Result<(ServiceHandles, SubscriptionFactory), ExitError> {
     // this code is duplicated from the base node
     let comms_config = create_comms_config(config, node_identity.clone());
 
@@ -71,7 +76,7 @@ pub async fn build_service_and_comms_stack(
         .add_initializer(P2pInitializer::new(comms_config, publisher))
         .build()
         .await
-        .map_err(|err| ExitCodes::ConfigError(err.to_string()))?;
+        .map_err(|err| ExitError::new(ExitCode::ConfigError, err))?;
 
     let comms = handles
         .take_handle::<UnspawnedCommsNode>()
@@ -81,15 +86,15 @@ pub async fn build_service_and_comms_stack(
 
     let comms = spawn_comms_using_transport(comms, create_transport_type(config))
         .await
-        .map_err(|e| ExitCodes::ConfigError(format!("Could not spawn using transport:{}", e)))?;
+        .map_err(|e| ExitError::new(ExitCode::ConfigError, format!("Could not spawn using transport:{}", e)))?;
 
     // Save final node identity after comms has initialized. This is required because the public_address can be
     // changed by comms during initialization when using tor.
     identity_management::save_as_json(&config.base_node_identity_file, &*comms.node_identity())
-        .map_err(|e| ExitCodes::ConfigError(format!("Failed to save node identity: {}", e)))?;
+        .map_err(|e| ExitError::new(ExitCode::ConfigError, format!("Failed to save node identity: {}", e)))?;
     if let Some(hs) = comms.hidden_service() {
         identity_management::save_as_json(&config.base_node_tor_identity_file, hs.tor_identity())
-            .map_err(|e| ExitCodes::ConfigError(format!("Failed to save tor identity: {}", e)))?;
+            .map_err(|e| ExitError::new(ExitCode::ConfigError, format!("Failed to save tor identity: {}", e)))?;
     }
 
     handles.register(comms);

--- a/applications/tari_validator_node/src/main.rs
+++ b/applications/tari_validator_node/src/main.rs
@@ -39,7 +39,11 @@ use futures::FutureExt;
 use log::*;
 use tari_app_grpc::tari_rpc::validator_node_server::ValidatorNodeServer;
 use tari_app_utilities::{identity_management::setup_node_identity, initialization::init_configuration};
-use tari_common::{configuration::bootstrap::ApplicationType, exit_codes::ExitCodes, GlobalConfig};
+use tari_common::{
+    configuration::bootstrap::ApplicationType,
+    exit_codes::{ExitCode, ExitError},
+    GlobalConfig,
+};
 use tari_comms::{connectivity::ConnectivityRequester, peer_manager::PeerFeatures, NodeIdentity};
 use tari_comms_dht::Dht;
 use tari_dan_core::services::{ConcreteAssetProcessor, ConcreteAssetProxy, MempoolServiceHandle, ServiceSpecification};
@@ -61,19 +65,18 @@ const LOG_TARGET: &str = "tari::validator_node::app";
 
 fn main() {
     // console_subscriber::init();
-    if let Err(exit_code) = main_inner() {
-        eprintln!("{:?}", exit_code);
+    if let Err(err) = main_inner() {
+        let exit_code = err.exit_code;
+        eprintln!("{:?}", err);
         error!(
             target: LOG_TARGET,
-            "Exiting with code ({}): {:?}",
-            exit_code.as_i32(),
-            exit_code
+            "Exiting with code ({}): {:?}", exit_code as i32, exit_code
         );
-        process::exit(exit_code.as_i32());
+        process::exit(exit_code as i32);
     }
 }
 
-fn main_inner() -> Result<(), ExitCodes> {
+fn main_inner() -> Result<(), ExitError> {
     let (bootstrap, config, _) = init_configuration(ApplicationType::ValidatorNode)?;
 
     // let _operation_mode = cmd_args::get_operation_mode();
@@ -87,10 +90,10 @@ fn main_inner() -> Result<(), ExitCodes> {
     Ok(())
 }
 
-async fn run_node(config: GlobalConfig, create_id: bool) -> Result<(), ExitCodes> {
+async fn run_node(config: GlobalConfig, create_id: bool) -> Result<(), ExitError> {
     let shutdown = Shutdown::new();
 
-    fs::create_dir_all(&config.peer_db_path).map_err(|err| ExitCodes::ConfigError(err.to_string()))?;
+    fs::create_dir_all(&config.peer_db_path).map_err(|err| ExitError::new(ExitCode::ConfigError, err))?;
     let node_identity = setup_node_identity(
         &config.base_node_identity_file,
         &config.public_address,
@@ -153,12 +156,12 @@ async fn run_node(config: GlobalConfig, create_id: bool) -> Result<(), ExitCodes
     Ok(())
 }
 
-fn build_runtime() -> Result<Runtime, ExitCodes> {
+fn build_runtime() -> Result<Runtime, ExitError> {
     let mut builder = runtime::Builder::new_multi_thread();
     builder
         .enable_all()
         .build()
-        .map_err(|e| ExitCodes::UnknownError(e.to_string()))
+        .map_err(|e| ExitError::new(ExitCode::UnknownError, e))
 }
 
 async fn run_dan_node(
@@ -169,7 +172,7 @@ async fn run_dan_node(
     handles: ServiceHandles,
     subscription_factory: SubscriptionFactory,
     node_identity: Arc<NodeIdentity>,
-) -> Result<(), ExitCodes> {
+) -> Result<(), ExitError> {
     let node = DanNode::new(config);
     node.start(
         shutdown_signal,

--- a/base_layer/wallet/src/error.rs
+++ b/base_layer/wallet/src/error.rs
@@ -23,7 +23,7 @@
 use diesel::result::Error as DieselError;
 use log::SetLoggerError;
 use serde_json::Error as SerdeJsonError;
-use tari_common::exit_codes::ExitCodes;
+use tari_common::exit_codes::{ExitCode, ExitError};
 use tari_common_sqlite::error::SqliteStorageError;
 use tari_comms::{
     connectivity::ConnectivityError,
@@ -105,11 +105,11 @@ pub enum WalletError {
 
 pub const LOG_TARGET: &str = "tari::application";
 
-impl From<WalletError> for ExitCodes {
+impl From<WalletError> for ExitError {
     fn from(err: WalletError) -> Self {
         // TODO: Log that outside
         log::error!(target: LOG_TARGET, "{}", err);
-        Self::WalletError(err.to_string())
+        Self::new(ExitCode::WalletError, err)
     }
 }
 
@@ -175,13 +175,12 @@ pub enum WalletStorageError {
     RecoverySeedError(String),
 }
 
-impl From<WalletStorageError> for ExitCodes {
+impl From<WalletStorageError> for ExitError {
     fn from(err: WalletStorageError) -> Self {
         use WalletStorageError::*;
         match err {
-            NoPasswordError => ExitCodes::NoPassword,
-            InvalidPassphrase => ExitCodes::IncorrectPassword,
-            e => ExitCodes::WalletError(e.to_string()),
+            NoPasswordError | InvalidPassphrase => ExitCode::IncorrectOrEmptyPassword.into(),
+            e => ExitError::new(ExitCode::WalletError, e),
         }
     }
 }

--- a/base_layer/wallet/src/output_manager_service/error.rs
+++ b/base_layer/wallet/src/output_manager_service/error.rs
@@ -21,7 +21,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use diesel::result::Error as DieselError;
-use tari_common::exit_codes::ExitCodes;
+use tari_common::exit_codes::{ExitCode, ExitError};
 use tari_comms::{connectivity::ConnectivityError, peer_manager::node_id::NodeIdError, protocol::rpc::RpcError};
 use tari_comms_dht::outbound::DhtOutboundError;
 use tari_core::transactions::{
@@ -176,10 +176,10 @@ pub enum OutputManagerStorageError {
     KeyManagerError(#[from] KeyManagerError),
 }
 
-impl From<OutputManagerError> for ExitCodes {
+impl From<OutputManagerError> for ExitError {
     fn from(err: OutputManagerError) -> Self {
         log::error!(target: crate::error::LOG_TARGET, "{}", err);
-        Self::WalletError(err.to_string())
+        Self::new(ExitCode::WalletError, err)
     }
 }
 

--- a/common/src/exit_codes.rs
+++ b/common/src/exit_codes.rs
@@ -31,30 +31,6 @@ impl fmt::Display for ExitError {
     }
 }
 
-impl From<ExitCodes> for ExitError {
-    fn from(codes: ExitCodes) -> Self {
-        use ExitCodes::*;
-        match codes {
-            ConfigError(s) => Self::new(ExitCode::ConfigError, s),
-            UnknownError(s) => Self::new(ExitCode::UnknownError, s),
-            InterfaceError => Self::from(ExitCode::InterfaceError),
-            WalletError(s) => Self::new(ExitCode::WalletError, s),
-            GrpcError(s) => Self::new(ExitCode::GrpcError, s),
-            InputError(s) => Self::new(ExitCode::InputError, s),
-            CommandError(s) => Self::new(ExitCode::CommandError, s),
-            IOError(s) => Self::new(ExitCode::IOError, s),
-            RecoveryError(s) => Self::new(ExitCode::RecoveryError, s),
-            NetworkError(s) => Self::new(ExitCode::NetworkError, s),
-            ConversionError(s) => Self::new(ExitCode::ConversionError, s),
-            IncorrectPassword => Self::from(ExitCode::IncorrectOrEmptyPassword),
-            NoPassword => Self::from(ExitCode::IncorrectOrEmptyPassword),
-            TorOffline => Self::from(ExitCode::TorOffline),
-            DatabaseError(s) => Self::new(ExitCode::DatabaseError, s),
-            DbInconsistentState(s) => Self::new(ExitCode::DbInconsistentState, s),
-        }
-    }
-}
-
 const TOR_HINT: &str = r#"\
 Unable to connect to the Tor control port.
 
@@ -111,86 +87,6 @@ pub enum ExitCode {
     DatabaseError = 114,
     #[error("Database is in an inconsistent state!")]
     DbInconsistentState = 115,
-}
-
-/// Enum to show failure information
-#[derive(Debug, Clone, Error)]
-pub enum ExitCodes {
-    #[error("There is an error in the configuration: {0}")]
-    ConfigError(String),
-    #[error("The application exited because an unknown error occurred: {0}. Check the logs for more details.")]
-    UnknownError(String),
-    #[error("The application exited because an interface error occurred. Check the logs for details.")]
-    InterfaceError,
-    #[error("The application exited. {0}")]
-    WalletError(String),
-    #[error("The application was not able to start the GRPC server. {0}")]
-    GrpcError(String),
-    #[error("The application did not accept the command input: {0}")]
-    InputError(String),
-    #[error("Invalid command: {0}")]
-    CommandError(String),
-    #[error("IO error: {0}")]
-    IOError(String),
-    #[error("Recovery failed: {0}")]
-    RecoveryError(String),
-    #[error("The application exited because of an internal network error: {0}")]
-    NetworkError(String),
-    #[error("The application exited because it received a message it could not interpret: {0}")]
-    ConversionError(String),
-    #[error("Your password was incorrect.")]
-    IncorrectPassword,
-    #[error("Your wallet is encrypted but no password was provided.")]
-    NoPassword,
-    #[error("The application encountered a database error: {0}")]
-    DatabaseError(String),
-    #[error("Tor connection is offline")]
-    TorOffline,
-    #[error("Database is in an inconsistent state!: {0}")]
-    DbInconsistentState(String),
-}
-
-impl ExitCodes {
-    pub fn as_i32(&self) -> i32 {
-        match self {
-            Self::ConfigError(_) => 101,
-            Self::UnknownError(_) => 102,
-            Self::InterfaceError => 103,
-            Self::WalletError(_) => 104,
-            Self::GrpcError(_) => 105,
-            Self::InputError(_) => 106,
-            Self::CommandError(_) => 107,
-            Self::IOError(_) => 108,
-            Self::RecoveryError(_) => 109,
-            Self::NetworkError(_) => 110,
-            Self::ConversionError(_) => 111,
-            Self::IncorrectPassword | Self::NoPassword => 112,
-            Self::TorOffline => 113,
-            Self::DatabaseError(_) => 114,
-            Self::DbInconsistentState(_) => 115,
-        }
-    }
-
-    pub fn eprint_details(&self) {
-        use ExitCodes::*;
-        match self {
-            TorOffline => {
-                eprintln!("Unable to connect to the Tor control port.");
-                eprintln!(
-                    "Please check that you have the Tor proxy running and that access to the Tor control port is \
-                     turned on.",
-                );
-                eprintln!("If you are unsure of what to do, use the following command to start the Tor proxy:");
-                eprintln!(
-                    "tor --allow-missing-torrc --ignore-missing-torrc --clientonly 1 --socksport 9050 --controlport \
-                     127.0.0.1:9051 --log \"warn stdout\" --clientuseipv6 1",
-                );
-            },
-            e => {
-                eprintln!("{}", e);
-            },
-        }
-    }
 }
 
 impl From<super::ConfigError> for ExitError {

--- a/common/src/exit_codes.rs
+++ b/common/src/exit_codes.rs
@@ -7,10 +7,40 @@ pub struct ExitError {
     details: Option<String>,
 }
 
+impl ExitError {
+    pub fn new(exit_code: ExitCode, details: Option<String>) -> Self {
+        Self { exit_code, details }
+    }
+}
+
 impl fmt::Display for ExitError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let details = self.details.as_ref().map(String::as_ref).unwrap_or("");
         write!(f, "{} {}", self.exit_code, details)
+    }
+}
+
+impl From<ExitCodes> for ExitError {
+    fn from(codes: ExitCodes) -> Self {
+        use ExitCodes::*;
+        match codes {
+            ConfigError(s) => Self::new(ExitCode::ConfigError, Some(s)),
+            UnknownError(s) => Self::new(ExitCode::UnknownError, Some(s)),
+            InterfaceError => Self::new(ExitCode::InterfaceError, None),
+            WalletError(s) => Self::new(ExitCode::WalletError, Some(s)),
+            GrpcError(s) => Self::new(ExitCode::GrpcError, Some(s)),
+            InputError(s) => Self::new(ExitCode::InputError, Some(s)),
+            CommandError(s) => Self::new(ExitCode::CommandError, Some(s)),
+            IOError(s) => Self::new(ExitCode::IOError, Some(s)),
+            RecoveryError(s) => Self::new(ExitCode::RecoveryError, Some(s)),
+            NetworkError(s) => Self::new(ExitCode::NetworkError, Some(s)),
+            ConversionError(s) => Self::new(ExitCode::ConversionError, Some(s)),
+            IncorrectPassword => Self::new(ExitCode::IncorrectOrEmptyPassword, None),
+            NoPassword => Self::new(ExitCode::IncorrectOrEmptyPassword, None),
+            TorOffline => Self::new(ExitCode::TorOffline, None),
+            DatabaseError(s) => Self::new(ExitCode::DatabaseError, Some(s)),
+            DbInconsistentState(s) => Self::new(ExitCode::DbInconsistentState, Some(s)),
+        }
     }
 }
 

--- a/common/src/exit_codes.rs
+++ b/common/src/exit_codes.rs
@@ -1,4 +1,76 @@
+use std::fmt;
 use thiserror::Error;
+
+#[derive(Debug, Clone, Error)]
+pub struct ExitError {
+    exit_code: ExitCode,
+    details: Option<String>,
+}
+
+impl fmt::Display for ExitError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let details = self.details.as_ref().map(String::as_ref).unwrap_or("");
+        write!(f, "{} {}", self.exit_code, details)
+    }
+}
+
+const TOR_HINT: &str = r#"\
+Unable to connect to the Tor control port.
+
+Please check that you have the Tor proxy running and \
+that access to the Tor control port is turned on.
+
+If you are unsure of what to do, use the following \
+command to start the Tor proxy:
+tor --allow-missing-torrc --ignore-missing-torrc \
+--clientonly 1 --socksport 9050 --controlport \
+127.0.0.1:9051 --log \"warn stdout\" --clientuseipv6 1
+"#;
+
+impl ExitCode {
+    pub fn hint(&self) -> &str {
+        use ExitCode::*;
+        match self {
+            TorOffline => TOR_HINT,
+            _ => "",
+        }
+    }
+}
+
+/// Enum to show failure information
+#[derive(Debug, Clone, Error)]
+pub enum ExitCode {
+    #[error("There is an error in the configuration.")]
+    ConfigError = 101,
+    #[error("The application exited because an unknown error occurred. Check the logs for more details.")]
+    UnknownError = 102,
+    #[error("The application exited because an interface error occurred. Check the logs for details.")]
+    InterfaceError = 103,
+    #[error("The application exited.")]
+    WalletError = 104,
+    #[error("The application was not able to start the GRPC server.")]
+    GrpcError = 105,
+    #[error("The application did not accept the command input.")]
+    InputError = 106,
+    #[error("Invalid command.")]
+    CommandError = 107,
+    #[error("IO error.")]
+    IOError = 108,
+    #[error("Recovery failed.")]
+    RecoveryError = 109,
+    #[error("The application exited because of an internal network error.")]
+    NetworkError = 110,
+    #[error("The application exited because it received a message it could not interpret.")]
+    ConversionError = 111,
+    #[error("Your password was incorrect or required, but not provided.")]
+    IncorrectOrEmptyPassword = 112,
+    #[error("Tor connection is offline")]
+    TorOffline = 113,
+    #[error("The application encountered a database error.")]
+    DatabaseError = 114,
+    #[error("Database is in an inconsistent state!")]
+    DbInconsistentState = 115,
+}
 
 /// Enum to show failure information
 #[derive(Debug, Clone, Error)]

--- a/common/src/exit_codes.rs
+++ b/common/src/exit_codes.rs
@@ -1,10 +1,11 @@
 use std::fmt;
+
 use thiserror::Error;
 
 #[derive(Debug, Clone, Error)]
 pub struct ExitError {
-    exit_code: ExitCode,
-    details: Option<String>,
+    pub exit_code: ExitCode,
+    pub details: Option<String>,
 }
 
 impl ExitError {
@@ -68,7 +69,7 @@ impl ExitCode {
 }
 
 /// Enum to show failure information
-#[derive(Debug, Clone, Error)]
+#[derive(Debug, Clone, Copy, Error)]
 pub enum ExitCode {
     #[error("There is an error in the configuration.")]
     ConfigError = 101,

--- a/common/src/exit_codes.rs
+++ b/common/src/exit_codes.rs
@@ -9,8 +9,18 @@ pub struct ExitError {
 }
 
 impl ExitError {
-    pub fn new(exit_code: ExitCode, details: Option<String>) -> Self {
+    pub fn new(exit_code: ExitCode, details: impl ToString) -> Self {
+        let details = Some(details.to_string());
         Self { exit_code, details }
+    }
+}
+
+impl From<ExitCode> for ExitError {
+    fn from(exit_code: ExitCode) -> Self {
+        Self {
+            exit_code,
+            details: None,
+        }
     }
 }
 
@@ -25,22 +35,22 @@ impl From<ExitCodes> for ExitError {
     fn from(codes: ExitCodes) -> Self {
         use ExitCodes::*;
         match codes {
-            ConfigError(s) => Self::new(ExitCode::ConfigError, Some(s)),
-            UnknownError(s) => Self::new(ExitCode::UnknownError, Some(s)),
-            InterfaceError => Self::new(ExitCode::InterfaceError, None),
-            WalletError(s) => Self::new(ExitCode::WalletError, Some(s)),
-            GrpcError(s) => Self::new(ExitCode::GrpcError, Some(s)),
-            InputError(s) => Self::new(ExitCode::InputError, Some(s)),
-            CommandError(s) => Self::new(ExitCode::CommandError, Some(s)),
-            IOError(s) => Self::new(ExitCode::IOError, Some(s)),
-            RecoveryError(s) => Self::new(ExitCode::RecoveryError, Some(s)),
-            NetworkError(s) => Self::new(ExitCode::NetworkError, Some(s)),
-            ConversionError(s) => Self::new(ExitCode::ConversionError, Some(s)),
-            IncorrectPassword => Self::new(ExitCode::IncorrectOrEmptyPassword, None),
-            NoPassword => Self::new(ExitCode::IncorrectOrEmptyPassword, None),
-            TorOffline => Self::new(ExitCode::TorOffline, None),
-            DatabaseError(s) => Self::new(ExitCode::DatabaseError, Some(s)),
-            DbInconsistentState(s) => Self::new(ExitCode::DbInconsistentState, Some(s)),
+            ConfigError(s) => Self::new(ExitCode::ConfigError, s),
+            UnknownError(s) => Self::new(ExitCode::UnknownError, s),
+            InterfaceError => Self::from(ExitCode::InterfaceError),
+            WalletError(s) => Self::new(ExitCode::WalletError, s),
+            GrpcError(s) => Self::new(ExitCode::GrpcError, s),
+            InputError(s) => Self::new(ExitCode::InputError, s),
+            CommandError(s) => Self::new(ExitCode::CommandError, s),
+            IOError(s) => Self::new(ExitCode::IOError, s),
+            RecoveryError(s) => Self::new(ExitCode::RecoveryError, s),
+            NetworkError(s) => Self::new(ExitCode::NetworkError, s),
+            ConversionError(s) => Self::new(ExitCode::ConversionError, s),
+            IncorrectPassword => Self::from(ExitCode::IncorrectOrEmptyPassword),
+            NoPassword => Self::from(ExitCode::IncorrectOrEmptyPassword),
+            TorOffline => Self::from(ExitCode::TorOffline),
+            DatabaseError(s) => Self::new(ExitCode::DatabaseError, s),
+            DbInconsistentState(s) => Self::new(ExitCode::DbInconsistentState, s),
         }
     }
 }

--- a/common/src/exit_codes.rs
+++ b/common/src/exit_codes.rs
@@ -193,34 +193,28 @@ impl ExitCodes {
     }
 }
 
-impl From<super::ConfigError> for ExitCodes {
+impl From<super::ConfigError> for ExitError {
     fn from(err: super::ConfigError) -> Self {
         // TODO: Move it out
         // error!(target: LOG_TARGET, "{}", err);
-        Self::ConfigError(err.to_string())
+        Self::new(ExitCode::ConfigError, err)
     }
 }
 
-impl From<crate::ConfigurationError> for ExitCodes {
+impl From<crate::ConfigurationError> for ExitError {
     fn from(err: crate::ConfigurationError) -> Self {
-        Self::ConfigError(err.to_string())
+        Self::new(ExitCode::ConfigError, err)
     }
 }
 
-impl From<multiaddr::Error> for ExitCodes {
+impl From<multiaddr::Error> for ExitError {
     fn from(err: multiaddr::Error) -> Self {
-        Self::ConfigError(err.to_string())
+        Self::new(ExitCode::ConfigError, err)
     }
 }
 
-impl From<std::io::Error> for ExitCodes {
+impl From<std::io::Error> for ExitError {
     fn from(err: std::io::Error) -> Self {
-        Self::IOError(err.to_string())
-    }
-}
-
-impl ExitCodes {
-    pub fn grpc<M: std::fmt::Display>(err: M) -> Self {
-        ExitCodes::GrpcError(format!("GRPC connection error: {}", err))
+        Self::new(ExitCode::IOError, err)
     }
 }

--- a/infrastructure/libtor/src/tor.rs
+++ b/infrastructure/libtor/src/tor.rs
@@ -26,7 +26,11 @@ use libtor::{LogDestination, LogLevel, TorFlag};
 use log::*;
 use multiaddr::Multiaddr;
 use rand::{distributions::Alphanumeric, thread_rng, Rng};
-use tari_common::{exit_codes::ExitCodes, CommsTransport, TorControlAuthentication};
+use tari_common::{
+    exit_codes::{ExitCode, ExitError},
+    CommsTransport,
+    TorControlAuthentication,
+};
 use tari_shutdown::ShutdownSignal;
 use tempfile::{tempdir, NamedTempFile, TempDir, TempPath};
 use tor_hash_passwd::EncryptedKey;
@@ -74,7 +78,7 @@ impl Tor {
     /// Two TCP ports will be provided by the operating system.
     /// These ports are used for the control and socks ports, the onion address and port info are still loaded from the
     /// node identity file.
-    pub fn initialize() -> Result<Tor, ExitCodes> {
+    pub fn initialize() -> Result<Tor, ExitError> {
         debug!(target: LOG_TARGET, "Initializing libtor");
         let mut instance = Tor::default();
 
@@ -108,7 +112,7 @@ impl Tor {
     }
 
     /// Override a given Tor comms transport with the control address and auth from this instance
-    pub fn update_comms_transport(&self, transport: CommsTransport) -> Result<CommsTransport, ExitCodes> {
+    pub fn update_comms_transport(&self, transport: CommsTransport) -> Result<CommsTransport, ExitError> {
         debug!(target: LOG_TARGET, "updating comms transport");
         if let CommsTransport::TorHiddenService {
             socks_address_override,
@@ -139,12 +143,12 @@ impl Tor {
             Ok(transport)
         } else {
             let e = format!("Expected a TorHiddenService comms transport, received: {:?}", transport);
-            Err(ExitCodes::ConfigError(e))
+            Err(ExitError::new(ExitCode::ConfigError, e))
         }
     }
 
     /// Run the Tor instance until the shutdown signal is received
-    pub async fn run(self, mut shutdown_signal: ShutdownSignal) -> Result<(), ExitCodes> {
+    pub async fn run(self, mut shutdown_signal: ShutdownSignal) -> Result<(), ExitError> {
         info!(target: LOG_TARGET, "Starting Tor instance");
 
         let Tor {


### PR DESCRIPTION
Description
---
The PR splits `ErrorCodes` into the pair of `ExitCode` enum and `ExitError` struct.

Motivation and Context
---
The purpose of this change is to separate strings from error codes in order to later use more specific error types instead of strings or `ErrorCodes` directly to have detailed backtraces that will simplify and speed up debugging of the code.

How Has This Been Tested?
---
CI pass expected

