### PR TITLE
feat(console-wallet): generate issuer key for contract init-definition

### DIFF
--- a/applications/tari_console_wallet/src/automation/commands.rs
+++ b/applications/tari_console_wallet/src/automation/commands.rs
@@ -22,9 +22,10 @@
 
 use std::{
     convert::TryFrom,
+    fs,
     fs::File,
-    io::{BufReader, BufWriter, LineWriter, Write},
-    path::PathBuf,
+    io::{LineWriter, Write},
+    path::{Path, PathBuf},
     time::{Duration, Instant},
 };
 
@@ -32,6 +33,7 @@ use chrono::{DateTime, Utc};
 use digest::Digest;
 use futures::FutureExt;
 use log::*;
+use serde::{de::DeserializeOwned, Serialize};
 use sha2::Sha256;
 use strum_macros::{Display, EnumIter, EnumString};
 use tari_common_types::{
@@ -71,7 +73,8 @@ use tari_wallet::{
         ContractUpdateProposalFileFormat,
     },
     error::WalletError,
-    output_manager_service::handle::OutputManagerHandle,
+    key_manager_service::{KeyManagerInterface, NextKeyResult},
+    output_manager_service::{handle::OutputManagerHandle, resources::OutputManagerKeyManagerBranch},
     transaction_service::handle::{TransactionEvent, TransactionServiceHandle},
     TransactionStage,
     WalletConfig,
@@ -84,7 +87,7 @@ use tokio::{
 
 use super::error::CommandError;
 use crate::{
-    automation::prompt::{HexArg, Prompt},
+    automation::prompt::{HexArg, Optional, Prompt},
     cli::{
         CliCommands,
         ContractCommand,
@@ -747,7 +750,7 @@ pub async fn command_runner(
                     .map_err(CommandError::TransactionServiceError)?;
             },
             Contract(subcommand) => {
-                handle_contract_definition_command(&wallet, subcommand).await?;
+                handle_contract_command(&wallet, subcommand).await?;
             },
         }
     }
@@ -790,12 +793,9 @@ pub async fn command_runner(
     Ok(())
 }
 
-async fn handle_contract_definition_command(
-    wallet: &WalletSqlite,
-    command: ContractCommand,
-) -> Result<(), CommandError> {
+async fn handle_contract_command(wallet: &WalletSqlite, command: ContractCommand) -> Result<(), CommandError> {
     match command.subcommand {
-        ContractSubcommand::InitDefinition(args) => init_contract_definition_spec(args),
+        ContractSubcommand::InitDefinition(args) => init_contract_definition_spec(wallet, args).await,
         ContractSubcommand::InitConstitution(args) => init_contract_constitution_spec(args),
         ContractSubcommand::PublishDefinition(args) => publish_contract_definition(wallet, args).await,
         ContractSubcommand::PublishConstitution(args) => publish_contract_constitution(wallet, args).await,
@@ -804,7 +804,7 @@ async fn handle_contract_definition_command(
     }
 }
 
-fn init_contract_definition_spec(args: InitDefinitionArgs) -> Result<(), CommandError> {
+async fn init_contract_definition_spec(wallet: &WalletSqlite, args: InitDefinitionArgs) -> Result<(), CommandError> {
     if args.dest_path.exists() {
         if args.force {
             println!("{} exists and will be overwritten.", args.dest_path.to_string_lossy());
@@ -816,31 +816,54 @@ fn init_contract_definition_spec(args: InitDefinitionArgs) -> Result<(), Command
             return Ok(());
         }
     }
-    let dest = args.dest_path;
+    let mut dest = args.dest_path;
+    if dest.extension().is_none() {
+        dest = dest.join("contract.json");
+    }
 
     let contract_name = Prompt::new("Contract name (max 32 characters):")
         .skip_if_some(args.contract_name)
-        .get_result()?;
-    let contract_issuer = Prompt::new("Issuer public Key (hex):")
+        .ask()?;
+    if contract_name.as_bytes().len() > 32 {
+        return Err(CommandError::InvalidArgument(
+            "Contract name must be at most 32 bytes.".to_string(),
+        ));
+    }
+    let mut contract_issuer = Prompt::new("Issuer public Key (hex): (Press enter to generate a new one)")
+        .with_default("")
         .skip_if_some(args.contract_issuer)
-        .get_result_parsed::<HexArg<_>>()?;
+        .ask_parsed::<Optional<HexArg<PublicKey>>>()?
+        .into_inner()
+        .map(|v| v.into_inner());
+    if contract_issuer.is_none() {
+        let issuer_key_path = dest.parent().unwrap_or(dest.as_path()).join("issuer_keys.json");
+        let issuer_public_key_path = Prompt::new("Enter path to generate new issuer public key:")
+            .with_default(issuer_key_path.to_string_lossy())
+            .ask_parsed::<PathBuf>()?;
+        let key_result = wallet
+            .key_manager_service
+            .get_next_key(OutputManagerKeyManagerBranch::ContractIssuer.get_branch_key())
+            .await?;
+
+        contract_issuer = Some(key_result.to_public_key());
+        write_to_issuer_key_file(&issuer_public_key_path, key_result)?;
+        println!("Wrote to key file {}", issuer_public_key_path.to_string_lossy());
+    }
+
     let runtime = Prompt::new("Contract runtime:")
         .skip_if_some(args.runtime)
-        .with_default("/tari/wasm/v0.1".to_string())
-        .get_result()?;
+        .with_default("/tari/wasm/v0.1")
+        .ask_parsed()?;
 
     let contract_definition = ContractDefinitionFileFormat {
         contract_name,
-        contract_issuer: contract_issuer.into_inner(),
+        contract_issuer: contract_issuer.expect("contract_issuer cannot be None"),
         contract_spec: ContractSpecificationFileFormat {
             runtime,
             public_functions: vec![],
         },
     };
-
-    let file = File::create(&dest).map_err(|e| CommandError::JsonFile(e.to_string()))?;
-    let writer = BufWriter::new(file);
-    serde_json::to_writer_pretty(writer, &contract_definition).map_err(|e| CommandError::JsonFile(e.to_string()))?;
+    write_json_file(&dest, &contract_definition).map_err(|e| CommandError::JsonFile(e.to_string()))?;
     println!("Wrote {}", dest.to_string_lossy());
     Ok(())
 }
@@ -861,16 +884,16 @@ fn init_contract_constitution_spec(args: InitConstitutionArgs) -> Result<(), Com
 
     let contract_id = Prompt::new("Contract id (hex):")
         .skip_if_some(args.contract_id)
-        .get_result()?;
+        .ask_parsed()?;
     let committee: Vec<String> = Prompt::new("Validator committee ids (hex):").ask_repeatedly()?;
     let acceptance_period_expiry = Prompt::new("Acceptance period expiry (in blocks, integer):")
         .skip_if_some(args.acceptance_period_expiry)
-        .with_default("50".to_string())
-        .get_result()?;
+        .with_default("50")
+        .ask_parsed()?;
     let minimum_quorum_required = Prompt::new("Minimum quorum:")
         .skip_if_some(args.minimum_quorum_required)
         .with_default(committee.len().to_string())
-        .get_result()?;
+        .ask_parsed()?;
 
     let constitution = ConstitutionDefinitionFileFormat {
         contract_id,
@@ -878,12 +901,8 @@ fn init_contract_constitution_spec(args: InitConstitutionArgs) -> Result<(), Com
         consensus: SideChainConsensus::MerkleRoot,
         initial_reward: 0,
         acceptance_parameters: ContractAcceptanceRequirements {
-            acceptance_period_expiry: acceptance_period_expiry
-                .parse::<u64>()
-                .map_err(|e| CommandError::InvalidArgument(e.to_string()))?,
-            minimum_quorum_required: minimum_quorum_required
-                .parse::<u32>()
-                .map_err(|e| CommandError::InvalidArgument(e.to_string()))?,
+            acceptance_period_expiry,
+            minimum_quorum_required,
         },
         checkpoint_parameters: CheckpointParameters {
             minimum_quorum_required: 0,
@@ -895,21 +914,15 @@ fn init_contract_constitution_spec(args: InitConstitutionArgs) -> Result<(), Com
         },
     };
 
-    let file = File::create(&dest).map_err(|e| CommandError::JsonFile(e.to_string()))?;
-    let writer = BufWriter::new(file);
-    serde_json::to_writer_pretty(writer, &constitution).map_err(|e| CommandError::JsonFile(e.to_string()))?;
+    write_json_file(&dest, &constitution).map_err(|e| CommandError::JsonFile(e.to_string()))?;
     println!("Wrote {}", dest.to_string_lossy());
     Ok(())
 }
 
 async fn publish_contract_definition(wallet: &WalletSqlite, args: PublishFileArgs) -> Result<(), CommandError> {
-    // open the JSON file with the contract definition values
-    let file = File::open(&args.file_path).map_err(|e| CommandError::JsonFile(e.to_string()))?;
-    let file_reader = BufReader::new(file);
-
-    // parse the JSON file
+    // open and parse the JSON file with the contract definition values
     let contract_definition: ContractDefinitionFileFormat =
-        serde_json::from_reader(file_reader).map_err(|e| CommandError::JsonFile(e.to_string()))?;
+        read_json_file(&args.file_path).map_err(|e| CommandError::JsonFile(e.to_string()))?;
     let contract_definition_features = ContractDefinition::from(contract_definition);
     let contract_id_hex = contract_definition_features.calculate_contract_id().to_vec().to_hex();
 
@@ -920,27 +933,24 @@ async fn publish_contract_definition(wallet: &WalletSqlite, args: PublishFileArg
         .await?;
 
     // publish the contract definition transaction
-    let message = format!("Contract definition for contract with id={}", contract_id_hex);
+    let message = format!("Contract definition for contract {}", contract_id_hex);
     let mut transaction_service = wallet.transaction_service.clone();
     transaction_service
         .submit_transaction(tx_id, transaction, 0.into(), message)
         .await?;
 
     println!(
-        "Contract definition transaction submitted with tx_id={} for contract with contract_id={}",
-        tx_id, contract_id_hex
+        "Contract definition submitted: contract_id is {} (TxID: {})",
+        contract_id_hex, tx_id,
     );
     println!("Done!");
     Ok(())
 }
 
 async fn publish_contract_constitution(wallet: &WalletSqlite, args: PublishFileArgs) -> Result<(), CommandError> {
-    let file = File::open(&args.file_path).map_err(|e| CommandError::JsonFile(e.to_string()))?;
-    let file_reader = BufReader::new(file);
-
     // parse the JSON file
     let constitution_definition: ConstitutionDefinitionFileFormat =
-        serde_json::from_reader(file_reader).map_err(|e| CommandError::JsonFile(e.to_string()))?;
+        read_json_file(&args.file_path).map_err(|e| CommandError::JsonFile(e.to_string()))?;
     let side_chain_features = SideChainFeatures::try_from(constitution_definition.clone()).unwrap();
 
     let mut asset_manager = wallet.asset_manager.clone();
@@ -949,7 +959,7 @@ async fn publish_contract_constitution(wallet: &WalletSqlite, args: PublishFileA
         .await?;
 
     let message = format!(
-        "Committee definition with {} members for {:?}",
+        "Contract constitution with {} members for {}",
         constitution_definition.validator_committee.len(),
         constitution_definition.contract_id
     );
@@ -1061,5 +1071,34 @@ fn write_utxos_to_csv_file(utxos: Vec<UnblindedOutput>, file_path: PathBuf) -> R
         )
         .map_err(|e| CommandError::CSVFile(e.to_string()))?;
     }
+    Ok(())
+}
+
+fn write_json_file<P: AsRef<Path>, T: Serialize>(path: P, data: &T) -> Result<(), CommandError> {
+    fs::create_dir_all(path.as_ref().parent().unwrap()).map_err(|e| CommandError::JsonFile(e.to_string()))?;
+    let file = File::create(path).map_err(|e| CommandError::JsonFile(e.to_string()))?;
+    serde_json::to_writer_pretty(file, data).map_err(|e| CommandError::JsonFile(e.to_string()))?;
+    Ok(())
+}
+
+fn read_json_file<P: AsRef<Path>, T: DeserializeOwned>(path: P) -> Result<T, CommandError> {
+    let file = File::open(path).map_err(|e| CommandError::JsonFile(e.to_string()))?;
+    serde_json::from_reader(file).map_err(|e| CommandError::JsonFile(e.to_string()))
+}
+
+fn write_to_issuer_key_file<P: AsRef<Path>>(path: P, key_result: NextKeyResult) -> Result<(), CommandError> {
+    let file_exists = path.as_ref().exists();
+    let mut root = if file_exists {
+        read_json_file::<_, Vec<serde_json::Value>>(&path).map_err(|e| CommandError::JsonFile(e.to_string()))?
+    } else {
+        vec![]
+    };
+    let json = serde_json::json!({
+        "name": format!("issuer-key-{}", key_result.index),
+        "public_key": key_result.to_public_key().to_hex(),
+        "secret_key": key_result.key.to_hex(),
+    });
+    root.push(json);
+    write_json_file(path, &root).map_err(|e| CommandError::JsonFile(e.to_string()))?;
     Ok(())
 }

--- a/applications/tari_console_wallet/src/automation/prompt.rs
+++ b/applications/tari_console_wallet/src/automation/prompt.rs
@@ -163,3 +163,24 @@ impl<T: FromStr> FromStr for Optional<T> {
         }
     }
 }
+
+#[derive(Debug, Clone, Copy)]
+pub struct YesNo(bool);
+
+impl YesNo {
+    pub fn as_bool(self) -> bool {
+        self.0
+    }
+}
+
+impl FromStr for YesNo {
+    type Err = CommandError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.trim().to_lowercase().as_str() {
+            "y" | "yes" => Ok(Self(true)),
+            "n" | "no" => Ok(Self(false)),
+            _ => Err(CommandError::Argument),
+        }
+    }
+}

--- a/base_layer/wallet/src/key_manager_service/interface.rs
+++ b/base_layer/wallet/src/key_manager_service/interface.rs
@@ -21,7 +21,8 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use aes_gcm::Aes256Gcm;
-use tari_common_types::types::PrivateKey;
+use tari_common_types::types::{PrivateKey, PublicKey};
+use tari_crypto::keys::PublicKey as PublicKeyTrait;
 
 use crate::key_manager_service::error::KeyManagerServiceError;
 
@@ -36,6 +37,12 @@ pub enum AddResult {
 pub struct NextKeyResult {
     pub key: PrivateKey,
     pub index: u64,
+}
+
+impl NextKeyResult {
+    pub fn to_public_key(&self) -> PublicKey {
+        PublicKey::from_secret_key(&self.key)
+    }
 }
 
 /// Behaviour required for the Key manager service

--- a/base_layer/wallet/src/key_manager_service/mod.rs
+++ b/base_layer/wallet/src/key_manager_service/mod.rs
@@ -40,4 +40,4 @@ mod test;
 mod interface;
 pub mod storage;
 
-pub use interface::{AddResult, KeyManagerInterface};
+pub use interface::{AddResult, KeyManagerInterface, NextKeyResult};

--- a/base_layer/wallet/src/output_manager_service/resources.rs
+++ b/base_layer/wallet/src/output_manager_service/resources.rs
@@ -55,6 +55,7 @@ pub enum OutputManagerKeyManagerBranch {
     RecoveryViewOnly,
     RecoveryBlinding,
     RecoveryByte,
+    ContractIssuer,
 }
 
 impl OutputManagerKeyManagerBranch {
@@ -69,6 +70,7 @@ impl OutputManagerKeyManagerBranch {
             OutputManagerKeyManagerBranch::RecoveryViewOnly => "recovery_viewonly".to_string(),
             OutputManagerKeyManagerBranch::RecoveryBlinding => "recovery_blinding".to_string(),
             OutputManagerKeyManagerBranch::RecoveryByte => "Recovery_byte".to_string(),
+            OutputManagerKeyManagerBranch::ContractIssuer => "contract_issuer".to_string(),
         }
     }
 }

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -170,31 +170,20 @@ where
     }
 
     async fn initialise_key_manager(key_manager: &TKeyManagerInterface) -> Result<(), OutputManagerError> {
-        key_manager
-            .add_new_branch(OutputManagerKeyManagerBranch::Spend.get_branch_key())
-            .await?;
-        key_manager
-            .add_new_branch(OutputManagerKeyManagerBranch::SpendScript.get_branch_key())
-            .await?;
-        key_manager
-            .add_new_branch(OutputManagerKeyManagerBranch::Coinbase.get_branch_key())
-            .await?;
-        key_manager
-            .add_new_branch(OutputManagerKeyManagerBranch::CoinbaseScript.get_branch_key())
-            .await?;
-        key_manager
-            .add_new_branch(OutputManagerKeyManagerBranch::RecoveryViewOnly.get_branch_key())
-            .await?;
-        key_manager
-            .add_new_branch(OutputManagerKeyManagerBranch::RecoveryByte.get_branch_key())
-            .await?;
-        match key_manager
-            .add_new_branch(OutputManagerKeyManagerBranch::RecoveryBlinding.get_branch_key())
-            .await
-        {
-            Ok(_) => Ok(()),
-            Err(e) => Err(OutputManagerError::KeyManagerServiceError(e)),
+        const BRANCHES: &[OutputManagerKeyManagerBranch] = &[
+            OutputManagerKeyManagerBranch::Spend,
+            OutputManagerKeyManagerBranch::SpendScript,
+            OutputManagerKeyManagerBranch::Coinbase,
+            OutputManagerKeyManagerBranch::CoinbaseScript,
+            OutputManagerKeyManagerBranch::RecoveryViewOnly,
+            OutputManagerKeyManagerBranch::RecoveryByte,
+            OutputManagerKeyManagerBranch::RecoveryBlinding,
+            OutputManagerKeyManagerBranch::ContractIssuer,
+        ];
+        for branch in BRANCHES {
+            key_manager.add_new_branch(branch.get_branch_key()).await?;
         }
+        Ok(())
     }
 
     /// Return the public rewind keys


### PR DESCRIPTION
Description
---
- adds prompt for if the user would like to use their wallet public key for the issuer public key
- adds issuer key generation for contract init-definition
- adds prompt for setting/creating a issuer key
- minor improvements to Prompt
- add ContractIssuer branch to key manager

Motivation and Context
---
Console wallet generates a new issuer key from the key manager when creating the contract definition json

How Has This Been Tested?
---
Manually
