### PR TITLE
fix: correct value for validator_node_timeout consensus constant in localnet

### DIFF
--- a/base_layer/core/src/consensus/consensus_constants.rs
+++ b/base_layer/core/src/consensus/consensus_constants.rs
@@ -329,7 +329,7 @@ impl ConsensusConstants {
             output_version_range,
             kernel_version_range,
             permitted_output_types: OutputType::all(),
-            validator_node_timeout: 0,
+            validator_node_timeout: 100,
         }]
     }
 


### PR DESCRIPTION
Description
---
Changed the `validator_node_timeout` consensus constant from `0` to `100` in the `localnet` network.

Motivation and Context
---
We use the `localnet` network in the `tari-dan` project `cucumber-rs` integration tests. The current value for the `validator_node_timeout` constant in that network is `0`, which makes the validator node registrations to never be valid. It should be a reasonable value, similar to the `igor` network.

How Has This Been Tested?
---
With this change, in the `tari-dan` project `cucumber-rs` integration tests does now list registered validator nodes
