### PR TITLE
feat: wallet password change

### DIFF
--- a/applications/tari_console_wallet/src/cli.rs
+++ b/applications/tari_console_wallet/src/cli.rs
@@ -51,7 +51,7 @@ pub struct Cli {
     /// possible.
     #[clap(long, env = "TARI_WALLET_PASSWORD", hide_env_values = true)]
     pub password: Option<SafePassword>,
-    /// Change the password for the console wallet
+    /// Change the password for the console wallet and exit
     #[clap(long, alias = "update-password")]
     pub change_password: bool,
     /// Force wallet recovery

--- a/applications/tari_console_wallet/src/init/mod.rs
+++ b/applications/tari_console_wallet/src/init/mod.rs
@@ -148,39 +148,39 @@ fn prompt_password(prompt: &str) -> Result<SafePassword, ExitError> {
 /// Allows the user to change the password of the wallet.
 pub async fn change_password(
     config: &ApplicationConfig,
-    arg_password: SafePassword,
+    existing: SafePassword,
     shutdown_signal: ShutdownSignal,
     non_interactive_mode: bool,
 ) -> Result<(), ExitError> {
-    let mut wallet = init_wallet(config, arg_password, None, None, shutdown_signal, non_interactive_mode).await?;
+    let mut wallet = init_wallet(
+        config,
+        existing.clone(),
+        None,
+        None,
+        shutdown_signal,
+        non_interactive_mode,
+    )
+    .await?;
 
-    let passphrase = prompt_password("New wallet password: ")?;
+    let new = prompt_password("New wallet password: ")?;
     let confirmed = prompt_password("Confirm new password: ")?;
 
-    if passphrase.reveal() != confirmed.reveal() {
+    if new.reveal() != confirmed.reveal() {
         return Err(ExitError::new(ExitCode::InputError, "Passwords don't match!"));
     }
-
-    // wallet
-    //     .remove_encryption()
-    //     .await
-    //     .map_err(|e| ExitError::new(ExitCode::WalletError, e))?;
-
-    // wallet
-    //     .apply_encryption(passphrase)
-    //     .await
-    //     .map_err(|e| ExitError::new(ExitCode::WalletError, e))?;
 
     println!("Passwords match.");
 
     // If the passphrase is weak, let the user know
-    display_password_feedback(&passphrase);
+    display_password_feedback(&new);
 
-    // TODO: remove this warning when this functionality is added
-    println!();
-    println!("WARNING: Password change functionality is not yet completed, so continue to use your existing password!");
-
-    Ok(())
+    // Use the existing and new passphrases to attempt to change the wallet passphrase
+    wallet.db.change_passphrase(&existing, &new).map_err(|e| match e {
+        WalletStorageError::InvalidPassphrase => {
+            ExitError::new(ExitCode::IncorrectOrEmptyPassword, "Your password was not changed.")
+        },
+        _ => ExitError::new(ExitCode::DatabaseError, "Your password was not changed."),
+    })
 }
 
 /// Populates the PeerConfig struct from:
@@ -667,7 +667,7 @@ pub(crate) fn boot_with_password(
         },
         WalletBoot::Existing | WalletBoot::Recovery => {
             debug!(target: LOG_TARGET, "Prompting for password.");
-            prompt_password("Prompt wallet password: ")?
+            prompt_password("Enter wallet password: ")?
         },
     };
 

--- a/base_layer/wallet/src/storage/database.rs
+++ b/base_layer/wallet/src/storage/database.rs
@@ -33,6 +33,7 @@ use tari_comms::{
     tor::TorIdentity,
 };
 use tari_key_manager::cipher_seed::CipherSeed;
+use tari_utilities::SafePassword;
 
 use crate::{error::WalletStorageError, utxo_scanner_service::service::ScannedBlock};
 
@@ -57,6 +58,9 @@ pub trait WalletBackend: Send + Sync + Clone {
         height: u64,
         exclude_recovered: bool,
     ) -> Result<(), WalletStorageError>;
+
+    /// Change the passphrase used to encrypt the database
+    fn change_passphrase(&self, existing: &SafePassword, new: &SafePassword) -> Result<(), WalletStorageError>;
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -133,6 +137,11 @@ where T: WalletBackend + 'static
 {
     pub fn new(db: T) -> Self {
         Self { db: Arc::new(db) }
+    }
+
+    pub fn change_passphrase(&self, existing: &SafePassword, new: &SafePassword) -> Result<(), WalletStorageError> {
+        self.db.change_passphrase(existing, new)?;
+        Ok(())
     }
 
     pub fn get_master_seed(&self) -> Result<Option<CipherSeed>, WalletStorageError> {


### PR DESCRIPTION
Description
---
Adds functionality to change wallet passphrase, updating to the latest encryption version parameters at the same time. Minor refactoring of database main and secondary key operations.

Removes unneeded functionality that tried to assert any cipher seed was encrypted (and [associated tests](https://github.com/tari-project/tari/blob/b7747a29c7032278b3ed88e13823d6e4fe7de45e/base_layer/wallet/src/storage/sqlite_db/wallet.rs#L771-L823)).

Closes [issue 5003](https://github.com/tari-project/tari/issues/5003).

Motivation and Context
---
Currently, wallet passphrases cannot be changed; there is a CLI flow, but it is non-functional.

This PR continues the work started in [PR 5154](https://github.com/tari-project/tari/pull/5154), which refactors wallet database encryption. When the user wishes to change their passphrase, we do the following:
- Attempt to use the existing passphrase to authenticate and decrypt the encrypted database main key. If this fails, the passphrase is incorrect, so we abort.
- Get the latest encryption version parameters from the hardcoded list.
- Generate a fresh secondary key salt. Use it and the new passphrase to derive a new secondary key, using the fetched encryption version parameters.
- Encrypt the database main key using the new secondary key.
- Store the new version identifier, secondary key salt, and encrypted main key in the database, overwriting the previous values.

The update operations are done in a single transaction to mitigate the (unlikely) risk of database corruption. There isn't an included test for this, but you can simulate a failure by having the transaction closure return an error, after which the existing wallet passphrase should continue to work.

How Has This Been Tested?
---
Existing unit tests pass. A new unit test passes. Manually tested a successful passphrase change. Manually tested a failed passphrase change. Manually tested a simulated database transaction failure.