### PR TITLE
chore(deps): improve GHA docker image builds

### DIFF
--- a/.github/workflows/launchpad_docker.yml
+++ b/.github/workflows/launchpad_docker.yml
@@ -101,8 +101,8 @@ jobs:
             DOCKERFILE=${IMAGE}.Dockerfile
             DOCKERCONTEXT=./applications/launchpad/docker_rig/
 
-            # Pull the docker image TAG from dockerfile
-            SUBTAG=$(awk -F '=' '/ARG .*_VERSION=/ \
+            # Pull the docker image version TAG from service dockerfile
+            SUBTAG=$(awk -v search="^ARG ${IMAGE^^}?_VERSION=" -F '=' '$0 ~ search \
               { gsub(/["]/, "", $2); printf("%s",$2) }' \
               "${GITHUB_WORKSPACE}/${DOCKERCONTEXT}${DOCKERFILE}")
 


### PR DESCRIPTION
Description
Fix GHA service TAG version from dockerfile

Motivation and Context
Remove the need for a versions/env file for tracking the released versions for sub-services.

How Has This Been Tested?
Build in my branch from GHA into Quay.io
