### PR TITLE
feat: logs cleanup and update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 ---
 name: CI
 
-'on':
+"on":
   workflow_dispatch:
   push:
     branches:
@@ -25,7 +25,7 @@ jobs:
   clippy:
     name: clippy
     #runs-on: [ self-hosted, ubuntu18.04-high-cpu ]
-    runs-on: [ ubuntu-20.04 ]
+    runs-on: [ubuntu-20.04]
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -55,7 +55,7 @@ jobs:
           args: clippy --all-targets --all-features
   build:
     name: cargo check
-    runs-on: [ self-hosted, ubuntu18.04-high-cpu ]
+    runs-on: [self-hosted, ubuntu18.04-high-cpu]
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -81,7 +81,7 @@ jobs:
           args: --release --package tari_wallet_ffi
   build-stable:
     name: cargo check stable
-    runs-on: [ self-hosted, ubuntu18.04-high-cpu ]
+    runs-on: [self-hosted, ubuntu18.04-high-cpu]
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -103,7 +103,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --release --all-targets --exclude tari_integration_tests --locked
+          args: --release --all-targets --workspace --exclude tari_integration_tests --locked
       - name: cargo check ffi separately
         uses: actions-rs/cargo@v1
         with:
@@ -111,7 +111,7 @@ jobs:
           args: --release --package tari_wallet_ffi
   licenses:
     name: file licenses
-    runs-on: [ ubuntu-20.04 ]
+    runs-on: [ubuntu-20.04]
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -124,7 +124,7 @@ jobs:
         run: ./scripts/file_license_check.sh
   test:
     name: test
-    runs-on: [ self-hosted, ubuntu18.04-high-cpu ]
+    runs-on: [self-hosted, ubuntu18.04-high-cpu]
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -154,7 +154,7 @@ jobs:
           args: -v --all-features --release --workspace --exclude tari_integration_tests
   integration_tests:
     name: integration tests
-    runs-on: [ self-hosted, ubuntu18.04-high-cpu ]
+    runs-on: [self-hosted, ubuntu18.04-high-cpu]
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -180,7 +180,7 @@ jobs:
   # Allows other workflows to know the PR number
   artifacts:
     name: pr_2_artifact
-    runs-on: [ ubuntu-20.04 ]
+    runs-on: [ubuntu-20.04]
     steps:
       - name: Save the PR number in an artifact
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --release --all-targets --locked
+          args: --release --all-targets --exclude tari_integration_tests --locked
       - name: cargo check ffi separately
         uses: actions-rs/cargo@v1
         with:

