### PR TITLE
feat: fix rpc transaction conversion

### DIFF
--- a/base_layer/core/src/proto/transaction.rs
+++ b/base_layer/core/src/proto/transaction.rs
@@ -259,7 +259,7 @@ impl TryFrom<proto::types::TransactionOutput> for TransactionOutput {
 
         let encrypted_value = EncryptedValue::from_bytes(&output.encrypted_value).map_err(|err| err.to_string())?;
 
-        let minimum_value_promise = MicroTari::zero();
+        let minimum_value_promise = output.minimum_value_promise.into();
 
         Ok(Self::new(
             TransactionOutputVersion::try_from(

--- a/base_layer/core/src/transactions/transaction_components/transaction_output.rs
+++ b/base_layer/core/src/transactions/transaction_components/transaction_output.rs
@@ -29,7 +29,6 @@ use std::{
 };
 
 use borsh::{BorshDeserialize, BorshSerialize};
-use log::*;
 use rand::rngs::OsRng;
 use serde::{Deserialize, Serialize};
 use tari_common_types::types::{
@@ -572,7 +571,7 @@ pub fn batch_verify_range_proofs(
         Ok(_) => Ok(()),
         Err(err_1) => {
             for output in outputs.iter() {
-                match output.verify_range_proof(&prover) {
+                match output.verify_range_proof(prover) {
                     Ok(_) => {},
                     Err(err_2) => {
                         let proof = output.proof.to_hex();


### PR DESCRIPTION
Description
---
Fixed RPC transaction proto conversion

Motivation and Context
---
With the RPC conversion `minimum_value_promise` was zeroed instead of assigned
See #5295 

How Has This Been Tested?
---

What process can a PR reviewer use to test or verify this change?
---
Run a system-level test to submit a transaction via gRPC to a base node where an output has `minimum_value_promise != 0` and then mine the transaction

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
