### PR TITLE
fix: use domain separation for wallet message signing

### DIFF
--- a/base_layer/common_types/src/types/mod.rs
+++ b/base_layer/common_types/src/types/mod.rs
@@ -32,6 +32,7 @@ use tari_crypto::{
         RistrettoComAndPubSig,
         RistrettoPublicKey,
         RistrettoSchnorr,
+        RistrettoSchnorrWithDomain,
         RistrettoSecretKey,
     },
 };
@@ -43,6 +44,8 @@ pub use fixed_hash::{FixedHash, FixedHashSizeError};
 /// Define the explicit Signature implementation for the Tari base layer. A different signature scheme can be
 /// employed by redefining this type.
 pub type Signature = RistrettoSchnorr;
+/// Define a generic signature type using a hash domain.
+pub type SignatureWithDomain<H> = RistrettoSchnorrWithDomain<H>;
 /// Define the explicit Commitment Signature implementation for the Tari base layer.
 pub type ComAndPubSignature = RistrettoComAndPubSig;
 

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -91,7 +91,7 @@ use tari_common_types::{
     emoji::emoji_set,
     tari_address::{TariAddress, TariAddressError},
     transaction::{TransactionDirection, TransactionStatus, TxId},
-    types::{ComAndPubSignature, Commitment, PublicKey, Signature},
+    types::{ComAndPubSignature, Commitment, PublicKey, SignatureWithDomain},
 };
 use tari_comms::{
     multiaddr::Multiaddr,
@@ -161,7 +161,7 @@ use tari_wallet::{
         },
     },
     utxo_scanner_service::{service::UtxoScannerService, RECOVERY_KEY},
-    wallet::{derive_comms_secret_key, read_or_create_master_seed},
+    wallet::{derive_comms_secret_key, read_or_create_master_seed, WalletMessageSigningDomain},
     Wallet,
     WalletConfig,
     WalletSqlite,
@@ -6163,7 +6163,7 @@ pub unsafe extern "C" fn wallet_verify_message_signature(
                     let public_nonce = TariPublicKey::from_hex(key2);
                     match public_nonce {
                         Ok(pn) => {
-                            let sig = Signature::new(pn, p);
+                            let sig = SignatureWithDomain::<WalletMessageSigningDomain>::new(pn, p);
                             result = (*wallet).wallet.verify_message_signature(&*public_key, &sig, &message)
                         },
                         Err(e) => {


### PR DESCRIPTION
Description
---
Uses domain separation for wallet message Schnorr signatures to prevent context misuse. Supersedes [PR 5394](https://github.com/tari-project/tari/pull/5394).

Motivation and Context
---
Wallets can sign and verify arbitrary messages using their secret keys. Because such messages are signed using Schnorr signatures with a default Fiat-Shamir challenge hash domain, it may be possible to replay them in different contexts, with possibly dangerous consequences.

Another [pending PR](https://github.com/tari-project/tari/pull/5394) suggests prepending fixed data to wallet messages, but this can still lead to collisions.

Fortunately, the `tari-crypto` signature API provides a [handy type alias](https://github.com/tari-project/tari-crypto/blob/8a0823ff690f35409b64ad85a064033706f17580/src/ristretto/ristretto_sig.rs#L116) that makes domain separation straightforward. Using this, it is not possible to produce signature collisions (up to the collision resistance of the hash function itself). This is a safer and more idiomatic design.

How Has This Been Tested?
---
An existing test passes.

What process can a PR reviewer use to test or verify this change?
---
Confirm that the `tari-crypto` signature API is being used correctly, and that the macro-derived domain separator is unique within the codebase.

Breaking Changes
---
Existing signatures will fail to verify, but this is unlikely to be problematic.