### PR TITLE
fix(comms/dht): fixes invalid peer ban on invalid encrypted msg signature

### DIFF
--- a/comms/dht/src/inbound/message.rs
+++ b/comms/dht/src/inbound/message.rs
@@ -39,6 +39,37 @@ use crate::{
 };
 
 #[derive(Debug, Clone)]
+pub struct ValidatedDhtInboundMessage {
+    message: DhtInboundMessage,
+    authenticated_origin: Option<CommsPublicKey>,
+}
+
+impl ValidatedDhtInboundMessage {
+    pub fn new(message: DhtInboundMessage, authenticated_origin: Option<CommsPublicKey>) -> Self {
+        Self {
+            message,
+            authenticated_origin,
+        }
+    }
+
+    pub fn into_message(self) -> DhtInboundMessage {
+        self.message
+    }
+
+    pub fn message(&self) -> &DhtInboundMessage {
+        &self.message
+    }
+
+    pub fn header(&self) -> &DhtMessageHeader {
+        &self.message.dht_header
+    }
+
+    pub fn authenticated_origin(&self) -> Option<&CommsPublicKey> {
+        self.authenticated_origin.as_ref()
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct DhtInboundMessage {
     pub tag: MessageTag,
     pub source_peer: Arc<Peer>,
@@ -48,6 +79,7 @@ pub struct DhtInboundMessage {
     pub dedup_hit_count: u32,
     pub body: Vec<u8>,
 }
+
 impl DhtInboundMessage {
     pub fn new(tag: MessageTag, dht_header: DhtMessageHeader, source_peer: Arc<Peer>, body: Vec<u8>) -> Self {
         Self {

--- a/comms/dht/src/message_signature.rs
+++ b/comms/dht/src/message_signature.rs
@@ -68,7 +68,7 @@ impl MessageSignature {
         }
     }
 
-    /// Returns true if the provided message valid for this origin MAC, otherwise false.
+    /// Returns true if the provided message valid for this message signature, otherwise false.
     pub fn verify(&self, message: &[u8]) -> bool {
         let challenge =
             construct_message_signature_hash(&self.signer_public_key, self.signature.get_public_nonce(), message);
@@ -95,13 +95,13 @@ impl TryFrom<ProtoMessageSignature> for MessageSignature {
 
     fn try_from(message_signature: ProtoMessageSignature) -> Result<Self, Self::Error> {
         let signer_public_key = CommsPublicKey::from_bytes(&message_signature.signer_public_key)
-            .map_err(|_| MessageSignatureError::InvalidSignerPublicKey)?;
+            .map_err(|_| MessageSignatureError::InvalidSignerPublicKeyBytes)?;
 
         let public_nonce = CommsPublicKey::from_bytes(&message_signature.public_nonce)
-            .map_err(|_| MessageSignatureError::InvalidPublicNonce)?;
+            .map_err(|_| MessageSignatureError::InvalidPublicNonceBytes)?;
 
         let signature = CommsSecretKey::from_bytes(&message_signature.signature)
-            .map_err(|_| MessageSignatureError::InvalidSignature)?;
+            .map_err(|_| MessageSignatureError::InvalidSignatureBytes)?;
 
         Ok(Self {
             signer_public_key,
@@ -123,15 +123,13 @@ pub struct ProtoMessageSignature {
 
 #[derive(Debug, thiserror::Error)]
 pub enum MessageSignatureError {
-    #[error("Failed to decrypt origin MAC")]
-    DecryptedFailed,
-    #[error("Failed to validate origin MAC signature")]
-    InvalidSignature,
-    #[error("Origin MAC contained an invalid public nonce")]
-    InvalidPublicNonce,
-    #[error("Origin MAC contained an invalid signer public key")]
-    InvalidSignerPublicKey,
-    #[error("Origin MAC failed to verify")]
+    #[error("Failed to validate message signature")]
+    InvalidSignatureBytes,
+    #[error("Message signature contained an invalid public nonce")]
+    InvalidPublicNonceBytes,
+    #[error("Message signature contained an invalid signer public key")]
+    InvalidSignerPublicKeyBytes,
+    #[error("Message signature failed to verify")]
     VerificationFailed,
 }
 

--- a/comms/dht/src/store_forward/saf_handler/task.rs
+++ b/comms/dht/src/store_forward/saf_handler/task.rs
@@ -563,7 +563,7 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
 
             trace!(
                 target: LOG_TARGET,
-                "Attempting to decrypt origin mac ({} byte(s))",
+                "Attempting to decrypt message signature ({} byte(s))",
                 header.message_signature.len()
             );
             let shared_secret = crypt::generate_ecdh_secret(node_identity.secret_key(), ephemeral_public_key);

--- a/comms/dht/src/store_forward/store.rs
+++ b/comms/dht/src/store_forward/store.rs
@@ -272,7 +272,7 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError> + Se
             Some(_) => {
                 // If the message doesnt have an origin we wont store it
                 if !message.has_message_signature() {
-                    log_not_eligible("it is a cleartext message and does not have an origin MAC");
+                    log_not_eligible("it is a cleartext message and does not have an message signature");
                     return Ok(None);
                 }
 
@@ -303,8 +303,9 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError> + Se
                     // TODO: #banheuristic - the source peer should not have propagated this message
                     debug!(
                         target: LOG_TARGET,
-                        "Store task received an encrypted message with no origin MAC. This message {} is invalid and \
-                         should not be stored or propagated. Dropping message. Sent by node '{}' (Trace: {})",
+                        "Store task received an encrypted message with no message signature. This message {} is \
+                         invalid and should not be stored or propagated. Dropping message. Sent by node '{}' (Trace: \
+                         {})",
                         message.tag,
                         message.source_peer.node_id.short_str(),
                         message.dht_header.message_tag


### PR DESCRIPTION
Description
---
- fixes invalid ban of source peer on the encrypted message signature, which can only be validated by the sender (#4339 ) 
- add two additional unit tests for this case

Motivation and Context
---
Ref #4339 
Previously, a sender may send a message with an invalid encrypted signature that cannot be validated and rejected by intermediate nodes. On receipt by the sender, an invalid signature is encountered and previously this would result in sending peer being banned. This PR changes this to only discard the message. The sender is only banned if unencrypted header data is malformed/invalid.

How Has This Been Tested?
---
New unit tests + existing tests + manually (no breaking changes)

