### PR TITLE
chore(version): v0.49.0-pre.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5114,7 +5114,7 @@ dependencies = [
 
 [[package]]
 name = "tari_app_grpc"
-version = "0.49.0-pre.5"
+version = "0.49.0-pre.6"
 dependencies = [
  "argon2",
  "base64 0.13.1",
@@ -5138,7 +5138,7 @@ dependencies = [
 
 [[package]]
 name = "tari_app_utilities"
-version = "0.49.0-pre.5"
+version = "0.49.0-pre.6"
 dependencies = [
  "clap 3.2.23",
  "futures 0.3.26",
@@ -5156,7 +5156,7 @@ dependencies = [
 
 [[package]]
 name = "tari_base_node"
-version = "0.49.0-pre.5"
+version = "0.49.0-pre.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5251,7 +5251,7 @@ dependencies = [
 
 [[package]]
 name = "tari_common"
-version = "0.49.0-pre.5"
+version = "0.49.0-pre.6"
 dependencies = [
  "anyhow",
  "blake2 0.9.2",
@@ -5277,7 +5277,7 @@ dependencies = [
 
 [[package]]
 name = "tari_common_sqlite"
-version = "0.49.0-pre.5"
+version = "0.49.0-pre.6"
 dependencies = [
  "chrono",
  "diesel",
@@ -5292,7 +5292,7 @@ dependencies = [
 
 [[package]]
 name = "tari_common_types"
-version = "0.49.0-pre.5"
+version = "0.49.0-pre.6"
 dependencies = [
  "borsh",
  "chacha20poly1305 0.10.1",
@@ -5310,7 +5310,7 @@ dependencies = [
 
 [[package]]
 name = "tari_comms"
-version = "0.49.0-pre.5"
+version = "0.49.0-pre.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5359,7 +5359,7 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_dht"
-version = "0.49.0-pre.5"
+version = "0.49.0-pre.6"
 dependencies = [
  "anyhow",
  "bitflags 1.3.2",
@@ -5403,7 +5403,7 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_rpc_macros"
-version = "0.49.0-pre.5"
+version = "0.49.0-pre.6"
 dependencies = [
  "futures 0.3.26",
  "proc-macro2",
@@ -5418,7 +5418,7 @@ dependencies = [
 
 [[package]]
 name = "tari_console_wallet"
-version = "0.49.0-pre.5"
+version = "0.49.0-pre.6"
 dependencies = [
  "bitflags 1.3.2",
  "chrono",
@@ -5466,7 +5466,7 @@ dependencies = [
 
 [[package]]
 name = "tari_contacts"
-version = "0.49.0-pre.5"
+version = "0.49.0-pre.6"
 dependencies = [
  "chrono",
  "diesel",
@@ -5494,7 +5494,7 @@ dependencies = [
 
 [[package]]
 name = "tari_core"
-version = "0.49.0-pre.5"
+version = "0.49.0-pre.6"
 dependencies = [
  "bincode",
  "bitflags 1.3.2",
@@ -5634,7 +5634,7 @@ dependencies = [
 
 [[package]]
 name = "tari_key_manager"
-version = "0.49.0-pre.5"
+version = "0.49.0-pre.6"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5688,7 +5688,7 @@ dependencies = [
 
 [[package]]
 name = "tari_merge_mining_proxy"
-version = "0.49.0-pre.5"
+version = "0.49.0-pre.6"
 dependencies = [
  "anyhow",
  "bincode",
@@ -5737,7 +5737,7 @@ dependencies = [
 
 [[package]]
 name = "tari_miner"
-version = "0.49.0-pre.5"
+version = "0.49.0-pre.6"
 dependencies = [
  "base64 0.13.1",
  "borsh",
@@ -5772,7 +5772,7 @@ dependencies = [
 
 [[package]]
 name = "tari_mining_helper_ffi"
-version = "0.49.0-pre.5"
+version = "0.49.0-pre.6"
 dependencies = [
  "borsh",
  "hex",
@@ -5788,7 +5788,7 @@ dependencies = [
 
 [[package]]
 name = "tari_mmr"
-version = "0.49.0-pre.5"
+version = "0.49.0-pre.6"
 dependencies = [
  "bincode",
  "blake2 0.9.2",
@@ -5808,7 +5808,7 @@ dependencies = [
 
 [[package]]
 name = "tari_p2p"
-version = "0.49.0-pre.5"
+version = "0.49.0-pre.6"
 dependencies = [
  "anyhow",
  "clap 2.34.0",
@@ -5862,7 +5862,7 @@ dependencies = [
 
 [[package]]
 name = "tari_service_framework"
-version = "0.49.0-pre.5"
+version = "0.49.0-pre.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5879,7 +5879,7 @@ dependencies = [
 
 [[package]]
 name = "tari_shutdown"
-version = "0.49.0-pre.5"
+version = "0.49.0-pre.6"
 dependencies = [
  "futures 0.3.26",
  "tokio",
@@ -5887,7 +5887,7 @@ dependencies = [
 
 [[package]]
 name = "tari_storage"
-version = "0.49.0-pre.5"
+version = "0.49.0-pre.6"
 dependencies = [
  "bincode",
  "lmdb-zero",
@@ -5900,7 +5900,7 @@ dependencies = [
 
 [[package]]
 name = "tari_test_utils"
-version = "0.49.0-pre.5"
+version = "0.49.0-pre.6"
 dependencies = [
  "futures 0.3.26",
  "futures-test",
@@ -5932,7 +5932,7 @@ dependencies = [
 
 [[package]]
 name = "tari_wallet"
-version = "0.49.0-pre.5"
+version = "0.49.0-pre.6"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5982,7 +5982,7 @@ dependencies = [
 
 [[package]]
 name = "tari_wallet_ffi"
-version = "0.49.0-pre.5"
+version = "0.49.0-pre.6"
 dependencies = [
  "borsh",
  "cbindgen 0.24.3",

--- a/applications/tari_app_grpc/Cargo.toml
+++ b/applications/tari_app_grpc/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "This crate is to provide a single source for all cross application grpc files and conversions to and from tari::core"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.49.0-pre.5"
+version = "0.49.0-pre.6"
 edition = "2018"
 
 [dependencies]

--- a/applications/tari_app_utilities/Cargo.toml
+++ b/applications/tari_app_utilities/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_app_utilities"
-version = "0.49.0-pre.5"
+version = "0.49.0-pre.6"
 authors = ["The Tari Development Community"]
 edition = "2018"
 license = "BSD-3-Clause"

--- a/applications/tari_base_node/Cargo.toml
+++ b/applications/tari_base_node/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "The tari full base node implementation"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.49.0-pre.5"
+version = "0.49.0-pre.6"
 edition = "2018"
 
 [dependencies]

--- a/applications/tari_console_wallet/Cargo.toml
+++ b/applications/tari_console_wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_console_wallet"
-version = "0.49.0-pre.5"
+version = "0.49.0-pre.6"
 authors = ["The Tari Development Community"]
 edition = "2018"
 license = "BSD-3-Clause"

--- a/applications/tari_merge_mining_proxy/Cargo.toml
+++ b/applications/tari_merge_mining_proxy/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "The Tari merge mining proxy for xmrig"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.49.0-pre.5"
+version = "0.49.0-pre.6"
 edition = "2018"
 
 [features]

--- a/applications/tari_miner/Cargo.toml
+++ b/applications/tari_miner/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "The tari miner implementation"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.49.0-pre.5"
+version = "0.49.0-pre.6"
 edition = "2018"
 
 [dependencies]

--- a/base_layer/common_types/Cargo.toml
+++ b/base_layer/common_types/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_common_types"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency common types"
 license = "BSD-3-Clause"
-version = "0.49.0-pre.5"
+version = "0.49.0-pre.6"
 edition = "2018"
 
 [dependencies]

--- a/base_layer/contacts/Cargo.toml
+++ b/base_layer/contacts/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_contacts"
 authors = ["The Tari Development Community"]
 description = "Tari contacts library"
 license = "BSD-3-Clause"
-version = "0.49.0-pre.5"
+version = "0.49.0-pre.6"
 edition = "2018"
 
 [dependencies]

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.49.0-pre.5"
+version = "0.49.0-pre.6"
 edition = "2018"
 
 [features]

--- a/base_layer/key_manager/Cargo.toml
+++ b/base_layer/key_manager/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency wallet key management"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.49.0-pre.5"
+version = "0.49.0-pre.6"
 edition = "2021"
 
 [lib]

--- a/base_layer/mmr/Cargo.toml
+++ b/base_layer/mmr/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "A Merkle Mountain Range implementation"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.49.0-pre.5"
+version = "0.49.0-pre.6"
 edition = "2018"
 
 [features]

--- a/base_layer/p2p/Cargo.toml
+++ b/base_layer/p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_p2p"
-version = "0.49.0-pre.5"
+version = "0.49.0-pre.6"
 authors = ["The Tari Development community"]
 description = "Tari base layer-specific peer-to-peer communication features"
 repository = "https://github.com/tari-project/tari"

--- a/base_layer/service_framework/Cargo.toml
+++ b/base_layer/service_framework/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_service_framework"
-version = "0.49.0-pre.5"
+version = "0.49.0-pre.6"
 authors = ["The Tari Development Community"]
 description = "The Tari communication stack service framework"
 repository = "https://github.com/tari-project/tari"

--- a/base_layer/tari_mining_helper_ffi/Cargo.toml
+++ b/base_layer/tari_mining_helper_ffi/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_mining_helper_ffi"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency miningcore C FFI bindings"
 license = "BSD-3-Clause"
-version = "0.49.0-pre.5"
+version = "0.49.0-pre.6"
 edition = "2018"
 
 [dependencies]

--- a/base_layer/wallet/Cargo.toml
+++ b/base_layer/wallet/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_wallet"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency wallet library"
 license = "BSD-3-Clause"
-version = "0.49.0-pre.5"
+version = "0.49.0-pre.6"
 edition = "2018"
 
 [dependencies]

--- a/base_layer/wallet_ffi/Cargo.toml
+++ b/base_layer/wallet_ffi/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_wallet_ffi"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency wallet C FFI bindings"
 license = "BSD-3-Clause"
-version = "0.49.0-pre.5"
+version = "0.49.0-pre.6"
 edition = "2018"
 
 [dependencies]

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,27 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [0.49.0-pre.6](https://github.com/tari-project/tari/compare/v0.49.0-pre.5...v0.49.0-pre.6) (2023-04-05)
+
+
+### ⚠ BREAKING CHANGES
+
+* move key manager service to key_manager (#5284)
+* add igor faucet (#5281)
+* reset dates for networks (#5283)
+
+### Features
+
+* add igor faucet ([#5281](https://github.com/tari-project/tari/issues/5281)) ([bfc92fd](https://github.com/tari-project/tari/commit/bfc92fdcb759aa31301cf11f239dc1aefd58ac63))
+* added auxiliary callback to push base node state changes [#5109](https://github.com/tari-project/tari/issues/5109) ([#5257](https://github.com/tari-project/tari/issues/5257)) ([b7f7d31](https://github.com/tari-project/tari/commit/b7f7d31fb634804ecf2f8ba1c39094163944f584))
+* move key manager service to key_manager ([#5284](https://github.com/tari-project/tari/issues/5284)) ([d50ed02](https://github.com/tari-project/tari/commit/d50ed02675dbca9294882e5bbe522b8fda00fb2a))
+* reset dates for networks ([#5283](https://github.com/tari-project/tari/issues/5283)) ([d6342a4](https://github.com/tari-project/tari/commit/d6342a4200cb7de469575d67129f9214535cf237))
+
+
+### Bug Fixes
+
+* resize transaction tab windows ([#5290](https://github.com/tari-project/tari/issues/5290)) ([bd95a85](https://github.com/tari-project/tari/commit/bd95a853b2eb166a4aa8e32778ed72bb1f8172ad)), closes [#4942](https://github.com/tari-project/tari/issues/4942) [#5289](https://github.com/tari-project/tari/issues/5289) [#12365](https://github.com/tari-project/tari/issues/12365)
+
 ## [0.49.0-pre.5](https://github.com/tari-project/tari/compare/v0.49.0-pre.4...v0.49.0-pre.5) (2023-04-04)
 
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.49.0-pre.5"
+version = "0.49.0-pre.6"
 edition = "2018"
 
 [features]

--- a/common_sqlite/Cargo.toml
+++ b/common_sqlite/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_common_sqlite"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency wallet library"
 license = "BSD-3-Clause"
-version = "0.49.0-pre.5"
+version = "0.49.0-pre.6"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/comms/core/Cargo.toml
+++ b/comms/core/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.49.0-pre.5"
+version = "0.49.0-pre.6"
 edition = "2018"
 
 [dependencies]

--- a/comms/dht/Cargo.toml
+++ b/comms/dht/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_comms_dht"
-version = "0.49.0-pre.5"
+version = "0.49.0-pre.6"
 authors = ["The Tari Development Community"]
 description = "Tari comms DHT module"
 repository = "https://github.com/tari-project/tari"

--- a/comms/rpc_macros/Cargo.toml
+++ b/comms/rpc_macros/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.49.0-pre.5"
+version = "0.49.0-pre.6"
 edition = "2018"
 
 [lib]

--- a/infrastructure/derive/Cargo.toml
+++ b/infrastructure/derive/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.49.0-pre.5"
+version = "0.49.0-pre.6"
 edition = "2018"
 
 [lib]

--- a/infrastructure/shutdown/Cargo.toml
+++ b/infrastructure/shutdown/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.49.0-pre.5"
+version = "0.49.0-pre.6"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/infrastructure/storage/Cargo.toml
+++ b/infrastructure/storage/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.49.0-pre.5"
+version = "0.49.0-pre.6"
 edition = "2018"
 
 [dependencies]

--- a/infrastructure/test_utils/Cargo.toml
+++ b/infrastructure/test_utils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_test_utils"
 description = "Utility functions used in Tari test functions"
-version = "0.49.0-pre.5"
+version = "0.49.0-pre.6"
 authors = ["The Tari Development Community"]
 edition = "2018"
 license = "BSD-3-Clause"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tari",
-  "version": "0.49.0-pre.5",
+  "version": "0.49.0-pre.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {}


### PR DESCRIPTION
## [0.49.0-pre.6](https://github.com/tari-project/tari/compare/v0.49.0-pre.5...v0.49.0-pre.6) (2023-04-05)


### ⚠ BREAKING CHANGES

* move key manager service to key_manager (5284)
* add igor faucet (5281)
* reset dates for networks (5283)

### Features

* add igor faucet ([5281](https://github.com/tari-project/tari/issues/5281)) ([bfc92fd](https://github.com/tari-project/tari/commit/bfc92fdcb759aa31301cf11f239dc1aefd58ac63))
* added auxiliary callback to push base node state changes [5109](https://github.com/tari-project/tari/issues/5109) ([#5257](https://github.com/tari-project/tari/issues/5257)) ([b7f7d31](https://github.com/tari-project/tari/commit/b7f7d31fb634804ecf2f8ba1c39094163944f584))
* move key manager service to key_manager ([5284](https://github.com/tari-project/tari/issues/5284)) ([d50ed02](https://github.com/tari-project/tari/commit/d50ed02675dbca9294882e5bbe522b8fda00fb2a))
* reset dates for networks ([5283](https://github.com/tari-project/tari/issues/5283)) ([d6342a4](https://github.com/tari-project/tari/commit/d6342a4200cb7de469575d67129f9214535cf237))


### Bug Fixes

* resize transaction tab windows ([5290](https://github.com/tari-project/tari/issues/5290)) ([bd95a85](https://github.com/tari-project/tari/commit/bd95a853b2eb166a4aa8e32778ed72bb1f8172ad)), closes [#4942](https://github.com/tari-project/tari/issues/4942) [#5289](https://github.com/tari-project/tari/issues/5289) [#12365](https://github.com/tari-project/tari/issues/12365)
