### PR TITLE
feat(base_layer): basic checkpoint validation

### DIFF
--- a/base_layer/core/src/transactions/transaction_components/side_chain/committee_signatures.rs
+++ b/base_layer/core/src/transactions/transaction_components/side_chain/committee_signatures.rs
@@ -23,6 +23,7 @@
 use std::{
     convert::{TryFrom, TryInto},
     io,
+    slice,
 };
 
 use serde::{Deserialize, Serialize};
@@ -67,6 +68,15 @@ impl IntoIterator for CommitteeSignatures {
 
     fn into_iter(self) -> Self::IntoIter {
         self.signatures.into_vec().into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a CommitteeSignatures {
+    type IntoIter = slice::Iter<'a, SignerSignature>;
+    type Item = <Self::IntoIter as Iterator>::Item;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.signatures.iter()
     }
 }
 

--- a/base_layer/core/src/validation/dan_validators/checkpoint_validator.rs
+++ b/base_layer/core/src/validation/dan_validators/checkpoint_validator.rs
@@ -23,7 +23,14 @@
 use super::helpers::{fetch_contract_constitution, get_sidechain_features};
 use crate::{
     chain_storage::{BlockchainBackend, BlockchainDatabase},
-    transactions::transaction_components::{ContractCheckpoint, OutputType, SideChainFeatures, TransactionOutput},
+    transactions::transaction_components::{
+        CommitteeSignatures,
+        ContractCheckpoint,
+        ContractConstitution,
+        OutputType,
+        SideChainFeatures,
+        TransactionOutput,
+    },
     validation::{
         dan_validators::{helpers::fetch_current_contract_checkpoint, DanLayerValidationError},
         ValidationError,
@@ -36,12 +43,22 @@ pub fn validate_contract_checkpoint<B: BlockchainBackend>(
 ) -> Result<(), ValidationError> {
     let sidechain_features = get_sidechain_features(output)?;
     let contract_id = sidechain_features.contract_id;
-    fetch_contract_constitution(db, contract_id)?;
+    let checkpoint = get_checkpoint(sidechain_features)?;
+
+    let constitution = fetch_contract_constitution(db, contract_id)?;
+    validate_committee(&constitution, &checkpoint.signatures)?;
 
     let prev_cp = fetch_current_contract_checkpoint(db, contract_id)?;
     validate_checkpoint_number(prev_cp.as_ref(), sidechain_features)?;
 
     Ok(())
+}
+
+fn get_checkpoint(sidechain_feature: &SideChainFeatures) -> Result<&ContractCheckpoint, DanLayerValidationError> {
+    match sidechain_feature.checkpoint.as_ref() {
+        Some(checkpoint) => Ok(checkpoint),
+        None => Err(DanLayerValidationError::ContractAcceptanceNotFound),
+    }
 }
 
 fn validate_checkpoint_number(
@@ -67,21 +84,40 @@ fn validate_checkpoint_number(
     }
 }
 
+fn validate_committee(
+    constitution: &ContractConstitution,
+    signatures: &CommitteeSignatures,
+) -> Result<(), DanLayerValidationError> {
+    let committee = &constitution.validator_committee;
+    let are_all_signers_in_committee = signatures.into_iter().all(|s| committee.contains(s.signer()));
+    if !are_all_signers_in_committee {
+        return Err(DanLayerValidationError::InconsistentCommittee);
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod test {
-    use crate::validation::dan_validators::{
-        test_helpers::{
-            assert_dan_validator_err,
-            assert_dan_validator_success,
-            create_contract_checkpoint,
-            create_contract_checkpoint_schema,
-            init_test_blockchain,
-            publish_checkpoint,
-            publish_contract,
-            publish_definition,
-            schema_to_transaction,
+    use tari_common_types::types::Signature;
+
+    use crate::{
+        validation::dan_validators::{
+            test_helpers::{
+                assert_dan_validator_err,
+                assert_dan_validator_success,
+                create_committee_signatures,
+                create_contract_checkpoint,
+                create_contract_checkpoint_schema,
+                create_random_key_pair,
+                init_test_blockchain,
+                publish_checkpoint,
+                publish_contract,
+                publish_definition,
+                schema_to_transaction,
+            },
+            DanLayerValidationError,
         },
-        DanLayerValidationError,
     };
 
     #[test]
@@ -170,7 +206,7 @@ mod test {
 
         // skip the contract constitution publication
 
-        // Create checkpoint 0 with no prior checkpoints
+        // Create a checkpoint
         let checkpoint = create_contract_checkpoint(0);
         let schema = create_contract_checkpoint_schema(contract_id, utxos[1].clone(), checkpoint);
         let (tx, _) = schema_to_transaction(&schema);
@@ -181,5 +217,27 @@ mod test {
             err,
             DanLayerValidationError::ContractConstitutionNotFound { .. }
         ));
+    }
+
+    #[test]
+    fn it_rejects_checkpoints_with_non_committee_members() {
+        // initialise a blockchain with enough funds to spend at contract transactions
+        let (mut blockchain, utxos) = init_test_blockchain();
+
+        // Publish a new contract specifying a committee with only one member ("alice")
+        let (_, alice) = create_random_key_pair();
+        let contract_id = publish_contract(&mut blockchain, &utxos, vec![alice.clone()]);
+
+        // Create a checkpoint, with a committe that has an extra member ("bob") not present in the constiution
+        let mut checkpoint = create_contract_checkpoint(0);
+        let (_, bob) = create_random_key_pair();
+        checkpoint.signatures =
+            create_committee_signatures(vec![(alice, Signature::default()), (bob, Signature::default())]);
+        let schema = create_contract_checkpoint_schema(contract_id, utxos[1].clone(), checkpoint);
+        let (tx, _) = schema_to_transaction(&schema);
+
+        // try to validate the acceptance transaction and check that we get the error
+        let err = assert_dan_validator_err(&blockchain, &tx);
+        assert!(matches!(err, DanLayerValidationError::InconsistentCommittee { .. }));
     }
 }

--- a/base_layer/core/src/validation/dan_validators/checkpoint_validator.rs
+++ b/base_layer/core/src/validation/dan_validators/checkpoint_validator.rs
@@ -101,23 +101,21 @@ fn validate_committee(
 mod test {
     use tari_common_types::types::Signature;
 
-    use crate::{
-        validation::dan_validators::{
-            test_helpers::{
-                assert_dan_validator_err,
-                assert_dan_validator_success,
-                create_committee_signatures,
-                create_contract_checkpoint,
-                create_contract_checkpoint_schema,
-                create_random_key_pair,
-                init_test_blockchain,
-                publish_checkpoint,
-                publish_contract,
-                publish_definition,
-                schema_to_transaction,
-            },
-            DanLayerValidationError,
+    use crate::validation::dan_validators::{
+        test_helpers::{
+            assert_dan_validator_err,
+            assert_dan_validator_success,
+            create_committee_signatures,
+            create_contract_checkpoint,
+            create_contract_checkpoint_schema,
+            create_random_key_pair,
+            init_test_blockchain,
+            publish_checkpoint,
+            publish_contract,
+            publish_definition,
+            schema_to_transaction,
         },
+        DanLayerValidationError,
     };
 
     #[test]

--- a/base_layer/core/src/validation/dan_validators/error.rs
+++ b/base_layer/core/src/validation/dan_validators/error.rs
@@ -65,4 +65,6 @@ pub enum DanLayerValidationError {
     ProposalAcceptanceWindowHasExpired { contract_id: FixedHash, proposal_id: u64 },
     #[error("Checkpoint has non-sequential number. Got: {got}, expected: {expected}")]
     CheckpointNonSequentialNumber { got: u64, expected: u64 },
+    #[error("Validator committee not consistent with contract constitution")]
+    InconsistentCommittee,
 }

--- a/base_layer/core/src/validation/dan_validators/test_helpers.rs
+++ b/base_layer/core/src/validation/dan_validators/test_helpers.rs
@@ -337,3 +337,12 @@ pub fn assert_dan_validator_fail(blockchain: &TestBlockchain, transaction: &Tran
 pub fn assert_dan_validator_success(blockchain: &TestBlockchain, transaction: &Transaction) {
     perform_validation(blockchain, transaction).unwrap()
 }
+
+pub fn create_committee_signatures(key_signature_pairs: Vec<(PublicKey, Signature)>) -> CommitteeSignatures {
+    let signer_signatures: Vec<SignerSignature> = key_signature_pairs
+        .iter()
+        .map(|(k, s)| SignerSignature::new(k.clone(), s.clone()))
+        .collect();
+
+    CommitteeSignatures::new(signer_signatures.try_into().unwrap())
+}


### PR DESCRIPTION
Description
---
* Removed unnecessary validation about required contract definition in checkpoints
* Added checkpoint validation of existing prior contract constitution
* Added checkpoint validation of checkpoint signer public keys being included in the constitution committee
* For convenience, implemented `IntoIterator` trait for references of `CommitteeSignatures`

Motivation and Context
---
The base layer must perform some basic validations on checkpoints:
- The constitution must have been published
- The checkpoint signers public keys must be included in the constitution committee

How Has This Been Tested?
---
The new unit tests for the new validations pass

