### PR TITLE
feat: add get tari address to wallet

### DIFF
--- a/applications/tari_app_grpc/proto/wallet.proto
+++ b/applications/tari_app_grpc/proto/wallet.proto
@@ -39,6 +39,8 @@ service Wallet {
     rpc CheckForUpdates (Empty) returns (SoftwareUpdate);
     // This returns the identity information
     rpc Identify (GetIdentityRequest) returns (GetIdentityResponse);
+    // This returns the tari address
+    rpc GetAddress (Empty) returns (GetAddressResponse);
     // This returns a coinbase transaction
     rpc GetCoinbase (GetCoinbaseRequest) returns (GetCoinbaseResponse);
     // Send Tari to a number of recipients
@@ -85,6 +87,10 @@ message GetVersionRequest { }
 
 message GetVersionResponse {
     string version = 1;
+}
+
+message GetAddressResponse {
+    bytes address = 1;
 }
 
 message TransferRequest {

--- a/applications/tari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/tari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -45,6 +45,7 @@ use tari_app_grpc::{
         CreateBurnTransactionResponse,
         CreateTemplateRegistrationRequest,
         CreateTemplateRegistrationResponse,
+        GetAddressResponse,
         GetBalanceRequest,
         GetBalanceResponse,
         GetCoinbaseRequest,
@@ -223,6 +224,15 @@ impl wallet_server::Wallet for WalletGrpcServer {
             public_key: identity.public_key().to_vec(),
             public_address: identity.public_address().to_string(),
             node_id: identity.node_id().to_vec(),
+        }))
+    }
+
+    async fn get_address(&self, _: Request<tari_rpc::Empty>) -> Result<Response<GetAddressResponse>, Status> {
+        let network = self.wallet.network.as_network();
+        let pk = self.wallet.comms.node_identity().public_key().clone();
+        let address = TariAddress::new(pk, network);
+        Ok(Response::new(GetAddressResponse {
+            address: address.to_bytes().to_vec(),
         }))
     }
 


### PR DESCRIPTION
Description
---
The public key is obsolete for wallets. The tari address is now needed.

How Has This Been Tested?
---
Manually using grpc repo utility.
