### PR TITLE
fix(base-node): assign correct base dir to tor identity

### DIFF
--- a/applications/tari_base_node/src/config.rs
+++ b/applications/tari_base_node/src/config.rs
@@ -153,6 +153,9 @@ impl BaseNodeConfig {
         if !self.identity_file.is_absolute() {
             self.identity_file = base_path.as_ref().join(self.identity_file.as_path());
         }
+        if !self.tor_identity_file.is_absolute() {
+            self.tor_identity_file = base_path.as_ref().join(self.tor_identity_file.as_path());
+        }
         if !self.data_dir.is_absolute() {
             self.data_dir = base_path.as_ref().join(self.data_dir.as_path());
         }

--- a/comms/core/src/connection_manager/dialer.rs
+++ b/comms/core/src/connection_manager/dialer.rs
@@ -31,6 +31,7 @@ use futures::{
 };
 use log::*;
 use tari_shutdown::{Shutdown, ShutdownSignal};
+use tari_utilities::hex::Hex;
 use tokio::{
     io::{AsyncRead, AsyncWrite, AsyncWriteExt},
     sync::{mpsc, oneshot},
@@ -355,7 +356,10 @@ where
             .ok_or(ConnectionManagerError::InvalidStaticPublicKey)?;
 
         if &authenticated_public_key != expected_public_key {
-            return Err(ConnectionManagerError::DialedPublicKeyMismatch);
+            return Err(ConnectionManagerError::DialedPublicKeyMismatch {
+                authenticated_pk: authenticated_public_key.to_hex(),
+                expected_pk: expected_public_key.to_hex(),
+            });
         }
 
         Ok(authenticated_public_key)

--- a/comms/core/src/connection_manager/error.rs
+++ b/comms/core/src/connection_manager/error.rs
@@ -53,8 +53,14 @@ pub enum ConnectionManagerError {
     ListenerError { address: String, details: String },
     #[error("Transport error for {address}: {details}")]
     TransportError { address: String, details: String },
-    #[error("The peer authenticated to a public key which did not match the dialed peer's public key")]
-    DialedPublicKeyMismatch,
+    #[error(
+        "The peer authenticated to public key '{authenticated_pk}' which did not match the dialed peer's public key \
+         '{expected_pk}'"
+    )]
+    DialedPublicKeyMismatch {
+        authenticated_pk: String,
+        expected_pk: String,
+    },
     #[error("The noise transport failed to provide a valid static public key for the peer")]
     InvalidStaticPublicKey,
     // This is a String because we need this error to be clonable so that we can


### PR DESCRIPTION
Description
---
Fixes regression: prepend the base directory to the tor identity file location.

Motivation and Context
---
The regression caused the tor identity, and therefore public address, to be shared amongst multiple base nodes.
This causes `DialedPublicKeyMismatch` errors that have been observed in logs.

How Has This Been Tested?
---
Manually checked that two base nodes have different tor identities and the file location is relative to the base dir.
