### PR TITLE
feat(core/sync): adds `connecting` sync status

### DIFF
--- a/applications/tari_app_grpc/proto/base_node.proto
+++ b/applications/tari_app_grpc/proto/base_node.proto
@@ -156,7 +156,7 @@ enum BaseNodeState{
     START_UP = 0;
     HEADER_SYNC = 1;
     HORIZON_SYNC = 2;
-    BLOCK_SYNC_STARTING= 3;
+    CONNECTING = 3;
     BLOCK_SYNC = 4;
     LISTENING = 5;
 }

--- a/applications/tari_app_grpc/src/conversions/base_node_state.rs
+++ b/applications/tari_app_grpc/src/conversions/base_node_state.rs
@@ -22,7 +22,7 @@
 
 use tari_core::base_node::state_machine_service::states::{
     StateInfo,
-    StateInfo::{BlockSync, BlockSyncStarting, HeaderSync, HorizonSync, Listening, StartUp},
+    StateInfo::{BlockSync, Connecting, HeaderSync, HorizonSync, Listening, StartUp},
 };
 
 use crate::tari_rpc as grpc;
@@ -33,7 +33,7 @@ impl From<StateInfo> for grpc::BaseNodeState {
             StartUp => grpc::BaseNodeState::HeaderSync,
             HeaderSync(_) => grpc::BaseNodeState::HeaderSync,
             HorizonSync(_) => grpc::BaseNodeState::HorizonSync,
-            BlockSyncStarting => grpc::BaseNodeState::BlockSyncStarting,
+            Connecting(_) => grpc::BaseNodeState::Connecting,
             BlockSync(_) => grpc::BaseNodeState::BlockSync,
             Listening(_) => grpc::BaseNodeState::Listening,
         }
@@ -46,7 +46,7 @@ impl From<&StateInfo> for grpc::BaseNodeState {
             StartUp => grpc::BaseNodeState::HeaderSync,
             HeaderSync(_) => grpc::BaseNodeState::HeaderSync,
             HorizonSync(_) => grpc::BaseNodeState::HorizonSync,
-            BlockSyncStarting => grpc::BaseNodeState::BlockSyncStarting,
+            Connecting(_) => grpc::BaseNodeState::Connecting,
             BlockSync(_) => grpc::BaseNodeState::BlockSync,
             Listening(_) => grpc::BaseNodeState::Listening,
         }

--- a/applications/tari_base_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/tari_base_node/src/grpc/base_node_grpc_server.rs
@@ -1394,7 +1394,7 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
                 local_height: info.local_height,
                 state: tari_rpc::SyncState::Header.into(),
             },
