### PR TITLE
feat: adds get-mempool-tx command

### DIFF
--- a/applications/tari_app_utilities/src/utilities.rs
+++ b/applications/tari_app_utilities/src/utilities.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::sync::Arc;
+use std::{convert::TryInto, str::FromStr, sync::Arc};
 
 use futures::future::Either;
 use log::*;
@@ -31,7 +31,10 @@ use tari_common::{
     SocksAuthentication,
     TorControlAuthentication,
 };
-use tari_common_types::{emoji::EmojiId, types::BlockHash};
+use tari_common_types::{
+    emoji::EmojiId,
+    types::{BlockHash, PublicKey},
+};
 use tari_comms::{
     peer_manager::NodeId,
     socks,
@@ -43,6 +46,7 @@ use tari_comms::{
 };
 use tari_p2p::transport::{TorConfig, TransportType};
 use tari_utilities::hex::Hex;
+use thiserror::Error;
 use tokio::{runtime, runtime::Runtime};
 
 use crate::identity_management::load_from_json;
@@ -185,6 +189,7 @@ pub fn parse_hash(hash_string: &str) -> Option<BlockHash> {
     BlockHash::from_hex(hash_string).ok()
 }
 
+// TODO: Use `UniId` instead
 /// Returns a CommsPublicKey from either a emoji id, a public key or node id
 pub fn parse_emoji_id_or_public_key_or_node_id(key: &str) -> Option<Either<CommsPublicKey, NodeId>> {
     parse_emoji_id_or_public_key(key)
@@ -192,9 +197,59 @@ pub fn parse_emoji_id_or_public_key_or_node_id(key: &str) -> Option<Either<Comms
         .or_else(|| NodeId::from_hex(key).ok().map(Either::Right))
 }
 
+// TODO: Use `UniId` instead
 pub fn either_to_node_id(either: Either<CommsPublicKey, NodeId>) -> NodeId {
     match either {
         Either::Left(pk) => NodeId::from_public_key(&pk),
         Either::Right(n) => n,
+    }
+}
+
+pub enum UniId {
+    PublicKey(PublicKey),
+    NodeId(NodeId),
+}
+
+#[derive(Debug, Error)]
+pub enum UniIdError {
+    #[error("unknown id type, expected emoji-id, public-key or node-id")]
+    UnknownIdType,
+    #[error("impossible convert a value to the expected type")]
+    Nonconvertible,
+}
+
+impl FromStr for UniId {
+    type Err = UniIdError;
+
+    fn from_str(key: &str) -> Result<Self, Self::Err> {
+        if let Ok(public_key) = EmojiId::str_to_pubkey(&key.trim().replace('|', "")) {
+            Ok(Self::PublicKey(public_key))
+        } else if let Ok(public_key) = PublicKey::from_hex(key) {
+            Ok(Self::PublicKey(public_key))
+        } else if let Ok(node_id) = NodeId::from_hex(key) {
+            Ok(Self::NodeId(node_id))
+        } else {
+            Err(UniIdError::UnknownIdType)
+        }
+    }
+}
+
+impl TryInto<PublicKey> for UniId {
+    type Error = UniIdError;
+
+    fn try_into(self) -> Result<PublicKey, Self::Error> {
+        match self {
+            UniId::PublicKey(public_key) => Ok(public_key),
+            UniId::NodeId(_) => Err(UniIdError::Nonconvertible),
+        }
+    }
+}
+
+impl From<UniId> for NodeId {
+    fn from(id: UniId) -> Self {
+        match id {
+            UniId::PublicKey(public_key) => NodeId::from_public_key(&public_key),
+            UniId::NodeId(node_id) => node_id,
+        }
     }
 }

--- a/applications/tari_base_node/src/args.rs
+++ b/applications/tari_base_node/src/args.rs
@@ -58,11 +58,12 @@ impl<'a> Args<'a> {
 
     // TODO: It have to return error if a value provided,
     // but can''t be parsed
-    pub fn take_node_id(&mut self) -> Option<NodeId> {
-        self.splitted
-            .next()
-            .and_then(parse_emoji_id_or_public_key_or_node_id)
+    pub fn take_node_id(&mut self) -> Result<NodeId, ArgsError> {
+        let param: String = self.take_next("node-id")?;
+        // TODO: Add and use error from that method
+        parse_emoji_id_or_public_key_or_node_id(&param)
             .map(either_to_node_id)
+            .ok_or_else(|| ArgsError::new("node-id", "can't parse node-id value"))
     }
 
     pub fn try_take_next<T>(&mut self, name: &'static str) -> Result<Option<T>, ArgsError>

--- a/applications/tari_base_node/src/args.rs
+++ b/applications/tari_base_node/src/args.rs
@@ -1,0 +1,77 @@
+use std::{
+    iter::Peekable,
+    str::{FromStr, SplitWhitespace},
+};
+
+use tari_app_utilities::utilities::{either_to_node_id, parse_emoji_id_or_public_key_or_node_id};
+use tari_comms::peer_manager::NodeId;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+#[error("{name} {reason}")]
+pub struct ArgsError {
+    name: &'static str,
+    reason: ArgsReason,
+}
+
+impl ArgsError {
+    pub fn new(name: &'static str, reason: ArgsReason) -> Self {
+        Self { name, reason }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum ArgsReason {
+    #[error("argument required")]
+    Required,
+    #[error("argument can't be parsed: {details}")]
+    NotParsed { details: String },
+}
+
+pub struct Args<'a> {
+    splitted: Peekable<SplitWhitespace<'a>>,
+}
+
+impl<'a> Args<'a> {
+    pub fn split(s: &'a str) -> Self {
+        Self {
+            splitted: s.split_whitespace().peekable(),
+        }
+    }
+
+    pub fn shift_one(&mut self) {
+        self.splitted.next();
+    }
+
+    // TODO: It have to return error if a value provided,
+    // but can''t be parsed
+    pub fn take_node_id(&mut self) -> Option<NodeId> {
+        self.splitted
+            .next()
+            .and_then(parse_emoji_id_or_public_key_or_node_id)
+            .map(either_to_node_id)
+    }
+
+    pub fn try_take_next<T>(&mut self, name: &'static str) -> Result<Option<T>, ArgsError>
+    where
+        T: FromStr,
+        T::Err: ToString,
+    {
+        match self.splitted.peek().map(|s| s.parse()) {
+            Some(Ok(value)) => Ok(Some(value)),
+            Some(Err(err)) => Err(ArgsError::new(name, ArgsReason::NotParsed {
+                details: err.to_string(),
+            })),
+            None => Ok(None),
+        }
+    }
+
+    pub fn take_next<T>(&mut self, name: &'static str) -> Result<T, ArgsError>
+    where
+        T: FromStr,
+        T::Err: ToString,
+    {
+        self.try_take_next(name)?
+            .ok_or_else(|| ArgsError::new(name, ArgsReason::Required))
+    }
+}

--- a/applications/tari_base_node/src/args.rs
+++ b/applications/tari_base_node/src/args.rs
@@ -3,8 +3,6 @@ use std::{
     str::{FromStr, SplitWhitespace},
 };
 
-use tari_app_utilities::utilities::{either_to_node_id, parse_emoji_id_or_public_key_or_node_id};
-use tari_comms::peer_manager::NodeId;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -55,16 +53,6 @@ impl<'a> Args<'a> {
     // TODO: Remove
     pub fn shift_one(&mut self) {
         self.splitted.next();
-    }
-
-    // TODO: It have to return error if a value provided,
-    // but can''t be parsed
-    pub fn take_node_id(&mut self) -> Result<NodeId, ArgsError> {
-        let param: String = self.take_next("node-id")?;
-        // TODO: Add and use error from that method
-        parse_emoji_id_or_public_key_or_node_id(&param)
-            .map(either_to_node_id)
-            .ok_or_else(|| ArgsError::new("node-id", "can't parse node-id value"))
     }
 
     // TODO: Use `next` always

--- a/applications/tari_base_node/src/args.rs
+++ b/applications/tari_base_node/src/args.rs
@@ -52,6 +52,7 @@ impl<'a> Args<'a> {
         }
     }
 
+    // TODO: Remove
     pub fn shift_one(&mut self) {
         self.splitted.next();
     }
@@ -66,6 +67,7 @@ impl<'a> Args<'a> {
             .ok_or_else(|| ArgsError::new("node-id", "can't parse node-id value"))
     }
 
+    // TODO: Use `next` always
     pub fn try_take_next<T>(&mut self, name: &'static str) -> Result<Option<T>, ArgsError>
     where
         T: FromStr,

--- a/applications/tari_base_node/src/args.rs
+++ b/applications/tari_base_node/src/args.rs
@@ -3,6 +3,7 @@ use std::{
     str::{FromStr, SplitWhitespace},
 };
 
+use tari_utilities::hex::{Hex, HexError};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -82,5 +83,15 @@ impl<'a> Args<'a> {
             },
             None => Err(ArgsError::new(name, ArgsReason::Required)),
         }
+    }
+}
+
+pub struct FromHex<T>(pub T);
+
+impl<T: Hex> FromStr for FromHex<T> {
+    type Err = HexError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        T::from_hex(s).map(Self)
     }
 }

--- a/applications/tari_base_node/src/args.rs
+++ b/applications/tari_base_node/src/args.rs
@@ -33,10 +33,10 @@ pub enum ArgsReason {
     Inconsistent { description: String },
 }
 
-impl From<&str> for ArgsReason {
-    fn from(value: &str) -> Self {
+impl<T: AsRef<str>> From<T> for ArgsReason {
+    fn from(value: T) -> Self {
         Self::Inconsistent {
-            description: value.to_owned(),
+            description: value.as_ref().to_owned(),
         }
     }
 }

--- a/applications/tari_base_node/src/command_handler.rs
+++ b/applications/tari_base_node/src/command_handler.rs
@@ -376,12 +376,11 @@ impl CommandHandler {
     }
 
     /// Function to process the get-mempool-state command
-    pub fn get_mempool_state(&self, full: bool, filter: Option<String>) {
+    pub fn get_mempool_state(&self, filter: Option<String>) {
         let mut handler = self.mempool_service.clone();
         self.executor.spawn(async move {
             match handler.get_mempool_state().await {
                 Ok(state) => {
-                    let mut filtered = 0;
                     println!("----------------- Mempool -----------------");
                     println!("--- Unconfirmed Pool ---");
                     for tx in &state.unconfirmed_pool {
@@ -391,13 +390,10 @@ impl CommandHandler {
                             .unwrap_or_else(|| "N/A".to_string());
                         if let Some(ref filter) = filter {
                             if !tx_sig.contains(filter) {
-                                filtered += 1;
+                                println!("--- TX: {} ---", tx_sig);
+                                println!("{}", tx.body);
                                 continue;
                             }
-                        }
-                        if full {
-                            println!("--- TX: {} ---", tx_sig);
-                            println!("{}", tx.body);
                         } else {
                             println!(
                                 "    {} Fee: {}, Outputs: {}, Kernels: {}, Inputs: {}, metadata: {} bytes",
@@ -410,10 +406,7 @@ impl CommandHandler {
                             );
                         }
                     }
-                    if filtered > 0 {
-                        println!("Filtered: {} transaction(s)", filtered);
-                    }
-                    if !full {
+                    if filter.is_none() {
                         println!("--- Reorg Pool ---");
                         for excess_sig in &state.reorg_pool {
                             println!("    {}", excess_sig.get_signature().to_hex());

--- a/applications/tari_base_node/src/macros.rs
+++ b/applications/tari_base_node/src/macros.rs
@@ -1,3 +1,4 @@
+// TODO: Remove this macro
 macro_rules! try_or_print {
     ($e:expr, $($arg:tt)*) => {
         match $e {

--- a/applications/tari_base_node/src/main.rs
+++ b/applications/tari_base_node/src/main.rs
@@ -86,6 +86,7 @@ mod table;
 #[macro_use]
 mod macros;
 
+mod args;
 mod bootstrap;
 mod builder;
 mod cli;

--- a/applications/tari_base_node/src/parser.rs
+++ b/applications/tari_base_node/src/parser.rs
@@ -337,6 +337,7 @@ impl Parser {
             },
             DiscoverPeer => {
                 println!("Attempt to discover a peer on the Tari network");
+                println!("discover-peer [hex public key or emoji id]");
             },
             GetPeer => {
                 println!("Get all available info about peer");
@@ -551,7 +552,6 @@ impl Parser {
             Some(v) => Box::new(v),
             None => {
                 println!("Please enter a valid destination public key or emoji id");
-                println!("discover-peer [hex public key or emoji id]");
                 return;
             },
         };

--- a/applications/tari_base_node/src/parser.rs
+++ b/applications/tari_base_node/src/parser.rs
@@ -34,7 +34,12 @@ use rustyline::{
 use rustyline_derive::{Helper, Highlighter, Validator};
 use strum::IntoEnumIterator;
 use strum_macros::{Display, EnumIter, EnumString};
-use tari_app_utilities::utilities::{either_to_node_id, parse_emoji_id_or_public_key_or_node_id, EmojiIdOrPublicKey};
+use tari_app_utilities::utilities::{
+    either_to_node_id,
+    parse_emoji_id_or_public_key_or_node_id,
+    UniNodeId,
+    UniPublicKey,
+};
 use tari_common_types::types::{Commitment, PrivateKey, PublicKey, Signature};
 use tari_core::proof_of_work::PowAlgorithm;
 use tari_shutdown::Shutdown;
@@ -544,7 +549,7 @@ impl Parser {
 
     /// Function to process the discover-peer command
     async fn process_discover_peer<'a>(&mut self, mut args: Args<'a>) -> Result<(), ArgsError> {
-        let key: EmojiIdOrPublicKey = args.take_next("id")?;
+        let key: UniPublicKey = args.take_next("id")?;
         self.command_handler.lock().await.discover_peer(Box::new(key.into()));
         Ok(())
     }
@@ -581,24 +586,27 @@ impl Parser {
 
     /// Function to process the dial-peer command
     async fn process_dial_peer<'a>(&mut self, mut args: Args<'a>) -> Result<(), ArgsError> {
-        let dest_node_id = args.take_node_id()?;
-        self.command_handler.lock().await.dial_peer(dest_node_id);
+        let dest_node_id: UniNodeId = args.take_next("node-id")?;
+        self.command_handler.lock().await.dial_peer(dest_node_id.into());
         Ok(())
     }
 
     /// Function to process the dial-peer command
     async fn process_ping_peer<'a>(&mut self, mut args: Args<'a>) -> Result<(), ArgsError> {
-        let dest_node_id = args.take_node_id()?;
-        self.command_handler.lock().await.ping_peer(dest_node_id);
+        let dest_node_id: UniNodeId = args.take_next("node-id")?;
+        self.command_handler.lock().await.ping_peer(dest_node_id.into());
         Ok(())
     }
 
     /// Function to process the ban-peer command
     async fn process_ban_peer<'a>(&mut self, mut args: Args<'a>, must_ban: bool) -> Result<(), ArgsError> {
-        let node_id = args.take_node_id()?;
+        let node_id: UniNodeId = args.take_next("node-id")?;
         let secs = args.try_take_next("length")?.unwrap_or(std::u64::MAX);
         let duration = Duration::from_secs(secs);
-        self.command_handler.lock().await.ban_peer(node_id, duration, must_ban);
+        self.command_handler
+            .lock()
+            .await
+            .ban_peer(node_id.into(), duration, must_ban);
         Ok(())
     }
 

--- a/applications/tari_base_node/src/parser.rs
+++ b/applications/tari_base_node/src/parser.rs
@@ -274,7 +274,7 @@ impl Parser {
                 self.command_handler.lock().await.get_mempool_stats();
             },
             GetMempoolState => {
-                self.command_handler.lock().await.get_mempool_state(false, None);
+                self.command_handler.lock().await.get_mempool_state(None);
             },
             GetMempoolTx => {
                 self.get_mempool_state_tx(typed_args).await;
@@ -542,7 +542,7 @@ impl Parser {
 
     async fn get_mempool_state_tx<'a>(&self, mut args: Args<'a>) {
         let filter = args.take_next("filter").ok();
-        self.command_handler.lock().await.get_mempool_state(true, filter)
+        self.command_handler.lock().await.get_mempool_state(filter)
     }
 
     /// Function to process the discover-peer command

--- a/applications/tari_base_node/src/parser.rs
+++ b/applications/tari_base_node/src/parser.rs
@@ -88,6 +88,7 @@ pub enum BaseNodeCommand {
     GetMempoolStats,
     GetMempoolState,
     GetMempoolStateFull,
+    GetMempoolStateTx,
     Whoami,
     GetStateInfo,
     GetNetworkStats,
@@ -275,10 +276,13 @@ impl Parser {
                 self.command_handler.lock().await.get_mempool_stats();
             },
             GetMempoolState => {
-                self.command_handler.lock().await.get_mempool_state(false);
+                self.command_handler.lock().await.get_mempool_state(false, None);
             },
             GetMempoolStateFull => {
-                self.command_handler.lock().await.get_mempool_state(true);
+                self.command_handler.lock().await.get_mempool_state(true, None);
+            },
+            GetMempoolStateTx => {
+                self.get_mempool_state_tx(typed_args).await;
             },
             Whoami => {
                 self.command_handler.lock().await.whoami();
@@ -437,6 +441,9 @@ impl Parser {
             GetMempoolStateFull => {
                 println!("Retrieves your mempools state (full)");
             },
+            GetMempoolStateTx => {
+                println!("Retrieves details about a transaction in the mempool");
+            },
             Whoami => {
                 println!(
                     "Display identity information about this node, including: public key, node ID and the public \
@@ -539,6 +546,11 @@ impl Parser {
         let kernel_sig = Signature::new(public_nonce, signature);
 
         self.command_handler.lock().await.search_kernel(kernel_sig)
+    }
+
+    async fn get_mempool_state_tx<'a>(&self, mut args: Args<'a>) {
+        let filter = args.take_next("filter").ok();
+        self.command_handler.lock().await.get_mempool_state(true, filter)
     }
 
     /// Function to process the discover-peer command

--- a/applications/tari_base_node/src/parser.rs
+++ b/applications/tari_base_node/src/parser.rs
@@ -505,7 +505,7 @@ impl Parser {
     }
 
     async fn process_get_peer<'a>(&mut self, mut args: Args<'a>) -> Result<(), ArgsError> {
-        let original_str: String = args
+        let original_str = args
             .try_take_next("node_id")?
             .ok_or_else(|| ArgsError::new("node_id", ArgsReason::Required))?;
         let node_id: Option<UniNodeId> = args.try_take_next("node_id")?;
@@ -584,9 +584,9 @@ impl Parser {
     }
 
     async fn process_header_stats<'a>(&self, mut args: Args<'a>) -> Result<(), ArgsError> {
-        let start_height: u64 = args.take_next("start_height")?;
-        let end_height: u64 = args.take_next("end_height")?;
-        let filename: String = args
+        let start_height = args.take_next("start_height")?;
+        let end_height = args.take_next("end_height")?;
+        let filename = args
             .try_take_next("filename")?
             .unwrap_or_else(|| "header-data.csv".into());
         let algo: Option<PowAlgorithm> = args.try_take_next("algo")?;

--- a/applications/tari_base_node/src/parser.rs
+++ b/applications/tari_base_node/src/parser.rs
@@ -87,7 +87,7 @@ pub enum BaseNodeCommand {
     SearchKernel,
     GetMempoolStats,
     GetMempoolState,
-    GetMempoolStateTx,
+    GetMempoolTx,
     Whoami,
     GetStateInfo,
     GetNetworkStats,
@@ -277,7 +277,7 @@ impl Parser {
             GetMempoolState => {
                 self.command_handler.lock().await.get_mempool_state(false, None);
             },
-            GetMempoolStateTx => {
+            GetMempoolTx => {
                 self.get_mempool_state_tx(typed_args).await;
             },
             Whoami => {
@@ -434,7 +434,7 @@ impl Parser {
             GetMempoolState => {
                 println!("Retrieves your mempools state");
             },
-            GetMempoolStateTx => {
+            GetMempoolTx => {
                 println!("Filters and retrieves details about transactions from the mempool's state");
             },
             Whoami => {

--- a/applications/tari_base_node/src/parser.rs
+++ b/applications/tari_base_node/src/parser.rs
@@ -86,6 +86,7 @@ pub enum BaseNodeCommand {
     SearchKernel,
     GetMempoolStats,
     GetMempoolState,
+    GetMempoolStateFull,
     Whoami,
     GetStateInfo,
     GetNetworkStats,
@@ -268,7 +269,10 @@ impl Parser {
                 self.command_handler.lock().await.get_mempool_stats();
             },
             GetMempoolState => {
-                self.command_handler.lock().await.get_mempool_state();
+                self.command_handler.lock().await.get_mempool_state(false);
+            },
+            GetMempoolStateFull => {
+                self.command_handler.lock().await.get_mempool_state(true);
             },
             Whoami => {
                 self.command_handler.lock().await.whoami();
@@ -423,6 +427,9 @@ impl Parser {
             },
             GetMempoolState => {
                 println!("Retrieves your mempools state");
+            },
+            GetMempoolStateFull => {
+                println!("Retrieves your mempools state (full)");
             },
             Whoami => {
                 println!(

--- a/applications/tari_base_node/src/parser.rs
+++ b/applications/tari_base_node/src/parser.rs
@@ -639,16 +639,7 @@ impl Parser {
         let filename: String = args
             .try_take_next("filename")?
             .unwrap_or_else(|| "header-data.csv".into());
-
-        // TODO: Replace that with a struct that impl `FromStr`
-        let algo_arg: Option<String> = args.try_take_next("algo")?;
-        let algo_str: Option<&str> = algo_arg.as_ref().map(String::as_ref);
-        let algo = match algo_str {
-            Some("monero") => Some(PowAlgorithm::Monero),
-            Some("sha") | Some("sha3") => Some(PowAlgorithm::Sha3),
-            None | Some("all") => None,
-            _ => return Err(ArgsError::new("algo", "Invalid pow algo")),
-        };
+        let algo: Option<PowAlgorithm> = args.try_take_next("algo")?;
 
         self.command_handler
             .lock()

--- a/applications/tari_base_node/src/parser.rs
+++ b/applications/tari_base_node/src/parser.rs
@@ -87,7 +87,6 @@ pub enum BaseNodeCommand {
     SearchKernel,
     GetMempoolStats,
     GetMempoolState,
-    GetMempoolStateFull,
     GetMempoolStateTx,
     Whoami,
     GetStateInfo,
@@ -278,9 +277,6 @@ impl Parser {
             GetMempoolState => {
                 self.command_handler.lock().await.get_mempool_state(false, None);
             },
-            GetMempoolStateFull => {
-                self.command_handler.lock().await.get_mempool_state(true, None);
-            },
             GetMempoolStateTx => {
                 self.get_mempool_state_tx(typed_args).await;
             },
@@ -438,11 +434,8 @@ impl Parser {
             GetMempoolState => {
                 println!("Retrieves your mempools state");
             },
-            GetMempoolStateFull => {
-                println!("Retrieves your mempools state (full)");
-            },
             GetMempoolStateTx => {
-                println!("Retrieves details about a transaction in the mempool");
+                println!("Filters and retrieves details about transactions from the mempool's state");
             },
             Whoami => {
                 println!(

--- a/base_layer/common_types/src/emoji.rs
+++ b/base_layer/common_types/src/emoji.rs
@@ -29,6 +29,7 @@ use tari_crypto::tari_utilities::{
     hex::{Hex, HexError},
     ByteArray,
 };
+use thiserror::Error;
 
 use crate::{
     luhn::{checksum, is_valid},
@@ -169,7 +170,9 @@ impl Display for EmojiId {
     }
 }
 
-#[derive(Debug)]
+// TODO: We have to add more details
+#[derive(Debug, Error)]
+#[error("emoji id error")]
 pub struct EmojiIdError;
 
 #[cfg(test)]

--- a/base_layer/core/src/mempool/mod.rs
+++ b/base_layer/core/src/mempool/mod.rs
@@ -75,7 +75,6 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "base_node")]
 pub use sync_protocol::MempoolSyncInitializer;
 use tari_common_types::types::Signature;
-use tari_crypto::tari_utilities::hex::Hex;
 
 use crate::transactions::transaction_components::Transaction;
 
@@ -101,32 +100,6 @@ impl Display for StatsResponse {
 pub struct StateResponse {
     pub unconfirmed_pool: Vec<Arc<Transaction>>,
     pub reorg_pool: Vec<Signature>,
-}
-
-impl Display for StateResponse {
-    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
-        writeln!(fmt, "----------------- Mempool -----------------")?;
-        writeln!(fmt, "--- Unconfirmed Pool ---")?;
-        for tx in &self.unconfirmed_pool {
-            writeln!(
-                fmt,
-                "    {} Fee: {}, Outputs: {}, Kernels: {}, Inputs: {}, metadata: {} bytes",
-                tx.first_kernel_excess_sig()
-                    .map(|sig| sig.get_signature().to_hex())
-                    .unwrap_or_else(|| "N/A".to_string()),
-                tx.body.get_total_fee(),
-                tx.body.outputs().len(),
-                tx.body.kernels().len(),
-                tx.body.inputs().len(),
-                tx.body.sum_metadata_size(),
-            )?;
-        }
-        writeln!(fmt, "--- Reorg Pool ---")?;
-        for excess_sig in &self.reorg_pool {
-            writeln!(fmt, "    {}", excess_sig.get_signature().to_hex())?;
-        }
-        Ok(())
-    }
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]

--- a/base_layer/core/src/proof_of_work/proof_of_work_algorithm.rs
+++ b/base_layer/core/src/proof_of_work/proof_of_work_algorithm.rs
@@ -19,9 +19,10 @@
 // SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-use std::convert::TryFrom;
+use std::{convert::TryFrom, str::FromStr};
 
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Hash, Eq)]
@@ -44,7 +45,14 @@ impl PowAlgorithm {
     }
 }
 
+#[derive(Debug, Error)]
+pub enum PowAlgorithmParseError {
+    #[error("unknown pow algorithm type {0}")]
+    UnknownType(String),
+}
+
 impl TryFrom<u64> for PowAlgorithm {
+    // TODO: Use `parse error` here
     type Error = String;
 
     fn try_from(v: u64) -> Result<Self, Self::Error> {
@@ -52,6 +60,18 @@ impl TryFrom<u64> for PowAlgorithm {
             0 => Ok(PowAlgorithm::Monero),
             1 => Ok(PowAlgorithm::Sha3),
             _ => Err("Invalid PoWAlgorithm".into()),
+        }
+    }
+}
+
+impl FromStr for PowAlgorithm {
+    type Err = PowAlgorithmParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "monero" => Ok(Self::Monero),
+            "sha" | "sha3" | "SHA3" => Ok(Self::Sha3),
+            other => Err(PowAlgorithmParseError::UnknownType(other.into())),
         }
     }
 }


### PR DESCRIPTION
Description
---
Adds `get-mempool-state-tx` command that prints detailed information of a transaction.
Also, this PR refactors the commands parser to remove unnecessary type parameters from methods, simplify the code and make easier further switching to crates like `clap` or `nom`.

Motivation and Context
---
For debugging purposes, we need a command to get the full details of a transaction.

How Has This Been Tested?
---
Manually

