### PR TITLE
fix: removed `seed_words` and `delete_seed_words` commands

### DIFF
--- a/applications/tari_app_grpc/proto/wallet.proto
+++ b/applications/tari_app_grpc/proto/wallet.proto
@@ -307,11 +307,3 @@ message TransactionEvent {
 message TransactionEventResponse {
     TransactionEvent transaction  = 1;
 }
-
-message SeedWordsResponse {
-    repeated string words = 1;
-}
-
-message FileDeletedResponse {
-
-}

--- a/applications/tari_app_grpc/proto/wallet.proto
+++ b/applications/tari_app_grpc/proto/wallet.proto
@@ -74,8 +74,6 @@ service Wallet {
     rpc SetBaseNode(SetBaseNodeRequest) returns (SetBaseNodeResponse);
 
     rpc StreamTransactionEvents(TransactionEventRequest) returns (stream TransactionEventResponse);
-    rpc SeedWords(Empty) returns (SeedWordsResponse);
-    rpc DeleteSeedWordsFile(Empty) returns (FileDeletedResponse);
 }
 
 message GetVersionRequest { }

--- a/applications/tari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/tari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -880,41 +880,6 @@ impl wallet_server::Wallet for WalletGrpcServer {
             },
         }
     }
-
-    /// Returns the contents of a seed words file, provided via CLI
-    async fn seed_words(&self, _: Request<tari_rpc::Empty>) -> Result<Response<SeedWordsResponse>, Status> {
-        let cli = Cli::parse();
-
-        let filepath: PathBuf = match cli.seed_words_file_name {
-            Some(filepath) => filepath,
-            None => return Err(Status::not_found("file path is empty")),
-        };
-
-        let words = fs::read_to_string(filepath)?
-            .split(' ')
-            .collect::<Vec<&str>>()
-            .iter()
-            .map(|&x| x.into())
-            .collect::<Vec<String>>();
-
-        Ok(Response::new(SeedWordsResponse { words }))
-    }
-
-    /// Deletes the seed words file, provided via CLI
-    async fn delete_seed_words_file(
-        &self,
-        _: Request<tari_rpc::Empty>,
-    ) -> Result<Response<FileDeletedResponse>, Status> {
-        let cli = Cli::parse();
-
-        // WARNING: the filepath used is supplied as an argument
-        fs::remove_file(match cli.seed_words_file_name {
-            Some(filepath) => filepath,
-            None => return Err(Status::not_found("file path is empty")),
-        })?;
-
-        Ok(Response::new(FileDeletedResponse {}))
-    }
 }
 
 async fn handle_completed_tx(

--- a/applications/tari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/tari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -20,13 +20,8 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{
-    convert::{TryFrom, TryInto},
-    fs,
-    path::PathBuf,
-};
+use std::convert::{TryFrom, TryInto};
 
-use clap::Parser;
 use futures::{
     channel::mpsc::{self, Sender},
     future,
@@ -48,7 +43,6 @@ use tari_app_grpc::{
         CoinSplitResponse,
         CreateBurnTransactionRequest,
         CreateBurnTransactionResponse,
-        FileDeletedResponse,
         GetBalanceRequest,
         GetBalanceResponse,
         GetCoinbaseRequest,
@@ -67,7 +61,6 @@ use tari_app_grpc::{
         ImportUtxosResponse,
         RevalidateRequest,
         RevalidateResponse,
-        SeedWordsResponse,
         SendShaAtomicSwapRequest,
         SendShaAtomicSwapResponse,
         SetBaseNodeRequest,
@@ -106,7 +99,6 @@ use tokio::{sync::broadcast, task};
 use tonic::{Request, Response, Status};
 
 use crate::{
-    cli::Cli,
     grpc::{convert_to_transaction_event, TransactionWrapper},
     notifier::{CANCELLED, CONFIRMATION, MINED, NEW_BLOCK_MINED, QUEUED, RECEIVED, SENT},
 };


### PR DESCRIPTION
Description
---
Delete Seed words commands from GRPC #4363
https://github.com/tari-project/tari/issues/4363

Motivation and Context
---
We need to remove this from GRPC service, this is a dangerous call.

How Has This Been Tested?
---
existing unit tests
