### PR TITLE
chore: upgrades to tari_crypto v0.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7151,8 +7151,8 @@ dependencies = [
 
 [[package]]
 name = "tari_crypto"
-version = "0.14.0"
-source = "git+https://github.com/tari-project/tari-crypto.git?tag=v0.14.0#60c7673ecde85f4cd155b3232e0b9994df88a536"
+version = "0.15.0"
+source = "git+https://github.com/tari-project/tari-crypto.git?tag=v0.15.0#75f9d2c6340ce212d24397cfcc5fc216cc12a02b"
 dependencies = [
  "base64 0.10.1",
  "blake2 0.9.2",

--- a/applications/tari_app_grpc/Cargo.toml
+++ b/applications/tari_app_grpc/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 tari_common_types = { version = "^0.33", path = "../../base_layer/common_types"}
 tari_comms = { path = "../../comms/core"}
 tari_core = {  path = "../../base_layer/core"}
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.14.0" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.0" }
 tari_script = { path = "../../infrastructure/tari_script" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.4" }
 

--- a/applications/tari_app_utilities/Cargo.toml
+++ b/applications/tari_app_utilities/Cargo.toml
@@ -7,7 +7,7 @@ license = "BSD-3-Clause"
 
 [dependencies]
 tari_comms = { path = "../../comms/core" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.14.0" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.0" }
 tari_common = { path = "../../common" }
 tari_common_types = { path = "../../base_layer/common_types" }
 tari_p2p = { path = "../../base_layer/p2p", features = ["auto-update"] }

--- a/applications/tari_base_node/Cargo.toml
+++ b/applications/tari_base_node/Cargo.toml
@@ -15,7 +15,7 @@ tari_comms = { path = "../../comms/core", features = ["rpc"] }
 tari_common_types = { path = "../../base_layer/common_types" }
 tari_comms_dht = { path = "../../comms/dht" }
 tari_core = { path = "../../base_layer/core", default-features = false, features = ["transactions"] }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.14.0" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.0" }
 tari_libtor = { path = "../../infrastructure/libtor" }
 tari_mmr = { path = "../../base_layer/mmr", features = ["native_bitmap"] }
 tari_p2p = { path = "../../base_layer/p2p", features = ["auto-update"] }
@@ -62,7 +62,7 @@ tari_metrics = { path = "../../infrastructure/metrics", optional = true, feature
 
 [features]
 default = ["metrics"]
-avx2 = ["tari_core/avx2", "tari_crypto/avx2", "tari_p2p/avx2", "tari_comms/avx2", "tari_comms_dht/avx2"]
+avx2 = ["tari_core/avx2", "tari_crypto/simd_backend", "tari_p2p/avx2", "tari_comms/avx2", "tari_comms_dht/avx2"]
 metrics = ["tari_metrics", "tari_comms/metrics"]
 safe = []
 libtor = ["tari_libtor/libtor"]

--- a/applications/tari_collectibles/src-tauri/Cargo.toml
+++ b/applications/tari_collectibles/src-tauri/Cargo.toml
@@ -19,7 +19,7 @@ tari_app_grpc = { path = "../../tari_app_grpc" }
 tari_app_utilities = { path = "../../tari_app_utilities" }
 tari_common = { path = "../../../common" }
 tari_common_types = { path = "../../../base_layer/common_types" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.14.0" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.0" }
 tari_key_manager = { path = "../../../base_layer/key_manager" }
 tari_mmr = { path = "../../../base_layer/mmr" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.4" }

--- a/applications/tari_collectibles/src-tauri/src/providers/key_manager_provider.rs
+++ b/applications/tari_collectibles/src-tauri/src/providers/key_manager_provider.rs
@@ -28,7 +28,7 @@ use crate::storage::{
 };
 use std::fmt::Display;
 use tari_common_types::types::{PrivateKey, PublicKey};
-use tari_crypto::{common::Blake256, keys::PublicKey as PublicKeyTrait};
+use tari_crypto::{hash::blake2::Blake256, keys::PublicKey as PublicKeyTrait};
 use tari_key_manager::key_manager::KeyManager;
 use tari_utilities::{hex::Hex, ByteArrayError};
 use uuid::Uuid;

--- a/applications/tari_console_wallet/Cargo.toml
+++ b/applications/tari_console_wallet/Cargo.toml
@@ -7,7 +7,7 @@ license = "BSD-3-Clause"
 
 [dependencies]
 tari_wallet = { path = "../../base_layer/wallet", features = ["bundled_sqlite"] }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.14.0" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.0" }
 tari_common = { path = "../../common" }
 tari_app_utilities = { path = "../tari_app_utilities" }
 tari_comms = { path = "../../comms/core" }
@@ -67,6 +67,6 @@ default-features = false
 features = ["crossterm"]
 
 [features]
-avx2 = ["tari_core/avx2", "tari_crypto/avx2", "tari_wallet/avx2", "tari_comms/avx2", "tari_comms_dht/avx2", "tari_p2p/avx2", "tari_key_manager/avx2"]
+avx2 = ["tari_core/avx2", "tari_crypto/simd_backend", "tari_wallet/avx2", "tari_comms/avx2", "tari_comms_dht/avx2", "tari_p2p/avx2", "tari_key_manager/avx2"]
 libtor = ["tari_libtor/libtor"]
 

--- a/applications/tari_merge_mining_proxy/Cargo.toml
+++ b/applications/tari_merge_mining_proxy/Cargo.toml
@@ -17,7 +17,7 @@ tari_common = { path = "../../common" }
 tari_comms = { path = "../../comms/core" }
 tari_core = { path = "../../base_layer/core", default-features = false, features = ["transactions"] }
 tari_app_utilities = { path = "../tari_app_utilities" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.14.0" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.0" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.4" }
 
 anyhow = "1.0.53"

--- a/applications/tari_miner/Cargo.toml
+++ b/applications/tari_miner/Cargo.toml
@@ -13,7 +13,7 @@ tari_common = {  path = "../../common" }
 tari_comms = {  path = "../../comms/core" }
 tari_app_utilities = { path = "../tari_app_utilities"}
 tari_app_grpc = {  path = "../tari_app_grpc" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.14.0" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.0" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.4" }
 
 crossterm = { version = "0.17" }

--- a/applications/tari_validator_node/Cargo.toml
+++ b/applications/tari_validator_node/Cargo.toml
@@ -14,7 +14,7 @@ tari_common = { path = "../../common" }
 tari_comms = { path = "../../comms/core" }
 tari_comms_dht = { path = "../../comms/dht" }
 tari_comms_rpc_macros = { path = "../../comms/rpc_macros" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.14.0" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.0" }
 tari_mmr = { path = "../../base_layer/mmr" }
 tari_p2p = { path = "../../base_layer/p2p" }
 tari_service_framework = { path = "../../base_layer/service_framework" }

--- a/applications/test_faucet/Cargo.toml
+++ b/applications/test_faucet/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2018"
 license = "BSD-3-Clause"
 
 [features]
-simd = ["tari_crypto/simd"]
+simd = ["tari_crypto/simd_backend"]
 avx2 = ["simd"]
 
 [dependencies]
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.14.0" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.0" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.4" }
 tari_common_types = { path = "../../base_layer/common_types" }
 tari_script = { path = "../../infrastructure/tari_script" }

--- a/base_layer/common_types/Cargo.toml
+++ b/base_layer/common_types/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.33.0"
 edition = "2018"
 
 [dependencies]
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.14.0" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.0" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.4" }
 
 digest = "0.9.0"

--- a/base_layer/common_types/src/types/mod.rs
+++ b/base_layer/common_types/src/types/mod.rs
@@ -25,7 +25,7 @@ mod fixed_hash;
 
 pub use bullet_rangeproofs::BulletRangeProof;
 use tari_crypto::{
-    common::Blake256,
+    hash::blake2::Blake256,
     ristretto::{
         bulletproofs_plus::BulletproofsPlusService,
         pedersen::{extended_commitment_factory::ExtendedPedersenCommitmentFactory, PedersenCommitment},

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -15,7 +15,7 @@ transactions = []
 mempool_proto = []
 base_node = []
 base_node_proto = []
-avx2 = ["tari_crypto/avx2"]
+avx2 = ["tari_crypto/simd_backend"]
 benches = ["base_node", "criterion"]
 
 [dependencies]
@@ -24,7 +24,7 @@ tari_common_types = { version = "^0.33", path = "../../base_layer/common_types" 
 tari_comms = { version = "^0.33", path = "../../comms/core" }
 tari_comms_dht = { version = "^0.33", path = "../../comms/dht" }
 tari_comms_rpc_macros = { version = "^0.33", path = "../../comms/rpc_macros" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.14.0" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.0" }
 tari_metrics = { path = "../../infrastructure/metrics" }
 tari_mmr = { version = "^0.33", path = "../../base_layer/mmr", optional = true, features = ["native_bitmap"] }
 tari_p2p = { version = "^0.33", path = "../../base_layer/p2p" }

--- a/base_layer/core/src/transactions/test_helpers.rs
+++ b/base_layer/core/src/transactions/test_helpers.rs
@@ -27,7 +27,7 @@ use tari_common::configuration::Network;
 use tari_common_types::types::{Commitment, CommitmentFactory, PrivateKey, PublicKey, Signature};
 use tari_crypto::{
     commitment::HomomorphicCommitmentFactory,
-    common::Blake256,
+    hash::blake2::Blake256,
     keys::{PublicKey as PK, SecretKey},
     range_proof::RangeProofService,
 };

--- a/base_layer/core/src/transactions/transaction_components/encrypted_value.rs
+++ b/base_layer/core/src/transactions/transaction_components/encrypted_value.rs
@@ -34,7 +34,7 @@ use chacha20poly1305::{
 };
 use serde::{Deserialize, Serialize};
 use tari_common_types::types::{Commitment, PrivateKey};
-use tari_crypto::common::Blake256;
+use tari_crypto::hash::blake2::Blake256;
 use tari_utilities::{ByteArray, ByteArrayError};
 use thiserror::Error;
 

--- a/base_layer/core/src/transactions/transaction_protocol/sender.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/sender.rs
@@ -776,8 +776,8 @@ mod test {
     use tari_common_types::types::{CommitmentFactory, PrivateKey, PublicKey, RangeProof};
     use tari_crypto::{
         commitment::HomomorphicCommitmentFactory,
-        common::Blake256,
         errors::RangeProofError::ProofConstructionError,
+        hash::blake2::Blake256,
         keys::{PublicKey as PublicKeyTrait, SecretKey as SecretKeyTrait},
         range_proof::RangeProofService,
         tari_utilities::{hex::Hex, ByteArray},

--- a/base_layer/core/src/transactions/transaction_protocol/transaction_initializer.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/transaction_initializer.rs
@@ -697,7 +697,7 @@ impl SenderTransactionInitializer {
 mod test {
     use rand::rngs::OsRng;
     use tari_common_types::types::PrivateKey;
-    use tari_crypto::{common::Blake256, keys::SecretKey};
+    use tari_crypto::{hash::blake2::Blake256, keys::SecretKey};
     use tari_script::{script, ExecutionStack, TariScript};
 
     use crate::{

--- a/base_layer/core/tests/helpers/chain_metadata.rs
+++ b/base_layer/core/tests/helpers/chain_metadata.rs
@@ -26,7 +26,7 @@ use blake2::Digest;
 use tari_common_types::chain_metadata::ChainMetadata;
 use tari_comms::peer_manager::NodeId;
 use tari_core::base_node::chain_metadata_service::{ChainMetadataEvent, ChainMetadataHandle, PeerChainMetadata};
-use tari_crypto::common::Blake256;
+use tari_crypto::hash::blake2::Blake256;
 use tari_utilities::ByteArray;
 use tokio::sync::broadcast;
 

--- a/base_layer/key_manager/Cargo.toml
+++ b/base_layer/key_manager/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["lib", "cdylib"]
 
 [dependencies]
 tari_common_types = { version = "^0.33", path = "../../base_layer/common_types" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.14.0" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.0" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.4" }
 
 arrayvec = "0.7.1"
@@ -41,6 +41,6 @@ wasm-bindgen-test = "0.3.28"
 sha2 = "0.9.8"
 
 [features]
-avx2 = ["tari_crypto/avx2"]
+avx2 = ["tari_crypto/simd_backend"]
 js = ["getrandom/js", "js-sys"]
 wasm = ["wasm-bindgen", "js"]

--- a/base_layer/key_manager/src/wasm.rs
+++ b/base_layer/key_manager/src/wasm.rs
@@ -26,7 +26,7 @@ use console_error_panic_hook;
 use derivative::Derivative;
 use serde::{Deserialize, Serialize};
 use tari_common_types::types::{PrivateKey, PublicKey};
-use tari_crypto::{common::Blake256, keys::PublicKey as PublicKeyTrait};
+use tari_crypto::{hash::blake2::Blake256, keys::PublicKey as PublicKeyTrait};
 use wasm_bindgen::prelude::*;
 
 use crate::{

--- a/base_layer/mmr/Cargo.toml
+++ b/base_layer/mmr/Cargo.toml
@@ -24,7 +24,7 @@ criterion = { version="0.2", optional = true }
 [dev-dependencies]
 rand="0.8.0"
 blake2 = "0.9.0"
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.14.0" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.0" }
 serde_json = "1.0"
 bincode = "1.1"
 [lib]

--- a/base_layer/mmr/tests/support/mod.rs
+++ b/base_layer/mmr/tests/support/mod.rs
@@ -23,7 +23,7 @@
 
 use croaring::Bitmap;
 use digest::Digest;
-use tari_crypto::common::Blake256;
+use tari_crypto::hash::blake2::Blake256;
 use tari_mmr::{Hash, HashSlice, MerkleMountainRange, MutableMmr};
 
 pub type Hasher = Blake256;

--- a/base_layer/p2p/Cargo.toml
+++ b/base_layer/p2p/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 tari_comms = { version = "^0.33", path = "../../comms/core" }
 tari_comms_dht = { version = "^0.33", path = "../../comms/dht" }
 tari_common = { version = "^0.33", path = "../../common" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.14.0" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.0" }
 tari_service_framework = { version = "^0.33", path = "../service_framework" }
 tari_shutdown = { version = "^0.33", path = "../../infrastructure/shutdown" }
 tari_storage = { version = "^0.33", path = "../../infrastructure/storage" }
@@ -58,7 +58,7 @@ tari_common = { version = "^0.33", path = "../../common", features = ["build"] }
 [features]
 test-mocks = []
 auto-update = ["reqwest/default", "pgp"]
-avx2 = ["tari_crypto/avx2"]
+avx2 = ["tari_crypto/simd_backend"]
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["openssl-sys"]

--- a/base_layer/tari_mining_helper_ffi/Cargo.toml
+++ b/base_layer/tari_mining_helper_ffi/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 tari_comms = { version = "^0.33", path = "../../comms/core" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.14.0" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.0" }
 tari_common = {  path = "../../common" }
 tari_core = {  path = "../core", default-features = false, features = ["transactions"]}
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.4" }

--- a/base_layer/wallet/Cargo.toml
+++ b/base_layer/wallet/Cargo.toml
@@ -11,7 +11,7 @@ tari_common = { path = "../../common" }
 tari_common_types = { version = "^0.33", path = "../../base_layer/common_types" }
 tari_comms = { version = "^0.33", path = "../../comms/core" }
 tari_comms_dht = { version = "^0.33", path = "../../comms/dht" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.14.0" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.0" }
 tari_key_manager = { version = "^0.33", path = "../key_manager" }
 tari_p2p = { version = "^0.33", path = "../p2p", features = ["auto-update"] }
 tari_script = { path = "../../infrastructure/tari_script" }
@@ -72,5 +72,5 @@ prost = "0.9.0"
 [features]
 default=["bundled_sqlite"]
 c_integration = []
-avx2 = ["tari_crypto/avx2", "tari_core/avx2"]
+avx2 = ["tari_crypto/simd_backend", "tari_core/avx2"]
 bundled_sqlite = ["libsqlite3-sys"]

--- a/base_layer/wallet/src/types.rs
+++ b/base_layer/wallet/src/types.rs
@@ -21,7 +21,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use tari_common_types::types::PublicKey;
-use tari_crypto::common::Blake256;
+use tari_crypto::hash::blake2::Blake256;
 
 use crate::error::WalletError;
 

--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -48,7 +48,7 @@ use tari_core::{
     },
 };
 use tari_crypto::{
-    common::Blake256,
+    hash::blake2::Blake256,
     ristretto::{RistrettoPublicKey, RistrettoSchnorr, RistrettoSecretKey},
     signatures::{SchnorrSignature, SchnorrSignatureError},
     tari_utilities::hex::Hex,

--- a/base_layer/wallet/tests/output_manager_service_tests/service.rs
+++ b/base_layer/wallet/tests/output_manager_service_tests/service.rs
@@ -58,7 +58,7 @@ use tari_core::{
 };
 use tari_crypto::{
     commitment::HomomorphicCommitmentFactory,
-    common::Blake256,
+    hash::blake2::Blake256,
     keys::{PublicKey as PublicKeyTrait, SecretKey},
 };
 use tari_key_manager::{cipher_seed::CipherSeed, mnemonic::Mnemonic};

--- a/base_layer/wallet/tests/transaction_service_tests/service.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/service.rs
@@ -89,7 +89,7 @@ use tari_core::{
 };
 use tari_crypto::{
     commitment::HomomorphicCommitmentFactory,
-    common::Blake256,
+    hash::blake2::Blake256,
     keys::{PublicKey as PK, SecretKey as SK},
 };
 use tari_key_manager::cipher_seed::CipherSeed;

--- a/base_layer/wallet_ffi/Cargo.toml
+++ b/base_layer/wallet_ffi/Cargo.toml
@@ -12,7 +12,7 @@ tari_common = {path="../../common"}
 tari_common_types = {path="../common_types"}
 tari_comms = { version = "^0.33", path = "../../comms/core", features = ["c_integration"]}
 tari_comms_dht = { version = "^0.33", path = "../../comms/dht", default-features = false }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.14.0" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.0" }
 tari_key_manager = { version = "^0.33", path = "../key_manager" }
 tari_p2p = { version = "^0.33", path = "../p2p" }
 tari_script = { path = "../../infrastructure/tari_script" }

--- a/base_layer/wallet_ffi/tari_wallet_ffi.h
+++ b/base_layer/wallet_ffi/tari_wallet_ffi.h
@@ -178,7 +178,7 @@ typedef PrivateKey TariPrivateKey;
  * ```rust
  * # use tari_crypto::ristretto::*;
  * # use tari_crypto::keys::*;
- * # use tari_crypto::common::*;
+ * # use tari_crypto::hash::blake2::Blake256;
  * # use digest::Digest;
  * # use tari_crypto::commitment::HomomorphicCommitmentFactory;
  * # use tari_crypto::ristretto::pedersen::*;
@@ -209,7 +209,7 @@ typedef PrivateKey TariPrivateKey;
  * # use tari_crypto::keys::*;
  * # use tari_crypto::commitment::HomomorphicCommitment;
  * # use tari_crypto::ristretto::pedersen::*;
- * # use tari_crypto::common::*;
+ * # use tari_crypto::hash::blake2::Blake256;
  * # use tari_utilities::hex::*;
  * # use tari_utilities::ByteArray;
  * # use digest::Digest;

--- a/comms/core/Cargo.toml
+++ b/comms/core/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.33.0"
 edition = "2018"
 
 [dependencies]
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.14.0" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.0" }
 tari_metrics = { path = "../../infrastructure/metrics" }
 tari_storage = { version = "^0.33", path = "../../infrastructure/storage" }
 tari_shutdown = { version = "^0.33", path = "../../infrastructure/shutdown" }
@@ -63,6 +63,6 @@ tari_common = { version = "^0.33", path = "../../common", features = ["build"] }
 
 [features]
 c_integration = []
-avx2 = ["tari_crypto/avx2"]
+avx2 = ["tari_crypto/simd_backend"]
 metrics = []
 rpc = ["tower/make", "tower/util"]

--- a/comms/core/src/types.rs
+++ b/comms/core/src/types.rs
@@ -22,7 +22,12 @@
 
 //! Common Tari comms types
 
-use tari_crypto::{common::Blake256, keys::PublicKey, ristretto::RistrettoPublicKey, signatures::SchnorrSignature};
+use tari_crypto::{
+    hash::blake2::Blake256,
+    keys::PublicKey,
+    ristretto::RistrettoPublicKey,
+    signatures::SchnorrSignature,
+};
 use tari_storage::lmdb_store::LMDBStore;
 #[cfg(test)]
 use tari_storage::HashmapDatabase;

--- a/comms/dht/Cargo.toml
+++ b/comms/dht/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 tari_comms = { version = "^0.33", path = "../core", features = ["rpc"] }
 tari_comms_rpc_macros = { version = "^0.33", path = "../rpc_macros" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.14.0" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.0" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.4" }
 tari_shutdown = { version = "^0.33", path = "../../infrastructure/shutdown" }
 tari_storage = { version = "^0.33", path = "../../infrastructure/storage" }
@@ -67,5 +67,5 @@ tari_common = { version = "^0.33", path = "../../common" }
 
 [features]
 test-mocks = []
-avx2 = ["tari_crypto/avx2"]
+avx2 = ["tari_crypto/simd_backend"]
 bundled-sqlite = ["libsqlite3-sys"]

--- a/dan_layer/core/Cargo.toml
+++ b/dan_layer/core/Cargo.toml
@@ -11,7 +11,7 @@ tari_common = { path = "../../common" }
 tari_comms = { path = "../../comms/core" }
 tari_comms_dht = { path = "../../comms/dht" }
 tari_comms_rpc_macros = { path = "../../comms/rpc_macros" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.14.0" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.0" }
 tari_mmr = { path = "../../base_layer/mmr" }
 tari_p2p = { path = "../../base_layer/p2p" }
 tari_service_framework = { path = "../../base_layer/service_framework" }

--- a/dan_layer/core/src/models/hot_stuff_message.rs
+++ b/dan_layer/core/src/models/hot_stuff_message.rs
@@ -23,7 +23,7 @@
 use digest::Digest;
 use tari_common_types::types::FixedHash;
 use tari_core::transactions::transaction_components::SignerSignature;
-use tari_crypto::common::Blake256;
+use tari_crypto::hash::blake2::Blake256;
 
 use crate::models::{
     HotStuffMessageType,

--- a/dan_layer/core/src/models/hot_stuff_tree_node.rs
+++ b/dan_layer/core/src/models/hot_stuff_tree_node.rs
@@ -21,7 +21,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use digest::{Digest, FixedOutput};
-use tari_crypto::common::Blake256;
+use tari_crypto::hash::blake2::Blake256;
 use tari_dan_engine::state::models::StateRoot;
 
 use crate::models::{Payload, TreeNodeHash};

--- a/dan_layer/core/src/models/instruction_set.rs
+++ b/dan_layer/core/src/models/instruction_set.rs
@@ -23,7 +23,7 @@
 use std::{convert::TryFrom, hash::Hash, iter::FromIterator};
 
 use tari_common_types::types::FixedHash;
-use tari_crypto::common::Blake256;
+use tari_crypto::hash::blake2::Blake256;
 use tari_dan_engine::instructions::Instruction;
 use tari_mmr::MerkleMountainRange;
 

--- a/dan_layer/core/src/models/tari_dan_payload.rs
+++ b/dan_layer/core/src/models/tari_dan_payload.rs
@@ -24,7 +24,7 @@ use std::fmt::Debug;
 
 use digest::Digest;
 use tari_common_types::types::FixedHash;
-use tari_crypto::common::Blake256;
+use tari_crypto::hash::blake2::Blake256;
 use tari_dan_engine::instructions::Instruction;
 
 use crate::models::{ConsensusHash, InstructionSet, Payload};

--- a/dan_layer/core/src/templates/tip004_template.rs
+++ b/dan_layer/core/src/templates/tip004_template.rs
@@ -24,7 +24,7 @@ use digest::Digest;
 use log::*;
 use prost::Message;
 use tari_core::transactions::transaction_components::TemplateParameter;
-use tari_crypto::common::Blake256;
+use tari_crypto::hash::blake2::Blake256;
 use tari_dan_common_types::proto::tips::tip004;
 use tari_dan_engine::state::{StateDbUnitOfWork, StateDbUnitOfWorkReader};
 use tari_utilities::hex::Hex;

--- a/dan_layer/engine/Cargo.toml
+++ b/dan_layer/engine/Cargo.toml
@@ -10,7 +10,7 @@ tari_common_types = {path = "../../base_layer/common_types"}
 tari_dan_common_types = {path = "../common_types"}
 tari_mmr = { path = "../../base_layer/mmr" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.4" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.14.0" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.0" }
 
 wasmer = "2.2.1"
 digest = "0.9.0"

--- a/dan_layer/engine/src/instructions/instruction.rs
+++ b/dan_layer/engine/src/instructions/instruction.rs
@@ -5,7 +5,7 @@ use std::fmt::{Display, Formatter};
 
 use digest::Digest;
 use tari_common_types::types::{FixedHash, PublicKey};
-use tari_crypto::common::Blake256;
+use tari_crypto::hash::blake2::Blake256;
 use tari_dan_common_types::TemplateId;
 use tari_utilities::hex::Hex;
 

--- a/dan_layer/engine/src/state/state_db_unit_of_work.rs
+++ b/dan_layer/engine/src/state/state_db_unit_of_work.rs
@@ -10,7 +10,7 @@ use std::{
 use digest::Digest;
 use log::*;
 use tari_common_types::types::{FixedHash, HashDigest};
-use tari_crypto::common::Blake256;
+use tari_crypto::hash::blake2::Blake256;
 use tari_dan_common_types::storage::UnitOfWorkTracker;
 use tari_mmr::{MemBackendVec, MerkleMountainRange};
 use tari_utilities::hex::Hex;

--- a/infrastructure/tari_script/Cargo.toml
+++ b/infrastructure/tari_script/Cargo.toml
@@ -12,7 +12,7 @@ license = "BSD-3-Clause"
 
 [dependencies]
 tari_common_types = { path = "../../base_layer/common_types" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.14.0" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.0" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.4" }
 
 blake2 = "0.9"

--- a/infrastructure/tari_script/src/script.rs
+++ b/infrastructure/tari_script/src/script.rs
@@ -22,7 +22,7 @@ use digest::Digest;
 use sha2::Sha256;
 use sha3::Sha3_256;
 use tari_crypto::{
-    common::Blake256,
+    hash::blake2::Blake256,
     ristretto::{RistrettoPublicKey, RistrettoSchnorr, RistrettoSecretKey},
 };
 use tari_utilities::{
@@ -595,7 +595,7 @@ mod test {
     use sha2::Sha256;
     use sha3::Sha3_256 as Sha3;
     use tari_crypto::{
-        common::Blake256,
+        hash::blake2::Blake256,
         keys::{PublicKey, SecretKey},
         ristretto::{pedersen::PedersenCommitment, RistrettoPublicKey, RistrettoSchnorr, RistrettoSecretKey},
     };

--- a/infrastructure/tari_script/src/script_commitment.rs
+++ b/infrastructure/tari_script/src/script_commitment.rs
@@ -99,7 +99,7 @@ impl ScriptCommitment {
 /// # use tari_crypto::ristretto::RistrettoSecretKey;
 /// # use tari_script::{ScriptCommitmentFactory, TariScript};
 /// # use tari_crypto::{
-///     common::Blake256,
+///     hash::blake2::Blake256,
 ///     keys::SecretKey,
 /// };
 ///
@@ -182,7 +182,7 @@ impl ScriptCommitmentFactory {
 mod tests {
     use blake2::Blake2b;
     use rand::RngCore;
-    use tari_crypto::{common::Blake256, keys::PublicKey, ristretto::RistrettoPublicKey};
+    use tari_crypto::{hash::blake2::Blake256, keys::PublicKey, ristretto::RistrettoPublicKey};
 
     use super::*;
     use crate::TariScript;

--- a/infrastructure/tari_script/src/stack.rs
+++ b/infrastructure/tari_script/src/stack.rs
@@ -333,7 +333,7 @@ fn counter(values: [u8; 5], item: &StackItem) -> [u8; 5] {
 mod test {
     use digest::Digest;
     use tari_crypto::{
-        common::Blake256,
+        hash::blake2::Blake256,
         keys::{PublicKey, SecretKey},
         ristretto::{utils, utils::SignatureSet, RistrettoPublicKey, RistrettoSchnorr, RistrettoSecretKey},
     };


### PR DESCRIPTION
Description
---
Upgrade repo to use tari_crypto v0.15.0

Motivation and Context
---
Allows the use of new tari crypto features incl domain-separated hashing

