### PR TITLE
ci: docker improvements

### DIFF
--- a/applications/launchpad/docker_rig/frontail.Dockerfile
+++ b/applications/launchpad/docker_rig/frontail.Dockerfile
@@ -1,9 +1,19 @@
+# Package build
 FROM node:16-alpine
+
+ARG BUILDPLATFORM
+ARG FRONTAIL_VERSION=4.9.2
+ARG VERSION=1.0.1
 
 RUN npm install -g frontail
 
 ADD run_frontail.sh /usr/bin/
 WORKDIR /var/tari
-ENTRYPOINT ["/usr/bin/run_frontail.sh"]
+
 EXPOSE 9001
+ENV dockerfile_version=$VERSION
+ENV dockerfile_build_arch=$BUILDPLATFORM
+ENV frontail_version=$FRONTAIL_VERSION
+
+ENTRYPOINT ["/usr/bin/run_frontail.sh"]
 CMD ["--help"]

--- a/applications/launchpad/docker_rig/monerod.Dockerfile
+++ b/applications/launchpad/docker_rig/monerod.Dockerfile
@@ -1,20 +1,59 @@
-# Usage: docker run --restart=always -v /var/data/blockchain-xmr:/root/.bitmonero -p 18080:18080 -p 18081:18081 --name=monerod -td kannix/monero-full-node
-FROM bitnami/minideb:bullseye AS build
-ENV MONERO_VERSION=0.17.2.3 MONERO_SHA256=8069012ad5e7b35f79e35e6ca71c2424efc54b61f6f93238b182981ba83f2311
+# Usage:
+#  docker run --restart=always -v /var/data/blockchain-xmr:/root/.bitmonero \
+#    -p 18080:18080 -p 18081:18081 --name=monerod -td kannix/monero-full-node
 
+# Binary build
+
+# Declare stage using linux/amd64 base image
+FROM --platform=linux/amd64 bitnami/minideb:bullseye AS build-stage-amd64
+
+# Platform Args
+ARG MONERO_ARCH=x64
+ARG MONERO_TAR=x86_64
+
+# https://github.com/monero-project/monero/releases
+ARG MONERO_VERSION=0.17.3.0
+ARG MONERO_SHA256=ac18ce3d1189410a5c175984827d5d601974733303411f6142296d647f6582ce
+
+# Declare stage using linux/arm64 base image
+FROM --platform=linux/arm64 bitnami/minideb:bullseye AS build-stage-arm64
+
+# Platform Args
+ARG MONERO_ARCH=armv8
+ARG MONERO_TAR=aarch64
+
+# https://github.com/monero-project/monero/releases
+ARG MONERO_VERSION=0.17.3.0
+ARG MONERO_SHA256=8fdb5761f6f4345dc670d184144ce8c2fa56eeb1609ed169e79b202fcca20f7d
+
+# Declare TARGETARCH to make it available
+ARG TARGETARCH
+# Select final stage based on TARGETARCH ARG
+FROM build-stage-${TARGETARCH} as build-stage-download
+
+ARG BUILDPLATFORM
+
+# Bring over the Args from platform selection
+ARG MONERO_ARCH
+ARG MONERO_TAR
+ARG MONERO_VERSION
+ARG MONERO_SHA256
 
 RUN apt-get update && apt-get install -y curl bzip2
 
 WORKDIR /root
 
-RUN curl https://dlsrc.getmonero.org/cli/monero-linux-x64-v$MONERO_VERSION.tar.bz2 -O &&\
-  echo "$MONERO_SHA256  monero-linux-x64-v$MONERO_VERSION.tar.bz2" | sha256sum -c - &&\
-  tar -xvf monero-linux-x64-v$MONERO_VERSION.tar.bz2 &&\
-  rm monero-linux-x64-v$MONERO_VERSION.tar.bz2 &&\
-  cp ./monero-x86_64-linux-gnu-v$MONERO_VERSION/monerod . &&\
+RUN curl https://dlsrc.getmonero.org/cli/monero-linux-$MONERO_ARCH-v$MONERO_VERSION.tar.bz2 -O &&\
+  echo "$MONERO_SHA256  monero-linux-$MONERO_ARCH-v$MONERO_VERSION.tar.bz2" | sha256sum -c - &&\
+  tar -xvf monero-linux-$MONERO_ARCH-v$MONERO_VERSION.tar.bz2 &&\
+  rm monero-linux-$MONERO_ARCH-v$MONERO_VERSION.tar.bz2 &&\
+  cp ./monero-$MONERO_TAR-linux-gnu-v$MONERO_VERSION/monerod . &&\
   rm -r monero-*
 
-FROM bitnami/minideb:bullseye
+FROM bitnami/minideb:bullseye AS runtime-stage
+
+# Bring over the Args from platform selection
+ARG MONERO_VERSION
 ARG VERSION=1.0.1
 
 RUN groupadd -g 1000 tari && useradd -ms /bin/bash -u 1000 -g 1000 tari \
