### PR TITLE
fix: use same instance of randomx factory for statemachine and validation

### DIFF
--- a/applications/tari_base_node/src/bootstrap.rs
+++ b/applications/tari_base_node/src/bootstrap.rs
@@ -155,7 +155,7 @@ where B: BlockchainBackend + 'static
                 base_node_config.state_machine.clone(),
                 self.rules,
                 self.factories,
-                self.randomx_factory.clone(),
+                self.randomx_factory,
                 self.app_config.base_node.bypass_range_proof_verification,
             ))
             .build()

--- a/applications/tari_base_node/src/bootstrap.rs
+++ b/applications/tari_base_node/src/bootstrap.rs
@@ -72,6 +72,7 @@ pub struct BaseNodeBootstrapper<'a, B> {
     pub mempool: Mempool,
     pub rules: ConsensusManager,
     pub factories: CryptoFactories,
+    pub randomx_factory: RandomXFactory,
     pub interrupt_signal: ShutdownSignal,
 }
 
@@ -154,7 +155,7 @@ where B: BlockchainBackend + 'static
                 base_node_config.state_machine.clone(),
                 self.rules,
                 self.factories,
-                RandomXFactory::new(self.app_config.base_node.max_randomx_vms),
+                self.randomx_factory.clone(),
                 self.app_config.base_node.bypass_range_proof_verification,
             ))
             .build()

--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -225,7 +225,7 @@ async fn build_node_context(
         rules.clone(),
         validators,
         app_config.base_node.storage,
-        DifficultyCalculator::new(rules.clone(), randomx_factory),
+        DifficultyCalculator::new(rules.clone(), randomx_factory.clone()),
     )
     .map_err(|err| {
         if let ChainStorageError::DatabaseResyncRequired(reason) = err {
@@ -262,6 +262,7 @@ async fn build_node_context(
         mempool,
         rules: rules.clone(),
         factories: factories.clone(),
+        randomx_factory,
         interrupt_signal: interrupt_signal.clone(),
     }
     .bootstrap()


### PR DESCRIPTION
Description
---
Uses same instance of `RadomXFactory` for the State machine and difficulty validator 

Motivation and Context
---
This allows the status line to report the correct number of rx VMs

How Has This Been Tested?
---
Manually
