### PR TITLE
ci: ignore cargo and target folders from coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -62,6 +62,8 @@ jobs:
           grcov . -s . --binary-path ./target/debug -t coveralls --branch --ignore-not-existing \
              -o ./target/coveralls_coverage.json \
              --token $COVERALLS_REPO_TOKEN \
+             --ignore target/**/*.rs \
+             --ignore **/.cargo/**/*.rs \
              --vcs-branch $GITHUB_REF_NAME \
              --service-name github \
              --service-job-id ${GITHUB_RUN_ID}


### PR DESCRIPTION
Ignore some folders from coverage report that goes to coveralls 

![image](https://user-images.githubusercontent.com/4200336/168991106-07c020e4-c8b7-4f12-8274-0596399284d4.png)
