### PR TITLE
fix!: update `argon2` and improve key handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5287,7 +5287,7 @@ dependencies = [
 name = "tari_wallet"
 version = "0.38.8"
 dependencies = [
- "argon2 0.2.4",
+ "argon2 0.4.1",
  "async-trait",
  "bincode",
  "blake2 0.9.2",
@@ -5331,6 +5331,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tower",
+ "zeroize",
 ]
 
 [[package]]

--- a/applications/tari_app_grpc/Cargo.toml
+++ b/applications/tari_app_grpc/Cargo.toml
@@ -15,7 +15,7 @@ tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "
 tari_script = { path = "../../infrastructure/tari_script" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag="v0.4.7" }
 
-argon2 = { version = "0.4.1", features = ["std"] }
+argon2 = { version = "0.4.1", features = ["std", "password-hash"] }
 base64 = "0.13.0"
 chrono = { version = "0.4.19", default-features = false }
 digest = "0.9"

--- a/base_layer/wallet/Cargo.toml
+++ b/base_layer/wallet/Cargo.toml
@@ -29,7 +29,7 @@ tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", t
 tokio = { version = "1.20", features = ["sync", "macros"] }
 
 async-trait = "0.1.50"
-argon2 = "0.2"
+argon2 = "0.4.1"
 bincode = "1.3.1"
 blake2 = "0.9.0"
 sha2 = "0.9.5"
@@ -55,6 +55,7 @@ tower = "0.4"
 prost = "0.9"
 itertools = "0.10.3"
 chacha20poly1305 = "0.9.1"
+zeroize = "1.3"
 
 [dev-dependencies]
 tari_p2p = { version = "^0.38", path = "../p2p", features = ["test-mocks"] }


### PR DESCRIPTION
Description
---
Updates `argon2` for the gRPC and wallet use cases. Improves handling of keys and secret data. Fixes [issue 4882](https://github.com/tari-project/tari/issues/4882).

Motivation and Context
---
[Issue 4882](https://github.com/tari-project/tari/issues/4882) notes that different versions of `argon2` are used throughout the codebase. The newer minor version `0.4` changes the API significantly, and the older version `0.2` is [no longer supported](https://crates.io/crates/argon2/0.2.0).

Additionally, gRPC and wallet implementations use the default parameter set from the crate, which is not in line with the [OWASP recommendations](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#argon2id) that we use elsewhere in the key manager.

Further, it's recommended that a [specific function](https://docs.rs/argon2/0.4.1/argon2/struct.Argon2.html#method.hash_password_into) be used when performing KDF functionality, as this binds the parameter set into the output. While not a major security issue, it's worth updating to this function where appropriate.

Finally, secret data is kept in memory in many places through the codebase, and this area is no exception. As part of good practice, we should try to zeroize such data wherever possible.

This PR addresses these issues. It updates the gRPC and wallet `argon2` versions to `0.4` (the key manager is addressed in [PR 4860](https://github.com/tari-project/tari/pull/4860) and makes the necessary API changes. It updates the parameter set to be consistent with the linked recommendations. It also adds some improved handling of secret data (but does not do so comprehensively, limiting the scope to the updated code).

How Has This Been Tested?
---
Existing tests pass.

BREAKING: This changes how wallet passphrase-based hashes and keys are derived.