### PR TITLE
feat: use caching across entire ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo bash scripts/install_ubuntu_dependencies.sh
+      - uses: Swatinem/rust-cache@v2
       - name: cargo format
         run: cargo fmt --all -- --check
       - name: Install cargo-lints
@@ -59,6 +60,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo bash scripts/install_ubuntu_dependencies.sh
+      - uses: Swatinem/rust-cache@v2
       - name: cargo machete
         run: |
           cargo install cargo-machete
@@ -73,6 +75,7 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.toolchain }}
+      - uses: Swatinem/rust-cache@v2
       - name: ubuntu dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo bash scripts/install_ubuntu_dependencies.sh
+      - uses: Swatinem/rust-cache@v2
       - name: test key manager wasm
         run: |
           cd base_layer/key_manager


### PR DESCRIPTION
Github actions allows caching, which can dramatically speed up CI runtimes by caching compiled versions of our dependencies.

Caches were not being used in every step of the `ci` workflow. This PR adds this everywhere, so expect to see significant speedups.

The caching works well, so no need to run the "build_dependencies" step, which was a poor man's attempt to perform caching by create a docker container with just the compiled dependencies. At best this wasn't really working, and at worse was busting caches.

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
