### PR TITLE
fix: remove tari_common dep from keymanager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7239,7 +7239,6 @@ dependencies = [
  "sha2 0.9.9",
  "strum 0.22.0",
  "strum_macros 0.22.0",
- "tari_common",
  "tari_common_types",
  "tari_crypto",
  "tari_utilities",

--- a/base_layer/key_manager/Cargo.toml
+++ b/base_layer/key_manager/Cargo.toml
@@ -12,7 +12,6 @@ crate-type = ["lib", "cdylib"]
 
 [dependencies]
 tari_common_types = { version = "^0.34", path = "../../base_layer/common_types" }
-tari_common = {path = "../../common"}
 tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.0" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.4" }
 

--- a/base_layer/key_manager/src/lib.rs
+++ b/base_layer/key_manager/src/lib.rs
@@ -1,8 +1,6 @@
 // Copyright 2022 The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
 
-use tari_common::hashing_domain::HashingDomain;
-
 pub mod cipher_seed;
 pub mod diacritics;
 pub mod error;
@@ -13,11 +11,3 @@ pub mod mnemonic_wordlists;
 #[allow(clippy::unused_unit)]
 #[cfg(feature = "wasm")]
 pub mod wasm;
-
-/// The base layer key manager domain separated hashing domain
-/// Usage:
-///   let hash = key_manager_hash_domain().digest::<Blake256>(b"my secret");
-///   etc.
-pub fn key_manager_hash_domain() -> HashingDomain {
-    HashingDomain::new("base_layer.key_manager")
-}


### PR DESCRIPTION
Description
---
- removes tari_common dependency from the key manager
- remove (unused) `key_manager_hash_domain` function

Motivation and Context
---
Quick fix to fix CI WASM tests as `fs2` does not support the WASM target.
Suggest moving hashing domain into its own crate.


A hardcoded domain for all keys within key manager is likely not correct and should be specified by the caller e.g. independent KeyManager domain for wallet etc.