### PR TITLE
feat: add mempool fee per gram stats to transaction service

### DIFF
--- a/base_layer/core/src/base_node/proto/rpc.proto
+++ b/base_layer/core/src/base_node/proto/rpc.proto
@@ -89,3 +89,18 @@ message SyncUtxosByBlockResponse  {
   uint64 height = 2;
   bytes header_hash = 3;
 }
+
+message GetMempoolFeePerGramStatsRequest {
+  uint64 count = 1;
+}
+
+message GetMempoolFeePerGramStatsResponse {
+  repeated MempoolFeePerGramStat stats = 1;
+}
+
+message MempoolFeePerGramStat {
+  uint64 order = 1;
+  uint64 max_fee_per_gram = 2;
+  uint64 avg_fee_per_gram = 4;
+  uint64 min_fee_per_gram = 5;
+}

--- a/base_layer/core/src/base_node/proto/rpc.rs
+++ b/base_layer/core/src/base_node/proto/rpc.rs
@@ -24,7 +24,7 @@ use std::convert::{TryFrom, TryInto};
 
 use tari_utilities::Hashable;
 
-use crate::{blocks::Block, chain_storage::PrunedOutput, proto::base_node as proto};
+use crate::{blocks::Block, chain_storage::PrunedOutput, mempool::FeePerGramStat, proto::base_node as proto};
 
 impl TryFrom<Block> for proto::BlockBodyResponse {
     type Error = String;
@@ -52,6 +52,25 @@ impl From<PrunedOutput> for proto::SyncUtxo {
             PrunedOutput::NotPruned { output } => proto::SyncUtxo {
                 utxo: Some(proto::sync_utxo::Utxo::Output(output.into())),
             },
+        }
+    }
+}
+
+impl From<Vec<FeePerGramStat>> for proto::GetMempoolFeePerGramStatsResponse {
+    fn from(stats: Vec<FeePerGramStat>) -> Self {
+        Self {
+            stats: stats.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<FeePerGramStat> for proto::MempoolFeePerGramStat {
+    fn from(stat: FeePerGramStat) -> Self {
+        Self {
+            order: stat.order,
+            min_fee_per_gram: stat.min_fee_per_gram.as_u64(),
+            avg_fee_per_gram: stat.avg_fee_per_gram.as_u64(),
+            max_fee_per_gram: stat.max_fee_per_gram.as_u64(),
         }
     }
 }

--- a/base_layer/core/src/base_node/rpc/mod.rs
+++ b/base_layer/core/src/base_node/rpc/mod.rs
@@ -43,6 +43,8 @@ use crate::{
         base_node::{
             FetchMatchingUtxos,
             FetchUtxosResponse,
+            GetMempoolFeePerGramStatsRequest,
+            GetMempoolFeePerGramStatsResponse,
             QueryDeletedRequest,
             QueryDeletedResponse,
             Signatures,
@@ -111,6 +113,12 @@ pub trait BaseNodeWalletService: Send + Sync + 'static {
         &self,
         request: Request<SyncUtxosByBlockRequest>,
     ) -> Result<Streaming<SyncUtxosByBlockResponse>, RpcStatus>;
+
+    #[rpc(method = 12)]
+    async fn get_mempool_fee_per_gram_stats(
+        &self,
+        request: Request<GetMempoolFeePerGramStatsRequest>,
+    ) -> Result<Response<GetMempoolFeePerGramStatsResponse>, RpcStatus>;
 }
 
 #[cfg(feature = "base_node")]

--- a/base_layer/core/src/mempool/mempool.rs
+++ b/base_layer/core/src/mempool/mempool.rs
@@ -31,6 +31,7 @@ use crate::{
     mempool::{
         error::MempoolError,
         mempool_storage::MempoolStorage,
+        FeePerGramStat,
         MempoolConfig,
         StateResponse,
         StatsResponse,
@@ -133,6 +134,15 @@ impl Mempool {
     /// Gathers and returns a breakdown of all the transaction in the Mempool.
     pub async fn state(&self) -> Result<StateResponse, MempoolError> {
         self.with_read_access(|storage| Ok(storage.state())).await
+    }
+
+    pub async fn get_fee_per_gram_stats(
+        &self,
+        count: usize,
+        tip_height: u64,
+    ) -> Result<Vec<FeePerGramStat>, MempoolError> {
+        self.with_read_access(move |storage| storage.get_fee_per_gram_stats(count, tip_height))
+            .await
     }
 
     async fn with_read_access<F, T>(&self, callback: F) -> Result<T, MempoolError>

--- a/base_layer/core/src/mempool/mempool_storage.rs
+++ b/base_layer/core/src/mempool/mempool_storage.rs
@@ -33,6 +33,7 @@ use crate::{
         error::MempoolError,
         reorg_pool::ReorgPool,
         unconfirmed_pool::UnconfirmedPool,
+        FeePerGramStat,
         MempoolConfig,
         StateResponse,
         StatsResponse,
@@ -299,5 +300,14 @@ impl MempoolStorage {
             unconfirmed_pool,
             reorg_pool,
         }
+    }
+
+    pub fn get_fee_per_gram_stats(&self, count: usize, tip_height: u64) -> Result<Vec<FeePerGramStat>, MempoolError> {
+        let target_weight = self
+            .rules
+            .consensus_constants(tip_height)
+            .get_max_block_weight_excluding_coinbase();
+        let stats = self.unconfirmed_pool.get_fee_per_gram_stats(count, target_weight)?;
+        Ok(stats)
     }
 }

--- a/base_layer/core/src/mempool/mod.rs
+++ b/base_layer/core/src/mempool/mod.rs
@@ -74,7 +74,10 @@ use serde::{Deserialize, Serialize};
 pub use sync_protocol::MempoolSyncInitializer;
 use tari_common_types::types::Signature;
 
-use crate::transactions::transaction_components::Transaction;
+use crate::{
+    proto::base_node as base_node_proto,
+    transactions::{tari_amount::MicroTari, transaction_components::Transaction},
+};
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct StatsResponse {
@@ -129,5 +132,24 @@ impl Display for TxStorageResponse {
             TxStorageResponse::NotStored => "Not stored",
         };
         fmt.write_str(storage)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct FeePerGramStat {
+    pub order: u64,
+    pub min_fee_per_gram: MicroTari,
+    pub avg_fee_per_gram: MicroTari,
+    pub max_fee_per_gram: MicroTari,
+}
+
+impl From<base_node_proto::MempoolFeePerGramStat> for FeePerGramStat {
+    fn from(value: base_node_proto::MempoolFeePerGramStat) -> Self {
+        Self {
+            order: value.order,
+            min_fee_per_gram: value.min_fee_per_gram.into(),
+            avg_fee_per_gram: value.avg_fee_per_gram.into(),
+            max_fee_per_gram: value.max_fee_per_gram.into(),
+        }
     }
 }

--- a/base_layer/core/src/mempool/service/handle.rs
+++ b/base_layer/core/src/mempool/service/handle.rs
@@ -26,6 +26,7 @@ use tari_service_framework::{reply_channel::TrySenderService, Service};
 use crate::{
     mempool::{
         service::{MempoolRequest, MempoolResponse},
+        FeePerGramStat,
         MempoolServiceError,
         StateResponse,
         StatsResponse,
@@ -78,6 +79,21 @@ impl MempoolHandle {
             .await??
         {
             MempoolResponse::TxStorage(resp) => Ok(resp),
+            _ => panic!("Incorrect response"),
+        }
+    }
+
+    pub async fn get_fee_per_gram_stats(
+        &mut self,
+        count: usize,
+        tip_height: u64,
+    ) -> Result<Vec<FeePerGramStat>, MempoolServiceError> {
+        match self
+            .inner
+            .call(MempoolRequest::GetFeePerGramStats { count, tip_height })
+            .await??
+        {
+            MempoolResponse::FeePerGramStats { response } => Ok(response),
             _ => panic!("Incorrect response"),
         }
     }

--- a/base_layer/core/src/mempool/service/inbound_handlers.rs
+++ b/base_layer/core/src/mempool/service/inbound_handlers.rs
@@ -57,7 +57,7 @@ impl MempoolInboundHandlers {
     /// Handle inbound Mempool service requests from remote nodes and local services.
     pub async fn handle_request(&mut self, request: MempoolRequest) -> Result<MempoolResponse, MempoolServiceError> {
         debug!(target: LOG_TARGET, "Handling remote request: {}", request);
-        use MempoolRequest::{GetState, GetStats, GetTxStateByExcessSig, SubmitTransaction};
+        use MempoolRequest::{GetFeePerGramStats, GetState, GetStats, GetTxStateByExcessSig, SubmitTransaction};
         match request {
             GetStats => Ok(MempoolResponse::Stats(self.mempool.stats().await?)),
             GetState => Ok(MempoolResponse::State(self.mempool.state().await?)),
@@ -71,6 +71,10 @@ impl MempoolInboundHandlers {
                     tx.body.kernels()[0].excess_sig.get_signature().to_hex(),
                 );
                 Ok(MempoolResponse::TxStorage(self.submit_transaction(tx, None).await?))
+            },
+            GetFeePerGramStats { count, tip_height } => {
+                let stats = self.mempool.get_fee_per_gram_stats(count, tip_height).await?;
+                Ok(MempoolResponse::FeePerGramStats { response: stats })
             },
         }
     }

--- a/base_layer/core/src/mempool/service/request.rs
+++ b/base_layer/core/src/mempool/service/request.rs
@@ -36,20 +36,25 @@ pub enum MempoolRequest {
     GetState,
     GetTxStateByExcessSig(Signature),
     SubmitTransaction(Transaction),
+    GetFeePerGramStats { count: usize, tip_height: u64 },
 }
 
 impl Display for MempoolRequest {
     fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
         match self {
-            MempoolRequest::GetStats => f.write_str("GetStats"),
-            MempoolRequest::GetState => f.write_str("GetState"),
+            MempoolRequest::GetStats => write!(f, "GetStats"),
+            MempoolRequest::GetState => write!(f, "GetState"),
             MempoolRequest::GetTxStateByExcessSig(sig) => {
-                f.write_str(&format!("GetTxStateByExcessSig ({})", sig.get_signature().to_hex()))
+                write!(f, "GetTxStateByExcessSig ({})", sig.get_signature().to_hex())
             },
-            MempoolRequest::SubmitTransaction(tx) => f.write_str(&format!(
+            MempoolRequest::SubmitTransaction(tx) => write!(
+                f,
                 "SubmitTransaction ({})",
                 tx.body.kernels()[0].excess_sig.get_signature().to_hex()
-            )),
+            ),
+            MempoolRequest::GetFeePerGramStats { count, tip_height } => {
+                write!(f, "GetFeePerGramStats(count: {}, tip_height: {})", *count, *tip_height)
+            },
         }
     }
 }

--- a/base_layer/core/src/mempool/service/response.rs
+++ b/base_layer/core/src/mempool/service/response.rs
@@ -24,7 +24,7 @@ use std::{fmt, fmt::Formatter};
 
 use tari_common_types::waiting_requests::RequestKey;
 
-use crate::mempool::{StateResponse, StatsResponse, TxStorageResponse};
+use crate::mempool::{FeePerGramStat, StateResponse, StatsResponse, TxStorageResponse};
 
 /// API Response enum for Mempool responses.
 #[derive(Clone, Debug)]
@@ -32,15 +32,17 @@ pub enum MempoolResponse {
     Stats(StatsResponse),
     State(StateResponse),
     TxStorage(TxStorageResponse),
+    FeePerGramStats { response: Vec<FeePerGramStat> },
 }
 
 impl fmt::Display for MempoolResponse {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        use MempoolResponse::{State, Stats, TxStorage};
+        use MempoolResponse::{FeePerGramStats, State, Stats, TxStorage};
         match &self {
             Stats(_) => write!(f, "Stats"),
             State(_) => write!(f, "State"),
             TxStorage(_) => write!(f, "TxStorage"),
+            FeePerGramStats { response } => write!(f, "FeePerGramStats({} item(s))", response.len()),
         }
     }
 }

--- a/base_layer/core/src/mempool/test_utils/mock.rs
+++ b/base_layer/core/src/mempool/test_utils/mock.rs
@@ -125,7 +125,7 @@ impl MempoolServiceMock {
     }
 
     async fn handle_request(&self, req: MempoolRequest) -> Result<MempoolResponse, MempoolServiceError> {
-        use MempoolRequest::{GetState, GetStats, GetTxStateByExcessSig, SubmitTransaction};
+        use MempoolRequest::{GetFeePerGramStats, GetState, GetStats, GetTxStateByExcessSig, SubmitTransaction};
 
         self.state.inc_call_count();
         match req {
@@ -137,6 +137,9 @@ impl MempoolServiceMock {
             SubmitTransaction(_) => Ok(MempoolResponse::TxStorage(
                 self.state.submit_transaction.lock().await.clone(),
             )),
+            GetFeePerGramStats { .. } => {
+                unimplemented!()
+            },
         }
     }
 }

--- a/base_layer/core/src/mempool/unconfirmed_pool/unconfirmed_pool.rs
+++ b/base_layer/core/src/mempool/unconfirmed_pool/unconfirmed_pool.rs
@@ -37,8 +37,10 @@ use crate::{
     mempool::{
         priority::{FeePriority, PrioritizedTransaction},
         unconfirmed_pool::UnconfirmedPoolError,
+        FeePerGramStat,
     },
     transactions::{
+        tari_amount::MicroTari,
         transaction_components::{Transaction, TransactionOutput},
         weight::TransactionWeight,
     },
@@ -542,6 +544,61 @@ impl UnconfirmedPool {
         })
     }
 
+    pub fn get_fee_per_gram_stats(
+        &self,
+        count: usize,
+        target_block_weight: u64,
+    ) -> Result<Vec<FeePerGramStat>, UnconfirmedPoolError> {
+        if count == 0 || target_block_weight == 0 {
+            return Ok(vec![]);
+        }
+
+        if self.len() == 0 {
+            return Ok(vec![]);
+        }
+
+        let mut stats = Vec::new();
+        let mut offset = 0usize;
+        for start in 0..count {
+            let mut total_weight = 0;
+            let mut total_fees = MicroTari::zero();
+            let mut min_fee_per_gram = MicroTari::from(u64::MAX);
+            let mut max_fee_per_gram = MicroTari::zero();
+            let mut last_count = 0;
+            for (i, key) in self.tx_by_priority.values().rev().enumerate().skip(offset) {
+                let tx = self
+                    .tx_by_key
+                    .get(key)
+                    .ok_or_else(|| UnconfirmedPoolError::StorageOutofSync)?;
+                let weight = tx.weight;
+
+                if total_weight + weight > target_block_weight {
+                    break;
+                }
+
+                let total_tx_fee = tx.transaction.body.get_total_fee();
+                last_count = i + 1;
+                let fee_per_gram = total_tx_fee / weight;
+                min_fee_per_gram = min_fee_per_gram.min(fee_per_gram);
+                max_fee_per_gram = max_fee_per_gram.max(fee_per_gram);
+                total_fees += total_tx_fee;
+                total_weight += weight;
+            }
+            if last_count > 0 {
+                let stat = FeePerGramStat {
+                    order: start as u64,
+                    min_fee_per_gram,
+                    avg_fee_per_gram: total_fees / total_weight,
+                    max_fee_per_gram,
+                };
+                stats.push(stat);
+            }
+            offset = last_count;
+        }
+
+        Ok(stats)
+    }
+
     /// Returns false if there are any inconsistencies in the internal mempool state, otherwise true
     #[cfg(test)]
     fn check_data_consistency(&self) -> bool {
@@ -961,8 +1018,6 @@ mod test {
         let (tx3, _, _) = tx!(MicroTari(350_000), fee: MicroTari(51), inputs:5, outputs:1, features: nft_features);
         let (tx4, _, _) = tx!(MicroTari(450_000), fee: MicroTari(50), inputs:5, outputs:5);
 
-        // Insert multiple transactions with the same outputs into the mempool
-
         let tx_weight = TransactionWeight::latest();
         let mut unconfirmed_pool = UnconfirmedPool::new(UnconfirmedPoolConfig {
             storage_capacity: 10,
@@ -1003,5 +1058,77 @@ mod test {
         assert!(results.retrieved_transactions.iter().any(|tx| *tx == tx3));
         assert!(results.retrieved_transactions.iter().any(|tx| *tx == tx4));
         assert_eq!(results.retrieved_transactions.len(), 3);
+    }
+
+    mod get_fee_per_gram_stats {
+
+        use super::*;
+
+        #[test]
+        fn it_returns_empty_stats_for_empty_mempool() {
+            let unconfirmed_pool = UnconfirmedPool::new(UnconfirmedPoolConfig::default());
+            let stats = unconfirmed_pool.get_fee_per_gram_stats(1, 19500).unwrap();
+            assert!(stats.is_empty());
+        }
+
+        #[test]
+        fn it_compiles_correct_stats_for_single_block() {
+            let (tx1, _, _) = tx!(MicroTari(150_000), fee: MicroTari(5), inputs:5, outputs:1);
+            let (tx2, _, _) = tx!(MicroTari(250_000), fee: MicroTari(5), inputs:5, outputs:5);
+            let (tx3, _, _) = tx!(MicroTari(350_000), fee: MicroTari(4), inputs:2, outputs:1);
+            let (tx4, _, _) = tx!(MicroTari(450_000), fee: MicroTari(4), inputs:4, outputs:5);
+
+            let tx_weight = TransactionWeight::latest();
+            let mut unconfirmed_pool = UnconfirmedPool::new(UnconfirmedPoolConfig::default());
+
+            let tx1 = Arc::new(tx1);
+            let tx2 = Arc::new(tx2);
+            let tx3 = Arc::new(tx3);
+            let tx4 = Arc::new(tx4);
+            unconfirmed_pool
+                .insert_many(vec![tx1.clone(), tx2.clone(), tx3.clone(), tx4.clone()], &tx_weight)
+                .unwrap();
+
+            let stats = unconfirmed_pool.get_fee_per_gram_stats(1, 19500).unwrap();
+            assert_eq!(stats[0].order, 0);
+            assert_eq!(stats[0].min_fee_per_gram, 4.into());
+            assert_eq!(stats[0].max_fee_per_gram, 5.into());
+            assert_eq!(stats[0].avg_fee_per_gram, 4.into());
+        }
+
+        #[test]
+        fn it_compiles_correct_stats_for_multiple_blocks() {
+            let expected_stats = [
+                FeePerGramStat {
+                    order: 0,
+                    min_fee_per_gram: 10.into(),
+                    avg_fee_per_gram: 10.into(),
+                    max_fee_per_gram: 10.into(),
+                },
+                FeePerGramStat {
+                    order: 1,
+                    min_fee_per_gram: 5.into(),
+                    avg_fee_per_gram: 9.into(),
+                    max_fee_per_gram: 10.into(),
+                },
+            ];
+
+            let mut transactions = (0u64..50)
+                .map(|i| {
+                    let (tx, _, _) = tx!(MicroTari(150_000 + i), fee: MicroTari(10), inputs: 1, outputs: 1);
+                    Arc::new(tx)
+                })
+                .collect::<Vec<_>>();
+            let (tx1, _, _) = tx!(MicroTari(150_000), fee: MicroTari(5), inputs:1, outputs: 5);
+            transactions.push(Arc::new(tx1));
+
+            let tx_weight = TransactionWeight::latest();
+            let mut unconfirmed_pool = UnconfirmedPool::new(UnconfirmedPoolConfig::default());
+
+            unconfirmed_pool.insert_many(transactions, &tx_weight).unwrap();
+
+            let stats = unconfirmed_pool.get_fee_per_gram_stats(2, 2000).unwrap();
+            assert_eq!(stats, expected_stats);
+        }
     }
 }

--- a/base_layer/core/src/transactions/tari_amount.rs
+++ b/base_layer/core/src/transactions/tari_amount.rs
@@ -85,6 +85,10 @@ impl Mul<MicroTari> for u64 {
 }
 
 impl MicroTari {
+    pub const fn zero() -> Self {
+        Self(0)
+    }
+
     pub fn checked_add(self, v: MicroTari) -> Option<MicroTari> {
         self.as_u64().checked_add(v.as_u64()).map(Into::into)
     }

--- a/base_layer/wallet/src/output_manager_service/handle.rs
+++ b/base_layer/wallet/src/output_manager_service/handle.rs
@@ -120,6 +120,7 @@ pub enum OutputManagerRequest {
         num_kernels: usize,
         num_outputs: usize,
     },
+
     ScanForRecoverableOutputs(Vec<TransactionOutput>),
     ScanOutputs(Vec<TransactionOutput>),
     AddKnownOneSidedPaymentScript(KnownOneSidedPaymentScript),

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -41,6 +41,7 @@ use tari_comms::{peer_manager::NodeIdentity, types::CommsPublicKey};
 use tari_comms_dht::outbound::OutboundMessageRequester;
 use tari_core::{
     covenants::Covenant,
+    mempool::FeePerGramStat,
     proto::base_node as base_node_proto,
     transactions::{
         tari_amount::MicroTari,
@@ -79,7 +80,13 @@ use crate::{
     transaction_service::{
         config::TransactionServiceConfig,
         error::{TransactionServiceError, TransactionServiceProtocolError},
-        handle::{TransactionEvent, TransactionEventSender, TransactionServiceRequest, TransactionServiceResponse},
+        handle::{
+            FeePerGramStatsResponse,
+            TransactionEvent,
+            TransactionEventSender,
+            TransactionServiceRequest,
+            TransactionServiceResponse,
+        },
         protocols::{
             transaction_broadcast_protocol::TransactionBroadcastProtocol,
             transaction_receive_protocol::{TransactionReceiveProtocol, TransactionReceiveProtocolStage},
@@ -720,6 +727,11 @@ where
                 .start_transaction_revalidation(transaction_validation_join_handles)
                 .await
                 .map(TransactionServiceResponse::ValidationStarted),
+            TransactionServiceRequest::GetFeePerGramStatsPerBlock { count } => {
+                let reply_channel = reply_channel.take().expect("reply_channel is Some");
+                self.handle_get_fee_per_gram_stats_per_block_request(count, reply_channel);
+                return Ok(());
+            },
         };
 
         // If the individual handlers did not already send the API response then do it here.
@@ -730,6 +742,48 @@ where
             });
         }
         Ok(())
+    }
+
+    fn handle_get_fee_per_gram_stats_per_block_request(
+        &self,
+        count: usize,
+        reply_channel: oneshot::Sender<Result<TransactionServiceResponse, TransactionServiceError>>,
+    ) {
+        let mut connectivity = self.resources.connectivity.clone();
+
+        let query_base_node_fut = async move {
+            let mut client = connectivity
+                .obtain_base_node_wallet_rpc_client()
+                .await
+                .ok_or_else(|| TransactionServiceError::Shutdown)?;
+
+            let resp = client
+                .get_mempool_fee_per_gram_stats(base_node_proto::GetMempoolFeePerGramStatsRequest {
+                    count: count as u64,
+                })
+                .await?;
+            let mut resp = FeePerGramStatsResponse::from(resp);
+            // If there are no transactions in the mempool, populate with a minimal fee per gram.
+            if resp.stats.is_empty() {
+                resp.stats = vec![FeePerGramStat {
+                    order: 0,
+                    min_fee_per_gram: 1.into(),
+                    avg_fee_per_gram: 1.into(),
+                    max_fee_per_gram: 1.into(),
+                }]
+            }
+            Ok(TransactionServiceResponse::FeePerGramStatsPerBlock(resp))
+        };
+
+        tokio::spawn(async move {
+            let resp = query_base_node_fut.await;
+            if reply_channel.send(resp).is_err() {
+                warn!(
+                    target: LOG_TARGET,
+                    "handle_get_fee_per_gram_stats_per_block_request: service reply cancelled"
+                );
+            }
+        });
     }
 
     async fn handle_base_node_service_event(

--- a/base_layer/wallet/tests/support/comms_rpc.rs
+++ b/base_layer/wallet/tests/support/comms_rpc.rs
@@ -45,6 +45,8 @@ use tari_core::{
             ChainMetadata as ChainMetadataProto,
             FetchMatchingUtxos,
             FetchUtxosResponse,
+            GetMempoolFeePerGramStatsRequest,
+            GetMempoolFeePerGramStatsResponse,
             QueryDeletedRequest,
             QueryDeletedResponse,
             Signatures as SignaturesProto,
@@ -105,6 +107,7 @@ pub struct BaseNodeWalletRpcMockState {
     synced: Arc<Mutex<bool>>,
     utxos: Arc<Mutex<Vec<TransactionOutput>>>,
     blocks: Arc<Mutex<HashMap<u64, BlockHeader>>>,
+    get_mempool_fee_per_gram_stats: Arc<Mutex<GetMempoolFeePerGramStatsResponse>>,
     utxos_by_block: Arc<Mutex<Vec<UtxosByBlock>>>,
     sync_utxos_by_block_trigger_channel: Arc<Mutex<Option<mpsc::Receiver<usize>>>>,
 }
@@ -168,6 +171,8 @@ impl BaseNodeWalletRpcMockState {
             synced: Arc::new(Mutex::new(true)),
             utxos: Arc::new(Mutex::new(Vec::new())),
             blocks: Arc::new(Mutex::new(Default::default())),
+            get_mempool_fee_per_gram_stats: Default::default(),
+
             utxos_by_block: Arc::new(Mutex::new(vec![])),
             sync_utxos_by_block_trigger_channel: Arc::new(Mutex::new(None)),
         }
@@ -228,6 +233,11 @@ impl BaseNodeWalletRpcMockState {
     pub fn set_blocks(&self, blocks: HashMap<u64, BlockHeader>) {
         let mut lock = acquire_lock!(self.blocks);
         *lock = blocks;
+    }
+
+    pub fn set_fee_per_gram_stats_response(&self, resp: GetMempoolFeePerGramStatsResponse) {
+        let mut lock = acquire_lock!(self.get_mempool_fee_per_gram_stats);
+        *lock = resp;
     }
 
     pub fn set_utxos_by_block(&self, utxos_by_block: Vec<UtxosByBlock>) {
@@ -822,6 +832,15 @@ impl BaseNodeWalletService for BaseNodeWalletRpcMockService {
         } else {
             Err(RpcStatus::not_found("Headers not found"))
         }
+    }
+
+    async fn get_mempool_fee_per_gram_stats(
+        &self,
+        _request: Request<GetMempoolFeePerGramStatsRequest>,
+    ) -> Result<Response<GetMempoolFeePerGramStatsResponse>, RpcStatus> {
+        Ok(Response::new(
+            acquire_lock!(self.state.get_mempool_fee_per_gram_stats).clone(),
+        ))
     }
 }
 


### PR DESCRIPTION
Description
---
- adds fee per gram stats call to transaction service.
- adds `get_mempool_fee_per_gram_stats` to wallet RPC service

Motivation and Context
---
Add call for the wallet to query the base node for min/max and average mempool fee per gram stats to allow it to determine the best fee given current network conditions.

How Has This Been Tested?
---
Added new unit tests

