### PR TITLE
chore: add relevant crates to source coverage

### DIFF
--- a/scripts/source_coverage.sh
+++ b/scripts/source_coverage.sh
@@ -16,11 +16,6 @@ tari_base_node
 tari_base_node_grpc_client
 tari_chat_client
 tari_chat_ffi
-tari_common_sqlite
-tari_common_types
-tari_comms
-tari_comms_dht
-tari_comms_rpc_macros
 tari_console_wallet
 tari_contacts
 tari_features
@@ -30,17 +25,24 @@ tari_merge_mining_proxy
 tari_metrics
 tari_miner
 tari_mining_helper_ffi
-tari_p2p
-tari_service_framework
 tari_test_utils
 tari_wallet_ffi
 tari_wallet_grpc_client
-tari_common
-tari_comms
-tari_core
-tari_storage
-tari_wallet
 )
+
+# Included:
+# tari_common
+# tari_comms
+# tari_core
+# tari_common_sqlite
+# tari_common_types
+# tari_comms
+# tari_comms_dht
+# tari_comms_rpc_macros
+# tari_p2p
+# tari_service_framework
+# tari_storage
+# tari_wallet
 
 echo "Check for cargo-llvm-cov"
 if [ "$(cargo llvm-cov --version)" ]


### PR DESCRIPTION
The source coverage GHA is working fine, so this adds all the core crates to the coverage tests.

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
