### PR TITLE
fix(wallet/grpc): add transaction id, template_address to template_reg response

### DIFF
--- a/applications/tari_app_grpc/proto/wallet.proto
+++ b/applications/tari_app_grpc/proto/wallet.proto
@@ -267,7 +267,10 @@ message CreateTemplateRegistrationRequest {
     uint64 fee_per_gram = 2;
 }
 
-message CreateTemplateRegistrationResponse { }
+message CreateTemplateRegistrationResponse {
+    uint64 tx_id = 1;
+    bytes template_address = 2;
+}
 
 message CancelTransactionRequest {
     uint64 tx_id = 1;


### PR DESCRIPTION
Description
---
Adds tx_id and template_address to create_template_registration method

Motivation and Context
---
Mainly helpful for displaying the template address in the vn cli.

How Has This Been Tested?
---

