### PR TITLE
test: coverage mocks for files common configuration files (PR #4116)

### DIFF
--- a/common/src/build/protobuf.rs
+++ b/common/src/build/protobuf.rs
@@ -210,3 +210,10 @@ impl ProtobufCompiler {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    
+}

--- a/common/src/build/protobuf.rs
+++ b/common/src/build/protobuf.rs
@@ -211,12 +211,3 @@ impl ProtobufCompiler {
     }
 }
 
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    fn rustfmt_test() {
-        let bytes_array = &[0u8, 1u8, 2u8, 3u8];
-        let path = Path::from_u8_slice(bytes_array);
-    }
-}

--- a/common/src/build/protobuf.rs
+++ b/common/src/build/protobuf.rs
@@ -210,4 +210,3 @@ impl ProtobufCompiler {
         Ok(())
     }
 }
-

--- a/common/src/build/protobuf.rs
+++ b/common/src/build/protobuf.rs
@@ -215,5 +215,8 @@ impl ProtobufCompiler {
 mod test {
     use super::*;
 
-    
+    fn rustfmt_test() {
+        let bytes_array = &[0u8, 1u8, 2u8, 3u8];
+        let path = Path::from_u8_slice(bytes_array);
+    }
 }

--- a/common/src/configuration/bootstrap.rs
+++ b/common/src/configuration/bootstrap.rs
@@ -96,7 +96,6 @@ impl Display for ApplicationType {
     }
 }
 
