### PR TITLE
fix(comms): simplify and remove possibility of deadlock from pipelines and substream close

### DIFF
--- a/base_layer/p2p/src/config.rs
+++ b/base_layer/p2p/src/config.rs
@@ -138,7 +138,7 @@ impl Default for P2pConfig {
             allow_test_addresses: false,
             listener_liveness_max_sessions: 0,
             listener_liveness_allowlist_cidrs: StringList::default(),
-            user_agent: "".to_string(),
+            user_agent: String::new(),
             auxiliary_tcp_listener_address: None,
             rpc_max_simultaneous_sessions: 100,
             rpc_max_sessions_per_peer: 10,

--- a/comms/core/src/pipeline/builder.rs
+++ b/comms/core/src/pipeline/builder.rs
@@ -115,7 +115,7 @@ where
         let pipeline = (factory)(sink_service);
         Ok(OutboundPipelineConfig {
             in_receiver,
-            out_receiver,
+            out_receiver: Some(out_receiver),
             pipeline,
         })
     }
@@ -147,7 +147,7 @@ pub struct OutboundPipelineConfig<TInItem, TPipeline> {
     /// Messages read from this stream are passed to the pipeline
     pub in_receiver: mpsc::Receiver<TInItem>,
     /// Receiver of `OutboundMessage`s coming from the pipeline
-    pub out_receiver: mpsc::UnboundedReceiver<OutboundMessage>,
+    pub out_receiver: Option<mpsc::UnboundedReceiver<OutboundMessage>>,
     /// The pipeline (`tower::Service`) to run for each in_stream message
     pub pipeline: TPipeline,
 }

