### PR TITLE
refactor: remove unwraps from some modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6677,6 +6677,7 @@ dependencies = [
 name = "tari_common_types"
 version = "0.30.0"
 dependencies = [
+ "anyhow",
  "digest 0.9.0",
  "lazy_static 1.4.0",
  "rand 0.8.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,9 +123,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.55"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "159bb86af3a200e19a068f4224eae4c8bb2d0fa054c7e5d1cacd5cef95e684cd"
+checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
 
 [[package]]
 name = "arc-swap"
@@ -7140,6 +7140,7 @@ dependencies = [
 name = "tari_mmr"
 version = "0.30.0"
 dependencies = [
+ "anyhow",
  "bincode",
  "blake2",
  "criterion",

--- a/applications/launchpad/backend/src/commands/pull_images.rs
+++ b/applications/launchpad/backend/src/commands/pull_images.rs
@@ -66,15 +66,12 @@ pub async fn pull_images(app: AppHandle<Wry>) -> Result<(), String> {
         .iter()
         .map(|image| pull_image(*image, app.clone()).map_err(|e| e.chained_message()));
     let results: Vec<Result<_, String>> = join_all(futures).await;
-    let errors = results
-        .into_iter()
-        .filter(|r| r.is_err())
-        .map(|e| e.unwrap_err())
-        .collect::<Vec<String>>();
-    if !errors.is_empty() {
-        return Err(errors.join("\n"));
+    let errors = results.into_iter().filter_map(Result::err).collect::<Vec<String>>();
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors.join("\n"))
     }
-    Ok(())
 }
 
 async fn pull_image(image: ImageType, app: AppHandle<Wry>) -> Result<(), LauncherError> {

--- a/applications/launchpad/backend/src/commands/service.rs
+++ b/applications/launchpad/backend/src/commands/service.rs
@@ -92,8 +92,8 @@ impl TryFrom<ServiceSettings> for LaunchpadConfig {
         };
         if let Some(val) = settings.monero_use_auth {
             mm_proxy.monero_use_auth = val;
-            mm_proxy.monero_username = settings.monero_username.unwrap_or_else(|| "".to_string());
-            mm_proxy.monero_password = settings.monero_password.unwrap_or_else(|| "".to_string());
+            mm_proxy.monero_username = settings.monero_username.unwrap_or_default();
+            mm_proxy.monero_password = settings.monero_password.unwrap_or_default();
         }
         let monero_mining_address = settings
             .monero_mining_address

--- a/applications/tari_collectibles/src-tauri/src/status.rs
+++ b/applications/tari_collectibles/src-tauri/src/status.rs
@@ -58,9 +58,13 @@ impl Status {
     }
   }
 
-  pub fn internal(message: String) -> Self {
-    Self::Internal { code: 500, message }
+  pub fn internal(message: impl ToString) -> Self {
+    Self::Internal {
+      code: 500,
+      message: message.to_string(),
+    }
   }
+
   pub fn not_found(entity: String) -> Self {
     Self::NotFound {
       code: 404,

--- a/base_layer/common_types/Cargo.toml
+++ b/base_layer/common_types/Cargo.toml
@@ -16,3 +16,6 @@ rand = "0.8"
 serde = { version = "1.0.106", features = ["derive"] }
 thiserror = "1.0.29"
 tokio = { version = "1.11", features = ["time", "sync"] }
+
+[dev-dependencies]
+anyhow = "1.0.56"

--- a/base_layer/common_types/src/waiting_requests.rs
+++ b/base_layer/common_types/src/waiting_requests.rs
@@ -57,7 +57,7 @@ impl<T> WaitingRequests<T> {
 
     /// Remove the waiting request corresponding to the provided key.
     pub async fn remove(&self, key: RequestKey) -> Option<(OneshotSender<T>, Instant)> {
-        self.requests.write().await.remove(&key).unwrap_or(None)
+        self.requests.write().await.remove(&key)?
     }
 }
 

--- a/base_layer/mmr/Cargo.toml
+++ b/base_layer/mmr/Cargo.toml
@@ -22,6 +22,7 @@ croaring =  { version = "=0.4.5", optional = true }
 criterion = { version="0.2", optional = true }
 
 [dev-dependencies]
+anyhow = "1.0.56"
 rand="0.8.0"
 blake2 = "0.9.0"
 tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.12.1" }

--- a/base_layer/mmr/src/common.rs
+++ b/base_layer/mmr/src/common.rs
@@ -210,6 +210,8 @@ pub fn checked_n_leaves(size: usize) -> Option<usize> {
 
 #[cfg(test)]
 mod test {
+    use anyhow::Error;
+
     use super::*;
 
     #[test]
@@ -281,14 +283,15 @@ mod test {
     }
 
     #[test]
-    fn families() {
-        assert_eq!(family(1).unwrap(), (2, 0));
-        assert_eq!(family(0).unwrap(), (2, 1));
-        assert_eq!(family(3).unwrap(), (5, 4));
-        assert_eq!(family(9).unwrap(), (13, 12));
-        assert_eq!(family(15).unwrap(), (17, 16));
-        assert_eq!(family(6).unwrap(), (14, 13));
-        assert_eq!(family(13).unwrap(), (14, 6));
+    fn families() -> Result<(), Error> {
+        assert_eq!(family(1)?, (2, 0));
+        assert_eq!(family(0)?, (2, 1));
+        assert_eq!(family(3)?, (5, 4));
+        assert_eq!(family(9)?, (13, 12));
+        assert_eq!(family(15)?, (17, 16));
+        assert_eq!(family(6)?, (14, 13));
+        assert_eq!(family(13)?, (14, 6));
+        Ok(())
     }
 
     #[test]

--- a/dan_layer/core/src/storage/chain/chain_db_unit_of_work.rs
+++ b/dan_layer/core/src/storage/chain/chain_db_unit_of_work.rs
@@ -79,7 +79,7 @@ impl<TBackendAdapter: ChainDbBackendAdapter> ChainDbUnitOfWork for ChainDbUnitOf
     // }
 
     fn commit(&mut self) -> Result<(), StorageError> {
-        let mut inner = self.inner.write().unwrap();
+        let mut inner = self.inner.write()?;
         let tx = inner
             .backend_adapter
             .create_transaction()
@@ -143,7 +143,7 @@ impl<TBackendAdapter: ChainDbBackendAdapter> ChainDbUnitOfWork for ChainDbUnitOf
     }
 
     fn add_node(&mut self, hash: TreeNodeHash, parent: TreeNodeHash, height: u32) -> Result<(), StorageError> {
-        self.inner.write().unwrap().nodes.push((
+        self.inner.write()?.nodes.push((
             None,
             UnitOfWorkTracker::new(
                 DbNode {
@@ -159,7 +159,7 @@ impl<TBackendAdapter: ChainDbBackendAdapter> ChainDbUnitOfWork for ChainDbUnitOf
     }
 
     fn add_instruction(&mut self, node_hash: TreeNodeHash, instruction: Instruction) -> Result<(), StorageError> {
-        self.inner.write().unwrap().instructions.push((
+        self.inner.write()?.instructions.push((
             None,
             UnitOfWorkTracker::new(DbInstruction { node_hash, instruction }, true),
         ));
@@ -167,7 +167,7 @@ impl<TBackendAdapter: ChainDbBackendAdapter> ChainDbUnitOfWork for ChainDbUnitOf
     }
 
     fn get_locked_qc(&mut self) -> Result<QuorumCertificate, StorageError> {
-        let mut inner = self.inner.write().unwrap();
+        let mut inner = self.inner.write()?;
 
         if let Some(locked_qc) = &inner.locked_qc {
             let locked_qc = locked_qc.get();
@@ -197,7 +197,7 @@ impl<TBackendAdapter: ChainDbBackendAdapter> ChainDbUnitOfWork for ChainDbUnitOf
     }
 
     fn set_locked_qc(&mut self, qc: &QuorumCertificate) -> Result<(), StorageError> {
-        let mut inner = self.inner.write().unwrap();
+        let mut inner = self.inner.write()?;
 
         if let Some(locked_qc) = &inner.locked_qc.as_ref() {
             let mut locked_qc = locked_qc.get_mut();
@@ -230,7 +230,7 @@ impl<TBackendAdapter: ChainDbBackendAdapter> ChainDbUnitOfWork for ChainDbUnitOf
     }
 
     fn get_prepare_qc(&mut self) -> Result<Option<QuorumCertificate>, StorageError> {
-        let mut inner = self.inner.write().unwrap();
+        let mut inner = self.inner.write()?;
 
         if let Some(prepare_qc) = &inner.prepare_qc {
             let prepare_qc = prepare_qc.get();
@@ -265,7 +265,7 @@ impl<TBackendAdapter: ChainDbBackendAdapter> ChainDbUnitOfWork for ChainDbUnitOf
     fn set_prepare_qc(&mut self, qc: &QuorumCertificate) -> Result<(), StorageError> {
         // put it in the tracker
         let _ = self.get_prepare_qc()?;
-        let mut inner = self.inner.write().unwrap();
+        let mut inner = self.inner.write()?;
         match inner.prepare_qc.as_mut() {
             None => {
                 inner.prepare_qc = Some(UnitOfWorkTracker::new(
@@ -291,7 +291,7 @@ impl<TBackendAdapter: ChainDbBackendAdapter> ChainDbUnitOfWork for ChainDbUnitOf
     }
 
     fn commit_node(&mut self, node_hash: &TreeNodeHash) -> Result<(), StorageError> {
-        let mut inner = self.inner.write().unwrap();
+        let mut inner = self.inner.write()?;
         let found_node = inner.find_proposed_node(node_hash)?;
         let mut node = found_node.1.get_mut();
         node.is_committed = true;
@@ -299,7 +299,7 @@ impl<TBackendAdapter: ChainDbBackendAdapter> ChainDbUnitOfWork for ChainDbUnitOf
     }
 
     fn get_tip_node(&self) -> Result<Option<Node>, StorageError> {
-        let inner = self.inner.read().unwrap();
+        let inner = self.inner.read()?;
         inner.get_tip_node()
     }
 }

--- a/dan_layer/core/src/storage/error.rs
+++ b/dan_layer/core/src/storage/error.rs
@@ -20,7 +20,7 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::io;
+use std::{io, sync::PoisonError};
 
 use lmdb_zero as lmdb;
 use tari_mmr::error::MerkleMountainRangeError;
@@ -52,4 +52,12 @@ pub enum StorageError {
     MerkleMountainRangeError(#[from] MerkleMountainRangeError),
     #[error("General storage error: {details}")]
     General { details: String },
+    #[error("Storage lock error")]
+    LockError,
+}
+
+impl<T> From<PoisonError<T>> for StorageError {
+    fn from(_err: PoisonError<T>) -> Self {
+        Self::LockError
+    }
 }


### PR DESCRIPTION
Description
---
Remove `unwrap` calls from some modules.

Motivation and Context
---
The code contains `unwrap` calls that can lead to panic. Using results instead of unwraps makes the code safer.

How Has This Been Tested?
---
CI

