### PR TITLE
feat(tari_explorer): add total hashrate chart

### DIFF
--- a/applications/tari_explorer/routes/index.js
+++ b/applications/tari_explorer/routes/index.js
@@ -116,6 +116,7 @@ router.get("/", async function (req, res) {
       moneroTimes: getBlockTimes(last100Headers, "0"),
       shaTimes: getBlockTimes(last100Headers, "1"),
       currentHashRate: totalHashRates[totalHashRates.length - 1],
+      totalHashRates,
       currentShaHashRate: shaHashRates[shaHashRates.length - 1],
       shaHashRates,
       currentMoneroHashRate: moneroHashRates[moneroHashRates.length - 1],

--- a/applications/tari_explorer/views/index.hbs
+++ b/applications/tari_explorer/views/index.hbs
@@ -97,6 +97,8 @@
       Current total estimated Hash Rate:
       {{this.currentHashRate}}
       H/s
+      <pre>{{chart this.totalHashRates 15}}
+      </pre>
     </td>
     <td>
     </td>


### PR DESCRIPTION
Description
---
Reused the already provided hashrate data by the gRPC client to plot the total in the Tari text explorer.

Motivation and Context
---
Recently we fixed the total estimated hashrate calculation, and included it in the Tari text explorer. We added charts for both Monero and SHA3 hashrates, but we didn't include a chart for the total hashrate.

The motivation of this PR is to add the total hashrate chart to the explorer:
![Screenshot 2022-04-26 at 17 19 13](https://user-images.githubusercontent.com/47919901/165349284-95ec2b18-5aa8-405a-b48b-46657446f89c.png)


How Has This Been Tested?
---
Manually running the text explorer
