### PR TITLE
fix: delete orphans if they exist

### DIFF
--- a/base_layer/core/src/base_node/sync/block_sync/synchronizer.rs
+++ b/base_layer/core/src/base_node/sync/block_sync/synchronizer.rs
@@ -307,6 +307,7 @@ impl<B: BlockchainBackend + 'static> BlockSynchronizer<B> {
                     if let Err(err) = self
                         .db
                         .write_transaction()
+                        .delete_orphan(header_hash)
                         .insert_bad_block(header_hash, current_height)
                         .commit()
                         .await
@@ -333,6 +334,7 @@ impl<B: BlockchainBackend + 'static> BlockSynchronizer<B> {
             let timer = Instant::now();
             self.db
                 .write_transaction()
+                .delete_orphan(header_hash)
                 .insert_block_body(block.clone())
                 .set_best_block(
                     block.height(),

--- a/base_layer/core/src/chain_storage/async_db.rs
+++ b/base_layer/core/src/chain_storage/async_db.rs
@@ -387,6 +387,11 @@ impl<'a, B: BlockchainBackend + 'static> AsyncDbTransaction<'a, B> {
         self
     }
 
+    pub fn delete_orphan(&mut self, hash: HashOutput) -> &mut Self {
+        self.transaction.delete_orphan(hash);
+        self
+    }
+
     pub fn insert_bad_block(&mut self, hash: HashOutput, height: u64) -> &mut Self {
         self.transaction.insert_bad_block(hash, height);
         self


### PR DESCRIPTION
Description
---
Orphans should be deleted from the orphan database if they exist. 

Motivation and Context
---
If the block is added to the main chain, it should not exist in the orphan database as well. It will also remove the orphan tips if it removes the block from the pool. 

How Has This Been Tested?
---
Unit test and manually running

fixes: #4867 

