### PR TITLE
ci(fix): bump actions/upload-artifact to 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,7 @@ jobs:
       - name: cargo test
         run: cargo nextest run --all-features --release -E "not package(tari_integration_tests)" --profile ci
       - name: upload artifact
-        uses: actions/upload-artifact@v2  # upload test results as artifact
+        uses: actions/upload-artifact@v3  # upload test results as artifact
         if: always()
         with:
           name: test-results

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -96,7 +96,7 @@ jobs:
             --retry 2
 
       - name: upload artifact
-        uses: actions/upload-artifact@v2  # upload test results as artifact
+        uses: actions/upload-artifact@v3  # upload test results as artifact
         if: always()
         with:
           name: junit-cucumber
@@ -165,7 +165,7 @@ jobs:
             --retry 2
 
       - name: upload artifact
-        uses: actions/upload-artifact@v2  # upload test results as artifact
+        uses: actions/upload-artifact@v3  # upload test results as artifact
         if: always()
         with:
           name: junit-ffi-cucumber


### PR DESCRIPTION
Description
bump actions/upload-artifact to 3

Motivation and Context
Removes warnings about 
```Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/upload-artifact@v2.```

How Has This Been Tested?
Run in local fork, without warning about NodeJS 16

What process can a PR reviewer use to test or verify this change?
Should be able to see the summary without the above warning for workflow 
