### PR TITLE
fix: addition overflow when coinbase + fees is too high

### DIFF
--- a/applications/minotari_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/minotari_node/src/grpc/base_node_grpc_server.rs
@@ -402,55 +402,65 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
                                 .map(|chain_block| {
                                     let (block, acc_data, confirmations, _) = chain_block.dissolve();
                                     let total_block_reward = consensus_rules
-                                        .calculate_coinbase_and_fees(block.header.height, block.body.kernels());
+                                        .calculate_coinbase_and_fees(block.header.height, block.body.kernels())
+                                        .unwrap(); // This makes the
 
-                                    tari_rpc::BlockHeaderResponse {
+                                    Ok(tari_rpc::BlockHeaderResponse {
                                         difficulty: acc_data.achieved_difficulty.into(),
                                         num_transactions: block.body.kernels().len() as u32,
                                         confirmations,
                                         header: Some(block.header.into()),
                                         reward: total_block_reward.into(),
-                                    }
+                                    })
                                 })
                                 .rev()
-                                .collect::<Vec<_>>()
+                                .collect::<Result<Vec<_>, String>>()
                         } else {
                             data.into_iter()
                                 .map(|chain_block| {
                                     let (block, acc_data, confirmations, _) = chain_block.dissolve();
                                     let total_block_reward = consensus_rules
-                                        .calculate_coinbase_and_fees(block.header.height, block.body.kernels());
+                                        .calculate_coinbase_and_fees(block.header.height, block.body.kernels())
+                                        .unwrap();
 
-                                    tari_rpc::BlockHeaderResponse {
+                                    Ok(tari_rpc::BlockHeaderResponse {
                                         difficulty: acc_data.achieved_difficulty.into(),
                                         num_transactions: block.body.kernels().len() as u32,
                                         confirmations,
                                         header: Some(block.header.into()),
                                         reward: total_block_reward.into(),
-                                    }
+                                    })
                                 })
-                                .collect()
+                                .collect::<Result<Vec<_>, String>>()
                         }
                     },
                 };
-                let result_size = result_data.len();
-                debug!(target: LOG_TARGET, "Result headers: {}", result_size);
 
-                for response in result_data {
-                    // header wont be none here as we just filled it in above
-                    debug!(
-                        target: LOG_TARGET,
-                        "Sending block header: {}",
-                        response.header.as_ref().map(|h| h.height).unwrap_or(0)
-                    );
-                    if tx.send(Ok(response)).await.is_err() {
-                        // Sender has closed i.e the connection has dropped/request was abandoned
-                        warn!(
-                            target: LOG_TARGET,
-                            "[list_headers] GRPC request cancelled while sending response"
-                        );
-                        return;
-                    }
+                match result_data {
+                    Err(e) => {
+                        error!(target: LOG_TARGET, "No result headers transmitted due to error: {}", e)
+                    },
+                    Ok(result_data) => {
+                        let result_size = result_data.len();
+                        debug!(target: LOG_TARGET, "Result headers: {}", result_size);
+
+                        for response in result_data {
+                            // header wont be none here as we just filled it in above
+                            debug!(
+                                target: LOG_TARGET,
+                                "Sending block header: {}",
+                                response.header.as_ref().map( | h| h.height).unwrap_or(0)
+                            );
+                            if tx.send(Ok(response)).await.is_err() {
+                                // Sender has closed i.e the connection has dropped/request was abandoned
+                                warn!(
+                                    target: LOG_TARGET,
+                                    "[list_headers] GRPC request cancelled while sending response"
+                                );
+                                return;
+                            }
+                        }
+                    },
                 }
             }
         });
@@ -1349,7 +1359,8 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
         let (block, acc_data, confirmations, _) = block.dissolve();
         let total_block_reward = self
             .consensus_rules
-            .calculate_coinbase_and_fees(block.header.height, block.body.kernels());
+            .calculate_coinbase_and_fees(block.header.height, block.body.kernels())
+            .map_err(Status::out_of_range)?;
 
         let resp = tari_rpc::BlockHeaderResponse {
             difficulty: acc_data.achieved_difficulty.into(),

--- a/applications/minotari_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/minotari_node/src/grpc/base_node_grpc_server.rs
@@ -401,17 +401,18 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
                             data.into_iter()
                                 .map(|chain_block| {
                                     let (block, acc_data, confirmations, _) = chain_block.dissolve();
-                                    let total_block_reward = consensus_rules
+                                    match consensus_rules
                                         .calculate_coinbase_and_fees(block.header.height, block.body.kernels())
-                                        .unwrap(); // This makes the
-
-                                    Ok(tari_rpc::BlockHeaderResponse {
-                                        difficulty: acc_data.achieved_difficulty.into(),
-                                        num_transactions: block.body.kernels().len() as u32,
-                                        confirmations,
-                                        header: Some(block.header.into()),
-                                        reward: total_block_reward.into(),
-                                    })
+                                    {
+                                        Ok(total_block_reward) => Ok(tari_rpc::BlockHeaderResponse {
+                                            difficulty: acc_data.achieved_difficulty.into(),
+                                            num_transactions: block.body.kernels().len() as u32,
+                                            confirmations,
+                                            header: Some(block.header.into()),
+                                            reward: total_block_reward.into(),
+                                        }),
+                                        Err(e) => Err(e),
+                                    }
                                 })
                                 .rev()
                                 .collect::<Result<Vec<_>, String>>()
@@ -419,17 +420,18 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
                             data.into_iter()
                                 .map(|chain_block| {
                                     let (block, acc_data, confirmations, _) = chain_block.dissolve();
-                                    let total_block_reward = consensus_rules
+                                    match consensus_rules
                                         .calculate_coinbase_and_fees(block.header.height, block.body.kernels())
-                                        .unwrap();
-
-                                    Ok(tari_rpc::BlockHeaderResponse {
-                                        difficulty: acc_data.achieved_difficulty.into(),
-                                        num_transactions: block.body.kernels().len() as u32,
-                                        confirmations,
-                                        header: Some(block.header.into()),
-                                        reward: total_block_reward.into(),
-                                    })
+                                    {
+                                        Ok(total_block_reward) => Ok(tari_rpc::BlockHeaderResponse {
+                                            difficulty: acc_data.achieved_difficulty.into(),
+                                            num_transactions: block.body.kernels().len() as u32,
+                                            confirmations,
+                                            header: Some(block.header.into()),
+                                            reward: total_block_reward.into(),
+                                        }),
+                                        Err(e) => Err(e),
+                                    }
                                 })
                                 .collect::<Result<Vec<_>, String>>()
                         }

