### PR TITLE
fix(wallet): avoids empty addresses in node identity

### DIFF
--- a/applications/tari_console_wallet/src/init/mod.rs
+++ b/applications/tari_console_wallet/src/init/mod.rs
@@ -315,10 +315,10 @@ pub async fn init_wallet(
     debug!(target: LOG_TARGET, "Databases Initialized. Wallet is encrypted.",);
 
     let node_addresses = if config.wallet.p2p.public_addresses.is_empty() {
-        vec![match wallet_db.get_node_address()? {
-            Some(addr) => addr,
-            None => Multiaddr::empty(),
-        }]
+        match wallet_db.get_node_address()? {
+            Some(addr) => vec![addr],
+            None => vec![],
+        }
     } else {
         config.wallet.p2p.public_addresses.clone()
     };


### PR DESCRIPTION
Description
---

Returns an empty set of addresses if the wallet address has never been set. 

Motivation and Context
---
Previously a Multiaddr::empty would be persisted in the wallet db as the first entry. This PR changes this so that when comms assigns an onion address later (if configured to do so) that address will be the first entry.

Wallet connections would fail on the base node with this error:
`Peer connection upgrade failed for peer because 'InvalidMultiaddr("Multiaddr was empty")'`

The function `NodeIdentity::first_public_address` will panic with no addresses, but does not seem to be causing an issue so any further fixes are left to another PR

If this error is encountered, you'll need to remove the empty address from the node identity/db (probably just delete your wallet db).

How Has This Been Tested?
---
Manually: fresh wallet connects to base node

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
