### PR TITLE
fix(wallet)!: use KDFs on ECDH shared secrets

### DIFF
--- a/base_layer/wallet/src/lib.rs
+++ b/base_layer/wallet/src/lib.rs
@@ -55,8 +55,22 @@ pub type WalletSqlite = Wallet<
 >;
 
 hash_domain!(
-    WalletSecretKeysDomain,
-    "com.tari.tari_project.base_layer.wallet.secret_keys",
+    WalletOutputRewindKeysDomain,
+    "com.tari.tari_project.base_layer.wallet.output_rewind_keys",
     1
 );
-type WalletSecretKeysDomainHasher = DomainSeparatedHasher<Blake256, WalletSecretKeysDomain>;
+type WalletOutputRewindKeysDomainHasher = DomainSeparatedHasher<Blake256, WalletOutputRewindKeysDomain>;
+
+hash_domain!(
+    WalletOutputEncryptionKeysDomain,
+    "com.tari.tari_project.base_layer.wallet.output_encryption_keys",
+    1
+);
+type WalletOutputEncryptionKeysDomainHasher = DomainSeparatedHasher<Blake256, WalletOutputEncryptionKeysDomain>;
+
+hash_domain!(
+    WalletOutputSpendingKeysDomain,
+    "com.tari.tari_project.base_layer.wallet.output_spending_keys",
+    1
+);
+type WalletOutputSpendingKeysDomainHasher = DomainSeparatedHasher<Blake256, WalletOutputSpendingKeysDomain>;

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -2321,7 +2321,10 @@ where
         pre_image: PublicKey,
         fee_per_gram: MicroTari,
     ) -> Result<(TxId, MicroTari, MicroTari, Transaction), OutputManagerError> {
-        let shared_secret = CommsDHKE::new(self.node_identity.as_ref().secret_key(), &output.sender_offset_public_key);
+        let shared_secret = CommsDHKE::new(
+            self.node_identity.as_ref().secret_key(),
+            &output.sender_offset_public_key,
+        );
         let blinding_key = shared_secret_to_output_rewind_key(&shared_secret)?;
         let encryption_key = shared_secret_to_output_encryption_key(&shared_secret)?;
         if let Ok(amount) = EncryptedValue::decrypt_value(&encryption_key, &output.commitment, &output.encrypted_value)
@@ -2551,15 +2554,13 @@ where
 
                         // match found
                         Some(matched_key) => {
-                            let shared_secret = CommsDHKE::new(
-                                &matched_key.private_key,
-                                &output.sender_offset_public_key
-                            );
+                            let shared_secret =
+                                CommsDHKE::new(&matched_key.private_key, &output.sender_offset_public_key);
                             scanned_outputs.push((
                                 output.clone(),
                                 OutputSource::OneSided,
                                 matched_key.private_key.clone(),
-                                shared_secret
+                                shared_secret,
                             ));
                         },
                     }
@@ -2732,7 +2733,7 @@ fn shared_secret_to_output_rewind_key(shared_secret: &CommsDHKE) -> Result<Priva
         WalletOutputRewindKeysDomainHasher::new()
             .chain(shared_secret.as_bytes())
             .finalize()
-            .as_ref()
+            .as_ref(),
     )
 }
 
@@ -2742,7 +2743,7 @@ fn shared_secret_to_output_encryption_key(shared_secret: &CommsDHKE) -> Result<P
         WalletOutputEncryptionKeysDomainHasher::new()
             .chain(shared_secret.as_bytes())
             .finalize()
-            .as_ref()
+            .as_ref(),
     )
 }
 

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -1062,14 +1062,14 @@ where
         // Prepare receiver part of the transaction
 
         // Diffie-Hellman shared secret `k_Ob * K_Sb = K_Ob * k_Sb` results in a public key, which is fed into
-        // KDFs to produce the spending, rewind, and encryption keys 
+        // KDFs to produce the spending, rewind, and encryption keys
         let sender_offset_private_key = stp
             .get_recipient_sender_offset_private_key(0)
             .map_err(|e| TransactionServiceProtocolError::new(tx_id, e.into()))?;
 
         let shared_secret = CommsDHKE::new(&sender_offset_private_key, &dest_pubkey);
         let spending_key = shared_secret_to_output_spending_key(&shared_secret)
-        .map_err(|e| TransactionServiceProtocolError::new(tx_id, e.into()))?;
+            .map_err(|e| TransactionServiceProtocolError::new(tx_id, e.into()))?;
 
         let sender_message = TransactionSenderMessage::new_single_round_message(stp.get_single_round_message()?);
         let rewind_blinding_key = shared_secret_to_output_rewind_key(&shared_secret)?;
@@ -1223,13 +1223,13 @@ where
         // Prepare receiver part of the transaction
 
         // Diffie-Hellman shared secret `k_Ob * K_Sb = K_Ob * k_Sb` results in a public key, which is fed into
