### PR TITLE
fix(p2p/liveness): remove fallible unwrap

### DIFF
--- a/base_layer/p2p/src/services/liveness/service.rs
+++ b/base_layer/p2p/src/services/liveness/service.rs
@@ -161,7 +161,7 @@ where
         match ping_pong_msg.kind().ok_or(LivenessError::InvalidPingPongType)? {
             PingPong::Ping => {
                 self.state.inc_pings_received();
-                self.send_pong(ping_pong_msg.nonce, public_key).await.unwrap();
+                self.send_pong(ping_pong_msg.nonce, public_key).await?;
                 self.state.inc_pongs_sent();
 
                 debug!(


### PR DESCRIPTION
Description
---
Removed stray unwrap in liveness service

Motivation and Context
---
Caused a base node to panic in stress test conditions.

```
thread 'tokio-runtime-worker' panicked at 'called `Result::unwrap()` on an `Err` value: DhtOutboundError(RequesterReplyChannelClosed)', base_layer\p2p\src\services\liveness\service.rs:164:71
```

How Has This Been Tested?
---
Tests pass
