### PR TITLE
ci: add docker image builds for launchpad

### DIFF
--- a/.github/workflows/launchpad_docker.yml
+++ b/.github/workflows/launchpad_docker.yml
@@ -1,0 +1,94 @@
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+    # branches:
+    #   - development
+  workflow_dispatch:
+    inputs:
+      docker_tag:
+        description: "Docker tag"
+        required: true
+        default: "development"
+
+name: Build launchpad docker images
+
+env:
+  toolchain: nightly-2021-11-20
+  CARGO_HTTP_MULTIPLEXING: false
+  CARGO_TERM_COLOR: always
+
+jobs:
+  docker:
+    name: build image
+    strategy:
+      fail-fast: true
+      matrix:
+        image_name:
+          [
+            monerod,
+            tari_base_node,
+            tari_console_wallet,
+            tari_mm_proxy,
+            tari_sha3_miner,
+            tor,
+            xmrig,
+          ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+
+      - name: set env
+        run: |
+          TAG=""
+          REF=${{github.ref}}
+          if [ "${{ startsWith(github.ref, 'refs/tags/v') }}" == "true" ]
+          then
+            TAG="${REF/refs\/tags\//}"
+            echo "docker tag from git: $TAG"
+          fi
+          echo "event name: ${{ github.event_name }}"
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]
+          then
+            TAG="${{ github.event.inputs.docker_tag }}"
+            echo "docker tag from workflow dispatch: $TAG"
+          fi
+          echo "TAG=$TAG" >> $GITHUB_ENV
+
+          IMAGE=${{ matrix.image_name }}
+          echo "image: $IMAGE"
+          TEMP=${IMAGE/tari_/}
+          # echo "temp: $TEMP"
+          SERVICE="${TEMP/console_/}"
+
+          echo "service: $SERVICE"
+          echo "SERVICE=$SERVICE" >> $GITHUB_ENV
+
+      - name: build docker image
+        run: |
+          if [ -z $SERVICE ]
+          then
+            echo "service is undefined!"
+            exit 1
+          fi
+          cd applications/launchpad/docker_rig
+          docker-compose build $SERVICE
+
+      - name: Login to Quay.io
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_ROBOT_TOKEN }}
+
+      - name: tag and push image
+        run: |
+          echo "tag: $TAG"
+          if [ -n "$TAG" ]
+          then
+            docker tag quay.io/tarilabs/${{ matrix.image_name }}:latest quay.io/tarilabs/${{ matrix.image_name }}:$TAG
+
+            docker push quay.io/tarilabs/${{ matrix.image_name }}:latest
+            docker push quay.io/tarilabs/${{ matrix.image_name }}:$TAG
+          fi

--- a/applications/launchpad/docker_rig/docker-compose.yml
+++ b/applications/launchpad/docker_rig/docker-compose.yml
@@ -5,11 +5,11 @@ services:
     build:
       context: .
       dockerfile: tor.Dockerfile
-#    volumes:
-#      - ${DATA_FOLDER}/tor:/etc/tor/
-#    ports:
-#      - 9050:9050
-#      - 9051:9051
+  #    volumes:
+  #      - ${DATA_FOLDER}/tor:/etc/tor/
+  #    ports:
+  #      - 9050:9050
+  #      - 9051:9051
 
   base_node:
     image: quay.io/tarilabs/tari_base_node:latest
@@ -100,13 +100,12 @@ services:
       TARI_BASE_NODE__DIBBLER__GRPC_BASE_NODE_ADDRESS: "/dns4/base_node/tcp/18142"
       TARI_BASE_NODE__DIBBLER__GRPC_CONSOLE_WALLET_ADDRESS: "/dns4/wallet/tcp/18143"
       TARI_WALLET__GRPC_ADDRESS: "/dns4/wallet/tcp/18143"
-    command: [ ]
+    command: []
     depends_on:
       - base_node
       - wallet
     volumes:
       - ${DATA_FOLDER}:/var/tari/
-
 
   xmrig:
     image: quay.io/tarilabs/xmrig:latest
@@ -114,12 +113,22 @@ services:
       context: .
       dockerfile: xmrig.Dockerfile
     #command: ["--url", "mm_proxy:18081", "--user", "${TARI_MONERO_WALLET_ADDRESS:-859CW1aiA8gUmAaTipKsYrF5r83MesesSjWoJSSRL6nnfi5LqBssxJmg7BzhgXYcjcPARM7bBvFR9H5dJdi6w93eKA53v8G}", "--coin", "monero", "--daemon", "--log-file=/var/xmrig/xmrig.log"]
-    command: ["--url", "mm_proxy:18081", "--user", "${TARI_MONERO_WALLET_ADDRESS:-5AJ8FwQge4UjT9Gbj4zn7yYcnpVQzzkqr636pKto59jQcu85CFsuYVeFgbhUdRpiPjUCkA4sQtWApUzCyTMmSigFG2hDo48}", "--coin", "monero", "--daemon", "--log-file=/var/xmrig/xmrig.log", "--verbose"]
+    command:
+      [
+        "--url",
+        "mm_proxy:18081",
+        "--user",
+        "${TARI_MONERO_WALLET_ADDRESS:-5AJ8FwQge4UjT9Gbj4zn7yYcnpVQzzkqr636pKto59jQcu85CFsuYVeFgbhUdRpiPjUCkA4sQtWApUzCyTMmSigFG2hDo48}",
+        "--coin",
+        "monero",
+        "--daemon",
+        "--log-file=/var/xmrig/xmrig.log",
+        "--verbose",
+      ]
     depends_on:
       - mm_proxy
     volumes:
       - ${DATA_FOLDER}/xmrig:/var/xmrig/
-
 
   monerod:
     image: quay.io/tarilabs/monerod:latest
@@ -166,7 +175,7 @@ services:
     depends_on:
       - base_node
       - wallet
-    command: [ ]
+    command: []
     volumes:
       - ${DATA_FOLDER}:/var/tari/
 #  pool-worker:


### PR DESCRIPTION
Description
---

Adds a github action to build, tag and push docker images for the docker_rig/launchpad to quay.io. 
Triggered by pushing a new git tag, or by workflow dispatch where the tag can be specified.

**NB: requires new repo secrets for quay login**

- `QUAY_USERNAME`
- `QUAY_ROBOT_TOKEN`

