### PR TITLE
fix: potential problem with not updating the OMS database

### DIFF
--- a/base_layer/wallet/tests/transaction_service_tests/transaction_protocols.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/transaction_protocols.rs
@@ -210,6 +210,7 @@ pub async fn oms_reply_channel_task(
         let (request, reply_tx) = request_context.split();
         let response = match request {
             OutputManagerRequest::CancelTransaction(_) => Ok(OutputManagerResponse::TransactionCancelled),
+            OutputManagerRequest::SetCoinbaseAbandoned(_, _) => Ok(OutputManagerResponse::CoinbaseAbandonedSet),
             _ => Err(OutputManagerError::InvalidResponseError(
                 "Unhandled request type".to_string(),
             )),


### PR DESCRIPTION
Description
---
The wallet uses two services, the OMS and TMS. The coinbase handling only happens inside of the TMS. When the TMS validates the coinbase and decides that the coinbase has been abandoned, it will update the TMS and then update the OMS. 

If the OMS update fails, then the TMS will have been updated and the OMS not, causing the two databases to be out of sync. And because the logic that determines if a coinbase has to be updated lives with the TMS,  it will never now it still needs to update the OMS. Causing the OMS to always have pending_incoming output. 

This PR updates the flow to first update the OMS so when this fails, it can at a later date try to update the TMS. If the TMS fails, it will update the TMS to make sure its correct. 

Fixes: https://github.com/tari-project/tari/issues/4505

