### PR TITLE
feat(dan_layer/core): track checkpoint number for each checkpoint submitted

### DIFF
--- a/applications/tari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/tari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -884,7 +884,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
             .await
             .map_err(|e| Status::internal(e.to_string()))?;
 
-        let message = format!("Sidechain state checkpoint for {}", contract_id);
+        let message = format!("Checkpoint #{} for {}", checkpoint_number, contract_id);
         transaction_service
             .submit_transaction(tx_id, transaction, 10.into(), message)
             .await

--- a/applications/tari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/tari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -833,8 +833,10 @@ impl wallet_server::Wallet for WalletGrpcServer {
 
         let committee_signatures = message
             .committee_signatures
-            .try_into()
-            .map_err(|_| Status::invalid_argument("Invalid committee signatures"))?;
+            .map(TryInto::try_into)
+            .transpose()
+            .map_err(|_| Status::invalid_argument("Invalid committee signatures"))?
+            .unwrap_or_default();
 
         let (tx_id, transaction) = asset_manager
             .create_initial_asset_checkpoint(contract_id, merkle_root, committee_signatures)
@@ -872,8 +874,10 @@ impl wallet_server::Wallet for WalletGrpcServer {
 
         let committee_signatures = message
             .committee_signatures
-            .try_into()
-            .map_err(|_| Status::invalid_argument("Invalid committee signatures"))?;
+            .map(TryInto::try_into)
+            .transpose()
+            .map_err(|_| Status::invalid_argument("Invalid committee signatures"))?
+            .unwrap_or_default();
 
         let (tx_id, transaction) = asset_manager
             .create_follow_on_asset_checkpoint(contract_id, checkpoint_number, merkle_root, committee_signatures)

--- a/applications/tari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/tari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -833,10 +833,8 @@ impl wallet_server::Wallet for WalletGrpcServer {
 
         let committee_signatures = message
             .committee_signatures
-            .map(TryInto::try_into)
-            .transpose()
-            .map_err(|_| Status::invalid_argument("Invalid committee signatures"))?
-            .unwrap_or_default();
+            .try_into()
+            .map_err(|_| Status::invalid_argument("Invalid committee signatures"))?;
 
         let (tx_id, transaction) = asset_manager
             .create_initial_asset_checkpoint(contract_id, merkle_root, committee_signatures)
@@ -874,10 +872,8 @@ impl wallet_server::Wallet for WalletGrpcServer {
 
         let committee_signatures = message
             .committee_signatures
-            .map(TryInto::try_into)
-            .transpose()
-            .map_err(|_| Status::invalid_argument("Invalid committee signatures"))?
-            .unwrap_or_default();
+            .try_into()
+            .map_err(|_| Status::invalid_argument("Invalid committee signatures"))?;
 
         let (tx_id, transaction) = asset_manager
             .create_follow_on_asset_checkpoint(contract_id, checkpoint_number, merkle_root, committee_signatures)

--- a/applications/tari_validator_node/src/grpc/services/wallet_client.rs
+++ b/applications/tari_validator_node/src/grpc/services/wallet_client.rs
@@ -23,7 +23,6 @@
 use std::net::SocketAddr;
 
 use async_trait::async_trait;
-use log::*;
 use tari_app_grpc::{
     tari_rpc as grpc,
     tari_rpc::{
@@ -39,7 +38,7 @@ use tari_crypto::tari_utilities::ByteArray;
 use tari_dan_core::{services::WalletClient, DigitalAssetError};
 use tari_dan_engine::state::models::StateRoot;
 
-const LOG_TARGET: &str = "tari::dan::wallet_grpc";
+const _LOG_TARGET: &str = "tari::dan::wallet_grpc";
 
 type Inner = grpc::wallet_client::WalletClient<tonic::transport::Channel>;
 
@@ -79,8 +78,6 @@ impl WalletClient for GrpcWalletClient {
         let committee_signatures = grpc::CommitteeSignatures {
             signatures: checkpoint_signatures.into_iter().map(Into::into).collect(),
         };
-
-        info!(target: LOG_TARGET, "✅ Creating checkpoint #{}", checkpoint_number);
 
         if checkpoint_number == 0 {
             let request = CreateInitialAssetCheckpointRequest {

--- a/dan_layer/core/src/services/service_specification.rs
+++ b/dan_layer/core/src/services/service_specification.rs
@@ -39,7 +39,13 @@ use crate::{
         SigningService,
         ValidatorNodeClientFactory,
     },
-    storage::{chain::ChainDbBackendAdapter, global::GlobalDbBackendAdapter, ChainStorageService, DbFactory},
+    storage::{
+        chain::{ChainDbBackendAdapter, ChainDbMetadataKey},
+        global::GlobalDbBackendAdapter,
+        ChainStorageService,
+        DbFactory,
+        MetadataBackendAdapter,
+    },
 };
 
 /// A trait to describe a specific configuration of services. This type allows other services to
@@ -50,7 +56,7 @@ pub trait ServiceSpecification: Default + Clone {
     type AssetProcessor: AssetProcessor + Clone;
     type AssetProxy: AssetProxy + Clone;
     type BaseNodeClient: BaseNodeClient + Clone;
-    type ChainDbBackendAdapter: ChainDbBackendAdapter;
+    type ChainDbBackendAdapter: ChainDbBackendAdapter + MetadataBackendAdapter<ChainDbMetadataKey>;
     type ChainStorageService: ChainStorageService<Self::Payload>;
     type CheckpointManager: CheckpointManager;
     type CommitteeManager: CommitteeManager<Self::Addr>;

--- a/dan_layer/core/src/storage/atomic_db.rs
+++ b/dan_layer/core/src/storage/atomic_db.rs
@@ -20,12 +20,13 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::global::schema::*;
+use crate::storage::StorageError;
 
-#[derive(Queryable, Insertable, Identifiable)]
-#[table_name = "metadata"]
-#[primary_key(key_name)]
-pub struct GlobalMetadata {
-    pub key_name: Vec<u8>,
-    pub value: Vec<u8>,
+pub trait AtomicDb {
+    type Error: Into<StorageError>;
+    type DbTransaction;
+
+    fn create_transaction(&self) -> Result<Self::DbTransaction, Self::Error>;
+
+    fn commit(&self, transaction: &Self::DbTransaction) -> Result<(), Self::Error>;
 }

--- a/dan_layer/core/src/storage/chain/metadata_key.rs
+++ b/dan_layer/core/src/storage/chain/metadata_key.rs
@@ -20,12 +20,25 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::global::schema::*;
+use std::fmt::{Display, Formatter};
 
-#[derive(Queryable, Insertable, Identifiable)]
-#[table_name = "metadata"]
-#[primary_key(key_name)]
-pub struct GlobalMetadata {
-    pub key_name: Vec<u8>,
-    pub value: Vec<u8>,
+use crate::storage::metadata_backend_adapter::AsKeyBytes;
+
+#[derive(Debug, Clone, Copy)]
+pub enum ChainDbMetadataKey {
+    CheckpointNumber,
+}
+
+impl AsKeyBytes for ChainDbMetadataKey {
+    fn as_key_bytes(&self) -> &[u8] {
+        match self {
+            ChainDbMetadataKey::CheckpointNumber => b"checkpoint-number",
+        }
+    }
+}
+
+impl Display for ChainDbMetadataKey {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", String::from_utf8_lossy(self.as_key_bytes()))
+    }
 }

--- a/dan_layer/core/src/storage/chain/metadata_key.rs
+++ b/dan_layer/core/src/storage/chain/metadata_key.rs
@@ -24,7 +24,7 @@ use std::fmt::{Display, Formatter};
 
 use crate::storage::metadata_backend_adapter::AsKeyBytes;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ChainDbMetadataKey {
     CheckpointNumber,
 }

--- a/dan_layer/core/src/storage/chain/mod.rs
+++ b/dan_layer/core/src/storage/chain/mod.rs
@@ -26,9 +26,12 @@ mod chain_db_unit_of_work;
 mod db_instruction;
 mod db_node;
 mod db_qc;
+mod metadata_key;
+
 pub use chain_db::ChainDb;
 pub use chain_db_backend_adapter::ChainDbBackendAdapter;
 pub use chain_db_unit_of_work::ChainDbUnitOfWork;
 pub use db_instruction::DbInstruction;
 pub use db_node::DbNode;
 pub use db_qc::DbQc;
+pub use metadata_key::ChainDbMetadataKey;

--- a/dan_layer/core/src/storage/metadata_backend_adapter.rs
+++ b/dan_layer/core/src/storage/metadata_backend_adapter.rs
@@ -23,7 +23,7 @@
 // TODO: probably want to use something like bors or consensus encoding
 use tari_utilities::message_format::MessageFormat;
 
-use crate::storage::StorageError;
+use crate::storage::AtomicDb;
 
 pub trait MetadataBackendAdapter<K: AsKeyBytes>: AtomicDb + Send + Sync + Clone {
     fn get_metadata<T: MessageFormat>(

--- a/dan_layer/core/src/storage/metadata_backend_adapter.rs
+++ b/dan_layer/core/src/storage/metadata_backend_adapter.rs
@@ -20,12 +20,28 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::global::schema::*;
+// TODO: probably want to use something like bors or consensus encoding
+use tari_utilities::message_format::MessageFormat;
 
-#[derive(Queryable, Insertable, Identifiable)]
-#[table_name = "metadata"]
-#[primary_key(key_name)]
-pub struct GlobalMetadata {
-    pub key_name: Vec<u8>,
-    pub value: Vec<u8>,
+use crate::storage::StorageError;
+
+pub trait MetadataBackendAdapter<K: AsKeyBytes>: AtomicDb + Send + Sync + Clone {
+    fn get_metadata<T: MessageFormat>(
+        &self,
+        key: &K,
+        transaction: &Self::DbTransaction,
+    ) -> Result<Option<T>, Self::Error>;
+
+    fn set_metadata<T: MessageFormat>(
+        &self,
+        key: K,
+        value: T,
+        transaction: &Self::DbTransaction,
+    ) -> Result<(), Self::Error>;
+
+    fn metadata_key_exists(&self, key: &K, transaction: &Self::DbTransaction) -> Result<bool, Self::Error>;
+}
+
+pub trait AsKeyBytes {
+    fn as_key_bytes(&self) -> &[u8];
 }

--- a/dan_layer/core/src/storage/mocks/mod.rs
+++ b/dan_layer/core/src/storage/mocks/mod.rs
@@ -32,7 +32,7 @@ use tari_common_types::types::FixedHash;
 use tari_dan_engine::state::{mocks::state_db::MockStateDbBackupAdapter, StateDb};
 
 use crate::storage::{
-    chain::{ChainDb, DbInstruction, DbNode, DbQc},
+    chain::{ChainDb, ChainDbMetadataKey, DbInstruction, DbNode, DbQc},
     global::GlobalDb,
     mocks::{chain_db::MockChainDbBackupAdapter, global_db::MockGlobalDbBackupAdapter},
     DbFactory,
@@ -106,6 +106,7 @@ pub(self) struct MemoryChainDb {
     pub instructions: MemoryDbTable<DbInstruction>,
     pub prepare_qc: MemoryDbTable<DbQc>,
     pub locked_qc: MemoryDbTable<DbQc>,
+    pub metadata: MemoryDbTable<(ChainDbMetadataKey, Vec<u8>)>,
 }
 
 #[derive(Debug)]

--- a/dan_layer/core/src/storage/mod.rs
+++ b/dan_layer/core/src/storage/mod.rs
@@ -28,8 +28,12 @@ mod chain_storage_service;
 mod db_factory;
 mod error;
 pub mod global;
+mod metadata_backend_adapter;
 mod store;
 
+pub use atomic_db::AtomicDb;
 pub use db_factory::DbFactory;
+pub use metadata_backend_adapter::{AsKeyBytes, MetadataBackendAdapter};
 
+mod atomic_db;
 pub mod mocks;

--- a/dan_layer/storage_sqlite/Cargo.toml
+++ b/dan_layer/storage_sqlite/Cargo.toml
@@ -5,16 +5,16 @@ edition = "2018"
 license = "BSD-3-Clause"
 
 [dependencies]
-tari_dan_core = {path="../core"}
-tari_common = { path = "../../common"}
-tari_common_types = {path = "../../base_layer/common_types"}
+tari_dan_core = { path = "../core" }
+tari_common = { path = "../../common" }
+tari_common_types = { path = "../../base_layer/common_types" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.4" }
-tari_dan_engine = { path = "../engine"}
+tari_dan_engine = { path = "../engine" }
 
-diesel = { version = "1.4.8", features = ["sqlite"] }
+diesel = { version = "1.4.8", default-features = false, features = ["sqlite"] }
 diesel_migrations = "1.4.0"
 thiserror = "1.0.30"
 async-trait = "0.1.50"
-tokio = { version="1.10", features = ["macros", "time"]}
+tokio = { version = "1.10", features = ["macros", "time"] }
 tokio-stream = { version = "0.1.7", features = ["sync"] }
 log = { version = "0.4.8", features = ["std"] }

--- a/dan_layer/storage_sqlite/migrations/2022-07-05-131723_create_metadata/down.sql
+++ b/dan_layer/storage_sqlite/migrations/2022-07-05-131723_create_metadata/down.sql
@@ -1,0 +1,1 @@
+drop table metadata;

--- a/dan_layer/storage_sqlite/migrations/2022-07-05-131723_create_metadata/up.sql
+++ b/dan_layer/storage_sqlite/migrations/2022-07-05-131723_create_metadata/up.sql
@@ -1,0 +1,5 @@
+create table metadata
+(
+    key   blob primary key not null,
+    value blob             not null
+)

--- a/dan_layer/storage_sqlite/src/error.rs
+++ b/dan_layer/storage_sqlite/src/error.rs
@@ -50,6 +50,8 @@ pub enum SqliteStorageError {
     ModelError(#[from] ModelError),
     #[error("Conversion error:{reason}")]
     ConversionError { reason: String },
+    #[error("Malformed metadata for key '{key}'")]
+    MalformedMetadata { key: String },
 }
 
 impl From<SqliteStorageError> for StorageError {

--- a/dan_layer/storage_sqlite/src/global/sqlite_global_db_backend_adapter.rs
+++ b/dan_layer/storage_sqlite/src/global/sqlite_global_db_backend_adapter.rs
@@ -28,7 +28,7 @@ use crate::{
     error::SqliteStorageError,
     global::models::{
         contract::{Contract, NewContract},
-        metadata::Metadata,
+        metadata::GlobalMetadata,
     },
     SqliteTransaction,
 };
@@ -74,7 +74,7 @@ impl GlobalDbBackendAdapter for SqliteGlobalDbBackendAdapter {
         let tx = self.create_transaction()?;
 
         match self.get_data_with_connection(&key, &tx) {
-            Ok(Some(r)) => diesel::update(&Metadata {
+            Ok(Some(r)) => diesel::update(&GlobalMetadata {
                 key_name: key.as_key_bytes().to_vec(),
                 value: r,
             })
@@ -103,7 +103,7 @@ impl GlobalDbBackendAdapter for SqliteGlobalDbBackendAdapter {
         use crate::global::schema::metadata::dsl;
         let connection = SqliteConnection::establish(self.database_url.as_str())?;
 
-        let row: Option<Metadata> = dsl::metadata
+        let row: Option<GlobalMetadata> = dsl::metadata
             .find(key.as_key_bytes())
             .first(&connection)
             .optional()
@@ -122,7 +122,7 @@ impl GlobalDbBackendAdapter for SqliteGlobalDbBackendAdapter {
     ) -> Result<Option<Vec<u8>>, Self::Error> {
         use crate::global::schema::metadata::dsl;
 
-        let row: Option<Metadata> = dsl::metadata
+        let row: Option<GlobalMetadata> = dsl::metadata
             .find(key.as_key_bytes())
             .first(tx.connection())
             .optional()

--- a/dan_layer/storage_sqlite/src/models/metadata.rs
+++ b/dan_layer/storage_sqlite/src/models/metadata.rs
@@ -20,12 +20,12 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::global::schema::*;
+use crate::schema::metadata;
 
 #[derive(Queryable, Insertable, Identifiable)]
 #[table_name = "metadata"]
-#[primary_key(key_name)]
-pub struct GlobalMetadata {
-    pub key_name: Vec<u8>,
+#[primary_key(key)]
+pub struct Metadata {
+    pub key: Vec<u8>,
     pub value: Vec<u8>,
 }

--- a/dan_layer/storage_sqlite/src/models/mod.rs
+++ b/dan_layer/storage_sqlite/src/models/mod.rs
@@ -22,6 +22,7 @@
 
 pub mod instruction;
 pub mod locked_qc;
+pub mod metadata;
 pub mod node;
 pub mod prepare_qc;
 pub mod state_key;

--- a/dan_layer/storage_sqlite/src/schema.rs
+++ b/dan_layer/storage_sqlite/src/schema.rs
@@ -1,24 +1,24 @@
-// Copyright 2022. The Tari Project
+//  Copyright 2022. The Tari Project
 //
-// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
-// following conditions are met:
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
 //
-// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
-// disclaimer.
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
 //
-// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
-// following disclaimer in the documentation and/or other materials provided with the distribution.
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
 //
-// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
-// products derived from this software without specific prior written permission.
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
-// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
-// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
-// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 table! {
     instructions (id) {
@@ -39,6 +39,13 @@ table! {
         view_number -> BigInt,
         node_hash -> Binary,
         signature -> Nullable<Binary>,
+    }
+}
+
+table! {
+    metadata (key) {
+        key -> Binary,
+        value -> Binary,
     }
 }
 
@@ -96,6 +103,7 @@ joinable!(instructions -> nodes (node_id));
 allow_tables_to_appear_in_same_query!(
     instructions,
     locked_qc,
+    metadata,
     nodes,
     prepare_qc,
     state_keys,


### PR DESCRIPTION
Description
---
- tracks the checkpoint number for a contract
- adds general-purpose metadata table to chain db
- adds `MetadataBackendAdapter` that specified interface for databases that support getting and setting metadata 

Motivation and Context
---
This PR adds functionality to persist the checkpoint number each time a checkpoint is submitted so that sequential checkpoints are submitted.

How Has This Been Tested?
---
Manually - VN submits sequential checkpoints
