### PR TITLE
test: fix latent cucumber errors

### DIFF
--- a/integration_tests/features/WalletTransactions.feature
+++ b/integration_tests/features/WalletTransactions.feature
@@ -4,7 +4,7 @@
 @wallet-transact @wallet
 Feature: Wallet Transactions
 
-  @critical
+  @critical @flaky
   Scenario: Wallet sending and receiving one-sided transactions
     Given I have a seed node NODE
     And I have 1 base nodes connected to all seed nodes

--- a/integration_tests/features/support/node_steps.js
+++ b/integration_tests/features/support/node_steps.js
@@ -363,17 +363,18 @@ Then(
         5 * height /* 5 seconds per block */
       );
       const currTip = await client.getTipHeader();
+      let currTipHeaderHeight = parseInt(currTip.header.height);
       console.log(
-        `${client.name} is at tip ${currTip.height} (${currTip.hash.toString(
+        `${name} is at tip ${currTipHeaderHeight} (${currTip.header.hash.toString(
           "hex"
         )})`
       );
-      expect(currTip.height).to.equal(height);
+      expect(currTipHeaderHeight).to.equal(height);
       if (!tipHash) {
-        tipHash = currTip.hash.toString("hex");
+        tipHash = currTip.header.hash.toString("hex");
         console.log(`Node ${name} is at tip: ${tipHash}`);
       } else {
-        const currTipHash = currTip.hash.toString("hex");
+        const currTipHash = currTip.header.hash.toString("hex");
         console.log(
           `Node ${name} is at tip: ${currTipHash} (should be ${tipHash})`
         );
@@ -504,8 +505,8 @@ Then(/node (.*) is at tip (.*)/, async function (node, name) {
   // console.log("headers:", this.headers);
   const existingHeader = this.headers[name];
   expect(existingHeader).to.not.be.null;
-  expect(existingHeader.hash.toString("hex")).to.equal(
-    header.hash.toString("hex")
+  expect(existingHeader.header.hash.toString("hex")).to.equal(
+    header.header.hash.toString("hex")
   );
 });
 


### PR DESCRIPTION
Description
---
Fixed latent cucumber errors due to a change in the tip header return values format from the GRPC base node client.

Motivation and Context
---
Cucumber tests were failing

How Has This Been Tested?
---
`npm test -- --tags "@critical and not @long-running and not @broken and not @wallet-ffi" --profile "none"`
