### PR TITLE
feat: add more detailed error mapping for the ffi

### DIFF
--- a/base_layer/wallet_ffi/src/error.rs
+++ b/base_layer/wallet_ffi/src/error.rs
@@ -313,6 +313,35 @@ impl From<WalletError> for LibWalletError {
                 code: 432,
                 message: format!("{:?}", w),
             },
+            WalletError::WalletStorageError(WalletStorageError::IoError(_)) => Self {
+                code: 433,
+                message: format!("{:?}", w),
+            },
+            WalletError::WalletStorageError(WalletStorageError::FileError(_)) => Self {
+                code: 434,
+                message: format!("{:?}", w),
+            },
+            // these are general catch errors to try and reduce 999 when we get it with zero additional logging
+            WalletError::SetLoggerError(_) => Self {
+                code: 994,
+                message: format!("{:?}", w),
+            },
+            WalletError::ConnectivityError(_) => Self {
+                code: 995,
+                message: format!("{:?}", w),
+            },
+            WalletError::ServiceInitializationError(_) => Self {
+                code: 996,
+                message: format!("{:?}", w),
+            },
+            WalletError::CommsInitializationError(_) => Self {
+                code: 997,
+                message: format!("{:?}", w),
+            },
+            WalletError::WalletStorageError(_) => Self {
+                code: 998,
+                message: format!("{:?}", w),
+            },
             // This is the catch all error code. Any error that is not explicitly mapped above will be given this code
             _ => Self {
                 code: 999,


### PR DESCRIPTION
Description
---
This adds more detailed error mapping for the FFI.

Motivation and Context
---
On sentry we get error 999, which is the general mapping for all error types without any other error logging with it. 
This is an attempt to get back more information to narrow down which error is causing the 999 without any logging. 
