### PR TITLE
chore(core/consensus): remove unnecessary clippy allows on FTL

### DIFF
--- a/base_layer/core/src/consensus/consensus_constants.rs
+++ b/base_layer/core/src/consensus/consensus_constants.rs
@@ -183,8 +183,6 @@ impl ConsensusConstants {
     /// Any block with a timestamp greater than this is rejected.
     pub fn ftl(&self) -> EpochTime {
         // Timestamp never negative
-        #[allow(clippy::cast_sign_loss)]
-        #[allow(clippy::cast_possible_wrap)]
         (Utc::now()
             .add(Duration::seconds(self.future_time_limit as i64))
             .timestamp() as u64)
@@ -195,8 +193,6 @@ impl ConsensusConstants {
     /// Any block with a timestamp greater than this is rejected.
     /// This function returns the FTL as a UTC datetime
     pub fn ftl_as_time(&self) -> DateTime<Utc> {
-        #[allow(clippy::cast_sign_loss)]
-        #[allow(clippy::cast_possible_wrap)]
         Utc::now().add(Duration::seconds(self.future_time_limit as i64))
     }
 


### PR DESCRIPTION
Description
---
Removed clippy allows on `flt` accesor method in consensus constants. Turns out that the allows were unnecessary, those rules are allowed by default in clippy and we haven't disabled them in the `lints.toml` file.

Motivation and Context
---
Solves https://github.com/tari-project/tari/issues/5511

How Has This Been Tested?
---
Clippy passes

What process can a PR reviewer use to test or verify this change?
---

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
