### PR TITLE
feat: different default grpc ports for different networks

### DIFF
--- a/applications/tari_base_node/src/config.rs
+++ b/applications/tari_base_node/src/config.rs
@@ -144,7 +144,7 @@ impl Default for BaseNodeConfig {
         Self {
             override_from: None,
             network: Network::default(),
-            grpc_address: Some("/ip4/127.0.0.1/tcp/18142".parse().unwrap()),
+            grpc_address: None,
             identity_file: PathBuf::from("config/base_node_id.json"),
             use_libtor: false,
             tor_identity_file: PathBuf::from("config/base_node_tor_id.json"),

--- a/applications/tari_base_node/src/config.rs
+++ b/applications/tari_base_node/src/config.rs
@@ -83,6 +83,8 @@ pub struct BaseNodeConfig {
     override_from: Option<String>,
     /// Selected network
     pub network: Network,
+    /// Enable the base node GRPC server
+    pub grpc_enabled: bool,
     /// GRPC address of base node
     pub grpc_address: Option<Multiaddr>,
     /// A path to the file that stores the base node identity and secret key
@@ -144,6 +146,7 @@ impl Default for BaseNodeConfig {
         Self {
             override_from: None,
             network: Network::default(),
+            grpc_enabled: true,
             grpc_address: None,
             identity_file: PathBuf::from("config/base_node_id.json"),
             use_libtor: false,

--- a/applications/tari_base_node/src/main.rs
+++ b/applications/tari_base_node/src/main.rs
@@ -94,7 +94,10 @@ use log::*;
 use opentelemetry::{self, global, KeyValue};
 use tari_app_utilities::{consts, identity_management::setup_node_identity, utilities::setup_runtime};
 use tari_common::{
-    configuration::{bootstrap::ApplicationType, Network},
+    configuration::{
+        bootstrap::{grpc_default_port, ApplicationType},
+        Network,
+    },
     exit_codes::{ExitCode, ExitError},
     initialize_logging,
     load_configuration,
@@ -229,11 +232,13 @@ async fn run_node(
     // Build, node, build!
     let ctx = builder::configure_and_initialize_node(config.clone(), node_identity, shutdown.to_signal()).await?;
 
-    if let Some(address) = config.base_node.grpc_address.clone() {
-        // Go, GRPC, go go
-        let grpc = crate::grpc::base_node_grpc_server::BaseNodeGrpcServer::from_base_node_context(&ctx);
-        task::spawn(run_grpc(grpc, address, shutdown.to_signal()));
-    }
+    let grpc_address = config.base_node.grpc_address.clone().unwrap_or_else(|| {
+        let port = grpc_default_port(ApplicationType::BaseNode, config.base_node.network);
+        format!("/ip4/127.0.0.1/tcp/{}", port).parse().unwrap()
+    });
+    // Go, GRPC, go go
+    let grpc = grpc::base_node_grpc_server::BaseNodeGrpcServer::from_base_node_context(&ctx);
+    task::spawn(run_grpc(grpc, grpc_address, shutdown.to_signal()));
 
     // Run, node, run!
     let context = CommandContext::new(&ctx, shutdown);
@@ -288,7 +293,7 @@ fn enable_tracing() {
 
 /// Runs the gRPC server
 async fn run_grpc(
-    grpc: crate::grpc::base_node_grpc_server::BaseNodeGrpcServer,
+    grpc: grpc::base_node_grpc_server::BaseNodeGrpcServer,
     grpc_address: Multiaddr,
     interrupt_signal: ShutdownSignal,
 ) -> Result<(), anyhow::Error> {

--- a/base_layer/wallet/src/config.rs
+++ b/base_layer/wallet/src/config.rs
@@ -99,7 +99,7 @@ pub struct WalletConfig {
     /// If true, a GRPC server will bind to the configured address and listen for incoming GRPC requests.
     pub grpc_enabled: bool,
     /// GRPC bind address of the wallet
-    pub grpc_address: Multiaddr,
+    pub grpc_address: Option<Multiaddr>,
     /// GRPC authentication mode
     pub grpc_authentication: GrpcAuthentication,
     /// A custom base node peer that will be used to obtain metadata from
@@ -144,7 +144,7 @@ impl Default for WalletConfig {
             command_send_wait_timeout: Duration::from_secs(300),
             notify_file: None,
             grpc_enabled: false,
-            grpc_address: "/ip4/127.0.0.1/tcp/18143".parse().unwrap(),
+            grpc_address: None,
             grpc_authentication: GrpcAuthentication::default(),
             custom_base_node: None,
             base_node_service_peers: StringList::default(),

--- a/common/config/presets/c_base_node.toml
+++ b/common/config/presets/c_base_node.toml
@@ -17,15 +17,19 @@ identity_file = "config/base_node_id_dibbler.json"
 # A path to the file that stores your node identity and secret key (default = "config/base_node_id.json")
 identity_file = "config/base_node_id_igor.json"
 
+# The socket to expose for the gRPC base node server (default = "/ip4/127.0.0.1/tcp/18152")
+#grpc_address = "/ip4/127.0.0.1/tcp/18152"
+
 [esmeralda.base_node]
 # A path to the file that stores your node identity and secret key (default = "config/base_node_id.json")
 identity_file = "config/base_node_id_esmeralda.json"
 
+# The socket to expose for the gRPC base node server (default = "/ip4/127.0.0.1/tcp/18142")
+#grpc_address = "/ip4/127.0.0.1/tcp/18142"
+
 [base_node]
 # Selected network (Note: Not implemented properly, please specify on the command line) (default = "emseralda")
 #network = "emseralda"
-# The socket to expose for the gRPC base node server (default = "/ip4/127.0.0.1/tcp/18142")
-#grpc_address = "/ip4/127.0.0.1/tcp/18142"
 
 # A path to the file that stores your node identity and secret key (default = "config/base_node_id.json")
 #identity_file = "config/base_node_id.json"

--- a/common/config/presets/c_base_node.toml
+++ b/common/config/presets/c_base_node.toml
@@ -31,6 +31,9 @@ identity_file = "config/base_node_id_esmeralda.json"
 # Selected network (Note: Not implemented properly, please specify on the command line) (default = "emseralda")
 #network = "emseralda"
 
+# Set to false to disable the base node GRPC server (default = true)
+#grpc_enabled = true
+
 # A path to the file that stores your node identity and secret key (default = "config/base_node_id.json")
 #identity_file = "config/base_node_id.json"
 

--- a/common/src/configuration/bootstrap.rs
+++ b/common/src/configuration/bootstrap.rs
@@ -10,6 +10,7 @@ use std::{
 };
 
 use super::error::ConfigError;
+use crate::configuration::Network;
 
 pub fn prompt(question: &str) -> bool {
     println!("{}", question);
@@ -94,6 +95,29 @@ impl Display for ApplicationType {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.as_str())?;
         Ok(())
+    }
+}
+
+/// Gets the default grpc port for the given application and network
+pub fn grpc_default_port(app_type: ApplicationType, network: Network) -> u16 {
+    match app_type {
+        ApplicationType::BaseNode => match network {
+            Network::MainNet => 18102u16,
+            Network::Weatherwax => 18112,
+            Network::Dibbler => 18122,
+            Network::Esmeralda => 18142,
+            Network::Igor => 18152,
+            _ => unreachable!("Network {} not supported", network),
+        },
+        ApplicationType::ConsoleWallet => match network {
+            Network::MainNet => 18103u16,
+            Network::Weatherwax => 18113,
+            Network::Dibbler => 18123,
+            Network::Esmeralda => 18143,
+            Network::Igor => 18153,
+            _ => unreachable!("Network {} not supported", network),
+        },
+        _ => unreachable!("Application {} not supported", app_type),
     }
 }
 


### PR DESCRIPTION
Description
---
Use different _default_ GRPC ports for different networks

- BaseNode
    - Dibbler: 18122
    - Esmeralda: 18142
    - Igor: 18152
- ConsoleWallet
    - Dibbler: 18123
    - Esmeralda: 18143
    - Igor: 18153
    
Motivation and Context
---
More explicit separation of networks allowing GRPC to work when running two different networks on the same machine.

How Has This Been Tested?
---
Manually
