### PR TITLE
feat: add graceful shutdown of base node

### DIFF
--- a/applications/tari_base_node/src/commands/cli_loop.rs
+++ b/applications/tari_base_node/src/commands/cli_loop.rs
@@ -177,7 +177,7 @@ impl CliLoop {
             if let Err(err) = self.context.handle_command_str(line).await {
                 println!("Wrong command to watch `{}`. Failed with: {}", line, err);
             } else {
-                loop {
+                while !self.done {
                     let interval = time::sleep(interval);
                     tokio::select! {
                         _ = interval => {
@@ -188,6 +188,9 @@ impl CliLoop {
                         },
                         _ = &mut interrupt => {
                             break;
+                        },
+                        _ = self.shutdown_signal.wait() => {
+                            self.done = true;
                         }
                     }
                 }


### PR DESCRIPTION
Description
---
The non-interactive node was not expecting shutdown to be triggered. Because in real life it will never happen. It was expecting ctrl-c to be pressed. But for the sake of tests the shutdown should be monitored.

Motivation and Context
---
Without it the exclusive locks will panic

How Has This Been Tested?
---
Simple test scenario, start node, stop node, start again.
