### PR TITLE
chore(core): make HashWriter API more ergonomic and similar to Digest

### DIFF
--- a/base_layer/core/src/common/hash_writer.rs
+++ b/base_layer/core/src/common/hash_writer.rs
@@ -24,6 +24,9 @@ use std::io::Write;
 
 use digest::{consts::U32, Digest, FixedOutput, Update};
 
+use crate::consensus::ConsensusEncoding;
+
+#[derive(Clone, Default)]
 pub struct HashWriter<H> {
     digest: H,
 }
@@ -35,10 +38,21 @@ impl<H: Digest> HashWriter<H> {
 }
 
 impl<H> HashWriter<H>
-where H: FixedOutput<OutputSize = U32>
+where H: FixedOutput<OutputSize = U32> + Update
 {
     pub fn finalize(self) -> [u8; 32] {
         self.digest.finalize_fixed().into()
+    }
+
+    pub fn update_consensus_encode<T: ConsensusEncoding>(&mut self, data: &T) {
+        // UNWRAP: ConsensusEncode MUST only error if the writer errors, HashWriter::write is infallible
+        data.consensus_encode(self)
+            .expect("Incorrect implementation of ConsensusEncoding encountered. Implementations MUST be infallible.");
+    }
+
+    pub fn chain<T: ConsensusEncoding>(mut self, data: &T) -> Self {
+        self.update_consensus_encode(data);
+        self
     }
 
     pub fn into_digest(self) -> H {

--- a/base_layer/core/src/transactions/transaction_components/mod.rs
+++ b/base_layer/core/src/transactions/transaction_components/mod.rs
@@ -86,7 +86,7 @@ pub const MAX_TRANSACTION_RECIPIENTS: usize = 15;
 
 //----------------------------------------     Crate functions   ----------------------------------------------------//
 
-use crate::{common::hash_writer::HashWriter, consensus::ConsensusEncoding, covenants::Covenant};
+use crate::{common::hash_writer::HashWriter, covenants::Covenant};
 
 /// Implement the canonical hashing function for TransactionOutput and UnblindedOutput for use in
 /// ordering as well as for the output hash calculation for TransactionInput.
@@ -102,12 +102,11 @@ pub(super) fn hash_output(
     script: &TariScript,
     covenant: &Covenant,
 ) -> [u8; 32] {
-    let mut hasher = HashWriter::new(HashDigest::new());
-    // unwrap: hashwriter is infallible
-    version.consensus_encode(&mut hasher).unwrap();
-    features.consensus_encode(&mut hasher).unwrap();
-    commitment.consensus_encode(&mut hasher).unwrap();
-    script.consensus_encode(&mut hasher).unwrap();
-    covenant.consensus_encode(&mut hasher).unwrap();
-    hasher.finalize()
+    HashWriter::new(HashDigest::new())
+        .chain(&version)
+        .chain(features)
+        .chain(commitment)
+        .chain(script)
+        .chain(covenant)
+        .finalize()
 }

--- a/base_layer/core/src/transactions/transaction_components/transaction_input.rs
+++ b/base_layer/core/src/transactions/transaction_components/transaction_input.rs
@@ -40,7 +40,6 @@ use tari_script::{ExecutionStack, ScriptContext, StackItem, TariScript};
 use super::{TransactionInputVersion, TransactionOutputVersion};
 use crate::{
     common::hash_writer::HashWriter,
-    consensus::ConsensusEncoding,
     covenants::Covenant,
     transactions::{
         transaction_components,
@@ -158,13 +157,14 @@ impl TransactionInput {
         script_public_key: &PublicKey,
         commitment: &Commitment,
     ) -> Vec<u8> {
-        let mut writer = HashWriter::new(HashDigest::new());
-        nonce_commitment.consensus_encode(&mut writer).unwrap();
-        script.consensus_encode(&mut writer).unwrap();
-        input_data.consensus_encode(&mut writer).unwrap();
-        script_public_key.consensus_encode(&mut writer).unwrap();
-        commitment.consensus_encode(&mut writer).unwrap();
-        writer.finalize().to_vec()
+        HashWriter::new(HashDigest::new())
+            .chain(nonce_commitment)
+            .chain(script)
+            .chain(input_data)
+            .chain(script_public_key)
+            .chain(commitment)
+            .finalize()
+            .to_vec()
     }
 
     pub fn commitment(&self) -> Result<&Commitment, TransactionError> {
@@ -324,7 +324,7 @@ impl TransactionInput {
         match self.spent_output {
             SpentOutput::OutputHash(_) => Err(TransactionError::MissingTransactionInputData),
             SpentOutput::OutputData {
-                version,
+                ref version,
                 ref features,
                 ref commitment,
                 ref script,
@@ -332,15 +332,15 @@ impl TransactionInput {
                 ref covenant,
             } => {
                 // TODO: Change this hash to what is in RFC-0121/Consensus Encoding #testnet-reset
-                let mut writer = HashWriter::new(HashDigest::new());
-                version.consensus_encode(&mut writer)?;
-                features.consensus_encode(&mut writer)?;
-                commitment.consensus_encode(&mut writer)?;
-                script.consensus_encode(&mut writer)?;
-                sender_offset_public_key.consensus_encode(&mut writer)?;
-                self.script_signature.consensus_encode(&mut writer)?;
-                self.input_data.consensus_encode(&mut writer)?;
-                covenant.consensus_encode(&mut writer)?;
+                let writer = HashWriter::new(HashDigest::new())
+                    .chain(version)
+                    .chain(features)
+                    .chain(commitment)
+                    .chain(script)
+                    .chain(sender_offset_public_key)
+                    .chain(&self.script_signature)
+                    .chain(&self.input_data)
+                    .chain(covenant);
 
                 Ok(writer.finalize().to_vec())
             },

--- a/base_layer/core/src/transactions/transaction_components/transaction_kernel.rs
+++ b/base_layer/core/src/transactions/transaction_components/transaction_kernel.rs
@@ -36,7 +36,6 @@ use tari_crypto::tari_utilities::{hex::Hex, message_format::MessageFormat, ByteA
 use super::TransactionKernelVersion;
 use crate::{
     common::hash_writer::HashWriter,
-    consensus::ConsensusEncoding,
     transactions::{
         tari_amount::MicroTari,
         transaction_components::{KernelFeatures, TransactionError},
@@ -129,16 +128,15 @@ impl Hashable for TransactionKernel {
     /// Produce a canonical hash for a transaction kernel. The hash is given by
     /// $$ H(feature_bits | fee | lock_height | P_excess | R_sum | s_sum)
     fn hash(&self) -> Vec<u8> {
-        let mut writer = HashWriter::new(HashDigest::new());
-        // unwraps: HashWriter is infallible
-        self.version.consensus_encode(&mut writer).unwrap();
-        self.features.consensus_encode(&mut writer).unwrap();
-        self.fee.consensus_encode(&mut writer).unwrap();
-        self.lock_height.consensus_encode(&mut writer).unwrap();
-        self.excess.consensus_encode(&mut writer).unwrap();
-        self.excess_sig.consensus_encode(&mut writer).unwrap();
-
-        writer.finalize().to_vec()
+        HashWriter::new(HashDigest::new())
+            .chain(&self.version)
+            .chain(&self.features)
+            .chain(&self.fee)
+            .chain(&self.lock_height)
+            .chain(&self.excess)
+            .chain(&self.excess_sig)
+            .finalize()
+            .to_vec()
     }
 }
 


### PR DESCRIPTION
Description
---
- adds chain method to `HashWriter` 

Motivation and Context
---
Improves ergonomics of `HashWriter` to remove the need to unwrap each call to consensus encode when using it

How Has This Been Tested?
---
Existing tests, manually to check no breaking changes

