### PR TITLE
fix: panic on overflow in release mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,9 +34,12 @@ members = [
 # Add here until we move to edition=2021
 resolver = "2"
 
-# Shutdown when panicking so we can see the error, specifically for the wallet
 [profile.release]
-panic = 'abort'
+# Shutdown when panicking so we can see the error, specifically for the wallet
+panic = "abort"
+# By default, Rust will wrap an integer in release mode instead of throwing the overflow error
+# seen in debug mode. Panicking at this time is better than silently using the wrong value.
+overflow-checks = true
 
 [patch.crates-io]
 # Temporarily lock pgp to commit (master branch at time of writing) because the currently release crate locks zeroize to =1.3


### PR DESCRIPTION
Description
---
Add a toml config to do the same overflow/underflow check in debug mode in release mode.

Motivation and Context
---
By default, Rust will wrap an integer in release mode instead of throwing the overflow error seen in debug mode. Panicking at this time is better than silently using the wrong value. IMO this could lead to all sorts of exploits.

Some Tari specific background: 
In the MMR crate there is this check: 

```
       let peaks = find_peaks(mmr_size);
        let mut peak_hashes = Vec::with_capacity(peaks.len() - 1);
```

We found in testing that on some machines this would panic and others would pass. (I can't remember if it was this exact line, since this should fail with allocating that much memory)


How Has This Been Tested?
---
Checked on rust pen to confirm that rust underflows in release mode with this code
```
fn main() {
   let vec: Vec<u8> = Vec::new();
   let val =  vec.len() - 1;
   println!("{}", val);
}
```
