### PR TITLE
docs: add second-preimage warning to MMR documentation

### DIFF
--- a/base_layer/mmr/src/merkle_mountain_range.rs
+++ b/base_layer/mmr/src/merkle_mountain_range.rs
@@ -51,6 +51,10 @@ use crate::{
 /// An implementation of a Merkle Mountain Range (MMR). The MMR is append-only and immutable. Only the hashes are
 /// stored in this data structure. The data itself can be stored anywhere as long as you can maintain a 1:1 mapping
 /// of the hash of that data to the leaf nodes in the MMR.
+///
+/// Because this implementation relies on the caller to hash leaf nodes, it is possible to instantiate an MMR that is
+/// susceptible to second-preimage attacks. The caller _must_ ensure that the hashers used to pre-hash leaf nodes and
+/// instantiate the MMR cannot produce collisions.
 #[derive(Debug)]
 pub struct MerkleMountainRange<D, B> {
     pub(crate) hashes: B,


### PR DESCRIPTION
Description
---
Updates documentation for the Merkle mountain range implementation to add a warning about second-preimage resistance.

Motivation and Context
---
The Merkle mountain range implementation can be instantiated in a way that makes it [susceptible](https://github.com/tari-project/tari/issues/5206) to second-preimage attacks, such that a given root does not computationally bind to a set of leaf nodes.

The linked issue discusses possible mitigations, with varying degrees of complexity. This PR implements the simplest approach, which is to warn the user that the caller is responsible for arranging its leaf node and MMR hashers to mitigate this attack risk.

It may still be desirable to implement one of the other mitigations discussed in the linked issue.

How Has This Been Tested?
---
No testing is needed.