### PR TITLE
fix: force wallet sqlite to do checkpoint after db decryption

### DIFF
--- a/base_layer/wallet/src/storage/sqlite_db/wallet.rs
+++ b/base_layer/wallet/src/storage/sqlite_db/wallet.rs
@@ -559,6 +559,8 @@ impl WalletBackend for WalletSqliteDatabase {
                 .map_err(|e| WalletStorageError::ConversionError(e.to_string()))?;
             WalletSettingSql::new(DbKey::TorId.to_string(), tor_string).set(&conn)?;
         }
+        //this is the last remove encryption so lets force a sql lite checkpoint
+            conn.execute("PRAGMA wal_checkpoint(2)")?;
 
         // Now that all the decryption has been completed we can safely remove the cipher fully
         std::mem::drop((*current_cipher).take());

--- a/base_layer/wallet/src/storage/sqlite_db/wallet.rs
+++ b/base_layer/wallet/src/storage/sqlite_db/wallet.rs
@@ -559,8 +559,8 @@ impl WalletBackend for WalletSqliteDatabase {
                 .map_err(|e| WalletStorageError::ConversionError(e.to_string()))?;
             WalletSettingSql::new(DbKey::TorId.to_string(), tor_string).set(&conn)?;
         }
-        //this is the last remove encryption so lets force a sql lite checkpoint
-            conn.execute("PRAGMA wal_checkpoint(2)")?;
+        // this is the last remove encryption so lets force a sql lite checkpoint
+        conn.execute("PRAGMA wal_checkpoint(2)")?;
 
         // Now that all the decryption has been completed we can safely remove the cipher fully
         std::mem::drop((*current_cipher).take());


### PR DESCRIPTION
Description
---
Forces the database to do a checkpoint after the last step of the database decryption. 

Motivation and Context
---
The mobile applications decrypt the SQLite wallet database, after which they copy it to a safe location to restore later.  
If we run database decrypt, the actual database file might not yet have the changes applied to it, this forces a checkpoint which will ensure that the changes are committed to on file

How Has This Been Tested?
---
manual

Fixes: #4904 
