### PR TITLE
feat(core): add tip height metric

### DIFF
--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -799,13 +799,16 @@ where B: BlockchainBackend + 'static
 
         match block_add_result {
             BlockAddResult::Ok(ref block) => {
+                metrics::tip_height().set(block.height() as i64);
                 update_target_difficulty(block);
                 let utxo_set_size = self.blockchain_db.utxo_count().await?;
                 metrics::utxo_set_size().set(utxo_set_size.try_into().unwrap_or(i64::MAX));
             },
             BlockAddResult::ChainReorg { added, removed } => {
-                let fork_height = added.last().map(|b| b.height() - 1).unwrap_or_default();
-                metrics::reorg(fork_height, added.len(), removed.len()).inc();
+                if let Some(fork_height) = added.last().map(|b| b.height()) {
+                    metrics::tip_height().set(fork_height as i64);
+                    metrics::reorg(fork_height, added.len(), removed.len()).inc();
+                }
                 for block in added {
                     update_target_difficulty(block);
                 }

--- a/base_layer/core/src/base_node/metrics.rs
+++ b/base_layer/core/src/base_node/metrics.rs
@@ -24,6 +24,14 @@ use once_cell::sync::Lazy;
 use tari_metrics::{IntCounter, IntCounterVec, IntGauge, IntGaugeVec};
 use tari_utilities::hex::to_hex;
 
+pub fn tip_height() -> IntGauge {
+    static METER: Lazy<IntGauge> = Lazy::new(|| {
+        tari_metrics::register_int_gauge("base_node::blockchain::tip_height", "The current tip height").unwrap()
+    });
+
+    METER.clone()
+}
+
 pub fn target_difficulty_sha(height: u64) -> IntGauge {
     static METER: Lazy<IntGaugeVec> = Lazy::new(|| {
         tari_metrics::register_int_gauge_vec(

--- a/base_layer/core/src/chain_storage/block_add_result.rs
+++ b/base_layer/core/src/chain_storage/block_add_result.rs
@@ -31,7 +31,9 @@ pub enum BlockAddResult {
     Ok(Arc<ChainBlock>),
     BlockExists,
     OrphanBlock,
-    /// Indicates the new block caused a chain reorg. This contains removed blocks followed by added blocks.
+    /// Indicates the new block caused a chain reorg.
+    /// This contains added blocks ordered from lowest to highest block height, and
+    /// the removed blocks ordered from highest to lowest block height.
     ChainReorg {
         added: Vec<Arc<ChainBlock>>,
         removed: Vec<Arc<ChainBlock>>,

--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -1907,7 +1907,7 @@ fn handle_possible_reorg<T: BlockchainBackend>(
 }
 
 /// Reorganize the main chain with the provided fork chain, starting at the specified height.
-/// Returns the blocks that were removed (if any), ordered from tip to fork (ie. height desc).
+/// Returns the blocks that were removed (if any), ordered from tip to fork (ie. height highest to lowest).
 fn reorganize_chain<T: BlockchainBackend>(
     backend: &mut T,
     block_validator: &dyn PostOrphanBodyValidation<T>,


### PR DESCRIPTION
Description
---
- adds `base_node::blockchain::tip_height` metric to track current tip height

Motivation and Context
---
The main reason for this is currently the tip height is extracted from the logs using Loki which does not support the `delta` function. `delta` is needed to determine if the chain tip has moved or not within a timespan.

Following query allows an alert to be created that checks that nothing has changed within 20 minutes (delta of 0 over 20 min timespan)
`delta(tari_base_node::blockchain::tip_height[20m])`

How Has This Been Tested?
---
Manually: Metrics appearts in local prometheus instance