-
 #[cfg(test)]
 mod test {
     use super::*;
@@ -141,7 +140,7 @@ mod test {
         let stratum_transcoder = ApplicationType::from_str("stratum-proxy").unwrap();
         let validator = ApplicationType::from_str("validator-node").unwrap();
 
-        // asserts 
+        // asserts
         assert!(matches!(node, ApplicationType::BaseNode));
         assert!(matches!(wallet, ApplicationType::ConsoleWallet));
         assert!(matches!(mm_proxy, ApplicationType::MergeMiningProxy));

--- a/common/src/configuration/bootstrap.rs
+++ b/common/src/configuration/bootstrap.rs
@@ -84,6 +84,7 @@ impl FromStr for ApplicationType {
             "miner" => Ok(Miner),
             "validator-node" => Ok(ValidatorNode),
             "stratum-proxy" => Ok(StratumTranscoder),
+            "collectibles" => Ok(Collectibles),
             _ => Err(ConfigError::new("Invalid ApplicationType", None)),
         }
     }
@@ -139,6 +140,7 @@ mod test {
         let miner = ApplicationType::from_str("miner").unwrap();
         let stratum_transcoder = ApplicationType::from_str("stratum-proxy").unwrap();
         let validator = ApplicationType::from_str("validator-node").unwrap();
+        let collectibles = ApplicationType::from_str("collectibles").unwrap();
 
         // asserts
         assert!(matches!(node, ApplicationType::BaseNode));
@@ -147,6 +149,7 @@ mod test {
         assert!(matches!(miner, ApplicationType::Miner));
         assert!(matches!(stratum_transcoder, ApplicationType::StratumTranscoder));
         assert!(matches!(validator, ApplicationType::ValidatorNode));
+        assert!(matches!(collectibles, ApplicationType::Collectibles));
 
         // in case of a non-specific message we should throw an error
         assert!(ApplicationType::from_str("random message").is_err());

--- a/common/src/configuration/bootstrap.rs
+++ b/common/src/configuration/bootstrap.rs
@@ -147,5 +147,8 @@ mod test {
         assert!(matches!(miner, ApplicationType::Miner));
         assert!(matches!(stratum_transcoder, ApplicationType::StratumTranscoder));
         assert!(matches!(validator, ApplicationType::ValidatorNode));
+
+        // in case of a non-specific message we should throw an error
+        assert!(ApplicationType::from_str("random message").is_err());
     }
 }

--- a/common/src/configuration/bootstrap.rs
+++ b/common/src/configuration/bootstrap.rs
@@ -95,3 +95,58 @@ impl Display for ApplicationType {
         Ok(())
     }
 }
+
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn application_type_as_str_test() {
+        // get application type's
+        let base_node = ApplicationType::BaseNode;
+        let console_wallet = ApplicationType::ConsoleWallet;
+        let mm_proxy = ApplicationType::MergeMiningProxy;
+        let miner = ApplicationType::Miner;
+        let stratum_transcoder = ApplicationType::StratumTranscoder;
+        let validator_node = ApplicationType::ValidatorNode;
+        let collectibles = ApplicationType::Collectibles;
+
+        // test `as_str` method
+        assert_eq!(base_node.as_str(), "Tari Base Node");
+        assert_eq!(console_wallet.as_str(), "Tari Console Wallet");
+        assert_eq!(mm_proxy.as_str(), "Tari Merge Mining Proxy");
+        assert_eq!(miner.as_str(), "Tari Miner");
+        assert_eq!(stratum_transcoder.as_str(), "Tari Stratum Transcoder");
+        assert_eq!(validator_node.as_str(), "Digital Assets Network Validator Node");
+        assert_eq!(collectibles.as_str(), "Tari Collectibles");
+
+        // test `as_config_str` method
+        assert_eq!(base_node.as_config_str(), "base_node");
+        assert_eq!(console_wallet.as_config_str(), "wallet");
+        assert_eq!(mm_proxy.as_config_str(), "merge_mining_proxy");
+        assert_eq!(miner.as_config_str(), "miner");
+        assert_eq!(stratum_transcoder.as_config_str(), "stratum-transcoder");
+        assert_eq!(validator_node.as_config_str(), "validator-node");
+        assert_eq!(collectibles.as_config_str(), "collectibles");
+    }
+
+    #[test]
+    fn application_type_from_str_test() {
+        // get application type's
+        let node = ApplicationType::from_str("base-node").unwrap();
+        let wallet = ApplicationType::from_str("console-wallet").unwrap();
+        let mm_proxy = ApplicationType::from_str("mm-proxy").unwrap();
+        let miner = ApplicationType::from_str("miner").unwrap();
+        let stratum_transcoder = ApplicationType::from_str("stratum-proxy").unwrap();
+        let validator = ApplicationType::from_str("validator-node").unwrap();
+
+        // asserts 
+        assert!(matches!(node, ApplicationType::BaseNode));
+        assert!(matches!(wallet, ApplicationType::ConsoleWallet));
+        assert!(matches!(mm_proxy, ApplicationType::MergeMiningProxy));
+        assert!(matches!(miner, ApplicationType::Miner));
+        assert!(matches!(stratum_transcoder, ApplicationType::StratumTranscoder));
+        assert!(matches!(validator, ApplicationType::ValidatorNode));
+    }
+}

--- a/common/src/configuration/common_config.rs
+++ b/common/src/configuration/common_config.rs
@@ -56,3 +56,26 @@ impl CommonConfig {
         &self.base_path
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn default_common_config() {
+        let default_common_config = CommonConfig::default();
+
+        assert!(matches!(default_common_config.override_from, None));
+        assert_eq!(
+            *default_common_config.base_path(),
+            dirs_next::home_dir()
+                .unwrap_or_else(|| PathBuf::from("."))
+                .join(PathBuf::from(".tari"))
+        );
+    }
+
+    #[test]
+    fn main_key_prefix_test() {
+        assert_eq!(CommonConfig::main_key_prefix(), "common");
+    }
+}

