### PR TITLE
feat(base_layer): remove the initial_reward field for contracts

### DIFF
--- a/applications/tari_app_grpc/proto/types.proto
+++ b/applications/tari_app_grpc/proto/types.proto
@@ -249,7 +249,6 @@ message ContractConstitution {
     SideChainConsensus consensus = 3;
     CheckpointParameters checkpoint_params = 4;
     ConstitutionChangeRules constitution_change_rules = 5;
-    uint64 initial_reward = 6;
 }
 
 message ContractAcceptanceRequirements {

--- a/applications/tari_app_grpc/src/conversions/sidechain_features.rs
+++ b/applications/tari_app_grpc/src/conversions/sidechain_features.rs
@@ -134,7 +134,6 @@ impl TryFrom<grpc::CreateConstitutionDefinitionRequest> for SideChainFeatures {
                         backup_keys: Some(validator_committee),
                     }),
                 },
-                initial_reward: 100.into(),
             }),
             acceptance: None,
             update_proposal: None,
@@ -269,7 +268,6 @@ impl From<ContractConstitution> for grpc::ContractConstitution {
             consensus: value.consensus.into(),
             checkpoint_params: Some(value.checkpoint_params.into()),
             constitution_change_rules: Some(value.constitution_change_rules.into()),
-            initial_reward: value.initial_reward.into(),
         }
     }
 }
@@ -296,7 +294,6 @@ impl TryFrom<grpc::ContractConstitution> for ContractConstitution {
             .constitution_change_rules
             .map(TryInto::try_into)
             .ok_or("constitution_change_rules not provided")??;
-        let initial_reward = value.initial_reward.into();
 
         Ok(Self {
             validator_committee,
@@ -304,7 +301,6 @@ impl TryFrom<grpc::ContractConstitution> for ContractConstitution {
             consensus,
             checkpoint_params,
             constitution_change_rules,
-            initial_reward,
         })
     }
 }

--- a/applications/tari_console_wallet/src/automation/commands.rs
+++ b/applications/tari_console_wallet/src/automation/commands.rs
@@ -957,7 +957,6 @@ async fn init_contract_constitution_spec(
         contract_id,
         validator_committee: committee.iter().map(|c| PublicKey::from_hex(c).unwrap()).collect(),
         consensus: SideChainConsensus::MerkleRoot,
-        initial_reward: 0,
         acceptance_parameters: ContractAcceptanceRequirements {
             acceptance_period_expiry,
             minimum_quorum_required,
@@ -1027,7 +1026,6 @@ async fn init_contract_update_proposal_spec(
         contract_id,
         validator_committee: committee.iter().map(|c| PublicKey::from_hex(c).unwrap()).collect(),
         consensus: SideChainConsensus::MerkleRoot,
-        initial_reward: 0,
         acceptance_parameters: ContractAcceptanceRequirements {
             acceptance_period_expiry,
             minimum_quorum_required,

--- a/applications/tari_explorer/partials/ContractConstitution.hbs
+++ b/applications/tari_explorer/partials/ContractConstitution.hbs
@@ -14,5 +14,4 @@
     <dt>Constitution change rules</dt>
     <dd>{{>ConstitutionChangeRules constitution_change_rules}}</dd>
   {{/if}}
-  <dt>Initial reward</dt><dd>{{initial_reward}}</dd>
 </dl>

--- a/base_layer/core/src/chain_storage/tests/helpers.rs
+++ b/base_layer/core/src/chain_storage/tests/helpers.rs
@@ -113,7 +113,6 @@ pub fn create_contract_constitution_transaction(
                         change_flags: ConstitutionChangeFlags::empty(),
                         requirements_for_constitution_change: None,
                     },
-                    initial_reward: 10u64.into(),
                 })
                 .finish(),
         )),

--- a/base_layer/core/src/proto/transaction.proto
+++ b/base_layer/core/src/proto/transaction.proto
@@ -128,7 +128,6 @@ message ContractConstitution {
     SideChainConsensus consensus = 3;
     CheckpointParameters checkpoint_params = 4;
     ConstitutionChangeRules constitution_change_rules = 5;
-    uint64 initial_reward = 6;
 }
 
 message ContractAcceptanceRequirements {

--- a/base_layer/core/src/proto/transaction.rs
+++ b/base_layer/core/src/proto/transaction.rs
@@ -420,7 +420,6 @@ impl From<ContractConstitution> for proto::types::ContractConstitution {
             consensus: value.consensus.into(),
             checkpoint_params: Some(value.checkpoint_params.into()),
             constitution_change_rules: Some(value.constitution_change_rules.into()),
-            initial_reward: value.initial_reward.into(),
         }
     }
 }
