### PR TITLE
fix: remove tari script serialization fix migration

### DIFF
--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb.rs
@@ -446,7 +446,8 @@ pub fn lmdb_clear(txn: &WriteTransaction<'_>, db: &Database) -> Result<usize, Ch
     Ok(num_deleted)
 }
 
-/// Used for migrations, you probably dont want to use this.
+/// Used for migrations, you probably dont want to use this as it loops though the entire database.
+#[allow(dead_code)]
 pub(super) fn lmdb_map_inplace<F, V, R>(
     txn: &WriteTransaction<'_>,
     db: &Database,


### PR DESCRIPTION
Description
---
- removes bugfix migration that no longer applies

Motivation and Context
---
Bug introduced in #4749 and fixed in #4791 can now be removed since enough nodes have upgraded.

How Has This Been Tested?
---
Just checked lints
