### PR TITLE
refactor: save re-wrapping

### DIFF
--- a/base_layer/core/src/transactions/key_manager/inner.rs
+++ b/base_layer/core/src/transactions/key_manager/inner.rs
@@ -330,10 +330,10 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
         value: u64,
     ) -> Result<bool, KeyManagerServiceError> {
         let spending_key = self.get_private_key(spending_key_id).await?;
-        Ok(self
-            .crypto_factories
+        self.crypto_factories
             .range_proof
-            .verify_mask(commitment, &spending_key, value)?)
+            .verify_mask(commitment, &spending_key, value)
+            .map_err(|e| e.into())
     }
 
     pub async fn get_diffie_hellman_shared_secret(
@@ -384,7 +384,7 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
 
         let spend_key = self.get_private_key(spending_key).await?;
 
-        let sig = RistrettoComSig::sign(
+        RistrettoComSig::sign(
             amount,
             &spend_key,
             &nonce_a,
@@ -392,8 +392,7 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
             &challenge,
             &*self.crypto_factories.commitment,
         )
-        .map_err(|e| TransactionError::InvalidSignatureError(e.to_string()))?;
-        Ok(sig)
+        .map_err(|e| TransactionError::InvalidSignatureError(e.to_string()))
     }
 
     // -----------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Description
---
Instead of unwrapping, and re-wrapping the same data just pass through with the correct error mapping. Just something I spotted while auditing, although not important for the audit.

Motivation and Context
---
Save micro seconds in processing?

How Has This Been Tested?
---
CI

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify