### PR TITLE
build(fix): target older MacOS SDK on ARM64 for randomx-rs

### DIFF
--- a/.github/workflows/base_node_binaries.yml
+++ b/.github/workflows/base_node_binaries.yml
@@ -182,6 +182,14 @@ jobs:
           echo "PLATFORM_SPECIFIC_DIR=osx" >> $GITHUB_ENV
           echo "LIB_EXT=.dylib" >> $GITHUB_ENV
 
+      # Hardcoded sdk for MacOSX 11 on ARM64
+      - name: Set environment variables - macOS - ARM64 (pin/sdk)
+        if: ${{ startsWith(runner.os,'macOS') && matrix.builds.name == 'macos-arm64' }}
+        run: |
+          xcrun --show-sdk-path
+          ls -la "/Library/Developer/CommandLineTools/SDKs/"
+          echo "RANDOMX_RS_CMAKE_OSX_SYSROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX12.1.sdk" >> $GITHUB_ENV
+
       - name: Set environment variables - Ubuntu
         if: startsWith(runner.os,'Linux')
         run: |


### PR DESCRIPTION
Description
Build fix to target older MacOS SDK on ARM64 for randomx-rs using an env to pass to cmake at build time. Will only work on ```randomx-rs``` later v1.1.14 or https://github.com/tari-project/randomx-rs/commit/7f3748bd14e20358003cda01f419f38c1e0d42f5

Motivation and Context
Related to https://github.com/tari-project/tari/issues/5350 and https://github.com/tari-project/tari/issues/5141 - adding a work around bug

How Has This Been Tested?
Built and test local and in my fork

What process can a PR reviewer use to test or verify this change?
When build has completed, find the ```randomx-tests``` run for your build platform and confirm no failed randomx tests.

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
