### PR TITLE
feat(ci): switch out ubuntu dependencies for script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 ---
 name: CI
 
-on:
+'on':
   workflow_dispatch:
   push:
     branches:
@@ -24,7 +24,8 @@ env:
 jobs:
   clippy:
     name: clippy
-    runs-on: [ self-hosted, ubuntu18.04-high-cpu ]
+    #runs-on: [ self-hosted, ubuntu18.04-high-cpu ]
+    runs-on: [ ubuntu-20.04 ]
     steps:
       - name: checkout
         uses: actions/checkout@v2
@@ -36,19 +37,8 @@ jobs:
           override: true
       - name: ubuntu dependencies
         run: |
-          sudo apt-get update && \
-          sudo apt-get -y install \
-          build-essential \
-          libgtk-3-dev \
-          libwebkit2gtk-4.0-dev \
-          libsoup2.4-dev \
-          curl \
-          wget \
-          libappindicator3-dev \
-          patchelf \
-          librsvg2-dev \
-          libprotobuf-dev \
-          protobuf-compiler
+          sudo apt-get update
+          sudo bash scripts/install_ubuntu_dependencies.sh
       - name: cargo fmt
         uses: actions-rs/cargo@v1
         with:
@@ -78,19 +68,8 @@ jobs:
           override: true
       - name: ubuntu dependencies
         run: |
-          sudo apt-get update && \
-          sudo apt-get -y install \
-          build-essential \
-          libgtk-3-dev \
-          libwebkit2gtk-4.0-dev \
-          libsoup2.4-dev \
-          curl \
-          wget \
-          libappindicator3-dev \
-          patchelf \
-          librsvg2-dev \
-          libprotobuf-dev \
-          protobuf-compiler
+          sudo apt-get update
+          sudo bash scripts/install_ubuntu_dependencies.sh
       - name: cargo check
         uses: actions-rs/cargo@v1
         with:
@@ -116,19 +95,8 @@ jobs:
       - uses: Swatinem/rust-cache@v1
       - name: ubuntu dependencies
         run: |
-          sudo apt-get update && \
-          sudo apt-get -y install \
-          build-essential \
-          libgtk-3-dev \
-          libwebkit2gtk-4.0-dev \
-          libsoup2.4-dev \
-          curl \
-          wget \
-          libappindicator3-dev \
-          patchelf \
-          librsvg2-dev \
-          libprotobuf-dev \
-          protobuf-compiler
+          sudo apt-get update
+          sudo bash scripts/install_ubuntu_dependencies.sh
       - name: rustup show
         run: |
           rustup show
@@ -167,19 +135,8 @@ jobs:
           toolchain: ${{ env.toolchain }}
       - name: ubuntu dependencies
         run: |
-          sudo apt-get update && \
-          sudo apt-get -y install \
-          build-essential \
-          libgtk-3-dev \
-          libwebkit2gtk-4.0-dev \
-          libsoup2.4-dev \
-          curl \
-          wget \
-          libappindicator3-dev \
-          patchelf \
-          librsvg2-dev \
-          libprotobuf-dev \
-          protobuf-compiler
+          sudo apt-get update
+          sudo bash scripts/install_ubuntu_dependencies.sh
       - name: test key manager wasm
         run: |
           npm install -g wasm-pack
@@ -196,9 +153,10 @@ jobs:
         with:
           command: test
           args: -v --all-features --release
+
   # Allows other workflows to know the PR number
   artifacts:
-    name: test
+    name: pr_2_artifact
     runs-on: [ ubuntu-20.04 ]
     steps:
       - name: Save the PR number in an artifact


### PR DESCRIPTION
Description
Switch out ubuntu dependencies for script from workflow

Motivation and Context
Using a single bash script makes updates easier. Also local installs can use the same ubuntu dependencies install script.

How Has This Been Tested?
Only clippy has been tested