### PR TITLE
feat: feature gate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5049,6 +5049,7 @@ dependencies = [
  "tari_comms_dht",
  "tari_core",
  "tari_crypto",
+ "tari_features",
  "tari_libtor",
  "tari_metrics",
  "tari_p2p",
@@ -5299,6 +5300,7 @@ dependencies = [
  "tari_comms_dht",
  "tari_core",
  "tari_crypto",
+ "tari_features",
  "tari_key_manager",
  "tari_libtor",
  "tari_p2p",
@@ -5408,6 +5410,13 @@ dependencies = [
  "thiserror",
  "wasm-bindgen",
  "zeroize",
+]
+
+[[package]]
+name = "tari_features"
+version = "0.0.1"
+dependencies = [
+ "tari_common",
 ]
 
 [[package]]
@@ -5522,6 +5531,7 @@ dependencies = [
  "tari_common",
  "tari_comms",
  "tari_core",
+ "tari_features",
  "tari_utilities",
  "tari_wallet_grpc_client",
  "thiserror",

--- a/applications/tari_base_node/Cargo.toml
+++ b/applications/tari_base_node/Cargo.toml
@@ -56,4 +56,5 @@ metrics = ["tari_metrics", "tari_comms/metrics"]
 safe = []
 libtor = ["tari_libtor"]
 
-
+[build-dependencies]
+tari_features = { version = "0.0.1", path = "../../common/tari_features"}

--- a/applications/tari_base_node/build.rs
+++ b/applications/tari_base_node/build.rs
@@ -1,8 +1,11 @@
 // Copyright 2022 The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
 
+use tari_features::resolver::build_features;
+
 #[cfg(windows)]
 fn main() {
+    build_features();
     use std::env;
     println!("cargo:rerun-if-changed=icon.res");
     let mut path = env::current_dir().unwrap();
@@ -11,4 +14,7 @@ fn main() {
 }
 
 #[cfg(not(windows))]
-fn main() {}
+pub fn main() {
+    build_features();
+    // Build as usual
+}

--- a/applications/tari_base_node/src/commands/command/mod.rs
+++ b/applications/tari_base_node/src/commands/command/mod.rs
@@ -41,6 +41,7 @@ mod list_connections;
 mod list_headers;
 mod list_peers;
 mod list_reorgs;
+#[cfg(tari_feature_dan_layer)]
 mod list_validator_nodes;
 mod period_stats;
 mod ping_peer;
@@ -132,6 +133,7 @@ pub enum Command {
     Whoami(whoami::Args),
     GetStateInfo(get_state_info::Args),
     GetNetworkStats(get_network_stats::Args),
+    #[cfg(tari_feature_dan_layer)]
     ListValidatorNodes(list_validator_nodes::Args),
     Quit(quit::Args),
     Exit(quit::Args),
@@ -227,9 +229,10 @@ impl CommandContext {
                 Command::GetMempoolTx(_) |
                 Command::Status(_) |
                 Command::Watch(_) |
-                Command::ListValidatorNodes(_) |
                 Command::Quit(_) |
                 Command::Exit(_) => 30,
+                #[cfg(tari_feature_dan_layer)]
+                Command::ListValidatorNodes(_) => 30,
                 // These commands involve intense blockchain db operations and needs a lot of time to complete
                 Command::CheckDb(_) | Command::PeriodStats(_) | Command::RewindBlockchain(_) => 600,
             };
@@ -292,6 +295,7 @@ impl HandleCommand<Command> for CommandContext {
             Command::ListBannedPeers(args) => self.handle_command(args).await,
             Command::Quit(args) | Command::Exit(args) => self.handle_command(args).await,
             Command::Watch(args) => self.handle_command(args).await,
+            #[cfg(tari_feature_dan_layer)]
             Command::ListValidatorNodes(args) => self.handle_command(args).await,
         }
     }

--- a/applications/tari_console_wallet/Cargo.toml
+++ b/applications/tari_console_wallet/Cargo.toml
@@ -20,6 +20,7 @@ tari_shutdown = { path = "../../infrastructure/shutdown" }
 tari_key_manager = { path = "../../base_layer/key_manager" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.10" }
 tari_script = { path = "../../infrastructure/tari_script" }
+tari_features = { version = "0.0.1", path = "../../common/tari_features"}
 
 # Uncomment for tokio tracing via tokio-console (needs "tracing" featurs)
 #console-subscriber = "0.1.3"
@@ -61,6 +62,9 @@ features = ["transactions", "mempool_proto", "base_node_proto"]
 version = "^0.16"
 default-features = false
 features = ["crossterm"]
+
+[build-dependencies]
+tari_features = { version = "0.0.1", path = "../../common/tari_features"}
 
 [features]
 avx2 = ["tari_core/avx2", "tari_crypto/simd_backend", "tari_wallet/avx2", "tari_comms/avx2", "tari_comms_dht/avx2", "tari_p2p/avx2", "tari_key_manager/avx2"]

--- a/applications/tari_console_wallet/build.rs
+++ b/applications/tari_console_wallet/build.rs
@@ -1,8 +1,11 @@
 // Copyright 2022 The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
 
+use tari_features::resolver::build_features;
+
 #[cfg(windows)]
 fn main() {
+    build_features();
     use std::env;
     println!("cargo:rerun-if-changed=icon.res");
     let mut path = env::current_dir().unwrap();
@@ -11,4 +14,7 @@ fn main() {
 }
 
 #[cfg(not(windows))]
-fn main() {}
+pub fn main() {
+    build_features();
+    // Build as usual
+}

--- a/applications/tari_console_wallet/src/automation/commands.rs
+++ b/applications/tari_console_wallet/src/automation/commands.rs
@@ -437,6 +437,7 @@ pub async fn make_it_rain(
                             )
                             .await
                         },
+                        #[cfg(tari_feature_dan_layer)]
                         MakeItRainTransactionType::BurnTari => burn_tari(tx_service, fee, amount, msg.clone()).await,
                     };
                     let submit_time = Instant::now();
@@ -646,6 +647,7 @@ pub async fn command_runner(
                     eprintln!("DiscoverPeer error! {}", e);
                 }
             },
+            #[cfg(tari_feature_dan_layer)]
             BurnTari(args) => {
                 match burn_tari(
                     transaction_service.clone(),
@@ -974,6 +976,7 @@ pub async fn command_runner(
                     Err(e) => eprintln!("HashGrpcPassword error! {}", e),
                 }
             },
+            #[cfg(tari_feature_dan_layer)]
             RegisterValidatorNode(args) => {
                 let tx_id = register_validator_node(
                     args.amount,

--- a/applications/tari_console_wallet/src/cli.rs
+++ b/applications/tari_console_wallet/src/cli.rs
@@ -115,6 +115,7 @@ impl ConfigOverrideProvider for Cli {
 pub enum CliCommands {
     GetBalance,
     SendTari(SendTariArgs),
+    #[cfg(tari_feature_dan_layer)]
     BurnTari(BurnTariArgs),
     SendOneSided(SendTariArgs),
     SendOneSidedToStealthAddress(SendTariArgs),
@@ -133,6 +134,7 @@ pub enum CliCommands {
     ClaimShaAtomicSwapRefund(ClaimShaAtomicSwapRefundArgs),
     RevalidateWalletDb,
     HashGrpcPassword(HashPasswordArgs),
+    #[cfg(tari_feature_dan_layer)]
     RegisterValidatorNode(RegisterValidatorNodeArgs),
 }
 
@@ -198,6 +200,7 @@ pub enum MakeItRainTransactionType {
     Interactive,
     OneSided,
     StealthOneSided,
+    #[cfg(tari_feature_dan_layer)]
     BurnTari,
 }
 

--- a/applications/tari_merge_mining_proxy/Cargo.toml
+++ b/applications/tari_merge_mining_proxy/Cargo.toml
@@ -41,4 +41,5 @@ tonic = "0.6.2"
 tracing = "0.1"
 url = "2.1.1"
 
-[dev-dependencies]
+[build-dependencies]
+tari_features = { version = "0.0.1", path = "../../common/tari_features"}

--- a/applications/tari_merge_mining_proxy/build.rs
+++ b/applications/tari_merge_mining_proxy/build.rs
@@ -1,8 +1,11 @@
 // Copyright 2022 The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
 
+use tari_features::resolver::build_features;
+
 #[cfg(windows)]
 fn main() {
+    build_features();
     use std::env;
     println!("cargo:rerun-if-changed=icon.res");
     let mut path = env::current_dir().unwrap();
@@ -11,4 +14,7 @@ fn main() {
 }
 
 #[cfg(not(windows))]
-fn main() {}
+pub fn main() {
+    build_features();
+    // Build as usual
+}

--- a/base_layer/core/src/blocks/genesis_block.rs
+++ b/base_layer/core/src/blocks/genesis_block.rs
@@ -50,9 +50,11 @@ use crate::{
 
 /// Returns the genesis block for the selected network.
 pub fn get_genesis_block(network: Network) -> ChainBlock {
-    use Network::{Dibbler, Esmeralda, Igor, LocalNet, MainNet, Ridcully, Stibbons, Weatherwax};
+    use Network::{Dibbler, Esmeralda, Igor, LocalNet, MainNet, NextNet, Ridcully, StageNet, Stibbons, Weatherwax};
     match network {
         MainNet => get_mainnet_genesis_block(),
+        StageNet => get_mainnet_genesis_block(),
+        NextNet => unimplemented!("NextNet is not yet implemented"),
         Igor => get_igor_genesis_block(),
         Esmeralda => get_esmeralda_genesis_block(),
         LocalNet => get_esmeralda_genesis_block(),

--- a/common/src/configuration/network.rs
+++ b/common/src/configuration/network.rs
@@ -38,6 +38,8 @@ use crate::ConfigurationError;
 #[serde(try_from = "String", into = "String")]
 pub enum Network {
     MainNet = 0x00,
+    StageNet = 0x02,
+    NextNet = 0x03,
     LocalNet = 0x10,
     Ridcully = 0x21,
     Stibbons = 0x22,
@@ -57,6 +59,8 @@ impl Network {
         use Network::*;
         match self {
             MainNet => "mainnet",
+            StageNet => "stagenet",
+            NextNet => "nextnet",
             Ridcully => "ridcully",
             Stibbons => "stibbons",
             Weatherwax => "weatherwax",

--- a/common/tari_features/Cargo.toml
+++ b/common/tari_features/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "tari_features"
+description = "Compilable features for Tari applications"
+authors = ["The Tari Development Community"]
+repository = "https://github.com/tari-project/tari"
+homepage = "https://tari.com"
+readme = "README.md"
+license = "BSD-3-Clause"
+version = "0.0.1"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+tari_common = { path = "../../common" }

--- a/common/tari_features/src/lib.rs
+++ b/common/tari_features/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019. The Tari Project
+// Copyright 2023. The Tari Project
 //
 // Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
 // following conditions are met:
@@ -20,39 +20,24 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use tari_common::configuration::Network;
+mod feature;
+pub mod resolver;
+mod status;
 
-use super::consensus_constants::ConsensusConstants;
+pub use feature::Feature;
+pub use status::Status;
 
-/// Represents the consensus used for a given network
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub struct NetworkConsensus(Network);
-
-impl NetworkConsensus {
-    pub fn create_consensus_constants(&self) -> Vec<ConsensusConstants> {
-        use Network::{Dibbler, Esmeralda, Igor, LocalNet, MainNet, NextNet, Ridcully, StageNet, Stibbons, Weatherwax};
-        match self.as_network() {
-            MainNet => ConsensusConstants::mainnet(),
-            StageNet => ConsensusConstants::mainnet(),
-            NextNet => unimplemented!("NextNet is not yet implemented"),
-            LocalNet => ConsensusConstants::localnet(),
-            Dibbler => ConsensusConstants::dibbler(),
-            Igor => ConsensusConstants::igor(),
-            Weatherwax => ConsensusConstants::weatherwax(),
-            Esmeralda => ConsensusConstants::esmeralda(),
-            Ridcully => unimplemented!("Ridcully network is no longer supported"),
-            Stibbons => unimplemented!("Stibbons network is no longer supported"),
-        }
-    }
-
-    #[inline]
-    pub fn as_network(self) -> Network {
-        self.0
-    }
-}
-
-impl From<Network> for NetworkConsensus {
-    fn from(global_network: Network) -> Self {
-        Self(global_network)
-    }
-}
+pub const FEATURE_LIST: [Feature; 2] = [
+    Feature::new(
+        "crash_on_thread_panic",
+        "Has the Validator node crash entirely if any thread panics",
+        None,
+        Status::New,
+    ),
+    Feature::new(
+        "dan_layer",
+        "Functionality for utilizing the dan layer",
+        None,
+        Status::Testing,
+    ),
+];

--- a/common/tari_features/src/resolver.rs
+++ b/common/tari_features/src/resolver.rs
@@ -1,0 +1,119 @@
+// Copyright 2023. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::{fmt::Display, str::FromStr};
+
+use tari_common::configuration::Network;
+
+use crate::{Feature, FEATURE_LIST};
+
+pub enum Target {
+    TestNet,
+    NextNet,
+    MainNet,
+}
+
+impl Display for Target {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Target::TestNet => f.write_str("TestNet"),
+            Target::NextNet => f.write_str("NextNet"),
+            Target::MainNet => f.write_str("MainNet"),
+        }
+    }
+}
+
+// Identify the target network by
+// 1. Checking whether --config tari-network=xxx was passed in as a config flag to cargo (or from Cargo.toml)
+// 2. Checking the environment variable TARI_NETWORK is set
+// 3. default to mainnet
+pub fn identify_target() -> Target {
+    check_envar("CARGO_CFG_TARI_NETWORK")
+        .or_else(|| check_envar("TARI_NETWORK"))
+        .unwrap_or(Target::TestNet)
+}
+
+pub fn check_envar(envar: &str) -> Option<Target> {
+    match std::env::var(envar) {
+        Ok(s) => {
+            let network =
+                Network::from_str(s.to_lowercase().as_str()).unwrap_or_else(|_| panic!("Unknown network, {}", s));
+            match network {
+                Network::MainNet | Network::StageNet => Some(Target::MainNet),
+                Network::NextNet => Some(Target::NextNet),
+                Network::LocalNet | Network::Igor | Network::Esmeralda => Some(Target::TestNet),
+                Network::Weatherwax | Network::Ridcully | Network::Stibbons | Network::Dibbler => None,
+            }
+        },
+        _ => None,
+    }
+}
+
+pub fn list_active_features() {
+    println!("These features are ACTIVE on mainnet (no special code handling is done)");
+    FEATURE_LIST
+        .iter()
+        .filter(|f| f.is_active())
+        .for_each(|f| println!("{}", f));
+}
+
+pub fn list_removed_features() {
+    println!("These features are DEPRECATED and will never be compiled");
+    FEATURE_LIST
+        .iter()
+        .filter(|f| f.was_removed())
+        .for_each(|f| println!("{}", f));
+}
+
+pub fn resolve_features(target: Target) -> Result<(), String> {
+    match target {
+        Target::MainNet => { /* No features are active at all */ },
+        Target::NextNet => FEATURE_LIST
+            .iter()
+            .filter(|f| f.is_active_in_nextnet())
+            .for_each(activate_feature),
+        Target::TestNet => FEATURE_LIST
+            .iter()
+            .filter(|f| f.is_active_in_testnet())
+            .for_each(activate_feature),
+    }
+    Ok(())
+}
+
+pub fn activate_feature(feature: &Feature) {
+    println!("** Activating {} **", feature);
+    println!("cargo:rustc-cfg={}", feature.attr_name());
+}
+
+pub fn build_features() {
+    // Make sure to rebuild when the network changes
+    println!("cargo:rerun-if-env-changed=TARI_NETWORK");
+
+    let target = identify_target();
+    println!("Building for {}", target);
+    list_active_features();
+    list_removed_features();
+    if let Err(e) = resolve_features(target) {
+        eprintln!("Could not build Tari due to issues with the feature flag set.\n{}", e);
+        panic!();
+    }
+}

--- a/common/tari_features/src/status.rs
+++ b/common/tari_features/src/status.rs
@@ -1,4 +1,4 @@
-// Copyright 2019. The Tari Project
+// Copyright 2023. The Tari Project
 //
 // Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
 // following conditions are met:
@@ -20,39 +20,9 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use tari_common::configuration::Network;
-
-use super::consensus_constants::ConsensusConstants;
-
-/// Represents the consensus used for a given network
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub struct NetworkConsensus(Network);
-
-impl NetworkConsensus {
-    pub fn create_consensus_constants(&self) -> Vec<ConsensusConstants> {
-        use Network::{Dibbler, Esmeralda, Igor, LocalNet, MainNet, NextNet, Ridcully, StageNet, Stibbons, Weatherwax};
-        match self.as_network() {
-            MainNet => ConsensusConstants::mainnet(),
-            StageNet => ConsensusConstants::mainnet(),
-            NextNet => unimplemented!("NextNet is not yet implemented"),
-            LocalNet => ConsensusConstants::localnet(),
-            Dibbler => ConsensusConstants::dibbler(),
-            Igor => ConsensusConstants::igor(),
-            Weatherwax => ConsensusConstants::weatherwax(),
-            Esmeralda => ConsensusConstants::esmeralda(),
-            Ridcully => unimplemented!("Ridcully network is no longer supported"),
-            Stibbons => unimplemented!("Stibbons network is no longer supported"),
-        }
-    }
-
-    #[inline]
-    pub fn as_network(self) -> Network {
-        self.0
-    }
-}
-
-impl From<Network> for NetworkConsensus {
-    fn from(global_network: Network) -> Self {
-        Self(global_network)
-    }
+pub enum Status {
+    New,     // new feature, may not even be working or compiling. Will be present on dibbler testnet
+    Testing, // potentially active feature, but still gated. Potentially present on nextnet,
+    Active,  // feature is live and gate has been removed. Will be running on stagenet and mainnet
+    Removed, // feature has been cancelled. Can not be invoked anywhere
 }


### PR DESCRIPTION
Description
---
This PR is for reflective purposes regarding feature gating at compile time. See #5135 for more info. This PR as it stands is to be used as an example of a network _type_ based feature gate at compile time. 
It allows setting an ENVVAR for the network with conditional compilation for features. The feature sets can be imported across any crate in the project easily and then used with the `#[cfg(tari_feature_...)]` attribute macro. 

I played with a few styles of gating code. In the case of burning, and validator registration what I found was it became easier to focus on the entry and exit points of the code. These functions don't have much outside effect other than their distinct purpose so preventing someone from calling them is good enough conditional compilation. It's easier than trying to remove every aspect of their existence throughout. This wouldn't always be the case though- with a feature that changes an existing feature the style of code writing has the potential to change heavily with possible duplication of entire enums or structs. It could be useful to have more examples to help guide people with, but also is something we'll probably see patterns for emerge naturally. The nice part is we have the flexibility to support different needs.

There was a desire to use the network based feature gating to prevent a "mainnet" compiled bin from compiling with testnet configuration at all. To remove conensus constants, or even the knowledge of the testnets. This proved more difficult with the current code base and would require a lot of refactoring. I've made another PR with a branch I consider broken demonstrating the minimal amount of changes needed to perform this kind of task and it doesn't seem to bring us a major benefit for the time being.

Motivation and Context
---
Preventing the use of certain network features that may not yet be prepared.

How Has This Been Tested?
---
Compilation locally.


Co-authored-by: Cayle Sharrock <CjS77@users.noreply.github.com>

