### PR TITLE
docs: add burn docs warning

### DIFF
--- a/base_layer/core/src/transactions/transaction_components/output_features.rs
+++ b/base_layer/core/src/transactions/transaction_components/output_features.rs
@@ -101,6 +101,8 @@ impl OutputFeatures {
     }
 
     /// creates output features for a burned output
+    /// Care should be taken with burning as we dont limit the burns to only side_chain features but any output can be
+    /// burned to keep it open for use by as many application as possible.
     pub fn create_burn_output() -> OutputFeatures {
         OutputFeatures {
             output_type: OutputType::Burn,

--- a/base_layer/core/src/transactions/transaction_components/output_type.rs
+++ b/base_layer/core/src/transactions/transaction_components/output_type.rs
@@ -50,6 +50,8 @@ pub enum OutputType {
     /// Output is a coinbase output, must not be spent until maturity.
     Coinbase = 1,
     /// Output is a burned output and can not be spent ever.
+    /// Care should be taken with burning as we dont limit the burns to only side_chain features but any output can be
+    /// burned to keep it open for use by as many application as possible.
     Burn = 2,
     /// Output defines a validator node registration
     ValidatorNodeRegistration = 3,


### PR DESCRIPTION
Description
---
Adds a warning to the burn outputs features to be wary of this. The primary goal of burned commitments is to be used to reclaim second-layer funds. Claiming on the second layer requires extra features attached to the kernel.  But we don't want to limit burns to only the second layer as there exist many use cases for burn outputs. 

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
