### PR TITLE
chore: dry up smt code

### DIFF
--- a/base_layer/mmr/src/sparse_merkle_tree/bit_utils.rs
+++ b/base_layer/mmr/src/sparse_merkle_tree/bit_utils.rs
@@ -1,6 +1,8 @@
 // Copyright 2023. The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
 
+use std::ops::Not;
+
 use crate::sparse_merkle_tree::{NodeKey, SMTError};
 
 /// Gets the bit at an offset from the most significant bit. Does NOT perform range checking
@@ -86,6 +88,17 @@ pub fn path_matches_key(key: &NodeKey, path: &[TraverseDirection]) -> bool {
 pub enum TraverseDirection {
     Left,
     Right,
+}
+
+impl Not for TraverseDirection {
+    type Output = Self;
+
+    fn not(self) -> Self::Output {
+        match self {
+            TraverseDirection::Left => TraverseDirection::Right,
+            TraverseDirection::Right => TraverseDirection::Left,
+        }
+    }
 }
 
 /// Checks whether the `child_key` would be a left or right child of the `parent_key` at the given height

--- a/base_layer/mmr/src/sparse_merkle_tree/node.rs
+++ b/base_layer/mmr/src/sparse_merkle_tree/node.rs
@@ -10,7 +10,7 @@ use std::{
 use digest::{consts::U32, Digest};
 
 use crate::sparse_merkle_tree::{
-    bit_utils::{count_common_prefix, get_bit, height_key},
+    bit_utils::{count_common_prefix, get_bit, height_key, TraverseDirection},
     Node::*,
     SMTError,
 };
@@ -361,6 +361,20 @@ impl<H> BranchNode<H> {
 
     pub fn key(&self) -> &NodeKey {
         &self.key
+    }
+
+    pub fn child(&self, direction: TraverseDirection) -> &Node<H> {
+        match direction {
+            TraverseDirection::Left => &self.left,
+            TraverseDirection::Right => &self.right,
+        }
+    }
+
+    pub fn child_mut(&mut self, direction: TraverseDirection) -> &mut Node<H> {
+        match direction {
+            TraverseDirection::Left => &mut self.left,
+            TraverseDirection::Right => &mut self.right,
+        }
     }
 
     pub fn left(&self) -> &Node<H> {

--- a/base_layer/mmr/src/sparse_merkle_tree/tree.rs
+++ b/base_layer/mmr/src/sparse_merkle_tree/tree.rs
@@ -371,9 +371,10 @@ impl<H: Digest<OutputSize = U32>> SparseMerkleTree<H> {
             let leaf = mem::replace(&mut self.root, Node::Empty(EmptyNode {}));
             let leaf_hash = leaf.to_leaf()?.to_value_hash();
             self.size -= 1;
-            return Ok(DeleteResult::Deleted(leaf_hash));
+            Ok(DeleteResult::Deleted(leaf_hash))
+        } else {
+            Ok(DeleteResult::KeyNotFound)
         }
-        return Ok(DeleteResult::KeyNotFound);
     }
 
     // Performs an update or insert if the root is a leaf.
@@ -387,7 +388,7 @@ impl<H: Digest<OutputSize = U32>> SparseMerkleTree<H> {
         let root = old_root.build_tree(0, new_leaf)?;
         self.root = Branch(root);
         self.size += 1;
-        return Ok(UpdateResult::Inserted);
+        Ok(UpdateResult::Inserted)
     }
 
     // This function attaches a node to the branch at the specified height.


### PR DESCRIPTION
Reviews the SMT code for cleanness and repetition.

- DRYed up several `match direction` cases into a `Branch::child` function.
- Added docs to every public function
- Converted docstrings to comments for private functions.
- Ordered functions with public methods first and private function last in `impl` blocks.



Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
