### PR TITLE
fix(core): calculate validator node MR at prepare block stage

### DIFF
--- a/applications/tari_app_grpc/proto/block.proto
+++ b/applications/tari_app_grpc/proto/block.proto
@@ -62,7 +62,7 @@ message BlockHeader {
     // Sum of script offsets for all kernels in this block.
     bytes total_script_offset = 15;
     // Merkle root of validator nodes
-    bytes validator_node_merkle_root = 16;
+    bytes validator_node_mr = 16;
 }
 
 // Metadata required for validating the Proof of Work calculation
@@ -119,8 +119,6 @@ message NewBlockHeaderTemplate {
 //    uint64 target_difficulty = 6;
     // Sum of script offsets for all kernels in this block.
     bytes total_script_offset = 7;
-    // Merkle root of validator nodes
-    bytes validator_node_merkle_root = 8;
 }
 
 // The new block template is used constructing a new partial block, allowing a miner to added the coinbase utxo and as a final step the Base node to add the MMR roots to the header.

--- a/applications/tari_app_grpc/proto/wallet.proto
+++ b/applications/tari_app_grpc/proto/wallet.proto
@@ -321,7 +321,7 @@ message TransactionEventResponse {
 }
 
 message RegisterValidatorNodeRequest {
-    string validator_node_public_key = 1;
+    bytes validator_node_public_key = 1;
     Signature validator_node_signature = 2;
     uint64 fee_per_gram = 3;
     string message = 4;

--- a/applications/tari_app_grpc/src/conversions/block_header.rs
+++ b/applications/tari_app_grpc/src/conversions/block_header.rs
@@ -53,7 +53,7 @@ impl From<BlockHeader> for grpc::BlockHeader {
                 pow_algo: pow_algo.as_u64(),
                 pow_data: h.pow.pow_data,
             }),
-            validator_node_merkle_root: h.validator_node_merkle_root,
+            validator_node_mr: h.validator_node_mr.to_vec(),
         }
     }
 }
@@ -86,13 +86,13 @@ impl TryFrom<grpc::BlockHeader> for BlockHeader {
             output_mr: FixedHash::try_from(header.output_mr).map_err(|err| err.to_string())?,
             witness_mr: FixedHash::try_from(header.witness_mr).map_err(|err| err.to_string())?,
             output_mmr_size: header.output_mmr_size,
-            kernel_mr: FixedHash::try_from(header.kernel_mr).expect("Array size 32 cannot fail"),
+            kernel_mr: FixedHash::try_from(header.kernel_mr).map_err(|err| err.to_string())?,
             kernel_mmr_size: header.kernel_mmr_size,
             total_kernel_offset,
             total_script_offset,
             nonce: header.nonce,
             pow,
-            validator_node_merkle_root: header.validator_node_merkle_root,
+            validator_node_mr: FixedHash::try_from(header.validator_node_mr).map_err(|err| err.to_string())?,
         })
     }
 }

--- a/applications/tari_app_grpc/src/conversions/new_block_template.rs
+++ b/applications/tari_app_grpc/src/conversions/new_block_template.rs
@@ -45,7 +45,6 @@ impl TryFrom<NewBlockTemplate> for grpc::NewBlockTemplate {
                 pow_algo: block.header.pow.pow_algo.as_u64(),
                 pow_data: block.header.pow.pow_data,
             }),
