### PR TITLE
chore(ci): libwallet add back changelog per multiNet

### DIFF
--- a/.github/workflows/build_libwallets_workflow.yml
+++ b/.github/workflows/build_libwallets_workflow.yml
@@ -15,6 +15,9 @@ name: Build libwallet - workflow_call/on-demand
         description: 'Rust toolchain'
         default: 'stable'
 
+env:
+  TARI_NETWORK_CHANGELOG: "development"
+
 jobs:
   android_build:
     name: Build Android
@@ -39,7 +42,9 @@ jobs:
         run: |
           source buildtools/multinet_envs.sh ${{github.ref_name}}
           echo ${TARI_NETWORK}
+          echo ${TARI_NETWORK_CHANGELOG}
           echo "TARI_NETWORK=${TARI_NETWORK}" >> $GITHUB_ENV
+          echo "TARI_NETWORK_CHANGELOG=${TARI_NETWORK_CHANGELOG}" >> $GITHUB_ENV
 
       - name: Setup Rust toolchain
         uses: actions-rs/toolchain@v1
@@ -77,10 +82,15 @@ jobs:
           cd "${{ runner.temp }}/libwallet-android-${target_platform}"
           cp -v "$GITHUB_WORKSPACE/target/${{ matrix.build }}/release/libtari_wallet_ffi.a" "libtari_wallet_ffi.android_${target_platform}.a"
           cp -v "$GITHUB_WORKSPACE/base_layer/wallet_ffi/wallet.h" libtari_wallet_ffi.h
+          if [ -f "$GITHUB_WORKSPACE/changelog-${{ env.TARI_NETWORK_CHANGELOG }}.md" ]; then
+            cp -v "$GITHUB_WORKSPACE/changelog-${{ env.TARI_NETWORK_CHANGELOG }}.md" .
+            TARI_NETWORK_CHANGELOG_FILE=libwallet-android-${target_platform}/changelog-${{ env.TARI_NETWORK_CHANGELOG }}.md
+            echo ${TARI_NETWORK_CHANGELOG_FILE}
+          fi
           cd ..
           shasum -a 256 \
             "libwallet-android-${target_platform}/libtari_wallet_ffi.android_${target_platform}.a" \
-            "libwallet-android-${target_platform}/libtari_wallet_ffi.h" \
+            "libwallet-android-${target_platform}/libtari_wallet_ffi.h" "${TARI_NETWORK_CHANGELOG_FILE}" \
               > "libwallet-android-${target_platform}/libtari_wallet_ffi.android_${target_platform}.sha256sums"
           ls -alht "${{ runner.temp }}/libwallet-android-${target_platform}"
 
@@ -114,7 +124,9 @@ jobs:
         run: |
           source buildtools/multinet_envs.sh ${{github.ref_name}}
           echo ${TARI_NETWORK}
+          echo ${TARI_NETWORK_CHANGELOG}
           echo "TARI_NETWORK=${TARI_NETWORK}" >> $GITHUB_ENV
+          echo "TARI_NETWORK_CHANGELOG=${TARI_NETWORK_CHANGELOG}" >> $GITHUB_ENV
 
       - name: Setup Rust toolchain
         uses: actions-rs/toolchain@v1
@@ -153,10 +165,16 @@ jobs:
           cd "${{ runner.temp }}/libwallet-ios-${target_platform}"
           cp -v "$GITHUB_WORKSPACE/target/${{ matrix.build }}/release/libtari_wallet_ffi.a" "libtari_wallet_ffi.ios_${target_platform}.a"
           cp -v "$GITHUB_WORKSPACE/base_layer/wallet_ffi/wallet.h" libtari_wallet_ffi.h
+          if [ -f "$GITHUB_WORKSPACE/changelog-${{ env.TARI_NETWORK_CHANGELOG }}.md" ]; then
+            cp -v "$GITHUB_WORKSPACE/changelog-${{ env.TARI_NETWORK_CHANGELOG }}.md" .
+            TARI_NETWORK_CHANGELOG_FILE=libwallet-ios-${target_platform}/changelog-${{ env.TARI_NETWORK_CHANGELOG }}.md
+            echo ${TARI_NETWORK_CHANGELOG_FILE}
+          fi
+
           cd ..
           shasum -a 256 \
             "libwallet-ios-${target_platform}/libtari_wallet_ffi.ios_${target_platform}.a" \
-            "libwallet-ios-${target_platform}/libtari_wallet_ffi.h" \
+            "libwallet-ios-${target_platform}/libtari_wallet_ffi.h" "${TARI_NETWORK_CHANGELOG_FILE}" \
               > "libwallet-ios-${target_platform}/libtari_wallet_ffi.ios_${target_platform}.sha256sums"
           ls -alht "${{ runner.temp }}/libwallet-ios-${target_platform}"
 
@@ -170,6 +188,7 @@ jobs:
     name: Assemble iOS universal
     if: ${{ inputs.build_ios == 'true' }}
     needs: ios_build
+
     strategy:
       fail-fast: false
 
@@ -197,19 +216,37 @@ jobs:
         shell: bash
         working-directory: libwallets
         run: |
