### PR TITLE
chore: update location of compiled bins in s3 for stagenet

### DIFF
--- a/.github/workflows/base_node_binaries.yml
+++ b/.github/workflows/base_node_binaries.yml
@@ -86,6 +86,32 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Declare TestNet for tags
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        shell: bash
+        run: |
+          tagnet=${{github.ref_name}}
+          echo $tagnet
+          # case match is not RegEx, but wildcards/globs
+          case "$tagnet" in
+            v*-pre.*)
+              TARI_NETWORK=esme
+              TARI_NETWORK_DIR=testnet
+              ;;
+            v*-rc.*)
+              TARI_NETWORK=nextnet
+              TARI_NETWORK_DIR=nextnet
+              ;;
+            *)
+              TARI_NETWORK=mainnet
+              TARI_NETWORK_DIR=mainnet
+              ;;
+          esac
+          echo ${TARI_NETWORK}
+          echo ${TARI_NETWORK_DIR}
+          echo "TARI_NETWORK=${TARI_NETWORK}" >> $GITHUB_ENV
+          echo "TARI_NETWORK_DIR=${TARI_NETWORK_DIR}" >> $GITHUB_ENV
+
       - name: Declare Global Variables 4 GHA ${{ github.event_name }}
         id: vars
         shell: bash
@@ -382,7 +408,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           SOURCE: "${{ github.workspace }}${{ env.TBN_DIST }}"
-          DEST_DIR: "${{ env.S3DESTOVERRIDE }}${{ env.PLATFORM_SPECIFIC_DIR }}/"
+          DEST_DIR: "${{ env.S3DESTOVERRIDE }}${{ env.PLATFORM_SPECIFIC_DIR }}/${{ env.TARI_NETWORK_DIR }}/"
           S3CMD: "cp"
           S3OPTIONS: '--recursive --exclude "*" --include "*.zip*" --include "*.pkg*"'
           # S3OPTIONS: '--recursive --exclude "*" --include "*.zip*"'
@@ -418,7 +444,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           SOURCE: "${{ github.workspace }}${{ env.TBN_DIST }}"
-          DEST_DIR: "${{ env.S3DESTOVERRIDE }}${{ env.PLATFORM_SPECIFIC_DIR }}/"
+          DEST_DIR: "${{ env.S3DESTOVERRIDE }}${{ env.PLATFORM_SPECIFIC_DIR }}/${{ env.TARI_NETWORK_DIR }}/"
           S3CMD: "cp"
           S3OPTIONS: '--recursive --exclude "*" --include "*.zip*" --include "*.pkg*"'
           # S3OPTIONS: '--acl public-read'


### PR DESCRIPTION
Separate the bins by network type to make it easier to distinguish on
the tari website for download.

Motivation and Context
---
It makes it easier to parse on the website, allowing us to deploy the
new design which should help people disambiguate which binary they
should download.

This was updated for TestNet, but not for Stagenet