### PR TITLE
fix(wallet): mark mined_height as null when pending outputs are cancelled

### DIFF
--- a/base_layer/wallet/src/output_manager_service/storage/database/backend.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/database/backend.rs
@@ -47,7 +47,7 @@ pub trait OutputManagerBackend: Send + Sync + Clone {
         mined_timestamp: u64,
     ) -> Result<(), OutputManagerStorageError>;
 
-    fn set_output_to_unmined(&self, hash: FixedHash) -> Result<(), OutputManagerStorageError>;
+    fn set_output_to_unmined_and_invalid(&self, hash: FixedHash) -> Result<(), OutputManagerStorageError>;
     fn set_outputs_to_be_revalidated(&self) -> Result<(), OutputManagerStorageError>;
 
     fn mark_output_as_spent(

--- a/base_layer/wallet/src/output_manager_service/storage/database/mod.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/database/mod.rs
@@ -416,9 +416,9 @@ where T: OutputManagerBackend + 'static
         Ok(())
     }
 
-    pub fn set_output_to_unmined(&self, hash: HashOutput) -> Result<(), OutputManagerStorageError> {
+    pub fn set_output_to_unmined_and_invalid(&self, hash: HashOutput) -> Result<(), OutputManagerStorageError> {
         let db = self.db.clone();
-        db.set_output_to_unmined(hash)?;
+        db.set_output_to_unmined_and_invalid(hash)?;
         Ok(())
     }
 

--- a/base_layer/wallet/src/output_manager_service/tasks/txo_validation_task.rs
+++ b/base_layer/wallet/src/output_manager_service/tasks/txo_validation_task.rs
@@ -355,7 +355,7 @@ where
                     self.operation_id
                 );
                 self.db
-                    .set_output_to_unmined(last_mined_output.hash)
+                    .set_output_to_unmined_and_invalid(last_mined_output.hash)
                     .for_protocol(self.operation_id)?;
             } else {
                 debug!(


### PR DESCRIPTION
Description
---

- Sets output `mined_height` in addition to `mined_in_block`  to NULL when cancelling pending transactions
- renames `set_output_to_unmined` to `set_output_to_unmined_and_invalid`

Motivation and Context
---
This can cause #4670 and was introduced in #3863

`set_output_to_unmined` also marks the output as invalid which is unexpected given the name. 

How Has This Been Tested?
---
Additional basic test for `set_output_to_unmined`