--- a/common/src/configuration/error.rs
+++ b/common/src/configuration/error.rs
@@ -37,3 +37,34 @@ impl From<ClapError> for ConfigError {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use structopt::clap::{Error as ClapError, ErrorKind};
+
+    use super::*;
+
+    #[test]
+    fn config_error_test() {
+        // new config error
+        let config_error = ConfigError::new("testing", Some(String::from("coverage")));
+
+        // test formatting
+        assert_eq!(format!("{}", config_error), "testing: coverage");
+
+        // create new error
+        let clap_error = ClapError {
+            message: String::from("error"),
+            kind: ErrorKind::InvalidValue,
+            info: Some(vec![String::from("for test purposes")]),
+        };
+        // get clap error string
+        let clap_error_str = clap_error.to_string();
+        // create a new config error from clap error
+        let new_config_error = ConfigError::from(clap_error);
+
+        // test specification of config error from clap error
+        assert_eq!(new_config_error.cause, "Failed to process commandline parameters");
+        assert_eq!(new_config_error.source, Some(clap_error_str));
+    }
+}

--- a/common/src/configuration/loader.rs
+++ b/common/src/configuration/loader.rs
@@ -348,12 +348,15 @@ impl From<serde_json::error::Error> for ConfigurationError {
 
 #[cfg(test)]
 mod test {
-    use crate::ConfigurationError;
+    use config::ConfigError;
 
     #[test]
     fn configuration_error() {
         let e = ConfigurationError::new("test", None, "is a string");
         assert_eq!(e.to_string(), "Invalid value for `test`: is a string");
+
+        let frozen_e = ConfigurationError::from(ConfigError::Frozen);
+        assert_eq!(frozen_e.to_string(), "Invalid value for ``: configuration is frozen");
     }
 
     use serde::{Deserialize, Serialize};

--- a/common/src/configuration/mod.rs
+++ b/common/src/configuration/mod.rs
@@ -64,3 +64,32 @@ pub fn socket_or_multi(addr: &str) -> Result<Multiaddr, Error> {
         })
         .or_else(|_| addr.parse::<Multiaddr>())
 }
+
+#[cfg(test)]
+mod test {
+    use std::net::{Ipv4Addr, Ipv6Addr};
+
+    use super::*;
+
+    #[test]
+    fn socket_or_multi_test() {
+        let v4_addr = "127.0.0.1:8080";
+        let multi_v4_addr = socket_or_multi(v4_addr).unwrap();
+        // ipv4 testing
+        assert_eq!(
+            multi_v4_addr,
+            Multiaddr::from_iter([Protocol::Ip4(Ipv4Addr::new(127, 0, 0, 1)), Protocol::Tcp(8080)])
+        );
+
+        let v6_addr = "[2001:db8::1]:8080";
+        let multi_v6_addr = socket_or_multi(v6_addr).unwrap();
+        // ipv6 testing
+        assert_eq!(
+            multi_v6_addr,
+            Multiaddr::from_iter([
+                Protocol::Ip6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1)),
+                Protocol::Tcp(8080)
+            ])
+        );
+    }
+}

--- a/common/src/configuration/name_server.rs
+++ b/common/src/configuration/name_server.rs
@@ -62,3 +62,26 @@ impl FromStr for DnsNameServer {
         })
     }
 }
+
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::net::{ SocketAddr, IpAddr, Ipv4Addr };
+
+    #[test]
+    fn dns_name_server_test() {
+        // create dns name server
+        let ipv4 = Ipv4Addr::new(127, 0, 0, 1);
+        let ip = IpAddr::V4(ipv4);
+        let socket = SocketAddr::new(ip, 8080);
+        let dns = DnsNameServer::new(socket, String::from("my_dns"));
+
+        // test formatting
+        assert_eq!(format!("{}", dns), "127.0.0.1:8080/my_dns");
+
+        // from str 
+        let new_dns = DnsNameServer::from_str("127.0.0.1:8080/my_dns").unwrap();
+        assert_eq!(new_dns, dns);
+    }
+}

--- a/common/src/configuration/name_server.rs
+++ b/common/src/configuration/name_server.rs
@@ -63,11 +63,11 @@ impl FromStr for DnsNameServer {
     }
 }
 
