### PR TITLE
feat(core)!: add contract index to blockchain database

### DIFF
--- a/base_layer/common_types/src/types/fixed_hash.rs
+++ b/base_layer/common_types/src/types/fixed_hash.rs
@@ -22,6 +22,7 @@
 
 use std::{
     convert::TryFrom,
+    fmt::{Display, Formatter},
     ops::{Deref, DerefMut},
 };
 
@@ -141,5 +142,11 @@ impl Deref for FixedHash {
 impl DerefMut for FixedHash {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
+    }
+}
+
+impl Display for FixedHash {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0.to_hex())
     }
 }

--- a/base_layer/core/src/chain_storage/blockchain_backend.rs
+++ b/base_layer/core/src/chain_storage/blockchain_backend.rs
@@ -6,7 +6,7 @@ use std::ops::Range;
 use croaring::Bitmap;
 use tari_common_types::{
     chain_metadata::ChainMetadata,
-    types::{Commitment, HashOutput, PublicKey, Signature},
+    types::{Commitment, FixedHash, HashOutput, PublicKey, Signature},
 };
 use tari_mmr::Hash;
 
@@ -33,7 +33,7 @@ use crate::{
         Reorg,
         UtxoMinedInfo,
     },
-    transactions::transaction_components::{TransactionInput, TransactionKernel, TransactionOutput},
+    transactions::transaction_components::{OutputType, TransactionInput, TransactionKernel, TransactionOutput},
 };
 
 /// Identify behaviour for Blockchain database backends. Implementations must support `Send` and `Sync` so that
@@ -215,4 +215,11 @@ pub trait BlockchainBackend: Send + Sync {
 
     /// Fetches all tracked reorgs
     fn fetch_all_reorgs(&self) -> Result<Vec<Reorg>, ChainStorageError>;
+
+    /// Fetch all contract UTXOs for the given contract ID and output type. An empty Vec is returned if none are found.
+    fn fetch_contract_outputs_by_contract_id_and_type(
+        &self,
+        contract_id: FixedHash,
+        output_type: OutputType,
+    ) -> Result<Vec<UtxoMinedInfo>, ChainStorageError>;
 }

--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -36,7 +36,7 @@ use log::*;
 use serde::{Deserialize, Serialize};
 use tari_common_types::{
     chain_metadata::ChainMetadata,
-    types::{BlockHash, Commitment, HashDigest, HashOutput, PublicKey, Signature},
+    types::{BlockHash, Commitment, FixedHash, HashDigest, HashOutput, PublicKey, Signature},
 };
 use tari_mmr::{pruned_hashset::PrunedHashSet, MerkleMountainRange, MutableMmr};
 use tari_utilities::{epoch_time::EpochTime, hex::Hex, ByteArray, Hashable};
