### PR TITLE
feat(metrics): add UTXO set size to base node metrics

### DIFF
--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -21,7 +21,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use std::{
-    convert::TryFrom,
+    convert::{TryFrom, TryInto},
     sync::Arc,
     time::{Duration, Instant},
 };
@@ -708,7 +708,7 @@ where B: BlockchainBackend + 'static
                     BlockAddResult::ChainReorg { .. } => true,
                 };
 
-                self.update_block_result_metrics(&block_add_result);
+                self.update_block_result_metrics(&block_add_result).await?;
                 self.publish_block_event(BlockEvent::ValidBlockAdded(block.clone(), block_add_result));
 
                 if should_propagate {
@@ -762,21 +762,41 @@ where B: BlockchainBackend + 'static
         }
     }
 
-    fn update_block_result_metrics(&self, block_add_result: &BlockAddResult) {
+    async fn update_block_result_metrics(&self, block_add_result: &BlockAddResult) -> Result<(), CommsInterfaceError> {
+        fn update_target_difficulty(block: &ChainBlock) {
+            match block.header().pow_algo() {
+                PowAlgorithm::Sha3 => {
+                    metrics::target_difficulty_sha(block.height())
+                        .set(i64::try_from(block.accumulated_data().target_difficulty.as_u64()).unwrap_or(i64::MAX));
+                },
+                PowAlgorithm::Monero => {
+                    metrics::target_difficulty_monero(block.height())
+                        .set(i64::try_from(block.accumulated_data().target_difficulty.as_u64()).unwrap_or(i64::MAX));
+                },
+            }
+        }
+
         match block_add_result {
             BlockAddResult::Ok(ref block) => {
-                metrics::target_difficulty(block.height())
-                    .set(i64::try_from(block.accumulated_data().target_difficulty.as_u64()).unwrap_or(i64::MAX));
+                update_target_difficulty(block);
+                let utxo_set_size = self.blockchain_db.utxo_count().await?;
+                metrics::utxo_set_size().set(utxo_set_size.try_into().unwrap_or(i64::MAX));
             },
             BlockAddResult::ChainReorg { added, removed } => {
                 let fork_height = added.last().map(|b| b.height() - 1).unwrap_or_default();
                 metrics::reorg(fork_height, added.len(), removed.len()).inc();
+                for block in added {
+                    update_target_difficulty(block);
+                }
+                let utxo_set_size = self.blockchain_db.utxo_count().await?;
+                metrics::utxo_set_size().set(utxo_set_size.try_into().unwrap_or(i64::MAX));
             },
             BlockAddResult::OrphanBlock => {
                 metrics::orphaned_blocks().inc();
             },
             _ => {},
         }
+        Ok(())
     }
 
     async fn get_target_difficulty_for_next_block(

--- a/base_layer/core/src/base_node/metrics.rs
+++ b/base_layer/core/src/base_node/metrics.rs
@@ -24,11 +24,24 @@ use once_cell::sync::Lazy;
 use tari_metrics::{IntCounter, IntCounterVec, IntGauge, IntGaugeVec};
 use tari_utilities::hex::to_hex;
 
-pub fn target_difficulty(height: u64) -> IntGauge {
+pub fn target_difficulty_sha(height: u64) -> IntGauge {
     static METER: Lazy<IntGaugeVec> = Lazy::new(|| {
         tari_metrics::register_int_gauge_vec(
-            "base_node::blockchain::target_difficulty",
-            "The current miner target difficulty",
+            "base_node::blockchain::target_difficulty_sha",
+            "The current miner target difficulty for the sha3 PoW algo",
+            &["height"],
+        )
+        .unwrap()
+    });
+
+    METER.with_label_values(&[&height.to_string()])
+}
+
+pub fn target_difficulty_monero(height: u64) -> IntGauge {
+    static METER: Lazy<IntGaugeVec> = Lazy::new(|| {
+        tari_metrics::register_int_gauge_vec(
+            "base_node::blockchain::target_difficulty_monero",
+            "The current miner target difficulty for the monero PoW algo",
             &["height"],
         )
         .unwrap()
@@ -110,6 +123,18 @@ pub fn active_sync_peers() -> IntGauge {
         tari_metrics::register_int_gauge(
             "base_node::sync::active_peers",
             "Number of active peers syncing from this node",
+        )
+        .unwrap()
+    });
+
+    METER.clone()
+}
+
+pub fn utxo_set_size() -> IntGauge {
+    static METER: Lazy<IntGauge> = Lazy::new(|| {
+        tari_metrics::register_int_gauge(
+            "base_node::blockchain::utxo_set_size",
+            "The number of UTXOs in the current UTXO set",
         )
         .unwrap()
     });

--- a/base_layer/core/src/chain_storage/async_db.rs
+++ b/base_layer/core/src/chain_storage/async_db.rs
@@ -174,6 +174,8 @@ impl<B: BlockchainBackend + 'static> AsyncBlockchainDb<B> {
         parent_public_key: PublicKey,
         range: Range<usize>) -> Vec<UtxoMinedInfo>, "fetch_all_unspent_by_parent_public_key");
 
+    make_async_fn!(utxo_count() -> usize, "utxo_count");
+
     //---------------------------------- Kernel --------------------------------------------//
     make_async_fn!(fetch_kernel_by_excess_sig(excess_sig: Signature) -> Option<(TransactionKernel, HashOutput)>, "fetch_kernel_by_excess_sig");
 

--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -450,6 +450,12 @@ where B: BlockchainBackend
         db.fetch_utxos_in_block(&hash, deleted.as_deref())
     }
 
+    /// Returns the number of UTXOs in the current unspent set
+    pub fn utxo_count(&self) -> Result<usize, ChainStorageError> {
+        let db = self.db_read_access()?;
+        db.utxo_count()
+    }
+
     /// Returns the block header at the given block height.
     pub fn fetch_header(&self, height: u64) -> Result<Option<BlockHeader>, ChainStorageError> {
         let db = self.db_read_access()?;

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -2105,7 +2105,7 @@ impl BlockchainBackend for LMDBDatabase {
 
     fn utxo_count(&self) -> Result<usize, ChainStorageError> {
         let txn = self.read_transaction()?;
-        lmdb_len(&txn, &self.utxos_db)
+        lmdb_len(&txn, &self.utxo_commitment_index)
     }
 
     fn kernel_count(&self) -> Result<usize, ChainStorageError> {

--- a/base_layer/core/src/proof_of_work/proof_of_work.rs
+++ b/base_layer/core/src/proof_of_work/proof_of_work.rs
@@ -77,16 +77,6 @@ impl ProofOfWork {
     }
 }
 
-impl Display for PowAlgorithm {
-    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
-        let algo = match self {
-            PowAlgorithm::Monero => "Monero",
-            PowAlgorithm::Sha3 => "Sha3",
-        };
-        fmt.write_str(&algo.to_string())
-    }
-}
-
 impl Display for ProofOfWork {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         writeln!(fmt, "Mining algorithm: {}", self.pow_algo)?;

--- a/base_layer/core/src/proof_of_work/proof_of_work_algorithm.rs
+++ b/base_layer/core/src/proof_of_work/proof_of_work_algorithm.rs
@@ -19,7 +19,11 @@
 // SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-use std::{convert::TryFrom, str::FromStr};
+use std::{
+    convert::TryFrom,
+    fmt::{Display, Formatter},
+    str::FromStr,
+};
 
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -73,5 +77,15 @@ impl FromStr for PowAlgorithm {
             "sha" | "sha3" | "SHA3" => Ok(Self::Sha3),
             other => Err(PowAlgorithmParseError::UnknownType(other.into())),
         }
+    }
+}
+
+impl Display for PowAlgorithm {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> std::fmt::Result {
+        let algo = match self {
+            PowAlgorithm::Monero => "Monero",
+            PowAlgorithm::Sha3 => "Sha3",
+        };
+        fmt.write_str(algo)
     }
 }

--- a/comms/src/peer_manager/manager.rs
+++ b/comms/src/peer_manager/manager.rs
@@ -26,6 +26,8 @@ use multiaddr::Multiaddr;
 use tari_storage::{lmdb_store::LMDBDatabase, IterationResult};
 use tokio::sync::RwLock;
 
+#[cfg(feature = "metrics")]
+use crate::peer_manager::metrics;
 use crate::{
     peer_manager::{
         migrations,
@@ -71,12 +73,26 @@ impl PeerManager {
     /// Adds a peer to the routing table of the PeerManager if the peer does not already exist. When a peer already
     /// exist, the stored version will be replaced with the newly provided peer.
     pub async fn add_peer(&self, peer: Peer) -> Result<PeerId, PeerManagerError> {
-        self.peer_storage.write().await.add_peer(peer)
+        let mut lock = self.peer_storage.write().await;
+        let peer_id = lock.add_peer(peer)?;
+        #[cfg(feature = "metrics")]
+        {
+            let count = lock.count();
+            metrics::peer_list_size().set(count as i64);
+        }
+        Ok(peer_id)
     }
 
     /// The peer with the specified public_key will be removed from the PeerManager
     pub async fn delete_peer(&self, node_id: &NodeId) -> Result<(), PeerManagerError> {
-        self.peer_storage.write().await.delete_peer(node_id)
+        let mut lock = self.peer_storage.write().await;
+        lock.delete_peer(node_id)?;
+        #[cfg(feature = "metrics")]
+        {
+            let count = lock.count();
+            metrics::peer_list_size().set(count as i64);
+        }
+        Ok(())
     }
 
     /// Performs the given [PeerQuery].

--- a/comms/src/peer_manager/metrics.rs
+++ b/comms/src/peer_manager/metrics.rs
@@ -1,0 +1,33 @@
+//  Copyright 2022, The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use once_cell::sync::Lazy;
+use tari_metrics::IntGauge;
+
+pub fn peer_list_size() -> IntGauge {
+    static METER: Lazy<IntGauge> = Lazy::new(|| {
+        tari_metrics::register_int_gauge("comms::peer_manager::peer_list_size", "The total number of known peers")
+            .unwrap()
+    });
+
+    METER.clone()
+}

--- a/comms/src/peer_manager/mod.rs
+++ b/comms/src/peer_manager/mod.rs
@@ -111,3 +111,6 @@ mod or_not_found;
 pub use or_not_found::OrNotFound;
 
 mod wrapper;
+
+#[cfg(feature = "metrics")]
+mod metrics;


### PR DESCRIPTION
Description
---
- adds `tari_base_node::blockchain::utxo_set_size`
- splits `tari_base_node::blockchain::target_difficulty` into `target_difficulty_sha` and `target_difficulty_monero`
- changes `BlockchainDb::utxo_count` to return the number of UTXOs in the unspent set, rather than the number of outputs that were ever stored (differs depending on pruned height).
- adds peer list size metric

Motivation and Context
---
Monitor the UTXO set size and independent PoW algos.
fix: `utco_count` was meant to return the current UTXO set size 

How Has This Been Tested?
---
Local prometheus 
