### PR TITLE
fix: wallet's `remove_encryption()` was removing cipher before decryption (see issue #4304)

### DIFF
--- a/applications/tari_console_wallet/src/grpc/mod.rs
+++ b/applications/tari_console_wallet/src/grpc/mod.rs
@@ -13,6 +13,7 @@ use tari_wallet::transaction_service::storage::models::{
 
 pub use self::wallet_grpc_server::*;
 
+#[allow(clippy::large_enum_variant)]
 pub enum TransactionWrapper {
     Completed(CompletedTransaction),
     Outbound(OutboundTransaction),
@@ -55,11 +56,7 @@ pub fn convert_to_transaction_event(event: String, source: TransactionWrapper) -
             /// The coinbase are technically Inbound.
             /// To determine whether a transaction is coinbase
             /// we will check whether the message contains `Coinbase`.
-            is_coinbase: if inbound.message.to_lowercase().contains("coinbase") {
-                true
-            } else {
-                false
-            },
+            is_coinbase: inbound.message.to_lowercase().contains("coinbase"),
         },
     }
 }

--- a/applications/tari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/tari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -1106,7 +1106,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
 
         let contents = fs::read_to_string(file_path)?;
         let words = contents
-            .split(" ")
+            .split(' ')
             .collect::<Vec<&str>>()
             .iter()
             .map(|&x| x.into())

