### PR TITLE
test: fix broken tests

### DIFF
--- a/comms/dht/src/crypt.rs
+++ b/comms/dht/src/crypt.rs
@@ -361,7 +361,7 @@ mod test {
 
         // manipulate tag and check that decryption fails
         let n = encrypted.len();
-        encrypted[n - 1] += 1;
+        encrypted[n - 1] = !encrypted[n - 1];
 
         // decryption should fail
         assert!(decrypt_signature(&key, encrypted.as_slice())
@@ -381,7 +381,7 @@ mod test {
         let mut encrypted = encrypt_signature(&key, signature).unwrap();
 
         // manipulate encrypted message body and check that decryption fails
-        encrypted[0] += 1;
+        encrypted[0] = !encrypted[0];
 
         // decryption should fail
         assert!(decrypt_signature(&key, encrypted.as_slice())
@@ -593,7 +593,8 @@ mod test {
         let mut msg = encode_with_prepended_length(&message, size_of::<Nonce>());
         encrypt_message(&key, &mut msg).unwrap();
 
-        msg[size_of::<u32>() + size_of::<Nonce>() + 1] += 1;
+        let index = size_of::<u32>() + size_of::<Nonce>() + 1;
+        msg[index] = !msg[index];
 
         decrypt_message(&key, &mut msg).unwrap();
         eprintln!("msg = {:?}", msg);


### PR DESCRIPTION
Description
---
Fixes broken tests.

Motivation and Context
---
Several tests were susceptible to overflow due to `u8` addition and could fail sporadically. This PR fixes them by replacing the addition with bitwise `NOT` operations.

How Has This Been Tested?
---
[Who tests the testers?](https://en.wikipedia.org/wiki/Quis_custodiet_ipsos_custodes%3F)