### PR TITLE
chore(release): v0.48.0-pre.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5155,7 +5155,7 @@ dependencies = [
 
 [[package]]
 name = "tari_app_grpc"
-version = "0.47.0-pre.0"
+version = "0.48.0-pre.0"
 dependencies = [
  "argon2",
  "base64 0.13.1",
@@ -5179,7 +5179,7 @@ dependencies = [
 
 [[package]]
 name = "tari_app_utilities"
-version = "0.47.0-pre.0"
+version = "0.48.0-pre.0"
 dependencies = [
  "clap 3.2.23",
  "futures 0.3.26",
@@ -5197,7 +5197,7 @@ dependencies = [
 
 [[package]]
 name = "tari_base_node"
-version = "0.47.0-pre.0"
+version = "0.48.0-pre.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5290,7 +5290,7 @@ dependencies = [
 
 [[package]]
 name = "tari_common"
-version = "0.47.0-pre.0"
+version = "0.48.0-pre.0"
 dependencies = [
  "anyhow",
  "blake2 0.9.2",
@@ -5316,7 +5316,7 @@ dependencies = [
 
 [[package]]
 name = "tari_common_sqlite"
-version = "0.47.0-pre.0"
+version = "0.48.0-pre.0"
 dependencies = [
  "diesel",
  "log",
@@ -5325,7 +5325,7 @@ dependencies = [
 
 [[package]]
 name = "tari_common_types"
-version = "0.47.0-pre.0"
+version = "0.48.0-pre.0"
 dependencies = [
  "borsh",
  "digest 0.9.0",
@@ -5342,7 +5342,7 @@ dependencies = [
 
 [[package]]
 name = "tari_comms"
-version = "0.47.0-pre.0"
+version = "0.48.0-pre.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5391,7 +5391,7 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_dht"
-version = "0.47.0-pre.0"
+version = "0.48.0-pre.0"
 dependencies = [
  "anyhow",
  "bitflags 1.3.2",
@@ -5435,7 +5435,7 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_rpc_macros"
-version = "0.47.0-pre.0"
+version = "0.48.0-pre.0"
 dependencies = [
  "futures 0.3.26",
  "proc-macro2",
@@ -5450,7 +5450,7 @@ dependencies = [
 
 [[package]]
 name = "tari_console_wallet"
-version = "0.47.0-pre.0"
+version = "0.48.0-pre.0"
 dependencies = [
  "bitflags 1.3.2",
  "chrono",
@@ -5497,7 +5497,7 @@ dependencies = [
 
 [[package]]
 name = "tari_core"
-version = "0.47.0-pre.0"
+version = "0.48.0-pre.0"
 dependencies = [
  "bincode",
  "bitflags 1.3.2",
@@ -5635,7 +5635,7 @@ dependencies = [
 
 [[package]]
 name = "tari_key_manager"
-version = "0.47.0-pre.0"
+version = "0.48.0-pre.0"
 dependencies = [
  "argon2",
  "blake2 0.9.2",
@@ -5678,7 +5678,7 @@ dependencies = [
 
 [[package]]
 name = "tari_merge_mining_proxy"
-version = "0.47.0-pre.0"
+version = "0.48.0-pre.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -5727,7 +5727,7 @@ dependencies = [
 
 [[package]]
 name = "tari_miner"
-version = "0.47.0-pre.0"
+version = "0.48.0-pre.0"
 dependencies = [
  "base64 0.13.1",
  "borsh",
@@ -5762,7 +5762,7 @@ dependencies = [
 
 [[package]]
 name = "tari_mining_helper_ffi"
-version = "0.47.0-pre.0"
+version = "0.48.0-pre.0"
 dependencies = [
  "borsh",
  "hex",
@@ -5778,7 +5778,7 @@ dependencies = [
 
 [[package]]
 name = "tari_mmr"
-version = "0.47.0-pre.0"
+version = "0.48.0-pre.0"
 dependencies = [
  "bincode",
  "blake2 0.9.2",
@@ -5797,7 +5797,7 @@ dependencies = [
 
 [[package]]
 name = "tari_p2p"
-version = "0.47.0-pre.0"
+version = "0.48.0-pre.0"
 dependencies = [
  "anyhow",
  "clap 2.34.0",
@@ -5851,7 +5851,7 @@ dependencies = [
 
 [[package]]
 name = "tari_service_framework"
-version = "0.47.0-pre.0"
+version = "0.48.0-pre.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5868,7 +5868,7 @@ dependencies = [
 
 [[package]]
 name = "tari_shutdown"
-version = "0.47.0-pre.0"
+version = "0.48.0-pre.0"
 dependencies = [
  "futures 0.3.26",
  "tokio",
@@ -5876,7 +5876,7 @@ dependencies = [
 
 [[package]]
 name = "tari_storage"
-version = "0.47.0-pre.0"
+version = "0.48.0-pre.0"
 dependencies = [
  "bincode",
  "lmdb-zero",
@@ -5889,7 +5889,7 @@ dependencies = [
 
 [[package]]
 name = "tari_test_utils"
-version = "0.47.0-pre.0"
+version = "0.48.0-pre.0"
 dependencies = [
  "futures 0.3.26",
  "futures-test",
@@ -5919,7 +5919,7 @@ dependencies = [
 
 [[package]]
 name = "tari_wallet"
-version = "0.47.0-pre.0"
+version = "0.48.0-pre.0"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5968,7 +5968,7 @@ dependencies = [
 
 [[package]]
 name = "tari_wallet_ffi"
-version = "0.47.0-pre.0"
+version = "0.48.0-pre.0"
 dependencies = [
  "borsh",
  "cbindgen 0.24.3",

--- a/applications/tari_app_grpc/Cargo.toml
+++ b/applications/tari_app_grpc/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "This crate is to provide a single source for all cross application grpc files and conversions to and from tari::core"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.47.0-pre.0"
+version = "0.48.0-pre.0"
 edition = "2018"
 
 [dependencies]

--- a/applications/tari_app_utilities/Cargo.toml
+++ b/applications/tari_app_utilities/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_app_utilities"
-version = "0.47.0-pre.0"
+version = "0.48.0-pre.0"
 authors = ["The Tari Development Community"]
 edition = "2018"
 license = "BSD-3-Clause"

--- a/applications/tari_base_node/Cargo.toml
+++ b/applications/tari_base_node/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "The tari full base node implementation"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.47.0-pre.0"
+version = "0.48.0-pre.0"
 edition = "2018"
 
 [dependencies]

--- a/applications/tari_console_wallet/Cargo.toml
+++ b/applications/tari_console_wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_console_wallet"
-version = "0.47.0-pre.0"
+version = "0.48.0-pre.0"
 authors = ["The Tari Development Community"]
 edition = "2018"
 license = "BSD-3-Clause"

--- a/applications/tari_merge_mining_proxy/Cargo.toml
+++ b/applications/tari_merge_mining_proxy/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "The Tari merge mining proxy for xmrig"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.47.0-pre.0"
+version = "0.48.0-pre.0"
 edition = "2018"
 
 [features]

--- a/applications/tari_miner/Cargo.toml
+++ b/applications/tari_miner/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "The tari miner implementation"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.47.0-pre.0"
+version = "0.48.0-pre.0"
 edition = "2018"
 
 [dependencies]

--- a/base_layer/common_types/Cargo.toml
+++ b/base_layer/common_types/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_common_types"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency common types"
 license = "BSD-3-Clause"
-version = "0.47.0-pre.0"
+version = "0.48.0-pre.0"
 edition = "2018"
 
 [dependencies]

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.47.0-pre.0"
+version = "0.48.0-pre.0"
 edition = "2018"
 
 [features]

--- a/base_layer/key_manager/Cargo.toml
+++ b/base_layer/key_manager/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency wallet key management"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.47.0-pre.0"
+version = "0.48.0-pre.0"
 edition = "2021"
 
 [lib]

--- a/base_layer/mmr/Cargo.toml
+++ b/base_layer/mmr/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "A Merkle Mountain Range implementation"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.47.0-pre.0"
+version = "0.48.0-pre.0"
 edition = "2018"
 
 [features]

--- a/base_layer/p2p/Cargo.toml
+++ b/base_layer/p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_p2p"
-version = "0.47.0-pre.0"
+version = "0.48.0-pre.0"
 authors = ["The Tari Development community"]
 description = "Tari base layer-specific peer-to-peer communication features"
 repository = "https://github.com/tari-project/tari"

--- a/base_layer/service_framework/Cargo.toml
+++ b/base_layer/service_framework/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_service_framework"
-version = "0.47.0-pre.0"
+version = "0.48.0-pre.0"
 authors = ["The Tari Development Community"]
 description = "The Tari communication stack service framework"
 repository = "https://github.com/tari-project/tari"

--- a/base_layer/tari_mining_helper_ffi/Cargo.toml
+++ b/base_layer/tari_mining_helper_ffi/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_mining_helper_ffi"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency miningcore C FFI bindings"
 license = "BSD-3-Clause"
-version = "0.47.0-pre.0"
+version = "0.48.0-pre.0"
 edition = "2018"
 
 [dependencies]

--- a/base_layer/wallet/Cargo.toml
+++ b/base_layer/wallet/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_wallet"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency wallet library"
 license = "BSD-3-Clause"
-version = "0.47.0-pre.0"
+version = "0.48.0-pre.0"
 edition = "2018"
 
 [dependencies]

--- a/base_layer/wallet_ffi/Cargo.toml
+++ b/base_layer/wallet_ffi/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_wallet_ffi"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency wallet C FFI bindings"
 license = "BSD-3-Clause"
-version = "0.47.0-pre.0"
+version = "0.48.0-pre.0"
 edition = "2018"
 
 [dependencies]

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,35 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [0.48.0-pre.0](https://github.com/tari-project/tari/compare/v0.47.0-pre.0...v0.48.0-pre.0) (2023-03-07)
+
+
+### ⚠ BREAKING CHANGES
+
+* **peer_db:** more accurate peer stats per address (#5142)
+* use consensus hashing API for validator node MMR (#5207)
+* **consensus:** add balanced binary merkle tree (#5189)
+
+### Features
+
+* add favourite flag to contact ([#5217](https://github.com/tari-project/tari/issues/5217)) ([0371b60](https://github.com/tari-project/tari/commit/0371b608dd7a59664e7c8e1494335709ad21943c))
+* add indexer config ([#5210](https://github.com/tari-project/tari/issues/5210)) ([cf95601](https://github.com/tari-project/tari/commit/cf9560192de56ce1be22468b4551c5a60e5d9440))
+* add merge proof for balanced binary merkle tree ([#5193](https://github.com/tari-project/tari/issues/5193)) ([8962909](https://github.com/tari-project/tari/commit/8962909127ded86249099bfdd384ac4e8b0db0ee))
+* **consensus:** add balanced binary merkle tree ([#5189](https://github.com/tari-project/tari/issues/5189)) ([8d34e8a](https://github.com/tari-project/tari/commit/8d34e8a8eee2ed88ad0ab866a185d10a43300ec1))
+* log to base dir ([#5197](https://github.com/tari-project/tari/issues/5197)) ([5147b5c](https://github.com/tari-project/tari/commit/5147b5c81082396dc80605e5a9422eec8b06c1b1))
+* **peer_db:** more accurate peer stats per address ([#5142](https://github.com/tari-project/tari/issues/5142)) ([fdad1c6](https://github.com/tari-project/tari/commit/fdad1c6bf7914bbdc0ffc25ef729506196881c35))
+
+
+### Bug Fixes
+
+* add grpc commitment signature proto type ([#5200](https://github.com/tari-project/tari/issues/5200)) ([d523f1e](https://github.com/tari-project/tari/commit/d523f1e556d0f56c784923600fe48f93e2239520))
+* peer seeds for esme/igor ([#5202](https://github.com/tari-project/tari/issues/5202)) ([1bc226c](https://github.com/tari-project/tari/commit/1bc226c85c0810c9ad01dfb6539d8b614cc71fb8))
+* remove panics from merged BBMT verification ([#5221](https://github.com/tari-project/tari/issues/5221)) ([a4c5fce](https://github.com/tari-project/tari/commit/a4c5fce5e43153db090465f3623989ed07dfd627))
+* source coverage ci failure ([#5209](https://github.com/tari-project/tari/issues/5209)) ([80294a1](https://github.com/tari-project/tari/commit/80294a1a931d248413166966eebb1e297249e506))
+* use consensus hashing API for validator node MMR ([#5207](https://github.com/tari-project/tari/issues/5207)) ([de28115](https://github.com/tari-project/tari/commit/de281154ac339cd0e8b0eac59bcf933851dcc5c6))
+* wallet reuse existing tor address ([#5092](https://github.com/tari-project/tari/issues/5092)) ([576f44e](https://github.com/tari-project/tari/commit/576f44e48d781e3a61be138549484c4b4a79773e))
+* **wallet:** avoids empty addresses in node identity ([#5224](https://github.com/tari-project/tari/issues/5224)) ([1a66312](https://github.com/tari-project/tari/commit/1a66312d13dff7fd627930be88cfebffc4b08074))
+
 ## [0.47.0-pre.0](https://github.com/tari-project/tari/compare/v0.46.0...v0.47.0-pre.0) (2023-02-27)
 
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.47.0-pre.0"
+version = "0.48.0-pre.0"
 edition = "2018"
 
 [features]

--- a/common_sqlite/Cargo.toml
+++ b/common_sqlite/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_common_sqlite"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency wallet library"
 license = "BSD-3-Clause"
-version = "0.47.0-pre.0"
+version = "0.48.0-pre.0"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/comms/core/Cargo.toml
+++ b/comms/core/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.47.0-pre.0"
+version = "0.48.0-pre.0"
 edition = "2018"
 
 [dependencies]

--- a/comms/dht/Cargo.toml
+++ b/comms/dht/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_comms_dht"
-version = "0.47.0-pre.0"
+version = "0.48.0-pre.0"
 authors = ["The Tari Development Community"]
 description = "Tari comms DHT module"
 repository = "https://github.com/tari-project/tari"

--- a/comms/rpc_macros/Cargo.toml
+++ b/comms/rpc_macros/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.47.0-pre.0"
+version = "0.48.0-pre.0"
 edition = "2018"
 
 [lib]

--- a/infrastructure/derive/Cargo.toml
+++ b/infrastructure/derive/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.47.0-pre.0"
+version = "0.48.0-pre.0"
 edition = "2018"
 
 [lib]

--- a/infrastructure/shutdown/Cargo.toml
+++ b/infrastructure/shutdown/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.47.0-pre.0"
+version = "0.48.0-pre.0"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/infrastructure/storage/Cargo.toml
+++ b/infrastructure/storage/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.47.0-pre.0"
+version = "0.48.0-pre.0"
 edition = "2018"
 
 [dependencies]

--- a/infrastructure/test_utils/Cargo.toml
+++ b/infrastructure/test_utils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_test_utils"
 description = "Utility functions used in Tari test functions"
-version = "0.47.0-pre.0"
+version = "0.48.0-pre.0"
 authors = ["The Tari Development Community"]
 edition = "2018"
 license = "BSD-3-Clause"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tari",
-  "version": "0.47.0-pre.0",
+  "version": "0.48.0-pre.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {}


### PR DESCRIPTION
### ⚠ BREAKING CHANGES

* **peer_db:** more accurate peer stats per address (5142)
* use consensus hashing API for validator node MMR (5207)
* **consensus:** add balanced binary merkle tree (5189)

### Features

* add favourite flag to contact ([5217](https://github.com/tari-project/tari/issues/5217)) ([0371b60](https://github.com/tari-project/tari/commit/0371b608dd7a59664e7c8e1494335709ad21943c))
* add indexer config ([5210](https://github.com/tari-project/tari/issues/5210)) ([cf95601](https://github.com/tari-project/tari/commit/cf9560192de56ce1be22468b4551c5a60e5d9440))
* add merge proof for balanced binary merkle tree ([5193](https://github.com/tari-project/tari/issues/5193)) ([8962909](https://github.com/tari-project/tari/commit/8962909127ded86249099bfdd384ac4e8b0db0ee))
* **consensus:** add balanced binary merkle tree ([5189](https://github.com/tari-project/tari/issues/5189)) ([8d34e8a](https://github.com/tari-project/tari/commit/8d34e8a8eee2ed88ad0ab866a185d10a43300ec1))
* log to base dir ([#5197](https://github.com/tari-project/tari/issues/5197)) ([5147b5c](https://github.com/tari-project/tari/commit/5147b5c81082396dc80605e5a9422eec8b06c1b1))
* **peer_db:** more accurate peer stats per address ([5142](https://github.com/tari-project/tari/issues/5142)) ([fdad1c6](https://github.com/tari-project/tari/commit/fdad1c6bf7914bbdc0ffc25ef729506196881c35))


### Bug Fixes

* add grpc commitment signature proto type ([5200](https://github.com/tari-project/tari/issues/5200)) ([d523f1e](https://github.com/tari-project/tari/commit/d523f1e556d0f56c784923600fe48f93e2239520))
* peer seeds for esme/igor ([5202](https://github.com/tari-project/tari/issues/5202)) ([1bc226c](https://github.com/tari-project/tari/commit/1bc226c85c0810c9ad01dfb6539d8b614cc71fb8))
* remove panics from merged BBMT verification ([5221](https://github.com/tari-project/tari/issues/5221)) ([a4c5fce](https://github.com/tari-project/tari/commit/a4c5fce5e43153db090465f3623989ed07dfd627))
* source coverage ci failure ([5209](https://github.com/tari-project/tari/issues/5209)) ([80294a1](https://github.com/tari-project/tari/commit/80294a1a931d248413166966eebb1e297249e506))
* use consensus hashing API for validator node MMR ([5207](https://github.com/tari-project/tari/issues/5207)) ([de28115](https://github.com/tari-project/tari/commit/de281154ac339cd0e8b0eac59bcf933851dcc5c6))
* wallet reuse existing tor address ([5092](https://github.com/tari-project/tari/issues/5092)) ([576f44e](https://github.com/tari-project/tari/commit/576f44e48d781e3a61be138549484c4b4a79773e))
* **wallet:** avoids empty addresses in node identity ([5224](https://github.com/tari-project/tari/issues/5224)) ([1a66312](https://github.com/tari-project/tari/commit/1a66312d13dff7fd627930be88cfebffc4b08074))