### PR TITLE
fix(p2p): remove DETACH flag usage

### DIFF
--- a/base_layer/p2p/src/initialization.rs
+++ b/base_layer/p2p/src/initialization.rs
@@ -275,7 +275,6 @@ async fn initialize_hidden_service(
     mut config: TorTransportConfig,
 ) -> Result<tor::HiddenServiceController, CommsInitializationError> {
     let mut builder = tor::HiddenServiceBuilder::new()
-        .with_hs_flags(tor::HsFlags::DETACH)
         .with_port_mapping(config.to_port_mapping()?)
         .with_socks_authentication(config.to_socks_auth())
         .with_control_server_auth(config.to_control_auth()?)

--- a/comms/core/examples/stress/node.rs
+++ b/comms/core/examples/stress/node.rs
@@ -131,7 +131,6 @@ pub async fn create(
             .unwrap()
     } else {
         let mut hs_builder = tor::HiddenServiceBuilder::new()
-            .with_hs_flags(HsFlags::DETACH)
             .with_port_mapping(port)
             .with_control_server_address(TOR_CONTROL_PORT_ADDR.parse().unwrap());
 

--- a/comms/dht/examples/propagation/node.rs
+++ b/comms/dht/examples/propagation/node.rs
@@ -91,7 +91,6 @@ pub async fn create<P: AsRef<Path>>(
     let (event_tx, _) = broadcast::channel(1);
 
     let mut hs_builder = tor::HiddenServiceBuilder::new()
-        .with_hs_flags(HsFlags::DETACH)
         .with_port_mapping(onion_port)
         .with_control_server_address(TOR_CONTROL_PORT_ADDR.parse().unwrap());
 


### PR DESCRIPTION
Description
---

Remove DETACH flag from tor hs initialization.

Motivation and Context
---
DETACH was previously added as an attempt to improve tor connection reliability, but allowing tor to keep the hidden service registered even after the node has shut down. However, this was never really confirmed to improve reliability. Since this causes tor to fail an assertion, and since testing shows that connections still function as expected, it is removed in this PR.

 
How Has This Been Tested?
---
Stopping and starting nodes and checking the tor log does not throw an error
