### PR TITLE
fix: fix ffi import external utxo from faucet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7450,6 +7450,7 @@ name = "tari_wallet_ffi"
 version = "0.30.0"
 dependencies = [
  "chrono",
+ "env_logger 0.7.1",
  "futures 0.3.21",
  "lazy_static 1.4.0",
  "libc",

--- a/applications/tari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/tari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -636,7 +636,11 @@ impl wallet_server::Wallet for WalletGrpcServer {
         for o in unblinded_outputs.iter() {
             tx_ids.push(
                 wallet
-                    .import_unblinded_utxo(o.clone(), &CommsPublicKey::default(), "Imported via gRPC".to_string())
+                    .import_unblinded_output_as_non_rewindable(
+                        o.clone(),
+                        &CommsPublicKey::default(),
+                        "Imported via gRPC".to_string(),
+                    )
                     .await
                     .map_err(|e| Status::internal(format!("{:?}", e)))?
                     .into(),

--- a/base_layer/wallet/src/output_manager_service/handle.rs
+++ b/base_layer/wallet/src/output_manager_service/handle.rs
@@ -115,6 +115,7 @@ pub enum OutputManagerRequest {
     CalculateRecoveryByte {
         spending_key: PrivateKey,
         value: u64,
+        with_rewind_data: bool,
     },
     FeeEstimate {
         amount: MicroTari,
@@ -172,7 +173,9 @@ impl fmt::Display for OutputManagerRequest {
             RemoveEncryption => write!(f, "RemoveEncryption"),
             GetCoinbaseTransaction(_) => write!(f, "GetCoinbaseTransaction"),
             GetPublicRewindKeys => write!(f, "GetPublicRewindKeys"),
-            CalculateRecoveryByte { spending_key, value } => write!(
+            CalculateRecoveryByte {
+                spending_key, value, ..
+            } => write!(
                 f,
                 "CalculateRecoveryByte ({},{})",
                 spending_key.as_bytes().to_vec().to_hex(),
@@ -630,10 +633,15 @@ impl OutputManagerHandle {
         &mut self,
         spending_key: PrivateKey,
         value: u64,
+        with_rewind_data: bool,
     ) -> Result<u8, OutputManagerError> {
         match self
             .handle
-            .call(OutputManagerRequest::CalculateRecoveryByte { spending_key, value })
+            .call(OutputManagerRequest::CalculateRecoveryByte {
+                spending_key,
+                value,
+                with_rewind_data,
+            })
             .await??
         {
             OutputManagerResponse::RecoveryByte(rk) => Ok(rk),

--- a/base_layer/wallet/src/output_manager_service/storage/sqlite_db/mod.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/sqlite_db/mod.rs
@@ -1156,7 +1156,7 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
         if start.elapsed().as_millis() > 0 {
             trace!(
                 target: LOG_TARGET,
-                "sqlite profile - reinstate_cancelled_inbound_output: lock {} + db_op {} = {} ms",
+                "sqlite profile - add_unvalidated_output: lock {} + db_op {} = {} ms",
                 acquire_lock.as_millis(),
                 (start.elapsed() - acquire_lock).as_millis(),
                 start.elapsed().as_millis()

--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -398,11 +398,10 @@ where
         self.updater_service.clone().unwrap()
     }
 
-    /// Import an external spendable UTXO into the wallet. The output will be added to the Output Manager and made
-    /// EncumberedToBeReceived. A faux incoming transaction will be created to provide a record of the event. The TxId
-    /// of the generated transaction is returned.
-
-    pub async fn import_utxo(
+    /// Import an external spendable UTXO into the wallet as a non-rewindable/non-recoverable UTXO. The output will be
+    /// added to the Output Manager and made EncumberedToBeReceived. A faux incoming transaction will be created to
+    /// provide a record of the event. The TxId of the generated transaction is returned.
+    pub async fn import_external_utxo_as_non_rewindable(
         &mut self,
         amount: MicroTari,
         spending_key: &PrivateKey,
@@ -449,22 +448,24 @@ where
             .map_err(WalletError::TransactionError)?
             .to_hex();
 
+        // As non-rewindable
         self.output_manager_service
             .add_unvalidated_output(tx_id, unblinded_output, None)
             .await?;
 
         info!(
             target: LOG_TARGET,
-            "UTXO (Commitment: {}) imported into wallet as 'ImportStatus::Imported'", commitment_hex
+            "UTXO (Commitment: {}) imported into wallet as 'ImportStatus::Imported' and is non-rewindable",
+            commitment_hex
         );
 
         Ok(tx_id)
     }
 
-    /// Import an external spendable UTXO into the wallet. The output will be added to the Output Manager and made
-    /// spendable. A faux incoming transaction will be created to provide a record of the event. The TxId of the
-    /// generated transaction is returned.
-    pub async fn import_unblinded_utxo(
+    /// Import an external spendable UTXO into the wallet as a non-rewindable/non-recoverable UTXO. The output will be
+    /// added to the Output Manager and made spendable. A faux incoming transaction will be created to provide a record
+    /// of the event. The TxId of the generated transaction is returned.
+    pub async fn import_unblinded_output_as_non_rewindable(
         &mut self,
         unblinded_output: UnblindedOutput,
         source_public_key: &CommsPublicKey,
@@ -483,13 +484,14 @@ where
             )
             .await?;
 
+        // As non-rewindable
         self.output_manager_service
             .add_output_with_tx_id(tx_id, unblinded_output.clone(), None)
             .await?;
 
         info!(
             target: LOG_TARGET,
-            "UTXO (Commitment: {}) imported into wallet as 'ImportStatus::Imported'",
+            "UTXO (Commitment: {}) imported into wallet as 'ImportStatus::Imported' and is non-rewindable",
             unblinded_output
                 .as_transaction_input(&self.factories.commitment)?
                 .commitment()

--- a/base_layer/wallet/tests/support/utils.rs
+++ b/base_layer/wallet/tests/support/utils.rs
@@ -68,7 +68,7 @@ pub async fn make_input<R: Rng + CryptoRng>(
     // further down the line
     if let Some(mut oms) = oms {
         if let Ok(val) = oms
-            .calculate_recovery_byte(utxo.spending_key.clone(), utxo.value.clone().as_u64())
+            .calculate_recovery_byte(utxo.spending_key.clone(), utxo.value.clone().as_u64(), true)
             .await
         {
             utxo.features.set_recovery_byte(val);
@@ -99,7 +99,7 @@ pub async fn make_input_with_features<R: Rng + CryptoRng>(
     // 'TestParamsHelpers::new()'; this will influence validation of output features and the metadata signature
     // further down the line
     if let Ok(val) = oms
-        .calculate_recovery_byte(utxo.spending_key.clone(), utxo.value.clone().as_u64())
+        .calculate_recovery_byte(utxo.spending_key.clone(), utxo.value.clone().as_u64(), true)
         .await
     {
         utxo.features.set_recovery_byte(val);

--- a/base_layer/wallet/tests/wallet.rs
+++ b/base_layer/wallet/tests/wallet.rs
@@ -767,7 +767,7 @@ async fn test_import_utxo() {
     let expected_output_hash = output.hash();
 
     let tx_id = alice_wallet
-        .import_utxo(
+        .import_external_utxo_as_non_rewindable(
             utxo.value,
             &utxo.spending_key,
             script.clone(),

--- a/base_layer/wallet_ffi/Cargo.toml
+++ b/base_layer/wallet_ffi/Cargo.toml
@@ -27,6 +27,7 @@ openssl = { version = "0.10", features = ["vendored"] }
 rand = "0.8"
 thiserror = "1.0.26"
 tokio = "1.11"
+env_logger = "0.7.0"
 
 # <workaround>
 # Temporary workaround until crates utilizing openssl have been updated from security-framework 2.4.0

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -123,7 +123,7 @@ use tari_comms::{
 use tari_comms_dht::{store_forward::SafConfig, DbConnectionUrl, DhtConfig};
 use tari_core::{
     covenants::Covenant,
-    transactions::{tari_amount::MicroTari, CryptoFactories},
+    transactions::{tari_amount::MicroTari, transaction_components::OutputFeatures, CryptoFactories},
 };
 use tari_crypto::{
     keys::{PublicKey as PublicKeyTrait, SecretKey},
@@ -141,7 +141,7 @@ use tari_utilities::{hex, hex::Hex};
 use tari_wallet::{
     connectivity_service::WalletConnectivityInterface,
     contacts_service::storage::database::Contact,
-    error::{WalletError, WalletStorageError},
+    error::{WalletError, WalletError::OutputManagerError, WalletStorageError},
     storage::{
         database::WalletDatabase,
         sqlite_db::wallet::WalletSqliteDatabase,
@@ -5137,26 +5137,31 @@ pub unsafe extern "C" fn wallet_get_public_key(wallet: *mut TariWallet, error_ou
     Box::into_raw(Box::new(pk))
 }
 
-/// Import a UTXO into the wallet. This will add a spendable UTXO and create a faux completed transaction to record the
-/// event.
+/// Import an external UTXO into the wallet as a non-rewindable (i.e. non-recoverable) output. This will add a spendable
+/// UTXO (as EncumberedToBeReceived) and create a faux completed transaction to record the event.
 ///
 /// ## Arguments
 /// `wallet` - The TariWallet pointer
 /// `amount` - The value of the UTXO in MicroTari
 /// `spending_key` - The private spending key
 /// `source_public_key` - The public key of the source of the transaction
+/// `features` - Options for an output's structure or use
+/// `metadata_signature` - UTXO signature with the script offset private key, k_O
+/// `sender_offset_public_key` - Tari script offset pubkey, K_O
+/// `script_private_key` - Tari script private key, k_S, is used to create the script signature
+/// `covenant` - The covenant that will be executed when spending this output
 /// `message` - The message that the transaction will have
 /// `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
 /// as an out parameter.
 ///
 /// ## Returns
-/// `c_ulonglong` -  Returns the TransactionID of the generated transaction, note that it will be zero if transaction is
-/// null
+/// `c_ulonglong` -  Returns the TransactionID of the generated transaction, note that it will be zero if the
+/// transaction is null
 ///
 /// # Safety
 /// None
 #[no_mangle]
-pub unsafe extern "C" fn wallet_import_utxo(
+pub unsafe extern "C" fn wallet_import_external_utxo_as_non_rewindable(
     wallet: *mut TariWallet,
     amount: c_ulonglong,
     spending_key: *mut TariPrivateKey,
@@ -5207,11 +5212,11 @@ pub unsafe extern "C" fn wallet_import_utxo(
         return 0;
     }
 
-    if features.is_null() {
-        error = LibWalletError::from(InterfaceError::NullError("features".to_string())).code;
-        ptr::swap(error_out, &mut error as *mut c_int);
-        return 0;
-    }
+    let mut updated_features = if features.is_null() {
+        OutputFeatures::default()
+    } else {
+        (*features).clone()
+    };
 
     let covenant = if covenant.is_null() {
         Covenant::default()
@@ -5247,21 +5252,43 @@ pub unsafe extern "C" fn wallet_import_utxo(
 
     let public_script_key = PublicKey::from_secret_key(&(*spending_key));
 
+    // On the blockchain, 'V0' of the output features encode and decode without the recovery byte, whereas 'V1' onwards
+    // adds it in, however, for the wallet, the recovery byte must be consistent with the value commitment to be
+    // accepted in the wallet irrespective if it is 'V0' or 'V1'
+    let recovery_byte =
+        match (*wallet)
+            .runtime
+            .block_on((*wallet).wallet.output_manager_service.calculate_recovery_byte(
+                (*spending_key).clone(),
+                amount,
+                false,
+            )) {
+            Ok(val) => val,
+            Err(e) => {
+                error = LibWalletError::from(OutputManagerError(e)).code;
+                ptr::swap(error_out, &mut error as *mut c_int);
+                return 0;
+            },
+        };
+    updated_features.set_recovery_byte(recovery_byte);
+
     // TODO: the script_lock_height can be something other than 0, for example an HTLC transaction
-    match (*wallet).runtime.block_on((*wallet).wallet.import_utxo(
-        MicroTari::from(amount),
-        &(*spending_key).clone(),
-        script!(Nop),
-        inputs!(public_script_key),
-        &(*source_public_key).clone(),
-        (*features).clone(),
-        message_string,
-        (*metadata_signature).clone(),
-        &(*script_private_key).clone(),
-        &(*sender_offset_public_key).clone(),
-        0,
-        covenant,
-    )) {
+    match (*wallet)
+        .runtime
+        .block_on((*wallet).wallet.import_external_utxo_as_non_rewindable(
+            MicroTari::from(amount),
+            &(*spending_key).clone(),
+            script!(Nop),
+            inputs!(public_script_key),
+            &(*source_public_key).clone(),
+            updated_features,
+            message_string,
+            (*metadata_signature).clone(),
+            &(*script_private_key).clone(),
+            &(*sender_offset_public_key).clone(),
+            0,
+            covenant,
+        )) {
         Ok(tx_id) => {
             if let Err(e) = (*wallet)
                 .runtime
@@ -6344,6 +6371,7 @@ mod test {
 
     use libc::{c_char, c_uchar, c_uint};
     use tari_common_types::{emoji, transaction::TransactionStatus};
+    use tari_core::transactions::test_helpers::{create_unblinded_output, TestParams};
     use tari_key_manager::{mnemonic::MnemonicLanguage, mnemonic_wordlists};
     use tari_test_utils::random;
     use tari_wallet::storage::sqlite_utilities::run_migration_and_create_sqlite_connection;
@@ -7459,6 +7487,209 @@ mod test {
                 // Clear memory
                 seed_words_destroy(mnemonic_wordlist_ffi);
             }
+        }
+    }
+
+    fn get_next_memory_address() -> Multiaddr {
+        let port = MemoryTransport::acquire_next_memsocket_port();
+        format!("/memory/{}", port).parse().unwrap()
+    }
+
+    #[test]
+    pub fn test_import_external_utxo() {
+        unsafe {
+            let mut error = 0;
+            let error_ptr = &mut error as *mut c_int;
+            let mut recovery_in_progress = true;
+            let recovery_in_progress_ptr = &mut recovery_in_progress as *mut bool;
+
+            // create a new wallet
+            let db_name = CString::new(random::string(8).as_str()).unwrap();
+            let db_name_str: *const c_char = CString::into_raw(db_name) as *const c_char;
+            let temp_dir = tempdir().unwrap();
+            let db_path = CString::new(temp_dir.path().to_str().unwrap()).unwrap();
+            let db_path_str: *const c_char = CString::into_raw(db_path) as *const c_char;
+            let transport_type = transport_memory_create();
+            let address = transport_memory_get_address(transport_type, error_ptr);
+            let address_str = CStr::from_ptr(address).to_str().unwrap().to_owned();
+            let address_str = CString::new(address_str).unwrap().into_raw() as *const c_char;
+
+            let network = CString::new(NETWORK_STRING).unwrap();
+            let network_str: *const c_char = CString::into_raw(network) as *const c_char;
+
+            let config = comms_config_create(
+                address_str,
+                transport_type,
+                db_name_str,
+                db_path_str,
+                20,
+                10800,
+                network_str,
+                error_ptr,
+            );
+
+            let wallet_ptr = wallet_create(
+                config,
+                ptr::null(),
+                0,
+                0,
+                ptr::null(),
+                ptr::null(),
+                received_tx_callback,
+                received_tx_reply_callback,
+                received_tx_finalized_callback,
+                broadcast_callback,
+                mined_callback,
+                mined_unconfirmed_callback,
+                scanned_callback,
+                scanned_unconfirmed_callback,
+                direct_send_callback,
+                store_and_forward_send_callback,
+                tx_cancellation_callback,
+                txo_validation_complete_callback,
+                contacts_liveness_data_updated_callback,
+                balance_updated_callback,
+                transaction_validation_complete_callback,
+                saf_messages_received_callback,
+                connectivity_status_callback,
+                recovery_in_progress_ptr,
+                error_ptr,
+            );
+
+            let node_identity =
+                NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE);
+            let base_node_peer_public_key_ptr = Box::into_raw(Box::new(node_identity.public_key().clone()));
+            let base_node_peer_address_ptr =
+                CString::into_raw(CString::new(node_identity.public_address().to_string()).unwrap()) as *const c_char;
+            wallet_add_base_node_peer(
+                wallet_ptr,
+                base_node_peer_public_key_ptr,
+                base_node_peer_address_ptr,
+                error_ptr,
+            );
+
+            // Create an unblinded output with a non-default recovery byte
+            let default_features = OutputFeatures::default();
+            let utxo_1;
+            loop {
+                let test_params = TestParams::new();
+                let utxo_temp = create_unblinded_output(
+                    script!(Nop),
+                    default_features.clone(),
+                    test_params.clone(),
+                    MicroTari::from(100_000),
+                );
+                if utxo_temp.features.recovery_byte != default_features.recovery_byte {
+                    utxo_1 = utxo_temp;
+                    break;
+                }
+            }
+            assert_ne!(utxo_1.features.recovery_byte, default_features.recovery_byte);
+
+            // Test the consistent features case, i.e. with valid 'recovery_byte'
+            let amount = utxo_1.value.as_u64();
+            let spending_key_ptr = Box::into_raw(Box::new(utxo_1.spending_key));
+            let features_ptr = Box::into_raw(Box::new(utxo_1.features.clone()));
+            let source_public_key_ptr = Box::into_raw(Box::new(TariPublicKey::default()));
+            let metadata_signature_ptr = Box::into_raw(Box::new(utxo_1.metadata_signature));
+            let sender_offset_public_key_ptr = Box::into_raw(Box::new(utxo_1.sender_offset_public_key));
+            let script_private_key_ptr = Box::into_raw(Box::new(utxo_1.script_private_key));
+            let covenant_ptr = Box::into_raw(Box::new(utxo_1.covenant));
+            let message_ptr = CString::into_raw(CString::new("For my friend").unwrap()) as *const c_char;
+
+            let tx_id = wallet_import_external_utxo_as_non_rewindable(
+                wallet_ptr,
+                amount,
+                spending_key_ptr,
+                source_public_key_ptr,
+                features_ptr,
+                metadata_signature_ptr,
+                sender_offset_public_key_ptr,
+                script_private_key_ptr,
+                covenant_ptr,
+                message_ptr,
+                error_ptr,
+            );
+            assert_eq!(error, 0);
+            assert!(tx_id > 0);
+
+            // Cleanup
+            string_destroy(message_ptr as *mut c_char);
+            let _covenant = Box::from_raw(covenant_ptr);
+            let _script_private_key = Box::from_raw(script_private_key_ptr);
+            let _sender_offset_public_key = Box::from_raw(sender_offset_public_key_ptr);
+            let _metadata_signature = Box::from_raw(metadata_signature_ptr);
+            let _features = Box::from_raw(features_ptr);
+            let _source_public_key = Box::from_raw(source_public_key_ptr);
+            let _spending_key = Box::from_raw(spending_key_ptr);
+
+            // Create an unblinded output with a non-default recovery byte
+            let mut utxo_2;
+            loop {
+                let test_params = TestParams::new();
+                let utxo_temp = create_unblinded_output(
+                    script!(Nop),
+                    default_features.clone(),
+                    test_params.clone(),
+                    MicroTari::from(200_000),
+                );
+                if utxo_temp.features.recovery_byte != default_features.recovery_byte {
+                    utxo_2 = utxo_temp;
+                    break;
+                }
+            }
+            assert_ne!(utxo_2.features.recovery_byte, default_features.recovery_byte);
+            // Reset the 'recovery_byte' to default; i.e. the 'metadata_signature' will now be inconsistent
+            utxo_2.features.set_recovery_byte(default_features.recovery_byte);
+
+            // Test the inconsistent features case, i.e. with invalid 'recovery_byte'
+            let amount = utxo_2.value.as_u64();
+            let spending_key_ptr = Box::into_raw(Box::new(utxo_2.spending_key));
+            let source_public_key_ptr = Box::into_raw(Box::new(TariPublicKey::default()));
+            let features_ptr = Box::into_raw(Box::new(utxo_2.features));
+            let metadata_signature_ptr = Box::into_raw(Box::new(utxo_2.metadata_signature));
+            let sender_offset_public_key_ptr = Box::into_raw(Box::new(utxo_2.sender_offset_public_key));
+            let script_private_key_ptr = Box::into_raw(Box::new(utxo_2.script_private_key));
+            let covenant_ptr = Box::into_raw(Box::new(utxo_2.covenant));
+            let message_ptr = CString::into_raw(CString::new("For my friend").unwrap()) as *const c_char;
+
+            let tx_id = wallet_import_external_utxo_as_non_rewindable(
+                wallet_ptr,
+                amount,
+                spending_key_ptr,
+                source_public_key_ptr,
+                features_ptr,
+                metadata_signature_ptr,
+                sender_offset_public_key_ptr,
+                script_private_key_ptr,
+                covenant_ptr,
+                message_ptr,
+                error_ptr,
+            );
+            assert_eq!(error, 0);
+            assert!(tx_id > 0);
+
+            // Cleanup
+            string_destroy(message_ptr as *mut c_char);
+            let _covenant = Box::from_raw(covenant_ptr);
+            let _script_private_key = Box::from_raw(script_private_key_ptr);
+            let _sender_offset_public_key = Box::from_raw(sender_offset_public_key_ptr);
+            let _metadata_signature = Box::from_raw(metadata_signature_ptr);
+            let _features = Box::from_raw(features_ptr);
+            let _source_public_key = Box::from_raw(source_public_key_ptr);
+            let _spending_key = Box::from_raw(spending_key_ptr);
+
+            let _base_node_peer_public_key = Box::from_raw(base_node_peer_public_key_ptr);
+            string_destroy(base_node_peer_address_ptr as *mut c_char);
+
+            string_destroy(network_str as *mut c_char);
+            string_destroy(db_name_str as *mut c_char);
+            string_destroy(db_path_str as *mut c_char);
+            string_destroy(address_str as *mut c_char);
+            transport_type_destroy(transport_type);
+
+            comms_config_destroy(config);
+            wallet_destroy(wallet_ptr);
         }
     }
 

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -672,9 +672,9 @@ struct TariPendingInboundTransaction *wallet_get_pending_inbound_transaction_by_
 // Get a Cancelled transaction from a TariWallet by its TransactionId. Pending Inbound or Outbound transaction will be converted to a CompletedTransaction
 struct TariCompletedTransaction *wallet_get_cancelled_transaction_by_id(struct TariWallet *wallet, unsigned long long transaction_id, int *error_out);
 
-// Import a UTXO into the wallet. This will add a spendable UTXO and create a faux completed transaction to record the
-// event.
-unsigned long long wallet_import_utxo(
+// Import an external UTXO into the wallet as a non-rewindable (i.e. non-recoverable) output. This will add a spendable
+// UTXO and create a faux completed transaction to record the event.
+unsigned long long wallet_import_external_utxo_as_non_rewindable(
     struct TariWallet *wallet,
     unsigned long long amount,
     struct TariPrivateKey *spending_key,

--- a/integration_tests/helpers/ffi/ffiInterface.js
+++ b/integration_tests/helpers/ffi/ffiInterface.js
@@ -385,7 +385,7 @@ class InterfaceFFI {
         this.ptr,
         [this.ptr, this.ulonglong, this.intPtr],
       ],
-      wallet_import_utxo: [
+      wallet_import_external_utxo_as_non_rewindable: [
         this.ulonglong,
         [
           this.ptr,
@@ -1524,7 +1524,7 @@ class InterfaceFFI {
     message
   ) {
     let error = this.initError();
-    let result = this.fn.wallet_import_utxo(
+    let result = this.fn.wallet_import_external_utxo_as_non_rewindable(
       ptr,
       amount,
       spending_key_ptr,


### PR DESCRIPTION
Description
---
- Fixed importing external UTXOs via the FFI _by changing the philosophy about having inconsistent recovery byte data in the wallet database_
- Renamed import UTXO methods to be more descriptive
- Added a unit test to test importing external UTXOs via the FFI

_**Note:** The FFI import UTXO method was renamed; this is a breaking change on the FFI interface._

Motivation and Context
---
See above

How Has This Been Tested?
---
Added a new unit test that test the import UTXO interface
