### PR TITLE
refactor(comms/dht)!: remove node id destination (ref #4139)

### DIFF
--- a/base_layer/wallet/src/transaction_service/protocols/transaction_send_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_send_protocol.rs
@@ -29,7 +29,7 @@ use tari_common_types::{
     transaction::{TransactionDirection, TransactionStatus, TxId},
     types::HashOutput,
 };
-use tari_comms::{peer_manager::NodeId, types::CommsPublicKey};
+use tari_comms::types::CommsPublicKey;
 use tari_comms_dht::{
     domain_message::OutboundDomainMessage,
     outbound::{OutboundEncryption, SendMessageResponse},
@@ -828,7 +828,7 @@ where
             .resources
             .outbound_message_service
             .closest_broadcast(
-                NodeId::from_public_key(&self.dest_pubkey),
+                self.dest_pubkey.clone(),
                 OutboundEncryption::encrypt_for(self.dest_pubkey.clone()),
                 vec![],
                 OutboundDomainMessage::new(&TariMessageType::SenderPartialTransaction, proto_message),

--- a/base_layer/wallet/src/transaction_service/tasks/send_finalized_transaction.rs
+++ b/base_layer/wallet/src/transaction_service/tasks/send_finalized_transaction.rs
@@ -25,7 +25,7 @@ use std::{convert::TryInto, time::Duration};
 
 use log::*;
 use tari_common_types::transaction::TxId;
-use tari_comms::{peer_manager::NodeId, types::CommsPublicKey};
+use tari_comms::types::CommsPublicKey;
 use tari_comms_dht::{
     domain_message::OutboundDomainMessage,
     outbound::{OutboundEncryption, OutboundMessageRequester, SendMessageResponse},
@@ -222,7 +222,7 @@ async fn send_transaction_finalized_message_store_and_forward(
 ) -> Result<bool, TransactionServiceError> {
     match outbound_message_service
         .closest_broadcast(
-            NodeId::from_public_key(&destination_pubkey),
+            destination_pubkey.clone(),
             OutboundEncryption::encrypt_for(destination_pubkey.clone()),
             vec![],
             OutboundDomainMessage::new(&TariMessageType::TransactionFinalized, msg.clone()),

--- a/base_layer/wallet/src/transaction_service/tasks/send_transaction_cancelled.rs
+++ b/base_layer/wallet/src/transaction_service/tasks/send_transaction_cancelled.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 use tari_common_types::transaction::TxId;
-use tari_comms::{peer_manager::NodeId, types::CommsPublicKey};
+use tari_comms::types::CommsPublicKey;
 use tari_comms_dht::{
     domain_message::OutboundDomainMessage,
     outbound::{OutboundEncryption, OutboundMessageRequester},
@@ -48,7 +48,7 @@ pub async fn send_transaction_cancelled_message(
 
     let _message_send_state = outbound_message_service
         .closest_broadcast(
-            NodeId::from_public_key(&destination_public_key),
+            destination_public_key.clone(),
             OutboundEncryption::encrypt_for(destination_public_key),
             vec![],
             OutboundDomainMessage::new(&TariMessageType::SenderPartialTransaction, proto_message),

--- a/base_layer/wallet/src/transaction_service/tasks/send_transaction_reply.rs
+++ b/base_layer/wallet/src/transaction_service/tasks/send_transaction_reply.rs
@@ -24,7 +24,7 @@ use std::time::Duration;
 
 use log::*;
 use tari_common_types::transaction::TxId;
-use tari_comms::{peer_manager::NodeId, types::CommsPublicKey};
+use tari_comms::types::CommsPublicKey;
 use tari_comms_dht::{
     domain_message::OutboundDomainMessage,
     outbound::{OutboundEncryption, OutboundMessageRequester, SendMessageResponse},
@@ -200,7 +200,7 @@ async fn send_transaction_reply_store_and_forward(
 ) -> Result<bool, TransactionServiceError> {
     match outbound_message_service
         .closest_broadcast(
-            NodeId::from_public_key(&destination_pubkey),
+            destination_pubkey.clone(),
             OutboundEncryption::encrypt_for(destination_pubkey.clone()),
             vec![],
             OutboundDomainMessage::new(&TariMessageType::ReceiverPartialTransactionReply, msg),

--- a/comms/dht/examples/memory_net/utilities.rs
+++ b/comms/dht/examples/memory_net/utilities.rs
@@ -148,7 +148,7 @@ pub async fn discovery(wallets: &[TestNode], messaging_events_rx: &mut NodeEvent
             .discovery_service_requester()
             .discover_peer(
                 wallet2.node_identity().public_key().clone(),
-                wallet2.node_identity().node_id().clone().into(),
+                wallet2.node_identity().public_key().clone().into(),
             )
             .await;
 
@@ -442,7 +442,7 @@ pub async fn do_store_and_forward_message_propagation(
             .dht
             .outbound_requester()
             .closest_broadcast(
-                node_identity.node_id().clone(),
+                node_identity.public_key().clone(),
                 OutboundEncryption::encrypt_for(node_identity.public_key().clone()),
                 vec![],
                 OutboundDomainMessage::new(&123i32, secret_message.clone()),

--- a/comms/dht/src/actor.rs
+++ b/comms/dht/src/actor.rs
@@ -450,7 +450,7 @@ impl DhtActor {
             .send_message_no_header(
                 SendMessageParams::new()
                     .closest(node_identity.node_id().clone(), vec![])
-                    .with_destination(node_identity.node_id().clone().into())
+                    .with_destination(node_identity.public_key().clone().into())
                     .with_dht_message_type(DhtMessageType::Join)
                     .force_origin()
                     .finish(),
@@ -549,10 +549,7 @@ impl DhtActor {
                 Ok(candidates)
             },
             Propagate(destination, exclude) => {
-                let dest_node_id = destination
-                    .node_id()
-                    .cloned()
-                    .or_else(|| destination.public_key().map(NodeId::from_public_key));
+                let dest_node_id = destination.to_derived_node_id();
 
                 let connections = match dest_node_id {
                     Some(node_id) => {
@@ -1171,7 +1168,7 @@ mod test {
 
         let peers = requester
             .select_peers(BroadcastStrategy::Propagate(
-                conn_out.peer_node_id().clone().into(),
+                node_identity.public_key().clone().into(),
                 Vec::new(),
             ))
             .await

--- a/comms/dht/src/dht.rs
+++ b/comms/dht/src/dht.rs
@@ -327,7 +327,6 @@ impl Dht {
                 self.store_and_forward_requester(),
                 self.dht_requester(),
                 Arc::clone(&self.node_identity),
-                Arc::clone(&self.peer_manager),
                 self.outbound_requester(),
                 self.saf_response_signal_sender.clone(),
             ))

--- a/comms/dht/src/inbound/dht_handler/task.rs
+++ b/comms/dht/src/inbound/dht_handler/task.rs
@@ -214,23 +214,21 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
             return Ok(());
         }
 
-        let origin_node_id = origin_peer.node_id;
+        let origin_public_key = origin_peer.public_key;
 
         // Only propagate a join that was not directly sent to this node
-        if dht_header.destination != self.node_identity.public_key() &&
-            dht_header.destination != self.node_identity.node_id()
-        {
+        if dht_header.destination != self.node_identity.public_key() {
             debug!(
                 target: LOG_TARGET,
                 "Propagating Join message from peer '{}'",
-                origin_node_id.short_str()
+                origin_peer.node_id.short_str()
             );
             // Propagate message to closer peers
             self.outbound_service
                 .send_raw(
                     SendMessageParams::new()
-                        .propagate(origin_node_id.clone().into(), vec![
-                            origin_node_id,
+                        .propagate(origin_public_key.clone().into(), vec![
+                            origin_peer.node_id,
                             source_peer.node_id.clone(),
                         ])
                         .with_dht_header(dht_header)

--- a/comms/dht/src/inbound/forward.rs
+++ b/comms/dht/src/inbound/forward.rs
@@ -212,7 +212,7 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
             .expect("previous check that decryption failed");
 
         let excluded_peers = vec![source_peer.node_id.clone()];
-        let dest_node_id = dht_header.destination.node_id();
+        let dest_node_id = dht_header.destination.to_derived_node_id();
 
         let mut send_params = SendMessageParams::new();
         match (dest_node_id, is_saf_stored) {
@@ -221,7 +221,7 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
                     target: LOG_TARGET,
                     "Forwarding SAF message directly to node: {}, {}", node_id, dht_header.message_tag
                 );
-                send_params.direct_or_closest_connected(node_id.clone(), excluded_peers);
+                send_params.direct_or_closest_connected(node_id, excluded_peers);
             },
             _ => {
                 debug!(
@@ -246,10 +246,6 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
     fn destination_matches_source(&self, destination: &NodeDestination, source: &Peer) -> bool {
         if let Some(pk) = destination.public_key() {
             return pk == &source.public_key;
-        }
-
-        if let Some(node_id) = destination.node_id() {
-            return node_id == &source.node_id;
         }
 
         false

--- a/comms/dht/src/outbound/requester.rs
+++ b/comms/dht/src/outbound/requester.rs
@@ -155,7 +155,7 @@ impl OutboundMessageRequester {
     /// Use this strategy to broadcast a message destined for a particular peer.
     pub async fn closest_broadcast<T>(
         &mut self,
-        destination_node_id: NodeId,
+        destination_public_key: CommsPublicKey,
         encryption: OutboundEncryption,
         exclude_peers: Vec<NodeId>,
         message: OutboundDomainMessage<T>,
@@ -165,9 +165,9 @@ impl OutboundMessageRequester {
     {
         self.send_message(
             SendMessageParams::new()
-                .closest(destination_node_id.clone(), exclude_peers)
+                .closest(NodeId::from_public_key(&destination_public_key), exclude_peers)
                 .with_encryption(encryption)
-                .with_destination(destination_node_id.into())
+                .with_destination(destination_public_key.into())
                 .finish(),
             message,
         )

--- a/comms/dht/src/proto/envelope.proto
+++ b/comms/dht/src/proto/envelope.proto
@@ -30,8 +30,6 @@ message DhtHeader {
         bool unknown = 3;
         // Destined for a particular public key
         bytes public_key = 4;
-        // Destined for a particular node id, or network region
-        bytes node_id = 5;
     }
 
     // Origin public key of the message. This can be the same peer that sent the message

--- a/comms/dht/src/store_forward/database/stored_message.rs
+++ b/comms/dht/src/store_forward/database/stored_message.rs
@@ -69,7 +69,10 @@ impl NewStoredMessage {
             origin_pubkey: authenticated_origin.as_ref().map(|pk| pk.to_hex()),
             message_type: dht_header.message_type as i32,
             destination_pubkey: dht_header.destination.public_key().map(|pk| pk.to_hex()),
-            destination_node_id: dht_header.destination.node_id().map(|node_id| node_id.to_hex()),
+            destination_node_id: dht_header
+                .destination
+                .to_derived_node_id()
+                .map(|node_id| node_id.to_hex()),
             is_encrypted: dht_header.flags.is_encrypted(),
             priority: priority as i32,
             header: {

--- a/comms/dht/src/store_forward/saf_handler/layer.rs
+++ b/comms/dht/src/store_forward/saf_handler/layer.rs
@@ -22,7 +22,7 @@
 
 use std::sync::Arc;
 
-use tari_comms::peer_manager::{NodeIdentity, PeerManager};
+use tari_comms::peer_manager::NodeIdentity;
 use tokio::sync::mpsc;
 use tower::layer::Layer;
 
@@ -38,7 +38,6 @@ pub struct MessageHandlerLayer {
     config: SafConfig,
     saf_requester: StoreAndForwardRequester,
     dht_requester: DhtRequester,
-    peer_manager: Arc<PeerManager>,
     node_identity: Arc<NodeIdentity>,
     outbound_service: OutboundMessageRequester,
     saf_response_signal_sender: mpsc::Sender<()>,
@@ -50,7 +49,6 @@ impl MessageHandlerLayer {
         saf_requester: StoreAndForwardRequester,
         dht_requester: DhtRequester,
         node_identity: Arc<NodeIdentity>,
-        peer_manager: Arc<PeerManager>,
         outbound_service: OutboundMessageRequester,
         saf_response_signal_sender: mpsc::Sender<()>,
     ) -> Self {
@@ -58,7 +56,6 @@ impl MessageHandlerLayer {
             config,
             saf_requester,
             dht_requester,
-            peer_manager,
             node_identity,
 
             outbound_service,
@@ -77,7 +74,6 @@ impl<S> Layer<S> for MessageHandlerLayer {
             self.saf_requester.clone(),
             self.dht_requester.clone(),
             Arc::clone(&self.node_identity),
-            Arc::clone(&self.peer_manager),
             self.outbound_service.clone(),
             self.saf_response_signal_sender.clone(),
         )

--- a/comms/dht/src/store_forward/saf_handler/middleware.rs
+++ b/comms/dht/src/store_forward/saf_handler/middleware.rs
@@ -23,10 +23,7 @@
 use std::{sync::Arc, task::Poll};
 
 use futures::{future::BoxFuture, task::Context};
-use tari_comms::{
-    peer_manager::{NodeIdentity, PeerManager},
-    pipeline::PipelineError,
-};
+use tari_comms::{peer_manager::NodeIdentity, pipeline::PipelineError};
 use tokio::sync::mpsc;
 use tower::Service;
 
@@ -44,7 +41,6 @@ pub struct MessageHandlerMiddleware<S> {
     next_service: S,
     saf_requester: StoreAndForwardRequester,
     dht_requester: DhtRequester,
-    peer_manager: Arc<PeerManager>,
     node_identity: Arc<NodeIdentity>,
     outbound_service: OutboundMessageRequester,
     saf_response_signal_sender: mpsc::Sender<()>,
@@ -57,7 +53,6 @@ impl<S> MessageHandlerMiddleware<S> {
         saf_requester: StoreAndForwardRequester,
         dht_requester: DhtRequester,
         node_identity: Arc<NodeIdentity>,
-        peer_manager: Arc<PeerManager>,
         outbound_service: OutboundMessageRequester,
         saf_response_signal_sender: mpsc::Sender<()>,
     ) -> Self {
@@ -66,7 +61,6 @@ impl<S> MessageHandlerMiddleware<S> {
             next_service,
             saf_requester,
             dht_requester,
-            peer_manager,
             node_identity,
 
             outbound_service,
@@ -95,7 +89,6 @@ where
                 self.next_service.clone(),
                 self.saf_requester.clone(),
                 self.dht_requester.clone(),
-                Arc::clone(&self.peer_manager),
                 self.outbound_service.clone(),
                 Arc::clone(&self.node_identity),
                 message,

--- a/comms/dht/src/store_forward/saf_handler/task.rs
+++ b/comms/dht/src/store_forward/saf_handler/task.rs
@@ -31,7 +31,7 @@ use log::*;
 use prost::Message;
 use tari_comms::{
     message::{EnvelopeBody, MessageTag},
-    peer_manager::{NodeId, NodeIdentity, Peer, PeerFeatures, PeerManager, PeerManagerError},
+    peer_manager::{NodeId, NodeIdentity, Peer, PeerFeatures, PeerManagerError},
     pipeline::PipelineError,
     types::CommsPublicKey,
 };
@@ -71,7 +71,6 @@ pub struct MessageHandlerTask<S> {
     config: SafConfig,
     next_service: S,
     dht_requester: DhtRequester,
-    peer_manager: Arc<PeerManager>,
     outbound_service: OutboundMessageRequester,
     node_identity: Arc<NodeIdentity>,
     message: Option<DecryptedDhtMessage>,
@@ -87,7 +86,6 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
         next_service: S,
         saf_requester: StoreAndForwardRequester,
         dht_requester: DhtRequester,
-        peer_manager: Arc<PeerManager>,
         outbound_service: OutboundMessageRequester,
         node_identity: Arc<NodeIdentity>,
         message: DecryptedDhtMessage,
@@ -98,7 +96,6 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
             saf_requester,
             dht_requester,
             next_service,
-            peer_manager,
             outbound_service,
             node_identity,
             message: Some(message),
@@ -426,8 +423,6 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
         message: ProtoStoredMessage,
     ) -> Result<(DecryptedDhtMessage, DateTime<Utc>), StoreAndForwardError> {
         let node_identity = &self.node_identity;
-        let peer_manager = &self.peer_manager;
-        let config = &self.config;
         if message.dht_header.is_none() {
             return Err(StoreAndForwardError::DhtHeaderNotProvided);
         }
@@ -489,7 +484,7 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
         }
 
         // Check that the destination is either undisclosed, for us or for our network region
-        Self::check_destination(config, peer_manager, node_identity, &dht_header).await?;
+        Self::check_destination(node_identity, &dht_header).await?;
 
         // Attempt to decrypt the message (if applicable), and deserialize it
         let (authenticated_pk, decrypted_body) =
@@ -527,20 +522,12 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
     }
 
     async fn check_destination(
-        config: &SafConfig,
-        peer_manager: &PeerManager,
         node_identity: &NodeIdentity,
         dht_header: &DhtMessageHeader,
     ) -> Result<(), StoreAndForwardError> {
         let is_valid_destination = match &dht_header.destination {
             NodeDestination::Unknown => true,
             NodeDestination::PublicKey(pk) => node_identity.public_key() == &**pk,
-            // Pass this check if the node id equals ours or is in this node's region
-            NodeDestination::NodeId(node_id) if node_identity.node_id() == &**node_id => true,
-            NodeDestination::NodeId(node_id) => peer_manager
-                .in_network_region(node_identity.node_id(), node_id, config.num_neighbouring_nodes)
-                .await
-                .unwrap_or(false),
         };
 
         if is_valid_destination {
@@ -691,7 +678,6 @@ mod test {
         let spy = service_spy();
         let (requester, mock_state) = create_store_and_forward_mock();
 
-        let peer_manager = build_peer_manager();
         let (outbound_requester, outbound_mock) = create_outbound_service_mock(10);
         let oms_mock_state = outbound_mock.get_state();
         task::spawn(outbound_mock.run());
@@ -737,7 +723,6 @@ mod test {
             spy.to_service::<PipelineError>(),
             requester.clone(),
             dht_requester.clone(),
-            peer_manager.clone(),
             outbound_requester.clone(),
             node_identity.clone(),
             message.clone(),
@@ -795,7 +780,6 @@ mod test {
             spy.to_service::<PipelineError>(),
             requester,
             dht_requester,
-            peer_manager,
             outbound_requester.clone(),
             node_identity.clone(),
             message,
@@ -924,7 +908,6 @@ mod test {
             spy.to_service::<PipelineError>(),
             saf_requester,
             dht_requester.clone(),
-            peer_manager,
             OutboundMessageRequester::new(oms_tx),
             node_identity,
             message,
@@ -1011,7 +994,6 @@ mod test {
             spy.to_service::<PipelineError>(),
             requester,
             dht_requester.clone(),
-            peer_manager,
             OutboundMessageRequester::new(oms_tx),
             node_identity,
             message,
@@ -1085,7 +1067,6 @@ mod test {
             spy.to_service::<PipelineError>(),
             saf_requester.clone(),
             dht_requester.clone(),
-            peer_manager.clone(),
             OutboundMessageRequester::new(oms_tx.clone()),
             node_identity.clone(),
             message.clone(),
@@ -1106,7 +1087,6 @@ mod test {
             spy.to_service::<PipelineError>(),
             saf_requester,
             dht_requester,
-            peer_manager,
             OutboundMessageRequester::new(oms_tx),
             node_identity,
             message,

--- a/comms/dht/src/store_forward/store.rs
+++ b/comms/dht/src/store_forward/store.rs
@@ -372,9 +372,7 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError> + Se
         let peer_manager = &self.peer_manager;
         let node_identity = &self.node_identity;
 
-        if message.dht_header.destination == node_identity.public_key() ||
-            message.dht_header.destination == node_identity.node_id()
-        {
+        if message.dht_header.destination == node_identity.public_key() {
             log_not_eligible("the message is destined for this node");
             return Ok(None);
         }

--- a/comms/dht/tests/dht.rs
+++ b/comms/dht/tests/dht.rs
@@ -358,7 +358,7 @@ async fn dht_discover_propagation() {
         .discovery_service_requester()
         .discover_peer(
             node_D.node_identity().public_key().clone(),
-            node_D.node_identity().node_id().clone().into(),
+            node_D.node_identity().public_key().clone().into(),
         )
         .await
         .unwrap();
@@ -409,7 +409,7 @@ async fn dht_store_forward() {
         .with_encryption(OutboundEncryption::encrypt_for(
             node_C_node_identity.public_key().clone(),
         ))
-        .with_destination(node_C_node_identity.node_id().clone().into())
+        .with_destination(node_C_node_identity.public_key().clone().into())
         .finish();
 
     let secret_msg1 = b"NCZW VUSX PNYM INHZ XMQX SFWX WLKJ AHSH";
@@ -573,7 +573,7 @@ async fn dht_propagate_dedup() {
         .dht
         .outbound_requester()
         .propagate(
-            node_D.node_identity().node_id().clone().into(),
+            node_D.node_identity().public_key().clone().into(),
             OutboundEncryption::encrypt_for(node_D.node_identity().public_key().clone()),
             vec![],
             out_msg,
@@ -962,7 +962,7 @@ async fn dht_propagate_message_contents_not_malleable_ban() {
         .send_message_no_header(
             SendMessageParams::new()
                 .direct_node_id(node_B.node_identity().node_id().clone())
-                .with_destination(node_A.node_identity().node_id().clone().into())
+                .with_destination(node_A.node_identity().public_key().clone().into())
                 .with_encryption(OutboundEncryption::ClearText)
                 .force_origin()
                 .finish(),
@@ -985,7 +985,7 @@ async fn dht_propagate_message_contents_not_malleable_ban() {
         .outbound_requester()
         .send_raw(
             SendMessageParams::new()
-                .propagate(node_B.node_identity().node_id().clone().into(), vec![msg
+                .propagate(node_B.node_identity().public_key().clone().into(), vec![msg
                     .source_peer
                     .node_id
                     .clone()])
@@ -1068,7 +1068,7 @@ async fn dht_header_not_malleable() {
         .send_message_no_header(
             SendMessageParams::new()
                 .direct_node_id(node_B.node_identity().node_id().clone())
-                .with_destination(node_A.node_identity().node_id().clone().into())
+                .with_destination(node_A.node_identity().public_key().clone().into())
                 .with_encryption(OutboundEncryption::ClearText)
                 .force_origin()
                 .finish(),
@@ -1091,7 +1091,7 @@ async fn dht_header_not_malleable() {
         .outbound_requester()
         .send_raw(
             SendMessageParams::new()
-                .propagate(node_B.node_identity().node_id().clone().into(), vec![msg
+                .propagate(node_B.node_identity().public_key().clone().into(), vec![msg
                     .source_peer
                     .node_id
                     .clone()])

--- a/integration_tests/helpers/baseNodeClient.js
+++ b/integration_tests/helpers/baseNodeClient.js
@@ -44,7 +44,7 @@ class BaseNodeClient {
 
   getHeaderAt(height) {
     return this.getHeaders(height, 1).then((header) =>
-      header && header.length ? header[0].header : null
+      header && header.length ? header[0] : null
     );
   }
 
@@ -66,7 +66,7 @@ class BaseNodeClient {
 
   getTipHeader() {
     return this.getHeaders(0, 1).then((headers) => {
-      const header = headers[0].header;
+      const header = headers[0];
       return Object.assign(header, {
         height: +header.height,
       });


### PR DESCRIPTION
Description
---
- removes NodeId destination variant from DHT protocol
- use public key destination for join message
- use public key destination for wallet-to-wallet transaction messages

Motivation and Context
---
Ref https://github.com/tari-project/tari/issues/4139 - because any node id can be used the recipient is not necessarily bound in the signature.
NodeId destination was not particularly useful and not required for messaging. It was used for DHT join messages and wallet-to-wallet transaction messages. 

How Has This Been Tested?
---
Existing tests updated and pass
Memorynet passes
Cucumber tests pass
Manually, sending a transaction via SAF