@@ -79,7 +79,7 @@ use crate::{
     common::rolling_vec::RollingVec,
     consensus::{chain_strength_comparer::ChainStrengthComparer, ConsensusConstants, ConsensusManager},
     proof_of_work::{monero_rx::MoneroPowData, PowAlgorithm, TargetDifficultyWindow},
-    transactions::transaction_components::{TransactionInput, TransactionKernel, TransactionOutput},
+    transactions::transaction_components::{OutputType, TransactionInput, TransactionKernel, TransactionOutput},
     validation::{
         helpers::calc_median_timestamp,
         DifficultyCalculator,
@@ -1169,6 +1169,15 @@ where B: BlockchainBackend
     pub fn fetch_all_reorgs(&self) -> Result<Vec<Reorg>, ChainStorageError> {
         let db = self.db_read_access()?;
         db.fetch_all_reorgs()
+    }
+
+    pub fn fetch_contract_outputs_by_contract_id_and_type(
+        &self,
+        contract_id: FixedHash,
+        output_type: OutputType,
+    ) -> Result<Vec<UtxoMinedInfo>, ChainStorageError> {
+        let db = self.db_read_access()?;
+        db.fetch_contract_outputs_by_contract_id_and_type(contract_id, output_type)
     }
 
     pub fn clear_all_reorgs(&self) -> Result<(), ChainStorageError> {

--- a/base_layer/core/src/chain_storage/error.rs
+++ b/base_layer/core/src/chain_storage/error.rs
@@ -129,6 +129,8 @@ pub enum ChainStorageError {
     TransactionError(#[from] TransactionError),
     #[error("Could not convert data:{0}")]
     ConversionError(String),
+    #[error("Unable to spend UTXO because it has dependant UTXOS: {details}")]
+    UnspendableDueToDependentUtxos { details: String },
 }
 
 impl ChainStorageError {

--- a/base_layer/core/src/chain_storage/lmdb_db/contract_index.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/contract_index.rs
@@ -1,0 +1,336 @@
+//  Copyright 2022, The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::{
+    collections::{hash_map::DefaultHasher, HashSet},
+    convert::{TryFrom, TryInto},
+    fmt::{Debug, Display, Formatter},
+    hash::BuildHasherDefault,
+    ops::Deref,
+};
+
+use lmdb_zero::{traits::AsLmdbBytes, ConstTransaction, Database, WriteTransaction};
+use log::*;
+use serde::{de::DeserializeOwned, Serialize};
+use tari_common_types::types::FixedHash;
+use tari_utilities::{hex::to_hex, Hashable};
+
+use crate::{
+    chain_storage::{
+        lmdb_db::lmdb::{lmdb_delete, lmdb_exists, lmdb_get, lmdb_insert, lmdb_replace},
+        ChainStorageError,
+    },
+    transactions::transaction_components::{OutputType, TransactionInput, TransactionOutput},
+};
+
+const LOG_TARGET: &str = "c::cs::lmdb_db::lmdb::contract_index";
+
+/// The Contract Index.
+///
+/// The contract index keeps track all UTXOs related to a particular contract as given by
+/// [OutputFeatures::contract_id](OutputFeatures::contract_id].
+pub(super) struct ContractIndex<'a, T> {
+    txn: &'a T,
+    db: &'a Database<'a>,
+}
+
+impl<'a, T> ContractIndex<'a, T>
+where T: Deref<Target = ConstTransaction<'a>>
+{
+    /// Create a new ContractIndex
+    pub fn new(txn: &'a T, db: &'a Database<'a>) -> Self {
+        Self { txn, db }
+    }
+
+    pub fn fetch(&self, contract_id: FixedHash, output_type: OutputType) -> Result<Vec<FixedHash>, ChainStorageError> {
+        let key = ContractIndexKey::new(contract_id, output_type);
+
+        match output_type {
+            OutputType::ContractDefinition | OutputType::ContractCheckpoint | OutputType::ContractConstitution => {
+                Ok(self.find::<FixedHash>(&key)?.into_iter().collect())
+            },
+            OutputType::ContractValidatorAcceptance |
+            OutputType::ContractConstitutionProposal |
+            OutputType::ContractConstitutionChangeAcceptance => {
+                Ok(self.find::<FixedHashSet>(&key)?.into_iter().flatten().collect())
+            },
+            _ => Err(ChainStorageError::InvalidOperation(format!(
+                "Cannot fetch output type {} from contract index",
+                output_type
+            ))),
+        }
+    }
+
+    fn find<V: DeserializeOwned>(&self, key: &ContractIndexKey) -> Result<Option<V>, ChainStorageError> {
+        lmdb_get(&**self.txn, self.db, key)
+    }
+
+    fn exists(&self, key: &ContractIndexKey) -> Result<bool, ChainStorageError> {
+        lmdb_exists(&**self.txn, self.db, key)
+    }
+}
+
+impl<'a> ContractIndex<'a, WriteTransaction<'a>> {
+    /// Called when a new output must be added to the index
+    pub fn add_output(&self, output: &TransactionOutput) -> Result<(), ChainStorageError> {
+        let output_hash = FixedHash::try_from(output.hash())
+            .map_err(|_| ChainStorageError::CriticalError("output.hash() was not 32-bytes".to_string()))?;
+
+        let contract_id = output.features.contract_id().ok_or_else(|| {
+            ChainStorageError::InvalidOperation(format!(
+                "Attempt to add non-contract output with hash {} to contract index.",
+                output_hash
+            ))
+        })?;
+        self.add_to_index(contract_id, output.features.output_type, output_hash)
+    }
+
+    /// Updates the index, removing references to the output that the given input spends.
+    pub fn spend(&self, input: &TransactionInput) -> Result<(), ChainStorageError> {
+        let output_hash = FixedHash::try_from(input.output_hash()).unwrap();
+        let features = input.features()?;
+        let contract_id = features.contract_id().ok_or_else(|| {
+            ChainStorageError::InvalidOperation(format!(
+                "Attempt to add non-contract output with hash {} to contract index.",
+                output_hash
+            ))
+        })?;
+        self.remove_from_index(contract_id, features.output_type, output_hash)
+    }
+
+    /// Updates the index, rewinding (undoing) the effect of the output on the index state.
+    pub fn rewind_output(&self, output: &TransactionOutput) -> Result<(), ChainStorageError> {
+        let output_hash = FixedHash::try_from(output.hash()).unwrap();
+        let features = &output.features;
+        let contract_id = features.contract_id().ok_or_else(|| {
+            ChainStorageError::InvalidOperation(format!(
+                "Attempt to add non-contract output with hash {} to contract index.",
+                output_hash
+            ))
+        })?;
+        self.remove_from_index(contract_id, features.output_type, output_hash)
+    }
+
+    /// Updates the index, rewinding (undoing) the effect of the input on the index state.
+    pub fn rewind_input(&self, input: &TransactionInput) -> Result<(), ChainStorageError> {
+        let output_hash = input
+            .output_hash()
+            .try_into()
+            .map_err(|_| ChainStorageError::CriticalError("input.output_hash() was not 32-bytes".to_string()))?;
+
+        let features = input.features()?;
+        let contract_id = features.contract_id().ok_or_else(|| {
+            ChainStorageError::InvalidOperation(format!(
+                "Attempt to add non-contract input with hash {} to contract index.",
+                output_hash
+            ))
+        })?;
+        self.add_to_index(contract_id, features.output_type, output_hash)
+    }
+
+    fn add_to_index(
+        &self,
+        contract_id: FixedHash,
+        output_type: OutputType,
+        output_hash: FixedHash,
+    ) -> Result<(), ChainStorageError> {
+        let key = ContractIndexKey::new(contract_id, output_type);
+        match output_type {
+            OutputType::ContractDefinition => {
+                debug!(
+                    target: LOG_TARGET,
+                    "inserting index for new contract_id {} in output {}.", contract_id, output_hash
+                );
+                self.insert(&key, &output_hash)?;
+
+                Ok(())
+            },
+            // Only one contract checkpoint and constitution can exist at a time and can be overwritten. Consensus rules
+            // decide whether this is valid but we just assume this is valid here.
+            OutputType::ContractConstitution | OutputType::ContractCheckpoint => {
+                self.assert_definition_exists(contract_id)?;
+                self.set(&key, &*output_hash)?;
+                Ok(())
+            },
+            // These are collections of output hashes
+            OutputType::ContractValidatorAcceptance | OutputType::ContractConstitutionProposal => {
+                self.assert_definition_exists(contract_id)?;
+                let mut hashes = self.find::<FixedHashSet>(&key)?.unwrap_or_default();
+
+                if !hashes.insert(output_hash) {
+                    return Err(ChainStorageError::InvalidOperation(format!(
+                        "{} UTXO for contract {} with hash {} has already been added to index",
+                        output_type, contract_id, output_hash
+                    )));
+                }
+
+                self.set(&key, &hashes)?;
+                Ok(())
+            },
+            _ => Err(ChainStorageError::InvalidOperation(format!(
+                "Invalid output_type for contract UTXO: output_hash: {}, contract_id: {}, output_type: {}",
+                output_hash, contract_id, output_type
+            ))),
+        }
+    }
+
+    fn remove_from_index(
+        &self,
+        contract_id: FixedHash,
+        output_type: OutputType,
+        output_hash: FixedHash,
+    ) -> Result<(), ChainStorageError> {
+        let key = ContractIndexKey::new(contract_id, output_type);
+
+        match output_type {
+            OutputType::ContractDefinition => {
+                if self.has_dependent_outputs(&key)? {
+                    return Err(ChainStorageError::UnspendableDueToDependentUtxos {
+                        details: format!(
+                            "Cannot deregister contract definition for contract {} because there are dependent outputs",
+                            contract_id
+                        ),
+                    });
+                }
+
+                self.delete(&key)?;
+                Ok(())
+            },
+            OutputType::ContractConstitution | OutputType::ContractCheckpoint => {
+                self.delete(&key)?;
+                Ok(())
+            },
+            OutputType::ContractValidatorAcceptance | OutputType::ContractConstitutionProposal => {
+                let mut hash_set = self.find::<FixedHashSet>(&key)?.unwrap_or_default();
+                if !hash_set.remove(&output_hash) {
+                    return Err(ChainStorageError::InvalidOperation(format!(
+                        "Output {} was not found in {} UTXO set for contract_id {}",
+                        output_hash, output_type, contract_id
+                    )));
+                }
+                if hash_set.is_empty() {
+                    self.delete(&key)?;
+                } else {
+                    self.set(&key, &hash_set)?;
+                }
+                Ok(())
+            },
+            _ => Err(ChainStorageError::InvalidOperation(format!(
+                "Invalid output_type {} for contract {} for UTXO {}",
+                output_type, contract_id, output_hash
+            ))),
+        }
+    }
+
+    fn has_dependent_outputs(&self, key: &ContractIndexKey) -> Result<bool, ChainStorageError> {
+        let constitution_key = key.to_key_with_output_type(OutputType::ContractConstitution);
+        if self.exists(&constitution_key)? {
+            return Ok(true);
+        }
+        let checkpoint_key = key.to_key_with_output_type(OutputType::ContractCheckpoint);
+        if self.exists(&checkpoint_key)? {
+            return Ok(true);
+        }
+        Ok(false)
+    }
+
+    fn assert_definition_exists(&self, contract_id: FixedHash) -> Result<(), ChainStorageError> {
+        let key = ContractIndexKey::new(contract_id, OutputType::ContractDefinition);
+        if self.exists(&key)? {
+            Ok(())
+        } else {
+            Err(ChainStorageError::InvalidOperation(format!(
+                "No contract definition for contract id {}",
+                contract_id
+            )))
+        }
+    }
+
+    fn insert<V: Serialize + Debug>(&self, key: &ContractIndexKey, value: &V) -> Result<(), ChainStorageError> {
+        lmdb_insert(self.txn, self.db, key, value, "contract_index")
+    }
+
+    fn set<V: Serialize>(&self, key: &ContractIndexKey, value: &V) -> Result<(), ChainStorageError> {
+        lmdb_replace(self.txn, self.db, key, value)
+    }
+
+    fn delete(&self, key: &ContractIndexKey) -> Result<(), ChainStorageError> {
+        lmdb_delete(self.txn, self.db, key, "contract_index")
+    }
+}
+
+/// A hash set using the DefaultHasher. Since output hashes are not user controlled and uniformly random there is no
+/// need to use RandomState hasher.
+type FixedHashSet = HashSet<FixedHash, BuildHasherDefault<DefaultHasher>>;
+
+/// A 33-byte contract ID index key.
+///
+/// The first 32-bytes are the contract ID, the next byte is the `OutputType`.
+#[derive(Debug, Clone, Copy)]
+pub(self) struct ContractIndexKey {
+    bytes: [u8; Self::FULL_KEY_LEN],
+}
+
+impl ContractIndexKey {
+    const FULL_KEY_LEN: usize = FixedHash::byte_size() + 1;
+
+    pub fn new(contract_id: FixedHash, output_type: OutputType) -> Self {
+        Self {
+            bytes: Self::bytes_from_parts(contract_id, output_type),
+        }
+    }
+
+    pub fn to_key_with_output_type(self, output_type: OutputType) -> Self {
+        let mut key = self;
+        key.bytes[FixedHash::byte_size()] = output_type.as_byte();
+        key
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.bytes[..]
+    }
+
+    fn bytes_from_parts(contract_id: FixedHash, output_type: OutputType) -> [u8; Self::FULL_KEY_LEN] {
+        let mut buf = Self::new_buf();
+        buf[..FixedHash::byte_size()].copy_from_slice(&*contract_id);
+        buf[FixedHash::byte_size()] = output_type.as_byte();
+        buf
+    }
+
+    /// Returns an 0xff filled buf. 0xff is used because if the 8-byte deleted_height part is not populated, it is the
+    /// last key value.
+    const fn new_buf() -> [u8; Self::FULL_KEY_LEN] {
+        [0x0u8; Self::FULL_KEY_LEN]
+    }
+}
+
+impl AsLmdbBytes for ContractIndexKey {
+    fn as_lmdb_bytes(&self) -> &[u8] {
+        self.as_bytes()
+    }
+}
+
+impl Display for ContractIndexKey {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", to_hex(self.as_bytes()))
+    }
+}

--- a/base_layer/core/src/chain_storage/lmdb_db/contract_index.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/contract_index.rs
@@ -316,8 +316,7 @@ impl ContractIndexKey {
         buf
     }
 
-    /// Returns an 0xff filled buf. 0xff is used because if the 8-byte deleted_height part is not populated, it is the
-    /// last key value.
+    /// Returns a fixed 0-filled byte array.
     const fn new_buf() -> [u8; Self::FULL_KEY_LEN] {
         [0x0u8; Self::FULL_KEY_LEN]
     }
@@ -332,5 +331,28 @@ impl AsLmdbBytes for ContractIndexKey {
 impl Display for ContractIndexKey {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", to_hex(self.as_bytes()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use digest::Digest;
+    use tari_common_types::types::HashDigest;
+
+    use super::*;
+    mod contract_index_key {
+
+        use super::*;
+
+        #[test]
+        fn it_represents_a_well_formed_contract_index_key() {
+            let hash = HashDigest::new().chain(b"foobar").finalize().into();
+            let key = ContractIndexKey::new(hash, OutputType::ContractCheckpoint);
+            assert_eq!(key.as_lmdb_bytes()[..32], *hash.as_slice());
+            assert_eq!(
+                OutputType::from_byte(key.as_lmdb_bytes()[32]).unwrap(),
+                OutputType::ContractCheckpoint
+            );
+        }
     }
 }

--- a/base_layer/core/src/chain_storage/lmdb_db/mod.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/mod.rs
@@ -26,6 +26,7 @@ use tari_common_types::types::HashOutput;
 
 use crate::transactions::transaction_components::{TransactionInput, TransactionKernel, TransactionOutput};
 
+mod contract_index;
 pub(crate) mod helpers;
 pub(crate) mod key_prefix_cursor;
 mod lmdb;

--- a/base_layer/core/src/chain_storage/tests/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/tests/blockchain_database.rs
@@ -19,21 +19,27 @@
 //  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
 use std::sync::Arc;
 
 use rand::rngs::OsRng;
-use tari_common_types::types::PublicKey;
-use tari_crypto::keys::PublicKey as PublicKeyTrait;
+use tari_common_types::types::{CommitmentFactory, FixedHash, PublicKey};
+use tari_crypto::{
+    commitment::HomomorphicCommitmentFactory,
+    keys::PublicKey as PublicKeyTrait,
+    ristretto::RistrettoPublicKey,
+};
 use tari_test_utils::unpack_enum;
 use tari_utilities::{hex::Hex, Hashable};
 
+use super::helpers;
 use crate::{
+    block_spec,
+    block_specs,
     blocks::{Block, BlockHeader, BlockHeaderAccumulatedData, ChainHeader, NewBlockTemplate},
     chain_storage::{BlockchainDatabase, ChainStorageError},
     proof_of_work::{AchievedTargetDifficulty, Difficulty, PowAlgorithm},
     test_helpers::{
-        blockchain::{create_new_blockchain, TempDatabase},
+        blockchain::{create_new_blockchain, TempDatabase, TestBlockchain},
         create_block,
         BlockSpec,
     },
@@ -41,6 +47,7 @@ use crate::{
         tari_amount::T,
         test_helpers::{schema_to_transaction, TransactionSchema},
         transaction_components::{OutputFeatures, OutputType, Transaction, UnblindedOutput},
+        CryptoFactories,
     },
     txn_schema,
 };
@@ -709,11 +716,7 @@ mod clear_all_pending_headers {
 }
 
 mod fetch_utxo_by_unique_id {
-    use tari_common_types::types::CommitmentFactory;
-    use tari_crypto::{commitment::HomomorphicCommitmentFactory, ristretto::RistrettoPublicKey};
-
     use super::*;
-    use crate::transactions::transaction_components::OutputType;
 
     #[test]
     fn it_returns_none_if_empty() {
@@ -846,5 +849,183 @@ mod fetch_utxo_by_unique_id {
             assert_utxo_found(asset_utxo1, Some(i));
         });
         assert_utxo_found(asset_utxo2, Some(11));
+    }
+}
+
+mod with_contract_utxos {
+    use super::*;
+
+    mod add_block {
+        use super::*;
+
+        #[test]
+        fn it_adds_the_contract_definition_to_the_index() {
+            // Don't validate because we're testing the behaviour of the DB contract index
+            let blockchain = helpers::create_blockchain_without_validation();
+            let (_, coinbase_a) = blockchain.create_next_tip(block_spec!("A", parent: "GB"));
+            let (contract_definition, _) =
+                helpers::create_contract_definition_transaction(vec![coinbase_a], vec![T], FixedHash::zero());
+            let _block = blockchain.create_next_tip(block_spec!("B", transactions: vec![contract_definition]));
+        }
+
+        #[test]
+        fn it_errors_if_adding_duplicate_contract_definition() {
+            let contract_id = FixedHash::zero();
+            // Don't validate because we're testing the behaviour of the DB contract index
+            let mut blockchain = helpers::create_blockchain_without_validation();
+            let (_, coinbase_a) = blockchain.append_to_tip(block_spec!("A", parent: "GB")).unwrap();
+            // Spend coinbase_a to new contract definition
+            let (contract_definition, outputs) =
+                helpers::create_contract_definition_transaction(vec![coinbase_a], vec![2 * T], contract_id);
+            let _output = blockchain
+                .append_to_tip(block_spec!("B", transactions: vec![contract_definition]))
+                .unwrap();
+
+            let change = outputs
+                .iter()
+                .find(|output| !output.features.is_sidechain_contract())
+                .unwrap()
+                .clone();
+            let (contract_definition, _) =
+                helpers::create_contract_definition_transaction(vec![change], vec![T], contract_id);
+            let err = blockchain
+                .append_to_tip(block_spec!("C", transactions: vec![contract_definition]))
+                .unwrap_err();
+            unpack_enum!(ChainStorageError::KeyExists { table_name, .. } = err);
+            assert_eq!(table_name, "contract_index");
+        }
+
+        #[test]
+        fn it_allows_spend_of_contract_definition_without_dependent_utxos() {
+            let contract_id = FixedHash::zero();
+            let mut blockchain = helpers::create_blockchain_without_validation();
+            let (_, coinbase_a) = blockchain.append_to_tip(block_spec!("A", parent: "GB")).unwrap();
+            // Spend coinbase_a to new contract definition
+            let (contract_definition, outputs) =
+                helpers::create_contract_definition_transaction(vec![coinbase_a], vec![2 * T], contract_id);
+            let _output = blockchain
+                .append_to_tip(block_spec!("B", transactions: vec![contract_definition]))
+                .unwrap();
+
+            let contract_definition = outputs
+                .iter()
+                .find(|output| output.features.is_sidechain_contract())
+                .unwrap()
+                .clone();
+            let (txns, _) = schema_to_transaction(&[txn_schema!(from: vec![contract_definition], to: vec![T])]);
+            blockchain
+                .append_to_tip(
+                    block_spec!("C", transactions: txns.into_iter().map(|tx| Arc::try_unwrap(tx).unwrap()).collect()),
+                )
+                .unwrap();
+        }
+
+        #[test]
+        fn it_errors_on_spend_of_contract_definition_with_dependent_utxos() {
+            let contract_id = FixedHash::zero();
+            // Don't validate because we're testing the behaviour of the DB contract index
+            let mut blockchain = helpers::create_blockchain_without_validation();
+            let (_, coinbase_a) = blockchain.append_to_tip(block_spec!("A", parent: "GB")).unwrap();
+            // Spend coinbase_a to new contract definition
+            let (contract_definition, outputs) =
+                helpers::create_contract_definition_transaction(vec![coinbase_a], vec![2 * T], contract_id);
+            let _output = blockchain
+                .append_to_tip(block_spec!("B", transactions: vec![contract_definition]))
+                .unwrap();
+            let (contract_definition, change) = outputs
+                .into_iter()
+                .partition::<Vec<_>, _>(|output| output.features.is_sidechain_contract());
+
+            let (constitution, _) = helpers::create_contract_constitution_transaction(change, contract_id);
+            blockchain
+                .append_to_tip(block_spec!("C", transactions: vec![constitution]))
+                .unwrap();
+            let (txns, _) = schema_to_transaction(&[txn_schema!(from: contract_definition, to: vec![T])]);
+            let err = blockchain
+                .append_to_tip(block_spec!("D", transactions: txns.into_iter().map(|tx| (*tx).clone()).collect()))
+                .unwrap_err();
+            unpack_enum!(ChainStorageError::UnspendableDueToDependentUtxos { .. } = err);
+        }
+    }
+
+    mod fetch_contract_outputs_by_contract_id_and_type {
+        use super::*;
+
+        #[test]
+        fn it_returns_none_if_contract_does_not_exist() {
+            let blockchain = TestBlockchain::default();
+            let utxo = blockchain
+                .db()
+                .fetch_contract_outputs_by_contract_id_and_type(FixedHash::zero(), OutputType::ContractDefinition)
+                .unwrap();
+            assert!(utxo.is_empty());
+        }
+
+        #[test]
+        fn it_errors_on_spend_of_contract_definition_with_dependent_utxos() {
+            let contract_id = FixedHash::zero();
+            let mut blockchain = helpers::create_blockchain_without_validation();
+            let (_, coinbase_a) = blockchain.append_to_tip(block_spec!("A", parent: "GB")).unwrap();
+            // Spend coinbase_a to new contract definition
+            let (contract_definition, outputs) =
+                helpers::create_contract_definition_transaction(vec![coinbase_a], vec![2 * T], contract_id);
+
+            let _block = blockchain
+                .append_to_tip(block_spec!("B", transactions: vec![contract_definition]))
+                .unwrap();
+            let (contract_definition, change) = outputs
+                .into_iter()
+                .partition::<Vec<_>, _>(|output| output.features.is_sidechain_contract());
+            let contract_def_hash = contract_definition[0].hash(&CryptoFactories::default());
+            let utxo = blockchain
+                .db()
+                .fetch_contract_outputs_by_contract_id_and_type(FixedHash::zero(), OutputType::ContractDefinition)
+                .unwrap();
+            assert_eq!(utxo[0].output.hash(), contract_def_hash);
+
+            let (constitution, outputs) = helpers::create_contract_constitution_transaction(change, contract_id);
+            blockchain
+                .append_to_tip(block_spec!("C", transactions: vec![constitution]))
+                .unwrap();
+            let contract_const_hash = outputs
+                .into_iter()
+                .find(|o| o.features.is_sidechain_contract())
+                .map(|o| o.hash(&CryptoFactories::default()))
+                .unwrap();
+            let utxos = blockchain
+                .db()
+                .fetch_contract_outputs_by_contract_id_and_type(FixedHash::zero(), OutputType::ContractConstitution)
+                .unwrap();
+            assert_eq!(utxos[0].output.hash(), contract_const_hash);
+        }
+    }
+
+    mod reorgs {
+        use super::*;
+
+        #[test]
+        fn it_removes_contract_utxo_from_index_on_reorg() {
+            let contract_id = FixedHash::zero();
+            let mut blockchain = helpers::create_blockchain_without_validation();
+            let (_, coinbase_a) = blockchain.append_to_tip(block_spec!("1->GB")).unwrap();
+            let (txn, _) = helpers::create_contract_definition_transaction(vec![coinbase_a], vec![2 * T], contract_id);
+            blockchain
+                .append_chain(block_specs!(["1a->GB"], ["2a->1a", transactions: vec![txn]]))
+                .unwrap();
+            let utxos = blockchain
+                .db()
+                .fetch_contract_outputs_by_contract_id_and_type(FixedHash::zero(), OutputType::ContractDefinition)
+                .unwrap();
+            assert_eq!(utxos.len(), 1);
+            // Reorg out
+            blockchain
+                .append_chain(block_specs!(["1b->GB"], ["2b->1b"], ["3b->2b", difficulty: 10]))
+                .unwrap();
+            let utxos = blockchain
+                .db()
+                .fetch_contract_outputs_by_contract_id_and_type(FixedHash::zero(), OutputType::ContractDefinition)
+                .unwrap();
+            assert_eq!(utxos.len(), 0);
+        }
     }
 }

--- a/base_layer/core/src/chain_storage/tests/helpers.rs
+++ b/base_layer/core/src/chain_storage/tests/helpers.rs
@@ -1,0 +1,124 @@
+//  Copyright 2022, The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::sync::Arc;
+
+use tari_common_types::types::{FixedHash, PublicKey};
+
+use crate::{
+    chain_storage::Validators,
+    test_helpers::blockchain::TestBlockchain,
+    transactions::{
+        tari_amount::{MicroTari, T},
+        test_helpers::schema_to_transaction,
+        transaction_components::{
+            CheckpointParameters,
+            CommitteeMembers,
+            ConstitutionChangeFlags,
+            ConstitutionChangeRules,
+            ContractAcceptanceRequirements,
+            ContractConstitution,
+            ContractDefinition,
+            ContractSpecification,
+            OutputFeatures,
+            OutputType,
+            SideChainConsensus,
+            SideChainFeatures,
+            Transaction,
+            UnblindedOutput,
+        },
+    },
+    txn_schema,
+    validation::mocks::MockValidator,
+};
+
+pub fn create_blockchain_without_validation() -> TestBlockchain {
+    TestBlockchain::with_validators(Validators {
+        block: Arc::new(MockValidator::new(true)),
+        header: Arc::new(MockValidator::new(true)),
+        orphan: Arc::new(MockValidator::new(true)),
+    })
+}
+
+pub fn create_contract_definition_features(contract_id: FixedHash) -> OutputFeatures {
+    OutputFeatures {
+        output_type: OutputType::ContractDefinition,
+        sidechain_features: Some(
+            SideChainFeatures::builder(contract_id)
+                .with_contract_definition(ContractDefinition {
+                    contract_name: [1u8; 32],
+                    contract_issuer: PublicKey::default(),
+                    contract_spec: ContractSpecification {
+                        runtime: [2u8; 32],
+                        public_functions: vec![],
+                    },
+                })
+                .finish(),
+        ),
+        ..Default::default()
+    }
+}
+
+pub fn create_contract_definition_transaction(
+    inputs: Vec<UnblindedOutput>,
+    outputs: Vec<MicroTari>,
+    contract_id: FixedHash,
+) -> (Transaction, Vec<UnblindedOutput>) {
+    let features = create_contract_definition_features(contract_id);
+    let (transactions, outputs) =
+        schema_to_transaction(&[txn_schema!(from: inputs, to: outputs, fee: 5.into(), lock: 0, features: features)]);
+    ((*transactions[0]).clone(), outputs)
+}
+
+pub fn create_contract_constitution_transaction(
+    inputs: Vec<UnblindedOutput>,
+    contract_id: FixedHash,
+) -> (Transaction, Vec<UnblindedOutput>) {
+    let features = OutputFeatures {
+        output_type: OutputType::ContractConstitution,
+        sidechain_features: Some(
+            SideChainFeatures::builder(contract_id)
+                .with_contract_constitution(ContractConstitution {
+                    validator_committee: CommitteeMembers::default(),
+                    acceptance_requirements: ContractAcceptanceRequirements {
+                        acceptance_period_expiry: 0,
+                        minimum_quorum_required: 0,
+                    },
+                    consensus: SideChainConsensus::Bft,
+                    checkpoint_params: CheckpointParameters {
+                        minimum_quorum_required: 1,
+                        abandoned_interval: 20,
+                    },
+                    constitution_change_rules: ConstitutionChangeRules {
+                        change_flags: ConstitutionChangeFlags::empty(),
+                        requirements_for_constitution_change: None,
+                    },
+                    initial_reward: 10u64.into(),
+                })
+                .finish(),
+        ),
+        ..Default::default()
+    };
+    let (transactions, outputs) =
+        schema_to_transaction(&[txn_schema!(from: inputs, to: vec![T], fee: 5.into(), lock: 0, features: features)]);
+    ((*transactions[0]).clone(), outputs)
+}

--- a/base_layer/core/src/chain_storage/tests/mod.rs
+++ b/base_layer/core/src/chain_storage/tests/mod.rs
@@ -21,3 +21,4 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 mod blockchain_database;
+mod helpers;

--- a/base_layer/core/src/transactions/transaction_components/mod.rs
+++ b/base_layer/core/src/transactions/transaction_components/mod.rs
@@ -36,7 +36,7 @@ pub use output_features::OutputFeatures;
 pub use output_features_version::OutputFeaturesVersion;
 pub use output_type::OutputType;
 pub use rewind_result::RewindResult;
-pub use side_chain::{ContractConstitution, *};
+pub use side_chain::*;
 pub use side_chain_checkpoint_features::SideChainCheckpointFeatures;
 use tari_common_types::types::Commitment;
 use tari_script::TariScript;

--- a/base_layer/core/src/transactions/transaction_components/output_features.rs
+++ b/base_layer/core/src/transactions/transaction_components/output_features.rs
@@ -342,6 +342,10 @@ impl OutputFeatures {
     pub fn contract_id(&self) -> Option<FixedHash> {
         self.sidechain_features.as_ref().map(|f| f.contract_id)
     }
+
+    pub fn is_sidechain_contract(&self) -> bool {
+        self.sidechain_features.is_some()
+    }
 }
 
 impl ConsensusEncoding for OutputFeatures {

--- a/base_layer/core/src/transactions/transaction_components/output_type.rs
+++ b/base_layer/core/src/transactions/transaction_components/output_type.rs
@@ -23,7 +23,11 @@
 // Portions of this file were originally copyrighted (c) 2018 The Grin Developers, issued under the Apache License,
 // Version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0.
 
-use std::{io, io::Read};
+use std::{
+    fmt::{Display, Formatter},
+    io,
+    io::Read,
+};
 
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
@@ -111,6 +115,13 @@ impl ConsensusDecoding for OutputType {
             )
         })?;
         Ok(output_type)
