### PR TITLE
chore(dht): take out "TODO: remove" for message tag

### DIFF
--- a/comms/dht/src/dedup/mod.rs
+++ b/comms/dht/src/dedup/mod.rs
@@ -77,13 +77,13 @@ where
             trace!(
                 target: LOG_TARGET,
                 "Inserting message hash {} for message {} (Trace: {})",
-                message.hash.to_hex(),
+                message.dedup_hash.to_hex(),
                 message.tag,
                 message.dht_header.message_tag
             );
 
             message.dedup_hit_count = dht_requester
-                .add_message_to_dedup_cache(message.hash.clone(), message.source_peer.public_key.clone())
+                .add_message_to_dedup_cache(message.dedup_hash.clone(), message.source_peer.public_key.clone())
                 .await?;
 
             if message.dedup_hit_count as usize > allowed_message_occurrences {
@@ -198,8 +198,8 @@ mod test {
         );
         let decrypted2 = DecryptedDhtMessage::succeeded(wrap_in_envelope_body!(vec![]), None, dht_message);
 
-        assert_eq!(decrypted1.hash, decrypted2.hash);
-        let subjects = &[decrypted1.hash, decrypted2.hash];
+        assert_eq!(decrypted1.dedup_hash, decrypted2.dedup_hash);
+        let subjects = &[decrypted1.dedup_hash, decrypted2.dedup_hash];
         assert!(subjects.iter().all(|h| h.to_hex() == EXPECTED_HASH));
     }
 }

--- a/comms/dht/src/envelope.rs
+++ b/comms/dht/src/envelope.rs
@@ -133,7 +133,7 @@ impl DhtMessageType {
 
 /// This struct mirrors the protobuf version of DhtHeader but is more ergonomic to work with.
 /// It is preferable to not to expose the generated prost structs publicly.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Eq)]
 pub struct DhtMessageHeader {
     pub version: DhtProtocolVersion,
     pub destination: NodeDestination,
@@ -154,6 +154,19 @@ impl DhtMessageHeader {
         } else {
             true
         }
+    }
+}
+
+impl PartialEq for DhtMessageHeader {
+    /// Checks equality between two `DhtMessageHeader`s disregarding the transient message_tag
+    fn eq(&self, other: &Self) -> bool {
+        self.version == other.version &&
+            self.destination == other.destination &&
+            self.origin_mac == other.origin_mac &&
+            self.ephemeral_public_key == other.ephemeral_public_key &&
+            self.message_type == other.message_type &&
+            self.flags == other.flags &&
+            self.expires == other.expires
     }
 }
 

--- a/comms/dht/src/inbound/message.rs
+++ b/comms/dht/src/inbound/message.rs
@@ -95,7 +95,7 @@ pub struct DecryptedDhtMessage {
     pub is_already_forwarded: bool,
     pub decryption_result: Result<EnvelopeBody, Vec<u8>>,
     pub dedup_hit_count: u32,
-    pub hash: Vec<u8>,
+    pub dedup_hash: Vec<u8>,
 }
 
 impl DecryptedDhtMessage {
@@ -116,7 +116,7 @@ impl DecryptedDhtMessage {
         message: DhtInboundMessage,
     ) -> Self {
         Self {
-            hash: hash_inbound_message(&message),
+            dedup_hash: hash_inbound_message(&message),
             tag: message.tag,
             source_peer: message.source_peer,
             authenticated_origin,
@@ -131,7 +131,7 @@ impl DecryptedDhtMessage {
 
     pub fn failed(message: DhtInboundMessage) -> Self {
         Self {
-            hash: hash_inbound_message(&message),
+            dedup_hash: hash_inbound_message(&message),
             tag: message.tag,
             source_peer: message.source_peer,
             authenticated_origin: None,

--- a/comms/dht/src/proto/envelope.proto
+++ b/comms/dht/src/proto/envelope.proto
@@ -42,7 +42,6 @@ message DhtHeader {
     DhtMessageType message_type = 8;
     uint32 flags = 10;
     // Message trace ID
-    // TODO: Remove for mainnet or when testing message traces is not required #LOGGED
     uint64 message_tag = 11;
     // Expiry timestamp for the message
     google.protobuf.Timestamp expires = 12;

--- a/comms/dht/src/store_forward/forward.rs
+++ b/comms/dht/src/store_forward/forward.rs
@@ -194,7 +194,7 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
         }
 
         if let Some(expires) = &dht_header.expires {
-            if expires < &EpochTime::now() {
+            if *expires < EpochTime::now() {
                 debug!(
                     target: LOG_TARGET,
                     "Received message {} from peer '{}' that is expired. Discarding message (Trace: {})",


### PR DESCRIPTION
Description
---
- removes todo comment from message tag
- renames message.hash to message.dedup_hash to clarify that the hash does not commit to all header fields and should only be used for deduping and debug tracing
- `PartialEq` impl on header disregards transient message tag
- fix memorynet to work on linux/windows

Motivation and Context
---
The message tag can be used to trace messages between nodes. The message dedup_hash is an alternative approach but we're keeping message_tag for now.

How Has This Been Tested?
---
Ran memory net, existing tests
