### PR TITLE
ci: add auto labeler for clippy

### DIFF
--- a/.github/workflows/auto_labels.yml
+++ b/.github/workflows/auto_labels.yml
@@ -1,0 +1,55 @@
+on:
+  workflow_run:
+    workflows:
+      - "Clippy check"
+    types:
+      - completed
+
+jobs:
+  on-success:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Download workflow artifact
+        uses: dawidd6/action-download-artifact@v2.11.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: CI
+          run_id: ${{ github.event.workflow_run.id }}
+
+      - name: Read PR number
+        id: pr_num
+        uses: juliangruber/read-file-action@v1.0.0
+        with:
+          path: ./pr_num.txt
+
+      - name: labeler
+        uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          github_token: ${{ github.token }}
+          labels: clippy failed
+          number: ${{ steps.pr_num.output.content }}
+
+  on-failure:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    steps:
+      - name: Download workflow artifact
+        uses: dawidd6/action-download-artifact@v2.11.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: CI
+          run_id: ${{ github.event.workflow_run.id }}
+
+      - name: Read PR number
+        id: pr_num
+        uses: juliangruber/read-file-action@v1.0.0
+        with:
+          path: ./pr_num.txt
+
+      - name: labeler
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          github_token: ${{ github.token }}
+          labels: clippy failed
+          number: ${{ steps.pr_num.output.content }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ env:
   PROTOC: protoc
 
 jobs:
+
   clippy:
     name: clippy
     runs-on: ubuntu-18.04
@@ -203,3 +204,19 @@ jobs:
         with:
           command: test
           args: -v --all-features
+  # Allows other workflows to know the PR number
+  artifacts:
+    name: test
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Save the PR number in an artifact
+        shell: bash
+        env:
+          PR_NUM: ${{ github.event.number }}
+        run: echo $PR_NUM > pr_num.txt
+
+      - name: Upload the PR number
+        uses: actions/upload-artifact@v2
+        with:
+          name: pr_num
+          path: ./pr_num.txt


### PR DESCRIPTION
Description
---
Adds `workflow_run` trigger that adds/removes "clippy failed" label depending on "Clippy check" step

Motivation and Context
---
Easier to tell at a glance of the PR list if clippy has failed

How Has This Been Tested?
---

