### PR TITLE
fix(core/weighting): remove optional and define correct rounding for usize::MAX

### DIFF
--- a/applications/tari_app_grpc/src/conversions/consensus_constants.rs
+++ b/applications/tari_app_grpc/src/conversions/consensus_constants.rs
@@ -47,12 +47,7 @@ impl From<ConsensusConstants> for grpc::ConsensusConstants {
             max: u64::from(valid_blockchain_version_range.1),
         };
         let transaction_weight = cc.transaction_weight_params();
-        let features_and_scripts_bytes_per_gram =
-            if let Some(val) = transaction_weight.params().features_and_scripts_bytes_per_gram {
-                u64::from(val)
-            } else {
-                0u64
-            };
+        let features_and_scripts_bytes_per_gram = transaction_weight.params().features_and_scripts_bytes_per_gram.get();
         let transaction_weight = grpc::WeightParams {
             kernel_weight: cc.transaction_weight_params().params().kernel_weight,
             input_weight: cc.transaction_weight_params().params().input_weight,


### PR DESCRIPTION
Description
---
make features_and_scripts_byte_per_gram mandatory and update the weighting code

Motivation and Context
---
The optional features_and_scripts_bytes_per_gram was previously optional to keep compatibility with a previous block/tx weighting calculation which did not account for metadata bytes (i.e. features_and_scripts_bytes_per_gram is None). This is no longer needed.

How Has This Been Tested?
---
Existing tests, updated a unit test

What process can a PR reviewer use to test or verify this change?
---
Mine blocks containing transactions
<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None (assuming no existing transaction metadata is big enough to exceed usize::MAX)
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
