### PR TITLE
feat: feature gates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5593,7 +5593,7 @@ dependencies = [
 
 [[package]]
 name = "tari_features"
-version = "0.0.1"
+version = "0.49.0-pre.6"
 dependencies = [
  "tari_common",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5186,6 +5186,7 @@ dependencies = [
  "tari_comms_dht",
  "tari_core",
  "tari_crypto",
+ "tari_features",
  "tari_libtor",
  "tari_metrics",
  "tari_p2p",
@@ -5447,6 +5448,7 @@ dependencies = [
  "tari_contacts",
  "tari_core",
  "tari_crypto",
+ "tari_features",
  "tari_key_manager",
  "tari_libtor",
  "tari_p2p",
@@ -5589,6 +5591,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "tari_features"
+version = "0.0.1"
+dependencies = [
+ "tari_common",
+]
+
+[[package]]
 name = "tari_integration_tests"
 version = "0.35.1"
 dependencies = [
@@ -5711,6 +5720,7 @@ dependencies = [
  "tari_common",
  "tari_comms",
  "tari_core",
+ "tari_features",
  "tari_utilities",
  "tari_wallet_grpc_client",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5149,6 +5149,7 @@ dependencies = [
  "tari_common",
  "tari_common_types",
  "tari_comms",
+ "tari_features",
  "tari_utilities",
  "thiserror",
  "tokio",

--- a/applications/tari_app_utilities/Cargo.toml
+++ b/applications/tari_app_utilities/Cargo.toml
@@ -6,9 +6,10 @@ edition = "2018"
 license = "BSD-3-Clause"
 
 [dependencies]
-tari_comms = { path = "../../comms/core" }
 tari_common = { path = "../../common" }
 tari_common_types = { path = "../../base_layer/common_types" }
+tari_comms = { path = "../../comms/core" }
+tari_features = { version = "0.0.1", path = "../../common/tari_features"}
 tari_utilities = { version = "0.4.10"}
 
 clap = { version = "3.2.0", features = ["derive", "env"] }
@@ -22,3 +23,4 @@ thiserror = "^1.0.26"
 
 [build-dependencies]
 tari_common = { path = "../../common", features = ["build", "static-application-info"] }
+tari_features = { version = "0.0.1", path = "../../common/tari_features"}

--- a/applications/tari_app_utilities/Cargo.toml
+++ b/applications/tari_app_utilities/Cargo.toml
@@ -9,7 +9,7 @@ license = "BSD-3-Clause"
 tari_common = { path = "../../common" }
 tari_common_types = { path = "../../base_layer/common_types" }
 tari_comms = { path = "../../comms/core" }
-tari_features = { version = "0.0.1", path = "../../common/tari_features"}
+tari_features = { version = "0.49.0-pre.6", path = "../../common/tari_features"}
 tari_utilities = { version = "0.4.10"}
 
 clap = { version = "3.2.0", features = ["derive", "env"] }
@@ -23,4 +23,4 @@ thiserror = "^1.0.26"
 
 [build-dependencies]
 tari_common = { path = "../../common", features = ["build", "static-application-info"] }
-tari_features = { version = "0.0.1", path = "../../common/tari_features"}
+tari_features = { version = "0.49.0-pre.6", path = "../../common/tari_features"}

--- a/applications/tari_app_utilities/build.rs
+++ b/applications/tari_app_utilities/build.rs
@@ -21,8 +21,10 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use tari_common::build::StaticApplicationInfo;
+use tari_features::resolver::build_features;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    build_features();
     let gen = StaticApplicationInfo::initialize()?;
     gen.write_consts_to_outdir("consts.rs")?;
     Ok(())

--- a/applications/tari_app_utilities/src/lib.rs
+++ b/applications/tari_app_utilities/src/lib.rs
@@ -22,6 +22,7 @@
 
 pub mod common_cli_args;
 pub mod identity_management;
+pub mod network_check;
 pub mod utilities;
 
 pub mod consts {

--- a/applications/tari_app_utilities/src/network_check.rs
+++ b/applications/tari_app_utilities/src/network_check.rs
@@ -53,18 +53,14 @@ pub const TARGET_NETWORK: Target = Target::NextNet;
 pub const TARGET_NETWORK: Target = Target::TestNet;
 
 pub fn is_network_choice_valid(network: Network) -> Result<(), NetworkCheckError> {
-    match TARGET_NETWORK {
-        Target::MainNet => match network {
-            Network::MainNet | Network::StageNet => Ok(()),
-            _ => Err(NetworkCheckError::MainNetBinary(network)),
-        },
-        Target::NextNet => match network {
-            Network::NextNet => Ok(()),
-            _ => Err(NetworkCheckError::NextNetBinary(network)),
-        },
-        Target::TestNet => match network {
-            Network::LocalNet | Network::Igor | Network::Esmeralda => Ok(()),
-            _ => Err(NetworkCheckError::TestNetBinary(network)),
-        },
+    match (TARGET_NETWORK, network) {
+        (Target::MainNet, Network::MainNet | Network::StageNet) => Ok(()),
+        (Target::MainNet, _) => Err(NetworkCheckError::MainNetBinary(network)),
+
+        (Target::NextNet, Network::NextNet) => Ok(()),
+        (Target::NextNet, _) => Err(NetworkCheckError::NextNetBinary(network)),
+
+        (Target::TestNet, Network::LocalNet | Network::Igor | Network::Esmeralda) => Ok(()),
+        (Target::TestNet, _) => Err(NetworkCheckError::TestNetBinary(network)),
     }
 }

--- a/applications/tari_app_utilities/src/network_check.rs
+++ b/applications/tari_app_utilities/src/network_check.rs
@@ -1,0 +1,70 @@
+//  Copyright 2023. The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use tari_common::{
+    configuration::Network,
+    exit_codes::{ExitCode, ExitError},
+};
+use tari_features::resolver::Target;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum NetworkCheckError {
+    #[error("The network {0} is invalid for this binary built for MainNet")]
+    MainNetBinary(Network),
+    #[error("The network {0} is invalid for this binary built for NextNet")]
+    NextNetBinary(Network),
+    #[error("The network {0} is invalid for this binary built for TestNet")]
+    TestNetBinary(Network),
+}
+
+impl From<NetworkCheckError> for ExitError {
+    fn from(err: NetworkCheckError) -> Self {
+        Self::new(ExitCode::NetworkError, err)
+    }
+}
+
+#[cfg(tari_network_mainnet)]
+pub const TARGET_NETWORK: Target = Target::MainNet;
+
+#[cfg(tari_network_nextnet)]
+pub const TARGET_NETWORK: Target = Target::NextNet;
+
+#[cfg(all(not(tari_network_mainnet), not(tari_network_nextnet)))]
+pub const TARGET_NETWORK: Target = Target::TestNet;
+
+pub fn is_network_choice_valid(network: Network) -> Result<(), NetworkCheckError> {
+    match TARGET_NETWORK {
+        Target::MainNet => match network {
+            Network::MainNet | Network::StageNet => Ok(()),
+            _ => Err(NetworkCheckError::MainNetBinary(network)),
+        },
+        Target::NextNet => match network {
+            Network::NextNet => Ok(()),
+            _ => Err(NetworkCheckError::NextNetBinary(network)),
+        },
+        Target::TestNet => match network {
+            Network::LocalNet | Network::Igor | Network::Esmeralda => Ok(()),
+            _ => Err(NetworkCheckError::TestNetBinary(network)),
+        },
+    }
+}

--- a/applications/tari_base_node/Cargo.toml
+++ b/applications/tari_base_node/Cargo.toml
@@ -57,4 +57,5 @@ metrics = ["tari_metrics", "tari_comms/metrics"]
 safe = []
 libtor = ["tari_libtor"]
 
-
+[build-dependencies]
+tari_features = { version = "0.0.1", path = "../../common/tari_features"}

--- a/applications/tari_base_node/Cargo.toml
+++ b/applications/tari_base_node/Cargo.toml
@@ -58,4 +58,4 @@ safe = []
 libtor = ["tari_libtor"]
 
 [build-dependencies]
-tari_features = { version = "0.0.1", path = "../../common/tari_features"}
+tari_features = { version = "0.49.0-pre.6", path = "../../common/tari_features"}

--- a/applications/tari_base_node/build.rs
+++ b/applications/tari_base_node/build.rs
@@ -1,8 +1,11 @@
 // Copyright 2022 The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
 
+use tari_features::resolver::build_features;
+
 #[cfg(windows)]
 fn main() {
+    build_features();
     use std::env;
     println!("cargo:rerun-if-changed=icon.res");
     let mut path = env::current_dir().unwrap();
@@ -11,4 +14,7 @@ fn main() {
 }
 
 #[cfg(not(windows))]
-fn main() {}
+pub fn main() {
+    build_features();
+    // Build as usual
+}

--- a/applications/tari_base_node/src/lib.rs
+++ b/applications/tari_base_node/src/lib.rs
@@ -42,7 +42,7 @@ use std::{process, sync::Arc};
 use commands::{cli_loop::CliLoop, command::CommandContext};
 use futures::FutureExt;
 use log::*;
-use tari_app_utilities::common_cli_args::CommonCliArgs;
+use tari_app_utilities::{common_cli_args::CommonCliArgs, network_check::is_network_choice_valid};
 use tari_common::{
     configuration::bootstrap::{grpc_default_port, ApplicationType},
     exit_codes::{ExitCode, ExitError},
@@ -97,6 +97,8 @@ pub async fn run_base_node_with_cli(
     cli: Cli,
     shutdown: Shutdown,
 ) -> Result<(), ExitError> {
+    is_network_choice_valid(config.network())?;
+
     #[cfg(feature = "metrics")]
     {
         metrics::install(

--- a/applications/tari_console_wallet/Cargo.toml
+++ b/applications/tari_console_wallet/Cargo.toml
@@ -14,7 +14,7 @@ tari_comms = { path = "../../comms/core" }
 tari_comms_dht = { path = "../../comms/dht" }
 tari_contacts = { path = "../../base_layer/contacts" }
 tari_crypto = { version = "0.16.11"}
-tari_features = { version = "0.0.1", path = "../../common/tari_features"}
+tari_features = { version = "0.49.0-pre.6", path = "../../common/tari_features"}
 tari_key_manager = { path = "../../base_layer/key_manager" }
 tari_libtor = { path = "../../infrastructure/libtor", optional = true }
 tari_p2p = { path = "../../base_layer/p2p", features = ["auto-update"] }
@@ -65,7 +65,7 @@ default-features = false
 features = ["crossterm"]
 
 [build-dependencies]
-tari_features = { version = "0.0.1", path = "../../common/tari_features"}
+tari_features = { version = "0.49.0-pre.6", path = "../../common/tari_features"}
 
 [features]
 avx2 = ["tari_core/avx2", "tari_crypto/simd_backend", "tari_wallet/avx2", "tari_comms/avx2", "tari_comms_dht/avx2", "tari_p2p/avx2", "tari_key_manager/avx2"]

--- a/applications/tari_console_wallet/Cargo.toml
+++ b/applications/tari_console_wallet/Cargo.toml
@@ -6,21 +6,22 @@ edition = "2018"
 license = "BSD-3-Clause"
 
 [dependencies]
-tari_wallet = { path = "../../base_layer/wallet", features = ["bundled_sqlite"] }
-tari_crypto = { version = "0.16.11"}
-tari_common = { path = "../../common" }
+tari_app_grpc = { path = "../tari_app_grpc" }
 tari_app_utilities = { path = "../tari_app_utilities" }
+tari_common = { path = "../../common" }
+tari_common_types = { path = "../../base_layer/common_types" }
 tari_comms = { path = "../../comms/core" }
 tari_comms_dht = { path = "../../comms/dht" }
-tari_common_types = { path = "../../base_layer/common_types" }
+tari_contacts = { path = "../../base_layer/contacts" }
+tari_crypto = { version = "0.16.11"}
+tari_features = { version = "0.0.1", path = "../../common/tari_features"}
+tari_key_manager = { path = "../../base_layer/key_manager" }
 tari_libtor = { path = "../../infrastructure/libtor", optional = true }
 tari_p2p = { path = "../../base_layer/p2p", features = ["auto-update"] }
-tari_app_grpc = { path = "../tari_app_grpc" }
-tari_shutdown = { path = "../../infrastructure/shutdown" }
-tari_key_manager = { path = "../../base_layer/key_manager" }
-tari_utilities = "0.4.10"
 tari_script = { path = "../../infrastructure/tari_script" }
-tari_contacts = { path = "../../base_layer/contacts" }
+tari_shutdown = { path = "../../infrastructure/shutdown" }
+tari_utilities = "0.4.10"
+tari_wallet = { path = "../../base_layer/wallet", features = ["bundled_sqlite"] }
 
 # Uncomment for tokio tracing via tokio-console (needs "tracing" featurs)
 #console-subscriber = "0.1.3"
@@ -62,6 +63,9 @@ features = ["transactions", "mempool_proto", "base_node_proto"]
 version = "^0.16"
 default-features = false
 features = ["crossterm"]
+
+[build-dependencies]
+tari_features = { version = "0.0.1", path = "../../common/tari_features"}
 
 [features]
 avx2 = ["tari_core/avx2", "tari_crypto/simd_backend", "tari_wallet/avx2", "tari_comms/avx2", "tari_comms_dht/avx2", "tari_p2p/avx2", "tari_key_manager/avx2"]

--- a/applications/tari_console_wallet/build.rs
+++ b/applications/tari_console_wallet/build.rs
@@ -1,8 +1,11 @@
 // Copyright 2022 The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
 
+use tari_features::resolver::build_features;
+
 #[cfg(windows)]
 fn main() {
+    build_features();
     use std::env;
     println!("cargo:rerun-if-changed=icon.res");
     let mut path = env::current_dir().unwrap();
@@ -11,4 +14,7 @@ fn main() {
 }
 
 #[cfg(not(windows))]
-fn main() {}
+pub fn main() {
+    build_features();
+    // Build as usual
+}

--- a/applications/tari_console_wallet/src/lib.rs
+++ b/applications/tari_console_wallet/src/lib.rs
@@ -49,7 +49,7 @@ pub use cli::{
 use init::{change_password, get_base_node_peer_config, init_wallet, start_wallet, tari_splash_screen, WalletBoot};
 use log::*;
 use recovery::{get_seed_from_seed_words, prompt_private_key_from_seed_words};
-use tari_app_utilities::{common_cli_args::CommonCliArgs, consts};
+use tari_app_utilities::{common_cli_args::CommonCliArgs, consts, network_check::is_network_choice_valid};
 use tari_common::{
     configuration::bootstrap::ApplicationType,
     exit_codes::{ExitCode, ExitError},
@@ -113,6 +113,8 @@ pub fn run_wallet_with_cli(
         ApplicationType::ConsoleWallet,
         consts::APP_VERSION
     );
+
+    is_network_choice_valid(config.wallet.network)?;
 
     let password = get_password(config, &cli);
 

--- a/applications/tari_merge_mining_proxy/Cargo.toml
+++ b/applications/tari_merge_mining_proxy/Cargo.toml
@@ -41,4 +41,5 @@ tonic = "0.6.2"
 tracing = "0.1"
 url = "2.1.1"
 
-[dev-dependencies]
+[build-dependencies]
+tari_features = { version = "0.0.1", path = "../../common/tari_features"}

--- a/applications/tari_merge_mining_proxy/Cargo.toml
+++ b/applications/tari_merge_mining_proxy/Cargo.toml
@@ -42,4 +42,4 @@ tracing = "0.1"
 url = "2.1.1"
 
 [build-dependencies]
-tari_features = { version = "0.0.1", path = "../../common/tari_features"}
+tari_features = { version = "0.49.0-pre.6", path = "../../common/tari_features"}

--- a/applications/tari_merge_mining_proxy/build.rs
+++ b/applications/tari_merge_mining_proxy/build.rs
@@ -1,8 +1,11 @@
 // Copyright 2022 The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
 
+use tari_features::resolver::build_features;
+
 #[cfg(windows)]
 fn main() {
+    build_features();
     use std::env;
     println!("cargo:rerun-if-changed=icon.res");
     let mut path = env::current_dir().unwrap();
@@ -11,4 +14,7 @@ fn main() {
 }
 
 #[cfg(not(windows))]
-fn main() {}
+pub fn main() {
+    build_features();
+    // Build as usual
+}

--- a/common/tari_features/Cargo.toml
+++ b/common/tari_features/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.0.1"
+version = "0.49.0-pre.6"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/common/tari_features/Cargo.toml
+++ b/common/tari_features/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "tari_features"
+description = "Compilable features for Tari applications"
+authors = ["The Tari Development Community"]
+repository = "https://github.com/tari-project/tari"
+homepage = "https://tari.com"
+readme = "README.md"
+license = "BSD-3-Clause"
+version = "0.0.1"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+tari_common = { path = "../../common" }

--- a/common/tari_features/src/feature.rs
+++ b/common/tari_features/src/feature.rs
@@ -1,0 +1,87 @@
+// Copyright 2023. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::fmt::{Display, Formatter};
+
+use super::Status;
+
+pub struct Feature {
+    name: &'static str,
+    description: &'static str,
+    tracking_issue: Option<usize>,
+    status: Status,
+}
+
+impl Feature {
+    pub const fn new(
+        name: &'static str,
+        description: &'static str,
+        tracking_issue: Option<usize>,
+        status: Status,
+    ) -> Self {
+        Feature {
+            name,
+            description,
+            tracking_issue,
+            status,
+        }
+    }
+
+    pub fn issue_url(&self) -> String {
+        match self.tracking_issue {
+            Some(n) => format!("https://github.com/tari-project/tari/issues/{}", n),
+            None => "None".into(),
+        }
+    }
+
+    pub fn attr_name(&self) -> String {
+        format!("tari_feature_{}", self.name)
+    }
+
+    pub fn is_active_in_testnet(&self) -> bool {
+        matches!(self.status, Status::New | Status::Testing)
+    }
+
+    pub fn is_active_in_nextnet(&self) -> bool {
+        matches!(self.status, Status::Testing)
+    }
+
+    pub fn is_active(&self) -> bool {
+        matches!(self.status, Status::Active)
+    }
+
+    pub fn was_removed(&self) -> bool {
+        matches!(self.status, Status::Removed)
+    }
+}
+
+impl Display for Feature {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}. {}. Tracking issue: {}",
+            self.name,
+            self.description,
+            self.issue_url()
+        )
+    }
+}

--- a/common/tari_features/src/lib.rs
+++ b/common/tari_features/src/lib.rs
@@ -27,11 +27,4 @@ mod status;
 pub use feature::Feature;
 pub use status::Status;
 
-pub const FEATURE_LIST: [Feature; 0] = [
-    // Feature::new(
-    //     "example_feature_name",
-    //     "example description",
-    //     None,
-    //     Status::New,
-    // ),
-];
+pub const FEATURE_LIST: [Feature; 0] = [];

--- a/common/tari_features/src/lib.rs
+++ b/common/tari_features/src/lib.rs
@@ -1,0 +1,37 @@
+// Copyright 2023. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+mod feature;
+pub mod resolver;
+mod status;
+
+pub use feature::Feature;
+pub use status::Status;
+
+pub const FEATURE_LIST: [Feature; 0] = [
+    // Feature::new(
+    //     "example_feature_name",
+    //     "example description",
+    //     None,
+    //     Status::New,
+    // ),
+];

--- a/common/tari_features/src/resolver.rs
+++ b/common/tari_features/src/resolver.rs
@@ -1,0 +1,119 @@
+// Copyright 2023. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::{fmt::Display, str::FromStr};
+
+use tari_common::configuration::Network;
+
+use crate::{Feature, FEATURE_LIST};
+
+pub enum Target {
+    TestNet,
+    NextNet,
+    MainNet,
+}
+
+impl Display for Target {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Target::TestNet => f.write_str("TestNet"),
+            Target::NextNet => f.write_str("NextNet"),
+            Target::MainNet => f.write_str("MainNet"),
+        }
+    }
+}
+
+// Identify the target network by
+// 1. Checking whether --config tari-network=xxx was passed in as a config flag to cargo (or from Cargo.toml)
+// 2. Checking the environment variable TARI_NETWORK is set
+// 3. default to mainnet
+pub fn identify_target() -> Target {
+    check_envar("CARGO_CFG_TARI_NETWORK")
+        .or_else(|| check_envar("TARI_NETWORK"))
+        .unwrap_or(Target::TestNet)
+}
+
+pub fn check_envar(envar: &str) -> Option<Target> {
+    match std::env::var(envar) {
+        Ok(s) => {
+            let network =
+                Network::from_str(s.to_lowercase().as_str()).unwrap_or_else(|_| panic!("Unknown network, {}", s));
+            match network {
+                Network::MainNet | Network::StageNet => Some(Target::MainNet),
+                Network::NextNet => Some(Target::NextNet),
+                Network::LocalNet | Network::Igor | Network::Esmeralda => Some(Target::TestNet),
+                Network::Weatherwax | Network::Ridcully | Network::Stibbons | Network::Dibbler => None,
+            }
+        },
+        _ => None,
+    }
+}
+
+pub fn list_active_features() {
+    println!("These features are ACTIVE on mainnet (no special code handling is done)");
+    FEATURE_LIST
+        .iter()
+        .filter(|f| f.is_active())
+        .for_each(|f| println!("{}", f));
+}
+
+pub fn list_removed_features() {
+    println!("These features are DEPRECATED and will never be compiled");
+    FEATURE_LIST
+        .iter()
+        .filter(|f| f.was_removed())
+        .for_each(|f| println!("{}", f));
+}
+
+pub fn resolve_features(target: Target) -> Result<(), String> {
+    match target {
+        Target::MainNet => { /* No features are active at all */ },
+        Target::NextNet => FEATURE_LIST
+            .iter()
+            .filter(|f| f.is_active_in_nextnet())
+            .for_each(activate_feature),
+        Target::TestNet => FEATURE_LIST
+            .iter()
+            .filter(|f| f.is_active_in_testnet())
+            .for_each(activate_feature),
+    }
+    Ok(())
+}
+
+pub fn activate_feature(feature: &Feature) {
+    println!("** Activating {} **", feature);
+    println!("cargo:rustc-cfg={}", feature.attr_name());
+}
+
+pub fn build_features() {
+    // Make sure to rebuild when the network changes
+    println!("cargo:rerun-if-env-changed=TARI_NETWORK");
+
+    let target = identify_target();
+    println!("Building for {}", target);
+    list_active_features();
+    list_removed_features();
+    if let Err(e) = resolve_features(target) {
+        eprintln!("Could not build Tari due to issues with the feature flag set.\n{}", e);
+        panic!();
+    }
+}

--- a/common/tari_features/src/resolver.rs
+++ b/common/tari_features/src/resolver.rs
@@ -32,6 +32,16 @@ pub enum Target {
     MainNet,
 }
 
+impl Target {
+    pub const fn as_key_str(&self) -> &'static str {
+        match self {
+            Target::MainNet => "mainnet",
+            Target::NextNet => "nextnet",
+            Target::TestNet => "testnet",
+        }
+    }
+}
+
 impl Display for Target {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -109,6 +119,7 @@ pub fn build_features() {
     println!("cargo:rerun-if-env-changed=TARI_NETWORK");
 
     let target = identify_target();
+    println!("cargo:rustc-cfg=tari_network_{}", target.as_key_str());
     println!("Building for {}", target);
     list_active_features();
     list_removed_features();

--- a/common/tari_features/src/status.rs
+++ b/common/tari_features/src/status.rs
@@ -1,0 +1,28 @@
+// Copyright 2023. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+pub enum Status {
+    New,     // new feature, may not even be working or compiling. Will be present on dibbler testnet
+    Testing, // potentially active feature, but still gated. Potentially present on nextnet,
+    Active,  // feature is live and gate has been removed. Will be running on stagenet and mainnet
+    Removed, // feature has been cancelled. Can not be invoked anywhere
+}

--- a/scripts/update_crate_metadata.sh
+++ b/scripts/update_crate_metadata.sh
@@ -45,6 +45,7 @@ function update_versions {
    base_layer/tari_mining_helper_ffi
    common
    common_sqlite
+   common/tari_features
    comms/core
    comms/dht
    comms/rpc_macros


### PR DESCRIPTION
Description
---
This PR is for reflective purposes regarding feature gating at compile time. See https://github.com/tari-project/tari/issues/5135 for more info. This PR as it stands is to be used as an example of a network _type_ based feature gate at compile time.
It allows setting an ENVVAR for the network with conditional compilation for features. The feature sets can be imported across any crate in the project easily and then used with the `#[cfg(tari_feature_...)]` attribute macro.

I've also introduced a secondary commit for binaries to perform a quick network check against itself to ensure the intended network is supported by the binary. This check is made non-invasive (not conditionally compiling possible network) as that method of check ends up being much more tedious.

Motivation and Context
---
We want some features on some networks, but maybe not all.

How Has This Been Tested?
---
Manually

What process can a PR reviewer use to test or verify this change?
---
Compile a binary with a set network
`TARI_NETWORK=nextnet cargo build --release --bin tari_base_node`

then run the binary with a test network as a parameter:

`./tari_base_node --network esme` 

and receive an error:

```
The application exited because of an internal network error. The network esmeralda is invalid for this binary built for NextNet
```

*Please note*

That running the binary will cause the build to default to the test network _always_. Meaning this will not work:

```
$ TARI_NETWORK=nextnet cargo build --release --bin tari_base_node
$ cargo run --release --bin tari_base_node --network nextnet
```

The second command `cargo run` will re-build the binary, and without the `TARI_NETWORK` env set the binary will default to a test binary.

In development if you want to call run and connect to a non test network you need to also pass the TARI_NETWORK envvar instead of the `--network` flag. 
`TARI_NETWORK=nextnet cargo run --bin tari_base_node --release -- --network nextnet`


Breaking Changes
---

- [x] None
