### PR TITLE
fix: readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ brew install --cask powershell
 ```
 
 #### (macOS M1 chipset)
-it is important to note that RandomX does not work on Xcode version 14.1 and newer. To to compile Tari and run properly you need to run XCode version 14.0 or earlier.
+it is important to note that RandomX does not work on Xcode version 14.1 and newer. To compile Tari and run properly you need to run XCode version 14.0 or earlier.
 To run multiple versions of XCode you can use this guide [here](https://hacknicity.medium.com/working-with-multiple-versions-of-xcode-e331c01aa6bc)
 
 #### (Ubuntu 18.04, including WSL-2 on Windows)

--- a/base_layer/key_manager/README.md
+++ b/base_layer/key_manager/README.md
@@ -5,6 +5,6 @@
 enabled by `js` rust feature
 
 see Makefile
-
+- run `cargo install wasm-pack`
 - `make build` or `make web`
 - `make test`


### PR DESCRIPTION
Description
---
Fixes typo in main readme
Add missing `cargo install wasm-pack` command from key manager readme


