### PR TITLE
fix(core): cleanup duplicate maturity check

### DIFF
--- a/base_layer/core/src/validation/helpers.rs
+++ b/base_layer/core/src/validation/helpers.rs
@@ -688,16 +688,6 @@ pub fn check_coinbase_reward(
     coinbase_kernel: &TransactionKernel,
     coinbase_output: &TransactionOutput,
 ) -> Result<(), ValidationError> {
-    let constants = rules.consensus_constants(height);
-    if coinbase_output.features.maturity < height + constants.coinbase_lock_height() {
-        warn!(
-            target: LOG_TARGET,
-            "Coinbase {} found with maturity set too low", coinbase_output
-        );
-        return Err(ValidationError::TransactionError(
-            TransactionError::InvalidCoinbaseMaturity,
-        ));
-    }
     let reward = rules.emission_schedule().block_reward(height) + total_fees;
     let rhs = &coinbase_kernel.excess + &factory.commit_value(&Default::default(), reward.into());
     if rhs != coinbase_output.commitment {


### PR DESCRIPTION
Description
---

Clean up duplicate maturity check introduced in #4168 

Motivation and Context
---
In PR #4168 I renamed`check_coinbase_reward` to `check_coinbase` but then decided that since `check_coinbase` doesn't fully check the coinbase, to split the checks into `check_coinbase_reward` and `check_coinbase_maturity` - however I forgot to take the code out of `check_coinbase_reward`.

[Duplicated code](https://github.com/tari-project/tari/pull/4168/files#diff-c76c3fe2827c9e3510483d26bf1c51ef22e25182e26719cfe26f123dfe598966R713)

How Has This Been Tested?
---
More tests are needed
