### PR TITLE
fix(comms): only set final forward address if configured to port 0

### DIFF
--- a/comms/core/src/builder/comms_node.rs
+++ b/comms/core/src/builder/comms_node.rs
@@ -23,6 +23,7 @@
 use std::{iter, sync::Arc, time::Duration};
 
 use log::*;
+use multiaddr::{multiaddr, Protocol};
 use tari_shutdown::ShutdownSignal;
 use tokio::{
     io::{AsyncRead, AsyncWrite},
@@ -222,9 +223,20 @@ impl UnspawnedCommsNode {
         );
 
         let listening_info = connection_manager_requester.wait_until_listening().await?;
+
+        // Final setup of the hidden service.
         let mut hidden_service = None;
         if let Some(mut ctl) = hidden_service_ctl {
-            ctl.set_proxied_addr(listening_info.bind_address());
+            // Only set the address to the bind address it is set to TCP port 0
+            let mut proxied_addr = ctl.proxied_address();
+            if proxied_addr.ends_with(&multiaddr!(Tcp(0u16))) {
+                // Remove the TCP port 0 address and replace it with the actual listener port
+                if let Some(Protocol::Tcp(port)) = listening_info.bind_address().iter().last() {
+                    proxied_addr.pop();
+                    proxied_addr.push(Protocol::Tcp(port));
+                    ctl.set_proxied_addr(&proxied_addr);
+                }
+            }
             let hs = ctl.create_hidden_service().await?;
             let onion_addr = hs.get_onion_address();
             if !node_identity.public_addresses().contains(&onion_addr) {

--- a/comms/core/src/lib.rs
+++ b/comms/core/src/lib.rs
@@ -61,7 +61,7 @@ pub mod traits;
 
 pub mod multiaddr {
     // Re-export so that client code does not have to have multiaddr as a dependency
-    pub use ::multiaddr::{Error, Multiaddr, Protocol};
+    pub use ::multiaddr::{multiaddr, Error, Multiaddr, Protocol};
 }
 
 pub use async_trait::async_trait;

--- a/comms/core/src/tor/control_client/types.rs
+++ b/comms/core/src/tor/control_client/types.rs
@@ -90,7 +90,7 @@ pub enum PrivateKey {
 
 /// Represents a mapping between an onion port and a proxied address (usually 127.0.0.1:xxxx).
 /// If the proxied_address is not specified, the default `127.0.0.1:[onion_port]` will be used.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Clone, Copy, Serialize, Deserialize)]
 pub struct PortMapping {
     onion_port: u16,
     proxied_address: SocketAddr,
@@ -144,5 +144,11 @@ impl<T: Into<u16>, U: Into<SocketAddr>> From<(T, U)> for PortMapping {
 impl fmt::Display for PortMapping {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(f, "PortMapping [{} -> {}]", self.onion_port, self.proxied_address)
+    }
+}
+
+impl fmt::Debug for PortMapping {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, f)
     }
 }


### PR DESCRIPTION
Description
---
Sets the onion service forward address to the correct port only if configured to port 0.

Motivation and Context
---
Fixes #5405 

How Has This Been Tested?
---
Manually, default settings were also tested.

What process can a PR reviewer use to test or verify this change?
---
```toml
# This doesnt work (no incoming connections as expected)
#tor.forward_address = "/dns4/localhost/tcp/12345"
# This does work
tor.forward_address = "/ip4/10.71.1.141/tcp/12345"
tor.listener_address_override = "/ip4/10.71.1.141/tcp/12345"
```

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
