### PR TITLE
fix(ci): add cargo cache, reduce Ubuntu dependencies and action on pull_request

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,8 +1,9 @@
 ---
 name: Source Coverage
 
-on:
+'on':
   workflow_dispatch:
+  pull_request:
   push:
     branches:
       - development
@@ -13,53 +14,38 @@ env:
 
 jobs:
   coverage:
-    name: test and generate cov
+    name: test and generate coverage
     runs-on: [ self-hosted, ubuntu18.04-high-mem ]
     steps:
+      - name: checkout source code
+        uses: actions/checkout@v3
+
       - name: ubuntu dependencies
         run: |
-          sudo apt-get update && \
-          sudo apt-get -y install \
-            openssl \
-            libssl-dev \
-            pkg-config \
-            libsqlite3-dev \
-            clang-10 \
-            git \
-            cmake \
-            libc++-dev \
-            libc++abi-dev \
-            libprotobuf-dev \
-            protobuf-compiler \
-            libncurses5-dev \
-            libncursesw5-dev \
-            zip \
-            build-essential \
-            libgtk-3-dev \
-            libwebkit2gtk-4.0-dev \
-            libsoup2.4-dev \
-            curl \
-            wget \
-            libappindicator3-dev \
-            patchelf \
-            librsvg2-dev
-      - name: checkout
-        uses: actions/checkout@v2
+          sudo apt-get update
+          sudo bash scripts/install_ubuntu_dependencies.sh
+
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
           override: true
           components: llvm-tools-preview
-      - uses: actions-rs/cargo@v1
+
+      - name: cache cargo files and outputs
+        uses: Swatinem/rust-cache@v2
         with:
-          command: test
-          args: --all-features --no-fail-fast
+          cache-on-failure: true
+
+      - uses: actions-rs/cargo@v1
         env:
           RUSTFLAGS: "-C instrument-coverage"
           RUSTDOCFLAGS: "-C instrument-coverage"
           LLVM_PROFILE_FILE: "coverage_data-%p-%m.profraw"
-      - id: coverage
-        name: Prepare coverage data
+        with:
+          command: test
+          args: --all-features --no-fail-fast
+
+      - name: prepare coverage data
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         run: |
@@ -72,13 +58,15 @@ jobs:
              --vcs-branch $GITHUB_REF_NAME \
              --service-name github \
              --service-job-id ${GITHUB_RUN_ID}
-      - id: archive-coverage
-        name: archive-coverage
+
+      - name: archive coverage data
         uses: actions/upload-artifact@v3
         with:
           path: target/coveralls_coverage.json
           name: coveralls-coverage
+
       - name: Coveralls upload
+        continue-on-error: true
         uses: toshke/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Description
add cargo cache, reduce Ubuntu dependencies and action on pull_request

Motivation and Context
Make CI faster, use the same Ubuntu dependencies and run on pull_requests

How Has This Been Tested?
Tested mostly in local fork

