### PR TITLE
fix: prevent access violation when running multiple vms at the same time

### DIFF
--- a/base_layer/core/src/base_node/state_machine_service/state_machine.rs
+++ b/base_layer/core/src/base_node/state_machine_service/state_machine.rs
@@ -202,8 +202,8 @@ impl<B: BlockchainBackend + 'static> BaseNodeStateMachine<B> {
         let status = StatusInfo {
             bootstrapped: self.is_bootstrapped(),
             state_info: self.info.clone(),
-            randomx_vm_cnt: self.randomx_factory.get_count(),
-            randomx_vm_flags: self.randomx_factory.get_flags(),
+            randomx_vm_cnt: self.randomx_factory.get_count().unwrap_or(0),
+            randomx_vm_flags: self.randomx_factory.get_flags().unwrap_or_default(),
         };
 
         if let Err(e) = self.status_event_sender.send(status) {
@@ -226,11 +226,11 @@ impl<B: BlockchainBackend + 'static> BaseNodeStateMachine<B> {
     }
 
     pub fn get_randomx_vm_cnt(&self) -> usize {
-        self.randomx_factory.get_count()
+        self.randomx_factory.get_count().unwrap_or_default()
     }
 
     pub fn get_randomx_vm_flags(&self) -> RandomXFlag {
-        self.randomx_factory.get_flags()
+        self.randomx_factory.get_flags().unwrap_or_default()
     }
 
     /// Start the base node runtime.

--- a/base_layer/core/src/proof_of_work/monero_rx/error.rs
+++ b/base_layer/core/src/proof_of_work/monero_rx/error.rs
@@ -20,10 +20,9 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use randomx_rs::RandomXError;
 use tari_utilities::hex::HexError;
 
-use crate::proof_of_work::DifficultyError;
+use crate::proof_of_work::{randomx_factory::RandomXVMFactoryError, DifficultyError};
 
 /// Errors that can occur when merging Monero PoW data with Tari PoW data
 #[derive(Debug, thiserror::Error)]
@@ -36,8 +35,8 @@ pub enum MergeMineError {
     DeserializeError(String),
     #[error("Hashing of Monero data failed: {0}")]
     HashingError(String),
-    #[error("RandomX error: {0}")]
-    RandomXError(#[from] RandomXError),
+    #[error("RandomX VM factory error: {0}")]
+    RandomXVMFactoryError(#[from] RandomXVMFactoryError),
     #[error("Validation error: {0}")]
     ValidationError(String),
     #[error("Hex conversion error: {0}")]


### PR DESCRIPTION
Description
---
Add a rwlock around the randomx virtual machine

Motivation and Context
---
Calling calculate hash on a vm while it is still busy with another calculate hash would result in a panic. The unit test I created recreated that problem. 

How Has This Been Tested?
---
New test to reproduce the error

What process can a PR reviewer use to test or verify this change?
---
Apply the unit test to the development branch without the changes and the test should fail

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
