### PR TITLE
docs: update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ brew install cmake openssl tor coreutils automake
 brew install --cask powershell
 ```
 
+#### (macOS M1 chipset)
+it is important to note that RandomX does not work on Xcode version 14.1 and newer. To to compile Tari and run properly you need to run XCode version 14.0 or earlier.
+To run multiple versions of XCode you can use this guide [here](https://hacknicity.medium.com/working-with-multiple-versions-of-xcode-e331c01aa6bc)
+
 #### (Ubuntu 18.04, including WSL-2 on Windows)
 
 ```


### PR DESCRIPTION
Description
---
Due to an issue with Mac M1 chipsets with XCode version 14.1 + later, and RandomX, M1 users need to downgrade their XCode to version 14.0. See issue: #5141 

This has been added to the readme. 