--- a/applications/tari_console_wallet/src/notifier/mod.rs
+++ b/applications/tari_console_wallet/src/notifier/mod.rs
@@ -48,6 +48,7 @@ pub const MINED: &str = "mined";
 pub const CANCELLED: &str = "cancelled";
 pub const NEW_BLOCK_MINED: &str = "new_block_mined";
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Clone)]
 pub enum WalletEventMessage {
     Completed {

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -25,10 +25,7 @@ use std::{convert::TryInto, fmt, sync::Arc};
 use blake2::Digest;
 use diesel::result::{DatabaseErrorKind, Error as DieselError};
 use futures::{pin_mut, StreamExt};
-use itertools::{
-    FoldWhile::{Continue, Done},
-    Itertools,
-};
+use itertools::Itertools;
 use log::*;
 use rand::{rngs::OsRng, RngCore};
 use tari_common_types::{
@@ -1468,137 +1465,6 @@ where
         self.resources.db.reinstate_cancelled_inbound_output(tx_id)?;
 
         Ok(())
-    }
-
-    // NOTE: WIP
-    #[allow(dead_code)]
-    async fn select_utxos2(
-        &mut self,
-        target_amount: MicroTari,
-        fee_per_gram: MicroTari,
-        num_outputs: usize,
-        total_output_metadata_byte_size: usize,
-        selection_criteria: UtxoSelectionCriteria,
-    ) -> Result<UtxoSelection, OutputManagerError> {
-        debug!(
-            target: LOG_TARGET,
-            "select_utxos target_amount: {}, fee_per_gram: {}, num_outputs: {}, output_metadata_byte_size: {}, \
-             selection_criteria: {:?}",
-            target_amount,
-            fee_per_gram,
-            num_outputs,
-            total_output_metadata_byte_size,
-            selection_criteria
-        );
-
-        let tip_height = self
-            .base_node_service
-            .get_chain_metadata()
-            .await?
-            .as_ref()
-            .map(|m| m.height_of_longest_chain());
-        let balance = self.get_balance(tip_height)?;
-
-        // collecting UTXOs sufficient to cover the target amount
-        let (_, accumulated_amount, utxos) = self
-            .resources
-            .db
-            .fetch_unspent_outputs_for_spending(selection_criteria.clone(), target_amount, tip_height)?
-            .into_iter()
-            .fold_while(
-                (1usize, MicroTari::zero(), Vec::<DbUnblindedOutput>::new()),
-                |mut acc, out| {
-                    let fee = self.get_fee_calc().calculate(
-                        fee_per_gram,
-                        1,
-                        acc.0,
-                        num_outputs,
-                        total_output_metadata_byte_size,
-                    );
-
-                    let next = acc.1 + out.unblinded_output.value;
-                    let target_amount_with_fee = target_amount + fee;
-
-                    // if next < target_amount_with_fee || acc.1 < target_amount_with_fee && next >=
-                    // target_amount_with_fee
-                    if next < target_amount_with_fee || acc.1 < target_amount_with_fee {
-                        acc.0 += 1;
-                        acc.1 = next;
-                        acc.2.push(out);
-                        Continue(acc)
-                    } else {
-                        Done(acc)
-                    }
-                },
-            )
-            .into_inner();
-
-        // let accumulated_amount = utxos
-        // .iter()
-        // .fold(MicroTari::zero(), |acc, x| acc + x.unblinded_output.value);
-
-        if accumulated_amount <= target_amount {
-            return Err(OutputManagerError::NotEnoughFunds);
-        }
-
-        let fee_without_change = self.get_fee_calc().calculate(
-            fee_per_gram,
-            1,
-            utxos.len(),
-            num_outputs,
-            total_output_metadata_byte_size,
-        );
-
-        // checking whether the total output value is enough
-        if accumulated_amount < (target_amount + fee_without_change) {
-            return Err(OutputManagerError::NotEnoughFunds);
-        }
-
-        let fee_with_change = match accumulated_amount
-            .saturating_sub(target_amount + fee_without_change)
-            .as_u64()
-        {
-            0 => fee_without_change,
-            _ => self.get_fee_calc().calculate(
-                fee_per_gram,
-                1,
-                utxos.len(),
-                num_outputs + 1,
-                total_output_metadata_byte_size + self.default_metadata_size(),
-            ),
-        };
-
-        // this is how much it would require in the end
-        let target_amount_with_fee = target_amount + fee_with_change;
-
-        // checking, again, whether a total output value is enough
-        if accumulated_amount < target_amount_with_fee {
-            return Err(OutputManagerError::NotEnoughFunds);
-        }
-
-        // balance check
-        if balance.available_balance < target_amount_with_fee {
-            return if accumulated_amount + balance.pending_incoming_balance >= target_amount_with_fee {
-                Err(OutputManagerError::FundsPending)
-            } else {
-                Err(OutputManagerError::NotEnoughFunds)
-            };
-        }
-
-        trace!(
-            target: LOG_TARGET,
-            "select_utxos selection criteria: {}\noutputs found: {}",
-            selection_criteria,
-            utxos.len()
-        );
-
-        Ok(UtxoSelection {
-            utxos,
-            requires_change_output: accumulated_amount.saturating_sub(target_amount_with_fee) > MicroTari::zero(),
-            total_value: accumulated_amount,
-            fee_without_change,
-            fee_with_change,
-        })
     }
 
     /// Select which unspent transaction outputs to use to send a transaction of the specified amount. Use the specified

--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -689,10 +689,10 @@ where
     /// Remove encryption from all the Wallet db backends. If any backends do not have encryption applied then this will
     /// fail
     pub async fn remove_encryption(&mut self) -> Result<(), WalletError> {
-        self.db.remove_encryption().await?;
         self.output_manager_service.remove_encryption().await?;
         self.transaction_service.remove_encryption().await?;
         self.key_manager_service.remove_encryption().await?;
+        self.db.remove_encryption().await?;
         Ok(())
     }
 


### PR DESCRIPTION
Description
---
When the client app is calling wallet_remove_encryption it expects that DB will remain decrypted till wallet_apply_encryption or wallet_create is called. However, the SQLite database is encrypted a brief moment after the decryption.

OS: iOS and Android (Aurora Wallet App)

Motivation and Context
---
https://github.com/tari-project/tari/issues/4304

How Has This Been Tested?
---
unit tests
