### PR TITLE
fix(dht): updates to message padding

### DIFF
--- a/comms/dht/src/crypt.rs
+++ b/comms/dht/src/crypt.rs
@@ -177,7 +177,7 @@ pub fn decrypt_with_chacha20_poly1305(
 /// Encrypt the plain text using the ChaCha20 stream cipher
 pub fn encrypt(cipher_key: &CipherKey, plain_text: &[u8]) -> Result<Vec<u8>, DhtOutboundError> {
     // pad plain_text to avoid message length leaks
-    let plain_text = pad_message_to_base_length_multiple(plain_text).unwrap();
+    let plain_text = pad_message_to_base_length_multiple(plain_text)?;
 
     let mut nonce = [0u8; size_of::<Nonce>()];
     OsRng.fill_bytes(&mut nonce);

--- a/comms/dht/src/crypt.rs
+++ b/comms/dht/src/crypt.rs
@@ -99,12 +99,16 @@ fn get_original_message_from_padded_text(padded_message: &[u8]) -> Result<Vec<u8
 
     // The padded message must be long enough to extract the encoded message length
     if padded_message.len() < size_of::<u32>() {
-        return Err(DhtOutboundError::PaddingError("Padded message is not long enough for length extraction".to_string()));
+        return Err(DhtOutboundError::PaddingError(
+            "Padded message is not long enough for length extraction".to_string(),
+        ));
     }
 
     // The padded message must be a multiple of the base length
     if (padded_message.len() % MESSAGE_BASE_LENGTH) != 0 {
-        return Err(DhtOutboundError::PaddingError("Padded message must be a multiple of the base length".to_string()));
+        return Err(DhtOutboundError::PaddingError(
+            "Padded message must be a multiple of the base length".to_string(),
+        ));
     }
 
     // Decode the message length
@@ -113,7 +117,9 @@ fn get_original_message_from_padded_text(padded_message: &[u8]) -> Result<Vec<u8
     let message_length = u32::from_le_bytes(encoded_length) as usize;
 
     // The padded message is too short for the decoded length
-    let end = message_length.checked_add(size_of::<u32>()).ok_or_else(|| DhtOutboundError::PaddingError("Claimed unpadded message length is too large".to_string()))?;
+    let end = message_length
+        .checked_add(size_of::<u32>())
+        .ok_or_else(|| DhtOutboundError::PaddingError("Claimed unpadded message length is too large".to_string()))?;
     if end > padded_message.len() {
         return Err(DhtOutboundError::CipherError(
             "Claimed unpadded message length is too large".to_string(),

--- a/comms/dht/src/crypt.rs
+++ b/comms/dht/src/crypt.rs
@@ -472,6 +472,30 @@ mod test {
     }
 
     #[test]
+    fn unpadding_failure_modes() {
+        // The padded message is empty
+        let message: [u8; 0] = [];
+        assert!(get_original_message_from_padded_text(&message)
+            .unwrap_err()
+            .to_string()
+            .contains("Bad padded message length"));
+
+        // We cannot extract the message length
+        let message = [0u8; size_of::<u32>() - 1];
+        assert!(get_original_message_from_padded_text(&message)
+            .unwrap_err()
+            .to_string()
+            .contains("Bad padded message length"));
+
+        // The padded message is not a multiple of the base length
+        let message = [0u8; 2 * MESSAGE_BASE_LENGTH + 1];
+        assert!(get_original_message_from_padded_text(&message)
+            .unwrap_err()
+            .to_string()
+            .contains("Bad padded message length"));
+    }
+
+    #[test]
     fn get_original_message_from_padded_text_successful() {
         // test for short message
         let message = vec![0u8, 10, 22, 11, 38, 74, 59, 91, 73, 82, 75, 23, 59];

--- a/comms/dht/src/crypt.rs
+++ b/comms/dht/src/crypt.rs
@@ -93,22 +93,22 @@ fn pad_message_to_base_length_multiple(message: &[u8]) -> Result<Vec<u8>, DhtOut
     Ok(padded_message)
 }
 
-fn get_original_message_from_padded_text(message: &[u8]) -> Result<Vec<u8>, DhtOutboundError> {
+fn get_original_message_from_padded_text(padded_message: &[u8]) -> Result<Vec<u8>, DhtOutboundError> {
     // NOTE: This function can return errors relating to message length
     // It is important not to leak error types to an adversary, or to have timing differences
 
     // Assert that the padded message is a multiple of the base length
-    if message.is_empty() || (message.len() % MESSAGE_BASE_LENGTH) != 0 {
+    if padded_message.is_empty() || (padded_message.len() % MESSAGE_BASE_LENGTH) != 0 {
         return Err(DhtOutboundError::CipherError("Bad padded message length".to_string()));
     }
 
     // Decode the message length
     let mut encoded_length = [0u8; size_of::<u32>()];
-    encoded_length.copy_from_slice(&message[0..size_of::<u32>()]);
+    encoded_length.copy_from_slice(&padded_message[0..size_of::<u32>()]);
     let message_length = u32::from_le_bytes(encoded_length) as usize;
 
     // The message is too short for the decoded length
-    if message_length + size_of::<u32>() > message.len() {
+    if message_length + size_of::<u32>() > padded_message.len() {
         return Err(DhtOutboundError::CipherError(
             "Message is too short to be unpadded".to_string(),
         ));
@@ -117,7 +117,7 @@ fn get_original_message_from_padded_text(message: &[u8]) -> Result<Vec<u8>, DhtO
     // Remove the padding
     let start = size_of::<u32>();
     let end = start + message_length;
-    let unpadded_message = &message[start..end];
+    let unpadded_message = &padded_message[start..end];
 
     Ok(unpadded_message.to_vec())
 }

--- a/comms/dht/src/dht.rs
+++ b/comms/dht/src/dht.rs
@@ -598,7 +598,7 @@ mod test {
         let node_identity2 = make_node_identity();
         let ecdh_key = crypt::generate_ecdh_secret(node_identity2.secret_key(), node_identity2.public_key());
         let key_message = crypt::generate_key_message(&ecdh_key);
-        let encrypted_bytes = crypt::encrypt(&key_message, &msg.to_encoded_bytes());
+        let encrypted_bytes = crypt::encrypt(&key_message, &msg.to_encoded_bytes()).unwrap();
         let dht_envelope = make_dht_envelope(
             &node_identity2,
             encrypted_bytes,

--- a/comms/dht/src/inbound/decryption.rs
+++ b/comms/dht/src/inbound/decryption.rs
@@ -650,7 +650,7 @@ mod test {
         let key_message = crypt::generate_key_message(&shared_secret);
         let msg_tag = MessageTag::new();
 
-        let message = crypt::encrypt(&key_message, &plain_text_msg);
+        let message = crypt::encrypt(&key_message, &plain_text_msg).unwrap();
         let header = make_dht_header(
             &node_identity,
             &e_public_key,
@@ -711,7 +711,7 @@ mod test {
         let key_message = crypt::generate_key_message(&shared_secret);
         let msg_tag = MessageTag::new();
 
-        let message = crypt::encrypt(&key_message, &plain_text_msg);
+        let message = crypt::encrypt(&key_message, &plain_text_msg).unwrap();
         let header = make_dht_header(
             &node_identity,
             &e_public_key,

--- a/comms/dht/src/outbound/broadcast.rs
+++ b/comms/dht/src/outbound/broadcast.rs
@@ -500,7 +500,7 @@ where S: Service<DhtOutboundMessage, Response = (), Error = PipelineError>
                 // Generate key message for encryption of message
                 let key_message = crypt::generate_key_message(&shared_ephemeral_secret);
                 // Encrypt the message with the body with key message above
-                let encrypted_body = crypt::encrypt(&key_message, &body).unwrap();
+                let encrypted_body = crypt::encrypt(&key_message, &body)?;
 
                 // Produce domain separated signature signature
                 let mac_signature = crypt::create_message_domain_separated_hash_parts(

--- a/comms/dht/src/outbound/broadcast.rs
+++ b/comms/dht/src/outbound/broadcast.rs
@@ -500,7 +500,7 @@ where S: Service<DhtOutboundMessage, Response = (), Error = PipelineError>
                 // Generate key message for encryption of message
                 let key_message = crypt::generate_key_message(&shared_ephemeral_secret);
                 // Encrypt the message with the body with key message above
-                let encrypted_body = crypt::encrypt(&key_message, &body);
+                let encrypted_body = crypt::encrypt(&key_message, &body).unwrap();
 
                 // Produce domain separated signature signature
                 let mac_signature = crypt::create_message_domain_separated_hash_parts(

--- a/comms/dht/src/outbound/error.rs
+++ b/comms/dht/src/outbound/error.rs
@@ -56,6 +56,8 @@ pub enum DhtOutboundError {
     NoMessagesQueued,
     #[error("Cipher error: `{0}`")]
     CipherError(String),
+    #[error("Padding error: `{0}`")]
+    PaddingError(String), // TODO: clean up these errors
 }
 
 impl From<SendFailure> for DhtOutboundError {

--- a/comms/dht/src/test_utils/makers.rs
+++ b/comms/dht/src/test_utils/makers.rs
@@ -164,7 +164,7 @@ pub fn make_dht_envelope(
     if flags.is_encrypted() {
         let shared_secret = crypt::generate_ecdh_secret(&e_secret_key, node_identity.public_key());
         let key_message = crypt::generate_key_message(&shared_secret);
-        message = crypt::encrypt(&key_message, &message);
+        message = crypt::encrypt(&key_message, &message).unwrap();
     }
     let header = make_dht_header(
         node_identity,


### PR DESCRIPTION
Description
---
[PR 4362](https://github.com/tari-project/tari/pull/4362) mitigates a metadata leak whereby encrypted messages are the same length as plaintext messages due to the use of a stream cipher. This work adds more complete length checks, such that padding can fail. It also more efficiently handles the edge case where no padding is needed.

Motivation and Context
---
To avoid directly leaking the length of plaintext messages after stream cipher encryption, [PR 4362](https://github.com/tari-project/tari/pull/4362) pads such messages to a multiple of a fixed base length after first prepending the original message length using a fixed encoding.

However, the following cases do not appear to be handled by the padding and unpadding code:
- The plaintext message length exceeds the fixed encoding length
- The ciphertext message is not long enough for extraction of the fixed encoding length
- The ciphertext message is not a multiple of the base length

Further, in the case where the message length (after length prepending) is exactly a multiple of the base length, an entire base length of padding is unnecessarily applied.

This work addresses these issues. The padding process now checks that the plaintext message does not exceed the limit enforced by the length encoding; as a result, it can now return an error that propagates to the encryption function caller. The padding algorithm has been simplified and now handles the multiple-of-the-base-length edge case by correctly applying no padding. The unpadding process now checks that it can safely extract the message length, and checks that the ciphertext message is a multiple of the base length.

How Has This Been Tested?
---
No test has been added for the case where the message length exceeds the limit allowed by the encoding, as this would imply very high memory usage (or swapping) exceeding 4 GB. Existing tests pass. A new test exercises the other failure modes.