### PR TITLE
fix: update rest of the crates to tokio 1.20

### DIFF
--- a/applications/tari_console_wallet/Cargo.toml
+++ b/applications/tari_console_wallet/Cargo.toml
@@ -22,9 +22,9 @@ tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", t
 
 # Uncomment for tokio tracing via tokio-console (needs "tracing" featurs)
 #console-subscriber = "0.1.3"
-#tokio = { version = "1.14", features = ["signal", "tracing"] }
+#tokio = { version = "1.20", features = ["signal", "tracing"] }
 # Uncomment for normal use (non tokio-console tracing)
-tokio = { version = "1.14", default-features = false, features = ["signal", "sync"] }
+tokio = { version = "1.20", default-features = false, features = ["signal", "sync"] }
 
 base64 = "0.13.0"
 bitflags = "1.2.1"

--- a/base_layer/service_framework/Cargo.toml
+++ b/base_layer/service_framework/Cargo.toml
@@ -17,12 +17,12 @@ async-trait = "0.1.50"
 futures = { version = "^0.3.16", features = ["async-await"] }
 log = "0.4.8"
 thiserror = "1.0.26"
-tokio = { version = "1.14", features = ["rt"] }
+tokio = { version = "1.20", features = ["rt"] }
 tower-service = { version = "0.3" }
 
 [dev-dependencies]
 tari_test_utils = { version = "^0.37", path = "../../infrastructure/test_utils" }
 
-tokio = { version = "1.14", features = ["rt-multi-thread", "macros", "time"] }
+tokio = { version = "1.20", features = ["rt-multi-thread", "macros", "time"] }
 futures-test = { version = "0.3.3" }
 tower = "0.4"

--- a/base_layer/wallet/Cargo.toml
+++ b/base_layer/wallet/Cargo.toml
@@ -23,9 +23,9 @@ tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", t
 
 # Uncomment for tokio tracing via tokio-console (needs "tracing" featurs)
 #console-subscriber = "0.1.3"
-#tokio = { version = "1.14", features = ["sync", "macros", "tracing"] }
+#tokio = { version = "1.20", features = ["sync", "macros", "tracing"] }
 # Uncomment for normal use (non tokio-console tracing)
-tokio = { version = "1.14", features = ["sync", "macros"] }
+tokio = { version = "1.20", features = ["sync", "macros"] }
 
 async-trait = "0.1.50"
 argon2 = "0.2"

--- a/comms/core/Cargo.toml
+++ b/comms/core/Cargo.toml
@@ -44,7 +44,7 @@ serde = "1.0.119"
 serde_derive = "1.0.119"
 snow = { version = "=0.8.0", features = ["default-resolver"] }
 thiserror = "1.0.26"
-tokio = { version = "1.14", features = ["rt-multi-thread", "time", "sync", "signal", "net", "macros", "io-util"] }
+tokio = { version = "1.20", features = ["rt-multi-thread", "time", "sync", "signal", "net", "macros", "io-util"] }
 tokio-stream = { version = "0.1.9", features = ["sync"] }
 tokio-util = { version = "0.6.7", features = ["codec", "compat"] }
 tower = {version = "0.4", features = ["util"]}

--- a/comms/dht/Cargo.toml
+++ b/comms/dht/Cargo.toml
@@ -43,9 +43,9 @@ zeroize = "1.4.0"
 
 # Uncomment for tokio tracing via tokio-console (needs "tracing" features)
 #console-subscriber = "0.1.3"
-#tokio = { version = "1.14", features = ["rt", "macros", "tracing"] }
+#tokio = { version = "1.20", features = ["rt", "macros", "tracing"] }
 # Uncomment for normal use (non tokio-console tracing)
-tokio = { version = "1.14", features = ["rt", "macros"] }
+tokio = { version = "1.20", features = ["rt", "macros"] }
 
 # tower-filter dependencies
 pin-project = "0.4"

--- a/infrastructure/metrics/Cargo.toml
+++ b/infrastructure/metrics/Cargo.toml
@@ -16,7 +16,7 @@ prometheus = "0.13.0"
 
 futures = { version = "0.3.15", default-features = false, optional = true }
 reqwest = { version = "0.11.4", default-features = false, optional = true }
-tokio = { version = "1.7.1", optional = true, features = ["time", "rt-multi-thread"] }
+tokio = { version = "1", optional = true, features = ["time", "rt-multi-thread"] }
 warp = { version = "0.3.1", optional = true, default-features = false }
 thiserror = "1.0.25"
 anyhow = { version = "1.0.53", optional = true }


### PR DESCRIPTION
Description
---
- updates remaining crates to 1.20

Motivation and Context
---
Some crates used 1.10 and others 1.14 - search and replace missed 1.14

How Has This Been Tested?
---
Search for all tokio deps and make sure they are set to 1.20