@@ -447,7 +446,6 @@ impl TryFrom<proto::types::ContractConstitution> for ContractConstitution {
             .constitution_change_rules
             .map(TryInto::try_into)
             .ok_or("constitution_change_rules not provided")??;
-        let initial_reward = value.initial_reward.into();
 
         Ok(Self {
             validator_committee,
@@ -455,7 +453,6 @@ impl TryFrom<proto::types::ContractConstitution> for ContractConstitution {
             consensus,
             checkpoint_params,
             constitution_change_rules,
-            initial_reward,
         })
     }
 }

--- a/base_layer/core/src/transactions/transaction_components/output_features.rs
+++ b/base_layer/core/src/transactions/transaction_components/output_features.rs
@@ -627,7 +627,6 @@ mod test {
                     ),
                 }),
             },
-            initial_reward: 100.into(),
         };
 
         OutputFeatures {

--- a/base_layer/core/src/transactions/transaction_components/side_chain/contract_amendment.rs
+++ b/base_layer/core/src/transactions/transaction_components/side_chain/contract_amendment.rs
@@ -79,17 +79,14 @@ mod tests {
     use super::*;
     use crate::{
         consensus::check_consensus_encoding_correctness,
-        transactions::{
-            tari_amount::MicroTari,
-            transaction_components::{
-                CheckpointParameters,
-                CommitteeMembers,
-                ConstitutionChangeFlags,
-                ConstitutionChangeRules,
-                ContractAcceptanceRequirements,
-                RequirementsForConstitutionChange,
-                SideChainConsensus,
-            },
+        transactions::transaction_components::{
+            CheckpointParameters,
+            CommitteeMembers,
+            ConstitutionChangeFlags,
+            ConstitutionChangeRules,
+            ContractAcceptanceRequirements,
+            RequirementsForConstitutionChange,
+            SideChainConsensus,
         },
     };
 
@@ -119,7 +116,6 @@ mod tests {
                     )),
                 }),
             },
-            initial_reward: MicroTari::from(123u64),
         };
 
         let amendment = ContractAmendment {

--- a/base_layer/core/src/transactions/transaction_components/side_chain/contract_constitution.rs
+++ b/base_layer/core/src/transactions/transaction_components/side_chain/contract_constitution.rs
@@ -31,10 +31,7 @@ use num_traits::FromPrimitive;
 use serde::{Deserialize, Serialize};
 
 use super::CommitteeMembers;
-use crate::{
-    consensus::{ConsensusDecoding, ConsensusEncoding, ConsensusEncodingSized},
-    transactions::tari_amount::MicroTari,
-};
+use crate::consensus::{ConsensusDecoding, ConsensusEncoding, ConsensusEncodingSized};
 
 /// # ContractConstitution
 ///
@@ -53,8 +50,6 @@ pub struct ContractConstitution {
     pub checkpoint_params: CheckpointParameters,
     /// The rules or restrictions on how and if a constitution may be changed.
     pub constitution_change_rules: ConstitutionChangeRules,
-    /// The initial reward paid to validator committee members.
-    pub initial_reward: MicroTari,
 }
 
 impl ConsensusEncoding for ContractConstitution {
@@ -64,7 +59,6 @@ impl ConsensusEncoding for ContractConstitution {
         self.consensus.consensus_encode(writer)?;
         self.checkpoint_params.consensus_encode(writer)?;
         self.constitution_change_rules.consensus_encode(writer)?;
-        self.initial_reward.consensus_encode(writer)?;
 
         Ok(())
     }
@@ -80,7 +74,6 @@ impl ConsensusDecoding for ContractConstitution {
             consensus: SideChainConsensus::consensus_decode(reader)?,
             checkpoint_params: CheckpointParameters::consensus_decode(reader)?,
             constitution_change_rules: ConstitutionChangeRules::consensus_decode(reader)?,
-            initial_reward: MicroTari::consensus_decode(reader)?,
         })
     }
 }
@@ -319,7 +312,6 @@ mod tests {
                     )),
                 }),
             },
