### PR TITLE
fix: fix compile error caused by decimal-rs 0.1.42

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1626,14 +1626,12 @@ checksum = "23d8666cb01533c39dde32bcbab8e227b4ed6679b2c925eba05feabea39508fb"
 
 [[package]]
 name = "decimal-rs"
-version = "0.1.41"
+version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90a2f41762c36b9a3a4ce1e1ee404201d779fd7d9280117acc1a43105bdfc1d"
+checksum = "af600a28ba8f319291ba644d5a6de01970230716284c25245118a05357019e00"
 dependencies = [
- "ethnum",
  "fast-float",
  "stack-buf",
- "thiserror",
 ]
 
 [[package]]
@@ -1959,12 +1957,6 @@ dependencies = [
  "libc",
  "str-buf",
 ]
-
-[[package]]
-name = "ethnum"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0198b9d0078e0f30dedc7acbb21c974e838fc8fae3ee170128658a98cb2c1c04"
 
 [[package]]
 name = "fancy-regex"

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -44,7 +44,7 @@ chacha20poly1305 = "0.10.1"
 chrono = { version = "0.4.19", default-features = false, features = ["serde"] }
 criterion = { version = "0.4.0", optional = true  }
 croaring = { version = "0.5.2", optional = true }
-decimal-rs = "0.1.20"
+decimal-rs = "0.1.42"
 derivative = "2.2.0"
 digest = "0.9.0"
 fs2 = "0.4.0"

--- a/base_layer/core/src/transactions/tari_amount.rs
+++ b/base_layer/core/src/transactions/tari_amount.rs
@@ -69,7 +69,14 @@ pub enum MicroTariError {
     #[error("Failed to parse value: {0}")]
     ParseError(String),
     #[error("Failed to convert value: {0}")]
-    ConversionError(#[from] DecimalConvertError),
+    ConversionError(DecimalConvertError),
+}
+
+// DecimalConvertError does not implement Error
+impl From<DecimalConvertError> for MicroTariError {
+    fn from(err: DecimalConvertError) -> Self {
+        MicroTariError::ConversionError(err)
+    }
 }
 /// A convenience constant that makes it easier to define Tari amounts.
 /// ```edition2018


### PR DESCRIPTION
Description
---
Fixes compile error caused by breaking change for decimal-rs >=0.1.42

Motivation and Context
---
decimal-rs removed the Error impl for their error type in 0.1.42 but released this breaking change as a patch.
The thiserror from impl requires that the Error trait be implemented so this PR manually implements From

~~Causing compile error in https://github.com/tari-project/tari-dan/pull/421~~ worked around this and other issues by not updating all dependencies and locking to 0.47.0-pre.0 tag.

How Has This Been Tested?
---
Code compiles

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
