### PR TITLE
feat(base-node): improve contract utxo scanning

### DIFF
--- a/applications/tari_app_grpc/proto/base_node.proto
+++ b/applications/tari_app_grpc/proto/base_node.proto
@@ -93,7 +93,7 @@ service BaseNode {
     rpc GetAssetMetadata(GetAssetMetadataRequest) returns (GetAssetMetadataResponse);
 
     // Get all constitutions where the public key is in the committee
-    rpc GetConstitutions(GetConstitutionsRequest) returns (stream TransactionOutput);
+    rpc GetConstitutions(GetConstitutionsRequest) returns (stream GetConstitutionsResponse);
 }
 
 message GetAssetMetadataRequest {
@@ -446,5 +446,13 @@ message MempoolStatsResponse {
 }
 
 message GetConstitutionsRequest {
-    bytes dan_node_public_key = 1;
+    bytes start_block_hash = 1;
+    bytes dan_node_public_key = 2;
+}
+
+message GetConstitutionsResponse {
+    TransactionOutput output = 1;
+    uint32 mmr_position = 2;
+    uint64 mined_height = 3;
+    bytes header_hash = 4;
 }

--- a/applications/tari_base_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/tari_base_node/src/grpc/base_node_grpc_server.rs
@@ -1889,6 +1889,7 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
                 if headers.is_empty() {
                     break;
                 }
+                let num_headers = headers.len();
 
                 for header in headers {
                     let block_hash_hex = header.hash().to_hex();
@@ -1943,6 +1944,10 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
                             return;
                         },
                     }
+                }
+
+                if num_headers < BATCH_SIZE as usize {
+                    break;
                 }
 
                 current_height += BATCH_SIZE + 1;

