### PR TITLE
fix: address domain separation regarding challenge generation for mac origin (see issue #4333)

### DIFF
--- a/base_layer/p2p/src/services/liveness/service.rs
+++ b/base_layer/p2p/src/services/liveness/service.rs
@@ -486,7 +486,7 @@ mod test {
             dht_header: DhtMessageHeader {
                 version: DhtProtocolVersion::latest(),
                 destination: Default::default(),
-                origin_mac: Vec::new(),
+                message_signature: Vec::new(),
                 ephemeral_public_key: None,
                 message_type: DhtMessageType::None,
                 flags: Default::default(),

--- a/base_layer/p2p/src/test_utils.rs
+++ b/base_layer/p2p/src/test_utils.rs
@@ -63,7 +63,7 @@ pub fn make_dht_header(trace: MessageTag) -> DhtMessageHeader {
     DhtMessageHeader {
         version: DhtProtocolVersion::latest(),
         destination: NodeDestination::Unknown,
-        origin_mac: Vec::new(),
+        message_signature: Vec::new(),
         ephemeral_public_key: None,
         message_type: DhtMessageType::None,
         flags: DhtMessageFlags::NONE,

--- a/base_layer/wallet/tests/support/comms_and_services.rs
+++ b/base_layer/wallet/tests/support/comms_and_services.rs
@@ -80,7 +80,7 @@ pub fn create_dummy_message<T>(inner: T, public_key: &CommsPublicKey) -> DomainM
         dht_header: DhtMessageHeader {
             version: DhtProtocolVersion::latest(),
             ephemeral_public_key: None,
-            origin_mac: Vec::new(),
+            message_signature: Vec::new(),
             message_type: Default::default(),
             flags: Default::default(),
             destination: Default::default(),

--- a/comms/dht/src/dedup/mod.rs
+++ b/comms/dht/src/dedup/mod.rs
@@ -44,11 +44,11 @@ use crate::{
 const LOG_TARGET: &str = "comms::dht::dedup";
 
 pub fn hash_inbound_message(msg: &DhtInboundMessage) -> [u8; 32] {
-    create_message_hash(&msg.dht_header.origin_mac, &msg.body)
+    create_message_hash(&msg.dht_header.message_signature, &msg.body)
 }
 
-pub fn create_message_hash(origin_mac: &[u8], body: &[u8]) -> [u8; 32] {
-    Challenge::new().chain(origin_mac).chain(&body).finalize().into()
+pub fn create_message_hash(message_signature: &[u8], body: &[u8]) -> [u8; 32] {
+    Challenge::new().chain(message_signature).chain(&body).finalize().into()
 }
 
 /// # DHT Deduplication middleware

--- a/comms/dht/src/dht.rs
+++ b/comms/dht/src/dht.rs
@@ -606,8 +606,8 @@ mod test {
             true,
         );
 
-        let origin_mac = dht_envelope.header.as_ref().unwrap().origin_mac.clone();
-        assert!(!origin_mac.is_empty());
+        let message_signature = dht_envelope.header.as_ref().unwrap().message_signature.clone();
+        assert!(!message_signature.is_empty());
         let inbound_message = make_comms_inbound_message(&node_identity, dht_envelope.to_encoded_bytes().into());
 
         service.call(inbound_message).await.unwrap();
@@ -616,7 +616,7 @@ mod test {
         let (params, _) = oms_mock_state.pop_call().await.unwrap();
 
         // Check that OMS got a request to forward with the original Dht Header
-        assert_eq!(params.dht_header.unwrap().origin_mac, origin_mac);
+        assert_eq!(params.dht_header.unwrap().message_signature, message_signature);
 
         // Check the next service was not called
         assert_eq!(spy.call_count(), 0);

--- a/comms/dht/src/envelope.rs
+++ b/comms/dht/src/envelope.rs
@@ -140,8 +140,8 @@ impl DhtMessageType {
 pub struct DhtMessageHeader {
     pub version: DhtProtocolVersion,
     pub destination: NodeDestination,
-    /// Encoded MessageSignature. Depending on message flags, this may be encrypted. This can refer to the same peer that sent
-    /// the message or another peer if the message is being propagated.
+    /// Encoded MessageSignature. Depending on message flags, this may be encrypted. This can refer to the same peer
+    /// that sent the message or another peer if the message is being propagated.
     pub message_signature: Vec<u8>,
     pub ephemeral_public_key: Option<CommsPublicKey>,
     pub message_type: DhtMessageType,

--- a/comms/dht/src/inbound/decryption.rs
+++ b/comms/dht/src/inbound/decryption.rs
@@ -248,7 +248,7 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
             Ok(origin_mac) => {
                 // If this fails, discard the message because we decrypted and deserialized the message with our shared
                 // ECDH secret but the message could not be authenticated
-                let msg_challenge = crypt::create_message_challenge(&message.dht_header, &message.body);
+                let msg_challenge = crypt::create_message_domain_separated_hash(&message.dht_header, &message.body);
                 Self::authenticate_origin_mac(&origin_mac, &msg_challenge)?;
                 origin_mac.into_signer_public_key()
             },
@@ -385,9 +385,9 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
                 .map_err(|_| DecryptionError::OriginMacClearTextDecodeFailed)?
                 .try_into()?;
 
-            let mac_challenge = crypt::create_message_challenge(&message.dht_header, &message.body);
+            let hash_data = crypt::create_message_domain_separated_hash(&message.dht_header, &message.body);
 
-            Self::authenticate_origin_mac(&origin_mac, &mac_challenge)?;
+            Self::authenticate_origin_mac(&origin_mac, &hash_data)?;
             Some(origin_mac.into_signer_public_key())
         };
 

--- a/comms/dht/src/inbound/decryption.rs
+++ b/comms/dht/src/inbound/decryption.rs
@@ -336,7 +336,10 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
         Ok(message_signature)
     }
 
-    fn authenticate_message_signature(message_signature: &MessageSignature, message: &[u8]) -> Result<(), DecryptionError> {
+    fn authenticate_message_signature(
+        message_signature: &MessageSignature,
+        message: &[u8],
+    ) -> Result<(), DecryptionError> {
         if message_signature.verify(message) {
             Ok(())
         } else {
@@ -382,9 +385,10 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
         let authenticated_pk = if message.dht_header.message_signature.is_empty() {
             None
         } else {
-            let message_signature: MessageSignature = ProtoMessageSignature::decode(message.dht_header.message_signature.as_slice())
-                .map_err(|_| DecryptionError::MessageSignatureClearTextDecodeFailed)?
-                .try_into()?;
+            let message_signature: MessageSignature =
+                ProtoMessageSignature::decode(message.dht_header.message_signature.as_slice())
+                    .map_err(|_| DecryptionError::MessageSignatureClearTextDecodeFailed)?
+                    .try_into()?;
 
             let binding_message_representation =
                 crypt::create_message_domain_separated_hash(&message.dht_header, &message.body);

--- a/comms/dht/src/inbound/decryption.rs
+++ b/comms/dht/src/inbound/decryption.rs
@@ -248,8 +248,8 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
             Ok(origin_mac) => {
                 // If this fails, discard the message because we decrypted and deserialized the message with our shared
                 // ECDH secret but the message could not be authenticated
-                let msg_challenge = crypt::create_message_domain_separated_hash(&message.dht_header, &message.body);
-                Self::authenticate_origin_mac(&origin_mac, &msg_challenge)?;
+                let binding_message_representation = crypt::create_message_domain_separated_hash(&message.dht_header, &message.body);
+                Self::authenticate_origin_mac(&origin_mac, &binding_message_representation)?;
                 origin_mac.into_signer_public_key()
             },
             Err(err) => {
@@ -385,9 +385,9 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
                 .map_err(|_| DecryptionError::OriginMacClearTextDecodeFailed)?
                 .try_into()?;
 
-            let hash_data = crypt::create_message_domain_separated_hash(&message.dht_header, &message.body);
+            let binding_message_representation = crypt::create_message_domain_separated_hash(&message.dht_header, &message.body);
 
-            Self::authenticate_origin_mac(&origin_mac, &hash_data)?;
+            Self::authenticate_origin_mac(&origin_mac, &binding_message_representation)?;
             Some(origin_mac.into_signer_public_key())
         };
 

--- a/comms/dht/src/inbound/decryption.rs
+++ b/comms/dht/src/inbound/decryption.rs
@@ -248,7 +248,8 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
             Ok(origin_mac) => {
                 // If this fails, discard the message because we decrypted and deserialized the message with our shared
                 // ECDH secret but the message could not be authenticated
-                let binding_message_representation = crypt::create_message_domain_separated_hash(&message.dht_header, &message.body);
+                let binding_message_representation =
+                    crypt::create_message_domain_separated_hash(&message.dht_header, &message.body);
                 Self::authenticate_origin_mac(&origin_mac, &binding_message_representation)?;
                 origin_mac.into_signer_public_key()
             },
@@ -385,7 +386,8 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
                 .map_err(|_| DecryptionError::OriginMacClearTextDecodeFailed)?
                 .try_into()?;
 
-            let binding_message_representation = crypt::create_message_domain_separated_hash(&message.dht_header, &message.body);
+            let binding_message_representation =
+                crypt::create_message_domain_separated_hash(&message.dht_header, &message.body);
 
             Self::authenticate_origin_mac(&origin_mac, &binding_message_representation)?;
             Some(origin_mac.into_signer_public_key())

--- a/comms/dht/src/inbound/decryption.rs
+++ b/comms/dht/src/inbound/decryption.rs
@@ -39,7 +39,7 @@ use crate::{
     crypt::CipherKey,
     envelope::DhtMessageHeader,
     inbound::message::{DecryptedDhtMessage, DhtInboundMessage},
-    origin_mac::{OriginMac, OriginMacError, ProtoOriginMac},
+    message_signature::{MessageSignature, MessageSignatureError, ProtoMessageSignature},
     DhtConfig,
 };
 
@@ -48,15 +48,15 @@ const LOG_TARGET: &str = "comms::middleware::decryption";
 #[derive(Error, Debug)]
 enum DecryptionError {
     #[error("Failed to validate origin MAC signature")]
-    OriginMacInvalidSignature,
+    MessageSignatureInvalidSignature,
     #[error("Origin MAC not provided for encrypted message")]
-    OriginMacNotProvided,
+    MessageSignatureNotProvided,
     #[error("Failed to decrypt origin MAC")]
-    OriginMacDecryptedFailed,
+    MessageSignatureDecryptedFailed,
     #[error("Failed to decode clear-text origin MAC")]
-    OriginMacClearTextDecodeFailed,
+    MessageSignatureClearTextDecodeFailed,
     #[error("Origin MAC error: {0}")]
-    OriginMacError(#[from] OriginMacError),
+    MessageSignatureError(#[from] MessageSignatureError),
     #[error("Ephemeral public key not provided for encrypted message")]
     EphemeralKeyNotProvided,
     #[error("Message rejected because this node could not decrypt a message that was addressed to it")]
@@ -169,11 +169,11 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
                 next_service.oneshot(msg).await
             },
 
-            Err(err @ OriginMacNotProvided) |
+            Err(err @ MessageSignatureNotProvided) |
             Err(err @ EphemeralKeyNotProvided) |
             Err(err @ EncryptedMessageNoDestination) |
-            Err(err @ OriginMacInvalidSignature) |
-            Err(err @ OriginMacError(_)) => {
+            Err(err @ MessageSignatureInvalidSignature) |
+            Err(err @ MessageSignatureError(_)) => {
                 // This message should not have been propagated, or has been manipulated in some way. Ban the source of
                 // this message.
                 connectivity
@@ -244,14 +244,14 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
         let shared_secret = crypt::generate_ecdh_secret(node_identity.secret_key(), e_pk);
 
         // Decrypt and verify the origin
-        let authenticated_origin = match Self::attempt_decrypt_origin_mac(&shared_secret, dht_header) {
-            Ok(origin_mac) => {
+        let authenticated_origin = match Self::attempt_decrypt_message_signature(&shared_secret, dht_header) {
+            Ok(message_signature) => {
                 // If this fails, discard the message because we decrypted and deserialized the message with our shared
                 // ECDH secret but the message could not be authenticated
                 let binding_message_representation =
                     crypt::create_message_domain_separated_hash(&message.dht_header, &message.body);
-                Self::authenticate_origin_mac(&origin_mac, &binding_message_representation)?;
-                origin_mac.into_signer_public_key()
+                Self::authenticate_message_signature(&message_signature, &binding_message_representation)?;
+                message_signature.into_signer_public_key()
             },
             Err(err) => {
                 trace!(
@@ -270,7 +270,7 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
                         message.tag,
                         message.dht_header.message_tag
                     );
-                    return Err(DecryptionError::OriginMacDecryptedFailed);
+                    return Err(DecryptionError::MessageSignatureDecryptedFailed);
                 }
                 return Ok(DecryptedDhtMessage::failed(message));
             },
@@ -318,29 +318,29 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
         }
     }
 
-    fn attempt_decrypt_origin_mac(
+    fn attempt_decrypt_message_signature(
         shared_secret: &CipherKey,
         dht_header: &DhtMessageHeader,
-    ) -> Result<OriginMac, DecryptionError> {
-        let encrypted_origin_mac = Some(&dht_header.origin_mac)
+    ) -> Result<MessageSignature, DecryptionError> {
+        let encrypted_message_signature = Some(&dht_header.message_signature)
             .filter(|b| !b.is_empty())
             // This should not have been sent/propagated
-            .ok_or( DecryptionError::OriginMacNotProvided)?;
+            .ok_or( DecryptionError::MessageSignatureNotProvided)?;
 
-        let decrypted_bytes = crypt::decrypt(shared_secret, encrypted_origin_mac)
-            .map_err(|_| DecryptionError::OriginMacDecryptedFailed)?;
-        let origin_mac = ProtoOriginMac::decode(decrypted_bytes.as_slice())
-            .map_err(|_| DecryptionError::OriginMacDecryptedFailed)?;
+        let decrypted_bytes = crypt::decrypt(shared_secret, encrypted_message_signature)
+            .map_err(|_| DecryptionError::MessageSignatureDecryptedFailed)?;
+        let message_signature = ProtoMessageSignature::decode(decrypted_bytes.as_slice())
+            .map_err(|_| DecryptionError::MessageSignatureDecryptedFailed)?;
 
-        let origin_mac = origin_mac.try_into()?;
-        Ok(origin_mac)
+        let message_signature = message_signature.try_into()?;
+        Ok(message_signature)
     }
 
-    fn authenticate_origin_mac(origin_mac: &OriginMac, message: &[u8]) -> Result<(), DecryptionError> {
-        if origin_mac.verify(message) {
+    fn authenticate_message_signature(message_signature: &MessageSignature, message: &[u8]) -> Result<(), DecryptionError> {
+        if message_signature.verify(message) {
             Ok(())
         } else {
-            Err(DecryptionError::OriginMacInvalidSignature)
+            Err(DecryptionError::MessageSignatureInvalidSignature)
         }
     }
 
@@ -379,18 +379,18 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
     }
 
     async fn success_not_encrypted(message: DhtInboundMessage) -> Result<DecryptedDhtMessage, DecryptionError> {
-        let authenticated_pk = if message.dht_header.origin_mac.is_empty() {
+        let authenticated_pk = if message.dht_header.message_signature.is_empty() {
             None
         } else {
-            let origin_mac: OriginMac = ProtoOriginMac::decode(message.dht_header.origin_mac.as_slice())
-                .map_err(|_| DecryptionError::OriginMacClearTextDecodeFailed)?
+            let message_signature: MessageSignature = ProtoMessageSignature::decode(message.dht_header.message_signature.as_slice())
+                .map_err(|_| DecryptionError::MessageSignatureClearTextDecodeFailed)?
                 .try_into()?;
 
             let binding_message_representation =
                 crypt::create_message_domain_separated_hash(&message.dht_header, &message.body);
 
-            Self::authenticate_origin_mac(&origin_mac, &binding_message_representation)?;
-            Some(origin_mac.into_signer_public_key())
+            Self::authenticate_message_signature(&message_signature, &binding_message_representation)?;
+            Some(message_signature.into_signer_public_key())
         };
 
         match EnvelopeBody::decode(message.body.as_slice()) {

--- a/comms/dht/src/inbound/message.rs
+++ b/comms/dht/src/inbound/message.rs
@@ -172,8 +172,8 @@ impl DecryptedDhtMessage {
         self.dht_header.flags.contains(DhtMessageFlags::ENCRYPTED)
     }
 
-    pub fn has_origin_mac(&self) -> bool {
-        !self.dht_header.origin_mac.is_empty()
+    pub fn has_message_signature(&self) -> bool {
+        !self.dht_header.message_signature.is_empty()
     }
 
     pub fn body_len(&self) -> usize {

--- a/comms/dht/src/lib.rs
+++ b/comms/dht/src/lib.rs
@@ -103,7 +103,7 @@ use tari_common::hashing_domain::HashingDomain;
 
 mod filter;
 mod logging_middleware;
-mod origin_mac;
+mod message_signature;
 mod peer_validator;
 mod proto;
 mod rpc;

--- a/comms/dht/src/message_signature.rs
+++ b/comms/dht/src/message_signature.rs
@@ -29,12 +29,12 @@ use tari_crypto::keys::PublicKey;
 use tari_utilities::ByteArray;
 
 #[derive(Debug, Clone)]
-pub struct OriginMac {
+pub struct MessageSignature {
     signer_public_key: CommsPublicKey,
     signature: Signature,
 }
 
-fn construct_origin_mac_hash(
+fn construct_message_signature_hash(
     signer_public_key: &CommsPublicKey,
     public_nonce: &CommsPublicKey,
     message: &[u8],
@@ -48,12 +48,12 @@ fn construct_origin_mac_hash(
         .into()
 }
 
-impl OriginMac {
-    /// Create a new signed [OriginMac](self::OriginMac) for the given message.
+impl MessageSignature {
+    /// Create a new signed [MessageSignature](self::MessageSignature) for the given message.
     pub fn new_signed(signer_secret_key: CommsSecretKey, message: &[u8]) -> Self {
         let (nonce_s, nonce_pk) = CommsPublicKey::random_keypair(&mut OsRng);
         let signer_public_key = CommsPublicKey::from_secret_key(&signer_secret_key);
-        let challenge = construct_origin_mac_hash(&signer_public_key, &nonce_pk, message);
+        let challenge = construct_message_signature_hash(&signer_public_key, &nonce_pk, message);
         let signature = Signature::sign(signer_secret_key, nonce_s, &challenge)
             .expect("challenge is [u8;32] but SchnorrSignature::sign failed");
 
@@ -65,7 +65,7 @@ impl OriginMac {
 
     /// Returns true if the provided message valid for this origin MAC, otherwise false.
     pub fn verify(&self, message: &[u8]) -> bool {
-        let challenge = construct_origin_mac_hash(&self.signer_public_key, self.signature.get_public_nonce(), message);
+        let challenge = construct_message_signature_hash(&self.signer_public_key, self.signature.get_public_nonce(), message);
         self.signature.verify_challenge(&self.signer_public_key, &challenge)
     }
 
@@ -75,8 +75,8 @@ impl OriginMac {
     }
 
     /// Converts to a protobuf struct
-    pub fn to_proto(&self) -> ProtoOriginMac {
-        ProtoOriginMac {
+    pub fn to_proto(&self) -> ProtoMessageSignature {
+        ProtoMessageSignature {
             signer_public_key: self.signer_public_key.to_vec(),
             public_nonce: self.signature.get_public_nonce().to_vec(),
             signature: self.signature.get_signature().to_vec(),
@@ -84,18 +84,18 @@ impl OriginMac {
     }
 }
 
-impl TryFrom<ProtoOriginMac> for OriginMac {
-    type Error = OriginMacError;
+impl TryFrom<ProtoMessageSignature> for MessageSignature {
+    type Error = MessageSignatureError;
 
-    fn try_from(origin_mac: ProtoOriginMac) -> Result<Self, Self::Error> {
-        let signer_public_key = CommsPublicKey::from_bytes(&origin_mac.signer_public_key)
-            .map_err(|_| OriginMacError::InvalidSignerPublicKey)?;
+    fn try_from(message_signature: ProtoMessageSignature) -> Result<Self, Self::Error> {
+        let signer_public_key = CommsPublicKey::from_bytes(&message_signature.signer_public_key)
+            .map_err(|_| MessageSignatureError::InvalidSignerPublicKey)?;
 
         let public_nonce =
-            CommsPublicKey::from_bytes(&origin_mac.public_nonce).map_err(|_| OriginMacError::InvalidPublicNonce)?;
+            CommsPublicKey::from_bytes(&message_signature.public_nonce).map_err(|_| MessageSignatureError::InvalidPublicNonce)?;
 
         let signature =
-            CommsSecretKey::from_bytes(&origin_mac.signature).map_err(|_| OriginMacError::InvalidSignature)?;
+            CommsSecretKey::from_bytes(&message_signature.signature).map_err(|_| MessageSignatureError::InvalidSignature)?;
 
         Ok(Self {
             signer_public_key,
@@ -104,9 +104,9 @@ impl TryFrom<ProtoOriginMac> for OriginMac {
     }
 }
 
-/// The Message Authentication Code (MAC) message format of the decrypted `DhtHeader::origin_mac` field
+/// The Message Authentication Code (MAC) message format of the decrypted `DhtHeader::message_signature` field
 #[derive(Clone, prost::Message)]
-pub struct ProtoOriginMac {
+pub struct ProtoMessageSignature {
     #[prost(bytes, tag = "1")]
     pub signer_public_key: Vec<u8>,
     #[prost(bytes, tag = "2")]
@@ -116,7 +116,7 @@ pub struct ProtoOriginMac {
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum OriginMacError {
+pub enum MessageSignatureError {
     #[error("Failed to decrypt origin MAC")]
     DecryptedFailed,
     #[error("Failed to validate origin MAC signature")]
@@ -136,9 +136,9 @@ mod test {
     use super::*;
     const MSG: &[u8] = b"100% genuine";
 
-    fn setup() -> (OriginMac, CommsSecretKey) {
+    fn setup() -> (MessageSignature, CommsSecretKey) {
         let signer_k = CommsSecretKey::random(&mut OsRng);
-        (OriginMac::new_signed(signer_k.clone(), MSG), signer_k)
+        (MessageSignature::new_signed(signer_k.clone(), MSG), signer_k)
     }
 
     #[test]
@@ -152,7 +152,7 @@ mod test {
     fn it_is_secure_against_related_key_attack() {
         let (mut mac, signer_k) = setup();
         let signer_pk = CommsPublicKey::from_secret_key(&signer_k);
-        let msg = construct_origin_mac_hash(&signer_pk, mac.signature.get_public_nonce(), MSG);
+        let msg = construct_message_signature_hash(&signer_pk, mac.signature.get_public_nonce(), MSG);
         let msg_scalar = CommsSecretKey::from_bytes(&msg).unwrap();
 
         // Some `a` key
@@ -173,7 +173,7 @@ mod test {
         let (nonce_k, _) = CommsPublicKey::random_keypair(&mut OsRng);
         // Get the original hashed challenge
         let signer_pk = CommsPublicKey::from_secret_key(&signer_k);
-        let msg = construct_origin_mac_hash(&signer_pk, mac.signature.get_public_nonce(), MSG);
+        let msg = construct_message_signature_hash(&signer_pk, mac.signature.get_public_nonce(), MSG);
 
         // Change <R, s> to <R', s>. Note: We need signer_k because the Signature interface does not provide a way to
         // change just the public nonce, an attacker does not need the secret key.

--- a/comms/dht/src/message_signature.rs
+++ b/comms/dht/src/message_signature.rs
@@ -65,7 +65,8 @@ impl MessageSignature {
 
     /// Returns true if the provided message valid for this origin MAC, otherwise false.
     pub fn verify(&self, message: &[u8]) -> bool {
-        let challenge = construct_message_signature_hash(&self.signer_public_key, self.signature.get_public_nonce(), message);
+        let challenge =
+            construct_message_signature_hash(&self.signer_public_key, self.signature.get_public_nonce(), message);
         self.signature.verify_challenge(&self.signer_public_key, &challenge)
     }
 
@@ -91,11 +92,11 @@ impl TryFrom<ProtoMessageSignature> for MessageSignature {
         let signer_public_key = CommsPublicKey::from_bytes(&message_signature.signer_public_key)
             .map_err(|_| MessageSignatureError::InvalidSignerPublicKey)?;
 
-        let public_nonce =
-            CommsPublicKey::from_bytes(&message_signature.public_nonce).map_err(|_| MessageSignatureError::InvalidPublicNonce)?;
+        let public_nonce = CommsPublicKey::from_bytes(&message_signature.public_nonce)
+            .map_err(|_| MessageSignatureError::InvalidPublicNonce)?;
 
-        let signature =
-            CommsSecretKey::from_bytes(&message_signature.signature).map_err(|_| MessageSignatureError::InvalidSignature)?;
+        let signature = CommsSecretKey::from_bytes(&message_signature.signature)
+            .map_err(|_| MessageSignatureError::InvalidSignature)?;
 
         Ok(Self {
             signer_public_key,

--- a/comms/dht/src/outbound/broadcast.rs
+++ b/comms/dht/src/outbound/broadcast.rs
@@ -509,11 +509,14 @@ where S: Service<DhtOutboundMessage, Response = (), Error = PipelineError>
                     &encrypted_body,
                 );
                 // Sign the encrypted message
-                let signature =
-                    MessageSignature::new_signed(self.node_identity.secret_key().clone(), &binding_message_representation)
-                        .to_proto();
+                let signature = MessageSignature::new_signed(
+                    self.node_identity.secret_key().clone(),
+                    &binding_message_representation,
+                )
+                .to_proto();
                 // Encrypt and set the origin field
-                let encrypted_message_signature = crypt::encrypt(&shared_ephemeral_secret, &signature.to_encoded_bytes());
+                let encrypted_message_signature =
+                    crypt::encrypt(&shared_ephemeral_secret, &signature.to_encoded_bytes());
                 Ok((
                     Some(Arc::new(e_public_key)),
                     Some(encrypted_message_signature.into()),
@@ -533,9 +536,11 @@ where S: Service<DhtOutboundMessage, Response = (), Error = PipelineError>
                         None,
                         &body,
                     );
-                    let signature =
-                        MessageSignature::new_signed(self.node_identity.secret_key().clone(), &binding_message_representation)
-                            .to_proto();
+                    let signature = MessageSignature::new_signed(
+                        self.node_identity.secret_key().clone(),
+                        &binding_message_representation,
+                    )
+                    .to_proto();
                     Ok((None, Some(signature.to_encoded_bytes().into()), body))
                 } else {
                     Ok((None, None, body))

--- a/comms/dht/src/outbound/broadcast.rs
+++ b/comms/dht/src/outbound/broadcast.rs
@@ -499,7 +499,7 @@ where S: Service<DhtOutboundMessage, Response = (), Error = PipelineError>
                 // Encrypt the message with the body
                 let encrypted_body = crypt::encrypt(&shared_ephemeral_secret, &body);
 
-                let mac_challenge = crypt::create_message_challenge_parts(
+                let hash_data = crypt::create_message_domain_separated_hash_parts(
                     self.protocol_version,
                     destination,
                     message_type,
@@ -510,7 +510,7 @@ where S: Service<DhtOutboundMessage, Response = (), Error = PipelineError>
                 );
                 // Sign the encrypted message
                 let origin_mac =
-                    OriginMac::new_signed(self.node_identity.secret_key().clone(), &mac_challenge).to_proto();
+                    OriginMac::new_signed(self.node_identity.secret_key().clone(), &hash_data).to_proto();
                 // Encrypt and set the origin field
                 let encrypted_origin_mac = crypt::encrypt(&shared_ephemeral_secret, &origin_mac.to_encoded_bytes());
                 Ok((
@@ -523,7 +523,7 @@ where S: Service<DhtOutboundMessage, Response = (), Error = PipelineError>
                 trace!(target: LOG_TARGET, "Encryption not requested for message");
 
                 if include_origin {
-                    let mac_challenge = crypt::create_message_challenge_parts(
+                    let hash_data = crypt::create_message_domain_separated_hash_parts(
                         self.protocol_version,
                         destination,
                         message_type,
@@ -533,7 +533,7 @@ where S: Service<DhtOutboundMessage, Response = (), Error = PipelineError>
                         &body,
                     );
                     let origin_mac =
-                        OriginMac::new_signed(self.node_identity.secret_key().clone(), &mac_challenge).to_proto();
+                        OriginMac::new_signed(self.node_identity.secret_key().clone(), &hash_data).to_proto();
                     Ok((None, Some(origin_mac.to_encoded_bytes().into()), body))
                 } else {
                     Ok((None, None, body))

--- a/comms/dht/src/outbound/broadcast.rs
+++ b/comms/dht/src/outbound/broadcast.rs
@@ -509,8 +509,7 @@ where S: Service<DhtOutboundMessage, Response = (), Error = PipelineError>
                     &encrypted_body,
                 );
                 // Sign the encrypted message
-                let origin_mac =
-                    OriginMac::new_signed(self.node_identity.secret_key().clone(), &hash_data).to_proto();
+                let origin_mac = OriginMac::new_signed(self.node_identity.secret_key().clone(), &hash_data).to_proto();
                 // Encrypt and set the origin field
                 let encrypted_origin_mac = crypt::encrypt(&shared_ephemeral_secret, &origin_mac.to_encoded_bytes());
                 Ok((

--- a/comms/dht/src/outbound/broadcast.rs
+++ b/comms/dht/src/outbound/broadcast.rs
@@ -509,7 +509,9 @@ where S: Service<DhtOutboundMessage, Response = (), Error = PipelineError>
                     &encrypted_body,
                 );
                 // Sign the encrypted message
-                let signature = OriginMac::new_signed(self.node_identity.secret_key().clone(), &binding_message_representation).to_proto();
+                let signature =
+                    OriginMac::new_signed(self.node_identity.secret_key().clone(), &binding_message_representation)
+                        .to_proto();
                 // Encrypt and set the origin field
                 let encrypted_origin_mac = crypt::encrypt(&shared_ephemeral_secret, &signature.to_encoded_bytes());
                 Ok((
@@ -532,7 +534,8 @@ where S: Service<DhtOutboundMessage, Response = (), Error = PipelineError>
                         &body,
                     );
                     let signature =
-                        OriginMac::new_signed(self.node_identity.secret_key().clone(), &binding_message_representation).to_proto();
+                        OriginMac::new_signed(self.node_identity.secret_key().clone(), &binding_message_representation)
+                            .to_proto();
                     Ok((None, Some(signature.to_encoded_bytes().into()), body))
                 } else {
                     Ok((None, None, body))

--- a/comms/dht/src/outbound/message.rs
+++ b/comms/dht/src/outbound/message.rs
@@ -168,7 +168,7 @@ pub struct DhtOutboundMessage {
     pub custom_header: Option<DhtMessageHeader>,
     pub body: Bytes,
     pub ephemeral_public_key: Option<Arc<CommsPublicKey>>,
-    pub origin_mac: Option<Bytes>,
+    pub message_signature: Option<Bytes>,
     pub destination: NodeDestination,
     pub dht_message_type: DhtMessageType,
     pub reply: MessagingReplyTx,

--- a/comms/dht/src/outbound/serialize.rs
+++ b/comms/dht/src/outbound/serialize.rs
@@ -76,7 +76,7 @@ where
             destination,
             dht_message_type,
             dht_flags,
-            origin_mac,
+            message_signature,
             reply,
             expires,
             ..
@@ -89,7 +89,7 @@ where
         );
         let dht_header = custom_header.map(DhtHeader::from).unwrap_or_else(|| DhtHeader {
             major: protocol_version.as_major() as u32,
-            origin_mac: origin_mac.map(|b| b.to_vec()).unwrap_or_else(Vec::new),
+            message_signature: message_signature.map(|b| b.to_vec()).unwrap_or_else(Vec::new),
             ephemeral_public_key: ephemeral_public_key.map(|e| e.to_vec()).unwrap_or_else(Vec::new),
             message_type: dht_message_type as i32,
             flags: dht_flags.bits(),

--- a/comms/dht/src/proto/envelope.proto
+++ b/comms/dht/src/proto/envelope.proto
@@ -38,7 +38,7 @@ message DhtHeader {
     // or another peer if the message should be forwarded. This is optional but MUST be specified
     // if the ENCRYPTED flag is set.
     // If an ephemeral_public_key is specified, this MUST be encrypted using a derived ECDH shared key
-    bytes origin_mac = 6;
+    bytes message_signature = 6;
     // Ephemeral public key component of the ECDH shared key. MUST be specified if the ENCRYPTED flag is set.
     bytes ephemeral_public_key = 7;
     // The type of message

--- a/comms/dht/src/store_forward/database/stored_message.rs
+++ b/comms/dht/src/store_forward/database/stored_message.rs
@@ -62,7 +62,7 @@ impl NewStoredMessage {
             Ok(envelope_body) => envelope_body.to_encoded_bytes(),
             Err(encrypted_body) => encrypted_body,
         };
-        let body_hash = hex::to_hex(&dedup::create_message_hash(&dht_header.origin_mac, &body));
+        let body_hash = hex::to_hex(&dedup::create_message_hash(&dht_header.message_signature, &body));
 
         Some(Self {
             version: dht_header.version.as_major().try_into().ok()?,

--- a/comms/dht/src/store_forward/error.rs
+++ b/comms/dht/src/store_forward/error.rs
@@ -33,7 +33,7 @@ use thiserror::Error;
 use crate::{
     actor::DhtActorError,
     envelope::DhtMessageError,
-    origin_mac::OriginMacError,
+    message_signature::MessageSignatureError,
     outbound::DhtOutboundError,
     storage::StorageError,
 };
@@ -52,7 +52,7 @@ pub enum StoreAndForwardError {
     #[error("Received stored message has an invalid destination")]
     InvalidDestination,
     #[error("Received stored message has an invalid origin signature: {0}")]
-    InvalidOriginMac(#[from] OriginMacError),
+    InvalidMessageSignature(#[from] MessageSignatureError),
     #[error("Invalid envelope body")]
     InvalidEnvelopeBody,
     #[error("DHT header is invalid")]

--- a/comms/dht/src/store_forward/saf_handler/task.rs
+++ b/comms/dht/src/store_forward/saf_handler/task.rs
@@ -660,7 +660,10 @@ mod test {
         dht_header: DhtMessageHeader,
         stored_at: NaiveDateTime,
     ) -> StoredMessage {
-        let msg_hash = hex::to_hex(&dedup::create_message_hash(&dht_header.message_signature, message.as_bytes()));
+        let msg_hash = hex::to_hex(&dedup::create_message_hash(
+            &dht_header.message_signature,
+            message.as_bytes(),
+        ));
         let body = message.into_bytes();
         StoredMessage {
             id: 1,

--- a/comms/dht/src/store_forward/saf_handler/task.rs
+++ b/comms/dht/src/store_forward/saf_handler/task.rs
@@ -601,9 +601,9 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
         let origin_mac = ProtoOriginMac::decode(cleartext_origin_mac_body)?;
         let origin_mac = OriginMac::try_from(origin_mac)?;
 
-        let challenge = crypt::create_message_challenge(header, body);
+        let hash_data = crypt::create_message_domain_separated_hash(header, body);
 
-        if origin_mac.verify(&challenge) {
+        if origin_mac.verify(&hash_data) {
             Ok(origin_mac.into_signer_public_key())
         } else {
             Err(StoreAndForwardError::InvalidOriginMac(

--- a/comms/dht/src/store_forward/saf_handler/task.rs
+++ b/comms/dht/src/store_forward/saf_handler/task.rs
@@ -601,9 +601,9 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
         let origin_mac = ProtoOriginMac::decode(cleartext_origin_mac_body)?;
         let origin_mac = OriginMac::try_from(origin_mac)?;
 
-        let hash_data = crypt::create_message_domain_separated_hash(header, body);
+        let binding_message_representation = crypt::create_message_domain_separated_hash(header, body);
 
-        if origin_mac.verify(&hash_data) {
+        if origin_mac.verify(&binding_message_representation) {
             Ok(origin_mac.into_signer_public_key())
         } else {
             Err(StoreAndForwardError::InvalidOriginMac(

--- a/comms/dht/src/store_forward/saf_handler/task.rs
+++ b/comms/dht/src/store_forward/saf_handler/task.rs
@@ -45,7 +45,7 @@ use crate::{
     dedup,
     envelope::{timestamp_to_datetime, DhtMessageHeader, NodeDestination},
     inbound::{DecryptedDhtMessage, DhtInboundMessage},
-    origin_mac::{OriginMac, OriginMacError, ProtoOriginMac},
+    message_signature::{MessageSignature, MessageSignatureError, ProtoMessageSignature},
     outbound::{OutboundMessageRequester, SendMessageParams},
     proto::{
         envelope::DhtMessageType,
@@ -452,7 +452,7 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
             message
                 .dht_header
                 .as_ref()
-                .map(|h| h.origin_mac.as_slice())
+                .map(|h| h.message_signature.as_slice())
                 .unwrap_or(&[]),
             &message.body,
         );
@@ -564,10 +564,10 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
             trace!(
                 target: LOG_TARGET,
                 "Attempting to decrypt origin mac ({} byte(s))",
-                header.origin_mac.len()
+                header.message_signature.len()
             );
             let shared_secret = crypt::generate_ecdh_secret(node_identity.secret_key(), ephemeral_public_key);
-            let decrypted = crypt::decrypt(&shared_secret, &header.origin_mac)?;
+            let decrypted = crypt::decrypt(&shared_secret, &header.message_signature)?;
             let authenticated_pk = Self::authenticate_message(&decrypted, header, body)?;
 
             trace!(
@@ -583,10 +583,10 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
             }
             Ok((Some(authenticated_pk), envelope_body))
         } else {
-            let authenticated_pk = if header.origin_mac.is_empty() {
+            let authenticated_pk = if header.message_signature.is_empty() {
                 None
             } else {
-                Some(Self::authenticate_message(&header.origin_mac, header, body)?)
+                Some(Self::authenticate_message(&header.message_signature, header, body)?)
             };
             let envelope_body = EnvelopeBody::decode(body).map_err(|_| StoreAndForwardError::MalformedMessage)?;
             Ok((authenticated_pk, envelope_body))
@@ -594,20 +594,20 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
     }
 
     fn authenticate_message(
-        cleartext_origin_mac_body: &[u8],
+        cleartext_message_signature_body: &[u8],
         header: &DhtMessageHeader,
         body: &[u8],
     ) -> Result<CommsPublicKey, StoreAndForwardError> {
-        let origin_mac = ProtoOriginMac::decode(cleartext_origin_mac_body)?;
-        let origin_mac = OriginMac::try_from(origin_mac)?;
+        let message_signature = ProtoMessageSignature::decode(cleartext_message_signature_body)?;
+        let message_signature = MessageSignature::try_from(message_signature)?;
 
         let binding_message_representation = crypt::create_message_domain_separated_hash(header, body);
 
-        if origin_mac.verify(&binding_message_representation) {
-            Ok(origin_mac.into_signer_public_key())
+        if message_signature.verify(&binding_message_representation) {
+            Ok(message_signature.into_signer_public_key())
         } else {
-            Err(StoreAndForwardError::InvalidOriginMac(
-                OriginMacError::VerificationFailed,
+            Err(StoreAndForwardError::InvalidMessageSignature(
+                MessageSignatureError::VerificationFailed,
             ))
         }
     }
@@ -660,7 +660,7 @@ mod test {
         dht_header: DhtMessageHeader,
         stored_at: NaiveDateTime,
     ) -> StoredMessage {
-        let msg_hash = hex::to_hex(&dedup::create_message_hash(&dht_header.origin_mac, message.as_bytes()));
+        let msg_hash = hex::to_hex(&dedup::create_message_hash(&dht_header.message_signature, message.as_bytes()));
         let body = message.into_bytes();
         StoredMessage {
             id: 1,

--- a/comms/dht/src/store_forward/store.rs
+++ b/comms/dht/src/store_forward/store.rs
@@ -271,7 +271,7 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError> + Se
             // The message decryption was successful, or the message was not encrypted
             Some(_) => {
                 // If the message doesnt have an origin we wont store it
-                if !message.has_origin_mac() {
+                if !message.has_message_signature() {
                     log_not_eligible("it is a cleartext message and does not have an origin MAC");
                     return Ok(None);
                 }
@@ -299,7 +299,7 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError> + Se
             },
             // This node could not decrypt the message
             None => {
-                if !message.has_origin_mac() {
+                if !message.has_message_signature() {
                     // TODO: #banheuristic - the source peer should not have propagated this message
                     debug!(
                         target: LOG_TARGET,

--- a/comms/dht/src/test_utils/makers.rs
+++ b/comms/dht/src/test_utils/makers.rs
@@ -85,7 +85,7 @@ pub fn make_dht_header(
     let mut origin_mac = Vec::new();
 
     if include_origin {
-        let challenge = crypt::create_message_challenge_parts(
+        let bind_data_challenge = crypt::create_message_domain_separated_hash_parts(
             DhtProtocolVersion::latest(),
             &destination,
             DhtMessageType::None,
@@ -94,7 +94,7 @@ pub fn make_dht_header(
             Some(e_public_key),
             message,
         );
-        origin_mac = make_valid_origin_mac(node_identity, &challenge);
+        origin_mac = make_valid_origin_mac(node_identity, &bind_data_challenge);
         if flags.is_encrypted() {
             let shared_secret = crypt::generate_ecdh_secret(e_secret_key, node_identity.public_key());
             origin_mac = crypt::encrypt(&shared_secret, &origin_mac);

--- a/comms/dht/src/test_utils/makers.rs
+++ b/comms/dht/src/test_utils/makers.rs
@@ -85,7 +85,7 @@ pub fn make_dht_header(
     let mut origin_mac = Vec::new();
 
     if include_origin {
-        let bind_data_challenge = crypt::create_message_domain_separated_hash_parts(
+        let binding_message_representation = crypt::create_message_domain_separated_hash_parts(
             DhtProtocolVersion::latest(),
             &destination,
             DhtMessageType::None,
@@ -94,10 +94,10 @@ pub fn make_dht_header(
             Some(e_public_key),
             message,
         );
-        origin_mac = make_valid_origin_mac(node_identity, &bind_data_challenge);
+        let signature = make_valid_origin_mac(node_identity, &binding_message_representation);
         if flags.is_encrypted() {
             let shared_secret = crypt::generate_ecdh_secret(e_secret_key, node_identity.public_key());
-            origin_mac = crypt::encrypt(&shared_secret, &origin_mac);
+            origin_mac = crypt::encrypt(&shared_secret, &signature);
         }
     }
     DhtMessageHeader {


### PR DESCRIPTION
Description
--- 
Add use of hashing API to create challenge for mac origin.

Motivation and Context
--- 
Tackle [issue](https://github.com/tari-project/tari/issues/4333).

How Has This Been Tested?
--- 
Existing unit tests.

