### PR TITLE
fix(core): fix build issues and add ban check listening

### DIFF
--- a/base_layer/core/src/base_node/state_machine_service/states/listening.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/listening.rs
@@ -135,6 +135,20 @@ impl Listening {
                     }
                 },
                 Ok(ChainMetadataEvent::PeerChainMetadataReceived(peer_metadata)) => {
+                    match shared.peer_manager.is_peer_banned(peer_metadata.node_id()).await {
+                        Ok(true) => {
+                            warn!(
+                                target: LOG_TARGET,
+                                "Ignoring chain metadata from banned peer {}",
+                                peer_metadata.node_id()
+                            );
+                            continue;
+                        },
+                        Ok(false) => {},
+                        Err(e) => {
+                            return FatalError(format!("Error checking if peer is banned: {}", e));
+                        },
+                    }
                     let peer_data = PeerMetadata {
                         metadata: peer_metadata.claimed_chain_metadata().clone(),
                         last_updated: EpochTime::now(),

--- a/base_layer/core/tests/helpers/chain_metadata.rs
+++ b/base_layer/core/tests/helpers/chain_metadata.rs
@@ -64,7 +64,7 @@ impl MockChainMetadata {
         metadata: &ChainMetadata,
     ) -> Result<usize, Arc<ChainMetadataEvent>> {
         let data = PeerChainMetadata::new(id.clone(), metadata.clone(), None);
-        self.publish_event(ChainMetadataEvent::PeerChainMetadataReceived(vec![data]))
+        self.publish_event(ChainMetadataEvent::PeerChainMetadataReceived(data))
     }
 }
 

--- a/base_layer/core/tests/helpers/chain_metadata.rs
+++ b/base_layer/core/tests/helpers/chain_metadata.rs
@@ -20,14 +20,11 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{convert::TryInto, sync::Arc};
+use std::sync::Arc;
 
-use blake2::Digest;
 use tari_common_types::chain_metadata::ChainMetadata;
 use tari_comms::peer_manager::NodeId;
 use tari_core::base_node::chain_metadata_service::{ChainMetadataEvent, ChainMetadataHandle, PeerChainMetadata};
-use tari_crypto::hash::blake2::Blake256;
-use tari_utilities::ByteArray;
 use tokio::sync::broadcast;
 
 /// Create a mock Chain Metadata stream.
@@ -66,13 +63,4 @@ impl MockChainMetadata {
         let data = PeerChainMetadata::new(id.clone(), metadata.clone(), None);
         self.publish_event(ChainMetadataEvent::PeerChainMetadataReceived(data))
     }
-}
-
-#[allow(dead_code)]
-pub fn random_peer_metadata(height: u64, difficulty: u128) -> PeerChainMetadata {
-    let key: Vec<u8> = (0..13).map(|_| rand::random::<u8>()).collect();
-    let id = NodeId::from_key(&key);
-    let block_hash = Blake256::digest(id.as_bytes()).to_vec().try_into().unwrap();
-    let metadata = ChainMetadata::new(height, block_hash, 2800, 0, difficulty, 0);
-    PeerChainMetadata::new(id, metadata, None)
 }


### PR DESCRIPTION
Description
---
- adds check for peer banning in the listening state
- fix build/test error in #5039 

Motivation and Context
---
Do one final check that the peer is not banned before processing chain metadata in the listening state (can happen due to race conditions)
Fix test failure

How Has This Been Tested?
---

