### PR TITLE
feat: add an encrypted value to the TransactionOutput

### DIFF
--- a/applications/tari_app_grpc/proto/types.proto
+++ b/applications/tari_app_grpc/proto/types.proto
@@ -177,6 +177,8 @@ message TransactionInput {
     bytes covenant = 10;
     // Version
     uint32 version = 11;
+    // The encrypted value
+    bytes encrypted_value = 12;
 }
 
 // Output for a transaction, defining the new ownership of coins that are being transferred. The commitment is a
@@ -202,6 +204,8 @@ message TransactionOutput {
     bytes covenant = 8;
     // Version
     uint32 version = 9;
+    // The encrypted value
+    bytes encrypted_value = 10;
 }
 
 // Options for UTXOs

--- a/applications/tari_app_grpc/src/conversions/transaction_output.rs
+++ b/applications/tari_app_grpc/src/conversions/transaction_output.rs
@@ -25,7 +25,7 @@ use std::convert::{TryFrom, TryInto};
 use tari_common_types::types::{BulletRangeProof, Commitment, PublicKey};
 use tari_core::{
     covenants::Covenant,
-    transactions::transaction_components::{TransactionOutput, TransactionOutputVersion},
+    transactions::transaction_components::{EncryptedValue, TransactionOutput, TransactionOutputVersion},
 };
 use tari_script::TariScript;
 use tari_utilities::{ByteArray, Hashable};
@@ -55,6 +55,7 @@ impl TryFrom<grpc::TransactionOutput> for TransactionOutput {
             .try_into()
             .map_err(|_| "Metadata signature could not be converted".to_string())?;
         let covenant = Covenant::from_bytes(&output.covenant).map_err(|err| err.to_string())?;
+        let encrypted_value = EncryptedValue::from_bytes(&output.encrypted_value).map_err(|err| err.to_string())?;
         Ok(Self::new(
             TransactionOutputVersion::try_from(
                 u8::try_from(output.version).map_err(|_| "Invalid version: overflowed u8")?,
@@ -66,6 +67,7 @@ impl TryFrom<grpc::TransactionOutput> for TransactionOutput {
             sender_offset_public_key,
             metadata_signature,
             covenant,
+            encrypted_value,
         ))
     }
 }
@@ -87,6 +89,7 @@ impl From<TransactionOutput> for grpc::TransactionOutput {
             }),
             covenant: output.covenant.to_bytes(),
             version: output.version as u32,
+            encrypted_value: output.encrypted_value.to_vec(),
         }
     }
 }

--- a/applications/test_faucet/src/main.rs
+++ b/applications/test_faucet/src/main.rs
@@ -182,6 +182,7 @@ fn create_utxo(
         offset_keys.pk,
         metadata_sig,
         covenant,
+        encrypted_value,
     );
     (utxo, keys.k, offset_keys.k)
 }

