### PR TITLE
fix: remove clear_on_drop dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4751,7 +4751,6 @@ dependencies = [
  "bytes 1.2.1",
  "chrono",
  "cidr",
- "clear_on_drop",
  "data-encoding",
  "derivative",
  "digest 0.9.0",
@@ -4788,6 +4787,7 @@ dependencies = [
  "tower",
  "tracing",
  "yamux",
+ "zeroize",
 ]
 
 [[package]]
@@ -4997,7 +4997,6 @@ dependencies = [
  "arrayvec 0.7.2",
  "blake2 0.9.2",
  "chacha20 0.7.3",
- "clear_on_drop",
  "console_error_panic_hook",
  "crc32fast",
  "derivative",
@@ -5017,6 +5016,7 @@ dependencies = [
  "thiserror",
  "wasm-bindgen",
  "wasm-bindgen-test",
+ "zeroize",
 ]
 
 [[package]]
@@ -5293,7 +5293,6 @@ dependencies = [
  "blake2 0.9.2",
  "chacha20poly1305",
  "chrono",
- "clear_on_drop",
  "derivative",
  "diesel",
  "diesel_migrations",

--- a/base_layer/key_manager/Cargo.toml
+++ b/base_layer/key_manager/Cargo.toml
@@ -20,7 +20,6 @@ arrayvec = "0.7.1"
 argon2 = { version = "0.2", features = ["std"] }
 blake2 = "0.9.1"
 chacha20 = "0.7.1"
-clear_on_drop = "=0.2.4"
 console_error_panic_hook = { version = "0.1.7", optional = true }
 crc32fast = "1.2.1"
 derivative = "2.2.0"
@@ -35,6 +34,7 @@ thiserror = "1.0.26"
 strum_macros = "0.22"
 strum = { version = "0.22", features = ["derive"] }
 wasm-bindgen = { version = "0.2", features = ["serde-serialize", "nightly"], optional = true }
+zeroize = "1"
 
 [dev-dependencies]
 sha2 = "0.9.8"

--- a/base_layer/key_manager/src/cipher_seed.rs
+++ b/base_layer/key_manager/src/cipher_seed.rs
@@ -41,6 +41,7 @@ use rand::{rngs::OsRng, RngCore};
 use serde::{Deserialize, Serialize};
 use tari_crypto::hash::blake2::Blake256;
 use tari_utilities::ByteArray;
+use zeroize::Zeroize;
 
 use crate::{
     error::KeyManagerError,
@@ -107,7 +108,8 @@ pub const CIPHER_SEED_MAC_BYTES: usize = 5;
 /// only have to scan the blocks in the chain since that day for full recovery, rather than scanning the entire
 /// blockchain.
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Zeroize)]
+#[zeroize(drop)]
 pub struct CipherSeed {
     version: u8,
     birthday: u16,
@@ -370,13 +372,6 @@ impl CipherSeed {
             .ok_or_else(|| KeyManagerError::CryptographicError("Problem generating encryption key hash".to_string()))?;
 
         Ok(derived_encryption_key.as_bytes().into())
-    }
-}
-
-impl Drop for CipherSeed {
-    fn drop(&mut self) {
-        use clear_on_drop::clear::Clear;
-        Clear::clear(&mut self.entropy);
     }
 }
 

--- a/base_layer/wallet/Cargo.toml
+++ b/base_layer/wallet/Cargo.toml
@@ -22,7 +22,7 @@ tari_storage = { version = "^0.38", path = "../../infrastructure/storage" }
 tari_common_sqlite = { path = "../../common_sqlite" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag="v0.4.7" }
 
-# Uncomment for tokio tracing via tokio-console (needs "tracing" featurs)
+# Uncomment for tokio tracing via tokio-console (needs "tracing" features)
 #console-subscriber = "0.1.3"
 #tokio = { version = "1.20", features = ["sync", "macros", "tracing"] }
 # Uncomment for normal use (non tokio-console tracing)
@@ -34,7 +34,6 @@ bincode = "1.3.1"
 blake2 = "0.9.0"
 sha2 = "0.9.5"
 chrono = { version = "0.4.19", default-features = false, features = ["serde"] }
-clear_on_drop = "=0.2.4"
 derivative = "2.2.0"
 diesel = { version = "1.4.8", features = ["sqlite", "serde_json", "chrono", "64-column-tables"] }
 diesel_migrations = "1.4.0"
@@ -56,7 +55,6 @@ tower = "0.4"
 prost = "0.9"
 itertools = "0.10.3"
 chacha20poly1305 = "0.9.1"
-
 
 [dev-dependencies]
 tari_p2p = { version = "^0.38", path = "../p2p", features = ["test-mocks"] }

--- a/comms/core/Cargo.toml
+++ b/comms/core/Cargo.toml
@@ -24,7 +24,6 @@ blake2 = "0.10.4"
 bytes = { version = "1", features = ["serde"] }
 chrono = { version = "0.4.19", default-features = false, features = ["serde", "clock"] }
 cidr = "0.1.0"
-clear_on_drop = "=0.2.4"
 data-encoding = "2.2.0"
 derivative = "2.2.0"
 digest = "0.9.0"
@@ -50,6 +49,7 @@ tokio-util = { version = "0.6.7", features = ["codec", "compat"] }
 tower = {version = "0.4", features = ["util"]}
 tracing = "0.1.26"
 yamux = "=0.10.2"
+zeroize = "1"
 
 [dev-dependencies]
 tari_test_utils = { version = "^0.38", path = "../../infrastructure/test_utils" }

--- a/comms/core/src/tor/control_client/types.rs
+++ b/comms/core/src/tor/control_client/types.rs
@@ -23,6 +23,7 @@
 use std::{fmt, net::SocketAddr};
 
 use serde_derive::{Deserialize, Serialize};
+use zeroize::Zeroize;
 
 #[derive(Clone, Copy, Debug)]
 pub enum KeyType {
@@ -78,26 +79,13 @@ impl fmt::Display for KeyBlob<'_> {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Zeroize)]
+#[zeroize(drop)]
 pub enum PrivateKey {
     /// The server should use the 1024 bit RSA key provided in as KeyBlob (v2).
     Rsa1024(String),
     /// The server should use the ed25519 v3 key provided in as KeyBlob (v3).
     Ed25519V3(String),
-}
-
-impl Drop for PrivateKey {
-    fn drop(&mut self) {
-        use clear_on_drop::clear::Clear;
-        match self {
-            PrivateKey::Rsa1024(ref mut key) => {
-                Clear::clear(key);
-            },
-            PrivateKey::Ed25519V3(ref mut key) => {
-                Clear::clear(key);
-            },
-        }
-    }
 }
 
 /// Represents a mapping between an onion port and a proxied address (usually 127.0.0.1:xxxx).


### PR DESCRIPTION
Description
---
Replaces `clear_on_drop` usage with `zeroize`

Motivation and Context
---
`zeroize` is preferred in the tari codebase
`clear_on_drop` is still listed as a dependency in `rpgp`, though AFAICS is unused. In the current master branch, it has been removed, so once `rpgp` releases that, the clear_on_drop dependency will be gone completely.

How Has This Been Tested?
---
Build passes
