### PR TITLE
feat: organize core_key_manager service

### DIFF
--- a/base_layer/core/src/core_key_manager/handle.rs
+++ b/base_layer/core/src/core_key_manager/handle.rs
@@ -31,6 +31,7 @@ use tari_key_manager::{
         KeyManagerInterface,
         KeyManagerServiceError,
         NextKeyResult,
+        NextPublicKeyResult,
     },
 };
 use tokio::sync::RwLock;
@@ -95,10 +96,20 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
         &self,
         branch: T,
     ) -> Result<NextKeyResult<PublicKey>, KeyManagerServiceError> {
+        unimplemented!(
+            "Oops! We do not share private keys outside `core_key_manager`. ({})",
+            branch.into(),
+        )
+    }
+
+    async fn get_next_public_key<T: Into<String> + Send>(
+        &self,
+        branch: T,
+    ) -> Result<NextPublicKeyResult<PublicKey>, KeyManagerServiceError> {
         (*self.core_key_manager_inner)
             .read()
             .await
-            .get_next_key(branch.into())
+            .get_next_public_key(branch.into())
             .await
     }
 
@@ -112,6 +123,18 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
             branch.into(),
             index
         )
+    }
+
+    async fn get_public_key_at_index<T: Into<String> + Send>(
+        &self,
+        branch: T,
+        index: u64,
+    ) -> Result<PublicKey, KeyManagerServiceError> {
+        (*self.core_key_manager_inner)
+            .read()
+            .await
+            .get_public_key_at_index(branch.into(), index)
+            .await
     }
 
     async fn find_key_index<T: Into<String> + Send>(

--- a/base_layer/core/src/core_key_manager/handle.rs
+++ b/base_layer/core/src/core_key_manager/handle.rs
@@ -107,11 +107,11 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
         branch: T,
         index: u64,
     ) -> Result<PrivateKey, KeyManagerServiceError> {
-        (*self.core_key_manager_inner)
-            .read()
-            .await
-            .get_key_at_index(branch.into(), index)
-            .await
+        unimplemented!(
+            "Oops! We do not share private keys outside `core_key_manager`. ({}, {})",
+            branch.into(),
+            index
+        )
     }
 
     async fn find_key_index<T: Into<String> + Send>(

--- a/base_layer/core/src/core_key_manager/service.rs
+++ b/base_layer/core/src/core_key_manager/service.rs
@@ -83,6 +83,10 @@ pub struct CoreKeyManagerInner<TBackend> {
 impl<TBackend> CoreKeyManagerInner<TBackend>
 where TBackend: KeyManagerBackend<PublicKey> + 'static
 {
+    // -----------------------------------------------------------------------------------------------------------------
+    // Key manager section
+    // -----------------------------------------------------------------------------------------------------------------
+
     pub fn new(
         master_seed: CipherSeed,
         db: KeyManagerDatabase<TBackend, PublicKey>,
@@ -148,7 +152,7 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
         })
     }
 
-    pub async fn get_key_at_index(&self, branch: String, index: u64) -> Result<PrivateKey, KeyManagerServiceError> {
+    async fn _get_key_at_index(&self, branch: String, index: u64) -> Result<PrivateKey, KeyManagerServiceError> {
         let km = self
             .key_managers
             .get(&branch)
@@ -210,6 +214,7 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
         Ok(())
     }
 
+    // Note!: This method may not be made public
     async fn get_private_key(&self, key_id: &KeyId) -> Result<PrivateKey, KeyManagerServiceError> {
         match key_id {
             KeyId::Default { branch, index } => {
@@ -229,6 +234,10 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
         }
     }
 
+    // -----------------------------------------------------------------------------------------------------------------
+    // General crypto section
+    // -----------------------------------------------------------------------------------------------------------------
+
     pub async fn get_commitment(
         &self,
         private_key: &KeyId,
@@ -237,6 +246,10 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
         let key = self.get_private_key(private_key).await?;
         Ok(self.crypto_factories.commitment.commit(&key, value))
     }
+
+    // -----------------------------------------------------------------------------------------------------------------
+    // Transaction input section (transactions > transaction_components > transaction_input)
+    // -----------------------------------------------------------------------------------------------------------------
 
     pub async fn get_script_signature(
         &self,
@@ -276,6 +289,10 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
         )?;
         Ok(script_signature)
     }
+
+    // -----------------------------------------------------------------------------------------------------------------
+    // Transaction output section (transactions > transaction_components > transaction_output)
+    // -----------------------------------------------------------------------------------------------------------------
 
     pub async fn construct_range_proof(
         &self,
@@ -325,93 +342,7 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
         })
     }
 
