### PR TITLE
fix(base-node): use Network::from_str to parse network in cli

### DIFF
--- a/applications/tari_base_node/src/cli.rs
+++ b/applications/tari_base_node/src/cli.rs
@@ -49,21 +49,17 @@ pub(crate) struct Cli {
     pub watch: Option<String>,
     /// Supply a network (overrides existing configuration)
     #[clap(long, env = "TARI_NETWORK")]
-    pub network: Option<String>,
+    pub network: Option<Network>,
 }
 
 impl ConfigOverrideProvider for Cli {
     fn get_config_property_overrides(&self, default_network: Network) -> Vec<(String, String)> {
         let mut overrides = self.common.get_config_property_overrides(default_network);
-        let network = self
-            .network
-            .as_ref()
-            .cloned()
-            .unwrap_or_else(|| default_network.to_string());
+        let network = self.network.unwrap_or(default_network);
         overrides.push(("base_node.override_from".to_string(), network.to_string()));
         overrides.push(("p2p.seeds.override_from".to_string(), network.to_string()));
         overrides.push(("auto_update.override_from".to_string(), network.to_string()));
-        overrides.push(("metrics.override_from".to_string(), network));
+        overrides.push(("metrics.override_from".to_string(), network.to_string()));
         overrides
     }
 }

--- a/applications/tari_base_node/src/main.rs
+++ b/applications/tari_base_node/src/main.rs
@@ -85,7 +85,7 @@ mod metrics;
 mod recovery;
 mod utils;
 
-use std::{env, process, str::FromStr, sync::Arc};
+use std::{env, process, sync::Arc};
 
 use clap::Parser;
 use commands::{cli_loop::CliLoop, command::CommandContext};
@@ -94,10 +94,7 @@ use log::*;
 use opentelemetry::{self, global, KeyValue};
 use tari_app_utilities::{consts, identity_management::setup_node_identity, utilities::setup_runtime};
 use tari_common::{
-    configuration::{
-        bootstrap::{grpc_default_port, ApplicationType},
-        Network,
-    },
+    configuration::bootstrap::{grpc_default_port, ApplicationType},
     exit_codes::{ExitCode, ExitError},
     initialize_logging,
     load_configuration,
@@ -149,8 +146,8 @@ fn main_inner() -> Result<(), ExitError> {
     )?;
 
     let mut config = ApplicationConfig::load_from(&cfg)?;
-    if let Some(network) = &cli.network {
-        config.base_node.network = Network::from_str(network)?;
+    if let Some(network) = cli.network {
+        config.base_node.network = network;
     }
     debug!(target: LOG_TARGET, "Using base node configuration: {:?}", config);
 

--- a/applications/tari_console_wallet/src/cli.rs
+++ b/applications/tari_console_wallet/src/cli.rs
@@ -81,7 +81,7 @@ pub(crate) struct Cli {
     pub command_mode_auto_exit: bool,
     /// Supply a network (overrides existing configuration)
     #[clap(long, env = "TARI_NETWORK")]
-    pub network: Option<String>,
+    pub network: Option<Network>,
     #[clap(long, env = "TARI_WALLET_ENABLE_GRPC", alias = "enable-grpc")]
     pub grpc_enabled: bool,
     #[clap(long, env = "TARI_WALLET_GRPC_ADDRESS")]
@@ -93,10 +93,10 @@ pub(crate) struct Cli {
 impl ConfigOverrideProvider for Cli {
     fn get_config_property_overrides(&self, default_network: Network) -> Vec<(String, String)> {
         let mut overrides = self.common.get_config_property_overrides(default_network);
-        let network = self.network.clone().unwrap_or_else(|| default_network.to_string());
-        overrides.push(("wallet.network".to_string(), network.clone()));
-        overrides.push(("wallet.override_from".to_string(), network.clone()));
-        overrides.push(("p2p.seeds.override_from".to_string(), network));
+        let network = self.network.unwrap_or(default_network);
+        overrides.push(("wallet.network".to_string(), network.to_string()));
+        overrides.push(("wallet.override_from".to_string(), network.to_string()));
+        overrides.push(("p2p.seeds.override_from".to_string(), network.to_string()));
         // Either of these configs enable grpc
         if let Some(ref addr) = self.grpc_address {
             overrides.push(("wallet.grpc_enabled".to_string(), "true".to_string()));

--- a/applications/tari_merge_mining_proxy/src/cli.rs
+++ b/applications/tari_merge_mining_proxy/src/cli.rs
@@ -32,14 +32,14 @@ pub(crate) struct Cli {
     pub common: CommonCliArgs,
     /// Supply a network (overrides existing configuration)
     #[clap(long, env = "TARI_NETWORK")]
-    pub network: Option<String>,
+    pub network: Option<Network>,
 }
 
 impl ConfigOverrideProvider for Cli {
     fn get_config_property_overrides(&self, default_network: Network) -> Vec<(String, String)> {
         let mut overrides = self.common.get_config_property_overrides(default_network);
-        let network = self.network.clone().unwrap_or_else(|| default_network.to_string());
-        overrides.push(("merge_mining_proxy.override_from".to_string(), network));
+        let network = self.network.unwrap_or(default_network);
+        overrides.push(("merge_mining_proxy.override_from".to_string(), network.to_string()));
         overrides
     }
 }


### PR DESCRIPTION
Description
---
- parses network in cli using Network::from_str
- fixes bug where valid network string 'esme' would break config overrides

Motivation and Context
---
Bug fix, using --network esme would result in different configuration from --network esmeralda

How Has This Been Tested?
---
Manually, `--network esme`
