### PR TITLE
feat: use tari_crypto's updated "extended pedersen commitment factory"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6919,7 +6919,7 @@ dependencies = [
 [[package]]
 name = "tari_crypto"
 version = "0.13.0"
-source = "git+https://github.com/tari-project/tari-crypto.git#a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312"
+source = "git+https://github.com/tari-project/tari-crypto.git?rev=a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312#a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312"
 dependencies = [
  "base64 0.10.1",
  "blake2 0.9.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6574,7 +6574,7 @@ dependencies = [
 [[package]]
 name = "tari_bulletproofs"
 version = "4.1.2"
-source = "git+https://github.com/tari-project/bulletproofs?tag=v4.1.2#bdad5232c447a3acc1384b950574c6890a444e85"
+source = "git+https://github.com/tari-project/bulletproofs#efb763c6c9ff52f9445ce98594af52d1dc01c53b"
 dependencies = [
  "blake2 0.9.2",
  "byteorder",
@@ -6587,6 +6587,26 @@ dependencies = [
  "serde_derive",
  "sha3",
  "subtle-ng",
+ "thiserror",
+ "zeroize",
+]
+
+[[package]]
+name = "tari_bulletproofs_plus"
+version = "0.0.5"
+source = "git+https://github.com/tari-project/bulletproofs-plus#28725cdd7d753478c9508cae629a8063fc46be37"
+dependencies = [
+ "blake2 0.9.2",
+ "byteorder",
+ "curve25519-dalek-ng",
+ "derivative",
+ "derive_more",
+ "digest 0.9.0",
+ "lazy_static",
+ "merlin",
+ "rand 0.8.5",
+ "serde",
+ "sha3",
  "thiserror",
  "zeroize",
 ]
@@ -6899,7 +6919,7 @@ dependencies = [
 [[package]]
 name = "tari_crypto"
 version = "0.13.0"
-source = "git+https://github.com/tari-project/tari-crypto.git?tag=v0.13.0#c4dd4c0e53528720642b54f42083c6d9e392ee29"
+source = "git+https://github.com/tari-project/tari-crypto.git#a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312"
 dependencies = [
  "base64 0.10.1",
  "blake2 0.9.2",
@@ -6907,6 +6927,7 @@ dependencies = [
  "curve25519-dalek-ng",
  "digest 0.9.0",
  "lazy_static",
+ "log",
  "merlin",
  "once_cell",
  "rand 0.8.5",
@@ -6914,6 +6935,7 @@ dependencies = [
  "serde_json",
  "sha3",
  "tari_bulletproofs",
+ "tari_bulletproofs_plus",
  "tari_utilities",
  "thiserror",
  "zeroize",
@@ -7307,8 +7329,8 @@ dependencies = [
 
 [[package]]
 name = "tari_utilities"
-version = "0.4.3"
-source = "git+https://github.com/tari-project/tari_utilities.git?tag=v0.4.3#bd328a01ed8f2fec0661e0bd39ea904e3be961cf"
+version = "0.4.4"
+source = "git+https://github.com/tari-project/tari_utilities.git?tag=v0.4.4#cf01f5e5c77457f59bd61ffbed1923f52f4a03c2"
 dependencies = [
  "base58-monero",
  "base64 0.13.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7257,6 +7257,7 @@ dependencies = [
  "serde",
  "sha2 0.9.9",
  "sha3",
+ "tari_common_types",
  "tari_crypto",
  "tari_utilities",
  "thiserror",

--- a/applications/tari_app_grpc/Cargo.toml
+++ b/applications/tari_app_grpc/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 tari_common_types = { version = "^0.32", path = "../../base_layer/common_types"}
 tari_comms = { path = "../../comms/core"}
 tari_core = {  path = "../../base_layer/core"}
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", commit = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", rev = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
 tari_script = { path = "../../infrastructure/tari_script" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.4" }
 

--- a/applications/tari_app_grpc/Cargo.toml
+++ b/applications/tari_app_grpc/Cargo.toml
@@ -11,9 +11,9 @@ edition = "2018"
 tari_common_types = { version = "^0.32", path = "../../base_layer/common_types"}
 tari_comms = { path = "../../comms/core"}
 tari_core = {  path = "../../base_layer/core"}
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.13.0" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", commit = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
 tari_script = { path = "../../infrastructure/tari_script" }
-tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.3" }
+tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.4" }
 
 chrono = { version = "0.4.19", default-features = false }
 prost = "0.9"

--- a/applications/tari_app_utilities/Cargo.toml
+++ b/applications/tari_app_utilities/Cargo.toml
@@ -7,7 +7,7 @@ license = "BSD-3-Clause"
 
 [dependencies]
 tari_comms = { path = "../../comms/core" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", commit = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", rev = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
 tari_common = { path = "../../common" }
 tari_common_types = { path = "../../base_layer/common_types" }
 tari_p2p = { path = "../../base_layer/p2p", features = ["auto-update"] }

--- a/applications/tari_app_utilities/Cargo.toml
+++ b/applications/tari_app_utilities/Cargo.toml
@@ -7,11 +7,11 @@ license = "BSD-3-Clause"
 
 [dependencies]
 tari_comms = { path = "../../comms/core" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.13.0" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", commit = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
 tari_common = { path = "../../common" }
 tari_common_types = { path = "../../base_layer/common_types" }
 tari_p2p = { path = "../../base_layer/p2p", features = ["auto-update"] }
-tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.3" }
+tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.4" }
 
 clap = { version = "3.1.1", features = ["derive", "env"] }
 config = { version = "0.13.0" }

--- a/applications/tari_base_node/Cargo.toml
+++ b/applications/tari_base_node/Cargo.toml
@@ -15,14 +15,14 @@ tari_comms = { path = "../../comms/core", features = ["rpc"] }
 tari_common_types = { path = "../../base_layer/common_types" }
 tari_comms_dht = { path = "../../comms/dht" }
 tari_core = { path = "../../base_layer/core", default-features = false, features = ["transactions"] }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.13.0" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", commit = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
 tari_libtor = { path = "../../infrastructure/libtor" }
 tari_mmr = { path = "../../base_layer/mmr", features = ["native_bitmap"] }
 tari_p2p = { path = "../../base_layer/p2p", features = ["auto-update"] }
 tari_storage = {path="../../infrastructure/storage"}
 tari_service_framework = { path = "../../base_layer/service_framework" }
 tari_shutdown = { path = "../../infrastructure/shutdown" }
-tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.3" }
+tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.4" }
 
 anyhow = "1.0.53"
 async-trait = "0.1.52"

--- a/applications/tari_base_node/Cargo.toml
+++ b/applications/tari_base_node/Cargo.toml
@@ -15,7 +15,7 @@ tari_comms = { path = "../../comms/core", features = ["rpc"] }
 tari_common_types = { path = "../../base_layer/common_types" }
 tari_comms_dht = { path = "../../comms/dht" }
 tari_core = { path = "../../base_layer/core", default-features = false, features = ["transactions"] }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", commit = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", rev = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
 tari_libtor = { path = "../../infrastructure/libtor" }
 tari_mmr = { path = "../../base_layer/mmr", features = ["native_bitmap"] }
 tari_p2p = { path = "../../base_layer/p2p", features = ["auto-update"] }

--- a/applications/tari_collectibles/src-tauri/Cargo.toml
+++ b/applications/tari_collectibles/src-tauri/Cargo.toml
@@ -19,7 +19,7 @@ tari_app_grpc = { path = "../../tari_app_grpc" }
 tari_app_utilities = { path = "../../tari_app_utilities" }
 tari_common = { path = "../../../common" }
 tari_common_types = { path = "../../../base_layer/common_types" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", commit = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", rev = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
 tari_key_manager = { path = "../../../base_layer/key_manager" }
 tari_mmr = { path = "../../../base_layer/mmr" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.4" }

--- a/applications/tari_collectibles/src-tauri/Cargo.toml
+++ b/applications/tari_collectibles/src-tauri/Cargo.toml
@@ -19,10 +19,10 @@ tari_app_grpc = { path = "../../tari_app_grpc" }
 tari_app_utilities = { path = "../../tari_app_utilities" }
 tari_common = { path = "../../../common" }
 tari_common_types = { path = "../../../base_layer/common_types" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.13.0" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", commit = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
 tari_key_manager = { path = "../../../base_layer/key_manager" }
 tari_mmr = { path = "../../../base_layer/mmr" }
-tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.3" }
+tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.4" }
 tari_dan_common_types = { path = "../../../dan_layer/common_types" }
 
 blake2 = "^0.9.0"

--- a/applications/tari_console_wallet/Cargo.toml
+++ b/applications/tari_console_wallet/Cargo.toml
@@ -7,7 +7,7 @@ license = "BSD-3-Clause"
 
 [dependencies]
 tari_wallet = { path = "../../base_layer/wallet", features = ["bundled_sqlite"] }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.13.0" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", commit = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
 tari_common = { path = "../../common" }
 tari_app_utilities = { path = "../tari_app_utilities" }
 tari_comms = { path = "../../comms/core" }
@@ -18,7 +18,7 @@ tari_p2p = { path = "../../base_layer/p2p", features = ["auto-update"] }
 tari_app_grpc = { path = "../tari_app_grpc" }
 tari_shutdown = { path = "../../infrastructure/shutdown" }
 tari_key_manager = { path = "../../base_layer/key_manager" }
-tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.3" }
+tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.4" }
 
 # Uncomment for tokio tracing via tokio-console (needs "tracing" featurs)
 #console-subscriber = "0.1.3"

--- a/applications/tari_console_wallet/Cargo.toml
+++ b/applications/tari_console_wallet/Cargo.toml
@@ -7,7 +7,7 @@ license = "BSD-3-Clause"
 
 [dependencies]
 tari_wallet = { path = "../../base_layer/wallet", features = ["bundled_sqlite"] }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", commit = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", rev = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
 tari_common = { path = "../../common" }
 tari_app_utilities = { path = "../tari_app_utilities" }
 tari_comms = { path = "../../comms/core" }

--- a/applications/tari_console_wallet/src/automation/commands.rs
+++ b/applications/tari_console_wallet/src/automation/commands.rs
@@ -37,7 +37,7 @@ use strum_macros::{Display, EnumIter, EnumString};
 use tari_common_types::{
     emoji::EmojiId,
     transaction::TxId,
-    types::{FixedHash, PublicKey},
+    types::{CommitmentFactory, FixedHash, PublicKey},
 };
 use tari_comms::{
     connectivity::{ConnectivityEvent, ConnectivityRequester},
@@ -59,7 +59,6 @@ use tari_core::transactions::{
         UnblindedOutput,
     },
 };
-use tari_crypto::ristretto::pedersen::commitment_factory::PedersenCommitmentFactory;
 use tari_utilities::{hex::Hex, ByteArray, Hashable};
 use tari_wallet::{
     assets::{
@@ -1030,7 +1029,7 @@ async fn publish_contract_amendment(wallet: &WalletSqlite, args: PublishFileArgs
 }
 
 fn write_utxos_to_csv_file(utxos: Vec<UnblindedOutput>, file_path: PathBuf) -> Result<(), CommandError> {
-    let factory = PedersenCommitmentFactory::default();
+    let factory = CommitmentFactory::default();
     let file = File::create(file_path).map_err(|e| CommandError::CSVFile(e.to_string()))?;
     let mut csv_file = LineWriter::new(file);
     writeln!(

--- a/applications/tari_console_wallet/src/automation/commands.rs
+++ b/applications/tari_console_wallet/src/automation/commands.rs
@@ -59,7 +59,7 @@ use tari_core::transactions::{
         UnblindedOutput,
     },
 };
-use tari_crypto::ristretto::pedersen::PedersenCommitmentFactory;
+use tari_crypto::ristretto::pedersen::commitment_factory::PedersenCommitmentFactory;
 use tari_utilities::{hex::Hex, ByteArray, Hashable};
 use tari_wallet::{
     assets::{

--- a/applications/tari_merge_mining_proxy/Cargo.toml
+++ b/applications/tari_merge_mining_proxy/Cargo.toml
@@ -17,7 +17,7 @@ tari_common = { path = "../../common" }
 tari_comms = { path = "../../comms/core" }
 tari_core = { path = "../../base_layer/core", default-features = false, features = ["transactions"] }
 tari_app_utilities = { path = "../tari_app_utilities" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", commit = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", rev = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.4" }
 
 anyhow = "1.0.53"

--- a/applications/tari_merge_mining_proxy/Cargo.toml
+++ b/applications/tari_merge_mining_proxy/Cargo.toml
@@ -17,8 +17,8 @@ tari_common = { path = "../../common" }
 tari_comms = { path = "../../comms/core" }
 tari_core = { path = "../../base_layer/core", default-features = false, features = ["transactions"] }
 tari_app_utilities = { path = "../tari_app_utilities" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.13.0" }
-tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.3" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", commit = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
+tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.4" }
 
 anyhow = "1.0.53"
 crossterm = { version = "0.17" }

--- a/applications/tari_miner/Cargo.toml
+++ b/applications/tari_miner/Cargo.toml
@@ -13,8 +13,8 @@ tari_common = {  path = "../../common" }
 tari_comms = {  path = "../../comms/core" }
 tari_app_utilities = { path = "../tari_app_utilities"}
 tari_app_grpc = {  path = "../tari_app_grpc" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.13.0" }
-tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.3" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", commit = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
+tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.4" }
 
 crossterm = { version = "0.17" }
 clap = { version = "3.1.1", features = ["derive"] }

--- a/applications/tari_miner/Cargo.toml
+++ b/applications/tari_miner/Cargo.toml
@@ -13,7 +13,7 @@ tari_common = {  path = "../../common" }
 tari_comms = {  path = "../../comms/core" }
 tari_app_utilities = { path = "../tari_app_utilities"}
 tari_app_grpc = {  path = "../tari_app_grpc" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", commit = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", rev = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.4" }
 
 crossterm = { version = "0.17" }

--- a/applications/tari_validator_node/Cargo.toml
+++ b/applications/tari_validator_node/Cargo.toml
@@ -14,7 +14,7 @@ tari_common = { path = "../../common" }
 tari_comms = { path = "../../comms/core" }
 tari_comms_dht = { path = "../../comms/dht" }
 tari_comms_rpc_macros = { path = "../../comms/rpc_macros" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.13.0" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", commit = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
 tari_mmr = { path = "../../base_layer/mmr" }
 tari_p2p = { path = "../../base_layer/p2p" }
 tari_service_framework = { path = "../../base_layer/service_framework" }

--- a/applications/tari_validator_node/Cargo.toml
+++ b/applications/tari_validator_node/Cargo.toml
@@ -14,7 +14,7 @@ tari_common = { path = "../../common" }
 tari_comms = { path = "../../comms/core" }
 tari_comms_dht = { path = "../../comms/dht" }
 tari_comms_rpc_macros = { path = "../../comms/rpc_macros" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", commit = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", rev = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
 tari_mmr = { path = "../../base_layer/mmr" }
 tari_p2p = { path = "../../base_layer/p2p" }
 tari_service_framework = { path = "../../base_layer/service_framework" }

--- a/applications/test_faucet/Cargo.toml
+++ b/applications/test_faucet/Cargo.toml
@@ -10,8 +10,8 @@ simd = ["tari_crypto/simd"]
 avx2 = ["simd"]
 
 [dependencies]
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.13.0" }
-tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.3" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", commit = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
+tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.4" }
 tari_common_types = { path = "../../base_layer/common_types" }
 tari_script = { path = "../../infrastructure/tari_script" }
 

--- a/applications/test_faucet/Cargo.toml
+++ b/applications/test_faucet/Cargo.toml
@@ -10,7 +10,7 @@ simd = ["tari_crypto/simd"]
 avx2 = ["simd"]
 
 [dependencies]
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", commit = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", rev = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.4" }
 tari_common_types = { path = "../../base_layer/common_types" }
 tari_script = { path = "../../infrastructure/tari_script" }

--- a/base_layer/common_types/Cargo.toml
+++ b/base_layer/common_types/Cargo.toml
@@ -7,8 +7,8 @@ version = "0.32.3"
 edition = "2018"
 
 [dependencies]
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.13.0" }
-tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.3" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", commit = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
+tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.4" }
 
 digest = "0.9.0"
 lazy_static = "1.4.0"

--- a/base_layer/common_types/Cargo.toml
+++ b/base_layer/common_types/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.32.3"
 edition = "2018"
 
 [dependencies]
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", commit = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", rev = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.4" }
 
 digest = "0.9.0"

--- a/base_layer/common_types/src/types/mod.rs
+++ b/base_layer/common_types/src/types/mod.rs
@@ -28,7 +28,7 @@ use tari_crypto::{
     common::Blake256,
     ristretto::{
         dalek_range_proof::DalekRangeProofService,
-        pedersen::{commitment_factory::PedersenCommitmentFactory, PedersenCommitment},
+        pedersen::{extended_commitment_factory::ExtendedPedersenCommitmentFactory, PedersenCommitment},
         RistrettoComSig,
         RistrettoPublicKey,
         RistrettoSchnorr,
@@ -49,7 +49,7 @@ pub type ComSignature = RistrettoComSig;
 
 /// Define the explicit Commitment implementation for the Tari base layer.
 pub type Commitment = PedersenCommitment;
-pub type CommitmentFactory = PedersenCommitmentFactory;
+pub type CommitmentFactory = ExtendedPedersenCommitmentFactory;
 
 /// Define the explicit Public key implementation for the Tari base layer
 pub type PublicKey = RistrettoPublicKey;
@@ -76,6 +76,7 @@ pub type HashOutput = Vec<u8>;
 pub const MAX_RANGE_PROOF_RANGE: usize = 64; // 2^64
 
 /// Specify the range proof type
+// TODO: Replace `DalekRangeProofService` with `BulletproofsPlusService` when 'bulletproofs_plus'
 pub type RangeProofService = DalekRangeProofService;
 
 /// Specify the range proof

--- a/base_layer/common_types/src/types/mod.rs
+++ b/base_layer/common_types/src/types/mod.rs
@@ -28,7 +28,7 @@ use tari_crypto::{
     common::Blake256,
     ristretto::{
         dalek_range_proof::DalekRangeProofService,
-        pedersen::{PedersenCommitment, PedersenCommitmentFactory},
+        pedersen::{commitment_factory::PedersenCommitmentFactory, PedersenCommitment},
         RistrettoComSig,
         RistrettoPublicKey,
         RistrettoSchnorr,

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -24,7 +24,7 @@ tari_common_types = { version = "^0.32", path = "../../base_layer/common_types" 
 tari_comms = { version = "^0.32", path = "../../comms/core" }
 tari_comms_dht = { version = "^0.32", path = "../../comms/dht" }
 tari_comms_rpc_macros = { version = "^0.32", path = "../../comms/rpc_macros" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.13.0" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", commit = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
 tari_metrics = { path = "../../infrastructure/metrics" }
 tari_mmr = { version = "^0.32", path = "../../base_layer/mmr", optional = true, features = ["native_bitmap"] }
 tari_p2p = { version = "^0.32", path = "../../base_layer/p2p" }
@@ -33,7 +33,7 @@ tari_service_framework = { version = "^0.32", path = "../service_framework" }
 tari_shutdown = { version = "^0.32", path = "../../infrastructure/shutdown" }
 tari_storage = { version = "^0.32", path = "../../infrastructure/storage" }
 tari_test_utils = { version = "^0.32", path = "../../infrastructure/test_utils" }
-tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.3" }
+tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.4" }
 
 async-trait = "0.1.50"
 bincode = "1.1.4"

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -24,7 +24,7 @@ tari_common_types = { version = "^0.32", path = "../../base_layer/common_types" 
 tari_comms = { version = "^0.32", path = "../../comms/core" }
 tari_comms_dht = { version = "^0.32", path = "../../comms/dht" }
 tari_comms_rpc_macros = { version = "^0.32", path = "../../comms/rpc_macros" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", commit = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", rev = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
 tari_metrics = { path = "../../infrastructure/metrics" }
 tari_mmr = { version = "^0.32", path = "../../base_layer/mmr", optional = true, features = ["native_bitmap"] }
 tari_p2p = { version = "^0.32", path = "../../base_layer/p2p" }

--- a/base_layer/core/src/transactions/crypto_factories.rs
+++ b/base_layer/core/src/transactions/crypto_factories.rs
@@ -4,11 +4,13 @@
 use std::sync::Arc;
 
 use tari_common_types::types::{CommitmentFactory, RangeProofService, MAX_RANGE_PROOF_RANGE};
+use tari_crypto::ristretto::pedersen::commitment_factory::PedersenCommitmentFactory;
 
 /// A convenience struct wrapping cryptographic factories that are used throughout the rest of the code base
 /// Uses Arcs internally so calling clone on this is cheap, no need to wrap this in an Arc
 pub struct CryptoFactories {
     pub commitment: Arc<CommitmentFactory>,
+    pub commitment_dalek_bulletproofs: Arc<PedersenCommitmentFactory>, // TODO: Remove this when 'bulletproofs_plus'
     pub range_proof: Arc<RangeProofService>,
 }
 
@@ -29,9 +31,13 @@ impl CryptoFactories {
     /// * `max_proof_range`: Sets the the maximum value in range proofs, where `max = 2^max_proof_range`
     pub fn new(max_proof_range: usize) -> Self {
         let commitment = Arc::new(CommitmentFactory::default());
-        let range_proof = Arc::new(RangeProofService::new(max_proof_range, &commitment).unwrap());
+        // TODO: Remove this when 'bulletproofs_plus'
+        let commitment_dalek_bulletproofs = Arc::new(PedersenCommitmentFactory::default());
+        // TODO: Replace `commitment_dalek_bulletproofs` with `commitment` when 'bulletproofs_plus'
+        let range_proof = Arc::new(RangeProofService::new(max_proof_range, &commitment_dalek_bulletproofs).unwrap());
         Self {
             commitment,
+            commitment_dalek_bulletproofs,
             range_proof,
         }
     }
@@ -42,6 +48,7 @@ impl Clone for CryptoFactories {
     fn clone(&self) -> Self {
         Self {
             commitment: self.commitment.clone(),
+            commitment_dalek_bulletproofs: self.commitment_dalek_bulletproofs.clone(),
             range_proof: self.range_proof.clone(),
         }
     }

--- a/base_layer/core/src/transactions/transaction_components/error.rs
+++ b/base_layer/core/src/transactions/transaction_components/error.rs
@@ -26,7 +26,7 @@
 use std::io;
 
 use serde::{Deserialize, Serialize};
-use tari_crypto::{range_proof::RangeProofError, signatures::CommitmentSignatureError};
+use tari_crypto::{errors::RangeProofError, signatures::CommitmentSignatureError};
 use tari_script::ScriptError;
 use thiserror::Error;
 

--- a/base_layer/core/src/transactions/transaction_components/full_rewind_result.rs
+++ b/base_layer/core/src/transactions/transaction_components/full_rewind_result.rs
@@ -24,7 +24,7 @@
 // Version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0.
 
 use tari_common_types::types::BlindingFactor;
-use tari_crypto::range_proof::{FullRewindResult as CryptoFullRewindResult, REWIND_USER_MESSAGE_LENGTH};
+use tari_crypto::rewindable_range_proof::{FullRewindResult as CryptoFullRewindResult, REWIND_USER_MESSAGE_LENGTH};
 
 use crate::transactions::tari_amount::MicroTari;
 

--- a/base_layer/core/src/transactions/transaction_components/rewind_result.rs
+++ b/base_layer/core/src/transactions/transaction_components/rewind_result.rs
@@ -22,7 +22,7 @@
 //
 // Portions of this file were originally copyrighted (c) 2018 The Grin Developers, issued under the Apache License,
 // Version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0.
-use tari_crypto::range_proof::{RewindResult as CryptoRewindResult, REWIND_USER_MESSAGE_LENGTH};
+use tari_crypto::rewindable_range_proof::{RewindResult as CryptoRewindResult, REWIND_USER_MESSAGE_LENGTH};
 
 use crate::transactions::tari_amount::MicroTari;
 

--- a/base_layer/core/src/transactions/transaction_components/test.rs
+++ b/base_layer/core/src/transactions/transaction_components/test.rs
@@ -22,14 +22,21 @@
 
 use digest::Digest;
 use rand::{self, rngs::OsRng, Rng};
-use tari_common_types::types::{BlindingFactor, ComSignature, PrivateKey, PublicKey, RangeProof, Signature};
+use tari_common_types::types::{
+    BlindingFactor,
+    ComSignature,
+    CommitmentFactory,
+    PrivateKey,
+    PublicKey,
+    RangeProof,
+    Signature,
+};
 use tari_comms::types::Challenge;
 use tari_crypto::{
     commitment::HomomorphicCommitmentFactory,
     errors::RangeProofError,
     keys::{PublicKey as PublicKeyTrait, SecretKey as SecretKeyTrait},
     range_proof::RangeProofService,
-    ristretto::pedersen::commitment_factory::PedersenCommitmentFactory,
     tari_utilities::{hex::Hex, Hashable},
 };
 use tari_script::{script, ExecutionStack, StackItem};
@@ -52,7 +59,7 @@ use crate::{
 #[test]
 fn input_and_output_and_unblinded_output_hash_match() {
     let test_params = TestParams::new();
-    let factory = PedersenCommitmentFactory::default();
+    let factory = CommitmentFactory::default();
 
     let i = test_params.create_unblinded_output(Default::default());
     let output = i.as_transaction_output(&CryptoFactories::default()).unwrap();
@@ -64,7 +71,7 @@ fn input_and_output_and_unblinded_output_hash_match() {
 #[test]
 fn unblinded_input() {
     let test_params = TestParams::new();
-    let factory = PedersenCommitmentFactory::default();
+    let factory = CommitmentFactory::default();
 
     let i = test_params.create_unblinded_output(Default::default());
     let input = i
@@ -83,7 +90,7 @@ fn unblinded_input() {
 #[test]
 fn unblinded_input_with_rewind_data() {
     let test_params = TestParams::new();
-    let factory = PedersenCommitmentFactory::default();
+    let factory = CommitmentFactory::default();
 
     let i = test_params.create_unblinded_output_with_rewind_data(Default::default());
     let input = i

--- a/base_layer/core/src/transactions/transaction_components/transaction_output.rs
+++ b/base_layer/core/src/transactions/transaction_components/transaction_output.rs
@@ -49,7 +49,6 @@ use tari_crypto::{
     keys::{PublicKey as PublicKeyTrait, SecretKey},
     range_proof::RangeProofService as RangeProofServiceTrait,
     rewindable_range_proof::RewindableRangeProofService,
-    ristretto::pedersen::commitment_factory::PedersenCommitmentFactory,
     tari_utilities::{hex::Hex, ByteArray, Hashable},
 };
 use tari_script::TariScript;
@@ -180,7 +179,7 @@ impl TransactionOutput {
         if !self.metadata_signature.verify_challenge(
             &(&self.commitment + &self.sender_offset_public_key),
             &challenge.finalize_fixed(),
-            &PedersenCommitmentFactory::default(),
+            &CommitmentFactory::default(),
         ) {
             return Err(TransactionError::InvalidSignatureError(
                 "Metadata signature not valid!".to_string(),
@@ -288,13 +287,13 @@ impl TransactionOutput {
     ) -> Result<ComSignature, TransactionError> {
         let nonce_a = PrivateKey::random(&mut OsRng);
         let nonce_b = PrivateKey::random(&mut OsRng);
-        let nonce_commitment = PedersenCommitmentFactory::default().commit(&nonce_b, &nonce_a);
+        let nonce_commitment = CommitmentFactory::default().commit(&nonce_b, &nonce_a);
         let nonce_commitment = match partial_commitment_nonce {
             None => nonce_commitment,
             Some(partial_nonce) => &nonce_commitment + partial_nonce,
         };
         let pk_value = PrivateKey::from(value.as_u64());
-        let commitment = PedersenCommitmentFactory::default().commit(spending_key, &pk_value);
+        let commitment = CommitmentFactory::default().commit(spending_key, &pk_value);
         let encrypted_value = EncryptedValue::todo_encrypt_from(value.as_u64());
         let e = TransactionOutput::build_metadata_signature_challenge(
             version,
@@ -317,7 +316,7 @@ impl TransactionOutput {
             &nonce_a,
             &nonce_b,
             &e.finalize_fixed(),
-            &PedersenCommitmentFactory::default(),
+            &CommitmentFactory::default(),
         )?)
     }
 

--- a/base_layer/core/src/transactions/transaction_components/transaction_output.rs
+++ b/base_layer/core/src/transactions/transaction_components/transaction_output.rs
@@ -48,7 +48,8 @@ use tari_crypto::{
     commitment::HomomorphicCommitmentFactory,
     keys::{PublicKey as PublicKeyTrait, SecretKey},
     range_proof::RangeProofService as RangeProofServiceTrait,
-    ristretto::pedersen::PedersenCommitmentFactory,
+    rewindable_range_proof::RewindableRangeProofService,
+    ristretto::pedersen::commitment_factory::PedersenCommitmentFactory,
     tari_utilities::{hex::Hex, ByteArray, Hashable},
 };
 use tari_script::TariScript;

--- a/base_layer/core/src/transactions/transaction_protocol/mod.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/mod.rs
@@ -91,7 +91,8 @@ use serde::{Deserialize, Serialize};
 use tari_common_types::types::{PrivateKey, PublicKey};
 use tari_comms::types::Challenge;
 use tari_crypto::{
-    range_proof::{RangeProofError, REWIND_USER_MESSAGE_LENGTH},
+    errors::RangeProofError,
+    rewindable_range_proof::REWIND_USER_MESSAGE_LENGTH,
     signatures::SchnorrSignatureError,
     tari_utilities::byte_array::ByteArray,
 };

--- a/base_layer/core/src/transactions/transaction_protocol/recipient.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/recipient.rs
@@ -275,7 +275,7 @@ mod test {
     }
 
     #[test]
-    fn single_round_recipient_with_rewinding() {
+    fn single_round_recipient_with_rewinding_dalek_bulletproofs() {
         let factories = CryptoFactories::default();
         let p = TestParams::new();
         // Rewind params

--- a/base_layer/core/src/transactions/transaction_protocol/sender.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/sender.rs
@@ -27,11 +27,20 @@ use digest::{Digest, FixedOutput};
 use serde::{Deserialize, Serialize};
 use tari_common_types::{
     transaction::TxId,
-    types::{BlindingFactor, ComSignature, HashOutput, PrivateKey, PublicKey, RangeProofService, Signature},
+    types::{
+        BlindingFactor,
+        ComSignature,
+        CommitmentFactory,
+        HashOutput,
+        PrivateKey,
+        PublicKey,
+        RangeProofService,
+        Signature,
+    },
 };
 use tari_crypto::{
     keys::PublicKey as PublicKeyTrait,
-    ristretto::pedersen::{commitment_factory::PedersenCommitmentFactory, PedersenCommitment},
+    ristretto::pedersen::PedersenCommitment,
     tari_utilities::ByteArray,
 };
 use tari_script::TariScript;
@@ -439,7 +448,7 @@ impl SenderTransactionProtocol {
                         private_commitment_nonce,
                         recipient_sender_offset_private_key,
                         &info.outputs[index].clone(),
-                        &PedersenCommitmentFactory::default(),
+                        &CommitmentFactory::default(),
                     )?;
                 }
 
@@ -458,7 +467,7 @@ impl SenderTransactionProtocol {
         private_commitment_nonce: &PrivateKey,
         sender_offset_private_key: &PrivateKey,
         output: &TransactionOutput,
-        commitment_factory: &PedersenCommitmentFactory,
+        commitment_factory: &CommitmentFactory,
     ) -> Result<ComSignature, TPE> {
         // Create sender signature
         let public_commitment_nonce = PublicKey::from_secret_key(private_commitment_nonce);
@@ -764,13 +773,12 @@ impl fmt::Display for SenderState {
 mod test {
     use digest::Digest;
     use rand::rngs::OsRng;
-    use tari_common_types::types::{PrivateKey, PublicKey, RangeProof};
+    use tari_common_types::types::{CommitmentFactory, PrivateKey, PublicKey, RangeProof};
     use tari_crypto::{
         commitment::HomomorphicCommitmentFactory,
         common::Blake256,
         keys::{PublicKey as PublicKeyTrait, SecretKey as SecretKeyTrait},
         range_proof::RangeProofService,
-        ristretto::pedersen::commitment_factory::PedersenCommitmentFactory,
         tari_utilities::{hex::Hex, ByteArray},
     };
     use tari_script::{script, ExecutionStack, TariScript};
@@ -862,7 +870,7 @@ mod test {
     #[test]
     fn test_metadata_signature_finalize() {
         // Defaults
-        let commitment_factory = PedersenCommitmentFactory::default();
+        let commitment_factory = CommitmentFactory::default();
         let crypto_factory = CryptoFactories::default();
 
         // Sender data

--- a/base_layer/core/src/transactions/transaction_protocol/sender.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/sender.rs
@@ -31,7 +31,7 @@ use tari_common_types::{
 };
 use tari_crypto::{
     keys::PublicKey as PublicKeyTrait,
-    ristretto::pedersen::{PedersenCommitment, PedersenCommitmentFactory},
+    ristretto::pedersen::{commitment_factory::PedersenCommitmentFactory, PedersenCommitment},
     tari_utilities::ByteArray,
 };
 use tari_script::TariScript;
@@ -770,7 +770,7 @@ mod test {
         common::Blake256,
         keys::{PublicKey as PublicKeyTrait, SecretKey as SecretKeyTrait},
         range_proof::RangeProofService,
-        ristretto::pedersen::PedersenCommitmentFactory,
+        ristretto::pedersen::commitment_factory::PedersenCommitmentFactory,
         tari_utilities::{hex::Hex, ByteArray},
     };
     use tari_script::{script, ExecutionStack, TariScript};
@@ -1223,7 +1223,7 @@ mod test {
     }
 
     #[test]
-    fn single_recipient_with_rewindable_change_and_receiver_outputs() {
+    fn single_recipient_with_rewindable_change_and_receiver_outputs_dalek_bulletproofs() {
         let factories = CryptoFactories::default();
         // Alice's parameters
         let a = TestParams::new();

--- a/base_layer/core/src/transactions/transaction_protocol/single_receiver.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/single_receiver.rs
@@ -23,8 +23,10 @@
 use tari_common_types::types::{PrivateKey as SK, PublicKey, RangeProof, Signature};
 use tari_crypto::{
     commitment::HomomorphicCommitmentFactory,
+    errors::RangeProofError,
     keys::PublicKey as PK,
-    range_proof::{RangeProofError, RangeProofService as RPS},
+    range_proof::RangeProofService as RPS,
+    rewindable_range_proof::RewindableRangeProofService,
     tari_utilities::byte_array::ByteArray,
 };
 
@@ -126,8 +128,11 @@ impl SingleReceiverTransactionProtocol {
         let output = TransactionOutput::new_current_version(
             sender_features,
             commitment,
-            RangeProof::from_bytes(&proof)
-                .map_err(|_| TPE::RangeProofError(RangeProofError::ProofConstructionError))?,
+            RangeProof::from_bytes(&proof).map_err(|_| {
+                TPE::RangeProofError(RangeProofError::ProofConstructionError(
+                    "Creating transaction output".to_string(),
+                ))
+            })?,
             sender_info.script.clone(),
             sender_info.sender_offset_public_key.clone(),
             partial_metadata_signature,

--- a/base_layer/core/src/transactions/transaction_protocol/transaction_initializer.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/transaction_initializer.rs
@@ -30,12 +30,11 @@ use log::*;
 use rand::rngs::OsRng;
 use tari_common_types::{
     transaction::TxId,
-    types::{BlindingFactor, HashOutput, PrivateKey, PublicKey},
+    types::{BlindingFactor, CommitmentFactory, HashOutput, PrivateKey, PublicKey},
 };
 use tari_crypto::{
     commitment::HomomorphicCommitmentFactory,
     keys::{PublicKey as PublicKeyTrait, SecretKey},
-    ristretto::pedersen::commitment_factory::PedersenCommitmentFactory,
     tari_utilities::{fixed_set::FixedSet, hex::to_hex},
 };
 use tari_script::{ExecutionStack, TariScript};
@@ -215,7 +214,7 @@ impl SenderTransactionInitializer {
         output: UnblindedOutput,
         sender_offset_private_key: PrivateKey,
     ) -> Result<&mut Self, BuildError> {
-        let commitment_factory = PedersenCommitmentFactory::default();
+        let commitment_factory = CommitmentFactory::default();
         let commitment = commitment_factory.commit(&output.spending_key, &PrivateKey::from(output.value));
         let recovery_byte = OutputFeatures::create_unique_recovery_byte(&commitment, self.rewind_data.as_ref());
         if recovery_byte != output.features.recovery_byte {

--- a/base_layer/core/src/transactions/transaction_protocol/transaction_initializer.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/transaction_initializer.rs
@@ -35,7 +35,7 @@ use tari_common_types::{
 use tari_crypto::{
     commitment::HomomorphicCommitmentFactory,
     keys::{PublicKey as PublicKeyTrait, SecretKey},
-    ristretto::pedersen::PedersenCommitmentFactory,
+    ristretto::pedersen::commitment_factory::PedersenCommitmentFactory,
     tari_utilities::{fixed_set::FixedSet, hex::to_hex},
 };
 use tari_script::{ExecutionStack, TariScript};

--- a/base_layer/key_manager/Cargo.toml
+++ b/base_layer/key_manager/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["lib", "cdylib"]
 
 [dependencies]
 tari_common_types = { version = "^0.32", path = "../../base_layer/common_types" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", commit = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", rev = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.4" }
 
 arrayvec = "0.7.1"

--- a/base_layer/key_manager/Cargo.toml
+++ b/base_layer/key_manager/Cargo.toml
@@ -12,8 +12,8 @@ crate-type = ["lib", "cdylib"]
 
 [dependencies]
 tari_common_types = { version = "^0.32", path = "../../base_layer/common_types" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.13.0" }
-tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.3" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", commit = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
+tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.4" }
 
 arrayvec = "0.7.1"
 argon2 = { version = "0.2", features = ["std"] }

--- a/base_layer/mmr/Cargo.toml
+++ b/base_layer/mmr/Cargo.toml
@@ -13,7 +13,7 @@ native_bitmap = ["croaring"]
 benches = ["criterion"]
 
 [dependencies]
-tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.3" }
+tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.4" }
 thiserror = "1.0.26"
 digest = "0.9.0"
 log = "0.4"
@@ -24,7 +24,7 @@ criterion = { version="0.2", optional = true }
 [dev-dependencies]
 rand="0.8.0"
 blake2 = "0.9.0"
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.13.0" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", commit = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
 serde_json = "1.0"
 bincode = "1.1"
 [lib]

--- a/base_layer/mmr/Cargo.toml
+++ b/base_layer/mmr/Cargo.toml
@@ -24,7 +24,7 @@ criterion = { version="0.2", optional = true }
 [dev-dependencies]
 rand="0.8.0"
 blake2 = "0.9.0"
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", commit = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", rev = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
 serde_json = "1.0"
 bincode = "1.1"
 [lib]

--- a/base_layer/p2p/Cargo.toml
+++ b/base_layer/p2p/Cargo.toml
@@ -13,11 +13,11 @@ edition = "2018"
 tari_comms = { version = "^0.32", path = "../../comms/core" }
 tari_comms_dht = { version = "^0.32", path = "../../comms/dht" }
 tari_common = { version = "^0.32", path = "../../common" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.13.0" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", commit = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
 tari_service_framework = { version = "^0.32", path = "../service_framework" }
 tari_shutdown = { version = "^0.32", path = "../../infrastructure/shutdown" }
 tari_storage = { version = "^0.32", path = "../../infrastructure/storage" }
-tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.3" }
+tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.4" }
 
 anyhow = "1.0.53"
 bytes = "0.5"

--- a/base_layer/p2p/Cargo.toml
+++ b/base_layer/p2p/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 tari_comms = { version = "^0.32", path = "../../comms/core" }
 tari_comms_dht = { version = "^0.32", path = "../../comms/dht" }
 tari_common = { version = "^0.32", path = "../../common" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", commit = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", rev = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
 tari_service_framework = { version = "^0.32", path = "../service_framework" }
 tari_shutdown = { version = "^0.32", path = "../../infrastructure/shutdown" }
 tari_storage = { version = "^0.32", path = "../../infrastructure/storage" }

--- a/base_layer/tari_mining_helper_ffi/Cargo.toml
+++ b/base_layer/tari_mining_helper_ffi/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 tari_comms = { version = "^0.32", path = "../../comms/core" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", commit = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", rev = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
 tari_common = {  path = "../../common" }
 tari_core = {  path = "../core", default-features = false, features = ["transactions"]}
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.4" }

--- a/base_layer/tari_mining_helper_ffi/Cargo.toml
+++ b/base_layer/tari_mining_helper_ffi/Cargo.toml
@@ -8,10 +8,10 @@ edition = "2018"
 
 [dependencies]
 tari_comms = { version = "^0.32", path = "../../comms/core" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.13.0" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", commit = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
 tari_common = {  path = "../../common" }
 tari_core = {  path = "../core", default-features = false, features = ["transactions"]}
-tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.3" }
+tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.4" }
 libc = "0.2.65"
 thiserror = "1.0.26"
 hex = "0.4.2"

--- a/base_layer/wallet/Cargo.toml
+++ b/base_layer/wallet/Cargo.toml
@@ -11,7 +11,7 @@ tari_common = { path = "../../common" }
 tari_common_types = { version = "^0.32", path = "../../base_layer/common_types" }
 tari_comms = { version = "^0.32", path = "../../comms/core" }
 tari_comms_dht = { version = "^0.32", path = "../../comms/dht" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.13.0" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", commit = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
 tari_key_manager = { version = "^0.32", path = "../key_manager" }
 tari_p2p = { version = "^0.32", path = "../p2p", features = ["auto-update"] }
 tari_script = { path = "../../infrastructure/tari_script" }
@@ -19,7 +19,7 @@ tari_service_framework = { version = "^0.32", path = "../service_framework" }
 tari_shutdown = { version = "^0.32", path = "../../infrastructure/shutdown" }
 tari_storage = { version = "^0.32", path = "../../infrastructure/storage" }
 tari_common_sqlite = { path = "../../common_sqlite" }
-tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.3" }
+tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.4" }
 
 # Uncomment for tokio tracing via tokio-console (needs "tracing" featurs)
 #console-subscriber = "0.1.3"

--- a/base_layer/wallet/Cargo.toml
+++ b/base_layer/wallet/Cargo.toml
@@ -11,7 +11,7 @@ tari_common = { path = "../../common" }
 tari_common_types = { version = "^0.32", path = "../../base_layer/common_types" }
 tari_comms = { version = "^0.32", path = "../../comms/core" }
 tari_comms_dht = { version = "^0.32", path = "../../comms/dht" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", commit = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", rev = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
 tari_key_manager = { version = "^0.32", path = "../key_manager" }
 tari_p2p = { version = "^0.32", path = "../p2p", features = ["auto-update"] }
 tari_script = { path = "../../infrastructure/tari_script" }

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -59,7 +59,7 @@ use tari_core::{
 use tari_crypto::{
     commitment::HomomorphicCommitmentFactory,
     keys::{DiffieHellmanSharedSecret, PublicKey as PublicKeyTrait, SecretKey},
-    range_proof::REWIND_USER_MESSAGE_LENGTH,
+    rewindable_range_proof::REWIND_USER_MESSAGE_LENGTH,
 };
 use tari_script::{inputs, script, TariScript};
 use tari_service_framework::reply_channel;

--- a/base_layer/wallet/tests/output_manager_service_tests/service.rs
+++ b/base_layer/wallet/tests/output_manager_service_tests/service.rs
@@ -52,7 +52,7 @@ use tari_crypto::{
     commitment::HomomorphicCommitmentFactory,
     common::Blake256,
     keys::{PublicKey as PublicKeyTrait, SecretKey},
-    range_proof::REWIND_USER_MESSAGE_LENGTH,
+    rewindable_range_proof::REWIND_USER_MESSAGE_LENGTH,
 };
 use tari_key_manager::{cipher_seed::CipherSeed, mnemonic::Mnemonic};
 use tari_script::{inputs, script, TariScript};
@@ -1214,7 +1214,7 @@ async fn coin_split_no_change() {
 }
 
 #[tokio::test]
-async fn handle_coinbase() {
+async fn handle_coinbase_with_dalek_bulletproofs_rewinding() {
     let factories = CryptoFactories::default();
     let (connection, _tempdir) = get_temp_sqlite_database_connection();
     let backend = OutputManagerSqliteDatabase::new(connection.clone(), None);

--- a/base_layer/wallet_ffi/Cargo.toml
+++ b/base_layer/wallet_ffi/Cargo.toml
@@ -11,12 +11,12 @@ tari_common = {path="../../common"}
 tari_common_types = {path="../common_types"}
 tari_comms = { version = "^0.32", path = "../../comms/core", features = ["c_integration"]}
 tari_comms_dht = { version = "^0.32", path = "../../comms/dht", default-features = false }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.13.0" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", commit = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
 tari_key_manager = { version = "^0.32", path = "../key_manager" }
 tari_p2p = { version = "^0.32", path = "../p2p" }
 tari_script = { path = "../../infrastructure/tari_script" }
 tari_shutdown = { version = "^0.32", path = "../../infrastructure/shutdown" }
-tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.3" }
+tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.4" }
 tari_wallet = { version = "^0.32", path = "../wallet", features = ["c_integration"]}
 
 chrono = { version = "0.4.19", default-features = false, features = ["serde"] }

--- a/base_layer/wallet_ffi/Cargo.toml
+++ b/base_layer/wallet_ffi/Cargo.toml
@@ -11,7 +11,7 @@ tari_common = {path="../../common"}
 tari_common_types = {path="../common_types"}
 tari_comms = { version = "^0.32", path = "../../comms/core", features = ["c_integration"]}
 tari_comms_dht = { version = "^0.32", path = "../../comms/dht", default-features = false }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", commit = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", rev = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
 tari_key_manager = { version = "^0.32", path = "../key_manager" }
 tari_p2p = { version = "^0.32", path = "../p2p" }
 tari_script = { path = "../../infrastructure/tari_script" }

--- a/comms/core/Cargo.toml
+++ b/comms/core/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.32.3"
 edition = "2018"
 
 [dependencies]
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", commit = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", rev = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
 tari_metrics = { path = "../../infrastructure/metrics" }
 tari_storage = { version = "^0.32", path = "../../infrastructure/storage" }
 tari_shutdown = { version = "^0.32", path = "../../infrastructure/shutdown" }

--- a/comms/core/Cargo.toml
+++ b/comms/core/Cargo.toml
@@ -10,11 +10,11 @@ version = "0.32.3"
 edition = "2018"
 
 [dependencies]
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.13.0" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", commit = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
 tari_metrics = { path = "../../infrastructure/metrics" }
 tari_storage = { version = "^0.32", path = "../../infrastructure/storage" }
 tari_shutdown = { version = "^0.32", path = "../../infrastructure/shutdown" }
-tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.3" }
+tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.4" }
 
 anyhow = "1.0.53"
 async-trait = "0.1.36"

--- a/comms/dht/Cargo.toml
+++ b/comms/dht/Cargo.toml
@@ -12,8 +12,8 @@ edition = "2018"
 [dependencies]
 tari_comms = { version = "^0.32", path = "../core", features = ["rpc"] }
 tari_comms_rpc_macros = { version = "^0.32", path = "../rpc_macros" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.13.0" }
-tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.3" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", commit = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
+tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.4" }
 tari_shutdown = { version = "^0.32", path = "../../infrastructure/shutdown" }
 tari_storage = { version = "^0.32", path = "../../infrastructure/storage" }
 tari_common_sqlite = { path = "../../common_sqlite" }

--- a/comms/dht/Cargo.toml
+++ b/comms/dht/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 tari_comms = { version = "^0.32", path = "../core", features = ["rpc"] }
 tari_comms_rpc_macros = { version = "^0.32", path = "../rpc_macros" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", commit = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", rev = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.4" }
 tari_shutdown = { version = "^0.32", path = "../../infrastructure/shutdown" }
 tari_storage = { version = "^0.32", path = "../../infrastructure/storage" }

--- a/dan_layer/core/Cargo.toml
+++ b/dan_layer/core/Cargo.toml
@@ -11,7 +11,7 @@ tari_common = { path = "../../common" }
 tari_comms = { path = "../../comms/core" }
 tari_comms_dht = { path = "../../comms/dht" }
 tari_comms_rpc_macros = { path = "../../comms/rpc_macros" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.13.0" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", commit = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
 tari_mmr = { path = "../../base_layer/mmr" }
 tari_p2p = { path = "../../base_layer/p2p" }
 tari_service_framework = { path = "../../base_layer/service_framework" }
@@ -20,7 +20,7 @@ tari_storage = { path = "../../infrastructure/storage" }
 tari_core = {path = "../../base_layer/core"}
 tari_dan_common_types = {path = "../common_types"}
 tari_common_types = {path = "../../base_layer/common_types"}
-tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.3" }
+tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.4" }
 
 anyhow = "1.0.53"
 async-trait = "0.1.50"

--- a/dan_layer/core/Cargo.toml
+++ b/dan_layer/core/Cargo.toml
@@ -11,7 +11,7 @@ tari_common = { path = "../../common" }
 tari_comms = { path = "../../comms/core" }
 tari_comms_dht = { path = "../../comms/dht" }
 tari_comms_rpc_macros = { path = "../../comms/rpc_macros" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", commit = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", rev = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
 tari_mmr = { path = "../../base_layer/mmr" }
 tari_p2p = { path = "../../base_layer/p2p" }
 tari_service_framework = { path = "../../base_layer/service_framework" }

--- a/dan_layer/storage_sqlite/Cargo.toml
+++ b/dan_layer/storage_sqlite/Cargo.toml
@@ -8,7 +8,7 @@ license = "BSD-3-Clause"
 tari_dan_core = {path="../core"}
 tari_common = { path = "../../common"}
 tari_common_types = {path = "../../base_layer/common_types"}
-tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.3" }
+tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.4" }
 
 
 diesel = { version = "1.4.8", features = ["sqlite"] }

--- a/infrastructure/storage/Cargo.toml
+++ b/infrastructure/storage/Cargo.toml
@@ -19,4 +19,4 @@ serde_derive = "1.0.80"
 
 [dev-dependencies]
 rand = "0.8"
-tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.3" }
+tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.4" }

--- a/infrastructure/tari_script/Cargo.toml
+++ b/infrastructure/tari_script/Cargo.toml
@@ -12,7 +12,7 @@ license = "BSD-3-Clause"
 
 [dependencies]
 tari_common_types = { path = "../../base_layer/common_types" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", commit = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", rev = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.4" }
 
 blake2 = "0.9"

--- a/infrastructure/tari_script/Cargo.toml
+++ b/infrastructure/tari_script/Cargo.toml
@@ -11,6 +11,7 @@ readme = "README.md"
 license = "BSD-3-Clause"
 
 [dependencies]
+tari_common_types = { path = "../../base_layer/common_types" }
 tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", commit = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.4" }
 

--- a/infrastructure/tari_script/Cargo.toml
+++ b/infrastructure/tari_script/Cargo.toml
@@ -11,8 +11,8 @@ readme = "README.md"
 license = "BSD-3-Clause"
 
 [dependencies]
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.13.0" }
-tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.3" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", commit = "a564ba8f15ea37f0e26f9e13d3ad7ed8e397d312" }
+tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.4" }
 
 blake2 = "0.9"
 digest = "0.9.0"

--- a/infrastructure/tari_script/src/script_commitment.rs
+++ b/infrastructure/tari_script/src/script_commitment.rs
@@ -19,7 +19,7 @@ use digest::Digest;
 use tari_crypto::{
     commitment::HomomorphicCommitmentFactory,
     ristretto::{
-        pedersen::{PedersenCommitment, PedersenCommitmentFactory},
+        pedersen::{commitment_factory::PedersenCommitmentFactory, PedersenCommitment},
         RistrettoSecretKey,
     },
 };

--- a/infrastructure/tari_script/src/script_commitment.rs
+++ b/infrastructure/tari_script/src/script_commitment.rs
@@ -16,12 +16,10 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use digest::Digest;
+use tari_common_types::types::CommitmentFactory;
 use tari_crypto::{
     commitment::HomomorphicCommitmentFactory,
-    ristretto::{
-        pedersen::{commitment_factory::PedersenCommitmentFactory, PedersenCommitment},
-        RistrettoSecretKey,
-    },
+    ristretto::{pedersen::PedersenCommitment, RistrettoSecretKey},
 };
 use tari_utilities::{ByteArray, ByteArrayError};
 use thiserror::Error;
@@ -89,7 +87,7 @@ impl ScriptCommitment {
     }
 }
 
-/// A factory for generating script commitments. The default [PedersenCommitmentFactory] is used by default.
+/// A factory for generating script commitments. The default [CommitmentFactory] is used by default.
 ///
 /// ## Example
 ///
@@ -117,7 +115,7 @@ impl ScriptCommitment {
 
 #[derive(Default)]
 pub struct ScriptCommitmentFactory {
-    factory: PedersenCommitmentFactory,
+    factory: CommitmentFactory,
 }
 
 impl ScriptCommitmentFactory {


### PR DESCRIPTION
Description
---
Update tari_crypto

- Updated tari_crypto to the latest version
- Switched to 'ExtendedPedersenCommitmentFactory' from 'PedersenCommitmentFactory'

_**Notes:**_
- _No functional changes, no commitment changes, no Bulletproof range proof changes._
- _Temporary use of the git commit instead of a tag for `tari-crypto` and in the `cargo.toml` files_

Motivation and Context
---
Preparation for `tari_bulletproofs_plus` implementation.

How Has This Been Tested?
---
- Existing unit tests pass
- Existing integration tests pass
