### PR TITLE
chore: remove unused lock logging

### DIFF
--- a/base_layer/core/src/base_node/service/service.rs
+++ b/base_layer/core/src/base_node/service/service.rs
@@ -346,7 +346,7 @@ where B: BlockchainBackend + 'static
             if let Err(res) = result {
                 error!(
                     target: LOG_TARGET,
-                   "BaseNodeService Caller dropped the oneshot receiver before reply could be sent. Reply: {:?}"
+                    "BaseNodeService Caller dropped the oneshot receiver before reply could be sent. Reply: {:?}",
                     res.map(|r| r.to_string()).map_err(|e| e.to_string())
                 );
             }

--- a/base_layer/core/src/base_node/sync/header_sync/synchronizer.rs
+++ b/base_layer/core/src/base_node/sync/header_sync/synchronizer.rs
@@ -802,8 +802,6 @@ enum BanReason {
     ValidationFailed(#[from] ValidationError),
     #[error("Peer could not find the location of a chain split")]
     ChainSplitNotFound,
-    #[error("Failed to synchronize headers from peer: {0}")]
-    GeneralHeaderSyncFailure(BlockHeaderSyncError),
     #[error("Peer did not respond timeously during RPC negotiation")]
     RpcNegotiationTimedOut,
     #[error("Header at height {height} did not form a chain. Expected {actual} to equal the previous hash {expected}")]

--- a/base_layer/wallet/src/transaction_service/storage/database.rs
+++ b/base_layer/wallet/src/transaction_service/storage/database.rs
@@ -669,7 +669,7 @@ where T: TransactionBackend + 'static
             ),
             TransactionStatus::try_from(import_status)?,
             message,
-            mined_timestamp.unwrap_or(Utc::now().naive_utc()),
+            mined_timestamp.unwrap_or_else(|| Utc::now().naive_utc()),
             TransactionDirection::Inbound,
             maturity,
             current_height,

--- a/base_layer/wallet/tests/utxo_scanner.rs
+++ b/base_layer/wallet/tests/utxo_scanner.rs
@@ -34,7 +34,7 @@ use tari_comms::{
 };
 use tari_core::{
     base_node::rpc::BaseNodeWalletRpcServer,
-    blocks::{genesis_block, BlockHeader},
+    blocks::BlockHeader,
     proto::base_node::{ChainMetadata, TipInfoResponse},
     transactions::{tari_amount::MicroTari, transaction_components::UnblindedOutput, CryptoFactories},
 };


### PR DESCRIPTION
Description
---
Remove unused logging of how long it takes to acquire a lock.

Motivation and Context
---
We use to have an RWlock on the wallet database. We added logging to measure how much of a performance issue the lock was. We removed the RWlock and introduced pooled connections. We have not removed the lock logging. 

