### PR TITLE
fix(core): remove implicit change in protocol for partial/full signatures

### DIFF
--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -1214,8 +1214,7 @@ where
 
         // Start finalizing
 
-        stp.add_single_recipient_info(recipient_reply, &self.resources.transaction_key_manager_service)
-            .await
+        stp.add_presigned_recipient_info(recipient_reply)
             .map_err(|e| TransactionServiceProtocolError::new(tx_id, e.into()))?;
 
         // Finalize
@@ -1402,9 +1401,7 @@ where
         let recipient_reply = rtp.get_signed_data()?.clone();
 
         // Start finalizing
-
-        stp.add_single_recipient_info(recipient_reply, &self.resources.transaction_key_manager_service)
-            .await
+        stp.add_presigned_recipient_info(recipient_reply)
             .map_err(|e| TransactionServiceProtocolError::new(tx_id, e.into()))?;
 
         // Finalize
@@ -1661,8 +1658,7 @@ where
         }
 
         // Start finalizing
-        stp.add_single_recipient_info(recipient_reply, &self.resources.transaction_key_manager_service)
-            .await
+        stp.add_presigned_recipient_info(recipient_reply)
             .map_err(|e| TransactionServiceProtocolError::new(tx_id, e.into()))?;
 
         // Finalize


### PR DESCRIPTION
Description
---
Removes check for an invalid signature, presumed to be a partial signature, which results in partial signature aggregation being skipped if a valid signature is passed in.

Motivation and Context
---
This check validates the receiver signature to determine if the signature is sent is partial or full. If partial we aggregate the sender and receiver partial signatures. A partial signature and an invalid signature run the same code path (`  if received_output.verify_metadata_signature().is_err() {`) This code branch is executed as part of every normal Tari transaction.

It is not possible for the (non-local) receiver to unilaterally produce a correct signature and "bypass" aggregation as they do not possess the required secrets. The primary reason for this check is to allow the protocol to be shortcut when the sender and receiver are the same party and therefore can produce a valid signature (sign_as_sender_and_receiver). This PR implements this shortcut explicitly by adding a separate call for this case `add_presigned_recipient_info`.

How Has This Been Tested?
---
Existing transaction tests.

What process can a PR reviewer use to test or verify this change?
---
Send a normal and send-to-self transaction
<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
