### PR TITLE
feat!: add claim public key to OutputFeatures

### DIFF
--- a/applications/tari_app_grpc/proto/sidechain_types.proto
+++ b/applications/tari_app_grpc/proto/sidechain_types.proto
@@ -29,6 +29,7 @@ message SideChainFeature {
     oneof side_chain_feature {
         ValidatorNodeRegistration validator_node_registration = 1;
         TemplateRegistration template_registration = 2;
+        ConfidentialOutputData confidential_output = 3;
     }
 }
 
@@ -46,6 +47,10 @@ message TemplateRegistration {
     BuildInfo build_info = 6;
     bytes binary_sha = 7;
     string binary_url = 8;
+}
+
+message ConfidentialOutputData {
+    bytes claim_public_key = 1;
 }
 
 message TemplateType {

--- a/applications/tari_app_grpc/src/conversions/sidechain_feature.rs
+++ b/applications/tari_app_grpc/src/conversions/sidechain_feature.rs
@@ -28,6 +28,7 @@ use tari_core::{
     transactions::transaction_components::{
         BuildInfo,
         CodeTemplateRegistration,
+        ConfidentialOutputData,
         SideChainFeature,
         TemplateType,
         ValidatorNodeRegistration,
@@ -56,6 +57,9 @@ impl From<SideChainFeature> for grpc::side_chain_feature::SideChainFeature {
             SideChainFeature::TemplateRegistration(template_reg) => {
                 grpc::side_chain_feature::SideChainFeature::TemplateRegistration(template_reg.into())
             },
+            SideChainFeature::ConfidentialOutput(output_data) => {
+                grpc::side_chain_feature::SideChainFeature::ConfidentialOutput(output_data.into())
+            },
         }
     }
 }
@@ -70,6 +74,9 @@ impl TryFrom<grpc::side_chain_feature::SideChainFeature> for SideChainFeature {
             },
             grpc::side_chain_feature::SideChainFeature::TemplateRegistration(template_reg) => {
                 Ok(SideChainFeature::TemplateRegistration(template_reg.try_into()?))
+            },
+            grpc::side_chain_feature::SideChainFeature::ConfidentialOutput(output_data) => {
+                Ok(SideChainFeature::ConfidentialOutput(output_data.try_into()?))
             },
         }
     }
@@ -140,6 +147,25 @@ impl From<CodeTemplateRegistration> for grpc::TemplateRegistration {
             build_info: Some(value.build_info.into()),
             binary_sha: value.binary_sha.to_vec(),
             binary_url: value.binary_url.to_string(),
+        }
+    }
+}
+
+// -------------------------------- ConfidentialOutputData -------------------------------- //
+impl TryFrom<grpc::ConfidentialOutputData> for ConfidentialOutputData {
+    type Error = String;
+
+    fn try_from(value: grpc::ConfidentialOutputData) -> Result<Self, Self::Error> {
+        Ok(ConfidentialOutputData {
+            claim_public_key: PublicKey::from_bytes(&value.claim_public_key).map_err(|e| e.to_string())?,
+        })
+    }
+}
+
+impl From<ConfidentialOutputData> for grpc::ConfidentialOutputData {
+    fn from(value: ConfidentialOutputData) -> Self {
+        Self {
+            claim_public_key: value.claim_public_key.to_vec(),
         }
     }
 }

--- a/base_layer/core/src/proto/sidechain_feature.proto
+++ b/base_layer/core/src/proto/sidechain_feature.proto
@@ -11,6 +11,7 @@ message SideChainFeature {
     oneof side_chain_feature {
         ValidatorNodeRegistration validator_node_registration = 1;
         TemplateRegistration template_registration = 2;
+        ConfidentialOutputData confidential_output = 3;
     }
 }
 
@@ -28,6 +29,10 @@ message TemplateRegistration {
     BuildInfo build_info = 6;
     bytes binary_sha = 7;
     string binary_url = 8;
+}
+
+message ConfidentialOutputData {
+    bytes claim_public_key = 1;
 }
 
 message TemplateType {

--- a/base_layer/core/src/proto/sidechain_feature.rs
+++ b/base_layer/core/src/proto/sidechain_feature.rs
@@ -33,6 +33,7 @@ use crate::{
     transactions::transaction_components::{
         BuildInfo,
         CodeTemplateRegistration,
+        ConfidentialOutputData,
         SideChainFeature,
         TemplateType,
         ValidatorNodeRegistration,
@@ -58,6 +59,9 @@ impl From<SideChainFeature> for proto::types::side_chain_feature::SideChainFeatu
             SideChainFeature::TemplateRegistration(template_reg) => {
                 proto::types::side_chain_feature::SideChainFeature::TemplateRegistration(template_reg.into())
             },
+            SideChainFeature::ConfidentialOutput(output_data) => {
+                proto::types::side_chain_feature::SideChainFeature::ConfidentialOutput(output_data.into())
+            },
         }
     }
 }
