### PR TITLE
fix: syncing from prune node

### DIFF
--- a/base_layer/core/src/base_node/state_machine_service/states/events_and_states.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/events_and_states.rs
@@ -131,7 +131,9 @@ impl Display for SyncStatus {
             ),
             UpToDate => f.write_str("UpToDate"),
             SyncStatus::BehindButNotYetLagging { .. } => f.write_str("Behind but not yet lagging"),
-            SyncStatus::SyncNotPossible { .. } => f.write_str("Behind but we cannot sync as we have no viable peers to sync to"),
+            SyncStatus::SyncNotPossible { .. } => {
+                f.write_str("Behind but we cannot sync as we have no viable peers to sync to")
+            },
         }
     }
 }

--- a/base_layer/core/src/base_node/state_machine_service/states/events_and_states.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/events_and_states.rs
@@ -97,11 +97,18 @@ pub enum SyncStatus {
         sync_peers: Vec<SyncPeer>,
     },
     UpToDate,
+    SyncNotPossible {
+        peers: Vec<SyncPeer>,
+    },
 }
 
 impl SyncStatus {
     pub fn is_lagging(&self) -> bool {
         matches!(self, SyncStatus::Lagging { .. })
+    }
+
+    pub fn is_sync_not_possible(&self) -> bool {
+        matches!(self, SyncStatus::SyncNotPossible { .. })
     }
 
     pub fn is_up_to_date(&self) -> bool {
@@ -124,6 +131,7 @@ impl Display for SyncStatus {
             ),
             UpToDate => f.write_str("UpToDate"),
             SyncStatus::BehindButNotYetLagging { .. } => f.write_str("Behind but not yet lagging"),
+            SyncStatus::SyncNotPossible { .. } => f.write_str("Behind but we cannot sync as we have no viable peers to sync to"),
         }
     }
 }

--- a/base_layer/core/src/base_node/state_machine_service/states/listening.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/listening.rs
@@ -305,8 +305,7 @@ fn determine_sync_mode(
         let pruned_mode = local.pruning_horizon() > 0;
         let pruning_horizon_check = network.claimed_chain_metadata().pruning_horizon() > 0 &&
             network.claimed_chain_metadata().pruning_horizon() < local.pruning_horizon();
-        let pruning_height_check =
-            network.claimed_chain_metadata().pruned_height() > local.height_of_longest_chain();
+        let pruning_height_check = network.claimed_chain_metadata().pruned_height() > local.height_of_longest_chain();
         let sync_able_peer = match (pruned_mode, pruning_horizon_check, pruning_height_check) {
             (true, true, _) => {
                 info!(


### PR DESCRIPTION
Description
---
This filters out nodes when deciding if we need to sync or not.

Motivation and Context
---
We should not try and sync from nodes that cannot provide us with the blocks we require. 
This can happen in two cases:

1. We are a pruned node and their pruning horizon is less then ours. 
2. They are a pruning node and their effective pruned height is more than our current tip.  

This means that although we know we are behind, we should not enter syncing mode to those nodes as they will not be able to supply us the blocks we need, so we should not enter sync mode and destroy our current chain. 
