### PR TITLE
fix: reduces RPC error log to debug when domain-level RPC service returns an error (fixes #4579)

### DIFF
--- a/comms/core/src/protocol/rpc/server/mod.rs
+++ b/comms/core/src/protocol/rpc/server/mod.rs
@@ -542,7 +542,7 @@ where
                         return Err(err);
                     }
                     let elapsed = start.elapsed();
-                    warn!(
+                    debug!(
                         target: LOG_TARGET,
                         "({}) RPC request completed in {:.0?}{}",
                         self.logging_context_string,
@@ -663,7 +663,7 @@ where
                 self.process_body(request_id, deadline, body).await?;
             },
             Err(err) => {
-                warn!(
+                debug!(
                     target: LOG_TARGET,
                     "{} Service returned an error: {}", self.logging_context_string, err
                 );

--- a/comms/core/src/protocol/rpc/server/mod.rs
+++ b/comms/core/src/protocol/rpc/server/mod.rs
@@ -542,7 +542,7 @@ where
                         return Err(err);
                     }
                     let elapsed = start.elapsed();
-                    debug!(
+                    warn!(
                         target: LOG_TARGET,
                         "({}) RPC request completed in {:.0?}{}",
                         self.logging_context_string,
@@ -663,7 +663,7 @@ where
                 self.process_body(request_id, deadline, body).await?;
             },
             Err(err) => {
-                error!(
+                warn!(
                     target: LOG_TARGET,
                     "{} Service returned an error: {}", self.logging_context_string, err
                 );


### PR DESCRIPTION
Description
---
The `comms` server code contains incorrect logs, as referred in #4579.

Motivation and Context
---
Fixes #4579.

How Has This Been Tested?
--- Log information

