### PR TITLE
fix: remove deprecated tauri config variable

### DIFF
--- a/applications/tari_collectibles/src-tauri/tauri.conf.json
+++ b/applications/tari_collectibles/src-tauri/tauri.conf.json
@@ -28,13 +28,11 @@
       "shortDescription": "",
       "longDescription": "",
       "deb": {
-        "depends": [],
-        "useBootstrapper": false
+        "depends": []
       },
       "macOS": {
         "frameworks": [],
         "minimumSystemVersion": "",
-        "useBootstrapper": false,
         "exceptionDomain": "",
         "signingIdentity": null,
         "entitlements": null


### PR DESCRIPTION
The `useBootstrapper` variable has been deprecated in Tauri. This
actually throws a hard error and is preventing builds.

The fix is to just remove it from the collectibles app config.

