### PR TITLE
fix(core): fix block consensus decoding and add tests

### DIFF
--- a/base_layer/core/src/consensus/consensus_encoding.rs
+++ b/base_layer/core/src/consensus/consensus_encoding.rs
@@ -71,7 +71,8 @@ impl<T: ConsensusEncoding + ConsensusEncodingSized + ?Sized> ToConsensusBytes fo
     fn to_consensus_bytes(&self) -> Vec<u8> {
         let mut buf = Vec::with_capacity(self.consensus_encode_exact_size());
         // Vec's write impl is infallible, as per the ConsensusEncoding contract, consensus_encode is infallible
-        self.consensus_encode(&mut buf).expect("unreachable panic");
+        self.consensus_encode(&mut buf)
+            .expect("invalid ConsensusEncoding implementation detected");
         buf
     }
 }
@@ -100,8 +101,7 @@ pub mod test {
     /// ConsensusDecoding implementations
     pub fn check_consensus_encoding_correctness<T>(subject: T) -> Result<(), io::Error>
     where T: ConsensusEncoding + ConsensusEncodingSized + ConsensusDecoding + Eq + std::fmt::Debug {
-        let mut buf = Vec::new();
-        subject.consensus_encode(&mut buf)?;
+        let buf = subject.to_consensus_bytes();
         assert_eq!(buf.len(), subject.consensus_encode_exact_size());
         let mut reader = buf.as_slice();
         let decoded = T::consensus_decode(&mut reader)?;

--- a/base_layer/core/src/proof_of_work/monero_rx/merkle_tree.rs
+++ b/base_layer/core/src/proof_of_work/monero_rx/merkle_tree.rs
@@ -195,7 +195,7 @@ impl ConsensusDecoding for MerkleProof {
 
 impl ConsensusEncoding for MerkleProof {
     fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<(), io::Error> {
-        let _ = self.branch.consensus_encode(writer)?;
+        self.branch.consensus_encode(writer)?;
         ConsensusEncoding::consensus_encode(&self.depth, writer)?;
         ConsensusEncoding::consensus_encode(&self.path_bitmap, writer)?;
         Ok(())

--- a/base_layer/core/src/proof_of_work/monero_rx/pow_data.rs
+++ b/base_layer/core/src/proof_of_work/monero_rx/pow_data.rs
@@ -121,12 +121,12 @@ impl ConsensusDecoding for MoneroPowData {
 
 impl ConsensusEncoding for MoneroPowData {
     fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<(), io::Error> {
-        let _ = self.header.consensus_encode(writer)?;
+        self.header.consensus_encode(writer)?;
         self.randomx_key.consensus_encode(writer)?;
         ConsensusEncoding::consensus_encode(&self.transaction_count, writer)?;
-        let _ = self.merkle_root.consensus_encode(writer)?;
+        self.merkle_root.consensus_encode(writer)?;
         self.coinbase_merkle_proof.consensus_encode(writer)?;
-        let _ = self.coinbase_tx.consensus_encode(writer)?;
+        self.coinbase_tx.consensus_encode(writer)?;
         Ok(())
     }
 }

--- a/base_layer/core/src/transactions/test_helpers.rs
+++ b/base_layer/core/src/transactions/test_helpers.rs
@@ -235,6 +235,10 @@ impl TestParams {
             script![Nop].consensus_encode_exact_size() + output_features.consensus_encode_exact_size(),
         ) * num_outputs
     }
+
+    pub fn commit_value(&self, value: MicroTari) -> Commitment {
+        self.commitment_factory.commit_value(&self.spend_key, value.as_u64())
+    }
 }
 
 impl Default for TestParams {

--- a/base_layer/core/src/transactions/transaction_components/encrypted_value.rs
+++ b/base_layer/core/src/transactions/transaction_components/encrypted_value.rs
@@ -136,7 +136,7 @@ impl ConsensusEncoding for EncryptedValue {
 
 impl ConsensusEncodingSized for EncryptedValue {
     fn consensus_encode_exact_size(&self) -> usize {
-        self.0.len()
+        SIZE
     }
 }
 
@@ -157,7 +157,7 @@ mod test {
     };
 
     use super::*;
-    use crate::consensus::ToConsensusBytes;
+    use crate::consensus::{check_consensus_encoding_correctness, ToConsensusBytes};
 
     #[test]
     fn it_encodes_to_bytes() {
@@ -190,5 +190,11 @@ mod test {
                 EncryptedValue::decrypt_value(&encryption_key, &commitment, &encrypted_value).unwrap();
             assert_eq!(amount, decrypted_value);
         }
+    }
+    #[test]
+    fn consensus_encoding() {
+        let value = [0u8; SIZE];
+        let encrypted_value = EncryptedValue(value);
+        check_consensus_encoding_correctness(encrypted_value).unwrap();
     }
 }

--- a/base_layer/core/src/transactions/transaction_components/output_type.rs
+++ b/base_layer/core/src/transactions/transaction_components/output_type.rs
@@ -106,6 +106,7 @@ impl Display for OutputType {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::consensus::check_consensus_encoding_correctness;
 
     #[test]
     fn it_converts_from_byte_to_output_type() {
@@ -113,5 +114,11 @@ mod tests {
         assert_eq!(OutputType::from_byte(1), Some(OutputType::Coinbase));
         assert_eq!(OutputType::from_byte(2), Some(OutputType::Burn));
         assert_eq!(OutputType::from_byte(255), None);
+    }
+
+    #[test]
+    fn consensus_encoding() {
+        let t = OutputType::Standard;
+        check_consensus_encoding_correctness(t).unwrap();
     }
 }

--- a/base_layer/core/src/transactions/transaction_components/side_chain/sidechain_features.rs
+++ b/base_layer/core/src/transactions/transaction_components/side_chain/sidechain_features.rs
@@ -46,4 +46,13 @@ impl ConsensusDecoding for SideChainFeatures {
 }
 
 #[cfg(test)]
-mod tests {}
+mod test {
+    use super::*;
+    use crate::consensus::check_consensus_encoding_correctness;
+
+    #[test]
+    fn consensus_encoding() {
+        let features = SideChainFeatures {};
+        check_consensus_encoding_correctness(features).unwrap();
+    }
+}

--- a/base_layer/core/src/transactions/transaction_components/transaction_input.rs
+++ b/base_layer/core/src/transactions/transaction_components/transaction_input.rs
@@ -37,7 +37,7 @@ use tari_script::{ExecutionStack, ScriptContext, StackItem, TariScript};
 
 use super::{TransactionInputVersion, TransactionOutputVersion};
 use crate::{
-    consensus::{ConsensusDecoding, ConsensusEncoding, DomainSeparatedConsensusHasher},
+    consensus::{ConsensusDecoding, ConsensusEncoding, ConsensusEncodingSized, DomainSeparatedConsensusHasher},
     covenants::Covenant,
     transactions::{
         tari_amount::MicroTari,
@@ -484,6 +484,8 @@ impl ConsensusEncoding for TransactionInput {
     }
 }
 
+impl ConsensusEncodingSized for TransactionInput {}
+
 impl ConsensusDecoding for TransactionInput {
     fn consensus_decode<R: Read>(reader: &mut R) -> Result<Self, io::Error> {
         let version = TransactionInputVersion::consensus_decode(reader)?;
@@ -581,5 +583,20 @@ impl ConsensusDecoding for SpentOutput {
             },
             _ => Err(io::Error::new(ErrorKind::InvalidInput, "Invalid SpentOutput type")),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use crate::{consensus::check_consensus_encoding_correctness, transactions::test_helpers::create_test_input};
+
+    #[test]
+    fn consensus_encoding() {
+        let factory = CommitmentFactory::default();
+
+        let (input, _) = create_test_input(123.into(), 321, &factory);
+        check_consensus_encoding_correctness(input).unwrap();
     }
 }

--- a/base_layer/core/src/transactions/transaction_components/transaction_input_version.rs
+++ b/base_layer/core/src/transactions/transaction_components/transaction_input_version.rs
@@ -36,7 +36,7 @@ impl TryFrom<u8> for TransactionInputVersion {
         match value {
             0 => Ok(TransactionInputVersion::V0),
             1 => Ok(TransactionInputVersion::V1),
-            _ => Err("Unknown version!".to_string()),
+            v => Err(format!("Unknown input version {}!", v)),
         }
     }
 }
@@ -60,7 +60,7 @@ impl ConsensusDecoding for TransactionInputVersion {
         reader.read_exact(&mut buf)?;
         let version = buf[0]
             .try_into()
-            .map_err(|_| io::Error::new(ErrorKind::InvalidInput, format!("Unknown version {}", buf[0])))?;
+            .map_err(|_| io::Error::new(ErrorKind::InvalidInput, format!("Unknown input version {}", buf[0])))?;
         Ok(version)
     }
 }

--- a/base_layer/core/src/transactions/transaction_components/transaction_kernel_version.rs
+++ b/base_layer/core/src/transactions/transaction_components/transaction_kernel_version.rs
@@ -32,7 +32,7 @@ impl TryFrom<u8> for TransactionKernelVersion {
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
             0 => Ok(TransactionKernelVersion::V0),
-            _ => Err("Unknown version!".to_string()),
+            v => Err(format!("Unknown kernel version {}!", v)),
         }
     }
 }
@@ -56,7 +56,7 @@ impl ConsensusDecoding for TransactionKernelVersion {
         reader.read_exact(&mut buf)?;
         let version = buf[0]
             .try_into()
-            .map_err(|_| io::Error::new(ErrorKind::InvalidInput, format!("Unknown version {}", buf[0])))?;
+            .map_err(|_| io::Error::new(ErrorKind::InvalidInput, format!("Unknown kernel version {}", buf[0])))?;
         Ok(version)
     }
 }

--- a/base_layer/core/src/transactions/transaction_components/transaction_output_version.rs
+++ b/base_layer/core/src/transactions/transaction_components/transaction_output_version.rs
@@ -58,7 +58,7 @@ impl TryFrom<u8> for TransactionOutputVersion {
         match value {
             0 => Ok(TransactionOutputVersion::V0),
             1 => Ok(TransactionOutputVersion::V1),
-            _ => Err("Unknown version!".to_string()),
+            v => Err(format!("Unknown output version {}!", v)),
         }
     }
 }
@@ -82,7 +82,7 @@ impl ConsensusDecoding for TransactionOutputVersion {
         reader.read_exact(&mut buf)?;
         let version = buf[0]
             .try_into()
-            .map_err(|_| io::Error::new(ErrorKind::InvalidInput, format!("Unknown version {}", buf[0])))?;
+            .map_err(|_| io::Error::new(ErrorKind::InvalidInput, format!("Unknown output version {}", buf[0])))?;
         Ok(version)
     }
 }


### PR DESCRIPTION
Description
---
- fix consensus decoding for transaction output
- add tests for all impls of consensus encoding

Motivation and Context
---
Transaction output consensus decoding was missing encrypted value.
Tests picked this up.

How Has This Been Tested?
---
New tests