### PR TITLE
fix: improve key handling

### DIFF
--- a/base_layer/core/src/transactions/transaction_components/mod.rs
+++ b/base_layer/core/src/transactions/transaction_components/mod.rs
@@ -79,7 +79,7 @@ pub const MAX_TRANSACTION_RECIPIENTS: usize = 15;
 pub(crate) const AEAD_KEY_LEN: usize = std::mem::size_of::<Key>();
 
 // Type for hiding aead key encryption
-hidden_type!(CoreTransactionAEADKey, SafeArray<u8, AEAD_KEY_LEN>);
+hidden_type!(EncryptedValueKey, SafeArray<u8, AEAD_KEY_LEN>);
 
 //----------------------------------------     Crate functions   ----------------------------------------------------//
 

--- a/comms/core/src/noise/mod.rs
+++ b/comms/core/src/noise/mod.rs
@@ -33,9 +33,9 @@ pub use error::NoiseError;
 
 mod socket;
 pub use socket::NoiseSocket;
-use tari_utilities::{hidden_type, Hidden};
+use tari_utilities::{hidden_type, safe_array::SafeArray, Hidden};
 use zeroize::Zeroize;
 
 pub(crate) const NOISE_KEY_LEN: usize = 32;
 
-hidden_type!(CommsNoiseKey, [u8; NOISE_KEY_LEN]);
+hidden_type!(CommsNoiseKey, SafeArray<u8, NOISE_KEY_LEN>);


### PR DESCRIPTION
Description
---
Updates the use of `CoreTransactionAEADKey` and `CommsNoiseKey` to be populated in place. Switches `CommsNoiseKey` to use a `SafeArray` under the hood.

Extends the work of [PR 4967](https://github.com/tari-project/tari/pull/4967).

Motivation and Context
---
Earlier work updates the use of keys for value encryption and Noise. Value encryption keys use a `SafeArray` type in a `Hidden` wrapper, and Noise keys use a `Hidden` array. However, in both cases, a copy of the hash output used to populate the keys is left in memory.

This work mitigates the problem. Because the hashing API now supports in-place output finalization via `finalize_into` and `finalize_into_reset`, we can populate keys directly by mutable reference.

It also renames `CoreTransactionAEADKey` to `EncryptedValueKey` for clarity, and switches `CommsNoiseKey` to be a `SafeArray` under the hood. There is [discussion](https://github.com/tari-project/tari/pull/4967#discussion_r1033628944) on whether `CommsNoiseKey` needs to be a `SafeArray`; while the reasoning makes sense, I still think it's good practice to take advantage of the benefits of `SafeArray` for array-like key types unless there's a compelling performance reason otherwise. Discussion on this is welcome!

How Has This Been Tested?
---
Existing tests pass.