### PR TITLE
fix(block-sync): use avg latency to determine slow sync peer for block sync

### DIFF
--- a/base_layer/core/src/base_node/state_machine_service/states/events_and_states.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/events_and_states.rs
@@ -269,7 +269,7 @@ impl BlockSyncInfo {
 
     pub fn sync_progress_string(&self) -> String {
         format!(
-            "({}) {}/{} ({:.0}%){} Latency: {:.2?}",
+            "({}) {}/{} ({:.0}%){}{}",
             self.sync_peer.node_id().short_str(),
             self.local_height,
             self.tip_height,
@@ -278,7 +278,10 @@ impl BlockSyncInfo {
                 .items_per_second()
                 .map(|bps| format!(" {:.2?} blks/s", bps))
                 .unwrap_or_default(),
-            self.sync_peer.latency().unwrap_or_default()
+            self.sync_peer
+                .calc_avg_latency()
+                .map(|avg| format!(", latency: {:.2?}", avg))
+                .unwrap_or_default(),
         )
     }
 }

--- a/base_layer/core/src/base_node/sync/block_sync/synchronizer.rs
+++ b/base_layer/core/src/base_node/sync/block_sync/synchronizer.rs
@@ -41,6 +41,7 @@ use crate::{
     },
     blocks::{Block, BlockValidationError, ChainBlock},
     chain_storage::{async_db::AsyncBlockchainDb, BlockchainBackend},
+    common::rolling_avg::RollingAverageTime,
     proto::base_node::SyncBlocksRequest,
     transactions::aggregated_body::AggregateBody,
     validation::{BlockSyncBodyValidation, ValidationError},
@@ -93,7 +94,7 @@ impl<B: BlockchainBackend + 'static> BlockSynchronizer<B> {
                 Ok(_) => return Ok(()),
                 Err(err @ BlockSyncError::AllSyncPeersExceedLatency) => {
                     warn!(target: LOG_TARGET, "{}", err);
-                    if self.sync_peers.len() == 1 {
+                    if self.sync_peers.len() <= 2 {
                         warn!(
                             target: LOG_TARGET,
                             "Insufficient sync peers to continue with block sync"
@@ -224,8 +225,10 @@ impl<B: BlockchainBackend + 'static> BlockSynchronizer<B> {
         let mut prev_hash = best_full_block_hash;
         let mut current_block = None;
         let mut last_sync_timer = Instant::now();
+        let mut avg_latency = RollingAverageTime::new(20);
         while let Some(block) = block_stream.next().await {
             let latency = last_sync_timer.elapsed();
+            avg_latency.add_sample(latency);
             let block = block?;
 
             let header = self
@@ -316,7 +319,12 @@ impl<B: BlockchainBackend + 'static> BlockSynchronizer<B> {
                 .commit()
                 .await?;
 
-            sync_peer.set_latency(latency);
+            // Average time between receiving blocks from the peer - used to detect a slow sync peer
+            let last_avg_latency = avg_latency.calculate_average();
+            if let Some(latency) = last_avg_latency {
+                sync_peer.set_latency(latency);
+            }
+            // Includes time to add block to database, used to show blocks/s on status line
             sync_peer.add_sample(last_sync_timer.elapsed());
             self.hooks
                 .call_on_progress_block_hooks(block.clone(), tip_height, &sync_peer);
@@ -334,7 +342,7 @@ impl<B: BlockchainBackend + 'static> BlockSynchronizer<B> {
                 block.accumulated_data().accumulated_sha_difficulty,
                 latency
             );
-            if latency > max_latency {
+            if last_avg_latency.map(|avg| avg > max_latency).unwrap_or(false) {
                 return Err(BlockSyncError::MaxLatencyExceeded {
                     peer: sync_peer.node_id().clone(),
                     latency,

--- a/base_layer/core/src/base_node/sync/config.rs
+++ b/base_layer/core/src/base_node/sync/config.rs
@@ -46,7 +46,7 @@ pub struct BlockchainSyncConfig {
 impl Default for BlockchainSyncConfig {
     fn default() -> Self {
         Self {
-            initial_max_sync_latency: Duration::from_secs(4),
+            initial_max_sync_latency: Duration::from_secs(10),
             max_latency_increase: Duration::from_secs(2),
             ban_period: Duration::from_secs(30 * 60),
             short_ban_period: Duration::from_secs(60),

--- a/base_layer/core/src/base_node/sync/config.rs
+++ b/base_layer/core/src/base_node/sync/config.rs
@@ -46,7 +46,7 @@ pub struct BlockchainSyncConfig {
 impl Default for BlockchainSyncConfig {
     fn default() -> Self {
         Self {
-            initial_max_sync_latency: Duration::from_secs(3),
+            initial_max_sync_latency: Duration::from_secs(4),
             max_latency_increase: Duration::from_secs(2),
             ban_period: Duration::from_secs(30 * 60),
             short_ban_period: Duration::from_secs(60),

--- a/base_layer/core/src/common/mod.rs
+++ b/base_layer/core/src/common/mod.rs
@@ -23,5 +23,6 @@
 pub mod byte_counter;
 pub mod hash_writer;
 pub mod limited_reader;
+pub mod rolling_avg;
 #[cfg(feature = "base_node")]
 pub mod rolling_vec;


### PR DESCRIPTION
Description
---
Uses average blocks received per second to determine slow sync peer.
Display average block receive time on status line

Motivation and Context
---
Esp. for large blocks, there could be a single large delay that would previously immediately cause the next peer to be attempted. Using the average blocks received per second, a "blip" in the latency will not cause the sync peer to switch.

How Has This Been Tested?
---
Manually
