### PR TITLE
docs: fix documentation for Noise pattern update

### DIFF
--- a/comms/core/src/noise/socket.rs
+++ b/comms/core/src/noise/socket.rs
@@ -557,7 +557,7 @@ where TSocket: AsyncRead + AsyncWrite + Unpin
             self.send().await?;
             self.flush().await?;
 
-            // <- e, ee, se, s, es
+            // <- e, ee, s, es
             self.receive().await?;
 
             //   -> s, se
@@ -567,7 +567,7 @@ where TSocket: AsyncRead + AsyncWrite + Unpin
             //   -> e
             self.receive().await?;
 
-            // <- e, ee, se, s, es
+            // <- e, ee, s, es
             self.send().await?;
             self.flush().await?;
 


### PR DESCRIPTION
Description
---
Minor comment fix for the Noise `XX` pattern.

Motivation and Context
---
An update in #5696 switches the [Noise](http://www.noiseprotocol.org/noise.html) handshake pattern from `IX` to `XX`, which moves the handshake to 1.5 RTT. The corresponding comment changes are slightly incorrect, which this PR fixes to improve clarity.

How Has This Been Tested?
---
No testing required.

What process can a PR reviewer use to test or verify this change?
---
Compare the updated handshake comments to the `XX` protocol described in the [Noise specification](http://www.noiseprotocol.org/noise.html#interactive-handshake-patterns-fundamental) and ensure they match.

Breaking Changes
---
None.