### PR TITLE
fix(wallet): use correct output features for send to self

### DIFF
--- a/applications/tari_console_wallet/Cargo.toml
+++ b/applications/tari_console_wallet/Cargo.toml
@@ -35,7 +35,7 @@ config = "0.13.0"
 crossterm = { version = "0.25.0" }
 digest = "0.9.0"
 futures = { version = "^0.3.16", default-features = false, features = ["alloc"] }
-log4rs = { version = "1.2.0", default_features = false, features = ["config_parsing", "threshold_filter", "yaml_format", "console_appender", "rolling_file_appender", "compound_policy", "size_trigger", "fixed_window_roller"] }
+log4rs = { version = "1.2.0", default_features = false, features = ["config_parsing", "threshold_filter", "yaml_format", "console_appender", "rolling_file_appender", "compound_policy", "size_trigger", "fixed_window_roller", "delete_roller"] }
 log = { version = "0.4.8", features = ["std"] }
 qrcode = { version = "0.12" }
 rand = "0.7.3"


### PR DESCRIPTION
Description
---
Uses the given output features for send to self transactions.

Also added `delete_roller` for `log4rs`.

Motivation and Context
---
Send to self would previously discard the output features, using default instead.

fixes #5471 

My console wallet would panic on startup because the default log config used delete roller.

How Has This Been Tested?
---
Manually, registered a validator node, observed output with correct features

What process can a PR reviewer use to test or verify this change?
---
Call register_validator_node grpc

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
