### PR TITLE
feat: improve block sync error handling

### DIFF
--- a/base_layer/core/src/base_node/service/error.rs
+++ b/base_layer/core/src/base_node/service/error.rs
@@ -25,7 +25,10 @@ use std::time::Duration;
 use tari_comms_dht::outbound::DhtOutboundError;
 use thiserror::Error;
 
-use crate::base_node::{comms_interface::CommsInterfaceError, service::initializer::ExtractBlockError};
+use crate::{
+    base_node::{comms_interface::CommsInterfaceError, service::initializer::ExtractBlockError},
+    common::BanReason,
+};
 
 #[derive(Debug, Error)]
 pub enum BaseNodeServiceError {
@@ -95,20 +98,5 @@ impl BaseNodeServiceError {
                 ban_duration: Duration::from_secs(60),
             }),
         }
-    }
-}
-
-pub struct BanReason {
-    reason: String,
-    ban_duration: Duration,
-}
-
-impl BanReason {
-    pub fn reason(&self) -> &str {
-        &self.reason
-    }
-
-    pub fn ban_duration(&self) -> Duration {
-        self.ban_duration
     }
 }

--- a/base_layer/core/src/base_node/sync/block_sync/error.rs
+++ b/base_layer/core/src/base_node/sync/block_sync/error.rs
@@ -29,7 +29,8 @@ use tari_comms::{
     protocol::rpc::{RpcError, RpcStatus, RpcStatusCode},
 };
 
