### PR TITLE
fix(wallet): detect base node change during txo_validation

### DIFF
--- a/base_layer/wallet/src/connectivity_service/mock.rs
+++ b/base_layer/wallet/src/connectivity_service/mock.rs
@@ -69,6 +69,11 @@ impl WalletConnectivityMock {
         self.base_node_watch.send(Some(base_node_peer));
     }
 
+    pub async fn base_node_changed(&mut self) -> Option<Peer> {
+        self.base_node_watch.changed().await;
+        self.base_node_watch.borrow().as_ref().cloned()
+    }
+
     pub fn send_shutdown(&self) {
         self.base_node_wallet_rpc_client.send(None);
         self.base_node_sync_rpc_client.send(None);

--- a/base_layer/wallet/src/output_manager_service/error.rs
+++ b/base_layer/wallet/src/output_manager_service/error.rs
@@ -94,6 +94,8 @@ pub enum OutputManagerError {
     ServiceError(String),
     #[error("Base node is not synced")]
     BaseNodeNotSynced,
+    #[error("Base node changed")]
+    BaseNodeChanged,
     #[error("Invalid Sender Message Type")]
     InvalidSenderMessage,
     #[error("Coinbase build error: `{0}`")]

--- a/base_layer/wallet/src/output_manager_service/tasks/txo_validation_task.rs
+++ b/base_layer/wallet/src/output_manager_service/tasks/txo_validation_task.rs
@@ -27,14 +27,14 @@ use std::{
 
 use log::*;
 use tari_common_types::types::{BlockHash, FixedHash};
-use tari_comms::protocol::rpc::RpcError::RequestFailed;
+use tari_comms::{peer_manager::Peer, protocol::rpc::RpcError::RequestFailed};
 use tari_core::{
     base_node::rpc::BaseNodeWalletRpcClient,
     blocks::BlockHeader,
     proto::base_node::{QueryDeletedRequest, UtxoQueryRequest},
 };
-use tari_shutdown::ShutdownSignal;
 use tari_utilities::hex::Hex;
+use tokio::sync::watch;
 
 use crate::{
     connectivity_service::WalletConnectivityInterface,
@@ -54,6 +54,7 @@ const LOG_TARGET: &str = "wallet::output_service::txo_validation_task";
 pub struct TxoValidationTask<TBackend, TWalletConnectivity> {
     operation_id: u64,
     db: OutputManagerDatabase<TBackend>,
+    base_node_watch: watch::Receiver<Option<Peer>>,
     connectivity: TWalletConnectivity,
     event_publisher: OutputManagerEventSender,
     config: OutputManagerServiceConfig,
@@ -74,13 +75,14 @@ where
         Self {
             operation_id,
             db,
+            base_node_watch: connectivity.get_current_base_node_watcher(),
             connectivity,
             event_publisher,
             config,
         }
     }
 
-    pub async fn execute(mut self, _shutdown: ShutdownSignal) -> Result<u64, OutputManagerProtocolError> {
+    pub async fn execute(mut self) -> Result<u64, OutputManagerProtocolError> {
         let mut base_node_client = self
             .connectivity
             .obtain_base_node_wallet_rpc_client()
@@ -88,9 +90,15 @@ where
             .ok_or(OutputManagerError::Shutdown)
             .for_protocol(self.operation_id)?;
 
+        let base_node_peer = self
+            .base_node_watch
+            .borrow()
+            .as_ref()
+            .map(|p| p.node_id.clone())
+            .ok_or_else(|| OutputManagerProtocolError::new(self.operation_id, OutputManagerError::BaseNodeChanged))?;
         debug!(
             target: LOG_TARGET,
-            "Starting TXO validation protocol (Id: {})", self.operation_id,
+            "Starting TXO validation protocol with peer {} (Id: {})", base_node_peer, self.operation_id,
         );
 
         let last_mined_header = self.check_for_reorgs(&mut base_node_client).await?;
@@ -99,10 +107,11 @@ where
 
         self.update_spent_outputs(&mut base_node_client, last_mined_header)
             .await?;
+
         self.publish_event(OutputManagerEvent::TxoValidationSuccess(self.operation_id));
         debug!(
             target: LOG_TARGET,
-            "Finished TXO validation protocol (Id: {})", self.operation_id,
+            "Finished TXO validation protocol from base node {} (Id: {})", base_node_peer, self.operation_id,
         );
         Ok(self.operation_id)
     }
@@ -233,6 +242,7 @@ where
                 batch.len(),
                 self.operation_id
             );
+
             let (mined, unmined, tip_height) = self
                 .query_base_node_for_outputs(batch, wallet_client)
                 .await

--- a/base_layer/wallet/src/transaction_service/error.rs
+++ b/base_layer/wallet/src/transaction_service/error.rs
@@ -94,6 +94,8 @@ pub enum TransactionServiceError {
     AttemptedToBroadcastCoinbaseTransaction(TxId),
     #[error("No Base Node public keys are provided for Base chain broadcast and monitoring")]
     NoBaseNodeKeysProvided,
+    #[error("Base node changed during {task_name}")]
+    BaseNodeChanged { task_name: &'static str },
     #[error("Error sending data to Protocol via registered channels")]
     ProtocolChannelError,
     #[error("Transaction detected as rejected by mempool")]

--- a/base_layer/wallet/tests/output_manager_service_tests/service.rs
+++ b/base_layer/wallet/tests/output_manager_service_tests/service.rs
@@ -146,17 +146,20 @@ async fn setup_output_manager_service<T: OutputManagerBackend + 'static, U: KeyM
     mock_base_node_service.set_default_base_node_state();
     task::spawn(mock_base_node_service.run());
 
-    let wallet_connectivity_mock = create_wallet_connectivity_mock();
+    let mut wallet_connectivity_mock = create_wallet_connectivity_mock();
     // let (connectivity, connectivity_mock) = create_connectivity_mock();
     // let connectivity_mock_state = connectivity_mock.get_shared_state();
     // task::spawn(connectivity_mock.run());
+    let server_node_identity = build_node_identity(PeerFeatures::COMMUNICATION_NODE);
+
+    wallet_connectivity_mock.notify_base_node_set(server_node_identity.to_peer());
+    wallet_connectivity_mock.base_node_changed().await;
 
     let service = BaseNodeWalletRpcMockService::new();
     let rpc_service_state = service.get_state();
 
     let server = BaseNodeWalletRpcServer::new(service);
     let protocol_name = server.as_protocol_name();
-    let server_node_identity = build_node_identity(PeerFeatures::COMMUNICATION_NODE);
 
     let mut mock_server = MockRpcServer::new(server, server_node_identity.clone());
     mock_server.serve();
@@ -1302,7 +1305,6 @@ async fn test_txo_validation() {
 
     let mut oms = setup_output_manager_service(backend, ks_backend, true).await;
 
-    oms.wallet_connectivity_mock.notify_base_node_set(oms.node_id.to_peer());
     // Now we add the connection
     let mut connection = oms
         .mock_rpc_service
@@ -1854,7 +1856,6 @@ async fn test_txo_revalidation() {
 
     let mut oms = setup_output_manager_service(backend, ks_backend, true).await;
 
-    oms.wallet_connectivity_mock.notify_base_node_set(oms.node_id.to_peer());
     // Now we add the connection
     let mut connection = oms
         .mock_rpc_service

--- a/base_layer/wallet/tests/transaction_service_tests/service.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/service.rs
@@ -292,7 +292,7 @@ async fn setup_transaction_service_no_comms(
 
     mock_rpc_server.serve();
 
-    let wallet_connectivity_service_mock = create_wallet_connectivity_mock();
+    let mut wallet_connectivity_service_mock = create_wallet_connectivity_mock();
 
     let mut rpc_server_connection = mock_rpc_server
         .create_connection(base_node_identity.to_peer(), protocol_name.into())
@@ -300,6 +300,8 @@ async fn setup_transaction_service_no_comms(
 
     wallet_connectivity_service_mock
         .set_base_node_wallet_rpc_client(connect_rpc_client(&mut rpc_server_connection).await);
+    wallet_connectivity_service_mock.set_base_node(base_node_identity.to_peer());
+    wallet_connectivity_service_mock.base_node_changed().await;
 
     let constants = ConsensusConstantsBuilder::new(Network::Weatherwax).build();
 
@@ -478,7 +480,7 @@ async fn manage_single_transaction() {
     let (bob_connection, _tempdir) = make_wallet_database_connection(Some(database_path.clone()));
 
     let shutdown = Shutdown::new();
-    let (mut alice_ts, mut alice_oms, _alice_comms, mut alice_connectivity) = setup_transaction_service(
+    let (mut alice_ts, mut alice_oms, _alice_comms, _alice_connectivity) = setup_transaction_service(
         alice_node_identity.clone(),
         vec![],
         factories.clone(),
@@ -489,13 +491,11 @@ async fn manage_single_transaction() {
     )
     .await;
 
-    alice_connectivity.set_base_node(base_node_identity.to_peer());
-
     let mut alice_event_stream = alice_ts.get_event_stream();
 
     sleep(Duration::from_secs(2)).await;
 
-    let (mut bob_ts, mut bob_oms, bob_comms, mut bob_connectivity) = setup_transaction_service(
+    let (mut bob_ts, mut bob_oms, bob_comms, _bob_connectivity) = setup_transaction_service(
         bob_node_identity.clone(),
         vec![alice_node_identity.clone()],
         factories.clone(),
@@ -505,7 +505,6 @@ async fn manage_single_transaction() {
         shutdown.to_signal(),
     )
     .await;
-    bob_connectivity.set_base_node(base_node_identity.to_peer());
 
     let mut bob_event_stream = bob_ts.get_event_stream();
 
@@ -620,7 +619,7 @@ async fn single_transaction_to_self() {
     let (db_connection, _tempdir) = make_wallet_database_connection(Some(database_path.clone()));
 
     let shutdown = Shutdown::new();
-    let (mut alice_ts, mut alice_oms, _alice_comms, mut alice_connectivity) = setup_transaction_service(
+    let (mut alice_ts, mut alice_oms, _alice_comms, _alice_connectivity) = setup_transaction_service(
         alice_node_identity.clone(),
         vec![],
         factories.clone(),
@@ -630,8 +629,6 @@ async fn single_transaction_to_self() {
         shutdown.to_signal(),
     )
     .await;
-
-    alice_connectivity.set_base_node(base_node_identity.to_peer());
 
     let initial_wallet_value = 25000.into();
     let (_utxo, uo1) = make_input(&mut OsRng, initial_wallet_value, &factories.commitment).await;
@@ -700,7 +697,7 @@ async fn send_one_sided_transaction_to_other() {
     let (db_connection, _tempdir) = make_wallet_database_connection(Some(database_path.clone()));
 
     let shutdown = Shutdown::new();
-    let (mut alice_ts, mut alice_oms, _alice_comms, mut alice_connectivity) = setup_transaction_service(
+    let (mut alice_ts, mut alice_oms, _alice_comms, _alice_connectivity) = setup_transaction_service(
         alice_node_identity,
         vec![],
         factories.clone(),
@@ -712,8 +709,6 @@ async fn send_one_sided_transaction_to_other() {
     .await;
 
     let mut alice_event_stream = alice_ts.get_event_stream();
-
-    alice_connectivity.set_base_node(base_node_identity.to_peer());
 
     let initial_wallet_value = 25000.into();
     let (_utxo, uo1) = make_input(&mut OsRng, initial_wallet_value, &factories.commitment).await;
@@ -807,7 +802,7 @@ async fn recover_one_sided_transaction() {
     let (bob_connection, _tempdir) = make_wallet_database_connection(Some(database_path2.clone()));
 
     let shutdown = Shutdown::new();
-    let (mut alice_ts, alice_oms, _alice_comms, mut alice_connectivity) = setup_transaction_service(
+    let (mut alice_ts, alice_oms, _alice_comms, _alice_connectivity) = setup_transaction_service(
         alice_node_identity,
         vec![],
         factories.clone(),
@@ -838,8 +833,6 @@ async fn recover_one_sided_transaction() {
     };
     let mut cloned_bob_oms = bob_oms.clone();
     cloned_bob_oms.add_known_script(known_script).await.unwrap();
-
-    alice_connectivity.set_base_node(base_node_identity.to_peer());
 
     let initial_wallet_value = 25000.into();
     let (_utxo, uo1) = make_input(&mut OsRng, initial_wallet_value, &factories.commitment).await;
@@ -913,7 +906,7 @@ async fn test_htlc_send_and_claim() {
     let bob_connection = run_migration_and_create_sqlite_connection(&bob_db_path, 16).unwrap();
 
     let shutdown = Shutdown::new();
-    let (mut alice_ts, mut alice_oms, _alice_comms, mut alice_connectivity) = setup_transaction_service(
+    let (mut alice_ts, mut alice_oms, _alice_comms, _alice_connectivity) = setup_transaction_service(
         alice_node_identity,
         vec![],
         factories.clone(),
@@ -932,8 +925,6 @@ async fn test_htlc_send_and_claim() {
     );
 
     let mut alice_event_stream = alice_ts.get_event_stream();
-
-    alice_connectivity.set_base_node(base_node_identity.to_peer());
 
     let initial_wallet_value = 25000.into();
     let (_utxo, uo1) = make_input(&mut OsRng, initial_wallet_value, &factories.commitment).await;
@@ -1035,7 +1026,7 @@ async fn send_one_sided_transaction_to_self() {
     let (alice_connection, _tempdir) = make_wallet_database_connection(Some(database_path.clone()));
 
     let shutdown = Shutdown::new();
-    let (alice_ts, alice_oms, _alice_comms, mut alice_connectivity) = setup_transaction_service(
+    let (alice_ts, alice_oms, _alice_comms, _alice_connectivity) = setup_transaction_service(
         alice_node_identity.clone(),
         vec![],
         factories.clone(),
@@ -1045,8 +1036,6 @@ async fn send_one_sided_transaction_to_self() {
         shutdown.to_signal(),
     )
     .await;
-
-    alice_connectivity.set_base_node(base_node_identity.to_peer());
 
     let initial_wallet_value = 2500.into();
     let (_utxo, uo1) = make_input(&mut OsRng, initial_wallet_value, &factories.commitment).await;
@@ -1078,7 +1067,6 @@ async fn send_one_sided_transaction_to_self() {
 
 #[tokio::test]
 async fn manage_multiple_transactions() {
-    env_logger::init();
     let factories = CryptoFactories::default();
     // Alice's parameters
     let alice_node_identity = Arc::new(NodeIdentity::random(
@@ -3323,11 +3311,6 @@ async fn test_coinbase_generation_and_monitoring() {
     assert!(transactions.values().any(|tx| tx.amount == fees1 + reward1));
     assert!(transactions.values().any(|tx| tx.amount == fees2b + reward2));
 
-    // Start the transaction protocols
-    alice_ts_interface
-        .wallet_connectivity_service_mock
-        .set_base_node(alice_ts_interface.base_node_identity.to_peer());
-
     let delay = sleep(Duration::from_secs(30));
     tokio::pin!(delay);
     let mut count = 0usize;
@@ -3399,10 +3382,6 @@ async fn test_coinbase_generation_and_monitoring() {
     alice_ts_interface
         .base_node_rpc_mock_state
         .set_transaction_query_batch_responses(batch_query_response);
-
-    alice_ts_interface
-        .wallet_connectivity_service_mock
-        .set_base_node(alice_ts_interface.base_node_identity.to_peer());
 
     alice_ts_interface
         .transaction_service_handle
@@ -3538,11 +3517,6 @@ async fn test_coinbase_abandoned() {
     alice_ts_interface
         .base_node_rpc_mock_state
         .set_transaction_query_batch_responses(batch_query_response);
-
-    // Start the transaction protocols
-    alice_ts_interface
-        .wallet_connectivity_service_mock
-        .set_base_node(alice_ts_interface.base_node_identity.to_peer());
 
     let balance = alice_ts_interface
         .output_manager_service_handle
@@ -5335,16 +5309,6 @@ async fn broadcast_all_completed_transactions_on_startup() {
             height_of_longest_chain: 0,
             mined_timestamp: None,
         });
-
-    assert!(alice_ts_interface
-        .transaction_service_handle
-        .restart_broadcast_protocols()
-        .await
-        .is_err());
-
-    alice_ts_interface
-        .wallet_connectivity_service_mock
-        .set_base_node(alice_ts_interface.base_node_identity.to_peer());
 
     // Note: The event stream has to be assigned before the broadcast protocol is restarted otherwise the events will be
     // dropped


### PR DESCRIPTION
Description
---

Interrupt txo_validation_protocol and txo_validation_task if base node is changed

Motivation and Context
---
These long-running tasks continue to run using the same base node even if it has changed. This PR checks for base node changes and interrupts the tasks at the correct points.

Other tasks may also need to be interrupted in a similar way.

Ref #4599 - this may fix this issue, but more info is needed to confirm

How Has This Been Tested?
---
Manually, changing the base node and checking that the tasks end.
