### PR TITLE
feat: up the timeout for comms

### DIFF
--- a/comms/core/src/connection_manager/manager.rs
+++ b/comms/core/src/connection_manager/manager.rs
@@ -141,12 +141,12 @@ impl Default for ConnectionManagerConfig {
             max_simultaneous_inbound_connects: 100,
             network_info: Default::default(),
             liveness_max_sessions: 1,
-            time_to_first_byte: Duration::from_secs(3),
+            time_to_first_byte: Duration::from_secs(6),
             liveness_cidr_allowlist: vec![cidr::AnyIpCidr::V4("127.0.0.1/32".parse().unwrap())],
             liveness_self_check_interval: None,
             auxiliary_tcp_listener_address: None,
             peer_validation_config: PeerValidatorConfig::default(),
-            noise_handshake_recv_timeout: Duration::from_secs(3),
+            noise_handshake_recv_timeout: Duration::from_secs(6),
         }
     }
 }

--- a/comms/core/src/connection_manager/peer_connection.rs
+++ b/comms/core/src/connection_manager/peer_connection.rs
@@ -62,7 +62,7 @@ use crate::{
 
 const LOG_TARGET: &str = "comms::connection_manager::peer_connection";
 
-const PROTOCOL_NEGOTIATION_TIMEOUT: Duration = Duration::from_secs(5);
+const PROTOCOL_NEGOTIATION_TIMEOUT: Duration = Duration::from_secs(10);
 
 static ID_COUNTER: AtomicUsize = AtomicUsize::new(0);
 

--- a/comms/core/src/noise/config.rs
+++ b/comms/core/src/noise/config.rs
@@ -58,7 +58,7 @@ impl NoiseConfig {
         Self {
             node_identity,
             parameters,
-            recv_timeout: Duration::from_secs(1),
+            recv_timeout: Duration::from_secs(3),
         }
     }
 


### PR DESCRIPTION
Description
---
increase timeouts

Motivation and Context
---
We recently decreased timeouts across the communications. This increases it again somewhat after it was observed that the newer timeouts maybe too quick for slow tor connections