### PR TITLE
fix(horizon_sync): check for leftover unpruned outputs

### DIFF
--- a/base_layer/core/src/base_node/sync/horizon_state_sync/synchronizer.rs
+++ b/base_layer/core/src/base_node/sync/horizon_state_sync/synchronizer.rs
@@ -727,6 +727,12 @@ impl<'a, B: BlockchainBackend + 'static> HorizonStateSynchronization<'a, B> {
             last_sync_timer = Instant::now();
         }
 
+        if !unpruned_outputs.is_empty() {
+            return Err(HorizonSyncError::IncorrectResponse(
+                "Sync node sent leftover unpruned outputs".to_string(),
+            ));
+        }
+
         if mmr_position != end {
             return Err(HorizonSyncError::IncorrectResponse(
                 "Sync node did not send all utxos requested".to_string(),


### PR DESCRIPTION
Description
---
Add a new check after UTXO sync, to ensure that the peer did not send any leftover unpruned outputs

Motivation and Context
---
On UTXO horizon sync, we only validate rangeproofs when receiving a specific type of output from the peer, assuming that that type will always be the last element of the stream,  we then validate the rangeproofs of all unpruned outputs.

But a malicious peer may send more unpruned outputs afterwards, bypassing the rangeproof validation. We need a check at the end of the stream to ensure that the peer did not send any leftover unpruned outputs.

How Has This Been Tested?
---
Tests pass

What process can a PR reviewer use to test or verify this change?
---
Code review

Breaking Changes
---
- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
