### PR TITLE
feat: improve the TMS validation process

### DIFF
--- a/base_layer/wallet/src/transaction_service/error.rs
+++ b/base_layer/wallet/src/transaction_service/error.rs
@@ -162,6 +162,8 @@ pub enum TransactionServiceError {
     ServiceError(String),
     #[error("Wallet Recovery in progress so Transaction Service Messaging Requests ignored")]
     WalletRecoveryInProgress,
+    #[error("Wallet Transaction Validation already in progress, request ignored")]
+    TransactionValidationInProgress,
     #[error("Connectivity error: {source}")]
     ConnectivityError {
         #[from]

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_validation_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_validation_protocol.rs
@@ -217,10 +217,10 @@ where
             // we can use expect here as fetch_last_mined_transaction filters on mined_height and mined_in block is some
             let mined_height = last_mined_transaction
                 .mined_height
-                .expect(&"Tx validation mined height is missing".to_string());
+                .expect("Tx validation mined height is missing");
             let mined_in_block_hash = last_mined_transaction
                 .mined_in_block
-                .expect(&"Tx validation mined in block is missing".to_string());
+                .expect("Tx validation mined in block is missing");
 
             let block_at_height = self
                 .get_base_node_block_at_height(mined_height, client)

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_validation_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_validation_protocol.rs
@@ -214,11 +214,13 @@ where
         );
         let op_id = self.operation_id;
         while let Some(last_mined_transaction) = self.db.fetch_last_mined_transaction().for_protocol(op_id)? {
-
-
             // we can use expect here as fetch_last_mined_transaction filters on mined_height and mined_in block is some
-            let mined_height = last_mined_transaction.mined_height.expect(&"Tx validation mined height is missing".to_string());
-            let mined_in_block_hash = last_mined_transaction.mined_in_block.expect(&"Tx validation mined in block is missing".to_string());
+            let mined_height = last_mined_transaction
+                .mined_height
+                .expect(&"Tx validation mined height is missing".to_string());
+            let mined_in_block_hash = last_mined_transaction
+                .mined_in_block
+                .expect(&"Tx validation mined in block is missing".to_string());
 
             let block_at_height = self
                 .get_base_node_block_at_height(mined_height, client)

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_validation_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_validation_protocol.rs
@@ -214,23 +214,11 @@ where
         );
         let op_id = self.operation_id;
         while let Some(last_mined_transaction) = self.db.fetch_last_mined_transaction().for_protocol(op_id)? {
-            let mined_height = last_mined_transaction
-                .mined_height
-                .ok_or_else(|| {
-                    TransactionServiceError::ServiceError(
-                        "fetch_last_mined_transaction() should return a transaction with a mined_height".to_string(),
-                    )
-                })
-                .for_protocol(op_id)?;
-            let mined_in_block_hash = last_mined_transaction
-                .mined_in_block
-                .ok_or_else(|| {
-                    TransactionServiceError::ServiceError(
-                        "fetch_last_mined_transaction() should return a transaction with a mined_in_block hash"
-                            .to_string(),
-                    )
-                })
-                .for_protocol(op_id)?;
+
+
+            // we can use expect here as fetch_last_mined_transaction filters on mined_height and mined_in block is some
+            let mined_height = last_mined_transaction.mined_height.expect(&"Tx validation mined height is missing".to_string());
+            let mined_in_block_hash = last_mined_transaction.mined_in_block.expect(&"Tx validation mined in block is missing".to_string());
 
             let block_at_height = self
                 .get_base_node_block_at_height(mined_height, client)

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -2204,6 +2204,10 @@ where
         let validation_in_progress = self.validation_in_progress.clone();
         let join_handle = tokio::spawn(async move {
             let mut _lock = validation_in_progress.try_lock().map_err(|_| {
+                debug!(
+                    target: LOG_TARGET,
+                    "Transaction Validation Protocol (Id: {}) spawned while a previous protocol was busy, ignored", id
+                );
                 TransactionServiceProtocolError::new(id, TransactionServiceError::TransactionValidationInProgress)
             })?;
             let exec_fut = protocol.execute();


### PR DESCRIPTION
Description
---
Adds a mutex on the TMS validation process to stop multiple validations running per time.

Motivation and Context
---
Validation on the transactions is run when the Base_node state changes, which is an automated event triggered when a base_node lags, a new block is received, or the wallet connects to a new base node. The other path for this is user triggered where the user manually triggers a validation. 

Triggering more than one validation at a time is a waste of resources and network traffic as the wallet now asks the same basenode for the same data more than once.

