### PR TITLE
fix: use mined at timestamp in fauxconfirmation

### DIFF
--- a/base_layer/wallet/src/transaction_service/tasks/check_faux_transaction_status.rs
+++ b/base_layer/wallet/src/transaction_service/tasks/check_faux_transaction_status.rs
@@ -138,7 +138,8 @@ pub async fn check_faux_transactions<TBackend: 'static + TransactionBackend>(
                 tx.tx_id,
                 mined_height,
                 mined_in_block,
-                0,
+                tx.mined_timestamp
+                    .map_or(0, |mined_timestamp| mined_timestamp.timestamp() as u64),
                 num_confirmations,
                 is_confirmed,
                 is_valid,


### PR DESCRIPTION
Description
---
We were passing 0 every time when we should have been using the mined at timestamp.

Motivation and Context
---
Once unconfirmed one sided transactions had been confirmed we were dropping the proper mined at timestamp.

How Has This Been Tested?
---
Locally with one sided, and one sided stealth transactions between local wallets on igor.

What process can a PR reviewer use to test or verify this change?
---
Receive a one sided TX, and validate the mined at timestamp is present once confirmed.

Closes: #5167

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
