### PR TITLE
fix: push test coverage even if some tests fail

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,4 +1,7 @@
 ---
+# Notes for this action:
+# Restoring caches is largely useless, since the compiler flags are only useful for code coverage runs.
+# This GA is self-hosted, and has local caching solutions.
 name: Source Coverage
 
 'on':
@@ -32,25 +35,9 @@ jobs:
           toolchain: nightly
           components: llvm-tools-preview
 
-      - name: caching (nightly)
-        # Don't use rust-cache.
-        # Rust-cache disables a key feature of actions/cache: restoreKeys.
-        # Without restore keys, we lose the ability to get partial matches on caches, and end
-        # up with too many cache misses.
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/registry/index
-            ~/.cargo/registry/cache
-            ~/.cargo/registry/CACHEDIR.TAG
-            ~/.cargo/git
-            target
-          key: tari-${{ runner.os }}-${{ runner.cpu-model }}-${{ env.toolchain }}-nightly-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            tari-${{ runner.os }}-${{ runner.cpu-model }}-${{ env.toolchain }}-nightly-${{ hashFiles('**/Cargo.lock') }}
-            tari-${{ runner.os }}-${{ runner.cpu-model }}-${{ env.toolchain }}-nightly
-
       - name: cargo test
+        # Prepare the coverage data, even if some tests fail
+        continue-on-error: true
         env:
           RUSTFLAGS: "-C instrument-coverage"
           RUSTDOCFLAGS: "-C instrument-coverage"


### PR DESCRIPTION
Description
---

Our test coverage shows 0% because the GA fails if even one test fails (and the integration tests typically have at least one failure).

So allow the coverage report to complete even without a clean bill of health.

Remote caching was also disabled for this GA, since the compiler flags are different for code coverage runs.

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
