### PR TITLE
fix: use correct TOML field for console wallet network address

### DIFF
--- a/common/config/presets/d_console_wallet.toml
+++ b/common/config/presets/d_console_wallet.toml
@@ -165,7 +165,7 @@ event_channel_size = 3500
 # peers can find you.
 # _NOTE_: If using the `tor` transport type, public_address will be ignored and an onion address will be
 # automatically configured
-#public_address = "/ip4/172.2.3.4/tcp/18189"
+#public_addresses = ["/ip4/172.2.3.4/tcp/18189",]
 
 # Optionally bind an additional TCP socket for inbound Tari P2P protocol commms.
 # Use cases include:


### PR DESCRIPTION
Description
---
Updates the preset wallet client configuration to fix a bad field name.

Motivation and Context
---
The preset wallet client TOML configuration [specifies](https://github.com/AaronFeickert/tari/blob/development/common/config/presets/d_console_wallet.toml#L164-L168) the field `wallet.p2p.public_address`, which is required for non-Tor network types. If the user uncomments this field when using such a network type, the wallet crashes and reports that the field does not exist.

The [correct](https://github.com/tari-project/tari/blob/2e400836111c14fdfc52d84e5a64bbbb2d438956/applications/tari_console_wallet/src/init/mod.rs#L405-L412) field name is `public_addresses`, which can be specified as either a single element or list. This PR updates the configuration to use the correct field name. It uses a list format for clarity and consistency with similar fields.

How Has This Been Tested?
---
Tested manually.

What process can a PR reviewer use to test or verify this change?
---
Using a non-Tor network type (like TCP), uncomment the `wallet.p2p.public_addresses` field and confirm that the wallet loads.

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---
None.