### PR TITLE
fix: tx importing status to correctly reflect the origin

### DIFF
--- a/base_layer/core/src/mempool/unconfirmed_pool/unconfirmed_pool.rs
+++ b/base_layer/core/src/mempool/unconfirmed_pool/unconfirmed_pool.rs
@@ -566,10 +566,7 @@ impl UnconfirmedPool {
             let mut max_fee_per_gram = MicroTari::zero();
             let mut last_count = 0;
             for (i, key) in self.tx_by_priority.values().rev().enumerate().skip(offset) {
-                let tx = self
-                    .tx_by_key
-                    .get(key)
-                    .ok_or_else(|| UnconfirmedPoolError::StorageOutofSync)?;
+                let tx = self.tx_by_key.get(key).ok_or(UnconfirmedPoolError::StorageOutofSync)?;
                 let weight = tx.weight;
 
                 if total_weight + weight > target_block_weight {
@@ -1088,7 +1085,7 @@ mod test {
             let tx3 = Arc::new(tx3);
             let tx4 = Arc::new(tx4);
             unconfirmed_pool
-                .insert_many(vec![tx1.clone(), tx2.clone(), tx3.clone(), tx4.clone()], &tx_weight)
+                .insert_many(vec![tx1, tx2, tx3, tx4], &tx_weight)
                 .unwrap();
 
             let stats = unconfirmed_pool.get_fee_per_gram_stats(1, 19500).unwrap();

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -756,7 +756,7 @@ where
             let mut client = connectivity
                 .obtain_base_node_wallet_rpc_client()
                 .await
-                .ok_or_else(|| TransactionServiceError::Shutdown)?;
+                .ok_or(TransactionServiceError::Shutdown)?;
 
             let resp = client
                 .get_mempool_fee_per_gram_stats(base_node_proto::GetMempoolFeePerGramStatsRequest {

--- a/base_layer/wallet/tests/transaction_service_tests/service.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/service.rs
@@ -5618,7 +5618,7 @@ fn test_get_fee_per_gram_per_block_basic() {
     let factories = CryptoFactories::default();
     let mut runtime = Runtime::new().unwrap();
     let (connection, _temp_dir) = make_wallet_database_connection(None);
-    let mut alice_ts_interface = setup_transaction_service_no_comms(&mut runtime, factories.clone(), connection, None);
+    let mut alice_ts_interface = setup_transaction_service_no_comms(&mut runtime, factories, connection, None);
     let stats = vec![base_node_proto::MempoolFeePerGramStat {
         order: 0,
         min_fee_per_gram: 1,


### PR DESCRIPTION
Description
---
Fixes the transaction import status to correctly reflect the origin. 

Motivation and Context
---
We currently always use fauxUnconfirmed for all transactions, this should only be for one-sided and imported for recovered. 



This also fixes some other clippy warnings. 