### PR TITLE
fix: deeplink to rfc spec

### DIFF
--- a/applications/tari_console_wallet/src/ui/state/app_state.rs
+++ b/applications/tari_console_wallet/src/ui/state/app_state.rs
@@ -1084,7 +1084,7 @@ pub struct EventListItem {
 impl AppStateData {
     pub fn new(wallet_identity: &WalletIdentity, base_node_selected: Peer, base_node_config: PeerConfig) -> Self {
         let eid = wallet_identity.address.to_emoji_string();
-        let qr_link = format!("tari_address://{}", wallet_identity.address.to_hex());
+        let qr_link = format!("tari://{}/transactions/send?tariAddress={}", wallet_identity.network,wallet_identity.address.to_hex());
         let code = QrCode::new(qr_link).unwrap();
         let image = code
             .render::<unicode::Dense1x2>()

--- a/applications/tari_console_wallet/src/ui/state/app_state.rs
+++ b/applications/tari_console_wallet/src/ui/state/app_state.rs
@@ -1084,7 +1084,11 @@ pub struct EventListItem {
 impl AppStateData {
     pub fn new(wallet_identity: &WalletIdentity, base_node_selected: Peer, base_node_config: PeerConfig) -> Self {
         let eid = wallet_identity.address.to_emoji_string();
-        let qr_link = format!("tari://{}/transactions/send?tariAddress={}", wallet_identity.network,wallet_identity.address.to_hex());
+        let qr_link = format!(
+            "tari://{}/transactions/send?tariAddress={}",
+            wallet_identity.network,
+            wallet_identity.address.to_hex()
+        );
         let code = QrCode::new(qr_link).unwrap();
         let image = code
             .render::<unicode::Dense1x2>()


### PR DESCRIPTION
Description
---
Fixes the console wallet  QR code deeplink to RFC spec

Motivation and Context
---
The current QR code does not follow [RFC-0154](https://rfc.tari.com/RFC-0154_DeepLinksConvencion.html)

How Has This Been Tested?
---
Manual 

What process can a PR reviewer use to test or verify this change?
---
Run a Console wallet and inspect the QR code
