### PR TITLE
feat: add more burn details to burn command

### DIFF
--- a/applications/tari_app_grpc/proto/wallet.proto
+++ b/applications/tari_app_grpc/proto/wallet.proto
@@ -137,6 +137,9 @@ message CreateBurnTransactionResponse{
     uint64 transaction_id = 1;
     bool is_success = 2;
     string failure_message = 3;
+    bytes commitment = 4;
+    bytes ownership_proof = 5;
+    bytes rangeproof = 6;
 }
 
 message TransferResult {

--- a/applications/tari_app_grpc/proto/wallet.proto
+++ b/applications/tari_app_grpc/proto/wallet.proto
@@ -105,6 +105,7 @@ message CreateBurnTransactionRequest{
     uint64 amount = 1;
     uint64 fee_per_gram = 2;
     string message = 3;
+    bytes claim_public_key = 4;
 }
 
 

--- a/applications/tari_console_wallet/src/automation/commands.rs
+++ b/applications/tari_console_wallet/src/automation/commands.rs
@@ -139,6 +139,7 @@ pub async fn burn_tari(
         .burn_tari(amount, UtxoSelectionCriteria::default(), fee_per_gram * uT, message)
         .await
         .map_err(CommandError::TransactionServiceError)
+        .map(|res| res.0)
 }
 
 /// publishes a tari-SHA atomic swap HTLC transaction

--- a/applications/tari_console_wallet/src/automation/commands.rs
+++ b/applications/tari_console_wallet/src/automation/commands.rs
@@ -136,7 +136,13 @@ pub async fn burn_tari(
     message: String,
 ) -> Result<TxId, CommandError> {
     wallet_transaction_service
-        .burn_tari(amount, UtxoSelectionCriteria::default(), fee_per_gram * uT, message)
+        .burn_tari(
+            amount,
+            UtxoSelectionCriteria::default(),
+            fee_per_gram * uT,
+            message,
+            None,
+        )
         .await
         .map_err(CommandError::TransactionServiceError)
         .map(|res| res.0)

--- a/applications/tari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/tari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -598,20 +598,23 @@ impl wallet_server::Wallet for WalletGrpcServer {
             )
             .await
         {
-            Ok(tx_id) => {
+            Ok((tx_id, commitment, ownership_proof, rangeproof)) => {
                 debug!(target: LOG_TARGET, "Transaction broadcast: {}", tx_id,);
                 CreateBurnTransactionResponse {
                     transaction_id: tx_id.as_u64(),
                     is_success: true,
                     failure_message: Default::default(),
+                    commitment: commitment.to_vec(),
+                    ownership_proof: ownership_proof.to_vec(),
+                    rangeproof: rangeproof.to_vec(),
                 }
             },
             Err(e) => {
                 warn!(target: LOG_TARGET, "Failed to burn Tarid: {}", e);
                 CreateBurnTransactionResponse {
-                    transaction_id: Default::default(),
                     is_success: false,
                     failure_message: e.to_string(),
+                    ..Default::default()
                 }
             },
         };

--- a/applications/tari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/tari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -595,6 +595,14 @@ impl wallet_server::Wallet for WalletGrpcServer {
                 UtxoSelectionCriteria::default(),
                 message.fee_per_gram.into(),
                 message.message,
+                if message.claim_public_key.is_empty() {
+                    None
+                } else {
+                    Some(
+                        PublicKey::from_bytes(&message.claim_public_key)
+                            .map_err(|e| Status::invalid_argument(e.to_string()))?,
+                    )
+                },
             )
             .await
         {
@@ -605,7 +613,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
                     is_success: true,
                     failure_message: Default::default(),
                     commitment: commitment.to_vec(),
-                    ownership_proof: ownership_proof.to_vec(),
+                    ownership_proof: ownership_proof.map(|o| o.to_vec()).unwrap_or(vec![]),
                     rangeproof: rangeproof.to_vec(),
                 }
             },

--- a/applications/tari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/tari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -617,7 +617,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
                     is_success: true,
                     failure_message: Default::default(),
                     commitment: commitment.to_vec(),
-                    ownership_proof: ownership_proof.map(|o| o.to_vec()).unwrap_or(vec![]),
+                    ownership_proof: ownership_proof.map(|o| o.to_vec()).unwrap_or_default(),
                     rangeproof: rangeproof.to_vec(),
                 }
             },

