### PR TITLE
fix(comms): dial if connection is not connected

### DIFF
--- a/comms/core/src/connectivity/manager.rs
+++ b/comms/core/src/connectivity/manager.rs
@@ -322,14 +322,24 @@ impl ConnectivityManagerActor {
                 }
             },
             maybe_state => {
-                info!(
-                    target: LOG_TARGET,
-                    "Connection is not connected (status={}) `{}`. Dialing...",
-                    maybe_state
-                        .map(|s| s.status().to_string())
-                        .unwrap_or_else(|| "NotConnected".to_string()),
-                    node_id.short_str()
-                );
+                match maybe_state {
+                    Some(state) => {
+                        info!(
+                            target: LOG_TARGET,
+                            "Connection was previously attempted for peer {}. Current status is '{}'. Dialing again...",
+                            node_id.short_str(),
+                            state.status()
+                        );
+                    },
+                    None => {
+                        info!(
+                            target: LOG_TARGET,
+                            "No connection for peer {}. Dialing...",
+                            node_id.short_str(),
+                        );
+                    },
+                }
+
                 if let Err(err) = self.connection_manager.send_dial_peer(node_id, reply_tx).await {
                     error!(
                         target: LOG_TARGET,

--- a/comms/core/src/connectivity/manager.rs
+++ b/comms/core/src/connectivity/manager.rs
@@ -315,6 +315,7 @@ impl ConnectivityManagerActor {
             },
         }
         match self.pool.get(&node_id) {
+            // The connection pool may temporarily contain a connection that is not connected so we need to check this.
             Some(state) if state.is_connected() => {
                 if let Some(reply_tx) = reply_tx {
                     let _result = reply_tx.send(Ok(state.connection().cloned().expect("Already checked")));
@@ -323,7 +324,7 @@ impl ConnectivityManagerActor {
             maybe_state => {
                 info!(
                     target: LOG_TARGET,
-                    "No connection found for peer (status={}) `{}`. Dialing...",
+                    "Connection is not connected (status={}) `{}`. Dialing...",
                     maybe_state
                         .map(|s| s.status().to_string())
                         .unwrap_or_else(|| "NotConnected".to_string()),


### PR DESCRIPTION
Description
---
Fix bug where recently disconnected connections do not get redialled

Motivation and Context
---
The connectivity manager pool maintains a list of connections including recently disconnected. These are cleared out periodically. The connectivity manager should not return disconnected connections to the caller.

How Has This Been Tested?
---
Manually: Connection is dialled when pool says the connection is not connected.

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
