### PR TITLE
fix: prepend message to prevent arbitrary signing

### DIFF
--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -498,12 +498,14 @@ where
         Ok(tx_id)
     }
 
+    /// Signs a message, but prepends the message with the prefix "tari_signed_message" to prevent unintentional
+    /// signing of transactions, etc.
     pub fn sign_message(
         &mut self,
         secret: &RistrettoSecretKey,
         message: &str,
     ) -> Result<SchnorrSignature<RistrettoPublicKey, RistrettoSecretKey>, SchnorrSignatureError> {
-        RistrettoSchnorr::sign_message(secret, message.as_bytes())
+        RistrettoSchnorr::sign_message(secret, format!("tari_signed_message:{}", message).as_bytes())
     }
 
     pub fn verify_message_signature(


### PR DESCRIPTION
Description
---
Add a message to prevent arbitrary signing

Motivation and Context
---
This method is exposed via ffi and could allow users to sign transactions or arbitrary data


<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [ ] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [x] Other - If this method was used externally, those methods will break. 

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
