### PR TITLE
fix: immediately fail to compile on 32-bit systems

### DIFF
--- a/applications/tari_app_utilities/src/lib.rs
+++ b/applications/tari_app_utilities/src/lib.rs
@@ -35,6 +35,6 @@ pub mod consts {
 macro_rules! deny_non_64_bit_archs {
     () => {
         #[cfg(not(target_pointer_width = "64"))]
-        compile_error!("Only 64-bit architectures are supported");
+        compile_error!("Only 64-bit architectures are supported. Here's a medal for trying 🏅");
     };
 }

--- a/applications/tari_app_utilities/src/lib.rs
+++ b/applications/tari_app_utilities/src/lib.rs
@@ -28,3 +28,13 @@ pub mod consts {
     // Import the auto-generated const values from the Manifest and Git
     include!(concat!(env!("OUT_DIR"), "/consts.rs"));
 }
+
+/// Non-64-bit architectures are untested. Depending on the application, it may not compile already or could be various
+/// classes of bugs (overflows, crashes, etc). Use this macro to explicitly fail compilation on non-64-bit targets.
+#[macro_export]
+macro_rules! deny_non_64_bit_archs {
+    () => {
+        #[cfg(not(target_pointer_width = "64"))]
+        compile_error!("Only 64-bit architectures are supported");
+    };
+}

--- a/applications/tari_base_node/src/lib.rs
+++ b/applications/tari_base_node/src/lib.rs
@@ -20,6 +20,9 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+// non-64-bit not supported
+tari_app_utilities::deny_non_64_bit_archs!();
+
 #[macro_use]
 mod table;
 

--- a/applications/tari_console_wallet/src/lib.rs
+++ b/applications/tari_console_wallet/src/lib.rs
@@ -20,6 +20,9 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+// non-64-bit not supported
+tari_app_utilities::deny_non_64_bit_archs!();
+
 mod automation;
 mod cli;
 mod config;

--- a/applications/tari_merge_mining_proxy/src/lib.rs
+++ b/applications/tari_merge_mining_proxy/src/lib.rs
@@ -20,6 +20,9 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+// non-64-bit not supported
+tari_app_utilities::deny_non_64_bit_archs!();
+
 mod block_template_data;
 mod block_template_protocol;
 mod cli;

--- a/applications/tari_miner/src/lib.rs
+++ b/applications/tari_miner/src/lib.rs
@@ -20,6 +20,9 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+// non-64-bit not supported
+tari_app_utilities::deny_non_64_bit_archs!();
+
 mod cli;
 pub use cli::Cli;
 use tari_common::exit_codes::ExitError;


### PR DESCRIPTION
Description
---
Fail to compile on 32-bit architectures

Motivation and Context
---
32-bit architectures are untested. Depending on the application, it may not compile already or there could be various classes of bugs (overflows, crashes, etc). This PR explicitly fails compilation to 32-bit targets for all applications.

How Has This Been Tested?
---
CI

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
