### PR TITLE
fix: ignores peer seed test that requires external DNS

### DIFF
--- a/base_layer/p2p/src/peer_seeds.rs
+++ b/base_layer/p2p/src/peer_seeds.rs
@@ -239,11 +239,12 @@ mod test {
         use crate::{dns::mock, DEFAULT_DNS_NAME_SERVER};
 
         #[tokio::test]
+        #[ignore = "Useful for developer testing but will fail unless the DNS has TXT records setup correctly."]
         async fn it_returns_seeds_from_real_address() {
             let mut resolver = DnsSeedResolver::connect(DEFAULT_DNS_NAME_SERVER.parse().unwrap())
                 .await
                 .unwrap();
-            let seeds = resolver.resolve("seeds.weatherwax.tari.com").await.unwrap();
+            let seeds = resolver.resolve("seeds.esmeralda.tari.com").await.unwrap();
             println!("{:?}", seeds);
             assert!(!seeds.is_empty());
         }


### PR DESCRIPTION
Description
---
 ignores peer seed test that requires external DNS

Motivation and Context
---
This test is currently failing and was originally ignored because it depends on an external DNS to pass.

How Has This Been Tested?
---
Test ignored

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
