### PR TITLE
fix(cucumber): handles listHeaders response correctly

### DIFF
--- a/integration_tests/features/support/node_steps.js
+++ b/integration_tests/features/support/node_steps.js
@@ -363,18 +363,18 @@ Then(
         5 * height /* 5 seconds per block */
       );
       const currTip = await client.getTipHeader();
-      let currTipHeaderHeight = parseInt(currTip.header.height);
+      let currTipHeaderHeight = parseInt(currTip.height);
       console.log(
-        `${name} is at tip ${currTipHeaderHeight} (${currTip.header.hash.toString(
+        `${name} is at tip ${currTipHeaderHeight} (${currTip.hash.toString(
           "hex"
         )})`
       );
       expect(currTipHeaderHeight).to.equal(height);
       if (!tipHash) {
-        tipHash = currTip.header.hash.toString("hex");
+        tipHash = currTip.hash.toString("hex");
         console.log(`Node ${name} is at tip: ${tipHash}`);
       } else {
-        const currTipHash = currTip.header.hash.toString("hex");
+        const currTipHash = currTip.hash.toString("hex");
         console.log(
           `Node ${name} is at tip: ${currTipHash} (should be ${tipHash})`
         );
@@ -506,7 +506,7 @@ Then(/node (.*) is at tip (.*)/, async function (node, name) {
   const existingHeader = this.headers[name];
   expect(existingHeader).to.not.be.null;
   expect(existingHeader.header.hash.toString("hex")).to.equal(
-    header.header.hash.toString("hex")
+    header.hash.toString("hex")
   );
 });
 

--- a/integration_tests/helpers/baseNodeClient.js
+++ b/integration_tests/helpers/baseNodeClient.js
@@ -43,13 +43,9 @@ class BaseNodeClient {
   }
 
   getHeaderAt(height) {
-    return this.client
-      .listHeaders()
-      .sendMessage({ from_height: height, num_headers: 1 })
-      .then((header) => {
-        console.log("Header:", header);
-        return header;
-      });
+    return this.getHeaders(height, 1).then((header) =>
+      header && header.length ? header[0].header : null
+    );
   }
 
   getNetworkDifficulties(tip, start, end) {
@@ -69,21 +65,19 @@ class BaseNodeClient {
   }
 
   getTipHeader() {
-    return this.client
-      .listHeaders()
-      .sendMessage({ from_height: 0, num_headers: 1 })
-      .then((headers) => {
-        const header = headers[0];
-        return Object.assign(header, {
-          height: +header.height,
-        });
+    return this.getHeaders(0, 1).then((headers) => {
+      const header = headers[0];
+      return Object.assign(header, {
+        height: +header.height,
       });
+    });
   }
 
   async getHeaders(from_height, num_headers, sorting = 0) {
     return await this.client
       .listHeaders()
-      .sendMessage({ from_height, num_headers, sorting });
+      .sendMessage({ from_height, num_headers, sorting })
+      .then((resp) => resp.map((r) => r.header));
   }
 
   getTipHeight() {

--- a/integration_tests/helpers/baseNodeClient.js
+++ b/integration_tests/helpers/baseNodeClient.js
@@ -66,7 +66,7 @@ class BaseNodeClient {
 
   getTipHeader() {
     return this.getHeaders(0, 1).then((headers) => {
-      const header = headers[0];
+      const header = headers[0].header;
       return Object.assign(header, {
         height: +header.height,
       });


### PR DESCRIPTION
Description
---
- Fixes how listHeaders GRPC response is handled (since #4515)

Motivation and Context
---
#4515 returns the header in a nested struct, this PR updates the js code to handle that correctly.

How Has This Been Tested?
---
`Pruned node should prune outputs` passes
