### PR TITLE
fix(dht): use new DHKE shared secret type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,12 +234,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "base-x"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
-
-[[package]]
 name = "base58-monero"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -510,7 +504,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c24dab4283a142afa2fdca129b80ad2c6284e073930f964c3a1293c225ee39a"
 dependencies = [
- "rustc_version 0.4.0",
+ "rustc_version",
 ]
 
 [[package]]
@@ -1315,7 +1309,7 @@ dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "rustc_version 0.4.0",
+ "rustc_version",
  "syn",
 ]
 
@@ -1425,12 +1419,6 @@ dependencies = [
  "redox_users",
  "winapi",
 ]
-
-[[package]]
-name = "discard"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
 name = "dlv-list"
@@ -1786,11 +1774,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
  "cfg-if 1.0.0",
- "js-sys",
  "libc",
- "stdweb",
  "wasi 0.9.0+wasi-snapshot-preview1",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -3889,20 +3874,11 @@ checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustc_version"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-dependencies = [
- "semver 0.9.0",
-]
-
-[[package]]
-name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.14",
+ "semver",
 ]
 
 [[package]]
@@ -4082,24 +4058,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
@@ -4351,7 +4312,7 @@ dependencies = [
  "chacha20poly1305",
  "curve25519-dalek 4.0.0-pre.2",
  "rand_core 0.6.4",
- "rustc_version 0.4.0",
+ "rustc_version",
  "sha2 0.10.6",
  "subtle",
 ]
@@ -4383,57 +4344,6 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "stdweb"
-version = "0.4.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
-dependencies = [
- "discard",
- "rustc_version 0.2.3",
- "serde",
- "serde_json",
- "stdweb-derive",
- "stdweb-internal-macros",
- "stdweb-internal-runtime",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "stdweb-derive"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde",
- "serde_derive",
- "syn",
-]
-
-[[package]]
-name = "stdweb-internal-macros"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
-dependencies = [
- "base-x",
- "proc-macro2",
- "quote",
- "serde",
- "serde_derive",
- "serde_json",
- "sha1 0.6.0",
- "syn",
-]
-
-[[package]]
-name = "stdweb-internal-runtime"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
 name = "str-buf"
