### PR TITLE
fix(wallet): use network specified by cli/envvar in console wallet

### DIFF
--- a/applications/tari_console_wallet/src/main.rs
+++ b/applications/tari_console_wallet/src/main.rs
@@ -100,8 +100,8 @@ fn main_inner() -> Result<(), ExitError> {
         include_str!("../log4rs_sample.yml"),
     )?;
 
-    #[cfg_attr(not(all(unix, feature = "libtor")), allow(unused_mut))]
     let mut config = ApplicationConfig::load_from(&cfg)?;
+    config.wallet.network = cli.network.parse()?;
 
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()


### PR DESCRIPTION
Description
---
Use network specified by `--network` cli / `TARI_NETWORK` envvar in console wallet

Motivation and Context
---
The network in wallet config uses `mainnet` by default and is not overridden by the cli / env var. This PR fixes that.

How Has This Been Tested?
---
Tested by running a console wallet without a network set in the config (default mainnet) and then passing `--network dibbler` 