### PR TITLE
fix: add const to FixedHash::zero

### DIFF
--- a/base_layer/common_types/src/types/fixed_hash.rs
+++ b/base_layer/common_types/src/types/fixed_hash.rs
@@ -59,7 +59,7 @@ impl FixedHash {
         32
     }
 
-    pub fn zero() -> Self {
+    pub const fn zero() -> Self {
         Self(ZERO_HASH)
     }
 


### PR DESCRIPTION
Description
---
Make `FixedHash::zero` a const fn

Motivation and Context
---
A function returning a constant value should be set as const to allow for minor compiled code optimisations. A zero hash is used more often in the DAN layer to indicate a genesis node.

How Has This Been Tested?
---
Minor change, clippy passes
