### PR TITLE
fix: console wallet display correct selected index and detail transaction

### DIFF
--- a/applications/tari_console_wallet/src/ui/components/transactions_tab.rs
+++ b/applications/tari_console_wallet/src/ui/components/transactions_tab.rs
@@ -172,6 +172,12 @@ impl TransactionsTab {
 
         let completed_txs = app_state.get_completed_txs();
         self.completed_list_state.set_num_items(completed_txs.len());
+        if let Some(detailed_tx) = &self.detailed_transaction {
+            if self.selected_tx_list == SelectedTransactionList::CompletedTxs {
+                 let found_index = completed_txs.iter().position(|tx| tx.tx_id == detailed_tx.tx_id);
+                self.completed_list_state.select(found_index);
+            }
+        }
         let mut completed_list_state = self
             .completed_list_state
             .get_list_state((area.height as usize).saturating_sub(3));

--- a/applications/tari_console_wallet/src/ui/components/transactions_tab.rs
+++ b/applications/tari_console_wallet/src/ui/components/transactions_tab.rs
@@ -174,7 +174,7 @@ impl TransactionsTab {
         self.completed_list_state.set_num_items(completed_txs.len());
         if let Some(detailed_tx) = &self.detailed_transaction {
             if self.selected_tx_list == SelectedTransactionList::CompletedTxs {
-                 let found_index = completed_txs.iter().position(|tx| tx.tx_id == detailed_tx.tx_id);
+                let found_index = completed_txs.iter().position(|tx| tx.tx_id == detailed_tx.tx_id);
                 self.completed_list_state.select(found_index);
             }
         }


### PR DESCRIPTION
Description
---
This PR fixes a small bug when a new transaction is displayed in the list. The selected index is updated but the detailed transaction is not. This PR ensures that the selected index is set to the transaction displayed in the detail transaction section.


How Has This Been Tested?
---
manual
