### PR TITLE
feat: publication of contract update proposal acceptances

### DIFF
--- a/applications/tari_app_grpc/proto/validator_node.proto
+++ b/applications/tari_app_grpc/proto/validator_node.proto
@@ -33,6 +33,7 @@ service ValidatorNode {
     rpc InvokeMethod(InvokeMethodRequest) returns (InvokeMethodResponse);
     rpc GetConstitutionRequests(GetConstitutionRequestsRequest) returns (stream TransactionOutput);
     rpc PublishContractAcceptance(PublishContractAcceptanceRequest) returns (PublishContractAcceptanceResponse);
+    rpc PublishContractUpdateProposalAcceptance(PublishContractUpdateProposalAcceptanceRequest) returns (PublishContractUpdateProposalAcceptanceResponse);
 }
 
 message GetConstitutionRequestsRequest {
@@ -48,6 +49,16 @@ message PublishContractAcceptanceRequest {
 }
 
 message PublishContractAcceptanceResponse {
+    string status = 1;
+    uint64 tx_id = 2;
+}
+
+message PublishContractUpdateProposalAcceptanceRequest {
+    bytes contract_id = 1;
+    uint64 proposal_id = 2;
+}
+
+message PublishContractUpdateProposalAcceptanceResponse {
     string status = 1;
     uint64 tx_id = 2;
 }

--- a/applications/tari_app_grpc/proto/wallet.proto
+++ b/applications/tari_app_grpc/proto/wallet.proto
@@ -84,6 +84,7 @@ service Wallet {
     rpc SetBaseNode(SetBaseNodeRequest) returns (SetBaseNodeResponse);
 
     rpc SubmitContractAcceptance(SubmitContractAcceptanceRequest) returns (SubmitContractAcceptanceResponse);
+    rpc SubmitContractUpdateProposalAcceptance(SubmitContractUpdateProposalAcceptanceRequest) returns (SubmitContractUpdateProposalAcceptanceResponse);
 }
 
 message GetVersionRequest { }
@@ -306,6 +307,17 @@ message SubmitContractAcceptanceRequest {
 }
 
 message SubmitContractAcceptanceResponse {
+    uint64 tx_id = 1;
+}
+
+message SubmitContractUpdateProposalAcceptanceRequest {
+    bytes contract_id = 1;
+    uint64 proposal_id = 2;
+    bytes validator_node_public_key = 3;
+    Signature signature = 4;
+}
+
+message SubmitContractUpdateProposalAcceptanceResponse {
     uint64 tx_id = 1;
 }
 

--- a/base_layer/core/src/chain_storage/lmdb_db/contract_index.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/contract_index.rs
@@ -172,7 +172,9 @@ impl<'a> ContractIndex<'a, WriteTransaction<'a>> {
                 Ok(())
             },
             // These are collections of output hashes
