### PR TITLE
fix: addresses mmr `find_peaks` bug

### DIFF
--- a/base_layer/mmr/src/common.rs
+++ b/base_layer/mmr/src/common.rs
@@ -84,10 +84,12 @@ pub fn find_peaks(size: usize) -> Option<Vec<usize>> {
         //   / \
         //  0   1   3   4
         // is invalid, as it can be completed to form
+        //       6
+        //     /    \
         //    2      5
         //  /  \    /  \
         // 0    1  3    4
-        // which is of size 6 (with peaks [2, 5])
+        // which is of size 7 (with single peak [6])
         return None;
     }
     Some(peaks)

--- a/base_layer/mmr/src/common.rs
+++ b/base_layer/mmr/src/common.rs
@@ -75,8 +75,12 @@ pub fn find_peaks(size: usize) -> Vec<usize> {
             sum_prev_peaks += peak_size;
             num_left -= peak_size;
         }
-        // need to verify that peaks can exist on the same height, in which case
-        // the size doesn't give rise to a complete mmr
+        // need to verify if other peaks exist on the same height, in which case
+        // the size doesn't generate a complete mmr, e.g.
+        //    2
+        //   / \
+        //  0   1   3   4
+        // where we have two peaks at height 0.
         if num_left < peak_size {
             peak_size >>= 1;
         }

