### PR TITLE
fix(core)!: adds utxo and block info to get_template_registrations request

### DIFF
--- a/applications/tari_app_grpc/proto/base_node.proto
+++ b/applications/tari_app_grpc/proto/base_node.proto
@@ -95,6 +95,7 @@ service BaseNode {
     rpc GetShardKey(GetShardKeyRequest) returns (GetShardKeyResponse);
     // Get templates
     rpc GetTemplateRegistrations(GetTemplateRegistrationsRequest) returns (stream GetTemplateRegistrationResponse);
+    rpc GetSideChainUtxos(GetSideChainUtxosRequest) returns (stream GetSideChainUtxosResponse);
 }
 
 message GetAssetMetadataRequest {
@@ -471,17 +472,28 @@ message GetShardKeyResponse {
 }
 
 message GetTemplateRegistrationsRequest {
-    uint64 start_height = 1;
-    uint64 end_height = 2;
+    bytes start_hash = 1;
+    uint64 count = 2;
 }
 
 message GetTemplateRegistrationResponse {
-    BlockInfo block_info = 1;
-    bytes utxo_hash = 2;
-    TemplateRegistration registration = 3;
+    bytes utxo_hash = 1;
+    TemplateRegistration registration = 2;
 }
 
 message BlockInfo {
     uint64 height = 1;
     bytes hash = 2;
+    bytes next_block_hash = 3;
 }
+
+message GetSideChainUtxosRequest {
+    bytes start_hash = 1;
+    uint64 count = 2;
+}
+
+message GetSideChainUtxosResponse {
+    BlockInfo block_info = 1;
+    repeated TransactionOutput outputs = 2;
+}
+

--- a/applications/tari_app_grpc/proto/base_node.proto
+++ b/applications/tari_app_grpc/proto/base_node.proto
@@ -94,7 +94,7 @@ service BaseNode {
     rpc GetCommittee(GetCommitteeRequest) returns (GetCommitteeResponse);
     rpc GetShardKey(GetShardKeyRequest) returns (GetShardKeyResponse);
     // Get templates
-    rpc GetTemplateRegistrations(GetTemplateRegistrationsRequest) returns (stream TemplateRegistration);
+    rpc GetTemplateRegistrations(GetTemplateRegistrationsRequest) returns (stream GetTemplateRegistrationResponse);
 }
 
 message GetAssetMetadataRequest {
@@ -471,5 +471,17 @@ message GetShardKeyResponse {
 }
 
 message GetTemplateRegistrationsRequest {
-    uint64 from_height = 1;
+    uint64 start_height = 1;
+    uint64 end_height = 2;
+}
+
+message GetTemplateRegistrationResponse {
+    BlockInfo block_info = 1;
+    bytes utxo_hash = 2;
+    TemplateRegistration registration = 3;
+}
+
+message BlockInfo {
+    uint64 height = 1;
+    bytes hash = 2;
 }

--- a/applications/tari_app_grpc/proto/validator_node.proto
+++ b/applications/tari_app_grpc/proto/validator_node.proto
@@ -118,7 +118,7 @@ message Authority {
     bytes proxied_by = 3;
 }
 
-message InvokeMethodRequest{
+message InvokeMethodRequest {
     bytes contract_id = 1;
     uint32 template_id = 2;
     string method = 3;

--- a/base_layer/core/src/base_node/comms_interface/comms_request.rs
+++ b/base_layer/core/src/base_node/comms_interface/comms_request.rs
@@ -76,7 +76,8 @@ pub enum NodeCommsRequest {
         public_key: PublicKey,
     },
     FetchTemplateRegistrations {
-        from_height: u64,
+        start_height: u64,
+        end_height: u64,
     },
 }
 
@@ -127,8 +128,11 @@ impl Display for NodeCommsRequest {
             GetShardKey { height, public_key } => {
                 write!(f, "GetShardKey height ({}), public key ({:?})", height, public_key)
             },
-            FetchTemplateRegistrations { from_height } => {
-                write!(f, "FetchTemplateRegistrations ({})", from_height)
+            FetchTemplateRegistrations {
+                start_height: start,
+                end_height: end,
+            } => {
+                write!(f, "FetchTemplateRegistrations ({}..={})", start, end)
             },
         }
     }

--- a/base_layer/core/src/base_node/comms_interface/comms_request.rs
+++ b/base_layer/core/src/base_node/comms_interface/comms_request.rs
@@ -26,7 +26,7 @@ use std::{
 };
 
 use serde::{Deserialize, Serialize};
-use tari_common_types::types::{Commitment, HashOutput, PrivateKey, PublicKey, Signature};
+use tari_common_types::types::{BlockHash, Commitment, HashOutput, PrivateKey, PublicKey, Signature};
 use tari_utilities::hex::Hex;
 
 use crate::{blocks::NewBlockTemplate, chain_storage::MmrTree, proof_of_work::PowAlgorithm};
@@ -78,6 +78,9 @@ pub enum NodeCommsRequest {
     FetchTemplateRegistrations {
         start_height: u64,
         end_height: u64,
+    },
+    FetchUnspentUtxosInBlock {
+        block_hash: BlockHash,
     },
 }
 
@@ -133,6 +136,9 @@ impl Display for NodeCommsRequest {
                 end_height: end,
             } => {
                 write!(f, "FetchTemplateRegistrations ({}..={})", start, end)
+            },
+            FetchUnspentUtxosInBlock { block_hash } => {
+                write!(f, "FetchUnspentUtxosInBlock ({})", block_hash)
             },
         }
     }

--- a/base_layer/core/src/base_node/comms_interface/comms_response.rs
+++ b/base_layer/core/src/base_node/comms_interface/comms_response.rs
@@ -32,7 +32,7 @@ use tari_common_types::{
 
 use crate::{
     blocks::{Block, ChainHeader, HistoricalBlock, NewBlockTemplate},
-    chain_storage::{ActiveValidatorNode, TemplateRegistrationEntry, UtxoMinedInfo},
+    chain_storage::{ActiveValidatorNode, TemplateRegistrationEntry},
     proof_of_work::Difficulty,
     transactions::transaction_components::{Transaction, TransactionKernel, TransactionOutput},
 };
@@ -55,22 +55,7 @@ pub enum NodeCommsResponse {
     },
     TargetDifficulty(Difficulty),
     MmrNodes(Vec<HashOutput>, Vec<u8>),
-    FetchTokensResponse {
-        outputs: Vec<(TransactionOutput, u64)>,
-    },
-    FetchAssetRegistrationsResponse {
-        outputs: Vec<UtxoMinedInfo>,
-    },
-    FetchAssetMetadataResponse {
-        output: Box<Option<UtxoMinedInfo>>,
-    },
     FetchMempoolTransactionsByExcessSigsResponse(FetchMempoolTransactionsResponse),
-    FetchOutputsForBlockResponse {
-        outputs: Vec<UtxoMinedInfo>,
-    },
-    FetchOutputsByContractIdResponse {
-        outputs: Vec<UtxoMinedInfo>,
-    },
     FetchValidatorNodesKeysResponse(Vec<(PublicKey, [u8; 32])>),
     FetchCommitteeResponse(Vec<ActiveValidatorNode>),
     GetShardKeyResponse(Option<[u8; 32]>),
@@ -102,17 +87,12 @@ impl Display for NodeCommsResponse {
             ),
             TargetDifficulty(_) => write!(f, "TargetDifficulty"),
             MmrNodes(_, _) => write!(f, "MmrNodes"),
-            FetchTokensResponse { .. } => write!(f, "FetchTokensResponse"),
-            FetchAssetRegistrationsResponse { .. } => write!(f, "FetchAssetRegistrationsResponse"),
-            FetchAssetMetadataResponse { .. } => write!(f, "FetchAssetMetadataResponse"),
             FetchMempoolTransactionsByExcessSigsResponse(resp) => write!(
                 f,
                 "FetchMempoolTransactionsByExcessSigsResponse({} transaction(s), {} not found)",
                 resp.transactions.len(),
                 resp.not_found.len()
             ),
-            FetchOutputsForBlockResponse { .. } => write!(f, "FetchConstitutionsResponse"),
-            FetchOutputsByContractIdResponse { .. } => write!(f, "FetchOutputsByContractIdResponse"),
             FetchValidatorNodesKeysResponse(_) => write!(f, "FetchValidatorNodesKeysResponse"),
             FetchCommitteeResponse(_) => write!(f, "FetchCommitteeResponse"),
             GetShardKeyResponse(_) => write!(f, "GetShardKeyResponse"),

--- a/base_layer/core/src/base_node/comms_interface/comms_response.rs
+++ b/base_layer/core/src/base_node/comms_interface/comms_response.rs
@@ -32,14 +32,9 @@ use tari_common_types::{
 
 use crate::{
     blocks::{Block, ChainHeader, HistoricalBlock, NewBlockTemplate},
-    chain_storage::{ActiveValidatorNode, UtxoMinedInfo},
+    chain_storage::{ActiveValidatorNode, TemplateRegistrationEntry, UtxoMinedInfo},
     proof_of_work::Difficulty,
-    transactions::transaction_components::{
-        CodeTemplateRegistration,
-        Transaction,
-        TransactionKernel,
-        TransactionOutput,
-    },
+    transactions::transaction_components::{Transaction, TransactionKernel, TransactionOutput},
 };
 
 /// API Response enum
@@ -79,7 +74,7 @@ pub enum NodeCommsResponse {
     FetchValidatorNodesKeysResponse(Vec<(PublicKey, [u8; 32])>),
     FetchCommitteeResponse(Vec<ActiveValidatorNode>),
     GetShardKeyResponse(Option<[u8; 32]>),
-    FetchTemplateRegistrationsResponse(Vec<CodeTemplateRegistration>),
+    FetchTemplateRegistrationsResponse(Vec<TemplateRegistrationEntry>),
 }
 
 impl Display for NodeCommsResponse {

--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -377,14 +377,14 @@ where B: BlockchainBackend + 'static
                 let shard_key = self.blockchain_db.get_shard_key(height, public_key).await?;
                 Ok(NodeCommsResponse::GetShardKeyResponse(shard_key))
             },
-            NodeCommsRequest::FetchTemplateRegistrations { from_height } => {
+            NodeCommsRequest::FetchTemplateRegistrations {
+                start_height,
+                end_height,
+            } => {
                 let template_registrations = self
                     .blockchain_db
-                    .fetch_template_registrations(from_height)
-                    .await?
-                    .into_iter()
-                    .map(|tr| tr.registration_data)
-                    .collect();
+                    .fetch_template_registrations(start_height..=end_height)
+                    .await?;
                 Ok(NodeCommsResponse::FetchTemplateRegistrationsResponse(
                     template_registrations,
                 ))

--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -389,6 +389,15 @@ where B: BlockchainBackend + 'static
                     template_registrations,
                 ))
             },
+            NodeCommsRequest::FetchUnspentUtxosInBlock { block_hash } => {
+                let utxos = self.blockchain_db.fetch_outputs_in_block(block_hash).await?;
+                Ok(NodeCommsResponse::TransactionOutputs(
+                    utxos
+                        .into_iter()
+                        .filter_map(|utxo| utxo.into_unpruned_output())
+                        .collect(),
+                ))
+            },
         }
     }
 

