### PR TITLE
fix: edge case about sync

### DIFF
--- a/base_layer/core/src/base_node/sync/header_sync/synchronizer.rs
+++ b/base_layer/core/src/base_node/sync/header_sync/synchronizer.rs
@@ -249,8 +249,13 @@ impl<'a, B: BlockchainBackend + 'static> HeaderSynchronizer<'a, B> {
 
         // Fetch the local tip header at the beginning of the sync process
         let local_tip_header = self.db.fetch_last_chain_header().await?;
-        let local_blockchain_tip_header = self.db.fetch_chain_header(self.local_metadata.height_of_longest_chain()).await?;
-        let local_total_accumulated_difficulty = local_blockchain_tip_header.accumulated_data().total_accumulated_difficulty;
+        let local_blockchain_tip_header = self
+            .db
+            .fetch_chain_header(self.local_metadata.height_of_longest_chain())
+            .await?;
+        let local_total_accumulated_difficulty = local_blockchain_tip_header
+            .accumulated_data()
+            .total_accumulated_difficulty;
         let header_tip_height = local_blockchain_tip_header.height();
         let sync_status = self
             .determine_sync_status(sync_peer, local_tip_header, local_blockchain_tip_header, &mut client)


### PR DESCRIPTION
Description
---
This fixes an edge case around sync where the local node has a higher chain header, but the remote node has a higher actual block chain height. 

Motivation and Context
---
When doing sync, and determining from where to sync, we need to look at the where out actual block chain is, especially when comparing chains. 
On the current code its possible that you node has a valid header chain of higher proof of work then the remote syncing peer, but the blocks are not valid for that chain, thus the remote chain has an actual higher proof of work block chain. 
The current code will ban the peer for lying about the pow, as the header sync uses the last chain header to determine pow, while the listing state will use the chain_meta_data to determine pow. 

We should look at out chain header tip when determining the fork header before starting header sync, but when we compare the chains, we need to look at what our actual pow chain is and not the tip chain header. 


How Has This Been Tested?
---
Manual. 

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
