### PR TITLE
fix(base-node): fix messy output in base node console

### DIFF
--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -70,12 +70,10 @@ pub struct BaseNodeContext {
 }
 
 impl BaseNodeContext {
-    /// Starts the node container. This entails the base node state machine.
+    /// Waits for shutdown of the base node state machine and comms.
     /// This call consumes the NodeContainer instance.
-    #[tracing::instrument(name = "base_node::run", skip(self))]
-    pub async fn run(self) {
-        info!(target: LOG_TARGET, "Tari base node has STARTED");
-
+    #[tracing::instrument(name = "base_node::wait_for_shutdown", skip(self))]
+    pub async fn wait_for_shutdown(self) {
         self.state_machine().shutdown_signal().wait().await;
         info!(target: LOG_TARGET, "Waiting for communications stack shutdown");
 

--- a/applications/tari_base_node/src/commands/cli_loop.rs
+++ b/applications/tari_base_node/src/commands/cli_loop.rs
@@ -129,11 +129,9 @@ impl CliLoop {
             } else {
                 let mut events = EventStream::new();
                 loop {
-                    terminal::enable_raw_mode().ok();
                     let interval = time::sleep(interval);
                     tokio::select! {
                         _ = interval => {
-                            terminal::disable_raw_mode().ok();
                             if let Err(err) = self.context.handle_command_str(line).await {
                                 println!("Watched command `{}` failed: {}", line, err);
                             }

--- a/applications/tari_base_node/src/main.rs
+++ b/applications/tari_base_node/src/main.rs
@@ -246,7 +246,6 @@ async fn run_node(
             "Node has been successfully configured and initialized. Starting CLI loop."
         );
     }
-    task::spawn(main_loop.cli_loop(config.base_node.resize_terminal_on_startup));
     if !config.base_node.force_sync_peers.is_empty() {
         warn!(
             target: LOG_TARGET,
@@ -254,7 +253,10 @@ async fn run_node(
         );
     }
 
-    ctx.run().await;
+    info!(target: LOG_TARGET, "Tari base node has STARTED");
+    main_loop.cli_loop(config.base_node.resize_terminal_on_startup).await;
+
+    ctx.wait_for_shutdown().await;
 
     println!("Goodbye!");
     Ok(())


### PR DESCRIPTION
Description
---
Fixes messy base node console output

Motivation and Context
---
Base node error output would start in the middle of the console instead of at the beginning of a new line.
The cli loop can run on the main thread instead of in a task.

```
09:24 v0.35.0, esmeralda, State: Listening, Tip: 610 (Mon, 22 Aug 2022 05:17:47 +0000), Mempool: 0tx (0g, +/- 0blks), Connections: 0, Banned: 0, Messages (last 60s): 0, Rpc: 0/100
09:24 WARN  Connectivity is OFFLINE (0/1 connections)
09:24 WARN  Connectivity is OFFLINE. Waiting for connections...
09:24 v0.35.0, esmeralda, State: Listening, Tip: 610 (Mon, 22 Aug 2022 05:17:47 +0000), Mempool: 0tx (0g, +/- 0blks), Connections: 7, Banned: 0, Messages (last 60s): 10, Rpc: 0/100
```

How Has This Been Tested?
---
Manually
