### PR TITLE
feat: add cucumber utils for mining blocks and arrive at height

### DIFF
--- a/integration_tests/tests/cucumber.rs
+++ b/integration_tests/tests/cucumber.rs
@@ -29,9 +29,11 @@ use std::{
     ops::DerefMut,
     path::{Path, PathBuf},
     sync::Arc,
+    thread::sleep,
     time::Duration,
 };
 
+use anyhow::bail;
 use async_trait::async_trait;
 use cucumber::{given, then, when, writer, World as _, WriterExt as _};
 use indexmap::IndexMap;
@@ -151,11 +153,6 @@ async fn create_miner(world: &mut TariWorld, miner_name: String, bn_name: String
     register_miner_process(world, miner_name, bn_name, wallet_name);
 }
 
-#[when(expr = "miner {word} mines {int} new blocks")]
-async fn run_miner(world: &mut TariWorld, miner_name: String, num_blocks: u64) {
-    mine_blocks(world, miner_name, num_blocks).await;
-}
-
 #[when(expr = "I wait {int} seconds")]
 async fn wait_seconds(_world: &mut TariWorld, seconds: u64) {
     tokio::time::sleep(Duration::from_secs(seconds)).await;
@@ -186,6 +183,50 @@ async fn node_pending_connection_to(
     }
 
     panic!("Peer was not connected in time");
+}
+
+#[when(expr = "mining node {word} mines {int} blocks")]
+#[given(expr = "mining node {word} mines {int} blocks")]
+async fn run_miner(world: &mut TariWorld, miner_name: String, num_blocks: u64) {
+    mine_blocks(world, miner_name, num_blocks).await;
+}
+
+#[then(expr = "all nodes are at height {int}")]
+#[when(expr = "all nodes are at height {int}")]
+async fn all_nodes_are_at_height(world: &mut TariWorld, height: u64) -> anyhow::Result<()> {
+    let base_node_pxs = world
+        .base_nodes
+        .iter()
+        .map(|(_, bn)| bn)
+        .collect::<Vec<_>>();
+
+    let num_retries = 100;
+    let mut already_sync = true;
+
+    for retry in 0..num_retries {
+        for bn in &base_node_pxs {
+            let mut bn_cli = bn.get_grpc_client().await?;
+            let chain_tip = bn_cli.get_tip_info(Empty {}).await?.into_inner();
+            let chain_hgt = chain_tip.metadata.unwrap().height_of_longest_chain;
+
+            if chain_hgt < height { 
+                already_sync = false;
+            }
+        }
+
+        if already_sync {
+            return Ok(());
+        }
+
+        already_sync = true;
+        tokio::time::sleep(Duration::from_secs(5));
+    }
+
+    if !already_sync {
+        bail!("base nodes not successfully synchronized at height {}", height);
+    }
+
+    Ok(())
 }
 
 #[when(expr = "I print the cucumber world")]


### PR DESCRIPTION
Description
---
To set up cucumber tests successfully, we need to be able to execute the following steps:

```
mining node {word} mines {int} blocks
all nodes are at height {int}
```

This PR implements the underlying logic in Rust.

Motivation and Context
---

How Has This Been Tested?
---

