### PR TITLE
fix: chat ffi seed peers

### DIFF
--- a/base_layer/chat_ffi/chat.h
+++ b/base_layer/chat_ffi/chat.h
@@ -234,7 +234,7 @@ struct ChatMessages *get_chat_messages(struct ChatClientFFI *client,
  * `message` should be destroyed eventually
  */
 void add_chat_message_metadata(struct Message *message,
-                               const int *metadata_type,
+                               int metadata_type,
                                const char *data,
                                int *error_out);
 

--- a/base_layer/chat_ffi/src/application_config.rs
+++ b/base_layer/chat_ffi/src/application_config.rs
@@ -28,7 +28,7 @@ use tari_chat_client::{
     networking::Multiaddr,
 };
 use tari_common::configuration::{MultiaddrList, Network};
-use tari_p2p::TransportConfig;
+use tari_p2p::{PeerSeedsConfig, TransportConfig};
 
 use crate::error::{InterfaceError, LibChatError};
 
@@ -175,6 +175,10 @@ pub unsafe extern "C" fn create_chat_config(
 
     let config = ApplicationConfig {
         chat_client: chat_client_config,
+        peer_seeds: PeerSeedsConfig {
+            dns_seeds_use_dnssec: true,
+            ..PeerSeedsConfig::default()
+        },
         ..ApplicationConfig::default()
     };
 

--- a/base_layer/chat_ffi/src/message_metadata.rs
+++ b/base_layer/chat_ffi/src/message_metadata.rs
@@ -45,7 +45,7 @@ use crate::error::{InterfaceError, LibChatError};
 #[no_mangle]
 pub unsafe extern "C" fn add_chat_message_metadata(
     message: *mut Message,
-    metadata_type: *const c_int,
+    metadata_type: c_int,
     data: *const c_char,
     error_out: *mut c_int,
 ) {
@@ -106,7 +106,7 @@ mod test {
 
         let error_out = Box::into_raw(Box::new(0));
 
-        unsafe { add_chat_message_metadata(message_ptr, 1 as *const c_int, data_char, error_out) }
+        unsafe { add_chat_message_metadata(message_ptr, 0 as c_int, data_char, error_out) }
 
         let message = unsafe { Box::from_raw(message_ptr) };
         assert_eq!(message.metadata.len(), 1)

--- a/integration_tests/src/chat_ffi.rs
+++ b/integration_tests/src/chat_ffi.rs
@@ -71,7 +71,7 @@ extern "C" {
     pub fn send_chat_message(client: *mut ClientFFI, message: *mut c_void, error_out: *const c_int);
     pub fn add_chat_message_metadata(
         message: *mut c_void,
-        metadata_type: *const c_int,
+        metadata_type: c_int,
         data: *const c_char,
         error_out: *const c_int,
     ) -> *mut c_void;
@@ -164,7 +164,7 @@ impl ChatClient for ChatFFI {
 
     fn add_metadata(&self, message: Message, metadata_type: MessageMetadataType, data: String) -> Message {
         let message_ptr = Box::into_raw(Box::new(message)) as *mut c_void;
-        let message_type = metadata_type.as_byte() as *const c_int;
+        let message_type = metadata_type.as_byte() as c_int;
 
         let data_c_str = CString::new(data).unwrap();
         let data_c_char: *const c_char = CString::into_raw(data_c_str) as *const c_char;

--- a/integration_tests/src/chat_ffi.rs
+++ b/integration_tests/src/chat_ffi.rs
@@ -164,7 +164,7 @@ impl ChatClient for ChatFFI {
 
     fn add_metadata(&self, message: Message, metadata_type: MessageMetadataType, data: String) -> Message {
         let message_ptr = Box::into_raw(Box::new(message)) as *mut c_void;
-        let message_type = metadata_type.as_byte() as c_int;
+        let message_type = i32::from(metadata_type.as_byte());
 
         let data_c_str = CString::new(data).unwrap();
         let data_c_char: *const c_char = CString::into_raw(data_c_str) as *const c_char;


### PR DESCRIPTION
Description
---
Previously we reconfigured the configuration (:D) for chat to allow for easier seed peer setting in the FFI, but I forgot to apply the boolean for using DNS peers.

Motivation and Context
---
Get peers on ffi.

How Has This Been Tested?
---
With disposable tests in cucumber locally, and CI

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
