### PR TITLE
feat(p2p): adds tor.forward_address setting

### DIFF
--- a/common/config/presets/base_node.toml
+++ b/common/config/presets/base_node.toml
@@ -64,6 +64,8 @@ tor.proxy_bypass_addresses = []
 #tor.proxy_bypass_addresses = ["/dns4/my-foo-base-node/tcp/9998"]
 # When using the tor transport and set to true, outbound TCP connections bypass the tor proxy. Defaults to false for better privacy
 tor.proxy_bypass_for_outbound_tcp = false
+# Custom address to forward tor traffic.
+#tor.forward_address = "/ip4/127.0.0.1/tcp/0"
 
 # Use a SOCKS5 proxy transport. This transport recognises any addresses supported by the proxy.
 #type = "socks5"


### PR DESCRIPTION
Description
---
Adds `tor.forward_address` to instruct tor to forward traffic to a custom address 

Motivation and Context
---
This setting is useful for docker setups where tor and the base node listener are accessible through DNS addresses.

How Has This Been Tested?
---
Manually: setting `tor.forward_address` and checking that traffic is forwarded through that port.
