### PR TITLE
fix: add burnt utxos to side chain query

### DIFF
--- a/base_layer/core/src/transactions/transaction_components/output_type.rs
+++ b/base_layer/core/src/transactions/transaction_components/output_type.rs
@@ -82,7 +82,7 @@ impl OutputType {
     pub fn is_sidechain_type(&self) -> bool {
         matches!(
             self,
-            OutputType::ValidatorNodeRegistration | OutputType::CodeTemplateRegistration
+            OutputType::ValidatorNodeRegistration | OutputType::CodeTemplateRegistration | OutputType::Burn
         )
     }
 }


### PR DESCRIPTION
Description
---
Add burnt UTXOs to the list of sidechain UTXOs that the second layer queries

Motivation and Context
---
The second layer queries only sidechain-relevant UTXOs. Burns were excluded, but need to be included in order to be scanned

How Has This Been Tested?
---
Manual testing with second layer scanner

