### PR TITLE
fix: header sync start info

### DIFF
--- a/base_layer/core/src/base_node/sync/header_sync/synchronizer.rs
+++ b/base_layer/core/src/base_node/sync/header_sync/synchronizer.rs
@@ -346,7 +346,11 @@ impl<'a, B: BlockchainBackend + 'static> HeaderSynchronizer<'a, B> {
             },
             SyncStatus::Lagging(split_info) => {
                 self.hooks.call_on_progress_header_hooks(
-                    split_info.local_tip_header.height(),
+                    split_info
+                        .local_tip_header
+                        .height()
+                        .checked_sub(split_info.reorg_steps_back)
+                        .unwrap_or_default(),
                     split_info.remote_tip_height,
                     sync_peer,
                 );


### PR DESCRIPTION
Description
---
When starting header sync if the remote tip is less than the local tip but has a higher pow, the description is wrong when it starts. 
```
10:06 v0.42.0 esmeralda State: Syncing headers: (5c38651e1b7ec007) 5241/5180 (101%) Tip: 5153
```

Motivation and Context
---
Fixes it to show the starting block height on startup and not the local tip before reorg. 

How Has This Been Tested?
---
Manual
