### PR TITLE
test: fix small latent cucumber errors

### DIFF
--- a/integration_tests/features/support/node_steps.js
+++ b/integration_tests/features/support/node_steps.js
@@ -500,12 +500,14 @@ Then(
 );
 
 Then(/node (.*) is at tip (.*)/, async function (node, name) {
+  // console.log("\nheaders:", this.headers, "\n");
   const client = this.getClient(node);
   const header = await client.getTipHeader();
-  // console.log("headers:", this.headers);
+  // console.log("\nheader:", header, "\n");
   const existingHeader = this.headers[name];
+  // console.log("\nexistingHeader:", existingHeader, "\n");
   expect(existingHeader).to.not.be.null;
-  expect(existingHeader.header.hash.toString("hex")).to.equal(
+  expect(existingHeader.hash.toString("hex")).to.equal(
     header.hash.toString("hex")
   );
 });

--- a/integration_tests/helpers/baseNodeClient.js
+++ b/integration_tests/helpers/baseNodeClient.js
@@ -44,7 +44,7 @@ class BaseNodeClient {
 
   getHeaderAt(height) {
     return this.getHeaders(height, 1).then((header) =>
-      header && header.length ? header[0].header : null
+      header && header.length ? header[0] : null
     );
   }
 
@@ -66,7 +66,7 @@ class BaseNodeClient {
 
   getTipHeader() {
     return this.getHeaders(0, 1).then((headers) => {
-      const header = headers[0].header;
+      const header = headers[0];
       return Object.assign(header, {
         height: +header.height,
       });


### PR DESCRIPTION
Description
---
Fixed small latent cucumber errors

Motivation and Context
---
Some cucumber tests were failing

How Has This Been Tested?
---
- `npm test -- --profile "none" --name "Wallet sending and receiving one-sided stealth transactions"`
- `npm test -- --profile "none" --name "Node rolls back reorg on invalid block"`
