### PR TITLE
feat(core): add contract acceptance utxo features

### DIFF
--- a/applications/tari_app_grpc/proto/types.proto
+++ b/applications/tari_app_grpc/proto/types.proto
@@ -232,6 +232,7 @@ message SideChainFeatures {
     bytes contract_id = 1;
     ContractDefinition definition = 2;
     ContractConstitution constitution = 3;
+    ContractAcceptance acceptance = 4;
 }
 
 message ContractConstitution {
@@ -326,6 +327,11 @@ message PublicFunction {
 message FunctionRef {
     bytes template_id = 1;
     uint32 function_id = 2;
+}
+
+message ContractAcceptance {
+    bytes validator_node_public_key = 1;
+    Signature signature = 2;
 }
 
 // The components of the block or transaction. The same struct can be used for either, since in Mimblewimble,

--- a/applications/tari_app_grpc/src/conversions/signature.rs
+++ b/applications/tari_app_grpc/src/conversions/signature.rs
@@ -38,3 +38,12 @@ impl TryFrom<grpc::Signature> for Signature {
         Ok(Self::new(public_nonce, signature))
     }
 }
+
+impl From<Signature> for grpc::Signature {
+    fn from(sig: Signature) -> Self {
+        Self {
+            public_nonce: sig.get_public_nonce().to_vec(),
+            signature: sig.get_signature().to_vec(),
+        }
+    }
+}

--- a/base_layer/core/src/proto/transaction.proto
+++ b/base_layer/core/src/proto/transaction.proto
@@ -105,6 +105,7 @@ message SideChainFeatures {
     bytes contract_id = 1;
     ContractDefinition definition = 2;
     ContractConstitution constitution = 3;
+    ContractAcceptance acceptance = 4;
 }
 
 message ContractConstitution {
@@ -198,6 +199,11 @@ message PublicFunction {
 message FunctionRef {
     bytes template_id = 1;
     uint32 function_id = 2;
+}
+
+message ContractAcceptance {
+    bytes validator_node_public_key = 1;
+    Signature signature = 2;
 }
 
 // The components of the block or transaction. The same struct can be used for either, since in Mimblewimble,

--- a/base_layer/core/src/transactions/transaction_components/output_features.rs
+++ b/base_layer/core/src/transactions/transaction_components/output_features.rs
@@ -443,6 +443,8 @@ impl Display for OutputFeatures {
 mod test {
     use std::{convert::TryInto, io::ErrorKind, iter};
 
+    use tari_common_types::types::Signature;
+
     use super::*;
     use crate::{
         consensus::check_consensus_encoding_correctness,
@@ -457,6 +459,7 @@ mod test {
                 SideChainConsensus,
             },
             vec_into_fixed_string,
+            ContractAcceptance,
             ContractConstitution,
             ContractDefinition,
             ContractSpecification,
@@ -527,6 +530,10 @@ mod test {
                             },
                         ],
                     },
+                }),
+                acceptance: Some(ContractAcceptance {
+                    validator_node_public_key: PublicKey::default(),
+                    signature: Signature::default(),
                 }),
             }),
             // Deprecated

--- a/base_layer/core/src/transactions/transaction_components/side_chain/contract_acceptance.rs
+++ b/base_layer/core/src/transactions/transaction_components/side_chain/contract_acceptance.rs
@@ -20,31 +20,53 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-mod contract_acceptance;
-pub use contract_acceptance::ContractAcceptance;
+use std::io::{Error, Read, Write};
 
-mod contract_constitution;
-pub use contract_constitution::{
-    CheckpointParameters,
-    ConstitutionChangeFlags,
-    ConstitutionChangeRules,
-    ContractAcceptanceRequirements,
-    ContractConstitution,
-    RequirementsForConstitutionChange,
-    SideChainConsensus,
-};
+use serde::{Deserialize, Serialize};
+use tari_common_types::types::{PublicKey, Signature};
 
-mod contract_definition;
-pub use contract_definition::{
-    vec_into_fixed_string,
-    ContractDefinition,
-    ContractSpecification,
-    FunctionRef,
-    PublicFunction,
-};
+use crate::consensus::{ConsensusDecoding, ConsensusEncoding, ConsensusEncodingSized};
 
-mod committee_members;
-pub use committee_members::CommitteeMembers;
+#[derive(Debug, Clone, Hash, PartialEq, Deserialize, Serialize, Eq)]
+pub struct ContractAcceptance {
+    validator_node_public_key: PublicKey,
+    signature: Signature,
+}
 
