### PR TITLE
fix: impl flush for yamux socket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,15 +153,6 @@ checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 
 [[package]]
 name = "arrayvec"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
-dependencies = [
- "nodrop",
-]
-
-[[package]]
-name = "arrayvec"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
@@ -791,6 +782,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1220,6 +1221,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "cxx"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f83d0ebf42c6eafb8d7c52f7e5f2d3003b89c7aa4fd2b79229209459a849af8"
+dependencies = [
+ "cc",
+ "cxxbridge-flags",
+ "cxxbridge-macro",
+ "link-cplusplus",
+]
+
+[[package]]
+name = "cxx-build"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07d050484b55975889284352b0ffc2ecbda25c0c55978017c132b29ba0818a86"
+dependencies = [
+ "cc",
+ "codespan-reporting",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "scratch",
+ "syn",
+]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d2199b00553eda8012dfec8d3b1c75fce747cf27c169a270b3b99e3448ab78"
+
+[[package]]
+name = "cxxbridge-macro"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb67a6de1f602736dd7eaead0080cf3435df806c61b24b13328db128c58868f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "darling"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1338,6 +1383,12 @@ dependencies = [
  "cipher 0.2.5",
  "opaque-debug",
 ]
+
+[[package]]
+name = "destructure_traitobject"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c877555693c14d2f84191cfd3ad8582790fc52b5e2274b40b59cf5f5cea25c7"
 
 [[package]]
 name = "diesel"
@@ -1953,7 +2004,7 @@ checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
 dependencies = [
  "bytes 1.2.1",
  "fnv",
- "itoa 1.0.3",
+ "itoa 1.0.4",
 ]
 
 [[package]]
@@ -2009,7 +2060,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa 1.0.3",
+ "itoa 1.0.4",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -2045,15 +2096,26 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.50"
+version = "0.1.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd911b35d940d2bd0bea0f9100068e5b97b51a1cbe13d13382f132e0365257a0"
+checksum = "f5a6ef98976b22b3b7f2f3a806f858cb862044cfa66805aa3ad84cb3d3b785ed"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
+ "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
  "winapi",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+dependencies = [
+ "cxx",
+ "cxx-build",
 ]
 
 [[package]]
@@ -2177,9 +2239,9 @@ checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
+checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
 
 [[package]]
 name = "js-sys"
@@ -2247,9 +2309,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.134"
+version = "0.2.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
+checksum = "68783febc7782c6c5cb401fbda4de5a9898be1762314da0bb2c10ced61f18b0c"
 
 [[package]]
 name = "libgit2-sys"
@@ -2372,6 +2434,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "link-cplusplus"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9272ab7b96c9046fbc5bc56c06c117cb639fe2d509df0c421cad82d2915cf369"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2432,9 +2503,9 @@ checksum = "a94d21414c1f4a51209ad204c1776a3d0765002c76c6abcb602a6f09f1e881c7"
 
 [[package]]
 name = "log4rs"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "893eaf59f4bef8e2e94302adf56385db445a0306b9823582b0b8d5a06d8822f3"
+checksum = "d36ca1786d9e79b8193a68d480a0907b612f109537115c6ff655a3a1967533fd"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2452,7 +2523,7 @@ dependencies = [
  "serde_yaml",
  "thiserror",
  "thread-id",
- "typemap",
+ "typemap-ors",
  "winapi",
 ]
 
@@ -2720,12 +2791,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nodrop"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
-
-[[package]]
 name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2813,12 +2878,12 @@ dependencies = [
 
 [[package]]
 name = "num-format"
-version = "0.4.0"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bafe4179722c2894288ee77a9f044f02811c86af699344c498b0840c698a2465"
+checksum = "54b862ff8df690cf089058c98b183676a7ed0f974cc08b426800093227cbff3b"
 dependencies = [
- "arrayvec 0.4.12",
- "itoa 0.4.8",
+ "arrayvec",
+ "itoa 1.0.4",
 ]
 
 [[package]]
@@ -3460,9 +3525,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
+checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
 dependencies = [
  "unicode-ident",
 ]
@@ -4078,6 +4143,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
+name = "scratch"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
+
+[[package]]
 name = "sct"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4194,11 +4265,11 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.85"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
+checksum = "41feea4228a6f1cd09ec7a3593a682276702cd67b5273544757dae23c096f074"
 dependencies = [
- "itoa 1.0.3",
+ "itoa 1.0.4",
  "ryu",
  "serde",
 ]
@@ -4221,7 +4292,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa 1.0.3",
+ "itoa 1.0.4",
  "ryu",
  "serde",
 ]
