### PR TITLE
fix(build): remove tari_validator_node from binary builds

### DIFF
--- a/.github/workflows/base_node_binaries.json
+++ b/.github/workflows/base_node_binaries.json
@@ -10,12 +10,11 @@
   },
   {
     "name": "linux-arm64",
-    "runs-on": "ubuntu-18.04",
+    "runs-on": "ubuntu-latest",
     "rust": "stable",
     "target": "aarch64-unknown-linux-gnu",
     "cross": false,
     "target_cpu": "generic",
-    "target_bins": "--bin tari_base_node --bin tari_console_wallet --bin tari_merge_mining_proxy --bin tari_miner --bin tari_validator_node",
     "features": "safe"
   },
   {
@@ -53,7 +52,7 @@
     "cross": false,
     "target_cpu": "generic",
     "features": "safe",
-    "target_bins": "--bin tari_base_node --bin tari_console_wallet --bin tari_merge_mining_proxy --bin tari_miner --bin tari_validator_node",
+    "target_bins": "--bin tari_base_node --bin tari_console_wallet --bin tari_merge_mining_proxy --bin tari_miner",
     "build_enabled": false
   }
 ]

--- a/.github/workflows/base_node_binaries.json
+++ b/.github/workflows/base_node_binaries.json
@@ -43,7 +43,6 @@
     "target": "x86_64-pc-windows-msvc",
     "cross": false,
     "target_cpu": "x86-64",
-    "target_bins": "--bin tari_base_node --bin tari_console_wallet --bin tari_merge_mining_proxy --bin tari_miner --bin tari_validator_node",
     "features": "safe"
   },
   {
@@ -54,6 +53,7 @@
     "cross": false,
     "target_cpu": "generic",
     "features": "safe",
+    "target_bins": "--bin tari_base_node --bin tari_console_wallet --bin tari_merge_mining_proxy --bin tari_miner --bin tari_validator_node",
     "build_enabled": false
   }
 ]

--- a/.github/workflows/base_node_binaries.yml
+++ b/.github/workflows/base_node_binaries.yml
@@ -229,7 +229,6 @@ jobs:
             "tari_console_wallet"
             "tari_miner"
             "tari_merge_mining_proxy"
-            "tari_validator_node"
           )
           for FILE in "${FILES[@]}"; do
             if [ -f "$GITHUB_WORKSPACE/target/${{ matrix.builds.target }}/release/${FILE}${TBN_EXT}" ]; then
@@ -274,7 +273,6 @@ jobs:
             "tari_console_wallet"
             "tari_miner"
             "tari_merge_mining_proxy"
-            "tari_validator_node"
           )
           for FILE in "${FILES[@]}"; do
             codesign --options runtime --force --verify --verbose --timestamp --sign "Developer ID Application: $MACOS_APPLICATION_ID" "/tmp/tari_testnet/runtime/$FILE"

--- a/buildtools/create_osx_install_zip.sh
+++ b/buildtools/create_osx_install_zip.sh
@@ -73,9 +73,6 @@ cp -f "${app_dir}/tari_merge_mining_proxy/osx/runtime/start_tari_merge_mining_pr
 cp -f "${app_dir}/tari_merge_mining_proxy/osx/runtime/start_xmrig.sh" "${tarball_folder}/runtime/start_xmrig.sh"
 cp -f "${project_dir}/${target_release}/tari_merge_mining_proxy" "${tarball_folder}/runtime/tari_merge_mining_proxy"
 
-# Validator node
-cp -f "${project_dir}/${target_release}/tari_validator_node" "${tarball_folder}/runtime/tari_validator_node"
-
 # 3rd party install
 cp -f "${local_dir}/install_xmrig.sh" "${tarball_folder}/runtime/install_xmrig.sh"
 cp -f "${local_dir}/get_xmrig_osx.ps1" "${tarball_folder}/runtime/get_xmrig_osx.ps1"

--- a/buildtools/create_ubuntu_install_zip.sh
+++ b/buildtools/create_ubuntu_install_zip.sh
@@ -71,9 +71,6 @@ cp -f "${app_dir}/tari_merge_mining_proxy/linux/runtime/start_tari_merge_mining_
 cp -f "${app_dir}/tari_merge_mining_proxy/linux/runtime/start_xmrig.sh" "${tarball_folder}/runtime/start_xmrig.sh"
 cp -f "${project_dir}/${target_release}/tari_merge_mining_proxy" "${tarball_folder}/runtime/tari_merge_mining_proxy"
 
-# Validator node
-cp -f "${project_dir}/${target_release}/tari_validator_node" "${tarball_folder}/runtime/tari_validator_node"
-
 # 3rd party install
 cp -f "${local_dir}/install_xmrig.sh" "${tarball_folder}/runtime/install_xmrig.sh"
 cp -f "${local_dir}/get_xmrig_ubuntu.ps1" "${tarball_folder}/runtime/get_xmrig_ubuntu.ps1"

--- a/buildtools/windows_inno_installer.iss
+++ b/buildtools/windows_inno_installer.iss
@@ -105,7 +105,6 @@ Source: "{#TariSuitePath}\tari_base_node.exe"; DestDir: "{app}\runtime"; Flags: 
 Source: "{#TariSuitePath}\tari_console_wallet.exe"; DestDir: "{app}\runtime"; Flags: ignoreversion
 Source: "{#TariSuitePath}\tari_miner.exe"; DestDir: "{app}\runtime"; Flags: ignoreversion
 Source: "{#TariSuitePath}\tari_merge_mining_proxy.exe"; DestDir: "{app}\runtime"; Flags: ignoreversion
-Source: "{#TariSuitePath}\tari_validator_node.exe"; DestDir: "{app}\runtime"; Flags: ignoreversion
 Source: "..\applications\tari_base_node\windows\runtime\start_all.bat"; DestDir: "{app}\runtime"; Flags: ignoreversion
 Source: "..\applications\tari_base_node\windows\runtime\start_tor.bat"; DestDir: "{app}\runtime"; Flags: ignoreversion
 Source: "..\applications\tari_base_node\windows\runtime\source_base_node_env.bat"; DestDir: "{app}\runtime"; Flags: ignoreversion


### PR DESCRIPTION
Description
Removed tari_validator_node from binary build process, solves build issues.

Motivation and Context
---

How Has This Been Tested?
Building in local fork

