### PR TITLE
chore: set Igor vn validity period to 3 epochs for upcoming test

### DIFF
--- a/applications/tari_app_grpc/src/conversions/consensus_constants.rs
+++ b/applications/tari_app_grpc/src/conversions/consensus_constants.rs
@@ -125,7 +125,7 @@ impl From<ConsensusConstants> for grpc::ConsensusConstants {
             max_randomx_seed_height: cc.max_randomx_seed_height(),
             output_version_range: Some(output_version_range),
             permitted_output_types,
-            validator_node_validity_period: cc.validator_node_validity_period().as_u64(),
+            validator_node_validity_period: cc.validator_node_validity_period_epochs().as_u64(),
             epoch_length: cc.epoch_length(),
         }
     }

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -1415,7 +1415,7 @@ impl LMDBDatabase {
         let prev_shard_key = store.get_shard_key(
             current_epoch
                 .as_u64()
-                .saturating_sub(constants.validator_node_validity_period().as_u64()) *
+                .saturating_sub(constants.validator_node_validity_period_epochs().as_u64()) *
                 constants.epoch_length(),
             current_epoch.as_u64() * constants.epoch_length(),
             vn_reg.public_key(),
@@ -1431,7 +1431,7 @@ impl LMDBDatabase {
         let validator_node = ValidatorNodeEntry {
             shard_key,
             start_epoch: next_epoch,
-            end_epoch: next_epoch + constants.validator_node_validity_period(),
+            end_epoch: next_epoch + constants.validator_node_validity_period_epochs(),
             public_key: vn_reg.public_key().clone(),
             commitment: commitment.clone(),
         };
@@ -2498,7 +2498,7 @@ impl BlockchainBackend for LMDBDatabase {
         // Get the current epoch for the height
         let end_epoch = constants.block_height_to_epoch(height);
         // Subtract the registration validaty period to get the start epoch
-        let start_epoch = end_epoch.saturating_sub(constants.validator_node_validity_period());
+        let start_epoch = end_epoch.saturating_sub(constants.validator_node_validity_period_epochs());
         // Convert these back to height as validators regs are indexed by height
         let start_height = start_epoch.as_u64() * constants.epoch_length();
         let end_height = end_epoch.as_u64() * constants.epoch_length();
@@ -2513,7 +2513,7 @@ impl BlockchainBackend for LMDBDatabase {
 
         // Get the epoch height boundaries for our query
         let current_epoch = constants.block_height_to_epoch(height);
-        let start_epoch = current_epoch.saturating_sub(constants.validator_node_validity_period());
+        let start_epoch = current_epoch.saturating_sub(constants.validator_node_validity_period_epochs());
         let start_height = start_epoch.as_u64() * constants.epoch_length();
         let end_height = current_epoch.as_u64() * constants.epoch_length();
         let maybe_shard_id = store.get_shard_key(start_height, end_height, &public_key)?;

--- a/base_layer/core/src/consensus/consensus_constants.rs
+++ b/base_layer/core/src/consensus/consensus_constants.rs
@@ -101,7 +101,7 @@ pub struct ConsensusConstants {
     /// Epoch duration in blocks
     vn_epoch_length: u64,
     /// The number of Epochs that a validator node registration is valid
-    vn_validity_period: VnEpoch,
+    vn_validity_period_epochs: VnEpoch,
     vn_registration_min_deposit_amount: MicroTari,
     vn_registration_lock_height: u64,
     vn_registration_shuffle_interval: VnEpoch,
@@ -303,8 +303,8 @@ impl ConsensusConstants {
         self.permitted_output_types
     }
 
-    pub fn validator_node_validity_period(&self) -> VnEpoch {
-        self.vn_validity_period
+    pub fn validator_node_validity_period_epochs(&self) -> VnEpoch {
+        self.vn_validity_period_epochs
     }
 
     pub fn validator_node_registration_shuffle_interval(&self) -> VnEpoch {
@@ -371,7 +371,7 @@ impl ConsensusConstants {
             kernel_version_range,
             permitted_output_types: OutputType::all(),
             vn_epoch_length: 10,
-            vn_validity_period: VnEpoch(100),
+            vn_validity_period_epochs: VnEpoch(100),
             vn_registration_min_deposit_amount: MicroTari(0),
             vn_registration_lock_height: 0,
             vn_registration_shuffle_interval: VnEpoch(100),
@@ -417,7 +417,7 @@ impl ConsensusConstants {
             kernel_version_range,
             permitted_output_types: Self::current_permitted_output_types(),
             vn_epoch_length: 60,
-            vn_validity_period: VnEpoch(100),
+            vn_validity_period_epochs: VnEpoch(100),
             vn_registration_min_deposit_amount: MicroTari(0),
             vn_registration_lock_height: 0,
             vn_registration_shuffle_interval: VnEpoch(100),
@@ -467,7 +467,7 @@ impl ConsensusConstants {
             // igor is the first network to support the new output types
             permitted_output_types: OutputType::all(),
             vn_epoch_length: 10,
-            vn_validity_period: VnEpoch(100),
+            vn_validity_period_epochs: VnEpoch(3),
             vn_registration_min_deposit_amount: MicroTari(0),
             vn_registration_lock_height: 0,
             vn_registration_shuffle_interval: VnEpoch(100),
@@ -523,7 +523,7 @@ impl ConsensusConstants {
                 kernel_version_range: kernel_version_range.clone(),
                 permitted_output_types: Self::current_permitted_output_types(),
                 vn_epoch_length: 60,
-                vn_validity_period: VnEpoch(100),
+                vn_validity_period_epochs: VnEpoch(100),
                 vn_registration_min_deposit_amount: MicroTari(0),
                 vn_registration_lock_height: 0,
                 vn_registration_shuffle_interval: VnEpoch(100),
@@ -552,7 +552,7 @@ impl ConsensusConstants {
                 kernel_version_range,
                 permitted_output_types: Self::current_permitted_output_types(),
                 vn_epoch_length: 60,
-                vn_validity_period: VnEpoch(100),
+                vn_validity_period_epochs: VnEpoch(100),
                 vn_registration_min_deposit_amount: MicroTari(0),
                 vn_registration_lock_height: 0,
                 vn_registration_shuffle_interval: VnEpoch(100),
@@ -605,7 +605,7 @@ impl ConsensusConstants {
             kernel_version_range,
             permitted_output_types: Self::current_permitted_output_types(),
             vn_epoch_length: 60,
-            vn_validity_period: VnEpoch(100),
+            vn_validity_period_epochs: VnEpoch(100),
             vn_registration_min_deposit_amount: MicroTari(0),
             vn_registration_lock_height: 0,
             vn_registration_shuffle_interval: VnEpoch(100),
@@ -654,7 +654,7 @@ impl ConsensusConstants {
             kernel_version_range,
             permitted_output_types: Self::current_permitted_output_types(),
             vn_epoch_length: 60,
-            vn_validity_period: VnEpoch(100),
+            vn_validity_period_epochs: VnEpoch(100),
             vn_registration_min_deposit_amount: MicroTari(0),
             vn_registration_lock_height: 0,
             vn_registration_shuffle_interval: VnEpoch(100),


### PR DESCRIPTION
Description
---
Sets Igor vn validity period to 3 epochs (30 blocks) for the upcoming test run and renamed to vn_validity_period_epochs to make it clearer that the period is in epochs

Motivation and Context
---
30 blocks is short enough that if we get liveness failures because of unavailable nodes, we don't have to wait too long for them to expire.

How Has This Been Tested?
---
N/A
