### PR TITLE
fix(block-sync): check coinbase maturity

### DIFF
--- a/base_layer/core/src/transactions/aggregated_body.rs
+++ b/base_layer/core/src/transactions/aggregated_body.rs
@@ -349,7 +349,6 @@ impl AggregateBody {
     /// This function does NOT check that inputs come from the UTXO set
     /// The reward is the total amount of Tari rewarded for this block (block reward + total fees), this should be 0
     /// for a transaction
-
     pub fn validate_internal_consistency(
         &self,
         tx_offset: &BlindingFactor,

--- a/base_layer/core/src/validation/block_validators/async_validator.rs
+++ b/base_layer/core/src/validation/block_validators/async_validator.rs
@@ -128,10 +128,11 @@ impl<B: BlockchainBackend + 'static> BlockValidator<B> {
         let kernels_result = kernels_task.await??;
 
         // Perform final checks using validation outputs
+        helpers::check_coinbase_maturity(&self.rules, valid_header.height, outputs_result.coinbase())?;
         helpers::check_coinbase_reward(
             &self.factories.commitment,
             &self.rules,
-            &valid_header,
+            valid_header.height,
             kernels_result.kernel_sum.fees,
             kernels_result.coinbase(),
             outputs_result.coinbase(),

--- a/base_layer/core/src/validation/helpers.rs
+++ b/base_layer/core/src/validation/helpers.rs
@@ -683,12 +683,22 @@ pub fn validate_covenants(block: &Block) -> Result<(), ValidationError> {
 pub fn check_coinbase_reward(
     factory: &CommitmentFactory,
     rules: &ConsensusManager,
-    header: &BlockHeader,
+    height: u64,
     total_fees: MicroTari,
     coinbase_kernel: &TransactionKernel,
     coinbase_output: &TransactionOutput,
 ) -> Result<(), ValidationError> {
-    let reward = rules.emission_schedule().block_reward(header.height) + total_fees;
+    let constants = rules.consensus_constants(height);
+    if coinbase_output.features.maturity < height + constants.coinbase_lock_height() {
+        warn!(
+            target: LOG_TARGET,
+            "Coinbase {} found with maturity set too low", coinbase_output
+        );
+        return Err(ValidationError::TransactionError(
+            TransactionError::InvalidCoinbaseMaturity,
+        ));
+    }
+    let reward = rules.emission_schedule().block_reward(height) + total_fees;
     let rhs = &coinbase_kernel.excess + &factory.commit_value(&Default::default(), reward.into());
     if rhs != coinbase_output.commitment {
         warn!(
@@ -696,6 +706,24 @@ pub fn check_coinbase_reward(
             "Coinbase {} amount validation failed", coinbase_output
         );
         return Err(ValidationError::TransactionError(TransactionError::InvalidCoinbase));
+    }
+    Ok(())
+}
+
+pub fn check_coinbase_maturity(
+    rules: &ConsensusManager,
+    height: u64,
+    coinbase_output: &TransactionOutput,
+) -> Result<(), ValidationError> {
+    let constants = rules.consensus_constants(height);
+    if coinbase_output.features.maturity < height + constants.coinbase_lock_height() {
+        warn!(
+            target: LOG_TARGET,
+            "Coinbase {} found with maturity set too low", coinbase_output
+        );
+        return Err(ValidationError::TransactionError(
+            TransactionError::InvalidCoinbaseMaturity,
+        ));
     }
     Ok(())
 }
@@ -774,7 +802,15 @@ pub fn check_blockchain_version(constants: &ConsensusConstants, version: u16) ->
 
 #[cfg(test)]
 mod test {
+
+    use tari_test_utils::unpack_enum;
+
     use super::*;
+    use crate::transactions::{
+        test_helpers,
+        test_helpers::TestParams,
+        transaction_components::{OutputFeatures, TransactionInputVersion},
+    };
 
     mod is_all_unique_and_sorted {
         use super::*;
@@ -843,7 +879,6 @@ mod test {
 
     mod check_lock_height {
         use super::*;
-        use crate::transactions::test_helpers;
 
         #[test]
         fn it_checks_the_kernel_timelock() {
@@ -861,7 +896,6 @@ mod test {
 
     mod check_maturity {
         use super::*;
-        use crate::transactions::transaction_components::{OutputFeatures, TransactionInputVersion};
 
         #[test]
         fn it_checks_the_input_maturity() {
@@ -891,6 +925,76 @@ mod test {
 
             check_maturity(5, &[input.clone()]).unwrap();
             check_maturity(6, &[input]).unwrap();
+        }
+    }
+
+    mod check_coinbase_maturity {
+
+        use super::*;
+
+        #[test]
+        fn it_succeeds_for_valid_coinbase() {
+            let test_params = TestParams::new();
+            let rules = test_helpers::create_consensus_manager();
+            let coinbase = test_helpers::create_unblinded_coinbase(&test_params, 1);
+            let coinbase_output = coinbase.as_transaction_output(&CryptoFactories::default()).unwrap();
+            check_coinbase_maturity(&rules, 1, &coinbase_output).unwrap();
+        }
+
+        #[test]
+        fn it_returns_error_for_invalid_coinbase_maturity() {
+            let test_params = TestParams::new();
+            let rules = test_helpers::create_consensus_manager();
+            let mut coinbase = test_helpers::create_unblinded_coinbase(&test_params, 1);
+            coinbase.features.maturity = 0;
+            let coinbase_output = coinbase.as_transaction_output(&CryptoFactories::default()).unwrap();
+            let err = check_coinbase_maturity(&rules, 1, &coinbase_output).unwrap_err();
+            unpack_enum!(ValidationError::TransactionError(err) = err);
+            unpack_enum!(TransactionError::InvalidCoinbaseMaturity = err);
+        }
+    }
+
+    mod check_coinbase_reward {
+
+        use super::*;
+
+        #[test]
+        fn it_succeeds_for_valid_coinbase() {
+            let test_params = TestParams::new();
+            let rules = test_helpers::create_consensus_manager();
+            let coinbase = test_helpers::create_unblinded_coinbase(&test_params, 1);
+            let coinbase_output = coinbase.as_transaction_output(&CryptoFactories::default()).unwrap();
+            let coinbase_kernel = test_helpers::create_coinbase_kernel(&coinbase.spending_key);
+            check_coinbase_reward(
+                &CommitmentFactory::default(),
+                &rules,
+                1,
+                0.into(),
+                &coinbase_kernel,
+                &coinbase_output,
+            )
+            .unwrap();
+        }
+
+        #[test]
+        fn it_returns_error_for_invalid_coinbase_reward() {
+            let test_params = TestParams::new();
+            let rules = test_helpers::create_consensus_manager();
+            let mut coinbase = test_helpers::create_unblinded_coinbase(&test_params, 1);
+            coinbase.value = 123.into();
+            let coinbase_output = coinbase.as_transaction_output(&CryptoFactories::default()).unwrap();
+            let coinbase_kernel = test_helpers::create_coinbase_kernel(&coinbase.spending_key);
+            let err = check_coinbase_reward(
+                &CommitmentFactory::default(),
+                &rules,
+                1,
+                0.into(),
+                &coinbase_kernel,
+                &coinbase_output,
+            )
+            .unwrap_err();
+            unpack_enum!(ValidationError::TransactionError(err) = err);
+            unpack_enum!(TransactionError::InvalidCoinbase = err);
         }
     }
 }

--- a/base_layer/core/tests/block_validation.rs
+++ b/base_layer/core/tests/block_validation.rs
@@ -792,7 +792,7 @@ async fn test_block_sync_body_validator() {
     let (coinbase_utxo, coinbase_kernel, _) = create_coinbase(
         &factories,
         rules.get_block_reward_at(1) + tx01.body.get_total_fee() + tx02.body.get_total_fee(),
-        1,
+        1 + rules.consensus_constants(1).coinbase_lock_height(),
     );
     let template = chain_block_with_coinbase(
         &genesis,

--- a/base_layer/core/tests/helpers/block_builders.rs
+++ b/base_layer/core/tests/helpers/block_builders.rs
@@ -307,7 +307,7 @@ pub fn chain_block_with_new_coinbase(
     let (coinbase_utxo, coinbase_kernel, coinbase_output) = create_coinbase(
         factories,
         coinbase_value,
-        height + consensus_manager.consensus_constants(0).coinbase_lock_height(),
+        height + consensus_manager.consensus_constants(height).coinbase_lock_height(),
     );
     let mut header = BlockHeader::from_previous(prev_block.header());
     header.height = height;


### PR DESCRIPTION
Description
---
- Checks for correct coinbase maturity in block sync validator
- Adds unit tests for `check_coinbase_maturity` and `check_coinbase_reward` helpers

Motivation and Context
---
Coinbase maturity should be checked on block sync.

How Has This Been Tested?
---
Additional unit tests pass. Manually  by syncing on dibbler testnet.

