### PR TITLE
test: fix mutable MMR test and add documentation

### DIFF
--- a/base_layer/mmr/src/mutable_mmr.rs
+++ b/base_layer/mmr/src/mutable_mmr.rs
@@ -117,7 +117,9 @@ where
     }
 
     /// Returns a merkle(ish) root for this merkle set.
-    ///
+    /// 
+    /// You _must_ have run `compress()` on this MMR if any deletions were made, or the root may be incorrect.
+    /// 
     /// The root is calculated by concatenating the MMR merkle root with the compressed serialisation of the bitmap
     /// and then hashing the result.
     pub fn get_merkle_root(&self) -> Result<Hash, MerkleMountainRangeError> {

--- a/base_layer/mmr/tests/pruned_mmr.rs
+++ b/base_layer/mmr/tests/pruned_mmr.rs
@@ -87,19 +87,23 @@ fn get_changes() -> (usize, Vec<Hash>, Vec<u32>) {
 /// result of `calculate_pruned_mmr_root`
 #[test]
 pub fn calculate_pruned_mmr_roots() {
+    // Check that the root changes with nontrivial additions and deletions
     let (src_size, additions, deletions) = get_changes();
     let mut src = create_mutable_mmr(src_size);
     let src_root = src.get_merkle_root().expect("Did not get source root");
     let root =
         calculate_pruned_mmr_root(&src, additions.clone(), deletions.clone()).expect("Did not calculate new root");
     assert_ne!(src_root, root);
-    // Double check
+
+    // To check the pruned root computation, manually apply the additions and deletions
+    // We need to compress the deletion bitmap, but as an extra check, we don't apply pruning
     additions.into_iter().for_each(|h| {
         src.push(h).unwrap();
     });
     deletions.iter().for_each(|i| {
         src.delete(*i);
     });
+    src.compress();
     let new_root = src.get_merkle_root().expect("Did not calculate new root");
     assert_eq!(root, new_root);
 }


### PR DESCRIPTION
Description
---
Fixes a broken [test](https://github.com/tari-project/tari/blob/e334a404e432b0911bae3054a28d8e8ca5876e6c/base_layer/mmr/tests/pruned_mmr.rs#L86-L105) of mutable MMR functionality. Updates documentation.

Closes [issue 5268](https://github.com/tari-project/tari/issues/5268).

Motivation and Context
---
A mutable MMR test is currently broken. The test checks a utility function (which is currently unused) against computation of a mutable pruned MMR root. The test fails intermittently due to a failure to compress the underlying deletion bitmap prior to computing the Merkle root. This PR adds the necessary compression step to fix the test.

However, the test failure reveals a risk. The functionality used to [compute the root](https://github.com/tari-project/tari/blob/e334a404e432b0911bae3054a28d8e8ca5876e6c/base_layer/mmr/src/mutable_mmr.rs#L119-L131) for a mutable MMR implicitly requires that the caller have already compressed the deletion bitmap if any deletions were performed. If the caller doesn't do this (as in the failed test), the root may be different.

It may be prudent, if feasible, to include compression in `get_merkle_root` directly, as suggested in [this issue](https://github.com/tari-project/tari/issues/5277). There are several critical places within the codebase where compression is performed, and where roots are computed. Relying on callers to do these steps correctly seems risky. This PR does not address this directly, but adds a warning to the `get_merkle_root` documentation.

How Has This Been Tested?
---
Manually checked (via looped testing) that the affected test succeeds.

What process can a PR reviewer use to test or verify this change?
---
Assert that CI passes. Run the test on a loop to assert that the test does not fail intermittently.

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
