### PR TITLE
fix(ci): resolve windows binary builds

### DIFF
--- a/.github/workflows/base_node_binaries.yml
+++ b/.github/workflows/base_node_binaries.yml
@@ -111,31 +111,29 @@ jobs:
         if: ${{ startsWith(runner.os,'Linux') && matrix.builds.name != 'linux-arm64' }}
         run: |
           sudo apt-get update
-          sudo apt-get -y install \
-            openssl \
-            libssl-dev \
-            pkg-config \
-            libsqlite3-dev \
-            clang-10 \
-            git \
-            cmake \
-            libc++-dev \
-            libc++abi-dev \
-            libprotobuf-dev \
-            protobuf-compiler \
-            libncurses5-dev \
-            libncursesw5-dev \
-            zip
+          sudo bash scripts/install_ubuntu_dependencies.sh
 
       - name: Install macOS dependencies
         if: startsWith(runner.os,'macOS')
-        run: brew install cmake zip coreutils automake autoconf
+        run: brew install cmake coreutils automake autoconf
 
       - name: Install Windows dependencies
+        #continue-on-error: true  # WARNING: workaround
         if: startsWith(runner.os,'Windows')
         run: |
           vcpkg.exe install sqlite3:x64-windows zlib:x64-windows
-          choco upgrade llvm zip psutils openssl strawberryperl -y
+          # Bug in choco - need to install each package individually
+          choco upgrade llvm -y
+          choco upgrade psutils -y
+          choco upgrade openssl -y
+          choco upgrade strawberryperl -y
+
+      - name: Debugging - Upload logs if dependences failures
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.TBN_FILENAME }}-windows-dependences-logs
+          path: C:\ProgramData\chocolatey\logs\chocolatey.log
 
       - name: Set environment variables - Nix
         if: "!startsWith(runner.os,'Windows')"
@@ -176,14 +174,9 @@ jobs:
           echo "C:\Strawberry\perl\bin" >> $GITHUB_PATH
 
       - name: Cache cargo files and outputs
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
 
-      - name: Revert Cargo.toml for Ubuntu to cross-compile ARM64
-        if: ${{ startsWith(runner.os,'Linux') && matrix.builds.name == 'linux-arm64' }}
-        run: sed -i-bak -e '/^resolver/s/2/1/' Cargo.toml
-
-      - name: Build rust binaries - Normal
-        #if: ${{ matrix.builds.name != 'linux-arm64' }}
+      - name: Build rust binaries
         uses: actions-rs/cargo@v1
         env:
           RUSTFLAGS: "-C target_cpu=${{ matrix.builds.target_cpu }}"
@@ -193,7 +186,7 @@ jobs:
           command: build
           args: --release --target ${{ matrix.builds.target }} --features ${{ matrix.builds.features }} ${{ matrix.builds.target_bins }} ${{ matrix.builds.flags }} --locked
 
-      - name: Copy binaries to folder for zipping
+      - name: Copy binaries to folder for archiving
         shell: bash
         run: |
           mkdir -p "$GITHUB_WORKSPACE${TBN_DIST}"
@@ -338,7 +331,8 @@ jobs:
         run: |
           echo "Archive ${{ env.BINFILE }} too ${{ env.BINFILE }}.zip"
           cd "$GITHUB_WORKSPACE${{ env.TBN_DIST }}"
-          zip -j "${{ env.BINFILE }}.zip" *
+          #zip -j "${{ env.BINFILE }}.zip" *
+          7z a "${{ env.BINFILE }}.zip" *
           echo "Compute shasum"
           ${SHARUN} "${{ env.BINFILE }}.zip" >> "${{ env.BINFILE }}.zip.sha256"
           cat "${{ env.BINFILE }}.zip.sha256"

--- a/.github/workflows/build_libwallets_workflow.yml
+++ b/.github/workflows/build_libwallets_workflow.yml
@@ -46,7 +46,7 @@ jobs:
           override: true
 
       - name: Cache cargo files and outputs
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
 
       - name: Build libwallet libraries
         uses: actions-rs/cargo@v1
@@ -115,7 +115,7 @@ jobs:
         run: brew install cmake
 
       - name: Cache cargo files and outputs
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
 
       - name: Build libwallet libraries
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
           toolchain: stable
           profile: minimal
           override: true
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       - name: ubuntu dependencies
         run: |
           sudo apt-get update


### PR DESCRIPTION
Description
Split out each choco windows package install/upgrade. Seems to be a new bug in choco.
Added a debug log upload, which should only be run on failure.
Also switched out zip for 7zip, as it's packaged with al runners. Had zip installs in the past.
Switched out Ubuntu apt-get install with scripts/install_ubuntu_dependencies.sh as a re-used script.
Update rust-cache action.

Motivation and Context
Fix Windows binary builds

How Has This Been Tested?
Test in local fork, builds complete.

