### PR TITLE
fix: makes header consensus encoding infallible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7141,22 +7141,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tari_mining_helper_ffi"
-version = "0.30.2"
-dependencies = [
- "hex",
- "libc",
- "serde",
- "serde_json",
- "tari_common",
- "tari_comms",
- "tari_core",
- "tari_crypto",
- "tari_utilities",
- "thiserror",
-]
-
-[[package]]
 name = "tari_miner"
 version = "0.31.1"
 dependencies = [
@@ -7189,6 +7173,22 @@ dependencies = [
  "thiserror",
  "tokio 1.17.0",
  "tonic",
+]
+
+[[package]]
+name = "tari_mining_helper_ffi"
+version = "0.30.2"
+dependencies = [
+ "hex",
+ "libc",
+ "serde",
+ "serde_json",
+ "tari_common",
+ "tari_comms",
+ "tari_core",
+ "tari_crypto",
+ "tari_utilities",
+ "thiserror",
 ]
 
 [[package]]

--- a/base_layer/common_types/src/array.rs
+++ b/base_layer/common_types/src/array.rs
@@ -20,6 +20,8 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use std::cmp;
+
 use tari_utilities::ByteArrayError;
 
 pub fn copy_into_fixed_array<T: Default + Copy, const SZ: usize>(elems: &[T]) -> Result<[T; SZ], ByteArrayError> {
@@ -29,4 +31,13 @@ pub fn copy_into_fixed_array<T: Default + Copy, const SZ: usize>(elems: &[T]) ->
     let mut buf = [T::default(); SZ];
     buf.copy_from_slice(&elems[0..SZ]);
     Ok(buf)
+}
+
+/// Copies `SZ` elements from a slice into a fixed array of size `SZ`. If the length of the slice is less than `SZ` the
+/// default value is used  for the  remaining elements.
+pub fn copy_into_fixed_array_lossy<T: Default + Copy, const SZ: usize>(elems: &[T]) -> [T; SZ] {
+    let len = cmp::min(elems.len(), SZ);
+    let mut buf = [T::default(); SZ];
+    buf[..len].copy_from_slice(&elems[..len]);
+    buf
 }


### PR DESCRIPTION
Description
---

- removes `BlockHeader::consensus_encode` impl  errors

Motivation and Context
---
The ConnsensusEncode contract states that the implementation should never be the source of errors, only the writer may return errors.

How Has This Been Tested?
---
Existing tests
manually, basenode sync
