### PR TITLE
fix: cleanup logs

### DIFF
--- a/base_layer/core/src/mempool/mempool_storage.rs
+++ b/base_layer/core/src/mempool/mempool_storage.rs
@@ -96,12 +96,12 @@ impl MempoolStorage {
                     self.unconfirmed_pool.insert(tx, Some(dependent_outputs), &weight)?;
                     Ok(TxStorageResponse::UnconfirmedPool)
                 } else {
-                    warn!(target: LOG_TARGET, "Validation failed due to unknown inputs");
+                    debug!(target: LOG_TARGET, "Validation failed due to unknown inputs");
                     Ok(TxStorageResponse::NotStoredOrphan)
                 }
             },
             Err(ValidationError::ContainsSTxO) => {
-                warn!(target: LOG_TARGET, "Validation failed due to already spent output");
+                debug!(target: LOG_TARGET, "Validation failed due to already spent output");
                 Ok(TxStorageResponse::NotStoredAlreadySpent)
             },
             Err(ValidationError::MaturityError) => {


### PR DESCRIPTION
Description
---
Both wallets submit transactions. This means that for every tx created at least 1 warn!(target: LOG_TARGET, "Validation failed due to unknown inputs" will be created. This reduces the log level for this so that it does not popup by default. 
