### PR TITLE
fix: potential ban

### DIFF
--- a/base_layer/core/src/base_node/sync/header_sync/synchronizer.rs
+++ b/base_layer/core/src/base_node/sync/header_sync/synchronizer.rs
@@ -701,17 +701,37 @@ impl<'a, B: BlockchainBackend + 'static> HeaderSynchronizer<'a, B> {
         }
 
         if !has_switched_to_new_chain {
-            return Err(BlockHeaderSyncError::PeerSentInaccurateChainMetadata {
-                claimed: sync_peer.claimed_chain_metadata().accumulated_difficulty(),
-                actual: self
-                    .header_validator
+            if sync_peer.claimed_chain_metadata().accumulated_difficulty() <
+                self.header_validator
                     .current_valid_chain_tip_header()
-                    .map(|h| h.accumulated_data().total_accumulated_difficulty),
-                local: split_info
-                    .local_tip_header
-                    .accumulated_data()
-                    .total_accumulated_difficulty,
-            });
+                    .map(|h| h.accumulated_data().total_accumulated_difficulty)
+                    .unwrap_or_default()
+            {
+                // We should only return this error if the peer sent a PoW less than they advertised.
+                return Err(BlockHeaderSyncError::PeerSentInaccurateChainMetadata {
+                    claimed: sync_peer.claimed_chain_metadata().accumulated_difficulty(),
+                    actual: self
+                        .header_validator
+                        .current_valid_chain_tip_header()
+                        .map(|h| h.accumulated_data().total_accumulated_difficulty),
+                    local: split_info
+                        .local_tip_header
+                        .accumulated_data()
+                        .total_accumulated_difficulty,
+                });
+            } else {
+                warn!(
+                    target: LOG_TARGET,
+                    "Received pow from peer matches claimed, difficulty #{} but local is higher: ({}) and we have not \
+                     swapped. Ignoring",
+                    sync_peer.claimed_chain_metadata().accumulated_difficulty(),
+                    split_info
+                        .local_tip_header
+                        .accumulated_data()
+                        .total_accumulated_difficulty
+                );
+                return Ok(())
+            }
         }
 
         // Commit the last blocks that don't fit into the COMMIT_EVENT_N_HEADERS blocks

--- a/base_layer/core/src/base_node/sync/header_sync/synchronizer.rs
+++ b/base_layer/core/src/base_node/sync/header_sync/synchronizer.rs
@@ -730,7 +730,7 @@ impl<'a, B: BlockchainBackend + 'static> HeaderSynchronizer<'a, B> {
                         .accumulated_data()
                         .total_accumulated_difficulty
                 );
-                return Ok(())
+                return Ok(());
             }
         }
 


### PR DESCRIPTION
Description
---
Fixes potential ban by making a check before we ban. 

Motivation and Context
---
Under very rare circumstances it might be possible for the base_node to receive the blocks required to up its local metadata. 
And here we can ban a local peer for providing inaccurate chain metadata although he could have provided the correct number, our chain could have advanced enough to not switch over.  


Fixes: https://github.com/tari-project/tari/issues/5143
