### PR TITLE
feat!: add checkpoint_number to checkpoint with basic base layer validations

### DIFF
--- a/applications/tari_app_grpc/proto/types.proto
+++ b/applications/tari_app_grpc/proto/types.proto
@@ -262,8 +262,9 @@ message CommitteeMembers {
 }
 
 message ContractCheckpoint {
-    bytes merkle_root = 1;
-    CommitteeSignatures signatures = 2;
+    uint64 checkpoint_number = 1;
+    bytes merkle_root = 2;
+    CommitteeSignatures signatures = 3;
 }
 
 message CheckpointParameters {

--- a/applications/tari_app_grpc/proto/wallet.proto
+++ b/applications/tari_app_grpc/proto/wallet.proto
@@ -279,8 +279,9 @@ message CreateInitialAssetCheckpointResponse {
 }
 
 message CreateFollowOnAssetCheckpointRequest {
-    bytes contract_id = 1;
-    bytes merkle_root = 2;
+    uint64 checkpoint_number = 1;
+    bytes contract_id = 2;
+    bytes merkle_root = 3;
 }
 
 message CreateFollowOnAssetCheckpointResponse {

--- a/applications/tari_app_grpc/src/conversions/sidechain_features.rs
+++ b/applications/tari_app_grpc/src/conversions/sidechain_features.rs
@@ -307,6 +307,7 @@ impl TryFrom<grpc::ContractConstitution> for ContractConstitution {
 impl From<ContractCheckpoint> for grpc::ContractCheckpoint {
     fn from(value: ContractCheckpoint) -> Self {
         Self {
+            checkpoint_number: value.checkpoint_number,
             merkle_root: value.merkle_root.to_vec(),
             signatures: Some(value.signatures.into()),
         }
@@ -320,6 +321,7 @@ impl TryFrom<grpc::ContractCheckpoint> for ContractCheckpoint {
         let merkle_root = value.merkle_root.try_into().map_err(|_| "Invalid merkle root")?;
         let signatures = value.signatures.map(TryInto::try_into).transpose()?.unwrap_or_default();
         Ok(Self {
+            checkpoint_number: value.checkpoint_number,
             merkle_root,
             signatures,
         })

--- a/applications/tari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/tari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -858,13 +858,15 @@ impl wallet_server::Wallet for WalletGrpcServer {
             .try_into()
             .map_err(|e| Status::invalid_argument(format!("Contract ID was not valid :{}", e)))?;
 
+        let checkpoint_number = message.checkpoint_number;
+
         let merkle_root = message
             .merkle_root
             .try_into()
             .map_err(|_| Status::invalid_argument("Incorrect merkle root length"))?;
 
         let (tx_id, transaction) = asset_manager
-            .create_follow_on_asset_checkpoint(contract_id, merkle_root)
+            .create_follow_on_asset_checkpoint(contract_id, checkpoint_number, merkle_root)
             .await
             .map_err(|e| Status::internal(e.to_string()))?;
 

--- a/applications/tari_validator_node/src/grpc/services/wallet_client.rs
+++ b/applications/tari_validator_node/src/grpc/services/wallet_client.rs
@@ -67,11 +67,11 @@ impl WalletClient for GrpcWalletClient {
         &mut self,
         contract_id: &FixedHash,
         state_root: &StateRoot,
-        is_initial: bool,
+        checkpoint_number: u64,
     ) -> Result<(), DigitalAssetError> {
         let inner = self.connection().await?;
 
-        if is_initial {
+        if checkpoint_number == 0 {
             let request = CreateInitialAssetCheckpointRequest {
                 contract_id: contract_id.to_vec(),
                 merkle_root: state_root.as_bytes().to_vec(),
@@ -84,6 +84,7 @@ impl WalletClient for GrpcWalletClient {
                 .map_err(|e| DigitalAssetError::FatalError(format!("Could not create checkpoint:{}", e)))?;
         } else {
             let request = CreateFollowOnAssetCheckpointRequest {
+                checkpoint_number,
                 contract_id: contract_id.to_vec(),
                 merkle_root: state_root.as_bytes().to_vec(),
             };

--- a/base_layer/core/src/proto/transaction.proto
+++ b/base_layer/core/src/proto/transaction.proto
@@ -117,8 +117,9 @@ message SideChainFeatures {
 }
 
 message ContractCheckpoint {
-    bytes merkle_root = 1;
-    CommitteeSignatures signatures = 2;
+    uint64 checkpoint_number = 1;
+    bytes merkle_root = 2;
+    CommitteeSignatures signatures = 3;
 }
 
 message ContractConstitution {

--- a/base_layer/core/src/proto/transaction.rs
+++ b/base_layer/core/src/proto/transaction.rs
@@ -464,6 +464,7 @@ impl TryFrom<proto::types::ContractConstitution> for ContractConstitution {
 impl From<ContractCheckpoint> for proto::types::ContractCheckpoint {
     fn from(value: ContractCheckpoint) -> Self {
         Self {
+            checkpoint_number: value.checkpoint_number,
             merkle_root: value.merkle_root.to_vec(),
             signatures: Some(value.signatures.into()),
         }
@@ -477,6 +478,7 @@ impl TryFrom<proto::types::ContractCheckpoint> for ContractCheckpoint {
         let merkle_root = value.merkle_root.try_into().map_err(|_| "Invalid merkle root")?;
         let signatures = value.signatures.map(TryInto::try_into).transpose()?.unwrap_or_default();
         Ok(Self {
+            checkpoint_number: value.checkpoint_number,
             merkle_root,
             signatures,
         })

--- a/base_layer/core/src/transactions/transaction_components/side_chain/contract_checkpoint.rs
+++ b/base_layer/core/src/transactions/transaction_components/side_chain/contract_checkpoint.rs
@@ -32,12 +32,14 @@ use crate::{
 
 #[derive(Debug, Clone, Hash, PartialEq, Deserialize, Serialize, Eq)]
 pub struct ContractCheckpoint {
+    pub checkpoint_number: u64,
     pub merkle_root: FixedHash,
     pub signatures: CommitteeSignatures,
 }
 
 impl ConsensusEncoding for ContractCheckpoint {
     fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
+        self.checkpoint_number.consensus_encode(writer)?;
         self.merkle_root.consensus_encode(writer)?;
         self.signatures.consensus_encode(writer)?;
         Ok(())
@@ -49,6 +51,7 @@ impl ConsensusEncodingSized for ContractCheckpoint {}
 impl ConsensusDecoding for ContractCheckpoint {
     fn consensus_decode<R: Read>(reader: &mut R) -> Result<Self, Error> {
         Ok(Self {
+            checkpoint_number: u64::consensus_decode(reader)?,
             merkle_root: ConsensusDecoding::consensus_decode(reader)?,
             signatures: ConsensusDecoding::consensus_decode(reader)?,
         })
@@ -67,6 +70,7 @@ mod tests {
     #[test]
     fn it_encodes_and_decodes_correctly() {
         let subject = ContractCheckpoint {
+            checkpoint_number: u64::MAX,
             merkle_root: FixedHash::zero(),
             signatures: vec![Signature::default(); 512].try_into().unwrap(),
         };

--- a/base_layer/core/src/transactions/transaction_components/side_chain/sidechain_features.rs
+++ b/base_layer/core/src/transactions/transaction_components/side_chain/sidechain_features.rs
@@ -260,6 +260,7 @@ mod tests {
                 activation_window: 0_u64,
             }),
             checkpoint: Some(ContractCheckpoint {
+                checkpoint_number: u64::MAX,
                 merkle_root: FixedHash::zero(),
                 signatures: vec![Signature::default(); 512].try_into().unwrap(),
             }),

--- a/base_layer/core/src/validation/dan_validators/checkpoint_validator.rs
+++ b/base_layer/core/src/validation/dan_validators/checkpoint_validator.rs
@@ -1,0 +1,165 @@
+//  Copyright 2022, The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use super::helpers::get_sidechain_features;
+use crate::{
+    chain_storage::{BlockchainBackend, BlockchainDatabase},
+    transactions::transaction_components::{ContractCheckpoint, OutputType, SideChainFeatures, TransactionOutput},
+    validation::{
+        dan_validators::{
+            constitution_validator::validate_definition_existence,
+            helpers::fetch_current_contract_checkpoint,
+            DanLayerValidationError,
+        },
+        ValidationError,
+    },
+};
+
+pub fn validate_contract_checkpoint<B: BlockchainBackend>(
+    db: &BlockchainDatabase<B>,
+    output: &TransactionOutput,
+) -> Result<(), ValidationError> {
+    let sidechain_features = get_sidechain_features(output)?;
+    let contract_id = sidechain_features.contract_id;
+    validate_definition_existence(db, contract_id)?;
+
+    let prev_cp = fetch_current_contract_checkpoint(db, contract_id)?;
+    validate_checkpoint_number(prev_cp.as_ref(), sidechain_features)?;
+
+    Ok(())
+}
+
+fn validate_checkpoint_number(
+    prev_checkpoint: Option<&ContractCheckpoint>,
+    sidechain_features: &SideChainFeatures,
+) -> Result<(), DanLayerValidationError> {
+    let checkpoint = sidechain_features
+        .checkpoint
+        .as_ref()
+        .ok_or(DanLayerValidationError::MissingContractData {
+            contract_id: sidechain_features.contract_id,
+            output_type: OutputType::ContractCheckpoint,
+        })?;
+
+    let expected_number = prev_checkpoint.map(|cp| cp.checkpoint_number + 1).unwrap_or(0);
+    if checkpoint.checkpoint_number == expected_number {
+        Ok(())
+    } else {
+        Err(DanLayerValidationError::CheckpointNonSequentialNumber {
+            got: checkpoint.checkpoint_number,
+            expected: expected_number,
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::validation::dan_validators::{
+        test_helpers::{
+            assert_dan_validator_err,
+            assert_dan_validator_success,
+            create_contract_checkpoint,
+            create_contract_checkpoint_schema,
+            init_test_blockchain,
+            publish_checkpoint,
+            publish_contract,
+            schema_to_transaction,
+        },
+        DanLayerValidationError,
+    };
+
+    #[test]
+    fn it_allows_initial_checkpoint_output_with_zero_checkpoint_number() {
+        // initialise a blockchain with enough funds to spend at contract transactions
+        let (mut blockchain, utxos) = init_test_blockchain();
+
+        // Publish a new contract
+        let contract_id = publish_contract(&mut blockchain, &utxos, vec![]);
+
+        // Create checkpoint 0 with no prior checkpoints
+        let checkpoint = create_contract_checkpoint(0);
+        let schema = create_contract_checkpoint_schema(contract_id, utxos[2].clone(), checkpoint);
+        let (tx, _) = schema_to_transaction(&schema);
+
+        assert_dan_validator_success(&blockchain, &tx);
+    }
+
+    #[test]
+    fn it_allows_checkpoint_output_with_correct_sequential_checkpoint_number() {
+        // initialise a blockchain with enough funds to spend at contract transactions
+        let (mut blockchain, utxos) = init_test_blockchain();
+
+        // Publish a new contract
+        let contract_id = publish_contract(&mut blockchain, &utxos, vec![]);
+
+        publish_checkpoint(&mut blockchain, "cp0", utxos[2].clone(), contract_id, 0);
+        publish_checkpoint(&mut blockchain, "cp1", utxos[3].clone(), contract_id, 1);
+        // Create checkpoint 0 with no prior checkpoints
+        let checkpoint = create_contract_checkpoint(2);
+        let schema = create_contract_checkpoint_schema(contract_id, utxos[4].clone(), checkpoint);
+        let (tx, _) = schema_to_transaction(&schema);
+
+        assert_dan_validator_success(&blockchain, &tx);
+    }
+
+    #[test]
+    fn it_rejects_initial_checkpoint_output_with_non_zero_checkpoint_number() {
+        // initialise a blockchain with enough funds to spend at contract transactions
+        let (mut blockchain, utxos) = init_test_blockchain();
+
+        // Publish a new contract
+        let contract_id = publish_contract(&mut blockchain, &utxos, vec![]);
+
+        // Create checkpoint 1 with no prior checkpoints
+        let checkpoint = create_contract_checkpoint(1);
+        let schema = create_contract_checkpoint_schema(contract_id, utxos[2].clone(), checkpoint);
+        let (tx, _) = schema_to_transaction(&schema);
+
+        let err = assert_dan_validator_err(&blockchain, &tx);
+        assert!(matches!(err, DanLayerValidationError::CheckpointNonSequentialNumber {
+            got: 1,
+            expected: 0
+        }))
+    }
+
+    #[test]
+    fn it_rejects_checkpoint_output_with_non_sequential_checkpoint_number() {
+        // initialise a blockchain with enough funds to spend at contract transactions
+        let (mut blockchain, utxos) = init_test_blockchain();
+
+        // Publish a new contract
+        let contract_id = publish_contract(&mut blockchain, &utxos, vec![]);
+
+        publish_checkpoint(&mut blockchain, "cp0", utxos[2].clone(), contract_id, 0);
+        publish_checkpoint(&mut blockchain, "cp1", utxos[3].clone(), contract_id, 1);
+        // Create checkpoint 0 with no prior checkpoints
+        let checkpoint = create_contract_checkpoint(3);
+        let schema = create_contract_checkpoint_schema(contract_id, utxos[2].clone(), checkpoint);
+        let (tx, _) = schema_to_transaction(&schema);
+
+        let err = assert_dan_validator_err(&blockchain, &tx);
+        assert!(matches!(err, DanLayerValidationError::CheckpointNonSequentialNumber {
+            got: 3,
+            expected: 2
+        }))
+    }
+}

--- a/base_layer/core/src/validation/dan_validators/definition_validator.rs
+++ b/base_layer/core/src/validation/dan_validators/definition_validator.rs
@@ -21,13 +21,12 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use tari_common_types::types::FixedHash;
-use tari_utilities::hex::Hex;
 
 use super::helpers::{fetch_contract_features, get_sidechain_features, validate_output_type};
 use crate::{
     chain_storage::{BlockchainBackend, BlockchainDatabase},
     transactions::transaction_components::{OutputType, TransactionOutput},
-    validation::ValidationError,
+    validation::{dan_validators::DanLayerValidationError, ValidationError},
 };
 
 pub fn validate_definition<B: BlockchainBackend>(
@@ -51,11 +50,11 @@ fn validate_uniqueness<B: BlockchainBackend>(
     let features = fetch_contract_features(db, contract_id, OutputType::ContractDefinition)?;
     let is_duplicated = !features.is_empty();
     if is_duplicated {
-        let msg = format!(
-            "Duplicated contract definition for contract_id ({:?})",
-            contract_id.to_hex()
-        );
-        return Err(ValidationError::DanLayerError(msg));
+        return Err(ValidationError::DanLayerError(DanLayerValidationError::DuplicateUtxo {
+            contract_id,
+            output_type: OutputType::ContractDefinition,
+            details: String::new(),
+        }));
     }
 
     Ok(())

--- a/base_layer/core/src/validation/dan_validators/definition_validator.rs
+++ b/base_layer/core/src/validation/dan_validators/definition_validator.rs
@@ -62,13 +62,21 @@ fn validate_uniqueness<B: BlockchainBackend>(
 
 #[cfg(test)]
 mod test {
-    use crate::validation::dan_validators::test_helpers::{
-        assert_dan_validator_fail,
-        assert_dan_validator_success,
-        create_contract_definition_schema,
-        init_test_blockchain,
-        publish_definition,
-        schema_to_transaction,
+    use tari_test_utils::unpack_enum;
+
+    use crate::{
+        transactions::transaction_components::OutputType,
+        validation::dan_validators::{
+            test_helpers::{
+                assert_dan_validator_err,
+                assert_dan_validator_success,
+                create_contract_definition_schema,
+                init_test_blockchain,
+                publish_definition,
+                schema_to_transaction,
+            },
+            DanLayerValidationError,
+        },
     };
 
     #[test]
@@ -89,13 +97,22 @@ mod test {
         let (mut blockchain, change) = init_test_blockchain();
 
         // publish the contract definition into a block
-        let _contract_id = publish_definition(&mut blockchain, change[0].clone());
+        let expected_contract_id = publish_definition(&mut blockchain, change[0].clone());
 
         // construct a transaction for the duplicated contract definition
         let (_, schema) = create_contract_definition_schema(change[1].clone());
         let (tx, _) = schema_to_transaction(&schema);
 
         // try to validate the duplicated definition transaction and check that we get the error
-        assert_dan_validator_fail(&blockchain, &tx, "Duplicated contract definition");
+        let err = assert_dan_validator_err(&blockchain, &tx);
+        unpack_enum!(
+            DanLayerValidationError::DuplicateUtxo {
+                output_type,
+                contract_id,
+                ..
+            } = err
+        );
+        assert_eq!(output_type, OutputType::ContractDefinition);
+        assert_eq!(contract_id, expected_contract_id);
     }
 }

--- a/base_layer/core/src/validation/dan_validators/error.rs
+++ b/base_layer/core/src/validation/dan_validators/error.rs
@@ -61,4 +61,6 @@ pub enum DanLayerValidationError {
     AcceptanceWindowHasExpired { contract_id: FixedHash },
     #[error("Proposal acceptance window has expired for contract_id ({contract_id}) and proposal_id ({proposal_id})")]
     ProposalAcceptanceWindowHasExpired { contract_id: FixedHash, proposal_id: u64 },
+    #[error("Checkpoint has non-sequential number. Got: {got}, expected: {expected}")]
+    CheckpointNonSequentialNumber { got: u64, expected: u64 },
 }

--- a/base_layer/core/src/validation/dan_validators/error.rs
+++ b/base_layer/core/src/validation/dan_validators/error.rs
@@ -1,0 +1,64 @@
+//  Copyright 2022. The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use tari_common_types::types::FixedHash;
+
+use crate::transactions::transaction_components::OutputType;
+
+#[derive(Debug, thiserror::Error)]
+pub enum DanLayerValidationError {
+    #[error("{output_type} output with contract id {contract_id} is missing required feature data")]
+    MissingContractData {
+        contract_id: FixedHash,
+        output_type: OutputType,
+    },
+    #[error("Data inconsistency: {details}")]
+    DataInconsistency { details: String },
+    #[error("Contract constitution not found for contract_id {contract_id}")]
+    ContractConstitutionNotFound { contract_id: FixedHash },
+    #[error("Sidechain features not provided")]
+    SidechainFeaturesNotProvided,
+    #[error("Contract update proposal not found for contract_id {contract_id} and proposal_id {proposal_id}")]
+    ContractUpdateProposalNotFound { contract_id: FixedHash, proposal_id: u64 },
+    #[error("Invalid output type: expected {expected} but got {got}")]
+    UnexpectedOutputType { got: OutputType, expected: OutputType },
+    #[error("Contract acceptance features not found")]
+    ContractAcceptanceNotFound,
+    #[error("Duplicate {output_type} contract UTXO: {details}")]
+    DuplicateUtxo {
+        contract_id: FixedHash,
+        output_type: OutputType,
+        details: String,
+    },
+    #[error("Validator node public key is not in committee ({public_key})")]
+    ValidatorNotInCommittee { public_key: String },
+    #[error("Contract definition not found for contract_id ({contract_id})")]
+    ContractDefnintionNotFound { contract_id: FixedHash },
+    #[error("Sidechain features data for {field_name} not provided")]
+    SideChainFeaturesDataNotProvided { field_name: &'static str },
+    #[error("The updated_constitution of the amendment does not match the one in the update proposal")]
+    UpdatedConstitutionAmendmentMismatch,
+    #[error("Acceptance window has expired for contract_id ({contract_id})")]
+    AcceptanceWindowHasExpired { contract_id: FixedHash },
+    #[error("Proposal acceptance window has expired for contract_id ({contract_id}) and proposal_id ({proposal_id})")]
+    ProposalAcceptanceWindowHasExpired { contract_id: FixedHash, proposal_id: u64 },
+}

--- a/base_layer/core/src/validation/dan_validators/helpers.rs
+++ b/base_layer/core/src/validation/dan_validators/helpers.rs
@@ -21,7 +21,6 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use tari_common_types::types::FixedHash;
-use tari_utilities::hex::Hex;
 
 use crate::{
     chain_storage::{BlockchainBackend, BlockchainDatabase, UtxoMinedInfo},
@@ -32,20 +31,19 @@ use crate::{
         SideChainFeatures,
         TransactionOutput,
     },
-    validation::ValidationError,
+    validation::{dan_validators::DanLayerValidationError, ValidationError},
 };
 
 pub fn validate_output_type(
     output: &TransactionOutput,
     expected_output_type: OutputType,
-) -> Result<(), ValidationError> {
+) -> Result<(), DanLayerValidationError> {
     let output_type = output.features.output_type;
     if output_type != expected_output_type {
-        let msg = format!(
-            "Invalid output type: expected {:?} but got {:?}",
-            expected_output_type, output_type
-        );
-        return Err(ValidationError::DanLayerError(msg));
+        return Err(DanLayerValidationError::UnexpectedOutputType {
+            got: output_type,
+            expected: expected_output_type,
+        });
     }
 
     Ok(())
@@ -57,10 +55,9 @@ pub fn fetch_contract_features<B: BlockchainBackend>(
     output_type: OutputType,
 ) -> Result<Vec<SideChainFeatures>, ValidationError> {
     let features = fetch_contract_utxos(db, contract_id, output_type)?
-        .iter()
-        .filter_map(|utxo| utxo.output.as_transaction_output())
-        .filter_map(|output| output.features.sidechain_features.as_ref())
-        .cloned()
+        .into_iter()
+        .filter_map(|utxo| utxo.output.into_unpruned_output())
+        .filter_map(|output| output.features.sidechain_features)
         .collect();
 
     Ok(features)
@@ -71,10 +68,7 @@ pub fn fetch_contract_utxos<B: BlockchainBackend>(
     contract_id: FixedHash,
     output_type: OutputType,
 ) -> Result<Vec<UtxoMinedInfo>, ValidationError> {
-    let utxos = db
-        .fetch_contract_outputs_by_contract_id_and_type(contract_id, output_type)
-        .map_err(|err| ValidationError::DanLayerError(format!("Could not search outputs: {}", err)))?;
-
+    let utxos = db.fetch_contract_outputs_by_contract_id_and_type(contract_id, output_type)?;
     Ok(utxos)
 }
 
@@ -82,26 +76,19 @@ pub fn fetch_contract_constitution<B: BlockchainBackend>(
     db: &BlockchainDatabase<B>,
     contract_id: FixedHash,
 ) -> Result<ContractConstitution, ValidationError> {
-    let features = fetch_contract_features(db, contract_id, OutputType::ContractConstitution)?;
-    if features.is_empty() {
-        return Err(ValidationError::DanLayerError(format!(
-            "Contract constitution not found for contract_id {}",
-            contract_id.to_hex()
-        )));
+    let mut features = fetch_contract_features(db, contract_id, OutputType::ContractConstitution)?;
+    let feature = features
+        .pop()
+        .ok_or(DanLayerValidationError::ContractConstitutionNotFound { contract_id })?;
+
+    match feature.constitution {
+        Some(value) => Ok(value),
+        None => Err(ValidationError::DanLayerError(
+            DanLayerValidationError::DataInconsistency {
+                details: "Contract constitution data not found in the output features".to_string(),
+            },
+        )),
     }
-
-    let feature = &features[0];
-
-    let constitution = match feature.constitution.as_ref() {
-        Some(value) => value,
-        None => {
-            return Err(ValidationError::DanLayerError(
-                "Contract constitution data not found in the output features".to_string(),
-            ))
-        },
-    };
-
-    Ok(constitution.clone())
 }
 
 pub fn fetch_contract_update_proposal<B: BlockchainBackend>(
@@ -116,19 +103,18 @@ pub fn fetch_contract_update_proposal<B: BlockchainBackend>(
         .find(|proposal| proposal.proposal_id == proposal_id)
     {
         Some(proposal) => Ok(proposal),
-        None => Err(ValidationError::DanLayerError(format!(
-            "Contract update proposal not found for contract_id {} and proposal_id {}",
-            contract_id.to_hex(),
-            proposal_id
-        ))),
+        None => Err(ValidationError::DanLayerError(
+            DanLayerValidationError::ContractUpdateProposalNotFound {
+                contract_id,
+                proposal_id,
+            },
+        )),
     }
 }
 
-pub fn get_sidechain_features(output: &TransactionOutput) -> Result<&SideChainFeatures, ValidationError> {
+pub fn get_sidechain_features(output: &TransactionOutput) -> Result<&SideChainFeatures, DanLayerValidationError> {
     match output.features.sidechain_features.as_ref() {
         Some(features) => Ok(features),
-        None => Err(ValidationError::DanLayerError(
-            "Sidechain features not found".to_string(),
-        )),
+        None => Err(DanLayerValidationError::SidechainFeaturesNotProvided),
     }
 }

--- a/base_layer/core/src/validation/dan_validators/mod.rs
+++ b/base_layer/core/src/validation/dan_validators/mod.rs
@@ -44,6 +44,9 @@ use update_proposal_acceptance_validator::validate_update_proposal_acceptance;
 mod amendment_validator;
 use amendment_validator::validate_amendment;
 
+mod checkpoint_validator;
+use checkpoint_validator::validate_contract_checkpoint;
+
 mod helpers;
 
 mod error;
@@ -71,7 +74,7 @@ impl<B: BlockchainBackend> MempoolTransactionValidation for TxDanLayerValidator<
                 OutputType::ContractDefinition => validate_definition(&self.db, output)?,
                 OutputType::ContractConstitution => validate_constitution(&self.db, output)?,
                 OutputType::ContractValidatorAcceptance => validate_acceptance(&self.db, output)?,
-                // OutputType::ContractCheckpoint => validate_contract_checkpoint(&self.db, output)?,
+                OutputType::ContractCheckpoint => validate_contract_checkpoint(&self.db, output)?,
                 OutputType::ContractConstitutionProposal => validate_update_proposal(&self.db, output)?,
                 OutputType::ContractConstitutionChangeAcceptance => {
                     validate_update_proposal_acceptance(&self.db, output)?

--- a/base_layer/core/src/validation/dan_validators/mod.rs
+++ b/base_layer/core/src/validation/dan_validators/mod.rs
@@ -46,6 +46,9 @@ use amendment_validator::validate_amendment;
 
 mod helpers;
 
+mod error;
+pub use error::DanLayerValidationError;
+
 #[cfg(test)]
 mod test_helpers;
 
@@ -68,6 +71,7 @@ impl<B: BlockchainBackend> MempoolTransactionValidation for TxDanLayerValidator<
                 OutputType::ContractDefinition => validate_definition(&self.db, output)?,
                 OutputType::ContractConstitution => validate_constitution(&self.db, output)?,
                 OutputType::ContractValidatorAcceptance => validate_acceptance(&self.db, output)?,
+                // OutputType::ContractCheckpoint => validate_contract_checkpoint(&self.db, output)?,
                 OutputType::ContractConstitutionProposal => validate_update_proposal(&self.db, output)?,
                 OutputType::ContractConstitutionChangeAcceptance => {
                     validate_update_proposal_acceptance(&self.db, output)?

--- a/base_layer/core/src/validation/error.rs
+++ b/base_layer/core/src/validation/error.rs
@@ -30,6 +30,7 @@ use crate::{
     covenants::CovenantError,
     proof_of_work::{monero_rx::MergeMineError, PowError},
     transactions::transaction_components::TransactionError,
+    validation::dan_validators::DanLayerValidationError,
 };
 
 #[derive(Debug, Error)]
@@ -117,7 +118,7 @@ pub enum ValidationError {
     #[error("Standard transaction contains coinbase output")]
     ErroneousCoinbaseOutput,
     #[error("Digital Asset Network Error: {0}")]
-    DanLayerError(String),
+    DanLayerError(#[from] DanLayerValidationError),
 }
 
 // ChainStorageError has a ValidationError variant, so to prevent a cyclic dependency we use a string representation in

--- a/base_layer/wallet/src/assets/asset_manager.rs
+++ b/base_layer/wallet/src/assets/asset_manager.rs
@@ -28,6 +28,7 @@ use tari_common_types::{
 use tari_core::transactions::transaction_components::{
     CommitteeSignatures,
     ContractAmendment,
+    ContractCheckpoint,
     ContractDefinition,
     ContractUpdateProposal,
     OutputFeatures,
@@ -183,12 +184,12 @@ impl<T: OutputManagerBackend + 'static> AssetManager<T> {
             .output_manager
             .create_output_with_features(
                 10.into(),
-                OutputFeatures::for_checkpoint(
-                    contract_id,
+                OutputFeatures::for_contract_checkpoint(contract_id, ContractCheckpoint {
+                    checkpoint_number: 0,
                     merkle_root,
                     // TODO: add vn signatures
-                    CommitteeSignatures::default(),
-                ),
+                    signatures: CommitteeSignatures::default(),
+                }),
             )
             .await?;
         // TODO: get consensus threshold from somewhere else
@@ -228,18 +229,19 @@ impl<T: OutputManagerBackend + 'static> AssetManager<T> {
     pub async fn create_follow_on_contract_checkpoint(
         &mut self,
         contract_id: FixedHash,
+        checkpoint_number: u64,
         merkle_root: FixedHash,
     ) -> Result<(TxId, Transaction), WalletError> {
         let output = self
             .output_manager
             .create_output_with_features(
                 10.into(),
-                OutputFeatures::for_checkpoint(
-                    contract_id,
+                OutputFeatures::for_contract_checkpoint(contract_id, ContractCheckpoint {
+                    checkpoint_number,
                     merkle_root,
-                    // TODO: Add vn sigs
-                    CommitteeSignatures::default(),
-                ),
+                    // TODO: add vn signatures
+                    signatures: CommitteeSignatures::default(),
+                }),
             )
             .await?;
         // TODO: get consensus threshold from somewhere else

--- a/base_layer/wallet/src/assets/asset_manager_handle.rs
+++ b/base_layer/wallet/src/assets/asset_manager_handle.rs
@@ -105,12 +105,14 @@ impl AssetManagerHandle {
     pub async fn create_follow_on_asset_checkpoint(
         &mut self,
         contract_id: FixedHash,
+        checkpoint_number: u64,
         merkle_root: FixedHash,
     ) -> Result<(TxId, Transaction), WalletError> {
         match self
             .handle
             .call(AssetManagerRequest::CreateFollowOnCheckpoint {
                 contract_id,
+                checkpoint_number,
                 merkle_root,
                 committee_public_keys: Vec::new(),
             })

--- a/base_layer/wallet/src/assets/infrastructure/asset_manager_service.rs
+++ b/base_layer/wallet/src/assets/infrastructure/asset_manager_service.rs
@@ -150,12 +150,13 @@ impl<T: OutputManagerBackend + 'static> AssetManagerService<T> {
             },
             AssetManagerRequest::CreateFollowOnCheckpoint {
                 contract_id,
+                checkpoint_number,
                 merkle_root,
                 committee_public_keys: _pks,
             } => {
                 let (tx_id, transaction) = self
                     .manager
-                    .create_follow_on_contract_checkpoint(contract_id, merkle_root)
+                    .create_follow_on_contract_checkpoint(contract_id, checkpoint_number, merkle_root)
                     .await?;
                 Ok(AssetManagerResponse::CreateFollowOnCheckpoint {
                     transaction: Box::new(transaction),

--- a/base_layer/wallet/src/assets/infrastructure/mod.rs
+++ b/base_layer/wallet/src/assets/infrastructure/mod.rs
@@ -67,6 +67,7 @@ pub enum AssetManagerRequest {
     },
     CreateFollowOnCheckpoint {
         contract_id: FixedHash,
+        checkpoint_number: u64,
         merkle_root: FixedHash,
         committee_public_keys: Vec<PublicKey>,
     },

--- a/base_layer/wallet/tests/output_manager_service_tests/service.rs
+++ b/base_layer/wallet/tests/output_manager_service_tests/service.rs
@@ -43,6 +43,7 @@ use tari_core::{
         test_helpers::{create_unblinded_output, TestParams as TestParamsHelpers},
         transaction_components::{
             CommitteeSignatures,
+            ContractCheckpoint,
             EncryptedValue,
             OutputFeatures,
             OutputType,
@@ -763,10 +764,13 @@ async fn utxo_selection_for_contract_checkpoint() {
         &mut OsRng.clone(),
         amount,
         &factories.commitment,
-        Some(OutputFeatures::for_checkpoint(
+        Some(OutputFeatures::for_contract_checkpoint(
             contract_id,
-            FixedHash::zero(),
-            CommitteeSignatures::empty(),
+            ContractCheckpoint {
+                checkpoint_number: 0,
+                merkle_root: FixedHash::zero(),
+                signatures: CommitteeSignatures::empty(),
+            },
         )),
         oms.clone(),
     )
@@ -795,7 +799,11 @@ async fn utxo_selection_for_contract_checkpoint() {
             // Spend more than the selected contract output, this will cause the other UTXO to be included
             MicroTari::from(2500),
             UtxoSelectionCriteria::for_contract(contract_id, OutputType::ContractCheckpoint),
-            OutputFeatures::for_checkpoint(contract_id, FixedHash::zero(), CommitteeSignatures::empty()),
+            OutputFeatures::for_contract_checkpoint(contract_id, ContractCheckpoint {
+                checkpoint_number: 0,
+                merkle_root: FixedHash::zero(),
+                signatures: CommitteeSignatures::empty(),
+            }),
             fee_per_gram,
             None,
             String::new(),

--- a/dan_layer/core/src/services/mocks/mod.rs
+++ b/dan_layer/core/src/services/mocks/mod.rs
@@ -340,7 +340,7 @@ impl WalletClient for MockWalletClient {
         &mut self,
         _contract_id: &FixedHash,
         _state_root: &StateRoot,
-        _is_initial: bool,
+        _checkpoint_number: u64,
     ) -> Result<(), DigitalAssetError> {
         Ok(())
     }

--- a/dan_layer/core/src/services/wallet_client.rs
+++ b/dan_layer/core/src/services/wallet_client.rs
@@ -31,7 +31,7 @@ pub trait WalletClient: Send + Sync {
         &mut self,
         contract_id: &FixedHash,
         state_root: &StateRoot,
-        is_initial: bool,
+        checkpoint_number: u64,
     ) -> Result<(), DigitalAssetError>;
 
     async fn submit_contract_acceptance(


### PR DESCRIPTION
Description
---
- feat(validator-node): specify checkpoint number in create checkpoint request
- feat(base_layer/wallet): adds checkpoint_number to asset manager
- feat(base_layer/core): adds checkpoint number validation
- feat(base_layer/wallet): adds checkpoint number to proto files
- feat(base_layer/core): adds checkpoint_number to checkpoint

Motivation and Context
---
A checkpoint number provides a sequential ordering of checkpoints that is validated by the base layer. 
This should make dan layer coordination of checkpointing easier and provides an indication of how much checkpoint history has existed on chain.

How Has This Been Tested?
---
New unit tests for the base layer validations
Manually (In progress)
