### PR TITLE
feat: add block height to input request to get network consensus constants

### DIFF
--- a/applications/tari_app_grpc/proto/base_node.proto
+++ b/applications/tari_app_grpc/proto/base_node.proto
@@ -40,7 +40,7 @@ service BaseNode {
     // Returns the block timing for the chain heights
     rpc GetBlockTiming(HeightRequest) returns (BlockTimingResponse);
     // Returns the network Constants
-    rpc GetConstants(Empty) returns (ConsensusConstants);
+    rpc GetConstants(BlockHeight) returns (ConsensusConstants);
     // Returns Block Sizes
     rpc GetBlockSize (BlockGroupRequest) returns (BlockGroupResponse);
     // Returns Block Fees

--- a/applications/tari_app_grpc/proto/types.proto
+++ b/applications/tari_app_grpc/proto/types.proto
@@ -32,6 +32,11 @@ message Range {
 /// An Empty placeholder for endpoints without request parameters
 message Empty {}
 
+/// Define an interface for block height
+message BlockHeight {
+    uint64 block_height = 1;
+}
+
 // Define the explicit Signature implementation for the Tari base layer. A different signature scheme can be
 // employed by redefining this type.
 message Signature {

--- a/applications/tari_base_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/tari_base_node/src/grpc/base_node_grpc_server.rs
@@ -1129,17 +1129,9 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
         debug!(target: LOG_TARGET, "Sending GetConstants response to client");
 
         let block_height = request.into_inner().block_height;
-        let network_consensus_constants = self.network.create_consensus_constants();
 
-        let mut consensus_constants = &network_consensus_constants[0];
-
-        for cc in &network_consensus_constants[1..] {
-            let effective_from_height = cc.effective_from_height();
-            if effective_from_height > block_height {
-                break;
-            }
-            consensus_constants = cc;
-        }
+        let consensus_manager = ConsensusManager::builder(self.network.as_network()).build();
+        let consensus_constants = consensus_manager.consensus_constants(block_height);
 
         Ok(Response::new(tari_rpc::ConsensusConstants::from(
             consensus_constants.clone(),


### PR DESCRIPTION
Description
---
In this PR, we refactor the method `get_constants` of `BaseNodeClient` to request a block height input.

Motivation and Context
---
In order to get `ConsensusConstants` values at the DAN layer, it is useful to be able to request the former using a block height, for synchronization purposes. This PR addresses this scenario.

How Has This Been Tested?
---

