### PR TITLE
fix(horizon_sync): check max number of kernels/utxos from peer

### DIFF
--- a/base_layer/core/src/base_node/sync/horizon_state_sync/synchronizer.rs
+++ b/base_layer/core/src/base_node/sync/horizon_state_sync/synchronizer.rs
@@ -360,6 +360,12 @@ impl<'a, B: BlockchainBackend + 'static> HorizonStateSynchronization<'a, B> {
 
             kernel_hashes.push(kernel.hash());
 
+            if mmr_position > end {
+                return Err(HorizonSyncError::IncorrectResponse(format!(
+                    "Peer sent too many kernels",
+                )));
+            }
+
             let mmr_position_u32 = u32::try_from(mmr_position).map_err(|_| HorizonSyncError::InvalidMmrPosition {
                 at_height: current_header.height(),
                 mmr_position,
@@ -548,6 +554,12 @@ impl<'a, B: BlockchainBackend + 'static> HorizonStateSynchronization<'a, B> {
             let latency = last_sync_timer.elapsed();
             avg_latency.add_sample(latency);
             let res: SyncUtxosResponse = response?;
+
+            if mmr_position > end {
+                return Err(HorizonSyncError::IncorrectResponse(format!(
+                    "Peer sent too many outputs",
+                )));
+            }
 
             if res.mmr_index != 0 && res.mmr_index != mmr_position {
                 return Err(HorizonSyncError::IncorrectResponse(format!(


### PR DESCRIPTION
Description
---
Add a upper limit check on the stream processing loop for both kernels and UTXOs.

Motivation and Context
---
The peer responses of the `sync_kenels` and `sync_utxos` RPC calls return streams. We don't have a check to avoid a malicious peer for repeatedly send data in the stream to keep the client node blocked.

How Has This Been Tested?
---
Tests pass

What process can a PR reviewer use to test or verify this change?
---
Code review

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
