### PR TITLE
fix: overflow of target difficulty

### DIFF
--- a/base_layer/core/src/proof_of_work/lwma_diff.rs
+++ b/base_layer/core/src/proof_of_work/lwma_diff.rs
@@ -15,6 +15,7 @@ use std::{
     cmp,
     cmp::{max, min},
     collections::VecDeque,
+    convert::TryFrom,
 };
 
 use log::*;
@@ -108,8 +109,7 @@ impl LinearWeightedMovingAverage {
         }
         // k is the sum of weights (1+2+..+n) * target_time
         let k = n * (n + 1) * self.target_time / 2;
-        #[allow(clippy::cast_possible_truncation)]
-        let target = (ave_difficulty * k / weighted_times) as u64;
+        let target = u64::try_from(ave_difficulty * k / weighted_times).unwrap_or(u64::MAX);
         trace!(
             target: LOG_TARGET,
             "DiffCalc; t={}; bw={}; n={}; ts[0]={}; ts[n]={}; weighted_ts={}; k={}; diff[0]={}; diff[n]={}; \


### PR DESCRIPTION
Description
---
The target difficulty overflow over u64 could happen and it would produce only module by u64. Now it returns u64::MAX if it's over.

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