--- a/applications/tari_validator_node/src/dan_node.rs
+++ b/applications/tari_validator_node/src/dan_node.rs
@@ -97,6 +97,7 @@ impl DanNode {
         for output in outputs {
             if let Some(sidechain_features) = output.features.sidechain_features {
                 let contract_id = sidechain_features.contract_id;
+                // TODO: expect will crash the validator node if the base node misbehaves
                 let constitution = sidechain_features.constitution.expect("Constitution wasn't present");
 
                 if constitution.acceptance_requirements.acceptance_period_expiry < last_tip {

--- a/base_layer/core/src/base_node/comms_interface/comms_request.rs
+++ b/base_layer/core/src/base_node/comms_interface/comms_request.rs
@@ -29,7 +29,12 @@ use serde::{Deserialize, Serialize};
 use tari_common_types::types::{Commitment, HashOutput, PrivateKey, PublicKey, Signature};
 use tari_utilities::hex::Hex;
 
-use crate::{blocks::NewBlockTemplate, chain_storage::MmrTree, proof_of_work::PowAlgorithm};
+use crate::{
+    blocks::NewBlockTemplate,
+    chain_storage::MmrTree,
+    proof_of_work::PowAlgorithm,
+    transactions::transaction_components::OutputType,
+};
 
 /// A container for the parameters required for a FetchMmrState request.
 #[derive(Debug, Serialize, Deserialize)]
@@ -70,8 +75,9 @@ pub enum NodeCommsRequest {
     FetchMempoolTransactionsByExcessSigs {
         excess_sigs: Vec<PrivateKey>,
     },
-    FetchConstitutions {
-        dan_node_public_key: PublicKey,
+    FetchContractOutputsForBlock {
+        block_hash: HashOutput,
+        output_type: OutputType,
     },
 }
 
@@ -122,7 +128,7 @@ impl Display for NodeCommsRequest {
             FetchMempoolTransactionsByExcessSigs { .. } => {
                 write!(f, "FetchMempoolTransactionsByExcessSigs")
             },
-            FetchConstitutions { .. } => {
+            FetchContractOutputsForBlock { .. } => {
                 write!(f, "FetchConstitutions")
             },
         }

--- a/base_layer/core/src/base_node/comms_interface/comms_response.rs
+++ b/base_layer/core/src/base_node/comms_interface/comms_response.rs
@@ -66,8 +66,8 @@ pub enum NodeCommsResponse {
         output: Box<Option<UtxoMinedInfo>>,
     },
     FetchMempoolTransactionsByExcessSigsResponse(FetchMempoolTransactionsResponse),
-    FetchConstitutionsResponse {
-        outputs: Vec<TransactionOutput>,
+    FetchOutputsForBlockResponse {
+        outputs: Vec<UtxoMinedInfo>,
     },
 }
 
@@ -106,7 +106,7 @@ impl Display for NodeCommsResponse {
                 resp.transactions.len(),
                 resp.not_found.len()
             ),
-            FetchConstitutionsResponse { .. } => write!(f, "FetchConstitutionsResponse"),
+            FetchOutputsForBlockResponse { .. } => write!(f, "FetchConstitutionsResponse"),
         }
     }
 }

--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -463,12 +463,15 @@ where B: BlockchainBackend + 'static
                 }
                 Ok(NodeCommsResponse::FetchTokensResponse { outputs })
             },
-            NodeCommsRequest::FetchConstitutions { dan_node_public_key } => {
-                debug!(target: LOG_TARGET, "Starting fetch constitutions");
-                Ok(NodeCommsResponse::FetchConstitutionsResponse {
-                    outputs: self.blockchain_db.fetch_all_constitutions(dan_node_public_key).await?,
-                })
-            },
+            NodeCommsRequest::FetchContractOutputsForBlock {
+                block_hash,
+                output_type,
+            } => Ok(NodeCommsResponse::FetchOutputsForBlockResponse {
+                outputs: self
+                    .blockchain_db
+                    .fetch_contract_outputs_for_block(block_hash, output_type)
+                    .await?,
+            }),
             NodeCommsRequest::FetchAssetRegistrations { range } => {
                 let top_level_pubkey = PublicKey::default();
                 #[allow(clippy::range_plus_one)]

--- a/base_layer/core/src/base_node/comms_interface/local_interface.rs
+++ b/base_layer/core/src/base_node/comms_interface/local_interface.rs
@@ -40,7 +40,7 @@ use crate::{
     blocks::{Block, ChainHeader, HistoricalBlock, NewBlockTemplate},
     chain_storage::UtxoMinedInfo,
     proof_of_work::PowAlgorithm,
-    transactions::transaction_components::{TransactionKernel, TransactionOutput},
+    transactions::transaction_components::{OutputType, TransactionKernel, TransactionOutput},
 };
 
 pub type BlockEventSender = broadcast::Sender<Arc<BlockEvent>>;
@@ -319,16 +319,20 @@ impl LocalNodeCommsInterface {
         }
     }
 
-    pub async fn get_constitutions(
+    pub async fn get_contract_outputs_for_block(
         &mut self,
-        dan_node_public_key: PublicKey,
-    ) -> Result<Vec<TransactionOutput>, CommsInterfaceError> {
+        block_hash: BlockHash,
+        output_type: OutputType,
+    ) -> Result<Vec<UtxoMinedInfo>, CommsInterfaceError> {
         match self
             .request_sender
-            .call(NodeCommsRequest::FetchConstitutions { dan_node_public_key })
+            .call(NodeCommsRequest::FetchContractOutputsForBlock {
+                block_hash,
+                output_type,
+            })
             .await??
         {
-            NodeCommsResponse::FetchConstitutionsResponse { outputs } => Ok(outputs),
+            NodeCommsResponse::FetchOutputsForBlockResponse { outputs } => Ok(outputs),
             _ => Err(CommsInterfaceError::UnexpectedApiResponse),
         }
     }

--- a/base_layer/core/src/chain_storage/async_db.rs
+++ b/base_layer/core/src/chain_storage/async_db.rs
@@ -66,7 +66,7 @@ use crate::{
     },
     common::rolling_vec::RollingVec,
     proof_of_work::{PowAlgorithm, TargetDifficultyWindow},
-    transactions::transaction_components::{TransactionKernel, TransactionOutput},
+    transactions::transaction_components::{OutputType, TransactionKernel, TransactionOutput},
 };
 
 const LOG_TARGET: &str = "c::bn::async_db";
@@ -176,7 +176,7 @@ impl<B: BlockchainBackend + 'static> AsyncBlockchainDb<B> {
 
     make_async_fn!(utxo_count() -> usize, "utxo_count");
 
-    make_async_fn!(fetch_all_constitutions(dan_node_public_key: PublicKey) -> Vec<TransactionOutput>, "fetch_all_constitutions");
+    make_async_fn!(fetch_contract_outputs_for_block(block_hash: BlockHash, output_type: OutputType) -> Vec<UtxoMinedInfo>, "fetch_contract_outputs_for_block");
 
     //---------------------------------- Kernel --------------------------------------------//
     make_async_fn!(fetch_kernel_by_excess_sig(excess_sig: Signature) -> Option<(TransactionKernel, HashOutput)>, "fetch_kernel_by_excess_sig");

--- a/base_layer/core/src/chain_storage/blockchain_backend.rs
+++ b/base_layer/core/src/chain_storage/blockchain_backend.rs
@@ -6,7 +6,7 @@ use std::ops::Range;
 use croaring::Bitmap;
 use tari_common_types::{
     chain_metadata::ChainMetadata,
-    types::{Commitment, FixedHash, HashOutput, PublicKey, Signature},
+    types::{BlockHash, Commitment, FixedHash, HashOutput, PublicKey, Signature},
 };
 use tari_mmr::Hash;
 
@@ -33,7 +33,7 @@ use crate::{
         Reorg,
         UtxoMinedInfo,
     },
-    transactions::transaction_components::{OutputType, TransactionInput, TransactionKernel, TransactionOutput},
+    transactions::transaction_components::{OutputType, TransactionInput, TransactionKernel},
 };
 
 /// Identify behaviour for Blockchain database backends. Implementations must support `Send` and `Sync` so that
@@ -138,10 +138,12 @@ pub trait BlockchainBackend: Send + Sync {
         range: Range<usize>,
     ) -> Result<Vec<UtxoMinedInfo>, ChainStorageError>;
 
-    fn fetch_all_constitutions(
+    /// Fetches contract UTXOs mined within the given block.
+    fn fetch_contract_outputs_for_block(
         &self,
-        dan_node_public_key: &PublicKey,
-    ) -> Result<Vec<TransactionOutput>, ChainStorageError>;
+        block_hash: &BlockHash,
+        output_type: OutputType,
+    ) -> Result<Vec<UtxoMinedInfo>, ChainStorageError>;
 
     /// Fetch all outputs in a block
     fn fetch_outputs_in_block(&self, header_hash: &HashOutput) -> Result<Vec<PrunedOutput>, ChainStorageError>;

