### PR TITLE
feat(base_layer): checkpoint abandonment interval validation

### DIFF
--- a/base_layer/core/src/validation/dan_validators/acceptance_validator.rs
+++ b/base_layer/core/src/validation/dan_validators/acceptance_validator.rs
@@ -24,6 +24,7 @@ use tari_common_types::types::{Commitment, FixedHash, PublicKey, Signature};
 use tari_utilities::hex::Hex;
 
 use super::helpers::{
+    fetch_constitution_height,
     fetch_contract_constitution,
     fetch_contract_features,
     fetch_contract_utxos,
@@ -137,20 +138,6 @@ fn validate_acceptance_window<B: BlockchainBackend>(
     }
 
     Ok(())
-}
-
-pub fn fetch_constitution_height<B: BlockchainBackend>(
-    db: &BlockchainDatabase<B>,
-    contract_id: FixedHash,
-) -> Result<u64, ValidationError> {
-    let utxos = fetch_contract_utxos(db, contract_id, OutputType::ContractConstitution)?;
-    // Only one constitution should be stored for a particular contract_id
-    match utxos.first() {
-        Some(utxo) => Ok(utxo.mined_height),
-        None => Err(ValidationError::DanLayerError(
-            DanLayerValidationError::ContractConstitutionNotFound { contract_id },
-        )),
-    }
 }
 
 pub fn validate_signature<B: BlockchainBackend>(

--- a/base_layer/core/src/validation/dan_validators/error.rs
+++ b/base_layer/core/src/validation/dan_validators/error.rs
@@ -67,4 +67,6 @@ pub enum DanLayerValidationError {
     CheckpointNonSequentialNumber { got: u64, expected: u64 },
     #[error("Validator committee not consistent with contract constitution")]
     InconsistentCommittee,
+    #[error("Checkpoint interval has expired for contract_id ({contract_id})")]
+    CheckpointIntervalHasExpired { contract_id: FixedHash },
 }

--- a/base_layer/core/src/validation/dan_validators/helpers.rs
+++ b/base_layer/core/src/validation/dan_validators/helpers.rs
@@ -99,6 +99,20 @@ pub fn fetch_contract_constitution<B: BlockchainBackend>(
     }
 }
 
+pub fn fetch_constitution_height<B: BlockchainBackend>(
+    db: &BlockchainDatabase<B>,
+    contract_id: FixedHash,
+) -> Result<u64, ValidationError> {
+    let utxos = fetch_contract_utxos(db, contract_id, OutputType::ContractConstitution)?;
+    // Only one constitution should be stored for a particular contract_id
+    match utxos.first() {
+        Some(utxo) => Ok(utxo.mined_height),
+        None => Err(ValidationError::DanLayerError(
+            DanLayerValidationError::ContractConstitutionNotFound { contract_id },
+        )),
+    }
+}
+
 pub fn fetch_contract_update_proposal<B: BlockchainBackend>(
     db: &BlockchainDatabase<B>,
     contract_id: FixedHash,


### PR DESCRIPTION
Description
---
Added a new base layer validation for checkpoints: error if the abandonment interval has been been surpassed when submitting a new checkpoint. The validation function itself could be reused for future checks of the abandonment lifecycle.

Motivation and Context
---
When submitting new checkpoints, base layer must check if abandonment interval has been surpassed, as specified in the contract constitution (field `checkpoint_params.abandoned_interval`).

How Has This Been Tested?
---
New unit test to check that the validation triggers an error after the abandonment interval has been surpassed.
