### PR TITLE
chore: fix warning about double short names

### DIFF
--- a/applications/tari_console_wallet/src/cli.rs
+++ b/applications/tari_console_wallet/src/cli.rs
@@ -148,7 +148,7 @@ pub struct MakeItRainArgs {
     pub start_time: Option<DateTime<Utc>>,
     #[clap(short, long)]
     pub one_sided: bool,
-    #[clap(short, long, alias = "stealth-one-sided")]
+    #[clap(long, alias = "stealth-one-sided")]
     pub stealth: bool,
     #[clap(short, long, default_value = "Make it rain")]
     pub message: String,


### PR DESCRIPTION
Description
---
Running clap_parses_user_defined_commands_as_expected  test, produces the following error:
```
Command make-it-rain: Short option names must be unique for each argument, but '-s' is in use by both 'start-amount' and 'stealth''
```

