### PR TITLE
feat!: add key commitment to database main key AEAD

### DIFF
--- a/base_layer/wallet/src/storage/database.rs
+++ b/base_layer/wallet/src/storage/database.rs
@@ -73,8 +73,9 @@ pub enum DbKey {
     ClientKey(String),
     MasterSeed,
     EncryptedMainKey,    // the database encryption key, itself encrypted with the secondary key
-    SecondaryKeySalt,    // the salt used (with the user's passphrase) to derive the secondary key
-    SecondaryKeyVersion, // the parameter version for the secondary key, which determines how it is derived
+    SecondaryKeySalt,    // the salt used (with the user's passphrase) to derive the secondary derivation key
+    SecondaryKeyVersion, // the parameter version for the secondary derivation key
+    SecondaryKeyHash,    // a hash commitment to the secondary derivation key
     WalletBirthday,
 }
 
@@ -90,6 +91,7 @@ impl DbKey {
             DbKey::EncryptedMainKey => "EncryptedMainKey".to_string(),
             DbKey::SecondaryKeySalt => "SecondaryKeySalt".to_string(),
             DbKey::SecondaryKeyVersion => "SecondaryKeyVersion".to_string(),
+            DbKey::SecondaryKeyHash => "SecondaryKeyHash".to_string(),
             DbKey::WalletBirthday => "WalletBirthday".to_string(),
             DbKey::CommsIdentitySignature => "CommsIdentitySignature".to_string(),
         }
@@ -108,6 +110,7 @@ pub enum DbValue {
     EncryptedMainKey(String),
     SecondaryKeySalt(String),
     SecondaryKeyVersion(String),
+    SecondaryKeyHash(String),
     WalletBirthday(String),
 }
 
@@ -348,6 +351,7 @@ impl Display for DbValue {
             DbValue::EncryptedMainKey(k) => f.write_str(&format!("EncryptedMainKey: {:?}", k)),
             DbValue::SecondaryKeySalt(s) => f.write_str(&format!("SecondaryKeySalt: {}", s)),
             DbValue::SecondaryKeyVersion(v) => f.write_str(&format!("SecondaryKeyVersion: {}", v)),
+            DbValue::SecondaryKeyHash(h) => f.write_str(&format!("SecondaryKeyHash: {}", h)),
             DbValue::WalletBirthday(b) => f.write_str(&format!("WalletBirthday: {}", b)),
             DbValue::CommsIdentitySignature(_) => f.write_str("CommsIdentitySignature"),
         }


### PR DESCRIPTION
Description
---
Updates database encryption by adding key commitment to the main key authenticated encryption.

Motivation and Context
---
Most authenticated encryption with associated data (AEAD) constructions, including the `XChaCha20-Poly1305` construction used in the codebase, do not commit to keys. This is often not problematic, but in the context of password-based encryption, it can remove certain formal guarantees of authenticity.

[Recent work](https://eprint.iacr.org/2023/197) suggests that the use of a key-committing AEAD as part of a password-based encryption design can provide improved security against particular attacks. While these are likely entirely theoretical for Tari database encryption, it makes sense to consider feasible mitigations.

While key-committing AEADs are not standardized or widely available in libraries, [one paper](https://www.usenix.org/conference/usenixsecurity22/presentation/albertini) suggests a particularly simple design that augments an arbitrary AEAD by using a key derivation process that includes a particular hash commitment with the ciphertext.

This PR adds the hash-of-key design to the AEAD used for encryption of the database main key.

Here is a diagram showing the complete database encryption design. Rectangular nodes are secret data, rounded nodes are functions/algorithms, and cylindrical nodes are data stored in the database. Double-ended arrows indicate encryption/decryption functionality.

```mermaid
flowchart LR
    pbkdf([PBKDF]) --> sdk[Secondary derivation key]
    pass[Passphrase] --> pbkdf
    salt[(Salt)] --> pbkdf
    version[(Version)] --> pbkdf

    sdk --> kdfenc([KDF]) --> sk[Secondary key]
    sdk --> kdfcom([KDF]) --> kc[(Key commitment)]

    aeadmk([AEAD])
    mk[Main key] <--> aeadmk
    sk --> aeadmk
    aeadmk <--> encmk[(Encrypted main key)]

    aeadfield([AEAD])
    field[Field data] <--> aeadfield
    mk --> aeadfield
    aeadfield <--> encfield[(Encrypted field data)]
```

How Has This Been Tested?
---
Existing unit tests pass. A new unit test passes. Manually tested creating a new wallet, loading it successfully (with the correct passphrase) and unsuccessfully (with an incorrect passphrase), and performing a successful and unsuccessful (with incorrect existing passphrase, and with a mistyped new passphrase) passphrase change.

BREAKING CHANGE: This adds an encryption-related field to the database and modifies key derivation, so attempts to access existing databases will fail.
