### PR TITLE
feat: sparse merkle trees

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,7 +279,7 @@ dependencies = [
  "matchit",
  "memchr",
  "mime",
- "percent-encoding 2.3.0",
+ "percent-encoding",
  "pin-project-lite",
  "rustversion",
  "serde",
@@ -686,6 +686,9 @@ name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cexpr"
@@ -1170,7 +1173,7 @@ dependencies = [
  "anes",
  "cast",
  "ciborium",
- "clap 4.3.0",
+ "clap 4.3.4",
  "criterion-plot",
  "is-terminal",
  "itertools",
@@ -2036,7 +2039,7 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
- "percent-encoding 2.3.0",
+ "percent-encoding",
 ]
 
 [[package]]
@@ -2244,15 +2247,15 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.8.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7339329bfa14a00223244311560d11f8f489b453fb90092af97f267a6090ab0"
+checksum = "2994bee4a3a6a51eb90c218523be382fd7ea09b16380b9312e9dbe955ff7c7d1"
 dependencies = [
  "bitflags 1.3.2",
  "libc",
  "libgit2-sys",
  "log",
- "url 1.7.2",
+ "url",
 ]
 
 [[package]]
@@ -2552,17 +2555,6 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
-dependencies = [
- "matches",
- "unicode-bidi",
- "unicode-normalization",
-]
-
-[[package]]
-name = "idna"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
@@ -2707,6 +2699,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
+name = "jobserver"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2782,9 +2783,9 @@ checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.7.11"
+version = "0.14.2+1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48441cb35dc255da8ae72825689a95368bf510659ae1ad55dc4aa88cb1789bf1"
+checksum = "7f3d95f6b51075fe9810a7ae22c7095f12b98005ab364d8544797a825ce946a4"
 dependencies = [
  "cc",
  "libc",
@@ -3140,11 +3141,11 @@ dependencies = [
  "byteorder",
  "data-encoding",
  "multihash",
- "percent-encoding 2.3.0",
+ "percent-encoding",
  "serde",
  "static_assertions",
  "unsigned-varint",
- "url 2.4.0",
+ "url",
 ]
 
 [[package]]
@@ -3601,12 +3602,6 @@ checksum = "01de5d978f34aa4b2296576379fcc416034702fd94117c56ffd8a1a767cefb30"
 dependencies = [
  "base64ct",
 ]
-
-[[package]]
-name = "percent-encoding"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 
 [[package]]
 name = "percent-encoding"
@@ -4286,7 +4281,7 @@ dependencies = [
  "mime",
  "native-tls",
  "once_cell",
- "percent-encoding 2.3.0",
+ "percent-encoding",
  "pin-project-lite",
  "serde",
  "serde_json",
@@ -4294,7 +4289,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tower-service",
- "url 2.4.0",
+ "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -5399,7 +5394,7 @@ dependencies = [
  "chacha20 0.7.3",
  "chacha20poly1305 0.10.1",
  "chrono",
- "clap 2.34.0",
+ "clap 3.2.25",
  "diesel",
  "diesel_migrations",
  "digest 0.9.0",
@@ -5497,7 +5492,7 @@ dependencies = [
  "tui",
  "unicode-segmentation",
  "unicode-width",
- "url 2.4.0",
+ "url",
  "zeroize",
  "zxcvbn",
 ]
@@ -5771,7 +5766,7 @@ dependencies = [
  "tokio",
  "tonic 0.6.2",
  "tracing",
- "url 2.4.0",
+ "url",
 ]
 
 [[package]]
@@ -5866,7 +5861,7 @@ name = "tari_p2p"
 version = "0.51.0-pre.1"
 dependencies = [
  "anyhow",
- "clap 2.34.0",
+ "clap 3.2.25",
  "config",
  "fs2",
  "futures 0.3.28",
@@ -6413,7 +6408,7 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-timeout",
- "percent-encoding 2.3.0",
+ "percent-encoding",
  "pin-project 1.1.0",
  "prost 0.9.0",
  "prost-derive 0.9.0",
@@ -6444,7 +6439,7 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-timeout",
- "percent-encoding 2.3.0",
+ "percent-encoding",
  "pin-project 1.1.0",
  "prost 0.11.9",
  "tokio",
@@ -6621,7 +6616,7 @@ dependencies = [
  "tinyvec",
  "tokio",
  "tokio-rustls",
- "url 2.4.0",
+ "url",
  "webpki 0.22.0",
 ]
 
@@ -6806,24 +6801,13 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
-version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
-dependencies = [
- "idna 0.1.5",
- "matches",
- "percent-encoding 1.0.1",
-]
-
-[[package]]
-name = "url"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
 dependencies = [
  "form_urlencoded",
  "idna 0.4.0",
- "percent-encoding 2.3.0",
+ "percent-encoding",
 ]
 
 [[package]]
@@ -6927,7 +6911,7 @@ dependencies = [
  "log",
  "mime",
  "mime_guess",
- "percent-encoding 2.3.0",
+ "percent-encoding",
  "pin-project 1.1.0",
  "rustls-pemfile 1.0.2",
  "scoped-tls",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,7 +279,7 @@ dependencies = [
  "matchit",
  "memchr",
  "mime",
- "percent-encoding",
+ "percent-encoding 2.3.0",
  "pin-project-lite",
  "rustversion",
  "serde",
@@ -686,9 +686,6 @@ name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
-dependencies = [
- "jobserver",
-]
 
 [[package]]
 name = "cexpr"
@@ -1173,7 +1170,7 @@ dependencies = [
  "anes",
  "cast",
  "ciborium",
- "clap 4.3.4",
+ "clap 4.3.0",
  "criterion-plot",
  "is-terminal",
  "itertools",
@@ -2039,7 +2036,7 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
- "percent-encoding",
+ "percent-encoding 2.3.0",
 ]
 
 [[package]]
@@ -2247,15 +2244,15 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.15.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2994bee4a3a6a51eb90c218523be382fd7ea09b16380b9312e9dbe955ff7c7d1"
+checksum = "c7339329bfa14a00223244311560d11f8f489b453fb90092af97f267a6090ab0"
 dependencies = [
  "bitflags 1.3.2",
  "libc",
  "libgit2-sys",
  "log",
- "url",
+ "url 1.7.2",
 ]
 
 [[package]]
@@ -2555,6 +2552,17 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "idna"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
@@ -2699,15 +2707,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
-name = "jobserver"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2783,9 +2782,9 @@ checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.14.2+1.5.1"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f3d95f6b51075fe9810a7ae22c7095f12b98005ab364d8544797a825ce946a4"
+checksum = "48441cb35dc255da8ae72825689a95368bf510659ae1ad55dc4aa88cb1789bf1"
 dependencies = [
  "cc",
  "libc",
@@ -3141,11 +3140,11 @@ dependencies = [
  "byteorder",
  "data-encoding",
  "multihash",
- "percent-encoding",
+ "percent-encoding 2.3.0",
  "serde",
  "static_assertions",
  "unsigned-varint",
- "url",
+ "url 2.4.0",
 ]
 
 [[package]]
@@ -3602,6 +3601,12 @@ checksum = "01de5d978f34aa4b2296576379fcc416034702fd94117c56ffd8a1a767cefb30"
 dependencies = [
  "base64ct",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 
 [[package]]
 name = "percent-encoding"
@@ -4281,7 +4286,7 @@ dependencies = [
  "mime",
  "native-tls",
  "once_cell",
- "percent-encoding",
+ "percent-encoding 2.3.0",
  "pin-project-lite",
  "serde",
  "serde_json",
@@ -4289,7 +4294,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tower-service",
- "url",
+ "url 2.4.0",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -5394,7 +5399,7 @@ dependencies = [
  "chacha20 0.7.3",
  "chacha20poly1305 0.10.1",
  "chrono",
- "clap 3.2.25",
+ "clap 2.34.0",
  "diesel",
  "diesel_migrations",
  "digest 0.9.0",
@@ -5492,7 +5497,7 @@ dependencies = [
  "tui",
  "unicode-segmentation",
  "unicode-width",
- "url",
+ "url 2.4.0",
  "zeroize",
  "zxcvbn",
 ]
@@ -5766,7 +5771,7 @@ dependencies = [
  "tokio",
  "tonic 0.6.2",
  "tracing",
- "url",
+ "url 2.4.0",
 ]
 
 [[package]]
@@ -5861,7 +5866,7 @@ name = "tari_p2p"
 version = "0.51.0-pre.1"
 dependencies = [
  "anyhow",
- "clap 3.2.25",
+ "clap 2.34.0",
  "config",
  "fs2",
  "futures 0.3.28",
@@ -6408,7 +6413,7 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-timeout",
- "percent-encoding",
+ "percent-encoding 2.3.0",
  "pin-project 1.1.0",
  "prost 0.9.0",
  "prost-derive 0.9.0",
@@ -6439,7 +6444,7 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-timeout",
- "percent-encoding",
+ "percent-encoding 2.3.0",
  "pin-project 1.1.0",
  "prost 0.11.9",
  "tokio",
@@ -6616,7 +6621,7 @@ dependencies = [
  "tinyvec",
  "tokio",
  "tokio-rustls",
- "url",
+ "url 2.4.0",
  "webpki 0.22.0",
 ]
 
@@ -6801,13 +6806,24 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
+dependencies = [
+ "idna 0.1.5",
+ "matches",
+ "percent-encoding 1.0.1",
+]
+
+[[package]]
+name = "url"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
 dependencies = [
  "form_urlencoded",
  "idna 0.4.0",
- "percent-encoding",
+ "percent-encoding 2.3.0",
 ]
 
 [[package]]
@@ -6911,7 +6927,7 @@ dependencies = [
  "log",
  "mime",
  "mime_guess",
- "percent-encoding",
+ "percent-encoding 2.3.0",
  "pin-project 1.1.0",
  "rustls-pemfile 1.0.2",
  "scoped-tls",

--- a/base_layer/mmr/Cargo.toml
+++ b/base_layer/mmr/Cargo.toml
@@ -10,7 +10,6 @@ edition = "2018"
 [features]
 default = []
 native_bitmap = ["croaring"]
-benches = ["criterion"]
 
 [dependencies]
 tari_utilities = "0.4"
@@ -22,20 +21,28 @@ digest = "0.9"
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 croaring = { version = "0.5", optional = true }
-criterion = { version = "0.5", optional = true }
 
 [dev-dependencies]
 rand = "0.8.0"
 blake2 = "0.9.0"
 serde_json = "1.0"
 bincode = "1.1"
+criterion = { version = "0.5" }
 
 [lib]
 # Disable libtest from intercepting Criterion bench arguments
 bench = false
 
 [[bench]]
-name = "bench"
+name = "mmr"
+harness = false
+
+[[bench]]
+name = "smt"
+harness = false
+
+[[bench]]
+name = "smt_vs_mmr"
 harness = false
 
 [[test]]

--- a/base_layer/mmr/benches/smt.rs
+++ b/base_layer/mmr/benches/smt.rs
@@ -1,3 +1,6 @@
+// Copyright 2023. The Tari Project
+// SPDX-License-Identifier: BSD-3-Clause
+
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use tari_crypto::hash::blake2::Blake256;
 use tari_mmr::sparse_merkle_tree::{NodeKey, SparseMerkleTree, ValueHash};

--- a/base_layer/mmr/benches/smt.rs
+++ b/base_layer/mmr/benches/smt.rs
@@ -1,0 +1,38 @@
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use tari_crypto::hash::blake2::Blake256;
+use tari_mmr::sparse_merkle_tree::{NodeKey, SparseMerkleTree, ValueHash};
+
+fn random_key() -> NodeKey {
+    let key = rand::random::<[u8; 32]>();
+    NodeKey::from(key)
+}
+
+fn get_keys(n: usize) -> Vec<NodeKey> {
+    (0..n).map(|_| random_key()).collect()
+}
+
+fn create_smt() -> SparseMerkleTree<Blake256> {
+    SparseMerkleTree::<Blake256>::new()
+}
+
+pub fn benchmark_sparse_merkle_trees(c: &mut Criterion) {
+    let sizes = [100, 10_000];
+    for size in sizes {
+        c.bench_function(&format!("SMT: Insert {size} keys"), move |b| {
+            let keys = get_keys(size);
+            let mut smt = create_smt();
+            b.iter_batched(
+                || keys.clone(),
+                |hashes| {
+                    hashes.into_iter().for_each(|key| {
+                        smt.upsert(key, ValueHash::default()).unwrap();
+                    });
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+}
+
+criterion_group!(smt, benchmark_sparse_merkle_trees);
+criterion_main!(smt);

--- a/base_layer/mmr/benches/smt_vs_mmr.rs
+++ b/base_layer/mmr/benches/smt_vs_mmr.rs
@@ -1,0 +1,126 @@
+#[cfg(feature = "native_bitmap")]
+use croaring::Bitmap;
+use tari_crypto::{hash::blake2::Blake256, hash_domain, hashing::DomainSeparatedHasher};
+use tari_mmr::sparse_merkle_tree::{NodeKey, SparseMerkleTree, ValueHash};
+#[cfg(feature = "native_bitmap")]
+use tari_mmr::{Hash, MutableMmr};
+use tari_utilities::hex::Hex;
+
+#[cfg(feature = "native_bitmap")]
+hash_domain!(
+    MmrBenchTestHashDomain,
+    "com.tari.tari_project.base_layer.mmr.benches",
+    1
+);
+#[cfg(feature = "native_bitmap")]
+pub type MmrTestHasherBlake256 = DomainSeparatedHasher<Blake256, MmrBenchTestHashDomain>;
+#[cfg(feature = "native_bitmap")]
+pub type TestMmr = MutableMmr<MmrTestHasherBlake256, Vec<Hash>>;
+
+fn random_key() -> NodeKey {
+    let key = rand::random::<[u8; 32]>();
+    NodeKey::from(key)
+}
+
+fn get_keys(n: usize) -> Vec<NodeKey> {
+    (0..n).map(|_| random_key()).collect()
+}
+
+fn create_smt() -> SparseMerkleTree<Blake256> {
+    SparseMerkleTree::<Blake256>::new()
+}
+
+fn insert_into_smt(keys: &[NodeKey], tree: &mut SparseMerkleTree<Blake256>) {
+    keys.iter().for_each(|key| {
+        tree.upsert(key.clone(), ValueHash::default()).unwrap();
+    });
+}
+
+fn delete_from_smt(keys: &[NodeKey], tree: &mut SparseMerkleTree<Blake256>) {
+    keys.into_iter().for_each(|key| {
+        tree.delete(key).unwrap();
+    });
+}
+
+#[cfg(feature = "native_bitmap")]
+fn insert_into_mmr(keys: &[Vec<u8>], mmr: &mut TestMmr) {
+    keys.iter().for_each(|key| {
+        mmr.push(key.clone()).unwrap();
+    });
+}
+
+#[cfg(feature = "native_bitmap")]
+fn delete_from_mmr(start: u32, n: u32, mmr: &mut TestMmr) {
+    (start..start + n).for_each(|i| {
+        mmr.delete(i);
+    });
+}
+
+fn time_function(header: &str, f: impl FnOnce()) -> std::time::Duration {
+    println!("Starting: {header}");
+    let now = std::time::Instant::now();
+    f();
+    let t = now.elapsed();
+    println!("Finished: {header} - {t:?}");
+    t
+}
+
+fn main() {
+    let size = 1_000_000;
+    let half_size = size / 2;
+    let keys = get_keys(size);
+    let mut tree = create_smt();
+    time_function(&format!("SMT: Inserting {size} keys"), || {
+        insert_into_smt(&keys, &mut tree);
+    });
+    time_function("SMT: Calculating root hash", || {
+        let size = tree.size();
+        let hash = tree.hash();
+        println!("Tree size: {size}. Root hash: {hash:x}");
+    });
+    time_function(&format!("SMT: Deleting {half_size} keys"), || {
+        delete_from_smt(&keys[0..half_size], &mut tree);
+    });
+    time_function("SMT: Calculating root hash", || {
+        let size = tree.size();
+        let hash = tree.hash();
+        println!("Tree size: {size}. Root hash: {hash:x}");
+    });
+    time_function(&format!("SMT: Deleting another {half_size} keys"), || {
+        delete_from_smt(&keys[half_size..], &mut tree);
+    });
+    time_function("SMT: Calculating root hash", || {
+        let size = tree.size();
+        let hash = tree.hash();
+        println!("Tree size: {size}. Root hash: {hash:x}");
+    });
+    #[cfg(feature = "native_bitmap")]
+    {
+        let mut mmr = TestMmr::new(Vec::default(), Bitmap::default()).unwrap();
+        let keys = keys.into_iter().map(|k| k.as_slice().to_vec()).collect::<Vec<_>>();
+        time_function(&format!("MMR: Inserting {size} keys"), || {
+            insert_into_mmr(&keys, &mut mmr);
+        });
+        time_function("SMT: Calculating root hash", || {
+            let size = mmr.len();
+            let hash = mmr.get_merkle_root().unwrap();
+            println!("Tree size: {size}. Root hash: {}", hash.to_hex());
+        });
+        time_function(&format!("MMR: Deleting {half_size} keys"), || {
+            delete_from_mmr(0, half_size as u32, &mut mmr);
+        });
+        time_function("SMT: Calculating root hash", || {
+            let size = mmr.len();
+            let hash = mmr.get_merkle_root().unwrap();
+            println!("Tree size: {size}. Root hash: {}", hash.to_hex());
+        });
+        time_function(&format!("MMR: Deleting another {half_size} keys"), || {
+            delete_from_mmr(half_size as u32, half_size as u32, &mut mmr);
+        });
+        time_function("SMT: Calculating root hash", || {
+            let size = mmr.len();
+            let hash = mmr.get_merkle_root().unwrap();
+            println!("Tree size: {size}. Root hash: {}", hash.to_hex());
+        });
+    }
+}

--- a/base_layer/mmr/benches/smt_vs_mmr.rs
+++ b/base_layer/mmr/benches/smt_vs_mmr.rs
@@ -1,10 +1,18 @@
+// Copyright 2023. The Tari Project
+// SPDX-License-Identifier: BSD-3-Clause
+
 #[cfg(feature = "native_bitmap")]
 use croaring::Bitmap;
-use tari_crypto::{hash::blake2::Blake256};
+use tari_crypto::hash::blake2::Blake256;
+#[cfg(feature = "native_bitmap")]
+use tari_crypto::hash_domain;
+#[cfg(feature = "native_bitmap")]
+use tari_crypto::hashing::DomainSeparatedHasher;
+#[cfg(feature = "native_bitmap")]
+use tari_crypto::tari_utilities::hex::Hex;
 use tari_mmr::sparse_merkle_tree::{NodeKey, SparseMerkleTree, ValueHash};
 #[cfg(feature = "native_bitmap")]
 use tari_mmr::{Hash, MutableMmr};
-
 
 #[cfg(feature = "native_bitmap")]
 hash_domain!(
@@ -101,7 +109,7 @@ fn main() {
         time_function(&format!("MMR: Inserting {size} keys"), || {
             insert_into_mmr(&keys, &mut mmr);
         });
-        time_function("SMT: Calculating root hash", || {
+        time_function("MMR: Calculating root hash", || {
             let size = mmr.len();
             let hash = mmr.get_merkle_root().unwrap();
             println!("Tree size: {size}. Root hash: {}", hash.to_hex());
@@ -109,7 +117,7 @@ fn main() {
         time_function(&format!("MMR: Deleting {half_size} keys"), || {
             delete_from_mmr(0, half_size as u32, &mut mmr);
         });
-        time_function("SMT: Calculating root hash", || {
+        time_function("MMR: Calculating root hash", || {
             let size = mmr.len();
             let hash = mmr.get_merkle_root().unwrap();
             println!("Tree size: {size}. Root hash: {}", hash.to_hex());
@@ -117,7 +125,7 @@ fn main() {
         time_function(&format!("MMR: Deleting another {half_size} keys"), || {
             delete_from_mmr(half_size as u32, half_size as u32, &mut mmr);
         });
-        time_function("SMT: Calculating root hash", || {
+        time_function("MMR: Calculating root hash", || {
             let size = mmr.len();
             let hash = mmr.get_merkle_root().unwrap();
             println!("Tree size: {size}. Root hash: {}", hash.to_hex());

--- a/base_layer/mmr/benches/smt_vs_mmr.rs
+++ b/base_layer/mmr/benches/smt_vs_mmr.rs
@@ -1,10 +1,10 @@
 #[cfg(feature = "native_bitmap")]
 use croaring::Bitmap;
-use tari_crypto::{hash::blake2::Blake256, hash_domain, hashing::DomainSeparatedHasher};
+use tari_crypto::{hash::blake2::Blake256};
 use tari_mmr::sparse_merkle_tree::{NodeKey, SparseMerkleTree, ValueHash};
 #[cfg(feature = "native_bitmap")]
 use tari_mmr::{Hash, MutableMmr};
-use tari_utilities::hex::Hex;
+
 
 #[cfg(feature = "native_bitmap")]
 hash_domain!(
@@ -37,7 +37,7 @@ fn insert_into_smt(keys: &[NodeKey], tree: &mut SparseMerkleTree<Blake256>) {
 }
 
 fn delete_from_smt(keys: &[NodeKey], tree: &mut SparseMerkleTree<Blake256>) {
-    keys.into_iter().for_each(|key| {
+    keys.iter().for_each(|key| {
         tree.delete(key).unwrap();
     });
 }

--- a/base_layer/mmr/src/lib.rs
+++ b/base_layer/mmr/src/lib.rs
@@ -142,6 +142,7 @@ mod mem_backend_vec;
 mod merkle_mountain_range;
 mod merkle_proof;
 mod serde_support;
+pub mod sparse_merkle_tree;
 
 // Less commonly used exports
 pub mod common;

--- a/base_layer/mmr/src/sparse_merkle_tree/bit_utils.rs
+++ b/base_layer/mmr/src/sparse_merkle_tree/bit_utils.rs
@@ -9,25 +9,15 @@ pub fn get_bit(data: &[u8], position: usize) -> usize {
     0
 }
 
-// /// Sets the bit at an offset from the most significant bit
-// #[inline]
-// fn set_bit_at_from_msb(data: &mut [u8], position: usize) {
-//     let mut n = data[position / 8] as usize;
-//     n |= 1 << (8 - 1 - (position % 8));
-//     data[position / 8] = n as u8;
-// }
-//
-// #[inline]
-// fn count_set_bits(data: &[u8]) -> usize {
-//     let mut count = 0;
-//     for i in 0..data.len() * 8 {
-//         if get_bit_at_from_msb(data, i) == 1 {
-//             count += 1;
-//         }
-//     }
-//     count
-// }
-//
+#[inline]
+pub fn set_bit(data: &mut [u8], position: usize, value: usize) {
+    match value {
+        0 => data[position / 8] &= !(1 << (7 - (position % 8))),
+        1 => data[position / 8] |= 1 << (7 - (position % 8)),
+        _ => panic!("Invalid bit value"),
+    }
+}
+
 #[inline]
 pub fn count_common_prefix(a: &NodeKey, b: &NodeKey) -> usize {
     let mut offset = 0;
@@ -61,6 +51,23 @@ pub fn height_key(key: &NodeKey, height: usize) -> NodeKey {
     // height % 8
     bytes[height / 8] = key[height / 8] & !(0xff >> (height % 8));
     result
+}
+
+pub fn path_matches_key(key: &NodeKey, path: &[TraverseDirection]) -> bool {
+    let height = path.len();
+
+    let prefix = path
+        .iter()
+        .enumerate()
+        .fold(NodeKey::default(), |mut prefix, (i, dir)| {
+            let bit = match dir {
+                TraverseDirection::Left => 0,
+                TraverseDirection::Right => 1,
+            };
+            set_bit(prefix.as_mut_slice(), i, bit);
+            prefix
+        });
+    count_common_prefix(key, &prefix) >= height
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/base_layer/mmr/src/sparse_merkle_tree/bit_utils.rs
+++ b/base_layer/mmr/src/sparse_merkle_tree/bit_utils.rs
@@ -1,0 +1,204 @@
+use crate::sparse_merkle_tree::{NodeKey, SMTError};
+
+/// Gets the bit at an offset from the most significant bit. Does NOT perform range checking
+#[inline]
+pub fn get_bit(data: &[u8], position: usize) -> usize {
+    if (data[position / 8] as usize) & (1 << (8 - 1 - (position % 8))) > 0 {
+        return 1;
+    }
+    0
+}
+
+// /// Sets the bit at an offset from the most significant bit
+// #[inline]
+// fn set_bit_at_from_msb(data: &mut [u8], position: usize) {
+//     let mut n = data[position / 8] as usize;
+//     n |= 1 << (8 - 1 - (position % 8));
+//     data[position / 8] = n as u8;
+// }
+//
+// #[inline]
+// fn count_set_bits(data: &[u8]) -> usize {
+//     let mut count = 0;
+//     for i in 0..data.len() * 8 {
+//         if get_bit_at_from_msb(data, i) == 1 {
+//             count += 1;
+//         }
+//     }
+//     count
+// }
+//
+#[inline]
+pub fn count_common_prefix(a: &NodeKey, b: &NodeKey) -> usize {
+    let mut offset = 0;
+    let n = a.len().min(b.len());
+    let a = a.as_slice();
+    let b = b.as_slice();
+    while offset < n && a[offset] == b[offset] {
+        offset += 1;
+    }
+    if offset == n {
+        return offset * 8;
+    }
+    let mut i = 0;
+    while get_bit(&a[offset..=offset], i) == get_bit(&b[offset..=offset], i) {
+        i += 1;
+    }
+    offset * 8 + i
+}
+
+/// For branch nodes, the key is the first `height` bits of all descendant node keys. This function calculates the
+/// branch key for a given key and height.
+#[inline]
+pub fn height_key(key: &NodeKey, height: usize) -> NodeKey {
+    let mut result = NodeKey::default();
+    // Keep the first `height` bits and ignore the rest
+    let key = key.as_slice();
+    let bytes = result.as_mut_slice();
+    // First height/8 bytes are the same, so just copy
+    bytes[0..height / 8].copy_from_slice(&key[0..height / 8]);
+    // The height/8th byte is only partially copied, so mask the byte & 11100000, where the number of 1s is
+    // height % 8
+    bytes[height / 8] = key[height / 8] & !(0xff >> (height % 8));
+    result
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TraverseDirection {
+    Left,
+    Right,
+}
+
+/// Checks whether the `child_key` would be a left or right child of the `parent_key` at the given height
+pub fn traverse_direction(
+    parent_height: usize,
+    parent_key: &NodeKey,
+    child_key: &NodeKey,
+) -> Result<TraverseDirection, SMTError> {
+    let common_prefix = count_common_prefix(parent_key, child_key);
+    if common_prefix < parent_height {
+        return Err(SMTError::InvalidChildKey {
+            height: parent_height,
+            child_key: child_key.clone(),
+            parent_key: parent_key.clone(),
+        });
+    }
+
+    match get_bit(child_key.as_slice(), parent_height) {
+        0 => Ok(TraverseDirection::Left),
+        1 => Ok(TraverseDirection::Right),
+        _ => unreachable!(),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::convert::TryFrom;
+
+    use super::*;
+    use crate::sparse_merkle_tree::{bit_utils::count_common_prefix, NodeKey};
+
+    #[test]
+    fn test_common_prefix() {
+        let a = NodeKey::from(b"abcdefgh12345678abcdefgh12345678");
+        let b = NodeKey::from(b"abcdefgh12345678abcdefgh12345678");
+        assert_eq!(count_common_prefix(&a, &b), 256);
+
+        let b = NodeKey::from(b"abcDEFgh12345678abcdefgh12345678");
+        // 'd' in binary is 01100100
+        // 'D' in binary is 01000100
+        assert_eq!(count_common_prefix(&a, &b), 3 * 8 + 2);
+
+        let b = NodeKey::from(b"\xffbcdefgh12345678abcdefgh12345678");
+        assert_eq!(count_common_prefix(&a, &b), 0);
+    }
+
+    #[test]
+    fn traverse_directions() {
+        let parent_key = NodeKey::try_from(b"\xffbcdefgh12345678abcdefgh12345678").unwrap();
+        // 10111111 in hex is 0xBF
+        let child_key = NodeKey::try_from(b"\xBFbcdefgh12345678abcdefgh12345678").unwrap();
+        assert_eq!(
+            traverse_direction(0, &parent_key, &child_key).unwrap(),
+            TraverseDirection::Right
+        );
+        assert_eq!(
+            traverse_direction(1, &parent_key, &child_key).unwrap(),
+            TraverseDirection::Left
+        );
+        // 111... doesn't match 101.. to 2 places, so is an error
+        let err = traverse_direction(2, &parent_key, &child_key);
+        let expected_err = Err(SMTError::InvalidChildKey {
+            height: 2,
+            child_key,
+            parent_key: parent_key.clone(),
+        });
+        assert_eq!(err, expected_err);
+        // 11011111 in hex is 0xDF
+        let child_key = NodeKey::try_from(b"\xDFbcdefgh12345678abcdefgh12345678").unwrap();
+        assert_eq!(
+            traverse_direction(0, &parent_key, &child_key).unwrap(),
+            TraverseDirection::Right
+        );
+        // matches to 1 place, next is a 1, so is a right child
+        assert_eq!(
+            traverse_direction(1, &parent_key, &child_key).unwrap(),
+            TraverseDirection::Right
+        );
+        // matches to 2 places, next is a 0, so is a left child
+        assert_eq!(
+            traverse_direction(2, &parent_key, &child_key).unwrap(),
+            TraverseDirection::Left
+        );
+
+        let parent_key = NodeKey::try_from(b"abcdefgh\x082345678abcdefgh12345678").unwrap();
+        let child_key = NodeKey::try_from(b"abcdefgh\x0A2345678abcdefgh12345678").unwrap();
+        // 0x8 in binary is 00001000
+        // 0xA in binary is 00001010
+        // matches to 8*8 + 5 places, next is a 0, so is a left child
+        assert_eq!(
+            traverse_direction(69, &parent_key, &child_key).unwrap(),
+            TraverseDirection::Left
+        );
+        // 0xC in binary is 00001100
+        // matches to 8*8 + 5 places, next is a 1, so is a right child
+        let child_key = NodeKey::try_from(b"abcdefgh\x0C2345678abcdefgh12345678").unwrap();
+        assert_eq!(
+            traverse_direction(69, &parent_key, &child_key).unwrap(),
+            TraverseDirection::Right
+        );
+
+        // doesn't match to 70 places, so is an error
+        let err = traverse_direction(71, &parent_key, &child_key);
+        let expected_err: Result<TraverseDirection, _> = Err(SMTError::InvalidChildKey {
+            height: 71,
+            child_key,
+            parent_key,
+        });
+        assert_eq!(err, expected_err);
+    }
+
+    #[test]
+    fn height_keys() {
+        let key = NodeKey::try_from(b"abcdefgh12345678abcdefgh12345678").unwrap();
+        let hkey = height_key(&key, 0);
+        assert_eq!(hkey.as_slice(), &[0u8; 32]);
+        let hkey = height_key(&key, 3);
+        let expected = NodeKey::from([
+            96, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        ]);
+        assert_eq!(hkey, expected);
+        let hkey = height_key(&key, 16);
+        // 'a' in decimal is 97
+        let expected = NodeKey::from([
+            97, 98, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        ]);
+        assert_eq!(hkey, expected);
+        let hkey = height_key(&key, 5 * 8 + 2);
+        // 102 in binary is 01100110
+        let expected = NodeKey::from([
+            97, 98, 99, 100, 101, 64, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        ]);
+        assert_eq!(hkey, expected);
+    }
+}

--- a/base_layer/mmr/src/sparse_merkle_tree/error.rs
+++ b/base_layer/mmr/src/sparse_merkle_tree/error.rs
@@ -1,3 +1,6 @@
+// Copyright 2023. The Tari Project
+// SPDX-License-Identifier: BSD-3-Clause
+
 use thiserror::Error;
 
 use crate::sparse_merkle_tree::NodeKey;

--- a/base_layer/mmr/src/sparse_merkle_tree/error.rs
+++ b/base_layer/mmr/src/sparse_merkle_tree/error.rs
@@ -24,4 +24,6 @@ pub enum SMTError {
     UnexpectedNodeType,
     #[error("The key is not valid: {0}")]
     IllegalKey(String),
+    #[error("The hash for the tree needs to be recalculated before calling this function")]
+    StaleHash,
 }

--- a/base_layer/mmr/src/sparse_merkle_tree/error.rs
+++ b/base_layer/mmr/src/sparse_merkle_tree/error.rs
@@ -1,0 +1,27 @@
+use thiserror::Error;
+
+use crate::sparse_merkle_tree::NodeKey;
+
+#[derive(Error, Debug, PartialEq, Eq)]
+pub enum SMTError {
+    #[error("Source data too short ({0})")]
+    ArrayTooShort(usize),
+    #[error("Invalid branch: {0}")]
+    InvalidBranch(String),
+    #[error("Tried to traverse to an invalid child key ({child_key}) at height {height} from parent {parent_key}.")]
+    InvalidChildKey {
+        height: usize,
+        parent_key: NodeKey,
+        child_key: NodeKey,
+    },
+    #[error("find_terminal returned a branch node")]
+    InvalidTerminalNode,
+    #[error("Changing a branch node would lead to loss of data")]
+    CannotMutateBranchNode,
+    #[error("Expected an empty node")]
+    ExpectedEmptyNode,
+    #[error("A node is not of the expected type")]
+    UnexpectedNodeType,
+    #[error("The key is not valid: {0}")]
+    IllegalKey(String),
+}

--- a/base_layer/mmr/src/sparse_merkle_tree/mod.rs
+++ b/base_layer/mmr/src/sparse_merkle_tree/mod.rs
@@ -72,6 +72,8 @@
 //! tree.delete(&new_key(79)).unwrap();
 //! assert!(tree.is_empty());
 //! ```
+//! Copyright 2023. The Tari Project
+//! SPDX-License-Identifier: BSD-3-Clause
 
 mod bit_utils;
 mod error;

--- a/base_layer/mmr/src/sparse_merkle_tree/mod.rs
+++ b/base_layer/mmr/src/sparse_merkle_tree/mod.rs
@@ -76,8 +76,10 @@
 mod bit_utils;
 mod error;
 mod node;
+mod proofs;
 mod tree;
 
 pub use error::SMTError;
 pub use node::{BranchNode, EmptyNode, LeafNode, Node, NodeHash, NodeKey, ValueHash, EMPTY_NODE_HASH};
+pub use proofs::MerkleProof;
 pub use tree::{SparseMerkleTree, UpdateResult};

--- a/base_layer/mmr/src/sparse_merkle_tree/mod.rs
+++ b/base_layer/mmr/src/sparse_merkle_tree/mod.rs
@@ -1,0 +1,83 @@
+//! Sparse Merkle trees
+//! A sparse Merkle tree is a Merkle tree where the non-empty nodes are stored in a map with the key being the hash
+//! of the node and the value being the node itself.
+//!
+//! Merkle trees are a mutable Merkle-ish tree structure, that supports full CRUD operations. Inclusion _and_
+//! exclusion proofs are supported, and are succinct.
+//!
+//! This implementation assumed that there is a key-value store elsewhere. Only the tree hashes themselves are
+//! handled in this data structure.
+//!
+//! When constructing a new tree, a hashing algorithm is specified. This is used to hash the non-leaf nodes. The
+//! "values" provided to the tree must already be a hash, and should have been generated from a different hashing
+//! algorithm to the one driving the tree, in order to prevent second pre-image attacks.
+//!
+//! # Example
+//!
+//! Let's create a SMT with four nodes. We'll use the `Blake256` hash function to hash the nodes, and we'll use
+//! the `ValueHash` type to represent the values. The `ValueHash` type is a wrapper around a `[u8; 32]` array.
+//!
+//! If we insert the nodes at
+//!  * A: 01001111 (79 in decimal)
+//!  * B: 01011111 (95 in decimal)
+//!  * C: 11100000 (224 in decimal)
+//!  * D: 11110000 (240 in decimal)
+//! you will notice that they the first two diverge at the first bit, while the first and last pairs differ at the
+//! fourth bit. This results in a SMT that looks like this:
+//!
+//! .           ┌──────┐
+//!       ┌─────┤ root ├─────┐
+//!       │     └──────┘     │
+//!      ┌┴┐                ┌┴┐1
+//!   ┌──┤ ├──┐          ┌──┤ ├───┐
+//!   │  └─┘  │          │  └─┘   │
+//!  ┌┴┐     ┌┴┐        ┌┴┐10    ┌┴┐11
+//!  │0│  ┌──┤ ├──┐     │0│    ┌─┤ ├─┐
+//!  └─┘  │  └─┘  │     └─┘    │ └─┘ │
+//!      ┌┴┐     ┌┴┐       110┌┴┐   ┌┴┐111
+//!    ┌─┤ ├─┐   │0│          │0│ ┌─┤ ├─┐
+//!    │ └─┘ │   └─┘          └─┘ │ └─┘ │
+//!   ┌┴┐   ┌┴┐                  ┌┴┐   ┌┴┐
+//!   │A│   │B│                  │D│   │C│
+//!   └─┘   └─┘                  └─┘   └─┘
+//!
+//! The merkle root is calculated by hashing nodes in the familiar way.
+//! ```rust
+//! use tari_crypto::hash::blake2::Blake256;
+//! use tari_mmr::sparse_merkle_tree::{NodeKey, SparseMerkleTree, ValueHash};
+//!
+//! fn new_key(v: u8) -> NodeKey {
+//!     let mut key = [0u8; 32];
+//!     key[0] = v;
+//!     NodeKey::from(key)
+//! }
+//! let mut tree = SparseMerkleTree::<Blake256>::default();
+//! tree.upsert(new_key(79), ValueHash::from([1u8; 32]))
+//!     .unwrap();
+//! tree.upsert(new_key(95), ValueHash::from([2u8; 32]))
+//!     .unwrap();
+//! tree.upsert(new_key(240), ValueHash::from([3u8; 32]))
+//!     .unwrap();
+//! tree.upsert(new_key(224), ValueHash::from([4u8; 32]))
+//!     .unwrap();
+//! assert_eq!(
+//!     tree.hash().to_string(),
+//!     "e88862dc2d50248e7830924c1c415e9789069ae451f9eb5e437fdd2d6dffd4dd"
+//! );
+//!
+//! // Deleting nodes is also supported
+//! tree.delete(&new_key(224)).unwrap();
+//! tree.delete(&new_key(95)).unwrap();
+//! tree.delete(&new_key(240)).unwrap();
+//! tree.delete(&new_key(79)).unwrap();
+//! assert!(tree.is_empty());
+//! ```
+
+mod bit_utils;
+mod error;
+mod node;
+mod tree;
+
+pub use error::SMTError;
+pub use node::{BranchNode, EmptyNode, LeafNode, Node, NodeHash, NodeKey, ValueHash, EMPTY_NODE_HASH};
+pub use tree::{SparseMerkleTree, UpdateResult};

--- a/base_layer/mmr/src/sparse_merkle_tree/node.rs
+++ b/base_layer/mmr/src/sparse_merkle_tree/node.rs
@@ -1,3 +1,6 @@
+// Copyright 2023. The Tari Project
+// SPDX-License-Identifier: BSD-3-Clause
+
 use std::{
     convert::TryFrom,
     fmt::{Debug, Formatter},

--- a/base_layer/mmr/src/sparse_merkle_tree/node.rs
+++ b/base_layer/mmr/src/sparse_merkle_tree/node.rs
@@ -1,0 +1,508 @@
+use std::{
+    convert::TryFrom,
+    fmt::{Debug, Formatter},
+    marker::PhantomData,
+};
+
+use digest::{consts::U32, Digest};
+
+use crate::sparse_merkle_tree::{
+    bit_utils::{count_common_prefix, get_bit, height_key},
+    Node::*,
+    SMTError,
+};
+
+macro_rules! hash_type {
+    ($name: ident) => {
+        /// A wrapper around a 32-byte hash value. Provides convenience functions to display as hex or binary
+        #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+        pub struct $name([u8; 32]);
+
+        impl $name {
+            pub fn as_slice(&self) -> &[u8] {
+                &self.0
+            }
+
+            pub fn as_mut_slice(&mut self) -> &mut [u8] {
+                &mut self.0
+            }
+
+            pub fn len(&self) -> usize {
+                self.0.len()
+            }
+
+            pub fn is_empty(&self) -> bool {
+                self.0.is_empty()
+            }
+        }
+
+        impl Default for $name {
+            fn default() -> Self {
+                Self([0; 32])
+            }
+        }
+
+        impl std::convert::TryFrom<&[u8]> for $name {
+            type Error = SMTError;
+
+            fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+                if value.len() < 32 {
+                    return Err(SMTError::ArrayTooShort(value.len()));
+                }
+                let mut bytes = [0u8; 32];
+                bytes.copy_from_slice(value);
+                Ok(Self(bytes))
+            }
+        }
+
+        impl From<[u8; 32]> for $name {
+            fn from(arr: [u8; 32]) -> Self {
+                Self(arr)
+            }
+        }
+
+        impl From<&[u8; 32]> for $name {
+            fn from(arr: &[u8; 32]) -> Self {
+                Self(arr.clone())
+            }
+        }
+
+        impl AsRef<[u8]> for $name {
+            fn as_ref(&self) -> &[u8] {
+                &self.0
+            }
+        }
+
+        impl std::fmt::UpperHex for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                self.0.iter().try_for_each(|b| write!(f, "{:02X}", b))
+            }
+        }
+
+        impl std::fmt::LowerHex for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                self.0.iter().try_for_each(|b| write!(f, "{:02x}", b))
+            }
+        }
+
+        impl std::fmt::Binary for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                self.0.iter().try_for_each(|b| write!(f, "{:08b}", b))
+            }
+        }
+
+        impl std::fmt::Display for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                if f.alternate() {
+                    write!(f, "{:b}", self)
+                } else {
+                    write!(f, "{:x}", self)
+                }
+            }
+        }
+    };
+}
+
+hash_type!(NodeHash);
+hash_type!(ValueHash);
+hash_type!(NodeKey);
+
+pub const EMPTY_NODE_HASH: NodeHash = NodeHash([0; 32]);
+
+#[derive(Debug)]
+pub enum Node<H> {
+    Empty(EmptyNode),
+    Leaf(LeafNode<H>),
+    Branch(BranchNode<H>),
+}
+
+impl<H> Clone for Node<H> {
+    fn clone(&self) -> Self {
+        match self {
+            Empty(n) => Empty(n.clone()),
+            Leaf(n) => Leaf(n.clone()),
+            Branch(_) => panic!("Branch nodes cannot be cloned"),
+        }
+    }
+}
+
+impl<H> Node<H> {
+    /// A non-mutable version of [`Node::hash`], which you can use if you _absolutely know_ that the hash is correct.
+    /// This would be the case for Empty or Leaf nodes, but you should never call this if the node might be a branch
+    /// node.
+    pub fn unsafe_hash(&self) -> &NodeHash {
+        match self {
+            Empty(n) => n.hash(),
+            Leaf(n) => n.hash(),
+            Branch(n) => n.unsafe_hash(),
+        }
+    }
+
+    /// Returns true if the node is empty, false otherwise.
+    pub fn is_empty(&self) -> bool {
+        matches!(self, Node::Empty(_))
+    }
+
+    /// Returns true if the node is a leaf, false otherwise.
+    pub fn is_leaf(&self) -> bool {
+        matches!(self, Node::Leaf(_))
+    }
+
+    /// Returns true if the node is a branch, false otherwise.
+    pub fn is_branch(&self) -> bool {
+        matches!(self, Node::Branch(_))
+    }
+
+    /// Casts the node as a branch node, if it is one.
+    pub fn as_branch(&self) -> Option<&BranchNode<H>> {
+        match self {
+            Node::Branch(n) => Some(n),
+            _ => None,
+        }
+    }
+
+    /// Casts the node as a mutable branch node, if it is one.
+    pub fn as_branch_mut(&mut self) -> Option<&mut BranchNode<H>> {
+        match self {
+            Branch(n) => Some(n),
+            _ => None,
+        }
+    }
+
+    /// Casts the node as a leaf node, if it is one.
+    pub fn as_leaf(&self) -> Option<&LeafNode<H>> {
+        match self {
+            Leaf(n) => Some(n),
+            _ => None,
+        }
+    }
+
+    pub fn to_leaf(self) -> Result<LeafNode<H>, SMTError> {
+        match self {
+            Leaf(n) => Ok(n),
+            _ => Err(SMTError::UnexpectedNodeType),
+        }
+    }
+
+    /// Indicates whether the node is semi-terminal, i.e. whether it is a leaf or empty node, or if a branch, if it is
+    /// the last branch in the sub-tree.
+    pub fn is_semi_terminal(&self) -> bool {
+        match self {
+            Leaf(_) | Empty(_) => true,
+            Branch(n) => !n.left.is_branch() && !n.right.is_branch(),
+        }
+    }
+}
+
+impl<H: Digest<OutputSize = U32>> Node<H> {
+    /// Returns the hash of the node. This is a convenience function that calls the appropriate hash function for the
+    /// node type. For empty nodes, this is the empty node hash.
+    /// For performance reasons, the function will lazily evaluate the hash of a branch node, which is why it takes
+    /// `&mut self`. If you need a read-only version of this function and **know** that the hash is correct, you can
+    /// use [`Node::unsafe_hash`] instead.
+    pub fn hash(&mut self) -> &NodeHash {
+        match self {
+            Empty(n) => n.hash(),
+            Leaf(n) => n.hash(),
+            Branch(n) => n.hash(),
+        }
+    }
+}
+
+//-------------------------------------       Empty Node     -----------------------------------------------------------
+
+/// An empty node. All empty nodes have the same hash, which acts as a marker value for truncated portions of the tree.
+#[derive(Clone, Debug)]
+pub struct EmptyNode {}
+
+impl EmptyNode {
+    pub fn hash(&self) -> &'static NodeHash {
+        &EMPTY_NODE_HASH
+    }
+}
+
+//-------------------------------------       Leaf Node     -----------------------------------------------------------
+pub struct LeafNode<H> {
+    key: NodeKey,
+    hash: NodeHash,
+    value: ValueHash,
+    hash_type: PhantomData<H>,
+}
+
+impl<H> Clone for LeafNode<H> {
+    fn clone(&self) -> Self {
+        Self {
+            key: self.key.clone(),
+            hash: self.hash.clone(),
+            value: self.value.clone(),
+            hash_type: PhantomData,
+        }
+    }
+}
+
+impl<H: Debug> Debug for LeafNode<H> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LeafNode")
+            .field("key", &self.key.to_string())
+            .field("hash", &self.hash.to_string())
+            .field("value", &self.value.to_string())
+            .finish()
+    }
+}
+
+impl<H> LeafNode<H> {
+    pub fn key(&self) -> &NodeKey {
+        &self.key
+    }
+
+    pub fn hash(&self) -> &NodeHash {
+        &self.hash
+    }
+
+    pub fn value(&self) -> &ValueHash {
+        &self.value
+    }
+
+    pub fn to_value_hash(self) -> ValueHash {
+        self.value
+    }
+}
+
+impl<H: Digest<OutputSize = U32>> LeafNode<H> {
+    pub fn new(key: NodeKey, value: ValueHash) -> Self {
+        let hash = Self::hash_value(&key, &value);
+        Self {
+            key,
+            hash,
+            value,
+            hash_type: PhantomData,
+        }
+    }
+
+    fn hash_value(key: &NodeKey, value: &ValueHash) -> NodeHash {
+        let hasher = H::new();
+        let hash = hasher
+            .chain(b"V")
+            .chain(key.as_slice())
+            .chain(value.as_slice())
+            .finalize();
+        let mut result = [0; 32];
+        result.copy_from_slice(hash.as_slice());
+        result.into()
+    }
+
+    /// Replaces this leaf node with a new tree that starts at the given height and branches until the given sibling
+    /// node is on the opposite side of the branch.
+    pub fn build_tree(self, height: usize, sibling: LeafNode<H>) -> Result<BranchNode<H>, SMTError> {
+        let diverge_height = count_common_prefix(&self.key, &sibling.key);
+        let num_branches = match diverge_height.checked_sub(height) {
+            Some(n) => n + 1,
+            None => {
+                let msg = format!("Diverge height {diverge_height} is less than height {height}");
+                return Err(SMTError::InvalidBranch(msg));
+            },
+        };
+        let root_key = height_key(&self.key, height);
+        if num_branches == 1 {
+            let (left, right) = if self.key < sibling.key {
+                (Leaf(self), Leaf(sibling))
+            } else {
+                (Leaf(sibling), Leaf(self))
+            };
+            let root = BranchNode::new(height, root_key, left, right)?;
+            Ok(root)
+        } else {
+            let (left, right) = if get_bit(self.key.as_slice(), height) == 0 {
+                (Branch(self.build_tree(height + 1, sibling)?), Empty(EmptyNode {}))
+            } else {
+                (Empty(EmptyNode {}), Branch(self.build_tree(height + 1, sibling)?))
+            };
+            let root = BranchNode::new(height, root_key, left, right)?;
+            Ok(root)
+        }
+    }
+}
+
+//-------------------------------------       Branch Node     ----------------------------------------------------------
+pub struct BranchNode<H> {
+    // The height of the branch. It is also the number of bits that all keys below this branch share.
+    height: usize,
+    // Only the first `height` bits of the key are relevant for this branch.
+    key: NodeKey,
+    hash: NodeHash,
+    // Flag to indicate that the tree hash changed somewhere below this branch. and that the hash should be
+    // recalculated.
+    is_hash_stale: bool,
+    left: Box<Node<H>>,
+    right: Box<Node<H>>,
+    hash_type: PhantomData<H>,
+}
+
+impl<H: Debug> Debug for BranchNode<H> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BranchNode")
+            .field("height", &self.height)
+            .field("key", &self.key.to_string())
+            .field("hash", &self.hash.to_string())
+            .field("is_hash_stale", &self.is_hash_stale)
+            .field("left", &self.left)
+            .field("right", &self.right)
+            .finish()
+    }
+}
+
+impl<H> BranchNode<H> {
+    pub fn height(&self) -> usize {
+        self.height
+    }
+
+    pub fn key(&self) -> &NodeKey {
+        &self.key
+    }
+
+    pub fn left(&self) -> &Node<H> {
+        &self.left
+    }
+
+    pub fn right(&self) -> &Node<H> {
+        &self.right
+    }
+
+    pub(crate) fn left_mut(&mut self) -> &mut Node<H> {
+        &mut self.left
+    }
+
+    pub(crate) fn right_mut(&mut self) -> &mut Node<H> {
+        &mut self.right
+    }
+
+    pub fn unsafe_hash(&self) -> &NodeHash {
+        &self.hash
+    }
+
+    /// Can be used to check if the hash needs to be recalculated.
+    pub fn is_stale(&self) -> bool {
+        self.is_hash_stale
+    }
+
+    pub(crate) fn mark_as_stale(&mut self) {
+        self.is_hash_stale = true;
+    }
+}
+
+impl<H: Digest<OutputSize = U32>> BranchNode<H> {
+    pub fn new(height: usize, key: NodeKey, left: Node<H>, right: Node<H>) -> Result<Self, SMTError> {
+        match (&left, &right) {
+            (Empty(_), Empty(_)) => Err(SMTError::InvalidBranch(
+                "Both left and right nodes are empty".to_string(),
+            )),
+            (Empty(_), Leaf(_)) | (Leaf(_), Empty(_)) => Err(SMTError::InvalidBranch(
+                "A branch node cannot an empty node and leaf node as children".into(),
+            )),
+            (Leaf(_) | Branch(_), Leaf(_) | Branch(_)) | (Empty(_), Branch(_)) | (Branch(_), Empty(_)) => Ok(Self {
+                height,
+                key,
+                hash: NodeHash::default(),
+                is_hash_stale: true,
+                left: Box::new(left),
+                right: Box::new(right),
+                hash_type: PhantomData,
+            }),
+        }
+    }
+
+    pub fn hash(&mut self) -> &NodeHash {
+        if self.is_hash_stale {
+            self.recalculate_hash();
+        }
+        &self.hash
+    }
+
+    fn recalculate_hash(&mut self) {
+        let hasher = H::new();
+        let hash = hasher
+            .chain(b"B")
+            .chain(self.height.to_le_bytes())
+            .chain(&self.key)
+            .chain(self.left.hash())
+            .chain(self.right.hash())
+            .finalize();
+        // Output is guaranteed to be 32 bytes at compile time due to trait constraint on `H`
+        let hash = NodeHash::try_from(hash.as_slice()).unwrap();
+        self.hash = hash;
+        self.is_hash_stale = false;
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use rand::{self, RngCore};
+    use tari_crypto::hash::blake2::Blake256;
+
+    use super::*;
+
+    fn random_arr() -> [u8; 32] {
+        let mut result = [0; 32];
+        rand::thread_rng().fill_bytes(&mut result);
+        result
+    }
+
+    fn random_key() -> NodeKey {
+        NodeKey::from(random_arr())
+    }
+
+    fn random_value_hash() -> ValueHash {
+        ValueHash::from(random_arr())
+    }
+
+    #[test]
+    fn empty_node() {
+        assert_eq!(EmptyNode {}.hash(), &EMPTY_NODE_HASH);
+    }
+
+    #[test]
+    fn leaf_node() {
+        let key = random_key();
+        let value = random_value_hash();
+        let node = LeafNode::<Blake256>::new(key, value);
+        let expect = Blake256::new()
+            .chain(b"V")
+            .chain(node.key())
+            .chain(node.value())
+            .finalize();
+        let expect = NodeHash::try_from(expect.as_slice()).unwrap();
+        assert_eq!(node.hash(), &expect);
+    }
+
+    #[test]
+    fn branch_empty_leaf() {
+        let left = Node::Empty(EmptyNode {});
+        let right = Node::Leaf(LeafNode::<Blake256>::new(random_key(), random_value_hash()));
+        let branch = BranchNode::<Blake256>::new(0, random_key(), left, right);
+        // Should not be allowed - since this can be represented as a leaf node
+        assert!(matches!(branch, Err(SMTError::InvalidBranch(_))));
+
+        let left = Node::Leaf(LeafNode::<Blake256>::new(random_key(), random_value_hash()));
+        let right = Node::Empty(EmptyNode {});
+        let branch = BranchNode::<Blake256>::new(0, random_key(), left, right);
+        // Should not be allowed - since this can be represented as a leaf node
+        assert!(matches!(branch, Err(SMTError::InvalidBranch(_))));
+    }
+
+    #[test]
+    fn branch_leaf_leaf() {
+        let left = Node::Leaf(LeafNode::<Blake256>::new(random_key(), random_value_hash()));
+        let right = Node::Leaf(LeafNode::<Blake256>::new(random_key(), random_value_hash()));
+        let l_hash = left.unsafe_hash().clone();
+        let r_hash = right.unsafe_hash().clone();
+        let mut branch = BranchNode::<Blake256>::new(0, random_key(), left, right).unwrap();
+        let expected = Blake256::new()
+            .chain(b"B")
+            .chain(branch.height().to_le_bytes())
+            .chain(branch.key())
+            .chain(l_hash)
+            .chain(r_hash)
+            .finalize();
+        assert_eq!(branch.hash().as_slice(), expected.as_slice());
+    }
+}

--- a/base_layer/mmr/src/sparse_merkle_tree/proofs.rs
+++ b/base_layer/mmr/src/sparse_merkle_tree/proofs.rs
@@ -1,0 +1,174 @@
+use std::marker::PhantomData;
+
+use digest::{consts::U32, Digest};
+
+use crate::sparse_merkle_tree::{
+    bit_utils::{height_key, path_matches_key, TraverseDirection},
+    BranchNode,
+    LeafNode,
+    NodeHash,
+    NodeKey,
+    SMTError,
+    SparseMerkleTree,
+    ValueHash,
+    EMPTY_NODE_HASH,
+};
+
+pub struct MerkleProof<H> {
+    path: Vec<TraverseDirection>,
+    siblings: Vec<NodeHash>,
+    key: NodeKey,
+    value: Option<ValueHash>,
+    phantom: std::marker::PhantomData<H>,
+}
+
+impl<H: Digest<OutputSize = U32>> MerkleProof<H> {
+    pub fn new(path: Vec<TraverseDirection>, siblings: Vec<NodeHash>, key: NodeKey, value: Option<ValueHash>) -> Self {
+        Self {
+            path,
+            siblings,
+            key,
+            value,
+            phantom: PhantomData::<H>::default(),
+        }
+    }
+
+    pub fn from_tree(tree: &SparseMerkleTree<H>, key: &NodeKey) -> Result<Self, SMTError> {
+        tree.build_proof(key)
+    }
+
+    fn calculate_root_hash(&self) -> NodeHash {
+        let node_hash = match self.value.as_ref() {
+            Some(v) => LeafNode::<H>::hash_value(&self.key, v),
+            None => EMPTY_NODE_HASH,
+        };
+        let n = self.siblings.len();
+        let hash = self.siblings.iter().zip(self.path.iter()).rev().enumerate().fold(
+            node_hash,
+            |current, (i, (sibling_hash, direction))| {
+                let height = n - i - 1;
+                
+                match direction {
+                    TraverseDirection::Left => {
+                        BranchNode::<H>::branch_hash(height, &height_key(&self.key, height), &current, sibling_hash)
+                    },
+                    TraverseDirection::Right => {
+                        BranchNode::<H>::branch_hash(height, &height_key(&self.key, height), sibling_hash, &current)
+                    },
+                }
+            },
+        );
+        let mut result = [0; 32];
+        result.copy_from_slice(hash.as_slice());
+        result.into()
+    }
+
+    pub fn validate_inclusion_proof(
+        &self,
+        expected_key: &NodeKey,
+        expected_value: &ValueHash,
+        expected_root: &NodeHash,
+    ) -> bool {
+        expected_key == &self.key &&
+            Some(expected_value) == self.value.as_ref() &&
+            expected_root == &self.calculate_root_hash()
+    }
+
+    pub fn validate_exclusion_proof(&self, expected_key: &NodeKey, expected_root: &NodeHash) -> bool {
+        path_matches_key(expected_key, &self.path) &&
+            expected_root == &self.calculate_root_hash() &&
+            (self.value.is_none() || &self.key != expected_key)
+    }
+
+    pub fn key(&self) -> &NodeKey {
+        &self.key
+    }
+
+    pub fn value_hash(&self) -> Option<&ValueHash> {
+        self.value.as_ref()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use rand::{RngCore, SeedableRng};
+    use tari_crypto::hash::blake2::Blake256;
+
+    use super::*;
+
+    fn random_arr(n: usize, seed: u64) -> Vec<[u8; 32]> {
+        let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+        (0..n)
+            .map(|_| {
+                let mut key = [0u8; 32];
+                rng.fill_bytes(&mut key);
+                key
+            })
+            .collect()
+    }
+
+    fn random_keys(n: usize, seed: u64) -> Vec<NodeKey> {
+        random_arr(n, seed).into_iter().map(|k| k.into()).collect()
+    }
+
+    fn random_values(n: usize, seed: u64) -> Vec<ValueHash> {
+        random_arr(n, seed).into_iter().map(|k| k.into()).collect()
+    }
+
+    #[test]
+    fn root_proof() {
+        let key = NodeKey::from([64u8; 32]);
+        let value = ValueHash::from([128u8; 32]);
+        let mut tree = SparseMerkleTree::<Blake256>::default();
+        let hash = tree.hash().clone();
+        let proof = tree.build_proof(&key).unwrap();
+
+        assert_eq!(proof.validate_inclusion_proof(&key, &value, &hash), false);
+        assert!(proof.validate_exclusion_proof(&key, &hash));
+
+        tree.upsert(key.clone(), value.clone()).unwrap();
+        let hash = tree.hash().clone();
+        let proof = tree.build_proof(&key).unwrap();
+
+        assert!(proof.validate_inclusion_proof(&key, &value, &hash));
+        assert_eq!(
+            proof.validate_inclusion_proof(&key, &ValueHash::from([1u8; 32]), &hash),
+            false
+        );
+        assert_eq!(proof.validate_exclusion_proof(&key, &hash), false);
+    }
+
+    #[test]
+    fn merkle_proofs() {
+        let n = 15;
+        let keys = random_keys(n, 420);
+        let values = random_values(n, 1420);
+        let mut tree = SparseMerkleTree::<Blake256>::default();
+        (0..n).for_each(|i| {
+            let _ = tree.upsert(keys[i].clone(), values[i].clone()).unwrap();
+        });
+        let root_hash = tree.hash().clone();
+        (0..n).for_each(|i| {
+            let proof = tree.build_proof(&keys[i]).unwrap();
+            // Validate the proof with correct key / value
+            assert!(proof.validate_inclusion_proof(&keys[i], &values[i], &root_hash));
+            // Show that incorrect value for existing key fails
+            assert_eq!(
+                proof.validate_inclusion_proof(&keys[i], &values[(i + 3) % n], &root_hash),
+                false
+            );
+            // Exclusion proof fails
+            assert_eq!(proof.validate_exclusion_proof(&keys[i], &root_hash), false);
+        });
+        // Test exclusion proof
+        let unused_keys = random_keys(n, 72);
+        (0..n).for_each(|i| {
+            let proof = tree.build_proof(&unused_keys[i]).unwrap();
+            assert!(proof.validate_exclusion_proof(&unused_keys[i], &root_hash));
+            assert_eq!(
+                proof.validate_inclusion_proof(&unused_keys[i], &values[i], &root_hash),
+                false
+            );
+        });
+    }
+}

--- a/base_layer/mmr/src/sparse_merkle_tree/proofs.rs
+++ b/base_layer/mmr/src/sparse_merkle_tree/proofs.rs
@@ -1,3 +1,6 @@
+// Copyright 2023. The Tari Project
+// SPDX-License-Identifier: BSD-3-Clause
+
 use std::marker::PhantomData;
 
 use digest::{consts::U32, Digest};
@@ -47,7 +50,7 @@ impl<H: Digest<OutputSize = U32>> MerkleProof<H> {
             node_hash,
             |current, (i, (sibling_hash, direction))| {
                 let height = n - i - 1;
-                
+
                 match direction {
                     TraverseDirection::Left => {
                         BranchNode::<H>::branch_hash(height, &height_key(&self.key, height), &current, sibling_hash)

--- a/base_layer/mmr/src/sparse_merkle_tree/tree.rs
+++ b/base_layer/mmr/src/sparse_merkle_tree/tree.rs
@@ -1,0 +1,726 @@
+use std::mem;
+
+use digest::{consts::U32, Digest};
+
+use crate::sparse_merkle_tree::{
+    bit_utils::{traverse_direction, TraverseDirection},
+    EmptyNode,
+    LeafNode,
+    Node,
+    Node::{Branch, Empty, Leaf},
+    NodeHash,
+    NodeKey,
+    SMTError,
+    ValueHash,
+};
+
+#[derive(Debug, PartialEq)]
+pub enum UpdateResult {
+    Updated(ValueHash),
+    Inserted,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum DeleteResult {
+    Deleted(ValueHash),
+    KeyNotFound,
+}
+
+pub struct SparseMerkleTree<H> {
+    size: u64,
+    root: Node<H>,
+}
+
+impl<H> SparseMerkleTree<H> {
+    pub fn new() -> Self {
+        Self {
+            size: 0,
+            root: Node::Empty(EmptyNode {}),
+        }
+    }
+
+    pub fn size(&self) -> u64 {
+        self.size
+    }
+
+    pub fn root(&self) -> &Node<H> {
+        &self.root
+    }
+}
+
+impl<H> Default for SparseMerkleTree<H> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+enum PathClassifier {
+    // The desired key is not in the tree
+    KeyDoesNotExist,
+    // The desired key is in a terminal node
+    TerminalBranch,
+    // The desired key is in a non-terminal node. The tree continues deeper on the other branch.
+    NonTerminalBranch,
+}
+
+/// Private struct, representing a terminal node in the tree. A terminal node is on that should house the key we've been
+/// searching for in a CRUD operation. The parent must exist (there's special handling for the root elsewhere) and is
+/// a branch node by definition.
+///
+/// There are utility methods for inserting or updating a leaf node, and for deleting a leaf node.
+struct TerminalBranch<'a, H> {
+    parent: &'a mut Node<H>,
+    direction: TraverseDirection,
+    empty_siblings: Vec<bool>,
+}
+
+impl<'a, H: Digest<OutputSize = U32>> TerminalBranch<'a, H> {
+    /// Returns the terminal node of the branch
+    pub fn terminal(&self) -> &Node<H> {
+        let branch = self.parent.as_branch().unwrap();
+        match &self.direction {
+            TraverseDirection::Left => branch.left(),
+            TraverseDirection::Right => branch.right(),
+        }
+    }
+
+    /// When inserting a new leaf node, there might be a slew of branch nodes to create depending on where the keys
+    /// of the existing leaf and new leaf node diverge. E.g. if a leaf node of key `1101` is being inserted into a
+    /// tree with a single leaf node of key `1100` then we must create branches at `1...`, `11..`, and `110.` with
+    /// the leaf nodes `1100` and `1101` being the left and right branches at height 4 respectively.
+    ///
+    /// This function handles this case, as well the simple update case, and the simple insert case, where the target
+    /// node is empty.
+    fn insert_or_update_leaf(&mut self, leaf: LeafNode<H>) -> Result<UpdateResult, SMTError> {
+        let height = self.parent.as_branch().ok_or(SMTError::UnexpectedNodeType)?.height();
+        self.parent
+            .as_branch_mut()
+            .ok_or(SMTError::UnexpectedNodeType)?
+            .mark_as_stale();
+        let terminal = match self.direction {
+            TraverseDirection::Left => self.parent.as_branch_mut().unwrap().left_mut(),
+            TraverseDirection::Right => self.parent.as_branch_mut().unwrap().right_mut(),
+        };
+        match terminal {
+            Empty(_) => {
+                *terminal = Node::Leaf(leaf);
+                Ok(UpdateResult::Inserted)
+            },
+            Leaf(old_leaf) if old_leaf.key() == leaf.key() => {
+                let old_value = old_leaf.value().clone();
+                *terminal = Node::Leaf(leaf);
+                Ok(UpdateResult::Updated(old_value))
+            },
+            Leaf(_) => {
+                let old_leaf = mem::replace(terminal, Node::Empty(EmptyNode {})).to_leaf()?;
+                let branch = old_leaf.build_tree(height + 1, leaf)?;
+                *terminal = Node::Branch(branch);
+                Ok(UpdateResult::Inserted)
+            },
+            _ => unreachable!(),
+        }
+    }
+
+    /// Classifies the type of deletion that should be performed on the terminal node. If the key is not in the tree,
+    /// there is nothing to delete and we return `KeyDoesNotExist`. If the key does exist, we need to know whether the
+    /// sibling node is a leaf (i.e. the parent is a `TerminalBranch`) or a branch (the parent is a
+    /// `NonTerminalBranch`). For terminal branches, the deletion logic is more complex as it is a reverse of the
+    /// `insert_or_update_leaf` logic for insertion.
+    fn exists(&self, key: &NodeKey) -> Result<PathClassifier, SMTError> {
+        let branch = self.parent.as_branch().ok_or(SMTError::UnexpectedNodeType)?;
+        let (terminal, other_is_branch) = match self.direction {
+            TraverseDirection::Left => (branch.left(), branch.right().is_branch()),
+            TraverseDirection::Right => (branch.right(), branch.left().is_branch()),
+        };
+        if terminal.is_empty() {
+            Ok(PathClassifier::KeyDoesNotExist)
+        } else if terminal.is_branch() {
+            Err(SMTError::InvalidTerminalNode)
+        } else {
+            let leaf = terminal.as_leaf().ok_or(SMTError::UnexpectedNodeType)?;
+            match (leaf.key() == key, other_is_branch) {
+                (false, _) => Ok(PathClassifier::KeyDoesNotExist),
+                (true, false) => Ok(PathClassifier::TerminalBranch),
+                (true, true) => Ok(PathClassifier::NonTerminalBranch),
+            }
+        }
+    }
+
+    /// When deleting a leaf node, there might be a slew of branch nodes to delete if the sibling node
+    /// of the deleted node is also a leaf node. It's essentially the reverse of the `insert_or_update_leaf` function
+    /// above.
+    fn prune(&mut self) -> Result<(Node<H>, usize), SMTError> {
+        let branches_to_prune = self.empty_siblings.iter()
+            .rev()
+            // The last branch has two non-empty nodes by definition, so it's always F.
+            .skip(1)
+            .take_while(|b| **b)
+            .count() +
+            1; // Account for the last branch
+        let depth = (self.parent.as_branch().ok_or(SMTError::UnexpectedNodeType)?.height() + 1)
+            .checked_sub(branches_to_prune)
+            .ok_or_else(|| SMTError::InvalidBranch("Logic error: Trying to brune beyond root".into()))?;
+        let orphan_node = match self.direction {
+            TraverseDirection::Left => {
+                let terminal = self
+                    .parent
+                    .as_branch_mut()
+                    .ok_or(SMTError::InvalidTerminalNode)?
+                    .right_mut();
+                mem::replace(terminal, Node::Empty(EmptyNode {}))
+            },
+            TraverseDirection::Right => {
+                let terminal = self
+                    .parent
+                    .as_branch_mut()
+                    .ok_or(SMTError::InvalidTerminalNode)?
+                    .left_mut();
+                mem::replace(terminal, Node::Empty(EmptyNode {}))
+            },
+        };
+        Ok((orphan_node, depth))
+    }
+
+    /// Replaces the terminal node with an Empty node, returning the deleted node
+    fn delete(&mut self) -> Result<ValueHash, SMTError> {
+        let branch = self.parent.as_branch_mut().ok_or(SMTError::UnexpectedNodeType)?;
+        let terminal = match &self.direction {
+            TraverseDirection::Left => branch.left_mut(),
+            TraverseDirection::Right => branch.right_mut(),
+        };
+        let old = mem::replace(terminal, Node::Empty(EmptyNode {}));
+        let hash = old.to_leaf()?.to_value_hash();
+        Ok(hash)
+    }
+}
+
+impl<H: Digest<OutputSize = U32>> SparseMerkleTree<H> {
+    pub fn hash(&mut self) -> &NodeHash {
+        self.root.hash()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.size == 0
+    }
+
+    pub fn delete(&mut self, key: &NodeKey) -> Result<DeleteResult, SMTError> {
+        if self.root.is_empty() {
+            return Ok(DeleteResult::KeyNotFound);
+        }
+        if self.root.is_leaf() {
+            let leaf = self.root.as_leaf().ok_or(SMTError::UnexpectedNodeType)?;
+            if leaf.key() == key {
+                let leaf = mem::replace(&mut self.root, Node::Empty(EmptyNode {}));
+                let leaf_hash = leaf.to_leaf()?.to_value_hash();
+                self.size -= 1;
+                return Ok(DeleteResult::Deleted(leaf_hash));
+            }
+            return Ok(DeleteResult::KeyNotFound);
+        }
+        let mut path = self.find_terminal_branch(key, false)?;
+        let result = match path.exists(key)? {
+            PathClassifier::KeyDoesNotExist => DeleteResult::KeyNotFound,
+            PathClassifier::TerminalBranch => {
+                let deleted = path
+                    .terminal()
+                    .as_leaf()
+                    .ok_or(SMTError::UnexpectedNodeType)?
+                    .value()
+                    .clone();
+                let (orphan, depth) = path.prune()?;
+                self.attach_orphan_at_depth(key, depth, orphan)?;
+                self.size -= 1;
+                DeleteResult::Deleted(deleted)
+            },
+            PathClassifier::NonTerminalBranch => {
+                let deleted_hash = path.delete()?;
+                self.size -= 1;
+                DeleteResult::Deleted(deleted_hash)
+            },
+        };
+        Ok(result)
+    }
+
+    pub fn upsert(&mut self, key: NodeKey, value: ValueHash) -> Result<UpdateResult, SMTError> {
+        let new_leaf = LeafNode::new(key, value);
+        if self.root.is_empty() {
+            self.root = Node::Leaf(new_leaf);
+            self.size += 1;
+            return Ok(UpdateResult::Inserted);
+        }
+        if self.root.is_leaf() {
+            let old_root = mem::replace(&mut self.root, Node::Empty(EmptyNode {})).to_leaf()?;
+            let root = old_root.build_tree(0, new_leaf)?;
+            self.root = Branch(root);
+            self.size += 1;
+            return Ok(UpdateResult::Inserted);
+        }
+        // Traverse the tree until we find either an empty node or a leaf node.
+        let mut terminal_node = self.find_terminal_branch(new_leaf.key(), true)?;
+        let result = terminal_node.insert_or_update_leaf(new_leaf)?;
+        if let UpdateResult::Inserted = result {
+            self.size += 1
+        }
+        Ok(result)
+    }
+
+    pub fn contains(&self, key: &NodeKey) -> bool {
+        self.search_node(key).ok().is_some()
+    }
+
+    pub fn get(&self, key: &NodeKey) -> Result<Option<&ValueHash>, SMTError> {
+        let node = self.search_node(key)?;
+        Ok(node.map(|n| n.as_leaf().unwrap().value()))
+    }
+
+    /// Finds the branch node above the terminal node. The case of "no parent" is already covered, so there will
+    /// always be a branch node
+    fn find_terminal_branch(
+        &mut self,
+        child_key: &NodeKey,
+        mark_stale: bool,
+    ) -> Result<TerminalBranch<'_, H>, SMTError> {
+        let mut parent_node = &mut self.root;
+        let mut empty_siblings = Vec::new();
+        if !parent_node.is_branch() {
+            return Err(SMTError::UnexpectedNodeType);
+        }
+        let mut done = false;
+        let mut traverse_dir = TraverseDirection::Left;
+        while !done {
+            let branch = parent_node.as_branch_mut().unwrap();
+            if mark_stale {
+                branch.mark_as_stale();
+            }
+            traverse_dir = traverse_direction(branch.height(), branch.key(), child_key)?;
+            let next = match traverse_dir {
+                TraverseDirection::Left => {
+                    empty_siblings.push(branch.right().is_empty());
+                    branch.left()
+                },
+                TraverseDirection::Right => {
+                    empty_siblings.push(branch.left().is_empty());
+                    branch.right()
+                },
+            };
+            if next.is_branch() {
+                parent_node = match traverse_dir {
+                    TraverseDirection::Left => parent_node.as_branch_mut().unwrap().left_mut(),
+                    TraverseDirection::Right => parent_node.as_branch_mut().unwrap().right_mut(),
+                };
+            } else {
+                done = true;
+            }
+        }
+        let terminal = TerminalBranch {
+            parent: parent_node,
+            direction: traverse_dir,
+            empty_siblings,
+        };
+        Ok(terminal)
+    }
+
+    fn search_node(&self, key: &NodeKey) -> Result<Option<&Node<H>>, SMTError> {
+        let mut node = &self.root;
+        loop {
+            match node {
+                Branch(branch) => {
+                    let traverse_dir = traverse_direction(branch.height(), branch.key(), key)?;
+                    node = match traverse_dir {
+                        TraverseDirection::Left => branch.left(),
+                        TraverseDirection::Right => branch.right(),
+                    };
+                },
+                Leaf(leaf) => {
+                    return if leaf.key() == key { Ok(Some(node)) } else { Ok(None) };
+                },
+                Empty(_) => {
+                    return Ok(None);
+                },
+            }
+        }
+    }
+
+    fn attach_orphan_at_depth(&mut self, key: &NodeKey, height: usize, orphan: Node<H>) -> Result<(), SMTError> {
+        if height == 0 {
+            self.root = orphan;
+            return Ok(());
+        }
+        let mut node = &mut self.root;
+        for _ in 0..height {
+            let branch = node.as_branch_mut().ok_or(SMTError::UnexpectedNodeType)?;
+            branch.mark_as_stale();
+            let traverse_dir = traverse_direction(branch.height(), branch.key(), key)?;
+            node = match traverse_dir {
+                TraverseDirection::Left => branch.left_mut(),
+                TraverseDirection::Right => branch.right_mut(),
+            };
+        }
+        *node = orphan;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use digest::{consts::U32, generic_array::GenericArray, Digest};
+    use tari_crypto::hash::blake2::Blake256;
+
+    use crate::sparse_merkle_tree::{
+        tree::{DeleteResult, SparseMerkleTree},
+        NodeKey,
+        UpdateResult,
+        ValueHash,
+        EMPTY_NODE_HASH,
+    };
+
+    fn short_key(v: u8) -> NodeKey {
+        let mut key = [0u8; 32];
+        key[0] = v;
+        NodeKey::from(key)
+    }
+
+    fn leaf_hash(k: &NodeKey, v: &ValueHash) -> GenericArray<u8, U32> {
+        Blake256::new().chain(b"V").chain(k).chain(v).finalize()
+    }
+
+    fn branch_hash<B1, B2>(height: usize, key: &NodeKey, left: B1, right: B2) -> GenericArray<u8, U32>
+    where
+        B1: AsRef<[u8]>,
+        B2: AsRef<[u8]>,
+    {
+        Blake256::new()
+            .chain(b"B")
+            .chain(height.to_le_bytes())
+            .chain(key)
+            .chain(left)
+            .chain(right)
+            .finalize()
+    }
+
+    #[test]
+    fn empty_tree() {
+        let tree = SparseMerkleTree::<Blake256>::default();
+        assert_eq!(tree.size(), 0);
+        assert!(tree.root().is_empty());
+    }
+
+    #[test]
+    fn zero_key() {
+        let mut tree = SparseMerkleTree::<Blake256>::default();
+        let res = tree.upsert([0u8; 32].into(), [1u8; 32].into());
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    fn single_node() {
+        let mut tree = SparseMerkleTree::<Blake256>::default();
+        let key = short_key(1);
+        let value = ValueHash::from([1u8; 32]);
+        let res = tree.upsert(key.clone(), value.clone()).unwrap();
+        assert!(matches!(res, UpdateResult::Inserted));
+        assert_eq!(tree.size(), 1);
+
+        assert!(tree.contains(&key));
+        assert_eq!(tree.get(&key).unwrap().unwrap(), &value);
+        assert_eq!(
+            tree.root().unsafe_hash().to_string(),
+            "f0ba9d3fa2b32a56d356b851098a2c7cb077f56735371f98eabccd5ffb9da689"
+        );
+    }
+
+    #[test]
+    fn simple_branch() {
+        // A simple branch off the root with 2 leaf nodes
+        //           +------+
+        //     +-----+ root +-----+
+        //     |     +------+     |
+        //     |                  |
+        // +---+----+         +---+----+
+        // |0111: v1|         |1111: v2|
+        // +--------+         +--------+
+        let mut tree = SparseMerkleTree::<Blake256>::default();
+        let key1 = short_key(127);
+        let value1 = ValueHash::from([1u8; 32]);
+        let res = tree.upsert(key1.clone(), value1.clone()).unwrap();
+        assert!(matches!(res, UpdateResult::Inserted));
+        let key2 = short_key(255);
+        let value2 = ValueHash::from([2u8; 32]);
+        let res = tree.upsert(key2.clone(), value2.clone()).unwrap();
+        assert!(matches!(res, UpdateResult::Inserted));
+
+        assert!(tree.contains(&key1));
+        assert!(tree.contains(&key2));
+        let _ = tree.hash();
+        let left_hash = leaf_hash(&key1, &value1);
+        let right_hash = leaf_hash(&key2, &value2);
+        let expected = branch_hash(0, &short_key(0), left_hash, right_hash);
+        let root = tree.root();
+        assert_eq!(root.unsafe_hash().to_string(), format!("{:x}", expected));
+        assert!(root.is_branch());
+        let left = root.as_branch().unwrap().left().as_leaf().unwrap();
+        let right = root.as_branch().unwrap().right().as_leaf().unwrap();
+
+        assert_eq!(tree.size(), 2);
+        assert_eq!(left.key(), &key1);
+        // Hash is 0d4789822d0861b4d17cad16df7a9c4d0689c0f65ffd7352d576243b38ab6539
+        assert_eq!(left.hash().to_string(), format!("{left_hash:x}"));
+
+        assert_eq!(right.key(), &key2);
+        // Hash is e3f62f1bfccca2e03e3238cf22748d6a39a7e5eee1dd4b78e2fdd04b5c47d303
+        assert_eq!(right.hash().to_string(), format!("{right_hash:x}"));
+    }
+
+    #[test]
+    fn deep_divergent_nodes() {
+        // As with the simple branch test above, but now the keys only diverge several levels down
+        let mut tree = SparseMerkleTree::<Blake256>::default();
+        let key1 = short_key(79);
+        let value1 = ValueHash::from([1u8; 32]);
+        let res = tree.upsert(key1.clone(), value1.clone()).unwrap();
+        assert!(matches!(res, UpdateResult::Inserted));
+        let key2 = short_key(95);
+        let value2 = ValueHash::from([2u8; 32]);
+        let res = tree.upsert(key2.clone(), value2.clone()).unwrap();
+        assert!(matches!(res, UpdateResult::Inserted));
+
+        assert!(tree.contains(&key1));
+        assert!(tree.contains(&key2));
+        let _ = tree.hash();
+        let left_hash = leaf_hash(&key1, &value1);
+        let right_hash = leaf_hash(&key2, &value2);
+        // The keys are (95) 0101.1111 and (79) 0100.1111, so the first 3 bits are the same
+        // The tree should look like this after 2 inserts:
+        //         ┌──────┐
+        //      ┌──┤ root ├──┐
+        //      │  └──────┘  │
+        //     ┌┴┐          ┌┴┐
+        //  ┌──┤ ├──┐       │0│
+        //  │  └─┘  │       └─┘
+        // ┌┴┐     ┌┴┐
+        // │0│  ┌──┤ ├──┐
+        // └─┘  │  └─┘  │
+        //     ┌┴┐     ┌┴┐
+        //   ┌─┤ ├─┐   │0│
+        //   │ └─┘ │   └─┘
+        //  ┌┴┐   ┌┴┐
+        //  │A│   │B│
+        //  └─┘   └─┘
+        assert_eq!(tree.size(), 2);
+        let root = tree.root().as_branch().unwrap();
+        assert!(root.left().is_branch());
+        assert!(root.right().is_empty());
+        let level1 = root.left().as_branch().unwrap();
+        assert!(level1.left().is_empty());
+        let level2 = level1.right().as_branch().unwrap();
+        assert!(level2.right().is_empty());
+        let level3 = level2.left().as_branch().unwrap();
+        assert!(level3.left().is_leaf());
+        assert!(level3.right().is_leaf());
+        assert_eq!(
+            level3.left().as_leaf().unwrap().hash().to_string(),
+            format!("{left_hash:x}")
+        );
+        assert_eq!(
+            level3.right().as_leaf().unwrap().hash().to_string(),
+            format!("{right_hash:x}")
+        );
+        // Calculate the root hash, starting from level 3
+        let level3_hash = branch_hash(3, &short_key(64), left_hash, right_hash);
+        assert_eq!(level3.unsafe_hash().to_string(), format!("{level3_hash:x}"));
+        // Level 2
+        let level2_hash = branch_hash(2, &short_key(64), level3_hash, &EMPTY_NODE_HASH);
+        assert_eq!(level2.unsafe_hash().to_string(), format!("{level2_hash:x}"));
+        // Level 1
+        let level1_hash = branch_hash(1, &short_key(0), EMPTY_NODE_HASH, level2_hash);
+        assert_eq!(level1.unsafe_hash().to_string(), format!("{level1_hash:x}"));
+        // Root hash
+        let root_hash = branch_hash(0, &short_key(0), level1_hash, EMPTY_NODE_HASH);
+        let hash = tree.hash();
+        assert_eq!(hash.to_string(), format!("{root_hash:x}"));
+
+        // Now add C to right branch of root at key 11110000....
+        // The tree should look like this after 3 inserts:
+        //         ┌──────┐
+        //      ┌──┤ root ├──┐
+        //      │  └──────┘  │
+        //     ┌┴┐          ┌┴┐
+        //  ┌──┤ ├──┐       │C│
+        //  │  └─┘  │       └─┘
+        // ┌┴┐     ┌┴┐
+        // │0│  ┌──┤ ├──┐
+        // └─┘  │  └─┘  │
+        //     ┌┴┐     ┌┴┐
+        //   ┌─┤ ├─┐   │0│
+        //   │ └─┘ │   └─┘
+        //  ┌┴┐   ┌┴┐
+        //  │A│   │B│
+        //  └─┘   └─┘
+        let key_c = short_key(240);
+        let value_c = ValueHash::from([3u8; 32]);
+        let res = tree.upsert(key_c.clone(), value_c.clone()).unwrap();
+        assert!(matches!(res, UpdateResult::Inserted));
+        assert!(tree.contains(&key_c));
+        assert_eq!(tree.size(), 3);
+
+        assert!(tree.root().as_branch().unwrap().is_stale());
+        let hash = tree.hash();
+        let hash_c = leaf_hash(&key_c, &value_c);
+        let expected_hash = branch_hash(0, &short_key(0), level1_hash, hash_c);
+        assert_eq!(hash.to_string(), format!("{expected_hash:x}"));
+        // Now insert another value causing a cascade of branches down the right:
+        //            ┌──────┐
+        //      ┌─────┤ root ├─────┐
+        //      │     └──────┘     │
+        //     ┌┴┐                ┌┴┐1
+        //  ┌──┤ ├──┐          ┌──┤ ├───┐
+        //  │  └─┘  │          │  └─┘   │
+        // ┌┴┐     ┌┴┐        ┌┴┐10    ┌┴┐11
+        // │0│  ┌──┤ ├──┐     │0│    ┌─┤ ├─┐
+        // └─┘  │  └─┘  │     └─┘    │ └─┘ │
+        //     ┌┴┐     ┌┴┐       110┌┴┐   ┌┴┐111
+        //   ┌─┤ ├─┐   │0│          │0│ ┌─┤ ├─┐
+        //   │ └─┘ │   └─┘          └─┘ │ └─┘ │
+        //  ┌┴┐   ┌┴┐                  ┌┴┐   ┌┴┐
+        //  │A│   │B│                  │D│   │C│
+        //  └─┘   └─┘                  └─┘   └─┘
+        // 11100000 in decimal is 224, so the first 3 bits are the same
+        let key4 = short_key(224);
+        let value4 = ValueHash::from([4u8; 32]);
+        let res = tree.upsert(key4.clone(), value4.clone()).unwrap();
+        let root = tree.hash().to_string();
+        assert!(matches!(res, UpdateResult::Inserted));
+        assert!(tree.contains(&key4));
+        assert_eq!(tree.size(), 4);
+
+        let hash_d = leaf_hash(&key4, &value4);
+        let level3_hash = branch_hash(3, &short_key(224), hash_d, hash_c);
+        let level2_hash = branch_hash(2, &short_key(192), &EMPTY_NODE_HASH, level3_hash);
+        let level1r_hash = branch_hash(1, &short_key(128), &EMPTY_NODE_HASH, level2_hash);
+        let root_hash = branch_hash(0, &short_key(0), level1_hash, level1r_hash);
+
+        let level1 = tree.root().as_branch().unwrap().right().as_branch().unwrap();
+        let level2 = level1.right().as_branch().unwrap();
+        let level3 = level2.right().as_branch().unwrap();
+
+        assert_eq!(level3.unsafe_hash().to_string(), format!("{level3_hash:x}"));
+        assert_eq!(level2.unsafe_hash().to_string(), format!("{level2_hash:x}"));
+        assert_eq!(level1.unsafe_hash().to_string(), format!("{level1r_hash:x}"));
+        assert_eq!(root, format!("{root_hash:x}"));
+    }
+
+    #[test]
+    fn order_does_not_matter() {
+        let mut tree = SparseMerkleTree::<Blake256>::new();
+        tree.upsert(short_key(42), ValueHash::from([4u8; 32])).unwrap();
+        tree.upsert(short_key(24), ValueHash::from([2u8; 32])).unwrap();
+        let hash1 = tree.hash().clone();
+
+        let mut tree = SparseMerkleTree::<Blake256>::new();
+        tree.upsert(short_key(24), ValueHash::from([2u8; 32])).unwrap();
+        tree.upsert(short_key(42), ValueHash::from([4u8; 32])).unwrap();
+        let hash2 = tree.hash().clone();
+
+        assert_eq!(hash1, hash2);
+    }
+
+    #[test]
+    fn delete_empty_tree() {
+        let mut tree = SparseMerkleTree::<Blake256>::new();
+        let key = short_key(42);
+        assert!(matches!(tree.delete(&key), Ok(DeleteResult::KeyNotFound)));
+    }
+
+    #[test]
+    fn delete_single_node() {
+        let mut tree = SparseMerkleTree::<Blake256>::new();
+        let key = short_key(42);
+        let value = ValueHash::from([1u8; 32]);
+        tree.upsert(key.clone(), value.clone()).unwrap();
+        assert_eq!(tree.size(), 1);
+        assert!(tree.contains(&key));
+        let res = tree.delete(&key);
+        assert!(matches!(res, Ok(DeleteResult::Deleted(node)) if node == value));
+        assert_eq!(tree.size(), 0);
+    }
+
+    #[test]
+    fn delete_deep_node() {
+        // Start with
+        //            ┌──────┐
+        //      ┌─────┤ root ├─────┐
+        //      │     └──────┘     │
+        //     ┌┴┐                ┌┴┐1
+        //  ┌──┤ ├──┐          ┌──┤ ├───┐
+        //  │  └─┘  │          │  └─┘   │
+        // ┌┴┐     ┌┴┐        ┌┴┐10    ┌┴┐11
+        // │0│  ┌──┤ ├──┐     │0│    ┌─┤ ├─┐
+        // └─┘  │  └─┘  │     └─┘    │ └─┘ │
+        //     ┌┴┐     ┌┴┐       110┌┴┐   ┌┴┐111
+        //   ┌─┤ ├─┐   │0│          │0│ ┌─┤ ├─┐
+        //   │ └─┘ │   └─┘          └─┘ │ └─┘ │
+        //  ┌┴┐   ┌┴┐                  ┌┴┐   ┌┴┐
+        //  │A│   │B│                  │D│   │C│
+        //  └─┘   └─┘                  └─┘   └─┘
+        let mut tree = SparseMerkleTree::<Blake256>::default();
+        tree.upsert(short_key(79), ValueHash::from([1u8; 32])).unwrap();
+        tree.upsert(short_key(95), ValueHash::from([2u8; 32])).unwrap();
+        tree.upsert(short_key(240), ValueHash::from([3u8; 32])).unwrap();
+        tree.upsert(short_key(224), ValueHash::from([4u8; 32])).unwrap();
+
+        // root hash is e88862dc2d50248e7830924c1c415e9789069ae451f9eb5e437fdd2d6dffd4dd
+        assert_eq!(
+            tree.hash().to_string(),
+            "e88862dc2d50248e7830924c1c415e9789069ae451f9eb5e437fdd2d6dffd4dd"
+        );
+
+        // Now deleting D should yield
+        //            ┌──────┐
+        //      ┌─────┤ root ├─────┐
+        //      │     └──────┘     │
+        //     ┌┴┐                ┌┴┐
+        //  ┌──┤ ├──┐             │C│
+        //  │  └─┘  │             └─┘
+        // ┌┴┐     ┌┴┐
+        // │0│  ┌──┤ ├──┐
+        // └─┘  │  └─┘  │
+        //     ┌┴┐     ┌┴┐
+        //   ┌─┤ ├─┐   │0│
+        //   │ └─┘ │   └─┘
+        //  ┌┴┐   ┌┴┐
+        //  │A│   │B│
+        //  └─┘   └─┘
+        // Root hash is e693520b5ba4ff8b1e37ae4feabcb54701f32efd6bc4b78db356fa9baa64ca99
+        let res = tree.delete(&short_key(224)).unwrap();
+        assert_eq!(res, DeleteResult::Deleted(ValueHash::from([4u8; 32])));
+        assert_eq!(
+            tree.hash().to_string(),
+            "e693520b5ba4ff8b1e37ae4feabcb54701f32efd6bc4b78db356fa9baa64ca99"
+        );
+        assert_eq!(tree.size(), 3);
+    }
+
+    #[test]
+    fn delete_highly_branched() {
+        let mut tree = SparseMerkleTree::<Blake256>::default();
+        tree.upsert(short_key(65), ValueHash::from([1u8; 32])).unwrap();
+        tree.upsert(short_key(79), ValueHash::from([1u8; 32])).unwrap();
+        let hash2 = tree.hash().clone();
+        tree.upsert(short_key(240), ValueHash::from([3u8; 32])).unwrap();
+        tree.upsert(short_key(224), ValueHash::from([4u8; 32])).unwrap();
+        let hash4 = tree.hash().clone();
+        tree.upsert(short_key(95), ValueHash::from([2u8; 32])).unwrap();
+        assert_eq!(tree.size(), 5);
+
+        let res = tree.delete(&short_key(95)).unwrap();
+        assert_eq!(res, DeleteResult::Deleted(ValueHash::from([2u8; 32])));
+        assert_eq!(tree.hash(), &hash4);
+
+        let _ = tree.delete(&short_key(240)).unwrap();
+        let _ = tree.delete(&short_key(224)).unwrap();
+        assert_eq!(tree.hash(), &hash2);
+        let _ = tree.delete(&short_key(79)).unwrap();
+        let _ = tree.delete(&short_key(65)).unwrap();
+        assert!(tree.is_empty());
+    }
+}

--- a/lints.toml
+++ b/lints.toml
@@ -66,5 +66,7 @@ allow = [
     'clippy::default_trait_access',
     # Generally when developers fix this, it can lead to leaky abstractions or worse, so
     # too many arguments is generally the lesser of two evils
-    'clippy::too_many_arguments'
+    'clippy::too_many_arguments',
+    # `assert!(!foo(bar))` is misread the majority of the time, while `assert_eq!(foo(bar), false)` is crystal clear
+    'clippy::bool-assert-comparison',
 ]


### PR DESCRIPTION
# Sparse Merkle trees 

## Description

A sparse Merkle tree is a Merkle tree where the non-empty nodes are stored in a map with the key being the hash
of the node and the value being the node itself.

Merkle trees are a mutable Merkle-ish tree structure, that supports full CRUD operations.

### Todo in this PR

* [x] Insert new values
* [x] Update existing values
* [x] Delete values
* [x] Inclusion proofs 
* [x] exclusion proofs.
* [x] Benchmarks

This implementation assumed that there is a key-value store elsewhere. Only the tree hashes themselves are
handled in this data structure.

When constructing a new tree, a hashing algorithm is specified. This is used to hash the non-leaf nodes. The
"values" provided to the tree must already be a hash, and should have been generated from a different hashing
algorithm to the one driving the tree, in order to prevent second pre-image attacks.

## Motivation and Context

tl;dr:
* Bandwidth  savings
* Scalability benefits
* Privacy benefits
* Compact inclusion _and_ exclusion proofs!

### Details
The SMT implementation is faster than `MutableMMR` up to around 10,000
nodes, and then the average depth starts to affect it. By 1,000,000
nodes, it is significantly slower than MMR.

This makes sense since MMR is basically O(1) for inserts, while SMT is O(log(n)).

You can see some results here:

```text
Starting: SMT: Inserting 1000000 keys
Finished: SMT: Inserting 1000000 keys - 1.921310493s
Starting: SMT: Calculating root hash
Tree size: 1000000. Root hash: 3e42ca40df366db52464c19b6ba71428976a56d7b120bc3c882fc29bf05dc1d7
Finished: SMT: Calculating root hash - 644.226062ms
Starting: SMT: Deleting 500000 keys
Finished: SMT: Deleting 500000 keys - 863.873761ms
Starting: SMT: Calculating root hash
Tree size: 500000. Root hash: 2a7b51f114a17c229f1067feb4ba5b6aad975689160a5eab0d90f89a3bcf09f8
Finished: SMT: Calculating root hash - 207.30907ms
Starting: SMT: Deleting another 500000 keys
Finished: SMT: Deleting another 500000 keys - 850.606501ms
Starting: SMT: Calculating root hash
Tree size: 0. Root hash: 0000000000000000000000000000000000000000000000000000000000000000
Finished: SMT: Calculating root hash - 3.892µs
Starting: MMR: Inserting 1000000 keys
Finished: MMR: Inserting 1000000 keys - 741.641704ms
Starting: SMT: Calculating root hash
Tree size: 1000000. Root hash: da6135ccaabf146024cae1b0e7ad6ba7e9dad79724fb9199b721d4cd243ba999
Finished: SMT: Calculating root hash - 8.649µs
Starting: MMR: Deleting 500000 keys
Finished: MMR: Deleting 500000 keys - 6.525858ms
Starting: SMT: Calculating root hash
Tree size: 500000. Root hash: fd60e168f27acba374109de9b8231e7252f0cfdf385f87dbfd92873d4956c995
Finished: SMT: Calculating root hash - 50.276µs
Starting: MMR: Deleting another 500000 keys
Finished: MMR: Deleting another 500000 keys - 6.862469ms
Starting: SMT: Calculating root hash
Tree size: 0. Root hash: 5d70f3177a0b46ea1b853c58d5e3f7d6e78cbc4149d71592bb6cea63d50ed96c
Finished: SMT: Calculating root hash - 93.618µs
```

SMT is taking 1.92s to insert 1 mil nodes, or 1.9us per node on average.

Still pretty rapid. Of course this nice thing here is that when we _delete_ all the nodes, the SMT hash is `000...`, which is the best part. The MMMR will never have a hash that's the same after adding, and then deleting the same node because of its bitmap tracking deleted entries :(

I also compared my SMT implementation to one on crates.io, and while it's hard to compare apples to apples (sparse-merkle-tree is really a KV store), my implementation is much, much faster. sparse-merkle-tree adds
10,000 nodes in ~1500ms, while my impl takes ~9ms plus 6ms for calculating the merkle root.

In terms of **space**, the SMT is much more efficient that MMMRs. To calculate the root of the UTXO set, for example, all you need is the UTXO set itself.

Imagine that there are 1,000,000 UTXOs, with another 2,000,000 UTXOs having being spent over the lifetime of the project.

If each UTXO hash is 32 bytes, you need serialize 32MB to recreate the merkle root for the SMT.

For the MMMR, you need all 3,000,0000 hashes (96MB) plus approximately 1MB for every million hashes in a bitmap to indicate which hashes have been deleted (3 MB) for a total of 100MB.

This only gets worse with time.

And keeping STXO hashes around forever -- that's not super great for privacy.

So even though the SMT is slower, it is still fast enough. The bandwidth savings are substantial and the privacy benefits are significant.


How Has This Been Tested?
---

Tests and benchmarks

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

This does not break anything right now. The intention is to write an RFC and then eventually replace the Output merkle tree with this data structure. That would be a breaking change though.

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
