### PR TITLE
fix!: use consensus hashing API for validator node MMR

### DIFF
--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -38,7 +38,6 @@ use tari_common_types::{
     chain_metadata::ChainMetadata,
     types::{BlockHash, Commitment, FixedHash, HashOutput, PublicKey, Signature},
 };
-use tari_crypto::hash::blake2::Blake256;
 use tari_mmr::pruned_hashset::PrunedHashSet;
 use tari_utilities::{epoch_time::EpochTime, hex::Hex, ByteArray};
 
@@ -79,9 +78,17 @@ use crate::{
         TargetDifficulties,
     },
     common::rolling_vec::RollingVec,
-    consensus::{chain_strength_comparer::ChainStrengthComparer, ConsensusConstants, ConsensusManager},
+    consensus::{
+        chain_strength_comparer::ChainStrengthComparer,
+        ConsensusConstants,
+        ConsensusManager,
+        DomainSeparatedConsensusHasher,
+    },
     proof_of_work::{monero_rx::MoneroPowData, PowAlgorithm, TargetDifficultyWindow},
-    transactions::transaction_components::{TransactionInput, TransactionKernel},
+    transactions::{
+        transaction_components::{TransactionInput, TransactionKernel},
+        TransactionHashDomain,
+    },
     validation::{
         helpers::calc_median_timestamp,
         CandidateBlockValidator,
@@ -1381,10 +1388,9 @@ pub fn calculate_mmr_roots<T: BlockchainBackend>(
 
 pub fn calculate_validator_node_mr(validator_nodes: &[(PublicKey, [u8; 32])]) -> tari_mmr::Hash {
     fn hash_node((pk, s): &(PublicKey, [u8; 32])) -> Vec<u8> {
-        use digest::Digest;
-        Blake256::new()
-            .chain(pk.as_bytes())
-            .chain(s.as_slice())
+        DomainSeparatedConsensusHasher::<TransactionHashDomain>::new("validator_node")
+            .chain(pk)
+            .chain(s)
             .finalize()
             .to_vec()
     }

--- a/base_layer/core/src/chain_storage/tests/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/tests/blockchain_database.rs
@@ -574,16 +574,14 @@ mod clear_all_pending_headers {
 }
 
 mod validator_node_merkle_root {
-    use digest::Digest;
     use rand::rngs::OsRng;
     use tari_common_types::types::PublicKey;
-    use tari_crypto::{hash::blake2::Blake256, keys::PublicKey as PublicKeyTrait};
-    use tari_utilities::ByteArray;
+    use tari_crypto::keys::PublicKey as PublicKeyTrait;
 
     use super::*;
     use crate::{
+        chain_storage::calculate_validator_node_mr,
         transactions::transaction_components::{OutputFeatures, ValidatorNodeSignature},
-        ValidatorNodeBMT,
         ValidatorNodeMmr,
     };
 
@@ -619,13 +617,9 @@ mod validator_node_merkle_root {
             .unwrap()
             .unwrap();
 
-        let vn_bmt = ValidatorNodeBMT::create(vec![Blake256::new()
-            .chain(public_key.as_bytes())
-            .chain(shard_key.as_slice())
-            .finalize()
-            .to_vec()]);
+        let merkle_root = calculate_validator_node_mr(&[(public_key, shard_key)]);
 
         let tip = db.fetch_tip_header().unwrap();
-        assert_eq!(tip.header().validator_node_mr, vn_bmt.get_merkle_root());
+        assert_eq!(tip.header().validator_node_mr, merkle_root);
     }
 }


### PR DESCRIPTION
Description
---
Uses the consensus hashing API to construct the hasher used to pre-hash validator node data for Merkle roots. Updates a test.

Closes [issue 5205](https://github.com/tari-project/tari/issues/5205).

Motivation and Context
---
The hasher currently used to pre-hash validator node keys and shard identifiers does not use domain separation or the consensus hashing API. This PR updates the hasher construction using the API.

How Has This Been Tested?
---
Existing tests pass.

BREAKING CHANGE: Renders existing validator node Merkle roots invalid.