### PR TITLE
chore: fix typo

### DIFF
--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -781,7 +781,7 @@ where B: BlockchainBackend + 'static
                 metrics::rejected_blocks(block.header.height, &block_hash).inc();
                 warn!(
                     target: LOG_TARGET,
-                    "Peer {} sent an invalid header: {}",
+                    "Peer {} sent an invalid block: {}",
                     source_peer
                         .as_ref()
                         .map(ToString::to_string)


### PR DESCRIPTION
This error should not be `header`, but should be `block`. 
Currently the displayed error reads:
`WARN Peer <local request> sent an invalid header: Validation error: The transaction is invalid: Signature is invalid: Verifying kernel signature`


Fixes: https://github.com/tari-project/tari/issues/4389