### PR TITLE
feat(comms): update yamux and snow dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -477,7 +477,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c24dab4283a142afa2fdca129b80ad2c6284e073930f964c3a1293c225ee39a"
 dependencies = [
- "rustc_version 0.4.0",
+ "rustc_version",
 ]
 
 [[package]]
@@ -574,7 +574,6 @@ dependencies = [
  "cfg-if 1.0.0",
  "cipher 0.3.0",
  "cpufeatures 0.1.5",
- "zeroize",
 ]
 
 [[package]]
@@ -598,19 +597,6 @@ dependencies = [
  "cfg-if 1.0.0",
  "cipher 0.4.3",
  "cpufeatures 0.2.2",
-]
-
-[[package]]
-name = "chacha20poly1305"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1580317203210c517b6d44794abfbe600698276db18127e37ad3e69bf5e848e5"
-dependencies = [
- "aead 0.4.3",
- "chacha20 0.7.1",
- "cipher 0.3.0",
- "poly1305 0.7.2",
- "zeroize",
 ]
 
 [[package]]
@@ -1233,6 +1219,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.0.0-pre.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4033478fbf70d6acf2655ac70da91ee65852d69daf7a67bf7a2f518fb47aafcf"
+dependencies = [
+ "byteorder",
+ "digest 0.9.0",
+ "rand_core 0.6.3",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "curve25519-dalek-ng"
 version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1363,7 +1362,7 @@ dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "rustc_version 0.4.0",
+ "rustc_version",
  "syn",
 ]
 
@@ -1498,11 +1497,11 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
- "curve25519-dalek",
+ "curve25519-dalek 3.2.0",
  "ed25519",
  "rand 0.7.3",
  "serde",
- "sha2",
+ "sha2 0.9.9",
  "zeroize",
 ]
 
@@ -2658,7 +2657,7 @@ version = "0.17.2"
 source = "git+https://github.com/tari-project/monero-rs.git?branch=main#7aebfd0aa037025cac6cbded3f72d73bf3c18123"
 dependencies = [
  "base58-monero 1.0.0",
- "curve25519-dalek",
+ "curve25519-dalek 3.2.0",
  "fixed-hash",
  "hex",
  "hex-literal",
@@ -3345,7 +3344,7 @@ dependencies = [
  "ripemd160",
  "rsa",
  "sha-1 0.9.8",
- "sha2",
+ "sha2 0.9.9",
  "sha3",
  "signature",
  "smallvec",
@@ -4008,20 +4007,11 @@ checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustc_version"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
-dependencies = [
- "semver 0.11.0",
-]
-
-[[package]]
-name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.10",
+ "semver",
 ]
 
 [[package]]
@@ -4192,27 +4182,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a41d061efea015927ac527063765e73601444cdc344ba855bc7bd44578b25e1c"
-
-[[package]]
-name = "semver-parser"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
-dependencies = [
- "pest",
-]
 
 [[package]]
 name = "serde"
@@ -4365,6 +4337,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899bf02746a2c92bf1053d9327dadb252b01af1f81f90cdb902411f518bc7215"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures 0.2.2",
+ "digest 0.10.3",
+]
+
+[[package]]
 name = "sha3"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4453,19 +4436,18 @@ checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
 name = "snow"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6142f7c25e94f6fd25a32c3348ec230df9109b463f59c8c7acc4bd34936babb7"
+checksum = "774d05a3edae07ce6d68ea6984f3c05e9bba8927e3dd591e3b479e5b03213d0d"
 dependencies = [
  "aes-gcm",
- "blake2 0.9.2",
- "chacha20poly1305 0.8.0",
- "rand 0.8.5",
+ "blake2 0.10.4",
+ "chacha20poly1305 0.9.1",
+ "curve25519-dalek 4.0.0-pre.1",
  "rand_core 0.6.3",
- "rustc_version 0.3.3",
- "sha2",
+ "rustc_version",
+ "sha2 0.10.3",
  "subtle",
- "x25519-dalek",
 ]
 
 [[package]]