--- a/base_layer/core/src/blocks/genesis_block.rs
+++ b/base_layer/core/src/blocks/genesis_block.rs
@@ -44,6 +44,7 @@ use crate::{
         aggregated_body::AggregateBody,
         tari_amount::MicroTari,
         transaction_components::{
+            EncryptedValue,
             KernelFeatures,
             OutputFeatures,
             OutputFeaturesVersion,
@@ -115,6 +116,7 @@ fn get_igor_genesis_block_raw() -> Block {
             // For genesis block: Metadata signature will never be checked
             Default::default(),
             Covenant::default(),
+            EncryptedValue::default(),
         )],
         vec![TransactionKernel::new_current_version(
             KernelFeatures::COINBASE_KERNEL,
@@ -214,7 +216,7 @@ pub fn get_dibbler_genesis_block() -> ChainBlock {
     // hardcode the Merkle roots once they've been computed above
     block.header.kernel_mr = from_hex("5b91bebd33e18798e03e9c5d831d161ee9c3d12560f50b987e1a8c3ec53146df").unwrap();
     block.header.witness_mr = from_hex("11227f6ce9ff34349d7dcab606b633f55234d5c8a73696a68c6e9ddc7cd3bc40").unwrap();
-    block.header.output_mr = from_hex("5e69274e72f8590e1cf91c189e24368527414aed966de62135d9273a6c14c3ef").unwrap();
+    block.header.output_mr = from_hex("e3d8e137e8efb476d0ef0149ec5f82441daec91847bd910c8d102d6432ce3278").unwrap();
 
     let accumulated_data = BlockHeaderAccumulatedData {
         hash: block.hash(),
@@ -259,7 +261,8 @@ fn get_dibbler_genesis_block_raw() -> Block {
             // For genesis block: Metadata signature will never be checked
             ComSignature::default(),
             // Covenant
-            Covenant::default()
+            Covenant::default(),
+            EncryptedValue::default(),
         );
     let kernel = TransactionKernel::new(
         TransactionKernelVersion::V0,

--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -1510,6 +1510,7 @@ fn fetch_block<T: BlockchainBackend>(db: &T, height: u64) -> Result<HistoricalBl
                         output.script,
                         output.sender_offset_public_key,
                         output.covenant,
+                        output.encrypted_value,
                     );
                     Ok(compact_input)
                 },

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -1056,6 +1056,7 @@ impl LMDBDatabase {
                         output.script,
                         output.sender_offset_public_key,
                         output.covenant,
+                        output.encrypted_value,
                     );
                 },
             }

--- a/base_layer/core/src/proto/transaction.proto
+++ b/base_layer/core/src/proto/transaction.proto
@@ -53,6 +53,8 @@ message TransactionInput {
     bytes covenant = 9;
     // Version
     uint32 version = 10;
+    // The encrypted value
+    bytes encrypted_value = 11;
 }
 
 // Output for a transaction, defining the new ownership of coins that are being transferred. The commitment is a
@@ -75,6 +77,8 @@ message TransactionOutput {
     bytes covenant = 7;
     // Version
     uint32 version = 8;
+    // The encrypted value
+    bytes encrypted_value = 9;
 }
 
 // Options for UTXOs

--- a/base_layer/core/src/transactions/test_helpers.rs
+++ b/base_layer/core/src/transactions/test_helpers.rs
@@ -704,7 +704,6 @@ pub fn create_stx_protocol(schema: TransactionSchema) -> (SenderTransactionProto
         let commitment = factories
             .commitment
             .commit_value(&utxo.spending_key, utxo.value.as_u64());
-        let encrypted_value = EncryptedValue::todo_encrypt_from(utxo.value.as_u64());
         let recovery_byte = OutputFeatures::create_unique_recovery_byte(&commitment, None);
         utxo.features.set_recovery_byte(recovery_byte);
         utxo.metadata_signature = TransactionOutput::create_final_metadata_signature(
@@ -715,7 +714,7 @@ pub fn create_stx_protocol(schema: TransactionSchema) -> (SenderTransactionProto
             &utxo.features,
             &test_params.sender_offset_private_key,
             &utxo.covenant,
-            &encrypted_value,
+            &utxo.encrypted_value,
         )
         .unwrap();
         utxo.sender_offset_public_key = test_params.sender_offset_public_key;
@@ -833,6 +832,7 @@ pub fn create_utxo(
         offset_keys.pk,
         metadata_sig,
         covenant.clone(),
+        encrypted_value,
     );
     (utxo, keys.k, offset_keys.k)
 }

--- a/base_layer/core/src/transactions/transaction_components/encrypted_value.rs
+++ b/base_layer/core/src/transactions/transaction_components/encrypted_value.rs
@@ -61,6 +61,14 @@ impl EncryptedValue {
         data[0..8].copy_from_slice(&value);
         Self(data)
     }
+
+    /// TODO: Replace this method with a real call of decryption service
+    /// that will produce a decrypted value from self.
+    pub fn todo_decrypt(&self) -> u64 {
+        let mut buffer = [0u8; 8];
+        (&mut buffer[0..8]).copy_from_slice(&self.0.as_slice()[0..8]);
+        u64::from_le_bytes(buffer)
+    }
 }
 
 impl ConsensusEncoding for EncryptedValue {

--- a/base_layer/core/src/transactions/transaction_components/mod.rs
+++ b/base_layer/core/src/transactions/transaction_components/mod.rs
@@ -103,6 +103,7 @@ pub(super) fn hash_output(
     commitment: &Commitment,
     script: &TariScript,
     covenant: &Covenant,
+    encrypted_value: &EncryptedValue,
 ) -> [u8; 32] {
     match version {
         TransactionOutputVersion::V0 | TransactionOutputVersion::V1 => ConsensusHashWriter::default()
@@ -111,6 +112,7 @@ pub(super) fn hash_output(
             .chain(commitment)
             .chain(script)
             .chain(covenant)
+            .chain(encrypted_value)
             .finalize(),
     }
 }

--- a/base_layer/core/src/transactions/transaction_components/test.rs
+++ b/base_layer/core/src/transactions/transaction_components/test.rs
@@ -164,6 +164,7 @@ fn range_proof_verification() {
         )
         .unwrap(),
         Covenant::default(),
+        encrypted_value,
     );
     tx_output3.verify_range_proof(&factories.range_proof).unwrap_err();
 }
@@ -248,6 +249,7 @@ fn check_timelocks() {
         script_signature,
         offset_pub_key,
         Covenant::default(),
+        EncryptedValue::default(),
     );
 
     let mut kernel = test_helpers::create_test_kernel(0.into(), 0);

--- a/base_layer/core/src/transactions/transaction_components/transaction_output.rs
+++ b/base_layer/core/src/transactions/transaction_components/transaction_output.rs
@@ -93,6 +93,8 @@ pub struct TransactionOutput {
     /// The covenant that will be executed when spending this output
     #[serde(default)]
     pub covenant: Covenant,
+    /// Encrypted value.
+    pub encrypted_value: EncryptedValue,
 }
 
 /// An output for a transaction, includes a range proof and Tari script metadata
@@ -108,6 +110,7 @@ impl TransactionOutput {
         sender_offset_public_key: PublicKey,
         metadata_signature: ComSignature,
         covenant: Covenant,
+        encrypted_value: EncryptedValue,
     ) -> TransactionOutput {
         TransactionOutput {
             version,
@@ -118,6 +121,7 @@ impl TransactionOutput {
             sender_offset_public_key,
             metadata_signature,
             covenant,
+            encrypted_value,
         }
     }
 
@@ -129,6 +133,7 @@ impl TransactionOutput {
         sender_offset_public_key: PublicKey,
         metadata_signature: ComSignature,
         covenant: Covenant,
+        encrypted_value: EncryptedValue,
     ) -> TransactionOutput {
         TransactionOutput::new(
             TransactionOutputVersion::get_current_version(),
@@ -139,6 +144,7 @@ impl TransactionOutput {
             sender_offset_public_key,
             metadata_signature,
             covenant,
+            encrypted_value,
         )
     }
 
@@ -173,8 +179,7 @@ impl TransactionOutput {
             self.metadata_signature.public_nonce(),
             &self.commitment,
             &self.covenant,
-            // TODO: Use `self.encrypted_value` instead
-            &EncryptedValue::default(),
+            &self.encrypted_value,
         );
         if !self.metadata_signature.verify_challenge(
             &(&self.commitment + &self.sender_offset_public_key),
@@ -243,7 +248,7 @@ impl TransactionOutput {
             &nonce_commitment,
             &self.commitment,
             &self.covenant,
-            &EncryptedValue::default(),
+            &self.encrypted_value,
         )
     }
 
@@ -256,7 +261,7 @@ impl TransactionOutput {
         public_commitment_nonce: &Commitment,
         commitment: &Commitment,
         covenant: &Covenant,
-        _encrypted_value: &EncryptedValue,
+        encrypted_value: &EncryptedValue,
     ) -> Challenge {
         match version {
             TransactionOutputVersion::V0 | TransactionOutputVersion::V1 => ConsensusHashWriter::default()
@@ -266,7 +271,7 @@ impl TransactionOutput {
                 .chain(sender_offset_public_key)
                 .chain(commitment)
                 .chain(covenant)
-                //.chain(encrypted_value)
+                .chain(encrypted_value)
                 .into_digest(),
         }
     }
@@ -283,7 +288,7 @@ impl TransactionOutput {
         partial_commitment_nonce: Option<&PublicKey>,
         sender_offset_private_key: Option<&PrivateKey>,
         covenant: &Covenant,
-        _encrypted_value: &EncryptedValue,
+        encrypted_value: &EncryptedValue,
     ) -> Result<ComSignature, TransactionError> {
         let nonce_a = PrivateKey::random(&mut OsRng);
         let nonce_b = PrivateKey::random(&mut OsRng);
@@ -294,7 +299,6 @@ impl TransactionOutput {
         };
         let pk_value = PrivateKey::from(value.as_u64());
         let commitment = CommitmentFactory::default().commit(spending_key, &pk_value);
-        let encrypted_value = EncryptedValue::todo_encrypt_from(value.as_u64());
         let e = TransactionOutput::build_metadata_signature_challenge(
             version,
             script,
@@ -303,13 +307,12 @@ impl TransactionOutput {
             &nonce_commitment,
             &commitment,
             covenant,
-            &encrypted_value,
+            encrypted_value,
         );
         let secret_x = match sender_offset_private_key {
             None => spending_key.clone(),
             Some(key) => spending_key + key,
         };
-        // TODO: Take `encrypted_value` into account
         Ok(ComSignature::sign(
             &pk_value,
             &secret_x,
@@ -396,6 +399,7 @@ impl Hashable for TransactionOutput {
             &self.commitment,
             &self.script,
             &self.covenant,
+            &self.encrypted_value,
         )
         .to_vec()
     }
@@ -411,6 +415,7 @@ impl Default for TransactionOutput {
             PublicKey::default(),
             ComSignature::default(),
             Covenant::default(),
+            EncryptedValue::default(),
         )
     }
 }
@@ -474,6 +479,7 @@ impl ConsensusDecoding for TransactionOutput {
         let sender_offset_public_key = PublicKey::consensus_decode(reader)?;
         let metadata_signature = ComSignature::consensus_decode(reader)?;
         let covenant = Covenant::consensus_decode(reader)?;
+        let encrypted_value = EncryptedValue::consensus_decode(reader)?;
         let output = TransactionOutput::new(
             version,
             features,
@@ -483,6 +489,7 @@ impl ConsensusDecoding for TransactionOutput {
             sender_offset_public_key,
             metadata_signature,
             covenant,
+            encrypted_value,
         );
         Ok(output)
     }

--- a/base_layer/core/src/transactions/transaction_components/unblinded_output.rs
+++ b/base_layer/core/src/transactions/transaction_components/unblinded_output.rs
@@ -188,6 +188,7 @@ impl UnblindedOutput {
                 sender_offset_public_key: self.sender_offset_public_key.clone(),
                 covenant: self.covenant.clone(),
                 version: self.version,
+                encrypted_value: self.encrypted_value.clone(),
             },
             self.input_data.clone(),
             script_signature,
@@ -248,6 +249,7 @@ impl UnblindedOutput {
             self.sender_offset_public_key.clone(),
             self.metadata_signature.clone(),
             self.covenant.clone(),
+            self.encrypted_value.clone(),
         );
 
         Ok(output)
@@ -305,6 +307,7 @@ impl UnblindedOutput {
             self.sender_offset_public_key.clone(),
             self.metadata_signature.clone(),
             self.covenant.clone(),
+            self.encrypted_value.clone(),
         );
 
         Ok(output)
@@ -320,8 +323,15 @@ impl UnblindedOutput {
     // Note: added to the struct to ensure consistency between `commitment`, `spending_key` and `value`.
     pub fn hash(&self, factories: &CryptoFactories) -> Vec<u8> {
         let commitment = factories.commitment.commit_value(&self.spending_key, self.value.into());
-        transaction_components::hash_output(self.version, &self.features, &commitment, &self.script, &self.covenant)
-            .to_vec()
+        transaction_components::hash_output(
+            self.version,
+            &self.features,
+            &commitment,
+            &self.script,
+            &self.covenant,
+            &self.encrypted_value,
+        )
+        .to_vec()
     }
 }
 

--- a/base_layer/core/src/transactions/transaction_protocol/sender.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/sender.rs
@@ -918,6 +918,7 @@ mod test {
             sender_offset_public_key,
             partial_metadata_signature.clone(),
             covenant,
+            encrypted_value,
         );
         assert!(!output.verify_metadata_signature().is_ok());
         assert!(partial_metadata_signature.verify_challenge(

--- a/base_layer/core/src/transactions/transaction_protocol/single_receiver.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/single_receiver.rs
@@ -137,6 +137,7 @@ impl SingleReceiverTransactionProtocol {
             sender_info.sender_offset_public_key.clone(),
             partial_metadata_signature,
             sender_info.covenant.clone(),
+            encrypted_value,
         );
         Ok(output)
     }

--- a/base_layer/core/src/validation/block_validators/async_validator.rs
+++ b/base_layer/core/src/validation/block_validators/async_validator.rs
@@ -281,6 +281,7 @@ impl<B: BlockchainBackend + 'static> BlockValidator<B> {
                                 output.script,
                                 output.sender_offset_public_key,
                                 output.covenant,
+                                output.encrypted_value,
                             );
                         },
                     }

--- a/base_layer/core/src/validation/helpers.rs
+++ b/base_layer/core/src/validation/helpers.rs
@@ -415,6 +415,7 @@ pub fn check_input_is_utxo<B: BlockchainBackend>(db: &B, input: &TransactionInpu
                         output.script,
                         output.sender_offset_public_key,
                         output.covenant,
+                        output.encrypted_value,
                     );
                     let input_hash = input.canonical_hash()?;
                     if compact.canonical_hash()? != input_hash {
@@ -895,6 +896,7 @@ mod test {
                     maturity: 5,
                     ..Default::default()
                 },
+                Default::default(),
                 Default::default(),
                 Default::default(),
                 Default::default(),

--- a/base_layer/core/tests/chain_storage_tests/chain_storage.rs
+++ b/base_layer/core/tests/chain_storage_tests/chain_storage.rs
@@ -1890,6 +1890,7 @@ mod malleability {
                     output.script.clone(),
                     output.sender_offset_public_key.clone(),
                     output.covenant.clone(),
+                    output.encrypted_value.clone(),
                 );
             });
         }

--- a/base_layer/core/tests/node_comms_interface.rs
+++ b/base_layer/core/tests/node_comms_interface.rs
@@ -42,13 +42,7 @@ use tari_core::{
     transactions::{
         tari_amount::MicroTari,
         test_helpers::{create_utxo, spend_utxos},
-        transaction_components::{
-            EncryptedValue,
-            OutputFeatures,
-            TransactionOutput,
-            TransactionOutputVersion,
-            UnblindedOutput,
-        },
+        transaction_components::{OutputFeatures, TransactionOutput, TransactionOutputVersion, UnblindedOutput},
         CryptoFactories,
     },
     txn_schema,
@@ -359,7 +353,6 @@ async fn inbound_fetch_blocks_before_horizon_height() {
     let script = script!(Nop);
     let amount = MicroTari(10_000);
     let (utxo, key, offset) = create_utxo(amount, &factories, &Default::default(), &script, &Covenant::default());
-    let encrypted_value = EncryptedValue::todo_encrypt_from(amount);
     let metadata_signature = TransactionOutput::create_final_metadata_signature(
         TransactionOutputVersion::get_current_version(),
         amount,
@@ -368,7 +361,7 @@ async fn inbound_fetch_blocks_before_horizon_height() {
         &OutputFeatures::default(),
         &offset,
         &Covenant::default(),
-        &encrypted_value,
+        &utxo.encrypted_value,
     )
     .unwrap();
     let unblinded_output = UnblindedOutput::new_current_version(
@@ -382,7 +375,7 @@ async fn inbound_fetch_blocks_before_horizon_height() {
         metadata_signature,
         0,
         Covenant::default(),
-        encrypted_value,
+        utxo.encrypted_value.clone(),
     );
     let mut txn = DbTransaction::new();
     txn.insert_utxo(utxo.clone(), block0.hash().clone(), 0, 4002);

--- a/base_layer/tari_mining_helper_ffi/src/lib.rs
+++ b/base_layer/tari_mining_helper_ffi/src/lib.rs
@@ -381,8 +381,8 @@ mod tests {
 
     #[test]
     fn detect_change_in_consensus_encoding() {
-        const NONCE: u64 = 11838733717659400015;
-        const DIFFICULTY: Difficulty = Difficulty::from_u64(5497);
+        const NONCE: u64 = 5776446118058080778;
+        const DIFFICULTY: Difficulty = Difficulty::from_u64(110571);
         // Use this to generate new NONCE and DIFFICULTY
         // let (difficulty, nonce) = generate_nonce_with_min_difficulty(MIN_DIFFICULTY).unwrap();
         // eprintln!("nonce = {:?}", nonce);

--- a/base_layer/wallet/src/output_manager_service/recovery/standard_outputs_recoverer.rs
+++ b/base_layer/wallet/src/output_manager_service/recovery/standard_outputs_recoverer.rs
@@ -29,7 +29,7 @@ use tari_common_types::{
     types::{BulletRangeProof, PrivateKey, PublicKey},
 };
 use tari_core::transactions::{
-    transaction_components::{EncryptedValue, TransactionOutput, UnblindedOutput},
+    transaction_components::{TransactionOutput, UnblindedOutput},
     transaction_protocol::RewindData,
     CryptoFactories,
 };
@@ -105,7 +105,6 @@ where
                     return None;
                 }
                 let script_key = PrivateKey::random(&mut OsRng);
-                let encrypted_value = EncryptedValue::todo_encrypt_from(rewind_result.committed_value);
                 Some((
                     UnblindedOutput::new(
                         output.version,
@@ -119,7 +118,7 @@ where
                         output.metadata_signature,
                         0,
                         output.covenant,
-                        encrypted_value,
+                        output.encrypted_value,
                     ),
                     output.proof,
                 ))

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -1798,7 +1798,6 @@ where
         let rewound =
             output.full_rewind_range_proof(&self.resources.factories.range_proof, &rewind_key, &blinding_key)?;
 
-        let encrypted_value = EncryptedValue::todo_encrypt_from(rewound.committed_value);
         let rewound_output = UnblindedOutput::new(
             output.version,
             rewound.committed_value,
@@ -1813,7 +1812,7 @@ where
             // as we are claiming the Hashed part which has a 0 time lock
             0,
             output.covenant,
-            encrypted_value,
+            output.encrypted_value,
         );
         let amount = rewound.committed_value;
 
@@ -2019,7 +2018,6 @@ where
                 );
 
                 if let Ok(rewound_result) = rewound {
-                    let encrypted_value = EncryptedValue::todo_encrypt_from(rewound_result.committed_value);
                     let rewound_output = UnblindedOutput::new(
                         output.version,
                         rewound_result.committed_value,
@@ -2032,7 +2030,7 @@ where
                         output.metadata_signature,
                         known_one_sided_payment_scripts[i].script_lock_height,
                         output.covenant,
-                        encrypted_value,
+                        output.encrypted_value,
                     );
 
                     let db_output = DbUnblindedOutput::rewindable_from_unblinded_output(

--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -421,8 +421,8 @@ where
         sender_offset_public_key: &PublicKey,
         script_lock_height: u64,
         covenant: Covenant,
+        encrypted_value: EncryptedValue,
     ) -> Result<TxId, WalletError> {
-        let encrypted_value = EncryptedValue::todo_encrypt_from(amount);
         let unblinded_output = UnblindedOutput::new_current_version(
             amount,
             spending_key.clone(),

--- a/base_layer/wallet/tests/wallet.rs
+++ b/base_layer/wallet/tests/wallet.rs
@@ -740,6 +740,7 @@ async fn test_import_utxo() {
             &p.sender_offset_public_key,
             0,
             Covenant::default(),
+            output.encrypted_value,
         )
         .await
         .unwrap();

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -204,6 +204,35 @@ struct TariCovenant *covenant_create_from_bytes(
 // Frees memory for a TariCovenant
 void covenant_destroy(struct TariCovenant *covenant);
 
+/// -------------------------------- EncryptedValue  --------------------------------------------- ///
+
+/// Creates a TariEncryptedValue from a ByteVector containing the encrypted_value bytes
+struct TariEncryptedValue *encrypted_value_create_from_bytes(
+    struct ByteVector encrypted_value_bytes,
+    int *error_out
+);
+
+/// Creates a ByteVector containing the encrypted_value bytes from a TariEncryptedValue
+struct ByteVector *encrypted_value_as_bytes(
+    struct TariEncryptedValue *encrypted_value,
+    int *error_out
+);
+
+// Creates a TariEncryptedValue from an amount
+struct TariEncryptedValue *encrypted_value_encrypt(
+    unsigned long long amount,
+    int *error_out
+)
+
+/// Creates an amount from a TariEncryptedValue
+unsigned long long encrypted_value_decrypt(
+    struct TariEncryptedValue *encrypted_value,
+    int *error_out
+);
+
+/// Frees memory for a TariEncryptedValue
+void  encrypted_value_destroy(struct TariEncryptedValue *encrypted_value);
+
 /// -------------------------------- Output Features  --------------------------------------------- ///
 
 // Creates a TariOutputFeatures from byte values
@@ -738,6 +767,7 @@ unsigned long long wallet_import_external_utxo_as_non_rewindable(
     struct TariPublicKey *sender_offset_public_key,
     struct TariPrivateKey *script_private_key,
     struct TariCovenant *covenant,
+    struct TariEncryptedValue *encrypted_value,
     const char *message,
     int *error_out
 );

--- a/integration_tests/helpers/ffi/ffiInterface.js
+++ b/integration_tests/helpers/ffi/ffiInterface.js
@@ -404,6 +404,7 @@ class InterfaceFFI {
           this.ptr,
           this.ptr,
           this.ptr,
+          this.ptr,
           this.string,
           this.intPtr,
         ],
@@ -1565,6 +1566,8 @@ class InterfaceFFI {
       // script_private_key
       spending_key_ptr,
       // default Covenant
+      null,
+      // default EncryptedValue
       null,
       message,
       error

--- a/integration_tests/helpers/util.js
+++ b/integration_tests/helpers/util.js
@@ -309,6 +309,9 @@ const getTransactionOutputHash = function (output) {
   ]);
   encodedBytesLength += covenant.length;
   blake2bUpdate(context, covenant);
+  // encrypted_value
+  encodedBytesLength += output.encrypted_value.length;
+  blake2bUpdate(context, output.encrypted_value);
 
   expect(context.c).to.equal(encodedBytesLength);
   const hash = blake2bFinal(context);


### PR DESCRIPTION
Description
---
The PR adds the `encrypted_value` field (of `EncryptedValue` type) to the `TransactionOutput` struct.
The same field also added to the `TransactionInput` for a case when input was produced from an output.

The changes also affected the genesis block, dibbler's faucet data, hashes and integration tests.

The value is not actually encrypted and now it's stored in the following format: u64le + 16 empty bytes.

Motivation and Context
---
Part of the BP+ features.

How Has This Been Tested?
---
CI tests (updated)

