### PR TITLE
feat: change tari explorer block view

### DIFF
--- a/applications/tari_explorer/app.js
+++ b/applications/tari_explorer/app.js
@@ -70,6 +70,8 @@ hbs.registerHelper("json", function (obj) {
   return JSON.stringify(obj);
 });
 
+hbs.registerPartials(path.join(__dirname, "partials"));
+
 var app = express();
 
 // view engine setup

--- a/applications/tari_explorer/partials/CheckpointParameters.hbs
+++ b/applications/tari_explorer/partials/CheckpointParameters.hbs
@@ -1,0 +1,4 @@
+<dl>
+  <dt>Abandoned interval</dt><dd>{{abandoned_interval}}</dd>
+  <dt>Minimum quorum required</dt><dd>{{minimum_quorum_required}}</dd>
+</dl>

--- a/applications/tari_explorer/partials/ComSignature.hbs
+++ b/applications/tari_explorer/partials/ComSignature.hbs
@@ -1,0 +1,5 @@
+<dl>
+  <dt>Public nonce commitment</dt><dd>{{hex public_nonce_commitment}}</dd>
+  <dt>Signature u</dt><dd>{{hex signature_u}}</dd>
+  <dt>Signature v</dt><dd>{{hex signature_v}}</dd>
+</dl>

