### PR TITLE
feat(base-node): allow status line interval to be configured

### DIFF
--- a/applications/tari_app_utilities/src/initialization.rs
+++ b/applications/tari_app_utilities/src/initialization.rs
@@ -50,7 +50,7 @@ pub fn init_configuration(
                 if let DatabaseType::LMDB(_) = global_config.db_type {
                     global_config.db_type = DatabaseType::LMDB(global_config.data_dir.join("db"));
                 }
-                global_config.peer_db_path = global_config.data_dir.join("peer_db");
+                global_config.comms_peer_db_path = global_config.data_dir.join("peer_db");
                 global_config.wallet_peer_db_path = global_config.data_dir.join("wallet_peer_db");
                 global_config.console_wallet_peer_db_path = global_config.data_dir.join("console_wallet_peer_db");
             },
@@ -78,8 +78,8 @@ fn check_file_paths(config: &mut GlobalConfig, bootstrap: &ConfigBootstrap) {
             config.db_type = DatabaseType::LMDB(config.data_dir.join("db"));
         }
     }
-    if !config.peer_db_path.is_absolute() {
-        config.peer_db_path = concatenate_paths_normalized(prepend.clone(), config.peer_db_path.clone());
+    if !config.comms_peer_db_path.is_absolute() {
+        config.comms_peer_db_path = concatenate_paths_normalized(prepend.clone(), config.comms_peer_db_path.clone());
     }
     if !config.base_node_identity_file.is_absolute() {
         config.base_node_identity_file =

--- a/applications/tari_base_node/src/bootstrap.rs
+++ b/applications/tari_base_node/src/bootstrap.rs
@@ -83,7 +83,7 @@ where B: BlockchainBackend + 'static
     pub async fn bootstrap(self) -> Result<ServiceHandles, anyhow::Error> {
         let config = self.config;
 
-        fs::create_dir_all(&config.peer_db_path)?;
+        fs::create_dir_all(&config.comms_peer_db_path)?;
 
         let buf_size = cmp::max(BASE_NODE_BUFFER_MIN_SIZE, config.buffer_size_base_node);
         let (publisher, peer_message_subscriptions) = pubsub_connector(buf_size, config.buffer_rate_limit_base_node);
@@ -218,7 +218,7 @@ where B: BlockchainBackend + 'static
         let dht = handles.expect_handle::<Dht>();
         let base_node_service = handles.expect_handle::<LocalNodeCommsInterface>();
         let builder = RpcServer::builder();
-        let builder = match config.rpc_max_simultaneous_sessions {
+        let builder = match config.comms_rpc_max_simultaneous_sessions {
             Some(limit) => builder.with_maximum_simultaneous_sessions(limit),
             None => {
                 warn!(
@@ -256,7 +256,7 @@ where B: BlockchainBackend + 'static
             node_identity: self.node_identity.clone(),
             transport_type: create_transport_type(self.config),
             auxilary_tcp_listener_address: self.config.auxilary_tcp_listener_address.clone(),
-            datastore_path: self.config.peer_db_path.clone(),
+            datastore_path: self.config.comms_peer_db_path.clone(),
             peer_database_name: "peers".to_string(),
             max_concurrent_inbound_tasks: 50,
             max_concurrent_outbound_tasks: 100,
@@ -264,18 +264,18 @@ where B: BlockchainBackend + 'static
             dht: DhtConfig {
                 database_url: DbConnectionUrl::File(self.config.data_dir.join("dht.db")),
                 auto_join: true,
-                allow_test_addresses: self.config.allow_test_addresses,
+                allow_test_addresses: self.config.comms_allow_test_addresses,
                 flood_ban_max_msg_count: self.config.flood_ban_max_msg_count,
                 saf_config: SafConfig {
                     msg_validity: self.config.saf_expiry_duration,
                     ..Default::default()
                 },
-                dedup_cache_capacity: self.config.dedup_cache_capacity,
+                dedup_cache_capacity: self.config.dht_dedup_cache_capacity,
                 ..Default::default()
             },
-            allow_test_addresses: self.config.allow_test_addresses,
-            listener_liveness_allowlist_cidrs: self.config.listener_liveness_allowlist_cidrs.clone(),
-            listener_liveness_max_sessions: self.config.listnener_liveness_max_sessions,
+            allow_test_addresses: self.config.comms_allow_test_addresses,
+            listener_liveness_allowlist_cidrs: self.config.comms_listener_liveness_allowlist_cidrs.clone(),
+            listener_liveness_max_sessions: self.config.comms_listener_liveness_max_sessions,
             user_agent: format!("tari/basenode/{}", env!("CARGO_PKG_VERSION")),
             // Also add sync peers to the peer seed list. Duplicates are acceptable.
             peer_seeds: self

--- a/applications/tari_base_node/src/commands/command_handler.rs
+++ b/applications/tari_base_node/src/commands/command_handler.rs
@@ -73,9 +73,9 @@ use tokio::{
 use super::status_line::StatusLine;
 use crate::{builder::BaseNodeContext, table::Table, utils::format_duration_basic, LOG_TARGET};
 
-pub enum StatusOutput {
+pub enum StatusLineOutput {
     Log,
-    Full,
+    StdOutAndLog,
 }
 
 pub struct CommandHandler {
@@ -117,7 +117,11 @@ impl CommandHandler {
         }
     }
 
-    pub async fn status(&mut self, output: StatusOutput) -> Result<(), Error> {
+    pub fn global_config(&self) -> Arc<GlobalConfig> {
+        self.config.clone()
+    }
+
+    pub async fn status(&mut self, output: StatusLineOutput) -> Result<(), Error> {
         let mut full_log = false;
         if self.last_time_full.elapsed() > Duration::from_secs(120) {
             self.last_time_full = Instant::now();
@@ -182,7 +186,7 @@ impl CommandHandler {
                 "{}/{}",
                 num_active_rpc_sessions,
                 self.config
-                    .rpc_max_simultaneous_sessions
+                    .comms_rpc_max_simultaneous_sessions
                     .as_ref()
                     .map(ToString::to_string)
                     .unwrap_or_else(|| "∞".to_string()),
@@ -201,11 +205,11 @@ impl CommandHandler {
 
         let target = "base_node::app::status";
         match output {
-            StatusOutput::Full => {
+            StatusLineOutput::StdOutAndLog => {
                 println!("{}", status_line);
                 info!(target: target, "{}", status_line);
             },
-            StatusOutput::Log => info!(target: target, "{}", status_line),
+            StatusLineOutput::Log => info!(target: target, "{}", status_line),
         };
         Ok(())
     }

--- a/applications/tari_base_node/src/commands/performer.rs
+++ b/applications/tari_base_node/src/commands/performer.rs
@@ -13,7 +13,7 @@ use tari_utilities::ByteArray;
 
 use super::{
     args::{Args, ArgsError, ArgsReason, FromHex},
-    command_handler::{CommandHandler, StatusOutput},
+    command_handler::{CommandHandler, StatusLineOutput},
     parser::BaseNodeCommand,
 };
 use crate::LOG_TARGET;
@@ -65,7 +65,7 @@ impl Performer {
                 self.print_help(command);
                 Ok(())
             },
-            Status => self.command_handler.status(StatusOutput::Full).await,
+            Status => self.command_handler.status(StatusLineOutput::StdOutAndLog).await,
             GetStateInfo => self.command_handler.state_info(),
             Version => self.command_handler.print_version(),
             CheckForUpdates => self.command_handler.check_for_updates().await,

--- a/applications/tari_console_wallet/src/init/mod.rs
+++ b/applications/tari_console_wallet/src/init/mod.rs
@@ -318,7 +318,7 @@ pub async fn init_wallet(
         "Databases Initialized. Wallet encrypted? {}.", wallet_encrypted
     );
 
-    let node_address = match config.public_address.clone() {
+    let node_address = match config.comms_public_address.clone() {
         Some(addr) => addr,
         None => match wallet_db.get_node_address().await? {
             Some(addr) => addr,
@@ -387,17 +387,17 @@ pub async fn init_wallet(
         dht: DhtConfig {
             database_url: DbConnectionUrl::File(config.data_dir.join("dht-console-wallet.db")),
             auto_join: true,
-            allow_test_addresses: config.allow_test_addresses,
+            allow_test_addresses: config.comms_allow_test_addresses,
             flood_ban_max_msg_count: config.flood_ban_max_msg_count,
             saf_config: SafConfig {
                 msg_validity: config.saf_expiry_duration,
                 ..Default::default()
             },
-            dedup_cache_capacity: config.dedup_cache_capacity,
+            dedup_cache_capacity: config.dht_dedup_cache_capacity,
             ..Default::default()
         },
         // This should be false unless testing locally
-        allow_test_addresses: config.allow_test_addresses,
+        allow_test_addresses: config.comms_allow_test_addresses,
         listener_liveness_allowlist_cidrs: Vec::new(),
         listener_liveness_max_sessions: 0,
         dns_seeds_name_server: DEFAULT_DNS_NAME_SERVER.parse().unwrap(),

--- a/applications/tari_validator_node/src/comms.rs
+++ b/applications/tari_validator_node/src/comms.rs
@@ -111,7 +111,7 @@ fn setup_p2p_rpc(
 ) -> UnspawnedCommsNode {
     let dht = handles.expect_handle::<Dht>();
     let builder = RpcServer::builder();
-    let builder = match config.rpc_max_simultaneous_sessions {
+    let builder = match config.comms_rpc_max_simultaneous_sessions {
         Some(limit) => builder.with_maximum_simultaneous_sessions(limit),
         None => {
             warn!(
@@ -136,7 +136,7 @@ fn create_comms_config(config: &GlobalConfig, node_identity: Arc<NodeIdentity>) 
         network: config.network,
         node_identity,
         transport_type: create_transport_type(config),
-        datastore_path: config.peer_db_path.clone(),
+        datastore_path: config.comms_peer_db_path.clone(),
         peer_database_name: "peers".to_string(),
         max_concurrent_inbound_tasks: 50,
         max_concurrent_outbound_tasks: 100,
@@ -144,7 +144,7 @@ fn create_comms_config(config: &GlobalConfig, node_identity: Arc<NodeIdentity>) 
         dht: DhtConfig {
             database_url: DbConnectionUrl::File(config.data_dir.join("dht.db")),
             auto_join: true,
-            allow_test_addresses: config.allow_test_addresses,
+            allow_test_addresses: config.comms_allow_test_addresses,
             flood_ban_max_msg_count: config.flood_ban_max_msg_count,
             saf_config: SafConfig {
                 msg_validity: config.saf_expiry_duration,
@@ -152,9 +152,9 @@ fn create_comms_config(config: &GlobalConfig, node_identity: Arc<NodeIdentity>) 
             },
             ..Default::default()
         },
-        allow_test_addresses: config.allow_test_addresses,
-        listener_liveness_allowlist_cidrs: config.listener_liveness_allowlist_cidrs.clone(),
-        listener_liveness_max_sessions: config.listnener_liveness_max_sessions,
+        allow_test_addresses: config.comms_allow_test_addresses,
+        listener_liveness_allowlist_cidrs: config.comms_listener_liveness_allowlist_cidrs.clone(),
+        listener_liveness_max_sessions: config.comms_listener_liveness_max_sessions,
         user_agent: format!("tari/dannode/{}", env!("CARGO_PKG_VERSION")),
         // Also add sync peers to the peer seed list. Duplicates are acceptable.
         peer_seeds: config

--- a/applications/tari_validator_node/src/main.rs
+++ b/applications/tari_validator_node/src/main.rs
@@ -97,10 +97,10 @@ async fn run_node(config: GlobalConfig, create_id: bool) -> Result<(), ExitError
         .as_ref()
         .ok_or_else(|| ExitError::new(ExitCode::ConfigError, "validator_node configuration not found"))?;
 
-    fs::create_dir_all(&config.peer_db_path).map_err(|err| ExitError::new(ExitCode::ConfigError, err))?;
+    fs::create_dir_all(&config.comms_peer_db_path).map_err(|err| ExitError::new(ExitCode::ConfigError, err))?;
     let node_identity = setup_node_identity(
         &config.base_node_identity_file,
-        &config.public_address,
+        &config.comms_public_address,
         create_id,
         PeerFeatures::NONE,
     )?;

--- a/common/config/presets/base_node.toml
+++ b/common/config/presets/base_node.toml
@@ -28,10 +28,8 @@
 grpc_enabled = true
 # The socket to expose for the gRPC base node server. This value is ignored if grpc_enabled is false.
 grpc_address = "/ip4/127.0.0.1/tcp/18142"
-
 # Set to true to record all reorgs. Recorded reorgs can be viewed using the list-reorgs command.
 track_reorgs = true
-
 
 # Configuration options for testnet dibbler
 [base_node.dibbler]

--- a/common/src/configuration/collectibles_config.rs
+++ b/common/src/configuration/collectibles_config.rs
@@ -60,7 +60,7 @@ fn default_wallet_grpc_address() -> SocketAddr {
 }
 
 impl CollectiblesConfig {
-    pub fn convert_if_present(cfg: Config) -> Result<Option<CollectiblesConfig>, ConfigurationError> {
+    pub fn convert_if_present(cfg: &Config) -> Result<Option<CollectiblesConfig>, ConfigurationError> {
         let section: Self = match cfg.get("collectibles") {
             Ok(s) => s,
             Err(_e) => {

--- a/common/src/configuration/global.rs
+++ b/common/src/configuration/global.rs
@@ -66,91 +66,92 @@ const DB_RESIZE_THRESHOLD_MIN_MB: i64 = 10;
 pub struct GlobalConfig {
     pub autoupdate_check_interval: Option<Duration>,
     pub autoupdate_dns_hosts: Vec<String>,
-    pub autoupdate_hashes_url: String,
     pub autoupdate_hashes_sig_url: String,
-    pub network: Network,
-    pub comms_transport: CommsTransport,
+    pub autoupdate_hashes_url: String,
     pub auxilary_tcp_listener_address: Option<Multiaddr>,
-    pub allow_test_addresses: bool,
-    pub listnener_liveness_max_sessions: usize,
-    pub listener_liveness_allowlist_cidrs: Vec<String>,
-    pub rpc_max_simultaneous_sessions: Option<usize>,
-    pub data_dir: PathBuf,
-    pub db_type: DatabaseType,
-    pub db_config: LMDBConfig,
-    pub orphan_storage_capacity: usize,
-    pub orphan_db_clean_out_threshold: usize,
-    pub pruning_horizon: u64,
-    pub pruned_mode_cleanup_interval: u64,
-    pub core_threads: Option<usize>,
-    pub base_node_identity_file: PathBuf,
-    pub public_address: Option<Multiaddr>,
+    pub base_node_bypass_range_proof_verification: bool,
     pub base_node_config: Option<BaseNodeConfig>,
-    pub wallet_config: Option<WalletConfig>,
-    pub peer_seeds: Vec<String>,
+    pub base_node_event_channel_size: usize,
+    pub base_node_identity_file: PathBuf,
+    pub base_node_query_timeout: Duration,
+    pub base_node_status_line_interval: Duration,
+    pub base_node_tor_identity_file: PathBuf,
+    pub base_node_use_libtor: bool,
+    pub blockchain_track_reorgs: bool,
+    pub blocks_behind_before_considered_lagging: u64,
+    pub buffer_rate_limit_base_node: usize,
+    pub buffer_rate_limit_console_wallet: usize,
+    pub buffer_size_base_node: usize,
+    pub buffer_size_console_wallet: usize,
+    pub collectibles_config: Option<CollectiblesConfig>,
+    pub comms_allow_test_addresses: bool,
+    pub comms_listener_liveness_allowlist_cidrs: Vec<String>,
+    pub comms_listener_liveness_max_sessions: usize,
+    pub comms_peer_db_path: PathBuf,
+    pub comms_public_address: Option<Multiaddr>,
+    pub comms_rpc_max_simultaneous_sessions: Option<usize>,
+    pub comms_transport: CommsTransport,
+    pub console_wallet_db_file: PathBuf,
+    pub console_wallet_notify_file: Option<PathBuf>,
+    pub console_wallet_password: Option<String>,
+    pub console_wallet_peer_db_path: PathBuf,
+    pub console_wallet_use_libtor: bool,
+    pub contacts_auto_ping_interval: u64,
+    pub core_threads: Option<usize>,
+    pub data_dir: PathBuf,
+    pub db_config: LMDBConfig,
+    pub db_type: DatabaseType,
+    pub dht_dedup_cache_capacity: usize,
     pub dns_seeds: Vec<String>,
     pub dns_seeds_name_server: DnsNameServer,
     pub dns_seeds_use_dnssec: bool,
-    pub peer_db_path: PathBuf,
-    pub num_mining_threads: usize,
-    pub base_node_tor_identity_file: PathBuf,
-    pub wallet_db_file: PathBuf,
-    pub console_wallet_db_file: PathBuf,
-    pub wallet_peer_db_path: PathBuf,
-    pub console_wallet_peer_db_path: PathBuf,
-    pub buffer_size_base_node: usize,
-    pub buffer_size_console_wallet: usize,
-    pub buffer_rate_limit_base_node: usize,
-    pub buffer_rate_limit_console_wallet: usize,
-    pub dedup_cache_capacity: usize,
     pub fetch_blocks_timeout: Duration,
     pub fetch_utxos_timeout: Duration,
-    pub service_request_timeout: Duration,
-    pub base_node_query_timeout: Duration,
-    pub saf_expiry_duration: Duration,
-    pub transaction_broadcast_monitoring_timeout: Duration,
-    pub transaction_chain_monitoring_timeout: Duration,
-    pub transaction_direct_send_timeout: Duration,
-    pub transaction_broadcast_send_timeout: Duration,
-    pub transaction_routing_mechanism: String,
-    pub transaction_num_confirmations_required: u64,
-    pub transaction_event_channel_size: usize,
-    pub base_node_event_channel_size: usize,
-    pub output_manager_event_channel_size: usize,
-    pub wallet_connection_manager_pool_size: usize,
-    pub wallet_recovery_retry_limit: usize,
-    pub console_wallet_password: Option<String>,
-    pub wallet_command_send_wait_stage: String,
-    pub wallet_command_send_wait_timeout: u64,
-    pub wallet_base_node_service_peers: Vec<String>,
-    pub wallet_custom_base_node: Option<String>,
-    pub wallet_base_node_service_refresh_interval: u64,
-    pub wallet_base_node_service_request_max_age: u64,
-    pub wallet_balance_enquiry_cooldown_period: u64,
-    pub prevent_fee_gt_amount: bool,
-    pub transcoder_host_address: SocketAddr,
-    pub proxy_submit_to_origin: bool,
-    pub force_sync_peers: Vec<String>,
-    pub wait_for_initial_sync_at_startup: bool,
-    pub max_randomx_vms: usize,
-    pub console_wallet_notify_file: Option<PathBuf>,
-    pub metadata_auto_ping_interval: u64,
-    pub contacts_auto_ping_interval: u64,
-    pub blocks_behind_before_considered_lagging: u64,
     pub flood_ban_max_msg_count: usize,
+    pub force_sync_peers: Vec<String>,
+    pub max_randomx_vms: usize,
+    pub merge_mining_config: Option<MergeMiningConfig>,
+    pub metadata_auto_ping_interval: u64,
+    pub wallet_peer_db_path: PathBuf,
+    pub metrics: MetricsConfig,
     pub mine_on_tip_only: bool,
-    pub validate_tip_timeout_sec: u64,
-    pub validator_node: Option<ValidatorNodeConfig>,
     pub mining_pool_address: String,
     pub mining_wallet_address: String,
     pub mining_worker_name: String,
-    pub base_node_bypass_range_proof_verification: bool,
-    pub metrics: MetricsConfig,
-    pub base_node_use_libtor: bool,
-    pub console_wallet_use_libtor: bool,
-    pub merge_mining_config: Option<MergeMiningConfig>,
-    pub blockchain_track_reorgs: bool,
-    pub collectibles_config: Option<CollectiblesConfig>,
+    pub network: Network,
+    pub num_mining_threads: usize,
+    pub orphan_db_clean_out_threshold: usize,
+    pub orphan_storage_capacity: usize,
+    pub output_manager_event_channel_size: usize,
+    pub peer_seeds: Vec<String>,
+    pub prevent_fee_gt_amount: bool,
+    pub proxy_submit_to_origin: bool,
+    pub pruned_mode_cleanup_interval: u64,
+    pub pruning_horizon: u64,
+    pub saf_expiry_duration: Duration,
+    pub service_request_timeout: Duration,
+    pub transaction_broadcast_monitoring_timeout: Duration,
+    pub transaction_broadcast_send_timeout: Duration,
+    pub transaction_chain_monitoring_timeout: Duration,
+    pub transaction_direct_send_timeout: Duration,
+    pub transaction_event_channel_size: usize,
+    pub transaction_num_confirmations_required: u64,
+    pub transaction_routing_mechanism: String,
+    pub transcoder_host_address: SocketAddr,
+    pub validate_tip_timeout_sec: u64,
+    pub validator_node: Option<ValidatorNodeConfig>,
+    pub wait_for_initial_sync_at_startup: bool,
+    pub wallet_balance_enquiry_cooldown_period: u64,
+    pub wallet_base_node_service_peers: Vec<String>,
+    pub wallet_recovery_retry_limit: usize,
+    pub wallet_base_node_service_refresh_interval: u64,
+    pub wallet_base_node_service_request_max_age: u64,
+    pub wallet_command_send_wait_stage: String,
+    pub wallet_command_send_wait_timeout: u64,
+    pub wallet_config: Option<WalletConfig>,
+    pub wallet_connection_manager_pool_size: usize,
+    pub wallet_custom_base_node: Option<String>,
+    pub wallet_db_file: PathBuf,
 }
 
 impl GlobalConfig {
@@ -328,11 +329,11 @@ fn convert_node_config(
         .transpose()?;
 
     let key = config_string("base_node", net_str, "allow_test_addresses");
-    let allow_test_addresses = cfg.get_bool(&key).unwrap_or(false);
+    let comms_allow_test_addresses = cfg.get_bool(&key).unwrap_or(false);
 
     // Public address
     let key = config_string("base_node", net_str, "public_address");
-    let public_address = optional(cfg.get_str(&key))?
+    let comms_public_address = optional(cfg.get_str(&key))?
         .map(|addr| {
             addr.parse::<Multiaddr>()
                 .map_err(|e| ConfigurationError::new(&key, Some(addr), &e.to_string()))
@@ -434,7 +435,7 @@ fn convert_node_config(
     let base_node_bypass_range_proof_verification = cfg.get_bool(&key).unwrap_or(false);
 
     // Peer DB path
-    let peer_db_path = data_dir.join("peer_db");
+    let comms_peer_db_path = data_dir.join("peer_db");
     let wallet_peer_db_path = data_dir.join("wallet_peer_db");
     let console_wallet_peer_db_path = data_dir.join("console_wallet_peer_db");
 
@@ -564,7 +565,7 @@ fn convert_node_config(
     };
 
     let key = config_string("wallet", net_str, "custom_base_node");
-    let custom_peer: Option<String> = match cfg.get_int(&key) {
+    let wallet_custom_base_node: Option<String> = match cfg.get_int(&key) {
         Ok(peer) => Some(peer.to_string()),
         Err(ConfigError::NotFound(_)) => None,
         Err(e) => return Err(ConfigurationError::new(&key, None, &e.to_string())),
@@ -598,20 +599,20 @@ fn convert_node_config(
         .map_err(|e| ConfigurationError::new(key, None, &e.to_string()))?;
 
     let key = "common.liveness_max_sessions";
-    let liveness_max_sessions = cfg
+    let comms_listener_liveness_max_sessions = cfg
         .get_int(key)
         .map_err(|e| ConfigurationError::new(key, None, &e.to_string()))?
         .try_into()
         .map_err(|e: TryFromIntError| ConfigurationError::new(key, None, &e.to_string()))?;
 
     let key = "common.liveness_allowlist_cidrs";
-    let liveness_allowlist_cidrs = cfg
+    let comms_listener_liveness_allowlist_cidrs = cfg
         .get_array(key)
         .map(|values| values.iter().map(ToString::to_string).collect())
         .unwrap_or_else(|_| vec!["127.0.0.1/32".to_string()]);
 
     let key = "common.rpc_max_simultaneous_sessions";
-    let rpc_max_simultaneous_sessions = cfg
+    let comms_rpc_max_simultaneous_sessions = cfg
         .get_int(key)
         .map_err(|e| ConfigurationError::new(key, None, &e.to_string()))
         .and_then(|v| match v {
@@ -645,7 +646,7 @@ fn convert_node_config(
             .map_err(|e| ConfigurationError::new(key, None, &e.to_string()))? as usize;
 
     let key = "common.dedup_cache_capacity";
-    let dedup_cache_capacity = cfg
+    let dht_dedup_cache_capacity = cfg
         .get_int(key)
         .map_err(|e| ConfigurationError::new(key, None, &e.to_string()))? as usize;
 
@@ -794,6 +795,11 @@ fn convert_node_config(
     let key = config_string("common", net_str, "auto_update.hashes_sig_url");
     let autoupdate_hashes_sig_url = optional(cfg.get_str(&key))?.unwrap_or_default();
 
+    let key = "base_node. status_line_interval_secs";
+    let base_node_status_line_interval = optional(cfg.get_int(key))?
+        .map(|s| Duration::from_secs(s as u64))
+        .unwrap_or_else(|| Duration::from_secs(30));
+
     let key = "mining_node.mining_pool_address";
     let mining_pool_address = cfg.get_str(key).unwrap_or_else(|_| "".to_string());
     let key = "mining_node.mining_wallet_address";
@@ -812,91 +818,92 @@ fn convert_node_config(
     Ok(GlobalConfig {
         autoupdate_check_interval,
         autoupdate_dns_hosts,
-        autoupdate_hashes_url,
         autoupdate_hashes_sig_url,
-        network,
-        comms_transport,
+        autoupdate_hashes_url,
         auxilary_tcp_listener_address,
-        allow_test_addresses,
-        listnener_liveness_max_sessions: liveness_max_sessions,
-        listener_liveness_allowlist_cidrs: liveness_allowlist_cidrs,
-        rpc_max_simultaneous_sessions,
-        data_dir,
-        db_type,
-        db_config,
-        orphan_storage_capacity,
-        orphan_db_clean_out_threshold,
-        pruning_horizon,
-        pruned_mode_cleanup_interval,
-        core_threads,
-        base_node_identity_file,
-        public_address,
+        base_node_bypass_range_proof_verification,
         base_node_config,
-        wallet_config,
-        peer_seeds,
+        base_node_event_channel_size,
+        base_node_identity_file,
+        base_node_query_timeout,
+        base_node_status_line_interval,
+        base_node_tor_identity_file,
+        base_node_use_libtor,
+        blockchain_track_reorgs,
+        blocks_behind_before_considered_lagging,
+        buffer_rate_limit_base_node,
+        buffer_rate_limit_console_wallet,
+        buffer_size_base_node,
+        buffer_size_console_wallet,
+        collectibles_config: CollectiblesConfig::convert_if_present(&cfg)?,
+        comms_allow_test_addresses,
+        comms_listener_liveness_allowlist_cidrs,
+        comms_listener_liveness_max_sessions,
+        comms_peer_db_path,
+        comms_public_address,
+        comms_rpc_max_simultaneous_sessions,
+        comms_transport,
+        console_wallet_db_file,
+        console_wallet_notify_file,
+        console_wallet_password,
+        console_wallet_peer_db_path,
+        console_wallet_use_libtor,
+        contacts_auto_ping_interval,
+        core_threads,
+        data_dir,
+        db_config,
+        db_type,
+        dht_dedup_cache_capacity,
         dns_seeds,
         dns_seeds_name_server,
         dns_seeds_use_dnssec,
-        peer_db_path,
-        num_mining_threads,
-        base_node_tor_identity_file,
-        wallet_db_file,
-        console_wallet_db_file,
-        wallet_peer_db_path,
-        console_wallet_peer_db_path,
-        buffer_size_base_node,
-        buffer_size_console_wallet,
-        buffer_rate_limit_base_node,
-        buffer_rate_limit_console_wallet,
-        dedup_cache_capacity,
         fetch_blocks_timeout,
         fetch_utxos_timeout,
-        service_request_timeout,
-        base_node_query_timeout,
-        saf_expiry_duration,
-        transaction_broadcast_monitoring_timeout,
-        transaction_chain_monitoring_timeout,
-        transaction_direct_send_timeout,
-        transaction_broadcast_send_timeout,
-        transaction_routing_mechanism,
-        transaction_num_confirmations_required,
-        transaction_event_channel_size,
-        base_node_event_channel_size,
-        wallet_connection_manager_pool_size,
-        wallet_recovery_retry_limit,
-        output_manager_event_channel_size,
-        console_wallet_password,
-        wallet_command_send_wait_stage,
-        wallet_command_send_wait_timeout,
-        wallet_base_node_service_peers,
-        wallet_custom_base_node: custom_peer,
-        wallet_base_node_service_refresh_interval,
-        wallet_base_node_service_request_max_age,
-        wallet_balance_enquiry_cooldown_period,
-        prevent_fee_gt_amount,
-        transcoder_host_address,
-        proxy_submit_to_origin,
-        force_sync_peers,
-        wait_for_initial_sync_at_startup,
-        max_randomx_vms,
-        console_wallet_notify_file,
-        metadata_auto_ping_interval,
-        contacts_auto_ping_interval,
-        blocks_behind_before_considered_lagging,
         flood_ban_max_msg_count,
+        force_sync_peers,
+        max_randomx_vms,
+        merge_mining_config,
+        metadata_auto_ping_interval,
+        metrics,
         mine_on_tip_only,
-        validate_tip_timeout_sec,
-        validator_node: ValidatorNodeConfig::convert_if_present(cfg.clone())?,
         mining_pool_address,
         mining_wallet_address,
         mining_worker_name,
-        base_node_bypass_range_proof_verification,
-        metrics,
-        base_node_use_libtor,
-        console_wallet_use_libtor,
-        merge_mining_config,
-        blockchain_track_reorgs,
-        collectibles_config: CollectiblesConfig::convert_if_present(cfg)?,
+        network,
+        num_mining_threads,
+        orphan_db_clean_out_threshold,
+        orphan_storage_capacity,
+        output_manager_event_channel_size,
+        peer_seeds,
+        prevent_fee_gt_amount,
+        proxy_submit_to_origin,
+        pruned_mode_cleanup_interval,
+        pruning_horizon,
+        saf_expiry_duration,
+        service_request_timeout,
+        transaction_broadcast_monitoring_timeout,
+        transaction_broadcast_send_timeout,
+        transaction_chain_monitoring_timeout,
+        transaction_direct_send_timeout,
+        transaction_event_channel_size,
+        transaction_num_confirmations_required,
+        transaction_routing_mechanism,
+        transcoder_host_address,
+        validate_tip_timeout_sec,
+        validator_node: ValidatorNodeConfig::convert_if_present(&cfg)?,
+        wait_for_initial_sync_at_startup,
+        wallet_balance_enquiry_cooldown_period,
+        wallet_base_node_service_peers,
+        wallet_base_node_service_refresh_interval,
+        wallet_base_node_service_request_max_age,
+        wallet_command_send_wait_stage,
+        wallet_command_send_wait_timeout,
+        wallet_config,
+        wallet_connection_manager_pool_size,
+        wallet_custom_base_node,
+        wallet_db_file,
+        wallet_peer_db_path,
+        wallet_recovery_retry_limit,
     })
 }
 

--- a/common/src/configuration/validator_node_config.rs
+++ b/common/src/configuration/validator_node_config.rs
@@ -68,7 +68,7 @@ fn default_wallet_grpc_address() -> SocketAddr {
 }
 
 impl ValidatorNodeConfig {
-    pub fn convert_if_present(cfg: Config) -> Result<Option<ValidatorNodeConfig>, ConfigurationError> {
+    pub fn convert_if_present(cfg: &Config) -> Result<Option<ValidatorNodeConfig>, ConfigurationError> {
         let section: Self = match cfg.get("validator_node") {
             Ok(s) => s,
             Err(ConfigError::NotFound(_)) => {


### PR DESCRIPTION
Description
---

- Allow status line interval to be configured e.g `base_node.status_line_interval_secs = 10`
- Show status line once immediately on startup
- chore: prefix and sort a few GlobalConfig variables to indicate which subsystem they pertain  
- set defaults for `validator_node.scan_for_assets` and `validator_node.new_asset_scanning_interval`

Motivation and Context
---
There are some cases where you may want to see the status line more often. 

How Has This Been Tested?
---
Manually
