### PR TITLE
fix(core/transactions)!: consistent output/kernel versions between sender and receiver

### DIFF
--- a/base_layer/core/src/transactions/transaction_components/transaction_kernel_version.rs
+++ b/base_layer/core/src/transactions/transaction_components/transaction_kernel_version.rs
@@ -21,6 +21,13 @@ impl TransactionKernelVersion {
         self as u8
     }
 }
+
+impl Default for TransactionKernelVersion {
+    fn default() -> Self {
+        Self::get_current_version()
+    }
+}
+
 impl TryFrom<u8> for TransactionKernelVersion {
     type Error = String;
 

--- a/base_layer/core/src/transactions/transaction_components/transaction_output_version.rs
+++ b/base_layer/core/src/transactions/transaction_components/transaction_output_version.rs
@@ -46,6 +46,12 @@ impl TransactionOutputVersion {
     }
 }
 
+impl Default for TransactionOutputVersion {
+    fn default() -> Self {
+        Self::get_current_version()
+    }
+}
+
 impl TryFrom<u8> for TransactionOutputVersion {
     type Error = String;
 

--- a/base_layer/core/src/transactions/transaction_protocol/proto/transaction_sender.proto
+++ b/base_layer/core/src/transactions/transaction_protocol/proto/transaction_sender.proto
@@ -35,9 +35,9 @@ message SingleRoundSenderData {
     // The minimum value of the commitment that is proven by the range proof (in MicroTari)
     uint64 minimum_value_promise = 12;
     /// The version of this transaction output
-    uint32 transaction_output_version = 13;
+    uint32 output_version = 13;
     /// The version of this transaction kernel
-    uint32 transaction_kernel_version = 14;
+    uint32 kernel_version = 14;
 }
 
 message TransactionSenderMessage {

--- a/base_layer/core/src/transactions/transaction_protocol/proto/transaction_sender.proto
+++ b/base_layer/core/src/transactions/transaction_protocol/proto/transaction_sender.proto
@@ -34,8 +34,10 @@ message SingleRoundSenderData {
     bytes covenant  = 11;
     // The minimum value of the commitment that is proven by the range proof (in MicroTari)
     uint64 minimum_value_promise = 12;
-    // Unique id for NFTs
-    // bytes unique_id = 12;
+    /// The version of this transaction output
+    uint32 transaction_output_version = 13;
+    /// The version of this transaction kernel
+    uint32 transaction_kernel_version = 14;
 }
 
 message TransactionSenderMessage {

--- a/base_layer/core/src/transactions/transaction_protocol/proto/transaction_sender.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/proto/transaction_sender.rs
@@ -108,11 +108,11 @@ impl TryFrom<proto::SingleRoundSenderData> for SingleRoundSenderData {
             .ok_or_else(|| "Transaction output features not provided".to_string())??;
         let mut buffer = data.covenant.as_slice();
         let covenant = BorshDeserialize::deserialize(&mut buffer).map_err(|err| err.to_string())?;
-        let transaction_output_version = u8::try_from(data.transaction_output_version)
+        let output_version = u8::try_from(data.output_version)
             .map_err(|_| "Transaction output version overflow")?
             .try_into()
             .map_err(|_| "Invalid transaction output version")?;
-        let transaction_kernel_version = u8::try_from(data.transaction_kernel_version)
+        let kernel_version = u8::try_from(data.kernel_version)
             .map_err(|_| "Transaction kernel version overflow")?
             .try_into()
             .map_err(|_| "Invalid transaction kernel version")?;
@@ -130,8 +130,8 @@ impl TryFrom<proto::SingleRoundSenderData> for SingleRoundSenderData {
             ephemeral_public_nonce,
             covenant,
             minimum_value_promise: data.minimum_value_promise.into(),
-            transaction_output_version,
-            transaction_kernel_version,
+            output_version,
+            kernel_version,
         })
     }
 }
@@ -157,8 +157,8 @@ impl TryFrom<SingleRoundSenderData> for proto::SingleRoundSenderData {
             ephemeral_public_nonce: sender_data.ephemeral_public_nonce.to_vec(),
             covenant,
             minimum_value_promise: sender_data.minimum_value_promise.into(),
-            transaction_output_version: sender_data.transaction_output_version.as_u8().into(),
-            transaction_kernel_version: sender_data.transaction_kernel_version.as_u8().into(),
+            output_version: sender_data.output_version.as_u8().into(),
+            kernel_version: sender_data.kernel_version.as_u8().into(),
         })
     }
 }