@@ -72,6 +76,9 @@ impl TryFrom<proto::types::side_chain_feature::SideChainFeature> for SideChainFe
             },
             proto::types::side_chain_feature::SideChainFeature::TemplateRegistration(template_reg) => {
                 Ok(SideChainFeature::TemplateRegistration(template_reg.try_into()?))
+            },
+            proto::types::side_chain_feature::SideChainFeature::ConfidentialOutput(output_data) => {
+                Ok(SideChainFeature::ConfidentialOutput(output_data.try_into()?))
             },
         }
     }
@@ -142,6 +149,25 @@ impl From<CodeTemplateRegistration> for proto::types::TemplateRegistration {
             build_info: Some(value.build_info.into()),
             binary_sha: value.binary_sha.to_vec(),
             binary_url: value.binary_url.to_string(),
+        }
+    }
+}
+
+// -------------------------------- ConfidentialOutputData -------------------------------- //
+impl TryFrom<proto::types::ConfidentialOutputData> for ConfidentialOutputData {
+    type Error = String;
+
+    fn try_from(value: proto::types::ConfidentialOutputData) -> Result<Self, Self::Error> {
+        Ok(ConfidentialOutputData {
+            claim_public_key: PublicKey::from_bytes(&value.claim_public_key).map_err(|e| e.to_string())?,
+        })
+    }
+}
+
+impl From<ConfidentialOutputData> for proto::types::ConfidentialOutputData {
+    fn from(value: ConfidentialOutputData) -> Self {
+        Self {
+            claim_public_key: value.claim_public_key.to_vec(),
         }
     }
 }

