### PR TITLE
feat: increase wallet FFI error codes

### DIFF
--- a/base_layer/wallet_ffi/src/error.rs
+++ b/base_layer/wallet_ffi/src/error.rs
@@ -231,6 +231,10 @@ impl From<WalletError> for LibWalletError {
                 code: 210,
                 message: format!("{:?}", w),
             },
+            WalletError::TransactionServiceError(TransactionServiceError::NoBaseNodeKeysProvided) => Self {
+                code: 212,
+                message: format!("{:?}", w),
+            },
             WalletError::TransactionServiceError(_) => Self {
                 code: 211,
                 message: format!("{:?}", w),


### PR DESCRIPTION
Description
---
When a wallet function is called after `wallet_create` and before `wallet_add_base_node_peer` the wallet will error with `211`. This increases the error codes to correctly error on 212 `NoBaseNodeKeysProvided`

Motivation and Context
---
Fixes: #5116 
Increases error clarity to help callee know whats wrong.

How Has This Been Tested?
---
manual
