### PR TITLE
fix: automatically set base node fetures on startup, sign only if necessary

### DIFF
--- a/applications/tari_app_utilities/src/identity_management.rs
+++ b/applications/tari_app_utilities/src/identity_management.rs
@@ -54,12 +54,15 @@ pub fn setup_node_identity<P: AsRef<Path>>(
     peer_features: PeerFeatures,
 ) -> Result<Arc<NodeIdentity>, ExitError> {
     match load_node_identity(&identity_file) {
-        Ok(id) => match public_address {
-            Some(public_address) => {
-                id.set_public_address(public_address.clone());
-                Ok(Arc::new(id))
-            },
-            None => Ok(Arc::new(id)),
+        Ok(mut id) => {
+            id.set_peer_features(peer_features);
+            match public_address {
+                Some(public_address) => {
+                    id.set_public_address(public_address.clone());
+                    Ok(Arc::new(id))
+                },
+                None => Ok(Arc::new(id)),
+            }
         },
         Err(IdentityError::InvalidPermissions) => Err(ExitError::new(
             ExitCode::ConfigError,

--- a/comms/core/src/peer_manager/node_identity.rs
+++ b/comms/core/src/peer_manager/node_identity.rs
@@ -127,6 +127,15 @@ impl NodeIdentity {
         }
     }
 
+    /// Modify the peer features
+    pub fn set_peer_features(&mut self, features: PeerFeatures) {
+        let must_sign = features != self.features;
+        self.features = features;
+        if must_sign {
+            self.sign()
+        }
+    }
+
     /// This returns a random NodeIdentity for testing purposes. This function can panic. If public_address
     /// is None, 127.0.0.1:9000 will be used (i.e. the caller doesn't care what the control_service_address is).
     #[cfg(test)]


### PR DESCRIPTION
Description
---
Ensure that the correct peer features are set for the base node on startup. The node identity will be re-signed if necessary.

Motivation and Context
---
Generated vanity ids with no features instead of base node features. This PR will make the base node fix this case as a base node should always advertise the correct features to participate in tx/block propagation etc

How Has This Been Tested?
---
Igor node with incorrect features, self-corrected.
