### PR TITLE
chore: change log level when picking up old transaction

### DIFF
--- a/base_layer/core/src/validation/transaction_validators.rs
+++ b/base_layer/core/src/validation/transaction_validators.rs
@@ -171,7 +171,6 @@ impl<B: BlockchainBackend> TxConsensusValidator<B> {
                     db_kernel.excess_sig.get_public_nonce().to_hex(),
                     db_kernel.excess_sig.get_signature().to_hex(),
                 );
-                debug!(target: LOG_TARGET, "{}", msg);
                 return Err(ValidationError::DuplicateKernelError(msg));
             };
         }

--- a/base_layer/core/src/validation/transaction_validators.rs
+++ b/base_layer/core/src/validation/transaction_validators.rs
@@ -171,7 +171,7 @@ impl<B: BlockchainBackend> TxConsensusValidator<B> {
                     db_kernel.excess_sig.get_public_nonce().to_hex(),
                     db_kernel.excess_sig.get_signature().to_hex(),
                 );
-                trace!(target: LOG_TARGET, "{}", msg);
+                debug!(target: LOG_TARGET, "{}", msg);
                 return Err(ValidationError::DuplicateKernelError(msg));
             };
         }

--- a/base_layer/core/src/validation/transaction_validators.rs
+++ b/base_layer/core/src/validation/transaction_validators.rs
@@ -171,7 +171,7 @@ impl<B: BlockchainBackend> TxConsensusValidator<B> {
                     db_kernel.excess_sig.get_public_nonce().to_hex(),
                     db_kernel.excess_sig.get_signature().to_hex(),
                 );
-                warn!(target: LOG_TARGET, "{}", msg);
+                trace!(target: LOG_TARGET, "{}", msg);
                 return Err(ValidationError::DuplicateKernelError(msg));
             };
         }


### PR DESCRIPTION
Description
---
Change log level from warn to trace
Motivation and Context
---
Currently its logging like this when pickup up an old transaction:
```
// base_layer/core/src/transactions/aggregated_body.rs:449 2022-09-07 12:47:12.330454000 [c::val::transaction_validators] [cc1ade71a24700ddefc86457dbb6e1446229641b0e1c56bce909bcd0f1a0f950,7acd212bf3c3b5a0428ebfec90] WARN  Block contains kernel excess: 7e466195f3ba58f88683b1da3fc628ec418b41b2f2b1f93e22afbc8fd4921b73 which matches already existing excess signature in chain database block hash: 38bd8d1a24b2512a56bacd8683843c167791767c97e9b294cc89714ce4b2f1d6. Existing kernel excess: 7e466195f3ba58f88683b1da3fc628ec418b41b2f2b1f93e22afbc8fd4921b73, excess sig nonce: ca1843aeab73ad01a3fa0f463ba916e77966fc223e85779ec7851f7b90c7a85d, excess signature: b68a423c5ffd80639722b687662d7d33006edc7da07bcdca7598a3d6e408b70e
 // base_layer/core/src/validation/transaction_validators.rs:174 2022-09-07 12:47:12.330458000 [c::mp::mempool_storage] [cc1ade71a24700ddefc86457dbb6e1446229641b0e1c56bce909bcd0f1a0f950,7acd212bf3c3b5a0428ebfec90] DEBUG Validation failed due to already mined kernel: Block contains kernel excess: 7e466195f3ba58f88683b1da3fc628ec418b41b2f2b1f93e22afbc8fd4921b73 which matches already existing excess signature in chain database block hash: 38bd8d1a24b2512a56bacd8683843c167791767c97e9b294cc89714ce4b2f1d6. Existing kernel excess: 7e466195f3ba58f88683b1da3fc628ec418b41b2f2b1f93e22afbc8fd4921b73, excess sig nonce: ca1843aeab73ad01a3fa0f463ba916e77966fc223e85779ec7851f7b90c7a85d, excess signature: b68a423c5ffd80639722b687662d7d33006edc7da07bcdca7598a3d6e408b70e
 ```
 
 This PR changes the first message to trace, as the info is already logged as debug, and this might not be a problem. 


