### PR TITLE
fix(comms): only permit a single inbound messaging substream per peer

### DIFF
--- a/base_layer/core/tests/tests/node_service.rs
+++ b/base_layer/core/tests/tests/node_service.rs
@@ -308,13 +308,13 @@ async fn propagate_and_forward_invalid_block_hash() {
     let msg_event = event_stream_next(&mut bob_message_events, Duration::from_secs(10))
         .await
         .unwrap();
-    unpack_enum!(MessagingEvent::MessageReceived(_a, _b) = &*msg_event);
+    unpack_enum!(MessagingEvent::MessageReceived(_a, _b) = &msg_event);
 
     // Bob asks Alice for missing transaction
     let msg_event = event_stream_next(&mut bob_message_events, Duration::from_secs(10))
         .await
         .unwrap();
-    unpack_enum!(MessagingEvent::MessageReceived(node_id, _a) = &*msg_event);
+    unpack_enum!(MessagingEvent::MessageReceived(node_id, _a) = &msg_event);
     assert_eq!(node_id, alice_node.node_identity.node_id());
 
     // Checking a negative: Bob should not have propagated this hash to Carol. If Bob does, this assertion will be

--- a/base_layer/p2p/src/initialization.rs
+++ b/base_layer/p2p/src/initialization.rs
@@ -198,7 +198,9 @@ pub async fn initialize_local_test_comms<P: AsRef<Path>>(
         .build();
 
     let comms = comms
-        .add_protocol_extension(MessagingProtocolExtension::new(event_sender.clone(), pipeline))
+        .add_protocol_extension(
+            MessagingProtocolExtension::new(event_sender.clone(), pipeline).enable_message_received_event(),
+        )
         .spawn_with_transport(MemoryTransport)
         .await?;
 

--- a/base_layer/p2p/src/initialization.rs
+++ b/base_layer/p2p/src/initialization.rs
@@ -373,10 +373,10 @@ async fn configure_comms_and_dht(
         .build();
 
     let (messaging_events_sender, _) = broadcast::channel(1);
-    comms = comms.add_protocol_extension(MessagingProtocolExtension::new(
-        messaging_events_sender,
-        messaging_pipeline,
-    ));
+    comms = comms.add_protocol_extension(
+        MessagingProtocolExtension::new(messaging_events_sender, messaging_pipeline)
+            .with_ban_duration(config.dht.ban_duration_short),
+    );
 
     Ok((comms, dht))
 }

--- a/comms/core/src/builder/tests.rs
+++ b/comms/core/src/builder/tests.rs
@@ -89,16 +89,19 @@ async fn spawn_node(
     let (messaging_events_sender, _) = broadcast::channel(100);
     let comms_node = comms_node
         .add_protocol_extensions(protocols.into())
-        .add_protocol_extension(MessagingProtocolExtension::new(
-            messaging_events_sender.clone(),
-            pipeline::Builder::new()
+        .add_protocol_extension(
+            MessagingProtocolExtension::new(
+                messaging_events_sender.clone(),
+                pipeline::Builder::new()
                 // Outbound messages will be forwarded "as is" to outbound messaging
                 .with_outbound_pipeline(outbound_rx, identity)
                 .max_concurrent_inbound_tasks(1)
                 // Inbound messages will be forwarded "as is" to inbound_tx
                 .with_inbound_pipeline(SinkService::new(inbound_tx))
                 .build(),
-        ))
+            )
+            .enable_message_received_event(),
+        )
         .spawn_with_transport(MemoryTransport)
         .await
         .unwrap();
@@ -251,7 +254,7 @@ async fn peer_to_peer_messaging() {
 
     let events = collect_recv!(messaging_events2, take = NUM_MSGS, timeout = Duration::from_secs(10));
     events.into_iter().for_each(|m| {
-        unpack_enum!(MessagingEvent::MessageReceived(_n, _t) = &*m);
+        unpack_enum!(MessagingEvent::MessageReceived(_n, _t) = &m);
     });
 
     // Send NUM_MSGS messages from node 2 to node 1

--- a/comms/core/src/protocol/messaging/inbound.rs
+++ b/comms/core/src/protocol/messaging/inbound.rs
@@ -20,8 +20,6 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::sync::Arc;
-
 use futures::StreamExt;
 use log::*;
 use tokio::{
@@ -38,19 +36,22 @@ const LOG_TARGET: &str = "comms::protocol::messaging::inbound";
 pub struct InboundMessaging {
     peer: NodeId,
     inbound_message_tx: mpsc::Sender<InboundMessage>,
-    messaging_events_tx: broadcast::Sender<Arc<MessagingEvent>>,
+    messaging_events_tx: broadcast::Sender<MessagingEvent>,
+    enable_message_received_event: bool,
 }
 
 impl InboundMessaging {
     pub fn new(
         peer: NodeId,
         inbound_message_tx: mpsc::Sender<InboundMessage>,
-        messaging_events_tx: broadcast::Sender<Arc<MessagingEvent>>,
+        messaging_events_tx: broadcast::Sender<MessagingEvent>,
+        enable_message_received_event: bool,
     ) -> Self {
         Self {
             peer,
             inbound_message_tx,
             messaging_events_tx,
+            enable_message_received_event,
         }
     }
 
@@ -83,21 +84,24 @@ impl InboundMessaging {
                         msg_len
                     );
 
-                    let event = MessagingEvent::MessageReceived(inbound_msg.source_peer.clone(), inbound_msg.tag);
+                    let message_tag = inbound_msg.tag;
 
-                    if let Err(err) = self.inbound_message_tx.send(inbound_msg).await {
-                        let tag = err.0.tag;
+                    if self.inbound_message_tx.send(inbound_msg).await.is_err() {
                         warn!(
                             target: LOG_TARGET,
                             "Failed to send InboundMessage {} for peer '{}' because inbound message channel closed",
-                            tag,
+                            message_tag,
                             peer.short_str(),
                         );
 
                         break;
                     }
 
-                    let _result = self.messaging_events_tx.send(Arc::new(event));
+                    if self.enable_message_received_event {
+                        let _result = self
+                            .messaging_events_tx
+                            .send(MessagingEvent::MessageReceived(peer.clone(), message_tag));
+                    }
                 },
                 Err(err) => {
                     metrics::error_count(peer).inc();
@@ -112,6 +116,9 @@ impl InboundMessaging {
             }
         }
 
+        let _ignore = self
+            .messaging_events_tx
+            .send(MessagingEvent::InboundProtocolExited(peer.clone()));
         metrics::num_sessions().dec();
         debug!(
             target: LOG_TARGET,

--- a/comms/core/src/protocol/messaging/mod.rs
+++ b/comms/core/src/protocol/messaging/mod.rs
@@ -37,7 +37,14 @@ mod inbound;
 mod metrics;
 mod outbound;
 mod protocol;
-pub use protocol::{MessagingEvent, MessagingEventReceiver, MessagingEventSender, MessagingProtocol, SendFailReason};
+pub use protocol::{
+    MessagingEvent,
+    MessagingEventReceiver,
+    MessagingEventSender,
+    MessagingProtocol,
+    SendFailReason,
+    MESSAGING_PROTOCOL_ID,
+};
 
 #[cfg(test)]
 mod test;

--- a/comms/core/src/protocol/messaging/outbound.rs
+++ b/comms/core/src/protocol/messaging/outbound.rs
@@ -33,7 +33,7 @@ use crate::{
     message::OutboundMessage,
     multiplexing::Substream,
     peer_manager::NodeId,
-    protocol::messaging::protocol::MESSAGING_PROTOCOL,
+    protocol::messaging::protocol::MESSAGING_PROTOCOL_ID,
     stream_id::StreamId,
 };
 
@@ -223,7 +223,7 @@ impl OutboundMessaging {
         &mut self,
         conn: &mut PeerConnection,
     ) -> Result<NegotiatedSubstream<Substream>, MessagingProtocolError> {
-        match conn.open_substream(&MESSAGING_PROTOCOL).await {
+        match conn.open_substream(&MESSAGING_PROTOCOL_ID).await {
             Ok(substream) => Ok(substream),
             Err(err) => {
                 debug!(

--- a/comms/core/src/protocol/messaging/outbound.rs
+++ b/comms/core/src/protocol/messaging/outbound.rs
@@ -123,7 +123,7 @@ impl OutboundMessaging {
             }
 
             metrics::num_sessions().dec();
-            let _ = messaging_events_tx
+            let _ignore = messaging_events_tx
                 .send(MessagingEvent::OutboundProtocolExited(peer_node_id))
                 .await;
         }

--- a/comms/core/src/protocol/messaging/test.rs
+++ b/comms/core/src/protocol/messaging/test.rs
@@ -33,7 +33,7 @@ use tokio::{
     time,
 };
 
-use super::protocol::{MessagingEvent, MessagingEventReceiver, MessagingProtocol, MESSAGING_PROTOCOL};
+use super::protocol::{MessagingEvent, MessagingEventReceiver, MessagingProtocol, MESSAGING_PROTOCOL_ID};
 use crate::{
     message::{InboundMessage, MessageTag, MessagingReplyRx, OutboundMessage},
     multiplexing::Substream,
@@ -81,7 +81,8 @@ async fn spawn_messaging_protocol() -> (
         events_tx,
         inbound_msg_tx,
         shutdown.to_signal(),
-    );
+    )
+    .set_message_received_event_enabled(true);
     tokio::spawn(msg_proto.run());
 
     (
@@ -123,7 +124,7 @@ async fn new_inbound_substream_handling() {
     let stream_ours = muxer_ours.get_yamux_control().open_stream().await.unwrap();
     proto_tx
         .send(ProtocolNotification::new(
-            MESSAGING_PROTOCOL.clone(),
+            MESSAGING_PROTOCOL_ID.clone(),
             ProtocolEvent::NewInboundSubstream(expected_node_id.clone(), stream_ours),
         ))
         .await
@@ -146,7 +147,7 @@ async fn new_inbound_substream_handling() {
         .await
         .unwrap()
         .unwrap();
-    unpack_enum!(MessagingEvent::MessageReceived(node_id, tag) = &*event);
+    unpack_enum!(MessagingEvent::MessageReceived(node_id, tag) = &event);
     assert_eq!(tag, &expected_tag);
     assert_eq!(*node_id, expected_node_id);
 }
@@ -188,7 +189,7 @@ async fn send_message_dial_failed() {
     request_tx.send(out_msg).unwrap();
 
     let event = event_tx.recv().await.unwrap();
-    unpack_enum!(MessagingEvent::OutboundProtocolExited(_node_id) = &*event);
+    unpack_enum!(MessagingEvent::OutboundProtocolExited(_node_id) = &event);
     let reply = reply_rx.await.unwrap().unwrap_err();
     unpack_enum!(SendFailReason::PeerDialFailed = reply);
 
@@ -260,7 +261,7 @@ async fn send_message_substream_bulk_failure() {
         .await
         .unwrap()
         .unwrap();
-    unpack_enum!(MessagingEvent::OutboundProtocolExited(node_id) = &*event);
+    unpack_enum!(MessagingEvent::OutboundProtocolExited(node_id) = &event);
     assert_eq!(node_id, peer_node_id);
 }
 
@@ -338,4 +339,94 @@ async fn many_concurrent_send_message_requests_that_fail() {
     let unordered = reply_rxs.into_iter().collect::<FuturesUnordered<_>>();
     let results = unordered.collect::<Vec<_>>().await;
     assert!(results.into_iter().map(|r| r.unwrap()).all(|r| r.is_err()));
+}
+
+#[tokio::test]
+async fn new_inbound_substream_only_single_session_permitted() {
+    let (peer_manager, _, _, proto_tx, _, mut inbound_msg_rx, _, _shutdown) = spawn_messaging_protocol().await;
+
+    let expected_node_id = node_id::random();
+    let (_, pk) = CommsPublicKey::random_keypair(&mut OsRng);
+    peer_manager
+        .add_peer(Peer::new(
+            pk.clone(),
+            expected_node_id.clone(),
+            MultiaddressesWithStats::default(),
+            PeerFlags::empty(),
+            PeerFeatures::COMMUNICATION_CLIENT,
+            Default::default(),
+            Default::default(),
+        ))
+        .await
+        .unwrap();
+
+    // Create connected memory sockets - we use each end of the connection as if they exist on different nodes
+    let (_, muxer_ours, mut muxer_theirs) = transport::build_multiplexed_connections().await;
+
+    // Notify the messaging protocol that a new substream has been established that wants to talk the messaging.
+    let stream_ours = muxer_ours.get_yamux_control().open_stream().await.unwrap();
+    proto_tx
+        .send(ProtocolNotification::new(
+            MESSAGING_PROTOCOL_ID.clone(),
+            ProtocolEvent::NewInboundSubstream(expected_node_id.clone(), stream_ours),
+        ))
+        .await
+        .unwrap();
+
+    // First stream is open
+    let stream_theirs = muxer_theirs.incoming_mut().next().await.unwrap();
+
+    // Open another one for messaging
+    let stream_ours2 = muxer_ours.get_yamux_control().open_stream().await.unwrap();
+    proto_tx
+        .send(ProtocolNotification::new(
+            MESSAGING_PROTOCOL_ID.clone(),
+            ProtocolEvent::NewInboundSubstream(expected_node_id.clone(), stream_ours2),
+        ))
+        .await
+        .unwrap();
+
+    // Check the second stream closes immediately
+    let stream_theirs2 = muxer_theirs.incoming_mut().next().await.unwrap();
+    let mut framed_ours2 = MessagingProtocol::framed(stream_theirs2);
+    let next = framed_ours2.next().await;
+    // The stream is closed
+    assert!(next.is_none());
+
+    // The first stream is still active
+    let mut framed_theirs = MessagingProtocol::framed(stream_theirs);
+
+    framed_theirs.send(TEST_MSG1.clone()).await.unwrap();
+
+    let in_msg = time::timeout(Duration::from_secs(5), inbound_msg_rx.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(in_msg.source_peer, expected_node_id);
+    assert_eq!(in_msg.body, TEST_MSG1);
+
+    // Close the first
+    framed_theirs.close().await.unwrap();
+
+    // Open another one for messaging
+    let stream_ours2 = muxer_ours.get_yamux_control().open_stream().await.unwrap();
+    proto_tx
+        .send(ProtocolNotification::new(
+            MESSAGING_PROTOCOL_ID.clone(),
+            ProtocolEvent::NewInboundSubstream(expected_node_id.clone(), stream_ours2),
+        ))
+        .await
+        .unwrap();
+
+    let stream_theirs = muxer_theirs.incoming_mut().next().await.unwrap();
+    let mut framed_theirs = MessagingProtocol::framed(stream_theirs);
+    framed_theirs.send(TEST_MSG1.clone()).await.unwrap();
+
+    // The second message comes through
+    let in_msg = time::timeout(Duration::from_secs(5), inbound_msg_rx.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(in_msg.source_peer, expected_node_id);
+    assert_eq!(in_msg.body, TEST_MSG1);
 }

--- a/comms/dht/src/peer_validator.rs
+++ b/comms/dht/src/peer_validator.rs
@@ -26,6 +26,7 @@ use tari_comms::{
     peer_manager::{NodeId, Peer, PeerFlags},
     peer_validator,
     peer_validator::{find_most_recent_claim, PeerValidatorError},
+    protocol::messaging::MESSAGING_PROTOCOL_ID,
 };
 
 use crate::{rpc::UnvalidatedPeerInfo, DhtConfig};
@@ -89,13 +90,16 @@ impl<'a> PeerValidator<'a> {
         let node_id = NodeId::from_public_key(&new_peer.public_key);
 
         let mut peer = existing_peer.unwrap_or_else(|| {
+            // All peer speak messaging protocol, as an optimisation we'll include it here so that we can do optimistic
+            // protocol negotiation.
+            let default_protocols = vec![MESSAGING_PROTOCOL_ID.clone()];
             Peer::new(
                 new_peer.public_key.clone(),
                 node_id,
                 MultiaddressesWithStats::default(),
                 PeerFlags::default(),
                 most_recent_claim.features,
-                vec![],
+                default_protocols,
                 String::new(),
             )
         });

--- a/comms/dht/tests/dht.rs
+++ b/comms/dht/tests/dht.rs
@@ -21,7 +21,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 mod harness;
-use std::{sync::Arc, time::Duration};
+use std::time::Duration;
 
 use harness::*;
 use tari_comms::{
@@ -244,7 +244,7 @@ async fn test_dht_store_forward() {
         .unwrap();
     // Wait for node C to and receive a response from the SAF request
     let event = collect_try_recv!(node_C_msg_events, take = 1, timeout = Duration::from_secs(20));
-    unpack_enum!(MessagingEvent::MessageReceived(_node_id, _msg) = event.get(0).unwrap().as_ref());
+    unpack_enum!(MessagingEvent::MessageReceived(_node_id, _msg) = event.get(0).unwrap());
 
     let msg = node_C.next_inbound_message(Duration::from_secs(5)).await.unwrap();
     assert_eq!(
@@ -908,21 +908,18 @@ async fn test_dht_header_not_malleable() {
     node_C.shutdown().await;
 }
 
-fn filter_received(events: Vec<Arc<MessagingEvent>>) -> Vec<Arc<MessagingEvent>> {
+fn filter_received(events: Vec<MessagingEvent>) -> Vec<MessagingEvent> {
     events
         .into_iter()
-        .filter(|e| match &**e {
-            MessagingEvent::MessageReceived(_, _) => true,
-            _ => unreachable!(),
-        })
+        .filter(|e| matches!(e, MessagingEvent::MessageReceived(_, _)))
         .collect()
 }
 
-fn count_messages_received(events: &[Arc<MessagingEvent>], node_ids: &[&NodeId]) -> usize {
+fn count_messages_received(events: &[MessagingEvent], node_ids: &[&NodeId]) -> usize {
     events
         .iter()
         .filter(|event| {
-            unpack_enum!(MessagingEvent::MessageReceived(recv_node_id, _tag) = &***event);
+            unpack_enum!(MessagingEvent::MessageReceived(recv_node_id, _tag) = &**event);
             node_ids.iter().any(|n| recv_node_id == *n)
         })
         .count()

--- a/comms/dht/tests/harness.rs
+++ b/comms/dht/tests/harness.rs
@@ -52,7 +52,7 @@ pub struct TestNode {
     pub comms: CommsNode,
     pub dht: Dht,
     pub inbound_messages: mpsc::Receiver<DecryptedDhtMessage>,
-    pub messaging_events: broadcast::Sender<Arc<MessagingEvent>>,
+    pub messaging_events: broadcast::Sender<MessagingEvent>,
     pub shutdown: Shutdown,
 }
 
@@ -197,7 +197,9 @@ pub async fn setup_comms_dht(
 
     let (event_tx, _) = broadcast::channel(100);
     let comms = comms
-        .add_protocol_extension(MessagingProtocolExtension::new(event_tx.clone(), pipeline))
+        .add_protocol_extension(
+            MessagingProtocolExtension::new(event_tx.clone(), pipeline).enable_message_received_event(),
+        )
         .spawn_with_transport(MemoryTransport)
         .await
         .unwrap();


### PR DESCRIPTION
Description
---
Only permit a single inbound messaging session per peer
Only emit MessageReceived event in tests
Ban peer if they exceed the frame size

Motivation and Context
---
A node may initiate boundless inbound messaging sessions. This PR limits the number of sessions to one. Tari nodes only initiate a single session as needed so this shouldn't have any effect on non-malicious nodes. 

MessageReceived events would be generated for each message received. This was only used in tests. Since these events aren't read in non-test contexts and because it can be very busy, this PR disables them by default and only enables in tests. This does not affect the message count in the minotari node status line.

How Has This Been Tested?
---
New unit test that checks sessions are closed as long as the first one is active.

What process can a PR reviewer use to test or verify this change?
---
Messaging still works as expected (ping-peer, discover-peer etc)
<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