--- a/base_layer/core/src/base_node/comms_interface/local_interface.rs
+++ b/base_layer/core/src/base_node/comms_interface/local_interface.rs
@@ -342,4 +342,19 @@ impl LocalNodeCommsInterface {
             _ => Err(CommsInterfaceError::UnexpectedApiResponse),
         }
     }
+
+    /// Fetches UTXOs that are not spent for the given block hash up to the current chain tip.
+    pub async fn fetch_unspent_utxos_in_block(
+        &mut self,
+        block_hash: BlockHash,
+    ) -> Result<Vec<TransactionOutput>, CommsInterfaceError> {
+        match self
+            .request_sender
+            .call(NodeCommsRequest::FetchUnspentUtxosInBlock { block_hash })
+            .await??
+        {
+            NodeCommsResponse::TransactionOutputs(outputs) => Ok(outputs),
+            _ => Err(CommsInterfaceError::UnexpectedApiResponse),
+        }
+    }
 }

--- a/base_layer/core/src/base_node/comms_interface/local_interface.rs
+++ b/base_layer/core/src/base_node/comms_interface/local_interface.rs
@@ -38,9 +38,9 @@ use crate::{
         NodeCommsResponse,
     },
     blocks::{Block, ChainHeader, HistoricalBlock, NewBlockTemplate},
