### PR TITLE
fix: currently newly created wallet does not prompt seed words (#5019)

### DIFF
--- a/applications/tari_console_wallet/src/init/mod.rs
+++ b/applications/tari_console_wallet/src/init/mod.rs
@@ -482,7 +482,7 @@ async fn validate_txos(wallet: &mut WalletSqlite) -> Result<(), ExitError> {
     Ok(())
 }
 
-fn confirm_seed_words(wallet: &mut WalletSqlite) -> Result<(), ExitError> {
+pub(crate) fn confirm_seed_words(wallet: &mut WalletSqlite) -> Result<(), ExitError> {
     let seed_words = wallet.get_seed_words(&MnemonicLanguage::English)?;
 
     println!();

--- a/applications/tari_console_wallet/src/lib.rs
+++ b/applications/tari_console_wallet/src/lib.rs
@@ -49,7 +49,7 @@ use tokio::runtime::Runtime;
 use wallet_modes::{command_mode, grpc_mode, recovery_mode, script_mode, tui_mode, WalletMode};
 
 pub use crate::config::ApplicationConfig;
-use crate::init::{boot_with_password, wallet_mode};
+use crate::init::{boot_with_password, confirm_seed_words, wallet_mode};
 
 pub const LOG_TARGET: &str = "wallet::console_wallet::main";
 
@@ -135,6 +135,12 @@ pub fn run_wallet_with_cli(runtime: Runtime, config: &mut ApplicationConfig, cli
         );
     }
 
+    let on_init = match boot_mode {
+        WalletBoot::New => true,
+        _ => false,
+    };
+    let on_recovery = recovery_seed.is_none();
+
     // initialize wallet
     let mut wallet = runtime.block_on(init_wallet(
         config,
@@ -144,6 +150,18 @@ pub fn run_wallet_with_cli(runtime: Runtime, config: &mut ApplicationConfig, cli
         shutdown_signal,
         cli.non_interactive_mode,
     ))?;
+
+    // if wallet is being set for the first time, wallet seed words are prompted on the screen
+    if !cli.non_interactive_mode && on_recovery && on_init {
+        match confirm_seed_words(&mut wallet) {
+            Ok(()) => {
+                print!("\x1Bc"); // Clear the screen
+            },
+            Err(error) => {
+                return Err(error);
+            },
+        };
+    }
 
     // Check if there is an in progress recovery in the wallet's database
     if wallet.is_recovery_in_progress()? {

--- a/applications/tari_console_wallet/src/lib.rs
+++ b/applications/tari_console_wallet/src/lib.rs
@@ -135,11 +135,8 @@ pub fn run_wallet_with_cli(runtime: Runtime, config: &mut ApplicationConfig, cli
         );
     }
 
-    let on_init = match boot_mode {
-        WalletBoot::New => true,
-        _ => false,
-    };
-    let on_recovery = recovery_seed.is_none();
+    let on_init = matches!(boot_mode, WalletBoot::New);
+    let not_recovery = recovery_seed.is_none();
 
     // initialize wallet
     let mut wallet = runtime.block_on(init_wallet(
@@ -152,7 +149,7 @@ pub fn run_wallet_with_cli(runtime: Runtime, config: &mut ApplicationConfig, cli
     ))?;
 
     // if wallet is being set for the first time, wallet seed words are prompted on the screen
-    if !cli.non_interactive_mode && on_recovery && on_init {
+    if !cli.non_interactive_mode && not_recovery && on_init {
         match confirm_seed_words(&mut wallet) {
             Ok(()) => {
                 print!("\x1Bc"); // Clear the screen

--- a/base_layer/core/src/base_node/service/service.rs
+++ b/base_layer/core/src/base_node/service/service.rs
@@ -346,7 +346,7 @@ where B: BlockchainBackend + 'static
             if let Err(res) = result {
                 error!(
                     target: LOG_TARGET,
-                   "BaseNodeService Caller dropped the oneshot receiver before reply could be sent. Reply: {:?}"
+                    "BaseNodeService Caller dropped the oneshot receiver before reply could be sent. Reply: {:?}",
                     res.map(|r| r.to_string()).map_err(|e| e.to_string())
                 );
             }


### PR DESCRIPTION
Description
---
Enforces display of seed words for newly created wallet.

Motivation and Context
---
In a previous refactor (#4984), a component of the wallet was accidentally removed, namely the prompt of seed words for newly created wallet. 

How Has This Been Tested?
---
In a folder with no wallet db, run `cargo run --release --bin tari_console_wallet` and chose the option create new wallet.
