### PR TITLE
fix: fix panic when no public addresses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -951,7 +951,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d379af7f68bfc21714c6c7dea883544201741d2ce8274bb12fa54f89507f52a7"
 dependencies = [
  "async-trait",
- "json5 0.4.1",
+ "json5",
  "lazy_static",
  "nom 7.1.3",
  "pathdiff",
@@ -2728,17 +2728,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "671a26f820db17c2a2750743f1dd03bafd15b98c9f30c7c2628c024c05d73397"
 dependencies = [
  "wasm-bindgen",
-]
-
-[[package]]
-name = "json5"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eb2522ff59fbfefb955e9bd44d04d5e5c2d0e8865bfc2c3d1ab3916183ef5ee"
-dependencies = [
- "pest",
- "pest_derive",
- "serde",
 ]
 
 [[package]]
@@ -5142,7 +5131,7 @@ version = "0.50.0-pre.0"
 dependencies = [
  "clap 3.2.23",
  "futures 0.3.26",
- "json5 0.2.8",
+ "json5",
  "log",
  "rand 0.7.3",
  "serde",

--- a/applications/tari_app_grpc/Cargo.toml
+++ b/applications/tari_app_grpc/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 tari_common_types = {  path = "../../base_layer/common_types" }
 tari_comms = { path = "../../comms/core" }
 tari_core = { path = "../../base_layer/core" }
-tari_crypto = { version = "0.16.12"}
+tari_crypto = { version = "0.16"}
 tari_script = { path = "../../infrastructure/tari_script" }
 tari_utilities = { version = "0.4.10"}
 

--- a/applications/tari_app_utilities/Cargo.toml
+++ b/applications/tari_app_utilities/Cargo.toml
@@ -14,7 +14,7 @@ tari_utilities = { version = "0.4.10"}
 
 clap = { version = "3.2.0", features = ["derive", "env"] }
 futures = { version = "^0.3.16", default-features = false, features = ["alloc"] }
-json5 = "0.2.2"
+json5 = "0.4"
 log = { version = "0.4.8", features = ["std"] }
 rand = "0.7.3"
 tokio = { version = "1.23", features = ["signal"] }

--- a/applications/tari_base_node/Cargo.toml
+++ b/applications/tari_base_node/Cargo.toml
@@ -15,7 +15,7 @@ tari_comms = { path = "../../comms/core", features = ["rpc"] }
 tari_common_types = { path = "../../base_layer/common_types" }
 tari_comms_dht = { path = "../../comms/dht" }
 tari_core = { path = "../../base_layer/core", default-features = false, features = ["transactions"] }
-tari_crypto = { version = "0.16.12"}
+tari_crypto = { version = "0.16"}
 tari_libtor = { path = "../../infrastructure/libtor", optional = true }
 tari_p2p = { path = "../../base_layer/p2p", features = ["auto-update"] }
 tari_storage = {path="../../infrastructure/storage"}

--- a/applications/tari_console_wallet/Cargo.toml
+++ b/applications/tari_console_wallet/Cargo.toml
@@ -13,7 +13,7 @@ tari_common_types = { path = "../../base_layer/common_types" }
 tari_comms = { path = "../../comms/core" }
 tari_comms_dht = { path = "../../comms/dht" }
 tari_contacts = { path = "../../base_layer/contacts" }
-tari_crypto = { version = "0.16.12"}
+tari_crypto = { version = "0.16"}
 tari_key_manager = { path = "../../base_layer/key_manager" }
 tari_libtor = { path = "../../infrastructure/libtor", optional = true }
 tari_p2p = { path = "../../base_layer/p2p", features = ["auto-update"] }

--- a/applications/tari_miner/Cargo.toml
+++ b/applications/tari_miner/Cargo.toml
@@ -14,7 +14,7 @@ tari_common_types = { path = "../../base_layer/common_types" }
 tari_comms = { path = "../../comms/core" }
 tari_app_utilities = { path = "../tari_app_utilities" }
 tari_app_grpc = { path = "../tari_app_grpc" }
-tari_crypto = { version = "0.16.12"}
+tari_crypto = { version = "0.16"}
 tari_utilities = "0.4.10"
 
 borsh = "0.9.3"

--- a/base_layer/common_types/Cargo.toml
+++ b/base_layer/common_types/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.50.0-pre.0"
 edition = "2018"
 
 [dependencies]
-tari_crypto = { version = "0.16.12"}
+tari_crypto = { version = "0.16"}
 tari_utilities = "0.4.10"
 # TODO: remove this dependency and move Network into tari_common_types
 tari_common = {  path = "../../common" }

--- a/base_layer/contacts/Cargo.toml
+++ b/base_layer/contacts/Cargo.toml
@@ -12,7 +12,7 @@ tari_common_sqlite = { path = "../../common_sqlite" }
 tari_common_types = {  path = "../../base_layer/common_types" }
 tari_comms = {  path = "../../comms/core" }
 tari_comms_dht = { path = "../../comms/dht" }
-tari_crypto = { version = "0.16.12"}
+tari_crypto = { version = "0.16"}
 tari_p2p = {  path = "../p2p", features = ["auto-update"] }
 tari_service_framework = {  path = "../service_framework" }
 tari_shutdown = {  path = "../../infrastructure/shutdown" }

--- a/base_layer/contacts/Cargo.toml
+++ b/base_layer/contacts/Cargo.toml
@@ -30,7 +30,7 @@ rand = "0.7.3"
 thiserror = "1.0.26"
 tokio = { version = "1.23", features = ["sync", "macros"] }
 tower = "0.4"
-uuid = { version = "1.3.1", features = ["v4"] }
+uuid = { version = "1.3", features = ["v4"] }
 
 [dev-dependencies]
 tari_comms_dht = {  path = "../../comms/dht", features = ["test-mocks"] }

--- a/base_layer/contacts/tests/contacts_service.rs
+++ b/base_layer/contacts/tests/contacts_service.rs
@@ -72,7 +72,7 @@ pub fn setup_contacts_service<T: ContactsBackend + 'static>(
         transport: TransportConfig {
             transport_type: TransportType::Memory,
             memory: MemoryTransportConfig {
-                listener_address: node_identity.first_public_address(),
+                listener_address: node_identity.first_public_address().unwrap(),
             },
             ..Default::default()
         },

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -24,7 +24,7 @@ tari_common_types = {  path = "../../base_layer/common_types" }
 tari_comms = {  path = "../../comms/core" }
 tari_comms_dht = {  path = "../../comms/dht" }
 tari_comms_rpc_macros = {  path = "../../comms/rpc_macros" }
-tari_crypto = { version = "0.16.12", features = ["borsh"] }
+tari_crypto = { version = "0.16", features = ["borsh"] }
 tari_metrics = { path = "../../infrastructure/metrics" }
 tari_mmr = {  path = "../../base_layer/mmr", optional = true, features = ["native_bitmap"] }
 tari_p2p = {  path = "../../base_layer/p2p" }

--- a/base_layer/key_manager/Cargo.toml
+++ b/base_layer/key_manager/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["lib", "cdylib"]
 
 # NB: All dependencies must support or be gated for the WASM target.
 [dependencies]
-tari_crypto = {version = "0.16.12"}
+tari_crypto = {version = "0.16"}
 tari_utilities = "0.4.10"
 tari_common_sqlite = { path = "../../common_sqlite" }
 tari_common_types = {  path = "../../base_layer/common_types"}

--- a/base_layer/mmr/Cargo.toml
+++ b/base_layer/mmr/Cargo.toml
@@ -14,7 +14,7 @@ benches = ["criterion"]
 
 [dependencies]
 tari_utilities = "0.4.10"
-tari_crypto = { version = "0.16.12"}
+tari_crypto = { version = "0.16"}
 tari_common = {path = "../../common"}
 thiserror = "1.0.26"
 borsh = "0.9.3"

--- a/base_layer/p2p/Cargo.toml
+++ b/base_layer/p2p/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 tari_comms = {  path = "../../comms/core" }
 tari_comms_dht = {  path = "../../comms/dht" }
 tari_common = {  path = "../../common" }
-tari_crypto = { version = "0.16.12"}
+tari_crypto = { version = "0.16"}
 tari_service_framework = {  path = "../service_framework" }
 tari_shutdown = {  path = "../../infrastructure/shutdown" }
 tari_storage = {  path = "../../infrastructure/storage" }

--- a/base_layer/p2p/src/initialization.rs
+++ b/base_layer/p2p/src/initialization.rs
@@ -155,7 +155,7 @@ pub async fn initialize_local_test_comms<P: AsRef<Path>>(
 
     let comms = CommsBuilder::new()
         .allow_test_addresses()
-        .with_listener_address(node_identity.first_public_address())
+        .with_listener_address(node_identity.first_public_address().unwrap())
         .with_listener_liveness_max_sessions(1)
         .with_node_identity(node_identity)
         .with_user_agent(&"/test/1.0")

--- a/base_layer/tari_mining_helper_ffi/Cargo.toml
+++ b/base_layer/tari_mining_helper_ffi/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 tari_comms = {  path = "../../comms/core" }
-tari_crypto = { version = "0.16.12"}
+tari_crypto = { version = "0.16"}
 tari_common = {  path = "../../common" }
 tari_core = {  path = "../core", default-features = false, features = ["transactions"]}
 tari_utilities = "0.4.10"

--- a/base_layer/wallet/Cargo.toml
+++ b/base_layer/wallet/Cargo.toml
@@ -12,7 +12,7 @@ tari_common = { path = "../../common" }
 tari_common_types = {  path = "../../base_layer/common_types" }
 tari_comms = {  path = "../../comms/core" }
 tari_comms_dht = {  path = "../../comms/dht" }
-tari_crypto = { version = "0.16.12"}
+tari_crypto = { version = "0.16"}
 tari_key_manager = {  path = "../key_manager", features = ["key_manager_service"] }
 tari_p2p = {  path = "../p2p", features = ["auto-update"] }
 tari_script = { path = "../../infrastructure/tari_script" }

--- a/base_layer/wallet/src/error.rs
+++ b/base_layer/wallet/src/error.rs
@@ -101,6 +101,8 @@ pub enum WalletError {
     TransportChannelError(#[from] TransportChannelError),
     #[error("Unexpected API Response while calling method `{method}` on `{api}`")]
     UnexpectedApiResponse { method: String, api: String },
+    #[error("Public address not set for this wallet")]
+    PublicAddressNotSet,
 }
 
 pub const LOG_TARGET: &str = "tari::application";

--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -273,7 +273,12 @@ where
 
         // Persist the comms node address and features after it has been spawned to capture any modifications made
         // during comms startup. In the case of a Tor Transport the public address could have been generated
-        wallet_database.set_node_address(comms.node_identity().first_public_address())?;
+        wallet_database.set_node_address(
+            comms
+                .node_identity()
+                .first_public_address()
+                .ok_or(WalletError::PublicAddressNotSet)?,
+        )?;
         wallet_database.set_node_features(comms.node_identity().features())?;
         let identity_sig = comms.node_identity().identity_signature_read().as_ref().cloned();
         if let Some(identity_sig) = identity_sig {

--- a/base_layer/wallet/tests/wallet.rs
+++ b/base_layer/wallet/tests/wallet.rs
@@ -130,7 +130,7 @@ async fn create_wallet(
         override_from: None,
         public_addresses: MultiaddrList::default(),
         transport: TransportConfig::new_memory(MemoryTransportConfig {
-            listener_address: node_identity.first_public_address(),
+            listener_address: node_identity.first_public_address().unwrap(),
         }),
         datastore_path: data_path.to_path_buf(),
         peer_database_name: random::string(8),
@@ -255,7 +255,7 @@ async fn test_wallet() {
         .peer_manager()
         .add_peer(create_peer(
             bob_identity.public_key().clone(),
-            bob_identity.first_public_address(),
+            bob_identity.first_public_address().unwrap(),
         ))
         .await
         .unwrap();
@@ -265,7 +265,7 @@ async fn test_wallet() {
         .peer_manager()
         .add_peer(create_peer(
             alice_identity.public_key().clone(),
-            alice_identity.first_public_address(),
+            alice_identity.first_public_address().unwrap(),
         ))
         .await
         .unwrap();
@@ -273,7 +273,7 @@ async fn test_wallet() {
     alice_wallet
         .set_base_node_peer(
             (*base_node_identity.public_key()).clone(),
-            base_node_identity.first_public_address().clone(),
+            base_node_identity.first_public_address().unwrap(),
         )
         .await
         .unwrap();
@@ -735,7 +735,10 @@ async fn test_import_utxo() {
     let expected_output_hash = output.hash();
     let node_address = TariAddress::new(node_identity.public_key().clone(), network);
     alice_wallet
-        .set_base_node_peer(node_identity.public_key().clone(), node_identity.first_public_address())
+        .set_base_node_peer(
+            node_identity.public_key().clone(),
+            node_identity.first_public_address().unwrap(),
+        )
         .await
         .unwrap();
     let tx_id = alice_wallet

--- a/base_layer/wallet_ffi/Cargo.toml
+++ b/base_layer/wallet_ffi/Cargo.toml
@@ -12,7 +12,7 @@ tari_common = { path="../../common" }
 tari_common_types = { path="../common_types" }
 tari_comms = {  path = "../../comms/core", features = ["c_integration"]}
 tari_comms_dht = {  path = "../../comms/dht", default-features = false }
-tari_crypto = { version = "0.16.12"}
+tari_crypto = { version = "0.16"}
 tari_key_manager = {  path = "../key_manager" }
 tari_p2p = {  path = "../p2p" }
 tari_script = { path = "../../infrastructure/tari_script" }

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -10754,7 +10754,7 @@ mod test {
                 NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE);
             let base_node_peer_public_key_ptr = Box::into_raw(Box::new(node_identity.public_key().clone()));
             let base_node_peer_address_ptr =
-                CString::into_raw(CString::new(node_identity.first_public_address().to_string()).unwrap())
+                CString::into_raw(CString::new(node_identity.first_public_address().unwrap().to_string()).unwrap())
                     as *const c_char;
             wallet_add_base_node_peer(
                 wallet_ptr,

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -14,7 +14,7 @@ build = ["toml", "prost-build"]
 static-application-info = ["git2"]
 
 [dependencies]
-tari_crypto = { version = "0.16.12"}
+tari_crypto = { version = "0.16"}
 
 anyhow = "1.0.53"
 config = { version = "0.13.0", default_features = false, features = ["toml"] }

--- a/comms/core/Cargo.toml
+++ b/comms/core/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.50.0-pre.0"
 edition = "2018"
 
 [dependencies]
-tari_crypto = { version = "0.16.12"}
+tari_crypto = { version = "0.16"}
 tari_metrics = { path = "../../infrastructure/metrics" }
 tari_storage = {  path = "../../infrastructure/storage" }
 tari_shutdown = {  path = "../../infrastructure/shutdown" }

--- a/comms/core/src/peer_manager/node_identity.rs
+++ b/comms/core/src/peer_manager/node_identity.rs
@@ -126,8 +126,8 @@ impl NodeIdentity {
         acquire_read_lock!(self.public_addresses).clone()
     }
 
-    pub fn first_public_address(&self) -> Multiaddr {
-        acquire_read_lock!(self.public_addresses)[0].clone()
+    pub fn first_public_address(&self) -> Option<Multiaddr> {
+        acquire_read_lock!(self.public_addresses).get(0).cloned()
     }
 
     /// Modify the public address.

--- a/comms/core/src/protocol/rpc/test/comms_integration.rs
+++ b/comms/core/src/protocol/rpc/test/comms_integration.rs
@@ -44,7 +44,7 @@ async fn run_service() {
     let mock_state = rpc_service.shared_state();
     let shutdown = Shutdown::new();
     let comms1 = CommsBuilder::new()
-        .with_listener_address(node_identity1.first_public_address())
+        .with_listener_address(node_identity1.first_public_address().unwrap())
         .with_node_identity(node_identity1)
         .with_shutdown_signal(shutdown.to_signal())
         .with_peer_storage(CommsDatabase::new(), None)
@@ -57,7 +57,7 @@ async fn run_service() {
 
     let node_identity2 = build_node_identity(Default::default());
     let comms2 = CommsBuilder::new()
-        .with_listener_address(node_identity2.first_public_address())
+        .with_listener_address(node_identity2.first_public_address().unwrap())
         .with_shutdown_signal(shutdown.to_signal())
         .with_node_identity(node_identity2.clone())
         .with_peer_storage(CommsDatabase::new(), None)

--- a/comms/dht/Cargo.toml
+++ b/comms/dht/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 tari_comms = {  path = "../core", features = ["rpc"] }
 tari_common = { path = "../../common" }
 tari_comms_rpc_macros = {  path = "../rpc_macros" }
-tari_crypto = { version = "0.16"}
+tari_crypto = { version = "0.16.2"}
 tari_utilities = "0.4.10"
 tari_shutdown = {  path = "../../infrastructure/shutdown" }
 tari_storage = {  path = "../../infrastructure/storage" }

--- a/comms/dht/Cargo.toml
+++ b/comms/dht/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 tari_comms = {  path = "../core", features = ["rpc"] }
 tari_common = { path = "../../common" }
 tari_comms_rpc_macros = {  path = "../rpc_macros" }
-tari_crypto = { version = "0.16.12"}
+tari_crypto = { version = "0.16"}
 tari_utilities = "0.4.10"
 tari_shutdown = {  path = "../../infrastructure/shutdown" }
 tari_storage = {  path = "../../infrastructure/storage" }

--- a/comms/dht/examples/memory_net/utilities.rs
+++ b/comms/dht/examples/memory_net/utilities.rs
@@ -903,7 +903,7 @@ async fn setup_comms_dht(
     let comms = CommsBuilder::new()
         .allow_test_addresses()
         // In this case the listener address and the public address are the same (/memory/...)
-        .with_listener_address(node_identity.first_public_address())
+        .with_listener_address(node_identity.first_public_address().unwrap())
         .with_shutdown_signal(shutdown_signal)
         .with_node_identity(node_identity)
         .with_min_connectivity(1)

--- a/comms/dht/tests/dht.rs
+++ b/comms/dht/tests/dht.rs
@@ -172,7 +172,7 @@ async fn setup_comms_dht(
     let comms = CommsBuilder::new()
         .allow_test_addresses()
         // In this case the listener address and the public address are the same (/memory/...)
-        .with_listener_address(node_identity.first_public_address())
+        .with_listener_address(node_identity.first_public_address().unwrap())
         .with_shutdown_signal(shutdown_signal)
         .with_node_identity(node_identity)
         .with_peer_storage(storage,None)

--- a/infrastructure/tari_script/Cargo.toml
+++ b/infrastructure/tari_script/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 license = "BSD-3-Clause"
 
 [dependencies]
-tari_crypto = { version = "0.16.12"}
+tari_crypto = { version = "0.16"}
 tari_utilities = "0.4.10"
 
 blake2 = "0.9"

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -13,7 +13,7 @@ tari_base_node = { path = "../applications/tari_base_node" }
 tari_base_node_grpc_client = { path = "../clients/rust/base_node_grpc_client" }
 tari_chat_client = { path = "../base_layer/contacts/examples/chat_client" }
 tari_chat_ffi = { path = "../base_layer/chat_ffi" }
-tari_crypto = "0.16.12"
+tari_crypto = "0.16"
 tari_common = { path = "../common" }
 tari_common_types = { path = "../base_layer/common_types" }
 tari_comms = { path = "../comms/core" }

--- a/integration_tests/src/chat_client.rs
+++ b/integration_tests/src/chat_client.rs
@@ -69,11 +69,11 @@ fn test_config(name: &str, port: u64, identity: &NodeIdentity) -> P2pConfig {
             ..DhtConfig::default_local_test()
         },
         transport: TransportConfig::new_tcp(TcpTransportConfig {
-            listener_address: identity.first_public_address(),
+            listener_address: identity.first_public_address().expect("No public address"),
             ..TcpTransportConfig::default()
         }),
         allow_test_addresses: true,
-        public_addresses: MultiaddrList::from(vec![identity.first_public_address()]),
+        public_addresses: MultiaddrList::from(vec![identity.first_public_address().expect("No public address")]),
         user_agent: "tari/chat-client/0.0.1".to_string(),
         ..P2pConfig::default()
     };

--- a/integration_tests/src/chat_ffi.rs
+++ b/integration_tests/src/chat_ffi.rs
@@ -194,11 +194,11 @@ fn test_config(base_dir: &PathBuf, identity: &NodeIdentity) -> P2pConfig {
             ..DhtConfig::default_local_test()
         },
         transport: TransportConfig::new_tcp(TcpTransportConfig {
-            listener_address: identity.first_public_address(),
+            listener_address: identity.first_public_address().expect("No public address"),
             ..TcpTransportConfig::default()
         }),
         allow_test_addresses: true,
-        public_addresses: MultiaddrList::from(vec![identity.first_public_address()]),
+        public_addresses: MultiaddrList::from(vec![identity.first_public_address().expect("No public address")]),
         user_agent: "tari/chat-client/0.0.1".to_string(),
         ..P2pConfig::default()
     };

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -78,7 +78,7 @@ pub async fn get_peer_addresses(world: &TariWorld, peers: &Vec<String>) -> Vec<S
         peer_addresses.push(format!(
             "{}::{}",
             peer.identity.public_key(),
-            peer.identity.first_public_address()
+            peer.identity.first_public_address().expect("No public addresses")
         ));
     }
 

--- a/integration_tests/tests/steps/wallet_ffi_steps.rs
+++ b/integration_tests/tests/steps/wallet_ffi_steps.rs
@@ -37,7 +37,7 @@ async fn ffi_start_wallet_connected_to_base_node(world: &mut TariWorld, wallet: 
     let base_node = world.get_node(&base_node).unwrap();
     world.get_ffi_wallet(&wallet).unwrap().add_base_node(
         base_node.identity.public_key().to_hex(),
-        base_node.identity.first_public_address().to_string(),
+        base_node.identity.first_public_address().unwrap().to_string(),
     );
 }
 
@@ -48,7 +48,7 @@ async fn ffi_start_wallet_connected_to_seed_node(world: &mut TariWorld, wallet: 
     let seed_node = world.get_node(&seed_node).unwrap();
     world.get_ffi_wallet(&wallet).unwrap().add_base_node(
         seed_node.identity.public_key().to_hex(),
-        seed_node.identity.first_public_address().to_string(),
+        seed_node.identity.first_public_address().unwrap().to_string(),
     );
 }
 
@@ -57,7 +57,7 @@ async fn ffi_set_base_node(world: &mut TariWorld, base_node: String, wallet: Str
     let base_node = world.get_node(&base_node).unwrap();
     world.get_ffi_wallet(&wallet).unwrap().add_base_node(
         base_node.identity.public_key().to_hex(),
-        base_node.identity.first_public_address().to_string(),
+        base_node.identity.first_public_address().unwrap().to_string(),
     );
 }
 
@@ -469,7 +469,7 @@ async fn ffi_recover_wallet(world: &mut TariWorld, wallet_name: String, ffi_wall
     let base_node = world.get_node(&base_node).unwrap();
     world.get_ffi_wallet(&ffi_wallet_name).unwrap().add_base_node(
         base_node.identity.public_key().to_hex(),
-        base_node.identity.first_public_address().to_string(),
+        base_node.identity.first_public_address().unwrap().to_string(),
     );
 }
 
@@ -481,7 +481,7 @@ async fn ffi_restart_wallet(world: &mut TariWorld, wallet: String, base_node: St
     let ffi_wallet = world.get_ffi_wallet(&wallet).unwrap();
     ffi_wallet.add_base_node(
         base_node.identity.public_key().to_hex(),
-        base_node.identity.first_public_address().to_string(),
+        base_node.identity.first_public_address().unwrap().to_string(),
     );
 }
 


### PR DESCRIPTION
Description
---
If there are no public addresses specified, there was a panic. This is solved by not starting a liveness service if there is no public address.

NOTE: I have changed the reference on tari-crypto to be the lowest version that it works with (i.e. 0.16, instead of 0.16.*). This is the best practice for libraries, according to Rust, and also helps with mismatches on the tari-dan repo.

Motivation and Context
---
When using TCP, a node might not have a public address, this may cause a panic with the current code. AFAIK a comms node (base node, wallet, dan indexer) can still work without a public address, but it can only initiate outbound connections.

How Has This Been Tested?
---
existing tests

What process can a PR reviewer use to test or verify this change?
---
TODO: I'm busy checking this on the DAN indexer, which has no public address during testing

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
