### PR TITLE
feat(wallet_ffi): added 2 functions, wallet_preview_coin_split and wallet_preview_coin_join

### DIFF
--- a/base_layer/wallet/src/output_manager_service/handle.rs
+++ b/base_layer/wallet/src/output_manager_service/handle.rs
@@ -110,6 +110,8 @@ pub enum OutputManagerRequest {
     RevalidateTxos,
     CreateCoinSplit((Vec<Commitment>, MicroTari, usize, MicroTari)),
     CreateCoinSplitEven((Vec<Commitment>, usize, MicroTari)),
+    PreviewCoinJoin((Vec<Commitment>, MicroTari)),
+    PreviewCoinSplitEven((Vec<Commitment>, usize, MicroTari)),
     CreateCoinJoin {
         commitments: Vec<Commitment>,
         fee_per_gram: MicroTari,
@@ -177,6 +179,16 @@ impl fmt::Display for OutputManagerRequest {
             GetInvalidOutputs => write!(f, "GetInvalidOutputs"),
             ValidateUtxos => write!(f, "ValidateUtxos"),
             RevalidateTxos => write!(f, "RevalidateTxos"),
+            PreviewCoinJoin((commitments, fee_per_gram)) => write!(
+                f,
+                "PreviewCoinJoin(commitments={:#?}, fee_per_gram={})",
+                commitments, fee_per_gram
+            ),
+            PreviewCoinSplitEven((commitments, number_of_splits, fee_per_gram)) => write!(
+                f,
+                "PreviewCoinSplitEven(commitments={:#?}, number_of_splits={}, fee_per_gram={})",
+                commitments, number_of_splits, fee_per_gram
+            ),
             CreateCoinSplit(v) => write!(f, "CreateCoinSplit ({:?})", v.0),
             CreateCoinSplitEven(v) => write!(f, "CreateCoinSplitEven ({:?})", v.0),
             CreateCoinJoin {
@@ -272,6 +284,7 @@ pub enum OutputManagerResponse {
     CoinbaseAbandonedSet,
     ClaimHtlcTransaction((TxId, MicroTari, MicroTari, Transaction)),
     OutputStatusesByTxId(OutputStatusesByTxId),
+    CoinPreview((Vec<MicroTari>, MicroTari)),
 }
 
 pub type OutputManagerEventSender = broadcast::Sender<Arc<OutputManagerEvent>>;
@@ -669,6 +682,41 @@ impl OutputManagerHandle {
     pub async fn validate_txos(&mut self) -> Result<u64, OutputManagerError> {
         match self.handle.call(OutputManagerRequest::ValidateUtxos).await?? {
             OutputManagerResponse::TxoValidationStarted(request_key) => Ok(request_key),
+            _ => Err(OutputManagerError::UnexpectedApiResponse),
+        }
+    }
+
+    pub async fn preview_coin_join_with_commitments(
+        &mut self,
+        commitments: Vec<Commitment>,
+        fee_per_gram: MicroTari,
+    ) -> Result<(Vec<MicroTari>, MicroTari), OutputManagerError> {
+        match self
+            .handle
+            .call(OutputManagerRequest::PreviewCoinJoin((commitments, fee_per_gram)))
+            .await??
+        {
+            OutputManagerResponse::CoinPreview((expected_outputs, fee)) => Ok((expected_outputs, fee)),
+            _ => Err(OutputManagerError::UnexpectedApiResponse),
+        }
+    }
+
+    pub async fn preview_coin_split_with_commitments_no_amount(
+        &mut self,
+        commitments: Vec<Commitment>,
+        split_count: usize,
+        fee_per_gram: MicroTari,
+    ) -> Result<(Vec<MicroTari>, MicroTari), OutputManagerError> {
+        match self
+            .handle
+            .call(OutputManagerRequest::PreviewCoinSplitEven((
+                commitments,
+                split_count,
+                fee_per_gram,
+            )))
+            .await??
+        {
+            OutputManagerResponse::CoinPreview((expected_outputs, fee)) => Ok((expected_outputs, fee)),
             _ => Err(OutputManagerError::UnexpectedApiResponse),
         }
     }


### PR DESCRIPTION
Description
---
Added 2 preview functions for coin split and join

Motivation and Context
---
To let mobile users appraise the fee and expected outputs without performing the actual split/join operation.

How Has This Been Tested?
---
unit tests
