### PR TITLE
feat: relax message size constraint

### DIFF
--- a/comms/core/src/protocol/rpc/mod.rs
+++ b/comms/core/src/protocol/rpc/mod.rs
@@ -32,7 +32,7 @@ mod test;
 /// This can be thought of as the hard limit on message size.
 pub const RPC_MAX_FRAME_SIZE: usize = 3 * 1024 * 1024; // 3 MiB
 /// Maximum number of chunks into which a message can be broken up.
-const RPC_CHUNKING_MAX_CHUNKS: usize = 16; // 16 x 256 Kib = 4 MiB max combined message size
+const RPC_CHUNKING_MAX_CHUNKS: usize = 20; // 20 x 256 Kib = 5 MiB max combined message size
 const RPC_CHUNKING_THRESHOLD: usize = 256 * 1024;
 const RPC_CHUNKING_SIZE_LIMIT: usize = 384 * 1024;
 


### PR DESCRIPTION
Description
---
Relaxed the message size constraint from 4 MiB to 5 MiB as it prevented faucet outputs from being streamed in an RPC request when a wallet requested all outputs.

Motivation and Context
---
Faucet outputs could not be streamed to the console wallet:
```
2023-04-06 17:08:52.630699700 [wallet::utxo_scanning] WARN  Failed to scan UTXO's from base node 6b8a34873128fc5323a86fbe6e: RpcStatus: `MalformedResponse: The response size exceeded the maximum allowed payload size. Max = 4.0000 MiB, Got = 4.5924 MiB`
2023-04-06 17:08:52.631420600 [wallet::utxo_scanning] WARN  Failed to scan UTXO's from base node 6b8a34873128fc5323a86fbe6e: RpcError: `Remote peer unexpectedly closed the RPC connection`
2023-04-06 17:08:52.631441300 [wallet::utxo_scanning] ERROR Error scanning UTXOs: Utxo Scanning Error: 'Failed to scan UTXO's after 2 attempt(s) using sync peer(s). Aborting...
```

How Has This Been Tested?
---
System-level testing on `igor`

What process can a PR reviewer use to test or verify this change?
---
System-level testing on `igor` 
- Prior to this PR: create a new wallet and monitor the log file for the error
- With this PR: create a new wallet and verify in the log file that UTXO scanning succeeds

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
