### PR TITLE
fix: vn less eager auto acceptance

### DIFF
--- a/applications/tari_app_grpc/proto/base_node.proto
+++ b/applications/tari_app_grpc/proto/base_node.proto
@@ -447,4 +447,5 @@ message MempoolStatsResponse {
 
 message GetConstitutionsRequest {
     bytes dan_node_public_key = 1;
+    uint64 vn_confirmation_time = 2;
 }

--- a/applications/tari_base_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/tari_base_node/src/grpc/base_node_grpc_server.rs
@@ -1848,7 +1848,10 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
                 target: LOG_TARGET,
                 "Starting thread to process GetConstitutions: dan_node_public_key: {}", dan_node_public_key_hex,
             );
-            let constitutions = match handler.get_constitutions(dan_node_public_key).await {
+            let constitutions = match handler
+                .get_constitutions(dan_node_public_key, request.vn_confirmation_time)
+                .await
+            {
                 Ok(constitutions) => constitutions,
                 Err(err) => {
                     warn!(target: LOG_TARGET, "Error communicating with base node: {:?}", err,);

--- a/applications/tari_validator_node/src/grpc/services/base_node_client.rs
+++ b/applications/tari_validator_node/src/grpc/services/base_node_client.rs
@@ -103,10 +103,12 @@ impl BaseNodeClient for GrpcBaseNodeClient {
     async fn get_constitutions(
         &mut self,
         dan_node_public_key: PublicKey,
+        vn_confirmation_time: u64,
     ) -> Result<Vec<TransactionOutput>, DigitalAssetError> {
         let inner = self.connection().await?;
         let request = grpc::GetConstitutionsRequest {
             dan_node_public_key: dan_node_public_key.as_bytes().to_vec(),
+            vn_confirmation_time,
         };
         let mut result = inner.get_constitutions(request).await?.into_inner();
         let mut outputs = vec![];

--- a/base_layer/core/src/base_node/comms_interface/comms_request.rs
+++ b/base_layer/core/src/base_node/comms_interface/comms_request.rs
@@ -72,6 +72,7 @@ pub enum NodeCommsRequest {
     },
     FetchConstitutions {
         dan_node_public_key: PublicKey,
+        vn_confirmation_time: u64,
     },
 }
 

--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -463,10 +463,16 @@ where B: BlockchainBackend + 'static
                 }
                 Ok(NodeCommsResponse::FetchTokensResponse { outputs })
             },
-            NodeCommsRequest::FetchConstitutions { dan_node_public_key } => {
+            NodeCommsRequest::FetchConstitutions {
+                dan_node_public_key,
+                vn_confirmation_time,
+            } => {
                 debug!(target: LOG_TARGET, "Starting fetch constitutions");
                 Ok(NodeCommsResponse::FetchConstitutionsResponse {
-                    outputs: self.blockchain_db.fetch_all_constitutions(dan_node_public_key).await?,
+                    outputs: self
+                        .blockchain_db
+                        .fetch_all_constitutions(dan_node_public_key, vn_confirmation_time)
+                        .await?,
                 })
             },
             NodeCommsRequest::FetchAssetRegistrations { range } => {

--- a/base_layer/core/src/base_node/comms_interface/local_interface.rs
+++ b/base_layer/core/src/base_node/comms_interface/local_interface.rs
@@ -322,10 +322,14 @@ impl LocalNodeCommsInterface {
     pub async fn get_constitutions(
         &mut self,
         dan_node_public_key: PublicKey,
+        vn_confirmation_time: u64,
     ) -> Result<Vec<TransactionOutput>, CommsInterfaceError> {
         match self
             .request_sender
-            .call(NodeCommsRequest::FetchConstitutions { dan_node_public_key })
+            .call(NodeCommsRequest::FetchConstitutions {
+                dan_node_public_key,
+                vn_confirmation_time,
+            })
             .await??
         {
             NodeCommsResponse::FetchConstitutionsResponse { outputs } => Ok(outputs),

--- a/base_layer/core/src/chain_storage/async_db.rs
+++ b/base_layer/core/src/chain_storage/async_db.rs
@@ -176,7 +176,7 @@ impl<B: BlockchainBackend + 'static> AsyncBlockchainDb<B> {
 
     make_async_fn!(utxo_count() -> usize, "utxo_count");
 
-    make_async_fn!(fetch_all_constitutions(dan_node_public_key: PublicKey) -> Vec<TransactionOutput>, "fetch_all_constitutions");
+    make_async_fn!(fetch_all_constitutions(dan_node_public_key: PublicKey, vn_confirmation_time: u64) -> Vec<TransactionOutput>, "fetch_all_constitutions");
 
     //---------------------------------- Kernel --------------------------------------------//
     make_async_fn!(fetch_kernel_by_excess_sig(excess_sig: Signature) -> Option<(TransactionKernel, HashOutput)>, "fetch_kernel_by_excess_sig");

--- a/base_layer/core/src/chain_storage/blockchain_backend.rs
+++ b/base_layer/core/src/chain_storage/blockchain_backend.rs
@@ -141,6 +141,8 @@ pub trait BlockchainBackend: Send + Sync {
     fn fetch_all_constitutions(
         &self,
         dan_node_public_key: &PublicKey,
+        vn_confirmation_time: u64,
+        tip_height: u64,
     ) -> Result<Vec<TransactionOutput>, ChainStorageError>;
 
     /// Fetch all outputs in a block

--- a/base_layer/core/src/chain_storage/blockchain_backend.rs
+++ b/base_layer/core/src/chain_storage/blockchain_backend.rs
@@ -33,7 +33,13 @@ use crate::{
         Reorg,
         UtxoMinedInfo,
     },
-    transactions::transaction_components::{OutputType, TransactionInput, TransactionKernel, TransactionOutput},
+    transactions::transaction_components::{
+        ContractAcceptance,
+        OutputType,
+        TransactionInput,
+        TransactionKernel,
+        TransactionOutput,
+    },
 };
 
 /// Identify behaviour for Blockchain database backends. Implementations must support `Send` and `Sync` so that
@@ -144,6 +150,12 @@ pub trait BlockchainBackend: Send + Sync {
         vn_confirmation_time: u64,
         tip_height: u64,
     ) -> Result<Vec<TransactionOutput>, ChainStorageError>;
+
+    fn fetch_acceptances_by_contract_id_and_vn_pubkey(
+        &self,
+        contract_id: FixedHash,
+        dan_node_public_key: PublicKey,
+    ) -> Result<ContractAcceptance, ChainStorageError>;
 
     /// Fetch all outputs in a block
     fn fetch_outputs_in_block(&self, header_hash: &HashOutput) -> Result<Vec<PrunedOutput>, ChainStorageError>;

--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -426,9 +426,11 @@ where B: BlockchainBackend
     pub fn fetch_all_constitutions(
         &self,
         dan_node_public_key: PublicKey,
+        vn_confirmation_time: u64,
     ) -> Result<Vec<TransactionOutput>, ChainStorageError> {
+        let tip_header = self.fetch_tip_header()?;
         let db = self.db_read_access()?;
-        db.fetch_all_constitutions(&dan_node_public_key)
+        db.fetch_all_constitutions(&dan_node_public_key, vn_confirmation_time, tip_header.height())
     }
 
     pub fn fetch_kernel_by_excess(

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -2068,6 +2068,32 @@ impl BlockchainBackend for LMDBDatabase {
                                 tip_height <= constitution_max_acceptance_height &&
                                 tip_height <= vn_max_acceptance_time
                             {
+                                let acceptances = self
+                                    .fetch_contract_outputs_by_contract_id_and_type(
+                                        sidechain_features.contract_id,
+                                        OutputType::ContractValidatorAcceptance,
+                                    )
+                                    .unwrap();
+
+                                for acceptance_output in acceptances {
+                                    if &acceptance_output
+                                        .output
+                                        .as_transaction_output()
+                                        .unwrap()
+                                        .features
+                                        .sidechain_features
+                                        .as_ref()
+                                        .unwrap()
+                                        .acceptance
+                                        .as_ref()
+                                        .unwrap()
+                                        .validator_node_public_key ==
+                                        dan_node_public_key
+                                    {
+                                        return None;
+                                    }
+                                }
+
                                 Some(txo)
                             } else {
                                 None

--- a/base_layer/core/src/test_helpers/blockchain.rs
+++ b/base_layer/core/src/test_helpers/blockchain.rs
@@ -329,8 +329,13 @@ impl BlockchainBackend for TempDatabase {
     fn fetch_all_constitutions(
         &self,
         dan_node_public_key: &PublicKey,
+        vn_confirmation_time: u64,
+        tip_height: u64,
     ) -> Result<Vec<TransactionOutput>, ChainStorageError> {
-        self.db.as_ref().unwrap().fetch_all_constitutions(dan_node_public_key)
+        self.db
+            .as_ref()
+            .unwrap()
+            .fetch_all_constitutions(dan_node_public_key, vn_confirmation_time, tip_height)
     }
 
     fn fetch_outputs_in_block(&self, header_hash: &HashOutput) -> Result<Vec<PrunedOutput>, ChainStorageError> {

--- a/base_layer/core/src/test_helpers/blockchain.rs
+++ b/base_layer/core/src/test_helpers/blockchain.rs
@@ -74,7 +74,14 @@ use crate::{
     proof_of_work::{AchievedTargetDifficulty, Difficulty, PowAlgorithm},
     test_helpers::{block_spec::BlockSpecs, create_consensus_rules, BlockSpec},
     transactions::{
-        transaction_components::{OutputType, TransactionInput, TransactionKernel, TransactionOutput, UnblindedOutput},
+        transaction_components::{
+            ContractAcceptance,
+            OutputType,
+            TransactionInput,
+            TransactionKernel,
+            TransactionOutput,
+            UnblindedOutput,
+        },
         CryptoFactories,
     },
     validation::{
@@ -336,6 +343,17 @@ impl BlockchainBackend for TempDatabase {
             .as_ref()
             .unwrap()
             .fetch_all_constitutions(dan_node_public_key, vn_confirmation_time, tip_height)
+    }
+
+    fn fetch_acceptances_by_contract_id_and_vn_pubkey(
+        &self,
+        contract_id: FixedHash,
+        dan_node_public_key: PublicKey,
+    ) -> Result<ContractAcceptance, ChainStorageError> {
+        self.db
+            .as_ref()
+            .unwrap()
+            .fetch_acceptances_by_contract_id_and_vn_pubkey(contract_id, dan_node_public_key)
     }
 
     fn fetch_outputs_in_block(&self, header_hash: &HashOutput) -> Result<Vec<PrunedOutput>, ChainStorageError> {

--- a/dan_layer/core/src/services/base_node_client.rs
+++ b/dan_layer/core/src/services/base_node_client.rs
@@ -43,6 +43,7 @@ pub trait BaseNodeClient: Send + Sync {
     async fn get_constitutions(
         &mut self,
         dan_node_public_key: PublicKey,
+        last_tip: u64,
     ) -> Result<Vec<TransactionOutput>, DigitalAssetError>;
 
     async fn check_if_in_committee(

--- a/dan_layer/core/src/services/mocks/mod.rs
+++ b/dan_layer/core/src/services/mocks/mod.rs
@@ -224,6 +224,7 @@ impl BaseNodeClient for MockBaseNodeClient {
     async fn get_constitutions(
         &mut self,
         _dan_node_public_key: PublicKey,
+        _last_tip: u64,
     ) -> Result<Vec<TransactionOutput>, DigitalAssetError> {
         todo!();
     }


### PR DESCRIPTION
Description
---
When the VN is fetching constitutions, filter them by the constitution expiry, the vn acceptance expiry, and if the constitution has already been accepted.

TODO: Check the mempool for the acceptance.

Motivation and Context
---
Previously the VN was fetching all constitutions it is a member off from the base node. Then it was aggressively accepting and re-accepting the constitution when the auto accept is set to true.

How Has This Been Tested?
---
Tested manually. Tested each expiry in isolation, tested to make sure once accepted it does not continue to send acceptances.

To perform the test I

- Set a 10 block acceptance period in the constitution. Mined 10 blocks. Verified the constitution no longer showed up in the list from the base node.
- Using GRPC I changed the vn acceptance period and verified the amount of blocks mined after the constitution was posted was more then the acceptance number. Ensured the constitution was no longer returned.
- Accepted the contituion. Once mined, ensured the VN no longer sent new acceptances.