### PR TITLE
fix: windows path format in log4rs files

### DIFF
--- a/common/src/logging.rs
+++ b/common/src/logging.rs
@@ -57,12 +57,13 @@ pub fn initialize_logging(config_file: &Path, base_path: &Path, default: &str) -
     file.read_to_string(&mut contents)
         .map_err(|e| ConfigError::new("Could not read file: {}", Some(e.to_string())))?;
 
-    let contents = contents.replace(
-        "{{log_dir}}",
-        base_path
-            .to_str()
-            .expect("Could not replace {{log_dir}} variable from the log4rs config"),
-    );
+    let replace_str = base_path
+        .to_str()
+        .expect("Could not replace {{log_dir}} variable from the log4rs config")
+        // log4rs requires the path to be in a unix format regardless of the system it's running on
+        .replace("\\", "/");
+
+    let contents = contents.replace("{{log_dir}}", &replace_str);
 
     let config: RawConfig =
         serde_yaml::from_str(&contents).expect("Could not parse the contents of the log file as yaml");


### PR DESCRIPTION
Description
---
This commit does a naive character replacement on the string path just before we do the path injection.

Motivation and Context
---
log4rs expects the paths to be in a unix format regardless of the system it's running on. When we started doing the dynamic injecting of the base path windows systems injected using a windows format, which mixed with the unix format. Resulting in strings that looked liked this: `C:\\brianp\.tari\config/log/base-node/network.log`

when log4rs wants the final format to be like this: `C://brianp/.tari/config/log/base-node/network.log`

How Has This Been Tested?
---
Manually on Hansie's windows machine

Co-authored-by: hansieodendaal 39146854+hansieodendaal@users.noreply.github.com