### PR TITLE
feat: add range proof batch verification to validators

### DIFF
--- a/base_layer/core/src/base_node/sync/horizon_state_sync/error.rs
+++ b/base_layer/core/src/base_node/sync/horizon_state_sync/error.rs
@@ -27,6 +27,7 @@ use tari_comms::{
     peer_manager::NodeId,
     protocol::rpc::{RpcError, RpcStatus},
 };
+use tari_crypto::errors::RangeProofError;
 use tari_mmr::error::MerkleMountainRangeError;
 use thiserror::Error;
 use tokio::task;
@@ -50,6 +51,8 @@ pub enum HorizonSyncError {
     FinalStateValidationFailed(ValidationError),
     #[error("Join error: {0}")]
     JoinError(#[from] task::JoinError),
+    #[error("A range proof verification has produced an error: {0}")]
+    RangeProofError(#[from] RangeProofError),
     #[error("Invalid kernel signature: {0}")]
     InvalidKernelSignature(TransactionError),
     #[error("MMR did not match for {mmr_tree} at height {at_height}. Expected {actual_hex} to equal {expected_hex}")]

--- a/base_layer/core/src/blocks/genesis_block.rs
+++ b/base_layer/core/src/blocks/genesis_block.rs
@@ -318,7 +318,7 @@ mod test {
     use crate::{
         consensus::ConsensusManager,
         test_helpers::blockchain::create_new_blockchain_with_network,
-        transactions::CryptoFactories,
+        transactions::{transaction_components::transaction_output::batch_verify_range_proofs, CryptoFactories},
         validation::{ChainBalanceValidator, FinalHorizonStateValidation},
     };
 
@@ -331,9 +331,8 @@ mod test {
 
         let factories = CryptoFactories::default();
         assert!(block.block().body.outputs().iter().any(|o| o.is_coinbase()));
-        for o in block.block().body.outputs() {
-            o.verify_range_proof(&factories.range_proof).unwrap();
-        }
+        let outputs = block.block().body.outputs().iter().collect::<Vec<_>>();
+        batch_verify_range_proofs(&factories.range_proof, &outputs).unwrap();
         // Coinbase and faucet kernel
         assert_eq!(
             block.block().body.kernels().len() as u64,

--- a/base_layer/core/src/transactions/aggregated_body.rs
+++ b/base_layer/core/src/transactions/aggregated_body.rs
@@ -52,6 +52,7 @@ use crate::{
         crypto_factories::CryptoFactories,
         tari_amount::MicroTari,
         transaction_components::{
+            transaction_output::batch_verify_range_proofs,
             KernelFeatures,
             KernelSum,
             OutputType,
@@ -478,9 +479,8 @@ impl AggregateBody {
 
     fn validate_range_proofs(&self, range_proof_service: &RangeProofService) -> Result<(), TransactionError> {
         trace!(target: LOG_TARGET, "Checking range proofs");
-        for o in &self.outputs {
-            o.verify_range_proof(range_proof_service)?;
-        }
+        let outputs = self.outputs.iter().collect::<Vec<_>>();
+        batch_verify_range_proofs(range_proof_service, &outputs)?;
         Ok(())
     }
 

--- a/base_layer/core/src/transactions/transaction_components/mod.rs
+++ b/base_layer/core/src/transactions/transaction_components/mod.rs
@@ -70,7 +70,7 @@ mod transaction_input;
 mod transaction_input_version;
 mod transaction_kernel;
 mod transaction_kernel_version;
-mod transaction_output;
+pub mod transaction_output;
 mod transaction_output_version;
 mod unblinded_output;
 mod unblinded_output_builder;

--- a/base_layer/core/src/validation/error.rs
+++ b/base_layer/core/src/validation/error.rs
@@ -21,6 +21,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use tari_common_types::types::{FixedHash, HashOutput};
+use tari_crypto::errors::RangeProofError;
 use thiserror::Error;
 use tokio::task;
 
@@ -47,6 +48,8 @@ pub enum ValidationError {
     UnknownInput,
     #[error("The transaction is invalid: {0}")]
     TransactionError(#[from] TransactionError),
+    #[error("A range proof verification has produced an error: {0}")]
+    RangeProofError(#[from] RangeProofError),
     #[error("Error: {0}")]
     CustomError(String),
     #[error("Fatal storage error during validation: {0}")]

--- a/base_layer/core/src/validation/helpers.rs
+++ b/base_layer/core/src/validation/helpers.rs
@@ -793,7 +793,6 @@ pub fn check_blockchain_version(constants: &ConsensusConstants, version: u16) ->
 
 #[cfg(test)]
 mod test {
-
     use tari_test_utils::unpack_enum;
 
     use super::*;

--- a/base_layer/core/tests/helpers/block_builders.rs
+++ b/base_layer/core/tests/helpers/block_builders.rs
@@ -44,6 +44,7 @@ use tari_core::{
             TransactionSchema,
         },
         transaction_components::{
+            transaction_output::batch_verify_range_proofs,
             KernelBuilder,
             KernelFeatures,
             OutputFeatures,
@@ -160,10 +161,9 @@ fn print_new_genesis_block(network: Network) {
     }
     for output in block.body.outputs() {
         output.verify_metadata_signature().unwrap();
-        output
-            .verify_range_proof(&CryptoFactories::default().range_proof)
-            .unwrap();
     }
+    let outputs = block.body.outputs().iter().collect::<Vec<_>>();
+    batch_verify_range_proofs(&CryptoFactories::default().range_proof, &outputs).unwrap();
 
     // Note: This is printed in the same order as needed for 'fn get_dibbler_genesis_block_raw()'
     println!();


### PR DESCRIPTION
Description
---
Added batch verification of range proofs where ever more than one range proof needed to be verified.

Motivation and Context
---
Batch verification range proofs is much faster than running linear proofs

How Has This Been Tested?
---
Unit tests
Integration tests
_System-level tests pending_
