### PR TITLE
fix: use SafePassword struct instead of String for passwords

### DIFF
--- a/applications/tari_console_wallet/src/cli.rs
+++ b/applications/tari_console_wallet/src/cli.rs
@@ -27,7 +27,10 @@ use clap::{Args, Parser, Subcommand};
 use tari_app_utilities::{common_cli_args::CommonCliArgs, utilities::UniPublicKey};
 use tari_comms::multiaddr::Multiaddr;
 use tari_core::transactions::{tari_amount, tari_amount::MicroTari};
-use tari_utilities::hex::{Hex, HexError};
+use tari_utilities::{
+    hex::{Hex, HexError},
+    SafePassword,
+};
 
 const DEFAULT_NETWORK: &str = "dibbler";
 
@@ -45,7 +48,7 @@ pub(crate) struct Cli {
     /// command line, since it's visible using `ps ax` from anywhere on the system, so always use the env var where
     /// possible.
     #[clap(long, env = "TARI_WALLET_PASSWORD", hide_env_values = true)]
-    pub password: Option<String>,
+    pub password: Option<SafePassword>,
     /// Change the password for the console wallet
     #[clap(long, alias = "update-password")]
     pub change_password: bool,

--- a/base_layer/wallet/src/config.rs
+++ b/base_layer/wallet/src/config.rs
@@ -34,6 +34,7 @@ use tari_common::{
 };
 use tari_comms::multiaddr::Multiaddr;
 use tari_p2p::P2pConfig;
+use tari_utilities::SafePassword;
 
 use crate::{
     base_node_service::config::BaseNodeServiceConfig,
@@ -72,7 +73,7 @@ pub struct WalletConfig {
     /// The main wallet db sqlite database backend connection pool size for concurrent reads
     pub db_connection_pool_size: usize,
     /// The main wallet password
-    pub password: Option<String>, // TODO: Make clear on drop
+    pub password: Option<SafePassword>,
     /// The auto ping interval to use for contacts liveness data
     #[serde(with = "serializers::seconds")]
     pub contacts_auto_ping_interval: Duration,

--- a/base_layer/wallet/src/storage/database.rs
+++ b/base_layer/wallet/src/storage/database.rs
@@ -34,6 +34,7 @@ use tari_comms::{
     tor::TorIdentity,
 };
 use tari_key_manager::cipher_seed::CipherSeed;
+use tari_utilities::SafePassword;
 
 use crate::{error::WalletStorageError, utxo_scanner_service::service::ScannedBlock};
 
@@ -46,7 +47,7 @@ pub trait WalletBackend: Send + Sync + Clone {
     /// Modify the state the of the backend with a write operation
     fn write(&self, op: WriteOperation) -> Result<Option<DbValue>, WalletStorageError>;
     /// Apply encryption to the backend.
-    fn apply_encryption(&self, passphrase: String) -> Result<Aes256Gcm, WalletStorageError>;
+    fn apply_encryption(&self, passphrase: SafePassword) -> Result<Aes256Gcm, WalletStorageError>;
     /// Remove encryption from the backend.
     fn remove_encryption(&self) -> Result<(), WalletStorageError>;
 
@@ -276,7 +277,7 @@ where T: WalletBackend + 'static
         Ok(())
     }
 
-    pub async fn apply_encryption(&self, passphrase: String) -> Result<Aes256Gcm, WalletStorageError> {
+    pub async fn apply_encryption(&self, passphrase: SafePassword) -> Result<Aes256Gcm, WalletStorageError> {
         let db_clone = self.db.clone();
         tokio::task::spawn_blocking(move || db_clone.apply_encryption(passphrase))
             .await

--- a/base_layer/wallet/src/storage/sqlite_utilities/mod.rs
+++ b/base_layer/wallet/src/storage/sqlite_utilities/mod.rs
@@ -25,6 +25,7 @@ use std::{fs::File, path::Path, time::Duration};
 use fs2::FileExt;
 use log::*;
 use tari_common_sqlite::sqlite_connection_pool::SqliteConnectionPool;
+use tari_utilities::SafePassword;
 pub use wallet_db_connection::WalletDbConnection;
 
 use crate::{
@@ -125,7 +126,7 @@ pub fn acquire_exclusive_file_lock(db_path: &Path) -> Result<File, WalletStorage
 
 pub fn initialize_sqlite_database_backends<P: AsRef<Path>>(
     db_path: P,
-    passphrase: Option<String>,
+    passphrase: Option<SafePassword>,
     sqlite_pool_size: usize,
 ) -> Result<
     (

--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -69,6 +69,7 @@ use tari_p2p::{
 use tari_script::{script, ExecutionStack, TariScript};
 use tari_service_framework::StackBuilder;
 use tari_shutdown::ShutdownSignal;
+use tari_utilities::SafePassword;
 
 use crate::{
     assets::{infrastructure::initializer::AssetManagerServiceInitializer, AssetManagerHandle},
@@ -685,7 +686,7 @@ where
 
     /// Apply encryption to all the Wallet db backends. The Wallet backend will test if the db's are already encrypted
     /// in which case this will fail.
-    pub async fn apply_encryption(&mut self, passphrase: String) -> Result<(), WalletError> {
+    pub async fn apply_encryption(&mut self, passphrase: SafePassword) -> Result<(), WalletError> {
         debug!(target: LOG_TARGET, "Applying wallet encryption.");
         let cipher = self.db.apply_encryption(passphrase).await?;
         self.output_manager_service.apply_encryption(cipher.clone()).await?;

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -131,7 +131,7 @@ use tari_p2p::{
 };
 use tari_script::{inputs, script};
 use tari_shutdown::Shutdown;
-use tari_utilities::{hex, hex::Hex};
+use tari_utilities::{hex, hex::Hex, SafePassword};
 use tari_wallet::{
     connectivity_service::WalletConnectivityInterface,
     contacts_service::storage::database::Contact,
@@ -4256,7 +4256,7 @@ pub unsafe extern "C" fn wallet_create(
             .to_str()
             .expect("A non-null passphrase should be able to be converted to string")
             .to_owned();
-        Some(pf)
+        Some(SafePassword::from(pf))
     };
 
     let network = if network_str.is_null() {
@@ -6792,8 +6792,8 @@ pub unsafe extern "C" fn wallet_apply_encryption(
 
     let pf = CStr::from_ptr(passphrase)
         .to_str()
-        .expect("A non-null passphrase should be able to be converted to string")
-        .to_owned();
+        .map(|s| SafePassword::from(s.to_owned()))
+        .expect("A non-null passphrase should be able to be converted to string");
 
     if let Err(e) = (*wallet).runtime.block_on((*wallet).wallet.apply_encryption(pf)) {
         error = LibWalletError::from(e).code;


### PR DESCRIPTION
Description
---
This update replaces `String` types with `SafePassword` wrapper to be sure app the passwords:
- zeroized
- never printed

Related: https://github.com/tari-project/tari_utilities/pull/46

Motivation and Context
---
To guarantee all the passphrases erased.

How Has This Been Tested?
---
CI

