### PR TITLE
fix: update wallet logging config

### DIFF
--- a/common/logging/log4rs_sample_wallet.yml
+++ b/common/logging/log4rs_sample_wallet.yml
@@ -13,14 +13,21 @@ refresh_rate: 30 seconds
 appenders:
 # An appender named "stdout" that writes to file.
   stdout:
-    kind: file
+    kind: rolling_file
     path: "log/wallet/stdout.log"
     append: false
     encoder:
       pattern: "{d(%Y-%m-%d %H:%M:%S.%f)} [{t}] {h({l}):5} {m}{n}"
     filters:
       - kind: threshold
-        level: warn
+        level: info
+    policy:
+      kind: compound
+      trigger:
+        kind: size
+        limit: 10mb
+      roller:
+        kind: delete
         
   # An appender named "network" that writes to a file with a custom pattern encoder
   network:
@@ -77,8 +84,7 @@ appenders:
 root:
   level: info
   appenders:
-    - base_layer
-    - stdout
+    - other
 
 loggers:
   # base_layer
@@ -86,6 +92,7 @@ loggers:
     level: info
     appenders:
       - base_layer
+      - stdout
     additive: false
   # other
   h2:


### PR DESCRIPTION
Description
---
Currently the tracing instrumentation is emitting as log records using the file names as the target. I have no idea how to stop it other than removing the tracing instrumentation. This behaviour is supposed to be an opt in feature but seems broken in Tracing.

So to combat this I updated the Root logger to rather just output to `other.log` which sends all these targetless records there and keeps the really log files clean.

I also updated the stdout appender to be a 10 meg rolling file that is not appended to and pointed the wallet logger at it so that the logging pane in the console wallet gets some useful info again.

