### PR TITLE
feat: improve block_chain backend reliability

### DIFF
--- a/base_layer/core/src/base_node/sync/block_sync/synchronizer.rs
+++ b/base_layer/core/src/base_node/sync/block_sync/synchronizer.rs
@@ -295,6 +295,11 @@ impl<B: BlockchainBackend + 'static> BlockSynchronizer<B> {
 
             let timer = Instant::now();
             let (header, header_accum_data) = header.into_parts();
+            trace!(
+                target: LOG_TARGET,
+                "Downloaded block from peer: {}",
+                Block::new(header.clone(), body.clone())
+            );
 
             let block = match self.block_validator.validate_body(Block::new(header, body)).await {
                 Ok(block) => block,

--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -1726,8 +1726,7 @@ fn rewind_to_height<T: BlockchainBackend>(db: &mut T, height: u64) -> Result<Vec
                 // had.
                 error!(
                     target: LOG_TARGET,
-                    "Failed to rewind the block chain, trying to recover the blockchain to previous height: {} ",
-                    e
+                    "Failed to rewind the block chain, trying to recover the blockchain to previous height: {} ", e
                 );
                 let mut txn = DbTransaction::new();
 
@@ -1778,7 +1777,7 @@ fn rewind_block<T: BlockchainBackend>(
     let mut txn = DbTransaction::new();
     info!(target: LOG_TARGET, "Deleting block {}", height);
     let block = fetch_block(db, height, false)?;
-    debug!(target: LOG_TARGET, "Goint to delete block: {}", block);
+    debug!(target: LOG_TARGET, "Going to delete block: {}", block);
     let block = Arc::new(block.try_into_chain_block()?);
     txn.delete_block(*block.hash());
     txn.delete_header(height);
@@ -2096,6 +2095,12 @@ fn insert_orphan_and_find_new_tips<T: BlockchainBackend>(
 
     // There cannot be any _new_ tips if we've seen this orphan block before
     if db.contains(&DbKey::OrphanBlock(hash))? {
+        info!(
+            target: LOG_TARGET,
+            "Orphan #{} ({}) already found in orphan database",
+            block.header.height,
+            hash.to_hex()
+        );
         return Ok(vec![]);
     }
     let mut txn = DbTransaction::new();
@@ -2123,22 +2128,14 @@ fn insert_orphan_and_find_new_tips<T: BlockchainBackend>(
                 curr_parent
             },
             None => {
-                let hash_hex = hash.to_hex();
-                if db.contains(&DbKey::OrphanBlock(hash))? {
-                    info!(
-                        target: LOG_TARGET,
-                        "Orphan #{} ({}) already found in orphan database", block.header.height, hash_hex
-                    );
-                } else {
-                    info!(
-                        target: LOG_TARGET,
-                        "Orphan #{} ({}) was not connected to any previous headers. Inserting as true orphan",
-                        block.header.height,
-                        hash_hex
-                    );
-                    txn.insert_orphan(block);
-                    db.write(txn)?;
-                }
+                info!(
+                    target: LOG_TARGET,
+                    "Orphan #{} ({}) was not connected to any previous headers. Inserting as true orphan",
+                    block.header.height,
+                    hash.to_hex()
+                );
+                txn.insert_orphan(block);
+                db.write(txn)?;
                 return Ok(vec![]);
             },
         },

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -792,7 +792,6 @@ impl LMDBDatabase {
                 "The first header inserted must have height 0. Height provided: {}",
                 header.height
             )));
-        } else {
         }
 
         lmdb_insert(

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -792,6 +792,7 @@ impl LMDBDatabase {
                 "The first header inserted must have height 0. Height provided: {}",
                 header.height
             )));
+        } else {
         }
 
         lmdb_insert(


### PR DESCRIPTION
Description
---
This PR tries to improve db transactions to make sure all changes are atomic and can be reset if need be, also improves logging and comments. 

Motivation and Context
---
We changed the rewind logic to use smaller multiple transactions after we encountered a few too-large transactions. 
Between the too-large transactions and using multiple transactions, if they fail, they might leave the database in an inconsistent state. This PR tries to ensure when adding information, we always use a single transaction and never leave the database in an inconsistent state. 

This PR changes the rewind to try make sure that if it fails, the rewind will try to reset it self back to the previous state. 

How Has This Been Tested?
---

- Manually sync node, and run node
- Unit tests


Fixes: #4850 