### PR TITLE
fix: add missing consensus constants to get_constants grpc

### DIFF
--- a/applications/tari_app_grpc/proto/types.proto
+++ b/applications/tari_app_grpc/proto/types.proto
@@ -145,4 +145,8 @@ message ConsensusConstants {
     repeated OutputType permitted_output_types = 29;
     /// The length of an epoch
     uint64 epoch_length = 30;
+    // The minimum deposit amount for a validator node registration
+    uint64 validator_node_registration_min_deposit_amount = 31;
+    uint64 validator_node_registration_min_lock_height = 32;
+    uint64 validator_node_registration_shuffle_interval_epoch = 33;
 }

--- a/applications/tari_app_grpc/src/conversions/consensus_constants.rs
+++ b/applications/tari_app_grpc/src/conversions/consensus_constants.rs
@@ -127,6 +127,13 @@ impl From<ConsensusConstants> for grpc::ConsensusConstants {
             permitted_output_types,
             validator_node_validity_period: cc.validator_node_validity_period_epochs().as_u64(),
             epoch_length: cc.epoch_length(),
+            validator_node_registration_min_deposit_amount: cc
+                .validator_node_registration_min_deposit_amount()
+                .as_u64(),
+            validator_node_registration_min_lock_height: cc.validator_node_registration_min_lock_height(),
+            validator_node_registration_shuffle_interval_epoch: cc
+                .validator_node_registration_shuffle_interval()
+                .as_u64(),
         }
     }
 }


### PR DESCRIPTION
Description
---
Adds `validator_node_registration_min_deposit_amount` `validator_node_registration_min_lock_height` `validator_node_registration_shuffle_interval_epoch` fields to `get_constants` base node GRPC method.

Motivation and Context
---
These fields are required for L2 consensus

How Has This Been Tested?
---
Type changes only, lints pass

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
