### PR TITLE
feat(base_layer): checkpoint signature validation

### DIFF
--- a/base_layer/core/src/validation/dan_validators/acceptance_validator.rs
+++ b/base_layer/core/src/validation/dan_validators/acceptance_validator.rs
@@ -165,7 +165,7 @@ pub fn validate_signature<B: BlockchainBackend>(
     let is_valid_signature = SignerSignature::verify(signature, validator_node_public_key, challenge);
     if !is_valid_signature {
         return Err(ValidationError::DanLayerError(
-            DanLayerValidationError::InvalidAcceptanceSignature,
+            DanLayerValidationError::InvalidSignature,
         ));
     }
 

--- a/base_layer/core/src/validation/dan_validators/acceptance_validator.rs
+++ b/base_layer/core/src/validation/dan_validators/acceptance_validator.rs
@@ -200,20 +200,24 @@ mod test {
     use super::fetch_constitution_commitment;
     use crate::{
         txn_schema,
-        validation::dan_validators::test_helpers::{
-            assert_dan_validator_fail,
-            assert_dan_validator_success,
-            create_acceptance_signature,
-            create_block,
-            create_contract_acceptance_schema,
-            create_contract_acceptance_schema_with_signature,
-            create_contract_constitution,
-            create_contract_constitution_schema,
-            create_random_key_pair,
-            init_test_blockchain,
-            publish_constitution,
-            publish_definition,
-            schema_to_transaction,
+        validation::dan_validators::{
+            test_helpers::{
+                assert_dan_validator_err,
+                assert_dan_validator_fail,
+                assert_dan_validator_success,
+                create_acceptance_signature,
+                create_block,
+                create_contract_acceptance_schema,
+                create_contract_acceptance_schema_with_signature,
+                create_contract_constitution,
+                create_contract_constitution_schema,
+                create_random_key_pair,
+                init_test_blockchain,
+                publish_constitution,
+                publish_definition,
+                schema_to_transaction,
+            },
+            DanLayerValidationError,
         },
     };
 
@@ -378,6 +382,7 @@ mod test {
         let (tx, _) = schema_to_transaction(&schema);
 
         // try to validate the acceptance transaction and check that we get the error
-        assert_dan_validator_fail(&blockchain, &tx, "Invalid acceptance signature");
+        let err = assert_dan_validator_err(&blockchain, &tx);
+        assert!(matches!(err, DanLayerValidationError::InvalidSignature { .. }));
     }
 }

--- a/base_layer/core/src/validation/dan_validators/error.rs
+++ b/base_layer/core/src/validation/dan_validators/error.rs
@@ -59,8 +59,8 @@ pub enum DanLayerValidationError {
     UpdatedConstitutionAmendmentMismatch,
     #[error("Acceptance window has expired for contract_id ({contract_id})")]
     AcceptanceWindowHasExpired { contract_id: FixedHash },
-    #[error("Invalid acceptance signature")]
-    InvalidAcceptanceSignature,
+    #[error("Invalid signature")]
+    InvalidSignature,
     #[error("Proposal acceptance window has expired for contract_id ({contract_id}) and proposal_id ({proposal_id})")]
     ProposalAcceptanceWindowHasExpired { contract_id: FixedHash, proposal_id: u64 },
     #[error("Checkpoint has non-sequential number. Got: {got}, expected: {expected}")]

--- a/base_layer/core/src/validation/dan_validators/test_helpers.rs
+++ b/base_layer/core/src/validation/dan_validators/test_helpers.rs
@@ -22,7 +22,7 @@
 
 use std::convert::TryInto;
 
-use tari_common_types::types::{Commitment, FixedHash, PublicKey, Signature};
+use tari_common_types::types::{Commitment, FixedHash, PrivateKey, PublicKey, Signature};
 use tari_crypto::ristretto::{RistrettoPublicKey, RistrettoSecretKey};
 use tari_p2p::Network;
 
@@ -338,10 +338,14 @@ pub fn assert_dan_validator_success(blockchain: &TestBlockchain, transaction: &T
     perform_validation(blockchain, transaction).unwrap()
 }
 
-pub fn create_committee_signatures(key_signature_pairs: Vec<(PublicKey, Signature)>) -> CommitteeSignatures {
-    let signer_signatures: Vec<SignerSignature> = key_signature_pairs
-        .iter()
-        .map(|(k, s)| SignerSignature::new(k.clone(), s.clone()))
+pub fn create_committee_signatures(keys: Vec<(PrivateKey, PublicKey)>, challenge: &[u8]) -> CommitteeSignatures {
+    let signer_signatures: Vec<SignerSignature> = keys
+        .into_iter()
+        .map(|(pri_k, pub_k)| {
+            let (nonce, _) = create_random_key_pair();
+            let signature = Signature::sign(pri_k, nonce, challenge).unwrap();
+            SignerSignature::new(pub_k, signature)
+        })
         .collect();
 
     CommitteeSignatures::new(signer_signatures.try_into().unwrap())


### PR DESCRIPTION
Description
---
* New base layer validation of checkpoint signatures: verifies that ALL the signatures present in the checkpoint are valid
* Unified the error type for invalid signatures across all contract output types

Motivation and Context
---
The base layer needs to check if all the signatures in a checkpoint are valid.

This PR is based on previous work on checkpoints (see #4261  and #4285). The checkpoint signature is calculated as:
`e = H_1(signer_public_key || public_nonce || H_2(contract_id||commitment||merkle_root||checkpoint_number))`

But take into account that the `commitment` is still a mock value as of now we still don't have a method for creating a shared value.

How Has This Been Tested?
---
New unit test checks that invalid signatures are detected
