### PR TITLE
fix(dht): zeroize AEAD keys on drop

### DIFF
--- a/comms/dht/src/crypt.rs
+++ b/comms/dht/src/crypt.rs
@@ -59,6 +59,9 @@ use crate::{
 #[derive(Debug, Clone, Zeroize)]
 #[zeroize(drop)]
 pub struct CipherKey(chacha20::Key);
+
+#[derive(Debug, Clone, Zeroize)]
+#[zeroize(drop)]
 pub struct AuthenticatedCipherKey(chacha20poly1305::Key);
 
 const MESSAGE_BASE_LENGTH: usize = 6000;


### PR DESCRIPTION
Description
---
Zeroizes authenticated encryption keys (via the `AuthenticatedCipherKey` struct) on drop. Fixes [issue 4842](https://github.com/tari-project/tari/issues/4842).

Motivation and Context
---
Authenticated encryption (AEAD) keys are intended to be zeroized on drop, but the relevant macros are not applied. This work adds the macros.

How Has This Been Tested?
---
Manually tested that `Zeroize` was not supported previously, and is supported now.