-            OutputType::ContractValidatorAcceptance | OutputType::ContractConstitutionProposal => {
+            OutputType::ContractValidatorAcceptance |
+            OutputType::ContractConstitutionProposal |
+            OutputType::ContractConstitutionChangeAcceptance => {
                 self.assert_definition_exists(contract_id)?;
                 let mut hashes = self.find::<FixedHashSet>(&key)?.unwrap_or_default();
 

--- a/base_layer/core/src/transactions/transaction_components/output_features.rs
+++ b/base_layer/core/src/transactions/transaction_components/output_features.rs
@@ -37,7 +37,13 @@ use tari_common_types::types::{Commitment, FixedHash, PublicKey, Signature};
 use tari_crypto::ristretto::pedersen::PedersenCommitment;
 use tari_utilities::ByteArray;
 
-use super::{ContractAcceptance, ContractDefinition, OutputFeaturesVersion, SideChainFeaturesBuilder};
+use super::{
+    ContractAcceptance,
+    ContractDefinition,
+    ContractUpdateProposalAcceptance,
+    OutputFeaturesVersion,
+    SideChainFeaturesBuilder,
+};
 use crate::{
     consensus::{ConsensusDecoding, ConsensusEncoding, ConsensusEncodingSized, MaxSizeBytes},
     transactions::{
@@ -302,6 +308,27 @@ impl OutputFeatures {
             sidechain_features: Some(
                 SideChainFeatures::builder(contract_id)
                     .with_contract_acceptance(ContractAcceptance {
+                        validator_node_public_key,
+                        signature,
+                    })
+                    .finish(),
+            ),
+            ..Default::default()
+        }
+    }
+
+    pub fn for_contract_update_proposal_acceptance(
+        contract_id: FixedHash,
+        proposal_id: u64,
+        validator_node_public_key: PublicKey,
+        signature: Signature,
+    ) -> OutputFeatures {
+        Self {
+            output_type: OutputType::ContractConstitutionChangeAcceptance,
+            sidechain_features: Some(
+                SideChainFeatures::builder(contract_id)
+                    .with_contract_update_proposal_acceptance(ContractUpdateProposalAcceptance {
+                        proposal_id,
                         validator_node_public_key,
                         signature,
                     })

--- a/base_layer/core/src/transactions/transaction_components/side_chain/sidechain_features.rs
+++ b/base_layer/core/src/transactions/transaction_components/side_chain/sidechain_features.rs
@@ -122,6 +122,14 @@ impl SideChainFeaturesBuilder {
         self
     }
 
+    pub fn with_contract_update_proposal_acceptance(
+        mut self,
+        contract_update_proposal_acceptance: ContractUpdateProposalAcceptance,
+    ) -> Self {
+        self.features.update_proposal_acceptance = Some(contract_update_proposal_acceptance);
+        self
+    }
+
     pub fn finish(self) -> SideChainFeatures {
         self.features
     }

--- a/base_layer/wallet/src/assets/asset_manager.rs
+++ b/base_layer/wallet/src/assets/asset_manager.rs
@@ -309,6 +309,34 @@ impl<T: OutputManagerBackend + 'static> AssetManager<T> {
 
         Ok((tx_id, transaction))
     }
+
+    pub async fn create_contract_update_proposal_acceptance(
+        &mut self,
+        contract_id: FixedHash,
+        proposal_id: u64,
+        validator_node_public_key: PublicKey,
+        signature: Signature,
+    ) -> Result<(TxId, Transaction), WalletError> {
+        let output = self
+            .output_manager
+            .create_output_with_features(
+                0.into(),
+                OutputFeatures::for_contract_update_proposal_acceptance(
+                    contract_id,
+                    proposal_id,
+                    validator_node_public_key,
+                    signature,
+                ),
+            )
+            .await?;
+
+        let (tx_id, transaction) = self
+            .output_manager
+            .create_send_to_self_with_output(vec![output], ASSET_FPG.into(), None, None)
+            .await?;
+
+        Ok((tx_id, transaction))
+    }
 }
 
 fn convert_to_asset(unblinded_output: DbUnblindedOutput) -> Result<Asset, WalletError> {

--- a/base_layer/wallet/src/assets/asset_manager_handle.rs
+++ b/base_layer/wallet/src/assets/asset_manager_handle.rs
@@ -235,4 +235,31 @@ impl AssetManagerHandle {
             }),
         }
     }
+
+    pub async fn create_contract_update_proposal_acceptance(
+        &mut self,
+        contract_id: &FixedHash,
+        proposal_id: u64,
+        validator_node_public_key: &PublicKey,
+        signature: &Signature,
+    ) -> Result<(TxId, Transaction), WalletError> {
+        match self
+            .handle
+            .call(AssetManagerRequest::CreateContractUpdateProposalAcceptance {
+                contract_id: *contract_id,
+                proposal_id,
+                validator_node_public_key: Box::new(validator_node_public_key.clone()),
+                signature: Box::new(signature.clone()),
+            })
+            .await??
+        {
+            AssetManagerResponse::CreateContractUpdateProposalAcceptance { transaction, tx_id } => {
+                Ok((tx_id, *transaction))
+            },
+            _ => Err(WalletError::UnexpectedApiResponse {
+                method: "create_contract_update_proposal_acceptance".to_string(),
+                api: "AssetManagerService".to_string(),
+            }),
+        }
+    }
 }

--- a/base_layer/wallet/src/assets/infrastructure/asset_manager_service.rs
+++ b/base_layer/wallet/src/assets/infrastructure/asset_manager_service.rs
@@ -193,6 +193,26 @@ impl<T: OutputManagerBackend + 'static> AssetManagerService<T> {
                     tx_id,
                 })
             },
