### PR TITLE
fix(comms+dht): mark peers as online inbound connection,join

### DIFF
--- a/comms/core/src/connection_manager/common.rs
+++ b/comms/core/src/connection_manager/common.rs
@@ -206,6 +206,9 @@ pub(super) fn create_or_update_peer_from_validated_peer_identity(
                     peer_identity_claim: peer_identity.claim.clone(),
                 });
 
+            peer.addresses
+                .mark_all_addresses_as_last_seen_now(&peer_identity.claim.addresses);
+
             peer.features = peer_identity.claim.features;
             peer.supported_protocols = peer_identity.metadata.supported_protocols.clone();
             peer.user_agent = peer_identity.metadata.user_agent.clone();

--- a/comms/core/src/connectivity/manager.rs
+++ b/comms/core/src/connectivity/manager.rs
@@ -636,8 +636,6 @@ impl ConnectivityManagerActor {
             (_, Connected) => match self.pool.get_connection(&node_id).cloned() {
                 Some(conn) => {
                     self.mark_connection_success(conn.peer_node_id().clone());
-                    self.mark_peer_last_seen_now(&conn).await?;
-
                     self.publish_event(ConnectivityEvent::PeerConnected(conn.into()));
                 },
                 None => unreachable!(
@@ -661,19 +659,6 @@ impl ConnectivityManagerActor {
             },
         }
 
-        Ok(())
-    }
-
-    async fn mark_peer_last_seen_now(&self, conn: &PeerConnection) -> Result<(), ConnectivityError> {
-        // Can't be None
-        if let Some(mut peer) = self.peer_manager.find_by_node_id(conn.peer_node_id()).await? {
-            if let Some(addr) = conn.known_address() {
-                peer.addresses.mark_last_seen_now(addr);
-            } else {
-                peer.addresses.mark_all_addresses_as_last_seen_now();
-            }
-            self.peer_manager.add_peer(peer).await?;
-        }
         Ok(())
     }
 

--- a/comms/core/src/connectivity/manager.rs
+++ b/comms/core/src/connectivity/manager.rs
@@ -473,7 +473,7 @@ impl ConnectivityManagerActor {
         }
     }
 
