### PR TITLE
fix: horizon sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,25 +387,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bindgen"
-version = "0.59.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd2a9a458e8f4304c52c43ebb0cfbd520289f8379a52e329a38afda99bf8eb8"
-dependencies = [
- "bitflags 1.3.2",
- "cexpr",
- "clang-sys",
- "lazy_static",
- "lazycell",
- "peeking_take_while",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
-]
-
-[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -674,15 +655,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom 7.1.3",
-]
-
-[[package]]
 name = "cfb-mode"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -838,17 +810,6 @@ name = "circular"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fc239e0f6cb375d2402d48afb92f76f5404fd1df208a41930ec81eda078bea"
-
-[[package]]
-name = "clang-sys"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c688fc74432808e3eb684cae8830a86be1d66a2bd58e1f248ed0960a590baf6f"
-dependencies = [
- "glob",
- "libc",
- "libloading",
-]
 
 [[package]]
 name = "clap"
@@ -1173,24 +1134,21 @@ checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
 
 [[package]]
 name = "croaring"
-version = "0.5.2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aff1eea8a79ffa2a743c1322d5c3853d45699b7842197160c7c32a18c32c1866"
+checksum = "7539e9413f81db118bf258689110a9db0298c6089206817df2bd164fc7cd39e5"
 dependencies = [
  "byteorder",
  "croaring-sys",
- "libc",
 ]
 
 [[package]]
 name = "croaring-sys"
-version = "0.5.2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21d77e33a1d5e04573f79846692e72f2e02e0fdd942b90f023c45f146d3447db"
+checksum = "3e20dc23cebbac3da66d0eb2222341f6991ba779d96119f7bfa508f91784a495"
 dependencies = [
- "bindgen",
  "cc",
- "libc",
 ]
 
 [[package]]
@@ -2238,12 +2196,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "glob"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
-
-[[package]]
 name = "globset"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2746,12 +2698,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "libc"
 version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2776,16 +2722,6 @@ source = "git+https://github.com/tari-project/lmdb-rs?tag=0.7.6-tari.1#8d8893317
 dependencies = [
  "cc",
  "libc",
-]
-
-[[package]]
-name = "libloading"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
-dependencies = [
- "cfg-if",
- "winapi",
 ]
 
 [[package]]
@@ -3889,12 +3825,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
-name = "peeking_take_while"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
-
-[[package]]
 name = "peg"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4720,12 +4650,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
 name = "rustc-hex"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5133,12 +5057,6 @@ checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
 dependencies = [
  "lazy_static",
 ]
-
-[[package]]
-name = "shlex"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "signal-hook"

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -45,7 +45,7 @@ bytes = "0.5"
 chacha20poly1305 = "0.10.1"
 chrono = { version = "0.4.19", default-features = false, features = ["serde"] }
 criterion = { version = "0.4.0", optional = true  }
-croaring = { version = "0.5.2", optional = true }
+croaring = { version = "0.9", optional = true }
 decimal-rs = "0.1.42"
 derivative = "2.2.0"
 digest = "0.10"

--- a/base_layer/core/src/consensus/consensus_manager.rs
+++ b/base_layer/core/src/consensus/consensus_manager.rs
@@ -124,8 +124,8 @@ impl ConsensusManager {
         let constants = self.consensus_constants(height);
         let block_window = constants.difficulty_block_window();
 
-        let block_window_u = usize::try_from(block_window)
-            .map_err(|e| format!("difficulty block window exceeds usize::MAX: {}", e.to_string()))?;
+        let block_window_u =
+            usize::try_from(block_window).map_err(|e| format!("difficulty block window exceeds usize::MAX: {}", e))?;
 
         TargetDifficultyWindow::new(block_window_u, constants.pow_target_block_interval(pow_algo))
     }

