### PR TITLE
refactor: improve ergonomics of error to RPC status

### DIFF
--- a/applications/tari_validator_node/src/p2p/rpc/service_impl.rs
+++ b/applications/tari_validator_node/src/p2p/rpc/service_impl.rs
@@ -25,7 +25,7 @@ use std::convert::{TryFrom, TryInto};
 use log::*;
 use tari_common_types::types::PublicKey;
 use tari_comms::{
-    protocol::rpc::{Request, Response, RpcStatus, Streaming},
+    protocol::rpc::{Request, Response, RpcStatus, RpcStatusResultExt, Streaming},
     utils,
 };
 use tari_crypto::tari_utilities::ByteArray;
@@ -171,19 +171,19 @@ where
         let db = self
             .db_factory
             .get_chain_db(&asset_public_key)
-            .map_err(RpcStatus::log_internal_error(LOG_TARGET))?
+            .rpc_status_internal_error(LOG_TARGET)?
             .ok_or_else(|| RpcStatus::not_found("Asset not found"))?;
 
         let start_block = db
             .find_sidechain_block_by_node_hash(&start_hash)
-            .map_err(RpcStatus::log_internal_error(LOG_TARGET))?
+            .rpc_status_internal_error(LOG_TARGET)?
             .ok_or_else(|| RpcStatus::not_found(format!("Block not found with start_hash '{}'", start_hash)))?;
 
         let end_block_exists = end_hash
             .as_ref()
             .map(|end_hash| db.sidechain_block_exists(end_hash))
             .transpose()
