### PR TITLE
fix(ci): workaround - lock linux-x86_64 to ubuntu 20.04

### DIFF
--- a/.github/workflows/base_node_binaries.json
+++ b/.github/workflows/base_node_binaries.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "linux-x86_64",
-    "runs-on": "ubuntu-latest",
+    "runs-on": "ubuntu-20.04",
     "rust": "nightly-2022-05-01",
     "target": "x86_64-unknown-linux-gnu",
     "cross": false,


### PR DESCRIPTION
Description
Lock linux-x86_64 to ubuntu 20.04 - workaround

Motivation and Context
GitHub action runner ```ubuntu-latest``` has been progressed to Ubuntu 22.04, install scripts target clang-10, which is default in Ubuntu 22.04

How Has This Been Tested?
Built locally and in local fork

