### PR TITLE
docs: improve m-of-n opcode docs

### DIFF
--- a/infrastructure/tari_script/src/op_codes.rs
+++ b/infrastructure/tari_script/src/op_codes.rs
@@ -229,14 +229,17 @@ pub enum Opcode {
     /// Identical to CheckSig, except that nothing is pushed to the stack if the signature is valid, and the operation
     /// fails with VERIFY_FAILED if the signature is invalid.
     CheckSigVerify(Box<Message>),
-    /// Pop m signatures from the stack. If m signatures out of the provided n public keys sign the 32-byte message,
-    /// push 1 to the stack, otherwise push 0.
+    /// Pops exactly m signatures from the stack. This will fail if a public key is used more than once or there are
+    /// more then m signatures. If all m signatures are out of the provided n public keys sign the 32-byte message,
+    /// pushes 1 to the stack, otherwise pushes 0.
     CheckMultiSig(u8, u8, Vec<RistrettoPublicKey>, Box<Message>),
-    /// Identical to CheckMultiSig, except that nothing is pushed to the stack if the m signatures are valid, and the
-    /// operation fails with VERIFY_FAILED if any of the signatures are invalid.
+    /// Pops exactly m signatures from the stack. This will fail if a public key is used more than once or there are
+    /// more then m signatures. If all m signatures are out of the provided n public keys sign the 32-byte message
+    /// nothing is pushed to the stack, otherwise fails with VERIFY_FAILED.
     CheckMultiSigVerify(u8, u8, Vec<RistrettoPublicKey>, Box<Message>),
-    /// Pop m signatures from the stack. If m signatures out of the provided n public keys sign the 32-byte message,
-    /// push the aggregate of the public keys to the stack, otherwise fails with VERIFY_FAILED.
+    /// Pops exactly m signatures from the stack. This will fail if a public key is used more than once or there are
+    /// more then m signatures. If all m signatures are out of the provided n public keys sign the 32-byte message,
+    /// pushes the aggregate of the public keys to the stack, otherwise fails with VERIFY_FAILED.
     CheckMultiSigVerifyAggregatePubKey(u8, u8, Vec<RistrettoPublicKey>, Box<Message>),
     /// Pops the top element which must be a valid 32-byte scalar or hash and calculates the corresponding Ristretto
     /// point, and pushes the result to the stack. Fails with EMPTY_STACK if the stack is empty.

--- a/infrastructure/tari_script/src/op_codes.rs
+++ b/infrastructure/tari_script/src/op_codes.rs
@@ -229,17 +229,17 @@ pub enum Opcode {
     /// Identical to CheckSig, except that nothing is pushed to the stack if the signature is valid, and the operation
     /// fails with VERIFY_FAILED if the signature is invalid.
     CheckSigVerify(Box<Message>),
-    /// Pops exactly m signatures from the stack. This will fail if a public key is used more than once or there are
-    /// more then m signatures. If all m signatures are out of the provided n public keys sign the 32-byte message,
+    /// Pops exactly m signatures from the stack. This will fail if a public key is used more than once or if there are
+    /// more than m signatures. If all m signatures are out of the provided n public keys sign the 32-byte message,
     /// pushes 1 to the stack, otherwise pushes 0.
     CheckMultiSig(u8, u8, Vec<RistrettoPublicKey>, Box<Message>),
-    /// Pops exactly m signatures from the stack. This will fail if a public key is used more than once or there are
-    /// more then m signatures. If all m signatures are out of the provided n public keys sign the 32-byte message
-    /// nothing is pushed to the stack, otherwise fails with VERIFY_FAILED.
+    /// Pops exactly m signatures from the stack. This will fail if a public key is used more than once or if there are
+    /// more than m signatures. If all m signatures are out of the provided n public keys sign the 32-byte message
+    /// nothing is pushed to the stack, otherwise, the script fails with VERIFY_FAILED.
     CheckMultiSigVerify(u8, u8, Vec<RistrettoPublicKey>, Box<Message>),
-    /// Pops exactly m signatures from the stack. This will fail if a public key is used more than once or there are
-    /// more then m signatures. If all m signatures are out of the provided n public keys sign the 32-byte message,
-    /// pushes the aggregate of the public keys to the stack, otherwise fails with VERIFY_FAILED.
+    /// Pops exactly m signatures from the stack. This will fail if a public key is used more than once or if there are
+    /// more than m signatures. If all m signatures are out of the provided n public keys sign the 32-byte message,
+    /// pushes the aggregate of the public keys to the stack, otherwise, the script fails with VERIFY_FAILED.
     CheckMultiSigVerifyAggregatePubKey(u8, u8, Vec<RistrettoPublicKey>, Box<Message>),
     /// Pops the top element which must be a valid 32-byte scalar or hash and calculates the corresponding Ristretto
     /// point, and pushes the result to the stack. Fails with EMPTY_STACK if the stack is empty.


### PR DESCRIPTION
Description
---
Improves the docs of the multi-sig opcodes to give a better indication of edge cases etc. 
Multi-sig behavior is properly discussed here: https://github.com/tari-project/tari/blob/6227cd2b02f39d765a07eca78d4d091c0c599d21/infrastructure/tari_script/src/script.rs#L508

But this is a private function. Most users will only ever see the opcodes when using this.  


Fixes: #4820 
