### PR TITLE
fix: make the first output optional in the wallet

### DIFF
--- a/base_layer/wallet/src/utxo_scanner_service/utxo_scanner_task.rs
+++ b/base_layer/wallet/src/utxo_scanner_service/utxo_scanner_task.rs
@@ -481,7 +481,7 @@ where
                 .into_iter()
                 .map(|utxo| TransactionOutput::try_from(utxo).map_err(UtxoScannerError::ConversionError))
                 .collect::<Result<Vec<_>, _>>()?;
-            let first_output = Some(outputs[0].clone());
+            let first_output = outputs.get(0).cloned();
             total_scanned += outputs.len();
 
             let start = Instant::now();


### PR DESCRIPTION
Description
---
The PR prevents panic in getting the first output of the `UtxoScannerTask`.

Motivation and Context
---
The `tari_console_wallet` app fails when a node is syncing:

```
 Base Node Status  - Chain Tip: #3498  Syncing...  Latency 630 ms
thread 'tokio-runtime-worker' panicked at 'index out of bounds: the len is 0 but the index is 0',
/home/denis/tari/base_layer/wallet/src/utxo_scanner_service/utxo_scanner_task.rs:484:37────────
 Network: esmeralda        Version: 0.50.0-pre.0    LeftArrow: Previous Tab  Tab/RightArrow: Next Tab
F10/Ctrl-note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Aborted (core dumped)
```

P.S. I wonder if the `None` value of the `first_output` variable breaks something, and we must panic there.

How Has This Been Tested?
---
Manually, by starting the `tari_console_wallet` with the changes.