### PR TITLE
ci(fix): add concurrency build limit

### DIFF
--- a/.github/workflows/base_node_binaries.yml
+++ b/.github/workflows/base_node_binaries.yml
@@ -16,16 +16,16 @@ name: Build Matrix of Binaries
         required: true
         default: "development-tag"
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 env:
   TBN_FILENAME: "tari_suite"
   TBN_BUNDLEID_BASE: "com.tarilabs.pkg"
   toolchain: nightly-2022-11-03
   matrix-json-file: ".github/workflows/base_node_binaries.json"
   CARGO_HTTP_MULTIPLEXING: false
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   matrix-prep:

--- a/.github/workflows/build_dockers.yml
+++ b/.github/workflows/build_dockers.yml
@@ -49,6 +49,10 @@ name: Build docker images
 env:
   toolchain_default: nightly-2022-11-03
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   builds_envs_setup:
     runs-on: ubuntu-latest

--- a/.github/workflows/build_libwallets.yml
+++ b/.github/workflows/build_libwallets.yml
@@ -24,6 +24,10 @@ name: Build libwallets
 env:
   toolchain_default: nightly-2022-11-03
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   builds_envs_setup:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,10 @@ env:
   PROTOC: protoc
   TERM: unkown
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   clippy:
     name: clippy

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,6 +10,10 @@ name: Source Coverage
 env:
   toolchain: nightly-2022-11-03
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   coverage:
     name: test and generate coverage

--- a/.github/workflows/pr_title.yml
+++ b/.github/workflows/pr_title.yml
@@ -11,6 +11,10 @@ name: PR
       - edited
       - synchronize
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-title:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Description
GHA add concurrency build limit

Motivation and Context
Reduce concurrent builds, so that new branch pushes cancel previous running builds.

How Has This Been Tested?
Tested in local fork with multi pushes.

