### PR TITLE
chore: fix potentially buggy split of string into lines

### DIFF
--- a/applications/tari_console_wallet/src/ui/components/log_tab.rs
+++ b/applications/tari_console_wallet/src/ui/components/log_tab.rs
@@ -71,10 +71,7 @@ impl LogTab {
             Err(err) => format!("Error reading log : {}", err),
         };
         // Convert the content into Spans
-        let mut text: Vec<Spans> = content
-            .split('\n')
-            .map(|line| self.format_line(line.to_string()))
-            .collect();
+        let mut text: Vec<Spans> = content.lines().map(|line| self.format_line(line.to_string())).collect();
         // We want newest at the top
         text.reverse();
         // Render the Paragraph

--- a/comms/core/src/tor/control_client/parsers.rs
+++ b/comms/core/src/tor/control_client/parsers.rs
@@ -90,7 +90,7 @@ pub fn key_value(line: &str) -> Result<(Cow<'_, str>, Vec<Cow<'_, str>>), ParseE
     let (rest, identifier) = take_while1(|ch| ch != '=')(line)?;
     let (rest, _) = chr('=')(rest)?;
 
-    let lines = rest.split('\n');
+    let lines = rest.lines();
     let parts = lines
         .filter(|s| !s.is_empty())
         .flat_map(|line| {


### PR DESCRIPTION
Description
This PR served for fixing the bug described in #4809 

Motivation and Context
Following the deepsource link in the issue above to fix.

How Has This Been Tested?
---