### PR TITLE
fix(core): periodically commit large transaction in prune_to_height

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4594,7 +4594,7 @@ dependencies = [
 
 [[package]]
 name = "tari_app_grpc"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "argon2 0.4.1",
  "base64 0.13.0",
@@ -4619,7 +4619,7 @@ dependencies = [
 
 [[package]]
 name = "tari_app_utilities"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "clap 3.2.22",
  "config",
@@ -4641,7 +4641,7 @@ dependencies = [
 
 [[package]]
 name = "tari_base_node"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4742,7 +4742,7 @@ dependencies = [
 
 [[package]]
 name = "tari_common"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "anyhow",
  "blake2 0.9.2",
@@ -4770,7 +4770,7 @@ dependencies = [
 
 [[package]]
 name = "tari_common_sqlite"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "diesel",
  "log",
@@ -4779,7 +4779,7 @@ dependencies = [
 
 [[package]]
 name = "tari_common_types"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "base64 0.13.0",
  "digest 0.9.0",
@@ -4795,7 +4795,7 @@ dependencies = [
 
 [[package]]
 name = "tari_comms"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4845,7 +4845,7 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_dht"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "anyhow",
  "bitflags 1.3.2",
@@ -4891,7 +4891,7 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_rpc_macros"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "futures 0.3.24",
  "proc-macro2",
@@ -4906,7 +4906,7 @@ dependencies = [
 
 [[package]]
 name = "tari_console_wallet"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "base64 0.13.0",
  "bitflags 1.3.2",
@@ -4956,7 +4956,7 @@ dependencies = [
 
 [[package]]
 name = "tari_core"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5044,7 +5044,7 @@ dependencies = [
 
 [[package]]
 name = "tari_key_manager"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "argon2 0.2.4",
  "arrayvec 0.7.2",
@@ -5091,7 +5091,7 @@ dependencies = [
 
 [[package]]
 name = "tari_merge_mining_proxy"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "anyhow",
  "bincode",
@@ -5143,7 +5143,7 @@ dependencies = [
 
 [[package]]
 name = "tari_miner"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "base64 0.13.0",
  "bufstream",
@@ -5179,7 +5179,7 @@ dependencies = [
 
 [[package]]
 name = "tari_mining_helper_ffi"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "hex",
  "libc",
@@ -5196,7 +5196,7 @@ dependencies = [
 
 [[package]]
 name = "tari_mmr"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "bincode",
  "blake2 0.9.2",
@@ -5215,7 +5215,7 @@ dependencies = [
 
 [[package]]
 name = "tari_p2p"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "anyhow",
  "bytes 0.5.6",
@@ -5272,7 +5272,7 @@ dependencies = [
 
 [[package]]
 name = "tari_service_framework"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5289,7 +5289,7 @@ dependencies = [
 
 [[package]]
 name = "tari_shutdown"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "futures 0.3.24",
  "tokio",
@@ -5297,7 +5297,7 @@ dependencies = [
 
 [[package]]
 name = "tari_storage"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "bincode",
  "lmdb-zero",
@@ -5311,7 +5311,7 @@ dependencies = [
 
 [[package]]
 name = "tari_test_utils"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "futures 0.3.24",
  "futures-test",
@@ -5338,7 +5338,7 @@ dependencies = [
 
 [[package]]
 name = "tari_wallet"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "argon2 0.2.4",
  "async-trait",
@@ -5389,7 +5389,7 @@ dependencies = [
 
 [[package]]
 name = "tari_wallet_ffi"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "cbindgen 0.24.3",
  "chrono",

--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -2374,6 +2374,10 @@ fn prune_to_height<T: BlockchainBackend>(db: &mut T, target_horizon_height: u64)
 
         txn.prune_outputs_at_positions(output_mmr_positions.to_vec());
         txn.delete_all_inputs_in_block(*header.hash());
+        if txn.operations().len() >= 100 {
+            txn.set_pruned_height(block_to_prune);
+            db.write(mem::take(&mut txn))?;
+        }
     }
 
     txn.set_pruned_height(target_horizon_height);


### PR DESCRIPTION
Description
---
Commits large (>= 100 ops) transaction in prune_to_height 

Motivation and Context
---
When partially using block sync, then switching to pruned sync, the base node prunes blocks. This typically involves many
database operations and can easily exceed the growth maximum of the chain storage db. 

This PR commits each time the transaction gets to >=100 operations.

Fixes #4760 

How Has This Been Tested?
---
Manually: Partially block sync then switch to pruned sync
