### PR TITLE
feat: chat scaffold

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5515,6 +5515,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tower",
+ "uuid",
 ]
 
 [[package]]
@@ -6787,6 +6788,15 @@ name = "utf8parse"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
+
+[[package]]
+name = "uuid"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b55a3fef2a1e3b3a00ce878640918820d3c51081576ac657d23af9fc7928fdb"
+dependencies = [
+ "getrandom 0.2.8",
+]
 
 [[package]]
 name = "valuable"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5252,6 +5252,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tari_chat_client"
+version = "0.48.0-pre.1"
+dependencies = [
+ "anyhow",
+ "diesel",
+ "lmdb-zero",
+ "tari_common_sqlite",
+ "tari_common_types",
+ "tari_comms",
+ "tari_comms_dht",
+ "tari_contacts",
+ "tari_p2p",
+ "tari_service_framework",
+ "tari_shutdown",
+ "tari_storage",
+ "tari_test_utils",
+]
+
+[[package]]
 name = "tari_common"
 version = "0.50.0-pre.0"
 dependencies = [
@@ -5475,8 +5494,10 @@ dependencies = [
  "diesel",
  "diesel_migrations",
  "futures 0.3.26",
- "libsqlite3-sys",
  "log",
+ "num-derive",
+ "num-traits",
+ "prost 0.9.0",
  "rand 0.7.3",
  "tari_common",
  "tari_common_sqlite",
@@ -5616,11 +5637,14 @@ dependencies = [
  "tari_app_utilities",
  "tari_base_node",
  "tari_base_node_grpc_client",
+ "tari_chat_client",
  "tari_common",
+ "tari_common_sqlite",
  "tari_common_types",
  "tari_comms",
  "tari_comms_dht",
  "tari_console_wallet",
+ "tari_contacts",
  "tari_core",
  "tari_crypto",
  "tari_merge_mining_proxy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5258,6 +5258,7 @@ dependencies = [
  "anyhow",
  "diesel",
  "lmdb-zero",
+ "tari_common",
  "tari_common_sqlite",
  "tari_common_types",
  "tari_comms",

--- a/applications/tari_console_wallet/log4rs_sample.yml
+++ b/applications/tari_console_wallet/log4rs_sample.yml
@@ -80,6 +80,23 @@ appenders:
     encoder:
       pattern: "{d(%Y-%m-%d %H:%M:%S.%f)} [{t}] [Thread:{I}] {l:5} {m}{n}"
 
+  # An appender named "contacts" that writes to a file with a custom pattern encoder
+  contacts:
+    kind: rolling_file
+    path: "{{log_dir}}/log/wallet/contacts.log"
+    policy:
+      kind: compound
+      trigger:
+        kind: size
+        limit: 10mb
+      roller:
+        kind: fixed_window
+        base: 1
+        count: 5
+        pattern: "{{log_dir}}/log/wallet/contacts.{}.log"
+    encoder:
+      pattern: "{d(%Y-%m-%d %H:%M:%S.%f)} [{t}] [Thread:{I}] {l:5} {m}{n}"
+
 # root (to base_layer)
 root:
   level: debug
@@ -115,6 +132,11 @@ loggers:
     level: info
     appenders:
       - network
+    additive: false
+  contacts:
+    level: info
+    appenders:
+      - contacts
     additive: false
   comms::noise:
     level: error

--- a/applications/tari_console_wallet/src/ui/state/app_state.rs
+++ b/applications/tari_console_wallet/src/ui/state/app_state.rs
@@ -42,7 +42,7 @@ use tari_comms::{
     net_address::{MultiaddressesWithStats, PeerAddressSource},
     peer_manager::{NodeId, Peer, PeerFeatures, PeerFlags},
 };
-use tari_contacts::contacts_service::{handle::ContactsLivenessEvent, storage::database::Contact};
+use tari_contacts::contacts_service::{handle::ContactsLivenessEvent, types::Contact};
 use tari_core::transactions::{
     tari_amount::{uT, MicroTari},
     transaction_components::OutputFeatures,

--- a/applications/tari_console_wallet/src/ui/state/wallet_event_monitor.rs
+++ b/applications/tari_console_wallet/src/ui/state/wallet_event_monitor.rs
@@ -266,7 +266,7 @@ impl WalletEventMonitor {
                                     );
                                     self.trigger_contacts_refresh().await;
                                 }
-                                ContactsLivenessEvent::NetworkSilence => {}
+                                ContactsLivenessEvent::NetworkSilence => {},
                             }
                         }
                         Err(broadcast::error::RecvError::Lagged(n)) => {

--- a/applications/tari_console_wallet/src/ui/ui_contact.rs
+++ b/applications/tari_console_wallet/src/ui/ui_contact.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 use chrono::{DateTime, Local};
-use tari_contacts::contacts_service::storage::database::Contact;
+use tari_contacts::contacts_service::types::Contact;
 
 #[derive(Debug, Clone)]
 pub struct UiContact {

--- a/base_layer/contacts/Cargo.toml
+++ b/base_layer/contacts/Cargo.toml
@@ -8,34 +8,33 @@ edition = "2018"
 
 [dependencies]
 tari_common = { path = "../../common" }
+tari_common_sqlite = { path = "../../common_sqlite" }
 tari_common_types = {  path = "../../base_layer/common_types" }
 tari_comms = {  path = "../../comms/core" }
+tari_comms_dht = { path = "../../comms/dht" }
 tari_crypto = { version = "0.16.11"}
 tari_p2p = {  path = "../p2p", features = ["auto-update"] }
 tari_service_framework = {  path = "../service_framework" }
 tari_shutdown = {  path = "../../infrastructure/shutdown" }
-tari_common_sqlite = { path = "../../common_sqlite" }
 tari_utilities = "0.4.10"
 
-tokio = { version = "1.23", features = ["sync", "macros"] }
 chrono = { version = "0.4.19", default-features = false, features = ["serde"] }
 diesel = { version = "2.0.3", features = ["sqlite", "serde_json", "chrono", "64-column-tables"] }
 diesel_migrations = "2.0.0"
 futures = { version = "^0.3.1", features = ["compat", "std"] }
-libsqlite3-sys = { version = "0.25.1", features = ["bundled"], optional = true }
 log = "0.4.6"
+num-traits = "0.2.15"
+num-derive = "0.3.3"
 rand = "0.7.3"
 thiserror = "1.0.26"
+tokio = { version = "1.23", features = ["sync", "macros"] }
 tower = "0.4"
+prost = "0.9"
 
 [dev-dependencies]
-tari_test_utils = {  path = "../../infrastructure/test_utils" }
 tari_comms_dht = {  path = "../../comms/dht", features = ["test-mocks"] }
+tari_test_utils = {  path = "../../infrastructure/test_utils" }
 tempfile = "3.1.0"
 
-[features]
-default=["bundled_sqlite"]
-bundled_sqlite = ["libsqlite3-sys"]
-
-[package.metadata.cargo-machete]
-ignored = ["libsqlite3-sys"] # this is so we can run cargo machete without getting false positive about macro dependancies
+[build-dependencies]
+tari_common = { path = "../../common" }

--- a/base_layer/contacts/Cargo.toml
+++ b/base_layer/contacts/Cargo.toml
@@ -23,13 +23,14 @@ diesel = { version = "2.0.3", features = ["sqlite", "serde_json", "chrono", "64-
 diesel_migrations = "2.0.0"
 futures = { version = "^0.3.1", features = ["compat", "std"] }
 log = "0.4.6"
-num-traits = "0.2.15"
 num-derive = "0.3.3"
+num-traits = "0.2.15"
+prost = "0.9"
 rand = "0.7.3"
 thiserror = "1.0.26"
 tokio = { version = "1.23", features = ["sync", "macros"] }
 tower = "0.4"
-prost = "0.9"
+uuid = { version = "1.3.1", features = ["v4"] }
 
 [dev-dependencies]
 tari_comms_dht = {  path = "../../comms/dht", features = ["test-mocks"] }

--- a/base_layer/contacts/Cargo.toml
+++ b/base_layer/contacts/Cargo.toml
@@ -39,3 +39,6 @@ tempfile = "3.1.0"
 
 [build-dependencies]
 tari_common = { path = "../../common" }
+
+[package.metadata.cargo-machete]
+ignored = ["prost"] # this is so we can run cargo machete without getting false positive about macro dependancies

--- a/base_layer/contacts/build.rs
+++ b/base_layer/contacts/build.rs
@@ -1,0 +1,31 @@
+//  Copyright 2023. The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tari_common::build::ProtobufCompiler::new()
+        .proto_paths(&["proto"])
+        .include_paths(&["proto"])
+        .emit_rerun_if_changed_directives()
+        .compile()
+        .unwrap();
+    Ok(())
+}

--- a/base_layer/contacts/migrations/2023-03-14-101758_create_messages/down.sql
+++ b/base_layer/contacts/migrations/2023-03-14-101758_create_messages/down.sql
@@ -1,0 +1,3 @@
+DROP INDEX idx_messages_address;
+
+DROP TABLE IF EXISTS messages;

--- a/base_layer/contacts/migrations/2023-03-14-101758_create_messages/up.sql
+++ b/base_layer/contacts/migrations/2023-03-14-101758_create_messages/up.sql
@@ -1,9 +1,9 @@
 CREATE TABLE messages (
-    address    BLOB                NOT NULL,
-    message_id INTEGER PRIMARY KEY NOT NULL,
-    body       BLOB                NOT NULL,
-    stored_at  TIMESTAMP           NOT NULL,
-    direction  INTEGER             NOT NULL
+    address    BLOB             NOT NULL,
+    message_id BLOB PRIMARY KEY NOT NULL,
+    body       BLOB             NOT NULL,
+    stored_at  TIMESTAMP        NOT NULL,
+    direction  INTEGER          NOT NULL
 );
 
 CREATE INDEX idx_messages_address ON messages (address);

--- a/base_layer/contacts/migrations/2023-03-14-101758_create_messages/up.sql
+++ b/base_layer/contacts/migrations/2023-03-14-101758_create_messages/up.sql
@@ -1,0 +1,9 @@
+CREATE TABLE messages (
+    address    BLOB                NOT NULL,
+    message_id INTEGER PRIMARY KEY NOT NULL,
+    body       BLOB                NOT NULL,
+    stored_at  TIMESTAMP           NOT NULL,
+    direction  INTEGER             NOT NULL
+);
+
+CREATE INDEX idx_messages_address ON messages (address);

--- a/base_layer/contacts/proto/message.proto
+++ b/base_layer/contacts/proto/message.proto
@@ -1,0 +1,18 @@
+// Copyright 2023 The Tari Project
+// SPDX-License-Identifier: BSD-3-Clause
+
+syntax = "proto3";
+package tari.contacts.chat;
+
+message Message {
+  bytes body = 1;
+  bytes address = 2;
+  DirectionEnum direction = 3;
+  uint64 stored_at = 4;
+  uint64 message_id = 5;
+}
+
+enum DirectionEnum {
+  Inbound = 0;
+  Outbound = 1;
+}

--- a/base_layer/contacts/proto/message.proto
+++ b/base_layer/contacts/proto/message.proto
@@ -9,7 +9,7 @@ message Message {
   bytes address = 2;
   DirectionEnum direction = 3;
   uint64 stored_at = 4;
-  uint64 message_id = 5;
+  bytes message_id = 5;
 }
 
 enum DirectionEnum {

--- a/base_layer/contacts/src/contacts_service/error.rs
+++ b/base_layer/contacts/src/contacts_service/error.rs
@@ -23,6 +23,7 @@
 use diesel::result::Error as DieselError;
 use tari_common_sqlite::error::SqliteStorageError;
 use tari_comms::connectivity::ConnectivityError;
+use tari_comms_dht::outbound::DhtOutboundError;
 use tari_p2p::services::liveness::error::LivenessError;
 use tari_service_framework::reply_channel::TransportChannelError;
 use thiserror::Error;
@@ -44,6 +45,8 @@ pub enum ContactsServiceError {
     LivenessError(#[from] LivenessError),
     #[error("ConnectivityError error: `{0}`")]
     ConnectivityError(#[from] ConnectivityError),
+    #[error("Outbound comms error: `{0}`")]
+    OutboundCommsError(#[from] DhtOutboundError),
 }
 
 #[derive(Debug, Error)]

--- a/base_layer/contacts/src/contacts_service/handle.rs
+++ b/base_layer/contacts/src/contacts_service/handle.rs
@@ -35,7 +35,7 @@ use tower::Service;
 use crate::contacts_service::{
     error::ContactsServiceError,
     service::{ContactMessageType, ContactOnlineStatus},
-    storage::database::Contact,
+    types::{Contact, Message},
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -130,6 +130,8 @@ pub enum ContactsServiceRequest {
     RemoveContact(TariAddress),
     GetContacts,
     GetContactOnlineStatus(Contact),
+    SendMessage(TariAddress, Message),
+    GetMessages(TariAddress, u64, u64),
 }
 
 #[derive(Debug)]
@@ -139,6 +141,8 @@ pub enum ContactsServiceResponse {
     Contact(Contact),
     Contacts(Vec<Contact>),
     OnlineStatus(ContactOnlineStatus),
+    Messages(Vec<Message>),
+    MessageSent,
 }
 
 #[derive(Clone)]
@@ -221,6 +225,33 @@ impl ContactsServiceHandle {
             .await??
         {
             ContactsServiceResponse::OnlineStatus(status) => Ok(status),
+            _ => Err(ContactsServiceError::UnexpectedApiResponse),
+        }
+    }
+
+    pub async fn get_messages(
+        &mut self,
+        pk: TariAddress,
+        x: u64,
+        y: u64,
+    ) -> Result<Vec<Message>, ContactsServiceError> {
+        match self
+            .request_response_service
+            .call(ContactsServiceRequest::GetMessages(pk, x, y))
+            .await??
+        {
+            ContactsServiceResponse::Messages(messages) => Ok(messages),
+            _ => Err(ContactsServiceError::UnexpectedApiResponse),
+        }
+    }
+
+    pub async fn send_message(&mut self, message: Message) -> Result<(), ContactsServiceError> {
+        match self
+            .request_response_service
+            .call(ContactsServiceRequest::SendMessage(message.address.clone(), message))
+            .await??
+        {
+            ContactsServiceResponse::MessageSent => Ok(()),
             _ => Err(ContactsServiceError::UnexpectedApiResponse),
         }
     }

--- a/base_layer/contacts/src/contacts_service/handle.rs
+++ b/base_layer/contacts/src/contacts_service/handle.rs
@@ -131,7 +131,7 @@ pub enum ContactsServiceRequest {
     GetContacts,
     GetContactOnlineStatus(Contact),
     SendMessage(TariAddress, Message),
-    GetMessages(TariAddress, u64, u64),
+    GetAllMessages(TariAddress),
 }
 
 #[derive(Debug)]
@@ -229,15 +229,10 @@ impl ContactsServiceHandle {
         }
     }
 
-    pub async fn get_messages(
-        &mut self,
-        pk: TariAddress,
-        x: u64,
-        y: u64,
-    ) -> Result<Vec<Message>, ContactsServiceError> {
+    pub async fn get_all_messages(&mut self, pk: TariAddress) -> Result<Vec<Message>, ContactsServiceError> {
         match self
             .request_response_service
-            .call(ContactsServiceRequest::GetMessages(pk, x, y))
+            .call(ContactsServiceRequest::GetAllMessages(pk))
             .await??
         {
             ContactsServiceResponse::Messages(messages) => Ok(messages),

--- a/base_layer/contacts/src/contacts_service/proto/mod.rs
+++ b/base_layer/contacts/src/contacts_service/proto/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2019. The Tari Project
+// Copyright 2023. The Tari Project
 //
 // Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
 // following conditions are met:
@@ -20,6 +20,4 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-pub mod database;
-pub mod sqlite_db;
-pub mod types;
+include!(concat!(env!("OUT_DIR"), "/tari.contacts.chat.rs"));

--- a/base_layer/contacts/src/contacts_service/service.rs
+++ b/base_layer/contacts/src/contacts_service/service.rs
@@ -32,12 +32,7 @@ use futures::{pin_mut, StreamExt};
 use log::*;
 use tari_common_types::tari_address::TariAddress;
 use tari_comms::connectivity::{ConnectivityEvent, ConnectivityRequester};
-use tari_comms_dht::{
-    domain_message::OutboundDomainMessage,
-    envelope::NodeDestination,
-    outbound::{DhtOutboundError, OutboundEncryption, SendMessageParams},
-    Dht,
-};
+use tari_comms_dht::{domain_message::OutboundDomainMessage, outbound::OutboundEncryption, Dht};
 use tari_p2p::{
     comms_connector::SubscriptionFactory,
     domain_message::DomainMessage,
@@ -290,19 +285,13 @@ where T: ContactsBackend + 'static
                         let mut comms_outbound = self.dht.outbound_requester();
 
                         comms_outbound
-                            .send_message(
-                                SendMessageParams::new()
-                                    .with_debug_info(format!("Send direct to {}", &address.public_key()))
-                                    .direct_public_key(address.public_key().clone())
-                                    .with_encryption(encryption)
-                                    .with_destination(NodeDestination::from(address.public_key().clone()))
-                                    .finish(),
+                            .send_direct(
+                                address.public_key().clone(),
                                 ob_message,
+                                encryption,
+                                "contact service messaging".to_string(),
                             )
-                            .await?
-                            .resolve()
-                            .await
-                            .map_err(Into::<DhtOutboundError>::into)?;
+                            .await?;
                     },
                     Err(e) => return Err(e),
                     _ => {

--- a/base_layer/contacts/src/contacts_service/service.rs
+++ b/base_layer/contacts/src/contacts_service/service.rs
@@ -285,7 +285,7 @@ where T: ContactsBackend + 'static
                         let mut comms_outbound = self.dht.outbound_requester();
 
                         comms_outbound
-                            .send_direct(
+                            .send_direct_encrypted(
                                 address.public_key().clone(),
                                 ob_message,
                                 encryption,

--- a/base_layer/contacts/src/contacts_service/service.rs
+++ b/base_layer/contacts/src/contacts_service/service.rs
@@ -266,7 +266,7 @@ where T: ContactsBackend + 'static
                 let result = self.get_online_status(&contact).await;
                 Ok(result.map(ContactsServiceResponse::OnlineStatus)?)
             },
-            ContactsServiceRequest::GetMessages(pk, _x, _y) => {
+            ContactsServiceRequest::GetAllMessages(pk) => {
                 let result = self.db.get_messages(pk);
                 Ok(result.map(ContactsServiceResponse::Messages)?)
             },

--- a/base_layer/contacts/src/contacts_service/service.rs
+++ b/base_layer/contacts/src/contacts_service/service.rs
@@ -297,7 +297,7 @@ where T: ContactsBackend + 'static
                     },
                 }
 
-                message.stored_at = Utc::now().naive_utc().timestamp_millis() as u64;
+                message.stored_at = Utc::now().naive_utc().timestamp() as u64;
                 self.db.save_message(message)?;
 
                 Ok(ContactsServiceResponse::MessageSent)
@@ -391,7 +391,7 @@ where T: ContactsBackend + 'static
         let message = Message::from(msg.clone());
         let message = Message {
             address: TariAddress::from_public_key(&source_public_key, message.address.network()),
-            stored_at: Utc::now().naive_utc().timestamp_millis() as u64,
+            stored_at: Utc::now().naive_utc().timestamp() as u64,
             ..msg.into()
         };
 

--- a/base_layer/contacts/src/contacts_service/storage/sqlite_db.rs
+++ b/base_layer/contacts/src/contacts_service/storage/sqlite_db.rs
@@ -22,24 +22,22 @@
 
 use std::{convert::TryFrom, io::Write, sync::Arc};
 
-use chrono::NaiveDateTime;
-use diesel::{prelude::*, result::Error as DieselError, SqliteConnection};
+use diesel::result::Error as DieselError;
 use diesel_migrations::{embed_migrations, EmbeddedMigrations, MigrationHarness};
-use tari_common_sqlite::{
-    error::SqliteStorageError,
-    sqlite_connection_pool::PooledDbConnection,
-    util::diesel_ext::ExpectedRowsExtension,
-};
+use tari_common_sqlite::{error::SqliteStorageError, sqlite_connection_pool::PooledDbConnection};
 use tari_common_types::tari_address::TariAddress;
-use tari_comms::peer_manager::NodeId;
 use tari_utilities::ByteArray;
 
-use crate::{
-    contacts_service::{
-        error::ContactsServiceStorageError,
-        storage::database::{Contact, ContactsBackend, DbKey, DbKeyValuePair, DbValue, WriteOperation},
+use crate::contacts_service::{
+    error::ContactsServiceStorageError,
+    storage::{
+        database::{ContactsBackend, DbKey, DbKeyValuePair, DbValue, WriteOperation},
+        types::{
+            contacts::{ContactSql, UpdateContact},
+            messages::{MessagesSql, MessagesSqlInsert},
+        },
     },
-    schema::contacts,
+    types::{Contact, Message},
 };
 
 const MIGRATIONS: EmbeddedMigrations = embed_migrations!("./migrations");
@@ -106,6 +104,16 @@ where TContactServiceDbConnection: PooledDbConnection<Error = SqliteStorageError
                     .map(|c| Contact::try_from(c.clone()))
                     .collect::<Result<Vec<_>, _>>()?,
             )),
+            DbKey::Messages(address) => match MessagesSql::find_by_address(&address.to_bytes(), &mut conn) {
+                Ok(messages) => Some(DbValue::Messages(
+                    messages
+                        .iter()
+                        .map(|m| Message::try_from(m.clone()).expect("Couldn't cast MessageSql to Message"))
+                        .collect::<Vec<Message>>(),
+                )),
+                Err(ContactsServiceStorageError::DieselError(DieselError::NotFound)) => None,
+                Err(e) => return Err(e),
+            },
         };
 
         Ok(result)
@@ -162,160 +170,17 @@ where TContactServiceDbConnection: PooledDbConnection<Error = SqliteStorageError
                     Err(e) => return Err(e),
                 },
                 DbKey::Contacts => return Err(ContactsServiceStorageError::OperationNotSupported),
+                DbKey::Messages(_pk) => return Err(ContactsServiceStorageError::OperationNotSupported),
+            },
+            WriteOperation::Insert(i) => {
+                if let DbValue::Message(m) = *i {
+                    MessagesSqlInsert::from(*m).commit(&mut conn)?;
+                }
             },
         }
 
         Ok(None)
     }
-}
-
-/// A Sql version of the Contact struct
-#[derive(Clone, Debug, Queryable, Insertable, PartialEq, Eq)]
-#[diesel(table_name = contacts)]
-struct ContactSql {
-    address: Vec<u8>,
-    node_id: Vec<u8>,
-    alias: String,
-    last_seen: Option<NaiveDateTime>,
-    latency: Option<i32>,
-    favourite: i32,
-}
-
-impl ContactSql {
-    /// Write this struct to the database
-    pub fn commit(&self, conn: &mut SqliteConnection) -> Result<(), ContactsServiceStorageError> {
-        diesel::insert_into(contacts::table)
-            .values(self.clone())
-            .execute(conn)?;
-        Ok(())
-    }
-
-    /// Return all contacts
-    pub fn index(conn: &mut SqliteConnection) -> Result<Vec<ContactSql>, ContactsServiceStorageError> {
-        Ok(contacts::table.load::<ContactSql>(conn)?)
-    }
-
-    /// Find a particular Contact by their address, if it exists
-    pub fn find_by_address(
-        address: &[u8],
-        conn: &mut SqliteConnection,
-    ) -> Result<ContactSql, ContactsServiceStorageError> {
-        Ok(contacts::table
-            .filter(contacts::address.eq(address))
-            .first::<ContactSql>(conn)?)
-    }
-
-    /// Find a particular Contact by their node ID, if it exists
-    pub fn find_by_node_id(
-        node_id: &[u8],
-        conn: &mut SqliteConnection,
-    ) -> Result<ContactSql, ContactsServiceStorageError> {
-        Ok(contacts::table
-            .filter(contacts::node_id.eq(node_id))
-            .first::<ContactSql>(conn)?)
-    }
-
-    /// Find a particular Contact by their address, and update it if it exists, returning the affected record
-    pub fn find_by_address_and_update(
-        conn: &mut SqliteConnection,
-        address: &[u8],
-        updated_contact: UpdateContact,
-    ) -> Result<ContactSql, ContactsServiceStorageError> {
-        // Note: `get_result` not implemented for SQLite
-        diesel::update(contacts::table.filter(contacts::address.eq(address)))
-            .set(updated_contact)
-            .execute(conn)
-            .num_rows_affected_or_not_found(1)?;
-        ContactSql::find_by_address(address, conn)
-    }
-
-    /// Find a particular Contact by their address, and delete it if it exists, returning the affected record
-    pub fn find_by_address_and_delete(
-        conn: &mut SqliteConnection,
-        address: &[u8],
-    ) -> Result<ContactSql, ContactsServiceStorageError> {
-        // Note: `get_result` not implemented for SQLite
-        let contact = ContactSql::find_by_address(address, conn)?;
-        if diesel::delete(contacts::table.filter(contacts::address.eq(address))).execute(conn)? == 0 {
-            return Err(ContactsServiceStorageError::ValuesNotFound);
-        }
-        Ok(contact)
-    }
-
-    /// Find a particular Contact by their node ID, and update it if it exists, returning the affected record
-    pub fn find_by_node_id_and_update(
-        conn: &mut SqliteConnection,
-        node_id: &[u8],
-        updated_contact: UpdateContact,
-    ) -> Result<ContactSql, ContactsServiceStorageError> {
-        // Note: `get_result` not implemented for SQLite
-        diesel::update(contacts::table.filter(contacts::node_id.eq(node_id)))
-            .set(updated_contact)
-            .execute(conn)
-            .num_rows_affected_or_not_found(1)?;
-        ContactSql::find_by_node_id(node_id, conn)
-    }
-
-    /// Find a particular Contact by their node ID, and delete it if it exists, returning the affected record
-    pub fn find_by_node_id_and_delete(
-        conn: &mut SqliteConnection,
-        node_id: &[u8],
-    ) -> Result<ContactSql, ContactsServiceStorageError> {
-        // Note: `get_result` not implemented for SQLite
-        let contact = ContactSql::find_by_node_id(node_id, conn)?;
-        if diesel::delete(contacts::table.filter(contacts::node_id.eq(node_id))).execute(conn)? == 0 {
-            return Err(ContactsServiceStorageError::ValuesNotFound);
-        }
-        Ok(contact)
-    }
-}
-
-/// Conversion from an Contact to the Sql datatype form
-impl TryFrom<ContactSql> for Contact {
-    type Error = ContactsServiceStorageError;
-
-    #[allow(clippy::cast_sign_loss)]
-    fn try_from(o: ContactSql) -> Result<Self, Self::Error> {
-        let address = TariAddress::from_bytes(&o.address).map_err(|_| ContactsServiceStorageError::ConversionError)?;
-        Ok(Self {
-            // Public key must always be the master data source for node ID here
-            node_id: NodeId::from_key(address.public_key()),
-            address,
-            alias: o.alias,
-            last_seen: o.last_seen,
-            latency: o.latency.map(|val| val as u32),
-            favourite: match o.favourite {
-                0 => false,
-                1 => true,
-                _ => return Err(ContactsServiceStorageError::ConversionError),
-            },
-        })
-    }
-}
-
-/// Conversion from a Contact to the Sql datatype form
-#[allow(clippy::cast_possible_wrap)]
-impl From<Contact> for ContactSql {
-    fn from(o: Contact) -> Self {
-        Self {
-            // Public key must always be the master data source for node ID here
-            node_id: NodeId::from_key(o.address.public_key()).to_vec(),
-            address: o.address.to_bytes().to_vec(),
-            alias: o.alias,
-            last_seen: o.last_seen,
-            latency: o.latency.map(|val| val as i32),
-            favourite: i32::from(o.favourite),
-        }
-    }
-}
-
-#[derive(AsChangeset)]
-#[diesel(table_name = contacts)]
-pub struct UpdateContact {
-    alias: Option<String>,
-    last_seen: Option<Option<NaiveDateTime>>,
-    latency: Option<Option<i32>>,
-    favourite: Option<i32>,
 }
 
 #[cfg(test)]
@@ -333,9 +198,9 @@ mod test {
     use tari_test_utils::{paths::with_temp_dir, random::string};
 
     use super::*;
-    use crate::contacts_service::storage::{
-        database::Contact,
-        sqlite_db::{ContactSql, UpdateContact},
+    use crate::contacts_service::{
+        storage::types::contacts::{ContactSql, UpdateContact},
+        types::Contact,
     };
 
     #[test]

--- a/base_layer/contacts/src/contacts_service/storage/types/contacts.rs
+++ b/base_layer/contacts/src/contacts_service/storage/types/contacts.rs
@@ -1,0 +1,184 @@
+// Copyright 2023. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::convert::TryFrom;
+
+use chrono::NaiveDateTime;
+use diesel::{prelude::*, SqliteConnection};
+use tari_common_sqlite::util::diesel_ext::ExpectedRowsExtension;
+use tari_common_types::tari_address::TariAddress;
+use tari_comms::peer_manager::NodeId;
+use tari_utilities::ByteArray;
+
+use crate::{
+    contacts_service::{error::ContactsServiceStorageError, types::Contact},
+    schema::contacts,
+};
+
+/// A Sql version of the Contact struct
+#[derive(Clone, Debug, Queryable, Insertable, PartialEq, Eq)]
+#[diesel(table_name = contacts)]
+pub struct ContactSql {
+    pub address: Vec<u8>,
+    node_id: Vec<u8>,
+    pub alias: String,
+    last_seen: Option<NaiveDateTime>,
+    latency: Option<i32>,
+    pub favourite: i32,
+}
+
+impl ContactSql {
+    /// Write this struct to the database
+    pub fn commit(&self, conn: &mut SqliteConnection) -> Result<(), ContactsServiceStorageError> {
+        diesel::insert_into(contacts::table)
+            .values(self.clone())
+            .execute(conn)?;
+        Ok(())
+    }
+
+    /// Return all contacts
+    pub fn index(conn: &mut SqliteConnection) -> Result<Vec<ContactSql>, ContactsServiceStorageError> {
+        Ok(contacts::table.load::<ContactSql>(conn)?)
+    }
+
+    /// Find a particular Contact by their address, if it exists
+    pub fn find_by_address(
+        address: &[u8],
+        conn: &mut SqliteConnection,
+    ) -> Result<ContactSql, ContactsServiceStorageError> {
+        Ok(contacts::table
+            .filter(contacts::address.eq(address))
+            .first::<ContactSql>(conn)?)
+    }
+
+    /// Find a particular Contact by their node ID, if it exists
+    pub fn find_by_node_id(
+        node_id: &[u8],
+        conn: &mut SqliteConnection,
+    ) -> Result<ContactSql, ContactsServiceStorageError> {
+        Ok(contacts::table
+            .filter(contacts::node_id.eq(node_id))
+            .first::<ContactSql>(conn)?)
+    }
+
+    /// Find a particular Contact by their address, and update it if it exists, returning the affected record
+    pub fn find_by_address_and_update(
+        conn: &mut SqliteConnection,
+        address: &[u8],
+        updated_contact: UpdateContact,
+    ) -> Result<ContactSql, ContactsServiceStorageError> {
+        // Note: `get_result` not implemented for SQLite
+        diesel::update(contacts::table.filter(contacts::address.eq(address)))
+            .set(updated_contact)
+            .execute(conn)
+            .num_rows_affected_or_not_found(1)?;
+        ContactSql::find_by_address(address, conn)
+    }
+
+    /// Find a particular Contact by their address, and delete it if it exists, returning the affected record
+    pub fn find_by_address_and_delete(
+        conn: &mut SqliteConnection,
+        address: &[u8],
+    ) -> Result<ContactSql, ContactsServiceStorageError> {
+        // Note: `get_result` not implemented for SQLite
+        let contact = ContactSql::find_by_address(address, conn)?;
+        if diesel::delete(contacts::table.filter(contacts::address.eq(address))).execute(conn)? == 0 {
+            return Err(ContactsServiceStorageError::ValuesNotFound);
+        }
+        Ok(contact)
+    }
+
+    /// Find a particular Contact by their node ID, and update it if it exists, returning the affected record
+    pub fn find_by_node_id_and_update(
+        conn: &mut SqliteConnection,
+        node_id: &[u8],
+        updated_contact: UpdateContact,
+    ) -> Result<ContactSql, ContactsServiceStorageError> {
+        // Note: `get_result` not implemented for SQLite
+        diesel::update(contacts::table.filter(contacts::node_id.eq(node_id)))
+            .set(updated_contact)
+            .execute(conn)
+            .num_rows_affected_or_not_found(1)?;
+        ContactSql::find_by_node_id(node_id, conn)
+    }
+
+    /// Find a particular Contact by their node ID, and delete it if it exists, returning the affected record
+    pub fn find_by_node_id_and_delete(
+        conn: &mut SqliteConnection,
+        node_id: &[u8],
+    ) -> Result<ContactSql, ContactsServiceStorageError> {
+        // Note: `get_result` not implemented for SQLite
+        let contact = ContactSql::find_by_node_id(node_id, conn)?;
+        if diesel::delete(contacts::table.filter(contacts::node_id.eq(node_id))).execute(conn)? == 0 {
+            return Err(ContactsServiceStorageError::ValuesNotFound);
+        }
+        Ok(contact)
+    }
+}
+
+/// Conversion from an Contact to the Sql datatype form
+impl TryFrom<ContactSql> for Contact {
+    type Error = ContactsServiceStorageError;
+
+    #[allow(clippy::cast_sign_loss)]
+    fn try_from(o: ContactSql) -> Result<Self, Self::Error> {
+        let address = TariAddress::from_bytes(&o.address).map_err(|_| ContactsServiceStorageError::ConversionError)?;
+        Ok(Self {
+            // Public key must always be the master data source for node ID here
+            node_id: NodeId::from_key(address.public_key()),
+            address,
+            alias: o.alias,
+            last_seen: o.last_seen,
+            latency: o.latency.map(|val| val as u32),
+            favourite: match o.favourite {
+                0 => false,
+                1 => true,
+                _ => return Err(ContactsServiceStorageError::ConversionError),
+            },
+        })
+    }
+}
+
+/// Conversion from a Contact to the Sql datatype form
+#[allow(clippy::cast_possible_wrap)]
+impl From<Contact> for ContactSql {
+    fn from(o: Contact) -> Self {
+        Self {
+            // Public key must always be the master data source for node ID here
+            node_id: NodeId::from_key(o.address.public_key()).to_vec(),
+            address: o.address.to_bytes().to_vec(),
+            alias: o.alias,
+            last_seen: o.last_seen,
+            latency: o.latency.map(|val| val as i32),
+            favourite: i32::from(o.favourite),
+        }
+    }
+}
+
+#[derive(AsChangeset)]
+#[diesel(table_name = contacts)]
+pub struct UpdateContact {
+    pub alias: Option<String>,
+    pub last_seen: Option<Option<NaiveDateTime>>,
+    pub latency: Option<Option<i32>>,
+    pub favourite: Option<i32>,
+}

--- a/base_layer/contacts/src/contacts_service/storage/types/contacts.rs
+++ b/base_layer/contacts/src/contacts_service/storage/types/contacts.rs
@@ -128,9 +128,9 @@ impl ContactSql {
     ) -> Result<ContactSql, ContactsServiceStorageError> {
         // Note: `get_result` not implemented for SQLite
         let contact = ContactSql::find_by_node_id(node_id, conn)?;
-        if diesel::delete(contacts::table.filter(contacts::node_id.eq(node_id))).execute(conn)? == 0 {
-            return Err(ContactsServiceStorageError::ValuesNotFound);
-        }
+        diesel::delete(contacts::table.filter(contacts::node_id.eq(node_id)))
+            .execute(conn)
+            .num_rows_affected_or_not_found(1)?;
         Ok(contact)
     }
 }

--- a/base_layer/contacts/src/contacts_service/storage/types/messages.rs
+++ b/base_layer/contacts/src/contacts_service/storage/types/messages.rs
@@ -1,0 +1,110 @@
+// Copyright 2023. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::convert::TryFrom;
+
+use chrono::NaiveDateTime;
+use diesel::{prelude::*, SqliteConnection};
+use tari_common_types::tari_address::TariAddress;
+
+use crate::{
+    contacts_service::{
+        error::ContactsServiceStorageError,
+        types::{Direction, Message},
+    },
+    schema::messages,
+};
+
+/// A Sql version of the Contact struct
+#[derive(Clone, Debug, Insertable, PartialEq, Eq)]
+#[diesel(table_name = messages)]
+#[diesel(primary_key(message_id))]
+pub struct MessagesSqlInsert {
+    pub address: Vec<u8>,
+    pub body: Vec<u8>,
+    pub direction: i32,
+    pub stored_at: NaiveDateTime,
+}
+
+#[derive(Clone, Debug, Queryable, PartialEq, Eq, QueryableByName)]
+#[diesel(table_name = messages)]
+#[diesel(primary_key(message_id))]
+pub struct MessagesSql {
+    pub address: Vec<u8>,
+    pub message_id: i64,
+    pub body: Vec<u8>,
+    pub stored_at: NaiveDateTime,
+    pub direction: i32,
+}
+
+impl MessagesSqlInsert {
+    /// Write this struct to the database
+    pub fn commit(&self, conn: &mut SqliteConnection) -> Result<(), ContactsServiceStorageError> {
+        diesel::insert_into(messages::table)
+            .values(self.clone())
+            .execute(conn)?;
+        Ok(())
+    }
+}
+
+impl MessagesSql {
+    /// Find a particular message by their address, if it exists
+    pub fn find_by_address(
+        address: &[u8],
+        conn: &mut SqliteConnection,
+    ) -> Result<Vec<MessagesSql>, ContactsServiceStorageError> {
+        Ok(messages::table
+            .filter(messages::address.eq(address))
+            .load::<MessagesSql>(conn)?)
+    }
+}
+
+/// Conversion from an Message to the Sql datatype form
+impl TryFrom<MessagesSql> for Message {
+    type Error = ContactsServiceStorageError;
+
+    #[allow(clippy::cast_sign_loss)]
+    fn try_from(o: MessagesSql) -> Result<Self, Self::Error> {
+        let address = TariAddress::from_bytes(&o.address).map_err(|_| ContactsServiceStorageError::ConversionError)?;
+        Ok(Self {
+            address,
+            direction: Direction::from_byte(o.direction as u8)
+                .unwrap_or_else(|| panic!("Direction from byte {}", o.direction)),
+            stored_at: o.stored_at.timestamp() as u64,
+            body: o.body,
+            message_id: o.message_id as u64,
+        })
+    }
+}
+
+/// Conversion from a Contact to the Sql datatype form
+#[allow(clippy::cast_possible_wrap)]
+impl From<Message> for MessagesSqlInsert {
+    fn from(o: Message) -> Self {
+        Self {
+            address: o.address.to_bytes().to_vec(),
+            direction: i32::from(o.direction.as_byte()),
+            stored_at: NaiveDateTime::from_timestamp_opt(o.stored_at as i64, 0).unwrap(),
+            body: o.body,
+        }
+    }
+}

--- a/base_layer/contacts/src/contacts_service/storage/types/messages.rs
+++ b/base_layer/contacts/src/contacts_service/storage/types/messages.rs
@@ -43,6 +43,7 @@ pub struct MessagesSqlInsert {
     pub body: Vec<u8>,
     pub direction: i32,
     pub stored_at: NaiveDateTime,
+    pub message_id: Vec<u8>,
 }
 
 #[derive(Clone, Debug, Queryable, PartialEq, Eq, QueryableByName)]
@@ -50,7 +51,7 @@ pub struct MessagesSqlInsert {
 #[diesel(primary_key(message_id))]
 pub struct MessagesSql {
     pub address: Vec<u8>,
-    pub message_id: i64,
+    pub message_id: Vec<u8>,
     pub body: Vec<u8>,
     pub stored_at: NaiveDateTime,
     pub direction: i32,
@@ -91,7 +92,7 @@ impl TryFrom<MessagesSql> for Message {
                 .unwrap_or_else(|| panic!("Direction from byte {}", o.direction)),
             stored_at: o.stored_at.timestamp() as u64,
             body: o.body,
-            message_id: o.message_id as u64,
+            message_id: o.message_id,
         })
     }
 }
@@ -105,6 +106,7 @@ impl From<Message> for MessagesSqlInsert {
             direction: i32::from(o.direction.as_byte()),
             stored_at: NaiveDateTime::from_timestamp_opt(o.stored_at as i64, 0).unwrap(),
             body: o.body,
+            message_id: o.message_id,
         }
     }
 }

--- a/base_layer/contacts/src/contacts_service/storage/types/mod.rs
+++ b/base_layer/contacts/src/contacts_service/storage/types/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2019. The Tari Project
+// Copyright 2023. The Tari Project
 //
 // Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
 // following conditions are met:
@@ -20,6 +20,5 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-pub mod database;
-pub mod sqlite_db;
-pub mod types;
+pub mod contacts;
+pub mod messages;

--- a/base_layer/contacts/src/contacts_service/types/contact.rs
+++ b/base_layer/contacts/src/contacts_service/types/contact.rs
@@ -1,4 +1,4 @@
-// Copyright 2019. The Tari Project
+// Copyright 2023. The Tari Project
 //
 // Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
 // following conditions are met:
@@ -20,6 +20,48 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-pub mod database;
-pub mod sqlite_db;
-pub mod types;
+use chrono::NaiveDateTime;
+use tari_common_types::tari_address::TariAddress;
+use tari_comms::peer_manager::NodeId;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Contact {
+    pub alias: String,
+    pub address: TariAddress,
+    pub node_id: NodeId,
+    pub last_seen: Option<NaiveDateTime>,
+    pub latency: Option<u32>,
+    pub favourite: bool,
+}
+
+impl Contact {
+    pub fn new(
+        alias: String,
+        address: TariAddress,
+        last_seen: Option<NaiveDateTime>,
+        latency: Option<u32>,
+        favourite: bool,
+    ) -> Self {
+        Self {
+            alias,
+            node_id: NodeId::from_key(address.public_key()),
+            address,
+            last_seen,
+            latency,
+            favourite,
+        }
+    }
+}
+
+impl From<&TariAddress> for Contact {
+    fn from(address: &TariAddress) -> Self {
+        Self {
+            alias: address.to_emoji_string(),
+            address: address.clone(),
+            node_id: NodeId::from_key(address.public_key()),
+            last_seen: None,
+            latency: None,
+            favourite: false,
+        }
+    }
+}

--- a/base_layer/contacts/src/contacts_service/types/message.rs
+++ b/base_layer/contacts/src/contacts_service/types/message.rs
@@ -35,7 +35,7 @@ pub struct Message {
     pub address: TariAddress,
     pub direction: Direction,
     pub stored_at: u64,
-    pub message_id: u64,
+    pub message_id: Vec<u8>,
 }
 
 #[repr(u8)]

--- a/base_layer/contacts/src/contacts_service/types/message.rs
+++ b/base_layer/contacts/src/contacts_service/types/message.rs
@@ -1,0 +1,93 @@
+// Copyright 2023. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use num_derive::FromPrimitive;
+use num_traits::FromPrimitive;
+use tari_common_types::tari_address::TariAddress;
+use tari_comms_dht::domain_message::OutboundDomainMessage;
+use tari_p2p::tari_message::TariMessageType;
+use tari_utilities::ByteArray;
+
+use crate::contacts_service::proto;
+
+#[derive(Clone, Debug, Default)]
+pub struct Message {
+    pub body: Vec<u8>,
+    pub address: TariAddress,
+    pub direction: Direction,
+    pub stored_at: u64,
+    pub message_id: u64,
+}
+
+#[repr(u8)]
+#[derive(FromPrimitive, Debug, Copy, Clone)]
+pub enum Direction {
+    Inbound = 0,
+    Outbound = 1,
+}
+
+impl Direction {
+    pub fn as_byte(self) -> u8 {
+        self as u8
+    }
+
+    pub fn from_byte(value: u8) -> Option<Self> {
+        FromPrimitive::from_u8(value)
+    }
+}
+
+impl Default for Direction {
+    fn default() -> Self {
+        Self::Outbound
+    }
+}
+
+impl From<proto::Message> for Message {
+    fn from(message: proto::Message) -> Self {
+        Self {
+            body: message.body,
+            address: TariAddress::from_bytes(&message.address).expect("Couldn't parse address"),
+            // A Message from a proto::Message will always be an inbound message
+            direction: Direction::Inbound,
+            stored_at: message.stored_at,
+            message_id: message.message_id,
+        }
+    }
+}
+
+impl From<Message> for proto::Message {
+    fn from(message: Message) -> Self {
+        Self {
+            body: message.body,
+            address: message.address.to_bytes().to_vec(),
+            direction: i32::from(message.direction.as_byte()),
+            stored_at: message.stored_at,
+            message_id: message.message_id,
+        }
+    }
+}
+
+impl From<Message> for OutboundDomainMessage<proto::Message> {
+    fn from(message: Message) -> Self {
+        Self::new(&TariMessageType::Chat, message.into())
+    }
+}

--- a/base_layer/contacts/src/contacts_service/types/message_builder.rs
+++ b/base_layer/contacts/src/contacts_service/types/message_builder.rs
@@ -21,6 +21,8 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use tari_common_types::tari_address::TariAddress;
+use tari_utilities::ByteArray;
+use uuid::Uuid;
 
 use crate::contacts_service::types::Message;
 
@@ -31,8 +33,13 @@ pub struct MessageBuilder {
 
 impl MessageBuilder {
     pub fn new() -> Self {
+        let message_id = Uuid::new_v4().into_bytes().to_vec();
+
         Self {
-            inner: Message::default(),
+            inner: Message {
+                message_id,
+                ..Message::default()
+            },
         }
     }
 

--- a/base_layer/contacts/src/contacts_service/types/message_builder.rs
+++ b/base_layer/contacts/src/contacts_service/types/message_builder.rs
@@ -1,4 +1,4 @@
-// Copyright 2019. The Tari Project
+// Copyright 2023. The Tari Project
 //
 // Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
 // following conditions are met:
@@ -20,6 +20,42 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-pub mod database;
-pub mod sqlite_db;
-pub mod types;
+use tari_common_types::tari_address::TariAddress;
+
+use crate::contacts_service::types::Message;
+
+#[derive(Clone, Debug, Default)]
+pub struct MessageBuilder {
+    inner: Message,
+}
+
+impl MessageBuilder {
+    pub fn new() -> Self {
+        Self {
+            inner: Message::default(),
+        }
+    }
+
+    pub fn address(&self, address: TariAddress) -> Self {
+        Self {
+            inner: Message {
+                address,
+                ..self.inner.clone()
+            },
+        }
+    }
+
+    pub fn message(&self, body: String) -> Self {
+        let body = body.into_bytes();
+        Self {
+            inner: Message {
+                body,
+                ..self.inner.clone()
+            },
+        }
+    }
+
+    pub fn build(&self) -> Message {
+        self.inner.clone()
+    }
+}

--- a/base_layer/contacts/src/contacts_service/types/mod.rs
+++ b/base_layer/contacts/src/contacts_service/types/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2019. The Tari Project
+// Copyright 2023. The Tari Project
 //
 // Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
 // following conditions are met:
@@ -20,6 +20,11 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-pub mod database;
-pub mod sqlite_db;
-pub mod types;
+mod contact;
+pub use contact::Contact;
+
+mod message;
+pub use message::{Direction, Message};
+
+mod message_builder;
+pub use message_builder::MessageBuilder;

--- a/base_layer/contacts/src/schema.rs
+++ b/base_layer/contacts/src/schema.rs
@@ -14,7 +14,7 @@ diesel::table! {
 diesel::table! {
     messages (message_id) {
         address -> Binary,
-        message_id -> BigInt,
+        message_id -> Binary,
         body -> Binary,
         stored_at -> Timestamp,
         direction -> Integer,

--- a/base_layer/contacts/src/schema.rs
+++ b/base_layer/contacts/src/schema.rs
@@ -10,3 +10,13 @@ diesel::table! {
         favourite -> Integer,
     }
 }
+
+diesel::table! {
+    messages (message_id) {
+        address -> Binary,
+        message_id -> BigInt,
+        body -> Binary,
+        stored_at -> Timestamp,
+        direction -> Integer,
+    }
+}

--- a/base_layer/contacts/tests/contacts_service.rs
+++ b/base_layer/contacts/tests/contacts_service.rs
@@ -32,9 +32,10 @@ use tari_contacts::contacts_service::{
     error::{ContactsServiceError, ContactsServiceStorageError},
     handle::ContactsServiceHandle,
     storage::{
-        database::{Contact, ContactsBackend, DbKey},
+        database::{ContactsBackend, DbKey},
         sqlite_db::ContactsServiceSqliteDatabase,
     },
+    types::Contact,
     ContactsServiceInitializer,
 };
 use tari_crypto::keys::PublicKey as PublicKeyTrait;
@@ -92,7 +93,7 @@ pub fn setup_contacts_service<T: ContactsBackend + 'static>(
         allow_test_addresses: true,
         listener_liveness_allowlist_cidrs: StringList::new(),
         listener_liveness_max_sessions: 0,
-        user_agent: "tari/test-wallet".to_string(),
+        user_agent: "tari/test-contacts-service".to_string(),
         rpc_max_simultaneous_sessions: 0,
         rpc_max_sessions_per_peer: 0,
         listener_liveness_check_interval: None,
@@ -114,9 +115,14 @@ pub fn setup_contacts_service<T: ContactsBackend + 'static>(
                 max_allowed_ping_failures: 0, // Peer with failed ping-pong will never be removed
                 ..Default::default()
             },
-            peer_message_subscription_factory,
+            peer_message_subscription_factory.clone(),
         ))
-        .add_initializer(ContactsServiceInitializer::new(backend, Duration::from_secs(5), 2))
+        .add_initializer(ContactsServiceInitializer::new(
+            backend,
+            peer_message_subscription_factory,
+            Duration::from_secs(5),
+            2,
+        ))
         .build();
 
     let handles = runtime.block_on(fut).expect("Service initialization failed");

--- a/base_layer/core/src/base_node/service/service.rs
+++ b/base_layer/core/src/base_node/service/service.rs
@@ -391,7 +391,7 @@ async fn handle_incoming_request<B: BlockchainBackend + 'static>(
     );
 
     let send_message_response = outbound_message_service
-        .send_direct(
+        .send_direct_unencrypted(
             origin_public_key,
             OutboundDomainMessage::new(&TariMessageType::BaseNodeResponse, message),
             "Outbound response message from base node".to_string(),

--- a/base_layer/core/tests/mempool.rs
+++ b/base_layer/core/tests/mempool.rs
@@ -854,7 +854,7 @@ async fn receive_and_propagate_transaction() {
 
     alice_node
         .outbound_message_service
-        .send_direct(
+        .send_direct_unencrypted(
             bob_node.node_identity.public_key().clone(),
             OutboundDomainMessage::new(
                 &TariMessageType::NewTransaction,
@@ -866,7 +866,7 @@ async fn receive_and_propagate_transaction() {
         .unwrap();
     alice_node
         .outbound_message_service
-        .send_direct(
+        .send_direct_unencrypted(
             carol_node.node_identity.public_key().clone(),
             OutboundDomainMessage::new(
                 &TariMessageType::NewTransaction,

--- a/base_layer/p2p/src/proto/message_type.proto
+++ b/base_layer/p2p/src/proto/message_type.proto
@@ -13,6 +13,7 @@ enum TariMessageType {
     // -- NetMessages --
 
     TariMessageTypePingPong = 1;
+    TariMessageTypeChat = 2;
 
     // -- Blockchain messages --
 

--- a/base_layer/p2p/src/services/liveness/service.rs
+++ b/base_layer/p2p/src/services/liveness/service.rs
@@ -226,7 +226,7 @@ where
     async fn send_pong(&mut self, nonce: u64, dest: CommsPublicKey) -> Result<(), LivenessError> {
         let msg = PingPongMessage::pong_with_metadata(nonce, self.state.metadata().clone());
         self.outbound_messaging
-            .send_direct(
+            .send_direct_unencrypted(
                 dest,
                 OutboundDomainMessage::new(&TariMessageType::PingPong, msg),
                 "Sending pong".to_string(),

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_send_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_send_protocol.rs
@@ -665,7 +665,7 @@ where
         match self
             .resources
             .outbound_message_service
-            .send_direct(
+            .send_direct_unencrypted(
                 self.dest_address.public_key().clone(),
                 OutboundDomainMessage::new(&TariMessageType::SenderPartialTransaction, proto_message.clone()),
                 "transaction send".to_string(),

--- a/base_layer/wallet/src/transaction_service/tasks/send_finalized_transaction.rs
+++ b/base_layer/wallet/src/transaction_service/tasks/send_finalized_transaction.rs
@@ -108,7 +108,7 @@ pub async fn send_finalized_transaction_message_direct(
     let mut store_and_forward_send_result = false;
     let mut direct_send_result = false;
     match outbound_message_service
-        .send_direct(
+        .send_direct_unencrypted(
             destination_public_key.clone(),
             OutboundDomainMessage::new(
                 &TariMessageType::TransactionFinalized,

--- a/base_layer/wallet/src/transaction_service/tasks/send_transaction_cancelled.rs
+++ b/base_layer/wallet/src/transaction_service/tasks/send_transaction_cancelled.rs
@@ -40,7 +40,7 @@ pub async fn send_transaction_cancelled_message(
     // Send both direct and SAF we are not going to monitor the progress on these messages for potential resend as
     // they are just courtesy messages
     let _send_message_response = outbound_message_service
-        .send_direct(
+        .send_direct_unencrypted(
             destination_public_key.clone(),
             OutboundDomainMessage::new(&TariMessageType::TransactionCancelled, proto_message.clone()),
             "transaction cancelled".to_string(),

--- a/base_layer/wallet/src/transaction_service/tasks/send_transaction_reply.rs
+++ b/base_layer/wallet/src/transaction_service/tasks/send_transaction_reply.rs
@@ -96,7 +96,7 @@ pub async fn send_transaction_reply_direct(
         .try_into()
         .map_err(TransactionServiceError::ServiceError)?;
     match outbound_message_service
-        .send_direct(
+        .send_direct_unencrypted(
             inbound_transaction.source_address.public_key().clone(),
             OutboundDomainMessage::new(&TariMessageType::ReceiverPartialTransactionReply, proto_message.clone()),
             "wallet transaction reply".to_string(),

--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -208,10 +208,11 @@ where
                     max_allowed_ping_failures: 0, // Peer with failed ping-pong will never be removed
                     ..Default::default()
                 },
-                peer_message_subscription_factory,
+                peer_message_subscription_factory.clone(),
             ))
             .add_initializer(ContactsServiceInitializer::new(
                 contacts_backend,
+                peer_message_subscription_factory,
                 config.contacts_auto_ping_interval,
                 config.contacts_online_ping_window,
             ))

--- a/base_layer/wallet/tests/wallet.rs
+++ b/base_layer/wallet/tests/wallet.rs
@@ -43,7 +43,8 @@ use tari_comms_dht::{store_forward::SafConfig, DhtConfig};
 use tari_contacts::contacts_service::{
     handle::ContactsLivenessEvent,
     service::ContactMessageType,
-    storage::{database::Contact, sqlite_db::ContactsServiceSqliteDatabase},
+    storage::sqlite_db::ContactsServiceSqliteDatabase,
+    types::Contact,
 };
 use tari_core::{
     consensus::ConsensusManager,

--- a/base_layer/wallet_ffi/src/callback_handler.rs
+++ b/base_layer/wallet_ffi/src/callback_handler.rs
@@ -379,7 +379,7 @@ where TBackend: TransactionBackend + 'static
                                     );
                                     self.trigger_contacts_refresh(data.deref().clone());
                                 }
-                                ContactsLivenessEvent::NetworkSilence => {}
+                                ContactsLivenessEvent::NetworkSilence => {},
                             }
                         }
                         Err(broadcast::error::RecvError::Lagged(n)) => {

--- a/base_layer/wallet_ffi/src/callback_handler_tests.rs
+++ b/base_layer/wallet_ffi/src/callback_handler_tests.rs
@@ -25,7 +25,7 @@ mod test {
     use tari_contacts::contacts_service::{
         handle::{ContactsLivenessData, ContactsLivenessEvent},
         service::{ContactMessageType, ContactOnlineStatus},
-        storage::database::Contact,
+        types::Contact,
     };
     use tari_core::transactions::{
         tari_amount::{uT, MicroTari},

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -100,7 +100,7 @@ use tari_comms::{
     types::CommsPublicKey,
 };
 use tari_comms_dht::{store_forward::SafConfig, DbConnectionUrl, DhtConfig};
-use tari_contacts::contacts_service::storage::database::Contact;
+use tari_contacts::contacts_service::types::Contact;
 use tari_core::{
     borsh::FromBytes,
     consensus::ConsensusManager,
@@ -210,7 +210,7 @@ pub struct TariUnblindedOutputs(Vec<DbUnblindedOutput>);
 
 pub struct TariContacts(Vec<TariContact>);
 
-pub type TariContact = tari_contacts::contacts_service::storage::database::Contact;
+pub type TariContact = tari_contacts::contacts_service::types::Contact;
 pub type TariCompletedTransaction = tari_wallet::transaction_service::storage::models::CompletedTransaction;
 pub type TariTransactionSendStatus = tari_wallet::transaction_service::handle::TransactionSendStatus;
 pub type TariFeePerGramStats = tari_wallet::transaction_service::handle::FeePerGramStatsResponse;

--- a/comms/dht/src/outbound/requester.rs
+++ b/comms/dht/src/outbound/requester.rs
@@ -55,6 +55,33 @@ impl OutboundMessageRequester {
         &mut self,
         dest_public_key: CommsPublicKey,
         message: OutboundDomainMessage<T>,
+        encryption: OutboundEncryption,
+        source_info: String,
+    ) -> Result<MessageSendStates, DhtOutboundError>
+    where
+        T: prost::Message,
+    {
+        self.send_message(
+            SendMessageParams::new()
+                .with_debug_info(format!("Send direct to {} from {}", &dest_public_key, source_info))
+                .direct_public_key(dest_public_key.clone())
+                .with_discovery(true)
+                .with_encryption(encryption)
+                .with_destination(dest_public_key.into())
+                .finish(),
+            message,
+        )
+        .await?
+        .resolve()
+        .await
+        .map_err(Into::into)
+    }
+
+    /// Send directly to a peer unencrypted. If the peer does not exist in the peer list, a discovery will be initiated.
+    pub async fn send_direct_unencrypted<T>(
+        &mut self,
+        dest_public_key: CommsPublicKey,
+        message: OutboundDomainMessage<T>,
         source_info: String,
     ) -> Result<SendMessageResponse, DhtOutboundError>
     where

--- a/comms/dht/src/outbound/requester.rs
+++ b/comms/dht/src/outbound/requester.rs
@@ -51,7 +51,7 @@ impl OutboundMessageRequester {
     }
 
     /// Send directly to a peer. If the peer does not exist in the peer list, a discovery will be initiated.
-    pub async fn send_direct<T>(
+    pub async fn send_direct_encrypted<T>(
         &mut self,
         dest_public_key: CommsPublicKey,
         message: OutboundDomainMessage<T>,

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -11,11 +11,14 @@ tari_app_grpc = { path = "../applications/tari_app_grpc" }
 tari_app_utilities = { path = "../applications/tari_app_utilities" }
 tari_base_node = { path = "../applications/tari_base_node" }
 tari_base_node_grpc_client = { path = "../clients/rust/base_node_grpc_client" }
+tari_chat_client = { path = "tests/utils/chat_client" }
 tari_common = { path = "../common" }
+tari_common_sqlite = { path = "../common_sqlite" }
 tari_common_types = { path = "../base_layer/common_types" }
 tari_comms = { path = "../comms/core" }
 tari_comms_dht = { path = "../comms/dht" }
 tari_console_wallet = { path = "../applications/tari_console_wallet" }
+tari_contacts = { path = "../base_layer/contacts" }
 tari_core = { path = "../base_layer/core" }
 tari_merge_mining_proxy = { path = "../applications/tari_merge_mining_proxy" }
 tari_miner = { path = "../applications/tari_miner" }
@@ -24,8 +27,8 @@ tari_script = { path = "../infrastructure/tari_script" }
 tari_shutdown = { path = "../infrastructure/shutdown" }
 tari_utilities = "0.4.10"
 tari_wallet = { path = "../base_layer/wallet" }
-tari_wallet_grpc_client = { path = "../clients/rust/wallet_grpc_client" }
 tari_wallet_ffi = { path = "../base_layer/wallet_ffi" }
+tari_wallet_grpc_client = { path = "../clients/rust/wallet_grpc_client" }
 
 anyhow = "1.0.53"
 async-trait = "0.1.50"

--- a/integration_tests/log4rs/base_node.yml
+++ b/integration_tests/log4rs/base_node.yml
@@ -109,6 +109,11 @@ loggers:
     level: debug
     appenders:
       - network
+  # Route log events sent to the "contacts" logger to the "network" appender
+  contacts:
+    level: debug
+    appenders:
+      - network
   # Route log events sent to the "p2p" logger to the "network" appender
   p2p:
     level: debug

--- a/integration_tests/log4rs/cucumber.yml
+++ b/integration_tests/log4rs/cucumber.yml
@@ -63,6 +63,21 @@ appenders:
         pattern: "{{log_dir}}/log/wallet.{}.log"
     encoder:
       pattern: "{d(%Y-%m-%d %H:%M:%S.%f)} [{X(grpc)}] {f}.{L} {i} [{t}] {l:5} {m}{n}"
+  base_layer_contacts:
+    kind: rolling_file
+    path: "{{log_dir}}/log/contacts.log"
+    policy:
+      kind: compound
+      trigger:
+        kind: size
+        limit: 100mb
+      roller:
+        kind: fixed_window
+        base: 1
+        count: 10
+        pattern: "{{log_dir}}/log/contacts.{}.log"
+    encoder:
+      pattern: "{d(%Y-%m-%d %H:%M:%S.%f)} [{X(grpc)}] {f}.{L} {i} [{t}] {l:5} {m}{n}"
   # An appender named "other" that writes to a file with a custom pattern encoder
   other:
     kind: rolling_file
@@ -79,6 +94,7 @@ appenders:
         pattern: "{{log_dir}}/log/other.{}.log"
     encoder:
       pattern: "{d(%Y-%m-%d %H:%M:%S.%f)} [{X(grpc)}] {f}.{L} {i} [{t}] {l:5} {m}{n}"
+
 # We don't want prints during cucumber test, everything useful will in logs.
 # root:
 #   level: warn
@@ -114,6 +130,11 @@ loggers:
     level: debug
     appenders:
       - network
+  # Route log events sent to the "contacts" logger to the "network" appender
+  contacts:
+    level: debug
+    appenders:
+      - base_layer_contacts
   # Route log events sent to the "p2p" logger to the "network" appender
   p2p:
     level: debug

--- a/integration_tests/log4rs/wallet.yml
+++ b/integration_tests/log4rs/wallet.yml
@@ -69,6 +69,23 @@ appenders:
     encoder:
       pattern: "{d(%Y-%m-%d %H:%M:%S.%f)} [{t}] {l:5} {m}{n}"
 
+  # An appender named "contacts" that writes to a file with a custom pattern encoder
+  contacts:
+    kind: rolling_file
+    path: "log/wallet/contacts.log"
+    policy:
+      kind: compound
+      trigger:
+        kind: size
+        limit: 10mb
+      roller:
+        kind: fixed_window
+        base: 1
+        count: 5
+        pattern: "log/wallet/contacts.{}.log"
+    encoder:
+      pattern: "{d(%Y-%m-%d %H:%M:%S.%f)} [{t}] [Thread:{I}] {l:5} {m}{n}"
+
 # Set the default logging level to "warn" and attach the "stdout" appender to the root
 root:
   level: warn
@@ -92,6 +109,11 @@ loggers:
     level: debug
     appenders:
       - network
+    additive: false
+  contacts:
+    level: debug
+    appenders:
+      - contacts
     additive: false
   comms::noise:
     level: error

--- a/integration_tests/tests/cucumber.rs
+++ b/integration_tests/tests/cucumber.rs
@@ -4997,7 +4997,12 @@ async fn chat_client_connected_to_base_node(world: &mut TariWorld, name: String,
     let address = Multiaddr::from_str(&format!("/ip4/127.0.0.1/tcp/{}", port)).unwrap();
     let identity = NodeIdentity::random(&mut OsRng, address, PeerFeatures::COMMUNICATION_NODE);
 
-    let mut client = Client::new(identity, vec![base_node.identity.to_peer()], temp_dir_path);
+    let mut client = Client::new(
+        identity,
+        vec![base_node.identity.to_peer()],
+        temp_dir_path,
+        Network::LocalNet,
+    );
     client.initialize().await;
 
     world.chat_clients.insert(name, client);
@@ -5013,7 +5018,7 @@ async fn chat_client_with_no_peers(world: &mut TariWorld, name: String) {
     let address = Multiaddr::from_str(&format!("/ip4/127.0.0.1/tcp/{}", port)).unwrap();
     let identity = NodeIdentity::random(&mut OsRng, address, PeerFeatures::COMMUNICATION_NODE);
 
-    let mut client = Client::new(identity, vec![], temp_dir_path);
+    let mut client = Client::new(identity, vec![], temp_dir_path, Network::LocalNet);
     client.initialize().await;
 
     world.chat_clients.insert(name, client);

--- a/integration_tests/tests/cucumber.rs
+++ b/integration_tests/tests/cucumber.rs
@@ -5058,8 +5058,8 @@ async fn receive_n_messages(world: &mut TariWorld, receiver: String, message_cou
     )
 }
 
-#[when(expr = "I add {word} as a contact to {word}")]
-async fn add_as_contact(world: &mut TariWorld, receiver: String, sender: String) {
+#[when(expr = "{word} adds {word} as a contact")]
+async fn add_as_contact(world: &mut TariWorld, sender: String, receiver: String) {
     let receiver: &Client = world.chat_clients.get(&receiver).unwrap();
     let sender: &Client = world.chat_clients.get(&sender).unwrap();
 

--- a/integration_tests/tests/features/Chat.feature
+++ b/integration_tests/tests/features/Chat.feature
@@ -7,9 +7,7 @@ Feature: Chat messaging
     Given I have a seed node SEED_A
     When I have a chat client CHAT_A connected to seed node SEED_A
     When I have a chat client CHAT_B connected to seed node SEED_A
-    When I wait 5 seconds
     When I use CHAT_A to send a message 'Hey there' to CHAT_B
-    When I wait 5 seconds
     Then CHAT_B will have 1 message with CHAT_A
 
   Scenario: A message is sent directly between nodes
@@ -17,9 +15,8 @@ Feature: Chat messaging
     When I have a chat client CHAT_A connected to seed node SEED_A
     When I have a chat client CHAT_B connected to seed node SEED_A
     When I add CHAT_B as a contact to CHAT_A
-    When I wait 5 seconds
+    When CHAT_A waits for contact CHAT_B to be online
     When I use CHAT_A to send a message 'Hey there' to CHAT_B
-    When I wait 5 seconds
     Then CHAT_B will have 1 message with CHAT_A
 
   Scenario: Message counts are distinct
@@ -27,14 +24,16 @@ Feature: Chat messaging
     When I have a chat client CHAT_A connected to seed node SEED_A
     When I have a chat client CHAT_B connected to seed node SEED_A
     When I have a chat client CHAT_C connected to seed node SEED_A
-    When I wait 5 seconds
-    When I use CHAT_A to send a message 'Message 1ab' to CHAT_B
-    When I use CHAT_A to send a message 'Message 2ab' to CHAT_B
-    When I use CHAT_C to send a message 'Message 1cb' to CHAT_B
-    When I use CHAT_A to send a message 'Message 1ac' to CHAT_C
-    When I use CHAT_B to send a message 'Message 1bc' to CHAT_C
-    When I use CHAT_B to send a message 'Message 2bc' to CHAT_C
-    When I wait 5 seconds
+
+    When I use CHAT_A to send a message 'Message 1 from a to b' to CHAT_B
+    When I use CHAT_A to send a message 'Message 2 from a to b' to CHAT_B
+    When I use CHAT_A to send a message 'Message 1 from a to c' to CHAT_C
+
+    When I use CHAT_B to send a message 'Message 1 from b to c' to CHAT_C
+    When I use CHAT_B to send a message 'Message 2 from b to c' to CHAT_C
+
+    When I use CHAT_C to send a message 'Message 1 from c to b' to CHAT_B
+
     Then CHAT_B will have 2 messages with CHAT_A
     Then CHAT_B will have 3 messages with CHAT_C
     Then CHAT_C will have 1 messages with CHAT_A

--- a/integration_tests/tests/features/Chat.feature
+++ b/integration_tests/tests/features/Chat.feature
@@ -3,7 +3,7 @@
 
 Feature: Chat messaging
 
-  Scenario: A message is propagated between nodes
+  Scenario: A message is propagated between nodes via 3rd party
     Given I have a seed node SEED_A
     When I have a chat client CHAT_A connected to seed node SEED_A
     When I have a chat client CHAT_B connected to seed node SEED_A
@@ -14,7 +14,8 @@ Feature: Chat messaging
     Given I have a seed node SEED_A
     When I have a chat client CHAT_A connected to seed node SEED_A
     When I have a chat client CHAT_B connected to seed node SEED_A
-    When I add CHAT_B as a contact to CHAT_A
+    When CHAT_A adds CHAT_B as a contact
+    When I stop node SEED_A
     When CHAT_A waits for contact CHAT_B to be online
     When I use CHAT_A to send a message 'Hey there' to CHAT_B
     Then CHAT_B will have 1 message with CHAT_A
@@ -24,6 +25,12 @@ Feature: Chat messaging
     When I have a chat client CHAT_A connected to seed node SEED_A
     When I have a chat client CHAT_B connected to seed node SEED_A
     When I have a chat client CHAT_C connected to seed node SEED_A
+
+    When CHAT_A adds CHAT_B as a contact
+    When CHAT_A adds CHAT_C as a contact
+    When CHAT_B adds CHAT_C as a contact
+    When CHAT_C adds CHAT_B as a contact
+    When I stop node SEED_A
 
     When I use CHAT_A to send a message 'Message 1 from a to b' to CHAT_B
     When I use CHAT_A to send a message 'Message 2 from a to b' to CHAT_B

--- a/integration_tests/tests/features/Chat.feature
+++ b/integration_tests/tests/features/Chat.feature
@@ -1,0 +1,44 @@
+# Copyright 2023 The Tari Project
+# SPDX-License-Identifier: BSD-3-Clause
+
+Feature: Chat messaging
+
+  Scenario: A message is propagated between nodes
+    Given I have a seed node SEED_A
+    When I have a chat client CHAT_A connected to seed node SEED_A
+    When I have a chat client CHAT_B connected to seed node SEED_A
+    When I wait 5 seconds
+    When I use CHAT_A to send a message 'Hey there' to CHAT_B
+    When I wait 5 seconds
+    Then CHAT_B will have 1 message with CHAT_A
+
+  Scenario: A message is sent directly between nodes
+    Given I have a seed node SEED_A
+    When I have a chat client CHAT_A connected to seed node SEED_A
+    When I have a chat client CHAT_B connected to seed node SEED_A
+    When I add CHAT_B as a contact to CHAT_A
+    When I wait 5 seconds
+    When I use CHAT_A to send a message 'Hey there' to CHAT_B
+    When I wait 5 seconds
+    Then CHAT_B will have 1 message with CHAT_A
+
+  Scenario: Message counts are distinct
+    Given I have a seed node SEED_A
+    When I have a chat client CHAT_A connected to seed node SEED_A
+    When I have a chat client CHAT_B connected to seed node SEED_A
+    When I have a chat client CHAT_C connected to seed node SEED_A
+    When I wait 5 seconds
+    When I use CHAT_A to send a message 'Message 1ab' to CHAT_B
+    When I use CHAT_A to send a message 'Message 2ab' to CHAT_B
+    When I use CHAT_C to send a message 'Message 1cb' to CHAT_B
+    When I use CHAT_A to send a message 'Message 1ac' to CHAT_C
+    When I use CHAT_B to send a message 'Message 1bc' to CHAT_C
+    When I use CHAT_B to send a message 'Message 2bc' to CHAT_C
+    When I wait 5 seconds
+    Then CHAT_B will have 2 messages with CHAT_A
+    Then CHAT_B will have 3 messages with CHAT_C
+    Then CHAT_C will have 1 messages with CHAT_A
+    Then CHAT_C will have 3 messages with CHAT_B
+    Then CHAT_A will have 2 messages with CHAT_B
+    Then CHAT_A will have 1 messages with CHAT_C
+

--- a/integration_tests/tests/utils/base_node_process.rs
+++ b/integration_tests/tests/utils/base_node_process.rs
@@ -46,6 +46,7 @@ use crate::{
     TariWorld,
 };
 
+#[derive(Clone)]
 pub struct BaseNodeProcess {
     pub name: String,
     pub port: u64,
@@ -180,11 +181,7 @@ pub async fn spawn_base_node_with_config(
             .tcp
             .listener_address
             .clone()]);
-        // base_node_config.base_node.p2p.datastore_path = temp_dir_path.to_path_buf();
-        // base_node_config.base_node.p2p.peer_database_name = "peer_db.mdb".to_string();
         base_node_config.base_node.p2p.dht = DhtConfig::default_local_test();
-        // base_node_config.base_node.p2p.dht.database_url =
-        //     DbConnectionUrl::File(temp_dir_path.clone().join("dht.sqlite"));
         base_node_config.base_node.p2p.dht.network_discovery.enabled = true;
         base_node_config.base_node.p2p.allow_test_addresses = true;
         base_node_config.base_node.storage.orphan_storage_capacity = 10;

--- a/integration_tests/tests/utils/chat_client/Cargo.toml
+++ b/integration_tests/tests/utils/chat_client/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "tari_chat_client"
+authors = ["The Tari Development Community"]
+description = "Tari cucumber chat client"
+license = "BSD-3-Clause"
+version = "0.48.0-pre.1"
+edition = "2018"
+
+[dependencies]
+tari_common_types = { path = "../../../../base_layer/common_types" }
+tari_common_sqlite = { path = "../../../../common_sqlite" }
+tari_comms = { path = "../../../../comms/core" }
+tari_comms_dht = { path = "../../../../comms/dht" }
+tari_contacts = { path = "../../../../base_layer/contacts" }
+tari_p2p = { path = "../../../../base_layer/p2p" }
+tari_service_framework= { path = "../../../../base_layer/service_framework" }
+tari_shutdown = { path = "../../../../infrastructure/shutdown" }
+tari_test_utils = { path = "../../../../infrastructure/test_utils" }
+tari_storage = { path = "../../../../infrastructure/storage" }
+
+anyhow = "1.0.41"
+diesel = { version = "2.0.3", features = ["sqlite", "r2d2", "serde_json", "chrono", "64-column-tables"] }
+lmdb-zero = "0.4.4"

--- a/integration_tests/tests/utils/chat_client/Cargo.toml
+++ b/integration_tests/tests/utils/chat_client/Cargo.toml
@@ -7,16 +7,17 @@ version = "0.48.0-pre.1"
 edition = "2018"
 
 [dependencies]
-tari_common_types = { path = "../../../../base_layer/common_types" }
+tari_common = { path = "../../../../common" }
 tari_common_sqlite = { path = "../../../../common_sqlite" }
+tari_common_types = { path = "../../../../base_layer/common_types" }
 tari_comms = { path = "../../../../comms/core" }
 tari_comms_dht = { path = "../../../../comms/dht" }
 tari_contacts = { path = "../../../../base_layer/contacts" }
 tari_p2p = { path = "../../../../base_layer/p2p" }
 tari_service_framework= { path = "../../../../base_layer/service_framework" }
 tari_shutdown = { path = "../../../../infrastructure/shutdown" }
-tari_test_utils = { path = "../../../../infrastructure/test_utils" }
 tari_storage = { path = "../../../../infrastructure/storage" }
+tari_test_utils = { path = "../../../../infrastructure/test_utils" }
 
 anyhow = "1.0.41"
 diesel = { version = "2.0.3", features = ["sqlite", "r2d2", "serde_json", "chrono", "64-column-tables"] }

--- a/integration_tests/tests/utils/chat_client/src/client.rs
+++ b/integration_tests/tests/utils/chat_client/src/client.rs
@@ -1,0 +1,149 @@
+//   Copyright 2023. The Tari Project
+//
+//   Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//   following conditions are met:
+//
+//   1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//   disclaimer.
+//
+//   2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//   following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//   3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//   products derived from this software without specific prior written permission.
+//
+//   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//   SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::{
+    fmt::{Debug, Formatter},
+    path::PathBuf,
+    sync::Arc,
+    time::Duration,
+};
+
+use tari_common_types::tari_address::TariAddress;
+use tari_comms::{peer_manager::Peer, CommsNode, NodeIdentity};
+use tari_contacts::contacts_service::{
+    handle::ContactsServiceHandle,
+    types::{Message, MessageBuilder},
+};
+use tari_shutdown::Shutdown;
+
+use crate::{database, networking};
+
+#[derive(Clone)]
+pub struct Client {
+    pub identity: Arc<NodeIdentity>,
+    pub base_dir: PathBuf,
+    pub seed_peers: Vec<Peer>,
+    pub shutdown: Shutdown,
+    pub contacts: Option<ContactsServiceHandle>,
+}
+
+impl Debug for Client {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Client")
+            .field("identity", &self.identity)
+            .field("base_dir", &self.base_dir)
+            .field("seed_peers", &self.seed_peers)
+            .field("shutdown", &self.shutdown)
+            .finish()
+    }
+}
+
+impl Drop for Client {
+    fn drop(&mut self) {
+        self.quit();
+    }
+}
+
+impl Client {
+    pub fn new(identity: NodeIdentity, seed_peers: Vec<Peer>, base_dir: PathBuf) -> Self {
+        Self {
+            identity: Arc::new(identity),
+            base_dir,
+            seed_peers,
+            shutdown: Shutdown::new(),
+            contacts: None,
+        }
+    }
+
+    pub async fn add_contact(&self, address: &TariAddress) {
+        if let Some(mut contacts_service) = self.contacts.clone() {
+            contacts_service
+                .upsert_contact(address.into())
+                .await
+                .expect("Contact wasn't added");
+        }
+    }
+
+    pub async fn send_message(&self, receiver: TariAddress, message: String) {
+        if let Some(mut contacts_service) = self.contacts.clone() {
+            contacts_service
+                .send_message(MessageBuilder::new().message(message).address(receiver).build())
+                .await
+                .expect("Message wasn't sent");
+        }
+    }
+
+    pub async fn get_messages(&self, sender: TariAddress) -> Vec<Message> {
+        let mut messages = vec![];
+        if let Some(mut contacts_service) = self.contacts.clone() {
+            messages = contacts_service
+                .get_messages(sender, 0, 0)
+                .await
+                .expect("Messages not fetched");
+        }
+
+        messages
+    }
+
+    pub async fn initialize(&mut self) {
+        println!("initializing chat");
+
+        let signal = self.shutdown.to_signal();
+        let db = database::create_chat_storage(self.base_dir.clone()).unwrap();
+
+        let (contacts, comms_node) = networking::start(
+            self.identity.clone(),
+            self.base_dir.clone(),
+            self.seed_peers.clone(),
+            db,
+            signal,
+        )
+        .await
+        .unwrap();
+
+        if !self.seed_peers.is_empty() {
+            loop {
+                println!("Waiting for peer connections...");
+                match wait_for_connectivity(comms_node.clone()).await {
+                    Ok(_) => break,
+                    Err(e) => println!("{}. Still waiting...", e),
+                }
+            }
+        }
+
+        self.contacts = Some(contacts);
+
+        println!("Connections established")
+    }
+
+    pub fn quit(&mut self) {
+        self.shutdown.trigger();
+    }
+}
+
+pub async fn wait_for_connectivity(comms: CommsNode) -> anyhow::Result<()> {
+    comms
+        .connectivity()
+        .wait_for_connectivity(Duration::from_secs(30))
+        .await?;
+    Ok(())
+}

--- a/integration_tests/tests/utils/chat_client/src/client.rs
+++ b/integration_tests/tests/utils/chat_client/src/client.rs
@@ -117,7 +117,7 @@ impl Client {
         let mut messages = vec![];
         if let Some(mut contacts_service) = self.contacts.clone() {
             messages = contacts_service
-                .get_messages(sender.clone(), 0, 0)
+                .get_all_messages(sender.clone())
                 .await
                 .expect("Messages not fetched");
         }

--- a/integration_tests/tests/utils/chat_client/src/client.rs
+++ b/integration_tests/tests/utils/chat_client/src/client.rs
@@ -34,24 +34,27 @@ use tari_contacts::contacts_service::{
     service::ContactOnlineStatus,
     types::{Message, MessageBuilder},
 };
+use tari_p2p::Network;
 use tari_shutdown::Shutdown;
 
 use crate::{database, networking};
 
 #[derive(Clone)]
 pub struct Client {
-    pub identity: Arc<NodeIdentity>,
     pub base_dir: PathBuf,
+    pub contacts: Option<ContactsServiceHandle>,
+    pub identity: Arc<NodeIdentity>,
+    pub network: Network,
     pub seed_peers: Vec<Peer>,
     pub shutdown: Shutdown,
-    pub contacts: Option<ContactsServiceHandle>,
 }
 
 impl Debug for Client {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Client")
-            .field("identity", &self.identity)
             .field("base_dir", &self.base_dir)
+            .field("identity", &self.identity)
+            .field("network", &self.network)
             .field("seed_peers", &self.seed_peers)
             .field("shutdown", &self.shutdown)
             .finish()
@@ -65,13 +68,14 @@ impl Drop for Client {
 }
 
 impl Client {
-    pub fn new(identity: NodeIdentity, seed_peers: Vec<Peer>, base_dir: PathBuf) -> Self {
+    pub fn new(identity: NodeIdentity, seed_peers: Vec<Peer>, base_dir: PathBuf, network: Network) -> Self {
         Self {
             identity: Arc::new(identity),
             base_dir,
             seed_peers,
             shutdown: Shutdown::new(),
             contacts: None,
+            network,
         }
     }
 
@@ -131,6 +135,7 @@ impl Client {
             self.identity.clone(),
             self.base_dir.clone(),
             self.seed_peers.clone(),
+            self.network,
             db,
             signal,
         )

--- a/integration_tests/tests/utils/chat_client/src/database.rs
+++ b/integration_tests/tests/utils/chat_client/src/database.rs
@@ -1,0 +1,55 @@
+//   Copyright 2023. The Tari Project
+//
+//   Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//   following conditions are met:
+//
+//   1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//   disclaimer.
+//
+//   2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//   following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//   3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//   products derived from this software without specific prior written permission.
+//
+//   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//   SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::{convert::TryInto, path::PathBuf};
+
+use diesel::{Connection, SqliteConnection};
+use tari_common_sqlite::{
+    connection::{DbConnection, DbConnectionUrl},
+    error::StorageError,
+};
+use tari_storage::lmdb_store::{LMDBBuilder, LMDBConfig};
+use tari_test_utils::random::string;
+
+pub fn create_chat_storage(base_path: PathBuf) -> Result<DbConnection, StorageError> {
+    std::fs::create_dir_all(&base_path).unwrap();
+    let db_name = format!("{}.sqlite3", string(8).as_str());
+    let db_path = format!("{}/{}", base_path.to_str().unwrap(), db_name);
+    let url: DbConnectionUrl = db_path.clone().try_into().unwrap();
+
+    // Create the db
+    let _db = SqliteConnection::establish(&db_path).unwrap_or_else(|_| panic!("Error connecting to {}", db_path));
+
+    DbConnection::connect_url(&url)
+}
+
+pub fn create_peer_storage(base_path: PathBuf) {
+    std::fs::create_dir_all(&base_path).unwrap();
+
+    LMDBBuilder::new()
+        .set_path(&base_path)
+        .set_env_config(LMDBConfig::default())
+        .set_max_number_of_databases(1)
+        .add_database("peerdb", lmdb_zero::db::CREATE)
+        .build()
+        .unwrap();
+}

--- a/integration_tests/tests/utils/chat_client/src/lib.rs
+++ b/integration_tests/tests/utils/chat_client/src/lib.rs
@@ -1,0 +1,27 @@
+//   Copyright 2023. The Tari Project
+//
+//   Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//   following conditions are met:
+//
+//   1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//   disclaimer.
+//
+//   2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//   following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//   3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//   products derived from this software without specific prior written permission.
+//
+//   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//   SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+mod client;
+pub use client::Client;
+
+pub mod database;
+pub mod networking;

--- a/integration_tests/tests/utils/chat_client/src/networking.rs
+++ b/integration_tests/tests/utils/chat_client/src/networking.rs
@@ -29,7 +29,7 @@ pub use tari_comms::{
     peer_manager::{NodeIdentity, PeerFeatures},
 };
 use tari_comms::{peer_manager::Peer, CommsNode, UnspawnedCommsNode};
-use tari_comms_dht::{DhtConfig, NetworkDiscoveryConfig};
+use tari_comms_dht::{store_forward::SafConfig, DhtConfig, NetworkDiscoveryConfig};
 use tari_contacts::contacts_service::{
     handle::ContactsServiceHandle,
     storage::sqlite_db::ContactsServiceSqliteDatabase,
@@ -76,12 +76,16 @@ pub async fn start(
                 enabled: true,
                 ..NetworkDiscoveryConfig::default()
             },
+            saf: SafConfig {
+                auto_request: true,
+                ..Default::default()
+            },
             ..DhtConfig::default_local_test()
         },
         transport: transport_config.clone(),
         allow_test_addresses: true,
         public_addresses: vec![node_identity.first_public_address()],
-        user_agent: format!("tari/chat-client/0.0.1"),
+        user_agent: "tari/chat-client/0.0.1".to_string(),
         ..P2pConfig::default()
     };
     config.set_base_path(base_path.clone());

--- a/integration_tests/tests/utils/chat_client/src/networking.rs
+++ b/integration_tests/tests/utils/chat_client/src/networking.rs
@@ -1,0 +1,138 @@
+//   Copyright 2023. The Tari Project
+//
+//   Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//   following conditions are met:
+//
+//   1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//   disclaimer.
+//
+//   2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//   following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//   3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//   products derived from this software without specific prior written permission.
+//
+//   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//   SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::{path::PathBuf, sync::Arc, time::Duration};
+
+use tari_common_sqlite::connection::DbConnection;
+// Re-exports
+pub use tari_comms::{
+    multiaddr::Multiaddr,
+    peer_manager::{NodeIdentity, PeerFeatures},
+};
+use tari_comms::{peer_manager::Peer, CommsNode, UnspawnedCommsNode};
+use tari_comms_dht::{DhtConfig, NetworkDiscoveryConfig};
+use tari_contacts::contacts_service::{
+    handle::ContactsServiceHandle,
+    storage::sqlite_db::ContactsServiceSqliteDatabase,
+    ContactsServiceInitializer,
+};
+use tari_p2p::{
+    comms_connector::pubsub_connector,
+    initialization::{spawn_comms_using_transport, P2pInitializer},
+    services::liveness::{LivenessConfig, LivenessInitializer},
+    Network,
+    P2pConfig,
+    PeerSeedsConfig,
+    TcpTransportConfig,
+    TransportConfig,
+};
+use tari_service_framework::StackBuilder;
+use tari_shutdown::ShutdownSignal;
+
+use crate::database;
+
+pub async fn start(
+    node_identity: Arc<NodeIdentity>,
+    base_path: PathBuf,
+    seed_peers: Vec<Peer>,
+    db: DbConnection,
+    shutdown_signal: ShutdownSignal,
+) -> anyhow::Result<(ContactsServiceHandle, CommsNode)> {
+    database::create_peer_storage(base_path.clone());
+    let backend = ContactsServiceSqliteDatabase::init(db);
+
+    let (publisher, subscription_factory) = pubsub_connector(100, 50);
+    let in_msg = Arc::new(subscription_factory);
+
+    let transport_config = TransportConfig::new_tcp(TcpTransportConfig {
+        listener_address: node_identity.first_public_address(),
+        ..TcpTransportConfig::default()
+    });
+
+    let mut config = P2pConfig {
+        datastore_path: base_path.clone(),
+        dht: DhtConfig {
+            network_discovery: NetworkDiscoveryConfig {
+                enabled: true,
+                ..NetworkDiscoveryConfig::default()
+            },
+            ..DhtConfig::default_local_test()
+        },
+        transport: transport_config.clone(),
+        allow_test_addresses: true,
+        public_addresses: vec![node_identity.first_public_address()],
+        ..P2pConfig::default()
+    };
+    config.set_base_path(base_path.clone());
+
+    let seed_config = PeerSeedsConfig {
+        peer_seeds: seed_peers
+            .iter()
+            .map(|p| format!("{}::{}", p.public_key, p.addresses.best().unwrap().address()))
+            .collect::<Vec<String>>()
+            .into(),
+        ..PeerSeedsConfig::default()
+    };
+
+    let fut = StackBuilder::new(shutdown_signal)
+        .add_initializer(P2pInitializer::new(
+            config,
+            seed_config,
+            Network::LocalNet,
+            node_identity,
+            publisher,
+        ))
+        .add_initializer(LivenessInitializer::new(
+            LivenessConfig {
+                auto_ping_interval: Some(Duration::from_secs(1)),
+                num_peers_per_round: 0,       // No random peers
+                max_allowed_ping_failures: 0, // Peer with failed ping-pong will never be removed
+                ..Default::default()
+            },
+            in_msg.clone(),
+        ))
+        .add_initializer(ContactsServiceInitializer::new(
+            backend,
+            in_msg,
+            Duration::from_secs(5),
+            2,
+        ))
+        .build();
+
+    let mut handles = fut.await.expect("Service initialization failed");
+
+    let comms = handles
+        .take_handle::<UnspawnedCommsNode>()
+        .expect("P2pInitializer was not added to the stack or did not add UnspawnedCommsNode");
+
+    let peer_manager = comms.peer_manager();
+    for peer in seed_peers {
+        peer_manager.add_peer(peer).await?;
+    }
+
+    let comms = spawn_comms_using_transport(comms, transport_config).await.unwrap();
+    handles.register(comms);
+
+    let comms = handles.expect_handle::<CommsNode>();
+    let contacts = handles.expect_handle::<ContactsServiceHandle>();
+    Ok((contacts, comms))
+}

--- a/integration_tests/tests/utils/chat_client/src/networking.rs
+++ b/integration_tests/tests/utils/chat_client/src/networking.rs
@@ -54,6 +54,7 @@ pub async fn start(
     node_identity: Arc<NodeIdentity>,
     base_path: PathBuf,
     seed_peers: Vec<Peer>,
+    network: Network,
     db: DbConnection,
     shutdown_signal: ShutdownSignal,
 ) -> anyhow::Result<(ContactsServiceHandle, CommsNode)> {
@@ -97,7 +98,7 @@ pub async fn start(
         .add_initializer(P2pInitializer::new(
             config,
             seed_config,
-            Network::LocalNet,
+            network,
             node_identity,
             publisher,
         ))

--- a/integration_tests/tests/utils/chat_client/src/networking.rs
+++ b/integration_tests/tests/utils/chat_client/src/networking.rs
@@ -81,6 +81,7 @@ pub async fn start(
         transport: transport_config.clone(),
         allow_test_addresses: true,
         public_addresses: vec![node_identity.first_public_address()],
+        user_agent: format!("tari/chat-client/0.0.1"),
         ..P2pConfig::default()
     };
     config.set_base_path(base_path.clone());

--- a/integration_tests/tests/utils/chat_client/src/networking.rs
+++ b/integration_tests/tests/utils/chat_client/src/networking.rs
@@ -22,6 +22,7 @@
 
 use std::{path::PathBuf, sync::Arc, time::Duration};
 
+use tari_common::configuration::MultiaddrList;
 use tari_common_sqlite::connection::DbConnection;
 // Re-exports
 pub use tari_comms::{
@@ -84,7 +85,7 @@ pub async fn start(
         },
         transport: transport_config.clone(),
         allow_test_addresses: true,
-        public_addresses: vec![node_identity.first_public_address()],
+        public_addresses: MultiaddrList::from(vec![node_identity.first_public_address()]),
         user_agent: "tari/chat-client/0.0.1".to_string(),
         ..P2pConfig::default()
     };


### PR DESCRIPTION
Description
---
- Refactor the contacts crate for better organization.
- Expand contacts with types, and capabilities for managing messaging over the existing comms network
- Add cucumber tests to provide support for new functionality

Motivation and Context
---
We want to expand Tari's communication network to handle p2p chat services. This PR sets us off in the right direction for the core Tari processes to be able to handle message passing and storage. Currently chat clients will be able to send, and receive messages when online or offline. Utilizing store and forward for sending communications offline.

How Has This Been Tested?
---
Via cucumber only. The chat client within cucumber is currently the only interface for trials.

Caveats and known issues
---
- [ ] Encryption at rest: We need to change the message storage to support encryption at rest
