### PR TITLE
fix: add grpc commitment signature proto type

### DIFF
--- a/applications/tari_app_grpc/proto/types.proto
+++ b/applications/tari_app_grpc/proto/types.proto
@@ -54,6 +54,14 @@ message ComAndPubSignature {
     bytes u_y = 5;
 }
 
+// Define the explicit CommitmentSignature implementation for the Tari base layer. A different signature scheme can be
+// employed by redefining this type
+message CommitmentSignature {
+    bytes public_nonce = 1;
+    bytes u = 2;
+    bytes v = 3;
+}
+
 /// PoW Algorithm constants
 message PowAlgorithmConstants {
     uint64 max_target_time = 1;

--- a/applications/tari_app_grpc/proto/wallet.proto
+++ b/applications/tari_app_grpc/proto/wallet.proto
@@ -139,7 +139,7 @@ message CreateBurnTransactionResponse{
     bool is_success = 2;
     string failure_message = 3;
     bytes commitment = 4;
-    bytes ownership_proof = 5;
+    CommitmentSignature ownership_proof = 5;
     bytes rangeproof = 6;
 }
 

--- a/applications/tari_app_grpc/src/conversions/commitment_signature.rs
+++ b/applications/tari_app_grpc/src/conversions/commitment_signature.rs
@@ -1,0 +1,52 @@
+// Copyright 2020. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::convert::TryFrom;
+
+use tari_common_types::types::{PrivateKey, PublicKey};
+use tari_crypto::{commitment::HomomorphicCommitment, signatures::CommitmentSignature};
+use tari_utilities::ByteArray;
+
+use crate::tari_rpc as grpc;
+
+impl TryFrom<grpc::CommitmentSignature> for CommitmentSignature<PublicKey, PrivateKey> {
+    type Error = String;
+
+    fn try_from(sig: grpc::CommitmentSignature) -> Result<Self, Self::Error> {
+        let public_nonce = HomomorphicCommitment::<PublicKey>::from_bytes(&sig.public_nonce)
+            .map_err(|_| "Could not get public nonce".to_string())?;
+        let u = PrivateKey::from_bytes(&sig.u).map_err(|_| "Could not get u_x".to_string())?;
+        let v = PrivateKey::from_bytes(&sig.v).map_err(|_| "Could not get v_x".to_string())?;
+
+        Ok(Self::new(public_nonce, u, v))
+    }
+}
+
+impl From<CommitmentSignature<PublicKey, PrivateKey>> for grpc::CommitmentSignature {
+    fn from(sig: CommitmentSignature<PublicKey, PrivateKey>) -> Self {
+        Self {
+            public_nonce: sig.public_nonce().to_vec(),
+            u: sig.u().to_vec(),
+            v: sig.v().to_vec(),
+        }
+    }
+}

--- a/applications/tari_app_grpc/src/conversions/mod.rs
+++ b/applications/tari_app_grpc/src/conversions/mod.rs
@@ -26,6 +26,7 @@ mod block;
 mod block_header;
 mod chain_metadata;
 mod com_and_pub_signature;
+mod commitment_signature;
 mod consensus_constants;
 mod historical_block;
 mod new_block_template;

--- a/applications/tari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/tari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -618,7 +618,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
                     is_success: true,
                     failure_message: Default::default(),
                     commitment: commitment.to_vec(),
-                    ownership_proof: ownership_proof.map(|o| CommitmentSignature::from(o)),
+                    ownership_proof: ownership_proof.map(CommitmentSignature::from),
                     rangeproof: rangeproof.to_vec(),
                 }
             },

--- a/applications/tari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/tari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -41,6 +41,7 @@ use tari_app_grpc::{
         ClaimShaAtomicSwapResponse,
         CoinSplitRequest,
         CoinSplitResponse,
+        CommitmentSignature,
         CreateBurnTransactionRequest,
         CreateBurnTransactionResponse,
         CreateTemplateRegistrationRequest,
@@ -617,7 +618,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
                     is_success: true,
                     failure_message: Default::default(),
                     commitment: commitment.to_vec(),
-                    ownership_proof: ownership_proof.map(|o| o.to_vec()).unwrap_or_default(),
+                    ownership_proof: ownership_proof.map(|o| CommitmentSignature::from(o)),
                     rangeproof: rangeproof.to_vec(),
                 }
             },


### PR DESCRIPTION
Description
---
To better handle the conversion between Tari's native `CommitmentSignature` and its proto counterpart.

Motivation and Context
---

How Has This Been Tested?
---


<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
