### PR TITLE
feat!: add tari address for wallet to use

### DIFF
--- a/.license.ignore
+++ b/.license.ignore
@@ -12,6 +12,7 @@
 ./applications/tari_base_node/osx-pkg/scripts/preinstall
 ./applications/tari_console_wallet/linux/start_tari_console_wallet
 ./base_layer/key_manager/Makefile
+./base_layer/wallet/src/schema.rs
 ./base_layer/p2p/src/dns/roots/tls.rs
 ./buildtools/docker/torrc
 ./docs/src/theme/book.js

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2877,9 +2877,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "111.22.0+1.1.1q"
+version = "111.24.0+1.1.1s"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f31f0d509d1c1ae9cada2f9539ff8f37933831fd5098879e482aa687d659853"
+checksum = "3498f259dab01178c6228c6b00dcef0ed2a2d5e20d648c017861227773ea4abd"
 dependencies = [
  "cc",
 ]
@@ -4516,6 +4516,7 @@ dependencies = [
  "lazy_static",
  "rand 0.7.3",
  "serde",
+ "tari_common",
  "tari_crypto",
  "tari_utilities",
  "thiserror",

--- a/applications/tari_app_grpc/proto/wallet.proto
+++ b/applications/tari_app_grpc/proto/wallet.proto
@@ -169,8 +169,8 @@ message GetTransactionInfoResponse {
 
 message TransactionInfo {
     uint64 tx_id = 1;
-    bytes source_pk = 2;
-    bytes dest_pk = 3;
+    bytes source_address = 2;
+    bytes dest_address = 3;
     TransactionStatus status = 4;
     TransactionDirection direction = 5;
     uint64 amount = 6;
@@ -310,8 +310,8 @@ message TransactionEventRequest{
 message TransactionEvent {
     string event = 1;
     string tx_id = 2;
-    bytes source_pk = 3;
-    bytes dest_pk = 4;
+    bytes source_address = 3;
+    bytes dest_address = 4;
     string status = 5;
     string direction = 6;
     uint64 amount = 7;

--- a/applications/tari_console_wallet/src/automation/commands.rs
+++ b/applications/tari_console_wallet/src/automation/commands.rs
@@ -40,6 +40,7 @@ use strum_macros::{Display, EnumIter, EnumString};
 use tari_app_grpc::authentication::salted_password::create_salted_hashed_password;
 use tari_common_types::{
     emoji::EmojiId,
+    tari_address::TariAddress,
     transaction::TxId,
     types::{CommitmentFactory, FixedHash, PublicKey, Signature},
 };
@@ -112,12 +113,12 @@ pub async fn send_tari(
     mut wallet_transaction_service: TransactionServiceHandle,
     fee_per_gram: u64,
     amount: MicroTari,
-    dest_pubkey: PublicKey,
+    destination: TariAddress,
     message: String,
 ) -> Result<TxId, CommandError> {
     wallet_transaction_service
         .send_transaction(
-            dest_pubkey,
+            destination,
             amount,
             UtxoSelectionCriteria::default(),
             OutputFeatures::default(),
@@ -146,11 +147,11 @@ pub async fn init_sha_atomic_swap(
     fee_per_gram: u64,
     amount: MicroTari,
     selection_criteria: UtxoSelectionCriteria,
-    dest_pubkey: PublicKey,
+    dest_address: TariAddress,
     message: String,
 ) -> Result<(TxId, PublicKey, TransactionOutput), CommandError> {
     let (tx_id, pre_image, output) = wallet_transaction_service
-        .send_sha_atomic_swap_transaction(dest_pubkey, amount, selection_criteria, fee_per_gram * uT, message)
+        .send_sha_atomic_swap_transaction(dest_address, amount, selection_criteria, fee_per_gram * uT, message)
         .await
         .map_err(CommandError::TransactionServiceError)?;
     Ok((tx_id, pre_image, output))
@@ -217,12 +218,12 @@ pub async fn send_one_sided(
     fee_per_gram: u64,
     amount: MicroTari,
     selection_criteria: UtxoSelectionCriteria,
-    dest_pubkey: PublicKey,
+    dest_address: TariAddress,
     message: String,
 ) -> Result<TxId, CommandError> {
     wallet_transaction_service
         .send_one_sided_transaction(
-            dest_pubkey,
+            dest_address,
             amount,
             selection_criteria,
             OutputFeatures::default(),
@@ -238,12 +239,12 @@ pub async fn send_one_sided_to_stealth_address(
     fee_per_gram: u64,
     amount: MicroTari,
     selection_criteria: UtxoSelectionCriteria,
-    dest_pubkey: PublicKey,
+    dest_address: TariAddress,
     message: String,
 ) -> Result<TxId, CommandError> {
     wallet_transaction_service
         .send_one_sided_to_stealth_address_transaction(
-            dest_pubkey,
+            dest_address,
             amount,
             selection_criteria,
             OutputFeatures::default(),
@@ -340,7 +341,7 @@ pub async fn make_it_rain(
     start_amount: MicroTari,
     increase_amount: MicroTari,
     start_time: DateTime<Utc>,
-    destination: PublicKey,
+    destination: TariAddress,
     transaction_type: MakeItRainTransactionType,
     message: String,
 ) -> Result<(), CommandError> {
@@ -403,14 +404,14 @@ pub async fn make_it_rain(
                 let delayed_for = Instant::now();
                 let sender_clone = sender.clone();
                 let fee = fee_per_gram;
-                let pk = destination.clone();
+                let address = destination.clone();
                 let msg = message.clone();
                 tokio::task::spawn(async move {
                     let spawn_start = Instant::now();
                     // Send transaction
                     let tx_id = match transaction_type {
                         MakeItRainTransactionType::Interactive => {
-                            send_tari(tx_service, fee, amount, pk.clone(), msg.clone()).await
+                            send_tari(tx_service, fee, amount, address.clone(), msg.clone()).await
                         },
                         MakeItRainTransactionType::OneSided => {
                             send_one_sided(
@@ -418,7 +419,7 @@ pub async fn make_it_rain(
                                 fee,
                                 amount,
                                 UtxoSelectionCriteria::default(),
-                                pk.clone(),
+                                address.clone(),
                                 msg.clone(),
                             )
                             .await
@@ -429,7 +430,7 @@ pub async fn make_it_rain(
                                 fee,
                                 amount,
                                 UtxoSelectionCriteria::default(),
-                                pk.clone(),
+                                address.clone(),
                                 msg.clone(),
                             )
                             .await
@@ -663,7 +664,7 @@ pub async fn command_runner(
                     transaction_service.clone(),
                     config.fee_per_gram,
                     args.amount,
-                    args.destination.into(),
+                    args.destination,
                     args.message,
                 )
                 .await
@@ -681,7 +682,7 @@ pub async fn command_runner(
                     config.fee_per_gram,
                     args.amount,
                     UtxoSelectionCriteria::default(),
-                    args.destination.into(),
+                    args.destination,
                     args.message,
                 )
                 .await
@@ -699,7 +700,7 @@ pub async fn command_runner(
                     config.fee_per_gram,
                     args.amount,
                     UtxoSelectionCriteria::default(),
-                    args.destination.into(),
+                    args.destination,
                     args.message,
                 )
                 .await
@@ -724,7 +725,7 @@ pub async fn command_runner(
                     args.start_amount,
                     args.increase_amount,
                     args.start_time.unwrap_or_else(Utc::now),
-                    args.destination.into(),
+                    args.destination,
                     transaction_type,
                     args.message,
                 )
@@ -864,7 +865,7 @@ pub async fn command_runner(
                     config.fee_per_gram,
                     args.amount,
                     UtxoSelectionCriteria::default(),
-                    args.destination.into(),
+                    args.destination,
                     args.message,
                 )
                 .await

--- a/applications/tari_console_wallet/src/cli.rs
+++ b/applications/tari_console_wallet/src/cli.rs
@@ -30,6 +30,7 @@ use chrono::{DateTime, Utc};
 use clap::{Args, Parser, Subcommand};
 use tari_app_utilities::{common_cli_args::CommonCliArgs, utilities::UniPublicKey};
 use tari_common::configuration::{ConfigOverrideProvider, Network};
+use tari_common_types::tari_address::TariAddress;
 use tari_comms::multiaddr::Multiaddr;
 use tari_core::transactions::{tari_amount, tari_amount::MicroTari};
 use tari_utilities::{
@@ -142,7 +143,7 @@ pub struct DiscoverPeerArgs {
 #[derive(Debug, Args, Clone)]
 pub struct SendTariArgs {
     pub amount: MicroTari,
-    pub destination: UniPublicKey,
+    pub destination: TariAddress,
     #[clap(short, long, default_value = "<No message>")]
     pub message: String,
 }
@@ -156,7 +157,7 @@ pub struct BurnTariArgs {
 
 #[derive(Debug, Args, Clone)]
 pub struct MakeItRainArgs {
-    pub destination: UniPublicKey,
+    pub destination: TariAddress,
     #[clap(short, long, alias="amount", default_value_t = tari_amount::T)]
     pub start_amount: MicroTari,
     #[clap(short, long, alias = "tps", default_value_t = 25)]

--- a/applications/tari_console_wallet/src/grpc/mod.rs
+++ b/applications/tari_console_wallet/src/grpc/mod.rs
@@ -4,7 +4,6 @@
 mod wallet_grpc_server;
 
 use tari_app_grpc::tari_rpc::TransactionEvent;
-use tari_utilities::hex::Hex;
 use tari_wallet::transaction_service::storage::models::{
     CompletedTransaction,
     InboundTransaction,
@@ -24,8 +23,8 @@ pub fn convert_to_transaction_event(event: String, source: TransactionWrapper) -
         TransactionWrapper::Completed(completed) => TransactionEvent {
             event,
             tx_id: completed.tx_id.to_string(),
-            source_pk: completed.source_public_key.to_hex().into_bytes(),
-            dest_pk: completed.destination_public_key.to_hex().into_bytes(),
+            source_address: completed.source_address.to_bytes().to_vec(),
+            dest_address: completed.destination_address.to_bytes().to_vec(),
             status: completed.status.to_string(),
             direction: completed.direction.to_string(),
             amount: completed.amount.as_u64(),
@@ -35,8 +34,8 @@ pub fn convert_to_transaction_event(event: String, source: TransactionWrapper) -
         TransactionWrapper::Outbound(outbound) => TransactionEvent {
             event,
             tx_id: outbound.tx_id.to_string(),
-            source_pk: vec![],
-            dest_pk: outbound.destination_public_key.to_hex().into_bytes(),
+            source_address: vec![],
+            dest_address: outbound.destination_address.to_bytes().to_vec(),
             status: outbound.status.to_string(),
             direction: "outbound".to_string(),
             amount: outbound.amount.as_u64(),
@@ -46,8 +45,8 @@ pub fn convert_to_transaction_event(event: String, source: TransactionWrapper) -
         TransactionWrapper::Inbound(inbound) => TransactionEvent {
             event,
             tx_id: inbound.tx_id.to_string(),
-            source_pk: inbound.source_public_key.to_hex().into_bytes(),
-            dest_pk: vec![],
+            source_address: inbound.source_address.to_bytes().to_vec(),
+            dest_address: vec![],
             status: inbound.status.to_string(),
             direction: "inbound".to_string(),
             amount: inbound.amount.as_u64(),

--- a/applications/tari_console_wallet/src/notifier/mod.rs
+++ b/applications/tari_console_wallet/src/notifier/mod.rs
@@ -311,8 +311,8 @@ fn args_from_complete(tx: &CompletedTransaction, event: &str, confirmations: Opt
         amount,
         tx.tx_id.to_string(),
         tx.message.clone(),
-        tx.source_public_key.to_hex(),
-        tx.destination_public_key.to_hex(),
+        tx.source_address.to_hex(),
+        tx.destination_address.to_hex(),
         status,
         excess,
         public_nonce,
@@ -332,7 +332,7 @@ fn args_from_outbound(tx: &OutboundTransaction, event: &str) -> Vec<String> {
         amount,
         tx.tx_id.to_string(),
         tx.message.clone(),
-        tx.destination_public_key.to_hex(),
+        tx.destination_address.to_hex(),
         status,
         "outbound".to_string(),
     ]
@@ -348,7 +348,7 @@ fn args_from_inbound(tx: &InboundTransaction, event: &str) -> Vec<String> {
         amount,
         tx.tx_id.to_string(),
         tx.message.clone(),
-        tx.source_public_key.to_hex(),
+        tx.source_address.to_hex(),
         status,
         "inbound".to_string(),
     ]

--- a/applications/tari_console_wallet/src/ui/app.rs
+++ b/applications/tari_console_wallet/src/ui/app.rs
@@ -20,9 +20,8 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use tari_common::configuration::Network;
 use tari_comms::peer_manager::Peer;
-use tari_wallet::{WalletConfig, WalletSqlite};
+use tari_wallet::{util::wallet_identity::WalletIdentity, WalletConfig, WalletSqlite};
 use tokio::runtime::Handle;
 use tui::{
     backend::Backend,
@@ -71,15 +70,14 @@ impl<B: Backend> App<B> {
     pub fn new(
         title: String,
         wallet: WalletSqlite,
-        network: Network,
         wallet_config: WalletConfig,
         base_node_selected: Peer,
         base_node_config: PeerConfig,
         notifier: Notifier,
     ) -> Self {
+        let wallet_id = WalletIdentity::new(wallet.comms.node_identity(), wallet.network.as_network());
         let app_state = AppState::new(
-            wallet.comms.node_identity().as_ref(),
-            network,
+            &wallet_id,
             wallet,
             base_node_selected.clone(),
             base_node_config,

--- a/applications/tari_console_wallet/src/ui/components/receive_tab.rs
+++ b/applications/tari_console_wallet/src/ui/components/receive_tab.rs
@@ -57,20 +57,20 @@ impl ReceiveTab {
             .title(Span::styled("Connection Details", Style::default().fg(Color::White)));
         f.render_widget(block, chunks[0]);
 
-        const ITEM_01: &str = "Public Key:     ";
+        const ITEM_01: &str = "Tari Address:     ";
         const ITEM_02: &str = "Node ID:        ";
-        const ITEM_03: &str = "Public Address: ";
+        const ITEM_03: &str = "Network Address: ";
         const ITEM_04: &str = "Emoji ID:       ";
 
-        // Public Key
-        let public_key_text = Spans::from(vec![
+        // Tari address
+        let tari_address_text = Spans::from(vec![
             Span::styled(ITEM_01, Style::default().fg(Color::Magenta)),
             Span::styled(
-                app_state.get_identity().public_key.clone(),
+                app_state.get_identity().tari_address.clone(),
                 Style::default().fg(Color::White),
             ),
         ]);
-        let paragraph = Paragraph::new(public_key_text).block(Block::default());
+        let paragraph = Paragraph::new(tari_address_text).block(Block::default());
         f.render_widget(paragraph, details_chunks[0]);
 
         // NodeId
@@ -85,14 +85,14 @@ impl ReceiveTab {
         f.render_widget(paragraph, details_chunks[1]);
 
         // Public Address
-        let public_ddress_text = Spans::from(vec![
+        let public_address_text = Spans::from(vec![
             Span::styled(ITEM_03, Style::default().fg(Color::Magenta)),
             Span::styled(
-                app_state.get_identity().public_address.clone(),
+                app_state.get_identity().network_address.clone(),
                 Style::default().fg(Color::White),
             ),
         ]);
-        let paragraph = Paragraph::new(public_ddress_text).block(Block::default());
+        let paragraph = Paragraph::new(public_address_text).block(Block::default());
         f.render_widget(paragraph, details_chunks[2]);
 
         // Emoji ID

--- a/applications/tari_console_wallet/src/ui/components/send_tab.rs
+++ b/applications/tari_console_wallet/src/ui/components/send_tab.rs
@@ -123,7 +123,7 @@ impl SendTab {
             .block(
                 Block::default()
                     .borders(Borders::ALL)
-                    .title("(T)o (Public Key or Emoji ID) :"),
+                    .title("(T)o (Tari Address or Emoji ID) :"),
             );
         f.render_widget(to_input, vert_chunks[1]);
 
@@ -402,7 +402,7 @@ impl SendTab {
                 .and_then(|i| app_state.get_contact(i))
                 .cloned()
             {
-                self.to_field = c.public_key;
+                self.to_field = c.address;
                 self.send_input_mode = SendInputMode::Amount;
                 self.show_contacts = false;
             }
@@ -577,7 +577,8 @@ impl<B: Backend> Component<B> for SendTab {
             'm' => self.send_input_mode = SendInputMode::Message,
             's' | 'o' | 'x' => {
                 if self.to_field.is_empty() {
-                    self.error_message = Some("Destination Public Key/Emoji ID\nPress Enter to continue.".to_string());
+                    self.error_message =
+                        Some("Destination Tari Address/Emoji ID\nPress Enter to continue.".to_string());
                     return;
                 }
                 if self.amount_field.is_empty() && self.selected_unique_id.is_none() {

--- a/applications/tari_console_wallet/src/ui/components/transactions_tab.rs
+++ b/applications/tari_console_wallet/src/ui/components/transactions_tab.rs
@@ -106,7 +106,7 @@ impl TransactionsTab {
                 .to_owned();
             if t.direction == TransactionDirection::Outbound {
                 column0_items.push(ListItem::new(Span::styled(
-                    app_state.get_alias(&t.destination_public_key),
+                    app_state.get_alias(&t.destination_address),
                     Style::default().fg(text_color),
                 )));
                 let amount_style = if t.cancelled.is_some() {
@@ -118,7 +118,7 @@ impl TransactionsTab {
                 column1_items.push(ListItem::new(Span::styled(amount, amount_style)));
             } else {
                 column0_items.push(ListItem::new(Span::styled(
-                    app_state.get_alias(&t.source_public_key),
+                    app_state.get_alias(&t.source_address),
                     Style::default().fg(text_color),
                 )));
                 let amount_style = if t.cancelled.is_some() {
@@ -200,7 +200,7 @@ impl TransactionsTab {
             let text_color = text_colors.get(&cancelled).unwrap_or(&Color::Reset).to_owned();
             if t.direction == TransactionDirection::Outbound {
                 column0_items.push(ListItem::new(Span::styled(
-                    app_state.get_alias(&t.destination_public_key),
+                    app_state.get_alias(&t.destination_address),
                     Style::default().fg(text_color),
                 )));
                 let amount_style = if t.cancelled.is_some() {
@@ -212,7 +212,7 @@ impl TransactionsTab {
                 column1_items.push(ListItem::new(Span::styled(amount, amount_style)));
             } else {
                 column0_items.push(ListItem::new(Span::styled(
-                    app_state.get_alias(&t.source_public_key),
+                    app_state.get_alias(&t.source_address),
                     Style::default().fg(text_color),
                 )));
                 let color = match (t.cancelled.is_some(), chain_height) {
@@ -328,16 +328,13 @@ impl TransactionsTab {
                 if tx.status == TransactionStatus::Pending && tx.direction == TransactionDirection::Outbound {
                     Span::raw("")
                 } else {
-                    Span::styled(format!("{}", tx.source_public_key), Style::default().fg(Color::White))
+                    Span::styled(format!("{}", tx.source_address), Style::default().fg(Color::White))
                 };
             let destination_public_key =
                 if tx.status == TransactionStatus::Pending && tx.direction == TransactionDirection::Inbound {
                     Span::raw("")
                 } else {
-                    Span::styled(
-                        format!("{}", tx.destination_public_key),
-                        Style::default().fg(Color::White),
-                    )
+                    Span::styled(format!("{}", tx.destination_address), Style::default().fg(Color::White))
                 };
             let direction = Span::styled(format!("{}", tx.direction), Style::default().fg(Color::White));
             let amount = tx.amount.to_string();

--- a/applications/tari_console_wallet/src/ui/state/tasks.rs
+++ b/applications/tari_console_wallet/src/ui/state/tasks.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use tari_comms::types::CommsPublicKey;
+use tari_common_types::tari_address::TariAddress;
 use tari_core::transactions::{tari_amount::MicroTari, transaction_components::OutputFeatures};
 use tari_wallet::{
     output_manager_service::UtxoSelectionCriteria,
@@ -33,7 +33,7 @@ use crate::ui::{state::UiTransactionSendStatus, UiError};
 const LOG_TARGET: &str = "wallet::console_wallet::tasks ";
 
 pub async fn send_transaction_task(
-    public_key: CommsPublicKey,
+    address: TariAddress,
     amount: MicroTari,
     selection_criteria: UtxoSelectionCriteria,
     output_features: OutputFeatures,
@@ -47,7 +47,7 @@ pub async fn send_transaction_task(
     let mut send_status = TransactionSendStatus::default();
     match transaction_service_handle
         .send_transaction(
-            public_key,
+            address,
             amount,
             selection_criteria,
             output_features,
@@ -109,7 +109,7 @@ pub async fn send_transaction_task(
 }
 
 pub async fn send_one_sided_transaction_task(
-    public_key: CommsPublicKey,
+    address: TariAddress,
     amount: MicroTari,
     selection_criteria: UtxoSelectionCriteria,
     output_features: OutputFeatures,
@@ -122,7 +122,7 @@ pub async fn send_one_sided_transaction_task(
     let mut event_stream = transaction_service_handle.get_event_stream();
     match transaction_service_handle
         .send_one_sided_transaction(
-            public_key,
+            address,
             amount,
             selection_criteria,
             output_features,
@@ -163,7 +163,7 @@ pub async fn send_one_sided_transaction_task(
 }
 
 pub async fn send_one_sided_to_stealth_address_transaction(
-    dest_pubkey: CommsPublicKey,
+    address: TariAddress,
     amount: MicroTari,
     selection_criteria: UtxoSelectionCriteria,
     output_features: OutputFeatures,
@@ -176,7 +176,7 @@ pub async fn send_one_sided_to_stealth_address_transaction(
     let mut event_stream = transaction_service_handle.get_event_stream();
     match transaction_service_handle
         .send_one_sided_to_stealth_address_transaction(
-            dest_pubkey,
+            address,
             amount,
             selection_criteria,
             output_features,

--- a/applications/tari_console_wallet/src/ui/ui_contact.rs
+++ b/applications/tari_console_wallet/src/ui/ui_contact.rs
@@ -2,13 +2,12 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 use chrono::{DateTime, Local};
-use tari_common_types::emoji::EmojiId;
 use tari_wallet::contacts_service::storage::database::Contact;
 
 #[derive(Debug, Clone)]
 pub struct UiContact {
     pub alias: String,
-    pub public_key: String,
+    pub address: String,
     pub emoji_id: String,
     pub last_seen: String,
     pub online_status: String,
@@ -25,8 +24,8 @@ impl From<Contact> for UiContact {
     fn from(c: Contact) -> Self {
         Self {
             alias: c.alias,
-            public_key: c.public_key.to_string(),
-            emoji_id: EmojiId::from_public_key(&c.public_key).to_emoji_string(),
+            address: c.address.to_hex(),
+            emoji_id: c.address.to_emoji_string(),
             last_seen: match c.last_seen {
                 Some(val) => DateTime::<Local>::from_utc(val, Local::now().offset().to_owned())
                     .format("%m-%dT%H:%M")

--- a/applications/tari_console_wallet/src/wallet_modes.rs
+++ b/applications/tari_console_wallet/src/wallet_modes.rs
@@ -296,7 +296,6 @@ pub fn tui_mode(
     let app = App::<CrosstermBackend<Stdout>>::new(
         "Tari Console Wallet".into(),
         wallet,
-        config.network,
         config.clone(),
         base_node_selected,
         base_node_config.clone(),
@@ -412,6 +411,7 @@ async fn run_grpc(
 
 #[cfg(test)]
 mod test {
+
     use crate::{cli::CliCommands, wallet_modes::parse_command_file};
 
     #[test]
@@ -425,7 +425,7 @@ mod test {
 
             discover-peer f6b2ca781342a3ebe30ee1643655c96f1d7c14f4d49f077695395de98ae73665
 
-            send-tari --message Our_secret! 125T 5c4f2a4b3f3f84e047333218a84fd24f581a9d7e4f23b78e3714e9d174427d61
+            send-tari --message Our_secret! 125T 5c4f2a4b3f3f84e047333218a84fd24f581a9d7e4f23b78e3714e9d174427d615e
             
             burn-tari --message Ups_these_funds_will_be_burned! 100T
 
@@ -433,7 +433,7 @@ mod test {
 
             make-it-rain --duration 100 --transactions-per-second 10 --start-amount 0.009200T --increase-amount 0T \
                       --start-time now --message Stressing_it_a_bit...!_(from_Feeling-a-bit-Generous) \
-                      5c4f2a4b3f3f84e047333218a84fd24f581a9d7e4f23b78e3714e9d174427d61
+                      5c4f2a4b3f3f84e047333218a84fd24f581a9d7e4f23b78e3714e9d174427d615e
 
             # End of script file
             "

--- a/base_layer/common_types/Cargo.toml
+++ b/base_layer/common_types/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 [dependencies]
 tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.7" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag="v0.4.7" }
+tari_common = { version = "^0.39", path = "../../common" }
 
 base64 = "0.13.0"
 digest = "0.9.0"

--- a/base_layer/common_types/src/emoji.rs
+++ b/base_layer/common_types/src/emoji.rs
@@ -75,7 +75,7 @@ const INTERNAL_SIZE: usize = 32; // number of bytes used for the internal repres
 const CHECKSUM_SIZE: usize = 1; // number of bytes in the checksum
 
 // The emoji table, mapping byte values to emoji characters
-const EMOJI: [char; DICT_SIZE] = [
+pub const EMOJI: [char; DICT_SIZE] = [
     '🌀', '🌂', '🌈', '🌊', '🌋', '🌍', '🌙', '🌝', '🌞', '🌟', '🌠', '🌰', '🌴', '🌵', '🌷', '🌸', '🌹', '🌻', '🌽',
     '🍀', '🍁', '🍄', '🍅', '🍆', '🍇', '🍈', '🍉', '🍊', '🍋', '🍌', '🍍', '🍎', '🍐', '🍑', '🍒', '🍓', '🍔', '🍕',
     '🍗', '🍚', '🍞', '🍟', '🍠', '🍣', '🍦', '🍩', '🍪', '🍫', '🍬', '🍭', '🍯', '🍰', '🍳', '🍴', '🍵', '🍶', '🍷',
@@ -94,7 +94,7 @@ const EMOJI: [char; DICT_SIZE] = [
 
 // The reverse table, mapping emoji to characters to byte values
 lazy_static! {
-    static ref REVERSE_EMOJI: HashMap<char, u8> = {
+    pub static ref REVERSE_EMOJI: HashMap<char, u8> = {
         let mut m = HashMap::with_capacity(DICT_SIZE);
         EMOJI.iter().enumerate().for_each(|(i, c)| {
             m.insert(*c, i as u8);

--- a/base_layer/common_types/src/lib.rs
+++ b/base_layer/common_types/src/lib.rs
@@ -24,6 +24,7 @@ pub mod chain_metadata;
 pub mod dammsum;
 pub mod emoji;
 pub mod grpc_authentication;
+pub mod tari_address;
 pub mod transaction;
 mod tx_id;
 pub mod types;

--- a/base_layer/common_types/src/tari_address.rs
+++ b/base_layer/common_types/src/tari_address.rs
@@ -1,0 +1,352 @@
+// Copyright 2020. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::{
+    convert::TryFrom,
+    fmt::{Display, Error, Formatter},
+    str::FromStr,
+};
+
+use serde::{Deserialize, Serialize};
+use tari_common::configuration::Network;
+use tari_crypto::tari_utilities::ByteArray;
+use tari_utilities::hex::{from_hex, Hex};
+use thiserror::Error;
+
+use crate::{
+    dammsum::{compute_checksum, validate_checksum},
+    emoji::{EMOJI, REVERSE_EMOJI},
+    types::PublicKey,
+};
+
+const INTERNAL_SIZE: usize = 33; // number of bytes used for the internal representation
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct TariAddress {
+    network: Network,
+    public_key: PublicKey,
+}
+
+#[derive(Debug, Error, PartialEq)]
+pub enum TariAddressError {
+    #[error("Invalid size")]
+    InvalidSize,
+    #[error("Invalid network or checksum")]
+    InvalidNetworkOrChecksum,
+    #[error("Invalid emoji character")]
+    InvalidEmoji,
+    #[error("Cannot recover public key")]
+    CannotRecoverPublicKey,
+}
+
+impl TariAddress {
+    /// Creates a new Tari Address from the provided public key and network while using the current version
+    pub fn new(public_key: PublicKey, network: Network) -> Self {
+        TariAddress { network, public_key }
+    }
+
+    /// helper function to convert emojis to u8
+    fn emoji_to_bytes(emoji: &str) -> Result<Vec<u8>, TariAddressError> {
+        // The string must be the correct size, including the checksum
+        if emoji.chars().count() != INTERNAL_SIZE {
+            return Err(TariAddressError::InvalidSize);
+        }
+
+        // Convert the emoji string to a byte array
+        let mut bytes = Vec::<u8>::with_capacity(INTERNAL_SIZE);
+        for c in emoji.chars() {
+            if let Some(i) = REVERSE_EMOJI.get(&c) {
+                bytes.push(*i);
+            } else {
+                return Err(TariAddressError::InvalidEmoji);
+            }
+        }
+        Ok(bytes)
+    }
+
+    /// Construct an TariAddress from an emoji string with checksum and network
+    pub fn from_emoji_string_with_network(emoji: &str, network: Network) -> Result<Self, TariAddressError> {
+        let bytes = TariAddress::emoji_to_bytes(emoji)?;
+
+        TariAddress::from_bytes_with_network(&bytes, network)
+    }
+
+    /// Construct an TariAddress from an emoji string with checksum trying to calculate the network
+    pub fn from_emoji_string(emoji: &str) -> Result<Self, TariAddressError> {
+        let bytes = TariAddress::emoji_to_bytes(emoji)?;
+
+        TariAddress::from_bytes(&bytes)
+    }
+
+    /// Construct an Tari Address from a public key
+    pub fn from_public_key(public_key: &PublicKey, network: Network) -> Self {
+        Self {
+            network,
+            public_key: public_key.clone(),
+        }
+    }
+
+    /// Gets the network from the Tari Address
+    pub fn network(&self) -> Network {
+        self.network
+    }
+
+    /// Convert Tari Address to an emoji string with checksum
+    pub fn to_emoji_string(&self) -> String {
+        // Convert the public key to bytes and compute the checksum
+        let bytes = self.to_bytes();
+        bytes.iter().map(|b| EMOJI[*b as usize]).collect::<String>()
+    }
+
+    /// Return the public key of an Tari Address
+    pub fn public_key(&self) -> &PublicKey {
+        &self.public_key
+    }
+
+    /// Construct Tari Address from bytes with network
+    pub fn from_bytes_with_network(bytes: &[u8], network: Network) -> Result<TariAddress, TariAddressError>
+    where Self: Sized {
+        if bytes.len() != INTERNAL_SIZE {
+            return Err(TariAddressError::InvalidSize);
+        }
+        let mut fixed_data = bytes.to_vec();
+        fixed_data[32] ^= network.as_byte();
+        // Assert the checksum is valid
+        if validate_checksum(&fixed_data).is_err() {
+            return Err(TariAddressError::InvalidNetworkOrChecksum);
+        }
+        let key = PublicKey::from_bytes(&bytes[0..32]).map_err(|_| TariAddressError::CannotRecoverPublicKey)?;
+        Ok(TariAddress {
+            public_key: key,
+            network,
+        })
+    }
+
+    /// Construct Tari Address from bytes and try to calculate the network
+    pub fn from_bytes(bytes: &[u8]) -> Result<TariAddress, TariAddressError>
+    where Self: Sized {
+        if bytes.len() != INTERNAL_SIZE {
+            return Err(TariAddressError::InvalidSize);
+        }
+        let checksum = compute_checksum(&bytes[0..32].to_vec());
+        // if the network is a valid network number, we can assume that the checksum as valid
+        let network =
+            Network::try_from(checksum ^ bytes[32]).map_err(|_| TariAddressError::InvalidNetworkOrChecksum)?;
+        let key = PublicKey::from_bytes(&bytes[0..32]).map_err(|_| TariAddressError::CannotRecoverPublicKey)?;
+        Ok(TariAddress {
+            public_key: key,
+            network,
+        })
+    }
+
+    /// Convert Tari Address to bytes
+    pub fn to_bytes(&self) -> [u8; INTERNAL_SIZE] {
+        let mut buf = [0u8; INTERNAL_SIZE];
+        buf[0..32].copy_from_slice(self.public_key.as_bytes());
+        let checksum = compute_checksum(&buf[0..32].to_vec());
+        buf[32] = self.network.as_byte() ^ checksum;
+        buf
+    }
+
+    /// Construct Tari Address from hex with network
+    pub fn from_hex_with_network(hex_str: &str, network: Network) -> Result<TariAddress, TariAddressError> {
+        let buf = from_hex(hex_str).map_err(|_| TariAddressError::CannotRecoverPublicKey)?;
+        TariAddress::from_bytes_with_network(buf.as_slice(), network)
+    }
+
+    /// Construct Tari Address from hex  and try to calculate the network
+    pub fn from_hex(hex_str: &str) -> Result<TariAddress, TariAddressError> {
+        let buf = from_hex(hex_str).map_err(|_| TariAddressError::CannotRecoverPublicKey)?;
+        TariAddress::from_bytes(buf.as_slice())
+    }
+
+    /// Convert Tari Address to bytes
+    pub fn to_hex(&self) -> String {
+        let buf = self.to_bytes();
+        buf.to_hex()
+    }
+}
+
+impl FromStr for TariAddress {
+    type Err = TariAddressError;
+
+    fn from_str(key: &str) -> Result<Self, Self::Err> {
+        if let Ok(address) = TariAddress::from_emoji_string(&key.trim().replace('|', "")) {
+            Ok(address)
+        } else if let Ok(address) = TariAddress::from_hex(key) {
+            Ok(address)
+        } else {
+            Err(TariAddressError::CannotRecoverPublicKey)
+        }
+    }
+}
+
+impl Display for TariAddress {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
+        fmt.write_str(&self.to_emoji_string())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use tari_crypto::keys::{PublicKey, SecretKey};
+
+    use super::*;
+    use crate::types::PrivateKey;
+
+    #[test]
+    /// Test valid tari address
+    fn valid_emoji_id() {
+        // Generate random public key
+        let mut rng = rand::thread_rng();
+        let public_key = PublicKey::from_secret_key(&PrivateKey::random(&mut rng));
+
+        // Generate an emoji ID from the public key and ensure we recover it
+        let emoji_id_from_public_key = TariAddress::from_public_key(&public_key, Network::Esmeralda);
+        assert_eq!(emoji_id_from_public_key.public_key(), &public_key);
+
+        // Check the size of the corresponding emoji string
+        let emoji_string = emoji_id_from_public_key.to_emoji_string();
+        assert_eq!(emoji_string.chars().count(), INTERNAL_SIZE);
+
+        // Generate an emoji ID from the emoji string and ensure we recover it
+        let emoji_id_from_emoji_string = TariAddress::from_emoji_string(&emoji_string).unwrap();
+        assert_eq!(emoji_id_from_emoji_string.to_emoji_string(), emoji_string);
+
+        // Return to the original public key for good measure
+        assert_eq!(emoji_id_from_emoji_string.public_key(), &public_key);
+    }
+
+    #[test]
+    /// Test encoding for tari address
+    fn encoding() {
+        // Generate random public key
+        let mut rng = rand::thread_rng();
+        let public_key = PublicKey::from_secret_key(&PrivateKey::random(&mut rng));
+
+        // Generate an emoji ID from the public key and ensure we recover it
+        let address = TariAddress::from_public_key(&public_key, Network::Esmeralda);
+
+        let buff = address.to_bytes();
+        let hex = address.to_hex();
+
+        let address_buff = TariAddress::from_bytes(&buff);
+        assert_eq!(address_buff, Ok(address.clone()));
+
+        let address_buff = TariAddress::from_bytes_with_network(&buff, Network::Esmeralda);
+        assert_eq!(address_buff, Ok(address.clone()));
+
+        let address_hex = TariAddress::from_hex(&hex);
+        assert_eq!(address_hex, Ok(address.clone()));
+
+        let address_hex = TariAddress::from_hex_with_network(&hex, Network::Esmeralda);
+        assert_eq!(address_hex, Ok(address));
+    }
+
+    #[test]
+    /// Test invalid size
+    fn invalid_size() {
+        // This emoji string is too short to be a valid emoji ID
+        let emoji_string = "🌴🐩🔌📌🚑🌰🎓🌴🐊🐌💕💡🐜📉👛🍵👛🐽🎂🐻🌀🍓😿🐭🐼🏀🎪💔💸🍅🔋🎒";
+        assert_eq!(
+            TariAddress::from_emoji_string(emoji_string),
+            Err(TariAddressError::InvalidSize)
+        );
+        // This emoji string is too long to be a valid emoji ID
+        let emoji_string = "🌴🐩🔌📌🚑🌰🎓🌴🐊🐌💕💡🐜📉👛🍵👛🐽🎂🐻🌀🍓😿🐭🐼🏀🎪💔💸🍅🔋🎒🎒🎒🎒🎒";
+        assert_eq!(
+            TariAddress::from_emoji_string(emoji_string),
+            Err(TariAddressError::InvalidSize)
+        );
+    }
+
+    #[test]
+    /// Test invalid emoji
+    fn invalid_emoji() {
+        // This emoji string contains an invalid emoji character
+        let emoji_string = "🌴🐩🔌📌🚑🌰🎓🌴🐊🐌💕💡🐜📉👛🍵👛🐽🎂🐻🌀🍓😿🐭🐼🏀🎪💔💸🍅🔋🎒🎅";
+        assert_eq!(
+            TariAddress::from_emoji_string(emoji_string),
+            Err(TariAddressError::InvalidEmoji)
+        );
+    }
+
+    #[test]
+    /// Test invalid checksum
+    fn invalid_checksum() {
+        // This emoji string contains an invalid checksum
+        let emoji_string = "🌴🐩🔌📌🚑🌰🎓🌴🐊🐌💕💡🐜📉👛🍵👛🐽🎂🐻🌀🍓😿🐭🐼🏀🎪💔💸🍅🔋🎒🎒";
+        assert_eq!(
+            TariAddress::from_emoji_string(emoji_string),
+            Err(TariAddressError::InvalidNetworkOrChecksum)
+        );
+    }
+
+    #[test]
+    /// Test invalid network
+    fn invalid_network() {
+        let mut rng = rand::thread_rng();
+        let public_key = PublicKey::from_secret_key(&PrivateKey::random(&mut rng));
+
+        let emoji_id_from_public_key = TariAddress::from_public_key(&public_key, Network::Esmeralda);
+
+        // let create byte string with bad network u8
+        let mut buf = [0u8; INTERNAL_SIZE];
+        buf[0..32].copy_from_slice(emoji_id_from_public_key.public_key.as_bytes());
+        let checksum = compute_checksum(&buf[0..32].to_vec());
+        // 0xb3 is a bad network
+        buf[32] = 0xb3 ^ checksum;
+
+        let mut bytes = emoji_id_from_public_key.to_bytes();
+        // make the network invalid
+        bytes[1] = 0xb3;
+        let emoji_string = bytes.iter().map(|b| EMOJI[*b as usize]).collect::<String>();
+
+        // This emoji string contains an invalid checksum
+        assert_eq!(
+            TariAddress::from_emoji_string(&emoji_string),
+            Err(TariAddressError::InvalidNetworkOrChecksum)
+        );
+
+        // This emoji string contains an invalid checksum
+        assert_eq!(
+            TariAddress::from_emoji_string_with_network(&emoji_string, Network::Esmeralda),
+            Err(TariAddressError::InvalidNetworkOrChecksum)
+        );
+    }
+
+    #[test]
+    /// Test invalid public key
+    fn invalid_public_key() {
+        let mut bytes = [0; 33].to_vec();
+        bytes[0] = 1;
+        let checksum = compute_checksum(&bytes[0..32].to_vec());
+        bytes[32] = Network::Esmeralda.as_byte() ^ checksum;
+        let emoji_string = bytes.iter().map(|b| EMOJI[*b as usize]).collect::<String>();
+
+        // This emoji string contains an invalid checksum
+        assert_eq!(
+            TariAddress::from_emoji_string(&emoji_string),
+            Err(TariAddressError::CannotRecoverPublicKey)
+        );
+    }
+}

--- a/base_layer/wallet/migrations/2022-08-08-134037_initial/up.sql
+++ b/base_layer/wallet/migrations/2022-08-08-134037_initial/up.sql
@@ -5,8 +5,8 @@ CREATE TABLE client_key_values (
 
 CREATE TABLE completed_transactions (
     tx_id                       BIGINT PRIMARY KEY NOT NULL,
-    source_public_key           BLOB               NOT NULL,
-    destination_public_key      BLOB               NOT NULL,
+    source_address              BLOB               NOT NULL,
+    destination_address         BLOB               NOT NULL,
     amount                      BIGINT             NOT NULL,
     fee                         BIGINT             NOT NULL, 
     transaction_protocol        TEXT               NOT NULL,
@@ -27,7 +27,7 @@ CREATE TABLE completed_transactions (
 );
 
 CREATE TABLE contacts (
-    public_key  BLOB PRIMARY KEY NOT NULL UNIQUE,
+    address     BLOB PRIMARY KEY NOT NULL UNIQUE,
     node_id     BLOB             NOT NULL UNIQUE,
     alias       TEXT             NOT NULL,
     last_seen   DATETIME         NULL,
@@ -36,7 +36,7 @@ CREATE TABLE contacts (
 
 CREATE TABLE inbound_transactions (
     tx_id               BIGINT PRIMARY KEY NOT NULL,
-    source_public_key   BLOB               NOT NULL,
+    source_address      BLOB               NOT NULL,
     amount              BIGINT             NOT NULL,
     receiver_protocol   TEXT               NOT NULL,
     message             TEXT               NOT NULL,
@@ -54,14 +54,6 @@ CREATE TABLE key_manager_states (
     timestamp         DATETIME            NOT NULL
 );
 
-CREATE TABLE key_manager_states_old (
-    id                INTEGER PRIMARY KEY NOT NULL,
-    seed              BLOB                NOT NULL,
-    branch_seed       TEXT UNIQUE         NOT NULL,
-    primary_key_index BLOB                NOT NULL,
-    timestamp         DATETIME            NOT NULL
-);
-
 CREATE TABLE known_one_sided_payment_scripts (
     script_hash        BLOB PRIMARY KEY NOT NULL,
     private_key        BLOB             NOT NULL,
@@ -72,7 +64,7 @@ CREATE TABLE known_one_sided_payment_scripts (
 
 CREATE TABLE outbound_transactions (
     tx_id                  BIGINT PRIMARY KEY NOT NULL,
-    destination_public_key BLOB               NOT NULL,
+    destination_address    BLOB               NOT NULL,
     amount                 BIGINT             NOT NULL,
     fee                    BIGINT             NOT NULL,
     sender_protocol        TEXT               NOT NULL,
@@ -110,14 +102,11 @@ CREATE TABLE outputs (
     spent_in_tx_id             BIGINT              NULL,
     coinbase_block_height      UNSIGNED BIGINT     NULL,
     metadata                   BLOB                NULL,
-    features_parent_public_key BLOB                NULL,
-    features_unique_id         BLOB                NULL,
     features_json              TEXT                NOT NULL DEFAULT '{}',
     spending_priority          UNSIGNED INTEGER    NOT NULL DEFAULT 500,
     covenant                   BLOB                NOT NULL,
     mined_timestamp            DATETIME            NULL,
     encrypted_value            BLOB                NOT NULL,
-    contract_id                BLOB                NULL,
     minimum_value_promise    BIGINT              NOT NULL,
     source                     INTEGER             NOT NULL DEFAULT 0,
     CONSTRAINT unique_commitment UNIQUE (commitment)

--- a/base_layer/wallet/src/contacts_service/service.rs
+++ b/base_layer/wallet/src/contacts_service/service.rs
@@ -206,7 +206,7 @@ where T: ContactsBackend + 'static
                 self.liveness.check_add_monitored_peer(c.node_id).await?;
                 info!(
                     target: LOG_TARGET,
-                    "Contact Saved: \nAlias: {}\nPubKey: {} ", c.alias, c.public_key
+                    "Contact Saved: \nAlias: {}\nAddress: {} ", c.alias, c.address
                 );
                 Ok(ContactsServiceResponse::ContactSaved)
             },
@@ -217,7 +217,7 @@ where T: ContactsBackend + 'static
                     .await?;
                 info!(
                     target: LOG_TARGET,
-                    "Contact Removed: \nAlias: {}\nPubKey: {} ", result.alias, result.public_key
+                    "Contact Removed: \nAlias: {}\nAddress: {} ", result.alias, result.address
                 );
                 Ok(ContactsServiceResponse::ContactRemoved(result))
             },
@@ -284,7 +284,7 @@ where T: ContactsBackend + 'static
                             continue;
                         }
                         let data = ContactsLivenessData::new(
-                            contact.public_key.clone(),
+                            contact.address.clone(),
                             contact.node_id.clone(),
                             contact.latency,
                             contact.last_seen,

--- a/base_layer/wallet/src/contacts_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/contacts_service/storage/sqlite_db.rs
@@ -24,7 +24,7 @@ use std::convert::TryFrom;
 
 use chrono::NaiveDateTime;
 use diesel::{prelude::*, result::Error as DieselError, SqliteConnection};
-use tari_common_types::types::PublicKey;
+use tari_common_types::tari_address::TariAddress;
 use tari_comms::peer_manager::NodeId;
 use tari_utilities::ByteArray;
 
@@ -54,7 +54,7 @@ impl ContactsBackend for ContactsServiceSqliteDatabase {
         let conn = self.database_connection.get_pooled_connection()?;
 
         let result = match key {
-            DbKey::Contact(pk) => match ContactSql::find_by_public_key(&pk.to_vec(), &conn) {
+            DbKey::Contact(address) => match ContactSql::find_by_address(&address.to_bytes(), &conn) {
                 Ok(c) => Some(DbValue::Contact(Box::new(Contact::try_from(c)?))),
                 Err(ContactsServiceStorageError::DieselError(DieselError::NotFound)) => None,
                 Err(e) => return Err(e),
@@ -81,7 +81,7 @@ impl ContactsBackend for ContactsServiceSqliteDatabase {
         match op {
             WriteOperation::Upsert(kvp) => match *kvp {
                 DbKeyValuePair::Contact(k, c) => {
-                    if ContactSql::find_by_public_key_and_update(&conn, &k.to_vec(), UpdateContact {
+                    if ContactSql::find_by_address_and_update(&conn, &k.to_bytes(), UpdateContact {
                         alias: Some(c.clone().alias),
                         last_seen: None,
                         latency: None,
@@ -100,15 +100,15 @@ impl ContactsBackend for ContactsServiceSqliteDatabase {
                         last_seen: Some(Some(date_time)),
                         latency: Some(latency),
                     })?;
-                    return Ok(Some(DbValue::PublicKey(Box::new(
-                        PublicKey::from_vec(&contact.public_key)
+                    return Ok(Some(DbValue::TariAddress(Box::new(
+                        TariAddress::from_bytes(&contact.address)
                             .map_err(|_| ContactsServiceStorageError::ConversionError)?,
                     ))));
                 },
                 DbKeyValuePair::Contact(..) => return Err(ContactsServiceStorageError::OperationNotSupported),
             },
             WriteOperation::Remove(k) => match k {
-                DbKey::Contact(k) => match ContactSql::find_by_public_key_and_delete(&conn, &k.to_vec()) {
+                DbKey::Contact(k) => match ContactSql::find_by_address_and_delete(&conn, &k.to_bytes()) {
                     Ok(c) => {
                         return Ok(Some(DbValue::Contact(Box::new(Contact::try_from(c)?))));
                     },
@@ -134,7 +134,7 @@ impl ContactsBackend for ContactsServiceSqliteDatabase {
 #[derive(Clone, Debug, Queryable, Insertable, PartialEq, Eq)]
 #[table_name = "contacts"]
 struct ContactSql {
-    public_key: Vec<u8>,
+    address: Vec<u8>,
     node_id: Vec<u8>,
     alias: String,
     last_seen: Option<NaiveDateTime>,
@@ -155,13 +155,10 @@ impl ContactSql {
         Ok(contacts::table.load::<ContactSql>(conn)?)
     }
 
-    /// Find a particular Contact by their public key, if it exists
-    pub fn find_by_public_key(
-        public_key: &[u8],
-        conn: &SqliteConnection,
-    ) -> Result<ContactSql, ContactsServiceStorageError> {
+    /// Find a particular Contact by their address, if it exists
+    pub fn find_by_address(address: &[u8], conn: &SqliteConnection) -> Result<ContactSql, ContactsServiceStorageError> {
         Ok(contacts::table
-            .filter(contacts::public_key.eq(public_key))
+            .filter(contacts::address.eq(address))
             .first::<ContactSql>(conn)?)
     }
 
@@ -172,28 +169,28 @@ impl ContactSql {
             .first::<ContactSql>(conn)?)
     }
 
-    /// Find a particular Contact by their public key, and update it if it exists, returning the affected record
-    pub fn find_by_public_key_and_update(
+    /// Find a particular Contact by their address, and update it if it exists, returning the affected record
+    pub fn find_by_address_and_update(
         conn: &SqliteConnection,
-        public_key: &[u8],
+        address: &[u8],
         updated_contact: UpdateContact,
     ) -> Result<ContactSql, ContactsServiceStorageError> {
         // Note: `get_result` not implemented for SQLite
-        diesel::update(contacts::table.filter(contacts::public_key.eq(public_key)))
+        diesel::update(contacts::table.filter(contacts::address.eq(address)))
             .set(updated_contact)
             .execute(conn)
             .num_rows_affected_or_not_found(1)?;
-        ContactSql::find_by_public_key(public_key, conn)
+        ContactSql::find_by_address(address, conn)
     }
 
-    /// Find a particular Contact by their public key, and delete it if it exists, returning the affected record
-    pub fn find_by_public_key_and_delete(
+    /// Find a particular Contact by their address, and delete it if it exists, returning the affected record
+    pub fn find_by_address_and_delete(
         conn: &SqliteConnection,
-        public_key: &[u8],
+        address: &[u8],
     ) -> Result<ContactSql, ContactsServiceStorageError> {
         // Note: `get_result` not implemented for SQLite
-        let contact = ContactSql::find_by_public_key(public_key, conn)?;
-        if diesel::delete(contacts::table.filter(contacts::public_key.eq(public_key))).execute(conn)? == 0 {
+        let contact = ContactSql::find_by_address(address, conn)?;
+        if diesel::delete(contacts::table.filter(contacts::address.eq(address))).execute(conn)? == 0 {
             return Err(ContactsServiceStorageError::ValuesNotFound);
         }
         Ok(contact)
@@ -233,12 +230,11 @@ impl TryFrom<ContactSql> for Contact {
 
     #[allow(clippy::cast_sign_loss)]
     fn try_from(o: ContactSql) -> Result<Self, Self::Error> {
-        let public_key =
-            PublicKey::from_vec(&o.public_key).map_err(|_| ContactsServiceStorageError::ConversionError)?;
+        let address = TariAddress::from_bytes(&o.address).map_err(|_| ContactsServiceStorageError::ConversionError)?;
         Ok(Self {
-            public_key: public_key.clone(),
             // Public key must always be the master data source for node ID here
-            node_id: NodeId::from_key(&public_key),
+            node_id: NodeId::from_key(address.public_key()),
+            address,
             alias: o.alias,
             last_seen: o.last_seen,
             latency: o.latency.map(|val| val as u32),
@@ -251,9 +247,9 @@ impl TryFrom<ContactSql> for Contact {
 impl From<Contact> for ContactSql {
     fn from(o: Contact) -> Self {
         Self {
-            public_key: o.public_key.to_vec(),
             // Public key must always be the master data source for node ID here
-            node_id: NodeId::from_key(&o.public_key).to_vec(),
+            node_id: NodeId::from_key(o.address.public_key()).to_vec(),
+            address: o.address.to_bytes().to_vec(),
             alias: o.alias,
             last_seen: o.last_seen,
             latency: o.latency.map(|val| val as i32),
@@ -275,11 +271,12 @@ mod test {
 
     use diesel::{Connection, SqliteConnection};
     use rand::rngs::OsRng;
-    use tari_common_types::types::{PrivateKey, PublicKey};
-    use tari_crypto::{
-        keys::{PublicKey as PublicKeyTrait, SecretKey as SecretKeyTrait},
-        tari_utilities::ByteArray,
+    use tari_common::configuration::Network;
+    use tari_common_types::{
+        tari_address::TariAddress,
+        types::{PrivateKey, PublicKey},
     };
+    use tari_crypto::keys::{PublicKey as PublicKeyTrait, SecretKey as SecretKeyTrait};
     use tari_test_utils::{paths::with_temp_dir, random::string};
 
     use crate::contacts_service::storage::{
@@ -306,7 +303,8 @@ mod test {
             let mut contacts = Vec::new();
             for i in 0..names.len() {
                 let pub_key = PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng));
-                contacts.push(Contact::new(names[i].clone(), pub_key, None, None));
+                let address = TariAddress::new(pub_key, Network::default());
+                contacts.push(Contact::new(names[i].clone(), address, None, None));
                 ContactSql::from(contacts[i].clone()).commit(&conn).unwrap();
             }
 
@@ -318,11 +316,11 @@ mod test {
 
             assert_eq!(
                 contacts[1],
-                Contact::try_from(ContactSql::find_by_public_key(&contacts[1].public_key.to_vec(), &conn).unwrap())
+                Contact::try_from(ContactSql::find_by_address(&contacts[1].address.to_bytes(), &conn).unwrap())
                     .unwrap()
             );
 
-            ContactSql::find_by_public_key_and_delete(&conn, &contacts[0].public_key.clone().to_vec()).unwrap();
+            ContactSql::find_by_address_and_delete(&conn, &contacts[0].address.clone().to_bytes()).unwrap();
 
             let retrieved_contacts = ContactSql::index(&conn).unwrap();
             assert_eq!(retrieved_contacts.len(), 2);
@@ -331,15 +329,14 @@ mod test {
                 .iter()
                 .any(|v| v == &ContactSql::from(contacts[0].clone())));
 
-            let _c =
-                ContactSql::find_by_public_key_and_update(&conn, &contacts[1].public_key.to_vec(), UpdateContact {
-                    alias: Some("Fred".to_string()),
-                    last_seen: None,
-                    latency: None,
-                })
-                .unwrap();
+            let _c = ContactSql::find_by_address_and_update(&conn, &contacts[1].address.to_bytes(), UpdateContact {
+                alias: Some("Fred".to_string()),
+                last_seen: None,
+                latency: None,
+            })
+            .unwrap();
 
-            let c_updated = ContactSql::find_by_public_key(&contacts[1].public_key.to_vec(), &conn).unwrap();
+            let c_updated = ContactSql::find_by_address(&contacts[1].address.to_bytes(), &conn).unwrap();
             assert_eq!(c_updated.alias, "Fred".to_string());
         });
     }

--- a/base_layer/wallet/src/schema.rs
+++ b/base_layer/wallet/src/schema.rs
@@ -1,37 +1,15 @@
-// Copyright 2020. The Tari Project
-//
-// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
-// following conditions are met:
-//
-// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
-// disclaimer.
-//
-// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
-// following disclaimer in the documentation and/or other materials provided with the distribution.
-//
-// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
-// products derived from this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
-// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
-// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
-// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-table! {
+diesel::table! {
     client_key_values (key) {
         key -> Text,
         value -> Text,
     }
 }
 
-table! {
+diesel::table! {
     completed_transactions (tx_id) {
         tx_id -> BigInt,
-        source_public_key -> Binary,
-        destination_public_key -> Binary,
+        source_address -> Binary,
+        destination_address -> Binary,
         amount -> BigInt,
         fee -> BigInt,
         transaction_protocol -> Text,
@@ -52,9 +30,9 @@ table! {
     }
 }
 
-table! {
-    contacts (public_key) {
-        public_key -> Binary,
+diesel::table! {
+    contacts (address) {
+        address -> Binary,
         node_id -> Binary,
         alias -> Text,
         last_seen -> Nullable<Timestamp>,
@@ -62,10 +40,10 @@ table! {
     }
 }
 
-table! {
+diesel::table! {
     inbound_transactions (tx_id) {
         tx_id -> BigInt,
-        source_public_key -> Binary,
+        source_address -> Binary,
         amount -> BigInt,
         receiver_protocol -> Text,
         message -> Text,
@@ -77,7 +55,7 @@ table! {
     }
 }
 
-table! {
+diesel::table! {
     key_manager_states (id) {
         id -> Integer,
         branch_seed -> Text,
@@ -86,17 +64,7 @@ table! {
     }
 }
 
-table! {
-    key_manager_states_old (id) {
-        id -> Integer,
-        seed -> Binary,
-        branch_seed -> Text,
-        primary_key_index -> BigInt,
-        timestamp -> Timestamp,
-    }
-}
-
-table! {
+diesel::table! {
     known_one_sided_payment_scripts (script_hash) {
         script_hash -> Binary,
         private_key -> Binary,
@@ -106,10 +74,10 @@ table! {
     }
 }
 
-table! {
+diesel::table! {
     outbound_transactions (tx_id) {
         tx_id -> BigInt,
-        destination_public_key -> Binary,
+        destination_address -> Binary,
         amount -> BigInt,
         fee -> BigInt,
         sender_protocol -> Text,
@@ -122,7 +90,7 @@ table! {
     }
 }
 
-table! {
+diesel::table! {
     outputs (id) {
         id -> Integer,
         commitment -> Nullable<Binary>,
@@ -159,7 +127,7 @@ table! {
     }
 }
 
-table! {
+diesel::table! {
     scanned_blocks (header_hash) {
         header_hash -> Binary,
         height -> BigInt,
@@ -169,20 +137,19 @@ table! {
     }
 }
 
-table! {
+diesel::table! {
     wallet_settings (key) {
         key -> Text,
         value -> Text,
     }
 }
 
-allow_tables_to_appear_in_same_query!(
+diesel::allow_tables_to_appear_in_same_query!(
     client_key_values,
     completed_transactions,
     contacts,
     inbound_transactions,
     key_manager_states,
-    key_manager_states_old,
     known_one_sided_payment_scripts,
     outbound_transactions,
     outputs,

--- a/base_layer/wallet/src/transaction_service/error.rs
+++ b/base_layer/wallet/src/transaction_service/error.rs
@@ -24,6 +24,7 @@ use diesel::result::Error as DieselError;
 use futures::channel::oneshot::Canceled;
 use serde_json::Error as SerdeJsonError;
 use tari_common_types::{
+    tari_address::TariAddressError,
     transaction::{TransactionConversionError, TransactionDirectionError, TxId},
     types::FixedHashSizeError,
 };
@@ -52,6 +53,8 @@ use crate::{
 pub enum TransactionServiceError {
     #[error("Transaction protocol is not in the correct state for this operation")]
     InvalidStateError,
+    #[error("Transaction is sending to a network different than ours")]
+    InvalidNetwork,
     #[error("One-sided transaction error: `{0}`")]
     OneSidedTransactionError(String),
     #[error("Transaction Protocol Error: `{0}`")]
@@ -179,10 +182,10 @@ pub enum TransactionServiceError {
 
 #[derive(Debug, Error)]
 pub enum TransactionKeyError {
-    #[error("Invalid source Publickey")]
-    Source(ByteArrayError),
-    #[error("Invalid destination PublicKey")]
-    Destination(ByteArrayError),
+    #[error("Invalid source address")]
+    Source(TariAddressError),
+    #[error("Invalid destination address")]
+    Destination(TariAddressError),
     #[error("Invalid transaction signature nonce")]
     SignatureNonce(ByteArrayError),
     #[error("Invalid transaction signature key")]
@@ -233,6 +236,8 @@ pub enum TransactionStorageError {
     TransactionNotMined(TxId),
     #[error("Conversion error: `{0}`")]
     ByteArrayError(#[from] ByteArrayError),
+    #[error("Tari address error: `{0}`")]
+    TariAddressError(#[from] TariAddressError),
     #[error("Not a coinbase transaction so cannot be abandoned")]
     NotCoinbase,
 }

--- a/base_layer/wallet/src/transaction_service/mod.rs
+++ b/base_layer/wallet/src/transaction_service/mod.rs
@@ -24,7 +24,6 @@ use std::sync::Arc;
 
 use futures::{Stream, StreamExt};
 use log::*;
-use tari_comms::peer_manager::NodeIdentity;
 use tari_comms_dht::Dht;
 use tari_core::{
     proto::base_node as base_node_proto,
@@ -56,6 +55,7 @@ use crate::{
         service::TransactionService,
         storage::database::{TransactionBackend, TransactionDatabase},
     },
+    util::wallet_identity::WalletIdentity,
 };
 
 pub mod config;
@@ -78,7 +78,7 @@ where
     config: TransactionServiceConfig,
     subscription_factory: Arc<SubscriptionFactory>,
     tx_backend: Option<T>,
-    node_identity: Arc<NodeIdentity>,
+    wallet_identity: WalletIdentity,
     factories: CryptoFactories,
     wallet_database: Option<WalletDatabase<W>>,
 }
@@ -92,7 +92,7 @@ where
         config: TransactionServiceConfig,
         subscription_factory: Arc<SubscriptionFactory>,
         backend: T,
-        node_identity: Arc<NodeIdentity>,
+        wallet_identity: WalletIdentity,
         factories: CryptoFactories,
         wallet_database: WalletDatabase<W>,
     ) -> Self {
@@ -100,7 +100,7 @@ where
             config,
             subscription_factory,
             tx_backend: Some(backend),
-            node_identity,
+            wallet_identity,
             factories,
             wallet_database: Some(wallet_database),
         }
@@ -204,7 +204,7 @@ where
             .take()
             .expect("Cannot start Transaction Service without providing a wallet database");
 
-        let node_identity = self.node_identity.clone();
+        let wallet_identity = self.wallet_identity.clone();
         let factories = self.factories.clone();
         let config = self.config.clone();
 
@@ -228,7 +228,7 @@ where
                 outbound_message_service,
                 connectivity,
                 publisher,
-                node_identity,
+                wallet_identity,
                 factories,
                 handles.get_shutdown_signal(),
                 base_node_service_handle,

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -34,13 +34,11 @@ use log::*;
 use rand::rngs::OsRng;
 use sha2::Sha256;
 use tari_common_types::{
+    tari_address::TariAddress,
     transaction::{ImportStatus, TransactionDirection, TransactionStatus, TxId},
     types::{PrivateKey, PublicKey, Signature},
 };
-use tari_comms::{
-    peer_manager::NodeIdentity,
-    types::{CommsDHKE, CommsPublicKey},
-};
+use tari_comms::types::{CommsDHKE, CommsPublicKey};
 use tari_comms_dht::outbound::OutboundMessageRequester;
 use tari_core::{
     covenants::Covenant,
@@ -119,7 +117,7 @@ use crate::{
         utc::utc_duration_since,
     },
     types::WalletHasher,
-    util::watch::Watch,
+    util::{wallet_identity::WalletIdentity, watch::Watch},
     utxo_scanner_service::RECOVERY_KEY,
     OperationId,
     WalletOutputEncryptionKeysDomainHasher,
@@ -164,12 +162,11 @@ pub struct TransactionService<
         reply_channel::Receiver<TransactionServiceRequest, Result<TransactionServiceResponse, TransactionServiceError>>,
     >,
     event_publisher: TransactionEventSender,
-    node_identity: Arc<NodeIdentity>,
     resources: TransactionServiceResources<TBackend, TWalletConnectivity>,
     pending_transaction_reply_senders: HashMap<TxId, Sender<(CommsPublicKey, RecipientSignedMessage)>>,
     base_node_response_senders: HashMap<TxId, (TxId, Sender<base_node_proto::BaseNodeServiceResponse>)>,
     send_transaction_cancellation_senders: HashMap<TxId, oneshot::Sender<()>>,
-    finalized_transaction_senders: HashMap<TxId, Sender<(CommsPublicKey, TxId, Transaction)>>,
+    finalized_transaction_senders: HashMap<TxId, Sender<(TariAddress, TxId, Transaction)>>,
     receiver_transaction_cancellation_senders: HashMap<TxId, oneshot::Sender<()>>,
     active_transaction_broadcast_protocols: HashSet<TxId>,
     timeout_update_watch: Watch<Duration>,
@@ -226,7 +223,7 @@ where
         outbound_message_service: OutboundMessageRequester,
         connectivity: TWalletConnectivity,
         event_publisher: TransactionEventSender,
-        node_identity: Arc<NodeIdentity>,
+        wallet_identity: WalletIdentity,
         factories: CryptoFactories,
         shutdown_signal: ShutdownSignal,
         base_node_service: BaseNodeServiceHandle,
@@ -239,7 +236,7 @@ where
             outbound_message_service,
             connectivity,
             event_publisher: event_publisher.clone(),
-            node_identity: node_identity.clone(),
+            wallet_identity,
             factories,
             config: config.clone(),
 
@@ -263,7 +260,6 @@ where
             transaction_cancelled_stream: Some(transaction_cancelled_stream),
             request_stream: Some(request_stream),
             event_publisher,
-            node_identity,
             resources,
             pending_transaction_reply_senders: HashMap::new(),
             base_node_response_senders: HashMap::new(),
@@ -395,7 +391,7 @@ where
                         }
                         Err(e) => {
                             warn!(target: LOG_TARGET, "Failed to handle incoming Transaction message: {} for NodeID: {}, Trace: {}",
-                                e, self.node_identity.node_id().short_str(), msg.dht_header.message_tag);
+                                e, self.resources.wallet_identity.node_identity.node_id().short_str(), msg.dht_header.message_tag);
                             let _size = self.event_publisher.send(Arc::new(TransactionEvent::Error(format!("Error handling \
                                 Transaction Sender message: {:?}", e).to_string())));
                         }
@@ -419,12 +415,12 @@ where
                         Err(TransactionServiceError::TransactionDoesNotExistError) => {
                             trace!(target: LOG_TARGET, "Unable to handle incoming Transaction Reply message from NodeId: \
                             {} due to Transaction not existing. This usually means the message was a repeated message \
-                            from Store and Forward, Trace: {}", self.node_identity.node_id().short_str(),
+                            from Store and Forward, Trace: {}", self.resources.wallet_identity.node_identity.node_id().short_str(),
                             msg.dht_header.message_tag);
                         },
                         Err(e) => {
                             warn!(target: LOG_TARGET, "Failed to handle incoming Transaction Reply message: {} \
-                            for NodeId: {}, Trace: {}", e, self.node_identity.node_id().short_str(),
+                            for NodeId: {}, Trace: {}", e, self.resources.wallet_identity.node_identity.node_id().short_str(),
                             msg.dht_header.message_tag);
                             let _size = self.event_publisher.send(Arc::new(TransactionEvent::Error("Error handling \
                             Transaction Recipient Reply message".to_string())));
@@ -456,12 +452,12 @@ where
                         Err(TransactionServiceError::TransactionDoesNotExistError) => {
                             trace!(target: LOG_TARGET, "Unable to handle incoming Finalized Transaction message from NodeId: \
                             {} due to Transaction not existing. This usually means the message was a repeated message \
-                            from Store and Forward, Trace: {}", self.node_identity.node_id().short_str(),
+                            from Store and Forward, Trace: {}", self.resources.wallet_identity.node_identity.node_id().short_str(),
                             msg.dht_header.message_tag);
                         },
                        Err(e) => {
                             warn!(target: LOG_TARGET, "Failed to handle incoming Transaction Finalized message: {} \
-                            for NodeID: {}, Trace: {}", e , self.node_identity.node_id().short_str(),
+                            for NodeID: {}, Trace: {}", e , self.resources.wallet_identity.node_identity.node_id().short_str(),
                             msg.dht_header.message_tag.as_value());
                             let _size = self.event_publisher.send(Arc::new(TransactionEvent::Error("Error handling Transaction \
                             Finalized message".to_string(),)));
@@ -482,7 +478,7 @@ where
                     trace!(target: LOG_TARGET, "Handling Base Node Response, Trace: {}", msg.dht_header.message_tag);
                     let _result = self.handle_base_node_response(inner_msg).await.map_err(|e| {
                         warn!(target: LOG_TARGET, "Error handling base node service response from {}: {:?} for \
-                        NodeID: {}, Trace: {}", origin_public_key, e, self.node_identity.node_id().short_str(),
+                        NodeID: {}, Trace: {}", origin_public_key, e, self.resources.wallet_identity.node_identity.node_id().short_str(),
                         msg.dht_header.message_tag.as_value());
                         e
                     });
@@ -578,7 +574,7 @@ where
         trace!(target: LOG_TARGET, "Handling Service Request: {}", request);
         let response = match request {
             TransactionServiceRequest::SendTransaction {
-                dest_pubkey,
+                destination,
                 amount,
                 selection_criteria,
                 output_features,
@@ -587,7 +583,7 @@ where
             } => {
                 let rp = reply_channel.take().expect("Cannot be missing");
                 self.send_transaction(
-                    dest_pubkey,
+                    destination,
                     amount,
                     selection_criteria,
                     *output_features,
@@ -602,7 +598,7 @@ where
                 return Ok(());
             },
             TransactionServiceRequest::SendOneSidedTransaction {
-                dest_pubkey,
+                destination,
                 amount,
                 selection_criteria,
                 output_features,
@@ -610,7 +606,7 @@ where
                 message,
             } => self
                 .send_one_sided_transaction(
-                    dest_pubkey,
+                    destination,
                     amount,
                     selection_criteria,
                     *output_features,
@@ -621,7 +617,7 @@ where
                 .await
                 .map(TransactionServiceResponse::TransactionSent),
             TransactionServiceRequest::SendOneSidedToStealthAddressTransaction {
-                dest_pubkey,
+                destination,
                 amount,
                 selection_criteria,
                 output_features,
@@ -629,7 +625,7 @@ where
                 message,
             } => self
                 .send_one_sided_to_stealth_address_transaction(
-                    dest_pubkey,
+                    destination,
                     amount,
                     selection_criteria,
                     *output_features,
@@ -676,14 +672,14 @@ where
                 return Ok(());
             },
             TransactionServiceRequest::SendShaAtomicSwapTransaction(
-                dest_pubkey,
+                destination,
                 amount,
                 selection_criteria,
                 fee_per_gram,
                 message,
             ) => Ok(TransactionServiceResponse::ShaAtomicSwapTransactionSent(
                 self.send_sha_atomic_swap_transaction(
-                    dest_pubkey,
+                    destination,
                     amount,
                     selection_criteria,
                     fee_per_gram,
@@ -727,7 +723,7 @@ where
             )),
             TransactionServiceRequest::ImportUtxoWithStatus {
                 amount,
-                source_public_key,
+                source_address,
                 message,
                 maturity,
                 import_status,
@@ -737,7 +733,7 @@ where
             } => self
                 .add_utxo_import_transaction_with_status(
                     amount,
-                    source_public_key,
+                    source_address,
                     message,
                     maturity,
                     import_status,
@@ -913,7 +909,7 @@ where
     /// 'fee_per_gram': The amount of fee per transaction gram to be included in transaction
     pub async fn send_transaction(
         &mut self,
-        dest_pubkey: CommsPublicKey,
+        destination: TariAddress,
         amount: MicroTari,
         selection_criteria: UtxoSelectionCriteria,
         output_features: OutputFeatures,
@@ -929,9 +925,12 @@ where
         reply_channel: oneshot::Sender<Result<TransactionServiceResponse, TransactionServiceError>>,
     ) -> Result<(), TransactionServiceError> {
         let tx_id = TxId::new_random();
-
+        if destination.network() != self.resources.wallet_identity.network {
+            return Err(TransactionServiceError::InvalidNetwork);
+        }
+        let dest_pubkey = destination.public_key();
         // If we're paying ourselves, let's complete and submit the transaction immediately
-        if self.node_identity.public_key() == &dest_pubkey {
+        if self.resources.wallet_identity.address.public_key() == dest_pubkey {
             debug!(
                 target: LOG_TARGET,
                 "Received transaction with spend-to-self transaction"
@@ -959,8 +958,8 @@ where
                 transaction_broadcast_join_handles,
                 CompletedTransaction::new(
                     tx_id,
-                    self.node_identity.public_key().clone(),
-                    self.node_identity.public_key().clone(),
+                    self.resources.wallet_identity.address.clone(),
+                    self.resources.wallet_identity.address.clone(),
                     amount,
                     fee,
                     transaction,
@@ -995,7 +994,7 @@ where
             self.resources.clone(),
             tx_reply_receiver,
             cancellation_receiver,
-            dest_pubkey,
+            destination,
             amount,
             fee_per_gram,
             message,
@@ -1020,7 +1019,7 @@ where
     #[allow(clippy::too_many_lines)]
     pub async fn send_sha_atomic_swap_transaction(
         &mut self,
-        dest_pubkey: CommsPublicKey,
+        destination: TariAddress,
         amount: MicroTari,
         selection_criteria: UtxoSelectionCriteria,
         fee_per_gram: MicroTari,
@@ -1029,6 +1028,7 @@ where
             JoinHandle<Result<TxId, TransactionServiceProtocolError<TxId>>>,
         >,
     ) -> Result<Box<(TxId, PublicKey, TransactionOutput)>, TransactionServiceError> {
+        let dest_pubkey = destination.public_key();
         let tx_id = TxId::new_random();
         // this can be anything, so lets generate a random private key
         let pre_image = PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng));
@@ -1042,7 +1042,7 @@ where
             HashSha256 PushHash(Box::new(hash)) Equal IfThen
                 PushPubKey(Box::new(dest_pubkey.clone()))
             Else
-                CheckHeightVerify(height) PushPubKey(Box::new(self.node_identity.public_key().clone()))
+                CheckHeightVerify(height) PushPubKey(Box::new(self.resources.wallet_identity.node_identity.public_key().clone()))
             EndIf
         );
 
@@ -1088,7 +1088,7 @@ where
             .get_recipient_sender_offset_private_key(0)
             .map_err(|e| TransactionServiceProtocolError::new(tx_id, e.into()))?;
 
-        let shared_secret = CommsDHKE::new(&sender_offset_private_key, &dest_pubkey);
+        let shared_secret = CommsDHKE::new(&sender_offset_private_key, destination.public_key());
         let spending_key = shared_secret_to_output_spending_key(&shared_secret)
             .map_err(|e| TransactionServiceProtocolError::new(tx_id, e.into()))?;
 
@@ -1123,8 +1123,10 @@ where
             spending_key,
             output.features.clone(),
             script,
-            inputs!(PublicKey::from_secret_key(self.node_identity.secret_key())),
-            self.node_identity.secret_key().clone(),
+            inputs!(PublicKey::from_secret_key(
+                self.resources.wallet_identity.node_identity.secret_key()
+            )),
+            self.resources.wallet_identity.node_identity.secret_key().clone(),
             output.sender_offset_public_key.clone(),
             output.metadata_signature.clone(),
             height,
@@ -1180,8 +1182,8 @@ where
             transaction_broadcast_join_handles,
             CompletedTransaction::new(
                 tx_id,
-                self.resources.node_identity.public_key().clone(),
-                dest_pubkey.clone(),
+                self.resources.wallet_identity.address.clone(),
+                destination,
                 amount,
                 fee,
                 tx.clone(),
@@ -1200,7 +1202,7 @@ where
 
     async fn send_one_sided_or_stealth(
         &mut self,
-        dest_pubkey: CommsPublicKey,
+        dest_address: TariAddress,
         amount: MicroTari,
         selection_criteria: UtxoSelectionCriteria,
         output_features: OutputFeatures,
@@ -1248,7 +1250,7 @@ where
         let sender_offset_private_key = stp
             .get_recipient_sender_offset_private_key(0)
             .map_err(|e| TransactionServiceProtocolError::new(tx_id, e.into()))?;
-        let shared_secret = CommsDHKE::new(&sender_offset_private_key, &dest_pubkey);
+        let shared_secret = CommsDHKE::new(&sender_offset_private_key, dest_address.public_key());
         let spending_key = shared_secret_to_output_spending_key(&shared_secret)
             .map_err(|e| TransactionServiceProtocolError::new(tx_id, e.into()))?;
 
@@ -1309,8 +1311,8 @@ where
             transaction_broadcast_join_handles,
             CompletedTransaction::new(
                 tx_id,
-                self.resources.node_identity.public_key().clone(),
-                dest_pubkey.clone(),
+                self.resources.wallet_identity.address.clone(),
+                dest_address,
                 amount,
                 fee,
                 tx.clone(),
@@ -1334,7 +1336,7 @@ where
     /// 'fee_per_gram': The amount of fee per transaction gram to be included in transaction
     pub async fn send_one_sided_transaction(
         &mut self,
-        dest_pubkey: CommsPublicKey,
+        destination: TariAddress,
         amount: MicroTari,
         selection_criteria: UtxoSelectionCriteria,
         output_features: OutputFeatures,
@@ -1344,14 +1346,18 @@ where
             JoinHandle<Result<TxId, TransactionServiceProtocolError<TxId>>>,
         >,
     ) -> Result<TxId, TransactionServiceError> {
-        if self.node_identity.public_key() == &dest_pubkey {
+        if destination.network() != self.resources.wallet_identity.network {
+            return Err(TransactionServiceError::InvalidNetwork);
+        }
+        if self.resources.wallet_identity.node_identity.public_key() == destination.public_key() {
             warn!(target: LOG_TARGET, "One-sided spend-to-self transactions not supported");
             return Err(TransactionServiceError::OneSidedTransactionError(
                 "One-sided spend-to-self transactions not supported".to_string(),
             ));
         }
+        let dest_pubkey = destination.public_key().clone();
         self.send_one_sided_or_stealth(
-            dest_pubkey.clone(),
+            destination,
             amount,
             selection_criteria,
             output_features,
@@ -1457,8 +1463,8 @@ where
             transaction_broadcast_join_handles,
             CompletedTransaction::new(
                 tx_id,
-                self.resources.node_identity.public_key().clone(),
-                CommsPublicKey::default(),
+                self.resources.wallet_identity.address.clone(),
+                TariAddress::default(),
                 amount,
                 fee,
                 tx.clone(),
@@ -1495,7 +1501,7 @@ where
         let tx_meta =
             TransactionMetadata::new_with_features(0.into(), 3, KernelFeatures::create_validator_node_registration());
         self.send_transaction(
-            self.node_identity.public_key().clone(),
+            self.resources.wallet_identity.address.clone(),
             MicroTari::from(1),
             selection_criteria,
             output_features,
@@ -1516,7 +1522,7 @@ where
     /// 'fee_per_gram': The amount of fee per transaction gram to be included in transaction
     pub async fn send_one_sided_to_stealth_address_transaction(
         &mut self,
-        dest_pubkey: CommsPublicKey,
+        destination: TariAddress,
         amount: MicroTari,
         selection_criteria: UtxoSelectionCriteria,
         output_features: OutputFeatures,
@@ -1526,7 +1532,10 @@ where
             JoinHandle<Result<TxId, TransactionServiceProtocolError<TxId>>>,
         >,
     ) -> Result<TxId, TransactionServiceError> {
-        if self.node_identity.public_key() == &dest_pubkey {
+        if destination.network() != self.resources.wallet_identity.network {
+            return Err(TransactionServiceError::InvalidNetwork);
+        }
+        if self.resources.wallet_identity.node_identity.public_key() == destination.public_key() {
             warn!(target: LOG_TARGET, "One-sided spend-to-self transactions not supported");
             return Err(TransactionServiceError::OneSidedTransactionError(
                 "One-sided-to-stealth-address spend-to-self transactions not supported".to_string(),
@@ -1535,15 +1544,16 @@ where
 
         let (nonce_private_key, nonce_public_key) = PublicKey::random_keypair(&mut OsRng);
 
+        let dest_pubkey = destination.public_key().clone();
         let c = WalletHasher::new_with_label("stealth_address")
             .chain((dest_pubkey.clone() * nonce_private_key).as_bytes())
             .finalize();
 
         let script_spending_key =
-            PublicKey::from_secret_key(&PrivateKey::from_bytes(c.as_ref()).unwrap()) + dest_pubkey.clone();
+            PublicKey::from_secret_key(&PrivateKey::from_bytes(c.as_ref()).unwrap()) + dest_pubkey;
 
         self.send_one_sided_or_stealth(
-            dest_pubkey,
+            destination,
             amount,
             selection_criteria,
             output_features,
@@ -1598,7 +1608,7 @@ where
 
         if let Ok(ctx) = completed_tx {
             // Check that it is from the same person
-            if ctx.destination_public_key != source_pubkey {
+            if ctx.destination_address.public_key() != &source_pubkey {
                 return Err(TransactionServiceError::InvalidSourcePublicKey);
             }
             if !check_cooldown(ctx.last_send_timestamp) {
@@ -1645,7 +1655,7 @@ where
 
         if let Ok(otx) = cancelled_outbound_tx {
             // Check that it is from the same person
-            if otx.destination_public_key != source_pubkey {
+            if otx.destination_address.public_key() != &source_pubkey {
                 return Err(TransactionServiceError::InvalidSourcePublicKey);
             }
             if !check_cooldown(otx.last_send_timestamp) {
@@ -1800,7 +1810,7 @@ where
         // Check that an inbound transaction exists to be cancelled and that the Source Public key for that transaction
         // is the same as the cancellation message
         if let Ok(inbound_tx) = self.db.get_pending_inbound_transaction(tx_id) {
-            if inbound_tx.source_public_key == source_pubkey {
+            if inbound_tx.source_address.public_key() == &source_pubkey {
                 self.cancel_pending_transaction(tx_id).await?;
             } else {
                 trace!(
@@ -1860,7 +1870,7 @@ where
                     self.resources.clone(),
                     tx_reply_receiver,
                     cancellation_receiver,
-                    tx.destination_public_key,
+                    tx.destination_address,
                     tx.amount,
                     tx.fee,
                     tx.message,
@@ -1913,7 +1923,7 @@ where
             if let Ok(Some(any_tx)) = self.db.get_any_cancelled_transaction(data.tx_id) {
                 let tx = CompletedTransaction::from(any_tx);
 
-                if tx.source_public_key != source_pubkey {
+                if tx.source_address.public_key() != &source_pubkey {
                     return Err(TransactionServiceError::InvalidSourcePublicKey);
                 }
                 trace!(
@@ -1933,7 +1943,7 @@ where
             // Check if this transaction has already been received.
             if let Ok(inbound_tx) = self.db.get_pending_inbound_transaction(data.tx_id) {
                 // Check that it is from the same person
-                if inbound_tx.source_public_key != source_pubkey {
+                if inbound_tx.source_address.public_key() != &source_pubkey {
                     return Err(TransactionServiceError::InvalidSourcePublicKey);
                 }
                 // Check if the last reply is beyond the resend cooldown
@@ -1990,10 +2000,11 @@ where
                 .insert(data.tx_id, tx_finalized_sender);
             self.receiver_transaction_cancellation_senders
                 .insert(data.tx_id, cancellation_sender);
-
+            // we are making the assumption that because we received this transaction, its on the same network as us.
+            let source_address = TariAddress::new(source_pubkey, self.resources.wallet_identity.network);
             let protocol = TransactionReceiveProtocol::new(
                 data.tx_id,
-                source_pubkey,
+                source_address,
                 sender_message,
                 TransactionReceiveProtocolStage::Initial,
                 self.resources.clone(),
@@ -2038,12 +2049,14 @@ where
                 )
             })?;
 
+        // assuming since we talked to the node, it has the same identity than
+        let source_address = TariAddress::new(source_pubkey, self.resources.wallet_identity.network);
         let sender = match self.finalized_transaction_senders.get_mut(&tx_id) {
             None => {
                 // First check if perhaps we know about this inbound transaction but it was cancelled
                 match self.db.get_cancelled_pending_inbound_transaction(tx_id) {
                     Ok(t) => {
-                        if t.source_public_key != source_pubkey {
+                        if t.source_address != source_address {
                             debug!(
                                 target: LOG_TARGET,
                                 "Received Finalized Transaction for a cancelled pending Inbound Transaction (TxId: \
@@ -2062,8 +2075,7 @@ where
                         self.output_manager_service
                             .reinstate_cancelled_inbound_transaction_outputs(tx_id)
                             .await?;
-
-                        self.restart_receive_transaction_protocol(tx_id, source_pubkey.clone(), join_handles);
+                        self.restart_receive_transaction_protocol(tx_id, source_address.clone(), join_handles);
                         match self.finalized_transaction_senders.get_mut(&tx_id) {
                             None => return Err(TransactionServiceError::TransactionDoesNotExistError),
                             Some(s) => s,
@@ -2076,7 +2088,7 @@ where
         };
 
         sender
-            .send((source_pubkey, tx_id, transaction))
+            .send((source_address, tx_id, transaction))
             .await
             .map_err(|_| TransactionServiceError::ProtocolChannelError)?;
 
@@ -2154,7 +2166,7 @@ where
     ) -> Result<(), TransactionServiceError> {
         let inbound_txs = self.db.get_pending_inbound_transaction_sender_info()?;
         for txn in inbound_txs {
-            self.restart_receive_transaction_protocol(txn.tx_id, txn.source_public_key, join_handles);
+            self.restart_receive_transaction_protocol(txn.tx_id, txn.source_address, join_handles);
         }
 
         Ok(())
@@ -2163,7 +2175,7 @@ where
     fn restart_receive_transaction_protocol(
         &mut self,
         tx_id: TxId,
-        source_public_key: CommsPublicKey,
+        source_address: TariAddress,
         join_handles: &mut FuturesUnordered<JoinHandle<Result<TxId, TransactionServiceProtocolError<TxId>>>>,
     ) {
         if !self.pending_transaction_reply_senders.contains_key(&tx_id) {
@@ -2178,7 +2190,7 @@ where
                 .insert(tx_id, cancellation_sender);
             let protocol = TransactionReceiveProtocol::new(
                 tx_id,
-                source_public_key,
+                source_address,
                 TransactionSenderMessage::None,
                 TransactionReceiveProtocolStage::WaitForFinalize,
                 self.resources.clone(),
@@ -2489,7 +2501,7 @@ where
     pub fn add_utxo_import_transaction_with_status(
         &mut self,
         value: MicroTari,
-        source_public_key: CommsPublicKey,
+        source_address: TariAddress,
         message: String,
         maturity: Option<u64>,
         import_status: ImportStatus,
@@ -2501,8 +2513,8 @@ where
         self.db.add_utxo_import_transaction_with_status(
             tx_id,
             value,
-            source_public_key,
-            self.node_identity.public_key().clone(),
+            source_address,
+            self.resources.wallet_identity.address.clone(),
             message,
             maturity,
             import_status.clone(),
@@ -2574,8 +2586,8 @@ where
             transaction_broadcast_join_handles,
             CompletedTransaction::new(
                 tx_id,
-                self.node_identity.public_key().clone(),
-                self.node_identity.public_key().clone(),
+                self.resources.wallet_identity.address.clone(),
+                self.resources.wallet_identity.address.clone(),
                 amount,
                 fee,
                 tx,
@@ -2627,8 +2639,8 @@ where
                     tx_id,
                     CompletedTransaction::new(
                         tx_id,
-                        self.node_identity.public_key().clone(),
-                        self.node_identity.public_key().clone(),
+                        self.resources.wallet_identity.address.clone(),
+                        self.resources.wallet_identity.address.clone(),
                         amount,
                         MicroTari::from(0),
                         tx.clone(),
@@ -2689,7 +2701,7 @@ pub struct TransactionServiceResources<TBackend, TWalletConnectivity> {
     pub outbound_message_service: OutboundMessageRequester,
     pub connectivity: TWalletConnectivity,
     pub event_publisher: TransactionEventSender,
-    pub node_identity: Arc<NodeIdentity>,
+    pub wallet_identity: WalletIdentity,
     pub factories: CryptoFactories,
     pub config: TransactionServiceConfig,
     pub shutdown_signal: ShutdownSignal,

--- a/base_layer/wallet/src/transaction_service/storage/models.rs
+++ b/base_layer/wallet/src/transaction_service/storage/models.rs
@@ -28,10 +28,10 @@ use std::{
 use chrono::NaiveDateTime;
 use serde::{Deserialize, Serialize};
 use tari_common_types::{
+    tari_address::TariAddress,
     transaction::{TransactionConversionError, TransactionDirection, TransactionStatus, TxId},
     types::{BlockHash, PrivateKey, Signature},
 };
-use tari_comms::types::CommsPublicKey;
 use tari_core::transactions::{
     tari_amount::MicroTari,
     transaction_components::Transaction,
@@ -42,7 +42,7 @@ use tari_core::transactions::{
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct InboundTransaction {
     pub tx_id: TxId,
-    pub source_public_key: CommsPublicKey,
+    pub source_address: TariAddress,
     pub amount: MicroTari,
     pub receiver_protocol: ReceiverTransactionProtocol,
     pub status: TransactionStatus,
@@ -57,7 +57,7 @@ pub struct InboundTransaction {
 impl InboundTransaction {
     pub fn new(
         tx_id: TxId,
-        source_public_key: CommsPublicKey,
+        source_address: TariAddress,
         amount: MicroTari,
         receiver_protocol: ReceiverTransactionProtocol,
         status: TransactionStatus,
@@ -66,7 +66,7 @@ impl InboundTransaction {
     ) -> Self {
         Self {
             tx_id,
-            source_public_key,
+            source_address,
             amount,
             receiver_protocol,
             status,
@@ -83,7 +83,7 @@ impl InboundTransaction {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct OutboundTransaction {
     pub tx_id: TxId,
-    pub destination_public_key: CommsPublicKey,
+    pub destination_address: TariAddress,
     pub amount: MicroTari,
     pub fee: MicroTari,
     pub sender_protocol: SenderTransactionProtocol,
@@ -99,7 +99,7 @@ pub struct OutboundTransaction {
 impl OutboundTransaction {
     pub fn new(
         tx_id: TxId,
-        destination_public_key: CommsPublicKey,
+        destination_address: TariAddress,
         amount: MicroTari,
         fee: MicroTari,
         sender_protocol: SenderTransactionProtocol,
@@ -110,7 +110,7 @@ impl OutboundTransaction {
     ) -> Self {
         Self {
             tx_id,
-            destination_public_key,
+            destination_address,
             amount,
             fee,
             sender_protocol,
@@ -128,8 +128,8 @@ impl OutboundTransaction {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct CompletedTransaction {
     pub tx_id: TxId,
-    pub source_public_key: CommsPublicKey,
-    pub destination_public_key: CommsPublicKey,
+    pub source_address: TariAddress,
+    pub destination_address: TariAddress,
     pub amount: MicroTari,
     pub fee: MicroTari,
     pub transaction: Transaction,
@@ -151,8 +151,8 @@ pub struct CompletedTransaction {
 impl CompletedTransaction {
     pub fn new(
         tx_id: TxId,
-        source_public_key: CommsPublicKey,
-        destination_public_key: CommsPublicKey,
+        source_address: TariAddress,
+        destination_address: TariAddress,
         amount: MicroTari,
         fee: MicroTari,
         transaction: Transaction,
@@ -171,8 +171,8 @@ impl CompletedTransaction {
         };
         Self {
             tx_id,
-            source_public_key,
-            destination_public_key,
+            source_address,
+            destination_address,
             amount,
             fee,
             transaction,
@@ -205,7 +205,7 @@ impl From<CompletedTransaction> for InboundTransaction {
     fn from(ct: CompletedTransaction) -> Self {
         Self {
             tx_id: ct.tx_id,
-            source_public_key: ct.source_public_key,
+            source_address: ct.source_address,
             amount: ct.amount,
             receiver_protocol: ReceiverTransactionProtocol::new_placeholder(),
             status: ct.status,
@@ -223,7 +223,7 @@ impl From<CompletedTransaction> for OutboundTransaction {
     fn from(ct: CompletedTransaction) -> Self {
         Self {
             tx_id: ct.tx_id,
-            destination_public_key: ct.destination_public_key,
+            destination_address: ct.destination_address,
             amount: ct.amount,
             fee: ct.fee,
             sender_protocol: SenderTransactionProtocol::new_placeholder(),
@@ -255,8 +255,8 @@ impl From<OutboundTransaction> for CompletedTransaction {
         };
         Self {
             tx_id: tx.tx_id,
-            source_public_key: Default::default(),
-            destination_public_key: tx.destination_public_key,
+            source_address: Default::default(),
+            destination_address: tx.destination_address,
             amount: tx.amount,
             fee: tx.fee,
             status: tx.status,
@@ -285,8 +285,8 @@ impl From<InboundTransaction> for CompletedTransaction {
     fn from(tx: InboundTransaction) -> Self {
         Self {
             tx_id: tx.tx_id,
-            source_public_key: tx.source_public_key,
-            destination_public_key: Default::default(),
+            source_address: tx.source_address,
+            destination_address: Default::default(),
             amount: tx.amount,
             fee: MicroTari::from(0),
             status: tx.status,

--- a/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
@@ -32,6 +32,7 @@ use chrono::{NaiveDateTime, Utc};
 use diesel::{prelude::*, result::Error as DieselError, SqliteConnection};
 use log::*;
 use tari_common_types::{
+    tari_address::TariAddress,
     transaction::{
         TransactionConversionError,
         TransactionDirection,
@@ -41,7 +42,6 @@ use tari_common_types::{
     },
     types::{BlockHash, PrivateKey, PublicKey, Signature},
 };
-use tari_comms::types::CommsPublicKey;
 use tari_core::transactions::tari_amount::MicroTari;
 use tari_utilities::{
     hex::{from_hex, Hex},
@@ -492,10 +492,10 @@ impl TransactionBackend for TransactionServiceSqliteDatabase {
         Ok(result)
     }
 
-    fn get_pending_transaction_counterparty_pub_key_by_tx_id(
+    fn get_pending_transaction_counterparty_address_by_tx_id(
         &self,
         tx_id: TxId,
-    ) -> Result<CommsPublicKey, TransactionStorageError> {
+    ) -> Result<TariAddress, TransactionStorageError> {
         let start = Instant::now();
         let conn = self.database_connection.get_pooled_connection()?;
         let acquire_lock = start.elapsed();
@@ -513,7 +513,7 @@ impl TransactionBackend for TransactionServiceSqliteDatabase {
                     start.elapsed().as_millis()
                 );
             }
-            return Ok(outbound_tx.destination_public_key);
+            return Ok(outbound_tx.destination_address);
         }
         if let Ok(mut inbound_tx_sql) = InboundTransactionSql::find_by_cancelled(tx_id, false, &conn) {
             self.decrypt_if_necessary(&mut inbound_tx_sql)?;
@@ -528,7 +528,7 @@ impl TransactionBackend for TransactionServiceSqliteDatabase {
                     start.elapsed().as_millis()
                 );
             }
-            return Ok(inbound_tx.source_public_key);
+            return Ok(inbound_tx.source_address);
         }
 
         Err(TransactionStorageError::ValuesNotFound)
@@ -1310,7 +1310,7 @@ impl TransactionBackend for TransactionServiceSqliteDatabase {
 #[derive(Debug, PartialEq)]
 pub struct InboundTransactionSenderInfo {
     pub(crate) tx_id: TxId,
-    pub(crate) source_public_key: CommsPublicKey,
+    pub(crate) source_address: TariAddress,
 }
 
 impl TryFrom<InboundTransactionSenderInfoSql> for InboundTransactionSenderInfo {
@@ -1319,8 +1319,8 @@ impl TryFrom<InboundTransactionSenderInfoSql> for InboundTransactionSenderInfo {
     fn try_from(i: InboundTransactionSenderInfoSql) -> Result<Self, Self::Error> {
         Ok(Self {
             tx_id: TxId::from(i.tx_id as u64),
-            source_public_key: CommsPublicKey::from_bytes(&*i.source_public_key)
-                .map_err(TransactionStorageError::ByteArrayError)?,
+            source_address: TariAddress::from_bytes(&*i.source_address)
+                .map_err(TransactionStorageError::TariAddressError)?,
         })
     }
 }
@@ -1328,7 +1328,7 @@ impl TryFrom<InboundTransactionSenderInfoSql> for InboundTransactionSenderInfo {
 #[derive(Clone, Queryable)]
 pub struct InboundTransactionSenderInfoSql {
     pub tx_id: i64,
-    pub source_public_key: Vec<u8>,
+    pub source_address: Vec<u8>,
 }
 
 impl InboundTransactionSenderInfoSql {
@@ -1336,7 +1336,7 @@ impl InboundTransactionSenderInfoSql {
         conn: &SqliteConnection,
     ) -> Result<Vec<InboundTransactionSenderInfoSql>, TransactionStorageError> {
         let query_result = inbound_transactions::table
-            .select((inbound_transactions::tx_id, inbound_transactions::source_public_key))
+            .select((inbound_transactions::tx_id, inbound_transactions::source_address))
             .filter(inbound_transactions::cancelled.eq(i32::from(false)))
             .load::<InboundTransactionSenderInfoSql>(conn)?;
         Ok(query_result)
@@ -1347,7 +1347,7 @@ impl InboundTransactionSenderInfoSql {
 #[table_name = "inbound_transactions"]
 struct InboundTransactionSql {
     tx_id: i64,
-    source_public_key: Vec<u8>,
+    source_address: Vec<u8>,
     amount: i64,
     receiver_protocol: String,
     message: String,
@@ -1565,7 +1565,7 @@ impl TryFrom<InboundTransaction> for InboundTransactionSql {
     fn try_from(i: InboundTransaction) -> Result<Self, Self::Error> {
         Ok(Self {
             tx_id: i.tx_id.as_u64() as i64,
-            source_public_key: i.source_public_key.to_vec(),
+            source_address: i.source_address.to_bytes().to_vec(),
             amount: u64::from(i.amount) as i64,
             receiver_protocol: serde_json::to_string(&i.receiver_protocol)?,
             message: i.message,
@@ -1584,7 +1584,7 @@ impl TryFrom<InboundTransactionSql> for InboundTransaction {
     fn try_from(i: InboundTransactionSql) -> Result<Self, Self::Error> {
         Ok(Self {
             tx_id: (i.tx_id as u64).into(),
-            source_public_key: PublicKey::from_vec(&i.source_public_key).map_err(TransactionKeyError::Source)?,
+            source_address: TariAddress::from_bytes(&i.source_address).map_err(TransactionKeyError::Source)?,
             amount: MicroTari::from(i.amount as u64),
             receiver_protocol: serde_json::from_str(&i.receiver_protocol.clone())?,
             status: TransactionStatus::Pending,
@@ -1613,7 +1613,7 @@ pub struct UpdateInboundTransactionSql {
 #[table_name = "outbound_transactions"]
 struct OutboundTransactionSql {
     tx_id: i64,
-    destination_public_key: Vec<u8>,
+    destination_address: Vec<u8>,
     amount: i64,
     fee: i64,
     sender_protocol: String,
@@ -1816,7 +1816,7 @@ impl TryFrom<OutboundTransaction> for OutboundTransactionSql {
     fn try_from(o: OutboundTransaction) -> Result<Self, Self::Error> {
         Ok(Self {
             tx_id: o.tx_id.as_u64() as i64,
-            destination_public_key: o.destination_public_key.to_vec(),
+            destination_address: o.destination_address.to_bytes().to_vec(),
             amount: u64::from(o.amount) as i64,
             fee: u64::from(o.fee) as i64,
             sender_protocol: serde_json::to_string(&o.sender_protocol)?,
@@ -1836,7 +1836,7 @@ impl TryFrom<OutboundTransactionSql> for OutboundTransaction {
     fn try_from(o: OutboundTransactionSql) -> Result<Self, Self::Error> {
         Ok(Self {
             tx_id: (o.tx_id as u64).into(),
-            destination_public_key: PublicKey::from_vec(&o.destination_public_key)
+            destination_address: TariAddress::from_bytes(&o.destination_address)
                 .map_err(TransactionKeyError::Destination)?,
             amount: MicroTari::from(o.amount as u64),
             fee: MicroTari::from(o.fee as u64),
@@ -1867,8 +1867,8 @@ pub struct UpdateOutboundTransactionSql {
 #[table_name = "completed_transactions"]
 struct CompletedTransactionSql {
     tx_id: i64,
-    source_public_key: Vec<u8>,
-    destination_public_key: Vec<u8>,
+    source_address: Vec<u8>,
+    destination_address: Vec<u8>,
     amount: i64,
     fee: i64,
     transaction_protocol: String,
@@ -2216,8 +2216,8 @@ impl TryFrom<CompletedTransaction> for CompletedTransactionSql {
     fn try_from(c: CompletedTransaction) -> Result<Self, Self::Error> {
         Ok(Self {
             tx_id: c.tx_id.as_u64() as i64,
-            source_public_key: c.source_public_key.to_vec(),
-            destination_public_key: c.destination_public_key.to_vec(),
+            source_address: c.source_address.to_bytes().to_vec(),
+            destination_address: c.destination_address.to_bytes().to_vec(),
             amount: u64::from(c.amount) as i64,
             fee: u64::from(c.fee) as i64,
             transaction_protocol: serde_json::to_string(&c.transaction)?,
@@ -2271,8 +2271,8 @@ impl TryFrom<CompletedTransactionSql> for CompletedTransaction {
         };
         Ok(Self {
             tx_id: (c.tx_id as u64).into(),
-            source_public_key: PublicKey::from_vec(&c.source_public_key).map_err(TransactionKeyError::Source)?,
-            destination_public_key: PublicKey::from_vec(&c.destination_public_key)
+            source_address: TariAddress::from_bytes(&c.source_address).map_err(TransactionKeyError::Source)?,
+            destination_address: TariAddress::from_bytes(&c.destination_address)
                 .map_err(TransactionKeyError::Destination)?,
             amount: MicroTari::from(c.amount as u64),
             fee: MicroTari::from(c.fee as u64),
@@ -2397,8 +2397,10 @@ mod test {
     use chrono::Utc;
     use diesel::{Connection, SqliteConnection};
     use rand::{rngs::OsRng, RngCore};
+    use tari_common::configuration::Network;
     use tari_common_sqlite::sqlite_connection_pool::SqliteConnectionPool;
     use tari_common_types::{
+        tari_address::TariAddress,
         transaction::{TransactionDirection, TransactionStatus, TxId},
         types::{PrivateKey, PublicKey, Signature},
     };
@@ -2490,9 +2492,13 @@ mod test {
 
         let mut stp = builder.build(&factories, None, u64::MAX).unwrap();
 
+        let address = TariAddress::new(
+            PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
+            Network::LocalNet,
+        );
         let outbound_tx1 = OutboundTransaction {
             tx_id: 1u64.into(),
-            destination_public_key: PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
+            destination_address: address,
             amount,
             fee: stp.get_fee_amount().unwrap(),
             sender_protocol: stp.clone(),
@@ -2504,10 +2510,13 @@ mod test {
             send_count: 0,
             last_send_timestamp: None,
         };
-
+        let address = TariAddress::new(
+            PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
+            Network::LocalNet,
+        );
         let outbound_tx2 = OutboundTransactionSql::try_from(OutboundTransaction {
             tx_id: 2u64.into(),
-            destination_public_key: PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
+            destination_address: address,
             amount,
             fee: stp.get_fee_amount().unwrap(),
             sender_protocol: stp.clone(),
@@ -2545,10 +2554,13 @@ mod test {
             PrivateKey::random(&mut OsRng),
             &factories,
         );
-
+        let address = TariAddress::new(
+            PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
+            Network::LocalNet,
+        );
         let inbound_tx1 = InboundTransaction {
             tx_id: 2u64.into(),
-            source_public_key: PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
+            source_address: address,
             amount,
             receiver_protocol: rtp.clone(),
             status: TransactionStatus::Pending,
@@ -2559,9 +2571,13 @@ mod test {
             send_count: 0,
             last_send_timestamp: None,
         };
+        let address = TariAddress::new(
+            PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
+            Network::LocalNet,
+        );
         let inbound_tx2 = InboundTransaction {
             tx_id: 3u64.into(),
-            source_public_key: PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
+            source_address: address,
             amount,
             receiver_protocol: rtp,
             status: TransactionStatus::Pending,
@@ -2600,11 +2616,18 @@ mod test {
             PrivateKey::random(&mut OsRng),
             PrivateKey::random(&mut OsRng),
         );
-
+        let source_address = TariAddress::new(
+            PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
+            Network::LocalNet,
+        );
+        let destination_address = TariAddress::new(
+            PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
+            Network::LocalNet,
+        );
         let completed_tx1 = CompletedTransaction {
             tx_id: 2u64.into(),
-            source_public_key: PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
-            destination_public_key: PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
+            source_address,
+            destination_address,
             amount,
             fee: MicroTari::from(100),
             transaction: tx.clone(),
@@ -2622,10 +2645,18 @@ mod test {
             mined_in_block: None,
             mined_timestamp: None,
         };
+        let source_address = TariAddress::new(
+            PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
+            Network::LocalNet,
+        );
+        let destination_address = TariAddress::new(
+            PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
+            Network::LocalNet,
+        );
         let completed_tx2 = CompletedTransaction {
             tx_id: 3u64.into(),
-            source_public_key: PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
-            destination_public_key: PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
+            source_address,
+            destination_address,
             amount,
             fee: MicroTari::from(100),
             transaction: tx.clone(),
@@ -2748,10 +2779,18 @@ mod test {
         assert!(CompletedTransactionSql::find_by_cancelled(completed_tx1.tx_id, false, &conn).is_err());
         assert!(CompletedTransactionSql::find_by_cancelled(completed_tx1.tx_id, true, &conn).is_ok());
 
+        let source_address = TariAddress::new(
+            PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
+            Network::LocalNet,
+        );
+        let destination_address = TariAddress::new(
+            PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
+            Network::LocalNet,
+        );
         let coinbase_tx1 = CompletedTransaction {
             tx_id: 101u64.into(),
-            source_public_key: PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
-            destination_public_key: PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
+            source_address,
+            destination_address,
             amount,
             fee: MicroTari::from(100),
             transaction: tx.clone(),
@@ -2770,10 +2809,18 @@ mod test {
             mined_timestamp: None,
         };
 
+        let source_address = TariAddress::new(
+            PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
+            Network::LocalNet,
+        );
+        let destination_address = TariAddress::new(
+            PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
+            Network::LocalNet,
+        );
         let coinbase_tx2 = CompletedTransaction {
             tx_id: 102u64.into(),
-            source_public_key: PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
-            destination_public_key: PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
+            source_address,
+            destination_address,
             amount,
             fee: MicroTari::from(100),
             transaction: tx.clone(),
@@ -2792,10 +2839,18 @@ mod test {
             mined_timestamp: None,
         };
 
+        let source_address = TariAddress::new(
+            PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
+            Network::LocalNet,
+        );
+        let destination_address = TariAddress::new(
+            PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
+            Network::LocalNet,
+        );
         let coinbase_tx3 = CompletedTransaction {
             tx_id: 103u64.into(),
-            source_public_key: PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
-            destination_public_key: PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
+            source_address,
+            destination_address,
             amount,
             fee: MicroTari::from(100),
             transaction: tx.clone(),
@@ -2836,6 +2891,7 @@ mod test {
     }
 
     #[test]
+    #[allow(clippy::too_many_lines)]
     fn test_encryption_crud() {
         let db_name = format!("{}.sqlite3", string(8).as_str());
         let temp_dir = tempdir().unwrap();
@@ -2854,9 +2910,13 @@ mod test {
         let key_ga = Key::from_slice(&key);
         let cipher = XChaCha20Poly1305::new(key_ga);
 
+        let source_address = TariAddress::new(
+            PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
+            Network::LocalNet,
+        );
         let inbound_tx = InboundTransaction {
             tx_id: 1u64.into(),
-            source_public_key: PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
+            source_address,
             amount: MicroTari::from(100),
             receiver_protocol: ReceiverTransactionProtocol::new_placeholder(),
             status: TransactionStatus::Pending,
@@ -2876,9 +2936,13 @@ mod test {
         let decrypted_inbound_tx = InboundTransaction::try_from(db_inbound_tx).unwrap();
         assert_eq!(inbound_tx, decrypted_inbound_tx);
 
+        let destination_address = TariAddress::new(
+            PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
+            Network::LocalNet,
+        );
         let outbound_tx = OutboundTransaction {
             tx_id: 2u64.into(),
-            destination_public_key: PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
+            destination_address,
             amount: MicroTari::from(100),
             fee: MicroTari::from(10),
             sender_protocol: SenderTransactionProtocol::new_placeholder(),
@@ -2900,10 +2964,18 @@ mod test {
         let decrypted_outbound_tx = OutboundTransaction::try_from(db_outbound_tx).unwrap();
         assert_eq!(outbound_tx, decrypted_outbound_tx);
 
+        let source_address = TariAddress::new(
+            PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
+            Network::LocalNet,
+        );
+        let destination_address = TariAddress::new(
+            PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
+            Network::LocalNet,
+        );
         let completed_tx = CompletedTransaction {
             tx_id: 3u64.into(),
-            source_public_key: PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
-            destination_public_key: PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
+            source_address,
+            destination_address,
             amount: MicroTari::from(100),
             fee: MicroTari::from(100),
             transaction: Transaction::new(
@@ -2939,6 +3011,7 @@ mod test {
     }
 
     #[test]
+    #[allow(clippy::too_many_lines)]
     fn test_apply_remove_encryption() {
         let db_name = format!("{}.sqlite3", string(8).as_str());
         let temp_dir = tempdir().unwrap();
@@ -2958,9 +3031,13 @@ mod test {
 
             embedded_migrations::run_with_output(&conn, &mut std::io::stdout()).expect("Migration failed");
 
+            let source_address = TariAddress::new(
+                PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
+                Network::LocalNet,
+            );
             let inbound_tx = InboundTransaction {
                 tx_id: 1u64.into(),
-                source_public_key: PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
+                source_address,
                 amount: MicroTari::from(100),
                 receiver_protocol: ReceiverTransactionProtocol::new_placeholder(),
                 status: TransactionStatus::Pending,
@@ -2974,9 +3051,13 @@ mod test {
             let inbound_tx_sql = InboundTransactionSql::try_from(inbound_tx).unwrap();
             inbound_tx_sql.commit(&conn).unwrap();
 
+            let destination_address = TariAddress::new(
+                PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
+                Network::LocalNet,
+            );
             let outbound_tx = OutboundTransaction {
                 tx_id: 2u64.into(),
-                destination_public_key: PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
+                destination_address,
                 amount: MicroTari::from(100),
                 fee: MicroTari::from(10),
                 sender_protocol: SenderTransactionProtocol::new_placeholder(),
@@ -2991,10 +3072,18 @@ mod test {
             let outbound_tx_sql = OutboundTransactionSql::try_from(outbound_tx).unwrap();
             outbound_tx_sql.commit(&conn).unwrap();
 
+            let source_address = TariAddress::new(
+                PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
+                Network::LocalNet,
+            );
+            let destination_address = TariAddress::new(
+                PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
+                Network::LocalNet,
+            );
             let completed_tx = CompletedTransaction {
                 tx_id: 3u64.into(),
-                source_public_key: PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
-                destination_public_key: PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
+                source_address,
+                destination_address,
                 amount: MicroTari::from(100),
                 fee: MicroTari::from(100),
                 transaction: Transaction::new(
@@ -3119,10 +3208,18 @@ mod test {
                 10 => (None, TransactionStatus::MinedConfirmed, None),
                 _ => (None, TransactionStatus::Completed, Some(i)),
             };
+            let source_address = TariAddress::new(
+                PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
+                Network::LocalNet,
+            );
+            let destination_address = TariAddress::new(
+                PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
+                Network::LocalNet,
+            );
             let completed_tx = CompletedTransaction {
                 tx_id: TxId::from(i),
-                source_public_key: PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
-                destination_public_key: PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
+                source_address,
+                destination_address,
                 amount: MicroTari::from(100),
                 fee: MicroTari::from(100),
                 transaction: Transaction::new(
@@ -3156,7 +3253,7 @@ mod test {
             if cancelled.is_none() {
                 info_list_reference.push(InboundTransactionSenderInfo {
                     tx_id: inbound_tx.tx_id,
-                    source_public_key: inbound_tx.source_public_key,
+                    source_address: inbound_tx.source_address,
                 })
             }
         }

--- a/base_layer/wallet/src/transaction_service/tasks/send_transaction_reply.rs
+++ b/base_layer/wallet/src/transaction_service/tasks/send_transaction_reply.rs
@@ -65,7 +65,7 @@ pub async fn send_transaction_reply(
         TransactionRoutingMechanism::StoreAndForwardOnly => {
             send_transaction_reply_store_and_forward(
                 inbound_transaction.tx_id,
-                inbound_transaction.source_public_key,
+                inbound_transaction.source_address.public_key().clone(),
                 proto_message.clone(),
                 &mut outbound_message_service,
             )
@@ -93,7 +93,7 @@ pub async fn send_transaction_reply_direct(
     let proto_message: proto::RecipientSignedMessage = recipient_reply.into();
     match outbound_message_service
         .send_direct(
-            inbound_transaction.source_public_key.clone(),
+            inbound_transaction.source_address.public_key().clone(),
             OutboundDomainMessage::new(&TariMessageType::ReceiverPartialTransactionReply, proto_message.clone()),
             "wallet transaction reply".to_string(),
         )
@@ -104,7 +104,7 @@ pub async fn send_transaction_reply_direct(
                 if wait_on_dial(
                     send_states,
                     tx_id,
-                    inbound_transaction.source_public_key.clone(),
+                    inbound_transaction.source_address.public_key().clone(),
                     "Transaction Reply",
                     direct_send_timeout,
                 )
@@ -115,15 +115,15 @@ pub async fn send_transaction_reply_direct(
                 // Send a Store and Forward (SAF) regardless.
                 info!(
                     target: LOG_TARGET,
-                    "Direct Send reply result was {}. Sending SAF for TxId: {} to recipient with Public Key: {}",
+                    "Direct Send reply result was {}. Sending SAF for TxId: {} to recipient with address: {}",
                     direct_send_result,
                     tx_id,
-                    inbound_transaction.source_public_key,
+                    inbound_transaction.source_address,
                 );
                 if transaction_routing_mechanism == TransactionRoutingMechanism::DirectAndStoreAndForward {
                     store_and_forward_send_result = send_transaction_reply_store_and_forward(
                         tx_id,
-                        inbound_transaction.source_public_key,
+                        inbound_transaction.source_address.public_key().clone(),
                         proto_message.clone(),
                         &mut outbound_message_service,
                     )
@@ -138,7 +138,7 @@ pub async fn send_transaction_reply_direct(
                 if transaction_routing_mechanism == TransactionRoutingMechanism::DirectAndStoreAndForward {
                     store_and_forward_send_result = send_transaction_reply_store_and_forward(
                         tx_id,
-                        inbound_transaction.source_public_key.clone(),
+                        inbound_transaction.source_address.public_key().clone(),
                         proto_message.clone(),
                         &mut outbound_message_service,
                     )
@@ -149,7 +149,7 @@ pub async fn send_transaction_reply_direct(
                 if transaction_routing_mechanism == TransactionRoutingMechanism::DirectAndStoreAndForward {
                     store_and_forward_send_result = send_transaction_reply_store_and_forward(
                         tx_id,
-                        inbound_transaction.source_public_key.clone(),
+                        inbound_transaction.source_address.public_key().clone(),
                         proto_message.clone(),
                         &mut outbound_message_service,
                     )
@@ -160,12 +160,12 @@ pub async fn send_transaction_reply_direct(
                     Ok(SendMessageResponse::Queued(send_states)) => {
                         debug!(
                             target: LOG_TARGET,
-                            "Discovery of {} completed for TxID: {}", inbound_transaction.source_public_key, tx_id
+                            "Discovery of {} completed for TxID: {}", inbound_transaction.source_address, tx_id
                         );
                         direct_send_result = wait_on_dial(
                             send_states,
                             tx_id,
-                            inbound_transaction.source_public_key.clone(),
+                            inbound_transaction.source_address.public_key().clone(),
                             "Transaction Reply",
                             direct_send_timeout,
                         )

--- a/base_layer/wallet/src/util/mod.rs
+++ b/base_layer/wallet/src/util/mod.rs
@@ -22,4 +22,5 @@
 
 pub mod diesel_ext;
 pub mod encryption;
+pub mod wallet_identity;
 pub mod watch;

--- a/base_layer/wallet/src/util/wallet_identity.rs
+++ b/base_layer/wallet/src/util/wallet_identity.rs
@@ -1,0 +1,54 @@
+//  Copyright 2022, The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::{fmt, fmt::Display, sync::Arc};
+
+use tari_common::configuration::Network;
+use tari_common_types::tari_address::TariAddress;
+use tari_comms::peer_manager::NodeIdentity;
+
+#[derive(Clone, Debug)]
+pub struct WalletIdentity {
+    pub node_identity: Arc<NodeIdentity>,
+    pub network: Network,
+    pub address: TariAddress,
+}
+
+impl WalletIdentity {
+    pub fn new(node_identity: Arc<NodeIdentity>, network: Network) -> Self {
+        let address = TariAddress::new(node_identity.public_key().clone(), network);
+        WalletIdentity {
+            node_identity,
+            network,
+            address,
+        }
+    }
+}
+
+impl Display for WalletIdentity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "{}", self.node_identity)?;
+        writeln!(f, "Network: {:?}", self.network)?;
+
+        Ok(())
+    }
+}

--- a/base_layer/wallet/src/utxo_scanner_service/service.rs
+++ b/base_layer/wallet/src/utxo_scanner_service/service.rs
@@ -20,13 +20,11 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::sync::Arc;
-
 use chrono::NaiveDateTime;
 use futures::FutureExt;
 use log::*;
 use tari_common_types::types::HashOutput;
-use tari_comms::{connectivity::ConnectivityRequester, peer_manager::Peer, types::CommsPublicKey, NodeIdentity};
+use tari_comms::{connectivity::ConnectivityRequester, peer_manager::Peer, types::CommsPublicKey};
 use tari_core::transactions::{tari_amount::MicroTari, CryptoFactories};
 use tari_shutdown::{Shutdown, ShutdownSignal};
 use tokio::{
@@ -41,6 +39,7 @@ use crate::{
     output_manager_service::handle::OutputManagerHandle,
     storage::database::{WalletBackend, WalletDatabase},
     transaction_service::handle::TransactionServiceHandle,
+    util::wallet_identity::WalletIdentity,
     utxo_scanner_service::{
         handle::UtxoScannerEvent,
         utxo_scanner_task::UtxoScannerTask,
@@ -198,7 +197,7 @@ pub struct UtxoScannerResources<TBackend, TWalletConnectivity> {
     pub current_base_node_watcher: watch::Receiver<Option<Peer>>,
     pub output_manager_service: OutputManagerHandle,
     pub transaction_service: TransactionServiceHandle,
-    pub node_identity: Arc<NodeIdentity>,
+    pub wallet_identity: WalletIdentity,
     pub factories: CryptoFactories,
     pub recovery_message: String,
     pub one_sided_payment_message: String,

--- a/base_layer/wallet/src/utxo_scanner_service/utxo_scanner_task.rs
+++ b/base_layer/wallet/src/utxo_scanner_service/utxo_scanner_task.rs
@@ -29,6 +29,7 @@ use chrono::{NaiveDateTime, Utc};
 use futures::StreamExt;
 use log::*;
 use tari_common_types::{
+    tari_address::TariAddress,
     transaction::{ImportStatus, TxId},
     types::HashOutput,
 };
@@ -579,22 +580,19 @@ where
     ) -> Result<(u64, MicroTari), UtxoScannerError> {
         let mut num_recovered = 0u64;
         let mut total_amount = MicroTari::from(0);
-        let default_key = CommsPublicKey::default();
-        let self_key = self.resources.node_identity.public_key().clone();
-
         for (uo, message, import_status, tx_id) in utxos {
-            let source_public_key = if uo.features.is_coinbase() {
+            let source_address = if uo.features.is_coinbase() {
                 // its a coinbase, so we know we mined it and it comes from us.
-                &self_key
+                self.resources.wallet_identity.address.clone()
             } else {
                 // Because we do not know the source public key we are making it the default key of zeroes to make it
                 // clear this value is a placeholder.
-                &default_key
+                TariAddress::default()
             };
             match self
                 .import_unblinded_utxo_to_transaction_service(
                     uo.clone(),
-                    source_public_key,
+                    source_address,
                     message,
                     import_status,
                     tx_id,
@@ -652,7 +650,7 @@ where
     pub async fn import_unblinded_utxo_to_transaction_service(
         &mut self,
         unblinded_output: UnblindedOutput,
-        source_public_key: &CommsPublicKey,
+        source_address: TariAddress,
         message: String,
         import_status: ImportStatus,
         tx_id: TxId,
@@ -664,7 +662,7 @@ where
             .transaction_service
             .import_utxo_with_status(
                 unblinded_output.value,
-                source_public_key.clone(),
+                source_address,
                 message,
                 Some(unblinded_output.features.maturity),
                 import_status.clone(),

--- a/base_layer/wallet/tests/transaction_service_tests/storage.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/storage.rs
@@ -25,7 +25,9 @@ use std::mem::size_of;
 use chacha20poly1305::{aead::NewAead, Key, XChaCha20Poly1305};
 use chrono::{NaiveDateTime, Utc};
 use rand::{rngs::OsRng, RngCore};
+use tari_common::configuration::Network;
 use tari_common_types::{
+    tari_address::TariAddress,
     transaction::{TransactionDirection, TransactionStatus, TxId},
     types::{FixedHash, PrivateKey, PublicKey, Signature},
 };
@@ -107,9 +109,13 @@ pub fn test_db_backend<T: TransactionBackend + 'static>(backend: T) {
 
     for i in 0..messages.len() {
         let tx_id = TxId::from(i + 10);
+        let address = TariAddress::new(
+            PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
+            Network::LocalNet,
+        );
         outbound_txs.push(OutboundTransaction {
             tx_id,
-            destination_public_key: PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
+            destination_address: address,
             amount: amounts[i],
             fee: stp.clone().get_fee_amount().unwrap(),
             sender_protocol: stp.clone(),
@@ -162,10 +168,14 @@ pub fn test_db_backend<T: TransactionBackend + 'static>(backend: T) {
     let mut inbound_txs = Vec::new();
 
     for i in 0..messages.len() {
+        let address = TariAddress::new(
+            PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
+            Network::LocalNet,
+        );
         let tx_id = TxId::from(i);
         inbound_txs.push(InboundTransaction {
             tx_id,
-            source_public_key: PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
+            source_address: address,
             amount: amounts[i],
             receiver_protocol: rtp.clone(),
             status: TransactionStatus::Pending,
@@ -203,19 +213,19 @@ pub fn test_db_backend<T: TransactionBackend + 'static>(backend: T) {
         panic!("Should have found inbound tx");
     }
 
-    let inbound_pub_key = db
-        .get_pending_transaction_counterparty_pub_key_by_tx_id(inbound_txs[0].tx_id)
+    let inbound_address = db
+        .get_pending_transaction_counterparty_address_by_tx_id(inbound_txs[0].tx_id)
         .unwrap();
-    assert_eq!(inbound_pub_key, inbound_txs[0].source_public_key);
+    assert_eq!(inbound_address, inbound_txs[0].source_address);
 
     assert!(db
-        .get_pending_transaction_counterparty_pub_key_by_tx_id(100u64.into())
+        .get_pending_transaction_counterparty_address_by_tx_id(100u64.into())
         .is_err());
 
-    let outbound_pub_key = db
-        .get_pending_transaction_counterparty_pub_key_by_tx_id(outbound_txs[0].tx_id)
+    let outbound_address = db
+        .get_pending_transaction_counterparty_address_by_tx_id(outbound_txs[0].tx_id)
         .unwrap();
-    assert_eq!(outbound_pub_key, outbound_txs[0].destination_public_key);
+    assert_eq!(outbound_address, outbound_txs[0].destination_address);
 
     let mut completed_txs = Vec::new();
     let tx = Transaction::new(
@@ -227,10 +237,18 @@ pub fn test_db_backend<T: TransactionBackend + 'static>(backend: T) {
     );
 
     for i in 0..messages.len() {
+        let source_address = TariAddress::new(
+            PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
+            Network::LocalNet,
+        );
+        let dest_address = TariAddress::new(
+            PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
+            Network::LocalNet,
+        );
         completed_txs.push(CompletedTransaction {
             tx_id: outbound_txs[i].tx_id,
-            source_public_key: PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
-            destination_public_key: PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
+            source_address,
+            destination_address: dest_address,
             amount: outbound_txs[i].amount,
             fee: MicroTari::from(200),
             transaction: tx.clone(),
@@ -330,12 +348,15 @@ pub fn test_db_backend<T: TransactionBackend + 'static>(backend: T) {
     } else {
         panic!("Should have found cancelled completed tx");
     }
-
+    let address = TariAddress::new(
+        PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
+        Network::LocalNet,
+    );
     db.add_pending_inbound_transaction(
         999u64.into(),
         InboundTransaction::new(
             999u64.into(),
-            PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
+            address,
             22 * uT,
             rtp,
             TransactionStatus::Pending,
@@ -378,12 +399,15 @@ pub fn test_db_backend<T: TransactionBackend + 'static>(backend: T) {
     let mut cancelled_txs = db.get_cancelled_pending_inbound_transactions().unwrap();
     assert_eq!(cancelled_txs.len(), 1);
     assert!(cancelled_txs.remove(&999u64.into()).is_some());
-
+    let address = TariAddress::new(
+        PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
+        Network::LocalNet,
+    );
     db.add_pending_outbound_transaction(
         998u64.into(),
         OutboundTransaction::new(
             998u64.into(),
-            PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
+            address,
             22 * uT,
             stp.get_fee_amount().unwrap(),
             stp,
@@ -484,8 +508,8 @@ async fn import_tx_and_read_it_from_db() {
 
     let transaction = CompletedTransaction::new(
         TxId::from(1u64),
-        PublicKey::default(),
-        PublicKey::default(),
+        TariAddress::default(),
+        TariAddress::default(),
         MicroTari::from(100000),
         MicroTari::from(0),
         Transaction::new(
@@ -513,8 +537,8 @@ async fn import_tx_and_read_it_from_db() {
 
     let transaction = CompletedTransaction::new(
         TxId::from(2u64),
-        PublicKey::default(),
-        PublicKey::default(),
+        TariAddress::default(),
+        TariAddress::default(),
         MicroTari::from(100000),
         MicroTari::from(0),
         Transaction::new(
@@ -542,8 +566,8 @@ async fn import_tx_and_read_it_from_db() {
 
     let transaction = CompletedTransaction::new(
         TxId::from(3u64),
-        PublicKey::default(),
-        PublicKey::default(),
+        TariAddress::default(),
+        TariAddress::default(),
         MicroTari::from(100000),
         MicroTari::from(0),
         Transaction::new(

--- a/base_layer/wallet/tests/wallet.rs
+++ b/base_layer/wallet/tests/wallet.rs
@@ -27,6 +27,7 @@ use support::{comms_and_services::get_next_memory_address, utils::make_input};
 use tari_common::configuration::StringList;
 use tari_common_types::{
     chain_metadata::ChainMetadata,
+    tari_address::TariAddress,
     transaction::TransactionStatus,
     types::{FixedHash, PrivateKey, PublicKey},
 };
@@ -210,6 +211,8 @@ async fn test_wallet() {
     let base_node_identity =
         NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE);
 
+    // create wallet creates a local wallet
+    let network = Network::LocalNet;
     let mut alice_wallet = create_wallet(
         alice_db_tempdir.path(),
         "alice_db",
@@ -233,6 +236,7 @@ async fn test_wallet() {
     .await
     .unwrap();
     let bob_identity = (*bob_wallet.comms.node_identity()).clone();
+    let bob_address = TariAddress::new(bob_identity.public_key().clone(), network);
 
     alice_wallet
         .comms
@@ -272,7 +276,7 @@ async fn test_wallet() {
     alice_wallet
         .transaction_service
         .send_transaction(
-            bob_identity.public_key().clone(),
+            bob_address.clone(),
             value,
             UtxoSelectionCriteria::default(),
             OutputFeatures::default(),
@@ -301,8 +305,9 @@ async fn test_wallet() {
     let mut contacts = Vec::new();
     for i in 0..2 {
         let (_secret_key, public_key) = PublicKey::random_keypair(&mut OsRng);
+        let address = TariAddress::new(public_key, Network::LocalNet);
 
-        contacts.push(Contact::new(random::string(8), public_key, None, None));
+        contacts.push(Contact::new(random::string(8), address, None, None));
 
         alice_wallet
             .contacts_service
@@ -496,6 +501,8 @@ async fn test_store_and_forward_send_tx() {
     let alice_db_tempdir = tempdir().unwrap();
     let carol_db_tempdir = tempdir().unwrap();
     let base_node_tempdir = tempdir().unwrap();
+    // create wallet uses local net
+    let network = Network::LocalNet;
 
     let mut alice_wallet = create_wallet(
         alice_db_tempdir.path(),
@@ -537,6 +544,7 @@ async fn test_store_and_forward_send_tx() {
     .unwrap();
 
     let carol_identity = carol_wallet.comms.node_identity();
+    let carol_address = TariAddress::new(carol_identity.public_key().clone(), network);
     let mut carol_event_stream = carol_wallet.transaction_service.get_event_stream();
 
     alice_wallet
@@ -562,7 +570,7 @@ async fn test_store_and_forward_send_tx() {
     alice_wallet
         .transaction_service
         .send_transaction(
-            carol_identity.public_key().clone(),
+            carol_address.clone(),
             value,
             UtxoSelectionCriteria::default(),
             OutputFeatures::default(),
@@ -620,6 +628,7 @@ async fn test_store_and_forward_send_tx() {
 #[allow(clippy::too_many_lines)]
 #[tokio::test]
 async fn test_import_utxo() {
+    let network = Network::Weatherwax;
     let factories = CryptoFactories::default();
     let shutdown = Shutdown::new();
     let alice_identity = Arc::new(NodeIdentity::random(
@@ -627,7 +636,7 @@ async fn test_import_utxo() {
         "/ip4/127.0.0.1/tcp/24521".parse().unwrap(),
         PeerFeatures::COMMUNICATION_NODE,
     ));
-    let base_node_identity = Arc::new(NodeIdentity::random(
+    let node_identity = Arc::new(NodeIdentity::random(
         &mut OsRng,
         "/ip4/127.0.0.1/tcp/24522".parse().unwrap(),
         PeerFeatures::COMMUNICATION_NODE,
@@ -658,7 +667,7 @@ async fn test_import_utxo() {
     };
     let config = WalletConfig {
         p2p: comms_config,
-        network: Network::Weatherwax,
+        network,
         ..Default::default()
     };
 
@@ -691,14 +700,14 @@ async fn test_import_utxo() {
     let utxo = create_unblinded_output(script.clone(), temp_features, &p, 20000 * uT);
     let output = utxo.as_transaction_output(&factories).unwrap();
     let expected_output_hash = output.hash();
-
+    let node_address = TariAddress::new(node_identity.public_key().clone(), network);
     let tx_id = alice_wallet
         .import_external_utxo_as_non_rewindable(
             utxo.value,
             &utxo.spending_key,
             script.clone(),
             input.clone(),
-            base_node_identity.public_key(),
+            node_address,
             utxo.features.clone(),
             "Testing".to_string(),
             utxo.metadata_signature.clone(),
@@ -797,7 +806,8 @@ async fn test_contacts_service_liveness() {
     let factories = CryptoFactories::default();
     let alice_db_tempdir = tempdir().unwrap();
     let bob_db_tempdir = tempdir().unwrap();
-
+    // network used by create wallet is local net
+    let network = Network::LocalNet;
     let mut alice_wallet = create_wallet(
         alice_db_tempdir.path(),
         "alice_db",
@@ -809,6 +819,7 @@ async fn test_contacts_service_liveness() {
     .await
     .unwrap();
     let alice_identity = alice_wallet.comms.node_identity();
+    let alice_address = TariAddress::new(alice_identity.public_key().clone(), network);
 
     let mut bob_wallet = create_wallet(
         bob_db_tempdir.path(),
@@ -821,6 +832,7 @@ async fn test_contacts_service_liveness() {
     .await
     .unwrap();
     let bob_identity = (*bob_wallet.comms.node_identity()).clone();
+    let bob_address = TariAddress::new(bob_identity.public_key().clone(), network);
 
     alice_wallet
         .comms
@@ -828,7 +840,7 @@ async fn test_contacts_service_liveness() {
         .add_peer(bob_identity.to_peer())
         .await
         .unwrap();
-    let contact_bob = Contact::new(random::string(8), bob_identity.public_key().clone(), None, None);
+    let contact_bob = Contact::new(random::string(8), bob_address.clone(), None, None);
     alice_wallet.contacts_service.upsert_contact(contact_bob).await.unwrap();
 
     bob_wallet
@@ -837,7 +849,7 @@ async fn test_contacts_service_liveness() {
         .add_peer(alice_identity.to_peer())
         .await
         .unwrap();
-    let contact_alice = Contact::new(random::string(8), alice_identity.public_key().clone(), None, None);
+    let contact_alice = Contact::new(random::string(8), alice_address.clone(), None, None);
     bob_wallet.contacts_service.upsert_contact(contact_alice).await.unwrap();
 
     alice_wallet
@@ -856,7 +868,7 @@ async fn test_contacts_service_liveness() {
         tokio::select! {
             event = liveness_event_stream_alice.recv() => {
                 if let ContactsLivenessEvent::StatusUpdated(data) = &*event.unwrap() {
-                    if data.public_key() == bob_identity.public_key(){
+                    if data.address() == &bob_address{
                         assert_eq!(data.node_id(), bob_identity.node_id());
                         match data.message_type()  {
                             ContactMessageType::Ping  => {
@@ -890,7 +902,7 @@ async fn test_contacts_service_liveness() {
         tokio::select! {
             event = liveness_event_stream_bob.recv() => {
                 if let ContactsLivenessEvent::StatusUpdated(data) = &*event.unwrap() {
-                    if data.public_key() == alice_identity.public_key(){
+                    if data.address() == &alice_address{
                         assert_eq!(data.node_id(), alice_identity.node_id());
                         if data.message_type() == ContactMessageType::Ping {
                             ping_count += 1;

--- a/base_layer/wallet_ffi/src/error.rs
+++ b/base_layer/wallet_ffi/src/error.rs
@@ -20,6 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 use log::*;
+use tari_common_types::tari_address::TariAddressError;
 use tari_comms::multiaddr;
 use tari_comms_dht::store_forward::StoreAndForwardError;
 use tari_crypto::{
@@ -386,6 +387,32 @@ impl From<ByteArrayError> for LibWalletError {
             ByteArrayError::IncorrectLength => Self {
                 code: 601,
                 message: format!("{:?}", b),
+            },
+        }
+    }
+}
+
+/// This implementation maps the internal TariAddressError to a set of LibWalletErrors.
+/// The mapping is explicitly managed here.
+impl From<TariAddressError> for LibWalletError {
+    fn from(e: TariAddressError) -> Self {
+        error!(target: LOG_TARGET, "{}", format!("{:?}", e));
+        match e {
+            TariAddressError::InvalidNetworkOrChecksum => Self {
+                code: 701,
+                message: format!("{:?}", e),
+            },
+            TariAddressError::CannotRecoverPublicKey => Self {
+                code: 702,
+                message: format!("{:?}", e),
+            },
+            TariAddressError::InvalidSize => Self {
+                code: 703,
+                message: format!("{:?}", e),
+            },
+            TariAddressError::InvalidEmoji => Self {
+                code: 704,
+                message: format!("{:?}", e),
             },
         }
     }

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -146,6 +146,8 @@ struct RistrettoPublicKey;
  */
 struct RistrettoSecretKey;
 
+struct TariAddress;
+
 struct TariCompletedTransactions;
 
 struct TariContacts;
@@ -203,6 +205,8 @@ typedef PublicKey TariPublicKey;
 typedef struct RistrettoSecretKey PrivateKey;
 
 typedef PrivateKey TariPrivateKey;
+
+typedef struct TariAddress TariWalletAddress;
 
 /**
  * # A Commitment signature implementation on Ristretto
@@ -655,39 +659,127 @@ TariPublicKey *public_key_from_hex(const char *key,
                                    int *error_out);
 
 /**
- * Creates a char array from a TariPublicKey in emoji format
+ * -------------------------------------------------------------------------------------------- ///
+ * -------------------------------- Tari Address ---------------------------------------------- ///
+ * Creates a TariWalletAddress from a ByteVector
  *
  * ## Arguments
- * `pk` - The pointer to a TariPublicKey
+ * `bytes` - The pointer to a ByteVector
+ * `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
+ * as an out parameter.
+ *
+ * ## Returns
+ * `TariWalletAddress` - Returns a public key. Note that it will be ptr::null_mut() if bytes is null or
+ * if there was an error with the contents of bytes
+ *
+ * # Safety
+ * The ```public_key_destroy``` function must be called when finished with a TariWalletAddress to prevent a memory leak
+ */
+TariWalletAddress *tari_address_create(struct ByteVector *bytes,
+                                       int *error_out);
+
+/**
+ * Frees memory for a TariWalletAddress
+ *
+ * ## Arguments
+ * `pk` - The pointer to a TariWalletAddress
+ *
+ * ## Returns
+ * `()` - Does not return a value, equivalent to void in C
+ *
+ * # Safety
+ * None
+ */
+void tari_address_destroy(TariWalletAddress *address);
+
+/**
+ * Gets a ByteVector from a TariWalletAddress
+ *
+ * ## Arguments
+ * `address` - The pointer to a TariWalletAddress
+ * `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
+ * as an out parameter.
+ *
+ * ## Returns
+ * `*mut ByteVector` - Returns a pointer to a ByteVector. Note that it returns ptr::null_mut() if address is null
+ *
+ * # Safety
+ * The ```byte_vector_destroy``` function must be called when finished with the ByteVector to prevent a memory leak.
+ */
+struct ByteVector *tari_address_get_bytes(TariWalletAddress *address,
+                                          int *error_out);
+
+/**
+ * Creates a TariWalletAddress from a TariPrivateKey
+ *
+ * ## Arguments
+ * `secret_key` - The pointer to a TariPrivateKey
+ * `network` - an u8 indicating the network
+ * `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
+ * as an out parameter.
+ *
+ * ## Returns
+ * `*mut TariWalletAddress` - Returns a pointer to a TariWalletAddress
+ *
+ * # Safety
+ * The ```private_key_destroy``` method must be called when finished with a private key to prevent a memory leak
+ */
+TariWalletAddress *tari_address_from_private_key(TariPrivateKey *secret_key,
+                                                 unsigned int network,
+                                                 int *error_out);
+
+/**
+ * Creates a TariWalletAddress from a char array
+ *
+ * ## Arguments
+ * `address` - The pointer to a char array which is hex encoded
+ * `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
+ * as an out parameter.
+ *
+ * ## Returns
+ * `*mut TariWalletAddress` - Returns a pointer to a TariWalletAddress. Note that it returns ptr::null_mut()
+ * if key is null or if there was an error creating the TariWalletAddress from key
+ *
+ * # Safety
+ * The ```public_key_destroy``` method must be called when finished with a TariWalletAddress to prevent a memory leak
+ */
+TariWalletAddress *tari_address_from_hex(const char *address,
+                                         int *error_out);
+
+/**
+ * Creates a char array from a TariWalletAddress in emoji format
+ *
+ * ## Arguments
+ * `address` - The pointer to a TariWalletAddress
  * `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
  * as an out parameter.
  *
  * ## Returns
  * `*mut c_char` - Returns a pointer to a char array. Note that it returns empty
- * if emoji is null or if there was an error creating the emoji string from TariPublicKey
+ * if emoji is null or if there was an error creating the emoji string from TariWalletAddress
  *
  * # Safety
  * The ```string_destroy``` method must be called when finished with a string from rust to prevent a memory leak
  */
-char *public_key_to_emoji_id(TariPublicKey *pk,
-                             int *error_out);
+char *tari_address_to_emoji_id(TariWalletAddress *address,
+                               int *error_out);
 
 /**
- * Creates a TariPublicKey from a char array in emoji format
+ * Creates a TariWalletAddress from a char array in emoji format
  *
  * ## Arguments
- * `const *c_char` - The pointer to a TariPublicKey
+ * `const *c_char` - The pointer to a TariWalletAddress
  * `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
  * as an out parameter.
  *
  * ## Returns
- * `*mut c_char` - Returns a pointer to a TariPublicKey. Note that it returns null on error.
+ * `*mut c_char` - Returns a pointer to a TariWalletAddress. Note that it returns null on error.
  *
  * # Safety
- * The ```public_key_destroy``` method must be called when finished with a TariPublicKey to prevent a memory leak
+ * The ```public_key_destroy``` method must be called when finished with a TariWalletAddress to prevent a memory leak
  */
-TariPublicKey *emoji_id_to_public_key(const char *emoji,
-                                      int *error_out);
+TariWalletAddress *emoji_id_to_tari_address(const char *emoji,
+                                            int *error_out);
 
 /**
  * -------------------------------------------------------------------------------------------- ///
@@ -700,7 +792,7 @@ TariPublicKey *emoji_id_to_public_key(const char *emoji,
  * as an out parameter.
  *
  * ## Returns
- * `*mut TariPrivateKey` - Returns a pointer to a TariPublicKey. Note that it returns ptr::null_mut()
+ * `*mut TariPrivateKey` - Returns a pointer to a TariPrivateKey. Note that it returns ptr::null_mut()
  * if bytes is null or if there was an error creating the TariPrivateKey from bytes
  *
  * # Safety
@@ -764,7 +856,7 @@ TariPrivateKey *private_key_generate(void);
  * as an out parameter.
  *
  * ## Returns
- * `*mut TariPrivateKey` - Returns a pointer to a TariPublicKey. Note that it returns ptr::null_mut()
+ * `*mut TariPrivateKey` - Returns a pointer to a TariPrivateKey. Note that it returns ptr::null_mut()
  * if key is null or if there was an error creating the TariPrivateKey from key
  *
  * # Safety
@@ -1056,7 +1148,7 @@ void seed_words_destroy(struct TariSeedWords *seed_words);
  *
  * ## Arguments
  * `alias` - The pointer to a char array
- * `public_key` - The pointer to a TariPublicKey
+ * `address` - The pointer to a TariWalletAddress
  * `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
  * as an out parameter.
  *
@@ -1068,7 +1160,7 @@ void seed_words_destroy(struct TariSeedWords *seed_words);
  * The ```contact_destroy``` method must be called when finished with a TariContact
  */
 TariContact *contact_create(const char *alias,
-                            TariPublicKey *public_key,
+                            TariWalletAddress *address,
                             int *error_out);
 
 /**
@@ -1090,7 +1182,7 @@ char *contact_get_alias(TariContact *contact,
                         int *error_out);
 
 /**
- * Gets the TariPublicKey of the TariContact
+ * Gets the TariWalletAddress of the TariContact
  *
  * ## Arguments
  * `contact` - The pointer to a TariContact
@@ -1098,14 +1190,14 @@ char *contact_get_alias(TariContact *contact,
  * as an out parameter.
  *
  * ## Returns
- * `*mut TariPublicKey` - Returns a pointer to a TariPublicKey. Note that it returns
+ * `*mut TariWalletAddress` - Returns a pointer to a TariWalletAddress. Note that it returns
  * ptr::null_mut() if contact is null
  *
  * # Safety
- * The ```public_key_destroy``` method must be called when finished with a TariPublicKey to prevent a memory leak
+ * The ```tari_address_destroy``` method must be called when finished with a TariWalletAddress to prevent a memory leak
  */
-TariPublicKey *contact_get_public_key(TariContact *contact,
-                                      int *error_out);
+TariWalletAddress *contact_get_tari_address(TariContact *contact,
+                                            int *error_out);
 
 /**
  * Frees memory for a TariContact
@@ -1185,15 +1277,15 @@ void contacts_destroy(struct TariContacts *contacts);
  * as an out parameter.
  *
  * ## Returns
- * `*mut TariPublicKey` - Returns a pointer to a TariPublicKey. Note that it returns ptr::null_mut() if
+ * `*mut TariWalletAddress` - Returns a pointer to a TariWalletAddress. Note that it returns ptr::null_mut() if
  * liveness_data is null.
  *
  * # Safety
  * The ```liveness_data_destroy``` method must be called when finished with a TariContactsLivenessData to prevent a
  * memory leak
  */
-TariPublicKey *liveness_data_get_public_key(TariContactsLivenessData *liveness_data,
-                                            int *error_out);
+TariWalletAddress *liveness_data_get_public_key(TariContactsLivenessData *liveness_data,
+                                                int *error_out);
 
 /**
  * Gets the latency in milli-seconds (ms) from a TariContactsLivenessData
@@ -1481,7 +1573,7 @@ unsigned long long completed_transaction_get_transaction_id(TariCompletedTransac
                                                             int *error_out);
 
 /**
- * Gets the destination TariPublicKey of a TariCompletedTransaction
+ * Gets the destination TariWalletAddress of a TariCompletedTransaction
  *
  * ## Arguments
  * `transaction` - The pointer to a TariCompletedTransaction
@@ -1489,14 +1581,14 @@ unsigned long long completed_transaction_get_transaction_id(TariCompletedTransac
  * as an out parameter.
  *
  * ## Returns
- * `*mut TariPublicKey` - Returns the destination TariPublicKey, note that it will be
+ * `*mut TariWalletAddress` - Returns the destination TariWalletAddress, note that it will be
  * ptr::null_mut() if transaction is null
  *
  * # Safety
- * The ```public_key_destroy``` method must be called when finished with a TariPublicKey to prevent a memory leak
+ * The ```public_key_destroy``` method must be called when finished with a TariWalletAddress to prevent a memory leak
  */
-TariPublicKey *completed_transaction_get_destination_public_key(TariCompletedTransaction *transaction,
-                                                                int *error_out);
+TariWalletAddress *completed_transaction_get_destination_public_key(TariCompletedTransaction *transaction,
+                                                                    int *error_out);
 
 /**
  * Gets the TariTransactionKernel of a TariCompletedTransaction
@@ -1519,7 +1611,7 @@ TariTransactionKernel *completed_transaction_get_transaction_kernel(TariComplete
                                                                     int *error_out);
 
 /**
- * Gets the source TariPublicKey of a TariCompletedTransaction
+ * Gets the source TariWalletAddress of a TariCompletedTransaction
  *
  * ## Arguments
  * `transaction` - The pointer to a TariCompletedTransaction
@@ -1527,14 +1619,14 @@ TariTransactionKernel *completed_transaction_get_transaction_kernel(TariComplete
  * as an out parameter.
  *
  * ## Returns
- * `*mut TariPublicKey` - Returns the source TariPublicKey, note that it will be
+ * `*mut TariWalletAddress` - Returns the source TariWalletAddress, note that it will be
  * ptr::null_mut() if transaction is null
  *
  * # Safety
- * The ```public_key_destroy``` method must be called when finished with a TariPublicKey to prevent a memory leak
+ * The ```tari_address_destroy``` method must be called when finished with a TariWalletAddress to prevent a memory leak
  */
-TariPublicKey *completed_transaction_get_source_public_key(TariCompletedTransaction *transaction,
-                                                           int *error_out);
+TariWalletAddress *completed_transaction_get_source_public_key(TariCompletedTransaction *transaction,
+                                                               int *error_out);
 
 /**
  * Gets the status of a TariCompletedTransaction
@@ -1727,7 +1819,7 @@ unsigned long long pending_outbound_transaction_get_transaction_id(TariPendingOu
                                                                    int *error_out);
 
 /**
- * Gets the destination TariPublicKey of a TariPendingOutboundTransaction
+ * Gets the destination TariWalletAddress of a TariPendingOutboundTransaction
  *
  * ## Arguments
  * `transaction` - The pointer to a TariPendingOutboundTransaction
@@ -1735,14 +1827,14 @@ unsigned long long pending_outbound_transaction_get_transaction_id(TariPendingOu
  * as an out parameter.
  *
  * ## Returns
- * `*mut TariPublicKey` - Returns the destination TariPublicKey, note that it will be
+ * `*mut TariWalletAddress` - Returns the destination TariWalletAddress, note that it will be
  * ptr::null_mut() if transaction is null
  *
  * # Safety
- * The ```public_key_destroy``` method must be called when finished with a TariPublicKey to prevent a memory leak
+ * The ```public_key_destroy``` method must be called when finished with a TariWalletAddress to prevent a memory leak
  */
-TariPublicKey *pending_outbound_transaction_get_destination_public_key(TariPendingOutboundTransaction *transaction,
-                                                                       int *error_out);
+TariWalletAddress *pending_outbound_transaction_get_destination_public_key(TariPendingOutboundTransaction *transaction,
+                                                                           int *error_out);
 
 /**
  * Gets the amount of a TariPendingOutboundTransaction
@@ -1874,7 +1966,7 @@ unsigned long long pending_inbound_transaction_get_transaction_id(TariPendingInb
                                                                   int *error_out);
 
 /**
- * Gets the source TariPublicKey of a TariPendingInboundTransaction
+ * Gets the source TariWalletAddress of a TariPendingInboundTransaction
  *
  * ## Arguments
  * `transaction` - The pointer to a TariPendingInboundTransaction
@@ -1882,14 +1974,14 @@ unsigned long long pending_inbound_transaction_get_transaction_id(TariPendingInb
  * as an out parameter.
  *
  * ## Returns
- * `*mut TariPublicKey` - Returns a pointer to the source TariPublicKey, note that it will be
+ * `*mut TariWalletAddress` - Returns a pointer to the source TariWalletAddress, note that it will be
  * ptr::null_mut() if transaction is null
  *
  * # Safety
- *  The ```public_key_destroy``` method must be called when finished with a TariPublicKey to prevent a memory leak
+ *  The ```public_key_destroy``` method must be called when finished with a TariWalletAddress to prevent a memory leak
  */
-TariPublicKey *pending_inbound_transaction_get_source_public_key(TariPendingInboundTransaction *transaction,
-                                                                 int *error_out);
+TariWalletAddress *pending_inbound_transaction_get_source_public_key(TariPendingInboundTransaction *transaction,
+                                                                     int *error_out);
 
 /**
  * Gets the amount of a TariPendingInboundTransaction
@@ -2633,7 +2725,7 @@ void balance_destroy(TariBalance *balance);
  *
  * ## Arguments
  * `wallet` - The TariWallet pointer
- * `dest_public_key` - The TariPublicKey pointer of the peer
+ * `destination` - The TariWalletAddress pointer of the peer
  * `amount` - The amount
  * `commitments` - A `TariVector` of "strings", tagged as `TariTypeTag::String`, containing commitment's hex values
  *   (see `Commitment::to_hex()`)
@@ -2649,7 +2741,7 @@ void balance_destroy(TariBalance *balance);
  * None
  */
 unsigned long long wallet_send_transaction(struct TariWallet *wallet,
-                                           TariPublicKey *dest_public_key,
+                                           TariWalletAddress *destination,
                                            unsigned long long amount,
                                            struct TariVector *commitments,
                                            unsigned long long fee_per_gram,
@@ -2906,7 +2998,7 @@ TariCompletedTransaction *wallet_get_cancelled_transaction_by_id(struct TariWall
                                                                  int *error_out);
 
 /**
- * Get the TariPublicKey from a TariWallet
+ * Get the TariWalletAddress from a TariWallet
  *
  * ## Arguments
  * `wallet` - The TariWallet pointer
@@ -2914,14 +3006,14 @@ TariCompletedTransaction *wallet_get_cancelled_transaction_by_id(struct TariWall
  * as an out parameter.
  *
  * ## Returns
- * `*mut TariPublicKey` - returns the public key, note that ptr::null_mut() is returned
+ * `*mut TariWalletAddress` - returns the address, note that ptr::null_mut() is returned
  * if wc is null
  *
  * # Safety
- * The ```public_key_destroy``` method must be called when finished with a TariPublicKey to prevent a memory leak
+ * The ```tari_address_destroy``` method must be called when finished with a TariWalletAddress to prevent a memory leak
  */
-TariPublicKey *wallet_get_public_key(struct TariWallet *wallet,
-                                     int *error_out);
+TariWalletAddress *wallet_get_tari_address(struct TariWallet *wallet,
+                                           int *error_out);
 
 /**
  * Import an external UTXO into the wallet as a non-rewindable (i.e. non-recoverable) output. This will add a spendable
@@ -2931,7 +3023,7 @@ TariPublicKey *wallet_get_public_key(struct TariWallet *wallet,
  * `wallet` - The TariWallet pointer
  * `amount` - The value of the UTXO in MicroTari
  * `spending_key` - The private spending key
- * `source_public_key` - The public key of the source of the transaction
+ * `source_address` - The tari address of the source of the transaction
  * `features` - Options for an output's structure or use
  * `metadata_signature` - UTXO signature with the script offset private key, k_O
  * `sender_offset_public_key` - Tari script offset pubkey, K_O
@@ -2953,7 +3045,7 @@ TariPublicKey *wallet_get_public_key(struct TariWallet *wallet,
 unsigned long long wallet_import_external_utxo_as_non_rewindable(struct TariWallet *wallet,
                                                                  unsigned long long amount,
                                                                  TariPrivateKey *spending_key,
-                                                                 TariPublicKey *source_public_key,
+                                                                 TariWalletAddress *source_address,
                                                                  TariOutputFeatures *features,
                                                                  TariCommitmentSignature *metadata_signature,
                                                                  TariPublicKey *sender_offset_public_key,

--- a/common/src/configuration/network.rs
+++ b/common/src/configuration/network.rs
@@ -113,6 +113,28 @@ impl From<Network> for String {
     }
 }
 
+impl TryFrom<u8> for Network {
+    type Error = ConfigurationError;
+
+    fn try_from(v: u8) -> Result<Self, ConfigurationError> {
+        match v {
+            x if x == Network::MainNet as u8 => Ok(Network::MainNet),
+            x if x == Network::LocalNet as u8 => Ok(Network::LocalNet),
+            x if x == Network::Ridcully as u8 => Ok(Network::Ridcully),
+            x if x == Network::Stibbons as u8 => Ok(Network::Stibbons),
+            x if x == Network::Weatherwax as u8 => Ok(Network::Weatherwax),
+            x if x == Network::Igor as u8 => Ok(Network::Igor),
+            x if x == Network::Dibbler as u8 => Ok(Network::Dibbler),
+            x if x == Network::Esmeralda as u8 => Ok(Network::Esmeralda),
+            _ => Err(ConfigurationError::new(
+                "network",
+                Some(v.to_string()),
+                &format!("Invalid network option: {}", v),
+            )),
+        }
+    }
+}
+
 impl Display for Network {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         f.write_str(self.as_key_str())
@@ -177,5 +199,17 @@ mod test {
         // catch error case
         let err_network = Network::from_str("invalid network");
         assert!(err_network.is_err());
+    }
+
+    #[test]
+    fn network_from_byte() {
+        assert_eq!(Network::try_from(0x00).unwrap(), Network::MainNet);
+        assert_eq!(Network::try_from(0x10).unwrap(), Network::LocalNet);
+        assert_eq!(Network::try_from(0x21).unwrap(), Network::Ridcully);
+        assert_eq!(Network::try_from(0x22).unwrap(), Network::Stibbons);
+        assert_eq!(Network::try_from(0xa3).unwrap(), Network::Weatherwax);
+        assert_eq!(Network::try_from(0x24).unwrap(), Network::Igor);
+        assert_eq!(Network::try_from(0x25).unwrap(), Network::Dibbler);
+        assert_eq!(Network::try_from(0x26).unwrap(), Network::Esmeralda);
     }
 }


### PR DESCRIPTION
Description
---
This changes the address used by the wallet to not just use the pubkey of another wallet, to a new custom address scheme.

Changes:
- Includes new address scheme : [version][network][pub_key]
- Replaces wallet pubkey with new address all over
- Calculate what address should be is message is received from network public key. 
- Cleans up database to remove broken fields and defunct tables

Motivation and Context
---
We need the wallets to be able to verify that the addresses used by the wallets are for the correct network and are wallets. In interactive transactions, transactions using the wrong pubkeys, will result in transactions eventually being self-canceled by the wallet as they are stale. But one-sided and stealth these will be sent and never recoverable. 

Using the new scheme wallets can verify addresses are on the correct network, and because base_nodes still use pubkeys the addresses differ between base_nodes and wallets. 

How Has This Been Tested?
---
All unit tests passed


Fixes: #4888 
Fixes: #4886 


BREAKING: This changes how the wallet accepts and presents addresses 