-mod sidechain_features;
-pub use sidechain_features::{SideChainFeatures, SideChainFeaturesBuilder};
+impl ConsensusEncoding for ContractAcceptance {
+    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
+        self.validator_node_public_key.consensus_encode(writer)?;
+        self.signature.consensus_encode(writer)?;
+
+        Ok(())
+    }
+}
+
+impl ConsensusEncodingSized for ContractAcceptance {}
+
+impl ConsensusDecoding for ContractAcceptance {
+    fn consensus_decode<R: Read>(reader: &mut R) -> Result<Self, Error> {
+        Ok(Self {
+            validator_node_public_key: PublicKey::consensus_decode(reader)?,
+            signature: Signature::consensus_decode(reader)?,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tari_common_types::types::PublicKey;
+
+    use super::*;
+    use crate::consensus::check_consensus_encoding_correctness;
+
+    #[test]
+    fn it_encodes_and_decodes_correctly() {
+        let subject = ContractAcceptance {
+            validator_node_public_key: PublicKey::default(),
+            signature: Signature::default(),
+        };
+
+        check_consensus_encoding_correctness(subject).unwrap();
+    }
+}

--- a/base_layer/core/src/transactions/transaction_components/side_chain/contract_acceptance.rs
+++ b/base_layer/core/src/transactions/transaction_components/side_chain/contract_acceptance.rs
@@ -29,8 +29,8 @@ use crate::consensus::{ConsensusDecoding, ConsensusEncoding, ConsensusEncodingSi
 
 #[derive(Debug, Clone, Hash, PartialEq, Deserialize, Serialize, Eq)]
 pub struct ContractAcceptance {
-    validator_node_public_key: PublicKey,
-    signature: Signature,
+    pub validator_node_public_key: PublicKey,
+    pub signature: Signature,
 }
 
 impl ConsensusEncoding for ContractAcceptance {

--- a/base_layer/core/src/transactions/transaction_components/side_chain/sidechain_features.rs
+++ b/base_layer/core/src/transactions/transaction_components/side_chain/sidechain_features.rs
@@ -25,7 +25,7 @@ use std::io::{Error, Read, Write};
 use serde::{Deserialize, Serialize};
 use tari_common_types::types::FixedHash;
 
-use super::ContractDefinition;
+use super::{ContractAcceptance, ContractDefinition};
 use crate::{
     consensus::{ConsensusDecoding, ConsensusEncoding, ConsensusEncodingSized},
     transactions::transaction_components::ContractConstitution,
@@ -36,6 +36,7 @@ pub struct SideChainFeatures {
     pub contract_id: FixedHash,
     pub definition: Option<ContractDefinition>,
     pub constitution: Option<ContractConstitution>,
+    pub acceptance: Option<ContractAcceptance>,
 }
 
 impl SideChainFeatures {
@@ -53,6 +54,7 @@ impl ConsensusEncoding for SideChainFeatures {
         self.contract_id.consensus_encode(writer)?;
         self.definition.consensus_encode(writer)?;
         self.constitution.consensus_encode(writer)?;
+        self.acceptance.consensus_encode(writer)?;
         Ok(())
     }
 }
@@ -65,6 +67,7 @@ impl ConsensusDecoding for SideChainFeatures {
             contract_id: FixedHash::consensus_decode(reader)?,
             definition: ConsensusDecoding::consensus_decode(reader)?,
             constitution: ConsensusDecoding::consensus_decode(reader)?,
+            acceptance: ConsensusDecoding::consensus_decode(reader)?,
         })
     }
 }
@@ -80,6 +83,7 @@ impl SideChainFeaturesBuilder {
                 contract_id,
                 definition: None,
                 constitution: None,
+                acceptance: None,
             },
         }
     }
@@ -94,6 +98,11 @@ impl SideChainFeaturesBuilder {
         self
     }
 
+    pub fn with_contract_acceptance(mut self, contract_acceptance: ContractAcceptance) -> Self {
+        self.features.acceptance = Some(contract_acceptance);
+        self
+    }
+
     pub fn finish(self) -> SideChainFeatures {
         self.features
     }
@@ -103,7 +112,7 @@ impl SideChainFeaturesBuilder {
 mod tests {
     use std::convert::TryInto;
 
-    use tari_common_types::types::PublicKey;
+    use tari_common_types::types::{PublicKey, Signature};
 
     use super::*;
     use crate::{
@@ -176,6 +185,10 @@ mod tests {
                         },
                     ],
                 },
+            }),
+            acceptance: Some(ContractAcceptance {
+                validator_node_public_key: PublicKey::default(),
+                signature: Signature::default(),
             }),
         };
 


### PR DESCRIPTION
Description
---
- Adds `ContractAcceptance` struct to the side-chain output features
- Implements consensus encoding/decoding for `ContractAcceptance`
- Updates related gRPC types and conversions

Motivation and Context
---
Create structs for contract acceptance in the side-chain features.

How Has This Been Tested?
---
- New unit test for consensus encoding/decoding of the `ContractAcceptance`
- Existing unit/integration test pass

