### PR TITLE
ci(fix): improve release assets listing for daig-utils

### DIFF
--- a/.github/workflows/base_node_binaries.yml
+++ b/.github/workflows/base_node_binaries.yml
@@ -323,6 +323,13 @@ jobs:
             echo -e "\nStapling package...${{ env.TBN_FILENAME }}-${{ matrix.builds.name }}-${{ env.VERSION }}.pkg\n"
             xcrun stapler staple -v "${distDirPKG}/${{ env.TBN_FILENAME }}-${{ matrix.builds.name }}-${{ env.VERSION }}.pkg"
           fi
+          cd ${distDirPKG}
+          echo "Compute pkg shasum"
+          ${SHARUN} "${{ env.TBN_FILENAME }}-${{ matrix.builds.name }}-${{ env.VERSION }}.pkg" \
+            >> "${{ env.TBN_FILENAME }}-${{ matrix.builds.name }}-${{ env.VERSION }}.pkg.sha256"
+          cat "${{ env.TBN_FILENAME }}-${{ matrix.builds.name }}-${{ env.VERSION }}.pkg.sha256"
+          echo "Checksum verification for pkg is "
+          ${SHARUN} --check "${{ env.TBN_FILENAME }}-${{ matrix.builds.name }}-${{ env.VERSION }}.pkg.sha256"
 
       - name: Artifact upload for macOS pkg
         if: startsWith(runner.os,'macOS')
@@ -330,7 +337,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: ${{ env.TBN_FILENAME }}-${{ matrix.builds.name }}-${{ env.VERSION }}.pkg
-          path: "${{ env.distDirPKG }}/${{ env.TBN_FILENAME }}-${{ matrix.builds.name }}-${{ env.VERSION }}*.pkg"
+          path: "${{ env.distDirPKG }}/${{ env.TBN_FILENAME }}-${{ matrix.builds.name }}-${{ env.VERSION }}*.pkg*"
 
       # unlike inno script studio, iscc.exe doesn't run the [precompile] step generate_config.bat
       - name: Build the Windows installer
@@ -353,19 +360,17 @@ jobs:
         run: |
           echo "Archive ${{ env.BINFILE }} too ${{ env.BINFILE }}.zip"
           cd "$GITHUB_WORKSPACE${{ env.TBN_DIST }}"
-          #zip -j "${{ env.BINFILE }}.zip" *
+          echo "Compute files shasum"
+          ${SHARUN} * >> "${{ env.BINFILE }}.sha256"
+          cat "${{ env.BINFILE }}.sha256"
+          echo "Checksum verification for files is "
+          ${SHARUN} --check "${{ env.BINFILE }}.sha256"
           7z a "${{ env.BINFILE }}.zip" *
-          echo "Compute shasum"
+          echo "Compute archive shasum"
           ${SHARUN} "${{ env.BINFILE }}.zip" >> "${{ env.BINFILE }}.zip.sha256"
           cat "${{ env.BINFILE }}.zip.sha256"
-          echo "Verifications is "
+          echo "Checkum verification archive is "
           ${SHARUN} --check "${{ env.BINFILE }}.zip.sha256"
-          if [ -f "${{ env.distDirPKG }}/${{ env.TBN_FILENAME }}-${{ matrix.builds.name }}-${{ env.VERSION }}.pkg" ]; then
-            echo "Add PKG to $GITHUB_WORKSPACE${{ env.TBN_DIST }} "
-            cp -v "${{ env.distDirPKG }}/${{ env.TBN_FILENAME }}-${{ matrix.builds.name }}-${{ env.VERSION }}.pkg" "$GITHUB_WORKSPACE${{ env.TBN_DIST }}"
-            ${SHARUN} "${{ env.TBN_FILENAME }}-${{ matrix.builds.name }}-${{ env.VERSION }}.pkg" >> "${{ env.TBN_FILENAME }}-${{ matrix.builds.name }}-${{ env.VERSION }}.pkg.sha256"
-            ${SHARUN} --check "${{ env.TBN_FILENAME }}-${{ matrix.builds.name }}-${{ env.VERSION }}.pkg.sha256"
-          fi
 
       - name: Artifact upload for Archive
         uses: actions/upload-artifact@v3
