### PR TITLE
fix: memory overflow panic

### DIFF
--- a/base_layer/core/src/covenants/covenant.rs
+++ b/base_layer/core/src/covenants/covenant.rs
@@ -55,8 +55,7 @@ pub struct Covenant {
 impl BorshSerialize for Covenant {
     fn serialize<W: Write>(&self, writer: &mut W) -> io::Result<()> {
         let bytes = self.to_bytes();
-        // writer.write_varint(bytes.len())?;
-        writer.write_varint(usize::MAX)?;
+        writer.write_varint(bytes.len())?;
         for b in &bytes {
             b.serialize(writer)?;
         }

--- a/base_layer/core/src/proof_of_work/monero_rx/merkle_tree.rs
+++ b/base_layer/core/src/proof_of_work/monero_rx/merkle_tree.rs
@@ -147,7 +147,7 @@ impl BorshDeserialize for MerkleProof {
         if len > MAX_MERKLE_TREE_BYTES {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
-                "Larger than max covenant bytes".to_string(),
+                "Larger than max merkle tree bytes".to_string(),
             ));
         }
         let mut branch = Vec::with_capacity(len);

--- a/base_layer/core/src/proof_of_work/monero_rx/merkle_tree.rs
+++ b/base_layer/core/src/proof_of_work/monero_rx/merkle_tree.rs
@@ -35,6 +35,8 @@ use monero::{
 
 use crate::proof_of_work::monero_rx::error::MergeMineError;
 
+const MAX_MERKLE_TREE_BYTES: usize = 4096;
+
 /// Returns the Keccak 256 hash of the byte input
 fn cn_fast_hash(data: &[u8]) -> Hash {
     Hash::new(data)
@@ -142,6 +144,12 @@ impl BorshDeserialize for MerkleProof {
     fn deserialize_reader<R>(reader: &mut R) -> Result<Self, io::Error>
     where R: io::Read {
         let len = reader.read_varint()?;
+        if len > MAX_MERKLE_TREE_BYTES {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "Larger than max covenant bytes".to_string(),
+            ));
+        }
         let mut branch = Vec::with_capacity(len);
         for _ in 0..len {
             branch.push(
@@ -556,6 +564,15 @@ mod test {
             let buf = &mut buf.as_slice();
             assert_eq!(proof, MerkleProof::deserialize(buf).unwrap());
             assert_eq!(buf, &[1, 2, 3]);
+        }
+
+        #[tokio::test]
+        async fn test_borsh_de_serialization_too_large() {
+            // We dont care about the actual merkle tree here, just that its not too large on the varint size
+            // We lie about the size to try and get a mem panic, and say this merkle tree is u64::max large.
+            let buf = vec![255, 255, 255, 255, 255, 255, 255, 255, 255, 1, 49, 8, 2, 5, 6];
+            let buf = &mut buf.as_slice();
+            assert!(MerkleProof::deserialize(buf).is_err());
         }
     }
 }

--- a/infrastructure/tari_script/src/script.rs
+++ b/infrastructure/tari_script/src/script.rs
@@ -80,7 +80,7 @@ impl BorshDeserialize for TariScript {
         if len > MAX_SCRIPT_BYTES {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
-                "Larger than max covenant bytes".to_string(),
+                "Larger than max script bytes".to_string(),
             ));
         }
         let mut data = Vec::with_capacity(len);

--- a/infrastructure/tari_script/src/script.rs
+++ b/infrastructure/tari_script/src/script.rs
@@ -55,6 +55,7 @@ macro_rules! script {
 }
 
 const MAX_MULTISIG_LIMIT: u8 = 32;
+const MAX_SCRIPT_BYTES: usize = 4096;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TariScript {
@@ -76,6 +77,12 @@ impl BorshDeserialize for TariScript {
     fn deserialize_reader<R>(reader: &mut R) -> Result<Self, io::Error>
     where R: io::Read {
         let len = reader.read_varint()?;
+        if len > MAX_SCRIPT_BYTES {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "Larger than max covenant bytes".to_string(),
+            ));
+        }
         let mut data = Vec::with_capacity(len);
         for _ in 0..len {
             data.push(u8::deserialize_reader(reader)?);
@@ -1680,5 +1687,14 @@ mod test {
         let buf = &mut buf.as_slice();
         assert_eq!(script, TariScript::deserialize(buf).unwrap());
         assert_eq!(buf, &[1, 2, 3]);
+    }
+
+    #[test]
+    fn test_borsh_de_serialization_too_large() {
+        // We dont care about the actual script here, just that its not too large on the varint size
+        // We lie about the size to try and get a mem panic, and say this script is u64::max large.
+        let buf = vec![255, 255, 255, 255, 255, 255, 255, 255, 255, 1, 49, 8, 2, 5, 6];
+        let buf = &mut buf.as_slice();
+        assert!(TariScript::deserialize(buf).is_err());
     }
 }

--- a/infrastructure/tari_script/src/stack.rs
+++ b/infrastructure/tari_script/src/stack.rs
@@ -199,6 +199,12 @@ impl BorshDeserialize for ExecutionStack {
     fn deserialize_reader<R>(reader: &mut R) -> Result<Self, io::Error>
     where R: io::Read {
         let len = reader.read_varint()?;
+        if len > MAX_STACK_SIZE {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "Larger than max covenant bytes".to_string(),
+            ));
+        }
         let mut data = Vec::with_capacity(len);
         for _ in 0..len {
             data.push(u8::deserialize_reader(reader)?);
@@ -519,5 +525,14 @@ mod test {
         let buf = &mut buf.as_slice();
         assert_eq!(stack, ExecutionStack::deserialize(buf).unwrap());
         assert_eq!(buf, &[1, 2, 3]);
+    }
+
+    #[test]
+    fn test_borsh_de_serialization_too_large() {
+        // We dont care about the actual stack here, just that its not too large on the varint size
+        // We lie about the size to try and get a mem panic, and say this stack is u64::max large.
+        let buf = vec![255, 255, 255, 255, 255, 255, 255, 255, 255, 1, 49, 8, 2, 5, 6];
+        let buf = &mut buf.as_slice();
+        assert!(ExecutionStack::deserialize(buf).is_err());
     }
 }

--- a/infrastructure/tari_script/src/stack.rs
+++ b/infrastructure/tari_script/src/stack.rs
@@ -202,7 +202,7 @@ impl BorshDeserialize for ExecutionStack {
         if len > MAX_STACK_SIZE {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
-                "Larger than max covenant bytes".to_string(),
+                "Larger than max execution stack bytes".to_string(),
             ));
         }
         let mut data = Vec::with_capacity(len);


### PR DESCRIPTION
Description
---
Limits the varint size that the merkle_tree, covenent, script and stack can be.

Motivation and Context
---
`fn deserialize_reader<R>(reader: &mut R) -> Result<Self, io::Error>` trusts that the len of the varint declaring the size of the vec<u8> it needs to read is honest. This can cause a node to comment up to u64::MAX memory and cause a memory overflow. This adds a hard limit to what the size can be and checks it before allocating the memory. 


How Has This Been Tested?
---
Unit tests

Audit Finding Number
--
TARI-020