### PR TITLE
feat: remove total_txs and rename total_weight in mempool

### DIFF
--- a/applications/tari_app_grpc/proto/base_node.proto
+++ b/applications/tari_app_grpc/proto/base_node.proto
@@ -441,10 +441,9 @@ enum TransactionLocation {
 }
 
 message MempoolStatsResponse {
-    uint64 total_txs = 1;
     uint64 unconfirmed_txs = 2;
     uint64 reorg_txs = 3;
-    uint64 total_weight = 4;
+    uint64 unconfirmed_weight = 4;
 }
 
 message GetConstitutionsRequest {

--- a/applications/tari_base_node/src/commands/command/status.rs
+++ b/applications/tari_base_node/src/commands/command/status.rs
@@ -88,11 +88,11 @@ impl CommandContext {
             format!(
                 "{}tx ({}g, +/- {}blks)",
                 mempool_stats.unconfirmed_txs,
-                mempool_stats.total_weight,
-                if mempool_stats.total_weight == 0 {
+                mempool_stats.unconfirmed_weight,
+                if mempool_stats.unconfirmed_weight == 0 {
                     0
                 } else {
-                    1 + mempool_stats.total_weight / constants.get_max_block_transaction_weight()
+                    1 + mempool_stats.unconfirmed_weight / constants.get_max_block_transaction_weight()
                 },
             ),
         );

--- a/applications/tari_base_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/tari_base_node/src/grpc/base_node_grpc_server.rs
@@ -1865,10 +1865,9 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
         })?;
 
         let response = tari_rpc::MempoolStatsResponse {
-            total_txs: mempool_stats.total_txs as u64,
             unconfirmed_txs: mempool_stats.unconfirmed_txs as u64,
             reorg_txs: mempool_stats.reorg_txs as u64,
-            total_weight: mempool_stats.total_weight,
+            unconfirmed_weight: mempool_stats.unconfirmed_weight,
         };
 
         Ok(Response::new(response))

--- a/base_layer/core/src/mempool/mempool_storage.rs
+++ b/base_layer/core/src/mempool/mempool_storage.rs
@@ -285,19 +285,13 @@ impl MempoolStorage {
             .ok_or(MempoolError::TransactionNoKernels)
     }
 
-    // Returns the total number of transactions in the Mempool.
-    fn len(&self) -> usize {
-        self.unconfirmed_pool.len() + self.reorg_pool.len()
-    }
-
     /// Gathers and returns the stats of the Mempool.
     pub fn stats(&self) -> StatsResponse {
         let weighting = self.get_transaction_weighting(0);
         StatsResponse {
-            total_txs: self.len() as u64,
             unconfirmed_txs: self.unconfirmed_pool.len() as u64,
             reorg_txs: self.reorg_pool.len() as u64,
-            total_weight: self.unconfirmed_pool.calculate_weight(&weighting),
+            unconfirmed_weight: self.unconfirmed_pool.calculate_weight(&weighting),
         }
     }
 

--- a/base_layer/core/src/mempool/mod.rs
+++ b/base_layer/core/src/mempool/mod.rs
@@ -81,18 +81,17 @@ use crate::{
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StatsResponse {
-    pub total_txs: u64,
     pub unconfirmed_txs: u64,
     pub reorg_txs: u64,
-    pub total_weight: u64,
+    pub unconfirmed_weight: u64,
 }
 
 impl Display for StatsResponse {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         write!(
             fmt,
-            "Mempool stats: Total transactions: {}, Unconfirmed: {}, Published: {}, Total Weight: {}g",
-            self.total_txs, self.unconfirmed_txs, self.reorg_txs, self.total_weight
+            "Mempool stats: Unconfirmed: {}, In Reorg Pool: {}, Total Weight: {}g",
+            self.unconfirmed_txs, self.reorg_txs, self.unconfirmed_weight
         )
     }
 }

--- a/base_layer/core/src/mempool/proto/stats_response.proto
+++ b/base_layer/core/src/mempool/proto/stats_response.proto
@@ -6,8 +6,7 @@ syntax = "proto3";
 package tari.mempool;
 
 message StatsResponse {
-    uint64 total_txs = 1;
     uint64 unconfirmed_txs = 2;
     uint64 reorg_txs = 5;
-    uint64 total_weight = 6;
+    uint64 unconfirmed_weight = 6;
 }

--- a/base_layer/core/src/mempool/proto/stats_response.rs
+++ b/base_layer/core/src/mempool/proto/stats_response.rs
@@ -29,10 +29,9 @@ impl TryFrom<ProtoStatsResponse> for StatsResponse {
 
     fn try_from(stats: ProtoStatsResponse) -> Result<Self, Self::Error> {
         Ok(Self {
-            total_txs: stats.total_txs,
             unconfirmed_txs: stats.unconfirmed_txs,
             reorg_txs: stats.reorg_txs,
-            total_weight: stats.total_weight,
+            unconfirmed_weight: stats.unconfirmed_weight,
         })
     }
 }
@@ -40,10 +39,9 @@ impl TryFrom<ProtoStatsResponse> for StatsResponse {
 impl From<StatsResponse> for ProtoStatsResponse {
     fn from(stats: StatsResponse) -> Self {
         Self {
-            total_txs: stats.total_txs,
             unconfirmed_txs: stats.unconfirmed_txs,
             reorg_txs: stats.reorg_txs,
-            total_weight: stats.total_weight,
+            unconfirmed_weight: stats.unconfirmed_weight,
         }
     }
 }

--- a/base_layer/core/src/mempool/rpc/test.rs
+++ b/base_layer/core/src/mempool/rpc/test.rs
@@ -48,11 +48,10 @@ mod get_stats {
     async fn it_returns_the_stats() {
         let (service, mempool, req_mock, _tmpdir) = setup();
         let expected_stats = StatsResponse {
-            total_txs: 1,
             unconfirmed_txs: 2,
 
             reorg_txs: 5,
-            total_weight: 6,
+            unconfirmed_weight: 6,
         };
         mempool.set_get_stats_response(expected_stats.clone()).await;
 

--- a/base_layer/core/src/mempool/service/local_service.rs
+++ b/base_layer/core/src/mempool/service/local_service.rs
@@ -118,10 +118,9 @@ mod test {
 
     fn request_stats() -> StatsResponse {
         StatsResponse {
-            total_txs: 10,
             unconfirmed_txs: 3,
             reorg_txs: 4,
-            total_weight: 1000,
+            unconfirmed_weight: 1000,
         }
     }
 

--- a/base_layer/core/src/mempool/test_utils/mock.rs
+++ b/base_layer/core/src/mempool/test_utils/mock.rs
@@ -58,10 +58,9 @@ impl Default for MempoolMockState {
     fn default() -> Self {
         Self {
             get_stats: Arc::new(Mutex::new(StatsResponse {
-                total_txs: 0,
                 unconfirmed_txs: 0,
                 reorg_txs: 0,
-                total_weight: 0,
+                unconfirmed_weight: 0,
             })),
             get_state: Arc::new(Mutex::new(StateResponse {
                 unconfirmed_pool: vec![],


### PR DESCRIPTION
Description
---
Remove total_tx and rename total weight to unconfirmed weight

Motivation and Context
---
total tx was not useful and could perhaps be interpreted as "all the transactions in the mempool", which is actually what  unconfirmed_tx represents. Total weight renamed for same reason

How Has This Been Tested?
---
CI and existing tests

