### PR TITLE
feat(comms): adds periodic socket-level liveness checks

### DIFF
--- a/applications/tari_base_node/src/bootstrap.rs
+++ b/applications/tari_base_node/src/bootstrap.rs
@@ -108,6 +108,8 @@ where B: BlockchainBackend + 'static
 
         // TODO: This should probably be disabled in future and have it optionally set/unset in the config - this check
         //       does allow MITM/ISP/tor router to connect this node's IP to a destination IP/onion address.
+        //       Specifically, "pingpong" text is periodically sent on an unencrypted socket allowing anyone observing
+        //       the traffic to recognise the sending IP address as almost certainly a tari node.
         p2p_config.listener_liveness_check_interval = Some(Duration::from_secs(15));
 
         let mut handles = StackBuilder::new(self.interrupt_signal)

--- a/applications/tari_base_node/src/bootstrap.rs
+++ b/applications/tari_base_node/src/bootstrap.rs
@@ -20,7 +20,7 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{cmp, str::FromStr, sync::Arc};
+use std::{cmp, str::FromStr, sync::Arc, time::Duration};
 
 use log::*;
 use tari_app_utilities::{consts, identity_management, identity_management::load_from_json};
@@ -105,6 +105,10 @@ where B: BlockchainBackend + 'static
         let tor_identity = load_from_json(&base_node_config.tor_identity_file)
             .map_err(|e| ExitError::new(ExitCode::ConfigError, e))?;
         p2p_config.transport.tor.identity = tor_identity;
