### PR TITLE
chore: remove broken tag from working tests

### DIFF
--- a/integration_tests/features/WalletFFI.feature
+++ b/integration_tests/features/WalletFFI.feature
@@ -137,8 +137,7 @@ Feature: Wallet FFI
         Then I want to view the transaction kernels for completed transactions in ffi wallet FFI_WALLET
         And I stop ffi wallet FFI_WALLET
 
-    #BROKEN: Sending via SAF works when running this test alone, but not when run with all other tests. Also works manually on dibbler
-    @critical @broken
+    @critical
     Scenario: As a client I want to receive Tari via my Public Key sent while I am offline when I come back online
         Given I have a seed node SEED
         And I have a base node BASE1 connected to all seed nodes
@@ -186,8 +185,7 @@ Feature: Wallet FFI
         Then wallet RECEIVER has at least 1 transactions that are all TRANSACTION_STATUS_FAUX_CONFIRMED and not cancelled
         And I stop ffi wallet FFI_WALLET
 
-    @critical @broken
-    # BROKEN: Runs fine when run by itself, but not with other tests - or maybe is flaky
+    @critical
     Scenario: As a client I want to receive a one-sided transaction
         Given I have a seed node SEED
         And I have a base node BASE1 connected to all seed nodes

--- a/integration_tests/features/WalletTransactions.feature
+++ b/integration_tests/features/WalletTransactions.feature
@@ -382,8 +382,7 @@ Feature: Wallet Transactions
     Then I restart wallet WALLET_RECV
     Then I wait for wallet WALLET_RECV to have at least 1000000 uT
 
-    # BROKEN: https://app.circleci.com/pipelines/github/sdbondi/tari/2534/workflows/5d482cd4-d51b-4322-8a77-89505a19fb06/jobs/6382/steps
-  @critical @broken
+  @critical
   Scenario: Wallet should cancel stale transactions
     Given I have a seed node NODE
     And I have 1 base nodes connected to all seed nodes

--- a/integration_tests/features/WalletTransfer.feature
+++ b/integration_tests/features/WalletTransfer.feature
@@ -6,7 +6,7 @@ Feature: Wallet Transfer
 
   # This is probably the most important base layer test
   # BROKEN: Runs fine when run by itself, but not with other tests - or maybe is flaky
-  @critical @broken
+  @critical
   Scenario: As a wallet send to a wallet connected to a different base node
     Given I have a seed node SEED_A
     And I have a seed node SEED_B


### PR DESCRIPTION
Description
---
Remove @broken tag from tests that are working. There is a possibility of flakiness (I did couple tests on my PC, worked fined everytime).
https://github.com/tari-project/tari/issues/4457

How Has This Been Tested?
---
Running npm test (for a single test as well as multiple at once).