-            validator_node_merkle_root: block.header.validator_node_merkle_root,
         };
         Ok(Self {
             body: Some(grpc::AggregateBody {
@@ -92,7 +91,6 @@ impl TryFrom<grpc::NewBlockTemplate> for NewBlockTemplate {
             total_kernel_offset,
             total_script_offset,
             pow,
-            validator_node_merkle_root: header.validator_node_merkle_root,
         };
         let body = block
             .body

--- a/applications/tari_app_grpc/src/conversions/sidechain_feature.rs
+++ b/applications/tari_app_grpc/src/conversions/sidechain_feature.rs
@@ -40,7 +40,9 @@ use crate::tari_rpc as grpc;
 //---------------------------------- SideChainFeature --------------------------------------------//
 impl From<SideChainFeature> for grpc::SideChainFeature {
     fn from(value: SideChainFeature) -> Self {
-        value.into()
+        Self {
+            side_chain_feature: Some(value.into()),
+        }
     }
 }
 

--- a/applications/tari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/tari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -936,7 +936,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
     ) -> Result<Response<RegisterValidatorNodeResponse>, Status> {
         let request = request.into_inner();
         let mut transaction_service = self.get_transaction_service();
-        let validator_node_public_key = CommsPublicKey::from_hex(&request.validator_node_public_key)
+        let validator_node_public_key = CommsPublicKey::from_bytes(&request.validator_node_public_key)
             .map_err(|_| Status::internal("Destination address is malformed".to_string()))?;
         let validator_node_signature = request
             .validator_node_signature

--- a/base_layer/common_types/src/types/fixed_hash.rs
+++ b/base_layer/common_types/src/types/fixed_hash.rs
@@ -104,6 +104,11 @@ impl PartialEq<Vec<u8>> for FixedHash {
         self == other.as_slice()
     }
 }
+impl PartialEq<FixedHash> for Vec<u8> {
+    fn eq(&self, other: &FixedHash) -> bool {
+        self == other.as_slice()
+    }
+}
 
 impl AsRef<[u8]> for FixedHash {
     fn as_ref(&self) -> &[u8] {

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -10,10 +10,10 @@ version = "0.38.3"
 edition = "2018"
 
 [features]
-default = ["croaring", "tari_mmr", "transactions", "base_node", "mempool_proto", "base_node_proto", "monero", "randomx-rs"]
+default = ["base_node"]
 transactions = []
 mempool_proto = []
-base_node = ["croaring", "tari_mmr", "transactions", "base_node_proto", "monero", "randomx-rs"]
+base_node = ["croaring", "tari_mmr", "transactions", "mempool_proto", "base_node_proto", "monero", "randomx-rs"]
 base_node_proto = []
 avx2 = ["tari_crypto/simd_backend"]
 benches = ["base_node", "criterion"]

--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -274,8 +274,7 @@ where B: BlockchainBackend + 'static
             },
             NodeCommsRequest::GetNewBlockTemplate(request) => {
                 let best_block_header = self.blockchain_db.fetch_tip_header().await?;
-                let vns = self.blockchain_db.get_validator_nodes_mr().await?;
-                let mut header = BlockHeader::from_previous(best_block_header.header(), vns);
+                let mut header = BlockHeader::from_previous(best_block_header.header());
                 let constants = self.consensus_manager.consensus_constants(header.height);
                 header.version = constants.blockchain_version();
                 header.pow.pow_algo = request.algo;

--- a/base_layer/core/src/base_node/sync/header_sync/validator.rs
+++ b/base_layer/core/src/base_node/sync/header_sync/validator.rs
@@ -261,7 +261,7 @@ mod test {
         let (validator, db) = setup();
         let mut tip = db.fetch_tip_header().await.unwrap();
         for _ in 0..n {
-            let mut header = BlockHeader::from_previous(tip.header(), tip.header().validator_node_merkle_root.clone());
+            let mut header = BlockHeader::from_previous(tip.header());
             // Needed to have unique keys for the blockchain db mmr count indexes (MDB_KEY_EXIST error)
             header.kernel_mmr_size += 1;
             header.output_mmr_size += 1;
@@ -316,11 +316,11 @@ mod test {
             let (mut validator, _, tip) = setup_with_headers(1).await;
             validator.initialize_state(tip.hash()).await.unwrap();
             assert!(validator.valid_headers().is_empty());
-            let next = BlockHeader::from_previous(tip.header(), tip.header().validator_node_merkle_root.clone());
+            let next = BlockHeader::from_previous(tip.header());
             validator.validate(next).unwrap();
             assert_eq!(validator.valid_headers().len(), 1);
             let tip = validator.valid_headers().last().cloned().unwrap();
-            let next = BlockHeader::from_previous(tip.header(), tip.header().validator_node_merkle_root.clone());
+            let next = BlockHeader::from_previous(tip.header());
             validator.validate(next).unwrap();
             assert_eq!(validator.valid_headers().len(), 2);
         }
@@ -329,7 +329,7 @@ mod test {
         async fn it_fails_if_height_is_not_serial() {
             let (mut validator, _, tip) = setup_with_headers(2).await;
             validator.initialize_state(tip.hash()).await.unwrap();
-            let mut next = BlockHeader::from_previous(tip.header(), tip.header().validator_node_merkle_root.clone());
+            let mut next = BlockHeader::from_previous(tip.header());
             next.height = 10;
             let err = validator.validate(next).unwrap_err();
             unpack_enum!(BlockHeaderSyncError::InvalidBlockHeight { expected, actual } = err);

--- a/base_layer/core/src/blocks/new_blockheader_template.rs
+++ b/base_layer/core/src/blocks/new_blockheader_template.rs
@@ -45,8 +45,6 @@ pub struct NewBlockHeaderTemplate {
     pub total_script_offset: BlindingFactor,
     /// Proof of work summary
     pub pow: ProofOfWork,
-    // Merkle root of all active validator node.
-    pub validator_node_merkle_root: Vec<u8>,
 }
 
 impl NewBlockHeaderTemplate {
@@ -58,7 +56,6 @@ impl NewBlockHeaderTemplate {
             total_kernel_offset: header.total_kernel_offset,
             total_script_offset: header.total_script_offset,
             pow: header.pow,
-            validator_node_merkle_root: header.validator_node_merkle_root,
         }
     }
 }

--- a/base_layer/core/src/chain_storage/async_db.rs
+++ b/base_layer/core/src/chain_storage/async_db.rs
@@ -110,7 +110,7 @@ macro_rules! make_async_fn {
      $(#[$outer:meta])*
      $fn:ident$(< $( $lt:tt $( : $clt:path )? ),+ >)?($($param:ident:$ptype:ty),+) -> $rtype:ty, $name:expr) => {
         $(#[$outer])*
-        pub async fn $fn$(< $( $lt $( : $clt )? ),+ +Sync+Send + 'static >)?(&self, $($param: $ptype),+) -> Result<$rtype, ChainStorageError> {
+        pub async fn $fn$(< $( $lt $( : $clt )? ),+ + Sync + Send + 'static >)?(&self, $($param: $ptype),+) -> Result<$rtype, ChainStorageError> {
             let db = self.db.clone();
             let mut mdc = vec![];
             log_mdc::iter(|k, v| mdc.push((k.to_owned(), v.to_owned())));
@@ -270,9 +270,7 @@ impl<B: BlockchainBackend + 'static> AsyncBlockchainDb<B> {
 
     make_async_fn!(fetch_committee(height: u64, shard: [u8;32]) -> Vec<ActiveValidatorNode>, "fetch_committee");
 
-    make_async_fn!(get_validator_nodes_mr() -> Vec<u8>, "get_validator_nodes_mr");
-
-    make_async_fn!(get_shard_key(height:u64, public_key:PublicKey) -> [u8;32], "get_shard_key");
+    make_async_fn!(get_shard_key(height:u64, public_key: PublicKey) -> [u8;32], "get_shard_key");
 }
 
 impl<B: BlockchainBackend + 'static> From<BlockchainDatabase<B>> for AsyncBlockchainDb<B> {

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -93,11 +93,10 @@ use crate::{
         PrunedOutput,
         Reorg,
     },
-    consensus::{ConsensusManager, DomainSeparatedConsensusHasher},
+    consensus::ConsensusManager,
     transactions::{
         aggregated_body::AggregateBody,
         transaction_components::{TransactionError, TransactionInput, TransactionKernel, TransactionOutput},
-        TransactionHashDomain,
     },
     MutablePrunedOutputMmr,
     PrunedKernelMmr,
@@ -1299,11 +1298,7 @@ impl LMDBDatabase {
                 .as_ref()
                 .and_then(|f| f.validator_node_registration())
             {
-                let shard_key = DomainSeparatedConsensusHasher::<TransactionHashDomain>::new("validator_node_root")
-                    // <pk, sig>
-                    .chain(vn_reg)
-                    .chain(&block_hash)
-                    .finalize();
+                let shard_key = vn_reg.derive_shard_key(&block_hash);
 
                 let validator_node = ActiveValidatorNode {
                     shard_key,

--- a/base_layer/core/src/lib.rs
+++ b/base_layer/core/src/lib.rs
@@ -108,14 +108,6 @@ mod domain_hashing {
     );
     pub type InputMmrHasherBlake256 = DomainSeparatedHasher<Blake256, InputMmrHashDomain>;
     pub type PrunedInputMmr = MerkleMountainRange<InputMmrHasherBlake256, PrunedHashSet>;
-}
-
-#[cfg(feature = "base_node")]
-pub use domain_hashing::*;
-
-mod validator_domain_hashing {
-    use tari_crypto::{hash::blake2::Blake256, hash_domain, hashing::DomainSeparatedHasher};
-    use tari_mmr::{Hash, MerkleMountainRange};
 
     hash_domain!(
         ValidatorNodeMmrHashDomain,
@@ -126,4 +118,5 @@ mod validator_domain_hashing {
     pub type ValidatorNodeMmr = MerkleMountainRange<ValidatorNodeMmrHasherBlake256, Vec<Hash>>;
 }
 
-pub use validator_domain_hashing::*;
+#[cfg(feature = "base_node")]
+pub use domain_hashing::*;

--- a/base_layer/core/src/proof_of_work/monero_rx/helpers.rs
+++ b/base_layer/core/src/proof_of_work/monero_rx/helpers.rs
@@ -203,7 +203,6 @@ mod test {
     use crate::{
         consensus::ConsensusEncoding,
         proof_of_work::{monero_rx::fixed_array::FixedByteArray, PowAlgorithm, ProofOfWork},
-        ValidatorNodeMmr,
     };
 
     // This tests checks the hash of monero-rs
@@ -293,7 +292,6 @@ mod test {
         let seed_hash = "9f02e032f9b15d2aded991e0f68cc3c3427270b568b782e55fbd269ead0bad97".to_string();
         let bytes = hex::decode(blocktemplate_blob).unwrap();
         let mut block = deserialize::<monero::Block>(&bytes[..]).unwrap();
-        let vn_mmr = ValidatorNodeMmr::new(Vec::new());
         let mut block_header = BlockHeader {
             version: 0,
             height: 0,
@@ -309,7 +307,7 @@ mod test {
             total_script_offset: Default::default(),
             nonce: 0,
             pow: ProofOfWork::default(),
-            validator_node_merkle_root: vn_mmr.get_merkle_root().unwrap(),
+            validator_node_mr: FixedHash::zero(),
         };
         let hash = block_header.mining_hash();
         append_merge_mining_tag(&mut block, hash).unwrap();
@@ -351,7 +349,6 @@ mod test {
         let seed_hash = "9f02e032f9b15d2aded991e0f68cc3c3427270b568b782e55fbd269ead0bad97".to_string();
         let bytes = hex::decode(blocktemplate_blob).unwrap();
         let mut block = deserialize::<monero::Block>(&bytes[..]).unwrap();
-        let vn_mmr = ValidatorNodeMmr::new(Vec::new());
         let mut block_header = BlockHeader {
             version: 0,
             height: 0,
@@ -367,7 +364,7 @@ mod test {
             total_script_offset: Default::default(),
             nonce: 0,
             pow: ProofOfWork::default(),
-            validator_node_merkle_root: vn_mmr.get_merkle_root().unwrap(),
+            validator_node_mr: FixedHash::zero(),
         };
         let hash = block_header.mining_hash();
         append_merge_mining_tag(&mut block, hash).unwrap();
@@ -405,7 +402,6 @@ mod test {
         let seed_hash = "9f02e032f9b15d2aded991e0f68cc3c3427270b568b782e55fbd269ead0bad97".to_string();
         let bytes = hex::decode(blocktemplate_blob).unwrap();
         let block = deserialize::<monero::Block>(&bytes[..]).unwrap();
-        let vn_mmr = ValidatorNodeMmr::new(Vec::new());
         let mut block_header = BlockHeader {
             version: 0,
             height: 0,
@@ -421,7 +417,7 @@ mod test {
             total_script_offset: Default::default(),
             nonce: 0,
             pow: ProofOfWork::default(),
-            validator_node_merkle_root: vn_mmr.get_merkle_root().unwrap(),
+            validator_node_mr: FixedHash::zero(),
         };
         let count = 1 + (u16::try_from(block.tx_hashes.len()).unwrap());
         let mut hashes = Vec::with_capacity(count as usize);
@@ -458,7 +454,6 @@ mod test {
         let seed_hash = "9f02e032f9b15d2aded991e0f68cc3c3427270b568b782e55fbd269ead0bad97".to_string();
         let bytes = hex::decode(blocktemplate_blob).unwrap();
         let mut block = deserialize::<monero::Block>(&bytes[..]).unwrap();
-        let vn_mmr = ValidatorNodeMmr::new(Vec::new());
         let mut block_header = BlockHeader {
             version: 0,
             height: 0,
@@ -474,7 +469,7 @@ mod test {
             total_script_offset: Default::default(),
             nonce: 0,
             pow: ProofOfWork::default(),
-            validator_node_merkle_root: vn_mmr.get_merkle_root().unwrap(),
+            validator_node_mr: FixedHash::zero(),
         };
         let hash = Hash::null();
         append_merge_mining_tag(&mut block, hash).unwrap();
@@ -515,7 +510,6 @@ mod test {
         let seed_hash = "9f02e032f9b15d2aded991e0f68cc3c3427270b568b782e55fbd269ead0bad97".to_string();
         let bytes = hex::decode(blocktemplate_blob).unwrap();
         let mut block = deserialize::<monero::Block>(&bytes[..]).unwrap();
-        let vn_mmr = ValidatorNodeMmr::new(Vec::new());
         let mut block_header = BlockHeader {
             version: 0,
             height: 0,
@@ -531,7 +525,7 @@ mod test {
             total_script_offset: Default::default(),
             nonce: 0,
             pow: ProofOfWork::default(),
-            validator_node_merkle_root: vn_mmr.get_merkle_root().unwrap(),
+            validator_node_mr: FixedHash::zero(),
         };
         let hash = block_header.mining_hash();
         append_merge_mining_tag(&mut block, hash).unwrap();
@@ -568,7 +562,6 @@ mod test {
 
     #[test]
     fn test_verify_header_no_data() {
-        let vn_mmr = ValidatorNodeMmr::new(Vec::new());
         let mut block_header = BlockHeader {
             version: 0,
             height: 0,
@@ -584,7 +577,7 @@ mod test {
             total_script_offset: Default::default(),
             nonce: 0,
             pow: ProofOfWork::default(),
-            validator_node_merkle_root: vn_mmr.get_merkle_root().unwrap(),
+            validator_node_mr: FixedHash::zero(),
         };
         let monero_data = MoneroPowData {
             header: Default::default(),
@@ -612,7 +605,6 @@ mod test {
         let seed_hash = "9f02e032f9b15d2aded991e0f68cc3c3427270b568b782e55fbd269ead0bad97".to_string();
         let bytes = hex::decode(blocktemplate_blob).unwrap();
         let mut block = deserialize::<monero::Block>(&bytes[..]).unwrap();
-        let vn_mmr = ValidatorNodeMmr::new(Vec::new());
         let mut block_header = BlockHeader {
             version: 0,
             height: 0,
@@ -628,7 +620,7 @@ mod test {
             total_script_offset: Default::default(),
             nonce: 0,
             pow: ProofOfWork::default(),
-            validator_node_merkle_root: vn_mmr.get_merkle_root().unwrap(),
+            validator_node_mr: FixedHash::zero(),
         };
         let hash = block_header.mining_hash();
         append_merge_mining_tag(&mut block, hash).unwrap();

--- a/base_layer/core/src/proto/block.proto
+++ b/base_layer/core/src/proto/block.proto
@@ -110,8 +110,6 @@ message NewBlockHeaderTemplate {
     ProofOfWork pow = 5;
     // Sum of script offsets for all kernels in this block.
     bytes total_script_offset = 6;
-    // Merkle root of validator nodes
-    bytes validator_node_merkle_root = 7;
 }
 
 // The new block template is used constructing a new partial block, allowing a miner to added the coinbase utxo and as a final step the Base node to add the MMR roots to the header.

--- a/base_layer/core/src/proto/block.rs
+++ b/base_layer/core/src/proto/block.rs
@@ -221,7 +221,6 @@ impl TryFrom<proto::NewBlockHeaderTemplate> for NewBlockHeaderTemplate {
             total_kernel_offset,
             total_script_offset,
             pow,
-            validator_node_merkle_root: header.validator_node_merkle_root,
         })
     }
 }
@@ -235,7 +234,6 @@ impl From<NewBlockHeaderTemplate> for proto::NewBlockHeaderTemplate {
             total_kernel_offset: header.total_kernel_offset.to_vec(),
             total_script_offset: header.total_script_offset.to_vec(),
             pow: Some(proto::ProofOfWork::from(header.pow)),
-            validator_node_merkle_root: header.validator_node_merkle_root,
         }
     }
 }

--- a/base_layer/core/src/proto/block_header.rs
+++ b/base_layer/core/src/proto/block_header.rs
@@ -68,7 +68,7 @@ impl TryFrom<proto::BlockHeader> for BlockHeader {
             total_script_offset,
             nonce: header.nonce,
             pow,
-            validator_node_merkle_root: header.validator_node_merkle_root,
+            validator_node_mr: FixedHash::try_from(header.validator_node_merkle_root).map_err(|err| err.to_string())?,
         })
     }
 }
@@ -91,7 +91,7 @@ impl From<BlockHeader> for proto::BlockHeader {
             pow: Some(proto::ProofOfWork::from(header.pow)),
             kernel_mmr_size: header.kernel_mmr_size,
             output_mmr_size: header.output_mmr_size,
-            validator_node_merkle_root: header.validator_node_merkle_root,
+            validator_node_merkle_root: header.validator_node_mr.to_vec(),
         }
     }
 }

--- a/base_layer/core/src/proto/sidechain_feature.rs
+++ b/base_layer/core/src/proto/sidechain_feature.rs
@@ -42,7 +42,9 @@ use crate::{
 //---------------------------------- SideChainFeature --------------------------------------------//
 impl From<SideChainFeature> for proto::types::SideChainFeature {
     fn from(value: SideChainFeature) -> Self {
-        value.into()
+        Self {
+            side_chain_feature: Some(value.into()),
+        }
     }
 }
 

--- a/base_layer/core/src/test_helpers/mod.rs
+++ b/base_layer/core/src/test_helpers/mod.rs
@@ -63,8 +63,7 @@ pub fn create_orphan_block(block_height: u64, transactions: Vec<Transaction>, co
 }
 
 pub fn create_block(rules: &ConsensusManager, prev_block: &Block, spec: BlockSpec) -> (Block, UnblindedOutput) {
-    let mut header =
-        BlockHeader::from_previous(&prev_block.header, prev_block.header.validator_node_merkle_root.clone());
+    let mut header = BlockHeader::from_previous(&prev_block.header);
     let block_height = spec.height_override.unwrap_or(prev_block.header.height + 1);
     header.height = block_height;
     // header.prev_hash = prev_block.hash();

--- a/base_layer/core/src/transactions/transaction_components/side_chain/validator_node_registration.rs
+++ b/base_layer/core/src/transactions/transaction_components/side_chain/validator_node_registration.rs
@@ -61,6 +61,14 @@ impl ValidatorNodeRegistration {
             .finalize()
             .into()
     }
+
+    pub fn derive_shard_key(&self, block_hash: &FixedHash) -> [u8; 32] {
+        DomainSeparatedConsensusHasher::<TransactionHashDomain>::new("validator_node_root")
+            // <pk, sig>
+            .chain(self)
+            .chain(block_hash)
+            .finalize()
+    }
 }
 
 impl ConsensusEncoding for ValidatorNodeRegistration {

--- a/base_layer/core/src/validation/helpers.rs
+++ b/base_layer/core/src/validation/helpers.rs
@@ -552,6 +552,19 @@ pub fn check_mmr_roots(header: &BlockHeader, mmr_roots: &MmrRoots) -> Result<(),
             kind: "Input",
         }));
     }
+    if header.validator_node_mr != mmr_roots.validator_node_mr {
+        warn!(
+            target: LOG_TARGET,
+            "Block header validator node merkle root in {} do not match calculated root. Header.validator_node_mr: \
+             {}, Calculated: {}",
+            header.hash().to_hex(),
+            header.validator_node_mr.to_hex(),
+            mmr_roots.validator_node_mr.to_hex()
+        );
+        return Err(ValidationError::BlockError(BlockValidationError::MismatchedMmrRoots {
+            kind: "Validator Node",
+        }));
+    }
     Ok(())
 }
 

--- a/base_layer/core/src/validation/test.rs
+++ b/base_layer/core/src/validation/test.rs
@@ -113,8 +113,7 @@ mod header_validators {
 
         let genesis = db.fetch_chain_header(0).unwrap();
 
-        let mut header =
-            BlockHeader::from_previous(genesis.header(), genesis.header().validator_node_merkle_root.clone());
+        let mut header = BlockHeader::from_previous(genesis.header());
         header.version = u16::MAX;
 
         let validator = HeaderValidator::new(consensus_manager.clone());
@@ -202,7 +201,7 @@ fn chain_balance_validation() {
         .build()
         .unwrap();
 
-    let mut header1 = BlockHeader::from_previous(genesis.header(), genesis.header().validator_node_merkle_root.clone());
+    let mut header1 = BlockHeader::from_previous(genesis.header());
     header1.kernel_mmr_size += 1;
     header1.output_mmr_size += 1;
     let achieved_difficulty = AchievedTargetDifficulty::try_construct(
@@ -254,7 +253,7 @@ fn chain_balance_validation() {
         .build()
         .unwrap();
 
-    let mut header2 = BlockHeader::from_previous(header1.header(), header1.header().validator_node_merkle_root.clone());
+    let mut header2 = BlockHeader::from_previous(header1.header());
     header2.kernel_mmr_size += 1;
     header2.output_mmr_size += 1;
     let achieved_difficulty = AchievedTargetDifficulty::try_construct(
@@ -376,7 +375,7 @@ fn chain_balance_validation_burned() {
         .build()
         .unwrap();
     burned_sum = &burned_sum + kernel2.get_burn_commitment().unwrap();
-    let mut header1 = BlockHeader::from_previous(genesis.header(), genesis.header().validator_node_merkle_root.clone());
+    let mut header1 = BlockHeader::from_previous(genesis.header());
     header1.kernel_mmr_size += 2;
     header1.output_mmr_size += 2;
     let achieved_difficulty = AchievedTargetDifficulty::try_construct(

--- a/base_layer/core/tests/chain_storage_tests/chain_storage.rs
+++ b/base_layer/core/tests/chain_storage_tests/chain_storage.rs
@@ -89,10 +89,7 @@ fn insert_and_fetch_header() {
     let _consensus_manager = ConsensusManagerBuilder::new(network).build();
     let store = create_test_blockchain_db();
     let genesis_block = store.fetch_tip_header().unwrap();
-    let mut header1 = BlockHeader::from_previous(
-        genesis_block.header(),
-        genesis_block.header().validator_node_merkle_root.clone(),
-    );
+    let mut header1 = BlockHeader::from_previous(genesis_block.header());
 
     header1.kernel_mmr_size += 1;
     header1.output_mmr_size += 1;
@@ -100,7 +97,7 @@ fn insert_and_fetch_header() {
     let chain1 = create_chain_header(header1.clone(), genesis_block.accumulated_data());
 
     store.insert_valid_headers(vec![chain1.clone()]).unwrap();
-    let mut header2 = BlockHeader::from_previous(&header1, header1.validator_node_merkle_root.clone());
+    let mut header2 = BlockHeader::from_previous(&header1);
     header2.kernel_mmr_size += 2;
     header2.output_mmr_size += 2;
     let chain2 = create_chain_header(header2.clone(), chain1.accumulated_data());

--- a/base_layer/core/tests/helpers/block_builders.rs
+++ b/base_layer/core/tests/helpers/block_builders.rs
@@ -58,6 +58,7 @@ use tari_core::{
     KernelMmr,
     KernelMmrHasherBlake256,
     MutableOutputMmr,
+    ValidatorNodeMmr,
     WitnessMmr,
     WitnessMmrHasherBlake256,
 };
@@ -107,24 +108,24 @@ fn genesis_template(
     (block, output)
 }
 
-#[test]
 // #[ignore = "used to generate a new esmeralda genesis block"]
 /// This is a helper function to generate and print out a block that can be used as the genesis block.
 /// 1. Run `cargo test --package tari_core --test mempool -- helpers::block_builders::print_new_genesis_block_esmeralda
 /// --exact --nocapture`
 /// 1. The block and range proof will be printed
 /// 1. Profit!
+#[test]
 fn print_new_genesis_block_esmeralda() {
     print_new_genesis_block(Network::Esmeralda);
 }
 
-#[test]
 // #[ignore = "used to generate a new igor genesis block"]
 /// This is a helper function to generate and print out a block that can be used as the genesis block.
 /// 1. Run `cargo test --package tari_core --test mempool -- helpers::block_builders::print_new_genesis_block_igor
 /// --exact --nocapture`
 /// 1. The block and range proof will be printed
 /// 1. Profit!
+#[test]
 fn print_new_genesis_block_igor() {
     print_new_genesis_block(Network::Igor);
 }
@@ -159,12 +160,14 @@ fn print_new_genesis_block(network: Network) {
     witness_mmr.push(utxo.witness_hash().to_vec()).unwrap();
     let mut output_mmr = MutableOutputMmr::new(Vec::new(), Bitmap::create()).unwrap();
     output_mmr.push(utxo.hash().to_vec()).unwrap();
+    let vn_mmr = ValidatorNodeMmr::new(Vec::new());
 
     header.kernel_mr = FixedHash::try_from(kernel_mmr.get_merkle_root().unwrap()).unwrap();
     header.kernel_mmr_size += 1;
     header.output_mr = FixedHash::try_from(output_mmr.get_merkle_root().unwrap()).unwrap();
     header.witness_mr = FixedHash::try_from(witness_mmr.get_merkle_root().unwrap()).unwrap();
     header.output_mmr_size += 1;
+    header.validator_node_mr = FixedHash::try_from(vn_mmr.get_merkle_root().unwrap()).unwrap();
 
     // header.kernel_mr = kernel.hash();
     // header.kernel_mmr_size += 1;
@@ -213,6 +216,7 @@ fn print_new_genesis_block(network: Network) {
     println!("header output_mr: {}", block.header.output_mr.to_hex());
     println!("header witness_mr: {}", block.header.witness_mr.to_hex());
     println!("header kernel_mr: {}", block.header.kernel_mr.to_hex());
+    println!("header validator_node_mr: {}", block.header.validator_node_mr.to_hex());
     println!(
         "header total_kernel_offset: {}",
         block.header.total_kernel_offset.to_hex()
@@ -338,8 +342,7 @@ pub fn chain_block(
     transactions: Vec<Transaction>,
     consensus: &ConsensusManager,
 ) -> NewBlockTemplate {
-    let mut header =
-        BlockHeader::from_previous(&prev_block.header, prev_block.header.validator_node_merkle_root.clone());
+    let mut header = BlockHeader::from_previous(&prev_block.header);
     header.version = consensus.consensus_constants(header.height).blockchain_version();
     let height = header.height;
     let reward = consensus.get_block_reward_at(height);
@@ -367,10 +370,7 @@ pub fn chain_block_with_coinbase(
     coinbase_kernel: TransactionKernel,
     consensus: &ConsensusManager,
 ) -> NewBlockTemplate {
-    let mut header = BlockHeader::from_previous(
-        prev_block.header(),
-        prev_block.header().validator_node_merkle_root.clone(),
-    );
+    let mut header = BlockHeader::from_previous(prev_block.header());
     header.version = consensus.consensus_constants(header.height).blockchain_version();
     let height = header.height;
     NewBlockTemplate::from_block(
@@ -401,10 +401,7 @@ pub fn chain_block_with_new_coinbase(
         coinbase_value,
         height + consensus_manager.consensus_constants(height).coinbase_lock_height(),
     );
-    let mut header = BlockHeader::from_previous(
-        prev_block.header(),
-        prev_block.header().validator_node_merkle_root.clone(),
-    );
+    let mut header = BlockHeader::from_previous(prev_block.header());
     header.height = height;
     header.version = consensus_manager
         .consensus_constants(header.height)


### PR DESCRIPTION
Description
---
- calculates validator node MR in `calculate_merkle_roots` function
- allows tari_core and wallet to compile without base node feature
- removes validator_node_mr param from `BlockHeader::from_previous`
- removes validator_node_mr from NewBlocktemplate
- removes validator node mr validation task from async validator
- adds validator node mr validator to `check_merkle_roots`
- removes unused get_validator_mr function from blockchain db
- checks validator node mr in genesis block sanity check
- removes panic from grpc conversion code

Motivation and Context
---
Validator node MR is created and checked in a different way from other merkle roots, this PR brings that code inline with other the current merkle root code + number of minor improvements.

How Has This Been Tested?
---
Existing tests - TODO: write validator node registration tests for blockchain db and block validators