--- a/comms/core/src/pipeline/inbound.rs
+++ b/comms/core/src/pipeline/inbound.rs
@@ -106,7 +106,7 @@ where
                 .spawn(async move {
                     let timer = Instant::now();
                     trace!(target: LOG_TARGET, "Start inbound pipeline {}", id);
-                    match time::timeout(Duration::from_secs(30), service.oneshot(item)).await {
+                    match time::timeout(Duration::from_secs(10), service.oneshot(item)).await {
                         Ok(Ok(_)) => {},
                         Ok(Err(err)) => {
                             warn!(target: LOG_TARGET, "Inbound pipeline returned an error: '{}'", err);

--- a/comms/core/src/pipeline/inbound.rs
+++ b/comms/core/src/pipeline/inbound.rs
@@ -88,15 +88,17 @@ where
 
             let num_available = self.executor.num_available();
             let max_available = self.executor.max_available();
-            // Only emit this message if there is any concurrent usage
-            if num_available < max_available {
-                debug!(
-                    target: LOG_TARGET,
-                    "Inbound pipeline usage: {}/{}",
-                    max_available - num_available,
-                    max_available
-                );
-            }
+            log!(
+                target: LOG_TARGET,
+                if num_available < max_available {
+                    Level::Debug
+                } else {
+                    Level::Trace
+                },
+                "Inbound pipeline usage: {}/{}",
+                max_available - num_available,
+                max_available
+            );
 
             let id = current_id;
             current_id = (current_id + 1) % u64::MAX;

--- a/comms/core/src/pipeline/outbound.rs
+++ b/comms/core/src/pipeline/outbound.rs
@@ -62,15 +62,17 @@ where
             // Pipeline IN received a message. Spawn a new task for the pipeline
             let num_available = self.executor.num_available();
             if let Some(max_available) = self.executor.max_available() {
-                // Only emit this message if there is any concurrent usage
-                if num_available < max_available {
-                    debug!(
-                        target: LOG_TARGET,
-                        "Outbound pipeline usage: {}/{}",
-                        max_available - num_available,
-                        max_available
-                    );
-                }
+                log!(
+                    target: LOG_TARGET,
+                    if num_available < max_available {
+                        Level::Debug
+                    } else {
+                        Level::Trace
+                    },
+                    "Outbound pipeline usage: {}/{}",
+                    max_available - num_available,
+                    max_available
+                );
             }
             let pipeline = self.config.pipeline.clone();
             let id = current_id;

--- a/comms/core/src/pipeline/outbound.rs
+++ b/comms/core/src/pipeline/outbound.rs
@@ -25,17 +25,11 @@ use std::{
     time::{Duration, Instant},
 };
 
-use futures::future::Either;
 use log::*;
-use tokio::{sync::mpsc, time};
+use tokio::time;
 use tower::{Service, ServiceExt};
 
-use crate::{
-    bounded_executor::OptionallyBoundedExecutor,
-    message::OutboundMessage,
-    pipeline::builder::OutboundPipelineConfig,
-    protocol::messaging::MessagingRequest,
-};
+use crate::{bounded_executor::OptionallyBoundedExecutor, pipeline::builder::OutboundPipelineConfig};
 
 const LOG_TARGET: &str = "comms::pipeline::outbound";
 
@@ -46,8 +40,6 @@ pub struct Outbound<TPipeline, TItem> {
     executor: OptionallyBoundedExecutor,
     /// Outbound pipeline configuration containing the pipeline and it's in and out streams
     config: OutboundPipelineConfig<TItem, TPipeline>,
-    /// Request sender for Messaging
-    messaging_request_tx: mpsc::Sender<MessagingRequest>,
 }
 
 impl<TPipeline, TItem> Outbound<TPipeline, TItem>
@@ -58,111 +50,67 @@ where
     TPipeline::Future: Send,
 {
     /// New outbound pipeline.
-    pub fn new(
-        executor: OptionallyBoundedExecutor,
-        config: OutboundPipelineConfig<TItem, TPipeline>,
-        messaging_request_tx: mpsc::Sender<MessagingRequest>,
-    ) -> Self {
-        Self {
-            executor,
-            config,
-            messaging_request_tx,
-        }
+    pub fn new(executor: OptionallyBoundedExecutor, config: OutboundPipelineConfig<TItem, TPipeline>) -> Self {
+        Self { executor, config }
     }
 
     /// Run the outbound pipeline.
     pub async fn run(mut self) {
         let mut current_id = 0;
-        loop {
-            let either = tokio::select! {
-                next = self.config.in_receiver.recv() => Either::Left(next),
-                next = self.config.out_receiver.recv() => Either::Right(next)
-            };
-            match either {
-                // Pipeline IN received a message. Spawn a new task for the pipeline
-                Either::Left(Some(msg)) => {
-                    let num_available = self.executor.num_available();
-                    if let Some(max_available) = self.executor.max_available() {
-                        // Only emit this message if there is any concurrent usage
-                        if num_available < max_available {
-                            debug!(
-                                target: LOG_TARGET,
-                                "Outbound pipeline usage: {}/{}",
-                                max_available - num_available,
-                                max_available
-                            );
-                        }
-                    }
-                    let pipeline = self.config.pipeline.clone();
-                    let id = current_id;
-                    current_id = (current_id + 1) % u64::MAX;
-                    self.executor
-                        .spawn(async move {
-                            let timer = Instant::now();
-                            trace!(target: LOG_TARGET, "Start outbound pipeline {}", id);
-                            match time::timeout(Duration::from_secs(30), pipeline.oneshot(msg)).await {
-                                Ok(Ok(_)) => {},
-                                Ok(Err(err)) => {
-                                    error!(
-                                        target: LOG_TARGET,
-                                        "Outbound pipeline {} returned an error: '{}'", id, err
-                                    );
-                                },
-                                Err(_) => {
-                                    error!(
-                                        target: LOG_TARGET,
-                                        "Outbound pipeline {} timed out and was aborted. THIS SHOULD NOT HAPPEN: \
-                                         there was a deadlock or excessive delay in processing this pipeline.",
-                                        id
-                                    );
-                                },
-                            }
 
-                            trace!(
-                                target: LOG_TARGET,
-                                "Finished outbound pipeline {} in {:.2?}",
-                                id,
-                                timer.elapsed()
-                            );
-                        })
-                        .await;
-                },
-                // Pipeline IN channel closed
-                Either::Left(None) => {
-                    info!(
+        while let Some(msg) = self.config.in_receiver.recv().await {
+            // Pipeline IN received a message. Spawn a new task for the pipeline
+            let num_available = self.executor.num_available();
+            if let Some(max_available) = self.executor.max_available() {
+                // Only emit this message if there is any concurrent usage
+                if num_available < max_available {
+                    debug!(
                         target: LOG_TARGET,
-                        "Outbound pipeline is shutting down because the in channel closed"
+                        "Outbound pipeline usage: {}/{}",
+                        max_available - num_available,
+                        max_available
                     );
-                    break;
-                },
-                // Pipeline OUT received a message
-                Either::Right(Some(out_msg)) => {
-                    if self.messaging_request_tx.is_closed() {
-                        // MessagingRequest channel closed
-                        break;
-                    }
-                    self.send_messaging_request(out_msg).await;
-                },
-                // Pipeline OUT channel closed
-                Either::Right(None) => {
-                    info!(
-                        target: LOG_TARGET,
-                        "Outbound pipeline is shutting down because the out channel closed"
-                    );
-                    break;
-                },
+                }
             }
-        }
-    }
+            let pipeline = self.config.pipeline.clone();
+            let id = current_id;
+            current_id = (current_id + 1) % u64::MAX;
+            self.executor
+                .spawn(async move {
+                    let timer = Instant::now();
+                    trace!(target: LOG_TARGET, "Start outbound pipeline {}", id);
+                    match time::timeout(Duration::from_secs(10), pipeline.oneshot(msg)).await {
+                        Ok(Ok(_)) => {},
+                        Ok(Err(err)) => {
+                            error!(
+                                target: LOG_TARGET,
+                                "Outbound pipeline {} returned an error: '{}'", id, err
+                            );
+                        },
+                        Err(_) => {
+                            error!(
+                                target: LOG_TARGET,
+                                "Outbound pipeline {} timed out and was aborted. THIS SHOULD NOT HAPPEN: there was a \
+                                 deadlock or excessive delay in processing this pipeline.",
+                                id
+                            );
+                        },
+                    }
 
-    async fn send_messaging_request(&mut self, out_msg: OutboundMessage) {
-        let msg_req = MessagingRequest::SendMessage(out_msg);
-        if let Err(err) = self.messaging_request_tx.send(msg_req).await {
-            error!(
-                target: LOG_TARGET,
-                "Failed to send OutboundMessage to Messaging protocol because '{}'", err
-            );
+                    trace!(
+                        target: LOG_TARGET,
+                        "Finished outbound pipeline {} in {:.2?}",
+                        id,
+                        timer.elapsed()
+                    );
+                })
+                .await;
         }
+
+        info!(
+            target: LOG_TARGET,
+            "Outbound pipeline is shutting down because the in channel closed"
+        );
     }
 }
 
@@ -171,43 +119,37 @@ mod test {
     use std::time::Duration;
 
     use bytes::Bytes;
-    use tari_test_utils::{collect_recv, unpack_enum};
-    use tokio::{runtime::Handle, time};
+    use tari_test_utils::collect_recv;
+    use tokio::{runtime::Handle, sync::mpsc, time};
 
     use super::*;
-    use crate::{pipeline::SinkService, runtime, utils};
+    use crate::{message::OutboundMessage, pipeline::SinkService, runtime, utils};
 
     #[runtime::test]
     async fn run() {
         const NUM_ITEMS: usize = 10;
-        let (tx, in_receiver) = mpsc::channel(NUM_ITEMS);
+        let (tx, mut in_receiver) = mpsc::channel(NUM_ITEMS);
         utils::mpsc::send_all(
             &tx,
             (0..NUM_ITEMS).map(|i| OutboundMessage::new(Default::default(), Bytes::copy_from_slice(&i.to_be_bytes()))),
         )
         .await
         .unwrap();
-        let (out_tx, out_rx) = mpsc::unbounded_channel();
-        let (msg_tx, mut msg_rx) = mpsc::channel(NUM_ITEMS);
+        in_receiver.close();
+
+        let (out_tx, mut out_rx) = mpsc::unbounded_channel();
         let executor = Handle::current();
 
-        let pipeline = Outbound::new(
-            executor.clone().into(),
-            OutboundPipelineConfig {
-                in_receiver,
-                out_receiver: out_rx,
-                pipeline: SinkService::new(out_tx),
-            },
-            msg_tx,
-        );
+        let pipeline = Outbound::new(executor.clone().into(), OutboundPipelineConfig {
+            in_receiver,
+            out_receiver: None,
+            pipeline: SinkService::new(out_tx),
+        });
 
         let spawned_task = executor.spawn(pipeline.run());
 
-        msg_rx.close();
-        let requests = collect_recv!(msg_rx, timeout = Duration::from_millis(5));
-        for req in requests {
-            unpack_enum!(MessagingRequest::SendMessage(_o) = req);
-        }
+        let requests = collect_recv!(out_rx, timeout = Duration::from_millis(5));
+        assert_eq!(requests.len(), NUM_ITEMS);
 
         // Check that this task ends because the stream has closed
         time::timeout(Duration::from_secs(5), spawned_task)

--- a/comms/core/src/protocol/messaging/extension.rs
+++ b/comms/core/src/protocol/messaging/extension.rs
@@ -47,10 +47,6 @@ pub const INBOUND_MESSAGE_BUFFER_SIZE: usize = 10;
 /// peers to concurrently request to speak /tari/messaging.
 pub const MESSAGING_PROTOCOL_EVENTS_BUFFER_SIZE: usize = 30;
 
-/// Buffer size for requests to the messaging protocol. All outbound messages will be sent along this channel. Some
-/// buffering may be required if the node needs to send many messages out at the same time.
-pub const MESSAGING_REQUEST_BUFFER_SIZE: usize = 50;
-
 /// Installs the messaging protocol
 pub struct MessagingProtocolExtension<TInPipe, TOutPipe, TOutReq> {
     event_tx: MessagingEventSender,
@@ -73,17 +69,17 @@ where
     TInPipe::Future: Send + 'static,
     TOutReq: Send + 'static,
 {
-    fn install(self: Box<Self>, context: &mut ProtocolExtensionContext) -> Result<(), ProtocolExtensionError> {
+    fn install(mut self: Box<Self>, context: &mut ProtocolExtensionContext) -> Result<(), ProtocolExtensionError> {
         let (proto_tx, proto_rx) = mpsc::channel(MESSAGING_PROTOCOL_EVENTS_BUFFER_SIZE);
         context.add_protocol(&[MESSAGING_PROTOCOL.clone()], &proto_tx);
 
-        let (messaging_request_tx, messaging_request_rx) = mpsc::channel(MESSAGING_REQUEST_BUFFER_SIZE);
         let (inbound_message_tx, inbound_message_rx) = mpsc::channel(INBOUND_MESSAGE_BUFFER_SIZE);
 
+        let message_receiver = self.pipeline.outbound.out_receiver.take().unwrap();
         let messaging = MessagingProtocol::new(
             context.connectivity(),
             proto_rx,
-            messaging_request_rx,
+            message_receiver,
             self.event_tx,
             inbound_message_tx,
             context.shutdown_signal(),
@@ -106,7 +102,7 @@ where
 
         let executor = OptionallyBoundedExecutor::from_current(self.pipeline.max_concurrent_outbound_tasks);
         // Spawn outbound pipeline
-        let outbound = pipeline::Outbound::new(executor, self.pipeline.outbound, messaging_request_tx);
+        let outbound = pipeline::Outbound::new(executor, self.pipeline.outbound);
         task::spawn(outbound.run());
 
         Ok(())

--- a/comms/core/src/protocol/messaging/mod.rs
+++ b/comms/core/src/protocol/messaging/mod.rs
@@ -37,14 +37,7 @@ mod inbound;
 mod metrics;
 mod outbound;
 mod protocol;
-pub use protocol::{
-    MessagingEvent,
-    MessagingEventReceiver,
-    MessagingEventSender,
-    MessagingProtocol,
-    MessagingRequest,
-    SendFailReason,
-};
+pub use protocol::{MessagingEvent, MessagingEventReceiver, MessagingEventSender, MessagingProtocol, SendFailReason};
 
 #[cfg(test)]
 mod test;

--- a/comms/core/src/protocol/messaging/outbound.rs
+++ b/comms/core/src/protocol/messaging/outbound.rs
@@ -270,10 +270,16 @@ impl OutboundMessaging {
             outbound_count.inc();
             event!(
                 Level::DEBUG,
-                "Message buffered for sending {} on stream {}",
+                "Message for peer '{}' sending {} on stream {}",
+                peer_node_id,
                 out_msg,
                 stream_id
             );
+            debug!(
+                target: LOG_TARGET,
+                "Message for peer '{}' sending {} on stream {}", peer_node_id, out_msg, stream_id
+            );
+
             out_msg.reply_success();
             Result::<_, MessagingProtocolError>::Ok(out_msg.body)
         });


### PR DESCRIPTION
Description
---
- Simplify outbound pipeline by removing the [pipeline] -> [messaging] channel
- Pipe outbound messages directly to the messaging protocol instead of through the outbound pipeline
- Fix rare lockup when calling yamux control close 

Motivation and Context
---
The outbound pipeline needed to poll two channels in order to make progress, some code branches in the outbound pipeline may need to use the other channel, and if that channel is full and the number of concurrent outbound tasks are full, a deadlock will occur. This case has not been directly observed, but is technically possible so should be eliminated.

This PR removes the [pipeline] -> [messaging] channel, making the outbound pipeline only have to poll one channel. It also directly pipes `OutboundMessage`s to the messaging protocol.

EDIT: I believe I've found the root cause. The connectivity manager would rarely "lock up" causing the pipelines to lock up (both pipelines require calls to connectivity manager). I traced this in the logs and found that the last thing the connectivity manager does is resolve a tie break before locking up. This involves disconnecting one of the peer connections, and it appeared this future, extremely rarely, did not resolve. Digging deeper from there, I was able to track down a flaw in the substream close procedure, write a test that reproduces it and make a fix.

How Has This Been Tested?
---
Number of ~1000-2000tx stress tests, leaving base nodes overnight (none of these are conclusive but no issues were encountered)
