### PR TITLE
[wip - fixing unit tests] feat: add genesis block checks with not-before-proof

### DIFF
--- a/applications/tari_app_grpc/proto/block.proto
+++ b/applications/tari_app_grpc/proto/block.proto
@@ -120,7 +120,6 @@ message NewBlockHeaderTemplate {
     bytes total_kernel_offset = 4;
     // Proof of work metadata
     ProofOfWork pow = 5;
-//    uint64 target_difficulty = 6;
     // Sum of script offsets for all kernels in this block.
     bytes total_script_offset = 7;
 }

--- a/applications/tari_app_grpc/src/conversions/new_block_template.rs
+++ b/applications/tari_app_grpc/src/conversions/new_block_template.rs
@@ -103,7 +103,7 @@ impl TryFrom<grpc::NewBlockTemplate> for NewBlockTemplate {
             header,
             body,
             target_difficulty: Default::default(),
-            reward: Default::default(),
+            emission: Default::default(),
             total_fees: Default::default(),
         })
     }

--- a/applications/tari_base_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/tari_base_node/src/grpc/base_node_grpc_server.rs
@@ -494,7 +494,7 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
         let pow = algo as i32;
         let response = tari_rpc::NewBlockTemplateResponse {
             miner_data: Some(tari_rpc::MinerData {
-                reward: new_template.reward.into(),
+                reward: new_template.emission.into(),
                 target_difficulty: new_template.target_difficulty.as_u64(),
                 total_fees: new_template.total_fees.into(),
                 algo: Some(tari_rpc::PowAlgo { pow_algo: pow }),

--- a/applications/tari_base_node/src/grpc/hash_rate.rs
+++ b/applications/tari_base_node/src/grpc/hash_rate.rs
@@ -180,7 +180,7 @@ mod test {
     }
 
     fn create_hash_rate_ma(pow_algo: PowAlgorithm) -> HashRateMovingAverage {
-        let consensus_manager = ConsensusManagerBuilder::new(Network::Esmeralda)
+        let consensus_manager = ConsensusManagerBuilder::new(Network::LocalNet)
             .add_consensus_constants(ConsensusConstants::esmeralda()[0].clone())
             .build()
             .unwrap();

--- a/base_layer/core/benches/mempool.rs
+++ b/base_layer/core/benches/mempool.rs
@@ -68,7 +68,7 @@ mod benches {
         let runtime = Runtime::new().unwrap();
         let config = MempoolConfig::default();
         let rules = ConsensusManager::builder(Network::LocalNet).build().unwrap();
-        let db = create_new_blockchain();
+        let db = create_new_blockchain().unwrap();
 
         let mempool_validator = TransactionFullValidator::new(CryptoFactories::default(), false, db, rules.clone());
         let mempool = Mempool::new(config, rules, Box::new(mempool_validator));

--- a/base_layer/core/src/base_node/sync/header_sync/validator.rs
+++ b/base_layer/core/src/base_node/sync/header_sync/validator.rs
@@ -225,7 +225,7 @@ mod test {
     fn setup() -> (BlockHeaderSyncValidator<TempDatabase>, AsyncBlockchainDb<TempDatabase>) {
         let rules = ConsensusManager::builder(Network::LocalNet).build().unwrap();
         let randomx_factory = RandomXFactory::default();
-        let db = create_new_blockchain();
+        let db = create_new_blockchain().unwrap();
         (
             BlockHeaderSyncValidator::new(db.clone().into(), rules, randomx_factory),
             db.into(),

--- a/base_layer/core/src/base_node/sync/rpc/tests.rs
+++ b/base_layer/core/src/base_node/sync/rpc/tests.rs
@@ -48,7 +48,7 @@ fn setup() -> (
     let peer_manager = create_peer_manager(&tmp);
     let request_mock = RpcRequestMock::new(peer_manager);
 
-    let db = create_new_blockchain();
+    let db = create_new_blockchain().unwrap();
     let (req_tx, _) = reply_channel::unbounded();
     let (block_tx, _) = reply_channel::unbounded();
     let (block_event_tx, _) = broadcast::channel(1);

--- a/base_layer/core/src/blocks/new_block_template.rs
+++ b/base_layer/core/src/blocks/new_block_template.rs
@@ -42,21 +42,21 @@ pub struct NewBlockTemplate {
     pub body: AggregateBody,
     /// The difficulty is defined as the maximum target divided by the block hash.
     pub target_difficulty: Difficulty,
-    /// The reward is the sum of the coinbase utxo and the total fees.
-    pub reward: MicroTari,
+    /// The emission is equal to the value of the coinbase utxo.
+    pub emission: MicroTari,
     /// The total fees is the sum of all the fees in the block.
     pub total_fees: MicroTari,
 }
 
 impl NewBlockTemplate {
-    pub fn from_block(block: Block, target_difficulty: Difficulty, reward: MicroTari) -> Self {
+    pub fn from_block(block: Block, target_difficulty: Difficulty, emission: MicroTari) -> Self {
         let Block { header, body } = block;
         let total_fees = body.get_total_fee();
         Self {
             header: NewBlockHeaderTemplate::from_header(header),
             body,
             target_difficulty,
-            reward,
+            emission,
             total_fees,
         }
     }
@@ -71,8 +71,8 @@ impl Display for NewBlockTemplate {
         writeln!(f, "{}", self.body)?;
         writeln!(
             f,
-            "Target difficulty: {}\nReward: {}\nTotal fees: {}",
-            self.target_difficulty, self.reward, self.total_fees
+            "Target difficulty: {}\nEmission: {}\nTotal fees: {}",
+            self.target_difficulty, self.emission, self.total_fees
         )?;
         Ok(())
     }

--- a/base_layer/core/src/chain_storage/async_db.rs
+++ b/base_layer/core/src/chain_storage/async_db.rs
@@ -419,7 +419,7 @@ mod tests {
     impl AsyncBlockchainDb<TempDatabase> {
         pub fn sample() -> Self {
             Self {
-                db: create_new_blockchain(),
+                db: create_new_blockchain().unwrap(),
             }
         }
     }

--- a/base_layer/core/src/chain_storage/error.rs
+++ b/base_layer/core/src/chain_storage/error.rs
@@ -30,6 +30,7 @@ use tokio::task;
 use crate::{
     blocks::BlockError,
     chain_storage::MmrTree,
+    consensus::ConsensusManagerError,
     proof_of_work::PowError,
     transactions::transaction_components::TransactionError,
     validation::ValidationError,
@@ -138,6 +139,8 @@ pub enum ChainStorageError {
     CompositeKeyLengthExceeded,
     #[error("Failed to decode key bytes: {0}")]
     FromKeyBytesFailed(String),
+    #[error("ConsensusManager Error: {0}")]
+    ConsensusManagerError(#[from] ConsensusManagerError),
 }
 
 impl ChainStorageError {

--- a/base_layer/core/src/chain_storage/tests/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/tests/blockchain_database.rs
@@ -39,7 +39,7 @@ use crate::{
     txn_schema,
 };
 
-fn setup() -> BlockchainDatabase<TempDatabase> {
+fn setup() -> Result<BlockchainDatabase<TempDatabase>, ChainStorageError> {
     create_new_blockchain()
 }
 
@@ -105,14 +105,14 @@ mod fetch_blocks {
 
     #[test]
     fn it_returns_genesis() {
-        let db = setup();
+        let db = setup().unwrap();
         let blocks = db.fetch_blocks(0.., true).unwrap();
         assert_eq!(blocks.len(), 1);
     }
 
     #[tokio::test]
     async fn it_returns_all() {
-        let db = setup();
+        let db = setup().unwrap();
         let key_manager = create_test_core_key_manager_with_memory_db();
         add_many_chained_blocks(4, &db, &key_manager).await;
         let blocks = db.fetch_blocks(.., true).unwrap();
@@ -124,7 +124,7 @@ mod fetch_blocks {
 
     #[tokio::test]
     async fn it_returns_one() {
-        let db = setup();
+        let db = setup().unwrap();
         let key_manager = create_test_core_key_manager_with_memory_db();
         let (new_blocks, _) = add_many_chained_blocks(1, &db, &key_manager).await;
         let blocks = db.fetch_blocks(1..=1, true).unwrap();
@@ -134,7 +134,7 @@ mod fetch_blocks {
 
     #[tokio::test]
     async fn it_returns_nothing_if_asking_for_blocks_out_of_range() {
-        let db = setup();
+        let db = setup().unwrap();
         let key_manager = create_test_core_key_manager_with_memory_db();
         add_many_chained_blocks(1, &db, &key_manager).await;
         let blocks = db.fetch_blocks(2.., true).unwrap();
@@ -143,7 +143,7 @@ mod fetch_blocks {
 
     #[tokio::test]
     async fn it_returns_blocks_between_bounds_exclusive() {
-        let db = setup();
+        let db = setup().unwrap();
         let key_manager = create_test_core_key_manager_with_memory_db();
         add_many_chained_blocks(5, &db, &key_manager).await;
         let blocks = db.fetch_blocks(3..5, true).unwrap();
@@ -154,7 +154,7 @@ mod fetch_blocks {
 
     #[tokio::test]
     async fn it_returns_blocks_between_bounds_inclusive() {
-        let db = setup();
+        let db = setup().unwrap();
         let key_manager = create_test_core_key_manager_with_memory_db();
         add_many_chained_blocks(5, &db, &key_manager).await;
         let blocks = db.fetch_blocks(3..=5, true).unwrap();
@@ -166,7 +166,7 @@ mod fetch_blocks {
 
     #[tokio::test]
     async fn it_returns_blocks_to_the_tip() {
-        let db = setup();
+        let db = setup().unwrap();
         let key_manager = create_test_core_key_manager_with_memory_db();
         add_many_chained_blocks(5, &db, &key_manager).await;
         let blocks = db.fetch_blocks(3.., true).unwrap();
@@ -178,7 +178,7 @@ mod fetch_blocks {
 
     #[tokio::test]
     async fn it_returns_blocks_from_genesis() {
-        let db = setup();
+        let db = setup().unwrap();
         let key_manager = create_test_core_key_manager_with_memory_db();
         add_many_chained_blocks(5, &db, &key_manager).await;
         let blocks = db.fetch_blocks(..=3, true).unwrap();
@@ -195,7 +195,7 @@ mod fetch_headers {
 
     #[test]
     fn it_returns_genesis() {
-        let db = setup();
+        let db = setup().unwrap();
         let headers = db.fetch_headers(0..).unwrap();
         assert_eq!(headers.len(), 1);
         let headers = db.fetch_headers(0..0).unwrap();
@@ -208,7 +208,7 @@ mod fetch_headers {
 
     #[tokio::test]
     async fn it_returns_all() {
-        let db = setup();
+        let db = setup().unwrap();
         let key_manager = create_test_core_key_manager_with_memory_db();
         add_many_chained_blocks(4, &db, &key_manager).await;
         let headers = db.fetch_headers(..).unwrap();
@@ -220,7 +220,7 @@ mod fetch_headers {
 
     #[tokio::test]
     async fn it_returns_nothing_if_asking_for_blocks_out_of_range() {
-        let db = setup();
+        let db = setup().unwrap();
         let key_manager = create_test_core_key_manager_with_memory_db();
         add_many_chained_blocks(1, &db, &key_manager).await;
         let headers = db.fetch_headers(2..).unwrap();
@@ -229,7 +229,7 @@ mod fetch_headers {
 
     #[tokio::test]
     async fn it_returns_blocks_between_bounds_exclusive() {
-        let db = setup();
+        let db = setup().unwrap();
         let key_manager = create_test_core_key_manager_with_memory_db();
         add_many_chained_blocks(5, &db, &key_manager).await;
         let headers = db.fetch_headers(3..5).unwrap();
@@ -240,7 +240,7 @@ mod fetch_headers {
 
     #[tokio::test]
     async fn it_returns_blocks_between_bounds_inclusive() {
-        let db = setup();
+        let db = setup().unwrap();
         let key_manager = create_test_core_key_manager_with_memory_db();
         add_many_chained_blocks(5, &db, &key_manager).await;
         let headers = db.fetch_headers(3..=5).unwrap();
@@ -251,7 +251,7 @@ mod fetch_headers {
     }
     #[tokio::test]
     async fn it_returns_blocks_to_the_tip() {
-        let db = setup();
+        let db = setup().unwrap();
         let key_manager = create_test_core_key_manager_with_memory_db();
         add_many_chained_blocks(5, &db, &key_manager).await;
         let headers = db.fetch_headers(3..).unwrap();
@@ -263,7 +263,7 @@ mod fetch_headers {
 
     #[tokio::test]
     async fn it_returns_blocks_from_genesis() {
-        let db = setup();
+        let db = setup().unwrap();
         let key_manager = create_test_core_key_manager_with_memory_db();
         add_many_chained_blocks(5, &db, &key_manager).await;
         let headers = db.fetch_headers(..=3).unwrap();
@@ -282,14 +282,14 @@ mod find_headers_after_hash {
 
     #[test]
     fn it_returns_none_given_empty_vec() {
-        let db = setup();
+        let db = setup().unwrap();
         let hashes = vec![];
         assert!(db.find_headers_after_hash(hashes, 1).unwrap().is_none());
     }
 
     #[tokio::test]
     async fn it_returns_from_genesis() {
-        let db = setup();
+        let db = setup().unwrap();
         let genesis_hash = db.fetch_block(0, true).unwrap().block().hash();
         let key_manager = create_test_core_key_manager_with_memory_db();
         add_many_chained_blocks(1, &db, &key_manager).await;
@@ -301,7 +301,7 @@ mod find_headers_after_hash {
     }
     #[tokio::test]
     async fn it_returns_the_first_headers_found() {
-        let db = setup();
+        let db = setup().unwrap();
         let key_manager = create_test_core_key_manager_with_memory_db();
         add_many_chained_blocks(5, &db, &key_manager).await;
         let hashes = (1..=3)
@@ -316,7 +316,7 @@ mod find_headers_after_hash {
 
     #[tokio::test]
     async fn fnit_ignores_unknown_hashes() {
-        let db = setup();
+        let db = setup().unwrap();
 
         let key_manager = create_test_core_key_manager_with_memory_db();
         add_many_chained_blocks(5, &db, &key_manager).await;
@@ -336,7 +336,7 @@ mod fetch_block_hashes_from_header_tip {
 
     #[test]
     fn it_returns_genesis() {
-        let db = setup();
+        let db = setup().unwrap();
         let genesis = db.fetch_tip_header().unwrap();
         let hashes = db.fetch_block_hashes_from_header_tip(10, 0).unwrap();
         assert_eq!(hashes.len(), 1);
@@ -344,7 +344,7 @@ mod fetch_block_hashes_from_header_tip {
     }
     #[tokio::test]
     async fn it_returns_empty_set_for_big_offset() {
-        let db = setup();
+        let db = setup().unwrap();
         let key_manager = create_test_core_key_manager_with_memory_db();
         add_many_chained_blocks(5, &db, &key_manager).await;
         let hashes = db.fetch_block_hashes_from_header_tip(3, 6).unwrap();
@@ -353,7 +353,7 @@ mod fetch_block_hashes_from_header_tip {
 
     #[tokio::test]
     async fn it_returns_n_hashes_from_tip() {
-        let db = setup();
+        let db = setup().unwrap();
         let key_manager = create_test_core_key_manager_with_memory_db();
         let (blocks, _) = add_many_chained_blocks(5, &db, &key_manager).await;
         let hashes = db.fetch_block_hashes_from_header_tip(3, 1).unwrap();
@@ -365,7 +365,7 @@ mod fetch_block_hashes_from_header_tip {
 
     #[tokio::test]
     async fn it_returns_hashes_without_overlapping() {
-        let db = setup();
+        let db = setup().unwrap();
         let key_manager = create_test_core_key_manager_with_memory_db();
         let (blocks, _) = add_many_chained_blocks(3, &db, &key_manager).await;
         let hashes = db.fetch_block_hashes_from_header_tip(2, 0).unwrap();
@@ -377,7 +377,7 @@ mod fetch_block_hashes_from_header_tip {
 
     #[tokio::test]
     async fn it_returns_all_hashes_from_tip() {
-        let db = setup();
+        let db = setup().unwrap();
         let genesis = db.fetch_tip_header().unwrap();
         let key_manager = create_test_core_key_manager_with_memory_db();
         let (blocks, _) = add_many_chained_blocks(5, &db, &key_manager).await;
@@ -393,7 +393,7 @@ mod get_stats {
 
     #[test]
     fn it_works_when_db_is_empty() {
-        let db = setup();
+        let db = setup().unwrap();
         let stats = db.get_stats().unwrap();
         assert_eq!(stats.root().depth, 1);
     }
@@ -404,7 +404,7 @@ mod fetch_total_size_stats {
 
     #[tokio::test]
     async fn it_measures_the_number_of_entries() {
-        let db = setup();
+        let db = setup().unwrap();
         let genesis_output_count = db.fetch_header(0).unwrap().unwrap().output_mmr_size;
         let key_manager = create_test_core_key_manager_with_memory_db();
         let _block_and_outputs = add_many_chained_blocks(2, &db, &key_manager).await;
@@ -421,7 +421,7 @@ mod prepare_new_block {
 
     #[test]
     fn it_errors_for_genesis_block() {
-        let db = setup();
+        let db = setup().unwrap();
         let genesis = db.fetch_block(0, true).unwrap();
         let template = NewBlockTemplate::from_block(genesis.block().clone(), Difficulty::min(), 5000 * T);
         let err = db.prepare_new_block(template).unwrap_err();
@@ -430,7 +430,7 @@ mod prepare_new_block {
 
     #[test]
     fn it_errors_for_non_tip_template() {
-        let db = setup();
+        let db = setup().unwrap();
         let genesis = db.fetch_block(0, true).unwrap();
         let next_block = BlockHeader::from_previous(genesis.header());
         let mut template = NewBlockTemplate::from_block(next_block.into_builder().build(), Difficulty::min(), 5000 * T);
@@ -445,7 +445,7 @@ mod prepare_new_block {
     }
     #[test]
     fn it_prepares_the_first_block() {
-        let db = setup();
+        let db = setup().unwrap();
         let genesis = db.fetch_block(0, true).unwrap();
         let next_block = BlockHeader::from_previous(genesis.header());
         let template = NewBlockTemplate::from_block(next_block.into_builder().build(), Difficulty::min(), 5000 * T);
@@ -459,38 +459,32 @@ mod fetch_header_containing_utxo_mmr {
 
     #[test]
     fn it_returns_genesis() {
-        let db = setup();
+        let db = setup().unwrap();
         let genesis = db.fetch_block(0, true).unwrap();
-        assert!(!genesis.block().body.outputs().is_empty());
-        let mut mmr_position = 0;
-        genesis.block().body.outputs().iter().for_each(|_| {
-            let header = db.fetch_header_containing_utxo_mmr(mmr_position).unwrap();
-            assert_eq!(header.height(), 0);
-            mmr_position += 1;
-        });
+        assert!(genesis.block().body.outputs().is_empty());
+        let mmr_position = 0;
         let err = db.fetch_header_containing_utxo_mmr(mmr_position).unwrap_err();
         matches!(err, ChainStorageError::ValueNotFound { .. });
     }
 
     #[tokio::test]
     async fn it_returns_corresponding_header() {
-        let db = setup();
+        let db = setup().unwrap();
         let genesis = db.fetch_block(0, true).unwrap();
         let key_manager = create_test_core_key_manager_with_memory_db();
         let _block_and_outputs = add_many_chained_blocks(5, &db, &key_manager).await;
         let num_genesis_outputs = genesis.block().body.outputs().len() as u64;
+        assert_eq!(num_genesis_outputs, 0);
 
-        let header = db.fetch_header_containing_utxo_mmr(num_genesis_outputs - 1).unwrap();
-        assert_eq!(header.height(), 0);
+        let header = db.fetch_header_containing_utxo_mmr(0).unwrap();
+        assert_eq!(header.height(), 1);
 
-        for i in 1..=5 {
-            let index = num_genesis_outputs + i - 1;
+        for i in 2..5 {
+            let index = i;
             let header = db.fetch_header_containing_utxo_mmr(index).unwrap();
-            assert_eq!(header.height(), i, "Incorrect header for MMR index = {}", index);
+            assert_eq!(header.height(), i + 1, "Incorrect header for MMR index = {}", index);
         }
-        let err = db
-            .fetch_header_containing_utxo_mmr(num_genesis_outputs + 5)
-            .unwrap_err();
+        let err = db.fetch_header_containing_utxo_mmr(5).unwrap_err();
         matches!(err, ChainStorageError::ValueNotFound { .. });
     }
 }
@@ -500,9 +494,9 @@ mod fetch_header_containing_kernel_mmr {
 
     #[test]
     fn it_returns_genesis() {
-        let db = setup();
+        let db = setup().unwrap();
         let genesis = db.fetch_block(0, true).unwrap();
-        assert_eq!(genesis.block().body.kernels().len(), 1);
+        assert_eq!(genesis.block().body.kernels().len(), 0);
         let mut mmr_position = 0;
         genesis.block().body.kernels().iter().for_each(|_| {
             let header = db.fetch_header_containing_kernel_mmr(mmr_position).unwrap();
@@ -515,11 +509,12 @@ mod fetch_header_containing_kernel_mmr {
 
     #[tokio::test]
     async fn it_returns_corresponding_header() {
-        let db = setup();
+        let db = setup().unwrap();
         let genesis = db.fetch_block(0, true).unwrap();
         let key_manager = create_test_core_key_manager_with_memory_db();
         let (blocks, outputs) = add_many_chained_blocks(1, &db, &key_manager).await;
         let num_genesis_kernels = genesis.block().body.kernels().len() as u64;
+        assert_eq!(num_genesis_kernels, 0); // no faucet, no coinbase
 
         let (txns, _) = schema_to_transaction(
             &[txn_schema!(from: vec![outputs[0].clone()], to: vec![50 * T])],
@@ -531,17 +526,13 @@ mod fetch_header_containing_kernel_mmr {
         db.add_block(block).unwrap();
         let _block_and_outputs = add_many_chained_blocks(3, &db, &key_manager).await;
 
-        let header = db.fetch_header_containing_kernel_mmr(num_genesis_kernels - 1).unwrap();
-        assert_eq!(header.height(), 0);
-        let header = db.fetch_header_containing_kernel_mmr(num_genesis_kernels).unwrap();
+        let header = db.fetch_header_containing_kernel_mmr(0).unwrap();
         assert_eq!(header.height(), 1);
+        let header = db.fetch_header_containing_kernel_mmr(1).unwrap();
+        assert_eq!(header.height(), 2);
 
-        for i in 1..=2 {
-            let header = db.fetch_header_containing_kernel_mmr(num_genesis_kernels + i).unwrap();
-            assert_eq!(header.height(), 2);
-        }
-        for i in 3..=5 {
-            let header = db.fetch_header_containing_kernel_mmr(num_genesis_kernels + i).unwrap();
+        for i in 2..=5 {
+            let header = db.fetch_header_containing_kernel_mmr(i).unwrap();
             assert_eq!(header.height(), i);
         }
 
@@ -557,7 +548,7 @@ mod clear_all_pending_headers {
 
     #[tokio::test]
     async fn it_clears_no_headers() {
-        let db = setup();
+        let db = setup().unwrap();
         assert_eq!(db.clear_all_pending_headers().unwrap(), 0);
         let key_manager = create_test_core_key_manager_with_memory_db();
         let _block_and_outputs = add_many_chained_blocks(2, &db, &key_manager).await;
@@ -568,7 +559,7 @@ mod clear_all_pending_headers {
 
     #[tokio::test]
     async fn it_clears_headers_after_tip() {
-        let db = setup();
+        let db = setup().unwrap();
         let key_manager = create_test_core_key_manager_with_memory_db();
         let _blocks_and_outputs = add_many_chained_blocks(2, &db, &key_manager).await;
         let prev_block = db.fetch_block(2, true).unwrap();
@@ -628,14 +619,14 @@ mod validator_node_merkle_root {
     async fn it_has_the_correct_genesis_merkle_root() {
         let key_manager = create_test_core_key_manager_with_memory_db();
         let vn_mmr = ValidatorNodeBMT::create(Vec::new());
-        let db = setup();
+        let db = setup().unwrap();
         let (blocks, _outputs) = add_many_chained_blocks(1, &db, &key_manager).await;
         assert_eq!(blocks[0].header.validator_node_mr, vn_mmr.get_merkle_root());
     }
 
     #[tokio::test]
     async fn it_has_the_correct_merkle_root_for_current_vn_set() {
-        let db = setup();
+        let db = setup().unwrap();
         let key_manager = create_test_core_key_manager_with_memory_db();
         let (blocks, outputs) = add_many_chained_blocks(1, &db, &key_manager).await;
 

--- a/base_layer/core/src/consensus/mod.rs
+++ b/base_layer/core/src/consensus/mod.rs
@@ -24,7 +24,7 @@
 pub(crate) mod chain_strength_comparer;
 
 pub mod consensus_constants;
-pub use consensus_constants::{ConsensusConstants, ConsensusConstantsBuilder};
+pub use consensus_constants::ConsensusConstants;
 
 mod consensus_manager;
 pub use consensus_manager::{ConsensusBuilderError, ConsensusManager, ConsensusManagerBuilder, ConsensusManagerError};
@@ -33,5 +33,7 @@ mod consensus_encoding;
 pub use consensus_encoding::{DomainSeparatedConsensusHasher, MaxSizeBytes, MaxSizeString};
 mod network;
 pub use network::NetworkConsensus;
+pub use test_helpers::TestConsensusConstantsBuilder;
 
 pub mod emission;
+pub mod test_helpers;

--- a/base_layer/core/src/consensus/test_helpers.rs
+++ b/base_layer/core/src/consensus/test_helpers.rs
@@ -1,0 +1,121 @@
+// Copyright 2019. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::collections::HashMap;
+
+use tari_common::configuration::Network;
+
+use crate::{
+    consensus::{consensus_constants::PowAlgorithmConstants, ConsensusConstants, NetworkConsensus},
+    proof_of_work::PowAlgorithm,
+    transactions::{
+        tari_amount::MicroTari,
+        transaction_components::{OutputType, RangeProofType},
+    },
+};
+
+/// Test class to create custom consensus constants
+pub struct TestConsensusConstantsBuilder {
+    consensus: ConsensusConstants,
+}
+
+impl TestConsensusConstantsBuilder {
+    pub fn new(network: Network) -> Self {
+        Self {
+            consensus: NetworkConsensus::from(network)
+                .create_consensus_constants()
+                .pop()
+                .expect("Empty consensus constants"),
+        }
+    }
+
+    pub fn clear_proof_of_work(mut self) -> Self {
+        self.consensus.proof_of_work = HashMap::new();
+        self
+    }
+
+    pub fn add_proof_of_work(mut self, proof_of_work: PowAlgorithm, constants: PowAlgorithmConstants) -> Self {
+        self.consensus.proof_of_work.insert(proof_of_work, constants);
+        self
+    }
+
+    pub fn with_coinbase_lockheight(mut self, height: u64) -> Self {
+        self.consensus.coinbase_min_maturity = height;
+        self
+    }
+
+    pub fn with_max_script_byte_size(mut self, byte_size: usize) -> Self {
+        self.consensus.max_script_byte_size = byte_size;
+        self
+    }
+
+    pub fn with_max_block_transaction_weight(mut self, weight: u64) -> Self {
+        self.consensus.max_block_transaction_weight = weight;
+        self
+    }
+
+    pub fn with_consensus_constants(mut self, consensus: ConsensusConstants) -> Self {
+        self.consensus = consensus;
+        self
+    }
+
+    pub fn with_max_randomx_seed_height(mut self, height: u64) -> Self {
+        self.consensus.max_randomx_seed_height = height;
+        self
+    }
+
+    pub fn with_faucet_value(mut self, value: MicroTari) -> Self {
+        self.consensus.faucet_value = value;
+        self
+    }
+
+    pub fn with_emission_amounts(
+        mut self,
+        intial_amount: MicroTari,
+        decay: &'static [u64],
+        tail_amount: MicroTari,
+    ) -> Self {
+        self.consensus.emission_initial = intial_amount;
+        self.consensus.emission_decay = decay;
+        self.consensus.emission_tail = tail_amount;
+        self
+    }
+
+    pub fn with_permitted_output_types(mut self, permitted_output_types: &'static [OutputType]) -> Self {
+        self.consensus.permitted_output_types = permitted_output_types;
+        self
+    }
+
+    pub fn with_permitted_range_proof_types(mut self, permitted_range_proof_types: &'static [RangeProofType]) -> Self {
+        self.consensus.permitted_range_proof_types = permitted_range_proof_types;
+        self
+    }
+
+    pub fn with_blockchain_version(mut self, version: u16) -> Self {
+        self.consensus.blockchain_version = version;
+        self
+    }
+
+    pub fn build(self) -> ConsensusConstants {
+        self.consensus
+    }
+}

--- a/base_layer/core/src/proto/block.proto
+++ b/base_layer/core/src/proto/block.proto
@@ -140,8 +140,8 @@ message NewBlockTemplate {
     tari.types.AggregateBody body = 2;
     // The difficulty is defined as the maximum target divided by the block hash.
     uint64 target_difficulty = 3;
-    // The reward is the sum of the coinbase utxo and the total fees.
-    uint64 reward = 4;
+    // The emission is equal to the value of the coinbase utxo.
+    uint64 emission = 4;
     // The total fees is the sum of all the fees in the block.
     uint64 total_fees  = 5;
 }

--- a/base_layer/core/src/proto/block.rs
+++ b/base_layer/core/src/proto/block.rs
@@ -167,7 +167,7 @@ impl TryFrom<proto::NewBlockTemplate> for NewBlockTemplate {
             header,
             body,
             target_difficulty: Difficulty::from_u64(block_template.target_difficulty).map_err(|e| e.to_string())?,
-            reward: block_template.reward.into(),
+            emission: block_template.emission.into(),
             total_fees: block_template.total_fees.into(),
         })
     }
@@ -181,7 +181,7 @@ impl TryFrom<NewBlockTemplate> for proto::NewBlockTemplate {
             header: Some(block_template.header.into()),
             body: Some(block_template.body.try_into()?),
             target_difficulty: block_template.target_difficulty.as_u64(),
-            reward: block_template.reward.0,
+            emission: block_template.emission.0,
             total_fees: block_template.total_fees.0,
         })
     }

--- a/base_layer/core/src/test_helpers/mod.rs
+++ b/base_layer/core/src/test_helpers/mod.rs
@@ -96,7 +96,7 @@ pub async fn create_block(
         .with_fees(0.into())
         .with_spend_key_id(spend_key_id.clone())
         .with_script_key_id(spend_key_id)
-        .build_with_reward(rules.consensus_constants(block_height), reward)
+        .build_with_emission(rules.consensus_constants(block_height), reward)
         .await
         .unwrap();
 

--- a/base_layer/core/src/transactions/aggregated_body.rs
+++ b/base_layer/core/src/transactions/aggregated_body.rs
@@ -258,7 +258,7 @@ impl AggregateBody {
     /// 1. The reward amount is correct.
     pub fn check_coinbase_output(
         &self,
-        reward: MicroTari,
+        reward: MicroTari, // emission + fees
         coinbase_min_maturity: u64,
         factories: &CryptoFactories,
         height: u64,

--- a/base_layer/core/src/transactions/test_helpers.rs
+++ b/base_layer/core/src/transactions/test_helpers.rs
@@ -319,7 +319,7 @@ pub async fn create_coinbase_wallet_output(
     test_params
         .create_output(
             UtxoTestParams {
-                value: rules.get_block_reward_at(height),
+                value: rules.get_block_emission_at(height),
                 features: OutputFeatures::create_coinbase(height + constants.coinbase_min_maturity(), extra),
                 ..Default::default()
             },

--- a/base_layer/core/src/validation/block_body/test.rs
+++ b/base_layer/core/src/validation/block_body/test.rs
@@ -30,7 +30,7 @@ use super::BlockBodyFullValidator;
 use crate::{
     block_spec,
     blocks::BlockValidationError,
-    consensus::{ConsensusConstantsBuilder, ConsensusManager},
+    consensus::{test_helpers::TestConsensusConstantsBuilder, ConsensusManager},
     proof_of_work::Difficulty,
     test_helpers::{blockchain::TestBlockchain, BlockSpec},
     transactions::{
@@ -55,7 +55,7 @@ fn setup_with_rules(rules: ConsensusManager) -> (TestBlockchain, BlockBodyFullVa
 fn setup() -> (TestBlockchain, BlockBodyFullValidator) {
     let rules = ConsensusManager::builder(Network::LocalNet)
         .add_consensus_constants(
-            ConsensusConstantsBuilder::new(Network::LocalNet)
+            TestConsensusConstantsBuilder::new(Network::LocalNet)
                 .with_coinbase_lockheight(0)
                 .build(),
         )
@@ -117,7 +117,7 @@ async fn it_checks_exactly_one_coinbase() {
         .with_fees(0.into())
         .with_spend_key_id(spend_key_id.clone())
         .with_script_key_id(spend_key_id)
-        .build_with_reward(blockchain.rules().consensus_constants(1), coinbase.value)
+        .build_with_emission(blockchain.rules().consensus_constants(1), coinbase.value)
         .await
         .unwrap();
 
@@ -230,7 +230,7 @@ async fn it_checks_txo_sort_order() {
 async fn it_limits_the_script_byte_size() {
     let rules = ConsensusManager::builder(Network::LocalNet)
         .add_consensus_constants(
-            ConsensusConstantsBuilder::new(Network::LocalNet)
+            TestConsensusConstantsBuilder::new(Network::LocalNet)
                 .with_coinbase_lockheight(0)
                 .with_max_script_byte_size(2)
                 .build(),
@@ -256,7 +256,7 @@ async fn it_limits_the_script_byte_size() {
 async fn it_rejects_invalid_input_metadata() {
     let rules = ConsensusManager::builder(Network::LocalNet)
         .add_consensus_constants(
-            ConsensusConstantsBuilder::new(Network::LocalNet)
+            TestConsensusConstantsBuilder::new(Network::LocalNet)
                 .with_coinbase_lockheight(0)
                 .build(),
         )
@@ -314,7 +314,7 @@ mod body_only {
     async fn it_rejects_invalid_input_metadata() {
         let rules = ConsensusManager::builder(Network::LocalNet)
             .add_consensus_constants(
-                ConsensusConstantsBuilder::new(Network::LocalNet)
+                TestConsensusConstantsBuilder::new(Network::LocalNet)
                     .with_coinbase_lockheight(0)
                     .build(),
             )
@@ -353,7 +353,7 @@ mod orphan_validator {
     async fn it_rejects_zero_conf_double_spends() {
         let rules = ConsensusManager::builder(Network::LocalNet)
             .add_consensus_constants(
-                ConsensusConstantsBuilder::new(Network::LocalNet)
+                TestConsensusConstantsBuilder::new(Network::LocalNet)
                     .with_coinbase_lockheight(0)
                     .build(),
             )
@@ -390,7 +390,7 @@ mod orphan_validator {
     async fn it_rejects_unpermitted_output_types() {
         let rules = ConsensusManager::builder(Network::LocalNet)
             .add_consensus_constants(
-                ConsensusConstantsBuilder::new(Network::LocalNet)
+                TestConsensusConstantsBuilder::new(Network::LocalNet)
                     .with_permitted_output_types(&[OutputType::Coinbase])
                     .with_coinbase_lockheight(0)
                     .build(),
@@ -418,7 +418,7 @@ mod orphan_validator {
     async fn it_rejects_unpermitted_range_proof_types() {
         let rules = ConsensusManager::builder(Network::LocalNet)
             .add_consensus_constants(
-                ConsensusConstantsBuilder::new(Network::LocalNet)
+                TestConsensusConstantsBuilder::new(Network::LocalNet)
                     .with_permitted_range_proof_types(&[RangeProofType::RevealedValue])
                     .with_coinbase_lockheight(0)
                     .build(),

--- a/base_layer/core/tests/chain_storage_tests/chain_storage.rs
+++ b/base_layer/core/tests/chain_storage_tests/chain_storage.rs
@@ -79,7 +79,7 @@ use crate::helpers::{
 fn test_fetch_nonexistent_header() {
     let network = Network::LocalNet;
     let _consensus_manager = ConsensusManagerBuilder::new(network).build();
-    let store = create_test_blockchain_db();
+    let store = create_test_blockchain_db().unwrap();
 
     assert_eq!(store.fetch_header(1).unwrap(), None);
 }
@@ -88,7 +88,7 @@ fn test_fetch_nonexistent_header() {
 fn test_insert_and_fetch_header() {
     let network = Network::LocalNet;
     let _consensus_manager = ConsensusManagerBuilder::new(network).build();
-    let store = create_test_blockchain_db();
+    let store = create_test_blockchain_db().unwrap();
     let genesis_block = store.fetch_tip_header().unwrap();
     let mut header1 = BlockHeader::from_previous(genesis_block.header());
 
@@ -114,7 +114,7 @@ fn test_insert_and_fetch_header() {
 fn test_insert_and_fetch_orphan() {
     let network = Network::LocalNet;
     let consensus_manager = ConsensusManagerBuilder::new(network).build();
-    let store = create_test_blockchain_db();
+    let store = create_test_blockchain_db().unwrap();
     let txs = vec![
         (tx!(1000.into(), fee: 4.into(), inputs: 2, outputs: 1)).0,
         (tx!(2000.into(), fee: 6.into(), inputs: 1, outputs: 1)).0,
@@ -149,7 +149,7 @@ fn test_add_multiple_blocks() {
     // Create new database with genesis block
     let network = Network::LocalNet;
     let consensus_manager = ConsensusManagerBuilder::new(network).build();
-    let store = create_store_with_consensus(consensus_manager.clone());
+    let store = create_store_with_consensus(consensus_manager.clone()).unwrap();
     let metadata = store.get_chain_metadata().unwrap();
     assert_eq!(metadata.height_of_longest_chain(), 0);
     let block0 = store.fetch_block(0, true).unwrap();
@@ -370,7 +370,7 @@ fn test_handle_tip_reorg_with_zero_conf() {
 
     // Create Forked Chain
 
-    let mut orphan_store = create_store_with_consensus(consensus_manager.clone());
+    let mut orphan_store = create_store_with_consensus(consensus_manager.clone()).unwrap();
     orphan_store.add_block(blocks[1].to_arc_block()).unwrap();
     let mut orphan_blocks = vec![blocks[0].clone(), blocks[1].clone()];
     let mut orphan_outputs = vec![outputs[0].clone(), outputs[1].clone()];
@@ -511,7 +511,7 @@ fn test_handle_tip_reorg() {
 
     // Create Forked Chain
 
-    let mut orphan_store = create_store_with_consensus(consensus_manager.clone());
+    let mut orphan_store = create_store_with_consensus(consensus_manager.clone()).unwrap();
     orphan_store.add_block(blocks[1].to_arc_block()).unwrap();
     let mut orphan_blocks = vec![blocks[0].clone(), blocks[1].clone()];
     let mut orphan_outputs = vec![outputs[0].clone(), outputs[1].clone()];
@@ -577,7 +577,7 @@ fn test_handle_tip_reset() {
 
     // Create Forked Chain
 
-    let mut orphan_store = create_store_with_consensus(consensus_manager.clone());
+    let mut orphan_store = create_store_with_consensus(consensus_manager.clone()).unwrap();
     orphan_store.add_block(blocks[1].to_arc_block()).unwrap();
     let mut orphan_blocks = vec![blocks[0].clone(), blocks[1].clone()];
     let mut orphan_outputs = vec![outputs[0].clone(), outputs[1].clone()];
@@ -689,7 +689,7 @@ fn test_handle_reorg() {
     .is_ok());
 
     // Create Forked Chain 1
-    let mut orphan1_store = create_store_with_consensus(consensus_manager.clone());
+    let mut orphan1_store = create_store_with_consensus(consensus_manager.clone()).unwrap();
     orphan1_store
         .add_block(blocks[1].to_arc_block())
         .unwrap()
@@ -734,7 +734,7 @@ fn test_handle_reorg() {
     .is_ok());
 
     // Create Forked Chain 2
-    let mut orphan2_store = create_store_with_consensus(consensus_manager.clone());
+    let mut orphan2_store = create_store_with_consensus(consensus_manager.clone()).unwrap();
     orphan2_store
         .add_block(blocks[1].to_arc_block())
         .unwrap()
@@ -819,7 +819,7 @@ fn test_reorgs_should_update_orphan_tips() {
     let (store, blocks, outputs, consensus_manager) = create_new_blockchain(network);
 
     // Create "A" Chain
-    let mut a_store = create_store_with_consensus(consensus_manager.clone());
+    let mut a_store = create_store_with_consensus(consensus_manager.clone()).unwrap();
     let mut a_blocks = vec![blocks[0].clone()];
     let mut a_outputs = vec![outputs[0].clone()];
 
@@ -853,7 +853,7 @@ fn test_reorgs_should_update_orphan_tips() {
     let a2_hash = *a_blocks[2].hash();
 
     // Create "B" Chain
-    let mut b_store = create_store_with_consensus(consensus_manager.clone());
+    let mut b_store = create_store_with_consensus(consensus_manager.clone()).unwrap();
     let mut b_blocks = vec![blocks[0].clone()];
     let mut b_outputs = vec![outputs[0].clone()];
 
@@ -1078,7 +1078,7 @@ fn test_handle_reorg_with_no_removed_blocks() {
     .unwrap();
 
     // Create Forked Chain 1
-    let mut orphan1_store = create_store_with_consensus(consensus_manager.clone());
+    let mut orphan1_store = create_store_with_consensus(consensus_manager.clone()).unwrap();
     orphan1_store.add_block(blocks[1].to_arc_block()).unwrap(); // A1
     let mut orphan1_blocks = vec![blocks[0].clone(), blocks[1].clone()];
     let mut orphan1_outputs = vec![outputs[0].clone(), outputs[1].clone()];
@@ -1188,7 +1188,7 @@ fn test_handle_reorg_failure_recovery() {
     .unwrap();
 
     // Create Forked Chain 1
-    let mut orphan1_store = create_store_with_consensus(consensus_manager.clone());
+    let mut orphan1_store = create_store_with_consensus(consensus_manager.clone()).unwrap();
     orphan1_store.add_block(blocks[1].to_arc_block()).unwrap(); // A1
     let mut orphan1_blocks = vec![blocks[0].clone(), blocks[1].clone()];
     let mut orphan1_outputs = vec![outputs[0].clone(), outputs[1].clone()];
@@ -1433,7 +1433,7 @@ fn test_invalid_block() {
     let validator = MockValidator::new(true);
     let is_valid = validator.shared_flag();
     let validators = Validators::new(MockValidator::new(true), MockValidator::new(true), validator);
-    let mut store = create_store_with_consensus_and_validators(consensus_manager.clone(), validators);
+    let mut store = create_store_with_consensus_and_validators(consensus_manager.clone(), validators).unwrap();
 
     let mut blocks = vec![block0];
     let mut outputs = vec![vec![output]];
@@ -1722,7 +1722,7 @@ fn test_orphan_cleanup_on_reorg() {
     .unwrap();
 
     // Create Forked Chain
-    let mut orphan_store = create_store_with_consensus(consensus_manager.clone());
+    let mut orphan_store = create_store_with_consensus(consensus_manager.clone()).unwrap();
     let mut orphan_blocks = vec![blocks[0].clone()];
     let mut orphan_outputs = vec![outputs[0].clone()];
     // Block B1

--- a/base_layer/core/tests/chain_storage_tests/mod.rs
+++ b/base_layer/core/tests/chain_storage_tests/mod.rs
@@ -21,5 +21,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 
+#[cfg(any(test))]
 mod chain_backend;
+#[cfg(any(test))]
 mod chain_storage;

--- a/base_layer/core/tests/helpers/mod.rs
+++ b/base_layer/core/tests/helpers/mod.rs
@@ -6,14 +6,25 @@
 //! There are macros, such as `txn_schema!` that help you to easily construct valid transactions in test blockchains,
 //! through to functions that bootstrap entire blockchains in `sample_blockchains`.
 
+#[cfg(any(test))]
 pub mod block_builders;
+#[cfg(any(test))]
 pub mod block_malleability;
+#[cfg(any(test))]
 pub mod block_proxy;
+#[cfg(any(test))]
 pub mod chain_metadata;
+#[cfg(any(test))]
 pub mod database;
+#[cfg(any(test))]
 pub mod event_stream;
+#[cfg(any(test))]
 pub mod mock_state_machine;
+#[cfg(any(test))]
 pub mod nodes;
+#[cfg(any(test))]
 pub mod sample_blockchains;
+#[cfg(any(test))]
 pub mod test_block_builder;
+#[cfg(any(test))]
 pub mod test_blockchain;

--- a/base_layer/core/tests/tests/node_comms_interface.rs
+++ b/base_layer/core/tests/tests/node_comms_interface.rs
@@ -63,7 +63,7 @@ fn new_mempool() -> Mempool {
 
 #[tokio::test]
 async fn inbound_get_metadata() {
-    let store = create_test_blockchain_db();
+    let store = create_test_blockchain_db().unwrap();
     let mempool = new_mempool();
 
     let network = Network::LocalNet;
@@ -97,7 +97,7 @@ async fn inbound_get_metadata() {
 
 #[tokio::test]
 async fn inbound_fetch_kernel_by_excess_sig() {
-    let store = create_test_blockchain_db();
+    let store = create_test_blockchain_db().unwrap();
     let mempool = new_mempool();
 
     let network = Network::LocalNet;
@@ -131,7 +131,7 @@ async fn inbound_fetch_kernel_by_excess_sig() {
 
 #[tokio::test]
 async fn inbound_fetch_headers() {
-    let store = create_test_blockchain_db();
+    let store = create_test_blockchain_db().unwrap();
     let mempool = new_mempool();
     let network = Network::LocalNet;
     let consensus_manager = ConsensusManager::builder(network).build().unwrap();
@@ -162,7 +162,7 @@ async fn inbound_fetch_headers() {
 
 #[tokio::test]
 async fn inbound_fetch_utxos() {
-    let store = create_test_blockchain_db();
+    let store = create_test_blockchain_db().unwrap();
     let mempool = new_mempool();
     let network = Network::LocalNet;
     let consensus_manager = ConsensusManager::builder(network).build().unwrap();
@@ -209,7 +209,7 @@ async fn inbound_fetch_utxos() {
 
 #[tokio::test]
 async fn inbound_fetch_blocks() {
-    let store = create_test_blockchain_db();
+    let store = create_test_blockchain_db().unwrap();
     let mempool = new_mempool();
     let (block_event_sender, _) = broadcast::channel(50);
     let network = Network::LocalNet;
@@ -246,7 +246,7 @@ async fn inbound_fetch_blocks() {
 #[allow(clippy::too_many_lines)]
 async fn inbound_fetch_blocks_before_horizon_height() {
     let consensus_manager = ConsensusManager::builder(Network::LocalNet).build().unwrap();
-    let block0 = consensus_manager.get_genesis_block();
+    let block0 = consensus_manager.get_genesis_block().unwrap();
     let key_manager = create_test_core_key_manager_with_memory_db();
     let validators = Validators::new(
         MockValidator::new(true),
@@ -258,7 +258,8 @@ async fn inbound_fetch_blocks_before_horizon_height() {
         pruning_interval: 1,
         ..Default::default()
     };
-    let store = create_store_with_consensus_and_validators_and_config(consensus_manager.clone(), validators, config);
+    let store =
+        create_store_with_consensus_and_validators_and_config(consensus_manager.clone(), validators, config).unwrap();
     let mempool_validator = TransactionChainLinkedValidator::new(store.clone(), consensus_manager.clone());
     let mempool = Mempool::new(
         MempoolConfig::default(),

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -1010,7 +1010,7 @@ where
             .with_script_key_id(coinbase_script_key)
             .with_script(script!(Nop))
             .with_extra(extra)
-            .build_with_reward(&self.resources.consensus_constants, reward)
+            .build_with_emission(&self.resources.consensus_constants, reward)
             .await?;
 
         let output = DbWalletOutput::from_wallet_output(

--- a/base_layer/wallet/tests/transaction_service_tests/service.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/service.rs
@@ -66,7 +66,7 @@ use tari_core::{
         rpc::BaseNodeWalletRpcServer,
     },
     blocks::BlockHeader,
-    consensus::{ConsensusConstantsBuilder, ConsensusManager},
+    consensus::{test_helpers::TestConsensusConstantsBuilder, ConsensusManager},
     covenants::Covenant,
     one_sided::shared_secret_to_output_encryption_key,
     proto::{
@@ -348,7 +348,7 @@ async fn setup_transaction_service_no_comms(
     wallet_connectivity_service_mock.base_node_changed().await;
 
     let consensus_manager = ConsensusManager::builder(Network::LocalNet).build().unwrap();
-    let constants = ConsensusConstantsBuilder::new(Network::LocalNet).build();
+    let constants = TestConsensusConstantsBuilder::new(Network::LocalNet).build();
 
     let shutdown = Shutdown::new();
 

--- a/integration_tests/src/miner.rs
+++ b/integration_tests/src/miner.rs
@@ -335,7 +335,7 @@ async fn generate_coinbase(
         .with_spend_key_id(spending_key_id)
         .with_script_key_id(script_key_id)
         .with_extra(extra)
-        .build_with_reward(consensus_constants, reward.into())
+        .build_with_emission(consensus_constants, reward.into())
         .await
         .unwrap();
 

--- a/integration_tests/tests/steps/wallet_steps.rs
+++ b/integration_tests/tests/steps/wallet_steps.rs
@@ -1535,7 +1535,7 @@ async fn wallet_with_tari_connected_to_base_node(
     while reward < amount {
         current_height += 1;
         num_blocks += 1;
-        reward += consensus_manager.get_block_reward_at(current_height).as_u64() / 1_000_000; // 1 T = 1_000_000 uT
+        reward += consensus_manager.get_block_emission_at(current_height).as_u64() / 1_000_000; // 1 T = 1_000_000 uT
     }
 
     println!("Creating miner...");


### PR DESCRIPTION

Description
---
- Added genesis block checks to `ConsensusManager::get_genesis_block`, as these were never checked in the production code. This check will be executed whenever a new genesis block is requested, either when a base node starts fresh or with blockchain recovery.
- Added a 'not-before-proof' to 'ProofOfWork::pow_data' that is also checked.
- Added a specific `localnet` genesis block that uses the `esmeralda` genesis block but without the faucet UTXOs.
- The `genesis_block_sanity_check` unit test now consolidates all previous genesis block sanity checks and also uses the production code to check the blocks.

```
genesis_block_sanity_check for 'stagenet': 24.5049ms
genesis_block_sanity_check for 'nextnet': 13.2398ms
genesis_block_sanity_check for 'localnet': 9.3392ms
genesis_block_sanity_check for 'igor': 22.1562012s
genesis_block_sanity_check for 'esmeralda': 10.3047587s
```

Motivation and Context
---
Preparation for code audit.
The genesis block was never checked in the production code. 

How Has This Been Tested?
---
Added to and modified `genesis_block_sanity_check` unit test

What process can a PR reviewer use to test or verify this change?
---
Review code changes

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
