### PR TITLE
feat: revalidate invalid utxo

### DIFF
--- a/base_layer/wallet/migrations/2022-12-07-110000/down.sql
+++ b/base_layer/wallet/migrations/2022-12-07-110000/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE outputs DROP COLUMN last_validation_timestamp;

--- a/base_layer/wallet/migrations/2022-12-07-110000/up.sql
+++ b/base_layer/wallet/migrations/2022-12-07-110000/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE outputs ADD last_validation_timestamp DATETIME NULL;

--- a/base_layer/wallet/src/output_manager_service/config.rs
+++ b/base_layer/wallet/src/output_manager_service/config.rs
@@ -42,7 +42,7 @@ pub struct OutputManagerServiceConfig {
     /// inputs for further transactions, but can still be selected individually as specific outputs.
     pub autoignore_onesided_utxos: bool,
     /// The number of seconds that have to pass for the wallet to run revalidation of invalid UTXOs on startup.
-    pub num_of_seconds_to_revalidate_invalid_utxos: i64,
+    pub num_of_seconds_to_revalidate_invalid_utxos: u64,
 }
 
 impl Default for OutputManagerServiceConfig {

--- a/base_layer/wallet/src/output_manager_service/config.rs
+++ b/base_layer/wallet/src/output_manager_service/config.rs
@@ -41,6 +41,8 @@ pub struct OutputManagerServiceConfig {
     /// If set to `true`, then outputs received via simple one-sided transactions, won't be automatically selected as
     /// inputs for further transactions, but can still be selected individually as specific outputs.
     pub autoignore_onesided_utxos: bool,
+    /// The number of seconds that have to pass for the wallet to run revalidation of invalid UTXOs on startup.
+    pub num_of_seconds_to_revalidate_invalid_utxos: i64,
 }
 
 impl Default for OutputManagerServiceConfig {
@@ -51,6 +53,7 @@ impl Default for OutputManagerServiceConfig {
             num_confirmations_required: 3,
             tx_validator_batch_size: 100,
             autoignore_onesided_utxos: false,
+            num_of_seconds_to_revalidate_invalid_utxos: 60 * 60 * 24 * 3,
         }
     }
 }

