### PR TITLE
chore(release): v0.46.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4979,7 +4979,7 @@ dependencies = [
 
 [[package]]
 name = "tari_app_grpc"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "argon2",
  "base64 0.13.1",
@@ -5003,7 +5003,7 @@ dependencies = [
 
 [[package]]
 name = "tari_app_utilities"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "clap 3.2.23",
  "futures 0.3.26",
@@ -5021,7 +5021,7 @@ dependencies = [
 
 [[package]]
 name = "tari_base_node"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5113,7 +5113,7 @@ dependencies = [
 
 [[package]]
 name = "tari_common"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "anyhow",
  "blake2 0.9.2",
@@ -5138,7 +5138,7 @@ dependencies = [
 
 [[package]]
 name = "tari_common_sqlite"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "diesel",
  "log",
@@ -5147,7 +5147,7 @@ dependencies = [
 
 [[package]]
 name = "tari_common_types"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "borsh",
  "digest 0.9.0",
@@ -5164,7 +5164,7 @@ dependencies = [
 
 [[package]]
 name = "tari_comms"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5213,7 +5213,7 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_dht"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "anyhow",
  "bitflags 1.3.2",
@@ -5257,7 +5257,7 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_rpc_macros"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "futures 0.3.26",
  "proc-macro2",
@@ -5272,7 +5272,7 @@ dependencies = [
 
 [[package]]
 name = "tari_console_wallet"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "bitflags 1.3.2",
  "chrono",
@@ -5319,7 +5319,7 @@ dependencies = [
 
 [[package]]
 name = "tari_core"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "bincode",
  "bitflags 1.3.2",
@@ -5457,7 +5457,7 @@ dependencies = [
 
 [[package]]
 name = "tari_key_manager"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "argon2",
  "blake2 0.9.2",
@@ -5500,7 +5500,7 @@ dependencies = [
 
 [[package]]
 name = "tari_merge_mining_proxy"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -5549,7 +5549,7 @@ dependencies = [
 
 [[package]]
 name = "tari_miner"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "base64 0.13.1",
  "borsh",
@@ -5584,7 +5584,7 @@ dependencies = [
 
 [[package]]
 name = "tari_mining_helper_ffi"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "borsh",
  "hex",
@@ -5600,7 +5600,7 @@ dependencies = [
 
 [[package]]
 name = "tari_mmr"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "bincode",
  "blake2 0.9.2",
@@ -5619,7 +5619,7 @@ dependencies = [
 
 [[package]]
 name = "tari_p2p"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "anyhow",
  "clap 2.34.0",
@@ -5673,7 +5673,7 @@ dependencies = [
 
 [[package]]
 name = "tari_service_framework"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5690,7 +5690,7 @@ dependencies = [
 
 [[package]]
 name = "tari_shutdown"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "futures 0.3.26",
  "tokio",
@@ -5698,7 +5698,7 @@ dependencies = [
 
 [[package]]
 name = "tari_storage"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "bincode",
  "lmdb-zero",
@@ -5711,7 +5711,7 @@ dependencies = [
 
 [[package]]
 name = "tari_test_utils"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "futures 0.3.26",
  "futures-test",
@@ -5741,7 +5741,7 @@ dependencies = [
 
 [[package]]
 name = "tari_wallet"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5790,7 +5790,7 @@ dependencies = [
 
 [[package]]
 name = "tari_wallet_ffi"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "borsh",
  "cbindgen 0.24.3",

--- a/applications/tari_app_grpc/Cargo.toml
+++ b/applications/tari_app_grpc/Cargo.toml
@@ -4,11 +4,11 @@ authors = ["The Tari Development Community"]
 description = "This crate is to provide a single source for all cross application grpc files and conversions to and from tari::core"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.45.0"
+version = "0.46.0"
 edition = "2018"
 
 [dependencies]
-tari_common_types = { version = "^0.45", path = "../../base_layer/common_types" }
+tari_common_types = { version = "^0.46", path = "../../base_layer/common_types" }
 tari_comms = { path = "../../comms/core" }
 tari_core = { path = "../../base_layer/core" }
 tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.16.6" }

--- a/applications/tari_app_utilities/Cargo.toml
+++ b/applications/tari_app_utilities/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_app_utilities"
-version = "0.45.0"
+version = "0.46.0"
 authors = ["The Tari Development Community"]
 edition = "2018"
 license = "BSD-3-Clause"

--- a/applications/tari_base_node/Cargo.toml
+++ b/applications/tari_base_node/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "The tari full base node implementation"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.45.0"
+version = "0.46.0"
 edition = "2018"
 
 [dependencies]

--- a/applications/tari_console_wallet/Cargo.toml
+++ b/applications/tari_console_wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_console_wallet"
-version = "0.45.0"
+version = "0.46.0"
 authors = ["The Tari Development Community"]
 edition = "2018"
 license = "BSD-3-Clause"

--- a/applications/tari_merge_mining_proxy/Cargo.toml
+++ b/applications/tari_merge_mining_proxy/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "The Tari merge mining proxy for xmrig"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.45.0"
+version = "0.46.0"
 edition = "2018"
 
 [features]

--- a/applications/tari_miner/Cargo.toml
+++ b/applications/tari_miner/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "The tari miner implementation"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.45.0"
+version = "0.46.0"
 edition = "2018"
 
 [dependencies]

--- a/base_layer/common_types/Cargo.toml
+++ b/base_layer/common_types/Cargo.toml
@@ -3,14 +3,14 @@ name = "tari_common_types"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency common types"
 license = "BSD-3-Clause"
-version = "0.45.0"
+version = "0.46.0"
 edition = "2018"
 
 [dependencies]
 tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.16.6" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag="v0.4.10" }
 # TODO: remove this dependency and move Network into tari_common_types
-tari_common = { version = "^0.45", path = "../../common" }
+tari_common = { version = "^0.46", path = "../../common" }
 
 
 borsh = "0.9.3"

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.45.0"
+version = "0.46.0"
 edition = "2018"
 
 [features]
@@ -19,20 +19,20 @@ avx2 = ["tari_crypto/simd_backend"]
 benches = ["base_node", "criterion"]
 
 [dependencies]
-tari_common = { version = "^0.45", path = "../../common" }
-tari_common_types = { version = "^0.45", path = "../../base_layer/common_types" }
-tari_comms = { version = "^0.45", path = "../../comms/core" }
-tari_comms_dht = { version = "^0.45", path = "../../comms/dht" }
-tari_comms_rpc_macros = { version = "^0.45", path = "../../comms/rpc_macros" }
+tari_common = { version = "^0.46", path = "../../common" }
+tari_common_types = { version = "^0.46", path = "../../base_layer/common_types" }
+tari_comms = { version = "^0.46", path = "../../comms/core" }
+tari_comms_dht = { version = "^0.46", path = "../../comms/dht" }
+tari_comms_rpc_macros = { version = "^0.46", path = "../../comms/rpc_macros" }
 tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.16.6", features = ["borsh"] }
 tari_metrics = { path = "../../infrastructure/metrics" }
-tari_mmr = { version = "^0.45", path = "../../base_layer/mmr", optional = true, features = ["native_bitmap"] }
-tari_p2p = { version = "^0.45", path = "../../base_layer/p2p" }
+tari_mmr = { version = "^0.46", path = "../../base_layer/mmr", optional = true, features = ["native_bitmap"] }
+tari_p2p = { version = "^0.46", path = "../../base_layer/p2p" }
 tari_script = { path = "../../infrastructure/tari_script" }
-tari_service_framework = { version = "^0.45", path = "../service_framework" }
-tari_shutdown = { version = "^0.45", path = "../../infrastructure/shutdown" }
-tari_storage = { version = "^0.45", path = "../../infrastructure/storage" }
-tari_test_utils = { version = "^0.45", path = "../../infrastructure/test_utils" }
+tari_service_framework = { version = "^0.46", path = "../service_framework" }
+tari_shutdown = { version = "^0.46", path = "../../infrastructure/shutdown" }
+tari_storage = { version = "^0.46", path = "../../infrastructure/storage" }
+tari_test_utils = { version = "^0.46", path = "../../infrastructure/test_utils" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.10", features = ["borsh"] }
 
 bincode = "1.1.4"
@@ -76,15 +76,15 @@ uint = { version = "0.9", default-features = false }
 zeroize = "1"
 
 [dev-dependencies]
-tari_p2p = { version = "^0.45", path = "../../base_layer/p2p", features = ["test-mocks"] }
-tari_test_utils = { version = "^0.45", path = "../../infrastructure/test_utils" }
+tari_p2p = { version = "^0.46", path = "../../base_layer/p2p", features = ["test-mocks"] }
+tari_test_utils = { version = "^0.46", path = "../../infrastructure/test_utils" }
 
 config = { version = "0.13.0" }
 env_logger = "0.7.0"
 tempfile = "3.1.0"
 
 [build-dependencies]
-tari_common = { version = "^0.45", path = "../../common", features = ["build"] }
+tari_common = { version = "^0.46", path = "../../common", features = ["build"] }
 
 [[bench]]
 name = "mempool"

--- a/base_layer/key_manager/Cargo.toml
+++ b/base_layer/key_manager/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency wallet key management"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.45.0"
+version = "0.46.0"
 edition = "2021"
 
 [lib]
@@ -12,7 +12,7 @@ crate-type = ["lib", "cdylib"]
 
 # NB: All dependencies must support or be gated for the WASM target.
 [dependencies]
-tari_common_types = { version = "^0.45", path = "../../base_layer/common_types", optional = true }
+tari_common_types = { version = "^0.46", path = "../../base_layer/common_types", optional = true }
 tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.16.6" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag="v0.4.10" }
 

--- a/base_layer/mmr/Cargo.toml
+++ b/base_layer/mmr/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "A Merkle Mountain Range implementation"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.45.0"
+version = "0.46.0"
 edition = "2018"
 
 [features]

--- a/base_layer/p2p/Cargo.toml
+++ b/base_layer/p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_p2p"
-version = "0.45.0"
+version = "0.46.0"
 authors = ["The Tari Development community"]
 description = "Tari base layer-specific peer-to-peer communication features"
 repository = "https://github.com/tari-project/tari"
@@ -10,13 +10,13 @@ license = "BSD-3-Clause"
 edition = "2018"
 
 [dependencies]
-tari_comms = { version = "^0.45", path = "../../comms/core" }
-tari_comms_dht = { version = "^0.45", path = "../../comms/dht" }
-tari_common = { version = "^0.45", path = "../../common" }
+tari_comms = { version = "^0.46", path = "../../comms/core" }
+tari_comms_dht = { version = "^0.46", path = "../../comms/dht" }
+tari_common = { version = "^0.46", path = "../../common" }
 tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.16.6" }
-tari_service_framework = { version = "^0.45", path = "../service_framework" }
-tari_shutdown = { version = "^0.45", path = "../../infrastructure/shutdown" }
-tari_storage = { version = "^0.45", path = "../../infrastructure/storage" }
+tari_service_framework = { version = "^0.46", path = "../service_framework" }
+tari_shutdown = { version = "^0.46", path = "../../infrastructure/shutdown" }
+tari_storage = { version = "^0.46", path = "../../infrastructure/storage" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag="v0.4.10" }
 
 anyhow = "1.0.53"
@@ -39,7 +39,7 @@ trust-dns-client = { version = "=0.21.0-alpha.5", features = ["dns-over-rustls"]
 webpki = "0.21"
 
 [dev-dependencies]
-tari_test_utils = { version = "^0.45", path = "../../infrastructure/test_utils" }
+tari_test_utils = { version = "^0.46", path = "../../infrastructure/test_utils" }
 
 config = "0.13.0"
 clap = "2.33.0"
@@ -47,7 +47,7 @@ lazy_static = "1.3.0"
 tempfile = "3.1.0"
 
 [build-dependencies]
-tari_common = { version = "^0.45", path = "../../common", features = ["build"] }
+tari_common = { version = "^0.46", path = "../../common", features = ["build"] }
 
 [features]
 test-mocks = []

--- a/base_layer/service_framework/Cargo.toml
+++ b/base_layer/service_framework/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_service_framework"
-version = "0.45.0"
+version = "0.46.0"
 authors = ["The Tari Development Community"]
 description = "The Tari communication stack service framework"
 repository = "https://github.com/tari-project/tari"
@@ -10,7 +10,7 @@ license = "BSD-3-Clause"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tari_shutdown = { version = "^0.45", path = "../../infrastructure/shutdown" }
+tari_shutdown = { version = "^0.46", path = "../../infrastructure/shutdown" }
 
 anyhow = "1.0.53"
 async-trait = "0.1.50"
@@ -21,7 +21,7 @@ tokio = { version = "1.23", features = ["rt"] }
 tower-service = { version = "0.3" }
 
 [dev-dependencies]
-tari_test_utils = { version = "^0.45", path = "../../infrastructure/test_utils" }
+tari_test_utils = { version = "^0.46", path = "../../infrastructure/test_utils" }
 
 tokio = { version = "1.23", features = ["rt-multi-thread", "macros", "time"] }
 futures-test = { version = "0.3.3" }

--- a/base_layer/tari_mining_helper_ffi/Cargo.toml
+++ b/base_layer/tari_mining_helper_ffi/Cargo.toml
@@ -3,11 +3,11 @@ name = "tari_mining_helper_ffi"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency miningcore C FFI bindings"
 license = "BSD-3-Clause"
-version = "0.45.0"
+version = "0.46.0"
 edition = "2018"
 
 [dependencies]
-tari_comms = { version = "^0.45", path = "../../comms/core" }
+tari_comms = { version = "^0.46", path = "../../comms/core" }
 tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.16.6"}
 tari_common = {  path = "../../common" }
 tari_core = {  path = "../core", default-features = false, features = ["transactions"]}

--- a/base_layer/wallet/Cargo.toml
+++ b/base_layer/wallet/Cargo.toml
@@ -3,21 +3,21 @@ name = "tari_wallet"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency wallet library"
 license = "BSD-3-Clause"
-version = "0.45.0"
+version = "0.46.0"
 edition = "2018"
 
 [dependencies]
-tari_core = { path = "../../base_layer/core", version = "^0.45", default-features = false, features = ["transactions", "mempool_proto", "base_node_proto"] }
+tari_core = { path = "../../base_layer/core", version = "^0.46", default-features = false, features = ["transactions", "mempool_proto", "base_node_proto"] }
 tari_common = { path = "../../common" }
-tari_common_types = { version = "^0.45", path = "../../base_layer/common_types" }
-tari_comms = { version = "^0.45", path = "../../comms/core" }
-tari_comms_dht = { version = "^0.45", path = "../../comms/dht" }
+tari_common_types = { version = "^0.46", path = "../../base_layer/common_types" }
+tari_comms = { version = "^0.46", path = "../../comms/core" }
+tari_comms_dht = { version = "^0.46", path = "../../comms/dht" }
 tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.16.6" }
-tari_key_manager = { version = "^0.45", path = "../key_manager" }
-tari_p2p = { version = "^0.45", path = "../p2p", features = ["auto-update"] }
+tari_key_manager = { version = "^0.46", path = "../key_manager" }
+tari_p2p = { version = "^0.46", path = "../p2p", features = ["auto-update"] }
 tari_script = { path = "../../infrastructure/tari_script" }
-tari_service_framework = { version = "^0.45", path = "../service_framework" }
-tari_shutdown = { version = "^0.45", path = "../../infrastructure/shutdown" }
+tari_service_framework = { version = "^0.46", path = "../service_framework" }
+tari_shutdown = { version = "^0.46", path = "../../infrastructure/shutdown" }
 tari_common_sqlite = { path = "../../common_sqlite" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag="v0.4.10" }
 
@@ -56,10 +56,10 @@ chacha20poly1305 = "0.10.1"
 zeroize = "1"
 
 [dev-dependencies]
-tari_p2p = { version = "^0.45", path = "../p2p", features = ["test-mocks"] }
-tari_comms_dht = { version = "^0.45", path = "../../comms/dht", features = ["test-mocks"] }
-tari_test_utils = { version = "^0.45", path = "../../infrastructure/test_utils" }
-tari_core = { path = "../../base_layer/core", version = "^0.45", default-features = false, features = ["transactions", "mempool_proto", "base_node_proto", "base_node"] }
+tari_p2p = { version = "^0.46", path = "../p2p", features = ["test-mocks"] }
+tari_comms_dht = { version = "^0.46", path = "../../comms/dht", features = ["test-mocks"] }
+tari_test_utils = { version = "^0.46", path = "../../infrastructure/test_utils" }
+tari_core = { path = "../../base_layer/core", version = "^0.46", default-features = false, features = ["transactions", "mempool_proto", "base_node_proto", "base_node"] }
 env_logger = "0.7.1"
 prost = "0.9.0"
 

--- a/base_layer/wallet_ffi/Cargo.toml
+++ b/base_layer/wallet_ffi/Cargo.toml
@@ -3,22 +3,22 @@ name = "tari_wallet_ffi"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency wallet C FFI bindings"
 license = "BSD-3-Clause"
-version = "0.45.0"
+version = "0.46.0"
 edition = "2018"
 
 [dependencies]
-tari_core = { version = "^0.45", path = "../../base_layer/core", default-features = false, features = ["tari_mmr", "transactions"] }
+tari_core = { version = "^0.46", path = "../../base_layer/core", default-features = false, features = ["tari_mmr", "transactions"] }
 tari_common = { path="../../common" }
 tari_common_types = { path="../common_types" }
-tari_comms = { version = "^0.45", path = "../../comms/core", features = ["c_integration"]}
-tari_comms_dht = { version = "^0.45", path = "../../comms/dht", default-features = false }
+tari_comms = { version = "^0.46", path = "../../comms/core", features = ["c_integration"]}
+tari_comms_dht = { version = "^0.46", path = "../../comms/dht", default-features = false }
 tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.16.6" }
-tari_key_manager = { version = "^0.45", path = "../key_manager" }
-tari_p2p = { version = "^0.45", path = "../p2p" }
+tari_key_manager = { version = "^0.46", path = "../key_manager" }
+tari_p2p = { version = "^0.46", path = "../p2p" }
 tari_script = { path = "../../infrastructure/tari_script" }
-tari_shutdown = { version = "^0.45", path = "../../infrastructure/shutdown" }
+tari_shutdown = { version = "^0.46", path = "../../infrastructure/shutdown" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag="v0.4.10" }
-tari_wallet = { version = "^0.45", path = "../wallet", features = ["c_integration"]}
+tari_wallet = { version = "^0.46", path = "../wallet", features = ["c_integration"]}
 
 chacha20poly1305 = "0.10.1"
 chrono = { version = "0.4.19", default-features = false, features = ["serde"] }
@@ -43,9 +43,9 @@ crate-type = ["staticlib","cdylib"]
 [dev-dependencies]
 tempfile = "3.1.0"
 lazy_static = "1.3.0"
-tari_key_manager = { version = "^0.45", path = "../key_manager" }
-tari_common_types = { version = "^0.45", path = "../../base_layer/common_types"}
-tari_test_utils = { version = "^0.45", path = "../../infrastructure/test_utils"}
+tari_key_manager = { version = "^0.46", path = "../key_manager" }
+tari_common_types = { version = "^0.46", path = "../../base_layer/common_types"}
+tari_test_utils = { version = "^0.46", path = "../../infrastructure/test_utils"}
 tari_service_framework = { path = "../../base_layer/service_framework" }
 borsh = "0.9.3"
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [0.46.0](https://github.com/tari-project/tari/compare/v0.45.0...v0.46.0) (2023-02-21)
+
+
+### ⚠ BREAKING CHANGES
+
+* add key commitment to database main key AEAD  (#5188)
+
+### Features
+
+* add key commitment to database main key AEAD  ([#5188](https://github.com/tari-project/tari/issues/5188)) ([95bc795](https://github.com/tari-project/tari/commit/95bc7956811020957d4cf0a8eef742124d44bcde))
+* add more burn details to burn command ([#5169](https://github.com/tari-project/tari/issues/5169)) ([e417e57](https://github.com/tari-project/tari/commit/e417e575beb23cd17a119984829ee7479d39c459))
+* print out warning if wallet grpc connections fails ([#5195](https://github.com/tari-project/tari/issues/5195)) ([4e1cb38](https://github.com/tari-project/tari/commit/4e1cb38aeec5cbb61e39920e3d1871699107c06f))
+
+
+### Bug Fixes
+
+* add missing consensus constants to get_constants grpc ([#5183](https://github.com/tari-project/tari/issues/5183)) ([9900d5d](https://github.com/tari-project/tari/commit/9900d5db3eacf463b479ad242391c9a2e0a38db8))
+
 ## [0.45.0](https://github.com/tari-project/tari/compare/v0.44.1...v0.45.0) (2023-02-14)
 
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.45.0"
+version = "0.46.0"
 edition = "2018"
 
 [features]
@@ -35,5 +35,5 @@ toml = { version = "0.5", optional = true }
 blake2 = "0.9.1"
 
 [dev-dependencies]
-tari_test_utils = { version = "^0.45", path = "../infrastructure/test_utils"}
+tari_test_utils = { version = "^0.46", path = "../infrastructure/test_utils"}
 toml = "0.5.8"

--- a/common_sqlite/Cargo.toml
+++ b/common_sqlite/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_common_sqlite"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency wallet library"
 license = "BSD-3-Clause"
-version = "0.45.0"
+version = "0.46.0"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/comms/core/Cargo.toml
+++ b/comms/core/Cargo.toml
@@ -6,14 +6,14 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.45.0"
+version = "0.46.0"
 edition = "2018"
 
 [dependencies]
 tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.16.6" }
 tari_metrics = { path = "../../infrastructure/metrics" }
-tari_storage = { version = "^0.45", path = "../../infrastructure/storage" }
-tari_shutdown = { version = "^0.45", path = "../../infrastructure/shutdown" }
+tari_storage = { version = "^0.46", path = "../../infrastructure/storage" }
+tari_shutdown = { version = "^0.46", path = "../../infrastructure/shutdown" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.10" }
 
 anyhow = "1.0.53"
@@ -50,7 +50,7 @@ yamux = "=0.10.2"
 zeroize = "1"
 
 [dev-dependencies]
-tari_test_utils = { version = "^0.45", path = "../../infrastructure/test_utils" }
+tari_test_utils = { version = "^0.46", path = "../../infrastructure/test_utils" }
 tari_comms_rpc_macros = { version = "*", path = "../rpc_macros" }
 
 env_logger = "0.7.0"
@@ -58,7 +58,7 @@ serde_json = "1.0.39"
 tempfile = "3.1.0"
 
 [build-dependencies]
-tari_common = { version = "^0.45", path = "../../common", features = ["build"] }
+tari_common = { version = "^0.46", path = "../../common", features = ["build"] }
 
 [features]
 c_integration = []

--- a/comms/dht/Cargo.toml
+++ b/comms/dht/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_comms_dht"
-version = "0.45.0"
+version = "0.46.0"
 authors = ["The Tari Development Community"]
 description = "Tari comms DHT module"
 repository = "https://github.com/tari-project/tari"
@@ -10,13 +10,13 @@ license = "BSD-3-Clause"
 edition = "2018"
 
 [dependencies]
-tari_comms = { version = "^0.45", path = "../core", features = ["rpc"] }
+tari_comms = { version = "^0.46", path = "../core", features = ["rpc"] }
 tari_common = { path = "../../common" }
-tari_comms_rpc_macros = { version = "^0.45", path = "../rpc_macros" }
+tari_comms_rpc_macros = { version = "^0.46", path = "../rpc_macros" }
 tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.16.6" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag="v0.4.10" }
-tari_shutdown = { version = "^0.45", path = "../../infrastructure/shutdown" }
-tari_storage = { version = "^0.45", path = "../../infrastructure/storage" }
+tari_shutdown = { version = "^0.46", path = "../../infrastructure/shutdown" }
+tari_storage = { version = "^0.46", path = "../../infrastructure/storage" }
 tari_common_sqlite = { path = "../../common_sqlite" }
 
 anyhow = "1.0.53"
@@ -48,7 +48,7 @@ tokio = { version = "1.23", features = ["rt", "macros"] }
 pin-project = "0.4"
 
 [dev-dependencies]
-tari_test_utils = { version = "^0.45", path = "../../infrastructure/test_utils" }
+tari_test_utils = { version = "^0.46", path = "../../infrastructure/test_utils" }
 
 env_logger = "0.7.0"
 futures-test = { version = "0.3.5" }
@@ -62,7 +62,7 @@ clap = "2.33.0"
 
 
 [build-dependencies]
-tari_common = { version = "^0.45", path = "../../common" }
+tari_common = { version = "^0.46", path = "../../common" }
 
 [features]
 test-mocks = []

--- a/comms/rpc_macros/Cargo.toml
+++ b/comms/rpc_macros/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.45.0"
+version = "0.46.0"
 edition = "2018"
 
 [lib]
@@ -19,8 +19,8 @@ quote = "1.0.7"
 syn = { version = "1.0.38", features = ["fold"] }
 
 [dev-dependencies]
-tari_comms = { version = "^0.45", path = "../core", features = ["rpc"] }
-tari_test_utils = { version = "^0.45", path = "../../infrastructure/test_utils" }
+tari_comms = { version = "^0.46", path = "../core", features = ["rpc"] }
+tari_test_utils = { version = "^0.46", path = "../../infrastructure/test_utils" }
 
 futures = "0.3.5"
 prost = "0.9.0"

--- a/infrastructure/derive/Cargo.toml
+++ b/infrastructure/derive/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.45.0"
+version = "0.46.0"
 edition = "2018"
 
 [lib]

--- a/infrastructure/libtor/Cargo.toml
+++ b/infrastructure/libtor/Cargo.toml
@@ -7,7 +7,7 @@ license = "BSD-3-Clause"
 [dependencies]
 tari_common = { path = "../../common" }
 tari_p2p = { path = "../../base_layer/p2p" }
-tari_shutdown = { version = "^0.45", path = "../shutdown"}
+tari_shutdown = { version = "^0.46", path = "../shutdown"}
 
 derivative = "2.2.0"
 log = "0.4.8"

--- a/infrastructure/shutdown/Cargo.toml
+++ b/infrastructure/shutdown/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.45.0"
+version = "0.46.0"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/infrastructure/storage/Cargo.toml
+++ b/infrastructure/storage/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.45.0"
+version = "0.46.0"
 edition = "2018"
 
 [dependencies]

--- a/infrastructure/test_utils/Cargo.toml
+++ b/infrastructure/test_utils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_test_utils"
 description = "Utility functions used in Tari test functions"
-version = "0.45.0"
+version = "0.46.0"
 authors = ["The Tari Development Community"]
 edition = "2018"
 license = "BSD-3-Clause"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tari",
-  "version": "0.45.0",
+  "version": "0.46.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {}


### PR DESCRIPTION
⚠ BREAKING CHANGES

* add key commitment to database main key AEAD  (5188)

Features

* add key commitment to database main key AEAD  ([5188](https://github.com/tari-project/tari/issues/5188)) ([95bc795](https://github.com/tari-project/tari/commit/95bc7956811020957d4cf0a8eef742124d44bcde))
* add more burn details to burn command ([5169](https://github.com/tari-project/tari/issues/5169)) ([e417e57](https://github.com/tari-project/tari/commit/e417e575beb23cd17a119984829ee7479d39c459))
* print out warning if wallet grpc connections fails ([5195](https://github.com/tari-project/tari/issues/5195)) ([4e1cb38](https://github.com/tari-project/tari/commit/4e1cb38aeec5cbb61e39920e3d1871699107c06f))


Bug Fixes

* add missing consensus constants to get_constants grpc ([5183](https://github.com/tari-project/tari/issues/5183)) ([9900d5d](https://github.com/tari-project/tari/commit/9900d5db3eacf463b479ad242391c9a2e0a38db8))

