### PR TITLE
fix: add further cucumber utils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5468,7 +5468,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tari_app_grpc",
- "tari_app_utilities",
  "tari_base_node",
  "tari_base_node_grpc_client",
  "tari_common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,9 +99,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.66"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
+checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
 
 [[package]]
 name = "arc-swap"
@@ -116,7 +116,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db4ce4441f99dbd377ca8a8f57b698c44d0d6e712d8329b5040da5a64aa1ce73"
 dependencies = [
  "base64ct",
- "blake2 0.10.5",
+ "blake2 0.10.6",
  "password-hash",
 ]
 
@@ -155,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.59"
+version = "0.1.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e6e93155431f3931513b243d371981bb2770112b370c82745a1d19d2f99364"
+checksum = "677d1d8ab452a3936018a687b20e6f7cf5363d713b732b8884001317b0e48aa3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -204,7 +204,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "itoa 1.0.4",
+ "itoa 1.0.5",
  "matchit",
  "memchr",
  "mime",
@@ -378,9 +378,9 @@ dependencies = [
 
 [[package]]
 name = "blake2"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b12e5fd123190ce1c2e559308a94c9bacad77907d4c6005d9e58fe1a0689e55e"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
  "digest 0.10.6",
 ]
@@ -621,9 +621,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.77"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f73505338f7d905b19d18738976aae232eb46b8efc15554ffc56deb5d9ebe4"
+checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
 
 [[package]]
 name = "cexpr"
@@ -1430,13 +1430,14 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.0.0-pre.1"
+version = "4.0.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4033478fbf70d6acf2655ac70da91ee65852d69daf7a67bf7a2f518fb47aafcf"
+checksum = "67bc65846be335cb20f4e52d49a437b773a2c1fdb42b19fc84e79e6f6771536f"
 dependencies = [
- "byteorder",
- "digest 0.9.0",
- "rand_core 0.6.4",
+ "cfg-if",
+ "fiat-crypto",
+ "packed_simd_2",
+ "platforms",
  "subtle",
  "zeroize",
 ]
@@ -1457,9 +1458,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.83"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdf07d07d6531bfcdbe9b8b739b104610c6508dcc4d63b410585faf338241daf"
+checksum = "5add3fc1717409d029b20c5b6903fc0c0b02fa6741d820054f4a2efa5e5816fd"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -1469,9 +1470,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.83"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2eb5b96ecdc99f72657332953d4d9c50135af1bac34277801cc3937906ebd39"
+checksum = "b4c87959ba14bc6fbc61df77c3fcfe180fc32b93538c4f1031dd802ccb5f2ff0"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -1484,15 +1485,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.83"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac040a39517fd1674e0f32177648334b0f4074625b5588a64519804ba0553b12"
+checksum = "69a3e162fde4e594ed2b07d0f83c6c67b745e7f28ce58c6df5e6b6bef99dfb59"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.83"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1362b0ddcfc4eb0a1f57b68bd77dd99f0e826958a96abd0ae9bd092e114ffed6"
+checksum = "3e7e2adeb6a0d4a282e581096b06e1791532b7d576dcde5ccd9382acf55db8e6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1536,9 +1537,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.3.2"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
+checksum = "23d8666cb01533c39dde32bcbab8e227b4ed6679b2c925eba05feabea39508fb"
 
 [[package]]
 name = "decimal-rs"
