### PR TITLE
feat: show the banned reason if a peer was banned in the contacts

### DIFF
--- a/applications/tari_console_wallet/src/ui/state/app_state.rs
+++ b/applications/tari_console_wallet/src/ui/state/app_state.rs
@@ -757,7 +757,7 @@ impl AppStateInner {
             let online_status = self
                 .wallet
                 .contacts_service
-                .get_contact_online_status(contact.last_seen)
+                .get_contact_online_status(contact.clone())
                 .await?;
             ui_contacts.push(UiContact::from(contact.clone()).with_online_status(format!("{}", online_status)));
         }

--- a/base_layer/wallet/src/contacts_service/error.rs
+++ b/base_layer/wallet/src/contacts_service/error.rs
@@ -21,6 +21,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use diesel::result::Error as DieselError;
+use tari_comms::connectivity::ConnectivityError;
 use tari_p2p::services::liveness::error::LivenessError;
 use tari_service_framework::reply_channel::TransportChannelError;
 use thiserror::Error;
@@ -40,6 +41,8 @@ pub enum ContactsServiceError {
     TransportChannelError(#[from] TransportChannelError),
     #[error("Livenessl error: `{0}`")]
     LivenessError(#[from] LivenessError),
+    #[error("ConnectivityError error: `{0}`")]
+    ConnectivityError(#[from] ConnectivityError),
 }
 
 #[derive(Debug, Error)]

--- a/base_layer/wallet/src/contacts_service/handle.rs
+++ b/base_layer/wallet/src/contacts_service/handle.rs
@@ -128,7 +128,7 @@ pub enum ContactsServiceRequest {
     UpsertContact(Contact),
     RemoveContact(CommsPublicKey),
     GetContacts,
-    GetContactOnlineStatus(Option<NaiveDateTime>),
+    GetContactOnlineStatus(Contact),
 }
 
 #[derive(Debug)]
@@ -212,11 +212,11 @@ impl ContactsServiceHandle {
     /// Determines the contact's online status based on their last seen time
     pub async fn get_contact_online_status(
         &mut self,
-        last_seen: Option<NaiveDateTime>,
+        contact: Contact,
     ) -> Result<ContactOnlineStatus, ContactsServiceError> {
         match self
             .request_response_service
-            .call(ContactsServiceRequest::GetContactOnlineStatus(last_seen))
+            .call(ContactsServiceRequest::GetContactOnlineStatus(contact))
             .await??
         {
             ContactsServiceResponse::OnlineStatus(status) => Ok(status),

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -1235,8 +1235,8 @@ int liveness_data_get_message_type(TariContactsLivenessData *liveness_data,
  * The ```liveness_data_destroy``` method must be called when finished with a TariContactsLivenessData to prevent a
  * memory leak
  */
-int liveness_data_get_online_status(TariContactsLivenessData *liveness_data,
-                                    int *error_out);
+const char *liveness_data_get_online_status(TariContactsLivenessData *liveness_data,
+                                            int *error_out);
 
 /**
  * Frees memory for a TariContactsLivenessData

--- a/comms/core/src/connectivity/manager.rs
+++ b/comms/core/src/connectivity/manager.rs
@@ -248,6 +248,16 @@ impl ConnectivityManagerActor {
                         .cloned(),
                 );
             },
+            GetPeerStats(node_id, reply) => {
+                let peer = match self.peer_manager.find_by_node_id(&node_id).await {
+                    Ok(v) => v,
+                    Err(e) => {
+                        error!(target: LOG_TARGET, "Error when retrieving peer: {:?}", e);
+                        None
+                    },
+                };
+                let _result = reply.send(peer);
+            },
             GetAllConnectionStates(reply) => {
                 let states = self.pool.all().into_iter().cloned().collect();
                 let _result = reply.send(states);

--- a/comms/core/src/test_utils/mocks/connectivity_manager.rs
+++ b/comms/core/src/test_utils/mocks/connectivity_manager.rs
@@ -259,6 +259,9 @@ impl ConnectivityManagerMock {
                     })
                     .await
             },
+            GetPeerStats(_, _) => {
+                unimplemented!()
+            },
             GetAllConnectionStates(_) => unimplemented!(),
             BanPeer(_, _, _) => {},
             AddPeerToAllowList(_) => {},


### PR DESCRIPTION
Description
---
Currently, if a peer has been banned, the constants will only show the peer is offline. 
This PR queries the peer manager for the peer to ask if the peer was banned or not. When asking the contact service in the wallet for the online status of the contact, the service will now report if the peer was banned, as well the reason for the banning. 
