### PR TITLE
feat: make wallet db storage calls synchronous rather than async

### DIFF
--- a/applications/tari_console_wallet/src/automation/commands.rs
+++ b/applications/tari_console_wallet/src/automation/commands.rs
@@ -704,23 +704,17 @@ pub async fn command_runner(
                     set_base_node_peer(wallet.clone(), args.public_key.into(), args.address).await?;
                 wallet
                     .db
-                    .set_client_key_value(CUSTOM_BASE_NODE_PUBLIC_KEY_KEY.to_string(), public_key.to_string())
-                    .await?;
+                    .set_client_key_value(CUSTOM_BASE_NODE_PUBLIC_KEY_KEY.to_string(), public_key.to_string())?;
                 wallet
                     .db
-                    .set_client_key_value(CUSTOM_BASE_NODE_ADDRESS_KEY.to_string(), net_address.to_string())
-                    .await?;
+                    .set_client_key_value(CUSTOM_BASE_NODE_ADDRESS_KEY.to_string(), net_address.to_string())?;
                 println!("Custom base node peer saved in wallet database.");
             },
             ClearCustomBaseNode => {
                 wallet
                     .db
-                    .clear_client_value(CUSTOM_BASE_NODE_PUBLIC_KEY_KEY.to_string())
-                    .await?;
-                wallet
-                    .db
-                    .clear_client_value(CUSTOM_BASE_NODE_ADDRESS_KEY.to_string())
-                    .await?;
+                    .clear_client_value(CUSTOM_BASE_NODE_PUBLIC_KEY_KEY.to_string())?;
+                wallet.db.clear_client_value(CUSTOM_BASE_NODE_ADDRESS_KEY.to_string())?;
                 println!("Custom base node peer cleared from wallet database.");
             },
             InitShaAtomicSwap(args) => {

--- a/applications/tari_console_wallet/src/init/mod.rs
+++ b/applications/tari_console_wallet/src/init/mod.rs
@@ -158,7 +158,7 @@ pub async fn get_base_node_peer_config(
         Some(ref custom) => SeedPeer::from_str(custom)
             .map(|node| Some(Peer::from(node)))
             .map_err(|err| ExitError::new(ExitCode::ConfigError, &format!("Malformed custom base node: {}", err)))?,
-        None => get_custom_base_node_peer_from_db(wallet).await,
+        None => get_custom_base_node_peer_from_db(wallet),
     };
 
     // If the user has not explicitly set a base node in the config, we try detect one
@@ -181,7 +181,7 @@ pub async fn get_base_node_peer_config(
                         let address = detected_node.addresses.first().ok_or_else(|| {
                             ExitError::new(ExitCode::ConfigError, "No address found for detected base node")
                         })?;
-                        set_custom_base_node_peer_in_db(wallet, &detected_node.public_key, address).await?;
+                        set_custom_base_node_peer_in_db(wallet, &detected_node.public_key, address)?;
                         selected_base_node = Some(detected_node.into());
                     }
                 },
