### PR TITLE
fix(key_manager): remove trailing '.' from hashing domains, fix WASM tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7215,7 +7215,6 @@ dependencies = [
  "sha2 0.9.9",
  "strum",
  "strum_macros",
- "tari_common",
  "tari_common_types",
  "tari_crypto",
  "tari_utilities",

--- a/base_layer/key_manager/Cargo.toml
+++ b/base_layer/key_manager/Cargo.toml
@@ -10,11 +10,11 @@ edition = "2021"
 [lib]
 crate-type = ["lib", "cdylib"]
 
+# NB: All dependencies must support or be gated for the WASM target.
 [dependencies]
 tari_common_types = { version = "^0.34", path = "../../base_layer/common_types" }
 tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.3" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.5" }
-tari_common = { path = "../../common" }
 
 arrayvec = "0.7.1"
 argon2 = { version = "0.2", features = ["std"] }

--- a/base_layer/key_manager/src/cipher_seed.rs
+++ b/base_layer/key_manager/src/cipher_seed.rs
@@ -20,12 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{
-    convert::TryFrom,
-    mem::size_of,
-    ops::Add,
-    time::{Duration, SystemTime, UNIX_EPOCH},
-};
+use std::{convert::TryFrom, mem::size_of};
 
 use argon2::{
     password_hash::{Salt, SaltString},
@@ -123,8 +118,9 @@ pub struct CipherSeed {
 impl CipherSeed {
     #[cfg(not(target_arch = "wasm32"))]
     pub fn new() -> Self {
+        use std::time::{Duration, SystemTime, UNIX_EPOCH};
         const SECONDS_PER_DAY: u64 = 24 * 60 * 60;
-        let birthday_genesis_date = UNIX_EPOCH.add(Duration::from_secs(BIRTHDAY_GENESIS_FROM_UNIX_EPOCH));
+        let birthday_genesis_date = UNIX_EPOCH + Duration::from_secs(BIRTHDAY_GENESIS_FROM_UNIX_EPOCH);
         let days = SystemTime::now()
             .duration_since(birthday_genesis_date)
             .unwrap()

--- a/base_layer/key_manager/src/lib.rs
+++ b/base_layer/key_manager/src/lib.rs
@@ -1,7 +1,11 @@
 // Copyright 2022 The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
 
-use tari_crypto::hash_domain;
+use digest::Digest;
+use tari_crypto::{
+    hash_domain,
+    hashing::{DomainSeparatedHasher, LengthExtensionAttackResistant},
+};
 
 pub mod cipher_seed;
 pub mod diacritics;
@@ -15,18 +19,14 @@ pub mod mnemonic_wordlists;
 pub mod wasm;
 
 hash_domain!(KeyManagerDomain, "com.tari.tari_project.base_layer.key_manager", 1);
-hash_domain!(
-    KeyManagerMacGeneration,
-    "com.tari.tari_project.base_layer.key_manager.mac_generation",
-    1
-);
-hash_domain!(
-    KeyManagerArgon2Encoding,
-    "com.tari.tari_project.base_layer.key_manager.argon2_encoding",
-    1
-);
-hash_domain!(
-    KeyManagerChacha20Encoding,
-    "com.tari.tari_project.base_layer.key_manager.chacha20_encoding",
-    1
-);
+
+const LABEL_ARGON_ENCODING: &str = "argon2_encoding";
+const LABEL_CHACHA20_ENCODING: &str = "chacha20_encoding";
+const LABEL_MAC_GENERATION: &str = "mac_generation";
+const LABEL_DERIVE_KEY: &str = "derive_key";
+
+pub(crate) fn mac_domain_hasher<D: Digest + LengthExtensionAttackResistant>(
+    label: &'static str,
+) -> DomainSeparatedHasher<D, KeyManagerDomain> {
+    DomainSeparatedHasher::<D, KeyManagerDomain>::new_with_label(label)
+}

--- a/base_layer/key_manager/src/wasm.rs
+++ b/base_layer/key_manager/src/wasm.rs
@@ -179,11 +179,11 @@ mod test {
 
     #[wasm_bindgen_test]
     fn it_creates_key_manager_from() {
-        let bytes = &[
-            0u8, 175, 181, 246, 157, 116, 78, 216, 151, 75, 19, 156, 105, 61, 136, 116, 128, 66, 73, 68, 229, 223, 123,
-            127, 116, 217, 17, 5, 250, 33, 50, 157, 17,
+        let bytes = [
+            0, 2, 116, 75, 54, 160, 21, 1, 43, 55, 107, 155, 189, 230, 182, 215, 17, 191, 94, 156, 114, 136, 40, 175,
+            144, 166, 93, 233, 179, 11, 8, 49, 139,
         ];
-        let seed = CipherSeed::from_enciphered_bytes(bytes, None).unwrap();
+        let seed = CipherSeed::from_enciphered_bytes(&bytes, None).unwrap();
         let seed = JsValue::from_serde(&seed).unwrap();
 
         let js = key_manager_from(seed, "asdf".into(), 0);
@@ -193,7 +193,7 @@ mod test {
         let next_key = response.key_manager.next_key().unwrap();
         assert_eq!(
             next_key.k.to_hex(),
-            "00afb5f69d744ed8974b139c693d887480424944e5df7b7f74d91105fa21329d11".to_string()
+            "84feaddf54f1b4321db67f7aae382c338d03c56280a417651c4e0cde3363d00a".to_string()
         )
     }
 


### PR DESCRIPTION
Description
---
- remove `tari_common` dependency from key manager as it does not support the wasm target.
- remove trailing `.` from hashing domains by using labels
- remove extra allocation in `CipherSeed::generate_mac`

Motivation and Context
---
`tari_common` includes `fs2` which does not support WASM targets causing [failed CI builds](https://github.com/tari-project/tari/runs/7645710771?check_suite_focus=true). This is currently breaking `development` branch tests.

Using a blank label appends a "." onto the domain, the current correct usage of the api is to use a label

How Has This Been Tested?
---
Existing tests pass

