### PR TITLE
DNM feat: reset database after failed horizon sync

### DIFF
--- a/base_layer/core/src/base_node/state_machine_service/states/horizon_state_sync.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/horizon_state_sync.rs
@@ -130,6 +130,12 @@ impl HorizonStateSync {
                     randomx_vm_cnt,
                     randomx_vm_flags,
                 });
+                if let Err(e) = shared.db.reset_blockchain_databases().await {
+                    error!(
+                        target: LOG_TARGET,
+                        "Failed to reset chain to 0: {}", e
+                    );
+                };
                 warn!(target: LOG_TARGET, "Synchronizing horizon state has failed. {}", err);
                 StateEvent::HorizonStateSyncFailure
             },

--- a/base_layer/core/src/chain_storage/async_db.rs
+++ b/base_layer/core/src/chain_storage/async_db.rs
@@ -249,6 +249,8 @@ impl<B: BlockchainBackend + 'static> AsyncBlockchainDb<B> {
 
     make_async_fn!(rewind_to_height(height: u64) -> Vec<Arc<ChainBlock>>, "rewind_to_height");
 
+    make_async_fn!(reset_blockchain_databases() -> (), "reset_blockchain_databases");
+
     make_async_fn!(rewind_to_hash(hash: BlockHash) -> Vec<Arc<ChainBlock>>, "rewind_to_hash");
 
     make_async_fn!(fetch_block_timestamps(start_hash: HashOutput) -> RollingVec<EpochTime>, "fetch_block_timestamps");

--- a/base_layer/core/src/chain_storage/blockchain_backend.rs
+++ b/base_layer/core/src/chain_storage/blockchain_backend.rs
@@ -203,5 +203,5 @@ pub trait BlockchainBackend: Send + Sync {
 
     /// This will delete and clear out all databases except the list of bad_blocks. This is used when horizon sync
     /// fails, and we need to reset the blockchain to tip 0 again
-    fn reset_blockchain_databases(&mut self) -> Result<(), ChainStorageError>;
+    fn clear_blockchain_databases(&mut self) -> Result<(), ChainStorageError>;
 }

--- a/base_layer/core/src/chain_storage/blockchain_backend.rs
+++ b/base_layer/core/src/chain_storage/blockchain_backend.rs
@@ -200,4 +200,8 @@ pub trait BlockchainBackend: Send + Sync {
         start_height: u64,
         end_height: u64,
     ) -> Result<Vec<TemplateRegistrationEntry>, ChainStorageError>;
+
+    /// This will delete and clear out all databases except the list of bad_blocks. This is used when horizon sync
+    /// fails, and we need to reset the blockchain to tip 0 again
+    fn reset_blockchain_databases(&mut self) -> Result<(), ChainStorageError>;
 }

--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -1120,10 +1120,10 @@ where B: BlockchainBackend
         clear_blockchain_databases(&mut *db)?;
         // lets add in the gen block again
         info!(
-        target: LOG_TARGET,
-        "Cleared DB. Adding genesis block back in {}.",
-        genesis_block.block().body.to_counts_string()
-    );
+            target: LOG_TARGET,
+            "Cleared DB. Adding genesis block back in {}.",
+            genesis_block.block().body.to_counts_string()
+        );
         insert_gen_block(&mut *db, self.config.pruning_horizon, genesis_block)
     }
 
@@ -1882,9 +1882,7 @@ fn rewind_to_height<T: BlockchainBackend>(db: &mut T, height: u64) -> Result<Vec
     Ok(removed_blocks)
 }
 
