### PR TITLE
fix: reduce warn log to debug in utxo scanner

### DIFF
--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -1473,7 +1473,7 @@ where
             selection_criteria.excluding_onesided = self.resources.config.autoignore_onesided_utxos;
         }
 
-        warn!(
+        debug!(
             target: LOG_TARGET,
             "select_utxos selection criteria: {}", selection_criteria
         );

--- a/base_layer/wallet/src/utxo_scanner_service/utxo_scanner_task.rs
+++ b/base_layer/wallet/src/utxo_scanner_service/utxo_scanner_task.rs
@@ -405,7 +405,7 @@ where
         }
 
         if let Some(sb) = found_scanned_block {
-            warn!(
+            debug!(
                 target: LOG_TARGET,
                 "Last scanned block found at height {} (Header Hash: {})",
                 sb.height,


### PR DESCRIPTION
Description
---
Reduces debug log in scanner from WARN to DEBUG
Reduces `select_utxos selection criteria: {}` log to DEBUG

Motivation and Context
---
Lots of false warning messages in cucumber logs
```
07:51 WARN  Last scanned block found at height 30 (Header Hash: a55cf603f5cdad623e7e2355535d79d1af02c7c6f04ca7b5e44dd113bd0d9d5a) 
07:51 WARN  Last scanned block found at height 32 (Header Hash: 676377e924ea94afdd2297607b10c0aeb1c8ad4e93d57f27fdb3842cd0ae8e1b)
07:51 WARN  Last scanned block found at height 33 (Header Hash: 3697fc22292f1eeb828c83bfa5281542cbfc3996b06985209ff1a7edfd2fd8be)

WARN  select_utxos selection criteria: filter: Standard, ordering: Default
```

How Has This Been Tested?
---
N/A

What process can a PR reviewer use to test or verify this change?
---
Less warning messages in CI

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
