### PR TITLE
test: coverage for rolling average time struct

### DIFF
--- a/base_layer/core/src/common/byte_counter.rs
+++ b/base_layer/core/src/common/byte_counter.rs
@@ -48,3 +48,24 @@ impl io::Write for ByteCounter {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn write_test() {
+        let mut byte_counter = ByteCounter::new();
+        let buf = [0u8, 1u8, 2u8, 3u8];
+        let new_count = byte_counter.write(&buf).unwrap();
+        assert_eq!(byte_counter.get(), new_count);
+    }
+
+    #[test]
+    fn flush_test() {
+        let mut byte_counter = ByteCounter::new();
+        let flushed = byte_counter.flush().unwrap();
+        assert_eq!(flushed, ());
+    }
+}

--- a/base_layer/core/src/common/byte_counter.rs
+++ b/base_layer/core/src/common/byte_counter.rs
@@ -67,7 +67,7 @@ mod test {
     fn flush_test() {
         let mut byte_counter = ByteCounter::new();
         let buf = [0u8, 1u8, 2u8, 3u8];
-        let count_bytes = byte_counter.write(&buf).unwrap();
+        let _count_bytes = byte_counter.write(&buf).unwrap();
         // test passes if the following method does not return an error
         byte_counter.flush().unwrap();
     }

--- a/base_layer/core/src/common/byte_counter.rs
+++ b/base_layer/core/src/common/byte_counter.rs
@@ -67,8 +67,8 @@ mod test {
     fn flush_test() {
         let mut byte_counter = ByteCounter::new();
         let buf = [0u8, 1u8, 2u8, 3u8];
-        byte_counter.write(&buf).unwrap();
-        let flushed = byte_counter.flush().unwrap();
-        assert_eq!(flushed, ());
+        let count_bytes = byte_counter.write(&buf).unwrap();
+        // test passes if the following method does not return an error
+        byte_counter.flush().unwrap();
     }
 }

--- a/base_layer/core/src/common/byte_counter.rs
+++ b/base_layer/core/src/common/byte_counter.rs
@@ -51,8 +51,9 @@ impl io::Write for ByteCounter {
 
 #[cfg(test)]
 mod test {
-    use super::*;
     use std::io::Write;
+
+    use super::*;
 
     #[test]
     fn write_test() {
@@ -65,6 +66,8 @@ mod test {
     #[test]
     fn flush_test() {
         let mut byte_counter = ByteCounter::new();
+        let buf = [0u8, 1u8, 2u8, 3u8];
+        byte_counter.write(&buf).unwrap();
         let flushed = byte_counter.flush().unwrap();
         assert_eq!(flushed, ());
     }

--- a/base_layer/core/src/common/limited_reader.rs
+++ b/base_layer/core/src/common/limited_reader.rs
@@ -51,11 +51,11 @@ impl<R: Read> Read for LimitedBytesReader<R> {
     }
 }
 
-
 #[cfg(test)]
 mod test {
-    use super::*;
     use std::io::Read;
+
+    use super::*;
 
     #[test]
     fn read_test() {

--- a/base_layer/core/src/common/limited_reader.rs
+++ b/base_layer/core/src/common/limited_reader.rs
@@ -50,3 +50,25 @@ impl<R: Read> Read for LimitedBytesReader<R> {
         Ok(read)
     }
 }
+
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::io::Read;
+
+    #[test]
+    fn read_test() {
+        // read should work fine in the case of a buffer whose length is within byte_limit
+        let inner: &[u8] = &[0u8, 1u8, 2u8, 3u8, 4u8];
+        let mut reader = LimitedBytesReader::new(3, inner);
+        let mut buf = [0u8; 3];
+        let output = reader.read(&mut buf).unwrap();
+        assert_eq!(output, buf.len());
+
+        // in case of buffer with length strictly bigger than reader byte_limit, the code should throw an error
+        let mut new_buf = [0u8; 4];
+        let output = reader.read(&mut new_buf);
+        assert!(output.is_err());
+    }
+}

--- a/base_layer/core/src/common/rolling_avg.rs
+++ b/base_layer/core/src/common/rolling_avg.rs
@@ -68,7 +68,6 @@ impl RollingAverageTime {
     }
 }
 
-
 #[cfg(test)]
 mod test {
     use super::*;
@@ -97,7 +96,7 @@ mod test {
         subject.add_sample(Duration::new(1, 0));
 
         assert_eq!(subject.calculate_average(), Some(Duration::new(1, 0)));
-        
+
         // insert new element pos full capacity and resulting average
         subject.add_sample(Duration::new(1, 1));
         assert_eq!(subject.calculate_average(), Some(Duration::new(1, 1)));
@@ -105,9 +104,9 @@ mod test {
 
     #[test]
     fn calculate_correct_average_with_multiple_durations() {
-        // test for average calculation over multiple Duration elements 
+        // test for average calculation over multiple Duration elements
         let mut subject = RollingAverageTime::new(3);
-        
+
         // durations
         let duration_1 = Duration::new(1, 999_999_999 as u32);
         let duration_2 = Duration::new(1, 0 as u32);
@@ -119,7 +118,7 @@ mod test {
         subject.add_sample(duration_3);
 
         // compute correct average
-        let correct_avg = (1_999_999_999 + 1_000_000_000 + 999_999_999)  / subject.samples.len() as u64;
+        let correct_avg = (1_999_999_999 + 1_000_000_000 + 999_999_999) / subject.samples.len() as u64;
         let correct_duration = Some(Duration::from_nanos(correct_avg));
 
         // assert that calculate_average computes the correct average
@@ -141,4 +140,4 @@ mod test {
         let correct_sample_per_second = 1_000_000.0 * ((subject.samples.len() as f64) / total_time);
         assert_eq!(subject.calc_samples_per_second(), Some(correct_sample_per_second));
     }
-}  
+}

--- a/base_layer/core/src/common/rolling_avg.rs
+++ b/base_layer/core/src/common/rolling_avg.rs
@@ -108,9 +108,9 @@ mod test {
         let mut subject = RollingAverageTime::new(3);
 
         // durations
-        let duration_1 = Duration::new(1, 999_999_999 as u32);
-        let duration_2 = Duration::new(1, 0 as u32);
-        let duration_3 = Duration::new(0, 999_999_999 as u32);
+        let duration_1 = Duration::new(1, 999_999_999_u32);
+        let duration_2 = Duration::new(1, 0_u32);
+        let duration_3 = Duration::new(0, 999_999_999_u32);
 
         // add samples
         subject.add_sample(duration_1);
@@ -136,7 +136,7 @@ mod test {
         subject.add_sample(Duration::new(0, 1));
 
         // assert that samples per second is correctly defined
-        let total_time = 2_000_000 as f64;
+        let total_time = 2_000_000_f64;
         let correct_sample_per_second = 1_000_000.0 * ((subject.samples.len() as f64) / total_time);
         assert_eq!(subject.calc_samples_per_second(), Some(correct_sample_per_second));
     }

--- a/base_layer/core/src/common/rolling_avg.rs
+++ b/base_layer/core/src/common/rolling_avg.rs
@@ -75,56 +75,68 @@ mod test {
 
     #[test]
     fn empty_average_is_none() {
-        let subject = RollingAverageTime::new(0);
+        // zero capacity RollingAverageTime
+        let mut subject = RollingAverageTime::new(0);
 
+        // average should assert to None (as there are no elements to compute average from)
         assert_eq!(subject.calculate_average(), None);
         assert_eq!(subject.calculate_average_with_min_samples(0), None);
-    }
+        assert_eq!(subject.samples.len(), 0);
 
-    #[test]
-    fn calculate_correct_average_with_multiple_durations() {
-        let mut subject = RollingAverageTime::new(3);
-
-        let duration_1 = Duration::new(1, 999_999_999 as u32);
-        let duration_2 = Duration::new(1, 0 as u32);
-        let duration_3 = Duration::new(0, 999_999_999 as u32);
-
-        subject.add_sample(duration_1);
-        subject.add_sample(duration_2);
-        subject.add_sample(duration_3);
-
-        let correct_avg = (1_999_999_999 + 1_000_000_000 + 999_999_999)  / subject.samples.len() as u64;
-        let correct_duration = Some(Duration::from_nanos(correct_avg));
-
-        let output_avg = subject.calculate_average();
-        assert_eq!(output_avg, correct_duration);
+        // re-test logic after adding sample
+        subject.add_sample(Duration::new(0, 999_999_999 as u32));
+        assert_eq!(subject.calculate_average(), None);
+        assert_eq!(subject.calculate_average_with_min_samples(0), None);
+        assert_eq!(subject.samples.len(), 0);
     }
 
     #[test]
     fn calculate_correct_average_with_single_duration() {
-        let mut cap_zero_subject = RollingAverageTime::new(0);
-        
-        cap_zero_subject.add_sample(Duration::new(0, 999_999_999 as u32));
-        assert_eq!(cap_zero_subject.samples.len(), 0);
-
+        // test case with a single case
         let mut subject = RollingAverageTime::new(1);
         subject.add_sample(Duration::new(1, 0));
 
         assert_eq!(subject.calculate_average(), Some(Duration::new(1, 0)));
         
-        // insert new element pos full capacity
+        // insert new element pos full capacity and resulting average
         subject.add_sample(Duration::new(1, 1));
         assert_eq!(subject.calculate_average(), Some(Duration::new(1, 1)));
+    }
+
+    #[test]
+    fn calculate_correct_average_with_multiple_durations() {
+        // test for average calculation over multiple Duration elements 
+        let mut subject = RollingAverageTime::new(3);
+        
+        // durations
+        let duration_1 = Duration::new(1, 999_999_999 as u32);
+        let duration_2 = Duration::new(1, 0 as u32);
+        let duration_3 = Duration::new(0, 999_999_999 as u32);
+
+        // add samples
+        subject.add_sample(duration_1);
+        subject.add_sample(duration_2);
+        subject.add_sample(duration_3);
+
+        // compute correct average
+        let correct_avg = (1_999_999_999 + 1_000_000_000 + 999_999_999)  / subject.samples.len() as u64;
+        let correct_duration = Some(Duration::from_nanos(correct_avg));
+
+        // assert that calculate_average computes the correct average
+        let output_avg = subject.calculate_average();
+        assert_eq!(output_avg, correct_duration);
     }
 
     #[test]
     fn correct_calc_samples_per_second() {
         let mut subject = RollingAverageTime::new(3);
 
+        // add samples
         subject.add_sample(Duration::new(0, 999_999_999));
         subject.add_sample(Duration::new(1, 0));
         subject.add_sample(Duration::new(0, 1));
 
+        // assert that samples per second is correctly defined
         let total_time = 2_000_000 as f64;
         let correct_sample_per_second = 1_000_000.0 * ((subject.samples.len() as f64) / total_time);
         assert_eq!(subject.calc_samples_per_second(), Some(correct_sample_per_second));

--- a/base_layer/core/src/common/rolling_avg.rs
+++ b/base_layer/core/src/common/rolling_avg.rs
@@ -83,7 +83,7 @@ mod test {
         assert_eq!(subject.samples.len(), 0);
 
         // re-test logic after adding sample
-        subject.add_sample(Duration::new(0, 999_999_999 as u32));
+        subject.add_sample(Duration::new(0, 999_999_999_u32));
         assert_eq!(subject.calculate_average(), None);
         assert_eq!(subject.calculate_average_with_min_samples(0), None);
         assert_eq!(subject.samples.len(), 0);

--- a/common/src/build/protobuf.rs
+++ b/common/src/build/protobuf.rs
@@ -210,3 +210,10 @@ impl ProtobufCompiler {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    
+}

--- a/common/src/build/protobuf.rs
+++ b/common/src/build/protobuf.rs
@@ -210,10 +210,3 @@ impl ProtobufCompiler {
         Ok(())
     }
 }
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    
-}


### PR DESCRIPTION
Description

- Add test coverage at `base_layer/core/src/common/...`

Motivation and Context

- Some additional coverage needs to be added to the code base . This PR adds a few of additional tests to cover logic regarding RollingAverageTime struct, etc.

How Has This Been Tested?

- We added tests for each of the present methods in the modified files.

