### PR TITLE
feat(base-node): adds `add-peer` command

### DIFF
--- a/applications/tari_base_node/src/commands/command/add_peer.rs
+++ b/applications/tari_base_node/src/commands/command/add_peer.rs
@@ -1,0 +1,64 @@
+//  Copyright 2022, The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use anyhow::{anyhow, Error};
+use async_trait::async_trait;
+use clap::Parser;
+use tari_app_utilities::utilities::UniPublicKey;
+use tari_comms::{
+    multiaddr::Multiaddr,
+    peer_manager::{NodeId, Peer, PeerFeatures, PeerFlags},
+};
+
+use super::{CommandContext, HandleCommand};
+
+/// Adds a peer
+#[derive(Debug, Parser)]
+pub struct ArgsAddPeer {
+    /// Peer public key
+    public_key: UniPublicKey,
+    /// Peer address
+    address: Multiaddr,
+}
+
+#[async_trait]
+impl HandleCommand<ArgsAddPeer> for CommandContext {
+    async fn handle_command(&mut self, args: ArgsAddPeer) -> Result<(), Error> {
+        let public_key = args.public_key.into();
+        if self.peer_manager.exists(&public_key).await {
+            return Err(anyhow!("Peer with public key '{}' already exists", public_key));
+        }
+        let node_id = NodeId::from_public_key(&public_key);
+        let peer = Peer::new(
+            public_key,
+            node_id.clone(),
+            vec![args.address].into(),
+            PeerFlags::empty(),
+            PeerFeatures::empty(),
+            vec![],
+            String::new(),
+        );
+        self.peer_manager.add_peer(peer).await?;
+        println!("Peer with node id '{}'was added to the base node.", node_id);
+        Ok(())
+    }
+}

--- a/applications/tari_base_node/src/commands/command/mod.rs
+++ b/applications/tari_base_node/src/commands/command/mod.rs
@@ -20,6 +20,7 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+mod add_peer;
 mod ban_peer;
 mod block_timing;
 mod check_db;
@@ -108,6 +109,7 @@ pub enum Command {
     PingPeer(ping_peer::Args),
     ResetOfflinePeers(reset_offline_peers::Args),
     RewindBlockchain(rewind_blockchain::Args),
+    AddPeer(add_peer::ArgsAddPeer),
     BanPeer(ban_peer::ArgsBan),
     UnbanPeer(ban_peer::ArgsUnban),
     UnbanAllPeers(unban_all_peers::Args),
@@ -224,6 +226,7 @@ impl HandleCommand<Command> for CommandContext {
             Command::ListPeers(args) => self.handle_command(args).await,
             Command::DialPeer(args) => self.handle_command(args).await,
             Command::PingPeer(args) => self.handle_command(args).await,
+            Command::AddPeer(args) => self.handle_command(args).await,
             Command::BanPeer(args) => self.handle_command(args).await,
             Command::UnbanPeer(args) => self.handle_command(args).await,
             Command::ResetOfflinePeers(args) => self.handle_command(args).await,


### PR DESCRIPTION
Description
---
Adds `add-peer` command to base node

Motivation and Context
---
Allows peers to be added by the base node command prompt. Previously, if you have a small network without valid seed peers
and wanted to connect to a new base node, you'd have to add the peer to your seed peer list in the config.

```
> add-peer b000b47f535b45e4cd0071d7161704cceb17e12fd1ee2dd3ca0337ea4161043d /onion3/fqdjgb4bh4frnaszxpv32jkup5qjbalbo7k2h4chj2zvfa7dasjyeoqd:18141
Peer with node id '89489c26c311bdd6a0912d37da'was added to the base node.
> dial-peer b000b47f535b45e4cd0071d7161704cceb17e12fd1ee2dd3ca0337ea4161043d
```

How Has This Been Tested?
---
Manually