+    }
+}
+
+impl Display for OutputType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        // Debug "shortcut" works because variants do not have fields
+        write!(f, "{:?}", self)
     }
 }
 

--- a/base_layer/core/src/validation/block_validators/test.rs
+++ b/base_layer/core/src/validation/block_validators/test.rs
@@ -87,7 +87,7 @@ async fn it_passes_if_block_is_valid() {
 async fn it_checks_the_coinbase_reward() {
     let (blockchain, validator) = setup();
 
-    let (block, _) = blockchain.create_chained_block("GB", BlockSpec::new().with_reward(10_000_000.into()).finish());
+    let (block, _) = blockchain.create_chained_block(block_spec!("A", parent: "GB", reward: 10 * T, ));
     let err = validator.validate_block_body(block.block().clone()).await.unwrap_err();
     assert!(matches!(
         err,
@@ -99,7 +99,7 @@ async fn it_checks_the_coinbase_reward() {
 async fn it_checks_exactly_one_coinbase() {
     let (blockchain, validator) = setup();
 
-    let (mut block, coinbase) = blockchain.create_unmined_block("GB", BlockSpec::new());
+    let (mut block, coinbase) = blockchain.create_unmined_block(block_spec!("A1", parent: "GB"));
 
     let (_, coinbase_output) = CoinbaseBuilder::new(CryptoFactories::default())
         .with_block_height(1)
@@ -119,7 +119,7 @@ async fn it_checks_exactly_one_coinbase() {
     let err = validator.validate_block_body(block.block().clone()).await.unwrap_err();
     unpack_enum!(ValidationError::TransactionError(TransactionError::MoreThanOneCoinbase) = err);
 
-    let (block, _) = blockchain.create_unmined_block("GB", BlockSpec::new().skip_coinbase().finish());
+    let (block, _) = blockchain.create_unmined_block(block_spec!("A2", parent: "GB", skip_coinbase: true,));
     let block = blockchain.mine_block("GB", block, 1.into());
 
     let err = validator.validate_block_body(block.block().clone()).await.unwrap_err();
@@ -130,15 +130,12 @@ async fn it_checks_exactly_one_coinbase() {
 async fn it_checks_double_spends() {
     let (mut blockchain, validator) = setup();
 
-    let (_, coinbase_a) = blockchain.add_next_tip("A", Default::default());
+    let (_, coinbase_a) = blockchain.add_next_tip(block_spec!("A")).unwrap();
     let (txs, _) = schema_to_transaction(&[txn_schema!(from: vec![coinbase_a], to: vec![50 * T])]);
 
-    blockchain.add_next_tip(
-        "B",
-        BlockSpec::new()
-            .with_transactions(txs.iter().map(|t| (**t).clone()).collect())
-            .finish(),
-    );
+    blockchain
+        .add_next_tip(block_spec!("1", transactions: txs.iter().map(|t| (**t).clone()).collect()))
+        .unwrap();
     let (block, _) = blockchain.create_next_tip(
         BlockSpec::new()
             .with_transactions(txs.iter().map(|t| (**t).clone()).collect())
@@ -152,7 +149,7 @@ async fn it_checks_double_spends() {
 async fn it_checks_input_maturity() {
     let (mut blockchain, validator) = setup();
 
-    let (_, coinbase_a) = blockchain.add_next_tip("A", Default::default());
+    let (_, coinbase_a) = blockchain.add_next_tip(block_spec!("A")).unwrap();
     let mut schema = txn_schema!(from: vec![coinbase_a], to: vec![50 * T]);
     schema.from[0].features.maturity = 100;
     let (txs, _) = schema_to_transaction(&[schema]);
@@ -174,13 +171,13 @@ async fn it_checks_input_maturity() {
 async fn it_checks_txo_sort_order() {
     let (mut blockchain, validator) = setup();
 
-    let (_, coinbase_a) = blockchain.add_next_tip("A", Default::default());
+    let (_, coinbase_a) = blockchain.add_next_tip(block_spec!("A")).unwrap();
 
     let schema1 = txn_schema!(from: vec![coinbase_a], to: vec![50 * T, 12 * T]);
     let (txs, _) = schema_to_transaction(&[schema1]);
     let txs = txs.into_iter().map(|t| Arc::try_unwrap(t).unwrap()).collect::<Vec<_>>();
 
-    let (mut block, _) = blockchain.create_unmined_block("B->A", BlockSpec::new().with_transactions(txs).finish());
+    let (mut block, _) = blockchain.create_unmined_block(block_spec!("B->A", transactions: txs));
     let outputs = block.body.outputs().iter().rev().cloned().collect::<Vec<_>>();
     let inputs = block.body.inputs().clone();
     let kernels = block.body.kernels().clone();
@@ -203,13 +200,13 @@ async fn it_limits_the_script_byte_size() {
         .build();
     let (mut blockchain, validator) = setup_with_rules(rules);
 
-    let (_, coinbase_a) = blockchain.add_next_tip("A", Default::default());
+    let (_, coinbase_a) = blockchain.add_next_tip(block_spec!("A")).unwrap();
 
     let mut schema1 = txn_schema!(from: vec![coinbase_a], to: vec![50 * T, 12 * T]);
     schema1.script = script!(Nop Nop Nop);
     let (txs, _) = schema_to_transaction(&[schema1]);
     let txs = txs.into_iter().map(|t| Arc::try_unwrap(t).unwrap()).collect::<Vec<_>>();
-    let (block, _) = blockchain.create_next_tip(BlockSpec::new().with_transactions(txs).finish());
+    let (block, _) = blockchain.create_next_tip(block_spec!("B", transactions: txs));
 
     let err = validator.validate_block_body(block.block().clone()).await.unwrap_err();
     assert!(matches!(err, ValidationError::TariScriptExceedsMaxSize { .. }));
@@ -226,13 +223,13 @@ async fn it_rejects_invalid_input_metadata() {
         .build();
     let (mut blockchain, validator) = setup_with_rules(rules);
 
-    let (_, coinbase_a) = blockchain.add_next_tip("A", Default::default());
+    let (_, coinbase_a) = blockchain.add_next_tip(block_spec!("A")).unwrap();
 
     let mut schema1 = txn_schema!(from: vec![coinbase_a], to: vec![50 * T, 12 * T]);
     schema1.from[0].sender_offset_public_key = Default::default();
     let (txs, _) = schema_to_transaction(&[schema1]);
     let txs = txs.into_iter().map(|t| Arc::try_unwrap(t).unwrap()).collect::<Vec<_>>();
-    let (block, _) = blockchain.create_next_tip(BlockSpec::new().with_transactions(txs).finish());
+    let (block, _) = blockchain.create_next_tip(block_spec!("B", transactions: txs));
 
     let err = validator.validate_block_body(block.block().clone()).await.unwrap_err();
     assert!(matches!(err, ValidationError::UnknownInputs(_)));
@@ -241,7 +238,7 @@ async fn it_rejects_invalid_input_metadata() {
 #[tokio::test]
 async fn it_rejects_zero_conf_double_spends() {
     let (mut blockchain, validator) = setup();
-    let (_, coinbase) = blockchain.append(block_spec!("1", parent: "GB"));
+    let (_, coinbase) = blockchain.append(block_spec!("1", parent: "GB")).unwrap();
 
     let schema = txn_schema!(from: vec![coinbase.clone()], to: vec![201 * T]);
     let (initial_tx, outputs) = schema_to_transaction(&[schema]);
@@ -259,7 +256,7 @@ async fn it_rejects_zero_conf_double_spends() {
         .map(|b| Arc::try_unwrap(b).unwrap())
         .collect::<Vec<_>>();
 
-    let (unmined, _) = blockchain.create_unmined_block("1", block_spec!("2", transactions: transactions));
+    let (unmined, _) = blockchain.create_unmined_block(block_spec!("2", parent: "1", transactions: transactions));
     let err = validator.validate_body(unmined).await.unwrap_err();
     assert!(matches!(err, ValidationError::UnsortedOrDuplicateInput));
 }
@@ -276,7 +273,7 @@ mod unique_id {
     ) -> (Arc<ChainBlock>, UnblindedOutput) {
         let (txs, outputs) = schema_to_transaction(&[schema]);
         let txs = txs.into_iter().map(|t| Arc::try_unwrap(t).unwrap()).collect::<Vec<_>>();
-        let (block, _) = blockchain.create_chained_block(parent_name, BlockSpec::new().with_transactions(txs).finish());
+        let (block, _) = blockchain.create_chained_block(block_spec!("", parent: parent_name, transactions: txs));
         let asset_output = outputs
             .into_iter()
             .find(|o| o.features.unique_asset_id().is_some())
@@ -288,7 +285,7 @@ mod unique_id {
     async fn it_checks_for_duplicate_unique_id_in_block() {
         let (mut blockchain, validator) = setup();
 
-        let (_, coinbase_a) = blockchain.add_next_tip("1", Default::default());
+        let (_, coinbase_a) = blockchain.add_next_tip(block_spec!("1")).unwrap();
         let unique_id = vec![1; 3];
         let parent_pk = PublicKey::default();
 
@@ -313,7 +310,7 @@ mod unique_id {
     async fn it_allows_spending_to_new_utxo() {
         let (mut blockchain, validator) = setup();
 
-        let (_, coinbase_a) = blockchain.add_next_tip("1", Default::default());
+        let (_, coinbase_a) = blockchain.add_next_tip(block_spec!("1")).unwrap();
         let unique_id = vec![1; 3];
         let parent_pk = PublicKey::default();
 
@@ -329,7 +326,7 @@ mod unique_id {
 
         let (block, asset_output) = create_block(&blockchain, "1", schema);
         validator.validate_block_body(block.block().clone()).await.unwrap();
-        blockchain.append_block("2", block);
+        blockchain.append_block("2", block).unwrap();
 
         let features = OutputFeatures {
             parent_public_key: Some(parent_pk),
@@ -340,14 +337,14 @@ mod unique_id {
         let schema = txn_schema!(from: vec![asset_output], to: vec![5 * T], fee: 5.into(), lock: 0, features: features);
         let (block, _) = create_block(&blockchain, "2", schema);
         validator.validate_block_body(block.block().clone()).await.unwrap();
-        blockchain.append_block("3", block);
+        blockchain.append_block("3", block).unwrap();
     }
 
     #[tokio::test]
     async fn it_checks_for_duplicate_unique_id_in_blockchain() {
         let (mut blockchain, validator) = setup();
 
-        let (_, coinbase_a) = blockchain.add_next_tip("1", Default::default());
+        let (_, coinbase_a) = blockchain.add_next_tip(block_spec!("1")).unwrap();
         let unique_id = vec![1; 3];
         let parent_pk = PublicKey::default();
 
@@ -363,7 +360,7 @@ mod unique_id {
 
         let (block, asset_output) = create_block(&blockchain, "1", schema);
         validator.validate_block_body(block.block().clone()).await.unwrap();
-        blockchain.append_block("2", block);
+        blockchain.append_block("2", block).unwrap();
 
         let features = OutputFeatures {
             output_type: OutputType::MintNonFungible,
@@ -382,7 +379,7 @@ mod unique_id {
     async fn it_allows_burn_flag() {
         let (mut blockchain, validator) = setup();
 
-        let (_, coinbase_a) = blockchain.add_next_tip("1", Default::default());
+        let (_, coinbase_a) = blockchain.add_next_tip(block_spec!("1")).unwrap();
         let unique_id = vec![1; 3];
         let parent_pk = PublicKey::default();
 
@@ -398,7 +395,7 @@ mod unique_id {
 
         let (block, asset_output) = create_block(&blockchain, "1", schema);
         validator.validate_block_body(block.block().clone()).await.unwrap();
-        blockchain.append_block("2", block);
+        blockchain.append_block("2", block).unwrap();
 
         let features = OutputFeatures {
             output_type: OutputType::BurnNonFungible,
@@ -428,7 +425,7 @@ mod body_only {
         let mut blockchain = TestBlockchain::create(rules.clone());
         let validator = BodyOnlyValidator::new(rules);
 
-        let (_, coinbase_a) = blockchain.add_next_tip("A", Default::default());
+        let (_, coinbase_a) = blockchain.add_next_tip(block_spec!("A")).unwrap();
 
         let mut schema1 = txn_schema!(from: vec![coinbase_a], to: vec![50 * T, 12 * T]);
         schema1.from[0].sender_offset_public_key = Default::default();
@@ -460,7 +457,7 @@ mod orphan_validator {
             .build();
         let mut blockchain = TestBlockchain::create(rules.clone());
         let validator = OrphanBlockValidator::new(rules, false, CryptoFactories::default());
-        let (_, coinbase) = blockchain.append(block_spec!("1", parent: "GB"));
+        let (_, coinbase) = blockchain.append(block_spec!("1", parent: "GB")).unwrap();
 
         let schema = txn_schema!(from: vec![coinbase], to: vec![201 * T]);
         let (initial_tx, outputs) = schema_to_transaction(&[schema]);
@@ -478,7 +475,7 @@ mod orphan_validator {
             .map(|b| Arc::try_unwrap(b).unwrap())
             .collect::<Vec<_>>();
 
-        let (unmined, _) = blockchain.create_unmined_block("1", block_spec!("2", transactions: transactions));
+        let (unmined, _) = blockchain.create_unmined_block(block_spec!("2", parent: "1", transactions: transactions));
         let err = validator.validate(&unmined).unwrap_err();
         assert!(matches!(err, ValidationError::UnsortedOrDuplicateInput));
     }

--- a/base_layer/core/src/validation/block_validators/test.rs
+++ b/base_layer/core/src/validation/block_validators/test.rs
@@ -180,7 +180,7 @@ async fn it_checks_txo_sort_order() {
     let (txs, _) = schema_to_transaction(&[schema1]);
     let txs = txs.into_iter().map(|t| Arc::try_unwrap(t).unwrap()).collect::<Vec<_>>();
 
-    let (mut block, _) = blockchain.create_unmined_block("A", BlockSpec::new().with_transactions(txs).finish());
+    let (mut block, _) = blockchain.create_unmined_block("B->A", BlockSpec::new().with_transactions(txs).finish());
     let outputs = block.body.outputs().iter().rev().cloned().collect::<Vec<_>>();
     let inputs = block.body.inputs().clone();
     let kernels = block.body.kernels().clone();

--- a/base_layer/wallet/src/assets/asset_manager.rs
+++ b/base_layer/wallet/src/assets/asset_manager.rs
@@ -257,6 +257,7 @@ impl<T: OutputManagerBackend + 'static> AssetManager<T> {
         let output = self
             .output_manager
             .create_output_with_features(0.into(), OutputFeatures {
+                output_type: OutputType::ContractConstitution,
                 sidechain_features: Some(constitution_definition.clone()),
                 ..Default::default()
             })


### PR DESCRIPTION
Description
---
 feat: add contract index to blockchain database
 feat: add fetch_contract_outputs_by_contract_id_and_type
 feat: impl Display for FixedHash
 feat: impl Display for OutputType
 feat: add is_sidechain_contract fn to OutputFeatures
 test: improvements to blockchain test helpers
 test: add contract index tests

Motivation and Context
---
The contract index keeps track of contract UTXOs in the current UTXO set.
This index allows UTXOs related to contracts to be efficiently fetched and enforces data integrity rules (e.g. only one contract definition is allowed, contract constitution cannot be created without a definition etc.)

How Has This Been Tested?
---
A number of new blockchain database unit tests.
Manually, adding definition and constitution UTXOs to blockchain