### PR TITLE
fix(comms): spawn liveness check after address is final

### DIFF
--- a/applications/tari_base_node/src/commands/command/status.rs
+++ b/applications/tari_base_node/src/commands/command/status.rs
@@ -131,7 +131,7 @@ impl CommandContext {
             ),
         );
 
-        match self.comms.listening_info().liveness_status() {
+        match self.comms.liveness_status() {
             LivenessStatus::Disabled => {},
             LivenessStatus::Checking => {
                 status_line.add("⏳️️");

--- a/comms/core/src/connection_manager/mod.rs
+++ b/comms/core/src/connection_manager/mod.rs
@@ -52,6 +52,7 @@ mod peer_connection;
 pub use peer_connection::{ConnectionId, NegotiatedSubstream, PeerConnection, PeerConnectionRequest};
 
 mod liveness;
+pub(crate) use liveness::LivenessCheck;
 pub use liveness::LivenessStatus;
 
 mod wire_mode;

--- a/comms/core/src/connection_manager/tests/listener_dialer.rs
+++ b/comms/core/src/connection_manager/tests/listener_dialer.rs
@@ -66,7 +66,7 @@ async fn listen() -> Result<(), Box<dyn Error>> {
         shutdown.to_signal(),
     );
 
-    let (mut bind_addr, _) = listener.listen().await?;
+    let mut bind_addr = listener.listen().await?;
 
     unpack_enum!(Protocol::Memory(port) = bind_addr.pop().unwrap());
     assert!(port > 0);
@@ -103,7 +103,7 @@ async fn smoke() {
     listener.set_supported_protocols(supported_protocols.clone());
 
     // Get the listening address of the peer
-    let (address, _) = listener.listen().await.unwrap();
+    let address = listener.listen().await.unwrap();
 
     let node_identity2 = build_node_identity(PeerFeatures::COMMUNICATION_NODE);
     let noise_config2 = NoiseConfig::new(node_identity2.clone());
@@ -207,7 +207,7 @@ async fn banned() {
     listener.set_supported_protocols(supported_protocols.clone());
 
     // Get the listener address of the peer
-    let (address, _) = listener.listen().await.unwrap();
+    let address = listener.listen().await.unwrap();
 
     let node_identity2 = build_node_identity(PeerFeatures::COMMUNICATION_NODE);
     // The listener has banned the dialer peer


### PR DESCRIPTION
Description
---
- Spawns the liveness check after the public address has been finalised

Motivation and Context
---
Fixes #4915 and fixes an edge case where the old address is used for liveness checks if the user deletes their tor identity before starting the node.

How Has This Been Tested?
---
Manually
