### PR TITLE
feat: add (de)serialize to BalancedBinaryMerkleTree

### DIFF
--- a/base_layer/mmr/src/balanced_binary_merkle_tree.rs
+++ b/base_layer/mmr/src/balanced_binary_merkle_tree.rs
@@ -23,6 +23,7 @@
 use std::{convert::TryFrom, marker::PhantomData};
 
 use digest::Digest;
+use serde::{Deserialize, Serialize};
 use tari_common::DomainDigest;
 use thiserror::Error;
 
@@ -46,7 +47,7 @@ pub enum BalancedBinaryMerkleTreeError {
 // Because this implementation relies on the caller to hash leaf nodes, it is possible to instantiate a tree that is
 /// susceptible to second-preimage attacks. The caller _must_ ensure that the hashers used to pre-hash leaf nodes and
 /// instantiate the tree cannot produce collisions.
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct BalancedBinaryMerkleTree<D> {
     hashes: Vec<Hash>,
     _phantom: PhantomData<D>,


### PR DESCRIPTION
Description
---
Add (de)serialize traits to `BalancedBinaryMerkleTree`

Motivation and Context
---
This is needed for caching the `BalancedBinaryMerkleTree` per epoch.

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
