### PR TITLE
fix: remove panics from merged BBMT verification

### DIFF
--- a/base_layer/mmr/src/balanced_binary_merkle_tree.rs
+++ b/base_layer/mmr/src/balanced_binary_merkle_tree.rs
@@ -58,7 +58,7 @@ where D: Digest + DomainDigest
                 _phantom: PhantomData,
             };
         }
-        // The size of the tree of `n` leaves is `2*n+1` where the leaves are at the end of the array.
+        // The size of the tree of `n` leaves is `2*n - 1` where the leaves are at the end of the array.
         let mut hashes = Vec::with_capacity(2 * leaves_cnt - 1);
         hashes.extend(vec![vec![0; 32]; leaves_cnt - 1]);
         hashes.extend(leaves);


### PR DESCRIPTION
Description
---
Removes panics from [merged balanced binary Merkle tree](https://github.com/tari-project/tari/pull/5193) proofs. Changes proof format to avoid a hash output size assumption. Minor renaming and typo fixes for clarity.

Closes [issue 5220](https://github.com/tari-project/tari/issues/5220).

Motivation and Context
---
Recent work implements merged balanced binary Merkle tree proofs. However, the verifier depended on a specific hash output length (32 bytes) to differentiate node hashes from proof indexes. This would lead to a panic if this size restriction was not met; it was not enforced because of how hashers are used in the design.

Separately, proof semantics were not checked by the verifier, which could lead to other panics.

This PR addresses both of these points. Instead of relying on hash output size, merged path data now includes a flag to indicate if each step references a proof index or a node hash. The verifier now returns a `Result`, producing an error if the proof semantics are incorrect. If they are correct, its return value can be unwrapped as a `bool` to assert the verification passes. It also fixes a few typos and does some minor renaming for clarity.

Note that the design still retains an original assumption of a universal `usize` that may be problematic. Non-merged proofs contain a `usize` index to the node in question, and merged proofs additionally contain `usize` vectors to indicate path lengths and proof indexes. This may lead to unexpected and inconsistent behavior, and should be carefully examined separately.

How Has This Been Tested?
---
Existing unit tests pass.
