### PR TITLE
chore: version bump to 0.51.0-pre.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5074,7 +5074,7 @@ dependencies = [
 
 [[package]]
 name = "tari_app_grpc"
-version = "0.51.0-pre.3"
+version = "0.51.0-pre.4"
 dependencies = [
  "argon2",
  "base64 0.13.1",
@@ -5098,7 +5098,7 @@ dependencies = [
 
 [[package]]
 name = "tari_app_utilities"
-version = "0.51.0-pre.3"
+version = "0.51.0-pre.4"
 dependencies = [
  "clap 3.2.25",
  "futures 0.3.28",
@@ -5117,7 +5117,7 @@ dependencies = [
 
 [[package]]
 name = "tari_base_node"
-version = "0.51.0-pre.3"
+version = "0.51.0-pre.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5214,7 +5214,7 @@ dependencies = [
 
 [[package]]
 name = "tari_chat_client"
-version = "0.51.0-pre.3"
+version = "0.51.0-pre.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5238,7 +5238,7 @@ dependencies = [
 
 [[package]]
 name = "tari_chat_ffi"
-version = "0.51.0-pre.3"
+version = "0.51.0-pre.4"
 dependencies = [
  "cbindgen 0.24.5",
  "libc",
@@ -5256,7 +5256,7 @@ dependencies = [
 
 [[package]]
 name = "tari_common"
-version = "0.51.0-pre.3"
+version = "0.51.0-pre.4"
 dependencies = [
  "anyhow",
  "blake2 0.9.2",
@@ -5283,7 +5283,7 @@ dependencies = [
 
 [[package]]
 name = "tari_common_sqlite"
-version = "0.51.0-pre.3"
+version = "0.51.0-pre.4"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -5297,7 +5297,7 @@ dependencies = [
 
 [[package]]
 name = "tari_common_types"
-version = "0.51.0-pre.3"
+version = "0.51.0-pre.4"
 dependencies = [
  "base64 0.21.2",
  "borsh",
@@ -5316,7 +5316,7 @@ dependencies = [
 
 [[package]]
 name = "tari_comms"
-version = "0.51.0-pre.3"
+version = "0.51.0-pre.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5366,7 +5366,7 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_dht"
-version = "0.51.0-pre.3"
+version = "0.51.0-pre.4"
 dependencies = [
  "anyhow",
  "bitflags 1.3.2",
@@ -5410,7 +5410,7 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_rpc_macros"
-version = "0.51.0-pre.3"
+version = "0.51.0-pre.4"
 dependencies = [
  "futures 0.3.28",
  "proc-macro2",
@@ -5425,7 +5425,7 @@ dependencies = [
 
 [[package]]
 name = "tari_console_wallet"
-version = "0.51.0-pre.3"
+version = "0.51.0-pre.4"
 dependencies = [
  "bitflags 1.3.2",
  "chrono",
@@ -5478,7 +5478,7 @@ dependencies = [
 
 [[package]]
 name = "tari_contacts"
-version = "0.51.0-pre.3"
+version = "0.51.0-pre.4"
 dependencies = [
  "chrono",
  "diesel",
@@ -5509,7 +5509,7 @@ dependencies = [
 
 [[package]]
 name = "tari_core"
-version = "0.51.0-pre.3"
+version = "0.51.0-pre.4"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5610,7 +5610,7 @@ dependencies = [
 
 [[package]]
 name = "tari_features"
-version = "0.51.0-pre.3"
+version = "0.51.0-pre.4"
 
 [[package]]
 name = "tari_integration_tests"
@@ -5661,7 +5661,7 @@ dependencies = [
 
 [[package]]
 name = "tari_key_manager"
-version = "0.51.0-pre.3"
+version = "0.51.0-pre.4"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5715,7 +5715,7 @@ dependencies = [
 
 [[package]]
 name = "tari_merge_mining_proxy"
-version = "0.51.0-pre.3"
+version = "0.51.0-pre.4"
 dependencies = [
  "anyhow",
  "bincode",
@@ -5765,7 +5765,7 @@ dependencies = [
 
 [[package]]
 name = "tari_miner"
-version = "0.51.0-pre.3"
+version = "0.51.0-pre.4"
 dependencies = [
  "base64 0.13.1",
  "borsh",
@@ -5801,7 +5801,7 @@ dependencies = [
 
 [[package]]
 name = "tari_mining_helper_ffi"
-version = "0.51.0-pre.3"
+version = "0.51.0-pre.4"
 dependencies = [
  "borsh",
  "hex",
@@ -5817,7 +5817,7 @@ dependencies = [
 
 [[package]]
 name = "tari_mmr"
-version = "0.51.0-pre.3"
+version = "0.51.0-pre.4"
 dependencies = [
  "bincode",
  "blake2 0.9.2",
@@ -5837,7 +5837,7 @@ dependencies = [
 
 [[package]]
 name = "tari_p2p"
-version = "0.51.0-pre.3"
+version = "0.51.0-pre.4"
 dependencies = [
  "anyhow",
  "clap 3.2.25",
@@ -5891,7 +5891,7 @@ dependencies = [
 
 [[package]]
 name = "tari_service_framework"
-version = "0.51.0-pre.3"
+version = "0.51.0-pre.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5908,7 +5908,7 @@ dependencies = [
 
 [[package]]
 name = "tari_shutdown"
-version = "0.51.0-pre.3"
+version = "0.51.0-pre.4"
 dependencies = [
  "futures 0.3.28",
  "tokio",
@@ -5916,7 +5916,7 @@ dependencies = [
 
 [[package]]
 name = "tari_storage"
-version = "0.51.0-pre.3"
+version = "0.51.0-pre.4"
 dependencies = [
  "bincode",
  "lmdb-zero",
@@ -5929,7 +5929,7 @@ dependencies = [
 
 [[package]]
 name = "tari_test_utils"
-version = "0.51.0-pre.3"
+version = "0.51.0-pre.4"
 dependencies = [
  "futures 0.3.28",
  "futures-test",
@@ -5961,7 +5961,7 @@ dependencies = [
 
 [[package]]
 name = "tari_wallet"
-version = "0.51.0-pre.3"
+version = "0.51.0-pre.4"
 dependencies = [
  "argon2",
  "async-trait",
@@ -6011,7 +6011,7 @@ dependencies = [
 
 [[package]]
 name = "tari_wallet_ffi"
-version = "0.51.0-pre.3"
+version = "0.51.0-pre.4"
 dependencies = [
  "borsh",
  "cbindgen 0.24.5",

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ The recommended running versions of each network are:
 
 | Network   | Version      |
 |-----------|--------------|
-| Stagenet  | 0.49.0       |
+| Stagenet  | 0.49.2       |
 | Nextnet   | 0.50.0-rc.0  |
-| Esmeralda | 0.51.0-pre.3 |
+| Esmeralda | 0.51.0-pre.4 |
 
 For more detail about versioning see [Release Ideology](https://github.com/tari-project/tari/blob/development/docs/src/branching_releases.md)
 

--- a/applications/tari_app_grpc/Cargo.toml
+++ b/applications/tari_app_grpc/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "This crate is to provide a single source for all cross application grpc files and conversions to and from tari::core"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.51.0-pre.3"
+version = "0.51.0-pre.4"
 edition = "2018"
 
 [dependencies]

--- a/applications/tari_app_utilities/Cargo.toml
+++ b/applications/tari_app_utilities/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_app_utilities"
-version = "0.51.0-pre.3"
+version = "0.51.0-pre.4"
 authors = ["The Tari Development Community"]
 edition = "2018"
 license = "BSD-3-Clause"
@@ -9,7 +9,7 @@ license = "BSD-3-Clause"
 tari_common = { path = "../../common" }
 tari_common_types = { path = "../../base_layer/common_types" }
 tari_comms = { path = "../../comms/core" }
-tari_features = { version = "0.51.0-pre.3", path = "../../common/tari_features"}
+tari_features = { version = "0.51.0-pre.4", path = "../../common/tari_features"}
 tari_utilities = { version = "0.4.10"}
 
 clap = { version = "3.2", features = ["derive", "env"] }
@@ -23,4 +23,4 @@ thiserror = "^1.0.26"
 
 [build-dependencies]
 tari_common = { path = "../../common", features = ["build", "static-application-info"] }
-tari_features = { version = "0.51.0-pre.3", path = "../../common/tari_features"}
+tari_features = { version = "0.51.0-pre.4", path = "../../common/tari_features"}

--- a/applications/tari_base_node/Cargo.toml
+++ b/applications/tari_base_node/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "The tari full base node implementation"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.51.0-pre.3"
+version = "0.51.0-pre.4"
 edition = "2018"
 
 [dependencies]
@@ -59,7 +59,7 @@ safe = []
 libtor = ["tari_libtor"]
 
 [build-dependencies]
-tari_features = { version = "0.51.0-pre.3", path = "../../common/tari_features"}
+tari_features = { version = "0.51.0-pre.4", path = "../../common/tari_features"}
 
 [package.metadata.cargo-machete]
 ignored = [

--- a/applications/tari_console_wallet/Cargo.toml
+++ b/applications/tari_console_wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_console_wallet"
-version = "0.51.0-pre.3"
+version = "0.51.0-pre.4"
 authors = ["The Tari Development Community"]
 edition = "2018"
 license = "BSD-3-Clause"
@@ -67,7 +67,7 @@ default-features = false
 features = ["crossterm"]
 
 [build-dependencies]
-tari_features = { version = "0.51.0-pre.3", path = "../../common/tari_features"}
+tari_features = { version = "0.51.0-pre.4", path = "../../common/tari_features"}
 
 [features]
 avx2 = ["tari_core/avx2", "tari_crypto/simd_backend", "tari_wallet/avx2", "tari_comms/avx2", "tari_comms_dht/avx2", "tari_p2p/avx2", "tari_key_manager/avx2"]

--- a/applications/tari_merge_mining_proxy/Cargo.toml
+++ b/applications/tari_merge_mining_proxy/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "The Tari merge mining proxy for xmrig"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.51.0-pre.3"
+version = "0.51.0-pre.4"
 edition = "2018"
 
 [features]
@@ -42,4 +42,4 @@ tracing = "0.1"
 url = "2.1.1"
 
 [build-dependencies]
-tari_features = { version = "0.51.0-pre.3", path = "../../common/tari_features"}
+tari_features = { version = "0.51.0-pre.4", path = "../../common/tari_features"}

--- a/applications/tari_miner/Cargo.toml
+++ b/applications/tari_miner/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "The tari miner implementation"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.51.0-pre.3"
+version = "0.51.0-pre.4"
 edition = "2018"
 
 [dependencies]

--- a/base_layer/chat_ffi/Cargo.toml
+++ b/base_layer/chat_ffi/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_chat_ffi"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency chat C FFI bindings"
 license = "BSD-3-Clause"
-version = "0.51.0-pre.3"
+version = "0.51.0-pre.4"
 edition = "2018"
 
 [dependencies]

--- a/base_layer/common_types/Cargo.toml
+++ b/base_layer/common_types/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_common_types"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency common types"
 license = "BSD-3-Clause"
-version = "0.51.0-pre.3"
+version = "0.51.0-pre.4"
 edition = "2018"
 
 [dependencies]

--- a/base_layer/contacts/Cargo.toml
+++ b/base_layer/contacts/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_contacts"
 authors = ["The Tari Development Community"]
 description = "Tari contacts library"
 license = "BSD-3-Clause"
-version = "0.51.0-pre.3"
+version = "0.51.0-pre.4"
 edition = "2018"
 
 [dependencies]

--- a/base_layer/contacts/examples/chat_client/Cargo.toml
+++ b/base_layer/contacts/examples/chat_client/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_chat_client"
 authors = ["The Tari Development Community"]
 description = "Tari cucumber chat client"
 license = "BSD-3-Clause"
-version = "0.51.0-pre.3"
+version = "0.51.0-pre.4"
 
 edition = "2018"
 

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.51.0-pre.3"
+version = "0.51.0-pre.4"
 edition = "2018"
 
 [features]

--- a/base_layer/key_manager/Cargo.toml
+++ b/base_layer/key_manager/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency wallet key management"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.51.0-pre.3"
+version = "0.51.0-pre.4"
 edition = "2021"
 
 [lib]

--- a/base_layer/mmr/Cargo.toml
+++ b/base_layer/mmr/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "A Merkle Mountain Range implementation"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.51.0-pre.3"
+version = "0.51.0-pre.4"
 edition = "2018"
 
 [features]

--- a/base_layer/p2p/Cargo.toml
+++ b/base_layer/p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_p2p"
-version = "0.51.0-pre.3"
+version = "0.51.0-pre.4"
 authors = ["The Tari Development community"]
 description = "Tari base layer-specific peer-to-peer communication features"
 repository = "https://github.com/tari-project/tari"

--- a/base_layer/service_framework/Cargo.toml
+++ b/base_layer/service_framework/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_service_framework"
-version = "0.51.0-pre.3"
+version = "0.51.0-pre.4"
 authors = ["The Tari Development Community"]
 description = "The Tari communication stack service framework"
 repository = "https://github.com/tari-project/tari"

--- a/base_layer/tari_mining_helper_ffi/Cargo.toml
+++ b/base_layer/tari_mining_helper_ffi/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_mining_helper_ffi"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency miningcore C FFI bindings"
 license = "BSD-3-Clause"
-version = "0.51.0-pre.3"
+version = "0.51.0-pre.4"
 edition = "2018"
 
 [dependencies]

--- a/base_layer/wallet/Cargo.toml
+++ b/base_layer/wallet/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_wallet"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency wallet library"
 license = "BSD-3-Clause"
-version = "0.51.0-pre.3"
+version = "0.51.0-pre.4"
 edition = "2018"
 
 [dependencies]

--- a/base_layer/wallet_ffi/Cargo.toml
+++ b/base_layer/wallet_ffi/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_wallet_ffi"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency wallet C FFI bindings"
 license = "BSD-3-Clause"
-version = "0.51.0-pre.3"
+version = "0.51.0-pre.4"
 edition = "2018"
 
 [dependencies]

--- a/changelog-development.md
+++ b/changelog-development.md
@@ -2,6 +2,30 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [0.51.0-pre.4](https://github.com/tari-project/tari/compare/v0.51.0-pre.3...v0.51.0-pre.4) (2023-06-30)
+
+#### Breaking Changes
+
+* hash domain consistency (#5556) ([64443c6f](https://github.com/tari-project/tari/commit/64443c6f428fa84f8ab3e4b86949be6faef35aeb))
+* consistent output/kernel versions between sender and receiver (#5553) ([74f9c35f](https://github.com/tari-project/tari/commit/74f9c35f6a34c1cf731274b7febb245734ae7032))
+
+#### Bug Fixes
+
+*   mempool should use the correct version of the consensus constant (#5549) ([46ab3ef0](https://github.com/tari-project/tari/commit/46ab3ef07e41b091b869ef59376d0709a24e7437))
+*   mempool fetch_highest_priority_txs (#5551) ([f7f749c4](https://github.com/tari-project/tari/commit/f7f749c4c476f489f9e30afb87461780d1996834)
+*   remove optional timestamp verification bypass (#5552) ([b5a5bed2](https://github.com/tari-project/tari/commit/b5a5bed2c23c273d3787afa1c845f62badec1a46))
+*   update code coverage approach (#5540) ([7a9830ed](https://github.com/tari-project/tari/commit/7a9830edb66b6be3edc40b84ae8a1a9c3f4ef525)
+*   use correct TOML field for console wallet network address (#5531) ([70763dde](https://github.com/tari-project/tari/commit/70763dde25c1569013e489a0798540fd66dfa571)
+*   llvm-tools installed correctly (#5534) ([4ab4b965](https://github.com/tari-project/tari/commit/4ab4b965e5f0556d508ec071a152deb5ad8ea8cc))
+*   push test coverage even if some tests fail (#5533) ([053c748d](https://github.com/tari-project/tari/commit/053c748d3d7aee674bada24609612bde9ba1420e)
+* **console-wallet:**  fix possible subtract underflow panic in list (#5535) ([8d5e8e6e](https://github.com/tari-project/tari/commit/8d5e8e6eac45b11867cee6104c207f6559851405)
+* **core:**  disable covenants for all networks except igor and localnet (#5505) ([308f5299](https://github.com/tari-project/tari/commit/308f5299007a67df8fb9fe73763809264005e35c)
+*   add a not before proof (#5560) ([11f42fb0](https://github.com/tari-project/tari/commit/11f42fb0942da3bd64db8ad203b75c364dbe0926)
+*   borsh sized serialization should be fallible   (#5537) ([53058ce2](https://github.com/tari-project/tari/commit/53058ce299cb89f118017ccec5e98a991a7fcbcc)
+*   add documentation to covenant crate (#5524) ([442d75b0](https://github.com/tari-project/tari/commit/442d75b09f439e4bc81919fc42eaf43846b2c8ca)
+*   covenants audit (#5526) ([dbb59758](https://github.com/tari-project/tari/commit/dbb59758a92cdf4483574dc6e7c719efa94eedfd)
+
+
 ## [0.51.0-pre.3](https://github.com/tari-project/tari/compare/v0.51.0-pre.2...v0.51.0-pre.3) (2023-06-26)
 
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.51.0-pre.3"
+version = "0.51.0-pre.4"
 edition = "2018"
 
 [features]
@@ -40,4 +40,4 @@ tari_test_utils = {  path = "../infrastructure/test_utils"}
 toml = "0.5.8"
 
 [build-dependencies]
-tari_features = { version = "0.51.0-pre.3", path = "./tari_features"}
+tari_features = { version = "0.51.0-pre.4", path = "./tari_features"}

--- a/common/tari_features/Cargo.toml
+++ b/common/tari_features/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.51.0-pre.3"
+version = "0.51.0-pre.4"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/common_sqlite/Cargo.toml
+++ b/common_sqlite/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_common_sqlite"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency wallet library"
 license = "BSD-3-Clause"
-version = "0.51.0-pre.3"
+version = "0.51.0-pre.4"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/comms/core/Cargo.toml
+++ b/comms/core/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.51.0-pre.3"
+version = "0.51.0-pre.4"
 edition = "2018"
 
 [dependencies]

--- a/comms/dht/Cargo.toml
+++ b/comms/dht/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_comms_dht"
-version = "0.51.0-pre.3"
+version = "0.51.0-pre.4"
 authors = ["The Tari Development Community"]
 description = "Tari comms DHT module"
 repository = "https://github.com/tari-project/tari"

--- a/comms/rpc_macros/Cargo.toml
+++ b/comms/rpc_macros/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.51.0-pre.3"
+version = "0.51.0-pre.4"
 edition = "2018"
 
 [lib]

--- a/infrastructure/derive/Cargo.toml
+++ b/infrastructure/derive/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.51.0-pre.3"
+version = "0.51.0-pre.4"
 edition = "2018"
 
 [lib]

--- a/infrastructure/shutdown/Cargo.toml
+++ b/infrastructure/shutdown/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.51.0-pre.3"
+version = "0.51.0-pre.4"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/infrastructure/storage/Cargo.toml
+++ b/infrastructure/storage/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.51.0-pre.3"
+version = "0.51.0-pre.4"
 edition = "2018"
 
 [dependencies]

--- a/infrastructure/test_utils/Cargo.toml
+++ b/infrastructure/test_utils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_test_utils"
 description = "Utility functions used in Tari test functions"
-version = "0.51.0-pre.3"
+version = "0.51.0-pre.4"
 authors = ["The Tari Development Community"]
 edition = "2018"
 license = "BSD-3-Clause"


### PR DESCRIPTION
Description
---
Version bump to 0.51.0-pre.4 as a code freeze tag

Motivation and Context
---
Moving up and forward!

How Has This Been Tested?
---
CI

Breaking Changes
---

- [ ] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [x] Other - Please specify

New signatures