@@ -23,14 +62,24 @@ RUN groupadd -g 1000 tari && useradd -ms /bin/bash -u 1000 -g 1000 tari \
 USER tari
 WORKDIR /home/tari
 
-COPY --chown=tari:tari --from=build /root/monerod /home/tari/monerod
+COPY --chown=tari:tari --from=build-stage-download /root/monerod /home/tari/monerod
 
 # blockchain location
 VOLUME /home/tari/.bitmonero
 ENV dockerfile_version=$VERSION
+ENV dockerfile_build_arch=$BUILDPLATFORM
+ENV monero_version=$MONERO_VERSION
 
-EXPOSE 18080 18081
+# Expose p2p port
+EXPOSE 18080
 
+EXPOSE 18081
+
+# Expose restricted RPC port
+EXPOSE 18089
+
+# Add HEALTHCHECK against get_info endpoint
+HEALTHCHECK --interval=30s --timeout=5s CMD curl --fail http://localhost:18089/get_info || exit 1
 
 ENTRYPOINT ["./monerod"]
-CMD ["--non-interactive", "--restricted-rpc", "--rpc-bind-ip=0.0.0.0", "--confirm-external-bind", "--enable-dns-blocklist", "--out-peers=16"]
+CMD ["--non-interactive", "--restricted-rpc", "--rpc-bind-ip=0.0.0.0", "--rpc-restricted-bind-port=18089", "--confirm-external-bind", "--enable-dns-blocklist", "--out-peers=16"]