@@ -379,8 +384,12 @@ jobs:
           cd "${{ github.workspace }}${{ env.TBN_DIST }}"
           cp -v "tari_miner${{ env.TBN_EXT}}" \
             "tari_miner-${{ matrix.builds.name }}${{ env.TBN_EXT}}"
+          echo "Compute miner shasum"
           ${SHARUN} "tari_miner-${{ matrix.builds.name }}${{ env.TBN_EXT}}" \
             >> "tari_miner-${{ matrix.builds.name }}${{ env.TBN_EXT}}.sha256"
+          cat "tari_miner-${{ matrix.builds.name }}${{ env.TBN_EXT}}.sha256"
+          echo "Checksum verification for miner is "
+          ${SHARUN} --check "tari_miner-${{ matrix.builds.name }}${{ env.TBN_EXT}}.sha256"
 
       - name: Artifact upload for Miner
         uses: actions/upload-artifact@v3
@@ -388,7 +397,7 @@ jobs:
           name: tari_miner-${{ matrix.builds.name }}
           path: "${{ github.workspace }}${{ env.TBN_DIST }}/tari_miner-${{ matrix.builds.name }}${{ env.TBN_EXT}}*"
 
-      - name: Prep diag-utils for upload
+      - name: Prep diag-utils archive for upload
         continue-on-error: true
         shell: bash
         run: |
@@ -397,15 +406,26 @@ jobs:
           # Find RandomX built tools for testing
           find "$GITHUB_WORKSPACE/target/${{ matrix.builds.target }}/release/" \
             -name "randomx-*${{ env.TBN_EXT}}" -type f -perm -+x -exec cp -v {} . \;
+          echo "Compute diag utils shasum"
           ${SHARUN} * \
             >> "${{ env.TBN_FILENAME }}_archive-diag-utils-${{ matrix.builds.name }}.sha256"
+          cat "${{ env.TBN_FILENAME }}_archive-diag-utils-${{ matrix.builds.name }}.sha256"
+          echo "Checksum verification for diag utils is "
+          ${SHARUN} --check "${{ env.TBN_FILENAME }}_archive-diag-utils-${{ matrix.builds.name }}.sha256"
+          7z a "${{ env.TBN_FILENAME }}_archive-diag-utils-${{ matrix.builds.name }}.zip" *
+          echo "Compute diag utils archive shasum"
+          ${SHARUN} "${{ env.TBN_FILENAME }}_archive-diag-utils-${{ matrix.builds.name }}.zip" \
+            >> "${{ env.TBN_FILENAME }}_archive-diag-utils-${{ matrix.builds.name }}.zip.sha256"
+          cat "${{ env.TBN_FILENAME }}_archive-diag-utils-${{ matrix.builds.name }}.zip.sha256"
+          echo "Checksum verification for diag utils archive is "
+          ${SHARUN} --check "${{ env.TBN_FILENAME }}_archive-diag-utils-${{ matrix.builds.name }}.zip.sha256"
 
       - name: Artifact upload for diag-utils
         continue-on-error: true
         uses: actions/upload-artifact@v3
         with:
           name: ${{ env.TBN_FILENAME }}_archive-diag-utils-${{ matrix.builds.name }}
-          path: "${{ github.workspace }}${{ env.TBN_DIST }}/diag-utils/*"
+          path: "${{ github.workspace }}${{ env.TBN_DIST }}/diag-utils/*.zip*"
 
       - name: Sync dist to S3 - Bash
         continue-on-error: true # Don't break if s3 upload fails


### PR DESCRIPTION
Description
move diag-utils into an archive
verify chechsums in workflow with debugging
move pkg checksum to OSX workflow

Motivation and Context
Current release only lists last diag-utils, not for all platforms (fix)

How Has This Been Tested?
Built in local fork for development and tagged release for each multiNet

What process can a PR reviewer use to test or verify this change?
Checksum and archive assets for platforms

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
