### PR TITLE
fix(core)!: include issuer public key in contract id hash

### DIFF
--- a/applications/tari_app_grpc/src/conversions/sidechain_features.rs
+++ b/applications/tari_app_grpc/src/conversions/sidechain_features.rs
@@ -24,7 +24,7 @@ use std::convert::{TryFrom, TryInto};
 
 use tari_common_types::types::{FixedHash, PublicKey, Signature};
 use tari_core::transactions::transaction_components::{
-    vec_into_fixed_string,
+    bytes_into_fixed_string,
     CheckpointParameters,
     CommitteeMembers,
     CommitteeSignatures,
@@ -145,7 +145,7 @@ impl TryFrom<grpc::ContractDefinition> for ContractDefinition {
     type Error = String;
 
     fn try_from(value: grpc::ContractDefinition) -> Result<Self, Self::Error> {
-        let contract_name = vec_into_fixed_string(value.contract_name);
+        let contract_name = bytes_into_fixed_string(value.contract_name);
 
         let contract_issuer =
             PublicKey::from_bytes(value.contract_issuer.as_bytes()).map_err(|err| format!("{:?}", err))?;
@@ -180,7 +180,7 @@ impl TryFrom<grpc::ContractSpecification> for ContractSpecification {
     type Error = String;
 
     fn try_from(value: grpc::ContractSpecification) -> Result<Self, Self::Error> {
-        let runtime = vec_into_fixed_string(value.runtime);
+        let runtime = bytes_into_fixed_string(value.runtime);
         let public_functions = value
             .public_functions
             .into_iter()
@@ -214,7 +214,7 @@ impl TryFrom<grpc::PublicFunction> for PublicFunction {
             .ok_or_else(|| "function is missing".to_string())??;
 
         Ok(Self {
-            name: vec_into_fixed_string(value.name),
+            name: bytes_into_fixed_string(value.name),
             function,
         })
     }

--- a/applications/tari_console_wallet/src/automation/error.rs
+++ b/applications/tari_console_wallet/src/automation/error.rs
@@ -77,6 +77,8 @@ pub enum CommandError {
     JsonFile(String),
     #[error(transparent)]
     IoError(#[from] io::Error),
+    #[error("General error: {0}")]
+    General(String),
 }
 
 impl From<CommandError> for ExitError {

--- a/base_layer/core/src/proto/transaction.rs
+++ b/base_layer/core/src/proto/transaction.rs
@@ -39,7 +39,7 @@ use crate::{
         aggregated_body::AggregateBody,
         tari_amount::MicroTari,
         transaction_components::{
-            vec_into_fixed_string,
+            bytes_into_fixed_string,
             AssetOutputFeatures,
             CheckpointParameters,
             CommitteeDefinitionFeatures,
@@ -954,7 +954,7 @@ impl TryFrom<proto::types::ContractDefinition> for ContractDefinition {
     type Error = String;
 
     fn try_from(value: proto::types::ContractDefinition) -> Result<Self, Self::Error> {
-        let contract_name = vec_into_fixed_string(value.contract_name);
+        let contract_name = bytes_into_fixed_string(value.contract_name);
 
         let contract_issuer =
             PublicKey::from_bytes(value.contract_issuer.as_bytes()).map_err(|err| format!("{:?}", err))?;
@@ -989,7 +989,7 @@ impl TryFrom<proto::types::ContractSpecification> for ContractSpecification {
     type Error = String;
 
     fn try_from(value: proto::types::ContractSpecification) -> Result<Self, Self::Error> {
-        let runtime = vec_into_fixed_string(value.runtime);
+        let runtime = bytes_into_fixed_string(value.runtime);
         let public_functions = value
             .public_functions
             .into_iter()
@@ -1023,7 +1023,7 @@ impl TryFrom<proto::types::PublicFunction> for PublicFunction {
             .ok_or_else(|| "function is missing".to_string())??;
 
         Ok(Self {
-            name: vec_into_fixed_string(value.name),
+            name: bytes_into_fixed_string(value.name),
             function,
         })
     }

--- a/base_layer/core/src/transactions/transaction_components/output_features.rs
+++ b/base_layer/core/src/transactions/transaction_components/output_features.rs
@@ -281,8 +281,8 @@ impl OutputFeatures {
         }
     }
 
-    pub fn for_contract_definition(commitment: &Commitment, definition: ContractDefinition) -> OutputFeatures {
-        let contract_id = definition.calculate_contract_id(commitment);
+    pub fn for_contract_definition(definition: ContractDefinition) -> OutputFeatures {
+        let contract_id = definition.calculate_contract_id();
 
         Self {
             output_type: OutputType::ContractDefinition,

--- a/base_layer/core/src/transactions/transaction_components/output_features.rs
+++ b/base_layer/core/src/transactions/transaction_components/output_features.rs
@@ -540,6 +540,7 @@ mod test {
     use crate::{
         consensus::check_consensus_encoding_correctness,
         transactions::transaction_components::{
+            bytes_into_fixed_string,
             side_chain::{
                 CheckpointParameters,
                 CommitteeMembers,
@@ -549,7 +550,6 @@ mod test {
                 RequirementsForConstitutionChange,
                 SideChainConsensus,
             },
-            vec_into_fixed_string,
             CommitteeSignatures,
             ContractAcceptance,
             ContractAmendment,
@@ -606,20 +606,20 @@ mod test {
                 contract_id: FixedHash::zero(),
                 constitution: Some(constitution.clone()),
                 definition: Some(ContractDefinition {
-                    contract_name: vec_into_fixed_string("name".as_bytes().to_vec()),
+                    contract_name: bytes_into_fixed_string("name"),
                     contract_issuer: PublicKey::default(),
                     contract_spec: ContractSpecification {
-                        runtime: vec_into_fixed_string("runtime".as_bytes().to_vec()),
+                        runtime: bytes_into_fixed_string("runtime"),
                         public_functions: vec![
                             PublicFunction {
-                                name: vec_into_fixed_string("foo".as_bytes().to_vec()),
+                                name: bytes_into_fixed_string("foo"),
                                 function: FunctionRef {
                                     template_id: FixedHash::zero(),
                                     function_id: 0_u16,
                                 },
                             },
                             PublicFunction {
-                                name: vec_into_fixed_string("bar".as_bytes().to_vec()),
+                                name: bytes_into_fixed_string("bar"),
                                 function: FunctionRef {
                                     template_id: FixedHash::zero(),
                                     function_id: 1_u16,

--- a/base_layer/core/src/transactions/transaction_components/output_features.rs
+++ b/base_layer/core/src/transactions/transaction_components/output_features.rs
@@ -281,8 +281,8 @@ impl OutputFeatures {
         }
     }
 
-    pub fn for_contract_definition(definition: ContractDefinition) -> OutputFeatures {
-        let contract_id = definition.calculate_contract_id();
+    pub fn for_contract_definition(commitment: &Commitment, definition: ContractDefinition) -> OutputFeatures {
+        let contract_id = definition.calculate_contract_id(commitment);
 
         Self {
             output_type: OutputType::ContractDefinition,

--- a/base_layer/core/src/transactions/transaction_components/side_chain/contract_definition.rs
+++ b/base_layer/core/src/transactions/transaction_components/side_chain/contract_definition.rs
@@ -23,7 +23,7 @@
 use std::io::{Error, Read, Write};
 
 use serde::{Deserialize, Serialize};
-use tari_common_types::types::{Commitment, FixedHash, PublicKey};
+use tari_common_types::types::{FixedHash, PublicKey};
 
 use crate::{
     consensus::{ConsensusDecoding, ConsensusEncoding, ConsensusEncodingSized, ConsensusHashWriter, MaxSizeVec},
@@ -49,12 +49,8 @@ impl ContractDefinition {
         }
     }
 
-    pub fn calculate_contract_id(&self, commitment: &Commitment) -> FixedHash {
-        ConsensusHashWriter::default()
-            .chain(commitment)
-            .chain(self)
-            .finalize()
-            .into()
+    pub fn calculate_contract_id(&self) -> FixedHash {
+        ConsensusHashWriter::default().chain(self).finalize().into()
     }
 }
 

--- a/base_layer/core/src/transactions/transaction_components/side_chain/mod.rs
+++ b/base_layer/core/src/transactions/transaction_components/side_chain/mod.rs
@@ -35,13 +35,7 @@ pub use contract_constitution::{
 };
 
 mod contract_definition;
-pub use contract_definition::{
-    vec_into_fixed_string,
-    ContractDefinition,
-    ContractSpecification,
-    FunctionRef,
-    PublicFunction,
-};
+pub use contract_definition::{ContractDefinition, ContractSpecification, FunctionRef, PublicFunction};
 
 mod contract_update_proposal;
 pub use contract_update_proposal::ContractUpdateProposal;
@@ -63,3 +57,11 @@ pub use sidechain_features::{SideChainFeatures, SideChainFeaturesBuilder};
 
 mod contract_checkpoint;
 pub use contract_checkpoint::ContractCheckpoint;
+
+// Length of FixedString
+pub const FIXED_STR_LEN: usize = 32;
+pub type FixedString = [u8; FIXED_STR_LEN];
+
+pub fn bytes_into_fixed_string<T: AsRef<[u8]>>(value: T) -> FixedString {
+    tari_common_types::array::copy_into_fixed_array_lossy::<_, FIXED_STR_LEN>(value.as_ref())
+}

--- a/base_layer/core/src/transactions/transaction_components/side_chain/sidechain_features.rs
+++ b/base_layer/core/src/transactions/transaction_components/side_chain/sidechain_features.rs
@@ -164,7 +164,7 @@ mod tests {
     use crate::{
         consensus::check_consensus_encoding_correctness,
         transactions::transaction_components::{
-            vec_into_fixed_string,
+            bytes_into_fixed_string,
             CheckpointParameters,
             CommitteeMembers,
             CommitteeSignatures,
@@ -212,20 +212,20 @@ mod tests {
             contract_id: FixedHash::zero(),
             constitution: Some(constitution.clone()),
             definition: Some(ContractDefinition {
-                contract_name: vec_into_fixed_string("name".as_bytes().to_vec()),
+                contract_name: bytes_into_fixed_string("name"),
                 contract_issuer: PublicKey::default(),
                 contract_spec: ContractSpecification {
-                    runtime: vec_into_fixed_string("runtime".as_bytes().to_vec()),
+                    runtime: bytes_into_fixed_string("runtime"),
                     public_functions: vec![
                         PublicFunction {
-                            name: vec_into_fixed_string("foo".as_bytes().to_vec()),
+                            name: bytes_into_fixed_string("foo"),
                             function: FunctionRef {
                                 template_id: FixedHash::zero(),
                                 function_id: 0_u16,
                             },
                         },
                         PublicFunction {
-                            name: vec_into_fixed_string("bar".as_bytes().to_vec()),
+                            name: bytes_into_fixed_string("bar"),
                             function: FunctionRef {
                                 template_id: FixedHash::zero(),
                                 function_id: 1_u16,

--- a/base_layer/core/src/transactions/transaction_components/unblinded_output_builder.rs
+++ b/base_layer/core/src/transactions/transaction_components/unblinded_output_builder.rs
@@ -45,11 +45,11 @@ use crate::{
 #[derive(Derivative, Clone)]
 #[derivative(Debug)]
 pub struct UnblindedOutputBuilder {
-    pub value: MicroTari,
+    value: MicroTari,
     #[derivative(Debug = "ignore")]
     spending_key: BlindingFactor,
-    pub features: OutputFeatures,
-    pub script: Option<TariScript>,
+    features: OutputFeatures,
+    script: Option<TariScript>,
     covenant: Covenant,
     input_data: Option<ExecutionStack>,
     #[derivative(Debug = "ignore")]
@@ -186,6 +186,18 @@ impl UnblindedOutputBuilder {
     pub fn with_script_private_key(mut self, script_private_key: PrivateKey) -> Self {
         self.script_private_key = Some(script_private_key);
         self
+    }
+
+    pub fn value(&self) -> MicroTari {
+        self.value
+    }
+
+    pub fn features(&self) -> &OutputFeatures {
+        &self.features
+    }
+
+    pub fn script(&self) -> Option<&TariScript> {
+        self.script.as_ref()
     }
 
     pub fn covenant(&self) -> &Covenant {

--- a/base_layer/core/src/validation/dan_validators/definition_validator.rs
+++ b/base_layer/core/src/validation/dan_validators/definition_validator.rs
@@ -100,7 +100,7 @@ mod test {
         let expected_contract_id = publish_definition(&mut blockchain, change[0].clone());
 
         // construct a transaction for the duplicated contract definition
-        let (_, schema) = create_contract_definition_schema(change[1].clone());
+        let (_, schema) = create_contract_definition_schema(change[0].clone());
         let (tx, _) = schema_to_transaction(&schema);
 
         // try to validate the duplicated definition transaction and check that we get the error

--- a/base_layer/core/src/validation/dan_validators/test_helpers.rs
+++ b/base_layer/core/src/validation/dan_validators/test_helpers.rs
@@ -35,7 +35,7 @@ use crate::{
         tari_amount::T,
         test_helpers::{spend_utxos, TransactionSchema},
         transaction_components::{
-            vec_into_fixed_string,
+            bytes_into_fixed_string,
             CheckpointParameters,
             CommitteeSignatures,
             ConstitutionChangeFlags,
@@ -152,10 +152,10 @@ pub fn create_block(
 
 pub fn create_contract_definition_schema(input: UnblindedOutput) -> (FixedHash, TransactionSchema) {
     let definition = ContractDefinition {
-        contract_name: vec_into_fixed_string("name".as_bytes().to_vec()),
+        contract_name: bytes_into_fixed_string("name"),
         contract_issuer: PublicKey::default(),
         contract_spec: ContractSpecification {
-            runtime: vec_into_fixed_string("runtime".as_bytes().to_vec()),
+            runtime: bytes_into_fixed_string("runtime"),
             public_functions: vec![],
         },
     };

--- a/base_layer/core/src/validation/dan_validators/test_helpers.rs
+++ b/base_layer/core/src/validation/dan_validators/test_helpers.rs
@@ -23,7 +23,6 @@
 use std::convert::TryInto;
 
 use tari_common_types::types::{FixedHash, PublicKey, Signature};
-use tari_crypto::commitment::HomomorphicCommitmentFactory;
 use tari_p2p::Network;
 
 use super::TxDanLayerValidator;
@@ -53,7 +52,6 @@ use crate::{
             Transaction,
             UnblindedOutput,
         },
-        CryptoFactories,
     },
     txn_schema,
     validation::{dan_validators::DanLayerValidationError, MempoolTransactionValidation, ValidationError},
@@ -159,11 +157,8 @@ pub fn create_contract_definition_schema(input: UnblindedOutput) -> (FixedHash, 
             public_functions: vec![],
         },
     };
-    let commitment = CryptoFactories::default()
-        .commitment
-        .commit(&input.spending_key, &input.value.into());
-    let contract_id = definition.calculate_contract_id(&commitment);
-    let definition_features = OutputFeatures::for_contract_definition(&commitment, definition);
+    let contract_id = definition.calculate_contract_id();
+    let definition_features = OutputFeatures::for_contract_definition(definition);
 
     let tx_schema =
         txn_schema!(from: vec![input], to: vec![0.into()], fee: 5.into(), lock: 0, features: definition_features);

--- a/base_layer/wallet/src/assets/asset_manager.rs
+++ b/base_layer/wallet/src/assets/asset_manager.rs
@@ -25,20 +25,17 @@ use tari_common_types::{
     transaction::TxId,
     types::{Commitment, FixedHash, PublicKey, Signature},
 };
-use tari_core::transactions::{
-    transaction_components::{
-        CommitteeSignatures,
-        ContractAmendment,
-        ContractCheckpoint,
-        ContractDefinition,
-        ContractUpdateProposal,
-        OutputFeatures,
-        OutputType,
-        SideChainFeatures,
-        TemplateParameter,
-        Transaction,
-    },
-    CryptoFactories,
+use tari_core::transactions::transaction_components::{
+    CommitteeSignatures,
+    ContractAmendment,
+    ContractCheckpoint,
+    ContractDefinition,
+    ContractUpdateProposal,
+    OutputFeatures,
+    OutputType,
+    SideChainFeatures,
+    TemplateParameter,
+    Transaction,
 };
 
 use crate::{
@@ -309,12 +306,7 @@ impl<T: OutputManagerBackend + 'static> AssetManager<T> {
             .create_output_with_features(1.into(), OutputFeatures::default())
             .await?;
 
-        let commitment = output.generate_commitment(&CryptoFactories::default());
-
-        output = output.with_features(OutputFeatures::for_contract_definition(
-            &commitment,
-            contract_definition,
-        ));
+        output = output.with_features(OutputFeatures::for_contract_definition(contract_definition));
 
         let (tx_id, transaction) = self
             .output_manager

--- a/base_layer/wallet/src/assets/contract_definition_file_format.rs
+++ b/base_layer/wallet/src/assets/contract_definition_file_format.rs
@@ -23,7 +23,7 @@
 use serde::{Deserialize, Serialize};
 use tari_common_types::types::{FixedHash, PublicKey};
 use tari_core::transactions::transaction_components::{
-    vec_into_fixed_string,
+    bytes_into_fixed_string,
     ContractDefinition,
     ContractSpecification,
     FunctionRef,
@@ -57,7 +57,7 @@ pub struct ContractSpecificationFileFormat {
 impl From<ContractSpecificationFileFormat> for ContractSpecification {
     fn from(value: ContractSpecificationFileFormat) -> Self {
         Self {
-            runtime: vec_into_fixed_string(value.runtime.into_bytes()),
+            runtime: bytes_into_fixed_string(value.runtime.into_bytes()),
             public_functions: value.public_functions.into_iter().map(|f| f.into()).collect(),
         }
     }
@@ -72,7 +72,7 @@ pub struct PublicFunctionFileFormat {
 impl From<PublicFunctionFileFormat> for PublicFunction {
     fn from(value: PublicFunctionFileFormat) -> Self {
         Self {
-            name: vec_into_fixed_string(value.name.into_bytes()),
+            name: bytes_into_fixed_string(value.name.into_bytes()),
             function: value.function.into(),
         }
     }

--- a/base_layer/wallet/src/assets/contract_definition_file_format.rs
+++ b/base_layer/wallet/src/assets/contract_definition_file_format.rs
@@ -40,7 +40,7 @@ pub struct ContractDefinitionFileFormat {
 
 impl From<ContractDefinitionFileFormat> for ContractDefinition {
     fn from(value: ContractDefinitionFileFormat) -> Self {
-        let contract_name = value.contract_name.into_bytes();
+        let contract_name = bytes_into_fixed_string(value.contract_name);
         let contract_issuer = value.contract_issuer;
         let contract_spec = value.contract_spec.into();
 

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -676,6 +676,8 @@ where
         features: OutputFeatures,
     ) -> Result<UnblindedOutputBuilder, OutputManagerError> {
         let (spending_key, script_private_key) = self.get_spend_and_script_keys().await?;
+        let input_data = inputs!(PublicKey::from_secret_key(&script_private_key));
+        let script = script!(Nop);
 
         Ok(UnblindedOutputBuilder::new(value, spending_key)
             .with_features(features)

--- a/integration_tests/fixtures/contract_constitution.json
+++ b/integration_tests/fixtures/contract_constitution.json
@@ -1,5 +1,5 @@
 {
-  "contract_id": "90b1da4524ea0e9479040d906db9194d8af90f28d05ff2d64c0a82eb93125177",
+  "contract_id": "a58fb2adefcc40242f20f2d896e14451549dd60839fee78a7bd40ba2cc0a0e91",
   "validator_committee": [
     "608001dffed28d058591cd65eaca11c465165592baf872cf1d984e26fb12b472",
     "ccac168b8edd67b10d152d1ed2337efc65da9fc0b6256dd49b3c559032553d44"


### PR DESCRIPTION
Description
---
- includes issuer public key ~~and commitment~~ in contract hash
- update command "wizard" code to fetch contract id from resulting transaction 
- simplify FixedString code
- removes unused Hashable trait impls

Motivation and Context
---
~~The contract ID should be a hash of all contract definition data. Adding the commitment allows contracts with the same name label to exist on the blockchain at the same time.~~
The contract name functions as a label and does not have to be globally unique. This PR essentially makes the
<issuer_pk, contract_name> pair unique. 

How Has This Been Tested?
---
Existing tests, manually