--- a/base_layer/core/src/transactions/transaction_components/output_features.rs
+++ b/base_layer/core/src/transactions/transaction_components/output_features.rs
@@ -34,6 +34,7 @@ use super::OutputFeaturesVersion;
 use crate::transactions::transaction_components::{
     side_chain::SideChainFeature,
     CodeTemplateRegistration,
+    ConfidentialOutputData,
     OutputType,
     ValidatorNodeRegistration,
     ValidatorNodeSignature,
@@ -103,6 +104,17 @@ impl OutputFeatures {
     pub fn create_burn_output() -> OutputFeatures {
         OutputFeatures {
             output_type: OutputType::Burn,
+            ..Default::default()
+        }
+    }
+
+    /// creates output features for a burned output with confidential output data
+    pub fn create_burn_confidential_output(claim_public_key: PublicKey) -> OutputFeatures {
+        OutputFeatures {
+            output_type: OutputType::Burn,
+            sidechain_feature: Some(SideChainFeature::ConfidentialOutput(ConfidentialOutputData {
+                claim_public_key,
+            })),
             ..Default::default()
         }
     }

--- a/base_layer/core/src/transactions/transaction_components/side_chain/confidential_output.rs
+++ b/base_layer/core/src/transactions/transaction_components/side_chain/confidential_output.rs
@@ -1,4 +1,4 @@
-//  Copyright 2022. The Tari Project
+//  Copyright 2023. The Tari Project
 //
 //  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
 //  following conditions are met:
@@ -22,39 +22,9 @@
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
-
-use crate::transactions::transaction_components::{
-    side_chain::confidential_output::ConfidentialOutputData,
-    CodeTemplateRegistration,
-    ValidatorNodeRegistration,
-};
+use tari_common_types::types::PublicKey;
 
 #[derive(Debug, Clone, Hash, PartialEq, Deserialize, Serialize, Eq, BorshSerialize, BorshDeserialize)]
-pub enum SideChainFeature {
-    ValidatorNodeRegistration(ValidatorNodeRegistration),
-    TemplateRegistration(CodeTemplateRegistration),
-    ConfidentialOutput(ConfidentialOutputData),
-}
-
-impl SideChainFeature {
-    pub fn template_registration(&self) -> Option<&CodeTemplateRegistration> {
-        match self {
-            Self::TemplateRegistration(v) => Some(v),
-            _ => None,
-        }
-    }
-
-    pub fn validator_node_registration(&self) -> Option<&ValidatorNodeRegistration> {
-        match self {
-            Self::ValidatorNodeRegistration(v) => Some(v),
-            _ => None,
-        }
-    }
-
-    pub fn confidential_output_data(&self) -> Option<&ConfidentialOutputData> {
-        match self {
-            Self::ConfidentialOutput(v) => Some(v),
-            _ => None,
-        }
-    }
+pub struct ConfidentialOutputData {
+    pub claim_public_key: PublicKey,
 }

--- a/base_layer/core/src/transactions/transaction_components/side_chain/mod.rs
+++ b/base_layer/core/src/transactions/transaction_components/side_chain/mod.rs
@@ -23,10 +23,12 @@
 mod sidechain_feature;
 pub use sidechain_feature::SideChainFeature;
 
+mod confidential_output;
 mod template_registration;
 mod validator_node_registration;
 mod validator_node_signature;
 
+pub use confidential_output::ConfidentialOutputData;
 use tari_crypto::{hash::blake2::Blake256, hash_domain, hashing::DomainSeparatedHasher};
 pub use template_registration::{BuildInfo, CodeTemplateRegistration, TemplateType};
 pub use validator_node_registration::ValidatorNodeRegistration;

--- a/base_layer/wallet/src/output_manager_service/recovery/standard_outputs_recoverer.rs
+++ b/base_layer/wallet/src/output_manager_service/recovery/standard_outputs_recoverer.rs
@@ -26,10 +26,11 @@ use log::*;
 use rand::rngs::OsRng;
 use tari_common_types::{
     transaction::TxId,
-    types::{BulletRangeProof, PrivateKey, PublicKey},
+    types::{BlindingFactor, BulletRangeProof, PrivateKey, PublicKey},
 };
 use tari_core::transactions::{
-    transaction_components::{EncryptedValue, TransactionOutput, UnblindedOutput},
+    tari_amount::MicroTari,
+    transaction_components::{EncryptedValue, OutputType, TransactionOutput, UnblindedOutput},
     transaction_protocol::RewindData,
     CryptoFactories,
 };
@@ -51,6 +52,7 @@ use crate::{
             OutputSource,
         },
     },
+    util::burn_proof::derive_diffie_hellman_burn_claim_encryption_key,
 };
 
 const LOG_TARGET: &str = "wallet::output_manager_service::recovery";
@@ -98,42 +100,47 @@ where
             if output.script != script!(Nop) && known_script_index.is_none() {
                 continue;
             }
-            let committed_value = EncryptedValue::decrypt_value(
-                &self.rewind_data.encryption_key,
-                &output.commitment,
-                &output.encrypted_value,
+
+            let (blinding_factor, committed_value) = match output.features.output_type {
+                OutputType::Standard |
+                OutputType::Coinbase |
+                OutputType::ValidatorNodeRegistration |
+                OutputType::CodeTemplateRegistration => match self.attempt_standard_output_recovery(&output)? {
+                    Some(recovered) => recovered,
+                    None => continue,
+                },
+                OutputType::Burn => match self.attempt_burn_output_recovery(&output)? {
+                    Some(recovered) => recovered,
+                    None => continue,
+                },
+            };
+
+            let (input_data, script_key) = if let Some(index) = known_script_index {
+                (
+                    known_scripts[index].input.clone(),
+                    known_scripts[index].private_key.clone(),
+                )
+            } else {
+                let key = PrivateKey::random(&mut OsRng);
+                (inputs!(PublicKey::from_secret_key(&key)), key)
+            };
+            let uo = UnblindedOutput::new(
+                output.version,
+                committed_value,
+                blinding_factor,
+                output.features,
+                output.script,
+                input_data,
+                script_key,
+                output.sender_offset_public_key,
+                output.metadata_signature,
+                0,
+                output.covenant,
+                output.encrypted_value,
+                output.minimum_value_promise,
             );
-            if let Ok(committed_value) = committed_value {
-                let blinding_factor =
-                    output.recover_mask(&self.factories.range_proof, &self.rewind_data.rewind_blinding_key)?;
-                if output.verify_mask(&self.factories.range_proof, &blinding_factor, committed_value.into())? {
-                    let (input_data, script_key) = if let Some(index) = known_script_index {
-                        (
-                            known_scripts[index].input.clone(),
-                            known_scripts[index].private_key.clone(),
-                        )
-                    } else {
-                        let key = PrivateKey::random(&mut OsRng);
-                        (inputs!(PublicKey::from_secret_key(&key)), key)
-                    };
-                    let uo = UnblindedOutput::new(
-                        output.version,
-                        committed_value,
-                        blinding_factor,
-                        output.features,
-                        output.script,
-                        input_data,
-                        script_key,
-                        output.sender_offset_public_key,
-                        output.metadata_signature,
-                        0,
-                        output.covenant,
-                        output.encrypted_value,
-                        output.minimum_value_promise,
-                    );
-                    rewound_outputs.push((uo, output.proof));
-                }
-            }
+
+            rewound_outputs.push((uo, output.proof));
         }
 
         let rewind_time = start.elapsed();
@@ -191,6 +198,61 @@ where
         }
 
         Ok(rewound_outputs_with_tx_id)
