### PR TITLE
fix: move peer dbs into sub folders

### DIFF
--- a/applications/tari_base_node/src/config.rs
+++ b/applications/tari_base_node/src/config.rs
@@ -112,6 +112,10 @@ pub struct BaseNodeConfig {
 
 impl Default for BaseNodeConfig {
     fn default() -> Self {
+        let p2p = P2pConfig {
+            datastore_path: PathBuf::from("peer_db/base_node"),
+            ..Default::default()
+        };
         Self {
             override_from: None,
             network: Network::LocalNet,
@@ -119,7 +123,7 @@ impl Default for BaseNodeConfig {
             identity_file: PathBuf::from("config/base_node_id.json"),
             use_libtor: false,
             tor_identity_file: PathBuf::from("config/tor_id.json"),
-            p2p: P2pConfig::default(),
+            p2p,
             db_type: DatabaseType::Lmdb,
             lmdb: Default::default(),
             data_dir: PathBuf::from("data/base_node"),

--- a/applications/tari_validator_node/src/config.rs
+++ b/applications/tari_validator_node/src/config.rs
@@ -84,6 +84,11 @@ impl ValidatorNodeConfig {
 
 impl Default for ValidatorNodeConfig {
     fn default() -> Self {
+        let p2p = P2pConfig {
+            datastore_path: PathBuf::from("peer_db/validator_node"),
+            ..Default::default()
+        };
+
         Self {
             override_from: None,
             identity_file: PathBuf::from("validator_node_id.json"),
@@ -98,7 +103,7 @@ impl Default for ValidatorNodeConfig {
             data_dir: PathBuf::from("/data/validator_node"),
             committee_management_confirmation_time: 10,
             committee_management_polling_interval: 5,
-            p2p: P2pConfig::default(),
+            p2p,
             grpc_address: Some("/ip4/127.0.0.1/tcp/18144".parse().unwrap()),
         }
     }

--- a/base_layer/wallet/src/config.rs
+++ b/base_layer/wallet/src/config.rs
@@ -78,9 +78,13 @@ pub struct WalletConfig {
 
 impl Default for WalletConfig {
     fn default() -> Self {
+        let p2p = P2pConfig {
+            datastore_path: PathBuf::from("peer_db/wallet"),
+            ..Default::default()
+        };
         Self {
             override_from: None,
-            p2p: Default::default(),
+            p2p,
             transaction_service_config: Default::default(),
             output_manager_service_config: Default::default(),
             buffer_size: 100,


### PR DESCRIPTION
Description
---
Add sub folders for each application's peer DB

Motivation and Context
---
If you run the base node and validator node in the same folder, you will get a file lock error. I added the same folder to the console wallet to keep it the same

How Has This Been Tested?
---
cargo test
