### PR TITLE
chore: add test coverage to coveralls

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,60 @@
+name: Source Coverage
+on:
+  push:
+    branches:
+      - development
+jobs:
+  coverage:
+    name: test
+    runs-on: ubuntu-18.04
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env.toolchain }}
+      - uses: Swatinem/rust-cache@v1
+      - name: ubuntu dependencies
+        run: |
+          sudo apt-get update && \
+          sudo apt-get -y install \
+          build-essential \
+          libgtk-3-dev \
+          libwebkit2gtk-4.0-dev \
+          libsoup2.4-dev \
+          curl \
+          wget \
+          libappindicator3-dev \
+          patchelf \
+          librsvg2-dev \
+          libprotobuf-dev \
+          protobuf-compiler
+      - name: test key manager wasm
+        run: |
+          npm install -g wasm-pack
+          cd base_layer/key_manager
+          rustup target add wasm32-unknown-unknown
+          make test
+      - name: cargo test compile
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-run --locked --all-features
+      - name: cargo test
+        uses: actions-rs/cargo@v1
+        env:
+          LLVM_PROFILE_FILE: "coverage_data-%p-%m.profraw"
+          RUSTFLAGS: "-Zinstrument-coverage"
+        with:
+          command: test
+          args: --all-features
+      - name: generate coverage report
+        usesid: coverage
+        run: |
+          grcov . -s . --binary-path ./target/debug -t lcov --branch --ignore-not-existing -o ./target/report.lcov
+      - name: Coveralls upload
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: ./target/report.lcov


### PR DESCRIPTION
Description
---
Add test coverage to coveralls.
I'm not sure if `grcov` has the same output as the `cov` (this one we use elsewhere). Both should be in `lcov` format. I hope that's a standard.