### PR TITLE
feat: remove tracing_subscriber

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,12 +151,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrayvec"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
-
-[[package]]
 name = "async-stream"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2103,12 +2097,6 @@ dependencies = [
 
 [[package]]
 name = "integer-encoding"
-version = "1.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48dc51180a9b377fd75814d0cc02199c20f8e99433d6762f650d39cdbbd3b56f"
-
-[[package]]
-name = "integer-encoding"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
@@ -2419,15 +2407,6 @@ dependencies = [
  "thread-id",
  "typemap-ors",
  "winapi",
-]
-
-[[package]]
-name = "matchers"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
-dependencies = [
- "regex-automata",
 ]
 
 [[package]]
@@ -2782,7 +2761,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bafe4179722c2894288ee77a9f044f02811c86af699344c498b0840c698a2465"
 dependencies = [
- "arrayvec 0.4.12",
+ "arrayvec",
  "itoa 0.4.8",
 ]
 
@@ -2917,76 +2896,6 @@ dependencies = [
  "openssl-src",
  "pkg-config",
  "vcpkg",
-]
-
-[[package]]
-name = "opentelemetry"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cf9b1c4e9a6c4de793c632496fa490bdc0e1eea73f0c91394f7b6990935d22"
-dependencies = [
- "async-trait",
- "crossbeam-channel",
- "futures 0.3.24",
- "js-sys",
- "lazy_static",
- "percent-encoding 2.2.0",
- "pin-project 1.0.12",
- "rand 0.8.5",
- "thiserror",
- "tokio",
- "tokio-stream",
-]
-
-[[package]]
-name = "opentelemetry-http"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d50ceb0b0e8b75cb3e388a2571a807c8228dabc5d6670f317b6eb21301095373"
-dependencies = [
- "async-trait",
- "bytes 1.2.1",
- "futures-util",
- "http",
- "opentelemetry",
- "reqwest",
-]
-
-[[package]]
-name = "opentelemetry-jaeger"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db22f492873ea037bc267b35a0e8e4fb846340058cb7c864efe3d0bf23684593"
-dependencies = [
- "async-trait",
- "headers",
- "http",
- "lazy_static",
- "opentelemetry",
- "opentelemetry-http",
- "opentelemetry-semantic-conventions",
- "reqwest",
- "thiserror",
- "thrift",
- "tokio",
-]
-
-[[package]]
-name = "opentelemetry-semantic-conventions"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffeac823339e8b0f27b961f4385057bf9f97f2863bc745bd015fd6091f2270e9"
-dependencies = [
- "opentelemetry",
-]
-
-[[package]]
-name = "ordered-float"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3305af35278dd29f46fcdd139e0b1fbfae2153f0e5928b39b035542dd31e37b7"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]
@@ -3706,9 +3615,6 @@ name = "regex-automata"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax",
-]
 
 [[package]]
 name = "regex-syntax"
@@ -4067,7 +3973,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
 dependencies = [
- "ordered-float 2.10.0",
+ "ordered-float",
  "serde",
 ]
 
@@ -4202,15 +4108,6 @@ dependencies = [
  "digest 0.9.0",
  "keccak",
  "opaque-debug",
-]
-
-[[package]]
-name = "sharded-slab"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
-dependencies = [
- "lazy_static",
 ]
 
 [[package]]
