### PR TITLE
fix(p2p): enable auto join when online

### DIFF
--- a/base_layer/p2p/src/config.rs
+++ b/base_layer/p2p/src/config.rs
@@ -141,6 +141,7 @@ impl Default for P2pConfig {
             max_concurrent_outbound_tasks: 4,
             dht: DhtConfig {
                 database_url: DbConnectionUrl::file("dht.sqlite"),
+                auto_join: true,
                 ..Default::default()
             },
             allow_test_addresses: false,


### PR DESCRIPTION
Description
---
Enable auto network join by default

Motivation and Context
---
At some point auto_join was set to false for base node and wallet.

How Has This Been Tested?
---
Manually - nodes detect a node coming online from the join message

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