-        // KDFs to produce the spending, rewind, and encryption keys 
+        // KDFs to produce the spending, rewind, and encryption keys
         let sender_offset_private_key = stp
             .get_recipient_sender_offset_private_key(0)
             .map_err(|e| TransactionServiceProtocolError::new(tx_id, e.into()))?;
         let shared_secret = CommsDHKE::new(&sender_offset_private_key, &dest_pubkey);
         let spending_key = shared_secret_to_output_spending_key(&shared_secret)
-        .map_err(|e| TransactionServiceProtocolError::new(tx_id, e.into()))?;
+            .map_err(|e| TransactionServiceProtocolError::new(tx_id, e.into()))?;
 
         let sender_message = TransactionSenderMessage::new_single_round_message(stp.get_single_round_message()?);
         let rewind_blinding_key = shared_secret_to_output_rewind_key(&shared_secret)?;
@@ -2665,7 +2665,7 @@ fn shared_secret_to_output_rewind_key(shared_secret: &CommsDHKE) -> Result<Priva
         WalletOutputRewindKeysDomainHasher::new()
             .chain(shared_secret.as_bytes())
             .finalize()
-            .as_ref()
+            .as_ref(),
     )
 }
 
@@ -2675,7 +2675,7 @@ fn shared_secret_to_output_encryption_key(shared_secret: &CommsDHKE) -> Result<P
         WalletOutputEncryptionKeysDomainHasher::new()
             .chain(shared_secret.as_bytes())
             .finalize()
-            .as_ref()
+            .as_ref(),
     )
 }
 
@@ -2685,7 +2685,7 @@ fn shared_secret_to_output_spending_key(shared_secret: &CommsDHKE) -> Result<Pri
         WalletOutputSpendingKeysDomainHasher::new()
             .chain(shared_secret.as_bytes())
             .finalize()
