### PR TITLE
feat: refactor configuration for chat so ffi can create and accept a config file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -215,7 +221,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -226,7 +232,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -335,9 +341,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.1"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f1e31e207a6b8fb791a38ea3105e6cb541f55e4d029902d3039a4ad07cc4105"
+checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
 
 [[package]]
 name = "base64-compat"
@@ -577,9 +583,9 @@ checksum = "40e38929add23cdf8a366df9b0e088953150724bcbe5fc330b0d8eb3b328eec8"
 
 [[package]]
 name = "bumpalo"
-version = "3.12.2"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c6ed94e98ecff0c12dd1b04c15ec0d7d9458ca8fe806cea6f12954efe74c63b"
+checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
 name = "bytecount"
@@ -662,7 +668,7 @@ dependencies = [
  "serde_json",
  "syn 1.0.109",
  "tempfile",
- "toml",
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -681,7 +687,7 @@ dependencies = [
  "serde_json",
  "syn 1.0.109",
  "tempfile",
- "toml",
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -782,13 +788,13 @@ checksum = "17cc5e6b5ab06331c33589842070416baa137e8b0eb912b008cfd4a78ada7919"
 
 [[package]]
 name = "chrono"
-version = "0.4.24"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
+checksum = "fdbc37d37da9e5bce8173f3a41b71d9bf3c674deebbaceacd0ebdabde76efb03"
 dependencies = [
+ "android-tzdata",
  "iana-time-zone",
  "js-sys",
- "num-integer",
  "num-traits",
  "serde",
  "time 0.1.45",
@@ -949,7 +955,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -1023,7 +1029,7 @@ dependencies = [
  "rust-ini",
  "serde",
  "serde_json",
- "toml",
+ "toml 0.5.11",
  "yaml-rust",
 ]
 
@@ -1336,7 +1342,7 @@ dependencies = [
  "crossterm_winapi 0.9.0",
  "futures-core",
  "libc",
- "mio 0.8.6",
+ "mio 0.8.7",
  "parking_lot 0.12.1",
  "signal-hook",
  "signal-hook-mio",
@@ -1352,7 +1358,7 @@ dependencies = [
  "bitflags 1.3.2",
  "crossterm_winapi 0.9.0",
  "libc",
- "mio 0.8.6",
+ "mio 0.8.7",
  "parking_lot 0.12.1",
  "signal-hook",
  "signal-hook-mio",
@@ -1746,9 +1752,9 @@ checksum = "3c877555693c14d2f84191cfd3ad8582790fc52b5e2274b40b59cf5f5cea25c7"
 
 [[package]]
 name = "diesel"
-version = "2.0.4"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72eb77396836a4505da85bae0712fa324b74acfe1876d7c2f7e694ef3d0ee373"
+checksum = "f7a532c1f99a0f596f6960a60d1e119e91582b24b39e2d83a190e61262c3ef0c"
 dependencies = [
  "bigdecimal",
  "chrono",
@@ -1759,29 +1765,39 @@ dependencies = [
  "num-traits",
  "r2d2",
  "serde_json",
+ "time 0.3.21",
 ]
 
 [[package]]
 name = "diesel_derives"
-version = "2.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad74fdcf086be3d4fdd142f67937678fe60ed431c3b2f08599e7687269410c4"
+checksum = "74398b79d81e52e130d991afeed9c86034bb1b7735f46d2f5bf7deb261d80303"
 dependencies = [
- "proc-macro-error",
+ "diesel_table_macro_syntax",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.18",
 ]
 
 [[package]]
 name = "diesel_migrations"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9ae22beef5e9d6fab9225ddb073c1c6c1a7a6ded5019d5da11d1e5c5adc34e2"
+checksum = "6036b3f0120c5961381b570ee20a02432d7e2d27ea60de9578799cf9156914ac"
 dependencies = [
  "diesel",
  "migrations_internals",
  "migrations_macros",
+]
+
+[[package]]
+name = "diesel_table_macro_syntax"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc5557efc453706fed5e4fa85006fe9817c224c3f480a34c7e5959fd700921c5"
+dependencies = [
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -2137,7 +2153,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -2259,7 +2275,7 @@ checksum = "e77ac7b51b8e6313251737fcef4b1c01a2ea102bde68415b62c0ee9268fec357"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -2678,9 +2694,9 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
  "hermit-abi 0.3.1",
  "libc",
@@ -2942,11 +2958,10 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
+checksum = "518ef76f2f87365916b142844c16d8fefd85039bc5699050210a7778ee1cd1de"
 dependencies = [
- "cfg-if",
  "serde",
 ]
 
@@ -3052,19 +3067,19 @@ dependencies = [
 
 [[package]]
 name = "migrations_internals"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c493c09323068c01e54c685f7da41a9ccf9219735c3766fbfd6099806ea08fbc"
+checksum = "0f23f71580015254b020e856feac3df5878c2c7a8812297edd6c0a485ac9dada"
 dependencies = [
  "serde",
- "toml",
+ "toml 0.7.4",
 ]
 
 [[package]]
 name = "migrations_macros"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a8ff27a350511de30cdabb77147501c36ef02e0451d957abea2f30caffb2b58"
+checksum = "cce3325ac70e67bbab5bd837a31cae01f1a6db64e0e744a33cb03a543469ef08"
 dependencies = [
  "migrations_internals",
  "proc-macro2",
@@ -3117,14 +3132,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
+checksum = "eebffdb73fe72e917997fad08bdbf31ac50b0fa91cec93e69a0662e4264d454c"
 dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3139,7 +3154,7 @@ dependencies = [
 [[package]]
 name = "monero"
 version = "0.18.2"
-source = "git+https://github.com/monero-rs/monero-rs.git#894ccd6b15d768bc261a224952a6d32b2a9dbbf7"
+source = "git+https://github.com/monero-rs/monero-rs.git#3decd79ea18b8dafcf9b028c8240b20826980f17"
 dependencies = [
  "base58-monero 1.0.0",
  "curve25519-dalek 3.2.0",
@@ -3447,7 +3462,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -3668,7 +3683,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -3788,7 +3803,7 @@ checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -3911,7 +3926,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
 dependencies = [
- "toml",
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -3921,7 +3936,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
 dependencies = [
  "thiserror",
- "toml",
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -3950,9 +3965,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.58"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa1fb82fc0c281dd9671101b66b771ebbe1eaf967b96ac8740dcba4b70005ca8"
+checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
 dependencies = [
  "unicode-ident",
 ]
@@ -4096,9 +4111,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
+checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
 dependencies = [
  "proc-macro2",
 ]
@@ -4306,13 +4321,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.1"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
+checksum = "81ca098a9821bd52d6b24fd8b10bd081f47d39c22778cafaa75a2857a62c6390"
 dependencies = [
  "aho-corasick 1.0.1",
  "memchr",
- "regex-syntax 0.7.1",
+ "regex-syntax 0.7.2",
 ]
 
 [[package]]
@@ -4332,9 +4347,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
+checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
 name = "reqwest"
@@ -4342,7 +4357,7 @@ version = "0.11.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
 dependencies = [
- "base64 0.21.1",
+ "base64 0.21.2",
  "bytes 1.4.0",
  "encoding_rs",
  "futures-core",
@@ -4512,7 +4527,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
- "base64 0.21.1",
+ "base64 0.21.2",
 ]
 
 [[package]]
@@ -4716,7 +4731,7 @@ checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -4738,7 +4753,16 @@ checksum = "bcec881020c684085e55a25f7fd888954d56609ef363479dc5a1305eb0d40cab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93107647184f6027e3b7dcb2e11034cf95ffa1e3a682c67951963ac69c1c007d"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -4877,7 +4901,7 @@ checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
 dependencies = [
  "libc",
  "mio 0.7.14",
- "mio 0.8.6",
+ "mio 0.8.7",
  "signal-hook",
 ]
 
@@ -5074,9 +5098,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.16"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6f671d4b5ffdb8eadec19c0ae67fe2639df8684bd7bc4b83d986b8db549cf01"
+checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5295,18 +5319,22 @@ version = "0.50.0-pre.2"
 dependencies = [
  "anyhow",
  "async-trait",
+ "config",
  "diesel",
  "lmdb-zero",
  "log",
+ "serde",
+ "tari_app_utilities",
+ "tari_common",
  "tari_common_sqlite",
  "tari_common_types",
  "tari_comms",
+ "tari_comms_dht",
  "tari_contacts",
  "tari_p2p",
  "tari_service_framework",
  "tari_shutdown",
  "tari_storage",
- "tari_test_utils",
 ]
 
 [[package]]
@@ -5317,13 +5345,12 @@ dependencies = [
  "libc",
  "log",
  "openssl",
- "serde_json",
+ "tari_app_utilities",
  "tari_chat_client",
  "tari_common",
  "tari_common_types",
  "tari_comms",
  "tari_contacts",
- "tari_p2p",
  "thiserror",
  "tokio",
 ]
@@ -5352,7 +5379,7 @@ dependencies = [
  "tari_test_utils",
  "tempfile",
  "thiserror",
- "toml",
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -5373,7 +5400,7 @@ dependencies = [
 name = "tari_common_types"
 version = "0.50.0-pre.2"
 dependencies = [
- "base64 0.21.1",
+ "base64 0.21.2",
  "borsh",
  "chacha20poly1305 0.10.1",
  "digest 0.9.0",
@@ -6195,7 +6222,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -6293,14 +6320,14 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.28.1"
+version = "1.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa32867d44e6f2ce3385e89dceb990188b8bb0fb25b0cf576647a6f98ac5105"
+checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
 dependencies = [
  "autocfg",
  "bytes 1.4.0",
  "libc",
- "mio 0.8.6",
+ "mio 0.8.7",
  "num_cpus",
  "pin-project-lite",
  "signal-hook-registry",
@@ -6328,7 +6355,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -6403,6 +6430,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6135d499e69981f9ff0ef2167955a5333c35e36f6937d382974566b3d5b94ec"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a76a9312f5ba4c2dec6b9161fdf25d87ad8a09256ccea5a556fef03c706a10f"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.19.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2380d56e8670370eee6566b0bfd4265f65b3f432e8c6d85623f728d4fa31f739"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
 name = "tonic"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6441,7 +6502,7 @@ checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
 dependencies = [
  "async-trait",
  "axum",
- "base64 0.21.1",
+ "base64 0.21.2",
  "bytes 1.4.0",
  "futures-core",
  "futures-util",
@@ -6540,7 +6601,7 @@ checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -6722,9 +6783,9 @@ checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
 
 [[package]]
 name = "unicode-linebreak"
@@ -7286,6 +7347,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
+name = "winnow"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61de7bac303dc551fe038e2b3cef0f571087a47571ea6e79a87692ac99b99699"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winreg"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7345,7 +7415,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "base_layer/tari_mining_helper_ffi",
     "clients/rust/base_node_grpc_client",
     "clients/rust/wallet_grpc_client",
+    # "clients/rust/web_chat",
     "comms/core",
     "comms/dht",
     "comms/rpc_macros",

--- a/base_layer/chat_ffi/Cargo.toml
+++ b/base_layer/chat_ffi/Cargo.toml
@@ -7,6 +7,7 @@ version = "0.50.0-pre.2"
 edition = "2018"
 
 [dependencies]
+tari_app_utilities = { path = "../../applications/tari_app_utilities" }
 tari_chat_client = { path = "../contacts/examples/chat_client" }
 tari_common = { path = "../../common" }
 tari_common_types = { path = "../common_types" }

--- a/base_layer/chat_ffi/Cargo.toml
+++ b/base_layer/chat_ffi/Cargo.toml
@@ -12,11 +12,9 @@ tari_common = { path = "../../common" }
 tari_common_types = { path = "../common_types" }
 tari_comms = { path = "../../comms/core" }
 tari_contacts = { path = "../contacts" }
-tari_p2p = { path = "../p2p" }
 
 libc = "0.2.65"
 log = "0.4.6"
-serde_json = "1.0.64"
 thiserror = "1.0.26"
 tokio = "1.23"
 

--- a/base_layer/chat_ffi/chat.h
+++ b/base_layer/chat_ffi/chat.h
@@ -12,13 +12,6 @@ struct ChatMessages;
 
 struct ClientFFI;
 
-struct ClientPeers;
-
-/**
- * Configuration for a comms node
- */
-struct P2pConfig;
-
 struct TariAddress;
 
 #ifdef __cplusplus
@@ -27,16 +20,10 @@ extern "C" {
 
 /**
  * Creates a Chat Client
- * TODO: This function takes a ptr to a collection of seed peers and this works fine in cucumber, or native rust but
- * isn't at all ideal for a real FFI. We need to work with the mobile teams and come up with a better interface
- * for supplying seed peers.
  *
  * ## Arguments
- * `config` - The P2PConfig pointer
+ * `config` - The ApplicationConfig pointer
  * `identity_file_path` - The path to the node identity file
- * `db_path` - The path to the db file
- * `seed_peers` - A ptr to a collection of seed peers
- * `network_str` - The network to connect to
  * `error_out` - Pointer to an int which will be modified
  *
  * ## Returns
@@ -46,11 +33,8 @@ extern "C" {
  * # Safety
  * The ```destroy_client``` method must be called when finished with a ClientFFI to prevent a memory leak
  */
-struct ClientFFI *create_chat_client(struct P2pConfig *config,
+struct ClientFFI *create_chat_client(ApplicationConfig *config,
                                      const char *identity_file_path,
-                                     const char *db_path,
-                                     struct ClientPeers *seed_peers,
-                                     const char *network_str,
                                      int *error_out);
 
 /**
@@ -66,6 +50,39 @@ struct ClientFFI *create_chat_client(struct P2pConfig *config,
  * None
  */
 void destroy_client_ffi(struct ClientFFI *client);
+
+/**
+ * Creates a Chat Client config
+ *
+ * ## Arguments
+ * `network` - The network to run on
+ * `public_address` - The nodes public address
+ * `error_out` - Pointer to an int which will be modified
+ *
+ * ## Returns
+ * `*mut ApplicationConfig` - Returns a pointer to an ApplicationConfig
+ *
+ * # Safety
+ * The ```destroy_config``` method must be called when finished with a Config to prevent a memory leak
+ */
+ApplicationConfig *create_chat_config(const char *network_str,
+                                      const char *public_address,
+                                      const char *datastore_path,
+                                      int *error_out);
+
+/**
+ * Frees memory for an ApplicationConfig
+ *
+ * ## Arguments
+ * `config` - The pointer of an ApplicationConfig
+ *
+ * ## Returns
+ * `()` - Does not return a value, equivalent to void in C
+ *
+ * # Safety
+ * None
+ */
+void destroy_config(ApplicationConfig *config);
 
 /**
  * Sends a message over a client

--- a/base_layer/chat_ffi/src/error.rs
+++ b/base_layer/chat_ffi/src/error.rs
@@ -30,7 +30,7 @@ pub enum InterfaceError {
     NullError(String),
     #[error("An error has occurred when trying to create the tokio runtime: `{0}`")]
     TokioError(String),
-    #[error("Emoji ID is invalid")]
+    #[error("Something about the argument is invalid: `{0}`")]
     InvalidArgument(String),
 }
 

--- a/base_layer/contacts/examples/chat_client/Cargo.toml
+++ b/base_layer/contacts/examples/chat_client/Cargo.toml
@@ -8,18 +8,22 @@ version = "0.50.0-pre.2"
 edition = "2018"
 
 [dependencies]
-tari_common_types = { path = "../../../common_types" }
+tari_app_utilities = { path = "../../../../applications/tari_app_utilities" }
+tari_common = { path = "../../../../common" }
 tari_common_sqlite = { path = "../../../../common_sqlite" }
+tari_common_types = { path = "../../../common_types" }
 tari_comms = { path = "../../../../comms/core" }
+tari_comms_dht = { path = "../../../../comms/dht" }
 tari_contacts = { path = "../../../contacts" }
 tari_p2p = { path = "../../../p2p" }
 tari_service_framework= { path = "../../../service_framework" }
 tari_shutdown = { path = "../../../../infrastructure/shutdown" }
-tari_test_utils = { path = "../../../../infrastructure/test_utils" }
 tari_storage = { path = "../../../../infrastructure/storage" }
 
 anyhow = "1.0.41"
 async-trait = "0.1.52"
+config = { version = "0.13.0" }
 diesel = { version = "2.0.3", features = ["sqlite", "r2d2", "serde_json", "chrono", "64-column-tables"] }
 lmdb-zero = "0.4.4"
 log = "0.4.17"
+serde = "1.0.136"

--- a/base_layer/contacts/examples/chat_client/src/client.rs
+++ b/base_layer/contacts/examples/chat_client/src/client.rs
@@ -22,7 +22,6 @@
 
 use std::{
     fmt::{Debug, Formatter},
-    path::PathBuf,
     sync::Arc,
     time::Duration,
 };
@@ -30,16 +29,15 @@ use std::{
 use async_trait::async_trait;
 use log::debug;
 use tari_common_types::tari_address::TariAddress;
-use tari_comms::{peer_manager::Peer, CommsNode, NodeIdentity};
+use tari_comms::{CommsNode, NodeIdentity};
 use tari_contacts::contacts_service::{
     handle::ContactsServiceHandle,
     service::ContactOnlineStatus,
     types::{Message, MessageBuilder},
 };
-use tari_p2p::{Network, P2pConfig};
 use tari_shutdown::Shutdown;
 
-use crate::networking;
+use crate::{config::ApplicationConfig, networking};
 
 const LOG_TARGET: &str = "contacts::chat_client";
 
@@ -53,12 +51,9 @@ pub trait ChatClient {
 }
 
 pub struct Client {
-    pub config: P2pConfig,
+    pub config: ApplicationConfig,
     pub contacts: Option<ContactsServiceHandle>,
-    pub db_path: PathBuf,
     pub identity: Arc<NodeIdentity>,
-    pub network: Network,
-    pub seed_peers: Vec<Peer>,
     pub shutdown: Shutdown,
 }
 
@@ -66,10 +61,7 @@ impl Debug for Client {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Client")
             .field("config", &self.config)
-            .field("db_path", &self.db_path)
             .field("identity", &self.identity)
-            .field("network", &self.network)
-            .field("seed_peers", &self.seed_peers)
             .field("shutdown", &self.shutdown)
             .finish()
     }
@@ -82,20 +74,11 @@ impl Drop for Client {
 }
 
 impl Client {
-    pub fn new(
-        identity: NodeIdentity,
-        config: P2pConfig,
-        seed_peers: Vec<Peer>,
-        db_path: PathBuf,
-        network: Network,
-    ) -> Self {
+    pub fn new(identity: Arc<NodeIdentity>, config: ApplicationConfig) -> Self {
         Self {
             config,
             contacts: None,
-            db_path,
-            identity: Arc::new(identity),
-            network,
-            seed_peers,
+            identity,
             shutdown: Shutdown::new(),
         }
     }
@@ -105,18 +88,11 @@ impl Client {
 
         let signal = self.shutdown.to_signal();
 
-        let (contacts, comms_node) = networking::start(
-            self.identity.clone(),
-            self.config.clone(),
-            self.seed_peers.clone(),
-            self.network,
-            self.db_path.clone(),
-            signal,
-        )
-        .await
-        .unwrap();
+        let (contacts, comms_node) = networking::start(self.identity.clone(), self.config.clone(), signal)
+            .await
+            .unwrap();
 
-        if !self.seed_peers.is_empty() {
+        if !self.config.peer_seeds.peer_seeds.is_empty() {
             loop {
                 debug!(target: LOG_TARGET, "Waiting for peer connections...");
                 match wait_for_connectivity(comms_node.clone()).await {

--- a/base_layer/contacts/examples/chat_client/src/config.rs
+++ b/base_layer/contacts/examples/chat_client/src/config.rs
@@ -1,0 +1,183 @@
+//  Copyright 2023. The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::{
+    path::{Path, PathBuf},
+    str::FromStr,
+    time::Duration,
+};
+
+use config::Config;
+use serde::{Deserialize, Serialize};
+use tari_app_utilities::consts;
+use tari_common::{
+    configuration::{serializers, CommonConfig, Network, StringList},
+    ConfigurationError,
+    DefaultConfigLoader,
+    SubConfigPath,
+};
+use tari_comms_dht::{store_forward::SafConfig, DbConnectionUrl, DhtConfig, NetworkDiscoveryConfig};
+use tari_p2p::{P2pConfig, PeerSeedsConfig, TcpTransportConfig, TransportConfig};
+use tari_storage::lmdb_store::LMDBConfig;
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ApplicationConfig {
+    pub common: CommonConfig,
+    pub chat_client: ChatClientConfig,
+    pub peer_seeds: PeerSeedsConfig,
+}
+
+impl ApplicationConfig {
+    pub fn load_from(cfg: &Config) -> Result<Self, ConfigurationError> {
+        let mut config = Self {
+            common: CommonConfig::load_from(cfg)?,
+            peer_seeds: PeerSeedsConfig::load_from(cfg)?,
+            chat_client: ChatClientConfig::load_from(cfg)?,
+        };
+
+        config.chat_client.set_base_path(config.common.base_path());
+        Ok(config)
+    }
+
+    pub fn network(&self) -> Network {
+        self.chat_client.network
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+#[allow(clippy::struct_excessive_bools)]
+pub struct ChatClientConfig {
+    override_from: Option<String>,
+    /// Selected network
+    pub network: Network,
+    /// A path to the file that stores the base node identity and secret key
+    pub identity_file: PathBuf,
+    /// A path to the file that stores the tor hidden service private key, if using the tor transport.
+    pub tor_identity_file: PathBuf,
+    /// The type of database backend to use
+    pub db_type: DatabaseType,
+    /// The lmdb config settings
+    pub lmdb: LMDBConfig,
+    /// The relative path to store persistent data
+    pub data_dir: PathBuf,
+    /// The name of the storage db
+    pub db_file: PathBuf,
+    /// The relative path to store the lmbd data
+    pub lmdb_path: PathBuf,
+    /// The p2p config settings
+    pub p2p: P2pConfig,
+    /// If set this node will only sync to the nodes in this set
+    pub force_sync_peers: StringList,
+    /// Liveness meta data auto ping interval between peers
+    #[serde(with = "serializers::seconds")]
+    pub metadata_auto_ping_interval: Duration,
+}
+
+impl Default for ChatClientConfig {
+    fn default() -> Self {
+        let p2p = P2pConfig {
+            datastore_path: PathBuf::from("peer_db/chat_client"),
+            user_agent: format!("tari/chat_client/{}", consts::APP_VERSION_NUMBER),
+            dht: DhtConfig {
+                database_url: DbConnectionUrl::file("data/chat_client/dht.sqlite"),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        Self {
+            override_from: None,
+            network: Network::default(),
+            identity_file: PathBuf::from("config/chat_client_id.json"),
+            tor_identity_file: PathBuf::from("config/chat_client_tor_id.json"),
+            p2p,
+            db_type: DatabaseType::Lmdb,
+            db_file: PathBuf::from_str("db/chat_client.db").unwrap(),
+            lmdb: Default::default(),
+            data_dir: PathBuf::from("data/chat_client"),
+            lmdb_path: PathBuf::from("db"),
+            force_sync_peers: StringList::default(),
+            metadata_auto_ping_interval: Duration::from_secs(30),
+        }
+    }
+}
+
+impl SubConfigPath for ChatClientConfig {
+    fn main_key_prefix() -> &'static str {
+        "chat_client"
+    }
+}
+
+impl ChatClientConfig {
+    pub fn set_base_path<P: AsRef<Path>>(&mut self, base_path: P) {
+        if !self.identity_file.is_absolute() {
+            self.identity_file = base_path.as_ref().join(self.identity_file.as_path());
+        }
+        if !self.tor_identity_file.is_absolute() {
+            self.tor_identity_file = base_path.as_ref().join(self.tor_identity_file.as_path());
+        }
+        if !self.data_dir.is_absolute() {
+            self.data_dir = base_path.as_ref().join(self.data_dir.as_path());
+        }
+        if !self.lmdb_path.is_absolute() {
+            self.lmdb_path = self.data_dir.join(self.lmdb_path.as_path());
+        }
+        if !self.db_file.is_absolute() {
+            self.db_file = self.data_dir.join(self.db_file.as_path());
+        }
+        self.p2p.set_base_path(base_path);
+    }
+
+    pub fn default_local_test() -> Self {
+        Self {
+            network: Network::LocalNet,
+            p2p: P2pConfig {
+                datastore_path: PathBuf::from("peer_db/chat_client"),
+                user_agent: format!("tari/chat_client/{}", consts::APP_VERSION_NUMBER),
+                dht: DhtConfig {
+                    database_url: DbConnectionUrl::file("data/chat_client/dht.sqlite"),
+                    network_discovery: NetworkDiscoveryConfig {
+                        enabled: true,
+                        ..NetworkDiscoveryConfig::default()
+                    },
+                    saf: SafConfig {
+                        auto_request: true,
+                        ..Default::default()
+                    },
+                    ..DhtConfig::default_local_test()
+                },
+                transport: TransportConfig::new_tcp(TcpTransportConfig {
+                    ..TcpTransportConfig::default()
+                }),
+                allow_test_addresses: true,
+                ..P2pConfig::default()
+            },
+            ..Self::default()
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DatabaseType {
+    Lmdb,
+}

--- a/base_layer/contacts/examples/chat_client/src/lib.rs
+++ b/base_layer/contacts/examples/chat_client/src/lib.rs
@@ -23,5 +23,6 @@
 mod client;
 pub use client::{ChatClient, Client};
 
+pub mod config;
 pub mod database;
 pub mod networking;

--- a/integration_tests/src/chat_client.rs
+++ b/integration_tests/src/chat_client.rs
@@ -22,67 +22,61 @@
 
 use std::str::FromStr;
 
-use rand::rngs::OsRng;
-use tari_chat_client::{database, Client};
-use tari_common::configuration::{MultiaddrList, Network};
+use tari_app_utilities::identity_management::setup_node_identity;
+use tari_chat_client::{
+    config::{ApplicationConfig, ChatClientConfig},
+    database,
+    Client,
+};
+use tari_common::configuration::MultiaddrList;
 use tari_comms::{
     multiaddr::Multiaddr,
     peer_manager::{Peer, PeerFeatures},
-    NodeIdentity,
 };
-use tari_comms_dht::{store_forward::SafConfig, DbConnectionUrl, DhtConfig, NetworkDiscoveryConfig};
-use tari_p2p::{P2pConfig, TcpTransportConfig, TransportConfig};
 
 use crate::{get_base_dir, get_port};
 
 pub async fn spawn_chat_client(name: &str, seed_peers: Vec<Peer>) -> Client {
     let port = get_port(18000..18499).unwrap();
-    let identity = identity_file(port);
-    let config = test_config(name, port, &identity);
-    let network = Network::LocalNet;
-    let db_path = database::create_chat_storage(&config.datastore_path).unwrap();
-    database::create_peer_storage(&config.datastore_path);
+    let address = Multiaddr::from_str(&format!("/ip4/127.0.0.1/tcp/{}", port)).unwrap();
 
-    let mut client = Client::new(identity, config, seed_peers, db_path, network);
+    let mut config = test_config(name, port, address.clone());
+    let identity = setup_node_identity(
+        &config.chat_client.identity_file,
+        vec![address],
+        true,
+        PeerFeatures::COMMUNICATION_NODE,
+    )
+    .unwrap();
+
+    database::create_chat_storage(&config.chat_client.db_file);
+    database::create_peer_storage(&config.chat_client.data_dir);
+
+    config.peer_seeds.peer_seeds = seed_peers
+        .iter()
+        .map(|p| p.to_short_string())
+        .collect::<Vec<String>>()
+        .into();
+
+    let mut client = Client::new(identity, config);
     client.initialize().await;
 
     client
 }
 
-fn test_config(name: &str, port: u64, identity: &NodeIdentity) -> P2pConfig {
+fn test_config(name: &str, port: u64, address: Multiaddr) -> ApplicationConfig {
     let temp_dir_path = get_base_dir()
         .join("chat_clients")
         .join(format!("port_{}", port))
         .join(name);
 
-    let mut config = P2pConfig {
-        datastore_path: temp_dir_path.clone(),
-        dht: DhtConfig {
-            database_url: DbConnectionUrl::file("dht.sqlite"),
-            network_discovery: NetworkDiscoveryConfig {
-                enabled: true,
-                ..NetworkDiscoveryConfig::default()
-            },
-            saf: SafConfig {
-                auto_request: true,
-                ..Default::default()
-            },
-            ..DhtConfig::default_local_test()
-        },
-        transport: TransportConfig::new_tcp(TcpTransportConfig {
-            listener_address: identity.first_public_address().expect("No public address"),
-            ..TcpTransportConfig::default()
-        }),
-        allow_test_addresses: true,
-        public_addresses: MultiaddrList::from(vec![identity.first_public_address().expect("No public address")]),
-        user_agent: "tari/chat-client/0.0.1".to_string(),
-        ..P2pConfig::default()
-    };
-    config.set_base_path(temp_dir_path);
-    config
-}
+    let mut chat_client_config = ChatClientConfig::default_local_test();
+    chat_client_config.p2p.transport.tcp.listener_address = address.clone();
+    chat_client_config.p2p.public_addresses = MultiaddrList::from(vec![address]);
+    chat_client_config.set_base_path(temp_dir_path);
 
-fn identity_file(port: u64) -> NodeIdentity {
-    let address = Multiaddr::from_str(&format!("/ip4/127.0.0.1/tcp/{}", port)).unwrap();
-    NodeIdentity::random(&mut OsRng, address, PeerFeatures::COMMUNICATION_NODE)
+    ApplicationConfig {
+        chat_client: chat_client_config,
+        ..ApplicationConfig::default()
+    }
 }


### PR DESCRIPTION
Description
---
This refactoring come on the heels of making testing easier via the chat configuration. As a result we also solve the problem about peer seeds in FFI. Previously the ffi required passing in a collection of peer seeds. This wasn't in any way ideal. Now we take a standard tari configuration setup, which will utilize the DNS seeds in the default configuration.

Motivation and Context
---
ChatFFI had a bad way to connect to peers. It needed fixing. Also cleanup of the integration tests was desired and making configuration simpler is helpful.

How Has This Been Tested?
---
Locally and CI

No new test was added for the configuration creation yet. As that config defaults to real config, not local config.

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
