### PR TITLE
refactor(core): use thiserror for DAN validation errors

### DIFF
--- a/base_layer/core/src/validation/dan_validators/amendment_validator.rs
+++ b/base_layer/core/src/validation/dan_validators/amendment_validator.rs
@@ -213,7 +213,7 @@ mod test {
         let (tx, _) = schema_to_transaction(&schema);
 
         // try to validate the duplicated amendment transaction and check that we get the error
-        assert_dan_validator_fail(&blockchain, &tx, "Duplicated amendment");
+        assert_dan_validator_fail(&blockchain, &tx, "Duplicate ContractAmendment contract UTXO");
     }
 
     #[test]

--- a/base_layer/core/src/validation/dan_validators/constitution_validator.rs
+++ b/base_layer/core/src/validation/dan_validators/constitution_validator.rs
@@ -138,6 +138,6 @@ mod test {
         let (tx, _) = schema_to_transaction(&schema);
 
         // try to validate the duplicated constitution transaction and check that we get the error
-        assert_dan_validator_fail(&blockchain, &tx, "Duplicated contract constitution");
+        assert_dan_validator_fail(&blockchain, &tx, "Duplicate ContractConstitution contract UTXO");
     }
 }

--- a/base_layer/core/src/validation/dan_validators/definition_validator.rs
+++ b/base_layer/core/src/validation/dan_validators/definition_validator.rs
@@ -96,6 +96,6 @@ mod test {
         let (tx, _) = schema_to_transaction(&schema);
 
         // try to validate the duplicated definition transaction and check that we get the error
-        assert_dan_validator_fail(&blockchain, &tx, "Duplicated contract definition");
+        assert_dan_validator_fail(&blockchain, &tx, "Duplicate ContractDefinition contract UTXO");
     }
 }

