### PR TITLE
fix: apply network config overrides from cli or else file

### DIFF
--- a/applications/tari_app_utilities/src/common_cli_args.rs
+++ b/applications/tari_app_utilities/src/common_cli_args.rs
@@ -23,6 +23,7 @@ use std::{error::Error, path::PathBuf};
 
 use clap::Args;
 use log::Level;
+use tari_common::configuration::{ConfigOverrideProvider, Network};
 
 #[derive(Args, Debug)]
 pub struct CommonCliArgs {
@@ -101,8 +102,10 @@ impl CommonCliArgs {
             path
         }
     }
+}
 
-    pub fn config_property_overrides(&self) -> Vec<(String, String)> {
+impl ConfigOverrideProvider for CommonCliArgs {
+    fn get_config_property_overrides(&self, _default_network: Network) -> Vec<(String, String)> {
         let mut overrides = self.config_property_overrides.clone();
         overrides.push(("common.base_path".to_string(), self.base_path.clone()));
         overrides

--- a/applications/tari_base_node/src/cli.rs
+++ b/applications/tari_base_node/src/cli.rs
@@ -22,6 +22,7 @@
 
 use clap::Parser;
 use tari_app_utilities::common_cli_args::CommonCliArgs;
+use tari_common::configuration::{ConfigOverrideProvider, Network};
 
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
@@ -51,16 +52,18 @@ pub(crate) struct Cli {
     pub network: Option<String>,
 }
 
-impl Cli {
-    pub fn config_property_overrides(&self) -> Vec<(String, String)> {
-        let mut overrides = self.common.config_property_overrides();
-        if let Some(network) = &self.network {
-            overrides.push(("base_node.override_from".to_string(), network.clone()));
-            overrides.push(("p2p.seeds.override_from".to_string(), network.clone()));
-            overrides.push(("auto_update.override_from".to_string(), network.clone()));
-            #[cfg(features = "metrics")]
-            overrides.push(("metrics.override_from".to_string(), network.clone()));
-        }
+impl ConfigOverrideProvider for Cli {
+    fn get_config_property_overrides(&self, default_network: Network) -> Vec<(String, String)> {
+        let mut overrides = self.common.get_config_property_overrides(default_network);
+        let network = self
+            .network
+            .as_ref()
+            .cloned()
+            .unwrap_or_else(|| default_network.to_string());
+        overrides.push(("base_node.override_from".to_string(), network.to_string()));
+        overrides.push(("p2p.seeds.override_from".to_string(), network.to_string()));
+        overrides.push(("auto_update.override_from".to_string(), network.to_string()));
+        overrides.push(("metrics.override_from".to_string(), network));
         overrides
     }
 }

--- a/applications/tari_base_node/src/config.rs
+++ b/applications/tari_base_node/src/config.rs
@@ -143,7 +143,7 @@ impl Default for BaseNodeConfig {
         };
         Self {
             override_from: None,
-            network: Network::Esmeralda,
+            network: Network::default(),
             grpc_address: Some("/ip4/127.0.0.1/tcp/18142".parse().unwrap()),
             identity_file: PathBuf::from("config/base_node_id.json"),
             use_libtor: false,

--- a/applications/tari_base_node/src/main.rs
+++ b/applications/tari_base_node/src/main.rs
@@ -138,7 +138,8 @@ fn main_inner() -> Result<(), ExitError> {
     let cli = Cli::parse();
 
     let config_path = cli.common.config_path();
-    let cfg = load_configuration(config_path, true, &cli.config_property_overrides())?;
+    let cfg = load_configuration(config_path, true, &cli)?;
+
     initialize_logging(
         &cli.common.log_config_path("base_node"),
         include_str!("../log4rs_sample.yml"),

--- a/applications/tari_collectibles/src-tauri/src/cli.rs
+++ b/applications/tari_collectibles/src-tauri/src/cli.rs
@@ -25,10 +25,11 @@ use crate::{
 };
 use clap::{Parser, Subcommand};
 use tari_app_utilities::common_cli_args::CommonCliArgs;
-use tari_common::exit_codes::{ExitCode, ExitError};
+use tari_common::{
+  configuration::{ConfigOverrideProvider, Network},
+  exit_codes::{ExitCode, ExitError},
+};
 use uuid::Uuid;
-
-const DEFAULT_NETWORK: &str = "esmeralda";
 
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
@@ -40,17 +41,18 @@ pub(crate) struct Cli {
   #[clap(subcommand)]
   pub command: Option<Commands>,
   /// Supply a network (overrides existing configuration)
-  #[clap(long, default_value = DEFAULT_NETWORK, env = "TARI_NETWORK")]
-  pub network: String,
+  #[clap(long, env = "TARI_NETWORK")]
+  pub network: Option<String>,
 }
 
-impl Cli {
-  pub fn config_property_overrides(&self) -> Vec<(String, String)> {
-    let mut overrides = self.common.config_property_overrides();
-    overrides.push((
-      "collectibles.override_from".to_string(),
-      self.network.clone(),
-    ));
+impl ConfigOverrideProvider for Cli {
+  fn get_config_property_overrides(&self, default_network: Network) -> Vec<(String, String)> {
+    let mut overrides = self.common.get_config_property_overrides(default_network);
+    let network = self
+      .network
+      .clone()
+      .unwrap_or_else(|| default_network.to_string());
+    overrides.push(("collectibles.override_from".to_string(), network));
     overrides
   }
 }

--- a/applications/tari_collectibles/src-tauri/src/main.rs
+++ b/applications/tari_collectibles/src-tauri/src/main.rs
@@ -59,11 +59,7 @@ pub fn process_command(command: Commands, state: &ConcurrentAppState) -> Result<
 
 fn main() -> Result<(), Box<dyn Error>> {
   let cli = Cli::parse();
-  let cfg = load_configuration(
-    cli.common.config_path(),
-    true,
-    &cli.config_property_overrides(),
-  )?;
+  let cfg = load_configuration(cli.common.config_path(), true, &cli)?;
 
   let config = CollectiblesConfig::load_from(&cfg)?;
   let state = ConcurrentAppState::new(cli.common.get_base_path(), config);

--- a/applications/tari_console_wallet/src/cli.rs
+++ b/applications/tari_console_wallet/src/cli.rs
@@ -25,14 +25,13 @@ use std::{path::PathBuf, time::Duration};
 use chrono::{DateTime, Utc};
 use clap::{Args, Parser, Subcommand};
 use tari_app_utilities::{common_cli_args::CommonCliArgs, utilities::UniPublicKey};
+use tari_common::configuration::{ConfigOverrideProvider, Network};
 use tari_comms::multiaddr::Multiaddr;
 use tari_core::transactions::{tari_amount, tari_amount::MicroTari};
 use tari_utilities::{
     hex::{Hex, HexError},
     SafePassword,
 };
-
-const DEFAULT_NETWORK: &str = "esmeralda";
 
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
@@ -77,17 +76,19 @@ pub(crate) struct Cli {
     #[clap(long, alias = "auto-exit")]
     pub command_mode_auto_exit: bool,
     /// Supply a network (overrides existing configuration)
-    #[clap(long, default_value = DEFAULT_NETWORK, env = "TARI_NETWORK")]
-    pub network: String,
+    #[clap(long, env = "TARI_NETWORK")]
+    pub network: Option<String>,
     #[clap(subcommand)]
     pub command2: Option<CliCommands>,
 }
 
-impl Cli {
-    pub fn config_property_overrides(&self) -> Vec<(String, String)> {
-        let mut overrides = self.common.config_property_overrides();
-        overrides.push(("wallet.override_from".to_string(), self.network.clone()));
-        overrides.push(("p2p.seeds.override_from".to_string(), self.network.clone()));
+impl ConfigOverrideProvider for Cli {
+    fn get_config_property_overrides(&self, default_network: Network) -> Vec<(String, String)> {
+        let mut overrides = self.common.get_config_property_overrides(default_network);
+        let network = self.network.clone().unwrap_or_else(|| default_network.to_string());
+        overrides.push(("wallet.network".to_string(), network.clone()));
+        overrides.push(("wallet.override_from".to_string(), network.clone()));
+        overrides.push(("p2p.seeds.override_from".to_string(), network));
         overrides
     }
 }

--- a/applications/tari_console_wallet/src/main.rs
+++ b/applications/tari_console_wallet/src/main.rs
@@ -93,14 +93,14 @@ fn main_inner() -> Result<(), ExitError> {
     let cli = Cli::parse();
 
     let config_path = cli.common.config_path();
-    let cfg = load_configuration(config_path.as_path(), true, &cli.config_property_overrides())?;
+    let cfg = load_configuration(config_path.as_path(), true, &cli)?;
     initialize_logging(
         &cli.common.log_config_path("wallet"),
         include_str!("../log4rs_sample.yml"),
     )?;
 
+    #[cfg_attr(feature = "libtor", allow(unused_mut))]
     let mut config = ApplicationConfig::load_from(&cfg)?;
-    config.wallet.network = cli.network.parse()?;
 
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()

--- a/applications/tari_merge_mining_proxy/src/main.rs
+++ b/applications/tari_merge_mining_proxy/src/main.rs
@@ -67,7 +67,7 @@ async fn main() -> Result<(), anyhow::Error> {
     let cli = Cli::parse();
 
     let config_path = cli.common.config_path();
-    let cfg = load_configuration(&config_path, true, &cli.config_property_overrides())?;
+    let cfg = load_configuration(&config_path, true, &cli)?;
     initialize_logging(
         &cli.common.log_config_path("proxy"),
         include_str!("../log4rs_sample.yml"),

--- a/applications/tari_miner/src/main.rs
+++ b/applications/tari_miner/src/main.rs
@@ -85,7 +85,7 @@ async fn main_inner() -> Result<(), ExitError> {
     let cli = Cli::parse();
 
     let config_path = cli.common.config_path();
-    let cfg = load_configuration(config_path.as_path(), true, &cli.common.config_property_overrides)?;
+    let cfg = load_configuration(config_path.as_path(), true, &cli.common)?;
     initialize_logging(
         &cli.common.log_config_path("miner"),
         include_str!("../log4rs_sample.yml"),

--- a/applications/tari_validator_node/src/cli.rs
+++ b/applications/tari_validator_node/src/cli.rs
@@ -22,8 +22,7 @@
 
 use clap::Parser;
 use tari_app_utilities::common_cli_args::CommonCliArgs;
-
-const DEFAULT_NETWORK: &str = "esmeralda";
+use tari_common::configuration::{ConfigOverrideProvider, Network};
 
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
@@ -35,16 +34,17 @@ pub(crate) struct Cli {
     #[clap(long, aliases = &["tracing", "enable-tracing"])]
     pub tracing_enabled: bool,
     /// Supply a network (overrides existing configuration)
-    #[clap(long, default_value = DEFAULT_NETWORK, env = "TARI_NETWORK")]
-    pub network: String,
+    #[clap(long, env = "TARI_NETWORK")]
+    pub network: Option<String>,
 }
 
-impl Cli {
-    pub fn config_property_overrides(&self) -> Vec<(String, String)> {
-        let mut overrides = self.common.config_property_overrides();
-        overrides.push(("network".to_string(), self.network.clone()));
-        overrides.push(("validator_node.override_from".to_string(), self.network.clone()));
-        overrides.push(("p2p.seeds.override_from".to_string(), self.network.clone()));
+impl ConfigOverrideProvider for Cli {
+    fn get_config_property_overrides(&self, default_network: Network) -> Vec<(String, String)> {
+        let mut overrides = self.common.get_config_property_overrides(default_network);
+        let network = self.network.clone().unwrap_or_else(|| default_network.to_string());
+        overrides.push(("network".to_string(), network.clone()));
+        overrides.push(("validator_node.override_from".to_string(), network.clone()));
+        overrides.push(("p2p.seeds.override_from".to_string(), network));
         overrides
     }
 }

--- a/applications/tari_validator_node/src/main.rs
+++ b/applications/tari_validator_node/src/main.rs
@@ -98,14 +98,14 @@ fn main() {
 
 fn main_inner() -> Result<(), ExitError> {
     let cli = Cli::parse();
-    println!("Starting validator node on network {}", cli.network);
     let config_path = cli.common.config_path();
-    let cfg = load_configuration(config_path, true, &cli.config_property_overrides())?;
+    let cfg = load_configuration(config_path, true, &cli)?;
     initialize_logging(
         &cli.common.log_config_path("validator"),
         include_str!("../log4rs_sample.yml"),
     )?;
     let config = ApplicationConfig::load_from(&cfg)?;
+    println!("Starting validator node on network {}", config.network);
     let runtime = build_runtime()?;
     runtime.block_on(run_node(&config))?;
 

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -1055,6 +1055,7 @@ where
         let sender_offset_private_key = stp
             .get_recipient_sender_offset_private_key(0)
             .map_err(|e| TransactionServiceProtocolError::new(tx_id, e.into()))?;
+
         let spend_key = PrivateKey::from_bytes(
             CommsPublicKey::shared_secret(&sender_offset_private_key.clone(), &dest_pubkey.clone()).as_bytes(),
         )

--- a/common/src/configuration/mod.rs
+++ b/common/src/configuration/mod.rs
@@ -65,6 +65,19 @@ pub fn socket_or_multi(addr: &str) -> Result<Multiaddr, Error> {
         .or_else(|_| addr.parse::<Multiaddr>())
 }
 
+/// Implement this trait to specify custom configuration overrides for a network when loading the config
+pub trait ConfigOverrideProvider {
+    fn get_config_property_overrides(&self, default_network: Network) -> Vec<(String, String)>;
+}
+
+pub struct NoConfigOverrides;
+
+impl ConfigOverrideProvider for NoConfigOverrides {
+    fn get_config_property_overrides(&self, _default_network: Network) -> Vec<(String, String)> {
+        Vec::new()
+    }
+}
+
 #[cfg(test)]
 mod test {
     use std::net::{Ipv4Addr, Ipv6Addr};

--- a/common/src/configuration/network.rs
+++ b/common/src/configuration/network.rs
@@ -68,9 +68,11 @@ impl Network {
     }
 }
 
+/// The default network for all applications
 impl Default for Network {
     fn default() -> Self {
-        Network::MainNet
+        // TODO: set the default network to mainnet
+        Network::Esmeralda
     }
 }
 
@@ -157,7 +159,7 @@ mod test {
     #[test]
     fn network_default() {
         let network = Network::default();
-        assert_eq!(network, Network::MainNet);
+        assert_eq!(network, Network::Esmeralda);
     }
 
     #[test]


### PR DESCRIPTION
Description
---
Uses `network` value from cli, config, then default (currently, Esmeralda) in that order.
The network is read from the config file before getting and applying config overrides.

Fixes #4402 

Motivation and Context
---
On the base node, the network would need to be explicitly provided on the cli for config file overrides to be applied.
The network value set in the config file was previously ignored.
The default network `Network::default()` is set in one place for every application. 

How Has This Been Tested?
---
Manually:
- not setting a network in cli on the base node and checking that esme is used
- changing network on in the config file and checking that it is used
