### PR TITLE
feat: listen to terminal events in the watch mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1451,15 +1451,16 @@ dependencies = [
 
 [[package]]
 name = "crossterm"
-version = "0.22.1"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85525306c4291d1b73ce93c8acf9c339f9b213aef6c1d85c3830cbf1c16325c"
+checksum = "f1fd7173631a4e9e2ca8b32ae2fad58aab9843ea5aaf56642661937d87e28a3e"
 dependencies = [
  "bitflags 1.3.2",
  "crossterm_winapi 0.9.0",
+ "futures-core",
  "libc",
  "mio 0.7.14",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.0",
  "signal-hook 0.3.13",
  "signal-hook-mio",
  "winapi 0.3.9",
@@ -2151,7 +2152,7 @@ checksum = "02ecad9808e0596f8956d14f7fa868f996290bd01c8d7329d6e5bc2bb76adf8f"
 dependencies = [
  "cfg-if 1.0.0",
  "rustix",
- "windows-sys",
+ "windows-sys 0.30.0",
 ]
 
 [[package]]
@@ -4514,6 +4515,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking_lot"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
+dependencies = [
+ "lock_api 0.4.6",
+ "parking_lot_core 0.9.1",
+]
+
+[[package]]
 name = "parking_lot_core"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4539,6 +4550,19 @@ dependencies = [
  "redox_syscall 0.2.11",
  "smallvec",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28141e0cc4143da2443301914478dc976a61ffdb3f043058310c70df2fed8954"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "redox_syscall 0.2.11",
+ "smallvec",
+ "windows-sys 0.32.0",
 ]
 
 [[package]]
@@ -6548,7 +6572,7 @@ dependencies = [
  "chrono",
  "clap 3.1.5",
  "config 0.9.3",
- "crossterm 0.22.1",
+ "crossterm 0.23.1",
  "derive_more",
  "either",
  "futures 0.3.21",
@@ -8863,7 +8887,7 @@ version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b749ebd2304aa012c5992d11a25d07b406bdbe5f79d371cb7a918ce501a19eb0"
 dependencies = [
- "windows_aarch64_msvc",
+ "windows_aarch64_msvc 0.30.0",
  "windows_i686_gnu 0.30.0",
  "windows_i686_msvc 0.30.0",
  "windows_x86_64_gnu 0.30.0",
@@ -8886,7 +8910,7 @@ version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "030b7ff91626e57a05ca64a07c481973cbb2db774e4852c9c7ca342408c6a99a"
 dependencies = [
- "windows_aarch64_msvc",
+ "windows_aarch64_msvc 0.30.0",
  "windows_i686_gnu 0.30.0",
  "windows_i686_msvc 0.30.0",
  "windows_x86_64_gnu 0.30.0",
@@ -8894,10 +8918,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3df6e476185f92a12c072be4a189a0210dcdcf512a1891d6dff9edb874deadc6"
+dependencies = [
+ "windows_aarch64_msvc 0.32.0",
+ "windows_i686_gnu 0.32.0",
+ "windows_i686_msvc 0.32.0",
+ "windows_x86_64_gnu 0.32.0",
+ "windows_x86_64_msvc 0.32.0",
+]
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29277a4435d642f775f63c7d1faeb927adba532886ce0287bd985bffb16b6bca"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8e92753b1c443191654ec532f14c199742964a061be25d77d7a96f09db20bf5"
 
 [[package]]
 name = "windows_gen"
@@ -8922,6 +8965,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1145e1989da93956c68d1864f32fb97c8f561a8f89a5125f6a2b7ea75524e4b8"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a711c68811799e017b6038e0922cb27a5e2f43a2ddb609fe0b6f3eeda9de615"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8932,6 +8981,12 @@ name = "windows_i686_msvc"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4a09e3a0d4753b73019db171c1339cd4362c8c44baf1bcea336235e955954a6"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c11bb1a02615db74680b32a68e2d61f553cc24c4eb5b4ca10311740e44172"
 
 [[package]]
 name = "windows_macros"
@@ -8970,6 +9025,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ca64fcb0220d58db4c119e050e7af03c69e6f4f415ef69ec1773d9aab422d5a"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c912b12f7454c6620635bbff3450962753834be2a594819bd5e945af18ec64bc"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8980,6 +9041,12 @@ name = "windows_x86_64_msvc"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08cabc9f0066848fef4bc6a1c1668e6efce38b661d2aeec75d18d8617eebb5f1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "504a2476202769977a040c6364301a3f65d0cc9e3fb08600b2bda150a0488316"
 
 [[package]]
 name = "winreg"

--- a/applications/tari_base_node/Cargo.toml
+++ b/applications/tari_base_node/Cargo.toml
@@ -29,7 +29,7 @@ bincode = "1.3.1"
 chrono = { version = "0.4.19", default-features = false }
 clap = { version = "3.1.1", features = ["derive"] }
 config = { version = "0.9.3" }
-crossterm = "0.22"
+crossterm = { version = "0.23.1", features = ["event-stream"] }
 derive_more = "0.99.17"
 either = "1.6.1"
 futures = { version = "^0.3.16", default-features = false, features = ["alloc"] }

--- a/applications/tari_base_node/src/commands/cli_loop.rs
+++ b/applications/tari_base_node/src/commands/cli_loop.rs
@@ -1,7 +1,4 @@
-use std::{
-    io,
-    time::{Duration, Instant},
-};
+use std::{io, time::Duration};
 
 use crossterm::{
     cursor,
@@ -114,7 +111,6 @@ impl CliLoop {
 
     async fn watch_loop(&mut self) {
         if let Some(command) = self.watch_task.take() {
-            let start_time = Instant::now();
             let mut interrupt = signal::ctrl_c().fuse().boxed();
             let mut software_update_notif = self.context.software_updater.new_update_notifier().clone();
             let config = self.context.config.clone();
@@ -129,7 +125,7 @@ impl CliLoop {
                 let mut events = EventStream::new();
                 loop {
                     terminal::enable_raw_mode().ok();
-                    let interval = get_status_interval(start_time, interval);
+                    let interval = time::sleep(interval);
                     tokio::select! {
                         _ = interval => {
                             terminal::disable_raw_mode().ok();
@@ -218,12 +214,4 @@ impl CliLoop {
             }
         }
     }
-}
-
-fn get_status_interval(start_time: Instant, long_interval: Duration) -> time::Sleep {
-    let duration = match start_time.elapsed().as_secs() {
-        0..=120 => Duration::from_secs(5),
-        _ => long_interval,
-    };
-    time::sleep(duration)
 }

--- a/applications/tari_base_node/src/commands/cli_loop.rs
+++ b/applications/tari_base_node/src/commands/cli_loop.rs
@@ -87,9 +87,9 @@ impl CliLoop {
         }
     }
 
-    fn is_interruption(&mut self, event: Option<Result<Event, io::Error>>) -> bool {
-        match event {
-            Some(Ok(Event::Key(key))) => match key {
+    fn is_interrupted(&mut self, event: Option<Result<Event, io::Error>>) -> bool {
+        if let Some(Ok(Event::Key(key))) = event {
+            match key {
                 KeyEvent {
                     code: KeyCode::Char('c'),
                     modifiers: KeyModifiers::CONTROL,
@@ -103,8 +103,7 @@ impl CliLoop {
                         println!("Press Ctrl-C to enter the interactive shell.");
                     }
                 },
-            },
-            _ => {},
+            }
         }
         false
     }
@@ -138,7 +137,7 @@ impl CliLoop {
                             break;
                         }
                         event = events.next() => {
-                            if self.is_interruption(event) {
+                            if self.is_interrupted(event) {
                                 break;
                             }
                         }

--- a/applications/tari_base_node/src/commands/cli_loop.rs
+++ b/applications/tari_base_node/src/commands/cli_loop.rs
@@ -1,0 +1,216 @@
+use std::time::{Duration, Instant};
+
+use crossterm::{
+    cursor,
+    event::{Event, EventStream, KeyCode, KeyEvent, KeyModifiers},
+    terminal,
+};
+use futures::{FutureExt, StreamExt};
+use rustyline::{config::OutputStreamType, error::ReadlineError, CompletionType, Config, EditMode, Editor};
+use tari_shutdown::ShutdownSignal;
+use tokio::{signal, time};
+
+use crate::{
+    commands::{
+        cli,
+        command::{CommandContext, WatchCommand},
+        parser::Parser,
+        reader::CommandReader,
+    },
+    LOG_TARGET,
+};
+
+pub struct CliLoop {
+    context: CommandContext,
+    reader: CommandReader,
+    commands: Vec<String>,
+    watch_task: Option<WatchCommand>,
+    non_interactive: bool,
+    first_signal: bool,
+    done: bool,
+    shutdown_signal: ShutdownSignal,
+}
+
+impl CliLoop {
+    pub fn new(context: CommandContext, watch_command: Option<String>, non_interactive: bool) -> Self {
+        let parser = Parser::new();
+        let commands = parser.get_commands();
+        let cli_config = Config::builder()
+            .history_ignore_space(true)
+            .completion_type(CompletionType::List)
+            .edit_mode(EditMode::Emacs)
+            .output_stream(OutputStreamType::Stdout)
+            .auto_add_history(true)
+            .build();
+        let mut rustyline = Editor::with_config(cli_config);
+        rustyline.set_helper(Some(parser));
+        let reader = CommandReader::new(rustyline);
+        let watch_task = {
+            if let Some(line) = watch_command {
+                WatchCommand::new(line)
+            } else if non_interactive {
+                WatchCommand::new("status --output log")
+            } else {
+                WatchCommand::new("status")
+            }
+        };
+        let shutdown_signal = context.shutdown.to_signal();
+        Self {
+            context,
+            reader,
+            commands,
+            watch_task: Some(watch_task),
+            non_interactive,
+            first_signal: false,
+            done: false,
+            shutdown_signal,
+        }
+    }
+
+    async fn run_watch_task(&mut self) {
+        if let Some(command) = self.watch_task.take() {
+            let start_time = Instant::now();
+            let mut interrupt = signal::ctrl_c().fuse().boxed();
+            let mut software_update_notif = self.context.software_updater.new_update_notifier().clone();
+            let config = self.context.config.clone();
+            let line = command.line();
+            let interval = command
+                .interval
+                .map(Duration::from_secs)
+                .unwrap_or(config.base_node_status_line_interval);
+            if let Err(err) = self.context.handle_command_str(line).await {
+                println!("Wrong command to watch `{}`. Failed with: {}", line, err);
+            } else {
+                let mut events = EventStream::new();
+                loop {
+                    terminal::enable_raw_mode().ok();
+                    let interval = get_status_interval(start_time, interval);
+                    tokio::select! {
+                        _ = interval => {
+                            terminal::disable_raw_mode().ok();
+                            if let Err(err) = self.context.handle_command_str(line).await {
+                                println!("Watched command `{}` failed: {}", line, err);
+                            }
+                            continue;
+                        },
+                        _ = &mut interrupt => {
+                            break;
+                        }
+                        event = events.next() => {
+                            match event {
+                                Some(Ok(Event::Key(key))) => {
+                                    match key {
+                                        KeyEvent { code: KeyCode::Char('c'), modifiers: KeyModifiers::CONTROL } => {
+                                            break;
+                                        }
+                                        _ => {
+                                            if self.non_interactive {
+                                                println!("Press Ctrl-C to interrupt the node.");
+                                            } else {
+                                                println!("Press Ctrl-C to enter the interactive shell.");
+                                            }
+                                        }
+                                    }
+                                }
+                                _ => {
+                                }
+                            }
+                        }
+                        // TODO: Is that good idea? Or add a separate command?
+                        Ok(_) = software_update_notif.changed() => {
+                            if let Some(ref update) = *software_update_notif.borrow() {
+                                println!(
+                                    "Version {} of the {} is available: {} (sha: {})",
+                                    update.version(),
+                                    update.app(),
+                                    update.download_url(),
+                                    update.to_hash_hex()
+                                );
+                            }
+                        }
+                    }
+                    crossterm::execute!(std::io::stdout(), cursor::MoveToNextLine(1)).ok();
+                }
+                terminal::disable_raw_mode().ok();
+            }
+        }
+    }
+
+    async fn execute_command(&mut self) {
+        tokio::select! {
+            res = self.reader.next_command() => {
+                if let Some(event) = res {
+                    match event {
+                        Ok(line) => {
+                            self.first_signal = false;
+                            if !line.is_empty() {
+                                match self.context.handle_command_str(&line).await {
+                                    Err(err) => {
+                                        println!("Command `{}` failed: {}", line, err);
+                                    }
+                                    Ok(command) => {
+                                        self.watch_task = command;
+                                    }
+                                }
+                            }
+                        }
+                        Err(ReadlineError::Interrupted) => {
+                            // If `Ctrl-C` is pressed
+                            if !self.first_signal {
+                                println!("Are you leaving already? Press Ctrl-C again (or Ctrl-D) to terminate the node.");
+                                self.first_signal = true;
+                            } else {
+                                self.done = true;
+                            }
+                        }
+                        Err(ReadlineError::Eof) => {
+                            // If `Ctrl-D` is pressed
+                            self.done = true;
+                        }
+                        Err(err) => {
+                            // TODO: Not sure we have to break here
+                            // This happens when the node is shutting down.
+                            log::debug!(target:  LOG_TARGET, "Could not read line from rustyline:{}", err);
+                            self.done = true;
+                        }
+                    }
+                } else {
+                    self.done = true;
+                }
+            },
+            _ = self.shutdown_signal.wait() => {
+                self.done = true;
+            }
+        }
+    }
+}
+
+impl CliLoop {
+    /// Runs the Base Node CLI loop
+    /// ## Parameters
+    /// `parser` - The parser to process input commands
+    /// `shutdown` - The trigger for shutting down
+    ///
+    /// ## Returns
+    /// Doesn't return anything
+    pub async fn cli_loop(mut self) {
+        cli::print_banner(self.commands.clone(), 3);
+
+        // TODO: Check for a new version here
+        while !self.done {
+            self.run_watch_task().await;
+            if self.non_interactive {
+                break;
+            }
+            self.execute_command().await;
+        }
+    }
+}
+
+fn get_status_interval(start_time: Instant, long_interval: Duration) -> time::Sleep {
+    let duration = match start_time.elapsed().as_secs() {
+        0..=120 => Duration::from_secs(5),
+        _ => long_interval,
+    };
+    time::sleep(duration)
+}

--- a/applications/tari_base_node/src/commands/command/mod.rs
+++ b/applications/tari_base_node/src/commands/command/mod.rs
@@ -253,10 +253,6 @@ impl HandleCommand<Command> for CommandContext {
 }
 
 impl CommandContext {
-    pub fn global_config(&self) -> Arc<GlobalConfig> {
-        self.config.clone()
-    }
-
     async fn fetch_banned_peers(&self) -> Result<Vec<Peer>, PeerManagerError> {
         let pm = &self.peer_manager;
         let query = PeerQuery::new().select_where(|p| p.is_banned());

--- a/applications/tari_base_node/src/commands/command/watch_command.rs
+++ b/applications/tari_base_node/src/commands/command/watch_command.rs
@@ -49,6 +49,15 @@ pub struct Args {
     pub command: String,
 }
 
+impl Args {
+    pub fn new(command: impl ToString) -> Self {
+        Self {
+            command: command.to_string(),
+            ..Default::default()
+        }
+    }
+}
+
 impl Default for Args {
     fn default() -> Self {
         Self {

--- a/applications/tari_base_node/src/commands/mod.rs
+++ b/applications/tari_base_node/src/commands/mod.rs
@@ -21,6 +21,7 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 pub mod cli;
+pub mod cli_loop;
 pub mod command;
 pub mod nom_parser;
 pub mod parser;

--- a/applications/tari_base_node/src/main.rs
+++ b/applications/tari_base_node/src/main.rs
@@ -93,28 +93,12 @@ mod utils;
 #[cfg(feature = "metrics")]
 mod metrics;
 
-use std::{
-    env,
-    net::SocketAddr,
-    process,
-    sync::Arc,
-    time::{Duration, Instant},
-};
+use std::{env, net::SocketAddr, process, sync::Arc};
 
-use commands::{
-    command::{CommandContext, WatchCommand},
-    parser::Parser,
-    reader::CommandReader,
-};
-use crossterm::{
-    cursor,
-    event::{Event, EventStream, KeyCode, KeyEvent, KeyModifiers},
-    terminal,
-};
-use futures::{FutureExt, StreamExt};
+use commands::{cli_loop::CliLoop, command::CommandContext};
+use futures::FutureExt;
 use log::*;
 use opentelemetry::{self, global, KeyValue};
-use rustyline::{config::OutputStreamType, error::ReadlineError, CompletionType, Config, EditMode, Editor};
 use tari_app_utilities::{
     consts,
     identity_management::setup_node_identity,
@@ -139,7 +123,7 @@ use tari_core::chain_storage::ChainStorageError;
 #[cfg(all(unix, feature = "libtor"))]
 use tari_libtor::tor::Tor;
 use tari_shutdown::{Shutdown, ShutdownSignal};
-use tokio::{signal, task, time};
+use tokio::task;
 use tonic::transport::Server;
 use tracing_subscriber::{layer::SubscriberExt, Registry};
 
@@ -289,7 +273,7 @@ async fn run_node(
 
     // Run, node, run!
     let context = CommandContext::new(&ctx, shutdown);
-    let main_loop = MainLoop::new(context, bootstrap.watch, bootstrap.non_interactive_mode);
+    let main_loop = CliLoop::new(context, bootstrap.watch, bootstrap.non_interactive_mode);
     if bootstrap.non_interactive_mode {
         println!("Node started in non-interactive mode (pid = {})", process::id());
     } else {
@@ -355,199 +339,4 @@ async fn run_grpc(
 
     info!(target: LOG_TARGET, "Stopping GRPC");
     Ok(())
-}
-
-fn get_status_interval(start_time: Instant, long_interval: Duration) -> time::Sleep {
-    let duration = match start_time.elapsed().as_secs() {
-        0..=120 => Duration::from_secs(5),
-        _ => long_interval,
-    };
-    time::sleep(duration)
-}
-
-struct MainLoop {
-    context: CommandContext,
-    reader: CommandReader,
-    commands: Vec<String>,
-    watch_task: Option<WatchCommand>,
-    non_interactive: bool,
-    first_signal: bool,
-    done: bool,
-    shutdown_signal: ShutdownSignal,
-}
-
-impl MainLoop {
-    fn new(context: CommandContext, watch_command: Option<String>, non_interactive: bool) -> Self {
-        let parser = Parser::new();
-        let commands = parser.get_commands();
-        let cli_config = Config::builder()
-            .history_ignore_space(true)
-            .completion_type(CompletionType::List)
-            .edit_mode(EditMode::Emacs)
-            .output_stream(OutputStreamType::Stdout)
-            .auto_add_history(true)
-            .build();
-        let mut rustyline = Editor::with_config(cli_config);
-        rustyline.set_helper(Some(parser));
-        let reader = CommandReader::new(rustyline);
-        let watch_task = {
-            if let Some(line) = watch_command {
-                WatchCommand::new(line)
-            } else if non_interactive {
-                WatchCommand::new("status --output log")
-            } else {
-                WatchCommand::new("status")
-            }
-        };
-        let shutdown_signal = context.shutdown.to_signal();
-        Self {
-            context,
-            reader,
-            commands,
-            watch_task: Some(watch_task),
-            non_interactive,
-            first_signal: false,
-            done: false,
-            shutdown_signal,
-        }
-    }
-
-    async fn run_watch_task(&mut self) {
-        if let Some(command) = self.watch_task.take() {
-            let start_time = Instant::now();
-            let mut interrupt = signal::ctrl_c().fuse().boxed();
-            let mut software_update_notif = self.context.software_updater.new_update_notifier().clone();
-            let config = self.context.config.clone();
-            let line = command.line();
-            let interval = command
-                .interval
-                .map(Duration::from_secs)
-                .unwrap_or(config.base_node_status_line_interval);
-            if let Err(err) = self.context.handle_command_str(line).await {
-                println!("Wrong command to watch `{}`. Failed with: {}", line, err);
-            } else {
-                let mut events = EventStream::new();
-                loop {
-                    terminal::enable_raw_mode().ok();
-                    let interval = get_status_interval(start_time, interval);
-                    tokio::select! {
-                        _ = interval => {
-                            terminal::disable_raw_mode().ok();
-                            if let Err(err) = self.context.handle_command_str(line).await {
-                                println!("Watched command `{}` failed: {}", line, err);
-                            }
-                            continue;
-                        },
-                        _ = &mut interrupt => {
-                            break;
-                        }
-                        event = events.next() => {
-                            match event {
-                                Some(Ok(Event::Key(key))) => {
-                                    match key {
-                                        KeyEvent { code: KeyCode::Char('c'), modifiers: KeyModifiers::CONTROL } => {
-                                            break;
-                                        }
-                                        _ => {
-                                            if self.non_interactive {
-                                                println!("Press Ctrl-C to interrupt the node.");
-                                            } else {
-                                                println!("Press Ctrl-C to enter the interactive shell.");
-                                            }
-                                        }
-                                    }
-                                }
-                                _ => {
-                                }
-                            }
-                        }
-                        // TODO: Is that good idea? Or add a separate command?
-                        Ok(_) = software_update_notif.changed() => {
-                            if let Some(ref update) = *software_update_notif.borrow() {
-                                println!(
-                                    "Version {} of the {} is available: {} (sha: {})",
-                                    update.version(),
-                                    update.app(),
-                                    update.download_url(),
-                                    update.to_hash_hex()
-                                );
-                            }
-                        }
-                    }
-                    crossterm::execute!(std::io::stdout(), cursor::MoveToNextLine(1)).ok();
-                }
-                terminal::disable_raw_mode().ok();
-            }
-        }
-    }
-
-    async fn execute_command(&mut self) {
-        tokio::select! {
-            res = self.reader.next_command() => {
-                if let Some(event) = res {
-                    match event {
-                        Ok(line) => {
-                            self.first_signal = false;
-                            if !line.is_empty() {
-                                match self.context.handle_command_str(&line).await {
-                                    Err(err) => {
-                                        println!("Command `{}` failed: {}", line, err);
-                                    }
-                                    Ok(command) => {
-                                        self.watch_task = command;
-                                    }
-                                }
-                            }
-                        }
-                        Err(ReadlineError::Interrupted) => {
-                            // If `Ctrl-C` is pressed
-                            if !self.first_signal {
-                                println!("Are you leaving already? Press Ctrl-C again (or Ctrl-D) to terminate the node.");
-                                self.first_signal = true;
-                            } else {
-                                self.done = true;
-                            }
-                        }
-                        Err(ReadlineError::Eof) => {
-                            // If `Ctrl-D` is pressed
-                            self.done = true;
-                        }
-                        Err(err) => {
-                            // TODO: Not sure we have to break here
-                            // This happens when the node is shutting down.
-                            debug!(target:  LOG_TARGET, "Could not read line from rustyline:{}", err);
-                            self.done = true;
-                        }
-                    }
-                } else {
-                    self.done = true;
-                }
-            },
-            _ = self.shutdown_signal.wait() => {
-                self.done = true;
-            }
-        }
-    }
-}
-
-impl MainLoop {
-    /// Runs the Base Node CLI loop
-    /// ## Parameters
-    /// `parser` - The parser to process input commands
-    /// `shutdown` - The trigger for shutting down
-    ///
-    /// ## Returns
-    /// Doesn't return anything
-    async fn cli_loop(mut self) {
-        commands::cli::print_banner(self.commands.clone(), 3);
-
-        // TODO: Check for a new version here
-        while !self.done {
-            self.run_watch_task().await;
-            if self.non_interactive {
-                break;
-            }
-            self.execute_command().await;
-        }
-    }
 }

--- a/applications/tari_base_node/src/main.rs
+++ b/applications/tari_base_node/src/main.rs
@@ -420,14 +420,16 @@ impl MainLoop {
                     println!("Wrong command to watch `{}`. Failed with: {}", line, err);
                 } else {
                     let mut events = EventStream::new();
-                    terminal::enable_raw_mode().ok();
                     loop {
+                        terminal::enable_raw_mode().ok();
                         let interval = get_status_interval(start_time, interval);
                         tokio::select! {
                             _ = interval => {
+                                terminal::disable_raw_mode().ok();
                                 if let Err(err) = self.context.handle_command_str(line).await {
                                     println!("Watched command `{}` failed: {}", line, err);
                                 }
+                                continue;
                             },
                             _ = &mut interrupt => {
                                 break;
@@ -440,7 +442,11 @@ impl MainLoop {
                                                 break;
                                             }
                                             _ => {
-                                                println!("Press Ctrl-C to enter the interactive shell.");
+                                                if non_interactive {
+                                                    println!("Press Ctrl-C to interrupt the node.");
+                                                } else {
+                                                    println!("Press Ctrl-C to enter the interactive shell.");
+                                                }
                                             }
                                         }
                                     }


### PR DESCRIPTION
Description
---
It adds an events stream to listens to key press events in the watch mode.

Another changes:
- `cli_loop` function replaced with the `CliLoop` struct that also moved to a separate module
- `status_loop` replaced with the `CliLoop` struct

Motivation and Context
---
We should suggest the user how to exit the watch mode.
Also the cli loop reduced and divided into several parts.

How Has This Been Tested?
---
Manually

