### PR TITLE
feat: allow network to be set by TARI_NETWORK env var

### DIFF
--- a/applications/tari_app_utilities/Cargo.toml
+++ b/applications/tari_app_utilities/Cargo.toml
@@ -13,7 +13,7 @@ tari_common_types = { path = "../../base_layer/common_types" }
 tari_p2p = { path = "../../base_layer/p2p", features = ["auto-update"] }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.3" }
 
-clap = { version = "3.1.1", features = ["derive"] }
+clap = { version = "3.1.1", features = ["derive", "env"] }
 config = { version = "0.13.0" }
 futures = { version = "^0.3.16", default-features = false, features = ["alloc"] }
 dirs-next = "1.0.2"

--- a/applications/tari_app_utilities/src/common_cli_args.rs
+++ b/applications/tari_app_utilities/src/common_cli_args.rs
@@ -31,7 +31,8 @@ pub struct CommonCliArgs {
         short,
         long,
         aliases = &["base_path", "base_dir", "base-dir"],
-        default_value_t= defaults::base_path()
+        default_value_t= defaults::base_path(),
+        env = "TARI_BASE_DIR"
     )]
     base_path: String,
     /// A path to the configuration file to use (config.toml)

--- a/applications/tari_base_node/Cargo.toml
+++ b/applications/tari_base_node/Cargo.toml
@@ -28,7 +28,7 @@ anyhow = "1.0.53"
 async-trait = "0.1.52"
 bincode = "1.3.1"
 chrono = { version = "0.4.19", default-features = false }
-clap = { version = "3.1.1", features = ["derive"] }
+clap = { version = "3.1.1", features = ["derive", "env"] }
 config = { version = "0.13.0" }
 crossterm = { version = "0.23.1", features = ["event-stream"] }
 derive_more = "0.99.17"

--- a/applications/tari_base_node/src/cli.rs
+++ b/applications/tari_base_node/src/cli.rs
@@ -42,13 +42,13 @@ pub(crate) struct Cli {
     #[clap(long, alias = "rebuild_db")]
     pub rebuild_db: bool,
     /// Run in non-interactive mode, with no UI.
-    #[clap(short, long, alias = "non-interactive")]
+    #[clap(short, long, alias = "non-interactive", env = "TARI_NON_INTERACTIVE")]
     pub non_interactive_mode: bool,
     /// Watch a command in the non-interactive mode.
     #[clap(long)]
     pub watch: Option<String>,
     /// Supply a network (overrides existing configuration)
-    #[clap(long, alias = "network", default_value = DEFAULT_NETWORK)]
+    #[clap(long, default_value = DEFAULT_NETWORK, env = "TARI_NETWORK")]
     pub network: String,
 }
 

--- a/applications/tari_collectibles/src-tauri/Cargo.toml
+++ b/applications/tari_collectibles/src-tauri/Cargo.toml
@@ -21,12 +21,12 @@ tari_common = { path = "../../../common" }
 tari_common_types = { path = "../../../base_layer/common_types" }
 tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.13.0" }
 tari_key_manager = { path = "../../../base_layer/key_manager" }
