### PR TITLE
fix: computation of vn mmr

### DIFF
--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -1329,7 +1329,8 @@ pub fn calculate_mmr_roots<T: BlockchainBackend>(db: &T, block: &Block) -> Resul
 
     output_mmr.compress();
 
-    let validator_nodes = db.fetch_active_validator_nodes(metadata.height_of_longest_chain() + 1)?;
+    let mut validator_nodes = db.fetch_active_validator_nodes(metadata.height_of_longest_chain() + 1)?;
+    validator_nodes.sort();
     let vn_mmr = ValidatorNodeMmr::new(validator_nodes.iter().map(|vn| vn.1.to_vec()).collect());
 
     let mmr_roots = MmrRoots {


### PR DESCRIPTION
Description
---
Fix the VNs mmr. The output vector was in random order that resulted in the mmr being kind of random as well.
So the miner and base node had different order of VNs and the blocks were invalidated. More VNs = less probability of passing.

How Has This Been Tested?
---
I manually registered 27 VNs and mined 100 blocks. 
