### PR TITLE
fix(dht): remove some invalid saf failure cases

### DIFF
--- a/comms/core/src/protocol/rpc/server/error.rs
+++ b/comms/core/src/protocol/rpc/server/error.rs
@@ -60,8 +60,17 @@ pub enum RpcServerError {
     ServiceCallExceededDeadline,
     #[error("Stream read exceeded deadline")]
     ReadStreamExceededDeadline,
-    #[error("Early close error: {0}")]
-    EarlyCloseError(#[from] EarlyCloseError<BytesMut>),
+    #[error("Early close: {0}")]
+    EarlyClose(#[from] EarlyCloseError<BytesMut>),
+}
+
+impl RpcServerError {
+    pub fn early_close_io(&self) -> Option<&io::Error> {
+        match self {
+            Self::EarlyClose(e) => e.io(),
+            _ => None,
+        }
+    }
 }
 
 impl From<oneshot::error::RecvError> for RpcServerError {

--- a/comms/dht/src/envelope.rs
+++ b/comms/dht/src/envelope.rs
@@ -43,7 +43,7 @@ use crate::version::DhtProtocolVersion;
 pub(crate) fn datetime_to_timestamp(datetime: DateTime<Utc>) -> Timestamp {
     Timestamp {
         seconds: datetime.timestamp(),
-        nanos: datetime.timestamp_subsec_nanos().try_into().unwrap_or(std::i32::MAX),
+        nanos: datetime.timestamp_subsec_nanos().try_into().unwrap_or(i32::MAX),
     }
 }
 

--- a/comms/dht/src/store_forward/database/stored_message.rs
+++ b/comms/dht/src/store_forward/database/stored_message.rs
@@ -20,8 +20,6 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::convert::TryInto;
-
 use chrono::NaiveDateTime;
 use tari_comms::message::MessageExt;
 use tari_utilities::{hex, hex::Hex};
@@ -50,7 +48,7 @@ pub struct NewStoredMessage {
 }
 
 impl NewStoredMessage {
-    pub fn try_construct(message: DecryptedDhtMessage, priority: StoredMessagePriority) -> Option<Self> {
+    pub fn new(message: DecryptedDhtMessage, priority: StoredMessagePriority) -> Self {
         let DecryptedDhtMessage {
             authenticated_origin,
             decryption_result,
@@ -64,8 +62,8 @@ impl NewStoredMessage {
         };
         let body_hash = hex::to_hex(&dedup::create_message_hash(&dht_header.message_signature, &body));
 
-        Some(Self {
-            version: dht_header.version.as_major().try_into().ok()?,
+        Self {
+            version: dht_header.version.as_major() as i32,
             origin_pubkey: authenticated_origin.as_ref().map(|pk| pk.to_hex()),
             message_type: dht_header.message_type as i32,
             destination_pubkey: dht_header.destination.public_key().map(|pk| pk.to_hex()),
@@ -81,7 +79,7 @@ impl NewStoredMessage {
             },
             body_hash,
             body,
-        })
+        }
     }
 }
 

--- a/comms/dht/src/store_forward/error.rs
+++ b/comms/dht/src/store_forward/error.rs
@@ -27,7 +27,7 @@ use tari_comms::{
     message::MessageError,
     peer_manager::{NodeId, PeerManagerError},
 };
-use tari_utilities::byte_array::ByteArrayError;
+use tari_utilities::{byte_array::ByteArrayError, epoch_time::EpochTime};
 use thiserror::Error;
 
 use crate::{
@@ -81,10 +81,10 @@ pub enum StoreAndForwardError {
     RequesterChannelClosed,
     #[error("The request was cancelled by the store and forward service")]
     RequestCancelled,
-    #[error("The message was not valid for store and forward")]
-    InvalidStoreMessage,
-    #[error("The envelope version is invalid")]
-    InvalidEnvelopeVersion,
+    #[error("The {field} field was not valid, discarding SAF response: {details}")]
+    InvalidSafResponseMessage { field: &'static str, details: String },
+    #[error("The message has expired, not storing message in SAF db (expiry: {expired}, now: {now})")]
+    NotStoringExpiredMessage { expired: EpochTime, now: EpochTime },
     #[error("MalformedNodeId: {0}")]
     MalformedNodeId(#[from] ByteArrayError),
     #[error("DHT message type should not have been forwarded")]

--- a/comms/dht/src/store_forward/message.rs
+++ b/comms/dht/src/store_forward/message.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::convert::{TryFrom, TryInto};
+use std::convert::TryFrom;
 
 use chrono::{DateTime, Utc};
 use prost::Message;
@@ -76,10 +76,7 @@ impl TryFrom<database::StoredMessage> for StoredMessage {
         let dht_header = DhtHeader::decode(message.header.as_slice())?;
         Ok(Self {
             stored_at: Some(datetime_to_timestamp(DateTime::from_utc(message.stored_at, Utc))),
-            version: message
-                .version
-                .try_into()
-                .map_err(|_| StoreAndForwardError::InvalidEnvelopeVersion)?,
+            version: message.version as u32,
             body: message.body,
             dht_header: Some(dht_header),
         })

--- a/comms/dht/src/store_forward/store.rs
+++ b/comms/dht/src/store_forward/store.rs
@@ -437,13 +437,13 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError> + Se
         );
 
         if let Some(expires) = message.dht_header.expires {
-            if expires < EpochTime::now() {
-                return SafResult::Err(StoreAndForwardError::InvalidStoreMessage);
+            let now = EpochTime::now();
+            if expires < now {
+                return Err(StoreAndForwardError::NotStoringExpiredMessage { expired: expires, now });
             }
         }
 
-        let stored_message =
-            NewStoredMessage::try_construct(message, priority).ok_or(StoreAndForwardError::InvalidStoreMessage)?;
+        let stored_message = NewStoredMessage::new(message, priority);
         self.saf_requester.insert_message(stored_message).await
     }
 }


### PR DESCRIPTION
Description
---
- Ignores nanos for `stored_at` field in StoredMessages
- Uses direct u32 <-> i32 conversion
- Improve error message if attempting to store an expired message
- Discard expired messages immediately
- Debug log when remote client closes the connection in RPC server

Motivation and Context
---
- Nano conversion will fail when >= 2_000_000_000, nanos are not important to preserve so we ignore them (set to zero)
- u32 to/from i32 conversion does not lose any data as both are 32-bit, only used as i32 in the database 
- 'The message was not valid for store and forward' occurs if the message has expired, this PR uses a more descriptive error message for this specific case.
- Expired messages should be discarded immediately
- Early close "errors" on the rpc server simply indicate that the client went away, which is expected and not something that the server controls, and so is logged at debug level 

How Has This Been Tested?
---
Manually, 