-fn clear_blockchain_databases<T: BlockchainBackend>(
-    db: &mut T,
-) -> Result<(), ChainStorageError> {
+fn clear_blockchain_databases<T: BlockchainBackend>(db: &mut T) -> Result<(), ChainStorageError> {
     db.clear_blockchain_databases()?;
     Ok(())
 }
@@ -1894,7 +1892,6 @@ fn insert_gen_block<T: BlockchainBackend>(
     pruning_horizon: u64,
     genesis_block: Arc<ChainBlock>,
 ) -> Result<(), ChainStorageError> {
-
     let mut txn = DbTransaction::new();
     insert_best_block(&mut txn, genesis_block.clone())?;
     let body = &genesis_block.block().body;

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -2497,11 +2497,17 @@ impl BlockchainBackend for LMDBDatabase {
 
         for (name, db) in self.all_dbs() {
             debug!(target: LOG_TARGET, "Clearing database '{}'", name);
-            lmdb_clear(&write_txn, &db)?;
+            // we dont want to rest bad blocks only data
+            match name {
+                "bad_blocks" => {},
+                _ => {
+                    lmdb_clear(&write_txn, &db)?;
+                },
+            }
         }
-        
+
         write_txn.commit()?;
-       
+
         Ok(())
     }
 }

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -2491,6 +2491,38 @@ impl BlockchainBackend for LMDBDatabase {
         }
         Ok(result)
     }
+
+    fn reset_blockchain_databases(&mut self) -> Result<(), ChainStorageError> {
+        let write_txn = self.write_transaction()?;
+
+        lmdb_clear(&write_txn, &self.metadata_db)?;
+        lmdb_clear(&write_txn, &self.headers_db)?;
+        lmdb_clear(&write_txn, &self.header_accumulated_data_db)?;
+        lmdb_clear(&write_txn, &self.block_accumulated_data_db)?;
+        lmdb_clear(&write_txn, &self.block_hashes_db)?;
+        lmdb_clear(&write_txn, &self.utxos_db)?;
+        lmdb_clear(&write_txn, &self.inputs_db)?;
+        lmdb_clear(&write_txn, &self.txos_hash_to_index_db)?;
+        lmdb_clear(&write_txn, &self.kernels_db)?;
+        lmdb_clear(&write_txn, &self.kernel_excess_index)?;
+        lmdb_clear(&write_txn, &self.kernel_excess_sig_index)?;
+        lmdb_clear(&write_txn, &self.kernel_mmr_size_index)?;
+        lmdb_clear(&write_txn, &self.output_mmr_size_index)?;
+        lmdb_clear(&write_txn, &self.utxo_commitment_index)?;
+        lmdb_clear(&write_txn, &self.unique_id_index)?;
+        lmdb_clear(&write_txn, &self.contract_index)?;
+        lmdb_clear(&write_txn, &self.deleted_txo_mmr_position_to_height_index)?;
+        lmdb_clear(&write_txn, &self.orphans_db)?;
+        lmdb_clear(&write_txn, &self.monero_seed_height_db)?;
+        lmdb_clear(&write_txn, &self.orphan_header_accumulated_data_db)?;
+        lmdb_clear(&write_txn, &self.orphan_chain_tips_db)?;
+        lmdb_clear(&write_txn, &self.orphan_parent_map_index)?;
+        lmdb_clear(&write_txn, &self.reorgs)?;
+        lmdb_clear(&write_txn, &self.validator_nodes)?;
+        lmdb_clear(&write_txn, &self.validator_nodes_mapping)?;
+        lmdb_clear(&write_txn, &self.template_registrations)?;
+        Ok(())
+    }
 }
 
 // Fetch the chain metadata

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -2495,32 +2495,13 @@ impl BlockchainBackend for LMDBDatabase {
     fn reset_blockchain_databases(&mut self) -> Result<(), ChainStorageError> {
         let write_txn = self.write_transaction()?;
 
-        lmdb_clear(&write_txn, &self.metadata_db)?;
-        lmdb_clear(&write_txn, &self.headers_db)?;
-        lmdb_clear(&write_txn, &self.header_accumulated_data_db)?;
-        lmdb_clear(&write_txn, &self.block_accumulated_data_db)?;
-        lmdb_clear(&write_txn, &self.block_hashes_db)?;
-        lmdb_clear(&write_txn, &self.utxos_db)?;
-        lmdb_clear(&write_txn, &self.inputs_db)?;
-        lmdb_clear(&write_txn, &self.txos_hash_to_index_db)?;
-        lmdb_clear(&write_txn, &self.kernels_db)?;
-        lmdb_clear(&write_txn, &self.kernel_excess_index)?;
-        lmdb_clear(&write_txn, &self.kernel_excess_sig_index)?;
-        lmdb_clear(&write_txn, &self.kernel_mmr_size_index)?;
-        lmdb_clear(&write_txn, &self.output_mmr_size_index)?;
-        lmdb_clear(&write_txn, &self.utxo_commitment_index)?;
-        lmdb_clear(&write_txn, &self.unique_id_index)?;
-        lmdb_clear(&write_txn, &self.contract_index)?;
-        lmdb_clear(&write_txn, &self.deleted_txo_mmr_position_to_height_index)?;
-        lmdb_clear(&write_txn, &self.orphans_db)?;
-        lmdb_clear(&write_txn, &self.monero_seed_height_db)?;
-        lmdb_clear(&write_txn, &self.orphan_header_accumulated_data_db)?;
-        lmdb_clear(&write_txn, &self.orphan_chain_tips_db)?;
-        lmdb_clear(&write_txn, &self.orphan_parent_map_index)?;
-        lmdb_clear(&write_txn, &self.reorgs)?;
-        lmdb_clear(&write_txn, &self.validator_nodes)?;
-        lmdb_clear(&write_txn, &self.validator_nodes_mapping)?;
-        lmdb_clear(&write_txn, &self.template_registrations)?;
+        for (name, db) in self.all_dbs() {
+            debug!(target: LOG_TARGET, "Clearing database '{}'", name);
+            lmdb_clear(&write_txn, &db)?;
+        }
+        
+        write_txn.commit()?;
+       
         Ok(())
     }
 }

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -2492,7 +2492,7 @@ impl BlockchainBackend for LMDBDatabase {
         Ok(result)
     }
 
