### PR TITLE
fix: make sure all needed libs are required for chatffi

### DIFF
--- a/base_layer/chat_ffi/build.rs
+++ b/base_layer/chat_ffi/build.rs
@@ -22,12 +22,13 @@ fn main() {
         parse: ParseConfig {
             parse_deps: true,
             include: Some(vec![
-                "tari_core".to_string(),
+                "minotari_wallet".to_string(),
+                "tari_chat_client".to_string(),
                 "tari_common_types".to_string(),
+                "tari_contacts".to_string(),
+                "tari_core".to_string(),
                 "tari_crypto".to_string(),
                 "tari_p2p".to_string(),
-                "minotari_wallet".to_string(),
-                "tari_contacts".to_string(),
             ]),
             ..Default::default()
         },

--- a/base_layer/chat_ffi/chat.h
+++ b/base_layer/chat_ffi/chat.h
@@ -8,6 +8,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+struct ApplicationConfig;
+
 struct ChatMessages;
 
 struct ClientFFI;
@@ -41,7 +43,7 @@ extern "C" {
  * # Safety
  * The ```destroy_client``` method must be called when finished with a ClientFFI to prevent a memory leak
  */
-struct ClientFFI *create_chat_client(ApplicationConfig *config,
+struct ClientFFI *create_chat_client(struct ApplicationConfig *config,
                                      const char *identity_file_path,
                                      int *error_out,
                                      CallbackContactStatusChange callback_contact_status_change,
@@ -75,11 +77,11 @@ void destroy_client_ffi(struct ClientFFI *client);
  * # Safety
  * The ```destroy_config``` method must be called when finished with a Config to prevent a memory leak
  */
-ApplicationConfig *create_chat_config(const char *network_str,
-                                      const char *public_address,
-                                      const char *datastore_path,
-                                      const char *log_path,
-                                      int *error_out);
+struct ApplicationConfig *create_chat_config(const char *network_str,
+                                             const char *public_address,
+                                             const char *datastore_path,
+                                             const char *log_path,
+                                             int *error_out);
 
 /**
  * Frees memory for an ApplicationConfig
@@ -93,7 +95,7 @@ ApplicationConfig *create_chat_config(const char *network_str,
  * # Safety
  * None
  */
-void destroy_config(ApplicationConfig *config);
+void destroy_config(struct ApplicationConfig *config);
 
 /**
  * Sends a message over a client


### PR DESCRIPTION
Description
---
The ffi relies on a struct in the ChatClient library which was not being included in the header build.

Motivation and Context
---
Less broken for the mobile teams.

How Has This Been Tested?
---
It build, and the struct is now present in the header file.

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