@@ -4966,8 +4876,8 @@ dependencies = [
 
 [[package]]
 name = "tari_crypto"
-version = "0.15.6"
-source = "git+https://github.com/tari-project/tari-crypto.git?tag=v0.15.6#d4f645403c6165534474338328582979a73d2b15"
+version = "0.15.7"
+source = "git+https://github.com/tari-project/tari-crypto.git?tag=v0.15.7#bd66b3d2021bf0b391d50f1ba8db339a62231738"
 dependencies = [
  "base64 0.10.1",
  "blake2 0.9.2",
@@ -5179,7 +5089,7 @@ dependencies = [
  "rand 0.7.3",
  "reqwest",
  "rustls",
- "semver 1.0.14",
+ "semver",
  "serde",
  "serde_derive",
  "tari_common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1774,8 +1774,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
  "cfg-if 1.0.0",
+ "js-sys",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -4884,6 +4886,7 @@ dependencies = [
  "cbindgen 0.17.0",
  "curve25519-dalek 3.2.1",
  "digest 0.9.0",
+ "getrandom 0.2.7",
  "lazy_static",
  "log",
  "merlin 2.0.1",
@@ -4896,6 +4899,7 @@ dependencies = [
  "tari_bulletproofs_plus",
  "tari_utilities",
  "thiserror",
+ "wasm-bindgen",
  "zeroize",
 ]
 

--- a/applications/tari_app_grpc/Cargo.toml
+++ b/applications/tari_app_grpc/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 tari_common_types = { version = "^0.38", path = "../../base_layer/common_types" }
 tari_comms = { path = "../../comms/core" }
 tari_core = { path = "../../base_layer/core" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.6" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.7" }
 tari_script = { path = "../../infrastructure/tari_script" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag="v0.4.7" }
 

--- a/applications/tari_app_utilities/Cargo.toml
+++ b/applications/tari_app_utilities/Cargo.toml
@@ -7,7 +7,7 @@ license = "BSD-3-Clause"
 
 [dependencies]
 tari_comms = { path = "../../comms/core" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.6" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.7" }
 tari_common = { path = "../../common" }
 tari_common_types = { path = "../../base_layer/common_types" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag="v0.4.7" }

--- a/applications/tari_base_node/Cargo.toml
+++ b/applications/tari_base_node/Cargo.toml
@@ -15,7 +15,7 @@ tari_comms = { path = "../../comms/core", features = ["rpc"] }
 tari_common_types = { path = "../../base_layer/common_types" }
 tari_comms_dht = { path = "../../comms/dht" }
 tari_core = { path = "../../base_layer/core", default-features = false, features = ["transactions"] }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.6" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.7" }
 tari_libtor = { path = "../../infrastructure/libtor", optional = true }
 tari_mmr = { path = "../../base_layer/mmr", features = ["native_bitmap"] }
 tari_p2p = { path = "../../base_layer/p2p", features = ["auto-update"] }

--- a/applications/tari_console_wallet/Cargo.toml
+++ b/applications/tari_console_wallet/Cargo.toml
@@ -7,7 +7,7 @@ license = "BSD-3-Clause"
 
 [dependencies]
 tari_wallet = { path = "../../base_layer/wallet", features = ["bundled_sqlite"] }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.6" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.7" }
 tari_common = { path = "../../common" }
 tari_app_utilities = { path = "../tari_app_utilities" }
 tari_comms = { path = "../../comms/core" }

--- a/applications/tari_merge_mining_proxy/Cargo.toml
+++ b/applications/tari_merge_mining_proxy/Cargo.toml
@@ -15,7 +15,7 @@ tari_common = { path = "../../common" }
 tari_comms = { path = "../../comms/core" }
 tari_core = { path = "../../base_layer/core", default-features = false, features = ["transactions"] }
 tari_app_utilities = { path = "../tari_app_utilities" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.6" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.7" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag="v0.4.7" }
 tari_base_node_grpc_client = {path="../../clients/rust/base_node_grpc_client" }
 tari_wallet_grpc_client = {path="../../clients/rust/wallet_grpc_client" }

--- a/applications/tari_miner/Cargo.toml
+++ b/applications/tari_miner/Cargo.toml
@@ -14,7 +14,7 @@ tari_common_types = { path = "../../base_layer/common_types" }
 tari_comms = { path = "../../comms/core" }
 tari_app_utilities = { path = "../tari_app_utilities" }
 tari_app_grpc = { path = "../tari_app_grpc" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.6" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.7" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag="v0.4.7" }
 
 crossterm = { version = "0.25.0" }

--- a/base_layer/common_types/Cargo.toml
+++ b/base_layer/common_types/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.38.8"
 edition = "2018"
 
 [dependencies]
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.6" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.7" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag="v0.4.7" }
 
 base64 = "0.13.0"

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -24,7 +24,7 @@ tari_common_types = { version = "^0.38", path = "../../base_layer/common_types" 
 tari_comms = { version = "^0.38", path = "../../comms/core" }
 tari_comms_dht = { version = "^0.38", path = "../../comms/dht" }
 tari_comms_rpc_macros = { version = "^0.38", path = "../../comms/rpc_macros" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.6" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.7" }
 tari_metrics = { path = "../../infrastructure/metrics" }
 tari_mmr = { version = "^0.38", path = "../../base_layer/mmr", optional = true, features = ["native_bitmap"] }
 tari_p2p = { version = "^0.38", path = "../../base_layer/p2p" }

--- a/base_layer/key_manager/Cargo.toml
+++ b/base_layer/key_manager/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["lib", "cdylib"]
 # NB: All dependencies must support or be gated for the WASM target.
 [dependencies]
 tari_common_types = { version = "^0.38", path = "../../base_layer/common_types", optional = true }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.6" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.7" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag="v0.4.7" }
 
 arrayvec = "0.7.1"

--- a/base_layer/key_manager/Cargo.toml
+++ b/base_layer/key_manager/Cargo.toml
@@ -43,4 +43,4 @@ wasm-bindgen-test = "0.3.28"
 [features]
 avx2 = ["tari_crypto/simd_backend"]
 js = ["getrandom/js", "js-sys"]
-wasm = ["wasm-bindgen", "js", "tari_common_types", "console_error_panic_hook"]
+wasm = ["tari_crypto/wasm", "wasm-bindgen", "js", "tari_common_types", "console_error_panic_hook"]

--- a/base_layer/mmr/Cargo.toml
+++ b/base_layer/mmr/Cargo.toml
@@ -14,7 +14,7 @@ benches = ["criterion"]
 
 [dependencies]
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag="v0.4.7" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.6" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.7" }
 tari_common = {path = "../../common"}
 thiserror = "1.0.26"
 digest = "0.9.0"

