### PR TITLE
fix(sync): ban peer if sending invalid prev_header

### DIFF
--- a/base_layer/core/src/base_node/sync/header_sync/error.rs
+++ b/base_layer/core/src/base_node/sync/header_sync/error.rs
@@ -67,8 +67,12 @@ pub enum BlockHeaderSyncError {
     NetworkSilence,
     #[error("Invalid protocol response: {0}")]
     InvalidProtocolResponse(String),
-    #[error("Headers did not form a chain. Expected {actual} to equal the previous hash {expected}")]
-    ChainLinkBroken { actual: String, expected: String },
+    #[error("Header at height {height} did not form a chain. Expected {actual} to equal the previous hash {expected}")]
+    ChainLinkBroken {
+        height: u64,
+        actual: String,
+        expected: String,
+    },
     #[error("Block error: {0}")]
     BlockError(#[from] BlockError),
     #[error(

--- a/base_layer/core/src/base_node/sync/header_sync/validator.rs
+++ b/base_layer/core/src/base_node/sync/header_sync/validator.rs
@@ -129,6 +129,7 @@ impl<B: BlockchainBackend + 'static> BlockHeaderSyncValidator<B> {
         }
         if header.prev_hash != state.previous_accum.hash {
             return Err(BlockHeaderSyncError::ChainLinkBroken {
+                height: header.height,
                 actual: header.prev_hash.to_hex(),
                 expected: state.previous_accum.hash.to_hex(),
             });


### PR DESCRIPTION
Description
---
- bans peer for ChainLinkBroken error

Motivation and Context
---
Node should not continue syncing from a peer that does not properly link headers

How Has This Been Tested?
---
Manually, my node banned peers that sent an incorrect prev header
