### PR TITLE
fix: fix config.toml bug

### DIFF
--- a/common/config/presets/c_base_node.toml
+++ b/common/config/presets/c_base_node.toml
@@ -118,7 +118,7 @@ track_reorgs = true
 # The maximum number of transactions to sync in a single sync session Default: 10_000
 #service.initial_sync_max_transactions = 10_000
 # The maximum number of blocks added via sync or re-org to triggering a sync
-#block_sync_trigger = 5
+#service.block_sync_trigger = 5
 
 [base_node.state_machine]
 # The initial max sync latency. If a peer fails to stream a header/block within this deadline another sync peer will be


### PR DESCRIPTION
Description
---
The base node errored when reading the `block_sync_trigger = 5` setting
```
ExitError { exit_code: ConfigError, details: Some("Invalid value for `base_node`: unknown field `block_sync_trigger`, expected one of `override_from`, `unconfirmed_pool`, `reorg_pool`, `service`") }
```

Motivation and Context
---
Reading default config settings should not cause an error

How Has This Been Tested?
---
System level testing
