### PR TITLE
feat: add static lifetime to emission amounts calculation

### DIFF
--- a/base_layer/core/src/consensus/consensus_constants.rs
+++ b/base_layer/core/src/consensus/consensus_constants.rs
@@ -142,7 +142,7 @@ impl ConsensusConstants {
     }
 
     /// This gets the emission curve values as (initial, decay, tail)
-    pub fn emission_amounts(&self) -> (MicroTari, &[u64], MicroTari) {
+    pub fn emission_amounts(&self) -> (MicroTari, &'static [u64], MicroTari) {
         (self.emission_initial, self.emission_decay, self.emission_tail)
     }
 


### PR DESCRIPTION
Description
---
Added a static lifetime to `emission_amounts` calculation. This is needed if the `pub fn emission_amounts` will be called from an external client.

Motivation and Context
---
The `&'[u64]` return value was at odds with the `emission_decay: &'static [u64]` definition.

How Has This Been Tested?
---
Unit tests
External client