-tari_mmr = { path = "../../../base_layer/mmr"}
+tari_mmr = { path = "../../../base_layer/mmr" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.3" }
-tari_dan_common_types = { path = "../../../dan_layer/common_types"}
+tari_dan_common_types = { path = "../../../dan_layer/common_types" }
 
 blake2 = "^0.9.0"
-clap = "3.1.8"
+clap = { version = "3.1.8", features = ["env"] }
 derivative = "2.2.0"
 diesel = { version = "1.4.8", features = ["sqlite"] }
 diesel_migrations = "1.4.0"
@@ -43,8 +43,8 @@ tauri = { version = "1.0.0-rc.6", features = ["api-all"] }
 thiserror = "1.0.30"
 tokio = { version = "1.11", features = ["signal"] }
 tonic = "0.6.2"
-uuid = {  version = "0.8.2", features = ["serde"] }
+uuid = { version = "0.8.2", features = ["serde"] }
 
 [features]
-default = [ "custom-protocol" ]
-custom-protocol = [ "tauri/custom-protocol" ]
+default = ["custom-protocol"]
+custom-protocol = ["tauri/custom-protocol"]

--- a/applications/tari_collectibles/src-tauri/src/cli.rs
+++ b/applications/tari_collectibles/src-tauri/src/cli.rs
@@ -40,7 +40,7 @@ pub(crate) struct Cli {
   #[clap(subcommand)]
   pub command: Option<Commands>,
   /// Supply a network (overrides existing configuration)
-  #[clap(long, default_value = DEFAULT_NETWORK)]
+  #[clap(long, default_value = DEFAULT_NETWORK, env = "TARI_NETWORK")]
   pub network: String,
 }
 

--- a/applications/tari_console_wallet/Cargo.toml
+++ b/applications/tari_console_wallet/Cargo.toml
@@ -28,7 +28,7 @@ tokio = { version = "1.14", default-features = false, features = ["signal", "syn
 
 sha2 = "0.9.5"
 digest = "0.9.0"
-clap = { version = "3.1.1", features = ["derive"] }
+clap = { version = "3.1.1", features = ["derive", "env"] }
 config = "0.13.0"
 chrono = { version = "0.4.19", default-features = false }
 bitflags = "1.2.1"

--- a/applications/tari_console_wallet/src/cli.rs
+++ b/applications/tari_console_wallet/src/cli.rs
@@ -39,7 +39,7 @@ pub(crate) struct Cli {
     /// Supply the password for the console wallet. It's very bad security practice to provide the password on the
     /// command line, since it's visible using `ps ax` from anywhere on the system, so always use the env var where
     /// possible.
-    #[clap(long)] // , env = "TARI_WALLET_PASSWORD")]
+    #[clap(long, env = "TARI_WALLET_PASSWORD", hide_env_values = true)]
     pub password: Option<String>,
     /// Change the password for the console wallet
     #[clap(long, alias = "update-password")]
@@ -69,7 +69,7 @@ pub(crate) struct Cli {
     #[clap(long, alias = "auto-exit")]
     pub command_mode_auto_exit: bool,
     /// Supply a network (overrides existing configuration)
-    #[clap(long, alias = "network", default_value = DEFAULT_NETWORK)]
+    #[clap(long, default_value = DEFAULT_NETWORK, env = "TARI_NETWORK")]
     pub network: String,
 }
 

--- a/applications/tari_merge_mining_proxy/Cargo.toml
+++ b/applications/tari_merge_mining_proxy/Cargo.toml
@@ -25,7 +25,7 @@ crossterm = { version = "0.17" }
 bincode = "1.3.1"
 bytes = "1.1"
 chrono = { version = "0.4.6", default-features = false }
-clap = { version = "3.1.1", features = ["derive"] }
+clap = { version = "3.1.1", features = ["derive", "env"] }
 config = { version = "0.13.0" }
 derivative = "2.2.0"
 env_logger = { version = "0.7.1", optional = true }

--- a/applications/tari_merge_mining_proxy/src/cli.rs
+++ b/applications/tari_merge_mining_proxy/src/cli.rs
@@ -32,7 +32,7 @@ pub(crate) struct Cli {
     #[clap(flatten)]
     pub common: CommonCliArgs,
     /// Supply a network (overrides existing configuration)
-    #[clap(long, alias = "network", default_value = DEFAULT_NETWORK)]
+    #[clap(long, default_value = DEFAULT_NETWORK, env = "TARI_NETWORK")]
     pub network: String,
 }
 

--- a/applications/tari_validator_node/Cargo.toml
+++ b/applications/tari_validator_node/Cargo.toml
@@ -29,7 +29,7 @@ tari_common_types = { path = "../../base_layer/common_types" }
 anyhow = "1.0.53"
 async-trait = "0.1.50"
 blake2 = "0.9.2"
-clap = "3.1.8"
+clap = { version = "3.1.8", features = ["env"] }
 config = "0.13.0"
 digest = "0.9.0"
 futures = { version = "^0.3.1" }

--- a/applications/tari_validator_node/src/cli.rs
+++ b/applications/tari_validator_node/src/cli.rs
@@ -20,28 +20,6 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//  Copyright 2022. The Tari Project
-//
-//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
-//  following conditions are met:
-//
-//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
-//  disclaimer.
-//
-//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
-//  following disclaimer in the documentation and/or other materials provided with the distribution.
-//
-//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
-//  products derived from this software without specific prior written permission.
-//
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
-//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
-//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
-//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
 use clap::Parser;
 use tari_app_utilities::common_cli_args::CommonCliArgs;
 
@@ -57,7 +35,7 @@ pub(crate) struct Cli {
     #[clap(long, aliases = &["tracing", "enable-tracing"])]
     pub tracing_enabled: bool,
     /// Supply a network (overrides existing configuration)
-    #[clap(long, alias = "network", default_value = DEFAULT_NETWORK)]
+    #[clap(long, default_value = DEFAULT_NETWORK, env = "TARI_NETWORK")]
     pub network: String,
 }
 


### PR DESCRIPTION
Description
---
Allows the base directory to be set using the `TARI_BASE_DIR` environment variable.
Allows the current network to be set by the `TARI_NETWORK` environment variable.
Allows the password to be passed in using an environment variable `TARI_WALLET_PASSWORD` in `tari_console_wallet`.

Motivation and Context
---
In some environments, it is desirable to use environment variables instead of passing cli arguments. 

How Has This Been Tested?
---
Setting env var `TARI_NETWORK=mainnet` and `dibbler` on the base node and wallet.
Setting env var `TARI_WALLET_PASSWORD = 'xxx'` on the console wallet
