### PR TITLE
fix(wallet): fix wallet_setting keys

### DIFF
--- a/base_layer/wallet/migrations/2022-11-29-113713_fix_up_settings_keys/down.sql
+++ b/base_layer/wallet/migrations/2022-11-29-113713_fix_up_settings_keys/down.sql
@@ -1,0 +1,1 @@
+-- This file should undo anything in `up.sql`

--- a/base_layer/wallet/migrations/2022-11-29-113713_fix_up_settings_keys/up.sql
+++ b/base_layer/wallet/migrations/2022-11-29-113713_fix_up_settings_keys/up.sql
@@ -1,0 +1,6 @@
+-- Your SQL goes here
+UPDATE wallet_settings SET key = 'Nod features' WHERE key = 'NodeFeatures';
+UPDATE wallet_settings SET key = 'ClientKey__recovery_data' WHERE key = 'ClientKey: "recovery_data"';
+UPDATE wallet_settings SET key = 'ClientKey__console_wallet_custom_base_node_public_key' WHERE key = 'ClientKey: "console_wallet_custom_base_node_public_key"';
+UPDATE wallet_settings SET key = 'ClientKey__console_wallet_custom_base_node_address' WHERE key = 'ClientKey: "console_wallet_custom_base_node_address"';
+UPDATE wallet_settings SET key = 'BaseNodeChainMetadata' WHERE key = 'Last seen Chain metadata from basw node';

--- a/base_layer/wallet/migrations/2022-11-29-113713_fix_up_settings_keys/up.sql
+++ b/base_layer/wallet/migrations/2022-11-29-113713_fix_up_settings_keys/up.sql
@@ -1,6 +1,6 @@
 -- Your SQL goes here
-UPDATE wallet_settings SET key = 'Nod features' WHERE key = 'NodeFeatures';
-UPDATE wallet_settings SET key = 'ClientKey__recovery_data' WHERE key = 'ClientKey: "recovery_data"';
-UPDATE wallet_settings SET key = 'ClientKey__console_wallet_custom_base_node_public_key' WHERE key = 'ClientKey: "console_wallet_custom_base_node_public_key"';
-UPDATE wallet_settings SET key = 'ClientKey__console_wallet_custom_base_node_address' WHERE key = 'ClientKey: "console_wallet_custom_base_node_address"';
+UPDATE wallet_settings SET key = 'NodeFeatures' WHERE key = 'Nod features';
+UPDATE wallet_settings SET key = 'ClientKey.recovery_data' WHERE key = 'ClientKey: "recovery_data"';
+UPDATE wallet_settings SET key = 'ClientKey.console_wallet_custom_base_node_public_key' WHERE key = 'ClientKey: "console_wallet_custom_base_node_public_key"';
+UPDATE wallet_settings SET key = 'ClientKey.console_wallet_custom_base_node_address' WHERE key = 'ClientKey: "console_wallet_custom_base_node_address"';
 UPDATE wallet_settings SET key = 'BaseNodeChainMetadata' WHERE key = 'Last seen Chain metadata from basw node';

