### PR TITLE
feat: remove extra validation

### DIFF
--- a/base_layer/core/src/transactions/transaction_protocol/transaction_initializer.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/transaction_initializer.rs
@@ -29,7 +29,7 @@ use log::*;
 use rand::rngs::OsRng;
 use tari_common_types::{
     transaction::TxId,
-    types::{BlindingFactor, Commitment, CommitmentFactory, HashOutput, PrivateKey, PublicKey},
+    types::{BlindingFactor, Commitment, HashOutput, PrivateKey, PublicKey},
 };
 use tari_crypto::{
     commitment::HomomorphicCommitmentFactory,
@@ -223,32 +223,6 @@ impl SenderTransactionInitializer {
         output: UnblindedOutput,
         sender_offset_private_key: PrivateKey,
     ) -> Result<&mut Self, BuildError> {
-        let commitment_factory = CommitmentFactory::default();
-        let commitment = commitment_factory.commit(&output.spending_key, &PrivateKey::from(output.value));
-        let e = TransactionOutput::build_metadata_signature_challenge(
-            output.version,
-            &output.script,
-            &output.features,
-            &output.sender_offset_public_key,
-            output.metadata_signature.ephemeral_commitment(),
-            output.metadata_signature.ephemeral_pubkey(),
-            &commitment,
-            &output.covenant,
-            &output.encrypted_value,
-            output.minimum_value_promise,
-        );
-        if !output.metadata_signature.verify_challenge(
-            &commitment,
-            &output.sender_offset_public_key,
-            &e,
-            &commitment_factory,
-            &mut OsRng,
-        ) {
-            return self.clone().build_err(&*format!(
-                "Metadata signature not valid, cannot add output: {:?}",
-                output
-            ))?;
-        }
         self.excess_blinding_factor = &self.excess_blinding_factor + &output.spending_key;
         self.sender_custom_outputs.push(output);
         self.sender_offset_private_keys.push(sender_offset_private_key);

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_send_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_send_protocol.rs
@@ -546,7 +546,7 @@ where
 
         outbound_tx
             .sender_protocol
-            .add_single_recipient_info(recipient_reply, &self.resources.factories.range_proof)
+            .add_single_recipient_info(recipient_reply)
             .map_err(|e| TransactionServiceProtocolError::new(self.id, TransactionServiceError::from(e)))?;
 
         outbound_tx

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -1141,7 +1141,7 @@ where
 
         // Start finalizing
 
-        stp.add_single_recipient_info(recipient_reply, &self.resources.factories.range_proof)
+        stp.add_single_recipient_info(recipient_reply)
             .map_err(|e| TransactionServiceProtocolError::new(tx_id, e.into()))?;
 
         // Finalize
@@ -1278,7 +1278,7 @@ where
 
         // Start finalizing
 
-        stp.add_single_recipient_info(recipient_reply, &self.resources.factories.range_proof)
+        stp.add_single_recipient_info(recipient_reply)
             .map_err(|e| TransactionServiceProtocolError::new(tx_id, e.into()))?;
 
         // Finalize
@@ -1430,7 +1430,7 @@ where
 
         // Start finalizing
 
-        stp.add_single_recipient_info(recipient_reply, &self.resources.factories.range_proof)
+        stp.add_single_recipient_info(recipient_reply)
             .map_err(|e| TransactionServiceProtocolError::new(tx_id, e.into()))?;
 
         // Finalize

--- a/base_layer/wallet/tests/transaction_service_tests/service.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/service.rs
@@ -1505,8 +1505,7 @@ async fn finalize_tx_with_incorrect_pubkey() {
         .try_into()
         .unwrap();
 
-    stp.add_single_recipient_info(recipient_reply.clone(), &factories.range_proof)
-        .unwrap();
+    stp.add_single_recipient_info(recipient_reply.clone()).unwrap();
     stp.finalize(&factories, None, u64::MAX).unwrap();
     let tx = stp.get_transaction().unwrap();
 
@@ -1620,8 +1619,7 @@ async fn finalize_tx_with_missing_output() {
         .try_into()
         .unwrap();
 
-    stp.add_single_recipient_info(recipient_reply.clone(), &factories.range_proof)
-        .unwrap();
+    stp.add_single_recipient_info(recipient_reply.clone()).unwrap();
     stp.finalize(&factories, None, u64::MAX).unwrap();
 
     let finalized_transaction_message = proto::TransactionFinalizedMessage {
@@ -2963,9 +2961,7 @@ async fn test_restarting_transaction_protocols() {
 
     let alice_reply = receiver_protocol.get_signed_data().unwrap().clone();
 
-    bob_stp
-        .add_single_recipient_info(alice_reply.clone(), &factories.range_proof)
-        .unwrap();
+    bob_stp.add_single_recipient_info(alice_reply.clone()).unwrap();
 
     match bob_stp.finalize(&factories, None, u64::MAX) {
         Ok(_) => (),


### PR DESCRIPTION
Description
---
This removes extra validation from transaction protocols. 

Motivation and Context
---
The transaction protocols do a lot of extra unnecessary validation. 
For example:
The code will run add_output(output), which will validate the range_proof and signatures. 
The next line will run tx.build(), which will again validate the range_proof and signatures. 
While these tests are not expensive, they are not free either. 

The second problem is that when we do aggregate transactions such as with branch: `feature-m-of-n` these validations fail as the signatures are partial until right before we build the final transaction

How Has This Been Tested?
---
Passes all unit tests

Fixes: https://github.com/tari-project/tari/issues/4813
