### PR TITLE
fix: export error types for balance merkle tree

### DIFF
--- a/base_layer/mmr/src/lib.rs
+++ b/base_layer/mmr/src/lib.rs
@@ -152,8 +152,12 @@ pub mod pruned_hashset;
 // Commonly used exports
 /// A vector-based backend for [MerkleMountainRange]
 pub use backend::{ArrayLike, ArrayLikeExt};
-pub use balanced_binary_merkle_proof::{BalancedBinaryMerkleProof, MergedBalancedBinaryMerkleProof};
-pub use balanced_binary_merkle_tree::BalancedBinaryMerkleTree;
+pub use balanced_binary_merkle_proof::{
+    BalancedBinaryMerkleProof,
+    MergedBalancedBinaryMerkleProof,
+    MergedBalancedBinaryMerkleProofError,
+};
+pub use balanced_binary_merkle_tree::{BalancedBinaryMerkleTree, BalancedBinaryMerkleTreeError};
 /// MemBackendVec is a shareable, memory only, vector that can be be used with MmrCache to store checkpoints.
 pub use mem_backend_vec::MemBackendVec;
 /// An immutable, append-only Merkle Mountain range (MMR) data structure


### PR DESCRIPTION
Description
---
Adds public exports for BMT error types

Motivation and Context
---
These are required to use BMT outside of the crate

How Has This Been Tested?
---
N/A

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