+            AssetManagerRequest::CreateContractUpdateProposalAcceptance {
+                contract_id,
+                proposal_id,
+                validator_node_public_key,
+                signature,
+            } => {
+                let (tx_id, transaction) = self
+                    .manager
+                    .create_contract_update_proposal_acceptance(
+                        contract_id,
+                        proposal_id,
+                        *validator_node_public_key,
+                        *signature,
+                    )
+                    .await?;
+                Ok(AssetManagerResponse::CreateContractUpdateProposalAcceptance {
+                    transaction: Box::new(transaction),
+                    tx_id,
+                })
+            },
         }
     }
 }

--- a/base_layer/wallet/src/assets/infrastructure/mod.rs
+++ b/base_layer/wallet/src/assets/infrastructure/mod.rs
@@ -79,6 +79,12 @@ pub enum AssetManagerRequest {
         validator_node_public_key: Box<PublicKey>,
         signature: Box<Signature>,
     },
+    CreateContractUpdateProposalAcceptance {
+        contract_id: FixedHash,
+        proposal_id: u64,
+        validator_node_public_key: Box<PublicKey>,
+        signature: Box<Signature>,
+    },
 }
 
 pub enum AssetManagerResponse {
@@ -91,4 +97,5 @@ pub enum AssetManagerResponse {
     CreateConstitutionDefinition { transaction: Box<Transaction>, tx_id: TxId },
     CreateContractDefinition { transaction: Box<Transaction>, tx_id: TxId },
     CreateContractAcceptance { transaction: Box<Transaction>, tx_id: TxId },
+    CreateContractUpdateProposalAcceptance { transaction: Box<Transaction>, tx_id: TxId },
 }

--- a/dan_layer/core/src/services/wallet_client.rs
+++ b/dan_layer/core/src/services/wallet_client.rs
@@ -42,4 +42,12 @@ pub trait WalletClient: Send + Sync {
         validator_node_public_key: &PublicKey,
         signature: &Signature,
     ) -> Result<u64, DigitalAssetError>;
+
+    async fn submit_contract_update_proposal_acceptance(
+        &mut self,
+        contract_id: &FixedHash,
+        proposal_id: u64,
+        validator_node_public_key: &PublicKey,
+        signature: &Signature,
+    ) -> Result<u64, DigitalAssetError>;
 }

--- a/integration_tests/features/ValidatorNode.feature
+++ b/integration_tests/features/ValidatorNode.feature
@@ -42,3 +42,14 @@ Feature: Validator Node
         Then I create a "constitution-definition" from file "fixtures/constitution_definition.json" on wallet WALLET1 via command line
         When I mine 8 blocks using wallet WALLET1 on NODE1
         Then wallet WALLET1 has at least 2 transactions that are all TRANSACTION_STATUS_MINED_CONFIRMED and not cancelled
+
+    @dan @critical
+    Scenario: Publish contract update proposal acceptance
+        Given I have a seed node NODE1
+        And I have wallet WALLET1 connected to all seed nodes
+        When I mine 9 blocks using wallet WALLET1 on NODE1
+        Then I wait for wallet WALLET1 to have at least 1000000 uT
+        And I have a validator node VN1 connected to base node NODE1 and wallet WALLET1 with "constitiution_auto_accept" set to "false"
+        Then I publish a contract update proposal acceptance transaction for the validator node VN1
+        When I mine 4 blocks using wallet WALLET1 on NODE1
+        Then wallet WALLET1 has at least 1 transactions that are all TRANSACTION_STATUS_MINED_CONFIRMED and not cancelled

--- a/integration_tests/features/ValidatorNode.feature
+++ b/integration_tests/features/ValidatorNode.feature
@@ -27,10 +27,13 @@ Feature: Validator Node
         And I have wallet WALLET1 connected to all seed nodes
         When I mine 9 blocks using wallet WALLET1 on NODE1
         Then I wait for wallet WALLET1 to have at least 1000000 uT
+        And I publish a contract definition from file "fixtures/contract_definition.json" on wallet WALLET1 via command line
+        When I mine 4 blocks using wallet WALLET1 on NODE1
+        Then wallet WALLET1 has at least 1 transactions that are all TRANSACTION_STATUS_MINED_CONFIRMED and not cancelled
         And I have a validator node VN1 connected to base node NODE1 and wallet WALLET1 with "constitiution_auto_accept" set to "false"
         Then I publish a contract acceptance transaction for the validator node VN1
         When I mine 4 blocks using wallet WALLET1 on NODE1