-            .map_err(RpcStatus::log_internal_error(LOG_TARGET))?;
+            .rpc_status_internal_error(LOG_TARGET)?;
 
         if !end_block_exists.unwrap_or(true) {
             return Err(RpcStatus::not_found(format!(
@@ -247,11 +247,11 @@ where
         let db = self
             .db_factory
             .get_state_db(&asset_public_key)
-            .map_err(RpcStatus::log_internal_error(LOG_TARGET))?
+            .rpc_status_internal_error(LOG_TARGET)?
             .ok_or_else(|| RpcStatus::not_found("Asset not found"))?;
 
         let uow = db.reader();
-        let data = uow.get_all_state().map_err(RpcStatus::log_internal_error(LOG_TARGET))?;
+        let data = uow.get_all_state().rpc_status_internal_error(LOG_TARGET)?;
         let (tx, rx) = mpsc::channel(10);
 
         task::spawn(async move {
@@ -291,13 +291,13 @@ where
         let db = self
             .db_factory
             .get_state_db(&asset_public_key)
-            .map_err(RpcStatus::log_internal_error(LOG_TARGET))?
+            .rpc_status_internal_error(LOG_TARGET)?
             .ok_or_else(|| RpcStatus::not_found("Asset not found"))?;
 
         let reader = db.reader();
         let op_logs = reader
             .get_op_logs_for_height(msg.height)
-            .map_err(RpcStatus::log_internal_error(LOG_TARGET))?;
+            .rpc_status_internal_error(LOG_TARGET)?;
 
         let resp = proto::GetStateOpLogsResponse {
             op_logs: op_logs.into_iter().map(Into::into).collect(),
@@ -318,10 +318,10 @@ where
         let db = self
             .db_factory
             .get_chain_db(&asset_public_key)
-            .map_err(RpcStatus::log_internal_error(LOG_TARGET))?
+            .rpc_status_internal_error(LOG_TARGET)?
             .ok_or_else(|| RpcStatus::not_found("Asset not found"))?;
 
-        let tip_node = db.get_tip_node().map_err(RpcStatus::log_internal_error(LOG_TARGET))?;
+        let tip_node = db.get_tip_node().rpc_status_internal_error(LOG_TARGET)?;
 
         let resp = proto::GetTipNodeResponse {
             tip_node: tip_node.map(Into::into),

--- a/base_layer/core/src/base_node/rpc/sync_utxos_by_block_task.rs
+++ b/base_layer/core/src/base_node/rpc/sync_utxos_by_block_task.rs
@@ -23,7 +23,7 @@
 use std::{sync::Arc, time::Instant};
 
 use log::*;
-use tari_comms::protocol::rpc::RpcStatus;
+use tari_comms::protocol::rpc::{RpcStatus, RpcStatusResultExt};
 use tari_crypto::tari_utilities::{hex::Hex, Hashable};
 use tokio::{sync::mpsc, task};
 
@@ -56,14 +56,14 @@ where B: BlockchainBackend + 'static
             .db
             .fetch_header_by_block_hash(request.start_header_hash.clone())
             .await
-            .map_err(RpcStatus::log_internal_error(LOG_TARGET))?
+            .rpc_status_internal_error(LOG_TARGET)?
             .ok_or_else(|| RpcStatus::not_found("Start header hash is was not found"))?;
 
         let end_header = self
             .db
             .fetch_header_by_block_hash(request.end_header_hash.clone())
             .await
-            .map_err(RpcStatus::log_internal_error(LOG_TARGET))?
+            .rpc_status_internal_error(LOG_TARGET)?
             .ok_or_else(|| RpcStatus::not_found("End header hash is was not found"))?;
 
         if start_header.height > end_header.height {
@@ -131,7 +131,7 @@ where B: BlockchainBackend + 'static
                 .db
                 .fetch_utxos_in_block(current_header.hash(), Some(bitmap.clone()))
                 .await
-                .map_err(RpcStatus::log_internal_error(LOG_TARGET))?;
+                .rpc_status_internal_error(LOG_TARGET)?;
 
             let utxos: Vec<proto::types::TransactionOutput> = utxos
                     .into_iter()
@@ -174,7 +174,7 @@ where B: BlockchainBackend + 'static
                 .db
                 .fetch_header(current_header.height + 1)
                 .await
-                .map_err(RpcStatus::log_internal_error(LOG_TARGET))?
+                .rpc_status_internal_error(LOG_TARGET)?
                 .ok_or_else(|| {
                     RpcStatus::general(format!(
                         "Potential data consistency issue: header {} not found",

--- a/base_layer/core/src/base_node/sync/rpc/sync_utxos_task.rs
+++ b/base_layer/core/src/base_node/sync/rpc/sync_utxos_task.rs
@@ -24,7 +24,7 @@ use std::{sync::Arc, time::Instant};
 
 use log::*;
 use tari_comms::{
-    protocol::rpc::{Request, RpcStatus},
+    protocol::rpc::{Request, RpcStatus, RpcStatusResultExt},
     utils,
 };
 use tari_crypto::tari_utilities::{hex::Hex, Hashable};
@@ -75,7 +75,7 @@ where B: BlockchainBackend + 'static
             .db
             .fetch_header_by_block_hash(msg.end_header_hash.clone())
             .await
-            .map_err(RpcStatus::log_internal_error(LOG_TARGET))?
+            .rpc_status_internal_error(LOG_TARGET)?
             .ok_or_else(|| RpcStatus::not_found("End header hash is was not found"))?;
 
         if start_header.height() > end_header.height {
@@ -93,7 +93,7 @@ where B: BlockchainBackend + 'static
                 .db
                 .fetch_header_by_block_hash(start_header.header().prev_hash.clone())
                 .await
-                .map_err(RpcStatus::log_internal_error(LOG_TARGET))?
+                .rpc_status_internal_error(LOG_TARGET)?
                 .ok_or_else(|| RpcStatus::not_found("Previous start header hash is was not found"))?;
 
             let skip = msg.start.checked_sub(prev_header.output_mmr_size)
@@ -186,7 +186,7 @@ where B: BlockchainBackend + 'static
                 .db
                 .fetch_utxos_in_block(current_header.hash(), Some(bitmap.clone()))
                 .await
-                .map_err(RpcStatus::log_internal_error(LOG_TARGET))?;
+                .rpc_status_internal_error(LOG_TARGET)?;
             debug!(
                 target: LOG_TARGET,
                 "Streaming UTXO(s) {}-{} ({}) for block #{}. Deleted diff len = {}",
@@ -254,7 +254,7 @@ where B: BlockchainBackend + 'static
                 .db
                 .fetch_header(current_header.height + 1)
                 .await
-                .map_err(RpcStatus::log_internal_error(LOG_TARGET))?
+                .rpc_status_internal_error(LOG_TARGET)?
                 .ok_or_else(|| {
                     RpcStatus::general(format!(
                         "Potential data consistency issue: header {} not found",

--- a/comms/src/protocol/rpc/mod.rs
+++ b/comms/src/protocol/rpc/mod.rs
@@ -84,7 +84,7 @@ mod handshake;
 pub use handshake::{Handshake, RpcHandshakeError};
 
 mod status;
-pub use status::{RpcStatus, RpcStatusCode};
+pub use status::{RpcStatus, RpcStatusCode, RpcStatusResultExt};
 
 mod not_found;
 

--- a/comms/src/protocol/rpc/status.rs
+++ b/comms/src/protocol/rpc/status.rs
@@ -182,6 +182,26 @@ impl From<prost::DecodeError> for RpcStatus {
     }
 }
 
+pub trait RpcStatusResultExt<T> {
+    fn rpc_status_internal_error(self, target: &str) -> Result<T, RpcStatus>;
+    fn rpc_status_not_found<S: ToString>(self, message: S) -> Result<T, RpcStatus>;
+    fn rpc_status_bad_request<S: ToString>(self, message: S) -> Result<T, RpcStatus>;
+}
+
+impl<T, E: std::error::Error> RpcStatusResultExt<T> for Result<T, E> {
+    fn rpc_status_internal_error(self, target: &str) -> Result<T, RpcStatus> {
+        self.map_err(RpcStatus::log_internal_error(target))
+    }
+
+    fn rpc_status_not_found<S: ToString>(self, message: S) -> Result<T, RpcStatus> {
+        self.map_err(|_| RpcStatus::not_found(message))
+    }
+
+    fn rpc_status_bad_request<S: ToString>(self, message: S) -> Result<T, RpcStatus> {
+        self.map_err(|_| RpcStatus::bad_request(message))
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RpcStatusCode {
     /// Request succeeded


### PR DESCRIPTION
Description
---
- Provide trait for easier conversion from internal errors to a RPC status error that does not leak details on the error to remote peers

Motivation and Context
---
Ultimately it's up to the implementer of the RPC service to ensure that arbitrary error info is not leaked. This PR makes footguns even harder.

How Has This Been Tested?
---
Code compiles
