### PR TITLE
chore: remove unused message field from OMS

### DIFF
--- a/base_layer/wallet/src/output_manager_service/handle.rs
+++ b/base_layer/wallet/src/output_manager_service/handle.rs
@@ -94,7 +94,6 @@ pub enum OutputManagerRequest {
         output_features: Box<OutputFeatures>,
         fee_per_gram: MicroTari,
         lock_height: Option<u64>,
-        message: String,
     },
     CreatePayToSelfWithOutputs {
         outputs: Vec<UnblindedOutputBuilder>,
@@ -167,7 +166,7 @@ impl fmt::Display for OutputManagerRequest {
             GetRecipientTransaction(_) => write!(f, "GetRecipientTransaction"),
             ConfirmPendingTransaction(v) => write!(f, "ConfirmPendingTransaction ({})", v),
             PrepareToSendTransaction { message, .. } => write!(f, "PrepareToSendTransaction ({})", message),
-            CreatePayToSelfTransaction { message, .. } => write!(f, "CreatePayToSelfTransaction ({})", message),
+            CreatePayToSelfTransaction { .. } => write!(f, "CreatePayToSelfTransaction",),
             CancelTransaction(v) => write!(f, "CancelTransaction ({})", v),
             GetSpentOutputs => write!(f, "GetSpentOutputs"),
             GetUnspentOutputs => write!(f, "GetUnspentOutputs"),
@@ -860,7 +859,6 @@ impl OutputManagerHandle {
         output_features: OutputFeatures,
         fee_per_gram: MicroTari,
         lock_height: Option<u64>,
-        message: String,
     ) -> Result<(MicroTari, Transaction), OutputManagerError> {
         match self
             .handle
@@ -871,7 +869,6 @@ impl OutputManagerHandle {
                 output_features: Box::new(output_features),
                 fee_per_gram,
                 lock_height,
-                message,
             })
             .await??
         {

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -313,7 +313,6 @@ where
                 output_features,
                 fee_per_gram,
                 lock_height,
-                message,
             } => self
                 .create_pay_to_self_transaction(
                     tx_id,
@@ -322,7 +321,6 @@ where
                     *output_features,
                     fee_per_gram,
                     lock_height,
-                    message,
                 )
                 .await
                 .map(OutputManagerResponse::PayToSelfTransaction),
@@ -1239,7 +1237,6 @@ where
         output_features: OutputFeatures,
         fee_per_gram: MicroTari,
         lock_height: Option<u64>,
-        message: String,
     ) -> Result<(MicroTari, Transaction), OutputManagerError> {
         let script = script!(Nop);
         let covenant = Covenant::default();
@@ -1267,7 +1264,6 @@ where
             .with_fee_per_gram(fee_per_gram)
             .with_offset(offset.clone())
             .with_private_nonce(nonce.clone())
-            .with_message(message)
             .with_rewindable_outputs(self.resources.rewind_data.clone())
             .with_prevent_fee_gt_amount(self.resources.config.prevent_fee_gt_amount)
             .with_kernel_features(KernelFeatures::empty())

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -942,15 +942,7 @@ where
 
             let (fee, transaction) = self
                 .output_manager_service
-                .create_pay_to_self_transaction(
-                    tx_id,
-                    amount,
-                    selection_criteria,
-                    output_features,
-                    fee_per_gram,
-                    None,
-                    message.clone(),
-                )
+                .create_pay_to_self_transaction(tx_id, amount, selection_criteria, output_features, fee_per_gram, None)
                 .await?;
 
             // Notify that the transaction was successfully resolved.


### PR DESCRIPTION
Description
---
Remove unused message field from OMS

Motivation and Context
---
The message field is used by some TMS requests to send a message over to a recipient with the tx. 
Some requests only use the message for a note like the pay-to-self or burn. 

Fixes: https://github.com/tari-project/tari/issues/4660

