### PR TITLE
fix: coinbase recovery

### DIFF
--- a/base_layer/core/src/transactions/key_manager/interface.rs
+++ b/base_layer/core/src/transactions/key_manager/interface.rs
@@ -35,6 +35,7 @@ use crate::transactions::{
         TransactionError,
         TransactionInputVersion,
         TransactionKernelVersion,
+        TransactionOutput,
         TransactionOutputVersion,
     },
 };
@@ -165,10 +166,9 @@ pub trait TransactionKeyManagerInterface: KeyManagerInterface<PublicKey> {
         value: u64,
     ) -> Result<EncryptedData, TransactionError>;
 
-    async fn try_commitment_key_recovery(
+    async fn try_output_key_recovery(
         &self,
-        commitment: &Commitment,
-        data: &EncryptedData,
+        output: &TransactionOutput,
         custom_recovery_key_id: Option<&TariKeyId>,
     ) -> Result<(TariKeyId, MicroTari), TransactionError>;
 

--- a/base_layer/core/src/transactions/key_manager/wrapper.rs
+++ b/base_layer/core/src/transactions/key_manager/wrapper.rs
@@ -52,6 +52,7 @@ use crate::transactions::{
         TransactionError,
         TransactionInputVersion,
         TransactionKernelVersion,
+        TransactionOutput,
         TransactionOutputVersion,
     },
     CryptoFactories,
@@ -339,16 +340,15 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
             .await
     }
 
-    async fn try_commitment_key_recovery(
+    async fn try_output_key_recovery(
         &self,
-        commitment: &Commitment,
-        data: &EncryptedData,
+        output: &TransactionOutput,
         custom_recovery_key_id: Option<&TariKeyId>,
     ) -> Result<(TariKeyId, MicroTari), TransactionError> {
         (*self.transaction_key_manager_inner)
             .read()
             .await
-            .try_commitment_key_recovery(commitment, data, custom_recovery_key_id)
+            .try_output_key_recovery(output, custom_recovery_key_id)
             .await
     }
 

--- a/base_layer/core/src/transactions/transaction_components/test.rs
+++ b/base_layer/core/src/transactions/transaction_components/test.rs
@@ -82,11 +82,13 @@ async fn key_manager_input() {
         .await
         .expect("Should be able to create transaction input");
 
-    assert_eq!(*input.features().unwrap(), OutputFeatures::default());
-    let (_, value) = key_manager
-        .try_commitment_key_recovery(input.commitment().unwrap(), input.encrypted_data().unwrap(), None)
+    let output = i
+        .as_transaction_output(&key_manager)
         .await
-        .unwrap();
+        .expect("Should be able to create transaction output");
+
+    assert_eq!(*input.features().unwrap(), OutputFeatures::default());
+    let (_, value) = key_manager.try_output_key_recovery(&output, None).await.unwrap();
     assert_eq!(value, i.value);
 }
 
@@ -503,10 +505,7 @@ async fn test_output_recover_openings() {
         .unwrap();
     let output = wallet_output.as_transaction_output(&key_manager).await.unwrap();
 
-    let (mask, value) = key_manager
-        .try_commitment_key_recovery(&output.commitment, &output.encrypted_data, None)
-        .await
-        .unwrap();
+    let (mask, value) = key_manager.try_output_key_recovery(&output, None).await.unwrap();
     assert_eq!(value, wallet_output.value);
     assert_eq!(mask, test_params.spend_key_id);
 }

--- a/base_layer/core/src/transactions/transaction_components/transaction_output.rs
+++ b/base_layer/core/src/transactions/transaction_components/transaction_output.rs
@@ -159,6 +159,11 @@ impl TransactionOutput {
         &self.commitment
     }
 
+    /// Accessor method for the encrypted_data contained in an output
+    pub fn encrypted_data(&self) -> &EncryptedData {
+        &self.encrypted_data
+    }
+
     /// Accessor method for the range proof contained in an output
     pub fn proof_result(&self) -> Result<&RangeProof, RangeProofError> {
         if let Some(proof) = self.proof.as_ref() {
@@ -587,10 +592,7 @@ mod test {
 
         assert!(tx_output.verify_range_proof(&factories.range_proof).is_ok());
         assert!(tx_output.verify_metadata_signature().is_ok());
-        let (_, recovered_value) = key_manager
-            .try_commitment_key_recovery(&tx_output.commitment, &tx_output.encrypted_data, None)
-            .await
-            .unwrap();
+        let (_, recovered_value) = key_manager.try_output_key_recovery(&tx_output, None).await.unwrap();
         assert_eq!(recovered_value, value);
     }
 

--- a/base_layer/core/src/transactions/transaction_components/wallet_output_builder.rs
+++ b/base_layer/core/src/transactions/transaction_components/wallet_output_builder.rs
@@ -267,10 +267,8 @@ mod test {
                     .await
                     .unwrap());
 
-                let (recovered_key_id, recovered_value) = key_manager
-                    .try_commitment_key_recovery(&output.commitment, &output.encrypted_data, None)
-                    .await
-                    .unwrap();
+                let (recovered_key_id, recovered_value) =
+                    key_manager.try_output_key_recovery(&output, None).await.unwrap();
                 assert_eq!(recovered_key_id, spending_key_id);
                 assert_eq!(recovered_value, value);
             },

--- a/base_layer/core/src/transactions/transaction_protocol/recipient.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/recipient.rs
@@ -290,10 +290,7 @@ mod test {
             .unwrap();
         assert_eq!(data.partial_signature, kernel_signature);
 
-        let (mask, value) = key_manager
-            .try_commitment_key_recovery(&data.output.commitment, &data.output.encrypted_data, None)
-            .await
-            .unwrap();
+        let (mask, value) = key_manager.try_output_key_recovery(&data.output, None).await.unwrap();
         assert_eq!(output.spending_key_id, mask);
         assert_eq!(output.value, value);
     }

--- a/base_layer/core/src/transactions/transaction_protocol/sender.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/sender.rs
@@ -1547,9 +1547,9 @@ mod test {
         let output_0 = &tx.body.outputs()[0];
         let output_1 = &tx.body.outputs()[1];
 
-        if let Ok((key, _value)) = key_manager_alice.try_output_key_recovery(&output_0, None).await {
+        if let Ok((key, _value)) = key_manager_alice.try_output_key_recovery(output_0, None).await {
             assert_eq!(key, change_params.spend_key_id);
-        } else if let Ok((key, _value)) = key_manager_alice.try_output_key_recovery(&output_1, None).await {
+        } else if let Ok((key, _value)) = key_manager_alice.try_output_key_recovery(output_1, None).await {
             assert_eq!(key, change_params.spend_key_id);
         } else {
             panic!("Could not recover Alice's output");

--- a/base_layer/core/src/transactions/transaction_protocol/sender.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/sender.rs
@@ -1547,15 +1547,9 @@ mod test {
         let output_0 = &tx.body.outputs()[0];
         let output_1 = &tx.body.outputs()[1];
 
-        if let Ok((key, _value)) = key_manager_alice
-            .try_commitment_key_recovery(&output_0.commitment, &output_0.encrypted_data, None)
-            .await
-        {
+        if let Ok((key, _value)) = key_manager_alice.try_output_key_recovery(&output_0, None).await {
             assert_eq!(key, change_params.spend_key_id);
-        } else if let Ok((key, _value)) = key_manager_alice
-            .try_commitment_key_recovery(&output_1.commitment, &output_1.encrypted_data, None)
-            .await
-        {
+        } else if let Ok((key, _value)) = key_manager_alice.try_output_key_recovery(&output_1, None).await {
             assert_eq!(key, change_params.spend_key_id);
         } else {
             panic!("Could not recover Alice's output");

--- a/base_layer/wallet/src/output_manager_service/recovery/standard_outputs_recoverer.rs
+++ b/base_layer/wallet/src/output_manager_service/recovery/standard_outputs_recoverer.rs
@@ -173,11 +173,7 @@ where
         &self,
         output: &TransactionOutput,
     ) -> Result<Option<(TariKeyId, MicroTari)>, OutputManagerError> {
-        let (key, committed_value) = match self
-            .master_key_manager
-            .try_commitment_key_recovery(&output.commitment, &output.encrypted_data, None)
-            .await
-        {
+        let (key, committed_value) = match self.master_key_manager.try_output_key_recovery(&output, None).await {
             Ok(value) => value,
             Err(_) => return Ok(None),
         };

--- a/base_layer/wallet/src/output_manager_service/recovery/standard_outputs_recoverer.rs
+++ b/base_layer/wallet/src/output_manager_service/recovery/standard_outputs_recoverer.rs
@@ -173,7 +173,7 @@ where
         &self,
         output: &TransactionOutput,
     ) -> Result<Option<(TariKeyId, MicroTari)>, OutputManagerError> {
-        let (key, committed_value) = match self.master_key_manager.try_output_key_recovery(&output, None).await {
+        let (key, committed_value) = match self.master_key_manager.try_output_key_recovery(output, None).await {
             Ok(value) => value,
             Err(_) => return Ok(None),
         };

--- a/base_layer/wallet/src/output_manager_service/storage/models.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/models.rs
@@ -68,9 +68,10 @@ impl DbWalletOutput {
         received_in_tx_id: Option<TxId>,
         spent_in_tx_id: Option<TxId>,
     ) -> Result<DbWalletOutput, OutputManagerStorageError> {
+        let tx_output = output.as_transaction_output(key_manager).await?;
         Ok(DbWalletOutput {
-            hash: output.hash(key_manager).await?,
-            commitment: output.commitment(key_manager).await?,
+            hash: tx_output.hash(),
+            commitment: tx_output.commitment,
             wallet_output: output,
             status: OutputStatus::NotStored,
             mined_height: None,

--- a/base_layer/wallet/tests/output_manager_service_tests/service.rs
+++ b/base_layer/wallet/tests/output_manager_service_tests/service.rs
@@ -1254,7 +1254,7 @@ async fn handle_coinbase_with_bulletproofs_rewinding() {
 
     let (_, decrypted_value) = oms
         .key_manager_handle
-        .try_commitment_key_recovery(&output.commitment, &output.encrypted_data, None)
+        .try_output_key_recovery(&output, None)
         .await
         .unwrap();
     assert_eq!(decrypted_value, value3);

--- a/base_layer/wallet/tests/transaction_service_tests/service.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/service.rs
@@ -860,11 +860,7 @@ async fn single_transaction_burn_tari() {
         if output.is_burned() {
             found_burned_output = true;
             match key_manager_handle
-                .try_commitment_key_recovery(
-                    &output.clone().commitment,
-                    &output.clone().encrypted_data,
-                    Some(&recovery_key_id),
-                )
+                .try_output_key_recovery(&output, Some(&recovery_key_id))
                 .await
             {
                 Ok((spending_key_id, value)) => {

--- a/base_layer/wallet/tests/transaction_service_tests/service.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/service.rs
@@ -860,7 +860,7 @@ async fn single_transaction_burn_tari() {
         if output.is_burned() {
             found_burned_output = true;
             match key_manager_handle
-                .try_output_key_recovery(&output, Some(&recovery_key_id))
+                .try_output_key_recovery(output, Some(&recovery_key_id))
                 .await
             {
                 Ok((spending_key_id, value)) => {


### PR DESCRIPTION
Description
---
Fixes the coinbase recovery. 
Speeds up recovery searching by looking on the private key.

Motivation and Context
---
The current code can recover the private key of the coinbase, but it searches in the `CommitmentMask` till index 1_000_000 not finding a match. Then it imports the key. For coinbase keys, the keys are derived not from `CommitmentMask` but from `Coinbase` so it much searches that index.

This bug will also slow down the wallet spending transactions by blocking the `CommitmentMask` branch via the mutex for that massive index search. This is now removed and will speed up the wallet also. 

How Has This Been Tested?
---
Unit tests, manual

What process can a PR reviewer use to test or verify this change?
---

