### PR TITLE
feat!: apply hashing api to the mmr

### DIFF
--- a/base_layer/core/src/blocks/genesis_block.rs
+++ b/base_layer/core/src/blocks/genesis_block.rs
@@ -75,26 +75,27 @@ pub fn get_igor_genesis_block() -> ChainBlock {
     // lets get the block
     let block = get_igor_genesis_block_raw();
 
-    // user this code to generate the correct header mr fields for igor if the gen block changes.
+    // Use this code to generate the correct header mr fields for igor if the gen block changes.
+
     // use croaring::Bitmap;
-    // use tari_mmr::{MerkleMountainRange, MutableMmr};
-    // use tari_crypto::hash::blake2::Blake256;
     //
-    // let mut kernel_mmr = MerkleMountainRange::<Blake256, _>::new(Vec::new());
+    // use crate::{KernelMmr, MutableOutputMmr, WitnessMmr};
+    //
+    // let mut kernel_mmr = KernelMmr::new(Vec::new());
     // for k in block.body.kernels() {
     //     println!("k: {}", k);
     //     kernel_mmr.push(k.hash()).unwrap();
     // }
     //
-    // let mut witness_mmr = MerkleMountainRange::<Blake256, _>::new(Vec::new());
-    // let mut output_mmr = MutableMmr::<Blake256, _>::new(Vec::new(), Bitmap::create()).unwrap();
+    // let mut witness_mmr = WitnessMmr::new(Vec::new());
+    // let mut output_mmr = MutableOutputMmr::new(Vec::new(), Bitmap::create()).unwrap();
     //
     // for o in block.body.outputs() {
     //     witness_mmr.push(o.witness_hash()).unwrap();
     //     output_mmr.push(o.hash()).unwrap();
     // }
     //
-    // println!("kernel mr: {}",kernel_mmr.get_merkle_root().unwrap().to_hex());
+    // println!("kernel mr: {}", kernel_mmr.get_merkle_root().unwrap().to_hex());
     // println!("witness mr: {}", witness_mmr.get_merkle_root().unwrap().to_hex());
     // println!("output mr: {}", output_mmr.get_merkle_root().unwrap().to_hex());
 
@@ -111,14 +112,16 @@ pub fn get_igor_genesis_block() -> ChainBlock {
 }
 
 fn get_igor_genesis_block_raw() -> Block {
+    // Note: Use print_new_genesis_block_igor in core/tests/helpers/block_builders.rs to generate the required fields
+    // below
     let sig = Signature::new(
-        PublicKey::from_hex("5ef2b1f20d1f2af8dd2bf816218d26c1d11a2e2e2b934a190945e97e0428ce54").unwrap(),
-        PrivateKey::from_hex("7955c5f2db0c243194d7dbbc587f2a21b8c69107a3fb0f90661a936302a9670e").unwrap(),
+        PublicKey::from_hex("90e9cd591ed69e325fbdf0b36fd4aeab8b1917542ff94c32b0e38896827d1943").unwrap(),
+        PrivateKey::from_hex("cbf10a5453e09990ecb22a55935acf2d6ad10237dde94fca56495ae2fead110b").unwrap(),
     );
     let coinbase_meta_sig = CommitmentSignature::new(
-        Commitment::from_hex("beb78b4d22dc8ceccaee9871484d3052e2bd1bb5b4323085f3e17a104b41b552").unwrap(),
-        PrivateKey::from_hex("0ee30fde0c595b3fe6ce08079f4cf3e4d062ec1b7c61e9640efcb4d2dbea1704").unwrap(),
-        PrivateKey::from_hex("92c0fd252fb03bdf0a470ea2cc957505f764eef8bbeda2a30a21e9d870c3b604").unwrap(),
+        Commitment::from_hex("1abc2df9fe3c6a3e68ef0e7219dd3dd617646e67857c39f4fcef7ee044191272").unwrap(),
+        PrivateKey::from_hex("fdbef6a0e7560d555c0c5cef216cae1549dbb43c9e0747ec42551f5efb318105").unwrap(),
+        PrivateKey::from_hex("1d317a93fd9aaad4ba172b0be0e7b2676287e68fb47cd0b8e6613506253be601").unwrap(),
     );
     let mut body = AggregateBody::new(
         vec![],
@@ -129,14 +132,14 @@ fn get_igor_genesis_block_raw() -> Block {
                 .. Default::default()
             },
             Commitment::from_hex(
-                "e82395916d1090bc2bc8eaada037e6747558d72614c685aefe008ead4caf4637",
+                "1805b11acc21796deeccecde810583fcf2d850bea46bce6beab6a76459eeeb26",
             )
                 .unwrap(),
-            BulletRangeProof::from_hex("0104072270fe6020497cd87d9da4b696a3727f6e46a0b66178f66de21f4c67a33766ccdea1422dd687e834d499b8ad53fe949fea878e5fbb1b00db312a377ca54c8a76776384f834ced9d17f0f5141efb3acd8b2d18b065eedb7b62e468454f87d36f2b5b3a2f430de8ec04ec45498388974af522daed4ede872dc0946c20aff4378402b241968ad850d3c3480ba836d435a78b571447cb4f96365d24c650694584421741197a4b7a206b3d728ce54860de73fb7821af5ebd633448444a275347aea2e10fb95355aa633dfff83a651c1f70337fecb91afe061eb14081f7be9d866acc0cfaf45289c7e937490b86f30c0a2686a65491a9f5cfd40cb3849181dc22fb6706d8f4a7eb27dd0a80fcf6ce121d4a79f709c83280fc21944877a21ec86466cb8aa752d1ea5fc4d822f91c8382798206b3c0157b1f939d659100139cf396664f6b8d945887112038785559dfafe4c7cdc77fc1d822e7c68ef2409ae82f002943650be275c23bbf80ad6fb0d3ab077a7b9e1c1c3051988886b8a78d0d0247f9a7ad70b419b63437959a3ad5a7e0cf821325e901a65f10fa5f58e70c67b5d47b81c9d1201acffede4bb377522771213975bda5366645451075f0f95e9405e26d810dfeddc0e9f2d6801af7db3763126b4c6085d6ae6d3ede44663168126ff4ac1e83deb4cb722f9c7249d18dba33e0e7169326bfd7fa586d990f3faefa6530348f83bb8786e035e4943bcafeb7db5ca97d0ed727e07fe30411063aaa20304061c91c56230c2207254586db650c897bc1782fc40c6f9df2a415bc389b3a6f901 ").unwrap(),
+            BulletRangeProof::from_hex("01369dfde898b40805d6a8964f3f8aff6d1bb17beaf71da91793fe097c0ee8b03930abd4672a4a90dd3610110d6e152c5105de7fdc50c582f810dc2be235dee61dfce10d7b487004f5023956fc346569be554c8d2a43c71f7d5fc83c2019aac07ae8f432cd6f18e98c2ce49908e4212e4f91b99c71bb87e4efe845096c87497c15189394092ce32b6a2f06765cc2124c6a07adc28f629cb26905c0da0d70ab112a301018acda9bdee5165662bb8afe3b43a4d373110086366bc18fd90683a4336b5a01008e174c134ceea61c04fe14cd16bce83bd36219410a5367e95a32460d42a89205c892870300a237652ed1d9d4c824c1eefc3f1da648bc22db11efc75b5e7cd8b709e1f89d53e81ff1267b896a74fb7f3870bbb413f5fdbfc34b66652b2fbcce1794db2416489b1b57ccbb034c4b88772368d8d9397726d9e52d40b2736a221ae6348790b58320df517cbd603f1f27ccf11980af0689ed529cad70631171823574480731971e546240e00f5358ac5bae24588a873e7649c97be62381b965c01f1372cd1eeff2048a5e0363c0ecf227ffbf1591b51f8f1a963b0db2266b00229ec70db46ed31812f13a0d1c432b71b8e7d0cdd9f293590b4bdb7ebe93e90fde0173afce419de1ff4af3cef277130e271c4a4417fff0d5d60e5483ccc7e236b1347e47063037252ae063f12ce903bc7947aedfcd70aa85a7ef628f31d9fe076508dba9f8b2091876b2f5795f68bbdd267ceb5d6b4ddfe3bf225b54fedd79001acda500080212469bd0e99c4721fda2363b16915c97c5bf8b1f8d4de8be760d").unwrap(),
             // For genesis block: A default script can never be spent, intentionally
             script!(Nop),
             // Script offset never checked for coinbase, thus can use default
-            PublicKey::from_hex("3087544d44fa95c0a92dc41f52d2586f03344a4f7b12654c0f07478944dd5203").unwrap(),
+            PublicKey::from_hex("3ec3bc4ab31d3266bec5e7ed977bb766ab9b1d8951547ae7f653dc6109334e38").unwrap(),
             // For genesis block: Metadata signature will never be checked
             coinbase_meta_sig,
             Covenant::default(),
@@ -149,7 +152,7 @@ fn get_igor_genesis_block_raw() -> Block {
             MicroTari(0),
             0,
             Commitment::from_hex(
-                "6a5b18da02df69f4cc69628b818f1a5bb7079c2b27021d69473d4c5288545a74",
+                "660d5125fee9784c7c4d7ae5c533591418bf081a3ff21097f0bf9157af5aa91a",
             )
                 .unwrap(),
             sig,None
@@ -167,10 +170,10 @@ fn get_igor_genesis_block_raw() -> Block {
             height: 0,
             prev_hash: vec![0; BLOCK_HASH_LENGTH],
             timestamp: timestamp.into(),
-            output_mr: from_hex("b7303adaedfb8ad36f297b259411285938c9ce3640f83e7e28a326d90e57a22c").unwrap(),
-            witness_mr: from_hex("4c65d88db394ae7ca4634a26fda6b71dab8ec19fe69ca0c9a0cda638c2b2f874").unwrap(),
+            output_mr: from_hex("331daafb9d16ab1b11a20dabb2ece9e609dfdef752793562173ed238d4e52d7f").unwrap(),
+            witness_mr: from_hex("33af10f6bd6e0cc06e1f2def2e0f61371a9ff62ef0cdee47ed76caa6ce3778dc").unwrap(),
             output_mmr_size: 1,
-            kernel_mr: from_hex("7b2a06b6cd391f241fd94eec3891ea52554f0a2a8aa7b6f45a125cc7c13e728a").unwrap(),
+            kernel_mr: from_hex("1830a7f405c7d50c386322e30d0de71d075ac11ec590c77e2826b7e65f0ed935").unwrap(),
             kernel_mmr_size: 1,
             input_mr: vec![0; BLOCK_HASH_LENGTH],
             total_kernel_offset: PrivateKey::from_hex(
@@ -214,19 +217,19 @@ pub fn get_esmeralda_genesis_block() -> ChainBlock {
 
     // Use this code if you need to generate new Merkle roots
     // NB: `esmerlada_genesis_sanity_check` must pass
-    //
+
     // use croaring::Bitmap;
-    // use tari_crypto::hash::blake2::Blake256;
-    // use tari_mmr::{MerkleMountainRange, MutableMmr};
     //
-    // let mut kernel_mmr = MerkleMountainRange::<Blake256, _>::new(Vec::new());
+    // use crate::{KernelMmr, MutableOutputMmr, WitnessMmr};
+    //
+    // let mut kernel_mmr = KernelMmr::new(Vec::new());
     // for k in block.body.kernels() {
     //     println!("k: {}", k);
     //     kernel_mmr.push(k.hash()).unwrap();
     // }
     //
-    // let mut witness_mmr = MerkleMountainRange::<Blake256, _>::new(Vec::new());
-    // let mut output_mmr = MutableMmr::<Blake256, _>::new(Vec::new(), Bitmap::create()).unwrap();
+    // let mut witness_mmr = WitnessMmr::new(Vec::new());
+    // let mut output_mmr = MutableOutputMmr::new(Vec::new(), Bitmap::create()).unwrap();
     //
     // for o in block.body.outputs() {
     //     witness_mmr.push(o.witness_hash()).unwrap();
@@ -241,9 +244,9 @@ pub fn get_esmeralda_genesis_block() -> ChainBlock {
     // println!("output mr: {}", block.header.output_mr.to_hex());
 
     // Hardcode the Merkle roots once they've been computed above
-    block.header.kernel_mr = from_hex("a6d5e97528fcf06741efdc51e7d7aeb800498a6370175f976d72583c30bdd6b6").unwrap();
-    block.header.witness_mr = from_hex("7e5e52e975fb4a60213c3ace23e32be1c25998efd53614c3d941f1938314a002").unwrap();
-    block.header.output_mr = from_hex("3421092eec9e185ffeadebc821e0fcfb543e99bba5f2f0df570d478633f60f79").unwrap();
+    block.header.kernel_mr = from_hex("a3ebc99443f546cadea6146ec12a841fc3d51d2c322029273d6bb44d9879d81a").unwrap();
+    block.header.witness_mr = from_hex("2ccdd0aeb1ff7b41ce0a6f1f3123a71138d705e9abf36b684271decca8e20855").unwrap();
+    block.header.output_mr = from_hex("b15724ad00693d13e574909af476fd980ea0ba183462b2389442043d785a3f0d").unwrap();
 
     let accumulated_data = BlockHeaderAccumulatedData {
         hash: block.hash(),
@@ -258,15 +261,16 @@ pub fn get_esmeralda_genesis_block() -> ChainBlock {
 }
 
 fn get_esmeralda_genesis_block_raw() -> Block {
-    // Note: Use print_new_genesis_block in core/tests/helpers/block_builders.rs to generate the required fields below
+    // Note: Use print_new_genesis_block_esme in core/tests/helpers/block_builders.rs to generate the required fields
+    // below
     let excess_sig = Signature::new(
-        PublicKey::from_hex("6451056817c90fb805bac8d224ddaa1e9808707d5783265c6c7d680d01983f78").unwrap(),
-        PrivateKey::from_hex("f4760c0552d6352420b2187aa30b5b6f8e59e9de79486268a7970040dd04ce0f").unwrap(),
+        PublicKey::from_hex("b4e82e14ab54f7fe025a832160ae589fbd2ccd8daa66d04e0e3c058b23c5d339").unwrap(),
+        PrivateKey::from_hex("c40cd89e2433f8ace92f544d291a8cc65686c2512cc6e1d01f68cf8856f3630e").unwrap(),
     );
     let coinbase_meta_sig = CommitmentSignature::new(
-        Commitment::from_hex("d091215bef2cf35b4bedd404ae30091f068dd38de250aa953b7cd2ab12207b33").unwrap(),
-        PrivateKey::from_hex("e20b5e6e9d6a42c0081d9108bbab7cd32406356f020b5c3077d664f7e95e840c").unwrap(),
-        PrivateKey::from_hex("97777a4fcab5348a52270e9d885d8539a3272d17fb781a74ac8a66b701ff6e0f").unwrap(),
+        Commitment::from_hex("1875cb95dc182a7186259af680b9ea4c2443850de37fac23928cbd5130d0af0d").unwrap(),
+        PrivateKey::from_hex("2f9d7e2a3e7ca12ed91e8e24c159d3274e871407fe72f220faab47fa46bde904").unwrap(),
+        PrivateKey::from_hex("39864d07c8c1134ce515a56ed56f35bddebb803bc944c0b9f0f588b5f19d3602").unwrap(),
     );
     let coinbase = TransactionOutput::new(
         TransactionOutputVersion::get_current_version(),
@@ -275,14 +279,20 @@ fn get_esmeralda_genesis_block_raw() -> Block {
             output_type: OutputType::Coinbase,
             maturity: 3,
             metadata: Vec::new(),
+            unique_id: None,
             sidechain_features: None,
+            parent_public_key: None,
+            asset: None,
+            mint_non_fungible: None,
+            sidechain_checkpoint: None,
+            committee_definition: None,
         },
-        Commitment::from_hex("a05abd3009b42f0713e8bda9d33c0d12ef8ad048929ea1e6e62ed9423715305d").unwrap(),
-        BulletRangeProof::from_hex("01acb432c02a7de7016df76edf94a97f19022a6c0b254cdf329f78dac57dba0e23c43f97851dd063f1388f9bbc2c9998c4446691404742b965643f12a6591c68545ccd912272d9fa8496109e84c15bb658baca78a619cee1403f7016b0b79f840ae0d2fb61d9d1832ee825fa54d943d9343eb4b48bf7be8b894291f3e63a4e7e6fd09e7bc033c1098c7ceec1ef0c99c5d24c9918ea301389300e0be5c62b848b35bc62a72b63f59c01ddfb80a9051e8f8d1da10d551a1cfc45f06a3e739b1ebf718e6808e3e04986401bbad703224c5d06107d83788c2586f4e51e5f0fd5071566e01335e1d2ef83655d8ae63ff03d00607469ee77c22e078398963ce2a1ed917ec630f533528c0c5dca366edd9a59317a23704c4a041ed8de774040e50ee7b576f4d3cffdcf2bd54f6968de9a68c7b7cd955064f7d3531ff1978e7dff692b9932eae7a05c70d7687cba4255da922acbd89c7424aaefacde949bcc6b4119dd8153026d599646e3bbc527ff3d807cc3ccac72d0d62aaf29671db66dfb27a269c55f684b0e0be9fa70d342b4dad548e31a6712ebb7205ac783caba96b852fc2ccc17007c71e786428023ced2203ab86b968373aa5ab22c719d603805035ed26cf8173e5f2d7d6871ebb0f16ca9fd606ad2c66fa740aacfe716f4b9c53a44109c9f259539cc5bad91ebd1af13cb2f18d233aba7a96ef08647f9896c8eed6eb1cbb40b8c2b80d644860a7457d7fbde4f42f04b2a2239619a06fa5247cb3874c7cac80ce70f6286732a0fc0c1f7631f7c800189f69bde41203746d2ca9fbf52e592d401").unwrap(),
+        Commitment::from_hex("00d6e2617fc58804c6c1723df20ad3941f66aecbf079f205a9ad5ba9c84b7d5b").unwrap(),
+        BulletRangeProof::from_hex("01b04258b14f2093e796290ba4e011e71745d38c6d59d47eee509f33fff8c0c467e23d95553482c3e48382f068841e8bc40238e53886a38148ab05ea0bcbe35e12e075c2b3ec2ed7a81d72b31c5a7c79c391bc5aec841917f01fa656220baac6370a1458732f50c0bb16b18058c52a0fb6dfdce745078f318055f66eb81d911b365032bb9672cce7d4fddaefadabbc35cd3b16782012ccbfedc774650eda66df53fe97c1c3b69feadd141865bfd218a20d7d9e1032957bcb87f28ad984b9a81b45b8869314bd39d7fec662270b5988b5e247b5c37f54132b37af115a61f40fef2cc2d696ca7413fb2a037dae574fbbd854d6fa4cec956088975ae2450e98a19c3492098ac1efe95c4b73deef206c03394a25679d03e89e74a626bec9b6a5c7104b5ca7e152119dc08b393238eeca34388d7364dcc6e13ffb1f57b3c038219a7f4b8043a6378e8310d2c6f229f716b438064d7b359717010118bf8860f7ae61a422104a73bd4c5d36538b5112dd0beb293b463bd3d15f4c847a8c848c7369bd395dfefd18ab6d1cf6e41f02916caa3659580149d31c33c1c4c2fb6645cef528a4704865d3f905fc12bba1c2469e3379999ad63c1266e73a7b9726ac99cc3700d5325aab127d74c4b025977ef9d2fcea26be519c1b2e8727e58ac943684e35e38c7d92217c8b2981a423a77849b94ec05d6b89700937916be5e31c74d8ba854af0023b6770b68962ca7e94123a1e8b13cef5844d0f8405ca89c0dbd56c6d1f96bc070077afcf72f55eb8375444f9d038bcb8b88ded2cb7abb7fb22d021581191b205").unwrap(),
         // A default script can never be spent, intentionally
         script!(Nop),
         // The Sender offset public key is not checked for coinbase outputs
-        PublicKey::from_hex("32a21d53836d8476458be02a9a591f7e37278383967ef42ded35f8d63f2f7c25").unwrap(),
+        PublicKey::from_hex("263adc1c006b85ac62df5e82e25274655ade2680ee6372e9291af031b0a3c025").unwrap(),
         // For genesis block: Metadata signature will never be checked
         coinbase_meta_sig,
         // Covenant
@@ -296,7 +306,7 @@ fn get_esmeralda_genesis_block_raw() -> Block {
         KernelFeatures::COINBASE_KERNEL,
         MicroTari(0),
         0,
-        Commitment::from_hex("947f7949c54c831c2189a1208bbb9c77fda9fd246ff4948a9fad542b27b4d426").unwrap(),
+        Commitment::from_hex("8e81612b46e718305fc18c1a1058450ff1799ec22fc538b29f065026791c5c05").unwrap(),
         excess_sig,
         None,
     );
@@ -312,10 +322,10 @@ fn get_esmeralda_genesis_block_raw() -> Block {
             height: 0,
             prev_hash: vec![0; BLOCK_HASH_LENGTH],
             timestamp: timestamp.into(),
-            output_mr: from_hex("ec3f1d12ebb1431132510b971f0747979a4304148775e4a1c483dd36ef127081").unwrap(),
-            witness_mr: from_hex("1dcd2c3210813980c7d7523800555d6fc2db4698d75995329551b39c25a28c3b").unwrap(),
+            output_mr: from_hex("867e4bfa4a5731652d49a7cd32a6ddcacc3473b8b8f446f6d7366aa671eb3842").unwrap(),
+            witness_mr: from_hex("36034e90dbf56b54fcc63fb26a6200a15b9fdb4957834d7de42ee3ada1aaaa00").unwrap(),
             output_mmr_size: 1,
-            kernel_mr: from_hex("0dd48e599a8d22e29f6ea80a88875761393d21546a72904b99428d54780e6078").unwrap(),
+            kernel_mr: from_hex("8ecc03eba1c5ee9ba7e5069c723e74587535eccbc06ce9149f6d4a0469900ffa").unwrap(),
             kernel_mmr_size: 1,
             input_mr: vec![0; BLOCK_HASH_LENGTH],
             total_kernel_offset: PrivateKey::from_hex(
@@ -341,8 +351,6 @@ mod test {
 
     use croaring::Bitmap;
     use tari_common_types::types::Commitment;
-    use tari_crypto::hash::blake2::Blake256;
-    use tari_mmr::{MerkleMountainRange, MutableMmr};
 
     use super::*;
     use crate::{
@@ -350,6 +358,9 @@ mod test {
         test_helpers::blockchain::create_new_blockchain_with_network,
         transactions::{transaction_components::transaction_output::batch_verify_range_proofs, CryptoFactories},
         validation::{ChainBalanceValidator, FinalHorizonStateValidation},
+        KernelMmr,
+        MutableOutputMmr,
+        WitnessMmr,
     };
 
     #[test]
@@ -384,13 +395,13 @@ mod test {
             .any(|k| k.features.contains(KernelFeatures::COINBASE_KERNEL)));
 
         // Check MMR
-        let mut kernel_mmr = MerkleMountainRange::<Blake256, _>::new(Vec::new());
+        let mut kernel_mmr = KernelMmr::new(Vec::new());
         for k in block.block().body.kernels() {
             kernel_mmr.push(k.hash()).unwrap();
         }
 
-        let mut witness_mmr = MerkleMountainRange::<Blake256, _>::new(Vec::new());
-        let mut output_mmr = MutableMmr::<Blake256, _>::new(Vec::new(), Bitmap::create()).unwrap();
+        let mut witness_mmr = WitnessMmr::new(Vec::new());
+        let mut output_mmr = MutableOutputMmr::new(Vec::new(), Bitmap::create()).unwrap();
 
         for o in block.block().body.outputs() {
             o.verify_metadata_signature().unwrap();
@@ -450,13 +461,13 @@ mod test {
             .any(|k| k.features.contains(KernelFeatures::COINBASE_KERNEL)));
 
         // Check MMR
-        let mut kernel_mmr = MerkleMountainRange::<Blake256, _>::new(Vec::new());
+        let mut kernel_mmr = KernelMmr::new(Vec::new());
         for k in block.block().body.kernels() {
             kernel_mmr.push(k.hash()).unwrap();
         }
 
-        let mut witness_mmr = MerkleMountainRange::<Blake256, _>::new(Vec::new());
-        let mut output_mmr = MutableMmr::<Blake256, _>::new(Vec::new(), Bitmap::create()).unwrap();
+        let mut witness_mmr = WitnessMmr::new(Vec::new());
+        let mut output_mmr = MutableOutputMmr::new(Vec::new(), Bitmap::create()).unwrap();
         assert_eq!(block.block().body.kernels().len(), 1);
         assert_eq!(block.block().body.outputs().len(), 1);
         for o in block.block().body.outputs() {

--- a/base_layer/core/src/blocks/genesis_block.rs
+++ b/base_layer/core/src/blocks/genesis_block.rs
@@ -115,13 +115,13 @@ fn get_igor_genesis_block_raw() -> Block {
     // Note: Use print_new_genesis_block_igor in core/tests/helpers/block_builders.rs to generate the required fields
     // below
     let sig = Signature::new(
-        PublicKey::from_hex("90e9cd591ed69e325fbdf0b36fd4aeab8b1917542ff94c32b0e38896827d1943").unwrap(),
-        PrivateKey::from_hex("cbf10a5453e09990ecb22a55935acf2d6ad10237dde94fca56495ae2fead110b").unwrap(),
+        PublicKey::from_hex("46f23560fb880900d03552e98ee511bceb03692635b3a50fe42be43e9fe80507").unwrap(),
+        PrivateKey::from_hex("8c781c1af074126539a950ca171b343d51659fb996b69d6f17e412cb952a610a").unwrap(),
     );
     let coinbase_meta_sig = CommitmentSignature::new(
-        Commitment::from_hex("1abc2df9fe3c6a3e68ef0e7219dd3dd617646e67857c39f4fcef7ee044191272").unwrap(),
-        PrivateKey::from_hex("fdbef6a0e7560d555c0c5cef216cae1549dbb43c9e0747ec42551f5efb318105").unwrap(),
-        PrivateKey::from_hex("1d317a93fd9aaad4ba172b0be0e7b2676287e68fb47cd0b8e6613506253be601").unwrap(),
+        Commitment::from_hex("5231d399cbc20df114953b04ee48987dc10b4508d936cd047a5e9764e587517c").unwrap(),
+        PrivateKey::from_hex("ae6c37d88b6df65295d30a09c0a92db27ee92b58f83379de5952b68af6040a09").unwrap(),
+        PrivateKey::from_hex("a6d7fab484d934127905925bf5cb6c163cbf91db14af3809cfd8ca83453e0803").unwrap(),
     );
     let mut body = AggregateBody::new(
         vec![],
@@ -132,14 +132,14 @@ fn get_igor_genesis_block_raw() -> Block {
                 .. Default::default()
             },
             Commitment::from_hex(
-                "1805b11acc21796deeccecde810583fcf2d850bea46bce6beab6a76459eeeb26",
+                "166e79a49c2ab50d2ef3c8246418c6e9897071dcdeaf3b6aba1ae600ebbc8202",
             )
                 .unwrap(),
-            BulletRangeProof::from_hex("01369dfde898b40805d6a8964f3f8aff6d1bb17beaf71da91793fe097c0ee8b03930abd4672a4a90dd3610110d6e152c5105de7fdc50c582f810dc2be235dee61dfce10d7b487004f5023956fc346569be554c8d2a43c71f7d5fc83c2019aac07ae8f432cd6f18e98c2ce49908e4212e4f91b99c71bb87e4efe845096c87497c15189394092ce32b6a2f06765cc2124c6a07adc28f629cb26905c0da0d70ab112a301018acda9bdee5165662bb8afe3b43a4d373110086366bc18fd90683a4336b5a01008e174c134ceea61c04fe14cd16bce83bd36219410a5367e95a32460d42a89205c892870300a237652ed1d9d4c824c1eefc3f1da648bc22db11efc75b5e7cd8b709e1f89d53e81ff1267b896a74fb7f3870bbb413f5fdbfc34b66652b2fbcce1794db2416489b1b57ccbb034c4b88772368d8d9397726d9e52d40b2736a221ae6348790b58320df517cbd603f1f27ccf11980af0689ed529cad70631171823574480731971e546240e00f5358ac5bae24588a873e7649c97be62381b965c01f1372cd1eeff2048a5e0363c0ecf227ffbf1591b51f8f1a963b0db2266b00229ec70db46ed31812f13a0d1c432b71b8e7d0cdd9f293590b4bdb7ebe93e90fde0173afce419de1ff4af3cef277130e271c4a4417fff0d5d60e5483ccc7e236b1347e47063037252ae063f12ce903bc7947aedfcd70aa85a7ef628f31d9fe076508dba9f8b2091876b2f5795f68bbdd267ceb5d6b4ddfe3bf225b54fedd79001acda500080212469bd0e99c4721fda2363b16915c97c5bf8b1f8d4de8be760d").unwrap(),
+            BulletRangeProof::from_hex("01007308cceb1c168fcf65174e3d5fccd466e84f36e541a6254a5677b48c186b02547b65e98f3319e83ec240485b7f5448912d8b9e656a6bf471e1a98e435f2978ba32a1e375cefc17e3f42f28b6b86bc2fa07126c15c9812ecfa5f7eebaaa5308169366cea3c6a1524ddbb9d1804193cc7a1fb149ddc70eee72c4792c0039206132a2f13dfe823a815d92337d35656f1983a31d440ad9e5fa7b47aaa2b682ba7ed29cf3ae681b730f49555d830025a50eaadaae7f62b5ce1107598130b904747292419e1520c1645547b1d046f5c1f71978eafb8edc485b7ff40e9633f1fed5446081bfe51c54cf6567cc6c14fa0715ddc285548acb256d0d52c3646cdb9b797dbceb2843d3b26d264a130da2a413b78b1e3b026a0f32ccd080cc7876b4fe0a702a92484dbafeea9470103ea380e0906bc26a43ea6215e0570a968530c1c9724d3ac5a7912f468adb6d82d1f5e34fdd43668f3b41ade8bf6c3b2148d1ac3f957c5883e60367fe906a74338837d0e98ad29db37e38c708c6c978d0e75ea656d26b2a8b38169f207c0f57f97f6169bda0427bc31430cf51671d6bb566315e19a6522ef61fb41842374285e509925a0966b66733fe2dc8bd190ba7d77c55f0b8401d78e08432d2950ff6a166ade9476a5165c7ccedaab4520b617530c9dbf83efe0a7f9a75b23e34e3ca548336cbbf696817ccbfc6467c5c9cec989050d8e7a2300ad5d65f90ba7b3fad98056114461cf1f06466a25a911c07467aad936eae99e001bc67377f450b60ef6f649e77ff495d382c39449c24d617ca54502209c1129e06").unwrap(),
             // For genesis block: A default script can never be spent, intentionally
             script!(Nop),
             // Script offset never checked for coinbase, thus can use default
-            PublicKey::from_hex("3ec3bc4ab31d3266bec5e7ed977bb766ab9b1d8951547ae7f653dc6109334e38").unwrap(),
+            PublicKey::from_hex("5c498523022af6acf2bc940122a3fbe82b90ae98a16707e1d942bb6ced94ba11").unwrap(),
             // For genesis block: Metadata signature will never be checked
             coinbase_meta_sig,
             Covenant::default(),
@@ -152,7 +152,7 @@ fn get_igor_genesis_block_raw() -> Block {
             MicroTari(0),
             0,
             Commitment::from_hex(
-                "660d5125fee9784c7c4d7ae5c533591418bf081a3ff21097f0bf9157af5aa91a",
+                "6454fc05c089122a833bb86311dd43a5f984730d110ba6d11a354ff90c240625",
             )
                 .unwrap(),
             sig,None
@@ -170,10 +170,10 @@ fn get_igor_genesis_block_raw() -> Block {
             height: 0,
             prev_hash: vec![0; BLOCK_HASH_LENGTH],
             timestamp: timestamp.into(),
-            output_mr: from_hex("331daafb9d16ab1b11a20dabb2ece9e609dfdef752793562173ed238d4e52d7f").unwrap(),
-            witness_mr: from_hex("33af10f6bd6e0cc06e1f2def2e0f61371a9ff62ef0cdee47ed76caa6ce3778dc").unwrap(),
+            output_mr: from_hex("3674e705fec6f4fd46357bb7fe56920febde9fc6d29633bc9b1e63320163a7fb").unwrap(),
+            witness_mr: from_hex("883eb8d91e4d7454ca9b8f1ede38117c6a1ea990d521902e9035e68bc6ed9b8b").unwrap(),
             output_mmr_size: 1,
-            kernel_mr: from_hex("1830a7f405c7d50c386322e30d0de71d075ac11ec590c77e2826b7e65f0ed935").unwrap(),
+            kernel_mr: from_hex("43aa6360a31d12460a4c6ba238394a5b7e838b4c8706c6773c1378096b15e44c").unwrap(),
             kernel_mmr_size: 1,
             input_mr: vec![0; BLOCK_HASH_LENGTH],
             total_kernel_offset: PrivateKey::from_hex(
@@ -244,9 +244,9 @@ pub fn get_esmeralda_genesis_block() -> ChainBlock {
     // println!("output mr: {}", block.header.output_mr.to_hex());
 
     // Hardcode the Merkle roots once they've been computed above
-    block.header.kernel_mr = from_hex("a3ebc99443f546cadea6146ec12a841fc3d51d2c322029273d6bb44d9879d81a").unwrap();
-    block.header.witness_mr = from_hex("2ccdd0aeb1ff7b41ce0a6f1f3123a71138d705e9abf36b684271decca8e20855").unwrap();
-    block.header.output_mr = from_hex("b15724ad00693d13e574909af476fd980ea0ba183462b2389442043d785a3f0d").unwrap();
+    block.header.kernel_mr = from_hex("e28cf2883b0d98eaf3b92ca3bbf273cb03ea076b93d72418d24e76b38fc064c1").unwrap();
+    block.header.witness_mr = from_hex("f217c83135a1813d63302be7332c0916e428597332f567a78554303ddcf94dc0").unwrap();
+    block.header.output_mr = from_hex("a316bac1be66adebc279b25f4095cadceffc7769550c8074c094ab49e19b57b0").unwrap();
 
     let accumulated_data = BlockHeaderAccumulatedData {
         hash: block.hash(),
@@ -261,16 +261,16 @@ pub fn get_esmeralda_genesis_block() -> ChainBlock {
 }
 
 fn get_esmeralda_genesis_block_raw() -> Block {
-    // Note: Use print_new_genesis_block_esme in core/tests/helpers/block_builders.rs to generate the required fields
-    // below
+    // Note: Use print_new_genesis_block_esmeralda in core/tests/helpers/block_builders.rs to generate the required
+    // fields below
     let excess_sig = Signature::new(
-        PublicKey::from_hex("b4e82e14ab54f7fe025a832160ae589fbd2ccd8daa66d04e0e3c058b23c5d339").unwrap(),
-        PrivateKey::from_hex("c40cd89e2433f8ace92f544d291a8cc65686c2512cc6e1d01f68cf8856f3630e").unwrap(),
+        PublicKey::from_hex("2e6e1612ecc4e73408ec49e182807e1e0d1cc19a27044de7c835cada1b4a8a34").unwrap(),
+        PrivateKey::from_hex("8c75a382785751d8a9b9e82c6ea1163781064faf70289aaebba69cd798134403").unwrap(),
     );
     let coinbase_meta_sig = CommitmentSignature::new(
-        Commitment::from_hex("1875cb95dc182a7186259af680b9ea4c2443850de37fac23928cbd5130d0af0d").unwrap(),
-        PrivateKey::from_hex("2f9d7e2a3e7ca12ed91e8e24c159d3274e871407fe72f220faab47fa46bde904").unwrap(),
-        PrivateKey::from_hex("39864d07c8c1134ce515a56ed56f35bddebb803bc944c0b9f0f588b5f19d3602").unwrap(),
+        Commitment::from_hex("74524345a8c1c7525c96a8580b3b847cdffde203e181825a233b6a98bd9eae18").unwrap(),
+        PrivateKey::from_hex("b99987bf957730cd5f4986a1d8d793f88ed5af4d50eb942d58a97b05bd97aa0a").unwrap(),
+        PrivateKey::from_hex("2c036580f0f60bf44f0b9a4a5045f5ab437fa87b136f47b548e56b9eb4ce1b00").unwrap(),
     );
     let coinbase = TransactionOutput::new(
         TransactionOutputVersion::get_current_version(),
@@ -279,20 +279,14 @@ fn get_esmeralda_genesis_block_raw() -> Block {
             output_type: OutputType::Coinbase,
             maturity: 3,
             metadata: Vec::new(),
-            unique_id: None,
             sidechain_features: None,
-            parent_public_key: None,
-            asset: None,
-            mint_non_fungible: None,
-            sidechain_checkpoint: None,
-            committee_definition: None,
         },
-        Commitment::from_hex("00d6e2617fc58804c6c1723df20ad3941f66aecbf079f205a9ad5ba9c84b7d5b").unwrap(),
-        BulletRangeProof::from_hex("01b04258b14f2093e796290ba4e011e71745d38c6d59d47eee509f33fff8c0c467e23d95553482c3e48382f068841e8bc40238e53886a38148ab05ea0bcbe35e12e075c2b3ec2ed7a81d72b31c5a7c79c391bc5aec841917f01fa656220baac6370a1458732f50c0bb16b18058c52a0fb6dfdce745078f318055f66eb81d911b365032bb9672cce7d4fddaefadabbc35cd3b16782012ccbfedc774650eda66df53fe97c1c3b69feadd141865bfd218a20d7d9e1032957bcb87f28ad984b9a81b45b8869314bd39d7fec662270b5988b5e247b5c37f54132b37af115a61f40fef2cc2d696ca7413fb2a037dae574fbbd854d6fa4cec956088975ae2450e98a19c3492098ac1efe95c4b73deef206c03394a25679d03e89e74a626bec9b6a5c7104b5ca7e152119dc08b393238eeca34388d7364dcc6e13ffb1f57b3c038219a7f4b8043a6378e8310d2c6f229f716b438064d7b359717010118bf8860f7ae61a422104a73bd4c5d36538b5112dd0beb293b463bd3d15f4c847a8c848c7369bd395dfefd18ab6d1cf6e41f02916caa3659580149d31c33c1c4c2fb6645cef528a4704865d3f905fc12bba1c2469e3379999ad63c1266e73a7b9726ac99cc3700d5325aab127d74c4b025977ef9d2fcea26be519c1b2e8727e58ac943684e35e38c7d92217c8b2981a423a77849b94ec05d6b89700937916be5e31c74d8ba854af0023b6770b68962ca7e94123a1e8b13cef5844d0f8405ca89c0dbd56c6d1f96bc070077afcf72f55eb8375444f9d038bcb8b88ded2cb7abb7fb22d021581191b205").unwrap(),
+        Commitment::from_hex("b2e78ac05e16f84187421842fbd12ff572cc9f1b37ddc639b06faac8f8e5270c").unwrap(),
+        BulletRangeProof::from_hex("0102804f62b404756c4e6ac0ca4c6b80de8cb9e587f906297dfdfb2868ceb89b4c38025068e435a54202efc8ea8eb62c1a9ba9397b60c32e6a15de70ab48fe154f987719c1e75b2c2c4059262150a8f2b6af6a9dc3296ce3fa9113fb348a3f5c7dea60432c369a61e425bbcd81b32ebfe075e97a69e4425a0992d587042788cc608af5a3b6e7f4e331e868b63f53b62a6d4379bfdbc34f300c64b59d53a943a8269cf9d92da950a78187536454bea76e2b1664345775b9b991ba63d3f463be06360e642394fc002435c7e200a51899909e2d06efb7859bbe590bd3b6a5ac662e6ee672e17b7f699efa62ac4cc0bb6c19da97b4dc93c421083e9d69e12aeeb49529e4d252b09dc4f1307f85d911a0b11e2cea120d7fed400c7d3e064ce4a36af04316f2f13ecfbf4e2dbdc9f5acfb7de61fb533e5a24499715be52ade128706fd2f0a33f6666631e3adb7e131f60e0e1a8d37f46df590031da629f78a984f5fe048f04cfa588461acd4fafe0b66599cac91066845fe02c7c55655db41797056dc0d2cd5bb27f9bec6ea7b276268c4f1e1fcb529a015cf12caecc6ae38ae3dddd35c42a0d0d131e5c7e468de63c6ecd47949c6b11c97bd35f0d77a92319bb0df6e1ae016626bf9b32f61b6ac92cc269f301f208cb3268f8f11e10c0b156e0e2b5d5ef6f2dfa4a3b55a7e9a9a6291f04349c19db9cdb3a63768afcecbb58057996d004480f075784c889b832f9a9438f22d98f6f1e44cb59b6bdc490e600c54be710785eaf8e7d4b1a9bee6c82581df3ab928180653e30f1340c01e752a0035f94f0b").unwrap(),
         // A default script can never be spent, intentionally
         script!(Nop),
         // The Sender offset public key is not checked for coinbase outputs
-        PublicKey::from_hex("263adc1c006b85ac62df5e82e25274655ade2680ee6372e9291af031b0a3c025").unwrap(),
+        PublicKey::from_hex("34b2aacea9871635fd0fb7d7b091b71a768d11dc63a2061769b30fb591452722").unwrap(),
         // For genesis block: Metadata signature will never be checked
         coinbase_meta_sig,
         // Covenant
@@ -306,7 +300,7 @@ fn get_esmeralda_genesis_block_raw() -> Block {
         KernelFeatures::COINBASE_KERNEL,
         MicroTari(0),
         0,
-        Commitment::from_hex("8e81612b46e718305fc18c1a1058450ff1799ec22fc538b29f065026791c5c05").unwrap(),
+        Commitment::from_hex("4ecf63f2c345b1231664abb0e6afea4fc050275d5945eeed454a10fa4e641936").unwrap(),
         excess_sig,
         None,
     );
@@ -322,10 +316,10 @@ fn get_esmeralda_genesis_block_raw() -> Block {
             height: 0,
             prev_hash: vec![0; BLOCK_HASH_LENGTH],
             timestamp: timestamp.into(),
-            output_mr: from_hex("867e4bfa4a5731652d49a7cd32a6ddcacc3473b8b8f446f6d7366aa671eb3842").unwrap(),
-            witness_mr: from_hex("36034e90dbf56b54fcc63fb26a6200a15b9fdb4957834d7de42ee3ada1aaaa00").unwrap(),
+            output_mr: from_hex("56309c4116b41b3135f6622dcecfeb257cd8ef4ba7b3d3c71da31427d5394750").unwrap(),
+            witness_mr: from_hex("863a50383a7a1e2cf12aab38ecb6701ed94875751cb69b7ecd0618d738112c20").unwrap(),
             output_mmr_size: 1,
-            kernel_mr: from_hex("8ecc03eba1c5ee9ba7e5069c723e74587535eccbc06ce9149f6d4a0469900ffa").unwrap(),
+            kernel_mr: from_hex("3295997cf718a0ed4cfcbf768d535abe8f40d1444703b196c833056828c65f98").unwrap(),
             kernel_mmr_size: 1,
             input_mr: vec![0; BLOCK_HASH_LENGTH],
             total_kernel_offset: PrivateKey::from_hex(

--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -38,8 +38,7 @@ use tari_common_types::{
     chain_metadata::ChainMetadata,
     types::{BlockHash, Commitment, HashOutput, Signature},
 };
-use tari_crypto::hash::blake2::Blake256;
-use tari_mmr::{pruned_hashset::PrunedHashSet, MerkleMountainRange, MutableMmr};
+use tari_mmr::pruned_hashset::PrunedHashSet;
 use tari_utilities::{epoch_time::EpochTime, hex::Hex, ByteArray, Hashable};
 
 use crate::{
@@ -88,6 +87,10 @@ use crate::{
         OrphanValidation,
         PostOrphanBodyValidation,
     },
+    MutablePrunedOutputMmr,
+    PrunedInputMmr,
+    PrunedKernelMmr,
+    PrunedWitnessMmr,
 };
 
 const LOG_TARGET: &str = "c::cs::database";
@@ -1215,10 +1218,10 @@ pub fn calculate_mmr_roots<T: BlockchainBackend>(db: &T, block: &Block) -> Resul
             value: header.prev_hash.to_hex(),
         })?;
 
-    let mut kernel_mmr = MerkleMountainRange::<Blake256, _>::new(kernels);
-    let mut output_mmr = MutableMmr::<Blake256, _>::new(outputs, deleted)?;
-    let mut witness_mmr = MerkleMountainRange::<Blake256, _>::new(range_proofs);
-    let mut input_mmr = MerkleMountainRange::<Blake256, _>::new(PrunedHashSet::default());
+    let mut kernel_mmr = PrunedKernelMmr::new(kernels);
+    let mut output_mmr = MutablePrunedOutputMmr::new(outputs, deleted)?;
+    let mut witness_mmr = PrunedWitnessMmr::new(range_proofs);
+    let mut input_mmr = PrunedInputMmr::new(PrunedHashSet::default());
     let mut deleted_outputs = Vec::new();
 
     for kernel in body.kernels().iter() {

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -36,7 +36,6 @@ use tari_common_types::{
     chain_metadata::ChainMetadata,
     types::{BlockHash, Commitment, HashOutput, Signature, BLOCK_HASH_LENGTH},
 };
-use tari_crypto::hash::blake2::Blake256;
 use tari_mmr::Hash;
 use tari_storage::lmdb_store::{db, LMDBBuilder, LMDBConfig, LMDBStore};
 use tari_utilities::{

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -37,7 +37,7 @@ use tari_common_types::{
     types::{BlockHash, Commitment, HashOutput, Signature, BLOCK_HASH_LENGTH},
 };
 use tari_crypto::hash::blake2::Blake256;
-use tari_mmr::{Hash, MerkleMountainRange, MutableMmr};
+use tari_mmr::Hash;
 use tari_storage::lmdb_store::{db, LMDBBuilder, LMDBConfig, LMDBStore};
 use tari_utilities::{
     hash::Hashable,
@@ -98,6 +98,9 @@ use crate::{
         aggregated_body::AggregateBody,
         transaction_components::{TransactionError, TransactionInput, TransactionKernel, TransactionOutput},
     },
+    MutablePrunedOutputMmr,
+    PrunedKernelMmr,
+    PrunedWitnessMmr,
 };
 
 type DatabaseRef = Arc<Database<'static>>;
@@ -1155,7 +1158,7 @@ impl LMDBDatabase {
             ..
         } = data;
 
-        let mut kernel_mmr = MerkleMountainRange::<Blake256, _>::new(pruned_kernel_set);
+        let mut kernel_mmr = PrunedKernelMmr::new(pruned_kernel_set);
 
         for kernel in kernels {
             total_kernel_sum = &total_kernel_sum + &kernel.excess;
@@ -1170,8 +1173,8 @@ impl LMDBDatabase {
             })?;
             self.insert_kernel(txn, &block_hash, &kernel, pos)?;
         }
-        let mut output_mmr = MutableMmr::<Blake256, _>::new(pruned_output_set, Bitmap::create())?;
-        let mut witness_mmr = MerkleMountainRange::<Blake256, _>::new(pruned_proof_set);
+        let mut output_mmr = MutablePrunedOutputMmr::new(pruned_output_set, Bitmap::create())?;
+        let mut witness_mmr = PrunedWitnessMmr::new(pruned_proof_set);
 
         let leaf_count = witness_mmr.get_leaf_count()?;
 

--- a/base_layer/core/src/lib.rs
+++ b/base_layer/core/src/lib.rs
@@ -66,4 +66,43 @@ pub mod large_ints {
         pub struct U512(8);
     }
 }
+
 pub use large_ints::{U256, U512};
+use tari_crypto::{hash::blake2::Blake256, hash_domain, hashing::DomainSeparatedHasher};
+use tari_mmr::{pruned_hashset::PrunedHashSet, Hash, MerkleMountainRange, MutableMmr};
+
+hash_domain!(
+    KernelMmrHashDomain,
+    "com.tari.tari_project.base_layer.core.kernel_mmr",
+    1
+);
+pub type KernelMmrHasherBlake256 = DomainSeparatedHasher<Blake256, KernelMmrHashDomain>;
+pub type KernelMmr = MerkleMountainRange<KernelMmrHasherBlake256, Vec<Hash>>;
+pub type PrunedKernelMmr = MerkleMountainRange<KernelMmrHasherBlake256, PrunedHashSet>;
+
+hash_domain!(
+    WitnessMmrHashDomain,
+    "com.tari.tari_project.base_layer.core.witness_mmr",
+    1
+);
+pub type WitnessMmrHasherBlake256 = DomainSeparatedHasher<Blake256, WitnessMmrHashDomain>;
+pub type WitnessMmr = MerkleMountainRange<WitnessMmrHasherBlake256, Vec<Hash>>;
+pub type PrunedWitnessMmr = MerkleMountainRange<WitnessMmrHasherBlake256, PrunedHashSet>;
+
+hash_domain!(
+    OutputMmrHashDomain,
+    "com.tari.tari_project.base_layer.core.output_mmr",
+    1
+);
+pub type OutputMmrHasherBlake256 = DomainSeparatedHasher<Blake256, OutputMmrHashDomain>;
+pub type MutableOutputMmr = MutableMmr<OutputMmrHasherBlake256, Vec<Hash>>;
+pub type PrunedOutputMmr = MerkleMountainRange<OutputMmrHasherBlake256, PrunedHashSet>;
+pub type MutablePrunedOutputMmr = MutableMmr<OutputMmrHasherBlake256, PrunedHashSet>;
+
+hash_domain!(
+    InputMmrHashDomain,
+    "com.tari.tari_project.base_layer.core.output_mmr",
+    1
+);
+pub type InputMmrHasherBlake256 = DomainSeparatedHasher<Blake256, InputMmrHashDomain>;
+pub type PrunedInputMmr = MerkleMountainRange<InputMmrHasherBlake256, PrunedHashSet>;

--- a/base_layer/core/tests/helpers/block_builders.rs
+++ b/base_layer/core/tests/helpers/block_builders.rs
@@ -55,13 +55,17 @@ use tari_core::{
         },
         CryptoFactories,
     },
+    KernelMmr,
+    KernelMmrHasherBlake256,
+    MutableOutputMmr,
+    WitnessMmr,
+    WitnessMmrHasherBlake256,
 };
 use tari_crypto::{
-    hash::blake2::Blake256,
     keys::PublicKey as PublicKeyTrait,
     tari_utilities::{hash::Hashable, hex::Hex},
 };
-use tari_mmr::{MerkleMountainRange, MutableMmr};
+use tari_mmr::{Hash, MutableMmr};
 use tari_script::script;
 
 pub fn create_coinbase(
@@ -151,12 +155,12 @@ fn print_new_genesis_block(network: Network) {
         .build()
         .unwrap();
 
-    let mut kernel_mmr = MerkleMountainRange::<Blake256, _>::new(Vec::new());
+    let mut kernel_mmr = KernelMmr::new(Vec::new());
     kernel_mmr.push(kernel.hash()).unwrap();
 
-    let mut witness_mmr = MerkleMountainRange::<Blake256, _>::new(Vec::new());
+    let mut witness_mmr = WitnessMmr::new(Vec::new());
     witness_mmr.push(utxo.witness_hash()).unwrap();
-    let mut output_mmr = MutableMmr::<Blake256, _>::new(Vec::new(), Bitmap::create()).unwrap();
+    let mut output_mmr = MutableOutputMmr::new(Vec::new(), Bitmap::create()).unwrap();
     output_mmr.push(utxo.hash()).unwrap();
 
     header.kernel_mr = kernel_mmr.get_merkle_root().unwrap();
@@ -235,6 +239,9 @@ pub fn create_genesis_block(
 
 // Calculate the MMR Merkle roots for the genesis block template and update the header.
 fn update_genesis_block_mmr_roots(template: NewBlockTemplate) -> Result<Block, ChainStorageError> {
+    type BaseLayerKernelMutableMmr = MutableMmr<KernelMmrHasherBlake256, Vec<Hash>>;
+    type BaseLayerWitnessMutableMmr = MutableMmr<WitnessMmrHasherBlake256, Vec<Hash>>;
+
     let NewBlockTemplate { header, mut body, .. } = template;
     // Make sure the body components are sorted. If they already are, this is a very cheap call.
     body.sort();
@@ -243,13 +250,13 @@ fn update_genesis_block_mmr_roots(template: NewBlockTemplate) -> Result<Block, C
     let rp_hashes: Vec<HashOutput> = body.outputs().iter().map(|out| out.witness_hash()).collect();
 
     let mut header = BlockHeader::from(header);
-    header.kernel_mr = MutableMmr::<Blake256, _>::new(kernel_hashes, Bitmap::create())
+    header.kernel_mr = BaseLayerKernelMutableMmr::new(kernel_hashes, Bitmap::create())
         .unwrap()
         .get_merkle_root()?;
-    header.output_mr = MutableMmr::<Blake256, _>::new(out_hashes, Bitmap::create())
+    header.output_mr = MutableOutputMmr::new(out_hashes, Bitmap::create())
         .unwrap()
         .get_merkle_root()?;
-    header.witness_mr = MutableMmr::<Blake256, _>::new(rp_hashes, Bitmap::create())
+    header.witness_mr = BaseLayerWitnessMutableMmr::new(rp_hashes, Bitmap::create())
         .unwrap()
         .get_merkle_root()?;
     Ok(Block { header, body })

--- a/base_layer/mmr/benches/bench.rs
+++ b/base_layer/mmr/benches/bench.rs
@@ -34,7 +34,16 @@ mod benches {
     use blake2::Blake2b;
     use criterion::{criterion_group, BatchSize, Criterion};
     use digest::Digest;
-    use tari_mmr::MerkleMountainRange;
+    use tari_crypto::{hash::blake2::Blake256, hash_domain, hashing::DomainSeparatedHasher};
+    use tari_mmr::{Hash, MerkleMountainRange};
+
+    hash_domain!(
+        MmrBenchTestHashDomain,
+        "com.tari.tari_project.base_layer.mmr.bemches",
+        1
+    );
+    pub type MmrTestHasherBlake256 = DomainSeparatedHasher<Blake256, MmrBenchTestHashDomain>;
+    pub type TestMmr = MerkleMountainRange<MmrTestHasherBlake256, Vec<Hash>>;
 
     fn get_hashes(n: usize) -> Vec<Vec<u8>> {
         (0..n).map(|i| Blake2b::digest(&i.to_le_bytes()).to_vec()).collect()
@@ -43,7 +52,7 @@ mod benches {
     fn build_mmr(c: &mut Criterion) {
         c.bench_function("Build MMR", move |b| {
             let hashes = get_hashes(1000);
-            let mut mmr = MerkleMountainRange::<Blake2b, _>::new(Vec::default());
+            let mut mmr = TestMmr::new(Vec::default());
             b.iter_batched(
                 || hashes.clone(),
                 |hashes| {

--- a/base_layer/mmr/src/common.rs
+++ b/base_layer/mmr/src/common.rs
@@ -26,6 +26,7 @@
 use std::convert::TryInto;
 
 use digest::Digest;
+use tari_common::DomainDigest;
 
 use crate::{error::MerkleMountainRangeError, Hash};
 
@@ -171,7 +172,7 @@ pub fn is_left_sibling(pos: usize) -> bool {
     (peak_map & peak) == 0
 }
 
-pub fn hash_together<D: Digest>(left: &[u8], right: &[u8]) -> Hash {
+pub fn hash_together<D: Digest + DomainDigest>(left: &[u8], right: &[u8]) -> Hash {
     D::new().chain(left).chain(right).finalize().to_vec()
 }
 

--- a/base_layer/mmr/src/functions.rs
+++ b/base_layer/mmr/src/functions.rs
@@ -30,6 +30,7 @@ use crate::{
 };
 use digest::Digest;
 use std::{convert::TryFrom, marker::PhantomData};
+use tari_common::DomainDigest;
 
 pub type PrunedMmr<D> = MerkleMountainRange<D, PrunedHashSet>;
 pub type PrunedMutableMmr<D> = MutableMmr<D, PrunedHashSet>;
@@ -41,7 +42,7 @@ pub type PrunedMutableMmr<D> = MutableMmr<D, PrunedHashSet>;
 /// `validate` will throw an error.
 pub fn prune_mmr<D, B>(mmr: &MerkleMountainRange<D, B>) -> Result<PrunedMmr<D>, MerkleMountainRangeError>
 where
-    D: Digest,
+    D: Digest + DomainDigest,
     B: ArrayLike<Value = Hash>,
 {
     let backend = PrunedHashSet::try_from(mmr)?;
@@ -54,7 +55,7 @@ where
 /// A convenience function in the same vein as [prune_mmr], but applied to `MutableMmr` instances.
 pub fn prune_mutable_mmr<D, B>(mmr: &MutableMmr<D, B>) -> Result<PrunedMutableMmr<D>, MerkleMountainRangeError>
 where
-    D: Digest,
+    D: Digest + DomainDigest,
     B: ArrayLike<Value = Hash>,
 {
     let backend = PrunedHashSet::try_from(&mmr.mmr)?;
@@ -84,7 +85,7 @@ pub fn calculate_pruned_mmr_root<D, B>(
     deletions: Vec<u32>,
 ) -> Result<Hash, MerkleMountainRangeError>
 where
-    D: Digest,
+    D: Digest + DomainDigest,
     B: ArrayLike<Value = Hash>,
 {
     let mut pruned_mmr = prune_mutable_mmr(src)?;
@@ -103,7 +104,7 @@ pub fn calculate_mmr_root<D, B>(
     additions: Vec<Hash>,
 ) -> Result<Hash, MerkleMountainRangeError>
 where
-    D: Digest,
+    D: Digest + DomainDigest,
     B: ArrayLike<Value = Hash>,
 {
     let mut mmr = prune_mmr(src)?;

--- a/base_layer/mmr/src/merkle_checkpoint.rs
+++ b/base_layer/mmr/src/merkle_checkpoint.rs
@@ -28,6 +28,7 @@ use serde::{
     de::{self, Deserialize, Deserializer, MapAccess, SeqAccess, Visitor},
     ser::{Serialize, SerializeStruct, Serializer},
 };
+use tari_common::DomainDigest;
 
 use crate::{backend::ArrayLike, error::MerkleMountainRangeError, mutable_mmr::MutableMmr, Hash};
 
@@ -55,7 +56,7 @@ impl MerkleCheckPoint {
     /// from here.
     pub fn apply<D, B2>(&self, mmr: &mut MutableMmr<D, B2>) -> Result<(), MerkleMountainRangeError>
     where
-        D: Digest,
+        D: Digest + DomainDigest,
         B2: ArrayLike<Value = Hash>,
     {
         for node in &self.nodes_added {

--- a/base_layer/mmr/src/merkle_mountain_range.rs
+++ b/base_layer/mmr/src/merkle_mountain_range.rs
@@ -28,6 +28,7 @@ use std::{
 };
 
 use digest::Digest;
+use tari_common::DomainDigest;
 
 use crate::{
     backend::ArrayLike,
@@ -57,7 +58,7 @@ pub struct MerkleMountainRange<D, B> {
 
 impl<D, B> MerkleMountainRange<D, B>
 where
-    D: Digest,
+    D: Digest + DomainDigest,
     B: ArrayLike<Value = Hash>,
 {
     /// Create a new Merkle mountain range using the given backend for storage
@@ -276,7 +277,7 @@ where
 
 impl<D, B, B2> PartialEq<MerkleMountainRange<D, B2>> for MerkleMountainRange<D, B>
 where
-    D: Digest,
+    D: Digest + DomainDigest,
     B: ArrayLike<Value = Hash>,
     B2: ArrayLike<Value = Hash>,
 {

--- a/base_layer/mmr/src/mmr_cache.rs
+++ b/base_layer/mmr/src/mmr_cache.rs
@@ -24,6 +24,7 @@ use std::ops::Deref;
 
 use croaring::Bitmap;
 use digest::Digest;
+use tari_common::DomainDigest;
 
 use crate::{
     backend::ArrayLike,
@@ -54,7 +55,7 @@ impl Default for MmrCacheConfig {
 #[derive(Debug)]
 pub struct MmrCache<D, BaseBackend, CpBackend>
 where
-    D: Digest,
+    D: Digest + DomainDigest,
     BaseBackend: ArrayLike<Value = Hash>,
 {
     // The last checkpoint index applied to the base MMR.
@@ -75,7 +76,7 @@ where
 
 impl<D, BaseBackend, CpBackend> MmrCache<D, BaseBackend, CpBackend>
 where
-    D: Digest,
+    D: Digest + DomainDigest,
     BaseBackend: ArrayLike<Value = Hash>,
     CpBackend: ArrayLike<Value = MerkleCheckPoint>,
 {
@@ -229,7 +230,7 @@ where
 
 impl<D, BaseBackend, CpBackend> Deref for MmrCache<D, BaseBackend, CpBackend>
 where
-    D: Digest,
+    D: Digest + DomainDigest,
     BaseBackend: ArrayLike<Value = Hash>,
 {
     type Target = PrunedMutableMmr<D>;

--- a/base_layer/mmr/src/mutable_mmr.rs
+++ b/base_layer/mmr/src/mutable_mmr.rs
@@ -24,6 +24,7 @@ use std::convert::TryFrom;
 
 use croaring::Bitmap;
 use digest::Digest;
+use tari_common::DomainDigest;
 
 use crate::{
     backend::ArrayLike,
@@ -44,7 +45,7 @@ use crate::{
 #[derive(Debug)]
 pub struct MutableMmr<D, B>
 where
-    D: Digest,
+    D: Digest + DomainDigest,
     B: ArrayLike<Value = Hash>,
 {
     pub(crate) mmr: MerkleMountainRange<D, B>,
@@ -57,7 +58,7 @@ where
 
 impl<D, B> MutableMmr<D, B>
 where
-    D: Digest,
+    D: Digest + DomainDigest,
     B: ArrayLike<Value = Hash>,
 {
     /// Create a new mutable MMR using the backend provided
@@ -255,7 +256,7 @@ where
 
 impl<D, B, B2> PartialEq<MutableMmr<D, B2>> for MutableMmr<D, B>
 where
-    D: Digest,
+    D: Digest + DomainDigest,
     B: ArrayLike<Value = Hash>,
     B2: ArrayLike<Value = Hash>,
 {

--- a/base_layer/mmr/src/pruned_hashset.rs
+++ b/base_layer/mmr/src/pruned_hashset.rs
@@ -24,6 +24,7 @@ use std::convert::TryFrom;
 
 use digest::Digest;
 use serde::{Deserialize, Serialize};
+use tari_common::DomainDigest;
 
 use crate::{common::find_peaks, error::MerkleMountainRangeError, ArrayLike, Hash, MerkleMountainRange};
 
@@ -50,7 +51,7 @@ pub struct PrunedHashSet {
 
 impl<D, B> TryFrom<&MerkleMountainRange<D, B>> for PrunedHashSet
 where
-    D: Digest,
+    D: Digest + DomainDigest,
     B: ArrayLike<Value = Hash>,
 {
     type Error = MerkleMountainRangeError;

--- a/base_layer/mmr/tests/merkle_mountain_range.rs
+++ b/base_layer/mmr/tests/merkle_mountain_range.rs
@@ -23,24 +23,24 @@
 #[allow(dead_code)]
 mod support;
 
-use digest::Digest;
-use support::{combine_hashes, create_mmr, int_to_hash, Hasher};
-use tari_mmr::MerkleMountainRange;
+use support::{combine_hashes, create_mmr, int_to_hash};
+
+use crate::support::{MmrTestHasherBlake256, TestMmr};
 
 /// MMRs with no elements should provide sane defaults. The merkle root must be the hash of an empty string, b"".
 #[test]
 fn zero_length_mmr() {
-    let mmr = MerkleMountainRange::<Hasher, _>::new(Vec::default());
+    let mmr = TestMmr::new(Vec::default());
     assert_eq!(mmr.len(), Ok(0));
     assert_eq!(mmr.is_empty(), Ok(true));
-    let empty_hash = Hasher::digest(b"").to_vec();
+    let empty_hash = MmrTestHasherBlake256::new().digest(b"").as_ref().to_vec();
     assert_eq!(mmr.get_merkle_root(), Ok(empty_hash));
 }
 
 /// Successively build up an MMR and check that the roots, heights and indices are all correct.
 #[test]
 fn build_mmr() {
-    let mut mmr = MerkleMountainRange::<Hasher, _>::new(Vec::default());
+    let mut mmr = TestMmr::new(Vec::default());
     // Add a single item
     let h0 = int_to_hash(0);
 
@@ -98,8 +98,8 @@ fn build_mmr() {
 
 #[test]
 fn equality_check() {
-    let mut ma = MerkleMountainRange::<Hasher, _>::new(Vec::default());
-    let mut mb = MerkleMountainRange::<Hasher, _>::new(Vec::default());
+    let mut ma = TestMmr::new(Vec::default());
+    let mut mb = TestMmr::new(Vec::default());
     assert!(ma == mb);
     assert!(ma.push(int_to_hash(1)).is_ok());
     assert!(ma != mb);
@@ -118,7 +118,7 @@ fn validate() {
 
 #[test]
 fn restore_from_leaf_hashes() {
-    let mut mmr = MerkleMountainRange::<Hasher, _>::new(Vec::default());
+    let mut mmr = TestMmr::new(Vec::default());
     let leaf_hashes = mmr.get_leaf_hashes(0, 1).unwrap();
     assert_eq!(leaf_hashes.len(), 0);
 
@@ -157,7 +157,7 @@ fn restore_from_leaf_hashes() {
 
 #[test]
 fn find_leaf_index() {
-    let mut mmr = MerkleMountainRange::<Hasher, _>::new(Vec::default());
+    let mut mmr = TestMmr::new(Vec::default());
     let h0 = int_to_hash(0);
     let h1 = int_to_hash(1);
     let h2 = int_to_hash(2);

--- a/base_layer/mmr/tests/mmr_cache.rs
+++ b/base_layer/mmr/tests/mmr_cache.rs
@@ -24,14 +24,17 @@
 mod support;
 
 use croaring::Bitmap;
-use support::{combine_hashes, int_to_hash, Hasher};
+use support::{combine_hashes, int_to_hash};
 use tari_mmr::{ArrayLike, ArrayLikeExt, MemBackendVec, MerkleCheckPoint, MmrCache, MmrCacheConfig};
+
+use crate::support::MmrTestHasherBlake256;
 
 #[test]
 fn create_cache_update_and_rewind() {
     let config = MmrCacheConfig { rewind_hist_len: 2 };
     let mut checkpoint_db = MemBackendVec::<MerkleCheckPoint>::new();
-    let mut mmr_cache = MmrCache::<Hasher, _, _>::new(Vec::new(), checkpoint_db.clone(), config).unwrap();
+    let mut mmr_cache =
+        MmrCache::<MmrTestHasherBlake256, _, _>::new(Vec::new(), checkpoint_db.clone(), config).unwrap();
 
     let h1 = int_to_hash(1);
     let h2 = int_to_hash(2);
@@ -94,7 +97,8 @@ fn create_cache_update_and_rewind() {
 fn multiple_rewinds() {
     let config = MmrCacheConfig { rewind_hist_len: 2 };
     let mut checkpoint_db = MemBackendVec::<MerkleCheckPoint>::new();
-    let mut mmr_cache = MmrCache::<Hasher, _, _>::new(Vec::new(), checkpoint_db.clone(), config).unwrap();
+    let mut mmr_cache =
+        MmrCache::<MmrTestHasherBlake256, _, _>::new(Vec::new(), checkpoint_db.clone(), config).unwrap();
 
     // Add h1, h2, h3 and h4 checkpoints
     let h1 = int_to_hash(1);
@@ -162,7 +166,8 @@ fn multiple_rewinds() {
 fn checkpoint_merging() {
     let config = MmrCacheConfig { rewind_hist_len: 2 };
     let mut checkpoint_db = MemBackendVec::<MerkleCheckPoint>::new();
-    let mut mmr_cache = MmrCache::<Hasher, _, _>::new(Vec::new(), checkpoint_db.clone(), config).unwrap();
+    let mut mmr_cache =
+        MmrCache::<MmrTestHasherBlake256, _, _>::new(Vec::new(), checkpoint_db.clone(), config).unwrap();
 
     let h1 = int_to_hash(1);
     let h2 = int_to_hash(2);
@@ -217,7 +222,8 @@ fn checkpoint_merging() {
     assert_eq!(mmr_cache.get_mmr_only_root(), Ok(cp6_mmr_only_root.clone()));
 
     // Recreate the MmrCache from the altered checkpoints
-    let mut mmr_cache = MmrCache::<Hasher, _, _>::new(Vec::new(), checkpoint_db.clone(), config).unwrap();
+    let mut mmr_cache =
+        MmrCache::<MmrTestHasherBlake256, _, _>::new(Vec::new(), checkpoint_db.clone(), config).unwrap();
     assert_eq!(mmr_cache.get_mmr_only_root(), Ok(cp6_mmr_only_root.clone()));
 
     // Replace all existing checkpoints with a single accumulated checkpoint

--- a/base_layer/mmr/tests/pruned_mmr.rs
+++ b/base_layer/mmr/tests/pruned_mmr.rs
@@ -34,6 +34,7 @@ use tari_mmr::{
     functions::{calculate_mmr_root, calculate_pruned_mmr_root, prune_mmr},
     Hash,
 };
+
 #[test]
 fn pruned_mmr_empty() {
     let mmr = create_mmr(0);

--- a/base_layer/mmr/tests/with_blake512_hash.rs
+++ b/base_layer/mmr/tests/with_blake512_hash.rs
@@ -23,67 +23,74 @@
 use std::string::ToString;
 
 use blake2::Blake2b;
-use digest::Digest;
+use tari_crypto::{hash_domain, hashing::DomainSeparatedHasher};
 use tari_mmr::MerkleMountainRange;
 use tari_utilities::hex::Hex;
+
+hash_domain!(Blake512TestMmrHashDomain, "mmr.tests.with_blake512_hash", 1);
+pub type Blake512TestMmrHasherBlake2b = DomainSeparatedHasher<Blake2b, Blake512TestMmrHashDomain>;
+
 #[allow(clippy::vec_init_then_push)]
 pub fn hash_values() -> Vec<String> {
     let mut hashvalues = Vec::new();
     // list of hex values of blake2b hashes
-    hashvalues.push("1ced8f5be2db23a6513eba4d819c73806424748a7bc6fa0d792cc1c7d1775a9778e894aa91413f6eb79ad5ae2f871eafcc78797e4c82af6d1cbfb1a294a10d10".to_string()); // 1
-    hashvalues.push("c5faca15ac2f93578b39ef4b6bbb871bdedce4ddd584fd31f0bb66fade3947e6bb1353e562414ed50638a8829ff3daccac7ef4a50acee72a5384ba9aeb604fc9".to_string()); // 2
-    hashvalues.push("4d3d9d4c8da746e2dcf236f31b53850e0e35a07c1d6082be51b33e7c1e11c39cf5e309953bf56866b0ccede95cdf3ae5f9823f6cf3bcc6ada19cf21b09884717".to_string()); // (1-2)
-    hashvalues.push("6f760b9e9eac89f07ab0223b0f4acb04d1e355d893a1b86a83f4d4b405adee99913dacb7bc3d6e6a46f996e59b965e82b1ffa1994062bcd8bef867bcf743c07c".to_string()); // 3
-    hashvalues.push("e8e70dc170e14333627b32c20ac6051fb9b6bd369c036afbaca2d9cd7ac3de65aeda9d9651423af4343fd8e13f6481081b473e22a58f3f0e2a28143e4fb70bc2".to_string()); // 4
-    hashvalues.push("ebf20fe26f69ab804b760fbf55eac3eba8f6cffa3f85d7b0c29ffd4a66a28deecc6f9eaaae758c49334f8b10ccfc743cee732e5486166cd3313a1881f7e0519e".to_string()); // (3-4)
-    hashvalues.push("8989c1ea10efac5b9897e9c227b307fd029005ba4f8e1590ec23942c3e788d7d280bb3cdbbd76cc9814755ee508174cb1d79a45f575a33240ac4b892ada7f850".to_string()); // (1-2)(3-4)
-    hashvalues.push("73776e3e4cd3684316d26ec93cc6c438497ace5b08e359698667af6dbded88b6750ba0b2c11ba7d52b69180f1924884a158d0b83d87ca9c65d2dae9d73387e43".to_string()); // 5
-    hashvalues.push("8d322d4b02d9fcfb05bc70e486406e53c3cf9b97a252bf64752cafc5c2aaf95baef7f6e30d0a64826921ad01ec9d8c010805367078e5b5963ab4be3efd8f4a78".to_string()); // 6
-    hashvalues.push("4a10141b2ba124991ddd81b4df78655f582872ba67928bbfc48282609de20ca40f745f622989cf3b71c790de6136173f6282780b2b7770b561f239ecddd40b78".to_string()); // (5-6)
+    hashvalues.push("f41960a92281bd1b35b764a4bae2aacbbe5323f9d19fdcef8a0f6b3bdaf62aa18b2d8cb1dfa1f036d6516d9767e27f2db630ac623c9019876e8361a77693a218".to_string()); // [1] 1
+    hashvalues.push("5df76cd358050159e016620f955d66185ba141b295a617a5075a1860a06e269b3822557108f281734da189d3ca12d4bed9e79be44ef99d008b40fe2f4c0d5998".to_string()); // [2] 2
+    hashvalues.push("fac58aa36091b0a736977e5b4131f103dca621dd86ae029ec20d32feb107d2258598c4518f1de9b32e3e919e0643e490d0ed0461f1364bad5960dc09819dd09c".to_string()); // [3] (1-2)
+    hashvalues.push("2ace5e8b05a801f016d29aecf8bef9c596d9be5e645d3658b5d3afa74c7f9e687734e214fbfac47102f3e708a47ee2f3d1c69ce7ef122e7e1d3a8a718036fb09".to_string()); // [4] 3
+    hashvalues.push("57431a18216bd392fd5a2227c88f0a9ab3ab3ae1ebb4859d9b1c8d5cb5d00f4ef5963b58a231b8ea54b52c04ee3178d7aa67acb387b109214d8c6d3e5a053700".to_string()); // [5] 4
+    hashvalues.push("7fd592e7c65d59672ca125a669f84eb93dc574b5cab542abc9d3fe9ef870d1cf68f737fdc9d78f2b34b1a828761c900828a39092211cbd72f758d0d7d2fa01d3".to_string()); // [6] (3-4)
+    hashvalues.push("e294c94a8e89adb73964309ed01bc84ff2bdd824a79c089b4f0600dd1fd02703a1753174c4a1943f5ec29fe8f6e0fd6681ad8169c5313f0ad191e353f4c59750".to_string()); // [7] (1-2)(3-4)
+    hashvalues.push("3fdeda4e128dd735acd9f6d97811f0a333968bd1f984230c5d2d0eb06961d3ff95a23a7c83913b06a1a3e40f21740820847cf9499eafcb298b10e5b09a1f2bbd".to_string()); // [8] 5
+    hashvalues.push("8e98aa650e1c0dffa58da99e64ed0d075f98dc25bfaf41fcedd1296c6b745c5895c53cbffc193ec4f64ea07a3797396d5e46ba1bf835f67aa11ef8063d9c716a".to_string()); // [9] 6
+    hashvalues.push("ec200c9b1920f0196466a7ee5fffac20938781043953e749080ed7f644768f16b604f904c18d0d56b507fdfeede245f75bb6f80c4c94111950355b90a28dbd1a".to_string()); // [10] (5-6)
                                                                                                                                                                      // index 10 ^
-    hashvalues.push("d5c47f63555ae063383c2a0df82bf309d90932bc8dd66a056d80e4d913e821faacf7e0e962c7bbac6c193e1e638b58b8baa1e71f57a945958b84c11536b7a82d".to_string()); // 7
-    hashvalues.push("818af2ae014b14c85a35639901ac6bfc47908bcbd94a7f5211627b1f52f316a994e1296503701dd6827a8e5969d33d1d0b68c452eb95e481035b168a6c0f09c4".to_string()); // 8
-    hashvalues.push("5b2abeb00cacb7465131a995bd4f5463032e69e1d3d9a55823536660d130a41bb23b529eec173ddd88a42e5db97cf6983cad0b36ef3de452ac66aba9f37b08ee".to_string()); // (7-8)
-    hashvalues.push("53d5d4b1b2f78468fea0292af1cb9e63a2e7460a66cc741756166e135817f20a6b96b60a76dee7f83615d881dfd58e3830003177d4aff13e392889e36f8c5718".to_string()); // (5-6)(7-8)
-    hashvalues.push("84247c7a397b4e7314a2a5edc993b12196fcbd2d8b3793d7cf8a63e9c5c8004103874260defe34a4ac739ed21d58bb9c325f96ba9d917d63295f71f45ce0054c".to_string()); // (1-2)(3-4)(5-6)(7-8)
-    hashvalues.push("2b57bf7664a4de943d93e4f5473a42da0d7a35065afd559303196fcc33414e73a91042f8d238fcaca45a93b17e577ad15191f95c6d7cf7c19e240a1e05100ad6".to_string()); // 9
-    hashvalues.push("f2e74cbc3eff574bbc45333c30edb947858543afda4cafdde2903324c9de0bd908b00575c556bd7b8aa2e32a32598a4d5f95cd4490b60a567a3d53680a3310f2".to_string()); // 10
-    hashvalues.push("7c7f5fb40b9d000435c001b05ab6e1409160d24292d8acb9bbd0936a07613fa82ccb01d65b92d5cd3f2103514fba108bdf1d960eeb4c75948cb716cde5c7fb4a".to_string()); // (9-10)
-    hashvalues.push("7aa7e388f8145d395ac616bb526eaa35b10069f49e2b36d7327157d1d4af360dfbbfea805aa7e405ed025ce5eadd56c27c40b92991727a5a16b51df5604ad006".to_string()); // 11
-    hashvalues.push("b7a5a0f0fb0c4a128b8a3e042fc860775d68d825bb3bf180479d0e12b1884e2652fe51ddb9c991b73824fc15609d82cb1cc19053db7dc7637288091f6027bbce".to_string()); // 12
+    hashvalues.push("849f295777f919b45f4ca987058b0ffa0491dd681c499fc33a76b51d1841ffc75f809f762b847c3ece9e87f862a3e18124c1095b8f9edd453b4f3e12b4353960".to_string()); // [11] 7
+    hashvalues.push("a47af3fb62de49b42cce01dd5ccd1c60117d7ba14a5fd8bb14d781d3c5417a13f2d78a6e5077f3473ad232c73a3be87e6bfda1d446a400d716fa2b45525ea698".to_string()); // [12] 8
+    hashvalues.push("6399503dd769db4876f887ad2d73c4502ebbfa3ef18e69cdf3ac8a60478395b0da0851a134c4848af5d23d3063694e9b17c082516fcf253911f9ac42d87aadc8".to_string()); // [13] (7-8)
+    hashvalues.push("d2ce84bb239097d9b320be4d2e0052e896a54d24df70da05dbe0a179b36d0527d20cb071f0f06d57ed86978492d846b8c71465a9c94a2bc2b9ad4e5bb3a9a1d5".to_string()); // [14] (5-6)(7-8)
+    hashvalues.push("d0db3dcb90db9751c97307e1c1e6dd8e776d4b5758e5e5b1dabbd365bc5c5dd302f5c01d11c2a8f6964f84a48d509e0c278cca5e279c49dd3cad8bc9dfa583c0".to_string()); // [15] (1-2)(3-4)(5-6)(7-8)
+    hashvalues.push("f565b57a5486f941b06fed78ac40216847e280c513e3e7493acb4b76aa71d5282b4fd8b06095f8d86a0e93038bfdd5fa626f6f8e14eb779f89a4c9a0b32a267d".to_string()); // [16] 9
+    hashvalues.push("e54dd791dec040e50633242e3f8ad1fdfb45c3809f2c04f4d8c05f1ed2a920df84040fb24f3aa211df515205c67966e506ab30f582ffbc1c90245d10ece7e6c4".to_string()); // [17] 10
+    hashvalues.push("c16dbf2f3863ed61b2cdba3247608b1d2dafa1d00b03d6e2777a98fc602369c29bdbfd55dbf0f5fccab24205df1795e2d923cfb0699cb9d1958e85c9a798c16c".to_string()); // [18] (9-10)
+    hashvalues.push("13abd19fb5c16d162a11b56eee943d2aa327e8cb76d26e08cd31c1390499630c28e4f2ecb3d7e856140c9576f47121d4a421e709504a67dbdb8c4e6332f5f6bd".to_string()); // [19] 11
+    hashvalues.push("863de8d58caee972ccdffd1d4c494adb5079c0095ef51dceecac0319b073b9021bc315d10fe0ba1a260c4529cf43313cce953583ea65a92e5fcba568d93381fb".to_string()); // [20] 12
                                                                                                                                                                      // index 20 ^
-    hashvalues.push("354db9c951738783a2d7c8c7301b1aedb4ed469df4b3bfa0368a69ab260ef0087952a7aca45ea67e7cd646aaacff6c9d75b60f194b39e6ad1f194df8b35a27c0".to_string()); // (11-12)
-    hashvalues.push("aea22e000365db9566cdab7d709c3c26e738bd41ac1f71cd2e4ad4d6f99e4286801e10d77cdea087b49ad135446130a0a32792250ba28bd211ffb68fe5d04fb0".to_string()); // (9-10)(11-12)
-    hashvalues.push("1da541ba91a8560c5dd0c1a4adc836dc4ac96bf5c407a89edb0a49d46de058a713c7b3d3fc8e0324f602c3a41978ef01dccb989eed22aa65bddc5621765713d3".to_string()); // 13
-    hashvalues.push("2b789cf44e92c3eacb652124e394b132337fc19378664e376a932723cebf2e0da057319d509a04fe403f2c563542932d1f44476b8f4cad6ccefbd2693c432d1c".to_string()); // 14
-    hashvalues.push("e4c46b221c1a82165c03816066af4c9546440705328dd1e419a04a17fbba70a717f67423fe1a553043c51e49cd369f02da979245007a5d09fd6ce0f2cb745491".to_string()); // (13-14)
-    hashvalues.push("4a9bb12a4834e77430779ea6759d0f4eb45abb9400a67b81985cd4b85e0a28b5d6b59f896ccc72cd6aad3390b51b02c7d6aeeb8f0dce205f425697e5180b35ae".to_string()); // 15
-    hashvalues.push("3346703bc50521b2bf93e8d581605de18ad415c3dcdc38373e37c1800fd332e67c9ef7267d546913b63f5e24324d0c5565c177030d6c30c254d647440191d95f".to_string()); // 16
-    hashvalues.push("39495d1ad29c6469ae18bc7316d98977754e0fdbb04a9e3e17c86c34f7fa751e09bbec588e8cfd5d4e55824b9705b1f52ab1a37b5b1fa5c8ea57b0951bdbccf3".to_string()); // (15-16)
-    hashvalues.push("77f4a6e8cb87bc79fea9893eeb2dde8a047b0d5786d324a2fb53f43414cfc8051d704f6088102fdf244de046fd5f8ea6cef854dc97488b173a0bb8d540c406ef".to_string()); // (13-14)(15-16)
-    hashvalues.push("af3f03f275e586e4449ff44146a27792b0f5a2143483a6dd6fe8405bd66a7ebe13f916d56bd3a152c2a25b6423f8b1bb4620f6d27fe55f1b82da61ff9b0825da".to_string()); // (9-10)(11-12)(13-14)(15-16)
+    hashvalues.push("4fc0c56d6a7cacf460ce8d13719c02f5aea15b3314b912ddebd10e06273d7c6c1dcf301f2c1257c4b690e1e61467ca33eb9708b834718dcf0318fa0c873aba66".to_string()); // [21] (11-12)
+    hashvalues.push("6351120253082a8caf598a25c8617c5c972e404c0df469e81925f9ab47e41028d1017d8b3d09d1bae49c0ae3258e76ca383d850682a67776574936609f4dde8e".to_string()); // [22] (9-10)(11-12)
+    hashvalues.push("15b983072eac1f7894c39c73d8a81d1bef67c6f30556d86c8cebb9f597d277c23caa54cdb58e3895247a56ebd94b0eef71b5e9e212def07a9c20d4e5fa9ae489".to_string()); // [23] 13
+    hashvalues.push("3c81e1d6e7a57d43afdb108569a6eeb7047456bdbfee60c673adb974fbe35a0a249b71e9395eebdaab44c8ecabca7f5b1bf4eaf47bb6fd070daf4c747d1ce983".to_string()); // [24] 14
+    hashvalues.push("890b2be31113f376f3be93581463cc5217feb3a00a4d092f1d65d7b635d684efab937207ac450f7cfceb013c89dad9a58322235b9d0e8d18245306f6dae11371".to_string()); // [25] (13-14)
+    hashvalues.push("552cde3a14a2025d81586cbe469f2ec53b59916d414e0c26369e6199c56121ad86c5a57fe6beb5f00a8d208556e38c34d64c648c75bc27e47326c2004cee5206".to_string()); // [26] 15
+    hashvalues.push("d3f20d372fd0af3cf6002d7437f267c5919ae043aeb2c8a93433216586d05151e28722ccbb80137e950d5db26f43620ea1ec6b65a6cde561fb60fab32af753db".to_string()); // [27] 16
+    hashvalues.push("93bb4769b2added4433a56144485a6c1e6b4fd4a2c6481054e087ca54b58b3a8133283f555cdc075c60abf3751d8beb8834655acd5c993277cfc613fa97cf2ca".to_string()); // [28] (15-16)
+    hashvalues.push("755782b3c6d6539f93f4b7eafecd94b41fb13a55fcf4332ae07b237fa058da6e0ad09206795205363a18ffc03eb5948ac1ddf16600f4298fa969edd63bb32754".to_string()); // [29] (13-14)(15-16)
+    hashvalues.push("6eb2973c8ed37717f50ea903a7a97f5343ae5cb9318fe120526afcddb41e1d6fbfd7932f25218a740e2f9f8cd56ecb5365d0cf8e15d4fcaaba6d7e00f8fc900e".to_string()); // [30] (9-10)(11-12)(13-14)(15-16)
                                                                                                                                                                      // index 30 ^
-    hashvalues.push("9a9a504247f809735602e7fdbe191c6129c075f6e1e1530bcfd45ab5e0f1c5974cce5d3eafed04b64b5c881ce369a272f6eca5f403178a51f677aedd6fe66d84".to_string()); // (1-2)(3-4)(5-6)(7-8)(9-10)(11-12)(13-14)(15-16)
-    hashvalues.push("5c3f20d14860fb11dca47a3ea972842763165f4cd657608df25fc8afe0cd67666d906cc36b556dccf7d0f9deafbd934fa466391a4f97d03b9fd3cf48f43346ad".to_string()); // 17
-    hashvalues.push("2344823c898d803bb0421d8e0e99dafb3feabd3fff02f98a9dae1eabf748c99c6beeb899a65c6a1a83ce60dc8c58332571ccefd11515447d69c73cb4415903a4".to_string()); // 18
-    hashvalues.push("a6ff99c73df5c5e9e01b2d6ffd923deba66c1eaa5c60699665c941569b09c756af55aaec9ff8469c7ffe9abd3ca5a3d1ada50ed4ee2cd3ff949177975f4f5141".to_string()); // (17-18)
-    hashvalues.push("33a389ba39d39595f2e43650eeaac81187c3a11c56f2930b042325c67adad310dad7ff9ed8077cfb0fa5136a2cfa725e55d567e7dac3483d5fb0ee787a0765ec".to_string()); // 19
-    hashvalues.push("92ce61bf50a5c299bc88d6adad5db7b68c4b61abb7760947e8b9898c99312b18ba974d427e1699ede1be7c1c25b03440235a41a71ab2b4d1410399b72da87111".to_string()); // 20
-    hashvalues.push("74d84a50748a78c7b98dcc9e22a62d64c726cb0e30126a26d8168e7252f4a67149506a4acde7a307372ebd0a0bcd3ef5f5670434262783d41675448ab7d06e3f".to_string()); // (19-20)
-    hashvalues.push("a14d655ecdf12d3dacc2bb9c6779345db9e08fa8ddaa2163ada5d2ff3c21b9bd5b9d59f4f7fbe489543deafd0e2ca45b75d7f7fd047b83e74b85b1ea0a5ec5ff".to_string()); // (17-18)(19-20)
-    hashvalues.push("8c715c0b894785852fbc391d662e2131bf0f0c703852f25b1c07429f35dc67ec8df5998acd4cafd4f1ff7019ebfda0877f79d6b91c1b98084efbb7314258608c".to_string()); // 21
-    hashvalues.push("3733d5bf4f3d2608ba160adf4a8cddbf545f77b417e3ee3a9e5d3b0afb351579125db853e5bce15d5e82c723f29de1ef294341f0ca3e8b3d3431cec7ac316f34".to_string()); // 22
+    hashvalues.push("5eb2c0de844a88872d072ad6e5d72fcbb49541fda7973af836e177be517eaac825d6710a44247b8f88050e53883ed3a73b9011925315177880051fbe97788c83".to_string()); // [31] (1-2)(3-4)(5-6)(7-8)(9-10)(11-12)(13-14)(15-16)
+    hashvalues.push("ce51144c142e5ef6a03ab0e1aff9e1ea2336d02da4a53b303c436039e5e41cb7560c5cc913cd156c6f9569ef701a9e6e195e0cfd0f76d6af6d4335568e04dcb0".to_string()); // [32] 17
+    hashvalues.push("88bdc0b1fe82a921e8027ca0ed0fdf38a93b98bd7b6487599aa6562bdefd50f0acb6455444bbf1063b63bd3020ba9df8c2e2f4523bfd87f3ce341ae680c64240".to_string()); // [33] 18
+    hashvalues.push("5c936f46932b142c97c9421b4103e979cee6a12360be87cda7b975d591fdf8c276301d058ea3e855b8efdee1de2185f086f89417d1c2d28cf89b69644f961748".to_string()); // [34] (17-18)
+    hashvalues.push("64b430d42973ee0743fb272d0e12fdd3f9c8aa56848c4617b90b60cf40faab4f5b11ff795979e492e14b0dafb305cc8effa5cc62e52dc500d86efecb7be549cf".to_string()); // [35] 19
+    hashvalues.push("e56bc2dc73e6249832a1e937f3dad9372b89313a4f3d0bc42d138835644c7ad54a7284a9b6ddea0580f2ccb0ddddc96fd2caa3c22f17b40c81503312680bad2c".to_string()); // [36] 20
+    hashvalues.push("030ba2a5bc1387865488ecdfb95f74f261d7637603cf10f6e329c4916729795a2873c8104f8361d438e9fdf799006e139a357efaa02b85504a8ab8b3cd3fce06".to_string()); // [37] (19-20)
+    hashvalues.push("99df3b2af84731794963c268f365f0ad24edbb3e7a28d12c7545e2fd7f3b20caac933fb0146884a898ad47876409398cfe0d76a8822c979d8ef1d2b2d8282a54".to_string()); // [38] (17-18)(19-20)
+    hashvalues.push("a106bc373d2c64dc945be67cf9ff060f6c0203f9a26f0f81fffe3cca01a145db51c0ac55db81e79f8b13d5c1b791f83bb99a2a85dc18e7ec506c0b06c5f99cd3".to_string()); // [39] 21
+    hashvalues.push("6569a6e61d5641a0cba01c421990b7caea38d120f3c8e4088c82c06eca41b25448f2a802371059f0cf8885f78c7c5516e5427ee88e841d999083cbf1a70e14a1".to_string()); // [40] 22
                                                                                                                                                                      // index 40 ^
-    hashvalues.push("77288840877c30ddc8769efac9786505e15729f3a4736996a3b4aed483e896f001acee59b8592ae3d37acbdc60467239dac09bf80a999675b0c2aca058a4003d".to_string()); // (21-22)
-    hashvalues.push("08949f758439c6293fe5924defaf3e32bb79b9a93c1331f019c51b386557a9412b27f5a60a80bfa1f524c0d0c2e1f63c5b93d108a9a3af8cdb7fc87c765fca3f".to_string()); // 23
+    hashvalues.push("50b4d2e4705e73ef6bba2f15bb10affa669ccd4ceba1aa4283b1358a5a352756926e38823606be5c8fdb074a8e77e7f0699c60a81860c43441b447d9a4cdbb6d".to_string()); // [41] (21-22)
+    hashvalues.push("8230fa69d4b843ecc925ec619e8fdc69989b12c48974cbe9cf747166c28c3ae03be378071b9550351d84d82cd2197aeb25c6c9ee6cf058a08533027481d063fc".to_string()); // [42] 23
 
     hashvalues
 }
 
-fn create_mmr() -> MerkleMountainRange<Blake2b, Vec<Vec<u8>>> {
-    let mut mmr = MerkleMountainRange::<Blake2b, _>::new(Vec::default());
+fn create_mmr() -> MerkleMountainRange<Blake512TestMmrHasherBlake2b, Vec<Vec<u8>>> {
+    let mut mmr = MerkleMountainRange::<Blake512TestMmrHasherBlake2b, _>::new(Vec::default());
     for i in 1..24 {
-        let hash = Blake2b::digest(i.to_string().as_bytes()).to_vec();
+        let hash = Blake512TestMmrHasherBlake2b::new()
+            .digest(i.to_string().as_bytes())
+            .as_ref()
+            .to_vec();
         assert!(mmr.push(hash).is_ok());
     }
     mmr
@@ -94,8 +101,13 @@ fn check_mmr_hashes() {
     let mmr = create_mmr();
     let hashes = hash_values();
     assert_eq!(mmr.len(), Ok(42));
+    let mut failed = false;
     for (i, item) in hashes.iter().enumerate().take(42) {
         let hash = mmr.get_node_hash(i).unwrap().unwrap();
-        assert_eq!(&hash.to_hex(), item);
+        if &hash.to_hex() != item {
+            failed = true;
+            println!("{}: expected {}\n{}: got      {}\n", i + 1, hash.to_hex(), i + 1, item);
+        }
     }
+    assert!(!failed);
 }

--- a/base_layer/tari_mining_helper_ffi/src/lib.rs
+++ b/base_layer/tari_mining_helper_ffi/src/lib.rs
@@ -371,13 +371,8 @@ mod tests {
 
     #[test]
     fn detect_change_in_consensus_encoding() {
-        const NONCE: u64 = 10670621423673715972;
-        const DIFFICULTY: Difficulty = Difficulty::from_u64(7416);
-        // Use this to generate new NONCE and DIFFICULTY
-        // Use ONLY if you know encoding has changed
-        // let (difficulty, nonce) = generate_nonce_with_min_difficulty(MIN_DIFFICULTY).unwrap();
-        // eprintln!("nonce = {:?}", nonce);
-        // eprintln!("difficulty = {:?}", difficulty);
+        const NONCE: u64 = 1171565169570754761;
+        const DIFFICULTY: Difficulty = Difficulty::from_u64(3394);
         unsafe {
             let mut error = -1;
             let error_ptr = &mut error as *mut c_int;
@@ -390,6 +385,11 @@ mod tests {
             assert_eq!(error, 0);
             let result = share_difficulty(byte_vec, error_ptr);
             if result != DIFFICULTY.as_u64() {
+                // Use this to generate new NONCE and DIFFICULTY
+                // Use ONLY if you know encoding has changed
+                let (difficulty, nonce) = generate_nonce_with_min_difficulty(MIN_DIFFICULTY).unwrap();
+                eprintln!("nonce = {:?}", nonce);
+                eprintln!("difficulty = {:?}", difficulty);
                 panic!(
                     "detect_change_in_consensus_encoding has failed. This indicates a change in consensus encoding \
                      which requires an update to the pool miner code."

--- a/base_layer/tari_mining_helper_ffi/src/lib.rs
+++ b/base_layer/tari_mining_helper_ffi/src/lib.rs
@@ -371,8 +371,8 @@ mod tests {
 
     #[test]
     fn detect_change_in_consensus_encoding() {
-        const NONCE: u64 = 1171565169570754761;
-        const DIFFICULTY: Difficulty = Difficulty::from_u64(3394);
+        const NONCE: u64 = 15888881865102486737;
+        const DIFFICULTY: Difficulty = Difficulty::from_u64(5590);
         unsafe {
             let mut error = -1;
             let error_ptr = &mut error as *mut c_int;

--- a/base_layer/wallet_ffi/Cargo.toml
+++ b/base_layer/wallet_ffi/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.35.0"
 edition = "2018"
 
 [dependencies]
-tari_core = { version = "^0.35", path = "../../base_layer/core", default-features = false, features = ["transactions"]}
+tari_core = { version = "^0.35", path = "../../base_layer/core", default-features = false, features = ["tari_mmr", "transactions"]}
 tari_common = {path="../../common"}
 tari_common_types = {path="../common_types"}
 tari_comms = { version = "^0.35", path = "../../comms/core", features = ["c_integration"]}


### PR DESCRIPTION
Description
---
Partial fulfillment for #4395:
- Added hashing API to the MMR by virtue of forcing the hashing type to be `D: Digest + DomainDigest` instead of only `D: Digest` at the lower level MMR methods and functions.
- base_layer/mmr/src/common.rs
- base_layer/mmr/src/merkle_mountain_range.rs
- base_layer/mmr/src/merkle_proof.rs
- base_layer/mmr/src/mutable_mmr.rs

Fixed cucumber function `const getTransactionOutputHash = function (output)`

Motivation and Context
---
Domain separated hashing as per the `tari_crypto` hashing API is needed for the MMR.

How Has This Been Tested?
---
- Passed unit tests
- Passed cucumber tests