--- a/base_layer/p2p/Cargo.toml
+++ b/base_layer/p2p/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 tari_comms = { version = "^0.38", path = "../../comms/core" }
 tari_comms_dht = { version = "^0.38", path = "../../comms/dht" }
 tari_common = { version = "^0.38", path = "../../common" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.6" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.7" }
 tari_service_framework = { version = "^0.38", path = "../service_framework" }
 tari_shutdown = { version = "^0.38", path = "../../infrastructure/shutdown" }
 tari_storage = { version = "^0.38", path = "../../infrastructure/storage" }

--- a/base_layer/tari_mining_helper_ffi/Cargo.toml
+++ b/base_layer/tari_mining_helper_ffi/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 tari_comms = { version = "^0.38", path = "../../comms/core" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.6" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.7" }
 tari_common = {  path = "../../common" }
 tari_core = {  path = "../core", default-features = false, features = ["transactions"]}
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag="v0.4.7" }

--- a/base_layer/wallet/Cargo.toml
+++ b/base_layer/wallet/Cargo.toml
@@ -12,7 +12,7 @@ tari_common = { path = "../../common" }
 tari_common_types = { version = "^0.38", path = "../../base_layer/common_types" }
 tari_comms = { version = "^0.38", path = "../../comms/core" }
 tari_comms_dht = { version = "^0.38", path = "../../comms/dht" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.6" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.7" }
 tari_key_manager = { version = "^0.38", path = "../key_manager" }
 tari_p2p = { version = "^0.38", path = "../p2p", features = ["auto-update"] }
 tari_script = { path = "../../infrastructure/tari_script" }

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -2558,11 +2558,7 @@ where
                         // match found
                         Some(matched_key) => {
                             match PrivateKey::from_bytes(
-                                CommsDHKE::new(
-                                    &matched_key.private_key,
-                                    &output.sender_offset_public_key,
-                                )
-                                .as_bytes(),
+                                CommsDHKE::new(&matched_key.private_key, &output.sender_offset_public_key).as_bytes(),
                             ) {
                                 Ok(spending_sk) => scanned_outputs.push((
                                     output.clone(),

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -32,7 +32,7 @@ use tari_common_types::{
     transaction::TxId,
     types::{BlockHash, Commitment, HashOutput, PrivateKey, PublicKey},
 };
-use tari_comms::{types::CommsPublicKey, NodeIdentity};
+use tari_comms::{types::CommsDHKE, NodeIdentity};
 use tari_core::{
     consensus::{ConsensusConstants, ConsensusEncodingSized},
     covenants::Covenant,
@@ -62,7 +62,7 @@ use tari_core::{
 use tari_crypto::{
     commitment::HomomorphicCommitmentFactory,
     errors::RangeProofError,
-    keys::{DiffieHellmanSharedSecret, PublicKey as PublicKeyTrait, SecretKey},
+    keys::{PublicKey as PublicKeyTrait, SecretKey},
     ristretto::RistrettoSecretKey,
 };
 use tari_script::{inputs, script, Opcode, TariScript};
@@ -2322,7 +2322,7 @@ where
         fee_per_gram: MicroTari,
     ) -> Result<(TxId, MicroTari, MicroTari, Transaction), OutputManagerError> {
         let spending_key = PrivateKey::from_bytes(
-            CommsPublicKey::shared_secret(
+            CommsDHKE::new(
                 self.node_identity.as_ref().secret_key(),
                 &output.sender_offset_public_key,
             )
@@ -2558,7 +2558,7 @@ where
                         // match found
                         Some(matched_key) => {
                             match PrivateKey::from_bytes(
-                                CommsPublicKey::shared_secret(
+                                CommsDHKE::new(
                                     &matched_key.private_key,
                                     &output.sender_offset_public_key,
                                 )
@@ -2591,7 +2591,7 @@ where
                     // computing shared secret
                     let shared_secret = PrivateKey::from_bytes(
                         WalletHasher::new_with_label("stealth_address")
-                            .chain(PublicKey::shared_secret(&wallet_sk, nonce.as_ref()).as_bytes())
+                            .chain(CommsDHKE::new(&wallet_sk, nonce.as_ref()).as_bytes())
                             .finalize()
                             .as_ref(),
                     )
@@ -2603,7 +2603,7 @@ where
                     }
 
                     match PrivateKey::from_bytes(
-                        CommsPublicKey::shared_secret(&wallet_sk, &output.sender_offset_public_key).as_bytes(),
+                        CommsDHKE::new(&wallet_sk, &output.sender_offset_public_key).as_bytes(),
                     ) {
                         Ok(spending_sk) => scanned_outputs.push((
                             output.clone(),

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -37,7 +37,10 @@ use tari_common_types::{
     transaction::{ImportStatus, TransactionDirection, TransactionStatus, TxId},
     types::{PrivateKey, PublicKey},
 };
-use tari_comms::{peer_manager::NodeIdentity, types::{CommsDHKE, CommsPublicKey}};
+use tari_comms::{
+    peer_manager::NodeIdentity,
+    types::{CommsDHKE, CommsPublicKey},
+};
 use tari_comms_dht::outbound::OutboundMessageRequester;
 use tari_core::{
     covenants::Covenant,
@@ -1062,10 +1065,9 @@ where
             .get_recipient_sender_offset_private_key(0)
             .map_err(|e| TransactionServiceProtocolError::new(tx_id, e.into()))?;
 
-        let spend_key = PrivateKey::from_bytes(
-            CommsDHKE::new(&sender_offset_private_key.clone(), &dest_pubkey.clone()).as_bytes(),
-        )
-        .map_err(|e| TransactionServiceProtocolError::new(tx_id, e.into()))?;
+        let spend_key =
+            PrivateKey::from_bytes(CommsDHKE::new(&sender_offset_private_key.clone(), &dest_pubkey.clone()).as_bytes())
+                .map_err(|e| TransactionServiceProtocolError::new(tx_id, e.into()))?;
 
         let sender_message = TransactionSenderMessage::new_single_round_message(stp.get_single_round_message()?);
         let rewind_blinding_key = PrivateKey::from_bytes(&hash_secret_key(&spend_key))?;
@@ -1223,10 +1225,9 @@ where
         let sender_offset_private_key = stp
             .get_recipient_sender_offset_private_key(0)
             .map_err(|e| TransactionServiceProtocolError::new(tx_id, e.into()))?;
-        let spend_key = PrivateKey::from_bytes(
-            CommsDHKE::new(&sender_offset_private_key, &dest_pubkey.clone()).as_bytes(),
-        )
-        .map_err(|e| TransactionServiceProtocolError::new(tx_id, e.into()))?;
+        let spend_key =
+            PrivateKey::from_bytes(CommsDHKE::new(&sender_offset_private_key, &dest_pubkey.clone()).as_bytes())
+                .map_err(|e| TransactionServiceProtocolError::new(tx_id, e.into()))?;
 
         let sender_message = TransactionSenderMessage::new_single_round_message(stp.get_single_round_message()?);
         let rewind_blinding_key = PrivateKey::from_bytes(&hash_secret_key(&spend_key))?;

--- a/base_layer/wallet_ffi/Cargo.toml
+++ b/base_layer/wallet_ffi/Cargo.toml
@@ -12,7 +12,7 @@ tari_common = {path="../../common"}
 tari_common_types = {path="../common_types"}
 tari_comms = { version = "^0.38", path = "../../comms/core", features = ["c_integration"]}
 tari_comms_dht = { version = "^0.38", path = "../../comms/dht", default-features = false }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.6" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.7" }
 tari_key_manager = { version = "^0.38", path = "../key_manager" }
 tari_p2p = { version = "^0.38", path = "../p2p" }
 tari_script = { path = "../../infrastructure/tari_script" }

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -109,10 +109,12 @@ struct P2pConfig;
  *
  * let mut rng = rand::thread_rng();
  * let _p1 = RistrettoPublicKey::from_bytes(&[
- *     224, 196, 24, 247, 200, 217, 196, 205, 215, 57, 91, 147, 234, 18, 79, 58, 217, 144, 33, 187, 104, 29, 252, 51,
- *     2, 169, 217, 154, 46, 83, 230, 78,
+ *     224, 196, 24, 247, 200, 217, 196, 205, 215, 57, 91, 147, 234, 18, 79, 58, 217, 144, 33,
+ *     187, 104, 29, 252, 51, 2, 169, 217, 154, 46, 83, 230, 78,
  * ]);
- * let _p2 = RistrettoPublicKey::from_hex(&"e882b131016b52c1d3337080187cf768423efccbb517bb495ab812c4160ff44e");
+ * let _p2 = RistrettoPublicKey::from_hex(
+ *     &"e882b131016b52c1d3337080187cf768423efccbb517bb495ab812c4160ff44e",
+ * );
  * let sk = RistrettoSecretKey::random(&mut rng);
  * let _p3 = RistrettoPublicKey::from_secret_key(&sk);
  * ```
@@ -135,7 +137,8 @@ struct RistrettoPublicKey;
  *
  * let mut rng = rand::thread_rng();
  * let _k1 = RistrettoSecretKey::from_bytes(&[
- *     1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+ *     1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+ *     0, 0,
  * ]);
  * let _k2 = RistrettoSecretKey::from_hex(&"100000002000000030000000040000000");
  * let _k3 = RistrettoSecretKey::random(&mut rng);
@@ -218,8 +221,10 @@ typedef PrivateKey TariPrivateKey;
  * # use tari_utilities::ByteArray;
  * # use tari_utilities::hex::Hex;
  *
- * let r_pub =
- *     HomomorphicCommitment::from_hex("8063d85e151abee630e643e2b3dc47bfaeb8aa859c9d10d60847985f286aad19").unwrap();
+ * let r_pub = HomomorphicCommitment::from_hex(
+ *     "8063d85e151abee630e643e2b3dc47bfaeb8aa859c9d10d60847985f286aad19",
+ * )
+ * .unwrap();
  * let u = RistrettoSecretKey::from_bytes(b"10000000000000000000000010000000").unwrap();
  * let v = RistrettoSecretKey::from_bytes(b"a00000000000000000000000a0000000").unwrap();
  * let sig = RistrettoComSig::new(r_pub, u, v);
@@ -268,12 +273,22 @@ typedef PrivateKey TariPrivateKey;
  * # use digest::Digest;
  * use tari_crypto::ristretto::pedersen::commitment_factory::PedersenCommitmentFactory;
  *
- * let commitment =
- *     HomomorphicCommitment::from_hex("167c6df11bf8106e89328c297e57423dc2a9be53df1ee63f6e50b4610104ab4a").unwrap();
- * let r_nonce =
- *     HomomorphicCommitment::from_hex("4033e00996e61df2ea1abd1494b751b946663e21a20e2729c6592712beb15356").unwrap();
- * let u = RistrettoSecretKey::from_hex("f44bbc3374b172f77ffa8b904ddf0ad9f879b3e6183f9e440c57e7f01e851300").unwrap();
- * let v = RistrettoSecretKey::from_hex("fd54afb2d8008c8a3af10272b24161247b2b7ae11687813fe9fb03e34dd7f009").unwrap();
+ * let commitment = HomomorphicCommitment::from_hex(
+ *     "167c6df11bf8106e89328c297e57423dc2a9be53df1ee63f6e50b4610104ab4a",
+ * )
+ * .unwrap();
+ * let r_nonce = HomomorphicCommitment::from_hex(
+ *     "4033e00996e61df2ea1abd1494b751b946663e21a20e2729c6592712beb15356",
+ * )
+ * .unwrap();
+ * let u = RistrettoSecretKey::from_hex(
+ *     "f44bbc3374b172f77ffa8b904ddf0ad9f879b3e6183f9e440c57e7f01e851300",
+ * )
+ * .unwrap();
+ * let v = RistrettoSecretKey::from_hex(
+ *     "fd54afb2d8008c8a3af10272b24161247b2b7ae11687813fe9fb03e34dd7f009",
+ * )
+ * .unwrap();
  * let sig = RistrettoComSig::new(r_nonce, u, v);
  * let e = Blake256::digest(b"Maskerade");
  * let factory = PedersenCommitmentFactory::default();

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -14,7 +14,7 @@ build = ["toml", "prost-build"]
 static-application-info = ["git2"]
 
 [dependencies]
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.6" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.7" }
 
 anyhow = "1.0.53"
 config = { version = "0.13.0", default_features = false, features = ["toml"] }

--- a/comms/core/Cargo.toml
+++ b/comms/core/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.38.8"
 edition = "2018"
 
 [dependencies]
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.6" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.7" }
 tari_common = {path = "../../common"}
 tari_metrics = { path = "../../infrastructure/metrics" }
 tari_storage = { version = "^0.38", path = "../../infrastructure/storage" }

--- a/comms/core/src/types.rs
+++ b/comms/core/src/types.rs
@@ -23,6 +23,7 @@
 //! Common Tari comms types
 
 use tari_crypto::{
+    dhke::DiffieHellmanSharedSecret,
     hash::blake2::Blake256,
     hash_domain,
     keys::PublicKey,
@@ -40,6 +41,9 @@ use crate::peer_manager::{Peer, PeerId};
 /// Public key type
 pub type CommsPublicKey = RistrettoPublicKey;
 pub type CommsSecretKey = <CommsPublicKey as PublicKey>::K;
+
+// Diffie-Hellman key exchange type
+pub type CommsDHKE = DiffieHellmanSharedSecret<CommsPublicKey>;
 
 /// Specify the digest type for the signature challenges
 pub type CommsChallenge = Blake256;

--- a/comms/dht/Cargo.toml
+++ b/comms/dht/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 tari_comms = { version = "^0.38", path = "../core", features = ["rpc"] }
 tari_common = { path = "../../common" }
 tari_comms_rpc_macros = { version = "^0.38", path = "../rpc_macros" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.6" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.7" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag="v0.4.7" }
 tari_shutdown = { version = "^0.38", path = "../../infrastructure/shutdown" }
 tari_storage = { version = "^0.38", path = "../../infrastructure/storage" }

--- a/comms/dht/src/crypt.rs
+++ b/comms/dht/src/crypt.rs
@@ -67,12 +67,10 @@ pub struct AuthenticatedCipherKey(chacha20poly1305::Key);
 const MESSAGE_BASE_LENGTH: usize = 6000;
 
 /// Generates a Diffie-Hellman secret `kx.G` as a `chacha20::Key` given secret scalar `k` and public key `P = x.G`.
-pub fn generate_ecdh_secret(secret_key: &CommsSecretKey, public_key: &CommsPublicKey) -> [u8; 32] {
-    let k = Zeroizing::new(CommsPublicKey::shared_secret(secret_key, public_key));
-    let mut output = [0u8; 32];
+pub fn generate_ecdh_secret(secret_key: &CommsSecretKey, public_key: &CommsPublicKey) -> Zeroizing<Vec<u8>> {
+    let k = CommsPublicKey::shared_secret(secret_key, public_key);
 
-    output.copy_from_slice(k.as_bytes());
-    output
+    Zeroizing::new(k.to_vec())
 }
 
 fn get_message_padding_length(message_length: usize) -> usize {

--- a/comms/dht/src/crypt.rs
+++ b/comms/dht/src/crypt.rs
@@ -45,7 +45,7 @@ use tari_crypto::{
     keys::DiffieHellmanSharedSecret,
     tari_utilities::{epoch_time::EpochTime, ByteArray},
 };
-use zeroize::Zeroize;
+use zeroize::{Zeroize, Zeroizing};
 
 use crate::{
     comms_dht_hash_domain_challenge,
@@ -68,9 +68,7 @@ const MESSAGE_BASE_LENGTH: usize = 6000;
 
 /// Generates a Diffie-Hellman secret `kx.G` as a `chacha20::Key` given secret scalar `k` and public key `P = x.G`.
 pub fn generate_ecdh_secret(secret_key: &CommsSecretKey, public_key: &CommsPublicKey) -> [u8; 32] {
-    // TODO: PK will still leave the secret in released memory. Implementing Zerioze on RistrettoPublicKey is not
-    //       currently possible because (Compressed)RistrettoPoint does not implement it.
-    let k = CommsPublicKey::shared_secret(secret_key, public_key);
+    let k = Zeroizing::new(CommsPublicKey::shared_secret(secret_key, public_key));
     let mut output = [0u8; 32];
 
     output.copy_from_slice(k.as_bytes());

--- a/comms/dht/src/crypt.rs
+++ b/comms/dht/src/crypt.rs
@@ -41,9 +41,7 @@ use tari_comms::{
     types::{CommsDHKE, CommsPublicKey},
     BufMut,
 };
-use tari_crypto::{
-    tari_utilities::{epoch_time::EpochTime, ByteArray},
-};
+use tari_crypto::tari_utilities::{epoch_time::EpochTime, ByteArray};
 use zeroize::Zeroize;
 
 use crate::{

--- a/comms/dht/src/dht.rs
+++ b/comms/dht/src/dht.rs
@@ -457,7 +457,7 @@ mod test {
         pipeline::SinkService,
         runtime,
         test_utils::mocks::create_connectivity_mock,
-        wrap_in_envelope_body,
+        wrap_in_envelope_body, types::CommsDHKE,
     };
     use tari_shutdown::Shutdown;
     use tokio::{sync::mpsc, task, time};
@@ -616,7 +616,7 @@ mod test {
 
         // Encrypt for someone else
         let node_identity2 = make_node_identity();
-        let ecdh_key = crypt::generate_ecdh_secret(node_identity2.secret_key(), node_identity2.public_key());
+        let ecdh_key = CommsDHKE::new(node_identity2.secret_key(), node_identity2.public_key());
         let key_message = crypt::generate_key_message(&ecdh_key);
         let mut encrypted_bytes = msg.encode_into_bytes_mut();
         crypt::encrypt(&key_message, &mut encrypted_bytes).unwrap();

--- a/comms/dht/src/dht.rs
+++ b/comms/dht/src/dht.rs
@@ -457,7 +457,8 @@ mod test {
         pipeline::SinkService,
         runtime,
         test_utils::mocks::create_connectivity_mock,
-        wrap_in_envelope_body, types::CommsDHKE,
+        types::CommsDHKE,
+        wrap_in_envelope_body,
     };
     use tari_shutdown::Shutdown;
     use tokio::{sync::mpsc, task, time};

--- a/comms/dht/src/inbound/decryption.rs
+++ b/comms/dht/src/inbound/decryption.rs
@@ -166,7 +166,6 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
         ban_duration: Duration,
         message: DhtInboundMessage,
     ) -> Result<(), PipelineError> {
-        #[allow(clippy::enum_glob_use)]
         use DecryptionError::*;
         let source = message.source_peer.clone();
         let trace_id = message.dht_header.message_tag;

--- a/comms/dht/src/outbound/broadcast.rs
+++ b/comms/dht/src/outbound/broadcast.rs
@@ -35,7 +35,7 @@ use tari_comms::{
     message::{MessageExt, MessageTag},
     peer_manager::{NodeId, NodeIdentity, Peer},
     pipeline::PipelineError,
-    types::{CommsPublicKey, CommsDHKE},
+    types::{CommsDHKE, CommsPublicKey},
     Bytes,
     BytesMut,
 };

--- a/comms/dht/src/outbound/broadcast.rs
+++ b/comms/dht/src/outbound/broadcast.rs
@@ -35,7 +35,7 @@ use tari_comms::{
     message::{MessageExt, MessageTag},
     peer_manager::{NodeId, NodeIdentity, Peer},
     pipeline::PipelineError,
-    types::CommsPublicKey,
+    types::{CommsPublicKey, CommsDHKE},
     Bytes,
     BytesMut,
 };
@@ -493,7 +493,7 @@ where S: Service<DhtOutboundMessage, Response = (), Error = PipelineError>
                 trace!(target: LOG_TARGET, "Encrypting message for {}", public_key);
                 // Generate ephemeral public/private key pair and ECDH shared secret
                 let (e_secret_key, e_public_key) = CommsPublicKey::random_keypair(&mut OsRng);
-                let shared_ephemeral_secret = crypt::generate_ecdh_secret(&e_secret_key, &**public_key);
+                let shared_ephemeral_secret = CommsDHKE::new(&e_secret_key, &**public_key);
 
                 // Generate key message for encryption of message
                 let key_message = crypt::generate_key_message(&shared_ephemeral_secret);

--- a/comms/dht/src/store_forward/saf_handler/task.rs
+++ b/comms/dht/src/store_forward/saf_handler/task.rs
@@ -33,7 +33,7 @@ use tari_comms::{
     message::{EnvelopeBody, MessageTag},
     peer_manager::{NodeId, NodeIdentity, Peer, PeerFeatures, PeerManagerError},
     pipeline::PipelineError,
-    types::CommsPublicKey,
+    types::{CommsPublicKey, CommsDHKE},
     BytesMut,
 };
 use tari_utilities::ByteArray;
@@ -557,7 +557,7 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
                 "Attempting to decrypt message signature ({} byte(s))",
                 header.message_signature.len()
             );
-            let shared_secret = crypt::generate_ecdh_secret(node_identity.secret_key(), ephemeral_public_key);
+            let shared_secret = CommsDHKE::new(node_identity.secret_key(), ephemeral_public_key);
             let key_signature = crypt::generate_key_signature_for_authenticated_encryption(&shared_secret);
             let decrypted = crypt::decrypt_with_chacha20_poly1305(&key_signature, &header.message_signature)?;
             let authenticated_pk = Self::authenticate_message(&decrypted, header, body)?;

--- a/comms/dht/src/store_forward/saf_handler/task.rs
+++ b/comms/dht/src/store_forward/saf_handler/task.rs
@@ -33,7 +33,7 @@ use tari_comms::{
     message::{EnvelopeBody, MessageTag},
     peer_manager::{NodeId, NodeIdentity, Peer, PeerFeatures, PeerManagerError},
     pipeline::PipelineError,
-    types::{CommsPublicKey, CommsDHKE},
+    types::{CommsDHKE, CommsPublicKey},
     BytesMut,
 };
 use tari_utilities::ByteArray;

--- a/comms/dht/src/test_utils/makers.rs
+++ b/comms/dht/src/test_utils/makers.rs
@@ -27,7 +27,7 @@ use tari_comms::{
     multiaddr::Multiaddr,
     peer_manager::{NodeId, NodeIdentity, Peer, PeerFeatures, PeerFlags, PeerManager},
     transports::MemoryTransport,
-    types::{CommsDatabase, CommsPublicKey, CommsSecretKey},
+    types::{CommsDatabase, CommsDHKE, CommsPublicKey, CommsSecretKey},
     Bytes,
 };
 use tari_crypto::keys::PublicKey;
@@ -97,7 +97,7 @@ pub fn make_dht_header(
         );
         let signature = make_valid_message_signature(node_identity, &binding_message_representation);
         if flags.is_encrypted() {
-            let shared_secret = crypt::generate_ecdh_secret(e_secret_key, node_identity.public_key());
+            let shared_secret = CommsDHKE::new(e_secret_key, node_identity.public_key());
             let key_signature = crypt::generate_key_signature_for_authenticated_encryption(&shared_secret);
             message_signature = crypt::encrypt_with_chacha20_poly1305(&key_signature, &signature)?;
         }
@@ -200,7 +200,7 @@ pub fn make_dht_envelope<T: prost::Message>(
 ) -> Result<DhtEnvelope, DhtOutboundError> {
     let (e_secret_key, e_public_key) = make_keypair();
     let message = if flags.is_encrypted() {
-        let shared_secret = crypt::generate_ecdh_secret(&e_secret_key, node_identity.public_key());
+        let shared_secret = CommsDHKE::new(&e_secret_key, node_identity.public_key());
         let key_message = crypt::generate_key_message(&shared_secret);
         let mut message = prepare_message(true, message);
         crypt::encrypt(&key_message, &mut message).unwrap();

--- a/comms/dht/src/test_utils/makers.rs
+++ b/comms/dht/src/test_utils/makers.rs
@@ -27,7 +27,7 @@ use tari_comms::{
     multiaddr::Multiaddr,
     peer_manager::{NodeId, NodeIdentity, Peer, PeerFeatures, PeerFlags, PeerManager},
     transports::MemoryTransport,
-    types::{CommsDatabase, CommsDHKE, CommsPublicKey, CommsSecretKey},
+    types::{CommsDHKE, CommsDatabase, CommsPublicKey, CommsSecretKey},
     Bytes,
 };
 use tari_crypto::keys::PublicKey;

--- a/infrastructure/tari_script/Cargo.toml
+++ b/infrastructure/tari_script/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 license = "BSD-3-Clause"
 
 [dependencies]
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.6" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.7" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag="v0.4.7" }
 
 blake2 = "0.9"


### PR DESCRIPTION
Description
---
Ensures safer use of ECDH shared secrets by switching to the new `DiffieHellmanSharedSecret` type. Updates `tari-crypto` to v0.15.7 to accomplish this.

Motivation and Context
---
Currently, an ECDH secret used for message keys is produced as a `RistrettoPublicKey`, converted to bytes, and returned as a byte array. However, neither the `RistrettoPublicKey` nor the byte array are cleared when dropped. In conjunction with `tari-crypto` [PR 137](https://github.com/tari-project/tari-crypto/pull/137), this work ensures both the `RistrettoPublicKey` and byte array representations of the ECDH secret are zeroized on drop by using that PR's new `DiffieHellmanSharedSecret` type.

How Has This Been Tested?
---
Tested after applying `tari-crypto` [PR 137](https://github.com/tari-project/tari-crypto/pull/137), which adds the new `DiffieHellmanSharedSecret` generic type.