-        Then wallet WALLET1 has at least 1 transactions that are all TRANSACTION_STATUS_MINED_CONFIRMED and not cancelled
+        Then wallet WALLET1 has at least 2 transactions that are all TRANSACTION_STATUS_MINED_CONFIRMED and not cancelled
 
     @dan @broken
     Scenario: Contract auto acceptance
@@ -49,7 +52,10 @@ Feature: Validator Node
         And I have wallet WALLET1 connected to all seed nodes
         When I mine 9 blocks using wallet WALLET1 on NODE1
         Then I wait for wallet WALLET1 to have at least 1000000 uT
+        And I publish a contract definition from file "fixtures/contract_definition.json" on wallet WALLET1 via command line
+        When I mine 4 blocks using wallet WALLET1 on NODE1
+        Then wallet WALLET1 has at least 1 transactions that are all TRANSACTION_STATUS_MINED_CONFIRMED and not cancelled
         And I have a validator node VN1 connected to base node NODE1 and wallet WALLET1 with "constitiution_auto_accept" set to "false"
         Then I publish a contract update proposal acceptance transaction for the validator node VN1
         When I mine 4 blocks using wallet WALLET1 on NODE1
-        Then wallet WALLET1 has at least 1 transactions that are all TRANSACTION_STATUS_MINED_CONFIRMED and not cancelled
+        Then wallet WALLET1 has at least 2 transactions that are all TRANSACTION_STATUS_MINED_CONFIRMED and not cancelled

--- a/integration_tests/features/ValidatorNode.feature
+++ b/integration_tests/features/ValidatorNode.feature
@@ -28,11 +28,11 @@ Feature: Validator Node
         When I mine 9 blocks using wallet WALLET1 on NODE1
         Then I wait for wallet WALLET1 to have at least 1000000 uT
         And I publish a contract definition from file "fixtures/contract_definition.json" on wallet WALLET1 via command line
-        When I mine 4 blocks using wallet WALLET1 on NODE1
+        When I mine 8 blocks using wallet WALLET1 on NODE1
         Then wallet WALLET1 has at least 1 transactions that are all TRANSACTION_STATUS_MINED_CONFIRMED and not cancelled
         And I have a validator node VN1 connected to base node NODE1 and wallet WALLET1 with "constitiution_auto_accept" set to "false"
         Then I publish a contract acceptance transaction for the validator node VN1
-        When I mine 4 blocks using wallet WALLET1 on NODE1
+        When I mine 8 blocks using wallet WALLET1 on NODE1
         Then wallet WALLET1 has at least 2 transactions that are all TRANSACTION_STATUS_MINED_CONFIRMED and not cancelled
 
     @dan @broken
@@ -53,9 +53,9 @@ Feature: Validator Node
         When I mine 9 blocks using wallet WALLET1 on NODE1
         Then I wait for wallet WALLET1 to have at least 1000000 uT
         And I publish a contract definition from file "fixtures/contract_definition.json" on wallet WALLET1 via command line
-        When I mine 4 blocks using wallet WALLET1 on NODE1
+        When I mine 8 blocks using wallet WALLET1 on NODE1
         Then wallet WALLET1 has at least 1 transactions that are all TRANSACTION_STATUS_MINED_CONFIRMED and not cancelled
         And I have a validator node VN1 connected to base node NODE1 and wallet WALLET1 with "constitiution_auto_accept" set to "false"
         Then I publish a contract update proposal acceptance transaction for the validator node VN1
-        When I mine 4 blocks using wallet WALLET1 on NODE1
+        When I mine 8 blocks using wallet WALLET1 on NODE1
         Then wallet WALLET1 has at least 2 transactions that are all TRANSACTION_STATUS_MINED_CONFIRMED and not cancelled

--- a/integration_tests/features/support/validator_node_steps.js
+++ b/integration_tests/features/support/validator_node_steps.js
@@ -168,3 +168,18 @@ Then(
     console.log({ response });
   }
 );
