### PR TITLE
chore(dev): version bump to 0.50.0-pre.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5175,7 +5175,7 @@ dependencies = [
 
 [[package]]
 name = "tari_app_grpc"
-version = "0.50.0-pre.2"
+version = "0.50.0-pre.3"
 dependencies = [
  "argon2",
  "base64 0.13.1",
@@ -5199,7 +5199,7 @@ dependencies = [
 
 [[package]]
 name = "tari_app_utilities"
-version = "0.50.0-pre.2"
+version = "0.50.0-pre.3"
 dependencies = [
  "clap 3.2.25",
  "futures 0.3.28",
@@ -5218,7 +5218,7 @@ dependencies = [
 
 [[package]]
 name = "tari_base_node"
-version = "0.50.0-pre.2"
+version = "0.50.0-pre.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5315,7 +5315,7 @@ dependencies = [
 
 [[package]]
 name = "tari_chat_client"
-version = "0.50.0-pre.2"
+version = "0.50.0-pre.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5339,7 +5339,7 @@ dependencies = [
 
 [[package]]
 name = "tari_chat_ffi"
-version = "0.50.0-pre.2"
+version = "0.50.0-pre.3"
 dependencies = [
  "cbindgen 0.24.3",
  "libc",
@@ -5357,7 +5357,7 @@ dependencies = [
 
 [[package]]
 name = "tari_common"
-version = "0.50.0-pre.2"
+version = "0.50.0-pre.3"
 dependencies = [
  "anyhow",
  "blake2 0.9.2",
@@ -5384,7 +5384,7 @@ dependencies = [
 
 [[package]]
 name = "tari_common_sqlite"
-version = "0.50.0-pre.2"
+version = "0.50.0-pre.3"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -5398,7 +5398,7 @@ dependencies = [
 
 [[package]]
 name = "tari_common_types"
-version = "0.50.0-pre.2"
+version = "0.50.0-pre.3"
 dependencies = [
  "base64 0.21.2",
  "borsh",
@@ -5417,7 +5417,7 @@ dependencies = [
 
 [[package]]
 name = "tari_comms"
-version = "0.50.0-pre.2"
+version = "0.50.0-pre.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5467,7 +5467,7 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_dht"
-version = "0.50.0-pre.2"
+version = "0.50.0-pre.3"
 dependencies = [
  "anyhow",
  "bitflags 1.3.2",
@@ -5511,7 +5511,7 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_rpc_macros"
-version = "0.50.0-pre.2"
+version = "0.50.0-pre.3"
 dependencies = [
  "futures 0.3.28",
  "proc-macro2",
@@ -5526,7 +5526,7 @@ dependencies = [
 
 [[package]]
 name = "tari_console_wallet"
-version = "0.50.0-pre.2"
+version = "0.50.0-pre.3"
 dependencies = [
  "bitflags 1.3.2",
  "chrono",
@@ -5577,7 +5577,7 @@ dependencies = [
 
 [[package]]
 name = "tari_contacts"
-version = "0.50.0-pre.2"
+version = "0.50.0-pre.3"
 dependencies = [
  "chrono",
  "diesel",
@@ -5608,7 +5608,7 @@ dependencies = [
 
 [[package]]
 name = "tari_core"
-version = "0.50.0-pre.2"
+version = "0.50.0-pre.3"
 dependencies = [
  "bincode",
  "bitflags 1.3.2",
@@ -5705,7 +5705,7 @@ dependencies = [
 
 [[package]]
 name = "tari_features"
-version = "0.50.0-pre.2"
+version = "0.50.0-pre.3"
 
 [[package]]
 name = "tari_integration_tests"
@@ -5756,7 +5756,7 @@ dependencies = [
 
 [[package]]
 name = "tari_key_manager"
-version = "0.50.0-pre.2"
+version = "0.50.0-pre.3"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5810,7 +5810,7 @@ dependencies = [
 
 [[package]]
 name = "tari_merge_mining_proxy"
-version = "0.50.0-pre.2"
+version = "0.50.0-pre.3"
 dependencies = [
  "anyhow",
  "bincode",
@@ -5860,7 +5860,7 @@ dependencies = [
 
 [[package]]
 name = "tari_miner"
-version = "0.50.0-pre.2"
+version = "0.50.0-pre.3"
 dependencies = [
  "base64 0.13.1",
  "borsh",
@@ -5896,7 +5896,7 @@ dependencies = [
 
 [[package]]
 name = "tari_mining_helper_ffi"
-version = "0.50.0-pre.2"
+version = "0.50.0-pre.3"
 dependencies = [
  "borsh",
  "hex",
@@ -5912,7 +5912,7 @@ dependencies = [
 
 [[package]]
 name = "tari_mmr"
-version = "0.50.0-pre.2"
+version = "0.50.0-pre.3"
 dependencies = [
  "bincode",
  "blake2 0.9.2",
@@ -5932,7 +5932,7 @@ dependencies = [
 
 [[package]]
 name = "tari_p2p"
-version = "0.50.0-pre.2"
+version = "0.50.0-pre.3"
 dependencies = [
  "anyhow",
  "clap 2.34.0",
@@ -5986,7 +5986,7 @@ dependencies = [
 
 [[package]]
 name = "tari_service_framework"
-version = "0.50.0-pre.2"
+version = "0.50.0-pre.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6003,7 +6003,7 @@ dependencies = [
 
 [[package]]
 name = "tari_shutdown"
-version = "0.50.0-pre.2"
+version = "0.50.0-pre.3"
 dependencies = [
  "futures 0.3.28",
  "tokio",
@@ -6011,7 +6011,7 @@ dependencies = [
 
 [[package]]
 name = "tari_storage"
-version = "0.50.0-pre.2"
+version = "0.50.0-pre.3"
 dependencies = [
  "bincode",
  "lmdb-zero",
@@ -6024,7 +6024,7 @@ dependencies = [
 
 [[package]]
 name = "tari_test_utils"
-version = "0.50.0-pre.2"
+version = "0.50.0-pre.3"
 dependencies = [
  "futures 0.3.28",
  "futures-test",
@@ -6056,7 +6056,7 @@ dependencies = [
 
 [[package]]
 name = "tari_wallet"
-version = "0.50.0-pre.2"
+version = "0.50.0-pre.3"
 dependencies = [
  "argon2",
  "async-trait",
@@ -6106,7 +6106,7 @@ dependencies = [
 
 [[package]]
 name = "tari_wallet_ffi"
-version = "0.50.0-pre.2"
+version = "0.50.0-pre.3"
 dependencies = [
  "borsh",
  "cbindgen 0.24.3",

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The recommended running versions of each network are:
 |-----------|--------------|
 | Stagenet  | 0.48.0       |
 | Nextnet   | 0.49.0-rc.3  |
-| Esmeralda | 0.50.0-pre.2 |
+| Esmeralda | 0.50.0-pre.3 |
 
 For more detail about versioning see [Release Ideology](https://github.com/tari-project/tari/blob/development/docs/src/branching_releases.md)
 

--- a/applications/tari_app_grpc/Cargo.toml
+++ b/applications/tari_app_grpc/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "This crate is to provide a single source for all cross application grpc files and conversions to and from tari::core"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.50.0-pre.2"
+version = "0.50.0-pre.3"
 edition = "2018"
 
 [dependencies]

--- a/applications/tari_app_utilities/Cargo.toml
+++ b/applications/tari_app_utilities/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_app_utilities"
-version = "0.50.0-pre.2"
+version = "0.50.0-pre.3"
 authors = ["The Tari Development Community"]
 edition = "2018"
 license = "BSD-3-Clause"
@@ -9,7 +9,7 @@ license = "BSD-3-Clause"
 tari_common = { path = "../../common" }
 tari_common_types = { path = "../../base_layer/common_types" }
 tari_comms = { path = "../../comms/core" }
-tari_features = { version = "0.50.0-pre.2", path = "../../common/tari_features"}
+tari_features = { version = "0.50.0-pre.3", path = "../../common/tari_features"}
 tari_utilities = { version = "0.4.10"}
 
 clap = { version = "3.2.0", features = ["derive", "env"] }
@@ -23,4 +23,4 @@ thiserror = "^1.0.26"
 
 [build-dependencies]
 tari_common = { path = "../../common", features = ["build", "static-application-info"] }
-tari_features = { version = "0.50.0-pre.2", path = "../../common/tari_features"}
+tari_features = { version = "0.50.0-pre.3", path = "../../common/tari_features"}

--- a/applications/tari_base_node/Cargo.toml
+++ b/applications/tari_base_node/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "The tari full base node implementation"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.50.0-pre.2"
+version = "0.50.0-pre.3"
 edition = "2018"
 
 [dependencies]
@@ -59,7 +59,7 @@ safe = []
 libtor = ["tari_libtor"]
 
 [build-dependencies]
-tari_features = { version = "0.50.0-pre.2", path = "../../common/tari_features"}
+tari_features = { version = "0.50.0-pre.3", path = "../../common/tari_features"}
 
 [package.metadata.cargo-machete]
 ignored = [

--- a/applications/tari_console_wallet/Cargo.toml
+++ b/applications/tari_console_wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_console_wallet"
-version = "0.50.0-pre.2"
+version = "0.50.0-pre.3"
 authors = ["The Tari Development Community"]
 edition = "2018"
 license = "BSD-3-Clause"
@@ -65,7 +65,7 @@ default-features = false
 features = ["crossterm"]
 
 [build-dependencies]
-tari_features = { version = "0.50.0-pre.2", path = "../../common/tari_features"}
+tari_features = { version = "0.50.0-pre.3", path = "../../common/tari_features"}
 
 [features]
 avx2 = ["tari_core/avx2", "tari_crypto/simd_backend", "tari_wallet/avx2", "tari_comms/avx2", "tari_comms_dht/avx2", "tari_p2p/avx2", "tari_key_manager/avx2"]

--- a/applications/tari_merge_mining_proxy/Cargo.toml
+++ b/applications/tari_merge_mining_proxy/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "The Tari merge mining proxy for xmrig"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.50.0-pre.2"
+version = "0.50.0-pre.3"
 edition = "2018"
 
 [features]
@@ -42,4 +42,4 @@ tracing = "0.1"
 url = "2.1.1"
 
 [build-dependencies]
-tari_features = { version = "0.50.0-pre.2", path = "../../common/tari_features"}
+tari_features = { version = "0.50.0-pre.3", path = "../../common/tari_features"}

--- a/applications/tari_miner/Cargo.toml
+++ b/applications/tari_miner/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "The tari miner implementation"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.50.0-pre.2"
+version = "0.50.0-pre.3"
 edition = "2018"
 
 [dependencies]

--- a/base_layer/chat_ffi/Cargo.toml
+++ b/base_layer/chat_ffi/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_chat_ffi"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency chat C FFI bindings"
 license = "BSD-3-Clause"
-version = "0.50.0-pre.2"
+version = "0.50.0-pre.3"
 edition = "2018"
 
 [dependencies]

--- a/base_layer/common_types/Cargo.toml
+++ b/base_layer/common_types/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_common_types"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency common types"
 license = "BSD-3-Clause"
-version = "0.50.0-pre.2"
+version = "0.50.0-pre.3"
 edition = "2018"
 
 [dependencies]

--- a/base_layer/contacts/Cargo.toml
+++ b/base_layer/contacts/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_contacts"
 authors = ["The Tari Development Community"]
 description = "Tari contacts library"
 license = "BSD-3-Clause"
-version = "0.50.0-pre.2"
+version = "0.50.0-pre.3"
 edition = "2018"
 
 [dependencies]

--- a/base_layer/contacts/examples/chat_client/Cargo.toml
+++ b/base_layer/contacts/examples/chat_client/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_chat_client"
 authors = ["The Tari Development Community"]
 description = "Tari cucumber chat client"
 license = "BSD-3-Clause"
-version = "0.50.0-pre.2"
+version = "0.50.0-pre.3"
 
 edition = "2018"
 

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.50.0-pre.2"
+version = "0.50.0-pre.3"
 edition = "2018"
 
 [features]

--- a/base_layer/key_manager/Cargo.toml
+++ b/base_layer/key_manager/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency wallet key management"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.50.0-pre.2"
+version = "0.50.0-pre.3"
 edition = "2021"
 
 [lib]

--- a/base_layer/mmr/Cargo.toml
+++ b/base_layer/mmr/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "A Merkle Mountain Range implementation"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.50.0-pre.2"
+version = "0.50.0-pre.3"
 edition = "2018"
 
 [features]

--- a/base_layer/mmr/src/balanced_binary_merkle_proof.rs
+++ b/base_layer/mmr/src/balanced_binary_merkle_proof.rs
@@ -442,6 +442,6 @@ mod test {
             .collect::<Vec<_>>();
 
         let merged = MergedBalancedBinaryMerkleProof::create_from_proofs(&proofs).unwrap();
-        assert!(merged.verify_consume(&root, leaf_hashes.clone()).unwrap());
+        assert!(merged.verify_consume(&root, leaf_hashes).unwrap());
     }
 }

--- a/base_layer/p2p/Cargo.toml
+++ b/base_layer/p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_p2p"
-version = "0.50.0-pre.2"
+version = "0.50.0-pre.3"
 authors = ["The Tari Development community"]
 description = "Tari base layer-specific peer-to-peer communication features"
 repository = "https://github.com/tari-project/tari"

--- a/base_layer/service_framework/Cargo.toml
+++ b/base_layer/service_framework/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_service_framework"
-version = "0.50.0-pre.2"
+version = "0.50.0-pre.3"
 authors = ["The Tari Development Community"]
 description = "The Tari communication stack service framework"
 repository = "https://github.com/tari-project/tari"

--- a/base_layer/tari_mining_helper_ffi/Cargo.toml
+++ b/base_layer/tari_mining_helper_ffi/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_mining_helper_ffi"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency miningcore C FFI bindings"
 license = "BSD-3-Clause"
-version = "0.50.0-pre.2"
+version = "0.50.0-pre.3"
 edition = "2018"
 
 [dependencies]

--- a/base_layer/wallet/Cargo.toml
+++ b/base_layer/wallet/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_wallet"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency wallet library"
 license = "BSD-3-Clause"
-version = "0.50.0-pre.2"
+version = "0.50.0-pre.3"
 edition = "2018"
 
 [dependencies]

--- a/base_layer/wallet_ffi/Cargo.toml
+++ b/base_layer/wallet_ffi/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_wallet_ffi"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency wallet C FFI bindings"
 license = "BSD-3-Clause"
-version = "0.50.0-pre.2"
+version = "0.50.0-pre.3"
 edition = "2018"
 
 [dependencies]

--- a/changelog-development.md
+++ b/changelog-development.md
@@ -2,6 +2,31 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [0.50.0-pre.3](https://github.com/tari-project/tari/compare/v0.50.0-pre.2...v0.50.0-pre.3) (2023-06-09)
+
+
+### ⚠ BREAKING CHANGES
+
+* use mined at timestamp in fauxconfirmation (#5443) ([f3833c9f](https://github.com/tari-project/tari/commit/f3833c9fc46d77fddaa7a23ef1d53ba9d860182a), breaks [#](https://github.com/tari-project/tari/issues/), [#](https://github.com/tari-project/tari/issues/), [#](https://github.com/tari-project/tari/issues/))
+* fix custom wallet startup logic for console wallet (#5429) ([0c1e5765](https://github.com/tari-project/tari/commit/0c1e5765676a9281b45fd66c8846b78ea4c76125), breaks [#](https://github.com/tari-project/tari/issues/), [#](https://github.com/tari-project/tari/issues/), [#](https://github.com/tari-project/tari/issues/))
+* refactor configuration for chat so ffi can create and accept a config file (#5426) ([9d0d8b52](https://github.com/tari-project/tari/commit/9d0d8b5277bd26e79b7fe5506edcaf197ba63eb7), breaks [#](https://github.com/tari-project/tari/issues/), [#](https://github.com/tari-project/tari/issues/), [#](https://github.com/tari-project/tari/issues/))
+* **balanced_mp:**  removes some panics, adds some checks and new tests (#5432) ([602f416f](https://github.com/tari-project/tari/commit/602f416f674b5e1835a634f3c8ab123001af600e), breaks [#](https://github.com/tari-project/tari/issues/), [#](https://github.com/tari-project/tari/issues/), [#](https://github.com/tari-project/tari/issues/))
+* **comms:**  validate onion3 checksum (#5440) ([0dfdb3a4](https://github.com/tari-project/tari/commit/0dfdb3a4bef51952f0cecf6f6fcb00f6b2bfe302), breaks [#](https://github.com/tari-project/tari/issues/), [#](https://github.com/tari-project/tari/issues/), [#](https://github.com/tari-project/tari/issues/))
+* **wallet-ffi:**  don't block on start (#5437) ([27fe8d9d](https://github.com/tari-project/tari/commit/27fe8d9d2fc3ea6468605ef5edea56efdcc8248f), breaks [#](https://github.com/tari-project/tari/issues/), [#](https://github.com/tari-project/tari/issues/), [#](https://github.com/tari-project/tari/issues/))
+
+#### Features
+
+* refactor configuration for chat so ffi can create and accept a config file (#5426) ([9d0d8b52](https://github.com/tari-project/tari/commit/9d0d8b5277bd26e79b7fe5506edcaf197ba63eb7), breaks [#](https://github.com/tari-project/tari/issues/), [#](https://github.com/tari-project/tari/issues/), [#](https://github.com/tari-project/tari/issues/))
+
+#### Bug Fixes
+
+* use mined at timestamp in fauxconfirmation (#5443) ([f3833c9f](https://github.com/tari-project/tari/commit/f3833c9fc46d77fddaa7a23ef1d53ba9d860182a), breaks [#](https://github.com/tari-project/tari/issues/), [#](https://github.com/tari-project/tari/issues/), [#](https://github.com/tari-project/tari/issues/))
+* fix custom wallet startup logic for console wallet (#5429) ([0c1e5765](https://github.com/tari-project/tari/commit/0c1e5765676a9281b45fd66c8846b78ea4c76125), breaks [#](https://github.com/tari-project/tari/issues/), [#](https://github.com/tari-project/tari/issues/), [#](https://github.com/tari-project/tari/issues/))
+* **balanced_mp:**  removes some panics, adds some checks and new tests (#5432) ([602f416f](https://github.com/tari-project/tari/commit/602f416f674b5e1835a634f3c8ab123001af600e), breaks [#](https://github.com/tari-project/tari/issues/), [#](https://github.com/tari-project/tari/issues/), [#](https://github.com/tari-project/tari/issues/))
+* **comms:**  validate onion3 checksum (#5440) ([0dfdb3a4](https://github.com/tari-project/tari/commit/0dfdb3a4bef51952f0cecf6f6fcb00f6b2bfe302), breaks [#](https://github.com/tari-project/tari/issues/), [#](https://github.com/tari-project/tari/issues/), [#](https://github.com/tari-project/tari/issues/))
+* **wallet-ffi:**  don't block on start (#5437) ([27fe8d9d](https://github.com/tari-project/tari/commit/27fe8d9d2fc3ea6468605ef5edea56efdcc8248f), breaks [#](https://github.com/tari-project/tari/issues/), [#](https://github.com/tari-project/tari/issues/), [#](https://github.com/tari-project/tari/issues/))
+
+
 ## [0.50.0-pre.2](https://github.com/tari-project/tari/compare/v0.50.0-pre.1...v0.50.0-pre.2) (2023-05-29)
 
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.50.0-pre.2"
+version = "0.50.0-pre.3"
 edition = "2018"
 
 [features]
@@ -40,4 +40,4 @@ tari_test_utils = {  path = "../infrastructure/test_utils"}
 toml = "0.5.8"
 
 [build-dependencies]
-tari_features = { version = "0.50.0-pre.2", path = "./tari_features"}
+tari_features = { version = "0.50.0-pre.3", path = "./tari_features"}

--- a/common/tari_features/Cargo.toml
+++ b/common/tari_features/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.50.0-pre.2"
+version = "0.50.0-pre.3"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/common_sqlite/Cargo.toml
+++ b/common_sqlite/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_common_sqlite"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency wallet library"
 license = "BSD-3-Clause"
-version = "0.50.0-pre.2"
+version = "0.50.0-pre.3"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/comms/core/Cargo.toml
+++ b/comms/core/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.50.0-pre.2"
+version = "0.50.0-pre.3"
 edition = "2018"
 
 [dependencies]

--- a/comms/dht/Cargo.toml
+++ b/comms/dht/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_comms_dht"
-version = "0.50.0-pre.2"
+version = "0.50.0-pre.3"
 authors = ["The Tari Development Community"]
 description = "Tari comms DHT module"
 repository = "https://github.com/tari-project/tari"

--- a/comms/rpc_macros/Cargo.toml
+++ b/comms/rpc_macros/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.50.0-pre.2"
+version = "0.50.0-pre.3"
 edition = "2018"
 
 [lib]

--- a/infrastructure/derive/Cargo.toml
+++ b/infrastructure/derive/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.50.0-pre.2"
+version = "0.50.0-pre.3"
 edition = "2018"
 
 [lib]

--- a/infrastructure/shutdown/Cargo.toml
+++ b/infrastructure/shutdown/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.50.0-pre.2"
+version = "0.50.0-pre.3"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/infrastructure/storage/Cargo.toml
+++ b/infrastructure/storage/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.50.0-pre.2"
+version = "0.50.0-pre.3"
 edition = "2018"
 
 [dependencies]

--- a/infrastructure/test_utils/Cargo.toml
+++ b/infrastructure/test_utils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_test_utils"
 description = "Utility functions used in Tari test functions"
-version = "0.50.0-pre.2"
+version = "0.50.0-pre.3"
 authors = ["The Tari Development Community"]
 edition = "2018"
 license = "BSD-3-Clause"


### PR DESCRIPTION
Description
---
Tagging a version before we bump to 0.51.0-pre.0

Motivation and Context
---
It helps us know what the last stuff to get merged was before it moved into nextnet. 