### PR TITLE
feat: add tx_id_to export

### DIFF
--- a/applications/tari_console_wallet/src/automation/commands.rs
+++ b/applications/tari_console_wallet/src/automation/commands.rs
@@ -765,6 +765,7 @@ pub async fn command_runner(
             },
             ExportUtxos(args) => match output_service.get_unspent_outputs().await {
                 Ok(utxos) => {
+                    let utxos: Vec<UnblindedOutput> = utxos.into_iter().map(|v| v.0).collect();
                     let count = utxos.len();
                     let sum: MicroTari = utxos.iter().map(|utxo| utxo.value).sum();
                     if let Some(file) = args.output_file {
@@ -801,6 +802,7 @@ pub async fn command_runner(
             },
             CountUtxos => match output_service.get_unspent_outputs().await {
                 Ok(utxos) => {
+                    let utxos: Vec<UnblindedOutput> = utxos.into_iter().map(|v| v.0).collect();
                     let count = utxos.len();
                     let values: Vec<MicroTari> = utxos.iter().map(|utxo| utxo.value).collect();
                     let sum: MicroTari = values.iter().sum();

--- a/applications/tari_console_wallet/src/automation/commands.rs
+++ b/applications/tari_console_wallet/src/automation/commands.rs
@@ -765,7 +765,7 @@ pub async fn command_runner(
             },
             ExportUtxos(args) => match output_service.get_unspent_outputs().await {
                 Ok(utxos) => {
-                    let utxos: Vec<UnblindedOutput> = utxos.into_iter().map(|v| v.0).collect();
+                    let utxos: Vec<UnblindedOutput> = utxos.into_iter().map(|v| v.unblinded_output).collect();
                     let count = utxos.len();
                     let sum: MicroTari = utxos.iter().map(|utxo| utxo.value).sum();
                     if let Some(file) = args.output_file {
@@ -802,7 +802,7 @@ pub async fn command_runner(
             },
             CountUtxos => match output_service.get_unspent_outputs().await {
                 Ok(utxos) => {
-                    let utxos: Vec<UnblindedOutput> = utxos.into_iter().map(|v| v.0).collect();
+                    let utxos: Vec<UnblindedOutput> = utxos.into_iter().map(|v| v.unblinded_output).collect();
                     let count = utxos.len();
                     let values: Vec<MicroTari> = utxos.iter().map(|utxo| utxo.value).collect();
                     let sum: MicroTari = values.iter().sum();

--- a/applications/tari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/tari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -274,7 +274,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
         Ok(Response::new(GetUnspentAmountsResponse {
             amount: unspent_amounts
                 .into_iter()
-                .map(|o| o.0.value.as_u64())
+                .map(|o| o.unblinded_output.value.as_u64())
                 .filter(|&a| a > 0)
                 .collect(),
         }))

--- a/applications/tari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/tari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -274,7 +274,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
         Ok(Response::new(GetUnspentAmountsResponse {
             amount: unspent_amounts
                 .into_iter()
-                .map(|o| o.value.as_u64())
+                .map(|o| o.0.value.as_u64())
                 .filter(|&a| a > 0)
                 .collect(),
         }))

--- a/base_layer/wallet/src/output_manager_service/handle.rs
+++ b/base_layer/wallet/src/output_manager_service/handle.rs
@@ -252,7 +252,7 @@ pub enum OutputManagerResponse {
     TransactionToSend(SenderTransactionProtocol),
     TransactionCancelled,
     SpentOutputs(Vec<UnblindedOutput>),
-    UnspentOutputs(Vec<UnblindedOutput>),
+    UnspentOutputs(Vec<(UnblindedOutput, u64)>),
     Outputs(Vec<UnblindedOutput>),
     InvalidOutputs(Vec<UnblindedOutput>),
     BaseNodePublicKeySet,
@@ -625,7 +625,7 @@ impl OutputManagerHandle {
     }
 
     /// Sorted from lowest value to highest
-    pub async fn get_unspent_outputs(&mut self) -> Result<Vec<UnblindedOutput>, OutputManagerError> {
+    pub async fn get_unspent_outputs(&mut self) -> Result<Vec<(UnblindedOutput, u64)>, OutputManagerError> {
         match self.handle.call(OutputManagerRequest::GetUnspentOutputs).await?? {
             OutputManagerResponse::UnspentOutputs(s) => Ok(s),
             _ => Err(OutputManagerError::UnexpectedApiResponse),

--- a/base_layer/wallet/src/output_manager_service/handle.rs
+++ b/base_layer/wallet/src/output_manager_service/handle.rs
@@ -53,7 +53,7 @@ use crate::output_manager_service::{
     service::{Balance, OutputStatusesByTxId},
     storage::{
         database::OutputBackendQuery,
-        models::{KnownOneSidedPaymentScript, SpendingPriority},
+        models::{DbUnblindedOutput, KnownOneSidedPaymentScript, SpendingPriority},
     },
     UtxoSelectionCriteria,
 };
@@ -252,7 +252,7 @@ pub enum OutputManagerResponse {
     TransactionToSend(SenderTransactionProtocol),
     TransactionCancelled,
     SpentOutputs(Vec<UnblindedOutput>),
-    UnspentOutputs(Vec<(UnblindedOutput, u64)>),
+    UnspentOutputs(Vec<DbUnblindedOutput>),
     Outputs(Vec<UnblindedOutput>),
     InvalidOutputs(Vec<UnblindedOutput>),
     BaseNodePublicKeySet,
@@ -625,7 +625,7 @@ impl OutputManagerHandle {
     }
 
     /// Sorted from lowest value to highest
-    pub async fn get_unspent_outputs(&mut self) -> Result<Vec<(UnblindedOutput, u64)>, OutputManagerError> {
+    pub async fn get_unspent_outputs(&mut self) -> Result<Vec<DbUnblindedOutput>, OutputManagerError> {
         match self.handle.call(OutputManagerRequest::GetUnspentOutputs).await?? {
             OutputManagerResponse::UnspentOutputs(s) => Ok(s),
             _ => Err(OutputManagerError::UnexpectedApiResponse),

--- a/base_layer/wallet/src/output_manager_service/recovery/standard_outputs_recoverer.rs
+++ b/base_layer/wallet/src/output_manager_service/recovery/standard_outputs_recoverer.rs
@@ -161,6 +161,8 @@ where
                 None,
                 Some(proof),
                 output_source,
+                None,
+                None,
             )?;
             let tx_id = TxId::new_random();
             let output_hex = db_output.commitment.to_hex();

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -351,7 +351,11 @@ where
                 Ok(OutputManagerResponse::SpentOutputs(outputs))
             },
             OutputManagerRequest::GetUnspentOutputs => {
-                let outputs = self.fetch_unspent_outputs()?.into_iter().map(|v| v.into()).collect();
+                let outputs = self
+                    .fetch_unspent_outputs()?
+                    .into_iter()
+                    .map(|(output, tx_id)| (output.into(), tx_id))
+                    .collect();
                 Ok(OutputManagerResponse::UnspentOutputs(outputs))
             },
             OutputManagerRequest::GetOutputsBy(q) => {
@@ -1533,7 +1537,7 @@ where
         Ok(self.resources.db.fetch_spent_outputs()?)
     }
 
-    pub fn fetch_unspent_outputs(&self) -> Result<Vec<DbUnblindedOutput>, OutputManagerError> {
+    pub fn fetch_unspent_outputs(&self) -> Result<Vec<(DbUnblindedOutput, u64)>, OutputManagerError> {
         Ok(self.resources.db.fetch_all_unspent_outputs()?)
     }
 

--- a/base_layer/wallet/src/output_manager_service/storage/database/mod.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/database/mod.rs
@@ -99,7 +99,7 @@ pub enum DbKey {
 pub enum DbValue {
     SpentOutput(Box<DbUnblindedOutput>),
     UnspentOutput(Box<DbUnblindedOutput>),
-    UnspentOutputs(Vec<(DbUnblindedOutput, u64)>),
+    UnspentOutputs(Vec<DbUnblindedOutput>),
     SpentOutputs(Vec<DbUnblindedOutput>),
     InvalidOutputs(Vec<DbUnblindedOutput>),
     KnownOneSidedPaymentScripts(Vec<KnownOneSidedPaymentScript>),
@@ -218,7 +218,7 @@ where T: OutputManagerBackend + 'static
         self.db.cancel_pending_transaction(tx_id)
     }
 
-    pub fn fetch_all_unspent_outputs(&self) -> Result<Vec<(DbUnblindedOutput, u64)>, OutputManagerStorageError> {
+    pub fn fetch_all_unspent_outputs(&self) -> Result<Vec<DbUnblindedOutput>, OutputManagerStorageError> {
         let result = match self.db.fetch(&DbKey::UnspentOutputs)? {
             Some(DbValue::UnspentOutputs(outputs)) => outputs,
             Some(other) => return unexpected_result(DbKey::UnspentOutputs, other),
@@ -300,8 +300,7 @@ where T: OutputManagerBackend + 'static
             Ok(Some(other)) => unexpected_result(DbKey::UnspentOutputs, other),
             Err(e) => log_error(DbKey::UnspentOutputs, e),
         }?;
-        let outputs = uo.into_iter().map(|(output, _)| (output)).collect();
-        Ok(outputs)
+        Ok(uo)
     }
 
     pub fn get_invalid_outputs(&self) -> Result<Vec<DbUnblindedOutput>, OutputManagerStorageError> {

--- a/base_layer/wallet/src/output_manager_service/storage/models.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/models.rs
@@ -24,7 +24,10 @@ use std::cmp::Ordering;
 
 use chrono::NaiveDateTime;
 use derivative::Derivative;
-use tari_common_types::types::{BlockHash, BulletRangeProof, Commitment, HashOutput, PrivateKey};
+use tari_common_types::{
+    transaction::TxId,
+    types::{BlockHash, BulletRangeProof, Commitment, HashOutput, PrivateKey},
+};
 use tari_core::transactions::{
     transaction_components::UnblindedOutput,
     transaction_protocol::RewindData,
@@ -51,6 +54,8 @@ pub struct DbUnblindedOutput {
     pub marked_deleted_in_block: Option<BlockHash>,
     pub spending_priority: SpendingPriority,
     pub source: OutputSource,
+    pub received_in_tx_id: Option<TxId>,
+    pub spent_in_tx_id: Option<TxId>,
 }
 
 impl DbUnblindedOutput {
@@ -59,6 +64,8 @@ impl DbUnblindedOutput {
         factory: &CryptoFactories,
         spend_priority: Option<SpendingPriority>,
         source: OutputSource,
+        received_in_tx_id: Option<TxId>,
+        spent_in_tx_id: Option<TxId>,
     ) -> Result<DbUnblindedOutput, OutputManagerStorageError> {
         let tx_out = output.as_transaction_output(factory)?;
         Ok(DbUnblindedOutput {
@@ -74,6 +81,8 @@ impl DbUnblindedOutput {
             marked_deleted_in_block: None,
             spending_priority: spend_priority.unwrap_or(SpendingPriority::Normal),
             source,
+            received_in_tx_id,
+            spent_in_tx_id,
         })
     }
 
@@ -84,6 +93,8 @@ impl DbUnblindedOutput {
         spending_priority: Option<SpendingPriority>,
         proof: Option<&BulletRangeProof>,
         source: OutputSource,
+        received_in_tx_id: Option<TxId>,
+        spent_in_tx_id: Option<TxId>,
     ) -> Result<DbUnblindedOutput, OutputManagerStorageError> {
         let tx_out = output.as_rewindable_transaction_output(factory, rewind_data, proof)?;
         Ok(DbUnblindedOutput {
@@ -99,6 +110,8 @@ impl DbUnblindedOutput {
             marked_deleted_in_block: None,
             spending_priority: spending_priority.unwrap_or(SpendingPriority::Normal),
             source,
+            received_in_tx_id,
+            spent_in_tx_id,
         })
     }
 }

--- a/base_layer/wallet/src/output_manager_service/storage/sqlite_db/mod.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/sqlite_db/mod.rs
@@ -202,11 +202,7 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
                 Some(DbValue::UnspentOutputs(
                     outputs
                         .iter()
-                        .map(|o| {
-                            o.clone()
-                                .to_db_unblinded_output(&cipher)
-                                .map(|v| (v, o.received_in_tx_id.unwrap_or_default() as u64))
-                        })
+                        .map(|o| o.clone().to_db_unblinded_output(&cipher))
                         .collect::<Result<Vec<_>, _>>()?,
                 ))
             },
@@ -226,11 +222,7 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
                 Some(DbValue::UnspentOutputs(
                     outputs
                         .iter()
-                        .map(|o| {
-                            o.clone()
-                                .to_db_unblinded_output(&cipher)
-                                .map(|v| (v, o.received_in_tx_id.unwrap_or_default() as u64))
-                        })
+                        .map(|o| o.clone().to_db_unblinded_output(&cipher))
                         .collect::<Result<Vec<_>, _>>()?,
                 ))
             },

--- a/base_layer/wallet/src/output_manager_service/storage/sqlite_db/mod.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/sqlite_db/mod.rs
@@ -1439,7 +1439,7 @@ mod test {
 
         for _i in 0..2 {
             let (_, uo) = make_input(MicroTari::from(100 + OsRng.next_u64() % 1000));
-            let uo = DbUnblindedOutput::from_unblinded_output(uo, &factories, None, OutputSource::Unknown).unwrap();
+            let uo = DbUnblindedOutput::from_unblinded_output(uo, &factories, None, OutputSource::Unknown, None, None).unwrap();
             let o = NewOutputSql::new(uo, OutputStatus::Unspent, None, None, &cipher).unwrap();
             outputs.push(o.clone());
             outputs_unspent.push(o.clone());
@@ -1448,7 +1448,7 @@ mod test {
 
         for _i in 0..3 {
             let (_, uo) = make_input(MicroTari::from(100 + OsRng.next_u64() % 1000));
-            let uo = DbUnblindedOutput::from_unblinded_output(uo, &factories, None, OutputSource::Unknown).unwrap();
+            let uo = DbUnblindedOutput::from_unblinded_output(uo, &factories, None, OutputSource::Unknown, None, None).unwrap();
             let o = NewOutputSql::new(uo, OutputStatus::Spent, None, None, &cipher).unwrap();
             outputs.push(o.clone());
             outputs_spent.push(o.clone());
@@ -1556,7 +1556,7 @@ mod test {
         let (_, uo) = make_input(MicroTari::from(100 + OsRng.next_u64() % 1000));
         let decrypted_spending_key = uo.spending_key.to_vec();
 
-        let uo = DbUnblindedOutput::from_unblinded_output(uo, &factories, None, OutputSource::Unknown).unwrap();
+        let uo = DbUnblindedOutput::from_unblinded_output(uo, &factories, None, OutputSource::Unknown, None, None).unwrap();
 
         let output = NewOutputSql::new(uo, OutputStatus::Unspent, None, None, &cipher).unwrap();
 

--- a/base_layer/wallet/src/output_manager_service/storage/sqlite_db/mod.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/sqlite_db/mod.rs
@@ -1412,6 +1412,7 @@ mod test {
         (input, unblinded_output)
     }
 
+    #[allow(clippy::too_many_lines)]
     #[test]
     fn test_crud() {
         let db_name = format!("{}.sqlite3", random::string(8).as_str());
@@ -1439,7 +1440,8 @@ mod test {
 
         for _i in 0..2 {
             let (_, uo) = make_input(MicroTari::from(100 + OsRng.next_u64() % 1000));
-            let uo = DbUnblindedOutput::from_unblinded_output(uo, &factories, None, OutputSource::Unknown, None, None).unwrap();
+            let uo = DbUnblindedOutput::from_unblinded_output(uo, &factories, None, OutputSource::Unknown, None, None)
+                .unwrap();
             let o = NewOutputSql::new(uo, OutputStatus::Unspent, None, None, &cipher).unwrap();
             outputs.push(o.clone());
             outputs_unspent.push(o.clone());
@@ -1448,7 +1450,8 @@ mod test {
 
         for _i in 0..3 {
             let (_, uo) = make_input(MicroTari::from(100 + OsRng.next_u64() % 1000));
-            let uo = DbUnblindedOutput::from_unblinded_output(uo, &factories, None, OutputSource::Unknown, None, None).unwrap();
+            let uo = DbUnblindedOutput::from_unblinded_output(uo, &factories, None, OutputSource::Unknown, None, None)
+                .unwrap();
             let o = NewOutputSql::new(uo, OutputStatus::Spent, None, None, &cipher).unwrap();
             outputs.push(o.clone());
             outputs_spent.push(o.clone());
@@ -1556,7 +1559,8 @@ mod test {
         let (_, uo) = make_input(MicroTari::from(100 + OsRng.next_u64() % 1000));
         let decrypted_spending_key = uo.spending_key.to_vec();
 
-        let uo = DbUnblindedOutput::from_unblinded_output(uo, &factories, None, OutputSource::Unknown, None, None).unwrap();
+        let uo =
+            DbUnblindedOutput::from_unblinded_output(uo, &factories, None, OutputSource::Unknown, None, None).unwrap();
 
         let output = NewOutputSql::new(uo, OutputStatus::Unspent, None, None, &cipher).unwrap();
 

--- a/base_layer/wallet/src/output_manager_service/storage/sqlite_db/mod.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/sqlite_db/mod.rs
@@ -202,7 +202,11 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
                 Some(DbValue::UnspentOutputs(
                     outputs
                         .iter()
-                        .map(|o| o.clone().to_db_unblinded_output(&cipher))
+                        .map(|o| {
+                            o.clone()
+                                .to_db_unblinded_output(&cipher)
+                                .map(|v| (v, o.received_in_tx_id.unwrap_or_default() as u64))
+                        })
                         .collect::<Result<Vec<_>, _>>()?,
                 ))
             },
@@ -222,7 +226,11 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
                 Some(DbValue::UnspentOutputs(
                     outputs
                         .iter()
-                        .map(|o| o.clone().to_db_unblinded_output(&cipher))
+                        .map(|o| {
+                            o.clone()
+                                .to_db_unblinded_output(&cipher)
+                                .map(|v| (v, o.received_in_tx_id.unwrap_or_default() as u64))
+                        })
                         .collect::<Result<Vec<_>, _>>()?,
                 ))
             },

--- a/base_layer/wallet/src/output_manager_service/storage/sqlite_db/output_sql.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/sqlite_db/output_sql.rs
@@ -795,6 +795,8 @@ impl OutputSql {
             marked_deleted_in_block,
             spending_priority,
             source: o.source.try_into()?,
+            received_in_tx_id: o.received_in_tx_id.map(|d| (d as u64).into()),
+            spent_in_tx_id: o.spent_in_tx_id.map(|d| (d as u64).into()),
         })
     }
 }

--- a/base_layer/wallet/src/storage/sqlite_db/wallet.rs
+++ b/base_layer/wallet/src/storage/sqlite_db/wallet.rs
@@ -866,7 +866,7 @@ mod test {
         let value2 = "value2".to_string();
 
         let passphrase = "a very very secret key example.".to_string().into();
-        let db = WalletSqliteDatabase::new(connection.clone(), passphrase).unwrap();
+        let db = WalletSqliteDatabase::new(connection, passphrase).unwrap();
         let cipher = db.cipher();
 
         ClientKeyValueSql::new(key1.clone(), value1.clone(), &cipher)

--- a/base_layer/wallet/tests/output_manager_service_tests/service.rs
+++ b/base_layer/wallet/tests/output_manager_service_tests/service.rs
@@ -495,8 +495,8 @@ async fn test_utxo_selection_no_chain_metadata() {
     assert_eq!(utxos.len(), 8);
     for (index, utxo) in utxos.iter().enumerate() {
         let i = index as u64 + 3;
-        assert_eq!(utxo.0.features.maturity, i);
-        assert_eq!(utxo.0.value, i * amount);
+        assert_eq!(utxo.unblinded_output.features.maturity, i);
+        assert_eq!(utxo.unblinded_output.value, i * amount);
     }
 
     // test that we can get a fee estimate with no chain metadata
@@ -530,10 +530,10 @@ async fn test_utxo_selection_no_chain_metadata() {
     // test that largest utxo was encumbered
     let utxos = oms.get_unspent_outputs().await.unwrap();
     assert_eq!(utxos.len(), 7);
-    for (index, (utxo, _)) in utxos.iter().enumerate() {
+    for (index, utxo) in utxos.iter().enumerate() {
         let i = index as u64 + 3;
-        assert_eq!(utxo.features.maturity, i);
-        assert_eq!(utxo.value, i * amount);
+        assert_eq!(utxo.unblinded_output.features.maturity, i);
+        assert_eq!(utxo.unblinded_output.value, i * amount);
     }
 }
 
@@ -621,7 +621,7 @@ async fn test_utxo_selection_with_chain_metadata() {
     // test that largest spendable utxo was encumbered
     let utxos = oms.get_unspent_outputs().await.unwrap();
     assert_eq!(utxos.len(), 9);
-    let found = utxos.iter().any(|u| u.0.value == 6 * amount);
+    let found = utxos.iter().any(|u| u.unblinded_output.value == 6 * amount);
     assert!(!found, "An unspendable utxo was selected");
 
     // test transactions
@@ -645,11 +645,11 @@ async fn test_utxo_selection_with_chain_metadata() {
     // test that utxos with the lowest 2 maturities were encumbered
     let utxos = oms.get_unspent_outputs().await.unwrap();
     assert_eq!(utxos.len(), 7);
-    for (utxo, _) in &utxos {
-        assert_ne!(utxo.features.maturity, 1);
-        assert_ne!(utxo.value, amount);
-        assert_ne!(utxo.features.maturity, 2);
-        assert_ne!(utxo.value, 2 * amount);
+    for utxo in &utxos {
+        assert_ne!(utxo.unblinded_output.features.maturity, 1);
+        assert_ne!(utxo.unblinded_output.value, amount);
+        assert_ne!(utxo.unblinded_output.features.maturity, 2);
+        assert_ne!(utxo.unblinded_output.value, 2 * amount);
     }
 
     // when the amount is greater than the largest utxo, then "Largest" selection strategy is used
@@ -673,11 +673,11 @@ async fn test_utxo_selection_with_chain_metadata() {
     // test that utxos with the highest spendable 2 maturities were encumbered
     let utxos = oms.get_unspent_outputs().await.unwrap();
     assert_eq!(utxos.len(), 5);
-    for (utxo, _) in &utxos {
-        assert_ne!(utxo.features.maturity, 4);
-        assert_ne!(utxo.value, 4 * amount);
-        assert_ne!(utxo.features.maturity, 5);
-        assert_ne!(utxo.value, 5 * amount);
+    for utxo in &utxos {
+        assert_ne!(utxo.unblinded_output.features.maturity, 4);
+        assert_ne!(utxo.unblinded_output.value, 4 * amount);
+        assert_ne!(utxo.unblinded_output.features.maturity, 5);
+        assert_ne!(utxo.unblinded_output.value, 5 * amount);
     }
 }
 
@@ -752,7 +752,7 @@ async fn test_utxo_selection_with_tx_priority() {
     let utxos = oms.get_unspent_outputs().await.unwrap();
     assert_eq!(utxos.len(), 1);
 
-    assert_ne!(utxos[0].0.features.output_type, OutputType::Coinbase);
+    assert_ne!(utxos[0].unblinded_output.features.output_type, OutputType::Coinbase);
 }
 
 #[tokio::test]

--- a/base_layer/wallet/tests/output_manager_service_tests/service.rs
+++ b/base_layer/wallet/tests/output_manager_service_tests/service.rs
@@ -495,8 +495,8 @@ async fn test_utxo_selection_no_chain_metadata() {
     assert_eq!(utxos.len(), 8);
     for (index, utxo) in utxos.iter().enumerate() {
         let i = index as u64 + 3;
-        assert_eq!(utxo.features.maturity, i);
-        assert_eq!(utxo.value, i * amount);
+        assert_eq!(utxo.0.features.maturity, i);
+        assert_eq!(utxo.0.value, i * amount);
     }
 
     // test that we can get a fee estimate with no chain metadata
@@ -530,7 +530,7 @@ async fn test_utxo_selection_no_chain_metadata() {
     // test that largest utxo was encumbered
     let utxos = oms.get_unspent_outputs().await.unwrap();
     assert_eq!(utxos.len(), 7);
-    for (index, utxo) in utxos.iter().enumerate() {
+    for (index, (utxo, _)) in utxos.iter().enumerate() {
         let i = index as u64 + 3;
         assert_eq!(utxo.features.maturity, i);
         assert_eq!(utxo.value, i * amount);
@@ -621,7 +621,7 @@ async fn test_utxo_selection_with_chain_metadata() {
     // test that largest spendable utxo was encumbered
     let utxos = oms.get_unspent_outputs().await.unwrap();
     assert_eq!(utxos.len(), 9);
-    let found = utxos.iter().any(|u| u.value == 6 * amount);
+    let found = utxos.iter().any(|u| u.0.value == 6 * amount);
     assert!(!found, "An unspendable utxo was selected");
 
     // test transactions
@@ -645,7 +645,7 @@ async fn test_utxo_selection_with_chain_metadata() {
     // test that utxos with the lowest 2 maturities were encumbered
     let utxos = oms.get_unspent_outputs().await.unwrap();
     assert_eq!(utxos.len(), 7);
-    for utxo in &utxos {
+    for (utxo, _) in &utxos {
         assert_ne!(utxo.features.maturity, 1);
         assert_ne!(utxo.value, amount);
         assert_ne!(utxo.features.maturity, 2);
@@ -673,7 +673,7 @@ async fn test_utxo_selection_with_chain_metadata() {
     // test that utxos with the highest spendable 2 maturities were encumbered
     let utxos = oms.get_unspent_outputs().await.unwrap();
     assert_eq!(utxos.len(), 5);
-    for utxo in &utxos {
+    for (utxo, _) in &utxos {
         assert_ne!(utxo.features.maturity, 4);
         assert_ne!(utxo.value, 4 * amount);
         assert_ne!(utxo.features.maturity, 5);
@@ -752,7 +752,7 @@ async fn test_utxo_selection_with_tx_priority() {
     let utxos = oms.get_unspent_outputs().await.unwrap();
     assert_eq!(utxos.len(), 1);
 
-    assert_ne!(utxos[0].features.output_type, OutputType::Coinbase);
+    assert_ne!(utxos[0].0.features.output_type, OutputType::Coinbase);
 }
 
 #[tokio::test]

--- a/base_layer/wallet/tests/output_manager_service_tests/storage.rs
+++ b/base_layer/wallet/tests/output_manager_service_tests/storage.rs
@@ -55,7 +55,8 @@ pub fn test_db_backend<T: OutputManagerBackend + 'static>(backend: T) {
             MicroTari::from(100 + OsRng.next_u64() % 1000),
             &factories.commitment,
         ));
-        let mut uo = DbUnblindedOutput::from_unblinded_output(uo, &factories, None, OutputSource::Unknown, None, None).unwrap();
+        let mut uo =
+            DbUnblindedOutput::from_unblinded_output(uo, &factories, None, OutputSource::Unknown, None, None).unwrap();
         uo.unblinded_output.features.maturity = i;
         db.add_unspent_output(uo.clone()).unwrap();
         unspent_outputs.push(uo);
@@ -102,7 +103,8 @@ pub fn test_db_backend<T: OutputManagerBackend + 'static>(backend: T) {
                 MicroTari::from(100 + OsRng.next_u64() % 1000),
                 &factories.commitment,
             ));
-            let uo = DbUnblindedOutput::from_unblinded_output(uo, &factories, None, OutputSource::Unknown, None, None).unwrap();
+            let uo = DbUnblindedOutput::from_unblinded_output(uo, &factories, None, OutputSource::Unknown, None, None)
+                .unwrap();
             db.add_unspent_output(uo.clone()).unwrap();
             pending_tx.outputs_to_be_spent.push(uo);
         }
@@ -112,7 +114,8 @@ pub fn test_db_backend<T: OutputManagerBackend + 'static>(backend: T) {
                 MicroTari::from(100 + OsRng.next_u64() % 1000),
                 &factories.commitment,
             ));
-            let uo = DbUnblindedOutput::from_unblinded_output(uo, &factories, None, OutputSource::Unknown, None, None).unwrap();
+            let uo = DbUnblindedOutput::from_unblinded_output(uo, &factories, None, OutputSource::Unknown, None, None)
+                .unwrap();
             pending_tx.outputs_to_be_received.push(uo);
         }
         db.encumber_outputs(
@@ -360,7 +363,8 @@ pub async fn test_short_term_encumberance() {
             &factories.commitment,
         )
         .await;
-        let mut uo = DbUnblindedOutput::from_unblinded_output(uo, &factories, None, OutputSource::Unknown, None, None).unwrap();
+        let mut uo =
+            DbUnblindedOutput::from_unblinded_output(uo, &factories, None, OutputSource::Unknown, None, None).unwrap();
         uo.unblinded_output.features.maturity = i;
         db.add_unspent_output(uo.clone()).unwrap();
         unspent_outputs.push(uo);

--- a/base_layer/wallet/tests/output_manager_service_tests/storage.rs
+++ b/base_layer/wallet/tests/output_manager_service_tests/storage.rs
@@ -55,7 +55,7 @@ pub fn test_db_backend<T: OutputManagerBackend + 'static>(backend: T) {
             MicroTari::from(100 + OsRng.next_u64() % 1000),
             &factories.commitment,
         ));
-        let mut uo = DbUnblindedOutput::from_unblinded_output(uo, &factories, None, OutputSource::Unknown).unwrap();
+        let mut uo = DbUnblindedOutput::from_unblinded_output(uo, &factories, None, OutputSource::Unknown, None, None).unwrap();
         uo.unblinded_output.features.maturity = i;
         db.add_unspent_output(uo.clone()).unwrap();
         unspent_outputs.push(uo);
@@ -102,7 +102,7 @@ pub fn test_db_backend<T: OutputManagerBackend + 'static>(backend: T) {
                 MicroTari::from(100 + OsRng.next_u64() % 1000),
                 &factories.commitment,
             ));
-            let uo = DbUnblindedOutput::from_unblinded_output(uo, &factories, None, OutputSource::Unknown).unwrap();
+            let uo = DbUnblindedOutput::from_unblinded_output(uo, &factories, None, OutputSource::Unknown, None, None).unwrap();
             db.add_unspent_output(uo.clone()).unwrap();
             pending_tx.outputs_to_be_spent.push(uo);
         }
@@ -112,7 +112,7 @@ pub fn test_db_backend<T: OutputManagerBackend + 'static>(backend: T) {
                 MicroTari::from(100 + OsRng.next_u64() % 1000),
                 &factories.commitment,
             ));
-            let uo = DbUnblindedOutput::from_unblinded_output(uo, &factories, None, OutputSource::Unknown).unwrap();
+            let uo = DbUnblindedOutput::from_unblinded_output(uo, &factories, None, OutputSource::Unknown, None, None).unwrap();
             pending_tx.outputs_to_be_received.push(uo);
         }
         db.encumber_outputs(
@@ -248,7 +248,7 @@ pub fn test_db_backend<T: OutputManagerBackend + 'static>(backend: T) {
         &factories.commitment,
     ));
     let output_to_be_received =
-        DbUnblindedOutput::from_unblinded_output(uo, &factories, None, OutputSource::Unknown).unwrap();
+        DbUnblindedOutput::from_unblinded_output(uo, &factories, None, OutputSource::Unknown, None, None).unwrap();
     db.add_output_to_be_received(TxId::from(11u64), output_to_be_received.clone(), None)
         .unwrap();
     pending_incoming_balance += output_to_be_received.unblinded_output.value;
@@ -360,7 +360,7 @@ pub async fn test_short_term_encumberance() {
             &factories.commitment,
         )
         .await;
-        let mut uo = DbUnblindedOutput::from_unblinded_output(uo, &factories, None, OutputSource::Unknown).unwrap();
+        let mut uo = DbUnblindedOutput::from_unblinded_output(uo, &factories, None, OutputSource::Unknown, None, None).unwrap();
         uo.unblinded_output.features.maturity = i;
         db.add_unspent_output(uo.clone()).unwrap();
         unspent_outputs.push(uo);
@@ -417,7 +417,7 @@ pub async fn test_no_duplicate_outputs() {
 
     // create an output
     let (_ti, uo) = make_input(&mut OsRng, MicroTari::from(1000), &factories.commitment).await;
-    let uo = DbUnblindedOutput::from_unblinded_output(uo, &factories, None, OutputSource::Unknown).unwrap();
+    let uo = DbUnblindedOutput::from_unblinded_output(uo, &factories, None, OutputSource::Unknown, None, None).unwrap();
 
     // add it to the database
     let result = db.add_unspent_output(uo.clone());
@@ -457,7 +457,7 @@ pub async fn test_mark_as_unmined() {
 
     // create an output
     let (_ti, uo) = make_input(&mut OsRng, MicroTari::from(1000), &factories.commitment).await;
-    let uo = DbUnblindedOutput::from_unblinded_output(uo, &factories, None, OutputSource::Unknown).unwrap();
+    let uo = DbUnblindedOutput::from_unblinded_output(uo, &factories, None, OutputSource::Unknown, None, None).unwrap();
 
     // add it to the database
     db.add_unspent_output(uo.clone()).unwrap();

--- a/base_layer/wallet/tests/utxo_scanner.rs
+++ b/base_layer/wallet/tests/utxo_scanner.rs
@@ -325,8 +325,15 @@ async fn test_utxo_scanner_recovery() {
     let mut total_amount_to_recover = MicroTari::from(0);
     for (h, outputs) in &unblinded_outputs {
         for output in outputs.iter().skip(outputs.len() / 2) {
-            let dbo = DbUnblindedOutput::from_unblinded_output(output.clone(), &factories, None, OutputSource::Unknown, None, None)
-                .unwrap();
+            let dbo = DbUnblindedOutput::from_unblinded_output(
+                output.clone(),
+                &factories,
+                None,
+                OutputSource::Unknown,
+                None,
+                None,
+            )
+            .unwrap();
             // Only the outputs in blocks after the birthday should be included in the recovered total
             if *h >= NUM_BLOCKS.saturating_sub(BIRTHDAY_OFFSET).saturating_sub(2) {
                 total_outputs_to_recover += 1;
@@ -417,8 +424,15 @@ async fn test_utxo_scanner_recovery_with_restart() {
     let mut total_amount_to_recover = MicroTari::from(0);
     for (h, outputs) in &unblinded_outputs {
         for output in outputs.iter().skip(outputs.len() / 2) {
-            let dbo = DbUnblindedOutput::from_unblinded_output(output.clone(), &factories, None, OutputSource::Unknown, None, None)
-                .unwrap();
+            let dbo = DbUnblindedOutput::from_unblinded_output(
+                output.clone(),
+                &factories,
+                None,
+                OutputSource::Unknown,
+                None,
+                None,
+            )
+            .unwrap();
             // Only the outputs in blocks after the birthday should be included in the recovered total
             if *h >= NUM_BLOCKS.saturating_sub(BIRTHDAY_OFFSET).saturating_sub(2) {
                 total_outputs_to_recover += 1;
@@ -573,8 +587,15 @@ async fn test_utxo_scanner_recovery_with_restart_and_reorg() {
     let mut db_unblinded_outputs = Vec::new();
     for outputs in unblinded_outputs.values() {
         for output in outputs.iter().skip(outputs.len() / 2) {
-            let dbo = DbUnblindedOutput::from_unblinded_output(output.clone(), &factories, None, OutputSource::Unknown, None, None)
-                .unwrap();
+            let dbo = DbUnblindedOutput::from_unblinded_output(
+                output.clone(),
+                &factories,
+                None,
+                OutputSource::Unknown,
+                None,
+                None,
+            )
+            .unwrap();
             db_unblinded_outputs.push(dbo);
         }
     }
@@ -642,8 +663,15 @@ async fn test_utxo_scanner_recovery_with_restart_and_reorg() {
     let mut total_amount_to_recover = MicroTari::from(0);
     for (h, outputs) in &unblinded_outputs {
         for output in outputs.iter().skip(outputs.len() / 2) {
-            let dbo = DbUnblindedOutput::from_unblinded_output(output.clone(), &factories, None, OutputSource::Unknown, None, None)
-                .unwrap();
+            let dbo = DbUnblindedOutput::from_unblinded_output(
+                output.clone(),
+                &factories,
+                None,
+                OutputSource::Unknown,
+                None,
+                None,
+            )
+            .unwrap();
             // Only the outputs in blocks after the birthday should be included in the recovered total
             if *h >= 4 {
                 total_outputs_to_recover += 1;
@@ -847,8 +875,15 @@ async fn test_utxo_scanner_one_sided_payments() {
     let mut total_amount_to_recover = MicroTari::from(0);
     for (h, outputs) in &unblinded_outputs {
         for output in outputs.iter().skip(outputs.len() / 2) {
-            let dbo = DbUnblindedOutput::from_unblinded_output(output.clone(), &factories, None, OutputSource::Unknown, None, None)
-                .unwrap();
+            let dbo = DbUnblindedOutput::from_unblinded_output(
+                output.clone(),
+                &factories,
+                None,
+                OutputSource::Unknown,
+                None,
+                None,
+            )
+            .unwrap();
             // Only the outputs in blocks after the birthday should be included in the recovered total
             if *h >= NUM_BLOCKS.saturating_sub(BIRTHDAY_OFFSET).saturating_sub(2) {
                 total_outputs_to_recover += 1;
@@ -921,8 +956,9 @@ async fn test_utxo_scanner_one_sided_payments() {
     utxos_by_block.push(block11);
     block_headers.insert(NUM_BLOCKS, block_header11);
 
-    db_unblinded_outputs
-        .push(DbUnblindedOutput::from_unblinded_output(uo, &factories, None, OutputSource::Unknown, None, None).unwrap());
+    db_unblinded_outputs.push(
+        DbUnblindedOutput::from_unblinded_output(uo, &factories, None, OutputSource::Unknown, None, None).unwrap(),
+    );
     test_interface
         .oms_mock_state
         .set_one_sided_payments(db_unblinded_outputs);

--- a/base_layer/wallet/tests/utxo_scanner.rs
+++ b/base_layer/wallet/tests/utxo_scanner.rs
@@ -325,7 +325,7 @@ async fn test_utxo_scanner_recovery() {
     let mut total_amount_to_recover = MicroTari::from(0);
     for (h, outputs) in &unblinded_outputs {
         for output in outputs.iter().skip(outputs.len() / 2) {
-            let dbo = DbUnblindedOutput::from_unblinded_output(output.clone(), &factories, None, OutputSource::Unknown)
+            let dbo = DbUnblindedOutput::from_unblinded_output(output.clone(), &factories, None, OutputSource::Unknown, None, None)
                 .unwrap();
             // Only the outputs in blocks after the birthday should be included in the recovered total
             if *h >= NUM_BLOCKS.saturating_sub(BIRTHDAY_OFFSET).saturating_sub(2) {
@@ -417,7 +417,7 @@ async fn test_utxo_scanner_recovery_with_restart() {
     let mut total_amount_to_recover = MicroTari::from(0);
     for (h, outputs) in &unblinded_outputs {
         for output in outputs.iter().skip(outputs.len() / 2) {
-            let dbo = DbUnblindedOutput::from_unblinded_output(output.clone(), &factories, None, OutputSource::Unknown)
+            let dbo = DbUnblindedOutput::from_unblinded_output(output.clone(), &factories, None, OutputSource::Unknown, None, None)
                 .unwrap();
             // Only the outputs in blocks after the birthday should be included in the recovered total
             if *h >= NUM_BLOCKS.saturating_sub(BIRTHDAY_OFFSET).saturating_sub(2) {
@@ -573,7 +573,7 @@ async fn test_utxo_scanner_recovery_with_restart_and_reorg() {
     let mut db_unblinded_outputs = Vec::new();
     for outputs in unblinded_outputs.values() {
         for output in outputs.iter().skip(outputs.len() / 2) {
-            let dbo = DbUnblindedOutput::from_unblinded_output(output.clone(), &factories, None, OutputSource::Unknown)
+            let dbo = DbUnblindedOutput::from_unblinded_output(output.clone(), &factories, None, OutputSource::Unknown, None, None)
                 .unwrap();
             db_unblinded_outputs.push(dbo);
         }
@@ -642,7 +642,7 @@ async fn test_utxo_scanner_recovery_with_restart_and_reorg() {
     let mut total_amount_to_recover = MicroTari::from(0);
     for (h, outputs) in &unblinded_outputs {
         for output in outputs.iter().skip(outputs.len() / 2) {
-            let dbo = DbUnblindedOutput::from_unblinded_output(output.clone(), &factories, None, OutputSource::Unknown)
+            let dbo = DbUnblindedOutput::from_unblinded_output(output.clone(), &factories, None, OutputSource::Unknown, None, None)
                 .unwrap();
             // Only the outputs in blocks after the birthday should be included in the recovered total
             if *h >= 4 {
@@ -847,7 +847,7 @@ async fn test_utxo_scanner_one_sided_payments() {
     let mut total_amount_to_recover = MicroTari::from(0);
     for (h, outputs) in &unblinded_outputs {
         for output in outputs.iter().skip(outputs.len() / 2) {
-            let dbo = DbUnblindedOutput::from_unblinded_output(output.clone(), &factories, None, OutputSource::Unknown)
+            let dbo = DbUnblindedOutput::from_unblinded_output(output.clone(), &factories, None, OutputSource::Unknown, None, None)
                 .unwrap();
             // Only the outputs in blocks after the birthday should be included in the recovered total
             if *h >= NUM_BLOCKS.saturating_sub(BIRTHDAY_OFFSET).saturating_sub(2) {
@@ -922,7 +922,7 @@ async fn test_utxo_scanner_one_sided_payments() {
     block_headers.insert(NUM_BLOCKS, block_header11);
 
     db_unblinded_outputs
-        .push(DbUnblindedOutput::from_unblinded_output(uo, &factories, None, OutputSource::Unknown).unwrap());
+        .push(DbUnblindedOutput::from_unblinded_output(uo, &factories, None, OutputSource::Unknown, None, None).unwrap());
     test_interface
         .oms_mock_state
         .set_one_sided_payments(db_unblinded_outputs);

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -203,7 +203,7 @@ pub type TariEncryptedValue = tari_core::transactions::transaction_components::E
 pub type TariComAndPubSignature = tari_common_types::types::ComAndPubSignature;
 pub type TariUnblindedOutput = tari_core::transactions::transaction_components::UnblindedOutput;
 
-pub struct TariUnblindedOutputs(Vec<(TariUnblindedOutput, u64)>);
+pub struct TariUnblindedOutputs(Vec<DbUnblindedOutput>);
 
 pub struct TariContacts(Vec<TariContact>);
 
@@ -1747,7 +1747,7 @@ pub unsafe extern "C" fn unblinded_outputs_get_at(
         ptr::swap(error_out, &mut error as *mut c_int);
         return ptr::null_mut();
     }
-    Box::into_raw(Box::new((*outputs).0[position as usize].0.clone()))
+    Box::into_raw(Box::new((*outputs).0[position as usize].unblinded_output.clone()))
 }
 
 /// Gets a TariUnblindedOutput from TariUnblindedOutputs at position
@@ -1765,7 +1765,7 @@ pub unsafe extern "C" fn unblinded_outputs_get_at(
 /// # Safety
 /// The ```contact_destroy``` method must be called when finished with a TariContact to prevent a memory leak
 #[no_mangle]
-pub unsafe extern "C" fn unblinded_outputs_tx_id_get_at(
+pub unsafe extern "C" fn unblinded_outputs_received_tx_id_get_at(
     outputs: *mut TariUnblindedOutputs,
     position: c_uint,
     error_out: *mut c_int,
@@ -1783,7 +1783,12 @@ pub unsafe extern "C" fn unblinded_outputs_tx_id_get_at(
         ptr::swap(error_out, &mut error as *mut c_int);
         return ptr::null_mut();
     }
-    Box::into_raw(Box::new((*outputs).0[position as usize].1))
+    Box::into_raw(Box::new(
+        (*outputs).0[position as usize]
+            .received_in_tx_id
+            .unwrap_or_default()
+            .as_u64(),
+    ))
 }
 
 /// Frees memory for a TariUnblindedOutputs

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -203,7 +203,7 @@ pub type TariEncryptedValue = tari_core::transactions::transaction_components::E
 pub type TariComAndPubSignature = tari_common_types::types::ComAndPubSignature;
 pub type TariUnblindedOutput = tari_core::transactions::transaction_components::UnblindedOutput;
 
-pub struct TariUnblindedOutputs(Vec<TariUnblindedOutput>);
+pub struct TariUnblindedOutputs(Vec<(TariUnblindedOutput, u64)>);
 
 pub struct TariContacts(Vec<TariContact>);
 
@@ -1613,10 +1613,10 @@ pub unsafe extern "C" fn tari_unblinded_output_to_json(
         ptr::swap(error_out, &mut error as *mut c_int);
     } else {
         match serde_json::to_string(&*output) {
-            Ok(json_string) => match CString::new(json_string.to_string()) {
+            Ok(json_string) => match CString::new(json_string) {
                 Ok(v) => hex_bytes = v,
                 _ => {
-                    error = LibWalletError::from(InterfaceError::PointerError("contact".to_string())).code;
+                    error = LibWalletError::from(InterfaceError::PointerError("output".to_string())).code;
                     ptr::swap(error_out, &mut error as *mut c_int);
                 },
             },
@@ -1747,7 +1747,43 @@ pub unsafe extern "C" fn unblinded_outputs_get_at(
         ptr::swap(error_out, &mut error as *mut c_int);
         return ptr::null_mut();
     }
-    Box::into_raw(Box::new((*outputs).0[position as usize].clone()))
+    Box::into_raw(Box::new((*outputs).0[position as usize].0.clone()))
+}
+
+/// Gets a TariUnblindedOutput from TariUnblindedOutputs at position
+///
+/// ## Arguments
+/// `outputs` - The pointer to a TariUnblindedOutputs
+/// `position` - The integer position
+/// `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
+/// as an out parameter.
+///
+/// ## Returns
+/// `*mut TariUnblindedOutput` - Returns a TariUnblindedOutput, note that it returns ptr::null_mut() if
+/// TariUnblindedOutputs is null or position is invalid
+///
+/// # Safety
+/// The ```contact_destroy``` method must be called when finished with a TariContact to prevent a memory leak
+#[no_mangle]
+pub unsafe extern "C" fn unblinded_outputs_tx_id_get_at(
+    outputs: *mut TariUnblindedOutputs,
+    position: c_uint,
+    error_out: *mut c_int,
+) -> *mut c_ulonglong {
+    let mut error = 0;
+    ptr::swap(error_out, &mut error as *mut c_int);
+    if outputs.is_null() {
+        error = LibWalletError::from(InterfaceError::NullError("outputs".to_string())).code;
+        ptr::swap(error_out, &mut error as *mut c_int);
+        return ptr::null_mut();
+    }
+    let len = unblinded_outputs_get_length(outputs, error_out) as c_int - 1;
+    if len < 0 || position > len as c_uint {
+        error = LibWalletError::from(InterfaceError::PositionInvalidError).code;
+        ptr::swap(error_out, &mut error as *mut c_int);
+        return ptr::null_mut();
+    }
+    Box::into_raw(Box::new((*outputs).0[position as usize].1))
 }
 
 /// Frees memory for a TariUnblindedOutputs
@@ -3676,6 +3712,99 @@ pub unsafe extern "C" fn completed_transaction_get_cancellation_reason(
     match (*tx).cancelled {
         None => -1i32,
         Some(reason) => reason as i32,
+    }
+}
+
+/// returns the TariCompletedTransaction as a json string
+///
+/// ## Arguments
+/// `tx` - The pointer to a TariCompletedTransaction
+///
+/// ## Returns
+/// `*mut c_char` - Returns a pointer to a char array. Note that it returns an empty char array if
+/// TariCompletedTransaction is null or the position is invalid
+///
+/// # Safety
+///  The ```completed_transaction_destroy``` function must be called when finished with a TariCompletedTransaction to
+/// prevent a memory leak
+#[no_mangle]
+pub unsafe extern "C" fn tari_completed_transaction_to_json(
+    tx: *mut TariCompletedTransaction,
+    error_out: *mut c_int,
+) -> *mut c_char {
+    let mut error = 0;
+    ptr::swap(error_out, &mut error as *mut c_int);
+    let mut hex_bytes = CString::new("").expect("Blank CString will not fail.");
+    if tx.is_null() {
+        error = LibWalletError::from(InterfaceError::NullError("transaction".to_string())).code;
+        ptr::swap(error_out, &mut error as *mut c_int);
+    } else {
+        match serde_json::to_string(&*tx) {
+            Ok(json_string) => match CString::new(json_string) {
+                Ok(v) => hex_bytes = v,
+                _ => {
+                    error = LibWalletError::from(InterfaceError::PointerError("transaction".to_string())).code;
+                    ptr::swap(error_out, &mut error as *mut c_int);
+                },
+            },
+            Err(_) => {
+                error = LibWalletError::from(HexError::HexConversionError).code;
+                ptr::swap(error_out, &mut error as *mut c_int);
+            },
+        }
+    }
+    CString::into_raw(hex_bytes)
+}
+
+/// Creates a TariUnblindedOutput from a char array
+///
+/// ## Arguments
+/// `tx_json` - The pointer to a char array which is json of the TariCompletedTransaction
+/// `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
+/// as an out parameter.
+///
+/// ## Returns
+/// `*mut TariCompletedTransaction` - Returns a pointer to a TariCompletedTransaction. Note that it returns
+/// ptr::null_mut() if key is null or if there was an error creating the TariCompletedTransaction from key
+///
+/// # Safety
+/// The ```completed_transaction_destroy``` function must be called when finished with a TariCompletedTransaction to
+// /// prevent a memory leak
+#[no_mangle]
+pub unsafe extern "C" fn create_tari_completed_transaction_from_json(
+    tx_json: *const c_char,
+    error_out: *mut c_int,
+) -> *mut TariCompletedTransaction {
+    let mut error = 0;
+    ptr::swap(error_out, &mut error as *mut c_int);
+    let tx_json_str;
+    if tx_json.is_null() {
+        error = LibWalletError::from(InterfaceError::NullError("tx_json".to_string())).code;
+        ptr::swap(error_out, &mut error as *mut c_int);
+        return ptr::null_mut();
+    } else {
+        match CStr::from_ptr(tx_json).to_str() {
+            Ok(v) => {
+                tx_json_str = v.to_owned();
+            },
+            _ => {
+                error = LibWalletError::from(InterfaceError::PointerError("tx_json".to_string())).code;
+                ptr::swap(error_out, &mut error as *mut c_int);
+                return ptr::null_mut();
+            },
+        };
+    }
+    let tx: Result<TariCompletedTransaction, _> = serde_json::from_str(&tx_json_str);
+
+    match tx {
+        Ok(tx) => Box::into_raw(Box::new(tx)),
+        Err(e) => {
+            error!(target: LOG_TARGET, "Error creating a transaction from json: {:?}", e);
+
+            error = LibWalletError::from(HexError::HexConversionError).code;
+            ptr::swap(error_out, &mut error as *mut c_int);
+            ptr::null_mut()
+        },
     }
 }
 

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -945,6 +945,26 @@ TariUnblindedOutput *unblinded_outputs_get_at(struct TariUnblindedOutputs *outpu
                                               int *error_out);
 
 /**
+ * Gets a TariUnblindedOutput from TariUnblindedOutputs at position
+ *
+ * ## Arguments
+ * `outputs` - The pointer to a TariUnblindedOutputs
+ * `position` - The integer position
+ * `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
+ * as an out parameter.
+ *
+ * ## Returns
+ * `*mut TariUnblindedOutput` - Returns a TariUnblindedOutput, note that it returns ptr::null_mut() if
+ * TariUnblindedOutputs is null or position is invalid
+ *
+ * # Safety
+ * The ```contact_destroy``` method must be called when finished with a TariContact to prevent a memory leak
+ */
+unsigned long long *unblinded_outputs_tx_id_get_at(struct TariUnblindedOutputs *outputs,
+                                                   unsigned int position,
+                                                   int *error_out);
+
+/**
  * Frees memory for a TariUnblindedOutputs
  *
  * ## Arguments
@@ -1971,6 +1991,41 @@ unsigned long long completed_transaction_get_confirmations(TariCompletedTransact
  */
 int completed_transaction_get_cancellation_reason(TariCompletedTransaction *tx,
                                                   int *error_out);
+
+/**
+ * returns the TariCompletedTransaction as a json string
+ *
+ * ## Arguments
+ * `tx` - The pointer to a TariCompletedTransaction
+ *
+ * ## Returns
+ * `*mut c_char` - Returns a pointer to a char array. Note that it returns an empty char array if
+ * TariCompletedTransaction is null or the position is invalid
+ *
+ * # Safety
+ *  The ```completed_transaction_destroy``` function must be called when finished with a TariCompletedTransaction to
+ * prevent a memory leak
+ */
+char *tari_completed_transaction_to_json(TariCompletedTransaction *tx,
+                                         int *error_out);
+
+/**
+ * Creates a TariUnblindedOutput from a char array
+ *
+ * ## Arguments
+ * `tx_json` - The pointer to a char array which is json of the TariCompletedTransaction
+ * `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
+ * as an out parameter.
+ *
+ * ## Returns
+ * `*mut TariCompletedTransaction` - Returns a pointer to a TariCompletedTransaction. Note that it returns ptr::null_mut()
+ * if key is null or if there was an error creating the TariCompletedTransaction from key
+ *
+ * # Safety
+ * The ```completed_transaction_destroy``` function must be called when finished with a TariCompletedTransaction to
+ */
+TariCompletedTransaction *create_tari_completed_transaction_from_json(const char *tx_json,
+                                                                      int *error_out);
 
 /**
  * Frees memory for a TariCompletedTransaction

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -960,9 +960,9 @@ TariUnblindedOutput *unblinded_outputs_get_at(struct TariUnblindedOutputs *outpu
  * # Safety
  * The ```contact_destroy``` method must be called when finished with a TariContact to prevent a memory leak
  */
-unsigned long long *unblinded_outputs_tx_id_get_at(struct TariUnblindedOutputs *outputs,
-                                                   unsigned int position,
-                                                   int *error_out);
+unsigned long long *unblinded_outputs_received_tx_id_get_at(struct TariUnblindedOutputs *outputs,
+                                                            unsigned int position,
+                                                            int *error_out);
 
 /**
  * Frees memory for a TariUnblindedOutputs
@@ -2018,8 +2018,8 @@ char *tari_completed_transaction_to_json(TariCompletedTransaction *tx,
  * as an out parameter.
  *
  * ## Returns
- * `*mut TariCompletedTransaction` - Returns a pointer to a TariCompletedTransaction. Note that it returns ptr::null_mut()
- * if key is null or if there was an error creating the TariCompletedTransaction from key
+ * `*mut TariCompletedTransaction` - Returns a pointer to a TariCompletedTransaction. Note that it returns
+ * ptr::null_mut() if key is null or if there was an error creating the TariCompletedTransaction from key
  *
  * # Safety
  * The ```completed_transaction_destroy``` function must be called when finished with a TariCompletedTransaction to


### PR DESCRIPTION
Description
---
Adds the tx_id to export unspent utxo request. 

Motivation and Context
---
This allows a callee to ask the TMS service using the tx_id for more details about how the output was received

How Has This Been Tested?
---
Unit tests. 

Fixes: https://github.com/tari-project/tari/issues/5117

