### PR TITLE
fix: default network selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5271,6 +5271,7 @@ dependencies = [
  "sha2 0.9.9",
  "structopt",
  "tari_crypto",
+ "tari_features",
  "tari_test_utils",
  "tempfile",
  "thiserror",
@@ -5593,9 +5594,6 @@ dependencies = [
 [[package]]
 name = "tari_features"
 version = "0.50.0-pre.0"
-dependencies = [
- "tari_common",
-]
 
 [[package]]
 name = "tari_integration_tests"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -38,3 +38,6 @@ blake2 = "0.9.1"
 [dev-dependencies]
 tari_test_utils = {  path = "../infrastructure/test_utils"}
 toml = "0.5.8"
+
+[build-dependencies]
+tari_features = { version = "0.50.0-pre.0", path = "./tari_features"}

--- a/common/build.rs
+++ b/common/build.rs
@@ -1,0 +1,9 @@
+// Copyright 2023 The Tari Project
+// SPDX-License-Identifier: BSD-3-Clause
+
+use tari_features::resolver::build_features;
+
+pub fn main() {
+    build_features();
+    // Build as usual
+}

--- a/common/tari_features/Cargo.toml
+++ b/common/tari_features/Cargo.toml
@@ -11,5 +11,6 @@ edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[dependencies]
-tari_common = { path = "../../common" }
+# So you're thinking about adding a dependency here?
+# This crate is utilized in the compilation of _most_ of our other crates. You're probably about
+# to create a cyclic depedency. Please think hard whether this change is actually required.

--- a/common/tari_features/src/resolver.rs
+++ b/common/tari_features/src/resolver.rs
@@ -20,9 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{fmt::Display, str::FromStr};
-
-use tari_common::configuration::Network;
+use std::fmt::Display;
 
 use crate::{Feature, FEATURE_LIST};
 
@@ -38,6 +36,17 @@ impl Target {
             Target::MainNet => "mainnet",
             Target::NextNet => "nextnet",
             Target::TestNet => "testnet",
+        }
+    }
+
+    pub fn from_network_str(value: &str) -> Self {
+        // The duplication of network names here isn't great but we're being lazy and non-exhaustive
+        // regarding the endless testnet possibilities. This minor MainNet, StageNet, and NextNet
+        // duplication allows us to leave the crate dependency free.
+        match value.to_lowercase().as_str() {
+            "mainnet" | "stagenet" => Target::MainNet,
+            "nextnet" => Target::NextNet,
+            _ => Target::TestNet,
         }
     }
 }
@@ -64,16 +73,7 @@ pub fn identify_target() -> Target {
 
 pub fn check_envar(envar: &str) -> Option<Target> {
     match std::env::var(envar) {
-        Ok(s) => {
-            let network =
-                Network::from_str(s.to_lowercase().as_str()).unwrap_or_else(|_| panic!("Unknown network, {}", s));
-            match network {
-                Network::MainNet | Network::StageNet => Some(Target::MainNet),
-                Network::NextNet => Some(Target::NextNet),
-                Network::LocalNet | Network::Igor | Network::Esmeralda => Some(Target::TestNet),
-                Network::Weatherwax | Network::Ridcully | Network::Stibbons | Network::Dibbler => None,
-            }
-        },
+        Ok(s) => Some(Target::from_network_str(s.to_lowercase().as_str())),
         _ => None,
     }
 }


### PR DESCRIPTION
Description
---
Features is now a frequently used build dep in most our crates. Common actually also needs to be feature aware during build time. This means tari-features should have little to no dependencies, and especially none from our own crates.

Motivation and Context
---
Related to issue #5326 
Related to nextnet hotfix #5327 

How Has This Been Tested?
---
Manually

What process can a PR reviewer use to test or verify this change?
---
Run cargo build with the desired network type (nextnet):
`TARI_NETWORK=nextnet cargo build --bin tari_base_node`

Run the bin directly without using cargo. It's important not to use cargo during the testing as the bin will likely rebuild when using `run` and change the previous `TARI_NETWORK` compilation settings:
`./target/tari_base_node` 

See that the default network is NextNet.

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
