### PR TITLE
chore: remove debug message

### DIFF
--- a/comms/core/src/protocol/rpc/server/mod.rs
+++ b/comms/core/src/protocol/rpc/server/mod.rs
@@ -883,7 +883,6 @@ fn into_response(request_id: u32, result: Result<BodyBytes, RpcStatus>) -> RpcRe
 }
 
 fn err_to_log_level(err: &io::Error) -> log::Level {
-    error!(target: LOG_TARGET, "KIND: {}", err.kind());
     match err.kind() {
         ErrorKind::ConnectionReset |
         ErrorKind::ConnectionAborted |


### PR DESCRIPTION
Description
---
removes a debug message that double logs an error message as error and debug

Motivation and Context
---
These "error" messages can happen during routine program flow and are not really errors. They should be logged as debug only. 

Fixes: https://github.com/tari-project/tari/issues/4935