--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -79,7 +79,7 @@ use crate::{
     common::rolling_vec::RollingVec,
     consensus::{chain_strength_comparer::ChainStrengthComparer, ConsensusConstants, ConsensusManager},
     proof_of_work::{monero_rx::MoneroPowData, PowAlgorithm, TargetDifficultyWindow},
-    transactions::transaction_components::{OutputType, TransactionInput, TransactionKernel, TransactionOutput},
+    transactions::transaction_components::{OutputType, TransactionInput, TransactionKernel},
     validation::{
         helpers::calc_median_timestamp,
         DifficultyCalculator,
@@ -423,12 +423,13 @@ where B: BlockchainBackend
         Ok(result)
     }
 
-    pub fn fetch_all_constitutions(
+    pub fn fetch_contract_outputs_for_block(
         &self,
-        dan_node_public_key: PublicKey,
-    ) -> Result<Vec<TransactionOutput>, ChainStorageError> {
+        block_hash: BlockHash,
+        output_type: OutputType,
+    ) -> Result<Vec<UtxoMinedInfo>, ChainStorageError> {
         let db = self.db_read_access()?;
-        db.fetch_all_constitutions(&dan_node_public_key)
+        db.fetch_contract_outputs_for_block(&block_hash, output_type)
     }
 
     pub fn fetch_kernel_by_excess(

--- a/base_layer/core/src/chain_storage/lmdb_db/composite_key.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/composite_key.rs
@@ -1,0 +1,93 @@
+//  Copyright 2022, The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::{
+    fmt::{Display, Formatter},
+    ops::{Deref, DerefMut},
+};
+
+use tari_utilities::hex::to_hex;
+
+#[derive(Debug, Clone, Copy)]
+pub(super) struct CompositeKey<const KEY_LEN: usize> {
+    bytes: [u8; KEY_LEN],
+    len: usize,
+}
+
+impl<const KEY_LEN: usize> CompositeKey<KEY_LEN> {
+    pub fn new() -> Self {
+        Self {
+            bytes: Self::new_buf(),
+            len: 0,
+        }
+    }
+
+    pub fn push<T: AsRef<[u8]>>(&mut self, bytes: T) -> bool {
+        let b = bytes.as_ref();
+        let new_len = self.len + b.len();
+        if new_len > KEY_LEN {
+            return false;
+        }
+        self.bytes[self.len..new_len].copy_from_slice(b);
+        self.len = new_len;
+        true
+    }
+
+    fn as_bytes(&self) -> &[u8] {
+        &self.bytes[..self.len]
+    }
+
+    fn as_bytes_mut(&mut self) -> &mut [u8] {
+        &mut self.bytes[..self.len]
+    }
+
+    /// Returns a fixed 0-filled byte array.
+    const fn new_buf() -> [u8; KEY_LEN] {
+        [0x0u8; KEY_LEN]
+    }
+}
+
+impl<const KEY_LEN: usize> Display for CompositeKey<KEY_LEN> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", to_hex(self.as_bytes()))
+    }
+}
+
+impl<const KEY_LEN: usize> Deref for CompositeKey<KEY_LEN> {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        self.as_bytes()
+    }
+}
+
+impl<const KEY_LEN: usize> DerefMut for CompositeKey<KEY_LEN> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.as_bytes_mut()
+    }
+}
+
+impl<const KEY_LEN: usize> AsRef<[u8]> for CompositeKey<KEY_LEN> {
+    fn as_ref(&self) -> &[u8] {
+        self.as_bytes()
+    }
+}

--- a/base_layer/core/src/chain_storage/lmdb_db/contract_index.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/contract_index.rs
@@ -23,20 +23,23 @@
 use std::{
     collections::{hash_map::DefaultHasher, HashSet},
     convert::{TryFrom, TryInto},
-    fmt::{Debug, Display, Formatter},
-    hash::BuildHasherDefault,
+    fmt::Debug,
+    hash::{BuildHasherDefault, Hash},
     ops::Deref,
 };
 
 use lmdb_zero::{traits::AsLmdbBytes, ConstTransaction, Database, WriteTransaction};
 use log::*;
-use serde::{de::DeserializeOwned, Serialize};
-use tari_common_types::types::FixedHash;
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use tari_common_types::types::{BlockHash, FixedHash};
 use tari_utilities::{hex::to_hex, Hashable};
 
 use crate::{
     chain_storage::{
-        lmdb_db::lmdb::{lmdb_delete, lmdb_exists, lmdb_get, lmdb_insert, lmdb_replace},
+        lmdb_db::{
+            composite_key::CompositeKey,
+            lmdb::{lmdb_delete, lmdb_exists, lmdb_fetch_matching_after, lmdb_get, lmdb_insert, lmdb_replace},
+        },
         ChainStorageError,
     },
     transactions::transaction_components::{OutputType, TransactionInput, TransactionOutput},
@@ -53,6 +56,12 @@ pub(super) struct ContractIndex<'a, T> {
     db: &'a Database<'a>,
 }
 
+/// A hash set using the DefaultHasher. Since output hashes are not user controlled and uniformly random there is no
+/// need to use RandomState hasher.
+type DefaultHashSet<T> = HashSet<T, BuildHasherDefault<DefaultHasher>>;
+type FixedHashSet = DefaultHashSet<FixedHash>;
+type ContractValueHashSet = DefaultHashSet<ContractIndexValue>;
+
 impl<'a, T> ContractIndex<'a, T>
 where T: Deref<Target = ConstTransaction<'a>>
 {
@@ -61,18 +70,28 @@ where T: Deref<Target = ConstTransaction<'a>>
         Self { txn, db }
     }
 
