### PR TITLE
ci: fail linting on truncated and wrapping casts

### DIFF
--- a/base_layer/common_types/src/emoji.rs
+++ b/base_layer/common_types/src/emoji.rs
@@ -97,7 +97,8 @@ lazy_static! {
     pub static ref REVERSE_EMOJI: HashMap<char, u8> = {
         let mut m = HashMap::with_capacity(DICT_SIZE);
         EMOJI.iter().enumerate().for_each(|(i, c)| {
-            m.insert(*c, i as u8);
+            #[allow(clippy::cast_possible_truncation)]
+            m.insert(*c, i as u8); // this can't truncate if the table contains at most 2^8 elements
         });
         m
     };

--- a/comms/dht/src/crypt.rs
+++ b/comms/dht/src/crypt.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{iter, mem::size_of};
+use std::{convert::TryFrom, iter, mem::size_of};
 
 use chacha20poly1305::{aead::AeadInPlace, ChaCha20Poly1305, KeyInit, Nonce, Tag};
 use digest::{generic_array::GenericArray, Digest, FixedOutput};
@@ -201,23 +201,27 @@ pub fn encrypt_message(
 }
 
 /// Encodes a prost Message, efficiently prepending the little-endian 32-bit length to the encoding
-fn encode_with_prepended_length<T: prost::Message>(msg: &T, additional_prefix_space: usize) -> BytesMut {
+fn encode_with_prepended_length<T: prost::Message>(
+    msg: &T,
+    additional_prefix_space: usize,
+) -> Result<BytesMut, DhtEncryptError> {
     let len = msg.encoded_len();
     let mut buf = BytesMut::with_capacity(size_of::<u32>() + additional_prefix_space + len);
     buf.extend(iter::repeat(0).take(additional_prefix_space));
-    buf.put_u32_le(len as u32);
-    msg.encode(&mut buf).expect(
-        "prost::Message::encode documentation says it is infallible unless the buffer has insufficient capacity. This \
-         buffer's capacity was set with encoded_len",
+    buf.put_u32_le(
+        u32::try_from(len).map_err(|_| DhtEncryptError::PaddingError(String::from("Message is too large to pad")))?,
     );
-    buf
+    msg.encode(&mut buf)
+        .map_err(|_| DhtEncryptError::PaddingError(String::from("Unable to pad message")))?;
+
+    Ok(buf)
 }
 
-pub fn prepare_message<T: prost::Message>(is_encrypted: bool, message: &T) -> BytesMut {
+pub fn prepare_message<T: prost::Message>(is_encrypted: bool, message: &T) -> Result<BytesMut, DhtEncryptError> {
     if is_encrypted {
         encode_with_prepended_length(message, 0)
     } else {
-        message.encode_into_bytes_mut()
+        Ok(message.encode_into_bytes_mut())
     }
 }
 
@@ -378,7 +382,7 @@ mod test {
         assert_eq!(pad, pad_message[message.len()..]);
 
         // test for large message
-        let message = encode_with_prepended_length(&vec![100u8; MESSAGE_BASE_LENGTH * 8 - 100], 0);
+        let message = encode_with_prepended_length(&vec![100u8; MESSAGE_BASE_LENGTH * 8 - 100], 0).unwrap();
         let mut pad_message = message.clone();
         pad_message_to_base_length_multiple(&mut pad_message, 0).unwrap();
         let pad = iter::repeat(0u8)
@@ -393,7 +397,7 @@ mod test {
         assert_eq!(pad, pad_message[message.len()..]);
 
         // test for base message of multiple base length
-        let message = encode_with_prepended_length(&vec![100u8; MESSAGE_BASE_LENGTH * 9 - 123], 0);
+        let message = encode_with_prepended_length(&vec![100u8; MESSAGE_BASE_LENGTH * 9 - 123], 0).unwrap();
         let pad = std::iter::repeat(0u8)
             .take((9 * MESSAGE_BASE_LENGTH) - message.len())
             .collect::<Vec<_>>();
@@ -409,7 +413,7 @@ mod test {
         assert_eq!(pad, pad_message[message.len()..]);
 
         // test for empty message
-        let message = encode_with_prepended_length(&vec![], 0);
+        let message = encode_with_prepended_length(&vec![], 0).unwrap();
         let mut pad_message = message.clone();
         pad_message_to_base_length_multiple(&mut pad_message, 0).unwrap();
         let pad = [0u8; MESSAGE_BASE_LENGTH - 4];
@@ -451,7 +455,7 @@ mod test {
     fn get_original_message_from_padded_text_successful() {
         // test for short message
         let message = vec![0u8, 10, 22, 11, 38, 74, 59, 91, 73, 82, 75, 23, 59];
-        let mut pad_message = encode_with_prepended_length(&message, 0);
+        let mut pad_message = encode_with_prepended_length(&message, 0).unwrap();
         pad_message_to_base_length_multiple(&mut pad_message, 0).unwrap();
 
         //
@@ -461,7 +465,7 @@ mod test {
 
         // test for large message
         let message = vec![100u8; 1024];
-        let mut pad_message = encode_with_prepended_length(&message, 0);
+        let mut pad_message = encode_with_prepended_length(&message, 0).unwrap();
         pad_message_to_base_length_multiple(&mut pad_message, 0).unwrap();
 
         let mut output_message = pad_message.clone();
@@ -470,7 +474,7 @@ mod test {
 
         // test for base message of base length
         let message = vec![100u8; 984];
-        let mut pad_message = encode_with_prepended_length(&message, 0);
+        let mut pad_message = encode_with_prepended_length(&message, 0).unwrap();
         pad_message_to_base_length_multiple(&mut pad_message, 0).unwrap();
 
         let mut output_message = pad_message.clone();
@@ -479,7 +483,7 @@ mod test {
 
         // test for empty message
         let message: Vec<u8> = vec![];
-        let mut pad_message = encode_with_prepended_length(&message, 0);
+        let mut pad_message = encode_with_prepended_length(&message, 0).unwrap();
         pad_message_to_base_length_multiple(&mut pad_message, 0).unwrap();
 
         let mut output_message = pad_message.clone();
@@ -490,7 +494,7 @@ mod test {
     #[test]
     fn padding_fails_if_pad_message_prepend_length_is_bigger_than_plaintext_length() {
         let message = "This is my secret message, keep it secret !".as_bytes().to_vec();
-        let mut pad_message = encode_with_prepended_length(&message, 0);
+        let mut pad_message = encode_with_prepended_length(&message, 0).unwrap();
         pad_message_to_base_length_multiple(&mut pad_message, 0).unwrap();
         let mut pad_message = pad_message.to_vec();
 

--- a/comms/dht/src/outbound/requester.rs
+++ b/comms/dht/src/outbound/requester.rs
@@ -288,7 +288,8 @@ impl OutboundMessageRequester {
             message.to_propagation_header()
         };
         let msg = wrap_in_envelope_body!(header, message.into_inner());
-        let body = prepare_message(params.encryption.is_encrypt(), &msg);
+        let body = prepare_message(params.encryption.is_encrypt(), &msg)
+            .map_err(|_| DhtOutboundError::PaddingError(String::from("Unable to pad message")))?;
         self.send_raw(params, body).await
     }
 
@@ -305,7 +306,8 @@ impl OutboundMessageRequester {
             trace!(target: LOG_TARGET, "Send Message: {} {:?}", params, message);
         }
         let msg = wrap_in_envelope_body!(message);
-        let body = prepare_message(params.encryption.is_encrypt(), &msg);
+        let body = prepare_message(params.encryption.is_encrypt(), &msg)
+            .map_err(|_| DhtOutboundError::PaddingError(String::from("Unable to pad message")))?;
         self.send_raw(params, body).await
     }
 
@@ -322,7 +324,8 @@ impl OutboundMessageRequester {
             trace!(target: LOG_TARGET, "Send Message: {} {:?}", params, message);
         }
         let msg = wrap_in_envelope_body!(message);
-        let body = prepare_message(params.encryption.is_encrypt(), &msg);
+        let body = prepare_message(params.encryption.is_encrypt(), &msg)
+            .map_err(|_| DhtOutboundError::PaddingError(String::from("Unable to pad message")))?;
         self.send_raw_no_wait(params, body).await
     }
 

--- a/comms/dht/src/test_utils/makers.rs
+++ b/comms/dht/src/test_utils/makers.rs
@@ -214,7 +214,7 @@ pub fn make_dht_envelope<T: prost::Message>(
         crypt::encrypt_message(&key_message, &mut message, masked_public_key.as_bytes()).unwrap();
         message.freeze()
     } else {
-        prepare_message(false, message).freeze()
+        prepare_message(false, message).unwrap().freeze()
     };
     let header = make_dht_header(
         node_identity,

--- a/lints.toml
+++ b/lints.toml
@@ -49,11 +49,9 @@ deny = [
     # Highlights potential casting mistakes
     'clippy::cast_lossless',
     'clippy::cast_possible_truncation',
-#    'clippy::cast_possible_wrap',
-    # Precision loss is almost always competely fine and is only useful as a sanity check.
-    # https://rust-lang.github.io/rust-clippy/master/index.html#cast_precision_loss
-    # 'clippy::cast_precision_loss',
-#    'clippy::cast_sign_loss'
+    'clippy::cast_possible_wrap',
+     'clippy::cast_precision_loss',
+    'clippy::cast_sign_loss'
     'clippy::unnecessary_to_owned',
     'clippy::nonminimal_bool',
     'clippy::needless_question_mark',

--- a/lints.toml
+++ b/lints.toml
@@ -48,7 +48,7 @@ deny = [
     'clippy::trivially_copy_pass_by_ref',
     # Highlights potential casting mistakes
     'clippy::cast_lossless',
-#    'clippy::cast_possible_truncation',
+    'clippy::cast_possible_truncation',
 #    'clippy::cast_possible_wrap',
     # Precision loss is almost always competely fine and is only useful as a sanity check.
     # https://rust-lang.github.io/rust-clippy/master/index.html#cast_precision_loss


### PR DESCRIPTION
Description
---
Fails linting on possible truncated or wrapping casts. Various updates to address failures.

Closes #5478.

Motivation and Context
---
It was observed in [another PR](https://github.com/tari-project/tari/pull/5232) that truncated casts are not picked up by the linter. The `clippy::cast_possible_truncation` lint will catch this, but was disabled. Some of these casts may be risky, so it seems prudent to fail on them unless specifically allowed and documented.

This PR enables the lint as a `deny`, as well as a related lint for wrapping. For each lint failure, it either uses an `allow` (if the truncation is impossible or safe) or makes an update to fix it.

Note that after [PR 5237](https://github.com/tari-project/tari/pull/5237) is merged, it can be assumed that the target `usize` is not 32 bits.

How Has This Been Tested?
---
It hasn't. This behavior occurs in multiple places (around a couple dozen) within the codebase; in each case, it needs to be decided if the cast is safe (in which case the lint can be selectively disabled) or risky (in which case it should be replaced). This should happen before the PR is merged.