### PR TITLE
chore: change error propagation in validator node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6973,6 +6973,7 @@ dependencies = [
  "thiserror",
  "tokio 1.17.0",
  "tokio-stream",
+ "tonic",
 ]
 
 [[package]]

--- a/applications/tari_validator_node/src/comms.rs
+++ b/applications/tari_validator_node/src/comms.rs
@@ -209,13 +209,12 @@ fn create_transport_type(config: &GlobalConfig) -> TransportType {
                 });
             debug!(
                 target: LOG_TARGET,
-                "Tor identity at path '{}' {:?}",
+                "Tor identity at path '{}' {}",
                 config.base_node_tor_identity_file.to_string_lossy(),
                 identity
                     .as_ref()
                     .map(|ident| format!("loaded for address '{}.onion'", ident.service_id))
-                    .or_else(|| Some("not found".to_string()))
-                    .unwrap()
+                    .unwrap_or_else(|| "not found".to_string())
             );
 
             let forward_addr = multiaddr_to_socketaddr(&forward_address).expect("Invalid tor forward address");

--- a/applications/tari_validator_node/src/dan_node.rs
+++ b/applications/tari_validator_node/src/dan_node.rs
@@ -93,7 +93,10 @@ impl DanNode {
         let mut tasks = HashMap::new();
         let mut next_scanned_height = 0u64;
         loop {
-            let tip = base_node_client.get_tip_info().await.unwrap();
+            let tip = base_node_client
+                .get_tip_info()
+                .await
+                .map_err(|e| ExitError::new(ExitCode::DigitalAssetError, e))?;
             if tip.height_of_longest_chain >= next_scanned_height {
                 info!(
                     target: LOG_TARGET,
@@ -105,11 +108,10 @@ impl DanNode {
                 } else {
                     next_scanned_height = u64::MAX; // Never run again.
                 }
-
                 let assets = base_node_client
                     .get_assets_for_dan_node(node_identity.public_key().clone())
                     .await
-                    .unwrap();
+                    .map_err(|e| ExitError::new(ExitCode::DigitalAssetError, e))?;
                 info!(
                     target: LOG_TARGET,
                     "Base node returned {} asset(s) to process",

--- a/applications/tari_validator_node/src/grpc/services/wallet_client.rs
+++ b/applications/tari_validator_node/src/grpc/services/wallet_client.rs
@@ -41,11 +41,7 @@ impl GrpcWalletClient {
     }
 
     pub async fn connect(&mut self) -> Result<(), DigitalAssetError> {
-        self.inner = Some(
-            grpc::wallet_client::WalletClient::connect(format!("http://{}", self.endpoint))
-                .await
-                .unwrap(),
-        );
+        self.inner = Some(grpc::wallet_client::WalletClient::connect(format!("http://{}", self.endpoint)).await?);
         Ok(())
     }
 }

--- a/applications/tari_validator_node/src/p2p/services/inbound_connection_service.rs
+++ b/applications/tari_validator_node/src/p2p/services/inbound_connection_service.rs
@@ -207,7 +207,7 @@ impl TariCommsInboundConnectionService {
     async fn forward_message(&mut self, message: Arc<PeerMessage>) -> Result<(), DigitalAssetError> {
         // let from = message.authenticated_origin.as_ref().unwrap().clone();
         let from = message.source_peer.public_key.clone();
-        let proto_message: proto::consensus::HotStuffMessage = message.decode_message().unwrap();
+        let proto_message: proto::consensus::HotStuffMessage = message.decode_message()?;
         let hot_stuff_message: HotStuffMessage<TariDanPayload> = proto_message
             .try_into()
             .map_err(DigitalAssetError::InvalidPeerMessage)?;

--- a/applications/tari_validator_node/src/p2p/services/outbound_connection_service.rs
+++ b/applications/tari_validator_node/src/p2p/services/outbound_connection_service.rs
@@ -82,17 +82,14 @@ impl OutboundService for TariCommsOutboundService<TariDanPayload> {
                 message.message_type(),
                 message.asset_public_key()
             );
-            self.loopback_service.send((from, message)).await.unwrap();
+            self.loopback_service.send((from, message)).await.map_err(Box::new)?;
             return Ok(());
         }
 
         let inner = proto::consensus::HotStuffMessage::from(message);
         let tari_message = OutboundDomainMessage::new(TariMessageType::DanConsensusMessage, inner);
 
-        self.outbound_message_requester
-            .send_direct(to, tari_message)
-            .await
-            .unwrap();
+        self.outbound_message_requester.send_direct(to, tari_message).await?;
         Ok(())
     }
 

--- a/common/src/exit_codes.rs
+++ b/common/src/exit_codes.rs
@@ -87,6 +87,8 @@ pub enum ExitCode {
     DatabaseError = 114,
     #[error("Database is in an inconsistent state!")]
     DbInconsistentState = 115,
+    #[error("DigitalAssetError")]
+    DigitalAssetError = 116,
 }
 
 impl From<super::ConfigError> for ExitError {

--- a/dan_layer/core/Cargo.toml
+++ b/dan_layer/core/Cargo.toml
@@ -37,6 +37,7 @@ serde = "1.0.126"
 thiserror = "^1.0.20"
 tokio = { version="1.10", features = ["macros", "time"]}
 tokio-stream = { version = "0.1.7", features = ["sync"] }
+tonic = "0.6.2"
 
 # saving of patricia tree
 patricia_tree = { version = "0.3.0", features = ["binary-format"] }


### PR DESCRIPTION
Description
---
This PR changes all (that can fail) `unwraps` to `?`.

Motivation and Context
---
There were too many unwraps that did not propagate the errors. It's better if we want to handle non fatal errors in the code instead of panicking .

How Has This Been Tested?
---
Just by running the validator node and collectibles.