### PR TITLE
fix(wallet): ensure that identity sig is stored on startup

### DIFF
--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -266,6 +266,9 @@ where
         wallet_database
             .set_node_features(comms.node_identity().features())
             .await?;
+        if let Some(identity_sig) = comms.node_identity().identity_signature_read().as_ref().cloned() {
+            wallet_database.set_comms_identity_signature(identity_sig).await?;
+        }
 
         Ok(Self {
             network: config.network,


### PR DESCRIPTION
Description
---
- adds code to store the identity signature

Motivation and Context
---
Whenever the node address changes, the identity signature is resigned for the new address. This identity signature should be preserved and reloaded later.

Ref #3950 

How Has This Been Tested?
---
Manually: Checking that identity signature is stored and doesnt change between reboots
