### PR TITLE
fix: seed words should be used in wallet recovery (see issue #4894)

### DIFF
--- a/applications/tari_console_wallet/src/init/mod.rs
+++ b/applications/tari_console_wallet/src/init/mod.rs
@@ -552,22 +552,7 @@ fn boot(cli: &Cli, wallet_config: &WalletConfig) -> Result<WalletBoot, ExitError
         return Ok(WalletBoot::Recovery);
     }
 
-    if cli.seed_words.is_some() && !wallet_exists && cli.password.is_some() {
-        return Ok(WalletBoot::Recovery);
-    }
-
     if cli.seed_words.is_some() && !wallet_exists {
-        if let Some(ref pass) = wallet_config.password {
-            let cli_pass = prompt_password("Please provide wallet password")?;
-
-            if cli_pass.reveal() == pass.reveal() {
-                return Ok(WalletBoot::Recovery);
-            } else {
-                return Err(ExitError::new(ExitCode::WalletError, "Invalid passphrase for wallet"));
-            }
-        }
-
-        // if both cli and config passwords are not available, we allow the user to recover its wallet
         return Ok(WalletBoot::Recovery);
     }
 

--- a/applications/tari_console_wallet/src/init/mod.rs
+++ b/applications/tari_console_wallet/src/init/mod.rs
@@ -550,7 +550,24 @@ fn boot(cli: &Cli, wallet_config: &WalletConfig) -> Result<WalletBoot, ExitError
             ));
         }
         return Ok(WalletBoot::Recovery);
-    } else if cli.seed_words.is_some() && !wallet_exists && cli.password.is_some() {
+    }
+
+    if cli.seed_words.is_some() && !wallet_exists && cli.password.is_some() {
+        return Ok(WalletBoot::Recovery);
+    }
+
+    if cli.seed_words.is_some() && !wallet_exists {
+        if let Some(ref pass) = wallet_config.password {
+            let cli_pass = prompt_password("Please provide wallet password")?;
+
+            if cli_pass.reveal() == pass.reveal() {
+                return Ok(WalletBoot::Recovery);
+            } else {
+                return Err(ExitError::new(ExitCode::WalletError, "Invalid passphrase for wallet"));
+            }
+        }
+
+        // if both cli and config passwords are not available, we allow the user to recover its wallet
         return Ok(WalletBoot::Recovery);
     }
 

--- a/applications/tari_console_wallet/src/init/mod.rs
+++ b/applications/tari_console_wallet/src/init/mod.rs
@@ -550,7 +550,7 @@ fn boot(cli: &Cli, wallet_config: &WalletConfig) -> Result<WalletBoot, ExitError
             ));
         }
         return Ok(WalletBoot::Recovery);
-    } else if cli.seed_words.is_some() && !wallet_exists {
+    } else if cli.seed_words.is_some() && !wallet_exists && cli.password.is_some() {
         return Ok(WalletBoot::Recovery);
     }
 

--- a/applications/tari_console_wallet/src/init/mod.rs
+++ b/applications/tari_console_wallet/src/init/mod.rs
@@ -605,6 +605,8 @@ pub(crate) fn boot(cli: &Cli, wallet_config: &WalletConfig) -> Result<WalletBoot
             ));
         }
         return Ok(WalletBoot::Recovery);
+    } else if cli.seed_words.is_some() && !wallet_exists {
+        return Ok(WalletBoot::Recovery);
     }
 
     if wallet_exists {


### PR DESCRIPTION
Description
---
Issue #4894 describes a current bug while running the tari console wallet command with seed phrase (and non existing wallet). We address this issue here.

Motivation and Context
---

How Has This Been Tested?
---
Running the non-working command in #4894.

