### PR TITLE
fix(comms): only reap when number of connections exceeds threshold

### DIFF
--- a/applications/tari_base_node/src/commands/command/list_connections.rs
+++ b/applications/tari_base_node/src/commands/command/list_connections.rs
@@ -88,7 +88,8 @@ impl CommandContext {
                 format!(
                     "{}hnd: {}, ss: {}, rpc: {}",
                     chain_height.map(|s| format!("{}, ", s)).unwrap_or_default(),
-                    conn.handle_count(),
+                    // Exclude the handle held by list-connections
+                    conn.handle_count().saturating_sub(1),
                     conn.substream_count(),
                     rpc_sessions
                 ),

--- a/applications/tari_base_node/src/commands/command/list_connections.rs
+++ b/applications/tari_base_node/src/commands/command/list_connections.rs
@@ -55,7 +55,6 @@ impl CommandContext {
                 "Address",
                 "Direction",
                 "Age",
-                "Role",
                 "User Agent",
                 "Info",
             ]);
@@ -73,19 +72,16 @@ impl CommandContext {
                     .map(|metadata| format!("height: {}", metadata.metadata.height_of_longest_chain()));
 
                 let ua = peer.user_agent;
+                let rpc_sessions = self
+                    .rpc_server
+                    .get_num_active_sessions_for(peer.node_id.clone())
+                    .await?;
                 table.add_row(row![
                     peer.node_id,
                     peer.public_key,
                     conn.address(),
                     conn.direction(),
                     format_duration_basic(conn.age()),
-                    {
-                        if peer.features.is_client() {
-                            "Wallet"
-                        } else {
-                            "Base node"
-                        }
-                    },
                     {
                         if ua.is_empty() {
                             "<unknown>"
@@ -94,9 +90,11 @@ impl CommandContext {
                         }
                     },
                     format!(
-                        "substreams: {}{}",
+                        "{}hnd: {}, ss: {}, rpc: {}",
+                        chain_height.map(|s| format!("{}, ", s)).unwrap_or_default(),
+                        conn.handle_count(),
                         conn.substream_count(),
-                        chain_height.map(|s| format!(", {}", s)).unwrap_or_default()
+                        rpc_sessions
                     ),
                 ]);
             }

--- a/comms/core/src/connectivity/config.rs
+++ b/comms/core/src/connectivity/config.rs
@@ -33,6 +33,9 @@ pub struct ConnectivityConfig {
     pub connection_pool_refresh_interval: Duration,
     /// True if connection reaping is enabled, otherwise false (default: true)
     pub is_connection_reaping_enabled: bool,
+    /// The minimum number of connections that must exist before any connections may be reaped
+    /// Default: 50
+    pub reaper_min_connection_threshold: usize,
     /// The minimum age of the connection before it can be reaped. This prevents a connection that has just been
     /// established from being reaped due to inactivity. Default: 20 minutes
     pub reaper_min_inactive_age: Duration,
@@ -54,6 +57,7 @@ impl Default for ConnectivityConfig {
             min_connectivity: 1,
             connection_pool_refresh_interval: Duration::from_secs(60),
             reaper_min_inactive_age: Duration::from_secs(20 * 60),
+            reaper_min_connection_threshold: 50,
             is_connection_reaping_enabled: true,
             max_failures_mark_offline: 1,
             connection_tie_break_linger: Duration::from_secs(2),

--- a/comms/core/src/connectivity/connection_pool.rs
+++ b/comms/core/src/connectivity/connection_pool.rs
@@ -161,8 +161,10 @@ impl ConnectionPool {
             .unwrap_or(ConnectionStatus::NotConnected)
     }
 
-    pub fn get_inactive_connections_mut(&mut self, min_age: Duration) -> Vec<&mut PeerConnection> {
-        self.filter_connections_mut(|conn| conn.age() > min_age && conn.handle_count() <= 1)
+    pub fn get_inactive_outbound_connections_mut(&mut self, min_age: Duration) -> Vec<&mut PeerConnection> {
+        self.filter_connections_mut(|conn| {
+            conn.age() > min_age && conn.handle_count() <= 1 && conn.substream_count() > 2
+        })
     }
 
     pub(in crate::connectivity) fn filter_drain<P>(&mut self, mut predicate: P) -> Vec<PeerConnectionState>

--- a/comms/dht/src/connectivity/mod.rs
+++ b/comms/dht/src/connectivity/mod.rs
@@ -406,11 +406,6 @@ impl DhtConnectivity {
             self.insert_neighbour(peer);
         });
 
-        // Drop any connection handles that removed from the neighbour pool
-        difference.iter().for_each(|peer| {
-            self.remove_connection_handle(peer);
-        });
-
         if !new_neighbours.is_empty() {
             self.connectivity.request_many_dials(new_neighbours).await?;
         }


### PR DESCRIPTION
Description
---
- only release connection handles of non-neighbouring peers after successful connect
- adds min threshold for connection reaping with default 50
- only reap connections that have less than 3 substreams
- only reap "excess" (num_connections - 50) connections
- adds RpcServer query that returns number of sessions for a peer
- updates list-connections command to display number of peer connection handles and rpc sessions 
- updates list-connections to display two tables, one with wallets and one with base nodes

Motivation and Context
---
Previously, connection handles would be dropped (making them reapable) when refreshing the neighbour peer pool. The neighbour pool only starts the attempt to connect, but the non-neighbouring connection handles should only be dropped if a replacement neighbour was actually able to connect.
Reaping should only apply when we have many connections, otherwise many connections are acceptable.

Fixes #4608 

How Has This Been Tested?
---
Manually, checking that connections to other base nodes/wallets running this PR stay connected