### PR TITLE
test: failed consensus encoding test

### DIFF
--- a/base_layer/tari_mining_helper_ffi/src/lib.rs
+++ b/base_layer/tari_mining_helper_ffi/src/lib.rs
@@ -370,8 +370,8 @@ mod tests {
 
     #[test]
     fn detect_change_in_consensus_encoding() {
-        const NONCE: u64 = 18006431465547767508;
-        const DIFFICULTY: Difficulty = Difficulty::from_u64(13879);
+        const NONCE: u64 = 4238854535428725996;
+        const DIFFICULTY: Difficulty = Difficulty::from_u64(12185);
         unsafe {
             let mut error = -1;
             let error_ptr = &mut error as *mut c_int;


### PR DESCRIPTION
Description
---
Fixes a failed CI test for consensus encoding.

Motivation and Context
---
The [update to v0.39.0](https://github.com/tari-project/tari/commit/1b980b0aad1879cf8e3dfb1bcccf1f25c2dc630a) introduces a [test](https://github.com/tari-project/tari/blob/43efc07a9713ebb498ca635603b97c34b561b1e2/base_layer/tari_mining_helper_ffi/src/lib.rs#L371-L399) failure relating to consensus encoding.

This PR updates the test's nonce and difficulty values.

How Has This Been Tested?
---
The failed test now passes.