### PR TITLE
chore(nextnet): fix cargo toml pointing toward correct tag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3139,7 +3139,7 @@ dependencies = [
 [[package]]
 name = "monero"
 version = "0.17.2"
-source = "git+https://github.com/tari-project/monero-rs.git?branch=main#7aebfd0aa037025cac6cbded3f72d73bf3c18123"
+source = "git+https://github.com/tari-project/monero-rs.git?rev=7aebfd0aa037025cac6cbded3f72d73bf3c18123#7aebfd0aa037025cac6cbded3f72d73bf3c18123"
 dependencies = [
  "base58-monero 1.0.0",
  "curve25519-dalek 3.2.0",

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -54,7 +54,7 @@ integer-encoding = "3.0.2"
 lmdb-zero = "0.4.4"
 log = "0.4"
 log-mdc = "0.1.0"
-monero = { git = "https://github.com/tari-project/monero-rs.git", branch = "main" , features = ["serde"], optional = true }
+monero = { git = "https://github.com/tari-project/monero-rs.git", rev = "7aebfd0aa037025cac6cbded3f72d73bf3c18123" , features = ["serde"], optional = true }
 newtype-ops = "0.1.4"
 num-traits = "0.2.15"
 num-derive = "0.3.3"


### PR DESCRIPTION
Description
---
Fixes the monero-rs to not point toward main branch, but rather the correct commit
Motivation and Context
---
We should not use main branch as the target for a github repo

How Has This Been Tested?
---
manual

