### PR TITLE
fix: ensures mutable MMR bitmaps are compressed

### DIFF
--- a/base_layer/core/src/base_node/sync/horizon_state_sync/synchronizer.rs
+++ b/base_layer/core/src/base_node/sync/horizon_state_sync/synchronizer.rs
@@ -606,7 +606,6 @@ impl<'a, B: BlockchainBackend + 'static> HorizonStateSynchronization<'a, B> {
                     // in the output MMR
                     let bitmap = self.full_bitmap_mut();
                     bitmap.or_inplace(&diff_bitmap);
-                    bitmap.run_optimize();
 
                     let pruned_output_set = output_mmr.get_pruned_hash_set()?;
                     let output_mmr = MutablePrunedOutputMmr::new(pruned_output_set.clone(), bitmap.clone())?;

--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -1360,8 +1360,6 @@ pub fn calculate_mmr_roots<T: BlockchainBackend>(
         }
     }
 
-    output_mmr.compress();
-
     let block_height = block.header.height;
     let epoch_len = rules.consensus_constants(block_height).epoch_length();
     let validator_node_mr = if block_height % epoch_len == 0 {

--- a/base_layer/mmr/src/functions.rs
+++ b/base_layer/mmr/src/functions.rs
@@ -95,7 +95,6 @@ where
     for index in deletions {
         pruned_mmr.delete(index);
     }
-    pruned_mmr.compress();
     pruned_mmr.get_merkle_root()
 }
 


### PR DESCRIPTION
Description
---
Ensures that mutable MMR root computation first performs deletion bitmap compression.

Closes [issue 5277](https://github.com/tari-project/tari/issues/5277).

Motivation and Context
---
Currently, when mutable MMR roots [are computed](https://github.com/tari-project/tari/blob/e334a404e432b0911bae3054a28d8e8ca5876e6c/base_layer/mmr/src/mutable_mmr.rs#L119-L131), it's implicitly assumed that the underlying deletion bitmap has been compressed. If it has not, it's possible for the resulting root to be different than if the bitmap were compressed. This already resulted in an intermittent [test failure](https://github.com/tari-project/tari/issues/5268).

To reduce the risk that a caller does not perform this compression correctly, this PR adds compression to the Merkle root computation functionality directly. It also removes a few compression calls that become redundant with this change.

Note that this may constitute an efficiency regression. If a mutable MMR does not have any deletions since its last bitmap compression, subsequent compression is not necessary. Further, we perform the compression on a clone of the bitmap; this is necessary to avoid mutability and ensure that operations like equality (which rely on root computation) function properly. The efficiency consequences of this change should be examined to ensure they are acceptable.

How Has This Been Tested?
---
Existing CI passes.

What process can a PR reviewer use to test or verify this change?
---
Run existing CI. To further check for intermittent test failures, loop affected tests.

Breaking Changes
---

- [ ] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [x] Other - Please specify

It may be the case that this change affects the way mutable MMR roots are computed in certain cases, which in turn may be a breaking change.