### PR TITLE
ci(fix): libwallet update to support TestNet env 

### DIFF
--- a/.github/workflows/build_libwallets_workflow.yml
+++ b/.github/workflows/build_libwallets_workflow.yml
@@ -33,6 +33,24 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v3
 
+      - name: Declare TestNet for tags
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        shell: bash
+        run: |
+          tagnet=${{github.ref_name}}
+          echo $tagnet
+          # case match is not RegEx, but wildcards/globs
+          case "$tagnet" in
+            v*-pre.*) TARI_NETWORK=esme
+              ;;
+            v*-rc.*) TARI_NETWORK=nextnet
+              ;;
+            *) TARI_NETWORK=mainnet
+              ;;
+          esac
+          echo ${TARI_NETWORK}
+          echo "TARI_NETWORK=${TARI_NETWORK}" >> $GITHUB_ENV
+
       - name: Setup Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -100,6 +118,24 @@ jobs:
     steps:
       - name: Checkout source code
         uses: actions/checkout@v3
+
+      - name: Declare TestNet for tags
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        shell: bash
+        run: |
+          tagnet=${{github.ref_name}}
+          echo $tagnet
+          # case match is not RegEx, but wildcards/globs
+          case "$tagnet" in
+            v*-pre.*) TARI_NETWORK=esme
+              ;;
+            v*-rc.*) TARI_NETWORK=nextnet
+              ;;
+            *) TARI_NETWORK=mainnet
+              ;;
+          esac
+          echo ${TARI_NETWORK}
+          echo "TARI_NETWORK=${TARI_NETWORK}" >> $GITHUB_ENV
 
       - name: Setup Rust toolchain
         uses: actions-rs/toolchain@v1

--- a/Cross.toml
+++ b/Cross.toml
@@ -2,13 +2,19 @@
 image = "ghcr.io/cross-rs/x86_64-linux-android:edge"
 
 [target.x86_64-linux-android.env]
-passthrough = ["CFLAGS"]
+passthrough = [
+  "CFLAGS",
+  "TARI_NETWORK",
+]
 
 [target.aarch64-linux-android]
 image = "ghcr.io/cross-rs/aarch64-linux-android:edge"
 
 [target.aarch64-linux-android.env]
-passthrough = ["CFLAGS"]
+passthrough = [
+  "CFLAGS",
+  "TARI_NETWORK",
+]
 
 [target.aarch64-unknown-linux-gnu]
 image = "ubuntu:18.04"
@@ -55,4 +61,5 @@ passthrough = [
   "CARGO_BUILD_TARGET",
   "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc",
   "BINDGEN_EXTRA_CLANG_ARGS=--sysroot /usr/aarch64-linux-gnu/include/",
+  "TARI_NETWORK",
 ]


### PR DESCRIPTION
Description
Updated the libwallet build to pass the TestNet env - ```TARI_NETWORK``` for tagged release

Motivation and Context
Split out the different networks when build on GitHub

How Has This Been Tested?
Build in local fork, tagged and untagged - compile completes

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
