### PR TITLE
fix(core): fixes stale chain metadata being sent to listening state

### DIFF
--- a/base_layer/core/src/base_node/chain_metadata_service/handle.rs
+++ b/base_layer/core/src/base_node/chain_metadata_service/handle.rs
@@ -80,8 +80,17 @@ impl Display for PeerChainMetadata {
 
 #[derive(Debug)]
 pub enum ChainMetadataEvent {
-    PeerChainMetadataReceived(Vec<PeerChainMetadata>),
+    PeerChainMetadataReceived(PeerChainMetadata),
     NetworkSilence,
+}
+
+impl ChainMetadataEvent {
+    pub fn peer_metadata(&self) -> Option<PeerChainMetadata> {
+        match self {
+            Self::PeerChainMetadataReceived(metadata) => Some(metadata.clone()),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Clone)]

--- a/base_layer/core/src/base_node/chain_metadata_service/service.rs
+++ b/base_layer/core/src/base_node/chain_metadata_service/service.rs
@@ -27,10 +27,7 @@ use num_format::{Locale, ToFormattedString};
 use prost::Message;
 use tari_common::log_if_error;
 use tari_common_types::chain_metadata::ChainMetadata;
-use tari_comms::{
-    connectivity::{ConnectivityEvent, ConnectivityRequester},
-    message::MessageExt,
-};
+use tari_comms::message::MessageExt;
 use tari_p2p::services::liveness::{LivenessEvent, LivenessHandle, MetadataKey, PingPongEvent};
 use tokio::sync::broadcast;
 
@@ -49,8 +46,6 @@ const NUM_ROUNDS_NETWORK_SILENCE: u16 = 3;
 pub(super) struct ChainMetadataService {
     liveness: LivenessHandle,
     base_node: LocalNodeCommsInterface,
-    peer_chain_metadata: Vec<PeerChainMetadata>,
-    connectivity: ConnectivityRequester,
     event_publisher: broadcast::Sender<Arc<ChainMetadataEvent>>,
     number_of_rounds_no_pings: u16,
 }
@@ -64,14 +59,11 @@ impl ChainMetadataService {
     pub fn new(
         liveness: LivenessHandle,
         base_node: LocalNodeCommsInterface,
-        connectivity: ConnectivityRequester,
         event_publisher: broadcast::Sender<Arc<ChainMetadataEvent>>,
     ) -> Self {
         Self {
             liveness,
             base_node,
-            peer_chain_metadata: Vec::new(),
-            connectivity,
             event_publisher,
             number_of_rounds_no_pings: 0,
         }
@@ -81,7 +73,6 @@ impl ChainMetadataService {
     pub async fn run(mut self) {
         let mut liveness_event_stream = self.liveness.get_event_stream();
         let mut block_event_stream = self.base_node.get_block_event_stream();
-        let mut connectivity_events = self.connectivity.get_event_subscription();
 
         log_if_error!(
             target: LOG_TARGET,
@@ -108,26 +99,7 @@ impl ChainMetadataService {
                     );
                 },
 
-                Ok(event) = connectivity_events.recv() => {
-                    self.handle_connectivity_event(event);
-                }
             }
-        }
-    }
-
-    fn handle_connectivity_event(&mut self, event: ConnectivityEvent) {
-        use ConnectivityEvent::{PeerBanned, PeerDisconnected};
-        match event {
-            PeerDisconnected(node_id) | PeerBanned(node_id) => {
-                if let Some(pos) = self.peer_chain_metadata.iter().position(|p| *p.node_id() == node_id) {
-                    debug!(
-                        target: LOG_TARGET,
-                        "Removing disconnected/banned peer `{}` from chain metadata list ", node_id
-                    );
-                    self.peer_chain_metadata.remove(pos);
-                }
-            },
-            _ => {},
         }
     }
 
@@ -166,8 +138,7 @@ impl ChainMetadataService {
                 );
                 self.number_of_rounds_no_pings = 0;
                 if event.metadata.has(MetadataKey::ChainMetadata) {
-                    self.collect_chain_state_from_ping_pong(event)?;
-                    self.send_chain_metadata_to_event_publisher().await?;
+                    self.send_chain_metadata_to_event_publisher(event).await?;
                 }
             },
             // Received a pong, check if our neighbour sent it and it contains ChainMetadata
@@ -179,8 +150,7 @@ impl ChainMetadataService {
                 );
                 self.number_of_rounds_no_pings = 0;
                 if event.metadata.has(MetadataKey::ChainMetadata) {
-                    self.collect_chain_state_from_ping_pong(event)?;
-                    self.send_chain_metadata_to_event_publisher().await?;
+                    self.send_chain_metadata_to_event_publisher(event).await?;
                 }
             },
             // New ping round has begun
@@ -197,10 +167,6 @@ impl ChainMetadataService {
                         self.number_of_rounds_no_pings = 0;
                     }
                 }
