### PR TITLE
chore: update location of compiled bins in s3

### DIFF
--- a/.github/workflows/base_node_binaries.yml
+++ b/.github/workflows/base_node_binaries.yml
@@ -94,15 +94,23 @@ jobs:
           echo $tagnet
           # case match is not RegEx, but wildcards/globs
           case "$tagnet" in
-            v*-pre.*) TARI_NETWORK=esme
+            v*-pre.*)
+              TARI_NETWORK=esme
+              TARI_NETWORK_DIR=testnet
               ;;
-            v*-rc.*) TARI_NETWORK=nextnet
+            v*-rc.*)
+              TARI_NETWORK=nextnet
+              TARI_NETWORK_DIR=nextnet
               ;;
-            *) TARI_NETWORK=mainnet
+            *)
+              TARI_NETWORK=mainnet
+              TARI_NETWORK_DIR=mainnet
               ;;
           esac
           echo ${TARI_NETWORK}
+          echo ${TARI_NETWORK_DIR}
           echo "TARI_NETWORK=${TARI_NETWORK}" >> $GITHUB_ENV
+          echo "TARI_NETWORK_DIR=${TARI_NETWORK_DIR}" >> $GITHUB_ENV
 
       - name: Declare Global Variables 4 GHA ${{ github.event_name }}
         id: vars
@@ -409,7 +417,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           SOURCE: "${{ github.workspace }}${{ env.TBN_DIST }}"
-          DEST_DIR: "${{ env.S3DESTOVERRIDE }}${{ env.PLATFORM_SPECIFIC_DIR }}/"
+          DEST_DIR: "${{ env.S3DESTOVERRIDE }}${{ env.PLATFORM_SPECIFIC_DIR }}/${{ env.TARI_NETWORK_DIR }}/"
           S3CMD: "cp"
           S3OPTIONS: '--recursive --exclude "*" --include "*.zip*" --include "*.pkg*"'
           # S3OPTIONS: '--recursive --exclude "*" --include "*.zip*"'
@@ -445,7 +453,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           SOURCE: "${{ github.workspace }}${{ env.TBN_DIST }}"
-          DEST_DIR: "${{ env.S3DESTOVERRIDE }}${{ env.PLATFORM_SPECIFIC_DIR }}/"
+          DEST_DIR: "${{ env.S3DESTOVERRIDE }}${{ env.PLATFORM_SPECIFIC_DIR }}/${{ env.TARI_NETWORK_DIR }}/"
           S3CMD: "cp"
           S3OPTIONS: '--recursive --exclude "*" --include "*.zip*" --include "*.pkg*"'
           # S3OPTIONS: '--acl public-read'


### PR DESCRIPTION
Description
---
Separate the bins by network type to make it easier to distinguish on the tari website for download.


Motivation and Context
---
It makes it easier to parse on the website, allowing us to deploy the new design which should help people disambiguate which binary they should download.


How Has This Been Tested?
---
#yolo

What process can a PR reviewer use to test or verify this change?
---
Know bash better than I do and validate with 100% certainty the change is most excellent

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
