### PR TITLE
feat(comms): allow multiple messaging protocol instances

### DIFF
--- a/comms/core/examples/stress/node.rs
+++ b/comms/core/examples/stress/node.rs
@@ -29,7 +29,7 @@ use tari_comms::{
     multiaddr::Multiaddr,
     pipeline,
     pipeline::SinkService,
-    protocol::{messaging::MessagingProtocolExtension, ProtocolNotification, Protocols},
+    protocol::{messaging::MessagingProtocolExtension, ProtocolId, ProtocolNotification, Protocols},
     tor,
     tor::TorIdentity,
     transports::{predicate::FalsePredicate, SocksConfig, TcpWithTorTransport},
@@ -46,6 +46,8 @@ use tari_storage::{
 use tokio::sync::{broadcast, mpsc};
 
 use super::{error::Error, STRESS_PROTOCOL_NAME, TOR_CONTROL_PORT_ADDR, TOR_SOCKS_ADDR};
+
+static MSG_PROTOCOL_ID: ProtocolId = ProtocolId::from_static(b"example/msg/1.0");
 
 pub async fn create(
     node_identity: Option<Arc<NodeIdentity>>,
@@ -115,6 +117,7 @@ pub async fn create(
             .build()?
             .add_protocol_extensions(protocols.into())
             .add_protocol_extension(MessagingProtocolExtension::new(
+                MSG_PROTOCOL_ID.clone(),
                 event_tx,
                 pipeline::Builder::new()
                     .with_inbound_pipeline(SinkService::new(inbound_tx))
@@ -148,6 +151,7 @@ pub async fn create(
             .with_hidden_service_controller(hs_ctl)
             .add_protocol_extensions(protocols.into())
             .add_protocol_extension(MessagingProtocolExtension::new(
+                MSG_PROTOCOL_ID.clone(),
                 event_tx,
                 pipeline::Builder::new()
                     .with_inbound_pipeline(SinkService::new(inbound_tx))

--- a/comms/core/examples/tor.rs
+++ b/comms/core/examples/tor.rs
@@ -14,7 +14,7 @@ use tari_comms::{
     peer_manager::{NodeId, NodeIdentity, Peer, PeerFeatures},
     pipeline,
     pipeline::SinkService,
-    protocol::messaging::MessagingProtocolExtension,
+    protocol::{messaging::MessagingProtocolExtension, ProtocolId},
     tor,
     CommsBuilder,
     CommsNode,
@@ -33,6 +33,8 @@ use tokio::{
 // Tor example for tari_comms.
 //
 // _Note:_ A running tor proxy with `ControlPort` set is required for this example to work.
+
+static MSG_PROTOCOL_ID: ProtocolId = ProtocolId::from_static(b"example/tor/msg/1.0");
 
 type Error = anyhow::Error;
 
@@ -195,6 +197,7 @@ async fn setup_node_with_tor<P: Into<tor::PortMapping>>(
     let (event_tx, _) = broadcast::channel(1);
     let comms_node = comms_node
         .add_protocol_extension(MessagingProtocolExtension::new(
+            MSG_PROTOCOL_ID.clone(),
             event_tx,
             pipeline::Builder::new()
             // Outbound messages will be forwarded "as is" to outbound messaging

--- a/comms/core/src/builder/tests.rs
+++ b/comms/core/src/builder/tests.rs
@@ -48,6 +48,7 @@ use crate::{
     protocol::{
         messaging::{MessagingEvent, MessagingEventSender, MessagingProtocolExtension},
         ProtocolEvent,
+        ProtocolId,
         Protocols,
     },
     test_utils::node_identity::build_node_identity,
@@ -91,6 +92,7 @@ async fn spawn_node(
         .add_protocol_extensions(protocols.into())
         .add_protocol_extension(
             MessagingProtocolExtension::new(
+                ProtocolId::from_static(b"test/msg"),
                 messaging_events_sender.clone(),
                 pipeline::Builder::new()
                 // Outbound messages will be forwarded "as is" to outbound messaging

--- a/comms/core/src/protocol/messaging/mod.rs
+++ b/comms/core/src/protocol/messaging/mod.rs
@@ -37,14 +37,7 @@ mod inbound;
 mod metrics;
 mod outbound;
 mod protocol;
-pub use protocol::{
-    MessagingEvent,
-    MessagingEventReceiver,
-    MessagingEventSender,
-    MessagingProtocol,
-    SendFailReason,
-    MESSAGING_PROTOCOL_ID,
-};
+pub use protocol::{MessagingEvent, MessagingEventReceiver, MessagingEventSender, MessagingProtocol, SendFailReason};
 
 #[cfg(test)]
 mod test;

--- a/comms/core/src/protocol/messaging/outbound.rs
+++ b/comms/core/src/protocol/messaging/outbound.rs
@@ -33,7 +33,7 @@ use crate::{
     message::OutboundMessage,
     multiplexing::Substream,
     peer_manager::NodeId,
-    protocol::messaging::protocol::MESSAGING_PROTOCOL_ID,
+    protocol::ProtocolId,
     stream_id::StreamId,
 };
 
@@ -50,6 +50,7 @@ pub struct OutboundMessaging {
     messaging_events_tx: mpsc::Sender<MessagingEvent>,
     retry_queue_tx: mpsc::UnboundedSender<OutboundMessage>,
     peer_node_id: NodeId,
+    protocol_id: ProtocolId,
 }
 
 impl OutboundMessaging {
@@ -59,6 +60,7 @@ impl OutboundMessaging {
         messages_rx: mpsc::UnboundedReceiver<OutboundMessage>,
         retry_queue_tx: mpsc::UnboundedSender<OutboundMessage>,
         peer_node_id: NodeId,
+        protocol_id: ProtocolId,
     ) -> Self {
         Self {
             connectivity,
@@ -66,6 +68,7 @@ impl OutboundMessaging {
             messaging_events_tx,
             retry_queue_tx,
             peer_node_id,
+            protocol_id,
         }
     }
 
@@ -223,7 +226,7 @@ impl OutboundMessaging {
         &mut self,
         conn: &mut PeerConnection,
     ) -> Result<NegotiatedSubstream<Substream>, MessagingProtocolError> {
-        match conn.open_substream(&MESSAGING_PROTOCOL_ID).await {
+        match conn.open_substream(&self.protocol_id).await {
             Ok(substream) => Ok(substream),
             Err(err) => {
                 debug!(

--- a/comms/core/src/protocol/messaging/test.rs
+++ b/comms/core/src/protocol/messaging/test.rs
@@ -33,13 +33,18 @@ use tokio::{
     time,
 };
 
-use super::protocol::{MessagingEvent, MessagingEventReceiver, MessagingProtocol, MESSAGING_PROTOCOL_ID};
+use super::protocol::{MessagingEventReceiver, MessagingProtocol};
 use crate::{
     message::{InboundMessage, MessageTag, MessagingReplyRx, OutboundMessage},
     multiplexing::Substream,
     net_address::MultiaddressesWithStats,
     peer_manager::{NodeId, NodeIdentity, Peer, PeerFeatures, PeerFlags, PeerManager},
-    protocol::{messaging::SendFailReason, ProtocolEvent, ProtocolNotification},
+    protocol::{
+        messaging::{MessagingEvent, SendFailReason},
+        ProtocolEvent,
+        ProtocolId,
+        ProtocolNotification,
+    },
     test_utils::{
         mocks::{create_connectivity_mock, create_peer_connection_mock_pair, ConnectivityManagerMockState},
         node_id,
@@ -50,6 +55,8 @@ use crate::{
 };
 
 static TEST_MSG1: Bytes = Bytes::from_static(b"TEST_MSG1");
+
+static MESSAGING_PROTOCOL_ID: ProtocolId = ProtocolId::from_static(b"test/msg");
 
 async fn spawn_messaging_protocol() -> (
     Arc<PeerManager>,
@@ -75,6 +82,7 @@ async fn spawn_messaging_protocol() -> (
     let (events_tx, events_rx) = broadcast::channel(100);
 
     let msg_proto = MessagingProtocol::new(
+        MESSAGING_PROTOCOL_ID.clone(),
         requester,
         proto_rx,
         request_rx,

--- a/comms/dht/examples/memory_net/utilities.rs
+++ b/comms/dht/examples/memory_net/utilities.rs
@@ -42,6 +42,7 @@ use tari_comms::{
     protocol::{
         messaging::{MessagingEvent, MessagingEventReceiver, MessagingEventSender, MessagingProtocolExtension},
         rpc::RpcServer,
+        ProtocolId,
     },
     transports::MemoryTransport,
     types::CommsDatabase,
@@ -75,6 +76,7 @@ use tower::ServiceBuilder;
 
 use crate::memory_net::DrainBurst;
 
+pub static MEMORYNET_MSG_PROTOCOL_ID: ProtocolId = ProtocolId::from_static(b"t/msg/1.0");
 pub type NodeEventRx = mpsc::UnboundedReceiver<(NodeId, NodeId)>;
 pub type NodeEventTx = mpsc::UnboundedSender<(NodeId, NodeId)>;
 
@@ -969,7 +971,8 @@ async fn setup_comms_dht(
     let comms = comms
         .add_rpc_server(RpcServer::new().add_service(dht.rpc_service()))
         .add_protocol_extension(
-            MessagingProtocolExtension::new(messaging_events_tx.clone(), pipeline).enable_message_received_event(),
+            MessagingProtocolExtension::new(MEMORYNET_MSG_PROTOCOL_ID.clone(), messaging_events_tx.clone(), pipeline)
+                .enable_message_received_event(),
         )
         .spawn_with_transport(MemoryTransport)
         .await

--- a/comms/dht/examples/propagation/node.rs
+++ b/comms/dht/examples/propagation/node.rs
@@ -28,7 +28,7 @@ use tari_comms::{
     peer_manager::PeerFeatures,
     pipeline,
     pipeline::SinkService,
-    protocol::{messaging::MessagingProtocolExtension, NodeNetworkInfo},
+    protocol::{messaging::MessagingProtocolExtension, NodeNetworkInfo, ProtocolId},
     tor,
     tor::TorIdentity,
     CommsBuilder,
@@ -45,6 +45,8 @@ use tokio::sync::{broadcast, mpsc};
 use tower::ServiceBuilder;
 
 use crate::parse_from_short_str;
+
+pub static MEMORYNET_MSG_PROTOCOL_ID: ProtocolId = ProtocolId::from_static(b"t/msg/1.0");
 
 pub const TOR_CONTROL_PORT_ADDR: &str = "/ip4/127.0.0.1/tcp/9051";
 
@@ -132,6 +134,7 @@ pub async fn create<P: AsRef<Path>>(
     let comms_node = comms_node
         .with_hidden_service_controller(hs_ctl)
         .add_protocol_extension(MessagingProtocolExtension::new(
+            MEMORYNET_MSG_PROTOCOL_ID.clone(),
             event_tx,
             pipeline::Builder::new()
                 .with_inbound_pipeline(

--- a/comms/dht/src/peer_validator.rs
+++ b/comms/dht/src/peer_validator.rs
@@ -26,7 +26,6 @@ use tari_comms::{
     peer_manager::{NodeId, Peer, PeerFlags},
     peer_validator,
     peer_validator::{find_most_recent_claim, PeerValidatorError},
-    protocol::messaging::MESSAGING_PROTOCOL_ID,
 };
 
 use crate::{rpc::UnvalidatedPeerInfo, DhtConfig};
@@ -90,16 +89,13 @@ impl<'a> PeerValidator<'a> {
         let node_id = NodeId::from_public_key(&new_peer.public_key);
 
         let mut peer = existing_peer.unwrap_or_else(|| {
-            // All peer speak messaging protocol, as an optimisation we'll include it here so that we can do optimistic
-            // protocol negotiation.
-            let default_protocols = vec![MESSAGING_PROTOCOL_ID.clone()];
             Peer::new(
                 new_peer.public_key.clone(),
                 node_id,
                 MultiaddressesWithStats::default(),
                 PeerFlags::default(),
                 most_recent_claim.features,
-                default_protocols,
+                vec![],
                 String::new(),
             )
         });

--- a/comms/dht/tests/harness.rs
+++ b/comms/dht/tests/harness.rs
@@ -28,7 +28,10 @@ use tari_comms::{
     peer_manager::{NodeIdentity, Peer, PeerFeatures},
     pipeline,
     pipeline::SinkService,
-    protocol::messaging::{MessagingEvent, MessagingEventSender, MessagingProtocolExtension},
+    protocol::{
+        messaging::{MessagingEvent, MessagingEventSender, MessagingProtocolExtension},
+        ProtocolId,
+    },
     transports::MemoryTransport,
     types::CommsDatabase,
     CommsBuilder,
@@ -198,7 +201,8 @@ pub async fn setup_comms_dht(
     let (event_tx, _) = broadcast::channel(100);
     let comms = comms
         .add_protocol_extension(
-            MessagingProtocolExtension::new(event_tx.clone(), pipeline).enable_message_received_event(),
+            MessagingProtocolExtension::new(ProtocolId::from_static(b"test"), event_tx.clone(), pipeline)
+                .enable_message_received_event(),
         )
         .spawn_with_transport(MemoryTransport)
         .await


### PR DESCRIPTION
Description
---
Allow multiple message protocol instances

Motivation and Context
---
In L2 we want to have 2 messaging substreams, one for hotstuff messages and one for the rest (transactions, network messages) to prevent the queue of incoming transactions from causing HS leader failures.

In the base layer we spawn a single messaging protocol with the same identitfier, so nothing changes
 
How Has This Been Tested?
---
Existing tests and manually

What process can a PR reviewer use to test or verify this change?
---
Node and wallet function as before

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
