### PR TITLE
fix(comms): fixes edge case where online status event does not get published

### DIFF
--- a/comms/core/src/connectivity/manager.rs
+++ b/comms/core/src/connectivity/manager.rs
@@ -758,6 +758,8 @@ impl ConnectivityManagerActor {
             n if n == 0 => {
                 if num_connected_clients == 0 {
                     self.transition(ConnectivityStatus::Offline, min_peers);
+                } else {
+                    self.transition(ConnectivityStatus::Degraded(n), min_peers);
                 }
             },
             _ => unreachable!("num_connected is unsigned and only negative pattern covered on this branch"),


### PR DESCRIPTION
Description
---
Ensures that connectivity status events are always published if a status change has occurred.

Motivation and Context
---
An online/degraded event should be emitted if any connections are present, including if only connected to walllets.
Some edge cases where connectivity status event was not emitted. These events are typically only used for logging and tests, but could be used in an application to wait for conenctivity to become available.

How Has This Been Tested?
---
Added to existing unit test, manually with DAN node
