### PR TITLE
feat: bump toolchain for GHA from nightly-2021-11-20 to nightly-2022-05-01

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,4 +1,5 @@
 # Runs daily
+---
 name: Security audit
 on:
   schedule:

--- a/.github/workflows/auto_labels.yml
+++ b/.github/workflows/auto_labels.yml
@@ -1,3 +1,4 @@
+---
 on:
   workflow_run:
     workflows:

--- a/.github/workflows/base_node_binaries.yml
+++ b/.github/workflows/base_node_binaries.yml
@@ -1,3 +1,4 @@
+---
 name: Build Matrix of Binaries
 
 on:
@@ -18,6 +19,7 @@ on:
 env:
   TBN_FILENAME: "tari_suite"
   TBN_BUNDLEID_BASE: "com.tarilabs.pkg"
+  toolchain: nightly-2022-05-01
 
 jobs:
   builds:
@@ -63,7 +65,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-05-01
+          toolchain: ${{ env.toolchain }}
           components: rustfmt
           override: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,4 @@
+---
 on:
   push:
     branches:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,3 +1,4 @@
+---
 name: Source Coverage
 on:
   push:
@@ -5,7 +6,7 @@ on:
       - development
 
 env:
-  toolchain: nightly-2021-11-20
+  toolchain: nightly-2022-05-01
 
 jobs:
   coverage:

--- a/.github/workflows/development-ci.yml
+++ b/.github/workflows/development-ci.yml
@@ -1,3 +1,4 @@
+---
 on:
   push:
     branches:
@@ -7,7 +8,7 @@ on:
 name: Development CI
 
 env:
-  toolchain: nightly-2021-11-20
+  toolchain: nightly-2022-05-01
   CARGO_HTTP_MULTIPLEXING: false
   CARGO_TERM_COLOR: always
   PROTOC: protoc
@@ -41,4 +42,3 @@ jobs:
         run: |
           cd applications/tari_web_extension_example
           npm audit
-

--- a/.github/workflows/launchpad_docker.yml
+++ b/.github/workflows/launchpad_docker.yml
@@ -15,7 +15,7 @@ on:
         default: "development"
 
 env:
-  toolchain: nightly-2021-11-20
+  toolchain: nightly-2022-05-01
   CARGO_HTTP_MULTIPLEXING: false
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/libwallet.yml
+++ b/.github/workflows/libwallet.yml
@@ -1,4 +1,5 @@
 # Build a new set of libraries when a new tag containing 'libwallet' is pushed
+---
 name: Build libwallet
 
 on:
@@ -11,6 +12,9 @@ on:
     - cron: "05 00 * * *"
   workflow_dispatch:
 
+env:
+  toolchain: nightly-2022-05-01
+
 jobs:
   android:
     runs-on: ubuntu-latest
@@ -19,7 +23,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-05-01
+          toolchain: ${{ env.toolchain }}
           override: true
       - name: Install cross
         run: |
@@ -66,13 +70,13 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-05-01
+          toolchain: ${{ env.toolchain }}
           target: aarch64-apple-ios
           components: rustfmt
           override: true
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-05-01
+          toolchain: ${{ env.toolchain }}
           target: x86_64-apple-ios
           components: rustfmt
           override: true

--- a/.github/workflows/long_running.yml
+++ b/.github/workflows/long_running.yml
@@ -1,11 +1,12 @@
 # Runs weekly (saturday noon)
+---
 name: Long running integration tests
 on:
   schedule:
     - cron: "0 12 * * 6"
 
 env:
-  toolchain: nightly-2021-11-20
+  toolchain: nightly-2022-05-01
 
 jobs:
   long-running:

--- a/.github/workflows/non_critical_integration_tests.yml
+++ b/.github/workflows/non_critical_integration_tests.yml
@@ -1,11 +1,12 @@
 # Runs daily (2am)
+---
 name: Non critical integration tests
 on:
   schedule:
     - cron: "0 2 * * *"
 
 env:
-  toolchain: nightly-2021-11-20
+  toolchain: nightly-2022-05-01
 
 jobs:
   non-critical:

--- a/.github/workflows/pr_title.yml
+++ b/.github/workflows/pr_title.yml
@@ -1,3 +1,4 @@
+---
 name: PR
 on:
   pull_request:

--- a/.github/workflows/rfc_deploy.yml
+++ b/.github/workflows/rfc_deploy.yml
@@ -1,3 +1,4 @@
+---
 on:
   push:
     branches:

--- a/.github/workflows/rfc_test.yml
+++ b/.github/workflows/rfc_test.yml
@@ -1,3 +1,4 @@
+---
 on:
   push:
     branches:


### PR DESCRIPTION
Description
Update all GHAs with env.toolchain and bump from nightly-2021-11-20 to nightly-2022-05-01

Motivation and Context
Fix broken builds for newer modules

How Has This Been Tested?
Build in local fork for binary builds only
