### PR TITLE
ci: add create release to libwallet build

### DIFF
--- a/.github/workflows/libwallet.yml
+++ b/.github/workflows/libwallet.yml
@@ -91,6 +91,21 @@ jobs:
           name: libwallet-ios
           path: ${{ github.workspace }}/MobileWallet/TariLib/
 
+  create-release:
+    runs-on: ubuntu-latest
+    needs: [android, ios]
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    steps:
+      - name: Download binaries
+        uses: actions/download-artifact@v2
+      - name: Create release
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: "libwallet*"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          prerelease: true
+          draft: true
+
   # "Error: Container action is only supported on Linux"
   # - name: Sync to S3
   #   uses: jakejarvis/s3-sync-action@v0.5.1


### PR DESCRIPTION
Description
---

- creates a release on libwallet tags (still requires testing)

