### PR TITLE
feat!: reset dates for networks

### DIFF
--- a/base_layer/core/src/blocks/genesis_block.rs
+++ b/base_layer/core/src/blocks/genesis_block.rs
@@ -122,7 +122,7 @@ fn get_stagenet_genesis_block_raw() -> Block {
     let mut body = AggregateBody::new(vec![], vec![coinbase], vec![kernel]);
     body.sort();
     // set genesis timestamp
-    let genesis = DateTime::parse_from_rfc2822("8 Feb 2023 13:00:00 -0800").unwrap();
+    let genesis = DateTime::parse_from_rfc2822("14 Jun 2023 13:00:00 +0200").unwrap();
     #[allow(clippy::cast_sign_loss)]
     let timestamp = genesis.timestamp() as u64;
     Block {
@@ -216,7 +216,7 @@ fn get_nextnet_genesis_block_raw() -> Block {
     let mut body = AggregateBody::new(vec![], vec![coinbase], vec![kernel]);
     body.sort();
     // set genesis timestamp
-    let genesis = DateTime::parse_from_rfc2822("24 Feb 2023 12:15:00 +0100").unwrap();
+    let genesis = DateTime::parse_from_rfc2822("14 Apr 2023 13:00:00 +0200").unwrap();
     #[allow(clippy::cast_sign_loss)]
     let timestamp = genesis.timestamp() as u64;
     Block {
@@ -509,7 +509,7 @@ fn get_esmeralda_genesis_block_raw() -> Block {
     let mut body = AggregateBody::new(vec![], vec![coinbase], vec![kernel]);
     body.sort();
     // set genesis timestamp
-    let genesis = DateTime::parse_from_rfc2822("15 Mar 2023 10:00:00 +0200").unwrap();
+    let genesis = DateTime::parse_from_rfc2822("31 Mar 2023 14:00:00 +0200").unwrap();
     #[allow(clippy::cast_sign_loss)]
     let timestamp = genesis.timestamp() as u64;
     Block {

--- a/base_layer/tari_mining_helper_ffi/src/lib.rs
+++ b/base_layer/tari_mining_helper_ffi/src/lib.rs
@@ -369,8 +369,8 @@ mod tests {
 
     #[test]
     fn detect_change_in_consensus_encoding() {
-        const NONCE: u64 = 17813882544908324661;
-        const DIFFICULTY: Difficulty = Difficulty::from_u64(1518);
+        const NONCE: u64 = 13922293050099851269;
+        const DIFFICULTY: Difficulty = Difficulty::from_u64(1027);
         unsafe {
             let mut error = -1;
             let error_ptr = &mut error as *mut c_int;


### PR DESCRIPTION
Description
---
Resets the dates for the following networks:
Esmeralda: Today
Nextnet: April 14th
Stagenet: Jun 14

Motivation and Context
---
For Nextnet and Stagenet these are the dates when these changes come into effect.
Esmeralda had a new Gen block as of PR #5282 

How Has This Been Tested?
---
Unit tests

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [x] None
- [x] Requires data directory on base node to be deleted
- [x] Requires hard fork
- [x] Other - Please specify
New Gen block, requires network reset

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
