### PR TITLE
fix(core/metrics): set target difficulty as single value

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,23 +126,13 @@ checksum = "983cd8b9d4b02a6dc6ffa557262eb5858a27a0038ffffe21a0f133eaa819a164"
 
 [[package]]
 name = "argon2"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca5162d1b961cb589a8ca08a2aa7cabc6341e05e0bf18d66a07697900b5d2ad0"
-dependencies = [
- "blake2 0.9.2",
- "password-hash 0.2.3",
-]
-
-[[package]]
-name = "argon2"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db4ce4441f99dbd377ca8a8f57b698c44d0d6e712d8329b5040da5a64aa1ce73"
 dependencies = [
  "base64ct",
  "blake2 0.10.4",
- "password-hash 0.4.2",
+ "password-hash",
 ]
 
 [[package]]
@@ -3084,17 +3074,6 @@ dependencies = [
 
 [[package]]
 name = "password-hash"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77e0b28ace46c5a396546bcf443bf422b57049617433d8854227352a4a9b24e7"
-dependencies = [
- "base64ct",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
-name = "password-hash"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
@@ -4455,7 +4434,7 @@ dependencies = [
 name = "tari_app_grpc"
 version = "0.38.8"
 dependencies = [
- "argon2 0.4.1",
+ "argon2",
  "base64 0.13.0",
  "chrono",
  "digest 0.9.0",
@@ -4907,7 +4886,7 @@ dependencies = [
 name = "tari_key_manager"
 version = "0.38.8"
 dependencies = [
- "argon2 0.4.1",
+ "argon2",
  "arrayvec 0.7.2",
  "blake2 0.9.2",
  "chacha20 0.7.3",
@@ -5202,7 +5181,7 @@ dependencies = [
 name = "tari_wallet"
 version = "0.38.8"
 dependencies = [
- "argon2 0.4.1",
+ "argon2",
  "async-trait",
  "bincode",
  "blake2 0.9.2",

--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -774,11 +774,11 @@ where B: BlockchainBackend + 'static
         fn update_target_difficulty(block: &ChainBlock) {
             match block.header().pow_algo() {
                 PowAlgorithm::Sha3 => {
-                    metrics::target_difficulty_sha(block.height())
+                    metrics::target_difficulty_sha()
                         .set(i64::try_from(block.accumulated_data().target_difficulty.as_u64()).unwrap_or(i64::MAX));
                 },
                 PowAlgorithm::Monero => {
-                    metrics::target_difficulty_monero(block.height())
+                    metrics::target_difficulty_monero()
                         .set(i64::try_from(block.accumulated_data().target_difficulty.as_u64()).unwrap_or(i64::MAX));
                 },
             }

--- a/base_layer/core/src/base_node/metrics.rs
+++ b/base_layer/core/src/base_node/metrics.rs
@@ -25,38 +25,36 @@ use tari_common_types::types::FixedHash;
 use tari_metrics::{IntCounter, IntCounterVec, IntGauge, IntGaugeVec};
 use tari_utilities::hex::Hex;
 
-pub fn tip_height() -> IntGauge {
+pub fn tip_height() -> &'static IntGauge {
     static METER: Lazy<IntGauge> = Lazy::new(|| {
         tari_metrics::register_int_gauge("base_node::blockchain::tip_height", "The current tip height").unwrap()
     });
 
-    METER.clone()
+    &METER
 }
 
-pub fn target_difficulty_sha(height: u64) -> IntGauge {
-    static METER: Lazy<IntGaugeVec> = Lazy::new(|| {
-        tari_metrics::register_int_gauge_vec(
+pub fn target_difficulty_sha() -> &'static IntGauge {
+    static METER: Lazy<IntGauge> = Lazy::new(|| {
+        tari_metrics::register_int_gauge(
             "base_node::blockchain::target_difficulty_sha",
             "The current miner target difficulty for the sha3 PoW algo",
-            &["height"],
         )
         .unwrap()
     });
 
-    METER.with_label_values(&[&height.to_string()])
+    &METER
 }
 
-pub fn target_difficulty_monero(height: u64) -> IntGauge {
-    static METER: Lazy<IntGaugeVec> = Lazy::new(|| {
-        tari_metrics::register_int_gauge_vec(
+pub fn target_difficulty_monero() -> &'static IntGauge {
+    static METER: Lazy<IntGauge> = Lazy::new(|| {
+        tari_metrics::register_int_gauge(
             "base_node::blockchain::target_difficulty_monero",
             "The current miner target difficulty for the monero PoW algo",
-            &["height"],
         )
         .unwrap()
     });
 
-    METER.with_label_values(&[&height.to_string()])
+    &METER
 }
 
 pub fn reorg(fork_height: u64, num_added: usize, num_removed: usize) -> IntGauge {
@@ -153,7 +151,7 @@ pub fn rejected_local_blocks(height: u64, hash: &FixedHash) -> IntCounter {
     METER.with_label_values(&[&height.to_string(), &hash.to_hex()])
 }
 
-pub fn active_sync_peers() -> IntGauge {
+pub fn active_sync_peers() -> &'static IntGauge {
     static METER: Lazy<IntGauge> = Lazy::new(|| {
         tari_metrics::register_int_gauge(
             "base_node::sync::active_peers",
@@ -162,10 +160,10 @@ pub fn active_sync_peers() -> IntGauge {
         .unwrap()
     });
 
-    METER.clone()
+    &METER
 }
 
-pub fn utxo_set_size() -> IntGauge {
+pub fn utxo_set_size() -> &'static IntGauge {
     static METER: Lazy<IntGauge> = Lazy::new(|| {
         tari_metrics::register_int_gauge(
             "base_node::blockchain::utxo_set_size",
@@ -174,5 +172,5 @@ pub fn utxo_set_size() -> IntGauge {
         .unwrap()
     });
 
-    METER.clone()
+    &METER
 }


### PR DESCRIPTION
Description
---
`base_node::blockchain::target_difficulty_sha` and `base_node::blockchain::target_difficulty_monero` are now single values at any point in time rather than qualified by block height. 


Motivation and Context
---
 I was not able to find a way (many months ago) to produce a performant non-timeseries graph that used height as the x-axis. The way I found tended to produce a lot of data on the endpoint side and crash grafana. We used a timeseries graph with an aggregation, producing an average difficulty over a time period. This PR allows for the precise difficulty w.r.t real time which I feel is better.

How Has This Been Tested?
---
Not tested, code compiles and this is how a lot of metric values work.
