### PR TITLE
fix(base_layer/core): fixes incorrect validator node merkle root calculation

### DIFF
--- a/applications/tari_base_node/src/commands/command/list_validator_nodes.rs
+++ b/applications/tari_base_node/src/commands/command/list_validator_nodes.rs
@@ -1,0 +1,88 @@
+//  Copyright 2022, The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use anyhow::Error;
+use async_trait::async_trait;
+use clap::Parser;
+use tari_common_types::{epoch::VnEpoch, types::PublicKey};
+use tari_utilities::hex::to_hex;
+
+use super::{CommandContext, HandleCommand};
+use crate::table::Table;
+
+/// Lists the peer connections currently held by this node
+#[derive(Debug, Parser)]
+pub struct Args {
+    epoch: Option<VnEpoch>,
+}
+
+#[async_trait]
+impl HandleCommand<Args> for CommandContext {
+    async fn handle_command(&mut self, args: Args) -> Result<(), Error> {
+        self.list_validator_nodes(args).await
+    }
+}
+
+impl CommandContext {
+    async fn print_validator_nodes_list(&mut self, vns: &[(PublicKey, [u8; 32])]) {
+        let num_vns = vns.len();
+        let mut table = Table::new();
+        table.set_titles(vec!["Public Key", "Shard ID"]);
+        for (public_key, shard_key) in vns {
+            table.add_row(row![public_key, to_hex(shard_key),]);
+        }
+
+        table.print_stdout();
+
+        println!();
+        println!("{} active validator(s)", num_vns);
+    }
+}
+
+impl CommandContext {
+    /// Function to process the list-connections command
+    pub async fn list_validator_nodes(&mut self, args: Args) -> Result<(), Error> {
+        let metadata = self.blockchain_db.get_chain_metadata().await?;
+        let constants = self
+            .consensus_rules
+            .consensus_constants(metadata.height_of_longest_chain());
+        let height = args
+            .epoch
+            .map(|epoch| constants.epoch_to_block_height(epoch))
+            .unwrap_or_else(|| metadata.height_of_longest_chain());
+        let vns = self.blockchain_db.fetch_active_validator_nodes(height).await?;
+
+        println!();
+        println!(
+            "Registered validator nodes for epoch {}",
+            constants.block_height_to_epoch(height).as_u64()
+        );
+        println!("----------------------------------");
+        if vns.is_empty() {
+            println!("No active validator nodes.");
+        } else {
+            println!();
+            self.print_validator_nodes_list(&vns).await;
+        }
+        Ok(())
+    }
+}

--- a/applications/tari_base_node/src/commands/command/mod.rs
+++ b/applications/tari_base_node/src/commands/command/mod.rs
@@ -41,6 +41,7 @@ mod list_connections;
 mod list_headers;
 mod list_peers;
 mod list_reorgs;
+mod list_validator_nodes;
 mod period_stats;
 mod ping_peer;
 mod quit;
@@ -131,6 +132,7 @@ pub enum Command {
     Whoami(whoami::Args),
     GetStateInfo(get_state_info::Args),
     GetNetworkStats(get_network_stats::Args),
+    ListValidatorNodes(list_validator_nodes::Args),
     Quit(quit::Args),
     Exit(quit::Args),
     Watch(watch_command::Args),
@@ -225,6 +227,7 @@ impl CommandContext {
                 Command::GetMempoolTx(_) |
                 Command::Status(_) |
                 Command::Watch(_) |
+                Command::ListValidatorNodes(_) |
                 Command::Quit(_) |
                 Command::Exit(_) => 30,
                 // These commands involve intense blockchain db operations and needs a lot of time to complete
@@ -289,6 +292,7 @@ impl HandleCommand<Command> for CommandContext {
             Command::ListBannedPeers(args) => self.handle_command(args).await,
             Command::Quit(args) | Command::Exit(args) => self.handle_command(args).await,
             Command::Watch(args) => self.handle_command(args).await,
+            Command::ListValidatorNodes(args) => self.handle_command(args).await,
         }
     }
 }

--- a/base_layer/common_types/src/epoch.rs
+++ b/base_layer/common_types/src/epoch.rs
@@ -1,10 +1,10 @@
 //  Copyright 2022. The Tari Project
 //
-//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
-//  following conditions are met:
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+// the  following conditions are met:
 //
-//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
-//  disclaimer.
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
+// following  disclaimer.
 //
 //  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
 //  following disclaimer in the documentation and/or other materials provided with the distribution.
