### PR TITLE
fix(comms/rpc): detect early close in all cases

### DIFF
--- a/applications/tari_base_node/src/bootstrap.rs
+++ b/applications/tari_base_node/src/bootstrap.rs
@@ -78,7 +78,7 @@ impl<B> BaseNodeBootstrapper<'_, B>
 where B: BlockchainBackend + 'static
 {
     pub async fn bootstrap(self) -> Result<ServiceHandles, ExitError> {
-        let base_node_config = &self.app_config.base_node;
+        let mut base_node_config = self.app_config.base_node.clone();
         let mut p2p_config = self.app_config.base_node.p2p.clone();
         let peer_seeds = &self.app_config.peer_seeds;
 
@@ -94,6 +94,8 @@ where B: BlockchainBackend + 'static
             .map(|r| r.map(Peer::from).map(|p| p.node_id))
             .collect::<Result<Vec<_>, _>>()
             .map_err(|e| ExitError::new(ExitCode::ConfigError, e))?;
+
+        base_node_config.state_machine.blockchain_sync_config.forced_sync_peers = sync_peers.clone();
 
         debug!(target: LOG_TARGET, "{} sync peer(s) configured", sync_peers.len());
 

--- a/base_layer/core/src/base_node/sync/rpc/service.rs
+++ b/base_layer/core/src/base_node/sync/rpc/service.rs
@@ -35,7 +35,7 @@ use tari_comms::{
 };
 use tari_utilities::hex::Hex;
 use tokio::{
-    sync::{mpsc, RwLock},
+    sync::{mpsc, Mutex},
     task,
 };
 use tracing::{instrument, span, Instrument, Level};
@@ -65,7 +65,7 @@ const LOG_TARGET: &str = "c::base_node::sync_rpc";
 
 pub struct BaseNodeSyncRpcService<B> {
     db: AsyncBlockchainDb<B>,
-    active_sessions: RwLock<Vec<Weak<NodeId>>>,
+    active_sessions: Mutex<Vec<Weak<NodeId>>>,
     base_node_service: LocalNodeCommsInterface,
 }
 
@@ -73,7 +73,7 @@ impl<B: BlockchainBackend + 'static> BaseNodeSyncRpcService<B> {
     pub fn new(db: AsyncBlockchainDb<B>, base_node_service: LocalNodeCommsInterface) -> Self {
         Self {
             db,
-            active_sessions: RwLock::new(Vec::new()),
+            active_sessions: Mutex::new(Vec::new()),
             base_node_service,
         }
     }
@@ -84,7 +84,7 @@ impl<B: BlockchainBackend + 'static> BaseNodeSyncRpcService<B> {
     }
 
     pub async fn try_add_exclusive_session(&self, peer: NodeId) -> Result<Arc<NodeId>, RpcStatus> {
-        let mut lock = self.active_sessions.write().await;
+        let mut lock = self.active_sessions.lock().await;
         *lock = lock.drain(..).filter(|l| l.strong_count() > 0).collect();
         debug!(target: LOG_TARGET, "Number of active sync sessions: {}", lock.len());
 

--- a/base_layer/p2p/src/services/liveness/state.rs
+++ b/base_layer/p2p/src/services/liveness/state.rs
@@ -173,9 +173,11 @@ impl LivenessState {
 
         let (node_id, _) = self.inflight_pings.get(&nonce)?;
         if node_id == sent_by {
-            self.inflight_pings
-                .remove(&nonce)
-                .map(|(node_id, sent_time)| self.add_latency_sample(node_id, sent_time.elapsed()).calc_average())
+            self.inflight_pings.remove(&nonce).map(|(node_id, sent_time)| {
+                let latency = sent_time.elapsed();
+                self.add_latency_sample(node_id, latency);
+                latency
+            })
         } else {
             warn!(
                 target: LOG_TARGET,

--- a/comms/core/src/protocol/rpc/server/early_close.rs
+++ b/comms/core/src/protocol/rpc/server/early_close.rs
@@ -1,0 +1,119 @@
+//  Copyright 2022. The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::{
+    io,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use futures::Sink;
+use tokio_stream::Stream;
+
+pub struct EarlyClose<TSock> {
+    inner: TSock,
+}
+
+impl<T, TSock: Stream<Item = io::Result<T>> + Unpin> EarlyClose<TSock> {
+    pub fn new(inner: TSock) -> Self {
+        Self { inner }
+    }
+}
+
+impl<TSock: Stream + Unpin> Stream for EarlyClose<TSock> {
+    type Item = TSock::Item;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Pin::new(&mut self.inner).poll_next(cx)
+    }
+}
+
+impl<TItem, TSock, T> Sink<TItem> for EarlyClose<TSock>
+where TSock: Sink<TItem, Error = io::Error> + Stream<Item = io::Result<T>> + Unpin
+{
+    type Error = EarlyCloseError<T>;
+
+    fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        if let Poll::Ready(r) = Pin::new(&mut self.inner).poll_ready(cx) {
+            return Poll::Ready(r.map_err(Into::into));
+        }
+        check_for_early_close(&mut self.inner, cx)
+    }
+
+    fn start_send(mut self: Pin<&mut Self>, item: TItem) -> Result<(), Self::Error> {
+        Pin::new(&mut self.inner).start_send(item)?;
+        Ok(())
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        if let Poll::Ready(r) = Pin::new(&mut self.inner).poll_flush(cx) {
+            return Poll::Ready(r.map_err(Into::into));
+        }
+        check_for_early_close(&mut self.inner, cx)
+    }
+
+    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        if let Poll::Ready(r) = Pin::new(&mut self.inner).poll_close(cx) {
+            return Poll::Ready(r.map_err(Into::into));
+        }
+        check_for_early_close(&mut self.inner, cx)
+    }
+}
+
+fn check_for_early_close<T, TSock: Stream<Item = io::Result<T>> + Unpin>(
+    sock: &mut TSock,
+    cx: &mut Context<'_>,
+) -> Poll<Result<(), EarlyCloseError<T>>> {
+    match Pin::new(sock).poll_next(cx) {
+        Poll::Ready(Some(Ok(msg))) => Poll::Ready(Err(EarlyCloseError::UnexpectedMessage(msg))),
+        Poll::Ready(Some(Err(err))) if err.kind() == io::ErrorKind::WouldBlock => Poll::Pending,
+        Poll::Pending => Poll::Pending,
+        Poll::Ready(Some(Err(err))) => Poll::Ready(Err(err.into())),
+        Poll::Ready(None) => Poll::Ready(Err(
+            io::Error::new(io::ErrorKind::BrokenPipe, "Connection closed").into()
+        )),
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum EarlyCloseError<T> {
+    #[error(transparent)]
+    Io(#[from] io::Error),
+    #[error("Unexpected message")]
+    UnexpectedMessage(T),
+}
+
+impl<T> EarlyCloseError<T> {
+    pub fn io(&self) -> Option<&io::Error> {
+        match self {
+            Self::Io(err) => Some(err),
+            _ => None,
+        }
+    }
+
+    pub fn unexpected_message(&self) -> Option<&T> {
+        match self {
+            EarlyCloseError::UnexpectedMessage(msg) => Some(msg),
+            _ => None,
+        }
+    }
+}

--- a/comms/core/src/protocol/rpc/server/error.rs
+++ b/comms/core/src/protocol/rpc/server/error.rs
@@ -22,10 +22,15 @@
 
 use std::io;
 
+use bytes::BytesMut;
 use prost::DecodeError;
 use tokio::sync::oneshot;
 
-use crate::{peer_manager::NodeId, proto, protocol::rpc::handshake::RpcHandshakeError};
+use crate::{
+    peer_manager::NodeId,
+    proto,
+    protocol::rpc::{handshake::RpcHandshakeError, server::early_close::EarlyCloseError},
+};
 
 #[derive(Debug, thiserror::Error)]
 pub enum RpcServerError {
@@ -55,6 +60,8 @@ pub enum RpcServerError {
     ServiceCallExceededDeadline,
     #[error("Stream read exceeded deadline")]
     ReadStreamExceededDeadline,
+    #[error("Early close error: {0}")]
+    EarlyCloseError(#[from] EarlyCloseError<BytesMut>),
 }
 
 impl From<oneshot::error::RecvError> for RpcServerError {

--- a/comms/core/src/protocol/rpc/server/mod.rs
+++ b/comms/core/src/protocol/rpc/server/mod.rs
@@ -34,6 +34,7 @@ mod metrics;
 
 pub mod mock;
 
+mod early_close;
 mod router;
 
 use std::{
@@ -50,6 +51,7 @@ use std::{
 };
 
 use futures::{future, stream, stream::FuturesUnordered, SinkExt, StreamExt};
+use log::*;
 use prost::Message;
 use router::Router;
 use tokio::{sync::mpsc, task::JoinHandle, time};
@@ -78,6 +80,7 @@ use crate::{
         rpc::{
             body::BodyBytes,
             message::{RpcMethod, RpcResponse},
+            server::early_close::EarlyClose,
         },
         ProtocolEvent,
         ProtocolId,
@@ -89,7 +92,7 @@ use crate::{
     Substream,
 };
 
-const LOG_TARGET: &str = "comms::rpc";
+const LOG_TARGET: &str = "comms::rpc::server";
 
 pub trait NamedProtocolService {
     const PROTOCOL_NAME: &'static [u8];
@@ -323,18 +326,7 @@ where
                 let _ = reply.send(num_active);
             },
             GetNumActiveSessionsForPeer(node_id, reply) => {
-                let num_active = self
-                    .sessions
-                    .get(&node_id)
-                    .map(|num_sessions| {
-                        let max_sessions = self
-                            .config
-                            .maximum_sessions_per_client
-                            .unwrap_or_else(BoundedExecutor::max_theoretical_tasks);
-                        max_sessions.saturating_sub(*num_sessions)
-                    })
-                    .unwrap_or(0);
-
+                let num_active = self.sessions.get(&node_id).copied().unwrap_or(0);
                 let _ = reply.send(num_active);
             },
         }
@@ -375,23 +367,23 @@ where
     }
 
     fn new_session_for(&mut self, node_id: NodeId) -> Result<usize, RpcServerError> {
+        let count = self.sessions.entry(node_id.clone()).or_insert(0);
         match self.config.maximum_sessions_per_client {
             Some(max) if max > 0 => {
-                let count = self.sessions.entry(node_id.clone()).or_insert(0);
-
                 debug_assert!(*count <= max);
                 if *count >= max {
                     return Err(RpcServerError::MaxSessionsPerClientReached { node_id });
                 }
-                *count += 1;
-                Ok(*count)
             },
-            Some(_) => Ok(0),
-            None => Ok(0),
+            Some(_) | None => {},
         }
+
+        *count += 1;
+        Ok(*count)
     }
 
     fn on_session_complete(&mut self, node_id: &NodeId) {
+        info!(target: LOG_TARGET, "Session complete for {}", node_id);
         if let Some(v) = self.sessions.get_mut(node_id) {
             *v -= 1;
             if *v == 0 {
@@ -438,11 +430,20 @@ where
             },
         };
 
-        if let Err(err) = self.new_session_for(node_id.clone()) {
-            handshake
-                .reject_with_reason(HandshakeRejectReason::NoSessionsAvailable)
-                .await?;
-            return Err(err);
+        match self.new_session_for(node_id.clone()) {
+            Ok(num_sessions) => {
+                info!(
+                    target: LOG_TARGET,
+                    "NEW SESSION for {} ({} active) ", node_id, num_sessions
+                );
+            },
+
+            Err(err) => {
+                handshake
+                    .reject_with_reason(HandshakeRejectReason::NoSessionsAvailable)
+                    .await?;
+                return Err(err);
+            },
         }
 
         let version = handshake.perform_server_handshake().await?;
@@ -467,7 +468,9 @@ where
                 let num_sessions = metrics::num_sessions(&node_id, &service.protocol);
                 num_sessions.inc();
                 service.start().await;
+                info!(target: LOG_TARGET, "END OF SESSION for {} ", node_id,);
                 num_sessions.dec();
+
                 node_id
             })
             .map_err(|_| RpcServerError::MaximumSessionsReached)?;
@@ -483,7 +486,7 @@ struct ActivePeerRpcService<TSvc, TCommsProvider> {
     protocol: ProtocolId,
     node_id: NodeId,
     service: TSvc,
-    framed: CanonicalFraming<Substream>,
+    framed: EarlyClose<CanonicalFraming<Substream>>,
     comms_provider: TCommsProvider,
     logging_context_string: Arc<String>,
 }
@@ -513,7 +516,7 @@ where
             protocol,
             node_id,
             service,
-            framed,
+            framed: EarlyClose::new(framed),
             comms_provider,
         }
     }
@@ -525,9 +528,17 @@ where
         );
         if let Err(err) = self.run().await {
             metrics::error_counter(&self.node_id, &self.protocol, &err).inc();
-            error!(
+            let level = match &err {
+                RpcServerError::Io(e) => err_to_log_level(e),
+                RpcServerError::EarlyCloseError(e) => e.io().map(err_to_log_level).unwrap_or(log::Level::Error),
+                _ => log::Level::Error,
+            };
+            log!(
                 target: LOG_TARGET,
-                "({}) Rpc server exited with an error: {}", self.logging_context_string, err
+                level,
+                "({}) Rpc server exited with an error: {}",
+                self.logging_context_string,
+                err
             );
         }
     }
@@ -541,11 +552,14 @@ where
                     request_bytes.observe(frame.len() as f64);
                     if let Err(err) = self.handle_request(frame.freeze()).await {
                         if let Err(err) = self.framed.close().await {
-                            error!(
+                            let level = err.io().map(err_to_log_level).unwrap_or(log::Level::Error);
+
+                            log!(
                                 target: LOG_TARGET,
+                                level,
                                 "({}) Failed to close substream after socket error: {}",
                                 self.logging_context_string,
-                                err
+                                err,
                             );
                         }
                         error!(
@@ -725,44 +739,50 @@ where
             .map(|resp| Bytes::from(resp.to_encoded_bytes()));
 
         loop {
-            // Check if the client interrupted the outgoing stream
-            if let Err(err) = self.check_interruptions().await {
-                match err {
-                    err @ RpcServerError::ClientInterruptedStream => {
-                        debug!(target: LOG_TARGET, "Stream was interrupted: {}", err);
-                        break;
-                    },
-                    err => {
-                        error!(target: LOG_TARGET, "Stream was interrupted: {}", err);
-                        return Err(err);
-                    },
-                }
-            }
-
             let next_item = log_timing(
                 self.logging_context_string.clone(),
                 request_id,
                 "message read",
                 stream.next(),
             );
-            match time::timeout(deadline, next_item).await {
-                Ok(Some(msg)) => {
-                    response_bytes.observe(msg.len() as f64);
-                    debug!(
-                        target: LOG_TARGET,
-                        "({}) Sending body len = {}",
-                        self.logging_context_string,
-                        msg.len()
-                    );
+            let timeout = time::sleep(deadline);
 
-                    self.framed.send(msg).await?;
+            tokio::select! {
+                // Check if the client interrupted the outgoing stream
+                Err(err) = self.check_interruptions() => {
+                    match err {
+                        err @ RpcServerError::ClientInterruptedStream => {
+                            debug!(target: LOG_TARGET, "Stream was interrupted by client: {}", err);
+                            break;
+                        },
+                        err => {
+                            error!(target: LOG_TARGET, "Stream was interrupted: {}", err);
+                            return Err(err);
+                        },
+                    }
                 },
-                Ok(None) => {
-                    debug!(target: LOG_TARGET, "{} Request complete", self.logging_context_string,);
-                    break;
+                msg = next_item => {
+                     match msg {
+                         Some(msg) => {
+                            response_bytes.observe(msg.len() as f64);
+                            debug!(
+                                target: LOG_TARGET,
+                                "({}) Sending body len = {}",
+                                self.logging_context_string,
+                                msg.len()
+                            );
+
+                            self.framed.send(msg).await?;
+                        },
+                        None => {
+                            debug!(target: LOG_TARGET, "{} Request complete", self.logging_context_string,);
+                            break;
+                        },
+                    }
                 },
-                Err(_) => {
-                    debug!(
+
+                _ = timeout => {
+                     debug!(
                         target: LOG_TARGET,
                         "({}) Failed to return result within client deadline ({:.0?})",
                         self.logging_context_string,
@@ -776,8 +796,8 @@ where
                     )
                     .inc();
                     break;
-                },
-            }
+                }
+            } // end select!
         } // end loop
         Ok(())
     }
@@ -833,11 +853,9 @@ async fn log_timing<R, F: Future<Output = R>>(context_str: Arc<String>, request_
     ret
 }
 
-#[allow(clippy::cognitive_complexity)]
 fn into_response(request_id: u32, result: Result<BodyBytes, RpcStatus>) -> RpcResponse {
     match result {
         Ok(msg) => {
-            trace!(target: LOG_TARGET, "Sending body len = {}", msg.len());
             let mut flags = RpcMessageFlags::empty();
             if msg.is_finished() {
                 flags |= RpcMessageFlags::FIN;
@@ -858,5 +876,12 @@ fn into_response(request_id: u32, result: Result<BodyBytes, RpcStatus>) -> RpcRe
                 payload: Bytes::from(err.to_details_bytes()),
             }
         },
+    }
+}
+
+fn err_to_log_level(err: &io::Error) -> log::Level {
+    match err.kind() {
+        io::ErrorKind::BrokenPipe | io::ErrorKind::WriteZero => log::Level::Debug,
+        _ => log::Level::Error,
     }
 }

--- a/comms/core/src/protocol/rpc/test/smoke.rs
+++ b/comms/core/src/protocol/rpc/test/smoke.rs
@@ -551,7 +551,7 @@ async fn max_per_client_sessions() {
 
     let socket = inbound.incoming_mut().next().await.unwrap();
     let framed = framing::canonical(socket, 1024);
-    let mut client = GreetingClient::builder()
+    let client = GreetingClient::builder()
         .with_deadline(Duration::from_secs(5))
         .connect(framed)
         .await
@@ -568,7 +568,6 @@ async fn max_per_client_sessions() {
     unpack_enum!(RpcError::HandshakeError(err) = err);
     unpack_enum!(RpcHandshakeError::Rejected(HandshakeRejectReason::NoSessionsAvailable) = err);
 
-    client.close().await;
     drop(client);
     let substream = outbound.get_yamux_control().open_stream().await.unwrap();
     muxer

--- a/comms/core/tests/rpc.rs
+++ b/comms/core/tests/rpc.rs
@@ -1,0 +1,125 @@
+//  Copyright 2021, The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#![cfg(feature = "rpc")]
+
+mod greeting_service;
+use greeting_service::{GreetingClient, GreetingServer, GreetingService, StreamLargeItemsRequest};
+
+mod helpers;
+use std::time::Duration;
+
+use futures::StreamExt;
+use helpers::create_comms;
+use tari_comms::{
+    protocol::rpc::{RpcServer, RpcServerHandle},
+    transports::TcpTransport,
+    CommsNode,
+};
+use tari_shutdown::{Shutdown, ShutdownSignal};
+use tari_test_utils::async_assert_eventually;
+use tokio::time;
+
+async fn spawn_node(signal: ShutdownSignal) -> (CommsNode, RpcServerHandle) {
+    let rpc_server = RpcServer::builder()
+        .with_unlimited_simultaneous_sessions()
+        .finish()
+        .add_service(GreetingServer::new(GreetingService::default()));
+
+    let rpc_server_hnd = rpc_server.get_handle();
+    let comms = create_comms(signal)
+        .add_rpc_server(rpc_server)
+        .spawn_with_transport(TcpTransport::new())
+        .await
+        .unwrap();
+
+    comms
+        .node_identity()
+        .set_public_address(comms.listening_address().clone());
+    (comms, rpc_server_hnd)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn client_prematurely_ends_session() {
+    env_logger::init();
+    let shutdown = Shutdown::new();
+    let (node1, _rpc_server1) = spawn_node(shutdown.to_signal()).await;
+    let (node2, mut rpc_server2) = spawn_node(shutdown.to_signal()).await;
+
+    node1
+        .peer_manager()
+        .add_peer(node2.node_identity().to_peer())
+        .await
+        .unwrap();
+
+    let mut conn1_2 = node1
+        .connectivity()
+        .dial_peer(node2.node_identity().node_id().clone())
+        .await
+        .unwrap();
+
+    {
+        let mut client = conn1_2.connect_rpc::<GreetingClient>().await.unwrap();
+
+        let num_sessions = rpc_server2
+            .get_num_active_sessions_for(node1.node_identity().node_id().clone())
+            .await
+            .unwrap();
+        assert_eq!(num_sessions, 1);
+
+        let mut stream = client
+            .stream_large_items(StreamLargeItemsRequest {
+                id: 1,
+                num_items: 100,
+                item_size: 2300 * 1024,
+                delay_ms: 50,
+            })
+            .await
+            .unwrap();
+
+        let mut count = 0;
+        while let Some(r) = stream.next().await {
+            count += 1;
+
+            let data = r.unwrap();
+            assert_eq!(data.len(), 2300 * 1024);
+            // Prematurely drop the stream
+            if count == 5 {
+                log::info!("Ending the stream prematurely");
+                drop(stream);
+                break;
+            }
+        }
+
+        // Drop stream and client
+    }
+
+    time::sleep(Duration::from_secs(1)).await;
+    async_assert_eventually!(
+        rpc_server2
+            .get_num_active_sessions_for(node1.node_identity().node_id().clone())
+            .await
+            .unwrap(),
+        expect = 0,
+        max_attempts = 20,
+        interval = Duration::from_millis(1000)
+    );
+}

--- a/comms/core/tests/rpc_stress.rs
+++ b/comms/core/tests/rpc_stress.rs
@@ -40,7 +40,7 @@ use tari_comms::{
 use tari_shutdown::{Shutdown, ShutdownSignal};
 use tokio::{task, time::Instant};
 
-pub async fn spawn_node(signal: ShutdownSignal) -> CommsNode {
+async fn spawn_node(signal: ShutdownSignal) -> CommsNode {
     let rpc_server = RpcServer::builder()
         .with_unlimited_simultaneous_sessions()
         .finish()
@@ -132,6 +132,7 @@ async fn run_stress_test(test_params: Params) {
                     id: i as u64,
                     num_items: num_items as u64,
                     item_size: payload_size as u64,
+                    delay_ms: 0,
                 })
                 .await
                 .unwrap();

--- a/infrastructure/test_utils/src/futures/async_assert_eventually.rs
+++ b/infrastructure/test_utils/src/futures/async_assert_eventually.rs
@@ -43,7 +43,7 @@ macro_rules! async_assert_eventually {
             assert!(
                 attempts <= $max_attempts,
                 "assert_eventually assertion failed. Expression did not equal value after {} attempts.",
-                attempts
+                attempts - 1
             );
             tokio::time::sleep($interval).await;
             value = $check_expr;


### PR DESCRIPTION
Description
---
- fix(rpc/server): detect stream interrupt when waiting for responses from domain service and when sending any data
- fix(rpc/client): detect early response stream drop while reading responses
- fix(rpc): correct value for number of sessions per peer
- fix(base_node/sync): use faster/simpler mutex for sync session tracking
- fix(base-node): set force_sync_peers conf from `base_node.force_sync_peers`
- tests(comms/rpc): test for session handling when a response stream with large messages is interrupted 
- fix(p2p/liveness): pong event returns the latency of the last ping/pong 

Motivation and Context
---
Whenever sync latency exceeds the max, the client interrupts the stream. The server rarely picks this up and since only one sync session is allowed, the client node can not resume syncing from the same node.

fixes #4630 
ref #4646 (fixes but duplicate config should be removed)
fixes #4636 

How Has This Been Tested?
---
New previously failing the integration test, manually by syncing a new base node
