### PR TITLE
feat: make wallet db calls synchronous rather than async

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1142,43 +1142,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "console-api"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc347c19eb5b940f396ac155822caee6662f850d97306890ac3773ed76c90c5a"
-dependencies = [
- "prost",
- "prost-types",
- "tonic",
- "tonic-build",
- "tracing-core",
-]
-
-[[package]]
-name = "console-subscriber"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "565a7dfea2d10dd0e5c57cc394d5d441b1910960d8c9211ed14135e0e6ec3a20"
-dependencies = [
- "console-api",
- "crossbeam-channel 0.5.4",
- "crossbeam-utils 0.8.8",
- "futures 0.3.21",
- "hdrhistogram",
- "humantime 2.1.0",
- "prost-types",
- "serde 1.0.136",
- "serde_json",
- "thread_local",
- "tokio 1.17.0",
- "tokio-stream",
- "tonic",
- "tracing",
- "tracing-core",
- "tracing-subscriber 0.3.9",
-]
-
-[[package]]
 name = "console_error_panic_hook"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6912,7 +6875,6 @@ version = "0.30.2"
 dependencies = [
  "bitflags 1.3.2",
  "chrono",
- "console-subscriber",
  "crossterm 0.17.7",
  "digest 0.9.0",
  "futures 0.3.21",
@@ -7514,7 +7476,6 @@ dependencies = [
  "blake2",
  "chrono",
  "clear_on_drop",
- "console-subscriber",
  "crossbeam-channel 0.3.9",
  "derivative",
  "diesel",
@@ -7965,7 +7926,6 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "tracing",
  "winapi 0.3.9",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1142,6 +1142,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "console-api"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc347c19eb5b940f396ac155822caee6662f850d97306890ac3773ed76c90c5a"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+ "tonic-build",
+ "tracing-core",
+]
+
+[[package]]
+name = "console-subscriber"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "565a7dfea2d10dd0e5c57cc394d5d441b1910960d8c9211ed14135e0e6ec3a20"
+dependencies = [
+ "console-api",
+ "crossbeam-channel 0.5.4",
+ "crossbeam-utils 0.8.8",
+ "futures 0.3.21",
+ "hdrhistogram",
+ "humantime 2.1.0",
+ "prost-types",
+ "serde 1.0.136",
+ "serde_json",
+ "thread_local",
+ "tokio 1.17.0",
+ "tokio-stream",
+ "tonic",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber 0.3.9",
+]
+
+[[package]]
 name = "console_error_panic_hook"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6875,6 +6912,7 @@ version = "0.30.2"
 dependencies = [
  "bitflags 1.3.2",
  "chrono",
+ "console-subscriber",
  "crossterm 0.17.7",
  "digest 0.9.0",
  "futures 0.3.21",
@@ -7476,6 +7514,7 @@ dependencies = [
  "blake2",
  "chrono",
  "clear_on_drop",
+ "console-subscriber",
  "crossbeam-channel 0.3.9",
  "derivative",
  "diesel",
@@ -7926,6 +7965,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
+ "tracing",
  "winapi 0.3.9",
 ]
 

--- a/applications/tari_app_utilities/src/initialization.rs
+++ b/applications/tari_app_utilities/src/initialization.rs
@@ -29,8 +29,8 @@ pub fn init_configuration(
     // Load and apply configuration file
     let cfg = bootstrap.load_configuration()?;
 
-    // Initialise the logger (Comment out to enable tokio tracing)
-    // bootstrap.initialize_logging()?;
+    // Initialise the logger (Comment out to enable tokio tracing via tokio-console)
+    bootstrap.initialize_logging()?;
 
     log::info!(target: LOG_TARGET, "{} ({})", application_type, consts::APP_VERSION);
 

--- a/applications/tari_app_utilities/src/initialization.rs
+++ b/applications/tari_app_utilities/src/initialization.rs
@@ -29,8 +29,8 @@ pub fn init_configuration(
     // Load and apply configuration file
     let cfg = bootstrap.load_configuration()?;
 
-    // Initialise the logger
-    bootstrap.initialize_logging()?;
+    // Initialise the logger (Comment out to enable tokio tracing)
+    // bootstrap.initialize_logging()?;
 
     log::info!(target: LOG_TARGET, "{} ({})", application_type, consts::APP_VERSION);
 

--- a/applications/tari_console_wallet/Cargo.toml
+++ b/applications/tari_console_wallet/Cargo.toml
@@ -20,13 +20,11 @@ tari_shutdown = { path = "../../infrastructure/shutdown" }
 tari_key_manager = { path = "../../base_layer/key_manager" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.3.1" }
 
-# Uncomment for tokio-console tracing
-#
-console-subscriber = "0.1.3"
-tokio = { version = "1.14", features = ["signal", "tracing"] }
+# Uncomment for tokio tracing via tokio-console (needs "tracing" featurs)
+#console-subscriber = "0.1.3"
+#tokio = { version = "1.14", features = ["signal", "tracing"] }
 # Uncomment for normal use (non tokio-console tracing)
-#
-#tokio = { version = "1.11", features = ["signal"] }
+tokio = { version = "1.14", features = ["signal"] }
 
 sha2 = "0.9.5"
 digest = "0.9.0"

--- a/applications/tari_console_wallet/Cargo.toml
+++ b/applications/tari_console_wallet/Cargo.toml
@@ -20,6 +20,14 @@ tari_shutdown = { path = "../../infrastructure/shutdown" }
 tari_key_manager = { path = "../../base_layer/key_manager" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.3.1" }
 
+# Uncomment for tokio-console tracing
+#
+console-subscriber = "0.1.3"
+tokio = { version = "1.14", features = ["signal", "tracing"] }
+# Uncomment for normal use (non tokio-console tracing)
+#
+#tokio = { version = "1.11", features = ["signal"] }
+
 sha2 = "0.9.5"
 digest = "0.9.0"
 chrono = { version = "0.4.19", default-features = false }
@@ -36,7 +44,6 @@ rpassword = "5.0"
 rustyline = "9.0"
 strum = "0.22"
 strum_macros = "0.22"
-tokio = { version = "1.11", features = ["signal"] }
 thiserror = "1.0.26"
 tonic = "0.6.2"
 tracing = "0.1.26"

--- a/applications/tari_console_wallet/src/automation/command_parser.rs
+++ b/applications/tari_console_wallet/src/automation/command_parser.rs
@@ -322,9 +322,9 @@ fn parse_make_it_rain(mut args: SplitWhitespace) -> Result<Vec<ParsedArgument>, 
     // txs per second
     let txps = args.next().ok_or_else(|| ParseError::Empty("Txs/s".to_string()))?;
     let txps = txps.parse::<f64>().map_err(ParseError::Float)?;
-    if txps > 25.0 {
-        println!("Maximum transaction rate is 25/sec");
-        return Err(ParseError::Invalid("Maximum transaction rate is 25/sec".to_string()));
+    if txps > 250.0 {
+        println!("Maximum transaction rate is 250/sec");
+        return Err(ParseError::Invalid("Maximum transaction rate is 250/sec".to_string()));
     }
     parsed_args.push(ParsedArgument::Float(txps));
 

--- a/applications/tari_console_wallet/src/main.rs
+++ b/applications/tari_console_wallet/src/main.rs
@@ -75,8 +75,8 @@ pub mod wallet_modes;
 
 /// Application entry point
 fn main() {
-    // Uncomment to enable tokio tracing
-    console_subscriber::init();
+    // Uncomment to enable tokio tracing via tokio-console
+    // console_subscriber::init();
 
     match main_inner() {
         Ok(_) => process::exit(0),

--- a/applications/tari_console_wallet/src/main.rs
+++ b/applications/tari_console_wallet/src/main.rs
@@ -75,6 +75,9 @@ pub mod wallet_modes;
 
 /// Application entry point
 fn main() {
+    // Uncomment to enable tokio tracing
+    console_subscriber::init();
+
     match main_inner() {
         Ok(_) => process::exit(0),
         Err(err) => {

--- a/applications/tari_mining_node/src/stratum/error.rs
+++ b/applications/tari_mining_node/src/stratum/error.rs
@@ -45,7 +45,7 @@ pub enum Error {
     #[error("Can't create TLS connector: {0}")]
     Tls(#[from] native_tls::Error),
     #[error("Can't establish TLS connection: {0}")]
-    Tcp(#[from] native_tls::HandshakeError<std::net::TcpStream>),
+    Tcp(#[from] Box<native_tls::HandshakeError<std::net::TcpStream>>),
     #[error("No connected stream")]
     NotConnected,
     #[error("Can't parse int: {0}")]
@@ -66,5 +66,11 @@ impl<T> From<std::sync::PoisonError<T>> for Error {
 impl<T> From<std::sync::mpsc::SendError<T>> for Error {
     fn from(error: std::sync::mpsc::SendError<T>) -> Self {
         Error::General(format!("Failed to send to a channel: {:?}", error))
+    }
+}
+
+impl From<native_tls::HandshakeError<std::net::TcpStream>> for Error {
+    fn from(error: native_tls::HandshakeError<std::net::TcpStream>) -> Self {
+        Error::General(format!("TLS handshake error: {:?}", error))
     }
 }

--- a/applications/tari_mining_node/src/stratum/stream.rs
+++ b/applications/tari_mining_node/src/stratum/stream.rs
@@ -33,7 +33,7 @@ use crate::stratum::error::Error;
 
 pub(crate) enum Stream {
     Stream(BufStream<TcpStream>),
-    TlsStream(BufStream<TlsStream<TcpStream>>),
+    TlsStream(Box<BufStream<TlsStream<TcpStream>>>),
 }
 
 impl Stream {
@@ -46,7 +46,7 @@ impl Stream {
             let base_host = format!("{}.{}", split_url[split_url.len() - 2], split_url[split_url.len() - 1]);
             let mut stream = connector.connect(&base_host, conn)?;
             stream.get_mut().set_nonblocking(true)?;
-            Ok(Self::TlsStream(BufStream::new(stream)))
+            Ok(Self::TlsStream(Box::from(BufStream::new(stream))))
         } else {
             conn.set_nonblocking(true)?;
             Ok(Self::Stream(BufStream::new(conn)))

--- a/applications/tari_validator_node/src/main.rs
+++ b/applications/tari_validator_node/src/main.rs
@@ -64,7 +64,7 @@ use crate::{
 const LOG_TARGET: &str = "tari::validator_node::app";
 
 fn main() {
-    // Uncomment to enable tokio tracing
+    // Uncomment to enable tokio tracing via tokio-console
     // console_subscriber::init();
 
     if let Err(err) = main_inner() {

--- a/applications/tari_validator_node/src/main.rs
+++ b/applications/tari_validator_node/src/main.rs
@@ -64,7 +64,9 @@ use crate::{
 const LOG_TARGET: &str = "tari::validator_node::app";
 
 fn main() {
+    // Uncomment to enable tokio tracing
     // console_subscriber::init();
+
     if let Err(err) = main_inner() {
         let exit_code = err.exit_code;
         eprintln!("{:?}", err);

--- a/base_layer/wallet/Cargo.toml
+++ b/base_layer/wallet/Cargo.toml
@@ -21,6 +21,14 @@ tari_storage = { version = "^0.30", path = "../../infrastructure/storage" }
 tari_common_sqlite = { path = "../../common_sqlite" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.3.1" }
 
+# Uncomment for tokio-console tracing
+#
+console-subscriber = "0.1.3"
+tokio = { version = "1.14", features = ["sync", "macros", "tracing"] }
+# Uncomment for normal use (non tokio-console tracing)
+#
+#tokio = { version = "1.11", features = ["sync", "macros"] }
+
 aes-gcm = "^0.8"
 async-trait = "0.1.50"
 argon2 = "0.2"
@@ -47,7 +55,6 @@ strum = "0.22"
 strum_macros = "0.22"
 tempfile = "3.1.0"
 thiserror = "1.0.26"
-tokio = { version = "1.11", features = ["sync", "macros"] }
 tower = "0.4"
 prost = "0.9"
 

--- a/base_layer/wallet/Cargo.toml
+++ b/base_layer/wallet/Cargo.toml
@@ -21,13 +21,11 @@ tari_storage = { version = "^0.30", path = "../../infrastructure/storage" }
 tari_common_sqlite = { path = "../../common_sqlite" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.3.1" }
 
-# Uncomment for tokio-console tracing
-#
-console-subscriber = "0.1.3"
-tokio = { version = "1.14", features = ["sync", "macros", "tracing"] }
+# Uncomment for tokio tracing via tokio-console (needs "tracing" featurs)
+#console-subscriber = "0.1.3"
+#tokio = { version = "1.14", features = ["sync", "macros", "tracing"] }
 # Uncomment for normal use (non tokio-console tracing)
-#
-#tokio = { version = "1.11", features = ["sync", "macros"] }
+tokio = { version = "1.14", features = ["sync", "macros"] }
 
 aes-gcm = "^0.8"
 async-trait = "0.1.50"

--- a/base_layer/wallet/src/assets/asset_manager.rs
+++ b/base_layer/wallet/src/assets/asset_manager.rs
@@ -58,7 +58,6 @@ impl<T: OutputManagerBackend + 'static> AssetManager<T> {
         let outputs = self
             .output_database
             .fetch_with_features(OutputFlags::ASSET_REGISTRATION)
-            .await
             .map_err(|err| WalletError::OutputManagerError(err.into()))?;
 
         debug!(

--- a/base_layer/wallet/src/output_manager_service/error.rs
+++ b/base_layer/wallet/src/output_manager_service/error.rs
@@ -165,14 +165,14 @@ pub enum OutputManagerStorageError {
     DieselConnectionError(#[from] diesel::ConnectionError),
     #[error("Database migration error: `{0}`")]
     DatabaseMigrationError(String),
-    #[error("Blocking task spawn error: `{0}`")]
-    BlockingTaskSpawnError(String),
     #[error("Wallet db is already encrypted and cannot be encrypted until the previous encryption is removed")]
     AlreadyEncrypted,
     #[error("Byte array error: `{0}`")]
     ByteArrayError(#[from] ByteArrayError),
     #[error("Aead error: `{0}`")]
     AeadError(String),
+    #[error("Tried to insert a script that already exists in the database")]
+    DuplicateScript,
     #[error("Tari script error : {0}")]
     ScriptError(#[from] ScriptError),
     #[error("Binary not stored as valid hex:{0}")]

--- a/base_layer/wallet/src/output_manager_service/recovery/standard_outputs_recoverer.rs
+++ b/base_layer/wallet/src/output_manager_service/recovery/standard_outputs_recoverer.rs
@@ -142,7 +142,7 @@ where
             )?;
             let tx_id = TxId::new_random();
             let output_hex = db_output.commitment.to_hex();
-            if let Err(e) = self.db.add_unspent_output_with_tx_id(tx_id, db_output).await {
+            if let Err(e) = self.db.add_unspent_output_with_tx_id(tx_id, db_output) {
                 match e {
                     OutputManagerStorageError::DuplicateOutput => {
                         info!(

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -131,7 +131,7 @@ where
     ) -> Result<Self, OutputManagerError> {
         // Clear any encumberances for transactions that were being negotiated but did not complete to become official
         // Pending Transactions.
-        db.clear_short_term_encumberances().await?;
+        db.clear_short_term_encumberances()?;
         Self::initialise_key_manager(&key_manager).await?;
         let rewind_key = key_manager
             .get_key_at_index(OutputManagerKeyManagerBranch::RecoveryViewOnly.get_branch_key(), 0)
@@ -258,33 +258,27 @@ where
         match request {
             OutputManagerRequest::AddOutput((uo, spend_priority)) => self
                 .add_output(None, *uo, spend_priority)
-                .await
                 .map(|_| OutputManagerResponse::OutputAdded),
             OutputManagerRequest::AddRewindableOutput((uo, spend_priority, custom_rewind_data)) => self
                 .add_rewindable_output(None, *uo, spend_priority, custom_rewind_data)
-                .await
                 .map(|_| OutputManagerResponse::OutputAdded),
             OutputManagerRequest::AddOutputWithTxId((tx_id, uo, spend_priority)) => self
                 .add_output(Some(tx_id), *uo, spend_priority)
-                .await
                 .map(|_| OutputManagerResponse::OutputAdded),
             OutputManagerRequest::AddRewindableOutputWithTxId((tx_id, uo, spend_priority, custom_rewind_data)) => self
                 .add_rewindable_output(Some(tx_id), *uo, spend_priority, custom_rewind_data)
-                .await
                 .map(|_| OutputManagerResponse::OutputAdded),
             OutputManagerRequest::ConvertToRewindableTransactionOutput(uo) => {
-                let transaction_output = self.convert_to_rewindable_transaction_output(*uo).await?;
+                let transaction_output = self.convert_to_rewindable_transaction_output(*uo)?;
                 Ok(OutputManagerResponse::ConvertedToTransactionOutput(Box::new(
                     transaction_output,
                 )))
             },
             OutputManagerRequest::AddUnvalidatedOutput((tx_id, uo, spend_priority)) => self
                 .add_unvalidated_output(tx_id, *uo, spend_priority)
-                .await
                 .map(|_| OutputManagerResponse::OutputAdded),
             OutputManagerRequest::UpdateOutputMetadataSignature(uo) => self
                 .update_output_metadata_signature(*uo)
-                .await
                 .map(|_| OutputManagerResponse::OutputMetadataSignatureUpdated),
             OutputManagerRequest::GetBalance => {
                 let current_tip_for_time_lock_calculation = match self.base_node_service.get_chain_metadata().await {
@@ -292,7 +286,6 @@ where
                     Err(_) => None,
                 };
                 self.get_balance(current_tip_for_time_lock_calculation)
-                    .await
                     .map(OutputManagerResponse::Balance)
             },
             OutputManagerRequest::GetRecipientTransaction(tsm) => self
@@ -358,28 +351,16 @@ where
                 .map(OutputManagerResponse::FeeEstimate),
             OutputManagerRequest::ConfirmPendingTransaction(tx_id) => self
                 .confirm_encumberance(tx_id)
-                .await
                 .map(|_| OutputManagerResponse::PendingTransactionConfirmed),
             OutputManagerRequest::CancelTransaction(tx_id) => self
                 .cancel_transaction(tx_id)
-                .await
                 .map(|_| OutputManagerResponse::TransactionCancelled),
             OutputManagerRequest::GetSpentOutputs => {
-                let outputs = self
-                    .fetch_spent_outputs()
-                    .await?
-                    .into_iter()
-                    .map(|v| v.into())
-                    .collect();
+                let outputs = self.fetch_spent_outputs()?.into_iter().map(|v| v.into()).collect();
                 Ok(OutputManagerResponse::SpentOutputs(outputs))
             },
             OutputManagerRequest::GetUnspentOutputs => {
-                let outputs = self
-                    .fetch_unspent_outputs()
-                    .await?
-                    .into_iter()
-                    .map(|v| v.into())
-                    .collect();
+                let outputs = self.fetch_unspent_outputs()?.into_iter().map(|v| v.into()).collect();
                 Ok(OutputManagerResponse::UnspentOutputs(outputs))
             },
             OutputManagerRequest::ValidateUtxos => {
@@ -387,15 +368,9 @@ where
             },
             OutputManagerRequest::RevalidateTxos => self
                 .revalidate_outputs()
-                .await
                 .map(OutputManagerResponse::TxoValidationStarted),
             OutputManagerRequest::GetInvalidOutputs => {
-                let outputs = self
-                    .fetch_invalid_outputs()
-                    .await?
-                    .into_iter()
-                    .map(|v| v.into())
-                    .collect();
+                let outputs = self.fetch_invalid_outputs()?.into_iter().map(|v| v.into()).collect();
                 Ok(OutputManagerResponse::InvalidOutputs(outputs))
             },
             OutputManagerRequest::CreateCoinSplit((amount_per_split, split_count, fee_per_gram, lock_height)) => self
@@ -406,14 +381,12 @@ where
                 .resources
                 .db
                 .apply_encryption(*cipher)
-                .await
                 .map(|_| OutputManagerResponse::EncryptionApplied)
                 .map_err(OutputManagerError::OutputManagerStorageError),
             OutputManagerRequest::RemoveEncryption => self
                 .resources
                 .db
                 .remove_encryption()
-                .await
                 .map(|_| OutputManagerResponse::EncryptionRemoved)
                 .map_err(OutputManagerError::OutputManagerStorageError),
 
@@ -440,15 +413,12 @@ where
             .map(OutputManagerResponse::RewoundOutputs),
             OutputManagerRequest::ScanOutputs(outputs) => self
                 .scan_outputs_for_one_sided_payments(outputs)
-                .await
                 .map(OutputManagerResponse::ScanOutputs),
             OutputManagerRequest::AddKnownOneSidedPaymentScript(known_script) => self
                 .add_known_script(known_script)
-                .await
                 .map(|_| OutputManagerResponse::AddKnownOneSidedPaymentScript),
             OutputManagerRequest::ReinstateCancelledInboundTx(tx_id) => self
                 .reinstate_cancelled_inbound_transaction_outputs(tx_id)
-                .await
                 .map(|_| OutputManagerResponse::ReinstatedCancelledInboundTx),
             OutputManagerRequest::CreateOutputWithFeatures { value, features } => {
                 let unblinded_output = self.create_output_with_features(value, *features).await?;
@@ -477,7 +447,6 @@ where
             },
             OutputManagerRequest::SetCoinbaseAbandoned(tx_id, abandoned) => self
                 .set_coinbase_abandoned(tx_id, abandoned)
-                .await
                 .map(|_| OutputManagerResponse::CoinbaseAbandonedSet),
             OutputManagerRequest::CreateClaimShaAtomicSwapTransaction(output_hash, pre_image, fee_per_gram) => {
                 self.claim_sha_atomic_swap_with_hash(output_hash, pre_image, fee_per_gram)
@@ -488,21 +457,14 @@ where
                 .await
                 .map(OutputManagerResponse::ClaimHtlcTransaction),
             OutputManagerRequest::GetOutputStatusesByTxId(tx_id) => {
-                let (statuses, mined_height, block_hash) = self.get_output_status_by_tx_id(tx_id).await?;
-                Ok(OutputManagerResponse::OutputStatusesByTxId {
-                    statuses,
-                    mined_height,
-                    block_hash,
-                })
+                let output_statuses_by_tx_id = self.get_output_status_by_tx_id(tx_id)?;
+                Ok(OutputManagerResponse::OutputStatusesByTxId(output_statuses_by_tx_id))
             },
         }
     }
 
-    async fn get_output_status_by_tx_id(
-        &self,
-        tx_id: TxId,
-    ) -> Result<(Vec<OutputStatus>, Option<u64>, Option<BlockHash>), OutputManagerError> {
-        let outputs = self.resources.db.fetch_outputs_by_tx_id(tx_id).await?;
+    fn get_output_status_by_tx_id(&self, tx_id: TxId) -> Result<OutputStatusesByTxId, OutputManagerError> {
+        let outputs = self.resources.db.fetch_outputs_by_tx_id(tx_id)?;
         let statuses = outputs.clone().into_iter().map(|uo| uo.status).collect();
         // We need the maximum mined height and corresponding block hash (faux transactions outputs can have different
         // mined heights)
@@ -516,7 +478,11 @@ where
                 }
             }
         }
-        Ok((statuses, max_mined_height, block_hash))
+        Ok(OutputStatusesByTxId {
+            statuses,
+            mined_height: max_mined_height,
+            block_hash,
+        })
     }
 
     async fn claim_sha_atomic_swap_with_hash(
@@ -596,8 +562,8 @@ where
         Ok(id)
     }
 
-    async fn revalidate_outputs(&mut self) -> Result<u64, OutputManagerError> {
-        self.resources.db.set_outputs_to_be_revalidated().await?;
+    fn revalidate_outputs(&mut self) -> Result<u64, OutputManagerError> {
+        self.resources.db.set_outputs_to_be_revalidated()?;
         self.validate_outputs()
     }
 
@@ -618,7 +584,7 @@ where
     }
 
     /// Add an unblinded non-rewindable output to the outputs table and mark it as `Unspent`.
-    pub async fn add_output(
+    pub fn add_output(
         &mut self,
         tx_id: Option<TxId>,
         output: UnblindedOutput,
@@ -636,14 +602,14 @@ where
             output.hash.to_hex()
         );
         match tx_id {
-            None => self.resources.db.add_unspent_output(output).await?,
-            Some(t) => self.resources.db.add_unspent_output_with_tx_id(t, output).await?,
+            None => self.resources.db.add_unspent_output(output)?,
+            Some(t) => self.resources.db.add_unspent_output_with_tx_id(t, output)?,
         }
         Ok(())
     }
 
     /// Add an unblinded rewindable output to the outputs table and marks is as `Unspent`.
-    pub async fn add_rewindable_output(
+    pub fn add_rewindable_output(
         &mut self,
         tx_id: Option<TxId>,
         output: UnblindedOutput,
@@ -673,14 +639,14 @@ where
             output.hash.to_hex()
         );
         match tx_id {
-            None => self.resources.db.add_unspent_output(output).await?,
-            Some(t) => self.resources.db.add_unspent_output_with_tx_id(t, output).await?,
+            None => self.resources.db.add_unspent_output(output)?,
+            Some(t) => self.resources.db.add_unspent_output_with_tx_id(t, output)?,
         }
         Ok(())
     }
 
     /// Convert an unblinded rewindable output into rewindable transaction output using the key manager's rewind data
-    pub async fn convert_to_rewindable_transaction_output(
+    pub fn convert_to_rewindable_transaction_output(
         &mut self,
         output: UnblindedOutput,
     ) -> Result<TransactionOutput, OutputManagerError> {
@@ -691,7 +657,7 @@ where
 
     /// Add an unblinded output to the outputs table and marks is as `EncumberedToBeReceived`. This is so that it will
     /// require a successful validation to confirm that it indeed spendable.
-    pub async fn add_unvalidated_output(
+    pub fn add_unvalidated_output(
         &mut self,
         tx_id: TxId,
         output: UnblindedOutput,
@@ -702,16 +668,13 @@ where
             "Add unvalidated output of value {} to Output Manager", output.value
         );
         let output = DbUnblindedOutput::from_unblinded_output(output, &self.resources.factories, spend_priority)?;
-        self.resources.db.add_unvalidated_output(tx_id, output).await?;
+        self.resources.db.add_unvalidated_output(tx_id, output)?;
         Ok(())
     }
 
     /// Update an output's metadata signature, akin to 'finalize output'
-    pub async fn update_output_metadata_signature(
-        &mut self,
-        output: TransactionOutput,
-    ) -> Result<(), OutputManagerError> {
-        self.resources.db.update_output_metadata_signature(output).await?;
+    pub fn update_output_metadata_signature(&mut self, output: TransactionOutput) -> Result<(), OutputManagerError> {
+        self.resources.db.update_output_metadata_signature(output)?;
         Ok(())
     }
 
@@ -759,15 +722,8 @@ where
             .with_script_private_key(script_private_key))
     }
 
-    async fn get_balance(
-        &self,
-        current_tip_for_time_lock_calculation: Option<u64>,
-    ) -> Result<Balance, OutputManagerError> {
-        let balance = self
-            .resources
-            .db
-            .get_balance(current_tip_for_time_lock_calculation)
-            .await?;
+    fn get_balance(&self, current_tip_for_time_lock_calculation: Option<u64>) -> Result<Balance, OutputManagerError> {
+        let balance = self.resources.db.get_balance(current_tip_for_time_lock_calculation)?;
         trace!(target: LOG_TARGET, "Balance: {:?}", balance);
         Ok(balance)
     }
@@ -830,8 +786,7 @@ where
 
         self.resources
             .db
-            .add_output_to_be_received(single_round_sender_data.tx_id, output, None)
-            .await?;
+            .add_output_to_be_received(single_round_sender_data.tx_id, output, None)?;
 
         let nonce = PrivateKey::random(&mut OsRng);
 
@@ -1028,8 +983,7 @@ where
         // store them until the transaction times out OR is confirmed
         self.resources
             .db
-            .encumber_outputs(tx_id, input_selection.into_selected(), change_output)
-            .await?;
+            .encumber_outputs(tx_id, input_selection.into_selected(), change_output)?;
 
         debug!(target: LOG_TARGET, "Prepared transaction (TxId: {}) to send", tx_id);
 
@@ -1071,7 +1025,7 @@ where
             .with_block_height(block_height)
             .with_fees(fees)
             .with_spend_key(spending_key.clone())
-            .with_script_key(script_private_key.clone())
+            .with_script_key(script_private_key)
             .with_script(script!(Nop))
             .with_nonce(nonce)
             .with_rewind_data(self.resources.rewind_data.clone())
@@ -1090,7 +1044,6 @@ where
             .resources
             .db
             .clear_pending_coinbase_transaction_at_block_height(block_height)
-            .await
         {
             Ok(_) => {
                 debug!(
@@ -1106,12 +1059,7 @@ where
 
         // Clear any matching outputs for this commitment. Even if the older output is valid
         // we are losing no information as this output has the same commitment.
-        match self
-            .resources
-            .db
-            .remove_output_by_commitment(output.commitment.clone())
-            .await
-        {
+        match self.resources.db.remove_output_by_commitment(output.commitment.clone()) {
             Ok(_) => {},
             Err(OutputManagerStorageError::ValueNotFound) => {},
             Err(e) => return Err(e.into()),
@@ -1119,10 +1067,9 @@ where
 
         self.resources
             .db
-            .add_output_to_be_received(tx_id, output, Some(block_height))
-            .await?;
+            .add_output_to_be_received(tx_id, output, Some(block_height))?;
 
-        self.confirm_encumberance(tx_id).await?;
+        self.confirm_encumberance(tx_id)?;
 
         Ok(tx)
     }
@@ -1280,8 +1227,7 @@ where
 
         self.resources
             .db
-            .encumber_outputs(tx_id, input_selection.into_selected(), db_outputs)
-            .await?;
+            .encumber_outputs(tx_id, input_selection.into_selected(), db_outputs)?;
         stp.finalize(KernelFeatures::empty(), &self.resources.factories, None, u64::MAX)?;
 
         Ok((tx_id, stp.take_transaction()?))
@@ -1431,9 +1377,8 @@ where
         );
         self.resources
             .db
-            .encumber_outputs(tx_id, input_selection.into_selected(), outputs)
-            .await?;
-        self.confirm_encumberance(tx_id).await?;
+            .encumber_outputs(tx_id, input_selection.into_selected(), outputs)?;
+        self.confirm_encumberance(tx_id)?;
         let fee = stp.get_fee_amount()?;
         trace!(target: LOG_TARGET, "Finalize send-to-self transaction ({}).", tx_id);
         stp.finalize(
@@ -1449,25 +1394,25 @@ where
 
     /// Confirm that a transaction has finished being negotiated between parties so the short-term encumberance can be
     /// made official
-    async fn confirm_encumberance(&mut self, tx_id: TxId) -> Result<(), OutputManagerError> {
-        self.resources.db.confirm_encumbered_outputs(tx_id).await?;
+    fn confirm_encumberance(&mut self, tx_id: TxId) -> Result<(), OutputManagerError> {
+        self.resources.db.confirm_encumbered_outputs(tx_id)?;
 
         Ok(())
     }
 
     /// Cancel a pending transaction and place the encumbered outputs back into the unspent pool
-    pub async fn cancel_transaction(&mut self, tx_id: TxId) -> Result<(), OutputManagerError> {
+    pub fn cancel_transaction(&mut self, tx_id: TxId) -> Result<(), OutputManagerError> {
         debug!(
             target: LOG_TARGET,
             "Cancelling pending transaction outputs for TxId: {}", tx_id
         );
-        Ok(self.resources.db.cancel_pending_transaction_outputs(tx_id).await?)
+        Ok(self.resources.db.cancel_pending_transaction_outputs(tx_id)?)
     }
 
     /// Restore the pending transaction encumberance and output for an inbound transaction that was previously
     /// cancelled.
-    async fn reinstate_cancelled_inbound_transaction_outputs(&mut self, tx_id: TxId) -> Result<(), OutputManagerError> {
-        self.resources.db.reinstate_cancelled_inbound_output(tx_id).await?;
+    fn reinstate_cancelled_inbound_transaction_outputs(&mut self, tx_id: TxId) -> Result<(), OutputManagerError> {
+        self.resources.db.reinstate_cancelled_inbound_output(tx_id)?;
 
         Ok(())
     }
@@ -1488,7 +1433,7 @@ where
             Some(unique_id) => {
                 debug!(target: LOG_TARGET, "Looking for {:?}", unique_id);
                 // todo: new method to fetch by unique asset id
-                let uo = self.resources.db.fetch_all_unspent_outputs().await?;
+                let uo = self.resources.db.fetch_all_unspent_outputs()?;
                 if let Some(token_id) = uo.into_iter().find(|x| match &x.unblinded_output.features.unique_id {
                     Some(token_unique_id) => {
                         debug!(target: LOG_TARGET, "Comparing with {:?}", token_unique_id);
@@ -1558,8 +1503,7 @@ where
         let uo = self
             .resources
             .db
-            .fetch_unspent_outputs_for_spending(strategy, amount, tip_height)
-            .await?;
+            .fetch_unspent_outputs_for_spending(strategy, amount, tip_height)?;
         trace!(target: LOG_TARGET, "We found {} UTXOs to select from", uo.len());
 
         // Assumes that default Outputfeatures are used for change utxo
@@ -1595,7 +1539,7 @@ where
 
         if !perfect_utxo_selection && !enough_spendable {
             let current_tip_for_time_lock_calculation = chain_metadata.map(|cm| cm.height_of_longest_chain());
-            let balance = self.get_balance(current_tip_for_time_lock_calculation).await?;
+            let balance = self.get_balance(current_tip_for_time_lock_calculation)?;
             let pending_incoming = balance.pending_incoming_balance;
             if utxos_total_value + pending_incoming >= amount + fee_with_change {
                 return Err(OutputManagerError::FundsPending);
@@ -1613,20 +1557,20 @@ where
         })
     }
 
-    pub async fn fetch_spent_outputs(&self) -> Result<Vec<DbUnblindedOutput>, OutputManagerError> {
-        Ok(self.resources.db.fetch_spent_outputs().await?)
+    pub fn fetch_spent_outputs(&self) -> Result<Vec<DbUnblindedOutput>, OutputManagerError> {
+        Ok(self.resources.db.fetch_spent_outputs()?)
     }
 
-    pub async fn fetch_unspent_outputs(&self) -> Result<Vec<DbUnblindedOutput>, OutputManagerError> {
-        Ok(self.resources.db.fetch_all_unspent_outputs().await?)
+    pub fn fetch_unspent_outputs(&self) -> Result<Vec<DbUnblindedOutput>, OutputManagerError> {
+        Ok(self.resources.db.fetch_all_unspent_outputs()?)
     }
 
-    pub async fn fetch_invalid_outputs(&self) -> Result<Vec<DbUnblindedOutput>, OutputManagerError> {
-        Ok(self.resources.db.get_invalid_outputs().await?)
+    pub fn fetch_invalid_outputs(&self) -> Result<Vec<DbUnblindedOutput>, OutputManagerError> {
+        Ok(self.resources.db.get_invalid_outputs()?)
     }
 
-    pub async fn set_coinbase_abandoned(&self, tx_id: TxId, abandoned: bool) -> Result<(), OutputManagerError> {
-        self.resources.db.set_coinbase_abandoned(tx_id, abandoned).await?;
+    pub fn set_coinbase_abandoned(&self, tx_id: TxId, abandoned: bool) -> Result<(), OutputManagerError> {
+        self.resources.db.set_coinbase_abandoned(tx_id, abandoned)?;
         Ok(())
     }
 
@@ -1781,9 +1725,8 @@ where
 
         self.resources
             .db
-            .encumber_outputs(tx_id, input_selection.into_selected(), outputs)
-            .await?;
-        self.confirm_encumberance(tx_id).await?;
+            .encumber_outputs(tx_id, input_selection.into_selected(), outputs)?;
+        self.confirm_encumberance(tx_id)?;
         trace!(target: LOG_TARGET, "Finalize coin split transaction ({}).", tx_id);
         stp.finalize(
             KernelFeatures::empty(),
@@ -1909,8 +1852,8 @@ where
         outputs.push(change_output);
 
         trace!(target: LOG_TARGET, "Claiming HTLC with transaction ({}).", tx_id);
-        self.resources.db.encumber_outputs(tx_id, Vec::new(), outputs).await?;
-        self.confirm_encumberance(tx_id).await?;
+        self.resources.db.encumber_outputs(tx_id, Vec::new(), outputs)?;
+        self.confirm_encumberance(tx_id)?;
         let fee = stp.get_fee_amount()?;
         trace!(target: LOG_TARGET, "Finalize send-to-self transaction ({}).", tx_id);
         stp.finalize(
@@ -1929,12 +1872,7 @@ where
         output_hash: HashOutput,
         fee_per_gram: MicroTari,
     ) -> Result<(TxId, MicroTari, MicroTari, Transaction), OutputManagerError> {
-        let output = self
-            .resources
-            .db
-            .get_unspent_output(output_hash)
-            .await?
-            .unblinded_output;
+        let output = self.resources.db.get_unspent_output(output_hash)?.unblinded_output;
 
         let amount = output.value;
 
@@ -2005,22 +1943,27 @@ where
 
         let tx = stp.take_transaction()?;
 
-        self.resources.db.encumber_outputs(tx_id, Vec::new(), outputs).await?;
-        self.confirm_encumberance(tx_id).await?;
+        self.resources.db.encumber_outputs(tx_id, Vec::new(), outputs)?;
+        self.confirm_encumberance(tx_id)?;
         Ok((tx_id, fee, amount - fee, tx))
     }
 
     /// Persist a one-sided payment script for a Comms Public/Private key. These are the scripts that this wallet knows
     /// to look for when scanning for one-sided payments
-    async fn add_known_script(&mut self, known_script: KnownOneSidedPaymentScript) -> Result<(), OutputManagerError> {
+    fn add_known_script(&mut self, known_script: KnownOneSidedPaymentScript) -> Result<(), OutputManagerError> {
         debug!(target: LOG_TARGET, "Adding new script to output manager service");
         // It is not a problem if the script has already been persisted
-        match self.resources.db.add_known_script(known_script).await {
+        match self.resources.db.add_known_script(known_script) {
             Ok(_) => (),
             Err(OutputManagerStorageError::DieselError(DieselError::DatabaseError(
                 DatabaseErrorKind::UniqueViolation,
                 _,
-            ))) => (),
+            ))) => {
+                trace!(target: LOG_TARGET, "Duplicate script not added");
+            },
+            Err(OutputManagerStorageError::DuplicateScript) => {
+                trace!(target: LOG_TARGET, "Duplicate script not added");
+            },
             Err(e) => return Err(e.into()),
         }
         Ok(())
@@ -2028,12 +1971,12 @@ where
 
     /// Attempt to scan and then rewind all of the given transaction outputs into unblinded outputs based on known
     /// pubkeys
-    async fn scan_outputs_for_one_sided_payments(
+    fn scan_outputs_for_one_sided_payments(
         &mut self,
         outputs: Vec<TransactionOutput>,
     ) -> Result<Vec<RecoveredOutput>, OutputManagerError> {
         let known_one_sided_payment_scripts: Vec<KnownOneSidedPaymentScript> =
-            self.resources.db.get_all_known_one_sided_payment_scripts().await?;
+            self.resources.db.get_all_known_one_sided_payment_scripts()?;
 
         let mut rewound_outputs: Vec<RecoveredOutput> = Vec::new();
         for output in outputs {
@@ -2088,7 +2031,7 @@ where
                     let output_hex = output.commitment.to_hex();
                     let tx_id = TxId::new_random();
 
-                    match self.resources.db.add_unspent_output_with_tx_id(tx_id, db_output).await {
+                    match self.resources.db.add_unspent_output_with_tx_id(tx_id, db_output) {
                         Ok(_) => {
                             rewound_outputs.push(RecoveredOutput {
                                 output: rewound_output,
@@ -2226,4 +2169,11 @@ impl UtxoSelection {
     pub fn iter(&self) -> impl Iterator<Item = &DbUnblindedOutput> + '_ {
         self.utxos.iter()
     }
+}
+
+#[derive(Debug, Clone)]
+pub struct OutputStatusesByTxId {
+    pub statuses: Vec<OutputStatus>,
+    pub(crate) mined_height: Option<u64>,
+    pub(crate) block_hash: Option<BlockHash>,
 }

--- a/base_layer/wallet/src/output_manager_service/storage/database/mod.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/database/mod.rs
@@ -102,140 +102,107 @@ where T: OutputManagerBackend + 'static
         Self { db: Arc::new(db) }
     }
 
-    pub async fn add_unspent_output(&self, output: DbUnblindedOutput) -> Result<(), OutputManagerStorageError> {
+    pub fn add_unspent_output(&self, output: DbUnblindedOutput) -> Result<(), OutputManagerStorageError> {
         let db_clone = self.db.clone();
-        tokio::task::spawn_blocking(move || {
-            db_clone.write(WriteOperation::Insert(DbKeyValuePair::UnspentOutput(
-                output.commitment.clone(),
-                Box::new(output),
-            )))
-        })
-        .await
-        .map_err(|err| OutputManagerStorageError::BlockingTaskSpawnError(err.to_string()))??;
+        db_clone.write(WriteOperation::Insert(DbKeyValuePair::UnspentOutput(
+            output.commitment.clone(),
+            Box::new(output),
+        )))?;
 
         Ok(())
     }
 
-    pub async fn add_unspent_output_with_tx_id(
+    pub fn add_unspent_output_with_tx_id(
         &self,
         tx_id: TxId,
         output: DbUnblindedOutput,
     ) -> Result<(), OutputManagerStorageError> {
         let db_clone = self.db.clone();
-        tokio::task::spawn_blocking(move || {
-            db_clone.write(WriteOperation::Insert(DbKeyValuePair::UnspentOutputWithTxId(
-                output.commitment.clone(),
-                (tx_id, Box::new(output)),
-            )))
-        })
-        .await
-        .map_err(|err| OutputManagerStorageError::BlockingTaskSpawnError(err.to_string()))??;
+        db_clone.write(WriteOperation::Insert(DbKeyValuePair::UnspentOutputWithTxId(
+            output.commitment.clone(),
+            (tx_id, Box::new(output)),
+        )))?;
 
         Ok(())
     }
 
-    pub async fn add_unvalidated_output(
+    pub fn add_unvalidated_output(
         &self,
         tx_id: TxId,
         output: DbUnblindedOutput,
     ) -> Result<(), OutputManagerStorageError> {
         let db_clone = self.db.clone();
-        tokio::task::spawn_blocking(move || db_clone.add_unvalidated_output(output, tx_id))
-            .await
-            .map_err(|err| OutputManagerStorageError::BlockingTaskSpawnError(err.to_string()))??;
+        db_clone.add_unvalidated_output(output, tx_id)?;
 
         Ok(())
     }
 
-    pub async fn add_output_to_be_received(
+    pub fn add_output_to_be_received(
         &self,
         tx_id: TxId,
         output: DbUnblindedOutput,
         coinbase_block_height: Option<u64>,
     ) -> Result<(), OutputManagerStorageError> {
         let db_clone = self.db.clone();
-        tokio::task::spawn_blocking(move || {
-            db_clone.write(WriteOperation::Insert(DbKeyValuePair::OutputToBeReceived(
-                output.commitment.clone(),
-                (tx_id, Box::new(output), coinbase_block_height),
-            )))
-        })
-        .await
-        .map_err(|err| OutputManagerStorageError::BlockingTaskSpawnError(err.to_string()))??;
+        db_clone.write(WriteOperation::Insert(DbKeyValuePair::OutputToBeReceived(
+            output.commitment.clone(),
+            (tx_id, Box::new(output), coinbase_block_height),
+        )))?;
 
         Ok(())
     }
 
-    pub async fn get_balance(
+    pub fn get_balance(
         &self,
         current_tip_for_time_lock_calculation: Option<u64>,
     ) -> Result<Balance, OutputManagerStorageError> {
         let db_clone = self.db.clone();
-        tokio::task::spawn_blocking(move || db_clone.get_balance(current_tip_for_time_lock_calculation))
-            .await
-            .map_err(|err| OutputManagerStorageError::BlockingTaskSpawnError(err.to_string()))?
+        db_clone.get_balance(current_tip_for_time_lock_calculation)
     }
 
     /// This method is called when a transaction is built to be sent. It will encumber unspent outputs against a pending
     /// transaction in the short term.
-    pub async fn encumber_outputs(
+    pub fn encumber_outputs(
         &self,
         tx_id: TxId,
         outputs_to_send: Vec<DbUnblindedOutput>,
         outputs_to_receive: Vec<DbUnblindedOutput>,
     ) -> Result<(), OutputManagerStorageError> {
         let db_clone = self.db.clone();
-        tokio::task::spawn_blocking(move || {
-            db_clone.short_term_encumber_outputs(tx_id, &outputs_to_send, &outputs_to_receive)
-        })
-        .await
-        .map_err(|err| OutputManagerStorageError::BlockingTaskSpawnError(err.to_string()))
-        .and_then(|inner_result| inner_result)
+        db_clone.short_term_encumber_outputs(tx_id, &outputs_to_send, &outputs_to_receive)
     }
 
     /// This method is called when a transaction is finished being negotiated. This will fully encumber the outputs
     /// against a pending transaction.
-    pub async fn confirm_encumbered_outputs(&self, tx_id: TxId) -> Result<(), OutputManagerStorageError> {
+    pub fn confirm_encumbered_outputs(&self, tx_id: TxId) -> Result<(), OutputManagerStorageError> {
         let db_clone = self.db.clone();
-        tokio::task::spawn_blocking(move || db_clone.confirm_encumbered_outputs(tx_id))
-            .await
-            .map_err(|err| OutputManagerStorageError::BlockingTaskSpawnError(err.to_string()))
-            .and_then(|inner_result| inner_result)
+        db_clone.confirm_encumbered_outputs(tx_id)
     }
 
     /// Clear all pending transaction encumberances marked as short term. These are the result of an unfinished
     /// transaction negotiation
-    pub async fn clear_short_term_encumberances(&self) -> Result<(), OutputManagerStorageError> {
+    pub fn clear_short_term_encumberances(&self) -> Result<(), OutputManagerStorageError> {
         let db_clone = self.db.clone();
-        tokio::task::spawn_blocking(move || db_clone.clear_short_term_encumberances())
-            .await
-            .map_err(|err| OutputManagerStorageError::BlockingTaskSpawnError(err.to_string()))
-            .and_then(|inner_result| inner_result)
+        db_clone.clear_short_term_encumberances()
     }
 
     /// When a pending transaction is cancelled the encumbered outputs are moved back to the `unspent_outputs`
     /// collection.
-    pub async fn cancel_pending_transaction_outputs(&self, tx_id: TxId) -> Result<(), OutputManagerStorageError> {
+    pub fn cancel_pending_transaction_outputs(&self, tx_id: TxId) -> Result<(), OutputManagerStorageError> {
         let db_clone = self.db.clone();
-        tokio::task::spawn_blocking(move || db_clone.cancel_pending_transaction(tx_id))
-            .await
-            .map_err(|err| OutputManagerStorageError::BlockingTaskSpawnError(err.to_string()))
-            .and_then(|inner_result| inner_result)
+        db_clone.cancel_pending_transaction(tx_id)
     }
 
     /// Check if there is a pending coinbase transaction at this block height, if there is clear it.
-    pub async fn clear_pending_coinbase_transaction_at_block_height(
+    pub fn clear_pending_coinbase_transaction_at_block_height(
         &self,
         block_height: u64,
     ) -> Result<(), OutputManagerStorageError> {
         let db_clone = self.db.clone();
-        tokio::task::spawn_blocking(move || db_clone.clear_pending_coinbase_transaction_at_block_height(block_height))
-            .await
-            .map_err(|err| OutputManagerStorageError::BlockingTaskSpawnError(err.to_string()))
-            .and_then(|inner_result| inner_result)
+        db_clone.clear_pending_coinbase_transaction_at_block_height(block_height)
     }
 
-    pub async fn fetch_all_unspent_outputs(&self) -> Result<Vec<DbUnblindedOutput>, OutputManagerStorageError> {
+    pub fn fetch_all_unspent_outputs(&self) -> Result<Vec<DbUnblindedOutput>, OutputManagerStorageError> {
         let result = match self.db.fetch(&DbKey::UnspentOutputs)? {
             Some(DbValue::UnspentOutputs(outputs)) => outputs,
             Some(other) => return unexpected_result(DbKey::UnspentOutputs, other),
@@ -244,7 +211,7 @@ where T: OutputManagerBackend + 'static
         Ok(result)
     }
 
-    pub async fn fetch_with_features(
+    pub fn fetch_with_features(
         &self,
         feature: OutputFlags,
     ) -> Result<Vec<DbUnblindedOutput>, OutputManagerStorageError> {
@@ -260,25 +227,21 @@ where T: OutputManagerBackend + 'static
     }
 
     /// Retrieves UTXOs than can be spent, sorted by priority, then value from smallest to largest.
-    pub async fn fetch_unspent_outputs_for_spending(
+    pub fn fetch_unspent_outputs_for_spending(
         &self,
         strategy: UTXOSelectionStrategy,
         amount: MicroTari,
         tip_height: Option<u64>,
     ) -> Result<Vec<DbUnblindedOutput>, OutputManagerStorageError> {
         let db_clone = self.db.clone();
-        let utxos = tokio::task::spawn_blocking(move || {
-            db_clone.fetch_unspent_outputs_for_spending(strategy, amount.as_u64(), tip_height)
-        })
-        .await
-        .map_err(|err| OutputManagerStorageError::BlockingTaskSpawnError(err.to_string()))??;
+        let utxos = db_clone.fetch_unspent_outputs_for_spending(strategy, amount.as_u64(), tip_height)?;
         Ok(utxos)
     }
 
-    pub async fn fetch_spent_outputs(&self) -> Result<Vec<DbUnblindedOutput>, OutputManagerStorageError> {
+    pub fn fetch_spent_outputs(&self) -> Result<Vec<DbUnblindedOutput>, OutputManagerStorageError> {
         let db_clone = self.db.clone();
 
-        let uo = tokio::task::spawn_blocking(move || match db_clone.fetch(&DbKey::SpentOutputs) {
+        let uo = match db_clone.fetch(&DbKey::SpentOutputs) {
             Ok(None) => log_error(
                 DbKey::SpentOutputs,
                 OutputManagerStorageError::UnexpectedResult("Could not retrieve spent outputs".to_string()),
@@ -286,32 +249,26 @@ where T: OutputManagerBackend + 'static
             Ok(Some(DbValue::SpentOutputs(uo))) => Ok(uo),
             Ok(Some(other)) => unexpected_result(DbKey::SpentOutputs, other),
             Err(e) => log_error(DbKey::SpentOutputs, e),
-        })
-        .await
-        .map_err(|err| OutputManagerStorageError::BlockingTaskSpawnError(err.to_string()))??;
+        }?;
         Ok(uo)
     }
 
-    pub async fn fetch_unconfirmed_outputs(&self) -> Result<Vec<DbUnblindedOutput>, OutputManagerStorageError> {
+    pub fn fetch_unconfirmed_outputs(&self) -> Result<Vec<DbUnblindedOutput>, OutputManagerStorageError> {
         let db_clone = self.db.clone();
-        let utxos = tokio::task::spawn_blocking(move || db_clone.fetch_unconfirmed_outputs())
-            .await
-            .map_err(|err| OutputManagerStorageError::BlockingTaskSpawnError(err.to_string()))??;
+        let utxos = db_clone.fetch_unconfirmed_outputs()?;
         Ok(utxos)
     }
 
-    pub async fn fetch_mined_unspent_outputs(&self) -> Result<Vec<DbUnblindedOutput>, OutputManagerStorageError> {
+    pub fn fetch_mined_unspent_outputs(&self) -> Result<Vec<DbUnblindedOutput>, OutputManagerStorageError> {
         let db_clone = self.db.clone();
-        let utxos = tokio::task::spawn_blocking(move || db_clone.fetch_mined_unspent_outputs())
-            .await
-            .map_err(|err| OutputManagerStorageError::BlockingTaskSpawnError(err.to_string()))??;
+        let utxos = db_clone.fetch_mined_unspent_outputs()?;
         Ok(utxos)
     }
 
-    pub async fn get_timelocked_outputs(&self, tip: u64) -> Result<Vec<DbUnblindedOutput>, OutputManagerStorageError> {
+    pub fn get_timelocked_outputs(&self, tip: u64) -> Result<Vec<DbUnblindedOutput>, OutputManagerStorageError> {
         let db_clone = self.db.clone();
 
-        let uo = tokio::task::spawn_blocking(move || match db_clone.fetch(&DbKey::TimeLockedUnspentOutputs(tip)) {
+        let uo = match db_clone.fetch(&DbKey::TimeLockedUnspentOutputs(tip)) {
             Ok(None) => log_error(
                 DbKey::UnspentOutputs,
                 OutputManagerStorageError::UnexpectedResult("Could not retrieve unspent outputs".to_string()),
@@ -319,16 +276,14 @@ where T: OutputManagerBackend + 'static
             Ok(Some(DbValue::UnspentOutputs(uo))) => Ok(uo),
             Ok(Some(other)) => unexpected_result(DbKey::UnspentOutputs, other),
             Err(e) => log_error(DbKey::UnspentOutputs, e),
-        })
-        .await
-        .map_err(|err| OutputManagerStorageError::BlockingTaskSpawnError(err.to_string()))??;
+        }?;
         Ok(uo)
     }
 
-    pub async fn get_invalid_outputs(&self) -> Result<Vec<DbUnblindedOutput>, OutputManagerStorageError> {
+    pub fn get_invalid_outputs(&self) -> Result<Vec<DbUnblindedOutput>, OutputManagerStorageError> {
         let db_clone = self.db.clone();
 
-        let uo = tokio::task::spawn_blocking(move || match db_clone.fetch(&DbKey::InvalidOutputs) {
+        let uo = match db_clone.fetch(&DbKey::InvalidOutputs) {
             Ok(None) => log_error(
                 DbKey::InvalidOutputs,
                 OutputManagerStorageError::UnexpectedResult("Could not retrieve invalid outputs".to_string()),
@@ -336,61 +291,41 @@ where T: OutputManagerBackend + 'static
             Ok(Some(DbValue::InvalidOutputs(uo))) => Ok(uo),
             Ok(Some(other)) => unexpected_result(DbKey::InvalidOutputs, other),
             Err(e) => log_error(DbKey::InvalidOutputs, e),
-        })
-        .await
-        .map_err(|err| OutputManagerStorageError::BlockingTaskSpawnError(err.to_string()))??;
+        }?;
         Ok(uo)
     }
 
-    pub async fn update_output_metadata_signature(
-        &self,
-        output: TransactionOutput,
-    ) -> Result<(), OutputManagerStorageError> {
+    pub fn update_output_metadata_signature(&self, output: TransactionOutput) -> Result<(), OutputManagerStorageError> {
         let db_clone = self.db.clone();
-        tokio::task::spawn_blocking(move || db_clone.update_output_metadata_signature(&output))
-            .await
-            .map_err(|err| OutputManagerStorageError::BlockingTaskSpawnError(err.to_string()))
-            .and_then(|inner_result| inner_result)
+        db_clone.update_output_metadata_signature(&output)
     }
 
-    pub async fn revalidate_output(&self, commitment: Commitment) -> Result<(), OutputManagerStorageError> {
+    pub fn revalidate_output(&self, commitment: Commitment) -> Result<(), OutputManagerStorageError> {
         let db_clone = self.db.clone();
-        tokio::task::spawn_blocking(move || db_clone.revalidate_unspent_output(&commitment))
-            .await
-            .map_err(|err| OutputManagerStorageError::BlockingTaskSpawnError(err.to_string()))
-            .and_then(|inner_result| inner_result)
+        db_clone.revalidate_unspent_output(&commitment)
     }
 
-    pub async fn reinstate_cancelled_inbound_output(&self, tx_id: TxId) -> Result<(), OutputManagerStorageError> {
+    pub fn reinstate_cancelled_inbound_output(&self, tx_id: TxId) -> Result<(), OutputManagerStorageError> {
         let db_clone = self.db.clone();
-        tokio::task::spawn_blocking(move || db_clone.reinstate_cancelled_inbound_output(tx_id))
-            .await
-            .map_err(|err| OutputManagerStorageError::BlockingTaskSpawnError(err.to_string()))
-            .and_then(|inner_result| inner_result)
+        db_clone.reinstate_cancelled_inbound_output(tx_id)
     }
 
-    pub async fn apply_encryption(&self, cipher: Aes256Gcm) -> Result<(), OutputManagerStorageError> {
+    pub fn apply_encryption(&self, cipher: Aes256Gcm) -> Result<(), OutputManagerStorageError> {
         let db_clone = self.db.clone();
-        tokio::task::spawn_blocking(move || db_clone.apply_encryption(cipher))
-            .await
-            .map_err(|err| OutputManagerStorageError::BlockingTaskSpawnError(err.to_string()))
-            .and_then(|inner_result| inner_result)
+        db_clone.apply_encryption(cipher)
     }
 
-    pub async fn remove_encryption(&self) -> Result<(), OutputManagerStorageError> {
+    pub fn remove_encryption(&self) -> Result<(), OutputManagerStorageError> {
         let db_clone = self.db.clone();
-        tokio::task::spawn_blocking(move || db_clone.remove_encryption())
-            .await
-            .map_err(|err| OutputManagerStorageError::BlockingTaskSpawnError(err.to_string()))
-            .and_then(|inner_result| inner_result)
+        db_clone.remove_encryption()
     }
 
-    pub async fn get_all_known_one_sided_payment_scripts(
+    pub fn get_all_known_one_sided_payment_scripts(
         &self,
     ) -> Result<Vec<KnownOneSidedPaymentScript>, OutputManagerStorageError> {
         let db_clone = self.db.clone();
 
-        let scripts = tokio::task::spawn_blocking(move || match db_clone.fetch(&DbKey::KnownOneSidedPaymentScripts) {
+        let scripts = match db_clone.fetch(&DbKey::KnownOneSidedPaymentScripts) {
             Ok(None) => log_error(
                 DbKey::KnownOneSidedPaymentScripts,
                 OutputManagerStorageError::UnexpectedResult("Could not retrieve known scripts".to_string()),
@@ -398,73 +333,56 @@ where T: OutputManagerBackend + 'static
             Ok(Some(DbValue::KnownOneSidedPaymentScripts(scripts))) => Ok(scripts),
             Ok(Some(other)) => unexpected_result(DbKey::KnownOneSidedPaymentScripts, other),
             Err(e) => log_error(DbKey::KnownOneSidedPaymentScripts, e),
-        })
-        .await
-        .map_err(|err| OutputManagerStorageError::BlockingTaskSpawnError(err.to_string()))??;
+        }?;
         Ok(scripts)
     }
 
-    pub async fn get_unspent_output(&self, output: HashOutput) -> Result<DbUnblindedOutput, OutputManagerStorageError> {
+    pub fn get_unspent_output(&self, output: HashOutput) -> Result<DbUnblindedOutput, OutputManagerStorageError> {
         let db_clone = self.db.clone();
 
-        let uo = tokio::task::spawn_blocking(
-            move || match db_clone.fetch(&DbKey::UnspentOutputHash(output.clone())) {
-                Ok(None) => log_error(
-                    DbKey::UnspentOutputHash(output.clone()),
-                    OutputManagerStorageError::UnexpectedResult(
-                        "Could not retrieve unspent output: ".to_string() + &output.to_hex(),
-                    ),
+        let uo = match db_clone.fetch(&DbKey::UnspentOutputHash(output.clone())) {
+            Ok(None) => log_error(
+                DbKey::UnspentOutputHash(output.clone()),
+                OutputManagerStorageError::UnexpectedResult(
+                    "Could not retrieve unspent output: ".to_string() + &output.to_hex(),
                 ),
-                Ok(Some(DbValue::UnspentOutput(uo))) => Ok(uo),
-                Ok(Some(other)) => unexpected_result(DbKey::UnspentOutputHash(output), other),
-                Err(e) => log_error(DbKey::UnspentOutputHash(output), e),
-            },
-        )
-        .await
-        .map_err(|err| OutputManagerStorageError::BlockingTaskSpawnError(err.to_string()))??;
+            ),
+            Ok(Some(DbValue::UnspentOutput(uo))) => Ok(uo),
+            Ok(Some(other)) => unexpected_result(DbKey::UnspentOutputHash(output), other),
+            Err(e) => log_error(DbKey::UnspentOutputHash(output), e),
+        }?;
         Ok(*uo)
     }
 
-    pub async fn get_last_mined_output(&self) -> Result<Option<DbUnblindedOutput>, OutputManagerStorageError> {
+    pub fn get_last_mined_output(&self) -> Result<Option<DbUnblindedOutput>, OutputManagerStorageError> {
         self.db.get_last_mined_output()
     }
 
-    pub async fn get_last_spent_output(&self) -> Result<Option<DbUnblindedOutput>, OutputManagerStorageError> {
+    pub fn get_last_spent_output(&self) -> Result<Option<DbUnblindedOutput>, OutputManagerStorageError> {
         self.db.get_last_spent_output()
     }
 
-    pub async fn add_known_script(
-        &self,
-        known_script: KnownOneSidedPaymentScript,
-    ) -> Result<(), OutputManagerStorageError> {
+    pub fn add_known_script(&self, known_script: KnownOneSidedPaymentScript) -> Result<(), OutputManagerStorageError> {
         let db_clone = self.db.clone();
-        tokio::task::spawn_blocking(move || {
-            db_clone.write(WriteOperation::Insert(DbKeyValuePair::KnownOneSidedPaymentScripts(
-                known_script,
-            )))
-        })
-        .await
-        .map_err(|err| OutputManagerStorageError::BlockingTaskSpawnError(err.to_string()))??;
+        db_clone.write(WriteOperation::Insert(DbKeyValuePair::KnownOneSidedPaymentScripts(
+            known_script,
+        )))?;
 
         Ok(())
     }
 
-    pub async fn remove_output_by_commitment(&self, commitment: Commitment) -> Result<(), OutputManagerStorageError> {
+    pub fn remove_output_by_commitment(&self, commitment: Commitment) -> Result<(), OutputManagerStorageError> {
         let db_clone = self.db.clone();
-        tokio::task::spawn_blocking(move || {
-            match db_clone.write(WriteOperation::Remove(DbKey::AnyOutputByCommitment(commitment.clone()))) {
-                Ok(None) => Ok(()),
-                Ok(Some(DbValue::AnyOutput(_))) => Ok(()),
-                Ok(Some(other)) => unexpected_result(DbKey::AnyOutputByCommitment(commitment.clone()), other),
-                Err(e) => log_error(DbKey::AnyOutputByCommitment(commitment), e),
-            }
-        })
-        .await
-        .map_err(|err| OutputManagerStorageError::BlockingTaskSpawnError(err.to_string()))??;
+        match db_clone.write(WriteOperation::Remove(DbKey::AnyOutputByCommitment(commitment.clone()))) {
+            Ok(None) => Ok(()),
+            Ok(Some(DbValue::AnyOutput(_))) => Ok(()),
+            Ok(Some(other)) => unexpected_result(DbKey::AnyOutputByCommitment(commitment), other),
+            Err(e) => log_error(DbKey::AnyOutputByCommitment(commitment), e),
+        }?;
         Ok(())
     }
 
-    pub async fn set_received_output_mined_height(
+    pub fn set_received_output_mined_height(
         &self,
         hash: HashOutput,
         mined_height: u64,
@@ -473,31 +391,23 @@ where T: OutputManagerBackend + 'static
         confirmed: bool,
     ) -> Result<(), OutputManagerStorageError> {
         let db = self.db.clone();
-        tokio::task::spawn_blocking(move || {
-            db.set_received_output_mined_height(hash, mined_height, mined_in_block, mmr_position, confirmed)
-        })
-        .await
-        .map_err(|err| OutputManagerStorageError::BlockingTaskSpawnError(err.to_string()))??;
+        db.set_received_output_mined_height(hash, mined_height, mined_in_block, mmr_position, confirmed)?;
         Ok(())
     }
 
-    pub async fn set_output_to_unmined(&self, hash: HashOutput) -> Result<(), OutputManagerStorageError> {
+    pub fn set_output_to_unmined(&self, hash: HashOutput) -> Result<(), OutputManagerStorageError> {
         let db = self.db.clone();
-        tokio::task::spawn_blocking(move || db.set_output_to_unmined(hash))
-            .await
-            .map_err(|err| OutputManagerStorageError::BlockingTaskSpawnError(err.to_string()))??;
+        db.set_output_to_unmined(hash)?;
         Ok(())
     }
 
-    pub async fn set_outputs_to_be_revalidated(&self) -> Result<(), OutputManagerStorageError> {
+    pub fn set_outputs_to_be_revalidated(&self) -> Result<(), OutputManagerStorageError> {
         let db = self.db.clone();
-        tokio::task::spawn_blocking(move || db.set_outputs_to_be_revalidated())
-            .await
-            .map_err(|err| OutputManagerStorageError::BlockingTaskSpawnError(err.to_string()))??;
+        db.set_outputs_to_be_revalidated()?;
         Ok(())
     }
 
-    pub async fn mark_output_as_spent(
+    pub fn mark_output_as_spent(
         &self,
         hash: HashOutput,
         deleted_height: u64,
@@ -505,36 +415,25 @@ where T: OutputManagerBackend + 'static
         confirmed: bool,
     ) -> Result<(), OutputManagerStorageError> {
         let db = self.db.clone();
-        tokio::task::spawn_blocking(move || db.mark_output_as_spent(hash, deleted_height, deleted_in_block, confirmed))
-            .await
-            .map_err(|err| OutputManagerStorageError::BlockingTaskSpawnError(err.to_string()))??;
+        db.mark_output_as_spent(hash, deleted_height, deleted_in_block, confirmed)?;
         Ok(())
     }
 
-    pub async fn mark_output_as_unspent(&self, hash: HashOutput) -> Result<(), OutputManagerStorageError> {
+    pub fn mark_output_as_unspent(&self, hash: HashOutput) -> Result<(), OutputManagerStorageError> {
         let db = self.db.clone();
-        tokio::task::spawn_blocking(move || db.mark_output_as_unspent(hash))
-            .await
-            .map_err(|err| OutputManagerStorageError::BlockingTaskSpawnError(err.to_string()))??;
+        db.mark_output_as_unspent(hash)?;
         Ok(())
     }
 
-    pub async fn set_coinbase_abandoned(&self, tx_id: TxId, abandoned: bool) -> Result<(), OutputManagerStorageError> {
+    pub fn set_coinbase_abandoned(&self, tx_id: TxId, abandoned: bool) -> Result<(), OutputManagerStorageError> {
         let db = self.db.clone();
-        tokio::task::spawn_blocking(move || db.set_coinbase_abandoned(tx_id, abandoned))
-            .await
-            .map_err(|err| OutputManagerStorageError::BlockingTaskSpawnError(err.to_string()))??;
+        db.set_coinbase_abandoned(tx_id, abandoned)?;
         Ok(())
     }
 
-    pub async fn fetch_outputs_by_tx_id(
-        &self,
-        tx_id: TxId,
-    ) -> Result<Vec<DbUnblindedOutput>, OutputManagerStorageError> {
+    pub fn fetch_outputs_by_tx_id(&self, tx_id: TxId) -> Result<Vec<DbUnblindedOutput>, OutputManagerStorageError> {
         let db_clone = self.db.clone();
-        let outputs = tokio::task::spawn_blocking(move || db_clone.fetch_outputs_by_tx_id(tx_id))
-            .await
-            .map_err(|err| OutputManagerStorageError::BlockingTaskSpawnError(err.to_string()))??;
+        let outputs = db_clone.fetch_outputs_by_tx_id(tx_id)?;
         Ok(outputs)
     }
 }

--- a/base_layer/wallet/src/output_manager_service/storage/sqlite_db/mod.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/sqlite_db/mod.rs
@@ -130,6 +130,9 @@ impl OutputManagerSqliteDatabase {
 
             DbKeyValuePair::KnownOneSidedPaymentScripts(script) => {
                 let mut script_sql = KnownOneSidedPaymentScriptSql::from(script);
+                if KnownOneSidedPaymentScriptSql::find(&script_sql.script_hash, conn).is_ok() {
+                    return Err(OutputManagerStorageError::DuplicateScript);
+                }
                 self.encrypt_if_necessary(&mut script_sql)?;
                 script_sql.commit(conn)?
             },
@@ -1292,7 +1295,7 @@ impl KnownOneSidedPaymentScriptSql {
         Ok(())
     }
 
-    /// Find a particular Output, if it exists
+    /// Find a particular script, if it exists
     pub fn find(
         hash: &[u8],
         conn: &SqliteConnection,

--- a/base_layer/wallet/src/output_manager_service/tasks/txo_validation_task.rs
+++ b/base_layer/wallet/src/output_manager_service/tasks/txo_validation_task.rs
@@ -108,11 +108,7 @@ where
         wallet_client: &mut BaseNodeWalletRpcClient,
         last_mined_header_hash: Option<BlockHash>,
     ) -> Result<(), OutputManagerProtocolError> {
-        let mined_outputs = self
-            .db
-            .fetch_mined_unspent_outputs()
-            .await
-            .for_protocol(self.operation_id)?;
+        let mined_outputs = self.db.fetch_mined_unspent_outputs().for_protocol(self.operation_id)?;
 
         if mined_outputs.is_empty() {
             return Ok(());
@@ -177,7 +173,6 @@ where
 
                     self.db
                         .mark_output_as_spent(output.hash.clone(), deleted_height, deleted_block, confirmed)
-                        .await
                         .for_protocol(self.operation_id)?;
                     info!(
                         target: LOG_TARGET,
@@ -200,7 +195,6 @@ where
                 {
                     self.db
                         .mark_output_as_unspent(output.hash.clone())
-                        .await
                         .for_protocol(self.operation_id)?;
                     info!(
                         target: LOG_TARGET,
@@ -220,11 +214,7 @@ where
         &self,
         wallet_client: &mut BaseNodeWalletRpcClient,
     ) -> Result<(), OutputManagerProtocolError> {
-        let unconfirmed_outputs = self
-            .db
-            .fetch_unconfirmed_outputs()
-            .await
-            .for_protocol(self.operation_id)?;
+        let unconfirmed_outputs = self.db.fetch_unconfirmed_outputs().for_protocol(self.operation_id)?;
 
         for batch in unconfirmed_outputs.chunks(self.config.tx_validator_batch_size) {
             debug!(
@@ -273,7 +263,7 @@ where
             "Checking last mined TXO to see if the base node has re-orged (Operation ID: {})", self.operation_id
         );
 
-        while let Some(last_spent_output) = self.db.get_last_spent_output().await.for_protocol(self.operation_id)? {
+        while let Some(last_spent_output) = self.db.get_last_spent_output().for_protocol(self.operation_id)? {
             let mined_height = last_spent_output
                 .marked_deleted_at_height
                 .ok_or(OutputManagerError::InconsistentDataError(
@@ -303,7 +293,6 @@ where
                 );
                 self.db
                     .mark_output_as_unspent(last_spent_output.hash.clone())
-                    .await
                     .for_protocol(self.operation_id)?;
             } else {
                 debug!(
@@ -315,7 +304,7 @@ where
             }
         }
 
-        while let Some(last_mined_output) = self.db.get_last_mined_output().await.for_protocol(self.operation_id)? {
+        while let Some(last_mined_output) = self.db.get_last_mined_output().for_protocol(self.operation_id)? {
             if last_mined_output.mined_height.is_none() || last_mined_output.mined_in_block.is_none() {
                 return Err(OutputManagerProtocolError::new(
                     self.operation_id,
@@ -341,7 +330,6 @@ where
                 );
                 self.db
                     .set_output_to_unmined(last_mined_output.hash.clone())
-                    .await
                     .for_protocol(self.operation_id)?;
             } else {
                 debug!(
@@ -452,7 +440,6 @@ where
                 mmr_position,
                 confirmed,
             )
-            .await
             .for_protocol(self.operation_id)?;
 
         Ok(())

--- a/base_layer/wallet/src/tokens/token_manager.rs
+++ b/base_layer/wallet/src/tokens/token_manager.rs
@@ -54,7 +54,6 @@ impl<T: OutputManagerBackend + 'static> TokenManager<T> {
         let outputs = self
             .output_database
             .fetch_with_features(OutputFlags::NON_FUNGIBLE)
-            .await
             .map_err(|err| WalletError::OutputManagerError(err.into()))?;
 
         // These will include assets registrations

--- a/base_layer/wallet/src/transaction_service/tasks/check_faux_transaction_status.rs
+++ b/base_layer/wallet/src/transaction_service/tasks/check_faux_transaction_status.rs
@@ -93,20 +93,24 @@ pub async fn check_faux_transactions<TBackend: 'static + TransactionBackend>(
         all_faux_transactions.len()
     );
     for tx in all_faux_transactions.into_iter() {
-        let (status, mined_height, block_hash) = match output_manager.get_output_statuses_by_tx_id(tx.tx_id).await {
+        let output_statuses_by_tx_id = match output_manager.get_output_statuses_by_tx_id(tx.tx_id).await {
             Ok(s) => s,
             Err(e) => {
                 error!(target: LOG_TARGET, "Problem retrieving output statuses: {}", e);
                 return;
             },
         };
-        if !status.iter().any(|s| s != &OutputStatus::Unspent) {
-            let mined_height = if let Some(height) = mined_height {
+        if !output_statuses_by_tx_id
+            .statuses
+            .iter()
+            .any(|s| s != &OutputStatus::Unspent)
+        {
+            let mined_height = if let Some(height) = output_statuses_by_tx_id.mined_height {
                 height
             } else {
                 tip_height
             };
-            let mined_in_block: BlockHash = if let Some(hash) = block_hash {
+            let mined_in_block: BlockHash = if let Some(hash) = output_statuses_by_tx_id.block_hash {
                 hash
             } else {
                 vec![0u8; 32]

--- a/base_layer/wallet/tests/output_manager_service_tests/service.rs
+++ b/base_layer/wallet/tests/output_manager_service_tests/service.rs
@@ -1867,7 +1867,7 @@ async fn test_txo_revalidation() {
     );
     let output1_tx_output = output1.as_transaction_output(&factories).unwrap();
     oms.output_manager_handle
-        .add_output_with_tx_id(1.into(), output1.clone(), None)
+        .add_output_with_tx_id(TxId::from(1), output1.clone(), None)
         .await
         .unwrap();
 
@@ -1881,7 +1881,7 @@ async fn test_txo_revalidation() {
     let output2_tx_output = output2.as_transaction_output(&factories).unwrap();
 
     oms.output_manager_handle
-        .add_output_with_tx_id(2.into(), output2.clone(), None)
+        .add_output_with_tx_id(TxId::from(2), output2.clone(), None)
         .await
         .unwrap();
 
@@ -2026,14 +2026,17 @@ async fn test_get_status_by_tx_id() {
         .await
         .unwrap();
 
-    let (status, _, _) = oms
+    let output_statuses_by_tx_id = oms
         .output_manager_handle
         .get_output_statuses_by_tx_id(TxId::from(1u64))
         .await
         .unwrap();
 
-    assert_eq!(status.len(), 1);
-    assert_eq!(status[0], OutputStatus::EncumberedToBeReceived);
+    assert_eq!(output_statuses_by_tx_id.statuses.len(), 1);
+    assert_eq!(
+        output_statuses_by_tx_id.statuses[0],
+        OutputStatus::EncumberedToBeReceived
+    );
 }
 
 #[tokio::test]

--- a/base_layer/wallet/tests/output_manager_service_tests/storage.rs
+++ b/base_layer/wallet/tests/output_manager_service_tests/storage.rs
@@ -58,19 +58,19 @@ pub fn test_db_backend<T: OutputManagerBackend + 'static>(backend: T) {
         ));
         let mut uo = DbUnblindedOutput::from_unblinded_output(uo, &factories, None).unwrap();
         uo.unblinded_output.features.maturity = i;
-        runtime.block_on(db.add_unspent_output(uo.clone())).unwrap();
+        db.add_unspent_output(uo.clone()).unwrap();
         unspent_outputs.push(uo);
     }
 
-    let time_locked_outputs = runtime.block_on(db.get_timelocked_outputs(3)).unwrap();
+    let time_locked_outputs = db.get_timelocked_outputs(3).unwrap();
     assert_eq!(time_locked_outputs.len(), 1);
     assert_eq!(unspent_outputs[4], time_locked_outputs[0]);
-    let time_locked_outputs = runtime.block_on(db.get_timelocked_outputs(4)).unwrap();
+    let time_locked_outputs = db.get_timelocked_outputs(4).unwrap();
     assert_eq!(time_locked_outputs.len(), 0);
     let time_locked_balance = unspent_outputs[4].unblinded_output.value;
 
     for i in 0..4usize {
-        let balance = runtime.block_on(db.get_balance(Some(i as u64))).unwrap();
+        let balance = db.get_balance(Some(i as u64)).unwrap();
         let mut sum = MicroTari::from(0);
         for output in unspent_outputs.iter().take(5).skip(i + 1) {
             sum += output.unblinded_output.value;
@@ -80,7 +80,7 @@ pub fn test_db_backend<T: OutputManagerBackend + 'static>(backend: T) {
 
     unspent_outputs.sort();
 
-    let outputs = runtime.block_on(db.fetch_mined_unspent_outputs()).unwrap();
+    let outputs = db.fetch_mined_unspent_outputs().unwrap();
     assert_eq!(unspent_outputs, outputs);
 
     // Add some sent transactions with outputs to be spent and received
@@ -105,7 +105,7 @@ pub fn test_db_backend<T: OutputManagerBackend + 'static>(backend: T) {
                 None,
             ));
             let uo = DbUnblindedOutput::from_unblinded_output(uo, &factories, None).unwrap();
-            runtime.block_on(db.add_unspent_output(uo.clone())).unwrap();
+            db.add_unspent_output(uo.clone()).unwrap();
             pending_tx.outputs_to_be_spent.push(uo);
         }
         for _ in 0..2 {
@@ -118,13 +118,12 @@ pub fn test_db_backend<T: OutputManagerBackend + 'static>(backend: T) {
             let uo = DbUnblindedOutput::from_unblinded_output(uo, &factories, None).unwrap();
             pending_tx.outputs_to_be_received.push(uo);
         }
-        runtime
-            .block_on(db.encumber_outputs(
-                pending_tx.tx_id,
-                pending_tx.outputs_to_be_spent.clone(),
-                pending_tx.outputs_to_be_received.clone(),
-            ))
-            .unwrap();
+        db.encumber_outputs(
+            pending_tx.tx_id,
+            pending_tx.outputs_to_be_spent.clone(),
+            pending_tx.outputs_to_be_received.clone(),
+        )
+        .unwrap();
         pending_txs.push(pending_tx);
     }
 
@@ -145,7 +144,7 @@ pub fn test_db_backend<T: OutputManagerBackend + 'static>(backend: T) {
             .fold(MicroTari::from(0), |acc, x| acc + x.unblinded_output.value);
     }
 
-    let balance = runtime.block_on(db.get_balance(None)).unwrap();
+    let balance = db.get_balance(None).unwrap();
     assert_eq!(balance, Balance {
         available_balance,
         time_locked_balance: None,
@@ -153,7 +152,7 @@ pub fn test_db_backend<T: OutputManagerBackend + 'static>(backend: T) {
         pending_outgoing_balance
     });
 
-    let balance = runtime.block_on(db.get_balance(Some(3))).unwrap();
+    let balance = db.get_balance(Some(3)).unwrap();
     assert_eq!(balance, Balance {
         available_balance,
         time_locked_balance: Some(time_locked_balance),
@@ -162,10 +161,10 @@ pub fn test_db_backend<T: OutputManagerBackend + 'static>(backend: T) {
     });
 
     for v in pending_txs.iter() {
-        runtime.block_on(db.confirm_encumbered_outputs(v.tx_id)).unwrap();
+        db.confirm_encumbered_outputs(v.tx_id).unwrap();
     }
 
-    let balance = runtime.block_on(db.get_balance(None)).unwrap();
+    let balance = db.get_balance(None).unwrap();
     assert_eq!(balance, Balance {
         available_balance,
         time_locked_balance: None,
@@ -176,19 +175,16 @@ pub fn test_db_backend<T: OutputManagerBackend + 'static>(backend: T) {
     // Set first pending tx to mined but unconfirmed
     let mut mmr_pos = 0;
     for o in pending_txs[0].outputs_to_be_received.iter() {
-        runtime
-            .block_on(db.set_received_output_mined_height(o.hash.clone(), 2, vec![], mmr_pos, false))
+        db.set_received_output_mined_height(o.hash.clone(), 2, vec![], mmr_pos, false)
             .unwrap();
         mmr_pos += 1;
     }
     for o in pending_txs[0].outputs_to_be_spent.iter() {
-        runtime
-            .block_on(db.mark_output_as_spent(o.hash.clone(), 3, vec![], false))
-            .unwrap();
+        db.mark_output_as_spent(o.hash.clone(), 3, vec![], false).unwrap();
     }
 
     // Balance shouldn't change
-    let balance = runtime.block_on(db.get_balance(None)).unwrap();
+    let balance = db.get_balance(None).unwrap();
 
     assert_eq!(balance, Balance {
         available_balance,
@@ -199,15 +195,12 @@ pub fn test_db_backend<T: OutputManagerBackend + 'static>(backend: T) {
 
     // Set second pending tx to mined and confirmed
     for o in pending_txs[1].outputs_to_be_received.iter() {
-        runtime
-            .block_on(db.set_received_output_mined_height(o.hash.clone(), 4, vec![], mmr_pos, true))
+        db.set_received_output_mined_height(o.hash.clone(), 4, vec![], mmr_pos, true)
             .unwrap();
         mmr_pos += 1;
     }
     for o in pending_txs[1].outputs_to_be_spent.iter() {
-        runtime
-            .block_on(db.mark_output_as_spent(o.hash.clone(), 5, vec![], true))
-            .unwrap();
+        db.mark_output_as_spent(o.hash.clone(), 5, vec![], true).unwrap();
     }
 
     // Balance with confirmed second pending tx
@@ -239,7 +232,7 @@ pub fn test_db_backend<T: OutputManagerBackend + 'static>(backend: T) {
         .iter()
         .fold(MicroTari::from(0), |acc, x| acc + x.unblinded_output.value);
 
-    let balance = runtime.block_on(db.get_balance(None)).unwrap();
+    let balance = db.get_balance(None).unwrap();
     assert_eq!(
         balance,
         Balance {
@@ -259,12 +252,11 @@ pub fn test_db_backend<T: OutputManagerBackend + 'static>(backend: T) {
         None,
     ));
     let output_to_be_received = DbUnblindedOutput::from_unblinded_output(uo, &factories, None).unwrap();
-    runtime
-        .block_on(db.add_output_to_be_received(11.into(), output_to_be_received.clone(), None))
+    db.add_output_to_be_received(TxId::from(11), output_to_be_received.clone(), None)
         .unwrap();
     pending_incoming_balance += output_to_be_received.unblinded_output.value;
 
-    let balance = runtime.block_on(db.get_balance(None)).unwrap();
+    let balance = db.get_balance(None).unwrap();
     assert_eq!(
         balance,
         Balance {
@@ -276,53 +268,48 @@ pub fn test_db_backend<T: OutputManagerBackend + 'static>(backend: T) {
         "Balance should reflect new output to be received"
     );
 
-    let spent_outputs = runtime.block_on(db.fetch_spent_outputs()).unwrap();
+    let spent_outputs = db.fetch_spent_outputs().unwrap();
     assert_eq!(spent_outputs.len(), 4);
 
-    let unconfirmed_outputs = runtime.block_on(db.fetch_unconfirmed_outputs()).unwrap();
+    let unconfirmed_outputs = db.fetch_unconfirmed_outputs().unwrap();
     assert_eq!(unconfirmed_outputs.len(), 22);
 
-    let mined_unspent_outputs = runtime.block_on(db.fetch_mined_unspent_outputs()).unwrap();
+    let mined_unspent_outputs = db.fetch_mined_unspent_outputs().unwrap();
     assert_eq!(mined_unspent_outputs.len(), 4);
 
     // Spend a received and confirmed output
-    runtime
-        .block_on(db.mark_output_as_spent(pending_txs[1].outputs_to_be_received[0].hash.clone(), 6, vec![], true))
+    db.mark_output_as_spent(pending_txs[1].outputs_to_be_received[0].hash.clone(), 6, vec![], true)
         .unwrap();
 
-    let mined_unspent_outputs = runtime.block_on(db.fetch_mined_unspent_outputs()).unwrap();
+    let mined_unspent_outputs = db.fetch_mined_unspent_outputs().unwrap();
     assert_eq!(mined_unspent_outputs.len(), 3);
 
-    let unspent_outputs = runtime.block_on(db.fetch_mined_unspent_outputs()).unwrap();
+    let unspent_outputs = db.fetch_mined_unspent_outputs().unwrap();
     assert_eq!(unspent_outputs.len(), 6);
 
-    let last_mined_output = runtime.block_on(db.get_last_mined_output()).unwrap().unwrap();
+    let last_mined_output = db.get_last_mined_output().unwrap().unwrap();
     assert!(pending_txs[1]
         .outputs_to_be_received
         .iter()
         .any(|o| o.commitment == last_mined_output.commitment));
 
-    let last_spent_output = runtime.block_on(db.get_last_spent_output()).unwrap().unwrap();
+    let last_spent_output = db.get_last_spent_output().unwrap().unwrap();
     assert_eq!(
         last_spent_output.commitment,
         pending_txs[1].outputs_to_be_received[0].commitment
     );
 
-    runtime
-        .block_on(db.remove_output_by_commitment(last_spent_output.commitment))
-        .unwrap();
-    let last_spent_output = runtime.block_on(db.get_last_spent_output()).unwrap().unwrap();
+    db.remove_output_by_commitment(last_spent_output.commitment).unwrap();
+    let last_spent_output = db.get_last_spent_output().unwrap().unwrap();
     assert_ne!(
         last_spent_output.commitment,
         pending_txs[1].outputs_to_be_received[0].commitment
     );
 
     // Test cancelling a pending transaction
-    runtime
-        .block_on(db.cancel_pending_transaction_outputs(pending_txs[2].tx_id))
-        .unwrap();
+    db.cancel_pending_transaction_outputs(pending_txs[2].tx_id).unwrap();
 
-    let unspent_outputs = runtime.block_on(db.fetch_mined_unspent_outputs()).unwrap();
+    let unspent_outputs = db.fetch_mined_unspent_outputs().unwrap();
     assert_eq!(unspent_outputs.len(), 10);
 }
 
@@ -363,15 +350,14 @@ pub async fn test_short_term_encumberance() {
         .await;
         let mut uo = DbUnblindedOutput::from_unblinded_output(uo, &factories, None).unwrap();
         uo.unblinded_output.features.maturity = i;
-        db.add_unspent_output(uo.clone()).await.unwrap();
+        db.add_unspent_output(uo.clone()).unwrap();
         unspent_outputs.push(uo);
     }
 
     db.encumber_outputs(1.into(), unspent_outputs[0..=2].to_vec(), vec![])
-        .await
         .unwrap();
 
-    let balance = db.get_balance(None).await.unwrap();
+    let balance = db.get_balance(None).unwrap();
     assert_eq!(
         balance.available_balance,
         unspent_outputs[3..5]
@@ -379,9 +365,9 @@ pub async fn test_short_term_encumberance() {
             .fold(MicroTari::from(0), |acc, x| acc + x.unblinded_output.value)
     );
 
-    db.clear_short_term_encumberances().await.unwrap();
+    db.clear_short_term_encumberances().unwrap();
 
-    let balance = db.get_balance(None).await.unwrap();
+    let balance = db.get_balance(None).unwrap();
     assert_eq!(
         balance.available_balance,
         unspent_outputs
@@ -390,13 +376,12 @@ pub async fn test_short_term_encumberance() {
     );
 
     db.encumber_outputs(2.into(), unspent_outputs[0..=2].to_vec(), vec![])
-        .await
         .unwrap();
 
-    db.confirm_encumbered_outputs(2.into()).await.unwrap();
-    db.clear_short_term_encumberances().await.unwrap();
+    db.confirm_encumbered_outputs(TxId::from(2)).unwrap();
+    db.clear_short_term_encumberances().unwrap();
 
-    let balance = db.get_balance(None).await.unwrap();
+    let balance = db.get_balance(None).unwrap();
     assert_eq!(
         balance.available_balance,
         unspent_outputs[3..5]
@@ -417,26 +402,24 @@ pub async fn test_no_duplicate_outputs() {
     let uo = DbUnblindedOutput::from_unblinded_output(uo, &factories, None).unwrap();
 
     // add it to the database
-    let result = db.add_unspent_output(uo.clone()).await;
+    let result = db.add_unspent_output(uo.clone());
     assert!(result.is_ok());
-    let result = db
-        .set_received_output_mined_height(uo.hash.clone(), 1, Vec::new(), 1, true)
-        .await;
+    let result = db.set_received_output_mined_height(uo.hash.clone(), 1, Vec::new(), 1, true);
     assert!(result.is_ok());
-    let outputs = db.fetch_mined_unspent_outputs().await.unwrap();
+    let outputs = db.fetch_mined_unspent_outputs().unwrap();
     assert_eq!(outputs.len(), 1);
 
     // adding it again should be an error
-    let err = db.add_unspent_output(uo.clone()).await.unwrap_err();
+    let err = db.add_unspent_output(uo.clone()).unwrap_err();
     assert!(matches!(err, OutputManagerStorageError::DuplicateOutput));
-    let outputs = db.fetch_mined_unspent_outputs().await.unwrap();
+    let outputs = db.fetch_mined_unspent_outputs().unwrap();
     assert_eq!(outputs.len(), 1);
 
     // add a pending transaction with the same duplicate output
 
-    assert!(db.encumber_outputs(2.into(), vec![], vec![uo.clone()]).await.is_err());
+    assert!(db.encumber_outputs(2.into(), vec![], vec![uo]).is_err());
 
     // we should still only have 1 unspent output
-    let outputs = db.fetch_mined_unspent_outputs().await.unwrap();
+    let outputs = db.fetch_mined_unspent_outputs().unwrap();
     assert_eq!(outputs.len(), 1);
 }

--- a/base_layer/wallet/tests/wallet.rs
+++ b/base_layer/wallet/tests/wallet.rs
@@ -799,7 +799,7 @@ async fn test_import_utxo() {
     assert_eq!(completed_tx.amount, 20000 * uT);
     assert_eq!(completed_tx.status, TransactionStatus::Imported);
     let db = OutputManagerDatabase::new(OutputManagerSqliteDatabase::new(connection, None));
-    let outputs = db.fetch_outputs_by_tx_id(tx_id).await.unwrap();
+    let outputs = db.fetch_outputs_by_tx_id(tx_id).unwrap();
     assert!(outputs.iter().any(|o| { o.hash == expected_output_hash }));
 }
 

--- a/comms/dht/Cargo.toml
+++ b/comms/dht/Cargo.toml
@@ -36,8 +36,13 @@ rand = "0.8"
 serde = "1.0.90"
 serde_derive = "1.0.90"
 thiserror = "1.0.26"
-tokio = { version = "1.14", features = ["rt", "macros"] }
 tower = { version = "0.4", features = ["full"] }
+
+# Uncomment for tokio tracing via tokio-console (needs "tracing" features)
+#console-subscriber = "0.1.3"
+#tokio = { version = "1.14", features = ["rt", "macros", "tracing"] }
+# Uncomment for normal use (non tokio-console tracing)
+tokio = { version = "1.14", features = ["rt", "macros"] }
 
 # tower-filter dependencies
 pin-project = "0.4"
@@ -55,10 +60,6 @@ tokio-stream = { version = "0.1.7", features = ["sync"] }
 petgraph = "0.5.1"
 clap = "2.33.0"
 
-# Uncomment for tokio-console tracing
-#
-#console-subscriber = "0.1.3"
-#tokio = { version = "1.14", features = ["rt", "macros", "tracing"] }
 
 [build-dependencies]
 tari_common = { version = "^0.30", path = "../../common" }

--- a/comms/dht/examples/propagation_stress.rs
+++ b/comms/dht/examples/propagation_stress.rs
@@ -46,7 +46,7 @@ use crate::propagation::prompt::{parse_from_short_str, user_prompt, SendMethod};
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     if env::args().any(|a| a == "--enable-tracing") {
-        // Uncomment to endable tokio tracing
+        // Uncomment to enable tokio tracing via tokio-console
         // console_subscriber::init();
     } else {
         // env logger does not work with console subscriber enabled


### PR DESCRIPTION
Description
---
Removed spawn blocking calls for db operations from the wallet in the output manager service. (_This is the first PR in a couple of PRs required to implement this fully throughout the wallet code._)

We are using SQLite in WAL mode, which provides concurrent read access and single thread write access for the number of pooled connections configured. Implementing spawn blocking calls on top of that for every db operation is counter productive and easily results in interlock situations within the wallet code, as is the case currently with sending transactions in batch mode.

Although batch mode transactions still does not work with only this PR, it showed a definite improvement monitoring the action with tokio console; all interlocks are now within the transaction service and not in the output manager service anymore.

Motivation and Context
---
When sending multiple transactions in batch mode (with for example the `make-it-rain` command), the wallet locks up and no transactions are being sent.

How Has This Been Tested?
---
System level tests sending multiple transactions in batch mode to three receiving wallets.
Monitoring with tokio console.

