### PR TITLE
feat(wallet_ffi): new ffi method to create covenant

### DIFF
--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -189,6 +189,17 @@ struct TariCommitmentSignature *commitment_signature_create_from_bytes(
 // Frees memory for a TariCommitmentSignature
 void commitment_signature_destroy(struct TariCommitmentSignature *com_sig);
 
+/// -------------------------------- Covenant  --------------------------------------------- ///
+
+// Creates a TariCovenant from a ByteVector containing the covenant bytes
+struct TariCovenant *covenant_create_from_bytes(
+    struct ByteVector *covenant_bytes,
+    int *error_out
+);
+
+// Frees memory for a TariCovenant
+void covenant_destroy(struct TariCovenant *covenant);
+
 /// -------------------------------- Seed Words  -------------------------------------------------- ///
 // Create an empty instance of TariSeedWords
 struct TariSeedWords *seed_words_create();

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -199,6 +199,7 @@ struct TariCovenant *covenant_create_from_bytes(
 
 // Frees memory for a TariCovenant
 void covenant_destroy(struct TariCovenant *covenant);
+
 /// -------------------------------- Output Features  --------------------------------------------- ///
 
 // Creates a TariOutputFeatures from byte values


### PR DESCRIPTION
Description
---
* Created a new FFI method to create a covenant object from bytes.
* Updated the C header with the definition of the new method

Motivation and Context
---
Currently the mobile apps cannot properly import faucet UTXOs, as they are passing null values for output features and covenants to the `wallet_import_external_utxo_as_non_rewindable` method, which is not allowed. So the mobile apps needs new FFI methods to create both output features and covenants. This pull request deals with covenants only.

How Has This Been Tested?
---
Created two new unit tests for the new FFI method
