### PR TITLE
docs: remove an outdated comment

### DIFF
--- a/comms/dht/src/inbound/decryption.rs
+++ b/comms/dht/src/inbound/decryption.rs
@@ -239,7 +239,7 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
         let sender_masked_public_key = validated_msg
             .authenticated_origin()
             .ok_or(DecryptionError::MessageRejectDecryptionFailed)?;
-        let sender_public_key = mask_inverse * sender_masked_public_key; // TODO: compute this using the mask inverse!
+        let sender_public_key = mask_inverse * sender_masked_public_key;
 
         trace!(
             target: LOG_TARGET,


### PR DESCRIPTION
Description
---
Removes an outdated comment, in what is possibly the silliest and smallest PR.

Motivation and Context
---
A comment was outdated.

How Has This Been Tested?
---
It hasn't.

What process can a PR reviewer use to test or verify this change?
---
Look for the comment. Find that it has vanished. Contemplate the consequences.