-            .as_ref()
+            .as_ref(),
     )
 }
 

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -70,7 +70,7 @@ use tari_core::{
 use tari_crypto::{
     commitment::HomomorphicCommitmentFactory,
     keys::{PublicKey as PKtrait, SecretKey},
-    tari_utilities::ByteArray,
+    tari_utilities::{ByteArray, ByteArrayError},
 };
 use tari_p2p::domain_message::DomainMessage;
 use tari_script::{inputs, script, TariScript};
@@ -122,7 +122,9 @@ use crate::{
     util::watch::Watch,
     utxo_scanner_service::RECOVERY_KEY,
     OperationId,
-    WalletSecretKeysDomainHasher,
+    WalletOutputEncryptionKeysDomainHasher,
+    WalletOutputRewindKeysDomainHasher,
+    WalletOutputSpendingKeysDomainHasher,
 };
 
 const LOG_TARGET: &str = "wallet::transaction_service::service";
@@ -1059,29 +1061,29 @@ where
 
         // Prepare receiver part of the transaction
 
-        // Diffie-Hellman shared secret `k_Ob * K_Sb = K_Ob * k_Sb` results in a public key, which is converted to
-        // bytes to enable conversion into a private key to be used as the spending key
+        // Diffie-Hellman shared secret `k_Ob * K_Sb = K_Ob * k_Sb` results in a public key, which is fed into
+        // KDFs to produce the spending, rewind, and encryption keys 
         let sender_offset_private_key = stp
             .get_recipient_sender_offset_private_key(0)
             .map_err(|e| TransactionServiceProtocolError::new(tx_id, e.into()))?;
 
-        let spend_key =
-            PrivateKey::from_bytes(CommsDHKE::new(&sender_offset_private_key.clone(), &dest_pubkey.clone()).as_bytes())
-                .map_err(|e| TransactionServiceProtocolError::new(tx_id, e.into()))?;
+        let shared_secret = CommsDHKE::new(&sender_offset_private_key, &dest_pubkey);
+        let spending_key = shared_secret_to_output_spending_key(&shared_secret)
+        .map_err(|e| TransactionServiceProtocolError::new(tx_id, e.into()))?;
 
         let sender_message = TransactionSenderMessage::new_single_round_message(stp.get_single_round_message()?);
-        let rewind_blinding_key = PrivateKey::from_bytes(&hash_secret_key(&spend_key))?;
-        let encryption_key = PrivateKey::from_bytes(&hash_secret_key(&rewind_blinding_key))?;
+        let rewind_blinding_key = shared_secret_to_output_rewind_key(&shared_secret)?;
+        let encryption_key = shared_secret_to_output_encryption_key(&shared_secret)?;
 
         let rewind_data = RewindData {
-            rewind_blinding_key: rewind_blinding_key.clone(),
-            encryption_key: encryption_key.clone(),
+            rewind_blinding_key,
+            encryption_key,
         };
 
         let rtp = ReceiverTransactionProtocol::new_with_rewindable_output(
             sender_message,
             PrivateKey::random(&mut OsRng),
-            spend_key.clone(),
+            spending_key.clone(),
             &self.resources.factories,
             &rewind_data,
         );
@@ -1092,12 +1094,12 @@ where
             .resources
             .factories
             .commitment
-            .commit_value(&spend_key, amount.into());
+            .commit_value(&spending_key, amount.into());
         let encrypted_value = EncryptedValue::encrypt_value(&rewind_data.encryption_key, &commitment, amount)?;
         let minimum_value_promise = MicroTari::zero();
         let unblinded_output = UnblindedOutput::new_current_version(
             amount,
-            spend_key,
+            spending_key,
             output.features.clone(),
             script,
             inputs!(PublicKey::from_secret_key(self.node_identity.secret_key())),
@@ -1220,18 +1222,18 @@ where
 
         // Prepare receiver part of the transaction
 
-        // Diffie-Hellman shared secret `k_Ob * K_Sb = K_Ob * k_Sb` results in a public key, which is converted to
-        // bytes to enable conversion into a private key to be used as the spending key
+        // Diffie-Hellman shared secret `k_Ob * K_Sb = K_Ob * k_Sb` results in a public key, which is fed into
+        // KDFs to produce the spending, rewind, and encryption keys 
         let sender_offset_private_key = stp
             .get_recipient_sender_offset_private_key(0)
             .map_err(|e| TransactionServiceProtocolError::new(tx_id, e.into()))?;
-        let spend_key =
-            PrivateKey::from_bytes(CommsDHKE::new(&sender_offset_private_key, &dest_pubkey.clone()).as_bytes())
-                .map_err(|e| TransactionServiceProtocolError::new(tx_id, e.into()))?;
+        let shared_secret = CommsDHKE::new(&sender_offset_private_key, &dest_pubkey);
+        let spending_key = shared_secret_to_output_spending_key(&shared_secret)
+        .map_err(|e| TransactionServiceProtocolError::new(tx_id, e.into()))?;
 
         let sender_message = TransactionSenderMessage::new_single_round_message(stp.get_single_round_message()?);
-        let rewind_blinding_key = PrivateKey::from_bytes(&hash_secret_key(&spend_key))?;
-        let encryption_key = PrivateKey::from_bytes(&hash_secret_key(&rewind_blinding_key))?;
+        let rewind_blinding_key = shared_secret_to_output_rewind_key(&shared_secret)?;
+        let encryption_key = shared_secret_to_output_encryption_key(&shared_secret)?;
         let rewind_data = RewindData {
             rewind_blinding_key,
             encryption_key,
@@ -1240,7 +1242,7 @@ where
         let rtp = ReceiverTransactionProtocol::new_with_rewindable_output(
             sender_message,
             PrivateKey::random(&mut OsRng),
-            spend_key,
+            spending_key,
             &self.resources.factories,
             &rewind_data,
         );
@@ -2657,12 +2659,34 @@ pub struct PendingCoinbaseSpendingKey {
     pub spending_key: PrivateKey,
 }
 
-fn hash_secret_key(key: &PrivateKey) -> Vec<u8> {
-    WalletSecretKeysDomainHasher::new()
-        .chain(key.as_bytes())
-        .finalize()
-        .as_ref()
-        .to_vec()
+/// Generate an output rewind key from a Diffie-Hellman shared secret
+fn shared_secret_to_output_rewind_key(shared_secret: &CommsDHKE) -> Result<PrivateKey, ByteArrayError> {
+    PrivateKey::from_bytes(
+        WalletOutputRewindKeysDomainHasher::new()
+            .chain(shared_secret.as_bytes())
+            .finalize()
+            .as_ref()
+    )
+}
+
+/// Generate an output encryption key from a Diffie-Hellman shared secret
+fn shared_secret_to_output_encryption_key(shared_secret: &CommsDHKE) -> Result<PrivateKey, ByteArrayError> {
+    PrivateKey::from_bytes(
+        WalletOutputEncryptionKeysDomainHasher::new()
+            .chain(shared_secret.as_bytes())
+            .finalize()
+            .as_ref()
+    )
+}
+
+/// Generate an output spending key from a Diffie-Hellman shared secret
+fn shared_secret_to_output_spending_key(shared_secret: &CommsDHKE) -> Result<PrivateKey, ByteArrayError> {
+    PrivateKey::from_bytes(
+        WalletOutputSpendingKeysDomainHasher::new()
+            .chain(shared_secret.as_bytes())
+            .finalize()
+            .as_ref()
+    )
 }
 
 /// Contains the generated TxId and TransactionStatus transaction send result


### PR DESCRIPTION
Description
---
Uses KDFs on ECDH shared secrets for output generation. Closes [issue 4717](https://github.com/tari-project/tari/issues/4717).

Motivation and Context
---
Several uses of ECDH shared secrets in the output manager and transaction services parse an ECDH shared secret as a scalar spending key, and use this as input to a chain of hash functions for use in rewinding and value encryption. This is non-standard.

This work uses separate KDFs to independently produce a spending key, rewind key, and value encryption key from a `DiffieHellmanSharedSecret`-type ECDH shared secret.

How Has This Been Tested?
---
Existing tests pass.

BREAKING CHANGE: Changes the way output keys are derived.