-
 #[cfg(test)]
 mod test {
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
     use super::*;
-    use std::net::{ SocketAddr, IpAddr, Ipv4Addr };
 
     #[test]
     fn dns_name_server_test() {
@@ -80,7 +80,7 @@ mod test {
         // test formatting
         assert_eq!(format!("{}", dns), "127.0.0.1:8080/my_dns");
 
-        // from str 
+        // from str
         let new_dns = DnsNameServer::from_str("127.0.0.1:8080/my_dns").unwrap();
         assert_eq!(new_dns, dns);
     }

--- a/common/src/configuration/network.rs
+++ b/common/src/configuration/network.rs
@@ -113,3 +113,67 @@ impl Display for Network {
         f.write_str(self.as_key_str())
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn network_bytes() { 
+        // get networks
+        let mainnet = Network::MainNet;
+        let localnet = Network::LocalNet;
+        let ridcully = Network::Ridcully;
+        let stibbons = Network::Stibbons;
+        let weatherwas = Network::Weatherwax;
+        let igor = Network::Igor;
+        let dibbler = Network::Dibbler;
+
+        // test .as_byte()
+        assert_eq!(mainnet.as_byte(), 0x00 as u8);
+        assert_eq!(localnet.as_byte(), 0x10 as u8);
+        assert_eq!(ridcully.as_byte(), 0x21 as u8);
+        assert_eq!(stibbons.as_byte(), 0x22 as u8);
+        assert_eq!(weatherwas.as_byte(), 0xa3 as u8);
+        assert_eq!(igor.as_byte(), 0x24 as u8);
+        assert_eq!(dibbler.as_byte(), 0x25 as u8);
+
+        // test .as_key_str() 
+        assert_eq!(mainnet.as_key_str(), "mainnet");
+        assert_eq!(localnet.as_key_str(), "localnet");
+        assert_eq!(ridcully.as_key_str(), "ridcully");
+        assert_eq!(stibbons.as_key_str(), "stibbons");
+        assert_eq!(weatherwas.as_key_str(), "weatherwax");
+        assert_eq!(igor.as_key_str(), "igor");
+        assert_eq!(dibbler.as_key_str(), "dibbler");
+    }
+
+    #[test]
+    fn network_default() {
+        let network = Network::default();
+        assert_eq!(network, Network::MainNet);
+    }
+
+    #[test]
+    fn network_from_str() {
+        let mainnet_str = "mainnet";
+        let localnet_str = "localnet";
+        let ridcully_str = "ridcully";
+        let stibbons_str = "stibbons";
+        let weatherwas_str = "weatherwax";
+        let igor_str = "igor";
+        let dibbler_str = "dibbler";
+
+        // test .from_str()
+        assert_eq!(Network::from_str(mainnet_str).unwrap(), Network::MainNet);
+        assert_eq!(Network::from_str(localnet_str).unwrap(), Network::LocalNet);
+        assert_eq!(Network::from_str(ridcully_str).unwrap(), Network::Ridcully);
+        assert_eq!(Network::from_str(stibbons_str).unwrap(), Network::Stibbons);
+        assert_eq!(Network::from_str(weatherwas_str).unwrap(), Network::Weatherwax);
+        assert_eq!(Network::from_str(igor_str).unwrap(), Network::Igor);
+        assert_eq!(Network::from_str(dibbler_str).unwrap(), Network::Dibbler);
+        // catch error case  
+        let err_network = Network::from_str("invalid network");
+        assert!(err_network.is_err());
+    }
+}

--- a/common/src/configuration/network.rs
+++ b/common/src/configuration/network.rs
@@ -119,7 +119,7 @@ mod test {
     use super::*;
 
     #[test]
-    fn network_bytes() { 
+    fn network_bytes() {
         // get networks
         let mainnet = Network::MainNet;
         let localnet = Network::LocalNet;
@@ -138,7 +138,7 @@ mod test {
         assert_eq!(igor.as_byte(), 0x24 as u8);
         assert_eq!(dibbler.as_byte(), 0x25 as u8);
 
-        // test .as_key_str() 
+        // test .as_key_str()
         assert_eq!(mainnet.as_key_str(), "mainnet");
         assert_eq!(localnet.as_key_str(), "localnet");
         assert_eq!(ridcully.as_key_str(), "ridcully");
@@ -172,7 +172,7 @@ mod test {
         assert_eq!(Network::from_str(weatherwas_str).unwrap(), Network::Weatherwax);
         assert_eq!(Network::from_str(igor_str).unwrap(), Network::Igor);
         assert_eq!(Network::from_str(dibbler_str).unwrap(), Network::Dibbler);
-        // catch error case  
+        // catch error case
         let err_network = Network::from_str("invalid network");
         assert!(err_network.is_err());
     }

--- a/common/src/configuration/string_list.rs
+++ b/common/src/configuration/string_list.rs
@@ -148,6 +148,39 @@ mod tests {
     }
 
     #[test]
+    fn with_capacity_test() {
+        let new_str_lst = StringList::with_capacity(3);
+        assert_eq!(new_str_lst.into_vec().capacity(), 3);
+    }
+
+    #[test]
+    fn from_vec_string_list() {
+        let vec_string = vec![String::from("random")];
+        let string_lst = StringList::from(vec_string);
+        assert_eq!(string_lst.into_vec(), vec![String::from("new")]);
+    }
+
+    #[test]
+    fn as_ref_string_list() {
+        let vec_string = vec![String::from("Tari")];
+        let vec_as_ref: &[String] = vec_string.as_ref();
+        let string_lst = StringList::from(vec![String::from("Tari")]);
+        assert_eq!(string_lst.as_ref(), vec_as_ref);
+    }
+
+    #[test]
+    fn into_iter_string_list() {
+        let vec_string = vec![String::from("Tari"), String::from("Project"), String::from("let's mine it!")];
+        let string_lst = StringList::from(vec_string);
+        let mut res_iter = string_lst.into_iter();
+
+        assert_eq!(Some(String::from("Tari")), res_iter.next());
+        assert_eq!(Some(String::from("Project")), res_iter.next());
+        assert_eq!(Some(String::from("let's mine it!")), res_iter.next());
+        assert_eq!(None, res_iter.into_iter().next());
+    }
+
+    #[test]
     fn it_deserializes_from_toml() {
         let config_str = r#"something = ["a","b","c"]"#;
         let test = toml::from_str::<Test>(config_str).unwrap();

--- a/common/src/configuration/string_list.rs
+++ b/common/src/configuration/string_list.rs
@@ -155,9 +155,9 @@ mod tests {
 
     #[test]
     fn from_vec_string_list() {
-        let vec_string = vec![String::from("random")];
+        let vec_string = vec![String::from("Tari is cool!")];
         let string_lst = StringList::from(vec_string);
-        assert_eq!(string_lst.into_vec(), vec![String::from("new")]);
+        assert_eq!(string_lst.into_vec(), vec![String::from("Tari is cool!")]);
     }
 
     #[test]
@@ -170,7 +170,11 @@ mod tests {
 
     #[test]
     fn into_iter_string_list() {
-        let vec_string = vec![String::from("Tari"), String::from("Project"), String::from("let's mine it!")];
+        let vec_string = vec![
+            String::from("Tari"),
+            String::from("Project"),
+            String::from("let's mine it!"),
+        ];
         let string_lst = StringList::from(vec_string);
         let mut res_iter = string_lst.into_iter();
 


### PR DESCRIPTION
Description

- We add simple mock tests to common configuration files (in `common/src/configuration/...`).

Motivation and Context

- The current code repository lacks test coverage in many files in the `common` folder. Our goal is to add some of needed test coverage.

How Has This Been Tested?

- Since the referred files usually contain simple logic, we added simple tests to cover mimic base usage of the implemented methods.
