### PR TITLE
fix: add prettierignore for partials

### DIFF
--- a/applications/tari_explorer/.prettierignore
+++ b/applications/tari_explorer/.prettierignore
@@ -1,0 +1,2 @@
+partials
+views/blocks.hbs

--- a/applications/tari_explorer/views/blocks.hbs
+++ b/applications/tari_explorer/views/blocks.hbs
@@ -86,8 +86,8 @@
       {{#each kernels as |kernel|}}
         <tr>
           <td>
-              <h3>Kernel {{@index}}</h3>
-              {{>TransactionKernel kernel}}
+            <h3>Kernel {{@index}}</h3>
+            {{>TransactionKernel kernel}}
           </td>
         </tr>
       {{/each}}
@@ -106,8 +106,8 @@
       {{#each outputs as |output|}}
         <tr>
           <td>
-              <h3>Output {{@index}}</h3>
-              {{>TransactionOutput output}}
+            <h3>Output {{@index}}</h3>
+            {{>TransactionOutput output}}
           </td>
         </tr>
       {{/each}}


### PR DESCRIPTION
Description
---
Prettier doesn't support handlebars partials. I had to add them and their usage to `.prettierignore`

How Has This Been Tested?
---
`npm run check-fmt`

