### PR TITLE
perf: speed up slow test

### DIFF
--- a/base_layer/core/src/transactions/transaction_protocol/transaction_initializer.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/transaction_initializer.rs
@@ -56,6 +56,7 @@ use crate::{
 };
 
 pub const LOG_TARGET: &str = "c::tx::tx_protocol::tx_initializer";
+
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub(super) struct ChangeDetails {
     change_spending_key_id: TariKeyId,
@@ -64,6 +65,7 @@ pub(super) struct ChangeDetails {
     change_script_key_id: TariKeyId,
     change_covenant: Covenant,
 }
+
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub(super) struct RecipientDetails {
     pub amount: MicroTari,
@@ -791,10 +793,9 @@ mod test {
             .await
             .unwrap()
             .with_fee_per_gram(MicroTari(2));
-
+        let input_base = create_test_input(MicroTari(50), 0, &key_manager).await;
         for _ in 0..=MAX_TRANSACTION_INPUTS {
-            let input = create_test_input(MicroTari(50), 0, &key_manager).await;
-            builder.with_input(input).await.unwrap();
+            builder.with_input(input_base.clone()).await.unwrap();
         }
         let err = builder.build().await.unwrap_err();
         assert_eq!(err.message, "Too many inputs in transaction");


### PR DESCRIPTION
`too_many_inputs` just tests the number of inputs in a tx, not that they're valid. Moving the expensive input generation call out of the hot loop reduces the test speed from 5-7minutes to 0.6s

You're welcome :)

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
