### PR TITLE
fix: possible overflow in difficulty calculation (fixes #3923)

### DIFF
--- a/base_layer/core/src/proof_of_work/difficulty.rs
+++ b/base_layer/core/src/proof_of_work/difficulty.rs
@@ -129,10 +129,41 @@ pub mod util {
         let result = U256::MAX / scalar;
         result.low_u64().into()
     }
+
+    #[cfg(test)]
+    mod test {
+        use super::*;
+
+        #[test]
+        fn high_target() {
+            let target: &[u8] = &[
+                0xff, 0xff, 0xff, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+            ];
+            let expected = Difficulty::from(1);
+            assert_eq!(big_endian_difficulty(target), expected);
+        }
+
+        #[test]
+        fn max_difficulty() {
+            let target = U256::MAX / U256::from(u64::MAX);
+            let mut bytes = [0u8; 32];
+            target.to_big_endian(&mut bytes);
+            assert_eq!(big_endian_difficulty(&bytes), Difficulty::from(u64::MAX));
+        }
+
+        #[test]
+        fn stop_overflow() {
+            let target: u64 = 64;
+            let expected = u64::MAX;
+            assert_eq!(big_endian_difficulty(&target.to_be_bytes()), Difficulty::from(expected));
+        }
+    }
 }
+
 #[cfg(test)]
 mod test {
-    use crate::proof_of_work::difficulty::{Difficulty, util::big_endian_difficulty};
+    use crate::proof_of_work::difficulty::Difficulty;
 
     #[test]
     fn add_difficulty() {
@@ -149,25 +180,4 @@ mod test {
         let d = Difficulty::from(1_000_000);
         assert_eq!("1,000,000", format!("{}", d));
     }
-
-    #[test]
-    fn high_target() {
-        let target: &[u8] = &[0xff, 0xff, 0xff, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 ];
-        let expected = Difficulty::from(1);
-        assert_eq!(big_endian_difficulty(target), expected);
-    } 
-
-    #[test]
-    fn max_difficulty() {
-        let target = u64::MAX;
-        let expected = u64::MAX;
-        assert_eq!(big_endian_difficulty(&target.to_be_bytes()), Difficulty::from(expected));
-    } 
-
-    #[test]
-    fn stop_overflow() {
-        let target: u64 = 64;
-        let expected = u64::MAX;
-        assert_eq!(big_endian_difficulty(&target.to_be_bytes()), Difficulty::from(expected));
-    } 
 }

--- a/base_layer/core/src/proof_of_work/difficulty.rs
+++ b/base_layer/core/src/proof_of_work/difficulty.rs
@@ -119,7 +119,7 @@ pub mod util {
     pub(crate) fn big_endian_difficulty(hash: &[u8]) -> Difficulty {
         let scalar = U256::from_big_endian(hash); // Big endian so the hash has leading zeroes
         let result = U256::MAX / scalar;
-        let result = result.min(u64::MAX.into()); // if difficulty is less than 
+        let result = result.min(u64::MAX.into());
         result.low_u64().into()
     }
 
@@ -132,7 +132,7 @@ pub mod util {
 }
 #[cfg(test)]
 mod test {
-    use crate::proof_of_work::difficulty::Difficulty;
+    use crate::proof_of_work::difficulty::{Difficulty, util::big_endian_difficulty};
 
     #[test]
     fn add_difficulty() {
@@ -149,4 +149,25 @@ mod test {
         let d = Difficulty::from(1_000_000);
         assert_eq!("1,000,000", format!("{}", d));
     }
+
+    #[test]
+    fn high_target() {
+        let target: &[u8] = &[0xff, 0xff, 0xff, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 ];
+        let expected = Difficulty::from(1);
+        assert_eq!(big_endian_difficulty(target), expected);
+    } 
+
+    #[test]
+    fn max_difficulty() {
+        let target = u64::MAX;
+        let expected = u64::MAX;
+        assert_eq!(big_endian_difficulty(&target.to_be_bytes()), Difficulty::from(expected));
+    } 
+
+    #[test]
+    fn stop_overflow() {
+        let target: u64 = 64;
+        let expected = u64::MAX;
+        assert_eq!(big_endian_difficulty(&target.to_be_bytes()), Difficulty::from(expected));
+    } 
 }

--- a/base_layer/core/src/proof_of_work/difficulty.rs
+++ b/base_layer/core/src/proof_of_work/difficulty.rs
@@ -118,6 +118,9 @@ pub mod util {
     /// This will provide the difficulty of the hash assuming the hash is big_endian
     pub(crate) fn big_endian_difficulty(hash: &[u8]) -> Difficulty {
         let scalar = U256::from_big_endian(hash); // Big endian so the hash has leading zeroes
+        if scalar <= U256::from(2).pow(U256::from(192)) {
+            return u64::MAX.into();
+        }
         let result = U256::MAX / scalar;
         result.low_u64().into()
     }

--- a/base_layer/core/src/proof_of_work/difficulty.rs
+++ b/base_layer/core/src/proof_of_work/difficulty.rs
@@ -118,10 +118,8 @@ pub mod util {
     /// This will provide the difficulty of the hash assuming the hash is big_endian
     pub(crate) fn big_endian_difficulty(hash: &[u8]) -> Difficulty {
         let scalar = U256::from_big_endian(hash); // Big endian so the hash has leading zeroes
-        if scalar <= U256::from(2).pow(U256::from(192)) {
-            return u64::MAX.into();
-        }
         let result = U256::MAX / scalar;
+        let result = result.min(u64::MAX.into()); // if difficulty is less than 
         result.low_u64().into()
     }
 


### PR DESCRIPTION
Description
 - First attempt to tackle issue #3923

Motivation and Context
 - The main goal is to avoid possible overflow of difficulty, which even though extremely unlikely, it is a possible scenario. 

How Has This Been Tested?
 - So far, changes have not been tested. I am more than happy to get recommendations of tests. I haven't add them at the moment because it is not clear how to build an hash whose big endian is a scalar less than 2^192. I am therefore, very interested to understand this concept and add tests accordingly.

