### PR TITLE
fix: support safe non-interactive mode

### DIFF
--- a/applications/tari_console_wallet/src/init/mod.rs
+++ b/applications/tari_console_wallet/src/init/mod.rs
@@ -555,8 +555,16 @@ pub(crate) fn boot(cli: &Cli, wallet_config: &WalletConfig) -> Result<WalletBoot
         Ok(WalletBoot::Existing)
     } else {
         // automation/wallet created with --password
-        if cli.password.is_some() {
+        if cli.password.is_some() || wallet_config.password.is_some() {
             return Ok(WalletBoot::New);
+        }
+
+        // In non-interactive mode, we never prompt. Otherwise, it's not very non-interactive, now is it?
+        if cli.non_interactive_mode {
+            let msg = "Wallet does not exist and no password was given to create one. Since we're in non-interactive \
+                       mode, we need to quit here. Try setting the TARI_WALLET__PASSWORD envar, or setting --password \
+                       on the command line";
+            return Err(ExitError::new(ExitCode::WalletError, &msg));
         }
 
         // prompt for new or recovery


### PR DESCRIPTION
Non-interactive mode should NEVER prompt the user. This PR clears one
path where this happens: If a wallet does not exist and a password has
not been provided so that we can auto-create one. In this case, the
application should just exit.

Providing passwords on the command line is VERY bad practice, since
anyone with access to the machine can see the password in plaintext by
inspecting the running jobs.

The ability to read the password from the commaond-line, OR config file OR envar was
removed in a previous PR, and this is rectified here.

How Has This Been Tested?
---
Manually, with various CLI and envar combinations
