### PR TITLE
fix!: remove tari prefix and only allow one mergemining tag

### DIFF
--- a/base_layer/core/src/blocks/block_header.rs
+++ b/base_layer/core/src/blocks/block_header.rs
@@ -234,9 +234,10 @@ impl BlockHeader {
     }
 
     pub fn merge_mining_hash(&self) -> FixedHash {
-        let mut mining_hash = self.mining_hash();
-        mining_hash[0..4].copy_from_slice(b"TARI"); // Maybe put this in a `const`
-        mining_hash
+        // let mining_hash = self.mining_hash();
+        // At a later stage if we want to allow other coins to be merge mined, we can add a prefix
+        // mining_hash[0..4].copy_from_slice(b"TARI"); // Maybe put this in a `const`
+        self.mining_hash()
     }
 
     #[inline]

--- a/base_layer/core/src/proof_of_work/monero_rx/helpers.rs
+++ b/base_layer/core/src/proof_of_work/monero_rx/helpers.rs
@@ -552,10 +552,9 @@ mod test {
         };
         let hash = block_header.merge_mining_hash();
         append_merge_mining_tag(&mut block, hash).unwrap();
-        #[allow(clippy::redundant_clone)]
         let mut block_header2 = block_header.clone();
         block_header2.version = 1;
-        let hash2 = block_header.merge_mining_hash();
+        let hash2 = block_header2.merge_mining_hash();
         append_merge_mining_tag(&mut block, hash2).unwrap();
         let count = 1 + (u16::try_from(block.tx_hashes.len()).unwrap());
         let mut hashes = Vec::with_capacity(count as usize);
@@ -584,7 +583,7 @@ mod test {
         block_header.pow = pow;
         let err = verify_header(&block_header).unwrap_err();
         unpack_enum!(MergeMineError::ValidationError(details) = err);
-        assert!(details.contains("More than one Tari header found in coinbase"));
+        assert!(details.contains("More than one merge mining tag found in coinbase"));
     }
 
     #[test]

--- a/base_layer/core/src/proof_of_work/monero_rx/helpers.rs
+++ b/base_layer/core/src/proof_of_work/monero_rx/helpers.rs
@@ -83,9 +83,9 @@ pub fn verify_header(header: &BlockHeader) -> Result<MoneroPowData, MergeMineErr
     let mut is_found = false;
     for item in extra_field.0 {
         if let SubField::MergeMining(Some(depth), merge_mining_hash) = item {
-            if is_found && &merge_mining_hash.as_bytes()[0..4] == b"TARI" {
+            if is_found {
                 return Err(MergeMineError::ValidationError(
-                    "More than one Tari header found in coinbase".to_string(),
+                    "More than one merge mining tag found in coinbase".to_string(),
                 ));
             }
             if depth == VarInt(0) && merge_mining_hash.as_bytes() == expected_merge_mining_hash.as_slice() {

--- a/base_layer/core/src/proof_of_work/monero_rx/helpers.rs
+++ b/base_layer/core/src/proof_of_work/monero_rx/helpers.rs
@@ -81,13 +81,15 @@ pub fn verify_header(header: &BlockHeader) -> Result<MoneroPowData, MergeMineErr
     // and that only 1 tari header is found
 
     let mut is_found = false;
+    let mut already_seen_mmfield = false;
     for item in extra_field.0 {
         if let SubField::MergeMining(Some(depth), merge_mining_hash) = item {
-            if is_found {
+            if already_seen_mmfield {
                 return Err(MergeMineError::ValidationError(
                     "More than one merge mining tag found in coinbase".to_string(),
                 ));
             }
+            already_seen_mmfield = true;
             if depth == VarInt(0) && merge_mining_hash.as_bytes() == expected_merge_mining_hash.as_slice() {
                 is_found = true;
             }


### PR DESCRIPTION
Remove the merge mining tag. There can now only be one merge mining tag in a block

BREAKING CHANGE: Merge mining hash has changed