### PR TITLE
feat: add mempool min fee

### DIFF
--- a/applications/minotari_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/minotari_node/src/grpc/base_node_grpc_server.rs
@@ -716,6 +716,7 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
             TxStorageResponse::NotStored |
             TxStorageResponse::NotStoredOrphan |
             TxStorageResponse::NotStoredConsensus |
+            TxStorageResponse::NotStoredFeeToLow |
             TxStorageResponse::NotStoredTimeLocked => tari_rpc::SubmitTransactionResponse {
                 result: tari_rpc::SubmitTransactionResult::Rejected.into(),
             },
@@ -787,6 +788,7 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
             TxStorageResponse::NotStored |
             TxStorageResponse::NotStoredConsensus |
             TxStorageResponse::NotStoredOrphan |
+            TxStorageResponse::NotStoredFeeToLow |
             TxStorageResponse::NotStoredTimeLocked |
             TxStorageResponse::NotStoredAlreadyMined => tari_rpc::TransactionStateResponse {
                 result: tari_rpc::TransactionLocation::NotStored.into(),

--- a/applications/minotari_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/minotari_node/src/grpc/base_node_grpc_server.rs
@@ -716,7 +716,7 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
             TxStorageResponse::NotStored |
             TxStorageResponse::NotStoredOrphan |
             TxStorageResponse::NotStoredConsensus |
-            TxStorageResponse::NotStoredFeeToLow |
+            TxStorageResponse::NotStoredFeeTooLow |
             TxStorageResponse::NotStoredTimeLocked => tari_rpc::SubmitTransactionResponse {
                 result: tari_rpc::SubmitTransactionResult::Rejected.into(),
             },
@@ -788,7 +788,7 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
             TxStorageResponse::NotStored |
             TxStorageResponse::NotStoredConsensus |
             TxStorageResponse::NotStoredOrphan |
-            TxStorageResponse::NotStoredFeeToLow |
+            TxStorageResponse::NotStoredFeeTooLow |
             TxStorageResponse::NotStoredTimeLocked |
             TxStorageResponse::NotStoredAlreadyMined => tari_rpc::TransactionStateResponse {
                 result: tari_rpc::TransactionLocation::NotStored.into(),

--- a/base_layer/core/src/base_node/proto/wallet_rpc.proto
+++ b/base_layer/core/src/base_node/proto/wallet_rpc.proto
@@ -17,6 +17,7 @@ enum TxSubmissionRejectionReason {
   TxSubmissionRejectionReasonOrphan = 3;
   TxSubmissionRejectionReasonTimeLocked = 4;
   TxSubmissionRejectionReasonValidationFailed = 5;
+  TxSubmissionRejectionReasonFeeToLow = 6;
 }
 
 message TxSubmissionResponse {

--- a/base_layer/core/src/base_node/proto/wallet_rpc.proto
+++ b/base_layer/core/src/base_node/proto/wallet_rpc.proto
@@ -17,7 +17,7 @@ enum TxSubmissionRejectionReason {
   TxSubmissionRejectionReasonOrphan = 3;
   TxSubmissionRejectionReasonTimeLocked = 4;
   TxSubmissionRejectionReasonValidationFailed = 5;
-  TxSubmissionRejectionReasonFeeToLow = 6;
+  TxSubmissionRejectionReasonFeeTooLow = 6;
 }
 
 message TxSubmissionResponse {

--- a/base_layer/core/src/base_node/proto/wallet_rpc.rs
+++ b/base_layer/core/src/base_node/proto/wallet_rpc.rs
@@ -45,6 +45,7 @@ pub enum TxSubmissionRejectionReason {
     Orphan,
     TimeLocked,
     ValidationFailed,
+    FeeToLow,
 }
 
 impl Display for TxSubmissionRejectionReason {
@@ -57,6 +58,7 @@ impl Display for TxSubmissionRejectionReason {
             Orphan => "Orphan",
             TimeLocked => "Time Locked",
             ValidationFailed => "Validation Failed",
+            FeeToLow => "Fee to low",
             None => "None",
         };
         fmt.write_str(response)
@@ -76,6 +78,7 @@ impl TryFrom<proto::TxSubmissionRejectionReason> for TxSubmissionRejectionReason
             Orphan => TxSubmissionRejectionReason::Orphan,
             TimeLocked => TxSubmissionRejectionReason::TimeLocked,
             ValidationFailed => TxSubmissionRejectionReason::ValidationFailed,
+            FeeToLow => TxSubmissionRejectionReason::FeeToLow,
         })
     }
 }
@@ -91,6 +94,7 @@ impl From<TxSubmissionRejectionReason> for proto::TxSubmissionRejectionReason {
             Orphan => proto::TxSubmissionRejectionReason::Orphan,
             TimeLocked => proto::TxSubmissionRejectionReason::TimeLocked,
             ValidationFailed => proto::TxSubmissionRejectionReason::ValidationFailed,
+            FeeToLow => proto::TxSubmissionRejectionReason::FeeToLow,
         }
     }
 }

