### PR TITLE
chore: fix cargo udeps warnings in tari_metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,22 +122,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "antidote"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34fde25430d87a9388dadbe6e34d7f72a462c8b43ac8d309b42b0a8505d7e2a5"
-
-[[package]]
 name = "anyhow"
 version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94a45b455c14666b85fc40a019e8ab9eb75e3a124e05494f5397122bc9eb06e0"
-
-[[package]]
-name = "arc-swap"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc4662175ead9cd84451d5c35070517777949a2ed84551764129cedb88384841"
 
 [[package]]
 name = "arc-swap"
@@ -3546,35 +3534,12 @@ checksum = "a94d21414c1f4a51209ad204c1776a3d0765002c76c6abcb602a6f09f1e881c7"
 
 [[package]]
 name = "log4rs"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "100052474df98158c0738a7d3f4249c99978490178b5f9f68cd835ac57adbd1b"
-dependencies = [
- "antidote",
- "arc-swap 0.3.11",
- "chrono",
- "fnv",
- "humantime 1.3.0",
- "libc",
- "log",
- "log-mdc",
- "serde 1.0.136",
- "serde-value 0.5.3",
- "serde_derive",
- "serde_yaml",
- "thread-id",
- "typemap",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "log4rs"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1572a880d1115ff867396eee7ae2bc924554225e67a0d3c85c745b3e60ca211"
 dependencies = [
  "anyhow",
- "arc-swap 0.4.8",
+ "arc-swap",
  "chrono",
  "derivative",
  "fnv",
@@ -3585,7 +3550,7 @@ dependencies = [
  "parking_lot 0.11.2",
  "regex",
  "serde 1.0.136",
- "serde-value 0.7.0",
+ "serde-value",
  "serde_json",
  "serde_yaml",
  "thiserror",
@@ -5823,16 +5788,6 @@ dependencies = [
 
 [[package]]
 name = "serde-value"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a663f873dedc4eac1a559d4c6bc0d0b2c34dc5ac4702e105014b8281489e44f"
-dependencies = [
- "ordered-float 1.1.1",
- "serde 1.0.136",
-]
-
-[[package]]
-name = "serde-value"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
@@ -6652,7 +6607,7 @@ dependencies = [
  "get_if_addrs",
  "git2",
  "log",
- "log4rs 1.0.0",
+ "log4rs",
  "multiaddr",
  "path-clean",
  "prost-build",
@@ -6713,7 +6668,6 @@ dependencies = [
  "multiaddr",
  "nom 5.1.2",
  "once_cell",
- "openssl-sys",
  "pin-project 1.0.10",
  "prost",
  "prost-types",
@@ -7050,7 +7004,7 @@ version = "0.24.0"
 dependencies = [
  "libtor",
  "log",
- "log4rs 1.0.0",
+ "log4rs",
  "multiaddr",
  "rand 0.8.4",
  "tari_common",
@@ -7169,7 +7123,7 @@ dependencies = [
  "lazy_static 1.4.0",
  "lmdb-zero",
  "log",
- "log4rs 0.8.3",
+ "openssl-sys",
  "pgp",
  "prost",
  "rand 0.8.4",
@@ -7392,7 +7346,7 @@ dependencies = [
  "libsqlite3-sys",
  "lmdb-zero",
  "log",
- "log4rs 1.0.0",
+ "log4rs",
  "prost",
  "rand 0.8.4",
  "serde 1.0.136",
@@ -7429,7 +7383,7 @@ dependencies = [
  "lazy_static 1.4.0",
  "libc",
  "log",
- "log4rs 1.0.0",
+ "log4rs",
  "openssl",
  "rand 0.8.4",
  "security-framework",

--- a/base_layer/p2p/Cargo.toml
+++ b/base_layer/p2p/Cargo.toml
@@ -26,6 +26,7 @@ fs2 = "0.3.0"
 futures = { version = "^0.3.1" }
 lmdb-zero = "0.4.4"
 log = "0.4.6"
+openssl-sys = { version = "=0.9.66", features = ["vendored"], optional = true }
 pgp = { version = "0.7.2", optional = true }
 prost = "=0.9.0"
 rand = "0.8"
@@ -49,11 +50,6 @@ clap = "2.33.0"
 lazy_static = "1.3.0"
 tempfile = "3.1.0"
 
-[dev-dependencies.log4rs]
-version = "^0.8"
-features = ["console_appender", "file_appender", "file", "yaml_format"]
-default-features = false
-
 [build-dependencies]
 tari_common = { version = "^0.28", path = "../../common", features = ["build"] }
 
@@ -61,3 +57,6 @@ tari_common = { version = "^0.28", path = "../../common", features = ["build"] }
 test-mocks = []
 auto-update = ["reqwest/default", "pgp"]
 avx2 = ["tari_crypto/avx2"]
+
+[package.metadata.cargo-udeps.ignore]
+normal = ["openssl-sys"]

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -10,31 +10,30 @@ version = "0.28.1"
 edition = "2018"
 
 [features]
-build = ["toml", "anyhow", "prost-build"]
+build = ["toml", "prost-build"]
 static-application-info = ["git2"]
 
 [dependencies]
-structopt = { version = "0.3.13", default_features = false }
+tari_storage = { version = "^0.28", path = "../infrastructure/storage"}
+
+anyhow = "1.0.53"
 config = { version = "0.9.3", default_features = false, features = ["toml"] }
-serde = { version = "1.0.106", default_features = false }
-serde_json = "1.0.51"
 dirs-next = "1.0.2"
+fs2 = "0.4.3"
 get_if_addrs = "0.5.3"
+git2 = { version = "0.8", optional = true }
 log = "0.4.8"
 log4rs = { version = "1.0.0", default_features = false, features = ["config_parsing", "threshold_filter", "yaml_format"] }
 multiaddr = { version = "0.13.0" }
-sha2 = "0.9.5"
 path-clean = "0.1.0"
-tari_storage = { version = "^0.28", path = "../infrastructure/storage"}
-
-anyhow = { version = "1.0.53", optional = true }
-git2 = { version = "0.8", optional = true }
 prost-build = { version = "0.9.0", optional = true }
-toml = { version = "0.5", optional = true }
-thiserror = "1.0.29"
-fs2 = "0.4.3"
+serde = { version = "1.0.106", default_features = false }
+serde_json = "1.0.51"
+sha2 = "0.9.5"
+structopt = { version = "0.3.13", default_features = false }
 tempfile = "3.1.0"
+thiserror = "1.0.29"
+toml = { version = "0.5", optional = true }
 
 [dev-dependencies]
 tari_test_utils = { version = "^0.28", path = "../infrastructure/test_utils"}
-anyhow = "1.0.53"

--- a/comms/Cargo.toml
+++ b/comms/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 
 [dependencies]
 tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", branch = "main" }
+tari_metrics = { path = "../infrastructure/metrics" }
 tari_storage = { version = "^0.28", path = "../infrastructure/storage" }
 tari_shutdown = { version = "^0.28", path = "../infrastructure/shutdown" }
 
@@ -32,7 +33,6 @@ log-mdc = "0.1.0"
 multiaddr = { version = "0.13.0" }
 nom = { version = "5.1.0", features = ["std"], default-features = false }
 once_cell = "1.8.0"
-openssl-sys = { version = "=0.9.66", features = ["vendored"], optional = true }
 pin-project = "1.0.8"
 prost = "=0.9.0"
 prost-types = "0.9.0"
@@ -47,9 +47,6 @@ tokio-util = { version = "0.6.7", features = ["codec", "compat"] }
 tower = {version = "0.4", features = ["util"]}
 tracing = "0.1.26"
 yamux = "=0.9.0"
-
-# Metrics
-tari_metrics = { path = "../infrastructure/metrics" }
 
 [dev-dependencies]
 tari_test_utils = { version = "^0.28", path = "../infrastructure/test_utils" }

--- a/infrastructure/metrics/Cargo.toml
+++ b/infrastructure/metrics/Cargo.toml
@@ -10,18 +10,18 @@ readme = "README.md"
 license = "BSD-3-Clause"
 
 [dependencies]
-log = "0.4.14"
+log = { version = "0.4.14", optional = true }
 once_cell = "1.8.0"
 prometheus = "0.13.0"
 
-futures = { version = "0.3.15", default-features = false, optional = false }
+futures = { version = "0.3.15", default-features = false, optional = true }
 reqwest = { version = "0.11.4", default-features = false, optional = true }
 tokio = { version = "1.7.1", optional = true, features = ["time", "rt-multi-thread"] }
 warp = { version = "0.3.1", optional = true, default-features = false }
 thiserror = "1.0.25"
-anyhow = "1.0.53"
+anyhow = { version = "1.0.53", optional = true }
 
 [features]
 pull = ["warp"]
 push = ["reqwest", "tokio"]
-server = ["pull", "push"]
+server = ["pull", "push", "log", "anyhow", "futures"]


### PR DESCRIPTION
Description
---
- adds `optional` attribute to some dependencies in tari_metrics that are only used with certain features.
- `cargo udeps` no longer gives any warnings about unused dependencies.
- moves openssl-sys vendoring dependency to from comms to tari_p2p (used by tari_p2p dns-seed implementation) 

Motivation and Context
---
`cargo udeps` passes

How Has This Been Tested?
---
cargo +nightly udeps 

