### PR TITLE
ci: add bors config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on:
       - development
       - main
       - ci-*
+      - staging
+      - trying
   pull_request:
     types:
       - opened
@@ -13,9 +15,10 @@ on:
 name: CI
 
 env:
-  CARGO_HTTP_MULTIPLEXING: false
-  PROTOC: protoc
   toolchain: nightly-2021-11-20
+  CARGO_HTTP_MULTIPLEXING: false
+  CARGO_TERM_COLOR: always
+  PROTOC: protoc
 
 jobs:
   clippy:

--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,8 @@
+status = [
+    "clippy",
+    "check nightly",
+    "check stable",
+    "test",
+    "ci/circleci: run-integration-tests",
+    "ci/circleci: run-ffi-integration-tests",
+]


### PR DESCRIPTION
Description
---

- Adds configuration to be able to use [bors](https://bors.tech) in place of mergequeue
- [bors documentation](https://bors.tech/documentation/)
- [example PR merged by bors](https://github.com/delta1/tari/pull/31) on my fork

## **Requires: Installing the [bors github application](https://github.com/apps/bors) into this repo**

