### PR TITLE
test: revert and freeze `wasm-pack` module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,12 +140,12 @@ jobs:
         run: |
           sudo apt-get update
           sudo bash scripts/install_ubuntu_dependencies.sh
-      #- name: test key manager wasm
-      #  run: |
-      #    npm install -g wasm-pack
-      #    cd base_layer/key_manager
-      #    rustup target add wasm32-unknown-unknown
-      #    make test
+      - name: test key manager wasm
+        run: |
+          npm install -g wasm-pack@0.10.3
+          cd base_layer/key_manager
+          rustup target add wasm32-unknown-unknown
+          make test
       - name: cargo test compile
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
Description
---
Reverts and freezes `wasm-pack@0.10.3` due to an apparent upstream issue.

Fixes (at least temporarily) [issue 5261](https://github.com/tari-project/tari/issues/5261).

Motivation and Context
---
There's an apparent issue with the `wasm-pack` Node.js module at the 0.11.0 version that breaks CI operations (and which [also affects](https://github.com/tari-project/tari-crypto/pull/174) `tari-crypto`).

While an [earlier PR](https://github.com/tari-project/tari/pull/5258) disabled this CI, it seems unnecessary and somewhat risky not to have these tests.

Reverting to the 0.10.3 version is at least a temporary fix.

How Has This Been Tested?
---
With the fix, CI should pass.

What process can a PR reviewer use to test or verify this change?
---
Run the equivalent commands locally, and ensure that CI passes with the change.


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
