### PR TITLE
feat: update console wallet notifications

### DIFF
--- a/applications/tari_console_wallet/src/ui/components/notification_tab.rs
+++ b/applications/tari_console_wallet/src/ui/components/notification_tab.rs
@@ -29,13 +29,21 @@ impl NotificationTab {
 
     fn draw_notifications<B>(&mut self, f: &mut Frame<B>, area: Rect, app_state: &AppState)
     where B: Backend {
+        let span_vec = vec![
+            Span::raw("Press "),
+            Span::styled("C", Style::default().add_modifier(Modifier::BOLD)),
+            Span::raw(" to clear notifications"),
+        ];
+
+        let instructions = Paragraph::new(Spans::from(span_vec)).wrap(Wrap { trim: false });
+
         let block = Block::default().borders(Borders::ALL).title(Span::styled(
             "Notifications",
             Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
         ));
         f.render_widget(block, area);
         let notifications_area = Layout::default()
-            .constraints([Constraint::Min(42)].as_ref())
+            .constraints([Constraint::Length(1), Constraint::Min(42)].as_ref())
             .margin(1)
             .split(area);
         let text = app_state
@@ -53,7 +61,9 @@ impl NotificationTab {
             })
             .collect::<Vec<_>>();
         let paragraph = Paragraph::new(text).wrap(Wrap { trim: true });
-        f.render_widget(paragraph, notifications_area[0]);
+
+        f.render_widget(instructions, notifications_area[0]);
+        f.render_widget(paragraph, notifications_area[1]);
     }
 }
 
@@ -78,6 +88,12 @@ impl<B: Backend> Component<B> for NotificationTab {
                 Style::default().fg(Color::LightGreen),
             )),
             false => Spans::from(Span::styled(title.to_owned(), Style::default().fg(Color::White))),
+        }
+    }
+
+    fn on_key(&mut self, app_state: &mut AppState, c: char) {
+        if c == 'c' {
+            Handle::current().block_on(app_state.clear_notifications());
         }
     }
 }

--- a/applications/tari_console_wallet/src/ui/components/notification_tab.rs
+++ b/applications/tari_console_wallet/src/ui/components/notification_tab.rs
@@ -4,9 +4,6 @@
 // are cleared.
 // Currently notifications are only added from the wallet_event_monitor which has
 // add_notification method.
-// TODO: auto delete old notifications. #LOGGED
-// TODO: add interaction with the notifications, e.g. if I have a pending transaction
-//       notification, the UI should go there if I click on it. #LOGGED
 
 use tari_comms::runtime::Handle;
 use tui::{

--- a/applications/tari_console_wallet/src/ui/state/app_state.rs
+++ b/applications/tari_console_wallet/src/ui/state/app_state.rs
@@ -529,6 +529,11 @@ impl AppState {
         }
     }
 
+    pub async fn clear_notifications(&mut self) {
+        let mut inner = self.inner.write().await;
+        inner.clear_notifications();
+    }
+
     pub fn get_default_fee_per_gram(&self) -> MicroTari {
         // this should not be empty as we this should have been created, but lets just be safe and use the default value
         // from the config
@@ -958,6 +963,12 @@ impl AppStateInner {
     }
 
     pub fn mark_notifications_as_read(&mut self) {
+        self.data.new_notification_count = 0;
+        self.updated = true;
+    }
+
+    pub fn clear_notifications(&mut self) {
+        self.data.notifications.clear();
         self.data.new_notification_count = 0;
         self.updated = true;
     }

--- a/applications/tari_console_wallet/src/ui/state/wallet_event_monitor.rs
+++ b/applications/tari_console_wallet/src/ui/state/wallet_event_monitor.rs
@@ -96,6 +96,7 @@ impl WalletEventMonitor {
                                         self.trigger_tx_state_refresh(tx_id).await;
                                         self.trigger_balance_refresh();
                                         notifier.transaction_received(tx_id);
+                                        self.add_notification(format!("Finalized Transaction Received - TxId: {}", tx_id)).await;
                                     },
                                     TransactionEvent::TransactionMinedUnconfirmed{tx_id, num_confirmations, is_valid: _}  |
                                     TransactionEvent::FauxTransactionUnconfirmed{tx_id, num_confirmations, is_valid: _}=> {
@@ -103,6 +104,7 @@ impl WalletEventMonitor {
                                         self.trigger_tx_state_refresh(tx_id).await;
                                         self.trigger_balance_refresh();
                                         notifier.transaction_mined_unconfirmed(tx_id, num_confirmations);
+                                        self.add_notification(format!("Transaction Mined Unconfirmed with {} confirmations - TxId: {}", num_confirmations, tx_id)).await;
                                     },
                                     TransactionEvent::TransactionMined{tx_id, is_valid: _} |
                                     TransactionEvent::FauxTransactionConfirmed{tx_id, is_valid: _}=> {
@@ -110,15 +112,28 @@ impl WalletEventMonitor {
                                         self.trigger_tx_state_refresh(tx_id).await;
                                         self.trigger_balance_refresh();
                                         notifier.transaction_mined(tx_id);
+                                        self.add_notification(format!("Transaction Confirmed - TxId: {}", tx_id)).await;
                                     },
                                     TransactionEvent::TransactionCancelled(tx_id, _) => {
                                         self.trigger_tx_state_refresh(tx_id).await;
                                         self.trigger_balance_refresh();
                                         notifier.transaction_cancelled(tx_id);
                                     },
-                                    TransactionEvent::ReceivedTransaction(tx_id) |
-                                    TransactionEvent::ReceivedTransactionReply(tx_id) |
-                                    TransactionEvent::TransactionBroadcast(tx_id) |
+                                    TransactionEvent::ReceivedTransaction(tx_id) => {
+                                        self.trigger_tx_state_refresh(tx_id).await;
+                                        self.trigger_balance_refresh();
+                                        self.add_notification(format!("Transaction Received - TxId: {}", tx_id)).await;
+                                    },
+                                    TransactionEvent::ReceivedTransactionReply(tx_id) => {
+                                        self.trigger_tx_state_refresh(tx_id).await;
+                                        self.trigger_balance_refresh();
+                                        self.add_notification(format!("Transaction Reply Received - TxId: {}", tx_id)).await;
+                                    },
+                                    TransactionEvent::TransactionBroadcast(tx_id) => {
+                                        self.trigger_tx_state_refresh(tx_id).await;
+                                        self.trigger_balance_refresh();
+                                        self.add_notification(format!("Transaction Broadcast to Mempool - TxId: {}", tx_id)).await;
+                                    },
                                     TransactionEvent::TransactionMinedRequestTimedOut(tx_id) |
                                     TransactionEvent::TransactionImported(tx_id)  => {
                                         self.trigger_tx_state_refresh(tx_id).await;


### PR DESCRIPTION
Description
---
This PR creates console wallet notifications for transaction events and also adds a hotkey to clear notifications.

A bug was also spotted in the way that Faux transactions were validated that resulted in the last Faux transaction confirmed event to be emitted after each validation. The validation was updated to only emit this event if the transaction was previously not confirmed.

