### PR TITLE
chore: fix ffi log type

### DIFF
--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -4232,7 +4232,7 @@ pub unsafe extern "C" fn wallet_create(
         let network = CStr::from_ptr(network_str)
             .to_str()
             .expect("A non-null network should be able to be converted to string");
-        error!(target: LOG_TARGET, "network set to {}", network);
+        info!(target: LOG_TARGET, "network set to {}", network);
         // eprintln!("network set to {}", network);
         match Network::from_str(&*network) {
             Ok(n) => n,


### PR DESCRIPTION
Description
---
Fixes a startup log type to the correct type. 
When the ffi wallet starts, it prints out the selected network type, but this is currently printed as error. 

