### PR TITLE
chore: remove dead VN MMR code

### DIFF
--- a/base_layer/core/src/base_node/sync/header_sync/error.rs
+++ b/base_layer/core/src/base_node/sync/header_sync/error.rs
@@ -87,12 +87,4 @@ pub enum BlockHeaderSyncError {
     },
     #[error("All sync peers exceeded max allowed latency")]
     AllSyncPeersExceedLatency,
-    #[error(
-        "Validator node MMR at height {height} is not correct. Expected {actual} to equal the computed {computed}"
-    )]
-    ValidatorNodeMmr {
-        height: u64,
-        actual: String,
-        computed: String,
-    },
 }

--- a/base_layer/core/src/chain_storage/tests/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/tests/blockchain_database.rs
@@ -582,15 +582,15 @@ mod validator_node_merkle_root {
     use crate::{
         chain_storage::calculate_validator_node_mr,
         transactions::transaction_components::{OutputFeatures, ValidatorNodeSignature},
-        ValidatorNodeMmr,
+        ValidatorNodeBMT,
     };
 
     #[test]
     fn it_has_the_correct_genesis_merkle_root() {
-        let vn_mmr = ValidatorNodeMmr::new(Vec::new());
+        let vn_mmr = ValidatorNodeBMT::create(Vec::new());
         let db = setup();
         let (blocks, _outputs) = add_many_chained_blocks(1, &db);
-        assert_eq!(blocks[0].header.validator_node_mr, vn_mmr.get_merkle_root().unwrap());
+        assert_eq!(blocks[0].header.validator_node_mr, vn_mmr.get_merkle_root());
     }
 
     #[test]

--- a/base_layer/core/src/lib.rs
+++ b/base_layer/core/src/lib.rs
@@ -112,13 +112,12 @@ mod domain_hashing {
     pub type PrunedInputMmr = MerkleMountainRange<InputMmrHasherBlake256, PrunedHashSet>;
 
     hash_domain!(
-        ValidatorNodeMmrHashDomain,
+        ValidatorNodeBmtHashDomain,
         "com.tari.tari_project.base_layer.core.validator_node_mmr",
         1
     );
-    pub type ValidatorNodeMmrHasherBlake256 = DomainSeparatedHasher<Blake256, ValidatorNodeMmrHashDomain>;
-    pub type ValidatorNodeMmr = MerkleMountainRange<ValidatorNodeMmrHasherBlake256, Vec<Hash>>;
-    pub type ValidatorNodeBMT = BalancedBinaryMerkleTree<ValidatorNodeMmrHasherBlake256>;
+    pub type ValidatorNodeBmtHasherBlake256 = DomainSeparatedHasher<Blake256, ValidatorNodeBmtHashDomain>;
+    pub type ValidatorNodeBMT = BalancedBinaryMerkleTree<ValidatorNodeBmtHasherBlake256>;
 }
 
 #[cfg(feature = "base_node")]


### PR DESCRIPTION
Description
---
Removes dead validator node Merkle mountain range (MMR) code left over from [another PR](https://github.com/tari-project/tari/pull/5189) and renames a few things for clarity.

Motivation and Context
---
An earlier PR moves validator node data from an MMR to a balanced binary Merkle tree, but leaves some old MMR code around. This PR removes that code and does some minor renaming for clarity.

How Has This Been Tested?
---
Existing tests pass. It should be separately confirmed that none of the removed or renamed functionality needs to be externally available.