### PR TITLE
feat(wallet_ffi): added mined_timestamp to TariUtxo

### DIFF
--- a/base_layer/wallet/src/output_manager_service/storage/models.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/models.rs
@@ -22,6 +22,7 @@
 
 use std::cmp::Ordering;
 
+use chrono::NaiveDateTime;
 use derivative::Derivative;
 use tari_common_types::types::{BlockHash, BulletRangeProof, Commitment, HashOutput, PrivateKey};
 use tari_core::transactions::{
@@ -43,6 +44,7 @@ pub struct DbUnblindedOutput {
     pub mined_height: Option<u64>,
     pub mined_in_block: Option<BlockHash>,
     pub mined_mmr_position: Option<u64>,
+    pub mined_timestamp: Option<NaiveDateTime>,
     pub marked_deleted_at_height: Option<u64>,
     pub marked_deleted_in_block: Option<BlockHash>,
     pub spending_priority: SpendingPriority,
@@ -63,6 +65,7 @@ impl DbUnblindedOutput {
             mined_height: None,
             mined_in_block: None,
             mined_mmr_position: None,
+            mined_timestamp: None,
             marked_deleted_at_height: None,
             marked_deleted_in_block: None,
             spending_priority: spend_priority.unwrap_or(SpendingPriority::Normal),
@@ -85,6 +88,7 @@ impl DbUnblindedOutput {
             mined_height: None,
             mined_in_block: None,
             mined_mmr_position: None,
+            mined_timestamp: None,
             marked_deleted_at_height: None,
             marked_deleted_in_block: None,
             spending_priority: spending_priority.unwrap_or(SpendingPriority::Normal),

--- a/base_layer/wallet/src/output_manager_service/storage/sqlite_db/output_sql.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/sqlite_db/output_sql.rs
@@ -726,6 +726,7 @@ impl TryFrom<OutputSql> for DbUnblindedOutput {
             mined_height: o.mined_height.map(|mh| mh as u64),
             mined_in_block: o.mined_in_block,
             mined_mmr_position: o.mined_mmr_position.map(|mp| mp as u64),
+            mined_timestamp: o.mined_timestamp,
             marked_deleted_at_height: o.marked_deleted_at_height.map(|d| d as u64),
             marked_deleted_in_block: o.marked_deleted_in_block,
             spending_priority,

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -272,6 +272,7 @@ pub struct TariUtxo {
     pub commitment: *mut c_char,
     pub value: u64,
     pub mined_height: u64,
+    pub mined_timestamp: u64,
     pub status: u8,
 }
 
@@ -287,6 +288,10 @@ impl TryFrom<DbUnblindedOutput> for TariUtxo {
                 .into_raw(),
             value: x.unblinded_output.value.as_u64(),
             mined_height: x.mined_height.unwrap_or(0),
+            mined_timestamp: x
+                .mined_timestamp
+                .map(|ts| ts.timestamp_millis() as u64)
+                .unwrap_or_default(),
             status: match x.status {
                 OutputStatus::Unspent => 0,
                 OutputStatus::Spent => 1,

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -304,6 +304,7 @@ struct TariUtxo {
   char *commitment;
   uint64_t value;
   uint64_t mined_height;
+  uint64_t mined_timestamp;
   uint8_t status;
 };
 


### PR DESCRIPTION
Description
---
Added `mined_timestamp` to TariUtxo in the FFI library.

Motivation and Context
---
To let the Aurora users see when an UTXO was mined (in UTC).

How Has This Been Tested?
---
unit test
