### PR TITLE
fix: sync handling and increase reorg speed in mempool

### DIFF
--- a/base_layer/core/src/base_node/chain_metadata_service/service.rs
+++ b/base_layer/core/src/base_node/chain_metadata_service/service.rs
@@ -136,7 +136,7 @@ impl ChainMetadataService {
         match event {
             BlockEvent::ValidBlockAdded(_, BlockAddResult::Ok(_)) |
             BlockEvent::ValidBlockAdded(_, BlockAddResult::ChainReorg { .. }) |
-            BlockEvent::BlockSyncComplete(_) => {
+            BlockEvent::BlockSyncComplete() => {
                 self.update_liveness_chain_metadata().await?;
             },
             _ => {},

--- a/base_layer/core/src/base_node/chain_metadata_service/service.rs
+++ b/base_layer/core/src/base_node/chain_metadata_service/service.rs
@@ -136,7 +136,7 @@ impl ChainMetadataService {
         match event {
             BlockEvent::ValidBlockAdded(_, BlockAddResult::Ok(_)) |
             BlockEvent::ValidBlockAdded(_, BlockAddResult::ChainReorg { .. }) |
-            BlockEvent::BlockSyncComplete() => {
+            BlockEvent::BlockSyncComplete(_, _) => {
                 self.update_liveness_chain_metadata().await?;
             },
             _ => {},

--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -70,7 +70,7 @@ pub enum BlockEvent {
     AddBlockErrored {
         block: Arc<Block>,
     },
-    BlockSyncComplete(Arc<ChainBlock>),
+    BlockSyncComplete(),
     BlockSyncRewind(Vec<Arc<ChainBlock>>),
 }
 

--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -70,7 +70,7 @@ pub enum BlockEvent {
     AddBlockErrored {
         block: Arc<Block>,
     },
-    BlockSyncComplete(),
+    BlockSyncComplete(Arc<ChainBlock>, u64),
     BlockSyncRewind(Vec<Arc<ChainBlock>>),
 }
 

--- a/base_layer/core/src/base_node/state_machine_service/states/block_sync.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/block_sync.rs
@@ -93,8 +93,8 @@ impl BlockSync {
         });
 
         let local_nci = shared.local_node_interface.clone();
-        synchronizer.on_complete(move |block| {
-            local_nci.publish_block_event(BlockEvent::BlockSyncComplete(block));
+        synchronizer.on_complete(move |_| {
+            local_nci.publish_block_event(BlockEvent::BlockSyncComplete());
         });
 
         let timer = Instant::now();

--- a/base_layer/core/src/base_node/state_machine_service/states/block_sync.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/block_sync.rs
@@ -93,8 +93,8 @@ impl BlockSync {
         });
 
         let local_nci = shared.local_node_interface.clone();
-        synchronizer.on_complete(move |_| {
-            local_nci.publish_block_event(BlockEvent::BlockSyncComplete());
+        synchronizer.on_complete(move |block, starting_height| {
+            local_nci.publish_block_event(BlockEvent::BlockSyncComplete(block, starting_height));
         });
 
         let timer = Instant::now();

--- a/base_layer/core/src/base_node/sync/block_sync/synchronizer.rs
+++ b/base_layer/core/src/base_node/sync/block_sync/synchronizer.rs
@@ -92,7 +92,7 @@ impl<B: BlockchainBackend + 'static> BlockSynchronizer<B> {
     }
 
     pub fn on_complete<H>(&mut self, hook: H)
-    where H: Fn(Arc<ChainBlock>) + Send + Sync + 'static {
+    where H: Fn(Arc<ChainBlock>, u64) + Send + Sync + 'static {
         self.hooks.add_on_complete_hook(hook);
     }
 
@@ -377,7 +377,7 @@ impl<B: BlockchainBackend + 'static> BlockSynchronizer<B> {
         }
 
         if let Some(block) = current_block {
-            self.hooks.call_on_complete_hooks(block);
+            self.hooks.call_on_complete_hooks(block, best_height);
         }
 
         debug!(target: LOG_TARGET, "Completed block sync with peer `{}`", sync_peer);

--- a/base_layer/core/src/base_node/sync/hooks.rs
+++ b/base_layer/core/src/base_node/sync/hooks.rs
@@ -35,7 +35,7 @@ pub(super) struct Hooks {
     on_progress_header: Vec<Box<dyn Fn(u64, u64, &SyncPeer) + Send + Sync>>,
     on_progress_block: Vec<Box<dyn Fn(Arc<ChainBlock>, u64, &SyncPeer) + Send + Sync>>,
     on_progress_horizon_sync: Vec<Box<dyn Fn(HorizonSyncInfo) + Send + Sync>>,
-    on_complete: Vec<Box<dyn Fn(Arc<ChainBlock>) + Send + Sync>>,
+    on_complete: Vec<Box<dyn Fn(Arc<ChainBlock>, u64) + Send + Sync>>,
     on_rewind: Vec<Box<dyn Fn(Vec<Arc<ChainBlock>>) + Send + Sync>>,
 }
 
@@ -81,12 +81,14 @@ impl Hooks {
     }
 
     pub fn add_on_complete_hook<H>(&mut self, hook: H)
-    where H: Fn(Arc<ChainBlock>) + Send + Sync + 'static {
+    where H: Fn(Arc<ChainBlock>, u64) + Send + Sync + 'static {
         self.on_complete.push(Box::new(hook));
     }
 
-    pub fn call_on_complete_hooks(&self, final_block: Arc<ChainBlock>) {
-        self.on_complete.iter().for_each(|f| (*f)(final_block.clone()));
+    pub fn call_on_complete_hooks(&self, final_block: Arc<ChainBlock>, starting_height: u64) {
+        self.on_complete
+            .iter()
+            .for_each(|f| (*f)(final_block.clone(), starting_height));
     }
 
     pub fn add_on_rewind_hook<H>(&mut self, hook: H)

--- a/base_layer/core/src/mempool/mempool.rs
+++ b/base_layer/core/src/mempool/mempool.rs
@@ -103,8 +103,7 @@ impl Mempool {
 
     /// After a sync event, we can move all orphan transactions to the unconfirmed pool after validation
     pub async fn process_sync(&self) -> Result<(), MempoolError> {
-        self.with_write_access(move |storage| storage.process_sync())
-            .await
+        self.with_write_access(move |storage| storage.process_sync()).await
     }
 
     /// Returns all unconfirmed transaction stored in the Mempool, except the transactions stored in the ReOrgPool.

--- a/base_layer/core/src/mempool/mempool.rs
+++ b/base_layer/core/src/mempool/mempool.rs
@@ -101,6 +101,17 @@ impl Mempool {
             .await
     }
 
+    /// In the event of a Rewind for a block sync, all transactions to the orphan pool
+    pub async fn process_rewind(&self, removed_blocks: Vec<Arc<Block>>) -> Result<(), MempoolError> {
+        self.with_write_access(move |storage| storage.process_rewind(&removed_blocks))
+            .await
+    }
+
+    /// After a sync event, we can move all orphan transactions to the unconfirmed pool after validation
+    pub async fn process_sync(&self) -> Result<(), MempoolError> {
+        self.with_write_access(move |storage| storage.process_sync()).await
+    }
+
     /// Returns all unconfirmed transaction stored in the Mempool, except the transactions stored in the ReOrgPool.
     pub async fn snapshot(&self) -> Result<Vec<Arc<Transaction>>, MempoolError> {
         self.with_read_access(|storage| Ok(storage.snapshot())).await

--- a/base_layer/core/src/mempool/mempool.rs
+++ b/base_layer/core/src/mempool/mempool.rs
@@ -102,8 +102,8 @@ impl Mempool {
     }
 
     /// After a sync event, we can move all orphan transactions to the unconfirmed pool after validation
-    pub async fn process_sync(&self, blocks_added: u64) -> Result<(), MempoolError> {
-        self.with_write_access(move |storage| storage.process_sync(blocks_added))
+    pub async fn process_sync(&self) -> Result<(), MempoolError> {
+        self.with_write_access(move |storage| storage.process_sync())
             .await
     }
 

--- a/base_layer/core/src/mempool/mempool.rs
+++ b/base_layer/core/src/mempool/mempool.rs
@@ -101,15 +101,10 @@ impl Mempool {
             .await
     }
 
-    /// In the event of a Rewind for a block sync, all transactions to the orphan pool
-    pub async fn process_rewind(&self, removed_blocks: Vec<Arc<Block>>) -> Result<(), MempoolError> {
-        self.with_write_access(move |storage| storage.process_rewind(&removed_blocks))
-            .await
-    }
-
     /// After a sync event, we can move all orphan transactions to the unconfirmed pool after validation
-    pub async fn process_sync(&self) -> Result<(), MempoolError> {
-        self.with_write_access(move |storage| storage.process_sync()).await
+    pub async fn process_sync(&self, blocks_added: u64) -> Result<(), MempoolError> {
+        self.with_write_access(move |storage| storage.process_sync(blocks_added))
+            .await
     }
 
     /// Returns all unconfirmed transaction stored in the Mempool, except the transactions stored in the ReOrgPool.

--- a/base_layer/core/src/mempool/mempool_storage.rs
+++ b/base_layer/core/src/mempool/mempool_storage.rs
@@ -191,14 +191,13 @@ impl MempoolStorage {
         // validation. This is important as invalid transactions that have not been mined yet may remain in the mempool
         // after a reorg.
         let removed_txs = self.unconfirmed_pool.drain_all_mempool_transactions();
-        // this returns all orphaned transaction, but because we know the new blocks are already added, they will still
-        // be orphaned, we can drop them here
-        let _ = self.insert_txs(removed_txs);
+        // Try to add in all the transactions again.
+        self.insert_txs(removed_txs);
         // Remove re-orged transactions from reorg  pool and re-submit them to the unconfirmed mempool
         let removed_txs = self
             .reorg_pool
             .remove_reorged_txs_and_discard_double_spends(removed_blocks, new_blocks);
-        let _ = self.insert_txs(removed_txs);
+        self.insert_txs(removed_txs);
         Ok(())
     }
 
@@ -210,7 +209,7 @@ impl MempoolStorage {
         let txs = self.unconfirmed_pool.drain_all_mempool_transactions();
         // lets add them all back into the mempool
         self.insert_txs(txs);
-        //let retrieve all re-org pool transactions as well as make sure they are mined as well
+        // let retrieve all re-org pool transactions as well as make sure they are mined as well
         let txs = self.reorg_pool.clear_and_retrieve_all();
         self.insert_txs(txs);
         Ok(())

--- a/base_layer/core/src/mempool/mempool_storage.rs
+++ b/base_layer/core/src/mempool/mempool_storage.rs
@@ -203,7 +203,7 @@ impl MempoolStorage {
     }
 
     /// After a sync event, we need to try to add in all the transaction form the reorg pool.
-    pub fn process_sync(&mut self, blocks_added: u64) -> Result<(), MempoolError> {
+    pub fn process_sync(&mut self) -> Result<(), MempoolError> {
         debug!(target: LOG_TARGET, "Mempool processing sync finished");
         // lets remove and revalidate all transactions from the mempool. All we know is that the state has changed, but
         // we dont have the data to know what.

--- a/base_layer/core/src/mempool/reorg_pool/reorg_pool.rs
+++ b/base_layer/core/src/mempool/reorg_pool/reorg_pool.rs
@@ -130,6 +130,17 @@ impl ReorgPool {
         }
     }
 
+    /// This will clear the reorg pool and return all transactions contained within
+    pub fn clear_and_retrieve_all(&mut self) -> Vec<Arc<Transaction>> {
+        let mut result = Vec::new();
+        for (_, tx) in self.tx_by_key.drain() {
+            result.push(tx);
+        }
+        self.txs_by_signature.clear();
+        self.txs_by_height.clear();
+        result
+    }
+
     pub fn retrieve_by_excess_sigs(&self, excess_sigs: &[PrivateKey]) -> (Vec<Arc<Transaction>>, Vec<PrivateKey>) {
         // Hashset used to prevent duplicates
         let mut found = HashSet::new();

--- a/base_layer/core/src/mempool/service/inbound_handlers.rs
+++ b/base_layer/core/src/mempool/service/inbound_handlers.rs
@@ -175,11 +175,11 @@ impl MempoolInboundHandlers {
             ValidBlockAdded(_, _) => {},
             BlockSyncRewind(removed_blocks) => {
                 self.mempool
-                    .process_reorg(removed_blocks.iter().map(|b| b.to_arc_block()).collect(), vec![])
+                    .process_rewind(removed_blocks.iter().map(|b| b.to_arc_block()).collect())
                     .await?;
             },
-            BlockSyncComplete(tip_block) => {
-                self.mempool.process_published_block(tip_block.to_arc_block()).await?;
+            BlockSyncComplete() => {
+                self.mempool.process_sync().await?;
             },
             AddBlockValidationFailed {
                 block: failed_block,

--- a/base_layer/core/src/mempool/service/inbound_handlers.rs
+++ b/base_layer/core/src/mempool/service/inbound_handlers.rs
@@ -173,13 +173,10 @@ impl MempoolInboundHandlers {
                     .await?;
             },
             ValidBlockAdded(_, _) => {},
-            BlockSyncRewind(removed_blocks) => {
-                self.mempool
-                    .process_rewind(removed_blocks.iter().map(|b| b.to_arc_block()).collect())
-                    .await?;
-            },
-            BlockSyncComplete() => {
-                self.mempool.process_sync().await?;
+            BlockSyncRewind(_) => {},
+            BlockSyncComplete(tip_block, starting_sync_height) => {
+                let height_diff = tip_block.height() - starting_sync_height;
+                self.mempool.process_sync(height_diff).await?;
             },
             AddBlockValidationFailed {
                 block: failed_block,

--- a/base_layer/core/src/mempool/service/inbound_handlers.rs
+++ b/base_layer/core/src/mempool/service/inbound_handlers.rs
@@ -174,9 +174,8 @@ impl MempoolInboundHandlers {
             },
             ValidBlockAdded(_, _) => {},
             BlockSyncRewind(_) => {},
-            BlockSyncComplete(tip_block, starting_sync_height) => {
-                let height_diff = tip_block.height() - starting_sync_height;
-                self.mempool.process_sync(height_diff).await?;
+            BlockSyncComplete(_,_) => {
+                self.mempool.process_sync().await?;
             },
             AddBlockValidationFailed {
                 block: failed_block,

--- a/base_layer/core/src/mempool/service/inbound_handlers.rs
+++ b/base_layer/core/src/mempool/service/inbound_handlers.rs
@@ -174,7 +174,7 @@ impl MempoolInboundHandlers {
             },
             ValidBlockAdded(_, _) => {},
             BlockSyncRewind(_) => {},
-            BlockSyncComplete(_,_) => {
+            BlockSyncComplete(_, _) => {
                 self.mempool.process_sync().await?;
             },
             AddBlockValidationFailed {

--- a/base_layer/core/src/mempool/unconfirmed_pool/unconfirmed_pool.rs
+++ b/base_layer/core/src/mempool/unconfirmed_pool/unconfirmed_pool.rs
@@ -475,21 +475,6 @@ impl UnconfirmedPool {
         Some(prioritized_transaction.transaction)
     }
 
-    /// Remove all unconfirmed transactions that have become time locked. This can happen when the chain height was
-    /// reduced on some reorgs.
-    pub fn remove_timelocked(&mut self, tip_height: u64) {
-        debug!(target: LOG_TARGET, "Removing time-locked inputs from unconfirmed pool");
-        let to_remove = self
-            .tx_by_key
-            .iter()
-            .filter(|(_, ptx)| ptx.transaction.min_spendable_height() > tip_height + 1)
-            .map(|(k, _)| *k)
-            .collect::<Vec<_>>();
-        for tx_key in to_remove {
-            self.remove_transaction(tx_key);
-        }
-    }
-
     /// Returns the total number of unconfirmed transactions stored in the UnconfirmedPool.
     pub fn len(&self) -> usize {
         self.txs_by_signature.len()

--- a/integration_tests/features/Mempool.feature
+++ b/integration_tests/features/Mempool.feature
@@ -88,7 +88,6 @@ Feature: Mempool
     Then SENDER has TX1 in NOT_STORED state
     Then SENDER has TX2 in MINED state
 
-  @flaky
   Scenario: Mempool clearing out invalid transactions after a reorg
     Given I have a seed node SEED_A
     And I have a base node NODE_A connected to seed SEED_A


### PR DESCRIPTION
Description
---
This PR updates the handling reorgs and syncs in the mempool. 

The reorg code is updated to remove unnecessary checks when handling reorgs.

The sync code is completely redone to now only listen for a sync completed status. As of now the mempool ignores the rewind event as the mempool knows this is not the final state, either the base node will forward to a new tip or reset itself to the old tip. The base node upon receiving sync completed event will re-evaluate all transactions inside of it and reset it state to the correct state. 

There will be a followup pr to add mempool sync