### PR TITLE
fix(wallet): fixes bug in fetch_by_commitment

### DIFF
--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -1109,15 +1109,7 @@ where
 
         // If there is no existing output available, we store the one we produced.
         match self.resources.db.fetch_by_commitment(output.commitment.clone()) {
-            Ok(outs) => {
-                if outs.is_empty() {
-                    self.resources
-                        .db
-                        .add_output_to_be_received(tx_id, output, Some(block_height))?;
-
-                    self.confirm_encumberance(tx_id)?;
-                }
-            },
+            Ok(_) => {},
             Err(OutputManagerStorageError::ValueNotFound) => {
                 self.resources
                     .db

--- a/base_layer/wallet/src/output_manager_service/storage/database/mod.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/database/mod.rs
@@ -228,16 +228,13 @@ where T: OutputManagerBackend + 'static
         Ok(result)
     }
 
-    pub fn fetch_by_commitment(
-        &self,
-        commitment: Commitment,
-    ) -> Result<Vec<DbUnblindedOutput>, OutputManagerStorageError> {
-        let result = match self.db.fetch(&DbKey::AnyOutputByCommitment(commitment))? {
-            Some(DbValue::UnspentOutputs(outputs)) => outputs,
-            Some(other) => return unexpected_result(DbKey::UnspentOutputs, other),
-            None => vec![],
-        };
-        Ok(result)
+    pub fn fetch_by_commitment(&self, commitment: Commitment) -> Result<DbUnblindedOutput, OutputManagerStorageError> {
+        let req = DbKey::AnyOutputByCommitment(commitment);
+        match self.db.fetch(&req)? {
+            Some(DbValue::AnyOutput(output)) => Ok(*output),
+            Some(other) => unexpected_result(req, other),
+            None => Err(OutputManagerStorageError::ValueNotFound),
+        }
     }
 
     pub fn fetch_with_features(

--- a/base_layer/wallet/src/output_manager_service/storage/sqlite_db/mod.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/sqlite_db/mod.rs
@@ -206,7 +206,7 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
                 match OutputSql::find_by_commitment(&commitment.to_vec(), &conn) {
                     Ok(mut o) => {
                         self.decrypt_if_necessary(&mut o)?;
-                        Some(DbValue::SpentOutput(Box::new(DbUnblindedOutput::try_from(o)?)))
+                        Some(DbValue::AnyOutput(Box::new(DbUnblindedOutput::try_from(o)?)))
                     },
                     Err(e) => {
                         match e {


### PR DESCRIPTION
Description
---
Fixes request/response mismatch bug in fetch_by_commitment.
`fetch_by_commitment` can only ever return one value, or a not found error

Motivation and Context
---
This error is encountered during merge mining
```text
Output manager error: `Output manager storage error: `Unexpected result: `Unexpected result for database query Unspent Outputs Key. Response: Spent Output
```

This is caused by `fetch(DbKey::AnyOutputByCommitment)` returning `DbValue::SpentOutput` but the caller expects `DbKey::UnspentOutput`

How Has This Been Tested?
---
Merge mining works
