### PR TITLE
fix: list-connections

### DIFF
--- a/applications/tari_base_node/src/commands/command/list_connections.rs
+++ b/applications/tari_base_node/src/commands/command/list_connections.rs
@@ -124,7 +124,7 @@ impl CommandContext {
         println!();
         println!("Wallets");
         println!("-------");
-        if nodes.is_empty() {
+        if clients.is_empty() {
             println!("No active wallet connections.");
         } else {
             println!();


### PR DESCRIPTION
Description
---
List-connections command prints wallets only if there are base node connections.

How Has This Been Tested?
---
Manually.

