### PR TITLE
chore: ci nightly should run on nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
       - name: toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{ env.toolchain }}
+          toolchain: nightly
           profile: minimal
           override: true
       - name: ubuntu dependencies


### PR DESCRIPTION
Description
---
This make the nightly CI job run on the actual nightly build.

Motivation and Context
---
Sure as heck makes naming less confusing.


How Has This Been Tested?
---
- [x] CI, running the nightly job on nightly _as expected_
