### PR TITLE
ci: feature selfhosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,5 @@
 on:
+  workflow_dispatch:
   push:
     branches:
       - development
@@ -19,11 +20,12 @@ env:
   CARGO_HTTP_MULTIPLEXING: false
   CARGO_TERM_COLOR: always
   PROTOC: protoc
-
+  TERM: unkown
+  
 jobs:
   clippy:
     name: clippy
-    runs-on: ubuntu-18.04
+    runs-on: [ self-hosted, ubuntu18.04-high-cpu ]
     steps:
       - name: checkout
         uses: actions/checkout@v2
@@ -33,7 +35,6 @@ jobs:
           toolchain: ${{ env.toolchain }}
           components: clippy, rustfmt
           override: true
-      - uses: Swatinem/rust-cache@v1
       - name: ubuntu dependencies
         run: |
           sudo apt-get update && \
@@ -66,7 +67,7 @@ jobs:
           args: clippy --all-targets
   build:
     name: check nightly
-    runs-on: ubuntu-18.04
+    runs-on: [ self-hosted, ubuntu18.04-high-cpu ]
     steps:
       - name: checkout
         uses: actions/checkout@v2
@@ -76,7 +77,6 @@ jobs:
           toolchain: ${{ env.toolchain }}
           profile: minimal
           override: true
-      - uses: Swatinem/rust-cache@v1
       - name: ubuntu dependencies
         run: |
           sudo apt-get update && \
@@ -105,7 +105,7 @@ jobs:
 
   build-stable:
     name: check stable
-    runs-on: ubuntu-18.04
+    runs-on: [ self-hosted, ubuntu18.04-high-cpu ]
     steps:
       - name: checkout
         uses: actions/checkout@v2
@@ -146,10 +146,13 @@ jobs:
           args: --release --package tari_wallet_ffi
   javascript:
     name: npm packages
-    runs-on: ubuntu-18.04
+    runs-on: [ ubuntu-20.04 ]
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
       - name: build launchpad gui-vue
         run: |
           cd applications/launchpad/gui-vue
@@ -168,7 +171,7 @@ jobs:
           npm run check-fmt
   licenses:
     name: file licenses
-    runs-on: ubuntu-20.04
+    runs-on: [ ubuntu-20.04 ]
     steps:
       - name: checkout
         uses: actions/checkout@v2
@@ -181,7 +184,7 @@ jobs:
         run: ./scripts/file_license_check.sh
   test:
     name: test
-    runs-on: ubuntu-18.04
+    runs-on: [ self-hosted, ubuntu18.04-high-cpu ]
     steps:
       - name: checkout
         uses: actions/checkout@v2
@@ -189,7 +192,6 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ env.toolchain }}
-      - uses: Swatinem/rust-cache@v1
       - name: ubuntu dependencies
         run: |
           sudo apt-get update && \
@@ -224,7 +226,7 @@ jobs:
   # Allows other workflows to know the PR number
   artifacts:
     name: test
-    runs-on: ubuntu-18.04
+    runs-on: [ ubuntu-20.04 ]
     steps:
       - name: Save the PR number in an artifact
         shell: bash

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,25 +1,16 @@
 name: Source Coverage
 on:
+  workflow_dispatch:
   push:
     branches:
       - development
-
-env:
-  toolchain: nightly-2021-11-20
+      - ci-*
 
 jobs:
   coverage:
-    name: test
-    runs-on: ubuntu-18.04
+    name: test and generate cov
+    runs-on: [ self-hosted, ubuntu18.04-high-mem ]
     steps:
-      - name: checkout
-        uses: actions/checkout@v2
-      - name: toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ env.toolchain }}
-          override: true
-          components: llvm-tools-preview
       - name: ubuntu dependencies
         run: |
           sudo apt-get update && \
@@ -46,28 +37,43 @@ jobs:
             wget \
             libappindicator3-dev \
             patchelf \
-            librsvg2-dev \
-      - name: install grcov
+            librsvg2-dev
+      - name: checkout
+        uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+          components: llvm-tools-preview
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --all-features --no-fail-fast
+        env:
+          RUSTFLAGS: "-C instrument-coverage"
+          RUSTDOCFLAGS: "-C instrument-coverage"
+          LLVM_PROFILE_FILE: "coverage_data-%p-%m.profraw"
+      - id: coverage
+        name: Prepare coverage data
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         run: |
           cargo install grcov
-      - name: cargo test compile
-        uses: actions-rs/cargo@v1
+          grcov . -s . --binary-path ./target/debug -t coveralls --branch --ignore-not-existing \
+             -o ./target/coveralls_coverage.json \
+             --token $COVERALLS_REPO_TOKEN \
+             --vcs-branch $GITHUB_REF_NAME \
+             --service-name github \
+             --service-job-id ${GITHUB_RUN_ID}
+      - id: archive-coverage
+        name: archive-coverage
+        uses: actions/upload-artifact@v3
         with:
-          command: test
-          args: --no-run --locked --all-features
-      - name: cargo test
-        uses: actions-rs/cargo@v1
-        env:
-          LLVM_PROFILE_FILE: "coverage_data-%p-%m.profraw"
-          RUSTFLAGS: "-Zinstrument-coverage"
-        with:
-          command: test
-          args: --all-features
-      - name: generate coverage report
-        run: |
-          grcov . -s . --binary-path ./target/debug -t lcov --branch --ignore-not-existing -o ./target/report.lcov
+          path: target/coveralls_coverage.json
+          name: coveralls-coverage
       - name: Coveralls upload
-        uses: coverallsapp/github-action@master
+        uses: toshke/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: ./target/report.lcov
+          path-to-lcov: ./target/coveralls_coverage.json
+          file-format: coveralls

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - development
-      - ci-*
+      - ci-coverage-*
 
 jobs:
   coverage:


### PR DESCRIPTION
Description

- Use self hosted runners for Continuous Integration and Code Coverage GH workflows
---

Motivation and Context
- Improve speed times for CI 
- Enable Code Coverage by providing enough underlying resources 
---

How Has This Been Tested?
---

Self hosted job runs can be found
[Here for CI JOB](https://github.com/tari-project/tari/actions/workflows/ci.yml?query=branch%3Aci-feature-selfhosted-runners)
[Here for Coverage JOB](https://github.com/tari-project/tari/actions/workflows/coverage.yml?query=branch%3Aci-feature-selfhosted-runners)

Tests for run to check concurrent builds of up to 7 jobs. 

