### PR TITLE
feat(collectibles): add basic window menu items

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7451,9 +7451,9 @@ dependencies = [
 
 [[package]]
 name = "tauri"
-version = "1.0.0-rc.0"
+version = "1.0.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05cd4bbdc3d855aa78bad4c7c39bf425d51f09d614d75fff2493c70aa89e16f4"
+checksum = "3571de0bcfd1f4f7599cbb3fe42f28ea9f52c3e89914ff04eaba68b5ee36bb51"
 dependencies = [
  "attohttpc",
  "bincode",
@@ -7515,9 +7515,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-codegen"
-version = "1.0.0-rc.0"
+version = "1.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a52763b36186053eeede537589a7373d8a253de5ac4c6235ad104c2c971343ce"
+checksum = "7d06ecdbd6beaf7348259f82885742f013c0c96ac139445ec7c4b8050cd18349"
 dependencies = [
  "base64 0.13.0",
  "blake3",
@@ -7536,9 +7536,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-macros"
-version = "1.0.0-rc.0"
+version = "1.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5493f2bcfc0634e77ace91d83820d4f7f597b94ff2314cd4b3431caf020a5558"
+checksum = "ba9ab86a4e81b31b227800c120b452dae137754e06d75b75c41c06cd06d301e2"
 dependencies = [
  "heck 0.4.0",
  "proc-macro2",
@@ -7550,9 +7550,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be5d4967753541a0d1ac324c50c2c381811fbdc3e743ad0a8b6132f55143ace5"
+checksum = "c683b979ec4841b86048a282cd86afbc13b418a0f546904b27fad06e882ad5d7"
 dependencies = [
  "gtk",
  "http",
@@ -7569,9 +7569,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime-wry"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61854d1fb4ebf92044a9885cf64e04e515fa1d50daa9390a8ab373b7b2a2b21c"
+checksum = "ec025e7c906451fd7ff9e46d106a2e1b5b73e48013d13d52ffce614212b63fdc"
 dependencies = [
  "gtk",
  "ico",
@@ -7587,9 +7587,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-utils"
-version = "1.0.0-rc.0"
+version = "1.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "355ec32fbbc19eadc28adc24a90882e5dac111d779fda60cb05c02b56080df5f"
+checksum = "abcbfec197c4cb959376607ac2fd99cecca02bd6d52b794bd882959501e34533"
 dependencies = [
  "ctor",
  "glob",

--- a/applications/tari_collectibles/src-tauri/Cargo.toml
+++ b/applications/tari_collectibles/src-tauri/Cargo.toml
@@ -24,23 +24,23 @@ tari_key_manager = { path = "../../../base_layer/key_manager" }
 tari_mmr = { path = "../../../base_layer/mmr"}
 tari_utilities = "*"
 tari_dan_common_types = { path = "../../../dan_layer/common_types"}
-log = { version = "0.4.8", features = ["std"] }
 
 blake2 = "^0.9.0"
-futures = "0.3.17"
-rand = "0.8"
-serde_json = "1.0"
-serde = { version = "1.0", features = ["derive"] }
-tonic = "0.6.2"
-tauri = { version = "1.0.0-beta.8", features = ["api-all"] }
 diesel = { version = "1.4.8", features = ["sqlite"] }
 diesel_migrations = "1.4.0"
-thiserror = "1.0.30"
-uuid = {  version = "0.8.2", features = ["serde"] }
+futures = "0.3.17"
+log = { version = "0.4.8", features = ["std"] }
 prost = "0.9"
 prost-types = "0.9"
+rand = "0.8"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 structopt = "0.3.25"
+tauri = { version = "1.0.0-rc.2", features = ["api-all"] }
+thiserror = "1.0.30"
 tokio = { version = "1.11", features = ["signal"] }
+tonic = "0.6.2"
+uuid = {  version = "0.8.2", features = ["serde"] }
 
 [features]
 default = [ "custom-protocol" ]

--- a/applications/tari_collectibles/src-tauri/src/main.rs
+++ b/applications/tari_collectibles/src-tauri/src/main.rs
@@ -4,6 +4,7 @@
 )]
 
 use std::error::Error;
+use tauri::{Menu, MenuItem, Submenu};
 
 use tari_app_utilities::initialization::init_configuration;
 use tari_common::configuration::bootstrap::ApplicationType;
@@ -33,7 +34,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     config.collectibles_config.unwrap_or_default(),
   );
 
-  let result = tauri::Builder::default()
+  tauri::Builder::default()
+    .menu(build_menu())
     .manage(state)
     .invoke_handler(tauri::generate_handler![
       commands::create_db,
@@ -60,5 +62,27 @@ fn main() -> Result<(), Box<dyn Error>> {
     ])
     .run(tauri::generate_context!())?;
 
-  Ok(result)
+  Ok(())
+}
+
+fn build_menu() -> Menu {
+  Menu::new()
+    .add_submenu(Submenu::new(
+      "Tari Collectibles",
+      Menu::new()
+        .add_native_item(MenuItem::Hide)
+        .add_native_item(MenuItem::Quit),
+    ))
+    .add_submenu(Submenu::new(
+      "Edit",
+      Menu::new()
+        .add_native_item(MenuItem::Copy)
+        .add_native_item(MenuItem::Cut)
+        .add_native_item(MenuItem::Paste)
+        .add_native_item(MenuItem::Separator)
+        .add_native_item(MenuItem::Undo)
+        .add_native_item(MenuItem::Redo)
+        .add_native_item(MenuItem::Separator)
+        .add_native_item(MenuItem::SelectAll),
+    ))
 }

--- a/applications/tari_collectibles/src-tauri/tauri.conf.json
+++ b/applications/tari_collectibles/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "package": {
-    "productName": "tari_collectibles",
+    "productName": "Tari Collectibles",
     "version": "0.1.0"
   },
   "build": {
@@ -53,7 +53,7 @@
     },
     "windows": [
       {
-        "title": "tari_collectibles",
+        "title": "Tari Collectibles",
         "width": 1524,
         "height": 800,
         "resizable": true,

--- a/applications/tari_collectibles/web-app/package.json
+++ b/applications/tari_collectibles/web-app/package.json
@@ -7,7 +7,7 @@
     "@emotion/styled": "^11.3.0",
     "@mui/icons-material": "^5.0.3",
     "@mui/material": "^5.0.3",
-    "@tauri-apps/api": "^1.0.0-beta.8",
+    "@tauri-apps/api": "^1.0.0-rc.1",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^11.2.7",
     "@testing-library/user-event": "^12.8.3",


### PR DESCRIPTION
Description
---

- Adds Copy, Cut, Paste, SelectAll, Undo, Redo and Quit to menu items
- Command + ? keys are now working on Mac
- Upgraded Tauri lib to 1.0.0.rc.2

Motivation and Context
---
These are basic and expected features for desktop apps.

Not able to set the mac default menu title, seems that is not currently possible (Ref https://github.com/tauri-apps/tauri/issues/2398)

How Has This Been Tested?
---
Manually
