### PR TITLE
ci: revert bors squash merge

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -7,4 +7,3 @@ status = [
     "ci/circleci: run-ffi-integration-tests",
 ]
 timeout_sec = 7200
-use_squash_merge = true


### PR DESCRIPTION
Description
---

Reverts bors squash merge setting until we can figure out why it's not working 