-    async fn get_private_kernel_signature_nonce(&self, spend_key_id: &KeyId) -> Result<PrivateKey, TransactionError> {
-        let hasher = DomainSeparatedHasher::<Blake256, KeyManagerHashingDomain>::new_with_label("kernel_private_nonce");
-        let spending_private_key = self.get_private_key(spend_key_id).await?;
-        let key_hash = hasher.chain(spending_private_key.as_bytes()).finalize();
-        PrivateKey::from_bytes(key_hash.as_ref()).map_err(|_| {
-            TransactionError::ConversionError("Invalid private key for kernel signature nonce".to_string())
-        })
-    }
-
-    pub async fn get_partial_kernel_signature(
-        &self,
-        spending_key: &KeyId,
-        total_nonce: &PublicKey,
-        total_excess: &PublicKey,
-        kernel_version: &TransactionKernelVersion,
-        kernel_message: &[u8; 32],
-    ) -> Result<Signature, TransactionError> {
-        let spending_private_key = self.get_private_key(spending_key).await?;
-        let private_nonce = self.get_private_kernel_signature_nonce(spending_key).await?;
-        let challenge = TransactionKernel::finalize_kernel_signature_challenge(
-            kernel_version,
-            total_nonce,
-            total_excess,
-            kernel_message,
-        );
-
-        let signature = Signature::sign_raw(&spending_private_key, private_nonce, &challenge)?;
-        Ok(signature)
-    }
-
-    pub async fn get_kernel_signature_nonce(&self, spend_key_id: &KeyId) -> Result<PublicKey, TransactionError> {
-        let private_key = self.get_private_kernel_signature_nonce(spend_key_id).await?;
-        Ok(PublicKey::from_secret_key(&private_key))
-    }
-
-    async fn get_recovery_key(&self) -> Result<PrivateKey, KeyManagerServiceError> {
-        let recovery_id = KeyId::Default {
-            branch: CoreKeyManagerBranch::DataEncryption.get_branch_key(),
-            index: 0,
-        };
-        self.get_private_key(&recovery_id).await
-    }
-
-    pub async fn encrypt_data_for_recovery(
-        &self,
-        spend_key_id: &KeyId,
-        value: u64,
-    ) -> Result<EncryptedData, TransactionError> {
-        let recovery_key = self.get_recovery_key().await?;
-        let value_key = value.into();
-        let commitment = self.get_commitment(spend_key_id, &value_key).await?;
-        let spend_key = self.get_private_key(spend_key_id).await?;
-        let data = EncryptedData::encrypt_data(&recovery_key, &commitment, value.into(), &spend_key)?;
-        Ok(data)
-    }
-
-    pub async fn try_commitment_key_recovery(
-        &self,
-        commitment: &Commitment,
-        data: &EncryptedData,
-    ) -> Result<(KeyId, u64), TransactionError> {
-        let recover_key = self.get_recovery_key().await?;
-        let (value, private_key) = EncryptedData::decrypt_data(&recover_key, commitment, data)?;
-        self.crypto_factories
-            .range_proof
-            .verify_mask(commitment, &private_key, value.into())?;
-        let public_key = PublicKey::from_secret_key(&private_key);
-        let key = match self
-            .find_key_index(CoreKeyManagerBranch::CommitmentMask.get_branch_key(), &public_key)
-            .await
-        {
-            Ok(index) => {
-                self.update_current_key_index_if_higher(CoreKeyManagerBranch::CommitmentMask.get_branch_key(), index)
-                    .await?;
-                KeyId::Default {
-                    branch: CoreKeyManagerBranch::CommitmentMask.get_branch_key(),
-                    index,
-                }
-            },
-            Err(_) => {
-                self.import_key(private_key).await?;
-                KeyId::Imported { key: public_key }
-            },
-        };
-        Ok((key, value.into()))
-    }
-
+    // Note!: This method may not be made public
     async fn get_sender_offset_private_key(&self, script_key_id: &KeyId) -> Result<PrivateKey, TransactionError> {
         let hasher = DomainSeparatedHasher::<Blake256, KeyManagerHashingDomain>::new_with_label("sender_offset_key");
         let script_private_key = self.get_private_key(script_key_id).await?;
@@ -426,6 +357,7 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
         Ok(PublicKey::from_secret_key(&sender_offset_private_key))
     }
 
+    // Note!: This method may not be made public
     async fn get_metadata_signature_ephemeral_private_key_pair(
         &self,
         spend_key_id: &KeyId,
@@ -458,6 +390,7 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
         Ok(self.crypto_factories.commitment.commit(&nonce_a, &nonce_b))
     }
 
