### PR TITLE
chore(release): nextnet hotfix default network selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5271,6 +5271,7 @@ dependencies = [
  "sha2 0.9.9",
  "structopt",
  "tari_crypto",
+ "tari_features",
  "tari_test_utils",
  "tempfile",
  "thiserror",
@@ -5593,9 +5594,6 @@ dependencies = [
 [[package]]
 name = "tari_features"
 version = "0.50.0-pre.0"
-dependencies = [
- "tari_common",
-]
 
 [[package]]
 name = "tari_integration_tests"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5114,7 +5114,7 @@ dependencies = [
 
 [[package]]
 name = "tari_app_grpc"
-version = "0.49.0-rc.0"
+version = "0.49.0-rc.1"
 dependencies = [
  "argon2",
  "base64 0.13.1",
@@ -5138,7 +5138,7 @@ dependencies = [
 
 [[package]]
 name = "tari_app_utilities"
-version = "0.49.0-rc.0"
+version = "0.49.0-rc.1"
 dependencies = [
  "clap 3.2.23",
  "futures 0.3.26",
@@ -5157,7 +5157,7 @@ dependencies = [
 
 [[package]]
 name = "tari_base_node"
-version = "0.49.0-rc.0"
+version = "0.49.0-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5253,7 +5253,7 @@ dependencies = [
 
 [[package]]
 name = "tari_common"
-version = "0.49.0-rc.0"
+version = "0.49.0-rc.1"
 dependencies = [
  "anyhow",
  "blake2 0.9.2",
@@ -5280,7 +5280,7 @@ dependencies = [
 
 [[package]]
 name = "tari_common_sqlite"
-version = "0.49.0-rc.0"
+version = "0.49.0-rc.1"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -5294,7 +5294,7 @@ dependencies = [
 
 [[package]]
 name = "tari_common_types"
-version = "0.49.0-rc.0"
+version = "0.49.0-rc.1"
 dependencies = [
  "borsh",
  "chacha20poly1305 0.10.1",
@@ -5312,7 +5312,7 @@ dependencies = [
 
 [[package]]
 name = "tari_comms"
-version = "0.49.0-rc.0"
+version = "0.49.0-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5361,7 +5361,7 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_dht"
-version = "0.49.0-rc.0"
+version = "0.49.0-rc.1"
 dependencies = [
  "anyhow",
  "bitflags 1.3.2",
@@ -5405,7 +5405,7 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_rpc_macros"
-version = "0.49.0-rc.0"
+version = "0.49.0-rc.1"
 dependencies = [
  "futures 0.3.26",
  "proc-macro2",
@@ -5420,7 +5420,7 @@ dependencies = [
 
 [[package]]
 name = "tari_console_wallet"
-version = "0.49.0-rc.0"
+version = "0.49.0-rc.1"
 dependencies = [
  "bitflags 1.3.2",
  "chrono",
@@ -5469,7 +5469,7 @@ dependencies = [
 
 [[package]]
 name = "tari_contacts"
-version = "0.50.0-pre.0"
+version = "0.49.0-rc.1"
 dependencies = [
  "chrono",
  "diesel",
@@ -5497,7 +5497,7 @@ dependencies = [
 
 [[package]]
 name = "tari_core"
-version = "0.49.0-rc.0"
+version = "0.49.0-rc.1"
 dependencies = [
  "bincode",
  "bitflags 1.3.2",
@@ -5593,7 +5593,7 @@ dependencies = [
 
 [[package]]
 name = "tari_features"
-version = "0.50.0-pre.0"
+version = "0.49.0-rc.1"
 
 [[package]]
 name = "tari_integration_tests"
@@ -5641,7 +5641,7 @@ dependencies = [
 
 [[package]]
 name = "tari_key_manager"
-version = "0.49.0-rc.0"
+version = "0.49.0-rc.1"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5695,7 +5695,7 @@ dependencies = [
 
 [[package]]
 name = "tari_merge_mining_proxy"
-version = "0.49.0-rc.0"
+version = "0.49.0-rc.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -5745,7 +5745,7 @@ dependencies = [
 
 [[package]]
 name = "tari_miner"
-version = "0.49.0-rc.0"
+version = "0.49.0-rc.1"
 dependencies = [
  "base64 0.13.1",
  "borsh",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "tari_mining_helper_ffi"
-version = "0.49.0-rc.0"
+version = "0.49.0-rc.1"
 dependencies = [
  "borsh",
  "hex",
@@ -5796,7 +5796,7 @@ dependencies = [
 
 [[package]]
 name = "tari_mmr"
-version = "0.49.0-rc.0"
+version = "0.49.0-rc.1"
 dependencies = [
  "bincode",
  "blake2 0.9.2",
@@ -5816,7 +5816,7 @@ dependencies = [
 
 [[package]]
 name = "tari_p2p"
-version = "0.49.0-rc.0"
+version = "0.49.0-rc.1"
 dependencies = [
  "anyhow",
  "clap 2.34.0",
@@ -5870,7 +5870,7 @@ dependencies = [
 
 [[package]]
 name = "tari_service_framework"
-version = "0.49.0-rc.0"
+version = "0.49.0-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5887,7 +5887,7 @@ dependencies = [
 
 [[package]]
 name = "tari_shutdown"
-version = "0.49.0-rc.0"
+version = "0.49.0-rc.1"
 dependencies = [
  "futures 0.3.26",
  "tokio",
@@ -5895,7 +5895,7 @@ dependencies = [
 
 [[package]]
 name = "tari_storage"
-version = "0.49.0-rc.0"
+version = "0.49.0-rc.1"
 dependencies = [
  "bincode",
  "lmdb-zero",
@@ -5908,7 +5908,7 @@ dependencies = [
 
 [[package]]
 name = "tari_test_utils"
-version = "0.49.0-rc.0"
+version = "0.49.0-rc.1"
 dependencies = [
  "futures 0.3.26",
  "futures-test",
@@ -5940,7 +5940,7 @@ dependencies = [
 
 [[package]]
 name = "tari_wallet"
-version = "0.49.0-rc.0"
+version = "0.49.0-rc.1"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5990,7 +5990,7 @@ dependencies = [
 
 [[package]]
 name = "tari_wallet_ffi"
-version = "0.49.0-rc.0"
+version = "0.49.0-rc.1"
 dependencies = [
  "borsh",
  "cbindgen 0.24.3",

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The recommended running versions of each network are:
 | Network  | Version      | 
 |----------|--------------|
 | Stagenet | 0.45.0       |
-| Nextnet  | 0.48.0-rc.2  |
+| Nextnet  | 0.49.0-rc.1  |
 | Development | 0.50.0-pre.0 |
 
 For more detail about versioning see [Release Ideology](https://github.com/tari-project/tari/blob/development/docs/src/branching_releases.md)

--- a/applications/tari_app_grpc/Cargo.toml
+++ b/applications/tari_app_grpc/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "This crate is to provide a single source for all cross application grpc files and conversions to and from tari::core"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.49.0-rc.0"
+version = "0.49.0-rc.1"
 edition = "2018"
 
 [dependencies]

--- a/applications/tari_app_utilities/Cargo.toml
+++ b/applications/tari_app_utilities/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_app_utilities"
-version = "0.49.0-rc.0"
+version = "0.49.0-rc.1"
 authors = ["The Tari Development Community"]
 edition = "2018"
 license = "BSD-3-Clause"
@@ -9,7 +9,7 @@ license = "BSD-3-Clause"
 tari_common = { path = "../../common" }
 tari_common_types = { path = "../../base_layer/common_types" }
 tari_comms = { path = "../../comms/core" }
-tari_features = { version = "0.50.0-pre.0", path = "../../common/tari_features"}
+tari_features = { version = "0.49.0-rc.1", path = "../../common/tari_features"}
 tari_utilities = { version = "0.4.10"}
 
 clap = { version = "3.2.0", features = ["derive", "env"] }
@@ -23,4 +23,4 @@ thiserror = "^1.0.26"
 
 [build-dependencies]
 tari_common = { path = "../../common", features = ["build", "static-application-info"] }
-tari_features = { version = "0.50.0-pre.0", path = "../../common/tari_features"}
+tari_features = { version = "0.49.0-rc.1", path = "../../common/tari_features"}

--- a/applications/tari_base_node/Cargo.toml
+++ b/applications/tari_base_node/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "The tari full base node implementation"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.49.0-rc.0"
+version = "0.49.0-rc.1"
 edition = "2018"
 
 [dependencies]
@@ -58,4 +58,4 @@ safe = []
 libtor = ["tari_libtor"]
 
 [build-dependencies]
-tari_features = { version = "0.50.0-pre.0", path = "../../common/tari_features"}
+tari_features = { version = "0.49.0-rc.1", path = "../../common/tari_features"}

--- a/applications/tari_console_wallet/Cargo.toml
+++ b/applications/tari_console_wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_console_wallet"
-version = "0.49.0-rc.0"
+version = "0.49.0-rc.1"
 authors = ["The Tari Development Community"]
 edition = "2018"
 license = "BSD-3-Clause"
@@ -14,7 +14,7 @@ tari_comms = { path = "../../comms/core" }
 tari_comms_dht = { path = "../../comms/dht" }
 tari_contacts = { path = "../../base_layer/contacts" }
 tari_crypto = { version = "0.16.11"}
-tari_features = { version = "0.50.0-pre.0", path = "../../common/tari_features"}
+tari_features = { version = "0.49.0-rc.1", path = "../../common/tari_features"}
 tari_key_manager = { path = "../../base_layer/key_manager" }
 tari_libtor = { path = "../../infrastructure/libtor", optional = true }
 tari_p2p = { path = "../../base_layer/p2p", features = ["auto-update"] }
@@ -65,7 +65,7 @@ default-features = false
 features = ["crossterm"]
 
 [build-dependencies]
-tari_features = { version = "0.50.0-pre.0", path = "../../common/tari_features"}
+tari_features = { version = "0.49.0-rc.1", path = "../../common/tari_features"}
 
 [features]
 avx2 = ["tari_core/avx2", "tari_crypto/simd_backend", "tari_wallet/avx2", "tari_comms/avx2", "tari_comms_dht/avx2", "tari_p2p/avx2", "tari_key_manager/avx2"]

--- a/applications/tari_merge_mining_proxy/Cargo.toml
+++ b/applications/tari_merge_mining_proxy/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "The Tari merge mining proxy for xmrig"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.49.0-rc.0"
+version = "0.49.0-rc.1"
 edition = "2018"
 
 [features]
@@ -42,4 +42,4 @@ tracing = "0.1"
 url = "2.1.1"
 
 [build-dependencies]
-tari_features = { version = "0.50.0-pre.0", path = "../../common/tari_features"}
+tari_features = { version = "0.49.0-rc.1", path = "../../common/tari_features"}

--- a/applications/tari_miner/Cargo.toml
+++ b/applications/tari_miner/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "The tari miner implementation"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.49.0-rc.0"
+version = "0.49.0-rc.1"
 edition = "2018"
 
 [dependencies]

--- a/base_layer/common_types/Cargo.toml
+++ b/base_layer/common_types/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_common_types"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency common types"
 license = "BSD-3-Clause"
-version = "0.49.0-rc.0"
+version = "0.49.0-rc.1"
 edition = "2018"
 
 [dependencies]

--- a/base_layer/contacts/Cargo.toml
+++ b/base_layer/contacts/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_contacts"
 authors = ["The Tari Development Community"]
 description = "Tari contacts library"
 license = "BSD-3-Clause"
-version = "0.50.0-pre.0"
+version = "0.49.0-rc.1"
 edition = "2018"
 
 [dependencies]

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.49.0-rc.0"
+version = "0.49.0-rc.1"
 edition = "2018"
 
 [features]

--- a/base_layer/key_manager/Cargo.toml
+++ b/base_layer/key_manager/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency wallet key management"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.49.0-rc.0"
+version = "0.49.0-rc.1"
 edition = "2021"
 
 [lib]

--- a/base_layer/mmr/Cargo.toml
+++ b/base_layer/mmr/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "A Merkle Mountain Range implementation"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.49.0-rc.0"
+version = "0.49.0-rc.1"
 edition = "2018"
 
 [features]

--- a/base_layer/p2p/Cargo.toml
+++ b/base_layer/p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_p2p"
-version = "0.49.0-rc.0"
+version = "0.49.0-rc.1"
 authors = ["The Tari Development community"]
 description = "Tari base layer-specific peer-to-peer communication features"
 repository = "https://github.com/tari-project/tari"

--- a/base_layer/service_framework/Cargo.toml
+++ b/base_layer/service_framework/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_service_framework"
-version = "0.49.0-rc.0"
+version = "0.49.0-rc.1"
 authors = ["The Tari Development Community"]
 description = "The Tari communication stack service framework"
 repository = "https://github.com/tari-project/tari"

--- a/base_layer/tari_mining_helper_ffi/Cargo.toml
+++ b/base_layer/tari_mining_helper_ffi/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_mining_helper_ffi"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency miningcore C FFI bindings"
 license = "BSD-3-Clause"
-version = "0.49.0-rc.0"
+version = "0.49.0-rc.1"
 edition = "2018"
 
 [dependencies]

--- a/base_layer/wallet/Cargo.toml
+++ b/base_layer/wallet/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_wallet"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency wallet library"
 license = "BSD-3-Clause"
-version = "0.49.0-rc.0"
+version = "0.49.0-rc.1"
 edition = "2018"
 
 [dependencies]

--- a/base_layer/wallet_ffi/Cargo.toml
+++ b/base_layer/wallet_ffi/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_wallet_ffi"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency wallet C FFI bindings"
 license = "BSD-3-Clause"
-version = "0.49.0-rc.0"
+version = "0.49.0-rc.1"
 edition = "2018"
 
 [dependencies]

--- a/changelog-nextnet.md
+++ b/changelog-nextnet.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [0.49.0-rc.1](https://github.com/tari-project/tari/compare/v0.49.0-rc.0...v0.49.0-rc.1) (2023-04-17)
+
+
+### Bug Fixes
+
+* Default network selection ([7acbebd](https://github.com/tari-project/tari/commit/7acbebd5d2b3f001176954dd8f03226f571c93cf))
+* wallet ffi header file ([#5329](https://github.com/tari-project/tari/issues/5329)) ([b0d2032](https://github.com/tari-project/tari/commit/b0d2032c680bbc9914acf21f42ae79499b6c9a44))
+
+
 ## [0.49.0-rc.0](https://github.com/tari-project/tari/compare/v0.48.0-rc.0...v0.49.0-rc.0) (2023-04-12)
 
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -38,3 +38,6 @@ blake2 = "0.9.1"
 [dev-dependencies]
 tari_test_utils = {  path = "../infrastructure/test_utils"}
 toml = "0.5.8"
+
+[build-dependencies]
+tari_features = { version = "0.50.0-pre.0", path = "./tari_features"}

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.49.0-rc.0"
+version = "0.49.0-rc.1"
 edition = "2018"
 
 [features]
@@ -40,4 +40,4 @@ tari_test_utils = {  path = "../infrastructure/test_utils"}
 toml = "0.5.8"
 
 [build-dependencies]
-tari_features = { version = "0.50.0-pre.0", path = "./tari_features"}
+tari_features = { version = "0.49.0-rc.1", path = "./tari_features"}

--- a/common/build.rs
+++ b/common/build.rs
@@ -1,0 +1,9 @@
+// Copyright 2023 The Tari Project
+// SPDX-License-Identifier: BSD-3-Clause
+
+use tari_features::resolver::build_features;
+
+pub fn main() {
+    build_features();
+    // Build as usual
+}

--- a/common/tari_features/Cargo.toml
+++ b/common/tari_features/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.50.0-pre.0"
+version = "0.49.0-rc.1"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/common/tari_features/Cargo.toml
+++ b/common/tari_features/Cargo.toml
@@ -11,5 +11,6 @@ edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[dependencies]
-tari_common = { path = "../../common" }
+# So you're thinking about adding a dependency here?
+# This crate is utilized in the compilation of _most_ of our other crates. You're probably about
+# to create a cyclic depedency. Please think hard whether this change is actually required.

--- a/common/tari_features/src/resolver.rs
+++ b/common/tari_features/src/resolver.rs
@@ -20,9 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{fmt::Display, str::FromStr};
-
-use tari_common::configuration::Network;
+use std::fmt::Display;
 
 use crate::{Feature, FEATURE_LIST};
 
@@ -38,6 +36,17 @@ impl Target {
             Target::MainNet => "mainnet",
             Target::NextNet => "nextnet",
             Target::TestNet => "testnet",
+        }
+    }
+
+    pub fn from_network_str(value: &str) -> Self {
+        // The duplication of network names here isn't great but we're being lazy and non-exhaustive
+        // regarding the endless testnet possibilities. This minor MainNet, StageNet, and NextNet
+        // duplication allows us to leave the crate dependency free.
+        match value.to_lowercase().as_str() {
+            "mainnet" | "stagenet" => Target::MainNet,
+            "nextnet" => Target::NextNet,
+            _ => Target::TestNet,
         }
     }
 }
@@ -64,16 +73,7 @@ pub fn identify_target() -> Target {
 
 pub fn check_envar(envar: &str) -> Option<Target> {
     match std::env::var(envar) {
-        Ok(s) => {
-            let network =
-                Network::from_str(s.to_lowercase().as_str()).unwrap_or_else(|_| panic!("Unknown network, {}", s));
-            match network {
-                Network::MainNet | Network::StageNet => Some(Target::MainNet),
-                Network::NextNet => Some(Target::NextNet),
-                Network::LocalNet | Network::Igor | Network::Esmeralda => Some(Target::TestNet),
-                Network::Weatherwax | Network::Ridcully | Network::Stibbons | Network::Dibbler => None,
-            }
-        },
+        Ok(s) => Some(Target::from_network_str(s.to_lowercase().as_str())),
         _ => None,
     }
 }

--- a/common_sqlite/Cargo.toml
+++ b/common_sqlite/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_common_sqlite"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency wallet library"
 license = "BSD-3-Clause"
-version = "0.49.0-rc.0"
+version = "0.49.0-rc.1"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/comms/core/Cargo.toml
+++ b/comms/core/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.49.0-rc.0"
+version = "0.49.0-rc.1"
 edition = "2018"
 
 [dependencies]

--- a/comms/dht/Cargo.toml
+++ b/comms/dht/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_comms_dht"
-version = "0.49.0-rc.0"
+version = "0.49.0-rc.1"
 authors = ["The Tari Development Community"]
 description = "Tari comms DHT module"
 repository = "https://github.com/tari-project/tari"

--- a/comms/rpc_macros/Cargo.toml
+++ b/comms/rpc_macros/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.49.0-rc.0"
+version = "0.49.0-rc.1"
 edition = "2018"
 
 [lib]

--- a/infrastructure/derive/Cargo.toml
+++ b/infrastructure/derive/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.49.0-rc.0"
+version = "0.49.0-rc.1"
 edition = "2018"
 
 [lib]

--- a/infrastructure/shutdown/Cargo.toml
+++ b/infrastructure/shutdown/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.49.0-rc.0"
+version = "0.49.0-rc.1"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/infrastructure/storage/Cargo.toml
+++ b/infrastructure/storage/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.49.0-rc.0"
+version = "0.49.0-rc.1"
 edition = "2018"
 
 [dependencies]

--- a/infrastructure/test_utils/Cargo.toml
+++ b/infrastructure/test_utils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_test_utils"
 description = "Utility functions used in Tari test functions"
-version = "0.49.0-rc.0"
+version = "0.49.0-rc.1"
 authors = ["The Tari Development Community"]
 edition = "2018"
 license = "BSD-3-Clause"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tari",
-  "version": "0.50.0-pre.0",
+  "version": "0.49.0-rc.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {}


### PR DESCRIPTION
Description
---
Features is now a frequently used build dep in most our crates. Common actually also needs to be feature aware during build time. This means tari-features should have little to no dependencies, and especially none from our own crates.

Motivation and Context
---
Related to #5326 
Development fix: #5333 

How Has This Been Tested?
---
Manually

What process can a PR reviewer use to test or verify this change?
---
Run cargo build with the desired network type (nextnet):
`TARI_NETWORK=nextnet cargo build --bin tari_base_node`

Run the bin directly without using cargo. It's important not to use cargo during the testing as the bin will likely rebuild when using `run` and change the previous `TARI_NETWORK` compilation settings:
`./target/tari_base_node` 

See that the default network is NextNet.

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify