### PR TITLE
feat(base_layer): validate acceptance window expiration on dan layer

### DIFF
--- a/base_layer/core/src/validation/dan_validators/constitution_validator.rs
+++ b/base_layer/core/src/validation/dan_validators/constitution_validator.rs
@@ -85,6 +85,7 @@ mod test {
     use crate::validation::dan_validators::test_helpers::{
         assert_dan_validator_fail,
         assert_dan_validator_success,
+        create_contract_constitution,
         create_contract_constitution_schema,
         init_test_blockchain,
         publish_constitution,
@@ -101,7 +102,8 @@ mod test {
         let contract_id = publish_definition(&mut blockchain, change[0].clone());
 
         // construct a valid constitution transaction
-        let schema = create_contract_constitution_schema(contract_id, change[2].clone(), Vec::new());
+        let constitution = create_contract_constitution();
+        let schema = create_contract_constitution_schema(contract_id, change[2].clone(), constitution);
         let (tx, _) = schema_to_transaction(&schema);
 
         assert_dan_validator_success(&blockchain, &tx);
@@ -114,7 +116,8 @@ mod test {
 
         // construct a transaction for a constitution, without a prior definition
         let contract_id = FixedHash::default();
-        let schema = create_contract_constitution_schema(contract_id, change[2].clone(), Vec::new());
+        let constitution = create_contract_constitution();
+        let schema = create_contract_constitution_schema(contract_id, change[2].clone(), constitution);
         let (tx, _) = schema_to_transaction(&schema);
 
         // try to validate the constitution transaction and check that we get the error
@@ -126,12 +129,15 @@ mod test {
         // initialise a blockchain with enough funds to spend at contract transactions
         let (mut blockchain, change) = init_test_blockchain();
 
-        // publish the contract definition and constitution into a block
+        // publish the contract definition into a block
         let contract_id = publish_definition(&mut blockchain, change[0].clone());
-        publish_constitution(&mut blockchain, change[1].clone(), contract_id, vec![]);
+
+        // publish the contract constitution into a block
+        let constitution = create_contract_constitution();
+        publish_constitution(&mut blockchain, change[1].clone(), contract_id, constitution.clone());
 
         // construct a transaction for the duplicated contract constitution
-        let schema = create_contract_constitution_schema(contract_id, change[2].clone(), Vec::new());
+        let schema = create_contract_constitution_schema(contract_id, change[2].clone(), constitution);
         let (tx, _) = schema_to_transaction(&schema);
 
         // try to validate the duplicated constitution transaction and check that we get the error

--- a/base_layer/core/src/validation/dan_validators/helpers.rs
+++ b/base_layer/core/src/validation/dan_validators/helpers.rs
@@ -66,25 +66,6 @@ pub fn fetch_contract_features<B: BlockchainBackend>(
     Ok(features)
 }
 
-pub fn fetch_height<B: BlockchainBackend>(
-    db: &BlockchainDatabase<B>,
-    contract_id: FixedHash,
-    output_type: OutputType,
-) -> Result<u64, ValidationError> {
-    let utxos = fetch_contract_utxos(db, contract_id, output_type)?;
-    match utxos.first() {
-        Some(utxo) => Ok(utxo.mined_height),
-        None => {
-            let msg = format!(
-                "Could not find UTXO for contract_id ({}) and type ({})",
-                contract_id.to_hex(),
-                output_type
-            );
-            Err(ValidationError::DanLayerError(msg))
-        },
-    }
-}
-
 pub fn fetch_contract_utxos<B: BlockchainBackend>(
     db: &BlockchainDatabase<B>,
     contract_id: FixedHash,

--- a/base_layer/core/src/validation/dan_validators/helpers.rs
+++ b/base_layer/core/src/validation/dan_validators/helpers.rs
@@ -66,6 +66,25 @@ pub fn fetch_contract_features<B: BlockchainBackend>(
     Ok(features)
 }
 
+pub fn fetch_height<B: BlockchainBackend>(
+    db: &BlockchainDatabase<B>,
+    contract_id: FixedHash,
+    output_type: OutputType,
+) -> Result<u64, ValidationError> {
+    let utxos = fetch_contract_utxos(db, contract_id, output_type)?;
+    match utxos.first() {
+        Some(utxo) => Ok(utxo.mined_height),
+        None => {
+            let msg = format!(
+                "Could not find UTXO for contract_id ({}) and type ({})",
+                contract_id.to_hex(),
+                output_type
+            );
+            Err(ValidationError::DanLayerError(msg))
+        },
+    }
+}
+
 pub fn fetch_contract_utxos<B: BlockchainBackend>(
     db: &BlockchainDatabase<B>,
     contract_id: FixedHash,

--- a/base_layer/core/src/validation/dan_validators/update_proposal_acceptance_validator.rs
+++ b/base_layer/core/src/validation/dan_validators/update_proposal_acceptance_validator.rs
@@ -129,6 +129,8 @@ fn validate_public_key(
 
 #[cfg(test)]
 mod test {
+    use std::convert::TryInto;
+
     use tari_common_types::types::PublicKey;
     use tari_utilities::hex::Hex;
 
@@ -136,7 +138,7 @@ mod test {
         assert_dan_validator_fail,
         assert_dan_validator_success,
         create_block,
-        create_contract_constitution_schema,
+        create_contract_constitution,
         create_contract_update_proposal_acceptance_schema,
         init_test_blockchain,
         publish_constitution,
@@ -156,11 +158,19 @@ mod test {
         // publish the contract constitution into a block
         let validator_node_public_key = PublicKey::default();
         let committee = vec![validator_node_public_key.clone()];
-        publish_constitution(&mut blockchain, change[1].clone(), contract_id, committee.clone());
+        let mut constitution = create_contract_constitution();
+        constitution.validator_committee = committee.try_into().unwrap();
+        publish_constitution(&mut blockchain, change[1].clone(), contract_id, constitution.clone());
 
         // publish the contract update proposal into a block
         let proposal_id: u64 = 1;
-        publish_update_proposal(&mut blockchain, change[2].clone(), contract_id, proposal_id, committee);
+        publish_update_proposal(
+            &mut blockchain,
+            change[2].clone(),
+            contract_id,
+            proposal_id,
+            constitution,
+        );
 
         // create a valid contract acceptance transaction
         let proposal_id = 1;
@@ -186,7 +196,9 @@ mod test {
         // publish the contract constitution into a block
         let validator_node_public_key = PublicKey::default();
         let committee = vec![validator_node_public_key.clone()];
-        publish_constitution(&mut blockchain, change[1].clone(), contract_id, committee);
+        let mut constitution = create_contract_constitution();
+        constitution.validator_committee = committee.try_into().unwrap();
+        publish_constitution(&mut blockchain, change[1].clone(), contract_id, constitution);
 
         // skip the publication of the contract update proposal
 
@@ -215,11 +227,19 @@ mod test {
         // publish the contract constitution into a block
         let validator_node_public_key = PublicKey::default();
         let committee = vec![validator_node_public_key.clone()];
-        publish_constitution(&mut blockchain, change[1].clone(), contract_id, committee.clone());
+        let mut constitution = create_contract_constitution();
+        constitution.validator_committee = committee.try_into().unwrap();
+        publish_constitution(&mut blockchain, change[1].clone(), contract_id, constitution.clone());
 
         // publish the contract update proposal into a block
         let proposal_id: u64 = 1;
-        publish_update_proposal(&mut blockchain, change[2].clone(), contract_id, proposal_id, committee);
+        publish_update_proposal(
+            &mut blockchain,
+            change[2].clone(),
+            contract_id,
+            proposal_id,
+            constitution,
+        );
 
         // publish the contract update proposal acceptance into a block
         let proposal_id = 1;
@@ -254,14 +274,24 @@ mod test {
         let contract_id = publish_definition(&mut blockchain, change[0].clone());
 
         // publish the contract constitution into a block
-        let schema = create_contract_constitution_schema(contract_id, change[1].clone(), vec![]);
-        create_block(&mut blockchain, "constitution", schema);
+        let committee = vec![];
+        let mut constitution = create_contract_constitution();
+        constitution.validator_committee = committee.try_into().unwrap();
+        publish_constitution(&mut blockchain, change[1].clone(), contract_id, constitution);
 
         // publish the contract update proposal into a block
         // we deliberately use a committee with only a defult public key to be able to trigger the committee error later
         let proposal_id: u64 = 1;
         let committee = vec![PublicKey::default()];
-        publish_update_proposal(&mut blockchain, change[2].clone(), contract_id, proposal_id, committee);
+        let mut constitution = create_contract_constitution();
+        constitution.validator_committee = committee.try_into().unwrap();
+        publish_update_proposal(
+            &mut blockchain,
+            change[2].clone(),
+            contract_id,
+            proposal_id,
+            constitution,
+        );
 
         // publish the contract update proposal acceptance into a block
         // we use a public key that is not included in the proposal committee, to trigger the error


### PR DESCRIPTION
Description
---
New validation step on contract acceptances (and contract update proposal acceptances) that:
* Retrieve the mined block height of the corresponding constitution/proposal
* Retrieve the specified acceptance window (as relative blocks) from the constitution/proposal
* Checks that the current tip height has not yet passed the sum of the two

Motivation and Context
---
The base layer need to verify that an acceptance (both constitution or proposal one) is inside the allowed acceptance window, specified as relative blocks in the constitution (or proposal).

How Has This Been Tested?
---
New unit tests to replicate the expiration error

