### PR TITLE
fix: update code coverage approach

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -34,42 +34,15 @@ jobs:
         with:
           toolchain: nightly
 
-      - name: cargo test
+      - name: run tests with coverage
         # Prepare the coverage data, even if some tests fail
         continue-on-error: true
-        env:
-          RUSTFLAGS: "-C instrument-coverage"
-          RUSTDOCFLAGS: "-C instrument-coverage"
-          LLVM_PROFILE_FILE: "coverage_data-%p-%m.profraw"
-          CARGO_UNSTABLE_SPARSE_REGISTRY: true
-        run: |
-          rustup component add llvm-tools-preview
-          cargo test --all-features --no-fail-fast --workspace --exclude tari_integration_tests
-
-      - name: prepare coverage data
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-        run: |
-          cargo install grcov
-          grcov . -s . --binary-path ./target/debug -t coveralls --branch --ignore-not-existing \
-             -o ./target/coveralls_coverage.json \
-             --token $COVERALLS_REPO_TOKEN \
-             --ignore target/**/*.rs \
-             --ignore **/.cargo/**/*.rs \
-             --vcs-branch $GITHUB_REF_NAME \
-             --service-name github \
-             --service-job-id ${GITHUB_RUN_ID}
-
-      - name: archive coverage data
-        uses: actions/upload-artifact@v3
-        with:
-          path: target/coveralls_coverage.json
-          name: coveralls-coverage
+        run: bash -c ./scripts/source_coverage.sh
 
       - name: Coveralls upload
-        continue-on-error: true
-        uses: toshke/github-action@master
+        uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: ./target/coveralls_coverage.json
-          file-format: coveralls
+          format: lcov
+          file: lcov.info
+

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ book/
 
 # Ignore Code Coverage Report files
 report
+lcov.info
 
 # On development branch only. This should be removed for point releases
 *.log

--- a/scripts/code_coverage.sh
+++ b/scripts/code_coverage.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+## DEPRECATION NOTICE ##
+#
+# This script is deprecated and will be removed in a future release.
+# Use the source_coverage.sh script for code coverage tests instead.
+#
 
 # Get package to test
 package_arg="--workspace --exclude tari_integration_tests"

--- a/scripts/source_coverage.sh
+++ b/scripts/source_coverage.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# When running in GHA, use lcov format
+if [[ "$CI" == "true" ]]; then
+  output_opts="--lcov --output-path lcov.info"
+else
+  export LLVM_COV_FLAGS="-coverage-watermark=90,66"
+  output_opts="--html"
+fi
+
+ignored_crates=(
+deps_only
+tari_app_grpc
+tari_app_utilities
+tari_base_node
+tari_base_node_grpc_client
+tari_chat_client
+tari_chat_ffi
+tari_common_sqlite
+tari_common_types
+tari_comms
+tari_comms_dht
+tari_comms_rpc_macros
+tari_console_wallet
+tari_contacts
+tari_features
+tari_integration_tests
+tari_libtor
+tari_merge_mining_proxy
+tari_metrics
+tari_miner
+tari_mining_helper_ffi
+tari_p2p
+tari_service_framework
+tari_test_utils
+tari_wallet_ffi
+tari_wallet_grpc_client
+tari_common
+tari_comms
+tari_core
+tari_storage
+tari_wallet
+)
+
+echo "Check for cargo-llvm-cov"
+if [ "$(cargo llvm-cov --version)" ]
+then
+    echo "    + Already installed"
+else
+    echo "    + Installing.."
+    cargo install cargo-llvm-cov
+fi
+
+echo "Source coverage environment parameters:"
+echo $(cargo llvm-cov show-env)
+echo "Output parameters: $output_opts"
+
+echo "Deleting old coverage files"
+cargo llvm-cov clean --workspace
+
+echo "Starting code coverage run"
+cargo llvm-cov test \
+  --all-features \
+  --verbose \
+  --workspace \
+  --ignore-run-fail \
+  --color auto \
+  ${output_opts} \
+  ${ignored_crates[@]/#/--exclude } \
+


### PR DESCRIPTION
Changing out the grcov approach with cargo-llvm-cov which is supposed to be much quicker.

Allows us to easily run code coverage from command line:

```
./scripts/source_coverage.sh
```

or in CI.

We can easily manage the crates that are included by editing the `ignored_crates` array.

In this PR only a small subset of crates are included. This is to check that everything is working. A follow up will add more crates to the coverage tests.


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
