### PR TITLE
test(block-validators): add 0-conf double spend tests

### DIFF
--- a/base_layer/core/src/test_helpers/block_spec.rs
+++ b/base_layer/core/src/test_helpers/block_spec.rs
@@ -97,8 +97,12 @@ macro_rules! block_spec {
         $spec = $spec.with_reward($reward.into());
         $crate::block_spec!(@ { spec } $($tail)*)
     };
+    (@ { $spec: ident } parent: $parent:expr, $($tail:tt)*) => {
+        $spec = $spec.with_prev_block($parent);
+        $crate::block_spec!(@ { spec } $($tail)*)
+    };
     (@ { $spec: ident } transactions: $transactions:expr, $($tail:tt)*) => {
-        $spec = $spec.with_transactions($transactions.into());
+        $spec = $spec.with_transactions($transactions);
         $crate::block_spec!(@ { spec } $($tail)*)
     };
 

--- a/base_layer/core/src/test_helpers/blockchain.rs
+++ b/base_layer/core/src/test_helpers/blockchain.rs
@@ -569,7 +569,10 @@ impl TestBlockchain {
         parent_name: &'static str,
         block_spec: BlockSpec,
     ) -> (Arc<ChainBlock>, UnblindedOutput) {
-        let parent = self.get_block_by_name(parent_name).unwrap();
+        let parent = self
+            .get_block_by_name(parent_name)
+            .ok_or_else(|| format!("Parent block not found with name '{}'", parent_name))
+            .unwrap();
         let difficulty = block_spec.difficulty;
         let (block, coinbase) = create_block(&self.rules, parent.block(), block_spec);
         let block = mine_block(block, parent.accumulated_data(), difficulty);
@@ -577,8 +580,13 @@ impl TestBlockchain {
     }
 
     pub fn create_unmined_block(&self, parent_name: &'static str, block_spec: BlockSpec) -> (Block, UnblindedOutput) {
-        let parent = self.get_block_by_name(parent_name).unwrap();
-        create_block(&self.rules, parent.block(), block_spec)
+        let parent = self
+            .get_block_by_name(parent_name)
+            .ok_or_else(|| format!("Parent block not found with name '{}'", parent_name))
+            .unwrap();
+        let (mut block, outputs) = create_block(&self.rules, parent.block(), block_spec);
+        block.body.sort();
+        (block, outputs)
     }
 
     pub fn mine_block(&self, parent_name: &'static str, block: Block, difficulty: Difficulty) -> Arc<ChainBlock> {
@@ -589,6 +597,13 @@ impl TestBlockchain {
     pub fn create_next_tip(&self, spec: BlockSpec) -> (Arc<ChainBlock>, UnblindedOutput) {
         let (name, _) = self.get_tip_block();
         self.create_chained_block(name, spec)
+    }
+
+    pub fn append(&mut self, spec: BlockSpec) -> (Arc<ChainBlock>, UnblindedOutput) {
+        let name = spec.name;
+        let (block, outputs) = self.create_chained_block(spec.prev_block, spec);
+        self.append_block(name, block.clone());
+        (block, outputs)
     }
 
     pub fn get_genesis_block(&self) -> Arc<ChainBlock> {

--- a/base_layer/core/src/validation/block_validators/async_validator.rs
+++ b/base_layer/core/src/validation/block_validators/async_validator.rs
@@ -91,7 +91,7 @@ impl<B: BlockchainBackend + 'static> BlockValidator<B> {
         Ok(block)
     }
 
-    pub async fn validate_block_body(&self, block: Block) -> Result<Block, ValidationError> {
+    pub(super) async fn validate_block_body(&self, block: Block) -> Result<Block, ValidationError> {
         let (valid_header, inputs, outputs, kernels) = block.dissolve();
 
         // Start all validation tasks concurrently


### PR DESCRIPTION
Description
---
- adds ` it_rejects_zero_conf_double_spends` unit test for block validators

Motivation and Context
---
Test 0-conf double spend case

How Has This Been Tested?
---
New tests pass

