### PR TITLE
refactor: dry grpc services of the validator node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7015,6 +7015,7 @@ dependencies = [
  "blake2",
  "bytecodec",
  "clap 2.34.0",
+ "derive_more",
  "digest 0.9.0",
  "futures 0.3.21",
  "lmdb-zero",

--- a/applications/tari_validator_node/src/grpc/services/base_node_client.rs
+++ b/applications/tari_validator_node/src/grpc/services/base_node_client.rs
@@ -20,10 +20,7 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{
-    convert::{TryFrom, TryInto},
-    net::SocketAddr,
-};
+use std::{convert::TryFrom, net::SocketAddr};
 
 use async_trait::async_trait;
 use log::*;
@@ -92,11 +89,11 @@ impl BaseNodeClient for GrpcBaseNodeClient {
         }
         let output = outputs
             .first()
-            .map(|o| match o.features.clone().unwrap().try_into() {
-                Ok(f) => Ok(BaseLayerOutput { features: f }),
-                Err(e) => Err(DigitalAssetError::ConversionError(e)),
-            })
-            .transpose()?;
+            .and_then(|o| o.features.clone())
+            .map(OutputFeatures::try_from)
+            .transpose()
+            .map_err(DigitalAssetError::ConversionError)?
+            .map(BaseLayerOutput::from);
         Ok(output)
     }
 

--- a/applications/tari_validator_node/src/grpc/services/base_node_client.rs
+++ b/applications/tari_validator_node/src/grpc/services/base_node_client.rs
@@ -35,10 +35,12 @@ use tari_dan_core::{
 
 const LOG_TARGET: &str = "tari::validator_node::app";
 
+type Inner = grpc::base_node_client::BaseNodeClient<tonic::transport::Channel>;
+
 #[derive(Clone)]
 pub struct GrpcBaseNodeClient {
     endpoint: SocketAddr,
-    inner: Option<grpc::base_node_client::BaseNodeClient<tonic::transport::Channel>>,
+    inner: Option<Inner>,
 }
 
 impl GrpcBaseNodeClient {
@@ -46,21 +48,21 @@ impl GrpcBaseNodeClient {
         Self { endpoint, inner: None }
     }
 
-    pub async fn connect(&mut self) -> Result<(), DigitalAssetError> {
-        self.inner = Some(grpc::base_node_client::BaseNodeClient::connect(format!("http://{}", self.endpoint)).await?);
-        Ok(())
+    pub async fn connection(&mut self) -> Result<&mut Inner, DigitalAssetError> {
+        if self.inner.is_none() {
+            let url = format!("http://{}", self.endpoint);
+            let inner = Inner::connect(url).await?;
+            self.inner = Some(inner);
+        }
+        self.inner
+            .as_mut()
+            .ok_or_else(|| DigitalAssetError::FatalError("no connection".into()))
     }
 }
 #[async_trait]
 impl BaseNodeClient for GrpcBaseNodeClient {
     async fn get_tip_info(&mut self) -> Result<BaseLayerMetadata, DigitalAssetError> {
-        let inner = match self.inner.as_mut() {
-            Some(i) => i,
-            None => {
-                self.connect().await?;
-                self.inner.as_mut().unwrap()
-            },
-        };
+        let inner = self.connection().await?;
         let request = grpc::Empty {};
         let result = inner.get_tip_info(request).await?.into_inner();
         Ok(BaseLayerMetadata {
@@ -74,13 +76,7 @@ impl BaseNodeClient for GrpcBaseNodeClient {
         asset_public_key: PublicKey,
         checkpoint_unique_id: Vec<u8>,
     ) -> Result<Option<BaseLayerOutput>, DigitalAssetError> {
-        let inner = match self.inner.as_mut() {
-            Some(i) => i,
-            None => {
-                self.connect().await?;
-                self.inner.as_mut().unwrap()
-            },
-        };
+        let inner = self.connection().await?;
         let request = grpc::GetTokensRequest {
             asset_public_key: asset_public_key.as_bytes().to_vec(),
             unique_ids: vec![checkpoint_unique_id],
@@ -104,13 +100,7 @@ impl BaseNodeClient for GrpcBaseNodeClient {
         &mut self,
         dan_node_public_key: PublicKey,
     ) -> Result<Vec<AssetDefinition>, DigitalAssetError> {
-        let inner = match self.inner.as_mut() {
-            Some(i) => i,
-            None => {
-                self.connect().await?;
-                self.inner.as_mut().unwrap()
-            },
-        };
+        let inner = self.connection().await?;
         // TODO: probably should use output mmr indexes here
         let request = grpc::ListAssetRegistrationsRequest { offset: 0, count: 100 };
         let mut result = inner.list_asset_registrations(request).await?.into_inner();
@@ -159,18 +149,11 @@ impl BaseNodeClient for GrpcBaseNodeClient {
         &mut self,
         asset_public_key: PublicKey,
     ) -> Result<Option<BaseLayerOutput>, DigitalAssetError> {
-        let conn = match self.inner.as_mut() {
-            Some(i) => i,
-            None => {
-                self.connect().await?;
-                self.inner.as_mut().unwrap()
-            },
-        };
-
+        let inner = self.connection().await?;
         let req = grpc::GetAssetMetadataRequest {
             asset_public_key: asset_public_key.to_vec(),
         };
-        let output = conn.get_asset_metadata(req).await.unwrap().into_inner();
+        let output = inner.get_asset_metadata(req).await.unwrap().into_inner();
 
         let output = output
             .features

--- a/dan_layer/core/Cargo.toml
+++ b/dan_layer/core/Cargo.toml
@@ -26,6 +26,7 @@ anyhow = "1.0.53"
 async-trait = "0.1.50"
 blake2 = "0.9.2"
 clap = "2.33.3"
+derive_more = "0.99.17"
 digest = "0.9.0"
 futures = { version = "^0.3.1" }
 log = { version = "0.4.8", features = ["std"] }

--- a/dan_layer/core/src/models/base_layer_output.rs
+++ b/dan_layer/core/src/models/base_layer_output.rs
@@ -23,12 +23,13 @@
 //! A trait to allow abstraction from a specific base layer output
 use std::convert::TryFrom;
 
+use derive_more::From;
 use tari_common_types::types::PublicKey;
 use tari_core::transactions::transaction_components::{OutputFeatures, OutputFlags};
 
 use crate::{fixed_hash::FixedHash, models::ModelError};
 
-#[derive(Debug)]
+#[derive(Debug, From)]
 pub struct BaseLayerOutput {
     pub features: OutputFeatures,
 }


### PR DESCRIPTION
Description
---
These changes remove unwrapping grpc connections from options in every method.

Motivation and Context
---
Reducing amount of `unwrap` calls, replace with `Result` when possible.

How Has This Been Tested?
---
CI

