### PR TITLE
fix(core): correctly filter pruned sync peers for block sync

### DIFF
--- a/base_layer/common_types/src/chain_metadata.rs
+++ b/base_layer/common_types/src/chain_metadata.rs
@@ -40,7 +40,7 @@ pub struct ChainMetadata {
     /// (exclusive). If `pruned_height` is equal to the `height_of_longest_chain` no blocks can be
     /// provided. Archival nodes wil always have an `pruned_height` of zero.
     pruned_height: u64,
-    /// The total accumuated proof of work of the longest chain
+    /// The total accumulated proof of work of the longest chain
     accumulated_difficulty: u128,
 }
 

--- a/base_layer/core/src/base_node/state_machine_service/states/sync_decide.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/sync_decide.rs
@@ -96,7 +96,7 @@ impl DecideNextSync {
                 .sync_peers
                 .drain(..)
                 .filter(|sync_peer| {
-                    sync_peer.claimed_chain_metadata().pruning_horizon() <= local_metadata.height_of_longest_chain()
+                    sync_peer.claimed_chain_metadata().pruned_height() <= local_metadata.height_of_longest_chain()
                 })
                 .collect::<Vec<_>>();
 


### PR DESCRIPTION
Description
---
Corrects filter predicate for full block sync peers

Motivation and Context
---
Rpc error: `Service returned an error: BadRequest: Requested full block body at height 6804, however this node has an effective pruned height of 15941` caused by peer incorrectly selecting pruned nodes. 

How Has This Been Tested?
---
Manually