@@ -1877,6 +1878,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fiat-crypto"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a214f5bb88731d436478f3ae1f8a277b62124089ba9fb67f4f93fb100ef73c90"
+
+[[package]]
 name = "fixed-hash"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2140,9 +2147,9 @@ dependencies = [
 
 [[package]]
 name = "ghost"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb19fe8de3ea0920d282f7b77dd4227aea6b8b999b42cdf0ca41b2472b14443a"
+checksum = "41973d4c45f7a35af8753ba3457cc99d406d863941fd7f52663cff54a5ab99b3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2323,7 +2330,7 @@ checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
 dependencies = [
  "bytes 1.3.0",
  "fnv",
- "itoa 1.0.4",
+ "itoa 1.0.5",
 ]
 
 [[package]]
@@ -2385,7 +2392,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa 1.0.4",
+ "itoa 1.0.5",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -2574,9 +2581,9 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "inventory"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e21e0a36a4dc4b469422ee17f715e8313f4a637675656d6a13637954278c6f55"
+checksum = "16fe3b35d64bd1f72917f06425e7573a2f63f74f42c8f56e53ea6826dde3a2b5"
 dependencies = [
  "ctor",
  "ghost",
@@ -2594,9 +2601,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.5.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f88c5561171189e69df9d98bcf18fd5f9558300f7ea7b801eb8a0fd748bd8745"
+checksum = "11b0d96e660696543b251e58030cf9787df56da39dab19ad60eae7353040917e"
 
 [[package]]
 name = "is-terminal"
@@ -2636,9 +2643,9 @@ checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
+checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
 name = "js-sys"
@@ -2818,9 +2825,9 @@ dependencies = [
 
 [[package]]
 name = "link-cplusplus"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9272ab7b96c9046fbc5bc56c06c117cb639fe2d509df0c421cad82d2915cf369"
+checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
 dependencies = [
  "cc",
 ]
@@ -2833,9 +2840,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f9f08d8963a6c613f4b1a78f4f4a4dbfadf8e6545b2d72861731e4858b8b47f"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "lmdb-zero"
@@ -3273,7 +3280,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
 dependencies = [
  "arrayvec",
- "itoa 1.0.4",
+ "itoa 1.0.5",
 ]
 
 [[package]]
@@ -3348,9 +3355,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.43"
+version = "0.10.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020433887e44c27ff16365eaa2d380547a94544ad509aff6eb5b6e3e0b27b376"
+checksum = "29d971fd5722fec23977260f6e81aa67d2f22cadbdc2aa049f1022d9a3be1566"
 dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
@@ -3389,9 +3396,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.78"
+version = "0.9.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07d5c8cb6e57b3a3612064d7b18b117912b4ce70955c2504d4b741c9e244b132"
+checksum = "5454462c0eced1e97f2ec09036abc8da362e66802f66fd20f86854d9d8cbcbc4"
 dependencies = [
  "autocfg",
  "cc",
@@ -3444,7 +3451,7 @@ checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
- "parking_lot_core 0.8.5",
+ "parking_lot_core 0.8.6",
 ]
 
 [[package]]
@@ -3459,9 +3466,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
 dependencies = [
  "cfg-if",
  "instant",
@@ -3755,6 +3762,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
+name = "platforms"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d7ddaed09e0eb771a79ab0fd64609ba0afb0a8366421957936ad14cbd13630"
+
+[[package]]
 name = "plotters"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3867,9 +3880,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
 dependencies = [
  "unicode-ident",
 ]
@@ -3966,9 +3979,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
 ]
@@ -4116,11 +4129,10 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e060280438193c554f654141c9ea9417886713b7acd75974c85b18a69a88e0b"
+checksum = "6db3a213adf02b3bcfd2d3846bb41cb22857d131789e01df434fb7e7bc0759b7"
 dependencies = [
- "crossbeam-deque",
  "either",
  "rayon-core",
 ]
@@ -4335,9 +4347,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.4"
+version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb93e85278e08bb5788653183213d3a60fc242b10cb9be96586f5a73dcb67c23"
+checksum = "a3807b5d10909833d3e9acd1eb5fb988f79376ff10fce42937de71a449c4c588"
 dependencies = [
  "bitflags 1.3.2",
  "errno",
@@ -4379,9 +4391,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
+checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
 
 [[package]]
 name = "rustyline"
@@ -4419,9 +4431,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
 
 [[package]]
 name = "safemem"
@@ -4471,9 +4483,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scratch"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
+checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
 
 [[package]]
 name = "sct"
@@ -4534,15 +4546,15 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.14"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
+checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
 
 [[package]]
 name = "serde"
-version = "1.0.149"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "256b9932320c590e707b94576e3cc1f7c9024d0ee6612dfbcf1cb106cbe8e055"
+checksum = "97fed41fc1a24994d044e6db6935e69511a1153b52c15eb42493b26fa87feba0"
 dependencies = [
  "serde_derive",
 ]
@@ -4579,9 +4591,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.149"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4eae9b04cbffdfd550eb462ed33bc6a1b68c935127d008b27444d08380f94e4"
+checksum = "255abe9a125a985c05190d687b320c12f9b1f0b99445e608c21ba0782c719ad8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4590,29 +4602,29 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.89"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020ff22c755c2ed3f8cf162dbb41a7268d934702f3ed3631656ea597e08fc3db"
+checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
 dependencies = [
- "itoa 1.0.4",
+ "itoa 1.0.5",
  "ryu",
  "serde",
 ]
 
 [[package]]
 name = "serde_path_to_error"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "184c643044780f7ceb59104cef98a5a6f12cb2288a7bc701ab93a362b49fd47d"
+checksum = "26b04f22b563c91331a10074bda3dd5492e3cc39d56bd557e91c0af42b6c7341"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde_repr"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fe39d9fbb0ebf5eb2c7cb7e2a47e4f462fad1379f1166b8ae49ad9eae89a7ca"
+checksum = "9a5ec9fa74a20ebbe5d9ac23dac1fc96ba0ecfe9f50f2843b52e537b10fbcb4e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4626,7 +4638,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa 1.0.4",
+ "itoa 1.0.5",
  "ryu",
  "serde",
 ]
@@ -4780,9 +4792,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "774d05a3edae07ce6d68ea6984f3c05e9bba8927e3dd591e3b479e5b03213d0d"
 dependencies = [
  "aes-gcm",
- "blake2 0.10.5",
+ "blake2 0.10.6",
  "chacha20poly1305 0.9.1",
- "curve25519-dalek 4.0.0-pre.1",
+ "curve25519-dalek 4.0.0-pre.5",
  "rand_core 0.6.4",
  "rustc_version",
  "sha2 0.10.6",
@@ -4910,9 +4922,9 @@ checksum = "171758edb47aa306a78dfa4ab9aeb5167405bd4e3dc2b64e88f6a84bbe98bd63"
 
 [[package]]
 name = "syn"
-version = "1.0.105"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b9b43d45702de4c839cb9b51d9f529c5dd26a4aff255b42b1ebc03e88ee908"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5178,7 +5190,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bitflags 1.3.2",
- "blake2 0.10.5",
+ "blake2 0.10.6",
  "bytes 1.3.0",
  "chrono",
  "cidr",
@@ -5947,18 +5959,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6048,9 +6060,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.22.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76ce4a75fb488c605c54bf610f221cea8b0dafb53333c1a67e8ee199dcd2ae3"
+checksum = "eab6d665857cc6ca78d6e80303a02cea7a7851e85dfbd77cbdc09bd129f1ef46"
 dependencies = [
  "autocfg",
  "bytes 1.3.0",
@@ -6062,7 +6074,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "winapi",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -6150,9 +6162,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
+checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
 dependencies = [
  "serde",
 ]
@@ -6413,9 +6425,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "ucd-trie"
@@ -6452,9 +6464,9 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
 name = "unicode-linebreak"

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -7,7 +7,6 @@ version = "0.35.1"
 edition = "2018"
 
 [dependencies]
-tari_app_utilities = { path = "../applications/tari_app_utilities" }
 tari_app_grpc = { path = "../applications/tari_app_grpc" }
 tari_base_node_grpc_client = { path = "../clients/rust/base_node_grpc_client" }
 tari_wallet_grpc_client = { path = "../clients/rust/wallet_grpc_client" }

--- a/integration_tests/tests/cucumber.rs
+++ b/integration_tests/tests/cucumber.rs
@@ -26,6 +26,7 @@ use std::{io, path::PathBuf, time::Duration};
 
 use cucumber::{given, then, when, writer, World as _, WriterExt as _};
 use indexmap::IndexMap;
+use tari_app_grpc::tari_rpc::{TransactionKernel, TransactionOutput};
 use tari_base_node_grpc_client::grpc::{Empty, GetBalanceRequest};
 use tari_common::initialize_logging;
 use tari_crypto::tari_utilities::ByteArray;
@@ -33,13 +34,10 @@ use tari_integration_tests::error::GrpcBaseNodeError;
 use thiserror::Error;
 use utils::{
     miner::{
-        coinbase_request,
-        create_block_template_with_coinbase_without_wallet,
-        generate_coinbase,
-        mine_block_without_wallet_with_template,
-        mine_blocks,
         mine_blocks_without_wallet,
+        mine_blocks,
         register_miner_process,
+        mine_block_with_coinbase_on_node,
     },
     wallet_process::spawn_wallet,
 };
@@ -329,19 +327,8 @@ async fn have_wallet_connect_to_seed_node(world: &mut TariWorld, wallet: String,
 }
 
 #[when(expr = "I mine a block on {word} with coinbase {word}")]
-async fn mine_block_with_coinbase_on_node(world: &mut TariWorld, base_node: String, coinbase_name: String) {
-    let mut client = world
-        .base_nodes
-        .get(&base_node)
-        .unwrap()
-        .get_grpc_client()
-        .await
-        .unwrap();
-    let template = create_block_template_with_coinbase_without_wallet(client);
-    let output = template_res.body.outputs.last().unwrap();
-    let kernel = template_res.body.kernels.last().unwrap();
-    world.coinbases.insert(coinbase_name, (output, kernel));
-    mine_block_without_wallet_with_template(world, template);
+async fn mine_block_with_coinbase_on_node_step(world: &mut TariWorld, base_node: String, coinbase_name: String) {
+    mine_block_with_coinbase_on_node(world, base_node, coinbase_name).await;
 }
 
 #[when(expr = "I print the cucumber world")]

--- a/integration_tests/tests/cucumber.rs
+++ b/integration_tests/tests/cucumber.rs
@@ -24,7 +24,7 @@ mod utils;
 
 use std::{io, path::PathBuf, time::Duration};
 
-use cucumber::{given, then, when, writer, World as _, WriterExt as _, gherkin::Scenario};
+use cucumber::{gherkin::Scenario, given, then, when, writer, World as _, WriterExt as _};
 use indexmap::IndexMap;
 use tari_app_grpc::tari_rpc::{TransactionKernel, TransactionOutput};
 use tari_base_node_grpc_client::grpc::{Empty, GetBalanceRequest};
@@ -33,12 +33,7 @@ use tari_crypto::tari_utilities::ByteArray;
 use tari_integration_tests::error::GrpcBaseNodeError;
 use thiserror::Error;
 use utils::{
-    miner::{
-        mine_blocks_without_wallet,
-        mine_blocks,
-        register_miner_process,
-        mine_block_with_coinbase_on_node,
-    },
+    miner::{mine_block_with_coinbase_on_node, mine_blocks, mine_blocks_without_wallet, register_miner_process},
     wallet_process::spawn_wallet,
 };
 
@@ -103,10 +98,10 @@ impl TariWorld {
     }
 
     pub async fn after(&mut self, _scenario: &Scenario) {
-    //     self.base_nodes.clear();
-    //     self.seed_nodes.clear();
-    //     self.wallets.clear();
-    //     self.miners.clear();
+        //     self.base_nodes.clear();
+        //     self.seed_nodes.clear();
+        //     self.wallets.clear();
+        //     self.miners.clear();
     }
 }
 

--- a/integration_tests/tests/cucumber.rs
+++ b/integration_tests/tests/cucumber.rs
@@ -294,7 +294,7 @@ async fn wallet_connected_to_base_node(world: &mut TariWorld, base_node: String,
 
 #[when(expr = "mining node {word} mines {int} blocks with min difficulty {int} and max difficulty {int}")]
 async fn mining_node_mines_blocks_with_difficulty(
-   _world: &mut TariWorld,
+    _world: &mut TariWorld,
     _miner: String,
     _block: u64,
     _min_difficulty: u64,

--- a/integration_tests/tests/cucumber.rs
+++ b/integration_tests/tests/cucumber.rs
@@ -31,6 +31,7 @@ use tari_base_node_grpc_client::grpc::{Empty, GetBalanceRequest};
 use tari_common::initialize_logging;
 use tari_crypto::tari_utilities::ByteArray;
 use tari_integration_tests::error::GrpcBaseNodeError;
+use tari_wallet::connectivity_service::WalletConnectivityInterface;
 use thiserror::Error;
 use utils::{
     miner::{mine_blocks, mine_blocks_without_wallet, register_miner_process},
@@ -104,7 +105,7 @@ async fn start_base_node(world: &mut TariWorld, name: String) {
 
 #[given(expr = "a wallet {word} connected to base node {word}")]
 async fn start_wallet(world: &mut TariWorld, wallet_name: String, node_name: String) {
-    spawn_wallet(world, wallet_name, Some(node_name), world.all_seed_nodes().to_vec()).await;
+    spawn_wallet(world, wallet_name, Some(node_name), world.base_nodes.get(&node_name).unwrap().seed_nodes.clone()).await;
 }
 
 #[when(expr = "I have a base node {word} connected to all seed nodes")]
@@ -300,6 +301,30 @@ async fn mining_node_mines_blocks_with_difficulty(
     _min_difficulty: u64,
     _max_difficulty: u64,
 ) {
+}
+
+#[when("I wait {int} seconds")]
+#[then("I wait {int} seconds")]
+async fn wait_seconds(world: &mut TariWorld, seconds: u64) {
+    tokio::time::sleep(Duration::from_secs(seconds)).await;
+}
+
+#[when("I have a base node {word}")]
+#[given("I have a base node {word}")]
+async fn create_and_add_base_node(world: &mut TariWorld, base_node: String) {
+    spawn_base_node(world, false, name, vec![]).await;
+}
+
+#[given("I have {int} seed nodes")]
+async fn have_seed_nodes(world: &mut TariWorld, seed_nodes: u64) {
+    for node in 0..seed_nodes {
+        spawn_base_node(world, true, format!("seed_node_{}", node), vec![]).await;
+    }
+}
+
+#[when("I have wallet {word} connected to seed node {word}")]
+async fn have_wallet_connect_to_seed_node(world: &mut TariWorld, wallet: String, seed_node: String) {
+    spawn_wallet(world, wallet_name, None, vec![seed_node]).await;
 }
 
 #[when(expr = "I print the cucumber world")]

--- a/integration_tests/tests/cucumber.rs
+++ b/integration_tests/tests/cucumber.rs
@@ -27,7 +27,7 @@ use std::{io, path::PathBuf, time::Duration};
 use anyhow::bail;
 use cucumber::{given, then, when, writer, World as _, WriterExt as _};
 use indexmap::IndexMap;
-use tari_base_node_grpc_client::grpc::{Empty, GetBalanceRequest, GetPeersRequest};
+use tari_base_node_grpc_client::grpc::{Empty, GetBalanceRequest};
 use tari_common::initialize_logging;
 use tari_crypto::tari_utilities::ByteArray;
 use tari_integration_tests::error::GrpcBaseNodeError;
@@ -208,11 +208,11 @@ async fn node_is_at_height(world: &mut TariWorld, base_node: String, height: u64
     let mut chain_hgt = 0;
 
     for _ in 0..=num_retries {
-        let chain_tip = client.get_tip_info(Empty {}).await.into_inner();
+        let chain_tip = client.get_tip_info(Empty {}).await.unwrap().into_inner();
         chain_hgt = chain_tip.metadata.unwrap().height_of_longest_chain;
 
         if chain_hgt >= height {
-            return Ok(());
+            return;
         }
 
         tokio::time::sleep(Duration::from_secs(5)).await;
@@ -294,11 +294,11 @@ async fn wallet_connected_to_base_node(world: &mut TariWorld, base_node: String,
 
 #[when(expr = "mining node {word} mines {int} blocks with min difficulty {int} and max difficulty {int}")]
 async fn mining_node_mines_blocks_with_difficulty(
-    world: &mut TariWorld,
-    miner: String,
-    block: u64,
-    min_difficulty: u64,
-    max_difficulty: u64,
+   _world: &mut TariWorld,
+    _miner: String,
+    _block: u64,
+    _min_difficulty: u64,
+    _max_difficulty: u64,
 ) {
 }
 

--- a/integration_tests/tests/cucumber.rs
+++ b/integration_tests/tests/cucumber.rs
@@ -258,11 +258,10 @@ async fn wait_for_wallet_to_have_micro_tari(world: &mut TariWorld, wallet: Strin
         tokio::time::sleep(Duration::from_secs(5)).await;
     }
 
-    // failed to get wallet right amount, so we bail out
+    // failed to get wallet right amount, so we panic
     panic!(
         "wallet failed to get right amount {}, current amount is {}",
-        amount,
-        curr_amount
+        amount, curr_amount
     );
 }
 
@@ -296,7 +295,7 @@ async fn wallet_connected_to_base_node(world: &mut TariWorld, base_node: String,
 async fn mining_node_mines_blocks_with_difficulty(
     _world: &mut TariWorld,
     _miner: String,
-    _block: u64,
+    _blocks: u64,
     _min_difficulty: u64,
     _max_difficulty: u64,
 ) {

--- a/integration_tests/tests/cucumber.rs
+++ b/integration_tests/tests/cucumber.rs
@@ -37,7 +37,7 @@ use anyhow::bail;
 use async_trait::async_trait;
 use cucumber::{given, then, when, writer, World as _, WriterExt as _};
 use indexmap::IndexMap;
-use tari_base_node_grpc_client::grpc::Empty;
+use tari_base_node_grpc_client::grpc::{Empty, GetBalanceRequest};
 use tari_common::initialize_logging;
 use tari_common_types::types::PublicKey;
 use tari_comms::peer_manager::{PeerFeatures, PeerFlags};
@@ -174,10 +174,10 @@ async fn run_miner(world: &mut TariWorld, miner_name: String, num_blocks: u64) {
 #[then(expr = "all nodes are at height {int}")]
 #[when(expr = "all nodes are at height {int}")]
 async fn all_nodes_are_at_height(world: &mut TariWorld, height: u64) -> anyhow::Result<()> {
-    let mut num_retries = 100;
+    let num_retries = 100;
     let mut already_sync = true;
 
-    for retry in 0..num_retries {
+    for _ in 0..num_retries {
         for (_, bn) in world.base_nodes.iter() {
             let mut client = bn.get_grpc_client().await?;
 
@@ -202,6 +202,74 @@ async fn all_nodes_are_at_height(world: &mut TariWorld, height: u64) -> anyhow::
     }
 
     Ok(())
+}
+
+#[when(expr = "node {word} is at height {int}")]
+#[then(expr = "node {word} is at height {int}")]
+async fn node_is_at_height(world: &mut TariWorld, base_node: String, height: u64) -> anyhow::Result<()> {
+    let num_retries = 100;
+
+    let mut client = world.base_nodes.get(&base_node).unwrap().get_grpc_client().await?;
+    let mut chain_hgt = 0;
+
+    for _ in 0..=num_retries {
+        let chain_tip = client.get_tip_info(Empty {}).await?.into_inner();
+        chain_hgt = chain_tip.metadata.unwrap().height_of_longest_chain;
+
+        if chain_hgt >= height {
+            return Ok(());
+        }
+
+        tokio::time::sleep(Duration::from_secs(5));
+    }
+
+    // base node didn't synchronize successfully at height, so we bail out
+    bail!(
+        "base node didn't synchronize successfully with height {}, current chain height {}",
+        height,
+        chain_hgt
+    );
+}
+
+#[when(expr = "I have mining node {word} connected to base node {word} and wallet {word}")]
+async fn miner_connected_to_base_node_and_wallet(
+    world: &mut TariWorld,
+    miner: String,
+    base_node: String,
+    wallet: String,
+) {
+    register_miner_process(world, miner, base_node, wallet);
+}
+
+#[when(expr = "I wait for wallet {word} to have at least {int} uT")]
+async fn wait_for_wallet_to_have_micro_tari(world: &mut TariWorld, wallet: String, amount: u64) -> anyhow::Result<()> {
+    let wallet = world.wallets.get(&wallet).unwrap();
+    let num_retries = 100;
+
+    let mut client = wallet.get_grpc_client().await.unwrap();
+    let mut curr_amount = 0;
+
+    for _ in 0..=100 {
+        curr_amount = client
+            .get_balance(GetBalanceRequest {})
+            .await
+            .unwrap()
+            .into_inner()
+            .available_balance;
+
+        if curr_amount >= amount {
+            return Ok(());
+        }
+
+        tokio::time::sleep(Duration::from_secs(5));
+    }
+
+    // failed to get wallet right amount, so we bail out
+    bail!(
+        "wallet failed to get right amount {}, current amount is {}",
+        amount,
+        curr_amount
+    );
 }
 
 #[when(expr = "I print the cucumber world")]

--- a/integration_tests/tests/cucumber.rs
+++ b/integration_tests/tests/cucumber.rs
@@ -183,7 +183,7 @@ async fn all_nodes_are_at_height(world: &mut TariWorld, height: u64) -> anyhow::
         }
 
         already_sync = true;
-        tokio::time::sleep(Duration::from_secs(retry)).await;
+        tokio::time::sleep(Duration::from_secs(5)).await;
     }
 
     if !already_sync {

--- a/integration_tests/tests/cucumber.rs
+++ b/integration_tests/tests/cucumber.rs
@@ -33,7 +33,7 @@ use tari_crypto::tari_utilities::ByteArray;
 use tari_integration_tests::error::GrpcBaseNodeError;
 use thiserror::Error;
 use utils::{
-    miner::{mine_blocks, register_miner_process, mine_blocks_without_wallet},
+    miner::{mine_blocks, mine_blocks_without_wallet, register_miner_process},
     wallet_process::spawn_wallet,
 };
 
@@ -270,7 +270,13 @@ async fn base_node_connected_to_seed(world: &mut TariWorld, base_node: String, s
 #[then(expr = "I mine {int} blocks on {word}")]
 #[when(expr = "I mine {int} blocks on {word}")]
 async fn mine_blocks_on(world: &mut TariWorld, base_node: String, blocks: u64) {
-    let mut client = world.base_nodes.get(&base_node).unwrap().get_grpc_client().await.unwrap();
+    let mut client = world
+        .base_nodes
+        .get(&base_node)
+        .unwrap()
+        .get_grpc_client()
+        .await
+        .unwrap();
     mine_blocks_without_wallet(world, &mut client, blocks);
 }
 

--- a/integration_tests/tests/cucumber.rs
+++ b/integration_tests/tests/cucumber.rs
@@ -24,7 +24,7 @@ mod utils;
 
 use std::{io, path::PathBuf, time::Duration};
 
-use cucumber::{given, then, when, writer, World as _, WriterExt as _};
+use cucumber::{given, then, when, writer, World as _, WriterExt as _, gherkin::Scenario};
 use indexmap::IndexMap;
 use tari_app_grpc::tari_rpc::{TransactionKernel, TransactionOutput};
 use tari_base_node_grpc_client::grpc::{Empty, GetBalanceRequest};
@@ -103,10 +103,10 @@ impl TariWorld {
     }
 
     pub async fn after(&mut self, _scenario: &Scenario) {
-        // self.base_nodes.clear();
-        // self.seed_nodes.clear();
-        // self.wallets.clear();
-        // self.miners.clear();
+    //     self.base_nodes.clear();
+    //     self.seed_nodes.clear();
+    //     self.wallets.clear();
+    //     self.miners.clear();
     }
 }
 

--- a/integration_tests/tests/utils/base_node_process.rs
+++ b/integration_tests/tests/utils/base_node_process.rs
@@ -59,6 +59,7 @@ pub struct BaseNodeProcess {
     pub identity: NodeIdentity,
     pub temp_dir_path: String,
     pub is_seed_node: bool,
+    pub seed_nodes: Vec<String>,
     pub cx: Arc<Mutex<Option<BaseNodeContext>>>,
 }
 
@@ -101,13 +102,14 @@ pub async fn spawn_base_node(world: &mut TariWorld, is_seed_node: bool, bn_name:
         identity,
         temp_dir_path,
         is_seed_node,
+        seed_nodes: peers.clone(),
         cx: Default::default(),
     };
 
     let name_cloned = bn_name.clone();
 
     let mut peer_addresses = vec![];
-    for peer in peers {
+    for peer in &peers {
         let peer = world.base_nodes.get(peer.as_str()).unwrap();
         peer_addresses.push(format!(
             "{}::{}",

--- a/integration_tests/tests/utils/miner.rs
+++ b/integration_tests/tests/utils/miner.rs
@@ -20,7 +20,7 @@
 //   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{str::FromStr, time::Duration, convert::TryInto};
+use std::{convert::TryInto, str::FromStr, time::Duration};
 
 use rand::rngs::OsRng;
 use tari_app_grpc::{
@@ -38,10 +38,12 @@ use tari_app_grpc::{
         TransactionOutput,
     },
 };
-use tari_core::consensus::consensus_constants::ConsensusConstants;
 use tari_base_node_grpc_client::BaseNodeGrpcClient;
 use tari_common_types::{grpc_authentication::GrpcAuthentication, types::PrivateKey};
-use tari_core::transactions::{CoinbaseBuilder, CryptoFactories};
+use tari_core::{
+    consensus::consensus_constants::ConsensusConstants,
+    transactions::{CoinbaseBuilder, CryptoFactories},
+};
 use tari_crypto::keys::SecretKey;
 use tonic::{
     codegen::InterceptedService,
@@ -216,7 +218,9 @@ async fn get_coinbase_outputs_and_kernels(
     extract_outputs_and_kernels(coinbase_res)
 }
 
-fn get_coinbase_without_wallet_client(template_res: NewBlockTemplateResponse) -> (TransactionOutput, TransactionKernel) {
+fn get_coinbase_without_wallet_client(
+    template_res: NewBlockTemplateResponse,
+) -> (TransactionOutput, TransactionKernel) {
     let coinbase_req = coinbase_request(&template_res);
     generate_coinbase(coinbase_req)
 }
@@ -244,7 +248,7 @@ fn generate_coinbase(coinbase_req: GetCoinbaseRequest) -> (TransactionOutput, Tr
     let tx_out = tx.body().outputs().first().unwrap().clone();
     let tx_krnl = tx.body().kernels().first().unwrap().clone();
 
-    return (tx_out.try_into().unwrap(), tx_krnl.into())
+    return (tx_out.try_into().unwrap(), tx_krnl.into());
 }
 
 fn coinbase_request(template_response: &NewBlockTemplateResponse) -> GetCoinbaseRequest {

--- a/integration_tests/tests/utils/miner.rs
+++ b/integration_tests/tests/utils/miner.rs
@@ -20,8 +20,9 @@
 //   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{str::FromStr, time::Duration};
+use std::{str::FromStr, time::Duration, convert::TryInto};
 
+use rand::rngs::OsRng;
 use tari_app_grpc::{
     authentication::ClientAuthenticationInterceptor,
     tari_rpc::{
@@ -37,8 +38,11 @@ use tari_app_grpc::{
         TransactionOutput,
     },
 };
+use tari_core::consensus::consensus_constants::ConsensusConstants;
 use tari_base_node_grpc_client::BaseNodeGrpcClient;
-use tari_common_types::grpc_authentication::GrpcAuthentication;
+use tari_common_types::{grpc_authentication::GrpcAuthentication, types::PrivateKey};
+use tari_core::transactions::{CoinbaseBuilder, CryptoFactories};
+use tari_crypto::keys::SecretKey;
 use tonic::{
     codegen::InterceptedService,
     transport::{Channel, Endpoint},
@@ -71,6 +75,16 @@ pub async fn mine_blocks(world: &mut TariWorld, miner_name: String, num_blocks: 
 
     for _ in 0..num_blocks {
         mine_block(&mut base_client, &mut wallet_client).await;
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    // Give some time for the base node and wallet to sync the new blocks
+    tokio::time::sleep(Duration::from_secs(5)).await;
+}
+
+pub async fn mine_blocks_without_wallet(world: &mut TariWorld, base_client: &mut BaseNodeClient, num_blocks: u64) {
+    for _ in 0..num_blocks {
+        mine_block_without_wallet(base_client).await;
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
 
@@ -117,6 +131,25 @@ async fn mine_block(base_client: &mut BaseNodeClient, wallet_client: &mut Wallet
     );
 }
 
+async fn mine_block_without_wallet(base_client: &mut BaseNodeClient) {
+    let block_template = create_block_template_with_coinbase_without_wallet(base_client).await;
+
+    // Ask the base node for a valid block using the template
+    let block_result = base_client
+        .get_new_block(block_template.clone())
+        .await
+        .unwrap()
+        .into_inner();
+    let block = block_result.block.unwrap();
+
+    // We don't need to mine, as Localnet blocks have difficulty 1s
+    let _submit_res = base_client.submit_block(block).await.unwrap();
+    println!(
+        "Block successfully mined at height {:?}",
+        block_template.header.unwrap().height
+    );
+}
+
 async fn create_block_template_with_coinbase(
     base_client: &mut BaseNodeClient,
     wallet_client: &mut WalletGrpcClient,
@@ -147,6 +180,33 @@ async fn create_block_template_with_coinbase(
     block_template
 }
 
+async fn create_block_template_with_coinbase_without_wallet(base_client: &mut BaseNodeClient) -> NewBlockTemplate {
+    // get the block template from the base node
+    let template_req = NewBlockTemplateRequest {
+        algo: Some(PowAlgo {
+            pow_algo: PowAlgos::Sha3.into(),
+        }),
+        max_weight: 0,
+    };
+
+    let template_res = base_client
+        .get_new_block_template(template_req)
+        .await
+        .unwrap()
+        .into_inner();
+
+    let mut block_template = template_res.new_block_template.clone().unwrap();
+
+    // add the coinbase outputs and kernels to the block template
+    let (output, kernel) = get_coinbase_without_wallet_client(template_res);
+    let body = block_template.body.as_mut().unwrap();
+
+    body.outputs.push(output);
+    body.kernels.push(kernel);
+
+    block_template
+}
+
 async fn get_coinbase_outputs_and_kernels(
     wallet_client: &mut WalletGrpcClient,
     template_res: NewBlockTemplateResponse,
@@ -154,6 +214,37 @@ async fn get_coinbase_outputs_and_kernels(
     let coinbase_req = coinbase_request(&template_res);
     let coinbase_res = wallet_client.get_coinbase(coinbase_req).await.unwrap().into_inner();
     extract_outputs_and_kernels(coinbase_res)
+}
+
+fn get_coinbase_without_wallet_client(template_res: NewBlockTemplateResponse) -> (TransactionOutput, TransactionKernel) {
+    let coinbase_req = coinbase_request(&template_res);
+    generate_coinbase(coinbase_req)
+}
+
+fn generate_coinbase(coinbase_req: GetCoinbaseRequest) -> (TransactionOutput, TransactionKernel) {
+    let reward = coinbase_req.reward;
+    let height = coinbase_req.height;
+    let fee = coinbase_req.fee;
+    let extra = coinbase_req.extra;
+
+    let spending_key = PrivateKey::random(&mut OsRng);
+    let script_private_key = PrivateKey::random(&mut OsRng);
+    let nonce = PrivateKey::random(&mut OsRng);
+
+    let (tx, _) = CoinbaseBuilder::new(CryptoFactories::default())
+        .with_block_height(height)
+        .with_fees(fee.into())
+        .with_spend_key(spending_key.clone())
+        .with_script_key(script_private_key.clone())
+        .with_nonce(nonce)
+        .with_extra(extra)
+        .build_with_reward(&ConsensusConstants::localnet().first().unwrap(), reward.into())
+        .unwrap();
+
+    let tx_out = tx.body().outputs().first().unwrap().clone();
+    let tx_krnl = tx.body().kernels().first().unwrap().clone();
+
+    return (tx_out.try_into().unwrap(), tx_krnl.into())
 }
 
 fn coinbase_request(template_response: &NewBlockTemplateResponse) -> GetCoinbaseRequest {

--- a/integration_tests/tests/utils/miner.rs
+++ b/integration_tests/tests/utils/miner.rs
@@ -84,7 +84,7 @@ pub async fn mine_blocks(world: &mut TariWorld, miner_name: String, num_blocks: 
     tokio::time::sleep(Duration::from_secs(5)).await;
 }
 
-pub async fn mine_blocks_without_wallet(world: &mut TariWorld, base_client: &mut BaseNodeClient, num_blocks: u64) {
+pub async fn mine_blocks_without_wallet(base_client: &mut BaseNodeClient, num_blocks: u64) {
     for _ in 0..num_blocks {
         mine_block_without_wallet(base_client).await;
         tokio::time::sleep(Duration::from_millis(100)).await;
@@ -238,17 +238,17 @@ fn generate_coinbase(coinbase_req: GetCoinbaseRequest) -> (TransactionOutput, Tr
     let (tx, _) = CoinbaseBuilder::new(CryptoFactories::default())
         .with_block_height(height)
         .with_fees(fee.into())
-        .with_spend_key(spending_key.clone())
-        .with_script_key(script_private_key.clone())
+        .with_spend_key(spending_key)
+        .with_script_key(script_private_key)
         .with_nonce(nonce)
         .with_extra(extra)
-        .build_with_reward(&ConsensusConstants::localnet().first().unwrap(), reward.into())
+        .build_with_reward(ConsensusConstants::localnet().first().unwrap(), reward.into())
         .unwrap();
 
     let tx_out = tx.body().outputs().first().unwrap().clone();
     let tx_krnl = tx.body().kernels().first().unwrap().clone();
 
-    return (tx_out.try_into().unwrap(), tx_krnl.into());
+    (tx_out.try_into().unwrap(), tx_krnl.into())
 }
 
 fn coinbase_request(template_response: &NewBlockTemplateResponse) -> GetCoinbaseRequest {

--- a/integration_tests/tests/utils/miner.rs
+++ b/integration_tests/tests/utils/miner.rs
@@ -71,8 +71,6 @@ pub fn register_miner_process(world: &mut TariWorld, miner_name: String, base_no
     world.miners.insert(miner_name, miner);
 }
 
-pub async fn create_miner_client(world: &mut TariWorld, miner_name: String) {}
-
 pub async fn mine_blocks(world: &mut TariWorld, miner_name: String, num_blocks: u64) {
     let mut base_client = create_base_node_client(world, &miner_name).await;
     let mut wallet_client = create_wallet_client(world, &miner_name).await;

--- a/integration_tests/tests/utils/miner.rs
+++ b/integration_tests/tests/utils/miner.rs
@@ -137,7 +137,7 @@ async fn mine_block(base_client: &mut BaseNodeClient, wallet_client: &mut Wallet
 
 async fn mine_block_without_wallet(base_client: &mut BaseNodeClient) {
     let block_template = create_block_template_with_coinbase_without_wallet(base_client).await;
-    mine_block_without_wallet_with_template(base_client, block_template);
+    mine_block_without_wallet_with_template(base_client, block_template).await;
 }
 
 async fn mine_block_without_wallet_with_template(base_client: &mut BaseNodeClient, block_template: NewBlockTemplate) {
@@ -290,5 +290,5 @@ pub async fn mine_block_with_coinbase_on_node(world: &mut TariWorld, base_node: 
     let output = body.outputs.last().unwrap();
     let kernel = body.kernels.last().unwrap();
     world.coinbases.insert(coinbase_name, (output.clone(), kernel.clone()));
-    mine_block_without_wallet_with_template(&mut client, template);
+    mine_block_without_wallet_with_template(&mut client, template).await;
 }

--- a/integration_tests/tests/utils/miner.rs
+++ b/integration_tests/tests/utils/miner.rs
@@ -41,6 +41,7 @@ use tari_app_grpc::{
 use tari_base_node_grpc_client::BaseNodeGrpcClient;
 use tari_common_types::{grpc_authentication::GrpcAuthentication, types::PrivateKey};
 use tari_core::{
+    blocks::NewBlock,
     consensus::consensus_constants::ConsensusConstants,
     transactions::{CoinbaseBuilder, CryptoFactories},
 };
@@ -135,7 +136,10 @@ async fn mine_block(base_client: &mut BaseNodeClient, wallet_client: &mut Wallet
 
 async fn mine_block_without_wallet(base_client: &mut BaseNodeClient) {
     let block_template = create_block_template_with_coinbase_without_wallet(base_client).await;
+    mine_block_without_wallet_with_template(base_client, block_template);
+}
 
+async fn mine_block_without_wallet_with_template(base_client: &mut BaseNodeClient, block_template: NewBlockTemplate) {
     // Ask the base node for a valid block using the template
     let block_result = base_client
         .get_new_block(block_template.clone())

--- a/integration_tests/tests/utils/miner.rs
+++ b/integration_tests/tests/utils/miner.rs
@@ -71,6 +71,8 @@ pub fn register_miner_process(world: &mut TariWorld, miner_name: String, base_no
     world.miners.insert(miner_name, miner);
 }
 
+pub async fn create_miner_client(world: &mut TariWorld, miner_name: String) {}
+
 pub async fn mine_blocks(world: &mut TariWorld, miner_name: String, num_blocks: u64) {
     let mut base_client = create_base_node_client(world, &miner_name).await;
     let mut wallet_client = create_wallet_client(world, &miner_name).await;


### PR DESCRIPTION
Description
---
To set up cucumber tests successfully, we need to be able to execute the following steps:

```
node {word} is at height {int}
I have mining node {word} connected to base node {word} and wallet {word}
I wait for wallet {word} to have at least {int} uT
```

This PR implements the underlying logic in Rust.

Motivation and Context
---

How Has This Been Tested?
---