-    fn reset_blockchain_databases(&mut self) -> Result<(), ChainStorageError> {
+    fn clear_blockchain_databases(&mut self) -> Result<(), ChainStorageError> {
         let write_txn = self.write_transaction()?;
 
         for (name, db) in self.all_dbs() {

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -2497,7 +2497,7 @@ impl BlockchainBackend for LMDBDatabase {
 
         for (name, db) in self.all_dbs() {
             debug!(target: LOG_TARGET, "Clearing database '{}'", name);
-            // we dont want to rest bad blocks only data
+            // we don't want to reset bad blocks only data
             match name {
                 "bad_blocks" => {},
                 _ => {

--- a/base_layer/core/src/test_helpers/blockchain.rs
+++ b/base_layer/core/src/test_helpers/blockchain.rs
@@ -432,6 +432,10 @@ impl BlockchainBackend for TempDatabase {
             .unwrap()
             .fetch_template_registrations(start_height, end_height)
     }
+
+    fn reset_blockchain_databases(&mut self) -> Result<(), ChainStorageError> {
+        self.db.as_mut().unwrap().reset_blockchain_databases()
+    }
 }
 
 pub async fn create_chained_blocks<T: Into<BlockSpecs>>(

--- a/base_layer/core/src/test_helpers/blockchain.rs
+++ b/base_layer/core/src/test_helpers/blockchain.rs
@@ -433,8 +433,8 @@ impl BlockchainBackend for TempDatabase {
             .fetch_template_registrations(start_height, end_height)
     }
 
-    fn reset_blockchain_databases(&mut self) -> Result<(), ChainStorageError> {
-        self.db.as_mut().unwrap().reset_blockchain_databases()
+    fn clear_blockchain_databases(&mut self) -> Result<(), ChainStorageError> {
+        self.db.as_mut().unwrap().clear_blockchain_databases()
     }
 }
 


### PR DESCRIPTION
Description
---
This will clear out the entire database after horizon sync fails. 

Motivation and Context
---

When horizon sync fails, we know that the database is in an inconsistent state. The safest way to do this is clear out the entire database and start over from genesis block. 

Discussion issue: #5771 