### PR TITLE
fix: fix handling of creating faux transaction for recovered outputs

### DIFF
--- a/base_layer/wallet/src/output_manager_service/handle.rs
+++ b/base_layer/wallet/src/output_manager_service/handle.rs
@@ -122,14 +122,8 @@ pub enum OutputManagerRequest {
         num_kernels: usize,
         num_outputs: usize,
     },
-    ScanForRecoverableOutputs {
-        outputs: Vec<TransactionOutput>,
-        tx_id: TxId,
-    },
-    ScanOutputs {
-        outputs: Vec<TransactionOutput>,
-        tx_id: TxId,
-    },
+    ScanForRecoverableOutputs(Vec<TransactionOutput>),
+    ScanOutputs(Vec<TransactionOutput>),
     AddKnownOneSidedPaymentScript(KnownOneSidedPaymentScript),
     CreateOutputWithFeatures {
         value: MicroTari,
@@ -194,8 +188,8 @@ impl fmt::Display for OutputManagerRequest {
                 "FeeEstimate(amount: {}, fee_per_gram: {}, num_kernels: {}, num_outputs: {})",
                 amount, fee_per_gram, num_kernels, num_outputs
             ),
-            ScanForRecoverableOutputs { .. } => write!(f, "ScanForRecoverableOutputs"),
-            ScanOutputs { .. } => write!(f, "ScanOutputs"),
+            ScanForRecoverableOutputs(_) => write!(f, "ScanForRecoverableOutputs"),
+            ScanOutputs(_) => write!(f, "ScanOutputs"),
             AddKnownOneSidedPaymentScript(_) => write!(f, "AddKnownOneSidedPaymentScript"),
             CreateOutputWithFeatures { value, features } => {
                 write!(f, "CreateOutputWithFeatures({}, {})", value, features,)
@@ -247,8 +241,8 @@ pub enum OutputManagerResponse {
     PublicRewindKeys(Box<PublicRewindKeys>),
     RecoveryByte(u8),
     FeeEstimate(MicroTari),
-    RewoundOutputs(Vec<UnblindedOutput>),
-    ScanOutputs(Vec<UnblindedOutput>),
+    RewoundOutputs(Vec<RecoveredOutput>),
+    ScanOutputs(Vec<RecoveredOutput>),
     AddKnownOneSidedPaymentScript,
     CreateOutputWithFeatures {
         output: Box<UnblindedOutputBuilder>,
@@ -298,6 +292,12 @@ impl fmt::Display for OutputManagerEvent {
 pub struct PublicRewindKeys {
     pub rewind_public_key: PublicKey,
     pub rewind_blinding_public_key: PublicKey,
+}
+
+#[derive(Debug, Clone)]
+pub struct RecoveredOutput {
+    pub tx_id: TxId,
+    pub output: UnblindedOutput,
 }
 
 #[derive(Clone)]
@@ -728,11 +728,10 @@ impl OutputManagerHandle {
     pub async fn scan_for_recoverable_outputs(
         &mut self,
         outputs: Vec<TransactionOutput>,
-        tx_id: TxId,
-    ) -> Result<Vec<UnblindedOutput>, OutputManagerError> {
+    ) -> Result<Vec<RecoveredOutput>, OutputManagerError> {
         match self
             .handle
-            .call(OutputManagerRequest::ScanForRecoverableOutputs { outputs, tx_id })
+            .call(OutputManagerRequest::ScanForRecoverableOutputs(outputs))
             .await??
         {
             OutputManagerResponse::RewoundOutputs(outputs) => Ok(outputs),
@@ -743,13 +742,8 @@ impl OutputManagerHandle {
     pub async fn scan_outputs_for_one_sided_payments(
         &mut self,
         outputs: Vec<TransactionOutput>,
-        tx_id: TxId,
-    ) -> Result<Vec<UnblindedOutput>, OutputManagerError> {
-        match self
-            .handle
-            .call(OutputManagerRequest::ScanOutputs { outputs, tx_id })
-            .await??
-        {
+    ) -> Result<Vec<RecoveredOutput>, OutputManagerError> {
+        match self.handle.call(OutputManagerRequest::ScanOutputs(outputs)).await?? {
             OutputManagerResponse::ScanOutputs(outputs) => Ok(outputs),
             _ => Err(OutputManagerError::UnexpectedApiResponse),
         }

--- a/base_layer/wallet/src/output_manager_service/recovery/standard_outputs_recoverer.rs
+++ b/base_layer/wallet/src/output_manager_service/recovery/standard_outputs_recoverer.rs
@@ -43,6 +43,7 @@ use crate::{
     key_manager_service::KeyManagerInterface,
     output_manager_service::{
         error::{OutputManagerError, OutputManagerStorageError},
+        handle::RecoveredOutput,
         resources::OutputManagerKeyManagerBranch,
         storage::{
             database::{OutputManagerBackend, OutputManagerDatabase},
@@ -84,8 +85,7 @@ where
     pub async fn scan_and_recover_outputs(
         &mut self,
         outputs: Vec<TransactionOutput>,
-        tx_id: TxId,
-    ) -> Result<Vec<UnblindedOutput>, OutputManagerError> {
+    ) -> Result<Vec<RecoveredOutput>, OutputManagerError> {
         let start = Instant::now();
         let outputs_length = outputs.len();
         let mut rewound_outputs: Vec<(UnblindedOutput, BulletRangeProof)> = outputs
@@ -131,7 +131,7 @@ where
             rewind_time.as_millis(),
         );
 
-        let mut rewound_outputs_to_return = Vec::new();
+        let mut rewound_outputs_with_tx_id: Vec<RecoveredOutput> = Vec::new();
         for (output, proof) in rewound_outputs.iter_mut() {
             let db_output = DbUnblindedOutput::rewindable_from_unblinded_output(
                 output.clone(),
@@ -140,6 +140,7 @@ where
                 None,
                 Some(proof),
             )?;
+            let tx_id = TxId::new_random();
             let output_hex = db_output.commitment.to_hex();
             if let Err(e) = self.db.add_unspent_output_with_tx_id(tx_id, db_output).await {
                 match e {
@@ -153,6 +154,11 @@ where
                     _ => return Err(OutputManagerError::from(e)),
                 }
             }
+
+            rewound_outputs_with_tx_id.push(RecoveredOutput {
+                output: output.clone(),
+                tx_id,
+            });
             self.update_outputs_script_private_key_and_update_key_manager_index(output)
                 .await?;
             trace!(
@@ -162,9 +168,9 @@ where
                 output.value,
                 output.features,
             );
-            rewound_outputs_to_return.push(output.clone());
         }
-        Ok(rewound_outputs_to_return)
+
+        Ok(rewound_outputs_with_tx_id)
     }
 
     /// Find the key manager index that corresponds to the spending key in the rewound output, if found then modify

--- a/base_layer/wallet/tests/output_manager_service_tests/service.rs
+++ b/base_layer/wallet/tests/output_manager_service_tests/service.rs
@@ -2147,7 +2147,7 @@ async fn scan_for_recovery_test() {
     for o in rewindable_unblinded_outputs.iter().skip(1) {
         assert!(recovered_outputs
             .iter()
-            .any(|ro| ro.outpuot.spending_key == o.spending_key));
+            .any(|ro| ro.output.spending_key == o.spending_key));
     }
 }
 

--- a/base_layer/wallet/tests/output_manager_service_tests/service.rs
+++ b/base_layer/wallet/tests/output_manager_service_tests/service.rs
@@ -2136,7 +2136,6 @@ async fn scan_for_recovery_test() {
                 .into_iter()
                 .chain(non_rewindable_outputs.clone().into_iter())
                 .collect::<Vec<TransactionOutput>>(),
-            TxId::from(1u64),
         )
         .await
         .unwrap();
@@ -2146,7 +2145,9 @@ async fn scan_for_recovery_test() {
 
     assert_eq!(recovered_outputs.len(), NUM_REWINDABLE - 1);
     for o in rewindable_unblinded_outputs.iter().skip(1) {
-        assert!(recovered_outputs.iter().any(|ro| ro.spending_key == o.spending_key));
+        assert!(recovered_outputs
+            .iter()
+            .any(|ro| ro.outpuot.spending_key == o.spending_key));
     }
 }
 
@@ -2172,7 +2173,7 @@ async fn recovered_output_key_not_in_keychain() {
 
     let result = oms
         .output_manager_handle
-        .scan_for_recoverable_outputs(vec![rewindable_output], TxId::from(1u64))
+        .scan_for_recoverable_outputs(vec![rewindable_output])
         .await;
 
     assert!(matches!(

--- a/base_layer/wallet/tests/transaction_service_tests/service.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/service.rs
@@ -925,18 +925,15 @@ fn recover_one_sided_transaction() {
         let outputs = completed_tx.transaction.body.outputs().clone();
 
         let unblinded = bob_oms
-            .scan_outputs_for_one_sided_payments(outputs.clone(), TxId::new_random())
+            .scan_outputs_for_one_sided_payments(outputs.clone())
             .await
             .unwrap();
         // Bob should be able to claim 1 output.
         assert_eq!(1, unblinded.len());
-        assert_eq!(value, unblinded[0].value);
+        assert_eq!(value, unblinded[0].output.value);
 
         // Should ignore already existing outputs
-        let unblinded = bob_oms
-            .scan_outputs_for_one_sided_payments(outputs, TxId::new_random())
-            .await
-            .unwrap();
+        let unblinded = bob_oms.scan_outputs_for_one_sided_payments(outputs).await.unwrap();
         assert!(unblinded.is_empty());
     });
 }


### PR DESCRIPTION
Description
---
There existed a bug in the UTXO scanner that if a block had multiple outputs in it it would assign a single TxId for all the output but try import a separate faux transaction for each output. After the first output the rest would be rejected as duplicated outputs.

This PR updates the OMS scanning process to produce a unique TxId per output to avoid this issue.

How Has This Been Tested?
---
cargo test and manually
