### PR TITLE
fix: add bound for number of console_wallet notifications

### DIFF
--- a/applications/tari_console_wallet/src/ui/state/app_state.rs
+++ b/applications/tari_console_wallet/src/ui/state/app_state.rs
@@ -959,6 +959,12 @@ impl AppStateInner {
     pub fn add_notification(&mut self, notification: String) {
         self.data.notifications.push((Local::now(), notification));
         self.data.new_notification_count += 1;
+
+        const MAX_NOTIFICATIONS: usize = 100;
+        if self.data.notifications.len() > MAX_NOTIFICATIONS {
+            let _ = self.data.notifications.remove(0);
+        }
+
         self.updated = true;
     }
 


### PR DESCRIPTION
Description
---
After sleeping on it I realised that notifications in the console wallet have no bound and an unattended wallet will fill its memory with notifications.

The notifications are ephemeral and do not have scrolling so this PR keeps just enough to be trivial in memory but fill a decent sized screen.

