### PR TITLE
fix(comms)!: use noise XX handshake pattern for improved privacy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1460,14 +1460,16 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.0.0-rc.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da00a7a9a4eb92a0a0f8e75660926d48f0d0f3c537e455c457bcdaa1e16b1ac"
+checksum = "f711ade317dd348950a9910f81c5947e3d8907ebd2b83f76203ff1807e6a2bc2"
 dependencies = [
  "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
  "fiat-crypto",
- "packed_simd_2",
  "platforms",
+ "rustc_version",
  "subtle",
  "zeroize",
 ]
@@ -2788,12 +2790,6 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a"
-
-[[package]]
-name = "libm"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
@@ -3628,7 +3624,7 @@ checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
 dependencies = [
  "byteorder",
  "lazy_static",
- "libm 0.2.7",
+ "libm",
  "num-integer",
  "num-iter",
  "num-traits",
@@ -3698,7 +3694,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
 dependencies = [
  "autocfg",
- "libm 0.2.7",
+ "libm",
 ]
 
 [[package]]
@@ -3820,16 +3816,6 @@ name = "os_str_bytes"
 version = "6.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d5d9eb14b174ee9aa2ef96dc2b94637a2d4b6e7cb873c7e171f0c20c6cf3eac"
-
-[[package]]
-name = "packed_simd_2"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1914cd452d8fccd6f9db48147b29fd4ae05bea9dc5d9ad578509f72415de282"
-dependencies = [
- "cfg-if",
- "libm 0.1.4",
-]
 
 [[package]]
 name = "parking_lot"
@@ -5236,14 +5222,14 @@ dependencies = [
 
 [[package]]
 name = "snow"
-version = "0.9.1"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12ba5f4d4ff12bdb6a169ed51b7c48c0e0ac4b0b4b31012b2571e97d78d3201d"
+checksum = "0c9d1425eb528a21de2755c75af4c9b5d57f50a0d4c3b7f1828a4cd03f8ba155"
 dependencies = [
  "aes-gcm",
  "blake2",
  "chacha20poly1305 0.9.1",
- "curve25519-dalek 4.0.0-rc.0",
+ "curve25519-dalek 4.0.0",
  "rand_core 0.6.4",
  "rustc_version",
  "sha2 0.10.7",

--- a/comms/core/Cargo.toml
+++ b/comms/core/Cargo.toml
@@ -40,7 +40,7 @@ rand = "0.8"
 serde = "1.0.119"
 serde_derive = "1.0.119"
 sha3 = "0.10"
-snow = { version = "=0.9.1", features = ["default-resolver"] }
+snow = { version = "=0.9.3", features = ["default-resolver"] }
 thiserror = "1.0.26"
 tokio = { version = "1.23", features = ["rt-multi-thread", "time", "sync", "signal", "net", "macros", "io-util"] }
 tokio-stream = { version = "0.1.9", features = ["sync"] }

--- a/comms/core/src/noise/crypto_resolver.rs
+++ b/comms/core/src/noise/crypto_resolver.rs
@@ -68,9 +68,11 @@ impl CryptoResolver for TariCryptoResolver {
     }
 }
 
+type TariCommsNoiseHasher = DomainSeparatedHasher<Blake2b<U32>, CommsCoreHashDomain>;
+
 fn noise_kdf(shared_key: &CommsDHKE) -> CommsNoiseKey {
     let mut comms_noise_key = CommsNoiseKey::from(SafeArray::default());
-    DomainSeparatedHasher::<Blake2b<U32>, CommsCoreHashDomain>::new_with_label("noise.dh")
+    TariCommsNoiseHasher::new_with_label("noise.dh")
         .chain(shared_key.as_bytes())
         .finalize_into(GenericArray::from_mut_slice(comms_noise_key.reveal_mut()));
 
@@ -132,15 +134,12 @@ mod test {
     use snow::Keypair;
 
     use super::{super::NOISE_KEY_LEN, *};
-    use crate::noise::config::NOISE_IX_PARAMETER;
+    use crate::noise::config::NOISE_PARAMETERS;
 
     fn build_keypair() -> Keypair {
-        snow::Builder::with_resolver(
-            NOISE_IX_PARAMETER.parse().unwrap(),
-            Box::<TariCryptoResolver>::default(),
-        )
-        .generate_keypair()
-        .unwrap()
+        snow::Builder::with_resolver(NOISE_PARAMETERS.parse().unwrap(), Box::<TariCryptoResolver>::default())
+            .generate_keypair()
+            .unwrap()
     }
 
     #[test]

--- a/comms/core/src/noise/mod.rs
+++ b/comms/core/src/noise/mod.rs
@@ -24,6 +24,7 @@
 //! using the Ristretto curve from dalek via [tari_crypto](https://github.com/tari-project/tari-crypto).
 
 mod config;
+
 pub use config::NoiseConfig;
 
 mod crypto_resolver;

--- a/comms/core/src/noise/socket.rs
+++ b/comms/core/src/noise/socket.rs
@@ -525,8 +525,8 @@ where TSocket: AsyncRead + AsyncWrite + Unpin
 {
     /// Perform a Single Round-Trip noise IX handshake returning the underlying [NoiseSocket]
     /// (switched to transport mode) upon success.
-    pub async fn handshake_1rt(mut self) -> io::Result<NoiseSocket<TSocket>> {
-        match self.perform_handshake().await {
+    pub async fn perform_handshake(mut self) -> io::Result<NoiseSocket<TSocket>> {
+        match self.handshake_1_5rtt().await {
             Ok(_) => self.build(),
             Err(err) => {
                 warn!(
@@ -539,21 +539,29 @@ where TSocket: AsyncRead + AsyncWrite + Unpin
         }
     }
 
-    pub async fn perform_handshake(&mut self) -> io::Result<()> {
+    /// Performs a 1.5 RTT handshake. For example, the noise XX handshake.
+    async fn handshake_1_5rtt(&mut self) -> io::Result<()> {
         if self.socket.state.is_initiator() {
-            // -> e, s
+            //   -> e
             self.send().await?;
             self.flush().await?;
 
             // <- e, ee, se, s, es
             self.receive().await?;
+
+            //   -> s, se
+            self.send().await?;
+            self.flush().await?;
         } else {
-            // -> e, s
+            //   -> e
             self.receive().await?;
 
             // <- e, ee, se, s, es
             self.send().await?;
             self.flush().await?;
+
+            //   -> s, se
+            self.receive().await?;
         }
 
         Ok(())
@@ -647,11 +655,11 @@ mod test {
     use snow::{params::NoiseParams, Builder, Error, Keypair};
 
     use super::*;
-    use crate::{memsocket::MemorySocket, noise::config::NOISE_IX_PARAMETER};
+    use crate::{memsocket::MemorySocket, noise::config::NOISE_PARAMETERS};
 
     async fn build_test_connection(
     ) -> Result<((Keypair, Handshake<MemorySocket>), (Keypair, Handshake<MemorySocket>)), Error> {
-        let parameters: NoiseParams = NOISE_IX_PARAMETER.parse().expect("Invalid protocol name");
+        let parameters: NoiseParams = NOISE_PARAMETERS.parse().expect("Invalid protocol name");
 
         let dialer_keypair = Builder::new(parameters.clone()).generate_keypair()?;
         let listener_keypair = Builder::new(parameters.clone()).generate_keypair()?;
@@ -679,7 +687,7 @@ mod test {
         dialer: Handshake<MemorySocket>,
         listener: Handshake<MemorySocket>,
     ) -> io::Result<(NoiseSocket<MemorySocket>, NoiseSocket<MemorySocket>)> {
-        let (dialer_result, listener_result) = join(dialer.handshake_1rt(), listener.handshake_1rt()).await;
+        let (dialer_result, listener_result) = join(dialer.perform_handshake(), listener.perform_handshake()).await;
 
         Ok((dialer_result?, listener_result?))
     }


### PR DESCRIPTION
Description
---
Replaces the noise IX handshake with the XX handshake
Adds a prologue to the noise hash state
Update snow from 0.9.1 to 0.9.3 (correctness issue fixed: https://github.com/mcginty/snow/releases/tag/v0.9.2)

Motivation and Context
---

http://www.noiseprotocol.org/noise.html

The IX protocol provides no privacy for the initiator static key. We replace it with XX which (essentially) encrypts the initiator static key with an ephemeral Diffie-Hellman before sending the initiator static public key at the cost of an extra send/recv i.e 1.5 RTT for XX vs 1 RTT for IX. This provides forward secrecy for the initiator but weaker privacy for the responder (Encrypted with forward secrecy, but can be probed by an anonymous initiator.). This shouldn't be an issue as any initiator can perform a valid connection and get the peer information anyway,

An alternative is XK (initiator key is transmitted, responder key is known) which does fit our requirements and has stronger privacy and similar security guarantees, however is a 2 RTT pattern 

A potential way to offset the increased RTT by -0.5 is to include identity information usually performed as a separate protocol directly after noise, as part of the noise handshake.

How Has This Been Tested?
---
Existing comms tests and all tests using comms

What process can a PR reviewer use to test or verify this change?
---
Create a localnet and check that nodes connect

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [ ] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [x] Other - Cannot connect to peers without this change

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
