### PR TITLE
fix: add output option to the status command

### DIFF
--- a/applications/tari_base_node/src/commands/command/status.rs
+++ b/applications/tari_base_node/src/commands/command/status.rs
@@ -34,7 +34,7 @@ use crate::commands::status_line::{StatusLine, StatusLineOutput};
 /// Prints out the status of this node
 #[derive(Debug, Parser)]
 pub struct Args {
-    #[clap(default_value_t = StatusLineOutput::StdOutAndLog)]
+    #[clap(short, long, default_value_t = StatusLineOutput::StdOutAndLog)]
     output: StatusLineOutput,
 }
 

--- a/applications/tari_base_node/src/commands/status_line.rs
+++ b/applications/tari_base_node/src/commands/status_line.rs
@@ -26,9 +26,10 @@ use chrono::Local;
 use strum::{Display, EnumString};
 
 #[derive(Debug, Display, EnumString)]
-#[strum(serialize_all = "lowercase")]
 pub enum StatusLineOutput {
+    #[strum(serialize = "log")]
     Log,
+    #[strum(serialize = "all")]
     StdOutAndLog,
 }
 


### PR DESCRIPTION
Description
---
Fixes an issue with `--non-interactive` mode.
The PR adds `--output` option to the `status` command that expected by the non-interactive mode.

Motivation and Context
---
Non interactive mode failed with:

```
Wrong command to watch `status --output log`. Failed with: error: Found argument '--output' which wasn't expected, or isn't valid in this context

        If you tried to supply `--output` as a value rather than a flag, use `-- --output`

USAGE:
    status [OUTPUT]

For more information try --help
```

How Has This Been Tested?
---
Manually

