### PR TITLE
WIP: fix: remove unnecessary database encryption MAC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,36 +18,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "aead"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c192eb8f11fc081b0fe4259ba5af04217d4e0faddd02417310a927911abd7c8"
-dependencies = [
- "crypto-common",
- "generic-array 0.14.5",
-]
-
-[[package]]
 name = "aes"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
 dependencies = [
  "cfg-if 1.0.0",
- "cipher 0.3.0",
+ "cipher",
  "cpufeatures 0.2.2",
  "opaque-debug 0.3.0",
-]
-
-[[package]]
-name = "aes"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe0133578c0986e1fe3dfcd4af1cc5b2dd6c3dbf534d69916ce16a2701d40ba"
-dependencies = [
- "cfg-if 1.0.0",
- "cipher 0.4.3",
- "cpufeatures 0.2.2",
 ]
 
 [[package]]
@@ -56,25 +35,11 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df5f85a83a7d8b0442b6aa7b504b8212c1733da07b98aae43d4bc21b2cb3cdf6"
 dependencies = [
- "aead 0.4.3",
- "aes 0.7.5",
- "cipher 0.3.0",
- "ctr 0.8.0",
- "ghash 0.4.4",
- "subtle",
-]
-
-[[package]]
-name = "aes-gcm"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e1366e0c69c9f927b1fa5ce2c7bf9eafc8f9268c0b9800729e8b267612447c"
-dependencies = [
- "aead 0.5.1",
- "aes 0.8.1",
- "cipher 0.4.3",
- "ctr 0.9.1",
- "ghash 0.5.0",
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
  "subtle",
 ]
 
@@ -377,7 +342,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cb03d1bed155d89dce0f845b7899b18a9a163e148fd004e1c28421a783e2d8e"
 dependencies = [
  "block-padding 0.2.1",
- "cipher 0.3.0",
+ "cipher",
 ]
 
 [[package]]
@@ -402,7 +367,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe3ff3fc1de48c1ac2e3341c4df38b0d1bfb8fdf04632a187c8b75aaa319a7ab"
 dependencies = [
  "byteorder",
- "cipher 0.3.0",
+ "cipher",
  "opaque-debug 0.3.0",
 ]
 
@@ -501,7 +466,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f69790da27038b52ffcf09e7874e1aae353c674d65242549a733ad9372e7281f"
 dependencies = [
  "byteorder",
- "cipher 0.3.0",
+ "cipher",
  "opaque-debug 0.3.0",
 ]
 
@@ -564,7 +529,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "750dfbb1b1f84475c1a92fed10fa5e76cb11adc0cda5225f137c5cac84e80860"
 dependencies = [
- "cipher 0.3.0",
+ "cipher",
 ]
 
 [[package]]
@@ -586,7 +551,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fee7ad89dc1128635074c268ee661f90c3f7e83d9fd12910608c36b47d6c3412"
 dependencies = [
  "cfg-if 1.0.0",
- "cipher 0.3.0",
+ "cipher",
  "cpufeatures 0.1.5",
  "zeroize",
 ]
@@ -598,7 +563,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c80e5460aa66fe3b91d40bcbdab953a597b60053e34d684ac6903f863b680a6"
 dependencies = [
  "cfg-if 1.0.0",
- "cipher 0.3.0",
+ "cipher",
  "cpufeatures 0.2.2",
  "zeroize",
 ]
@@ -609,9 +574,9 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1580317203210c517b6d44794abfbe600698276db18127e37ad3e69bf5e848e5"
 dependencies = [
- "aead 0.4.3",
+ "aead",
  "chacha20 0.7.1",
- "cipher 0.3.0",
+ "cipher",
  "poly1305",
  "zeroize",
 ]
@@ -622,9 +587,9 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a18446b09be63d457bbec447509e85f662f32952b035ce892290396bc0b0cff5"
 dependencies = [
- "aead 0.4.3",
+ "aead",
  "chacha20 0.8.2",
- "cipher 0.3.0",
+ "cipher",
  "poly1305",
  "zeroize",
 ]
@@ -666,16 +631,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
 dependencies = [
  "generic-array 0.14.5",
-]
-
-[[package]]
-name = "cipher"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1873270f8f7942c191139cb8a40fd228da6c3fd2fc376d7e92d47aa14aeb59e"
-dependencies = [
- "crypto-common",
- "inout",
 ]
 
 [[package]]
@@ -1147,7 +1102,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array 0.14.5",
- "rand_core 0.6.3",
  "typenum",
 ]
 
@@ -1189,16 +1143,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
 dependencies = [
- "cipher 0.3.0",
-]
-
-[[package]]
-name = "ctr"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d14f329cfbaf5d0e06b5e87fff7e265d2673c5ea7d2c27691a2c107db1442a0"
-dependencies = [
- "cipher 0.4.3",
+ "cipher",
 ]
 
 [[package]]
@@ -1372,7 +1317,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac41dd49fb554432020d52c875fc290e110113f864c6b1b525cd62c7e7747a5d"
 dependencies = [
  "byteorder",
- "cipher 0.3.0",
+ "cipher",
  "opaque-debug 0.3.0",
 ]
 
@@ -1869,17 +1814,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1583cc1656d7839fd3732b80cf4f38850336cdb9b8ded1cd399ca62958de3c99"
 dependencies = [
  "opaque-debug 0.3.0",
- "polyval 0.5.3",
-]
-
-[[package]]
-name = "ghash"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d930750de5717d2dd0b8c0d42c076c0e884c81a73e6cab859bbd2339c71e3e40"
-dependencies = [
- "opaque-debug 0.3.0",
- "polyval 0.6.0",
+ "polyval",
 ]
 
 [[package]]
@@ -2166,15 +2101,6 @@ checksum = "e6012d540c5baa3589337a98ce73408de9b5a25ec9fc2c6fd6be8f0d39e0ca5a"
 dependencies = [
  "autocfg",
  "hashbrown 0.11.2",
-]
-
-[[package]]
-name = "inout"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
-dependencies = [
- "generic-array 0.14.5",
 ]
 
 [[package]]
