### PR TITLE
feat: merged proof

### DIFF
--- a/base_layer/mmr/src/lib.rs
+++ b/base_layer/mmr/src/lib.rs
@@ -152,7 +152,7 @@ pub mod pruned_hashset;
 // Commonly used exports
 /// A vector-based backend for [MerkleMountainRange]
 pub use backend::{ArrayLike, ArrayLikeExt};
-pub use balanced_binary_merkle_proof::BalancedBinaryMerkleProof;
+pub use balanced_binary_merkle_proof::{BalancedBinaryMerkleProof, MergedBalancedBinaryMerkleProof};
 pub use balanced_binary_merkle_tree::BalancedBinaryMerkleTree;
 /// MemBackendVec is a shareable, memory only, vector that can be be used with MmrCache to store checkpoints.
 pub use mem_backend_vec::MemBackendVec;


### PR DESCRIPTION
Description
---
This change introduces merged merkle proofs over balanced binary trees. It works by merging and cutting the paths of individual proofs. So only one proof will be stored with the same length as provided. All others will join this proof along the way. When a proof joins any other proof it will store the join index. And the other path instead of storing the hash of the sibling will store the index of this joined proof. So it will uses it's hash.

Motivation and Context
---
Save space and time for merkle proofs. The original MMR didn't support merged proofs.

How Has This Been Tested?
---
There are cargo tests in the proof file.