### PR TITLE
feat: encrypted data cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5675,9 +5675,9 @@ dependencies = [
 
 [[package]]
 name = "tari_crypto"
-version = "0.16.12"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a8a3646b9897a87275a408c57b87685108a35773252eb444a30b56be98744f2"
+checksum = "8e45195ef6357eb040b4053876f942eacf7fb58dd33735284876a3d24b2d1d72"
 dependencies = [
  "base64 0.10.1",
  "blake2 0.9.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,6 +25,7 @@ checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
  "crypto-common",
  "generic-array",
+ "heapless",
 ]
 
 [[package]]
@@ -233,6 +234,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.18",
+]
+
+[[package]]
+name = "atomic-polyfill"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ff7eb3f316534d83a8a2c3d1674ace8a5a71198eba31e2e2b597833f699b28"
+dependencies = [
+ "critical-section",
 ]
 
 [[package]]
@@ -1226,6 +1236,12 @@ dependencies = [
  "cast 0.3.0",
  "itertools 0.10.5",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6548a0ad5d2549e111e1f6a11a6c2e2d00ce6a3dafe22948d67c2b443f775e52"
 
 [[package]]
 name = "croaring"
@@ -2347,6 +2363,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2400,6 +2425,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
 dependencies = [
  "http",
+]
+
+[[package]]
+name = "heapless"
+version = "0.7.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db04bc24a18b9ea980628ecf00e6c0264f3c1426dac36c00cb49b6fbad8b0743"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version",
+ "spin 0.9.8",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -2804,7 +2842,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 dependencies = [
- "spin",
+ "spin 0.5.2",
 ]
 
 [[package]]
@@ -4397,7 +4435,7 @@ dependencies = [
  "cc",
  "libc",
  "once_cell",
- "spin",
+ "spin 0.5.2",
  "untrusted",
  "web-sys",
  "winapi",
@@ -4974,6 +5012,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "spki"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4982,6 +5029,12 @@ dependencies = [
  "base64ct",
  "der",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "stack-buf"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,6 @@ checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
  "crypto-common",
  "generic-array",
- "heapless",
 ]
 
 [[package]]
@@ -234,15 +233,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.18",
-]
-
-[[package]]
-name = "atomic-polyfill"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ff7eb3f316534d83a8a2c3d1674ace8a5a71198eba31e2e2b597833f699b28"
-dependencies = [
- "critical-section",
 ]
 
 [[package]]
@@ -1236,12 +1226,6 @@ dependencies = [
  "cast 0.3.0",
  "itertools 0.10.5",
 ]
-
-[[package]]
-name = "critical-section"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6548a0ad5d2549e111e1f6a11a6c2e2d00ce6a3dafe22948d67c2b443f775e52"
 
 [[package]]
 name = "croaring"
@@ -2363,15 +2347,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
-name = "hash32"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2425,19 +2400,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
 dependencies = [
  "http",
-]
-
-[[package]]
-name = "heapless"
-version = "0.7.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db04bc24a18b9ea980628ecf00e6c0264f3c1426dac36c00cb49b6fbad8b0743"
-dependencies = [
- "atomic-polyfill",
- "hash32",
- "rustc_version",
- "spin 0.9.8",
- "stable_deref_trait",
 ]
 
 [[package]]
@@ -2842,7 +2804,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 dependencies = [
- "spin 0.5.2",
+ "spin",
 ]
 
 [[package]]
@@ -4435,7 +4397,7 @@ dependencies = [
  "cc",
  "libc",
  "once_cell",
- "spin 0.5.2",
+ "spin",
  "untrusted",
  "web-sys",
  "winapi",
@@ -5012,15 +4974,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
-]
-
-[[package]]
 name = "spki"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5029,12 +4982,6 @@ dependencies = [
  "base64ct",
  "der",
 ]
-
-[[package]]
-name = "stable_deref_trait"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "stack-buf"

--- a/applications/tari_app_grpc/Cargo.toml
+++ b/applications/tari_app_grpc/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 tari_common_types = {  path = "../../base_layer/common_types" }
 tari_comms = { path = "../../comms/core" }
 tari_core = { path = "../../base_layer/core" }
-tari_crypto = { version = "0.16"}
+tari_crypto = { version = "0.17" }
 tari_script = { path = "../../infrastructure/tari_script" }
 tari_utilities = { version = "0.4.10"}
 

--- a/applications/tari_base_node/Cargo.toml
+++ b/applications/tari_base_node/Cargo.toml
@@ -15,7 +15,7 @@ tari_comms = { path = "../../comms/core", features = ["rpc"] }
 tari_common_types = { path = "../../base_layer/common_types" }
 tari_comms_dht = { path = "../../comms/dht" }
 tari_core = { path = "../../base_layer/core", default-features = false, features = ["transactions"] }
-tari_crypto = { version = "0.16"}
+tari_crypto = { version = "0.17" }
 tari_libtor = { path = "../../infrastructure/libtor", optional = true }
 tari_p2p = { path = "../../base_layer/p2p", features = ["auto-update"] }
 tari_storage = {path="../../infrastructure/storage"}

--- a/applications/tari_console_wallet/Cargo.toml
+++ b/applications/tari_console_wallet/Cargo.toml
@@ -13,7 +13,7 @@ tari_common_types = { path = "../../base_layer/common_types" }
 tari_comms = { path = "../../comms/core" }
 tari_comms_dht = { path = "../../comms/dht" }
 tari_contacts = { path = "../../base_layer/contacts" }
-tari_crypto = { version = "0.16"}
+tari_crypto = { version = "0.17" }
 tari_key_manager = { path = "../../base_layer/key_manager" }
 tari_libtor = { path = "../../infrastructure/libtor", optional = true }
 tari_p2p = { path = "../../base_layer/p2p", features = ["auto-update"] }

--- a/applications/tari_miner/Cargo.toml
+++ b/applications/tari_miner/Cargo.toml
@@ -14,7 +14,7 @@ tari_common_types = { path = "../../base_layer/common_types" }
 tari_comms = { path = "../../comms/core" }
 tari_app_utilities = { path = "../tari_app_utilities" }
 tari_app_grpc = { path = "../tari_app_grpc" }
-tari_crypto = { version = "0.16"}
+tari_crypto = { version = "0.17" }
 tari_utilities = "0.4.10"
 
 borsh = "0.9.3"

--- a/base_layer/common_types/Cargo.toml
+++ b/base_layer/common_types/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.51.0-pre.1"
 edition = "2018"
 
 [dependencies]
-tari_crypto = { version = "0.16"}
+tari_crypto = { version = "0.17" }
 tari_utilities = "0.4.10"
 # TODO: remove this dependency and move Network into tari_common_types
 tari_common = {  path = "../../common" }

--- a/base_layer/contacts/Cargo.toml
+++ b/base_layer/contacts/Cargo.toml
@@ -12,7 +12,7 @@ tari_common_sqlite = { path = "../../common_sqlite" }
 tari_common_types = {  path = "../../base_layer/common_types" }
 tari_comms = {  path = "../../comms/core" }
 tari_comms_dht = { path = "../../comms/dht" }
-tari_crypto = { version = "0.16"}
+tari_crypto = { version = "0.17" }
 tari_p2p = {  path = "../p2p", features = ["auto-update"] }
 tari_service_framework = {  path = "../service_framework" }
 tari_shutdown = {  path = "../../infrastructure/shutdown" }

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -24,7 +24,7 @@ tari_common_types = {  path = "../../base_layer/common_types" }
 tari_comms = {  path = "../../comms/core" }
 tari_comms_dht = {  path = "../../comms/dht" }
 tari_comms_rpc_macros = {  path = "../../comms/rpc_macros" }
-tari_crypto = { version = "0.16", features = ["borsh"] }
+tari_crypto = { version = "0.17", features = ["borsh"] }
 tari_metrics = { path = "../../infrastructure/metrics" }
 tari_mmr = {  path = "../../base_layer/mmr", optional = true, features = ["native_bitmap"] }
 tari_p2p = {  path = "../../base_layer/p2p" }
@@ -38,7 +38,7 @@ tari_utilities = { version="0.4.10", features = ["borsh"] }
 bincode = "1.1.4"
 bitflags = "1.0.4"
 blake2 = "^0.9.0"
-borsh = "0.9.3"
+borsh = { version = "0.9.3", features = ["const-generics"] }
 bytes = "0.5"
 chacha20poly1305 = "0.10.1"
 chrono = { version = "0.4.19", default-features = false, features = ["serde"] }

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -40,7 +40,7 @@ bitflags = "1.0.4"
 blake2 = "^0.9.0"
 borsh = "0.9.3"
 bytes = "0.5"
-chacha20poly1305 = "0.10.1"
+chacha20poly1305 = { version = "0.10.1", features = ["heapless"] }
 chrono = { version = "0.4.19", default-features = false, features = ["serde"] }
 criterion = { version = "0.4.0", optional = true  }
 croaring = { version = "0.5.2", optional = true }

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -40,7 +40,7 @@ bitflags = "1.0.4"
 blake2 = "^0.9.0"
 borsh = "0.9.3"
 bytes = "0.5"
-chacha20poly1305 = { version = "0.10.1", features = ["heapless"] }
+chacha20poly1305 = "0.10.1"
 chrono = { version = "0.4.19", default-features = false, features = ["serde"] }
 criterion = { version = "0.4.0", optional = true  }
 croaring = { version = "0.5.2", optional = true }

--- a/base_layer/core/src/transactions/transaction_components/encrypted_data.rs
+++ b/base_layer/core/src/transactions/transaction_components/encrypted_data.rs
@@ -105,7 +105,7 @@ impl EncryptedData {
         data[SIZE_NONCE..SIZE_NONCE + SIZE_VALUE + SIZE_MASK].clone_from_slice(bytes.as_slice());
         data[SIZE_NONCE + SIZE_VALUE + SIZE_MASK..].clone_from_slice(&tag);
 
-        EncryptedData::from_bytes(data.as_slice())
+        Ok(Self { data })
     }
 
     /// Authenticate and decrypt the value and mask
@@ -173,7 +173,7 @@ impl EncryptedData {
             self.to_hex()
         } else {
             let encrypted_data_hex = self.to_hex();
-            if encrypted_data_hex.len() > DISPLAY_CUTOFF {
+            if encrypted_data_hex.len() > 2 * DISPLAY_CUTOFF {
                 format!(
                     "Some({}..{})",
                     &encrypted_data_hex[0..DISPLAY_CUTOFF],

--- a/base_layer/key_manager/Cargo.toml
+++ b/base_layer/key_manager/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["lib", "cdylib"]
 
 # NB: All dependencies must support or be gated for the WASM target.
 [dependencies]
-tari_crypto = {version = "0.16"}
+tari_crypto = { version = "0.17" }
 tari_utilities = "0.4.10"
 tari_common_sqlite = { path = "../../common_sqlite" }
 tari_common_types = {  path = "../../base_layer/common_types"}

--- a/base_layer/mmr/Cargo.toml
+++ b/base_layer/mmr/Cargo.toml
@@ -14,7 +14,7 @@ benches = ["criterion"]
 
 [dependencies]
 tari_utilities = "0.4"
-tari_crypto = { version = "0.16" }
+tari_crypto = { version = "0.17" }
 tari_common = { path = "../../common" }
 thiserror = "1.0"
 borsh = "0.9"

--- a/base_layer/p2p/Cargo.toml
+++ b/base_layer/p2p/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 tari_comms = {  path = "../../comms/core" }
 tari_comms_dht = {  path = "../../comms/dht" }
 tari_common = {  path = "../../common" }
-tari_crypto = { version = "0.16"}
+tari_crypto = { version = "0.17" }
 tari_service_framework = {  path = "../service_framework" }
 tari_shutdown = {  path = "../../infrastructure/shutdown" }
 tari_storage = {  path = "../../infrastructure/storage" }

--- a/base_layer/tari_mining_helper_ffi/Cargo.toml
+++ b/base_layer/tari_mining_helper_ffi/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 tari_comms = {  path = "../../comms/core" }
-tari_crypto = { version = "0.16"}
+tari_crypto = { version = "0.17" }
 tari_common = {  path = "../../common" }
 tari_core = {  path = "../core", default-features = false, features = ["transactions"]}
 tari_utilities = "0.4.10"

--- a/base_layer/wallet/Cargo.toml
+++ b/base_layer/wallet/Cargo.toml
@@ -12,7 +12,7 @@ tari_common = { path = "../../common" }
 tari_common_types = {  path = "../../base_layer/common_types" }
 tari_comms = {  path = "../../comms/core" }
 tari_comms_dht = {  path = "../../comms/dht" }
-tari_crypto = { version = "0.16"}
+tari_crypto = { version = "0.17" }
 tari_key_manager = {  path = "../key_manager", features = ["key_manager_service"] }
 tari_p2p = {  path = "../p2p", features = ["auto-update"] }
 tari_script = { path = "../../infrastructure/tari_script" }

--- a/base_layer/wallet_ffi/Cargo.toml
+++ b/base_layer/wallet_ffi/Cargo.toml
@@ -12,7 +12,7 @@ tari_common = { path="../../common" }
 tari_common_types = { path="../common_types" }
 tari_comms = {  path = "../../comms/core", features = ["c_integration"]}
 tari_comms_dht = {  path = "../../comms/dht", default-features = false }
-tari_crypto = { version = "0.16"}
+tari_crypto = { version = "0.17" }
 tari_key_manager = {  path = "../key_manager" }
 tari_p2p = {  path = "../p2p" }
 tari_script = { path = "../../infrastructure/tari_script" }

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -76,10 +76,6 @@ struct Covenant;
 
 struct EmojiSet;
 
-/**
- * Encrypted data for the extended-nonce variant XChaCha20-Poly1305 encryption
- * Borsh schema only accept array sizes 0 - 32, 64, 65, 128, 256, 512, 1024 and 2048
- */
 struct EncryptedData;
 
 struct FeePerGramStat;

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -14,7 +14,7 @@ build = ["toml", "prost-build"]
 static-application-info = ["git2"]
 
 [dependencies]
-tari_crypto = { version = "0.16"}
+tari_crypto = { version = "0.17" }
 
 anyhow = "1.0.53"
 blake2 = "0.9.1"

--- a/comms/core/Cargo.toml
+++ b/comms/core/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.51.0-pre.1"
 edition = "2018"
 
 [dependencies]
-tari_crypto = { version = "0.16"}
+tari_crypto = { version = "0.17" }
 tari_metrics = { path = "../../infrastructure/metrics" }
 tari_storage = {  path = "../../infrastructure/storage" }
 tari_shutdown = {  path = "../../infrastructure/shutdown" }

--- a/comms/dht/Cargo.toml
+++ b/comms/dht/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 tari_comms = {  path = "../core", features = ["rpc"] }
 tari_common = { path = "../../common" }
 tari_comms_rpc_macros = {  path = "../rpc_macros" }
-tari_crypto = { version = "0.16.2"}
+tari_crypto = { version = "0.17" }
 tari_utilities = "0.4.10"
 tari_shutdown = {  path = "../../infrastructure/shutdown" }
 tari_storage = {  path = "../../infrastructure/storage" }

--- a/infrastructure/tari_script/Cargo.toml
+++ b/infrastructure/tari_script/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 license = "BSD-3-Clause"
 
 [dependencies]
-tari_crypto = { version = "0.16"}
+tari_crypto = { version = "0.17" }
 tari_utilities = "0.4.10"
 
 blake2 = "0.9"

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -13,7 +13,7 @@ tari_base_node = { path = "../applications/tari_base_node" }
 tari_base_node_grpc_client = { path = "../clients/rust/base_node_grpc_client" }
 tari_chat_client = { path = "../base_layer/contacts/examples/chat_client" }
 tari_chat_ffi = { path = "../base_layer/chat_ffi" }
-tari_crypto = "0.16"
+tari_crypto = { version = "0.17" }
 tari_common = { path = "../common" }
 tari_common_types = { path = "../base_layer/common_types" }
 tari_comms = { path = "../comms/core" }


### PR DESCRIPTION
Description
---
Cleans up and improves `EncryptedData` for simpler operations. Supersedes [PR 5433](https://github.com/tari-project/tari/pull/5433).

Motivation and Context
---
A pending PR updates `EncryptedData` to zeroize the plaintext commitment mask and expose the data as a tuple of byte arrays. However, there are more improvements and simplifications we can make.

This PR does several things:
- Uses the `const-generics` feature in `borsh` to allow for the use of a single byte array to represent the entire `EncryptedData` struct
- Performs zeroizing of the plaintext mask during encryption and decryption
- Uses the work in [another PR](https://github.com/tari-project/tari-crypto/pull/181) to get the byte-encoded length of the mask at compile time (instead of relying on a brittle use of `size_of` that isn't guaranteed to hold)
- Removes heap allocations during encryption and decryption
- Provides `as_bytes` to expose the `EncryptedData` as a byte slice
- Provides `to_bytes` to expose the `EncryptedData` as a byte array
- Cleans up comments and naming for clarity
- Updates faucet output JSON encoding to account for the changes (this does not affect genesis block data otherwise)

How Has This Been Tested?
---
Existing tests pass.

What process can a PR reviewer use to test or verify this change?
---
Confirm that existing tests pass, and that the listed features are implemented correctly.

Breaking Changes
---
There are no breaking changes. The existing `EncryptedData` API is unchanged.