### PR TITLE
fix: reduce buffer allocation size

### DIFF
--- a/comms/dht/src/crypt.rs
+++ b/comms/dht/src/crypt.rs
@@ -99,7 +99,7 @@ fn pad_message_to_base_length_multiple(
         get_message_padding_length(message.len().checked_sub(additional_prefix_space).ok_or_else(|| {
             DhtEncryptError::PaddingError("Message length shorter than the additional_prefix_space".to_string())
         })?);
-    message.reserve(message.len() + padding_length);
+    message.reserve(padding_length);
     message.extend(iter::repeat(0u8).take(padding_length));
 
     Ok(())


### PR DESCRIPTION
Description
---
Reduces the size of a buffer allocation when padding messages for encryption.

Closes [issue 4829](https://github.com/tari-project/tari/issues/4829).

Motivation and Context
---
As noted in [issue 4829](https://github.com/tari-project/tari/issues/4829), the `BytesMut` used to hold messages during padding and encryption allocates more space than is needed, possibly due to a mistaken assumption of the behavior of `reserve(...)`. This PR ensures that the minimum number of extra bytes needed for padding is reserved, avoiding unnecessarily large allocation.

How Has This Been Tested?
---
Existing tests.

