### PR TITLE
fix(core): use domain-separated kdf for encrypted value

### DIFF
--- a/base_layer/core/src/transactions/mod.rs
+++ b/base_layer/core/src/transactions/mod.rs
@@ -28,3 +28,4 @@ pub mod weight;
 pub mod test_helpers;
 
 hash_domain!(TransactionHashDomain, "com.tari.base_layer.core.transactions", 0);
+hash_domain!(TransactionKdfDomain, "com.tari.base_layer.core.transactions.kdf", 0);


### PR DESCRIPTION
Description
---
- uses domain-separated KDF for encrypted value key

Motivation and Context
---
Use the domain-separated API for the aead_key derivation. 

I'm not sure, but using a static salt may be a bad idea. 

How Has This Been Tested?
---
Existing tests
