### PR TITLE
fix(wallet): do not prompt for password if given in config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7141,22 +7141,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tari_mining_helper_ffi"
-version = "0.30.2"
-dependencies = [
- "hex",
- "libc",
- "serde",
- "serde_json",
- "tari_common",
- "tari_comms",
- "tari_core",
- "tari_crypto",
- "tari_utilities",
- "thiserror",
-]
-
-[[package]]
 name = "tari_miner"
 version = "0.31.1"
 dependencies = [
@@ -7189,6 +7173,22 @@ dependencies = [
  "thiserror",
  "tokio 1.17.0",
  "tonic",
+]
+
+[[package]]
+name = "tari_mining_helper_ffi"
+version = "0.30.2"
+dependencies = [
+ "hex",
+ "libc",
+ "serde",
+ "serde_json",
+ "tari_common",
+ "tari_comms",
+ "tari_core",
+ "tari_crypto",
+ "tari_utilities",
+ "thiserror",
 ]
 
 [[package]]


### PR DESCRIPTION
Description
---
- uses cli password followed by configured password if specified

Motivation and Context
---
Should not prompt for password if given in config

How Has This Been Tested?
---
Manually

