### PR TITLE
test(cucumber): use separate FFI target dir

### DIFF
--- a/integration_tests/helpers/ffi/ffiInterface.js
+++ b/integration_tests/helpers/ffi/ffiInterface.js
@@ -51,7 +51,7 @@ class InterfaceFFI {
       }
       const ps = spawn(cmd, args, {
         cwd: baseDir,
-        env: { ...process.env },
+        env: { ...process.env, CARGO_TARGET_DIR: process.cwd() +"/temp/ffi-target" },
       });
       ps.on("close", (_code) => {
         resolve(ps);

--- a/integration_tests/helpers/ffi/ffiInterface.js
+++ b/integration_tests/helpers/ffi/ffiInterface.js
@@ -51,7 +51,10 @@ class InterfaceFFI {
       }
       const ps = spawn(cmd, args, {
         cwd: baseDir,
-        env: { ...process.env, CARGO_TARGET_DIR: process.cwd() +"/temp/ffi-target" },
+        env: {
+          ...process.env,
+          CARGO_TARGET_DIR: process.cwd() + "/temp/ffi-target",
+        },
       });
       ps.on("close", (_code) => {
         resolve(ps);


### PR DESCRIPTION
Description
---
Uses `./temp/ffi-target` as the cargo target dir for FFI compilation.

Motivation and Context
---
The wallet and wallet FFI need to be recompiled for each run of the integration tests. This is because the compilation target differs between native and ffi, so previous compilations are overwritten. This PR sets a separate the target dir for FFI so that subsequent runs do not need to recompile the wallet and wallet FFI on each run.

How Has This Been Tested?
---
Locally, the wallet and FFI do not need to be recompiled after the initial run.