### PR TITLE
ci: run coverage on prs

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -7,6 +7,11 @@ on:
     branches:
       - development
       - ci-coverage-*
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
 
 env:
   toolchain: nightly-2022-05-01


### PR DESCRIPTION
Description
---
Run coverage on all PRs

Motivation and Context
---
Currently, this is only run after merge. This is often missed. With fewer PRs, and a more stable code base, I think we can run it on every PR

How Has This Been Tested?
---
Since this is CI related, I'll be using the PR itself to test

