### PR TITLE
ci(feature): add secondary docker image repo - ghcr.io

### DIFF
--- a/.github/workflows/build_dockers_workflow.yml
+++ b/.github/workflows/build_dockers_workflow.yml
@@ -158,18 +158,40 @@ jobs:
             fi
           fi
 
+      - name: Set up QEMU for Docker
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            #name/${{ matrix.builds.image_name }}
+            ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          #username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Login to Docker Image Provider
         uses: docker/login-action@v2
         with:
           registry: ${{ secrets.DOCKER_PROVIDER }}
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Set up QEMU for Docker
-        uses: docker/setup-qemu-action@v2
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
 
       - name: Docker image build and push
         id: docker_build
@@ -189,8 +211,10 @@ jobs:
             APP_EXEC=${{ matrix.builds.app_exec }}
             ${{ env.DOCKER_SUBTAG }}
           tags: |
+            ${{ steps.meta.outputs.tags }}
             ${{ secrets.DOCKER_PROVIDER }}/${{ secrets.DOCKER_REPO }}/${{ matrix.builds.image_name }}:${{ env.VERSION }}
             ${{ env.TAG_ALIAS }}
+          labels: ${{ steps.meta.outputs.labels }}
 
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/build_dockers_workflow.yml
+++ b/.github/workflows/build_dockers_workflow.yml
@@ -170,7 +170,8 @@ jobs:
         with:
           images: |
             #name/${{ matrix.builds.image_name }}
-            ghcr.io/${{ github.repository }}
+            #ghcr.io/${{ github.repository }}
+            ghcr.io/${{ github.repository_owner }}/${{ matrix.builds.image_name }}
           tags: |
             type=ref,event=branch
             type=ref,event=pr


### PR DESCRIPTION
Description
Add GitHub Container Registry as a secondary docker image repo 

Motivation and Context
Having a secondary docker image repo for redundancy is never bad

How Has This Been Tested?
Built with GHA in local fork
