### PR TITLE
feat(ci): expose iOS libwallet individually

### DIFF
--- a/.github/workflows/build_libwallets.yml
+++ b/.github/workflows/build_libwallets.yml
@@ -35,6 +35,7 @@ jobs:
     steps:
       - name: envs setup
         id: envs_setup
+        shell: bash
         run: |
           TOOLCHAIN=${{ github.event.inputs.toolchain }}
           echo "toolchain=${TOOLCHAIN:-${{ env.toolchain_default }}}" >> $GITHUB_OUTPUT

--- a/.github/workflows/build_libwallets_workflow.yml
+++ b/.github/workflows/build_libwallets_workflow.yml
@@ -123,15 +123,21 @@ jobs:
           mkdir -p MobileWallet/TariLib/
           cd base_layer/wallet_ffi
           mv ios.config build.config
+          export TARGET_CLEAN=0
           ./mobile_build.sh || exit 1
+          find "$GITHUB_WORKSPACE" -iname libtari_wallet_ffi.a
           mkdir -p "${{ runner.temp }}/libwallet-ios"
           cd "${{ runner.temp }}/libwallet-ios"
-          cp -v "$GITHUB_WORKSPACE/MobileWallet/TariLib/libtari_wallet_ffi.a" libtari_wallet_ffi.ios.a
+          cp -v "$GITHUB_WORKSPACE/target/x86_64-apple-ios/release/libtari_wallet_ffi.a" libtari_wallet_ffi.ios_x86_64.a
+          cp -v "$GITHUB_WORKSPACE/target/aarch64-apple-ios/release/libtari_wallet_ffi.a" libtari_wallet_ffi.ios_aarch64.a
           cp -v "$GITHUB_WORKSPACE/base_layer/wallet_ffi/wallet.h" libtari_wallet_ffi.h
+          cp -v "$GITHUB_WORKSPACE/MobileWallet/TariLib/libtari_wallet_ffi.a" libtari_wallet_ffi.ios_universal.a
           cp -v "$GITHUB_WORKSPACE/changelog.md" .
           cd ..
           shasum -a 256 \
-            "libwallet-ios/libtari_wallet_ffi.ios.a" \
+            "libwallet-ios/libtari_wallet_ffi.ios_x86_64.a" \
+            "libwallet-ios/libtari_wallet_ffi.ios_aarch64.a" \
+            "libwallet-ios/libtari_wallet_ffi.ios_universal.a" \
             "libwallet-ios/libtari_wallet_ffi.h" \
               > "libwallet-ios/libtari_wallet_ffi.ios.sha256sums"
           ls -alht "${{ runner.temp }}/libwallet-ios"

--- a/base_layer/wallet_ffi/mobile_build.sh
+++ b/base_layer/wallet_ffi/mobile_build.sh
@@ -14,6 +14,7 @@ NC='\033[0m' # No Color
 source build.config
 TARI_REPO_PATH=${TARI_REPO_PATH:-$(git rev-parse --show-toplevel)}
 CURRENT_DIR=${TARI_REPO_PATH}/base_layer/wallet_ffi
+TARGET_CLEAN=${TARGET_CLEAN:-1}
 cd "${CURRENT_DIR}" || exit
 mkdir -p logs
 cd logs || exit
@@ -94,7 +95,9 @@ if [ -n "${DEPENDENCIES}" ] && [ -n "${PKG_PATH}" ] && [ "${BUILD_IOS}" -eq 1 ] 
   # XCode will select the relevant set of symbols to be included in the mobile application depending on which arch is built
   cp libtari_wallet_ffi.a "${DEPENDENCIES}/MobileWallet/TariLib/" || exit
   cd ../../.. || exit
-  rm -rf target
+  if [ "${TARGET_CLEAN}" -eq 1 ]; then
+    rm -rf target
+  fi
   cd "${DEPENDENCIES}" || exit
   echo "${GREEN}iOS build completed${NC}"
 elif [ "${BUILD_IOS}" -eq 1 ]; then
@@ -432,7 +435,9 @@ EOF
       cd release || exit
       cp libtari_wallet_ffi.a "${OUTPUT_DIR}"
       cd ../..
-      rm -rf target
+      if [ "${TARGET_CLEAN}" -eq 1 ]; then
+        rm -rf target
+      fi
       cd "${DEPENDENCIES}" || exit
       mkdir -p "${PLATFORM_OUTDIR}"
       cd "${PLATFORM_OUTDIR}" || exit


### PR DESCRIPTION
Description
Expose iOS libwallet individually - universal / x86-64 / aarch64

Motivation and Context
Give developers an option for accessing each iOS architecture individually or as the combined universal library.

How Has This Been Tested?
Build locally in fork and all libs accessible
