### PR TITLE
fix(comms/dht)!: limit number of peer claims and addresses for all sources

### DIFF
--- a/applications/minotari_app_grpc/proto/network.proto
+++ b/applications/minotari_app_grpc/proto/network.proto
@@ -31,7 +31,7 @@ message NodeIdentity {
     bytes node_id = 3;
 }
 
-message Peer{
+message Peer {
     /// Public key of the peer
     bytes public_key =1;
     /// NodeId of the peer
@@ -46,7 +46,7 @@ message Peer{
     string banned_reason= 7;
     google.protobuf.Timestamp offline_at = 8;
     /// Features supported by the peer
-    uint64 features = 9;
+    uint32 features = 9;
     /// used as information for more efficient protocol negotiation.
     repeated bytes supported_protocols = 11;
     /// User agent advertised by the peer

--- a/applications/minotari_app_grpc/src/conversions/peer.rs
+++ b/applications/minotari_app_grpc/src/conversions/peer.rs
@@ -63,12 +63,12 @@ impl From<Peer> for grpc::Peer {
 impl From<MultiaddrWithStats> for grpc::Address {
     fn from(address_with_stats: MultiaddrWithStats) -> Self {
         let address = address_with_stats.address().to_vec();
-        let last_seen = match address_with_stats.last_seen {
+        let last_seen = match address_with_stats.last_seen() {
             Some(v) => v.to_string(),
             None => String::new(),
         };
-        let connection_attempts = address_with_stats.connection_attempts;
-        let avg_latency = address_with_stats.avg_latency.as_secs();
+        let connection_attempts = address_with_stats.connection_attempts();
+        let avg_latency = address_with_stats.avg_latency().as_secs();
         Self {
             address,
             last_seen,

--- a/applications/minotari_node/src/commands/command/get_peer.rs
+++ b/applications/minotari_node/src/commands/command/get_peer.rs
@@ -90,14 +90,14 @@ impl CommandContext {
                 println!(
                     "- {} Score: {}  - Source: {} Latency: {:?} - Last Seen: {} - Last Failure:{}",
                     a.address(),
-                    a.quality_score,
-                    a.source,
-                    a.avg_latency,
-                    a.last_seen
+                    a.quality_score(),
+                    a.source(),
+                    a.avg_latency(),
+                    a.last_seen()
                         .as_ref()
                         .map(|t| t.to_string())
                         .unwrap_or_else(|| "Never".to_string()),
-                    a.last_failed_reason.as_ref().unwrap_or(&"None".to_string())
+                    a.last_failed_reason().unwrap_or("None")
                 );
             });
             println!("User agent: {}", peer.user_agent);

--- a/base_layer/p2p/src/initialization.rs
+++ b/base_layer/p2p/src/initialization.rs
@@ -555,11 +555,11 @@ impl ServiceInitializer for P2pInitializer {
             })
             .set_liveness_check(config.listener_liveness_check_interval);
 
-        if config.allow_test_addresses || config.dht.allow_test_addresses {
+        if config.allow_test_addresses || config.dht.peer_validator_config.allow_test_addresses {
             // The default is false, so ensure that both settings are true in this case
             config.allow_test_addresses = true;
-            config.dht.allow_test_addresses = true;
             builder = builder.allow_test_addresses();
+            config.dht.peer_validator_config = builder.peer_validator_config().clone();
         }
 
         let (comms, dht) = configure_comms_and_dht(builder, &config, connector).await?;

--- a/base_layer/p2p/src/services/liveness/service.rs
+++ b/base_layer/p2p/src/services/liveness/service.rs
@@ -575,7 +575,7 @@ mod test {
         let msg = create_dummy_message(PingPongMessage::pong_with_metadata(123, metadata.clone()));
 
         state.add_inflight_ping(
-            msg.inner.as_ref().map(|i| i.nonce.clone()).unwrap(),
+            msg.inner.as_ref().map(|i| i.nonce).unwrap(),
             msg.source_peer.node_id.clone(),
         );
 

--- a/base_layer/wallet/src/storage/sqlite_db/wallet.rs
+++ b/base_layer/wallet/src/storage/sqlite_db/wallet.rs
@@ -303,7 +303,7 @@ impl WalletSqliteDatabase {
 
     fn get_comms_features(&self, conn: &mut SqliteConnection) -> Result<Option<PeerFeatures>, WalletStorageError> {
         if let Some(key_str) = WalletSettingSql::get(&DbKey::CommsFeatures, conn)? {
-            let features = u64::from_str(&key_str).map_err(|e| WalletStorageError::ConversionError(e.to_string()))?;
+            let features = u32::from_str(&key_str).map_err(|e| WalletStorageError::ConversionError(e.to_string()))?;
             let peer_features = PeerFeatures::from_bits(features);
             Ok(peer_features)
         } else {

--- a/comms/core/src/bans.rs
+++ b/comms/core/src/bans.rs
@@ -1,0 +1,27 @@
+// // Copyright 2023. The Tari Project
+// //
+// // Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// // following conditions are met:
+// //
+// // 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
+// following // disclaimer.
+// //
+// // 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// // following disclaimer in the documentation and/or other materials provided with the distribution.
+// //
+// // 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// // products derived from this software without specific prior written permission.
+// //
+// // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// // INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// // SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// // SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::time::Duration;
+
+// TODO: consolidate ban durations
+pub const BAN_DURATION_LONG: Duration = Duration::from_secs(2 * 60 * 60);
+pub const BAN_DURATION_SHORT: Duration = Duration::from_secs(2 * 60);

--- a/comms/core/src/connection_manager/dialer.rs
+++ b/comms/core/src/connection_manager/dialer.rs
@@ -50,6 +50,7 @@ use crate::{
     backoff::Backoff,
     connection_manager::{
         common,
+        common::ValidatedPeerIdentityExchange,
         dial_state::DialState,
         manager::{ConnectionManagerConfig, ConnectionManagerEvent},
         metrics,
@@ -68,8 +69,15 @@ use crate::{
 const LOG_TARGET: &str = "comms::connection_manager::dialer";
 
 type DialResult<TSocket> = Result<(NoiseSocket<TSocket>, Multiaddr), ConnectionManagerError>;
-type DialFuturesUnordered =
-    FuturesUnordered<BoxFuture<'static, (DialState, Result<PeerConnection, ConnectionManagerError>)>>;
+type DialFuturesUnordered = FuturesUnordered<
+    BoxFuture<
+        'static,
+        (
+            DialState,
+            Result<(PeerConnection, ValidatedPeerIdentityExchange), ConnectionManagerError>,
+        ),
+    >,
+>;
 
 #[derive(Debug)]
 pub(crate) enum DialerRequest {
@@ -94,7 +102,7 @@ pub struct Dialer<TTransport, TBackoff> {
     conn_man_notifier: mpsc::Sender<ConnectionManagerEvent>,
     shutdown: Option<ShutdownSignal>,
     pending_dial_requests: HashMap<NodeId, Vec<oneshot::Sender<Result<PeerConnection, ConnectionManagerError>>>>,
-    our_supported_protocols: Vec<ProtocolId>,
+    our_supported_protocols: Arc<Vec<ProtocolId>>,
 }
 
 impl<TTransport, TBackoff> Dialer<TTransport, TBackoff>
@@ -126,13 +134,13 @@ where
             conn_man_notifier,
             shutdown: Some(shutdown),
             pending_dial_requests: Default::default(),
-            our_supported_protocols: Vec::new(),
+            our_supported_protocols: Arc::new(Vec::new()),
         }
     }
 
     /// Set the supported protocols of this node to send to peers during the peer identity exchange
     pub fn set_supported_protocols(&mut self, our_supported_protocols: Vec<ProtocolId>) -> &mut Self {
-        self.our_supported_protocols = our_supported_protocols;
+        self.our_supported_protocols = Arc::new(our_supported_protocols);
         self
     }
 
@@ -193,7 +201,7 @@ where
 
     fn resolve_pending_dials(&mut self, conn: PeerConnection) {
         let peer = conn.peer_node_id().clone();
-        self.reply_to_pending_requests(&peer, &Ok(conn));
+        self.reply_to_pending_requests(&peer, Ok(conn));
         self.cancel_dial(&peer);
     }
 
@@ -215,53 +223,43 @@ where
     async fn handle_dial_result(
         &mut self,
         mut dial_state: DialState,
-        dial_result: Result<PeerConnection, ConnectionManagerError>,
+        dial_result: Result<(PeerConnection, ValidatedPeerIdentityExchange), ConnectionManagerError>,
     ) {
         let node_id = dial_state.peer().node_id.clone();
         metrics::pending_connections(Some(&node_id), ConnectionDirection::Outbound).inc();
 
-        // try save the peer back to the peer manager
-        let peer = dial_state.peer_mut();
-        if let Ok(peer_connection) = &dial_result {
-            if let Some(peer_identity) = peer_connection.peer_identity_claim() {
-                peer.update_addresses(&peer_identity.addresses, &PeerAddressSource::FromPeerConnection {
-                    peer_identity_claim: peer_identity.clone(),
+        match dial_result {
+            Ok((conn, peer_identity)) => {
+                // try save the peer back to the peer manager
+                let peer = dial_state.peer_mut();
+                peer.update_addresses(&peer_identity.claim.addresses, &PeerAddressSource::FromPeerConnection {
+                    peer_identity_claim: peer_identity.claim.clone(),
                 });
-                if let Some(unverified_data) = &peer_identity.unverified_data {
-                    for protocol in &unverified_data.supported_protocols {
-                        if !peer.supported_protocols.contains(protocol) {
-                            peer.supported_protocols.push(protocol.clone());
-                        }
-                    }
-                    if peer.user_agent != unverified_data.user_agent && !unverified_data.user_agent.is_empty() {
-                        peer.user_agent = unverified_data.user_agent.clone();
-                    }
-                }
-            } else {
-                error!(target: LOG_TARGET, "No identity claim provided");
-                let _ = dial_state
-                    .send_reply(Err(ConnectionManagerError::PeerConnectionError(
-                        "No identity claim provided".to_string(),
-                    )))
-                    .map_err(|e| error!(target: LOG_TARGET, "Could not send reply to dial request: {:?}", e));
-            }
-        }
+                peer.supported_protocols = peer_identity.metadata.supported_protocols;
+                peer.user_agent = peer_identity.metadata.user_agent;
 
-        let _ = self
-            .peer_manager
-            .add_peer(dial_state.peer().clone())
-            .await
-            .map_err(|e| {
-                error!("Could not update peer data:{}", e);
-                let _ = dial_state
-                    .send_reply(Err(ConnectionManagerError::PeerManagerError(e)))
-                    .map_err(|e| error!(target: LOG_TARGET, "Could not send reply to dial request: {:?}", e));
-            });
-        match &dial_result {
-            Ok(conn) => {
+                let _ = self
+                    .peer_manager
+                    .add_peer(dial_state.peer().clone())
+                    .await
+                    .map_err(|e| {
+                        error!("Could not update peer data:{}", e);
+                        let _ = dial_state
+                            .send_reply(Err(ConnectionManagerError::PeerManagerError(e)))
+                            .map_err(|e| error!(target: LOG_TARGET, "Could not send reply to dial request: {:?}", e));
+                    });
                 debug!(target: LOG_TARGET, "Successfully dialed peer '{}'", node_id);
                 self.notify_connection_manager(ConnectionManagerEvent::PeerConnected(conn.clone().into()))
-                    .await
+                    .await;
+
+                if dial_state.send_reply(Ok(conn.clone())).is_err() {
+                    warn!(
+                        target: LOG_TARGET,
+                        "Reply oneshot was closed before dial response for peer '{}' was sent", node_id
+                    );
+                }
+
+                self.reply_to_pending_requests(&node_id, Ok(conn));
             },
             Err(err) => {
                 debug!(
@@ -269,20 +267,20 @@ where
                     "Failed to dial peer '{}' because '{:?}'", node_id, err
                 );
                 self.notify_connection_manager(ConnectionManagerEvent::PeerConnectFailed(node_id.clone(), err.clone()))
-                    .await
+                    .await;
+
+                if dial_state.send_reply(Err(err.clone())).is_err() {
+                    warn!(
+                        target: LOG_TARGET,
+                        "Reply oneshot was closed before dial response for peer '{}' was sent", node_id
+                    );
+                }
+                self.reply_to_pending_requests(&node_id, Err(err));
             },
         }
 
         metrics::pending_connections(Some(&node_id), ConnectionDirection::Outbound).dec();
 
-        if dial_state.send_reply(dial_result.clone()).is_err() {
-            warn!(
-                target: LOG_TARGET,
-                "Reply oneshot was closed before dial response for peer '{}' was sent", node_id
-            );
-        }
-
-        self.reply_to_pending_requests(&node_id, &dial_result);
         self.cancel_dial(&node_id);
     }
 
@@ -297,7 +295,7 @@ where
     fn reply_to_pending_requests(
         &mut self,
         peer_node_id: &NodeId,
-        result: &Result<PeerConnection, ConnectionManagerError>,
+        result: Result<PeerConnection, ConnectionManagerError>,
     ) {
         self.pending_dial_requests
             .remove(peer_node_id)
@@ -345,6 +343,7 @@ where
         let supported_protocols = self.our_supported_protocols.clone();
         let noise_config = self.noise_config.clone();
         let config = self.config.clone();
+        let peer_manager = self.peer_manager.clone();
 
         let span = span!(Level::TRACE, "handle_dial_peer_request_inner1");
         let dial_fut = async move {
@@ -369,7 +368,8 @@ where
                         };
 
                     let result = Self::perform_socket_upgrade_procedure(
-                        node_identity,
+                        &peer_manager,
+                        &node_identity,
                         socket,
                         addr.clone(),
                         authenticated_public_key,
@@ -418,34 +418,43 @@ where
     }
 
     async fn perform_socket_upgrade_procedure(
-        node_identity: Arc<NodeIdentity>,
+        peer_manager: &PeerManager,
+        node_identity: &NodeIdentity,
         mut socket: NoiseSocket<TTransport::Output>,
         dialed_addr: Multiaddr,
         authenticated_public_key: CommsPublicKey,
         conn_man_notifier: mpsc::Sender<ConnectionManagerEvent>,
-        our_supported_protocols: Vec<ProtocolId>,
+        our_supported_protocols: Arc<Vec<ProtocolId>>,
         config: &ConnectionManagerConfig,
         cancel_signal: ShutdownSignal,
-    ) -> Result<PeerConnection, ConnectionManagerError> {
+    ) -> Result<(PeerConnection, ValidatedPeerIdentityExchange), ConnectionManagerError> {
         static CONNECTION_DIRECTION: ConnectionDirection = ConnectionDirection::Outbound;
         debug!(
             target: LOG_TARGET,
             "Starting peer identity exchange for peer with public key '{}'", authenticated_public_key
         );
 
-        let peer_identity = common::perform_identity_exchange(
+        let peer_identity_result = common::perform_identity_exchange(
             &mut socket,
-            &node_identity,
-            &our_supported_protocols,
+            node_identity,
+            &*our_supported_protocols,
             config.network_info.clone(),
         )
-        .await?;
+        .await;
+        let peer_identity =
+            common::ban_on_offence(peer_manager, &authenticated_public_key, peer_identity_result).await?;
 
         if cancel_signal.is_terminated() {
             return Err(ConnectionManagerError::DialCancelled);
         }
 
-        common::validate_peer_identity(&authenticated_public_key, &peer_identity, config.allow_test_addresses).await?;
+        let peer_identity_result = common::validate_peer_identity_message(
+            &config.peer_validation_config,
+            &authenticated_public_key,
+            peer_identity,
+        );
+        let peer_identity =
+            common::ban_on_offence(peer_manager, &authenticated_public_key, peer_identity_result).await?;
 
         if cancel_signal.is_terminated() {
             return Err(ConnectionManagerError::DialCancelled);
@@ -459,17 +468,18 @@ where
             return Err(ConnectionManagerError::DialCancelled);
         }
 
-        peer_connection::try_create(
+        let peer_connection = peer_connection::create(
             muxer,
             dialed_addr,
             NodeId::from_public_key(&authenticated_public_key),
-            peer_identity.features,
+            peer_identity.claim.features,
             CONNECTION_DIRECTION,
             conn_man_notifier,
             our_supported_protocols,
-            peer_identity.supported_protocols(),
-            peer_identity,
-        )
+            peer_identity.metadata.supported_protocols.clone(),
+        );
+
+        Ok((peer_connection, peer_identity))
     }
 
     async fn dial_peer_with_retry(

--- a/comms/core/src/connection_manager/error.rs
+++ b/comms/core/src/connection_manager/error.rs
@@ -27,6 +27,7 @@ use crate::{
     connection_manager::PeerConnectionRequest,
     noise,
     peer_manager::PeerManagerError,
+    peer_validator::PeerValidatorError,
     protocol::{IdentityProtocolError, ProtocolError},
 };
 
@@ -81,14 +82,8 @@ pub enum ConnectionManagerError {
     NoiseProtocolTimeout,
     #[error("Listener oneshot cancelled")]
     ListenerOneshotCancelled,
-    #[error("Peer sent invalid identity signature")]
-    PeerIdentityInvalidSignature,
-    #[error("Peer did not provide an identity signature")]
-    PeerIdentityNoSignature,
-    #[error("Peer did not provide any public addresses")]
-    PeerIdentityNoAddresses,
-    #[error("Onion v2 is no longer supported")]
-    OnionV2NotSupported,
+    #[error("Peer validation error: {0}")]
+    PeerValidationError(#[from] PeerValidatorError),
 }
 
 impl From<yamux::ConnectionError> for ConnectionManagerError {

--- a/comms/core/src/connection_manager/listener.rs
+++ b/comms/core/src/connection_manager/listener.rs
@@ -80,7 +80,7 @@ pub struct PeerListener<TTransport> {
     noise_config: NoiseConfig,
     peer_manager: Arc<PeerManager>,
     node_identity: Arc<NodeIdentity>,
-    our_supported_protocols: Vec<ProtocolId>,
+    our_supported_protocols: Arc<Vec<ProtocolId>>,
     liveness_session_count: Arc<AtomicUsize>,
     on_listening: OneshotTrigger<Result<Multiaddr, ConnectionManagerError>>,
 }
@@ -108,7 +108,7 @@ where
             peer_manager,
             node_identity,
             shutdown_signal,
-            our_supported_protocols: Vec::new(),
+            our_supported_protocols: Arc::new(Vec::new()),
             bounded_executor: BoundedExecutor::new(config.max_simultaneous_inbound_connects),
             liveness_session_count: Arc::new(AtomicUsize::new(config.liveness_max_sessions)),
             config,
@@ -127,7 +127,7 @@ where
 
     /// Set the supported protocols of this node to send to peers during the peer identity exchange
     pub fn set_supported_protocols(&mut self, our_supported_protocols: Vec<ProtocolId>) -> &mut Self {
-        self.our_supported_protocols = our_supported_protocols;
+        self.our_supported_protocols = Arc::new(our_supported_protocols);
         self
     }
 
@@ -245,8 +245,8 @@ where
                 Ok(WireMode::Comms(byte)) if byte == config.network_info.network_byte => {
                     let this_node_id_str = node_identity.node_id().short_str();
                     let result = Self::perform_socket_upgrade_procedure(
-                        node_identity,
-                        peer_manager,
+                        &node_identity,
+                        &peer_manager,
                         noise_config.clone(),
                         conn_man_notifier.clone(),
                         socket,
@@ -335,16 +335,16 @@ where
     }
 
     async fn perform_socket_upgrade_procedure(
-        node_identity: Arc<NodeIdentity>,
-        peer_manager: Arc<PeerManager>,
+        node_identity: &NodeIdentity,
+        peer_manager: &PeerManager,
         noise_config: NoiseConfig,
         conn_man_notifier: mpsc::Sender<ConnectionManagerEvent>,
         socket: TTransport::Output,
         peer_addr: Multiaddr,
-        our_supported_protocols: Vec<ProtocolId>,
+        our_supported_protocols: Arc<Vec<ProtocolId>>,
         config: &ConnectionManagerConfig,
     ) -> Result<PeerConnection, ConnectionManagerError> {
-        static CONNECTION_DIRECTION: ConnectionDirection = ConnectionDirection::Inbound;
+        const CONNECTION_DIRECTION: ConnectionDirection = ConnectionDirection::Inbound;
         debug!(
             target: LOG_TARGET,
             "Starting noise protocol upgrade for peer at address '{}'", peer_addr
@@ -370,44 +370,56 @@ where
         );
 
         // Check if we know the peer and if it is banned
-        let known_peer = common::find_unbanned_peer(&peer_manager, &authenticated_public_key).await?;
+        let known_peer = common::find_unbanned_peer(peer_manager, &authenticated_public_key).await?;
 
         debug!(
             target: LOG_TARGET,
             "Starting peer identity exchange for peer with public key '{}'", authenticated_public_key
         );
 
-        let peer_identity = common::perform_identity_exchange(
+        let peer_identity_result = common::perform_identity_exchange(
             &mut noise_socket,
-            &node_identity,
-            &our_supported_protocols,
+            node_identity,
+            &*our_supported_protocols,
             config.network_info.clone(),
         )
-        .await?;
+        .await;
 
-        let peer_node_id = common::validate_and_add_peer_from_peer_identity(
-            &peer_manager,
+        let peer_identity =
+            common::ban_on_offence(peer_manager, &authenticated_public_key, peer_identity_result).await?;
+
+        let valid_peer_identity_result = common::validate_peer_identity_message(
+            &config.peer_validation_config,
+            &authenticated_public_key,
+            peer_identity,
+        );
+
+        let valid_peer_identity =
+            common::ban_on_offence(peer_manager, &authenticated_public_key, valid_peer_identity_result).await?;
+
+        let peer = common::create_or_update_peer_from_validated_peer_identity(
             known_peer,
             authenticated_public_key,
-            &peer_identity,
-            config.allow_test_addresses,
-        )
-        .await?;
+            &valid_peer_identity,
+        );
 
         let muxer = Yamux::upgrade_connection(noise_socket, CONNECTION_DIRECTION)
             .map_err(|err| ConnectionManagerError::YamuxUpgradeFailure(err.to_string()))?;
 
-        peer_connection::try_create(
+        let conn = peer_connection::create(
             muxer,
             peer_addr,
-            peer_node_id,
-            peer_identity.features,
+            peer.node_id.clone(),
+            peer.features,
             CONNECTION_DIRECTION,
             conn_man_notifier,
             our_supported_protocols,
-            peer_identity.supported_protocols(),
-            peer_identity,
-        )
+            valid_peer_identity.metadata.supported_protocols,
+        );
+
+        peer_manager.add_peer(peer).await?;
+
+        Ok(conn)
     }
 
     async fn bind(&mut self) -> Result<(TTransport::Listener, Multiaddr), ConnectionManagerError> {

--- a/comms/core/src/connection_manager/manager.rs
+++ b/comms/core/src/connection_manager/manager.rs
@@ -47,6 +47,7 @@ use crate::{
     multiplexing::Substream,
     noise::NoiseConfig,
     peer_manager::{NodeId, NodeIdentity, PeerManagerError},
+    peer_validator::PeerValidatorConfig,
     protocol::{NodeNetworkInfo, ProtocolEvent, ProtocolId, Protocols},
     transports::{TcpTransport, Transport},
     PeerManager,
@@ -100,9 +101,6 @@ pub struct ConnectionManagerConfig {
     /// The maximum number of connection tasks that will be spawned at the same time. Once this limit is reached, peers
     /// attempting to connect will have to wait for another connection attempt to complete. Default: 100
     pub max_simultaneous_inbound_connects: usize,
-    /// Set to true to allow peers to send loopback, local-link and other addresses normally not considered valid for
-    /// peer-to-peer comms. Default: false
-    pub allow_test_addresses: bool,
     /// Version information for this node
     pub network_info: NodeNetworkInfo,
     /// The maximum time to wait for the first byte before closing the connection. Default: 45s
@@ -116,6 +114,7 @@ pub struct ConnectionManagerConfig {
     /// If set, an additional TCP-only p2p listener will be started. This is useful for local wallet connections.
     /// Default: None (disabled)
     pub auxiliary_tcp_listener_address: Option<Multiaddr>,
+    pub peer_validation_config: PeerValidatorConfig,
 }
 
 impl Default for ConnectionManagerConfig {
@@ -130,16 +129,12 @@ impl Default for ConnectionManagerConfig {
             max_dial_attempts: 1,
             max_simultaneous_inbound_connects: 100,
             network_info: Default::default(),
-            #[cfg(not(test))]
-            allow_test_addresses: false,
-            // This must always be true for internal crate tests
-            #[cfg(test)]
-            allow_test_addresses: true,
             liveness_max_sessions: 1,
             time_to_first_byte: Duration::from_secs(45),
             liveness_cidr_allowlist: vec![cidr::AnyIpCidr::V4("127.0.0.1/32".parse().unwrap())],
             liveness_self_check_interval: None,
             auxiliary_tcp_listener_address: None,
+            peer_validation_config: PeerValidatorConfig::default(),
         }
     }
 }

--- a/comms/core/src/connection_manager/peer_connection.rs
+++ b/comms/core/src/connection_manager/peer_connection.rs
@@ -357,9 +357,7 @@ impl PeerConnectionActor {
             incoming_substreams: connection.into_incoming(),
             request_rx,
             event_notifier,
-            // our_supported_protocols never changes so we make it cheap to clone (used in inbound_protocol_negotiations
-            // futures)
-            our_supported_protocols: Arc::new(our_supported_protocols),
+            our_supported_protocols,
             inbound_protocol_negotiations: FuturesUnordered::new(),
             their_supported_protocols,
         }

--- a/comms/core/src/connection_manager/tests/listener_dialer.rs
+++ b/comms/core/src/connection_manager/tests/listener_dialer.rs
@@ -246,8 +246,10 @@ async fn banned() {
     let err = reply_rx.await.unwrap().unwrap_err();
     unpack_enum!(ConnectionManagerError::IdentityProtocolError(_err) = err);
 
-    unpack_enum!(ConnectionManagerEvent::PeerInboundConnectFailed(err) = event_rx.recv().await.unwrap());
-    unpack_enum!(ConnectionManagerError::PeerBanned = err);
+    unpack_enum!(
+        ConnectionManagerEvent::PeerInboundConnectFailed(ConnectionManagerError::PeerBanned) =
+            event_rx.recv().await.unwrap()
+    );
 
     shutdown.trigger();
 

--- a/comms/core/src/connectivity/manager.rs
+++ b/comms/core/src/connectivity/manager.rs
@@ -265,7 +265,7 @@ impl ConnectivityManagerActor {
                 } else if let Err(err) = self.ban_peer(&node_id, duration, reason).await {
                     error!(target: LOG_TARGET, "Error when banning peer: {:?}", err);
                 } else {
-                    // we ban the peer
+                    // we banned the peer
                 }
             },
             AddPeerToAllowList(node_id) => {

--- a/comms/core/src/connectivity/requester.rs
+++ b/comms/core/src/connectivity/requester.rs
@@ -248,14 +248,14 @@ impl ConnectivityRequester {
     }
 
     /// Ban peer for the given Duration. The ban `reason` is persisted in the peer database for reference.
-    pub async fn ban_peer_until(
+    pub async fn ban_peer_until<T: Into<String>>(
         &mut self,
         node_id: NodeId,
         duration: Duration,
-        reason: String,
+        reason: T,
     ) -> Result<(), ConnectivityError> {
         self.sender
-            .send(ConnectivityRequest::BanPeer(node_id, duration, reason))
+            .send(ConnectivityRequest::BanPeer(node_id, duration, reason.into()))
             .await
             .map_err(|_| ConnectivityError::ActorDisconnected)?;
         Ok(())

--- a/comms/core/src/lib.rs
+++ b/comms/core/src/lib.rs
@@ -18,7 +18,7 @@ mod builder;
 pub use builder::{CommsBuilder, CommsBuilderError, CommsNode, UnspawnedCommsNode};
 
 pub mod connection_manager;
-pub use connection_manager::{validate_addresses, PeerConnection, PeerConnectionError};
+pub use connection_manager::{PeerConnection, PeerConnectionError};
 
 pub mod connectivity;
 
@@ -51,6 +51,9 @@ pub mod types;
 #[macro_use]
 pub mod utils;
 
+pub mod peer_validator;
+
+mod bans;
 pub mod test_utils;
 pub mod traits;
 

--- a/comms/core/src/net_address/multiaddr_with_stats.rs
+++ b/comms/core/src/net_address/multiaddr_with_stats.rs
@@ -19,20 +19,279 @@ use crate::{peer_manager::PeerIdentityClaim, types::CommsPublicKey};
 
 const MAX_LATENCY_SAMPLE_COUNT: u32 = 100;
 const MAX_INITIAL_DIAL_TIME_SAMPLE_COUNT: u32 = 100;
+const HIGH_QUALITY_SCORE: i32 = 1000;
 
 #[derive(Debug, Eq, Clone, Deserialize, Serialize)]
 pub struct MultiaddrWithStats {
     address: Multiaddr,
-    pub last_seen: Option<NaiveDateTime>,
-    pub connection_attempts: u32,
-    pub avg_initial_dial_time: Duration,
+    last_seen: Option<NaiveDateTime>,
+    connection_attempts: u32,
+    avg_initial_dial_time: Duration,
     initial_dial_time_sample_count: u32,
-    pub avg_latency: Duration,
+    avg_latency: Duration,
     latency_sample_count: u32,
-    pub last_attempted: Option<NaiveDateTime>,
-    pub last_failed_reason: Option<String>,
-    pub quality_score: i32,
-    pub source: PeerAddressSource,
+    last_attempted: Option<NaiveDateTime>,
+    last_failed_reason: Option<String>,
+    quality_score: i32,
+    source: PeerAddressSource,
+}
+
+impl MultiaddrWithStats {
+    /// Constructs a new net address with zero stats
+    pub fn new(address: Multiaddr, source: PeerAddressSource) -> Self {
+        let mut addr = Self {
+            address,
+            last_seen: None,
+            connection_attempts: 0,
+            avg_initial_dial_time: Duration::from_secs(0),
+            initial_dial_time_sample_count: 0,
+            avg_latency: Duration::from_millis(0),
+            latency_sample_count: 0,
+            last_attempted: None,
+            last_failed_reason: None,
+            quality_score: 0,
+            source,
+        };
+        addr.update_quality_score();
+        addr
+    }
+
+    pub fn merge(&mut self, other: &Self) {
+        if self.address == other.address {
+            self.last_seen = cmp::max(other.last_seen, self.last_seen);
+            self.connection_attempts = cmp::max(self.connection_attempts, other.connection_attempts);
+            match self.latency_sample_count.cmp(&other.latency_sample_count) {
+                Ordering::Less => {
+                    self.avg_latency = other.avg_latency;
+                    self.latency_sample_count = other.latency_sample_count;
+                },
+                Ordering::Equal | Ordering::Greater => {},
+            }
+            match self
+                .initial_dial_time_sample_count
+                .cmp(&other.initial_dial_time_sample_count)
+            {
+                Ordering::Less => {
+                    self.avg_initial_dial_time = other.avg_initial_dial_time;
+                    self.initial_dial_time_sample_count = other.initial_dial_time_sample_count;
+                },
+                Ordering::Equal | Ordering::Greater => {},
+            }
+            self.last_attempted = cmp::max(self.last_attempted, other.last_attempted);
+            self.last_failed_reason = other.last_failed_reason.clone();
+            self.update_source_if_better(&other.source);
+        }
+    }
+
+    pub fn update_source_if_better(&mut self, source: &PeerAddressSource) {
+        match (self.source.peer_identity_claim(), source.peer_identity_claim()) {
+            (None, None) => (),
+            (None, Some(_)) => {
+                self.source = source.clone();
+            },
+            (Some(_), None) => (),
+            (Some(self_source), Some(other_source)) => {
+                if other_source.signature.updated_at() > self_source.signature.updated_at() {
+                    self.source = source.clone();
+                }
+            },
+        }
+        self.update_quality_score();
+    }
+
+    pub fn address(&self) -> &Multiaddr {
+        &self.address
+    }
+
+    pub fn offline_at(&self) -> Option<NaiveDateTime> {
+        if self.last_failed_reason.is_some() {
+            self.last_attempted
+        } else {
+            None
+        }
+    }
+
+    /// Updates the average latency by including another measured latency sample. The historical average is updated by
+    /// allowing the new measurement to provide a weighted contribution to the historical average. As more samples are
+    /// received the historical average will have a larger weight compare to the new measurement, this will have a
+    /// filtering effect similar to a sliding window without needing previous measurements to be stored. When a new
+    /// latency measurement is received and the latency_sample_count is equal or have surpassed the
+    /// MAX_LATENCY_SAMPLE_COUNT then the current avg_latency is scaled so that the new latency_measurement only makes a
+    /// small weighted change to the avg_latency. The previous avg_latency will have a weight of
+    /// MAX_LATENCY_SAMPLE_COUNT and the new latency_measurement will have a weight of 1.
+    pub fn update_latency(&mut self, latency_measurement: Duration) {
+        self.last_seen = Some(Utc::now().naive_utc());
+
+        self.avg_latency = ((self.avg_latency.saturating_mul(self.latency_sample_count))
+            .saturating_add(latency_measurement)) /
+            (self.latency_sample_count + 1);
+        if self.latency_sample_count < MAX_LATENCY_SAMPLE_COUNT {
+            self.latency_sample_count += 1;
+        }
+
+        self.update_quality_score();
+    }
+
+    pub fn update_initial_dial_time(&mut self, initial_dial_time: Duration) {
+        self.last_seen = Some(Utc::now().naive_utc());
+
+        self.avg_initial_dial_time = ((self.avg_initial_dial_time * self.initial_dial_time_sample_count) +
+            initial_dial_time) /
+            (self.initial_dial_time_sample_count + 1);
+        if self.initial_dial_time_sample_count < MAX_INITIAL_DIAL_TIME_SAMPLE_COUNT {
+            self.initial_dial_time_sample_count += 1;
+        }
+        self.update_quality_score();
+    }
+
+    /// Mark that a successful interaction occurred with this address
+    pub fn mark_last_seen_now(&mut self) -> &mut Self {
+        self.last_seen = Some(Utc::now().naive_utc());
+        self.last_failed_reason = None;
+        self.reset_connection_attempts();
+        self.update_quality_score();
+        self
+    }
+
+    /// Reset the connection attempts on this net address for a later session of retries
+    pub fn reset_connection_attempts(&mut self) {
+        self.connection_attempts = 0;
+    }
+
+    /// Mark that a connection could not be established with this net address
+    pub fn mark_failed_connection_attempt(&mut self, error_string: String) -> &mut Self {
+        self.connection_attempts += 1;
+        self.last_failed_reason = Some(error_string);
+        self.update_quality_score();
+        self
+    }
+
+    #[cfg(test)]
+    pub fn mark_last_attempted(&mut self, timestamp: NaiveDateTime) -> &mut Self {
+        self.last_attempted = Some(timestamp);
+        self.update_quality_score();
+        self
+    }
+
+    pub fn mark_last_attempted_now(&mut self) -> &mut Self {
+        self.last_attempted = Some(Utc::now().naive_utc());
+        self.update_quality_score();
+        self
+    }
+
+    /// Get as a Multiaddr
+    pub fn as_net_address(&self) -> Multiaddr {
+        self.clone().address
+    }
+
+    fn calculate_quality_score(&self) -> i32 {
+        // If we have never seen or attempted the peer, we start with a high score to ensure that
+        if self.last_seen.is_none() && self.last_attempted.is_none() {
+            return HIGH_QUALITY_SCORE;
+        }
+
+        let mut score_self = 0;
+
+        if self.avg_latency.as_millis() == 0 {
+            score_self += 100;
+        } else {
+            // explicitly truncate the latency to avoid casting problems
+            let avg_latency_millis = i32::try_from(self.avg_latency.as_millis()).unwrap_or(i32::MAX);
+            score_self += cmp::max(0, 100i32.saturating_sub(avg_latency_millis / 100));
+        }
+
+        let last_seen_seconds: i32 = self
+            .last_seen
+            .map(|x| Utc::now().naive_utc() - x)
+            .map(|x| x.num_seconds())
+            .unwrap_or(0)
+            .try_into()
+            .unwrap_or(i32::MAX);
+        score_self += cmp::max(0, 100i32.saturating_sub(last_seen_seconds));
+
+        if self.last_failed_reason.is_some() {
+            score_self -= 100;
+        }
+
+        score_self
+    }
+
+    fn update_quality_score(&mut self) {
+        self.quality_score = self.calculate_quality_score();
+    }
+
+    pub fn source(&self) -> &PeerAddressSource {
+        &self.source
+    }
+
+    pub fn last_seen(&self) -> Option<NaiveDateTime> {
+        self.last_seen
+    }
+
+    pub fn connection_attempts(&self) -> u32 {
+        self.connection_attempts
+    }
+
+    pub fn avg_initial_dial_time(&self) -> Duration {
+        self.avg_initial_dial_time
+    }
+
+    pub fn initial_dial_time_sample_count(&self) -> u32 {
+        self.initial_dial_time_sample_count
+    }
+
+    pub fn avg_latency(&self) -> Duration {
+        self.avg_latency
+    }
+
+    pub fn latency_sample_count(&self) -> u32 {
+        self.latency_sample_count
+    }
+
+    pub fn last_attempted(&self) -> Option<NaiveDateTime> {
+        self.last_attempted
+    }
+
+    pub fn last_failed_reason(&self) -> Option<&str> {
+        self.last_failed_reason.as_deref()
+    }
+
+    pub fn quality_score(&self) -> i32 {
+        self.quality_score
+    }
+}
+
+// Reliability ordering of net addresses: prioritize net addresses according to previous successful connections,
+// connection attempts, latency and last seen A lower ordering has a higher priority and a higher ordering has a lower
+// priority, this ordering switch allows searching for, and updating of net addresses to be performed more efficiently
+impl Ord for MultiaddrWithStats {
+    fn cmp(&self, other: &MultiaddrWithStats) -> Ordering {
+        self.quality_score.cmp(&other.quality_score)
+    }
+}
+
+impl PartialOrd for MultiaddrWithStats {
+    fn partial_cmp(&self, other: &MultiaddrWithStats) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl PartialEq for MultiaddrWithStats {
+    fn eq(&self, other: &MultiaddrWithStats) -> bool {
+        self.address == other.address
+    }
+}
+
+impl Hash for MultiaddrWithStats {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.address.hash(state)
+    }
+}
+
+impl Display for MultiaddrWithStats {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.address)
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq)]
@@ -114,204 +373,6 @@ impl PartialEq for PeerAddressSource {
         }
     }
 }
-
-impl MultiaddrWithStats {
-    /// Constructs a new net address with zero stats
-    pub fn new(address: Multiaddr, source: PeerAddressSource) -> Self {
-        Self {
-            address,
-            last_seen: None,
-            connection_attempts: 0,
-            avg_initial_dial_time: Duration::from_secs(0),
-            initial_dial_time_sample_count: 0,
-            avg_latency: Duration::from_millis(0),
-            latency_sample_count: 0,
-            last_attempted: None,
-            last_failed_reason: None,
-            quality_score: 0,
-            source,
-        }
-    }
-
-    pub fn merge(&mut self, other: &Self) {
-        if self.address == other.address {
-            self.last_seen = cmp::max(other.last_seen, self.last_seen);
-            self.connection_attempts = cmp::max(self.connection_attempts, other.connection_attempts);
-            match self.latency_sample_count.cmp(&other.latency_sample_count) {
-                Ordering::Less => {
-                    self.avg_latency = other.avg_latency;
-                    self.latency_sample_count = other.latency_sample_count;
-                },
-                Ordering::Equal | Ordering::Greater => {},
-            }
-            match self
-                .initial_dial_time_sample_count
-                .cmp(&other.initial_dial_time_sample_count)
-            {
-                Ordering::Less => {
-                    self.avg_initial_dial_time = other.avg_initial_dial_time;
-                    self.initial_dial_time_sample_count = other.initial_dial_time_sample_count;
-                },
-                Ordering::Equal | Ordering::Greater => {},
-            }
-            self.last_attempted = cmp::max(self.last_attempted, other.last_attempted);
-            self.last_failed_reason = other.last_failed_reason.clone();
-            self.update_source_if_better(&other.source);
-        }
-    }
-
-    pub fn update_source_if_better(&mut self, source: &PeerAddressSource) {
-        match (self.source.peer_identity_claim(), source.peer_identity_claim()) {
-            (None, None) => (),
-            (None, Some(_)) => {
-                self.source = source.clone();
-            },
-            (Some(_), None) => (),
-            (Some(self_source), Some(other_source)) => {
-                if other_source.signature.updated_at() > self_source.signature.updated_at() {
-                    self.source = source.clone();
-                }
-            },
-        }
-        self.calculate_quality_score();
-    }
-
-    pub fn address(&self) -> &Multiaddr {
-        &self.address
-    }
-
-    pub fn offline_at(&self) -> Option<NaiveDateTime> {
-        if self.last_failed_reason.is_some() {
-            self.last_attempted
-        } else {
-            None
-        }
-    }
-
-    /// Updates the average latency by including another measured latency sample. The historical average is updated by
-    /// allowing the new measurement to provide a weighted contribution to the historical average. As more samples are
-    /// received the historical average will have a larger weight compare to the new measurement, this will have a
-    /// filtering effect similar to a sliding window without needing previous measurements to be stored. When a new
-    /// latency measurement is received and the latency_sample_count is equal or have surpassed the
-    /// MAX_LATENCY_SAMPLE_COUNT then the current avg_latency is scaled so that the new latency_measurement only makes a
-    /// small weighted change to the avg_latency. The previous avg_latency will have a weight of
-    /// MAX_LATENCY_SAMPLE_COUNT and the new latency_measurement will have a weight of 1.
-    pub fn update_latency(&mut self, latency_measurement: Duration) {
-        self.last_seen = Some(Utc::now().naive_utc());
-
-        self.avg_latency =
-            ((self.avg_latency * self.latency_sample_count) + latency_measurement) / (self.latency_sample_count + 1);
-        if self.latency_sample_count < MAX_LATENCY_SAMPLE_COUNT {
-            self.latency_sample_count += 1;
-        }
-
-        self.calculate_quality_score();
-    }
-
-    pub fn update_initial_dial_time(&mut self, initial_dial_time: Duration) {
-        self.last_seen = Some(Utc::now().naive_utc());
-
-        self.avg_initial_dial_time = ((self.avg_initial_dial_time * self.initial_dial_time_sample_count) +
-            initial_dial_time) /
-            (self.initial_dial_time_sample_count + 1);
-        if self.initial_dial_time_sample_count < MAX_INITIAL_DIAL_TIME_SAMPLE_COUNT {
-            self.initial_dial_time_sample_count += 1;
-        }
-        self.calculate_quality_score();
-    }
-
-    /// Mark that a successful interaction occurred with this address
-    pub fn mark_last_seen_now(&mut self) {
-        self.last_seen = Some(Utc::now().naive_utc());
-        self.last_failed_reason = None;
-        self.reset_connection_attempts();
-        self.calculate_quality_score();
-    }
-
-    /// Reset the connection attempts on this net address for a later session of retries
-    pub fn reset_connection_attempts(&mut self) {
-        self.connection_attempts = 0;
-    }
-
-    /// Mark that a connection could not be established with this net address
-    pub fn mark_failed_connection_attempt(&mut self, error_string: String) {
-        self.connection_attempts += 1;
-        self.last_failed_reason = Some(error_string);
-        self.calculate_quality_score();
-    }
-
-    /// Get as a Multiaddr
-    pub fn as_net_address(&self) -> Multiaddr {
-        self.clone().address
-    }
-
-    fn calculate_quality_score(&mut self) {
-        // Try these first
-        if self.last_seen.is_none() && self.last_attempted.is_none() {
-            self.quality_score = 1000;
-            return;
-        }
-
-        let mut score_self = 0;
-
-        // explicitly truncate the latency to avoid casting problems
-        let avg_latency_millis = i32::try_from(self.avg_latency.as_millis()).unwrap_or(i32::MAX);
-        score_self += cmp::max(0, 100 - (avg_latency_millis / 100));
-
-        let last_seen_seconds: i32 = self
-            .last_seen
-            .map(|x| Utc::now().naive_utc() - x)
-            .map(|x| x.num_seconds())
-            .unwrap_or(0)
-            .try_into()
-            .unwrap_or(i32::MAX);
-        score_self += cmp::max(0, 100 - last_seen_seconds);
-
-        if self.last_failed_reason.is_some() {
-            score_self -= 100;
-        }
-
-        self.quality_score = score_self;
-    }
-
-    pub fn source(&self) -> &PeerAddressSource {
-        &self.source
-    }
-}
-
-// Reliability ordering of net addresses: prioritize net addresses according to previous successful connections,
-// connection attempts, latency and last seen A lower ordering has a higher priority and a higher ordering has a lower
-// priority, this ordering switch allows searching for, and updating of net addresses to be performed more efficiently
-impl Ord for MultiaddrWithStats {
-    fn cmp(&self, other: &MultiaddrWithStats) -> Ordering {
-        self.quality_score.cmp(&other.quality_score).reverse()
-    }
-}
-
-impl PartialOrd for MultiaddrWithStats {
-    fn partial_cmp(&self, other: &MultiaddrWithStats) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl PartialEq for MultiaddrWithStats {
-    fn eq(&self, other: &MultiaddrWithStats) -> bool {
-        self.address == other.address
-    }
-}
-
-impl Hash for MultiaddrWithStats {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.address.hash(state)
-    }
-}
-
-impl fmt::Display for MultiaddrWithStats {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.address)
-    }
-}
-
 #[cfg(test)]
 mod test {
     use std::time::Duration;
@@ -358,5 +419,22 @@ mod test {
         assert_eq!(net_address_with_stats.connection_attempts, 2);
         net_address_with_stats.reset_connection_attempts();
         assert_eq!(net_address_with_stats.connection_attempts, 0);
+    }
+
+    #[test]
+    fn test_calculate_quality_score() {
+        let address = "/ip4/123.0.0.123/tcp/8000".parse().unwrap();
+        let mut address = MultiaddrWithStats::new(address, PeerAddressSource::Config);
+        assert_eq!(address.quality_score, 1000);
+        address.mark_last_seen_now();
+        assert!(address.quality_score > 100);
+        address.mark_failed_connection_attempt("Testing".to_string());
+        assert!(address.quality_score <= 100);
+
+        let another_addr = "/ip4/1.0.0.1/tcp/8000".parse().unwrap();
+        let another_addr = MultiaddrWithStats::new(another_addr, PeerAddressSource::Config);
+        assert_eq!(another_addr.quality_score, 1000);
+
+        assert_eq!(another_addr.cmp(&address), Ordering::Greater);
     }
 }

--- a/comms/core/src/peer_manager/error.rs
+++ b/comms/core/src/peer_manager/error.rs
@@ -22,8 +22,11 @@
 
 use std::sync::PoisonError;
 
+use multiaddr::Multiaddr;
 use tari_storage::KeyValStoreError;
 use thiserror::Error;
+
+use crate::peer_manager::NodeId;
 
 /// Error type for [PeerManager](super::PeerManager).
 #[derive(Debug, Error, Clone)]
@@ -46,6 +49,10 @@ pub enum PeerManagerError {
     MultiaddrError(String),
     #[error("Unable to parse any of the network addresses offered by the connecting peer")]
     PeerIdentityNoValidAddresses,
+    #[error("Invalid peer feature bits '{bits:#x}'")]
+    InvalidPeerFeatures { bits: u32 },
+    #[error("Address {address} not found for peer {node_id}")]
+    AddressNotFoundError { address: Multiaddr, node_id: NodeId },
 }
 
 impl PeerManagerError {

--- a/comms/core/src/peer_manager/mod.rs
+++ b/comms/core/src/peer_manager/mod.rs
@@ -70,9 +70,6 @@
 //! let returned_peer = peer_manager.find_by_node_id(&node_id).unwrap();
 //! ```
 
-/// The maximum size of the peer's user agent string. If the peer sends a longer string it is truncated.
-const MAX_USER_AGENT_LEN: usize = 100;
-
 mod error;
 pub use error::PeerManagerError;
 

--- a/comms/core/src/peer_manager/node_identity.rs
+++ b/comms/core/src/peer_manager/node_identity.rs
@@ -235,7 +235,6 @@ impl NodeIdentity {
                 &self.public_addresses(),
                 Utc::now(),
             ),
-            unverified_data: None,
         };
         let peer = Peer::new(
             self.public_key().clone(),

--- a/comms/core/src/peer_manager/peer.rs
+++ b/comms/core/src/peer_manager/peer.rs
@@ -159,20 +159,11 @@ impl Peer {
     }
 
     pub fn last_connect_attempt(&self) -> Option<NaiveDateTime> {
-        let mut last_connected_attempt = None;
-        for address in self.addresses.addresses() {
-            if let Some(address_time) = address.last_attempted {
-                match last_connected_attempt {
-                    Some(last_time) => {
-                        if last_time < address_time {
-                            last_connected_attempt = address.last_attempted
-                        }
-                    },
-                    None => last_connected_attempt = address.last_attempted,
-                }
-            }
-        }
-        last_connected_attempt
+        self.addresses
+            .addresses()
+            .iter()
+            .max_by_key(|a| a.last_attempted())
+            .and_then(|a| a.last_attempted())
     }
 
     /// Returns true if the peer is marked as offline
@@ -210,11 +201,6 @@ impl Peer {
     pub fn last_seen_since(&self) -> Option<Duration> {
         self.last_seen()
             .and_then(|dt| Utc::now().naive_utc().signed_duration_since(dt).to_std().ok())
-    }
-
-    /// Returns true if this peer has the given feature, otherwise false
-    pub fn has_features(&self, features: PeerFeatures) -> bool {
-        self.features.contains(features)
     }
 
     /// Returns the ban status of the peer

--- a/comms/core/src/peer_manager/peer_features.rs
+++ b/comms/core/src/peer_manager/peer_features.rs
@@ -28,7 +28,7 @@ use serde::{Deserialize, Serialize};
 bitflags! {
     /// Peer feature flags. These advertised the capabilities of peer nodes.
     #[derive(Serialize, Deserialize)]
-    pub struct PeerFeatures: u64 {
+    pub struct PeerFeatures: u32 {
         /// No capabilities
         const NONE = 0b0000_0000;
         /// Node is able to propagate messages

--- a/comms/core/src/peer_manager/peer_storage.rs
+++ b/comms/core/src/peer_manager/peer_storage.rs
@@ -853,7 +853,7 @@ mod test {
         let mut not_active_peer = create_test_peer(PeerFeatures::COMMUNICATION_NODE, false);
         let address = not_active_peer.addresses.best().unwrap();
         let mut address = MultiaddrWithStats::new(address.address().clone(), PeerAddressSource::Config);
-        address.last_seen = Some(NaiveDateTime::from_timestamp_opt(a_week_ago, 0).unwrap());
+        address.mark_last_attempted(NaiveDateTime::from_timestamp_opt(a_week_ago, 0).unwrap());
         not_active_peer
             .addresses
             .merge(&MultiaddressesWithStats::from(vec![address]));

--- a/comms/core/src/peer_validator/helpers.rs
+++ b/comms/core/src/peer_validator/helpers.rs
@@ -1,0 +1,288 @@
+// Copyright 2020, The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::net::Ipv6Addr;
+
+use digest::Digest;
+
+use crate::{
+    multiaddr::{Multiaddr, Protocol},
+    peer_manager::{NodeId, PeerIdentityClaim},
+    peer_validator::{error::PeerValidatorError, PeerValidatorConfig},
+    types::CommsPublicKey,
+};
+
+/// Checks that the given peer addresses are well-formed and valid. If allow_test_addrs is false, all localhost and
+/// memory addresses will be rejected.
+pub fn validate_addresses(config: &PeerValidatorConfig, addresses: &[Multiaddr]) -> Result<(), PeerValidatorError> {
+    if addresses.is_empty() {
+        return Err(PeerValidatorError::PeerIdentityNoAddresses);
+    }
+
+    if addresses.len() > config.max_permitted_peer_addresses_per_claim {
+        return Err(PeerValidatorError::PeerIdentityTooManyAddresses {
+            length: addresses.len(),
+            max: config.max_permitted_peer_addresses_per_claim,
+        });
+    }
+    for addr in addresses {
+        validate_address(addr, config.allow_test_addresses)?;
+    }
+
+    Ok(())
+}
+
+pub fn find_most_recent_claim<'a, I: IntoIterator<Item = &'a PeerIdentityClaim>>(
+    claims: I,
+) -> Option<&'a PeerIdentityClaim> {
+    claims.into_iter().max_by_key(|c| c.signature.updated_at())
+}
+
+pub fn validate_peer_identity_claim(
+    config: &PeerValidatorConfig,
+    public_key: &CommsPublicKey,
+    claim: &PeerIdentityClaim,
+) -> Result<(), PeerValidatorError> {
+    validate_addresses(config, &claim.addresses)?;
+
+    if !claim.is_valid(public_key) {
+        return Err(PeerValidatorError::InvalidPeerSignature {
+            peer: NodeId::from_public_key(public_key),
+        });
+    }
+
+    Ok(())
+}
+fn validate_address(addr: &Multiaddr, allow_test_addrs: bool) -> Result<(), PeerValidatorError> {
+    let mut addr_iter = addr.iter();
+    let proto = addr_iter
+        .next()
+        .ok_or_else(|| PeerValidatorError::InvalidMultiaddr("Multiaddr was empty".to_string()))?;
+
+    /// Returns [true] if the address is a unicast link-local address (fe80::/10).
+    /// Taken from stdlib
+    #[inline]
+    const fn is_unicast_link_local(addr: &Ipv6Addr) -> bool {
+        (addr.segments()[0] & 0xffc0) == 0xfe80
+    }
+
+    match proto {
+        Protocol::Dns4(_) | Protocol::Dns6(_) | Protocol::Dnsaddr(_) => {
+            let tcp = addr_iter.next().ok_or_else(|| {
+                PeerValidatorError::InvalidMultiaddr("Address does not include a TCP port".to_string())
+            })?;
+
+            validate_tcp_port(tcp)?;
+            expect_end_of_address(addr_iter)
+        },
+
+        Protocol::Ip4(addr)
+            if !allow_test_addrs && (addr.is_loopback() || addr.is_link_local() || addr.is_unspecified()) =>
+        {
+            Err(PeerValidatorError::InvalidMultiaddr(
+                "Non-global IP addresses are invalid".to_string(),
+            ))
+        },
+        Protocol::Ip6(addr)
+            if !allow_test_addrs && (addr.is_loopback() || is_unicast_link_local(&addr) || addr.is_unspecified()) =>
+        {
+            Err(PeerValidatorError::InvalidMultiaddr(
+                "Non-global IP addresses are invalid".to_string(),
+            ))
+        },
+        Protocol::Ip4(_) | Protocol::Ip6(_) => {
+            let tcp = addr_iter.next().ok_or_else(|| {
+                PeerValidatorError::InvalidMultiaddr("Address does not include a TCP port".to_string())
+            })?;
+
+            validate_tcp_port(tcp)?;
+            expect_end_of_address(addr_iter)
+        },
+        Protocol::Memory(0) => Err(PeerValidatorError::InvalidMultiaddr(
+            "Cannot connect to a zero memory port".to_string(),
+        )),
+        Protocol::Memory(_) if allow_test_addrs => expect_end_of_address(addr_iter),
+        Protocol::Memory(_) => Err(PeerValidatorError::InvalidMultiaddr(
+            "Memory addresses are invalid".to_string(),
+        )),
+        // Zero-port onions should have already failed when parsing. Keep these checks here just in case.
+        Protocol::Onion(_, 0) => Err(PeerValidatorError::InvalidMultiaddr(
+            "A zero onion port is not valid in the onion spec".to_string(),
+        )),
+        Protocol::Onion3(addr) if addr.port() == 0 => Err(PeerValidatorError::InvalidMultiaddr(
+            "A zero onion port is not valid in the onion spec".to_string(),
+        )),
+        Protocol::Onion(_, _) => Err(PeerValidatorError::OnionV2NotSupported),
+        Protocol::Onion3(addr) => {
+            expect_end_of_address(addr_iter)?;
+            validate_onion3_address(&addr)
+        },
+        p => Err(PeerValidatorError::InvalidMultiaddr(format!(
+            "Unsupported address type '{}'",
+            p
+        ))),
+    }
+}
+
+fn expect_end_of_address(mut iter: multiaddr::Iter<'_>) -> Result<(), PeerValidatorError> {
+    match iter.next() {
+        Some(p) => Err(PeerValidatorError::InvalidMultiaddr(format!(
+            "Unexpected multiaddress component '{}'",
+            p
+        ))),
+        None => Ok(()),
+    }
+}
+
+fn validate_tcp_port(expected_tcp: Protocol) -> Result<(), PeerValidatorError> {
+    match expected_tcp {
+        Protocol::Tcp(0) => Err(PeerValidatorError::InvalidMultiaddr(
+            "Cannot connect to a zero TCP port".to_string(),
+        )),
+        Protocol::Tcp(_) => Ok(()),
+        p => Err(PeerValidatorError::InvalidMultiaddr(format!(
+            "Expected TCP address component but got '{}'",
+            p
+        ))),
+    }
+}
+
+/// Validates the onion3 version and checksum as per https://github.com/torproject/torspec/blob/main/rend-spec-v3.txt#LL2258C6-L2258C6
+fn validate_onion3_address(addr: &multiaddr::Onion3Addr<'_>) -> Result<(), PeerValidatorError> {
+    const ONION3_PUBKEY_SIZE: usize = 32;
+    const ONION3_CHECKSUM_SIZE: usize = 2;
+
+    let (pub_key, checksum_version) = addr.hash().split_at(ONION3_PUBKEY_SIZE);
+    let (checksum, version) = checksum_version.split_at(ONION3_CHECKSUM_SIZE);
+
+    if version != b"\x03" {
+        return Err(PeerValidatorError::InvalidMultiaddr(
+            "Invalid version in onion address".to_string(),
+        ));
+    }
+
+    let calculated_checksum = sha3::Sha3_256::new()
+        .chain_update(".onion checksum")
+        .chain_update(pub_key)
+        .chain_update(version)
+        .finalize();
+
+    if calculated_checksum[..2] != *checksum {
+        return Err(PeerValidatorError::InvalidMultiaddr(
+            "Invalid checksum in onion address".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use multiaddr::multiaddr;
+
+    use super::*;
+    use crate::peer_validator::error::PeerValidatorError;
+
+    #[test]
+    fn validate_address_strict() {
+        let valid = [
+            multiaddr!(Ip4([172, 0, 0, 1]), Tcp(1u16)),
+            multiaddr!(Ip6([172, 0, 0, 1, 1, 1, 1, 1]), Tcp(1u16)),
+            "/onion3/vww6ybal4bd7szmgncyruucpgfkqahzddi37ktceo3ah7ngmcopnpyyd:1234"
+                .parse()
+                .unwrap(),
+            multiaddr!(Dnsaddr("mike-magic-nodes.com"), Tcp(1u16)),
+        ];
+
+        let invalid = &[
+            "/onion/aaimaq4ygg2iegci:1234".parse().unwrap(),
+            multiaddr!(Ip4([127, 0, 0, 1]), Tcp(1u16)),
+            multiaddr!(Ip4([169, 254, 0, 1]), Tcp(1u16)),
+            multiaddr!(Ip4([172, 0, 0, 1])),
+            "/onion/aaimaq4ygg2iegci:1234/http".parse().unwrap(),
+            multiaddr!(Dnsaddr("mike-magic-nodes.com")),
+            multiaddr!(Memory(1234u64)),
+            multiaddr!(Memory(0u64)),
+        ];
+
+        for addr in valid {
+            validate_address(&addr, false).unwrap();
+        }
+        for addr in invalid {
+            validate_address(addr, false).unwrap_err();
+        }
+    }
+
+    #[test]
+    fn validate_address_allow_test_addrs() {
+        let valid = [
+            multiaddr!(Ip4([127, 0, 0, 1]), Tcp(1u16)),
+            multiaddr!(Ip4([169, 254, 0, 1]), Tcp(1u16)),
+            multiaddr!(Ip4([172, 0, 0, 1]), Tcp(1u16)),
+            multiaddr!(Ip6([172, 0, 0, 1, 1, 1, 1, 1]), Tcp(1u16)),
+            "/onion3/vww6ybal4bd7szmgncyruucpgfkqahzddi37ktceo3ah7ngmcopnpyyd:1234"
+                .parse()
+                .unwrap(),
+            multiaddr!(Dnsaddr("mike-magic-nodes.com"), Tcp(1u16)),
+            multiaddr!(Memory(1234u64)),
+        ];
+
+        let invalid = &[
+            "/onion/aaimaq4ygg2iegci:1234".parse().unwrap(),
+            multiaddr!(Ip4([172, 0, 0, 1])),
+            "/onion/aaimaq4ygg2iegci:1234/http".parse().unwrap(),
+            multiaddr!(Dnsaddr("mike-magic-nodes.com")),
+            multiaddr!(Memory(0u64)),
+        ];
+
+        for addr in valid {
+            validate_address(&addr, true).unwrap();
+        }
+        for addr in invalid {
+            validate_address(addr, true).unwrap_err();
+        }
+    }
+
+    #[test]
+    fn validate_onion3_checksum() {
+        let valid: Multiaddr = "/onion3/vww6ybal4bd7szmgncyruucpgfkqahzddi37ktceo3ah7ngmcopnpyyd:1234"
+            .parse()
+            .unwrap();
+
+        validate_address(&valid, false).unwrap();
+
+        // Change one byte
+        let invalid: Multiaddr = "/onion3/www6ybal4bd7szmgncyruucpgfkqahzddi37ktceo3ah7ngmcopnpyyd:1234"
+            .parse()
+            .unwrap();
+
+        validate_address(&invalid, false).unwrap_err();
+
+        // Randomly generated
+        let invalid: Multiaddr = "/onion3/pd6sf3mqkkkfrn4rk5odgcr2j5sn7m523a4tm7pzpuotk2b7rpuhaeym:1234"
+            .parse()
+            .unwrap();
+
+        let err = validate_address(&invalid, false).unwrap_err();
+        assert!(matches!(err, PeerValidatorError::InvalidMultiaddr(_)));
+    }
+}

--- a/comms/core/src/peer_validator/mod.rs
+++ b/comms/core/src/peer_validator/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2019, The Tari Project
+// Copyright 2023, The Tari Project
 //
 // Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
 // following conditions are met:
@@ -19,42 +19,13 @@
 // SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//! # ConnectionManager
-//!
-//! This component is responsible for orchestrating PeerConnections, specifically:
-//! - dialing peers,
-//! - listening for peer connections on the configured transport,
-//! - performing connection upgrades (noise protocol, identity and multiplexing),
-//! - and, notifying the connectivity manager of changes in connection state (new connections, disconnects, etc)
-
-mod dial_state;
-mod dialer;
-mod listener;
-mod metrics;
-
-mod common;
-
-mod direction;
-pub use direction::ConnectionDirection;
-
-mod requester;
-pub use requester::{ConnectionManagerRequest, ConnectionManagerRequester};
-
-mod manager;
-pub(crate) use manager::ConnectionManager;
-pub use manager::{ConnectionManagerConfig, ConnectionManagerEvent, ListenerInfo};
 
 mod error;
-pub use error::{ConnectionManagerError, PeerConnectionError};
+pub use error::*;
 
-mod peer_connection;
-pub use peer_connection::{ConnectionId, NegotiatedSubstream, PeerConnection, PeerConnectionRequest};
+mod config;
+pub use config::*;
 
-mod liveness;
-pub(crate) use liveness::LivenessCheck;
-pub use liveness::LivenessStatus;
+mod helpers;
 
-mod wire_mode;
-
-#[cfg(test)]
-mod tests;
+pub use helpers::*;

--- a/comms/core/src/proto/identity.proto
+++ b/comms/core/src/proto/identity.proto
@@ -9,7 +9,7 @@ package tari.comms.identity;
 
 message PeerIdentityMsg {
     repeated bytes addresses = 1;
-    uint64 features = 2;
+    uint32 features = 2;
     // Note: not part of the signature
     repeated bytes supported_protocols = 3;
     // Note: not part of the signature

--- a/comms/core/src/protocol/identity.rs
+++ b/comms/core/src/protocol/identity.rs
@@ -31,10 +31,11 @@ use tokio::{
 };
 
 use crate::{
+    bans::{BAN_DURATION_LONG, BAN_DURATION_SHORT},
     message::MessageExt,
     peer_manager::NodeIdentity,
     proto::identity::PeerIdentityMsg,
-    protocol::{NodeNetworkInfo, ProtocolError, ProtocolId},
+    protocol::{NodeNetworkInfo, ProtocolId},
 };
 
 const LOG_TARGET: &str = "comms::protocol::identity";
@@ -77,26 +78,35 @@ where
     socket.flush().await?;
 
     // Receive the connecting node's identity
-    let (version, msg_bytes) = time::timeout(Duration::from_secs(10), read_protocol_frame(socket)).await??;
+    let (_, msg_bytes) = time::timeout(
+        Duration::from_secs(10),
+        read_protocol_frame(socket, network_info.major_version),
+    )
+    .await??;
+
+    debug!(
+        target: LOG_TARGET,
+        "Identity message received {} bytes",
+        msg_bytes.len()
+    );
     let identity_msg = PeerIdentityMsg::decode(Bytes::from(msg_bytes))?;
-
-    if version > network_info.major_version {
-        warn!(
-            target: LOG_TARGET,
-            "Peer sent mismatching major protocol version '{}'. This node has version '{}'",
-            version,
-            network_info.major_version
-        );
-        return Err(IdentityProtocolError::ProtocolVersionMismatch);
-    }
-
     Ok(identity_msg)
 }
 
-async fn read_protocol_frame<S: AsyncRead + Unpin>(socket: &mut S) -> Result<(u8, Vec<u8>), IdentityProtocolError> {
+async fn read_protocol_frame<S: AsyncRead + Unpin>(
+    socket: &mut S,
+    max_supported_version: u8,
+) -> Result<(u8, Vec<u8>), IdentityProtocolError> {
     let mut buf = [0u8; 3];
     socket.read_exact(&mut buf).await?;
     let version = buf[0];
+    if version > max_supported_version {
+        return Err(IdentityProtocolError::UnsupportedProtocolVersion {
+            max_supported_version,
+            provided_version: version,
+        });
+    }
+
     let buf = [buf[1], buf[2]];
     let len = u16::from_le_bytes(buf);
     if len > MAX_IDENTITY_PROTOCOL_MSG_SIZE {
@@ -105,6 +115,7 @@ async fn read_protocol_frame<S: AsyncRead + Unpin>(socket: &mut S) -> Result<(u8
             got: len,
         });
     }
+
     let len = len as usize;
     let mut msg = vec![0u8; len];
     socket.read_exact(&mut msg).await?;
@@ -116,17 +127,17 @@ async fn write_protocol_frame<S: AsyncWrite + Unpin>(
     version: u8,
     msg_bytes: &[u8],
 ) -> Result<(), IdentityProtocolError> {
-    debug_assert!(
-        msg_bytes.len() <= MAX_IDENTITY_PROTOCOL_MSG_SIZE as usize,
-        "Sending identity protocol message of size {}, greater than {} bytes. This is a protocol violation",
-        msg_bytes.len(),
-        MAX_IDENTITY_PROTOCOL_MSG_SIZE
-    );
+    if msg_bytes.len() > MAX_IDENTITY_PROTOCOL_MSG_SIZE as usize {
+        return Err(IdentityProtocolError::InvariantError(format!(
+            "Sending identity protocol message of size {}, greater than {} bytes. This is a protocol violation",
+            msg_bytes.len(),
+            MAX_IDENTITY_PROTOCOL_MSG_SIZE
+        )));
+    }
 
     let len = u16::try_from(msg_bytes.len()).map_err(|_| {
-        IdentityProtocolError::ProtocolError(format!(
-            "Identity protocol attempted to send a message larger than u16::MAX bytes. len = {}",
-            msg_bytes.len()
+        IdentityProtocolError::InvariantError(format!(
+            "This node attempted to send a message of size greater than u16::MAX"
         ))
     })?;
     let version_bytes = [version];
@@ -148,31 +159,46 @@ async fn write_protocol_frame<S: AsyncWrite + Unpin>(
 pub enum IdentityProtocolError {
     #[error("IoError: {0}")]
     IoError(String),
-    #[error("ProtocolError: {0}")]
-    ProtocolError(String),
+    #[error("Possible bug: InvariantError {0}")]
+    InvariantError(String),
     #[error("ProtobufDecodeError: {0}")]
     ProtobufDecodeError(String),
-    #[error("Failed to encode protobuf message")]
-    ProtobufEncodingError,
     #[error("Peer unexpectedly closed the connection")]
     PeerUnexpectedCloseConnection,
     #[error("Timeout waiting for peer to send identity information")]
     Timeout,
-    #[error("Protocol version mismatch")]
-    ProtocolVersionMismatch,
+    #[error(
+        "Unsupported protocol version. Max supported version: {max_supported_version}, provided version: \
+         {provided_version}"
+    )]
+    UnsupportedProtocolVersion {
+        max_supported_version: u8,
+        provided_version: u8,
+    },
     #[error("Max identity protocol message size exceeded. Expected <= {expected} got {got}")]
     MaxMsgSizeExceeded { expected: u16, got: u16 },
+}
+
+impl IdentityProtocolError {
+    pub fn as_ban_duration(&self) -> Option<Duration> {
+        match self {
+            // Don't ban
+            IdentityProtocolError::InvariantError(_) | IdentityProtocolError::IoError(_) => None,
+            // Long bans
+            IdentityProtocolError::ProtobufDecodeError(_) | IdentityProtocolError::MaxMsgSizeExceeded { .. } => {
+                Some(BAN_DURATION_LONG)
+            },
+            // Short bans
+            IdentityProtocolError::PeerUnexpectedCloseConnection |
+            IdentityProtocolError::UnsupportedProtocolVersion { .. } |
+            IdentityProtocolError::Timeout => Some(BAN_DURATION_SHORT),
+        }
+    }
 }
 
 impl From<time::error::Elapsed> for IdentityProtocolError {
     fn from(_: time::error::Elapsed) -> Self {
         IdentityProtocolError::Timeout
-    }
-}
-
-impl From<ProtocolError> for IdentityProtocolError {
-    fn from(err: ProtocolError) -> Self {
-        IdentityProtocolError::ProtocolError(err.to_string())
     }
 }
 
@@ -297,7 +323,7 @@ mod test {
         .await;
 
         let err = result1.unwrap_err();
-        assert!(matches!(err, IdentityProtocolError::ProtocolVersionMismatch));
+        assert!(matches!(err, IdentityProtocolError::UnsupportedProtocolVersion { .. }));
 
         // Passes because older versions are supported
         result2.unwrap();

--- a/comms/core/src/test_utils/mocks/peer_connection.rs
+++ b/comms/core/src/test_utils/mocks/peer_connection.rs
@@ -56,7 +56,7 @@ pub fn create_dummy_peer_connection(node_id: NodeId) -> (PeerConnection, mpsc::R
     let (tx, rx) = mpsc::channel(1);
     let addr = Multiaddr::from_str("/ip4/23.23.23.23/tcp/80").unwrap();
     (
-        PeerConnection::unverified(
+        PeerConnection::new(
             1,
             tx,
             node_id,
@@ -92,7 +92,7 @@ pub async fn create_peer_connection_mock_pair(
     rt_handle.spawn(mock.run());
 
     (
-        PeerConnection::unverified(
+        PeerConnection::new(
             // ID must be unique since it is used for connection equivalency, so we re-implement this in the mock
             ID_COUNTER.fetch_add(1, Ordering::SeqCst),
             tx1,
@@ -103,7 +103,7 @@ pub async fn create_peer_connection_mock_pair(
             mock_state_in.substream_counter(),
         ),
         mock_state_in,
-        PeerConnection::unverified(
+        PeerConnection::new(
             ID_COUNTER.fetch_add(1, Ordering::SeqCst),
             tx2,
             peer1.node_id,

--- a/comms/core/src/test_utils/test_node.rs
+++ b/comms/core/src/test_utils/test_node.rs
@@ -35,6 +35,7 @@ use crate::{
     multiplexing::Substream,
     noise::NoiseConfig,
     peer_manager::{NodeIdentity, PeerFeatures, PeerManager},
+    peer_validator::PeerValidatorConfig,
     protocol::Protocols,
     transports::Transport,
 };
@@ -56,7 +57,10 @@ impl Default for TestNodeConfig {
 
         Self {
             connection_manager_config: ConnectionManagerConfig {
-                allow_test_addresses: true,
+                peer_validation_config: PeerValidatorConfig {
+                    allow_test_addresses: true,
+                    ..Default::default()
+                },
                 listener_address: "/memory/0".parse().unwrap(),
                 ..Default::default()
             },

--- a/comms/dht/src/config.rs
+++ b/comms/dht/src/config.rs
@@ -27,6 +27,7 @@ use tari_common::configuration::serializers;
 use tari_comms::peer_validator::PeerValidatorConfig;
 
 use crate::{
+    actor::OffenceSeverity,
     network_discovery::NetworkDiscoveryConfig,
     storage::DbConnectionUrl,
     store_forward::SafConfig,
@@ -105,8 +106,11 @@ pub struct DhtConfig {
     /// Default: 24 hours
     #[serde(with = "serializers::seconds")]
     pub offline_peer_cooldown: Duration,
-
+    /// The maximum number of peer claims accepted by this node. Only peer sync sends more than one claim.
+    /// Default: 5
     pub max_permitted_peer_claims: usize,
+    /// Configuration for peer validation
+    /// See [PeerValidatorConfig]
     pub peer_validator_config: PeerValidatorConfig,
 }
 
@@ -146,6 +150,14 @@ impl DhtConfig {
     /// Sets relative paths to use a common base path
     pub fn set_base_path<P: AsRef<Path>>(&mut self, base_path: P) {
         self.database_url.set_base_path(base_path);
+    }
+
+    /// Returns a ban duration from the given severity
+    pub fn ban_duration_from_severity(&self, severity: OffenceSeverity) -> Duration {
+        match severity {
+            OffenceSeverity::Low | OffenceSeverity::Medium => self.ban_duration_short,
+            OffenceSeverity::High => self.ban_duration,
+        }
     }
 }
 

--- a/comms/dht/src/config.rs
+++ b/comms/dht/src/config.rs
@@ -24,6 +24,7 @@ use std::{path::Path, time::Duration};
 
 use serde::{Deserialize, Serialize};
 use tari_common::configuration::serializers;
+use tari_comms::peer_validator::PeerValidatorConfig;
 
 use crate::{
     network_discovery::NetworkDiscoveryConfig,
@@ -89,9 +90,7 @@ pub struct DhtConfig {
     /// Default: 30 mins
     #[serde(with = "serializers::seconds")]
     pub ban_duration_short: Duration,
-    /// This allows the use of test addresses in the network.
-    /// Default: false
-    pub allow_test_addresses: bool,
+
     /// The maximum number of messages over `flood_ban_timespan` to allow before banning the peer (for
     /// `ban_duration_short`) Default: 100_000 messages
     pub flood_ban_max_msg_count: usize,
@@ -106,6 +105,9 @@ pub struct DhtConfig {
     /// Default: 24 hours
     #[serde(with = "serializers::seconds")]
     pub offline_peer_cooldown: Duration,
+
+    pub max_permitted_peer_claims: usize,
+    pub peer_validator_config: PeerValidatorConfig,
 }
 
 impl DhtConfig {
@@ -133,7 +135,10 @@ impl DhtConfig {
                 enabled: false,
                 ..Default::default()
             },
-            allow_test_addresses: true,
+            peer_validator_config: PeerValidatorConfig {
+                allow_test_addresses: true,
+                ..Default::default()
+            },
             ..Default::default()
         }
     }
@@ -166,10 +171,11 @@ impl Default for DhtConfig {
             network_discovery: Default::default(),
             ban_duration: Duration::from_secs(6 * 60 * 60),
             ban_duration_short: Duration::from_secs(60 * 60),
-            allow_test_addresses: false,
             flood_ban_max_msg_count: 100_000,
             flood_ban_timespan: Duration::from_secs(100),
+            max_permitted_peer_claims: 5,
             offline_peer_cooldown: Duration::from_secs(24 * 60 * 60),
+            peer_validator_config: Default::default(),
         }
     }
 }

--- a/comms/dht/src/dht.rs
+++ b/comms/dht/src/dht.rs
@@ -95,7 +95,7 @@ pub struct Dht {
     dht_sender: mpsc::Sender<DhtRequest>,
     /// Sender for SAF requests
     saf_sender: mpsc::Sender<StoreAndForwardRequest>,
-    /// Sender for SAF repsonse signals
+    /// Sender for SAF response signals
     saf_response_signal_sender: mpsc::Sender<()>,
     /// Sender for DHT discovery requests
     discovery_sender: mpsc::Sender<DhtDiscoveryRequest>,
@@ -322,6 +322,7 @@ impl Dht {
                 self.store_and_forward_requester(),
             ))
             .layer(ForwardLayer::new(
+                self.dht_requester(),
                 self.outbound_requester(),
                 self.node_identity.features().contains(PeerFeatures::DHT_STORE_FORWARD),
             ))
@@ -337,7 +338,7 @@ impl Dht {
                 self.config.clone(),
                 self.node_identity.clone(),
                 self.peer_manager.clone(),
-                self.connectivity.clone(),
+                self.dht_requester(),
                 self.discovery_service_requester(),
                 self.outbound_requester(),
             ))

--- a/comms/dht/src/dht.rs
+++ b/comms/dht/src/dht.rs
@@ -197,6 +197,7 @@ impl Dht {
             self.config.clone(),
             Arc::clone(&self.node_identity),
             Arc::clone(&self.peer_manager),
+            self.connectivity.clone(),
             self.outbound_requester(),
             request_receiver,
             shutdown_signal,
@@ -336,6 +337,7 @@ impl Dht {
                 self.config.clone(),
                 self.node_identity.clone(),
                 self.peer_manager.clone(),
+                self.connectivity.clone(),
                 self.discovery_service_requester(),
                 self.outbound_requester(),
             ))

--- a/comms/dht/src/discovery/error.rs
+++ b/comms/dht/src/discovery/error.rs
@@ -24,7 +24,10 @@ use tari_comms::peer_manager::PeerManagerError;
 use thiserror::Error;
 use tokio::sync::mpsc::error::SendError;
 
-use crate::outbound::{message::SendFailure, DhtOutboundError};
+use crate::{
+    outbound::{message::SendFailure, DhtOutboundError},
+    peer_validator::DhtPeerValidatorError,
+};
 
 #[derive(Debug, Error)]
 pub enum DhtDiscoveryError {
@@ -48,6 +51,10 @@ pub enum DhtDiscoveryError {
     NoSignatureProvided,
     #[error("Invalid signature: {0}")]
     InvalidSignature(String),
+    #[error("Invalid discovery response: {details}")]
+    InvalidDiscoveryResponse { details: anyhow::Error },
+    #[error("DHT peer validator error: {0}")]
+    PeerValidatorError(#[from] DhtPeerValidatorError),
 }
 
 impl DhtDiscoveryError {

--- a/comms/dht/src/envelope.rs
+++ b/comms/dht/src/envelope.rs
@@ -117,11 +117,19 @@ impl DhtMessageType {
     }
 
     pub fn is_dht_message(self) -> bool {
-        self.is_dht_discovery() || matches!(self, DhtMessageType::DiscoveryResponse) || self.is_dht_join()
+        self.is_dht_discovery() || self.is_dht_discovery_response() || self.is_dht_join()
+    }
+
+    pub fn is_forwardable(self) -> bool {
+        self.is_domain_message() || self.is_dht_discovery() || self.is_dht_join()
     }
 
     pub fn is_dht_discovery(self) -> bool {
         matches!(self, DhtMessageType::Discovery)
+    }
+
+    pub fn is_dht_discovery_response(self) -> bool {
+        matches!(self, DhtMessageType::DiscoveryResponse)
     }
 
     pub fn is_dht_join(self) -> bool {

--- a/comms/dht/src/inbound/dht_handler/layer.rs
+++ b/comms/dht/src/inbound/dht_handler/layer.rs
@@ -22,7 +22,10 @@
 
 use std::sync::Arc;
 
-use tari_comms::peer_manager::{NodeIdentity, PeerManager};
+use tari_comms::{
+    connectivity::ConnectivityRequester,
+    peer_manager::{NodeIdentity, PeerManager},
+};
 use tower::layer::Layer;
 
 use super::middleware::DhtHandlerMiddleware;
@@ -32,6 +35,7 @@ pub struct DhtHandlerLayer {
     config: Arc<DhtConfig>,
     peer_manager: Arc<PeerManager>,
     node_identity: Arc<NodeIdentity>,
+    connectivity: ConnectivityRequester,
     outbound_service: OutboundMessageRequester,
     discovery_requester: DhtDiscoveryRequester,
 }
@@ -41,6 +45,7 @@ impl DhtHandlerLayer {
         config: Arc<DhtConfig>,
         node_identity: Arc<NodeIdentity>,
         peer_manager: Arc<PeerManager>,
+        connectivity: ConnectivityRequester,
         discovery_requester: DhtDiscoveryRequester,
         outbound_service: OutboundMessageRequester,
     ) -> Self {
@@ -48,6 +53,7 @@ impl DhtHandlerLayer {
             config,
             peer_manager,
             node_identity,
+            connectivity,
             outbound_service,
             discovery_requester,
         }
@@ -63,6 +69,7 @@ impl<S> Layer<S> for DhtHandlerLayer {
             Arc::clone(&self.node_identity),
             Arc::clone(&self.peer_manager),
             self.outbound_service.clone(),
+            self.connectivity.clone(),
             self.discovery_requester.clone(),
             self.config.clone(),
         )

--- a/comms/dht/src/inbound/dht_handler/layer.rs
+++ b/comms/dht/src/inbound/dht_handler/layer.rs
@@ -22,20 +22,17 @@
 
 use std::sync::Arc;
 
-use tari_comms::{
-    connectivity::ConnectivityRequester,
-    peer_manager::{NodeIdentity, PeerManager},
-};
+use tari_comms::peer_manager::{NodeIdentity, PeerManager};
 use tower::layer::Layer;
 
 use super::middleware::DhtHandlerMiddleware;
-use crate::{discovery::DhtDiscoveryRequester, outbound::OutboundMessageRequester, DhtConfig};
+use crate::{discovery::DhtDiscoveryRequester, outbound::OutboundMessageRequester, DhtConfig, DhtRequester};
 
 pub struct DhtHandlerLayer {
     config: Arc<DhtConfig>,
     peer_manager: Arc<PeerManager>,
     node_identity: Arc<NodeIdentity>,
-    connectivity: ConnectivityRequester,
+    dht: DhtRequester,
     outbound_service: OutboundMessageRequester,
     discovery_requester: DhtDiscoveryRequester,
 }
@@ -45,7 +42,7 @@ impl DhtHandlerLayer {
         config: Arc<DhtConfig>,
         node_identity: Arc<NodeIdentity>,
         peer_manager: Arc<PeerManager>,
-        connectivity: ConnectivityRequester,
+        dht: DhtRequester,
         discovery_requester: DhtDiscoveryRequester,
         outbound_service: OutboundMessageRequester,
     ) -> Self {
@@ -53,7 +50,7 @@ impl DhtHandlerLayer {
             config,
             peer_manager,
             node_identity,
-            connectivity,
+            dht,
             outbound_service,
             discovery_requester,
         }
@@ -69,7 +66,7 @@ impl<S> Layer<S> for DhtHandlerLayer {
             Arc::clone(&self.node_identity),
             Arc::clone(&self.peer_manager),
             self.outbound_service.clone(),
-            self.connectivity.clone(),
+            self.dht.clone(),
             self.discovery_requester.clone(),
             self.config.clone(),
         )

--- a/comms/dht/src/inbound/dht_handler/middleware.rs
+++ b/comms/dht/src/inbound/dht_handler/middleware.rs
@@ -24,6 +24,7 @@ use std::{sync::Arc, task::Poll};
 
 use futures::{future::BoxFuture, task::Context};
 use tari_comms::{
+    connectivity::ConnectivityRequester,
     peer_manager::{NodeIdentity, PeerManager},
     pipeline::PipelineError,
 };
@@ -42,6 +43,7 @@ pub struct DhtHandlerMiddleware<S> {
     next_service: S,
     peer_manager: Arc<PeerManager>,
     node_identity: Arc<NodeIdentity>,
+    connectivity: ConnectivityRequester,
     outbound_service: OutboundMessageRequester,
     discovery_requester: DhtDiscoveryRequester,
     config: Arc<DhtConfig>,
@@ -53,6 +55,7 @@ impl<S> DhtHandlerMiddleware<S> {
         node_identity: Arc<NodeIdentity>,
         peer_manager: Arc<PeerManager>,
         outbound_service: OutboundMessageRequester,
+        connectivity: ConnectivityRequester,
         discovery_requester: DhtDiscoveryRequester,
         config: Arc<DhtConfig>,
     ) -> Self {
@@ -60,6 +63,7 @@ impl<S> DhtHandlerMiddleware<S> {
             next_service,
             peer_manager,
             node_identity,
+            connectivity,
             outbound_service,
             discovery_requester,
             config,
@@ -87,6 +91,7 @@ where
                 Arc::clone(&self.peer_manager),
                 self.outbound_service.clone(),
                 Arc::clone(&self.node_identity),
+                self.connectivity.clone(),
                 self.discovery_requester.clone(),
                 message,
                 self.config.clone(),

--- a/comms/dht/src/inbound/dht_handler/middleware.rs
+++ b/comms/dht/src/inbound/dht_handler/middleware.rs
@@ -24,7 +24,6 @@ use std::{sync::Arc, task::Poll};
 
 use futures::{future::BoxFuture, task::Context};
 use tari_comms::{
-    connectivity::ConnectivityRequester,
     peer_manager::{NodeIdentity, PeerManager},
     pipeline::PipelineError,
 };
@@ -36,6 +35,7 @@ use crate::{
     inbound::DecryptedDhtMessage,
     outbound::OutboundMessageRequester,
     DhtConfig,
+    DhtRequester,
 };
 
 #[derive(Clone)]
@@ -43,7 +43,7 @@ pub struct DhtHandlerMiddleware<S> {
     next_service: S,
     peer_manager: Arc<PeerManager>,
     node_identity: Arc<NodeIdentity>,
-    connectivity: ConnectivityRequester,
+    dht: DhtRequester,
     outbound_service: OutboundMessageRequester,
     discovery_requester: DhtDiscoveryRequester,
     config: Arc<DhtConfig>,
@@ -55,7 +55,7 @@ impl<S> DhtHandlerMiddleware<S> {
         node_identity: Arc<NodeIdentity>,
         peer_manager: Arc<PeerManager>,
         outbound_service: OutboundMessageRequester,
-        connectivity: ConnectivityRequester,
+        dht: DhtRequester,
         discovery_requester: DhtDiscoveryRequester,
         config: Arc<DhtConfig>,
     ) -> Self {
@@ -63,7 +63,7 @@ impl<S> DhtHandlerMiddleware<S> {
             next_service,
             peer_manager,
             node_identity,
-            connectivity,
+            dht,
             outbound_service,
             discovery_requester,
             config,
@@ -91,7 +91,7 @@ where
                 Arc::clone(&self.peer_manager),
                 self.outbound_service.clone(),
                 Arc::clone(&self.node_identity),
-                self.connectivity.clone(),
+                self.dht.clone(),
                 self.discovery_requester.clone(),
                 message,
                 self.config.clone(),

--- a/comms/dht/src/inbound/error.rs
+++ b/comms/dht/src/inbound/error.rs
@@ -20,19 +20,10 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use tari_comms::{
-    connectivity::ConnectivityError,
-    message::MessageError,
-    peer_manager::{NodeId, PeerManagerError},
-};
+use tari_comms::{connectivity::ConnectivityError, message::MessageError, peer_manager::PeerManagerError};
 use thiserror::Error;
 
-use crate::{
-    discovery::DhtDiscoveryError,
-    error::DhtEncryptError,
-    outbound::DhtOutboundError,
-    peer_validator::DhtPeerValidatorError,
-};
+use crate::{discovery::DhtDiscoveryError, outbound::DhtOutboundError, peer_validator::DhtPeerValidatorError};
 
 #[derive(Debug, Error)]
 pub enum DhtInboundError {
@@ -42,20 +33,12 @@ pub enum DhtInboundError {
     PeerManagerError(#[from] PeerManagerError),
     #[error("DhtOutboundError: {0}")]
     DhtOutboundError(#[from] DhtOutboundError),
-    #[error("DhtEncryptError: {0}")]
-    DhtEncryptError(#[from] DhtEncryptError),
     #[error("Message body invalid")]
     InvalidMessageBody,
-    #[error("One or more peer addresses were invalid for '{peer}'")]
-    InvalidPeerAddresses { peer: NodeId },
     #[error("DhtDiscoveryError: {0}")]
     DhtDiscoveryError(#[from] DhtDiscoveryError),
     #[error("OriginRequired: {0}")]
     OriginRequired(String),
-    #[error("Invalid peer identity signature: {0}")]
-    InvalidPeerIdentitySignature(String),
-    #[error("No peer identity signature")]
-    NoPeerIdentitySignature,
     #[error("Peer validation failed: {0}")]
     PeerValidatorError(#[from] DhtPeerValidatorError),
     #[error("Invalid discovery message {0}")]

--- a/comms/dht/src/logging_middleware.rs
+++ b/comms/dht/src/logging_middleware.rs
@@ -20,12 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{
-    borrow::Cow,
-    fmt::{Debug, Display},
-    marker::PhantomData,
-    task::Poll,
-};
+use std::{borrow::Cow, fmt::Display, marker::PhantomData, task::Poll};
 
 use futures::task::Context;
 use log::*;
@@ -80,7 +75,7 @@ impl<'a, S> MessageLoggingService<'a, S> {
 impl<S, R> Service<R> for MessageLoggingService<'_, S>
 where
     S: Service<R>,
-    R: Display + Debug,
+    R: Display,
 {
     type Error = S::Error;
     type Future = S::Future;
@@ -91,7 +86,7 @@ where
     }
 
     fn call(&mut self, msg: R) -> Self::Future {
-        debug!(target: LOG_TARGET, "{}{:?}", self.prefix_msg, msg);
+        debug!(target: LOG_TARGET, "{}{:#}", self.prefix_msg, msg);
         self.inner.call(msg)
     }
 }

--- a/comms/dht/src/network_discovery/error.rs
+++ b/comms/dht/src/network_discovery/error.rs
@@ -22,7 +22,7 @@
 
 use tari_comms::{connectivity::ConnectivityError, peer_manager::PeerManagerError, protocol::rpc::RpcError};
 
-use crate::peer_validator::PeerValidatorError;
+use crate::peer_validator::DhtPeerValidatorError;
 
 #[derive(thiserror::Error, Debug)]
 pub enum NetworkDiscoveryError {
@@ -35,5 +35,5 @@ pub enum NetworkDiscoveryError {
     #[error("No sync peers available")]
     NoSyncPeers,
     #[error("Sync peer sent invalid peer: {0}")]
-    PeerValidationError(#[from] PeerValidatorError),
+    PeerValidationError(#[from] DhtPeerValidatorError),
 }

--- a/comms/dht/src/network_discovery/on_connect.rs
+++ b/comms/dht/src/network_discovery/on_connect.rs
@@ -37,7 +37,7 @@ use crate::{
     peer_validator::PeerValidator,
     proto::rpc::GetPeersRequest,
     rpc,
-    rpc::PeerInfo,
+    rpc::UnvalidatedPeerInfo,
     DhtConfig,
 };
 const LOG_TARGET: &str = "comms::dht::network_discovery:onconnect";
@@ -127,6 +127,19 @@ impl OnConnect {
             .get_peers(GetPeersRequest {
                 n: NUM_FETCH_PEERS,
                 include_clients: false,
+                max_claims: self.config().max_permitted_peer_claims.try_into().unwrap_or_else(|_| {
+                    error!(target: LOG_TARGET, "Node configured to accept more than u32::MAX claims per peer");
+                    u32::MAX
+                }),
+                max_addresses_per_claim: self
+                    .config()
+                    .peer_validator_config
+                    .max_permitted_peer_addresses_per_claim
+                    .try_into()
+                    .unwrap_or_else(|_| {
+                        error!(target: LOG_TARGET, "Node configured to accept more than u32::MAX addresses per claim");
+                        u32::MAX
+                    }),
             })
             .await?;
 
@@ -170,11 +183,14 @@ impl OnConnect {
         Ok(())
     }
 
-    // Returns true if the peer was added
-    async fn validate_and_add_peer(&self, peer: PeerInfo) -> Result<bool, NetworkDiscoveryError> {
-        let peer_validator = PeerValidator::new(&self.context.peer_manager, self.config());
-
-        Ok(peer_validator.validate_and_add_peer(peer).await?)
+    /// Returns true if the peer is a new peer
+    async fn validate_and_add_peer(&self, peer: UnvalidatedPeerInfo) -> Result<bool, NetworkDiscoveryError> {
+        let peer_validator = PeerValidator::new(self.config());
+        let maybe_existing_peer = self.context.peer_manager.find_by_public_key(&peer.public_key).await?;
+        let is_new_peer = maybe_existing_peer.is_none();
+        let valid_peer = peer_validator.validate_peer(peer, maybe_existing_peer)?;
+        self.context.peer_manager.add_peer(valid_peer).await?;
+        Ok(is_new_peer)
     }
 
     #[inline]

--- a/comms/dht/src/network_discovery/test.rs
+++ b/comms/dht/src/network_discovery/test.rs
@@ -48,7 +48,7 @@ use crate::{
 
 mod state_machine {
     use super::*;
-    use crate::rpc::PeerInfo;
+    use crate::rpc::UnvalidatedPeerInfo;
 
     async fn setup(
         mut config: DhtConfig,
@@ -113,7 +113,7 @@ mod state_machine {
         };
         let peers = iter::repeat_with(|| make_node_identity().to_peer())
             .map(|p| GetPeersResponse {
-                peer: Some(PeerInfo::from(p).into()),
+                peer: Some(UnvalidatedPeerInfo::from_peer_limited_claims(p, 5, 5).into()),
             })
             .take(NUM_PEERS)
             .collect();

--- a/comms/dht/src/outbound/message.rs
+++ b/comms/dht/src/outbound/message.rs
@@ -189,15 +189,21 @@ impl fmt::Display for DhtOutboundMessage {
                     self.dht_flags, self.destination, self.tag,
                 )
             });
-        write!(
+
+        writeln!(
             f,
-            "\n---- Outgoing message ---- \nSize: {} byte(s)\nType: {}\nPeer: {}\nHeader: {}\n{}\n----\n{:?}\n",
+            "\n---- Outgoing message ---- \nSize: {} byte(s)\nType: {}\nPeer: {}\nHeader: {}\n{}\n----",
             self.body.len(),
             self.dht_message_type,
             self.destination,
             header_str,
             self.tag,
-            self.body
-        )
+        )?;
+
+        if f.alternate() {
+            write!(f, "(body omitted)")
+        } else {
+            write!(f, "{:?}", self.body)
+        }
     }
 }

--- a/comms/dht/src/outbound/message_params.rs
+++ b/comms/dht/src/outbound/message_params.rs
@@ -104,6 +104,7 @@ impl SendMessageParams {
         Default::default()
     }
 
+    /// Not currently used
     pub fn with_debug_info(&mut self, debug_info: String) -> &mut Self {
         self.params_mut().debug_info = Some(debug_info);
         self

--- a/comms/dht/src/peer_validator.rs
+++ b/comms/dht/src/peer_validator.rs
@@ -22,103 +22,96 @@
 
 use log::*;
 use tari_comms::{
-    connection_manager::validate_address_and_source,
-    net_address::{MultiaddrWithStats, MultiaddressesWithStats, PeerAddressSource},
-    peer_manager::{NodeId, Peer, PeerFlags, PeerManagerError},
-    types::CommsPublicKey,
-    PeerManager,
+    net_address::{MultiaddressesWithStats, PeerAddressSource},
+    peer_manager::{NodeId, Peer, PeerFlags},
+    peer_validator,
+    peer_validator::{find_most_recent_claim, PeerValidatorError},
 };
 
-use crate::{rpc::PeerInfo, DhtConfig};
+use crate::{rpc::UnvalidatedPeerInfo, DhtConfig};
 
-const LOG_TARGET: &str = "dht::network_discovery::peer_validator";
+const _LOG_TARGET: &str = "dht::network_discovery::peer_validator";
 
 /// Validation errors for peers shared on the network
 #[derive(Debug, thiserror::Error)]
-pub enum PeerValidatorError {
-    #[error("Node ID was invalid for peer '{peer}'")]
-    InvalidNodeId { peer: NodeId },
-    #[error("Peer signature was invalid for peer '{peer}'")]
-    InvalidPeerSignature { peer: NodeId },
-    #[error("One or more peer addresses were invalid for '{peer}'")]
-    InvalidPeerAddresses { peer: NodeId },
-    #[error("Peer '{peer}' was banned")]
-    PeerHasNoAddresses { peer: NodeId },
-    #[error("Peer manager error: {0}")]
-    PeerManagerError(#[from] PeerManagerError),
+pub enum DhtPeerValidatorError {
+    #[error("Peer '{peer}' is banned: {reason}")]
+    Banned { peer: NodeId, reason: String },
+    #[error(transparent)]
+    ValidatorError(#[from] PeerValidatorError),
+    #[error("Peer provided too many claims: expected max {max} but got {length}")]
+    IdentityTooManyClaims { length: usize, max: usize },
 }
 
 /// Validator for Peers
 pub struct PeerValidator<'a> {
-    peer_manager: &'a PeerManager,
     config: &'a DhtConfig,
 }
 
 impl<'a> PeerValidator<'a> {
     /// Creates a new peer validator
-    pub fn new(peer_manager: &'a PeerManager, config: &'a DhtConfig) -> Self {
-        Self { peer_manager, config }
+    pub fn new(config: &'a DhtConfig) -> Self {
+        Self { config }
     }
 
     /// Validates the new peer against the current peer database. Returning true if a new peer was added and false if
     /// the peer already exists.
-    pub async fn validate_and_add_peer(&self, new_peer: PeerInfo) -> Result<bool, PeerValidatorError> {
-        let node_id = NodeId::from_public_key(&new_peer.public_key);
-
-        if new_peer.addresses.is_empty() {
-            return Err(PeerValidatorError::PeerHasNoAddresses { peer: node_id });
+    pub fn validate_peer(
+        &self,
+        new_peer: UnvalidatedPeerInfo,
+        existing_peer: Option<Peer>,
+    ) -> Result<Peer, DhtPeerValidatorError> {
+        if new_peer.claims.is_empty() {
+            return Err(PeerValidatorError::PeerHasNoAddresses {
+                peer: NodeId::from_public_key(&new_peer.public_key),
+            }
+            .into());
         }
-        let mut peer = Peer::new(
-            new_peer.public_key.clone(),
-            node_id.clone(),
-            MultiaddressesWithStats::new(vec![]),
-            PeerFlags::default(),
-            new_peer.peer_features,
-            new_peer.supported_protocols,
-            new_peer.user_agent,
-        );
 
-        for addr in new_peer.addresses {
-            let multiaddr_and_stats = MultiaddrWithStats::new(addr.address.clone(), PeerAddressSource::FromDiscovery {
-                peer_identity_claim: addr.peer_identity_claim,
+        if new_peer.claims.len() > self.config.max_permitted_peer_claims {
+            return Err(DhtPeerValidatorError::IdentityTooManyClaims {
+                length: new_peer.claims.len(),
+                max: self.config.max_permitted_peer_claims,
             });
-            match validate_address_and_source(
-                &new_peer.public_key,
-                &multiaddr_and_stats,
-                self.config.allow_test_addresses,
-            ) {
-                Ok(()) => {
-                    peer.addresses
-                        .add_address(multiaddr_and_stats.address(), multiaddr_and_stats.source());
-                },
-                Err(e) => {
-                    warn!(
-                        target: LOG_TARGET,
-                        "Peer provided info on another peer that had a bad address or signature (new peer: {} \
-                         address: {}): error:{}. Ignoring.",
-                        new_peer.public_key,
-                        addr.address,
-                        e
-                    );
-                },
+        }
+
+        if let Some(ref peer) = existing_peer {
+            if peer.is_banned() {
+                return Err(DhtPeerValidatorError::Banned {
+                    peer: peer.node_id.clone(),
+                    reason: peer.banned_reason.clone(),
+                });
             }
         }
-        validate_node_id(&peer.public_key, &peer.node_id)?;
 
-        let exists = self.peer_manager.exists(&peer.public_key).await;
+        let most_recent_claim = find_most_recent_claim(&new_peer.claims).expect("new_peer.claims is not empty");
 
-        self.peer_manager.add_peer(peer).await?;
+        let node_id = NodeId::from_public_key(&new_peer.public_key);
 
-        Ok(!exists)
-    }
-}
+        let mut peer = existing_peer.unwrap_or_else(|| {
+            Peer::new(
+                new_peer.public_key.clone(),
+                node_id,
+                MultiaddressesWithStats::default(),
+                PeerFlags::default(),
+                most_recent_claim.features,
+                vec![],
+                String::new(),
+            )
+        });
 
-fn validate_node_id(public_key: &CommsPublicKey, node_id: &NodeId) -> Result<NodeId, PeerValidatorError> {
-    let expected_node_id = NodeId::from_key(public_key);
-    if expected_node_id == *node_id {
-        Ok(expected_node_id)
-    } else {
-        Err(PeerValidatorError::InvalidNodeId { peer: node_id.clone() })
+        for claim in new_peer.claims {
+            peer_validator::validate_peer_identity_claim(
+                &self.config.peer_validator_config,
+                &new_peer.public_key,
+                &claim,
+            )?;
+            peer.update_addresses(&claim.addresses, &PeerAddressSource::FromDiscovery {
+                peer_identity_claim: claim.clone(),
+            });
+        }
+
+        Ok(peer)
     }
 }
 
@@ -137,11 +130,10 @@ mod tests {
     use tari_utilities::ByteArray;
 
     use super::*;
-    use crate::test_utils::{build_peer_manager, make_node_identity};
+    use crate::test_utils::make_node_identity;
 
     #[tokio::test]
-    async fn it_adds_a_valid_unsigned_peer() {
-        let peer_manager = build_peer_manager();
+    async fn it_errors_with_invalid_signature() {
         let config = DhtConfig::default_local_test();
         let node_identity = make_node_identity();
         let mut peer = node_identity.to_peer();
@@ -159,26 +151,26 @@ mod tests {
                     ),
                     Default::default(),
                 ),
-                unverified_data: None,
             },
         });
-        let validator = PeerValidator::new(&peer_manager, &config);
-        let is_new = validator.validate_and_add_peer(peer.clone().into()).await.unwrap();
-        assert!(is_new);
-        assert!(peer_manager.exists(&peer.public_key).await);
+        let validator = PeerValidator::new(&config);
+        let err = validator
+            .validate_peer(UnvalidatedPeerInfo::from_peer_limited_claims(peer.clone(), 5, 5), None)
+            .unwrap_err();
+        unpack_enum!(DhtPeerValidatorError::ValidatorError(PeerValidatorError::InvalidPeerSignature { .. }) = err);
     }
 
     #[tokio::test]
     async fn it_does_not_add_an_invalid_peer() {
-        let peer_manager = build_peer_manager();
         let config = DhtConfig::default_local_test();
         let node_identity = make_node_identity();
         let mut peer = node_identity.to_peer();
         // Peer MUST provide at least one address
         peer.addresses = MultiaddressesWithStats::new(vec![]);
-        let validator = PeerValidator::new(&peer_manager, &config);
-        let err = validator.validate_and_add_peer(peer.clone().into()).await.unwrap_err();
-        unpack_enum!(PeerValidatorError::PeerHasNoAddresses { .. } = err);
-        assert!(!peer_manager.exists(&peer.public_key).await);
+        let validator = PeerValidator::new(&config);
+        let err = validator
+            .validate_peer(UnvalidatedPeerInfo::from_peer_limited_claims(peer, 5, 5), None)
+            .unwrap_err();
+        unpack_enum!(DhtPeerValidatorError::ValidatorError(PeerValidatorError::PeerHasNoAddresses { .. }) = err);
     }
 }

--- a/comms/dht/src/proto/dht.proto
+++ b/comms/dht/src/proto/dht.proto
@@ -16,7 +16,7 @@ import "common.proto";
 message JoinMessage {
     bytes public_key =1;
     repeated bytes addresses = 2;
-    uint64 peer_features = 3;
+    uint32 peer_features = 3;
     uint64 nonce = 4;
     tari.dht.common.IdentitySignature identity_signature = 5;
 }
@@ -29,7 +29,7 @@ message JoinMessage {
 message DiscoveryMessage {
     bytes public_key =1;
     repeated bytes addresses = 2;
-    uint64 peer_features = 3;
+    uint32 peer_features = 3;
     uint64 nonce = 4;
     tari.dht.common.IdentitySignature identity_signature = 5;
 }
@@ -37,7 +37,7 @@ message DiscoveryMessage {
 message DiscoveryResponseMessage {
     bytes public_key = 1;
     repeated bytes addresses = 2;
-    uint64 peer_features = 3;
+    uint32 peer_features = 3;
     uint64 nonce = 4;
     tari.dht.common.IdentitySignature identity_signature = 5;
 }

--- a/comms/dht/src/proto/mod.rs
+++ b/comms/dht/src/proto/mod.rs
@@ -82,9 +82,9 @@ impl fmt::Display for dht::JoinMessage {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "JoinMessage(PK = {}, Addresses = {:?}, Features = {:?})",
+            "JoinMessage(PK = {}, {} Addresses, Features = {:?})",
             self.public_key.to_hex(),
-            self.addresses,
+            self.addresses.len(),
             PeerFeatures::from_bits_truncate(self.peer_features),
         )
     }

--- a/comms/dht/src/proto/mod.rs
+++ b/comms/dht/src/proto/mod.rs
@@ -34,14 +34,9 @@ use tari_comms::{
     types::{CommsPublicKey, CommsSecretKey, Signature},
     NodeIdentity,
 };
-use tari_crypto::ristretto::RistrettoPublicKey;
-use tari_utilities::{hex::Hex, ByteArray, ByteArrayError};
-use thiserror::Error;
+use tari_utilities::{hex::Hex, ByteArray};
 
-use crate::{
-    proto::dht::{DiscoveryMessage, JoinMessage},
-    rpc::{PeerInfo, PeerInfoAddress},
-};
+use crate::{proto::dht::JoinMessage, rpc::UnvalidatedPeerInfo};
 
 pub mod common {
     tari_comms::outdir_include!("tari.dht.common.rs");
@@ -97,79 +92,11 @@ impl fmt::Display for dht::JoinMessage {
 
 //---------------------------------- Rpc Message Conversions --------------------------------------------//
 
-#[derive(Debug, Error, PartialEq)]
-enum PeerInfoConvertError {
-    #[error("Could not convert into byte array: `{0}`")]
-    ByteArrayError(String),
-}
-
-impl From<ByteArrayError> for PeerInfoConvertError {
-    fn from(e: ByteArrayError) -> Self {
-        PeerInfoConvertError::ByteArrayError(e.to_string())
-    }
-}
-
-impl TryFrom<DiscoveryMessage> for PeerInfo {
-    type Error = anyhow::Error;
-
-    fn try_from(value: DiscoveryMessage) -> Result<Self, Self::Error> {
-        let identity_signature = value
-            .identity_signature
-            .ok_or_else(|| anyhow!("DiscoveryMessage missing peer_identity_claim"))?
-            .try_into()?;
-
-        let identity_claim = PeerIdentityClaim {
-            addresses: value
-                .addresses
-                .iter()
-                .map(|a| Multiaddr::try_from(a.clone()))
-                .collect::<Result<_, _>>()?,
-            features: PeerFeatures::from_bits_truncate(value.peer_features),
-            signature: identity_signature,
-            unverified_data: None,
-        };
-
-        Ok(Self {
-            public_key: RistrettoPublicKey::from_bytes(&value.public_key)
-                .map_err(|e| PeerInfoConvertError::ByteArrayError(format!("{}", e)))?,
-            addresses: value
-                .addresses
-                .iter()
-                .map(|a| {
-                    Ok(PeerInfoAddress {
-                        address: Multiaddr::try_from(a.clone())?,
-                        peer_identity_claim: identity_claim.clone(),
-                    })
-                })
-                .collect::<Result<_, Self::Error>>()?,
-            peer_features: PeerFeatures::from_bits_truncate(value.peer_features),
-            supported_protocols: vec![],
-            user_agent: "".to_string(),
-        })
-    }
-}
-
-impl From<PeerInfo> for rpc::PeerInfo {
-    fn from(value: PeerInfo) -> Self {
+impl From<UnvalidatedPeerInfo> for rpc::PeerInfo {
+    fn from(value: UnvalidatedPeerInfo) -> Self {
         Self {
             public_key: value.public_key.to_vec(),
-            addresses: value.addresses.into_iter().map(Into::into).collect(),
-            peer_features: value.peer_features.bits(),
-            supported_protocols: value
-                .supported_protocols
-                .into_iter()
-                .map(|b| b.as_ref().to_vec())
-                .collect(),
-            user_agent: value.user_agent,
-        }
-    }
-}
-
-impl From<PeerInfoAddress> for rpc::PeerInfoAddress {
-    fn from(value: PeerInfoAddress) -> Self {
-        Self {
-            address: value.address.to_vec(),
-            peer_identity_claim: Some(value.peer_identity_claim.into()),
+            claims: value.claims.into_iter().map(Into::into).collect(),
         }
     }
 }
@@ -184,62 +111,34 @@ impl From<PeerIdentityClaim> for rpc::PeerIdentityClaim {
     }
 }
 
-impl TryInto<PeerInfo> for rpc::PeerInfo {
+impl TryFrom<rpc::PeerInfo> for UnvalidatedPeerInfo {
     type Error = anyhow::Error;
 
-    fn try_into(self) -> Result<PeerInfo, Self::Error> {
-        let public_key = CommsPublicKey::from_bytes(&self.public_key)
-            .map_err(|e| PeerInfoConvertError::ByteArrayError(format!("{}", e)))?;
-        let addresses = self
-            .addresses
+    fn try_from(value: rpc::PeerInfo) -> Result<UnvalidatedPeerInfo, Self::Error> {
+        let public_key =
+            CommsPublicKey::from_bytes(&value.public_key).map_err(|e| anyhow!("PeerInfo invalid public key: {}", e))?;
+        let claims = value
+            .claims
             .into_iter()
             .map(TryInto::try_into)
-            .collect::<Result<Vec<_>, _>>()?;
-        let peer_features = PeerFeatures::from_bits_truncate(self.peer_features);
-        let supported_protocols = self
-            .supported_protocols
-            .into_iter()
-            .map(|b| b.try_into())
-            .collect::<Result<Vec<_>, _>>()?;
-        Ok(PeerInfo {
-            public_key,
-            addresses,
-            peer_features,
-            user_agent: self.user_agent,
-            supported_protocols,
-        })
+            .collect::<Result<_, _>>()?;
+
+        Ok(Self { public_key, claims })
     }
 }
 
-impl TryInto<PeerInfoAddress> for rpc::PeerInfoAddress {
+impl TryFrom<rpc::PeerIdentityClaim> for PeerIdentityClaim {
     type Error = anyhow::Error;
 
-    fn try_into(self) -> Result<PeerInfoAddress, Self::Error> {
-        let address = Multiaddr::try_from(self.address)?;
-        let peer_identity_claim = self
-            .peer_identity_claim
-            .ok_or_else(|| anyhow::anyhow!("Missing peer identity claim"))?
-            .try_into()?;
-
-        Ok(PeerInfoAddress {
-            address,
-            peer_identity_claim,
-        })
-    }
-}
-
-impl TryInto<PeerIdentityClaim> for rpc::PeerIdentityClaim {
-    type Error = anyhow::Error;
-
-    fn try_into(self) -> Result<PeerIdentityClaim, Self::Error> {
-        let addresses = self
+    fn try_from(value: rpc::PeerIdentityClaim) -> Result<PeerIdentityClaim, Self::Error> {
+        let addresses = value
             .addresses
             .into_iter()
             .filter_map(|addr| Multiaddr::try_from(addr).ok())
             .collect::<Vec<_>>();
 
-        let features = PeerFeatures::from_bits_truncate(self.peer_features);
-        let signature = self
+        let features = PeerFeatures::from_bits(value.peer_features).ok_or_else(|| anyhow!("Invalid peer features"))?;
+        let signature = value
             .identity_signature
             .map(TryInto::try_into)
             .ok_or_else(|| anyhow::anyhow!("No signature"))??;
@@ -247,7 +146,6 @@ impl TryInto<PeerIdentityClaim> for rpc::PeerIdentityClaim {
             addresses,
             features,
             signature,
-            unverified_data: None,
         })
     }
 }
@@ -258,10 +156,10 @@ impl TryFrom<common::IdentitySignature> for IdentitySignature {
     fn try_from(value: common::IdentitySignature) -> Result<Self, Self::Error> {
         let version = u8::try_from(value.version)
             .map_err(|_| anyhow::anyhow!("Invalid peer identity signature version {}", value.version))?;
-        let public_nonce = CommsPublicKey::from_bytes(&value.public_nonce)
-            .map_err(|e| PeerInfoConvertError::ByteArrayError(format!("{}", e)))?;
-        let signature = CommsSecretKey::from_bytes(&value.signature)
-            .map_err(|e| PeerInfoConvertError::ByteArrayError(format!("{}", e)))?;
+        let public_nonce =
+            CommsPublicKey::from_bytes(&value.public_nonce).map_err(|e| anyhow!("Invalid public nonce: {}", e))?;
+        let signature =
+            CommsSecretKey::from_bytes(&value.signature).map_err(|e| anyhow!("Invalid signature: {}", e))?;
         let updated_at = NaiveDateTime::from_timestamp_opt(value.updated_at, 0)
             .ok_or_else(|| anyhow::anyhow!("updated_at overflowed"))?;
         let updated_at = DateTime::<Utc>::from_utc(updated_at, Utc);

--- a/comms/dht/src/proto/rpc.proto
+++ b/comms/dht/src/proto/rpc.proto
@@ -14,6 +14,8 @@ message GetCloserPeersRequest {
   repeated bytes excluded = 2;
   bytes closer_to = 3;
   bool include_clients = 4;
+  uint32 max_claims = 5;
+  uint32 max_addresses_per_claim = 6;
 }
 
 // `get_peers` request
@@ -21,6 +23,8 @@ message GetPeersRequest {
   // The number of peers to return, 0 for all peers
   uint32 n = 1;
   bool include_clients = 2;
+  uint32 max_claims = 3;
+  uint32 max_addresses_per_claim = 4;
 }
 
 // GET peers response
@@ -31,21 +35,11 @@ message GetPeersResponse {
 // Minimal peer information
 message PeerInfo {
   bytes public_key = 1;
-  repeated PeerInfoAddress addresses = 2;
-  uint64 peer_features = 3;
-  repeated bytes supported_protocols = 4;
-  // Note: not part of the signature
-  string user_agent = 5;
-
-}
-
-message PeerInfoAddress {
-  bytes address = 1;
-  PeerIdentityClaim peer_identity_claim = 2;
+  repeated PeerIdentityClaim claims = 2;
 }
 
 message PeerIdentityClaim {
   repeated bytes addresses = 1;
-  uint64 peer_features = 2;
+  uint32 peer_features = 2;
   tari.dht.common.IdentitySignature identity_signature = 3;
 }

--- a/comms/dht/src/rpc/mod.rs
+++ b/comms/dht/src/rpc/mod.rs
@@ -37,7 +37,7 @@ use tari_comms_rpc_macros::tari_rpc;
 use crate::proto::rpc::{GetCloserPeersRequest, GetPeersRequest, GetPeersResponse};
 
 mod peer_info;
-pub use peer_info::{PeerInfo, PeerInfoAddress};
+pub use peer_info::UnvalidatedPeerInfo;
 
 #[tari_rpc(protocol_name = b"t/dht/1", server_struct = DhtService, client_struct = DhtClient)]
 pub trait DhtRpcService: Send + Sync + 'static {

--- a/comms/dht/src/rpc/peer_info.rs
+++ b/comms/dht/src/rpc/peer_info.rs
@@ -20,47 +20,145 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use std::convert::{TryFrom, TryInto};
+
+use anyhow::anyhow;
 use tari_comms::{
     multiaddr::Multiaddr,
     peer_manager::{Peer, PeerFeatures, PeerIdentityClaim},
-    protocol::ProtocolId,
     types::CommsPublicKey,
 };
+use tari_crypto::ristretto::RistrettoPublicKey;
+use tari_utilities::ByteArray;
 
-pub struct PeerInfo {
+use crate::proto::dht::{DiscoveryMessage, DiscoveryResponseMessage, JoinMessage};
+
+pub struct UnvalidatedPeerInfo {
     pub public_key: CommsPublicKey,
-    pub addresses: Vec<PeerInfoAddress>,
-    pub peer_features: PeerFeatures,
-    pub user_agent: String,
-    pub supported_protocols: Vec<ProtocolId>,
+    pub claims: Vec<PeerIdentityClaim>,
 }
 
-pub struct PeerInfoAddress {
-    pub address: Multiaddr,
-    pub peer_identity_claim: PeerIdentityClaim,
-}
+impl UnvalidatedPeerInfo {
+    pub fn from_peer_limited_claims(peer: Peer, max_claims: usize, max_addresse_per_claim: usize) -> Self {
+        let claims = peer
+            .addresses
+            .addresses()
+            .iter()
+            .filter_map(|addr| {
+                if addr.address().is_empty() {
+                    return None;
+                }
 
-impl From<Peer> for PeerInfo {
-    fn from(peer: Peer) -> Self {
-        PeerInfo {
+                let claim = addr.source().peer_identity_claim()?;
+
+                if claim.addresses.len() > max_addresse_per_claim {
+                    return None;
+                }
+
+                Some(claim)
+            })
+            .take(max_claims)
+            .cloned()
+            .collect::<Vec<_>>();
+
+        Self {
             public_key: peer.public_key,
-            addresses: peer
-                .addresses
-                .addresses()
-                .iter()
-                .filter_map(|addr| {
-                    if addr.address().is_empty() {
-                        return None;
-                    }
-                    addr.source.peer_identity_claim().map(|claim| PeerInfoAddress {
-                        address: addr.address().clone(),
-                        peer_identity_claim: claim.clone(),
-                    })
-                })
-                .collect(),
-            peer_features: peer.features,
-            user_agent: peer.user_agent,
-            supported_protocols: peer.supported_protocols,
+            claims,
         }
+    }
+}
+
+impl TryFrom<DiscoveryMessage> for UnvalidatedPeerInfo {
+    type Error = anyhow::Error;
+
+    fn try_from(value: DiscoveryMessage) -> Result<Self, Self::Error> {
+        let public_key = RistrettoPublicKey::from_bytes(&value.public_key)
+            .map_err(|e| anyhow!("DiscoveryMessage invalid public key: {}", e))?;
+
+        let features = PeerFeatures::from_bits(value.peer_features)
+            .ok_or_else(|| anyhow!("Invalid peer features. Bits: {:#04x}", value.peer_features))?;
+
+        let identity_signature = value
+            .identity_signature
+            .ok_or_else(|| anyhow!("DiscoveryMessage missing peer_identity_claim"))?
+            .try_into()?;
+        let identity_claim = PeerIdentityClaim {
+            addresses: value
+                .addresses
+                .into_iter()
+                .map(Multiaddr::try_from)
+                .collect::<Result<_, _>>()?,
+            features,
+            signature: identity_signature,
+        };
+
+        Ok(Self {
+            public_key,
+            claims: vec![identity_claim],
+        })
+    }
+}
+
+impl TryFrom<DiscoveryResponseMessage> for UnvalidatedPeerInfo {
+    type Error = anyhow::Error;
+
+    fn try_from(value: DiscoveryResponseMessage) -> Result<Self, Self::Error> {
+        let public_key = RistrettoPublicKey::from_bytes(&value.public_key)
+            .map_err(|e| anyhow!("DiscoveryMessage invalid public key: {}", e))?;
+
+        let features = PeerFeatures::from_bits(value.peer_features)
+            .ok_or_else(|| anyhow!("Invalid peer features. Bits: {:#04x}", value.peer_features))?;
+
+        let identity_signature = value
+            .identity_signature
+            .ok_or_else(|| anyhow!("DiscoveryMessage missing peer_identity_claim"))?
+            .try_into()?;
+
+        let identity_claim = PeerIdentityClaim {
+            addresses: value
+                .addresses
+                .into_iter()
+                .map(Multiaddr::try_from)
+                .collect::<Result<_, _>>()?,
+            features,
+            signature: identity_signature,
+        };
+
+        Ok(Self {
+            public_key,
+            claims: vec![identity_claim],
+        })
+    }
+}
+
+impl TryFrom<JoinMessage> for UnvalidatedPeerInfo {
+    type Error = anyhow::Error;
+
+    fn try_from(value: JoinMessage) -> Result<Self, Self::Error> {
+        let public_key = RistrettoPublicKey::from_bytes(&value.public_key)
+            .map_err(|e| anyhow!("JoinMessage invalid public key: {}", e))?;
+
+        let features = PeerFeatures::from_bits(value.peer_features)
+            .ok_or_else(|| anyhow!("Invalid peer features. Bits: {:#04x}", value.peer_features))?;
+
+        let identity_signature = value
+            .identity_signature
+            .ok_or_else(|| anyhow!("JoinMessage missing peer_identity_claim"))?
+            .try_into()?;
+
+        let identity_claim = PeerIdentityClaim {
+            addresses: value
+                .addresses
+                .into_iter()
+                .map(Multiaddr::try_from)
+                .collect::<Result<_, _>>()?,
+            features,
+            signature: identity_signature,
+        };
+
+        Ok(Self {
+            public_key,
+            claims: vec![identity_claim],
+        })
     }
 }

--- a/comms/dht/src/rpc/test.rs
+++ b/comms/dht/src/rpc/test.rs
@@ -51,7 +51,7 @@ mod get_closer_peers {
     use std::borrow::BorrowMut;
 
     use super::*;
-    use crate::rpc::PeerInfo;
+    use crate::rpc::UnvalidatedPeerInfo;
 
     #[tokio::test]
     async fn it_returns_empty_peer_stream() {
@@ -62,6 +62,8 @@ mod get_closer_peers {
             excluded: vec![],
             closer_to: node_identity.node_id().to_vec(),
             include_clients: false,
+            max_claims: 5,
+            max_addresses_per_claim: 5,
         };
 
         let req = mock.request_with_context(node_identity.node_id().clone(), req);
@@ -89,6 +91,8 @@ mod get_closer_peers {
             excluded: vec![],
             closer_to: node_identity.node_id().to_vec(),
             include_clients: false,
+            max_claims: 5,
+            max_addresses_per_claim: 5,
         };
 
         let req = mock.request_with_context(node_identity.node_id().clone(), req);
@@ -101,7 +105,7 @@ mod get_closer_peers {
             .map(Result::unwrap)
             .map(|r| r.peer.unwrap())
             .map(|p| p.try_into().unwrap())
-            .collect::<Vec<PeerInfo>>();
+            .collect::<Vec<UnvalidatedPeerInfo>>();
 
         let mut dist = NodeDistance::zero();
         for p in &peers {
@@ -130,6 +134,8 @@ mod get_closer_peers {
             excluded: vec![],
             closer_to: node_identity.node_id().to_vec(),
             include_clients: false,
+            max_claims: 5,
+            max_addresses_per_claim: 5,
         };
 
         let req = mock.request_with_context(node_identity.node_id().clone(), req);
@@ -158,6 +164,8 @@ mod get_closer_peers {
             excluded: vec![excluded_peer.node_id().to_vec()],
             closer_to: node_identity.node_id().to_vec(),
             include_clients: true,
+            max_claims: 5,
+            max_addresses_per_claim: 5,
         };
 
         let req = mock.request_with_context(node_identity.node_id().clone(), req);
@@ -188,7 +196,7 @@ mod get_peers {
     use tari_comms::test_utils::node_identity::build_many_node_identities;
 
     use super::*;
-    use crate::{proto::rpc::GetPeersRequest, rpc::PeerInfo};
+    use crate::{proto::rpc::GetPeersRequest, rpc::UnvalidatedPeerInfo};
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn it_returns_empty_peer_stream() {
@@ -197,6 +205,8 @@ mod get_peers {
         let req = GetPeersRequest {
             n: 10,
             include_clients: false,
+            max_claims: 5,
+            max_addresses_per_claim: 5,
         };
 
         let req = mock.request_with_context(node_identity.node_id().clone(), req);
@@ -222,6 +232,8 @@ mod get_peers {
         let req = GetPeersRequest {
             n: 5,
             include_clients: true,
+            max_claims: 5,
+            max_addresses_per_claim: 5,
         };
 
         let peers_stream = service
@@ -236,10 +248,10 @@ mod get_peers {
             .map(Result::unwrap)
             .map(|r| r.peer.unwrap())
             .map(|p| p.try_into().unwrap())
-            .collect::<Vec<PeerInfo>>();
+            .collect::<Vec<UnvalidatedPeerInfo>>();
 
-        assert_eq!(peers.iter().filter(|p| p.peer_features.is_client()).count(), 2);
-        assert_eq!(peers.iter().filter(|p| p.peer_features.is_node()).count(), 3);
+        assert_eq!(peers.iter().filter(|p| p.claims[0].features.is_client()).count(), 2);
+        assert_eq!(peers.iter().filter(|p| p.claims[0].features.is_node()).count(), 3);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -258,6 +270,8 @@ mod get_peers {
         let req = GetPeersRequest {
             n: 3,
             include_clients: false,
+            max_claims: 5,
+            max_addresses_per_claim: 5,
         };
 
         let peers_stream = service
@@ -272,9 +286,9 @@ mod get_peers {
             .map(Result::unwrap)
             .map(|r| r.peer.unwrap())
             .map(|p| p.try_into().unwrap())
-            .collect::<Vec<PeerInfo>>();
+            .collect::<Vec<UnvalidatedPeerInfo>>();
 
-        assert!(peers.iter().all(|p| p.peer_features.is_node()));
+        assert!(peers.iter().all(|p| p.claims[0].features.is_node()));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -294,6 +308,8 @@ mod get_peers {
         let req = GetPeersRequest {
             n: 2,
             include_clients: false,
+            max_claims: 5,
+            max_addresses_per_claim: 5,
         };
 
         let req = mock.request_with_context(node_identity.node_id().clone(), req);

--- a/comms/dht/src/store_forward/saf_handler/task.rs
+++ b/comms/dht/src/store_forward/saf_handler/task.rs
@@ -341,7 +341,7 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
 
                     // Every other error shouldn't happen if the sending node is behaving
                     Err(err) => {
-                        // TODO: #banheuristics
+                        //  #banheuristics
                         warn!(
                             target: LOG_TARGET,
                             "SECURITY: invalid store and forward message was discarded from NodeId={}. Reason: {}. \

--- a/comms/dht/src/store_forward/saf_handler/task.rs
+++ b/comms/dht/src/store_forward/saf_handler/task.rs
@@ -41,7 +41,7 @@ use tokio::sync::mpsc;
 use tower::{Service, ServiceExt};
 
 use crate::{
-    actor::DhtRequester,
+    actor::{DhtRequester, OffenceSeverity},
     crypt,
     dedup,
     envelope::{timestamp_to_datetime, DhtMessageHeader, NodeDestination},
@@ -349,6 +349,13 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
                             source_peer.node_id.short_str(),
                             err
                         );
+                        self.dht_requester
+                            .ban_peer(
+                                source_peer.public_key.clone(),
+                                OffenceSeverity::High,
+                                format!("Invalid SAF message: {}", err),
+                            )
+                            .await
                     },
                 }
 

--- a/comms/dht/src/test_utils/dht_actor_mock.rs
+++ b/comms/dht/src/test_utils/dht_actor_mock.rs
@@ -137,6 +137,7 @@ impl DhtActorMock {
                 reply_tx.send(Ok(())).unwrap();
             },
             DialDiscoverPeer { .. } => unimplemented!(),
+            BanPeer { .. } => unimplemented!(),
         }
     }
 }

--- a/comms/dht/tests/attacks.rs
+++ b/comms/dht/tests/attacks.rs
@@ -1,0 +1,179 @@
+// // Copyright 2023. The Tari Project
+// //
+// // Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// // following conditions are met:
+// //
+// // 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
+// following // disclaimer.
+// //
+// // 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// // following disclaimer in the documentation and/or other materials provided with the distribution.
+// //
+// // 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// // products derived from this software without specific prior written permission.
+// //
+// // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// // INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// // SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// // SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+mod harness;
+use std::{iter, time::Duration};
+
+use harness::*;
+use rand::{rngs::OsRng, Rng, RngCore};
+use tari_comms::{
+    peer_manager::{IdentitySignature, PeerFeatures},
+    NodeIdentity,
+};
+use tari_comms_dht::{envelope::DhtMessageType, outbound::SendMessageParams};
+use tari_test_utils::async_assert_eventually;
+use tari_utilities::ByteArray;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn large_join_messages_with_many_addresses() {
+    // Create 3 nodes where only Node B knows A and C, but A and C want to talk to each other
+
+    // Node C knows no one
+    let node_c = make_node("node_C", PeerFeatures::COMMUNICATION_NODE, dht_config(), None).await;
+    // Node B knows about Node C
+    let node_b = make_node(
+        "node_B",
+        PeerFeatures::COMMUNICATION_NODE,
+        dht_config(),
+        Some(node_c.to_peer()),
+    )
+    .await;
+    // Node A knows about Node B
+    let node_a = make_node(
+        "node_A",
+        PeerFeatures::COMMUNICATION_NODE,
+        dht_config(),
+        Some(node_b.to_peer()),
+    )
+    .await;
+
+    node_a
+        .comms
+        .connectivity()
+        .wait_for_connectivity(Duration::from_secs(10))
+        .await
+        .unwrap();
+    node_b
+        .comms
+        .connectivity()
+        .wait_for_connectivity(Duration::from_secs(10))
+        .await
+        .unwrap();
+
+    let addresses = iter::repeat_with(random_multiaddr_bytes)
+        .take(900 * 1024 / 32)
+        .collect::<Vec<_>>();
+    let node_identity = (*node_a.node_identity()).clone();
+    let message = JoinMessage::from_node_identity(&node_identity, addresses);
+
+    node_a
+        .dht
+        .outbound_requester()
+        .send_message_no_header(
+            SendMessageParams::new()
+                .direct_node_id(node_b.node_identity().node_id().clone())
+                .with_destination(node_c.comms.node_identity().public_key().clone().into())
+                .with_dht_message_type(DhtMessageType::Join)
+                .force_origin()
+                .finish(),
+            message,
+        )
+        .await
+        .unwrap();
+
+    let node_b_peer_manager = node_b.comms.peer_manager();
+    let node_c_peer_manager = node_c.comms.peer_manager();
+
+    // Check that Node B bans node A
+    async_assert_eventually!(
+        node_b_peer_manager
+            .is_peer_banned(node_a.node_identity().node_id())
+            .await
+            .unwrap(),
+        expect = true,
+        max_attempts = 10,
+        interval = Duration::from_secs(1)
+    );
+    // Node B did not propagate
+    assert!(!node_c_peer_manager.exists(node_a.node_identity().public_key()).await);
+
+    node_a.shutdown().await;
+    node_b.shutdown().await;
+    node_c.shutdown().await;
+}
+
+// Copies of non-public the JoinMessage and IdentitySignature structs too allow this test to manipulate them
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct JoinMessage {
+    #[prost(bytes = "vec", tag = "1")]
+    pub public_key: Vec<u8>,
+    #[prost(bytes = "vec", repeated, tag = "2")]
+    pub addresses: Vec<Vec<u8>>,
+    #[prost(uint32, tag = "3")]
+    pub peer_features: u32,
+    #[prost(uint64, tag = "4")]
+    pub nonce: u64,
+    #[prost(message, optional, tag = "5")]
+    pub identity_signature: Option<IdentitySignatureProto>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct IdentitySignatureProto {
+    #[prost(uint32, tag = "1")]
+    pub version: u32,
+    #[prost(bytes = "vec", tag = "2")]
+    pub signature: Vec<u8>,
+    #[prost(bytes = "vec", tag = "3")]
+    pub public_nonce: Vec<u8>,
+    /// The EPOCH timestamp used in the identity signature challenge
+    #[prost(int64, tag = "4")]
+    pub updated_at: i64,
+}
+
+impl JoinMessage {
+    fn from_node_identity(node_identity: &NodeIdentity, raw_addresses: Vec<Vec<u8>>) -> Self {
+        Self {
+            public_key: node_identity.public_key().to_vec(),
+            addresses: raw_addresses,
+            peer_features: node_identity.features().bits(),
+            nonce: OsRng.next_u64(),
+            identity_signature: node_identity.identity_signature_read().as_ref().map(Into::into),
+        }
+    }
+}
+
+impl From<&IdentitySignature> for IdentitySignatureProto {
+    fn from(identity_sig: &IdentitySignature) -> Self {
+        Self {
+            version: u32::from(identity_sig.version()),
+            signature: identity_sig.signature().get_signature().to_vec(),
+            public_nonce: identity_sig.signature().get_public_nonce().to_vec(),
+            updated_at: identity_sig.updated_at().timestamp(),
+        }
+    }
+}
+
+fn random_port() -> u16 {
+    let mut rng = rand::thread_rng();
+    rng.gen_range(1024..=65535)
+}
+
+fn random_multiaddr_bytes() -> Vec<u8> {
+    let port = random_port();
+    let mut rng = rand::thread_rng();
+
+    let mut bytes = Vec::with_capacity(7);
+    bytes.push(4); // IP4 code
+    bytes.extend([rng.gen::<u8>(), rng.gen(), rng.gen(), rng.gen()]);
+    bytes.push(6); // TCP code
+    bytes.extend(&port.to_be_bytes());
+
+    bytes
+}

--- a/comms/dht/tests/dht.rs
+++ b/comms/dht/tests/dht.rs
@@ -223,7 +223,7 @@ async fn setup_comms_dht(
 
 fn dht_config() -> DhtConfig {
     let mut config = DhtConfig::default_local_test();
-    config.allow_test_addresses = true;
+    config.peer_validator_config.allow_test_addresses = true;
     config.saf.auto_request = false;
     config.discovery_request_timeout = Duration::from_secs(60);
     config.num_neighbouring_nodes = 8;

--- a/comms/dht/tests/dht.rs
+++ b/comms/dht/tests/dht.rs
@@ -20,215 +20,23 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+mod harness;
 use std::{sync::Arc, time::Duration};
 
-use rand::rngs::OsRng;
+use harness::*;
 use tari_comms::{
-    backoff::ConstantBackoff,
     connectivity::ConnectivityEvent,
     message::MessageExt,
-    peer_manager::{NodeId, NodeIdentity, Peer, PeerFeatures},
-    pipeline,
-    pipeline::SinkService,
-    protocol::messaging::{MessagingEvent, MessagingEventSender, MessagingProtocolExtension},
-    transports::MemoryTransport,
-    types::CommsDatabase,
-    CommsBuilder,
-    CommsNode,
+    peer_manager::{NodeId, PeerFeatures},
+    protocol::messaging::MessagingEvent,
 };
 use tari_comms_dht::{
     domain_message::OutboundDomainMessage,
     envelope::{DhtMessageType, NodeDestination},
     event::DhtEvent,
-    inbound::DecryptedDhtMessage,
     outbound::{OutboundEncryption, SendMessageParams},
-    DbConnectionUrl,
-    Dht,
-    DhtConfig,
 };
-use tari_shutdown::{Shutdown, ShutdownSignal};
-use tari_storage::{
-    lmdb_store::{LMDBBuilder, LMDBConfig},
-    LMDBWrapper,
-};
-use tari_test_utils::{
-    async_assert_eventually,
-    collect_try_recv,
-    paths::create_temporary_data_path,
-    random,
-    streams,
-    unpack_enum,
-};
-use tokio::{
-    sync::{broadcast, mpsc},
-    time,
-};
-use tower::ServiceBuilder;
-
-struct TestNode {
-    name: String,
-    comms: CommsNode,
-    dht: Dht,
-    inbound_messages: mpsc::Receiver<DecryptedDhtMessage>,
-    messaging_events: broadcast::Sender<Arc<MessagingEvent>>,
-    shutdown: Shutdown,
-}
-
-impl TestNode {
-    pub fn node_identity(&self) -> Arc<NodeIdentity> {
-        self.comms.node_identity()
-    }
-
-    pub fn to_peer(&self) -> Peer {
-        self.comms.node_identity().to_peer()
-    }
-
-    pub fn name(&self) -> &str {
-        &self.name
-    }
-
-    pub async fn next_inbound_message(&mut self, timeout: Duration) -> Option<DecryptedDhtMessage> {
-        time::timeout(timeout, self.inbound_messages.recv()).await.ok()?
-    }
-
-    pub async fn shutdown(mut self) {
-        self.shutdown.trigger();
-        self.comms.wait_until_shutdown().await;
-    }
-}
-
-fn make_node_identity(features: PeerFeatures) -> Arc<NodeIdentity> {
-    let port = MemoryTransport::acquire_next_memsocket_port();
-    Arc::new(NodeIdentity::random(
-        &mut OsRng,
-        format!("/memory/{}", port).parse().unwrap(),
-        features,
-    ))
-}
-
-fn create_peer_storage() -> CommsDatabase {
-    let database_name = random::string(8);
-    let datastore = LMDBBuilder::new()
-        .set_path(create_temporary_data_path())
-        .set_env_config(LMDBConfig::default())
-        .set_max_number_of_databases(1)
-        .add_database(&database_name, lmdb_zero::db::CREATE)
-        .build()
-        .unwrap();
-
-    let peer_database = datastore.get_handle(&database_name).unwrap();
-    LMDBWrapper::new(Arc::new(peer_database))
-}
-
-async fn make_node<I: IntoIterator<Item = Peer>>(
-    name: &str,
-    features: PeerFeatures,
-    dht_config: DhtConfig,
-    known_peers: I,
-) -> TestNode {
-    let node_identity = make_node_identity(features);
-    make_node_with_node_identity(name, node_identity, dht_config, known_peers).await
-}
-
-async fn make_node_with_node_identity<I: IntoIterator<Item = Peer>>(
-    name: &str,
-    node_identity: Arc<NodeIdentity>,
-    dht_config: DhtConfig,
-    known_peers: I,
-) -> TestNode {
-    let (tx, inbound_messages) = mpsc::channel(10);
-    let shutdown = Shutdown::new();
-    let (comms, dht, messaging_events) = setup_comms_dht(
-        node_identity,
-        create_peer_storage(),
-        tx,
-        known_peers.into_iter().collect(),
-        dht_config,
-        shutdown.to_signal(),
-    )
-    .await;
-
-    TestNode {
-        name: name.to_string(),
-        comms,
-        dht,
-        inbound_messages,
-        messaging_events,
-        shutdown,
-    }
-}
-
-async fn setup_comms_dht(
-    node_identity: Arc<NodeIdentity>,
-    storage: CommsDatabase,
-    inbound_tx: mpsc::Sender<DecryptedDhtMessage>,
-    peers: Vec<Peer>,
-    dht_config: DhtConfig,
-    shutdown_signal: ShutdownSignal,
-) -> (CommsNode, Dht, MessagingEventSender) {
-    // Create inbound and outbound channels
-    let (outbound_tx, outbound_rx) = mpsc::channel(10);
-
-    let comms = CommsBuilder::new()
-        .allow_test_addresses()
-        // In this case the listener address and the public address are the same (/memory/...)
-        .with_listener_address(node_identity.first_public_address().unwrap())
-        .with_shutdown_signal(shutdown_signal)
-        .with_node_identity(node_identity)
-        .with_peer_storage(storage,None)
-        .with_min_connectivity(1)
-        .with_dial_backoff(ConstantBackoff::new(Duration::from_millis(100)))
-        .build()
-        .unwrap();
-
-    let dht = Dht::builder()
-        .with_config(dht_config)
-        .with_database_url(DbConnectionUrl::MemoryShared(random::string(8)))
-        .with_outbound_sender(outbound_tx)
-        .build(
-            comms.node_identity(),
-            comms.peer_manager(),
-            comms.connectivity(),
-            comms.shutdown_signal(),
-        )
-        .await
-        .unwrap();
-
-    for peer in peers {
-        comms.peer_manager().add_peer(peer).await.unwrap();
-    }
-
-    let dht_outbound_layer = dht.outbound_middleware_layer();
-    let pipeline = pipeline::Builder::new()
-        .with_outbound_pipeline(outbound_rx, |sink| {
-            ServiceBuilder::new().layer(dht_outbound_layer).service(sink)
-        })
-        .max_concurrent_inbound_tasks(10)
-        .with_inbound_pipeline(
-            ServiceBuilder::new()
-                .layer(dht.inbound_middleware_layer())
-                .service(SinkService::new(inbound_tx)),
-        )
-        .build();
-
-    let (event_tx, _) = broadcast::channel(100);
-    let comms = comms
-        .add_protocol_extension(MessagingProtocolExtension::new(event_tx.clone(), pipeline))
-        .spawn_with_transport(MemoryTransport)
-        .await
-        .unwrap();
-
-    (comms, dht, event_tx)
-}
-
-fn dht_config() -> DhtConfig {
-    let mut config = DhtConfig::default_local_test();
-    config.peer_validator_config.allow_test_addresses = true;
-    config.saf.auto_request = false;
-    config.discovery_request_timeout = Duration::from_secs(60);
-    config.num_neighbouring_nodes = 8;
-    config
-}
+use tari_test_utils::{async_assert_eventually, collect_try_recv, streams, unpack_enum};
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 #[allow(non_snake_case)]

--- a/comms/dht/tests/harness.rs
+++ b/comms/dht/tests/harness.rs
@@ -1,0 +1,215 @@
+// // Copyright 2023. The Tari Project
+// //
+// // Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// // following conditions are met:
+// //
+// // 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
+// following // disclaimer.
+// //
+// // 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// // following disclaimer in the documentation and/or other materials provided with the distribution.
+// //
+// // 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// // products derived from this software without specific prior written permission.
+// //
+// // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// // INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// // SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// // SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::{sync::Arc, time::Duration};
+
+use rand::rngs::OsRng;
+use tari_comms::{
+    backoff::ConstantBackoff,
+    peer_manager::{NodeIdentity, Peer, PeerFeatures},
+    pipeline,
+    pipeline::SinkService,
+    protocol::messaging::{MessagingEvent, MessagingEventSender, MessagingProtocolExtension},
+    transports::MemoryTransport,
+    types::CommsDatabase,
+    CommsBuilder,
+    CommsNode,
+};
+use tari_comms_dht::{inbound::DecryptedDhtMessage, DbConnectionUrl, Dht, DhtConfig};
+use tari_shutdown::{Shutdown, ShutdownSignal};
+use tari_storage::{
+    lmdb_store::{LMDBBuilder, LMDBConfig},
+    LMDBWrapper,
+};
+use tari_test_utils::{paths::create_temporary_data_path, random};
+use tokio::{
+    sync::{broadcast, mpsc},
+    time,
+};
+use tower::ServiceBuilder;
+
+pub struct TestNode {
+    pub name: String,
+    pub comms: CommsNode,
+    pub dht: Dht,
+    pub inbound_messages: mpsc::Receiver<DecryptedDhtMessage>,
+    pub messaging_events: broadcast::Sender<Arc<MessagingEvent>>,
+    pub shutdown: Shutdown,
+}
+
+impl TestNode {
+    pub fn node_identity(&self) -> Arc<NodeIdentity> {
+        self.comms.node_identity()
+    }
+
+    pub fn to_peer(&self) -> Peer {
+        self.comms.node_identity().to_peer()
+    }
+
+    #[allow(dead_code)]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    #[allow(dead_code)]
+    pub async fn next_inbound_message(&mut self, timeout: Duration) -> Option<DecryptedDhtMessage> {
+        time::timeout(timeout, self.inbound_messages.recv()).await.ok()?
+    }
+
+    pub async fn shutdown(mut self) {
+        self.shutdown.trigger();
+        self.comms.wait_until_shutdown().await;
+    }
+}
+
+pub fn make_node_identity(features: PeerFeatures) -> Arc<NodeIdentity> {
+    let port = MemoryTransport::acquire_next_memsocket_port();
+    Arc::new(NodeIdentity::random(
+        &mut OsRng,
+        format!("/memory/{}", port).parse().unwrap(),
+        features,
+    ))
+}
+
+pub fn create_peer_storage() -> CommsDatabase {
+    let database_name = random::string(8);
+    let datastore = LMDBBuilder::new()
+        .set_path(create_temporary_data_path())
+        .set_env_config(LMDBConfig::default())
+        .set_max_number_of_databases(1)
+        .add_database(&database_name, lmdb_zero::db::CREATE)
+        .build()
+        .unwrap();
+
+    let peer_database = datastore.get_handle(&database_name).unwrap();
+    LMDBWrapper::new(Arc::new(peer_database))
+}
+
+pub async fn make_node<I: IntoIterator<Item = Peer>>(
+    name: &str,
+    features: PeerFeatures,
+    dht_config: DhtConfig,
+    known_peers: I,
+) -> TestNode {
+    let node_identity = make_node_identity(features);
+    make_node_with_node_identity(name, node_identity, dht_config, known_peers).await
+}
+
+pub async fn make_node_with_node_identity<I: IntoIterator<Item = Peer>>(
+    name: &str,
+    node_identity: Arc<NodeIdentity>,
+    dht_config: DhtConfig,
+    known_peers: I,
+) -> TestNode {
+    let (tx, inbound_messages) = mpsc::channel(10);
+    let shutdown = Shutdown::new();
+    let (comms, dht, messaging_events) = setup_comms_dht(
+        node_identity,
+        create_peer_storage(),
+        tx,
+        known_peers.into_iter().collect(),
+        dht_config,
+        shutdown.to_signal(),
+    )
+    .await;
+
+    TestNode {
+        name: name.to_string(),
+        comms,
+        dht,
+        inbound_messages,
+        messaging_events,
+        shutdown,
+    }
+}
+
+pub async fn setup_comms_dht(
+    node_identity: Arc<NodeIdentity>,
+    storage: CommsDatabase,
+    inbound_tx: mpsc::Sender<DecryptedDhtMessage>,
+    peers: Vec<Peer>,
+    dht_config: DhtConfig,
+    shutdown_signal: ShutdownSignal,
+) -> (CommsNode, Dht, MessagingEventSender) {
+    // Create inbound and outbound channels
+    let (outbound_tx, outbound_rx) = mpsc::channel(10);
+
+    let comms = CommsBuilder::new()
+        .allow_test_addresses()
+        // In this case the listener address and the public address are the same (/memory/...)
+        .with_listener_address(node_identity.first_public_address().unwrap())
+        .with_shutdown_signal(shutdown_signal)
+        .with_node_identity(node_identity)
+        .with_peer_storage(storage,None)
+        .with_min_connectivity(1)
+        .with_dial_backoff(ConstantBackoff::new(Duration::from_millis(100)))
+        .build()
+        .unwrap();
+
+    let dht = Dht::builder()
+        .with_config(dht_config)
+        .with_database_url(DbConnectionUrl::MemoryShared(random::string(8)))
+        .with_outbound_sender(outbound_tx)
+        .build(
+            comms.node_identity(),
+            comms.peer_manager(),
+            comms.connectivity(),
+            comms.shutdown_signal(),
+        )
+        .await
+        .unwrap();
+
+    for peer in peers {
+        comms.peer_manager().add_peer(peer).await.unwrap();
+    }
+
+    let dht_outbound_layer = dht.outbound_middleware_layer();
+    let pipeline = pipeline::Builder::new()
+        .with_outbound_pipeline(outbound_rx, |sink| {
+            ServiceBuilder::new().layer(dht_outbound_layer).service(sink)
+        })
+        .max_concurrent_inbound_tasks(10)
+        .with_inbound_pipeline(
+            ServiceBuilder::new()
+                .layer(dht.inbound_middleware_layer())
+                .service(SinkService::new(inbound_tx)),
+        )
+        .build();
+
+    let (event_tx, _) = broadcast::channel(100);
+    let comms = comms
+        .add_protocol_extension(MessagingProtocolExtension::new(event_tx.clone(), pipeline))
+        .spawn_with_transport(MemoryTransport)
+        .await
+        .unwrap();
+
+    (comms, dht, event_tx)
+}
+
+pub fn dht_config() -> DhtConfig {
+    let mut config = DhtConfig::default_local_test();
+    config.peer_validator_config.allow_test_addresses = true;
+    config.saf.auto_request = false;
+    config.discovery_request_timeout = Duration::from_secs(60);
+    config.num_neighbouring_nodes = 8;
+    config
+}


### PR DESCRIPTION
Description
---
Implement validations and bans for peers that violate peer identity exchange protocol rules
Consolidate peer claim and identity validations
Removed a number of dead functions and error variants
Reduced memory footprint of peer connection handle
Removed unverified claim data, this data is not unverified and is only ever added for authenticated direct connections
Check that discovery response comes from the peer that directly connected to us
Reduce peer flags size from u64 to u32 (smaller would require many more changes)
Reduce memory footprint in dialer

Motivation and Context
---
TARI-021

All peer source validations use the same code. We previously allowed a peer to send any number of identity claims when doing discovery. Discovery RPC protocol now allows a limited number of claims to be sent, ordered by local quality score.

How Has This Been Tested?
---
Existing test, localnet network (2 bn 2 wallets)

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [ ] None
- [x] Requires _peer_ data directory on base node to be deleted
- [ ] Requires hard fork
- [x] Other - some network messages relating to peer sync are not compatible
<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
