### PR TITLE
feat(core/consensus)!: restrict output types to only those permitted by consensus

### DIFF
--- a/base_layer/core/src/consensus/consensus_constants.rs
+++ b/base_layer/core/src/consensus/consensus_constants.rs
@@ -38,6 +38,7 @@ use crate::{
         transaction_components::{
             OutputFeatures,
             OutputFeaturesVersion,
+            OutputType,
             TransactionInputVersion,
             TransactionKernelVersion,
             TransactionOutputVersion,
@@ -85,11 +86,13 @@ pub struct ConsensusConstants {
     /// Maximum byte size of TariScript
     max_script_byte_size: usize,
     /// Range of valid transaction input versions
-    pub(crate) input_version_range: RangeInclusive<TransactionInputVersion>,
+    input_version_range: RangeInclusive<TransactionInputVersion>,
     /// Range of valid transaction output (and features) versions
-    pub(crate) output_version_range: OutputVersionRange,
+    output_version_range: OutputVersionRange,
     /// Range of valid transaction kernel versions
-    pub(crate) kernel_version_range: RangeInclusive<TransactionKernelVersion>,
+    kernel_version_range: RangeInclusive<TransactionKernelVersion>,
+    /// An allowlist of output types
+    permitted_output_types: &'static [OutputType],
 }
 
 // todo: remove this once OutputFeaturesVersion is removed in favor of just TransactionOutputVersion
@@ -277,6 +280,11 @@ impl ConsensusConstants {
         &self.kernel_version_range
     }
 
+    /// Returns the permitted OutputTypes
+    pub fn permitted_output_types(&self) -> &[OutputType] {
+        self.permitted_output_types
+    }
+
     pub fn localnet() -> Vec<Self> {
         let difficulty_block_window = 90;
         let mut algos = HashMap::new();
@@ -313,6 +321,7 @@ impl ConsensusConstants {
             input_version_range,
             output_version_range,
             kernel_version_range,
+            permitted_output_types: OutputType::all(),
         }]
     }
 
@@ -352,6 +361,7 @@ impl ConsensusConstants {
             input_version_range,
             output_version_range,
             kernel_version_range,
+            permitted_output_types: Self::current_permitted_output_types(),
         }]
     }
 
@@ -394,6 +404,7 @@ impl ConsensusConstants {
             input_version_range,
             output_version_range,
             kernel_version_range,
+            permitted_output_types: Self::current_permitted_output_types(),
         }]
     }
 
@@ -443,6 +454,7 @@ impl ConsensusConstants {
                 input_version_range: input_version_range.clone(),
                 output_version_range: output_version_range.clone(),
                 kernel_version_range: kernel_version_range.clone(),
+                permitted_output_types: Self::current_permitted_output_types(),
             },
             ConsensusConstants {
                 effective_from_height: 23000,
@@ -465,6 +477,7 @@ impl ConsensusConstants {
                 input_version_range,
                 output_version_range,
                 kernel_version_range,
+                permitted_output_types: Self::current_permitted_output_types(),
             },
         ]
     }
@@ -512,6 +525,7 @@ impl ConsensusConstants {
             input_version_range,
             output_version_range,
             kernel_version_range,
+            permitted_output_types: Self::current_permitted_output_types(),
         }]
     }
 
@@ -552,7 +566,12 @@ impl ConsensusConstants {
             input_version_range,
             output_version_range,
             kernel_version_range,
+            permitted_output_types: Self::current_permitted_output_types(),
         }]
+    }
+
+    const fn current_permitted_output_types() -> &'static [OutputType] {
+        &[OutputType::Coinbase, OutputType::Standard, OutputType::Burn]
     }
 }
 
@@ -625,6 +644,11 @@ impl ConsensusConstantsBuilder {
         self.consensus.emission_initial = intial_amount;
         self.consensus.emission_decay = decay;
         self.consensus.emission_tail = tail_amount;
+        self
+    }
+
+    pub fn with_permitted_output_types(mut self, permitted_output_types: &'static [OutputType]) -> Self {
+        self.consensus.permitted_output_types = permitted_output_types;
         self
     }
 

