### PR TITLE
[wip] fix: implement qr code for base node -> mobile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6628,6 +6628,7 @@ dependencies = [
  "num_cpus",
  "opentelemetry",
  "opentelemetry-jaeger",
+ "qrcode",
  "regex",
  "rustyline",
  "rustyline-derive",

--- a/applications/tari_base_node/Cargo.toml
+++ b/applications/tari_base_node/Cargo.toml
@@ -37,6 +37,7 @@ log = { version = "0.4.8", features = ["std"] }
 log-mdc = "0.1.0"
 num_cpus = "1"
 nom = "7.1.0"
+qrcode = { version = "0.12" }
 regex = "1"
 rustyline = "9.0"
 rustyline-derive = "0.5"

--- a/applications/tari_base_node/src/commands/command/mod.rs
+++ b/applications/tari_base_node/src/commands/command/mod.rs
@@ -52,6 +52,7 @@ mod unban_all_peers;
 mod version;
 mod watch_command;
 mod whoami;
+mod show_qr;
 
 use std::{
     str::FromStr,
@@ -132,6 +133,7 @@ pub enum Command {
     Quit(quit::Args),
     Exit(quit::Args),
     Watch(watch_command::Args),
+    ShowQr(show_qr::Args),
 }
 
 impl Command {
@@ -247,6 +249,7 @@ impl HandleCommand<Command> for CommandContext {
             Command::ListBannedPeers(args) => self.handle_command(args).await,
             Command::Quit(args) | Command::Exit(args) => self.handle_command(args).await,
             Command::Watch(args) => self.handle_command(args).await,
+            Command::ShowQr(args) => self.handle_command(args).await,
         }
     }
 }

--- a/applications/tari_base_node/src/commands/command/mod.rs
+++ b/applications/tari_base_node/src/commands/command/mod.rs
@@ -47,12 +47,12 @@ mod reset_offline_peers;
 mod rewind_blockchain;
 mod search_kernel;
 mod search_utxo;
+mod show_qr;
 mod status;
 mod unban_all_peers;
 mod version;
 mod watch_command;
 mod whoami;
-mod show_qr;
 
 use std::{
     str::FromStr,

--- a/applications/tari_base_node/src/commands/command/show_qr.rs
+++ b/applications/tari_base_node/src/commands/command/show_qr.rs
@@ -1,0 +1,65 @@
+//  Copyright 2022, The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use anyhow::Error;
+use async_trait::async_trait;
+use clap::Parser;
+use qrcode::{QrCode, render::unicode};
+
+use super::{CommandContext, HandleCommand};
+
+/// Display a QR code with a deeplink, so the wallet can scan it and set the base node
+#[derive(Debug, Parser)]
+pub struct Args {}
+
+#[async_trait]
+impl HandleCommand<Args> for CommandContext {
+    async fn handle_command(&mut self, _: Args) -> Result<(), Error> {
+        self.show_qr()
+    }
+}
+
+impl CommandContext {
+    /// Function to process the whoami command
+    pub fn show_qr(&self) -> Result<(), Error> {
+        let network = self.config.network;
+
+        let name = self.base_node_identity.node_id();
+
+        let public_key= self.base_node_identity.public_key();
+        let public_address = self.base_node_identity.public_address();
+        let peer = format!{"{}::{}", public_key, public_address};
+
+        let qr_link = format!("tari://{}/base_nodes/add?name={}&peer={}", network, name, peer);
+        let code = QrCode::new(qr_link).unwrap();
+        let image = code
+            .render::<unicode::Dense1x2>()
+            .dark_color(unicode::Dense1x2::Dark)
+            .light_color(unicode::Dense1x2::Light)
+            .build()
+            .lines()
+            .skip(1)
+            .fold("".to_string(), |acc, l| format!("{}{}\n", acc, l));
+        println!("{}", image);
+        Ok(())
+    }
+}

--- a/applications/tari_base_node/src/commands/command/show_qr.rs
+++ b/applications/tari_base_node/src/commands/command/show_qr.rs
@@ -23,7 +23,7 @@
 use anyhow::Error;
 use async_trait::async_trait;
 use clap::Parser;
-use qrcode::{QrCode, render::unicode};
+use qrcode::{render::unicode, QrCode};
 
 use super::{CommandContext, HandleCommand};
 
@@ -45,9 +45,9 @@ impl CommandContext {
 
         let name = self.base_node_identity.node_id();
 
-        let public_key= self.base_node_identity.public_key();
+        let public_key = self.base_node_identity.public_key();
         let public_address = self.base_node_identity.public_address();
-        let peer = format!{"{}::{}", public_key, public_address};
+        let peer = format! {"{}::{}", public_key, public_address};
 
         let qr_link = format!("tari://{}/base_nodes/add?name={}&peer={}", network, name, peer);
         let code = QrCode::new(qr_link).unwrap();


### PR DESCRIPTION
Description
---
Added a new command `show-qr` to the base node. It shows a QR code with a deeplink pointing to `/base_nodes/add` according to the [RFC-0154](https://rfc.tari.com/RFC-0154_DeepLinksConvencion.html), so that the wallet can scan it and set the base node.

Motivation and Context
---
In Aurora you can scan a QR code to set the base node. Currently the base node does not display the QR code at all, so we need to add a function to display it.

How Has This Been Tested?
---
**This could not be tested yet,** as I use Android and the wallet functionality for it is not yet merged
