### PR TITLE
refactor: constitution subcommands

### DIFF
--- a/applications/tari_console_wallet/src/automation/commands.rs
+++ b/applications/tari_console_wallet/src/automation/commands.rs
@@ -64,13 +64,7 @@ use tokio::{
 use super::error::CommandError;
 use crate::{
     automation::prompt::{HexArg, Prompt},
-    cli::{
-        CliCommands,
-        ContractDefinitionCommand,
-        ContractDefinitionSubcommand,
-        InitContractDefinitionArgs,
-        PublishDefinitionArgs,
-    },
+    cli::{CliCommands, ContractCommand, ContractSubcommand, InitDefinitionArgs, PublishFileArgs},
     utils::db::{CUSTOM_BASE_NODE_ADDRESS_KEY, CUSTOM_BASE_NODE_PUBLIC_KEY_KEY},
 };
 
@@ -750,7 +744,7 @@ pub async fn command_runner(
                     .await
                     .map_err(CommandError::TransactionServiceError)?;
             },
-            ContractDefinition(subcommand) => {
+            Contract(subcommand) => {
                 handle_contract_definition_command(&wallet, subcommand).await?;
             },
         }
@@ -796,15 +790,15 @@ pub async fn command_runner(
 
 async fn handle_contract_definition_command(
     wallet: &WalletSqlite,
-    command: ContractDefinitionCommand,
+    command: ContractCommand,
 ) -> Result<(), CommandError> {
     match command.subcommand {
-        ContractDefinitionSubcommand::Init(args) => init_contract_definition_spec(args),
-        ContractDefinitionSubcommand::Publish(args) => publish_contract_definition(wallet, args).await,
+        ContractSubcommand::InitDefinition(args) => init_contract_definition_spec(args),
+        ContractSubcommand::PublishDefinition(args) => publish_contract_definition(wallet, args).await,
     }
 }
 
-fn init_contract_definition_spec(args: InitContractDefinitionArgs) -> Result<(), CommandError> {
+fn init_contract_definition_spec(args: InitDefinitionArgs) -> Result<(), CommandError> {
     if args.dest_path.exists() {
         if args.force {
             println!("{} exists and will be overwritten.", args.dest_path.to_string_lossy());
@@ -845,7 +839,7 @@ fn init_contract_definition_spec(args: InitContractDefinitionArgs) -> Result<(),
     Ok(())
 }
 
-async fn publish_contract_definition(wallet: &WalletSqlite, args: PublishDefinitionArgs) -> Result<(), CommandError> {
+async fn publish_contract_definition(wallet: &WalletSqlite, args: PublishFileArgs) -> Result<(), CommandError> {
     // open the JSON file with the contract definition values
     let file = File::open(&args.file_path).map_err(|e| CommandError::JsonFile(e.to_string()))?;
     let file_reader = BufReader::new(file);

--- a/applications/tari_console_wallet/src/automation/prompt.rs
+++ b/applications/tari_console_wallet/src/automation/prompt.rs
@@ -63,6 +63,40 @@ impl<'a> Prompt<'a> {
         Ok(parsed)
     }
 
+    pub fn ask_repeatedly<T>(self) -> Result<Vec<T>, CommandError>
+    where
+        T: FromStr,
+        T::Err: ToString,
+    {
+        let mut collection: Vec<T> = vec![];
+
+        loop {
+            let prompt = Prompt::new(self.label);
+            let result = prompt.get_result_parsed()?;
+            collection.push(result);
+
+            loop {
+                println!("Add another? Y/N");
+                print!("> ");
+
+                io::stdout().flush()?;
+                let mut line_buf = String::new();
+                io::stdin().read_line(&mut line_buf)?;
+                println!();
+
+                let trimmed = line_buf.trim();
+
+                match trimmed {
+                    "N" => {
+                        return Ok(collection);
+                    },
+                    "Y" => break,
+                    _ => continue,
+                }
+            }
+        }
+    }
+
     pub fn get_result(self) -> Result<String, CommandError> {
         if let Some(value) = self.skip_if_some {
             return Ok(value);

--- a/applications/tari_console_wallet/src/cli.rs
+++ b/applications/tari_console_wallet/src/cli.rs
@@ -108,7 +108,6 @@ pub enum CliCommands {
     InitShaAtomicSwap(SendTariArgs),
     FinaliseShaAtomicSwap(FinaliseShaAtomicSwapArgs),
     ClaimShaAtomicSwapRefund(ClaimShaAtomicSwapRefundArgs),
-    PublishConstitutionDefinition(PublishFileArgs),
     RevalidateWalletDb,
     Contract(ContractCommand),
 }
@@ -216,6 +215,9 @@ pub enum ContractSubcommand {
 
     /// Creates and publishes a contract definition UTXO from the JSON spec file.
     PublishDefinition(PublishFileArgs),
+
+    /// Creates and publishes a contract definition UTXO from the JSON spec file.
+    PublishConstitution(PublishFileArgs),
 }
 
 #[derive(Debug, Args, Clone)]

--- a/applications/tari_console_wallet/src/cli.rs
+++ b/applications/tari_console_wallet/src/cli.rs
@@ -108,9 +108,9 @@ pub enum CliCommands {
     InitShaAtomicSwap(SendTariArgs),
     FinaliseShaAtomicSwap(FinaliseShaAtomicSwapArgs),
     ClaimShaAtomicSwapRefund(ClaimShaAtomicSwapRefundArgs),
-    PublishConstitutionDefinition(PublishDefinitionArgs),
+    PublishConstitutionDefinition(PublishFileArgs),
     RevalidateWalletDb,
-    ContractDefinition(ContractDefinitionCommand),
+    Contract(ContractCommand),
 }
 
 #[derive(Debug, Args, Clone)]
@@ -200,22 +200,22 @@ pub struct ClaimShaAtomicSwapRefundArgs {
 }
 
 #[derive(Debug, Args, Clone)]
-pub struct ContractDefinitionCommand {
+pub struct ContractCommand {
     #[clap(subcommand)]
-    pub subcommand: ContractDefinitionSubcommand,
+    pub subcommand: ContractSubcommand,
 }
 
 #[derive(Debug, Subcommand, Clone)]
-pub enum ContractDefinitionSubcommand {
+pub enum ContractSubcommand {
     /// Generates a new contract definition JSON spec file that can be edited and passed to other contract definition
     /// commands.
-    Init(InitContractDefinitionArgs),
+    InitDefinition(InitDefinitionArgs),
     /// Creates and publishes a contract definition UTXO from the JSON spec file.
-    Publish(PublishDefinitionArgs),
+    PublishDefinition(PublishFileArgs),
 }
 
 #[derive(Debug, Args, Clone)]
-pub struct InitContractDefinitionArgs {
+pub struct InitDefinitionArgs {
     /// The destination path of the contract definition to create
     pub dest_path: PathBuf,
     /// Force overwrite the destination file if it already exists
@@ -230,6 +230,6 @@ pub struct InitContractDefinitionArgs {
 }
 
 #[derive(Debug, Args, Clone)]
-pub struct PublishDefinitionArgs {
+pub struct PublishFileArgs {
     pub file_path: PathBuf,
 }

--- a/applications/tari_console_wallet/src/cli.rs
+++ b/applications/tari_console_wallet/src/cli.rs
@@ -210,6 +210,10 @@ pub enum ContractSubcommand {
     /// Generates a new contract definition JSON spec file that can be edited and passed to other contract definition
     /// commands.
     InitDefinition(InitDefinitionArgs),
+
+    /// A generator for constitution files that can be edited and passed to other contract commands
+    InitConstitution(InitConstitutionArgs),
+
     /// Creates and publishes a contract definition UTXO from the JSON spec file.
     PublishDefinition(PublishFileArgs),
 }
@@ -227,6 +231,23 @@ pub struct InitDefinitionArgs {
     pub contract_issuer: Option<String>,
     #[clap(long, alias = "runtime")]
     pub runtime: Option<String>,
+}
+
+#[derive(Debug, Args, Clone)]
+pub struct InitConstitutionArgs {
+    /// The destination path of the contract definition to create
+    pub dest_path: PathBuf,
+    /// Force overwrite the destination file if it already exists
+    #[clap(short = 'f', long)]
+    pub force: bool,
+    #[clap(long, alias = "id")]
+    pub contract_id: Option<String>,
+    #[clap(long, alias = "committee")]
+    pub validator_committee: Option<Vec<String>>,
+    #[clap(long, alias = "acceptance_period")]
+    pub acceptance_period_expiry: Option<String>,
+    #[clap(long, alias = "quorum_required")]
+    pub minimum_quorum_required: Option<String>,
 }
 
 #[derive(Debug, Args, Clone)]

--- a/base_layer/wallet/src/assets/mod.rs
+++ b/base_layer/wallet/src/assets/mod.rs
@@ -34,5 +34,5 @@ pub(crate) mod infrastructure;
 mod constitution_definition_file_format;
 mod contract_definition_file_format;
 
-pub use constitution_definition_file_format::ConstitutionDefinitionFileFormat;
+pub use constitution_definition_file_format::{ConstitutionChangeRulesFileFormat, ConstitutionDefinitionFileFormat};
 pub use contract_definition_file_format::{ContractDefinitionFileFormat, ContractSpecificationFileFormat};


### PR DESCRIPTION
Description
---
This moves the previous command usage under the new contract subcommand and provides a constitution generator for quickly creating new template files.

Motivation and Context
---
Easier to use, and easier to read.

How Has This Been Tested?
---
~It hasn't. Another bug is now preventing the creation and publishing of contracts or constitutions.~

Manually tested. Both definition, and constitution can generate and publish (given the correct inputs)
