### PR TITLE
docs: add second-preimage warning to BBMT documentation

### DIFF
--- a/base_layer/mmr/src/balanced_binary_merkle_tree.rs
+++ b/base_layer/mmr/src/balanced_binary_merkle_tree.rs
@@ -36,6 +36,10 @@ pub enum BalancedBinaryMerkleTreeError {
 
 // The hashes are perfectly balanced binary tree, so parent at index `i` (0-based) has children at positions `2*i+1` and
 // `2*i+1`.
+//
+// Because this implementation relies on the caller to hash leaf nodes, it is possible to instantiate a tree that is
+/// susceptible to second-preimage attacks. The caller _must_ ensure that the hashers used to pre-hash leaf nodes and
+/// instantiate the tree cannot produce collisions.
 #[derive(Debug)]
 pub struct BalancedBinaryMerkleTree<D> {
     hashes: Vec<Hash>,


### PR DESCRIPTION
Description
---
Updates documentation for the balanced binary Merkle tree implementation to add a warning about second-preimage resistance.

Motivation and Context
---
Similarly to [Merkle mountain ranges](https://github.com/tari-project/tari/pull/5208), the implementation for balanced binary Merkle trees can be instantiated to be [susceptible](https://github.com/tari-project/tari/issues/5206) to second-preimage attacks.

This PR updates the documentation to warn of this risk.

How Has This Been Tested?
---
No tests needed.