+    }
+
+    fn attempt_standard_output_recovery(
+        &self,
+        output: &TransactionOutput,
+    ) -> Result<Option<(BlindingFactor, MicroTari)>, OutputManagerError> {
+        let committed_value = EncryptedValue::decrypt_value(
+            &self.rewind_data.encryption_key,
+            &output.commitment,
+            &output.encrypted_value,
+        );
+        let committed_value = match committed_value {
+            Ok(value) => value,
+            Err(_) => {
+                return Ok(None);
+            },
+        };
+
+        let blinding_factor =
+            output.recover_mask(&self.factories.range_proof, &self.rewind_data.rewind_blinding_key)?;
+        if !output.verify_mask(&self.factories.range_proof, &blinding_factor, committed_value.into())? {
+            return Ok(None);
+        }
+
+        Ok(Some((blinding_factor, committed_value)))
+    }
+
+    fn attempt_burn_output_recovery(
+        &self,
+        output: &TransactionOutput,
+    ) -> Result<Option<(BlindingFactor, MicroTari)>, OutputManagerError> {
+        let Some(confidential_data) = output.features.sidechain_feature.as_ref().and_then(|f| f.confidential_output_data()) else {
+            return self.attempt_standard_output_recovery(output);
+        };
+
+        let blinding_factor =
+            output.recover_mask(&self.factories.range_proof, &self.rewind_data.rewind_blinding_key)?;
+
+        let shard_encryption_key =
+            derive_diffie_hellman_burn_claim_encryption_key(&blinding_factor, &confidential_data.claim_public_key);
+
+        let committed_value =
+            EncryptedValue::decrypt_value(&shard_encryption_key, &output.commitment, &output.encrypted_value);
+        let committed_value = match committed_value {
+            Ok(value) => value,
+            Err(_) => {
+                return Ok(None);
+            },
+        };
+
+        if !output.verify_mask(&self.factories.range_proof, &blinding_factor, committed_value.into())? {
+            return Ok(None);
+        }
+
+        Ok(Some((blinding_factor, committed_value)))
     }
 
     /// Find the key manager index that corresponds to the spending key in the rewound output, if found then modify

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -1390,7 +1390,11 @@ where
         >,
     ) -> Result<(TxId, BurntProof), TransactionServiceError> {
         let tx_id = TxId::new_random();
-        let output_features = OutputFeatures::create_burn_output();
+        let output_features = claim_public_key
+            .as_ref()
+            .cloned()
+            .map(OutputFeatures::create_burn_confidential_output)
+            .unwrap_or_else(OutputFeatures::create_burn_output);
         // Prepare sender part of the transaction
         let tx_meta = TransactionMetadata::new_with_features(0.into(), 0, KernelFeatures::create_burn());
         let mut stp = self
@@ -1535,7 +1539,7 @@ where
             reciprocal_claim_public_key: public_spend_key,
             commitment,
             ownership_proof,
-            range_proof: range_proof.into(),
+            range_proof,
         }))
     }
 


### PR DESCRIPTION
Description
---
- Adds confidential claim data to chain when burn_tari is invoked with claim_public_key set.
- Updates output recovery in wallet to recover burnt outputs

Motivation and Context
---
Claim key is required for mask and value recovery of burnt funds on L2.
Unfortunately, since burnt outputs are not part of the utxo set, the wallet does not receive these outputs when recovering. Resolving this is out of scope for this PR. 

How Has This Been Tested?
---
Manually: normal wallet recovery OK. Resync base node OK.

<!-- Does this include a breaking change? If so, include this line as a footer -->
 BREAKING CHANGE: Not database or network breaking, but a chain split will occur if a burnt utxo with the claim public key set is broadcast and some nodes have not upgraded.
