### PR TITLE
fix: source coverage ci failure

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -45,7 +45,7 @@ jobs:
           LLVM_PROFILE_FILE: "coverage_data-%p-%m.profraw"
         with:
           command: test
-          args: --all-features --no-fail-fast
+          args: --all-features --no-fail-fast --exclude tari_integration_tests
 
       - name: prepare coverage data
         env:


### PR DESCRIPTION
Description
---
Don't run cucumber during the coverage runner. It always returns a non 0 exit code when additional cucumber params aren't passed making CI think it's a failure.

Motivation and Context
---
After PR's get merged the coverage ci fails: https://github.com/tari-project/tari/actions/runs/4281676173/jobs/7454994490

How Has This Been Tested?
---
#yolo 🤞🏻