--- a/base_layer/wallet/src/lib.rs
+++ b/base_layer/wallet/src/lib.rs
@@ -20,6 +20,7 @@ pub mod test_utils;
 pub mod transaction_service;
 pub mod types;
 
+use tari_crypto::{hash::blake2::Blake256, hash_domain, hashing::DomainSeparatedHasher};
 pub use types::WalletHasher; // For use externally to the code base
 pub mod util;
 pub mod wallet;
@@ -57,24 +58,3 @@ pub type WalletSqlite = Wallet<
 
 hash_domain!(BurntOutputDomain, "burnt_output", 1);
 type BurntOutputDomainHasher = DomainSeparatedHasher<Blake256, BurntOutputDomain>;
-
-hash_domain!(
-    WalletOutputRewindKeysDomain,
-    "com.tari.tari_project.base_layer.wallet.output_rewind_keys",
-    1
-);
-type WalletOutputRewindKeysDomainHasher = DomainSeparatedHasher<Blake256, WalletOutputRewindKeysDomain>;
-
-hash_domain!(
-    WalletOutputEncryptionKeysDomain,
-    "com.tari.tari_project.base_layer.wallet.output_encryption_keys",
-    1
-);
-type WalletOutputEncryptionKeysDomainHasher = DomainSeparatedHasher<Blake256, WalletOutputEncryptionKeysDomain>;
-
-hash_domain!(
-    WalletOutputSpendingKeysDomain,
-    "com.tari.tari_project.base_layer.wallet.output_spending_keys",
-    1
-);
-type WalletOutputSpendingKeysDomainHasher = DomainSeparatedHasher<Blake256, WalletOutputSpendingKeysDomain>;

--- a/base_layer/wallet/src/lib.rs
+++ b/base_layer/wallet/src/lib.rs
@@ -54,6 +54,9 @@ pub type WalletSqlite = Wallet<
     KeyManagerSqliteDatabase,
 >;
 