@@ -4495,8 +4392,6 @@ dependencies = [
  "log-mdc",
  "nom 7.1.1",
  "num_cpus",
- "opentelemetry",
- "opentelemetry-jaeger",
  "qrcode",
  "regex",
  "rustyline",
@@ -4525,8 +4420,6 @@ dependencies = [
  "tokio",
  "tonic",
  "tracing",
- "tracing-opentelemetry",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -4755,8 +4648,6 @@ dependencies = [
  "digest 0.9.0",
  "futures 0.3.24",
  "log",
- "opentelemetry",
- "opentelemetry-jaeger",
  "qrcode",
  "rand 0.7.3",
  "regex",
@@ -4785,8 +4676,6 @@ dependencies = [
  "tokio",
  "tonic",
  "tracing",
- "tracing-opentelemetry",
- "tracing-subscriber",
  "tui",
  "unicode-segmentation",
  "unicode-width",
@@ -4813,7 +4702,7 @@ dependencies = [
  "fs2",
  "futures 0.3.24",
  "hex",
- "integer-encoding 3.0.4",
+ "integer-encoding",
  "lmdb-zero",
  "log",
  "log-mdc",
@@ -4887,7 +4776,6 @@ name = "tari_key_manager"
 version = "0.38.8"
 dependencies = [
  "argon2",
- "arrayvec 0.7.2",
  "blake2 0.9.2",
  "chacha20 0.7.3",
  "console_error_panic_hook",
@@ -5101,7 +4989,7 @@ version = "0.12.0"
 dependencies = [
  "blake2 0.9.2",
  "digest 0.9.0",
- "integer-encoding 3.0.4",
+ "integer-encoding",
  "rand 0.7.3",
  "serde",
  "sha2 0.9.9",
@@ -5341,37 +5229,6 @@ dependencies = [
  "libc",
  "redox_syscall",
  "winapi",
-]
-
-[[package]]
-name = "thread_local"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
-dependencies = [
- "once_cell",
-]
-
-[[package]]
-name = "threadpool"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
-dependencies = [
- "num_cpus",
-]
-
-[[package]]
-name = "thrift"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6d965454947cc7266d22716ebfd07b18d84ebaf35eec558586bbb2a8cb6b5b"
-dependencies = [
- "byteorder",
- "integer-encoding 1.1.7",
- "log",
- "ordered-float 1.1.1",
- "threadpool",
 ]
 
 [[package]]
@@ -5655,12 +5512,11 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aeea4303076558a00714b823f9ad67d58a3bbda1df83d8827d21193156e22f7"
+checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
- "valuable",
 ]
 
 [[package]]
@@ -5671,62 +5527,6 @@ checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
  "pin-project 1.0.12",
  "tracing",
-]
-
-[[package]]
-name = "tracing-log"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
-dependencies = [
- "lazy_static",
- "log",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-opentelemetry"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "599f388ecb26b28d9c1b2e4437ae019a7b336018b45ed911458cd9ebf91129f6"
-dependencies = [
- "opentelemetry",
- "tracing",
- "tracing-core",
- "tracing-log",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "tracing-serde"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
-dependencies = [
- "serde",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
-dependencies = [
- "ansi_term",
- "chrono",
- "lazy_static",
- "matchers",
- "regex",
- "serde",
- "serde_json",
- "sharded-slab",
- "smallvec",
- "thread_local",
- "tracing",
- "tracing-core",
- "tracing-log",
- "tracing-serde",
 ]
 
 [[package]]
@@ -5960,12 +5760,6 @@ name = "utf8parse"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
-
-[[package]]
-name = "valuable"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vcpkg"

--- a/applications/tari_base_node/Cargo.toml
+++ b/applications/tari_base_node/Cargo.toml
@@ -51,12 +51,6 @@ tokio = { version = "1.20", features = ["signal"] }
 tonic = "0.6.2"
 tracing = "0.1.26"
 
-# network tracing, rt-tokio for async batch export
-opentelemetry = { version = "0.16", default-features = false, features = ["trace", "rt-tokio"] }
-opentelemetry-jaeger = { version = "0.15", features = ["rt-tokio", "collector_client", "reqwest_collector_client"] }
-tracing-opentelemetry = "0.15.0"
-tracing-subscriber = "0.2.20"
-
 # Metrics
 tari_metrics = { path = "../../infrastructure/metrics", optional = true, features = ["server"] }
 

--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -72,7 +72,6 @@ pub struct BaseNodeContext {
 impl BaseNodeContext {
     /// Waits for shutdown of the base node state machine and comms.
     /// This call consumes the NodeContainer instance.
-    #[tracing::instrument(name = "base_node::wait_for_shutdown", skip(self))]
     pub async fn wait_for_shutdown(self) {
         self.state_machine().shutdown_signal().wait().await;
         info!(target: LOG_TARGET, "Waiting for communications stack shutdown");

--- a/applications/tari_base_node/src/cli.rs
+++ b/applications/tari_base_node/src/cli.rs
@@ -34,9 +34,6 @@ pub(crate) struct Cli {
     /// Create a default configuration file if it doesn't exist
     #[clap(long)]
     pub init: bool,
-    /// Enable tracing
-    #[clap(long, aliases = &["tracing", "enable-tracing"])]
-    pub tracing_enabled: bool,
     /// This will rebuild the db, adding block for block in
     // TODO: Should be a command rather
     #[clap(long, alias = "rebuild_db")]

--- a/applications/tari_console_wallet/Cargo.toml
+++ b/applications/tari_console_wallet/Cargo.toml
@@ -48,14 +48,8 @@ strum_macros = "0.22"
 thiserror = "1.0.26"
 tonic = "0.6.2"
 tracing = "0.1.26"
-tracing-opentelemetry = "0.15.0"
-tracing-subscriber = "0.2.20"
 unicode-segmentation = "1.6.0"
 unicode-width = "0.1"
-
-# network tracing, rt-tokio for async batch export
-opentelemetry = { version = "0.16", default-features = false, features = ["trace", "rt-tokio"] }
-opentelemetry-jaeger = { version = "0.15", features = ["rt-tokio"] }
 
 [dependencies.tari_core]
 path = "../../base_layer/core"

--- a/applications/tari_console_wallet/src/cli.rs
+++ b/applications/tari_console_wallet/src/cli.rs
@@ -44,9 +44,6 @@ use tari_utilities::{
 pub(crate) struct Cli {
     #[clap(flatten)]
     pub common: CommonCliArgs,
-    /// Enable tracing
-    #[clap(long, aliases = &["tracing", "enable-tracing"])]
-    pub tracing_enabled: bool,
     /// Supply the password for the console wallet. It's very bad security practice to provide the password on the
     /// command line, since it's visible using `ps ax` from anywhere on the system, so always use the env var where
     /// possible.

--- a/base_layer/key_manager/Cargo.toml
+++ b/base_layer/key_manager/Cargo.toml
@@ -16,7 +16,6 @@ tari_common_types = { version = "^0.38", path = "../../base_layer/common_types",
 tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.7" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag="v0.4.7" }
 
-arrayvec = "0.7.1"
 argon2 = { version = "0.4.1", features = ["std", "alloc"] }
 blake2 = "0.9.1"
 chacha20 = "0.7.1"


### PR DESCRIPTION
Description
---
Remove tracing_subscriber and opentelemetry. 

Motivation and Context
---
Fixes #4651 
To my knowledge, this is not used anymore. There seems to be an update to this crate which solves the RUSTSEC warning, but the public API has changed, and it feels better to remove it, and then add it back if it is used or needed in future.

How Has This Been Tested?
---
Cargo build. The use of this feature was opt-in via the `--enable-tracing` arg, so was not run by default.
