### PR TITLE
fix: cli wallet cucumber

### DIFF
--- a/integration_tests/features/WalletCli.feature
+++ b/integration_tests/features/WalletCli.feature
@@ -66,8 +66,7 @@ Feature: Wallet CLI
         When I create a burn transaction of 201552500000 uT from WALLET via command line
         When I mine 5 blocks on BASE
         Then all nodes are at height 20
-        # Then I wait for wallet WALLET to have at least 100 uT
-        Then I get balance of wallet WALLET is at most 18462621580 uT via command line
+        Then I get balance of wallet WALLET is at least 20000000000 uT via command line
         # TODO: verify the actual burned kernel
         
     @long-running

--- a/integration_tests/features/WalletTransactions.feature
+++ b/integration_tests/features/WalletTransactions.feature
@@ -405,11 +405,15 @@ Feature: Wallet Transactions
    Given I have a seed node NODE
    And I have 2 base nodes connected to all seed nodes
    And I have wallet WALLET_A connected to all seed nodes
-   And I have mining node MINER connected to base node NODE and wallet WALLET_A
-   When mining node MINER mines 15 blocks
+   And I have wallet WALLET_B connected to all seed nodes
+   And I have mining node MINER_A connected to base node NODE and wallet WALLET_A
+   And I have mining node MINER_B connected to base node NODE and wallet WALLET_B
+   When mining node MINER_A mines 12 blocks
+   When mining node MINER_B mines 3 blocks
    Then all nodes are at height 15
-   When I wait for wallet WALLET_A to have at least 55000000000 uT
-   When I create a burn transaction of 1000000 uT from WALLET_A at fee 100
-   When mining node MINER mines 10 blocks
-   Then all nodes are at height 25
+   When I wait for wallet WALLET_A to have at least 221552530060 uT
+   When I create a burn transaction of 201552500000 uT from WALLET_A at fee 100
+   When mining node MINER_B mines 5 blocks
+   Then all nodes are at height 20
    Then wallet WALLET_A detects all transactions as Mined_Confirmed
+   When I wait for wallet WALLET_A to have at least 20000000000 uT

--- a/integration_tests/helpers/walletProcess.js
+++ b/integration_tests/helpers/walletProcess.js
@@ -285,6 +285,7 @@ class WalletProcess {
       "--non-interactive",
       "--network",
       "localnet",
+      "--enable-grpc",
     ];
     if (this.logFilePath) {
       args.push("--log-config", this.logFilePath);


### PR DESCRIPTION
Description
---
Fix the burn cli cucumber.
The command run for wallet didn't start with grpc. And the wallet in non-interactive mode without grpc will not start. So it was not in sync with the base node.
Modify the standard cucumber burn test to do the same as the cli test.

How Has This Been Tested?
---
npm test -- --name "As a user I want to burn tari via command line"