+    // Note!: This method may not be made public
     async fn get_metadata_signature_ephemeral_private_key(
         &self,
         script_key_id: &KeyId,
@@ -550,5 +483,102 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
             &*self.crypto_factories.commitment,
         )?;
         Ok(metadata_signature)
+    }
+
+    // -----------------------------------------------------------------------------------------------------------------
+    // Transaction kernel section (transactions > transaction_components > transaction_kernel)
+    // -----------------------------------------------------------------------------------------------------------------
+
+    // Note!: This method may not be made public
+    async fn get_private_kernel_signature_nonce(&self, spend_key_id: &KeyId) -> Result<PrivateKey, TransactionError> {
+        let hasher = DomainSeparatedHasher::<Blake256, KeyManagerHashingDomain>::new_with_label("kernel_private_nonce");
+        let spending_private_key = self.get_private_key(spend_key_id).await?;
+        let key_hash = hasher.chain(spending_private_key.as_bytes()).finalize();
+        PrivateKey::from_bytes(key_hash.as_ref()).map_err(|_| {
+            TransactionError::ConversionError("Invalid private key for kernel signature nonce".to_string())
+        })
+    }
+
+    pub async fn get_partial_kernel_signature(
+        &self,
+        spending_key: &KeyId,
+        total_nonce: &PublicKey,
+        total_excess: &PublicKey,
+        kernel_version: &TransactionKernelVersion,
+        kernel_message: &[u8; 32],
+    ) -> Result<Signature, TransactionError> {
+        let spending_private_key = self.get_private_key(spending_key).await?;
+        let private_nonce = self.get_private_kernel_signature_nonce(spending_key).await?;
+        let challenge = TransactionKernel::finalize_kernel_signature_challenge(
+            kernel_version,
+            total_nonce,
+            total_excess,
+            kernel_message,
+        );
+
+        let signature = Signature::sign_raw(&spending_private_key, private_nonce, &challenge)?;
+        Ok(signature)
+    }
+
+    pub async fn get_kernel_signature_nonce(&self, spend_key_id: &KeyId) -> Result<PublicKey, TransactionError> {
+        let private_key = self.get_private_kernel_signature_nonce(spend_key_id).await?;
+        Ok(PublicKey::from_secret_key(&private_key))
+    }
+
+    // -----------------------------------------------------------------------------------------------------------------
+    // Encrypted data section (transactions > transaction_components > encrypted_data)
+    // -----------------------------------------------------------------------------------------------------------------
+
+    // Note!: This method may not be made public
+    async fn get_recovery_key(&self) -> Result<PrivateKey, KeyManagerServiceError> {
+        let recovery_id = KeyId::Default {
+            branch: CoreKeyManagerBranch::DataEncryption.get_branch_key(),
+            index: 0,
+        };
+        self.get_private_key(&recovery_id).await
+    }
+
+    pub async fn encrypt_data_for_recovery(
+        &self,
+        spend_key_id: &KeyId,
+        value: u64,
+    ) -> Result<EncryptedData, TransactionError> {
+        let recovery_key = self.get_recovery_key().await?;
+        let value_key = value.into();
+        let commitment = self.get_commitment(spend_key_id, &value_key).await?;
+        let spend_key = self.get_private_key(spend_key_id).await?;
+        let data = EncryptedData::encrypt_data(&recovery_key, &commitment, value.into(), &spend_key)?;
+        Ok(data)
+    }
+
+    pub async fn try_commitment_key_recovery(
+        &self,
+        commitment: &Commitment,
+        data: &EncryptedData,
+    ) -> Result<(KeyId, u64), TransactionError> {
+        let recover_key = self.get_recovery_key().await?;
+        let (value, private_key) = EncryptedData::decrypt_data(&recover_key, commitment, data)?;
+        self.crypto_factories
+            .range_proof
+            .verify_mask(commitment, &private_key, value.into())?;
+        let public_key = PublicKey::from_secret_key(&private_key);
+        let key = match self
+            .find_key_index(CoreKeyManagerBranch::CommitmentMask.get_branch_key(), &public_key)
+            .await
+        {
+            Ok(index) => {
+                self.update_current_key_index_if_higher(CoreKeyManagerBranch::CommitmentMask.get_branch_key(), index)
+                    .await?;
+                KeyId::Default {
+                    branch: CoreKeyManagerBranch::CommitmentMask.get_branch_key(),
+                    index,
+                }
+            },
+            Err(_) => {
+                self.import_key(private_key).await?;
+                KeyId::Imported { key: public_key }
+            },
+        };
+        Ok((key, value.into()))
     }
 }

