### PR TITLE
refactor(core): remove contract id from the contract definition output features

### DIFF
--- a/applications/tari_app_grpc/proto/types.proto
+++ b/applications/tari_app_grpc/proto/types.proto
@@ -307,10 +307,9 @@ message CommitteeDefinitionFeatures {
 }
 
 message ContractDefinition {
-    bytes contract_id = 1;
-    bytes contract_name = 2;
-    bytes contract_issuer = 3;
-    ContractSpecification contract_spec = 4;
+    bytes contract_name = 1;
+    bytes contract_issuer = 2;
+    ContractSpecification contract_spec = 3;
 }
 
 message ContractSpecification {

--- a/applications/tari_app_grpc/src/conversions/sidechain_features.rs
+++ b/applications/tari_app_grpc/src/conversions/sidechain_features.rs
@@ -74,8 +74,6 @@ impl TryFrom<grpc::ContractDefinition> for ContractDefinition {
     type Error = String;
 
     fn try_from(value: grpc::ContractDefinition) -> Result<Self, Self::Error> {
-        let contract_id = FixedHash::try_from(value.contract_id).map_err(|err| format!("{:?}", err))?;
-
         let contract_name = vec_into_fixed_string(value.contract_name);
 
         let contract_issuer =
@@ -88,7 +86,6 @@ impl TryFrom<grpc::ContractDefinition> for ContractDefinition {
             .map_err(|err| err)?;
 
         Ok(Self {
-            contract_id,
             contract_name,
             contract_issuer,
             contract_spec,
@@ -98,12 +95,10 @@ impl TryFrom<grpc::ContractDefinition> for ContractDefinition {
 
 impl From<ContractDefinition> for grpc::ContractDefinition {
     fn from(value: ContractDefinition) -> Self {
-        let contract_id = value.contract_id.as_bytes().to_vec();
         let contract_name = value.contract_name.as_bytes().to_vec();
         let contract_issuer = value.contract_issuer.as_bytes().to_vec();
 
         Self {
-            contract_id,
             contract_name,
             contract_issuer,
             contract_spec: Some(value.contract_spec.into()),

--- a/applications/tari_console_wallet/src/automation/commands.rs
+++ b/applications/tari_console_wallet/src/automation/commands.rs
@@ -922,7 +922,7 @@ pub async fn command_runner(
                 let contract_definition: ContractDefinitionFileFormat =
                     serde_json::from_reader(file_reader).map_err(|e| CommandError::JSONFile(e.to_string()))?;
                 let contract_definition_features = ContractDefinition::from(contract_definition);
-                let contract_id_hex = contract_definition_features.contract_id.to_vec().to_hex();
+                let contract_id_hex = contract_definition_features.calculate_contract_id().to_vec().to_hex();
 
                 // create the contract definition transaction
                 let mut asset_manager = wallet.asset_manager.clone();

--- a/base_layer/core/src/proto/transaction.proto
+++ b/base_layer/core/src/proto/transaction.proto
@@ -179,10 +179,9 @@ message CommitteeDefinitionFeatures {
 }
 
 message ContractDefinition {
-    bytes contract_id = 1;
-    bytes contract_name = 2;
-    bytes contract_issuer = 3;
-    ContractSpecification contract_spec = 4;
+    bytes contract_name = 1;
+    bytes contract_issuer = 2;
+    ContractSpecification contract_spec = 3;
 }
 
 message ContractSpecification {

--- a/base_layer/core/src/proto/transaction.rs
+++ b/base_layer/core/src/proto/transaction.rs
@@ -711,8 +711,6 @@ impl TryFrom<proto::types::ContractDefinition> for ContractDefinition {
     type Error = String;
 
     fn try_from(value: proto::types::ContractDefinition) -> Result<Self, Self::Error> {
-        let contract_id = FixedHash::try_from(value.contract_id).map_err(|err| format!("{:?}", err))?;
-
         let contract_name = vec_into_fixed_string(value.contract_name);
 
         let contract_issuer =
@@ -725,7 +723,6 @@ impl TryFrom<proto::types::ContractDefinition> for ContractDefinition {
             .map_err(|err| err)?;
 
         Ok(Self {
-            contract_id,
             contract_name,
             contract_issuer,
             contract_spec,
@@ -735,12 +732,10 @@ impl TryFrom<proto::types::ContractDefinition> for ContractDefinition {
 
 impl From<ContractDefinition> for proto::types::ContractDefinition {
     fn from(value: ContractDefinition) -> Self {
-        let contract_id = value.contract_id.as_bytes().to_vec();
         let contract_name = value.contract_name.as_bytes().to_vec();
         let contract_issuer = value.contract_issuer.as_bytes().to_vec();
 
         Self {
-            contract_id,
             contract_name,
             contract_issuer,
             contract_spec: Some(value.contract_spec.into()),

--- a/base_layer/core/src/transactions/transaction_components/output_features.rs
+++ b/base_layer/core/src/transactions/transaction_components/output_features.rs
@@ -283,10 +283,12 @@ impl OutputFeatures {
     }
 
     pub fn for_contract_definition(definition: ContractDefinition) -> OutputFeatures {
+        let contract_id = definition.calculate_contract_id();
+
         Self {
             flags: OutputFlags::CONTRACT_DEFINITION,
             sidechain_features: Some(
-                SideChainFeaturesBuilder::new(definition.contract_id)
+                SideChainFeaturesBuilder::new(contract_id)
                     .with_contract_definition(definition)
                     .finish(),
             ),
@@ -505,7 +507,6 @@ mod test {
                     initial_reward: 100.into(),
                 }),
                 definition: Some(ContractDefinition {
-                    contract_id: FixedHash::zero(),
                     contract_name: vec_into_fixed_string("name".as_bytes().to_vec()),
                     contract_issuer: PublicKey::default(),
                     contract_spec: ContractSpecification {

--- a/base_layer/core/src/transactions/transaction_components/side_chain/sidechain_features.rs
+++ b/base_layer/core/src/transactions/transaction_components/side_chain/sidechain_features.rs
@@ -154,7 +154,6 @@ mod tests {
                 initial_reward: 100.into(),
             }),
             definition: Some(ContractDefinition {
-                contract_id: FixedHash::zero(),
                 contract_name: vec_into_fixed_string("name".as_bytes().to_vec()),
                 contract_issuer: PublicKey::default(),
                 contract_spec: ContractSpecification {


### PR DESCRIPTION
Description
---
* Removed the `contract_id` field in the contract definition output features
* Created a utility method in the contract definition struct to calculate the contract id, as it's derived from the definition contents.

Motivation and Context
---
The `contract_id` field in the contract definition output features is not needed anymore. That's because the parent features (`SideChainFeatures`) already stores it.

How Has This Been Tested?
---
The existing unit test and integration tests for the contract definition pass.
