### PR TITLE
feat: cleanup errors

### DIFF
--- a/base_layer/core/src/base_node/state_machine_service/states/header_sync.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/header_sync.rs
@@ -160,12 +160,6 @@ impl HeaderSyncState {
                         warn!(target: LOG_TARGET, "{}. Continuing...", err);
                         StateEvent::Continue
                     },
-                    BlockHeaderSyncError::NetworkSilence => {
-                        log_mdc::extend(mdc);
-                        warn!(target: LOG_TARGET, "{}", err);
-                        self.is_synced = true;
-                        StateEvent::NetworkSilence
-                    },
                     _ => {
                         log_mdc::extend(mdc);
                         debug!(target: LOG_TARGET, "Header sync failed: {}", err);

--- a/base_layer/core/src/base_node/sync/block_sync/error.rs
+++ b/base_layer/core/src/base_node/sync/block_sync/error.rs
@@ -32,6 +32,8 @@ use tari_comms::{
 use crate::{chain_storage::ChainStorageError, validation::ValidationError};
 #[derive(Debug, thiserror::Error)]
 pub enum BlockSyncError {
+    #[error("Async validation task failed: {0}")]
+    AsyncTaskFailed(#[from] tokio::task::JoinError),
     #[error("RPC error: {0}")]
     RpcError(#[from] RpcError),
     #[error("RPC request failed: {0}")]
@@ -70,6 +72,7 @@ impl BlockSyncError {
                 "RpcTimeout"
             },
             BlockSyncError::RpcRequestError(_) => "RpcRequestError",
+            BlockSyncError::AsyncTaskFailed(_) => "AsyncTaskFailed",
             BlockSyncError::ChainStorageError(_) => "ChainStorageError",
             BlockSyncError::PeerSentBlockThatDidNotFormAChain { .. } => "PeerSentBlockThatDidNotFormAChain",
             BlockSyncError::ConnectivityError(_) => "ConnectivityError",

--- a/base_layer/core/src/base_node/sync/header_sync/error.rs
+++ b/base_layer/core/src/base_node/sync/header_sync/error.rs
@@ -58,8 +58,6 @@ pub enum BlockHeaderSyncError {
     InvalidBlockHeight { expected: u64, actual: u64 },
     #[error("Unable to find chain split from peer `{0}`")]
     ChainSplitNotFound(NodeId),
-    #[error("Node could not find any other node with which to sync. Silence.")]
-    NetworkSilence,
     #[error("Invalid protocol response: {0}")]
     InvalidProtocolResponse(String),
     #[error("Header at height {height} did not form a chain. Expected {actual} to equal the previous hash {expected}")]

--- a/base_layer/core/src/base_node/sync/header_sync/validator.rs
+++ b/base_layer/core/src/base_node/sync/header_sync/validator.rs
@@ -138,8 +138,7 @@ impl<B: BlockchainBackend + 'static> BlockHeaderSyncValidator<B> {
             // We dont want to mark a block as bad for internal failures
             Err(
                 e @ ValidationError::FatalStorageError(_) |
-                e @ ValidationError::IncorrectNumberOfTimestampsProvided { .. } |
-                e @ ValidationError::AsyncTaskFailed(_),
+                e @ ValidationError::IncorrectNumberOfTimestampsProvided { .. },
             ) => return Err(e.into()),
             // We dont have to mark the block twice
             Err(e @ ValidationError::BadBlockFound { .. }) => return Err(e.into()),

--- a/base_layer/core/src/blocks/block.rs
+++ b/base_layer/core/src/blocks/block.rs
@@ -59,8 +59,6 @@ use crate::{
 pub enum BlockValidationError {
     #[error("A transaction in the block failed to validate: `{0}`")]
     TransactionError(#[from] TransactionError),
-    #[error("Invalid input in block")]
-    InvalidInput,
     #[error("Mismatched {kind} MMR roots")]
     MismatchedMmrRoots { kind: &'static str },
     #[error("MMR size for {mmr_tree} does not match. Expected: {expected}, received: {actual}")]

--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -2164,9 +2164,7 @@ fn insert_orphan_and_find_new_tips<T: BlockchainBackend>(
         },
         // We dont want to mark a block as bad for internal failures
         Err(
-            e @ ValidationError::FatalStorageError(_) |
-            e @ ValidationError::IncorrectNumberOfTimestampsProvided { .. } |
-            e @ ValidationError::AsyncTaskFailed(_),
+            e @ ValidationError::FatalStorageError(_) | e @ ValidationError::IncorrectNumberOfTimestampsProvided { .. },
         ) => return Err(e.into()),
         // We dont have to mark the block twice
         Err(e @ ValidationError::BadBlockFound { .. }) => return Err(e.into()),

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -95,13 +95,7 @@ use crate::{
     consensus::{ConsensusConstants, ConsensusManager},
     transactions::{
         aggregated_body::AggregateBody,
-        transaction_components::{
-            TransactionError,
-            TransactionInput,
-            TransactionKernel,
-            TransactionOutput,
-            ValidatorNodeRegistration,
-        },
+        transaction_components::{TransactionInput, TransactionKernel, TransactionOutput, ValidatorNodeRegistration},
     },
     MutablePrunedOutputMmr,
     PrunedKernelMmr,
@@ -1032,11 +1026,12 @@ impl LMDBDatabase {
             })?;
 
             match utxo_mined_info.output {
-                PrunedOutput::Pruned { .. } => {
+                PrunedOutput::Pruned { output_hash } => {
                     debug!(target: LOG_TARGET, "Output Transaction Input is spending is pruned");
-                    return Err(ChainStorageError::TransactionError(
-                        TransactionError::MissingTransactionInputData,
-                    ));
+                    return Err(ChainStorageError::InvalidOperation(format!(
+                        "Output Transaction Input: {} is spending is pruned",
+                        output_hash,
+                    )));
                 },
                 PrunedOutput::NotPruned { output } => {
                     let rp_hash = match output.proof {

--- a/base_layer/core/src/proof_of_work/error.rs
+++ b/base_layer/core/src/proof_of_work/error.rs
@@ -33,6 +33,8 @@ pub enum PowError {
     InvalidProofOfWork,
     #[error("Achieved difficulty is below the minimum")]
     AchievedDifficultyBelowMin,
+    #[error("Proof of work data must be empty for Sha3 blocks")]
+    Sha3HeaderNonEmptyPowBytes,
     #[error("Target difficulty {target} not achieved. Achieved difficulty: {achieved}")]
     AchievedDifficultyTooLow { target: Difficulty, achieved: Difficulty },
     #[error("Invalid target difficulty (expected: {expected}, got: {got})")]

--- a/base_layer/core/src/transactions/key_manager/inner.rs
+++ b/base_layer/core/src/transactions/key_manager/inner.rs
@@ -494,7 +494,7 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
         if self.crypto_factories.range_proof.range() < 64 &&
             value >= 1u64.shl(&self.crypto_factories.range_proof.range())
         {
-            return Err(TransactionError::ValidationError(
+            return Err(TransactionError::BuilderError(
                 "Value provided is outside the range allowed by the range proof".into(),
             ));
         }
@@ -560,7 +560,7 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
                 );
                 let a_hash = hasher_a.chain(nonce_private_key.as_bytes()).finalize();
                 PrivateKey::from_bytes(a_hash.as_ref()).map_err(|_| {
-                    TransactionError::ConversionError("Invalid private key for sender offset private key".to_string())
+                    TransactionError::KeyManagerError("Invalid private key for sender offset private key".to_string())
                 })
             },
             RangeProofType::RevealedValue => Ok(PrivateKey::default()),
@@ -571,7 +571,7 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
         );
         let b_hash = hasher_b.chain(nonce_private_key.as_bytes()).finalize();
         let nonce_b = PrivateKey::from_bytes(b_hash.as_ref()).map_err(|_| {
-            TransactionError::ConversionError("Invalid private key for sender offset private key".to_string())
+            TransactionError::KeyManagerError("Invalid private key for sender offset private key".to_string())
         })?;
         Ok((nonce_a, nonce_b))
     }
@@ -761,7 +761,7 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
             .chain(nonce_private_key.as_bytes())
             .finalize();
         PrivateKey::from_bytes(key_hash.as_ref()).map_err(|_| {
-            TransactionError::ConversionError("Invalid private key for kernel signature nonce".to_string())
+            TransactionError::KeyManagerError("Invalid private key for kernel signature nonce".to_string())
         })
     }
 

--- a/base_layer/core/src/transactions/transaction_components/error.rs
+++ b/base_layer/core/src/transactions/transaction_components/error.rs
@@ -30,24 +30,19 @@ use tari_crypto::{
 };
 use tari_key_manager::key_manager_service::KeyManagerServiceError;
 use tari_script::ScriptError;
-use tari_utilities::ByteArrayError;
 use thiserror::Error;
 
-use crate::{covenants::CovenantError, transactions::transaction_components::EncryptedDataError};
+use crate::transactions::transaction_components::EncryptedDataError;
 
 //----------------------------------------     TransactionError   ----------------------------------------------------//
 #[derive(Clone, Debug, PartialEq, Error, Deserialize, Serialize, Eq)]
 pub enum TransactionError {
-    #[error("Error validating the transaction: {0}")]
-    ValidationError(String),
+    #[error("Error building the transaction: {0}")]
+    BuilderError(String),
     #[error("Signature is invalid: {0}")]
     InvalidSignatureError(String),
-    #[error("Transaction kernel does not contain a signature")]
-    NoSignatureError,
     #[error("A range proof construction or verification has produced an error: {0}")]
     RangeProofError(String),
-    #[error("An error occurred while performing a commitment signature: {0}")]
-    SigningError(String),
     #[error("Invalid kernel in body: {0}")]
     InvalidKernel(String),
     #[error("Invalid coinbase in body")]
@@ -58,48 +53,24 @@ pub enum TransactionError {
     MoreThanOneCoinbase,
     #[error("No coinbase in body")]
     NoCoinbase,
-    #[error("Missing range proof")]
-    MissingRangeProof,
     #[error("Input maturity not reached")]
     InputMaturity,
     #[error("Tari script error: {0}")]
     ScriptError(#[from] ScriptError),
-    #[error("Schnorr signature error: {0}")]
-    SchnorrSignatureError(String),
-    #[error("Error performing conversion: {0}")]
-    ConversionError(String),
-    #[error("Error performing encryption: {0}")]
-    EncryptionError(String),
     #[error("The script offset in body does not balance")]
     ScriptOffset,
     #[error("Error executing script: {0}")]
     ScriptExecutionError(String),
-    #[error("TransactionInput is missing the data from the output being spent")]
-    MissingTransactionInputData,
-    #[error("Error executing covenant: {0}")]
-    CovenantError(String),
-    #[error("Committee contains too many members: contains {len} members but maximum is {max}")]
-    InvalidCommitteeLength { len: usize, max: usize },
-    #[error("Missing validator node signature")]
-    MissingValidatorNodeSignature,
+    #[error("Compact TransactionInput is missing {0}")]
+    CompactInputMissingData(String),
     #[error("Only coinbase outputs may have extra coinbase info")]
     NonCoinbaseHasOutputFeaturesCoinbaseExtra,
     #[error("Coinbase extra size is {len} but the maximum is {max}")]
     InvalidOutputFeaturesCoinbaseExtraSize { len: usize, max: u32 },
-    #[error("Invalid revealed value: {0}")]
-    InvalidRevealedValue(String),
     #[error("KeyManager encountered an error: {0}")]
     KeyManagerError(String),
     #[error("EncryptedData error: {0}")]
     EncryptedDataError(String),
-    #[error("Conversion error: {0}")]
-    ByteArrayError(String),
-}
-
-impl From<CovenantError> for TransactionError {
-    fn from(err: CovenantError) -> Self {
-        TransactionError::CovenantError(err.to_string())
-    }
 }
 
 impl From<KeyManagerServiceError> for TransactionError {
@@ -114,12 +85,6 @@ impl From<EncryptedDataError> for TransactionError {
     }
 }
 
-impl From<ByteArrayError> for TransactionError {
-    fn from(err: ByteArrayError) -> Self {
-        TransactionError::ByteArrayError(err.to_string())
-    }
-}
-
 impl From<RangeProofError> for TransactionError {
     fn from(e: RangeProofError) -> Self {
         TransactionError::RangeProofError(e.to_string())
@@ -128,12 +93,12 @@ impl From<RangeProofError> for TransactionError {
 
 impl From<CommitmentAndPublicKeySignatureError> for TransactionError {
     fn from(e: CommitmentAndPublicKeySignatureError) -> Self {
-        TransactionError::SigningError(e.to_string())
+        TransactionError::InvalidSignatureError(e.to_string())
     }
 }
 
 impl From<SchnorrSignatureError> for TransactionError {
     fn from(e: SchnorrSignatureError) -> Self {
-        TransactionError::SchnorrSignatureError(e.to_string())
+        TransactionError::InvalidSignatureError(e.to_string())
     }
 }

--- a/base_layer/core/src/transactions/transaction_components/kernel_builder.rs
+++ b/base_layer/core/src/transactions/transaction_components/kernel_builder.rs
@@ -85,7 +85,9 @@ impl KernelBuilder {
 
     pub fn build(self) -> Result<TransactionKernel, TransactionError> {
         if self.excess.is_none() || self.excess_sig.is_none() {
-            return Err(TransactionError::NoSignatureError);
+            return Err(TransactionError::BuilderError(
+                "Kernel does not contain an excess or signature".to_string(),
+            ));
         }
         Ok(TransactionKernel::new_current_version(
             self.features,

--- a/base_layer/core/src/transactions/transaction_components/test.rs
+++ b/base_layer/core/src/transactions/transaction_components/test.rs
@@ -635,7 +635,7 @@ mod validate_internal_consistency {
         .await
         .unwrap_err();
 
-        unpack_enum!(TransactionProtocolError::ValidationError(err) = err);
+        unpack_enum!(TransactionProtocolError::TransactionBuildError(err) = err);
         unpack_enum!(TransactionError::BuilderError(_s) = err);
 
         //---------------------------------- Case4 - PASS --------------------------------------------//

--- a/base_layer/core/src/transactions/transaction_components/test.rs
+++ b/base_layer/core/src/transactions/transaction_components/test.rs
@@ -135,7 +135,7 @@ async fn range_proof_verification() {
     match wallet_output2 {
         Ok(_) => panic!("Range proof should have failed to verify"),
         Err(e) => {
-            unpack_enum!(TransactionError::ValidationError(s) = e);
+            unpack_enum!(TransactionError::BuilderError(s) = e);
             assert_eq!(s, "Value provided is outside the range allowed by the range proof");
         },
     }
@@ -566,7 +566,7 @@ mod validate_internal_consistency {
         let validator = TransactionInternalConsistencyValidator::new(false, rules, CryptoFactories::default());
         validator
             .validate(&tx, None, None, height)
-            .map_err(|err| TransactionError::ValidationError(err.to_string()))?;
+            .map_err(|err| TransactionError::BuilderError(err.to_string()))?;
         Ok(())
     }
 
@@ -635,8 +635,8 @@ mod validate_internal_consistency {
         .await
         .unwrap_err();
 
-        unpack_enum!(TransactionProtocolError::TransactionBuildError(err) = err);
-        unpack_enum!(TransactionError::ValidationError(_s) = err);
+        unpack_enum!(TransactionProtocolError::ValidationError(err) = err);
+        unpack_enum!(TransactionError::BuilderError(_s) = err);
 
         //---------------------------------- Case4 - PASS --------------------------------------------//
         // Pass because maturity is set

--- a/base_layer/core/src/transactions/transaction_components/transaction_builder.rs
+++ b/base_layer/core/src/transactions/transaction_components/transaction_builder.rs
@@ -100,9 +100,7 @@ impl TransactionBuilder {
             tx.body.sort();
             Ok(tx)
         } else {
-            Err(TransactionError::ValidationError(
-                "Transaction validation failed".into(),
-            ))
+            Err(TransactionError::BuilderError("Transaction validation failed".into()))
         }
     }
 }

--- a/base_layer/core/src/transactions/transaction_components/transaction_input.rs
+++ b/base_layer/core/src/transactions/transaction_components/transaction_input.rs
@@ -232,7 +232,7 @@ impl TransactionInput {
     /// Returns the Commitment of this input. An error is returned if this is a compact input.
     pub fn commitment(&self) -> Result<&Commitment, TransactionError> {
         match self.spent_output {
-            SpentOutput::OutputHash(_) => Err(TransactionError::MissingTransactionInputData),
+            SpentOutput::OutputHash(_) => Err(TransactionError::CompactInputMissingData("commitment".to_string())),
             SpentOutput::OutputData { ref commitment, .. } => Ok(commitment),
         }
     }
@@ -240,7 +240,7 @@ impl TransactionInput {
     /// Returns the OutputFeatures of this input. An error is returned if this is a compact input.
     pub fn features(&self) -> Result<&OutputFeatures, TransactionError> {
         match self.spent_output {
-            SpentOutput::OutputHash(_) => Err(TransactionError::MissingTransactionInputData),
+            SpentOutput::OutputHash(_) => Err(TransactionError::CompactInputMissingData("features".to_string())),
             SpentOutput::OutputData { ref features, .. } => Ok(features),
         }
     }
@@ -250,7 +250,7 @@ impl TransactionInput {
     #[cfg(test)]
     pub fn features_mut(&mut self) -> Result<&mut OutputFeatures, TransactionError> {
         match self.spent_output {
-            SpentOutput::OutputHash(_) => Err(TransactionError::MissingTransactionInputData),
+            SpentOutput::OutputHash(_) => Err(TransactionError::CompactInputMissingData("features".to_string())),
             SpentOutput::OutputData { ref mut features, .. } => Ok(features),
         }
     }
@@ -258,7 +258,7 @@ impl TransactionInput {
     /// Returns a reference to the TariScript of this input. An error is returned if this is a compact input.
     pub fn script(&self) -> Result<&TariScript, TransactionError> {
         match self.spent_output {
-            SpentOutput::OutputHash(_) => Err(TransactionError::MissingTransactionInputData),
+            SpentOutput::OutputHash(_) => Err(TransactionError::CompactInputMissingData("script".to_string())),
             SpentOutput::OutputData { ref script, .. } => Ok(script),
         }
     }
@@ -267,7 +267,9 @@ impl TransactionInput {
     /// input.
     pub fn sender_offset_public_key(&self) -> Result<&PublicKey, TransactionError> {
         match self.spent_output {
-            SpentOutput::OutputHash(_) => Err(TransactionError::MissingTransactionInputData),
+            SpentOutput::OutputHash(_) => Err(TransactionError::CompactInputMissingData(
+                "sender offset public key".to_string(),
+            )),
             SpentOutput::OutputData {
                 ref sender_offset_public_key,
                 ..
@@ -278,7 +280,7 @@ impl TransactionInput {
     /// Returns a reference to the covenant of this input. An error is returned if this is a compact input.
     pub fn covenant(&self) -> Result<&Covenant, TransactionError> {
         match self.spent_output {
-            SpentOutput::OutputHash(_) => Err(TransactionError::MissingTransactionInputData),
+            SpentOutput::OutputHash(_) => Err(TransactionError::CompactInputMissingData("covenant".to_string())),
             SpentOutput::OutputData { ref covenant, .. } => Ok(covenant),
         }
     }
@@ -286,7 +288,7 @@ impl TransactionInput {
     /// Returns a reference to the EncryptedData of this input. An error is returned if this is a compact input.
     pub fn encrypted_data(&self) -> Result<&EncryptedData, TransactionError> {
         match self.spent_output {
-            SpentOutput::OutputHash(_) => Err(TransactionError::MissingTransactionInputData),
+            SpentOutput::OutputHash(_) => Err(TransactionError::CompactInputMissingData("encrypted data".to_string())),
             SpentOutput::OutputData { ref encrypted_data, .. } => Ok(encrypted_data),
         }
     }
@@ -294,7 +296,9 @@ impl TransactionInput {
     /// Returns a reference to the metadata signature of this input. An error is returned if this is a compact input.
     pub fn metadata_signature(&self) -> Result<&ComAndPubSignature, TransactionError> {
         match self.spent_output {
-            SpentOutput::OutputHash(_) => Err(TransactionError::MissingTransactionInputData),
+            SpentOutput::OutputHash(_) => Err(TransactionError::CompactInputMissingData(
+                "metadata signature".to_string(),
+            )),
             SpentOutput::OutputData {
                 ref metadata_signature, ..
             } => Ok(metadata_signature),
@@ -304,7 +308,7 @@ impl TransactionInput {
     /// Returns a reference to the rangeproof hash of this input. An error is returned if this is a compact input.
     pub fn rangeproof_hash(&self) -> Result<&FixedHash, TransactionError> {
         match self.spent_output {
-            SpentOutput::OutputHash(_) => Err(TransactionError::MissingTransactionInputData),
+            SpentOutput::OutputHash(_) => Err(TransactionError::CompactInputMissingData("rangeproof hash".to_string())),
             SpentOutput::OutputData {
                 ref rangeproof_hash, ..
             } => Ok(rangeproof_hash),
@@ -314,7 +318,9 @@ impl TransactionInput {
     /// Returns a reference to the minimum value promise of this input. An error is returned if this is a compact input.
     pub fn minimum_value_promise(&self) -> Result<&MicroMinotari, TransactionError> {
         match self.spent_output {
-            SpentOutput::OutputHash(_) => Err(TransactionError::MissingTransactionInputData),
+            SpentOutput::OutputHash(_) => Err(TransactionError::CompactInputMissingData(
+                "minimum value promise".to_string(),
+            )),
             SpentOutput::OutputData {
                 ref minimum_value_promise,
                 ..
@@ -334,7 +340,7 @@ impl TransactionInput {
         let context = context.unwrap_or_default();
 
         match self.spent_output {
-            SpentOutput::OutputHash(_) => Err(TransactionError::MissingTransactionInputData),
+            SpentOutput::OutputHash(_) => Err(TransactionError::CompactInputMissingData("script".to_string())),
             SpentOutput::OutputData { ref script, .. } => {
                 match script.execute_with_context(&self.input_data, &context)? {
                     StackItem::PublicKey(pubkey) => Ok(pubkey),
@@ -356,7 +362,9 @@ impl TransactionInput {
         factory: &CommitmentFactory,
     ) -> Result<(), TransactionError> {
         match self.spent_output {
-            SpentOutput::OutputHash(_) => Err(TransactionError::MissingTransactionInputData),
+            SpentOutput::OutputHash(_) => Err(TransactionError::CompactInputMissingData(
+                "script signature".to_string(),
+            )),
             SpentOutput::OutputData {
                 ref script,
                 ref commitment,
@@ -404,7 +412,7 @@ impl TransactionInput {
     /// An error is returned if this is a compact input.
     pub fn is_mature_at(&self, block_height: u64) -> Result<bool, TransactionError> {
         match self.spent_output {
-            SpentOutput::OutputHash(_) => Err(TransactionError::MissingTransactionInputData),
+            SpentOutput::OutputHash(_) => Err(TransactionError::CompactInputMissingData("features".to_string())),
             SpentOutput::OutputData { ref features, .. } => Ok(features.maturity <= block_height),
         }
     }
@@ -465,7 +473,7 @@ impl TransactionInput {
             features.maturity = maturity;
             Ok(())
         } else {
-            Err(TransactionError::MissingTransactionInputData)
+            Err(TransactionError::CompactInputMissingData("features".to_string()))
         }
     }
 
@@ -477,7 +485,7 @@ impl TransactionInput {
             *script = new_script;
             Ok(())
         } else {
-            Err(TransactionError::MissingTransactionInputData)
+            Err(TransactionError::CompactInputMissingData("script".to_string()))
         }
     }
 

--- a/base_layer/core/src/transactions/transaction_components/transaction_output.rs
+++ b/base_layer/core/src/transactions/transaction_components/transaction_output.rs
@@ -226,7 +226,7 @@ impl TransactionOutput {
         match self.features.range_proof_type {
             RangeProofType::RevealedValue => match self.revealed_value_range_proof_check() {
                 Ok(_) => Ok(()),
-                Err(e) => Err(TransactionError::ValidationError(format!(
+                Err(e) => Err(TransactionError::RangeProofError(format!(
                     "Recipient output RevealedValue range proof for commitment {} failed to verify ({})",
                     self.commitment.to_hex(),
                     e
@@ -241,7 +241,7 @@ impl TransactionOutput {
                 };
                 match prover.verify_batch(vec![&self.proof_result()?.0], vec![&statement]) {
                     Ok(_) => Ok(()),
-                    Err(e) => Err(TransactionError::ValidationError(format!(
+                    Err(e) => Err(TransactionError::RangeProofError(format!(
                         "Recipient output BulletProofPlus range proof for commitment {} failed to verify ({})",
                         self.commitment.to_hex(),
                         e
@@ -736,7 +736,7 @@ mod test {
         .await
         {
             Ok(_) => panic!("Should not have been able to create output"),
-            Err(e) => assert_eq!(e, "Invalid revealed value: Expected 20 µT, received 0 µT"),
+            Err(e) => assert_eq!(e, "A range proof construction or verification has produced an error: Invalid revealed value: Expected 20 µT, received 0 µT"),
         }
     }
 

--- a/base_layer/core/src/transactions/transaction_components/transaction_output.rs
+++ b/base_layer/core/src/transactions/transaction_components/transaction_output.rs
@@ -736,7 +736,11 @@ mod test {
         .await
         {
             Ok(_) => panic!("Should not have been able to create output"),
-            Err(e) => assert_eq!(e, "A range proof construction or verification has produced an error: Invalid revealed value: Expected 20 µT, received 0 µT"),
+            Err(e) => assert_eq!(
+                e,
+                "A range proof construction or verification has produced an error: Invalid revealed value: Expected \
+                 20 µT, received 0 µT"
+            ),
         }
     }
 

--- a/base_layer/core/src/transactions/transaction_components/wallet_output.rs
+++ b/base_layer/core/src/transactions/transaction_components/wallet_output.rs
@@ -251,8 +251,8 @@ impl WalletOutput {
         key_manager: &KM,
     ) -> Result<TransactionOutput, TransactionError> {
         if self.features.range_proof_type == RangeProofType::RevealedValue && self.minimum_value_promise != self.value {
-            return Err(TransactionError::InvalidRevealedValue(format!(
-                "Expected {}, received {}",
+            return Err(TransactionError::RangeProofError(format!(
+                "Invalid revealed value: Expected {}, received {}",
                 self.value, self.minimum_value_promise
             )));
         }

--- a/base_layer/core/src/transactions/transaction_components/wallet_output_builder.rs
+++ b/base_layer/core/src/transactions/transaction_components/wallet_output_builder.rs
@@ -157,7 +157,7 @@ impl WalletOutputBuilder {
         let script = self
             .script
             .as_ref()
-            .ok_or_else(|| TransactionError::ValidationError("Cannot sign metadata without a script".to_string()))?;
+            .ok_or_else(|| TransactionError::BuilderError("Cannot sign metadata without a script".to_string()))?;
         let sender_offset_public_key = key_manager.get_public_key_at_key_id(sender_offset_key_id).await?;
         let metadata_message = TransactionOutput::metadata_signature_message_from_parts(
             &self.version,
@@ -189,12 +189,12 @@ impl WalletOutputBuilder {
         key_manager: &KM,
     ) -> Result<WalletOutput, TransactionError> {
         if !self.metadata_signed_by_receiver {
-            return Err(TransactionError::ValidationError(
+            return Err(TransactionError::BuilderError(
                 "Cannot build output because it has not been signed by the receiver".to_string(),
             ));
         }
         if !self.metadata_signed_by_sender {
-            return Err(TransactionError::ValidationError(
+            return Err(TransactionError::BuilderError(
                 "Cannot build output because it has not been signed by the sender".to_string(),
             ));
         }
@@ -204,15 +204,15 @@ impl WalletOutputBuilder {
             self.spending_key_id,
             self.features,
             self.script
-                .ok_or_else(|| TransactionError::ValidationError("script must be set".to_string()))?,
+                .ok_or_else(|| TransactionError::BuilderError("script must be set".to_string()))?,
             self.input_data
-                .ok_or_else(|| TransactionError::ValidationError("input_data must be set".to_string()))?,
+                .ok_or_else(|| TransactionError::BuilderError("input_data must be set".to_string()))?,
             self.script_key_id
-                .ok_or_else(|| TransactionError::ValidationError("script_private_key must be set".to_string()))?,
+                .ok_or_else(|| TransactionError::BuilderError("script_private_key must be set".to_string()))?,
             self.sender_offset_public_key
-                .ok_or_else(|| TransactionError::ValidationError("sender_offset_public_key must be set".to_string()))?,
+                .ok_or_else(|| TransactionError::BuilderError("sender_offset_public_key must be set".to_string()))?,
             self.metadata_signature
-                .ok_or_else(|| TransactionError::ValidationError("metadata_signature must be set".to_string()))?,
+                .ok_or_else(|| TransactionError::BuilderError("metadata_signature must be set".to_string()))?,
             0,
             self.covenant,
             self.encrypted_data,

--- a/base_layer/core/src/validation/aggregate_body/aggregate_body_chain_validator.rs
+++ b/base_layer/core/src/validation/aggregate_body/aggregate_body_chain_validator.rs
@@ -114,11 +114,11 @@ fn validate_input_not_pruned<B: BlockchainBackend>(
         if input.is_compact() {
             let output_mined_info = db
                 .fetch_output(&input.output_hash())?
-                .ok_or(ValidationError::TransactionInputSpentOutputMissing)?;
+                .ok_or(ValidationError::UnknownInput)?;
 
             match output_mined_info.output {
                 PrunedOutput::Pruned { .. } => {
-                    return Err(ValidationError::TransactionInputSpendsPrunedOutput);
+                    return Err(ValidationError::ContainsSTxO);
                 },
                 PrunedOutput::NotPruned { output } => {
                     let rp_hash = match output.proof {

--- a/base_layer/core/src/validation/aggregate_body/aggregate_body_internal_validator.rs
+++ b/base_layer/core/src/validation/aggregate_body/aggregate_body_internal_validator.rs
@@ -207,9 +207,7 @@ fn validate_kernel_sum(
         fees.to_hex()
     );
     if excess != &sum_io + &fees {
-        return Err(ValidationError::CustomError(
-            "Sum of inputs and outputs did not equal sum of kernels with fees".into(),
-        ));
+        return Err(ValidationError::InvalidAccountingBalance);
     }
 
     Ok(())
@@ -306,7 +304,9 @@ fn check_weight(
 ) -> Result<(), ValidationError> {
     let block_weight = body
         .calculate_weight(consensus_constants.transaction_weight_params())
-        .map_err(|e| ValidationError::CustomError(e.to_string()))?;
+        .map_err(|e| {
+            ValidationError::SerializationError(format!("Unable to calculate body weight: {}", e.to_string()))
+        })?;
     let max_weight = consensus_constants.max_block_transaction_weight();
     if block_weight <= max_weight {
         trace!(

--- a/base_layer/core/src/validation/header/header_full_validator.rs
+++ b/base_layer/core/src/validation/header/header_full_validator.rs
@@ -30,7 +30,7 @@ use crate::{
     blocks::{BlockHeader, BlockHeaderValidationError},
     chain_storage::BlockchainBackend,
     consensus::{ConsensusConstants, ConsensusManager},
-    proof_of_work::{monero_rx::MoneroPowData, AchievedTargetDifficulty, Difficulty, PowAlgorithm},
+    proof_of_work::{monero_rx::MoneroPowData, AchievedTargetDifficulty, Difficulty, PowAlgorithm, PowError},
     validation::{
         helpers::{check_header_timestamp_greater_than_median, check_target_difficulty},
         DifficultyCalculator,
@@ -187,8 +187,7 @@ fn check_pow_data<B: BlockchainBackend>(
                     BlockHeaderValidationError::InvalidNonce,
                 ));
             }
-            let monero_data =
-                MoneroPowData::from_header(block_header).map_err(|e| ValidationError::CustomError(e.to_string()))?;
+            let monero_data = MoneroPowData::from_header(block_header)?;
             let seed_height = db.fetch_monero_seed_first_seen_height(&monero_data.randomx_key)?;
             if seed_height != 0 {
                 // Saturating sub: subtraction can underflow in reorgs / rewind-blockchain command
@@ -204,9 +203,7 @@ fn check_pow_data<B: BlockchainBackend>(
         },
         Sha3x => {
             if !block_header.pow.pow_data.is_empty() {
-                return Err(ValidationError::CustomError(
-                    "Proof of work data must be empty for Sha3 blocks".to_string(),
-                ));
+                return Err(PowError::Sha3HeaderNonEmptyPowBytes.into());
             }
             Ok(())
         },

--- a/base_layer/core/src/validation/helpers.rs
+++ b/base_layer/core/src/validation/helpers.rs
@@ -198,9 +198,9 @@ pub fn check_input_is_utxo<B: BlockchainBackend>(db: &B, input: &TransactionInpu
 
 /// Checks the byte size of TariScript is less than or equal to the given size, otherwise returns an error.
 pub fn check_tari_script_byte_size(script: &TariScript, max_script_size: usize) -> Result<(), ValidationError> {
-    let script_size = script
-        .get_serialized_size()
-        .map_err(|e| ValidationError::CustomError(e.to_string()))?;
+    let script_size = script.get_serialized_size().map_err(|e| {
+        ValidationError::SerializationError(format!("Failed to get serialized script size: {}", e.to_string()))
+    })?;
     if script_size > max_script_size {
         return Err(ValidationError::TariScriptExceedsMaxSize {
             max_script_size,

--- a/base_layer/core/src/validation/mocks.rs
+++ b/base_layer/core/src/validation/mocks.rs
@@ -74,8 +74,8 @@ impl<B: BlockchainBackend> BlockBodyValidator<B> for MockValidator {
         if self.is_valid.load(Ordering::SeqCst) {
             Ok(block.clone())
         } else {
-            Err(ValidationError::custom_error(
-                "This mock validator always returns an error",
+            Err(ValidationError::ConsensusError(
+                "This mock validator always returns an error".to_string(),
             ))
         }
     }
@@ -86,8 +86,8 @@ impl<B: BlockchainBackend> CandidateBlockValidator<B> for MockValidator {
         if self.is_valid.load(Ordering::SeqCst) {
             Ok(())
         } else {
-            Err(ValidationError::custom_error(
-                "This mock validator always returns an error",
+            Err(ValidationError::ConsensusError(
+                "This mock validator always returns an error".to_string(),
             ))
         }
     }
@@ -99,8 +99,8 @@ impl InternalConsistencyValidator for MockValidator {
         if self.is_valid.load(Ordering::SeqCst) {
             Ok(())
         } else {
-            Err(ValidationError::custom_error(
-                "This mock validator always returns an error",
+            Err(ValidationError::ConsensusError(
+                "This mock validator always returns an error".to_string(),
             ))
         }
     }
@@ -121,8 +121,8 @@ impl<B: BlockchainBackend> HeaderChainLinkedValidator<B> for MockValidator {
             let achieved_target_diff = difficulty_calculator.check_achieved_and_target_difficulty(db, header)?;
             Ok(achieved_target_diff)
         } else {
-            Err(ValidationError::custom_error(
-                "This mock validator always returns an error",
+            Err(ValidationError::ConsensusError(
+                "This mock validator always returns an error".to_string(),
             ))
         }
     }
@@ -133,8 +133,8 @@ impl TransactionValidator for MockValidator {
         if self.is_valid.load(Ordering::SeqCst) {
             Ok(())
         } else {
-            Err(ValidationError::custom_error(
-                "This mock validator always returns an error",
+            Err(ValidationError::ConsensusError(
+                "This mock validator always returns an error".to_string(),
             ))
         }
     }
@@ -152,8 +152,8 @@ impl<B: BlockchainBackend> FinalHorizonStateValidation<B> for MockValidator {
         if self.is_valid.load(Ordering::SeqCst) {
             Ok(())
         } else {
-            Err(ValidationError::custom_error(
-                "This mock validator always returns an error",
+            Err(ValidationError::ConsensusError(
+                "This mock validator always returns an error".to_string(),
             ))
         }
     }

--- a/base_layer/core/src/validation/test.rs
+++ b/base_layer/core/src/validation/test.rs
@@ -518,7 +518,7 @@ mod transaction_validator {
     use crate::{
         transactions::{
             test_helpers::create_test_core_key_manager_with_memory_db,
-            transaction_components::TransactionError,
+            transaction_components::{OutputType, TransactionError},
         },
         validation::transaction::TransactionInternalConsistencyValidator,
     };
@@ -538,7 +538,11 @@ mod transaction_validator {
         };
         let tip = db.get_chain_metadata().unwrap();
         let err = validator.validate_with_current_tip(&tx, tip).unwrap_err();
-        unpack_enum!(ValidationError::ErroneousCoinbaseOutput = err);
+        unpack_enum!(
+            ValidationError::OutputTypeNotPermitted {
+                output_type: OutputType::Coinbase
+            } = err
+        );
     }
 
     #[tokio::test]

--- a/base_layer/core/src/validation/transaction/transaction_chain_validator.rs
+++ b/base_layer/core/src/validation/transaction/transaction_chain_validator.rs
@@ -47,10 +47,18 @@ impl<B: BlockchainBackend> TransactionValidator for TransactionChainLinkedValida
         // validate maximum tx weight
         if tx
             .calculate_weight(consensus_constants.transaction_weight_params())
-            .map_err(|e| ValidationError::CustomError(e.to_string()))? >
-            consensus_constants
-                .max_block_weight_excluding_coinbase()
-                .map_err(|e| ValidationError::CustomError(e.to_string()))?
+            .map_err(|e| {
+                ValidationError::SerializationError(format!(
+                    "Unable to calculate the transaction weight: {}",
+                    e.to_string()
+                ))
+            })? >
+            consensus_constants.max_block_weight_excluding_coinbase().map_err(|e| {
+                ValidationError::ConsensusError(format!(
+                    "Unable to get max block weight from consensus constants: {}",
+                    e.to_string()
+                ))
+            })?
         {
             return Err(ValidationError::MaxTransactionWeightExceeded);
         }

--- a/base_layer/core/src/validation/transaction/transaction_internal_validator.rs
+++ b/base_layer/core/src/validation/transaction/transaction_internal_validator.rs
@@ -24,7 +24,11 @@ use tari_common_types::{chain_metadata::ChainMetadata, types::HashOutput};
 
 use crate::{
     consensus::ConsensusManager,
-    transactions::{tari_amount::MicroMinotari, transaction_components::Transaction, CryptoFactories},
+    transactions::{
+        tari_amount::MicroMinotari,
+        transaction_components::{OutputType::Coinbase, Transaction},
+        CryptoFactories,
+    },
     validation::{aggregate_body::AggregateBodyInternalConsistencyValidator, ValidationError},
 };
 
@@ -70,7 +74,7 @@ impl TransactionInternalConsistencyValidator {
         tip_metadata: ChainMetadata,
     ) -> Result<(), ValidationError> {
         if tx.body.outputs().iter().any(|o| o.features.is_coinbase()) {
-            return Err(ValidationError::ErroneousCoinbaseOutput);
+            return Err(ValidationError::OutputTypeNotPermitted { output_type: Coinbase });
         }
 
         // We can call this function with a constant value, because we've just shown that this is NOT a coinbase, and

--- a/base_layer/core/tests/tests/block_validation.rs
+++ b/base_layer/core/tests/tests/block_validation.rs
@@ -155,7 +155,7 @@ async fn test_monero_blocks() {
     add_bad_monero_data(&mut extra_bytes_block_3, seed2);
     match db.add_block(Arc::new(extra_bytes_block_3)) {
         Err(ChainStorageError::ValidationError {
-            source: ValidationError::CustomError(_),
+            source: ValidationError::MergeMineError(_),
         }) => (),
         Err(e) => {
             panic!("Failed due to other error:{:?}", e);


### PR DESCRIPTION
Description
---
This ensures that we do not have any unused error types left in the validation errors. 
Renames some old errors to more clearly represent the actual error. 

Motivation and Context
---
Some errors where unused while some where sending the wrong error type back

