### PR TITLE
fix(wallet): ensure block hash exists

### DIFF
--- a/base_layer/wallet/src/transaction_service/protocols/transaction_validation_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_validation_protocol.rs
@@ -322,7 +322,7 @@ where
                 .map_err(TransactionServiceError::ProtobufConversionError)?;
             let sig = response.signature;
             if let Some(unconfirmed_tx) = batch_signatures.get(&sig) {
-                if response.location == TxLocation::Mined {
+                if response.location == TxLocation::Mined && response.block_hash.is_some() {
                     mined.push((
                         (*unconfirmed_tx).clone(),
                         response.block_height,
@@ -330,6 +330,14 @@ where
                         response.confirmations,
                     ));
                 } else {
+                    warn!(
+                        target: LOG_TARGET,
+                        "Marking transaction {} as unmined and confirmed '{}' with block '{}' (Operation ID: {})",
+                        &unconfirmed_tx.tx_id,
+                        &response.confirmations >= &self.config.num_confirmations_required,
+                        response.block_hash.is_some(),
+                        self.operation_id,
+                    );
                     unmined.push((*unconfirmed_tx).clone());
                 }
             }


### PR DESCRIPTION
Description
---
Adds a quick data validation check before updating the database. The base node may return a response without a block_hash and the resulting db update creates an invalidatable scenario for the wallet.

Motivation and Context
---
An aurora wallet is failing to validate and causing problems

How Has This Been Tested?
---
It has not yet been tested.