@@ -12,13 +12,17 @@
 //  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
 //  products derived from this software without specific prior written permission.
 //
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
-//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
-//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
-//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+// WARRANTIES,  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+// PARTICULAR PURPOSE ARE  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL,  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY,  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+// OTHERWISE) ARISING IN ANY WAY OUT OF THE  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+
+use std::str::FromStr;
+
 use newtype_ops::newtype_ops;
 use serde::{Deserialize, Serialize};
 
@@ -42,3 +46,11 @@ impl VnEpoch {
 newtype_ops! { [VnEpoch] {add sub mul div} {:=} Self Self }
 newtype_ops! { [VnEpoch] {add sub mul div} {:=} &Self &Self }
 newtype_ops! { [VnEpoch] {add sub mul div} {:=} Self &Self }
+
+impl FromStr for VnEpoch {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(VnEpoch(s.parse::<u64>().map_err(|e| e.to_string())?))
+    }
+}

--- a/base_layer/core/src/base_node/sync/header_sync/error.rs
+++ b/base_layer/core/src/base_node/sync/header_sync/error.rs
@@ -95,7 +95,7 @@ pub enum BlockHeaderSyncError {
     #[error(
         "Validator node MMR at height {height} is not correct. Expected {actual} to equal the computed {computed}"
     )]
-    ValidatorNodeMmmr {
+    ValidatorNodeMmr {
         height: u64,
         actual: String,
         computed: String,

--- a/base_layer/core/src/blocks/block_header.rs
+++ b/base_layer/core/src/blocks/block_header.rs
@@ -292,7 +292,7 @@ impl Display for BlockHeader {
         )?;
         writeln!(
             fmt,
-            "Merkle roots:\nInputs: {},\nOutputs: {} ({})\nWitness: {}\nKernels: {} ({})\n",
+            "Merkle roots:\nInputs: {},\nOutputs: {} ({})\nWitness: {}\nKernels: {} ({})",
             self.input_mr.to_hex(),
             self.output_mr.to_hex(),
             self.output_mmr_size,
@@ -300,6 +300,7 @@ impl Display for BlockHeader {
             self.kernel_mr.to_hex(),
             self.kernel_mmr_size
         )?;
+        writeln!(fmt, "ValidatorNode: {}\n", self.validator_node_mr.to_hex())?;
         writeln!(
             fmt,
             "Total offset: {}\nTotal script offset: {}\nNonce: {}\nProof of work:\n{}",

--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -1398,7 +1398,10 @@ pub fn calculate_validator_node_mr(
             .to_vec()
     }
 
-    let vn_mmr = ValidatorNodeMmr::new(validator_nodes.iter().map(hash_node).collect());
+    let mut vn_mmr = ValidatorNodeMmr::new(Vec::new());
+    for vn in validator_nodes {
+        vn_mmr.push(hash_node(vn))?;
+    }
     let merkle_root = vn_mmr.get_merkle_root()?;
     Ok(merkle_root)
 }

--- a/base_layer/core/src/consensus/consensus_constants.rs
+++ b/base_layer/core/src/consensus/consensus_constants.rs
@@ -320,18 +320,17 @@ impl ConsensusConstants {
     }
 
     /// Returns the current epoch from the given height
-    pub fn block_height_to_current_epoch(&self, height: u64) -> VnEpoch {
+    pub fn block_height_to_epoch(&self, height: u64) -> VnEpoch {
         VnEpoch(height / self.vn_epoch_length)
+    }
+
+    /// Returns the block height of the start of the given epoch
+    pub fn epoch_to_block_height(&self, epoch: VnEpoch) -> u64 {
+        epoch.as_u64() * self.vn_epoch_length
     }
 
     pub fn epoch_length(&self) -> u64 {
         self.vn_epoch_length
-    }
-
-    /// Returns the next epoch up from the given height
-    pub fn block_height_to_next_epoch(&self, height: u64) -> VnEpoch {
-        let rem = height % self.vn_epoch_length;
-        VnEpoch((height + rem) / self.vn_epoch_length)
     }
 
     pub fn localnet() -> Vec<Self> {


### PR DESCRIPTION
Description
---

feat: add list-validator-nodes command
fix: typo in error variant
feat: output validator Merkle root in BlockHeader Display impl
fix: correct validator node Merkle root calculation
fix: bug in internal epoch numbering
tests: new unit tests

Motivation and Context
---
The validator node MR calculation was invalid due to incorrect usage of the MMR API.
There was a subtraction underflow bug in insert_validator_node in lmdb_db
Registering on a new epoch should be valid for the next epoch
list-validator-nodes was added to make it easy to check the current validator node set

How Has This Been Tested?
---
Added some new unit tests that check the validator node registration MR
