### PR TITLE
wip: fix(tests): broken unit tests after validator refactor

### DIFF
--- a/base_layer/core/tests/mempool.rs
+++ b/base_layer/core/tests/mempool.rs
@@ -301,7 +301,6 @@ async fn test_time_locked() {
 
 // TODO: this test fails after the validation refactors, as the test was probably not written correctly due to
 // maturities not being checked before
-#[ignore]
 #[tokio::test]
 #[allow(clippy::identity_op)]
 async fn test_retrieve() {
@@ -1228,7 +1227,6 @@ async fn consensus_validation_unique_excess_sig() {
     assert!(matches!(response, TxStorageResponse::NotStoredAlreadyMined));
 }
 
-#[ignore]
 #[tokio::test]
 #[allow(clippy::identity_op)]
 #[allow(clippy::too_many_lines)]


### PR DESCRIPTION
Description
---

Motivation and Context
---
After https://github.com/tari-project/tari/pull/5079, there were some broken tests that were unignored:
* `block_event_and_reorg_event_handling`
* `test_retrieve`
* `test_base_node_wallet_rpc`

The goal of this PR is to unignore and fix them

How Has This Been Tested?
---

