### PR TITLE
fix: default to esme

### DIFF
--- a/applications/tari_base_node/src/config.rs
+++ b/applications/tari_base_node/src/config.rs
@@ -143,7 +143,7 @@ impl Default for BaseNodeConfig {
         };
         Self {
             override_from: None,
-            network: Network::LocalNet,
+            network: Network::Esmeralda,
             grpc_address: Some("/ip4/127.0.0.1/tcp/18142".parse().unwrap()),
             identity_file: PathBuf::from("config/base_node_id.json"),
             use_libtor: false,

--- a/common/config/presets/c_base_node.toml
+++ b/common/config/presets/c_base_node.toml
@@ -17,9 +17,13 @@ identity_file = "config/base_node_id_dibbler.json"
 # A path to the file that stores your node identity and secret key (default = "config/base_node_id.json")
 identity_file = "config/base_node_id_igor.json"
 
+[esmeralda.base_node]
+# A path to the file that stores your node identity and secret key (default = "config/base_node_id.json")
+identity_file = "config/base_node_id_esmeralda.json"
+
 [base_node]
-# Selected network (Note: Not implemented properly, please specify on the command line) (default = "localnet")
-#network = "localnet"
+# Selected network (Note: Not implemented properly, please specify on the command line) (default = "emseralda")
+#network = "emseralda"
 # The socket to expose for the gRPC base node server (default = "/ip4/127.0.0.1/tcp/18142")
 #grpc_address = "/ip4/127.0.0.1/tcp/18142"
 


### PR DESCRIPTION
Make the base_node select the Esmeralda network by default if no network was provided