--- a/base_layer/core/src/validation/aggregate_body/aggregate_body_internal_validator.rs
+++ b/base_layer/core/src/validation/aggregate_body/aggregate_body_internal_validator.rs
@@ -304,9 +304,7 @@ fn check_weight(
 ) -> Result<(), ValidationError> {
     let block_weight = body
         .calculate_weight(consensus_constants.transaction_weight_params())
-        .map_err(|e| {
-            ValidationError::SerializationError(format!("Unable to calculate body weight: {}", e.to_string()))
-        })?;
+        .map_err(|e| ValidationError::SerializationError(format!("Unable to calculate body weight: {}", e)))?;
     let max_weight = consensus_constants.max_block_transaction_weight();
     if block_weight <= max_weight {
         trace!(

--- a/base_layer/core/src/validation/helpers.rs
+++ b/base_layer/core/src/validation/helpers.rs
@@ -198,9 +198,9 @@ pub fn check_input_is_utxo<B: BlockchainBackend>(db: &B, input: &TransactionInpu
 
 /// Checks the byte size of TariScript is less than or equal to the given size, otherwise returns an error.
 pub fn check_tari_script_byte_size(script: &TariScript, max_script_size: usize) -> Result<(), ValidationError> {
-    let script_size = script.get_serialized_size().map_err(|e| {
-        ValidationError::SerializationError(format!("Failed to get serialized script size: {}", e.to_string()))
-    })?;
+    let script_size = script
+        .get_serialized_size()
+        .map_err(|e| ValidationError::SerializationError(format!("Failed to get serialized script size: {}", e)))?;
     if script_size > max_script_size {
         return Err(ValidationError::TariScriptExceedsMaxSize {
             max_script_size,

--- a/base_layer/core/src/validation/transaction/transaction_chain_validator.rs
+++ b/base_layer/core/src/validation/transaction/transaction_chain_validator.rs
@@ -48,15 +48,12 @@ impl<B: BlockchainBackend> TransactionValidator for TransactionChainLinkedValida
         if tx
             .calculate_weight(consensus_constants.transaction_weight_params())
             .map_err(|e| {
-                ValidationError::SerializationError(format!(
-                    "Unable to calculate the transaction weight: {}",
-                    e.to_string()
-                ))
+                ValidationError::SerializationError(format!("Unable to calculate the transaction weight: {}", e))
             })? >
             consensus_constants.max_block_weight_excluding_coinbase().map_err(|e| {
                 ValidationError::ConsensusError(format!(
                     "Unable to get max block weight from consensus constants: {}",
-                    e.to_string()
+                    e
                 ))
             })?
         {

--- a/base_layer/mmr/Cargo.toml
+++ b/base_layer/mmr/Cargo.toml
@@ -20,7 +20,7 @@ borsh = "0.10"
 digest = "0.10"
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
-croaring = { version = "0.5", optional = true }
+croaring = { version = "0.9", optional = true }
 
 [dev-dependencies]
 rand = "0.8"

--- a/base_layer/mmr/benches/smt_vs_mmr.rs
+++ b/base_layer/mmr/benches/smt_vs_mmr.rs
@@ -109,7 +109,7 @@ fn main() {
             insert_into_mmr(&keys, &mut mmr);
         });
         time_function("MMR: Calculating root hash", || {
-            let size = mmr.len();
+            let size = mmr.len().unwrap();
             let hash = mmr.get_merkle_root().unwrap();
             println!("Tree size: {size}. Root hash: {}", hash.to_hex());
         });
@@ -117,7 +117,7 @@ fn main() {
             delete_from_mmr(0, u32::try_from(half_size).unwrap(), &mut mmr);
         });
         time_function("MMR: Calculating root hash", || {
-            let size = mmr.len();
+            let size = mmr.len().unwrap();
             let hash = mmr.get_merkle_root().unwrap();
             println!("Tree size: {size}. Root hash: {}", hash.to_hex());
         });
@@ -129,7 +129,7 @@ fn main() {
             );
         });
         time_function("MMR: Calculating root hash", || {
-            let size = mmr.len();
+            let size = mmr.len().unwrap();
             let hash = mmr.get_merkle_root().unwrap();
             println!("Tree size: {size}. Root hash: {}", hash.to_hex());
         });

--- a/base_layer/mmr/src/mutable_mmr.rs
+++ b/base_layer/mmr/src/mutable_mmr.rs
@@ -212,11 +212,14 @@ where
     fn get_sub_bitmap(&self, leaf_index: LeafIndex, count: usize) -> Result<Bitmap, MerkleMountainRangeError> {
         let mut deleted = self.deleted.clone();
         if leaf_index.0 > 0 {
+            //Overflow not possible here as leaf_index.0 will always be greater than 0, min > 1-1=0
             deleted.remove_range(0..u32::try_from(leaf_index.0 - 1).map_err(|_|MerkleMountainRangeError::InvalidMmrSize)?)
         }
         let leaf_count = self.mmr.get_leaf_count()?;
         if leaf_count > 1 {
+            //Overflow not possible here as leaf_index.0 will always be greater than 0, min > 1+0-1=0
             let last_index = leaf_index.0 + count - 1;
+            //Overflow not possible here as leaf_count will always be greater than 0, min > 1-1=0
             if last_index < leaf_count - 1 {
                 deleted.remove_range(u32::try_from(last_index + 1).map_err(|_|MerkleMountainRangeError::InvalidMmrSize)?..u32::try_from(leaf_count).map_err(|_|MerkleMountainRangeError::InvalidMmrSize)?);
             }

--- a/base_layer/mmr/src/mutable_mmr.rs
+++ b/base_layer/mmr/src/mutable_mmr.rs
@@ -84,7 +84,9 @@ where
     /// deletion.
     #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> Result<u32,MerkleMountainRangeError> {
-        Ok(self.size - u32::try_from(self.deleted.cardinality()).map_err(|_|MerkleMountainRangeError::InvalidMmrSize)?)
+        let deleted_size = u32::try_from(self.deleted.cardinality()).map_err(|_|MerkleMountainRangeError::InvalidMmrSize)?;
+        let result = self.size.checked_sub(deleted_size).ok_or(MerkleMountainRangeError::InvalidMmrSize)?;
+        Ok(result )
     }
 
     /// Returns true if the the MMR contains no nodes, OR all nodes have been marked for deletion

--- a/base_layer/mmr/src/mutable_mmr.rs
+++ b/base_layer/mmr/src/mutable_mmr.rs
@@ -212,16 +212,16 @@ where
     fn get_sub_bitmap(&self, leaf_index: LeafIndex, count: usize) -> Result<Bitmap, MerkleMountainRangeError> {
         let mut deleted = self.deleted.clone();
         if leaf_index.0 > 0 {
-            //Overflow not possible here as leaf_index.0 will always be greater than 0, min > 1-1=0
-            deleted.remove_range(0..u32::try_from(leaf_index.0 - 1).map_err(|_|MerkleMountainRangeError::InvalidMmrSize)?)
+            let remove_range = leaf_index.0.checked_sub(1).ok_or(MerkleMountainRangeError::InvalidMmrSize)?;
+            deleted.remove_range(0..u32::try_from(remove_range).map_err(|_|MerkleMountainRangeError::InvalidMmrSize)?)
         }
         let leaf_count = self.mmr.get_leaf_count()?;
         if leaf_count > 1 {
-            //Overflow not possible here as leaf_index.0 will always be greater than 0, min > 1+0-1=0
-            let last_index = leaf_index.0 + count - 1;
+            let last_index = leaf_index.0.checked_add(count).ok_or(MerkleMountainRangeError::InvalidMmrSize)?.checked_sub(1).ok_or(MerkleMountainRangeError::InvalidMmrSize)?;
             //Overflow not possible here as leaf_count will always be greater than 0, min > 1-1=0
             if last_index < leaf_count - 1 {
-                deleted.remove_range(u32::try_from(last_index + 1).map_err(|_|MerkleMountainRangeError::InvalidMmrSize)?..u32::try_from(leaf_count).map_err(|_|MerkleMountainRangeError::InvalidMmrSize)?);
+                let remove_range = last_index.checked_add(1).ok_or(MerkleMountainRangeError::InvalidMmrSize)?;
+                deleted.remove_range(u32::try_from(remove_range).map_err(|_|MerkleMountainRangeError::InvalidMmrSize)?..u32::try_from(leaf_count).map_err(|_|MerkleMountainRangeError::InvalidMmrSize)?);
             }
         }
         Ok(deleted)

--- a/base_layer/mmr/tests/tests/mutable_mmr.rs
+++ b/base_layer/mmr/tests/tests/mutable_mmr.rs
@@ -42,7 +42,7 @@ fn hash_with_bitmap(hash: &HashSlice, bitmap: &mut Bitmap) -> Hash {
 #[test]
 fn zero_length_mmr() {
     let mmr = MutableTestMmr::new(Vec::default(), Bitmap::create()).unwrap();
-    assert_eq!(mmr.len(), 0);
+    assert_eq!(mmr.len().unwrap(), 0);
     assert_eq!(mmr.is_empty(), Ok(true));
     let empty_hash = MmrTestHasherBlake256::new().digest(b"").as_ref().to_vec();
     assert_eq!(
@@ -59,7 +59,7 @@ fn delete() {
     for i in 0..5 {
         assert!(mmr.push(int_to_hash(i)).is_ok());
     }
-    assert_eq!(mmr.len(), 5);
+    assert_eq!(mmr.len().unwrap(), 5);
     let root = mmr.get_merkle_root().unwrap();
     assert_eq!(
         &root.to_hex(),
@@ -67,7 +67,7 @@ fn delete() {
     );
     // Can't delete past bounds
     assert!(!mmr.delete(5));
-    assert_eq!(mmr.len(), 5);
+    assert_eq!(mmr.len().unwrap(), 5);
     assert_eq!(mmr.is_empty(), Ok(false));
     assert_eq!(mmr.get_merkle_root(), Ok(root));
     // Delete some nodes
@@ -80,7 +80,7 @@ fn delete() {
         &root.to_hex(),
         "9418eecd5f30ae1d892024e068c18013bb4f79f584c9aa5fdba818f9bd40da1e"
     );
-    assert_eq!(mmr.len(), 3);
+    assert_eq!(mmr.len().unwrap(), 3);
     assert_eq!(mmr.is_empty(), Ok(false));
     // Can't delete that which has already been deleted
     assert!(!mmr.delete(0,));
@@ -88,14 +88,14 @@ fn delete() {
     assert!(!mmr.delete(0,));
     // .. or beyond bounds of MMR
     assert!(!mmr.delete(9));
-    assert_eq!(mmr.len(), 3);
+    assert_eq!(mmr.len().unwrap(), 3);
     assert_eq!(mmr.is_empty(), Ok(false));
     // Merkle root should not have changed:
     assert_eq!(mmr.get_merkle_root(), Ok(root));
     assert!(mmr.delete(1));
     assert!(mmr.delete(5));
     assert!(mmr.delete(3));
-    assert_eq!(mmr.len(), 0);
+    assert_eq!(mmr.len().unwrap(), 0);
     assert_eq!(mmr.is_empty(), Ok(true));
     mmr.compress();
     let root = mmr.get_merkle_root().unwrap();
@@ -118,7 +118,7 @@ fn build_mmr() {
         assert!(mmr.push(int_to_hash(i)).is_ok());
     }
     // MutableMmr::len gives the size in terms of leaf nodes:
-    assert_eq!(mmr.len(), 5);
+    assert_eq!(mmr.len().unwrap(), 5);
     let mmr_root = mmr_check.get_merkle_root().unwrap();
     let root_check = hash_with_bitmap(&mmr_root, &mut bitmap);
     assert_eq!(mmr.get_merkle_root(), Ok(root_check));

--- a/comms/core/src/protocol/identity.rs
+++ b/comms/core/src/protocol/identity.rs
@@ -136,9 +136,9 @@ async fn write_protocol_frame<S: AsyncWrite + Unpin>(
     }
 
     let len = u16::try_from(msg_bytes.len()).map_err(|_| {
-        IdentityProtocolError::InvariantError(format!(
-            "This node attempted to send a message of size greater than u16::MAX"
-        ))
+        IdentityProtocolError::InvariantError(
+            "This node attempted to send a message of size greater than u16::MAX".to_string(),
+        )
     })?;
     let version_bytes = [version];
     let len_bytes = len.to_le_bytes();


### PR DESCRIPTION
Description
---
Fixes horizon sync
Run optimized needs to be forced with the correct mutability to ensure it runs from the correct optimized bitmap

Motivation and Context
---
MMR root failure occurs during sync as the optimized run fails in Merkle tree, this provides an already optimized bitmap to the merkle tree.

How Has This Been Tested?
---
Manual sync

