### PR TITLE
fix(dht): use limited ban period for invalid peer

### DIFF
--- a/comms/dht/src/network_discovery/discovering.rs
+++ b/comms/dht/src/network_discovery/discovering.rs
@@ -222,9 +222,13 @@ impl Discovering {
                 );
                 self.context
                     .connectivity
-                    .ban_peer(
+                    .ban_peer_until(
                         sync_peer.clone(),
-                        format!("Network discovery peer sent invalid peer '{}'", new_peer_node_id),
+                        self.context.config.ban_duration,
+                        format!(
+                            "Network discovery peer sent invalid peer '{}'. {}",
+                            new_peer_node_id, err
+                        ),
                     )
                     .await?;
                 Err(err.into())


### PR DESCRIPTION
Description
---
- changes ban period for a remote node sending an invalid peer from permanent to limited (6 hours).
- adds more detail on the reason for the ban

Motivation and Context
---
Seeing permanent bans for this case. This should make diagnosis easier.

How Has This Been Tested?
---
Simple change
