### PR TITLE
feat: chatffi simpler callbacks and managed identity and db

### DIFF
--- a/base_layer/chat_ffi/chat.h
+++ b/base_layer/chat_ffi/chat.h
@@ -10,17 +10,26 @@
 
 struct ApplicationConfig;
 
-struct ChatFFIContactsLivenessData;
-
-struct ChatFFIMessage;
-
 struct ChatMessages;
 
 struct ClientFFI;
 
 struct TariAddress;
 
+struct ChatFFIContactsLivenessData {
+  const char *address;
+  uint64_t last_seen;
+  uint8_t online_status;
+};
+
 typedef void (*CallbackContactStatusChange)(struct ChatFFIContactsLivenessData*);
+
+struct ChatFFIMessage {
+  const char *body;
+  const char *from_address;
+  uint64_t stored_at;
+  const char *message_id;
+};
 
 typedef void (*CallbackMessageReceived)(struct ChatFFIMessage*);
 
@@ -214,6 +223,34 @@ struct TariAddress *create_tari_address(const char *receiver_c_char, int *error_
  * None
  */
 void destroy_tari_address(struct TariAddress *address);
+
+/**
+ * Frees memory for a ChatFFIMessage
+ *
+ * ## Arguments
+ * `address` - The pointer of a ChatFFIMessage
+ *
+ * ## Returns
+ * `()` - Does not return a value, equivalent to void in C
+ *
+ * # Safety
+ * None
+ */
+void destroy_chat_ffi_message(struct ChatFFIMessage *address);
+
+/**
+ * Frees memory for a ChatFFIContactsLivenessData
+ *
+ * ## Arguments
+ * `address` - The pointer of a ChatFFIContactsLivenessData
+ *
+ * ## Returns
+ * `()` - Does not return a value, equivalent to void in C
+ *
+ * # Safety
+ * None
+ */
+void destroy_chat_ffi_liveness_data(struct ChatFFIContactsLivenessData *address);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/base_layer/chat_ffi/chat.h
+++ b/base_layer/chat_ffi/chat.h
@@ -44,7 +44,6 @@ extern "C" {
  * The ```destroy_client``` method must be called when finished with a ClientFFI to prevent a memory leak
  */
 struct ClientFFI *create_chat_client(struct ApplicationConfig *config,
-                                     const char *identity_file_path,
                                      int *error_out,
                                      CallbackContactStatusChange callback_contact_status_change,
                                      CallbackMessageReceived callback_message_received);
@@ -80,6 +79,7 @@ void destroy_client_ffi(struct ClientFFI *client);
 struct ApplicationConfig *create_chat_config(const char *network_str,
                                              const char *public_address,
                                              const char *datastore_path,
+                                             const char *identity_file_path,
                                              const char *log_path,
                                              int *error_out);
 
@@ -96,6 +96,20 @@ struct ApplicationConfig *create_chat_config(const char *network_str,
  * None
  */
 void destroy_config(struct ApplicationConfig *config);
+
+/**
+ * Write an identity file
+ *
+ * ## Arguments
+ * `config` - The pointer of an ApplicationConfig
+ *
+ * ## Returns
+ * `()` - Does not return a value, equivalent to void in C
+ *
+ * # Safety
+ * None
+ */
+void create_identity_file(struct ApplicationConfig *config, int *error_out);
 
 /**
  * Sends a message over a client

--- a/base_layer/chat_ffi/chat.h
+++ b/base_layer/chat_ffi/chat.h
@@ -98,20 +98,6 @@ struct ApplicationConfig *create_chat_config(const char *network_str,
 void destroy_config(struct ApplicationConfig *config);
 
 /**
- * Write an identity file
- *
- * ## Arguments
- * `config` - The pointer of an ApplicationConfig
- *
- * ## Returns
- * `()` - Does not return a value, equivalent to void in C
- *
- * # Safety
- * None
- */
-void create_identity_file(struct ApplicationConfig *config, int *error_out);
-
-/**
  * Sends a message over a client
  *
  * ## Arguments

--- a/base_layer/chat_ffi/chat.h
+++ b/base_layer/chat_ffi/chat.h
@@ -10,19 +10,19 @@
 
 struct ApplicationConfig;
 
+struct ChatFFIMessage;
+
 struct ChatMessages;
 
 struct ClientFFI;
 
 struct ContactsLivenessData;
 
-struct Message;
-
 struct TariAddress;
 
 typedef void (*CallbackContactStatusChange)(struct ContactsLivenessData*);
 
-typedef void (*CallbackMessageReceived)(struct Message*);
+typedef void (*CallbackMessageReceived)(struct ChatFFIMessage*);
 
 #ifdef __cplusplus
 extern "C" {

--- a/base_layer/chat_ffi/chat.h
+++ b/base_layer/chat_ffi/chat.h
@@ -10,17 +10,17 @@
 
 struct ApplicationConfig;
 
+struct ChatFFIContactsLivenessData;
+
 struct ChatFFIMessage;
 
 struct ChatMessages;
 
 struct ClientFFI;
 
-struct ContactsLivenessData;
-
 struct TariAddress;
 
-typedef void (*CallbackContactStatusChange)(struct ContactsLivenessData*);
+typedef void (*CallbackContactStatusChange)(struct ChatFFIContactsLivenessData*);
 
 typedef void (*CallbackMessageReceived)(struct ChatFFIMessage*);
 

--- a/base_layer/chat_ffi/src/callback_handler.rs
+++ b/base_layer/chat_ffi/src/callback_handler.rs
@@ -35,6 +35,7 @@ const LOG_TARGET: &str = "chat_ffi::callback_handler";
 pub(crate) type CallbackContactStatusChange = unsafe extern "C" fn(*mut ChatFFIContactsLivenessData);
 pub(crate) type CallbackMessageReceived = unsafe extern "C" fn(*mut ChatFFIMessage);
 
+#[repr(C)]
 pub struct ChatFFIContactsLivenessData {
     pub address: *const c_char,
     pub last_seen: u64,
@@ -66,6 +67,7 @@ impl TryFrom<ContactsLivenessData> for ChatFFIContactsLivenessData {
     }
 }
 
+#[repr(C)]
 pub struct ChatFFIMessage {
     pub body: *const c_char,
     pub from_address: *const c_char,

--- a/base_layer/chat_ffi/src/lib.rs
+++ b/base_layer/chat_ffi/src/lib.rs
@@ -55,7 +55,7 @@ use tari_contacts::contacts_service::{
 use tokio::runtime::Runtime;
 
 use crate::{
-    callback_handler::{CallbackHandler, CallbackMessageReceived},
+    callback_handler::{CallbackHandler, CallbackMessageReceived, ChatFFIContactsLivenessData, ChatFFIMessage},
     error::{InterfaceError, LibChatError},
 };
 
@@ -698,6 +698,40 @@ pub unsafe extern "C" fn create_tari_address(
 /// None
 #[no_mangle]
 pub unsafe extern "C" fn destroy_tari_address(address: *mut TariAddress) {
+    if !address.is_null() {
+        drop(Box::from_raw(address))
+    }
+}
+
+/// Frees memory for a ChatFFIMessage
+///
+/// ## Arguments
+/// `address` - The pointer of a ChatFFIMessage
+///
+/// ## Returns
+/// `()` - Does not return a value, equivalent to void in C
+///
+/// # Safety
+/// None
+#[no_mangle]
+pub unsafe extern "C" fn destroy_chat_ffi_message(address: *mut ChatFFIMessage) {
+    if !address.is_null() {
+        drop(Box::from_raw(address))
+    }
+}
+
+/// Frees memory for a ChatFFIContactsLivenessData
+///
+/// ## Arguments
+/// `address` - The pointer of a ChatFFIContactsLivenessData
+///
+/// ## Returns
+/// `()` - Does not return a value, equivalent to void in C
+///
+/// # Safety
+/// None
+#[no_mangle]
+pub unsafe extern "C" fn destroy_chat_ffi_liveness_data(address: *mut ChatFFIContactsLivenessData) {
     if !address.is_null() {
         drop(Box::from_raw(address))
     }

--- a/base_layer/chat_ffi/src/lib.rs
+++ b/base_layer/chat_ffi/src/lib.rs
@@ -22,7 +22,7 @@
 
 #![recursion_limit = "1024"]
 
-use std::{convert::TryFrom, ffi::CStr, path::PathBuf, ptr, str::FromStr, sync::Arc};
+use std::{convert::TryFrom, ffi::CStr, path::PathBuf, ptr, str::FromStr};
 
 use callback_handler::CallbackContactStatusChange;
 use libc::{c_char, c_int};
@@ -38,7 +38,7 @@ use log4rs::{
     config::{Appender, Config, Logger, Root},
     encode::pattern::PatternEncoder,
 };
-use minotari_app_utilities::identity_management::{load_from_json, setup_node_identity};
+use minotari_app_utilities::identity_management::setup_node_identity;
 use tari_chat_client::{
     config::{ApplicationConfig, ChatClientConfig},
     networking::PeerFeatures,
@@ -194,6 +194,7 @@ pub unsafe extern "C" fn destroy_client_ffi(client: *mut ClientFFI) {
 ///
 /// # Safety
 /// The ```destroy_config``` method must be called when finished with a Config to prevent a memory leak
+#[allow(clippy::too_many_lines)]
 #[no_mangle]
 pub unsafe extern "C" fn create_chat_config(
     network_str: *const c_char,

--- a/base_layer/contacts/examples/chat_client/src/networking.rs
+++ b/base_layer/contacts/examples/chat_client/src/networking.rs
@@ -38,13 +38,17 @@ use tari_p2p::{
 use tari_service_framework::StackBuilder;
 use tari_shutdown::ShutdownSignal;
 
-use crate::{config::ApplicationConfig, database::connect_to_db};
+use crate::{
+    config::ApplicationConfig,
+    database::{connect_to_db, create_chat_storage},
+};
 
 pub async fn start(
     node_identity: Arc<NodeIdentity>,
     config: ApplicationConfig,
     shutdown_signal: ShutdownSignal,
 ) -> anyhow::Result<(ContactsServiceHandle, CommsNode)> {
+    create_chat_storage(&config.chat_client.db_file);
     let backend = connect_to_db(config.chat_client.db_file)?;
 
     let (publisher, subscription_factory) = pubsub_connector(100);

--- a/integration_tests/src/chat_ffi.rs
+++ b/integration_tests/src/chat_ffi.rs
@@ -60,7 +60,6 @@ extern "C" fn callback_message_received(_state: *mut c_void) {
 extern "C" {
     pub fn create_chat_client(
         config: *mut c_void,
-        identity_file_path: *const c_char,
         out_error: *const c_int,
         callback_contact_status_change: unsafe extern "C" fn(*mut c_void),
         callback_message_received: unsafe extern "C" fn(*mut c_void),
@@ -76,6 +75,7 @@ extern "C" {
         out_error: *const c_int,
     ) -> *mut c_void;
     pub fn destroy_client_ffi(client: *mut ClientFFI);
+    pub fn create_identity_file(config: *mut c_void);
 }
 
 #[derive(Debug)]
@@ -181,18 +181,6 @@ pub async fn spawn_ffi_chat_client(name: &str, seed_peers: Vec<Peer>, base_dir: 
         .collect::<Vec<String>>()
         .into();
 
-    let identity_path_c_str = CString::new(
-        config
-            .chat_client
-            .identity_file
-            .clone()
-            .into_os_string()
-            .into_string()
-            .unwrap(),
-    )
-    .unwrap();
-    let identity_path_c_char: *const c_char = CString::into_raw(identity_path_c_str) as *const c_char;
-
     let config_ptr = Box::into_raw(Box::new(config)) as *mut c_void;
 
     let client_ptr;
@@ -204,7 +192,6 @@ pub async fn spawn_ffi_chat_client(name: &str, seed_peers: Vec<Peer>, base_dir: 
 
         client_ptr = create_chat_client(
             config_ptr,
-            identity_path_c_char,
             out_error,
             callback_contact_status_change,
             callback_message_received,


### PR DESCRIPTION
Description
---
Offer a managed identity file, and db creation. 
Simplify callback return values to c-readable structs.

Motivation and Context
---
- Wallet can't provide it's identity file, and we probably shouldn't share it anyway. So lets write and use our own in the chatffi.
- Callbacks couldn't be read as rust structs
- db init can be managed on our end

How Has This Been Tested?
---
CI

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify