### PR TITLE
fix: launchpad build docker images

### DIFF
--- a/applications/launchpad/docker_rig/base_node.Dockerfile
+++ b/applications/launchpad/docker_rig/base_node.Dockerfile
@@ -1,4 +1,25 @@
-FROM quay.io/tarilabs/rust_tari-build-with-deps:nightly-2021-11-01 as builder
+FROM rust:1.60-buster as builder
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt update && apt -y install \
+  apt-transport-https \
+  bash \
+  ca-certificates \
+  curl \
+  gpg \
+  iputils-ping \
+  less \
+  libreadline-dev \
+  libsqlite3-0 \
+  openssl \
+  telnet \
+  cargo \
+  clang \
+  cmake
+
+RUN apt update && apt upgrade -y  && apt clean 
+
+
 WORKDIR /tari
 
 # Adding only necessary things up front and copying the entrypoint script last
@@ -65,7 +86,7 @@ ENV dockerfile_version=$VERSION
 ENV APP_NAME=base_node APP_EXEC=tari_base_node
 
 COPY --from=builder /tari/target/release/$APP_EXEC /usr/bin/
-COPY applications/launchpad/docker_rig/start_tari_app.sh /usr/bin/start_tari_app.sh
+COPY /applications/launchpad/docker_rig/start_tari_app.sh /usr/bin/start_tari_app.sh
+
 
 ENTRYPOINT [ "start_tari_app.sh", "-c", "/var/tari/config/config.toml", "-b", "/var/tari/base_node" ]
-# CMD [ "--non-interactive-mode" ]

--- a/applications/launchpad/docker_rig/console_wallet.Dockerfile
+++ b/applications/launchpad/docker_rig/console_wallet.Dockerfile
@@ -1,4 +1,25 @@
-FROM quay.io/tarilabs/rust_tari-build-with-deps:nightly-2021-11-01 as builder
+FROM rust:1.60-buster as builder
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt update && apt -y install \
+  apt-transport-https \
+  bash \
+  ca-certificates \
+  curl \
+  gpg \
+  iputils-ping \
+  less \
+  libreadline-dev \
+  libsqlite3-0 \
+  openssl \
+  telnet \
+  cargo \
+  clang \
+  cmake
+
+RUN apt update && apt upgrade -y  && apt clean 
+
+
 WORKDIR /tari
 
 # Adding only necessary things up front and copying the entrypoint script last
@@ -61,4 +82,3 @@ COPY --from=builder /tari/target/release/$APP_EXEC /usr/bin/
 COPY applications/launchpad/docker_rig/start_tari_app.sh /usr/bin/start_tari_app.sh
 
 ENTRYPOINT [ "start_tari_app.sh", "-c", "/var/tari/config/config.toml", "-b", "/var/tari/wallet" ]
-# CMD [ "--non-interactive-mode" ]

--- a/applications/launchpad/docker_rig/docker-compose.yml
+++ b/applications/launchpad/docker_rig/docker-compose.yml
@@ -5,11 +5,8 @@ services:
     build:
       context: .
       dockerfile: tor.Dockerfile
-  #    volumes:
-  #      - ${DATA_FOLDER}/tor:/etc/tor/
-  #    ports:
-  #      - 9050:9050
-  #      - 9051:9051
+    volumes:
+      - ${DATA_FOLDER}/tor:/etc/tor/
 
   base_node:
     image: quay.io/tarilabs/tari_base_node:latest
@@ -25,16 +22,7 @@ services:
       APP_EXEC: tari_base_node
       WAIT_FOR_TOR: ${WAIT_FOR_TOR:-0}
       TARI_NETWORK: ${TARI_NETWORK}
-      TARI_BASE_NODE__DIBBLER__TOR_CONTROL_AUTH: "password=${TOR_CONTROL_AUTH:-tari}"
-      TARI_BASE_NODE__DIBBLER__DATA_DIR: "/blockchain/dibbler"
-      TARI_BASE_NODE__IGOR__DATA_DIR: "/blockchain/igor"
-      TARI_BASE_NODE__MAINNET__DATA_DIR: "/blockchain/mainnet"
-      TARI_BASE_NODE__DIBBLER__TOR_CONTROL_ADDRESS: "/dns4/tor/tcp/9051"
-      TARI_BASE_NODE__DIBBLER__TOR_SOCKS_ADDRESS_OVERRIDE: "/dns4/tor/tcp/9050"
-      TARI_BASE_NODE__DIBBLER__TOR_FORWARD_ADDRESS: "/dns4/base_node/tcp/18189"
-      TARI_BASE_NODE__DIBBLER__TCP_LISTENER_ADDRESS: "/dns4/base_node/tcp/18189"
-      TARI_BASE_NODE__DIBBLER__GRPC_BASE_NODE_ADDRESS: "0.0.0.0:18142"
-      TARI_BASE_NODE__DIBBLER__GRPC_ENABLED: "1"
+      TARI_DIBBLER__BASE_NODE__DATA_DIR: "/blockchain/dibbler"
     ports:
       - 18189:18189
       - 18142:18142
@@ -64,12 +52,6 @@ services:
       TERM: "linux"
       TARI_WALLET_PASSWORD: ${TARI_WALLET_PASSWORD:-tari}
       TARI_NETWORK: ${TARI_NETWORK:-dibbler}
-      TARI_WALLET__DIBBLER__TOR_CONTROL_AUTH: "password=${TOR_CONTROL_AUTH:-tari}"
-      TARI_WALLET__DIBBLER__TOR_CONTROL_ADDRESS: "/dns4/tor/tcp/9051"
-      TARI_WALLET__DIBBLER__TOR_SOCKS_ADDRESS_OVERRIDE: "/dns4/tor/tcp/9050"
-      TARI_WALLET__DIBBLER__TOR_FORWARD_ADDRESS: "/dns4/wallet/tcp/18188"
-      TARI_WALLET__DIBBLER__TCP_LISTENER_ADDRESS: "/dns4/wallet/tcp/18188"
-      TARI_BASE_NODE__DIBBLER__GRPC_CONSOLE_WALLET_ADDRESS: "0.0.0.0:18143"
     command: ["--non-interactive"]
     ports:
       - 18188:18188
@@ -97,9 +79,8 @@ services:
       TARI_NETWORK: ${TARI_NETWORK}
       TARI_MINER__NUM_MINING_THREADS: 2
       TARI_MINER__MINE_ON_TIP_ONLY: 1
-      TARI_BASE_NODE__DIBBLER__GRPC_BASE_NODE_ADDRESS: "/dns4/base_node/tcp/18142"
-      TARI_BASE_NODE__DIBBLER__GRPC_CONSOLE_WALLET_ADDRESS: "/dns4/wallet/tcp/18143"
-      TARI_WALLET__GRPC_ADDRESS: "/dns4/wallet/tcp/18143"
+      TARI_MINER__BASE_NODE_ADDR: "/dns4/base_node/tcp/18142"
+      TARI_MINER__WALLET_ADDR: "/dns4/wallet/tcp/18143"
     command: []
     depends_on:
       - base_node
@@ -164,14 +145,12 @@ services:
       APP_EXEC: tari_merge_mining_proxy
       WAIT_FOR_TOR: 0
       TARI_NETWORK: ${TARI_NETWORK}
