### PR TITLE
feat: peer sync limiter

### DIFF
--- a/applications/tari_base_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/tari_base_node/src/grpc/base_node_grpc_server.rs
@@ -810,7 +810,7 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
         let peers = self
             .comms
             .peer_manager()
-            .discovery_syncing()
+            .all()
             .await
             .map_err(|e| obscure_error_if_true(report_error_flag, Status::internal(e.to_string())))?;
         let peers: Vec<tari_rpc::Peer> = peers.into_iter().map(|p| p.into()).collect();

--- a/applications/tari_base_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/tari_base_node/src/grpc/base_node_grpc_server.rs
@@ -810,7 +810,7 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
         let peers = self
             .comms
             .peer_manager()
-            .all()
+            .discovery_syncing()
             .await
             .map_err(|e| obscure_error_if_true(report_error_flag, Status::internal(e.to_string())))?;
         let peers: Vec<tari_rpc::Peer> = peers.into_iter().map(|p| p.into()).collect();

--- a/comms/core/src/peer_manager/manager.rs
+++ b/comms/core/src/peer_manager/manager.rs
@@ -141,8 +141,16 @@ impl PeerManager {
     ///  - Peer has been seen within a defined time span (1 week)
     ///  - Only returns a maximum number of syncable peers (corresponds with the max possible number of requestable
     ///    peers to sync)
-    pub async fn discovery_syncing(&self) -> Result<Vec<Peer>, PeerManagerError> {
-        self.peer_storage.read().await.discovery_syncing()
+    pub async fn discovery_syncing(
+        &self,
+        n: usize,
+        excluded_peers: &[NodeId],
+        features: Option<PeerFeatures>,
+    ) -> Result<Vec<Peer>, PeerManagerError> {
+        self.peer_storage
+            .read()
+            .await
+            .discovery_syncing(n, excluded_peers, features)
     }
 
     /// Adds or updates a peer and sets the last connection as successful.
@@ -357,7 +365,9 @@ impl fmt::Debug for PeerManager {
 
 #[cfg(test)]
 mod test {
-    use rand::rngs::OsRng;
+    use std::borrow::BorrowMut;
+
+    use rand::{rngs::OsRng, Rng};
     use tari_crypto::{keys::PublicKey, ristretto::RistrettoPublicKey};
     use tari_storage::HashmapDatabase;
 
@@ -374,10 +384,22 @@ mod test {
     fn create_test_peer(ban_flag: bool, features: PeerFeatures) -> Peer {
         let (_sk, pk) = RistrettoPublicKey::random_keypair(&mut OsRng);
         let node_id = NodeId::from_key(&pk);
-        let net_addresses = MultiaddressesWithStats::from_addresses_with_source(
-            vec!["/ip4/1.2.3.4/tcp/8000".parse::<Multiaddr>().unwrap()],
-            &PeerAddressSource::Config,
-        );
+        let mut net_addresses = MultiaddressesWithStats::from_addresses_with_source(vec![], &PeerAddressSource::Config);
+
+        // Create 1 to 4 random addresses
+        for _i in 1..=rand::thread_rng().gen_range(1, 4) {
+            let n = vec![
+                rand::thread_rng().gen_range(1, 9),
+                rand::thread_rng().gen_range(1, 9),
+                rand::thread_rng().gen_range(1, 9),
+                rand::thread_rng().gen_range(1, 9),
+            ];
+            let net_address = format!("/ip4/{}.{}.{}.{}/tcp/{0}{1}{2}{3}", n[0], n[1], n[2], n[3],)
+                .parse::<Multiaddr>()
+                .unwrap();
+            net_addresses.add_address(&net_address, &PeerAddressSource::Config);
+        }
+
         let mut peer = Peer::new(
             pk,
             node_id,
@@ -390,6 +412,11 @@ mod test {
         if ban_flag {
             peer.ban_for(Duration::from_secs(1000), "".to_string());
         }
+
+        let good_addresses = peer.addresses.borrow_mut();
+        let good_address = good_addresses.addresses()[0].address().clone();
+        good_addresses.mark_last_seen_now(&good_address);
+
         peer
     }
 

--- a/comms/core/src/peer_manager/manager.rs
+++ b/comms/core/src/peer_manager/manager.rs
@@ -135,6 +135,16 @@ impl PeerManager {
         self.peer_storage.read().await.all()
     }
 
+    /// Return "good" peers for syncing
+    /// Criteria:
+    ///  - Peer is not banned
+    ///  - Peer has been seen within a defined time span (1 week)
+    ///  - Only returns a maximum number of syncable peers (corresponds with the max possible number of requestable
+    ///    peers to sync)
+    pub async fn discovery_syncing(&self) -> Result<Vec<Peer>, PeerManagerError> {
+        self.peer_storage.read().await.discovery_syncing()
+    }
+
     /// Adds or updates a peer and sets the last connection as successful.
     /// If the peer is marked as offline, it will be unmarked.
     pub async fn add_or_update_online_peer(

--- a/comms/core/src/peer_manager/peer_storage.rs
+++ b/comms/core/src/peer_manager/peer_storage.rs
@@ -764,11 +764,26 @@ mod test {
 
     fn create_test_peer(features: PeerFeatures, ban: bool) -> Peer {
         let mut rng = rand::rngs::OsRng;
+
         let (_sk, pk) = RistrettoPublicKey::random_keypair(&mut rng);
         let node_id = NodeId::from_key(&pk);
-        let net_address = "/ip4/1.2.3.4/tcp/8000".parse::<Multiaddr>().unwrap();
-        let net_addresses =
-            MultiaddressesWithStats::from_addresses_with_source(vec![net_address], &PeerAddressSource::Config);
+
+        let mut net_addresses = MultiaddressesWithStats::from_addresses_with_source(vec![], &PeerAddressSource::Config);
+
+        // Create 1 to 4 random addresses
+        for _i in 1..=rand::thread_rng().gen_range(1, 4) {
+            let n = vec![
+                rand::thread_rng().gen_range(1, 9),
+                rand::thread_rng().gen_range(1, 9),
+                rand::thread_rng().gen_range(1, 9),
+                rand::thread_rng().gen_range(1, 9),
+            ];
+            let net_address = format!("/ip4/{}.{}.{}.{}/tcp/{0}{1}{2}{3}", n[0], n[1], n[2], n[3],)
+                .parse::<Multiaddr>()
+                .unwrap();
+            net_addresses.add_address(&net_address, &PeerAddressSource::Config);
+        }
+
         let mut peer = Peer::new(
             pk,
             node_id,

--- a/comms/core/src/peer_manager/peer_storage.rs
+++ b/comms/core/src/peer_manager/peer_storage.rs
@@ -43,8 +43,8 @@ use crate::{
 };
 
 const LOG_TARGET: &str = "comms::peer_manager::peer_storage";
-/// The maximum number of peers to return from the flood_identities method in peer manager
-const PEER_MANAGER_MAX_FLOOD_PEERS: usize = 1000;
+/// The maximum number of peers to return in peer manager
+const PEER_MANAGER_SYNC_PEERS: usize = 1000;
 const PEER_ACTIVE_WITHIN_DURATION: u64 = 7 * 24 * 60 * 60; // 7 days, 24h, 60m, 60s = 1 week
 
 /// PeerStorage provides a mechanism to keep a datastore and a local copy of all peers in sync and allow fast searches
@@ -300,7 +300,7 @@ where DS: KeyValueStore<PeerId, Peer>
     /// Compile a list of all known peers
     pub fn flood_peers(&self) -> Result<Vec<Peer>, PeerManagerError> {
         self.peer_db
-            .filter_take(PEER_MANAGER_MAX_FLOOD_PEERS, |(_, peer)| !peer.is_banned())
+            .filter_take(PEER_MANAGER_SYNC_PEERS, |(_, peer)| !peer.is_banned())
             .map(|pairs| pairs.into_iter().map(|(_, peer)| peer).collect())
             .map_err(PeerManagerError::DatabaseError)
     }

--- a/comms/dht/src/network_discovery/on_connect.rs
+++ b/comms/dht/src/network_discovery/on_connect.rs
@@ -41,7 +41,7 @@ use crate::{
     DhtConfig,
 };
 const LOG_TARGET: &str = "comms::dht::network_discovery:onconnect";
-const NUM_FETCH_PEERS: u32 = 1000;
+const NUM_FETCH_PEERS: u32 = 100;
 
 #[derive(Debug)]
 pub(super) struct OnConnect {

--- a/comms/dht/src/rpc/service.rs
+++ b/comms/dht/src/rpc/service.rs
@@ -24,7 +24,7 @@ use std::{cmp, sync::Arc};
 
 use log::*;
 use tari_comms::{
-    peer_manager::{NodeId, Peer, PeerFeatures, PeerQuery},
+    peer_manager::{NodeId, Peer, PeerFeatures},
     protocol::rpc::{Request, RpcError, RpcStatus, Streaming},
     utils,
     PeerManager,
@@ -151,25 +151,17 @@ impl DhtRpcService for DhtRpcServiceImpl {
 
     async fn get_peers(&self, request: Request<GetPeersRequest>) -> Result<Streaming<GetPeersResponse>, RpcStatus> {
         let message = request.message();
-        let requester_node_id = request.context().peer_node_id();
-
-        let mut query = PeerQuery::new().select_where(|peer| {
-            &peer.node_id != requester_node_id &&
-                (message.include_clients || !peer.features.is_client()) &&
-                !peer.is_banned() &&
-                peer.deleted_at.is_none()
-        });
-
-        if message.n > 0 {
-            query = query.limit(message.n as usize);
+        let excluded_peers = vec![request.context().peer_node_id().clone()];
+        let mut features = Some(PeerFeatures::COMMUNICATION_NODE);
+        if message.include_clients {
+            features = None;
         }
 
-        // This result set can/will be large
-        // Ideally, we'd need a lazy-loaded iterator, however that requires a long-lived read transaction and
-        // the lifetime of that transaction is proportional on the time it takes to send the peers.
-        // Either we should not need to return all peers, or we can find a way to do an iterator which does not
-        // require a long-lived read transaction (we don't strictly care about read consistency in this case).
-        let peers = self.peer_manager.perform_query(query).await.map_err(RpcError::from)?;
+        let peers = self
+            .peer_manager
+            .discovery_syncing(message.n as usize, &excluded_peers, features)
+            .await
+            .map_err(RpcError::from)?;
 
         let node_id = request.context().peer_node_id();
         debug!(

--- a/comms/dht/src/rpc/test.rs
+++ b/comms/dht/src/rpc/test.rs
@@ -48,6 +48,8 @@ fn setup() -> (DhtRpcServiceImpl, RpcRequestMock, Arc<PeerManager>) {
 
 // Unit tests for get_closer_peers request
 mod get_closer_peers {
+    use std::borrow::BorrowMut;
+
     use super::*;
     use crate::rpc::PeerInfo;
 
@@ -75,7 +77,12 @@ mod get_closer_peers {
         let node_identity = build_node_identity(PeerFeatures::COMMUNICATION_NODE);
         let peers = ordered_node_identities_by_distance(node_identity.node_id(), 10, PeerFeatures::COMMUNICATION_NODE);
         for peer in &peers {
-            peer_manager.add_peer(peer.to_peer()).await.unwrap();
+            let mut peer = peer.to_peer();
+            let good_addresses = peer.addresses.borrow_mut();
+            let good_address = good_addresses.addresses()[0].address().clone();
+            good_addresses.mark_last_seen_now(&good_address);
+
+            peer_manager.add_peer(peer).await.unwrap();
         }
         let req = GetCloserPeersRequest {
             n: 15,
@@ -111,7 +118,12 @@ mod get_closer_peers {
         let node_identity = build_node_identity(PeerFeatures::COMMUNICATION_NODE);
         let peers = ordered_node_identities_by_distance(node_identity.node_id(), 6, PeerFeatures::COMMUNICATION_NODE);
         for peer in &peers {
-            peer_manager.add_peer(peer.to_peer()).await.unwrap();
+            let mut peer = peer.to_peer();
+            let good_addresses = peer.addresses.borrow_mut();
+            let good_address = good_addresses.addresses()[0].address().clone();
+            good_addresses.mark_last_seen_now(&good_address);
+
+            peer_manager.add_peer(peer).await.unwrap();
         }
         let req = GetCloserPeersRequest {
             n: 5,
@@ -133,7 +145,12 @@ mod get_closer_peers {
         let node_identity = build_node_identity(PeerFeatures::COMMUNICATION_NODE);
         let peers = ordered_node_identities_by_distance(node_identity.node_id(), 5, PeerFeatures::COMMUNICATION_NODE);
         for peer in &peers {
-            peer_manager.add_peer(peer.to_peer()).await.unwrap();
+            let mut peer = peer.to_peer();
+            let good_addresses = peer.addresses.borrow_mut();
+            let good_address = good_addresses.addresses()[0].address().clone();
+            good_addresses.mark_last_seen_now(&good_address);
+
+            peer_manager.add_peer(peer).await.unwrap();
         }
         let excluded_peer = peers.last().unwrap();
         let req = GetCloserPeersRequest {
@@ -166,7 +183,7 @@ mod get_closer_peers {
 }
 
 mod get_peers {
-    use std::time::Duration;
+    use std::{borrow::BorrowMut, time::Duration};
 
     use tari_comms::test_utils::node_identity::build_many_node_identities;
 
@@ -195,10 +212,15 @@ mod get_peers {
         let nodes = build_many_node_identities(3, PeerFeatures::COMMUNICATION_NODE);
         let clients = build_many_node_identities(2, PeerFeatures::COMMUNICATION_CLIENT);
         for peer in nodes.iter().chain(clients.iter()) {
-            peer_manager.add_peer(peer.to_peer()).await.unwrap();
+            let mut peer = peer.to_peer();
+            let good_addresses = peer.addresses.borrow_mut();
+            let good_address = good_addresses.addresses()[0].address().clone();
+            good_addresses.mark_last_seen_now(&good_address);
+
+            peer_manager.add_peer(peer).await.unwrap();
         }
         let req = GetPeersRequest {
-            n: 0,
+            n: 5,
             include_clients: true,
         };
 
@@ -226,10 +248,15 @@ mod get_peers {
         let nodes = build_many_node_identities(3, PeerFeatures::COMMUNICATION_NODE);
         let clients = build_many_node_identities(2, PeerFeatures::COMMUNICATION_CLIENT);
         for peer in nodes.iter().chain(clients.iter()) {
-            peer_manager.add_peer(peer.to_peer()).await.unwrap();
+            let mut peer = peer.to_peer();
+            let good_addresses = peer.addresses.borrow_mut();
+            let good_address = good_addresses.addresses()[0].address().clone();
+            good_addresses.mark_last_seen_now(&good_address);
+
+            peer_manager.add_peer(peer).await.unwrap();
         }
         let req = GetPeersRequest {
-            n: 0,
+            n: 3,
             include_clients: false,
         };
 
@@ -257,7 +284,12 @@ mod get_peers {
         let node_identity = build_node_identity(PeerFeatures::COMMUNICATION_NODE);
         let peers = build_many_node_identities(3, PeerFeatures::COMMUNICATION_NODE);
         for peer in &peers {
-            peer_manager.add_peer(peer.to_peer()).await.unwrap();
+            let mut peer = peer.to_peer();
+            let good_addresses = peer.addresses.borrow_mut();
+            let good_address = good_addresses.addresses()[0].address().clone();
+            good_addresses.mark_last_seen_now(&good_address);
+
+            peer_manager.add_peer(peer).await.unwrap();
         }
         let req = GetPeersRequest {
             n: 2,


### PR DESCRIPTION
Description
---
This adds more criteria to the peers that get sent during a discovery, and on connect. Nodes should only send non-banned peers, who have been active within the week. They should send a max of 1000 peers per request. More discovery can occur when connecting to those new peers.

Motivation and Context
---
This helps to prevent trustworthy nodes from sharing bad peers, or junk data over the network. It limits an attack surface to a reach of 1, where a bad actor may sync 1000 max junk records to direct connections, but these connections would never propagate the junk peers forward as they'll never see them online.

How Has This Been Tested?
---
Unit test added for the filtering of peers. Untested in network enviornment

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
