### PR TITLE
fix: handle out of sync errors when returning mempool transactions

### DIFF
--- a/base_layer/core/src/mempool/error.rs
+++ b/base_layer/core/src/mempool/error.rs
@@ -42,4 +42,6 @@ pub enum MempoolError {
     BlockingTaskError(#[from] JoinError),
     #[error("Internal error: {0}")]
     InternalError(String),
+    #[error("Mempool indexes out of sync: transaction exists in txs_by_signature but not in tx_by_key")]
+    IndexOutOfSync,
 }

--- a/base_layer/core/src/mempool/mempool.rs
+++ b/base_layer/core/src/mempool/mempool.rs
@@ -125,7 +125,7 @@ impl Mempool {
         &self,
         excess_sigs: Vec<PrivateKey>,
     ) -> Result<(Vec<Arc<Transaction>>, Vec<PrivateKey>), MempoolError> {
-        self.with_read_access(move |storage| Ok(storage.retrieve_by_excess_sigs(&excess_sigs)))
+        self.with_read_access(move |storage| storage.retrieve_by_excess_sigs(&excess_sigs))
             .await
     }
 

--- a/base_layer/core/src/mempool/mempool_storage.rs
+++ b/base_layer/core/src/mempool/mempool_storage.rs
@@ -285,14 +285,22 @@ impl MempoolStorage {
         Ok(results.retrieved_transactions)
     }
 
-    pub fn retrieve_by_excess_sigs(&self, excess_sigs: &[PrivateKey]) -> (Vec<Arc<Transaction>>, Vec<PrivateKey>) {
-        let (found_txns, remaining) = self.unconfirmed_pool.retrieve_by_excess_sigs(excess_sigs);
-        let (found_published_transactions, remaining) = self.reorg_pool.retrieve_by_excess_sigs(&remaining);
+    pub fn retrieve_by_excess_sigs(
+        &self,
+        excess_sigs: &[PrivateKey],
+    ) -> Result<(Vec<Arc<Transaction>>, Vec<PrivateKey>), MempoolError> {
+        let (found_txns, remaining) = match self.unconfirmed_pool.retrieve_by_excess_sigs(excess_sigs) {
+            Ok((found_txns, remaining)) => (found_txns, remaining),
+            Err(e) => return Err(e),
+        };
 
-        (
-            found_txns.into_iter().chain(found_published_transactions).collect(),
-            remaining,
-        )
+        match self.reorg_pool.retrieve_by_excess_sigs(&remaining) {
+            Ok((found_published_transactions, remaining)) => Ok((
+                found_txns.into_iter().chain(found_published_transactions).collect(),
+                remaining,
+            )),
+            Err(e) => Err(e),
+        }
     }
 
     /// Check if the specified excess signature is found in the Mempool.

--- a/base_layer/core/src/mempool/mempool_storage.rs
+++ b/base_layer/core/src/mempool/mempool_storage.rs
@@ -289,10 +289,7 @@ impl MempoolStorage {
         &self,
         excess_sigs: &[PrivateKey],
     ) -> Result<(Vec<Arc<Transaction>>, Vec<PrivateKey>), MempoolError> {
-        let (found_txns, remaining) = match self.unconfirmed_pool.retrieve_by_excess_sigs(excess_sigs) {
-            Ok((found_txns, remaining)) => (found_txns, remaining),
-            Err(e) => return Err(e),
-        };
+        let (found_txns, remaining) = self.unconfirmed_pool.retrieve_by_excess_sigs(excess_sigs)?;
 
         match self.reorg_pool.retrieve_by_excess_sigs(&remaining) {
             Ok((found_published_transactions, remaining)) => Ok((


### PR DESCRIPTION
Description
---
Add a new error type and gracefully recover from possible runtime panic.

Motivation and Context
---
Currently, there is a minimal possibility that the collection of tx's is out sync. If this occurs the base node will likely crash. 

How Has This Been Tested?
---
CI

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify