### PR TITLE
chore: version bump development to 0.51.0-pre.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5095,7 +5095,7 @@ dependencies = [
 
 [[package]]
 name = "tari_app_grpc"
-version = "0.51.0-pre.1"
+version = "0.51.0-pre.2"
 dependencies = [
  "argon2",
  "base64 0.13.1",
@@ -5119,7 +5119,7 @@ dependencies = [
 
 [[package]]
 name = "tari_app_utilities"
-version = "0.51.0-pre.1"
+version = "0.51.0-pre.2"
 dependencies = [
  "clap 3.2.25",
  "futures 0.3.28",
@@ -5138,7 +5138,7 @@ dependencies = [
 
 [[package]]
 name = "tari_base_node"
-version = "0.51.0-pre.1"
+version = "0.51.0-pre.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5235,7 +5235,7 @@ dependencies = [
 
 [[package]]
 name = "tari_chat_client"
-version = "0.51.0-pre.1"
+version = "0.51.0-pre.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5259,7 +5259,7 @@ dependencies = [
 
 [[package]]
 name = "tari_chat_ffi"
-version = "0.51.0-pre.1"
+version = "0.51.0-pre.2"
 dependencies = [
  "cbindgen 0.24.5",
  "libc",
@@ -5277,7 +5277,7 @@ dependencies = [
 
 [[package]]
 name = "tari_common"
-version = "0.51.0-pre.1"
+version = "0.51.0-pre.2"
 dependencies = [
  "anyhow",
  "blake2 0.9.2",
@@ -5304,7 +5304,7 @@ dependencies = [
 
 [[package]]
 name = "tari_common_sqlite"
-version = "0.51.0-pre.1"
+version = "0.51.0-pre.2"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -5318,7 +5318,7 @@ dependencies = [
 
 [[package]]
 name = "tari_common_types"
-version = "0.51.0-pre.1"
+version = "0.51.0-pre.2"
 dependencies = [
  "base64 0.21.2",
  "borsh",
@@ -5337,7 +5337,7 @@ dependencies = [
 
 [[package]]
 name = "tari_comms"
-version = "0.51.0-pre.1"
+version = "0.51.0-pre.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5387,7 +5387,7 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_dht"
-version = "0.51.0-pre.1"
+version = "0.51.0-pre.2"
 dependencies = [
  "anyhow",
  "bitflags 1.3.2",
@@ -5431,7 +5431,7 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_rpc_macros"
-version = "0.51.0-pre.1"
+version = "0.51.0-pre.2"
 dependencies = [
  "futures 0.3.28",
  "proc-macro2",
@@ -5446,7 +5446,7 @@ dependencies = [
 
 [[package]]
 name = "tari_console_wallet"
-version = "0.51.0-pre.1"
+version = "0.51.0-pre.2"
 dependencies = [
  "bitflags 1.3.2",
  "chrono",
@@ -5499,7 +5499,7 @@ dependencies = [
 
 [[package]]
 name = "tari_contacts"
-version = "0.51.0-pre.1"
+version = "0.51.0-pre.2"
 dependencies = [
  "chrono",
  "diesel",
@@ -5530,7 +5530,7 @@ dependencies = [
 
 [[package]]
 name = "tari_core"
-version = "0.51.0-pre.1"
+version = "0.51.0-pre.2"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5631,7 +5631,7 @@ dependencies = [
 
 [[package]]
 name = "tari_features"
-version = "0.51.0-pre.1"
+version = "0.51.0-pre.2"
 
 [[package]]
 name = "tari_integration_tests"
@@ -5682,7 +5682,7 @@ dependencies = [
 
 [[package]]
 name = "tari_key_manager"
-version = "0.51.0-pre.1"
+version = "0.51.0-pre.2"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5736,7 +5736,7 @@ dependencies = [
 
 [[package]]
 name = "tari_merge_mining_proxy"
-version = "0.51.0-pre.1"
+version = "0.51.0-pre.2"
 dependencies = [
  "anyhow",
  "bincode",
@@ -5786,7 +5786,7 @@ dependencies = [
 
 [[package]]
 name = "tari_miner"
-version = "0.51.0-pre.1"
+version = "0.51.0-pre.2"
 dependencies = [
  "base64 0.13.1",
  "borsh",
@@ -5822,7 +5822,7 @@ dependencies = [
 
 [[package]]
 name = "tari_mining_helper_ffi"
-version = "0.51.0-pre.1"
+version = "0.51.0-pre.2"
 dependencies = [
  "borsh",
  "hex",
@@ -5838,7 +5838,7 @@ dependencies = [
 
 [[package]]
 name = "tari_mmr"
-version = "0.51.0-pre.1"
+version = "0.51.0-pre.2"
 dependencies = [
  "bincode",
  "blake2 0.9.2",
@@ -5858,7 +5858,7 @@ dependencies = [
 
 [[package]]
 name = "tari_p2p"
-version = "0.51.0-pre.1"
+version = "0.51.0-pre.2"
 dependencies = [
  "anyhow",
  "clap 3.2.25",
@@ -5912,7 +5912,7 @@ dependencies = [
 
 [[package]]
 name = "tari_service_framework"
-version = "0.51.0-pre.1"
+version = "0.51.0-pre.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5929,7 +5929,7 @@ dependencies = [
 
 [[package]]
 name = "tari_shutdown"
-version = "0.51.0-pre.1"
+version = "0.51.0-pre.2"
 dependencies = [
  "futures 0.3.28",
  "tokio",
@@ -5937,7 +5937,7 @@ dependencies = [
 
 [[package]]
 name = "tari_storage"
-version = "0.51.0-pre.1"
+version = "0.51.0-pre.2"
 dependencies = [
  "bincode",
  "lmdb-zero",
@@ -5950,7 +5950,7 @@ dependencies = [
 
 [[package]]
 name = "tari_test_utils"
-version = "0.51.0-pre.1"
+version = "0.51.0-pre.2"
 dependencies = [
  "futures 0.3.28",
  "futures-test",
@@ -5982,7 +5982,7 @@ dependencies = [
 
 [[package]]
 name = "tari_wallet"
-version = "0.51.0-pre.1"
+version = "0.51.0-pre.2"
 dependencies = [
  "argon2",
  "async-trait",
@@ -6032,7 +6032,7 @@ dependencies = [
 
 [[package]]
 name = "tari_wallet_ffi"
-version = "0.51.0-pre.1"
+version = "0.51.0-pre.2"
 dependencies = [
  "borsh",
  "cbindgen 0.24.5",

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The recommended running versions of each network are:
 |-----------|--------------|
 | Stagenet  | 0.49.0       |
 | Nextnet   | 0.50.0-rc.0  |
-| Esmeralda | 0.51.0-pre.0 |
+| Esmeralda | 0.51.0-pre.2 |
 
 For more detail about versioning see [Release Ideology](https://github.com/tari-project/tari/blob/development/docs/src/branching_releases.md)
 

--- a/applications/tari_app_grpc/Cargo.toml
+++ b/applications/tari_app_grpc/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "This crate is to provide a single source for all cross application grpc files and conversions to and from tari::core"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.51.0-pre.1"
+version = "0.51.0-pre.2"
 edition = "2018"
 
 [dependencies]

--- a/applications/tari_app_utilities/Cargo.toml
+++ b/applications/tari_app_utilities/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_app_utilities"
-version = "0.51.0-pre.1"
+version = "0.51.0-pre.2"
 authors = ["The Tari Development Community"]
 edition = "2018"
 license = "BSD-3-Clause"
@@ -9,7 +9,7 @@ license = "BSD-3-Clause"
 tari_common = { path = "../../common" }
 tari_common_types = { path = "../../base_layer/common_types" }
 tari_comms = { path = "../../comms/core" }
-tari_features = { version = "0.51.0-pre.1", path = "../../common/tari_features"}
+tari_features = { version = "0.51.0-pre.2", path = "../../common/tari_features"}
 tari_utilities = { version = "0.4.10"}
 
 clap = { version = "3.2", features = ["derive", "env"] }
@@ -23,4 +23,4 @@ thiserror = "^1.0.26"
 
 [build-dependencies]
 tari_common = { path = "../../common", features = ["build", "static-application-info"] }
-tari_features = { version = "0.51.0-pre.1", path = "../../common/tari_features"}
+tari_features = { version = "0.51.0-pre.2", path = "../../common/tari_features"}

--- a/applications/tari_base_node/Cargo.toml
+++ b/applications/tari_base_node/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "The tari full base node implementation"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.51.0-pre.1"
+version = "0.51.0-pre.2"
 edition = "2018"
 
 [dependencies]
@@ -59,7 +59,7 @@ safe = []
 libtor = ["tari_libtor"]
 
 [build-dependencies]
-tari_features = { version = "0.51.0-pre.1", path = "../../common/tari_features"}
+tari_features = { version = "0.51.0-pre.2", path = "../../common/tari_features"}
 
 [package.metadata.cargo-machete]
 ignored = [

--- a/applications/tari_console_wallet/Cargo.toml
+++ b/applications/tari_console_wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_console_wallet"
-version = "0.51.0-pre.1"
+version = "0.51.0-pre.2"
 authors = ["The Tari Development Community"]
 edition = "2018"
 license = "BSD-3-Clause"
@@ -67,7 +67,7 @@ default-features = false
 features = ["crossterm"]
 
 [build-dependencies]
-tari_features = { version = "0.51.0-pre.1", path = "../../common/tari_features"}
+tari_features = { version = "0.51.0-pre.2", path = "../../common/tari_features"}
 
 [features]
 avx2 = ["tari_core/avx2", "tari_crypto/simd_backend", "tari_wallet/avx2", "tari_comms/avx2", "tari_comms_dht/avx2", "tari_p2p/avx2", "tari_key_manager/avx2"]

--- a/applications/tari_merge_mining_proxy/Cargo.toml
+++ b/applications/tari_merge_mining_proxy/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "The Tari merge mining proxy for xmrig"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.51.0-pre.1"
+version = "0.51.0-pre.2"
 edition = "2018"
 
 [features]
@@ -42,4 +42,4 @@ tracing = "0.1"
 url = "2.1.1"
 
 [build-dependencies]
-tari_features = { version = "0.51.0-pre.1", path = "../../common/tari_features"}
+tari_features = { version = "0.51.0-pre.2", path = "../../common/tari_features"}

--- a/applications/tari_miner/Cargo.toml
+++ b/applications/tari_miner/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "The tari miner implementation"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.51.0-pre.1"
+version = "0.51.0-pre.2"
 edition = "2018"
 
 [dependencies]

--- a/base_layer/chat_ffi/Cargo.toml
+++ b/base_layer/chat_ffi/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_chat_ffi"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency chat C FFI bindings"
 license = "BSD-3-Clause"
-version = "0.51.0-pre.1"
+version = "0.51.0-pre.2"
 edition = "2018"
 
 [dependencies]

--- a/base_layer/common_types/Cargo.toml
+++ b/base_layer/common_types/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_common_types"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency common types"
 license = "BSD-3-Clause"
-version = "0.51.0-pre.1"
+version = "0.51.0-pre.2"
 edition = "2018"
 
 [dependencies]

--- a/base_layer/contacts/Cargo.toml
+++ b/base_layer/contacts/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_contacts"
 authors = ["The Tari Development Community"]
 description = "Tari contacts library"
 license = "BSD-3-Clause"
-version = "0.51.0-pre.1"
+version = "0.51.0-pre.2"
 edition = "2018"
 
 [dependencies]

--- a/base_layer/contacts/examples/chat_client/Cargo.toml
+++ b/base_layer/contacts/examples/chat_client/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_chat_client"
 authors = ["The Tari Development Community"]
 description = "Tari cucumber chat client"
 license = "BSD-3-Clause"
-version = "0.51.0-pre.1"
+version = "0.51.0-pre.2"
 
 edition = "2018"
 

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.51.0-pre.1"
+version = "0.51.0-pre.2"
 edition = "2018"
 
 [features]

--- a/base_layer/key_manager/Cargo.toml
+++ b/base_layer/key_manager/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency wallet key management"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.51.0-pre.1"
+version = "0.51.0-pre.2"
 edition = "2021"
 
 [lib]

--- a/base_layer/mmr/Cargo.toml
+++ b/base_layer/mmr/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "A Merkle Mountain Range implementation"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.51.0-pre.1"
+version = "0.51.0-pre.2"
 edition = "2018"
 
 [features]

--- a/base_layer/p2p/Cargo.toml
+++ b/base_layer/p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_p2p"
-version = "0.51.0-pre.1"
+version = "0.51.0-pre.2"
 authors = ["The Tari Development community"]
 description = "Tari base layer-specific peer-to-peer communication features"
 repository = "https://github.com/tari-project/tari"

--- a/base_layer/service_framework/Cargo.toml
+++ b/base_layer/service_framework/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_service_framework"
-version = "0.51.0-pre.1"
+version = "0.51.0-pre.2"
 authors = ["The Tari Development Community"]
 description = "The Tari communication stack service framework"
 repository = "https://github.com/tari-project/tari"

--- a/base_layer/tari_mining_helper_ffi/Cargo.toml
+++ b/base_layer/tari_mining_helper_ffi/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_mining_helper_ffi"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency miningcore C FFI bindings"
 license = "BSD-3-Clause"
-version = "0.51.0-pre.1"
+version = "0.51.0-pre.2"
 edition = "2018"
 
 [dependencies]

--- a/base_layer/wallet/Cargo.toml
+++ b/base_layer/wallet/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_wallet"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency wallet library"
 license = "BSD-3-Clause"
-version = "0.51.0-pre.1"
+version = "0.51.0-pre.2"
 edition = "2018"
 
 [dependencies]

--- a/base_layer/wallet_ffi/Cargo.toml
+++ b/base_layer/wallet_ffi/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_wallet_ffi"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency wallet C FFI bindings"
 license = "BSD-3-Clause"
-version = "0.51.0-pre.1"
+version = "0.51.0-pre.2"
 edition = "2018"
 
 [dependencies]

--- a/changelog-development.md
+++ b/changelog-development.md
@@ -1,18 +1,29 @@
-## [0.51.0-pre.0](https://github.com/tari-project/tari/compare/v0.50.0-pre.3...v0.51.0-pre.0) (2023-06-09)
+# Changelog
+
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+## 0.51.0-pre.2 (2023-06-22)
+
+
+#### Features
+
+*   sparse merkle trees (#5457) ([f536d219](https://github.com/tari-project/tari/commit/f536d21929e4eeb11cc185c013eef0b336def216)
+
+#### Performance
+
+*   speed up slow test (#5481) ([589ea3e2](https://github.com/tari-project/tari/commit/589ea3e2df45668bbb493411191d0cb9837c5eec)
 
 #### Bug Fixes
+
+* **mmr:**  support zero sized balanced merkle proof (#5474) ([ef984823](https://github.com/tari-project/tari/commit/ef98482313c9b9480ac663709162ae62e9c26978)
+* **wallet:**  use correct output features for send to self (#5472) ([ce1f0686](https://github.com/tari-project/tari/commit/ce1f0686f56367ff094bf28cfd0388b2ea94a8c9)
+
+## [0.51.0-pre.0](https://github.com/tari-project/tari/compare/v0.50.0-pre.3...v0.51.0-pre.0) (2023-06-09)
+
 
 #### Features
 
 *   ui for template registration in console wallet (#5444) ([701e3c23](https://github.com/tari-project/tari/commit/701e3c2341d1029c2711b81a66952f3bee7d8e42), breaks [#](https://github.com/tari-project/tari/issues/), [#](https://github.com/tari-project/tari/issues/), [#](https://github.com/tari-project/tari/issues/))
-
-#### Breaking Changes
-
-
-
-# Changelog
-
-All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
 ## [0.50.0-pre.3](https://github.com/tari-project/tari/compare/v0.50.0-pre.2...v0.50.0-pre.3) (2023-06-09)
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.51.0-pre.1"
+version = "0.51.0-pre.2"
 edition = "2018"
 
 [features]
@@ -40,4 +40,4 @@ tari_test_utils = {  path = "../infrastructure/test_utils"}
 toml = "0.5.8"
 
 [build-dependencies]
-tari_features = { version = "0.51.0-pre.1", path = "./tari_features"}
+tari_features = { version = "0.51.0-pre.2", path = "./tari_features"}

--- a/common/tari_features/Cargo.toml
+++ b/common/tari_features/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.51.0-pre.1"
+version = "0.51.0-pre.2"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/common_sqlite/Cargo.toml
+++ b/common_sqlite/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_common_sqlite"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency wallet library"
 license = "BSD-3-Clause"
-version = "0.51.0-pre.1"
+version = "0.51.0-pre.2"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/comms/core/Cargo.toml
+++ b/comms/core/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.51.0-pre.1"
+version = "0.51.0-pre.2"
 edition = "2018"
 
 [dependencies]

--- a/comms/dht/Cargo.toml
+++ b/comms/dht/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_comms_dht"
-version = "0.51.0-pre.1"
+version = "0.51.0-pre.2"
 authors = ["The Tari Development Community"]
 description = "Tari comms DHT module"
 repository = "https://github.com/tari-project/tari"

--- a/comms/rpc_macros/Cargo.toml
+++ b/comms/rpc_macros/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.51.0-pre.1"
+version = "0.51.0-pre.2"
 edition = "2018"
 
 [lib]

--- a/infrastructure/derive/Cargo.toml
+++ b/infrastructure/derive/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.51.0-pre.1"
+version = "0.51.0-pre.2"
 edition = "2018"
 
 [lib]

--- a/infrastructure/shutdown/Cargo.toml
+++ b/infrastructure/shutdown/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.51.0-pre.1"
+version = "0.51.0-pre.2"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/infrastructure/storage/Cargo.toml
+++ b/infrastructure/storage/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.51.0-pre.1"
+version = "0.51.0-pre.2"
 edition = "2018"
 
 [dependencies]

--- a/infrastructure/test_utils/Cargo.toml
+++ b/infrastructure/test_utils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_test_utils"
 description = "Utility functions used in Tari test functions"
-version = "0.51.0-pre.1"
+version = "0.51.0-pre.2"
 authors = ["The Tari Development Community"]
 edition = "2018"
 license = "BSD-3-Clause"


### PR DESCRIPTION
Description
---
Version bump development so we can tag a new release.

Motivation and Context
---
The dan layer team requires it.