### PR TITLE
fix: clippy issues with config

### DIFF
--- a/applications/tari_base_node/src/main.rs
+++ b/applications/tari_base_node/src/main.rs
@@ -130,7 +130,10 @@ fn main_inner() -> Result<(), ExitError> {
         consts::APP_VERSION
     );
 
+    #[cfg(all(unix, feature = "libtor"))]
     let mut config = ApplicationConfig::load_from(&cfg)?;
+    #[cfg(not(all(unix, feature = "libtor")))]
+    let config = ApplicationConfig::load_from(&cfg)?;
     debug!(target: LOG_TARGET, "Using base node configuration: {:?}", config);
 
     // Load or create the Node identity


### PR DESCRIPTION
Description
---
Apply the mut to the config only when unix and libtor flag is used. Otherwise that piece of code (the one where mut is actually needed) is never used and then clippy complains that `mut` is not necessary.


<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