--- a/applications/tari_explorer/partials/CommitteeMembers.hbs
+++ b/applications/tari_explorer/partials/CommitteeMembers.hbs
@@ -1,0 +1,6 @@
+<dl>
+  <dt>Members</dt>
+  {{#each this.members as |member|}}
+    <dd>{{hex member}}</dd>
+  {{/each}}
+</dl>

--- a/applications/tari_explorer/partials/CommitteeSignatures.hbs
+++ b/applications/tari_explorer/partials/CommitteeSignatures.hbs
@@ -1,0 +1,5 @@
+<dl>
+  {{#each signatures as |signature|}}
+    <dt>{{>Signature signature}}</dt>
+  {{/each}}
+</dl>

--- a/applications/tari_explorer/partials/CommitteeSignatures.hbs
+++ b/applications/tari_explorer/partials/CommitteeSignatures.hbs
@@ -1,5 +1,6 @@
 <dl>
+  <dt>Signatures</dt>
   {{#each signatures as |signature|}}
-    <dt>{{>Signature signature}}</dt>
+    <dd>{{>Signature signature}}</dd>
   {{/each}}
 </dl>

--- a/applications/tari_explorer/partials/ConstitutionChangeRules.hbs
+++ b/applications/tari_explorer/partials/ConstitutionChangeRules.hbs
@@ -1,0 +1,7 @@
+<dl>
+  <dt>Change flags</dt><dd>{{change_flags}}</dd>
+  {{#if requirements_for_constitution_change}}
+    <dt>Requirements for constitution change</dt>
+    <dd>{{>RequirementsForConstitutionChange requirements_for_constitution_change}}</dd>
+  {{/if}}
+</dl>

--- a/applications/tari_explorer/partials/ContractAcceptance.hbs
+++ b/applications/tari_explorer/partials/ContractAcceptance.hbs
@@ -1,0 +1,7 @@
+<dl>
+  <dt>Validator node public key</dt><dd>{{hex validator_node_public_key}}</dd>
+  {{#if signature}}
+    <dt>Signature</dt>
+    <dd>{{>Signature signature}}</dd>
+  {{/if}}
+</dl>

--- a/applications/tari_explorer/partials/ContractAcceptanceRequirements.hbs
+++ b/applications/tari_explorer/partials/ContractAcceptanceRequirements.hbs
@@ -1,0 +1,4 @@
+<dl>
+  <dt>Acceptance period expiry</dt><dd>{{acceptance_period_expiry}}</dd>
+  <dt>Minimum quorum required</dt><dd>{{minimum_quorum_required}}</dd>
+</dl>

--- a/applications/tari_explorer/partials/ContractAmendment.hbs
+++ b/applications/tari_explorer/partials/ContractAmendment.hbs
@@ -1,0 +1,16 @@
+<dl>
+  <dt>Proposal id</dt><dd>{{proposal_id}}</dd>
+  {{#if validator_committee}}
+    <dt>Validator committee</dt>
+    {{>CommitteeMembers validator_committee}}
+  {{/if}}
+  {{#if validator_signatures}}
+    <dt>Validator signatures</dt>
+    {{>CommitteeSignatures validator_signatures}}
+  {{/if}}
+  {{#if updated_constitution}}
+    <dt>Updated constitution</dt>
+    <dd>{{>ContractConstitution updated_constitution}}</dd>
+  {{/if}}
+  <dt>Activation window</dt><dd>{{activation_window}}</dd>
+</dl>

--- a/applications/tari_explorer/partials/ContractCheckpoint.hbs
+++ b/applications/tari_explorer/partials/ContractCheckpoint.hbs
@@ -1,0 +1,4 @@
+<dl>
+  <dt>Merkle root</dt><dd>{{hex merkle_root}}</dd>
+  <dt>Signatures</dt><dd>{{>CommitteeSignatures signatures}}</dd>
+</dl>

--- a/applications/tari_explorer/partials/ContractConstitution.hbs
+++ b/applications/tari_explorer/partials/ContractConstitution.hbs
@@ -1,0 +1,18 @@
+<dl>
+  <dt>Validator committee</dt>
+  <dd>{{>CommitteeMembers validator_committee}}</dd>
+  {{#if acceptance_requirements}}
+    <dt>Acceptance requirements</dt>
+    <dd>{{>ContractAcceptanceRequirements acceptance_requirements}}</dd>
+  {{/if}}
+  <dt>Consensus</dt><dd>{{consensus}}</dd>
+  {{#if checkpoint_params}}
+    <dt>Checkpoint params</dt>
+    <dd>{{>CheckpointParameters checkpoint_params}}</dd>
+  {{/if}}
+  {{#if constitution_change_rules}}
+    <dt>Constitution change rules</dt>
+    <dd>{{>ConstitutionChangeRules constitution_change_rules}}</dd>
+  {{/if}}
+  <dt>Initial reward</dt><dd>{{initial_reward}}</dd>
+</dl>

--- a/applications/tari_explorer/partials/ContractDefinition.hbs
+++ b/applications/tari_explorer/partials/ContractDefinition.hbs
@@ -1,0 +1,5 @@
+<dl>
+  <dt>Contract name</dt><dd>{{contract_name}}</dd>
+  <dt>Contract issuer</dt><dd>{{hex contract_issuer}}</dd>
+  <dt>Contract spec</dt><dd>{{>ContractSpecification contract_spec}}</dd>
+</dl>

--- a/applications/tari_explorer/partials/ContractSpecification.hbs
+++ b/applications/tari_explorer/partials/ContractSpecification.hbs
@@ -1,0 +1,9 @@
+<dl>
+  <dt>runtime</dt><dd>{{runtime}}</dd>
+  {{#if public_functions.length}}
+    <dt>Public functions</dt>
+    {{#each public_functions as |public_function|}}
+    <dd>{{>PublicFunction public_function}}</dd>
+    {{/each}}
+  {{/if}}
+</dl>

--- a/applications/tari_explorer/partials/ContractUpdateProposal.hbs
+++ b/applications/tari_explorer/partials/ContractUpdateProposal.hbs
@@ -1,0 +1,11 @@
+<dl>
+  <dt>Proposal id</dt><dd>{{proposal_id}}</dd>
+  {{#if signature}}
+    <dt>Signature</dt>
+    <dd>{{>Signature signature}}</dd>
+  {{/if}}
+  {{#if updated_constitution}}
+    <dt>Updated constitution</dt>
+    <dd>{{>ContractConstitution updated_constitution}}</dd>
+  {{/if}}
+</dl>

--- a/applications/tari_explorer/partials/ContractUpdateProposalAcceptance.hbs
+++ b/applications/tari_explorer/partials/ContractUpdateProposalAcceptance.hbs
@@ -1,0 +1,8 @@
+<dl>
+  <dt>Proposal id</dt><dd>{{proposal_id}}</dd>
+  <dt>Validator node public key</dt><dd>{{hex validator_node_public_key}}</dd>
+  {{#if signature}}
+    <dt>Signature</dt>
+    <dd>{{>Signature signature}}</dd>
+  {{/if}}
+</dl>

--- a/applications/tari_explorer/partials/FunctionRef.hbs
+++ b/applications/tari_explorer/partials/FunctionRef.hbs
@@ -1,0 +1,4 @@
+<dl>
+  <dt>Template id</dt><dd>{{hex template_id}}</dd>
+  <dt>Function id</dt><dd>{{function_id}}</dd>
+</dl>

--- a/applications/tari_explorer/partials/OutputFeatures.hbs
+++ b/applications/tari_explorer/partials/OutputFeatures.hbs
@@ -1,0 +1,39 @@
+{{#*inline 1}}
+Coinbase
+{{/inline}}
+{{#*inline 2}}
+Contract definition
+{{/inline}}
+{{#*inline 3}}
+Contract constitution
+{{/inline}}
+{{#*inline 4}}
+Contract validator acceptance
+{{/inline}}
+{{#*inline 5}}
+Contract checkpoint
+{{/inline}}
+{{#*inline 6}}
+Contract constitution proposal
+{{/inline}}
+{{#*inline 7}}
+Contract constitution change acceptance
+{{/inline}}
+<dl>
+  <dt>Version</dt><dd>{{version}}</dd>
+  <dt>Output Type</dt>
+  <dd>
+    {{#> (lookup . 'output_type')}} 
+    {{!-- Lookup to output_type 0 will evaluate as undefined, so there can't be inline partial for 0 as is for the rest above--}}
+    Standard
+    {{/undefined}}
+  </dd>
+  <dt>Maturity</dt><dd>{{maturity}}</dd>
+  {{#if metadata.length}}<dt>Metadata</dt><dd>{{json metadata}}</dd>{{/if}}
+  <dt>Recovery byte</dt><dd>{{recovery_byte}}</dd>
+  {{#if sidechain_features}}
+    <dt>Sidechain Features</dt>
+    {{>SideChainFeatures sidechain_features}}
+  {{/if}}
+  {{#if unique_id.length}}<dt>Unique id</dt><dd>{{hex unique_id}}</dd>{{/if}}
+</dl>

--- a/applications/tari_explorer/partials/PublicFunction.hbs
+++ b/applications/tari_explorer/partials/PublicFunction.hbs
@@ -1,0 +1,4 @@
+<dl>
+  <dt>Name</dt><dd>{{name}}</dd>
+  <dt>Function</dt><dd>{{>FunctionRef function}}</dd>
+</dl>

--- a/applications/tari_explorer/partials/RequirementsForConstitutionChange.hbs
+++ b/applications/tari_explorer/partials/RequirementsForConstitutionChange.hbs
@@ -1,0 +1,6 @@
+<dl>
+  <dt>Minimum constitution committee signatures</dt>
+  <dd>{{minimum_constitution_committee_signatures}}</dd>
+  <dt>Constitution committee</dt>
+  <dd>{{>CommitteeMembers constitution_committee}}</dd>
+</dl>

--- a/applications/tari_explorer/partials/SideChainFeatures.hbs
+++ b/applications/tari_explorer/partials/SideChainFeatures.hbs
@@ -1,0 +1,29 @@
+<dd>
+  <dl>
+    <dt>Contract id</dt><dd>{{hex contract_id}}</dd>
+    {{#if definition}}
+      <dt>Definition</dt>
+      <dd>{{>ContractDefinition definition}}</dd>
+    {{/if}}
+    {{#if constitution}}
+      <dt>Constitution</dt>
+      <dd>{{>ContractConstitution constitution}}</dd>
+    {{/if}}
+    {{#if acceptance}}
+      <dt>Acceptance</dt>
+      <dd>{{>ContractAcceptance acceptance}}</dd>
+    {{/if}}
+    {{#if update_proposal}}
+      <dt>Update proposal</dt>
+      <dd>{{>ContractUpdateProposal update_proposal}}</dd>
+    {{/if}}
+    {{#if update_proposal_acceptance}}
+      <dt>Update proposal acceptance</dt>
+      <dd>{{>ContractUpdateProposalAcceptance update_proposal_acceptance}}</dd>
+    {{/if}}
+    {{#if amendment}}
+      <dt>amendment</dt>
+      <dd>{{>ContractAmendment amendment}}</dd>
+    {{/if}}
+  </dl>
+</dd>

--- a/applications/tari_explorer/partials/SideChainFeatures.hbs
+++ b/applications/tari_explorer/partials/SideChainFeatures.hbs
@@ -25,5 +25,9 @@
       <dt>amendment</dt>
       <dd>{{>ContractAmendment amendment}}</dd>
     {{/if}}
+    {{#if checkpoint}}
+      <dt>Checkpoint</dt>
+      <dd>{{>ContractCheckpoint checkpoint}}</dd>
+    {{/if}}
   </dl>
 </dd>

--- a/applications/tari_explorer/partials/Signature.hbs
+++ b/applications/tari_explorer/partials/Signature.hbs
@@ -1,0 +1,4 @@
+<dl>
+  <dt>Public nonce</dt><dd>{{hex public_nonce}}</dd>
+  <dt>Signature</dt><dd>{{hex signature}}</dd>
+</dl>

--- a/applications/tari_explorer/partials/TransactionInput.hbs
+++ b/applications/tari_explorer/partials/TransactionInput.hbs
@@ -1,0 +1,13 @@
+<dl>
+  <dt>Features</dt><dd>{{>OutputFeatures features}}</dd>
+  <dt>Commitment</dt><dd>{{hex commitment}}</dd>
+  <dt>Hash</dt><dd>{{hex hash}}</dd>
+  <dt>Script</dt><dd>{{hex script}}</dd>
+  <dt>Input data</dt><dd>{{hex input_data}}</dd>
+  <dt>Script signature</dt><dd>{{>ComSignature script_signature}}</dd>
+  <dt>Sender offset public key</dt><dd>{{hex sender_offset_public_key}}</dd>
+  <dt>Output hash</dt><dd>{{hex output_hash}}</dd>
+  <dt>Covenant</dt><dd>{{hex covenant}}</dd>
+  <dt>Version</dt><dd>{{version}}</dd>
+  <dt>Encrypted value</dt><dd>{{hex encrypted_value}}</dd>
+</dl>

--- a/applications/tari_explorer/partials/TransactionKernel.hbs
+++ b/applications/tari_explorer/partials/TransactionKernel.hbs
@@ -1,0 +1,9 @@
+<dl>
+  <dt>Features</dt><dd>{{features}}</dd>
+  <dt>Fee</dt><dd>{{fee}}</dd>
+  <dt>Lock height</dt><dd>{{lock_height}}</dd>
+  <dt>Excess</dt><dd>{{hex excess}}</dd>
+  <dt>Excess sig</dt><dd>{{>Signature excess_sig}}</dd>
+  <dt>Hash</dt><dd>{{hex hash}}</dd>
+  <dt>Version</dt><dd>{{version}}</dd>
+</dl>

--- a/applications/tari_explorer/partials/TransactionOutput.hbs
+++ b/applications/tari_explorer/partials/TransactionOutput.hbs
@@ -1,0 +1,15 @@
+<dl>
+  <dt>Features</dt>
+  <dd>
+    {{>OutputFeatures features}}
+  </dd>
+  <dt>Commitment</dt><dd>{{hex commitment}}</dd>
+  <dt>Hash</dt><dd>{{hex hash}}</dd>
+  <dt>Script</dt><dd>{{hex script}}</dd>
+  <dt>Sender offset public key</dt><dd>{{hex sender_offset_public_key}}</dd>
+  <dt>Metadata signature</dt>
+  <dd>{{>ComSignature metadata_signature}}</dd>
+  {{#if covenant.length}}<dt>Covenant</dt><dd>{{covenant}}</dd>{{/if}}
+  <dt>Version</dt><dd>{{version}}</dd>
+  {{#if encrypted_value.length}}<dt>Encrypted value</dt><dd>{{hex encrypted_value}}</dd>{{/if}}
+</dl>

--- a/applications/tari_explorer/views/blocks.hbs
+++ b/applications/tari_explorer/views/blocks.hbs
@@ -73,86 +73,64 @@
   </tr>
 </table>
 
-<br />
-<h3>Kernels</h3>
-<table>
-  <thead>
-    <tr>
-      <th>Hash</th>
-      <th>Excess</th>
-      <th>Excess Signature</th>
-      <th>Fee</th>
-      <th>Lock Height</th>
-      <th>Features</th>
-    </tr>
-  </thead>
-  <tbody>
-    {{#each this.block.body.kernels}}
+{{#with this.block.body}}
+  <table>
+    <thead>
       <tr>
-        <td>{{hex hash}}</td>
-        <td>{{hex excess}}</td>
-        <td>Nonce:{{hex excess_sig.public_nonce}}
-          Sig:{{hex excess_sig.signature}}</td>
-        <td>{{fee}}</td>
-        <td>{{lock_height}}</td>
-        <td>{{features}}</td>
+        <th>
+          <h2>Kernels({{kernels.length}})</h2>
+        </th>
       </tr>
-    {{/each}}
-  </tbody>
-</table>
+    </thead>
+    <tbody>
+      {{#each kernels as |kernel|}}
+        <tr>
+          <td>
+              <h3>Kernel {{@index}}</h3>
+              {{>TransactionKernel kernel}}
+          </td>
+        </tr>
+      {{/each}}
+    </tbody>
+  </table>
 
-<br />
-<h3>Outputs</h3>
-<table>
-  <thead>
-    <tr>
-      <th>Hash</th>
-      <th>Commitment</th>
-      <th>Flags</th>
-      <th>Maturity</th>
-      <th>Parent PK</th>
-      <th>Unique Id</th>
-      <th>Other Features</th>
-      <th>Script</th>
-    </tr>
-  </thead>
-  <tbody>
-    {{#each this.block.body.outputs}}
+  <table>
+    <thead>
       <tr>
-        <td>{{hex hash}}</td>
-        <td>{{hex commitment}}</td>
-        <td>{{features.flags}}</td>
-        <td>{{features.maturity}}</td>
-        <td><a href="/assets/{{hex features.parent_public_key}}">{{hex
-              features.parent_public_key
-            }}</a></td>
-        <td>{{hex features.unique_id}}</td>
-        <td>{{json features}}</td>
-        <td>{{hex script}}</td>
+        <th>
+          <h2>Outputs({{outputs.length}})</h2>
+        </th>
       </tr>
-    {{/each}}
-  </tbody>
-</table>
+    </thead>
+    <tbody>
+      {{#each outputs as |output|}}
+        <tr>
+          <td>
+              <h3>Output {{@index}}</h3>
+              {{>TransactionOutput output}}
+          </td>
+        </tr>
+      {{/each}}
+    </tbody>
+  </table>
 
-<br />
-<h3>Spent Inputs</h3>
-<table>
-  <thead>
-    <tr>
-      <th>Hash</th>
-      <th>Commitment</th>
-      <th>Flags</th>
-      <th>Maturity</th>
-    </tr>
-  </thead>
-  <tbody>
-    {{#each this.block.body.inputs}}
+  <table>
+    <thead>
       <tr>
-        <td>{{hex hash}}</td>
-        <td>{{hex commitment}}</td>
-        <td>{{features.flags}}</td>
-        <td>{{features.maturity}}</td>
+        <th>
+          <h2>Inputs({{inputs.length}})</h2>
+        </th>
       </tr>
-    {{/each}}
-  </tbody>
-</table>
+    </thead>
+    <tbody>
+      {{#each inputs as |input|}}
+        <tr>
+          <td>
+            <h3>Input {{@index}}</h4>
+            {{>TransactionInput input}}
+          </td>
+        </tr>
+      {{/each}}
+    </tbody>
+  </table>
+{{/with}}

--- a/applications/tari_explorer/views/layout.hbs
+++ b/applications/tari_explorer/views/layout.hbs
@@ -5,11 +5,11 @@
       body { font-family: "Courier New"; font-size: small; margin: 20px; width:
       1100px; } h1, h2, h3, h4, h5, h6 { font-family: Arial, Helvetica,
       sans-serif; } a { color: #932fff; } table { border-collapse: collapse;
-      border: 1px solid #efefef; width: 100%; } th, td { padding: 5px; border:
-      1px solid #efefef; } .noborder, .noborder td, .noborder th { border: none;
-      } @media (prefers-color-scheme: dark) { body { background: #111; color:
-      #eee; } table { border-color: #333; } th, td { border-color: #333; } }
-
+      border: 1px solid #efefef; width: 100%; margin:1em; } th, td { padding:
+      5px; border: 1px solid #efefef; } .noborder, .noborder td, .noborder th {
+      border: none; } @media (prefers-color-scheme: dark) { body { background:
+      #111; color: #eee; } } dl {margin:0; font-size:medium} dd {font-style:
+      italic;} dt{font-style: normal;} h2 {margin:0;}
     </style>
   </head>
   <body>


### PR DESCRIPTION
Description
---
Make partials (this is the name for handlebars component) for each proto message (e.g. message ConstitutionChangeRules is in ConstitutionChangeRules.hbs). This way it's more readable code, and easily extensible.
The fields that are empty are not in the output.

Motivation and Context
---
Reading json for the features was not ideal way.
Now everything is in readable format.
Example output:
![image](https://user-images.githubusercontent.com/35243812/175246425-bcc490bf-bf4e-431c-a90e-0dc0fb19e8fc.png)


How Has This Been Tested?
---
Manually. But I haven't seen all output types. If we add new output_type, it will be shown as "Standard" due to how lookup works. This should be kept in mind.
