### PR TITLE
fix: show mined timestamp for import tx

### DIFF
--- a/base_layer/wallet/src/transaction_service/storage/database.rs
+++ b/base_layer/wallet/src/transaction_service/storage/database.rs
@@ -669,7 +669,7 @@ where T: TransactionBackend + 'static
             ),
             TransactionStatus::try_from(import_status)?,
             message,
-            Utc::now().naive_utc(),
+            mined_timestamp.unwrap_or(Utc::now().naive_utc()),
             TransactionDirection::Inbound,
             maturity,
             current_height,


### PR DESCRIPTION
Description
---
Don't show the current time for an import, rather show the mined timestamp

Motivation and Context
---
Fixes: https://github.com/tari-project/tari/issues/4923