+hash_domain!(BurntOutputDomain, "burnt_output", 1);
+type BurntOutputDomainHasher = DomainSeparatedHasher<Blake256, BurntOutputDomain>;
+
 hash_domain!(
     WalletOutputRewindKeysDomain,
     "com.tari.tari_project.base_layer.wallet.output_rewind_keys",

--- a/base_layer/wallet/src/transaction_service/error.rs
+++ b/base_layer/wallet/src/transaction_service/error.rs
@@ -34,6 +34,7 @@ use tari_core::transactions::{
     transaction_components::{EncryptionError, TransactionError},
     transaction_protocol::TransactionProtocolError,
 };
+use tari_crypto::signatures::CommitmentSignatureError;
 use tari_p2p::services::liveness::error::LivenessError;
 use tari_service_framework::reply_channel::TransportChannelError;
 use tari_utilities::ByteArrayError;
@@ -178,6 +179,8 @@ pub enum TransactionServiceError {
     EncryptionError(#[from] EncryptionError),
     #[error("FixedHash size error: `{0}`")]
     FixedHashSizeError(#[from] FixedHashSizeError),
+    #[error("Commitment signature error: {0}")]
+    CommitmentSignatureError(#[from] CommitmentSignatureError),
 }
 
 #[derive(Debug, Error)]

--- a/base_layer/wallet/src/transaction_service/handle.rs
+++ b/base_layer/wallet/src/transaction_service/handle.rs
@@ -87,6 +87,7 @@ pub enum TransactionServiceRequest {
         selection_criteria: UtxoSelectionCriteria,
         fee_per_gram: MicroTari,
         message: String,
+        claim_public_key: Option<PublicKey>,
     },
     RegisterValidatorNode {
         amount: MicroTari,
@@ -239,7 +240,7 @@ pub enum TransactionServiceResponse {
     BurntTransactionSent {
         tx_id: TxId,
         commitment: Commitment,
-        ownership_proof: RistrettoComSig,
+        ownership_proof: Option<RistrettoComSig>,
         rangeproof: BulletRangeProof,
     },
     TransactionCancelled,
@@ -526,7 +527,8 @@ impl TransactionServiceHandle {
         selection_criteria: UtxoSelectionCriteria,
         fee_per_gram: MicroTari,
         message: String,
-    ) -> Result<(TxId, Commitment, RistrettoComSig, BulletRangeProof), TransactionServiceError> {
+        claim_public_key: Option<PublicKey>,
+    ) -> Result<(TxId, Commitment, Option<RistrettoComSig>, BulletRangeProof), TransactionServiceError> {
         match self
             .handle
             .call(TransactionServiceRequest::BurnTari {
@@ -534,6 +536,7 @@ impl TransactionServiceHandle {
                 selection_criteria,
                 fee_per_gram,
                 message,
+                claim_public_key,
             })
             .await??
         {

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -1425,7 +1425,7 @@ where
         let range_proof = recipient_reply.output.proof.clone();
         let (nonce_a, pub_nonce_a) = PublicKey::random_keypair(&mut OsRng);
         let (nonce_x, pub_nonce_x) = PublicKey::random_keypair(&mut OsRng);
-        let pub_nonce = pub_nonce_a + pub_nonce_x;
+        let pub_nonce = self.resources.factories.commitment.commit(&nonce_x, &nonce_a);
         let mut ownership_proof = None;
 
         if let Some(claim_public_key) = claim_public_key {
@@ -1435,6 +1435,13 @@ where
                 .chain(claim_public_key.as_bytes());
 
             let challenge: FixedHash = digest::Digest::finalize(hasher).into();
+
+            warn!(target: LOG_TARGET, "Pub nonce: {}", pub_nonce.to_vec().to_hex());
+            warn!(
+                target: LOG_TARGET,
+                "claim_public_key: {}",
+                claim_public_key.to_vec().to_hex()
+            );
             warn!(target: LOG_TARGET, "Challenge: {}", challenge.to_vec().to_hex());
             ownership_proof = Some(RistrettoComSig::sign(
                 &PrivateKey::from(amount),

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -1368,7 +1368,11 @@ where
         .await
     }
 
-    /// Creates a transaction to burn some Tari
+    /// Creates a transaction to burn some Tari. The optional _claim public key_ parameter is used in the challenge of the 
+    corresponding optional _ownership proof_ return value. Burn commitments and ownership proofs will exclusively be 
+    used in the 2nd layer (DAN layer). When such an _ownership proof_ is presented later on as part of some transaction 
+    metadata, the _claim public key_ can be revealed to enable verification of the _ownership proof_ and the transaction 
+    can be signed with the private key corresponding to the claim public key.
     pub async fn burn_tari(
         &mut self,
         amount: MicroTari,

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -1380,6 +1380,7 @@ where
     // used in the 2nd layer (DAN layer). When such an _ownership proof_ is presented later on as part of some
     // transaction metadata, the _claim public key_ can be revealed to enable verification of the _ownership proof_
     // and the transaction can be signed with the private key corresponding to the claim public key.
+    #[allow(clippy::too_many_lines)]
     pub async fn burn_tari(
         &mut self,
         amount: MicroTari,
@@ -1434,8 +1435,8 @@ where
         let recipient_reply = rtp.get_signed_data()?.clone();
         let commitment = recipient_reply.output.commitment.clone();
         let range_proof = recipient_reply.output.proof.clone();
-        let (nonce_a, _pub_nonce_a) = PublicKey::random_keypair(&mut OsRng);
-        let (nonce_x, _pub_nonce_x) = PublicKey::random_keypair(&mut OsRng);
+        let nonce_a = PrivateKey::random(&mut OsRng);
+        let nonce_x = PrivateKey::random(&mut OsRng);
         let pub_nonce = self.resources.factories.commitment.commit(&nonce_x, &nonce_a);
         let mut ownership_proof = None;
 

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -1368,11 +1368,12 @@ where
         .await
     }
 
-    /// Creates a transaction to burn some Tari. The optional _claim public key_ parameter is used in the challenge of the 
-    corresponding optional _ownership proof_ return value. Burn commitments and ownership proofs will exclusively be 
-    used in the 2nd layer (DAN layer). When such an _ownership proof_ is presented later on as part of some transaction 
-    metadata, the _claim public key_ can be revealed to enable verification of the _ownership proof_ and the transaction 
-    can be signed with the private key corresponding to the claim public key.
+    /// Creates a transaction to burn some Tari. The optional _claim public key_ parameter is used in the challenge of
+    /// the
+    // corresponding optional _ownership proof_ return value. Burn commitments and ownership proofs will exclusively be
+    // used in the 2nd layer (DAN layer). When such an _ownership proof_ is presented later on as part of some
+    // transaction metadata, the _claim public key_ can be revealed to enable verification of the _ownership proof_
+    // and the transaction can be signed with the private key corresponding to the claim public key.
     pub async fn burn_tari(
         &mut self,
         amount: MicroTari,
@@ -1427,8 +1428,8 @@ where
         let recipient_reply = rtp.get_signed_data()?.clone();
         let commitment = recipient_reply.output.commitment.clone();
         let range_proof = recipient_reply.output.proof.clone();
-        let (nonce_a, pub_nonce_a) = PublicKey::random_keypair(&mut OsRng);
-        let (nonce_x, pub_nonce_x) = PublicKey::random_keypair(&mut OsRng);
+        let (nonce_a, _pub_nonce_a) = PublicKey::random_keypair(&mut OsRng);
+        let (nonce_x, _pub_nonce_x) = PublicKey::random_keypair(&mut OsRng);
         let pub_nonce = self.resources.factories.commitment.commit(&nonce_x, &nonce_a);
         let mut ownership_proof = None;
 

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -76,6 +76,7 @@ use tari_p2p::domain_message::DomainMessage;
 use tari_script::{inputs, script, TariScript};
 use tari_service_framework::{reply_channel, reply_channel::Receiver};
 use tari_shutdown::ShutdownSignal;
+use tari_utilities::hex::Hex;
 use tokio::{
     sync::{mpsc, mpsc::Sender, oneshot, Mutex},
     task::JoinHandle,
@@ -1434,6 +1435,7 @@ where
                 .chain(claim_public_key.as_bytes());
 
             let challenge: FixedHash = digest::Digest::finalize(hasher).into();
+            warn!(target: LOG_TARGET, "Challenge: {}", challenge.to_vec().to_hex());
             ownership_proof = Some(RistrettoComSig::sign(
                 &PrivateKey::from(amount),
                 &spend_key,
@@ -1442,6 +1444,11 @@ where
                 challenge.as_bytes(),
                 &*self.resources.factories.commitment,
             )?);
+            warn!(
+                target: LOG_TARGET,
+                "Ownership proof: {}",
+                ownership_proof.clone().unwrap().to_vec().to_hex()
+            );
         }
         // Start finalizing
 

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -1424,12 +1424,12 @@ where
         let range_proof = recipient_reply.output.proof.clone();
         let (nonce_a, pub_nonce_a) = PublicKey::random_keypair(&mut OsRng);
         let (nonce_x, pub_nonce_x) = PublicKey::random_keypair(&mut OsRng);
+        let pub_nonce = pub_nonce_a + pub_nonce_x;
         let mut ownership_proof = None;
 
         if let Some(claim_public_key) = claim_public_key {
             let hasher = BurntOutputDomainHasher::new_with_label("commitment_signature")
-                .chain(pub_nonce_a.as_bytes())
-                .chain(pub_nonce_x.as_bytes())
+                .chain(pub_nonce.as_bytes())
                 .chain(commitment.as_bytes())
                 .chain(claim_public_key.as_bytes());
 

--- a/comms/dht/src/store_forward/store.rs
+++ b/comms/dht/src/store_forward/store.rs
@@ -219,7 +219,7 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError> + Se
         );
 
         let service = self.next_service.ready_oneshot().await?;
-        return service.oneshot(message).await;
+        service.oneshot(message).await
     }
 
     async fn get_storage_priority(&self, message: &DecryptedDhtMessage) -> SafResult<Option<StoredMessagePriority>> {

--- a/integration_tests/tests/cucumber.rs
+++ b/integration_tests/tests/cucumber.rs
@@ -3815,11 +3815,13 @@ async fn node_reached_sync(world: &mut TariWorld, node: String) {
 #[when(expr = "I create a burn transaction of {int} uT from {word} at fee {int}")]
 async fn burn_transaction(world: &mut TariWorld, amount: u64, wallet: String, fee: u64) {
     let mut client = world.get_wallet_client(&wallet).await.unwrap();
+    let identity = client.identify(GetIdentityRequest {}).await.unwrap().into_inner();
 
     let req = grpc::CreateBurnTransactionRequest {
         amount,
         fee_per_gram: fee,
         message: "Burning some tari".to_string(),
+        claim_public_key: identity.public_key,
     };
 
     let result = client.create_burn_transaction(req).await.unwrap();


### PR DESCRIPTION
Description
---
Add burn fields to the GRPC method of burning

Motivation and Context
---
When claiming funds on the second layer, you will need a few proofs to claim them. This allows the wallet to provide them

How Has This Been Tested?
---
CI

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
