### PR TITLE
feat(dan_layer)!: generate and add checkpoint signatures

### DIFF
--- a/applications/tari_app_grpc/proto/types.proto
+++ b/applications/tari_app_grpc/proto/types.proto
@@ -313,7 +313,12 @@ message ContractAmendment {
 }
 
 message CommitteeSignatures {
-    repeated Signature signatures = 1;
+    repeated SignerSignature signatures = 1;
+}
+
+message SignerSignature {
+    bytes signer = 1;
+    Signature signature = 2;
 }
 
 // TODO: DEPRECATED

--- a/applications/tari_app_grpc/proto/wallet.proto
+++ b/applications/tari_app_grpc/proto/wallet.proto
@@ -271,8 +271,7 @@ message RegisterAssetResponse {
 message CreateInitialAssetCheckpointRequest {
     bytes contract_id = 1;
     bytes merkle_root = 2;
-    repeated bytes committee = 3;
-    CommitteeSignatures committee_signatures = 4;
+    CommitteeSignatures committee_signatures = 3;
 }
 
 message CreateInitialAssetCheckpointResponse {

--- a/applications/tari_app_grpc/proto/wallet.proto
+++ b/applications/tari_app_grpc/proto/wallet.proto
@@ -272,6 +272,7 @@ message CreateInitialAssetCheckpointRequest {
     bytes contract_id = 1;
     bytes merkle_root = 2;
     repeated bytes committee = 3;
+    CommitteeSignatures committee_signatures = 4;
 }
 
 message CreateInitialAssetCheckpointResponse {
@@ -282,6 +283,7 @@ message CreateFollowOnAssetCheckpointRequest {
     uint64 checkpoint_number = 1;
     bytes contract_id = 2;
     bytes merkle_root = 3;
+    CommitteeSignatures committee_signatures = 4;
 }
 
 message CreateFollowOnAssetCheckpointResponse {

--- a/applications/tari_app_grpc/src/conversions/sidechain_features.rs
+++ b/applications/tari_app_grpc/src/conversions/sidechain_features.rs
@@ -20,9 +20,12 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::convert::{TryFrom, TryInto};
+use std::{
+    borrow::Borrow,
+    convert::{TryFrom, TryInto},
+};
 
-use tari_common_types::types::{FixedHash, PublicKey, Signature};
+use tari_common_types::types::{FixedHash, PublicKey};
 use tari_core::transactions::transaction_components::{
     vec_into_fixed_string,
     CheckpointParameters,
@@ -44,6 +47,7 @@ use tari_core::transactions::transaction_components::{
     RequirementsForConstitutionChange,
     SideChainConsensus,
     SideChainFeatures,
+    SignerSignature,
 };
 use tari_utilities::ByteArray;
 
@@ -489,7 +493,7 @@ impl TryFrom<grpc::CommitteeMembers> for CommitteeMembers {
 impl From<CommitteeSignatures> for grpc::CommitteeSignatures {
     fn from(value: CommitteeSignatures) -> Self {
         Self {
-            signatures: value.signatures().into_iter().map(Into::into).collect(),
+            signatures: value.signatures().iter().map(Into::into).collect(),
         }
     }
 }
@@ -511,7 +515,7 @@ impl TryFrom<grpc::CommitteeSignatures> for CommitteeSignatures {
             .into_iter()
             .enumerate()
             .map(|(i, s)| {
-                Signature::try_from(s)
+                SignerSignature::try_from(s)
                     .map_err(|err| format!("committee signature #{} was not a valid signature: {}", i + 1, err))
             })
             .collect::<Result<Vec<_>, _>>()?;
@@ -521,6 +525,29 @@ impl TryFrom<grpc::CommitteeSignatures> for CommitteeSignatures {
     }
 }
 
+//---------------------------------- SignerSignature --------------------------------------------//
+impl<B: Borrow<SignerSignature>> From<B> for grpc::SignerSignature {
+    fn from(value: B) -> Self {
+        Self {
+            signer: value.borrow().signer.to_vec(),
+            signature: Some(grpc::Signature::from(&value.borrow().signature)),
+        }
+    }
+}
+
+impl TryFrom<grpc::SignerSignature> for SignerSignature {
+    type Error = String;
+
+    fn try_from(value: grpc::SignerSignature) -> Result<Self, Self::Error> {
+        Ok(Self {
+            signer: PublicKey::from_bytes(&value.signer).map_err(|err| err.to_string())?,
+            signature: value
+                .signature
+                .map(TryInto::try_into)
+                .ok_or("signature not provided")??,
+        })
+    }
+}
 //---------------------------------- ContractAcceptance --------------------------------------------//
 
 impl From<ContractAcceptance> for grpc::ContractAcceptance {

--- a/applications/tari_app_grpc/src/conversions/signature.rs
+++ b/applications/tari_app_grpc/src/conversions/signature.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::convert::TryFrom;
+use std::{borrow::Borrow, convert::TryFrom};
 
 use tari_common_types::types::{PrivateKey, PublicKey, Signature};
 use tari_utilities::ByteArray;
@@ -39,11 +39,11 @@ impl TryFrom<grpc::Signature> for Signature {
     }
 }
 
-impl From<Signature> for grpc::Signature {
-    fn from(sig: Signature) -> Self {
+impl<T: Borrow<Signature>> From<T> for grpc::Signature {
+    fn from(sig: T) -> Self {
         Self {
-            public_nonce: sig.get_public_nonce().to_vec(),
-            signature: sig.get_signature().to_vec(),
+            public_nonce: sig.borrow().get_public_nonce().to_vec(),
+            signature: sig.borrow().get_signature().to_vec(),
         }
     }
 }

--- a/applications/tari_collectibles/src-tauri/src/clients/wallet_client.rs
+++ b/applications/tari_collectibles/src-tauri/src/clients/wallet_client.rs
@@ -117,12 +117,11 @@ impl WalletClient {
     merkle_root: Vec<u8>,
   ) -> Result<grpc::CreateInitialAssetCheckpointResponse, CollectiblesError> {
     let inner = self.get_inner_mut()?;
-    let committee = vec![];
     let request = grpc::CreateInitialAssetCheckpointRequest {
       // TODO: contract id
       contract_id: Vec::from_hex(asset_public_key)?,
       merkle_root,
-      committee,
+      committee_signatures: None,
     };
     let result = inner
       .create_initial_asset_checkpoint(request)

--- a/applications/tari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/tari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -833,8 +833,10 @@ impl wallet_server::Wallet for WalletGrpcServer {
 
         let committee_signatures = message
             .committee_signatures
-            .try_into()
-            .map_err(|_| Status::invalid_argument("Invalid committee signatures"))?;
+            .map(TryInto::try_into)
+            .transpose()
+            .map_err(|_| Status::invalid_argument("Invalid committee signatures"))?
+            .unwrap_or_default();
 
         let (tx_id, transaction) = asset_manager
             .create_initial_asset_checkpoint(contract_id, merkle_root, committee_signatures)
@@ -872,8 +874,10 @@ impl wallet_server::Wallet for WalletGrpcServer {
 
         let committee_signatures = message
             .committee_signatures
-            .try_into()
-            .map_err(|_| Status::invalid_argument("Invalid committee signatures"))?;
+            .map(TryInto::try_into)
+            .transpose()
+            .map_err(|_| Status::invalid_argument("Invalid committee signatures"))?
+            .unwrap_or_default();
 
         let (tx_id, transaction) = asset_manager
             .create_follow_on_asset_checkpoint(contract_id, checkpoint_number, merkle_root, committee_signatures)

--- a/applications/tari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/tari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -831,8 +831,13 @@ impl wallet_server::Wallet for WalletGrpcServer {
             .try_into()
             .map_err(|_| Status::invalid_argument("Merkle root has an incorrect length"))?;
 
+        let committee_signatures = message
+            .committee_signatures
+            .try_into()
+            .map_err(|_| Status::invalid_argument("Invalid committee signatures"))?;
+
         let (tx_id, transaction) = asset_manager
-            .create_initial_asset_checkpoint(contract_id, merkle_root)
+            .create_initial_asset_checkpoint(contract_id, merkle_root, committee_signatures)
             .await
             .map_err(|e| Status::internal(e.to_string()))?;
 
@@ -865,8 +870,13 @@ impl wallet_server::Wallet for WalletGrpcServer {
             .try_into()
             .map_err(|_| Status::invalid_argument("Incorrect merkle root length"))?;
 
+        let committee_signatures = message
+            .committee_signatures
+            .try_into()
+            .map_err(|_| Status::invalid_argument("Invalid committee signatures"))?;
+
         let (tx_id, transaction) = asset_manager
-            .create_follow_on_asset_checkpoint(contract_id, checkpoint_number, merkle_root)
+            .create_follow_on_asset_checkpoint(contract_id, checkpoint_number, merkle_root, committee_signatures)
             .await
             .map_err(|e| Status::internal(e.to_string()))?;
 

--- a/applications/tari_explorer/partials/CommitteeSignatures.hbs
+++ b/applications/tari_explorer/partials/CommitteeSignatures.hbs
@@ -1,6 +1,8 @@
 <dl>
-  <dt>Signatures</dt>
+{{#if signatures}}
+    <dt>{{signatures.length}} signatures</dt>
   {{#each signatures as |signature|}}
-    <dd>{{>Signature signature}}</dd>
+      <dd>{{>SignerSignature signature}}</dd>
   {{/each}}
+{{/if}}
 </dl>

--- a/applications/tari_explorer/partials/ContractCheckpoint.hbs
+++ b/applications/tari_explorer/partials/ContractCheckpoint.hbs
@@ -1,4 +1,5 @@
 <dl>
+  <dt>Number</dt><dd>{{checkpoint_number}}</dd>
   <dt>Merkle root</dt><dd>{{hex merkle_root}}</dd>
   <dt>Signatures</dt><dd>{{>CommitteeSignatures signatures}}</dd>
 </dl>

--- a/applications/tari_explorer/partials/SignerSignature.hbs
+++ b/applications/tari_explorer/partials/SignerSignature.hbs
@@ -1,0 +1,4 @@
+<dl>
+  <dt>Signer</dt><dd>{{hex signer}}</dd>
+  <dt>Signature</dt><dd>{{>Signature signature}}</dd>
+</dl>

--- a/applications/tari_validator_node/proto/dan/common.proto
+++ b/applications/tari_validator_node/proto/dan/common.proto
@@ -27,3 +27,13 @@ message Instruction {
 message InstructionSet{
   repeated Instruction instructions = 1;
 }
+
+message SignerSignature {
+  bytes signer = 1;
+  Signature signature = 2;
+}
+
+message Signature {
+  bytes public_nonce = 1;
+  bytes signature = 2;
+}

--- a/applications/tari_validator_node/proto/dan/consensus.proto
+++ b/applications/tari_validator_node/proto/dan/consensus.proto
@@ -22,16 +22,17 @@ message HotStuffMessage {
     HotStuffMessageType message_type = 2;
     QuorumCertificate justify = 3;
     HotStuffTreeNode node= 4;
-    Signature partial_sig = 5;
+    ValidatorSignature partial_sig = 5;
     bytes node_hash = 6;
     bytes contract_id = 7;
+    tari.dan.common.SignerSignature checkpoint_signature = 8;
 }
 
 message QuorumCertificate {
     HotStuffMessageType message_type = 1;
     bytes node_hash = 2;
     uint64 view_number = 3;
-    Signature signature = 4;
+    ValidatorSignature signature = 4;
 }
 
 message HotStuffTreeNode {
@@ -41,7 +42,7 @@ message HotStuffTreeNode {
     bytes state_root =4;
 }
 
-message Signature{
+message ValidatorSignature{
 
 }
 

--- a/applications/tari_validator_node/src/contract_worker_manager.rs
+++ b/applications/tari_validator_node/src/contract_worker_manager.rs
@@ -140,9 +140,7 @@ impl ContractWorkerManager {
     pub async fn start(mut self) -> Result<(), WorkerManagerError> {
         self.load_initial_state()?;
 
-        if self.config.constitution_auto_accept {
-            info!("constitution_auto_accept is true");
-        }
+        info!("constitution_auto_accept is {}", self.config.constitution_auto_accept);
 
         if !self.config.scan_for_assets {
             info!(
@@ -180,7 +178,7 @@ impl ContractWorkerManager {
         for contract in active_contracts {
             let contract_id = FixedHash::try_from(contract.contract_id)?;
 
-            println!("Starting contract {}", contract_id.to_hex());
+            println!("Starting contract {}", contract_id);
 
             let constitution = ContractConstitution::from_binary(&*contract.constitution).map_err(|error| {
                 WorkerManagerError::DataCorruption {

--- a/applications/tari_validator_node/src/grpc/services/wallet_client.rs
+++ b/applications/tari_validator_node/src/grpc/services/wallet_client.rs
@@ -23,6 +23,7 @@
 use std::net::SocketAddr;
 
 use async_trait::async_trait;
+use log::*;
 use tari_app_grpc::{
     tari_rpc as grpc,
     tari_rpc::{
@@ -33,9 +34,12 @@ use tari_app_grpc::{
     },
 };
 use tari_common_types::types::{FixedHash, PublicKey, Signature};
+use tari_core::transactions::transaction_components::SignerSignature;
 use tari_crypto::tari_utilities::ByteArray;
 use tari_dan_core::{services::WalletClient, DigitalAssetError};
 use tari_dan_engine::state::models::StateRoot;
+
+const LOG_TARGET: &str = "tari::dan::wallet_grpc";
 
 type Inner = grpc::wallet_client::WalletClient<tonic::transport::Channel>;
 
@@ -69,14 +73,20 @@ impl WalletClient for GrpcWalletClient {
         contract_id: &FixedHash,
         state_root: &StateRoot,
         checkpoint_number: u64,
+        checkpoint_signatures: Vec<SignerSignature>,
     ) -> Result<(), DigitalAssetError> {
         let inner = self.connection().await?;
+        let committee_signatures = grpc::CommitteeSignatures {
+            signatures: checkpoint_signatures.into_iter().map(Into::into).collect(),
+        };
+
+        info!(target: LOG_TARGET, "✅ Creating checkpoint #{}", checkpoint_number);
 
         if checkpoint_number == 0 {
             let request = CreateInitialAssetCheckpointRequest {
                 contract_id: contract_id.to_vec(),
                 merkle_root: state_root.as_bytes().to_vec(),
-                committee: vec![],
+                committee_signatures: Some(committee_signatures),
             };
 
             let _res = inner
@@ -88,6 +98,7 @@ impl WalletClient for GrpcWalletClient {
                 checkpoint_number,
                 contract_id: contract_id.to_vec(),
                 merkle_root: state_root.as_bytes().to_vec(),
+                committee_signatures: Some(committee_signatures),
             };
 
             let _res = inner

--- a/applications/tari_validator_node/src/p2p/proto/conversions.rs
+++ b/applications/tari_validator_node/src/p2p/proto/conversions.rs
@@ -20,9 +20,13 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::convert::{TryFrom, TryInto};
+use std::{
+    borrow::Borrow,
+    convert::{TryFrom, TryInto},
+};
 
-use tari_common_types::types::PublicKey;
+use tari_common_types::types::{PrivateKey, PublicKey, Signature};
+use tari_core::transactions::transaction_components::SignerSignature;
 use tari_crypto::tari_utilities::ByteArray;
 use tari_dan_common_types::TemplateId;
 use tari_dan_core::models::{
@@ -34,9 +38,9 @@ use tari_dan_core::models::{
     Node,
     QuorumCertificate,
     SideChainBlock,
-    Signature,
     TariDanPayload,
     TreeNodeHash,
+    ValidatorSignature,
     ViewId,
 };
 use tari_dan_engine::{
@@ -63,6 +67,7 @@ impl From<HotStuffMessage<TariDanPayload>> for proto::consensus::HotStuffMessage
                 .unwrap_or_else(TreeNodeHash::zero)
                 .as_bytes()
                 .to_vec(),
+            checkpoint_signature: source.checkpoint_signature().map(Into::into),
             contract_id: source.contract_id().to_vec(),
         }
     }
@@ -90,8 +95,8 @@ impl From<QuorumCertificate> for proto::consensus::QuorumCertificate {
     }
 }
 
-impl From<Signature> for proto::consensus::Signature {
-    fn from(_s: Signature) -> Self {
+impl From<ValidatorSignature> for proto::consensus::ValidatorSignature {
+    fn from(_s: ValidatorSignature) -> Self {
         Self {}
     }
 }
@@ -139,6 +144,7 @@ impl TryFrom<proto::consensus::HotStuffMessage> for HotStuffMessage<TariDanPaylo
             value.node.map(|n| n.try_into()).transpose()?,
             node_hash,
             value.partial_sig.map(|p| p.try_into()).transpose()?,
+            value.checkpoint_signature.map(|p| p.try_into()).transpose()?,
             value
                 .contract_id
                 .try_into()
@@ -185,10 +191,10 @@ impl TryFrom<proto::consensus::HotStuffTreeNode> for HotStuffTreeNode<TariDanPay
     }
 }
 
-impl TryFrom<proto::consensus::Signature> for Signature {
+impl TryFrom<proto::consensus::ValidatorSignature> for ValidatorSignature {
     type Error = String;
 
-    fn try_from(_value: proto::consensus::Signature) -> Result<Self, Self::Error> {
+    fn try_from(_value: proto::consensus::ValidatorSignature) -> Result<Self, Self::Error> {
         Ok(Self {})
     }
 }
@@ -364,5 +370,50 @@ impl TryFrom<proto::validator_node::StateOpLog> for StateOpLogEntry {
             value: Some(value.value).filter(|v| !v.is_empty()),
         }
         .into())
+    }
+}
+
+//---------------------------------- SignerSignature --------------------------------------------//
+impl<B: Borrow<SignerSignature>> From<B> for proto::common::SignerSignature {
+    fn from(signature: B) -> Self {
+        Self {
+            signer: signature.borrow().signer().to_vec(),
+            signature: Some(signature.borrow().signature().into()),
+        }
+    }
+}
+
+impl TryFrom<proto::common::SignerSignature> for SignerSignature {
+    type Error = String;
+
+    fn try_from(value: proto::common::SignerSignature) -> Result<Self, Self::Error> {
+        Ok(Self {
+            signer: PublicKey::from_bytes(&value.signer).map_err(|err| err.to_string())?,
+            signature: value
+                .signature
+                .map(TryInto::try_into)
+                .ok_or("signature not provided")??,
+        })
+    }
+}
+
+//---------------------------------- Signature --------------------------------------------//
+impl TryFrom<proto::common::Signature> for Signature {
+    type Error = String;
+
+    fn try_from(sig: proto::common::Signature) -> Result<Self, Self::Error> {
+        let public_nonce = PublicKey::from_bytes(&sig.public_nonce).map_err(|e| e.to_string())?;
+        let signature = PrivateKey::from_bytes(&sig.signature).map_err(|e| e.to_string())?;
+
+        Ok(Self::new(public_nonce, signature))
+    }
+}
+
+impl<T: Borrow<Signature>> From<T> for proto::common::Signature {
+    fn from(sig: T) -> Self {
+        Self {
+            public_nonce: sig.borrow().get_public_nonce().to_vec(),
+            signature: sig.borrow().get_signature().to_vec(),
+        }
     }
 }

--- a/base_layer/core/src/base_node/proto/wallet_rpc.rs
+++ b/base_layer/core/src/base_node/proto/wallet_rpc.rs
@@ -27,7 +27,6 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 use tari_common_types::types::{BlockHash, Signature};
-use tari_utilities::ByteArrayError;
 
 use crate::proto::{base_node as proto, types};
 
@@ -220,8 +219,7 @@ impl TryFrom<proto::TxQueryBatchResponse> for TxQueryBatchResponse {
                 proto_response
                     .signature
                     .ok_or_else(|| "Signature not present".to_string())?,
-            )
-            .map_err(|err: ByteArrayError| err.to_string())?,
+            )?,
             location: TxLocation::try_from(
                 proto::TxLocation::from_i32(proto_response.location)
                     .ok_or_else(|| "Invalid or unrecognised `TxLocation` enum".to_string())?,

--- a/base_layer/core/src/consensus/consensus_encoding/vec.rs
+++ b/base_layer/core/src/consensus/consensus_encoding/vec.rs
@@ -58,6 +58,15 @@ impl<T, const MAX: usize> MaxSizeVec<T, MAX> {
         }
         Some(Self { inner })
     }
+
+    #[must_use = "resulting bool must be checked to ensure that the item was added"]
+    pub fn push(&mut self, item: T) -> bool {
+        if self.inner.len() + 1 > MAX {
+            return false;
+        }
+        self.inner.push(item);
+        true
+    }
 }
 
 impl<T, const MAX: usize> Deref for MaxSizeVec<T, MAX> {

--- a/base_layer/core/src/proto/transaction.proto
+++ b/base_layer/core/src/proto/transaction.proto
@@ -240,7 +240,7 @@ message ContractAmendment {
 }
 
 message CommitteeSignatures {
-    repeated Signature signatures = 1;
+    repeated SignerSignature signatures = 1;
 }
 
 // The components of the block or transaction. The same struct can be used for either, since in Mimblewimble,

--- a/base_layer/core/src/proto/types.proto
+++ b/base_layer/core/src/proto/types.proto
@@ -22,6 +22,12 @@ message Signature {
     bytes signature = 2;
 }
 
+// Signature containing the signer that signed it
+message SignerSignature {
+    bytes signer = 1;
+    Signature signature = 2;
+}
+
 // Define the explicit ComSignature implementation for the Tari base layer. A different signature scheme can be
 // employed by redefining this type.
 message ComSignature {

--- a/base_layer/core/src/transactions/transaction_components/output_features.rs
+++ b/base_layer/core/src/transactions/transaction_components/output_features.rs
@@ -560,6 +560,7 @@ mod test {
             ContractUpdateProposalAcceptance,
             FunctionRef,
             PublicFunction,
+            SignerSignature,
         },
     };
 
@@ -647,7 +648,7 @@ mod test {
                     validator_committee: vec![PublicKey::default(); CommitteeMembers::MAX_MEMBERS]
                         .try_into()
                         .unwrap(),
-                    validator_signatures: vec![Signature::default(); CommitteeSignatures::MAX_SIGNATURES]
+                    validator_signatures: vec![SignerSignature::default(); CommitteeSignatures::MAX_SIGNATURES]
                         .try_into()
                         .unwrap(),
                     updated_constitution: constitution,
@@ -656,7 +657,7 @@ mod test {
                 checkpoint: Some(ContractCheckpoint {
                     checkpoint_number: u64::MAX,
                     merkle_root: FixedHash::zero(),
-                    signatures: vec![Signature::default(); 512].try_into().unwrap(),
+                    signatures: vec![SignerSignature::default(); 512].try_into().unwrap(),
                 }),
             }),
             // Deprecated
@@ -793,7 +794,7 @@ mod test {
         let checkpoint = ContractCheckpoint {
             checkpoint_number: 123,
             merkle_root: hash,
-            signatures: vec![Signature::default()].try_into().unwrap(),
+            signatures: vec![SignerSignature::default()].try_into().unwrap(),
         };
 
         let features = OutputFeatures::for_contract_checkpoint(contract_id, checkpoint.clone());

--- a/base_layer/core/src/transactions/transaction_components/side_chain/contract_checkpoint.rs
+++ b/base_layer/core/src/transactions/transaction_components/side_chain/contract_checkpoint.rs
@@ -62,17 +62,18 @@ impl ConsensusDecoding for ContractCheckpoint {
 mod tests {
     use std::convert::TryInto;
 
-    use tari_common_types::types::Signature;
-
     use super::*;
-    use crate::consensus::check_consensus_encoding_correctness;
+    use crate::{
+        consensus::check_consensus_encoding_correctness,
+        transactions::transaction_components::SignerSignature,
+    };
 
     #[test]
     fn it_encodes_and_decodes_correctly() {
         let subject = ContractCheckpoint {
             checkpoint_number: u64::MAX,
             merkle_root: FixedHash::zero(),
-            signatures: vec![Signature::default(); 512].try_into().unwrap(),
+            signatures: vec![SignerSignature::default(); 512].try_into().unwrap(),
         };
         check_consensus_encoding_correctness(subject).unwrap();
     }

--- a/base_layer/core/src/transactions/transaction_components/side_chain/mod.rs
+++ b/base_layer/core/src/transactions/transaction_components/side_chain/mod.rs
@@ -58,6 +58,9 @@ pub use committee_members::CommitteeMembers;
 mod committee_signatures;
 pub use committee_signatures::CommitteeSignatures;
 
+mod signer_signature;
+pub use signer_signature::SignerSignature;
+
 mod sidechain_features;
 pub use sidechain_features::{SideChainFeatures, SideChainFeaturesBuilder};
 

--- a/base_layer/core/src/transactions/transaction_components/side_chain/sidechain_features.rs
+++ b/base_layer/core/src/transactions/transaction_components/side_chain/sidechain_features.rs
@@ -176,6 +176,7 @@ mod tests {
             PublicFunction,
             RequirementsForConstitutionChange,
             SideChainConsensus,
+            SignerSignature,
         },
     };
 
@@ -253,7 +254,7 @@ mod tests {
                 validator_committee: vec![PublicKey::default(); CommitteeMembers::MAX_MEMBERS]
                     .try_into()
                     .unwrap(),
-                validator_signatures: vec![Signature::default(); CommitteeSignatures::MAX_SIGNATURES]
+                validator_signatures: vec![SignerSignature::default(); CommitteeSignatures::MAX_SIGNATURES]
                     .try_into()
                     .unwrap(),
                 updated_constitution: constitution,
@@ -262,7 +263,7 @@ mod tests {
             checkpoint: Some(ContractCheckpoint {
                 checkpoint_number: u64::MAX,
                 merkle_root: FixedHash::zero(),
-                signatures: vec![Signature::default(); 512].try_into().unwrap(),
+                signatures: vec![SignerSignature::default(); 512].try_into().unwrap(),
             }),
         };
 

--- a/base_layer/core/src/transactions/transaction_components/side_chain/signer_signature.rs
+++ b/base_layer/core/src/transactions/transaction_components/side_chain/signer_signature.rs
@@ -1,0 +1,101 @@
+//  Copyright 2022. The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::io;
+
+use digest::Digest;
+use rand::rngs::OsRng;
+use serde::{Deserialize, Serialize};
+use tari_common_types::types::{HashDigest, PrivateKey, PublicKey, Signature};
+use tari_crypto::keys::PublicKey as PublicKeyT;
+use tari_utilities::ByteArray;
+
+use crate::consensus::{ConsensusDecoding, ConsensusEncoding, ConsensusEncodingSized};
+
+#[derive(Debug, Clone, Hash, PartialEq, Deserialize, Serialize, Eq, Default)]
+pub struct SignerSignature {
+    pub signer: PublicKey,
+    pub signature: Signature,
+}
+
+impl SignerSignature {
+    pub fn new(signer: PublicKey, signature: Signature) -> Self {
+        Self { signer, signature }
+    }
+
+    pub fn sign<C: AsRef<[u8]>>(signer_secret: &PrivateKey, challenge: C) -> Self {
+        let signer = PublicKey::from_secret_key(signer_secret);
+        let (nonce, public_nonce) = PublicKey::random_keypair(&mut OsRng);
+        // TODO: Use domain-seperated hasher from tari_crypto
+        let final_challenge = HashDigest::new()
+            .chain(signer.as_bytes())
+            .chain(public_nonce.as_bytes())
+            .chain(challenge)
+            .finalize();
+        let signature =
+            Signature::sign(signer_secret.clone(), nonce, &*final_challenge).expect("challenge is the correct length");
+        Self { signer, signature }
+    }
+
+    pub fn signer(&self) -> &PublicKey {
+        &self.signer
+    }
+
+    pub fn signature(&self) -> &Signature {
+        &self.signature
+    }
+}
+
+impl ConsensusEncoding for SignerSignature {
+    fn consensus_encode<W: io::Write>(&self, writer: &mut W) -> Result<(), io::Error> {
+        self.signer.consensus_encode(writer)?;
+        self.signature.consensus_encode(writer)?;
+        Ok(())
+    }
+}
+
+impl ConsensusEncodingSized for SignerSignature {
+    fn consensus_encode_exact_size(&self) -> usize {
+        32 + 64
+    }
+}
+
+impl ConsensusDecoding for SignerSignature {
+    fn consensus_decode<R: io::Read>(reader: &mut R) -> Result<Self, io::Error> {
+        Ok(Self {
+            signer: PublicKey::consensus_decode(reader)?,
+            signature: Signature::consensus_decode(reader)?,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::consensus::check_consensus_encoding_correctness;
+
+    #[test]
+    fn it_encodes_and_decodes_correctly() {
+        let subject = SignerSignature::default();
+        check_consensus_encoding_correctness(subject).unwrap();
+    }
+}

--- a/base_layer/core/src/transactions/transaction_protocol/proto/recipient_signed_message.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/proto/recipient_signed_message.rs
@@ -42,8 +42,7 @@ impl TryFrom<proto::RecipientSignedMessage> for RecipientSignedMessage {
         let partial_signature = message
             .partial_signature
             .map(TryInto::try_into)
-            .ok_or_else(|| "Transaction partial signature not provided".to_string())?
-            .map_err(|err| format!("{}", err))?;
+            .ok_or_else(|| "Transaction partial signature not provided".to_string())??;
 
         Ok(Self {
             tx_id: message.tx_id.into(),

--- a/base_layer/core/src/validation/dan_validators/test_helpers.rs
+++ b/base_layer/core/src/validation/dan_validators/test_helpers.rs
@@ -49,6 +49,7 @@ use crate::{
             OutputFeatures,
             RequirementsForConstitutionChange,
             SideChainConsensus,
+            SignerSignature,
             Transaction,
             UnblindedOutput,
         },
@@ -273,7 +274,7 @@ pub fn create_contract_amendment_schema(
         proposal_id,
         updated_constitution: updated_constitution.clone(),
         validator_committee: updated_constitution.validator_committee,
-        validator_signatures: vec![Signature::default()].try_into().unwrap(),
+        validator_signatures: vec![SignerSignature::default()].try_into().unwrap(),
         activation_window: 100,
     };
 

--- a/base_layer/wallet/src/assets/asset_manager.rs
+++ b/base_layer/wallet/src/assets/asset_manager.rs
@@ -179,6 +179,7 @@ impl<T: OutputManagerBackend + 'static> AssetManager<T> {
         &mut self,
         contract_id: FixedHash,
         merkle_root: FixedHash,
+        committee_signatures: CommitteeSignatures,
     ) -> Result<(TxId, Transaction), WalletError> {
         let output = self
             .output_manager
@@ -187,8 +188,7 @@ impl<T: OutputManagerBackend + 'static> AssetManager<T> {
                 OutputFeatures::for_contract_checkpoint(contract_id, ContractCheckpoint {
                     checkpoint_number: 0,
                     merkle_root,
-                    // TODO: add vn signatures
-                    signatures: CommitteeSignatures::default(),
+                    signatures: committee_signatures,
                 }),
             )
             .await?;
@@ -231,6 +231,7 @@ impl<T: OutputManagerBackend + 'static> AssetManager<T> {
         contract_id: FixedHash,
         checkpoint_number: u64,
         merkle_root: FixedHash,
+        committee_signatures: CommitteeSignatures,
     ) -> Result<(TxId, Transaction), WalletError> {
         let output = self
             .output_manager
@@ -239,8 +240,7 @@ impl<T: OutputManagerBackend + 'static> AssetManager<T> {
                 OutputFeatures::for_contract_checkpoint(contract_id, ContractCheckpoint {
                     checkpoint_number,
                     merkle_root,
-                    // TODO: add vn signatures
-                    signatures: CommitteeSignatures::default(),
+                    signatures: committee_signatures,
                 }),
             )
             .await?;

--- a/base_layer/wallet/src/assets/asset_manager_handle.rs
+++ b/base_layer/wallet/src/assets/asset_manager_handle.rs
@@ -25,6 +25,7 @@ use tari_common_types::{
     types::{Commitment, FixedHash, PublicKey, Signature},
 };
 use tari_core::transactions::transaction_components::{
+    CommitteeSignatures,
     ContractAmendment,
     ContractDefinition,
     ContractUpdateProposal,
@@ -84,13 +85,14 @@ impl AssetManagerHandle {
         &mut self,
         contract_id: FixedHash,
         merkle_root: FixedHash,
+        committee_signatures: CommitteeSignatures,
     ) -> Result<(TxId, Transaction), WalletError> {
         match self
             .handle
             .call(AssetManagerRequest::CreateInitialCheckpoint {
                 contract_id,
                 merkle_root,
-                committee_public_keys: Vec::new(),
+                committee_signatures,
             })
             .await??
         {
@@ -107,6 +109,7 @@ impl AssetManagerHandle {
         contract_id: FixedHash,
         checkpoint_number: u64,
         merkle_root: FixedHash,
+        committee_signatures: CommitteeSignatures,
     ) -> Result<(TxId, Transaction), WalletError> {
         match self
             .handle
@@ -114,7 +117,7 @@ impl AssetManagerHandle {
                 contract_id,
                 checkpoint_number,
                 merkle_root,
-                committee_public_keys: Vec::new(),
+                committee_signatures,
             })
             .await??
         {

--- a/base_layer/wallet/src/assets/infrastructure/asset_manager_service.rs
+++ b/base_layer/wallet/src/assets/infrastructure/asset_manager_service.rs
@@ -137,11 +137,11 @@ impl<T: OutputManagerBackend + 'static> AssetManagerService<T> {
             AssetManagerRequest::CreateInitialCheckpoint {
                 contract_id,
                 merkle_root,
-                committee_public_keys: _pks,
+                committee_signatures,
             } => {
                 let (tx_id, transaction) = self
                     .manager
-                    .create_initial_asset_checkpoint(contract_id, merkle_root)
+                    .create_initial_asset_checkpoint(contract_id, merkle_root, committee_signatures)
                     .await?;
                 Ok(AssetManagerResponse::CreateInitialCheckpoint {
                     transaction: Box::new(transaction),
@@ -152,11 +152,16 @@ impl<T: OutputManagerBackend + 'static> AssetManagerService<T> {
                 contract_id,
                 checkpoint_number,
                 merkle_root,
-                committee_public_keys: _pks,
+                committee_signatures,
             } => {
                 let (tx_id, transaction) = self
                     .manager
-                    .create_follow_on_contract_checkpoint(contract_id, checkpoint_number, merkle_root)
+                    .create_follow_on_contract_checkpoint(
+                        contract_id,
+                        checkpoint_number,
+                        merkle_root,
+                        committee_signatures,
+                    )
                     .await?;
                 Ok(AssetManagerResponse::CreateFollowOnCheckpoint {
                     transaction: Box::new(transaction),

--- a/base_layer/wallet/src/assets/infrastructure/mod.rs
+++ b/base_layer/wallet/src/assets/infrastructure/mod.rs
@@ -27,6 +27,7 @@ use tari_common_types::{
     types::{Commitment, FixedHash, PublicKey, Signature},
 };
 use tari_core::transactions::transaction_components::{
+    CommitteeSignatures,
     ContractAmendment,
     ContractDefinition,
     ContractUpdateProposal,
@@ -63,13 +64,13 @@ pub enum AssetManagerRequest {
     CreateInitialCheckpoint {
         contract_id: FixedHash,
         merkle_root: FixedHash,
-        committee_public_keys: Vec<PublicKey>,
+        committee_signatures: CommitteeSignatures,
     },
     CreateFollowOnCheckpoint {
         contract_id: FixedHash,
         checkpoint_number: u64,
         merkle_root: FixedHash,
-        committee_public_keys: Vec<PublicKey>,
+        committee_signatures: CommitteeSignatures,
     },
     CreateConstitutionDefinition {
         constitution_definition: Box<SideChainFeatures>,

--- a/dan_layer/core/src/models/mod.rs
+++ b/dan_layer/core/src/models/mod.rs
@@ -25,6 +25,7 @@ use std::{convert::TryFrom, fmt::Debug, hash::Hash};
 mod asset_definition;
 mod base_layer_metadata;
 mod base_layer_output;
+mod checkpoint_challenge;
 mod committee;
 pub mod domain_events;
 mod error;
@@ -44,6 +45,7 @@ mod view_id;
 pub use asset_definition::{AssetDefinition, InitialState};
 pub use base_layer_metadata::BaseLayerMetadata;
 pub use base_layer_output::{BaseLayerOutput, CheckpointOutput, CommitteeOutput};
+pub use checkpoint_challenge::CheckpointChallenge;
 pub use committee::Committee;
 pub use error::ModelError;
 pub use hot_stuff_message::HotStuffMessage;
@@ -156,14 +158,14 @@ pub enum ConsensusWorkerState {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct Signature {}
+pub struct ValidatorSignature {}
 
-impl Signature {
+impl ValidatorSignature {
     pub fn from_bytes(_source: &[u8]) -> Self {
         Self {}
     }
 
-    pub fn combine(&self, other: &Signature) -> Signature {
+    pub fn combine(&self, other: &ValidatorSignature) -> ValidatorSignature {
         other.clone()
     }
 

--- a/dan_layer/core/src/models/quorum_certificate.rs
+++ b/dan_layer/core/src/models/quorum_certificate.rs
@@ -21,7 +21,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{
-    models::{HotStuffMessageType, Signature, TreeNodeHash, ViewId},
+    models::{HotStuffMessageType, TreeNodeHash, ValidatorSignature, ViewId},
     storage::chain::DbQc,
 };
 
@@ -30,7 +30,7 @@ pub struct QuorumCertificate {
     message_type: HotStuffMessageType,
     node_hash: TreeNodeHash,
     view_number: ViewId,
-    signature: Option<Signature>,
+    signatures: Option<ValidatorSignature>,
 }
 
 impl QuorumCertificate {
@@ -38,13 +38,13 @@ impl QuorumCertificate {
         message_type: HotStuffMessageType,
         view_number: ViewId,
         node_hash: TreeNodeHash,
-        signature: Option<Signature>,
+        signature: Option<ValidatorSignature>,
     ) -> Self {
         Self {
             message_type,
             node_hash,
             view_number,
-            signature,
+            signatures: signature,
         }
     }
 
@@ -53,7 +53,7 @@ impl QuorumCertificate {
             message_type: HotStuffMessageType::Genesis,
             node_hash,
             view_number: 0.into(),
-            signature: None,
+            signatures: None,
         }
     }
 
@@ -69,12 +69,12 @@ impl QuorumCertificate {
         self.message_type
     }
 
-    pub fn signature(&self) -> Option<&Signature> {
-        self.signature.as_ref()
+    pub fn signature(&self) -> Option<&ValidatorSignature> {
+        self.signatures.as_ref()
     }
 
-    pub fn combine_sig(&mut self, partial_sig: &Signature) {
-        self.signature = match &self.signature {
+    pub fn combine_sig(&mut self, partial_sig: &ValidatorSignature) {
+        self.signatures = match &self.signatures {
             None => Some(partial_sig.clone()),
             Some(s) => Some(s.combine(partial_sig)),
         };
@@ -92,7 +92,7 @@ impl From<DbQc> for QuorumCertificate {
             message_type: rec.message_type,
             node_hash: rec.node_hash,
             view_number: rec.view_number,
-            signature: rec.signature,
+            signatures: rec.signature,
         }
     }
 }

--- a/dan_layer/core/src/services/checkpoint_manager.rs
+++ b/dan_layer/core/src/services/checkpoint_manager.rs
@@ -22,6 +22,7 @@
 
 use async_trait::async_trait;
 use log::*;
+use tari_core::transactions::transaction_components::SignerSignature;
 use tari_dan_engine::state::models::StateRoot;
 
 use crate::{models::AssetDefinition, services::wallet_client::WalletClient, DigitalAssetError};
@@ -30,7 +31,11 @@ const LOG_TARGET: &str = "tari::dan::checkpoint_manager";
 
 #[async_trait]
 pub trait CheckpointManager {
-    async fn create_checkpoint(&mut self, state_root: StateRoot) -> Result<(), DigitalAssetError>;
+    async fn create_checkpoint(
+        &mut self,
+        state_root: StateRoot,
+        signature: Vec<SignerSignature>,
+    ) -> Result<(), DigitalAssetError>;
 }
 
 #[derive(Default)]
@@ -54,7 +59,11 @@ impl<TWallet: WalletClient> ConcreteCheckpointManager<TWallet> {
 
 #[async_trait]
 impl<TWallet: WalletClient + Sync + Send> CheckpointManager for ConcreteCheckpointManager<TWallet> {
-    async fn create_checkpoint(&mut self, state_root: StateRoot) -> Result<(), DigitalAssetError> {
+    async fn create_checkpoint(
+        &mut self,
+        state_root: StateRoot,
+        signatures: Vec<SignerSignature>,
+    ) -> Result<(), DigitalAssetError> {
         if self.num_calls == 0 || self.num_calls >= self.checkpoint_interval {
             // TODO: fetch and increment checkpoint number
             let checkpoint_number = u64::from(self.num_calls / self.checkpoint_interval);
@@ -63,7 +72,12 @@ impl<TWallet: WalletClient + Sync + Send> CheckpointManager for ConcreteCheckpoi
                 "Creating checkpoint for contract {}", self.asset_definition.contract_id
             );
             self.wallet
-                .create_new_checkpoint(&self.asset_definition.contract_id, &state_root, checkpoint_number)
+                .create_new_checkpoint(
+                    &self.asset_definition.contract_id,
+                    &state_root,
+                    checkpoint_number,
+                    signatures,
+                )
                 .await?;
         }
         self.num_calls += 1;

--- a/dan_layer/core/src/services/mocks/mod.rs
+++ b/dan_layer/core/src/services/mocks/mod.rs
@@ -28,7 +28,10 @@ use std::{
 
 use async_trait::async_trait;
 use tari_common_types::types::{FixedHash, PublicKey};
-use tari_core::{chain_storage::UtxoMinedInfo, transactions::transaction_components::OutputType};
+use tari_core::{
+    chain_storage::UtxoMinedInfo,
+    transactions::transaction_components::{OutputType, SignerSignature},
+};
 use tari_crypto::ristretto::RistrettoPublicKey;
 use tari_dan_common_types::TemplateId;
 #[cfg(test)]
@@ -56,9 +59,9 @@ use crate::{
         Payload,
         SideChainBlock,
         SidechainMetadata,
-        Signature,
         TariDanPayload,
         TreeNodeHash,
+        ValidatorSignature,
     },
     services::{
         base_node_client::BaseNodeClient,
@@ -207,8 +210,8 @@ pub struct MockSigningService<TAddr: NodeAddressable> {
 }
 
 impl<TAddr: NodeAddressable> SigningService<TAddr> for MockSigningService<TAddr> {
-    fn sign(&self, _identity: &TAddr, _challenge: &[u8]) -> Result<Signature, DigitalAssetError> {
-        Ok(Signature {})
+    fn sign(&self, _identity: &TAddr, _challenge: &[u8]) -> Result<ValidatorSignature, DigitalAssetError> {
+        Ok(ValidatorSignature {})
     }
 }
 
@@ -342,6 +345,7 @@ impl WalletClient for MockWalletClient {
         _contract_id: &FixedHash,
         _state_root: &StateRoot,
         _checkpoint_number: u64,
+        _checkpoint_signatures: Vec<SignerSignature>,
     ) -> Result<(), DigitalAssetError> {
         Ok(())
     }

--- a/dan_layer/core/src/services/signing_service.rs
+++ b/dan_layer/core/src/services/signing_service.rs
@@ -26,12 +26,12 @@ use tari_comms::{types::CommsPublicKey, NodeIdentity};
 
 use crate::{
     digital_assets_error::DigitalAssetError,
-    models::Signature,
+    models::ValidatorSignature,
     services::infrastructure_services::NodeAddressable,
 };
 
 pub trait SigningService<TAddr: NodeAddressable> {
-    fn sign(&self, identity: &TAddr, challenge: &[u8]) -> Result<Signature, DigitalAssetError>;
+    fn sign(&self, identity: &TAddr, challenge: &[u8]) -> Result<ValidatorSignature, DigitalAssetError>;
 }
 
 pub struct NodeIdentitySigningService {
@@ -45,12 +45,12 @@ impl NodeIdentitySigningService {
 }
 
 impl SigningService<CommsPublicKey> for NodeIdentitySigningService {
-    fn sign(&self, identity: &CommsPublicKey, _challenge: &[u8]) -> Result<Signature, DigitalAssetError> {
+    fn sign(&self, identity: &CommsPublicKey, _challenge: &[u8]) -> Result<ValidatorSignature, DigitalAssetError> {
         if identity != self.node_identity.public_key() {
             return Err(DigitalAssetError::InvalidSignature);
         }
 
         // TODO better sig
-        Ok(Signature {})
+        Ok(ValidatorSignature {})
     }
 }

--- a/dan_layer/core/src/storage/chain/db_qc.rs
+++ b/dan_layer/core/src/storage/chain/db_qc.rs
@@ -20,12 +20,12 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::models::{HotStuffMessageType, Signature, TreeNodeHash, ViewId};
+use crate::models::{HotStuffMessageType, TreeNodeHash, ValidatorSignature, ViewId};
 
 #[derive(Debug, Clone)]
 pub struct DbQc {
     pub message_type: HotStuffMessageType,
     pub view_number: ViewId,
     pub node_hash: TreeNodeHash,
-    pub signature: Option<Signature>,
+    pub signature: Option<ValidatorSignature>,
 }

--- a/dan_layer/core/src/workers/consensus_worker.rs
+++ b/dan_layer/core/src/workers/consensus_worker.rs
@@ -312,9 +312,10 @@ impl<'a, T: ServiceSpecification<Addr = PublicKey>> ConsensusWorkerProcessor<'a,
         unit_of_work.commit()?;
         if let Some(mut state_tx) = self.worker.state_db_unit_of_work.take() {
             state_tx.commit()?;
+            let signatures = state.collected_checkpoint_signatures();
             self.worker
                 .checkpoint_manager
-                .create_checkpoint(state_tx.calculate_root()?)
+                .create_checkpoint(state_tx.calculate_root()?, signatures)
                 .await?;
             Ok(res)
         } else {

--- a/dan_layer/core/src/workers/states/decide_state.rs
+++ b/dan_layer/core/src/workers/states/decide_state.rs
@@ -24,6 +24,7 @@ use std::collections::HashMap;
 
 use log::*;
 use tari_common_types::types::FixedHash;
+use tari_core::transactions::transaction_components::SignerSignature;
 use tari_utilities::hex::Hex;
 use tokio::time::{sleep, Duration};
 
@@ -114,6 +115,7 @@ impl<TSpecification: ServiceSpecification> DecideState<TSpecification> {
             warn!(target: LOG_TARGET, "Already received message from {:?}", &sender);
             return Ok(None);
         }
+        debug!(target: LOG_TARGET, "MSG={:?}", message);
 
         self.received_new_view_messages.insert(sender.clone(), message);
 
@@ -218,5 +220,12 @@ impl<TSpecification: ServiceSpecification> DecideState<TSpecification> {
             warn!(target: LOG_TARGET, "received non justify message");
             Ok(None)
         }
+    }
+
+    pub fn collected_checkpoint_signatures(&self) -> Vec<SignerSignature> {
+        self.received_new_view_messages
+            .values()
+            .filter_map(|msg| msg.checkpoint_signature().cloned())
+            .collect()
     }
 }

--- a/dan_layer/storage_sqlite/src/sqlite_chain_backend_adapter.rs
+++ b/dan_layer/storage_sqlite/src/sqlite_chain_backend_adapter.rs
@@ -25,7 +25,7 @@ use std::convert::{TryFrom, TryInto};
 use diesel::{prelude::*, Connection, SqliteConnection};
 use log::*;
 use tari_dan_core::{
-    models::{HotStuffMessageType, QuorumCertificate, Signature, TariDanPayload, TreeNodeHash, ViewId},
+    models::{HotStuffMessageType, QuorumCertificate, TariDanPayload, TreeNodeHash, ValidatorSignature, ViewId},
     storage::chain::{ChainDbBackendAdapter, DbInstruction, DbNode, DbQc},
 };
 use tari_utilities::ByteArray;
@@ -273,7 +273,7 @@ impl ChainDbBackendAdapter for SqliteChainBackendAdapter {
                 HotStuffMessageType::try_from(u8::try_from(qc.message_type).unwrap()).unwrap(),
                 ViewId::from(qc.view_number as u64),
                 qc.node_hash.try_into()?,
-                qc.signature.map(|s| Signature::from_bytes(s.as_slice())),
+                qc.signature.map(|s| ValidatorSignature::from_bytes(s.as_slice())),
             ))
         })
         .transpose()
@@ -336,7 +336,7 @@ impl ChainDbBackendAdapter for SqliteChainBackendAdapter {
             HotStuffMessageType::try_from(u8::try_from(qc.message_type).unwrap()).unwrap(),
             ViewId::from(qc.view_number as u64),
             qc.node_hash.try_into()?,
-            qc.signature.map(|s| Signature::from_bytes(s.as_slice())),
+            qc.signature.map(|s| ValidatorSignature::from_bytes(s.as_slice())),
         ))
     }
 
@@ -355,7 +355,7 @@ impl ChainDbBackendAdapter for SqliteChainBackendAdapter {
             HotStuffMessageType::try_from(u8::try_from(qc.message_type).unwrap()).unwrap(),
             ViewId::from(qc.view_number as u64),
             qc.node_hash.try_into()?,
-            qc.signature.map(|s| Signature::from_bytes(s.as_slice())),
+            qc.signature.map(|s| ValidatorSignature::from_bytes(s.as_slice())),
         ))
     }
 

--- a/integration_tests/fixtures/contract_amendment.json
+++ b/integration_tests/fixtures/contract_amendment.json
@@ -7,16 +7,25 @@
   ],
   "validator_signatures": [
     {
-      "public_nonce": "3431860a4f70ddd6748d759cf66179321809e1c120a97cbdbbf2c01af5c8802f",
-      "signature": "be1b1e7cd18210bfced717d39bebc2534b31274976fb141856d9ee2bfe571900"
+      "signer": "ccac168b8edd67b10d152d1ed2337efc65da9fc0b6256dd49b3c559032553d44",
+      "signature": {
+        "public_nonce": "3431860a4f70ddd6748d759cf66179321809e1c120a97cbdbbf2c01af5c8802f",
+        "signature": "be1b1e7cd18210bfced717d39bebc2534b31274976fb141856d9ee2bfe571900"
+      }
     },
     {
-      "public_nonce": "3431860a4f70ddd6748d759cf66179321809e1c120a97cbdbbf2c01af5c8802f",
-      "signature": "be1b1e7cd18210bfced717d39bebc2534b31274976fb141856d9ee2bfe571900"
+      "signer": "ccac168b8edd67b10d152d1ed2337efc65da9fc0b6256dd49b3c559032553d44",
+      "signature": {
+        "public_nonce": "3431860a4f70ddd6748d759cf66179321809e1c120a97cbdbbf2c01af5c8802f",
+        "signature": "be1b1e7cd18210bfced717d39bebc2534b31274976fb141856d9ee2bfe571900"
+      }
     },
     {
-      "public_nonce": "3431860a4f70ddd6748d759cf66179321809e1c120a97cbdbbf2c01af5c8802f",
-      "signature": "be1b1e7cd18210bfced717d39bebc2534b31274976fb141856d9ee2bfe571900"
+      "signer": "ccac168b8edd67b10d152d1ed2337efc65da9fc0b6256dd49b3c559032553d44",
+      "signature": {
+        "public_nonce": "3431860a4f70ddd6748d759cf66179321809e1c120a97cbdbbf2c01af5c8802f",
+        "signature": "be1b1e7cd18210bfced717d39bebc2534b31274976fb141856d9ee2bfe571900"
+      }
     }
   ],
   "updated_constitution": {


### PR DESCRIPTION
Description
---
- feat(dan_layer): generate and add checkpoint signatures
- feat(explorer): update text explorer to include signatures
-  feat(base_layer/wallet): update wallet command file formats
-  feat(base_layer/core): wires up committee signatures to grpc with conversions
-  feat(base_layer/core): adds SignerSignature struct for CommitteeSignatures
-  feat(base_layer/wallet): include committee signatures for checkpoint GRPC requests

Motivation and Context
---
DAN committees need to collect signatures to include in checkpoints. This PR adds the initial implementation of that.
The signature challenge is: 

`e = H_1(signer_public_key || public_nonce || H_2(contract_id||commitment||merkle_root||checkpoint_number))`

Although constructing a challenge with actual data is a TODO as that involves a bit of a refactor.

This PR also adds the `SignerSignature` struct that includes the signing public key along with the Schnorr signature tuple `<R, s>`. This is so that we know which if the validators signed. There may be an aggregate signature scheme that allows this.

How Has This Been Tested?
---
Manually, initial checkpoint contains signature.
