### PR TITLE
fix: don't use in memory datastores for chat client dht in integration tests

### DIFF
--- a/integration_tests/src/chat_client.rs
+++ b/integration_tests/src/chat_client.rs
@@ -30,7 +30,7 @@ use tari_comms::{
     peer_manager::{Peer, PeerFeatures},
     NodeIdentity,
 };
-use tari_comms_dht::{store_forward::SafConfig, DhtConfig, NetworkDiscoveryConfig};
+use tari_comms_dht::{store_forward::SafConfig, DbConnectionUrl, DhtConfig, NetworkDiscoveryConfig};
 use tari_p2p::{P2pConfig, TcpTransportConfig, TransportConfig};
 
 use crate::{base_node_process::get_base_dir, get_port};
@@ -58,6 +58,7 @@ fn test_config(name: &str, port: u64, identity: &NodeIdentity) -> P2pConfig {
     let mut config = P2pConfig {
         datastore_path: temp_dir_path.clone(),
         dht: DhtConfig {
+            database_url: DbConnectionUrl::file("dht.sqlite"),
             network_discovery: NetworkDiscoveryConfig {
                 enabled: true,
                 ..NetworkDiscoveryConfig::default()

--- a/integration_tests/src/chat_ffi.rs
+++ b/integration_tests/src/chat_ffi.rs
@@ -42,7 +42,7 @@ use tari_comms::{
     peer_manager::{Peer, PeerFeatures},
     NodeIdentity,
 };
-use tari_comms_dht::{store_forward::SafConfig, DhtConfig, NetworkDiscoveryConfig};
+use tari_comms_dht::{store_forward::SafConfig, DbConnectionUrl, DhtConfig, NetworkDiscoveryConfig};
 use tari_contacts::contacts_service::{service::ContactOnlineStatus, types::Message};
 use tari_p2p::{P2pConfig, TcpTransportConfig, TransportConfig};
 use tari_utilities::message_format::MessageFormat;
@@ -183,6 +183,7 @@ fn test_config(base_dir: &PathBuf, identity: &NodeIdentity) -> P2pConfig {
     let mut config = P2pConfig {
         datastore_path: base_dir.clone(),
         dht: DhtConfig {
+            database_url: DbConnectionUrl::file("dht.sqlite"),
             network_discovery: NetworkDiscoveryConfig {
                 enabled: true,
                 ..NetworkDiscoveryConfig::default()


### PR DESCRIPTION
Description
---
Use filestore instead of in memory store for DHT tables.

Motivation and Context
---
I think at some point the reference to the store is being dropped causing the tables to no longer exist.

How Has This Been Tested?
---
Locally

What process can a PR reviewer use to test or verify this change?
---
Run the tests, watch CI.

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
