### PR TITLE
docs: add range proof verification warnings

### DIFF
--- a/base_layer/core/src/transactions/transaction_components/transaction_output.rs
+++ b/base_layer/core/src/transactions/transaction_components/transaction_output.rs
@@ -210,6 +210,10 @@ impl TransactionOutput {
     }
 
     /// Verify that range proof is valid
+    ///
+    /// WARNING: In the case of a revealed-value range proof using a metadata signature, the metadata signature _must_
+    /// separately be verified! If this is not done, the range proof verification is inconclusive and _must not_ be
+    /// relied on.
     pub fn verify_range_proof(&self, prover: &RangeProofService) -> Result<(), TransactionError> {
         match self.features.range_proof_type {
             RangeProofType::RevealedValue => match self.revealed_value_range_proof_check() {
@@ -619,6 +623,10 @@ impl Ord for TransactionOutput {
 }
 
 /// Performs batched range proof verification for an arbitrary number of outputs
+///
+/// WARNING: In the case of a revealed-value range proof using a metadata signature, the metadata signature _must_
+/// separately be verified! If this is not done, the range proof verification is inconclusive and _must not_ be relied
+/// on.
 pub fn batch_verify_range_proofs(
     prover: &RangeProofService,
     outputs: &[&TransactionOutput],


### PR DESCRIPTION
Description
---
Adds warning comments about revealed-value range proof verification to help guard against misuse.

Motivation and Context
---
As noted in a [comment](https://github.com/tari-project/tari/pull/5372#issuecomment-1561898855) on #5372, verification of a revealed-value range proof requires separate verification of the corresponding metadata signature. Without such a check, range proof verification is inconclusive.

Because this is a major but subtle change to the guarantees provided by the single and batch range proof verification functions, this PR adds scary warning comments .

How Has This Been Tested?
---
The comments look sufficiently frightening.

What process can a PR reviewer use to test or verify this change?
---
Ensure that there are no code paths that assume revealed-value range proof validity without metadata signature verification.