### PR TITLE
fix(wallet): tor identity private key needs to be serialized

### DIFF
--- a/comms/src/tor/hidden_service/mod.rs
+++ b/comms/src/tor/hidden_service/mod.rs
@@ -91,7 +91,6 @@ fn multiaddr_from_service_id_and_port(service_id: &str, onion_port: u16) -> Resu
 #[derive(Clone, Derivative, Serialize, Deserialize)]
 #[derivative(Debug)]
 pub struct TorIdentity {
-    #[serde(skip_serializing)]
     #[derivative(Debug = "ignore")]
     pub private_key: PrivateKey,
     pub service_id: String,


### PR DESCRIPTION
Description
---
- fixes regression where tor identity private key is not serialised in wallet db

Motivation and Context
---
Following error on wallet startup
```
ExitError { exit_code: WalletError, details: Some("Wallet storage error: `Error converting a type: `An error occurred de-/serialising an object from/into JSON``") }
```

Ref #3905 

How Has This Been Tested?
---
Wallet starts up