--- a/base_layer/core/src/validation/dan_validators/definition_validator.rs
+++ b/base_layer/core/src/validation/dan_validators/definition_validator.rs
@@ -21,13 +21,12 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use tari_common_types::types::FixedHash;
-use tari_utilities::hex::Hex;
 
 use super::helpers::{fetch_contract_features, get_sidechain_features, validate_output_type};
 use crate::{
     chain_storage::{BlockchainBackend, BlockchainDatabase},
     transactions::transaction_components::{OutputType, TransactionOutput},
-    validation::ValidationError,
+    validation::{dan_validators::DanLayerValidationError, ValidationError},
 };
 
 pub fn validate_definition<B: BlockchainBackend>(
@@ -51,11 +50,11 @@ fn validate_uniqueness<B: BlockchainBackend>(
     let features = fetch_contract_features(db, contract_id, OutputType::ContractDefinition)?;
     let is_duplicated = !features.is_empty();
     if is_duplicated {
-        let msg = format!(
-            "Duplicated contract definition for contract_id ({:?})",
-            contract_id.to_hex()
-        );
-        return Err(ValidationError::DanLayerError(msg));
+        return Err(ValidationError::DanLayerError(DanLayerValidationError::DuplicateUtxo {
+            contract_id,
+            output_type: OutputType::ContractDefinition,
+            details: String::new(),
+        }));
     }
 
     Ok(())

--- a/base_layer/core/src/validation/dan_validators/error.rs
+++ b/base_layer/core/src/validation/dan_validators/error.rs
@@ -1,0 +1,64 @@
+//  Copyright 2022. The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use tari_common_types::types::FixedHash;
+
+use crate::transactions::transaction_components::OutputType;
+
+#[derive(Debug, thiserror::Error)]
+pub enum DanLayerValidationError {
+    #[error("{output_type} output with contract id {contract_id} is missing required feature data")]
+    MissingContractData {
+        contract_id: FixedHash,
+        output_type: OutputType,
+    },
+    #[error("Data inconsistency: {details}")]
+    DataInconsistency { details: String },
+    #[error("Contract constitution not found for contract_id {contract_id}")]
+    ContractConstitutionNotFound { contract_id: FixedHash },
+    #[error("Sidechain features not provided")]
+    SidechainFeaturesNotProvided,
+    #[error("Contract update proposal not found for contract_id {contract_id} and proposal_id {proposal_id}")]
+    ContractUpdateProposalNotFound { contract_id: FixedHash, proposal_id: u64 },
+    #[error("Invalid output type: expected {expected} but got {got}")]
+    UnexpectedOutputType { got: OutputType, expected: OutputType },
+    #[error("Contract acceptance features not found")]
+    ContractAcceptanceNotFound,
+    #[error("Duplicate {output_type} contract UTXO: {details}")]
+    DuplicateUtxo {
+        contract_id: FixedHash,
+        output_type: OutputType,
+        details: String,
+    },
+    #[error("Validator node public key is not in committee ({public_key})")]
+    ValidatorNotInCommittee { public_key: String },
+    #[error("Contract definition not found for contract_id ({contract_id})")]
+    ContractDefnintionNotFound { contract_id: FixedHash },
+    #[error("Sidechain features data for {field_name} not provided")]
+    SideChainFeaturesDataNotProvided { field_name: &'static str },
+    #[error("The updated_constitution of the amendment does not match the one in the update proposal")]
+    UpdatedConstitutionAmendmentMismatch,
+    #[error("Acceptance window has expired for contract_id ({contract_id})")]
+    AcceptanceWindowHasExpired { contract_id: FixedHash },
+    #[error("Proposal acceptance window has expired for contract_id ({contract_id}) and proposal_id ({proposal_id})")]
+    ProposalAcceptanceWindowHasExpired { contract_id: FixedHash, proposal_id: u64 },
+}

--- a/base_layer/core/src/validation/dan_validators/helpers.rs
+++ b/base_layer/core/src/validation/dan_validators/helpers.rs
@@ -21,7 +21,6 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use tari_common_types::types::FixedHash;
-use tari_utilities::hex::Hex;
 
 use crate::{
     chain_storage::{BlockchainBackend, BlockchainDatabase, UtxoMinedInfo},
@@ -32,20 +31,19 @@ use crate::{
         SideChainFeatures,
         TransactionOutput,
     },
-    validation::ValidationError,
+    validation::{dan_validators::DanLayerValidationError, ValidationError},
 };
 
 pub fn validate_output_type(
     output: &TransactionOutput,
     expected_output_type: OutputType,
-) -> Result<(), ValidationError> {
+) -> Result<(), DanLayerValidationError> {
     let output_type = output.features.output_type;
     if output_type != expected_output_type {
-        let msg = format!(
-            "Invalid output type: expected {:?} but got {:?}",
-            expected_output_type, output_type
-        );
-        return Err(ValidationError::DanLayerError(msg));
+        return Err(DanLayerValidationError::UnexpectedOutputType {
+            got: output_type,
+            expected: expected_output_type,
+        });
     }
 
     Ok(())
@@ -57,10 +55,9 @@ pub fn fetch_contract_features<B: BlockchainBackend>(
     output_type: OutputType,
 ) -> Result<Vec<SideChainFeatures>, ValidationError> {
     let features = fetch_contract_utxos(db, contract_id, output_type)?
-        .iter()
-        .filter_map(|utxo| utxo.output.as_transaction_output())
-        .filter_map(|output| output.features.sidechain_features.as_ref())
-        .cloned()
+        .into_iter()
+        .filter_map(|utxo| utxo.output.into_unpruned_output())
+        .filter_map(|output| output.features.sidechain_features)
         .collect();
 
     Ok(features)
@@ -71,10 +68,7 @@ pub fn fetch_contract_utxos<B: BlockchainBackend>(
     contract_id: FixedHash,
     output_type: OutputType,
 ) -> Result<Vec<UtxoMinedInfo>, ValidationError> {
-    let utxos = db
-        .fetch_contract_outputs_by_contract_id_and_type(contract_id, output_type)
-        .map_err(|err| ValidationError::DanLayerError(format!("Could not search outputs: {}", err)))?;
-
+    let utxos = db.fetch_contract_outputs_by_contract_id_and_type(contract_id, output_type)?;
     Ok(utxos)
 }
 
@@ -82,26 +76,19 @@ pub fn fetch_contract_constitution<B: BlockchainBackend>(
     db: &BlockchainDatabase<B>,
     contract_id: FixedHash,
 ) -> Result<ContractConstitution, ValidationError> {
-    let features = fetch_contract_features(db, contract_id, OutputType::ContractConstitution)?;
-    if features.is_empty() {
-        return Err(ValidationError::DanLayerError(format!(
-            "Contract constitution not found for contract_id {}",
-            contract_id.to_hex()
-        )));
+    let mut features = fetch_contract_features(db, contract_id, OutputType::ContractConstitution)?;
+    let feature = features
+        .pop()
+        .ok_or(DanLayerValidationError::ContractConstitutionNotFound { contract_id })?;
+
+    match feature.constitution {
+        Some(value) => Ok(value),
+        None => Err(ValidationError::DanLayerError(
+            DanLayerValidationError::DataInconsistency {
+                details: "Contract constitution data not found in the output features".to_string(),
+            },
+        )),
     }
-
-    let feature = &features[0];
-
-    let constitution = match feature.constitution.as_ref() {
-        Some(value) => value,
-        None => {
-            return Err(ValidationError::DanLayerError(
-                "Contract constitution data not found in the output features".to_string(),
-            ))
-        },
-    };
-
-    Ok(constitution.clone())
 }
 
 pub fn fetch_contract_update_proposal<B: BlockchainBackend>(
@@ -116,19 +103,18 @@ pub fn fetch_contract_update_proposal<B: BlockchainBackend>(
         .find(|proposal| proposal.proposal_id == proposal_id)
     {
         Some(proposal) => Ok(proposal),
-        None => Err(ValidationError::DanLayerError(format!(
-            "Contract update proposal not found for contract_id {} and proposal_id {}",
-            contract_id.to_hex(),
-            proposal_id
-        ))),
+        None => Err(ValidationError::DanLayerError(
+            DanLayerValidationError::ContractUpdateProposalNotFound {
+                contract_id,
+                proposal_id,
+            },
+        )),
     }
 }
 
-pub fn get_sidechain_features(output: &TransactionOutput) -> Result<&SideChainFeatures, ValidationError> {
+pub fn get_sidechain_features(output: &TransactionOutput) -> Result<&SideChainFeatures, DanLayerValidationError> {
     match output.features.sidechain_features.as_ref() {
         Some(features) => Ok(features),
-        None => Err(ValidationError::DanLayerError(
-            "Sidechain features not found".to_string(),
-        )),
+        None => Err(DanLayerValidationError::SidechainFeaturesNotProvided),
     }
 }

--- a/base_layer/core/src/validation/dan_validators/mod.rs
+++ b/base_layer/core/src/validation/dan_validators/mod.rs
@@ -46,6 +46,9 @@ use amendment_validator::validate_amendment;
 
 mod helpers;
 
+mod error;
+pub use error::DanLayerValidationError;
+
 #[cfg(test)]
 mod test_helpers;
 
@@ -68,6 +71,7 @@ impl<B: BlockchainBackend> MempoolTransactionValidation for TxDanLayerValidator<
                 OutputType::ContractDefinition => validate_definition(&self.db, output)?,
                 OutputType::ContractConstitution => validate_constitution(&self.db, output)?,
                 OutputType::ContractValidatorAcceptance => validate_acceptance(&self.db, output)?,
+                // OutputType::ContractCheckpoint => validate_contract_checkpoint(&self.db, output)?,
                 OutputType::ContractConstitutionProposal => validate_update_proposal(&self.db, output)?,
                 OutputType::ContractConstitutionChangeAcceptance => {
                     validate_update_proposal_acceptance(&self.db, output)?

--- a/base_layer/core/src/validation/dan_validators/update_proposal_acceptance_validator.rs
+++ b/base_layer/core/src/validation/dan_validators/update_proposal_acceptance_validator.rs
@@ -320,7 +320,11 @@ mod test {
         let (tx, _) = schema_to_transaction(&schema);
 
         // try to validate the (duplicated) proposal acceptance transaction and check that we get the error
-        assert_dan_validator_fail(&blockchain, &tx, "Duplicated contract update proposal acceptance");
+        assert_dan_validator_fail(
+            &blockchain,
+            &tx,
+            "Duplicate ContractConstitutionChangeAcceptance contract UTXO",
+        );
     }
 
     #[test]

--- a/base_layer/core/src/validation/dan_validators/update_proposal_validator.rs
+++ b/base_layer/core/src/validation/dan_validators/update_proposal_validator.rs
@@ -178,6 +178,6 @@ mod test {
         let (tx, _) = schema_to_transaction(&schema);
 
         // try to validate the duplicated proposal transaction and check that we get the error
-        assert_dan_validator_fail(&blockchain, &tx, "Duplicated contract update proposal");
+        assert_dan_validator_fail(&blockchain, &tx, "Duplicate ContractConstitutionProposal contract UTXO");
     }
 }

--- a/base_layer/core/src/validation/error.rs
+++ b/base_layer/core/src/validation/error.rs
@@ -30,6 +30,7 @@ use crate::{
     covenants::CovenantError,
     proof_of_work::{monero_rx::MergeMineError, PowError},
     transactions::transaction_components::TransactionError,
+    validation::dan_validators::DanLayerValidationError,
 };
 
 #[derive(Debug, Error)]
@@ -117,7 +118,7 @@ pub enum ValidationError {
     #[error("Standard transaction contains coinbase output")]
     ErroneousCoinbaseOutput,
     #[error("Digital Asset Network Error: {0}")]
-    DanLayerError(String),
+    DanLayerError(#[from] DanLayerValidationError),
 }
 
 // ChainStorageError has a ValidationError variant, so to prevent a cyclic dependency we use a string representation in


### PR DESCRIPTION
Description
---
- replaces string literals with `thiserror` variants in DAN validations

Motivation and Context
---
This is standard in the core code, makes errors more maintainable and removes brittleness in tests by removing string comparisons (tests use string comparisons, not updated, but left as a low priority).

How Has This Been Tested?
---
