### PR TITLE
fix(wallet header): remove function argument

### DIFF
--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -456,7 +456,6 @@ struct TariCommsConfig *comms_config_create(const char *public_address,
                                             const char *datastore_path,
                                             unsigned long long discovery_timeout_in_secs,
                                             unsigned long long saf_message_duration_in_secs,
-                                            const char *network,
                                             int *error_out);
 
 // Frees memory for a TariCommsConfig


### PR DESCRIPTION
Description
---
As per https://github.com/tari-project/tari/commit/fcbdb0a424f66b9c77ca5334aec72290b07c7593 we removed the `network` argument from `comms_config_create` but forgot to remove it from the header file causing mobile builds to fail.

Motivation and Context
---
Corrective actions.

How Has This Been Tested?
---
It's been tested in the iOS build that went from not working to working.