-    pub fn fetch(&self, contract_id: FixedHash, output_type: OutputType) -> Result<Vec<FixedHash>, ChainStorageError> {
+    pub fn find_by_contract_id(
+        &self,
+        contract_id: FixedHash,
+        output_type: OutputType,
+    ) -> Result<Vec<FixedHash>, ChainStorageError> {
         let key = ContractIndexKey::new(contract_id, output_type);
-
         match output_type {
             OutputType::ContractDefinition | OutputType::ContractCheckpoint | OutputType::ContractConstitution => {
-                Ok(self.find::<FixedHash>(&key)?.into_iter().collect())
+                Ok(self
+                    .get::<_, ContractIndexValue>(&key)?
+                    .into_iter()
+                    .map(|v| v.output_hash)
+                    .collect())
             },
             OutputType::ContractValidatorAcceptance |
             OutputType::ContractConstitutionProposal |
-            OutputType::ContractConstitutionChangeAcceptance => {
-                Ok(self.find::<FixedHashSet>(&key)?.into_iter().flatten().collect())
-            },
+            OutputType::ContractConstitutionChangeAcceptance => Ok(self
+                .get::<_, ContractValueHashSet>(&key)?
+                .into_iter()
+                .flatten()
+                .map(|v| v.output_hash)
+                .collect()),
             _ => Err(ChainStorageError::InvalidOperation(format!(
                 "Cannot fetch output type {} from contract index",
                 output_type
@@ -80,18 +99,48 @@ where T: Deref<Target = ConstTransaction<'a>>
         }
     }
 
-    fn find<V: DeserializeOwned>(&self, key: &ContractIndexKey) -> Result<Option<V>, ChainStorageError> {
+    pub fn find_by_block(
+        &self,
+        block_hash: FixedHash,
+        output_type: OutputType,
+    ) -> Result<Vec<FixedHash>, ChainStorageError> {
+        let key = BlockContractIndexKey::prefixed(block_hash, output_type);
+        match output_type {
+            OutputType::ContractDefinition | OutputType::ContractCheckpoint | OutputType::ContractConstitution => {
+                self.get_all_matching::<_, FixedHash>(&key)
+            },
+            OutputType::ContractValidatorAcceptance |
+            OutputType::ContractConstitutionProposal |
+            OutputType::ContractConstitutionChangeAcceptance => Ok(self
+                .get_all_matching::<_, FixedHashSet>(&key)?
+                .into_iter()
+                .flatten()
+                .collect()),
+            _ => Err(ChainStorageError::InvalidOperation(format!(
+                "Cannot fetch output type {} from contract index",
+                output_type
+            ))),
+        }
+    }
+
+    fn get<K: AsLmdbBytes, V: DeserializeOwned>(&self, key: &K) -> Result<Option<V>, ChainStorageError> {
         lmdb_get(&**self.txn, self.db, key)
     }
 
-    fn exists(&self, key: &ContractIndexKey) -> Result<bool, ChainStorageError> {
+    fn get_all_matching<K: AsLmdbBytes, V: DeserializeOwned>(&self, key: &K) -> Result<Vec<V>, ChainStorageError> {
+        lmdb_fetch_matching_after(&**self.txn, self.db, key.as_lmdb_bytes())
+    }
+
+    fn exists<K: AsLmdbBytes>(&self, key: &K) -> Result<bool, ChainStorageError> {
         lmdb_exists(&**self.txn, self.db, key)
     }
 }
 
 impl<'a> ContractIndex<'a, WriteTransaction<'a>> {
     /// Called when a new output must be added to the index
-    pub fn add_output(&self, output: &TransactionOutput) -> Result<(), ChainStorageError> {
+    pub fn add_output(&self, block_hash: &BlockHash, output: &TransactionOutput) -> Result<(), ChainStorageError> {
+        let block_hash = FixedHash::try_from(block_hash.as_slice())
+            .map_err(|_| ChainStorageError::CriticalError("block_hash was not 32-bytes".to_string()))?;
         let output_hash = FixedHash::try_from(output.hash())
             .map_err(|_| ChainStorageError::CriticalError("output.hash() was not 32-bytes".to_string()))?;
 
@@ -101,12 +150,14 @@ impl<'a> ContractIndex<'a, WriteTransaction<'a>> {
                 output_hash
             ))
         })?;
-        self.add_to_index(contract_id, output.features.output_type, output_hash)
+        self.add_to_index(block_hash, contract_id, output.features.output_type, output_hash)
     }
 
     /// Updates the index, removing references to the output that the given input spends.
     pub fn spend(&self, input: &TransactionInput) -> Result<(), ChainStorageError> {
-        let output_hash = FixedHash::try_from(input.output_hash()).unwrap();
+        let output_hash = FixedHash::try_from(input.output_hash())
+            .map_err(|_| ChainStorageError::CriticalError("input.output_hash() was not 32-bytes".to_string()))?;
+
         let features = input.features()?;
         let contract_id = features.contract_id().ok_or_else(|| {
             ChainStorageError::InvalidOperation(format!(
@@ -119,7 +170,8 @@ impl<'a> ContractIndex<'a, WriteTransaction<'a>> {
 
     /// Updates the index, rewinding (undoing) the effect of the output on the index state.
     pub fn rewind_output(&self, output: &TransactionOutput) -> Result<(), ChainStorageError> {
-        let output_hash = FixedHash::try_from(output.hash()).unwrap();
+        let output_hash = FixedHash::try_from(output.hash())
+            .map_err(|_| ChainStorageError::CriticalError("output.hash() was not 32-bytes".to_string()))?;
         let features = &output.features;
         let contract_id = features.contract_id().ok_or_else(|| {
             ChainStorageError::InvalidOperation(format!(
@@ -131,7 +183,11 @@ impl<'a> ContractIndex<'a, WriteTransaction<'a>> {
     }
 
     /// Updates the index, rewinding (undoing) the effect of the input on the index state.
-    pub fn rewind_input(&self, input: &TransactionInput) -> Result<(), ChainStorageError> {
+    pub fn rewind_input(&self, block_hash: &[u8], input: &TransactionInput) -> Result<(), ChainStorageError> {
+        let block_hash = block_hash
+            .try_into()
+            .map_err(|_| ChainStorageError::CriticalError("block_hash was not 32-bytes".to_string()))?;
+
         let output_hash = input
             .output_hash()
             .try_into()
@@ -144,31 +200,40 @@ impl<'a> ContractIndex<'a, WriteTransaction<'a>> {
                 output_hash
             ))
         })?;
-        self.add_to_index(contract_id, features.output_type, output_hash)
+        self.add_to_index(block_hash, contract_id, features.output_type, output_hash)
     }
 
     fn add_to_index(
         &self,
+        block_hash: FixedHash,
         contract_id: FixedHash,
         output_type: OutputType,
         output_hash: FixedHash,
     ) -> Result<(), ChainStorageError> {
-        let key = ContractIndexKey::new(contract_id, output_type);
+        let contract_key = ContractIndexKey::new(contract_id, output_type);
+        let block_key = BlockContractIndexKey::new(block_hash, output_type, contract_id);
         match output_type {
             OutputType::ContractDefinition => {
                 debug!(
                     target: LOG_TARGET,
                     "inserting index for new contract_id {} in output {}.", contract_id, output_hash
                 );
-                self.insert(&key, &output_hash)?;
-
+                self.insert(&contract_key, &ContractIndexValue {
+                    block_hash,
+                    output_hash,
+                })?;
+                self.insert(&block_key, &output_hash)?;
                 Ok(())
             },
             // Only one contract checkpoint and constitution can exist at a time and can be overwritten. Consensus rules
             // decide whether this is valid but we just assume this is valid here.
             OutputType::ContractConstitution | OutputType::ContractCheckpoint => {
                 self.assert_definition_exists(contract_id)?;
-                self.set(&key, &*output_hash)?;
+                self.set(&contract_key, &ContractIndexValue {
+                    block_hash,
+                    output_hash,
+                })?;
+                self.set(&block_key, &output_hash)?;
                 Ok(())
             },
             // These are collections of output hashes
@@ -177,16 +242,11 @@ impl<'a> ContractIndex<'a, WriteTransaction<'a>> {
             OutputType::ContractConstitutionChangeAcceptance |
             OutputType::ContractAmendment => {
                 self.assert_definition_exists(contract_id)?;
-                let mut hashes = self.find::<FixedHashSet>(&key)?.unwrap_or_default();
-
-                if !hashes.insert(output_hash) {
-                    return Err(ChainStorageError::InvalidOperation(format!(
-                        "{} UTXO for contract {} with hash {} has already been added to index",
-                        output_type, contract_id, output_hash
-                    )));
-                }
-
-                self.set(&key, &hashes)?;
+                self.add_to_set(&contract_key, ContractIndexValue {
+                    block_hash,
+                    output_hash,
+                })?;
+                self.add_to_set(&block_key, output_hash)?;
                 Ok(())
             },
             _ => Err(ChainStorageError::InvalidOperation(format!(
@@ -202,11 +262,11 @@ impl<'a> ContractIndex<'a, WriteTransaction<'a>> {
         output_type: OutputType,
         output_hash: FixedHash,
     ) -> Result<(), ChainStorageError> {
-        let key = ContractIndexKey::new(contract_id, output_type);
+        let contract_key = ContractIndexKey::new(contract_id, output_type);
 
         match output_type {
             OutputType::ContractDefinition => {
-                if self.has_dependent_outputs(&key)? {
+                if self.has_dependent_outputs(&contract_key)? {
                     return Err(ChainStorageError::UnspendableDueToDependentUtxos {
                         details: format!(
                             "Cannot deregister contract definition for contract {} because there are dependent outputs",
@@ -215,26 +275,21 @@ impl<'a> ContractIndex<'a, WriteTransaction<'a>> {
                     });
                 }
 
-                self.delete(&key)?;
+                let contract = self.get_and_delete::<_, ContractIndexValue>(&contract_key)?;
+                let block_key = BlockContractIndexKey::new(contract.block_hash, output_type, contract_id);
+                self.delete(&block_key)?;
                 Ok(())
             },
             OutputType::ContractConstitution | OutputType::ContractCheckpoint => {
-                self.delete(&key)?;
+                let contract = self.get_and_delete::<_, ContractIndexValue>(&contract_key)?;
+                let block_key = BlockContractIndexKey::new(contract.block_hash, output_type, contract_id);
+                self.delete(&block_key)?;
                 Ok(())
             },
             OutputType::ContractValidatorAcceptance | OutputType::ContractConstitutionProposal => {
-                let mut hash_set = self.find::<FixedHashSet>(&key)?.unwrap_or_default();
-                if !hash_set.remove(&output_hash) {
-                    return Err(ChainStorageError::InvalidOperation(format!(
-                        "Output {} was not found in {} UTXO set for contract_id {}",
-                        output_hash, output_type, contract_id
-                    )));
-                }
-                if hash_set.is_empty() {
-                    self.delete(&key)?;
-                } else {
-                    self.set(&key, &hash_set)?;
-                }
+                let contract = self.remove_from_contract_index(&contract_key, &output_hash)?;
+                let block_key = BlockContractIndexKey::new(contract.block_hash, output_type, contract_id);
+                self.remove_from_set(&block_key, &output_hash)?;
                 Ok(())
             },
             _ => Err(ChainStorageError::InvalidOperation(format!(
@@ -242,6 +297,68 @@ impl<'a> ContractIndex<'a, WriteTransaction<'a>> {
                 output_type, contract_id, output_hash
             ))),
         }
+    }
+
+    fn add_to_set<K: AsLmdbBytes, V: Eq + Hash + Serialize + DeserializeOwned>(
+        &self,
+        key: &K,
+        value: V,
+    ) -> Result<(), ChainStorageError> {
+        let mut hash_set = self.get::<_, DefaultHashSet<V>>(key)?.unwrap_or_default();
+        if !hash_set.insert(value) {
+            return Err(ChainStorageError::InvalidOperation(format!(
+                "UTXO with has already been added to contract index at key {}",
+                to_hex(key.as_lmdb_bytes())
+            )));
+        }
+
+        self.set(key, &hash_set)?;
+        Ok(())
+    }
+
+    fn remove_from_contract_index(
+        &self,
+        key: &ContractIndexKey,
+        output_hash: &FixedHash,
+    ) -> Result<ContractIndexValue, ChainStorageError> {
+        let mut hash_set = self.get::<_, ContractValueHashSet>(key)?.unwrap_or_default();
+        let value = hash_set
+            .iter()
+            .find(|v| v.output_hash == *output_hash)
+            .cloned()
+            .ok_or_else(|| {
+                ChainStorageError::InvalidOperation(format!(
+                    "Contract output was not found in UTXO set with key {}",
+                    to_hex(key.as_lmdb_bytes())
+                ))
+            })?;
+        hash_set.remove(&value);
+        if hash_set.is_empty() {
+            self.delete(key)?;
+        } else {
+            self.set(key, &hash_set)?;
+        }
+        Ok(value)
+    }
+
+    fn remove_from_set<K: AsLmdbBytes, V: Eq + Hash + Serialize + DeserializeOwned>(
+        &self,
+        key: &K,
+        value: &V,
+    ) -> Result<(), ChainStorageError> {
+        let mut hash_set = self.get::<_, DefaultHashSet<V>>(key)?.unwrap_or_default();
+        if !hash_set.remove(value) {
+            return Err(ChainStorageError::InvalidOperation(format!(
+                "Contract output was not found in UTXO set with key {}",
+                to_hex(key.as_lmdb_bytes())
+            )));
+        }
+        if hash_set.is_empty() {
+            self.delete(key)?;
+        } else {
+            self.set(key, &hash_set)?;
+        }
+        Ok(())
     }
 
     fn has_dependent_outputs(&self, key: &ContractIndexKey) -> Result<bool, ChainStorageError> {
@@ -268,72 +385,119 @@ impl<'a> ContractIndex<'a, WriteTransaction<'a>> {
         }
     }
 
-    fn insert<V: Serialize + Debug>(&self, key: &ContractIndexKey, value: &V) -> Result<(), ChainStorageError> {
+    fn insert<K: AsLmdbBytes + Debug, V: Serialize + Debug>(
+        &self,
+        key: &K,
+        value: &V,
+    ) -> Result<(), ChainStorageError> {
         lmdb_insert(self.txn, self.db, key, value, "contract_index")
     }
 
-    fn set<V: Serialize>(&self, key: &ContractIndexKey, value: &V) -> Result<(), ChainStorageError> {
+    fn set<K: AsLmdbBytes, V: Serialize>(&self, key: &K, value: &V) -> Result<(), ChainStorageError> {
         lmdb_replace(self.txn, self.db, key, value)
     }
 
-    fn delete(&self, key: &ContractIndexKey) -> Result<(), ChainStorageError> {
+    fn delete<K: AsLmdbBytes>(&self, key: &K) -> Result<(), ChainStorageError> {
         lmdb_delete(self.txn, self.db, key, "contract_index")
+    }
+
+    fn get_and_delete<K: AsLmdbBytes, V: DeserializeOwned>(&self, key: &K) -> Result<V, ChainStorageError> {
+        let value = self.get(key)?.ok_or_else(|| ChainStorageError::ValueNotFound {
+            entity: "contract_index",
+            field: "<unknown>",
+            value: to_hex(key.as_lmdb_bytes()),
+        })?;
+        self.delete(key)?;
+        Ok(value)
     }
 }
 
-/// A hash set using the DefaultHasher. Since output hashes are not user controlled and uniformly random there is no
-/// need to use RandomState hasher.
-type FixedHashSet = HashSet<FixedHash, BuildHasherDefault<DefaultHasher>>;
+#[derive(Debug, Clone, Serialize, Deserialize, Hash, PartialEq, Eq)]
+struct ContractIndexValue {
+    pub block_hash: FixedHash,
+    pub output_hash: FixedHash,
+}
 
-/// A 33-byte contract ID index key.
-///
-/// The first 32-bytes are the contract ID, the next byte is the `OutputType`.
 #[derive(Debug, Clone, Copy)]
-pub(self) struct ContractIndexKey {
-    bytes: [u8; Self::FULL_KEY_LEN],
+#[repr(u8)]
+enum KeyType {
+    PerContract = 0,
+    PerBlock = 1,
+}
+
+/// An index key constisting of {block_hash, output_type, contract_id}.
+#[derive(Debug, Clone, Copy)]
+struct BlockContractIndexKey {
+    key: CompositeKey<{ Self::KEY_LEN }>,
+}
+
+impl BlockContractIndexKey {
+    const KEY_LEN: usize = 1 + 32 + 1 + 32;
+
+    pub fn new(block_hash: FixedHash, output_type: OutputType, contract_id: FixedHash) -> Self {
+        let mut key = Self::prefixed(block_hash, output_type);
+        assert!(key.key.push(&contract_id));
+        key
+    }
+
+    pub fn prefixed(block_hash: FixedHash, output_type: OutputType) -> Self {
+        let mut key = CompositeKey::new();
+        assert!(key.push(&[KeyType::PerBlock as u8]));
+        assert!(key.push(&block_hash));
+        assert!(key.push(&[output_type.as_byte()]));
+        Self { key }
+    }
+}
+
+impl Deref for BlockContractIndexKey {
+    type Target = CompositeKey<{ Self::KEY_LEN }>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.key
+    }
+}
+
+impl AsLmdbBytes for BlockContractIndexKey {
+    fn as_lmdb_bytes(&self) -> &[u8] {
+        &self.key
+    }
+}
+
+/// An index key constisting of {contract_id, output_type}.
+#[derive(Debug, Clone, Copy)]
+struct ContractIndexKey {
+    key: CompositeKey<{ Self::KEY_LEN }>,
 }
 
 impl ContractIndexKey {
-    const FULL_KEY_LEN: usize = FixedHash::byte_size() + 1;
+    const KEY_LEN: usize = 1 + 32 + 1;
 
     pub fn new(contract_id: FixedHash, output_type: OutputType) -> Self {
-        Self {
-            bytes: Self::bytes_from_parts(contract_id, output_type),
-        }
+        let mut key = CompositeKey::new();
+        assert!(key.push(&[KeyType::PerContract as u8]));
+        assert!(key.push(&*contract_id));
+        assert!(key.push(&[output_type.as_byte()]));
+        Self { key }
     }
 
     pub fn to_key_with_output_type(self, output_type: OutputType) -> Self {
         let mut key = self;
-        key.bytes[FixedHash::byte_size()] = output_type.as_byte();
+        key.key[FixedHash::byte_size() + 1] = output_type.as_byte();
         key
     }
+}
 
-    pub fn as_bytes(&self) -> &[u8] {
-        &self.bytes[..]
-    }
+impl Deref for ContractIndexKey {
+    type Target = CompositeKey<{ Self::KEY_LEN }>;
 
-    fn bytes_from_parts(contract_id: FixedHash, output_type: OutputType) -> [u8; Self::FULL_KEY_LEN] {
-        let mut buf = Self::new_buf();
-        buf[..FixedHash::byte_size()].copy_from_slice(&*contract_id);
-        buf[FixedHash::byte_size()] = output_type.as_byte();
-        buf
-    }
-
-    /// Returns a fixed 0-filled byte array.
-    const fn new_buf() -> [u8; Self::FULL_KEY_LEN] {
-        [0x0u8; Self::FULL_KEY_LEN]
+    fn deref(&self) -> &Self::Target {
+        &self.key
     }
 }
 
 impl AsLmdbBytes for ContractIndexKey {
     fn as_lmdb_bytes(&self) -> &[u8] {
-        self.as_bytes()
-    }
-}
-
-impl Display for ContractIndexKey {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", to_hex(self.as_bytes()))
+        &self.key
     }
 }
 
@@ -344,16 +508,16 @@ mod tests {
 
     use super::*;
     mod contract_index_key {
-
         use super::*;
 
         #[test]
         fn it_represents_a_well_formed_contract_index_key() {
             let hash = HashDigest::new().chain(b"foobar").finalize().into();
             let key = ContractIndexKey::new(hash, OutputType::ContractCheckpoint);
-            assert_eq!(key.as_lmdb_bytes()[..32], *hash.as_slice());
+            assert_eq!(key.as_lmdb_bytes()[0], KeyType::PerContract as u8);
+            assert_eq!(key.as_lmdb_bytes()[1..33], *hash.as_slice());
             assert_eq!(
-                OutputType::from_byte(key.as_lmdb_bytes()[32]).unwrap(),
+                OutputType::from_byte(key.as_lmdb_bytes()[33]).unwrap(),
                 OutputType::ContractCheckpoint
             );
         }

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -196,28 +196,52 @@ pub struct LMDBDatabase {
     env: Arc<Environment>,
     env_config: LMDBConfig,
     metadata_db: DatabaseRef,
+    /// Maps height -> BlockHeader
     headers_db: DatabaseRef,
+    /// Maps height -> BlockHeaderAccumulatedData
     header_accumulated_data_db: DatabaseRef,
+    /// Maps height -> BlockAccumulatedData
     block_accumulated_data_db: DatabaseRef,
+    /// Maps block_hash -> height
     block_hashes_db: DatabaseRef,
+    /// Maps OutputKey -> TransactionOutputRowData
     utxos_db: DatabaseRef,
+    /// Maps InputKey -> TransactionInputRowData
     inputs_db: DatabaseRef,
+    /// Maps OutputHash -> <mmr_pos, OutputKey>
     txos_hash_to_index_db: DatabaseRef,
+    /// Maps KernelKey -> TransactionKernelRowData
     kernels_db: DatabaseRef,
+    /// Maps excess -> <block_hash, mmr_pos, kernel_hash>
     kernel_excess_index: DatabaseRef,
+    /// Maps excess_sig -> <block_hash, mmr_pos, kernel_hash>
     kernel_excess_sig_index: DatabaseRef,
+    /// Maps kernel_mmr_size -> height
     kernel_mmr_size_index: DatabaseRef,
+    /// Maps output_mmr_size -> height
     output_mmr_size_index: DatabaseRef,
+    /// Maps commitment -> output_hash
     utxo_commitment_index: DatabaseRef,
+    /// Maps unique_id -> output_hash
     unique_id_index: DatabaseRef,
+    /// Maps <contract_id, output_type> -> (block_hash, output_hash)
+    /// and  <block_hash, output_type, contract_id> -> output_hash
     contract_index: DatabaseRef,
+    /// Maps output_mmr_pos -> <block_hash, output_hash>
     deleted_txo_mmr_position_to_height_index: DatabaseRef,
+    /// Maps block_hash -> Block
     orphans_db: DatabaseRef,
+    /// Maps randomx_seed -> height
     monero_seed_height_db: DatabaseRef,
+    /// Maps block_hash -> BlockHeaderAccumulatedData
     orphan_header_accumulated_data_db: DatabaseRef,
+    /// Stores the orphan tip block hashes
     orphan_chain_tips_db: DatabaseRef,
+    /// Maps parent_block_hash -> block_hash
     orphan_parent_map_index: DatabaseRef,
+    /// Stores bad blocks by block_hash and height
     bad_blocks: DatabaseRef,
+    /// Stores reorgs by epochtime and Reorg
     reorgs: DatabaseRef,
     _file_lock: Arc<File>,
 }

--- a/base_layer/core/src/chain_storage/lmdb_db/mod.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/mod.rs
@@ -26,6 +26,7 @@ use tari_common_types::types::HashOutput;
 
 use crate::transactions::transaction_components::{TransactionInput, TransactionKernel, TransactionOutput};
 
+mod composite_key;
 mod contract_index;
 pub(crate) mod helpers;
 pub(crate) mod key_prefix_cursor;

--- a/base_layer/core/src/test_helpers/blockchain.rs
+++ b/base_layer/core/src/test_helpers/blockchain.rs
@@ -32,7 +32,7 @@ use croaring::Bitmap;
 use tari_common::configuration::Network;
 use tari_common_types::{
     chain_metadata::ChainMetadata,
-    types::{Commitment, FixedHash, HashOutput, PublicKey, Signature},
+    types::{BlockHash, Commitment, FixedHash, HashOutput, PublicKey, Signature},
 };
 use tari_storage::lmdb_store::LMDBConfig;
 use tari_test_utils::paths::create_temporary_data_path;
@@ -74,7 +74,7 @@ use crate::{
     proof_of_work::{AchievedTargetDifficulty, Difficulty, PowAlgorithm},
     test_helpers::{block_spec::BlockSpecs, create_consensus_rules, BlockSpec},
     transactions::{
-        transaction_components::{OutputType, TransactionInput, TransactionKernel, TransactionOutput, UnblindedOutput},
+        transaction_components::{OutputType, TransactionInput, TransactionKernel, UnblindedOutput},
         CryptoFactories,
     },
     validation::{
@@ -326,11 +326,15 @@ impl BlockchainBackend for TempDatabase {
             .fetch_all_unspent_by_parent_public_key(parent_public_key, range)
     }
 
-    fn fetch_all_constitutions(
+    fn fetch_contract_outputs_for_block(
         &self,
-        dan_node_public_key: &PublicKey,
-    ) -> Result<Vec<TransactionOutput>, ChainStorageError> {
-        self.db.as_ref().unwrap().fetch_all_constitutions(dan_node_public_key)
+        block_hash: &BlockHash,
+        output_type: OutputType,
+    ) -> Result<Vec<UtxoMinedInfo>, ChainStorageError> {
+        self.db
+            .as_ref()
+            .unwrap()
+            .fetch_contract_outputs_for_block(block_hash, output_type)
     }
 
     fn fetch_outputs_in_block(&self, header_hash: &HashOutput) -> Result<Vec<PrunedOutput>, ChainStorageError> {

--- a/base_layer/core/src/transactions/transaction_components/output_type.rs
+++ b/base_layer/core/src/transactions/transaction_components/output_type.rs
@@ -79,6 +79,20 @@ impl OutputType {
     pub fn from_byte(value: u8) -> Option<Self> {
         FromPrimitive::from_u8(value)
     }
+
+    pub fn is_contract_utxo(self) -> bool {
+        #[allow(clippy::enum_glob_use)]
+        use OutputType::*;
+        matches!(
+            self,
+            ContractDefinition |
+                ContractConstitution |
+                ContractValidatorAcceptance |
+                ContractCheckpoint |
+                ContractConstitutionProposal |
+                ContractConstitutionChangeAcceptance
+        )
+    }
 }
 
 impl Default for OutputType {

--- a/base_layer/core/src/transactions/transaction_components/side_chain/committee_members.rs
+++ b/base_layer/core/src/transactions/transaction_components/side_chain/committee_members.rs
@@ -48,6 +48,10 @@ impl CommitteeMembers {
     pub fn members(&self) -> &[PublicKey] {
         &self.members
     }
+
+    pub fn contains(&self, x: &PublicKey) -> bool {
+        self.members.contains(x)
+    }
 }
 
 impl TryFrom<Vec<PublicKey>> for CommitteeMembers {

--- a/integration_tests/features/ValidatorNode.feature
+++ b/integration_tests/features/ValidatorNode.feature
@@ -21,7 +21,9 @@ Feature: Validator Node
         And I create 40 NFTs
         And I mine 3 blocks
 
-    @dan @critical
+    # Broken: needs a contract definition before publishing acceptance, however this is currently not easily done because
+    # GRPC methods need to be added and you cannot use the cli for a wallet while that wallet is already running
+    @dan @critical @broken
     Scenario: Publish contract acceptance
         Given I have a seed node NODE1
         And I have wallet WALLET1 connected to all seed nodes

--- a/integration_tests/helpers/walletProcess.js
+++ b/integration_tests/helpers/walletProcess.js
@@ -291,8 +291,11 @@ class WalletProcess {
 
     const overrides = this.getOverrides();
     Object.keys(overrides).forEach((k) => {
-      args.push("-p");
-      args.push(`${k}=${overrides[k]}`);
+      let v = overrides[k];
+      if (typeof v !== "undefined") {
+        args.push("-p");
+        args.push(`${k}=${v}`);
+      }
     });
 
     // Append command arguments


### PR DESCRIPTION
Description
---
```
 feat(blockchain-db):      add {block_hash, output_type, contract_id} index to contract_index
 docs(chain-storage):      document mapping for each lmdb database
 feat(chain-storage):      replace fetch_all_constitutions with fetch_contract_outputs_for_block
 test(chain-storage):      add unit tests for fetch_contract_outputs_for_block
 feat(base-node-service):  replace get_constitutions with get_contract_outputs_for_block
 feat(base-node-grpc):     use get_contract_outputs_for_block to fetch constitutions
 test(cucumber):           mark `Publish contract acceptance` as broken
 test(cucumber):           fix command to publish contract utxos
```

Motivation and Context
---
`get_all_constitutions` is currently very inefficient and has to load the entire UTXO set. This PR adds a `<block_hash, output_type, contract_id>` index to contract_index db that allows efficient loading of contract outputs optionally filtered by type contained in a block. 

The get_constitutions grpc method now takes in a start_block_hash and streams utxos starting from that hash. 

How Has This Been Tested?
---
Additional unit tests
Manually, sync on igor