-            StateInfo::BlockSyncStarting => tari_rpc::SyncProgressResponse {
+            StateInfo::Connecting(_) => tari_rpc::SyncProgressResponse {
                 tip_height: 0,
                 local_height: 0,
                 state: tari_rpc::SyncState::BlockStarting.into(),

--- a/base_layer/core/src/base_node/state_machine_service/states/events_and_states.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/events_and_states.rs
@@ -166,25 +166,32 @@ impl Display for BaseNodeState {
 #[derive(Debug, Clone, PartialEq)]
 pub enum StateInfo {
     StartUp,
+    Connecting(SyncPeer),
     HeaderSync(Option<BlockSyncInfo>),
     HorizonSync(HorizonSyncInfo),
-    BlockSyncStarting,
     BlockSync(BlockSyncInfo),
     Listening(ListeningInfo),
 }
 
 impl StateInfo {
     pub fn short_desc(&self) -> String {
-        use StateInfo::{BlockSync, BlockSyncStarting, HeaderSync, HorizonSync, Listening, StartUp};
+        use StateInfo::{BlockSync, Connecting, HeaderSync, HorizonSync, Listening, StartUp};
         match self {
             StartUp => "Starting up".to_string(),
+            Connecting(sync_peer) => format!(
+                "Connecting to {}{}",
+                sync_peer.node_id().short_str(),
+                sync_peer
+                    .latency()
+                    .map(|l| format!(", Latency: {:.2?}", l))
+                    .unwrap_or_else(|| "".to_string())
+            ),
             HeaderSync(None) => "Starting header sync".to_string(),
             HeaderSync(Some(info)) => format!("Syncing headers: {}", info.sync_progress_string()),
             HorizonSync(info) => info.to_progress_string(),
 
             BlockSync(info) => format!("Syncing blocks: {}", info.sync_progress_string()),
             Listening(_) => "Listening".to_string(),
-            BlockSyncStarting => "Starting block sync".to_string(),
         }
     }
 
@@ -196,9 +203,9 @@ impl StateInfo {
     }
 
     pub fn is_synced(&self) -> bool {
-        use StateInfo::{BlockSync, BlockSyncStarting, HeaderSync, HorizonSync, Listening, StartUp};
+        use StateInfo::{BlockSync, Connecting, HeaderSync, HorizonSync, Listening, StartUp};
         match self {
-            StartUp | HeaderSync(_) | HorizonSync(_) | BlockSync(_) | BlockSyncStarting => false,
+            StartUp | Connecting(_) | HeaderSync(_) | HorizonSync(_) | BlockSync(_) => false,
             Listening(info) => info.is_synced(),
         }
     }
@@ -206,15 +213,16 @@ impl StateInfo {
 
 impl Display for StateInfo {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
-        use StateInfo::{BlockSync, BlockSyncStarting, HeaderSync, HorizonSync, Listening, StartUp};
+        #[allow(clippy::enum_glob_use)]
+        use StateInfo::*;
         match self {
             StartUp => write!(f, "Node starting up"),
+            Connecting(sync_peer) => write!(f, "Connecting to {}", sync_peer),
             HeaderSync(Some(info)) => write!(f, "Synchronizing block headers: {}", info),
             HeaderSync(None) => write!(f, "Synchronizing block headers: Starting"),
             HorizonSync(info) => write!(f, "Synchronizing horizon state: {}", info),
             BlockSync(info) => write!(f, "Synchronizing blocks: {}", info),
             Listening(info) => write!(f, "Listening: {}", info),
-            BlockSyncStarting => write!(f, "Synchronizing blocks: Starting"),
         }
     }
 }
@@ -275,7 +283,7 @@ impl BlockSyncInfo {
             self.sync_peer.node_id().short_str(),
             self.local_height,
             self.tip_height,
-            (self.local_height as f64 / self.tip_height as f64 * 100.0),
+            (self.local_height as f64 / self.tip_height as f64 * 100.0).floor(),
             self.sync_peer
                 .items_per_second()
                 .map(|bps| format!(" {:.2?} blks/s", bps))

--- a/base_layer/core/src/base_node/state_machine_service/states/header_sync.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/header_sync.rs
@@ -88,10 +88,10 @@ impl HeaderSyncState {
         let bootstrapped = shared.is_bootstrapped();
         let randomx_vm_cnt = shared.get_randomx_vm_cnt();
         let randomx_vm_flags = shared.get_randomx_vm_flags();
-        synchronizer.on_starting(move || {
+        synchronizer.on_starting(move |sync_peer| {
             let _result = status_event_sender.send(StatusInfo {
                 bootstrapped,
-                state_info: StateInfo::HeaderSync(None),
+                state_info: StateInfo::Connecting(sync_peer.clone()),
                 randomx_vm_cnt,
                 randomx_vm_flags,
             });

--- a/base_layer/core/src/base_node/state_machine_service/states/horizon_state_sync.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/horizon_state_sync.rs
@@ -31,7 +31,7 @@ use super::{StateEvent, StateInfo};
 use crate::{
     base_node::{
         state_machine_service::states::StatusInfo,
-        sync::{HorizonStateSynchronization, HorizonSyncInfo, HorizonSyncStatus, SyncPeer},
+        sync::{HorizonStateSynchronization, SyncPeer},
         BaseNodeStateMachine,
     },
     chain_storage::BlockchainBackend,
@@ -101,12 +101,10 @@ impl HorizonStateSync {
         let bootstrapped = shared.is_bootstrapped();
         let randomx_vm_cnt = shared.get_randomx_vm_cnt();
         let randomx_vm_flags = shared.get_randomx_vm_flags();
-        let sync_peers_node_id = sync_peers.iter().map(|p| p.node_id()).cloned().collect();
-        horizon_sync.on_starting(move || {
-            let info = HorizonSyncInfo::new(sync_peers_node_id, HorizonSyncStatus::Starting);
+        horizon_sync.on_starting(move |sync_peer| {
             let _result = status_event_sender.send(StatusInfo {
                 bootstrapped,
-                state_info: StateInfo::HorizonSync(info),
+                state_info: StateInfo::Connecting(sync_peer.clone()),
                 randomx_vm_cnt,
                 randomx_vm_flags,
             });

--- a/base_layer/core/src/base_node/sync/hooks.rs
+++ b/base_layer/core/src/base_node/sync/hooks.rs
@@ -31,7 +31,7 @@ use crate::{
 
 #[derive(Default)]
 pub(super) struct Hooks {
-    on_starting: Vec<Box<dyn FnOnce() + Send + Sync>>,
+    on_starting: Vec<Box<dyn FnOnce(&SyncPeer) + Send + Sync>>,
     on_progress_header: Vec<Box<dyn Fn(u64, u64, &SyncPeer) + Send + Sync>>,
     on_progress_block: Vec<Box<dyn Fn(Arc<ChainBlock>, u64, &SyncPeer) + Send + Sync>>,
     on_progress_horizon_sync: Vec<Box<dyn Fn(HorizonSyncInfo) + Send + Sync>>,
@@ -41,12 +41,12 @@ pub(super) struct Hooks {
 
 impl Hooks {
     pub fn add_on_starting_hook<H>(&mut self, hook: H)
-    where H: FnOnce() + Send + Sync + 'static {
+    where H: FnOnce(&SyncPeer) + Send + Sync + 'static {
         self.on_starting.push(Box::new(hook));
     }
 
-    pub fn call_on_starting_hook(&mut self) {
-        self.on_starting.drain(..).for_each(|f| (f)());
+    pub fn call_on_starting_hook(&mut self, sync_peer: &SyncPeer) {
+        self.on_starting.drain(..).for_each(|f| (f)(sync_peer));
     }
 
     pub fn add_on_progress_header_hook<H>(&mut self, hook: H)


### PR DESCRIPTION
Description
---
- Adds connecting sync status

Motivation and Context
---
Statuses like "starting block sync" did not show which peer is being synced from.
This PR changes the status to connecting and includes the sync peer that is being connected to.

How Has This Been Tested?
---
Manually