--- a/base_layer/wallet/src/error.rs
+++ b/base_layer/wallet/src/error.rs
@@ -135,7 +135,7 @@ pub enum WalletStorageError {
     DieselConnectionError(#[from] diesel::ConnectionError),
     #[error("Database migration error")]
     DatabaseMigrationError(String),
-    #[error("Value not found: `{0}`")]
+    #[error("Value not found: `{}`", .0.to_key_string())]
     ValueNotFound(DbKey),
     #[error("Unexpected result: `{0}`")]
     UnexpectedResult(String),

--- a/base_layer/wallet/src/storage/database.rs
+++ b/base_layer/wallet/src/storage/database.rs
@@ -79,6 +79,23 @@ pub enum DbKey {
     WalletBirthday,
 }
 
+impl DbKey {
+    pub fn to_key_string(&self) -> String {
+        match self {
+            DbKey::MasterSeed => "MasterSeed".to_string(),
+            DbKey::CommsAddress => "CommsAddress".to_string(),
+            DbKey::CommsFeatures => "NodeFeatures".to_string(),
+            DbKey::TorId => "TorId".to_string(),
+            DbKey::ClientKey(k) => format!("ClientKey__{}", k),
+            DbKey::BaseNodeChainMetadata => "BaseNodeChainMetadata".to_string(),
+            DbKey::PassphraseHash => "PassphraseHash".to_string(),
+            DbKey::EncryptionSalt => "EncryptionSalt".to_string(),
+            DbKey::WalletBirthday => "WalletBirthday".to_string(),
+            DbKey::CommsIdentitySignature => "CommsIdentitySignature".to_string(),
+        }
+    }
+}
+
 pub enum DbValue {
     CommsAddress(Multiaddr),
     CommsFeatures(PeerFeatures),
@@ -320,23 +337,6 @@ where T: WalletBackend + 'static
     }
 }
 
-impl Display for DbKey {
-    fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
-        match self {
-            DbKey::MasterSeed => f.write_str("MasterSeed"),
-            DbKey::CommsAddress => f.write_str("CommsAddress"),
-            DbKey::CommsFeatures => f.write_str("Nod features"),
-            DbKey::TorId => f.write_str("TorId"),
-            DbKey::ClientKey(k) => f.write_str(&format!("ClientKey: {:?}", k)),
-            DbKey::BaseNodeChainMetadata => f.write_str("Last seen Chain metadata from basw node"),
-            DbKey::PassphraseHash => f.write_str("PassphraseHash"),
-            DbKey::EncryptionSalt => f.write_str("EncryptionSalt"),
-            DbKey::WalletBirthday => f.write_str("WalletBirthday"),
-            DbKey::CommsIdentitySignature => f.write_str("CommsIdentitySignature"),
-        }
-    }
-}
-
 impl Display for DbValue {
     fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
         match self {
@@ -359,14 +359,18 @@ fn log_error<T>(req: DbKey, err: WalletStorageError) -> Result<T, WalletStorageE
     error!(
         target: LOG_TARGET,
         "Database access error on request: {}: {}",
-        req,
+        req.to_key_string(),
         err.to_string()
     );
     Err(err)
 }
 
 fn unexpected_result<T>(req: DbKey, res: DbValue) -> Result<T, WalletStorageError> {
-    let msg = format!("Unexpected result for database query {}. Response: {}", req, res);
+    let msg = format!(
+        "Unexpected result for database query {}. Response: {}",
+        req.to_key_string(),
+        res
+    );
     error!(target: LOG_TARGET, "{}", msg);
     Err(WalletStorageError::UnexpectedResult(msg))
 }

--- a/base_layer/wallet/src/storage/database.rs
+++ b/base_layer/wallet/src/storage/database.rs
@@ -86,7 +86,7 @@ impl DbKey {
             DbKey::CommsAddress => "CommsAddress".to_string(),
             DbKey::CommsFeatures => "NodeFeatures".to_string(),
             DbKey::TorId => "TorId".to_string(),
-            DbKey::ClientKey(k) => format!("ClientKey__{}", k),
+            DbKey::ClientKey(k) => format!("ClientKey.{}", k),
             DbKey::BaseNodeChainMetadata => "BaseNodeChainMetadata".to_string(),
             DbKey::PassphraseHash => "PassphraseHash".to_string(),
             DbKey::EncryptionSalt => "EncryptionSalt".to_string(),

--- a/base_layer/wallet/src/storage/sqlite_db/wallet.rs
+++ b/base_layer/wallet/src/storage/sqlite_db/wallet.rs
@@ -90,15 +90,15 @@ impl WalletSqliteDatabase {
             None => {
                 let seed_bytes = seed.encipher(None)?;
                 let birthday = seed.birthday();
-                WalletSettingSql::new(DbKey::MasterSeed.to_string(), seed_bytes.to_hex()).set(conn)?;
-                WalletSettingSql::new(DbKey::WalletBirthday.to_string(), birthday.to_string()).set(conn)?;
+                WalletSettingSql::new(DbKey::MasterSeed, seed_bytes.to_hex()).set(conn)?;
+                WalletSettingSql::new(DbKey::WalletBirthday, birthday.to_string()).set(conn)?;
             },
             Some(cipher) => {
                 let seed_bytes = Hidden::hide(seed.encipher(None)?);
                 let ciphertext_integral_nonce =
                     encrypt_bytes_integral_nonce(cipher, b"wallet_setting_master_seed".to_vec(), seed_bytes)
                         .map_err(|e| WalletStorageError::AeadError(format!("Encryption Error:{}", e)))?;
-                WalletSettingSql::new(DbKey::MasterSeed.to_string(), ciphertext_integral_nonce.to_hex()).set(conn)?;
+                WalletSettingSql::new(DbKey::MasterSeed, ciphertext_integral_nonce.to_hex()).set(conn)?;
             },
         }
 
@@ -107,7 +107,7 @@ impl WalletSqliteDatabase {
 
     fn get_master_seed(&self, conn: &SqliteConnection) -> Result<Option<CipherSeed>, WalletStorageError> {
         let cipher = acquire_read_lock!(self.cipher);
-        if let Some(seed_str) = WalletSettingSql::get(DbKey::MasterSeed.to_string(), conn)? {
+        if let Some(seed_str) = WalletSettingSql::get(&DbKey::MasterSeed, conn)? {
             let seed = match cipher.as_ref() {
                 None => CipherSeed::from_enciphered_bytes(&from_hex(seed_str.as_str())?, None)?,
                 Some(cipher) => {
@@ -150,7 +150,7 @@ impl WalletSqliteDatabase {
     }
 
     fn get_comms_address(&self, conn: &SqliteConnection) -> Result<Option<Multiaddr>, WalletStorageError> {
-        if let Some(key_str) = WalletSettingSql::get(DbKey::CommsAddress.to_string(), conn)? {
+        if let Some(key_str) = WalletSettingSql::get(&DbKey::CommsAddress, conn)? {
             Ok(Some(
                 Multiaddr::from_str(key_str.as_str())
                     .map_err(|e| WalletStorageError::ConversionError(e.to_string()))?,
@@ -161,7 +161,7 @@ impl WalletSqliteDatabase {
     }
 
     fn get_comms_features(&self, conn: &SqliteConnection) -> Result<Option<PeerFeatures>, WalletStorageError> {
-        if let Some(key_str) = WalletSettingSql::get(DbKey::CommsFeatures.to_string(), conn)? {
+        if let Some(key_str) = WalletSettingSql::get(&DbKey::CommsFeatures, conn)? {
             let features = u64::from_str(&key_str).map_err(|e| WalletStorageError::ConversionError(e.to_string()))?;
             let peer_features = PeerFeatures::from_bits(features);
             Ok(peer_features)
@@ -177,7 +177,7 @@ impl WalletSqliteDatabase {
             .map_err(|e| WalletStorageError::ConversionError(e.to_string()))?;
         match cipher.as_ref() {
             None => {
-                WalletSettingSql::new(DbKey::TorId.to_string(), tor_string).set(conn)?;
+                WalletSettingSql::new(DbKey::TorId, tor_string).set(conn)?;
             },
             Some(cipher) => {
                 let bytes = Hidden::hide(
@@ -187,7 +187,7 @@ impl WalletSqliteDatabase {
                     encrypt_bytes_integral_nonce(cipher, b"wallet_setting_tor_id".to_vec(), bytes)
                         .map_err(|e| WalletStorageError::AeadError(format!("Encryption Error:{}", e)))?;
 
-                WalletSettingSql::new(DbKey::TorId.to_string(), ciphertext_integral_nonce.to_hex()).set(conn)?;
+                WalletSettingSql::new(DbKey::TorId, ciphertext_integral_nonce.to_hex()).set(conn)?;
             },
         }
 
@@ -196,7 +196,7 @@ impl WalletSqliteDatabase {
 
     fn get_tor_id(&self, conn: &SqliteConnection) -> Result<Option<DbValue>, WalletStorageError> {
         let cipher = acquire_read_lock!(self.cipher);
-        if let Some(key_str) = WalletSettingSql::get(DbKey::TorId.to_string(), conn)? {
+        if let Some(key_str) = WalletSettingSql::get(&DbKey::TorId, conn)? {
             let id = match cipher.as_ref() {
                 None => {
                     TorIdentity::from_json(&key_str).map_err(|e| WalletStorageError::ConversionError(e.to_string()))?
@@ -221,12 +221,12 @@ impl WalletSqliteDatabase {
 
     fn set_chain_metadata(&self, chain: ChainMetadata, conn: &SqliteConnection) -> Result<(), WalletStorageError> {
         let bytes = bincode::serialize(&chain).map_err(|e| WalletStorageError::ConversionError(e.to_string()))?;
-        WalletSettingSql::new(DbKey::BaseNodeChainMetadata.to_string(), bytes.to_hex()).set(conn)?;
+        WalletSettingSql::new(DbKey::BaseNodeChainMetadata, bytes.to_hex()).set(conn)?;
         Ok(())
     }
 
     fn get_chain_metadata(&self, conn: &SqliteConnection) -> Result<Option<ChainMetadata>, WalletStorageError> {
-        if let Some(key_str) = WalletSettingSql::get(DbKey::BaseNodeChainMetadata.to_string(), conn)? {
+        if let Some(key_str) = WalletSettingSql::get(&DbKey::BaseNodeChainMetadata, conn)? {
             let chain_metadata = bincode::deserialize(&from_hex(&key_str)?)
                 .map_err(|e| WalletStorageError::ConversionError(e.to_string()))?;
             Ok(Some(chain_metadata))
@@ -280,19 +280,15 @@ impl WalletSqliteDatabase {
             },
             DbKeyValuePair::CommsAddress(ca) => {
                 kvp_text = "CommsAddress";
-                WalletSettingSql::new(DbKey::CommsAddress.to_string(), ca.to_string()).set(&conn)?;
+                WalletSettingSql::new(DbKey::CommsAddress, ca.to_string()).set(&conn)?;
             },
             DbKeyValuePair::CommsFeatures(cf) => {
                 kvp_text = "CommsFeatures";
-                WalletSettingSql::new(DbKey::CommsFeatures.to_string(), cf.bits().to_string()).set(&conn)?;
+                WalletSettingSql::new(DbKey::CommsFeatures, cf.bits().to_string()).set(&conn)?;
             },
             DbKeyValuePair::CommsIdentitySignature(identity_sig) => {
                 kvp_text = "CommsIdentitySignature";
-                WalletSettingSql::new(
-                    DbKey::CommsIdentitySignature.to_string(),
-                    identity_sig.to_bytes().to_hex(),
-                )
-                .set(&conn)?;
+                WalletSettingSql::new(DbKey::CommsIdentitySignature, identity_sig.to_bytes().to_hex()).set(&conn)?;
             },
         }
         if start.elapsed().as_millis() > 0 {
@@ -314,7 +310,7 @@ impl WalletSqliteDatabase {
         let acquire_lock = start.elapsed();
         match k {
             DbKey::MasterSeed => {
-                let _ = WalletSettingSql::clear(DbKey::MasterSeed.to_string(), &conn)?;
+                let _ = WalletSettingSql::clear(&DbKey::MasterSeed, &conn)?;
             },
             DbKey::ClientKey(ref k) => {
                 if ClientKeyValueSql::clear(k, &conn)? {
@@ -322,7 +318,7 @@ impl WalletSqliteDatabase {
                 }
             },
             DbKey::TorId => {
-                let _ = WalletSettingSql::clear(DbKey::TorId.to_string(), &conn)?;
+                let _ = WalletSettingSql::clear(&DbKey::TorId, &conn)?;
             },
             DbKey::CommsFeatures |
             DbKey::CommsAddress |
@@ -337,8 +333,8 @@ impl WalletSqliteDatabase {
         if start.elapsed().as_millis() > 0 {
             trace!(
                 target: LOG_TARGET,
-                "sqlite profile - remove_key '{}': lock {} + db_op {} = {} ms",
-                k,
+                "sqlite profile - remove_key '{}': lock {} + db_op {} = {} &ms",
+                k.to_key_string(),
                 acquire_lock.as_millis(),
                 (start.elapsed() - acquire_lock).as_millis(),
                 start.elapsed().as_millis()
@@ -372,10 +368,10 @@ impl WalletBackend for WalletSqliteDatabase {
             DbKey::TorId => self.get_tor_id(&conn)?,
             DbKey::CommsFeatures => self.get_comms_features(&conn)?.map(DbValue::CommsFeatures),
             DbKey::BaseNodeChainMetadata => self.get_chain_metadata(&conn)?.map(DbValue::BaseNodeChainMetadata),
-            DbKey::PassphraseHash => WalletSettingSql::get(key.to_string(), &conn)?.map(DbValue::PassphraseHash),
-            DbKey::EncryptionSalt => WalletSettingSql::get(key.to_string(), &conn)?.map(DbValue::EncryptionSalt),
-            DbKey::WalletBirthday => WalletSettingSql::get(key.to_string(), &conn)?.map(DbValue::WalletBirthday),
-            DbKey::CommsIdentitySignature => WalletSettingSql::get(key.to_string(), &conn)?
+            DbKey::PassphraseHash => WalletSettingSql::get(key, &conn)?.map(DbValue::PassphraseHash),
+            DbKey::EncryptionSalt => WalletSettingSql::get(key, &conn)?.map(DbValue::EncryptionSalt),
+            DbKey::WalletBirthday => WalletSettingSql::get(key, &conn)?.map(DbValue::WalletBirthday),
+            DbKey::CommsIdentitySignature => WalletSettingSql::get(key, &conn)?
                 .and_then(|s| from_hex(&s).ok())
                 .and_then(|bytes| IdentitySignature::from_bytes(&bytes).ok())
                 .map(Box::new)
@@ -385,7 +381,7 @@ impl WalletBackend for WalletSqliteDatabase {
             trace!(
                 target: LOG_TARGET,
                 "sqlite profile - fetch '{}': lock {} + db_op {} = {} ms",
-                key,
+                key.to_key_string(),
                 acquire_lock.as_millis(),
                 (start.elapsed() - acquire_lock).as_millis(),
                 start.elapsed().as_millis()
@@ -413,8 +409,8 @@ impl WalletBackend for WalletSqliteDatabase {
         let acquire_lock = start.elapsed();
 
         // Check if there is an existing passphrase applied
-        let db_passphrase_hash = WalletSettingSql::get(DbKey::PassphraseHash.to_string(), &conn)?;
-        let db_encryption_salt = WalletSettingSql::get(DbKey::EncryptionSalt.to_string(), &conn)?;
+        let db_passphrase_hash = WalletSettingSql::get(&DbKey::PassphraseHash, &conn)?;
+        let db_encryption_salt = WalletSettingSql::get(&DbKey::EncryptionSalt, &conn)?;
         if db_encryption_salt.is_some() || db_passphrase_hash.is_some() {
             return Err(WalletStorageError::AlreadyEncrypted);
         }
@@ -467,10 +463,10 @@ impl WalletBackend for WalletSqliteDatabase {
 
         let cipher = XChaCha20Poly1305::new(Key::from_slice(derived_encryption_key.as_ref()));
 
-        WalletSettingSql::new(DbKey::PassphraseHash.to_string(), passphrase_hash).set(&conn)?;
-        WalletSettingSql::new(DbKey::EncryptionSalt.to_string(), encryption_salt.as_str().to_string()).set(&conn)?;
+        WalletSettingSql::new(DbKey::PassphraseHash, passphrase_hash).set(&conn)?;
+        WalletSettingSql::new(DbKey::EncryptionSalt, encryption_salt.as_str().to_string()).set(&conn)?;
 
-        let master_seed_str = match WalletSettingSql::get(DbKey::MasterSeed.to_string(), &conn)? {
+        let master_seed_str = match WalletSettingSql::get(&DbKey::MasterSeed, &conn)? {
             None => return Err(WalletStorageError::ValueNotFound(DbKey::MasterSeed)),
             Some(sk) => sk,
         };
@@ -482,7 +478,7 @@ impl WalletBackend for WalletSqliteDatabase {
         let ciphertext_integral_nonce =
             encrypt_bytes_integral_nonce(&cipher, b"wallet_setting_master_seed".to_vec(), master_seed_bytes)
                 .map_err(|e| WalletStorageError::AeadError(format!("Encryption Error:{}", e)))?;
-        WalletSettingSql::new(DbKey::MasterSeed.to_string(), ciphertext_integral_nonce.to_hex()).set(&conn)?;
+        WalletSettingSql::new(DbKey::MasterSeed, ciphertext_integral_nonce.to_hex()).set(&conn)?;
 
         // Encrypt all the client values
         let mut client_key_values = ClientKeyValueSql::index(&conn)?;
@@ -493,7 +489,7 @@ impl WalletBackend for WalletSqliteDatabase {
         }
 
         // Encrypt tor_id if present
-        let tor_id = WalletSettingSql::get(DbKey::TorId.to_string(), &conn)?;
+        let tor_id = WalletSettingSql::get(&DbKey::TorId, &conn)?;
         if let Some(v) = tor_id {
             let tor = TorIdentity::from_json(&v).map_err(|e| WalletStorageError::ConversionError(e.to_string()))?;
             let bytes =
@@ -501,7 +497,7 @@ impl WalletBackend for WalletSqliteDatabase {
             let ciphertext_integral_nonce =
                 encrypt_bytes_integral_nonce(&cipher, b"wallet_setting_tor_id".to_vec(), bytes)
                     .map_err(|e| WalletStorageError::AeadError(format!("Encryption Error:{}", e)))?;
-            WalletSettingSql::new(DbKey::TorId.to_string(), ciphertext_integral_nonce.to_hex()).set(&conn)?;
+            WalletSettingSql::new(DbKey::TorId, ciphertext_integral_nonce.to_hex()).set(&conn)?;
         }
 
         (*current_cipher) = Some(cipher.clone());
@@ -528,7 +524,7 @@ impl WalletBackend for WalletSqliteDatabase {
         let start = Instant::now();
         let conn = self.database_connection.get_pooled_connection()?;
         let acquire_lock = start.elapsed();
-        let master_seed_str = match WalletSettingSql::get(DbKey::MasterSeed.to_string(), &conn)? {
+        let master_seed_str = match WalletSettingSql::get(&DbKey::MasterSeed, &conn)? {
             None => return Err(WalletStorageError::ValueNotFound(DbKey::MasterSeed)),
             Some(sk) => sk,
         };
@@ -544,10 +540,10 @@ impl WalletBackend for WalletSqliteDatabase {
 
         // Sanity check that the decrypted bytes are a valid CipherSeed
         let _master_seed = CipherSeed::from_enciphered_bytes(master_seed_bytes.reveal(), None)?;
-        WalletSettingSql::new(DbKey::MasterSeed.to_string(), master_seed_bytes.reveal().to_hex()).set(&conn)?;
+        WalletSettingSql::new(DbKey::MasterSeed, master_seed_bytes.reveal().to_hex()).set(&conn)?;
 
-        let _ = WalletSettingSql::clear(DbKey::PassphraseHash.to_string(), &conn)?;
-        let _ = WalletSettingSql::clear(DbKey::EncryptionSalt.to_string(), &conn)?;
+        let _ = WalletSettingSql::clear(&DbKey::PassphraseHash, &conn)?;
+        let _ = WalletSettingSql::clear(&DbKey::EncryptionSalt, &conn)?;
 
         // Decrypt all the client values
         let mut client_key_values = ClientKeyValueSql::index(&conn)?;
@@ -558,7 +554,7 @@ impl WalletBackend for WalletSqliteDatabase {
         }
 
         // remove tor id encryption if present
-        let key_str = WalletSettingSql::get(DbKey::TorId.to_string(), &conn)?;
+        let key_str = WalletSettingSql::get(&DbKey::TorId, &conn)?;
         if let Some(v) = key_str {
             // decrypted_key_bytes contains sensitive information regarding private key, we thus
             // make sure the data is appropriately zeroized when we leave the current scope
@@ -573,7 +569,7 @@ impl WalletBackend for WalletSqliteDatabase {
             let tor_string = tor_id
                 .to_json()
                 .map_err(|e| WalletStorageError::ConversionError(e.to_string()))?;
-            WalletSettingSql::new(DbKey::TorId.to_string(), tor_string).set(&conn)?;
+            WalletSettingSql::new(DbKey::TorId, tor_string).set(&conn)?;
         }
         // this is the last remove encryption so lets force a sql lite checkpoint
         conn.execute("PRAGMA wal_checkpoint(2)")?;
@@ -641,8 +637,8 @@ fn check_db_encryption_status(
     let conn = database_connection.get_pooled_connection()?;
     let acquire_lock = start.elapsed();
 
-    let db_passphrase_hash = WalletSettingSql::get(DbKey::PassphraseHash.to_string(), &conn)?;
-    let db_encryption_salt = WalletSettingSql::get(DbKey::EncryptionSalt.to_string(), &conn)?;
+    let db_passphrase_hash = WalletSettingSql::get(&DbKey::PassphraseHash, &conn)?;
+    let db_encryption_salt = WalletSettingSql::get(&DbKey::EncryptionSalt, &conn)?;
 
     let cipher = match (passphrase, db_passphrase_hash, db_encryption_salt) {
         (Some(_), None, _) => {
@@ -688,7 +684,7 @@ fn check_db_encryption_status(
         _ => None,
     };
 
-    let secret_seed = WalletSettingSql::get(DbKey::MasterSeed.to_string(), &conn)?;
+    let secret_seed = WalletSettingSql::get(&DbKey::MasterSeed, &conn)?;
 
     if cipher.is_some() && secret_seed.is_none() {
         error!(
@@ -769,8 +765,11 @@ pub(crate) struct WalletSettingSql {
 }
 
 impl WalletSettingSql {
-    pub fn new(key: String, value: String) -> Self {
-        Self { key, value }
+    pub fn new(key: DbKey, value: String) -> Self {
+        Self {
+            key: key.to_key_string(),
+            value,
+        }
     }
 
     pub fn set(&self, conn: &SqliteConnection) -> Result<(), WalletStorageError> {
@@ -781,9 +780,9 @@ impl WalletSettingSql {
         Ok(())
     }
 
-    pub fn get(key: String, conn: &SqliteConnection) -> Result<Option<String>, WalletStorageError> {
+    pub fn get(key: &DbKey, conn: &SqliteConnection) -> Result<Option<String>, WalletStorageError> {
         wallet_settings::table
-            .filter(wallet_settings::key.eq(key))
+            .filter(wallet_settings::key.eq(key.to_key_string()))
             .first::<WalletSettingSql>(conn)
             .map(|v: WalletSettingSql| Some(v.value))
             .or_else(|err| match err {
@@ -792,9 +791,9 @@ impl WalletSettingSql {
             })
     }
 
-    pub fn clear(key: String, conn: &SqliteConnection) -> Result<bool, WalletStorageError> {
-        let num_deleted = diesel::delete(wallet_settings::table.filter(wallet_settings::key.eq(key))).execute(conn)?;
-
+    pub fn clear(key: &DbKey, conn: &SqliteConnection) -> Result<bool, WalletStorageError> {
+        let num_deleted = diesel::delete(wallet_settings::table.filter(wallet_settings::key.eq(key.to_key_string())))
+            .execute(conn)?;
         Ok(num_deleted > 0)
     }
 }
@@ -904,12 +903,9 @@ mod test {
 
         {
             let conn = connection.get_pooled_connection().unwrap();
-            WalletSettingSql::new(
-                DbKey::MasterSeed.to_string(),
-                secret_seed1.encipher(None).unwrap().to_hex(),
-            )
-            .set(&conn)
-            .unwrap();
+            WalletSettingSql::new(DbKey::MasterSeed, secret_seed1.encipher(None).unwrap().to_hex())
+                .set(&conn)
+                .unwrap();
         }
 
         let db = WalletSqliteDatabase::new(connection.clone(), None).unwrap();
@@ -948,7 +944,7 @@ mod test {
         let seed = CipherSeed::new();
         {
             let conn = connection.get_pooled_connection().unwrap();
-            WalletSettingSql::new(DbKey::MasterSeed.to_string(), seed.encipher(None).unwrap().to_hex())
+            WalletSettingSql::new(DbKey::MasterSeed, seed.encipher(None).unwrap().to_hex())
                 .set(&conn)
                 .unwrap();
         }
@@ -1017,14 +1013,10 @@ mod test {
         assert_eq!(seed, read_seed2);
         {
             let conn = connection.get_pooled_connection().unwrap();
-            let secret_key_str = WalletSettingSql::get(DbKey::MasterSeed.to_string(), &conn)
-                .unwrap()
-                .unwrap();
+            let secret_key_str = WalletSettingSql::get(&DbKey::MasterSeed, &conn).unwrap().unwrap();
             assert!(secret_key_str.len() > 64);
             db.set_master_seed(&seed, &conn).unwrap();
-            let secret_key_str = WalletSettingSql::get(DbKey::MasterSeed.to_string(), &conn)
-                .unwrap()
-                .unwrap();
+            let secret_key_str = WalletSettingSql::get(&DbKey::MasterSeed, &conn).unwrap().unwrap();
             assert!(secret_key_str.len() > 64);
         }
 


### PR DESCRIPTION
Description
---
- Fixes various typos in wallet settings keys
- Removes usage if Display impl for key to string conversion
- Add key name db migration

Motivation and Context
---
A number of key names had typos, this is likely because it is not clear that the string used comes from the Display impl.
This PR uses the DbKey type in the function signatures to ensure that keys are well formed and replaces the Display impl with `to_key_string` to make it clear that these keys are used as keys, and do not need to be human readable

How Has This Been Tested?
---
Manually, wallet updates keys and works
