### PR TITLE
feat(wallet): uses tip height to calc abs acceptance period

### DIFF
--- a/applications/tari_console_wallet/src/automation/prompt.rs
+++ b/applications/tari_console_wallet/src/automation/prompt.rs
@@ -84,13 +84,12 @@ impl Prompt {
                 io::stdin().read_line(&mut line_buf)?;
                 println!();
 
-                let trimmed = line_buf.trim();
-
-                match trimmed {
-                    "N" => {
+                let trimmed = line_buf.trim().to_lowercase();
+                match trimmed.as_str() {
+                    "n" => {
                         return Ok(collection);
                     },
-                    "Y" => break,
+                    "y" => break,
                     _ => continue,
                 }
             }

--- a/base_layer/wallet/src/connectivity_service/interface.rs
+++ b/base_layer/wallet/src/connectivity_service/interface.rs
@@ -20,6 +20,8 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use std::time::Duration;
+
 use tari_comms::{
     peer_manager::{NodeId, Peer},
     protocol::rpc::RpcClientLease,
@@ -43,6 +45,16 @@ pub trait WalletConnectivityInterface: Clone + Send + Sync + 'static {
     /// shutting down, where it will return None. Use this function whenever no work can be done without a
     /// BaseNodeWalletRpcClient RPC session.
     async fn obtain_base_node_wallet_rpc_client(&mut self) -> Option<RpcClientLease<BaseNodeWalletRpcClient>>;
+
+    async fn obtain_base_node_wallet_rpc_client_timeout(
+        &mut self,
+        timeout: Duration,
+    ) -> Option<RpcClientLease<BaseNodeWalletRpcClient>> {
+        tokio::time::timeout(timeout, self.obtain_base_node_wallet_rpc_client())
+            .await
+            .ok()
+            .flatten()
+    }
 
     /// Obtain a BaseNodeSyncRpcClient.
     ///


### PR DESCRIPTION
Description
---
- fetches tip height from base node to determine the absolute height for the VN acceptance period

Motivation and Context
---
When using `init-constitution` command used an absolute height for the acceptance period, which made it easy to 
make the mistake of creating a constitution that expires immediately.  

This PR fetches the tip height from the base node and uses that, if able, to make the height relative. If not able, the user is warned and prompted to enter an ABSOLUTE height.

How Has This Been Tested?
---
Manually

