### PR TITLE
feat: prevent compilation on non-64bit systems

### DIFF
--- a/applications/tari_base_node/src/main.rs
+++ b/applications/tari_base_node/src/main.rs
@@ -85,6 +85,10 @@ const LOG_TARGET: &str = "tari::base_node::app";
 
 /// Application entry point
 fn main() {
+    // Only compile on 64bit systems
+    #[cfg(not(target_pointer_width = "64"))]
+    compile_error!("Non 64-bit systems are not supported.");
+
     // Setup a panic hook which prints the default rust panic message but also exits the process. This makes a panic in
     // any thread "crash" the system instead of silently continuing.
     let default_hook = panic::take_hook();

--- a/applications/tari_console_wallet/src/main.rs
+++ b/applications/tari_console_wallet/src/main.rs
@@ -47,6 +47,10 @@ mod utils;
 mod wallet_modes;
 
 fn main() {
+    // Only compile on 64bit systems
+    #[cfg(not(target_pointer_width = "64"))]
+    compile_error!("Non 64-bit systems are not supported.");
+
     // Setup a panic hook which prints the default rust panic message but also exits the process. This makes a panic in
     // any thread "crash" the system instead of silently continuing.
     let default_hook = panic::take_hook();


### PR DESCRIPTION
Description
---
generate a compile error when attempting to compile on a non-64-bit system, specifically 32 bit systems are not supported.

How Has This Been Tested?
---
I inverted the condition and verified that it fails on a 64 bit system

What process can a PR reviewer use to test or verify this change?
---
Same as above.

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
