### PR TITLE
fix(dht): saf storage uses constructs correct msg hash

### DIFF
--- a/comms/dht/src/actor.rs
+++ b/comms/dht/src/actor.rs
@@ -348,7 +348,7 @@ impl DhtActor {
             } => {
                 let msg_hash_cache = self.msg_hash_dedup_cache.clone();
                 Box::pin(async move {
-                    match msg_hash_cache.add_body_hash(message_hash, &received_from) {
+                    match msg_hash_cache.add_msg_hash(&message_hash, &received_from) {
                         Ok(hit_count) => {
                             let _ = reply_tx.send(hit_count);
                         },
@@ -366,7 +366,7 @@ impl DhtActor {
             GetMsgHashHitCount(hash, reply_tx) => {
                 let msg_hash_cache = self.msg_hash_dedup_cache.clone();
                 Box::pin(async move {
-                    let hit_count = msg_hash_cache.get_hit_count(hash)?;
+                    let hit_count = msg_hash_cache.get_hit_count(&hash)?;
                     let _ = reply_tx.send(hit_count);
                     Ok(())
                 })
@@ -1043,7 +1043,7 @@ mod test {
         for key in &signatures {
             let num_hits = actor
                 .msg_hash_dedup_cache
-                .add_body_hash(key.clone(), &CommsPublicKey::default())
+                .add_msg_hash(key, &CommsPublicKey::default())
                 .unwrap();
             assert_eq!(num_hits, 1);
         }
@@ -1051,7 +1051,7 @@ mod test {
         for key in &signatures {
             let num_hits = actor
                 .msg_hash_dedup_cache
-                .add_body_hash(key.clone(), &CommsPublicKey::default())
+                .add_msg_hash(key, &CommsPublicKey::default())
                 .unwrap();
             assert_eq!(num_hits, 2);
         }

--- a/comms/dht/src/inbound/message.rs
+++ b/comms/dht/src/inbound/message.rs
@@ -26,22 +26,17 @@ use std::{
     sync::Arc,
 };
 
-use digest::Digest;
 use tari_comms::{
     message::{EnvelopeBody, MessageTag},
     peer_manager::Peer,
-    types::{Challenge, CommsPublicKey},
+    types::CommsPublicKey,
 };
+use tari_utilities::ByteArray;
 
-use crate::envelope::{DhtMessageFlags, DhtMessageHeader};
-
-fn hash_inbound_message(message: &DhtInboundMessage) -> Vec<u8> {
-    Challenge::new()
-        .chain(&message.dht_header.origin_mac)
-        .chain(&message.body)
-        .finalize()
-        .to_vec()
-}
+use crate::{
+    dedup,
+    envelope::{DhtMessageFlags, DhtMessageHeader},
+};
 
 #[derive(Debug, Clone)]
 pub struct DhtInboundMessage {
@@ -116,7 +111,7 @@ impl DecryptedDhtMessage {
         message: DhtInboundMessage,
     ) -> Self {
         Self {
-            dedup_hash: hash_inbound_message(&message),
+            dedup_hash: dedup::hash_inbound_message(&message).to_vec(),
             tag: message.tag,
             source_peer: message.source_peer,
             authenticated_origin,
@@ -131,7 +126,7 @@ impl DecryptedDhtMessage {
 
     pub fn failed(message: DhtInboundMessage) -> Self {
         Self {
-            dedup_hash: hash_inbound_message(&message),
+            dedup_hash: dedup::hash_inbound_message(&message).to_vec(),
             tag: message.tag,
             source_peer: message.source_peer,
             authenticated_origin: None,

--- a/comms/dht/src/test_utils/store_and_forward_mock.rs
+++ b/comms/dht/src/test_utils/store_and_forward_mock.rs
@@ -29,11 +29,8 @@ use std::{
 };
 
 use chrono::Utc;
-use digest::Digest;
 use log::*;
 use rand::{rngs::OsRng, RngCore};
-use tari_comms::types::Challenge;
-use tari_utilities::hex;
 use tokio::{
     runtime,
     sync::{mpsc, RwLock},
@@ -150,7 +147,7 @@ impl StoreAndForwardMock {
                     is_encrypted: msg.is_encrypted,
                     priority: msg.priority,
                     stored_at: Utc::now().naive_utc(),
-                    body_hash: hex::to_hex(&Challenge::new().chain(msg.body).finalize()),
+                    body_hash: msg.body_hash,
                 });
                 reply_tx.send(Ok(false)).unwrap();
             },


### PR DESCRIPTION
Description
---
- construct the dedup hash correctly in SAF messages
- consolidate dedup hashing
- move dedup to after decryption/validation step in saf processor

Motivation and Context
---
SAF db is also used for dedup, so the hash must match. 
Closes #3419

How Has This Been Tested?
---
Existing unit tests, memorynet and manually
