### PR TITLE
Revert "ci: run coverage on prs"

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,11 +6,6 @@ name: Source Coverage
     branches:
       - development
       - ci-coverage-*
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
 
 env:
   toolchain: nightly-2022-05-01


### PR DESCRIPTION
Reverts tari-project/tari#4738

Coverage tests take a long time to run, and are more for tracking than gatekeeping, so better to keep them on the main branches only.