### PR TITLE
refactor(base-node): use existing peer feature methods to check if is a base or client node

### DIFF
--- a/applications/tari_base_node/src/commands/command/list_connections.rs
+++ b/applications/tari_base_node/src/commands/command/list_connections.rs
@@ -23,7 +23,6 @@
 use anyhow::Error;
 use async_trait::async_trait;
 use clap::Parser;
-use tari_comms::peer_manager::PeerFeatures;
 use tari_core::base_node::state_machine_service::states::PeerMetadata;
 
 use super::{CommandContext, HandleCommand};

--- a/applications/tari_base_node/src/commands/command/list_connections.rs
+++ b/applications/tari_base_node/src/commands/command/list_connections.rs
@@ -81,7 +81,7 @@ impl CommandContext {
                     conn.direction(),
                     format_duration_basic(conn.age()),
                     {
-                        if peer.features == PeerFeatures::COMMUNICATION_CLIENT {
+                        if peer.features.is_client() {
                             "Wallet"
                         } else {
                             "Base node"

--- a/applications/tari_base_node/src/commands/command/list_peers.rs
+++ b/applications/tari_base_node/src/commands/command/list_peers.rs
@@ -24,7 +24,7 @@ use anyhow::Error;
 use async_trait::async_trait;
 use chrono::Utc;
 use clap::Parser;
-use tari_comms::peer_manager::{PeerFeatures, PeerQuery};
+use tari_comms::peer_manager::PeerQuery;
 use tari_core::base_node::state_machine_service::states::PeerMetadata;
 
 use super::{CommandContext, HandleCommand};
@@ -49,10 +49,8 @@ impl CommandContext {
         if let Some(f) = filter {
             let filter = f.to_lowercase();
             query = query.select_where(move |p| match filter.as_str() {
-                "basenode" | "basenodes" | "base_node" | "base-node" | "bn" => {
-                    p.features == PeerFeatures::COMMUNICATION_NODE
-                },
-                "wallet" | "wallets" | "w" => p.features == PeerFeatures::COMMUNICATION_CLIENT,
+                "basenode" | "basenodes" | "base_node" | "base-node" | "bn" => p.features.is_node(),
+                "wallet" | "wallets" | "w" => p.features.is_client(),
                 _ => false,
             })
         }
@@ -116,7 +114,7 @@ impl CommandContext {
                 peer.node_id,
                 peer.public_key,
                 {
-                    if peer.features == PeerFeatures::COMMUNICATION_CLIENT {
+                    if peer.features.is_client() {
                         "Wallet"
                     } else {
                         "Base node"


### PR DESCRIPTION
Description
---
Refactored the `list-peers` and `list-connections` base node console commands to reuse the existing peer feature methods to check if is a base or client node.

Motivation and Context
---
Up until now,  the `list-peers` and `list-connections` base node console commands check if a node is a client/node by comparing values against enums, but there are already some convenient methods to check that.

How Has This Been Tested?
---
We don't have unit or integrations tests on console commands, so I tested by manually running the `list-peers` and `list-connections` to check if the results are correct.
