### PR TITLE
ci(fix): add weekly dual arch docker builds with tags plus network

### DIFF
--- a/.github/workflows/base_node_binaries.yml
+++ b/.github/workflows/base_node_binaries.yml
@@ -58,6 +58,8 @@ jobs:
           echo "matrix=${matrix}" >> $GITHUB_OUTPUT
 
   matrix-check:
+    # Debug matrix
+    if: ${{ false }}
     runs-on: ubuntu-latest
     needs: matrix-prep
     steps:

--- a/.github/workflows/build_dockers.yml
+++ b/.github/workflows/build_dockers.yml
@@ -91,11 +91,18 @@ jobs:
             echo "tag_alias=${{ github.event.inputs.tag_alias }}" >> $GITHUB_OUTPUT
             echo "build_items=${{ github.event.inputs.build_items }}" >> $GITHUB_OUTPUT
           fi
-          if [ "${{ github.event_name }}" == "schedule" ] && [ "${{ github.event.schedule }}" == "05 00 * * *" ] ; then
-            echo "Daily Build - limited"
-            echo "platforms=linux/amd64" >> $GITHUB_OUTPUT
-            echo "tag_alias=latest-daily" >> $GITHUB_OUTPUT
-            echo "build_items=minotari_all" >> $GITHUB_OUTPUT
+          if [ "${{ github.event_name }}" == "schedule" ] ; then
+            if [[ $(date +%u) -eq 7 ]] ; then
+              echo "Weekly Build - limited dual arch"
+              echo "platforms=linux/arm64, linux/amd64" >> $GITHUB_OUTPUT
+              echo "tag_alias=latest-weekly" >> $GITHUB_OUTPUT
+              echo "build_items=minotari_all" >> $GITHUB_OUTPUT
+            else
+              echo "Daily Build - limited"
+              echo "platforms=linux/amd64" >> $GITHUB_OUTPUT
+              echo "tag_alias=latest-daily" >> $GITHUB_OUTPUT
+              echo "build_items=minotari_all" >> $GITHUB_OUTPUT
+            fi
           fi
 
   builds_run:

--- a/.github/workflows/build_dockers_workflow.yml
+++ b/.github/workflows/build_dockers_workflow.yml
@@ -124,7 +124,7 @@ jobs:
         shell: bash
         run: |
           IMAGE_NAME=${{ matrix.builds.image_name }}
-          if [ -z "${{ inputs.version }}" ]; then
+          if [ -z "${{ inputs.version }}" ] ; then
             echo "Get tari version"
             TARI_SOURCE_ROOT="tari/"
             VAPP=$(awk -F ' = ' \
@@ -139,9 +139,14 @@ jobs:
           fi
           echo "Setting ${VERSION} as docker tag"
           echo "VERSION=${VERSION}" >> $GITHUB_ENV
-          if [ ! -z "${{ inputs.tag_alias }}" ]; then
-            echo "Setup tag_alias"
-            echo "TAG_ALIAS=${{ secrets.DOCKER_PROVIDER }}/${{ secrets.DOCKER_REPO }}/${{ matrix.builds.image_name }}:${{ inputs.tag_alias }}" >> $GITHUB_ENV
+          if [ ! -z "${{ inputs.tag_alias }}" ] ; then
+            if [ -z "${{ env.TARI_NETWORK }}" ] ; then
+              echo "Setup tag_alias"
+              echo "TAG_ALIAS=${{ secrets.DOCKER_PROVIDER }}/${{ secrets.DOCKER_REPO }}/${{ matrix.builds.image_name }}:${{ inputs.tag_alias }}" >> $GITHUB_ENV
+            else
+              echo "Setup tag_alias with network"
+              echo "TAG_ALIAS=${{ secrets.DOCKER_PROVIDER }}/${{ secrets.DOCKER_REPO }}/${{ matrix.builds.image_name }}:${{ inputs.tag_alias }}-${{ env.TARI_NETWORK }}" >> $GITHUB_ENV
+            fi
           fi
           if [ "${IMAGE_NAME:0:9}" = "minotari_" ] ; then
             echo "Minotari builds"
@@ -152,7 +157,7 @@ jobs:
             echo "APP_EXEC=${{ matrix.builds.app_exec }}" >> $GITHUB_ENV
           else
             echo "3rd Party builds - ${IMAGE_NAME}"
-            if [ -f "./tari-launchpad/docker_rig/${IMAGE_NAME}.Dockerfile" ]; then
+            if [ -f "./tari-launchpad/docker_rig/${IMAGE_NAME}.Dockerfile" ] ; then
               echo "DOCKERFILE=${IMAGE_NAME}" >> $GITHUB_ENV
               SUBTAG=$(awk -v search="^ARG ${IMAGE_NAME^^}?_VERSION=" -F '=' '$0 ~ search \
                 { gsub(/["]/, "", $2); printf("%s",$2) }' \


### PR DESCRIPTION
Description
add scheduled weekly (Sunday) dual arch docker builds with tags plus network

Motivation and Context
Build arm64 and x86_64 dual images more often, so that we can test more regular

How Has This Been Tested?
Built in local fork for pushes, tags and schedules.

What process can a PR reviewer use to test or verify this change?
Check on release that docker images have network tags and weekly dual arch builds

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
