### PR TITLE
fix: coinbase handling

### DIFF
--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -1410,9 +1410,9 @@ where
         let chain_metadata = self.base_node_service.get_chain_metadata().await?;
 
         // Respecting the setting to not choose outputs that reveal the address
-      if self.resources.config.autoignore_onesided_utxos {
-          selection_criteria.excluding_onesided = self.resources.config.autoignore_onesided_utxos;
-          }
+        if self.resources.config.autoignore_onesided_utxos {
+            selection_criteria.excluding_onesided = self.resources.config.autoignore_onesided_utxos;
+        }
 
         warn!(
             target: LOG_TARGET,

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -2528,12 +2528,6 @@ where
                     .output_manager_service
                     .get_coinbase_transaction(tx_id, reward, fees, block_height)
                     .await?;
-
-                // Cancel existing unmined coinbase transactions for this blockheight
-                self.db
-                    .cancel_coinbase_transaction_at_block_height(block_height)
-                    .await?;
-
                 self.db
                     .insert_completed_transaction(
                         tx_id,


### PR DESCRIPTION
Description
---
A race condition exists if more than one miner asks for a coinbase with different values.  The first transaction will be canceled by the second one. Coinbase transactions should only ever be canceled by the validation process after confirming they have not been mined. 
