### PR TITLE
fix(ci): libtor build on Ubuntu

### DIFF
--- a/scripts/install_ubuntu_dependencies.sh
+++ b/scripts/install_ubuntu_dependencies.sh
@@ -6,6 +6,7 @@ apt-get -y install \
   clang-10 \
   git \
   cmake \
+  dh-autoreconf \
   libc++-dev \
   libc++abi-dev \
   libprotobuf-dev \


### PR DESCRIPTION
Description
libtor-sys requires autoconf & automake tools to build 

Motivation and Context
Improve builds on Ubuntu

How Has This Been Tested?
Tested in a clean Vagrant VM using ```scripts/install_ubuntu_dependencies.sh```