@@ -3309,7 +3235,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0c63db779c3f090b540dfa0484f8adc2d380e3aa60cdb0f3a7a97454e22edc5"
 dependencies = [
- "aes 0.7.5",
+ "aes",
  "base64 0.13.0",
  "bitfield",
  "block-modes",
@@ -3320,7 +3246,7 @@ dependencies = [
  "cast5",
  "cfb-mode",
  "chrono",
- "cipher 0.3.0",
+ "cipher",
  "circular",
  "clear_on_drop",
  "crc24",
@@ -3468,7 +3394,7 @@ checksum = "048aeb476be11a4b6ca432ca569e375810de9294ae78f4774e78ea98a9246ede"
 dependencies = [
  "cpufeatures 0.2.2",
  "opaque-debug 0.3.0",
- "universal-hash 0.4.1",
+ "universal-hash",
 ]
 
 [[package]]
@@ -3480,19 +3406,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures 0.2.2",
  "opaque-debug 0.3.0",
- "universal-hash 0.4.1",
-]
-
-[[package]]
-name = "polyval"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef234e08c11dfcb2e56f79fd70f6f2eb7f025c0ce2333e82f4f0518ecad30c6"
-dependencies = [
- "cfg-if 1.0.0",
- "cpufeatures 0.2.2",
- "opaque-debug 0.3.0",
- "universal-hash 0.5.0",
+ "universal-hash",
 ]
 
 [[package]]
@@ -4455,7 +4369,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6142f7c25e94f6fd25a32c3348ec230df9109b463f59c8c7acc4bd34936babb7"
 dependencies = [
- "aes-gcm 0.9.4",
+ "aes-gcm",
  "blake2 0.9.2",
  "chacha20poly1305 0.8.0",
  "rand 0.8.5",
@@ -5347,11 +5261,12 @@ dependencies = [
 name = "tari_wallet"
 version = "0.36.0"
 dependencies = [
- "aes-gcm 0.10.1",
  "argon2",
  "async-trait",
  "bincode",
  "blake2 0.9.2",
+ "chacha20 0.7.1",
+ "chacha20poly1305 0.9.1",
  "chrono",
  "clear_on_drop",
  "crossbeam-channel",
@@ -5971,7 +5886,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "728f6b7e784825d272fe9d2a77e44063f4197a570cbedc6fdcc90a6ddac91296"
 dependencies = [
  "byteorder",
- "cipher 0.3.0",
+ "cipher",
  "opaque-debug 0.3.0",
 ]
 
@@ -6063,16 +5978,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
 dependencies = [
  "generic-array 0.14.5",
- "subtle",
-]
-
-[[package]]
-name = "universal-hash"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d3160b73c9a19f7e2939a2fdad446c57c1bbbbf4d919d3213ff1267a580d8b5"
-dependencies = [
- "crypto-common",
  "subtle",
 ]
 

--- a/base_layer/wallet/Cargo.toml
+++ b/base_layer/wallet/Cargo.toml
@@ -27,12 +27,13 @@ tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", t
 # Uncomment for normal use (non tokio-console tracing)
 tokio = { version = "1.14", features = ["sync", "macros"] }
 
-aes-gcm = "0.10.1"
 async-trait = "0.1.50"
 argon2 = "0.2"
 bincode = "1.3.1"
 blake2 = "0.9.0"
 sha2 = "0.9.5"
+chacha20 = "0.7.1"
+chacha20poly1305 = "0.9.1"
 chrono = { version = "0.4.19", default-features = false, features = ["serde"] }
 clear_on_drop = "=0.2.4"
 crossbeam-channel = "0.5.4"

--- a/base_layer/wallet/src/key_manager_service/handle.rs
+++ b/base_layer/wallet/src/key_manager_service/handle.rs
@@ -22,7 +22,7 @@
 
 use std::sync::Arc;
 
-use aes_gcm::Aes256Gcm;
+use chacha20poly1305::ChaCha20Poly1305;
 use tari_common_types::types::PrivateKey;
 use tari_key_manager::cipher_seed::CipherSeed;
 use tokio::sync::RwLock;
@@ -70,7 +70,7 @@ where TBackend: KeyManagerBackend + 'static
             .await
     }
 
-    async fn apply_encryption(&self, cipher: Aes256Gcm) -> Result<(), KeyManagerServiceError> {
+    async fn apply_encryption(&self, cipher: ChaCha20Poly1305) -> Result<(), KeyManagerServiceError> {
         (*self.key_manager_inner).write().await.apply_encryption(cipher).await
     }
 

--- a/base_layer/wallet/src/key_manager_service/interface.rs
+++ b/base_layer/wallet/src/key_manager_service/interface.rs
@@ -20,7 +20,7 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use aes_gcm::Aes256Gcm;
+use chacha20poly1305::ChaCha20Poly1305;
 use tari_common_types::types::{PrivateKey, PublicKey};
 use tari_crypto::keys::PublicKey as PublicKeyTrait;
 
@@ -57,7 +57,7 @@ pub trait KeyManagerInterface: Clone + Send + Sync + 'static {
 
     /// Encrypts the key manager state using the provided cipher. An error is returned if the state is already
     /// encrypted.
-    async fn apply_encryption(&self, cipher: Aes256Gcm) -> Result<(), KeyManagerServiceError>;
+    async fn apply_encryption(&self, cipher: ChaCha20Poly1305) -> Result<(), KeyManagerServiceError>;
 
     /// Decrypts the key manager state using the provided cipher. An error is returned if the state is not encrypted.
     async fn remove_encryption(&self) -> Result<(), KeyManagerServiceError>;

--- a/base_layer/wallet/src/key_manager_service/mock.rs
+++ b/base_layer/wallet/src/key_manager_service/mock.rs
@@ -20,7 +20,7 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use aes_gcm::Aes256Gcm;
+use chacha20poly1305::ChaCha20Poly1305;
 use log::*;
 use tari_common_types::types::PrivateKey;
 use tari_key_manager::{cipher_seed::CipherSeed, key_manager::KeyManager};
@@ -154,7 +154,7 @@ impl KeyManagerInterface for KeyManagerMock {
         self.get_key_at_index_mock(branch.into(), index).await
     }
 
-    async fn apply_encryption(&self, _cipher: Aes256Gcm) -> Result<(), KeyManagerServiceError> {
+    async fn apply_encryption(&self, _cipher: ChaCha20Poly1305) -> Result<(), KeyManagerServiceError> {
         unimplemented!("Not supported");
     }
 

--- a/base_layer/wallet/src/key_manager_service/service.rs
+++ b/base_layer/wallet/src/key_manager_service/service.rs
@@ -19,7 +19,7 @@
 //  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-use aes_gcm::Aes256Gcm;
+use chacha20poly1305::ChaCha20Poly1305;
 use futures::lock::Mutex;
 use log::*;
 use tari_common_types::types::PrivateKey;
@@ -110,7 +110,7 @@ where TBackend: KeyManagerBackend + 'static
         Ok(key.k)
     }
 
-    pub async fn apply_encryption(&self, cipher: Aes256Gcm) -> Result<(), KeyManagerServiceError> {
+    pub async fn apply_encryption(&self, cipher: ChaCha20Poly1305) -> Result<(), KeyManagerServiceError> {
         self.db.apply_encryption(cipher).await?;
         Ok(())
     }

--- a/base_layer/wallet/src/key_manager_service/storage/database/backend.rs
+++ b/base_layer/wallet/src/key_manager_service/storage/database/backend.rs
@@ -1,4 +1,3 @@
-use chacha20::ChaCha;
 // Copyright 2022. The Tari Project
 //
 // Redistribution and use in source and binary forms, with or without modification, are permitted provided that the

--- a/base_layer/wallet/src/key_manager_service/storage/database/backend.rs
+++ b/base_layer/wallet/src/key_manager_service/storage/database/backend.rs
@@ -4,8 +4,8 @@ use chacha20::ChaCha;
 // Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
 // following conditions are met:
 //
-// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
-// disclaimer.
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
+// following disclaimer.
 //
 // 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
 // following disclaimer in the documentation and/or other materials provided with the distribution.
@@ -13,13 +13,14 @@ use chacha20::ChaCha;
 // 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
 // products derived from this software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
-// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
-// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
-// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+// WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+// PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
 use chacha20poly1305::ChaCha20Poly1305;
 
 use crate::key_manager_service::{error::KeyManagerStorageError, storage::database::KeyManagerState};

--- a/base_layer/wallet/src/key_manager_service/storage/database/backend.rs
+++ b/base_layer/wallet/src/key_manager_service/storage/database/backend.rs
@@ -1,3 +1,4 @@
+use chacha20::ChaCha;
 // Copyright 2022. The Tari Project
 //
 // Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
@@ -19,7 +20,7 @@
 // SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-use aes_gcm::Aes256Gcm;
+use chacha20poly1305::ChaCha20Poly1305;
 
 use crate::key_manager_service::{error::KeyManagerStorageError, storage::database::KeyManagerState};
 
@@ -35,7 +36,7 @@ pub trait KeyManagerBackend: Send + Sync + Clone {
     /// This method will set the currently stored key index for the key manager.
     fn set_key_index(&self, branch: String, index: u64) -> Result<(), KeyManagerStorageError>;
     /// Apply encryption to the backend.
-    fn apply_encryption(&self, cipher: Aes256Gcm) -> Result<(), KeyManagerStorageError>;
+    fn apply_encryption(&self, cipher: ChaCha20Poly1305) -> Result<(), KeyManagerStorageError>;
     /// Remove encryption from the backend.
     fn remove_encryption(&self) -> Result<(), KeyManagerStorageError>;
 }

--- a/base_layer/wallet/src/key_manager_service/storage/database/mod.rs
+++ b/base_layer/wallet/src/key_manager_service/storage/database/mod.rs
@@ -23,7 +23,7 @@
 mod backend;
 use std::sync::Arc;
 
-use aes_gcm::Aes256Gcm;
+use chacha20poly1305::ChaCha20Poly1305;
 pub use backend::KeyManagerBackend;
 
 use crate::key_manager_service::error::KeyManagerStorageError;
@@ -95,7 +95,7 @@ where T: KeyManagerBackend + 'static
 
     /// Encrypts the entire key manager with all branches.
     /// This will only encrypt the index used, as the master seed phrase is not directly stored with the key manager.
-    pub async fn apply_encryption(&self, cipher: Aes256Gcm) -> Result<(), KeyManagerStorageError> {
+    pub async fn apply_encryption(&self, cipher: ChaCha20Poly1305) -> Result<(), KeyManagerStorageError> {
         let db_clone = self.db.clone();
         tokio::task::spawn_blocking(move || db_clone.apply_encryption(cipher))
             .await

--- a/base_layer/wallet/src/key_manager_service/storage/database/mod.rs
+++ b/base_layer/wallet/src/key_manager_service/storage/database/mod.rs
@@ -23,8 +23,8 @@
 mod backend;
 use std::sync::Arc;
 
-use chacha20poly1305::ChaCha20Poly1305;
 pub use backend::KeyManagerBackend;
+use chacha20poly1305::ChaCha20Poly1305;
 
 use crate::key_manager_service::error::KeyManagerStorageError;
 

--- a/base_layer/wallet/src/key_manager_service/storage/sqlite_db/key_manager_state.rs
+++ b/base_layer/wallet/src/key_manager_service/storage/sqlite_db/key_manager_state.rs
@@ -22,7 +22,7 @@
 
 use std::convert::TryFrom;
 
-use aes_gcm::Aes256Gcm;
+use chacha20poly1305::ChaCha20Poly1305;
 use chrono::{NaiveDateTime, Utc};
 use diesel::{prelude::*, SqliteConnection};
 
@@ -150,21 +150,21 @@ pub struct KeyManagerStateUpdateSql {
     primary_key_index: Option<Vec<u8>>,
 }
 
-impl Encryptable<Aes256Gcm> for KeyManagerStateSql {
+impl Encryptable<ChaCha20Poly1305> for KeyManagerStateSql {
     fn domain(&self, field_name: &'static str) -> Vec<u8> {
         [Self::KEY_MANAGER, self.branch_seed.as_bytes(), field_name.as_bytes()]
             .concat()
             .to_vec()
     }
 
-    fn encrypt(&mut self, cipher: &Aes256Gcm) -> Result<(), String> {
+    fn encrypt(&mut self, cipher: &ChaCha20Poly1305) -> Result<(), String> {
         self.primary_key_index =
             encrypt_bytes_integral_nonce(cipher, self.domain("primary_key_index"), self.primary_key_index.clone())?;
 
         Ok(())
     }
 
-    fn decrypt(&mut self, cipher: &Aes256Gcm) -> Result<(), String> {
+    fn decrypt(&mut self, cipher: &ChaCha20Poly1305) -> Result<(), String> {
         self.primary_key_index =
             decrypt_bytes_integral_nonce(cipher, self.domain("primary_key_index"), self.primary_key_index.clone())?;
 
@@ -172,21 +172,21 @@ impl Encryptable<Aes256Gcm> for KeyManagerStateSql {
     }
 }
 
-impl Encryptable<Aes256Gcm> for NewKeyManagerStateSql {
+impl Encryptable<ChaCha20Poly1305> for NewKeyManagerStateSql {
     fn domain(&self, field_name: &'static str) -> Vec<u8> {
         [Self::KEY_MANAGER, self.branch_seed.as_bytes(), field_name.as_bytes()]
             .concat()
             .to_vec()
     }
 
-    fn encrypt(&mut self, cipher: &Aes256Gcm) -> Result<(), String> {
+    fn encrypt(&mut self, cipher: &ChaCha20Poly1305) -> Result<(), String> {
         self.primary_key_index =
             encrypt_bytes_integral_nonce(cipher, self.domain("primary_key_index"), self.primary_key_index.clone())?;
 
         Ok(())
     }
 
-    fn decrypt(&mut self, _cipher: &Aes256Gcm) -> Result<(), String> {
+    fn decrypt(&mut self, _cipher: &ChaCha20Poly1305) -> Result<(), String> {
         unimplemented!("Not supported")
     }
 }

--- a/base_layer/wallet/src/key_manager_service/storage/sqlite_db/mod.rs
+++ b/base_layer/wallet/src/key_manager_service/storage/sqlite_db/mod.rs
@@ -230,7 +230,7 @@ impl KeyManagerBackend for KeyManagerSqliteDatabase {
             key_manager_state.set_state(&conn)?;
         }
         // Now that all the decryption has been completed we can safely remove the cipher fully
-        let _ = (*current_cipher).take();
+        *current_cipher = None;
         if start.elapsed().as_millis() > 0 {
             trace!(
                 target: LOG_TARGET,

--- a/base_layer/wallet/src/key_manager_service/storage/sqlite_db/mod.rs
+++ b/base_layer/wallet/src/key_manager_service/storage/sqlite_db/mod.rs
@@ -25,7 +25,7 @@ use std::{
     sync::{Arc, RwLock},
 };
 
-use aes_gcm::Aes256Gcm;
+use chacha20poly1305::ChaCha20Poly1305;
 pub use key_manager_state::{KeyManagerStateSql, NewKeyManagerStateSql};
 use log::*;
 use tokio::time::Instant;
@@ -47,7 +47,7 @@ const LOG_TARGET: &str = "wallet::key_manager_service::database::wallet";
 #[derive(Clone)]
 pub struct KeyManagerSqliteDatabase {
     database_connection: WalletDbConnection,
-    cipher: Arc<RwLock<Option<Aes256Gcm>>>,
+    cipher: Arc<RwLock<Option<ChaCha20Poly1305>>>,
 }
 
 impl KeyManagerSqliteDatabase {
@@ -56,7 +56,7 @@ impl KeyManagerSqliteDatabase {
     ///   not encrypt sensitive fields
     pub fn new(
         database_connection: WalletDbConnection,
-        cipher: Option<Aes256Gcm>,
+        cipher: Option<ChaCha20Poly1305>,
     ) -> Result<Self, KeyManagerStorageError> {
         let db = Self {
             database_connection,
@@ -65,7 +65,7 @@ impl KeyManagerSqliteDatabase {
         Ok(db)
     }
 
-    fn decrypt_if_necessary<T: Encryptable<Aes256Gcm>>(&self, o: &mut T) -> Result<(), KeyManagerStorageError> {
+    fn decrypt_if_necessary<T: Encryptable<ChaCha20Poly1305>>(&self, o: &mut T) -> Result<(), KeyManagerStorageError> {
         let cipher = acquire_read_lock!(self.cipher);
         if let Some(cipher) = cipher.as_ref() {
             o.decrypt(cipher)
@@ -74,7 +74,7 @@ impl KeyManagerSqliteDatabase {
         Ok(())
     }
 
-    fn encrypt_if_necessary<T: Encryptable<Aes256Gcm>>(&self, o: &mut T) -> Result<(), KeyManagerStorageError> {
+    fn encrypt_if_necessary<T: Encryptable<ChaCha20Poly1305>>(&self, o: &mut T) -> Result<(), KeyManagerStorageError> {
         let cipher = acquire_read_lock!(self.cipher);
         if let Some(cipher) = cipher.as_ref() {
             o.encrypt(cipher)
@@ -178,7 +178,7 @@ impl KeyManagerBackend for KeyManagerSqliteDatabase {
         Ok(())
     }
 
-    fn apply_encryption(&self, cipher: Aes256Gcm) -> Result<(), KeyManagerStorageError> {
+    fn apply_encryption(&self, cipher: ChaCha20Poly1305) -> Result<(), KeyManagerStorageError> {
         let mut current_cipher = acquire_write_lock!(self.cipher);
 
         if (*current_cipher).is_some() {

--- a/base_layer/wallet/src/output_manager_service/handle.rs
+++ b/base_layer/wallet/src/output_manager_service/handle.rs
@@ -22,7 +22,7 @@
 
 use std::{fmt, fmt::Formatter, sync::Arc};
 
-use aes_gcm::Aes256Gcm;
+use chacha20poly1305::ChaCha20Poly1305;
 use tari_common_types::{
     transaction::TxId,
     types::{Commitment, HashOutput, PublicKey},
@@ -116,7 +116,7 @@ pub enum OutputManagerRequest {
         commitments: Vec<Commitment>,
         fee_per_gram: MicroTari,
     },
-    ApplyEncryption(Box<Aes256Gcm>),
+    ApplyEncryption(Box<ChaCha20Poly1305>),
     RemoveEncryption,
     FeeEstimate {
         amount: MicroTari,
@@ -769,7 +769,7 @@ impl OutputManagerHandle {
         }
     }
 
-    pub async fn apply_encryption(&mut self, cipher: Aes256Gcm) -> Result<(), OutputManagerError> {
+    pub async fn apply_encryption(&mut self, cipher: ChaCha20Poly1305) -> Result<(), OutputManagerError> {
         match self
             .handle
             .call(OutputManagerRequest::ApplyEncryption(Box::new(cipher)))

--- a/base_layer/wallet/src/output_manager_service/storage/database/backend.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/database/backend.rs
@@ -1,7 +1,7 @@
 // Copyright 2022 The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
 
-use aes_gcm::Aes256Gcm;
+use chacha20poly1305::ChaCha20Poly1305;
 use tari_common_types::{transaction::TxId, types::Commitment};
 use tari_core::transactions::transaction_components::{OutputType, TransactionOutput};
 
@@ -80,7 +80,7 @@ pub trait OutputManagerBackend: Send + Sync + Clone {
     /// If an invalid output is found to be valid this function will turn it back into an unspent output
     fn revalidate_unspent_output(&self, spending_key: &Commitment) -> Result<(), OutputManagerStorageError>;
     /// Apply encryption to the backend.
-    fn apply_encryption(&self, cipher: Aes256Gcm) -> Result<(), OutputManagerStorageError>;
+    fn apply_encryption(&self, cipher: ChaCha20Poly1305) -> Result<(), OutputManagerStorageError>;
     /// Remove encryption from the backend.
     fn remove_encryption(&self) -> Result<(), OutputManagerStorageError>;
 

--- a/base_layer/wallet/src/output_manager_service/storage/database/mod.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/database/mod.rs
@@ -26,7 +26,7 @@ use std::{
     sync::Arc,
 };
 
-use aes_gcm::Aes256Gcm;
+use chacha20poly1305::ChaCha20Poly1305;
 pub use backend::OutputManagerBackend;
 use log::*;
 use tari_common_types::{
@@ -327,7 +327,7 @@ where T: OutputManagerBackend + 'static
         self.db.reinstate_cancelled_inbound_output(tx_id)
     }
 
-    pub fn apply_encryption(&self, cipher: Aes256Gcm) -> Result<(), OutputManagerStorageError> {
+    pub fn apply_encryption(&self, cipher: ChaCha20Poly1305) -> Result<(), OutputManagerStorageError> {
         self.db.apply_encryption(cipher)
     }
 

--- a/base_layer/wallet/src/output_manager_service/storage/database/mod.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/database/mod.rs
@@ -26,8 +26,8 @@ use std::{
     sync::Arc,
 };
 
-use chacha20poly1305::ChaCha20Poly1305;
 pub use backend::OutputManagerBackend;
+use chacha20poly1305::ChaCha20Poly1305;
 use log::*;
 use tari_common_types::{
     transaction::TxId,

--- a/base_layer/wallet/src/output_manager_service/storage/sqlite_db/mod.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/sqlite_db/mod.rs
@@ -1053,7 +1053,7 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
         }
 
         // Now that all the decryption has been completed we can safely remove the cipher fully
-        let _ = (*current_cipher).take();
+        *current_cipher = None;
         if start.elapsed().as_millis() > 0 {
             trace!(
                 target: LOG_TARGET,

--- a/base_layer/wallet/src/output_manager_service/storage/sqlite_db/mod.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/sqlite_db/mod.rs
@@ -25,7 +25,7 @@ use std::{
     sync::{Arc, RwLock},
 };
 
-use aes_gcm::Aes256Gcm;
+use chacha20poly1305::ChaCha20Poly1305;
 use chrono::NaiveDateTime;
 use derivative::Derivative;
 use diesel::{prelude::*, result::Error as DieselError, SqliteConnection};
@@ -69,18 +69,18 @@ const LOG_TARGET: &str = "wallet::output_manager_service::database::wallet";
 #[derive(Clone)]
 pub struct OutputManagerSqliteDatabase {
     database_connection: WalletDbConnection,
-    cipher: Arc<RwLock<Option<Aes256Gcm>>>,
+    cipher: Arc<RwLock<Option<ChaCha20Poly1305>>>,
 }
 
 impl OutputManagerSqliteDatabase {
-    pub fn new(database_connection: WalletDbConnection, cipher: Option<Aes256Gcm>) -> Self {
+    pub fn new(database_connection: WalletDbConnection, cipher: Option<ChaCha20Poly1305>) -> Self {
         Self {
             database_connection,
             cipher: Arc::new(RwLock::new(cipher)),
         }
     }
 
-    fn decrypt_if_necessary<T: Encryptable<Aes256Gcm>>(&self, o: &mut T) -> Result<(), OutputManagerStorageError> {
+    fn decrypt_if_necessary<T: Encryptable<ChaCha20Poly1305>>(&self, o: &mut T) -> Result<(), OutputManagerStorageError> {
         let cipher = acquire_read_lock!(self.cipher);
         if let Some(cipher) = cipher.as_ref() {
             o.decrypt(cipher)
@@ -89,7 +89,7 @@ impl OutputManagerSqliteDatabase {
         Ok(())
     }
 
-    fn encrypt_if_necessary<T: Encryptable<Aes256Gcm>>(&self, o: &mut T) -> Result<(), OutputManagerStorageError> {
+    fn encrypt_if_necessary<T: Encryptable<ChaCha20Poly1305>>(&self, o: &mut T) -> Result<(), OutputManagerStorageError> {
         let cipher = acquire_read_lock!(self.cipher);
         if let Some(cipher) = cipher.as_ref() {
             o.encrypt(cipher)
@@ -962,7 +962,7 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
         Ok(())
     }
 
-    fn apply_encryption(&self, cipher: Aes256Gcm) -> Result<(), OutputManagerStorageError> {
+    fn apply_encryption(&self, cipher: ChaCha20Poly1305) -> Result<(), OutputManagerStorageError> {
         let mut current_cipher = acquire_write_lock!(self.cipher);
 
         if (*current_cipher).is_some() {
@@ -1417,7 +1417,7 @@ impl From<KnownOneSidedPaymentScript> for KnownOneSidedPaymentScriptSql {
     }
 }
 
-impl Encryptable<Aes256Gcm> for KnownOneSidedPaymentScriptSql {
+impl Encryptable<ChaCha20Poly1305> for KnownOneSidedPaymentScriptSql {
     fn domain(&self, field_name: &'static str) -> Vec<u8> {
         [
             Self::KNOWN_ONESIDED_PAYMENT_SCRIPT,
@@ -1428,12 +1428,12 @@ impl Encryptable<Aes256Gcm> for KnownOneSidedPaymentScriptSql {
         .to_vec()
     }
 
-    fn encrypt(&mut self, cipher: &Aes256Gcm) -> Result<(), String> {
+    fn encrypt(&mut self, cipher: &ChaCha20Poly1305) -> Result<(), String> {
         self.private_key = encrypt_bytes_integral_nonce(cipher, self.domain("private_key"), self.private_key.clone())?;
         Ok(())
     }
 
-    fn decrypt(&mut self, cipher: &Aes256Gcm) -> Result<(), String> {
+    fn decrypt(&mut self, cipher: &ChaCha20Poly1305) -> Result<(), String> {
         self.private_key = decrypt_bytes_integral_nonce(cipher, self.domain("private_key"), self.private_key.clone())?;
         Ok(())
     }
@@ -1443,7 +1443,7 @@ impl Encryptable<Aes256Gcm> for KnownOneSidedPaymentScriptSql {
 mod test {
     use std::time::Duration;
 
-    use aes_gcm::{aead::generic_array::GenericArray, Aes256Gcm, KeyInit};
+    use chacha20poly1305::{aead::NewAead,Key,ChaCha20Poly1305};
     use diesel::{Connection, SqliteConnection};
     use rand::{rngs::OsRng, RngCore};
     use tari_common_sqlite::sqlite_connection_pool::SqliteConnectionPool;
@@ -1619,8 +1619,8 @@ mod test {
         let uo = DbUnblindedOutput::from_unblinded_output(uo, &factories, None).unwrap();
         let output = NewOutputSql::new(uo, OutputStatus::Unspent, None, None).unwrap();
 
-        let key = GenericArray::from_slice(b"an example very very secret key.");
-        let cipher = Aes256Gcm::new(key);
+        let key = Key::from_slice(b"an example very very secret key.");
+        let cipher = ChaCha20Poly1305::new(key);
 
         output.commit(&conn).unwrap();
         let unencrypted_output = OutputSql::find(output.spending_key.as_slice(), &conn).unwrap();
@@ -1637,8 +1637,8 @@ mod test {
         decrypted_output.decrypt(&cipher).unwrap();
         assert_eq!(decrypted_output.spending_key, output.spending_key);
 
-        let wrong_key = GenericArray::from_slice(b"an example very very wrong key!!");
-        let wrong_cipher = Aes256Gcm::new(wrong_key);
+        let wrong_key = Key::from_slice(b"an example very very wrong key!!");
+        let wrong_cipher = ChaCha20Poly1305::new(wrong_key);
         assert!(outputs[0].clone().decrypt(&wrong_cipher).is_err());
 
         decrypted_output.update_encryption(&conn).unwrap();
@@ -1691,8 +1691,8 @@ mod test {
             output2.commit(&conn).unwrap();
         }
 
-        let key = GenericArray::from_slice(b"an example very very secret key.");
-        let cipher = Aes256Gcm::new(key);
+        let key = Key::from_slice(b"an example very very secret key.");
+        let cipher = ChaCha20Poly1305::new(key);
 
         let connection = WalletDbConnection::new(pool, None);
 

--- a/base_layer/wallet/src/output_manager_service/storage/sqlite_db/mod.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/sqlite_db/mod.rs
@@ -80,7 +80,10 @@ impl OutputManagerSqliteDatabase {
         }
     }
 
-    fn decrypt_if_necessary<T: Encryptable<ChaCha20Poly1305>>(&self, o: &mut T) -> Result<(), OutputManagerStorageError> {
+    fn decrypt_if_necessary<T: Encryptable<ChaCha20Poly1305>>(
+        &self,
+        o: &mut T,
+    ) -> Result<(), OutputManagerStorageError> {
         let cipher = acquire_read_lock!(self.cipher);
         if let Some(cipher) = cipher.as_ref() {
             o.decrypt(cipher)
@@ -89,7 +92,10 @@ impl OutputManagerSqliteDatabase {
         Ok(())
     }
 
-    fn encrypt_if_necessary<T: Encryptable<ChaCha20Poly1305>>(&self, o: &mut T) -> Result<(), OutputManagerStorageError> {
+    fn encrypt_if_necessary<T: Encryptable<ChaCha20Poly1305>>(
+        &self,
+        o: &mut T,
+    ) -> Result<(), OutputManagerStorageError> {
         let cipher = acquire_read_lock!(self.cipher);
         if let Some(cipher) = cipher.as_ref() {
             o.encrypt(cipher)
@@ -1443,7 +1449,7 @@ impl Encryptable<ChaCha20Poly1305> for KnownOneSidedPaymentScriptSql {
 mod test {
     use std::time::Duration;
 
-    use chacha20poly1305::{aead::NewAead,Key,ChaCha20Poly1305};
+    use chacha20poly1305::{aead::NewAead, ChaCha20Poly1305, Key};
     use diesel::{Connection, SqliteConnection};
     use rand::{rngs::OsRng, RngCore};
     use tari_common_sqlite::sqlite_connection_pool::SqliteConnectionPool;

--- a/base_layer/wallet/src/output_manager_service/storage/sqlite_db/new_output_sql.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/sqlite_db/new_output_sql.rs
@@ -19,7 +19,7 @@
 //  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-use aes_gcm::Aes256Gcm;
+use chacha20poly1305::ChaCha20Poly1305;
 use derivative::Derivative;
 use diesel::{prelude::*, SqliteConnection};
 use tari_common_types::transaction::TxId;
@@ -109,7 +109,7 @@ impl NewOutputSql {
     }
 }
 
-impl Encryptable<Aes256Gcm> for NewOutputSql {
+impl Encryptable<ChaCha20Poly1305> for NewOutputSql {
     fn domain(&self, field_name: &'static str) -> Vec<u8> {
         // WARNING: using `OUTPUT` for both NewOutputSql and OutputSql due to later transition without re-encryption
         [Self::OUTPUT, self.script.as_slice(), field_name.as_bytes()]
@@ -117,7 +117,7 @@ impl Encryptable<Aes256Gcm> for NewOutputSql {
             .to_vec()
     }
 
-    fn encrypt(&mut self, cipher: &Aes256Gcm) -> Result<(), String> {
+    fn encrypt(&mut self, cipher: &ChaCha20Poly1305) -> Result<(), String> {
         self.spending_key =
             encrypt_bytes_integral_nonce(cipher, self.domain("spending_key"), self.spending_key.clone())?;
 
@@ -130,7 +130,7 @@ impl Encryptable<Aes256Gcm> for NewOutputSql {
         Ok(())
     }
 
-    fn decrypt(&mut self, cipher: &Aes256Gcm) -> Result<(), String> {
+    fn decrypt(&mut self, cipher: &ChaCha20Poly1305) -> Result<(), String> {
         self.spending_key =
             decrypt_bytes_integral_nonce(cipher, self.domain("spending_key"), self.spending_key.clone())?;
 

--- a/base_layer/wallet/src/output_manager_service/storage/sqlite_db/output_sql.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/sqlite_db/output_sql.rs
@@ -22,7 +22,7 @@
 
 use std::convert::{TryFrom, TryInto};
 
-use aes_gcm::Aes256Gcm;
+use chacha20poly1305::ChaCha20Poly1305;
 use chrono::NaiveDateTime;
 use derivative::Derivative;
 use diesel::{prelude::*, sql_query, SqliteConnection};
@@ -722,7 +722,7 @@ impl TryFrom<OutputSql> for DbUnblindedOutput {
     }
 }
 
-impl Encryptable<Aes256Gcm> for OutputSql {
+impl Encryptable<ChaCha20Poly1305> for OutputSql {
     fn domain(&self, field_name: &'static str) -> Vec<u8> {
         // WARNING: using `OUTPUT` for both NewOutputSql and OutputSql due to later transition without re-encryption
         [Self::OUTPUT, self.script.as_slice(), field_name.as_bytes()]
@@ -730,7 +730,7 @@ impl Encryptable<Aes256Gcm> for OutputSql {
             .to_vec()
     }
 
-    fn encrypt(&mut self, cipher: &Aes256Gcm) -> Result<(), String> {
+    fn encrypt(&mut self, cipher: &ChaCha20Poly1305) -> Result<(), String> {
         self.spending_key =
             encrypt_bytes_integral_nonce(cipher, self.domain("spending_key"), self.spending_key.clone())?;
 
@@ -743,7 +743,7 @@ impl Encryptable<Aes256Gcm> for OutputSql {
         Ok(())
     }
 
-    fn decrypt(&mut self, cipher: &Aes256Gcm) -> Result<(), String> {
+    fn decrypt(&mut self, cipher: &ChaCha20Poly1305) -> Result<(), String> {
         self.spending_key =
             decrypt_bytes_integral_nonce(cipher, self.domain("spending_key"), self.spending_key.clone())?;
 

--- a/base_layer/wallet/src/storage/database.rs
+++ b/base_layer/wallet/src/storage/database.rs
@@ -25,7 +25,7 @@ use std::{
     sync::Arc,
 };
 
-use aes_gcm::Aes256Gcm;
+use chacha20poly1305::ChaCha20Poly1305;
 use log::*;
 use tari_common_types::chain_metadata::ChainMetadata;
 use tari_comms::{
@@ -47,7 +47,7 @@ pub trait WalletBackend: Send + Sync + Clone {
     /// Modify the state the of the backend with a write operation
     fn write(&self, op: WriteOperation) -> Result<Option<DbValue>, WalletStorageError>;
     /// Apply encryption to the backend.
-    fn apply_encryption(&self, passphrase: SafePassword) -> Result<Aes256Gcm, WalletStorageError>;
+    fn apply_encryption(&self, passphrase: SafePassword) -> Result<ChaCha20Poly1305, WalletStorageError>;
     /// Remove encryption from the backend.
     fn remove_encryption(&self) -> Result<(), WalletStorageError>;
 
@@ -277,7 +277,7 @@ where T: WalletBackend + 'static
         Ok(())
     }
 
-    pub async fn apply_encryption(&self, passphrase: SafePassword) -> Result<Aes256Gcm, WalletStorageError> {
+    pub async fn apply_encryption(&self, passphrase: SafePassword) -> Result<ChaCha20Poly1305, WalletStorageError> {
         let db_clone = self.db.clone();
         tokio::task::spawn_blocking(move || db_clone.apply_encryption(passphrase))
             .await

--- a/base_layer/wallet/src/storage/sqlite_db/wallet.rs
+++ b/base_layer/wallet/src/storage/sqlite_db/wallet.rs
@@ -26,16 +26,11 @@ use std::{
     sync::{Arc, RwLock},
 };
 
-use chacha20poly1305::{
-    aead::NewAead,
-    Key,
-    Nonce,
-    ChaCha20Poly1305
-};
 use argon2::{
     password_hash::{rand_core::OsRng, PasswordHash, PasswordHasher, PasswordVerifier, SaltString},
     Argon2,
 };
+use chacha20poly1305::{aead::NewAead, ChaCha20Poly1305, Key, Nonce};
 use diesel::{prelude::*, SqliteConnection};
 use log::*;
 use tari_common_types::chain_metadata::ChainMetadata;
@@ -60,11 +55,7 @@ use crate::{
         sqlite_db::scanned_blocks::ScannedBlockSql,
         sqlite_utilities::wallet_db_connection::WalletDbConnection,
     },
-    util::encryption::{
-        decrypt_bytes_integral_nonce,
-        encrypt_bytes_integral_nonce,
-        Encryptable,
-    },
+    util::encryption::{decrypt_bytes_integral_nonce, encrypt_bytes_integral_nonce, Encryptable},
     utxo_scanner_service::service::ScannedBlock,
 };
 

--- a/base_layer/wallet/src/storage/sqlite_db/wallet.rs
+++ b/base_layer/wallet/src/storage/sqlite_db/wallet.rs
@@ -529,7 +529,7 @@ impl WalletBackend for WalletSqliteDatabase {
         }
 
         // Now that all the decryption has been completed we can safely remove the cipher fully
-        let _ = (*current_cipher).take();
+        *current_cipher = None;
         if start.elapsed().as_millis() > 0 {
             trace!(
                 target: LOG_TARGET,

--- a/base_layer/wallet/src/storage/sqlite_db/wallet.rs
+++ b/base_layer/wallet/src/storage/sqlite_db/wallet.rs
@@ -58,7 +58,6 @@ use crate::{
         decrypt_bytes_integral_nonce,
         encrypt_bytes_integral_nonce,
         Encryptable,
-        AES_MAC_BYTES,
         AES_NONCE_BYTES,
     },
     utxo_scanner_service::service::ScannedBlock,
@@ -650,7 +649,7 @@ fn check_db_encryption_status(
                 if let Some(cipher_inner) = cipher.clone() {
                     let sk_bytes: Vec<u8> = from_hex(sk.as_str())?;
 
-                    if sk_bytes.len() < AES_NONCE_BYTES + AES_MAC_BYTES {
+                    if sk_bytes.len() < AES_NONCE_BYTES {
                         return Err(WalletStorageError::MissingNonce);
                     }
 

--- a/base_layer/wallet/src/transaction_service/handle.rs
+++ b/base_layer/wallet/src/transaction_service/handle.rs
@@ -27,7 +27,7 @@ use std::{
     sync::Arc,
 };
 
-use aes_gcm::Aes256Gcm;
+use chacha20poly1305::ChaCha20Poly1305;
 use chrono::NaiveDateTime;
 use tari_common_types::{
     transaction::{ImportStatus, TxId},
@@ -114,7 +114,7 @@ pub enum TransactionServiceRequest {
     SubmitTransactionToSelf(TxId, Transaction, MicroTari, MicroTari, String),
     SetLowPowerMode,
     SetNormalPowerMode,
-    ApplyEncryption(Box<Aes256Gcm>),
+    ApplyEncryption(Box<ChaCha20Poly1305>),
     RemoveEncryption,
     GenerateCoinbaseTransaction(MicroTari, MicroTari, u64),
     RestartTransactionProtocols,
@@ -713,7 +713,7 @@ impl TransactionServiceHandle {
         }
     }
 
-    pub async fn apply_encryption(&mut self, cipher: Aes256Gcm) -> Result<(), TransactionServiceError> {
+    pub async fn apply_encryption(&mut self, cipher: ChaCha20Poly1305) -> Result<(), TransactionServiceError> {
         match self
             .handle
             .call(TransactionServiceRequest::ApplyEncryption(Box::new(cipher)))

--- a/base_layer/wallet/src/transaction_service/storage/database.rs
+++ b/base_layer/wallet/src/transaction_service/storage/database.rs
@@ -28,7 +28,7 @@ use std::{
     sync::Arc,
 };
 
-use aes_gcm::Aes256Gcm;
+use chacha20poly1305::ChaCha20Poly1305;
 use chrono::{NaiveDateTime, Utc};
 use log::*;
 use tari_common_types::{
@@ -125,7 +125,7 @@ pub trait TransactionBackend: Send + Sync + Clone {
         amount: MicroTari,
     ) -> Result<Option<CompletedTransaction>, TransactionStorageError>;
     /// Apply encryption to the backend.
-    fn apply_encryption(&self, cipher: Aes256Gcm) -> Result<(), TransactionStorageError>;
+    fn apply_encryption(&self, cipher: ChaCha20Poly1305) -> Result<(), TransactionStorageError>;
     /// Remove encryption from the backend.
     fn remove_encryption(&self) -> Result<(), TransactionStorageError>;
     /// Increment the send counter and timestamp of a transaction
@@ -827,7 +827,7 @@ where T: TransactionBackend + 'static
             .and_then(|inner_result| inner_result)
     }
 
-    pub async fn apply_encryption(&self, cipher: Aes256Gcm) -> Result<(), TransactionStorageError> {
+    pub async fn apply_encryption(&self, cipher: ChaCha20Poly1305) -> Result<(), TransactionStorageError> {
         let db_clone = self.db.clone();
         tokio::task::spawn_blocking(move || db_clone.apply_encryption(cipher))
             .await

--- a/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
@@ -900,7 +900,7 @@ impl TransactionBackend for TransactionServiceSqliteDatabase {
         }
 
         // Now that all the decryption has been completed we can safely remove the cipher fully
-        let _ = (*current_cipher).take();
+        *current_cipher = None;
         if start.elapsed().as_millis() > 0 {
             trace!(
                 target: LOG_TARGET,

--- a/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
@@ -2189,7 +2189,7 @@ impl UnconfirmedTransactionInfoSql {
 mod test {
     use std::{convert::TryFrom, time::Duration};
 
-    use chacha20poly1305::{aead::NewAead, Key, ChaCha20Poly1305};
+    use chacha20poly1305::{aead::NewAead, ChaCha20Poly1305, Key};
     use chrono::Utc;
     use diesel::{Connection, SqliteConnection};
     use rand::rngs::OsRng;

--- a/base_layer/wallet/src/types.rs
+++ b/base_layer/wallet/src/types.rs
@@ -32,12 +32,4 @@ pub(crate) trait PersistentKeyManager {
     fn create_and_store_new(&mut self) -> Result<PublicKey, WalletError>;
 }
 
-hasher!(
-    Blake256,
-    WalletEncryptionHasher,
-    "com.tari.base_layer.wallet.encryption",
-    1,
-    wallet_encryption_hasher
-);
-
 hasher!(Blake256, WalletHasher, "com.tari.base_layer.wallet", 1, wallet_hasher);

--- a/base_layer/wallet/src/util/encryption.rs
+++ b/base_layer/wallet/src/util/encryption.rs
@@ -24,10 +24,10 @@ use std::mem::size_of;
 
 use chacha20poly1305::{
     self,
-    aead::{Aead, Payload, Error as AeadError},
+    aead::{Aead, Error as AeadError, Payload},
     ChaCha20Poly1305,
     Nonce,
-    Tag
+    Tag,
 };
 use rand::{rngs::OsRng, RngCore};
 use tari_utilities::ByteArray;
@@ -84,9 +84,7 @@ pub fn encrypt_bytes_integral_nonce(
         aad: domain.as_bytes(),
     };
 
-    let mut ciphertext = cipher
-        .encrypt(nonce_ga, payload)
-        .map_err(|e| e.to_string())?;
+    let mut ciphertext = cipher.encrypt(nonce_ga, payload).map_err(|e| e.to_string())?;
 
     let mut ciphertext_integral_nonce = nonce.to_vec();
     ciphertext_integral_nonce.append(&mut ciphertext);
@@ -98,20 +96,10 @@ pub fn encrypt_bytes_integral_nonce(
 mod test {
     use std::mem::size_of;
 
-    use chacha20poly1305::{
-        self,
-        aead::NewAead,
-        ChaCha20Poly1305,
-        Key,
-        Nonce,
-        Tag
-    };
+    use chacha20poly1305::{self, aead::NewAead, ChaCha20Poly1305, Key, Nonce, Tag};
     use rand::{rngs::OsRng, RngCore};
 
-    use crate::util::encryption::{
-        decrypt_bytes_integral_nonce,
-        encrypt_bytes_integral_nonce
-    };
+    use crate::util::encryption::{decrypt_bytes_integral_nonce, encrypt_bytes_integral_nonce};
 
     #[test]
     fn test_encrypt_decrypt() {
@@ -145,7 +133,7 @@ mod test {
                 0u8;
                 plaintext.len()
             ])
-        .collect();
+            .collect();
         assert!(decrypt_bytes_integral_nonce(&cipher, b"correct_domain".to_vec(), ciphertext_with_evil_nonce).is_err());
 
         // must fail with evil tag

--- a/base_layer/wallet/src/util/encryption.rs
+++ b/base_layer/wallet/src/util/encryption.rs
@@ -97,7 +97,12 @@ pub fn encrypt_bytes_integral_nonce(
 mod test {
     use aes_gcm::{aead::generic_array::GenericArray, Aes256Gcm, KeyInit};
 
-    use crate::util::encryption::{decrypt_bytes_integral_nonce, encrypt_bytes_integral_nonce, AES_NONCE_BYTES, AES_TAG_BYTES};
+    use crate::util::encryption::{
+        decrypt_bytes_integral_nonce,
+        encrypt_bytes_integral_nonce,
+        AES_NONCE_BYTES,
+        AES_TAG_BYTES
+    };
 
     #[test]
     fn test_encrypt_decrypt() {
@@ -116,15 +121,27 @@ mod test {
         assert!(decrypt_bytes_integral_nonce(&cipher, b"wrong_domain".to_vec(), ciphertext.clone()).is_err());
 
         // must fail with evil nonce
-        let ciphertext_with_evil_nonce = ciphertext.clone().splice(0..AES_NONCE_BYTES, [0u8; AES_NONCE_BYTES]).collect();
+        let ciphertext_with_evil_nonce = ciphertext
+            .clone()
+            .splice(0..AES_NONCE_BYTES, [0u8; AES_NONCE_BYTES])
+            .collect();
         assert!(decrypt_bytes_integral_nonce(&cipher, b"correct_domain".to_vec(), ciphertext_with_evil_nonce).is_err());
 
         // must fail with evil ciphertext
-        let ciphertext_with_evil_nonce = ciphertext.clone().splice(AES_NONCE_BYTES..(AES_NONCE_BYTES + plaintext.len()), vec![0u8; plaintext.len()]).collect();
+        let ciphertext_with_evil_nonce = ciphertext
+            .clone()
+            .splice(AES_NONCE_BYTES..(AES_NONCE_BYTES + plaintext.len()), vec![
+                0u8;
+                plaintext.len()
+            ])
+        .collect();
         assert!(decrypt_bytes_integral_nonce(&cipher, b"correct_domain".to_vec(), ciphertext_with_evil_nonce).is_err());
 
         // must fail with evil tag
-        let ciphertext_with_evil_tag = ciphertext.clone().splice((ciphertext.len() - AES_TAG_BYTES).., [0u8; AES_TAG_BYTES]).collect();
+        let ciphertext_with_evil_tag = ciphertext
+            .clone()
+            .splice((ciphertext.len() - AES_TAG_BYTES).., [0u8; AES_TAG_BYTES])
+            .collect();
         assert!(decrypt_bytes_integral_nonce(&cipher, b"correct_domain".to_vec(), ciphertext_with_evil_tag).is_err());
 
         // must fail with truncation

--- a/base_layer/wallet/tests/key_manager_service_tests/service.rs
+++ b/base_layer/wallet/tests/key_manager_service_tests/service.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use aes_gcm::{aead::generic_array::GenericArray, Aes256Gcm, KeyInit};
+use chacha20poly1305::{aead::NewAead, Key, ChaCha20Poly1305};
 use tari_key_manager::cipher_seed::CipherSeed;
 use tari_wallet::key_manager_service::{
     storage::{database::KeyManagerDatabase, sqlite_db::KeyManagerSqliteDatabase},
@@ -73,8 +73,8 @@ async fn get_key_at_test_no_encryption() {
 async fn get_key_at_test_with_encryption() {
     let (connection, _tempdir) = get_temp_sqlite_database_connection();
     let cipher = CipherSeed::new();
-    let key = GenericArray::from_slice(b"an example very very secret key.");
-    let db_cipher = Aes256Gcm::new(key);
+    let key = Key::from_slice(b"an example very very secret key.");
+    let db_cipher = ChaCha20Poly1305::new(key);
     let key_manager = KeyManagerHandle::new(
         cipher,
         KeyManagerDatabase::new(KeyManagerSqliteDatabase::new(connection, Some(db_cipher)).unwrap()),

--- a/base_layer/wallet/tests/key_manager_service_tests/service.rs
+++ b/base_layer/wallet/tests/key_manager_service_tests/service.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use chacha20poly1305::{aead::NewAead, Key, ChaCha20Poly1305};
+use chacha20poly1305::{aead::NewAead, ChaCha20Poly1305, Key};
 use tari_key_manager::cipher_seed::CipherSeed;
 use tari_wallet::key_manager_service::{
     storage::{database::KeyManagerDatabase, sqlite_db::KeyManagerSqliteDatabase},

--- a/base_layer/wallet/tests/output_manager_service_tests/storage.rs
+++ b/base_layer/wallet/tests/output_manager_service_tests/storage.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use chacha20poly1305::{aead::NewAead, Key, ChaCha20Poly1305};
+use chacha20poly1305::{aead::NewAead, ChaCha20Poly1305, Key};
 use rand::{rngs::OsRng, RngCore};
 use tari_common_types::transaction::TxId;
 use tari_core::transactions::{tari_amount::MicroTari, CryptoFactories};

--- a/base_layer/wallet/tests/output_manager_service_tests/storage.rs
+++ b/base_layer/wallet/tests/output_manager_service_tests/storage.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use aes_gcm::{aead::generic_array::GenericArray, Aes256Gcm, KeyInit};
+use chacha20poly1305::{aead::NewAead, Key, ChaCha20Poly1305};
 use rand::{rngs::OsRng, RngCore};
 use tari_common_types::transaction::TxId;
 use tari_core::transactions::{tari_amount::MicroTari, CryptoFactories};
@@ -317,8 +317,8 @@ pub fn test_output_manager_sqlite_db() {
 pub fn test_output_manager_sqlite_db_encrypted() {
     let (connection, _tempdir) = get_temp_sqlite_database_connection();
 
-    let key = GenericArray::from_slice(b"an example very very secret key.");
-    let cipher = Aes256Gcm::new(key);
+    let key = Key::from_slice(b"an example very very secret key.");
+    let cipher = ChaCha20Poly1305::new(key);
 
     test_db_backend(OutputManagerSqliteDatabase::new(connection, Some(cipher)));
 }

--- a/base_layer/wallet/tests/transaction_service_tests/storage.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/storage.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use chacha20poly1305::{aead::NewAead, Key, ChaCha20Poly1305};
+use chacha20poly1305::{aead::NewAead, ChaCha20Poly1305, Key};
 use chrono::{NaiveDateTime, Utc};
 use rand::rngs::OsRng;
 use tari_common_types::{

--- a/base_layer/wallet/tests/transaction_service_tests/storage.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/storage.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use aes_gcm::{aead::generic_array::GenericArray, Aes256Gcm, KeyInit};
+use chacha20poly1305::{aead::NewAead, Key, ChaCha20Poly1305};
 use chrono::{NaiveDateTime, Utc};
 use rand::rngs::OsRng;
 use tari_common_types::{
@@ -579,8 +579,8 @@ pub fn test_transaction_service_sqlite_db_encrypted() {
     let db_path = format!("{}/{}", db_folder, db_name);
     let connection = run_migration_and_create_sqlite_connection(&db_path, 16).unwrap();
 
-    let key = GenericArray::from_slice(b"an example very very secret key.");
-    let cipher = Aes256Gcm::new(key);
+    let key = Key::from_slice(b"an example very very secret key.");
+    let cipher = ChaCha20Poly1305::new(key);
 
     test_db_backend(TransactionServiceSqliteDatabase::new(connection, Some(cipher)));
 }
@@ -593,8 +593,8 @@ async fn import_tx_and_read_it_from_db() {
     let db_path = format!("{}/{}", db_folder, db_name);
     let connection = run_migration_and_create_sqlite_connection(&db_path, 16).unwrap();
 
-    let key = GenericArray::from_slice(b"an example very very secret key.");
-    let cipher = Aes256Gcm::new(key);
+    let key = Key::from_slice(b"an example very very secret key.");
+    let cipher = ChaCha20Poly1305::new(key);
     let sqlite_db = TransactionServiceSqliteDatabase::new(connection, Some(cipher));
 
     let transaction = CompletedTransaction::new(


### PR DESCRIPTION
Description
---
[PR 4340](https://github.com/tari-project/tari/pull/4340) adds an unnecessary MAC.

Motivation and Context
---
The existing AES-GCM AEAD includes an authentication tag, but it does not bind to the domain. This PR binds the domain to the existing AEAD tag, and removes the unnecessary MAC. It also improves the tests.

How Has This Been Tested?
---
Existing tests are updated.

