### PR TITLE
fix: deadlock

### DIFF
--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -807,8 +807,8 @@ where B: BlockchainBackend
         if median_timestamp > header.timestamp {
             header.timestamp = median_timestamp.increase(1);
         }
-        let block = Block { header, body };
-        let (mut block, roots) = self.calculate_mmr_roots(block)?;
+        let mut block = Block { header, body };
+        let roots = calculate_mmr_roots(&*db, &block)?;
         block.header.kernel_mr = roots.kernel_mr;
         block.header.kernel_mmr_size = roots.kernel_mmr_size;
         block.header.input_mr = roots.input_mr;


### PR DESCRIPTION
Description
---
This fixes a deadlock in the code. 

The `RwLock` allows a mutex to exist that allows concurrent reads but blocks concurrent writes, this behaves differently depending on the OS.
On Linux systems: The lock favors reads, meaning that as long as there exists a reader lock, it will allow a new reader lock to open. This means that the system can cause starvation of writers. 
On Mac/Win the lock has equal ordering, this means that as soon as a writer queues for a lock, all additional readers will be blocked till after the writer has acquired and released its lock. 

This behavior can be dangerous if recursive locks are used, as was the case here. 


At about the same time, a block was submitted, and a template was constructed for a new miner. 
The `add_block` process requires a write lock, while the `block template` process requires a read lock. 
The `template process` was first in acquiring a lock on the read, followed shortly by the `add_block` on the blocking for a write. But the deadlock was caused after the `add_block` blocked for a write, the `block template` required an additional read_lock on the calculation of the mmr roots. And thus, the entire `block_chain db `class is deadlocked. 


Fixes: https://github.com/tari-project/tari/issues/4668

