### PR TITLE
fix(wallet)!: ensure burn shared keys and hashes match dan layer

### DIFF
--- a/base_layer/wallet/src/types.rs
+++ b/base_layer/wallet/src/types.rs
@@ -21,7 +21,8 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use tari_common_types::types::PublicKey;
-use tari_crypto::{hash::blake2::Blake256, hasher};
+use tari_core::consensus::DomainSeparatedConsensusHasher;
+use tari_crypto::{hash::blake2::Blake256, hash_domain, hasher};
 
 use crate::error::WalletError;
 
@@ -34,11 +35,10 @@ pub(crate) trait PersistentKeyManager {
 
 hasher!(Blake256, WalletHasher, "com.tari.base_layer.wallet", 1, wallet_hasher);
 
-// Hasher used in the DAN to derive masks and encrypted value keys
-hasher!(
-    Blake256,
-    ConfidentialOutputHasher,
+hash_domain!(
+    ConfidentialOutputHashDomain,
     "com.tari.layer_two.confidential_output",
-    1,
-    confidentia_output_hasher
+    1
 );
+/// Hasher used in the DAN to derive masks and encrypted value keys
+pub type ConfidentialOutputHasher = DomainSeparatedConsensusHasher<ConfidentialOutputHashDomain>;

--- a/base_layer/wallet/src/util/burn_proof.rs
+++ b/base_layer/wallet/src/util/burn_proof.rs
@@ -20,7 +20,7 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use tari_common_types::types::{PrivateKey, PublicKey};
+use tari_common_types::types::{Commitment, PrivateKey, PublicKey};
 use tari_comms::types::CommsDHKE;
 use tari_utilities::ByteArray;
 
@@ -31,19 +31,18 @@ pub fn derive_diffie_hellman_burn_claim_spend_key(
     private_key: &PrivateKey,
     claim_public_key: &PublicKey,
 ) -> PrivateKey {
-    let hash = ConfidentialOutputHasher::new_with_label("spend_key")
-        .chain(CommsDHKE::new(private_key, claim_public_key).as_bytes())
+    let private_key = PrivateKey::from_bytes(CommsDHKE::new(private_key, claim_public_key).as_bytes()).unwrap();
+    let hash = ConfidentialOutputHasher::new("spend_key")
+        .chain(&private_key)
         .finalize();
     PrivateKey::from_bytes(hash.as_ref()).expect("'DomainSeparatedHash<Blake256>' has correct size")
 }
 
 /// Derives a shared DH value encryption key for a burnt output using a claim public key
-pub fn derive_diffie_hellman_burn_claim_encryption_key(
-    private_key: &PrivateKey,
-    claim_public_key: &PublicKey,
-) -> PrivateKey {
-    let hash = ConfidentialOutputHasher::new_with_label("encryption_key")
-        .chain(CommsDHKE::new(private_key, claim_public_key).as_bytes())
+pub fn derive_burn_claim_encryption_key(private_key: &PrivateKey, commitment: &Commitment) -> PrivateKey {
+    let hash = ConfidentialOutputHasher::new("encryption_key")
+        .chain(private_key)
+        .chain(commitment)
         .finalize();
     PrivateKey::from_bytes(hash.as_ref()).expect("'DomainSeparatedHash<Blake256>' has correct size")
 }


### PR DESCRIPTION
Description
---
- derives encryption key using DH shared spend key
- use consensus hasher to ensure consistent hash preimages
- recovered blinding factor is the shared key, so logic updated not to calculate another Diffie-Helman from the claim key

Motivation and Context
---
Mask and encrypted value key derivation currently should match confidential claims and transfers on the DAN layer.

```
shared_key = DH(claim_pubkey, spend_key) 
shared_mask = dan_mask_kdf(shared_key)
commitment = commit(shared_mask, value)
shared_value_encryption_key = dan_encrypted_value_kdf(shared_mask, commitment)
encrypted_value = encrypt(shared_value_encryption_key, value)
```

How Has This Been Tested?
---
Tested that claims work on the DAN

<!-- Does this include a breaking change? If so, include this line as a footer -->
BREAKING CHANGE: Burn with claim mask and encrypted value key derivation has changed. Existing burnt funds are not claimable on the DAN.
