### PR TITLE
fix: zeroize openings, expose EncryptedData inner arrays

### DIFF
--- a/base_layer/core/src/transactions/transaction_components/encrypted_data.rs
+++ b/base_layer/core/src/transactions/transaction_components/encrypted_data.rs
@@ -167,6 +167,11 @@ impl EncryptedData {
         bytes
     }
 
+    /// Return a copy of the inner data arrays
+    pub fn to_inner_arrays(&self) -> ([u8; BORSH_64], [u8; BORSH_X]) {
+        (self.data_1, self.data_2)
+    }
+
     /// Accessor method for the encrypted data hex display
     pub fn hex_display(&self, full: bool) -> String {
         if full {

--- a/base_layer/core/src/transactions/transaction_components/encrypted_data.rs
+++ b/base_layer/core/src/transactions/transaction_components/encrypted_data.rs
@@ -39,7 +39,7 @@ use digest::{generic_array::GenericArray, FixedOutput};
 use rand::{rngs::OsRng, RngCore};
 use serde::{Deserialize, Serialize};
 use tari_common_types::types::{Commitment, PrivateKey};
-use tari_crypto::{hash::blake2::Blake256, hashing::DomainSeparatedHasher};
+use tari_crypto::{hash::blake2::Blake256, hashing::DomainSeparatedHasher, keys::SecretKey};
 use tari_utilities::{
     hex::{from_hex, to_hex, Hex, HexError},
     safe_array::SafeArray,
@@ -84,8 +84,9 @@ impl EncryptedData {
         value: MicroTari,
         mask: &PrivateKey,
     ) -> Result<EncryptedData, EncryptedDataError> {
-        let mut openings = value.as_u64().to_le_bytes().to_vec();
-        openings.append(&mut mask.to_vec());
+        let mut openings = Vec::with_capacity(size_of::<u64>() + PrivateKey::key_length());
+        openings.extend(value.as_u64().to_le_bytes());
+        openings.extend(mask.as_bytes());
         let aead_payload = Payload {
             msg: openings.as_slice(),
             aad: Self::TAG,

--- a/base_layer/core/src/transactions/transaction_components/encrypted_data.rs
+++ b/base_layer/core/src/transactions/transaction_components/encrypted_data.rs
@@ -99,6 +99,10 @@ impl EncryptedData {
         let aead_key = kdf_aead(encryption_key, commitment);
         let cipher = XChaCha20Poly1305::new(GenericArray::from_slice(aead_key.reveal()));
         let mut ciphertext = cipher.encrypt(nonce_ga, aead_payload)?;
+
+        // Openings contains the mask so we need to zeroize it
+        openings.zeroize();
+
         let mut ciphertext_integral_nonce = nonce.to_vec();
         ciphertext_integral_nonce.append(&mut ciphertext);
 


### PR DESCRIPTION
Description
---
Zeriozes `openings` before returning from `EncryptedData::encrypt_data`
Adds `EncryptedData::to_inner_arrays() -> ([u8; 64], [u8; 16])`
Reduced heap allocations (up to 3 removed)

Motivation and Context
---
Openings contain the mask so must be zeroized.

For claim burn in the DAN repo (and potentially in general), we want to extract the inner arrays without a heap allocation or byte mangling.

How Has This Been Tested?
---
N/A

What process can a PR reviewer use to test or verify this change?
---
N/A
<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