--- a/applications/launchpad/docker_rig/tarilabs.Dockerfile
+++ b/applications/launchpad/docker_rig/tarilabs.Dockerfile
@@ -1,0 +1,154 @@
+# syntax = docker/dockerfile:1.3
+FROM --platform=$BUILDPLATFORM rust:1.60-bullseye as builder
+
+# Declare to make available
+ARG BUILDPLATFORM
+ARG BUILDOS
+ARG BUILDARCH
+ARG BUILDVARIANT
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+
+# Disable anti-cache
+RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
+# https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/syntax.md#run---mounttypecache
+RUN --mount=type=cache,id=build-apt-cache-${BUILDOS}-${BUILDARCH}${BUILDVARIANT},sharing=locked,target=/var/cache/apt \
+    --mount=type=cache,id=build-apt-lib-${BUILDOS}-${BUILDARCH}${BUILDVARIANT},sharing=locked,target=/var/lib/apt \
+  apt update && apt-get install -y \
+  apt-transport-https \
+  bash \
+  ca-certificates \
+  curl \
+  gpg \
+  iputils-ping \
+  less \
+  libreadline-dev \
+  libsqlite3-0 \
+  openssl \
+  telnet \
+  cargo \
+  clang \
+  cmake
+
+ARG ARCH=native
+#ARG FEATURES=avx2
+ARG FEATURES=safe
+ENV RUSTFLAGS="-C target_cpu=$ARCH"
+ENV ROARING_ARCH=$ARCH
+ENV CARGO_HTTP_MULTIPLEXING=false
+
+ARG APP_NAME=wallet
+ARG APP_EXEC=tari_console_wallet
+
+# GNU C compiler for the arm64 architecture and GNU C++ compiler
+#RUN if [[ "${TARGETPLATFORM}" == "linux/arm64" ]] ; then \
+RUN if [ "${TARGETARCH}" = "arm64" ] ; then \
+      echo "Setup ARM64" && \
+      apt update && \
+      apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu && \
+      rustup target add aarch64-unknown-linux-gnu && \
+      rustup toolchain install stable-aarch64-unknown-linux-gnu ; \
+    else \
+      echo "Setup x86-64" ; \
+    fi
+
+WORKDIR /tari
+
+ADD Cargo.toml .
+ADD Cargo.lock .
+ADD applications applications
+ADD base_layer base_layer
+ADD clients clients
+ADD common common
+ADD common_sqlite common_sqlite
+ADD comms comms
+ADD infrastructure infrastructure
+ADD dan_layer dan_layer
+ADD meta meta
+
+RUN --mount=type=cache,id=rust-git-${TARGETOS}-${TARGETARCH}${TARGETVARIANT},sharing=locked,target=/home/rust/.cargo/git \
+    --mount=type=cache,id=rust-home-registry-${TARGETOS}-${TARGETARCH}${TARGETVARIANT},sharing=locked,target=/home/rust/.cargo/registry \
+    --mount=type=cache,id=rust-local-registry-${TARGETOS}-${TARGETARCH}${TARGETVARIANT},sharing=locked,target=/usr/local/cargo/registry \
+    --mount=type=cache,id=rust-src-target-${TARGETOS}-${TARGETARCH}${TARGETVARIANT},sharing=locked,target=/home/rust/src/target \
+    --mount=type=cache,id=rust-target-${TARGETOS}-${TARGETARCH}${TARGETVARIANT},sharing=locked,target=/tari/target \
+    if [ "${TARGETARCH}" = "arm64" ] ; then \
+      export BUILD_TARGET="aarch64-unknown-linux-gnu/" && \
+      export RUST_TARGET="--target=aarch64-unknown-linux-gnu" && \
+      export ARCH=generic && \
+      export FEATURES=safe && \
+      export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc && \
+      export CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc && \
+      export CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++ && \
+      export BINDGEN_EXTRA_CLANG_ARGS="--sysroot /usr/aarch64-linux-gnu/include/" && \
+      export RUSTFLAGS="-C target_cpu=generic" && \
+      export ROARING_ARCH=generic ; \
+    fi && \
+    cargo update && \
+    cargo build ${RUST_TARGET} \
+      --bin ${APP_EXEC} --release --features $FEATURES --locked && \
+    # Copy executable out of the cache so it is available in the runtime image.
+    cp -v /tari/target/${BUILD_TARGET}release/${APP_EXEC} /tari/${APP_EXEC}
+
+# Create runtime base minimal image for the target platform executables
+FROM --platform=$TARGETPLATFORM bitnami/minideb:bullseye as runtime
+
+ARG BUILDPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+
+ARG VERSION=1.0.1
+
+ARG APP_NAME
+ARG APP_EXEC
+
+# Disable Prompt During Packages Installation
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Disable anti-cache
+RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
+RUN --mount=type=cache,id=runtime-apt-cache-${TARGETOS}-${TARGETARCH}${TARGETVARIANT},sharing=locked,target=/var/cache/apt \
+    --mount=type=cache,id=runtime-apt-lib-${TARGETOS}-${TARGETARCH}${TARGETVARIANT},sharing=locked,target=/var/lib/apt \
+  apt update && apt-get --no-install-recommends install -y \
+  apt-transport-https \
+  bash \
+  ca-certificates \
+  curl \
+  gpg \
+  iputils-ping \
+  less \
+  libreadline8 \
+  libreadline-dev \
+  libsqlite3-0 \
+  openssl \
+  telnet
+
+RUN groupadd -g 1000 tari && useradd -s /bin/bash -u 1000 -g 1000 tari
+
+ENV dockerfile_version=$VERSION
+ENV dockerfile_build_arch=$BUILDPLATFORM
+ENV APP_NAME=${APP_NAME:-wallet}
+ENV APP_EXEC=${APP_EXEC:-tari_console_wallet}
+
+RUN mkdir -p "/var/tari/${APP_NAME}" && \
+    chown -R tari.tari "/var/tari/${APP_NAME}"
+
+# Setup blockchain path for base_node only
+RUN if [ "${APP_NAME}" = "base_node" ] ; then \
+      echo "Base_node bits" && \
+      mkdir /blockchain && \
+      chown -R tari.tari /blockchain && \
+      chmod -R 0700 /blockchain ; \
+    else \
+      echo "Not base_node" ; \
+    fi
+
+USER tari
+
+COPY --from=builder /tari/$APP_EXEC /usr/bin/
+COPY applications/launchpad/docker_rig/start_tari_app.sh /usr/bin/start_tari_app.sh
+
+ENTRYPOINT [ "start_tari_app.sh", "-c", "/var/tari/config/config.toml", "-b", "/var/tari/${APP_NAME}" ]
+# CMD [ "--non-interactive-mode" ]

--- a/applications/launchpad/docker_rig/tor.Dockerfile
+++ b/applications/launchpad/docker_rig/tor.Dockerfile
@@ -1,15 +1,23 @@
+# Package build
 FROM alpine:latest
+
+ARG BUILDPLATFORM
 ARG VERSION=1.0.1
+
+# https://pkgs.alpinelinux.org/packages?name=tor&branch=v3.16&repo=community
+ARG TOR_VERSION=0.4.7.7-r1
 
 RUN apk update \
  && apk upgrade \
- && apk add tor \
-            bash \
+ && apk add tor=$TOR_VERSION \
  && rm /var/cache/apk/*
 
 EXPOSE 9050
 EXPOSE 9051
 ENV dockerfile_version=$VERSION
+ENV dockerfile_build_arch=$BUILDPLATFORM
+ENV tor_version=$TOR_VERSION
 
 USER tor
-CMD /usr/bin/tor -f /etc/tor/torrc
+ENTRYPOINT ["/usr/bin/tor"]
+CMD ["-f", "/etc/tor/torrc"]


### PR DESCRIPTION
Description
Update 3rd party docker images to support dual platform builds (x86-64/arm64)

Added TariLabs suite docker caching for quicker repeat builds locally

Motivation and Context
Multi platform builds from less dockerfiles, should mean less bit rote

How Has This Been Tested?
Build locally for all services.
