### PR TITLE
chore: update peer seeds

### DIFF
--- a/common/config/presets/b_peer_seeds.toml
+++ b/common/config/presets/b_peer_seeds.toml
@@ -20,18 +20,24 @@
 dns_seeds = ["seeds.esmeralda.tari.com"]
 # Custom specified peer seed nodes
 peer_seeds = [
-    # 00000df938d2615412b1e9fe9b
-    "68667362ceadf4543f4bac3a47e8bd1b6c5cbdab90fa781392e419b8ee03a153::/onion3/lf2p2zwuinjkk4bzzwddbol64x5ycofanja25zu2oxmrofa3nk43ypyd:18141",
-    # 33333faa19573c7d4c35d54c68
-    "a482e5541dfc76b53bddda5ad68a8bdec290c862e6e5c716e6014acd65347411::/onion3/3mpymjycel3ufraw55cnl5tvednrnzmqvq56vaydswnboibkja2d4tid:18141",
-    # 55555c74402e51a342a92afaea
-    "fe67c469fe61f31765f43ec781dcdde78092204d36bbdc544cb09ca41d495e06::/onion3/tbmffvb67hf2ujfh5md6n2hhgi5guao2ahmv54bh3vr5x3wjor2u5cid:18141",
-    # 88888dfde986ebd7a40966169e
-    "3cf5da9cecaf347b6fcfee9c8751be9fad529878572b19da3bd24c9704ab2426::/onion3/jxh2bl4zunbrd3y7pgayvcj3l4iczcne2s5h47lclv6e3kjzxbaplgqd:18141",
-    # 222223a86f76f1d09c05ef96cd
-    "18df727907476f455809d3794cfec1d489b6bf305d06467e8cf5cb102402530b::/onion3/vv26lxr727pvvxbmgf3sdbobqsqqfrtasfkavs4js5vlq3lk34a54hid:18141",
-    # 444447b8fdcfc7458f727ef9a2
-    "72468fae60e65218276793eabb764ed7280049bb74560ca18710755234bcce49::/onion3/oqpd4wgd7tzagvvgkfwrdu6ssvoqaw4zdoqhvutof2flgkgj6gwrpfqd:18141",
+    # 7777773c100a094c4feaa686cf
+    "d2cc8ad88271f075d7c3896179dc867a79115a136c9d9e175fe4ea774dafc75c::/onion3/atlitn6ewryimdviu4kjkjos3ift5v3ykvosgtnfgjocpdmondhykqid:18141",
+    # 222222c9629a9fcf5a71a18838
+    "78b2c0bda70fd12a9987757ffc2851e197080af804353e8e025d28c785b6b447::/onion3/ysj76foyp7qkl7d5x63hyocmp5ydwcgkb25oalo23kj2vvx7zjvofqad:18141",
+    # 3333334aee7f7bfde22e77af02
+    "8648575c606269b032f43cd0d54728628ddb911e636bd65ea36e867a5ffd3643::/onion3/5d2owx6uoqcsoapprattb4fmektm3rcpfyzmmwmf64dsu55mhcqef2yd:18141",
+    # 888888fe452d7db3e87224cafb
+    "083ff333ad7e0e9f3678b67378ec339074474342a6357de64a76bdf15e4c955b::/onion3/ldgdytcrwzfbmbpz3dmyi6yzqzqbeamitpb2saxzxmp52qywlmsg4vyd:18141",
+    # 555555cf2a79f8da9a6b1fecb3
+    "ea420ae2948739bc35907b8ab5a2d41526ccef22ec92f8f8e2bb398500bf435a::/onion3/uybnlnzve4j4w2lj5bdoe2uurwsbjm73ck2cotlnknhu2l7msn26oeyd:18141",
+    # 444444f30fe3a4bf8e5937773e
+    "f688c69f2397dc0d4ad18168cd6ad13f93241a665acf19ab7f358fd661ac3d1c::/onion3/qejny5yprzidxt4rhstjmhsyfmeq4yb4r6tnn3pqowjr7e7roxcpxsqd:18141",
+    # 0000008034cc6453ffae1d0b80
+    "40717ea5146cf6183c07469d188792b12a57b9da2e5af5bc50df270ff789257f::/onion3/qhmrwr2h3fnszwc4udhlgfpealm7mvw64enqghullrarc633fzmd6zqd:18141",
+    # bbbbbb1746d41d5be9936652fd
+    "faf52a5c6364e6bb7dc3a02743273115c7e218e1ef78f27d540c87b35715a005::/onion3/g5txoagsodgpkm2onsfn6r2fuzdzxlggaewre3edghdfzlw6szeo4cqd:18141",
+    # aaaaaac0add43b4b29a983891c
+    "a0e604c9a504558839a5c38faf034024a38c95fe6b04638b89dbfda756adff54::/onion3/vslf4ro52c4dktz2r5qybpwho3v25ikviwgvxf3ujryn2afock3qowad:18141",
 ]
 
 [igor.p2p.seeds]


### PR DESCRIPTION
Description
---
Updates the peer seeds to the new fixed addresses and signatures so that the peer seeds will advertise themselves as base_nodes and not wallets. 
