### PR TITLE
chore: hide private values in debug and serialize

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6611,6 +6611,7 @@ name = "tari_collectibles"
 version = "0.1.0"
 dependencies = [
  "blake2",
+ "derivative",
  "diesel",
  "diesel_migrations",
  "futures 0.3.21",
@@ -6644,6 +6645,7 @@ version = "0.30.0"
 dependencies = [
  "anyhow",
  "config 0.9.3",
+ "derivative",
  "dirs-next 1.0.2",
  "fs2 0.4.3",
  "get_if_addrs",
@@ -6700,6 +6702,7 @@ dependencies = [
  "cidr",
  "clear_on_drop",
  "data-encoding",
+ "derivative",
  "digest 0.9.0",
  "env_logger 0.7.1",
  "futures 0.3.21",
@@ -6853,6 +6856,7 @@ dependencies = [
  "config 0.9.3",
  "croaring",
  "decimal-rs",
+ "derivative",
  "derive_more",
  "digest 0.9.0",
  "env_logger 0.7.1",
@@ -7002,6 +7006,7 @@ dependencies = [
  "clear_on_drop",
  "console_error_panic_hook",
  "crc32fast",
+ "derivative",
  "digest 0.9.0",
  "getrandom 0.2.5",
  "js-sys",
@@ -7025,6 +7030,7 @@ version = "0.30.0"
 dependencies = [
  "bollard",
  "config 0.11.0",
+ "derivative",
  "env_logger 0.9.0",
  "futures 0.3.21",
  "log",
@@ -7046,6 +7052,7 @@ dependencies = [
 name = "tari_libtor"
 version = "0.24.0"
 dependencies = [
+ "derivative",
  "libtor",
  "log",
  "log4rs",
@@ -7066,6 +7073,7 @@ dependencies = [
  "bytes 1.1.0",
  "chrono",
  "config 0.9.3",
+ "derivative",
  "env_logger 0.7.1",
  "futures 0.3.21",
  "hex",
@@ -7113,6 +7121,7 @@ dependencies = [
  "bufstream",
  "chrono",
  "crossbeam",
+ "derivative",
  "futures 0.3.21",
  "hex",
  "log",
@@ -7397,6 +7406,7 @@ dependencies = [
  "chrono",
  "clear_on_drop",
  "crossbeam-channel 0.3.9",
+ "derivative",
  "diesel",
  "diesel_migrations",
  "digest 0.9.0",

--- a/applications/launchpad/backend/Cargo.toml
+++ b/applications/launchpad/backend/Cargo.toml
@@ -30,6 +30,7 @@ tor-hash-passwd = "1.0.1"
 thiserror = "1.0.30"
 tokio = { version = "1.9", features= ["sync"] }
 futures = "0.3"
+derivative = "2.2.0"
 
 [features]
 default = [ "custom-protocol" ]

--- a/applications/launchpad/backend/src/commands/launch_docker.rs
+++ b/applications/launchpad/backend/src/commands/launch_docker.rs
@@ -23,6 +23,7 @@
 
 use std::{convert::TryFrom, path::PathBuf, time::Duration};
 
+use derivative::Derivative;
 use log::*;
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Manager, Wry};
@@ -45,7 +46,8 @@ use crate::{
     error::LauncherError,
 };
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Derivative, Serialize, Deserialize)]
+#[derivative(Debug)]
 pub struct WorkspaceLaunchOptions {
     root_folder: String,
     tari_network: String,
@@ -55,10 +57,14 @@ pub struct WorkspaceLaunchOptions {
     has_mm_proxy: bool,
     has_xmrig: bool,
     wait_for_tor: Option<u64>,
+    #[derivative(Debug = "ignore")]
+    #[serde(skip_serializing)]
     wallet_password: Option<String>,
     sha3_mining_threads: Option<usize>,
     monerod_url: Option<String>,
     monero_username: Option<String>,
+    #[derivative(Debug = "ignore")]
+    #[serde(skip_serializing)]
     monero_password: Option<String>,
     monero_use_auth: Option<bool>,
     monero_mining_address: Option<String>,

--- a/applications/launchpad/backend/src/commands/service.rs
+++ b/applications/launchpad/backend/src/commands/service.rs
@@ -24,6 +24,7 @@
 use std::{convert::TryFrom, path::PathBuf, time::Duration};
 
 use bollard::Docker;
+use derivative::Derivative;
 use futures::StreamExt;
 use log::*;
 use serde::{Deserialize, Serialize};
@@ -52,11 +53,13 @@ use crate::{
 };
 
 /// "Global" settings from the launcher front-end
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Derivative, Deserialize)]
+#[derivative(Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct ServiceSettings {
     pub tari_network: String,
     pub root_folder: String,
+    #[derivative(Debug = "ignore")]
     pub wallet_password: String,
     pub monero_mining_address: Option<String>,
     pub num_mining_threads: i64,
@@ -64,6 +67,7 @@ pub struct ServiceSettings {
     pub docker_tag: Option<String>,
     pub monerod_url: Option<String>,
     pub monero_username: Option<String>,
+    #[derivative(Debug = "ignore")]
     pub monero_password: Option<String>,
     pub monero_use_auth: Option<bool>,
 }

--- a/applications/launchpad/backend/src/docker/settings.rs
+++ b/applications/launchpad/backend/src/docker/settings.rs
@@ -25,6 +25,7 @@ use std::{collections::HashMap, path::PathBuf, time::Duration};
 
 use bollard::models::{Mount, MountTypeEnum, PortBinding, PortMap};
 use config::ConfigError;
+use derivative::Derivative;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tor_hash_passwd::EncryptedKey;
@@ -43,11 +44,14 @@ pub struct BaseNodeConfig {
     pub delay: Duration,
 }
 
-#[derive(Default, Debug, Serialize, Deserialize)]
+#[derive(Default, Derivative, Serialize, Deserialize)]
+#[derivative(Debug)]
 pub struct WalletConfig {
     /// The time delay before starting the container and running the wallet executable
     pub delay: Duration,
     /// The password to de/en-crypt the wallet database
+    #[serde(skip_serializing)]
+    #[derivative(Debug = "ignore")]
     pub password: String,
 }
 
@@ -67,7 +71,8 @@ pub struct Sha3MinerConfig {
     pub num_mining_threads: usize,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Derivative, Serialize, Deserialize)]
+#[derivative(Debug)]
 pub struct MmProxyConfig {
     /// The time delay before starting the container and running the proxy executable
     pub delay: Duration,
@@ -76,6 +81,8 @@ pub struct MmProxyConfig {
     /// If required, the monero username for the monero daemon
     pub monero_username: String,
     /// If required, the password needed to access the monero deamon
+    #[serde(skip_serializing)]
+    #[derivative(Debug = "ignore")]
     pub monero_password: String,
     /// If true, provide the monero username and password to the daemon. Otherwise those strings are ignored.
     pub monero_use_auth: bool,

--- a/applications/tari_collectibles/src-tauri/Cargo.toml
+++ b/applications/tari_collectibles/src-tauri/Cargo.toml
@@ -26,6 +26,7 @@ tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", t
 tari_dan_common_types = { path = "../../../dan_layer/common_types"}
 
 blake2 = "^0.9.0"
+derivative = "2.2.0"
 diesel = { version = "1.4.8", features = ["sqlite"] }
 diesel_migrations = "1.4.0"
 futures = "0.3.17"

--- a/applications/tari_collectibles/src-tauri/src/models/wallet.rs
+++ b/applications/tari_collectibles/src-tauri/src/models/wallet.rs
@@ -20,14 +20,18 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use derivative::Derivative;
 use serde::{Deserialize, Serialize};
 use tari_key_manager::cipher_seed::CipherSeed;
 use uuid::Uuid;
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Derivative, Clone)]
+#[derivative(Debug)]
 pub struct Wallet {
   pub id: Uuid,
   pub name: Option<String>,
+  #[serde(skip_serializing)]
+  #[derivative(Debug = "ignore")]
   pub cipher_seed: CipherSeed,
 }
 

--- a/applications/tari_merge_mining_proxy/Cargo.toml
+++ b/applications/tari_merge_mining_proxy/Cargo.toml
@@ -25,6 +25,7 @@ bincode = "1.3.1"
 bytes = "1.1"
 chrono = { version = "0.4.6", default-features = false }
 config = { version = "0.9.3" }
+derivative = "2.2.0"
 env_logger = { version = "0.7.1", optional = true }
 futures = "0.3.5"
 hex = "0.4.2"

--- a/applications/tari_merge_mining_proxy/src/proxy.rs
+++ b/applications/tari_merge_mining_proxy/src/proxy.rs
@@ -37,6 +37,7 @@ use std::{
 };
 
 use bytes::Bytes;
+use derivative::Derivative;
 use hyper::{header::HeaderValue, service::Service, Body, Method, Request, Response, StatusCode, Uri};
 use json::json;
 use jsonrpc::error::StandardError;
@@ -62,11 +63,13 @@ pub(crate) const MMPROXY_AUX_KEY_NAME: &str = "_aux";
 /// The identifier used to identify the tari aux chain data
 const TARI_CHAIN_ID: &str = "xtr";
 
-#[derive(Debug, Clone)]
+#[derive(Derivative, Clone)]
+#[derivative(Debug)]
 pub struct MergeMiningProxyConfig {
     pub network: Network,
     pub monerod_url: Vec<String>,
     pub monerod_username: String,
+    #[derivative(Debug = "ignore")]
     pub monerod_password: String,
     pub monerod_use_auth: bool,
     pub grpc_base_node_address: SocketAddr,

--- a/applications/tari_mining_node/Cargo.toml
+++ b/applications/tari_mining_node/Cargo.toml
@@ -33,6 +33,7 @@ native-tls = "0.2"
 bufstream = "0.1"
 chrono = { version = "0.4.19", default-features = false }
 hex = "0.4.2"
+derivative = "2.2.0"
 
 [dev-dependencies]
 prost-types = "0.9"

--- a/applications/tari_mining_node/src/stratum/stratum_types/login_params.rs
+++ b/applications/tari_mining_node/src/stratum/stratum_types/login_params.rs
@@ -20,11 +20,15 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
+use derivative::Derivative;
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Derivative)]
+#[derivative(Debug)]
 pub struct LoginParams {
     pub login: String,
+    #[derivative(Debug = "ignore")]
+    #[serde(skip_serializing)]
     pub pass: String,
     pub agent: String,
 }

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -42,6 +42,7 @@ bytes = "0.5"
 chrono = { version = "0.4.19", default-features = false, features = ["serde"] }
 croaring = { version = "=0.4.5", optional = true }
 decimal-rs = "0.1.20"
+derivative = "2.2.0"
 derive_more = "0.99.16"
 digest = "0.9.0"
 fs2 = "0.3.0"

--- a/base_layer/core/src/transactions/transaction_components/unblinded_output_builder.rs
+++ b/base_layer/core/src/transactions/transaction_components/unblinded_output_builder.rs
@@ -20,6 +20,7 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use derivative::Derivative;
 use tari_common_types::types::{BlindingFactor, ComSignature, PrivateKey, PublicKey};
 use tari_crypto::commitment::HomomorphicCommitmentFactory;
 use tari_script::{ExecutionStack, TariScript};
@@ -34,14 +35,17 @@ use crate::{
     },
 };
 
-#[derive(Debug, Clone)]
+#[derive(Derivative, Clone)]
+#[derivative(Debug)]
 pub struct UnblindedOutputBuilder {
     pub value: MicroTari,
+    #[derivative(Debug = "ignore")]
     spending_key: BlindingFactor,
     pub features: OutputFeatures,
     pub script: Option<TariScript>,
     covenant: Covenant,
     input_data: Option<ExecutionStack>,
+    #[derivative(Debug = "ignore")]
     script_private_key: Option<PrivateKey>,
     sender_offset_public_key: Option<PublicKey>,
     metadata_signature: Option<ComSignature>,

--- a/base_layer/core/src/transactions/transaction_protocol/mod.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/mod.rs
@@ -82,6 +82,7 @@
 
 // #![allow(clippy::op_ref)]
 
+use derivative::Derivative;
 use digest::Digest;
 use serde::{Deserialize, Serialize};
 use tari_common_types::types::{MessageHash, PrivateKey, PublicKey};
@@ -140,9 +141,12 @@ pub struct TransactionMetadata {
     pub lock_height: u64,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Derivative, Clone)]
+#[derivative(Debug)]
 pub struct RewindData {
+    #[derivative(Debug = "ignore")]
     pub rewind_key: PrivateKey,
+    #[derivative(Debug = "ignore")]
     pub rewind_blinding_key: PrivateKey,
     pub recovery_byte_key: PrivateKey,
     pub proof_message: [u8; REWIND_USER_MESSAGE_LENGTH],

--- a/base_layer/core/src/transactions/transaction_protocol/sender.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/sender.rs
@@ -22,6 +22,7 @@
 
 use std::fmt;
 
+use derivative::Derivative;
 use digest::{Digest, FixedOutput};
 use serde::{Deserialize, Serialize};
 use tari_common_types::{
@@ -70,7 +71,8 @@ use crate::{
 /// Transaction construction process.
 // TODO: Investigate necessity to use the 'Serialize' and 'Deserialize' traits here; this could potentially leak
 // TODO:   information when least expected. #LOGGED
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Derivative, Serialize, Deserialize, PartialEq)]
+#[derivative(Debug)]
 pub(super) struct RawTransactionInfo {
     pub num_recipients: usize,
     // The sum of self-created outputs plus change
@@ -79,9 +81,11 @@ pub(super) struct RawTransactionInfo {
     pub amounts: Vec<MicroTari>,
     pub recipient_scripts: Vec<TariScript>,
     pub recipient_output_features: Vec<OutputFeatures>,
+    #[derivative(Debug = "ignore")]
     pub recipient_sender_offset_private_keys: Vec<PrivateKey>,
     pub recipient_covenants: Vec<Covenant>,
     // The sender's portion of the public commitment nonce
+    #[derivative(Debug = "ignore")]
     pub private_commitment_nonces: Vec<PrivateKey>,
     pub change: MicroTari,
     pub change_output_metadata_signature: Option<ComSignature>,
@@ -93,9 +97,11 @@ pub(super) struct RawTransactionInfo {
     pub offset: BlindingFactor,
     // The sender's blinding factor shifted by the sender-selected offset
     pub offset_blinding_factor: BlindingFactor,
+    #[derivative(Debug = "ignore")]
     pub gamma: PrivateKey,
     pub public_excess: PublicKey,
     // The sender's private nonce
+    #[derivative(Debug = "ignore")]
     pub private_nonce: PrivateKey,
     // The sender's public nonce
     pub public_nonce: PublicKey,

--- a/base_layer/key_manager/Cargo.toml
+++ b/base_layer/key_manager/Cargo.toml
@@ -22,6 +22,7 @@ chrono = { version = "0.4.19", default-features = false, features = ["serde"] }
 clear_on_drop = "=0.2.4"
 console_error_panic_hook = "0.1.7"
 crc32fast = "1.2.1"
+derivative = "2.2.0"
 digest = "0.9.0"
 getrandom = { version = "0.2.3", optional = true }
 js-sys = { version = "0.3.55", optional = true }

--- a/base_layer/key_manager/src/key_manager.rs
+++ b/base_layer/key_manager/src/key_manager.rs
@@ -22,6 +22,7 @@
 
 use std::marker::PhantomData;
 
+use derivative::Derivative;
 use digest::Digest;
 use serde::{Deserialize, Serialize};
 use tari_crypto::{
@@ -31,17 +32,23 @@ use tari_crypto::{
 
 use crate::cipher_seed::CipherSeed;
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Derivative, Serialize, Deserialize)]
+#[derivative(Debug)]
 pub struct DerivedKey<K>
 where K: SecretKey
 {
+    #[derivative(Debug = "ignore")]
+    #[serde(skip_serializing)]
     pub k: K,
     pub key_index: u64,
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Derivative, PartialEq, Serialize, Deserialize)]
+#[derivative(Debug)]
 pub struct KeyManager<K: SecretKey, D: Digest> {
+    #[derivative(Debug = "ignore")]
     seed: CipherSeed,
+    #[derivative(Debug = "ignore")]
     pub branch_seed: String,
     primary_key_index: u64,
     digest_type: PhantomData<D>,

--- a/base_layer/key_manager/src/wasm.rs
+++ b/base_layer/key_manager/src/wasm.rs
@@ -23,6 +23,7 @@
 use std::fmt::Display;
 
 use console_error_panic_hook;
+use derivative::Derivative;
 use serde::{Deserialize, Serialize};
 use tari_common_types::types::{PrivateKey, PublicKey};
 use tari_crypto::{common::Blake256, keys::PublicKey as PublicKeyTrait};
@@ -37,8 +38,10 @@ type KeyDigest = Blake256;
 
 type KeyManager = GenericKeyManager<PrivateKey, KeyDigest>;
 
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Clone, Derivative, Deserialize, Serialize, PartialEq)]
+#[derivative(Debug)]
 struct DerivedKeypair {
+    #[derivative(Debug = "ignore")]
     private_key: PrivateKey,
     public_key: PublicKey,
     key_index: u64,

--- a/base_layer/wallet/Cargo.toml
+++ b/base_layer/wallet/Cargo.toml
@@ -30,6 +30,7 @@ sha2 = "0.9.5"
 chrono = { version = "0.4.19", default-features = false, features = ["serde"] }
 clear_on_drop = "=0.2.4"
 crossbeam-channel = "0.3.8"
+derivative = "2.2.0"
 diesel = { version = "1.4.7", features = ["sqlite", "serde_json", "chrono"] }
 diesel_migrations = "1.4.0"
 digest = "0.9.0"

--- a/base_layer/wallet/src/output_manager_service/storage/models.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/models.rs
@@ -22,6 +22,7 @@
 
 use std::cmp::Ordering;
 
+use derivative::Derivative;
 use tari_common_types::types::{BlockHash, BulletRangeProof, Commitment, HashOutput, PrivateKey};
 use tari_core::transactions::{
     transaction_components::UnblindedOutput,
@@ -143,9 +144,11 @@ impl From<SpendingPriority> for u32 {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Derivative, Clone)]
+#[derivative(Debug)]
 pub struct KnownOneSidedPaymentScript {
     pub script_hash: Vec<u8>,
+    #[derivative(Debug = "ignore")]
     pub private_key: PrivateKey,
     pub script: TariScript,
     pub input: ExecutionStack,

--- a/base_layer/wallet/src/output_manager_service/storage/sqlite_db/mod.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/sqlite_db/mod.rs
@@ -26,6 +26,7 @@ use std::{
 };
 
 use aes_gcm::Aes256Gcm;
+use derivative::Derivative;
 use diesel::{prelude::*, result::Error as DieselError, SqliteConnection};
 use log::*;
 pub use new_output_sql::NewOutputSql;
@@ -1259,12 +1260,14 @@ impl From<UpdateOutput> for UpdateOutputSql {
     }
 }
 
-#[derive(Clone, Debug, Queryable, Insertable, Identifiable, PartialEq, AsChangeset)]
+#[derive(Clone, Derivative, Queryable, Insertable, Identifiable, PartialEq, AsChangeset)]
+#[derivative(Debug)]
 #[table_name = "known_one_sided_payment_scripts"]
 #[primary_key(script_hash)]
 // #[identifiable_options(primary_key(hash))]
 pub struct KnownOneSidedPaymentScriptSql {
     pub script_hash: Vec<u8>,
+    #[derivative(Debug = "ignore")]
     pub private_key: Vec<u8>,
     pub script: Vec<u8>,
     pub input: Vec<u8>,

--- a/base_layer/wallet/src/output_manager_service/storage/sqlite_db/new_output_sql.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/sqlite_db/new_output_sql.rs
@@ -20,6 +20,7 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 use aes_gcm::Aes256Gcm;
+use derivative::Derivative;
 use diesel::{prelude::*, SqliteConnection};
 use tari_common_types::transaction::TxId;
 use tari_crypto::tari_utilities::ByteArray;
@@ -35,10 +36,12 @@ use crate::{
 
 /// This struct represents an Output in the Sql database. A distinct struct is required to define the Sql friendly
 /// equivalent datatypes for the members.
-#[derive(Clone, Debug, Insertable, PartialEq)]
+#[derive(Clone, Derivative, Insertable, PartialEq)]
+#[derivative(Debug)]
 #[table_name = "outputs"]
 pub struct NewOutputSql {
     pub commitment: Option<Vec<u8>>,
+    #[derivative(Debug = "ignore")]
     pub spending_key: Vec<u8>,
     pub value: i64,
     pub flags: i32,
@@ -48,6 +51,7 @@ pub struct NewOutputSql {
     pub hash: Option<Vec<u8>>,
     pub script: Vec<u8>,
     pub input_data: Vec<u8>,
+    #[derivative(Debug = "ignore")]
     pub script_private_key: Vec<u8>,
     pub metadata: Option<Vec<u8>>,
     pub features_parent_public_key: Option<Vec<u8>>,

--- a/base_layer/wallet/src/output_manager_service/storage/sqlite_db/output_sql.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/sqlite_db/output_sql.rs
@@ -23,6 +23,7 @@
 use std::convert::{TryFrom, TryInto};
 
 use aes_gcm::Aes256Gcm;
+use derivative::Derivative;
 use diesel::{prelude::*, sql_query, SqliteConnection};
 use log::*;
 use tari_common_types::{
@@ -60,11 +61,13 @@ use crate::{
 
 const LOG_TARGET: &str = "wallet::output_manager_service::database::wallet";
 
-#[derive(Clone, Debug, Queryable, Identifiable, PartialEq, QueryableByName)]
+#[derive(Clone, Derivative, Queryable, Identifiable, PartialEq, QueryableByName)]
+#[derivative(Debug)]
 #[table_name = "outputs"]
 pub struct OutputSql {
     pub id: i32, // Auto inc primary key
     pub commitment: Option<Vec<u8>>,
+    #[derivative(Debug = "ignore")]
     pub spending_key: Vec<u8>,
     pub value: i64,
     pub flags: i32,
@@ -74,6 +77,7 @@ pub struct OutputSql {
     pub hash: Option<Vec<u8>>,
     pub script: Vec<u8>,
     pub input_data: Vec<u8>,
+    #[derivative(Debug = "ignore")]
     pub script_private_key: Vec<u8>,
     pub script_lock_height: i64,
     pub sender_offset_public_key: Vec<u8>,

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -18,6 +18,7 @@ tari_storage = { version = "^0.30", path = "../infrastructure/storage"}
 
 anyhow = "1.0.53"
 config = { version = "0.9.3", default_features = false, features = ["toml"] }
+derivative = "2.2.0"
 dirs-next = "1.0.2"
 fs2 = "0.4.3"
 get_if_addrs = "0.5.3"

--- a/common/src/configuration/global.rs
+++ b/common/src/configuration/global.rs
@@ -35,6 +35,7 @@ use std::{
 };
 
 use config::{Config, ConfigError, Environment};
+use derivative::Derivative;
 use multiaddr::{Error, Multiaddr, Protocol};
 use tari_storage::lmdb_store::LMDBConfig;
 
@@ -1148,10 +1149,11 @@ impl fmt::Debug for TorControlAuthentication {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Derivative, Clone)]
+#[derivative(Debug)]
 pub enum SocksAuthentication {
     None,
-    UsernamePassword(String, String),
+    UsernamePassword(String, #[derivative(Debug = "ignore")] String),
 }
 
 impl FromStr for SocksAuthentication {

--- a/common/src/configuration/merge_mining_config.rs
+++ b/common/src/configuration/merge_mining_config.rs
@@ -20,13 +20,16 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use derivative::Derivative;
 use multiaddr::Multiaddr;
 
-#[derive(Debug, Clone)]
+#[derive(Derivative, Clone)]
+#[derivative(Debug)]
 pub struct MergeMiningConfig {
     pub monerod_url: Vec<String>,
     pub monerod_use_auth: bool,
     pub monerod_username: String,
+    #[derivative(Debug = "ignore")]
     pub monerod_password: String,
     pub proxy_host_address: Multiaddr,
     pub base_node_grpc_address: Multiaddr,

--- a/comms/Cargo.toml
+++ b/comms/Cargo.toml
@@ -24,6 +24,7 @@ chrono = { version = "0.4.19", default-features = false, features = ["serde"] }
 cidr = "0.1.0"
 clear_on_drop = "=0.2.4"
 data-encoding = "2.2.0"
+derivative = "2.2.0"
 digest = "0.9.0"
 futures = { version = "^0.3", features = ["async-await"] }
 lazy_static = "1.4.0"

--- a/comms/src/tor/control_client/commands/add_onion.rs
+++ b/comms/src/tor/control_client/commands/add_onion.rs
@@ -22,6 +22,8 @@
 
 use std::{borrow::Cow, fmt, num::NonZeroU16};
 
+use derivative::Derivative;
+
 use crate::tor::control_client::{
     commands::TorCommand,
     error::TorClientError,
@@ -188,9 +190,11 @@ impl fmt::Display for AddOnion<'_> {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Derivative, Clone)]
+#[derivative(Debug)]
 pub struct AddOnionResponse {
     pub(crate) service_id: String,
+    #[derivative(Debug = "ignore")]
     pub(crate) private_key: Option<PrivateKey>,
     pub(crate) onion_port: u16,
 }

--- a/comms/src/tor/hidden_service/mod.rs
+++ b/comms/src/tor/hidden_service/mod.rs
@@ -29,6 +29,7 @@ pub use controller::{HiddenServiceController, HiddenServiceControllerError};
 mod proxy_opts;
 use std::fmt;
 
+use derivative::Derivative;
 pub use proxy_opts::TorProxyOpts;
 use serde_derive::{Deserialize, Serialize};
 use tari_shutdown::OptionalShutdownSignal;
@@ -87,8 +88,11 @@ fn multiaddr_from_service_id_and_port(service_id: &str, onion_port: u16) -> Resu
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Derivative, Serialize, Deserialize)]
+#[derivative(Debug)]
 pub struct TorIdentity {
+    #[serde(skip_serializing)]
+    #[derivative(Debug = "ignore")]
     pub private_key: PrivateKey,
     pub service_id: String,
     pub onion_port: u16,

--- a/infrastructure/libtor/Cargo.toml
+++ b/infrastructure/libtor/Cargo.toml
@@ -6,6 +6,7 @@ license = "BSD-3-Clause"
 
 [dependencies]
 tari_common = { path = "../../common" }
+derivative = "2.2.0"
 log = "0.4.8"
 log4rs = { version = "1.0.0", default_features = false, features = ["config_parsing", "threshold_filter", "yaml_format"] }
 multiaddr = { version = "0.13.0" }

--- a/infrastructure/libtor/src/tor.rs
+++ b/infrastructure/libtor/src/tor.rs
@@ -22,6 +22,7 @@
 
 use std::{fmt, io, net::TcpListener};
 
+use derivative::Derivative;
 use libtor::{LogDestination, LogLevel, TorFlag};
 use log::*;
 use multiaddr::Multiaddr;
@@ -45,12 +46,14 @@ impl fmt::Debug for TorPassword {
     }
 }
 
-#[derive(Debug)]
+#[derive(Derivative)]
+#[derivative(Debug)]
 pub struct Tor {
     control_port: u16,
     data_dir: String,
     log_destination: String,
     log_level: LogLevel,
+    #[derivative(Debug = "ignore")]
     passphrase: TorPassword,
     socks_port: u16,
     temp_dir: Option<TempDir>,


### PR DESCRIPTION
Description
---
Added `derivative` macro to get rid of the debug prints.

Motivation and Context
---
Hide all private values that can be exposed accidentally via debug or serializing.

How Has This Been Tested?
---
integration tests only