### PR TITLE
fix: fee estimate

### DIFF
--- a/base_layer/wallet/tests/output_manager_service_tests/service.rs
+++ b/base_layer/wallet/tests/output_manager_service_tests/service.rs
@@ -496,21 +496,19 @@ async fn test_utxo_selection_no_chain_metadata() {
     let expected_fee = fee_calc.calculate(fee_per_gram, 1, 1, 3, default_metadata_byte_size() * 3);
     assert_eq!(fee, expected_fee);
 
-
     let spendable_amount = (3..=10).sum::<u64>() * amount;
     let fee = oms
         .fee_estimate(spendable_amount, UtxoSelectionCriteria::default(), fee_per_gram, 1, 2)
         .await
         .unwrap();
-    assert_eq!(fee,MicroTari::from(250));
-
+    assert_eq!(fee, MicroTari::from(250));
 
     let broke_amount = spendable_amount + MicroTari::from(2000);
     let fee = oms
         .fee_estimate(broke_amount, UtxoSelectionCriteria::default(), fee_per_gram, 1, 2)
         .await
         .unwrap();
-    assert_eq!(fee,MicroTari::from(250));
+    assert_eq!(fee, MicroTari::from(250));
 
     // coin split uses the "Largest" selection strategy
     let (_, tx, utxos_total_value) = oms.create_coin_split(vec![], amount, 5, fee_per_gram).await.unwrap();
@@ -596,7 +594,7 @@ async fn test_utxo_selection_with_chain_metadata() {
         .fee_estimate(spendable_amount, UtxoSelectionCriteria::default(), fee_per_gram, 1, 2)
         .await
         .unwrap();
-    assert_eq!(fee,MicroTari::from(250));
+    assert_eq!(fee, MicroTari::from(250));
 
     // test coin split is maturity aware
     let (_, tx, utxos_total_value) = oms.create_coin_split(vec![], amount, 5, fee_per_gram).await.unwrap();

--- a/base_layer/wallet/tests/output_manager_service_tests/service.rs
+++ b/base_layer/wallet/tests/output_manager_service_tests/service.rs
@@ -397,7 +397,7 @@ async fn fee_estimate() {
     }
 
     // not enough funds
-    let err = oms
+    let fee = oms
         .output_manager_handle
         .fee_estimate(
             MicroTari::from(2750),
@@ -407,8 +407,8 @@ async fn fee_estimate() {
             1,
         )
         .await
-        .unwrap_err();
-    assert!(matches!(err, OutputManagerError::NotEnoughFunds));
+        .unwrap();
+    assert_eq!(fee, MicroTari::from(360));
 }
 
 #[allow(clippy::identity_op)]


### PR DESCRIPTION
Description
---
Allows fee estimate to always return an estimated fee. 

Motivation and Context
---
Currently, when calling fee estimate and you do not have enough funds, or funds pending, the fee estimate will error. 
We do not require such a high level of accuracy when calculating a fee estimate for an external call for an estimation. 
When the wallet does not have enough funds available, the API will return the fee estimate for default with 1 input and 1 kernel. 


How Has This Been Tested?
---
unit test