-      TARI_BASE_NODE__DIBBLER__GRPC_BASE_NODE_ADDRESS: "/dns4/base_node/tcp/18142"
-      TARI_BASE_NODE__DIBBLER__GRPC_CONSOLE_WALLET_ADDRESS: "/dns4/wallet/tcp/18143"
-      TARI_WALLET__GRPC_ADDRESS: "/dns4/wallet/tcp/18143"
-      TARI_MERGE_MINING_PROXY__DIBBLER__MONEROD_URL: ${TARI_MONEROD_URL:-["http://stagenet.community.xmr.to:38081","http://monero-stagenet.exan.tech:38081","http://stagenet.xmr-tw.org:38081","http://xmr-lux.boldsuck.org:38081","http://singapore.node.xmr.pm:38081"]}
-      TARI_MERGE_MINING_PROXY__DIBBLER__MONEROD_USERNAME: ${TARI_MONEROD_USERNAME}
-      TARI_MERGE_MINING_PROXY__DIBBLER__MONEROD_PASSWORD: ${TARI_MONEROD_PASSWORD}
-      TARI_MERGE_MINING_PROXY__DIBBLER__MONEROD_USE_AUTH: ${TARI_MONEROD_USE_AUTH:-0}
-      TARI_MERGE_MINING_PROXY__DIBBLER__PROXY_HOST_ADDRESS: "0.0.0.0:18081"
+      TARI_MERGE_MINING_PROXY__BASE_NODE_GRPC_ADDRESS: "/dns4/base_node/tcp/18142"
+      TARI_MERGE_MINING_PROXY__CONSOLE_WALLET_GRPC_ADDRESS: "/dns4/wallet/tcp/18143"
+      TARI_MERGE_MINING_PROXY__MONEROD_USERNAME: ${TARI_MONEROD_USERNAME}
+      TARI_MERGE_MINING_PROXY__MONEROD_PASSWORD: ${TARI_MONEROD_PASSWORD}
+      TARI_MERGE_MINING_PROXY__MONEROD_USE_AUTH: ${TARI_MONEROD_USE_AUTH:-0}
+      TARI_MERGE_MINING_PROXY__LISTENER_ADDRESS: "/ip4/0.0.0.0/tcp/18081"
     depends_on:
       - base_node
       - wallet

--- a/applications/launchpad/docker_rig/sha3_miner.Dockerfile
+++ b/applications/launchpad/docker_rig/sha3_miner.Dockerfile
@@ -1,4 +1,25 @@
-FROM quay.io/tarilabs/rust_tari-build-with-deps:nightly-2021-11-01 as builder
+FROM rust:1.60-buster as builder
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt update && apt -y install \
+  apt-transport-https \
+  bash \
+  ca-certificates \
+  curl \
+  gpg \
+  iputils-ping \
+  less \
+  libreadline-dev \
+  libsqlite3-0 \
+  openssl \
+  telnet \
+  cargo \
+  clang \
+  cmake
+
+RUN apt update && apt upgrade -y  && apt clean 
+
+
 WORKDIR /tari
 
 # Adding only necessary things up front and copying the entrypoint script last
@@ -39,15 +60,19 @@ ARG VERSION=1.0.1
 # Disable Prompt During Packages Installation
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt update && apt -y install \
-    apt-transport-https \
-    bash \
-    ca-certificates \
-    curl \
-    gpg \
-    iputils-ping \
-    less \
-    openssl
-# Now create a new image with only the essentials and throw everything else away
+  apt-transport-https \
+  bash \
+  ca-certificates \
+  curl \
+  gpg \
+  iputils-ping \
+  less \
+  libreadline8 \
+  libreadline-dev \
+  libsqlite3-0 \
+  openssl \
+  telnet
+
 FROM base
 RUN groupadd -g 1000 tari && useradd -s /bin/bash -u 1000 -g 1000 tari
 USER tari
@@ -59,3 +84,4 @@ COPY --from=builder /tari/target/release/$APP_EXEC /usr/bin/
 COPY applications/launchpad/docker_rig/start_tari_app.sh /usr/bin/start_tari_app.sh
 
 ENTRYPOINT [ "start_tari_app.sh", "-c", "/var/tari/config/config.toml", "-b", "/var/tari/sha3_miner" ]
+


### PR DESCRIPTION
Description
---
Building docker images fail on Mac M1 Pro with error 137.

Motivation and Context
---
Make launchpad docker images buildable and running.
Replaced the original `Tari` image with `rust:1.60-buster` and configured properly the build env.
The docker-compose file is updated to reflect the latest configuration changes.

How Has This Been Tested?
---
Build and test locally on Mac M1 Pro and Ubuntu 20.04 (LTS)x64