+
+        // TODO: This should probably be disabled in future and have it optionally set/unset in the config - this check
+        //       does allow MITM/ISP/tor router to connect this node's IP to a destination IP/onion address.
+        p2p_config.listener_liveness_check_interval = Some(Duration::from_secs(15));
 
         let mut handles = StackBuilder::new(self.interrupt_signal)
             .add_initializer(P2pInitializer::new(

--- a/applications/tari_base_node/src/commands/command/add_peer.rs
+++ b/applications/tari_base_node/src/commands/command/add_peer.rs
@@ -44,7 +44,8 @@ pub struct ArgsAddPeer {
 impl HandleCommand<ArgsAddPeer> for CommandContext {
     async fn handle_command(&mut self, args: ArgsAddPeer) -> Result<(), Error> {
         let public_key = args.public_key.into();
-        if self.peer_manager.exists(&public_key).await {
+        let peer_manager = self.comms.peer_manager();
+        if peer_manager.exists(&public_key).await {
             return Err(anyhow!("Peer with public key '{}' already exists", public_key));
         }
         let node_id = NodeId::from_public_key(&public_key);
@@ -57,7 +58,7 @@ impl HandleCommand<ArgsAddPeer> for CommandContext {
             vec![],
             String::new(),
         );
-        self.peer_manager.add_peer(peer).await?;
+        peer_manager.add_peer(peer).await?;
         println!("Peer with node id '{}'was added to the base node.", node_id);
         Ok(())
     }

--- a/applications/tari_base_node/src/commands/command/ban_peer.rs
+++ b/applications/tari_base_node/src/commands/command/ban_peer.rs
@@ -80,13 +80,14 @@ impl CommandContext {
         if self.base_node_identity.node_id() == &node_id {
             Err(ArgsError::BanSelf.into())
         } else if must_ban {
-            self.connectivity
+            self.comms
+                .connectivity()
                 .ban_peer_until(node_id.clone(), duration, "UI manual ban".to_string())
                 .await?;
             println!("Peer was banned in base node.");
             Ok(())
         } else {
-            self.peer_manager.unban_peer(&node_id).await?;
+            self.comms.peer_manager().unban_peer(&node_id).await?;
             println!("Peer ban was removed from base node.");
             Ok(())
         }

--- a/applications/tari_base_node/src/commands/command/dial_peer.rs
+++ b/applications/tari_base_node/src/commands/command/dial_peer.rs
@@ -48,7 +48,7 @@ impl HandleCommand<Args> for CommandContext {
 impl CommandContext {
     /// Function to process the dial-peer command
     pub async fn dial_peer(&self, dest_node_id: NodeId) -> Result<(), Error> {
-        let connectivity = self.connectivity.clone();
+        let connectivity = self.comms.connectivity();
         task::spawn(async move {
             let start = Instant::now();
             println!("☎️  Dialing peer...");

--- a/applications/tari_base_node/src/commands/command/get_peer.rs
+++ b/applications/tari_base_node/src/commands/command/get_peer.rs
@@ -63,7 +63,8 @@ enum ArgsError {
 
 impl CommandContext {
     pub async fn get_peer(&self, partial: Vec<u8>, original_str: String) -> Result<(), Error> {
-        let peers = self.peer_manager.find_all_starts_with(&partial).await?;
+        let peer_manager = self.comms.peer_manager();
+        let peers = peer_manager.find_all_starts_with(&partial).await?;
         let peer = {
             if let Some(peer) = peers.into_iter().next() {
                 peer
@@ -71,8 +72,7 @@ impl CommandContext {
                 let pk = parse_emoji_id_or_public_key(&original_str).ok_or_else(|| ArgsError::NoPeerMatching {
                     original_str: original_str.clone(),
                 })?;
-                let peer = self
-                    .peer_manager
+                let peer = peer_manager
                     .find_by_public_key(&pk)
                     .await?
                     .ok_or(ArgsError::NoPeerMatching { original_str })?;

--- a/applications/tari_base_node/src/commands/command/list_connections.rs
+++ b/applications/tari_base_node/src/commands/command/list_connections.rs
@@ -53,9 +53,9 @@ impl CommandContext {
             "User Agent",
             "Info",
         ]);
+        let peer_manager = self.comms.peer_manager();
         for conn in conns {
-            let peer = self
-                .peer_manager
+            let peer = peer_manager
                 .find_by_node_id(conn.peer_node_id())
                 .await
                 .expect("Unexpected peer database error")
@@ -105,7 +105,7 @@ impl CommandContext {
 impl CommandContext {
     /// Function to process the list-connections command
     pub async fn list_connections(&mut self) -> Result<(), Error> {
-        let conns = self.connectivity.get_active_connections().await?;
+        let conns = self.comms.connectivity().get_active_connections().await?;
         let (mut nodes, mut clients) = conns
             .into_iter()
             .partition::<Vec<_>, _>(|a| a.peer_features().is_node());

--- a/applications/tari_base_node/src/commands/command/list_peers.rs
+++ b/applications/tari_base_node/src/commands/command/list_peers.rs
@@ -54,7 +54,7 @@ impl CommandContext {
                 _ => false,
             })
         }
-        let peers = self.peer_manager.perform_query(query).await?;
+        let peers = self.comms.peer_manager().perform_query(query).await?;
         let num_peers = peers.len();
         println!();
         let mut table = Table::new();

--- a/applications/tari_base_node/src/commands/command/reset_offline_peers.rs
+++ b/applications/tari_base_node/src/commands/command/reset_offline_peers.rs
@@ -40,7 +40,8 @@ impl HandleCommand<Args> for CommandContext {
 impl CommandContext {
     pub async fn reset_offline_peers(&self) -> Result<(), Error> {
         let num_updated = self
-            .peer_manager
+            .comms
+            .peer_manager()
             .update_each(|mut peer| {
                 if peer.is_offline() {
                     peer.set_offline(false);

--- a/applications/tari_base_node/src/commands/command/status.rs
+++ b/applications/tari_base_node/src/commands/command/status.rs
@@ -27,6 +27,7 @@ use async_trait::async_trait;
 use chrono::{DateTime, NaiveDateTime, Utc};
 use clap::Parser;
 use tari_app_utilities::consts;
+use tari_comms::connection_manager::LivenessStatus;
 use tokio::time;
 
 use super::{CommandContext, HandleCommand};
@@ -47,6 +48,7 @@ impl HandleCommand<Args> for CommandContext {
 }
 
 impl CommandContext {
+    #[allow(clippy::too_many_lines)]
     pub async fn status(&mut self, output: StatusLineOutput) -> Result<(), Error> {
         let mut full_log = false;
         if self.last_time_full.elapsed() > Duration::from_secs(120) {
@@ -102,7 +104,7 @@ impl CommandContext {
             status_line.add_field("Mempool", "query timed out");
         };
 
-        let conns = self.connectivity.get_active_connections().await?;
+        let conns = self.comms.connectivity().get_active_connections().await?;
         let (num_nodes, num_clients) = conns.iter().fold((0usize, 0usize), |(nodes, clients), conn| {
             if conn.peer_features().is_node() {
                 (nodes + 1, clients)
@@ -137,6 +139,19 @@ impl CommandContext {
                     self.state_machine_info.borrow().randomx_vm_flags
                 ),
             );
+        }
+
+        match self.comms.listening_info().liveness_status() {
+            LivenessStatus::Disabled => {},
+            LivenessStatus::Checking => {
+                status_line.add("⏳️️");
+            },
+            LivenessStatus::Unreachable => {
+                status_line.add("‼️");
+            },
+            LivenessStatus::Live(latency) => {
+                status_line.add(format!("⚡️ {:.2?}", latency));
+            },
         }
 
         let target = "base_node::app::status";

--- a/applications/tari_base_node/src/commands/command/unban_all_peers.rs
+++ b/applications/tari_base_node/src/commands/command/unban_all_peers.rs
@@ -41,10 +41,11 @@ impl HandleCommand<Args> for CommandContext {
 impl CommandContext {
     pub async fn unban_all_peers(&self) -> Result<(), Error> {
         let query = PeerQuery::new().select_where(|p| p.is_banned());
-        let peers = self.peer_manager.perform_query(query).await?;
+        let peer_manager = self.comms.peer_manager();
+        let peers = peer_manager.perform_query(query).await?;
         let num_peers = peers.len();
         for peer in peers {
-            if let Err(err) = self.peer_manager.unban_peer(&peer.node_id).await {
+            if let Err(err) = peer_manager.unban_peer(&peer.node_id).await {
                 println!("Failed to unban peer: {}", err);
             }
         }

--- a/applications/tari_base_node/src/commands/status_line.rs
+++ b/applications/tari_base_node/src/commands/status_line.rs
@@ -43,6 +43,10 @@ impl StatusLine {
         Default::default()
     }
 
+    pub fn add<T: ToString>(&mut self, value: T) -> &mut Self {
+        self.add_field("", value)
+    }
+
     pub fn add_field<T: ToString>(&mut self, name: &'static str, value: T) -> &mut Self {
         self.fields.push((name, value.to_string()));
         self
@@ -54,7 +58,7 @@ impl Display for StatusLine {
         write!(f, "{} ", Local::now().format("%H:%M"))?;
         let s = self.fields.iter().map(|(k, v)| format(k, v)).collect::<Vec<_>>();
 
-        write!(f, "{}", s.join(", "))
+        write!(f, "{}", s.join(" "))
     }
 }
 

--- a/base_layer/p2p/src/config.rs
+++ b/base_layer/p2p/src/config.rs
@@ -20,11 +20,15 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::path::{Path, PathBuf};
+use std::{
+    path::{Path, PathBuf},
+    time::Duration,
+};
 
 use serde::{Deserialize, Serialize};
 use tari_common::{
     configuration::{
+        serializers,
         utils::{deserialize_string_or_struct, serialize_string},
         StringList,
     },
@@ -105,6 +109,9 @@ pub struct P2pConfig {
     /// Liveness sessions can be used by third party tooling to determine node liveness.
     /// A value of 0 will disallow any liveness sessions.
     pub listener_liveness_max_sessions: usize,
+    /// If Some, enables periodic socket-level liveness checks
+    #[serde(with = "serializers::optional_seconds")]
+    pub listener_liveness_check_interval: Option<Duration>,
     /// CIDR for addresses allowed to enter into liveness check mode on the listener.
     pub listener_liveness_allowlist_cidrs: StringList,
     /// User agent string for this node
@@ -137,6 +144,7 @@ impl Default for P2pConfig {
             },
             allow_test_addresses: false,
             listener_liveness_max_sessions: 0,
+            listener_liveness_check_interval: None,
             listener_liveness_allowlist_cidrs: StringList::default(),
             user_agent: String::new(),
             auxiliary_tcp_listener_address: None,

--- a/base_layer/p2p/src/initialization.rs
+++ b/base_layer/p2p/src/initialization.rs
@@ -543,7 +543,8 @@ impl ServiceInitializer for P2pInitializer {
                 minor_version: MINOR_NETWORK_VERSION,
                 network_byte: self.network.as_byte(),
                 user_agent: config.user_agent.clone(),
-            });
+            })
+            .set_liveness_check(config.listener_liveness_check_interval);
 
         if config.allow_test_addresses || config.dht.allow_test_addresses {
             // The default is false, so ensure that both settings are true in this case

--- a/base_layer/wallet/src/config.rs
+++ b/base_layer/wallet/src/config.rs
@@ -123,6 +123,7 @@ impl Default for WalletConfig {
     fn default() -> Self {
         let p2p = P2pConfig {
             datastore_path: PathBuf::from("peer_db/wallet"),
+            listener_liveness_check_interval: None,
             ..Default::default()
         };
         Self {

--- a/base_layer/wallet/tests/contacts_service.rs
+++ b/base_layer/wallet/tests/contacts_service.rs
@@ -98,6 +98,7 @@ pub fn setup_contacts_service<T: ContactsBackend + 'static>(
         user_agent: "tari/test-wallet".to_string(),
         rpc_max_simultaneous_sessions: 0,
         rpc_max_sessions_per_peer: 0,
+        listener_liveness_check_interval: None,
     };
     let peer_message_subscription_factory = Arc::new(subscription_factory);
     let shutdown = Shutdown::new();

--- a/base_layer/wallet/tests/wallet.rs
+++ b/base_layer/wallet/tests/wallet.rs
@@ -145,6 +145,7 @@ async fn create_wallet(
         auxiliary_tcp_listener_address: None,
         rpc_max_simultaneous_sessions: 0,
         rpc_max_sessions_per_peer: 0,
+        listener_liveness_check_interval: None,
     };
 
     let sql_database_path = comms_config
@@ -679,6 +680,7 @@ async fn test_import_utxo() {
         auxiliary_tcp_listener_address: None,
         rpc_max_simultaneous_sessions: 0,
         rpc_max_sessions_per_peer: 0,
+        listener_liveness_check_interval: None,
     };
     let config = WalletConfig {
         p2p: comms_config,

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -3919,6 +3919,7 @@ pub unsafe extern "C" fn comms_config_create(
                 user_agent: format!("tari/mobile_wallet/{}", env!("CARGO_PKG_VERSION")),
                 rpc_max_simultaneous_sessions: 0,
                 rpc_max_sessions_per_peer: 0,
+                listener_liveness_check_interval: None,
             };
 
             Box::into_raw(Box::new(config))

--- a/common/config/presets/c_base_node.toml
+++ b/common/config/presets/c_base_node.toml
@@ -178,6 +178,8 @@ track_reorgs = true
 
 # CIDR for addresses allowed to enter into liveness check mode on the listener.
 #listener_liveness_allowlist_cidrs = []
+# Enables periodic socket-level liveness checks. Default: Disabled
+listener_liveness_check_interval = 15
 
 # User agent string for this node
 #user_agent = ""

--- a/common/config/presets/d_console_wallet.toml
+++ b/common/config/presets/d_console_wallet.toml
@@ -201,6 +201,8 @@ event_channel_size = 3500
 
 # CIDR for addresses allowed to enter into liveness check mode on the listener.
 #listener_liveness_allowlist_cidrs = []
+# Enables periodic socket-level liveness checks. Default: Disabled
+# listener_liveness_check_interval = 15
 
 # User agent string for this node
 #user_agent = ""

--- a/comms/core/src/builder/comms_node.rs
+++ b/comms/core/src/builder/comms_node.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{iter, sync::Arc};
+use std::{iter, sync::Arc, time::Duration};
 
 use log::*;
 use tari_shutdown::ShutdownSignal;
@@ -122,6 +122,12 @@ impl UnspawnedCommsNode {
     /// Set the tor hidden service controller to associate with this comms instance
     pub fn with_hidden_service_controller(mut self, hidden_service_ctl: tor::HiddenServiceController) -> Self {
         self.builder.hidden_service_ctl = Some(hidden_service_ctl);
+        self
+    }
+
+    /// Set to true to enable self liveness checking for the configured public address
+    pub fn set_liveness_check(mut self, interval: Option<Duration>) -> Self {
+        self.builder = self.builder.set_liveness_check(interval);
         self
     }
 
@@ -315,6 +321,11 @@ impl CommsNode {
     /// Return the Ip/Tcp address that this node is listening on
     pub fn listening_address(&self) -> &Multiaddr {
         self.listening_info.bind_address()
+    }
+
+    /// Return [ListenerInfo]
+    pub fn listening_info(&self) -> &ListenerInfo {
+        &self.listening_info
     }
 
     /// Return the Ip/Tcp address that this node is listening on

--- a/comms/core/src/builder/mod.rs
+++ b/comms/core/src/builder/mod.rs
@@ -265,6 +265,12 @@ impl CommsBuilder {
         self
     }
 
+    /// Enable and set interval for self-liveness checks, or None to disable it (default)
+    pub fn set_liveness_check(mut self, check_interval: Option<Duration>) -> Self {
+        self.connection_manager_config.liveness_self_check_interval = check_interval;
+        self
+    }
+
     fn make_peer_manager(&mut self) -> Result<Arc<PeerManager>, CommsBuilderError> {
         let file_lock = self.peer_storage_file_lock.take();
 

--- a/comms/core/src/connection_manager/liveness.rs
+++ b/comms/core/src/connection_manager/liveness.rs
@@ -20,14 +20,27 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::future::Future;
+use std::{
+    future::Future,
+    time::{Duration, Instant},
+};
 
-use futures::StreamExt;
-use tokio::io::{AsyncRead, AsyncWrite};
+use futures::{future, SinkExt, StreamExt};
+use log::*;
+use multiaddr::Multiaddr;
+use tari_shutdown::ShutdownSignal;
+use tokio::{
+    io::{AsyncRead, AsyncWrite, AsyncWriteExt},
+    sync::watch,
+    time,
+};
 use tokio_util::codec::{Framed, LinesCodec, LinesCodecError};
+
+use crate::{connection_manager::wire_mode::WireMode, transports::Transport};
 
 /// Max line length accepted by the liveness session.
 const MAX_LINE_LENGTH: usize = 50;
+const LOG_TARGET: &str = "comms::connection_manager::liveness";
 
 /// Echo server for liveness checks
 pub struct LivenessSession<TSocket> {
@@ -46,6 +59,120 @@ where TSocket: AsyncRead + AsyncWrite + Unpin
     pub fn run(self) -> impl Future<Output = Result<(), LinesCodecError>> {
         let (sink, stream) = self.framed.split();
         stream.forward(sink)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum LivenessStatus {
+    Disabled,
+    Checking,
+    Unreachable,
+    Live(Duration),
+}
+
+pub struct LivenessCheck<TTransport> {
+    transport: TTransport,
+    address: Multiaddr,
+    interval: Duration,
+    tx_watch: watch::Sender<LivenessStatus>,
+    shutdown_signal: ShutdownSignal,
+}
+
+impl<TTransport> LivenessCheck<TTransport>
+where
+    TTransport: Transport + Send + Sync + 'static,
+    TTransport::Output: AsyncRead + AsyncWrite + Unpin + Send,
+{
+    pub fn spawn(
+        transport: TTransport,
+        address: Multiaddr,
+        interval: Duration,
+        shutdown_signal: ShutdownSignal,
+    ) -> watch::Receiver<LivenessStatus> {
+        let (tx_watch, rx_watch) = watch::channel(LivenessStatus::Checking);
+        let check = Self {
+            transport,
+            address,
+            interval,
+            tx_watch,
+            shutdown_signal,
+        };
+        tokio::spawn(check.run_until_shutdown());
+        rx_watch
+    }
+
+    pub async fn run_until_shutdown(self) {
+        let shutdown_signal = self.shutdown_signal.clone();
+        let run_fut = self.run();
+        tokio::pin!(run_fut);
+        future::select(run_fut, shutdown_signal).await;
+    }
+
+    pub async fn run(mut self) {
+        info!(
+            target: LOG_TARGET,
+            "🔌️ Starting liveness self-check with interval {:.2?}", self.interval
+        );
+        loop {
+            let timer = Instant::now();
+            let _ = self.tx_watch.send(LivenessStatus::Checking);
+            match self.transport.dial(&self.address).await {
+                Ok(mut socket) => {
+                    info!(target: LOG_TARGET, "🔌 liveness dial took {:.2?}", timer.elapsed());
+                    if let Err(err) = socket.write(&[WireMode::Liveness.as_byte()]).await {
+                        warn!(target: LOG_TARGET, "🔌️ liveness failed to write byte: {}", err);
+                        self.tx_watch.send_replace(LivenessStatus::Unreachable);
+                        continue;
+                    }
+                    let mut framed = Framed::new(socket, LinesCodec::new_with_max_length(MAX_LINE_LENGTH));
+                    loop {
+                        match self.ping_pong(&mut framed).await {
+                            Ok(Some(latency)) => {
+                                info!(target: LOG_TARGET, "⚡️️ liveness check latency {:.2?}", latency);
+                                self.tx_watch.send_replace(LivenessStatus::Live(latency));
+                            },
+                            Ok(None) => {
+                                info!(target: LOG_TARGET, "🔌️ liveness connection closed");
+                                self.tx_watch.send_replace(LivenessStatus::Unreachable);
+                                break;
+                            },
+                            Err(err) => {
+                                warn!(target: LOG_TARGET, "🔌️ ping pong failed: {}", err);
+                                self.tx_watch.send_replace(LivenessStatus::Unreachable);
+                                // let _ = framed.close().await;
+                                break;
+                            },
+                        }
+
+                        time::sleep(self.interval).await;
+                    }
+                },
+                Err(err) => {
+                    self.tx_watch.send_replace(LivenessStatus::Unreachable);
+                    warn!(
+                        target: LOG_TARGET,
+                        "🔌️ Failed to dial public address for self check: {}", err
+                    );
+                },
+            }
+            time::sleep(self.interval).await;
+        }
+    }
+
+    async fn ping_pong(
+        &mut self,
+        framed: &mut Framed<TTransport::Output, LinesCodec>,
+    ) -> Result<Option<Duration>, LinesCodecError> {
+        let timer = Instant::now();
+        framed.send("pingpong".to_string()).await?;
+        match framed.next().await {
+            Some(res) => {
+                let val = res?;
+                debug!(target: LOG_TARGET, "Received: {}", val);
+                Ok(Some(timer.elapsed()))
+            },
+            None => Ok(None),
+        }
     }
 }
 

--- a/comms/core/src/connection_manager/mod.rs
+++ b/comms/core/src/connection_manager/mod.rs
@@ -52,6 +52,8 @@ mod peer_connection;
 pub use peer_connection::{ConnectionId, NegotiatedSubstream, PeerConnection, PeerConnectionRequest};
 
 mod liveness;
+pub use liveness::LivenessStatus;
+
 mod wire_mode;
 
 #[cfg(test)]

--- a/comms/core/src/connection_manager/tests/listener_dialer.rs
+++ b/comms/core/src/connection_manager/tests/listener_dialer.rs
@@ -66,7 +66,7 @@ async fn listen() -> Result<(), Box<dyn Error>> {
         shutdown.to_signal(),
     );
 
-    let mut bind_addr = listener.listen().await?;
+    let (mut bind_addr, _) = listener.listen().await?;
 
     unpack_enum!(Protocol::Memory(port) = bind_addr.pop().unwrap());
     assert!(port > 0);
@@ -103,7 +103,7 @@ async fn smoke() {
     listener.set_supported_protocols(supported_protocols.clone());
 
     // Get the listening address of the peer
-    let address = listener.listen().await.unwrap();
+    let (address, _) = listener.listen().await.unwrap();
 
     let node_identity2 = build_node_identity(PeerFeatures::COMMUNICATION_NODE);
     let noise_config2 = NoiseConfig::new(node_identity2.clone());
@@ -207,7 +207,7 @@ async fn banned() {
     listener.set_supported_protocols(supported_protocols.clone());
 
     // Get the listener address of the peer
-    let address = listener.listen().await.unwrap();
+    let (address, _) = listener.listen().await.unwrap();
 
     let node_identity2 = build_node_identity(PeerFeatures::COMMUNICATION_NODE);
     // The listener has banned the dialer peer

--- a/comms/core/src/connection_manager/wire_mode.rs
+++ b/comms/core/src/connection_manager/wire_mode.rs
@@ -22,11 +22,21 @@
 
 use std::convert::TryFrom;
 
-pub(crate) const LIVENESS_WIRE_MODE: u8 = 0xa6; // E
+pub(crate) const LIVENESS_WIRE_MODE: u8 = 0xa6;
 
+#[derive(Debug, Clone, Copy)]
 pub enum WireMode {
     Comms(u8),
     Liveness,
+}
+
+impl WireMode {
+    pub fn as_byte(self) -> u8 {
+        match self {
+            WireMode::Comms(byte) => byte,
+            WireMode::Liveness => LIVENESS_WIRE_MODE,
+        }
+    }
 }
 
 impl TryFrom<u8> for WireMode {

--- a/comms/core/src/protocol/identity.rs
+++ b/comms/core/src/protocol/identity.rs
@@ -204,9 +204,9 @@ mod test {
     async fn identity_exchange() {
         let transport = MemoryTransport;
         let addr = "/memory/0".parse().unwrap();
-        let (mut listener, addr) = transport.listen(addr).await.unwrap();
+        let (mut listener, addr) = transport.listen(&addr).await.unwrap();
 
-        let (out_sock, in_sock) = future::join(transport.dial(addr), listener.next()).await;
+        let (out_sock, in_sock) = future::join(transport.dial(&addr), listener.next()).await;
 
         let mut out_sock = out_sock.unwrap();
         let (mut in_sock, _) = in_sock.unwrap().unwrap();
@@ -251,9 +251,9 @@ mod test {
     async fn fail_cases() {
         let transport = MemoryTransport;
         let addr = "/memory/0".parse().unwrap();
-        let (mut listener, addr) = transport.listen(addr).await.unwrap();
+        let (mut listener, addr) = transport.listen(&addr).await.unwrap();
 
-        let (out_sock, in_sock) = future::join(transport.dial(addr), listener.next()).await;
+        let (out_sock, in_sock) = future::join(transport.dial(&addr), listener.next()).await;
 
         let mut out_sock = out_sock.unwrap();
         let (mut in_sock, _) = in_sock.unwrap().unwrap();

--- a/comms/core/src/test_utils/transport.rs
+++ b/comms/core/src/test_utils/transport.rs
@@ -31,8 +31,8 @@ use crate::{
 };
 
 pub async fn build_connected_sockets() -> (Multiaddr, MemorySocket, MemorySocket) {
-    let (mut listener, addr) = MemoryTransport.listen("/memory/0".parse().unwrap()).await.unwrap();
-    let (dial_sock, listen_sock) = future::join(MemoryTransport.dial(addr.clone()), listener.next()).await;
+    let (mut listener, addr) = MemoryTransport.listen(&"/memory/0".parse().unwrap()).await.unwrap();
+    let (dial_sock, listen_sock) = future::join(MemoryTransport.dial(&addr), listener.next()).await;
     let (listen_sock, _) = listen_sock.unwrap().unwrap();
     (addr, dial_sock.unwrap(), listen_sock)
 }

--- a/comms/core/src/tor/control_client/client.rs
+++ b/comms/core/src/tor/control_client/client.rs
@@ -62,7 +62,7 @@ impl TorControlPortClient {
     ) -> Result<Self, TorClientError> {
         let mut tcp = TcpTransport::new();
         tcp.set_nodelay(true);
-        let socket = tcp.dial(addr).await?;
+        let socket = tcp.dial(&addr).await?;
         Ok(Self::new(socket, event_tx))
     }
 
@@ -304,7 +304,7 @@ mod test {
     #[runtime::test]
     async fn connect() {
         let (mut listener, addr) = TcpTransport::default()
-            .listen("/ip4/127.0.0.1/tcp/0".parse().unwrap())
+            .listen(&"/ip4/127.0.0.1/tcp/0".parse().unwrap())
             .await
             .unwrap();
         let (event_tx, _) = broadcast::channel(1);

--- a/comms/core/src/transports/dns/mod.rs
+++ b/comms/core/src/transports/dns/mod.rs
@@ -38,6 +38,7 @@ use crate::multiaddr::Multiaddr;
 
 pub type DnsResolverRef = Arc<dyn DnsResolver>;
 
+// TODO: use async_trait
 pub trait DnsResolver: Send + Sync + 'static {
     fn resolve(&self, addr: Multiaddr) -> BoxFuture<'static, Result<SocketAddr, DnsResolverError>>;
 }

--- a/comms/core/src/transports/dns/tor.rs
+++ b/comms/core/src/transports/dns/tor.rs
@@ -48,7 +48,7 @@ impl TorDnsResolver {
     }
 
     pub async fn connect(self) -> Result<TcpSocks5Client, DnsResolverError> {
-        let mut client = connect_inner(self.socks_config.proxy_address)
+        let mut client = connect_inner(&self.socks_config.proxy_address)
             .await
             .map_err(DnsResolverError::ProxyConnectFailed)?;
         client.with_authentication(self.socks_config.authentication)?;
@@ -56,7 +56,7 @@ impl TorDnsResolver {
     }
 }
 
-async fn connect_inner(addr: Multiaddr) -> io::Result<TcpSocks5Client> {
+async fn connect_inner(addr: &Multiaddr) -> io::Result<TcpSocks5Client> {
     let socket = SocksTransport::create_socks_tcp_transport().dial(addr).await?;
     Ok(Socks5Client::new(socket))
 }

--- a/comms/core/src/transports/mod.rs
+++ b/comms/core/src/transports/mod.rs
@@ -61,8 +61,8 @@ pub trait Transport {
     type Listener: Stream<Item = Result<(Self::Output, Multiaddr), Self::Error>> + Send + Unpin;
 
     /// Listen for connections on the given multiaddr
-    async fn listen(&self, addr: Multiaddr) -> Result<(Self::Listener, Multiaddr), Self::Error>;
+    async fn listen(&self, addr: &Multiaddr) -> Result<(Self::Listener, Multiaddr), Self::Error>;
 
     /// Connect (dial) to the given multiaddr
-    async fn dial(&self, addr: Multiaddr) -> Result<Self::Output, Self::Error>;
+    async fn dial(&self, addr: &Multiaddr) -> Result<Self::Output, Self::Error>;
 }

--- a/comms/core/src/transports/tcp.rs
+++ b/comms/core/src/transports/tcp.rs
@@ -125,10 +125,10 @@ impl Transport for TcpTransport {
     type Listener = TcpInbound;
     type Output = TcpStream;
 
-    async fn listen(&self, addr: Multiaddr) -> Result<(Self::Listener, Multiaddr), Self::Error> {
+    async fn listen(&self, addr: &Multiaddr) -> Result<(Self::Listener, Multiaddr), Self::Error> {
         let socket_addr = self
             .dns_resolver
-            .resolve(addr)
+            .resolve(addr.clone())
             .await
             .map_err(|err| io::Error::new(io::ErrorKind::Other, format!("Failed to resolve address: {}", err)))?;
         let listener = TcpListener::bind(&socket_addr).await?;
@@ -136,10 +136,10 @@ impl Transport for TcpTransport {
         Ok((TcpInbound::new(self.clone(), listener), local_addr))
     }
 
-    async fn dial(&self, addr: Multiaddr) -> Result<Self::Output, Self::Error> {
+    async fn dial(&self, addr: &Multiaddr) -> Result<Self::Output, Self::Error> {
         let socket_addr = self
             .dns_resolver
-            .resolve(addr)
+            .resolve(addr.clone())
             .await
             .map_err(|err| io::Error::new(io::ErrorKind::Other, format!("Address resolution failed: {}", err)))?;
 

--- a/comms/core/src/transports/tcp_with_tor.rs
+++ b/comms/core/src/transports/tcp_with_tor.rs
@@ -67,11 +67,11 @@ impl Transport for TcpWithTorTransport {
     type Listener = <TcpTransport as Transport>::Listener;
     type Output = TcpStream;
 
-    async fn listen(&self, addr: Multiaddr) -> Result<(Self::Listener, Multiaddr), Self::Error> {
+    async fn listen(&self, addr: &Multiaddr) -> Result<(Self::Listener, Multiaddr), Self::Error> {
         self.tcp_transport.listen(addr).await
     }
 
-    async fn dial(&self, addr: Multiaddr) -> Result<Self::Output, Self::Error> {
+    async fn dial(&self, addr: &Multiaddr) -> Result<Self::Output, Self::Error> {
         if addr.is_empty() {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
@@ -79,7 +79,7 @@ impl Transport for TcpWithTorTransport {
             ));
         }
 
-        if is_onion_address(&addr) {
+        if is_onion_address(addr) {
             match self.socks_transport {
                 Some(ref transport) => {
                     let socket = transport.dial(addr).await?;


### PR DESCRIPTION
Description
---
- adds socket-level liveness checks
- adds configuration to enable liveness checks (currently enabled by default in base node, disabled in wallet)
- update status line to display liveness status

Motivation and Context
---
Allows us to gain visibility on the base latency of the transport without including overhead of the noise socket and yamux

How Has This Been Tested?
---
Manually
