### PR TITLE
feat: spend a checkpoint to mark a contract as quarantiend

### DIFF
--- a/applications/tari_console_wallet/src/cli.rs
+++ b/applications/tari_console_wallet/src/cli.rs
@@ -25,6 +25,7 @@ use std::{path::PathBuf, time::Duration};
 use chrono::{DateTime, Utc};
 use clap::{Args, Parser, Subcommand};
 use tari_app_utilities::{common_cli_args::CommonCliArgs, utilities::UniPublicKey};
+use tari_common_types::types::FixedHash;
 use tari_comms::multiaddr::Multiaddr;
 use tari_core::transactions::{tari_amount, tari_amount::MicroTari};
 use tari_utilities::hex::{Hex, HexError};
@@ -230,6 +231,9 @@ pub enum ContractSubcommand {
 
     /// Creates and publishes a contract amendment UTXO from the JSON spec file.
     PublishAmendment(PublishFileArgs),
+
+    /// Moves a contract into a quarantine state
+    Quarantine(QuarantineArgs),
 }
 
 #[derive(Debug, Args, Clone)]
@@ -308,4 +312,14 @@ pub struct PublishFileArgs {
 #[derive(Debug, Args, Clone)]
 pub struct PublishUpdateProposalArgs {
     pub file_path: PathBuf,
+}
+
+fn parse_contract_id(s: &str) -> Result<FixedHash, HexError> {
+    FixedHash::from_hex(s)
+}
+
+#[derive(Debug, Args, Clone)]
+pub struct QuarantineArgs {
+    #[clap(short, long, parse(try_from_str = parse_contract_id), required = true)]
+    pub contract_id: FixedHash,
 }

--- a/base_layer/core/src/transactions/transaction_components/output_features.rs
+++ b/base_layer/core/src/transactions/transaction_components/output_features.rs
@@ -375,6 +375,14 @@ impl OutputFeatures {
         }
     }
 
+    pub fn for_quarantine(contract_id: FixedHash) -> OutputFeatures {
+        Self {
+            output_type: OutputType::ContractQuarantine,
+            sidechain_features: Some(Box::new(SideChainFeaturesBuilder::new(contract_id).finish())),
+            ..Default::default()
+        }
+    }
+
     pub fn unique_asset_id(&self) -> Option<&[u8]> {
         self.unique_id.as_deref()
     }

--- a/base_layer/core/src/transactions/transaction_components/output_type.rs
+++ b/base_layer/core/src/transactions/transaction_components/output_type.rs
@@ -56,16 +56,18 @@ pub enum OutputType {
     ContractConstitutionChangeAcceptance = 7,
     /// Output that defines an amendment of a contract constitution.
     ContractAmendment = 8,
+    /// Output that defines a quarantined contract
+    ContractQuarantine = 9,
 
     // TODO: Remove these deprecated flags
-    NonFungible = 9,
-    AssetRegistration = 10,
-    MintNonFungible = 11,
-    BurnNonFungible = 12,
-    SidechainInitialCheckpoint = 13,
-    SidechainCheckpoint = 14,
-    CommitteeInitialDefinition = 15,
-    CommitteeDefinition = 16,
+    NonFungible = 10,
+    AssetRegistration = 11,
+    MintNonFungible = 12,
+    BurnNonFungible = 13,
+    SidechainInitialCheckpoint = 14,
+    SidechainCheckpoint = 15,
+    CommitteeInitialDefinition = 16,
+    CommitteeDefinition = 17,
 }
 
 impl OutputType {
@@ -91,7 +93,8 @@ impl OutputType {
                 ContractCheckpoint |
                 ContractConstitutionProposal |
                 ContractConstitutionChangeAcceptance |
-                ContractAmendment
+                ContractAmendment |
+                ContractQuarantine
         )
     }
 }

--- a/base_layer/core/src/validation/dan_validators/error.rs
+++ b/base_layer/core/src/validation/dan_validators/error.rs
@@ -69,4 +69,6 @@ pub enum DanLayerValidationError {
     InconsistentCommittee,
     #[error("Validator committee quorum not met: Got: {got}, minimum expected: {minimum} ")]
     InsufficientQuorum { got: u32, minimum: u32 },
+    #[error("Constitution committee not present in the change rules")]
+    NoConstitutionCommittee,
 }

--- a/base_layer/core/src/validation/dan_validators/mod.rs
+++ b/base_layer/core/src/validation/dan_validators/mod.rs
@@ -47,6 +47,9 @@ use amendment_validator::validate_amendment;
 mod checkpoint_validator;
 use checkpoint_validator::validate_contract_checkpoint;
 
+mod quarantine_validator;
+use quarantine_validator::validate_quarantine;
+
 mod helpers;
 
 mod error;
@@ -82,6 +85,7 @@ impl<B: BlockchainBackend> MempoolTransactionValidation for TxDanLayerValidator<
                     validate_update_proposal_acceptance(&self.db, output)?
                 },
                 OutputType::ContractAmendment => validate_amendment(&self.db, output)?,
+                OutputType::ContractQuarantine => validate_quarantine(&self.db, output)?,
                 _ => validate_no_sidechain_features(output)?,
             }
         }

