### PR TITLE
test: fix latent transaction service unit test errors

### DIFF
--- a/base_layer/wallet/tests/transaction_service_tests/service.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/service.rs
@@ -3386,7 +3386,7 @@ async fn test_coinbase_generation_and_monitoring() {
 
     let _tx_batch_query_calls = alice_ts_interface
         .base_node_rpc_mock_state
-        .wait_pop_transaction_batch_query_calls(1, Duration::from_secs(30))
+        .wait_pop_transaction_batch_query_calls(2, Duration::from_secs(30))
         .await
         .unwrap();
 
@@ -3937,10 +3937,13 @@ async fn test_coinbase_transaction_reused_for_same_height() {
         .await
         .unwrap();
 
+    let expected_pending_incoming_balance = fees1 + reward1;
     assert_eq!(transactions.len(), 1);
+    let mut amount = MicroTari::zero();
     for tx in transactions.values() {
-        assert_eq!(tx.amount, fees1 + reward1);
+        amount += tx.amount;
     }
+    assert_eq!(amount, expected_pending_incoming_balance);
     // balance should be fees1 + reward1, not double
     assert_eq!(
         ts_interface
@@ -3949,7 +3952,7 @@ async fn test_coinbase_transaction_reused_for_same_height() {
             .await
             .unwrap()
             .pending_incoming_balance,
-        fees1 + reward1
+        expected_pending_incoming_balance
     );
 
     // a requested coinbase transaction for the same height but new amount should be different
@@ -3965,10 +3968,13 @@ async fn test_coinbase_transaction_reused_for_same_height() {
         .get_completed_transactions()
         .await
         .unwrap();
-    assert_eq!(transactions.len(), 1); // tx1 and tx2 should be cancelled
+    let expected_pending_incoming_balance = fees1 + reward1 + fees2 + reward2;
+    assert_eq!(transactions.len(), 2);
+    let mut amount = MicroTari::zero();
     for tx in transactions.values() {
-        assert_eq!(tx.amount, fees2 + reward2);
+        amount += tx.amount;
     }
+    assert_eq!(amount, expected_pending_incoming_balance);
     assert_eq!(
         ts_interface
             .output_manager_service_handle
@@ -3976,7 +3982,7 @@ async fn test_coinbase_transaction_reused_for_same_height() {
             .await
             .unwrap()
             .pending_incoming_balance,
-        fees1 + reward1 + fees2 + reward2
+        expected_pending_incoming_balance
     );
 
     // a requested coinbase transaction for a new height should be different
@@ -3992,10 +3998,13 @@ async fn test_coinbase_transaction_reused_for_same_height() {
         .get_completed_transactions()
         .await
         .unwrap();
-    assert_eq!(transactions.len(), 2);
+    let expected_pending_incoming_balance = fees1 + reward1 + 2 * (fees2 + reward2);
+    assert_eq!(transactions.len(), 3);
+    let mut amount = MicroTari::zero();
     for tx in transactions.values() {
-        assert_eq!(tx.amount, fees2 + reward2);
+        amount += tx.amount;
     }
+    assert_eq!(amount, expected_pending_incoming_balance);
     assert_eq!(
         ts_interface
             .output_manager_service_handle
@@ -4003,7 +4012,7 @@ async fn test_coinbase_transaction_reused_for_same_height() {
             .await
             .unwrap()
             .pending_incoming_balance,
-        fees1 + reward1 + 2 * (fees2 + reward2)
+        expected_pending_incoming_balance
     );
 }
 
@@ -4180,7 +4189,7 @@ async fn test_transaction_resending() {
 
     assert!(alice_ts_interface
         .outbound_service_mock_state
-        .wait_call_count(1, Duration::from_secs(5))
+        .wait_call_count(1, Duration::from_secs(8))
         .await
         .is_err());
 


### PR DESCRIPTION
Description
---
Fixed latent transaction service unit test errors

Motivation and Context
---
Some failing tests due to recent coinbase handling logic changes:
```
failures:

---- transaction_service_tests::service::test_coinbase_transaction_reused_for_same_height stdout ----
thread 'transaction_service_tests::service::test_coinbase_transaction_reused_for_same_height' panicked at 'assertion failed: `(left == right)`
  left: `2`,
 right: `1`', base_layer/wallet/tests/transaction_service_tests/service.rs:3968:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- transaction_service_tests::service::test_coinbase_generation_and_monitoring stdout ----
thread 'transaction_service_tests::service::test_coinbase_generation_and_monitoring' panicked at 'assertion failed: `(left == right)`
  left: `Coinbase`,
 right: `MinedUnconfirmed`', base_layer/wallet/tests/transaction_service_tests/service.rs:3405:5

---- transaction_service_tests::service::test_transaction_resending stdout ----
thread 'transaction_service_tests::service::test_transaction_resending' panicked at 'assertion failed: alice_ts_interface.outbound_service_mock_state.wait_call_count(1,\n            Duration::from_secs(5)).await.is_err()', base_layer/wallet/tests/transaction_service_tests/service.rs:4181:5


failures:
    transaction_service_tests::service::test_coinbase_generation_and_monitoring
    transaction_service_tests::service::test_coinbase_transaction_reused_for_same_height
    transaction_service_tests::service::test_transaction_resending

test result: FAILED. 39 passed; 3 failed; 0 ignored; 0 measured; 0 filtered out; finished in 107.87s
```

How Has This Been Tested?
---
Failing uni tests passed
