### PR TITLE
refactor(core): change ConsensusEncoding trait not to return written bytes

### DIFF
--- a/base_layer/core/src/blocks/block.rs
+++ b/base_layer/core/src/blocks/block.rs
@@ -269,10 +269,10 @@ impl Hashable for Block {
 }
 
 impl ConsensusEncoding for Block {
-    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<usize, io::Error> {
-        let mut written = self.header.consensus_encode(writer)?;
-        written += self.body.consensus_encode(writer)?;
-        Ok(written)
+    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<(), io::Error> {
+        self.header.consensus_encode(writer)?;
+        self.body.consensus_encode(writer)?;
+        Ok(())
     }
 }
 

--- a/base_layer/core/src/blocks/block_header.rs
+++ b/base_layer/core/src/blocks/block_header.rs
@@ -394,22 +394,22 @@ pub(crate) mod hash_serializer {
 }
 
 impl ConsensusEncoding for BlockHeader {
-    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<usize, io::Error> {
-        let mut written = self.version.consensus_encode(writer)?;
-        written += self.height.consensus_encode(writer)?;
-        written += copy_into_fixed_array_lossy::<_, 32>(&self.prev_hash).consensus_encode(writer)?;
-        written += self.timestamp.consensus_encode(writer)?;
-        written += copy_into_fixed_array_lossy::<_, 32>(&self.output_mr).consensus_encode(writer)?;
-        written += copy_into_fixed_array_lossy::<_, 32>(&self.witness_mr).consensus_encode(writer)?;
-        written += self.output_mmr_size.consensus_encode(writer)?;
-        written += copy_into_fixed_array_lossy::<_, 32>(&self.kernel_mr).consensus_encode(writer)?;
-        written += self.kernel_mmr_size.consensus_encode(writer)?;
-        written += copy_into_fixed_array_lossy::<_, 32>(&self.input_mr).consensus_encode(writer)?;
-        written += self.total_kernel_offset.consensus_encode(writer)?;
-        written += self.total_script_offset.consensus_encode(writer)?;
-        written += self.nonce.consensus_encode(writer)?;
-        written += self.pow.consensus_encode(writer)?;
-        Ok(written)
+    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<(), io::Error> {
+        self.version.consensus_encode(writer)?;
+        self.height.consensus_encode(writer)?;
+        copy_into_fixed_array_lossy::<_, 32>(&self.prev_hash).consensus_encode(writer)?;
+        self.timestamp.consensus_encode(writer)?;
+        copy_into_fixed_array_lossy::<_, 32>(&self.output_mr).consensus_encode(writer)?;
+        copy_into_fixed_array_lossy::<_, 32>(&self.witness_mr).consensus_encode(writer)?;
+        self.output_mmr_size.consensus_encode(writer)?;
+        copy_into_fixed_array_lossy::<_, 32>(&self.kernel_mr).consensus_encode(writer)?;
+        self.kernel_mmr_size.consensus_encode(writer)?;
+        copy_into_fixed_array_lossy::<_, 32>(&self.input_mr).consensus_encode(writer)?;
+        self.total_kernel_offset.consensus_encode(writer)?;
+        self.total_script_offset.consensus_encode(writer)?;
+        self.nonce.consensus_encode(writer)?;
+        self.pow.consensus_encode(writer)?;
+        Ok(())
     }
 }
 

--- a/base_layer/core/src/consensus/consensus_encoding.rs
+++ b/base_layer/core/src/consensus/consensus_encoding.rs
@@ -41,7 +41,7 @@ use crate::common::byte_counter::ByteCounter;
 pub trait ConsensusEncoding {
     /// Encode to the given writer returning the number of bytes written.
     /// If writing to this Writer is infallible, this implementation MUST always succeed.
-    fn consensus_encode<W: io::Write>(&self, writer: &mut W) -> Result<usize, io::Error>;
+    fn consensus_encode<W: io::Write>(&self, writer: &mut W) -> Result<(), io::Error>;
 }
 
 pub trait ConsensusEncodingSized: ConsensusEncoding {

--- a/base_layer/core/src/consensus/consensus_encoding/bytes.rs
+++ b/base_layer/core/src/consensus/consensus_encoding/bytes.rs
@@ -32,11 +32,11 @@ use integer_encoding::{VarInt, VarIntReader, VarIntWriter};
 use crate::consensus::{ConsensusDecoding, ConsensusEncoding, ConsensusEncodingSized};
 
 impl ConsensusEncoding for Vec<u8> {
-    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<usize, io::Error> {
+    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<(), io::Error> {
         let len = self.len();
-        let mut written = writer.write_varint(len)?;
-        written += writer.write(self)?;
-        Ok(written)
+        writer.write_varint(len)?;
+        writer.write_all(self)?;
+        Ok(())
     }
 }
 
@@ -98,11 +98,11 @@ impl<const MAX: usize> Deref for MaxSizeBytes<MAX> {
 }
 
 impl ConsensusEncoding for &[u8] {
-    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<usize, io::Error> {
+    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<(), io::Error> {
         let len = self.len();
-        let mut written = writer.write_varint(len)?;
-        written += writer.write(self)?;
-        Ok(written)
+        writer.write_varint(len)?;
+        writer.write_all(self)?;
+        Ok(())
     }
 }
 
@@ -113,10 +113,10 @@ impl ConsensusEncodingSized for &[u8] {
 }
 
 impl<const N: usize> ConsensusEncoding for [u8; N] {
-    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<usize, Error> {
+    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
         // For fixed length types we dont need a length byte
         writer.write_all(&self[..])?;
-        Ok(N)
+        Ok(())
     }
 }
 

--- a/base_layer/core/src/consensus/consensus_encoding/crypto.rs
+++ b/base_layer/core/src/consensus/consensus_encoding/crypto.rs
@@ -34,8 +34,9 @@ use crate::consensus::{ConsensusDecoding, ConsensusEncoding, ConsensusEncodingSi
 //---------------------------------- PublicKey --------------------------------------------//
 
 impl ConsensusEncoding for PublicKey {
-    fn consensus_encode<W: io::Write>(&self, writer: &mut W) -> Result<usize, io::Error> {
-        writer.write(self.as_bytes())
+    fn consensus_encode<W: io::Write>(&self, writer: &mut W) -> Result<(), io::Error> {
+        writer.write_all(self.as_bytes())?;
+        Ok(())
     }
 }
 
@@ -57,8 +58,9 @@ impl ConsensusDecoding for PublicKey {
 //---------------------------------- PrivateKey --------------------------------------------//
 
 impl ConsensusEncoding for PrivateKey {
-    fn consensus_encode<W: io::Write>(&self, writer: &mut W) -> Result<usize, io::Error> {
-        writer.write(self.as_bytes())
+    fn consensus_encode<W: io::Write>(&self, writer: &mut W) -> Result<(), io::Error> {
+        writer.write_all(self.as_bytes())?;
+        Ok(())
     }
 }
 
@@ -80,11 +82,10 @@ impl ConsensusDecoding for PrivateKey {
 //---------------------------------- Commitment --------------------------------------------//
 
 impl ConsensusEncoding for Commitment {
-    fn consensus_encode<W: io::Write>(&self, writer: &mut W) -> Result<usize, io::Error> {
+    fn consensus_encode<W: io::Write>(&self, writer: &mut W) -> Result<(), io::Error> {
         let buf = self.as_bytes();
-        let len = buf.len();
         writer.write_all(buf)?;
-        Ok(len)
+        Ok(())
     }
 }
 
@@ -107,10 +108,10 @@ impl ConsensusDecoding for Commitment {
 //---------------------------------- Signature --------------------------------------------//
 
 impl ConsensusEncoding for Signature {
-    fn consensus_encode<W: io::Write>(&self, writer: &mut W) -> Result<usize, io::Error> {
-        let mut written = self.get_public_nonce().consensus_encode(writer)?;
-        written += self.get_signature().consensus_encode(writer)?;
-        Ok(written)
+    fn consensus_encode<W: io::Write>(&self, writer: &mut W) -> Result<(), io::Error> {
+        self.get_public_nonce().consensus_encode(writer)?;
+        self.get_signature().consensus_encode(writer)?;
+        Ok(())
     }
 }
 
@@ -131,7 +132,7 @@ impl ConsensusDecoding for Signature {
 //---------------------------------- RangeProof --------------------------------------------//
 
 impl ConsensusEncoding for RangeProof {
-    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<usize, Error> {
+    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
         self.0.consensus_encode(writer)
     }
 }
@@ -153,11 +154,11 @@ impl ConsensusDecoding for RangeProof {
 //---------------------------------- Commitment Signature --------------------------------------------//
 
 impl ConsensusEncoding for ComSignature {
-    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<usize, Error> {
-        let mut written = self.u().consensus_encode(writer)?;
-        written += self.v().consensus_encode(writer)?;
-        written += self.public_nonce().consensus_encode(writer)?;
-        Ok(written)
+    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
+        self.u().consensus_encode(writer)?;
+        self.v().consensus_encode(writer)?;
+        self.public_nonce().consensus_encode(writer)?;
+        Ok(())
     }
 }
 

--- a/base_layer/core/src/consensus/consensus_encoding/epoch_time.rs
+++ b/base_layer/core/src/consensus/consensus_encoding/epoch_time.rs
@@ -27,7 +27,7 @@ use tari_utilities::epoch_time::EpochTime;
 use crate::consensus::{ConsensusDecoding, ConsensusEncoding, ConsensusEncodingSized};
 
 impl ConsensusEncoding for EpochTime {
-    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<usize, Error> {
+    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
         self.as_u64().consensus_encode(writer)
     }
 }

--- a/base_layer/core/src/consensus/consensus_encoding/generic.rs
+++ b/base_layer/core/src/consensus/consensus_encoding/generic.rs
@@ -30,21 +30,18 @@ use integer_encoding::VarIntWriter;
 use crate::consensus::{ConsensusDecoding, ConsensusEncoding, ConsensusEncodingSized};
 
 impl<T: ConsensusEncoding> ConsensusEncoding for Option<T> {
-    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<usize, io::Error> {
-        let mut written = 0;
+    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<(), io::Error> {
         match self {
             Some(t) => {
                 writer.write_all(&[1u8])?;
-                written += 1;
-                written += t.consensus_encode(writer)?;
+                t.consensus_encode(writer)?;
             },
             None => {
                 writer.write_all(&[0u8])?;
-                written += 1;
             },
         }
 
-        Ok(written)
+        Ok(())
     }
 }
 
@@ -70,12 +67,12 @@ impl<T: ConsensusDecoding> ConsensusDecoding for Option<T> {
 
 //---------------------------------- Vec<T> --------------------------------------------//
 impl<T: ConsensusEncoding> ConsensusEncoding for Vec<T> {
-    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<usize, io::Error> {
-        let mut written = writer.write_varint(self.len())?;
+    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<(), io::Error> {
+        writer.write_varint(self.len())?;
         for elem in self {
-            written += elem.consensus_encode(writer)?;
+            elem.consensus_encode(writer)?;
         }
-        Ok(written)
+        Ok(())
     }
 }
 

--- a/base_layer/core/src/consensus/consensus_encoding/integers.rs
+++ b/base_layer/core/src/consensus/consensus_encoding/integers.rs
@@ -23,10 +23,10 @@
 macro_rules! consensus_encoding_varint_impl {
     ($ty:ty) => {
         impl $crate::consensus::ConsensusEncoding for $ty {
-            fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, std::io::Error> {
+            fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
                 use integer_encoding::VarIntWriter;
-                let bytes_written = writer.write_varint(*self)?;
-                Ok(bytes_written)
+                writer.write_varint(*self)?;
+                Ok(())
             }
         }
 

--- a/base_layer/core/src/consensus/consensus_encoding/micro_tari.rs
+++ b/base_layer/core/src/consensus/consensus_encoding/micro_tari.rs
@@ -33,9 +33,9 @@ use crate::{
 const U64_SIZE: usize = mem::size_of::<u64>();
 
 impl ConsensusEncoding for MicroTari {
-    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<usize, Error> {
+    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
         writer.write_all(&self.0.to_le_bytes()[..])?;
-        Ok(U64_SIZE)
+        Ok(())
     }
 }
 

--- a/base_layer/core/src/consensus/consensus_encoding/script.rs
+++ b/base_layer/core/src/consensus/consensus_encoding/script.rs
@@ -30,7 +30,7 @@ use tari_script::{ExecutionStack, TariScript};
 use crate::consensus::{ConsensusDecoding, ConsensusEncoding, ConsensusEncodingSized, MaxSizeBytes};
 
 impl ConsensusEncoding for TariScript {
-    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<usize, io::Error> {
+    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<(), io::Error> {
         self.as_bytes().consensus_encode(writer)
     }
 }
@@ -53,7 +53,7 @@ impl ConsensusDecoding for TariScript {
 }
 
 impl ConsensusEncoding for ExecutionStack {
-    fn consensus_encode<W: io::Write>(&self, writer: &mut W) -> Result<usize, io::Error> {
+    fn consensus_encode<W: io::Write>(&self, writer: &mut W) -> Result<(), io::Error> {
         self.as_bytes().consensus_encode(writer)
     }
 }

--- a/base_layer/core/src/covenants/arguments.rs
+++ b/base_layer/core/src/covenants/arguments.rs
@@ -117,54 +117,53 @@ impl CovenantArg {
         }
     }
 
-    pub fn write_to<W: io::Write>(&self, writer: &mut W) -> Result<usize, io::Error> {
+    pub fn write_to<W: io::Write>(&self, writer: &mut W) -> Result<(), io::Error> {
         use byte_codes::*;
         use CovenantArg::{Bytes, Commitment, Covenant, Hash, OutputField, OutputFields, PublicKey, TariScript, Uint};
 
-        let mut written = 0;
         match self {
             Hash(hash) => {
-                written += writer.write_u8_fixed(ARG_HASH)?;
-                written += hash.len();
+                writer.write_u8_fixed(ARG_HASH)?;
+                hash.len();
                 writer.write_all(&hash[..])?;
             },
             PublicKey(pk) => {
-                written += writer.write_u8_fixed(ARG_PUBLIC_KEY)?;
-                written += pk.consensus_encode(writer)?;
+                writer.write_u8_fixed(ARG_PUBLIC_KEY)?;
+                pk.consensus_encode(writer)?;
             },
             Commitment(commitment) => {
-                written += writer.write_u8_fixed(ARG_COMMITMENT)?;
-                written += commitment.consensus_encode(writer)?;
+                writer.write_u8_fixed(ARG_COMMITMENT)?;
+                commitment.consensus_encode(writer)?;
             },
             TariScript(script) => {
-                written += writer.write_u8_fixed(ARG_TARI_SCRIPT)?;
-                written += script.consensus_encode(writer)?;
+                writer.write_u8_fixed(ARG_TARI_SCRIPT)?;
+                script.consensus_encode(writer)?;
             },
             Covenant(covenant) => {
-                written += writer.write_u8_fixed(ARG_COVENANT)?;
+                writer.write_u8_fixed(ARG_COVENANT)?;
                 let len = covenant.get_byte_length();
-                written += writer.write_varint(len)?;
-                written += covenant.write_to(writer)?;
+                writer.write_varint(len)?;
+                covenant.write_to(writer)?;
             },
             Uint(int) => {
-                written += writer.write_u8_fixed(ARG_UINT)?;
-                written += int.consensus_encode(writer)?;
+                writer.write_u8_fixed(ARG_UINT)?;
+                int.consensus_encode(writer)?;
             },
             OutputField(field) => {
-                written += writer.write_u8_fixed(ARG_OUTPUT_FIELD)?;
-                written += writer.write_u8_fixed(field.as_byte())?;
+                writer.write_u8_fixed(ARG_OUTPUT_FIELD)?;
+                writer.write_u8_fixed(field.as_byte())?;
             },
             OutputFields(fields) => {
-                written += writer.write_u8_fixed(ARG_OUTPUT_FIELDS)?;
-                written += fields.write_to(writer)?;
+                writer.write_u8_fixed(ARG_OUTPUT_FIELDS)?;
+                fields.write_to(writer)?;
             },
             Bytes(bytes) => {
-                written += writer.write_u8_fixed(ARG_BYTES)?;
-                written += bytes.consensus_encode(writer)?;
+                writer.write_u8_fixed(ARG_BYTES)?;
+                bytes.consensus_encode(writer)?;
             },
         }
 
-        Ok(written)
+        Ok(())
     }
 }
 

--- a/base_layer/core/src/covenants/covenant.rs
+++ b/base_layer/core/src/covenants/covenant.rs
@@ -67,7 +67,7 @@ impl Covenant {
         buf
     }
 
-    pub(super) fn write_to<W: io::Write>(&self, writer: &mut W) -> Result<usize, io::Error> {
+    pub(super) fn write_to<W: io::Write>(&self, writer: &mut W) -> Result<(), io::Error> {
         CovenantTokenEncoder::new(self.tokens.as_slice()).write_to(writer)
     }
 
@@ -114,11 +114,11 @@ impl Covenant {
 }
 
 impl ConsensusEncoding for Covenant {
-    fn consensus_encode<W: io::Write>(&self, writer: &mut W) -> Result<usize, io::Error> {
+    fn consensus_encode<W: io::Write>(&self, writer: &mut W) -> Result<(), io::Error> {
         let len = self.get_byte_length();
-        let mut written = writer.write_varint(len)?;
-        written += self.write_to(writer)?;
-        Ok(written)
+        writer.write_varint(len)?;
+        self.write_to(writer)?;
+        Ok(())
     }
 }
 

--- a/base_layer/core/src/covenants/encoder.rs
+++ b/base_layer/core/src/covenants/encoder.rs
@@ -33,12 +33,11 @@ impl<'a> CovenantTokenEncoder<'a> {
         Self { tokens }
     }
 
-    pub fn write_to<W: io::Write>(&self, writer: &mut W) -> Result<usize, io::Error> {
-        let mut written = 0;
+    pub fn write_to<W: io::Write>(&self, writer: &mut W) -> Result<(), io::Error> {
         for token in self.tokens {
-            written += token.write_to(writer)?;
+            token.write_to(writer)?;
         }
-        Ok(written)
+        Ok(())
     }
 }
 
@@ -69,9 +68,8 @@ mod tests {
     fn it_encodes_empty_tokens() {
         let encoder = CovenantTokenEncoder::new(&[]);
         let mut buf = Vec::<u8>::new();
-        let written = encoder.write_to(&mut buf).unwrap();
+        encoder.write_to(&mut buf).unwrap();
         assert_eq!(buf, [] as [u8; 0]);
-        assert_eq!(written, 0);
     }
 
     #[test]
@@ -79,9 +77,8 @@ mod tests {
         let covenant = covenant!(and(identity(), or(identity())));
         let encoder = CovenantTokenEncoder::new(covenant.tokens());
         let mut buf = Vec::<u8>::new();
-        let written = encoder.write_to(&mut buf).unwrap();
+        encoder.write_to(&mut buf).unwrap();
         assert_eq!(buf, [FILTER_AND, FILTER_IDENTITY, FILTER_OR, FILTER_IDENTITY]);
-        assert_eq!(written, 4);
     }
 
     #[test]
@@ -90,7 +87,7 @@ mod tests {
         let covenant = covenant!(field_eq(@field::features, @hash(dummy)));
         let encoder = CovenantTokenEncoder::new(covenant.tokens());
         let mut buf = Vec::<u8>::new();
-        let written = encoder.write_to(&mut buf).unwrap();
+        encoder.write_to(&mut buf).unwrap();
         assert_eq!(buf[..4], [
             FILTER_FIELD_EQ,
             ARG_OUTPUT_FIELD,
@@ -98,7 +95,6 @@ mod tests {
             ARG_HASH
         ]);
         assert_eq!(buf[4..], [0u8; 32]);
-        assert_eq!(written, 36);
     }
 
     mod covenant_write_ext {

--- a/base_layer/core/src/covenants/filters/filter.rs
+++ b/base_layer/core/src/covenants/filters/filter.rs
@@ -66,8 +66,9 @@ impl CovenantFilter {
         byte_codes::is_valid_filter_code(code)
     }
 
-    pub fn write_to<W: io::Write>(&self, writer: &mut W) -> Result<usize, io::Error> {
-        writer.write_u8_fixed(self.as_byte_code())
+    pub fn write_to<W: io::Write>(&self, writer: &mut W) -> Result<(), io::Error> {
+        writer.write_u8_fixed(self.as_byte_code())?;
+        Ok(())
     }
 
     fn as_byte_code(&self) -> u8 {

--- a/base_layer/core/src/covenants/token.rs
+++ b/base_layer/core/src/covenants/token.rs
@@ -71,7 +71,7 @@ impl CovenantToken {
         }
     }
 
-    pub fn write_to<W: io::Write>(&self, writer: &mut W) -> Result<usize, io::Error> {
+    pub fn write_to<W: io::Write>(&self, writer: &mut W) -> Result<(), io::Error> {
         match self {
             CovenantToken::Filter(filter) => filter.write_to(writer),
             CovenantToken::Arg(arg) => arg.write_to(writer),

--- a/base_layer/core/src/proof_of_work/proof_of_work.rs
+++ b/base_layer/core/src/proof_of_work/proof_of_work.rs
@@ -88,10 +88,10 @@ impl Display for ProofOfWork {
 }
 
 impl ConsensusEncoding for ProofOfWork {
-    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<usize, io::Error> {
-        let mut written = self.pow_algo.as_u64().consensus_encode(writer)?;
-        written += self.pow_data.consensus_encode(writer)?;
-        Ok(written)
+    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<(), io::Error> {
+        self.pow_algo.as_u64().consensus_encode(writer)?;
+        self.pow_data.consensus_encode(writer)?;
+        Ok(())
     }
 }
 

--- a/base_layer/core/src/transactions/aggregated_body.rs
+++ b/base_layer/core/src/transactions/aggregated_body.rs
@@ -571,11 +571,11 @@ impl Display for AggregateBody {
 }
 
 impl ConsensusEncoding for AggregateBody {
-    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<usize, io::Error> {
-        let mut written = self.inputs.consensus_encode(writer)?;
-        written += self.outputs.consensus_encode(writer)?;
-        written += self.kernels.consensus_encode(writer)?;
-        Ok(written)
+    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<(), io::Error> {
+        self.inputs.consensus_encode(writer)?;
+        self.outputs.consensus_encode(writer)?;
+        self.kernels.consensus_encode(writer)?;
+        Ok(())
     }
 }
 

--- a/base_layer/core/src/transactions/transaction_components/asset_output_features.rs
+++ b/base_layer/core/src/transactions/transaction_components/asset_output_features.rs
@@ -42,11 +42,11 @@ pub struct AssetOutputFeatures {
 }
 
 impl ConsensusEncoding for AssetOutputFeatures {
-    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<usize, io::Error> {
-        let mut written = self.public_key.consensus_encode(writer)?;
-        written += self.template_ids_implemented.consensus_encode(writer)?;
-        written += self.template_parameters.consensus_encode(writer)?;
-        Ok(written)
+    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<(), io::Error> {
+        self.public_key.consensus_encode(writer)?;
+        self.template_ids_implemented.consensus_encode(writer)?;
+        self.template_parameters.consensus_encode(writer)?;
+        Ok(())
     }
 }
 

--- a/base_layer/core/src/transactions/transaction_components/committee_definition_features.rs
+++ b/base_layer/core/src/transactions/transaction_components/committee_definition_features.rs
@@ -36,10 +36,10 @@ pub struct CommitteeDefinitionFeatures {
 }
 
 impl ConsensusEncoding for CommitteeDefinitionFeatures {
-    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<usize, Error> {
-        let mut written = self.committee.consensus_encode(writer)?;
-        written += self.effective_sidechain_height.consensus_encode(writer)?;
-        Ok(written)
+    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
+        self.committee.consensus_encode(writer)?;
+        self.effective_sidechain_height.consensus_encode(writer)?;
+        Ok(())
     }
 }
 

--- a/base_layer/core/src/transactions/transaction_components/kernel_features.rs
+++ b/base_layer/core/src/transactions/transaction_components/kernel_features.rs
@@ -46,9 +46,9 @@ impl KernelFeatures {
 }
 
 impl ConsensusEncoding for KernelFeatures {
-    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<usize, Error> {
+    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
         writer.write_all(&[self.bits][..])?;
-        Ok(1)
+        Ok(())
     }
 }
 
@@ -68,22 +68,12 @@ impl ConsensusDecoding for KernelFeatures {
 
 #[cfg(test)]
 mod test {
-    use std::io::Cursor;
 
     use super::*;
+    use crate::consensus::check_consensus_encoding_correctness;
 
     #[test]
-    fn test_consensus() {
-        let mut buffer = Cursor::new(vec![0; KernelFeatures::create_coinbase().consensus_encode_exact_size()]);
-        assert_eq!(
-            KernelFeatures::create_coinbase().consensus_encode(&mut buffer).unwrap(),
-            KernelFeatures::create_coinbase().consensus_encode_exact_size()
-        );
-        // Reset the buffer to original position, we are going to read.
-        buffer.set_position(0);
-        assert_eq!(
-            KernelFeatures::consensus_decode(&mut buffer).unwrap(),
-            KernelFeatures::create_coinbase()
-        );
+    fn test_consensus_encoding() {
+        check_consensus_encoding_correctness(KernelFeatures::create_coinbase()).unwrap();
     }
 }

--- a/base_layer/core/src/transactions/transaction_components/mint_non_fungible_features.rs
+++ b/base_layer/core/src/transactions/transaction_components/mint_non_fungible_features.rs
@@ -39,10 +39,10 @@ pub struct MintNonFungibleFeatures {
 }
 
 impl ConsensusEncoding for MintNonFungibleFeatures {
-    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<usize, io::Error> {
-        let mut written = self.asset_public_key.consensus_encode(writer)?;
-        written += self.asset_owner_commitment.consensus_encode(writer)?;
-        Ok(written)
+    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<(), io::Error> {
+        self.asset_public_key.consensus_encode(writer)?;
+        self.asset_owner_commitment.consensus_encode(writer)?;
+        Ok(())
     }
 }
 

--- a/base_layer/core/src/transactions/transaction_components/output_features.rs
+++ b/base_layer/core/src/transactions/transaction_components/output_features.rs
@@ -300,29 +300,29 @@ impl OutputFeatures {
 }
 
 impl ConsensusEncoding for OutputFeatures {
-    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<usize, io::Error> {
-        let mut written = self.version.consensus_encode(writer)?;
-        written += self.maturity.consensus_encode(writer)?;
-        written += self.flags.consensus_encode(writer)?;
+    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<(), io::Error> {
+        self.version.consensus_encode(writer)?;
+        self.maturity.consensus_encode(writer)?;
+        self.flags.consensus_encode(writer)?;
         match self.version {
             OutputFeaturesVersion::V0 => (),
             OutputFeaturesVersion::V1 => {
-                written += OutputFeatures::consensus_encode_recovery_byte(self.recovery_byte, writer)?;
+                OutputFeatures::consensus_encode_recovery_byte(self.recovery_byte, writer)?;
             },
         }
-        written += self.parent_public_key.consensus_encode(writer)?;
-        written += self.unique_id.consensus_encode(writer)?;
-        written += self.asset.consensus_encode(writer)?;
-        written += self.mint_non_fungible.consensus_encode(writer)?;
-        written += self.sidechain_checkpoint.consensus_encode(writer)?;
-        written += self.metadata.consensus_encode(writer)?;
+        self.parent_public_key.consensus_encode(writer)?;
+        self.unique_id.consensus_encode(writer)?;
+        self.asset.consensus_encode(writer)?;
+        self.mint_non_fungible.consensus_encode(writer)?;
+        self.sidechain_checkpoint.consensus_encode(writer)?;
+        self.metadata.consensus_encode(writer)?;
         match self.version {
             OutputFeaturesVersion::V0 => (),
             OutputFeaturesVersion::V1 => {
-                written += self.committee_definition.consensus_encode(writer)?;
+                self.committee_definition.consensus_encode(writer)?;
             },
         }
-        Ok(written)
+        Ok(())
     }
 }
 

--- a/base_layer/core/src/transactions/transaction_components/output_features_version.rs
+++ b/base_layer/core/src/transactions/transaction_components/output_features_version.rs
@@ -42,9 +42,9 @@ impl TryFrom<u8> for OutputFeaturesVersion {
 }
 
 impl ConsensusEncoding for OutputFeaturesVersion {
-    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<usize, io::Error> {
+    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<(), io::Error> {
         writer.write_all(&[self.as_u8()])?;
-        Ok(1)
+        Ok(())
     }
 }
 

--- a/base_layer/core/src/transactions/transaction_components/output_flags.rs
+++ b/base_layer/core/src/transactions/transaction_components/output_flags.rs
@@ -59,8 +59,9 @@ bitflags! {
 }
 
 impl ConsensusEncoding for OutputFlags {
-    fn consensus_encode<W: io::Write>(&self, writer: &mut W) -> Result<usize, io::Error> {
-        writer.write(&self.bits.to_le_bytes())
+    fn consensus_encode<W: io::Write>(&self, writer: &mut W) -> Result<(), io::Error> {
+        writer.write_all(&self.bits.to_le_bytes())?;
+        Ok(())
     }
 }
 

--- a/base_layer/core/src/transactions/transaction_components/side_chain_checkpoint_features.rs
+++ b/base_layer/core/src/transactions/transaction_components/side_chain_checkpoint_features.rs
@@ -36,11 +36,10 @@ pub struct SideChainCheckpointFeatures {
 }
 
 impl ConsensusEncoding for SideChainCheckpointFeatures {
-    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<usize, Error> {
+    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
         self.merkle_root.consensus_encode(writer)?;
-        let mut written = 32;
-        written += self.committee.consensus_encode(writer)?;
-        Ok(written)
+        self.committee.consensus_encode(writer)?;
+        Ok(())
     }
 }
 

--- a/base_layer/core/src/transactions/transaction_components/template_parameter.rs
+++ b/base_layer/core/src/transactions/transaction_components/template_parameter.rs
@@ -38,11 +38,11 @@ pub struct TemplateParameter {
 }
 
 impl ConsensusEncoding for TemplateParameter {
-    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<usize, io::Error> {
-        let mut written = writer.write_varint(self.template_id)?;
-        written += writer.write_varint(self.template_data_version)?;
-        written += self.template_data.consensus_encode(writer)?;
-        Ok(written)
+    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<(), io::Error> {
+        writer.write_varint(self.template_id)?;
+        writer.write_varint(self.template_data_version)?;
+        self.template_data.consensus_encode(writer)?;
+        Ok(())
     }
 }
 

--- a/base_layer/core/src/transactions/transaction_components/test.rs
+++ b/base_layer/core/src/transactions/transaction_components/test.rs
@@ -475,16 +475,16 @@ mod output_features {
         features.version = OutputFeaturesVersion::V0;
 
         let mut buf = Vec::new();
-        let written = features.consensus_encode(&mut buf).unwrap();
+        features.consensus_encode(&mut buf).unwrap();
         assert_eq!(buf.len(), 10);
-        assert_eq!(written, 10);
+        assert_eq!(features.consensus_encode_exact_size(), 10);
 
         let mut features = OutputFeatures::default();
         features.version = OutputFeaturesVersion::V1;
         let mut buf = Vec::new();
-        let written = features.consensus_encode(&mut buf).unwrap();
+        features.consensus_encode(&mut buf).unwrap();
         assert_eq!(buf.len(), 12);
-        assert_eq!(written, 12);
+        assert_eq!(features.consensus_encode_exact_size(), 12);
     }
 
     #[test]
@@ -498,9 +498,9 @@ mod output_features {
         assert_eq!(known_size_u8_max, known_size_u8_min);
         let mut buf = Vec::with_capacity(known_size_u8_max);
         assert_eq!(known_size_u8_max, 19);
-        let written = features_u8_max.consensus_encode(&mut buf).unwrap();
+        features_u8_max.consensus_encode(&mut buf).unwrap();
         assert_eq!(buf.len(), 19);
-        assert_eq!(written, 19);
+        assert_eq!(features_u8_max.consensus_encode_exact_size(), 19);
         let decoded_features = OutputFeatures::consensus_decode(&mut &buf[..]).unwrap();
         // Recovery byte is not encoded for OutputFeaturesVersion::V0; the default is returned when decoded
         assert_ne!(features_u8_max, decoded_features);
@@ -514,9 +514,9 @@ mod output_features {
         assert_eq!(known_size_u8_max, known_size_u8_min);
         assert_eq!(known_size_u8_max, 21);
         let mut buf = Vec::with_capacity(known_size_u8_max);
-        let written = features_u8_max.consensus_encode(&mut buf).unwrap();
+        features_u8_max.consensus_encode(&mut buf).unwrap();
         assert_eq!(buf.len(), 21);
-        assert_eq!(written, 21);
+        assert_eq!(features_u8_max.consensus_encode_exact_size(), 21);
         let decoded_features = OutputFeatures::consensus_decode(&mut &buf[..]).unwrap();
         assert_eq!(features_u8_max, decoded_features);
 
@@ -525,9 +525,9 @@ mod output_features {
         let known_size = features.consensus_encode_exact_size();
         let mut buf = Vec::with_capacity(known_size);
         assert_eq!(known_size, 21);
-        let written = features.consensus_encode(&mut buf).unwrap();
+        features.consensus_encode(&mut buf).unwrap();
         assert_eq!(buf.len(), 21);
-        assert_eq!(written, 21);
+        assert_eq!(features.consensus_encode_exact_size(), 21);
         let decoded_features = OutputFeatures::consensus_decode(&mut &buf[..]).unwrap();
         assert_eq!(features, decoded_features);
     }

--- a/base_layer/core/src/transactions/transaction_components/transaction_input.rs
+++ b/base_layer/core/src/transactions/transaction_components/transaction_input.rs
@@ -432,12 +432,12 @@ impl Ord for TransactionInput {
 }
 
 impl ConsensusEncoding for TransactionInput {
-    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<usize, io::Error> {
-        let mut written = self.version.consensus_encode(writer)?;
-        written += self.spent_output.consensus_encode(writer)?;
-        written += self.input_data.consensus_encode(writer)?;
-        written += self.script_signature.consensus_encode(writer)?;
-        Ok(written)
+    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<(), io::Error> {
+        self.version.consensus_encode(writer)?;
+        self.spent_output.consensus_encode(writer)?;
+        self.input_data.consensus_encode(writer)?;
+        self.script_signature.consensus_encode(writer)?;
+        Ok(())
     }
 }
 
@@ -477,9 +477,9 @@ impl SpentOutput {
 }
 
 impl ConsensusEncoding for SpentOutput {
-    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<usize, io::Error> {
+    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<(), io::Error> {
         writer.write_all(&[self.get_type()])?;
-        let written = match self {
+        match self {
             SpentOutput::OutputHash(hash) => hash.consensus_encode(writer)?,
             SpentOutput::OutputData {
                 version,
@@ -489,16 +489,15 @@ impl ConsensusEncoding for SpentOutput {
                 sender_offset_public_key,
                 covenant,
             } => {
-                let mut write = version.consensus_encode(writer)?;
-                write += features.consensus_encode(writer)?;
-                write += commitment.consensus_encode(writer)?;
-                write += script.consensus_encode(writer)?;
-                write += sender_offset_public_key.consensus_encode(writer)?;
-                write += covenant.consensus_encode(writer)?;
-                write
+                version.consensus_encode(writer)?;
+                features.consensus_encode(writer)?;
+                commitment.consensus_encode(writer)?;
+                script.consensus_encode(writer)?;
+                sender_offset_public_key.consensus_encode(writer)?;
+                covenant.consensus_encode(writer)?;
             },
         };
-        Ok(written + 1)
+        Ok(())
     }
 }
 

--- a/base_layer/core/src/transactions/transaction_components/transaction_input_version.rs
+++ b/base_layer/core/src/transactions/transaction_components/transaction_input_version.rs
@@ -42,9 +42,9 @@ impl TryFrom<u8> for TransactionInputVersion {
 }
 
 impl ConsensusEncoding for TransactionInputVersion {
-    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<usize, io::Error> {
+    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<(), io::Error> {
         writer.write_all(&[self.as_u8()])?;
-        Ok(1)
+        Ok(())
     }
 }
 
@@ -67,9 +67,9 @@ impl ConsensusDecoding for TransactionInputVersion {
 
 #[cfg(test)]
 mod test {
-    use std::io::Cursor;
 
     use super::*;
+    use crate::consensus::check_consensus_encoding_correctness;
 
     #[test]
     fn test_as_u8() {
@@ -92,22 +92,6 @@ mod test {
 
     #[test]
     fn test_decode_encode() {
-        let mut buffer = Cursor::new(vec![
-            0;
-            TransactionInputVersion::get_current_version()
-                .consensus_encode_exact_size()
-        ]);
-        assert_eq!(
-            TransactionInputVersion::get_current_version()
-                .consensus_encode(&mut buffer)
-                .unwrap(),
-            TransactionInputVersion::get_current_version().consensus_encode_exact_size()
-        );
-        // Reset the buffer to original position, we are going to read.
-        buffer.set_position(0);
-        assert_eq!(
-            TransactionInputVersion::consensus_decode(&mut buffer).unwrap(),
-            TransactionInputVersion::get_current_version()
-        );
+        check_consensus_encoding_correctness(TransactionInputVersion::get_current_version()).unwrap();
     }
 }

--- a/base_layer/core/src/transactions/transaction_components/transaction_kernel.rs
+++ b/base_layer/core/src/transactions/transaction_components/transaction_kernel.rs
@@ -161,14 +161,14 @@ impl Ord for TransactionKernel {
 }
 
 impl ConsensusEncoding for TransactionKernel {
-    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<usize, io::Error> {
-        let mut written = self.version.consensus_encode(writer)?;
-        written += self.features.consensus_encode(writer)?;
-        written += self.fee.consensus_encode(writer)?;
-        written += self.lock_height.consensus_encode(writer)?;
-        written += self.excess.consensus_encode(writer)?;
-        written += self.excess_sig.consensus_encode(writer)?;
-        Ok(written)
+    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<(), io::Error> {
+        self.version.consensus_encode(writer)?;
+        self.features.consensus_encode(writer)?;
+        self.fee.consensus_encode(writer)?;
+        self.lock_height.consensus_encode(writer)?;
+        self.excess.consensus_encode(writer)?;
+        self.excess_sig.consensus_encode(writer)?;
+        Ok(())
     }
 }
 

--- a/base_layer/core/src/transactions/transaction_components/transaction_kernel_version.rs
+++ b/base_layer/core/src/transactions/transaction_components/transaction_kernel_version.rs
@@ -38,9 +38,9 @@ impl TryFrom<u8> for TransactionKernelVersion {
 }
 
 impl ConsensusEncoding for TransactionKernelVersion {
-    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<usize, io::Error> {
+    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<(), io::Error> {
         writer.write_all(&[self.as_u8()])?;
-        Ok(1)
+        Ok(())
     }
 }
 
@@ -63,9 +63,9 @@ impl ConsensusDecoding for TransactionKernelVersion {
 
 #[cfg(test)]
 mod test {
-    use std::io::Cursor;
 
     use super::*;
+    use crate::consensus::check_consensus_encoding_correctness;
 
     #[test]
     fn test_try_from() {
@@ -75,22 +75,6 @@ mod test {
 
     #[test]
     fn test_consensus() {
-        let mut buffer = Cursor::new(vec![
-            0;
-            TransactionKernelVersion::get_current_version()
-                .consensus_encode_exact_size()
-        ]);
-        assert_eq!(
-            TransactionKernelVersion::get_current_version()
-                .consensus_encode(&mut buffer)
-                .unwrap(),
-            TransactionKernelVersion::get_current_version().consensus_encode_exact_size()
-        );
-        // Reset the buffer to original position, we are going to read.
-        buffer.set_position(0);
-        assert_eq!(
-            TransactionKernelVersion::consensus_decode(&mut buffer).unwrap(),
-            TransactionKernelVersion::get_current_version()
-        );
+        check_consensus_encoding_correctness(TransactionKernelVersion::get_current_version()).unwrap();
     }
 }

--- a/base_layer/core/src/transactions/transaction_components/transaction_output.rs
+++ b/base_layer/core/src/transactions/transaction_components/transaction_output.rs
@@ -437,16 +437,16 @@ impl Ord for TransactionOutput {
 }
 
 impl ConsensusEncoding for TransactionOutput {
-    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<usize, io::Error> {
-        let mut written = self.version.consensus_encode(writer)?;
-        written += self.features.consensus_encode(writer)?;
-        written += self.commitment.consensus_encode(writer)?;
-        written += self.proof.consensus_encode(writer)?;
-        written += self.script.consensus_encode(writer)?;
-        written += self.sender_offset_public_key.consensus_encode(writer)?;
-        written += self.metadata_signature.consensus_encode(writer)?;
-        written += self.covenant.consensus_encode(writer)?;
-        Ok(written)
+    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<(), io::Error> {
+        self.version.consensus_encode(writer)?;
+        self.features.consensus_encode(writer)?;
+        self.commitment.consensus_encode(writer)?;
+        self.proof.consensus_encode(writer)?;
+        self.script.consensus_encode(writer)?;
+        self.sender_offset_public_key.consensus_encode(writer)?;
+        self.metadata_signature.consensus_encode(writer)?;
+        self.covenant.consensus_encode(writer)?;
+        Ok(())
     }
 }
 

--- a/base_layer/core/src/transactions/transaction_components/transaction_output_version.rs
+++ b/base_layer/core/src/transactions/transaction_components/transaction_output_version.rs
@@ -64,9 +64,9 @@ impl TryFrom<u8> for TransactionOutputVersion {
 }
 
 impl ConsensusEncoding for TransactionOutputVersion {
-    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<usize, io::Error> {
+    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<(), io::Error> {
         writer.write_all(&[self.as_u8()])?;
-        Ok(1)
+        Ok(())
     }
 }
 
@@ -89,9 +89,9 @@ impl ConsensusDecoding for TransactionOutputVersion {
 
 #[cfg(test)]
 mod test {
-    use std::io::Cursor;
 
     use super::*;
+    use crate::consensus::check_consensus_encoding_correctness;
 
     #[test]
     fn test_try_from() {
@@ -101,23 +101,7 @@ mod test {
     }
 
     #[test]
-    fn test_consensus() {
-        let mut buffer = Cursor::new(vec![
-            0;
-            TransactionOutputVersion::get_current_version()
-                .consensus_encode_exact_size()
-        ]);
-        assert_eq!(
-            TransactionOutputVersion::get_current_version()
-                .consensus_encode(&mut buffer)
-                .unwrap(),
-            TransactionOutputVersion::get_current_version().consensus_encode_exact_size()
-        );
-        // Reset the buffer to original position, we are going to read.
-        buffer.set_position(0);
-        assert_eq!(
-            TransactionOutputVersion::consensus_decode(&mut buffer).unwrap(),
-            TransactionOutputVersion::get_current_version()
-        );
+    fn test_consensus_encoding() {
+        check_consensus_encoding_correctness(TransactionOutputVersion::get_current_version()).unwrap();
     }
 }


### PR DESCRIPTION
Description
---
- Changes ConsensusEncoding trait not to return written bytes

Motivation and Context
---
Returning the number of bytes written from `consensus_encode` is unused, adds cruft to the API, and is error-prone.

This also uncovered some potential bugs where `write` was used instead of `write_all` (must use warnings) 
though this would only be an issue if writing to an `impl Write` that cannot always write all bytes in one go (e.g. network socket)

How Has This Been Tested?
---
Existing tests updated and pass
