### PR TITLE
fix(comms): greatly reduce timeouts for first byte and noise handshake

### DIFF
--- a/comms/core/src/builder/comms_node.rs
+++ b/comms/core/src/builder/comms_node.rs
@@ -43,7 +43,6 @@ use crate::{
     },
     connectivity::{ConnectivityEventRx, ConnectivityManager, ConnectivityRequest, ConnectivityRequester},
     multiaddr::Multiaddr,
-    noise::NoiseConfig,
     peer_manager::{NodeIdentity, PeerManager},
     protocol::{
         ProtocolExtension,
@@ -188,12 +187,9 @@ impl UnspawnedCommsNode {
 
         //---------------------------------- Connection Manager --------------------------------------------//
 
-        let noise_config = NoiseConfig::new(node_identity.clone());
-
         let mut connection_manager = ConnectionManager::new(
             connection_manager_config.clone(),
             transport.clone(),
-            noise_config,
             dial_backoff,
             connection_manager_request_rx,
             node_identity.clone(),

--- a/comms/core/src/connection_manager/dialer.rs
+++ b/comms/core/src/connection_manager/dialer.rs
@@ -20,11 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{
-    collections::HashMap,
-    sync::Arc,
-    time::{Duration, Instant},
-};
+use std::{collections::HashMap, sync::Arc, time::Instant};
 
 use futures::{
     future,
@@ -593,12 +589,9 @@ where
                     .await
                     .map_err(|_| ConnectionManagerError::WireFormatSendFailed)?;
 
-                let noise_socket = time::timeout(
-                    Duration::from_secs(40),
-                    noise_config.upgrade_socket(socket, ConnectionDirection::Outbound),
-                )
-                .await
-                .map_err(|_| ConnectionManagerError::NoiseProtocolTimeout)??;
+                let noise_socket = noise_config
+                    .upgrade_socket(socket, ConnectionDirection::Outbound)
+                    .await?;
 
                 let noise_upgrade_time = timer.elapsed();
                 debug!(

--- a/comms/core/src/connection_manager/error.rs
+++ b/comms/core/src/connection_manager/error.rs
@@ -78,8 +78,6 @@ pub enum ConnectionManagerError {
     InvalidMultiaddr(String),
     #[error("Failed to send wire format byte")]
     WireFormatSendFailed,
-    #[error("Noise protocol handshake timed out")]
-    NoiseProtocolTimeout,
     #[error("Listener oneshot cancelled")]
     ListenerOneshotCancelled,
     #[error("Peer validation error: {0}")]

--- a/comms/core/src/connection_manager/listener.rs
+++ b/comms/core/src/connection_manager/listener.rs
@@ -351,12 +351,7 @@ where
         );
 
         let timer = Instant::now();
-        let mut noise_socket = time::timeout(
-            Duration::from_secs(30),
-            noise_config.upgrade_socket(socket, CONNECTION_DIRECTION),
-        )
-        .await
-        .map_err(|_| ConnectionManagerError::NoiseProtocolTimeout)??;
+        let mut noise_socket = noise_config.upgrade_socket(socket, CONNECTION_DIRECTION).await?;
 
         let authenticated_public_key = noise_socket
             .get_remote_public_key()

--- a/comms/core/src/connection_manager/tests/manager.rs
+++ b/comms/core/src/connection_manager/tests/manager.rs
@@ -34,14 +34,12 @@ use tokio::{
 use crate::{
     backoff::ConstantBackoff,
     connection_manager::{
-        error::ConnectionManagerError,
-        manager::ConnectionManagerEvent,
         ConnectionManager,
+        ConnectionManagerError,
+        ConnectionManagerEvent,
         ConnectionManagerRequester,
-        PeerConnectionError,
     },
     net_address::{MultiaddressesWithStats, PeerAddressSource},
-    noise::NoiseConfig,
     peer_manager::{NodeId, Peer, PeerFeatures, PeerFlags, PeerManagerError},
     protocol::{ProtocolEvent, ProtocolId, Protocols},
     test_utils::{
@@ -51,13 +49,13 @@ use crate::{
         test_node::{build_connection_manager, TestNodeConfig},
     },
     transports::{MemoryTransport, TcpTransport},
+    PeerConnectionError,
 };
 
 #[tokio::test]
 async fn connect_to_nonexistent_peer() {
     let rt_handle = Handle::current();
     let node_identity = build_node_identity(PeerFeatures::empty());
-    let noise_config = NoiseConfig::new(node_identity.clone());
     let (request_tx, request_rx) = mpsc::channel(1);
     let (event_tx, _) = broadcast::channel(1);
     let mut requester = ConnectionManagerRequester::new(request_tx, event_tx.clone());
@@ -68,7 +66,6 @@ async fn connect_to_nonexistent_peer() {
     let connection_manager = ConnectionManager::new(
         Default::default(),
         MemoryTransport,
-        noise_config,
         ConstantBackoff::new(Duration::from_secs(1)),
         request_rx,
         node_identity,
@@ -80,8 +77,7 @@ async fn connect_to_nonexistent_peer() {
     rt_handle.spawn(connection_manager.run());
 
     let err = requester.dial_peer(NodeId::default()).await.unwrap_err();
-    unpack_enum!(ConnectionManagerError::PeerManagerError(err) = err);
-    unpack_enum!(PeerManagerError::PeerNotFoundError = err);
+    unpack_enum!(ConnectionManagerError::PeerManagerError(PeerManagerError::PeerNotFoundError) = err);
 
     shutdown.trigger();
 }

--- a/comms/core/src/test_utils/test_node.rs
+++ b/comms/core/src/test_utils/test_node.rs
@@ -33,7 +33,6 @@ use crate::{
     backoff::ConstantBackoff,
     connection_manager::{ConnectionManager, ConnectionManagerConfig, ConnectionManagerRequester},
     multiplexing::Substream,
-    noise::NoiseConfig,
     peer_manager::{NodeIdentity, PeerFeatures, PeerManager},
     peer_validator::PeerValidatorConfig,
     protocol::Protocols,
@@ -81,7 +80,6 @@ where
     TTransport: Transport + Unpin + Send + Sync + Clone + 'static,
     TTransport::Output: AsyncRead + AsyncWrite + Send + Sync + Unpin + 'static,
 {
-    let noise_config = NoiseConfig::new(config.node_identity.clone());
     let (request_tx, request_rx) = mpsc::channel(10);
     let (event_tx, _) = broadcast::channel(100);
 
@@ -90,7 +88,6 @@ where
     let mut connection_manager = ConnectionManager::new(
         config.connection_manager_config,
         transport,
-        noise_config,
         ConstantBackoff::new(config.dial_backoff_duration),
         request_rx,
         config.node_identity,


### PR DESCRIPTION
Description
---
Reduce time to first byte timeout from 45s to 3s
Remove noise protocol timeout
Add timeout for receiving noise handshake replies

Motivation and Context
---
Time to first byte should be short to prevent a malicious connection from holding many open for long periods.

The "global" noise handshake timeout was excessively long (40s), this is replaced with a timeout on the receive calls inside
the  NoiseSocket. This means that the responder in the XX handshake will wait for up to 6s (2 x receives) while the initiator will wait for 3s (1 receive). This should be more robust and reflect that the wait time for a responder is generally larger than for the initiator. 

How Has This Been Tested?
---
Existing tests, manually

What process can a PR reviewer use to test or verify this change?
---
Connections work!
<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