--- a/base_layer/core/src/transactions/transaction_protocol/proto/transaction_sender.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/proto/transaction_sender.rs
@@ -108,6 +108,14 @@ impl TryFrom<proto::SingleRoundSenderData> for SingleRoundSenderData {
             .ok_or_else(|| "Transaction output features not provided".to_string())??;
         let mut buffer = data.covenant.as_slice();
         let covenant = BorshDeserialize::deserialize(&mut buffer).map_err(|err| err.to_string())?;
+        let transaction_output_version = u8::try_from(data.transaction_output_version)
+            .map_err(|_| "Transaction output version overflow")?
+            .try_into()
+            .map_err(|_| "Invalid transaction output version")?;
+        let transaction_kernel_version = u8::try_from(data.transaction_kernel_version)
+            .map_err(|_| "Transaction kernel version overflow")?
+            .try_into()
+            .map_err(|_| "Invalid transaction kernel version")?;
 
         Ok(Self {
             tx_id: data.tx_id.into(),
@@ -122,6 +130,8 @@ impl TryFrom<proto::SingleRoundSenderData> for SingleRoundSenderData {
             ephemeral_public_nonce,
             covenant,
             minimum_value_promise: data.minimum_value_promise.into(),
+            transaction_output_version,
+            transaction_kernel_version,
         })
     }
 }
@@ -147,6 +157,8 @@ impl TryFrom<SingleRoundSenderData> for proto::SingleRoundSenderData {
             ephemeral_public_nonce: sender_data.ephemeral_public_nonce.to_vec(),
             covenant,
             minimum_value_promise: sender_data.minimum_value_promise.into(),
+            transaction_output_version: sender_data.transaction_output_version.as_u8().into(),
+            transaction_kernel_version: sender_data.transaction_kernel_version.as_u8().into(),
         })
     }
 }

