### PR TITLE
chore: update to use crates.io versions of tari

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1479,20 +1479,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "curve25519-dalek"
-version = "4.0.1"
-source = "git+https://github.com/tari-project/curve25519-dalek?tag=v4.0.1#380f59be1fd2eaf924c62b94d3673a660c650c74"
-dependencies = [
- "byteorder",
- "digest 0.9.0",
- "packed_simd_2",
- "rand_core 0.5.1",
- "serde",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "cxx"
 version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3061,18 +3047,6 @@ dependencies = [
  "byteorder",
  "keccak",
  "rand_core 0.5.1",
- "zeroize",
-]
-
-[[package]]
-name = "merlin"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
-dependencies = [
- "byteorder",
- "keccak",
- "rand_core 0.6.4",
  "zeroize",
 ]
 
@@ -5124,6 +5098,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tari-curve25519-dalek"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31932eba12039b52c2bab4c77e5180cd934a359e83de99ce0b867b0425f2da5c"
+dependencies = [
+ "byteorder",
+ "digest 0.9.0",
+ "packed_simd_2",
+ "rand_core 0.5.1",
+ "serde",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "tari_app_grpc"
 version = "0.49.0-pre.4"
 dependencies = [
@@ -5219,41 +5208,43 @@ dependencies = [
 
 [[package]]
 name = "tari_bulletproofs"
-version = "4.4.0"
-source = "git+https://github.com/tari-project/bulletproofs?tag=v4.4.0#b2f933feaaf00264e9212be5bce10c3a7a5508cc"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2386133cd3bb3dc075aa39016523a375919aa0316ba27b9dc27b7a9bbda24ca"
 dependencies = [
  "blake2 0.9.2",
  "byteorder",
- "curve25519-dalek 4.0.1",
  "digest 0.9.0",
- "merlin 2.0.1",
+ "merlin",
  "rand 0.7.3",
  "rand_core 0.5.1",
  "serde",
  "serde_derive",
  "sha3",
  "subtle",
+ "tari-curve25519-dalek",
  "thiserror",
  "zeroize",
 ]
 
 [[package]]
 name = "tari_bulletproofs_plus"
-version = "0.2.1"
-source = "git+https://github.com/tari-project/bulletproofs-plus?tag=v0.2.1#34c10ba72d17658c37ee81365608c19a36589747"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4681528b53b9980d9687129fd6075ba761a97a414809fc374e9bc1d23268d33"
 dependencies = [
  "blake2 0.9.2",
  "byteorder",
- "curve25519-dalek 4.0.1",
  "derivative",
  "derive_more",
  "digest 0.9.0",
  "lazy_static",
- "merlin 3.0.0",
+ "merlin",
  "rand 0.7.3",
  "rand_core 0.5.1",
  "serde",
  "sha3",
+ "tari-curve25519-dalek",
  "thiserror",
  "zeroize",
 ]
@@ -5565,19 +5556,19 @@ dependencies = [
 
 [[package]]
 name = "tari_crypto"
-version = "0.16.8"
-source = "git+https://github.com/tari-project/tari-crypto.git?tag=v0.16.8#abbd7208a4fef9664d233aff50a34a9637825dbe"
+version = "0.16.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3322c238eb9012d355f962a101a8dbaa9e3144c79942d0555b1b46691a25bcc9"
 dependencies = [
  "base64 0.10.1",
  "blake2 0.9.2",
  "borsh",
  "cbindgen 0.17.0",
- "curve25519-dalek 4.0.1",
  "digest 0.9.0",
  "getrandom 0.2.8",
  "lazy_static",
  "log",
- "merlin 2.0.1",
+ "merlin",
  "once_cell",
  "rand 0.7.3",
  "rand_chacha 0.3.1",
@@ -5586,6 +5577,7 @@ dependencies = [
  "serde-wasm-bindgen",
  "serde_json",
  "sha3",
+ "tari-curve25519-dalek",
  "tari_bulletproofs",
  "tari_bulletproofs_plus",
  "tari_utilities",
@@ -5909,7 +5901,8 @@ dependencies = [
 [[package]]
 name = "tari_utilities"
 version = "0.4.10"
-source = "git+https://github.com/tari-project/tari_utilities.git?tag=v0.4.10#1fd912bd69ac4980a96d7863632c69779a295ce9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96ee4eb0990ee7c898b955a24b8479134851c301b31d2426a7606f57d2d6f181"
 dependencies = [
  "base58-monero 0.3.2",
  "base64 0.13.1",

--- a/applications/tari_app_grpc/Cargo.toml
+++ b/applications/tari_app_grpc/Cargo.toml
@@ -11,9 +11,9 @@ edition = "2018"
 tari_common_types = {  path = "../../base_layer/common_types" }
 tari_comms = { path = "../../comms/core" }
 tari_core = { path = "../../base_layer/core" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.16.8" }
+tari_crypto = { version="0.16.11"}
 tari_script = { path = "../../infrastructure/tari_script" }
-tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag="v0.4.10" }
+tari_utilities = { version = "0.4.10"}
 
 argon2 = { version = "0.4.1", features = ["std", "password-hash"] }
 base64 = "0.13.0"

--- a/applications/tari_app_utilities/Cargo.toml
+++ b/applications/tari_app_utilities/Cargo.toml
@@ -9,7 +9,7 @@ license = "BSD-3-Clause"
 tari_comms = { path = "../../comms/core" }
 tari_common = { path = "../../common" }
 tari_common_types = { path = "../../base_layer/common_types" }
-tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag="v0.4.10" }
+tari_utilities = { version = "0.4.10"}
 
 clap = { version = "3.2.0", features = ["derive", "env"] }
 futures = { version = "^0.3.16", default-features = false, features = ["alloc"] }

--- a/applications/tari_base_node/Cargo.toml
+++ b/applications/tari_base_node/Cargo.toml
@@ -15,13 +15,13 @@ tari_comms = { path = "../../comms/core", features = ["rpc"] }
 tari_common_types = { path = "../../base_layer/common_types" }
 tari_comms_dht = { path = "../../comms/dht" }
 tari_core = { path = "../../base_layer/core", default-features = false, features = ["transactions"] }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.16.8" }
+tari_crypto = { version = "0.16.11"}
 tari_libtor = { path = "../../infrastructure/libtor", optional = true }
 tari_p2p = { path = "../../base_layer/p2p", features = ["auto-update"] }
 tari_storage = {path="../../infrastructure/storage"}
 tari_service_framework = { path = "../../base_layer/service_framework" }
 tari_shutdown = { path = "../../infrastructure/shutdown" }
-tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag="v0.4.10" }
+tari_utilities = { version= "0.4.10"}
 
 anyhow = "1.0.53"
 async-trait = "0.1.52"

--- a/applications/tari_console_wallet/Cargo.toml
+++ b/applications/tari_console_wallet/Cargo.toml
@@ -7,7 +7,7 @@ license = "BSD-3-Clause"
 
 [dependencies]
 tari_wallet = { path = "../../base_layer/wallet", features = ["bundled_sqlite"] }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.16.8" }
+tari_crypto = { version = "0.16.11"}
 tari_common = { path = "../../common" }
 tari_app_utilities = { path = "../tari_app_utilities" }
 tari_comms = { path = "../../comms/core" }
@@ -18,7 +18,7 @@ tari_p2p = { path = "../../base_layer/p2p", features = ["auto-update"] }
 tari_app_grpc = { path = "../tari_app_grpc" }
 tari_shutdown = { path = "../../infrastructure/shutdown" }
 tari_key_manager = { path = "../../base_layer/key_manager" }
-tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.10" }
+tari_utilities = "0.4.10"
 tari_script = { path = "../../infrastructure/tari_script" }
 tari_contacts = { path = "../../base_layer/contacts" }
 

--- a/applications/tari_merge_mining_proxy/Cargo.toml
+++ b/applications/tari_merge_mining_proxy/Cargo.toml
@@ -15,7 +15,7 @@ tari_common = { path = "../../common" }
 tari_comms = { path = "../../comms/core" }
 tari_core = { path = "../../base_layer/core", default-features = false, features = ["transactions"] }
 tari_app_utilities = { path = "../tari_app_utilities" }
-tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag="v0.4.10" }
+tari_utilities = "0.4.10"
 tari_base_node_grpc_client = {path="../../clients/rust/base_node_grpc_client" }
 tari_wallet_grpc_client = {path="../../clients/rust/wallet_grpc_client" }
 

--- a/applications/tari_miner/Cargo.toml
+++ b/applications/tari_miner/Cargo.toml
@@ -14,8 +14,8 @@ tari_common_types = { path = "../../base_layer/common_types" }
 tari_comms = { path = "../../comms/core" }
 tari_app_utilities = { path = "../tari_app_utilities" }
 tari_app_grpc = { path = "../tari_app_grpc" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.16.8" }
-tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag="v0.4.10" }
+tari_crypto = { version = "0.16.11"}
+tari_utilities = "0.4.10"
 
 borsh = "0.9.3"
 crossterm = { version = "0.25.0" }

--- a/base_layer/common_types/Cargo.toml
+++ b/base_layer/common_types/Cargo.toml
@@ -7,8 +7,8 @@ version = "0.49.0-pre.4"
 edition = "2018"
 
 [dependencies]
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.16.8" }
-tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag="v0.4.10" }
+tari_crypto = { version = "0.16.11"}
+tari_utilities = "0.4.10"
 # TODO: remove this dependency and move Network into tari_common_types
 tari_common = {  path = "../../common" }
 

--- a/base_layer/contacts/Cargo.toml
+++ b/base_layer/contacts/Cargo.toml
@@ -10,12 +10,12 @@ edition = "2018"
 tari_common = { path = "../../common" }
 tari_common_types = {  path = "../../base_layer/common_types" }
 tari_comms = {  path = "../../comms/core" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.16.8" }
+tari_crypto = { version = "0.16.11"}
 tari_p2p = {  path = "../p2p", features = ["auto-update"] }
 tari_service_framework = {  path = "../service_framework" }
 tari_shutdown = {  path = "../../infrastructure/shutdown" }
 tari_common_sqlite = { path = "../../common_sqlite" }
-tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag="v0.4.10" }
+tari_utilities = "0.4.10"
 
 tokio = { version = "1.23", features = ["sync", "macros"] }
 chrono = { version = "0.4.19", default-features = false, features = ["serde"] }

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -24,7 +24,7 @@ tari_common_types = {  path = "../../base_layer/common_types" }
 tari_comms = {  path = "../../comms/core" }
 tari_comms_dht = {  path = "../../comms/dht" }
 tari_comms_rpc_macros = {  path = "../../comms/rpc_macros" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.16.8", features = ["borsh"] }
+tari_crypto = { version="0.16.11", features = ["borsh"] }
 tari_metrics = { path = "../../infrastructure/metrics" }
 tari_mmr = {  path = "../../base_layer/mmr", optional = true, features = ["native_bitmap"] }
 tari_p2p = {  path = "../../base_layer/p2p" }
@@ -33,7 +33,7 @@ tari_service_framework = {  path = "../service_framework" }
 tari_shutdown = {  path = "../../infrastructure/shutdown" }
 tari_storage = {  path = "../../infrastructure/storage" }
 tari_test_utils = {  path = "../../infrastructure/test_utils" }
-tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.10", features = ["borsh"] }
+tari_utilities = { version="0.4.10", features = ["borsh"] }
 
 bincode = "1.1.4"
 bitflags = "1.0.4"

--- a/base_layer/key_manager/Cargo.toml
+++ b/base_layer/key_manager/Cargo.toml
@@ -13,8 +13,8 @@ crate-type = ["lib", "cdylib"]
 # NB: All dependencies must support or be gated for the WASM target.
 [dependencies]
 tari_common_types = {  path = "../../base_layer/common_types", optional = true }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.16.8" }
-tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag="v0.4.10" }
+tari_crypto = { version = "0.16.11"}
+tari_utilities = "0.4.10"
 
 argon2 = { version = "0.4.1", features = ["std", "alloc"] }
 blake2 = "0.9.1"

--- a/base_layer/mmr/Cargo.toml
+++ b/base_layer/mmr/Cargo.toml
@@ -13,8 +13,8 @@ native_bitmap = ["croaring"]
 benches = ["criterion"]
 
 [dependencies]
-tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag="v0.4.10" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.16.8" }
+tari_utilities = "0.4.10"
+tari_crypto = { version = "0.16.11"}
 tari_common = {path = "../../common"}
 thiserror = "1.0.26"
 borsh = "0.9.3"

--- a/base_layer/p2p/Cargo.toml
+++ b/base_layer/p2p/Cargo.toml
@@ -13,11 +13,11 @@ edition = "2018"
 tari_comms = {  path = "../../comms/core" }
 tari_comms_dht = {  path = "../../comms/dht" }
 tari_common = {  path = "../../common" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.16.8" }
+tari_crypto = { version = "0.16.11"}
 tari_service_framework = {  path = "../service_framework" }
 tari_shutdown = {  path = "../../infrastructure/shutdown" }
 tari_storage = {  path = "../../infrastructure/storage" }
-tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag="v0.4.10" }
+tari_utilities = "0.4.10"
 
 anyhow = "1.0.53"
 fs2 = "0.4.0"

--- a/base_layer/tari_mining_helper_ffi/Cargo.toml
+++ b/base_layer/tari_mining_helper_ffi/Cargo.toml
@@ -8,10 +8,10 @@ edition = "2018"
 
 [dependencies]
 tari_comms = {  path = "../../comms/core" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.16.8"}
+tari_crypto = { version = "0.16.11"}
 tari_common = {  path = "../../common" }
 tari_core = {  path = "../core", default-features = false, features = ["transactions"]}
-tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag="v0.4.10"}
+tari_utilities = "0.4.10"
 libc = "0.2.65"
 thiserror = "1.0.26"
 borsh = "0.9.3"

--- a/base_layer/wallet/Cargo.toml
+++ b/base_layer/wallet/Cargo.toml
@@ -12,14 +12,14 @@ tari_common = { path = "../../common" }
 tari_common_types = {  path = "../../base_layer/common_types" }
 tari_comms = {  path = "../../comms/core" }
 tari_comms_dht = {  path = "../../comms/dht" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.16.8" }
+tari_crypto = "0.16.11"
 tari_key_manager = {  path = "../key_manager" }
 tari_p2p = {  path = "../p2p", features = ["auto-update"] }
 tari_script = { path = "../../infrastructure/tari_script" }
 tari_service_framework = {  path = "../service_framework" }
 tari_shutdown = {  path = "../../infrastructure/shutdown" }
 tari_common_sqlite = { path = "../../common_sqlite" }
-tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag="v0.4.10" }
+tari_utilities = "0.4.10"
 tari_contacts = { path = "../../base_layer/contacts" }
 
 # Uncomment for tokio tracing via tokio-console (needs "tracing" features)

--- a/base_layer/wallet/src/key_manager_service/mock.rs
+++ b/base_layer/wallet/src/key_manager_service/mock.rs
@@ -20,21 +20,26 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use std::{collections::HashMap, sync::Arc};
+
 use log::*;
 use tari_common_types::types::PrivateKey;
 use tari_key_manager::{cipher_seed::CipherSeed, key_manager::KeyManager};
 use tokio::sync::RwLock;
 
 use crate::{
-    key_manager_service::{interface::NextKeyResult, AddResult, KeyManagerInterface},
+    key_manager_service::{
+        error::KeyManagerServiceError,
+        interface::NextKeyResult,
+        storage::database::KeyManagerState,
+        AddResult,
+        KeyManagerInterface,
+    },
     types::KeyDigest,
 };
 
 const LOG_TARGET: &str = "wallet::Key_manager_mock";
 const KEY_MANAGER_MAX_SEARCH_DEPTH: u64 = 1_000_000;
-use std::{collections::HashMap, sync::Arc};
-
-use crate::key_manager_service::{error::KeyManagerServiceError, storage::database::KeyManagerState};
 
 /// Testing Mock for the key manager service
 /// Contains all functionality of the normal key manager service except persistent storage

--- a/base_layer/wallet/src/key_manager_service/service.rs
+++ b/base_layer/wallet/src/key_manager_service/service.rs
@@ -19,24 +19,25 @@
 //  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+use std::collections::HashMap;
+
 use futures::lock::Mutex;
 use log::*;
 use tari_common_types::types::PrivateKey;
 use tari_key_manager::{cipher_seed::CipherSeed, key_manager::KeyManager};
 
-use crate::types::KeyDigest;
+use crate::{
+    key_manager_service::{
+        error::KeyManagerServiceError,
+        interface::NextKeyResult,
+        storage::database::{KeyManagerBackend, KeyManagerDatabase, KeyManagerState},
+        AddResult,
+    },
+    types::KeyDigest,
+};
 
 const LOG_TARGET: &str = "wallet::key_manager";
 const KEY_MANAGER_MAX_SEARCH_DEPTH: u64 = 1_000_000;
-
-use std::collections::HashMap;
-
-use crate::key_manager_service::{
-    error::KeyManagerServiceError,
-    interface::NextKeyResult,
-    storage::database::{KeyManagerBackend, KeyManagerDatabase, KeyManagerState},
-    AddResult,
-};
 
 pub struct KeyManagerInner<TBackend> {
     key_managers: HashMap<String, Mutex<KeyManager<PrivateKey, KeyDigest>>>,

--- a/base_layer/wallet_ffi/Cargo.toml
+++ b/base_layer/wallet_ffi/Cargo.toml
@@ -12,12 +12,12 @@ tari_common = { path="../../common" }
 tari_common_types = { path="../common_types" }
 tari_comms = {  path = "../../comms/core", features = ["c_integration"]}
 tari_comms_dht = {  path = "../../comms/dht", default-features = false }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.16.8" }
+tari_crypto = { version="0.16.11"}
 tari_key_manager = {  path = "../key_manager" }
 tari_p2p = {  path = "../p2p" }
 tari_script = { path = "../../infrastructure/tari_script" }
 tari_shutdown = {  path = "../../infrastructure/shutdown" }
-tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag="v0.4.10" }
+tari_utilities = { version = "0.4.10"}
 tari_wallet = {  path = "../wallet", features = ["c_integration"]}
 tari_contacts = { path = "../../base_layer/contacts" }
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -14,7 +14,7 @@ build = ["toml", "prost-build"]
 static-application-info = ["git2"]
 
 [dependencies]
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.16.8" }
+tari_crypto = { version = "0.16.11"}
 
 anyhow = "1.0.53"
 config = { version = "0.13.0", default_features = false, features = ["toml"] }

--- a/common_sqlite/Cargo.toml
+++ b/common_sqlite/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag="v0.4.10" }
+tari_utilities = "0.4.10"
 
 chrono = { version = "0.4.19", default-features = false, features = ["serde"] }
 diesel = { version = "2.0.3", features = ["sqlite", "r2d2", "serde_json", "chrono", "64-column-tables"] }

--- a/comms/core/Cargo.toml
+++ b/comms/core/Cargo.toml
@@ -10,11 +10,11 @@ version = "0.49.0-pre.4"
 edition = "2018"
 
 [dependencies]
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.16.8" }
+tari_crypto = { version = "0.16.11"}
 tari_metrics = { path = "../../infrastructure/metrics" }
 tari_storage = {  path = "../../infrastructure/storage" }
 tari_shutdown = {  path = "../../infrastructure/shutdown" }
-tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.10" }
+tari_utilities = "0.4.10"
 
 anyhow = "1.0.53"
 async-trait = "0.1.36"

--- a/comms/dht/Cargo.toml
+++ b/comms/dht/Cargo.toml
@@ -13,8 +13,8 @@ edition = "2018"
 tari_comms = {  path = "../core", features = ["rpc"] }
 tari_common = { path = "../../common" }
 tari_comms_rpc_macros = {  path = "../rpc_macros" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.16.8" }
-tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag="v0.4.10" }
+tari_crypto = { version = "0.16.11"}
+tari_utilities = "0.4.10"
 tari_shutdown = {  path = "../../infrastructure/shutdown" }
 tari_storage = {  path = "../../infrastructure/storage" }
 tari_common_sqlite = { path = "../../common_sqlite" }

--- a/infrastructure/storage/Cargo.toml
+++ b/infrastructure/storage/Cargo.toml
@@ -18,4 +18,4 @@ serde = "1.0.80"
 
 [dev-dependencies]
 rand = "0.7.3"
-tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.10", features = ["borsh"] }
+tari_utilities = { version="0.4.10", features = ["borsh"] }

--- a/infrastructure/tari_script/Cargo.toml
+++ b/infrastructure/tari_script/Cargo.toml
@@ -11,8 +11,8 @@ readme = "README.md"
 license = "BSD-3-Clause"
 
 [dependencies]
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.16.8" }
-tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag="v0.4.10" }
+tari_crypto = { version = "0.16.11"}
+tari_utilities = "0.4.10"
 
 blake2 = "0.9"
 borsh = "0.9.3"

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -22,7 +22,7 @@ tari_miner = { path = "../applications/tari_miner" }
 tari_p2p = { path = "../base_layer/p2p" }
 tari_script = { path = "../infrastructure/tari_script" }
 tari_shutdown = { path = "../infrastructure/shutdown" }
-tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag="v0.4.10"}
+tari_utilities = "0.4.10"
 tari_wallet = { path = "../base_layer/wallet" }
 tari_wallet_grpc_client = { path = "../clients/rust/wallet_grpc_client" }
 tari_wallet_ffi = { path = "../base_layer/wallet_ffi" }
@@ -45,7 +45,7 @@ tonic = "0.6.2"
 
 
 [dev-dependencies]
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.16.8" }
+tari_crypto = { version = "0.16.11"}
 
 # FIXME: the newest version failed compilation due to a missing "bool_to_option" unstable feature
 #cucumber = { version = "0.13.0", features = ["default"] }


### PR DESCRIPTION
We currently use a tagged version of `tari_crypto` and `tari_utilities`, this is useful when there are many changes to those crates and we want to use a specific version, but with the `tari_dan` crates also using them, it means the libraries must all be updated at the same time. Using `crates.io` versions means that the end applications will be able to choose a version that works, adhering to semver rules