### PR TITLE
ci(fix): add TARI_NETWORK env support in GHA docker builds

### DIFF
--- a/.github/workflows/build_dockers_workflow.yml
+++ b/.github/workflows/build_dockers_workflow.yml
@@ -112,6 +112,24 @@ jobs:
           ref: ${{ env.LAUNCHPAD_BRANCH }}
           path: tari-launchpad
 
+      - name: Declare TestNet for tags
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        shell: bash
+        run: |
+          tagnet=${{github.ref_name}}
+          echo $tagnet
+          # case match is not RegEx, but wildcards/globs
+          case "$tagnet" in
+            v*-pre.*) TARI_NETWORK=esme
+              ;;
+            v*-rc.*) TARI_NETWORK=nextnet
+              ;;
+            *) TARI_NETWORK=mainnet
+              ;;
+          esac
+          echo ${TARI_NETWORK}
+          echo "TARI_NETWORK=${TARI_NETWORK}" >> $GITHUB_ENV
+
       - name: environment setup
         shell: bash
         run: |
@@ -211,6 +229,7 @@ jobs:
             FEATURES=${{ inputs.features }}
             APP_NAME=${{ matrix.builds.app_name }}
             APP_EXEC=${{ matrix.builds.app_exec }}
+            TARI_NETWORK=${{ env.TARI_NETWORK }}
             ${{ env.DOCKER_SUBTAG }}
           tags: |
             ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
Description
add TARI_NETWORK env support in GHA docker builds

Motivation and Context
Support ```TARI_NETWORK``` env selection from git tag in docker builds

How Has This Been Tested?
Build locally and in local fork

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
