### PR TITLE
ci: remove duplicate test jobs on push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,6 @@ name: CI
 
 'on':
   workflow_dispatch:
-  push:
-    branches:
-      - development
-      - main
-      - ci-*
   pull_request:
     types:
       - opened

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -8,9 +8,6 @@ name: Integration tests
       - reopened
       - synchronize
   merge_group:
-  push:
-    paths-ignore:
-      - '**/*.md'
   schedule:
     - cron: '0 2 * * *'   # daily @ 02h00 (non-critical)
     - cron: '0 12 * * 6'  # weekly - Saturday @ noon (long-running)


### PR DESCRIPTION
Description
---
Remove the testing jobs from github pushes

Motivation and Context
---
These tests are already done for PRs and are duplicated if you push to a branch on the main fork.

How Has This Been Tested?
---
will use CI to verify it works

What process can a PR reviewer use to test or verify this change?
---
Unfortunately, this is a CI only change

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
