### PR TITLE
build(feature): add diag-utils for binary archives

### DIFF
--- a/.github/workflows/base_node_binaries.yml
+++ b/.github/workflows/base_node_binaries.yml
@@ -148,7 +148,7 @@ jobs:
         run: brew install cmake coreutils automake autoconf
 
       - name: Install Windows dependencies
-        #continue-on-error: true  # WARNING: workaround
+        # continue-on-error: true  # WARNING: workaround
         if: startsWith(runner.os,'Windows')
         run: |
           vcpkg.exe install sqlite3:x64-windows zlib:x64-windows
@@ -381,7 +381,7 @@ jobs:
           name: ${{ env.TBN_FILENAME }}_archive-${{ matrix.builds.name }}
           path: "${{ github.workspace }}${{ env.TBN_DIST }}/${{ env.BINFILE }}.zip*"
 
-      - name: Prep miner for upload
+      - name: Prep Miner for upload
         shell: bash
         run: |
           cd "${{ github.workspace }}${{ env.TBN_DIST }}"
@@ -395,6 +395,25 @@ jobs:
         with:
           name: tari_miner-${{ matrix.builds.name }}
           path: "${{ github.workspace }}${{ env.TBN_DIST }}/tari_miner-${{ matrix.builds.name }}${{ env.TBN_EXT}}*"
+
+      - name: Prep diag-utils for upload
+        continue-on-error: true
+        shell: bash
+        run: |
+          mkdir "${{ github.workspace }}${{ env.TBN_DIST }}/diag-utils"
+          cd "${{ github.workspace }}${{ env.TBN_DIST }}/diag-utils"
+          # Find RandomX built tools for testing
+          find "$GITHUB_WORKSPACE/target/${{ matrix.builds.target }}/release/" \
+            -name "randomx-*${{ env.TBN_EXT}}" -type f -perm -+x -exec cp -v {} . \;
+          ${SHARUN} * \
+            >> "${{ env.TBN_FILENAME }}_archive-diag-utils-${{ matrix.builds.name }}.sha256"
+
+      - name: Artifact upload for diag-utils
+        continue-on-error: true
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.TBN_FILENAME }}_archive-diag-utils-${{ matrix.builds.name }}
+          path: "${{ github.workspace }}${{ env.TBN_DIST }}/diag-utils/*"
 
       - name: Sync dist to S3 - Bash
         continue-on-error: true # Don't break if s3 upload fails


### PR DESCRIPTION
Description
Add a diag-utils archive, that can be downloaded per platform.

Motivation and Context
Including ```randomx-tests``` and friends. Needed to test randomx on Apple M1 for corner case bug, without waiting for block that triggered the bug.

Might be worth adding other tools or utilities and/or ReadMe file, but that would be better in the repo, than in the workflow.

How Has This Been Tested?
Built in local fork and tested downloads
