### PR TITLE
wip: message signature ("origin mac") challenge should use hashing api #4332

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6946,6 +6946,7 @@ dependencies = [
  "serde_json",
  "snow",
  "tari_common",
+ "tari_common_types",
  "tari_comms_rpc_macros",
  "tari_crypto",
  "tari_metrics",

--- a/base_layer/core/src/transactions/transaction_components/test.rs
+++ b/base_layer/core/src/transactions/transaction_components/test.rs
@@ -20,7 +20,6 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use digest::Digest;
 use rand::{self, rngs::OsRng};
 use tari_common_types::types::{BlindingFactor, ComSignature, CommitmentFactory, PrivateKey, PublicKey, Signature};
 use tari_comms::types::Challenge;
@@ -608,10 +607,14 @@ mod validate_internal_consistency {
 
         //---------------------------------- Case2 - PASS --------------------------------------------//
         features.parent_public_key = Some(PublicKey::default());
-        let hash = Challenge::new()
-            .chain(Some(PublicKey::default()).to_consensus_bytes())
-            .chain(Some(unique_id.clone()).to_consensus_bytes())
-            .finalize();
+        let mut hash = [0u8; 32];
+        hash.copy_from_slice(
+            Challenge::new("test_tag")
+                .chain(Some(PublicKey::default()).to_consensus_bytes())
+                .chain(Some(unique_id.clone()).to_consensus_bytes())
+                .finalize()
+                .as_ref(),
+        );
 
         let covenant = covenant!(fields_hashed_eq(@fields(@field::features_parent_public_key, @field::features_unique_id), @hash(hash.into())));
 

--- a/base_layer/core/src/transactions/transaction_components/test.rs
+++ b/base_layer/core/src/transactions/transaction_components/test.rs
@@ -551,6 +551,7 @@ mod output_features {
 }
 
 mod validate_internal_consistency {
+    use tari_common::hashing_domain::HashToBytes;
 
     use super::*;
     use crate::consensus::ToConsensusBytes;
@@ -607,14 +608,12 @@ mod validate_internal_consistency {
 
         //---------------------------------- Case2 - PASS --------------------------------------------//
         features.parent_public_key = Some(PublicKey::default());
-        let mut hash = [0u8; 32];
-        hash.copy_from_slice(
-            Challenge::new("test_tag")
-                .chain(Some(PublicKey::default()).to_consensus_bytes())
-                .chain(Some(unique_id.clone()).to_consensus_bytes())
-                .finalize()
-                .as_ref(),
-        );
+        let hash = Challenge::new("test_tag")
+            .chain(Some(PublicKey::default()).to_consensus_bytes())
+            .chain(Some(unique_id.clone()).to_consensus_bytes())
+            .finalize()
+            .hash_to_bytes()
+            .expect("failed to build challenge");
 
         let covenant = covenant!(fields_hashed_eq(@fields(@field::features_parent_public_key, @field::features_unique_id), @hash(hash.into())));
 

--- a/base_layer/core/src/transactions/transaction_protocol/mod.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/mod.rs
@@ -86,7 +86,6 @@
 // #![allow(clippy::op_ref)]
 
 use derivative::Derivative;
-use digest::Digest;
 use serde::{Deserialize, Serialize};
 use tari_common_types::types::{PrivateKey, PublicKey};
 use tari_comms::types::Challenge;
@@ -154,10 +153,16 @@ pub struct RewindData {
 
 /// Convenience function that calculates the challenge for the Schnorr signatures
 pub fn build_challenge(sum_public_nonces: &PublicKey, metadata: &TransactionMetadata) -> [u8; 32] {
-    Challenge::new()
-        .chain(sum_public_nonces.as_bytes())
-        .chain(&u64::from(metadata.fee).to_le_bytes())
-        .chain(&metadata.lock_height.to_le_bytes())
-        .finalize()
-        .into()
+    let mut result = [0u8; 32];
+
+    result.copy_from_slice(
+        Challenge::new("com.tari.core.transaction_protocol")
+            .chain(sum_public_nonces.as_bytes())
+            .chain(&u64::from(metadata.fee).to_le_bytes())
+            .chain(&metadata.lock_height.to_le_bytes())
+            .finalize()
+            .as_ref(),
+    );
+
+    result
 }

--- a/comms/core/Cargo.toml
+++ b/comms/core/Cargo.toml
@@ -16,6 +16,8 @@ tari_metrics = { path = "../../infrastructure/metrics" }
 tari_storage = { version = "^0.34", path = "../../infrastructure/storage" }
 tari_shutdown = { version = "^0.34", path = "../../infrastructure/shutdown" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.4" }
+tari_common_types = { path = "../../base_layer/common_types" }
+
 
 anyhow = "1.0.53"
 async-trait = "0.1.36"

--- a/comms/core/src/peer_manager/identity_signature.rs
+++ b/comms/core/src/peer_manager/identity_signature.rs
@@ -138,7 +138,7 @@ impl IdentitySignature {
         updated_at: DateTime<Utc>,
     ) -> Challenge {
         // e = H(P||R||m)
-        let challenge = Challenge::new("com.tari.comms.challenge")
+        let challenge = Challenge::new("challenge")
             .chain(public_key.as_bytes())
             .chain(public_nonce.as_bytes())
             .chain(version.to_le_bytes())

--- a/comms/core/src/types.rs
+++ b/comms/core/src/types.rs
@@ -22,9 +22,9 @@
 
 //! Common Tari comms types
 
+use tari_common_types::types::MacDomainHasher;
 use tari_crypto::{
     hash::blake2::Blake256,
-    hashing::{DomainSeparatedHasher, GenericHashDomain},
     keys::PublicKey,
     ristretto::RistrettoPublicKey,
     signatures::SchnorrSignature,
@@ -42,7 +42,8 @@ pub type CommsPublicKey = RistrettoPublicKey;
 pub type CommsSecretKey = <CommsPublicKey as PublicKey>::K;
 
 /// Specify the digest type for the signature challenges
-pub type Challenge = DomainSeparatedHasher<Blake256, GenericHashDomain>;
+pub type Challenge = MacDomainHasher<Blake256>;
+
 /// Comms signature type
 pub type Signature = SchnorrSignature<CommsPublicKey, CommsSecretKey>;
 

--- a/comms/core/src/types.rs
+++ b/comms/core/src/types.rs
@@ -24,6 +24,7 @@
 
 use tari_crypto::{
     hash::blake2::Blake256,
+    hashing::{DomainSeparatedHasher, GenericHashDomain},
     keys::PublicKey,
     ristretto::RistrettoPublicKey,
     signatures::SchnorrSignature,
@@ -41,7 +42,7 @@ pub type CommsPublicKey = RistrettoPublicKey;
 pub type CommsSecretKey = <CommsPublicKey as PublicKey>::K;
 
 /// Specify the digest type for the signature challenges
-pub type Challenge = Blake256;
+pub type Challenge = DomainSeparatedHasher<Blake256, GenericHashDomain>;
 /// Comms signature type
 pub type Signature = SchnorrSignature<CommsPublicKey, CommsSecretKey>;
 

--- a/comms/dht/src/crypt.rs
+++ b/comms/dht/src/crypt.rs
@@ -28,7 +28,6 @@ use chacha20::{
     Key,
     Nonce,
 };
-use digest::{Digest, FixedOutput};
 use rand::{rngs::OsRng, RngCore};
 use tari_comms::types::{Challenge, CommsPublicKey};
 use tari_crypto::{
@@ -111,7 +110,7 @@ pub fn create_message_challenge_parts(
     ephemeral_public_key: Option<&CommsPublicKey>,
     body: &[u8],
 ) -> [u8; 32] {
-    let mut mac_challenge = Challenge::new();
+    let mut mac_challenge = Challenge::new("com.tari.comms.challenge");
     mac_challenge.update(&protocol_version.as_bytes());
     mac_challenge.update(destination.to_inner_bytes());
     mac_challenge.update(&(message_type as i32).to_le_bytes());
@@ -130,7 +129,10 @@ pub fn create_message_challenge_parts(
     mac_challenge.update(&e_pk);
 
     mac_challenge.update(&body);
-    mac_challenge.finalize_fixed().into()
+
+    let mut result = [0u8; 32];
+    result.copy_from_slice(mac_challenge.finalize().as_ref());
+    result
 }
 
 #[cfg(test)]

--- a/comms/dht/src/dedup/mod.rs
+++ b/comms/dht/src/dedup/mod.rs
@@ -29,7 +29,6 @@ mod dedup_cache;
 use std::task::Poll;
 
 pub use dedup_cache::DedupCacheDatabase;
-use digest::Digest;
 use futures::{future::BoxFuture, task::Context};
 use log::*;
 use tari_comms::{pipeline::PipelineError, types::Challenge};
@@ -48,7 +47,17 @@ pub fn hash_inbound_message(msg: &DhtInboundMessage) -> [u8; 32] {
 }
 
 pub fn create_message_hash(origin_mac: &[u8], body: &[u8]) -> [u8; 32] {
-    Challenge::new().chain(origin_mac).chain(&body).finalize().into()
+    let mut result = [0u8; 32];
+
+    result.copy_from_slice(
+        Challenge::new("com.tari.comms.message_hash")
+            .chain(origin_mac)
+            .chain(&body)
+            .finalize()
+            .as_ref(),
+    );
+
+    result
 }
 
 /// # DHT Deduplication middleware

--- a/comms/dht/src/origin_mac.rs
+++ b/comms/dht/src/origin_mac.rs
@@ -22,7 +22,6 @@
 
 use std::convert::TryFrom;
 
-use digest::{Digest, FixedOutput};
 use rand::rngs::OsRng;
 use tari_comms::types::{Challenge, CommsPublicKey, CommsSecretKey, Signature};
 use tari_crypto::keys::PublicKey;
@@ -40,13 +39,26 @@ fn construct_origin_mac_hash(
     message: &[u8],
 ) -> [u8; 32] {
     // e = H_mac(P||R||m)
-    Challenge::with_params(&[], &[], b"TARIDHTORIGINMAC")
-        .expect("params for Challenge should not produce failure")
-        .chain(signer_public_key.as_bytes())
-        .chain(public_nonce.as_bytes())
-        .chain(message)
-        .finalize_fixed()
-        .into()
+    // Challenge::with_params(&[], &[], b"TARIDHTORIGINMAC")
+    // .chain(signer_public_key.as_bytes())
+    // .chain(public_nonce.as_bytes())
+    // .chain(message)
+    // .finalize_fixed()
+    // .into()
+
+    // e = H_mac(P||R||m)
+    let mut result = [0u8; 32];
+
+    result.copy_from_slice(
+        Challenge::new("com.tari.comms.challenge.origin_mac")
+            .chain(signer_public_key.as_bytes())
+            .chain(public_nonce.as_bytes())
+            .chain(message)
+            .finalize()
+            .as_ref(),
+    );
+
+    result
 }
 
 impl OriginMac {

--- a/comms/dht/src/origin_mac.rs
+++ b/comms/dht/src/origin_mac.rs
@@ -23,6 +23,7 @@
 use std::convert::TryFrom;
 
 use rand::rngs::OsRng;
+use tari_common::hashing_domain::HashToBytes;
 use tari_comms::types::{Challenge, CommsPublicKey, CommsSecretKey, Signature};
 use tari_crypto::keys::PublicKey;
 use tari_utilities::ByteArray;
@@ -47,18 +48,14 @@ fn construct_origin_mac_hash(
     // .into()
 
     // e = H_mac(P||R||m)
-    let mut result = [0u8; 32];
 
-    result.copy_from_slice(
-        Challenge::new("com.tari.comms.challenge.origin_mac")
-            .chain(signer_public_key.as_bytes())
-            .chain(public_nonce.as_bytes())
-            .chain(message)
-            .finalize()
-            .as_ref(),
-    );
-
-    result
+    Challenge::new("origin_mac")
+        .chain(signer_public_key.as_bytes())
+        .chain(public_nonce.as_bytes())
+        .chain(message)
+        .finalize()
+        .hash_to_bytes()
+        .expect("failed to construct origin mac hash")
 }
 
 impl OriginMac {


### PR DESCRIPTION
Description
---
https://github.com/tari-project/tari/issues/4332

Motivation and Context
---
Message signature ("origin MAC") challenge should use hashing API #4332


How Has This Been Tested?
---

