### PR TITLE
chore: update log4rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1340,6 +1340,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "destructure_traitobject"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c877555693c14d2f84191cfd3ad8582790fc52b5e2274b40b59cf5f5cea25c7"
+
+[[package]]
 name = "diesel"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2432,9 +2438,9 @@ checksum = "a94d21414c1f4a51209ad204c1776a3d0765002c76c6abcb602a6f09f1e881c7"
 
 [[package]]
 name = "log4rs"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "893eaf59f4bef8e2e94302adf56385db445a0306b9823582b0b8d5a06d8822f3"
+checksum = "d36ca1786d9e79b8193a68d480a0907b612f109537115c6ff655a3a1967533fd"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2452,7 +2458,7 @@ dependencies = [
  "serde_yaml",
  "thiserror",
  "thread-id",
- "typemap",
+ "typemap-ors",
  "winapi",
 ]
 
@@ -5889,12 +5895,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "traitobject"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
-
-[[package]]
 name = "trust-dns-client"
 version = "0.21.0-alpha.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5987,12 +5987,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "typemap"
-version = "0.3.3"
+name = "typemap-ors"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "653be63c80a3296da5551e1bfd2cca35227e13cdd08c6668903ae2f4f77aa1f6"
+checksum = "a68c24b707f02dd18f1e4ccceb9d49f2058c2fb86384ef9972592904d7a28867"
 dependencies = [
- "unsafe-any",
+ "unsafe-any-ors",
 ]
 
 [[package]]
@@ -6078,12 +6078,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "unsafe-any"
-version = "0.4.2"
+name = "unsafe-any-ors"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30360d7979f5e9c6e6cea48af192ea8fab4afb3cf72597154b8f08935bc9c7f"
+checksum = "e0a303d30665362d9680d7d91d78b23f5f899504d4f08b3c4cf08d055d87c0ad"
 dependencies = [
- "traitobject",
+ "destructure_traitobject",
 ]
 
 [[package]]

--- a/base_layer/wallet/Cargo.toml
+++ b/base_layer/wallet/Cargo.toml
@@ -43,7 +43,7 @@ futures = { version = "^0.3.1", features = ["compat", "std"] }
 libsqlite3-sys = { version = "0.22.2", features = ["bundled"], optional = true }
 lmdb-zero = "0.4.4"
 log = "0.4.6"
-log4rs = { version = "1.0.0", features = ["console_appender", "file_appender", "yaml_format"] }
+log4rs = { version = "1.2.0", features = ["console_appender", "file_appender", "yaml_format"] }
 rand = "0.7.3"
 serde = { version = "1.0.89", features = ["derive"] }
 serde_json = "1.0.39"

--- a/base_layer/wallet_ffi/Cargo.toml
+++ b/base_layer/wallet_ffi/Cargo.toml
@@ -24,7 +24,7 @@ chrono = { version = "0.4.19", default-features = false, features = ["serde"] }
 futures =  { version = "^0.3.1", features =["compat", "std"]}
 libc = "0.2.65"
 log = "0.4.6"
-log4rs = {version = "1.0.0", features = ["console_appender", "file_appender", "yaml_format"]}
+log4rs = {version = "1.2.0", features = ["console_appender", "file_appender", "yaml_format"]}
 # Needs to be higher than 0.10.41 to address a security issue
 openssl = { version = "0.10.41", features = ["vendored"] }
 rand = "0.7.3"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -23,7 +23,7 @@ dirs-next = "1.0.2"
 fs2 = "0.4.3"
 git2 = { version = "0.8", optional = true }
 log = "0.4.8"
-log4rs = { version = "1.0.0", default_features = false, features = ["config_parsing", "threshold_filter", "yaml_format"] }
+log4rs = { version = "1.2.0", default_features = false, features = ["config_parsing", "threshold_filter", "yaml_format"] }
 multiaddr = { version = "0.14.0" }
 path-clean = "0.1.0"
 prost-build = { version = "0.9.0", optional = true }

--- a/infrastructure/libtor/Cargo.toml
+++ b/infrastructure/libtor/Cargo.toml
@@ -11,7 +11,7 @@ tari_shutdown = { version = "^0.38", path = "../shutdown"}
 
 derivative = "2.2.0"
 log = "0.4.8"
-log4rs = { version = "1.0.0", default_features = false, features = ["config_parsing", "threshold_filter", "yaml_format"] }
+log4rs = { version = "1.2.0", default_features = false, features = ["config_parsing", "threshold_filter", "yaml_format"] }
 multiaddr = { version = "0.14.0" }
 rand = "0.7.3"
 tempfile = "3.1.0"


### PR DESCRIPTION
Description
---
Finally updates log4rs to remove a vuln in `traitobject`

Motivation and Context
---
https://rustsec.org/advisories/RUSTSEC-2020-0027

How Has This Been Tested?
---

