### PR TITLE
feat: loosen ffi import utxo requirements

### DIFF
--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -468,6 +468,19 @@ int pending_inbound_transaction_get_status(struct TariPendingInboundTransaction 
 // Frees memory for a TariPendingInboundTransaction
 void pending_inbound_transaction_destroy(struct TariPendingInboundTransaction *transaction);
 
+/// -------------------------------- Transport Send Status ------------------------------------------------------ ///
+
+// Decode the transaction send status of a TariTransactionSendStatus
+//     !direct_send & !saf_send &  queued   = 0
+//      direct_send &  saf_send & !queued   = 1
+//      direct_send & !saf_send & !queued   = 2
+//     !direct_send &  saf_send & !queued   = 3
+//     any other combination (is not valid) = 4
+unsigned int fn transaction_send_status_decode(struct TariTransactionSendStatus *status, int *error_out);
+
+// Frees memory for a TariTransactionSendStatus
+void transaction_send_status_destroy(struct TariTransactionSendStatus *status);
+
 /// -------------------------------- InboundTransactions ------------------------------------------------------ ///
 
 // Gets the number of elements in a TariPendingInboundTransactions


### PR DESCRIPTION
Description
---
- Made import UTXO less strict for the FFI - _source public key_, _features_ and _covenant_ are now optional inputs.
- Added missing `TariTransactionSendStatus` decode and destroy methods to the FFI interface file `wallet.h`.

Motivation and Context
---
- The facet is missing some non-critical parameters
- Methods to de-structure `callback_transaction_send_result` were missing in the FFI interface file `wallet.h`.

How Has This Been Tested?
---
Existing unit tests