--- a/integration_tests/log4rs/cucumber.yml
+++ b/integration_tests/log4rs/cucumber.yml
@@ -1,0 +1,164 @@
+#  See https://docs.rs/log4rs/1.1.1/log4rs/encode/pattern/index.html for deciphering the log pattern.
+refresh_rate: 30 seconds
+appenders:
+  # An appender named "stdout" that writes to stdout
+  stdout:
+    kind: rolling_file
+    path: "log/stdout.log"
+    policy:
+      kind: compound
+      trigger:
+        kind: size
+        limit: 100mb
+      roller:
+        kind: fixed_window
+        base: 1
+        count: 10
+        pattern: "log/stdout.{}.log"
+    encoder:
+      pattern: "{m}"
+  # An appender named "network" that writes to a file with a custom pattern encoder
+  network:
+    kind: rolling_file
+    path: "log/network.log"
+    policy:
+      kind: compound
+      trigger:
+        kind: size
+        limit: 100mb
+      roller:
+        kind: fixed_window
+        base: 1
+        count: 10
+        pattern: "log/network.{}.log"
+    encoder:
+      pattern: "{d(%Y-%m-%d %H:%M:%S.%f)} {f}.{L} {i} [{t}] {l:5} {m}{n}"
+  base_layer_base_node:
+    kind: rolling_file
+    path: "log/base_node.log"
+    policy:
+      kind: compound
+      trigger:
+        kind: size
+        limit: 100mb
+      roller:
+        kind: fixed_window
+        base: 1
+        count: 10
+        pattern: "log/base_node.{}.log"
+    encoder:
+      pattern: "{d(%Y-%m-%d %H:%M:%S.%f)} {f}.{L} {i} [{t}] {l:5} {m}{n}"
+  base_layer_wallet:
+    kind: rolling_file
+    path: "log/wallet.log"
+    policy:
+      kind: compound
+      trigger:
+        kind: size
+        limit: 100mb
+      roller:
+        kind: fixed_window
+        base: 1
+        count: 10
+        pattern: "log/wallet.{}.log"
+    encoder:
+      pattern: "{d(%Y-%m-%d %H:%M:%S.%f)} {f}.{L} {i} [{t}] {l:5} {m}{n}"
+  # An appender named "other" that writes to a file with a custom pattern encoder
+  other:
+    kind: rolling_file
+    path: "log/other.log"
+    policy:
+      kind: compound
+      trigger:
+        kind: size
+        limit: 10mb
+      roller:
+        kind: fixed_window
+        base: 1
+        count: 5
+        pattern: "log/other.{}.log"
+    encoder:
+      pattern: "{d(%Y-%m-%d %H:%M:%S.%f)} {f}.{L} {i} [{t}] {l:5} {m}{n}"
+# We don't want prints during cucumber test, everything useful will in logs.
+# root:
+#   level: warn
+#   appenders:
+#     - stdout
+
+loggers:
+  cucumber:
+    level: info
+    appenders:
+      - network
+      - base_layer_wallet
+      - base_layer_base_node
+    additive: true
+  stdout:
+    level: info # we have only single print, and it's info
+    appenders:
+      - stdout
+  tari:
+    level: debug
+    appenders:
+      - base_layer_base_node
+  wallet:
+    level: debug
+    appenders:
+      - base_layer_wallet
+  comms:
+    level: debug
+    appenders:
+      - network
+  # Route log events sent to the "p2p" logger to the "network" appender
+  p2p:
+    level: debug
+    appenders:
+      - network
+  # Route log events sent to the "comms" logger to the "network" appender
+  comms:
+    level: debug
+    appenders:
+      - network
+  # Route log events sent to the "p2p" logger to the "network" appender
+  p2p:
+    level: debug
+    appenders:
+      - network
+    # Route log events sent to the "yamux" logger to the "network" appender
+  yamux:
+    level: debug
+    appenders:
+      - network
+  # Route log events sent to the "mio" logger to the "network" appender
+  mio:
+    level: error
+    appenders:
+      - network
+  # Route log events sent to the "rustyline" logger to the "other" appender
+  rustyline:
+    level: error
+    appenders:
+      - other
+    additive: false
+
+  # Route log events sent to the "tokio_util" logger to the "other" appender
+  tokio_util:
+    level: error
+    appenders:
+      - other
+  # Route PGP log events
+  pgp:
+    level: warn
+    appenders:
+      - other
+  # Route log events sent to the "tari_mm_proxy" logger to the "base_layer" appender
+  tari_mm_proxy:
+    level: debug
+    appenders:
+      - base_layer
+  # Route R2D2 log events
+  r2d2:
+    level: info
+    appenders:
+      - other
+    additive: false


### PR DESCRIPTION
Description
---
Much better logs.
- base_node/base_layer is now just base_node, 
- wallet/base_layer is just wallet
- other and network are there, but they are written from both nodes and wallets
- added a file:line for easier location of the log
- added a threadid for easier identification what process produced that log
- added a new log stdout, which will just grab everything from println! and similar, the stdout logs also a scenario name in the before step for easier identification, nothing else is printed to the file
- the tests will run only one at a time, otherwise the logs are messy

Motivation and Context
---
Much easier to see what's happening and where.

How Has This Been Tested?
---
I did run couple tests.
