### PR TITLE
chore(release): nextnet hotfix, fix console wallet qr code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5114,7 +5114,7 @@ dependencies = [
 
 [[package]]
 name = "tari_app_grpc"
-version = "0.49.0-rc.2"
+version = "0.49.0-rc.3"
 dependencies = [
  "argon2",
  "base64 0.13.1",
@@ -5138,7 +5138,7 @@ dependencies = [
 
 [[package]]
 name = "tari_app_utilities"
-version = "0.49.0-rc.2"
+version = "0.49.0-rc.3"
 dependencies = [
  "clap 3.2.23",
  "futures 0.3.26",
@@ -5157,7 +5157,7 @@ dependencies = [
 
 [[package]]
 name = "tari_base_node"
-version = "0.49.0-rc.2"
+version = "0.49.0-rc.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5253,7 +5253,7 @@ dependencies = [
 
 [[package]]
 name = "tari_common"
-version = "0.49.0-rc.2"
+version = "0.49.0-rc.3"
 dependencies = [
  "anyhow",
  "blake2 0.9.2",
@@ -5280,7 +5280,7 @@ dependencies = [
 
 [[package]]
 name = "tari_common_sqlite"
-version = "0.49.0-rc.2"
+version = "0.49.0-rc.3"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -5294,7 +5294,7 @@ dependencies = [
 
 [[package]]
 name = "tari_common_types"
-version = "0.49.0-rc.2"
+version = "0.49.0-rc.3"
 dependencies = [
  "borsh",
  "chacha20poly1305 0.10.1",
@@ -5312,7 +5312,7 @@ dependencies = [
 
 [[package]]
 name = "tari_comms"
-version = "0.49.0-rc.2"
+version = "0.49.0-rc.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5361,7 +5361,7 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_dht"
-version = "0.49.0-rc.2"
+version = "0.49.0-rc.3"
 dependencies = [
  "anyhow",
  "bitflags 1.3.2",
@@ -5405,7 +5405,7 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_rpc_macros"
-version = "0.49.0-rc.2"
+version = "0.49.0-rc.3"
 dependencies = [
  "futures 0.3.26",
  "proc-macro2",
@@ -5420,7 +5420,7 @@ dependencies = [
 
 [[package]]
 name = "tari_console_wallet"
-version = "0.49.0-rc.2"
+version = "0.49.0-rc.3"
 dependencies = [
  "bitflags 1.3.2",
  "chrono",
@@ -5469,7 +5469,7 @@ dependencies = [
 
 [[package]]
 name = "tari_contacts"
-version = "0.49.0-rc.2"
+version = "0.49.0-rc.3"
 dependencies = [
  "chrono",
  "diesel",
@@ -5497,7 +5497,7 @@ dependencies = [
 
 [[package]]
 name = "tari_core"
-version = "0.49.0-rc.2"
+version = "0.49.0-rc.3"
 dependencies = [
  "bincode",
  "bitflags 1.3.2",
@@ -5593,7 +5593,7 @@ dependencies = [
 
 [[package]]
 name = "tari_features"
-version = "0.49.0-rc.2"
+version = "0.49.0-rc.3"
 
 [[package]]
 name = "tari_integration_tests"
@@ -5641,7 +5641,7 @@ dependencies = [
 
 [[package]]
 name = "tari_key_manager"
-version = "0.49.0-rc.2"
+version = "0.49.0-rc.3"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5695,7 +5695,7 @@ dependencies = [
 
 [[package]]
 name = "tari_merge_mining_proxy"
-version = "0.49.0-rc.2"
+version = "0.49.0-rc.3"
 dependencies = [
  "anyhow",
  "bincode",
@@ -5745,7 +5745,7 @@ dependencies = [
 
 [[package]]
 name = "tari_miner"
-version = "0.49.0-rc.2"
+version = "0.49.0-rc.3"
 dependencies = [
  "base64 0.13.1",
  "borsh",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "tari_mining_helper_ffi"
-version = "0.49.0-rc.2"
+version = "0.49.0-rc.3"
 dependencies = [
  "borsh",
  "hex",
@@ -5796,7 +5796,7 @@ dependencies = [
 
 [[package]]
 name = "tari_mmr"
-version = "0.49.0-rc.2"
+version = "0.49.0-rc.3"
 dependencies = [
  "bincode",
  "blake2 0.9.2",
@@ -5816,7 +5816,7 @@ dependencies = [
 
 [[package]]
 name = "tari_p2p"
-version = "0.49.0-rc.2"
+version = "0.49.0-rc.3"
 dependencies = [
  "anyhow",
  "clap 2.34.0",
@@ -5870,7 +5870,7 @@ dependencies = [
 
 [[package]]
 name = "tari_service_framework"
-version = "0.49.0-rc.2"
+version = "0.49.0-rc.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5887,7 +5887,7 @@ dependencies = [
 
 [[package]]
 name = "tari_shutdown"
-version = "0.49.0-rc.2"
+version = "0.49.0-rc.3"
 dependencies = [
  "futures 0.3.26",
  "tokio",
@@ -5895,7 +5895,7 @@ dependencies = [
 
 [[package]]
 name = "tari_storage"
-version = "0.49.0-rc.2"
+version = "0.49.0-rc.3"
 dependencies = [
  "bincode",
  "lmdb-zero",
@@ -5908,7 +5908,7 @@ dependencies = [
 
 [[package]]
 name = "tari_test_utils"
-version = "0.49.0-rc.2"
+version = "0.49.0-rc.3"
 dependencies = [
  "futures 0.3.26",
  "futures-test",
@@ -5940,7 +5940,7 @@ dependencies = [
 
 [[package]]
 name = "tari_wallet"
-version = "0.49.0-rc.2"
+version = "0.49.0-rc.3"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5990,7 +5990,7 @@ dependencies = [
 
 [[package]]
 name = "tari_wallet_ffi"
-version = "0.49.0-rc.2"
+version = "0.49.0-rc.3"
 dependencies = [
  "borsh",
  "cbindgen 0.24.3",

--- a/applications/tari_app_grpc/Cargo.toml
+++ b/applications/tari_app_grpc/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "This crate is to provide a single source for all cross application grpc files and conversions to and from tari::core"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.49.0-rc.2"
+version = "0.49.0-rc.3"
 edition = "2018"
 
 [dependencies]

--- a/applications/tari_app_utilities/Cargo.toml
+++ b/applications/tari_app_utilities/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_app_utilities"
-version = "0.49.0-rc.2"
+version = "0.49.0-rc.3"
 authors = ["The Tari Development Community"]
 edition = "2018"
 license = "BSD-3-Clause"

--- a/applications/tari_base_node/Cargo.toml
+++ b/applications/tari_base_node/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "The tari full base node implementation"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.49.0-rc.2"
+version = "0.49.0-rc.3"
 edition = "2018"
 
 [dependencies]

--- a/applications/tari_console_wallet/Cargo.toml
+++ b/applications/tari_console_wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_console_wallet"
-version = "0.49.0-rc.2"
+version = "0.49.0-rc.3"
 authors = ["The Tari Development Community"]
 edition = "2018"
 license = "BSD-3-Clause"

--- a/applications/tari_console_wallet/src/ui/state/app_state.rs
+++ b/applications/tari_console_wallet/src/ui/state/app_state.rs
@@ -1084,7 +1084,7 @@ pub struct EventListItem {
 impl AppStateData {
     pub fn new(wallet_identity: &WalletIdentity, base_node_selected: Peer, base_node_config: PeerConfig) -> Self {
         let eid = wallet_identity.address.to_emoji_string();
-        let qr_link = format!("tari_address://{}", wallet_identity.address.to_hex());
+        let qr_link = format!("tari://{}/transactions/send?publicKey={}", wallet_identity.network,wallet_identity.address.to_hex());
         let code = QrCode::new(qr_link).unwrap();
         let image = code
             .render::<unicode::Dense1x2>()

--- a/applications/tari_console_wallet/src/ui/state/app_state.rs
+++ b/applications/tari_console_wallet/src/ui/state/app_state.rs
@@ -1084,7 +1084,11 @@ pub struct EventListItem {
 impl AppStateData {
     pub fn new(wallet_identity: &WalletIdentity, base_node_selected: Peer, base_node_config: PeerConfig) -> Self {
         let eid = wallet_identity.address.to_emoji_string();
-        let qr_link = format!("tari://{}/transactions/send?publicKey={}", wallet_identity.network,wallet_identity.address.to_hex());
+        let qr_link = format!(
+            "tari://{}/transactions/send?publicKey={}",
+            wallet_identity.network,
+            wallet_identity.address.to_hex()
+        );
         let code = QrCode::new(qr_link).unwrap();
         let image = code
             .render::<unicode::Dense1x2>()

--- a/applications/tari_merge_mining_proxy/Cargo.toml
+++ b/applications/tari_merge_mining_proxy/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "The Tari merge mining proxy for xmrig"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.49.0-rc.2"
+version = "0.49.0-rc.3"
 edition = "2018"
 
 [features]

--- a/applications/tari_miner/Cargo.toml
+++ b/applications/tari_miner/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "The tari miner implementation"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.49.0-rc.2"
+version = "0.49.0-rc.3"
 edition = "2018"
 
 [dependencies]

--- a/base_layer/common_types/Cargo.toml
+++ b/base_layer/common_types/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_common_types"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency common types"
 license = "BSD-3-Clause"
-version = "0.49.0-rc.2"
+version = "0.49.0-rc.3"
 edition = "2018"
 
 [dependencies]

--- a/base_layer/contacts/Cargo.toml
+++ b/base_layer/contacts/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_contacts"
 authors = ["The Tari Development Community"]
 description = "Tari contacts library"
 license = "BSD-3-Clause"
-version = "0.49.0-rc.2"
+version = "0.49.0-rc.3"
 edition = "2018"
 
 [dependencies]

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.49.0-rc.2"
+version = "0.49.0-rc.3"
 edition = "2018"
 
 [features]

--- a/base_layer/key_manager/Cargo.toml
+++ b/base_layer/key_manager/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency wallet key management"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.49.0-rc.2"
+version = "0.49.0-rc.3"
 edition = "2021"
 
 [lib]

--- a/base_layer/mmr/Cargo.toml
+++ b/base_layer/mmr/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "A Merkle Mountain Range implementation"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.49.0-rc.2"
+version = "0.49.0-rc.3"
 edition = "2018"
 
 [features]

--- a/base_layer/p2p/Cargo.toml
+++ b/base_layer/p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_p2p"
-version = "0.49.0-rc.2"
+version = "0.49.0-rc.3"
 authors = ["The Tari Development community"]
 description = "Tari base layer-specific peer-to-peer communication features"
 repository = "https://github.com/tari-project/tari"

--- a/base_layer/service_framework/Cargo.toml
+++ b/base_layer/service_framework/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_service_framework"
-version = "0.49.0-rc.2"
+version = "0.49.0-rc.3"
 authors = ["The Tari Development Community"]
 description = "The Tari communication stack service framework"
 repository = "https://github.com/tari-project/tari"

--- a/base_layer/tari_mining_helper_ffi/Cargo.toml
+++ b/base_layer/tari_mining_helper_ffi/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_mining_helper_ffi"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency miningcore C FFI bindings"
 license = "BSD-3-Clause"
-version = "0.49.0-rc.2"
+version = "0.49.0-rc.3"
 edition = "2018"
 
 [dependencies]

--- a/base_layer/wallet/Cargo.toml
+++ b/base_layer/wallet/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_wallet"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency wallet library"
 license = "BSD-3-Clause"
-version = "0.49.0-rc.2"
+version = "0.49.0-rc.3"
 edition = "2018"
 
 [dependencies]

--- a/base_layer/wallet_ffi/Cargo.toml
+++ b/base_layer/wallet_ffi/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_wallet_ffi"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency wallet C FFI bindings"
 license = "BSD-3-Clause"
-version = "0.49.0-rc.2"
+version = "0.49.0-rc.3"
 edition = "2018"
 
 [dependencies]

--- a/changelog-nextnet.md
+++ b/changelog-nextnet.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [0.49.0-rc.3](https://github.com/tari-project/tari/compare/v0.49.0-rc.2...v0.49.0-rc.3) (2023-04-19)
+
+
+### Bug Fixes
+
+* fix console wallet qr code([0b74528](https://github.com/tari-project/tari/commit/0b74528983a2a44d85cd55e3a46c96dfbe21c965))
+
 ## [0.49.0-rc.2](https://github.com/tari-project/tari/compare/v0.49.0-rc.1...v0.49.0-rc.2) (2023-04-19)
 
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.49.0-rc.2"
+version = "0.49.0-rc.3"
 edition = "2018"
 
 [features]

--- a/common/tari_features/Cargo.toml
+++ b/common/tari_features/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.49.0-rc.2"
+version = "0.49.0-rc.3"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/common_sqlite/Cargo.toml
+++ b/common_sqlite/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_common_sqlite"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency wallet library"
 license = "BSD-3-Clause"
-version = "0.49.0-rc.2"
+version = "0.49.0-rc.3"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/comms/core/Cargo.toml
+++ b/comms/core/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.49.0-rc.2"
+version = "0.49.0-rc.3"
 edition = "2018"
 
 [dependencies]

--- a/comms/dht/Cargo.toml
+++ b/comms/dht/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_comms_dht"
-version = "0.49.0-rc.2"
+version = "0.49.0-rc.3"
 authors = ["The Tari Development Community"]
 description = "Tari comms DHT module"
 repository = "https://github.com/tari-project/tari"

--- a/comms/rpc_macros/Cargo.toml
+++ b/comms/rpc_macros/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.49.0-rc.2"
+version = "0.49.0-rc.3"
 edition = "2018"
 
 [lib]

--- a/infrastructure/derive/Cargo.toml
+++ b/infrastructure/derive/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.49.0-rc.2"
+version = "0.49.0-rc.3"
 edition = "2018"
 
 [lib]

--- a/infrastructure/shutdown/Cargo.toml
+++ b/infrastructure/shutdown/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.49.0-rc.2"
+version = "0.49.0-rc.3"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/infrastructure/storage/Cargo.toml
+++ b/infrastructure/storage/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.49.0-rc.2"
+version = "0.49.0-rc.3"
 edition = "2018"
 
 [dependencies]

--- a/infrastructure/test_utils/Cargo.toml
+++ b/infrastructure/test_utils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_test_utils"
 description = "Utility functions used in Tari test functions"
-version = "0.49.0-rc.2"
+version = "0.49.0-rc.3"
 authors = ["The Tari Development Community"]
 edition = "2018"
 license = "BSD-3-Clause"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tari",
-  "version": "0.49.0-rc.2",
+  "version": "0.49.0-rc.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {}


### PR DESCRIPTION
Description
---
Fixes the console wallet  QR code deeplink to RFC spec

Motivation and Context
---
The current QR code does not follow [RFC-0154](https://rfc.tari.com/RFC-0154_DeepLinksConvencion.html)

How Has This Been Tested?
---
Manual 

What process can a PR reviewer use to test or verify this change?
---
Run a Console wallet and inspect the QR code
