### PR TITLE
feat: new message callback to chat-ffi

### DIFF
--- a/base_layer/chat_ffi/chat.h
+++ b/base_layer/chat_ffi/chat.h
@@ -14,9 +14,13 @@ struct ClientFFI;
 
 struct ContactsLivenessData;
 
+struct Message;
+
 struct TariAddress;
 
 typedef void (*CallbackContactStatusChange)(struct ContactsLivenessData*);
+
+typedef void (*CallbackMessageReceived)(struct Message*);
 
 #ifdef __cplusplus
 extern "C" {
@@ -40,7 +44,8 @@ extern "C" {
 struct ClientFFI *create_chat_client(ApplicationConfig *config,
                                      const char *identity_file_path,
                                      int *error_out,
-                                     CallbackContactStatusChange callback_contact_status_change);
+                                     CallbackContactStatusChange callback_contact_status_change,
+                                     CallbackMessageReceived callback_message_received);
 
 /**
  * Frees memory for a ClientFFI

--- a/base_layer/chat_ffi/src/lib.rs
+++ b/base_layer/chat_ffi/src/lib.rs
@@ -39,7 +39,7 @@ use tari_contacts::contacts_service::types::Message;
 use tokio::runtime::Runtime;
 
 use crate::{
-    callback_handler::CallbackHandler,
+    callback_handler::{CallbackHandler, CallbackMessageReceived},
     error::{InterfaceError, LibChatError},
 };
 
@@ -73,6 +73,7 @@ pub unsafe extern "C" fn create_chat_client(
     identity_file_path: *const c_char,
     error_out: *mut c_int,
     callback_contact_status_change: CallbackContactStatusChange,
+    callback_message_received: CallbackMessageReceived,
 ) -> *mut ClientFFI {
     let mut error = 0;
     ptr::swap(error_out, &mut error as *mut c_int);
@@ -122,6 +123,7 @@ pub unsafe extern "C" fn create_chat_client(
         client.contacts.clone().expect("No contacts service loaded yet"),
         client.shutdown.to_signal(),
         callback_contact_status_change,
+        callback_message_received,
     );
 
     runtime.spawn(async move {

--- a/base_layer/contacts/src/contacts_service/handle.rs
+++ b/base_layer/contacts/src/contacts_service/handle.rs
@@ -150,6 +150,7 @@ pub struct ContactsServiceHandle {
     request_response_service:
         SenderService<ContactsServiceRequest, Result<ContactsServiceResponse, ContactsServiceError>>,
     liveness_events: broadcast::Sender<Arc<ContactsLivenessEvent>>,
+    message_events: broadcast::Sender<Arc<Message>>,
 }
 
 impl ContactsServiceHandle {
@@ -159,10 +160,12 @@ impl ContactsServiceHandle {
             Result<ContactsServiceResponse, ContactsServiceError>,
         >,
         liveness_events: broadcast::Sender<Arc<ContactsLivenessEvent>>,
+        message_events: broadcast::Sender<Arc<Message>>,
     ) -> Self {
         Self {
             request_response_service,
             liveness_events,
+            message_events,
         }
     }
 
@@ -212,6 +215,10 @@ impl ContactsServiceHandle {
 
     pub fn get_contacts_liveness_event_stream(&self) -> broadcast::Receiver<Arc<ContactsLivenessEvent>> {
         self.liveness_events.subscribe()
+    }
+
+    pub fn get_messages_event_stream(&self) -> broadcast::Receiver<Arc<Message>> {
+        self.message_events.subscribe()
     }
 
     /// Determines the contact's online status based on their last seen time

--- a/base_layer/contacts/src/contacts_service/service.rs
+++ b/base_layer/contacts/src/contacts_service/service.rs
@@ -130,6 +130,7 @@ where T: ContactsBackend + 'static
     dht: Dht,
     subscription_factory: Arc<SubscriptionFactory>,
     event_publisher: broadcast::Sender<Arc<ContactsLivenessEvent>>,
+    message_publisher: broadcast::Sender<Arc<Message>>,
     number_of_rounds_no_pings: u16,
     contacts_auto_ping_interval: Duration,
     contacts_online_ping_window: usize,
@@ -150,6 +151,7 @@ where T: ContactsBackend + 'static
         dht: Dht,
         subscription_factory: Arc<SubscriptionFactory>,
         event_publisher: broadcast::Sender<Arc<ContactsLivenessEvent>>,
+        message_publisher: broadcast::Sender<Arc<Message>>,
         contacts_auto_ping_interval: Duration,
         contacts_online_ping_window: usize,
     ) -> Self {
@@ -163,6 +165,7 @@ where T: ContactsBackend + 'static
             dht,
             subscription_factory,
             event_publisher,
+            message_publisher,
             number_of_rounds_no_pings: 0,
             contacts_auto_ping_interval,
             contacts_online_ping_window,
@@ -415,7 +418,10 @@ where T: ContactsBackend + 'static
                 ..msg.into()
             };
 
-            self.db.save_message(message).expect("Couldn't save the message");
+            self.db
+                .save_message(message.clone())
+                .expect("Couldn't save the message");
+            let _msg = self.message_publisher.send(Arc::new(message));
         }
 
         Ok(())

--- a/integration_tests/src/chat_ffi.rs
+++ b/integration_tests/src/chat_ffi.rs
@@ -50,6 +50,11 @@ extern "C" fn callback_contact_status_change(_state: *mut c_void) {
     *callback.contact_status_change.lock().unwrap() += 1;
 }
 
+extern "C" fn callback_message_received(_state: *mut c_void) {
+    let callback = ChatCallback::instance();
+    *callback.message_received.lock().unwrap() += 1;
+}
+
 #[cfg_attr(windows, link(name = "tari_chat_ffi.dll"))]
 #[cfg_attr(not(windows), link(name = "tari_chat_ffi"))]
 extern "C" {
@@ -58,6 +63,7 @@ extern "C" {
         identity_file_path: *const c_char,
         out_error: *const c_int,
         callback_contact_status_change: unsafe extern "C" fn(*mut c_void),
+        callback_message_received: unsafe extern "C" fn(*mut c_void),
     ) -> *mut ClientFFI;
     pub fn send_message(client: *mut ClientFFI, receiver: *mut c_void, message: *const c_char, out_error: *const c_int);
     pub fn add_contact(client: *mut ClientFFI, address: *mut c_void, out_error: *const c_int);
@@ -193,6 +199,7 @@ pub async fn spawn_ffi_chat_client(name: &str, seed_peers: Vec<Peer>, base_dir: 
             identity_path_c_char,
             out_error,
             callback_contact_status_change,
+            callback_message_received,
         );
     }
 
@@ -208,6 +215,7 @@ static START: Once = Once::new();
 #[derive(Default)]
 pub struct ChatCallback {
     pub contact_status_change: Mutex<u64>,
+    pub message_received: Mutex<u64>,
 }
 
 impl ChatCallback {

--- a/integration_tests/tests/features/ChatFFI.feature
+++ b/integration_tests/tests/features/ChatFFI.feature
@@ -11,6 +11,14 @@ Feature: Chat FFI messaging
     When I use CHAT_A to send a message 'Hey there' to CHAT_B
     Then CHAT_B will have 1 message with CHAT_A
 
+  Scenario: Callback for new message received
+    Given I have a seed node SEED_A
+    When I have a chat FFI client CHAT_A connected to seed node SEED_A
+    When I have a chat FFI client CHAT_B connected to seed node SEED_A
+    When I use CHAT_A to send a message 'Hey there' to CHAT_B
+    Then there will be a MessageReceived callback of at least 1
+    Then CHAT_B will have 1 message with CHAT_A
+
   # Also flaky on CI. Seems liveness has issues on CI
   @broken
   Scenario: Callback for status change is received

--- a/integration_tests/tests/steps/chat_ffi_steps.rs
+++ b/integration_tests/tests/steps/chat_ffi_steps.rs
@@ -61,3 +61,22 @@ async fn contact_status_update_callback(_world: &mut TariWorld, callback_count: 
         callback_count, count
     );
 }
+
+#[then(expr = "there will be a MessageReceived callback of at least {int}")]
+async fn message_reveived_callback(_world: &mut TariWorld, callback_count: usize) {
+    let mut count = 0;
+    for _ in 0..(TWO_MINUTES_WITH_HALF_SECOND_SLEEP) {
+        count = *ChatCallback::instance().message_received.lock().unwrap();
+
+        if count >= callback_count as u64 {
+            return;
+        }
+
+        tokio::time::sleep(Duration::from_millis(HALF_SECOND)).await;
+    }
+
+    panic!(
+        "contact status update never received. Callbacks expected: {}, Callbacks received: {:?}",
+        callback_count, count
+    );
+}


### PR DESCRIPTION
Description
---
Adds a callback function to the chat ffi when a new message is received

Motivation and Context
---
So ffi consumers don't need to poll for new messages.

How Has This Been Tested?
---
Cucumber

What process can a PR reviewer use to test or verify this change?
---
Review the general implementation style.

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
