### PR TITLE
fix(ci): pin ci to ubuntu 20.04

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -31,7 +31,7 @@ env:
 jobs:
   cucumber_tests:
     name: Cucumber tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
         uses: actions/checkout@v3


### PR DESCRIPTION
Description
Pin CI to ubuntu 20.04

Motivation and Context
Get CI running again with least amount of change


