### PR TITLE
fix(core/sync): handle deadline timeouts by changing peer

### DIFF
--- a/base_layer/core/src/base_node/sync/config.rs
+++ b/base_layer/core/src/base_node/sync/config.rs
@@ -48,17 +48,21 @@ pub struct BlockchainSyncConfig {
     pub forced_sync_peers: Vec<NodeId>,
     /// Number of threads to use for validation
     pub validation_concurrency: usize,
+    /// The RPC deadline to set on sync clients. If this deadline is reached, a new sync peer will be selected for
+    /// sync.
+    pub rpc_deadline: Duration,
 }
 
 impl Default for BlockchainSyncConfig {
     fn default() -> Self {
         Self {
-            initial_max_sync_latency: Duration::from_secs(10),
+            initial_max_sync_latency: Duration::from_secs(20),
             max_latency_increase: Duration::from_secs(2),
             ban_period: Duration::from_secs(30 * 60),
             short_ban_period: Duration::from_secs(60),
             forced_sync_peers: Default::default(),
             validation_concurrency: 6,
+            rpc_deadline: Duration::from_secs(10),
         }
     }
 }

--- a/base_layer/core/src/base_node/sync/horizon_state_sync/synchronizer.rs
+++ b/base_layer/core/src/base_node/sync/horizon_state_sync/synchronizer.rs
@@ -32,7 +32,11 @@ use croaring::Bitmap;
 use futures::{stream::FuturesUnordered, StreamExt};
 use log::*;
 use tari_common_types::types::{Commitment, RangeProofService};
-use tari_comms::{connectivity::ConnectivityRequester, peer_manager::NodeId};
+use tari_comms::{
+    connectivity::ConnectivityRequester,
+    peer_manager::NodeId,
+    protocol::rpc::{RpcClient, RpcError},
+};
 use tari_crypto::{commitment::HomomorphicCommitment, tari_utilities::hex::Hex};
 use tokio::task;
 
@@ -178,7 +182,10 @@ impl<'a, B: BlockchainBackend + 'static> HorizonStateSynchronization<'a, B> {
     async fn sync(&mut self, header: &BlockHeader) -> Result<(), HorizonSyncError> {
         for (i, sync_peer) in self.sync_peers.iter().enumerate() {
             let mut connection = self.connectivity.dial_peer(sync_peer.node_id().clone()).await?;
-            let mut client = connection.connect_rpc::<rpc::BaseNodeSyncRpcClient>().await?;
+            let config = RpcClient::builder()
+                .with_deadline(self.config.rpc_deadline)
+                .with_deadline_grace_period(Duration::from_secs(3));
+            let mut client = connection.connect_rpc_using_builder(config).await?;
 
             match self.begin_sync(sync_peer.clone(), &mut client, header).await {
                 Ok(_) => match self.finalize_horizon_sync(sync_peer).await {
@@ -188,6 +195,7 @@ impl<'a, B: BlockchainBackend + 'static> HorizonStateSynchronization<'a, B> {
                         return Err(err);
                     },
                 },
+                Err(err @ HorizonSyncError::RpcError(RpcError::ReplyTimeout)) |
                 Err(err @ HorizonSyncError::MaxLatencyExceeded { .. }) => {
                     warn!(target: LOG_TARGET, "{}", err);
                     if i == self.sync_peers.len() - 1 {


### PR DESCRIPTION
Description
---
If the RPC deadline is reached, immediately move on to the next sync peer.

Motivation and Context
---
Fixes #4648

How Has This Been Tested?
---
Manually, header, pruned and block sync
