### PR TITLE
fix(comms/messaging): fix possible deadlock in outbound pipeline

### DIFF
--- a/base_layer/p2p/src/config.rs
+++ b/base_layer/p2p/src/config.rs
@@ -95,8 +95,6 @@ pub struct P2pConfig {
     /// The maximum number of concurrent outbound tasks allowed before back-pressure is applied to outbound messaging
     /// queue
     pub max_concurrent_outbound_tasks: usize,
-    /// The size of the buffer (channel) which holds pending outbound message requests
-    pub outbound_buffer_size: usize,
     /// Configuration for DHT
     pub dht: DhtConfig,
     /// Set to true to allow peers to provide test addresses (loopback, memory etc.). If set to false, memory
@@ -131,9 +129,8 @@ impl Default for P2pConfig {
             transport: Default::default(),
             datastore_path: PathBuf::from("peer_db"),
             peer_database_name: "peers".to_string(),
-            max_concurrent_inbound_tasks: 50,
-            max_concurrent_outbound_tasks: 100,
-            outbound_buffer_size: 100,
+            max_concurrent_inbound_tasks: 4,
+            max_concurrent_outbound_tasks: 4,
             dht: DhtConfig {
                 database_url: DbConnectionUrl::file("dht.sqlite"),
                 ..Default::default()

--- a/base_layer/p2p/src/initialization.rs
+++ b/base_layer/p2p/src/initialization.rs
@@ -186,7 +186,6 @@ pub async fn initialize_local_test_comms<P: AsRef<Path>>(
     let dht_outbound_layer = dht.outbound_middleware_layer();
     let (event_sender, _) = broadcast::channel(100);
     let pipeline = pipeline::Builder::new()
-        .outbound_buffer_size(10)
         .with_outbound_pipeline(outbound_rx, |sink| {
             ServiceBuilder::new().layer(dht_outbound_layer).service(sink)
         })
@@ -333,7 +332,7 @@ async fn configure_comms_and_dht(
     let node_identity = comms.node_identity();
     let shutdown_signal = comms.shutdown_signal();
     // Create outbound channel
-    let (outbound_tx, outbound_rx) = mpsc::channel(config.outbound_buffer_size);
+    let (outbound_tx, outbound_rx) = mpsc::channel(config.dht.outbound_buffer_size);
 
     let mut dht = Dht::builder();
     dht.with_config(config.dht.clone()).with_outbound_sender(outbound_tx);
@@ -350,7 +349,6 @@ async fn configure_comms_and_dht(
 
     // Hook up DHT messaging middlewares
     let messaging_pipeline = pipeline::Builder::new()
-        .outbound_buffer_size(config.outbound_buffer_size)
         .with_outbound_pipeline(outbound_rx, |sink| {
             ServiceBuilder::new().layer(dht_outbound_layer).service(sink)
         })

--- a/base_layer/wallet/tests/contacts_service.rs
+++ b/base_layer/wallet/tests/contacts_service.rs
@@ -83,7 +83,6 @@ pub fn setup_contacts_service<T: ContactsBackend + 'static>(
         peer_database_name: random::string(8),
         max_concurrent_inbound_tasks: 10,
         max_concurrent_outbound_tasks: 10,
-        outbound_buffer_size: 100,
         dht: DhtConfig {
             discovery_request_timeout: Duration::from_secs(1),
             auto_join: true,

--- a/base_layer/wallet/tests/wallet.rs
+++ b/base_layer/wallet/tests/wallet.rs
@@ -129,7 +129,6 @@ async fn create_wallet(
         peer_database_name: random::string(8),
         max_concurrent_inbound_tasks: 10,
         max_concurrent_outbound_tasks: 10,
-        outbound_buffer_size: 100,
         dht: DhtConfig {
             discovery_request_timeout: Duration::from_secs(1),
             auto_join: true,
@@ -672,7 +671,6 @@ async fn test_import_utxo() {
         peer_database_name: random::string(8),
         max_concurrent_inbound_tasks: 10,
         max_concurrent_outbound_tasks: 10,
-        outbound_buffer_size: 10,
         dht: Default::default(),
         allow_test_addresses: true,
         listener_liveness_allowlist_cidrs: StringList::new(),

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -3899,7 +3899,6 @@ pub unsafe extern "C" fn comms_config_create(
                 peer_database_name: database_name_string,
                 max_concurrent_inbound_tasks: 25,
                 max_concurrent_outbound_tasks: 50,
-                outbound_buffer_size: 50,
                 dht: DhtConfig {
                     discovery_request_timeout: Duration::from_secs(discovery_timeout_in_secs),
                     database_url: DbConnectionUrl::File(dht_database_path),

--- a/common/config/presets/c_base_node.toml
+++ b/common/config/presets/c_base_node.toml
@@ -157,10 +157,10 @@ track_reorgs = true
 #peer_database_name = "peers"
 
 # The maximum number of concurrent Inbound tasks allowed before back-pressure is applied to peers
-#max_concurrent_inbound_tasks = 50
+#max_concurrent_inbound_tasks = 4
 
 # The maximum number of concurrent outbound tasks allowed before back-pressure is applied to outbound messaging queue
-#max_concurrent_outbound_tasks = 100
+#max_concurrent_outbound_tasks = 4
 
 # Set to true to allow peers to provide test addresses (loopback, memory etc.). If set to false, memory
 # addresses, loopback, local-link (i.e addresses used in local tests) will not be accepted from peers. This

--- a/common/config/presets/c_base_node.toml
+++ b/common/config/presets/c_base_node.toml
@@ -162,9 +162,6 @@ track_reorgs = true
 # The maximum number of concurrent outbound tasks allowed before back-pressure is applied to outbound messaging queue
 #max_concurrent_outbound_tasks = 100
 
-# The size of the buffer (channel) which holds pending outbound message requests
-#outbound_buffer_size = 100
-
 # Set to true to allow peers to provide test addresses (loopback, memory etc.). If set to false, memory
 # addresses, loopback, local-link (i.e addresses used in local tests) will not be accepted from peers. This
 # should always be false for non-test nodes.

--- a/common/config/presets/d_console_wallet.toml
+++ b/common/config/presets/d_console_wallet.toml
@@ -189,10 +189,10 @@ event_channel_size = 3500
 #peer_database_name = "peers"
 
 # The maximum number of concurrent Inbound tasks allowed before back-pressure is applied to peers
-#max_concurrent_inbound_tasks = 50
+#max_concurrent_inbound_tasks = 4
 
 # The maximum number of concurrent outbound tasks allowed before back-pressure is applied to outbound messaging queue
-#max_concurrent_outbound_tasks = 100
+#max_concurrent_outbound_tasks = 4
 
 # Set to true to allow peers to provide test addresses (loopback, memory etc.). If set to false, memory
 # addresses, loopback, local-link (i.e addresses used in local tests) will not be accepted from peers. This

--- a/common/config/presets/d_console_wallet.toml
+++ b/common/config/presets/d_console_wallet.toml
@@ -194,9 +194,6 @@ event_channel_size = 3500
 # The maximum number of concurrent outbound tasks allowed before back-pressure is applied to outbound messaging queue
 #max_concurrent_outbound_tasks = 100
 
-# The size of the buffer (channel) which holds pending outbound message requests
-#outbound_buffer_size = 100
-
 # Set to true to allow peers to provide test addresses (loopback, memory etc.). If set to false, memory
 # addresses, loopback, local-link (i.e addresses used in local tests) will not be accepted from peers. This
 # should always be false for non-test nodes.

--- a/comms/core/src/pipeline/builder.rs
+++ b/comms/core/src/pipeline/builder.rs
@@ -30,16 +30,14 @@ use crate::{
 };
 
 const DEFAULT_MAX_CONCURRENT_TASKS: usize = 50;
-const DEFAULT_OUTBOUND_BUFFER_SIZE: usize = 50;
 
-type OutboundMessageSinkService = SinkService<mpsc::Sender<OutboundMessage>>;
+type OutboundMessageSinkService = SinkService<mpsc::UnboundedSender<OutboundMessage>>;
 
 /// Message pipeline builder
 #[derive(Default)]
 pub struct Builder<TInSvc, TOutSvc, TOutReq> {
     max_concurrent_inbound_tasks: usize,
     max_concurrent_outbound_tasks: Option<usize>,
-    outbound_buffer_size: usize,
     inbound: Option<TInSvc>,
     outbound_rx: Option<mpsc::Receiver<TOutReq>>,
     outbound_pipeline_factory: Option<Box<dyn FnOnce(OutboundMessageSinkService) -> TOutSvc>>,
@@ -50,7 +48,6 @@ impl Builder<(), (), ()> {
         Self {
             max_concurrent_inbound_tasks: DEFAULT_MAX_CONCURRENT_TASKS,
             max_concurrent_outbound_tasks: None,
-            outbound_buffer_size: DEFAULT_OUTBOUND_BUFFER_SIZE,
             inbound: None,
             outbound_rx: None,
             outbound_pipeline_factory: None,
@@ -69,11 +66,6 @@ impl<TInSvc, TOutSvc, TOutReq> Builder<TInSvc, TOutSvc, TOutReq> {
         self
     }
 
-    pub fn outbound_buffer_size(mut self, buf_size: usize) -> Self {
-        self.outbound_buffer_size = buf_size;
-        self
-    }
-
     pub fn with_outbound_pipeline<F, S, R>(self, receiver: mpsc::Receiver<R>, factory: F) -> Builder<TInSvc, S, R>
     where
         // Factory function takes in a SinkService and returns a new composed service
@@ -87,7 +79,6 @@ impl<TInSvc, TOutSvc, TOutReq> Builder<TInSvc, TOutSvc, TOutReq> {
             max_concurrent_inbound_tasks: self.max_concurrent_inbound_tasks,
             max_concurrent_outbound_tasks: self.max_concurrent_outbound_tasks,
             inbound: self.inbound,
-            outbound_buffer_size: self.outbound_buffer_size,
         }
     }
 
@@ -100,7 +91,6 @@ impl<TInSvc, TOutSvc, TOutReq> Builder<TInSvc, TOutSvc, TOutReq> {
             max_concurrent_outbound_tasks: self.max_concurrent_outbound_tasks,
             outbound_rx: self.outbound_rx,
             outbound_pipeline_factory: self.outbound_pipeline_factory,
-            outbound_buffer_size: self.outbound_buffer_size,
         }
     }
 }
@@ -111,7 +101,7 @@ where
     TInSvc: Service<InboundMessage> + Clone + Send + 'static,
 {
     fn build_outbound(&mut self) -> Result<OutboundPipelineConfig<TOutReq, TOutSvc>, PipelineBuilderError> {
-        let (out_sender, out_receiver) = mpsc::channel(self.outbound_buffer_size);
+        let (out_sender, out_receiver) = mpsc::unbounded_channel();
 
         let in_receiver = self
             .outbound_rx
@@ -157,7 +147,7 @@ pub struct OutboundPipelineConfig<TInItem, TPipeline> {
     /// Messages read from this stream are passed to the pipeline
     pub in_receiver: mpsc::Receiver<TInItem>,
     /// Receiver of `OutboundMessage`s coming from the pipeline
-    pub out_receiver: mpsc::Receiver<OutboundMessage>,
+    pub out_receiver: mpsc::UnboundedReceiver<OutboundMessage>,
     /// The pipeline (`tower::Service`) to run for each in_stream message
     pub pipeline: TPipeline,
 }

--- a/comms/core/src/protocol/messaging/extension.rs
+++ b/comms/core/src/protocol/messaging/extension.rs
@@ -39,7 +39,7 @@ use crate::{
     runtime::task,
 };
 
-/// Buffer size for inbound messages from _all_ peers. Is the message consumer is slow to get through this queue,
+/// Buffer size for inbound messages from _all_ peers. If the message consumer is slow to get through this queue,
 /// sending peers will start to experience backpressure (this is a good thing).
 pub const INBOUND_MESSAGE_BUFFER_SIZE: usize = 10;
 /// Buffer size notifications that a peer wants to speak /tari/messaging. This buffer is used for all peers, but a low

--- a/comms/core/src/protocol/messaging/extension.rs
+++ b/comms/core/src/protocol/messaging/extension.rs
@@ -39,9 +39,9 @@ use crate::{
     runtime::task,
 };
 
-/// Buffer size for inbound messages from _all_ peers. This should be large enough to buffer quite a few incoming
-/// messages before creating backpressure on peers speaking the messaging protocol.
-pub const INBOUND_MESSAGE_BUFFER_SIZE: usize = 100;
+/// Buffer size for inbound messages from _all_ peers. Is the message consumer is slow to get through this queue,
+/// sending peers will start to experience backpressure (this is a good thing).
+pub const INBOUND_MESSAGE_BUFFER_SIZE: usize = 10;
 /// Buffer size notifications that a peer wants to speak /tari/messaging. This buffer is used for all peers, but a low
 /// value is ok because this events happen once (or less) per connecting peer. For e.g. a value of 10 would allow 10
 /// peers to concurrently request to speak /tari/messaging.

--- a/comms/dht/examples/memory_net/utilities.rs
+++ b/comms/dht/examples/memory_net/utilities.rs
@@ -949,7 +949,6 @@ async fn setup_comms_dht(
 
     let dht_outbound_layer = dht.outbound_middleware_layer();
     let pipeline = pipeline::Builder::new()
-        .outbound_buffer_size(10)
         .with_outbound_pipeline(outbound_rx, |sink| {
             ServiceBuilder::new().layer(dht_outbound_layer).service(sink)
         })

--- a/comms/dht/src/dht.rs
+++ b/comms/dht/src/dht.rs
@@ -615,7 +615,10 @@ mod test {
 
         service.call(inbound_message).await.unwrap();
 
-        assert_eq!(oms_mock_state.call_count().await, 1);
+        oms_mock_state
+            .wait_call_count(1, Duration::from_secs(10))
+            .await
+            .unwrap();
         let (params, _) = oms_mock_state.pop_call().await.unwrap();
 
         // Check that OMS got a request to forward with the original Dht Header

--- a/comms/dht/src/inbound/dht_handler/task.rs
+++ b/comms/dht/src/inbound/dht_handler/task.rs
@@ -225,7 +225,7 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
             );
             // Propagate message to closer peers
             self.outbound_service
-                .send_raw(
+                .send_raw_no_wait(
                     SendMessageParams::new()
                         .propagate(origin_public_key.clone().into(), vec![
                             origin_peer.node_id,
@@ -349,7 +349,7 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
 
         trace!(target: LOG_TARGET, "Sending discovery response to {}", dest_public_key);
         self.outbound_service
-            .send_message_no_header(
+            .send_message_no_header_no_wait(
                 SendMessageParams::new()
                     .direct_public_key(dest_public_key)
                     .with_destination(NodeDestination::Unknown)

--- a/comms/dht/src/outbound/broadcast.rs
+++ b/comms/dht/src/outbound/broadcast.rs
@@ -267,10 +267,6 @@ where S: Service<DhtOutboundMessage, Response = (), Error = PipelineError>
 
         match self.select_peers(broadcast_strategy.clone()).await {
             Ok(mut peers) => {
-                if reply_tx.is_closed() {
-                    return Err(DhtOutboundError::ReplyChannelCanceled);
-                }
-
                 let mut reply_tx = Some(reply_tx);
 
                 trace!(

--- a/comms/dht/src/outbound/error.rs
+++ b/comms/dht/src/outbound/error.rs
@@ -47,8 +47,6 @@ pub enum DhtOutboundError {
     RequesterReplyChannelClosed,
     #[error("Peer selection failed")]
     PeerSelectionFailed,
-    #[error("Reply channel cancelled")]
-    ReplyChannelCanceled,
     #[error("Attempted to send a message to ourselves")]
     SendToOurselves,
     #[error("Discovery process failed")]

--- a/comms/dht/src/outbound/mock.rs
+++ b/comms/dht/src/outbound/mock.rs
@@ -184,34 +184,31 @@ impl OutboundServiceMock {
                             match behaviour.direct {
                                 ResponseType::Queued => {
                                     let (response, mut inner_reply_tx) = self.add_call((*params).clone(), body).await;
-                                    reply_tx.send(response).expect("Reply channel cancelled");
+                                    let _ignore = reply_tx.send(response);
                                     inner_reply_tx.reply_success();
                                 },
                                 ResponseType::QueuedFail => {
                                     let (response, mut inner_reply_tx) = self.add_call((*params).clone(), body).await;
-                                    reply_tx.send(response).expect("Reply channel cancelled");
+                                    let _ignore = reply_tx.send(response);
                                     inner_reply_tx.reply_fail(SendFailReason::PeerDialFailed);
                                 },
                                 ResponseType::QueuedSuccessDelay(delay) => {
                                     let (response, mut inner_reply_tx) = self.add_call((*params).clone(), body).await;
-                                    reply_tx.send(response).expect("Reply channel cancelled");
+                                    let _ignore = reply_tx.send(response);
                                     sleep(delay).await;
                                     inner_reply_tx.reply_success();
                                 },
                                 resp => {
-                                    reply_tx
-                                        .send(SendMessageResponse::Failed(SendFailure::General(format!(
-                                            "Unexpected mock response {:?}",
-                                            resp
-                                        ))))
-                                        .expect("Reply channel cancelled");
+                                    let _ignore = reply_tx.send(SendMessageResponse::Failed(SendFailure::General(
+                                        format!("Unexpected mock response {:?}", resp),
+                                    )));
                                 },
                             };
                         },
                         BroadcastStrategy::ClosestNodes(_) => {
                             if behaviour.broadcast == ResponseType::Queued {
                                 let (response, mut inner_reply_tx) = self.add_call((*params).clone(), body).await;
-                                reply_tx.send(response).expect("Reply channel cancelled");
+                                let _ignore = reply_tx.send(response);
                                 inner_reply_tx.reply_success();
                             } else {
                                 reply_tx
@@ -223,7 +220,7 @@ impl OutboundServiceMock {
                         },
                         _ => {
                             let (response, mut inner_reply_tx) = self.add_call((*params).clone(), body).await;
-                            reply_tx.send(response).expect("Reply channel cancelled");
+                            let _ignore = reply_tx.send(response);
                             inner_reply_tx.reply_success();
                         },
                     }

--- a/comms/dht/src/store_forward/saf_handler/task.rs
+++ b/comms/dht/src/store_forward/saf_handler/task.rs
@@ -229,15 +229,13 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
 
             match self
                 .outbound_service
-                .send_message_no_header(
+                .send_message_no_header_no_wait(
                     SendMessageParams::new()
                         .direct_public_key(message.source_peer.public_key.clone())
                         .with_dht_message_type(DhtMessageType::SafStoredMessages)
                         .finish(),
                     stored_messages,
                 )
-                .await?
-                .resolve()
                 .await
             {
                 Ok(_) => {

--- a/comms/dht/tests/dht.rs
+++ b/comms/dht/tests/dht.rs
@@ -201,7 +201,6 @@ async fn setup_comms_dht(
 
     let dht_outbound_layer = dht.outbound_middleware_layer();
     let pipeline = pipeline::Builder::new()
-        .outbound_buffer_size(10)
         .with_outbound_pipeline(outbound_rx, |sink| {
             ServiceBuilder::new().layer(dht_outbound_layer).service(sink)
         })


### PR DESCRIPTION
Description
---
- Fixes possible rare deadlock when broadcasting many messages due to internal channel
- Reduce number of inbound and outbound pipeline workers
- Greatly reduce buffer size between inbound messaging and the inbound pipeline to allow for substream backpressure
- Adds "last resort" timeout in outbound pipeline

Motivation and Context
---

The outbound pipeline could deadlock when all pipeline workers are busy, and the outbound sink service is full, causing the pipeline to wait for both a free executor slot and a free slot to send on the channel

How Has This Been Tested?
---
Memorynet, Manually: wallet stress tests (2 x wallets, 2 x base nodes), checked SAF message exchange
