### PR TITLE
ci(fix): add TestNet for tagged releases

### DIFF
--- a/.github/workflows/base_node_binaries.yml
+++ b/.github/workflows/base_node_binaries.yml
@@ -86,6 +86,24 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Declare TestNet for tags
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        shell: bash
+        run: |
+          tagnet=${{github.ref_name}}
+          echo $tagnet
+          # case match is not RegEx, but wildcards/globs
+          case "$tagnet" in
+            v*-pre.*) TARI_NETWORK=esme
+              ;;
+            v*-rc.*) TARI_NETWORK=nextnet
+              ;;
+            *) TARI_NETWORK=mainnet
+              ;;
+          esac
+          echo ${TARI_NETWORK}
+          echo "TARI_NETWORK=${TARI_NETWORK}" >> $GITHUB_ENV
+
       - name: Declare Global Variables 4 GHA ${{ github.event_name }}
         id: vars
         shell: bash


### PR DESCRIPTION
Description
Add TestNet for tagged releases for binaries and package builds

Motivation and Context
Split out the different networks when build on GitHub
