### PR TITLE
fix: remove critical tag from flaky cucumber test

### DIFF
--- a/integration_tests/features/WalletRecovery.feature
+++ b/integration_tests/features/WalletRecovery.feature
@@ -35,7 +35,7 @@ Feature: Wallet Recovery
         Then I stop all wallets
         When I recover all wallets connected to all seed nodes
         Then I wait for recovered wallets to have at least 15000000000 uT
-        @critical
+        
         Examples:
             | NumWallets |
             | 4        |


### PR DESCRIPTION
Description
---

The `Multiple Wallet recovery from seed node` is flaky on CI and the functionality is tested in ` Wallet recovery with connected base node staying online` so the this PR removes the @critical tag from the flaky test


