### PR TITLE
fix: fix rustls and trust-dns-client after version bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,6 +183,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
+name = "async-broadcast"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90622698a1218e0b2fb846c97b5f19a0831f6baddee73d9454156365ccfa473b"
+dependencies = [
+ "easy-parallel",
+ "event-listener",
+ "futures-core",
+]
+
+[[package]]
+name = "async-channel"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2114d64672151c0c5eaa5e131ec84a74f06e1e559830dabba01ca30605d66319"
+dependencies = [
+ "concurrent-queue",
+ "event-listener",
+ "futures-core",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "871f9bb5e0a22eeb7e8cf16641feb87c9dc67032ccf8ff49e772eb9941d3a965"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "once_cell",
+ "slab",
+]
+
+[[package]]
 name = "async-io"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -199,6 +235,26 @@ dependencies = [
  "socket2",
  "waker-fn",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "async-lock"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6a8ea61bf9947a1007c5cada31e647dbc77b103c679858150003ba697ea798b"
+dependencies = [
+ "event-listener",
+]
+
+[[package]]
+name = "async-recursion"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7d78656ba01f1b93024b7c3a0467f1608e4be67d725749fdcd7d2c7678fd7a2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -221,6 +277,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "async-task"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d306121baf53310a3fd342d88dc0824f6bbeace68347593658525565abee8"
 
 [[package]]
 name = "async-trait"
@@ -268,7 +330,7 @@ dependencies = [
  "log",
  "native-tls",
  "openssl",
- "serde 1.0.135",
+ "serde 1.0.136",
  "serde_json",
  "serde_urlencoded 0.6.1",
  "url 2.2.2",
@@ -288,15 +350,18 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
+checksum = "0dde43e75fd43e8a1bf86103336bc699aa8d17ad1be60c76c0bdfd4828e19b78"
+dependencies = [
+ "autocfg 1.1.0",
+]
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "autotools"
@@ -369,7 +434,7 @@ version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
- "serde 1.0.135",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -443,9 +508,9 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882e99e4a0cb2ae6cb6e442102e8e6b7131718d94110e64c3e6a34ea9b106f37"
+checksum = "a08e53fc5a564bb15bfe6fae56bd71522205f1f91893f9c0116edad6496c183f"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.2",
@@ -486,9 +551,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1d36a02058e76b040de25a4464ba1c80935655595b661505c8b39b664828b95"
+checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
 dependencies = [
  "generic-array 0.14.5",
 ]
@@ -557,12 +622,12 @@ dependencies = [
  "hyperlocal",
  "log",
  "pin-project 1.0.10",
- "serde 1.0.135",
+ "serde 1.0.136",
  "serde_derive",
  "serde_json",
  "serde_urlencoded 0.7.1",
  "thiserror",
- "tokio 1.15.0",
+ "tokio 1.16.1",
  "tokio-util",
  "url 2.2.2",
  "winapi 0.3.9",
@@ -575,7 +640,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2f2e73fffe9455141e170fb9c1feb0ac521ec7e7dcd47a7cab72a658490fb8"
 dependencies = [
  "chrono",
- "serde 1.0.135",
+ "serde 1.0.136",
  "serde_with",
 ]
 
@@ -594,7 +659,7 @@ dependencies = [
  "lazy_static 1.4.0",
  "memchr",
  "regex-automata",
- "serde 1.0.135",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -633,7 +698,7 @@ checksum = "adf4c9d0bbf32eea58d7c0f812058138ee8edaf0f2802b6d03561b504729a325"
 dependencies = [
  "bincode",
  "byteorder",
- "serde 1.0.135",
+ "serde 1.0.136",
  "trackable 0.2.24",
 ]
 
@@ -661,7 +726,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 dependencies = [
- "serde 1.0.135",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -759,7 +824,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "serde 1.0.135",
+ "serde 1.0.136",
  "serde_json",
  "syn",
  "tempfile",
@@ -870,8 +935,8 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits 0.2.14",
- "serde 1.0.135",
- "time",
+ "serde 1.0.136",
+ "time 0.1.43",
  "winapi 0.3.9",
 ]
 
@@ -882,7 +947,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6316c62053228eddd526a5e6deb6344c80bf2bc1e9786e7f90b3083e73197c1"
 dependencies = [
  "bitstring",
- "serde 1.0.135",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -911,9 +976,9 @@ checksum = "b0fc239e0f6cb375d2402d48afb92f76f5404fd1df208a41930ec81eda078bea"
 
 [[package]]
 name = "clang-sys"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa66045b9cb23c2e9c1520732030608b02ee07e5cfaa5a521ec15ded7fa24c90"
+checksum = "4cc00842eed744b858222c4c9faf7243aafc6d33f92f96935263ef4d8a41ce21"
 dependencies = [
  "glob",
  "libc",
@@ -956,9 +1021,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.0.6"
+version = "3.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "517358c28fcef6607bf6f76108e02afad7e82297d132a6b846dcc1fc3efcd153"
+checksum = "9a1132dc3944b31c20dd8b906b3a9f0a5d0243e092d59171414969657ac6aa85"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
@@ -1005,7 +1070,7 @@ dependencies = [
  "bitflags 1.3.2",
  "block",
  "cocoa-foundation",
- "core-foundation 0.9.2",
+ "core-foundation 0.9.3",
  "core-graphics 0.22.3",
  "foreign-types",
  "libc",
@@ -1020,7 +1085,7 @@ checksum = "7ade49b65d560ca58c403a479bb396592b155c0185eada742ee323d1d68d6318"
 dependencies = [
  "bitflags 1.3.2",
  "block",
- "core-foundation 0.9.2",
+ "core-foundation 0.9.3",
  "core-graphics-types",
  "foreign-types",
  "libc",
@@ -1082,7 +1147,7 @@ dependencies = [
  "lazy_static 1.4.0",
  "nom 4.2.3",
  "rust-ini",
- "serde 1.0.135",
+ "serde 1.0.136",
  "serde-hjson 0.8.2",
  "serde_json",
  "toml 0.4.10",
@@ -1098,7 +1163,7 @@ dependencies = [
  "lazy_static 1.4.0",
  "nom 5.1.2",
  "rust-ini",
- "serde 1.0.135",
+ "serde 1.0.136",
  "serde-hjson 0.9.1",
  "serde_json",
  "toml 0.5.8",
@@ -1139,9 +1204,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6888e10551bb93e424d8df1d07f1a8b4fceb0001a3a4b048bfc47554946f47b3"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
 dependencies = [
  "core-foundation-sys 0.8.3",
  "libc",
@@ -1178,7 +1243,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2581bbab3b8ffc6fcbd550bf46c355135d16e9ff2a6ea032ad6b9bf1d7efe4fb"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation 0.9.2",
+ "core-foundation 0.9.3",
  "core-graphics-types",
  "foreign-types",
  "libc",
@@ -1191,7 +1256,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a68b68b3446082644c91ac778bf50cd4104bfb002b5a6a7c44cca5a2c70788b"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation 0.9.2",
+ "core-foundation 0.9.3",
  "foreign-types",
  "libc",
 ]
@@ -1232,9 +1297,9 @@ checksum = "fd121741cf3eb82c08dd3023eb55bf2665e5f60ec20f89760cf836ae4562e6a0"
 
 [[package]]
 name = "crc32fast"
-version = "1.3.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2209c310e29876f7f0b2721e7e26b84aff178aa3da5d091f9bfbf47669e60e3"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -1259,7 +1324,7 @@ dependencies = [
  "rand_xoshiro",
  "rayon",
  "rayon-core",
- "serde 1.0.135",
+ "serde 1.0.136",
  "serde_derive",
  "serde_json",
  "tinytemplate",
@@ -1310,7 +1375,7 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-epoch",
  "crossbeam-queue",
- "crossbeam-utils 0.8.6",
+ "crossbeam-utils 0.8.7",
 ]
 
 [[package]]
@@ -1329,7 +1394,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e54ea8bc3fb1ee042f5aace6e3c6e025d3874866da222930f70ce62aceba0bfa"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.6",
+ "crossbeam-utils 0.8.7",
 ]
 
 [[package]]
@@ -1340,17 +1405,17 @@ checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-epoch",
- "crossbeam-utils 0.8.6",
+ "crossbeam-utils 0.8.7",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.6"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97242a70df9b89a65d0b6df3c4bf5b9ce03c5b7309019777fbde37e7537f8762"
+checksum = "c00d6d2ea26e8b151d99093005cb442fb9a37aeaca582a03ec70946f49ab5ed9"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.6",
+ "crossbeam-utils 0.8.7",
  "lazy_static 1.4.0",
  "memoffset",
  "scopeguard",
@@ -1358,12 +1423,12 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b979d76c9fcb84dffc80a73f7290da0f83e4c95773494674cb44b76d13a7a110"
+checksum = "4dd435b205a4842da59efd07628f921c096bc1cc0a156835b4fa0bcb9a19bcce"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.6",
+ "crossbeam-utils 0.8.7",
 ]
 
 [[package]]
@@ -1378,9 +1443,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcae03edb34f947e64acdb1c33ec169824e20657e9ecb61cef6c8c74dcb8120"
+checksum = "b5e5bed1f1c269533fa816a0a5492b3545209a205ca1a54842be180eb63a16a6"
 dependencies = [
  "cfg-if 1.0.0",
  "lazy_static 1.4.0",
@@ -1498,7 +1563,7 @@ dependencies = [
  "csv-core",
  "itoa 0.4.8",
  "ryu",
- "serde 1.0.135",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -1558,7 +1623,7 @@ dependencies = [
  "byteorder",
  "digest 0.9.0",
  "rand_core 0.5.1",
- "serde 1.0.135",
+ "serde 1.0.136",
  "subtle",
  "zeroize",
 ]
@@ -1573,7 +1638,7 @@ dependencies = [
  "digest 0.9.0",
  "packed_simd_2",
  "rand_core 0.6.3",
- "serde 1.0.135",
+ "serde 1.0.136",
  "subtle-ng",
  "zeroize",
 ]
@@ -1816,7 +1881,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b697d66081d42af4fba142d56918a3cb21dc8eb63372c6b85d14f44fb9c5979b"
 dependencies = [
- "block-buffer 0.10.0",
+ "block-buffer 0.10.2",
  "crypto-common",
  "generic-array 0.14.5",
  "subtle",
@@ -1886,6 +1951,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "easy-parallel"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6907e25393cdcc1f4f3f513d9aac1e840eb1cc341a0fccb01171f7d14d10b946"
+
+[[package]]
 name = "ed25519"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1903,7 +1974,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "rand 0.7.3",
- "serde 1.0.135",
+ "serde 1.0.136",
  "sha2",
  "zeroize",
 ]
@@ -1949,19 +2020,19 @@ dependencies = [
 
 [[package]]
 name = "enumflags2"
-version = "0.6.4"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83c8d82922337cd23a15f88b70d8e4ef5f11da38dd7cdb55e84dd5de99695da0"
+checksum = "a25c90b056b3f84111cf183cbeddef0d3a0bbe9a674f057e1a1533c315f24def"
 dependencies = [
  "enumflags2_derive",
- "serde 1.0.135",
+ "serde 1.0.136",
 ]
 
 [[package]]
 name = "enumflags2_derive"
-version = "0.6.4"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "946ee94e3dbf58fdd324f9ce245c7b238d46a66f00e86a020b71996349e46cce"
+checksum = "144ec79496cbab6f84fa125dc67be9264aef22eb8a28da8454d9c33f15108da4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2043,6 +2114,12 @@ name = "ethnum"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f58da196a1fc8f14cb51f373f504efc66c434c577b777c2cd30d6fad16e4822"
+
+[[package]]
+name = "event-listener"
+version = "2.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77f3309417938f28bf8228fcff79a4a37103981e3e186d2ccd19c74b38f4eb71"
 
 [[package]]
 name = "fake-simd"
@@ -2216,9 +2293,9 @@ checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c9c1ce3fa9336301af935ab852c437817d14cd33690446569392e65170aac3b"
+checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
 dependencies = [
  "mac",
  "new_debug_unreachable",
@@ -2232,9 +2309,9 @@ checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
 
 [[package]]
 name = "futures"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28560757fe2bb34e79f907794bb6b22ae8b0e5c669b638a1132f2592b19035b4"
+checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2247,9 +2324,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3dda0b6588335f360afc675d0564c17a77a2bda81ca178a4b6081bd86c7f0b"
+checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2257,15 +2334,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c8ff0461b82559810cdccfde3215c3f373807f5e5232b71479bff7bb2583d7"
+checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29d6d2ff5bb10fb95c85b8ce46538a2e5f5e7fdc755623a7d4529ab8a4ed9d2a"
+checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2274,9 +2351,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f9d34af5a1aac6fb380f735fe510746c38067c5bf16c7fd250280503c971b2"
+checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
 
 [[package]]
 name = "futures-lite"
@@ -2295,9 +2372,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dbd947adfffb0efc70599b3ddcf7b5597bb5fa9e245eb99f62b3a5f7bb8bd3c"
+checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2306,21 +2383,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3055baccb68d74ff6480350f8d6eb8fcfa3aa11bdc1a1ae3afdd0514617d508"
+checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
 
 [[package]]
 name = "futures-task"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ee7c6485c30167ce4dfb83ac568a849fe53274c831081476ee13e0dce1aad72"
+checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
 
 [[package]]
 name = "futures-test"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e741bc851e1e90ad08901b329389ae77e02d5e9a0ec61955b80834630fbdc2f"
+checksum = "8c3e9379dbbfb35dd6df79e895d73c0f75558827fe68eb853b858ff417a8ee98"
 dependencies = [
  "futures-core",
  "futures-executor",
@@ -2335,9 +2412,9 @@ dependencies = [
 
 [[package]]
 name = "futures-util"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b5cf40b47a271f77a8b1bec03ca09044d99d2372c0de244e66430761127164"
+checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
 dependencies = [
  "futures 0.1.31",
  "futures-channel",
@@ -2734,9 +2811,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9de88456263e249e241fcd211d3954e2c9b0ef7ccfc235a444eb367cae3689"
+checksum = "d9f1f717ddc7b2ba36df7e871fd88db79326551d3d6f1fc406fbfd28b582ff8e"
 dependencies = [
  "bytes 1.1.0",
  "fnv",
@@ -2746,7 +2823,7 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio 1.15.0",
+ "tokio 1.16.1",
  "tokio-util",
  "tracing",
 ]
@@ -2773,9 +2850,9 @@ dependencies = [
 
 [[package]]
 name = "headers"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c4eb0471fcb85846d8b0690695ef354f9afb11cb03cac2e1d7c9253351afb0"
+checksum = "c84c647447a07ca16f5fbd05b633e535cc41a08d2d74ab1e08648df53be9cb89"
 dependencies = [
  "base64 0.13.0",
  "bitflags 1.3.2",
@@ -2876,9 +2953,9 @@ checksum = "eee9694f83d9b7c09682fdb32213682939507884e5bcf227be9aff5d644b90dc"
 
 [[package]]
 name = "httparse"
-version = "1.5.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acd94fdbe1d4ff688b67b04eee2e17bd50995534a61539e45adfefb45e5e5503"
+checksum = "9100414882e15fb7feccb4897e5f0ff0ff1ca7d1a86a23208ada4d7a18e6c6c4"
 
 [[package]]
 name = "httpdate"
@@ -2919,7 +2996,7 @@ dependencies = [
  "itoa 0.4.8",
  "pin-project-lite 0.2.8",
  "socket2",
- "tokio 1.15.0",
+ "tokio 1.16.1",
  "tower-service",
  "tracing",
  "want",
@@ -2933,7 +3010,7 @@ checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
  "hyper",
  "pin-project-lite 0.2.8",
- "tokio 1.15.0",
+ "tokio 1.16.1",
  "tokio-io-timeout",
 ]
 
@@ -2946,7 +3023,7 @@ dependencies = [
  "bytes 1.1.0",
  "hyper",
  "native-tls",
- "tokio 1.15.0",
+ "tokio 1.16.1",
  "tokio-native-tls",
 ]
 
@@ -2960,7 +3037,7 @@ dependencies = [
  "hex",
  "hyper",
  "pin-project 1.0.10",
- "tokio 1.15.0",
+ "tokio 1.16.1",
 ]
 
 [[package]]
@@ -3007,7 +3084,7 @@ version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "713f1b139373f96a2e0ce3ac931cd01ee973c3c5dd7c40c0c2efe96ad2b6751d"
 dependencies = [
- "crossbeam-utils 0.8.6",
+ "crossbeam-utils 0.8.7",
  "globset",
  "lazy_static 1.4.0",
  "log",
@@ -3039,7 +3116,7 @@ version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg 1.1.0",
  "hashbrown",
 ]
 
@@ -3187,7 +3264,7 @@ checksum = "8eb2522ff59fbfefb955e9bd44d04d5e5c2d0e8865bfc2c3d1ab3916183ef5ee"
 dependencies = [
  "pest",
  "pest_derive",
- "serde 1.0.135",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -3197,7 +3274,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f8423b78fc94d12ef1a4a9d13c348c9a78766dda0cc18817adf0faf77e670c8"
 dependencies = [
  "base64-compat",
- "serde 1.0.135",
+ "serde 1.0.136",
  "serde_derive",
  "serde_json",
 ]
@@ -3266,9 +3343,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.113"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eef78b64d87775463c549fbd80e19249ef436ea3bf1de2a1eb7e717ec7fab1e9"
+checksum = "e74d72e0f9b65b5b4ca49a346af3976df0f9c61d550727f349ecd559f251a26c"
 
 [[package]]
 name = "libgit2-sys"
@@ -3313,9 +3390,9 @@ checksum = "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a"
 
 [[package]]
 name = "libm"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
+checksum = "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db"
 
 [[package]]
 name = "libsqlite3-sys"
@@ -3436,9 +3513,9 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
+checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
 dependencies = [
  "scopeguard",
 ]
@@ -3450,7 +3527,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if 1.0.0",
- "serde 1.0.135",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -3473,7 +3550,7 @@ dependencies = [
  "libc",
  "log",
  "log-mdc",
- "serde 1.0.135",
+ "serde 1.0.136",
  "serde-value 0.5.3",
  "serde_derive",
  "serde_yaml",
@@ -3499,7 +3576,7 @@ dependencies = [
  "log-mdc",
  "parking_lot 0.11.2",
  "regex",
- "serde 1.0.135",
+ "serde 1.0.136",
  "serde-value 0.7.0",
  "serde_json",
  "serde_yaml",
@@ -3518,10 +3595,10 @@ dependencies = [
  "cfg-if 1.0.0",
  "generator",
  "scoped-tls",
- "serde 1.0.135",
+ "serde 1.0.136",
  "serde_json",
  "tracing",
- "tracing-subscriber 0.3.6",
+ "tracing-subscriber 0.3.8",
 ]
 
 [[package]]
@@ -3618,7 +3695,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg 1.1.0",
 ]
 
 [[package]]
@@ -3692,7 +3769,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
 dependencies = [
  "adler",
- "autocfg 1.0.1",
+ "autocfg 1.1.0",
 ]
 
 [[package]]
@@ -3759,7 +3836,7 @@ dependencies = [
  "fixed-hash",
  "hex",
  "hex-literal",
- "serde 1.0.135",
+ "serde 1.0.136",
  "serde-big-array",
  "thiserror",
  "tiny-keccak",
@@ -3777,7 +3854,7 @@ dependencies = [
  "data-encoding",
  "multihash",
  "percent-encoding 2.1.0",
- "serde 1.0.135",
+ "serde 1.0.136",
  "static_assertions",
  "unsigned-varint",
  "url 2.2.2",
@@ -3830,16 +3907,6 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
-]
-
-[[package]]
-name = "nb-connect"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1bb540dc6ef51cfe1916ec038ce7a620daf3a111e2502d745197cd53d6bca15"
-dependencies = [
- "libc",
- "socket2",
 ]
 
 [[package]]
@@ -3922,19 +3989,6 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50e4785f2c3b7589a0d0c1dd60285e1188adac4006e8abd6dd578e1567027363"
-dependencies = [
- "bitflags 1.3.2",
- "cc",
- "cfg-if 0.1.10",
- "libc",
- "void",
-]
-
-[[package]]
-name = "nix"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f866317acbd3a240710c63f065ffb1e4fd466259045ccb504130b7f668f35c6"
@@ -3981,12 +4035,12 @@ dependencies = [
 
 [[package]]
 name = "notify-rust"
-version = "4.5.5"
+version = "4.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca6ebab865e67efdd7182a88d76cadbdd2a8d02d1c7a4e16bb7c234016a12cac"
+checksum = "367e1355a950d3e758e414f3ca1b3981a57a2aa1fa3338eb0059f5b230b6ffa4"
 dependencies = [
  "mac-notification-sys",
- "serde 1.0.135",
+ "serde 1.0.136",
  "winrt-notification",
  "zbus",
  "zvariant",
@@ -4008,7 +4062,7 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg 1.1.0",
  "num-integer",
  "num-traits 0.2.14",
 ]
@@ -4019,15 +4073,15 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d51546d704f52ef14b3c962b5776e53d5b862e5790e40a350d366c209bd7f7a"
 dependencies = [
- "autocfg 0.1.7",
+ "autocfg 0.1.8",
  "byteorder",
  "lazy_static 1.4.0",
- "libm 0.2.1",
+ "libm 0.2.2",
  "num-integer",
  "num-iter",
  "num-traits 0.2.14",
  "rand 0.7.3",
- "serde 1.0.135",
+ "serde 1.0.136",
  "smallvec",
  "zeroize",
 ]
@@ -4059,7 +4113,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg 1.1.0",
  "num-traits 0.2.14",
 ]
 
@@ -4069,7 +4123,7 @@ version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg 1.1.0",
  "num-integer",
  "num-traits 0.2.14",
 ]
@@ -4080,7 +4134,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg 1.1.0",
  "num-integer",
  "num-traits 0.2.14",
 ]
@@ -4100,7 +4154,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg 1.1.0",
 ]
 
 [[package]]
@@ -4132,6 +4186,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97ba99ba6393e2c3734791401b66902d981cb03bf190af674ca69949b6d5fb15"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -4226,7 +4289,7 @@ version = "0.9.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1996d2d305e561b70d1ee0c53f1542833f4e1ac6ce9a6708b6ff2738ca67dc82"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg 1.1.0",
  "cc",
  "libc",
  "openssl-src",
@@ -4242,14 +4305,14 @@ checksum = "e1cf9b1c4e9a6c4de793c632496fa490bdc0e1eea73f0c91394f7b6990935d22"
 dependencies = [
  "async-trait",
  "crossbeam-channel 0.5.2",
- "futures 0.3.19",
+ "futures 0.3.21",
  "js-sys",
  "lazy_static 1.4.0",
  "percent-encoding 2.1.0",
  "pin-project 1.0.10",
  "rand 0.8.4",
  "thiserror",
- "tokio 1.15.0",
+ "tokio 1.16.1",
  "tokio-stream",
 ]
 
@@ -4283,7 +4346,7 @@ dependencies = [
  "reqwest",
  "thiserror",
  "thrift",
- "tokio 1.15.0",
+ "tokio 1.16.1",
 ]
 
 [[package]]
@@ -4314,13 +4377,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "os_info"
-version = "3.1.0"
+name = "ordered-stream"
+version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "198e392be7e882f0c2836f425e430f81d9a0e99651e4646311347417cddbfd43"
+checksum = "44630c059eacfd6e08bdaa51b1db2ce33119caa4ddc1235e923109aa5f25ccb1"
+dependencies = [
+ "futures-core",
+ "pin-project-lite 0.2.8",
+]
+
+[[package]]
+name = "os_info"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "023df84d545ef479cf67fd2f4459a613585c9db4852c2fad12ab70587859d340"
 dependencies = [
  "log",
- "serde 1.0.135",
+ "serde 1.0.136",
  "winapi 0.3.9",
 ]
 
@@ -4342,11 +4415,11 @@ checksum = "afb2e1c3ee07430c2cf76151675e583e0f19985fa6efae47d6848a3e2c824f85"
 
 [[package]]
 name = "packed_simd_2"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c0c06716cfc81616fa8e22b721ce92fecd594508bc0eb3d04ae3ef35ac10c5"
+checksum = "defdcfef86dcc44ad208f71d9ff4ce28df6537a4e0d6b0e8e845cb8ca10059a6"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libm 0.1.4",
 ]
 
@@ -4398,7 +4471,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
- "lock_api 0.4.5",
+ "lock_api 0.4.6",
  "parking_lot_core 0.8.5",
 ]
 
@@ -4979,9 +5052,9 @@ dependencies = [
 
 [[package]]
 name = "protobuf"
-version = "2.25.2"
+version = "2.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c327e191621a2158159df97cdbc2e7074bb4e940275e35abf38eb3d2595754"
+checksum = "cf7e6d18738ecd0902d30d1ad232c9125985a3422929b16c65517b38adc14f96"
 
 [[package]]
 name = "qrcode"
@@ -5195,7 +5268,7 @@ version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg 1.1.0",
  "crossbeam-deque",
  "either",
  "rayon-core",
@@ -5209,7 +5282,7 @@ checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
 dependencies = [
  "crossbeam-channel 0.5.2",
  "crossbeam-deque",
- "crossbeam-utils 0.8.6",
+ "crossbeam-utils 0.8.7",
  "lazy_static 1.4.0",
  "num_cpus",
 ]
@@ -5318,10 +5391,10 @@ dependencies = [
  "native-tls",
  "percent-encoding 2.1.0",
  "pin-project-lite 0.2.8",
- "serde 1.0.135",
+ "serde 1.0.136",
  "serde_json",
  "serde_urlencoded 0.7.1",
- "tokio 1.15.0",
+ "tokio 1.16.1",
  "tokio-native-tls",
  "url 2.2.2",
  "wasm-bindgen",
@@ -5397,7 +5470,7 @@ checksum = "011e1d58446e9fa3af7cdc1fb91295b10621d3ac4cb3a85cc86385ee9ca50cd3"
 dependencies = [
  "byteorder",
  "rmp",
- "serde 1.0.135",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -5441,7 +5514,7 @@ dependencies = [
  "base64 0.13.0",
  "blake2b_simd",
  "constant_time_eq",
- "crossbeam-utils 0.8.6",
+ "crossbeam-utils 0.8.7",
 ]
 
 [[package]]
@@ -5477,7 +5550,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.4",
+ "semver 1.0.5",
 ]
 
 [[package]]
@@ -5496,15 +5569,23 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.19.1"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
+checksum = "d37e5e2290f3e040b594b1a9e04377c2c671f1a1cfd9bfdef82106ac1c113f84"
 dependencies = [
- "base64 0.13.0",
  "log",
  "ring",
  "sct",
- "webpki",
+ "webpki 0.22.0",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eebeaeb360c87bfb72e84abdb3447159c0eaececf1bef2aecd65a8be949d1c9"
+dependencies = [
+ "base64 0.13.0",
 ]
 
 [[package]]
@@ -5527,7 +5608,7 @@ dependencies = [
  "libc",
  "log",
  "memchr",
- "nix 0.23.1",
+ "nix",
  "radix_trie",
  "scopeguard",
  "smallvec",
@@ -5601,9 +5682,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "sct"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
  "ring",
  "untrusted",
@@ -5611,12 +5692,12 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d09d3c15d814eda1d6a836f2f2b56a6abc1446c8a34351cb3180d3db92ffe4ce"
+checksum = "2dc14f172faf8a0194a3aded622712b0de276821addc574fa54fc0a1167e10dc"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation 0.9.2",
+ "core-foundation 0.9.3",
  "core-foundation-sys 0.8.3",
  "libc",
  "security-framework-sys",
@@ -5624,9 +5705,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e90dd10c41c6bfc633da6e0c659bd25d31e0791e5974ac42970267d59eba87f7"
+checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
 dependencies = [
  "core-foundation-sys 0.8.3",
  "libc",
@@ -5663,9 +5744,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
+checksum = "0486718e92ec9a68fbed73bb5ef687d71103b142595b406835649bebd33f72c7"
 
 [[package]]
 name = "semver-parser"
@@ -5684,9 +5765,9 @@ checksum = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
 
 [[package]]
 name = "serde"
-version = "1.0.135"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cf9235533494ea2ddcdb794665461814781c53f19d87b76e571a1c35acbad2b"
+checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
 dependencies = [
  "serde_derive",
 ]
@@ -5697,7 +5778,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18b20e7752957bbe9661cff4e0bb04d183d0948cdab2ea58cdb9df36a61dfe62"
 dependencies = [
- "serde 1.0.135",
+ "serde 1.0.136",
  "serde_derive",
 ]
 
@@ -5733,7 +5814,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a663f873dedc4eac1a559d4c6bc0d0b2c34dc5ac4702e105014b8281489e44f"
 dependencies = [
  "ordered-float 1.1.1",
- "serde 1.0.135",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -5743,14 +5824,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
 dependencies = [
  "ordered-float 2.10.0",
- "serde 1.0.135",
+ "serde 1.0.136",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.135"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dcde03d87d4c973c04be249e7d8f0b35db1c848c487bd43032808e59dd8328d"
+checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5765,7 +5846,7 @@ checksum = "d23c1ba4cf0efd44be32017709280b32d1cea5c3f1275c3b6d9e8bc54f758085"
 dependencies = [
  "itoa 1.0.1",
  "ryu",
- "serde 1.0.135",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -5796,7 +5877,7 @@ checksum = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
 dependencies = [
  "dtoa",
  "itoa 0.4.8",
- "serde 1.0.135",
+ "serde 1.0.136",
  "url 2.2.2",
 ]
 
@@ -5809,17 +5890,17 @@ dependencies = [
  "form_urlencoded",
  "itoa 1.0.1",
  "ryu",
- "serde 1.0.135",
+ "serde 1.0.136",
 ]
 
 [[package]]
 name = "serde_with"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad6056b4cb69b6e43e3a0f055def223380baecc99da683884f205bf347f7c4b3"
+checksum = "ec1e6ec4d8950e5b1e894eac0d360742f3b1407a6078a604a731c4b3f49cefbc"
 dependencies = [
  "rustversion",
- "serde 1.0.135",
+ "serde 1.0.136",
  "serde_with_macros",
 ]
 
@@ -5843,7 +5924,7 @@ checksum = "a4a521f2940385c165a24ee286aa8599633d162077a54bdcae2a6fd5a7bfa7a0"
 dependencies = [
  "indexmap",
  "ryu",
- "serde 1.0.135",
+ "serde 1.0.136",
  "yaml-rust",
 ]
 
@@ -6033,9 +6114,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f82496b90c36d70af5fcd482edaa2e0bd16fade569de1330405fecbbdac736b"
+checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
 dependencies = [
  "libc",
  "winapi 0.3.9",
@@ -6097,16 +6178,16 @@ checksum = "d44a3643b4ff9caf57abcee9c2c621d6c03d9135e0d8b589bd9afb5992cb176a"
 
 [[package]]
 name = "string_cache"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "923f0f39b6267d37d23ce71ae7235602134b250ace715dd2c90421998ddac0c6"
+checksum = "33994d0838dc2d152d17a62adf608a869b5e846b65b389af7f3dbc1de45c5b26"
 dependencies = [
  "lazy_static 1.4.0",
  "new_debug_unreachable",
  "parking_lot 0.11.2",
- "phf_shared 0.8.0",
+ "phf_shared 0.10.0",
  "precomputed-hash",
- "serde 1.0.135",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -6323,7 +6404,7 @@ dependencies = [
  "cairo-rs",
  "cc",
  "cocoa",
- "core-foundation 0.9.2",
+ "core-foundation 0.9.3",
  "core-graphics 0.22.3",
  "core-video-sys",
  "crossbeam-channel 0.5.2",
@@ -6346,7 +6427,7 @@ dependencies = [
  "parking_lot 0.11.2",
  "raw-window-handle 0.3.4",
  "scopeguard",
- "serde 1.0.135",
+ "serde 1.0.136",
  "unicode-segmentation",
  "winapi 0.3.9",
  "x11-dl",
@@ -6385,11 +6466,11 @@ version = "0.27.3"
 dependencies = [
  "config 0.9.3",
  "dirs-next 1.0.2",
- "futures 0.3.19",
+ "futures 0.3.21",
  "json5",
  "log",
  "rand 0.8.4",
- "serde 1.0.135",
+ "serde 1.0.136",
  "structopt",
  "tari_common",
  "tari_common_types",
@@ -6398,7 +6479,7 @@ dependencies = [
  "tari_p2p",
  "tari_utilities",
  "thiserror",
- "tokio 1.15.0",
+ "tokio 1.16.1",
 ]
 
 [[package]]
@@ -6410,7 +6491,7 @@ dependencies = [
  "chrono",
  "config 0.9.3",
  "either",
- "futures 0.3.19",
+ "futures 0.3.21",
  "log",
  "log-mdc",
  "num_cpus",
@@ -6437,7 +6518,7 @@ dependencies = [
  "tari_shutdown",
  "tari_utilities",
  "thiserror",
- "tokio 1.15.0",
+ "tokio 1.16.1",
  "tonic",
  "tracing",
  "tracing-opentelemetry",
@@ -6457,7 +6538,7 @@ dependencies = [
  "merlin",
  "rand 0.8.4",
  "rand_core 0.6.3",
- "serde 1.0.135",
+ "serde 1.0.136",
  "serde_derive",
  "sha3",
  "subtle-ng",
@@ -6471,12 +6552,12 @@ dependencies = [
  "blake2",
  "diesel",
  "diesel_migrations",
- "futures 0.3.19",
+ "futures 0.3.21",
  "log",
  "prost",
  "prost-types",
  "rand 0.8.4",
- "serde 1.0.135",
+ "serde 1.0.136",
  "serde_json",
  "structopt",
  "tari_app_grpc",
@@ -6491,7 +6572,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "thiserror",
- "tokio 1.15.0",
+ "tokio 1.16.1",
  "tonic",
  "uuid",
 ]
@@ -6511,7 +6592,7 @@ dependencies = [
  "multiaddr",
  "path-clean",
  "prost-build",
- "serde 1.0.135",
+ "serde 1.0.136",
  "serde_json",
  "sha2",
  "structopt",
@@ -6538,11 +6619,11 @@ dependencies = [
  "digest 0.9.0",
  "lazy_static 1.4.0",
  "rand 0.8.4",
- "serde 1.0.135",
+ "serde 1.0.136",
  "tari_crypto",
  "tari_utilities",
  "thiserror",
- "tokio 1.15.0",
+ "tokio 1.16.1",
 ]
 
 [[package]]
@@ -6560,7 +6641,7 @@ dependencies = [
  "data-encoding",
  "digest 0.9.0",
  "env_logger 0.7.1",
- "futures 0.3.19",
+ "futures 0.3.21",
  "lazy_static 1.4.0",
  "lmdb-zero",
  "log",
@@ -6573,7 +6654,7 @@ dependencies = [
  "prost",
  "prost-types",
  "rand 0.8.4",
- "serde 1.0.135",
+ "serde 1.0.136",
  "serde_derive",
  "serde_json",
  "snow",
@@ -6586,7 +6667,7 @@ dependencies = [
  "tari_test_utils 0.27.3",
  "tempfile",
  "thiserror",
- "tokio 1.15.0",
+ "tokio 1.16.1",
  "tokio-stream",
  "tokio-util",
  "tower",
@@ -6608,7 +6689,7 @@ dependencies = [
  "diesel_migrations",
  "digest 0.9.0",
  "env_logger 0.7.1",
- "futures 0.3.19",
+ "futures 0.3.21",
  "futures-test",
  "futures-util",
  "lazy_static 1.4.0",
@@ -6621,7 +6702,7 @@ dependencies = [
  "prost",
  "prost-types",
  "rand 0.8.4",
- "serde 1.0.135",
+ "serde 1.0.136",
  "serde_derive",
  "tari_common",
  "tari_common_sqlite",
@@ -6634,7 +6715,7 @@ dependencies = [
  "tari_utilities",
  "tempfile",
  "thiserror",
- "tokio 1.15.0",
+ "tokio 1.16.1",
  "tokio-stream",
  "tower",
 ]
@@ -6643,14 +6724,14 @@ dependencies = [
 name = "tari_comms_rpc_macros"
 version = "0.27.3"
 dependencies = [
- "futures 0.3.19",
+ "futures 0.3.21",
  "proc-macro2",
  "prost",
  "quote",
  "syn",
  "tari_comms",
  "tari_test_utils 0.27.3",
- "tokio 1.15.0",
+ "tokio 1.16.1",
  "tower-service",
 ]
 
@@ -6662,7 +6743,7 @@ dependencies = [
  "chrono",
  "crossterm 0.17.7",
  "digest 0.9.0",
- "futures 0.3.19",
+ "futures 0.3.21",
  "log",
  "opentelemetry",
  "opentelemetry-jaeger",
@@ -6689,7 +6770,7 @@ dependencies = [
  "tari_utilities",
  "tari_wallet",
  "thiserror",
- "tokio 1.15.0",
+ "tokio 1.16.1",
  "tonic",
  "tracing",
  "tracing-opentelemetry",
@@ -6716,7 +6797,7 @@ dependencies = [
  "digest 0.9.0",
  "env_logger 0.7.1",
  "fs2 0.3.0",
- "futures 0.3.19",
+ "futures 0.3.21",
  "hex",
  "integer-encoding 3.0.2",
  "lmdb-zero",
@@ -6730,7 +6811,7 @@ dependencies = [
  "prost-types",
  "rand 0.8.4",
  "randomx-rs",
- "serde 1.0.135",
+ "serde 1.0.136",
  "serde_json",
  "sha3",
  "strum_macros 0.22.0",
@@ -6750,7 +6831,7 @@ dependencies = [
  "tari_utilities",
  "tempfile",
  "thiserror",
- "tokio 1.15.0",
+ "tokio 1.16.1",
  "tracing",
  "tracing-attributes",
  "uint",
@@ -6771,7 +6852,7 @@ dependencies = [
  "merlin",
  "rand 0.8.4",
  "rmp-serde",
- "serde 1.0.135",
+ "serde 1.0.136",
  "serde_json",
  "sha2",
  "sha3",
@@ -6799,13 +6880,13 @@ dependencies = [
  "bytecodec",
  "clap 2.34.0",
  "digest 0.9.0",
- "futures 0.3.19",
+ "futures 0.3.21",
  "lmdb-zero",
  "log",
  "patricia_tree",
  "prost",
  "prost-types",
- "serde 1.0.135",
+ "serde 1.0.136",
  "serde_json",
  "tari_common",
  "tari_common_types",
@@ -6823,7 +6904,7 @@ dependencies = [
  "tari_test_utils 0.8.1",
  "tari_utilities",
  "thiserror",
- "tokio 1.15.0",
+ "tokio 1.16.1",
  "tokio-stream",
 ]
 
@@ -6842,7 +6923,7 @@ dependencies = [
  "tari_dan_core",
  "tari_utilities",
  "thiserror",
- "tokio 1.15.0",
+ "tokio 1.16.1",
  "tokio-stream",
 ]
 
@@ -6862,7 +6943,7 @@ dependencies = [
  "getrandom 0.2.4",
  "js-sys",
  "rand 0.8.4",
- "serde 1.0.135",
+ "serde 1.0.136",
  "serde_derive",
  "serde_json",
  "sha2",
@@ -6882,10 +6963,10 @@ dependencies = [
  "bollard",
  "config 0.11.0",
  "env_logger 0.9.0",
- "futures 0.3.19",
+ "futures 0.3.21",
  "log",
  "rand 0.8.4",
- "serde 1.0.135",
+ "serde 1.0.136",
  "serde_json",
  "strum 0.23.0",
  "strum_macros 0.23.1",
@@ -6894,7 +6975,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "thiserror",
- "tokio 1.15.0",
+ "tokio 1.16.1",
  "tor-hash-passwd",
 ]
 
@@ -6923,14 +7004,14 @@ dependencies = [
  "chrono",
  "config 0.9.3",
  "env_logger 0.7.1",
- "futures 0.3.19",
+ "futures 0.3.21",
  "hex",
  "hyper",
  "jsonrpc",
  "log",
  "rand 0.8.4",
  "reqwest",
- "serde 1.0.135",
+ "serde 1.0.136",
  "serde_json",
  "structopt",
  "tari_app_grpc",
@@ -6941,7 +7022,7 @@ dependencies = [
  "tari_crypto",
  "tari_utilities",
  "thiserror",
- "tokio 1.15.0",
+ "tokio 1.16.1",
  "tonic",
  "tracing",
  "url 2.2.2",
@@ -6952,13 +7033,13 @@ name = "tari_metrics"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "futures 0.3.19",
+ "futures 0.3.21",
  "log",
  "once_cell",
  "prometheus",
  "reqwest",
  "thiserror",
- "tokio 1.15.0",
+ "tokio 1.16.1",
  "warp",
 ]
 
@@ -6969,7 +7050,7 @@ dependencies = [
  "bufstream",
  "chrono",
  "crossbeam",
- "futures 0.3.19",
+ "futures 0.3.21",
  "hex",
  "log",
  "native-tls",
@@ -6977,7 +7058,7 @@ dependencies = [
  "prost-types",
  "rand 0.8.4",
  "reqwest",
- "serde 1.0.135",
+ "serde 1.0.136",
  "serde_json",
  "sha3",
  "tari_app_grpc",
@@ -6988,7 +7069,7 @@ dependencies = [
  "tari_crypto",
  "tari_utilities",
  "thiserror",
- "tokio 1.15.0",
+ "tokio 1.16.1",
  "tonic",
 ]
 
@@ -7003,7 +7084,7 @@ dependencies = [
  "digest 0.9.0",
  "log",
  "rand 0.8.4",
- "serde 1.0.135",
+ "serde 1.0.136",
  "serde_json",
  "tari_crypto",
  "tari_utilities",
@@ -7019,7 +7100,7 @@ dependencies = [
  "chrono",
  "clap 2.34.0",
  "fs2 0.3.0",
- "futures 0.3.19",
+ "futures 0.3.21",
  "lazy_static 1.4.0",
  "lmdb-zero",
  "log",
@@ -7029,8 +7110,8 @@ dependencies = [
  "rand 0.8.4",
  "reqwest",
  "rustls",
- "semver 1.0.4",
- "serde 1.0.135",
+ "semver 1.0.5",
+ "serde 1.0.136",
  "serde_derive",
  "tari_common",
  "tari_comms",
@@ -7043,12 +7124,12 @@ dependencies = [
  "tari_utilities",
  "tempfile",
  "thiserror",
- "tokio 1.15.0",
+ "tokio 1.16.1",
  "tokio-stream",
  "tower",
  "tower-service",
  "trust-dns-client",
- "webpki",
+ "webpki 0.21.4",
 ]
 
 [[package]]
@@ -7057,13 +7138,13 @@ version = "0.27.3"
 dependencies = [
  "anyhow",
  "async-trait",
- "futures 0.3.19",
+ "futures 0.3.21",
  "futures-test",
  "log",
  "tari_shutdown",
  "tari_test_utils 0.27.3",
  "thiserror",
- "tokio 1.15.0",
+ "tokio 1.16.1",
  "tower",
  "tower-service",
 ]
@@ -7072,8 +7153,8 @@ dependencies = [
 name = "tari_shutdown"
 version = "0.27.3"
 dependencies = [
- "futures 0.3.19",
- "tokio 1.15.0",
+ "futures 0.3.21",
+ "tokio 1.16.1",
 ]
 
 [[package]]
@@ -7084,7 +7165,7 @@ dependencies = [
  "lmdb-zero",
  "log",
  "rand 0.8.4",
- "serde 1.0.135",
+ "serde 1.0.136",
  "serde_derive",
  "tari_utilities",
  "thiserror",
@@ -7096,7 +7177,7 @@ version = "0.27.3"
 dependencies = [
  "hex",
  "libc",
- "serde 1.0.135",
+ "serde 1.0.136",
  "serde_json",
  "tari_common",
  "tari_comms",
@@ -7115,14 +7196,14 @@ dependencies = [
  "chrono",
  "config 0.9.3",
  "env_logger 0.7.1",
- "futures 0.3.19",
+ "futures 0.3.21",
  "hex",
  "hyper",
  "jsonrpc",
  "log",
  "rand 0.7.3",
  "reqwest",
- "serde 1.0.135",
+ "serde 1.0.136",
  "serde_json",
  "structopt",
  "tari_app_grpc",
@@ -7132,7 +7213,7 @@ dependencies = [
  "tari_crypto",
  "tari_utilities",
  "thiserror",
- "tokio 1.15.0",
+ "tokio 1.16.1",
  "tonic",
  "tonic-build",
  "tracing",
@@ -7145,7 +7226,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f11c0804a3f136ad0f821981411215886f0039bf1519c4ec0ec0af8098a8def"
 dependencies = [
- "futures 0.3.19",
+ "futures 0.3.21",
  "futures-test",
  "lazy_static 1.4.0",
  "rand 0.7.3",
@@ -7157,12 +7238,12 @@ dependencies = [
 name = "tari_test_utils"
 version = "0.27.3"
 dependencies = [
- "futures 0.3.19",
+ "futures 0.3.21",
  "futures-test",
  "rand 0.8.4",
  "tari_shutdown",
  "tempfile",
- "tokio 1.15.0",
+ "tokio 1.16.1",
 ]
 
 [[package]]
@@ -7178,7 +7259,7 @@ dependencies = [
  "clear_on_drop",
  "newtype-ops",
  "rand 0.7.3",
- "serde 1.0.135",
+ "serde 1.0.136",
  "serde_json",
  "thiserror",
 ]
@@ -7193,13 +7274,13 @@ dependencies = [
  "bytecodec",
  "clap 2.34.0",
  "digest 0.9.0",
- "futures 0.3.19",
+ "futures 0.3.21",
  "lmdb-zero",
  "log",
  "patricia_tree",
  "prost",
  "prost-types",
- "serde 1.0.135",
+ "serde 1.0.136",
  "serde_json",
  "tari_app_grpc",
  "tari_app_utilities",
@@ -7220,7 +7301,7 @@ dependencies = [
  "tari_storage",
  "tari_test_utils 0.27.3",
  "thiserror",
- "tokio 1.15.0",
+ "tokio 1.16.1",
  "tokio-stream",
  "tonic",
 ]
@@ -7242,14 +7323,14 @@ dependencies = [
  "digest 0.9.0",
  "env_logger 0.7.1",
  "fs2 0.3.0",
- "futures 0.3.19",
+ "futures 0.3.21",
  "libsqlite3-sys",
  "lmdb-zero",
  "log",
  "log4rs 1.0.0",
  "prost",
  "rand 0.8.4",
- "serde 1.0.135",
+ "serde 1.0.136",
  "serde_json",
  "sha2",
  "strum 0.22.0",
@@ -7270,7 +7351,7 @@ dependencies = [
  "tari_utilities",
  "tempfile",
  "thiserror",
- "tokio 1.15.0",
+ "tokio 1.16.1",
  "tower",
 ]
 
@@ -7279,7 +7360,7 @@ name = "tari_wallet_ffi"
 version = "0.27.3"
 dependencies = [
  "chrono",
- "futures 0.3.19",
+ "futures 0.3.21",
  "lazy_static 1.4.0",
  "libc",
  "log",
@@ -7301,7 +7382,7 @@ dependencies = [
  "tari_wallet",
  "tempfile",
  "thiserror",
- "tokio 1.15.0",
+ "tokio 1.16.1",
 ]
 
 [[package]]
@@ -7319,7 +7400,7 @@ dependencies = [
  "either",
  "embed_plist",
  "flate2",
- "futures 0.3.19",
+ "futures 0.3.21",
  "futures-lite",
  "glib",
  "gtk",
@@ -7335,8 +7416,8 @@ dependencies = [
  "rand 0.8.4",
  "raw-window-handle 0.3.4",
  "rfd",
- "semver 1.0.4",
- "serde 1.0.135",
+ "semver 1.0.5",
+ "serde 1.0.136",
  "serde_json",
  "serde_repr",
  "shared_child",
@@ -7348,7 +7429,7 @@ dependencies = [
  "tauri-utils",
  "tempfile",
  "thiserror",
- "tokio 1.15.0",
+ "tokio 1.16.1",
  "url 2.2.2",
  "uuid",
  "zip",
@@ -7379,7 +7460,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "serde 1.0.135",
+ "serde 1.0.136",
  "serde_json",
  "tauri-utils",
  "thiserror",
@@ -7409,7 +7490,7 @@ dependencies = [
  "http",
  "http-range",
  "infer",
- "serde 1.0.135",
+ "serde 1.0.136",
  "serde_json",
  "tauri-utils",
  "thiserror",
@@ -7445,7 +7526,7 @@ dependencies = [
  "phf 0.10.1",
  "proc-macro2",
  "quote",
- "serde 1.0.135",
+ "serde 1.0.136",
  "serde_json",
  "thiserror",
  "url 2.2.2",
@@ -7491,13 +7572,13 @@ name = "test_faucet"
 version = "0.27.3"
 dependencies = [
  "rand 0.8.4",
- "serde 1.0.135",
+ "serde 1.0.136",
  "serde_json",
  "tari_common_types",
  "tari_core",
  "tari_crypto",
  "tari_utilities",
- "tokio 1.15.0",
+ "tokio 1.16.1",
 ]
 
 [[package]]
@@ -7597,6 +7678,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "004cbc98f30fa233c61a38bc77e96a9106e65c88f2d3bef182ae952027e5753d"
+dependencies = [
+ "libc",
+ "num_threads",
+]
+
+[[package]]
 name = "tiny-keccak"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7611,7 +7702,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
- "serde 1.0.135",
+ "serde 1.0.136",
  "serde_json",
 ]
 
@@ -7646,9 +7737,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.15.0"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbbf1c778ec206785635ce8ad57fe52b3009ae9e0c9f574a728f3049d3e55838"
+checksum = "0c27a64b625de6d309e8c57716ba93021dccf1b3b5c97edd6d3dd2d2135afc0a"
 dependencies = [
  "bytes 1.1.0",
  "libc",
@@ -7669,7 +7760,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
 dependencies = [
  "pin-project-lite 0.2.8",
- "tokio 1.15.0",
+ "tokio 1.16.1",
 ]
 
 [[package]]
@@ -7690,18 +7781,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
  "native-tls",
- "tokio 1.15.0",
+ "tokio 1.16.1",
 ]
 
 [[package]]
 name = "tokio-rustls"
-version = "0.22.0"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
+checksum = "a27d5f2b839802bd8267fa19b0530f5a08b9c08cd417976be2a65d130fe1c11b"
 dependencies = [
  "rustls",
- "tokio 1.15.0",
- "webpki",
+ "tokio 1.16.1",
+ "webpki 0.22.0",
 ]
 
 [[package]]
@@ -7712,7 +7803,7 @@ checksum = "50145484efff8818b5ccd256697f36863f587da82cf8b409c53adf1e840798e3"
 dependencies = [
  "futures-core",
  "pin-project-lite 0.2.8",
- "tokio 1.15.0",
+ "tokio 1.16.1",
  "tokio-util",
 ]
 
@@ -7728,7 +7819,7 @@ dependencies = [
  "futures-sink",
  "log",
  "pin-project-lite 0.2.8",
- "tokio 1.15.0",
+ "tokio 1.16.1",
 ]
 
 [[package]]
@@ -7737,7 +7828,7 @@ version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
 dependencies = [
- "serde 1.0.135",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -7746,7 +7837,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
- "serde 1.0.135",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -7770,7 +7861,7 @@ dependencies = [
  "pin-project 1.0.10",
  "prost",
  "prost-derive",
- "tokio 1.15.0",
+ "tokio 1.16.1",
  "tokio-stream",
  "tokio-util",
  "tower",
@@ -7819,7 +7910,7 @@ dependencies = [
  "pin-project-lite 0.2.8",
  "rand 0.8.4",
  "slab",
- "tokio 1.15.0",
+ "tokio 1.16.1",
  "tokio-stream",
  "tokio-util",
  "tower-layer",
@@ -7841,9 +7932,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
+checksum = "2d8d93354fe2a8e50d5953f5ae2e47a3fc2ef03292e7ea46e3cc38f549525fb9"
 dependencies = [
  "cfg-if 1.0.0",
  "log",
@@ -7854,9 +7945,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f480b8f81512e825f337ad51e94c1eb5d3bbdf2b363dcd01e2b19a9ffe3f8e"
+checksum = "8276d9a4a3a558d7b7ad5303ad50b53d58264641b82914b7ada36bd762e7a716"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7865,11 +7956,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
+checksum = "03cfcb51380632a72d3111cb8d3447a8d908e577d31beeac006f836383d29a23"
 dependencies = [
  "lazy_static 1.4.0",
+ "valuable",
 ]
 
 [[package]]
@@ -7908,11 +8000,11 @@ dependencies = [
 
 [[package]]
 name = "tracing-serde"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb65ea441fbb84f9f6748fd496cf7f63ec9af5bca94dd86456978d055e8eb28b"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
 dependencies = [
- "serde 1.0.135",
+ "serde 1.0.136",
  "tracing-core",
 ]
 
@@ -7927,7 +8019,7 @@ dependencies = [
  "lazy_static 1.4.0",
  "matchers 0.0.1",
  "regex",
- "serde 1.0.135",
+ "serde 1.0.136",
  "serde_json",
  "sharded-slab",
  "smallvec",
@@ -7940,9 +8032,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.6"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77be66445c4eeebb934a7340f227bfe7b338173d3f8c00a60a5a58005c9faecf"
+checksum = "74786ce43333fcf51efe947aed9718fbe46d5c7328ec3f1029e818083966d9aa"
 dependencies = [
  "ansi_term",
  "lazy_static 1.4.0",
@@ -7993,12 +8085,11 @@ checksum = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
 
 [[package]]
 name = "trust-dns-client"
-version = "0.21.0-alpha.4"
+version = "0.21.0-alpha.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44bd50900d7796338807398681ed6d8de0c840d0d9aac65cff093b5635b22e57"
+checksum = "b62dfcea87b25f0810e2a527458dd621e252fd8a5827153329308d6e1f252d68"
 dependencies = [
  "cfg-if 1.0.0",
- "chrono",
  "data-encoding",
  "futures-channel",
  "futures-util",
@@ -8009,16 +8100,17 @@ dependencies = [
  "ring",
  "rustls",
  "thiserror",
- "tokio 1.15.0",
+ "time 0.3.7",
+ "tokio 1.16.1",
  "trust-dns-proto",
- "webpki",
+ "webpki 0.22.0",
 ]
 
 [[package]]
 name = "trust-dns-proto"
-version = "0.21.0-alpha.4"
+version = "0.21.0-alpha.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e43c627e8301d45629cdfaf63e2e0c57305a07e9f1ea48208fd262ba2d87eb"
+checksum = "df4689a56fb36e79b76d13f52056c116f1f014afb1bd330162f2d9dc08ef5405"
 dependencies = [
  "async-trait",
  "cfg-if 1.0.0",
@@ -8034,13 +8126,14 @@ dependencies = [
  "rand 0.8.4",
  "ring",
  "rustls",
+ "rustls-pemfile",
  "smallvec",
  "thiserror",
  "tinyvec",
- "tokio 1.15.0",
+ "tokio 1.16.1",
  "tokio-rustls",
  "url 2.2.2",
- "webpki",
+ "webpki 0.22.0",
 ]
 
 [[package]]
@@ -8105,9 +8198,9 @@ checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "uint"
-version = "0.9.1"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6470ab50f482bde894a037a57064480a246dbfdd5960bd65a44824693f08da5f"
+checksum = "12f03af7ccf01dd611cc450a0d10dbc9b745770d096473e2faf0ca6e2d66d1e0"
 dependencies = [
  "byteorder",
  "crunchy",
@@ -8141,9 +8234,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
+checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
 
 [[package]]
 name = "unicode-width"
@@ -8209,7 +8302,7 @@ dependencies = [
  "idna 0.2.3",
  "matches",
  "percent-encoding 2.1.0",
- "serde 1.0.135",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -8231,8 +8324,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
  "getrandom 0.2.4",
- "serde 1.0.135",
+ "serde 1.0.136",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vcpkg"
@@ -8269,12 +8368,6 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "waker-fn"
@@ -8321,10 +8414,10 @@ dependencies = [
  "percent-encoding 2.1.0",
  "pin-project 1.0.10",
  "scoped-tls",
- "serde 1.0.135",
+ "serde 1.0.136",
  "serde_json",
  "serde_urlencoded 0.7.1",
- "tokio 1.15.0",
+ "tokio 1.16.1",
  "tokio-stream",
  "tokio-util",
  "tower-service",
@@ -8350,7 +8443,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25f1af7423d8588a3d840681122e72e6a24ddbcb3f0ec385cac0d12d24256c06"
 dependencies = [
  "cfg-if 1.0.0",
- "serde 1.0.135",
+ "serde 1.0.136",
  "serde_json",
  "wasm-bindgen-macro",
 ]
@@ -8496,6 +8589,16 @@ name = "webpki"
 version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
 dependencies = [
  "ring",
  "untrusted",
@@ -8734,7 +8837,7 @@ dependencies = [
  "objc",
  "objc_id",
  "once_cell",
- "serde 1.0.135",
+ "serde 1.0.136",
  "serde_json",
  "tao",
  "thiserror",
@@ -8808,7 +8911,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7d9028f208dd5e63c614be69f115c1b53cacc1111437d4c765185856666c107"
 dependencies = [
- "futures 0.3.19",
+ "futures 0.3.21",
  "log",
  "nohash-hasher",
  "parking_lot 0.11.2",
@@ -8818,37 +8921,63 @@ dependencies = [
 
 [[package]]
 name = "zbus"
-version = "1.9.1"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2326acc379a3ac4e34b794089f5bdb17086bf29a5fdf619b7b4cc772dc2e9dad"
+checksum = "7bb86f3d4592e26a48b2719742aec94f8ae6238ebde20d98183ee185d1275e9a"
 dependencies = [
+ "async-broadcast",
+ "async-channel",
+ "async-executor",
  "async-io",
+ "async-lock",
+ "async-recursion",
+ "async-task",
+ "async-trait",
  "byteorder",
  "derivative",
  "enumflags2",
- "fastrand",
- "futures 0.3.19",
- "nb-connect",
- "nix 0.17.0",
+ "event-listener",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "hex",
+ "lazy_static 1.4.0",
+ "nix",
  "once_cell",
- "polling",
- "scoped-tls",
- "serde 1.0.135",
+ "ordered-stream",
+ "rand 0.8.4",
+ "serde 1.0.136",
  "serde_repr",
+ "sha1",
+ "static_assertions",
+ "winapi 0.3.9",
  "zbus_macros",
+ "zbus_names",
  "zvariant",
 ]
 
 [[package]]
 name = "zbus_macros"
-version = "1.9.1"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a482c56029e48681b89b92b5db3c446db0915e8dd1052c0328a574eda38d5f93"
+checksum = "36823cc10fddc3c6b19f048903262dacaf8274170e9a255784bdd8b4570a8040"
 dependencies = [
- "proc-macro-crate 0.1.5",
+ "proc-macro-crate 1.1.0",
  "proc-macro2",
  "quote",
+ "regex",
  "syn",
+]
+
+[[package]]
+name = "zbus_names"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45dfcdcf87b71dad505d30cc27b1b7b88a64b6d1c435648f48f9dbc1fdc4b7e1"
+dependencies = [
+ "serde 1.0.136",
+ "static_assertions",
+ "zvariant",
 ]
 
 [[package]]
@@ -8883,7 +9012,7 @@ dependencies = [
  "crc32fast",
  "flate2",
  "thiserror",
- "time",
+ "time 0.1.43",
 ]
 
 [[package]]
@@ -8917,23 +9046,23 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
-version = "2.10.0"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68c7b55f2074489b7e8e07d2d0a6ee6b4f233867a653c664d8020ba53692525"
+checksum = "49ea5dc38b2058fae6a5b79009388143dadce1e91c26a67f984a0fc0381c8033"
 dependencies = [
  "byteorder",
  "enumflags2",
  "libc",
- "serde 1.0.135",
+ "serde 1.0.136",
  "static_assertions",
  "zvariant_derive",
 ]
 
 [[package]]
 name = "zvariant_derive"
-version = "2.10.0"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4ca5e22593eb4212382d60d26350065bf2a02c34b85bc850474a74b589a3de9"
+checksum = "8c2cecc5a61c2a053f7f653a24cd15b3b0195d7f7ddb5042c837fb32e161fb7a"
 dependencies = [
  "proc-macro-crate 1.1.0",
  "proc-macro2",

--- a/base_layer/p2p/Cargo.toml
+++ b/base_layer/p2p/Cargo.toml
@@ -38,8 +38,8 @@ tokio = { version = "1.11", features = ["macros"] }
 tokio-stream = { version = "0.1.7", default-features = false, features = ["time"] }
 tower = "0.4.11"
 tower-service = { version = "0.3.1" }
-trust-dns-client = { version = "0.21.0-alpha.4", features = ["dns-over-rustls"] }
-rustls = "0.19.1"
+trust-dns-client = { version = "=0.21.0-alpha.5", features = ["dns-over-rustls"] }
+rustls = "0.20.2"
 webpki = "0.21"
 
 [dev-dependencies]

--- a/base_layer/p2p/src/auto_update/dns.rs
+++ b/base_layer/p2p/src/auto_update/dns.rs
@@ -208,9 +208,9 @@ mod test {
         let mut record = Record::new();
         record
             .set_record_type(RecordType::TXT)
-            .set_rdata(RData::TXT(rdata::TXT::new(
+            .set_data(Some(RData::TXT(rdata::TXT::new(
                 contents.into_iter().map(ToString::to_string).collect(),
-            )));
+            ))));
 
         mock::message(resp_query, vec![record], vec![], vec![]).into()
     }

--- a/base_layer/p2p/src/dns/error.rs
+++ b/base_layer/p2p/src/dns/error.rs
@@ -32,4 +32,6 @@ pub enum DnsClientError {
     Timeout,
     #[error("Failed to parse name server string")]
     NameServerParseFailed,
+    #[error("No record data present")]
+    NoRecordDataPresent,
 }

--- a/base_layer/p2p/src/peer_seeds.rs
+++ b/base_layer/p2p/src/peer_seeds.rs
@@ -218,9 +218,9 @@ mod test {
             let mut record = Record::new();
             record
                 .set_record_type(RecordType::TXT)
-                .set_rdata(RData::TXT(rdata::TXT::new(
+                .set_data(Some(RData::TXT(rdata::TXT::new(
                     contents.into_iter().map(ToString::to_string).collect(),
-                )));
+                ))));
 
             mock::message(resp_query, vec![record], vec![], vec![]).into()
         }


### PR DESCRIPTION
Description
---
This PR just upgrades the use of the trust-dns-client and rustls to work with the latest version as pinning the specific version was not possible due to trust-dns-client itself not pinning the rustls version.


How Has This Been Tested?
---
updated existing tests