--- a/base_layer/mmr/src/common.rs
+++ b/base_layer/mmr/src/common.rs
@@ -248,17 +248,34 @@ mod test {
     fn peak_vectors() {
         assert_eq!(find_peaks(0), Vec::<usize>::new());
         assert_eq!(find_peaks(1), vec![0]);
+        assert_eq!(find_peaks(2), vec![0, 1]);
         assert_eq!(find_peaks(3), vec![2]);
         assert_eq!(find_peaks(4), vec![2, 3]);
-        assert_eq!(find_peaks(15), vec![14]);
-        assert_eq!(find_peaks(23), vec![14, 21, 22]);
-        assert_eq!(find_peaks(123), vec![62, 93, 108, 115, 122]);
-        assert_eq!(find_peaks(130), vec![126, 129]);
-        assert_eq!(find_peaks(56), vec![30, 45, 52, 55]);
-        assert_eq!(find_peaks(60), vec![30, 45, 52, 59]);
-        assert_eq!(find_peaks(28), vec![14, 21, 24, 27]);
         assert_eq!(find_peaks(5), vec![2, 3, 4]);
         assert_eq!(find_peaks(6), vec![2, 5]);
+        assert_eq!(find_peaks(7), vec![6]);
+        assert_eq!(find_peaks(8), vec![6, 7]);
+        assert_eq!(find_peaks(9), vec![6, 7, 8]);
+        assert_eq!(find_peaks(10), vec![6, 9]);
+        assert_eq!(find_peaks(11), vec![6, 9, 10]);
+        assert_eq!(find_peaks(12), vec![6, 9, 10, 11]);
+        assert_eq!(find_peaks(13), vec![6, 9, 12]);
+        assert_eq!(find_peaks(14), vec![6, 13]);
+        assert_eq!(find_peaks(15), vec![14]);
+        assert_eq!(find_peaks(16), vec![14, 15]);
+        assert_eq!(find_peaks(17), vec![14, 15, 16]);
+        assert_eq!(find_peaks(18), vec![14, 17]);
+        assert_eq!(find_peaks(19), vec![14, 17, 18]);
+        assert_eq!(find_peaks(20), vec![14, 17, 18, 19]);
+        assert_eq!(find_peaks(21), vec![14, 17, 20]);
+        assert_eq!(find_peaks(22), vec![14, 21]);
+        assert_eq!(find_peaks(23), vec![14, 21, 22]);
+        assert_eq!(find_peaks(24), vec![14, 21, 22, 23]);
+        assert_eq!(find_peaks(28), vec![14, 21, 24, 27]);
+        assert_eq!(find_peaks(56), vec![30, 45, 52, 55]);
+        assert_eq!(find_peaks(60), vec![30, 45, 52, 59]);
+        assert_eq!(find_peaks(123), vec![62, 93, 108, 115, 122]);
+        assert_eq!(find_peaks(130), vec![126, 129]);
     }
 
     #[test]

--- a/base_layer/mmr/src/common.rs
+++ b/base_layer/mmr/src/common.rs
@@ -72,7 +72,11 @@ pub fn find_peaks(size: usize) -> Vec<usize> {
             sum_prev_peaks += peak_size;
             num_left -= peak_size;
         }
-        peak_size >>= 1;
+        // need to verify that peaks can exist on the same height, in which case
+        // the size doesn't give rise to a complete mmr
+        if num_left < peak_size {
+            peak_size >>= 1;
+        }
     }
     if num_left > 0 {
         return vec![];
@@ -248,6 +252,13 @@ mod test {
         assert_eq!(find_peaks(4), vec![2, 3]);
         assert_eq!(find_peaks(15), vec![14]);
         assert_eq!(find_peaks(23), vec![14, 21, 22]);
+        assert_eq!(find_peaks(123), vec![62, 93, 108, 115, 122]);
+        assert_eq!(find_peaks(130), vec![126, 129]);
+        assert_eq!(find_peaks(56), vec![30, 45, 52, 55]);
+        assert_eq!(find_peaks(60), vec![30, 45, 52, 59]);
+        assert_eq!(find_peaks(28), vec![14, 21, 24, 27]);
+        assert_eq!(find_peaks(5), vec![2, 3, 4]);
+        assert_eq!(find_peaks(6), vec![2, 5]);
     }
 
     #[test]
@@ -349,9 +360,9 @@ mod test {
     fn find_peaks_when_num_left_gt_zero() {
         assert!(find_peaks(0).is_empty());
         assert_eq!(find_peaks(1), vec![0]);
-        assert!(find_peaks(2).is_empty());
+        assert_eq!(find_peaks(2), vec![0, 1]);
         assert_eq!(find_peaks(3), vec![2]);
         assert_eq!(find_peaks(usize::MAX), [18446744073709551614].to_vec());
-        assert_eq!(find_peaks(usize::MAX - 1).len(), 0);
+        assert_eq!(find_peaks(usize::MAX - 1).len(), 2);
     }
 }

--- a/base_layer/mmr/src/error.rs
+++ b/base_layer/mmr/src/error.rs
@@ -38,6 +38,8 @@ pub enum MerkleMountainRangeError {
     OutOfRange,
     #[error("Conflicting or invalid configuration parameters provided.")]
     InvalidConfig,
+    #[error("Invalid Merkle Mountain Range size")]
+    InvalidMmrSize,
 }
 
 impl MerkleMountainRangeError {

--- a/base_layer/mmr/src/merkle_mountain_range.rs
+++ b/base_layer/mmr/src/merkle_mountain_range.rs
@@ -149,7 +149,8 @@ where
             self.hashes
                 .len()
                 .map_err(|e| MerkleMountainRangeError::BackendError(e.to_string()))?,
-        );
+        )
+        .ok_or(MerkleMountainRangeError::InvalidMmrSize)?;
         Ok(peaks
             .into_iter()
             .map(|i| {

--- a/base_layer/mmr/src/merkle_proof.rs
+++ b/base_layer/mmr/src/merkle_proof.rs
@@ -137,7 +137,7 @@ impl MerkleProof {
 
         // Get the peaks of the merkle trees, which are bagged together to form the root
         // For the proof, we must leave out the local root for the candidate node
-        let peaks = find_peaks(mmr_size);
+        let peaks = find_peaks(mmr_size).ok_or(MerkleMountainRangeError::InvalidMmrSize)?;
         let mut peak_hashes = Vec::with_capacity(peaks.len() - 1);
         for peak_index in peaks {
             if peak_index != peak_pos {
@@ -174,7 +174,7 @@ impl MerkleProof {
     ) -> Result<(), MerkleProofError> {
         let mut proof = self.clone();
         // calculate the peaks once as these are based on overall MMR size (and will not change)
-        let peaks = find_peaks(self.mmr_size);
+        let peaks = find_peaks(self.mmr_size).ok_or(MerkleMountainRangeError::InvalidMmrSize)?;
         proof.verify_consume::<D>(root, hash, pos, &peaks)
     }
 

--- a/base_layer/mmr/src/pruned_hashset.rs
+++ b/base_layer/mmr/src/pruned_hashset.rs
@@ -58,7 +58,7 @@ where
 
     fn try_from(base_mmr: &MerkleMountainRange<D, B>) -> Result<Self, Self::Error> {
         let base_offset = base_mmr.len()?;
-        let peak_indices = find_peaks(base_offset);
+        let peak_indices = find_peaks(base_offset).ok_or(MerkleMountainRangeError::InvalidMmrSize)?;
         let peak_hashes = peak_indices
             .iter()
             .map(|i| match base_mmr.get_node_hash(*i)? {


### PR DESCRIPTION
Description
---
Currently, the Tari MMR repo contains a bug on the `find_peaks` function, in `base_layer/mmr/src/common.rs`. The source of the problem arises from the fact that the current implementation does not consider possible Merkle Mountain Ranges, in which all nodes are filled to the possible top (that is, every possible spawned peak exists in the MMR). Moreover, the current function implementation handles this issue by returning an empty `vec![]`. This works as a 'silent error' being passed upstream. In order to handle this problem, we impose that the height to check that a new peak exists only decreases if we are guaranteed that every peak at the same height does in fact not exists. In this way, proofs can be created for every MMR size. 

PS: Want to add further unit tests.

Motivation and Context
---

How Has This Been Tested?
---
More extensive unit testing.


<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
