### PR TITLE
fix: check bytes remaining on monero blocks

### DIFF
--- a/base_layer/core/src/proof_of_work/monero_rx/pow_data.rs
+++ b/base_layer/core/src/proof_of_work/monero_rx/pow_data.rs
@@ -97,9 +97,10 @@ impl MoneroPowData {
         let pow_data =
             BorshDeserialize::deserialize(&mut v).map_err(|e| MergeMineError::DeserializeError(format!("{:?}", e)))?;
         if !v.is_empty() {
-            return Err(MergeMineError::DeserializeError(
-                format!("{} bytes leftover after deserialize", v.len())
-            ));
+            return Err(MergeMineError::DeserializeError(format!(
+                "{} bytes leftover after deserialize",
+                v.len()
+            )));
         }
         Ok(pow_data)
     }

--- a/base_layer/core/src/proof_of_work/monero_rx/pow_data.rs
+++ b/base_layer/core/src/proof_of_work/monero_rx/pow_data.rs
@@ -94,7 +94,14 @@ impl MoneroPowData {
     /// Create a new MoneroPowData struct from the given header
     pub fn from_header(tari_header: &BlockHeader) -> Result<MoneroPowData, MergeMineError> {
         let mut v = tari_header.pow.pow_data.as_slice();
-        BorshDeserialize::deserialize(&mut v).map_err(|e| MergeMineError::DeserializeError(format!("{:?}", e)))
+        let pow_data =
+            BorshDeserialize::deserialize(&mut v).map_err(|e| MergeMineError::DeserializeError(format!("{:?}", e)))?;
+        if !v.is_empty() {
+            return Err(MergeMineError::DeserializeError(
+                "Bytes leftover after deserialize".to_string(),
+            ));
+        }
+        Ok(pow_data)
     }
 
     /// Returns true if the coinbase merkle proof produces the `merkle_root` hash, otherwise false

--- a/base_layer/core/src/proof_of_work/monero_rx/pow_data.rs
+++ b/base_layer/core/src/proof_of_work/monero_rx/pow_data.rs
@@ -98,7 +98,7 @@ impl MoneroPowData {
             BorshDeserialize::deserialize(&mut v).map_err(|e| MergeMineError::DeserializeError(format!("{:?}", e)))?;
         if !v.is_empty() {
             return Err(MergeMineError::DeserializeError(
-                "Bytes leftover after deserialize".to_string(),
+                format!("{} bytes leftover after deserialize", v.len())
             ));
         }
         Ok(pow_data)

--- a/base_layer/core/tests/tests/block_validation.rs
+++ b/base_layer/core/tests/tests/block_validation.rs
@@ -215,33 +215,9 @@ fn add_monero_data(tblock: &mut Block, seed_key: &str) {
 }
 
 fn add_bad_monero_data(tblock: &mut Block, seed_key: &str) {
-    let blocktemplate_blob =
-        "0c0c8cd6a0fa057fe21d764e7abf004e975396a2160773b93712bf6118c3b4959ddd8ee0f76aad0000000002e1ea2701ffa5ea2701d5a299e2abb002028eb3066ced1b2cc82ea046f3716a48e9ae37144057d5fb48a97f941225a1957b2b0106225b7ec0a6544d8da39abe68d8bd82619b4a7c5bdae89c3783b256a8fa47820208f63aa86d2e857f070000"
-            .to_string();
-    let bytes = hex::decode(blocktemplate_blob).unwrap();
-    let mut mblock = monero_rx::deserialize::<MoneroBlock>(&bytes[..]).unwrap();
-    let hash = tblock.header.mining_hash();
-    monero_rx::append_merge_mining_tag(&mut mblock, hash).unwrap();
-    let hashes = monero_rx::create_ordered_transaction_hashes_from_block(&mblock);
-    let merkle_root = monero_rx::tree_hash(&hashes).unwrap();
-    let coinbase_merkle_proof = monero_rx::create_merkle_proof(&hashes, &hashes[0]).unwrap();
-    #[allow(clippy::cast_possible_truncation)]
-    let monero_data = MoneroPowData {
-        header: mblock.header,
-        randomx_key: FixedByteArray::from_hex(seed_key).unwrap(),
-        transaction_count: hashes.len() as u16,
-        merkle_root,
-        coinbase_merkle_proof,
-        coinbase_tx: mblock.miner_tx,
-    };
-    let mut serialized = Vec::new();
-    // This version adds over and over some data to the serialized vector
-    BorshSerialize::serialize(&monero_data, &mut serialized).unwrap();
-    for _ in 1..100 {
-        BorshSerialize::serialize(&(1 << 30), &mut serialized).unwrap();
-    }
-    tblock.header.pow.pow_algo = PowAlgorithm::RandomX;
-    tblock.header.pow.pow_data = serialized;
+    add_monero_data(tblock, seed_key);
+    // Add some "garbage" bytes to the end of the pow_data
+    tblock.header.pow.pow_data.extend([1u8; 100]);
 }
 
 #[tokio::test]


### PR DESCRIPTION
Description
---
Checks the bytes left after deserializing monero pow_data to ensure all bytes have been used.

Motivation and Context
---
Because the struct is stored as raw vec<u8> in headers, we need to ensure that all the bytes are used after deserializing to ensure that malicious nodes dont attcked bytes to change the hash or enlarge the headers. See TARI-010

How Has This Been Tested?
---
unit tests

Audit Finding Number
---
TARI-010