### PR TITLE
fix(base-node): minor fixups for hex/type parsing and long running commands

### DIFF
--- a/applications/tari_base_node/src/commands/command/dial_peer.rs
+++ b/applications/tari_base_node/src/commands/command/dial_peer.rs
@@ -48,7 +48,7 @@ impl HandleCommand<Args> for CommandContext {
 impl CommandContext {
     /// Function to process the dial-peer command
     pub async fn dial_peer(&self, dest_node_id: NodeId) -> Result<(), Error> {
-        let mut connectivity = self.connectivity.clone();
+        let connectivity = self.connectivity.clone();
         task::spawn(async move {
             let start = Instant::now();
             println!("☎️  Dialing peer...");

--- a/applications/tari_base_node/src/commands/command/dial_peer.rs
+++ b/applications/tari_base_node/src/commands/command/dial_peer.rs
@@ -27,6 +27,7 @@ use async_trait::async_trait;
 use clap::Parser;
 use tari_app_utilities::utilities::UniNodeId;
 use tari_comms::peer_manager::NodeId;
+use tokio::task;
 
 use super::{CommandContext, HandleCommand};
 
@@ -47,12 +48,21 @@ impl HandleCommand<Args> for CommandContext {
 impl CommandContext {
     /// Function to process the dial-peer command
     pub async fn dial_peer(&self, dest_node_id: NodeId) -> Result<(), Error> {
-        let start = Instant::now();
-        println!("☎️  Dialing peer...");
+        let mut connectivity = self.connectivity.clone();
+        task::spawn(async move {
+            let start = Instant::now();
+            println!("☎️  Dialing peer...");
 
-        let connection = self.connectivity.dial_peer(dest_node_id).await?;
-        println!("⚡️ Peer connected in {}ms!", start.elapsed().as_millis());
-        println!("Connection: {}", connection);
+            match connectivity.dial_peer(dest_node_id).await {
+                Ok(connection) => {
+                    println!("⚡️ Peer connected in {}ms!", start.elapsed().as_millis());
+                    println!("Connection: {}", connection);
+                },
+                Err(err) => {
+                    println!("☠️ {}", err);
+                },
+            }
+        });
         Ok(())
     }
 }


### PR DESCRIPTION
Description
---
1. [fix(base-node): make dial-peer and discover-peer run in their own task](https://github.com/tari-project/tari/commit/5bd5ef5caab4355783ff11991ce17c261ef9e6c7)
1. [fix(base-node): when parsing hex or type commands, do string parsing first](https://github.com/tari-project/tari/commit/1d3dde3130d8e00749c48e173a33d0ab9dd25c54) 

Motivation and Context
---
1. Some commands can run for a long time, while they are running they cannot be interrupted and no other commands can be issued. This change makes dial-peer and discover-peer run on their own task so that they do not block other commands.
2. get-block 1234 would be interpreted as hex instead of as a block height. This PR fixes that.

How Has This Been Tested?
---
Manually
