### PR TITLE
fix: error out the stx protocol if the sender sends unsupported data

### DIFF
--- a/base_layer/wallet/src/output_manager_service/error.rs
+++ b/base_layer/wallet/src/output_manager_service/error.rs
@@ -116,6 +116,10 @@ pub enum OutputManagerError {
     NodeIdError(#[from] NodeIdError),
     #[error("Script hash does not match expected script")]
     InvalidScriptHash,
+    #[error("Unsupported Covenant")]
+    InvalidCovenant,
+    #[error("Unsupported Output Features")]
+    InvalidOutputFeatures,
     #[error("Tari script error: {0}")]
     ScriptError(#[from] ScriptError),
     #[error("Master secret key does not match persisted key manager state")]

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -233,7 +233,7 @@ where
                     .map(OutputManagerResponse::Balance)
             },
             OutputManagerRequest::GetRecipientTransaction(tsm) => self
-                .get_recipient_transaction(tsm)
+                .get_default_recipient_transaction(tsm)
                 .await
                 .map(OutputManagerResponse::RecipientTransactionGenerated),
             OutputManagerRequest::GetCoinbaseTransaction {
@@ -680,7 +680,7 @@ where
     }
 
     /// Request a receiver transaction be generated from the supplied Sender Message
-    async fn get_recipient_transaction(
+    async fn get_default_recipient_transaction(
         &mut self,
         sender_message: TransactionSenderMessage,
     ) -> Result<ReceiverTransactionProtocol, OutputManagerError> {

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -696,7 +696,7 @@ where
 
         // Confirm output features is default
         if single_round_sender_data.features != OutputFeatures::default() {
-            return Err(OutputManagerError::InvalidCovenant);
+            return Err(OutputManagerError::InvalidOutputFeatures);
         }
 
         let (spending_key_id, _, script_key_id, script_public_key) =


### PR DESCRIPTION
Description
---
Will error out the stx protocol if the sender sends unsupported script, features, or covenant

Motivation and Context
---
Its possible for the sender to block the spending of the transaction by using unsupported script, covenant or features. This will now make it that the receiver will not accept a transaction it does not know how to spend. 

How Has This Been Tested?
---
Passes all unit tests. 