@@ -4363,9 +4434,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.6.3"
+version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb766570a2825fa972bceff0d195727876a9cdf2460ab2e52d455dc2de47fd9"
+checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 
 [[package]]
 name = "simple_asn1"
@@ -4571,9 +4642,9 @@ checksum = "171758edb47aa306a78dfa4ab9aeb5167405bd4e3dc2b64e88f6a84bbe98bd63"
 
 [[package]]
 name = "syn"
-version = "1.0.101"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e90cde112c4b9690b8cbe810cba9ddd8bc1d7472e2cae317b69e9438c1cba7d2"
+checksum = "3fcd952facd492f9be3ef0d0b7032a6e442ee9b361d4acc2b1d0c4aaa5f613a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4594,7 +4665,7 @@ dependencies = [
 
 [[package]]
 name = "tari_app_grpc"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "argon2 0.4.1",
  "base64 0.13.0",
@@ -4619,7 +4690,7 @@ dependencies = [
 
 [[package]]
 name = "tari_app_utilities"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "clap 3.2.22",
  "config",
@@ -4641,7 +4712,7 @@ dependencies = [
 
 [[package]]
 name = "tari_base_node"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4742,7 +4813,7 @@ dependencies = [
 
 [[package]]
 name = "tari_common"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "anyhow",
  "blake2 0.9.2",
@@ -4770,7 +4841,7 @@ dependencies = [
 
 [[package]]
 name = "tari_common_sqlite"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "diesel",
  "log",
@@ -4779,7 +4850,7 @@ dependencies = [
 
 [[package]]
 name = "tari_common_types"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "base64 0.13.0",
  "digest 0.9.0",
@@ -4795,7 +4866,7 @@ dependencies = [
 
 [[package]]
 name = "tari_comms"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4845,7 +4916,7 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_dht"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "anyhow",
  "bitflags 1.3.2",
@@ -4891,7 +4962,7 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_rpc_macros"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "futures 0.3.24",
  "proc-macro2",
@@ -4906,7 +4977,7 @@ dependencies = [
 
 [[package]]
 name = "tari_console_wallet"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "base64 0.13.0",
  "bitflags 1.3.2",
@@ -4956,7 +5027,7 @@ dependencies = [
 
 [[package]]
 name = "tari_core"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5044,10 +5115,10 @@ dependencies = [
 
 [[package]]
 name = "tari_key_manager"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "argon2 0.2.4",
- "arrayvec 0.7.2",
+ "arrayvec",
  "blake2 0.9.2",
  "chacha20 0.7.3",
  "clear_on_drop",
@@ -5091,7 +5162,7 @@ dependencies = [
 
 [[package]]
 name = "tari_merge_mining_proxy"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "anyhow",
  "bincode",
@@ -5143,7 +5214,7 @@ dependencies = [
 
 [[package]]
 name = "tari_miner"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "base64 0.13.0",
  "bufstream",
@@ -5179,7 +5250,7 @@ dependencies = [
 
 [[package]]
 name = "tari_mining_helper_ffi"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "hex",
  "libc",
@@ -5196,7 +5267,7 @@ dependencies = [
 
 [[package]]
 name = "tari_mmr"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "bincode",
  "blake2 0.9.2",
@@ -5215,7 +5286,7 @@ dependencies = [
 
 [[package]]
 name = "tari_p2p"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "anyhow",
  "bytes 0.5.6",
@@ -5272,7 +5343,7 @@ dependencies = [
 
 [[package]]
 name = "tari_service_framework"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5289,7 +5360,7 @@ dependencies = [
 
 [[package]]
 name = "tari_shutdown"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "futures 0.3.24",
  "tokio",
@@ -5297,7 +5368,7 @@ dependencies = [
 
 [[package]]
 name = "tari_storage"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "bincode",
  "lmdb-zero",
@@ -5311,7 +5382,7 @@ dependencies = [
 
 [[package]]
 name = "tari_test_utils"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "futures 0.3.24",
  "futures-test",
@@ -5338,7 +5409,7 @@ dependencies = [
 
 [[package]]
 name = "tari_wallet"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "argon2 0.2.4",
  "async-trait",
@@ -5389,7 +5460,7 @@ dependencies = [
 
 [[package]]
 name = "tari_wallet_ffi"
-version = "0.38.6"
+version = "0.38.7"
 dependencies = [
  "cbindgen 0.24.3",
  "chrono",
@@ -5651,9 +5722,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6edf2d6bc038a43d31353570e27270603f4648d18f5ed10c0e179abe43255af"
+checksum = "d660770404473ccd7bc9f8b28494a811bc18542b915c0855c51e8f419d5223ce"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -5778,9 +5849,9 @@ dependencies = [
 
 [[package]]
 name = "tower-layer"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "343bc9466d3fe6b0f960ef45960509f84480bf4fd96f92901afe7ff3df9d3a62"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
 
 [[package]]
 name = "tower-service"
@@ -5790,9 +5861,9 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.36"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if 1.0.0",
  "log",
@@ -5803,9 +5874,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2"
+checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5814,9 +5885,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aeea4303076558a00714b823f9ad67d58a3bbda1df83d8827d21193156e22f7"
+checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -5887,12 +5958,6 @@ dependencies = [
  "tracing-log",
  "tracing-serde",
 ]
-
-[[package]]
-name = "traitobject"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
 
 [[package]]
 name = "trust-dns-client"
@@ -5987,12 +6052,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "typemap"
-version = "0.3.3"
+name = "typemap-ors"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "653be63c80a3296da5551e1bfd2cca35227e13cdd08c6668903ae2f4f77aa1f6"
+checksum = "a68c24b707f02dd18f1e4ccceb9d49f2058c2fb86384ef9972592904d7a28867"
 dependencies = [
- "unsafe-any",
+ "unsafe-any-ors",
 ]
 
 [[package]]
@@ -6036,9 +6101,9 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
+checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
 
 [[package]]
 name = "unicode-normalization"
@@ -6078,12 +6143,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "unsafe-any"
-version = "0.4.2"
+name = "unsafe-any-ors"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30360d7979f5e9c6e6cea48af192ea8fab4afb3cf72597154b8f08935bc9c7f"
+checksum = "e0a303d30665362d9680d7d91d78b23f5f899504d4f08b3c4cf08d055d87c0ad"
 dependencies = [
- "traitobject",
+ "destructure_traitobject",
 ]
 
 [[package]]
@@ -6463,8 +6528,7 @@ dependencies = [
 [[package]]
 name = "yamux"
 version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d9ba232399af1783a58d8eb26f6b5006fbefe2dc9ef36bd283324792d03ea5"
+source = "git+https://github.com/tari-project/yamux.git?branch=tari-flush-cmd#254f4022090d940dfab604301ee16220efe50588"
 dependencies = [
  "futures 0.3.24",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,4 @@ panic = 'abort'
 # Temporarily lock pgp to commit (master branch at time of writing) because the currently release crate locks zeroize to =1.3
 liblmdb-sys = { git = "https://github.com/tari-project/lmdb-rs", tag = "0.7.6-tari.1" }
 
+yamux = { git = "https://github.com/tari-project/yamux.git", branch = "tari-flush-cmd" }

--- a/comms/core/src/protocol/rpc/client/mod.rs
+++ b/comms/core/src/protocol/rpc/client/mod.rs
@@ -801,6 +801,7 @@ where TSubstream: AsyncRead + AsyncWrite + Unpin + Send + StreamId
             });
         }
         self.framed.send(payload.into()).await?;
+        self.framed.flush().await?;
         Ok(())
     }
 

--- a/comms/core/src/protocol/rpc/handshake.rs
+++ b/comms/core/src/protocol/rpc/handshake.rs
@@ -99,6 +99,7 @@ where T: AsyncRead + AsyncWrite + Unpin
                         .send(reply.to_encoded_bytes().into())
                         .instrument(span)
                         .await?;
+                    self.framed.flush().await?;
                     return Ok(*version);
                 }
 


### PR DESCRIPTION
Description
---

Motivation and Context
---
This PR attempts to flush the socket as soon as a request is sent.

Flushing has no effect on yamux sockets, but I've implemented a flush command here to see what difference if any it makes
https://github.com/tari-project/yamux/tree/tari-flush-cmd

After looking into it, this is unlikely to make a difference as yamux flushes while reading.
If anything it may make performance worse, as flush calls are expensive, but I have not observed this and it seems to perform similarly with a small make-it-rain (120 tx). Difficult to draw conclusions without perf testing.

The idea though is to remove an unnecessary delay before a request message is actually sent

How Has This Been Tested?
---

