### PR TITLE
chore: add stealth address to wallet

### DIFF
--- a/applications/tari_console_wallet/src/init/mod.rs
+++ b/applications/tari_console_wallet/src/init/mod.rs
@@ -395,7 +395,8 @@ async fn setup_identity_from_db<D: WalletBackend + 'static>(
 
     let identity_sig = wallet_db.get_comms_identity_signature().await?;
 
-    let comms_secret_key = derive_comms_secret_key(master_seed)?;
+    let (comms_secret_key, stealth_address_scanning_private_key, stealth_address_spending_private_key) =
+        derive_comms_secret_key(master_seed)?;
 
     // This checks if anything has changed by validating the previous signature and if invalid, setting identity_sig
     // to None
@@ -407,6 +408,8 @@ async fn setup_identity_from_db<D: WalletBackend + 'static>(
     // SAFETY: we are manually checking the validity of this signature before adding Some(..)
     let node_identity = Arc::new(NodeIdentity::with_signature_unchecked(
         comms_secret_key,
+        stealth_address_scanning_private_key,
+        stealth_address_spending_private_key,
         node_address,
         node_features,
         identity_sig,

--- a/applications/tari_console_wallet/src/ui/state/app_state.rs
+++ b/applications/tari_console_wallet/src/ui/state/app_state.rs
@@ -1172,6 +1172,8 @@ impl AppStateData {
             emoji_id: eid,
             qr_code: image,
             node_id: node_identity.node_id().to_string(),
+            stealth_address_scanning: node_identity.stealth_address_scanning_public_key().to_string(),
+            stealth_address_spending: node_identity.stealth_address_spending_public_key().to_string(),
         };
         let base_node_previous = base_node_selected.clone();
 
@@ -1226,6 +1228,8 @@ pub struct MyIdentity {
     pub emoji_id: String,
     pub qr_code: String,
     pub node_id: String,
+    pub stealth_address_scanning: String,
+    pub stealth_address_spending: String,
 }
 
 #[derive(Clone, Debug)]

--- a/base_layer/wallet/migrations/2022-07-08-170000_known_stealth_addresses/up.sql
+++ b/base_layer/wallet/migrations/2022-07-08-170000_known_stealth_addresses/up.sql
@@ -1,0 +1,5 @@
+CREATE TABLE known_stealth_addresses (
+    stealth_address_hash BLOB PRIMARY KEY NOT NULL,
+    scanning_private_key BLOB             NOT NULL,
+    spending_private_key BLOB             NOT NULL
+);

--- a/base_layer/wallet/src/output_manager_service/error.rs
+++ b/base_layer/wallet/src/output_manager_service/error.rs
@@ -175,6 +175,8 @@ pub enum OutputManagerStorageError {
     AeadError(String),
     #[error("Tried to insert a script that already exists in the database")]
     DuplicateScript,
+    #[error("Tried to insert a stealth address that already exists in the database")]
+    DuplicateStealthAddress,
     #[error("Tari script error : {0}")]
     ScriptError(#[from] ScriptError),
     #[error("Binary not stored as valid hex:{0}")]

--- a/base_layer/wallet/src/output_manager_service/handle.rs
+++ b/base_layer/wallet/src/output_manager_service/handle.rs
@@ -55,7 +55,7 @@ use crate::output_manager_service::{
     service::{Balance, OutputStatusesByTxId},
     storage::{
         database::OutputBackendQuery,
-        models::{KnownOneSidedPaymentScript, SpendingPriority},
+        models::{KnownOneSidedPaymentScript, KnownStealthAddress, SpendingPriority},
     },
     UtxoSelectionCriteria,
 };
@@ -127,6 +127,7 @@ pub enum OutputManagerRequest {
     ScanForRecoverableOutputs(Vec<TransactionOutput>),
     ScanOutputs(Vec<TransactionOutput>),
     AddKnownOneSidedPaymentScript(KnownOneSidedPaymentScript),
+    AddKnownStealthAddress(KnownStealthAddress),
     CreateOutputWithFeatures {
         value: MicroTari,
         features: Box<OutputFeatures>,
@@ -196,6 +197,7 @@ impl fmt::Display for OutputManagerRequest {
             ScanForRecoverableOutputs(_) => write!(f, "ScanForRecoverableOutputs"),
             ScanOutputs(_) => write!(f, "ScanOutputs"),
             AddKnownOneSidedPaymentScript(_) => write!(f, "AddKnownOneSidedPaymentScript"),
+            AddKnownStealthAddress(_) => write!(f, "AddKnownStealthAddress"),
             CreateOutputWithFeatures { value, features } => {
                 write!(f, "CreateOutputWithFeatures({}, {})", value, features,)
             },
@@ -250,6 +252,7 @@ pub enum OutputManagerResponse {
     RewoundOutputs(Vec<RecoveredOutput>),
     ScanOutputs(Vec<RecoveredOutput>),
     AddKnownOneSidedPaymentScript,
+    AddKnownStealthAddress,
     CreateOutputWithFeatures { output: Box<UnblindedOutputBuilder> },
     CreatePayToSelfWithOutputs { transaction: Box<Transaction>, tx_id: TxId },
     ReinstatedCancelledInboundTx,
@@ -751,6 +754,20 @@ impl OutputManagerHandle {
             .await??
         {
             OutputManagerResponse::AddKnownOneSidedPaymentScript => Ok(()),
+            _ => Err(OutputManagerError::UnexpectedApiResponse),
+        }
+    }
+
+    pub async fn add_known_stealth_address(
+        &mut self,
+        stealth_address: KnownStealthAddress,
+    ) -> Result<(), OutputManagerError> {
+        match self
+            .handle
+            .call(OutputManagerRequest::AddKnownStealthAddress(stealth_address))
+            .await??
+        {
+            OutputManagerResponse::AddKnownStealthAddress => Ok(()),
             _ => Err(OutputManagerError::UnexpectedApiResponse),
         }
     }

--- a/base_layer/wallet/src/output_manager_service/storage/models.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/models.rs
@@ -160,3 +160,17 @@ impl PartialEq for KnownOneSidedPaymentScript {
         self.script_hash == other.script_hash
     }
 }
+
+#[derive(Derivative, Clone)]
+#[derivative(Debug)]
+pub struct KnownStealthAddress {
+    pub stealth_address_hash: Vec<u8>,
+    pub scanning_private_key: PrivateKey,
+    pub spending_private_key: PrivateKey,
+}
+
+impl PartialEq for KnownStealthAddress {
+    fn eq(&self, other: &KnownStealthAddress) -> bool {
+        self.stealth_address_hash == other.stealth_address_hash
+    }
+}

--- a/base_layer/wallet/src/schema.rs
+++ b/base_layer/wallet/src/schema.rs
@@ -106,6 +106,14 @@ table! {
 }
 
 table! {
+    known_stealth_addresses (stealth_address_hash) {
+        stealth_address_hash -> Binary,
+        scanning_private_key -> Binary,
+        spending_private_key -> Binary,
+    }
+}
+
+table! {
     outbound_transactions (tx_id) {
         tx_id -> BigInt,
         destination_public_key -> Binary,
@@ -184,6 +192,7 @@ allow_tables_to_appear_in_same_query!(
     key_manager_states,
     key_manager_states_old,
     known_one_sided_payment_scripts,
+    known_stealth_addresses,
     outbound_transactions,
     outputs,
     scanned_blocks,

--- a/comms/core/src/test_utils/factories/node_identity.rs
+++ b/comms/core/src/test_utils/factories/node_identity.rs
@@ -65,6 +65,8 @@ impl TestFactory for NodeIdentityFactory {
             .unwrap_or(super::net_address::create().build()?);
 
         Ok(NodeIdentity::new(
+            secret_key.clone(),
+            secret_key.clone(),
             secret_key,
             control_service_address,
             self.peer_features,


### PR DESCRIPTION
Description
---
Add a stealth address scanning and spending keys. Currently they are equal to wallet key. But that can change in the future.
This addresses will be used in sending and scaning. So if we change it future, we have to rewrite just one line of code and some UI. But no the whole scanning and sending.
The know stealth addresses table was also added. The table consist of hash of the stealth address (hash of `hex(scanning)::hex(spending)` key string. That hash is used as a primary key to the table.