--- a/base_layer/key_manager/src/key_manager_service/handle.rs
+++ b/base_layer/key_manager/src/key_manager_service/handle.rs
@@ -34,6 +34,7 @@ use crate::{
         AddResult,
         KeyManagerInner,
         KeyManagerInterface,
+        NextPublicKeyResult,
     },
 };
 
@@ -83,6 +84,13 @@ where
         (*self.key_manager_inner).read().await.get_next_key(branch.into()).await
     }
 
+    async fn get_next_public_key<T: Into<String> + Send>(
+        &self,
+        branch: T,
+    ) -> Result<NextPublicKeyResult<PK>, KeyManagerServiceError> {
+        unimplemented!("Oops! This is reserved for `core_key_manager`. ({})", branch.into(),)
+    }
+
     async fn get_key_at_index<T: Into<String> + Send>(
         &self,
         branch: T,
@@ -93,6 +101,18 @@ where
             .await
             .get_key_at_index(branch.into(), index)
             .await
+    }
+
+    async fn get_public_key_at_index<T: Into<String> + Send>(
+        &self,
+        branch: T,
+        index: u64,
+    ) -> Result<PK, KeyManagerServiceError> {
+        unimplemented!(
+            "Oops! This is reserved for `core_key_manager`. ({}, {})",
+            branch.into(),
+            index
+        )
     }
 
     async fn find_key_index<T: Into<String> + Send>(&self, branch: T, key: &PK) -> Result<u64, KeyManagerServiceError> {

--- a/base_layer/key_manager/src/key_manager_service/interface.rs
+++ b/base_layer/key_manager/src/key_manager_service/interface.rs
@@ -39,6 +39,11 @@ pub struct NextKeyResult<PK: PublicKey> {
     pub index: u64,
 }
 
+pub struct NextPublicKeyResult<PK: PublicKey> {
+    pub key: PK,
+    pub index: u64,
+}
+
 /// Behaviour required for the Key manager service
 #[async_trait::async_trait]
 pub trait KeyManagerInterface<PK>: Clone + Send + Sync + 'static
@@ -59,12 +64,25 @@ where
         branch: T,
     ) -> Result<NextKeyResult<PK>, KeyManagerServiceError>;
 
+    /// Gets the next key from the branch. This will auto-increment the branch key index by 1
+    async fn get_next_public_key<T: Into<String> + Send>(
+        &self,
+        branch: T,
+    ) -> Result<NextPublicKeyResult<PK>, KeyManagerServiceError>;
+
     /// Gets the key at the specified index
     async fn get_key_at_index<T: Into<String> + Send>(
         &self,
         branch: T,
         index: u64,
     ) -> Result<PK::K, KeyManagerServiceError>;
+
+    /// Gets the public key at the specified index
+    async fn get_public_key_at_index<T: Into<String> + Send>(
+        &self,
+        branch: T,
+        index: u64,
+    ) -> Result<PK, KeyManagerServiceError>;
 
     /// Searches the branch to find the index used to generated the key, O(N) where N = index used.
     async fn find_key_index<T: Into<String> + Send>(&self, branch: T, key: &PK) -> Result<u64, KeyManagerServiceError>;

--- a/base_layer/key_manager/src/key_manager_service/mod.rs
+++ b/base_layer/key_manager/src/key_manager_service/mod.rs
@@ -55,4 +55,4 @@ mod test;
 mod interface;
 pub mod storage;
 
-pub use interface::{AddResult, KeyManagerInterface, NextKeyResult};
+pub use interface::{AddResult, KeyManagerInterface, NextKeyResult, NextPublicKeyResult};


### PR DESCRIPTION
Description
---
- Organized core/src/core_key_manager/service into logic units by comment sections, as it is not feasible to structure it as such.
- Added `async fn get_next_public_key` and `async fn get_public_key_at_index` to `KeyManagerInterface`
- Prohibit pass-back of the private keys from trait functions `get_key_at_index` and `get_next_key` for `CoreKeyManagerHandle`
- Prohibit pass-back of public keys from trait functions `get_next_public_key` and `get_public_key_at_index` for `KeyManagerHandle`
- Added implementations `get_next_public_key` and `get_public_key_at_index` for `CoreKeyManagerInner`

Motivation and Context
---
A little bit of code organisation was needed

How Has This Been Tested?
---
Unit test 

What process can a PR reviewer use to test or verify this change?
---
Inspection

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