+
+Then(
+  "I publish a contract update proposal acceptance transaction for the validator node {word}",
+  { timeout: 20 * 1000 },
+  async function (vn_name) {
+    let dan_node = this.getNode(vn_name);
+    let grpc_dan_node = await dan_node.createGrpcClient();
+    let response = await grpc_dan_node.publishContractUpdateProposalAcceptance(
+      "f665775dbbf4e428e5c8c2bb1c5e7d2e508e93c83250c495ac617a0a1fb2d76d", // contract_id
+      0 // proposal_id
+    );
+    expect(response.status).to.be.equal("Accepted");
+    console.log({ response });
+  }
+);

--- a/integration_tests/features/support/validator_node_steps.js
+++ b/integration_tests/features/support/validator_node_steps.js
@@ -162,7 +162,7 @@ Then(
     let dan_node = this.getNode(vn_name);
     let grpc_dan_node = await dan_node.createGrpcClient();
     let response = await grpc_dan_node.publishContractAcceptance(
-      "f665775dbbf4e428e5c8c2bb1c5e7d2e508e93c83250c495ac617a0a1fb2d76d" // contract_id
+      "90b1da4524ea0e9479040d906db9194d8af90f28d05ff2d64c0a82eb93125177" // contract_id
     );
     expect(response.status).to.be.equal("Accepted");
     console.log({ response });
@@ -176,7 +176,7 @@ Then(
     let dan_node = this.getNode(vn_name);
     let grpc_dan_node = await dan_node.createGrpcClient();
     let response = await grpc_dan_node.publishContractUpdateProposalAcceptance(
-      "f665775dbbf4e428e5c8c2bb1c5e7d2e508e93c83250c495ac617a0a1fb2d76d", // contract_id
+      "90b1da4524ea0e9479040d906db9194d8af90f28d05ff2d64c0a82eb93125177", // contract_id
       0 // proposal_id
     );
     expect(response.status).to.be.equal("Accepted");

--- a/integration_tests/features/support/wallet_cli_steps.js
+++ b/integration_tests/features/support/wallet_cli_steps.js
@@ -323,7 +323,7 @@ Then(
 
     let output = await wallet_run_command(
       wallet,
-      `publish-constitution-definition ${absolute_path}`
+      `contract publish-constitution ${absolute_path}`
     );
     console.log(output.buffer);
   }

--- a/integration_tests/features/support/wallet_cli_steps.js
+++ b/integration_tests/features/support/wallet_cli_steps.js
@@ -308,7 +308,7 @@ Then(
     let wallet = this.getWallet(wallet_name);
     let output = await wallet_run_command(
       wallet,
-      `contract-definition publish ${absolute_path}`
+      `contract publish-definition ${absolute_path}`
     );
     console.log(output.buffer);
   }

--- a/integration_tests/helpers/validatorNodeClient.js
+++ b/integration_tests/helpers/validatorNodeClient.js
@@ -70,6 +70,16 @@ class ValidatorNodeClient {
       contract_id: convertHexStringToVec(contract_id),
     });
   }
+
+  publishContractUpdateProposalAcceptance(contract_id, proposal_id) {
+    console.log(
+      `Publishing contract update proposal acceptance for contract_id = ${contract_id} `
+    );
+    return this.client.publishContractUpdateProposalAcceptance().sendMessage({
+      contract_id: convertHexStringToVec(contract_id),
+      proposal_id,
+    });
+  }
 }
 
 module.exports = ValidatorNodeClient;


### PR DESCRIPTION
Description
---
* New gRPC method in the validator node for publishing a proposal acceptance:
    * The arguments are the `contract_id` and the `proposal_id`
    * The validator node internally uses its own public key for building the acceptance.
    * The signature of the acceptance only has a mock value for now. In the future we probably would want it to be the signature of a hash of a contract update proposal.
    * Calls the new gRPC method in the wallet to publish the transaction
* New gRPC method in the wallet to submit a proposal acceptance. It builds and sends to the network a transaction with the corresponding type and features
* For now, we do not check if the `proposal_id` is valid, or any other base layer validation.

Motivation and Context
---
Validator nodes need to be able to publish contract update proposal acceptances, for contracts in which they are included as committee members and an update proposal is issued.

This PR provides a gRPC method in the validator node (and a corresponding one in the wallet) to publish proposal acceptances.

How Has This Been Tested?
---
New integration test that publishes and mines a proposal acceptance through the new validator node gRPC endpoint
