### PR TITLE
feat: resize base node terminal on startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1484,6 +1484,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossterm"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c85525306c4291d1b73ce93c8acf9c339f9b213aef6c1d85c3830cbf1c16325c"
+dependencies = [
+ "bitflags 1.3.2",
+ "crossterm_winapi 0.9.0",
+ "libc",
+ "mio 0.7.14",
+ "parking_lot 0.11.2",
+ "signal-hook 0.3.13",
+ "signal-hook-mio",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "crossterm_winapi"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1497,6 +1513,15 @@ name = "crossterm_winapi"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a6966607622438301997d3dac0d2f6e9a90c68bb6bc1785ea98456ab93c0507"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ae1b35a484aa10e07fe0638d02301c5ad24de82d310ccbd2f3693da5f09bf1c"
 dependencies = [
  "winapi 0.3.9",
 ]
@@ -6490,6 +6515,7 @@ dependencies = [
  "bincode",
  "chrono",
  "config 0.9.3",
+ "crossterm 0.22.1",
  "either",
  "futures 0.3.21",
  "log",

--- a/applications/tari_base_node/Cargo.toml
+++ b/applications/tari_base_node/Cargo.toml
@@ -27,6 +27,7 @@ anyhow = "1.0.53"
 bincode = "1.3.1"
 chrono = { version = "0.4.19", default-features = false }
 config = { version = "0.9.3" }
+crossterm = "0.22"
 either = "1.6.1"
 futures = { version = "^0.3.16", default-features = false, features = ["alloc"] }
 log = { version = "0.4.8", features = ["std"] }

--- a/applications/tari_base_node/src/cli.rs
+++ b/applications/tari_base_node/src/cli.rs
@@ -20,7 +20,13 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use std::io::stdout;
+
 use chrono::{Datelike, Utc};
+use crossterm::{
+    execute,
+    terminal::{size, SetSize},
+};
 use tari_app_utilities::consts;
 
 /// returns the top or bottom box line of the specified length
@@ -100,6 +106,16 @@ fn multiline_find_display_length(lines: &str) -> usize {
     result
 }
 
+/// Try to resize terminal to make sure the width is enough.
+/// In case of error, just simply print out the error.
+fn resize_terminal_to_fit_the_box(width: usize) {
+    if let Ok((_, rows)) = size() {
+        if let Err(e) = execute!(stdout(), SetSize(width as u16, rows)) {
+            println!("Can't resize terminal to fit the box. Error: {}", e)
+        }
+    }
+}
+
 /// Prints a pretty banner on the console as well as the list of available commands
 pub fn print_banner(commands: Vec<String>, chunk_size: i32) {
     let chunks: Vec<Vec<String>> = commands.chunks(chunk_size as usize).map(|x| x.to_vec()).collect();
@@ -141,6 +157,9 @@ pub fn print_banner(commands: Vec<String>, chunk_size: i32) {
 
     let banner = include!("../assets/tari_banner.rs");
     let target_line_length = multiline_find_display_length(banner);
+
+    resize_terminal_to_fit_the_box(target_line_length);
+
     for line in banner.lines() {
         println!("{}", line);
     }


### PR DESCRIPTION
feat(cli): resolves (#1728) Command Line Resize.

Description
---
Use [crossterm](https://github.com/crossterm-rs/crossterm) crate to resize cli properly.

Motivation and Context
---
My very first `good first issue` to work on tari codebase. ;-)

How Has This Been Tested?
---
Tested on macOS Monterey (12.1).
Works for system Terminal app.
Doesn't work for iTerm2.
