### PR TITLE
ci(fix): build only bins and include in archive/packages

### DIFF
--- a/.github/workflows/base_node_binaries.json
+++ b/.github/workflows/base_node_binaries.json
@@ -6,6 +6,7 @@
     "target": "x86_64-unknown-linux-gnu",
     "cross": false,
     "target_cpu": "x86-64",
+    "target_bins": "--bin tari_base_node --bin tari_console_wallet --bin tari_merge_mining_proxy --bin tari_miner",
     "features": "safe"
   },
   {
@@ -14,9 +15,10 @@
     "rust": "stable",
     "target": "aarch64-unknown-linux-gnu",
     "cross": true,
-    "target_bins": "--bin tari_base_node --bin tari_console_wallet --bin tari_merge_mining_proxy --bin tari_miner",
     "target_cpu": "generic",
-    "features": "safe"
+    "features": "safe",
+    "target_bins": "--bin tari_base_node --bin tari_console_wallet --bin tari_merge_mining_proxy --bin tari_miner",
+    "flags": "--workspace --exclude tari_mining_helper_ffi --exclude tari_integration_tests"
   },
   {
     "name": "macos-x86_64",
@@ -25,6 +27,7 @@
     "target": "x86_64-apple-darwin",
     "cross": false,
     "target_cpu": "x86-64",
+    "target_bins": "--bin tari_base_node --bin tari_console_wallet --bin tari_merge_mining_proxy --bin tari_miner",
     "features": "safe"
   },
   {
@@ -34,6 +37,7 @@
     "target": "aarch64-apple-darwin",
     "cross": false,
     "target_cpu": "generic",
+    "target_bins": "--bin tari_base_node --bin tari_console_wallet --bin tari_merge_mining_proxy --bin tari_miner",
     "features": "safe"
   },
   {
@@ -44,6 +48,7 @@
     "cross": false,
     "target_cpu": "x86-64",
     "features": "safe",
+    "target_bins": "--bin tari_base_node --bin tari_console_wallet --bin tari_merge_mining_proxy --bin tari_miner",
     "flags": "--workspace --exclude tari_libtor"
   },
   {

--- a/.github/workflows/base_node_binaries.yml
+++ b/.github/workflows/base_node_binaries.yml
@@ -154,7 +154,6 @@ jobs:
           echo "SHARUN=shasum --algorithm 256" >> $GITHUB_ENV
           echo "CC=gcc" >> $GITHUB_ENV
           echo "TBN_EXT=" >> $GITHUB_ENV
-          echo "LIB_PRE=lib" >> $GITHUB_ENV
           echo "SHELL_EXT=.sh" >> $GITHUB_ENV
           echo "PLATFORM_SPECIFIC_DIR=linux" >> $GITHUB_ENV
           echo "TBN_DIST=/dist" >> $GITHUB_ENV
@@ -186,7 +185,6 @@ jobs:
           echo "SHARUN=pwsh C:\ProgramData\chocolatey\lib\psutils\tools\psutils-master\shasum.ps1 --algorithm 256" >> $GITHUB_ENV
           echo "TBN_EXT=.exe" >> $GITHUB_ENV
           echo "LIB_EXT=.dll" >> $GITHUB_ENV
-          echo "LIB_PRE=" >> $GITHUB_ENV
           echo "SHELL_EXT=.bat" >> $GITHUB_ENV
           echo "TBN_DIST=\dist" >> $GITHUB_ENV
           echo "PLATFORM_SPECIFIC_DIR=windows" >> $GITHUB_ENV
@@ -245,9 +243,6 @@ jobs:
               cp -v "$GITHUB_WORKSPACE/target/${{ matrix.builds.target }}/release/${FILE}${TBN_EXT}" .
             fi
           done
-          if [ -f "$GITHUB_WORKSPACE/target/${{ matrix.builds.target }}/release/${LIB_PRE}tari_mining_helper_ffi${LIB_EXT}" ]; then
-            cp -v "$GITHUB_WORKSPACE/target/${{ matrix.builds.target }}/release/${LIB_PRE}tari_mining_helper_ffi${LIB_EXT}" .
-          fi
           if [ -f "$GITHUB_WORKSPACE/applications/tari_base_node/${PLATFORM_SPECIFIC_DIR}/runtime/start_tor${SHELL_EXT}" ]; then
             cp -v "$GITHUB_WORKSPACE/applications/tari_base_node/${PLATFORM_SPECIFIC_DIR}/runtime/start_tor${SHELL_EXT}" .
           fi


### PR DESCRIPTION
Description
Limit build to only binaries that are included in the archives and packages

Motivation and Context
In the name of efficiency, which save about 30% of build time if we only build the binaries packaged

How Has This Been Tested?
Built in local fork and used archive to run a local node, wallet and miner.

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---
Removed tari_mining_helper_ffi from archives and packages

- [ ] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [x] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
