### PR TITLE
fix: monero fork attack

### DIFF
--- a/base_layer/core/src/blocks/block_header.rs
+++ b/base_layer/core/src/blocks/block_header.rs
@@ -74,6 +74,8 @@ pub enum BlockHeaderValidationError {
     ProofOfWorkError(#[from] PowError),
     #[error("Monero seed hash too old")]
     OldSeedHash,
+    #[error("Monero blocks must have a nonce of 0")]
+    InvalidNonce,
     #[error("Incorrect height: Expected {expected} but got {actual}")]
     InvalidHeight { expected: u64, actual: u64 },
     #[error("Incorrect previous hash: Expected {expected} but got {actual}")]

--- a/base_layer/core/src/proof_of_work/monero_rx/helpers.rs
+++ b/base_layer/core/src/proof_of_work/monero_rx/helpers.rs
@@ -72,7 +72,7 @@ fn get_random_x_difficulty(input: &[u8], vm: &RandomXVMInstance) -> Result<(Diff
 /// 1. The merkle proof and coinbase hash produce a matching merkle root
 ///
 /// If these assertions pass, a valid `MoneroPowData` instance is returned
-fn verify_header(header: &BlockHeader) -> Result<MoneroPowData, MergeMineError> {
+pub fn verify_header(header: &BlockHeader) -> Result<MoneroPowData, MergeMineError> {
     let monero_data = MoneroPowData::from_header(header)?;
     let expected_merge_mining_hash = header.mining_hash();
     let extra_field = ExtraField::try_parse(&monero_data.coinbase_tx.prefix.extra)

--- a/base_layer/core/src/proof_of_work/monero_rx/mod.rs
+++ b/base_layer/core/src/proof_of_work/monero_rx/mod.rs
@@ -32,6 +32,7 @@ pub use helpers::{
     extract_tari_hash,
     randomx_difficulty,
     serialize_monero_block_to_hex,
+    verify_header,
 };
 
 mod fixed_array;

--- a/base_layer/core/src/validation/header/header_full_validator.rs
+++ b/base_layer/core/src/validation/header/header_full_validator.rs
@@ -178,6 +178,11 @@ fn check_pow_data<B: BlockchainBackend>(
     use PowAlgorithm::{RandomX, Sha3x};
     match block_header.pow.pow_algo {
         RandomX => {
+            if block_header.nonce != 0 {
+                return Err(ValidationError::BlockHeaderError(
+                    BlockHeaderValidationError::InvalidNonce,
+                ));
+            }
             let monero_data =
                 MoneroPowData::from_header(block_header).map_err(|e| ValidationError::CustomError(e.to_string()))?;
             let seed_height = db.fetch_monero_seed_first_seen_height(&monero_data.randomx_key)?;


### PR DESCRIPTION
Description
---
Forces the nonce of all Monero blocks to be 0. 

Motivation and Context
---
The Nonce field in the header is used when calculating the hash of the block. When merge mining monero blocks, the nonce used by the monero mining sits in pow->monero_header->nonce. It does not use the tari block header nonce. 

But this allows any node to change the nonce in the header and not break the mined pow, but change the hash of monero header. This will cause the network to fork of valid mined monero blocks. 

How Has This Been Tested?
---
unit tests

RFC update: https://github.com/tari-project/rfcs/pull/104