--- a/base_layer/wallet/src/output_manager_service/storage/database/backend.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/database/backend.rs
@@ -30,6 +30,8 @@ pub trait OutputManagerBackend: Send + Sync + Clone {
     fn fetch_sorted_unspent_outputs(&self) -> Result<Vec<DbUnblindedOutput>, OutputManagerStorageError>;
     /// Retrieve outputs that have been mined but not spent yet (have not been deleted)
     fn fetch_mined_unspent_outputs(&self) -> Result<Vec<DbUnblindedOutput>, OutputManagerStorageError>;
+    /// Retrieve outputs that are invalid
+    fn fetch_invalid_outputs(&self, timestamp: i64) -> Result<Vec<DbUnblindedOutput>, OutputManagerStorageError>;
     /// Retrieve outputs that have not been found or confirmed in the block chain yet
     fn fetch_unspent_mined_unconfirmed_outputs(&self) -> Result<Vec<DbUnblindedOutput>, OutputManagerStorageError>;
     /// Modify the state the of the backend with a write operation
@@ -47,6 +49,7 @@ pub trait OutputManagerBackend: Send + Sync + Clone {
     ) -> Result<(), OutputManagerStorageError>;
 
     fn set_output_to_unmined_and_invalid(&self, hash: FixedHash) -> Result<(), OutputManagerStorageError>;
+    fn update_last_validation_timestamp(&self, hash: FixedHash) -> Result<(), OutputManagerStorageError>;
     fn set_outputs_to_be_revalidated(&self) -> Result<(), OutputManagerStorageError>;
 
     fn mark_output_as_spent(

--- a/base_layer/wallet/src/output_manager_service/storage/database/mod.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/database/mod.rs
@@ -285,6 +285,11 @@ where T: OutputManagerBackend + 'static
         Ok(utxos)
     }
 
+    pub fn fetch_invalid_outputs(&self, timestamp: i64) -> Result<Vec<DbUnblindedOutput>, OutputManagerStorageError> {
+        let utxos = self.db.fetch_invalid_outputs(timestamp)?;
+        Ok(utxos)
+    }
+
     pub fn get_timelocked_outputs(&self, tip: u64) -> Result<Vec<DbUnblindedOutput>, OutputManagerStorageError> {
         let uo = match self.db.fetch(&DbKey::TimeLockedUnspentOutputs(tip)) {
             Ok(None) => log_error(
@@ -413,6 +418,12 @@ where T: OutputManagerBackend + 'static
     pub fn set_outputs_to_be_revalidated(&self) -> Result<(), OutputManagerStorageError> {
         let db = self.db.clone();
         db.set_outputs_to_be_revalidated()?;
+        Ok(())
+    }
+
+    pub fn update_last_validation_timestamp(&self, hash: HashOutput) -> Result<(), OutputManagerStorageError> {
+        let db = self.db.clone();
+        db.update_last_validation_timestamp(hash)?;
         Ok(())
     }
 

--- a/base_layer/wallet/src/output_manager_service/storage/sqlite_db/output_sql.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/sqlite_db/output_sql.rs
@@ -106,6 +106,7 @@ pub struct OutputSql {
     pub encrypted_value: Vec<u8>,
     pub minimum_value_promise: i64,
     pub source: i32,
+    pub last_validation_timestamp: Option<NaiveDateTime>,
 }
 
 impl OutputSql {
@@ -321,6 +322,25 @@ impl OutputSql {
             .filter(outputs::marked_deleted_in_block.is_null().or(outputs::status.eq(OutputStatus::SpentMinedUnconfirmed as i32)))
             // Only return mined
             .filter(outputs::mined_in_block.is_not_null().and(outputs::mined_height.is_not_null()))
+            .order(outputs::id.asc())
+            .load(conn)?)
+    }
+
+    pub fn index_invalid(
+        timestamp: &NaiveDateTime,
+        conn: &SqliteConnection,
+    ) -> Result<Vec<OutputSql>, OutputManagerStorageError> {
+        Ok(outputs::table
+            .filter(
+                outputs::status
+                    .eq(OutputStatus::Invalid as i32)
+                    .or(outputs::status.eq(OutputStatus::CancelledInbound as i32)),
+            )
+            .filter(
+                outputs::last_validation_timestamp
+                    .le(timestamp)
+                    .or(outputs::last_validation_timestamp.is_null()),
+            )
             .order(outputs::id.asc())
             .load(conn)?)
     }

--- a/base_layer/wallet/src/output_manager_service/tasks/txo_validation_task.rs
+++ b/base_layer/wallet/src/output_manager_service/tasks/txo_validation_task.rs
@@ -126,7 +126,16 @@ where
         let invalid_outputs = self
             .db
             .fetch_invalid_outputs(
-                (Utc::now() - Duration::seconds(self.config.num_of_seconds_to_revalidate_invalid_utxos)).timestamp(),
+                (Utc::now() -
+                    Duration::seconds(
+                        self.config
+                            .num_of_seconds_to_revalidate_invalid_utxos
+                            .try_into()
+                            .map_err(|_| {
+                                OutputManagerProtocolError::new(self.operation_id, OutputManagerError::InvalidConfig)
+                            })?,
+                    ))
+                .timestamp(),
             )
             .for_protocol(self.operation_id)?;
 

--- a/base_layer/wallet/src/schema.rs
+++ b/base_layer/wallet/src/schema.rs
@@ -128,6 +128,7 @@ diesel::table! {
         encrypted_value -> Binary,
         minimum_value_promise -> BigInt,
         source -> Integer,
+        last_validation_timestamp -> Nullable<Timestamp>,
     }
 }
 

--- a/common/config/presets/d_console_wallet.toml
+++ b/common/config/presets/d_console_wallet.toml
@@ -157,6 +157,10 @@ event_channel_size = 3500
 # The number of batches the unconfirmed outputs will be divided into before being queried from the base node
 # (default = 100)
 #tx_validator_batch_size = 100
+# Number of seconds that have to pass for the wallet to run revalidation of invalid UTXOs on startup.
+# If you set it to zero, the revalidation will be on every wallet rerun. Default is 3 days.
+#num_of_seconds_to_revalidate_invalid_utxos = 259200
+
 
 [wallet.base_node]
 # Configuration for the wallet's base node service


### PR DESCRIPTION
Description
---
Add `last_validation_timestamp` for `Invalid`/`CancelledInbound` transactions.
Configurable interval for revalidation `num_of_seconds_to_revalidate_invalid_utxos`. Default is 3 days. When set to zero, the revalidation will be run every time. When revalidation failes, the `last_validation_timestamp` is updated.

How Has This Been Tested?
---
Partially (revalidation to valid tx).

