### PR TITLE
docs: update sender protocol docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
 
 [[package]]
+name = "aquamarine"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a941c39708478e8eea39243b5983f1c42d2717b3620ee91f4a52115fd02ac43f"
+dependencies = [
+ "itertools 0.9.0",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "arc-swap"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2296,6 +2309,15 @@ name = "itertools"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
 dependencies = [
  "either",
 ]
@@ -4916,6 +4938,7 @@ dependencies = [
 name = "tari_core"
 version = "0.41.0"
 dependencies = [
+ "aquamarine",
  "async-trait",
  "bincode",
  "bitflags 1.3.2",

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -35,6 +35,8 @@ tari_storage = { version = "^0.41", path = "../../infrastructure/storage" }
 tari_test_utils = { version = "^0.41", path = "../../infrastructure/test_utils" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.10", features = ["borsh"] }
 
+# Used for showing mermaid diagrams in docs
+aquamarine = "0.1.12"
 async-trait = "0.1.50"
 bincode = "1.1.4"
 bitflags = "1.0.4"
@@ -77,6 +79,7 @@ tracing-attributes = "*"
 uint = { version = "0.9", default-features = false }
 zeroize = "1"
 
+
 [dev-dependencies]
 tari_p2p = { version = "^0.41", path = "../../base_layer/p2p", features = ["test-mocks"] }
 tari_test_utils = { version = "^0.41", path = "../../infrastructure/test_utils" }
@@ -87,6 +90,8 @@ tempfile = "3.1.0"
 
 [build-dependencies]
 tari_common = { version = "^0.41", path = "../../common", features = ["build"] }
+
+
 
 [[bench]]
 name = "mempool"

--- a/base_layer/core/src/transactions/mod.rs
+++ b/base_layer/core/src/transactions/mod.rs
@@ -1,6 +1,14 @@
 // Copyright 2022 The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
 
+//! This module contains transaction related types. Of particular interest is the [transaction_protocol]
+//! module which allows the creation of a transaction between two parties.
+//!
+//! Example
+//! ```
+//! todo!()
+//! ```
+
 pub mod aggregated_body;
 
 mod crypto_factories;

--- a/base_layer/core/src/transactions/transaction_protocol/mod.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/mod.rs
@@ -16,72 +16,7 @@
 //! illustrates the progression of the two state machines and shows where the public data messages are constructed and
 //! accepted in each state machine
 //!
-//! The sequence diagram for the single receiver protocol is:
-//!
-//! <div class="mermaid">
-//!   sequenceDiagram
-//!   participant Sender
-//!   participant Receiver
-//! #
-//!   activate Sender
-//!     Sender-->>Sender: initialize transaction
-//!   deactivate Sender
-//! #
-//!   activate Sender
-//!   Sender-->>+Receiver: partial tx info
-//!   Receiver-->>Receiver: validate tx info
-//!   Receiver-->>Receiver: create new output and sign
-//!   Receiver-->>-Sender: signed partial transaction
-//!   deactivate Sender
-//! #
-//!   activate Sender
-//!     Sender-->>Sender: validate and sign
-//!   deactivate Sender
-//! #
-//!   alt tx is valid
-//!   Sender-->>Network: Broadcast transaction
-//!   else tx is invalid
-//!   Sender--XSender: Failed
-//!   end
-//! </div>
-//!
-//! If there are multiple recipients, the protocol is more involved and requires three rounds of communication:
-//!
-//! <div class="mermaid">
-//!   sequenceDiagram
-//!   participant Sender
-//!   participant Receivers
-//! #
-//!   activate Sender
-//!   Sender-->>Sender: initialize
-//!   deactivate Sender
-//! #
-//!   activate Sender
-//!   Sender-->>+Receivers: [tx_id, amount_i]
-//!   note left of Sender: CollectingPubKeys
-//!   note right of Receivers: Initialization
-//!   Receivers-->>-Sender: [tx_id, Pi, Ri]
-//!   deactivate Sender
-//! #
-//!   alt invalid
-//!   Sender--XSender: failed
-//!   end
-//! #
-//!   activate Sender
-//!   Sender-->>+Receivers: [tx_id, ΣR, ΣP]
-//!   note left of Sender: CollectingSignatures
-//!   note right of Receivers: Signing
-//!   Receivers-->>Receivers: create output and sign
-//!   Receivers-->>-Sender: [tx_id, Output_i, s_i]
-//!   deactivate Sender
-//! #
-//!   note left of Sender: Finalizing
-//!   alt is_valid()
-//!   Sender-->>Sender: Finalized
-//!   else invalid
-//!   Sender--XSender: Failed
-//!   end
-//! </div>
+//! See [single_receiver::SingleReceiverTransactionProtocol] for more detail.
 
 // #![allow(clippy::op_ref)]
 

--- a/base_layer/core/src/transactions/transaction_protocol/mod.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/mod.rs
@@ -17,6 +17,30 @@
 //! accepted in each state machine
 //!
 //! See [single_receiver::SingleReceiverTransactionProtocol] for more detail.
+//!
+//! Example use:
+//! ```
+//! use tari_core::{
+//!     test_helpers::create_consensus_constants,
+//!     transactions::{
+//!         test_helpers::TestParams,
+//!         transaction_protocol::single_receiver::SingleReceiverTransactionProtocol,
+//!         CryptoFactories,
+//!         SenderTransactionProtocol,
+//!     },
+//! };
+//!
+//! let alice_secrets = TestParams::new();
+//! let bob_secrets = TestParams::new();
+//!
+//! let builder = SenderTransactionProtocol::builder(1, create_consensus_constants(0));
+//! // ... set builder options
+//! let mut alice = builder.build(&CryptoFactories::default(), None, u64::MAX).unwrap();
+//! let msg = alice.build_single_round_message().unwrap();
+//! let mut bob_info = SingleReceiverTransactionProtocol::create(&msg, b.nonce, b.spend_key, &factories, None).unwrap();
+//! alice.add_single_recipient_info(bob_info.clone()).unwrap();
+//! alice.finalize(&factories, None, u64::MAX).unwrap();
+//! ```
 
 // #![allow(clippy::op_ref)]
 

--- a/base_layer/core/src/transactions/transaction_protocol/transaction_initializer.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/transaction_initializer.rs
@@ -69,13 +69,8 @@ use crate::{
 pub const LOG_TARGET: &str = "c::tx::tx_protocol::tx_initializer";
 
 /// The SenderTransactionProtocolBuilder is a Builder that helps set up the initial state for the Sender party of a new
-/// transaction Typically you don't instantiate this object directly. Rather use
-/// ```ignore
-/// # use crate::SenderTransactionProtocol;
-/// SenderTransactionProtocol::new(1);
-/// ```
-/// which returns an instance of this builder. Once all the sender's information has been added via the builder
-/// methods, you can call `build()` which will return a
+/// transaction. Once all the sender's information has been added via the builder
+/// methods, you can call `build()` which will return a [SenderTransactionProtocol]
 #[derive(Debug, Clone)]
 pub struct SenderTransactionInitializer {
     num_recipients: usize,
@@ -157,7 +152,7 @@ impl SenderTransactionInitializer {
         }
     }
 
-    /// Set the fee per weight for the transaction. See (Fee::calculate)[Struct.Fee.html#calculate] for how the
+    /// Set the fee per weight for the transaction. See [Fee::calculate] for how the
     /// absolute fee is calculated from the fee-per-gram value.
     pub fn with_fee_per_gram(&mut self, fee_per_gram: MicroTari) -> &mut Self {
         self.fee_per_gram = Some(fee_per_gram);
@@ -171,7 +166,10 @@ impl SenderTransactionInitializer {
     }
 
     /// Set the spending script of the ith recipient's output, a script offset will be generated for this recipient at
-    /// the same time. This method will silently fail if `receiver_index` >= num_receivers.
+    /// the same time.
+    /// The script and covenant will usually be supplied by the recipient, but the sender commits to the script
+    /// by using the script offset public key.
+    /// > This method will silently fail if `receiver_index` >= num_receivers.
     pub fn with_recipient_data(
         &mut self,
         receiver_index: usize,


### PR DESCRIPTION
Description
---
Update the docs on SenderProtocol for clarity.

Motivation and Context
---
Working through the docs, some type aliases were confusing. Also added a dependency on `aquamarine` to show mermaid diagrams automatically. Unfortunately, it does not work on module level docs, so I have moved the mermaid diagram to SingleRoundSender. 

I also removed the multi-receiver example since it is a bit out of date.

Previous: 
![image](https://user-images.githubusercontent.com/4200336/204870899-9f3b57d7-c7a8-4a57-9629-4f69258e3882.png)

![image](https://user-images.githubusercontent.com/4200336/204870842-0b2cc146-55f2-4132-8c5d-c177800cf221.png)


New docs render:
![image](https://user-images.githubusercontent.com/4200336/204870276-f6460fe8-d443-498a-b649-e93837785059.png)

![image](https://user-images.githubusercontent.com/4200336/204870343-2bf36d85-636b-4e07-9c47-cbf6940c5052.png)


How Has This Been Tested?
---
cargo doc