-                // Ensure that we're waiting for the correct amount of peers to respond
-                // and have allocated space for their replies
-
-                self.resize_chainstate_buffer(*num_peers);
             },
         }
 
@@ -212,31 +178,10 @@ impl ChainMetadataService {
         Ok(())
     }
 
-    async fn send_chain_metadata_to_event_publisher(&mut self) -> Result<(), ChainMetadataSyncError> {
-        // send only fails if there are no subscribers.
-        let _size = self
-            .event_publisher
-            .send(Arc::new(ChainMetadataEvent::PeerChainMetadataReceived(
-                self.peer_chain_metadata.clone(),
-            )));
-
-        Ok(())
-    }
-
-    fn resize_chainstate_buffer(&mut self, n: usize) {
-        match self.peer_chain_metadata.capacity() {
-            cap if n > cap => {
-                let additional = n - self.peer_chain_metadata.len();
-                self.peer_chain_metadata.reserve_exact(additional);
-            },
-            cap if n < cap => {
-                self.peer_chain_metadata.shrink_to(cap);
-            },
-            _ => {},
-        }
-    }
-
-    fn collect_chain_state_from_ping_pong(&mut self, event: &PingPongEvent) -> Result<(), ChainMetadataSyncError> {
+    async fn send_chain_metadata_to_event_publisher(
+        &mut self,
+        event: &PingPongEvent,
+    ) -> Result<(), ChainMetadataSyncError> {
         let chain_metadata_bytes = event
             .metadata
             .get(MetadataKey::ChainMetadata)
@@ -252,19 +197,15 @@ impl ChainMetadataService {
             chain_metadata.accumulated_difficulty().to_formatted_string(&Locale::en),
         );
 
-        if let Some(pos) = self
-            .peer_chain_metadata
-            .iter()
-            .position(|peer_chainstate| *peer_chainstate.node_id() == event.node_id)
-        {
-            self.peer_chain_metadata.remove(pos);
-        }
+        let peer_chain_metadata = PeerChainMetadata::new(event.node_id.clone(), chain_metadata, event.latency);
 
-        self.peer_chain_metadata.push(PeerChainMetadata::new(
-            event.node_id.clone(),
-            chain_metadata,
-            event.latency,
-        ));
+        // send only fails if there are no subscribers.
+        let _size = self
+            .event_publisher
+            .send(Arc::new(ChainMetadataEvent::PeerChainMetadataReceived(
+                peer_chain_metadata,
+            )));
+
         Ok(())
     }
 }