-          ls -alht
+          ls -alhtR
           mkdir libwallet-ios-universal
           cp -v "libwallet-ios-x86_64/libtari_wallet_ffi.h" \
             libwallet-ios-universal/
+          echo "Check for changelog"
+          if [ -f libwallet-ios-x86_64/changelog-*.md ]; then
+            echo "Changelog found"
+            envChangelogFull=$(ls libwallet-ios-x86_64/changelog-*.md)
+            echo ${envChangelogFull}
+            # Strip suffix
+            #envChangelog=${envChangelogFull::-3}
+            envChangelog=${envChangelogFull:0:${#envChangelogFull}-3}
+            echo ${envChangelog}
+            # Strip prefix
+            TARI_NETWORK_CHANGELOG=${envChangelog##*/changelog-}
+            echo ${TARI_NETWORK_CHANGELOG}
+            cp -v "libwallet-ios-x86_64/changelog-${TARI_NETWORK_CHANGELOG}.md" libwallet-ios-universal/
+            TARI_NETWORK_CHANGELOG_FILE=libwallet-ios-universal/changelog-${TARI_NETWORK_CHANGELOG}.md
+            echo ${TARI_NETWORK_CHANGELOG_FILE}
+          else
+            echo "No changelog found"
+          fi
           lipo -create \
             "libwallet-ios-x86_64/libtari_wallet_ffi.ios_x86_64.a" \
             "libwallet-ios-aarch64/libtari_wallet_ffi.ios_aarch64.a" \
               -output "libwallet-ios-universal/libtari_wallet_ffi.ios_universal.a"
           shasum -a 256 \
             "libwallet-ios-universal/libtari_wallet_ffi.ios_universal.a" \
-            "libwallet-ios-universal/libtari_wallet_ffi.h" \
+            "libwallet-ios-universal/libtari_wallet_ffi.h" "${TARI_NETWORK_CHANGELOG_FILE}" \
               > "libwallet-ios-universal/libtari_wallet_ffi.ios_universal.sha256sums"
-          ls -alht
+          ls -alhtR
 
       - name: Upload iOS universal libwallet artifacts
         uses: actions/upload-artifact@v3
@@ -221,13 +258,31 @@ jobs:
         shell: bash
         working-directory: libwallets
         run: |
-          ls -alht
+          ls -alhtR
           mkdir libwallet-ios-universal-sim
           lipo -create \
             "libwallet-ios-x86_64/libtari_wallet_ffi.ios_x86_64.a" \
             "libwallet-ios-aarch64-sim/libtari_wallet_ffi.ios_aarch64-sim.a" \
               -output "libwallet-ios-universal-sim/libtari_wallet_ffi.ios_universal-sim.a"
           mkdir libwallet-ios-xcframework
+          echo "Check for changelog"
+          if [ -f libwallet-ios-x86_64/changelog-*.md ]; then
+            echo "Changelog found"
+            envChangelogFull=$(ls libwallet-ios-x86_64/changelog-*.md)
+            echo ${envChangelogFull}
+            # Strip suffix
+            #envChangelog=${envChangelogFull::-3}
+            envChangelog=${envChangelogFull:0:${#envChangelogFull}-3}
+            echo ${envChangelog}
+            # Strip prefix
+            TARI_NETWORK_CHANGELOG=${envChangelog##*/changelog-}
+            echo ${TARI_NETWORK_CHANGELOG}
+            cp -v "libwallet-ios-x86_64/changelog-${TARI_NETWORK_CHANGELOG}.md" libwallet-ios-xcframework/
+            TARI_NETWORK_CHANGELOG_FILE=libwallet-ios-xcframework/changelog-${TARI_NETWORK_CHANGELOG}.md
+            echo ${TARI_NETWORK_CHANGELOG_FILE}
+          else
+            echo "No changelog found"
+          fi
           xcodebuild -create-xcframework \
             -library "libwallet-ios-universal-sim/libtari_wallet_ffi.ios_universal-sim.a" \
               -headers "libwallet-ios-x86_64/libtari_wallet_ffi.h" \
@@ -240,8 +295,9 @@ jobs:
             "libwallet-ios-xcframework/libtari_wallet_ffi_ios.xcframework/ios-arm64/libtari_wallet_ffi.ios_aarch64.a" \
             "libwallet-ios-xcframework/libtari_wallet_ffi_ios.xcframework/ios-arm64_x86_64-simulator/Headers" \
             "libwallet-ios-xcframework/libtari_wallet_ffi_ios.xcframework/ios-arm64_x86_64-simulator/libtari_wallet_ffi.ios_universal-sim.a" \
+            "${TARI_NETWORK_CHANGELOG_FILE}" \
               > "libwallet-ios-xcframework/libtari_wallet_ffi.ios_xcframework.sha256sums"
-          ls -alht
+          ls -alhtR
 
       - name: Upload iOS xcframework libwallet artifacts
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
Description
Add back changelog per multiNet for libwallet

How Has This Been Tested?
Built in local fork for untagged and tagged release. 

What process can a PR reviewer use to test or verify this change?
Check assists for changelog-network.md