--- a/base_layer/core/src/validation/dan_validators/quarantine_validator.rs
+++ b/base_layer/core/src/validation/dan_validators/quarantine_validator.rs
@@ -1,0 +1,53 @@
+//  Copyright 2022, The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use super::helpers::{get_sidechain_features, validate_output_type};
+use crate::{
+    chain_storage::{BlockchainBackend, BlockchainDatabase},
+    transactions::transaction_components::{OutputType, TransactionOutput},
+    validation::{dan_validators::DanLayerValidationError, ValidationError},
+};
+
+pub fn validate_quarantine<B: BlockchainBackend>(
+    _db: &BlockchainDatabase<B>,
+    output: &TransactionOutput,
+) -> Result<(), ValidationError> {
+    validate_output_type(output, OutputType::ContractQuarantine)?;
+
+    let sidechain_features = get_sidechain_features(output)?;
+
+    let _emergency_keys = sidechain_features
+        .constitution
+        .as_ref()
+        .and_then(|constitution| {
+            constitution
+                .constitution_change_rules
+                .requirements_for_constitution_change
+                .as_ref()
+        })
+        .and_then(|change_rules| change_rules.constitution_committee.as_ref())
+        .ok_or(DanLayerValidationError::NoConstitutionCommittee)?;
+
+    // TODO: Use TariScript to ensure only the correct people are spending the checkpoint into a quarantine state
+
+    Ok(())
+}

--- a/base_layer/wallet/src/assets/asset_manager.rs
+++ b/base_layer/wallet/src/assets/asset_manager.rs
@@ -404,6 +404,24 @@ impl<T: OutputManagerBackend + 'static> AssetManager<T> {
 
         Ok((tx_id, transaction))
     }
+
+    pub async fn quarantine_contract(&mut self, contract_id: FixedHash) -> Result<(TxId, Transaction), WalletError> {
+        let output = self
+            .output_manager
+            .create_output_with_features(0.into(), OutputFeatures::for_quarantine(contract_id))
+            .await?;
+
+        let (tx_id, transaction) = self
+            .output_manager
+            .create_send_to_self_with_output(
+                vec![output],
+                ASSET_FPG.into(),
+                UtxoSelectionCriteria::for_contract(contract_id, OutputType::ContractCheckpoint),
+            )
+            .await?;
+
+        Ok((tx_id, transaction))
+    }
 }
 
 fn convert_to_asset(unblinded_output: DbUnblindedOutput) -> Result<Asset, WalletError> {

--- a/base_layer/wallet/src/assets/asset_manager_handle.rs
+++ b/base_layer/wallet/src/assets/asset_manager_handle.rs
@@ -311,6 +311,22 @@ impl AssetManagerHandle {
         }
     }
 
+    pub async fn quarantine_contract(&mut self, contract_id: &FixedHash) -> Result<(TxId, Transaction), WalletError> {
+        match self
+            .handle
+            .call(AssetManagerRequest::QuarantineContract {
+                contract_id: *contract_id,
+            })
+            .await??
+        {
+            AssetManagerResponse::QuarantineContract { transaction, tx_id } => Ok((tx_id, *transaction)),
+            _ => Err(WalletError::UnexpectedApiResponse {
+                method: "quarantine_contract".to_string(),
+                api: "AssetManagerService".to_string(),
+            }),
+        }
+    }
+
     pub async fn list_owned_constitutions(&mut self) -> Result<Vec<DbUnblindedOutput>, WalletError> {
         match self
             .handle

--- a/base_layer/wallet/src/assets/infrastructure/asset_manager_service.rs
+++ b/base_layer/wallet/src/assets/infrastructure/asset_manager_service.rs
@@ -247,6 +247,13 @@ impl<T: OutputManagerBackend + 'static> AssetManagerService<T> {
                     tx_id,
                 })
             },
+            AssetManagerRequest::QuarantineContract { contract_id } => {
+                let (tx_id, transaction) = self.manager.quarantine_contract(contract_id).await?;
+                Ok(AssetManagerResponse::QuarantineContract {
+                    transaction: Box::new(transaction),
+                    tx_id,
+                })
+            },
         }
     }
 }

--- a/base_layer/wallet/src/assets/infrastructure/mod.rs
+++ b/base_layer/wallet/src/assets/infrastructure/mod.rs
@@ -97,6 +97,9 @@ pub enum AssetManagerRequest {
         contract_id: FixedHash,
         contract_amendment: Box<ContractAmendment>,
     },
+    QuarantineContract {
+        contract_id: FixedHash,
+    },
 }
 
 pub enum AssetManagerResponse {
@@ -113,4 +116,5 @@ pub enum AssetManagerResponse {
     CreateContractUpdateProposalAcceptance { transaction: Box<Transaction>, tx_id: TxId },
     CreateContractUpdateProposal { transaction: Box<Transaction>, tx_id: TxId },
     CreateContractAmendment { transaction: Box<Transaction>, tx_id: TxId },
+    QuarantineContract { transaction: Box<Transaction>, tx_id: TxId },
 }


### PR DESCRIPTION
Description
---
This adds two distinct features. The ability to spend a checkpoint into a quarantine state. And for VN's to recognize a contract has been marked as quarantine and stop working on it.

Motivation and Context
---
VN's need to know when a contract isn't worth processing. Emergency keys need to be able to try and salvage it.

How Has This Been Tested?
---
Manually