### PR TITLE
fix: fix OSX GHA build fix by bumping OSX release

### DIFF
--- a/.github/workflows/base_node_binaries.yml
+++ b/.github/workflows/base_node_binaries.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, macos-10.15, windows-2019]
+        os: [ubuntu-18.04, macos-11, windows-2019]
         # https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html
         target_cpu: ["x86-64"]
         # https://github.com/zkcrypto/curve25519-dalek-ng/pull/14


### PR DESCRIPTION
Description
OSX GHA build fix by bumping OSX release

How Has This Been Tested?
Build in local fork