@@ -293,13 +293,13 @@ pub async fn init_wallet(
 
     let node_address = match config.wallet.p2p.public_address.clone() {
         Some(addr) => addr,
-        None => match wallet_db.get_node_address().await? {
+        None => match wallet_db.get_node_address()? {
             Some(addr) => addr,
             None => Multiaddr::empty(),
         },
     };
 
-    let master_seed = read_or_create_master_seed(recovery_seed.clone(), &wallet_db).await?;
+    let master_seed = read_or_create_master_seed(recovery_seed.clone(), &wallet_db)?;
 
     let node_identity = match config.wallet.identity_file.as_ref() {
         Some(identity_file) => {
@@ -315,12 +315,12 @@ pub async fn init_wallet(
                 PeerFeatures::COMMUNICATION_CLIENT,
             )?
         },
-        None => setup_identity_from_db(&wallet_db, &master_seed, node_address.clone()).await?,
+        None => setup_identity_from_db(&wallet_db, &master_seed, node_address.clone())?,
     };
 
     let mut wallet_config = config.wallet.clone();
     if let TransportType::Tor = config.wallet.p2p.transport.transport_type {
-        wallet_config.p2p.transport.tor.identity = wallet_db.get_tor_id().await?;
+        wallet_config.p2p.transport.tor.identity = wallet_db.get_tor_id()?;
     }
 
     let factories = CryptoFactories::default();
@@ -352,7 +352,6 @@ pub async fn init_wallet(
         wallet
             .db
             .set_tor_identity(hs.tor_identity().clone())
-            .await
             .map_err(|e| ExitError::new(ExitCode::WalletError, format!("Problem writing tor identity. {}", e)))?;
     }
 
@@ -381,7 +380,7 @@ pub async fn init_wallet(
         debug!(target: LOG_TARGET, "Wallet encrypted.");
 
         if interactive && recovery_seed.is_none() {
-            match confirm_seed_words(&mut wallet).await {
+            match confirm_seed_words(&mut wallet) {
                 Ok(()) => {
                     print!("\x1Bc"); // Clear the screen
                 },
@@ -392,7 +391,7 @@ pub async fn init_wallet(
         }
     }
     if let Some(file_name) = seed_words_file_name {
-        let seed_words = wallet.get_seed_words(&MnemonicLanguage::English).await?.join(" ");
+        let seed_words = wallet.get_seed_words(&MnemonicLanguage::English)?.join(" ");
         let _result = fs::write(file_name, seed_words).map_err(|e| {
             ExitError::new(
                 ExitCode::WalletError,
@@ -416,17 +415,16 @@ async fn detect_local_base_node() -> Option<SeedPeer> {
     Some(SeedPeer::new(public_key, vec![address]))
 }
 
-async fn setup_identity_from_db<D: WalletBackend + 'static>(
+fn setup_identity_from_db<D: WalletBackend + 'static>(
     wallet_db: &WalletDatabase<D>,
     master_seed: &CipherSeed,
     node_address: Multiaddr,
 ) -> Result<Arc<NodeIdentity>, ExitError> {
     let node_features = wallet_db
-        .get_node_features()
-        .await?
+        .get_node_features()?
         .unwrap_or(PeerFeatures::COMMUNICATION_CLIENT);
 
-    let identity_sig = wallet_db.get_comms_identity_signature().await?;
+    let identity_sig = wallet_db.get_comms_identity_signature()?;
 
     let comms_secret_key = derive_comms_secret_key(master_seed)?;
 
@@ -452,7 +450,7 @@ async fn setup_identity_from_db<D: WalletBackend + 'static>(
             .as_ref()
             .expect("unreachable panic")
             .clone();
-        wallet_db.set_comms_identity_signature(sig).await?;
+        wallet_db.set_comms_identity_signature(sig)?;
     }
 
     Ok(node_identity)
@@ -514,8 +512,8 @@ async fn validate_txos(wallet: &mut WalletSqlite) -> Result<(), ExitError> {
     Ok(())
 }
 
-async fn confirm_seed_words(wallet: &mut WalletSqlite) -> Result<(), ExitError> {
-    let seed_words = wallet.get_seed_words(&MnemonicLanguage::English).await?;
+fn confirm_seed_words(wallet: &mut WalletSqlite) -> Result<(), ExitError> {
+    let seed_words = wallet.get_seed_words(&MnemonicLanguage::English)?;
 
     println!();
     println!("=========================");

--- a/applications/tari_console_wallet/src/main.rs
+++ b/applications/tari_console_wallet/src/main.rs
@@ -167,7 +167,7 @@ fn main_inner() -> Result<(), ExitError> {
     ))?;
 
     // Check if there is an in progress recovery in the wallet's database
-    if runtime.block_on(wallet.is_recovery_in_progress())? {
+    if wallet.is_recovery_in_progress()? {
         println!("A Wallet Recovery was found to be in progress, continuing.");
         boot_mode = WalletBoot::Recovery;
     }

--- a/applications/tari_console_wallet/src/ui/state/app_state.rs
+++ b/applications/tari_console_wallet/src/ui/state/app_state.rs
@@ -892,15 +892,11 @@ impl AppStateInner {
         // persist the custom node in wallet db
         self.wallet
             .db
-            .set_client_key_value(CUSTOM_BASE_NODE_PUBLIC_KEY_KEY.to_string(), peer.public_key.to_string())
-            .await?;
-        self.wallet
-            .db
-            .set_client_key_value(
-                CUSTOM_BASE_NODE_ADDRESS_KEY.to_string(),
-                peer.addresses.first().ok_or(UiError::NoAddress)?.to_string(),
-            )
-            .await?;
+            .set_client_key_value(CUSTOM_BASE_NODE_PUBLIC_KEY_KEY.to_string(), peer.public_key.to_string())?;
+        self.wallet.db.set_client_key_value(
+            CUSTOM_BASE_NODE_ADDRESS_KEY.to_string(),
+            peer.addresses.first().ok_or(UiError::NoAddress)?.to_string(),
+        )?;
         info!(
             target: LOG_TARGET,
             "Setting custom base node peer for wallet: {}::{}",
@@ -931,12 +927,10 @@ impl AppStateInner {
         // clear from wallet db
         self.wallet
             .db
-            .clear_client_value(CUSTOM_BASE_NODE_PUBLIC_KEY_KEY.to_string())
-            .await?;
+            .clear_client_value(CUSTOM_BASE_NODE_PUBLIC_KEY_KEY.to_string())?;
         self.wallet
             .db
-            .clear_client_value(CUSTOM_BASE_NODE_ADDRESS_KEY.to_string())
-            .await?;
+            .clear_client_value(CUSTOM_BASE_NODE_ADDRESS_KEY.to_string())?;
         Ok(())
     }
 

--- a/applications/tari_console_wallet/src/utils/db.rs
+++ b/applications/tari_console_wallet/src/utils/db.rs
@@ -36,11 +36,10 @@ pub const CUSTOM_BASE_NODE_ADDRESS_KEY: &str = "console_wallet_custom_base_node_
 
 /// This helper function will attempt to read a stored base node public key and address from the wallet database.
 /// If both are found they are used to construct and return a Peer.
-pub async fn get_custom_base_node_peer_from_db(wallet: &mut WalletSqlite) -> Option<Peer> {
+pub fn get_custom_base_node_peer_from_db(wallet: &mut WalletSqlite) -> Option<Peer> {
     let custom_base_node_peer_pubkey = match wallet
         .db
         .get_client_key_value(CUSTOM_BASE_NODE_PUBLIC_KEY_KEY.to_string())
-        .await
     {
         Ok(val) => val,
         Err(e) => {
@@ -48,11 +47,7 @@ pub async fn get_custom_base_node_peer_from_db(wallet: &mut WalletSqlite) -> Opt
             return None;
         },
     };
-    let custom_base_node_peer_address = match wallet
-        .db
-        .get_client_key_value(CUSTOM_BASE_NODE_ADDRESS_KEY.to_string())
-        .await
-    {
+    let custom_base_node_peer_address = match wallet.db.get_client_key_value(CUSTOM_BASE_NODE_ADDRESS_KEY.to_string()) {
         Ok(val) => val,
         Err(e) => {
             warn!(target: LOG_TARGET, "Problem reading from wallet database: {}", e);
@@ -91,23 +86,19 @@ pub async fn get_custom_base_node_peer_from_db(wallet: &mut WalletSqlite) -> Opt
 }
 
 /// Sets the base node peer in the database
-pub async fn set_custom_base_node_peer_in_db(
+pub fn set_custom_base_node_peer_in_db(
     wallet: &mut WalletSqlite,
     base_node_public_key: &CommsPublicKey,
     base_node_address: &Multiaddr,
 ) -> Result<(), WalletStorageError> {
-    wallet
-        .db
-        .set_client_key_value(
-            CUSTOM_BASE_NODE_PUBLIC_KEY_KEY.to_string(),
-            base_node_public_key.to_hex(),
-        )
-        .await?;
+    wallet.db.set_client_key_value(
+        CUSTOM_BASE_NODE_PUBLIC_KEY_KEY.to_string(),
+        base_node_public_key.to_hex(),
+    )?;
 
     wallet
         .db
-        .set_client_key_value(CUSTOM_BASE_NODE_ADDRESS_KEY.to_string(), base_node_address.to_string())
-        .await?;
+        .set_client_key_value(CUSTOM_BASE_NODE_ADDRESS_KEY.to_string(), base_node_address.to_string())?;
 
     Ok(())
 }

--- a/applications/tari_console_wallet/src/wallet_modes.rs
+++ b/applications/tari_console_wallet/src/wallet_modes.rs
@@ -282,7 +282,7 @@ pub fn tui_mode(
     let base_node_selected;
     if let Some(peer) = base_node_config.base_node_custom.clone() {
         base_node_selected = peer;
-    } else if let Some(peer) = handle.block_on(get_custom_base_node_peer_from_db(&mut wallet)) {
+    } else if let Some(peer) = get_custom_base_node_peer_from_db(&mut wallet) {
         base_node_selected = peer;
     } else if let Some(peer) = handle.block_on(wallet.get_base_node_peer()) {
         base_node_selected = peer;

--- a/base_layer/wallet/src/base_node_service/monitor.rs
+++ b/base_layer/wallet/src/base_node_service/monitor.rs
@@ -163,7 +163,7 @@ where
                 timer.elapsed().as_millis()
             );
 
-            self.db.set_chain_metadata(chain_metadata.clone()).await?;
+            self.db.set_chain_metadata(chain_metadata.clone())?;
 
             let is_synced = tip_info.is_synced;
             let height_of_longest_chain = chain_metadata.height_of_longest_chain();

--- a/base_layer/wallet/src/base_node_service/service.rs
+++ b/base_layer/wallet/src/base_node_service/service.rs
@@ -150,11 +150,11 @@ where T: WalletBackend + 'static
             "Handling Wallet Base Node Service Request: {:?}", request
         );
         match request {
-            BaseNodeServiceRequest::GetChainMetadata => match self.get_state().await.chain_metadata.clone() {
+            BaseNodeServiceRequest::GetChainMetadata => match self.get_state().await.chain_metadata {
                 Some(metadata) => Ok(BaseNodeServiceResponse::ChainMetadata(Some(metadata))),
                 None => {
                     // if we don't have live state, check if we've previously stored state in the wallet db
-                    let metadata = self.db.get_chain_metadata().await?;
+                    let metadata = self.db.get_chain_metadata()?;
                     Ok(BaseNodeServiceResponse::ChainMetadata(metadata))
                 },
             },

--- a/base_layer/wallet/src/storage/database.rs
+++ b/base_layer/wallet/src/storage/database.rs
@@ -121,218 +121,143 @@ where T: WalletBackend + 'static
         Self { db: Arc::new(db) }
     }
 
-    pub async fn get_master_seed(&self) -> Result<Option<CipherSeed>, WalletStorageError> {
-        let db_clone = self.db.clone();
-
-        let c = tokio::task::spawn_blocking(move || match db_clone.fetch(&DbKey::MasterSeed) {
+    pub fn get_master_seed(&self) -> Result<Option<CipherSeed>, WalletStorageError> {
+        let c = match self.db.fetch(&DbKey::MasterSeed) {
             Ok(None) => Ok(None),
             Ok(Some(DbValue::MasterSeed(k))) => Ok(Some(k)),
             Ok(Some(other)) => unexpected_result(DbKey::MasterSeed, other),
             Err(e) => log_error(DbKey::MasterSeed, e),
-        })
-        .await
-        .map_err(|err| WalletStorageError::BlockingTaskSpawnError(err.to_string()))??;
+        }?;
         Ok(c)
     }
 
-    pub async fn set_master_seed(&self, seed: CipherSeed) -> Result<(), WalletStorageError> {
-        let db_clone = self.db.clone();
-
-        tokio::task::spawn_blocking(move || db_clone.write(WriteOperation::Insert(DbKeyValuePair::MasterSeed(seed))))
-            .await
-            .map_err(|err| WalletStorageError::BlockingTaskSpawnError(err.to_string()))??;
+    pub fn set_master_seed(&self, seed: CipherSeed) -> Result<(), WalletStorageError> {
+        self.db
+            .write(WriteOperation::Insert(DbKeyValuePair::MasterSeed(seed)))?;
         Ok(())
     }
 
-    pub async fn clear_master_seed(&self) -> Result<(), WalletStorageError> {
-        let db_clone = self.db.clone();
-        tokio::task::spawn_blocking(move || db_clone.write(WriteOperation::Remove(DbKey::MasterSeed)))
-            .await
-            .map_err(|err| WalletStorageError::BlockingTaskSpawnError(err.to_string()))??;
+    pub fn clear_master_seed(&self) -> Result<(), WalletStorageError> {
+        self.db.write(WriteOperation::Remove(DbKey::MasterSeed))?;
         Ok(())
     }
 
-    pub async fn get_tor_id(&self) -> Result<Option<TorIdentity>, WalletStorageError> {
-        let db_clone = self.db.clone();
-
-        let c = tokio::task::spawn_blocking(move || match db_clone.fetch(&DbKey::TorId) {
+    pub fn get_tor_id(&self) -> Result<Option<TorIdentity>, WalletStorageError> {
+        let c = match self.db.fetch(&DbKey::TorId) {
             Ok(None) => Ok(None),
             Ok(Some(DbValue::TorId(k))) => Ok(Some(k)),
             Ok(Some(other)) => unexpected_result(DbKey::TorId, other),
             Err(e) => log_error(DbKey::TorId, e),
-        })
-        .await
-        .map_err(|err| WalletStorageError::BlockingTaskSpawnError(err.to_string()))??;
+        }?;
         Ok(c)
     }
 
-    pub async fn set_tor_identity(&self, id: TorIdentity) -> Result<(), WalletStorageError> {
-        let db_clone = self.db.clone();
-
-        tokio::task::spawn_blocking(move || db_clone.write(WriteOperation::Insert(DbKeyValuePair::TorId(id))))
-            .await
-            .map_err(|err| WalletStorageError::BlockingTaskSpawnError(err.to_string()))??;
+    pub fn set_tor_identity(&self, id: TorIdentity) -> Result<(), WalletStorageError> {
+        self.db.write(WriteOperation::Insert(DbKeyValuePair::TorId(id)))?;
         Ok(())
     }
 
-    pub async fn get_node_address(&self) -> Result<Option<Multiaddr>, WalletStorageError> {
-        let db_clone = self.db.clone();
-
-        let c = tokio::task::spawn_blocking(move || match db_clone.fetch(&DbKey::CommsAddress) {
+    pub fn get_node_address(&self) -> Result<Option<Multiaddr>, WalletStorageError> {
+        let c = match self.db.fetch(&DbKey::CommsAddress) {
             Ok(None) => Ok(None),
             Ok(Some(DbValue::CommsAddress(k))) => Ok(Some(k)),
             Ok(Some(other)) => unexpected_result(DbKey::CommsAddress, other),
             Err(e) => log_error(DbKey::CommsAddress, e),
-        })
-        .await
-        .map_err(|err| WalletStorageError::BlockingTaskSpawnError(err.to_string()))??;
+        }?;
         Ok(c)
     }
 
-    pub async fn set_node_address(&self, address: Multiaddr) -> Result<(), WalletStorageError> {
-        let db_clone = self.db.clone();
-
-        tokio::task::spawn_blocking(move || {
-            db_clone.write(WriteOperation::Insert(DbKeyValuePair::CommsAddress(address)))
-        })
-        .await
-        .map_err(|err| WalletStorageError::BlockingTaskSpawnError(err.to_string()))??;
+    pub fn set_node_address(&self, address: Multiaddr) -> Result<(), WalletStorageError> {
+        self.db
+            .write(WriteOperation::Insert(DbKeyValuePair::CommsAddress(address)))?;
         Ok(())
     }
 
-    pub async fn get_node_features(&self) -> Result<Option<PeerFeatures>, WalletStorageError> {
-        let db_clone = self.db.clone();
-
-        let c = tokio::task::spawn_blocking(move || match db_clone.fetch(&DbKey::CommsFeatures) {
+    pub fn get_node_features(&self) -> Result<Option<PeerFeatures>, WalletStorageError> {
+        let c = match self.db.fetch(&DbKey::CommsFeatures) {
             Ok(None) => Ok(None),
             Ok(Some(DbValue::CommsFeatures(k))) => Ok(Some(k)),
             Ok(Some(other)) => unexpected_result(DbKey::CommsFeatures, other),
             Err(e) => log_error(DbKey::CommsFeatures, e),
-        })
-        .await
-        .map_err(|err| WalletStorageError::BlockingTaskSpawnError(err.to_string()))??;
+        }?;
         Ok(c)
     }
 
-    pub async fn set_node_features(&self, features: PeerFeatures) -> Result<(), WalletStorageError> {
-        let db_clone = self.db.clone();
-
-        tokio::task::spawn_blocking(move || {
-            db_clone.write(WriteOperation::Insert(DbKeyValuePair::CommsFeatures(features)))
-        })
-        .await
-        .map_err(|err| WalletStorageError::BlockingTaskSpawnError(err.to_string()))??;
+    pub fn set_node_features(&self, features: PeerFeatures) -> Result<(), WalletStorageError> {
+        self.db
+            .write(WriteOperation::Insert(DbKeyValuePair::CommsFeatures(features)))?;
         Ok(())
     }
 
-    pub async fn get_comms_identity_signature(&self) -> Result<Option<IdentitySignature>, WalletStorageError> {
-        let db = self.db.clone();
-
-        let sig = tokio::task::spawn_blocking(move || match db.fetch(&DbKey::CommsIdentitySignature) {
+    pub fn get_comms_identity_signature(&self) -> Result<Option<IdentitySignature>, WalletStorageError> {
+        let sig = match self.db.fetch(&DbKey::CommsIdentitySignature) {
             Ok(None) => Ok(None),
             Ok(Some(DbValue::CommsIdentitySignature(k))) => Ok(Some(*k)),
             Ok(Some(other)) => unexpected_result(DbKey::CommsIdentitySignature, other),
             Err(e) => log_error(DbKey::CommsIdentitySignature, e),
-        })
-        .await
-        .map_err(|err| WalletStorageError::BlockingTaskSpawnError(err.to_string()))??;
+        }?;
         Ok(sig)
     }
 
-    pub async fn set_comms_identity_signature(&self, sig: IdentitySignature) -> Result<(), WalletStorageError> {
-        let db = self.db.clone();
-
-        tokio::task::spawn_blocking(move || {
-            db.write(WriteOperation::Insert(DbKeyValuePair::CommsIdentitySignature(
+    pub fn set_comms_identity_signature(&self, sig: IdentitySignature) -> Result<(), WalletStorageError> {
+        self.db
+            .write(WriteOperation::Insert(DbKeyValuePair::CommsIdentitySignature(
                 Box::new(sig),
-            )))
-        })
-        .await
-        .map_err(|err| WalletStorageError::BlockingTaskSpawnError(err.to_string()))??;
+            )))?;
         Ok(())
     }
 
-    pub async fn get_chain_metadata(&self) -> Result<Option<ChainMetadata>, WalletStorageError> {
-        let db_clone = self.db.clone();
-
-        let c = tokio::task::spawn_blocking(move || match db_clone.fetch(&DbKey::BaseNodeChainMetadata) {
+    pub fn get_chain_metadata(&self) -> Result<Option<ChainMetadata>, WalletStorageError> {
+        let c = match self.db.fetch(&DbKey::BaseNodeChainMetadata) {
             Ok(None) => Ok(None),
             Ok(Some(DbValue::BaseNodeChainMetadata(metadata))) => Ok(Some(metadata)),
             Ok(Some(other)) => unexpected_result(DbKey::BaseNodeChainMetadata, other),
             Err(e) => log_error(DbKey::BaseNodeChainMetadata, e),
-        })
-        .await
-        .map_err(|err| WalletStorageError::BlockingTaskSpawnError(err.to_string()))??;
+        }?;
         Ok(c)
     }
 
-    pub async fn set_chain_metadata(&self, metadata: ChainMetadata) -> Result<(), WalletStorageError> {
-        let db_clone = self.db.clone();
-
-        tokio::task::spawn_blocking(move || {
-            db_clone.write(WriteOperation::Insert(DbKeyValuePair::BaseNodeChainMetadata(metadata)))
-        })
-        .await
-        .map_err(|err| WalletStorageError::BlockingTaskSpawnError(err.to_string()))??;
+    pub fn set_chain_metadata(&self, metadata: ChainMetadata) -> Result<(), WalletStorageError> {
+        self.db
+            .write(WriteOperation::Insert(DbKeyValuePair::BaseNodeChainMetadata(metadata)))?;
         Ok(())
     }
 
-    pub async fn apply_encryption(&self, passphrase: SafePassword) -> Result<XChaCha20Poly1305, WalletStorageError> {
-        let db_clone = self.db.clone();
-        tokio::task::spawn_blocking(move || db_clone.apply_encryption(passphrase))
-            .await
-            .map_err(|err| WalletStorageError::BlockingTaskSpawnError(err.to_string()))
-            .and_then(|inner_result| inner_result)
+    pub fn apply_encryption(&self, passphrase: SafePassword) -> Result<XChaCha20Poly1305, WalletStorageError> {
+        self.db.apply_encryption(passphrase)
     }
 
-    pub async fn remove_encryption(&self) -> Result<(), WalletStorageError> {
-        let db_clone = self.db.clone();
-        tokio::task::spawn_blocking(move || db_clone.remove_encryption())
-            .await
-            .map_err(|err| WalletStorageError::BlockingTaskSpawnError(err.to_string()))
-            .and_then(|inner_result| inner_result)
+    pub fn remove_encryption(&self) -> Result<(), WalletStorageError> {
+        self.db.remove_encryption()
     }
 
-    pub async fn set_client_key_value(&self, key: String, value: String) -> Result<(), WalletStorageError> {
-        let db_clone = self.db.clone();
-
-        tokio::task::spawn_blocking(move || {
-            db_clone.write(WriteOperation::Insert(DbKeyValuePair::ClientKeyValue(key, value)))
-        })
-        .await
-        .map_err(|err| WalletStorageError::BlockingTaskSpawnError(err.to_string()))??;
+    pub fn set_client_key_value(&self, key: String, value: String) -> Result<(), WalletStorageError> {
+        self.db
+            .write(WriteOperation::Insert(DbKeyValuePair::ClientKeyValue(key, value)))?;
         Ok(())
     }
 
-    pub async fn get_client_key_value(&self, key: String) -> Result<Option<String>, WalletStorageError> {
-        let db_clone = self.db.clone();
-
-        let c = tokio::task::spawn_blocking(move || match db_clone.fetch(&DbKey::ClientKey(key.clone())) {
+    pub fn get_client_key_value(&self, key: String) -> Result<Option<String>, WalletStorageError> {
+        let c = match self.db.fetch(&DbKey::ClientKey(key.clone())) {
             Ok(None) => Ok(None),
             Ok(Some(DbValue::ClientValue(k))) => Ok(Some(k)),
             Ok(Some(other)) => unexpected_result(DbKey::ClientKey(key), other),
             Err(e) => log_error(DbKey::ClientKey(key), e),
-        })
-        .await
-        .map_err(|err| WalletStorageError::BlockingTaskSpawnError(err.to_string()))??;
+        }?;
         Ok(c)
     }
 
-    pub async fn get_client_key_from_str<V>(&self, key: String) -> Result<Option<V>, WalletStorageError>
+    pub fn get_client_key_from_str<V>(&self, key: String) -> Result<Option<V>, WalletStorageError>
     where
         V: std::str::FromStr,
         V::Err: ToString,
     {
-        let db = self.db.clone();
-
-        let value = tokio::task::spawn_blocking(move || match db.fetch(&DbKey::ClientKey(key.clone())) {
+        let value = match self.db.fetch(&DbKey::ClientKey(key.clone())) {
             Ok(None) => Ok(None),
             Ok(Some(DbValue::ClientValue(k))) => Ok(Some(k)),
             Ok(Some(other)) => unexpected_result(DbKey::ClientKey(key), other),
             Err(e) => log_error(DbKey::ClientKey(key), e),
-        })
-        .await
-        .map_err(|err| WalletStorageError::BlockingTaskSpawnError(err.to_string()))??;
+        }?;
 
         match value {
             Some(c) => {
@@ -343,89 +268,54 @@ where T: WalletBackend + 'static
         }
     }
 
-    pub async fn clear_client_value(&self, key: String) -> Result<bool, WalletStorageError> {
-        let db_clone = self.db.clone();
-
-        let c = tokio::task::spawn_blocking(move || {
-            match db_clone.write(WriteOperation::Remove(DbKey::ClientKey(key.clone()))) {
-                Ok(None) => Ok(false),
-                Ok(Some(DbValue::ValueCleared)) => Ok(true),
-                Ok(Some(other)) => unexpected_result(DbKey::ClientKey(key), other),
-                Err(e) => log_error(DbKey::ClientKey(key), e),
-            }
-        })
-        .await
-        .map_err(|err| WalletStorageError::BlockingTaskSpawnError(err.to_string()))??;
+    pub fn clear_client_value(&self, key: String) -> Result<bool, WalletStorageError> {
+        let c = match self.db.write(WriteOperation::Remove(DbKey::ClientKey(key.clone()))) {
+            Ok(None) => Ok(false),
+            Ok(Some(DbValue::ValueCleared)) => Ok(true),
+            Ok(Some(other)) => unexpected_result(DbKey::ClientKey(key), other),
+            Err(e) => log_error(DbKey::ClientKey(key), e),
+        }?;
         Ok(c)
     }
 
-    pub async fn get_wallet_birthday(&self) -> Result<u16, WalletStorageError> {
-        let db_clone = self.db.clone();
-
-        let result = tokio::task::spawn_blocking(move || match db_clone.fetch(&DbKey::WalletBirthday) {
+    pub fn get_wallet_birthday(&self) -> Result<u16, WalletStorageError> {
+        let result = match self.db.fetch(&DbKey::WalletBirthday) {
             Ok(None) => Err(WalletStorageError::ValueNotFound(DbKey::WalletBirthday)),
             Ok(Some(DbValue::WalletBirthday(b))) => Ok(b
                 .parse::<u16>()
                 .map_err(|_| WalletStorageError::ConversionError("Could not parse wallet birthday".to_string()))?),
             Ok(Some(other)) => unexpected_result(DbKey::WalletBirthday, other),
             Err(e) => log_error(DbKey::WalletBirthday, e),
-        })
-        .await
-        .map_err(|err| WalletStorageError::BlockingTaskSpawnError(err.to_string()))??;
+        }?;
         Ok(result)
     }
 
-    pub async fn get_scanned_blocks(&self) -> Result<Vec<ScannedBlock>, WalletStorageError> {
-        let db_clone = self.db.clone();
-
-        let result = tokio::task::spawn_blocking(move || db_clone.get_scanned_blocks())
-            .await
-            .map_err(|err| WalletStorageError::BlockingTaskSpawnError(err.to_string()))??;
-
+    pub fn get_scanned_blocks(&self) -> Result<Vec<ScannedBlock>, WalletStorageError> {
+        let result = self.db.get_scanned_blocks()?;
         Ok(result)
     }
 
-    pub async fn save_scanned_block(&self, scanned_block: ScannedBlock) -> Result<(), WalletStorageError> {
-        let db_clone = self.db.clone();
-
-        tokio::task::spawn_blocking(move || db_clone.save_scanned_block(scanned_block))
-            .await
-            .map_err(|err| WalletStorageError::BlockingTaskSpawnError(err.to_string()))??;
-
+    pub fn save_scanned_block(&self, scanned_block: ScannedBlock) -> Result<(), WalletStorageError> {
+        self.db.save_scanned_block(scanned_block)?;
         Ok(())
     }
 
-    pub async fn clear_scanned_blocks(&self) -> Result<(), WalletStorageError> {
-        let db_clone = self.db.clone();
-
-        tokio::task::spawn_blocking(move || db_clone.clear_scanned_blocks())
-            .await
-            .map_err(|err| WalletStorageError::BlockingTaskSpawnError(err.to_string()))??;
-
+    pub fn clear_scanned_blocks(&self) -> Result<(), WalletStorageError> {
+        self.db.clear_scanned_blocks()?;
         Ok(())
     }
 
-    pub async fn clear_scanned_blocks_from_and_higher(&self, height: u64) -> Result<(), WalletStorageError> {
-        let db_clone = self.db.clone();
-
-        tokio::task::spawn_blocking(move || db_clone.clear_scanned_blocks_from_and_higher(height))
-            .await
-            .map_err(|err| WalletStorageError::BlockingTaskSpawnError(err.to_string()))??;
-
+    pub fn clear_scanned_blocks_from_and_higher(&self, height: u64) -> Result<(), WalletStorageError> {
+        self.db.clear_scanned_blocks_from_and_higher(height)?;
         Ok(())
     }
 
-    pub async fn clear_scanned_blocks_before_height(
+    pub fn clear_scanned_blocks_before_height(
         &self,
         height: u64,
         exclude_recovered: bool,
     ) -> Result<(), WalletStorageError> {
-        let db_clone = self.db.clone();
-
-        tokio::task::spawn_blocking(move || db_clone.clear_scanned_blocks_before_height(height, exclude_recovered))
-            .await
-            .map_err(|err| WalletStorageError::BlockingTaskSpawnError(err.to_string()))??;
-
+        self.db.clear_scanned_blocks_before_height(height, exclude_recovered)?;
         Ok(())
     }
 }
@@ -486,7 +376,6 @@ mod test {
     use tari_key_manager::cipher_seed::CipherSeed;
     use tari_test_utils::random::string;
     use tempfile::tempdir;
-    use tokio::runtime::Runtime;
 
     use crate::storage::{
         database::WalletDatabase,
@@ -496,8 +385,6 @@ mod test {
 
     #[test]
     fn test_database_crud() {
-        let runtime = Runtime::new().unwrap();
-
         let db_name = format!("{}.sqlite3", string(8).as_str());
         let db_folder = tempdir().unwrap().path().to_str().unwrap().to_string();
         let connection = run_migration_and_create_sqlite_connection(&format!("{}{}", db_folder, db_name), 16).unwrap();
@@ -505,13 +392,13 @@ mod test {
         let db = WalletDatabase::new(WalletSqliteDatabase::new(connection, None).unwrap());
 
         // Test wallet settings
-        assert!(runtime.block_on(db.get_master_seed()).unwrap().is_none());
+        assert!(db.get_master_seed().unwrap().is_none());
         let seed = CipherSeed::new();
-        runtime.block_on(db.set_master_seed(seed.clone())).unwrap();
-        let stored_seed = runtime.block_on(db.get_master_seed()).unwrap().unwrap();
+        db.set_master_seed(seed.clone()).unwrap();
+        let stored_seed = db.get_master_seed().unwrap().unwrap();
         assert_eq!(seed, stored_seed);
-        runtime.block_on(db.clear_master_seed()).unwrap();
-        assert!(runtime.block_on(db.get_master_seed()).unwrap().is_none());
+        db.clear_master_seed().unwrap();
+        assert!(db.get_master_seed().unwrap().is_none());
 
         let client_key_values = vec![
             ("key1".to_string(), "value1".to_string()),
@@ -520,36 +407,25 @@ mod test {
         ];
 
         for kv in &client_key_values {
-            runtime
-                .block_on(db.set_client_key_value(kv.0.clone(), kv.1.clone()))
-                .unwrap();
+            db.set_client_key_value(kv.0.clone(), kv.1.clone()).unwrap();
         }
 
-        assert!(runtime
-            .block_on(db.get_client_key_value("wrong".to_string()))
-            .unwrap()
-            .is_none());
+        assert!(db.get_client_key_value("wrong".to_string()).unwrap().is_none());
 
-        runtime
-            .block_on(db.set_client_key_value(client_key_values[0].0.clone(), "updated".to_string()))
+        db.set_client_key_value(client_key_values[0].0.clone(), "updated".to_string())
             .unwrap();
 
         assert_eq!(
-            runtime
-                .block_on(db.get_client_key_value(client_key_values[0].0.clone()))
+            db.get_client_key_value(client_key_values[0].0.clone())
                 .unwrap()
                 .unwrap(),
             "updated".to_string()
         );
 
-        assert!(!runtime.block_on(db.clear_client_value("wrong".to_string())).unwrap());
+        assert!(!db.clear_client_value("wrong".to_string()).unwrap());
 
-        assert!(runtime
-            .block_on(db.clear_client_value(client_key_values[0].0.clone()))
-            .unwrap());
+        assert!(db.clear_client_value(client_key_values[0].0.clone()).unwrap());
 
-        assert!(!runtime
-            .block_on(db.clear_client_value(client_key_values[0].0.clone()))
-            .unwrap());
+        assert!(!db.clear_client_value(client_key_values[0].0.clone()).unwrap());
     }
 }

--- a/base_layer/wallet/src/storage/sqlite_utilities/mod.rs
+++ b/base_layer/wallet/src/storage/sqlite_utilities/mod.rs
@@ -71,7 +71,7 @@ pub fn run_migration_and_create_sqlite_connection<P: AsRef<Path>>(
 
 /// This function will copy a wallet database to the provided path and then clear the Master Private Key from the
 /// database.
-pub async fn partial_wallet_backup<P: AsRef<Path>>(current_db: P, backup_path: P) -> Result<(), WalletStorageError> {
+pub fn partial_wallet_backup<P: AsRef<Path>>(current_db: P, backup_path: P) -> Result<(), WalletStorageError> {
     // Copy the current db to the backup path
     let db_path = current_db
         .as_ref()
@@ -87,7 +87,7 @@ pub async fn partial_wallet_backup<P: AsRef<Path>>(current_db: P, backup_path: P
     // open a connection and clear the Master Secret Key
     let connection = run_migration_and_create_sqlite_connection(backup_path, 16)?;
     let db = WalletDatabase::new(WalletSqliteDatabase::new(connection, None)?);
-    db.clear_master_seed().await?;
+    db.clear_master_seed()?;
 
     Ok(())
 }

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -856,7 +856,7 @@ where
         if let OutputManagerEvent::TxoValidationSuccess(_) = (*event).clone() {
             let db = self.db.clone();
             let output_manager_handle = self.output_manager_service.clone();
-            let metadata = match self.wallet_db.get_chain_metadata().await {
+            let metadata = match self.wallet_db.get_chain_metadata() {
                 Ok(data) => data,
                 Err(_) => None,
             };
@@ -1498,7 +1498,7 @@ where
         recipient_reply: proto::RecipientSignedMessage,
     ) -> Result<(), TransactionServiceError> {
         // Check if a wallet recovery is in progress, if it is we will ignore this request
-        self.check_recovery_status().await?;
+        self.check_recovery_status()?;
 
         let recipient_reply: RecipientSignedMessage = recipient_reply
             .try_into()
@@ -1827,7 +1827,7 @@ where
         join_handles: &mut FuturesUnordered<JoinHandle<Result<TxId, TransactionServiceProtocolError<TxId>>>>,
     ) -> Result<(), TransactionServiceError> {
         // Check if a wallet recovery is in progress, if it is we will ignore this request
-        self.check_recovery_status().await?;
+        self.check_recovery_status()?;
 
         let sender_message: TransactionSenderMessage = sender_message
             .try_into()
@@ -1955,7 +1955,7 @@ where
         join_handles: &mut FuturesUnordered<JoinHandle<Result<TxId, TransactionServiceProtocolError<TxId>>>>,
     ) -> Result<(), TransactionServiceError> {
         // Check if a wallet recovery is in progress, if it is we will ignore this request
-        self.check_recovery_status().await?;
+        self.check_recovery_status()?;
 
         let tx_id = finalized_transaction.tx_id.into();
         let transaction: Transaction = finalized_transaction
@@ -2575,8 +2575,8 @@ where
 
     /// Check if a Recovery Status is currently stored in the databse, this indicates that a wallet recovery is in
     /// progress
-    async fn check_recovery_status(&self) -> Result<(), TransactionServiceError> {
-        let value = self.wallet_db.get_client_key_value(RECOVERY_KEY.to_owned()).await?;
+    fn check_recovery_status(&self) -> Result<(), TransactionServiceError> {
+        let value = self.wallet_db.get_client_key_value(RECOVERY_KEY.to_owned())?;
         match value {
             None => Ok(()),
             Some(_) => Err(TransactionServiceError::WalletRecoveryInProgress),

--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -267,15 +267,11 @@ where
 
         // Persist the comms node address and features after it has been spawned to capture any modifications made
         // during comms startup. In the case of a Tor Transport the public address could have been generated
-        wallet_database
-            .set_node_address(comms.node_identity().public_address())
-            .await?;
-        wallet_database
-            .set_node_features(comms.node_identity().features())
-            .await?;
+        wallet_database.set_node_address(comms.node_identity().public_address())?;
+        wallet_database.set_node_features(comms.node_identity().features())?;
         let identity_sig = comms.node_identity().identity_signature_read().as_ref().cloned();
         if let Some(identity_sig) = identity_sig {
-            wallet_database.set_comms_identity_signature(identity_sig).await?;
+            wallet_database.set_comms_identity_signature(identity_sig)?;
         }
 
         Ok(Self {
@@ -678,7 +674,7 @@ where
     /// in which case this will fail.
     pub async fn apply_encryption(&mut self, passphrase: SafePassword) -> Result<(), WalletError> {
         debug!(target: LOG_TARGET, "Applying wallet encryption.");
-        let cipher = self.db.apply_encryption(passphrase).await?;
+        let cipher = self.db.apply_encryption(passphrase)?;
         self.output_manager_service.apply_encryption(cipher.clone()).await?;
         self.transaction_service.apply_encryption(cipher.clone()).await?;
         self.key_manager_service.apply_encryption(cipher).await?;
@@ -691,18 +687,18 @@ where
         self.output_manager_service.remove_encryption().await?;
         self.transaction_service.remove_encryption().await?;
         self.key_manager_service.remove_encryption().await?;
-        self.db.remove_encryption().await?;
+        self.db.remove_encryption()?;
         Ok(())
     }
 
     /// Utility function to find out if there is data in the database indicating that there is an incomplete recovery
     /// process in progress
-    pub async fn is_recovery_in_progress(&self) -> Result<bool, WalletError> {
-        Ok(self.db.get_client_key_value(RECOVERY_KEY.to_string()).await?.is_some())
+    pub fn is_recovery_in_progress(&self) -> Result<bool, WalletError> {
+        Ok(self.db.get_client_key_value(RECOVERY_KEY.to_string())?.is_some())
     }
 
-    pub async fn get_seed_words(&self, language: &MnemonicLanguage) -> Result<Vec<String>, WalletError> {
-        let master_seed = self.db.get_master_seed().await?.ok_or_else(|| {
+    pub fn get_seed_words(&self, language: &MnemonicLanguage) -> Result<Vec<String>, WalletError> {
+        let master_seed = self.db.get_master_seed()?.ok_or_else(|| {
             WalletError::WalletStorageError(WalletStorageError::RecoverySeedError(
                 "Cipher Seed not found".to_string(),
             ))
@@ -713,24 +709,24 @@ where
     }
 }
 
-pub async fn read_or_create_master_seed<T: WalletBackend + 'static>(
+pub fn read_or_create_master_seed<T: WalletBackend + 'static>(
     recovery_seed: Option<CipherSeed>,
     db: &WalletDatabase<T>,
 ) -> Result<CipherSeed, WalletError> {
-    let db_master_seed = db.get_master_seed().await?;
+    let db_master_seed = db.get_master_seed()?;
 
     let master_seed = match recovery_seed {
         None => match db_master_seed {
             None => {
                 let seed = CipherSeed::new();
-                db.set_master_seed(seed.clone()).await?;
+                db.set_master_seed(seed.clone())?;
                 seed
             },
             Some(seed) => seed,
         },
         Some(recovery_seed) => {
             if db_master_seed.is_none() {
-                db.set_master_seed(recovery_seed.clone()).await?;
+                db.set_master_seed(recovery_seed.clone())?;
                 recovery_seed
             } else {
                 error!(

--- a/base_layer/wallet/tests/utxo_scanner.rs
+++ b/base_layer/wallet/tests/utxo_scanner.rs
@@ -289,7 +289,7 @@ async fn test_utxo_scanner_recovery() {
 
     let cipher_seed = CipherSeed::new();
     let birthday_epoch_time = u64::from(cipher_seed.birthday() - 2) * 60 * 60 * 24;
-    test_interface.wallet_db.set_master_seed(cipher_seed).await.unwrap();
+    test_interface.wallet_db.set_master_seed(cipher_seed).unwrap();
 
     const NUM_BLOCKS: u64 = 11;
     const BIRTHDAY_OFFSET: u64 = 5;
@@ -372,7 +372,7 @@ async fn test_utxo_scanner_recovery_with_restart() {
 
     let cipher_seed = CipherSeed::new();
     let birthday_epoch_time = u64::from(cipher_seed.birthday() - 2) * 60 * 60 * 24;
-    test_interface.wallet_db.set_master_seed(cipher_seed).await.unwrap();
+    test_interface.wallet_db.set_master_seed(cipher_seed).unwrap();
 
     test_interface
         .scanner_handle
@@ -536,7 +536,7 @@ async fn test_utxo_scanner_recovery_with_restart_and_reorg() {
 
     let cipher_seed = CipherSeed::new();
     let birthday_epoch_time = u64::from(cipher_seed.birthday() - 2) * 60 * 60 * 24;
-    test_interface.wallet_db.set_master_seed(cipher_seed).await.unwrap();
+    test_interface.wallet_db.set_master_seed(cipher_seed).unwrap();
 
     const NUM_BLOCKS: u64 = 11;
     const BIRTHDAY_OFFSET: u64 = 5;
@@ -700,13 +700,12 @@ async fn test_utxo_scanner_scanned_block_cache_clearing() {
                     .checked_sub_signed(ChronoDuration::days(1000))
                     .unwrap(),
             })
-            .await
             .unwrap();
     }
 
     let cipher_seed = CipherSeed::new();
     let birthday_epoch_time = u64::from(cipher_seed.birthday() - 2) * 60 * 60 * 24;
-    test_interface.wallet_db.set_master_seed(cipher_seed).await.unwrap();
+    test_interface.wallet_db.set_master_seed(cipher_seed).unwrap();
 
     const NUM_BLOCKS: u64 = 11;
     const BIRTHDAY_OFFSET: u64 = 5;
@@ -751,7 +750,6 @@ async fn test_utxo_scanner_scanned_block_cache_clearing() {
             amount: None,
             timestamp: Utc::now().naive_utc(),
         })
-        .await
         .unwrap();
 
     let mut scanner_event_stream = test_interface.scanner_handle.get_event_receiver();
@@ -776,7 +774,7 @@ async fn test_utxo_scanner_scanned_block_cache_clearing() {
             }
         }
     }
-    let scanned_blocks = test_interface.wallet_db.get_scanned_blocks().await.unwrap();
+    let scanned_blocks = test_interface.wallet_db.get_scanned_blocks().unwrap();
 
     use tari_wallet::utxo_scanner_service::service::SCANNED_BLOCK_CACHE_SIZE;
     let threshold = 800 + NUM_BLOCKS - 1 - SCANNED_BLOCK_CACHE_SIZE;
@@ -809,7 +807,7 @@ async fn test_utxo_scanner_one_sided_payments() {
 
     let cipher_seed = CipherSeed::new();
     let birthday_epoch_time = u64::from(cipher_seed.birthday() - 2) * 60 * 60 * 24;
-    test_interface.wallet_db.set_master_seed(cipher_seed).await.unwrap();
+    test_interface.wallet_db.set_master_seed(cipher_seed).unwrap();
 
     const NUM_BLOCKS: u64 = 11;
     const BIRTHDAY_OFFSET: u64 = 5;

--- a/base_layer/wallet/tests/wallet.rs
+++ b/base_layer/wallet/tests/wallet.rs
@@ -175,7 +175,7 @@ async fn create_wallet(
     let _db_value = wallet_backend.write(WriteOperation::Insert(DbKeyValuePair::BaseNodeChainMetadata(metadata)));
 
     let wallet_db = WalletDatabase::new(wallet_backend);
-    let master_seed = read_or_create_master_seed(recovery_seed, &wallet_db).await?;
+    let master_seed = read_or_create_master_seed(recovery_seed, &wallet_db)?;
 
     let output_db = OutputManagerDatabase::new(output_manager_backend.clone());
 
@@ -401,19 +401,17 @@ async fn test_wallet() {
 
     let alice_seed = CipherSeed::new();
 
-    alice_wallet.db.set_master_seed(alice_seed).await.unwrap();
+    alice_wallet.db.set_master_seed(alice_seed).unwrap();
 
     shutdown_a.trigger();
     alice_wallet.wait_until_shutdown().await;
 
-    partial_wallet_backup(current_wallet_path.clone(), backup_wallet_path.clone())
-        .await
-        .unwrap();
+    partial_wallet_backup(current_wallet_path.clone(), backup_wallet_path.clone()).unwrap();
 
     let connection =
         run_migration_and_create_sqlite_connection(&current_wallet_path, 16).expect("Could not open Sqlite db");
     let wallet_db = WalletDatabase::new(WalletSqliteDatabase::new(connection.clone(), None).unwrap());
-    let master_seed = wallet_db.get_master_seed().await.unwrap();
+    let master_seed = wallet_db.get_master_seed().unwrap();
     assert!(master_seed.is_some());
     // Checking that the backup has had its Comms Private Key is cleared.
     let connection = run_migration_and_create_sqlite_connection(&backup_wallet_path, 16).expect(
@@ -421,7 +419,7 @@ async fn test_wallet() {
     db",
     );
     let backup_wallet_db = WalletDatabase::new(WalletSqliteDatabase::new(connection.clone(), None).unwrap());
-    let master_seed = backup_wallet_db.get_master_seed().await.unwrap();
+    let master_seed = backup_wallet_db.get_master_seed().unwrap();
     assert!(master_seed.is_none());
 
     shutdown_b.trigger();
@@ -811,7 +809,7 @@ async fn test_recovery_birthday() {
     .await
     .unwrap();
 
-    let db_birthday = wallet.db.get_wallet_birthday().await.unwrap();
+    let db_birthday = wallet.db.get_wallet_birthday().unwrap();
     assert_eq!(birthday, db_birthday);
 }
 

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -4285,23 +4285,21 @@ pub unsafe extern "C" fn wallet_create(
     // If the transport type is Tor then check if there is a stored TorID, if there is update the Transport Type
     let mut comms_config = (*config).clone();
     if let TransportType::Tor = comms_config.transport.transport_type {
-        comms_config.transport.tor.identity = runtime.block_on(wallet_database.get_tor_id()).ok().flatten();
+        comms_config.transport.tor.identity = wallet_database.get_tor_id().ok().flatten();
     }
 
     let result = runtime.block_on(async {
         let master_seed = read_or_create_master_seed(recovery_seed, &wallet_database)
-            .await
             .map_err(|err| WalletStorageError::RecoverySeedError(err.to_string()))?;
         let comms_secret_key = derive_comms_secret_key(&master_seed)
             .map_err(|err| WalletStorageError::RecoverySeedError(err.to_string()))?;
 
-        let node_features = wallet_database.get_node_features().await?.unwrap_or_default();
+        let node_features = wallet_database.get_node_features()?.unwrap_or_default();
         let node_address = wallet_database
-            .get_node_address()
-            .await?
+            .get_node_address()?
             .or_else(|| comms_config.public_address.clone())
             .unwrap_or_else(Multiaddr::empty);
-        let identity_sig = wallet_database.get_comms_identity_signature().await?;
+        let identity_sig = wallet_database.get_comms_identity_signature()?;
 
         // This checks if anything has changed by validating the previous signature and if invalid, setting identity_sig
         // to None
@@ -4325,7 +4323,7 @@ pub unsafe extern "C" fn wallet_create(
                 .as_ref()
                 .expect("unreachable panic")
                 .clone();
-            wallet_database.set_comms_identity_signature(sig).await?;
+            wallet_database.set_comms_identity_signature(sig)?;
         }
         Ok((master_seed, node_identity))
     });
@@ -4351,7 +4349,7 @@ pub unsafe extern "C" fn wallet_create(
         ..Default::default()
     };
 
-    let mut recovery_lookup = match runtime.block_on(wallet_database.get_client_key_value(RECOVERY_KEY.to_owned())) {
+    let mut recovery_lookup = match wallet_database.get_client_key_value(RECOVERY_KEY.to_owned()) {
         Err(_) => false,
         Ok(None) => false,
         Ok(Some(_)) => true,
@@ -4386,7 +4384,7 @@ pub unsafe extern "C" fn wallet_create(
         Ok(mut w) => {
             // lets ensure the wallet tor_id is saved, this could have been changed during wallet startup
             if let Some(hs) = w.comms.hidden_service() {
-                if let Err(e) = runtime.block_on(w.db.set_tor_identity(hs.tor_identity().clone())) {
+                if let Err(e) = w.db.set_tor_identity(hs.tor_identity().clone()) {
                     warn!(target: LOG_TARGET, "Could not save tor identity to db: {:?}", e);
                 }
             }
@@ -6655,10 +6653,7 @@ pub unsafe extern "C" fn wallet_get_seed_words(wallet: *mut TariWallet, error_ou
         return ptr::null_mut();
     }
 
-    match (*wallet)
-        .runtime
-        .block_on((*wallet).wallet.get_seed_words(&MnemonicLanguage::English))
-    {
+    match (*wallet).wallet.get_seed_words(&MnemonicLanguage::English) {
         Ok(seed_words) => Box::into_raw(Box::new(TariSeedWords(seed_words))),
         Err(e) => {
             error = LibWalletError::from(e).code;
@@ -6857,10 +6852,7 @@ pub unsafe extern "C" fn wallet_set_key_value(
         }
     }
 
-    match (*wallet)
-        .runtime
-        .block_on((*wallet).wallet.db.set_client_key_value(key_string, value_string))
-    {
+    match (*wallet).wallet.db.set_client_key_value(key_string, value_string) {
         Ok(_) => true,
         Err(e) => {
             error = LibWalletError::from(WalletError::WalletStorageError(e)).code;
@@ -6917,10 +6909,7 @@ pub unsafe extern "C" fn wallet_get_value(
         }
     }
 
-    match (*wallet)
-        .runtime
-        .block_on((*wallet).wallet.db.get_client_key_value(key_string))
-    {
+    match (*wallet).wallet.db.get_client_key_value(key_string) {
         Ok(result) => match result {
             None => {
                 error = LibWalletError::from(WalletError::WalletStorageError(WalletStorageError::ValuesNotFound)).code;
@@ -6987,10 +6976,7 @@ pub unsafe extern "C" fn wallet_clear_value(
         }
     }
 
-    match (*wallet)
-        .runtime
-        .block_on((*wallet).wallet.db.clear_client_value(key_string))
-    {
+    match (*wallet).wallet.db.clear_client_value(key_string) {
         Ok(result) => result,
         Err(e) => {
             error = LibWalletError::from(WalletError::WalletStorageError(e)).code;
@@ -7024,7 +7010,7 @@ pub unsafe extern "C" fn wallet_is_recovery_in_progress(wallet: *mut TariWallet,
         return false;
     }
 
-    match (*wallet).runtime.block_on((*wallet).wallet.is_recovery_in_progress()) {
+    match (*wallet).wallet.is_recovery_in_progress() {
         Ok(result) => result,
         Err(e) => {
             error = LibWalletError::from(e).code;
@@ -7257,17 +7243,10 @@ pub unsafe extern "C" fn file_partial_backup(
     }
     let backup_path = PathBuf::from(backup_path_string);
 
-    let runtime = Runtime::new();
-    match runtime {
-        Ok(runtime) => match runtime.block_on(partial_wallet_backup(original_path, backup_path)) {
-            Ok(_) => (),
-            Err(e) => {
-                error = LibWalletError::from(WalletError::WalletStorageError(e)).code;
-                ptr::swap(error_out, &mut error as *mut c_int);
-            },
-        },
+    match partial_wallet_backup(original_path, backup_path) {
+        Ok(_) => (),
         Err(e) => {
-            error = LibWalletError::from(InterfaceError::TokioError(e.to_string())).code;
+            error = LibWalletError::from(WalletError::WalletStorageError(e)).code;
             ptr::swap(error_out, &mut error as *mut c_int);
         },
     }
@@ -8511,13 +8490,11 @@ mod test {
                 error_ptr,
             );
 
-            let runtime = Runtime::new().unwrap();
-
             let connection =
                 run_migration_and_create_sqlite_connection(&sql_database_path, 16).expect("Could not open Sqlite db");
             let wallet_backend = WalletDatabase::new(WalletSqliteDatabase::new(connection, None).unwrap());
 
-            let stored_seed = runtime.block_on(wallet_backend.get_master_seed()).unwrap();
+            let stored_seed = wallet_backend.get_master_seed().unwrap();
             drop(wallet_backend);
             assert!(stored_seed.is_none(), "No key should be stored yet");
 
@@ -8556,7 +8533,7 @@ mod test {
                 run_migration_and_create_sqlite_connection(&sql_database_path, 16).expect("Could not open Sqlite db");
             let wallet_backend = WalletDatabase::new(WalletSqliteDatabase::new(connection, None).unwrap());
 
-            let stored_seed1 = runtime.block_on(wallet_backend.get_master_seed()).unwrap().unwrap();
+            let stored_seed1 = wallet_backend.get_master_seed().unwrap().unwrap();
 
             drop(wallet_backend);
 
@@ -8597,7 +8574,7 @@ mod test {
                 run_migration_and_create_sqlite_connection(&sql_database_path, 16).expect("Could not open Sqlite db");
             let wallet_backend = WalletDatabase::new(WalletSqliteDatabase::new(connection, None).unwrap());
 
-            let stored_seed2 = runtime.block_on(wallet_backend.get_master_seed()).unwrap().unwrap();
+            let stored_seed2 = wallet_backend.get_master_seed().unwrap().unwrap();
 
             assert_eq!(stored_seed1, stored_seed2);
 
@@ -8616,7 +8593,7 @@ mod test {
                 run_migration_and_create_sqlite_connection(&sql_database_path, 16).expect("Could not open Sqlite db");
             let wallet_backend = WalletDatabase::new(WalletSqliteDatabase::new(connection, None).unwrap());
 
-            let stored_seed = runtime.block_on(wallet_backend.get_master_seed()).unwrap();
+            let stored_seed = wallet_backend.get_master_seed().unwrap();
 
             assert!(stored_seed.is_none(), "key should be cleared");
             drop(wallet_backend);


### PR DESCRIPTION
Description
---
Removed spawn blocking calls for db operations from the wallet in the wallet storage. (This is another PR in a couple of PRs required to implement this fully throughout the wallet code.)

Motivation and Context
---
As per https://github.com/tari-project/tari/pull/3982 and https://github.com/tari-project/tari/issues/4555

How Has This Been Tested?
---
Unit tests
Cucumber tests