### PR TITLE
chore: update README's "Conversation channels" part

### DIFF
--- a/README.md
+++ b/README.md
@@ -991,12 +991,4 @@ See [RFC-0110/CodeStructure](./RFC/src/RFC-0010_CodeStructure.md) for details on
 
 ## Conversation channels
 
-[<img src="https://ionicons.com/ionicons/svg/md-paper-plane.svg" width="32">](https://t.me/tarilab) Non-technical discussions and gentle sparring.
-
-[<img src="https://ionicons.com/ionicons/svg/logo-reddit.svg" width="32">](https://reddit.com/r/tari/) Forum-style Q&A
-and other Tari-related discussions.
-
-[<img src="https://ionicons.com/ionicons/svg/logo-twitter.svg" width="32">](https://twitter.com/tari) Follow @tari to be
-the first to know about important updates and announcements about the project.
-
-Most of the technical conversation about Tari development happens on [#FreeNode IRC](https://freenode.net/) in the #tari-dev room.
+See https://www.tari.com/#dev-community.


### PR DESCRIPTION
Description
---
Point to the relevant part of the website, so DRY with outdated information (such as IRC part).
