### PR TITLE
ci(fix): pin osx arm64 build for randomx

### DIFF
--- a/.github/workflows/base_node_binaries.json
+++ b/.github/workflows/base_node_binaries.json
@@ -29,7 +29,7 @@
   },
   {
     "name": "macos-arm64",
-    "runs-on": "macos-latest",
+    "runs-on": "macos-11",
     "rust": "stable",
     "target": "aarch64-apple-darwin",
     "cross": true,

--- a/.github/workflows/base_node_binaries.json
+++ b/.github/workflows/base_node_binaries.json
@@ -32,7 +32,7 @@
     "runs-on": "macos-11",
     "rust": "stable",
     "target": "aarch64-apple-darwin",
-    "cross": true,
+    "cross": false,
     "target_cpu": "generic",
     "features": "safe"
   },


### PR DESCRIPTION
Description
Build osx arm64 on OSX-11, pinning XCode to 13.2.1 - https://github.com/actions/runner-images/blob/main/images/macos/macos-11-Readme.md#xcode

Motivation and Context
RandomX workaround https://github.com/tari-project/tari/issues/5141

How Has This Been Tested?
Builds, but needs testing by Apple M1 user

