### PR TITLE
refactor: change atomics to use SeqCst

### DIFF
--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -339,15 +339,15 @@ where B: BlockchainBackend
     }
 
     pub(crate) fn is_add_block_disabled(&self) -> bool {
-        self.disable_add_block_flag.load(atomic::Ordering::Acquire)
+        self.disable_add_block_flag.load(atomic::Ordering::SeqCst)
     }
 
     pub(crate) fn set_disable_add_block_flag(&self) {
-        self.disable_add_block_flag.store(true, atomic::Ordering::Release);
+        self.disable_add_block_flag.store(true, atomic::Ordering::SeqCst);
     }
 
     pub(crate) fn clear_disable_add_block_flag(&self) {
-        self.disable_add_block_flag.store(false, atomic::Ordering::Release);
+        self.disable_add_block_flag.store(false, atomic::Ordering::SeqCst);
     }
 
     pub fn write(&self, transaction: DbTransaction) -> Result<(), ChainStorageError> {

--- a/base_layer/core/src/mempool/sync_protocol/mod.rs
+++ b/base_layer/core/src/mempool/sync_protocol/mod.rs
@@ -204,7 +204,7 @@ where TSubstream: AsyncRead + AsyncWrite + Unpin + Send + Sync + 'static
         // we want to at least sync initial_sync_num_peers, so we reset the num_synced to 0, so it can run till
         // initial_sync_num_peers again. This is made to run as a best effort in that it will at least run the
         // initial_sync_num_peers
-        self.num_synched.store(0, Ordering::Release);
+        self.num_synched.store(0, Ordering::SeqCst);
         let connections = match self
             .connectivity
             .select_connections(ConnectivitySelection::random_nodes(

--- a/base_layer/service_framework/src/stack.rs
+++ b/base_layer/service_framework/src/stack.rs
@@ -151,7 +151,7 @@ mod test {
                 service_fn(|_: ()| future::ok::<_, ()>(handle.0));
             });
 
-            self.state.fetch_add(1, Ordering::AcqRel);
+            self.state.fetch_add(1, Ordering::SeqCst);
             Ok(())
         }
     }

--- a/base_layer/service_framework/src/tower/service_ext.rs
+++ b/base_layer/service_framework/src/tower/service_ext.rs
@@ -124,7 +124,7 @@ mod test {
             type Response = u32;
 
             fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-                if self.flag.load(Ordering::Acquire) {
+                if self.flag.load(Ordering::SeqCst) {
                     Ok(()).into()
                 } else {
                     Poll::Pending
@@ -151,7 +151,7 @@ mod test {
             _ => panic!("Expected future to be pending"),
         }
 
-        ready_flag.store(true, Ordering::Release);
+        ready_flag.store(true, Ordering::SeqCst);
 
         match fut.poll_unpin(&mut cx) {
             Poll::Ready(Ok(v)) => assert_eq!(v, 314),

--- a/comms/core/src/connection_manager/peer_connection.rs
+++ b/comms/core/src/connection_manager/peer_connection.rs
@@ -85,7 +85,7 @@ pub fn try_create(
     );
     // All requests are request/response, so a channel size of 1 is all that is needed
     let (peer_tx, peer_rx) = mpsc::channel(1);
-    let id = ID_COUNTER.fetch_add(1, Ordering::Relaxed); // Monotonic
+    let id = ID_COUNTER.fetch_add(1, Ordering::SeqCst); // Monotonic
     let substream_counter = connection.substream_counter();
     let peer_conn = PeerConnection::new(
         id,

--- a/comms/core/src/protocol/rpc/test/greeting_service.rs
+++ b/comms/core/src/protocol/rpc/test/greeting_service.rs
@@ -87,11 +87,11 @@ impl GreetingService {
     }
 
     pub fn call_count(&self) -> usize {
-        self.call_count.load(Ordering::Acquire)
+        self.call_count.load(Ordering::SeqCst)
     }
 
     fn inc_call_count(&self) {
-        self.call_count.fetch_add(1, Ordering::Relaxed);
+        self.call_count.fetch_add(1, Ordering::SeqCst);
     }
 }
 

--- a/comms/core/src/test_utils/mocks/peer_connection.rs
+++ b/comms/core/src/test_utils/mocks/peer_connection.rs
@@ -94,7 +94,7 @@ pub async fn create_peer_connection_mock_pair(
     (
         PeerConnection::unverified(
             // ID must be unique since it is used for connection equivalency, so we re-implement this in the mock
-            ID_COUNTER.fetch_add(1, Ordering::Relaxed),
+            ID_COUNTER.fetch_add(1, Ordering::SeqCst),
             tx1,
             peer2.node_id,
             peer2.features,
@@ -104,7 +104,7 @@ pub async fn create_peer_connection_mock_pair(
         ),
         mock_state_in,
         PeerConnection::unverified(
-            ID_COUNTER.fetch_add(1, Ordering::Relaxed),
+            ID_COUNTER.fetch_add(1, Ordering::SeqCst),
             tx2,
             peer1.node_id,
             peer1.features,

--- a/comms/dht/src/network_discovery/state_machine.rs
+++ b/comms/dht/src/network_discovery/state_machine.rs
@@ -134,17 +134,17 @@ pub(super) struct NetworkDiscoveryContext {
 impl NetworkDiscoveryContext {
     /// Increment the number of rounds by 1
     pub(super) fn increment_num_rounds(&self) -> usize {
-        self.num_rounds.fetch_add(1, Ordering::AcqRel)
+        self.num_rounds.fetch_add(1, Ordering::SeqCst)
     }
 
     /// Get the number of rounds
     pub fn num_rounds(&self) -> usize {
-        self.num_rounds.load(Ordering::Relaxed)
+        self.num_rounds.load(Ordering::SeqCst)
     }
 
     /// Reset the number of rounds to 0
     pub(super) fn reset_num_rounds(&self) {
-        self.num_rounds.store(0, Ordering::Release);
+        self.num_rounds.store(0, Ordering::SeqCst);
     }
 
     pub(super) fn publish_event(&self, event: DhtEvent) {


### PR DESCRIPTION
Description
---
Change all Atomic* to use SeqCst instead of a mishmash of Relaxed, Acquire and Release

Motivation and Context
---
From the nomicom:

> In practice, sequential consistency is rarely necessary for program correctness. However sequential consistency is definitely the right choice if you're not confident about the other memory orders. Having your program run a bit slower than it needs to is certainly better than it running incorrectly!

> Asking for guarantees that are too weak on strongly-ordered hardware is more likely to happen to work, even though your program is strictly incorrect. If possible, concurrent algorithms should be tested on weakly-ordered hardware.

So IMO, it's better to err on the safe side since we can't practically test every PR on ARM machines.

How Has This Been Tested?
---
As described in the nomicon, there will be little difference between these orderings on my machine. I suspect there will be no noticeable difference in CI either

What process can a PR reviewer use to test or verify this change?
---
See above

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
