### PR TITLE
feat(console-wallet): detect local base node and prompt

### DIFF
--- a/applications/tari_console_wallet/src/main.rs
+++ b/applications/tari_console_wallet/src/main.rs
@@ -173,7 +173,11 @@ fn main_inner() -> Result<(), ExitError> {
     }
 
     // get base node/s
-    let base_node_config = runtime.block_on(get_base_node_peer_config(&config, &mut wallet))?;
+    let base_node_config = runtime.block_on(get_base_node_peer_config(
+        &config,
+        &mut wallet,
+        cli.non_interactive_mode,
+    ))?;
     let base_node_selected = base_node_config.get_base_node_peer()?;
 
     let wallet_mode = wallet_mode(&cli, boot_mode);

--- a/applications/tari_console_wallet/src/utils/db.rs
+++ b/applications/tari_console_wallet/src/utils/db.rs
@@ -25,9 +25,10 @@ use tari_common_types::types::PublicKey;
 use tari_comms::{
     multiaddr::Multiaddr,
     peer_manager::{NodeId, Peer, PeerFeatures, PeerFlags},
+    types::CommsPublicKey,
 };
 use tari_utilities::hex::Hex;
-use tari_wallet::WalletSqlite;
+use tari_wallet::{error::WalletStorageError, WalletSqlite};
 
 pub const LOG_TARGET: &str = "wallet::utils::db";
 pub const CUSTOM_BASE_NODE_PUBLIC_KEY_KEY: &str = "console_wallet_custom_base_node_public_key";
@@ -87,4 +88,26 @@ pub async fn get_custom_base_node_peer_from_db(wallet: &mut WalletSqlite) -> Opt
         },
         (_, _) => None,
     }
+}
+
+/// Sets the base node peer in the database
+pub async fn set_custom_base_node_peer_in_db(
+    wallet: &mut WalletSqlite,
+    base_node_public_key: &CommsPublicKey,
+    base_node_address: &Multiaddr,
+) -> Result<(), WalletStorageError> {
+    wallet
+        .db
+        .set_client_key_value(
+            CUSTOM_BASE_NODE_PUBLIC_KEY_KEY.to_string(),
+            base_node_public_key.to_hex(),
+        )
+        .await?;
+
+    wallet
+        .db
+        .set_client_key_value(CUSTOM_BASE_NODE_ADDRESS_KEY.to_string(), base_node_address.to_string())
+        .await?;
+
+    Ok(())
 }

--- a/base_layer/p2p/src/peer_seeds.rs
+++ b/base_layer/p2p/src/peer_seeds.rs
@@ -86,6 +86,10 @@ pub struct SeedPeer {
 }
 
 impl SeedPeer {
+    pub fn new(public_key: CommsPublicKey, addresses: Vec<Multiaddr>) -> Self {
+        Self { public_key, addresses }
+    }
+
     #[inline]
     pub fn derive_node_id(&self) -> NodeId {
         NodeId::from_public_key(&self.public_key)

--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -69,7 +69,7 @@ use tari_p2p::{
 use tari_script::{script, ExecutionStack, TariScript};
 use tari_service_framework::StackBuilder;
 use tari_shutdown::ShutdownSignal;
-use tari_utilities::SafePassword;
+use tari_utilities::{ByteArray, SafePassword};
 
 use crate::{
     base_node_service::{handle::BaseNodeServiceHandle, BaseNodeServiceInitializer},
@@ -758,7 +758,7 @@ pub fn derive_comms_secret_key(master_seed: &CipherSeed) -> Result<CommsSecretKe
 /// Persist the one-sided payment script for the current wallet NodeIdentity for use during scanning for One-sided
 /// payment outputs. This is peristed so that if the Node Identity changes the wallet will still scan for outputs
 /// using old node identities.
-pub async fn persist_one_sided_payment_script_for_node_identity(
+async fn persist_one_sided_payment_script_for_node_identity(
     output_manager_service: &mut OutputManagerHandle,
     node_identity: Arc<NodeIdentity>,
 ) -> Result<(), WalletError> {


### PR DESCRIPTION
Description
---
Auto-detects base node grpc on console wallet startup and prompts to use it

Motivation and Context
---
Resolves #4414 

Behaviour:
- if custom base node is set in the config, dont prompt
- if non interactive mode, dont prompt
- if custom base node in the database is already set to detected base node, dont prompt

How Has This Been Tested?
---
Manually, no base node set, startup with and without base node grpc available