### PR TITLE
feat(p2p): allow listener bind to differ from the tor forward address

### DIFF
--- a/base_layer/p2p/examples/gen_tor_identity.rs
+++ b/base_layer/p2p/examples/gen_tor_identity.rs
@@ -90,7 +90,6 @@ async fn main() {
         .with_port_mapping(port)
         .with_control_server_address(tor_control_addr)
         .build()
-        .await
         .unwrap()
         .create_hidden_service()
         .await

--- a/base_layer/p2p/src/transport.rs
+++ b/base_layer/p2p/src/transport.rs
@@ -147,8 +147,11 @@ pub struct TorTransportConfig {
     /// When set to true, outbound TCP connections bypass the tor proxy. Defaults to false for better privacy, setting
     /// to true may improve network performance for TCP nodes.
     pub proxy_bypass_for_outbound_tcp: bool,
-    /// If set, instructs tor to forward traffic the the provided address.
+    /// If set, instructs tor to forward traffic the the provided address. Otherwise, an OS-assigned port on 127.0.0.1
+    /// is used.
     pub forward_address: Option<Multiaddr>,
+    /// If set, the listener will bind to this address instead of the forward_address.
+    pub listener_address_override: Option<Multiaddr>,
     /// The tor identity to use to create the hidden service. If None, a new one will be generated.
     #[serde(skip)]
     pub identity: Option<TorIdentity>,
@@ -195,6 +198,7 @@ impl Default for TorTransportConfig {
             proxy_bypass_addresses: vec![],
             proxy_bypass_for_outbound_tcp: false,
             forward_address: None,
+            listener_address_override: None,
             identity: None,
         }
     }

--- a/common/config/presets/c_base_node.toml
+++ b/common/config/presets/c_base_node.toml
@@ -223,8 +223,10 @@ listener_liveness_check_interval = 15
 # When using the tor transport and set to true, outbound TCP connections bypass the tor proxy. Defaults to false for
 # better privacy
 #tor.proxy_bypass_for_outbound_tcp = false
-# If set, instructs tor to forward traffic the the provided address. (e.g. "/ip4/127.0.0.1/tcp/0") (default = )
+# If set, instructs tor to forward traffic the the provided address. (e.g. "/dns4/my-base-node/tcp/32123") (default = OS-assigned port)
 #tor.forward_address =
+# If set, the listener will bind to this address instead of the forward_address. You need to make sure that this listener is connectable from the forward_address.
+#tor.listener_address_override =
 
 # Use a SOCKS5 proxy transport. This transport recognises any addresses supported by the proxy.
 # (use: type = "socks5")

--- a/comms/core/examples/stress/node.rs
+++ b/comms/core/examples/stress/node.rs
@@ -139,7 +139,7 @@ pub async fn create(
             hs_builder = hs_builder.with_tor_identity(tor_identity);
         }
 
-        let mut hs_ctl = hs_builder.build().await?;
+        let mut hs_ctl = hs_builder.build()?;
         let transport = hs_ctl.initialize_transport().await?;
 
         builder

--- a/comms/core/examples/tor.rs
+++ b/comms/core/examples/tor.rs
@@ -175,7 +175,7 @@ async fn setup_node_with_tor<P: Into<tor::PortMapping>>(
         hs_builder = hs_builder.with_tor_identity(ident);
     }
 
-    let mut hs_controller = hs_builder.build().await?;
+    let mut hs_controller = hs_builder.build()?;
 
     let node_identity = Arc::new(NodeIdentity::random(
         &mut OsRng,

--- a/comms/core/src/tor/hidden_service/builder.rs
+++ b/comms/core/src/tor/hidden_service/builder.rs
@@ -156,7 +156,7 @@ impl HiddenServiceBuilder {
 
 impl HiddenServiceBuilder {
     /// Create a HiddenService with the given builder parameters.
-    pub async fn build(self) -> Result<HiddenServiceController, HiddenServiceBuilderError> {
+    pub fn build(self) -> Result<HiddenServiceController, HiddenServiceBuilderError> {
         let proxied_port_mapping = self
             .port_mapping
             .ok_or(HiddenServiceBuilderError::ProxiedPortMappingNotProvided)?;

--- a/comms/dht/examples/propagation/node.rs
+++ b/comms/dht/examples/propagation/node.rs
@@ -103,7 +103,7 @@ pub async fn create<P: AsRef<Path>>(
         hs_builder = hs_builder.with_tor_identity(tor_identity);
     }
 
-    let mut hs_ctl = hs_builder.build().await?;
+    let mut hs_ctl = hs_builder.build()?;
     let transport = hs_ctl.initialize_transport().await?;
 
     let comms_node = builder.with_listener_address(hs_ctl.proxied_address()).build()?;


### PR DESCRIPTION
Description
---
Add `p2p.tor.listener_address_override` config to allow a listener bind address that differs from the forward_address for incoming tor connections.

Motivation and Context
---
This is useful for docker setups where containers are addressed by DNS. In this case, the forward_address would be `/dns4/my_base_node/tcp/xxxxx` and the `listener_address_override="/ip4/0.0.0.0/tcp/xxxxx"` 

How Has This Been Tested?
---
Manually by setting the override to `"/ip4/0.0.0.0/tcp/12345"` and the forward_address to `/dns4/localhost/tcp/12345` 

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
