### PR TITLE
fix: possible exception in request_context

### DIFF
--- a/base_layer/mmr/src/sparse_merkle_tree/proofs.rs
+++ b/base_layer/mmr/src/sparse_merkle_tree/proofs.rs
@@ -335,7 +335,7 @@ mod test {
         // feature?)
         assert!(proof.validate(&NodeKey::from([67u8; 32]), tree.hash()));
         // Use an exclusion proof to try and give an invalid validation for a key that does exist
-        assert_eq!(proof.validate(&NodeKey::from([64u8; 32]), tree.hash()), false);
+        assert!(!proof.validate(&NodeKey::from([64u8; 32]), tree.hash()));
 
         // A tree with branches
         tree.upsert(NodeKey::from([96u8; 32]), ValueHash::from([1u8; 32]))
@@ -352,11 +352,11 @@ mod test {
         // Does not validate against invalid root hash
         assert!(!proof.validate(&NodeKey::from([99u8; 32]), &NodeHash::default()));
         // Not all non-existent keys will validate. (bug or feature?)
-        assert_eq!(proof.validate(&NodeKey::from([65; 32]), tree.hash()), false);
+        assert!(!proof.validate(&NodeKey::from([65; 32]), tree.hash()));
         // But any keys with prefix 011 (that is not 96) will validate
         assert!(proof.validate(&NodeKey::from([0b0110_0011; 32]), tree.hash()));
         assert!(proof.validate(&NodeKey::from([0b0111_0001; 32]), tree.hash()));
         // The key 96 does exist..
-        assert_eq!(proof.validate(&NodeKey::from([0b0110_0000; 32]), tree.hash()), false);
+        assert!(!proof.validate(&NodeKey::from([0b0110_0000; 32]), tree.hash()));
     }
 }

--- a/base_layer/service_framework/src/lib.rs
+++ b/base_layer/service_framework/src/lib.rs
@@ -52,7 +52,7 @@
 //!         // At the same time receive the request and reply
 //!         async move {
 //!             let req_context = receiver.next().await.unwrap();
-//!             let msg = req_context.request().unwrap().clone();
+//!             let msg = req_context.request().clone();
 //!             req_context.reply(msg.to_uppercase());
 //!         }
 //!     );

--- a/base_layer/service_framework/src/reply_channel.rs
+++ b/base_layer/service_framework/src/reply_channel.rs
@@ -137,10 +137,7 @@ pub struct RequestContext<TReq, TResp> {
 impl<TReq, TResp> RequestContext<TReq, TResp> {
     /// Create a new RequestContect
     pub fn new(request: TReq, reply_tx: oneshot::Sender<TResp>) -> Self {
-        Self {
-            request,
-            reply_tx,
-        }
+        Self { request, reply_tx }
     }
 
     /// Return a reference to the request object. None is returned after take_request has
@@ -152,10 +149,7 @@ impl<TReq, TResp> RequestContext<TReq, TResp> {
     /// Consume this object and return it's parts. Namely, the request object and
     /// the reply oneshot channel.
     pub fn split(self) -> (TReq, oneshot::Sender<TResp>) {
-        (
-            self.request,
-            self.reply_tx,
-        )
+        (self.request, self.reply_tx)
     }
 
     /// Sends a reply to the caller

--- a/base_layer/service_framework/src/reply_channel.rs
+++ b/base_layer/service_framework/src/reply_channel.rs
@@ -131,35 +131,29 @@ impl<T> Future for TransportResponseFuture<T> {
 /// request.
 pub struct RequestContext<TReq, TResp> {
     reply_tx: oneshot::Sender<TResp>,
-    request: Option<TReq>,
+    request: TReq,
 }
 
 impl<TReq, TResp> RequestContext<TReq, TResp> {
     /// Create a new RequestContect
     pub fn new(request: TReq, reply_tx: oneshot::Sender<TResp>) -> Self {
         Self {
-            request: Some(request),
+            request,
             reply_tx,
         }
     }
 
     /// Return a reference to the request object. None is returned after take_request has
     /// been called.
-    pub fn request(&self) -> Option<&TReq> {
-        self.request.as_ref()
-    }
-
-    /// Take ownership of the request object, if ownership has not already been taken,
-    /// otherwise None is returned.
-    pub fn take_request(&mut self) -> Option<TReq> {
-        self.request.take()
+    pub fn request(&self) -> &TReq {
+        &self.request
     }
 
     /// Consume this object and return it's parts. Namely, the request object and
     /// the reply oneshot channel.
     pub fn split(self) -> (TReq, oneshot::Sender<TResp>) {
         (
-            self.request.expect("RequestContext must be initialized with a request"),
+            self.request,
             self.reply_tx,
         )
     }


### PR DESCRIPTION

Description
---
Fixed possible exception in `pub struct RequestContext` that could occur when splitting the request and reply channel in `pub fn split`

Motivation and Context
---
The code should not be allowed to panic in use in the wrong context.

How Has This Been Tested?
---
Unit tests

What process can a PR reviewer use to test or verify this change?
---
Code walk through

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
