### PR TITLE
feat: change default logging level to be debug

### DIFF
--- a/applications/tari_base_node/log4rs_sample.yml
+++ b/applications/tari_base_node/log4rs_sample.yml
@@ -98,7 +98,7 @@ root:
 loggers:
   # Route log events common to every application to all appenders
   tari::application:
-    level: info
+    level: debug
     appenders:
       - base_layer
       - network
@@ -107,17 +107,17 @@ loggers:
 
   # Route log events sent to the "core" logger to the "base_layer" appender
   c:
-    level: info
+    level: debug
     appenders:
       - base_layer
   tari:
-    level: info
+    level: debug
     appenders:
       - base_layer
 
   # Route log events sent to the "wallet" logger to the "base_layer" appender
   wallet:
-    level: info
+    level: debug
     appenders:
       - base_layer
   # Route log events sent to the "comms" logger to the "network" appender

--- a/applications/tari_console_wallet/log4rs_sample.yml
+++ b/applications/tari_console_wallet/log4rs_sample.yml
@@ -82,14 +82,14 @@ appenders:
 
 # root (to base_layer)
 root:
-  level: info
+  level: debug
   appenders:
     - other
 
 loggers:
   # base_layer
   wallet:
-    level: info
+    level: debug
     appenders:
       - base_layer
       - stdout


### PR DESCRIPTION
Description
---
Change the default logging level to be default and not info

Motivation and Context
---
Most people who run the wallet and base node don't change the log settings. If at some point in the future, you require logging information to debug some issue, info does not have much information to go about. Debug includes some very useful information to debug issues. 

How Has This Been Tested?
---
Manual
