### PR TITLE
feat: make build_script_challenge public

### DIFF
--- a/base_layer/core/src/transactions/transaction_components/transaction_input.rs
+++ b/base_layer/core/src/transactions/transaction_components/transaction_input.rs
@@ -159,7 +159,7 @@ impl TransactionInput {
         };
     }
 
-    pub(super) fn build_script_challenge(
+    pub fn build_script_challenge(
         version: TransactionInputVersion,
         nonce_commitment: &Commitment,
         script: &TariScript,


### PR DESCRIPTION
Description
---
Made `build_script_challenge` public

Motivation and Context
---
Some clients need to calculate the script signature's challenge independently.

How Has This Been Tested?
---
Tested with an external client.
