### PR TITLE
fix(dht): optimisation, no decrypt if public key dest doesn't match

### DIFF
--- a/comms/dht/src/inbound/decryption.rs
+++ b/comms/dht/src/inbound/decryption.rs
@@ -197,6 +197,7 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
         }
     }
 
+    #[allow(clippy::too_many_lines)]
     async fn validate_and_decrypt_message(
         node_identity: Arc<NodeIdentity>,
         message: DhtInboundMessage,
@@ -218,6 +219,24 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
         // Check if there is no destination specified and discard
         if dht_header.destination.is_unknown() {
             return Err(DecryptionError::EncryptedMessageNoDestination);
+        }
+
+        if !message.dht_header.destination.is_unknown() &&
+            message
+                .dht_header
+                .destination
+                .public_key()
+                .map(|pk| pk != node_identity.public_key())
+                .unwrap_or(false)
+        {
+            debug!(
+                target: LOG_TARGET,
+                "Encrypted message (source={}, {}) not destined for this peer. Passing to next service (Trace: {})",
+                message.source_peer.node_id,
+                message.dht_header.message_tag,
+                message.tag
+            );
+            return Ok(DecryptedDhtMessage::failed(message));
         }
 
         let e_pk = dht_header


### PR DESCRIPTION
Description
---
Don't attempt decryption if the public key destination does not match the node identity

Motivation and Context
---
Decryption is not necessary if the destination public key is specified and does not match.

How Has This Been Tested?
---
Manually, Memorynet and existing tests that check this case already pass.