-    chain_storage::ActiveValidatorNode,
+    chain_storage::{ActiveValidatorNode, TemplateRegistrationEntry},
     proof_of_work::PowAlgorithm,
-    transactions::transaction_components::{CodeTemplateRegistration, TransactionKernel, TransactionOutput},
+    transactions::transaction_components::{TransactionKernel, TransactionOutput},
 };
 
 pub type BlockEventSender = broadcast::Sender<Arc<BlockEvent>>;
@@ -327,11 +327,15 @@ impl LocalNodeCommsInterface {
 
     pub async fn get_template_registrations(
         &mut self,
-        from_height: u64,
-    ) -> Result<Vec<CodeTemplateRegistration>, CommsInterfaceError> {
+        start_height: u64,
+        end_height: u64,
+    ) -> Result<Vec<TemplateRegistrationEntry>, CommsInterfaceError> {
         match self
             .request_sender
-            .call(NodeCommsRequest::FetchTemplateRegistrations { from_height })
+            .call(NodeCommsRequest::FetchTemplateRegistrations {
+                start_height,
+                end_height,
+            })
             .await??
         {
             NodeCommsResponse::FetchTemplateRegistrationsResponse(template_registrations) => Ok(template_registrations),

--- a/base_layer/core/src/chain_storage/async_db.rs
+++ b/base_layer/core/src/chain_storage/async_db.rs
@@ -163,6 +163,8 @@ impl<B: BlockchainBackend + 'static> AsyncBlockchainDb<B> {
 
     make_async_fn!(fetch_utxos_in_block(hash: HashOutput, deleted: Option<Arc<Bitmap>>) -> (Vec<PrunedOutput>, Bitmap), "fetch_utxos_in_block");
 
+    make_async_fn!(fetch_outputs_in_block(hash: HashOutput) -> Vec<PrunedOutput>, "fetch_outputs_in_block");
+
     make_async_fn!(utxo_count() -> usize, "utxo_count");
 
     //---------------------------------- Kernel --------------------------------------------//

--- a/base_layer/core/src/chain_storage/async_db.rs
+++ b/base_layer/core/src/chain_storage/async_db.rs
@@ -30,7 +30,7 @@ use tari_common_types::{
 };
 use tari_utilities::epoch_time::EpochTime;
 
-use super::{ActiveValidatorNode, TemplateRegistration};
+use super::{ActiveValidatorNode, TemplateRegistrationEntry};
 use crate::{
     blocks::{
         Block,
@@ -271,7 +271,7 @@ impl<B: BlockchainBackend + 'static> AsyncBlockchainDb<B> {
 
     make_async_fn!(get_shard_key(height:u64, public_key: PublicKey) -> Option<[u8;32]>, "get_shard_key");
 
-    make_async_fn!(fetch_template_registrations(from_height: u64) -> Vec<TemplateRegistration>, "fetch_template_registrations");
+    make_async_fn!(fetch_template_registrations<T: RangeBounds<u64>>(range: T) -> Vec<TemplateRegistrationEntry>, "fetch_template_registrations");
 }
 
 impl<B: BlockchainBackend + 'static> From<BlockchainDatabase<B>> for AsyncBlockchainDb<B> {

--- a/base_layer/core/src/chain_storage/blockchain_backend.rs
+++ b/base_layer/core/src/chain_storage/blockchain_backend.rs
@@ -7,7 +7,7 @@ use tari_common_types::{
     types::{Commitment, HashOutput, PublicKey, Signature},
 };
 
-use super::{ActiveValidatorNode, TemplateRegistration};
+use super::{ActiveValidatorNode, TemplateRegistrationEntry};
 use crate::{
     blocks::{
         Block,
@@ -196,5 +196,9 @@ pub trait BlockchainBackend: Send + Sync {
     fn fetch_active_validator_nodes(&self, height: u64) -> Result<Vec<(PublicKey, [u8; 32])>, ChainStorageError>;
     fn fetch_committee(&self, height: u64, shard: [u8; 32]) -> Result<Vec<ActiveValidatorNode>, ChainStorageError>;
     fn get_shard_key(&self, height: u64, public_key: PublicKey) -> Result<Option<[u8; 32]>, ChainStorageError>;
-    fn fetch_template_registrations(&self, from_height: u64) -> Result<Vec<TemplateRegistration>, ChainStorageError>;
+    fn fetch_template_registrations(
+        &self,
+        start_height: u64,
+        end_height: u64,
+    ) -> Result<Vec<TemplateRegistrationEntry>, ChainStorageError>;
 }

--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -41,7 +41,7 @@ use tari_common_types::{
 use tari_mmr::pruned_hashset::PrunedHashSet;
 use tari_utilities::{epoch_time::EpochTime, hex::Hex, ByteArray};
 
-use super::{ActiveValidatorNode, TemplateRegistration};
+use super::{ActiveValidatorNode, TemplateRegistrationEntry};
 use crate::{
     blocks::{
         Block,
@@ -1188,12 +1188,18 @@ where B: BlockchainBackend
         db.fetch_committee(height, shard)
     }
 
-    pub fn fetch_template_registrations(
+    pub fn fetch_template_registrations<T: RangeBounds<u64>>(
         &self,
-        from_height: u64,
-    ) -> Result<Vec<TemplateRegistration>, ChainStorageError> {
+        range: T,
+    ) -> Result<Vec<TemplateRegistrationEntry>, ChainStorageError> {
         let db = self.db_read_access()?;
-        db.fetch_template_registrations(from_height)
+        let (start, mut end) = convert_to_option_bounds(range);
+        if end.is_none() {
+            // `(n..)` means fetch block headers until this node's tip
+            end = Some(db.fetch_last_header()?.height);
+        }
+        let (start, end) = (start.unwrap_or(0), end.unwrap());
+        db.fetch_template_registrations(start, end)
     }
 }
 

--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -439,6 +439,11 @@ where B: BlockchainBackend
         db.fetch_utxos_in_block(&hash, deleted.as_deref())
     }
 
+    pub fn fetch_outputs_in_block(&self, hash: HashOutput) -> Result<Vec<PrunedOutput>, ChainStorageError> {
+        let db = self.db_read_access()?;
+        db.fetch_outputs_in_block(&hash)
+    }
+
     /// Returns the number of UTXOs in the current unspent set
     pub fn utxo_count(&self) -> Result<usize, ChainStorageError> {
         let db = self.db_read_access()?;

--- a/base_layer/core/src/chain_storage/db_transaction.rs
+++ b/base_layer/core/src/chain_storage/db_transaction.rs
@@ -30,7 +30,7 @@ use croaring::Bitmap;
 use tari_common_types::types::{BlockHash, Commitment, HashOutput};
 use tari_utilities::hex::Hex;
 
-use super::{ActiveValidatorNode, TemplateRegistration};
+use super::{ActiveValidatorNode, TemplateRegistrationEntry};
 use crate::{
     blocks::{Block, BlockHeader, BlockHeaderAccumulatedData, ChainBlock, ChainHeader, UpdateBlockAccumulatedData},
     chain_storage::{error::ChainStorageError, HorizonData, Reorg},
@@ -363,7 +363,7 @@ pub enum WriteOperation {
         validator_node: ActiveValidatorNode,
     },
     InsertTemplateRegistration {
-        template_registration: TemplateRegistration,
+        template_registration: TemplateRegistrationEntry,
     },
 }
 

--- a/base_layer/core/src/chain_storage/error.rs
+++ b/base_layer/core/src/chain_storage/error.rs
@@ -134,6 +134,8 @@ pub enum ChainStorageError {
     UnspendableDueToDependentUtxos { details: String },
     #[error("FixedHashSize Error: {0}")]
     FixedHashSizeError(#[from] FixedHashSizeError),
+    #[error("Composite key length was exceeded (THIS SHOULD NEVER HAPPEN)")]
+    CompositeKeyLengthExceeded,
 }
 
 impl ChainStorageError {

--- a/base_layer/core/src/chain_storage/lmdb_db/mod.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/mod.rs
@@ -28,6 +28,7 @@ use tari_crypto::hash_domain;
 use crate::transactions::transaction_components::{TransactionInput, TransactionKernel, TransactionOutput};
 
 // mod composite_key;
+mod composite_key;
 pub(crate) mod helpers;
 pub(crate) mod key_prefix_cursor;
 mod lmdb;

--- a/base_layer/core/src/chain_storage/mod.rs
+++ b/base_layer/core/src/chain_storage/mod.rs
@@ -84,4 +84,4 @@ mod active_validator_node;
 pub use active_validator_node::ActiveValidatorNode;
 
 mod template_registation;
-pub use template_registation::TemplateRegistration;
+pub use template_registation::TemplateRegistrationEntry;

--- a/base_layer/core/src/chain_storage/template_registation.rs
+++ b/base_layer/core/src/chain_storage/template_registation.rs
@@ -21,11 +21,14 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use serde::{Deserialize, Serialize};
+use tari_common_types::types::FixedHash;
 
 use crate::transactions::transaction_components::CodeTemplateRegistration;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct TemplateRegistration {
+pub struct TemplateRegistrationEntry {
     pub registration_data: CodeTemplateRegistration,
-    pub height: u64,
+    pub output_hash: FixedHash,
+    pub block_height: u64,
+    pub block_hash: FixedHash,
 }

--- a/base_layer/core/src/test_helpers/blockchain.rs
+++ b/base_layer/core/src/test_helpers/blockchain.rs
@@ -67,7 +67,7 @@ use crate::{
         MmrTree,
         PrunedOutput,
         Reorg,
-        TemplateRegistration,
+        TemplateRegistrationEntry,
         UtxoMinedInfo,
         Validators,
     },
@@ -427,8 +427,15 @@ impl BlockchainBackend for TempDatabase {
         self.db.as_ref().unwrap().get_shard_key(height, public_key)
     }
 
-    fn fetch_template_registrations(&self, from_height: u64) -> Result<Vec<TemplateRegistration>, ChainStorageError> {
-        self.db.as_ref().unwrap().fetch_template_registrations(from_height)
+    fn fetch_template_registrations(
+        &self,
+        start_height: u64,
+        end_height: u64,
+    ) -> Result<Vec<TemplateRegistrationEntry>, ChainStorageError> {
+        self.db
+            .as_ref()
+            .unwrap()
+            .fetch_template_registrations(start_height, end_height)
     }
 }
 

--- a/base_layer/core/src/transactions/transaction_components/output_type.rs
+++ b/base_layer/core/src/transactions/transaction_components/output_type.rs
@@ -71,6 +71,13 @@ impl OutputType {
             OutputType::CodeTemplateRegistration,
         ]
     }
+
+    pub fn is_sidechain_type(&self) -> bool {
+        matches!(
+            self,
+            OutputType::ValidatorNodeRegistration | OutputType::CodeTemplateRegistration
+        )
+    }
 }
 
 impl Default for OutputType {

--- a/base_layer/core/src/transactions/transaction_components/side_chain/template_registration.rs
+++ b/base_layer/core/src/transactions/transaction_components/side_chain/template_registration.rs
@@ -23,19 +23,15 @@
 use std::io::{Error, ErrorKind, Read, Write};
 
 use serde::{Deserialize, Serialize};
-use tari_common_types::types::{FixedHash, PublicKey, Signature};
+use tari_common_types::types::{PublicKey, Signature};
 
-use crate::{
-    consensus::{
-        read_byte,
-        ConsensusDecoding,
-        ConsensusEncoding,
-        ConsensusEncodingSized,
-        DomainSeparatedConsensusHasher,
-        MaxSizeBytes,
-        MaxSizeString,
-    },
-    transactions::TransactionHashDomain,
+use crate::consensus::{
+    read_byte,
+    ConsensusDecoding,
+    ConsensusEncoding,
+    ConsensusEncodingSized,
+    MaxSizeBytes,
+    MaxSizeString,
 };
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Deserialize, Serialize)]
@@ -48,22 +44,6 @@ pub struct CodeTemplateRegistration {
     pub build_info: BuildInfo,
     pub binary_sha: MaxSizeBytes<32>,
     pub binary_url: MaxSizeString<255>,
-}
-
-impl CodeTemplateRegistration {
-    pub fn hash(&self) -> FixedHash {
-        DomainSeparatedConsensusHasher::<TransactionHashDomain>::new("template_registration")
-            .chain(&self.author_public_key)
-            .chain(&self.author_signature)
-            .chain(&self.template_name)
-            .chain(&self.template_version)
-            .chain(&self.template_type)
-            .chain(&self.build_info)
-            .chain(&self.binary_sha)
-            .chain(&self.binary_url)
-            .finalize()
-            .into()
-    }
 }
 
 impl ConsensusEncoding for CodeTemplateRegistration {


### PR DESCRIPTION
Description
---
- adds UTXO and block info to get_template_registrations request
- adds end_height to get_template_registrations request
- Changes validator node registration key to <block_height, output_hash>
- uses CompositeKey for all composite keys
- Removed some unused (previous contract code) response types

Motivation and Context
---
DAN template scanner requires block hash info to determine last scanned height.
Indexing template validations by block height enable more efficient retrievals

NOTE: blockchain db will need to be resynced

How Has This Been Tested?
---
Manually - DAN block scanner
