### PR TITLE
fix(wallet): use RPC pool connections for non-recovery utxo scanning

### DIFF
--- a/applications/tari_console_wallet/src/recovery.rs
+++ b/applications/tari_console_wallet/src/recovery.rs
@@ -29,6 +29,7 @@ use tari_key_manager::{cipher_seed::CipherSeed, mnemonic::Mnemonic};
 use tari_shutdown::Shutdown;
 use tari_utilities::hex::Hex;
 use tari_wallet::{
+    connectivity_service::WalletConnectivityHandle,
     storage::sqlite_db::wallet::WalletSqliteDatabase,
     utxo_scanner_service::{handle::UtxoScannerEvent, service::UtxoScannerService},
     WalletSqlite,
@@ -107,7 +108,7 @@ pub async fn wallet_recovery(
             .map_err(|err| ExitError::new(ExitCode::NetworkError, err))?;
     }
 
-    let mut recovery_task = UtxoScannerService::<WalletSqliteDatabase>::builder()
+    let mut recovery_task = UtxoScannerService::<WalletSqliteDatabase, WalletConnectivityHandle>::builder()
         .with_peers(peer_public_keys)
         // Do not make this a small number as wallet recovery needs to be resilient
         .with_retry_limit(retry_limit)

--- a/base_layer/wallet/src/connectivity_service/service.rs
+++ b/base_layer/wallet/src/connectivity_service/service.rs
@@ -304,8 +304,7 @@ impl WalletConnectivityService {
             conn.peer_node_id()
         );
         self.pools = Some(ClientPoolContainer {
-            base_node_sync_rpc_client: conn
-                .create_rpc_client_pool(self.config.base_node_rpc_pool_size, Default::default()),
+            base_node_sync_rpc_client: conn.create_rpc_client_pool(1, Default::default()),
             base_node_wallet_rpc_client: conn
                 .create_rpc_client_pool(self.config.base_node_rpc_pool_size, Default::default()),
         });

--- a/base_layer/wallet/src/utxo_scanner_service/error.rs
+++ b/base_layer/wallet/src/utxo_scanner_service/error.rs
@@ -61,4 +61,6 @@ pub enum UtxoScannerError {
     OverflowError,
     #[error("FixedHash size error: `{0}`")]
     FixedHashSizeError(#[from] FixedHashSizeError),
+    #[error("Connectivity has shut down")]
+    ConnectivityShutdown,
 }

--- a/base_layer/wallet/src/utxo_scanner_service/initializer.rs
+++ b/base_layer/wallet/src/utxo_scanner_service/initializer.rs
@@ -31,7 +31,7 @@ use tokio::sync::broadcast;
 
 use crate::{
     base_node_service::handle::BaseNodeServiceHandle,
-    connectivity_service::{WalletConnectivityHandle, WalletConnectivityInterface},
+    connectivity_service::WalletConnectivityHandle,
     output_manager_service::handle::OutputManagerHandle,
     storage::database::{WalletBackend, WalletDatabase},
     transaction_service::handle::TransactionServiceHandle,
@@ -97,14 +97,14 @@ where T: WalletBackend + 'static
             let wallet_connectivity = handles.expect_handle::<WalletConnectivityHandle>();
             let base_node_service_handle = handles.expect_handle::<BaseNodeServiceHandle>();
 
-            let scanning_service = UtxoScannerService::<T>::builder()
+            let scanning_service = UtxoScannerService::<T, WalletConnectivityHandle>::builder()
                 .with_peers(vec![])
                 .with_retry_limit(2)
                 .with_mode(UtxoScannerMode::Scanning)
                 .build_with_resources(
                     backend,
                     comms_connectivity,
-                    wallet_connectivity.get_current_base_node_watcher(),
+                    wallet_connectivity.clone(),
                     output_manager_service,
                     transaction_service,
                     node_identity,

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -125,7 +125,7 @@ use tari_script::{inputs, script};
 use tari_shutdown::Shutdown;
 use tari_utilities::{hex, hex::Hex, SafePassword};
 use tari_wallet::{
-    connectivity_service::WalletConnectivityInterface,
+    connectivity_service::{WalletConnectivityHandle, WalletConnectivityInterface},
     contacts_service::storage::database::Contact,
     error::{WalletError, WalletStorageError},
     output_manager_service::{
@@ -7094,7 +7094,7 @@ pub unsafe extern "C" fn wallet_start_recovery(
 
     let shutdown_signal = (*wallet).shutdown.to_signal();
     let peer_public_keys: Vec<TariPublicKey> = vec![(*base_node_public_key).clone()];
-    let mut recovery_task_builder = UtxoScannerService::<WalletSqliteDatabase>::builder();
+    let mut recovery_task_builder = UtxoScannerService::<WalletSqliteDatabase, WalletConnectivityHandle>::builder();
 
     if !recovered_output_message.is_null() {
         let message_str = match CStr::from_ptr(recovered_output_message).to_str() {


### PR DESCRIPTION
Description
---
- use RPC pool in wallet connectivity when scanning for UTXOs from the base node peer
- extra: make potentially long-running `ping-peer` async 

Motivation and Context
---

Fixes the wallet exceeding the max RPC sessions per peer limit of 10.
```
09:53 WARN  Rejecting handshake because no more RPC sessions available
09:53 ERROR error=Maximum number of client RPC sessions reached for node ee4baee242d0baffcab6ef5f20
```

How Has This Been Tested?
---
Manual, 6 wallets connected to one base node, UTXO scanning and recovery and a number of stress tests - max rpc sessions were used but not exceeded