-use crate::{chain_storage::ChainStorageError, validation::ValidationError};
+use crate::{chain_storage::ChainStorageError, common::BanReason, validation::ValidationError};
+
 #[derive(Debug, thiserror::Error)]
 pub enum BlockSyncError {
     #[error("Async validation task failed: {0}")]
@@ -41,17 +42,19 @@ pub enum BlockSyncError {
     #[error("Chain storage error: {0}")]
     ChainStorageError(#[from] ChainStorageError),
     #[error("Peer sent a block that did not form a chain. Expected hash = {expected}, got = {got}")]
-    PeerSentBlockThatDidNotFormAChain { expected: String, got: String },
+    BlockWithoutParent { expected: String, got: String },
     #[error("Connectivity Error: {0}")]
     ConnectivityError(#[from] ConnectivityError),
-    #[error("No sync peers available")]
-    NoSyncPeers,
+    #[error("No more sync peers available: {0}")]
+    NoMoreSyncPeers(String),
     #[error("Block validation failed: {0}")]
     ValidationError(#[from] ValidationError),
     #[error("Failed to construct valid chain block")]
     FailedToConstructChainBlock,
-    #[error("Peer violated the block sync protocol: {0}")]
-    ProtocolViolation(String),
+    #[error("Peer sent unknown hash")]
+    UnknownHeaderHash(String),
+    #[error("Peer sent block with invalid block body")]
+    InvalidBlockBody(String),
     #[error("Peer {peer} exceeded maximum permitted sync latency. latency: {latency:.2?}, max: {max_latency:.2?}")]
     MaxLatencyExceeded {
         peer: NodeId,
@@ -62,6 +65,8 @@ pub enum BlockSyncError {
     AllSyncPeersExceedLatency,
     #[error("FixedHash size error: {0}")]
     FixedHashSizeError(#[from] FixedHashSizeError),
+    #[error("This sync round failed")]
+    SyncRoundFailed,
 }
 
 impl BlockSyncError {
@@ -74,15 +79,48 @@ impl BlockSyncError {
             BlockSyncError::RpcRequestError(_) => "RpcRequestError",
             BlockSyncError::AsyncTaskFailed(_) => "AsyncTaskFailed",
             BlockSyncError::ChainStorageError(_) => "ChainStorageError",
-            BlockSyncError::PeerSentBlockThatDidNotFormAChain { .. } => "PeerSentBlockThatDidNotFormAChain",
+            BlockSyncError::BlockWithoutParent { .. } => "PeerSentBlockThatDidNotFormAChain",
             BlockSyncError::ConnectivityError(_) => "ConnectivityError",
-            BlockSyncError::NoSyncPeers => "NoSyncPeers",
+            BlockSyncError::NoMoreSyncPeers(_) => "NoMoreSyncPeers",
             BlockSyncError::ValidationError(_) => "ValidationError",
             BlockSyncError::FailedToConstructChainBlock => "FailedToConstructChainBlock",
-            BlockSyncError::ProtocolViolation(_) => "ProtocolViolation",
+            BlockSyncError::UnknownHeaderHash(_) => "UnknownHeaderHash",
+            BlockSyncError::InvalidBlockBody(_) => "InvalidBlockBody",
             BlockSyncError::MaxLatencyExceeded { .. } => "MaxLatencyExceeded",
             BlockSyncError::AllSyncPeersExceedLatency => "AllSyncPeersExceedLatency",
             BlockSyncError::FixedHashSizeError(_) => "FixedHashSizeError",
+            BlockSyncError::SyncRoundFailed => "SyncRoundFailed",
+        }
+    }
+}
+
+impl BlockSyncError {
+    pub fn get_ban_reason(&self, short_ban: Duration, long_ban: Duration) -> Option<BanReason> {
+        match self {
+            BlockSyncError::AsyncTaskFailed(_) |
+            BlockSyncError::RpcError(_) |
+            BlockSyncError::RpcRequestError(_) |
+            BlockSyncError::ChainStorageError(_) |
+            BlockSyncError::ConnectivityError(_) |
+            BlockSyncError::NoMoreSyncPeers(_) |
+            BlockSyncError::AllSyncPeersExceedLatency |
+            BlockSyncError::FailedToConstructChainBlock |
+            BlockSyncError::SyncRoundFailed => None,
+
+            err @ BlockSyncError::MaxLatencyExceeded { .. } => Some(BanReason {
+                reason: format!("{}", err),
+                ban_duration: short_ban,
+            }),
+
+            err @ BlockSyncError::BlockWithoutParent { .. } |
+            err @ BlockSyncError::UnknownHeaderHash(_) |
+            err @ BlockSyncError::InvalidBlockBody(_) |
+            err @ BlockSyncError::FixedHashSizeError(_) => Some(BanReason {
+                reason: format!("{}", err),
+                ban_duration: long_ban,
+            }),
+
+            BlockSyncError::ValidationError(err) => ValidationError::get_ban_reason(err, Some(long_ban)),
         }
     }
 }

--- a/base_layer/core/src/common/mod.rs
+++ b/base_layer/core/src/common/mod.rs
@@ -20,6 +20,9 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#[cfg(feature = "base_node")]
+use std::time::Duration;
+
 use tari_crypto::hash_domain;
 
 use crate::consensus::DomainSeparatedConsensusHasher;
@@ -36,3 +39,25 @@ pub mod rolling_vec;
 hash_domain!(ConfidentialOutputHashDomain, "com.tari.dan.confidential_output", 1);
 /// Hasher used in the DAN to derive masks and encrypted value keys
 pub type ConfidentialOutputHasher = DomainSeparatedConsensusHasher<ConfidentialOutputHashDomain>;
+
+/// The reason for a peer being banned
+#[cfg(feature = "base_node")]
+pub struct BanReason {
+    /// The reason for the ban
+    pub reason: String,
+    /// The duration of the ban
+    pub ban_duration: Duration,
+}
+
+#[cfg(feature = "base_node")]
+impl BanReason {
+    /// Create a new ban reason
+    pub fn reason(&self) -> &str {
+        &self.reason
+    }
+
+    /// The duration of the ban
+    pub fn ban_duration(&self) -> Duration {
+        self.ban_duration
+    }
+}


### PR DESCRIPTION
Description
---
Improved block sync error handling
- Comms and PRC errors will not invalidate the block sync in itself, but permit block sync to be tried from another sync peer.
- Better and more consistent clean-up if block sync fails.
- More consistent retries from another sync peer in case of errors.

Motivation and Context
---
Error handling was not consistent and opened avenues for malicious peers to interfere.

How Has This Been Tested?
---
Existing tests pass

What process can a PR reviewer use to test or verify this change?
---
Code walkthrough

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