--- a/base_layer/core/src/base_node/proto/wallet_rpc.rs
+++ b/base_layer/core/src/base_node/proto/wallet_rpc.rs
@@ -45,7 +45,7 @@ pub enum TxSubmissionRejectionReason {
     Orphan,
     TimeLocked,
     ValidationFailed,
-    FeeToLow,
+    FeeTooLow,
 }
 
 impl Display for TxSubmissionRejectionReason {
@@ -58,7 +58,7 @@ impl Display for TxSubmissionRejectionReason {
             Orphan => "Orphan",
             TimeLocked => "Time Locked",
             ValidationFailed => "Validation Failed",
-            FeeToLow => "Fee to low",
+            FeeTooLow => "Fee too low",
             None => "None",
         };
         fmt.write_str(response)
@@ -78,7 +78,7 @@ impl TryFrom<proto::TxSubmissionRejectionReason> for TxSubmissionRejectionReason
             Orphan => TxSubmissionRejectionReason::Orphan,
             TimeLocked => TxSubmissionRejectionReason::TimeLocked,
             ValidationFailed => TxSubmissionRejectionReason::ValidationFailed,
-            FeeToLow => TxSubmissionRejectionReason::FeeToLow,
+            FeeTooLow => TxSubmissionRejectionReason::FeeTooLow,
         })
     }
 }
@@ -94,7 +94,7 @@ impl From<TxSubmissionRejectionReason> for proto::TxSubmissionRejectionReason {
             Orphan => proto::TxSubmissionRejectionReason::Orphan,
             TimeLocked => proto::TxSubmissionRejectionReason::TimeLocked,
             ValidationFailed => proto::TxSubmissionRejectionReason::ValidationFailed,
-            FeeToLow => proto::TxSubmissionRejectionReason::FeeToLow,
+            FeeTooLow => proto::TxSubmissionRejectionReason::FeeTooLow,
         }
     }
 }

--- a/base_layer/core/src/base_node/rpc/service.rs
+++ b/base_layer/core/src/base_node/rpc/service.rs
@@ -158,7 +158,7 @@ impl<B: BlockchainBackend + 'static> BaseNodeWalletRpcService<B> {
             TxStorageResponse::NotStoredAlreadySpent |
             TxStorageResponse::NotStoredConsensus |
             TxStorageResponse::NotStored |
-            TxStorageResponse::NotStoredFeeToLow |
+            TxStorageResponse::NotStoredFeeTooLow |
             TxStorageResponse::NotStoredAlreadyMined => TxQueryResponse {
                 location: TxLocation::NotStored as i32,
                 block_hash: None,
@@ -207,9 +207,9 @@ impl<B: BlockchainBackend + 'static> BaseNodeWalletService for BaseNodeWalletRpc
                 rejection_reason: TxSubmissionRejectionReason::Orphan.into(),
                 is_synced,
             },
-            TxStorageResponse::NotStoredFeeToLow => TxSubmissionResponse {
+            TxStorageResponse::NotStoredFeeTooLow => TxSubmissionResponse {
                 accepted: false,
-                rejection_reason: TxSubmissionRejectionReason::FeeToLow.into(),
+                rejection_reason: TxSubmissionRejectionReason::FeeTooLow.into(),
                 is_synced,
             },
             TxStorageResponse::NotStoredTimeLocked => TxSubmissionResponse {

--- a/base_layer/core/src/mempool/mempool_storage.rs
+++ b/base_layer/core/src/mempool/mempool_storage.rs
@@ -88,6 +88,10 @@ impl MempoolStorage {
                 );
                 let timer = Instant::now();
                 let weight = self.get_transaction_weighting();
+                if tx.body.get_total_fee().as_u64() < self.unconfirmed_pool.config.min_fee {
+                    warn!(target: LOG_TARGET, "Tx: ({}) fee too low, rejecting",tx_id);
+                    return Ok(TxStorageResponse::NotStoredFeeToLow);
+                }
                 self.unconfirmed_pool.insert(tx, None, &weight)?;
                 debug!(
                     target: LOG_TARGET,
@@ -100,6 +104,10 @@ impl MempoolStorage {
             Err(ValidationError::UnknownInputs(dependent_outputs)) => {
                 if self.unconfirmed_pool.contains_all_outputs(&dependent_outputs) {
                     let weight = self.get_transaction_weighting();
+                    if tx.body.get_total_fee().as_u64() < self.unconfirmed_pool.config.min_fee {
+                        warn!(target: LOG_TARGET, "Tx: ({}) fee too low, rejecting",tx_id);
+                        return Ok(TxStorageResponse::NotStoredFeeToLow);
+                    }
                     self.unconfirmed_pool.insert(tx, Some(dependent_outputs), &weight)?;
                     Ok(TxStorageResponse::UnconfirmedPool)
                 } else {

--- a/base_layer/core/src/mempool/mempool_storage.rs
+++ b/base_layer/core/src/mempool/mempool_storage.rs
@@ -89,7 +89,7 @@ impl MempoolStorage {
                 let timer = Instant::now();
                 let weight = self.get_transaction_weighting();
                 if tx.body.get_total_fee().as_u64() < self.unconfirmed_pool.config.min_fee {
-                    warn!(target: LOG_TARGET, "Tx: ({}) fee too low, rejecting",tx_id);
+                    debug!(target: LOG_TARGET, "Tx: ({}) fee too low, rejecting",tx_id);
                     return Ok(TxStorageResponse::NotStoredFeeTooLow);
                 }
                 self.unconfirmed_pool.insert(tx, None, &weight)?;
@@ -105,7 +105,7 @@ impl MempoolStorage {
                 if self.unconfirmed_pool.contains_all_outputs(&dependent_outputs) {
                     let weight = self.get_transaction_weighting();
                     if tx.body.get_total_fee().as_u64() < self.unconfirmed_pool.config.min_fee {
-                        warn!(target: LOG_TARGET, "Tx: ({}) fee too low, rejecting",tx_id);
+                        debug!(target: LOG_TARGET, "Tx: ({}) fee too low, rejecting",tx_id);
                         return Ok(TxStorageResponse::NotStoredFeeTooLow);
                     }
                     self.unconfirmed_pool.insert(tx, Some(dependent_outputs), &weight)?;

--- a/base_layer/core/src/mempool/mempool_storage.rs
+++ b/base_layer/core/src/mempool/mempool_storage.rs
@@ -90,7 +90,7 @@ impl MempoolStorage {
                 let weight = self.get_transaction_weighting();
                 if tx.body.get_total_fee().as_u64() < self.unconfirmed_pool.config.min_fee {
                     warn!(target: LOG_TARGET, "Tx: ({}) fee too low, rejecting",tx_id);
-                    return Ok(TxStorageResponse::NotStoredFeeToLow);
+                    return Ok(TxStorageResponse::NotStoredFeeTooLow);
                 }
                 self.unconfirmed_pool.insert(tx, None, &weight)?;
                 debug!(
@@ -106,7 +106,7 @@ impl MempoolStorage {
                     let weight = self.get_transaction_weighting();
                     if tx.body.get_total_fee().as_u64() < self.unconfirmed_pool.config.min_fee {
                         warn!(target: LOG_TARGET, "Tx: ({}) fee too low, rejecting",tx_id);
-                        return Ok(TxStorageResponse::NotStoredFeeToLow);
+                        return Ok(TxStorageResponse::NotStoredFeeTooLow);
                     }
                     self.unconfirmed_pool.insert(tx, Some(dependent_outputs), &weight)?;
                     Ok(TxStorageResponse::UnconfirmedPool)

--- a/base_layer/core/src/mempool/mod.rs
+++ b/base_layer/core/src/mempool/mod.rs
@@ -114,6 +114,7 @@ pub enum TxStorageResponse {
     NotStoredConsensus,
     NotStored,
     NotStoredAlreadyMined,
+    NotStoredFeeToLow,
 }
 
 impl TxStorageResponse {
@@ -133,6 +134,7 @@ impl Display for TxStorageResponse {
             TxStorageResponse::NotStoredConsensus => "Not stored due to consensus rule",
             TxStorageResponse::NotStored => "Not stored",
             TxStorageResponse::NotStoredAlreadyMined => "Not stored tx already mined",
+            TxStorageResponse::NotStoredFeeToLow => "Not stored tx fee is below the minimum accepted by this mempool",
         };
         fmt.write_str(storage)
     }

--- a/base_layer/core/src/mempool/mod.rs
+++ b/base_layer/core/src/mempool/mod.rs
@@ -114,7 +114,7 @@ pub enum TxStorageResponse {
     NotStoredConsensus,
     NotStored,
     NotStoredAlreadyMined,
-    NotStoredFeeToLow,
+    NotStoredFeeTooLow,
 }
 
 impl TxStorageResponse {
@@ -134,7 +134,7 @@ impl Display for TxStorageResponse {
             TxStorageResponse::NotStoredConsensus => "Not stored due to consensus rule",
             TxStorageResponse::NotStored => "Not stored",
             TxStorageResponse::NotStoredAlreadyMined => "Not stored tx already mined",
-            TxStorageResponse::NotStoredFeeToLow => "Not stored tx fee is below the minimum accepted by this mempool",
+            TxStorageResponse::NotStoredFeeTooLow => "Not stored tx fee is below the minimum accepted by this mempool",
         };
         fmt.write_str(storage)
     }

--- a/base_layer/core/src/mempool/proto/tx_storage_response.rs
+++ b/base_layer/core/src/mempool/proto/tx_storage_response.rs
@@ -51,6 +51,7 @@ impl From<TxStorageResponse> for proto::TxStorageResponse {
             NotStoredAlreadySpent => proto::TxStorageResponse::NotStored,
             NotStoredConsensus => proto::TxStorageResponse::NotStored,
             NotStoredAlreadyMined => proto::TxStorageResponse::NotStored,
+            NotStoredFeeToLow => proto::TxStorageResponse::NotStored,
         }
     }
 }

--- a/base_layer/core/src/mempool/proto/tx_storage_response.rs
+++ b/base_layer/core/src/mempool/proto/tx_storage_response.rs
@@ -51,7 +51,7 @@ impl From<TxStorageResponse> for proto::TxStorageResponse {
             NotStoredAlreadySpent => proto::TxStorageResponse::NotStored,
             NotStoredConsensus => proto::TxStorageResponse::NotStored,
             NotStoredAlreadyMined => proto::TxStorageResponse::NotStored,
-            NotStoredFeeToLow => proto::TxStorageResponse::NotStored,
+            NotStoredFeeTooLow => proto::TxStorageResponse::NotStored,
         }
     }
 }

--- a/base_layer/core/src/mempool/unconfirmed_pool/unconfirmed_pool.rs
+++ b/base_layer/core/src/mempool/unconfirmed_pool/unconfirmed_pool.rs
@@ -54,6 +54,8 @@ pub struct UnconfirmedPoolConfig {
     /// The maximum number of transactions that can be skipped when compiling a set of highest priority transactions,
     /// skipping over large transactions are performed in an attempt to fit more transactions into the remaining space.
     pub weight_tx_skip_count: usize,
+    /// The minimum fee accepted by this mempool
+    pub min_fee: u64,
 }
 
 impl Default for UnconfirmedPoolConfig {
@@ -61,6 +63,7 @@ impl Default for UnconfirmedPoolConfig {
         Self {
             storage_capacity: 40_000,
             weight_tx_skip_count: 20,
+            min_fee: 0,
         }
     }
 }
@@ -74,7 +77,7 @@ impl Default for UnconfirmedPoolConfig {
 /// be included in a block. The excess_sig of a transaction is used as a key to uniquely identify a specific transaction
 /// in these containers.
 pub struct UnconfirmedPool {
-    config: UnconfirmedPoolConfig,
+    pub(crate) config: UnconfirmedPoolConfig,
     key_counter: usize,
     tx_by_key: HashMap<TransactionKey, PrioritizedTransaction>,
     txs_by_signature: HashMap<PrivateKey, Vec<TransactionKey>>,
@@ -873,6 +876,7 @@ mod test {
         let mut unconfirmed_pool = UnconfirmedPool::new(UnconfirmedPoolConfig {
             storage_capacity: 4,
             weight_tx_skip_count: 3,
+            min_fee: 0,
         });
 
         let tx_weight = TransactionWeight::latest();
@@ -970,6 +974,7 @@ mod test {
         let mut unconfirmed_pool = UnconfirmedPool::new(UnconfirmedPoolConfig {
             storage_capacity: 4,
             weight_tx_skip_count: 3,
+            min_fee: 0,
         });
 
         let tx_weight = TransactionWeight::latest();
@@ -1029,6 +1034,7 @@ mod test {
         let mut unconfirmed_pool = UnconfirmedPool::new(UnconfirmedPoolConfig {
             storage_capacity: 10,
             weight_tx_skip_count: 3,
+            min_fee: 0,
         });
         unconfirmed_pool
             .insert_many(
@@ -1100,6 +1106,7 @@ mod test {
         let mut unconfirmed_pool = UnconfirmedPool::new(UnconfirmedPoolConfig {
             storage_capacity: 10,
             weight_tx_skip_count: 3,
+            min_fee: 0,
         });
         unconfirmed_pool
             .insert_many(
@@ -1154,6 +1161,7 @@ mod test {
         let mut unconfirmed_pool = UnconfirmedPool::new(UnconfirmedPoolConfig {
             storage_capacity: 10,
             weight_tx_skip_count: 3,
+            min_fee: 0,
         });
         let txns = vec![
             Arc::new(tx1.clone()),

--- a/base_layer/core/tests/tests/mempool.rs
+++ b/base_layer/core/tests/tests/mempool.rs
@@ -1348,6 +1348,158 @@ async fn consensus_validation_large_tx() {
     // make sure the tx was not accepted into the mempool
     assert!(matches!(response, TxStorageResponse::NotStored));
 }
+
+#[tokio::test]
+#[allow(clippy::too_many_lines)]
+async fn validation_reject_min_fee() {
+    let network = Network::LocalNet;
+    // We dont want to compute the 19500 limit of local net, so we create smaller blocks
+    let consensus_constants = ConsensusConstantsBuilder::new(network)
+        .with_emission_amounts(100_000_000.into(), &EMISSION, 100.into())
+        .with_coinbase_lockheight(1)
+        .with_max_block_transaction_weight(500)
+        .build();
+    let (mut store, mut blocks, mut outputs, consensus_manager, key_manager) =
+        create_new_blockchain_with_constants(network, consensus_constants).await;
+    let mempool_validator = TransactionFullValidator::new(
+        CryptoFactories::default(),
+        true,
+        store.clone(),
+        consensus_manager.clone(),
+    );
+    let mut mempool_config = MempoolConfig::default();
+    mempool_config.unconfirmed_pool.min_fee = 1;
+    let mempool = Mempool::new(mempool_config, consensus_manager.clone(), Box::new(mempool_validator));
+    // Create a block with 1 output
+    let txs = vec![txn_schema!(from: vec![outputs[0][0].clone()], to: vec![5 * T])];
+    generate_new_block(
+        &mut store,
+        &mut blocks,
+        &mut outputs,
+        txs,
+        &consensus_manager,
+        &key_manager,
+    )
+    .await
+    .unwrap();
+
+    // build huge 0 fee tx manually
+    let input = outputs[1][0].clone();
+    let inputs = vec![input.to_transaction_input(&key_manager).await.unwrap()];
+    let input_script_keys = vec![input.script_key_id];
+
+    let fee = 0.into();
+
+    let (input_kernel_nonce, mut pub_nonce) = key_manager
+        .get_next_key(TransactionKeyManagerBranch::KernelNonce.get_branch_key())
+        .await
+        .unwrap();
+    let mut pub_excess = PublicKey::default() -
+        key_manager
+            .get_txo_kernel_signature_excess_with_offset(&input.spending_key_id, &input_kernel_nonce)
+            .await
+            .unwrap();
+    let mut sender_offsets = Vec::new();
+
+    let test_params = TestParams::new(&key_manager).await;
+    let wallet_output = create_wallet_output_with_data(
+        script!(Nop),
+        OutputFeatures::default(),
+        &test_params,
+        input.value,
+        &key_manager,
+    )
+    .await
+    .unwrap();
+    pub_excess = pub_excess +
+        key_manager
+            .get_txo_kernel_signature_excess_with_offset(
+                &wallet_output.spending_key_id,
+                &test_params.kernel_nonce_key_id,
+            )
+            .await
+            .unwrap();
+    pub_nonce = pub_nonce + test_params.kernel_nonce_key_pk;
+    sender_offsets.push(test_params.sender_offset_key_id.clone());
+
+    let mut agg_sig = Signature::default();
+    let mut offset = PrivateKey::default();
+    let tx_meta = TransactionMetadata::new(fee, 0);
+    let kernel_version = TransactionKernelVersion::get_current_version();
+    let kernel_message = TransactionKernel::build_kernel_signature_message(
+        &kernel_version,
+        tx_meta.fee,
+        tx_meta.lock_height,
+        &tx_meta.kernel_features,
+        &tx_meta.burn_commitment,
+    );
+
+    let tx_output = wallet_output.to_transaction_output(&key_manager).await.unwrap();
+    offset = &offset +
+        &key_manager
+            .get_txo_private_kernel_offset(&wallet_output.spending_key_id, &test_params.kernel_nonce_key_id)
+            .await
+            .unwrap();
+    let sig = key_manager
+        .get_partial_txo_kernel_signature(
+            &wallet_output.spending_key_id,
+            &test_params.kernel_nonce_key_id,
+            &pub_nonce,
+            &pub_excess,
+            &kernel_version,
+            &kernel_message,
+            &tx_meta.kernel_features,
+            TxoStage::Output,
+        )
+        .await
+        .unwrap();
+    agg_sig = &agg_sig + sig;
+
+    offset = &offset -
+        &key_manager
+            .get_txo_private_kernel_offset(&input.spending_key_id, &input_kernel_nonce)
+            .await
+            .unwrap();
+    let sig = key_manager
+        .get_partial_txo_kernel_signature(
+            &input.spending_key_id,
+            &input_kernel_nonce,
+            &pub_nonce,
+            &pub_excess,
+            &kernel_version,
+            &kernel_message,
+            &tx_meta.kernel_features,
+            TxoStage::Input,
+        )
+        .await
+        .unwrap();
+    agg_sig = &agg_sig + sig;
+
+    let kernel = KernelBuilder::new()
+        .with_fee(fee)
+        .with_lock_height(0)
+        .with_excess(&Commitment::from_public_key(&pub_excess))
+        .with_features(tx_meta.kernel_features)
+        .with_signature(agg_sig)
+        .build()
+        .unwrap();
+    let kernels = vec![kernel];
+    let script_offset = key_manager
+        .get_script_offset(&input_script_keys, &sender_offsets)
+        .await
+        .unwrap();
+    let mut tx = Transaction::new(inputs, vec![tx_output], kernels, offset, script_offset);
+    tx.body.sort();
+
+    // make sure the tx was correctly made and is valid
+    let factories = CryptoFactories::default();
+    let validator = TransactionInternalConsistencyValidator::new(true, consensus_manager.clone(), factories);
+    validator.validate(&tx, None, None, u64::MAX).unwrap();
+    let response = mempool.insert(Arc::new(tx)).await.unwrap();
+    // make sure the tx was not accepted into the mempool
+    assert!(matches!(response, TxStorageResponse::NotStoredFeeToLow));
+}
+
 #[tokio::test]
 #[allow(clippy::erasing_op)]
 #[allow(clippy::identity_op)]

--- a/base_layer/core/tests/tests/mempool.rs
+++ b/base_layer/core/tests/tests/mempool.rs
@@ -1497,7 +1497,7 @@ async fn validation_reject_min_fee() {
     validator.validate(&tx, None, None, u64::MAX).unwrap();
     let response = mempool.insert(Arc::new(tx)).await.unwrap();
     // make sure the tx was not accepted into the mempool
-    assert!(matches!(response, TxStorageResponse::NotStoredFeeToLow));
+    assert!(matches!(response, TxStorageResponse::NotStoredFeeTooLow));
 }
 
 #[tokio::test]

--- a/common/config/presets/c_base_node.toml
+++ b/common/config/presets/c_base_node.toml
@@ -108,7 +108,7 @@ track_reorgs = true
 # skipping over large transactions are performed in an attempt to fit more transactions into the remaining space.
 #unconfirmed_pool.weight_tx_skip_count = 20
 # The minimum fee accepted by the mempool
-#unconfirmed_pool.min_fee: = 0,
+#unconfirmed_pool.min_fee = 0,
 
 # The height horizon to clear transactions from the reorg pool.
 #reorg_pool.expiry_height = 5

--- a/common/config/presets/c_base_node.toml
+++ b/common/config/presets/c_base_node.toml
@@ -107,6 +107,8 @@ track_reorgs = true
 # The maximum number of transactions that can be skipped when compiling a set of highest priority transactions,
 # skipping over large transactions are performed in an attempt to fit more transactions into the remaining space.
 #unconfirmed_pool.weight_tx_skip_count = 20
+# The minimum fee accepted by the mempool
+#unconfirmed_pool.min_fee: = 0,
 
 # The height horizon to clear transactions from the reorg pool.
 #reorg_pool.expiry_height = 5


### PR DESCRIPTION
Description
---
adds in a config option to specify the min fee accepted by the mempool

Motivation and Context
---
It is possible to flood the mempool with multiple cheap low fee transactions and waste resources validating them. 

How Has This Been Tested?
---
Unit test

Audit Finding Number
---
TARI-004