### PR TITLE
test(core): reinstate inputs_not_mallaeble test

### DIFF
--- a/base_layer/core/src/transactions/transaction_components/test.rs
+++ b/base_layer/core/src/transactions/transaction_components/test.rs
@@ -372,7 +372,6 @@ fn check_duplicate_inputs_outputs() {
 }
 
 #[test]
-#[ignore = "TODO: fix script error"]
 fn inputs_not_malleable() {
     let (inputs, outputs) = test_helpers::create_unblinded_txos(
         5000.into(),
@@ -381,18 +380,17 @@ fn inputs_not_malleable() {
         2,
         15.into(),
         Default::default(),
-        script![Drop],
+        script![Nop],
         Default::default(),
     );
-    let script_pk = PublicKey::from_secret_key(&outputs[0].0.script_private_key);
     let mut stack = inputs[0].input_data.clone();
     let mut tx = test_helpers::create_transaction_with(1, 15.into(), inputs, outputs);
 
     stack
         .push(StackItem::Hash(*b"Pls put this on tha tari network"))
         .unwrap();
-    stack.push(StackItem::PublicKey(script_pk)).unwrap();
 
+    tx.body.inputs_mut()[0].set_script(script![Drop]).unwrap();
     tx.body.inputs_mut()[0].input_data = stack;
 
     let factories = CryptoFactories::default();
@@ -400,7 +398,6 @@ fn inputs_not_malleable() {
         .validate_internal_consistency(false, &factories, None, None, u64::MAX)
         .unwrap_err();
     unpack_enum!(TransactionError::InvalidSignatureError(_a) = err);
-    // assert!(matches!(err, TransactionError::InvalidSignatureError(_)));
 }
 
 #[test]

--- a/base_layer/core/src/transactions/transaction_components/transaction_input.rs
+++ b/base_layer/core/src/transactions/transaction_components/transaction_input.rs
@@ -356,6 +356,8 @@ impl TransactionInput {
         }
     }
 
+    /// Sets the input's Tari script. Only useful in tests.
+    #[cfg(test)]
     pub fn set_script(&mut self, new_script: TariScript) -> Result<(), TransactionError> {
         if let SpentOutput::OutputData { ref mut script, .. } = self.spent_output {
             *script = new_script;

--- a/base_layer/core/src/transactions/transaction_components/transaction_input.rs
+++ b/base_layer/core/src/transactions/transaction_components/transaction_input.rs
@@ -356,6 +356,15 @@ impl TransactionInput {
         }
     }
 
+    pub fn set_script(&mut self, new_script: TariScript) -> Result<(), TransactionError> {
+        if let SpentOutput::OutputData { ref mut script, .. } = self.spent_output {
+            *script = new_script;
+            Ok(())
+        } else {
+            Err(TransactionError::MissingTransactionInputData)
+        }
+    }
+
     /// Return a clone of this Input into its compact form
     pub fn to_compact(&self) -> Self {
         Self::new(


### PR DESCRIPTION
Description
---
Reinstate/unignore `inputs_not_malleable` unit test

Motivation and Context
---
Test was broken 

How Has This Been Tested?
---
Test passes
