### PR TITLE
fix(core): increase sync timeouts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4594,7 +4594,7 @@ dependencies = [
 
 [[package]]
 name = "tari_app_grpc"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "argon2 0.4.1",
  "base64 0.13.0",
@@ -4619,7 +4619,7 @@ dependencies = [
 
 [[package]]
 name = "tari_app_utilities"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "clap 3.2.22",
  "config",
@@ -4641,7 +4641,7 @@ dependencies = [
 
 [[package]]
 name = "tari_base_node"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4742,7 +4742,7 @@ dependencies = [
 
 [[package]]
 name = "tari_common"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "anyhow",
  "blake2 0.9.2",
@@ -4770,7 +4770,7 @@ dependencies = [
 
 [[package]]
 name = "tari_common_sqlite"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "diesel",
  "log",
@@ -4779,7 +4779,7 @@ dependencies = [
 
 [[package]]
 name = "tari_common_types"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "base64 0.13.0",
  "digest 0.9.0",
@@ -4795,7 +4795,7 @@ dependencies = [
 
 [[package]]
 name = "tari_comms"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4845,7 +4845,7 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_dht"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "anyhow",
  "bitflags 1.3.2",
@@ -4891,7 +4891,7 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_rpc_macros"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "futures 0.3.24",
  "proc-macro2",
@@ -4906,7 +4906,7 @@ dependencies = [
 
 [[package]]
 name = "tari_console_wallet"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "base64 0.13.0",
  "bitflags 1.3.2",
@@ -4956,7 +4956,7 @@ dependencies = [
 
 [[package]]
 name = "tari_core"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5044,7 +5044,7 @@ dependencies = [
 
 [[package]]
 name = "tari_key_manager"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "argon2 0.2.4",
  "arrayvec 0.7.2",
@@ -5091,7 +5091,7 @@ dependencies = [
 
 [[package]]
 name = "tari_merge_mining_proxy"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "anyhow",
  "bincode",
@@ -5143,7 +5143,7 @@ dependencies = [
 
 [[package]]
 name = "tari_miner"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "base64 0.13.0",
  "bufstream",
@@ -5179,7 +5179,7 @@ dependencies = [
 
 [[package]]
 name = "tari_mining_helper_ffi"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "hex",
  "libc",
@@ -5196,7 +5196,7 @@ dependencies = [
 
 [[package]]
 name = "tari_mmr"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "bincode",
  "blake2 0.9.2",
@@ -5215,7 +5215,7 @@ dependencies = [
 
 [[package]]
 name = "tari_p2p"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "anyhow",
  "bytes 0.5.6",
@@ -5272,7 +5272,7 @@ dependencies = [
 
 [[package]]
 name = "tari_service_framework"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5289,7 +5289,7 @@ dependencies = [
 
 [[package]]
 name = "tari_shutdown"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "futures 0.3.24",
  "tokio",
@@ -5297,7 +5297,7 @@ dependencies = [
 
 [[package]]
 name = "tari_storage"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "bincode",
  "lmdb-zero",
@@ -5311,7 +5311,7 @@ dependencies = [
 
 [[package]]
 name = "tari_test_utils"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "futures 0.3.24",
  "futures-test",
@@ -5338,7 +5338,7 @@ dependencies = [
 
 [[package]]
 name = "tari_wallet"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "argon2 0.2.4",
  "async-trait",
@@ -5389,7 +5389,7 @@ dependencies = [
 
 [[package]]
 name = "tari_wallet_ffi"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "cbindgen 0.24.3",
  "chrono",

--- a/base_layer/core/src/base_node/sync/config.rs
+++ b/base_layer/core/src/base_node/sync/config.rs
@@ -56,13 +56,13 @@ pub struct BlockchainSyncConfig {
 impl Default for BlockchainSyncConfig {
     fn default() -> Self {
         Self {
-            initial_max_sync_latency: Duration::from_secs(20),
+            initial_max_sync_latency: Duration::from_secs(30),
             max_latency_increase: Duration::from_secs(2),
             ban_period: Duration::from_secs(30 * 60),
             short_ban_period: Duration::from_secs(60),
             forced_sync_peers: Default::default(),
             validation_concurrency: 6,
-            rpc_deadline: Duration::from_secs(10),
+            rpc_deadline: Duration::from_secs(30),
         }
     }
 }


### PR DESCRIPTION
Description
---
- Increases default sync rpc deadline from 10s to 30s

Motivation and Context
---
Large 2Mb+ blocks often take more than 10s to come through, often 11/12s. This results in longer sync times because the data that was 1/2s+ from coming through was thrown away and sync has to re-establish and continue.

How Has This Been Tested?
---
Sync works without timing out
