### PR TITLE
test(wallet): fixes transaction service tests stack overflow

### DIFF
--- a/base_layer/wallet/src/transaction_service/handle.rs
+++ b/base_layer/wallet/src/transaction_service/handle.rs
@@ -75,14 +75,14 @@ pub enum TransactionServiceRequest {
     SendTransaction {
         dest_pubkey: CommsPublicKey,
         amount: MicroTari,
-        output_features: OutputFeatures,
+        output_features: Box<OutputFeatures>,
         fee_per_gram: MicroTari,
         message: String,
     },
     SendOneSidedTransaction {
         dest_pubkey: CommsPublicKey,
         amount: MicroTari,
-        output_features: OutputFeatures,
+        output_features: Box<OutputFeatures>,
         fee_per_gram: MicroTari,
         message: String,
     },
@@ -405,7 +405,7 @@ impl TransactionServiceHandle {
             .call(TransactionServiceRequest::SendTransaction {
                 dest_pubkey,
                 amount,
-                output_features,
+                output_features: Box::new(output_features),
                 fee_per_gram,
                 message,
             })
@@ -429,7 +429,7 @@ impl TransactionServiceHandle {
             .call(TransactionServiceRequest::SendOneSidedTransaction {
                 dest_pubkey,
                 amount,
-                output_features,
+                output_features: Box::new(output_features),
                 fee_per_gram,
                 message,
             })

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -578,7 +578,7 @@ where
                 self.send_transaction(
                     dest_pubkey,
                     amount,
-                    output_features,
+                    *output_features,
                     fee_per_gram,
                     message,
                     send_transaction_join_handles,
@@ -598,7 +598,7 @@ where
                 .send_one_sided_transaction(
                     dest_pubkey,
                     amount,
-                    output_features,
+                    *output_features,
                     fee_per_gram,
                     message,
                     transaction_broadcast_join_handles,

--- a/comms/dht/src/dht.rs
+++ b/comms/dht/src/dht.rs
@@ -612,8 +612,8 @@ mod test {
 
         service.call(inbound_message).await.unwrap();
 
-        assert_eq!(oms_mock_state.call_count(), 1);
-        let (params, _) = oms_mock_state.pop_call().unwrap();
+        assert_eq!(oms_mock_state.call_count().await, 1);
+        let (params, _) = oms_mock_state.pop_call().await.unwrap();
 
         // Check that OMS got a request to forward with the original Dht Header
         assert_eq!(params.dht_header.unwrap().origin_mac, origin_mac);

--- a/comms/dht/src/discovery/service.rs
+++ b/comms/dht/src/discovery/service.rs
@@ -394,8 +394,8 @@ mod test {
 
         assert!(result.unwrap_err().is_timeout());
 
-        oms_mock_state.wait_call_count(1, Duration::from_secs(5)).unwrap();
-        let (params, _) = oms_mock_state.pop_call().unwrap();
+        oms_mock_state.wait_call_count(1, Duration::from_secs(5)).await.unwrap();
+        let (params, _) = oms_mock_state.pop_call().await.unwrap();
         assert_eq!(params.dht_message_type, DhtMessageType::Discovery);
         assert_eq!(params.encryption, OutboundEncryption::EncryptFor(dest_public_key));
     }

--- a/comms/dht/src/inbound/forward.rs
+++ b/comms/dht/src/inbound/forward.rs
@@ -309,8 +309,8 @@ mod test {
         service.call(msg).await.unwrap();
         assert!(spy.is_called());
 
-        assert_eq!(oms_mock_state.call_count(), 1);
-        let (params, body) = oms_mock_state.pop_call().unwrap();
+        assert_eq!(oms_mock_state.call_count().await, 1);
+        let (params, body) = oms_mock_state.pop_call().await.unwrap();
 
         // Header and body are preserved when forwarding
         assert_eq!(&body.to_vec(), &sample_body);

--- a/integration_tests/features/WalletFFI.feature
+++ b/integration_tests/features/WalletFFI.feature
@@ -171,12 +171,12 @@ Feature: Wallet FFI
         And I have mining node MINER connected to base node BASE1 and wallet SENDER
         And mining node MINER mines 10 blocks
         Then I wait for wallet SENDER to have at least 5000000 uT
-        And I send 2400000 uT from wallet SENDER to wallet FFI_WALLET at fee 20
-        And I send 2400000 uT from wallet SENDER to wallet FFI_WALLET at fee 20
+        And I send 2400000 uT from wallet SENDER to wallet FFI_WALLET at fee 5
+        And I send 2400000 uT from wallet SENDER to wallet FFI_WALLET at fee 5
         Then ffi wallet FFI_WALLET detects AT_LEAST 2 ffi transactions to be TRANSACTION_STATUS_BROADCAST
         And mining node MINER mines 10 blocks
         Then I wait for ffi wallet FFI_WALLET to have at least 4000000 uT
-        And I send 1000000 uT from ffi wallet FFI_WALLET to wallet RECEIVER at fee 20 via one-sided transactions
+        And I send 1000000 uT from ffi wallet FFI_WALLET to wallet RECEIVER at fee 5 via one-sided transactions
         Then ffi wallet FFI_WALLET detects AT_LEAST 2 ffi transactions to be TRANSACTION_STATUS_BROADCAST
         And mining node MINER mines 2 blocks
         Then all nodes are at height 22

--- a/integration_tests/features/WalletRecovery.feature
+++ b/integration_tests/features/WalletRecovery.feature
@@ -15,7 +15,7 @@ Feature: Wallet Recovery
         When I mine 5 blocks on NODE
         When I wait for wallet WALLET_A to have at least 55000000000 uT
         Then all nodes are at height 15
-        And I send 200000 uT from wallet WALLET_A to wallet WALLET_B at fee 100
+        And I send 200000 uT from wallet WALLET_A to wallet WALLET_B at fee 25
         And I have mining node MINER_B connected to base node NODE and wallet WALLET_B
         When mining node MINER_B mines 2 blocks
         When I mine 5 blocks on NODE
@@ -24,7 +24,7 @@ Feature: Wallet Recovery
         When I recover wallet WALLET_B into wallet WALLET_C connected to all seed nodes
         When I wait for wallet WALLET_C to have at least 10000200000 uT
         And I have wallet WALLET_D connected to all seed nodes
-        And I send 100000 uT from wallet WALLET_C to wallet WALLET_D at fee 100
+        And I send 100000 uT from wallet WALLET_C to wallet WALLET_D at fee 25
         When I mine 5 blocks on NODE
         Then all nodes are at height 27
         Then I wait for wallet WALLET_D to have at least 100000 uT


### PR DESCRIPTION
Description
---
- Fixes stack overflow in `discovery_async_return_test`
- Removes creation of custom runtime for each test

Motivation and Context
---
CI was reporting a stack overflow in `discovery_async_return_test`. 
All async tests should use `tokio::test`. The use of a std::sync::CondVar caused tests to fail when used in an async thread,
this was replaced with a tokio watch.

How Has This Been Tested?
---
Tests pass

