### PR TITLE
ci: move npm audit to development only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,35 +19,6 @@ env:
   PROTOC: protoc
 
 jobs:
-  checks:
-    name: npm checks
-    runs-on: ubuntu-latest
-    steps:
-      - name: checkout
-        uses: actions/checkout@v2
-      - name: npm audit launchpad gui
-        run: |
-          cd applications/launchpad/gui-vue
-          npm audit
-      - name: npm audit collectibles
-        run: |
-          cd applications/tari_collectibles/web-app
-          # We have to ignore this for now because audit error is in react-scripts
-          npm audit || true
-      - name: npm audit explorer
-        run: |
-          cd applications/tari_explorer
-          npm audit
-      - name: npm audit web extensions
-        run: |
-          cd applications/tari_web_extension
-          # We have to ignore this for now because audit error is in react-scripts
-          npm audit || true
-      - name: npm audit web extensions example
-        run: |
-          cd applications/tari_web_extension_example
-          npm audit
-
   clippy:
     name: clippy
     runs-on: ubuntu-18.04

--- a/.github/workflows/development-ci.yml
+++ b/.github/workflows/development-ci.yml
@@ -1,0 +1,44 @@
+on:
+  push:
+    branches:
+      - development
+      - main
+
+name: Development CI
+
+env:
+  toolchain: nightly-2021-11-20
+  CARGO_HTTP_MULTIPLEXING: false
+  CARGO_TERM_COLOR: always
+  PROTOC: protoc
+
+jobs:
+  checks:
+    name: npm checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: npm audit launchpad gui
+        run: |
+          cd applications/launchpad/gui-vue
+          npm audit
+      - name: npm audit collectibles
+        run: |
+          cd applications/tari_collectibles/web-app
+          # We have to ignore this for now because audit error is in react-scripts
+          npm audit || true
+      - name: npm audit explorer
+        run: |
+          cd applications/tari_explorer
+          npm audit
+      - name: npm audit web extensions
+        run: |
+          cd applications/tari_web_extension
+          # We have to ignore this for now because audit error is in react-scripts
+          npm audit || true
+      - name: npm audit web extensions example
+        run: |
+          cd applications/tari_web_extension_example
+          npm audit
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7141,22 +7141,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tari_mining_helper_ffi"
-version = "0.30.2"
-dependencies = [
- "hex",
- "libc",
- "serde",
- "serde_json",
- "tari_common",
- "tari_comms",
- "tari_core",
- "tari_crypto",
- "tari_utilities",
- "thiserror",
-]
-
-[[package]]
 name = "tari_miner"
 version = "0.31.1"
 dependencies = [
@@ -7189,6 +7173,22 @@ dependencies = [
  "thiserror",
  "tokio 1.17.0",
  "tonic",
+]
+
+[[package]]
+name = "tari_mining_helper_ffi"
+version = "0.30.2"
+dependencies = [
+ "hex",
+ "libc",
+ "serde",
+ "serde_json",
+ "tari_common",
+ "tari_comms",
+ "tari_core",
+ "tari_crypto",
+ "tari_utilities",
+ "thiserror",
 ]
 
 [[package]]


### PR DESCRIPTION
Description
---
Separate `npm audit` into it's own CI file and run it only on `development` branch merges