-    fn mark_peer_succeeded(&mut self, node_id: NodeId) {
+    fn mark_connection_success(&mut self, node_id: NodeId) {
         let entry = self.get_connection_stat_mut(node_id);
         entry.set_connection_success();
     }
@@ -635,7 +635,9 @@ impl ConnectivityManagerActor {
         match (old_status, new_status) {
             (_, Connected) => match self.pool.get_connection(&node_id).cloned() {
                 Some(conn) => {
-                    self.mark_peer_succeeded(node_id.clone());
+                    self.mark_connection_success(conn.peer_node_id().clone());
+                    self.mark_peer_last_seen_now(&conn).await?;
+
                     self.publish_event(ConnectivityEvent::PeerConnected(conn.into()));
                 },
                 None => unreachable!(
@@ -659,6 +661,19 @@ impl ConnectivityManagerActor {
             },
         }
 
+        Ok(())
+    }
+
+    async fn mark_peer_last_seen_now(&self, conn: &PeerConnection) -> Result<(), ConnectivityError> {
+        // Can't be None
+        if let Some(mut peer) = self.peer_manager.find_by_node_id(conn.peer_node_id()).await? {
+            if let Some(addr) = conn.known_address() {
+                peer.addresses.mark_last_seen_now(addr);
+            } else {
+                peer.addresses.mark_all_addresses_as_last_seen_now();
+            }
+            self.peer_manager.add_peer(peer).await?;
+        }
         Ok(())
     }
 

--- a/comms/core/src/net_address/mutliaddresses_with_stats.rs
+++ b/comms/core/src/net_address/mutliaddresses_with_stats.rs
@@ -174,6 +174,16 @@ impl MultiaddressesWithStats {
         }
     }
 
+    /// Mark all addresses as seen. This can be used in a case where you know the peer is online but you dont have an
+    /// address.
+    /// Prefer using mark_last_seen_now with the actual address.
+    pub fn mark_all_addresses_as_last_seen_now(&mut self) {
+        for addr in &mut self.addresses {
+            addr.mark_last_seen_now().mark_last_attempted_now();
+        }
+        self.sort_addresses();
+    }
+
     /// Mark that a connection could not be established with the specified net address
     ///
     /// Returns true if the address is contained in this instance, otherwise false

--- a/comms/core/src/net_address/mutliaddresses_with_stats.rs
+++ b/comms/core/src/net_address/mutliaddresses_with_stats.rs
@@ -174,14 +174,19 @@ impl MultiaddressesWithStats {
         }
     }
 
-    /// Mark all addresses as seen. This can be used in a case where you know the peer is online but you dont have an
-    /// address.
-    /// Prefer using mark_last_seen_now with the actual address.
-    pub fn mark_all_addresses_as_last_seen_now(&mut self) {
-        for addr in &mut self.addresses {
-            addr.mark_last_seen_now().mark_last_attempted_now();
+    /// Mark all addresses as seen. Returns true if all addresses are contained in this instance, otherwise false
+    pub fn mark_all_addresses_as_last_seen_now(&mut self, addresses: &[Multiaddr]) -> bool {
+        let mut all_exist = true;
+        for address in addresses {
+            match self.find_address_mut(address) {
+                Some(addr) => {
+                    addr.mark_last_seen_now().mark_last_attempted_now();
+                },
+                None => all_exist = false,
+            }
         }
         self.sort_addresses();
+        all_exist
     }
 
     /// Mark that a connection could not be established with the specified net address

--- a/comms/dht/src/inbound/dht_handler/task.rs
+++ b/comms/dht/src/inbound/dht_handler/task.rs
@@ -217,7 +217,7 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
 
         let validator = PeerValidator::new(&self.config);
         let maybe_existing = self.peer_manager.find_by_public_key(&authenticated_pk).await?;
-        let mut valid_peer = self
+        let valid_peer = self
             .ban_on_offence(
                 &authenticated_pk,
                 validator
@@ -229,8 +229,6 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
         let is_banned = valid_peer.is_banned();
         let valid_peer_node_id = valid_peer.node_id.clone();
         let valid_peer_public_key = valid_peer.public_key.clone();
-        // Mark the peer as online
-        valid_peer.addresses.mark_all_addresses_as_last_seen_now();
         // Update peer details. If the peer is banned we preserve the ban but still allow them to update their claims.
         self.peer_manager.add_peer(valid_peer).await?;
 

--- a/comms/dht/src/inbound/dht_handler/task.rs
+++ b/comms/dht/src/inbound/dht_handler/task.rs
@@ -217,7 +217,7 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
 
         let validator = PeerValidator::new(&self.config);
         let maybe_existing = self.peer_manager.find_by_public_key(&authenticated_pk).await?;
-        let valid_peer = self
+        let mut valid_peer = self
             .ban_on_offence(
                 &authenticated_pk,
                 validator
@@ -229,6 +229,8 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
         let is_banned = valid_peer.is_banned();
         let valid_peer_node_id = valid_peer.node_id.clone();
         let valid_peer_public_key = valid_peer.public_key.clone();
+        // Mark the peer as online
+        valid_peer.addresses.mark_all_addresses_as_last_seen_now();
         // Update peer details. If the peer is banned we preserve the ban but still allow them to update their claims.
         self.peer_manager.add_peer(valid_peer).await?;
 

--- a/comms/dht/src/peer_validator.rs
+++ b/comms/dht/src/peer_validator.rs
@@ -113,6 +113,7 @@ impl<'a> PeerValidator<'a> {
             peer.update_addresses(&claim.addresses, &PeerAddressSource::FromDiscovery {
                 peer_identity_claim: claim.clone(),
             });
+            peer.addresses.mark_all_addresses_as_last_seen_now(&claim.addresses);
         }
 
         Ok(peer)


### PR DESCRIPTION
Description
---
- mark peers as online inbound connection and on join msg
- fix DHT peer query logic

Motivation and Context
---
Peers were not being marked as online whenever we have proof that they are online, specifically in the  inbound connection and join msg.

The peer query to exclude peers if we have attempted them but never succeeded was incorrect and filtered out most peers. This was changed to 

```rust
 // we have tried to connect to this peer, and we have never made a successful attempt at connection
if peer.last_connect_attempt().is_some() && peer.last_seen().is_none() {
    return false;
}
```

How Has This Been Tested?
---
Manually, node reconnects quickly to peers on startup

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
