### PR TITLE
feat: improve bn command mode timeouts

### DIFF
--- a/applications/tari_base_node/src/commands/command/mod.rs
+++ b/applications/tari_base_node/src/commands/command/mod.rs
@@ -222,14 +222,13 @@ impl CommandContext {
                 Command::HeaderStats(_) |
                 Command::SearchUtxo(_) |
                 Command::SearchKernel(_) |
-                Command::Quit(_) |
-                Command::Exit(_) => 30,
-                // Depending on the state and busyness of the mempool, these commands can take a fairly long time
-                Command::Status(_) |
-                Command::Watch(_) |
                 Command::GetMempoolStats(_) |
                 Command::GetMempoolState(_) |
-                Command::GetMempoolTx(_) => 180,
+                Command::GetMempoolTx(_) |
+                Command::Status(_) |
+                Command::Watch(_) |
+                Command::Quit(_) |
+                Command::Exit(_) => 30,
                 // These commands involve intense blockchain db operations and needs a lot of time to complete
                 Command::CheckDb(_) | Command::PeriodStats(_) | Command::RewindBlockchain(_) => 600,
             };

--- a/applications/tari_base_node/src/commands/command/mod.rs
+++ b/applications/tari_base_node/src/commands/command/mod.rs
@@ -193,8 +193,50 @@ impl CommandContext {
         if let Command::Watch(command) = args.command {
             Ok(Some(command))
         } else {
+            let time_out = match args.command {
+                // These commands should complete quickly, some of them like 'discover-peer' returns immediately
+                // although the requested action can take a long time
+                Command::Version(_) |
+                Command::Whoami(_) |
+                Command::CheckForUpdates(_) |
+                Command::AddPeer(_) |
+                Command::BanPeer(_) |
+                Command::UnbanAllPeers(_) |
+                Command::UnbanPeer(_) |
+                Command::GetPeer(_) |
+                Command::ResetOfflinePeers(_) |
+                Command::DialPeer(_) |
+                Command::PingPeer(_) |
+                Command::DiscoverPeer(_) |
+                Command::ListPeers(_) |
+                Command::ListBannedPeers(_) |
+                Command::ListConnections(_) |
+                Command::GetNetworkStats(_) |
+                Command::BlockTiming(_) |
+                Command::GetChainMetadata(_) |
+                Command::GetDbStats(_) |
+                Command::GetStateInfo(_) |
+                Command::ListReorgs(_) |
+                Command::GetBlock(_) |
+                Command::ListHeaders(_) |
+                Command::HeaderStats(_) |
+                Command::SearchUtxo(_) |
+                Command::SearchKernel(_) |
+                Command::Quit(_) |
+                Command::Exit(_) => 30,
+                // Depending on the state and busyness of the mempool, these commands can take a fairly long time
+                Command::Status(_) |
+                Command::Watch(_) |
+                Command::GetMempoolStats(_) |
+                Command::GetMempoolState(_) |
+                Command::GetMempoolTx(_) => 180,
+                // These commands involve intense blockchain db operations and needs a lot of time to complete
+                Command::CheckDb(_) | Command::PeriodStats(_) | Command::RewindBlockchain(_) => 600,
+            };
             let fut = self.handle_command(args.command);
-            time::timeout(Duration::from_secs(70), fut).await??;
+            if let Err(e) = time::timeout(Duration::from_secs(time_out), fut).await? {
+                return Err(Error::msg(format!("{} ({} s)", e, time_out)));
+            };
             Ok(None)
         }
     }

--- a/applications/tari_base_node/src/commands/command/status.rs
+++ b/applications/tari_base_node/src/commands/command/status.rs
@@ -85,7 +85,7 @@ impl CommandContext {
             .consensus_constants(metadata.height_of_longest_chain());
         // TODO: This code enables a status line display even if the mempool stats times out
         let fut = self.mempool_service.get_mempool_stats();
-        if let Ok(mempool_stats) = time::timeout(Duration::from_secs(15), fut).await? {
+        if let Ok(mempool_stats) = time::timeout(Duration::from_secs(5), fut).await? {
             status_line.add_field(
                 "Mempool",
                 format!(

--- a/applications/tari_base_node/src/commands/command/status.rs
+++ b/applications/tari_base_node/src/commands/command/status.rs
@@ -28,6 +28,7 @@ use chrono::{DateTime, NaiveDateTime, Utc};
 use clap::Parser;
 use tari_app_utilities::consts;
 use tari_comms::connectivity::ConnectivitySelection;
+use tokio::time;
 
 use super::{CommandContext, HandleCommand};
 use crate::commands::status_line::{StatusLine, StatusLineOutput};
@@ -82,20 +83,25 @@ impl CommandContext {
         let constants = self
             .consensus_rules
             .consensus_constants(metadata.height_of_longest_chain());
-        let mempool_stats = self.mempool_service.get_mempool_stats().await?;
-        status_line.add_field(
-            "Mempool",
-            format!(
-                "{}tx ({}g, +/- {}blks)",
-                mempool_stats.unconfirmed_txs,
-                mempool_stats.unconfirmed_weight,
-                if mempool_stats.unconfirmed_weight == 0 {
-                    0
-                } else {
-                    1 + mempool_stats.unconfirmed_weight / constants.get_max_block_transaction_weight()
-                },
-            ),
-        );
+        // TODO: This code enables a status line display even if the mempool stats times out
+        let fut = self.mempool_service.get_mempool_stats();
+        if let Ok(mempool_stats) = time::timeout(Duration::from_secs(15), fut).await? {
+            status_line.add_field(
+                "Mempool",
+                format!(
+                    "{}tx ({}g, +/- {}blks)",
+                    mempool_stats.unconfirmed_txs,
+                    mempool_stats.unconfirmed_weight,
+                    if mempool_stats.unconfirmed_weight == 0 {
+                        0
+                    } else {
+                        1 + mempool_stats.unconfirmed_weight / constants.get_max_block_transaction_weight()
+                    },
+                ),
+            );
+        } else {
+            status_line.add_field("Mempool", "query timed out");
+        };
 
         let conns = self
             .connectivity


### PR DESCRIPTION
Description
---
Assigned a base node command mode time-out based on the typical time it will take to return back to the command line for specific commands.

Motivation and Context
---
Differentiation in the time-out is needed for the various commands, for example, `check-db` and `rewind-blockchain` need a lot more time to complete than `version` or `whoami`. The specific case encountered was that the previous blanket allowed time-out of `70s` was not sufficient to perform `check-db`  or `get-mempool-stats` for a busy (stressed) block chain and mempool.

How Has This Been Tested?
---
System-level testing.

