### PR TITLE
test: fix wallet ffi base dirs in tests to prevent ci from returning false failures

### DIFF
--- a/integration_tests/src/base_node_process.rs
+++ b/integration_tests/src/base_node_process.rs
@@ -24,7 +24,6 @@ use std::{
     default::Default,
     fmt::{Debug, Formatter},
     path::PathBuf,
-    process,
     str::FromStr,
     sync::Arc,
     time::Duration,
@@ -42,7 +41,7 @@ use tari_shutdown::Shutdown;
 use tokio::task;
 use tonic::transport::Channel;
 
-use crate::{get_peer_addresses, get_port, wait_for_service, TariWorld};
+use crate::{get_base_dir, get_peer_addresses, get_port, wait_for_service, TariWorld};
 
 #[derive(Clone)]
 pub struct BaseNodeProcess {
@@ -79,11 +78,6 @@ impl Debug for BaseNodeProcess {
 
 pub async fn spawn_base_node(world: &mut TariWorld, is_seed_node: bool, bn_name: String, peers: Vec<String>) {
     spawn_base_node_with_config(world, is_seed_node, bn_name, peers, BaseNodeConfig::default()).await;
-}
-
-pub fn get_base_dir() -> PathBuf {
-    let crate_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    crate_root.join(format!("tests/temp/cucumber_{}", process::id()))
 }
 
 pub async fn spawn_base_node_with_config(

--- a/integration_tests/src/chat_client.rs
+++ b/integration_tests/src/chat_client.rs
@@ -33,7 +33,7 @@ use tari_comms::{
 use tari_comms_dht::{store_forward::SafConfig, DbConnectionUrl, DhtConfig, NetworkDiscoveryConfig};
 use tari_p2p::{P2pConfig, TcpTransportConfig, TransportConfig};
 
-use crate::{base_node_process::get_base_dir, get_port};
+use crate::{get_base_dir, get_port};
 
 pub async fn spawn_chat_client(name: &str, seed_peers: Vec<Peer>) -> Client {
     let port = get_port(18000..18499).unwrap();

--- a/integration_tests/src/chat_ffi.rs
+++ b/integration_tests/src/chat_ffi.rs
@@ -47,7 +47,7 @@ use tari_contacts::contacts_service::{service::ContactOnlineStatus, types::Messa
 use tari_p2p::{P2pConfig, TcpTransportConfig, TransportConfig};
 use tari_utilities::message_format::MessageFormat;
 
-use crate::{base_node_process::get_base_dir, get_port};
+use crate::{get_base_dir, get_port};
 
 #[cfg_attr(windows, link(name = "tari_chat_ffi.dll"))]
 #[cfg_attr(not(windows), link(name = "tari_chat_ffi"))]

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -20,7 +20,7 @@
 //   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{net::TcpListener, ops::Range, time::Duration};
+use std::{net::TcpListener, ops::Range, path::PathBuf, process, time::Duration};
 
 use rand::Rng;
 
@@ -49,6 +49,11 @@ pub fn get_port(range: Range<u16>) -> Option<u64> {
             return Some(u64::from(port));
         }
     }
+}
+
+pub fn get_base_dir() -> PathBuf {
+    let crate_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    crate_root.join(format!("tests/temp/cucumber_{}", process::id()))
 }
 
 pub async fn wait_for_service(port: u64) {

--- a/integration_tests/src/wallet_process.rs
+++ b/integration_tests/src/wallet_process.rs
@@ -20,7 +20,7 @@
 //   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{path::PathBuf, process, str::FromStr, thread, time::Duration};
+use std::{path::PathBuf, str::FromStr, thread, time::Duration};
 
 use tari_app_grpc::tari_rpc::SetBaseNodeRequest;
 use tari_app_utilities::common_cli_args::CommonCliArgs;
@@ -35,7 +35,7 @@ use tari_wallet_grpc_client::WalletGrpcClient;
 use tokio::runtime;
 use tonic::transport::Channel;
 
-use crate::{get_peer_addresses, get_port, wait_for_service, TariWorld};
+use crate::{get_base_dir, get_peer_addresses, get_port, wait_for_service, TariWorld};
 
 #[derive(Clone, Debug)]
 pub struct WalletProcess {
@@ -245,9 +245,4 @@ impl WalletProcess {
     pub fn kill(&mut self) {
         self.kill_signal.trigger();
     }
-}
-
-pub fn get_base_dir() -> PathBuf {
-    let crate_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    crate_root.join(format!("tests/temp/cucumber_{}", process::id()))
 }


### PR DESCRIPTION
Description
---
The wallet ffi started using the log directory for it's data directory. This conflicted with the new code to move logs into the test run dir.

Motivation and Context
---
CI was passing and reporting failure.

How Has This Been Tested?
---
Locally

What process can a PR reviewer use to test or verify this change?
---
Watch CI pass

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