--- a/base_layer/core/src/transactions/transaction_components/output_type.rs
+++ b/base_layer/core/src/transactions/transaction_components/output_type.rs
@@ -57,6 +57,10 @@ impl OutputType {
     pub fn from_byte(value: u8) -> Option<Self> {
         FromPrimitive::from_u8(value)
     }
+
+    pub const fn all() -> &'static [Self] {
+        &[OutputType::Standard, OutputType::Coinbase, OutputType::Burn]
+    }
 }
 
 impl Default for OutputType {
@@ -107,5 +111,7 @@ mod tests {
     fn it_converts_from_byte_to_output_type() {
         assert_eq!(OutputType::from_byte(0), Some(OutputType::Standard));
         assert_eq!(OutputType::from_byte(1), Some(OutputType::Coinbase));
+        assert_eq!(OutputType::from_byte(2), Some(OutputType::Burn));
+        assert_eq!(OutputType::from_byte(255), None);
     }
 }

--- a/base_layer/core/src/validation/block_validators/orphan.rs
+++ b/base_layer/core/src/validation/block_validators/orphan.rs
@@ -34,6 +34,7 @@ use crate::{
             check_coinbase_output,
             check_kernel_lock_height,
             check_maturity,
+            check_permitted_output_types,
             check_sorting_and_duplicates,
             check_total_burned,
         },
@@ -86,7 +87,8 @@ impl OrphanValidation for OrphanBlockValidator {
         };
         trace!(target: LOG_TARGET, "Validating {}", block_id);
 
-        check_block_weight(block, self.rules.consensus_constants(height))?;
+        let constants = self.rules.consensus_constants(height);
+        check_block_weight(block, constants)?;
         trace!(target: LOG_TARGET, "SV - Block weight is ok for {} ", &block_id);
 
         trace!(
@@ -100,6 +102,10 @@ impl OrphanValidation for OrphanBlockValidator {
             "SV - No duplicate inputs / outputs for {} ",
             &block_id
         );
+        for output in block.body.outputs() {
+            check_permitted_output_types(constants, output)?;
+        }
+        trace!(target: LOG_TARGET, "SV - Permitted output type ok for {} ", &block_id);
         check_total_burned(&block.body)?;
         trace!(target: LOG_TARGET, "SV - Burned outputs ok for {} ", &block_id);
 

--- a/base_layer/core/src/validation/block_validators/test.rs
+++ b/base_layer/core/src/validation/block_validators/test.rs
@@ -295,7 +295,7 @@ mod body_only {
 
 mod orphan_validator {
     use super::*;
-    use crate::txn_schema;
+    use crate::{transactions::transaction_components::OutputType, txn_schema};
 
     #[test]
     fn it_rejects_zero_conf_double_spends() {
@@ -329,5 +329,30 @@ mod orphan_validator {
         let (unmined, _) = blockchain.create_unmined_block(block_spec!("2", parent: "1", transactions: transactions));
         let err = validator.validate(&unmined).unwrap_err();
         assert!(matches!(err, ValidationError::UnsortedOrDuplicateInput));
+    }
+
+    #[test]
+    fn it_rejects_unpermitted_output_types() {
+        let rules = ConsensusManager::builder(Network::LocalNet)
+            .add_consensus_constants(
+                ConsensusConstantsBuilder::new(Network::LocalNet)
+                    .with_permitted_output_types(&[OutputType::Coinbase])
+                    .with_coinbase_lockheight(0)
+                    .build(),
+            )
+            .build();
+        let mut blockchain = TestBlockchain::create(rules.clone());
+        let validator = OrphanBlockValidator::new(rules, false, CryptoFactories::default());
+        let (_, coinbase) = blockchain.append(block_spec!("1", parent: "GB")).unwrap();
+
+        let schema = txn_schema!(from: vec![coinbase], to: vec![201 * T]);
+        let (tx, _) = schema_to_transaction(&[schema]);
+
+        let transactions = tx.into_iter().map(|b| Arc::try_unwrap(b).unwrap()).collect::<Vec<_>>();
+
+        let (unmined, _) = blockchain.create_unmined_block(block_spec!("2", parent: "1", transactions: transactions));
+        let err = validator.validate(&unmined).unwrap_err();
+        unpack_enum!(ValidationError::OutputTypeNotPermitted { output_type } = err);
+        assert_eq!(output_type, OutputType::Standard);
     }
 }

--- a/base_layer/core/src/validation/error.rs
+++ b/base_layer/core/src/validation/error.rs
@@ -128,6 +128,8 @@ pub enum ValidationError {
     },
     #[error("Contains Invalid Burn: {0}")]
     InvalidBurnError(String),
+    #[error("Output type '{output_type}' is not permitted")]
+    OutputTypeNotPermitted { output_type: OutputType },
 }
 
 // ChainStorageError has a ValidationError variant, so to prevent a cyclic dependency we use a string representation in


### PR DESCRIPTION
Description
---
Adds a new transaction and block validation that enforces allow-listed `OutputType`s

Motivation and Context
---
As more `OutputType`s are added, they should only be permitted by consensus from a known height to allow for gradual network upgrades.

How Has This Been Tested?
---
New unit test for orphan validator.
All output types are permitted for localnet/cucumber tests
