### PR TITLE
fix(stagenet)!: set gen block time to now

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5114,7 +5114,7 @@ dependencies = [
 
 [[package]]
 name = "tari_app_grpc"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "argon2",
  "base64 0.13.1",
@@ -5138,7 +5138,7 @@ dependencies = [
 
 [[package]]
 name = "tari_app_utilities"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "clap 3.2.25",
  "futures 0.3.28",
@@ -5157,7 +5157,7 @@ dependencies = [
 
 [[package]]
 name = "tari_base_node"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5253,7 +5253,7 @@ dependencies = [
 
 [[package]]
 name = "tari_common"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "anyhow",
  "blake2 0.9.2",
@@ -5280,7 +5280,7 @@ dependencies = [
 
 [[package]]
 name = "tari_common_sqlite"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -5294,7 +5294,7 @@ dependencies = [
 
 [[package]]
 name = "tari_common_types"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "borsh",
  "chacha20poly1305 0.10.1",
@@ -5312,7 +5312,7 @@ dependencies = [
 
 [[package]]
 name = "tari_comms"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5361,7 +5361,7 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_dht"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "anyhow",
  "bitflags 1.3.2",
@@ -5405,7 +5405,7 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_rpc_macros"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "futures 0.3.28",
  "proc-macro2",
@@ -5420,7 +5420,7 @@ dependencies = [
 
 [[package]]
 name = "tari_console_wallet"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "bitflags 1.3.2",
  "chrono",
@@ -5469,7 +5469,7 @@ dependencies = [
 
 [[package]]
 name = "tari_contacts"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "chrono",
  "diesel",
@@ -5497,7 +5497,7 @@ dependencies = [
 
 [[package]]
 name = "tari_core"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "bincode",
  "bitflags 1.3.2",
@@ -5593,7 +5593,7 @@ dependencies = [
 
 [[package]]
 name = "tari_features"
-version = "0.49.0"
+version = "0.49.1"
 
 [[package]]
 name = "tari_integration_tests"
@@ -5641,7 +5641,7 @@ dependencies = [
 
 [[package]]
 name = "tari_key_manager"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5695,7 +5695,7 @@ dependencies = [
 
 [[package]]
 name = "tari_merge_mining_proxy"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -5745,7 +5745,7 @@ dependencies = [
 
 [[package]]
 name = "tari_miner"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "base64 0.13.1",
  "borsh",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "tari_mining_helper_ffi"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "borsh",
  "hex",
@@ -5796,7 +5796,7 @@ dependencies = [
 
 [[package]]
 name = "tari_mmr"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "bincode",
  "blake2 0.9.2",
@@ -5816,7 +5816,7 @@ dependencies = [
 
 [[package]]
 name = "tari_p2p"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "anyhow",
  "clap 2.34.0",
@@ -5870,7 +5870,7 @@ dependencies = [
 
 [[package]]
 name = "tari_service_framework"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5887,7 +5887,7 @@ dependencies = [
 
 [[package]]
 name = "tari_shutdown"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "futures 0.3.28",
  "tokio",
@@ -5895,7 +5895,7 @@ dependencies = [
 
 [[package]]
 name = "tari_storage"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "bincode",
  "lmdb-zero",
@@ -5908,7 +5908,7 @@ dependencies = [
 
 [[package]]
 name = "tari_test_utils"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "futures 0.3.28",
  "futures-test",
@@ -5940,7 +5940,7 @@ dependencies = [
 
 [[package]]
 name = "tari_wallet"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5990,7 +5990,7 @@ dependencies = [
 
 [[package]]
 name = "tari_wallet_ffi"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "borsh",
  "cbindgen 0.24.3",

--- a/applications/tari_app_grpc/Cargo.toml
+++ b/applications/tari_app_grpc/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "This crate is to provide a single source for all cross application grpc files and conversions to and from tari::core"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.49.0"
+version = "0.49.1"
 edition = "2018"
 
 [dependencies]

--- a/applications/tari_app_utilities/Cargo.toml
+++ b/applications/tari_app_utilities/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_app_utilities"
-version = "0.49.0"
+version = "0.49.1"
 authors = ["The Tari Development Community"]
 edition = "2018"
 license = "BSD-3-Clause"

--- a/applications/tari_base_node/Cargo.toml
+++ b/applications/tari_base_node/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "The tari full base node implementation"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.49.0"
+version = "0.49.1"
 edition = "2018"
 
 [dependencies]

--- a/applications/tari_console_wallet/Cargo.toml
+++ b/applications/tari_console_wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_console_wallet"
-version = "0.49.0"
+version = "0.49.1"
 authors = ["The Tari Development Community"]
 edition = "2018"
 license = "BSD-3-Clause"

--- a/applications/tari_merge_mining_proxy/Cargo.toml
+++ b/applications/tari_merge_mining_proxy/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "The Tari merge mining proxy for xmrig"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.49.0"
+version = "0.49.1"
 edition = "2018"
 
 [features]

--- a/applications/tari_miner/Cargo.toml
+++ b/applications/tari_miner/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "The tari miner implementation"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.49.0"
+version = "0.49.1"
 edition = "2018"
 
 [dependencies]

--- a/base_layer/common_types/Cargo.toml
+++ b/base_layer/common_types/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_common_types"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency common types"
 license = "BSD-3-Clause"
-version = "0.49.0"
+version = "0.49.1"
 edition = "2018"
 
 [dependencies]

--- a/base_layer/contacts/Cargo.toml
+++ b/base_layer/contacts/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_contacts"
 authors = ["The Tari Development Community"]
 description = "Tari contacts library"
 license = "BSD-3-Clause"
-version = "0.49.0"
+version = "0.49.1"
 edition = "2018"
 
 [dependencies]

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.49.0"
+version = "0.49.1"
 edition = "2018"
 
 [features]

--- a/base_layer/core/src/blocks/genesis_block.rs
+++ b/base_layer/core/src/blocks/genesis_block.rs
@@ -122,7 +122,7 @@ fn get_stagenet_genesis_block_raw() -> Block {
     let mut body = AggregateBody::new(vec![], vec![coinbase], vec![kernel]);
     body.sort();
     // set genesis timestamp
-    let genesis = DateTime::parse_from_rfc2822("14 Jun 2023 13:00:00 +0200").unwrap();
+    let genesis = DateTime::parse_from_rfc2822("12 Jun 2023 08:00:00 +0200").unwrap();
     #[allow(clippy::cast_sign_loss)]
     let timestamp = genesis.timestamp() as u64;
     Block {

--- a/base_layer/key_manager/Cargo.toml
+++ b/base_layer/key_manager/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency wallet key management"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.49.0"
+version = "0.49.1"
 edition = "2021"
 
 [lib]

--- a/base_layer/mmr/Cargo.toml
+++ b/base_layer/mmr/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "A Merkle Mountain Range implementation"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.49.0"
+version = "0.49.1"
 edition = "2018"
 
 [features]

--- a/base_layer/p2p/Cargo.toml
+++ b/base_layer/p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_p2p"
-version = "0.49.0"
+version = "0.49.1"
 authors = ["The Tari Development community"]
 description = "Tari base layer-specific peer-to-peer communication features"
 repository = "https://github.com/tari-project/tari"

--- a/base_layer/service_framework/Cargo.toml
+++ b/base_layer/service_framework/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_service_framework"
-version = "0.49.0"
+version = "0.49.1"
 authors = ["The Tari Development Community"]
 description = "The Tari communication stack service framework"
 repository = "https://github.com/tari-project/tari"

--- a/base_layer/tari_mining_helper_ffi/Cargo.toml
+++ b/base_layer/tari_mining_helper_ffi/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_mining_helper_ffi"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency miningcore C FFI bindings"
 license = "BSD-3-Clause"
-version = "0.49.0"
+version = "0.49.1"
 edition = "2018"
 
 [dependencies]

--- a/base_layer/wallet/Cargo.toml
+++ b/base_layer/wallet/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_wallet"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency wallet library"
 license = "BSD-3-Clause"
-version = "0.49.0"
+version = "0.49.1"
 edition = "2018"
 
 [dependencies]

--- a/base_layer/wallet_ffi/Cargo.toml
+++ b/base_layer/wallet_ffi/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_wallet_ffi"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency wallet C FFI bindings"
 license = "BSD-3-Clause"
-version = "0.49.0"
+version = "0.49.1"
 edition = "2018"
 
 [dependencies]

--- a/changelog-stagenet.md
+++ b/changelog-stagenet.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.49.1](https://github.com/tari-project/tari/compare/v0.49.0...v0.49.1) (2023-06-12)
+
+### ⚠ BREAKING CHANGES
+
+* set gen block time to now (#5454)
+  
+* ### Features
+
+### Bug Fixes
+
+* set gen block time to now ([4ba4280](https://github.com/tari-project/tari/commit/4ba4280e614a2984a570c54da533e55441603412))
 
 ## [0.49.0](https://github.com/tari-project/tari/compare/v0.48.0...v0.49.0) (2023-04-19)
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.49.0"
+version = "0.49.1"
 edition = "2018"
 
 [features]

--- a/common/tari_features/Cargo.toml
+++ b/common/tari_features/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.49.0"
+version = "0.49.1"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/common_sqlite/Cargo.toml
+++ b/common_sqlite/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_common_sqlite"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency wallet library"
 license = "BSD-3-Clause"
-version = "0.49.0"
+version = "0.49.1"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/comms/core/Cargo.toml
+++ b/comms/core/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.49.0"
+version = "0.49.1"
 edition = "2018"
 
 [dependencies]

--- a/comms/dht/Cargo.toml
+++ b/comms/dht/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_comms_dht"
-version = "0.49.0"
+version = "0.49.1"
 authors = ["The Tari Development Community"]
 description = "Tari comms DHT module"
 repository = "https://github.com/tari-project/tari"

--- a/comms/rpc_macros/Cargo.toml
+++ b/comms/rpc_macros/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.49.0"
+version = "0.49.1"
 edition = "2018"
 
 [lib]

--- a/infrastructure/derive/Cargo.toml
+++ b/infrastructure/derive/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.49.0"
+version = "0.49.1"
 edition = "2018"
 
 [lib]

--- a/infrastructure/shutdown/Cargo.toml
+++ b/infrastructure/shutdown/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.49.0"
+version = "0.49.1"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/infrastructure/storage/Cargo.toml
+++ b/infrastructure/storage/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.49.0"
+version = "0.49.1"
 edition = "2018"
 
 [dependencies]

--- a/infrastructure/test_utils/Cargo.toml
+++ b/infrastructure/test_utils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_test_utils"
 description = "Utility functions used in Tari test functions"
-version = "0.49.0"
+version = "0.49.1"
 authors = ["The Tari Development Community"]
 edition = "2018"
 license = "BSD-3-Clause"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tari",
-  "version": "0.49.0",
+  "version": "0.49.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {}


### PR DESCRIPTION
Description
---
Sets the the genesis block time to now and not a future data.
Release a new version

Motivation and Context
---
We cannot mine on stagenet till the genesisblock timestamp has past.

How Has This Been Tested?
---

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
Changes the genesis block, so need to reset data folder