### PR TITLE
fix: burned reorg

### DIFF
--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -949,6 +949,10 @@ impl LMDBDatabase {
                 if inputs.iter().any(|r| r.input.output_hash() == output_hash) {
                     continue;
                 }
+                // if an output was burned, it was never created as an unspent utxo
+                if output.is_burned() {
+                    continue;
+                }
                 lmdb_delete(
                     txn,
                     &*self.utxo_commitment_index,

--- a/integration_tests/features/Reorgs.feature
+++ b/integration_tests/features/Reorgs.feature
@@ -41,21 +41,21 @@ Feature: Reorgs
 
     When I wait for wallet WB to have at least 55000000000 uT
     When I create a burn transaction of 1000000 uT from WB at fee 100
-    And mining node BM mines 5 blocks with min difficulty 1 and max difficulty 50
+    And mining node BM mines 5 blocks with min difficulty 1 and max difficulty 1
         # Chain 2
         #     Note: Use more than 1 base node to speed up the test
     Given I have a seed node SEED_C
     And I have a base node C connected to seed SEED_C
     And I have wallet WC connected to base node C
     And I have mining node CM connected to base node C and wallet WC
-    And mining node CM mines 11 blocks with min difficulty 1 and max difficulty 1
+    And mining node CM mines 17 blocks with min difficulty 1 and max difficulty 1
         # Connect chain 1 and 2
-    Then node B is at height 20
-    And node C is at height 30
+    Then node B is at height 15
+    And node C is at height 17
     Given I have a base node SA connected to nodes B,C
-    Then node SA is at height 30
-    And node B is at height 30
-    And node C is at height 30
+    Then node SA is at height 17
+    And node B is at height 17
+    And node C is at height 17
 
   @critical
   Scenario: Node rolls back reorg on invalid block

--- a/integration_tests/features/Reorgs.feature
+++ b/integration_tests/features/Reorgs.feature
@@ -37,7 +37,8 @@ Feature: Reorgs
     And I have a base node B connected to seed SEED_B
     And I have wallet WB connected to base node B
     And I have mining node BM connected to base node B and wallet WB
-    And mining node BM mines 15 blocks with min difficulty 1 and max difficulty 50
+    And mining node BM mines 10 blocks with min difficulty 1 and max difficulty 1
+
     When I wait for wallet WB to have at least 55000000000 uT
     When I create a burn transaction of 1000000 uT from WB at fee 100
     And mining node BM mines 5 blocks with min difficulty 1 and max difficulty 50

--- a/integration_tests/features/Reorgs.feature
+++ b/integration_tests/features/Reorgs.feature
@@ -28,6 +28,34 @@ Feature: Reorgs
     And node B is at height 10
     And node C is at height 10
 
+
+  @critical
+  Scenario: Simple reorg with burned output
+        # Chain 1
+        #     Note: Use more than 1 base node to speed up the test
+    Given I have a seed node SEED_B
+    And I have a base node B connected to seed SEED_B
+    And I have wallet WB connected to base node B
+    And I have mining node BM connected to base node B and wallet WB
+    And mining node BM mines 15 blocks with min difficulty 1 and max difficulty 50
+    When I wait for wallet WB to have at least 55000000000 uT
+    When I create a burn transaction of 1000000 uT from WB at fee 100
+    And mining node BM mines 5 blocks with min difficulty 1 and max difficulty 50
+        # Chain 2
+        #     Note: Use more than 1 base node to speed up the test
+    Given I have a seed node SEED_C
+    And I have a base node C connected to seed SEED_C
+    And I have wallet WC connected to base node C
+    And I have mining node CM connected to base node C and wallet WC
+    And mining node CM mines 30 blocks with min difficulty 51 and max difficulty 9999999999
+        # Connect chain 1 and 2
+    Then node B is at height 20
+    And node C is at height 30
+    Given I have a base node SA connected to nodes B,C
+    Then node SA is at height 30
+    And node B is at height 30
+    And node C is at height 30
+
   @critical
   Scenario: Node rolls back reorg on invalid block
     Given I have a seed node SA

--- a/integration_tests/features/Reorgs.feature
+++ b/integration_tests/features/Reorgs.feature
@@ -48,7 +48,7 @@ Feature: Reorgs
     And I have a base node C connected to seed SEED_C
     And I have wallet WC connected to base node C
     And I have mining node CM connected to base node C and wallet WC
-    And mining node CM mines 30 blocks with min difficulty 51 and max difficulty 9999999999
+    And mining node CM mines 11 blocks with min difficulty 1 and max difficulty 1
         # Connect chain 1 and 2
     Then node B is at height 20
     And node C is at height 30


### PR DESCRIPTION
Description
---
Fixes rewind to height for burned outputs

Motivation and Context
---
When rewinding the blockchain, the rewind tries to delete the "unspent" utxo. But burned outputs never have spent utxos created for them. This causes rewinds to break. 


How Has This Been Tested?
---
Added a new cucumber test

Fixes: #4662 
