### PR TITLE
feat(miner): friendlier miner output

### DIFF
--- a/applications/tari_miner/src/main.rs
+++ b/applications/tari_miner/src/main.rs
@@ -179,7 +179,7 @@ async fn main_inner() -> Result<(), ExitError> {
                     sleep(config.wait_timeout()).await;
                 },
                 Ok(submitted) => {
-                    info!(target: LOG_TARGET, "Found block");
+                    info!(target: LOG_TARGET, "💰 Found block");
                     if submitted {
                         blocks_found += 1;
                     }
@@ -196,12 +196,10 @@ async fn main_inner() -> Result<(), ExitError> {
 
 async fn connect(config: &MinerConfig) -> Result<(BaseNodeClient<Channel>, WalletClient<Channel>), MinerError> {
     let base_node_addr = multiaddr_to_socketaddr(&config.base_node_addr)?;
-    println!("Connecting to base node at {}", base_node_addr);
-    error!(target: LOG_TARGET, "Connecting to base node at {}", base_node_addr);
+    info!(target: LOG_TARGET, "🔗 Connecting to base node at {}", base_node_addr);
     let node_conn = BaseNodeClient::connect(format!("http://{}", base_node_addr)).await?;
     let wallet_addr = multiaddr_to_socketaddr(&config.wallet_addr)?;
-    println!("Connecting to wallet at {}", config.wallet_addr);
-    error!(target: LOG_TARGET, "Connecting to wallet at {}", wallet_addr);
+    info!(target: LOG_TARGET, "👛 Connecting to wallet at {}", wallet_addr);
     let wallet_conn = WalletClient::connect(format!("http://{}", wallet_addr)).await?;
 
     Ok((node_conn, wallet_conn))
@@ -316,7 +314,7 @@ async fn display_report(report: &MiningReport, num_mining_threads: usize) {
     let hashrate = report.hashes as f64 / report.elapsed.as_micros() as f64;
     info!(
         target: LOG_TARGET,
-        "Miner {} reported {:.2}MH/s with total {:.2}MH/s over {} threads. Height: {}. Target: {})",
+        "⛏ Miner {} reported {:.2}MH/s with total {:.2}MH/s over {} threads. Height: {}. Target: {})",
         report.miner,
         hashrate,
         hashrate * num_mining_threads as f64,


### PR DESCRIPTION
Description
---

Cleans up the miner output:
 - ~~output warn level to console output~~
 - use emojis for miner reports
 - change connect via grpc messages to info level

Motivation and Context
---
The miner would start with two red error messages that showed successful connections to the wallet and base node.
This PR cleans that up and adds emojis. 

```
11:03 INFO  🔗 Connecting to base node at 127.0.0.1:18142
11:03 INFO  👛 Connecting to wallet at 127.0.0.1:18143
11:03 INFO  ⛏ Miner 0 reported 0.91MH/s with total 9.15MH/s over 10 threads. Height: 32. Target: 344194565)
11:03 INFO  ⛏ Miner 3 reported 0.59MH/s with total 5.94MH/s over 10 threads. Height: 32. Target: 344194565)
11:03 INFO  ⛏ Miner 5 reported 0.84MH/s with total 8.44MH/s over 10 threads. Height: 32. Target: 344194565)
11:03 INFO  ⛏ Miner 4 reported 0.77MH/s with total 7.69MH/s over 10 threads. Height: 32. Target: 344194565)
11:03 INFO  ⛏ Miner 6 reported 0.81MH/s with total 8.08MH/s over 10 threads. Height: 32. Target: 344194565)
11:03 INFO  ⛏ Miner 1 reported 0.79MH/s with total 7.86MH/s over 10 threads. Height: 32. Target: 344194565)
11:03 INFO  ⛏ Miner 2 reported 0.79MH/s with total 7.89MH/s over 10 threads. Height: 32. Target: 344194565)
11:03 INFO  ⛏ Miner 7 reported 0.79MH/s with total 7.91MH/s over 10 threads. Height: 32. Target: 344194565)
11:04 INFO  ⛏ Miner 9 reported 0.80MH/s with total 8.05MH/s over 10 threads. Height: 32. Target: 344194565)
11:04 INFO 💰 Found block
```

How Has This Been Tested?
---
Manually
