### PR TITLE
fix: add a macos dependency to compile libtor

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ First you'll need to make sure you have a full development environment set up:
 
 ```
 brew update
-brew install cmake openssl tor coreutils
+brew install cmake openssl tor coreutils automake
 brew install --cask powershell
 ```
 


### PR DESCRIPTION
Description
---

The current instructions to "Building from source" on macOS is breaking if you didn't have already installed the `automake` package.


Part of the `cargo build --release` logs:
```sh
cargo:include=/Users/willyrgf/development/rust/src/github.com/willyrgf/tari/target/release/build/libtor-sys-6d75ded0116fce22/out/libevent/include
  cargo:lib=/Users/willyrgf/development/rust/src/github.com/willyrgf/tari/target/release/build/libtor-sys-6d75ded0116fce22/out/libevent/lib
  OPT_LEVEL = Some("3")
  CC_x86_64-apple-darwin = None
  CC_x86_64_apple_darwin = None
  HOST_CC = None
  CC = None
  CFLAGS_x86_64-apple-darwin = None
  CFLAGS_x86_64_apple_darwin = None
  HOST_CFLAGS = None
  CFLAGS = None
  CRATE_CC_NO_DEFAULTS = None
  DEBUG = Some("false")
  CARGO_CFG_TARGET_FEATURE = Some("cmpxchg16b,fxsr,llvm14-builtins-abi,sse,sse2,sse3,ssse3")
  cargo:warning=Failed to run `autoreconf`: Ok("Can't exec \"aclocal\": No such file or directory at /usr/local/Cellar/autoconf/2.71/share/autoconf/Autom4te/FileUtils.pm line 274.\nautoreconf: error: aclocal failed with exit status: 2\n")
  cargo:rustc-link-search=native=/Users/willyrgf/development/rust/src/github.com/willyrgf/tari/target/release/build/libz-sys-95a1e0c1156d6a5e/out/lib
  running: "sh" "-c" "exec \"$0\" \"$@\"" "/Users/willyrgf/development/rust/src/github.com/willyrgf/tari/target/release/build/libtor-sys-6d75ded0116fce22/out/tor-src/configure" "--prefix=/Users/willyrgf/development/rust/src/github.com/willyrgf/tari/target/release/build/libtor-sys-6d75ded0116fce22/out" "--disable-shared" "--enable-static" "--host=x86_64-apple-darwin" "--with-libevent-dir=/Users/willyrgf/development/rust/src/github.com/willyrgf/tari/target/release/build/libtor-sys-6d75ded0116fce22/out/libevent" "--enable-pic" "--enable-static-libevent" "--enable-static-zlib" "--disable-system-torrc" "--disable-asciidoc" "--disable-systemd" "--disable-largefile" "--disable-unittests" "--disable-tool-name-check" "--disable-manpage" "--disable-html-manual" "--disable-module-dirauth" "--disable-module-relay" "--disable-module-dircache" "--disable-seccomp" "--disable-libscrypt" "--disable-rust" "--disable-lzma" "--disable-zstd" "--with-openssl-dir=/Users/willyrgf/development/rust/src/github.com/willyrgf/tari/target/release/build/openssl-sys-cdb931563d1b5beb/out/openssl-build/install" "--enable-static-openssl" "--with-zlib-dir=/Users/willyrgf/development/rust/src/github.com/willyrgf/tari/target/release/build/libz-sys-95a1e0c1156d6a5e/out/lib"

  --- stderr
  /Users/willyrgf/development/rust/src/github.com/willyrgf/tari/target/release/build/libtor-sys-6d75ded0116fce22/out/tor-src/configure: /Users/willyrgf/development/rust/src/github.com/willyrgf/tari/target/release/build/libtor-sys-6d75ded0116fce22/out/tor-src/configure: No such file or directory
  /Users/willyrgf/development/rust/src/github.com/willyrgf/tari/target/release/build/libtor-sys-6d75ded0116fce22/out/tor-src/configure: line 0: exec: /Users/willyrgf/development/rust/src/github.com/willyrgf/tari/target/release/build/libtor-sys-6d75ded0116fce22/out/tor-src/configure: cannot execute: No such file or directory
  thread 'main' panicked at '
  command did not execute successfully, got: exit status: 126
```
```
cargo:include=/Users/willyrgf/development/rust/src/github.com/tari-project/tari/target/release/build/libtor-sys-6d75ded0116fce22/out/libevent/include
  cargo:lib=/Users/willyrgf/development/rust/src/github.com/tari-project/tari/target/release/build/libtor-sys-6d75ded0116fce22/out/libevent/lib
  OPT_LEVEL = Some("3")
  CC_x86_64-apple-darwin = None
  CC_x86_64_apple_darwin = None
  HOST_CC = None
  CC = None
  CFLAGS_x86_64-apple-darwin = None
  CFLAGS_x86_64_apple_darwin = None
  HOST_CFLAGS = None
  CFLAGS = None
  CRATE_CC_NO_DEFAULTS = None
  DEBUG = Some("false")
  CARGO_CFG_TARGET_FEATURE = Some("cmpxchg16b,fxsr,llvm14-builtins-abi,sse,sse2,sse3,ssse3")
  cargo:warning=Failed to run `autoreconf`: Ok("Os { code: 2, kind: NotFound, message: \"No such file or directory\" }")
  cargo:rustc-link-search=native=/Users/willyrgf/development/rust/src/github.com/tari-project/tari/target/release/build/libz-sys-95a1e0c1156d6a5e/out/lib
  running: "sh" "-c" "exec \"$0\" \"$@\"" "/Users/willyrgf/development/rust/src/github.com/tari-project/tari/target/release/build/libtor-sys-6d75ded0116fce22/out/tor-src/configure" "--prefix=/Users/willyrgf/development/rust/src/github.com/tari-project/tari/target/release/build/libtor-sys-6d75ded0116fce22/out" "--disable-shared" "--enable-static" "--host=x86_64-apple-darwin" "--with-libevent-dir=/Users/willyrgf/development/rust/src/github.com/tari-project/tari/target/release/build/libtor-sys-6d75ded0116fce22/out/libevent" "--enable-pic" "--enable-static-libevent" "--enable-static-zlib" "--disable-system-torrc" "--disable-asciidoc" "--disable-systemd" "--disable-largefile" "--disable-unittests" "--disable-tool-name-check" "--disable-manpage" "--disable-html-manual" "--disable-module-dirauth" "--disable-module-relay" "--disable-module-dircache" "--disable-seccomp" "--disable-libscrypt" "--disable-rust" "--disable-lzma" "--disable-zstd" "--with-openssl-dir=/Users/willyrgf/development/rust/src/github.com/tari-project/tari/target/release/build/openssl-sys-cdb931563d1b5beb/out/openssl-build/install" "--enable-static-openssl" "--with-zlib-dir=/Users/willyrgf/development/rust/src/github.com/tari-project/tari/target/release/build/libz-sys-95a1e0c1156d6a5e/out/lib"

  --- stderr
  /Users/willyrgf/development/rust/src/github.com/tari-project/tari/target/release/build/libtor-sys-6d75ded0116fce22/out/tor-src/configure: /Users/willyrgf/development/rust/src/github.com/tari-project/tari/target/release/build/libtor-sys-6d75ded0116fce22/out/tor-src/configure: No such file or directory
  /Users/willyrgf/development/rust/src/github.com/tari-project/tari/target/release/build/libtor-sys-6d75ded0116fce22/out/tor-src/configure: line 0: exec: /Users/willyrgf/development/rust/src/github.com/tari-project/tari/target/release/build/libtor-sys-6d75ded0116fce22/out/tor-src/configure: cannot execute: No such file or directory
  thread 'main' panicked at '
  command did not execute successfully, got: exit status: 126
  ```


How Has This Been Tested?
---
After install `automake`, recompile the binary using `cargo build --release` with success.

