### PR TITLE
fix: added UtxoSelectionMode to enable unrestricted output listing [issue #4811]

### DIFF
--- a/base_layer/wallet/src/output_manager_service/input_selection.rs
+++ b/base_layer/wallet/src/output_manager_service/input_selection.rs
@@ -27,8 +27,16 @@ use std::{
 
 use tari_common_types::types::Commitment;
 
+#[derive(Debug, Copy, Clone, Default, Eq, PartialEq)]
+pub enum UtxoSelectionMode {
+    #[default]
+    Safe,
+    ListingOnly,
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct UtxoSelectionCriteria {
+    pub mode: UtxoSelectionMode,
     pub filter: UtxoSelectionFilter,
     pub ordering: UtxoSelectionOrdering,
     pub excluding: Vec<Commitment>,


### PR DESCRIPTION
Description
---
Added UtxoSelectionMode to enable output listing, unrestricted by `script_lock_height` or `maturity`, it has two modes at the moment: `Safe` and `ListingOnly`: 
- `Safe` is supposed to be used when payment is expected,
- `ListingOnly` is to have an option to view existing outputs e.g., to see received, but yet to be matured outputs.

And brushed up a little for easier readability.

Motivation and Context
---
Under certain conditions the function select_utxos selects utxo's which it cannot spend yet due to the timelocks.
Since PR https://github.com/tari-project/tari/pull/4227, the wallet can under certain conditions (not default) select UTXOs that have not yet been matured.
The Wallet should ALWAYS look to only select utxos that have matured on script_lock_height and maturity

Fixes https://github.com/tari-project/tari/issues/4811

How Has This Been Tested?
---
existing unit tests