--- a/base_layer/core/src/consensus/consensus_manager.rs
+++ b/base_layer/core/src/consensus/consensus_manager.rs
@@ -131,9 +131,18 @@ impl ConsensusManager {
     }
 
     /// Creates a total_coinbase offset containing all fees for the validation from the height and kernel set
-    pub fn calculate_coinbase_and_fees(&self, height: u64, kernels: &[TransactionKernel]) -> MicroMinotari {
+    pub fn calculate_coinbase_and_fees(
+        &self,
+        height: u64,
+        kernels: &[TransactionKernel],
+    ) -> Result<MicroMinotari, String> {
         let coinbase = self.emission_schedule().block_reward(height);
-        kernels.iter().fold(coinbase, |total, k| total + k.fee)
+        Ok(kernels.iter().fold(coinbase, |total, k| {
+            total.checked_add(k.fee).expect(&format!(
+                "Kernal's total ({}) + fee ({}) exceeds max transactions allowance",
+                total, k.fee
+            ))
+        }))
     }
 
     /// Returns a ref to the chain strength comparer

--- a/base_layer/core/src/test_helpers/mod.rs
+++ b/base_layer/core/src/test_helpers/mod.rs
@@ -79,14 +79,16 @@ pub async fn create_block(
     header.height = block_height;
     // header.prev_hash = prev_block.hash();
     let reward = spec.reward_override.unwrap_or_else(|| {
-        rules.calculate_coinbase_and_fees(
-            header.height,
-            &spec
-                .transactions
-                .iter()
-                .flat_map(|tx| tx.body.kernels().clone())
-                .collect::<Vec<_>>(),
-        )
+        rules
+            .calculate_coinbase_and_fees(
+                header.height,
+                &spec
+                    .transactions
+                    .iter()
+                    .flat_map(|tx| tx.body.kernels().clone())
+                    .collect::<Vec<_>>(),
+            )
+            .unwrap()
     });
 
     let spend_key_id = KeyId::Managed {

--- a/base_layer/core/src/validation/error.rs
+++ b/base_layer/core/src/validation/error.rs
@@ -67,6 +67,8 @@ pub enum ValidationError {
     ContainsDuplicateUtxoCommitment,
     #[error("Final state validation failed: The UTXO set did not balance with the expected emission at height {0}")]
     ChainBalanceValidationFailed(u64),
+    #[error("The total value + fees of the block exceeds the maximum allowance on chain")]
+    CoinbaseExceedsMaxLimit,
     #[error("Proof of work error: {0}")]
     ProofOfWorkError(#[from] PowError),
     #[error("Attempted to validate genesis block")]

--- a/base_layer/core/src/validation/helpers.rs
+++ b/base_layer/core/src/validation/helpers.rs
@@ -534,7 +534,7 @@ mod test {
 
             let body = AggregateBody::new(vec![], vec![coinbase_output], vec![coinbase_kernel]);
 
-            let reward = rules.calculate_coinbase_and_fees(height, body.kernels());
+            let reward = rules.calculate_coinbase_and_fees(height, body.kernels()).unwrap();
             let coinbase_lock_height = rules.consensus_constants(height).coinbase_min_maturity();
             body.check_coinbase_output(reward, coinbase_lock_height, &CryptoFactories::default(), height)
                 .unwrap();
@@ -553,7 +553,7 @@ mod test {
 
             let body = AggregateBody::new(vec![], vec![coinbase_output], vec![coinbase_kernel]);
 
-            let reward = rules.calculate_coinbase_and_fees(height, body.kernels());
+            let reward = rules.calculate_coinbase_and_fees(height, body.kernels()).unwrap();
             let coinbase_lock_height = rules.consensus_constants(height).coinbase_min_maturity();
 
             let err = body
@@ -574,7 +574,7 @@ mod test {
             let coinbase_kernel = test_helpers::create_coinbase_kernel(&coinbase.spending_key_id, &key_manager).await;
 
             let body = AggregateBody::new(vec![], vec![coinbase_output], vec![coinbase_kernel]);
-            let reward = rules.calculate_coinbase_and_fees(height, body.kernels());
+            let reward = rules.calculate_coinbase_and_fees(height, body.kernels()).unwrap();
             let coinbase_lock_height = rules.consensus_constants(height).coinbase_min_maturity();
 
             let err = body


### PR DESCRIPTION
Description
---
Use a `checked_addition` and catch errors when overflow occurs.

Motivation and Context
---
Block could be produced and shared that have coinbases and fees that are too high resulting in an overflow and node crash.

How Has This Been Tested?
---
CI

What process can a PR reviewer use to test or verify this change?
---
Mostly see if you like what's happening. In `base_node_grpc_server.rs` a fair bit of the new wrapping results in either getting the expected result or returning this specific problem and I'm not so sure it's the most generic way to recover.

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