@@ -4774,7 +4756,7 @@ dependencies = [
  "prost-build",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.9.9",
  "sha3",
  "structopt",
  "tari_common_types",
@@ -4944,7 +4926,7 @@ dependencies = [
  "rustyline",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.9.9",
  "strum",
  "strum_macros",
  "tari_app_grpc",
@@ -5079,7 +5061,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "sha2",
+ "sha2 0.9.9",
  "strum",
  "strum_macros",
  "tari_common_types",
@@ -5250,7 +5232,7 @@ dependencies = [
  "rand 0.8.5",
  "reqwest",
  "rustls",
- "semver 1.0.10",
+ "semver",
  "serde",
  "serde_derive",
  "tari_common",
@@ -5281,7 +5263,7 @@ dependencies = [
  "integer-encoding 3.0.3",
  "rand 0.8.5",
  "serde",
- "sha2",
+ "sha2 0.9.9",
  "sha3",
  "tari_common",
  "tari_common_types",
@@ -5384,7 +5366,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.9.9",
  "strum",
  "strum_macros",
  "tari_common",
@@ -6502,7 +6484,7 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a0c105152107e3b96f6a00a65e86ce82d9b125230e1c4302940eca58ff71f4f"
 dependencies = [
- "curve25519-dalek",
+ "curve25519-dalek 3.2.0",
  "rand_core 0.5.1",
  "zeroize",
 ]
@@ -6518,14 +6500,14 @@ dependencies = [
 
 [[package]]
 name = "yamux"
-version = "0.9.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7d9028f208dd5e63c614be69f115c1b53cacc1111437d4c765185856666c107"
+checksum = "e5d9ba232399af1783a58d8eb26f6b5006fbefe2dc9ef36bd283324792d03ea5"
 dependencies = [
  "futures 0.3.21",
  "log",
  "nohash-hasher",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.1",
  "rand 0.8.5",
  "static_assertions",
 ]

--- a/comms/core/Cargo.toml
+++ b/comms/core/Cargo.toml
@@ -42,14 +42,14 @@ prost-types = "0.9.0"
 rand = "0.8"
 serde = "1.0.119"
 serde_derive = "1.0.119"
-snow = { version = "=0.8.0", features = ["default-resolver"] }
+snow = { version = "=0.9.0", features = ["default-resolver"] }
 thiserror = "1.0.26"
 tokio = { version = "1.20", features = ["rt-multi-thread", "time", "sync", "signal", "net", "macros", "io-util"] }
 tokio-stream = { version = "0.1.9", features = ["sync"] }
 tokio-util = { version = "0.6.7", features = ["codec", "compat"] }
 tower = {version = "0.4", features = ["util"]}
 tracing = "0.1.26"
-yamux = "=0.9.0"
+yamux = "=0.10.2"
 
 [dev-dependencies]
 tari_test_utils = { version = "^0.38", path = "../../infrastructure/test_utils" }

--- a/comms/core/src/noise/crypto_resolver.rs
+++ b/comms/core/src/noise/crypto_resolver.rs
@@ -112,8 +112,8 @@ impl Dh for CommsDiffieHellman {
         self.secret_key.as_bytes()
     }
 
-    fn dh(&self, public_key: &[u8], out: &mut [u8]) -> Result<(), ()> {
-        let pk = CommsPublicKey::from_bytes(&public_key[..self.pub_len()]).map_err(|_| ())?;
+    fn dh(&self, public_key: &[u8], out: &mut [u8]) -> Result<(), snow::Error> {
+        let pk = CommsPublicKey::from_bytes(&public_key[..self.pub_len()]).map_err(|_| snow::Error::Dh)?;
         let shared = CommsPublicKey::shared_secret(&self.secret_key, &pk);
         let hash = noise_kdf(&shared);
         copy_slice!(hash, out);


### PR DESCRIPTION
Description
---
- updates `yamux` from `0.9.0` to `0.10.2`
- updates `snow` from `0.8.0` to `0.9.0`

Motivation and Context
---

[Yamux changelog](https://github.com/libp2p/rust-yamux/blob/master/CHANGELOG.md)
[Snow changes](https://github.com/mcginty/snow/commits/master)

How Has This Been Tested?
---
Manually: Joined existing esme network, with wallet and base nodes and they continued to work