@@ -274,13 +215,7 @@ mod test {
     use std::convert::TryInto;
 
     use futures::StreamExt;
-    use tari_comms::{
-        peer_manager::NodeId,
-        test_utils::{
-            mocks::{create_connectivity_mock, ConnectivityManagerMockState},
-            node_identity::build_many_node_identities,
-        },
-    };
+    use tari_comms::peer_manager::NodeId;
     use tari_p2p::services::liveness::{
         mock::{create_p2p_liveness_mock, LivenessMockState},
         LivenessRequest,
@@ -323,33 +258,24 @@ mod test {
     fn setup() -> (
         ChainMetadataService,
         LivenessMockState,
-        ConnectivityManagerMockState,
         reply_channel::TryReceiver<NodeCommsRequest, NodeCommsResponse, CommsInterfaceError>,
+        broadcast::Receiver<Arc<ChainMetadataEvent>>,
     ) {
         let (liveness_handle, mock, _) = create_p2p_liveness_mock(1);
         let liveness_mock_state = mock.get_mock_state();
         task::spawn(mock.run());
 
         let (base_node, base_node_receiver) = create_base_node_nci();
-        let (publisher, _) = broadcast::channel(1);
+        let (publisher, event_rx) = broadcast::channel(10);
 
-        let (connectivity, mock) = create_connectivity_mock();
-        let connectivity_mock_state = mock.get_shared_state();
-        task::spawn(mock.run());
+        let service = ChainMetadataService::new(liveness_handle, base_node, publisher);
 
-        let service = ChainMetadataService::new(liveness_handle, base_node, connectivity, publisher);
-
-        (
-            service,
-            liveness_mock_state,
-            connectivity_mock_state,
-            base_node_receiver,
-        )
+        (service, liveness_mock_state, base_node_receiver, event_rx)
     }
 
     #[tokio::test]
     async fn update_liveness_chain_metadata() {
-        let (mut service, liveness_mock_state, _, mut base_node_receiver) = setup();
+        let (mut service, liveness_mock_state, mut base_node_receiver, _) = setup();
 
         let mut proto_chain_metadata = create_sample_proto_chain_metadata();
         proto_chain_metadata.height_of_longest_chain = Some(123);
@@ -375,7 +301,7 @@ mod test {
     }
     #[tokio::test]
     async fn handle_liveness_event_ok() {
-        let (mut service, _, _, _) = setup();
+        let (mut service, _, _, mut events_rx) = setup();
 
         let mut metadata = Metadata::new();
         let proto_chain_metadata = create_sample_proto_chain_metadata();
@@ -388,13 +314,9 @@ mod test {
             latency: None,
         };
 
-        // To prevent the chain metadata buffer being flushed after receiving a single pong event,
-        // extend it's capacity to 2
-        service.peer_chain_metadata.reserve_exact(2);
         let sample_event = LivenessEvent::ReceivedPong(Box::new(pong_event));
         service.handle_liveness_event(&sample_event).await.unwrap();
-        assert_eq!(service.peer_chain_metadata.len(), 1);
-        let metadata = service.peer_chain_metadata.remove(0);
+        let metadata = events_rx.recv().await.unwrap().peer_metadata().unwrap();
         assert_eq!(*metadata.node_id(), node_id);
         assert_eq!(
             metadata.claimed_chain_metadata().height_of_longest_chain(),
@@ -403,42 +325,8 @@ mod test {
     }
 
     #[tokio::test]
-    async fn handle_liveness_event_banned_peer() {
-        let (mut service, _, _, _) = setup();
-
-        let mut metadata = Metadata::new();
-        let proto_chain_metadata = create_sample_proto_chain_metadata();
-        metadata.insert(MetadataKey::ChainMetadata, proto_chain_metadata.to_encoded_bytes());
-
-        service.peer_chain_metadata.reserve_exact(3);
-
-        let nodes = build_many_node_identities(2, Default::default());
-        for node in &nodes {
-            let pong_event = PingPongEvent {
-                metadata: metadata.clone(),
-                node_id: node.node_id().clone(),
-                latency: None,
-            };
-
-            let sample_event = LivenessEvent::ReceivedPong(Box::new(pong_event));
-            service.handle_liveness_event(&sample_event).await.unwrap();
-        }
-
-        assert!(service
-            .peer_chain_metadata
-            .iter()
-            .any(|p| p.node_id() == nodes[0].node_id()));
-        service.handle_connectivity_event(ConnectivityEvent::PeerBanned(nodes[0].node_id().clone()));
-        // Check that banned peer was removed
-        assert!(service
-            .peer_chain_metadata
-            .iter()
-            .all(|p| p.node_id() != nodes[0].node_id()));
-    }
-
-    #[tokio::test]
     async fn handle_liveness_event_no_metadata() {
-        let (mut service, _, _, _) = setup();
+        let (mut service, _, _, mut event_rx) = setup();
 
         let metadata = Metadata::new();
         let node_id = NodeId::new();
@@ -450,12 +338,12 @@ mod test {
 
         let sample_event = LivenessEvent::ReceivedPong(Box::new(pong_event));
         service.handle_liveness_event(&sample_event).await.unwrap();
-        assert!(service.peer_chain_metadata.is_empty());
+        assert!(event_rx.try_recv().is_err());
     }
 
     #[tokio::test]
     async fn handle_liveness_event_bad_metadata() {
-        let (mut service, _, _, _) = setup();
+        let (mut service, _, _, mut event_rx) = setup();
 
         let mut metadata = Metadata::new();
         metadata.insert(MetadataKey::ChainMetadata, b"no-good".to_vec());
@@ -469,6 +357,6 @@ mod test {
         let sample_event = LivenessEvent::ReceivedPong(Box::new(pong_event));
         let err = service.handle_liveness_event(&sample_event).await.unwrap_err();
         unpack_enum!(ChainMetadataSyncError::DecodeError(_err) = err);
-        assert_eq!(service.peer_chain_metadata.len(), 0);
+        assert!(event_rx.try_recv().is_err());
     }
 }

--- a/base_layer/core/src/base_node/state_machine_service/states/listening.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/listening.rs
@@ -134,58 +134,26 @@ impl Listening {
                         debug!(target: LOG_TARGET, "Initial sync achieved");
                     }
                 },
-                Ok(ChainMetadataEvent::PeerChainMetadataReceived(peer_metadata_list)) => {
-                    // Convert a &Vec<..> to a Vec<&..> without copying each element
-                    let mut peer_metadata_list = peer_metadata_list.iter().collect::<Vec<_>>();
-
-                    // lets update the peer data from the chain meta data
-                    for peer in &peer_metadata_list {
-                        let peer_data = PeerMetadata {
-                            metadata: peer.claimed_chain_metadata().clone(),
-                            last_updated: EpochTime::now(),
-                        };
-                        // If this fails, its not the end of the world, we just want to keep record of the stats of
-                        // the peer
-                        let _old_data = shared
-                            .peer_manager
-                            .set_peer_metadata(peer.node_id(), 1, peer_data.to_bytes())
-                            .await;
-                        log_mdc::extend(mdc.clone());
-                    }
+                Ok(ChainMetadataEvent::PeerChainMetadataReceived(peer_metadata)) => {
+                    let peer_data = PeerMetadata {
+                        metadata: peer_metadata.claimed_chain_metadata().clone(),
+                        last_updated: EpochTime::now(),
+                    };
+                    // If this fails, its not the end of the world, we just want to keep record of the stats of
+                    // the peer
+                    let _old_data = shared
+                        .peer_manager
+                        .set_peer_metadata(peer_metadata.node_id(), 1, peer_data.to_bytes())
+                        .await;
+                    log_mdc::extend(mdc.clone());
 
                     let configured_sync_peers = &shared.config.blockchain_sync_config.forced_sync_peers;
                     if !configured_sync_peers.is_empty() {
                         // If a _forced_ set of sync peers have been specified, ignore other peers when determining if
                         // we're out of sync
-                        peer_metadata_list.retain(|p| configured_sync_peers.contains(p.node_id()));
-                    };
-
-                    // If ther peer metadata list is empty, there is nothing to do except stay in listening
-                    if peer_metadata_list.is_empty() {
-                        debug!(
-                            target: LOG_TARGET,
-                            "No peer metadata to check. Continuing in listening state.",
-                        );
-
-                        if !self.is_synced {
-                            debug!(target: LOG_TARGET, "Initial sync achieved");
-                            self.is_synced = true;
-                            shared.set_state_info(StateInfo::Listening(ListeningInfo::new(true)));
-                        }
-                        continue;
-                    }
-
-                    // Find the best network metadata and set of sync peers with the best tip.
-                    let best_metadata = match best_claimed_metadata(&peer_metadata_list) {
-                        Some(m) => m,
-                        None => {
-                            debug!(
-                                target: LOG_TARGET,
-                                "No better metadata advertised for {} peer(s)",
-                                peer_metadata_list.len()
-                            );
+                        if !configured_sync_peers.contains(peer_metadata.node_id()) {
                             continue;
-                        },
+                        }
                     };
 
                     let local = match shared.db.get_chain_metadata().await {
@@ -199,7 +167,8 @@ impl Listening {
                     // If this node is just one block behind, wait for block propagation before
                     // rushing to sync mode
                     if self.is_synced &&
-                        best_metadata.height_of_longest_chain() == local.height_of_longest_chain() + 1 &&
+                        peer_metadata.claimed_chain_metadata().height_of_longest_chain() ==
+                            local.height_of_longest_chain() + 1 &&
                         time_since_better_block
                             .map(|ts: Instant| ts.elapsed() < ONE_BLOCK_BEHIND_WAIT_PERIOD)
                             .unwrap_or(true)
@@ -210,18 +179,11 @@ impl Listening {
                         debug!(
                             target: LOG_TARGET,
                             "This node is one block behind. Best network metadata is at height {}.",
-                            best_metadata.height_of_longest_chain()
+                            peer_metadata.claimed_chain_metadata().height_of_longest_chain()
                         );
                         continue;
                     }
                     time_since_better_block = None;
-
-                    // If we have configured sync peers, they are already filtered at this point
-                    let sync_peers = if configured_sync_peers.is_empty() {
-                        select_sync_peers(best_metadata, &peer_metadata_list)
-                    } else {
-                        peer_metadata_list
-                    };
 
                     let local_metadata = match shared.db.get_chain_metadata().await {
                         Ok(m) => m,
@@ -234,8 +196,7 @@ impl Listening {
                     let sync_mode = determine_sync_mode(
                         shared.config.blocks_behind_before_considered_lagging,
                         &local_metadata,
-                        best_metadata,
-                        sync_peers,
+                        peer_metadata,
                     );
 
                     if sync_mode.is_lagging() {
@@ -294,50 +255,18 @@ impl From<DecideNextSync> for Listening {
     }
 }
 
-// Finds the set of sync peers that have the best tip on their main chain and have all the data required to update the
-// local node.
-fn select_sync_peers<'a>(
-    best_metadata: &ChainMetadata,
-    peer_metadata_list: &[&'a PeerChainMetadata],
-) -> Vec<&'a PeerChainMetadata> {
-    peer_metadata_list
-        .iter()
-        // Check if the peer can provide blocks higher than the local tip height
-        .filter(|peer| {
-            peer.claimed_chain_metadata().best_block() == best_metadata.best_block()
-        })
-        // &T is a Copy type
-        .copied()
-        .collect()
-}
-
-/// Determine the best metadata claimed from a set of metadata received from the network.
-fn best_claimed_metadata<'a>(metadata_list: &[&'a PeerChainMetadata]) -> Option<&'a ChainMetadata> {
-    metadata_list
-        .iter()
-        .map(|c| c.claimed_chain_metadata())
-        .fold(None, |best, current| {
-            if current.accumulated_difficulty() >= best.map(|cm| cm.accumulated_difficulty()).unwrap_or(0) {
-                Some(current)
-            } else {
-                best
-            }
-        })
-}
-
 /// Given a local and the network chain state respectively, figure out what synchronisation state we should be in.
 fn determine_sync_mode(
     blocks_behind_before_considered_lagging: u64,
     local: &ChainMetadata,
-    network: &ChainMetadata,
-    sync_peers: Vec<&PeerChainMetadata>,
+    network: &PeerChainMetadata,
 ) -> SyncStatus {
     use SyncStatus::{Lagging, UpToDate};
-    let network_tip_accum_difficulty = network.accumulated_difficulty();
+    let network_tip_accum_difficulty = network.claimed_chain_metadata().accumulated_difficulty();
     let local_tip_accum_difficulty = local.accumulated_difficulty();
     if local_tip_accum_difficulty < network_tip_accum_difficulty {
         let local_tip_height = local.height_of_longest_chain();
-        let network_tip_height = network.height_of_longest_chain();
+        let network_tip_height = network.claimed_chain_metadata().height_of_longest_chain();
         info!(
             target: LOG_TARGET,
             "Our local blockchain accumulated difficulty is a little behind that of the network. We're at block #{} \
@@ -364,12 +293,19 @@ fn determine_sync_mode(
 
         debug!(
             target: LOG_TARGET,
-            "Lagging (local height = {}, network height = {})", local_tip_height, network_tip_height
+            "Lagging (local height = {}, network height = {}, peer = {} ({}))",
+            local_tip_height,
+            network_tip_height,
+            network.node_id(),
+            network
+                .latency()
+                .map(|l| format!("{:.2?}", l))
+                .unwrap_or_else(|| "unknown".to_string())
         );
         Lagging {
             local: local.clone(),
-            network: network.clone(),
-            sync_peers: sync_peers.into_iter().cloned().map(Into::into).collect(),
+            network: network.claimed_chain_metadata().clone(),
+            sync_peers: vec![network.clone().into()],
         }
     } else {
         debug!(
@@ -384,7 +320,7 @@ fn determine_sync_mode(
             },
             local.height_of_longest_chain(),
             local_tip_accum_difficulty.to_formatted_string(&Locale::en),
-            network.height_of_longest_chain(),
+            network.claimed_chain_metadata().height_of_longest_chain(),
             network_tip_accum_difficulty.to_formatted_string(&Locale::en),
         );
         UpToDate
@@ -393,8 +329,6 @@ fn determine_sync_mode(
 
 #[cfg(test)]
 mod test {
-    use std::convert::TryInto;
-
     use rand::rngs::OsRng;
     use tari_common_types::types::FixedHash;
     use tari_comms::{peer_manager::NodeId, types::CommsPublicKey};
@@ -408,153 +342,40 @@ mod test {
     }
 
     #[test]
-    fn sync_peer_selection() {
-        let network_tip_height = 5000;
-        let block_hash1: FixedHash = vec![
+    fn test_determine_sync_mode() {
+        const NETWORK_TIP_HEIGHT: u64 = 5000;
+        let block_hash = FixedHash::from([
             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28,
             29, 30, 31,
-        ]
-        .try_into()
-        .unwrap();
-        let block_hash2: FixedHash = vec![
-            1, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28,
-            29, 30, 31,
-        ]
-        .try_into()
-        .unwrap();
-        let accumulated_difficulty1 = 200000;
-        let accumulated_difficulty2 = 100000;
+        ]);
+        const ACCUMULATED_DIFFICULTY: u128 = 10000;
 
-        let mut peer_metadata_list = Vec::new();
-        let best_network_metadata = best_claimed_metadata(&peer_metadata_list);
-        assert!(best_network_metadata.is_none());
-        let best_network_metadata = ChainMetadata::empty();
-        assert_eq!(
-            best_network_metadata,
-            ChainMetadata::new(0, FixedHash::zero(), 0, 0, 0, 0)
-        );
-        let sync_peers = select_sync_peers(&best_network_metadata, &peer_metadata_list);
-        assert_eq!(sync_peers.len(), 0);
-
-        let node_id1 = random_node_id();
-        let node_id2 = random_node_id();
-        let node_id3 = random_node_id();
-        let node_id4 = random_node_id();
-        let node_id5 = random_node_id();
-        // Archival node
-        let peer1 = PeerChainMetadata::new(
-            node_id1.clone(),
-            ChainMetadata::new(network_tip_height, block_hash1, 0, 0, accumulated_difficulty1, 0),
+        let archival_node = PeerChainMetadata::new(
+            random_node_id(),
+            ChainMetadata::new(NETWORK_TIP_HEIGHT, block_hash, 0, 0, ACCUMULATED_DIFFICULTY, 0),
             None,
         );
 
-        // Pruning horizon is to short to sync from
-        let peer2 = PeerChainMetadata::new(
-            node_id2,
+        let behind_node = PeerChainMetadata::new(
+            random_node_id(),
             ChainMetadata::new(
-                network_tip_height,
-                block_hash1,
-                500,
-                5000 - 500,
-                accumulated_difficulty1,
+                NETWORK_TIP_HEIGHT - 1,
+                block_hash,
+                0,
+                0,
+                ACCUMULATED_DIFFICULTY - 1000,
                 0,
             ),
             None,
         );
 
-        let peer3 = PeerChainMetadata::new(
-            node_id3.clone(),
-            ChainMetadata::new(
-                network_tip_height,
-                block_hash1,
-                1440,
-                5000 - 1440,
-                accumulated_difficulty1,
-                0,
-            ),
-            None,
-        );
-        let peer4 = PeerChainMetadata::new(
-            node_id4,
-            ChainMetadata::new(
-                network_tip_height,
-                block_hash2,
-                2880,
-                5000 - 2880,
-                accumulated_difficulty2,
-                0,
-            ),
-            None,
-        );
-        // Node running a fork
-        let peer5 = PeerChainMetadata::new(
-            node_id5.clone(),
-            ChainMetadata::new(
-                network_tip_height,
-                block_hash1,
-                2880,
-                5000 - 2880,
-                accumulated_difficulty1,
-                0,
-            ),
-            None,
-        );
-        peer_metadata_list.push(&peer1);
-        peer_metadata_list.push(&peer2);
-        peer_metadata_list.push(&peer3);
-        peer_metadata_list.push(&peer4);
-        peer_metadata_list.push(&peer5);
+        let sync_mode = determine_sync_mode(0, archival_node.claimed_chain_metadata(), &behind_node);
+        assert!(sync_mode.is_up_to_date());
 
-        let best_network_metadata = best_claimed_metadata(peer_metadata_list.as_slice()).unwrap();
-        assert_eq!(best_network_metadata.height_of_longest_chain(), network_tip_height);
-        assert_eq!(best_network_metadata.best_block(), &block_hash1);
-        assert_eq!(best_network_metadata.accumulated_difficulty(), accumulated_difficulty1);
-        let sync_peers = select_sync_peers(best_network_metadata, &peer_metadata_list);
-        assert_eq!(sync_peers.len(), 4);
-        sync_peers.iter().find(|p| *p.node_id() == node_id1).unwrap();
-        sync_peers.iter().find(|p| *p.node_id() == node_id3).unwrap();
-        sync_peers.iter().find(|p| *p.node_id() == node_id5).unwrap();
-    }
+        let sync_mode = determine_sync_mode(1, behind_node.claimed_chain_metadata(), &archival_node);
+        assert!(sync_mode.is_lagging());
 
-    #[test]
-    fn sync_mode_selection() {
-        let local = ChainMetadata::new(0, FixedHash::zero(), 0, 0, 500_000, 0);
-        match determine_sync_mode(0, &local, &local, vec![]) {
-            SyncStatus::UpToDate => {},
-            _ => panic!(),
-        }
-
-        let network = ChainMetadata::new(0, FixedHash::zero(), 0, 0, 499_000, 0);
-        match determine_sync_mode(0, &local, &network, vec![]) {
-            SyncStatus::UpToDate => {},
-            _ => panic!(),
-        }
-
-        let network = ChainMetadata::new(0, FixedHash::zero(), 0, 0, 500_001, 0);
-        match determine_sync_mode(0, &local, &network, vec![]) {
-            SyncStatus::Lagging { network: n, .. } => assert_eq!(n, network),
-            _ => panic!(),
-        }
-
-        let local = ChainMetadata::new(100, FixedHash::zero(), 50, 50, 500_000, 0);
-        let network = ChainMetadata::new(150, FixedHash::zero(), 0, 0, 500_001, 0);
-        match determine_sync_mode(0, &local, &network, vec![]) {
-            SyncStatus::Lagging { network: n, .. } => assert_eq!(n, network),
-            _ => panic!(),
-        }
-
-        let local = ChainMetadata::new(0, FixedHash::zero(), 50, 50, 500_000, 0);
-        let network = ChainMetadata::new(100, FixedHash::zero(), 0, 0, 500_001, 0);
-        match determine_sync_mode(0, &local, &network, vec![]) {
-            SyncStatus::Lagging { network: n, .. } => assert_eq!(n, network),
-            _ => panic!(),
-        }
-
-        let local = ChainMetadata::new(99, FixedHash::zero(), 50, 50, 500_000, 0);
-        let network = ChainMetadata::new(150, FixedHash::zero(), 0, 0, 500_001, 0);
-        match determine_sync_mode(0, &local, &network, vec![]) {
-            SyncStatus::Lagging { network: n, .. } => assert_eq!(n, network),
-            _ => panic!(),
-        }
+        let sync_mode = determine_sync_mode(2, behind_node.claimed_chain_metadata(), &archival_node);
+        assert!(sync_mode.is_up_to_date());
     }
 }


### PR DESCRIPTION
Description
---
- Removes "caching" of peer metadata
- Send only one peer chain metadata at a time to the listening state
- increase chain metadata event channel to 20 (so that 20 of the last chain metadata received can be read by listening)

Motivation and Context
---
Fixes #5037 and #5030 (needs to be confirmed since this case is not easy to reproduce)

What I've observed is that the peer is banned twice. The first time, for 30 minutes (between 04:07:23.802123900 and 2022-12-09 04:41:26.365429300) then again permanently (bad metadata sig). It's clear in the logs that the pong is received before being banned, the node is banned (chain metadata service clears the peer's metadata) but the message is already in the domain pipeline so another one is received. The chain metadata service now keeps the peer's chain metadata and sends it to the listening state every time because it is not cleared.

TL;DR classic race condition.

Order of events:

- peer is banned for 30 minutes
- peer ban expires
- we receive a ping from the peer
- at almost the same time peer is banned (see logs in [this comment](https://github.com/tari-project/tari/issues/5030#issuecomment-1344335004))
- chain metadata service clears the peer from peer_chain_metadata
- the ping/pong is received (already in the pipeline from before the ban)
- the chain metadata is added to the vec, and is never cleared (because the peer is not banned again)
- the peer stays in the list despite being banned and NOT connected, so the header sync continues to try to connect to it


How Has This Been Tested?
---
Manually: rewind-blockchain and sync, enters sync mode timeously
Removed some tests that test removed functions
Added a new unit test for determine_sync_state
