### PR TITLE
ci: bump bors timeout to 2 hours

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,4 +169,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all-features
+          args: -v --all-features

--- a/bors.toml
+++ b/bors.toml
@@ -6,3 +6,4 @@ status = [
     "ci/circleci: run-integration-tests",
     "ci/circleci: run-ffi-integration-tests",
 ]
+timeout_sec = 7200


### PR DESCRIPTION
Description
---

- Increases the bors timeout to 2 hours after observing timeout in #3881 
- Adds `-v` to the CI test run, want to see if that helps the sigkill issue 

