### PR TITLE
fix(comms)!: use domain hasher for noise DH key derivation

### DIFF
--- a/comms/core/src/types.rs
+++ b/comms/core/src/types.rs
@@ -24,6 +24,7 @@
 
 use tari_crypto::{
     hash::blake2::Blake256,
+    hash_domain,
     keys::PublicKey,
     ristretto::RistrettoPublicKey,
     signatures::SchnorrSignature,
@@ -55,3 +56,5 @@ pub type CommsDataStore = LMDBStore;
 pub type CommsDatabase = LMDBWrapper<PeerId, Peer>;
 #[cfg(test)]
 pub type CommsDatabase = HashmapDatabase<PeerId, Peer>;
+
+hash_domain!(CommsCoreHashDomain, "com.tari.comms.core", 0);


### PR DESCRIPTION
Description
---
Hashes the noise DH shared secret  

Motivation and Context
---
All DH shared secrets should be hashed to remove any possible slight bias in the resulting key.

Ref #4393 

How Has This Been Tested?
---
Unit test updated. Existing tests pass
