### PR TITLE
fix(ci): sort .license.ignore locally before diff

### DIFF
--- a/scripts/file_license_check.sh
+++ b/scripts/file_license_check.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
-# run from the repo root
+# Must be run from the repo root
 
 rg -i "Copyright.*The Tari Project" --files-without-match \
     -g '!*.{Dockerfile,asc,bat,config,config.js,css,csv,drawio,gitkeep,hbs,html,iss,json,lock,md,min.js,ps1,py,rc,scss,sh,sql,svg,toml,txt,yml,vue}' . \
-    | sort >/tmp/rgtemp
+    | sort > /tmp/rgtemp
 
-DIFFS=$(diff -u .license.ignore /tmp/rgtemp)
+# sort the .license.ignore file as sorting seems to behave differently on different platforms
+cat .license.ignore | sort > /tmp/.license.ignore
+
+DIFFS=$(diff -u /tmp/.license.ignore /tmp/rgtemp)
 
 if [ -n "$DIFFS" ]; then
     echo "New files detected that either need copyright/license identifiers added, or they need to be added to .license.ignore"


### PR DESCRIPTION
Description
---

- sorts license.ignore localy before diffing

Motivation and Context
---
The license check does not always pass. I'm not really able to explain why it is flaky but on my local linux machine
it does not pass because the `sort` command behaves slightly differently. 

This PR sorts the ignore file locally so that we can be sure the sorting is consistent before the diff.

How Has This Been Tested?
---
Manually run ./scripts/file_license_check.sh
