### PR TITLE
feat: let sql in wal mode provide async db, not app level spawn blocking (transaction service)

### DIFF
--- a/base_layer/wallet/src/transaction_service/protocols/transaction_broadcast_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_broadcast_protocol.rs
@@ -99,7 +99,7 @@ where
                 .await
                 .ok_or_else(|| TransactionServiceProtocolError::new(self.tx_id, TransactionServiceError::Shutdown))?;
 
-            let completed_tx = match self.resources.db.get_completed_transaction(self.tx_id).await {
+            let completed_tx = match self.resources.db.get_completed_transaction(self.tx_id) {
                 Ok(tx) => tx,
                 Err(e) => {
                     error!(
@@ -275,7 +275,6 @@ where
             self.resources
                 .db
                 .broadcast_completed_transaction(self.tx_id)
-                .await
                 .map_err(|e| TransactionServiceProtocolError::new(self.tx_id, TransactionServiceError::from(e)))?;
             let _size = self
                 .resources
@@ -430,7 +429,7 @@ where
                 "Failed to Cancel outputs for TxId: {} after failed sending attempt with error {:?}", self.tx_id, e
             );
         }
-        if let Err(e) = self.resources.db.reject_completed_transaction(self.tx_id, reason).await {
+        if let Err(e) = self.resources.db.reject_completed_transaction(self.tx_id, reason) {
             warn!(
                 target: LOG_TARGET,
                 "Failed to Cancel TxId: {} after failed sending attempt with error {:?}", self.tx_id, e

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_receive_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_receive_protocol.rs
@@ -131,7 +131,6 @@ where
                 .resources
                 .db
                 .transaction_exists(data.tx_id)
-                .await
                 .map_err(|e| TransactionServiceProtocolError::new(self.id, TransactionServiceError::from(e)))?
             {
                 trace!(
@@ -167,7 +166,6 @@ where
             self.resources
                 .db
                 .add_pending_inbound_transaction(inbound_transaction.tx_id, inbound_transaction.clone())
-                .await
                 .map_err(|e| TransactionServiceProtocolError::new(self.id, TransactionServiceError::from(e)))?;
 
             let send_result = send_transaction_reply(
@@ -182,7 +180,6 @@ where
             self.resources
                 .db
                 .increment_send_count(self.id)
-                .await
                 .map_err(|e| TransactionServiceProtocolError::new(self.id, TransactionServiceError::from(e)))?;
 
             if send_result {
@@ -237,7 +234,7 @@ where
             .ok_or_else(|| TransactionServiceProtocolError::new(self.id, TransactionServiceError::InvalidStateError))?
             .fuse();
 
-        let inbound_tx = match self.resources.db.get_pending_inbound_transaction(self.id).await {
+        let inbound_tx = match self.resources.db.get_pending_inbound_transaction(self.id) {
             Ok(tx) => tx,
             Err(_e) => {
                 debug!(
@@ -295,7 +292,6 @@ where
             self.resources
                 .db
                 .increment_send_count(self.id)
-                .await
                 .map_err(|e| TransactionServiceProtocolError::new(self.id, TransactionServiceError::from(e)))?;
         }
 
@@ -339,7 +335,6 @@ where
                             Ok(_) => self.resources
                                         .db
                                         .increment_send_count(self.id)
-                                        .await
                                         .map_err(|e| TransactionServiceProtocolError::new(self.id, TransactionServiceError::from(e)))?,
                             Err(e) => warn!(
                                             target: LOG_TARGET,
@@ -456,8 +451,7 @@ where
 
             self.resources
                 .db
-                .complete_inbound_transaction(self.id, completed_transaction.clone())
-                .await
+                .complete_inbound_transaction(self.id, completed_transaction)
                 .map_err(|e| TransactionServiceProtocolError::new(self.id, TransactionServiceError::from(e)))?;
 
             info!(
@@ -486,17 +480,13 @@ where
             "Cancelling Transaction Receive Protocol (TxId: {}) due to timeout after no counterparty response", self.id
         );
 
-        self.resources
-            .db
-            .cancel_pending_transaction(self.id)
-            .await
-            .map_err(|e| {
-                warn!(
-                    target: LOG_TARGET,
-                    "Pending Transaction does not exist and could not be cancelled: {:?}", e
-                );
-                TransactionServiceProtocolError::new(self.id, TransactionServiceError::from(e))
-            })?;
+        self.resources.db.cancel_pending_transaction(self.id).map_err(|e| {
+            warn!(
+                target: LOG_TARGET,
+                "Pending Transaction does not exist and could not be cancelled: {:?}", e
+            );
+            TransactionServiceProtocolError::new(self.id, TransactionServiceError::from(e))
+        })?;
 
         self.resources
             .output_manager_service

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_send_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_send_protocol.rs
@@ -317,7 +317,6 @@ where
             .resources
             .db
             .transaction_exists(tx_id)
-            .await
             .map_err(|e| TransactionServiceProtocolError::new(self.id, TransactionServiceError::from(e)))?
         {
             let fee = sender_protocol
@@ -337,14 +336,12 @@ where
             self.resources
                 .db
                 .add_pending_outbound_transaction(outbound_tx.tx_id, outbound_tx)
-                .await
                 .map_err(|e| TransactionServiceProtocolError::new(self.id, TransactionServiceError::from(e)))?;
         }
         if transaction_status == TransactionStatus::Pending {
             self.resources
                 .db
                 .increment_send_count(self.id)
-                .await
                 .map_err(|e| TransactionServiceProtocolError::new(self.id, TransactionServiceError::from(e)))?;
         }
 
@@ -394,7 +391,6 @@ where
             .resources
             .db
             .get_pending_outbound_transaction(tx_id)
-            .await
             .map_err(|e| TransactionServiceProtocolError::new(self.id, TransactionServiceError::from(e)))?;
 
         if !outbound_tx.sender_protocol.is_collecting_single_signature() {
@@ -452,7 +448,6 @@ where
                         self.resources
                             .db
                             .increment_send_count(self.id)
-                            .await
                             .map_err(|e| TransactionServiceProtocolError::new(self.id, e.into()))?
                     }
                 },
@@ -499,7 +494,6 @@ where
                         self.resources
                             .db
                             .increment_send_count(self.id)
-                            .await
                             .map_err(|e| TransactionServiceProtocolError::new(
                                 self.id, TransactionServiceError::from(e))
                             )?;
@@ -521,7 +515,6 @@ where
                              self.resources
                                 .db
                                 .increment_send_count(self.id)
-                                .await
                                 .map_err(|e| TransactionServiceProtocolError::new(
                                     self.id, TransactionServiceError::from(e))
                                 )?
@@ -594,7 +587,6 @@ where
         self.resources
             .db
             .complete_outbound_transaction(tx_id, completed_transaction.clone())
-            .await
             .map_err(|e| TransactionServiceProtocolError::new(self.id, TransactionServiceError::from(e)))?;
         info!(
             target: LOG_TARGET,
@@ -615,7 +607,6 @@ where
         self.resources
             .db
             .increment_send_count(tx_id)
-            .await
             .map_err(|e| TransactionServiceProtocolError::new(self.id, TransactionServiceError::from(e)))?;
 
         let _size = self
@@ -905,20 +896,15 @@ where
         self.resources
             .db
             .increment_send_count(self.id)
-            .await
             .map_err(|e| TransactionServiceProtocolError::new(self.id, TransactionServiceError::from(e)))?;
 
-        self.resources
-            .db
-            .cancel_pending_transaction(self.id)
-            .await
-            .map_err(|e| {
-                warn!(
-                    target: LOG_TARGET,
-                    "Pending Transaction does not exist and could not be cancelled: {:?}", e
-                );
-                TransactionServiceProtocolError::new(self.id, TransactionServiceError::from(e))
-            })?;
+        self.resources.db.cancel_pending_transaction(self.id).map_err(|e| {
+            warn!(
+                target: LOG_TARGET,
+                "Pending Transaction does not exist and could not be cancelled: {:?}", e
+            );
+            TransactionServiceProtocolError::new(self.id, TransactionServiceError::from(e))
+        })?;
 
         self.resources
             .output_manager_service

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_validation_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_validation_protocol.rs
@@ -112,7 +112,6 @@ where
         let unconfirmed_transactions = self
             .db
             .fetch_unconfirmed_transactions_info()
-            .await
             .for_protocol(self.operation_id)
             .unwrap();
 
@@ -216,7 +215,7 @@ where
             self.operation_id
         );
         let op_id = self.operation_id;
-        while let Some(last_mined_transaction) = self.db.fetch_last_mined_transaction().await.for_protocol(op_id)? {
+        while let Some(last_mined_transaction) = self.db.fetch_last_mined_transaction().for_protocol(op_id)? {
             let mined_height = last_mined_transaction
                 .mined_height
                 .ok_or_else(|| {
@@ -414,7 +413,6 @@ where
                 num_confirmations >= self.config.num_confirmations_required,
                 status.is_faux(),
             )
-            .await
             .for_protocol(self.operation_id)?;
 
         if num_confirmations >= self.config.num_confirmations_required {
@@ -488,12 +486,10 @@ where
                 num_confirmations >= self.config.num_confirmations_required,
                 false,
             )
-            .await
             .for_protocol(self.operation_id)?;
 
         self.db
             .abandon_coinbase_transaction(tx_id)
-            .await
             .for_protocol(self.operation_id)?;
 
         self.publish_event(TransactionEvent::TransactionCancelled(
@@ -510,7 +506,6 @@ where
     ) -> Result<(), TransactionServiceProtocolError<OperationId>> {
         self.db
             .set_transaction_as_unmined(tx_id)
-            .await
             .for_protocol(self.operation_id)?;
 
         if *status == TransactionStatus::Coinbase {

--- a/base_layer/wallet/src/transaction_service/tasks/check_faux_transaction_status.rs
+++ b/base_layer/wallet/src/transaction_service/tasks/check_faux_transaction_status.rs
@@ -49,14 +49,14 @@ pub async fn check_faux_transactions<TBackend: 'static + TransactionBackend>(
     event_publisher: TransactionEventSender,
     tip_height: u64,
 ) {
-    let mut all_faux_transactions: Vec<CompletedTransaction> = match db.get_imported_transactions().await {
+    let mut all_faux_transactions: Vec<CompletedTransaction> = match db.get_imported_transactions() {
         Ok(txs) => txs,
         Err(e) => {
             error!(target: LOG_TARGET, "Problem retrieving imported transactions: {}", e);
             return;
         },
     };
-    let mut unconfirmed_faux = match db.get_unconfirmed_faux_transactions().await {
+    let mut unconfirmed_faux = match db.get_unconfirmed_faux_transactions() {
         Ok(txs) => txs,
         Err(e) => {
             error!(
@@ -69,7 +69,7 @@ pub async fn check_faux_transactions<TBackend: 'static + TransactionBackend>(
     all_faux_transactions.append(&mut unconfirmed_faux);
     // Reorged faux transactions cannot be detected by excess signature, thus use last known confirmed transaction
     // height or current tip height with safety margin to determine if these should be returned
-    let last_mined_transaction = match db.fetch_last_mined_transaction().await {
+    let last_mined_transaction = match db.fetch_last_mined_transaction() {
         Ok(tx) => tx,
         Err(_) => None,
     };
@@ -79,7 +79,7 @@ pub async fn check_faux_transactions<TBackend: 'static + TransactionBackend>(
     } else {
         height_with_margin
     };
-    let mut confirmed_faux = match db.get_confirmed_faux_transactions_from_height(check_height).await {
+    let mut confirmed_faux = match db.get_confirmed_faux_transactions_from_height(check_height) {
         Ok(txs) => txs,
         Err(e) => {
             error!(
@@ -134,17 +134,15 @@ pub async fn check_faux_transactions<TBackend: 'static + TransactionBackend>(
                 num_confirmations,
                 is_valid,
             );
-            let result = db
-                .set_transaction_mined_height(
-                    tx.tx_id,
-                    mined_height,
-                    mined_in_block,
-                    0,
-                    num_confirmations,
-                    is_confirmed,
-                    is_valid,
-                )
-                .await;
+            let result = db.set_transaction_mined_height(
+                tx.tx_id,
+                mined_height,
+                mined_in_block,
+                0,
+                num_confirmations,
+                is_confirmed,
+                is_valid,
+            );
             if let Err(e) = result {
                 error!(
                     target: LOG_TARGET,

--- a/base_layer/wallet/tests/transaction_service_tests/transaction_protocols.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/transaction_protocols.rs
@@ -181,7 +181,7 @@ pub async fn add_transaction_to_database(
 ) {
     let factories = CryptoFactories::default();
     let (_utxo, uo0) = make_input(&mut OsRng, 10 * amount, &factories.commitment).await;
-    let (txs1, _uou1) = schema_to_transaction(&[txn_schema!(from: vec![uo0.clone()], to: vec![amount])]);
+    let (txs1, _uou1) = schema_to_transaction(&[txn_schema!(from: vec![uo0], to: vec![amount])]);
     let tx1 = (*txs1[0]).clone();
     let completed_tx1 = CompletedTransaction::new(
         tx_id,
@@ -189,7 +189,7 @@ pub async fn add_transaction_to_database(
         CommsPublicKey::default(),
         amount,
         200 * uT,
-        tx1.clone(),
+        tx1,
         status.unwrap_or(TransactionStatus::Completed),
         "Test".to_string(),
         Utc::now().naive_local(),
@@ -198,7 +198,7 @@ pub async fn add_transaction_to_database(
         None,
         None,
     );
-    db.insert_completed_transaction(tx_id, completed_tx1).await.unwrap();
+    db.insert_completed_transaction(tx_id, completed_tx1).unwrap();
 }
 
 /// Simple task that responds with a OutputManagerResponse::TransactionCancelled response to any request made on this
@@ -254,7 +254,7 @@ async fn tx_broadcast_protocol_submit_success() {
 
     add_transaction_to_database(1u64.into(), 1 * T, None, None, resources.db.clone()).await;
 
-    let db_completed_tx = resources.db.get_completed_transaction(1u64.into()).await.unwrap();
+    let db_completed_tx = resources.db.get_completed_transaction(1u64.into()).unwrap();
     assert!(db_completed_tx.confirmations.is_none());
 
     let protocol = TransactionBroadcastProtocol::new(1u64.into(), resources.clone(), timeout_watch.get_receiver());
@@ -352,7 +352,7 @@ async fn tx_broadcast_protocol_submit_rejection() {
     }
 
     // Check transaction is cancelled in db
-    let db_completed_tx = resources.db.get_completed_transaction(1u64.into()).await;
+    let db_completed_tx = resources.db.get_completed_transaction(1u64.into());
     assert!(db_completed_tx.is_err());
 
     // Check that the appropriate events were emitted
@@ -461,7 +461,7 @@ async fn tx_broadcast_protocol_restart_protocol_as_query() {
     assert_eq!(result.unwrap(), TxId::from(1u64));
 
     // Check transaction status is updated
-    let db_completed_tx = resources.db.get_completed_transaction(1u64.into()).await.unwrap();
+    let db_completed_tx = resources.db.get_completed_transaction(1u64.into()).unwrap();
     assert_eq!(db_completed_tx.status, TransactionStatus::Broadcast);
 }
 
@@ -535,7 +535,7 @@ async fn tx_broadcast_protocol_submit_success_followed_by_rejection() {
     }
 
     // Check transaction is cancelled in db
-    let db_completed_tx = resources.db.get_completed_transaction(1u64.into()).await;
+    let db_completed_tx = resources.db.get_completed_transaction(1u64.into());
     assert!(db_completed_tx.is_err());
 
     // Check that the appropriate events were emitted
@@ -621,7 +621,7 @@ async fn tx_broadcast_protocol_submit_already_mined() {
     assert_eq!(result.unwrap(), 1);
 
     // Check transaction status is updated
-    let db_completed_tx = resources.db.get_completed_transaction(1u64.into()).await.unwrap();
+    let db_completed_tx = resources.db.get_completed_transaction(1u64.into()).unwrap();
     assert_eq!(db_completed_tx.status, TransactionStatus::Completed);
 }
 
@@ -719,7 +719,7 @@ async fn tx_broadcast_protocol_submit_and_base_node_gets_changed() {
     assert_eq!(result.unwrap(), TxId::from(1u64));
 
     // Check transaction status is updated
-    let db_completed_tx = resources.db.get_completed_transaction(1u64.into()).await.unwrap();
+    let db_completed_tx = resources.db.get_completed_transaction(1u64.into()).unwrap();
     assert_eq!(db_completed_tx.status, TransactionStatus::Broadcast);
 }
 
@@ -761,7 +761,7 @@ async fn tx_validation_protocol_tx_becomes_mined_unconfirmed_then_confirmed() {
     )
     .await;
 
-    let tx2 = resources.db.get_completed_transaction(2u64.into()).await.unwrap();
+    let tx2 = resources.db.get_completed_transaction(2u64.into()).unwrap();
 
     let transaction_query_batch_responses = vec![TxQueryBatchResponseProto {
         signature: Some(SignatureProto::from(
@@ -797,7 +797,7 @@ async fn tx_validation_protocol_tx_becomes_mined_unconfirmed_then_confirmed() {
     let result = join_handle.await.unwrap();
     assert!(result.is_ok());
 
-    let completed_txs = resources.db.get_completed_transactions().await.unwrap();
+    let completed_txs = resources.db.get_completed_transactions().unwrap();
 
     assert_eq!(
         completed_txs.get(&1u64.into()).unwrap().status,
@@ -825,7 +825,7 @@ async fn tx_validation_protocol_tx_becomes_mined_unconfirmed_then_confirmed() {
     let result = join_handle.await.unwrap();
     assert!(result.is_ok());
 
-    let completed_txs = resources.db.get_completed_transactions().await.unwrap();
+    let completed_txs = resources.db.get_completed_transactions().unwrap();
 
     assert_eq!(
         completed_txs.get(&1u64.into()).unwrap().status,
@@ -871,7 +871,7 @@ async fn tx_validation_protocol_tx_becomes_mined_unconfirmed_then_confirmed() {
     let result = join_handle.await.unwrap();
     assert!(result.is_ok());
 
-    let completed_txs = resources.db.get_completed_transactions().await.unwrap();
+    let completed_txs = resources.db.get_completed_transactions().unwrap();
 
     assert_eq!(
         completed_txs.get(&2u64.into()).unwrap().status,
@@ -917,7 +917,7 @@ async fn tx_revalidation() {
     )
     .await;
 
-    let tx2 = resources.db.get_completed_transaction(2u64.into()).await.unwrap();
+    let tx2 = resources.db.get_completed_transaction(2u64.into()).unwrap();
 
     // set tx2 as fully mined
     let transaction_query_batch_responses = vec![TxQueryBatchResponseProto {
@@ -954,7 +954,7 @@ async fn tx_revalidation() {
     let result = join_handle.await.unwrap();
     assert!(result.is_ok());
 
-    let completed_txs = resources.db.get_completed_transactions().await.unwrap();
+    let completed_txs = resources.db.get_completed_transactions().unwrap();
 
     assert_eq!(
         completed_txs.get(&2u64.into()).unwrap().status,
@@ -983,8 +983,8 @@ async fn tx_revalidation() {
 
     rpc_service_state.set_transaction_query_batch_responses(batch_query_response.clone());
     // revalidate sets all to unvalidated, so lets check that thay are
-    resources.db.mark_all_transactions_as_unvalidated().await.unwrap();
-    let completed_txs = resources.db.get_completed_transactions().await.unwrap();
+    resources.db.mark_all_transactions_as_unvalidated().unwrap();
+    let completed_txs = resources.db.get_completed_transactions().unwrap();
     assert_eq!(
         completed_txs.get(&2u64.into()).unwrap().status,
         TransactionStatus::MinedConfirmed
@@ -1005,7 +1005,7 @@ async fn tx_revalidation() {
     let result = join_handle.await.unwrap();
     assert!(result.is_ok());
 
-    let completed_txs = resources.db.get_completed_transactions().await.unwrap();
+    let completed_txs = resources.db.get_completed_transactions().unwrap();
     // data should now be updated and changed
     assert_eq!(
         completed_txs.get(&2u64.into()).unwrap().status,
@@ -1073,13 +1073,13 @@ async fn tx_validation_protocol_reorg() {
     }
     rpc_service_state.set_blocks(block_headers.clone());
 
-    let tx1 = resources.db.get_completed_transaction(1u64.into()).await.unwrap();
-    let tx2 = resources.db.get_completed_transaction(2u64.into()).await.unwrap();
-    let tx3 = resources.db.get_completed_transaction(3u64.into()).await.unwrap();
-    let tx4 = resources.db.get_completed_transaction(4u64.into()).await.unwrap();
-    let tx5 = resources.db.get_completed_transaction(5u64.into()).await.unwrap();
-    let coinbase_tx1 = resources.db.get_completed_transaction(6u64.into()).await.unwrap();
-    let coinbase_tx2 = resources.db.get_completed_transaction(7u64.into()).await.unwrap();
+    let tx1 = resources.db.get_completed_transaction(1u64.into()).unwrap();
+    let tx2 = resources.db.get_completed_transaction(2u64.into()).unwrap();
+    let tx3 = resources.db.get_completed_transaction(3u64.into()).unwrap();
+    let tx4 = resources.db.get_completed_transaction(4u64.into()).unwrap();
+    let tx5 = resources.db.get_completed_transaction(5u64.into()).unwrap();
+    let coinbase_tx1 = resources.db.get_completed_transaction(6u64.into()).unwrap();
+    let coinbase_tx2 = resources.db.get_completed_transaction(7u64.into()).unwrap();
 
     let transaction_query_batch_responses = vec![
         TxQueryBatchResponseProto {
@@ -1177,7 +1177,7 @@ async fn tx_validation_protocol_reorg() {
     let result = join_handle.await.unwrap();
     assert!(result.is_ok());
 
-    let completed_txs = resources.db.get_completed_transactions().await.unwrap();
+    let completed_txs = resources.db.get_completed_transactions().unwrap();
     let mut unconfirmed_count = 0;
     let mut confirmed_count = 0;
     for tx in completed_txs.values() {
@@ -1296,7 +1296,7 @@ async fn tx_validation_protocol_reorg() {
 
     assert_eq!(rpc_service_state.take_get_header_by_height_calls().len(), 0);
 
-    let completed_txs = resources.db.get_completed_transactions().await.unwrap();
+    let completed_txs = resources.db.get_completed_transactions().unwrap();
     assert_eq!(
         completed_txs.get(&4u64.into()).unwrap().status,
         TransactionStatus::Completed
@@ -1317,7 +1317,7 @@ async fn tx_validation_protocol_reorg() {
         completed_txs.get(&7u64.into()).unwrap().status,
         TransactionStatus::Coinbase
     );
-    let cancelled_completed_txs = resources.db.get_cancelled_completed_transactions().await.unwrap();
+    let cancelled_completed_txs = resources.db.get_cancelled_completed_transactions().unwrap();
 
     assert!(matches!(
         cancelled_completed_txs.get(&6u64.into()).unwrap().cancelled,

--- a/base_layer/wallet_ffi/src/callback_handler.rs
+++ b/base_layer/wallet_ffi/src/callback_handler.rs
@@ -235,15 +235,15 @@ where TBackend: TransactionBackend + 'static
                             trace!(target: LOG_TARGET, "Transaction Service Callback Handler event {:?}", msg);
                             match (*msg).clone() {
                                 TransactionEvent::ReceivedTransaction(tx_id) => {
-                                    self.receive_transaction_event(tx_id).await;
+                                    self.receive_transaction_event(tx_id);
                                     self.trigger_balance_refresh().await;
                                 },
                                 TransactionEvent::ReceivedTransactionReply(tx_id) => {
-                                    self.receive_transaction_reply_event(tx_id).await;
+                                    self.receive_transaction_reply_event(tx_id);
                                     self.trigger_balance_refresh().await;
                                 },
                                 TransactionEvent::ReceivedFinalizedTransaction(tx_id) => {
-                                    self.receive_finalized_transaction_event(tx_id).await;
+                                    self.receive_finalized_transaction_event(tx_id);
                                     self.trigger_balance_refresh().await;
                                 },
                                 TransactionEvent::TransactionSendResult(tx_id, status) => {
@@ -251,27 +251,27 @@ where TBackend: TransactionBackend + 'static
                                     self.trigger_balance_refresh().await;
                                 },
                                 TransactionEvent::TransactionCancelled(tx_id, reason) => {
-                                    self.receive_transaction_cancellation(tx_id, reason as u64).await;
+                                    self.receive_transaction_cancellation(tx_id, reason as u64);
                                     self.trigger_balance_refresh().await;
                                 },
                                 TransactionEvent::TransactionBroadcast(tx_id) => {
-                                    self.receive_transaction_broadcast_event(tx_id).await;
+                                    self.receive_transaction_broadcast_event(tx_id);
                                     self.trigger_balance_refresh().await;
                                 },
                                 TransactionEvent::TransactionMined{tx_id, is_valid: _} => {
-                                    self.receive_transaction_mined_event(tx_id).await;
+                                    self.receive_transaction_mined_event(tx_id);
                                     self.trigger_balance_refresh().await;
                                 },
                                 TransactionEvent::TransactionMinedUnconfirmed{tx_id, num_confirmations, is_valid: _} => {
-                                    self.receive_transaction_mined_unconfirmed_event(tx_id, num_confirmations).await;
+                                    self.receive_transaction_mined_unconfirmed_event(tx_id, num_confirmations);
                                     self.trigger_balance_refresh().await;
                                 },
                                 TransactionEvent::FauxTransactionConfirmed{tx_id, is_valid: _} => {
-                                    self.receive_faux_transaction_confirmed_event(tx_id).await;
+                                    self.receive_faux_transaction_confirmed_event(tx_id);
                                     self.trigger_balance_refresh().await;
                                 },
                                 TransactionEvent::FauxTransactionUnconfirmed{tx_id, num_confirmations, is_valid: _} => {
-                                    self.receive_faux_transaction_unconfirmed_event(tx_id, num_confirmations).await;
+                                    self.receive_faux_transaction_unconfirmed_event(tx_id, num_confirmations);
                                     self.trigger_balance_refresh().await;
                                 },
                                 TransactionEvent::TransactionValidationStateChanged(_request_key)  => {
@@ -358,8 +358,8 @@ where TBackend: TransactionBackend + 'static
         }
     }
 
-    async fn receive_transaction_event(&mut self, tx_id: TxId) {
-        match self.db.get_pending_inbound_transaction(tx_id).await {
+    fn receive_transaction_event(&mut self, tx_id: TxId) {
+        match self.db.get_pending_inbound_transaction(tx_id) {
             Ok(tx) => {
                 debug!(
                     target: LOG_TARGET,
@@ -377,8 +377,8 @@ where TBackend: TransactionBackend + 'static
         }
     }
 
-    async fn receive_transaction_reply_event(&mut self, tx_id: TxId) {
-        match self.db.get_completed_transaction(tx_id).await {
+    fn receive_transaction_reply_event(&mut self, tx_id: TxId) {
+        match self.db.get_completed_transaction(tx_id) {
             Ok(tx) => {
                 debug!(
                     target: LOG_TARGET,
@@ -393,8 +393,8 @@ where TBackend: TransactionBackend + 'static
         }
     }
 
-    async fn receive_finalized_transaction_event(&mut self, tx_id: TxId) {
-        match self.db.get_completed_transaction(tx_id).await {
+    fn receive_finalized_transaction_event(&mut self, tx_id: TxId) {
+        match self.db.get_completed_transaction(tx_id) {
             Ok(tx) => {
                 debug!(
                     target: LOG_TARGET,
@@ -458,15 +458,15 @@ where TBackend: TransactionBackend + 'static
         }
     }
 
-    async fn receive_transaction_cancellation(&mut self, tx_id: TxId, reason: u64) {
+    fn receive_transaction_cancellation(&mut self, tx_id: TxId, reason: u64) {
         let mut transaction = None;
-        if let Ok(tx) = self.db.get_cancelled_completed_transaction(tx_id).await {
+        if let Ok(tx) = self.db.get_cancelled_completed_transaction(tx_id) {
             transaction = Some(tx);
-        } else if let Ok(tx) = self.db.get_cancelled_pending_outbound_transaction(tx_id).await {
+        } else if let Ok(tx) = self.db.get_cancelled_pending_outbound_transaction(tx_id) {
             let mut outbound_tx = CompletedTransaction::from(tx);
             outbound_tx.source_public_key = self.comms_public_key.clone();
             transaction = Some(outbound_tx);
-        } else if let Ok(tx) = self.db.get_cancelled_pending_inbound_transaction(tx_id).await {
+        } else if let Ok(tx) = self.db.get_cancelled_pending_inbound_transaction(tx_id) {
             let mut inbound_tx = CompletedTransaction::from(tx);
             inbound_tx.destination_public_key = self.comms_public_key.clone();
             transaction = Some(inbound_tx);
@@ -491,8 +491,8 @@ where TBackend: TransactionBackend + 'static
         }
     }
 
-    async fn receive_transaction_broadcast_event(&mut self, tx_id: TxId) {
-        match self.db.get_completed_transaction(tx_id).await {
+    fn receive_transaction_broadcast_event(&mut self, tx_id: TxId) {
+        match self.db.get_completed_transaction(tx_id) {
             Ok(tx) => {
                 debug!(
                     target: LOG_TARGET,
@@ -507,8 +507,8 @@ where TBackend: TransactionBackend + 'static
         }
     }
 
-    async fn receive_transaction_mined_event(&mut self, tx_id: TxId) {
-        match self.db.get_completed_transaction(tx_id).await {
+    fn receive_transaction_mined_event(&mut self, tx_id: TxId) {
+        match self.db.get_completed_transaction(tx_id) {
             Ok(tx) => {
                 debug!(
                     target: LOG_TARGET,
@@ -523,8 +523,8 @@ where TBackend: TransactionBackend + 'static
         }
     }
 
-    async fn receive_transaction_mined_unconfirmed_event(&mut self, tx_id: TxId, confirmations: u64) {
-        match self.db.get_completed_transaction(tx_id).await {
+    fn receive_transaction_mined_unconfirmed_event(&mut self, tx_id: TxId, confirmations: u64) {
+        match self.db.get_completed_transaction(tx_id) {
             Ok(tx) => {
                 debug!(
                     target: LOG_TARGET,
@@ -539,8 +539,8 @@ where TBackend: TransactionBackend + 'static
         }
     }
 
-    async fn receive_faux_transaction_confirmed_event(&mut self, tx_id: TxId) {
-        match self.db.get_completed_transaction(tx_id).await {
+    fn receive_faux_transaction_confirmed_event(&mut self, tx_id: TxId) {
+        match self.db.get_completed_transaction(tx_id) {
             Ok(tx) => {
                 debug!(
                     target: LOG_TARGET,
@@ -555,8 +555,8 @@ where TBackend: TransactionBackend + 'static
         }
     }
 
-    async fn receive_faux_transaction_unconfirmed_event(&mut self, tx_id: TxId, confirmations: u64) {
-        match self.db.get_completed_transaction(tx_id).await {
+    fn receive_faux_transaction_unconfirmed_event(&mut self, tx_id: TxId, confirmations: u64) {
+        match self.db.get_completed_transaction(tx_id) {
             Ok(tx) => {
                 debug!(
                     target: LOG_TARGET,

--- a/base_layer/wallet_ffi/src/callback_handler_tests.rs
+++ b/base_layer/wallet_ffi/src/callback_handler_tests.rs
@@ -247,8 +247,7 @@ mod test {
             "1".to_string(),
             Utc::now().naive_utc(),
         );
-        runtime
-            .block_on(db.add_pending_inbound_transaction(1u64.into(), inbound_tx.clone()))
+        db.add_pending_inbound_transaction(1u64.into(), inbound_tx.clone())
             .unwrap();
 
         let completed_tx = CompletedTransaction::new(
@@ -272,8 +271,7 @@ mod test {
             None,
             None,
         );
-        runtime
-            .block_on(db.insert_completed_transaction(2u64.into(), completed_tx.clone()))
+        db.insert_completed_transaction(2u64.into(), completed_tx.clone())
             .unwrap();
 
         let stp = SenderTransactionProtocol::new_placeholder();
@@ -288,29 +286,25 @@ mod test {
             Utc::now().naive_utc(),
             false,
         );
-        runtime
-            .block_on(db.add_pending_outbound_transaction(3u64.into(), outbound_tx.clone()))
+        db.add_pending_outbound_transaction(3u64.into(), outbound_tx.clone())
             .unwrap();
-        runtime.block_on(db.cancel_pending_transaction(3u64.into())).unwrap();
+        db.cancel_pending_transaction(3u64.into()).unwrap();
 
         let inbound_tx_cancelled = InboundTransaction {
             tx_id: 4u64.into(),
             ..inbound_tx.clone()
         };
-        runtime
-            .block_on(db.add_pending_inbound_transaction(4u64.into(), inbound_tx_cancelled))
+        db.add_pending_inbound_transaction(4u64.into(), inbound_tx_cancelled)
             .unwrap();
-        runtime.block_on(db.cancel_pending_transaction(4u64.into())).unwrap();
+        db.cancel_pending_transaction(4u64.into()).unwrap();
 
         let completed_tx_cancelled = CompletedTransaction {
             tx_id: 5u64.into(),
             ..completed_tx.clone()
         };
-        runtime
-            .block_on(db.insert_completed_transaction(5u64.into(), completed_tx_cancelled.clone()))
+        db.insert_completed_transaction(5u64.into(), completed_tx_cancelled.clone())
             .unwrap();
-        runtime
-            .block_on(db.reject_completed_transaction(5u64.into(), TxCancellationReason::Unknown))
+        db.reject_completed_transaction(5u64.into(), TxCancellationReason::Unknown)
             .unwrap();
 
         let faux_unconfirmed_tx = CompletedTransaction::new(
@@ -334,8 +328,7 @@ mod test {
             Some(2),
             Some(NaiveDateTime::from_timestamp(0, 0)),
         );
-        runtime
-            .block_on(db.insert_completed_transaction(6u64.into(), faux_unconfirmed_tx.clone()))
+        db.insert_completed_transaction(6u64.into(), faux_unconfirmed_tx.clone())
             .unwrap();
 
         let faux_confirmed_tx = CompletedTransaction::new(
@@ -359,8 +352,7 @@ mod test {
             Some(5),
             Some(NaiveDateTime::from_timestamp(0, 0)),
         );
-        runtime
-            .block_on(db.insert_completed_transaction(7u64.into(), faux_confirmed_tx.clone()))
+        db.insert_completed_transaction(7u64.into(), faux_confirmed_tx.clone())
             .unwrap();
 
         let (transaction_event_sender, transaction_event_receiver) = broadcast::channel(20);


### PR DESCRIPTION
Description
---
Removed spawn blocking calls for db operations from the wallet in the transaction service.
(This is the last  PR in a couple of PRs required to implement this fully throughout the wallet code.)

Motivation and Context
---
As per https://github.com/tari-project/tari/pull/3982 and https://github.com/tari-project/tari/issues/4555

How Has This Been Tested?
---
Unit tests
Cucumber tests
