### PR TITLE
fix: miner delay attack

### DIFF
--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -470,7 +470,7 @@ where B: BlockchainBackend + 'static
                 );
                 return Ok(());
             }
-            if write_lock.contains(&block_hash) {
+            if !write_lock.insert(block_hash) {
                 debug!(
                     target: LOG_TARGET,
                     "Block with hash `{}` is already being reconciled",
@@ -478,7 +478,6 @@ where B: BlockchainBackend + 'static
                 );
                 return Ok(());
             }
-            write_lock.insert(block_hash);
         }
 
         debug!(

--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -447,8 +447,9 @@ where B: BlockchainBackend + 'static
             return Ok(());
         }
 
-       {
-            // we use a double lock to make sure we can only reconcile one unique block at a time. We may receive the same block from multiple peer near simultaneously. We should only reconcile each unique block once.
+        {
+            // we use a double lock to make sure we can only reconcile one unique block at a time. We may receive the
+            // same block from multiple peer near simultaneously. We should only reconcile each unique block once.
             let read_lock = self.list_of_reconciling_blocks.read().await;
             if read_lock.contains(&block_hash) {
                 debug!(
@@ -487,7 +488,6 @@ where B: BlockchainBackend + 'static
             block_hash.to_hex(),
             source_peer
         );
-
 
         let block_result = self.reconcile_block(source_peer.clone(), new_block).await;
 

--- a/base_layer/core/src/transactions/aggregated_body.rs
+++ b/base_layer/core/src/transactions/aggregated_body.rs
@@ -369,7 +369,8 @@ impl AggregateBody {
     }
 
     pub fn is_sorted(&self) -> bool {
-        self.sorted
+        // a block containing only a single kernel, single output and single input is sorted by default
+        self.sorted || (self.kernels.len() <= 1 && self.outputs.len() <= 1 && self.inputs.len() <= 1)
     }
 
     /// Lists the number of inputs, outputs, and kernels in the block

--- a/base_layer/core/src/transactions/aggregated_body.rs
+++ b/base_layer/core/src/transactions/aggregated_body.rs
@@ -369,8 +369,7 @@ impl AggregateBody {
     }
 
     pub fn is_sorted(&self) -> bool {
-        // a block containing only a single kernel, single output and single input is sorted by default
-        self.sorted || (self.kernels.len() <= 1 && self.outputs.len() <= 1 && self.inputs.len() <= 1)
+        self.sorted
     }
 
     /// Lists the number of inputs, outputs, and kernels in the block


### PR DESCRIPTION
Description
---
Stops the node blocking until it has a full block

Audit Finding Number
---
TARI-0001, TARI-0002

Motivation and Context
---
Its possible for a malicious node to block access to the full block by using first the mempool to say it does not have the missing transactions, then when asked for the full block to only then provide the full block. But these requests can be made slow to delay the node constructing the new block by almost 2 mins. This is the block time. 

By only accepting 1 block request at a time, a malicious node can lock down the local node for that entire 2 mins knowing they wont accept any other blocks. This changes it so that nodes can still process new requests. The first complete block will be served first. 


Also changes the display of block information to ensure block sorted is correctly used. 