### PR TITLE
feat: read tor cookies from a file

### DIFF
--- a/base_layer/p2p/src/initialization.rs
+++ b/base_layer/p2p/src/initialization.rs
@@ -256,7 +256,7 @@ async fn initialize_hidden_service(
         .with_hs_flags(tor::HsFlags::DETACH)
         .with_port_mapping(config.to_port_mapping()?)
         .with_socks_authentication(config.to_socks_auth())
-        .with_control_server_auth(config.to_control_auth())
+        .with_control_server_auth(config.to_control_auth()?)
         .with_socks_address_override(config.socks_address_override)
         .with_control_server_address(config.control_address)
         .with_bypass_proxy_addresses(config.proxy_bypass_addresses.into());

--- a/base_layer/p2p/src/transport.rs
+++ b/base_layer/p2p/src/transport.rs
@@ -172,8 +172,11 @@ impl TorTransportConfig {
         Ok(tor::PortMapping::new(self.onion_port.get(), forward_addr))
     }
 
-    pub fn to_control_auth(&self) -> tor::Authentication {
-        self.control_auth.clone().into()
+    pub fn to_control_auth(&self) -> Result<tor::Authentication, CommsInitializationError> {
+        self.control_auth
+            .clone()
+            .make_tor_auth()
+            .map_err(CommsInitializationError::from)
     }
 
     pub fn to_socks_auth(&self) -> socks::Authentication {

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -3374,7 +3374,7 @@ pub unsafe extern "C" fn transport_tor_create(
         TorControlAuthentication::None
     } else {
         let cookie_hex = hex::to_hex((*tor_cookie).0.as_slice());
-        TorControlAuthentication::Cookie(cookie_hex)
+        TorControlAuthentication::hex(cookie_hex)
     };
 
     let onion_port = match NonZeroU16::new(tor_port) {


### PR DESCRIPTION
Description
---
The PR adds a capability to read a tor cookie from a file.
To set a `cookie` value in the config of the `tari_base_node` we could use three ways:

```toml
tor.control_auth = "cookie=HEX"
tor.control_auth = "cookie=@" # read `/run/tor/control.authcookie` default cookie file
tor.control_auth = "cookie=@/custom/path/to/cookie/file"
```

Motivation and Context
---
Fixes https://github.com/tari-project/tari/issues/2808

How Has This Been Tested?
---
CI and manually (Fedora 35, stardard `tor` service + added `ControlPort` to the config)