--- a/base_layer/core/src/transactions/transaction_protocol/recipient.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/recipient.rs
@@ -191,7 +191,12 @@ mod test {
             key_manager::{TransactionKeyManagerBranch, TransactionKeyManagerInterface, TxoStage},
             tari_amount::*,
             test_helpers::{create_test_core_key_manager_with_memory_db, TestParams, UtxoTestParams},
-            transaction_components::{OutputFeatures, TransactionKernel, TransactionKernelVersion},
+            transaction_components::{
+                OutputFeatures,
+                TransactionKernel,
+                TransactionKernelVersion,
+                TransactionOutputVersion,
+            },
             transaction_protocol::{
                 sender::{SingleRoundSenderData, TransactionSenderMessage},
                 TransactionMetadata,
@@ -222,6 +227,8 @@ mod test {
             ephemeral_public_nonce: sender_test_params.ephemeral_public_nonce_key_pk,
             covenant: Covenant::default(),
             minimum_value_promise: MicroTari::zero(),
+            transaction_output_version: TransactionOutputVersion::get_current_version(),
+            transaction_kernel_version: TransactionKernelVersion::get_current_version(),
         };
         let sender_info = TransactionSenderMessage::Single(Box::new(msg.clone()));
         let params = UtxoTestParams {

--- a/base_layer/core/src/transactions/transaction_protocol/recipient.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/recipient.rs
@@ -233,8 +233,8 @@ mod test {
             ephemeral_public_nonce: sender_test_params.ephemeral_public_nonce_key_pk,
             covenant: Covenant::default(),
             minimum_value_promise: MicroTari::zero(),
-            transaction_output_version: TransactionOutputVersion::get_current_version(),
-            transaction_kernel_version: TransactionKernelVersion::get_current_version(),
+            output_version: TransactionOutputVersion::get_current_version(),
+            kernel_version: TransactionKernelVersion::get_current_version(),
         };
         let sender_info = TransactionSenderMessage::Single(Box::new(msg.clone()));
         let params = UtxoTestParams {

--- a/base_layer/core/src/transactions/transaction_protocol/sender.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/sender.rs
@@ -516,9 +516,10 @@ impl SenderTransactionProtocol {
         key_manager: &KM,
     ) -> Result<ComAndPubSignature, TPE> {
         let received_output = &rec.output;
+        let version = TransactionOutputVersion::get_current_version();
         // we need to make sure we use our values here and not the received values.
         let metadata_message = TransactionOutput::metadata_signature_message_from_parts(
-            &received_output.version,
+            &version,
             &received_output.script, /* receiver chooses script here, can change fee per gram see issue: https://github.com/tari-project/tari/issues/5430 */
             &info
                 .recipient_data
@@ -557,7 +558,7 @@ impl SenderTransactionProtocol {
                 &recipient_sender_offset_key_id,
                 &received_output.commitment,
                 received_output.metadata_signature.ephemeral_commitment(),
-                &received_output.version,
+                &version,
                 &metadata_message,
             )
             .await?;
@@ -587,6 +588,7 @@ impl SenderTransactionProtocol {
         let mut signature = info.recipient_partial_kernel_signature.clone();
         let mut script_keys = Vec::new();
         let mut sender_offset_keys = Vec::new();
+        let kernel_version = TransactionKernelVersion::get_current_version();
 
         let kernel_message = TransactionKernel::build_kernel_signature_message(
             &TransactionKernelVersion::get_current_version(),
@@ -605,7 +607,7 @@ impl SenderTransactionProtocol {
                         &input.kernel_nonce,
                         &total_public_nonce,
                         &total_public_excess,
-                        &TransactionKernelVersion::get_current_version(),
+                        &kernel_version,
                         &kernel_message,
                         &info.metadata.kernel_features,
                         TxoStage::Input,
@@ -627,7 +629,7 @@ impl SenderTransactionProtocol {
                         &output.kernel_nonce,
                         &total_public_nonce,
                         &total_public_excess,
-                        &TransactionKernelVersion::get_current_version(),
+                        &kernel_version,
                         &kernel_message,
                         &info.metadata.kernel_features,
                         TxoStage::Output,
@@ -656,7 +658,7 @@ impl SenderTransactionProtocol {
                         &change.kernel_nonce,
                         &total_public_nonce,
                         &total_public_excess,
-                        &TransactionKernelVersion::get_current_version(),
+                        &kernel_version,
                         &kernel_message,
                         &info.metadata.kernel_features,
                         TxoStage::Output,
@@ -1112,7 +1114,8 @@ mod test {
         let input = create_test_input(MicroTari(1200), 0, &key_manager).await;
         let utxo = input.to_transaction_input(&key_manager).await.unwrap();
         let script = script!(Nop);
-        let mut builder = SenderTransactionProtocol::builder(create_consensus_constants(0), key_manager.clone());
+        let consensus_constants = create_consensus_constants(0);
+        let mut builder = SenderTransactionProtocol::builder(consensus_constants.clone(), key_manager.clone());
         let fee_per_gram = MicroTari(4);
         let fee = builder.fee().calculate(fee_per_gram, 1, 1, 1, 0);
         builder
@@ -1176,9 +1179,10 @@ mod test {
             .unwrap();
 
         // Receiver gets message, deserializes it etc, and creates his response
-        let mut bob_info = SingleReceiverTransactionProtocol::create(&msg, bob_output, &key_manager)
-            .await
-            .unwrap(); // Alice gets message back, deserializes it, etc
+        let mut bob_info =
+            SingleReceiverTransactionProtocol::create(&msg, bob_output, &key_manager, &consensus_constants)
+                .await
+                .unwrap(); // Alice gets message back, deserializes it, etc
         alice
             .add_single_recipient_info(bob_info.clone(), &key_manager)
             .await
@@ -1215,7 +1219,8 @@ mod test {
         // Bob's parameters
         let bob_key = TestParams::new(&key_manager).await;
         let input = create_test_input(MicroTari(25000), 0, &key_manager).await;
-        let mut builder = SenderTransactionProtocol::builder(create_consensus_constants(0), key_manager.clone());
+        let consensus_constants = create_consensus_constants(0);
+        let mut builder = SenderTransactionProtocol::builder(consensus_constants.clone(), key_manager.clone());
         let script = script!(Nop);
         let expected_fee = builder.fee().calculate(
             MicroTari(20),
@@ -1294,7 +1299,7 @@ mod test {
             .unwrap();
 
         // Receiver gets message, deserializes it etc, and creates his response
-        let bob_info = SingleReceiverTransactionProtocol::create(&msg, bob_output, &key_manager)
+        let bob_info = SingleReceiverTransactionProtocol::create(&msg, bob_output, &key_manager, &consensus_constants)
             .await
             .unwrap();
         // Alice gets message back, deserializes it, etc
@@ -1325,7 +1330,8 @@ mod test {
         let input = create_test_input(MicroTari(10000), 0, &key_manager).await;
         let input2 = create_test_input(MicroTari(2000), 0, &key_manager).await;
         let input3 = create_test_input(MicroTari(15000), 0, &key_manager).await;
-        let mut builder = SenderTransactionProtocol::builder(create_consensus_constants(0), key_manager.clone());
+        let consensus_constants = create_consensus_constants(0);
+        let mut builder = SenderTransactionProtocol::builder(consensus_constants.clone(), key_manager.clone());
         let script = script!(Nop);
         let change = TestParams::new(&key_manager).await;
         builder
@@ -1403,7 +1409,7 @@ mod test {
             .unwrap();
 
         // Receiver gets message, deserializes it etc, and creates his response
-        let bob_info = SingleReceiverTransactionProtocol::create(&msg, bob_output, &key_manager)
+        let bob_info = SingleReceiverTransactionProtocol::create(&msg, bob_output, &key_manager, &consensus_constants)
             .await
             .unwrap();
         // Alice gets message back, deserializes it, etc
@@ -1509,10 +1515,10 @@ mod test {
         let bob_test_params = TestParams::new(&key_manager_bob).await;
         let alice_value = MicroTari(25000);
         let input = create_test_input(alice_value, 0, &key_manager_alice).await;
-
         let script = script!(Nop);
+        let consensus_constants = create_consensus_constants(0);
 
-        let mut builder = SenderTransactionProtocol::builder(create_consensus_constants(0), key_manager_alice.clone());
+        let mut builder = SenderTransactionProtocol::builder(consensus_constants.clone(), key_manager_alice.clone());
         let change_params = TestParams::new(&key_manager_alice).await;
         builder
             .with_lock_height(0)
@@ -1575,9 +1581,10 @@ mod test {
         .unwrap();
 
         // Receiver gets message, deserializes it etc, and creates his response
-        let bob_info = SingleReceiverTransactionProtocol::create(&msg, bob_output, &key_manager_bob)
-            .await
-            .unwrap();
+        let bob_info =
+            SingleReceiverTransactionProtocol::create(&msg, bob_output, &key_manager_bob, &consensus_constants)
+                .await
+                .unwrap();
 
         // Alice gets message back, deserializes it, etc
         alice

--- a/base_layer/core/src/transactions/transaction_protocol/sender.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/sender.rs
@@ -146,9 +146,9 @@ pub struct SingleRoundSenderData {
     /// The minimum value of the commitment that is proven by the range proof
     pub minimum_value_promise: MicroTari,
     /// The version of this transaction output
-    pub transaction_output_version: TransactionOutputVersion,
+    pub output_version: TransactionOutputVersion,
     /// The version of this transaction kernel
-    pub transaction_kernel_version: TransactionKernelVersion,
+    pub kernel_version: TransactionKernelVersion,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -415,8 +415,8 @@ impl SenderTransactionProtocol {
                     .get_public_key_at_key_id(&ephemeral_public_key_nonce)
                     .await?;
 
-                let transaction_output_version = TransactionOutputVersion::get_current_version();
-                let transaction_kernel_version = TransactionKernelVersion::get_current_version();
+                let output_version = TransactionOutputVersion::get_current_version();
+                let kernel_version = TransactionKernelVersion::get_current_version();
 
                 Ok(SingleRoundSenderData {
                     tx_id: info.tx_id,
@@ -431,8 +431,8 @@ impl SenderTransactionProtocol {
                     ephemeral_public_nonce,
                     covenant: recipient_covenant,
                     minimum_value_promise: recipient_minimum_value_promise,
-                    transaction_output_version,
-                    transaction_kernel_version,
+                    output_version,
+                    kernel_version,
                 })
             },
             _ => Err(TPE::InvalidStateError),

--- a/base_layer/core/src/transactions/transaction_protocol/sender.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/sender.rs
@@ -47,6 +47,7 @@ use crate::{
             TransactionKernel,
             TransactionKernelVersion,
             TransactionOutput,
+            TransactionOutputVersion,
             WalletOutput,
             MAX_TRANSACTION_INPUTS,
             MAX_TRANSACTION_OUTPUTS,
@@ -144,6 +145,10 @@ pub struct SingleRoundSenderData {
     pub covenant: Covenant,
     /// The minimum value of the commitment that is proven by the range proof
     pub minimum_value_promise: MicroTari,
+    /// The version of this transaction output
+    pub transaction_output_version: TransactionOutputVersion,
+    /// The version of this transaction kernel
+    pub transaction_kernel_version: TransactionKernelVersion,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -410,6 +415,9 @@ impl SenderTransactionProtocol {
                     .get_public_key_at_key_id(&ephemeral_public_key_nonce)
                     .await?;
 
+                let transaction_output_version = TransactionOutputVersion::get_current_version();
+                let transaction_kernel_version = TransactionKernelVersion::get_current_version();
+
                 Ok(SingleRoundSenderData {
                     tx_id: info.tx_id,
                     amount,
@@ -423,6 +431,8 @@ impl SenderTransactionProtocol {
                     ephemeral_public_nonce,
                     covenant: recipient_covenant,
                     minimum_value_promise: recipient_minimum_value_promise,
+                    transaction_output_version,
+                    transaction_kernel_version,
                 })
             },
             _ => Err(TPE::InvalidStateError),

--- a/base_layer/core/src/transactions/transaction_protocol/single_receiver.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/single_receiver.rs
@@ -124,6 +124,7 @@ mod test {
                 TransactionKernel,
                 TransactionKernelVersion,
                 TransactionOutput,
+                TransactionOutputVersion,
                 WalletOutput,
             },
             transaction_protocol::{
@@ -202,6 +203,8 @@ mod test {
             ephemeral_public_nonce: ephemeral_public_nonce.clone(),
             covenant: Default::default(),
             minimum_value_promise: MicroTari::zero(),
+            transaction_output_version: TransactionOutputVersion::get_current_version(),
+            transaction_kernel_version: TransactionKernelVersion::get_current_version(),
         };
         let bob_public_key = key_manager
             .get_public_key_at_key_id(&test_params.sender_offset_key_id)

--- a/base_layer/core/src/transactions/transaction_protocol/single_receiver.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/single_receiver.rs
@@ -48,7 +48,6 @@ impl SingleReceiverTransactionProtocol {
         key_manager: &KM,
         consensus_constants: &ConsensusConstants,
     ) -> Result<RecipientSignedMessage, TPE> {
-        // output.fill in metadata
         SingleReceiverTransactionProtocol::validate_sender_data(sender_info, consensus_constants)?;
         let transaction_output = output.to_transaction_output(key_manager).await?;
 

--- a/base_layer/core/src/transactions/transaction_protocol/single_receiver.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/single_receiver.rs
@@ -67,7 +67,7 @@ impl SingleReceiverTransactionProtocol {
             .await?;
 
         let kernel_message = TransactionKernel::build_kernel_signature_message(
-            &sender_info.transaction_kernel_version,
+            &sender_info.kernel_version,
             tx_meta.fee,
             tx_meta.lock_height,
             &tx_meta.kernel_features,
@@ -79,7 +79,7 @@ impl SingleReceiverTransactionProtocol {
                 &nonce_id,
                 &(&sender_info.public_nonce + &public_nonce),
                 &(&sender_info.public_excess + &public_excess),
-                &sender_info.transaction_kernel_version,
+                &sender_info.kernel_version,
                 &kernel_message,
                 &tx_meta.kernel_features,
                 TxoStage::Output,
@@ -113,11 +113,11 @@ impl SingleReceiverTransactionProtocol {
         // validate kernel version
         if !consensus_constants
             .kernel_version_range()
-            .contains(&sender_info.transaction_kernel_version)
+            .contains(&sender_info.kernel_version)
         {
             let msg = format!(
                 "Transaction kernel version is not allowed by consensus ({:?})",
-                &sender_info.transaction_kernel_version
+                &sender_info.kernel_version
             );
             return Err(TPE::ValidationError(msg));
         }
@@ -126,11 +126,11 @@ impl SingleReceiverTransactionProtocol {
         if !consensus_constants
             .output_version_range()
             .outputs
-            .contains(&sender_info.transaction_output_version)
+            .contains(&sender_info.output_version)
         {
             let msg = format!(
                 "Transaction output version is not allowed by consensus ({:?})",
-                &sender_info.transaction_output_version
+                &sender_info.output_version
             );
             return Err(TPE::ValidationError(msg));
         }
@@ -244,8 +244,8 @@ mod test {
             ephemeral_public_nonce: ephemeral_public_nonce.clone(),
             covenant: Default::default(),
             minimum_value_promise: MicroTari::zero(),
-            transaction_output_version: TransactionOutputVersion::get_current_version(),
-            transaction_kernel_version: TransactionKernelVersion::get_current_version(),
+            output_version: TransactionOutputVersion::get_current_version(),
+            kernel_version: TransactionKernelVersion::get_current_version(),
         };
         let bob_public_key = key_manager
             .get_public_key_at_key_id(&test_params.sender_offset_key_id)

--- a/base_layer/core/src/transactions/transaction_protocol/single_receiver.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/single_receiver.rs
@@ -20,13 +20,16 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::transactions::{
-    key_manager::{TransactionKeyManagerBranch, TransactionKeyManagerInterface, TxoStage},
-    transaction_components::{TransactionKernel, TransactionKernelVersion, WalletOutput},
-    transaction_protocol::{
-        recipient::RecipientSignedMessage,
-        sender::SingleRoundSenderData,
-        TransactionProtocolError as TPE,
+use crate::{
+    consensus::ConsensusConstants,
+    transactions::{
+        key_manager::{TransactionKeyManagerBranch, TransactionKeyManagerInterface, TxoStage},
+        transaction_components::{TransactionKernel, WalletOutput},
+        transaction_protocol::{
+            recipient::RecipientSignedMessage,
+            sender::SingleRoundSenderData,
+            TransactionProtocolError as TPE,
+        },
     },
 };
 
@@ -43,9 +46,10 @@ impl SingleReceiverTransactionProtocol {
         sender_info: &SingleRoundSenderData,
         output: WalletOutput,
         key_manager: &KM,
+        consensus_constants: &ConsensusConstants,
     ) -> Result<RecipientSignedMessage, TPE> {
         // output.fill in metadata
-        SingleReceiverTransactionProtocol::validate_sender_data(sender_info)?;
+        SingleReceiverTransactionProtocol::validate_sender_data(sender_info, consensus_constants)?;
         let transaction_output = output.to_transaction_output(key_manager).await?;
 
         let (nonce_id, public_nonce) = key_manager
@@ -63,7 +67,7 @@ impl SingleReceiverTransactionProtocol {
             .await?;
 
         let kernel_message = TransactionKernel::build_kernel_signature_message(
-            &TransactionKernelVersion::get_current_version(),
+            &sender_info.transaction_kernel_version,
             tx_meta.fee,
             tx_meta.lock_height,
             &tx_meta.kernel_features,
@@ -75,7 +79,7 @@ impl SingleReceiverTransactionProtocol {
                 &nonce_id,
                 &(&sender_info.public_nonce + &public_nonce),
                 &(&sender_info.public_excess + &public_excess),
-                &TransactionKernelVersion::get_current_version(),
+                &sender_info.transaction_kernel_version,
                 &kernel_message,
                 &tx_meta.kernel_features,
                 TxoStage::Output,
@@ -97,10 +101,40 @@ impl SingleReceiverTransactionProtocol {
     }
 
     /// Validates the sender info
-    fn validate_sender_data(sender_info: &SingleRoundSenderData) -> Result<(), TPE> {
+    fn validate_sender_data(
+        sender_info: &SingleRoundSenderData,
+        consensus_constants: &ConsensusConstants,
+    ) -> Result<(), TPE> {
+        // validate amount
         if sender_info.amount == 0.into() {
             return Err(TPE::ValidationError("Cannot send zero microTari".into()));
         }
+
+        // validate kernel version
+        if !consensus_constants
+            .kernel_version_range()
+            .contains(&sender_info.transaction_kernel_version)
+        {
+            let msg = format!(
+                "Transaction kernel version is not allowed by consensus ({:?})",
+                &sender_info.transaction_kernel_version
+            );
+            return Err(TPE::ValidationError(msg));
+        }
+
+        // validate output version
+        if !consensus_constants
+            .output_version_range()
+            .outputs
+            .contains(&sender_info.transaction_output_version)
+        {
+            let msg = format!(
+                "Transaction output version is not allowed by consensus ({:?})",
+                &sender_info.transaction_output_version
+            );
+            return Err(TPE::ValidationError(msg));
+        }
+
         Ok(())
     }
 }
@@ -114,6 +148,7 @@ mod test {
 
     use crate::{
         covenants::Covenant,
+        test_helpers::create_consensus_constants,
         transactions::{
             key_manager::TransactionKeyManagerInterface,
             tari_amount::*,
@@ -140,6 +175,7 @@ mod test {
     async fn zero_amount_fails() {
         let key_manager = create_test_core_key_manager_with_memory_db();
         let test_params = TestParams::new(&key_manager).await;
+        let consensus_constants = create_consensus_constants(0);
         let info = SingleRoundSenderData::default();
         let bob_output = WalletOutput::new_current_version(
             MicroTari(5000),
@@ -160,7 +196,7 @@ mod test {
         .unwrap();
 
         #[allow(clippy::match_wild_err_arm)]
-        match SingleReceiverTransactionProtocol::create(&info, bob_output, &key_manager).await {
+        match SingleReceiverTransactionProtocol::create(&info, bob_output, &key_manager, &consensus_constants).await {
             Ok(_) => panic!("Zero amounts should fail"),
             Err(TransactionProtocolError::ValidationError(s)) => assert_eq!(s, "Cannot send zero microTari"),
             Err(_) => panic!("Protocol fails for the wrong reason"),
@@ -169,7 +205,12 @@ mod test {
 
     #[tokio::test]
     async fn valid_request() {
-        let key_manager = create_test_core_key_manager_with_memory_db();
+        let key_manager: crate::transactions::key_manager::TransactionKeyManagerWrapper<
+            tari_key_manager::key_manager_service::storage::sqlite_db::KeyManagerSqliteDatabase<
+                tari_common_sqlite::connection::DbConnection,
+            >,
+        > = create_test_core_key_manager_with_memory_db();
+        let consensus_constants = create_consensus_constants(0);
         let m = TransactionMetadata::new(MicroTari(100), 0);
         let test_params = TestParams::new(&key_manager).await;
         let test_params2 = TestParams::new(&key_manager).await;
@@ -241,7 +282,7 @@ mod test {
             .await
             .unwrap();
 
-        let prot = SingleReceiverTransactionProtocol::create(&info, bob_output, &key_manager)
+        let prot = SingleReceiverTransactionProtocol::create(&info, bob_output, &key_manager, &consensus_constants)
             .await
             .unwrap();
         assert_eq!(prot.tx_id.as_u64(), 500, "tx_id is incorrect");

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -760,9 +760,13 @@ where
             .db
             .add_output_to_be_received(single_round_sender_data.tx_id, output, None)?;
 
-        let rtp =
-            ReceiverTransactionProtocol::new(sender_message.clone(), key_kanager_output, &self.resources.key_manager)
-                .await;
+        let rtp = ReceiverTransactionProtocol::new(
+            sender_message.clone(),
+            key_kanager_output,
+            &self.resources.key_manager,
+            &self.resources.consensus_constants,
+        )
+        .await;
 
         Ok(rtp)
     }

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -178,6 +178,7 @@ pub struct TransactionService<
     base_node_service: BaseNodeServiceHandle,
     last_seen_tip_height: Option<u64>,
     validation_in_progress: Arc<Mutex<()>>,
+    consensus_manager: ConsensusManager,
 }
 
 impl<
@@ -250,7 +251,7 @@ where
             factories,
             config: config.clone(),
             shutdown_signal,
-            consensus_manager,
+            consensus_manager: consensus_manager.clone(),
         };
         let power_mode = PowerMode::default();
         let timeout = match power_mode {
@@ -281,6 +282,7 @@ where
             wallet_db,
             last_seen_tip_height: None,
             validation_in_progress: Arc::new(Mutex::new(())),
+            consensus_manager,
         }
     }
 
@@ -1080,7 +1082,8 @@ where
         let hash: [u8; 32] = Sha256::digest(pre_image.as_bytes()).into();
 
         // lets make the unlock height a day from now, 2 min blocks which gives us 30 blocks per hour * 24 hours
-        let height = self.last_seen_tip_height.unwrap_or(0) + (24 * 30);
+        let tip_height = self.last_seen_tip_height.unwrap_or(0);
+        let height = tip_height + (24 * 30);
 
         // lets create the HTLC script
         let script = script!(
@@ -1203,10 +1206,12 @@ where
             .await
             .unwrap();
 
+        let consensus_constants = self.consensus_manager.consensus_constants(tip_height);
         let rtp = ReceiverTransactionProtocol::new(
             sender_message,
             output.clone(),
             &self.resources.transaction_key_manager_service,
+            consensus_constants,
         )
         .await;
 
@@ -1394,9 +1399,15 @@ where
             .try_build(&self.resources.transaction_key_manager_service)
             .await?;
 
-        let rtp =
-            ReceiverTransactionProtocol::new(sender_message, output, &self.resources.transaction_key_manager_service)
-                .await;
+        let tip_height = self.last_seen_tip_height.unwrap_or(0);
+        let consensus_constants = self.consensus_manager.consensus_constants(tip_height);
+        let rtp = ReceiverTransactionProtocol::new(
+            sender_message,
+            output,
+            &self.resources.transaction_key_manager_service,
+            consensus_constants,
+        )
+        .await;
 
         let recipient_reply = rtp.get_signed_data()?.clone();
 
@@ -1639,9 +1650,15 @@ where
             .try_build(&self.resources.transaction_key_manager_service)
             .await?;
 
-        let rtp =
-            ReceiverTransactionProtocol::new(sender_message, output, &self.resources.transaction_key_manager_service)
-                .await;
+        let tip_height = self.last_seen_tip_height.unwrap_or(0);
+        let consensus_constants = self.consensus_manager.consensus_constants(tip_height);
+        let rtp = ReceiverTransactionProtocol::new(
+            sender_message,
+            output,
+            &self.resources.transaction_key_manager_service,
+            consensus_constants,
+        )
+        .await;
 
         let recipient_reply = rtp.get_signed_data()?.clone();
         let range_proof = recipient_reply.output.proof_result()?.clone();

--- a/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
@@ -2295,6 +2295,7 @@ mod test {
     #[allow(clippy::too_many_lines)]
     async fn test_crud() {
         let key_manager = create_test_core_key_manager_with_memory_db();
+        let consensus_constants = create_consensus_constants(0);
         let db_name = format!("{}.sqlite3", string(8).as_str());
         let temp_dir = tempdir().unwrap();
         let db_folder = temp_dir.path().to_str().unwrap().to_string();
@@ -2447,6 +2448,7 @@ mod test {
             TransactionSenderMessage::Single(Box::new(stp.build_single_round_message(&key_manager).await.unwrap())),
             output,
             &key_manager,
+            &consensus_constants,
         )
         .await;
         let address = TariAddress::new(

--- a/base_layer/wallet/tests/transaction_service_tests/service.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/service.rs
@@ -1629,7 +1629,7 @@ async fn manage_multiple_transactions() {
 #[tokio::test]
 async fn test_accepting_unknown_tx_id_and_malformed_reply() {
     let factories = CryptoFactories::default();
-
+    let consensus_constants = create_consensus_constants(0);
     let temp_dir = tempdir().unwrap();
     let path_string = temp_dir.path().to_str().unwrap().to_string();
     let alice_db_name = format!("{}.sqlite3", random::string(8).as_str());
@@ -1683,7 +1683,13 @@ async fn test_accepting_unknown_tx_id_and_malformed_reply() {
 
     let sender = sender_message.try_into().unwrap();
     let output = create_wallet_output_from_sender_data(&sender, &alice_ts_interface.key_manager_handle).await;
-    let rtp = ReceiverTransactionProtocol::new(sender, output, &alice_ts_interface.key_manager_handle).await;
+    let rtp = ReceiverTransactionProtocol::new(
+        sender,
+        output,
+        &alice_ts_interface.key_manager_handle,
+        &consensus_constants,
+    )
+    .await;
 
     let mut tx_reply = rtp.get_signed_data().unwrap().clone();
     let mut wrong_tx_id = tx_reply.clone();
@@ -3300,7 +3306,7 @@ async fn test_restarting_transaction_protocols() {
     let constants = create_consensus_constants(0);
     let fee_calc = Fee::new(*constants.transaction_weight_params());
     let key_manager = create_test_core_key_manager_with_memory_db();
-    let mut builder = SenderTransactionProtocol::builder(constants, key_manager.clone());
+    let mut builder = SenderTransactionProtocol::builder(constants.clone(), key_manager.clone());
     let fee = fee_calc.calculate(MicroTari(4), 1, 1, 1, 0);
     let change = TestParams::new(&key_manager).await;
     builder
@@ -3334,7 +3340,7 @@ async fn test_restarting_transaction_protocols() {
     let sender_info = TransactionSenderMessage::Single(Box::new(msg.clone()));
 
     let output = create_wallet_output_from_sender_data(&sender_info, &key_manager).await;
-    let receiver_protocol = ReceiverTransactionProtocol::new(sender_info, output, &key_manager).await;
+    let receiver_protocol = ReceiverTransactionProtocol::new(sender_info, output, &key_manager, &constants).await;
 
     let alice_reply = receiver_protocol.get_signed_data().unwrap().clone();
 
@@ -4653,7 +4659,7 @@ async fn test_resend_on_startup() {
     .unwrap();
     let constants = create_consensus_constants(0);
     let key_manager = create_test_core_key_manager_with_memory_db();
-    let mut builder = SenderTransactionProtocol::builder(constants, key_manager.clone());
+    let mut builder = SenderTransactionProtocol::builder(constants.clone(), key_manager.clone());
     let amount = MicroTari::from(10_000);
     let change = TestParams::new(&key_manager).await;
     builder
@@ -4811,7 +4817,13 @@ async fn test_resend_on_startup() {
 
     // Now we do this for the Transaction Reply
     let output = create_wallet_output_from_sender_data(&tx_sender_msg, &alice2_ts_interface.key_manager_handle).await;
-    let rtp = ReceiverTransactionProtocol::new(tx_sender_msg, output, &alice2_ts_interface.key_manager_handle).await;
+    let rtp = ReceiverTransactionProtocol::new(
+        tx_sender_msg,
+        output,
+        &alice2_ts_interface.key_manager_handle,
+        &constants,
+    )
+    .await;
     let address = TariAddress::new(
         PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
         Network::LocalNet,

--- a/base_layer/wallet/tests/transaction_service_tests/storage.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/storage.rs
@@ -86,7 +86,7 @@ pub async fn test_db_backend<T: TransactionBackend + 'static>(backend: T) {
     .unwrap();
     let constants = create_consensus_constants(0);
     let key_manager = create_test_core_key_manager_with_memory_db();
-    let mut builder = SenderTransactionProtocol::builder(constants, key_manager.clone());
+    let mut builder = SenderTransactionProtocol::builder(constants.clone(), key_manager.clone());
     let amount = MicroTari::from(10_000);
     builder
         .with_lock_height(0)
@@ -215,9 +215,13 @@ pub async fn test_db_backend<T: TransactionBackend + 'static>(backend: T) {
         .await
         .unwrap();
 
-    let rtp =
-        ReceiverTransactionProtocol::new(TransactionSenderMessage::Single(Box::new(sender)), output, &key_manager)
-            .await;
+    let rtp = ReceiverTransactionProtocol::new(
+        TransactionSenderMessage::Single(Box::new(sender)),
+        output,
+        &key_manager,
+        &constants,
+    )
+    .await;
 
     let mut inbound_txs = Vec::new();
 


### PR DESCRIPTION
Description
---
* Added new fields `kernel_version` and `output_version` in `SingleRoundSenderData`
* Updated `protobuf` messages and conversions for the new fields in `SingleRoundSenderData`
* Sender never uses the versions provided by the receiver (e.g. in signatures), only uses its own versions
* Receiver checks (and uses) the versions provided by the sender. Raises an error if the version is not in the allowed range of the consensus constants.
* Implemented the `Default` trait in kernel and output version structs for convenience

Motivation and Context
---
Ref https://github.com/tari-project/tari/issues/5536

When doing a new transaction, the sender protocol must enforce consistent output and kernel versions between senders  and receivers. This is needed to prevent invalid signatures if wallet versions mismatch.

We need to make sure that:
* All information signed in the challenge of the metadata and kernel signatures are sent over to the receiver to be used and checked
* If the receiver does not support the sender's versions, the transaction should be failed
* The sender never uses the receiver versions when building a challenge

How Has This Been Tested?
---
New unit test to check expected behaviour on mismatched versions between sender and receiver.

Manual testing is tricky here, would involve spawning a sender and receiver with mismatched versions (probably by hardcoding values) and try sending transactions between them.

What process can a PR reviewer use to test or verify this change?
---
Manual testing with mismatched versions between transaction sender and receiver

Breaking Changes
---

- [ ] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [x] The transaction protocol messages (`protobuf`) formats have new extra fields

**⚠ BREAKING CHANGE: old wallets will be incompatible as the messages for new transactions now expect additional fields**
