### PR TITLE
fix: revalidate rejected transactions when revalidating wallet database

### DIFF
--- a/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
@@ -1152,8 +1152,9 @@ impl TransactionBackend for TransactionServiceSqliteDatabase {
         let start = Instant::now();
         let conn = self.database_connection.get_pooled_connection()?;
         let acquire_lock = start.elapsed();
-        let result = diesel::update(completed_transactions::table.filter(completed_transactions::cancelled.is_null()))
+        let result = diesel::update(completed_transactions::table)
             .set((
+                completed_transactions::cancelled.eq::<Option<i32>>(None),
                 completed_transactions::mined_height.eq::<Option<i64>>(None),
                 completed_transactions::mined_in_block.eq::<Option<Vec<u8>>>(None),
             ))


### PR DESCRIPTION
Description
---
Changes the revelation SQL query to cause rejected transactions to be invalidated as well. 

Motivation and Context
---
Before this change, a wallet can have funds from a transaction that it believes wrongly was rejected. The revaluation will correctly cause that no funds are lost, but the UI displaying the transactions will still display that the transaction was rejected. This PR will fix this so that the wallet can correctly change this transaction to display mined. 

How Has This Been Tested?
---
Manual