-            initial_reward: MicroTari::from(123u64),
         };
 
         check_consensus_encoding_correctness(subject).unwrap();

--- a/base_layer/core/src/transactions/transaction_components/side_chain/contract_update_proposal.rs
+++ b/base_layer/core/src/transactions/transaction_components/side_chain/contract_update_proposal.rs
@@ -73,17 +73,14 @@ mod tests {
     use super::*;
     use crate::{
         consensus::check_consensus_encoding_correctness,
-        transactions::{
-            tari_amount::MicroTari,
-            transaction_components::{
-                CheckpointParameters,
-                CommitteeMembers,
-                ConstitutionChangeFlags,
-                ConstitutionChangeRules,
-                ContractAcceptanceRequirements,
-                RequirementsForConstitutionChange,
-                SideChainConsensus,
-            },
+        transactions::transaction_components::{
+            CheckpointParameters,
+            CommitteeMembers,
+            ConstitutionChangeFlags,
+            ConstitutionChangeRules,
+            ContractAcceptanceRequirements,
+            RequirementsForConstitutionChange,
+            SideChainConsensus,
         },
     };
 
@@ -113,7 +110,6 @@ mod tests {
                     )),
                 }),
             },
-            initial_reward: MicroTari::from(123u64),
         };
 
         let constitution_update_proposal = ContractUpdateProposal {

--- a/base_layer/core/src/transactions/transaction_components/side_chain/sidechain_features.rs
+++ b/base_layer/core/src/transactions/transaction_components/side_chain/sidechain_features.rs
@@ -212,7 +212,6 @@ mod tests {
                     ),
                 }),
             },
-            initial_reward: 100.into(),
         };
 
         let subject = SideChainFeatures {

--- a/base_layer/core/src/validation/dan_validators/test_helpers.rs
+++ b/base_layer/core/src/validation/dan_validators/test_helpers.rs
@@ -200,7 +200,6 @@ pub fn create_contract_constitution() -> ContractConstitution {
                 backup_keys: Some(vec![].try_into().unwrap()),
             }),
         },
-        initial_reward: 100.into(),
     }
 }
 

--- a/base_layer/wallet/src/assets/constitution_definition_file_format.rs
+++ b/base_layer/wallet/src/assets/constitution_definition_file_format.rs
@@ -41,7 +41,6 @@ pub struct ConstitutionDefinitionFileFormat {
     pub contract_id: String,
     pub validator_committee: Vec<PublicKey>,
     pub consensus: SideChainConsensus,
-    pub initial_reward: u64,
     pub acceptance_parameters: ContractAcceptanceRequirements,
     pub checkpoint_parameters: CheckpointParameters,
     pub constitution_change_rules: ConstitutionChangeRulesFileFormat,
@@ -57,7 +56,6 @@ impl TryFrom<ConstitutionDefinitionFileFormat> for ContractConstitution {
             consensus: value.consensus,
             checkpoint_params: value.checkpoint_parameters,
             constitution_change_rules: value.constitution_change_rules.try_into()?,
-            initial_reward: value.initial_reward.into(),
         })
     }
 }

--- a/integration_tests/fixtures/contract_amendment.json
+++ b/integration_tests/fixtures/contract_amendment.json
@@ -28,8 +28,7 @@
     },
     "constitution_change_rules": {
       "change_flags": 1
-    },
-    "initial_reward": 5
+    }
   },
   "activation_window": 100
 }

--- a/integration_tests/fixtures/contract_constitution.json
+++ b/integration_tests/fixtures/contract_constitution.json
@@ -16,6 +16,5 @@
   },
   "constitution_change_rules": {
     "change_flags": 1
-  },
-  "initial_reward": 5
+  }
 }

--- a/integration_tests/fixtures/contract_update_proposal.json
+++ b/integration_tests/fixtures/contract_update_proposal.json
@@ -23,7 +23,6 @@
     },
     "constitution_change_rules": {
       "change_flags": 1
-    },
-    "initial_reward": 5
+    }
   }
 }


### PR DESCRIPTION
Description
---
Removed the initial_reward field from:
* Contract constitution and update proposal output features
* gRPC type definitions
* Sample test data
* Tari explorer visualizations

Motivation and Context
---
The team has discarded the direct reward system for contracts, so we need to remove all associated functionality from the project.

How Has This Been Tested?
---
The existing unit and integration test pass
