### PR TITLE
fix(base_node_config): check_interval is 0 made base node is panicked

### DIFF
--- a/base_layer/p2p/src/auto_update/service.rs
+++ b/base_layer/p2p/src/auto_update/service.rs
@@ -95,9 +95,13 @@ impl SoftwareUpdaterService {
     ) {
         let mut interval_or_never = match self.config.check_interval {
             Some(interval) => {
-                let mut interval = time::interval(interval);
-                interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
-                Either::Left(wrappers::IntervalStream::new(interval))
+                if interval.is_zero() {
+                    Either::Right(stream::empty())
+                } else {
+                    let mut interval = time::interval(interval);
+                    interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+                    Either::Left(wrappers::IntervalStream::new(interval))
+                }
             },
             None => Either::Right(stream::empty()),
         };


### PR DESCRIPTION
Description
--
This PR served for fixing the bug described in #4399 

Motivation and Context
---
My target is finding a way to change it with as little change and minimal impact as possible. So here's how I can think of it. I'm not sure if this is the best solution. Any comments are welcome.

How Has This Been Tested?
---
Build runs in local fork, with `check_interval` = 0 and w/o `check_interval` setting.