### PR TITLE
chore: add clippy style to lints

### DIFF
--- a/base_layer/p2p/src/transport.rs
+++ b/base_layer/p2p/src/transport.rs
@@ -164,7 +164,7 @@ impl TorTransportConfig {
         let forward_addr = self
             .forward_address
             .as_ref()
-            .map(|addr| multiaddr_to_socketaddr(addr))
+            .map(multiaddr_to_socketaddr)
             .transpose()
             .map_err(CommsInitializationError::InvalidTorForwardAddress)?
             .unwrap_or_else(|| ([127, 0, 0, 1], 0).into());

--- a/lints.toml
+++ b/lints.toml
@@ -37,6 +37,7 @@ deny = [
     'clippy::needless_borrow',
 
     # style
+    'clippy::style',
     'clippy::explicit_into_iter_loop',
     'clippy::explicit_iter_loop',
     'clippy::if_not_else',


### PR DESCRIPTION
adds `clippy::style` to `lints.toml`

