### PR TITLE
feat: chat ffi verbose logging options

### DIFF
--- a/base_layer/chat_ffi/chat.h
+++ b/base_layer/chat_ffi/chat.h
@@ -97,6 +97,7 @@ struct ApplicationConfig *create_chat_config(const char *network_str,
                                              const char *identity_file_path,
                                              struct TransportConfig *tor_transport_config,
                                              const char *log_path,
+                                             int log_verbosity,
                                              int *error_out);
 
 /**

--- a/base_layer/chat_ffi/src/application_config.rs
+++ b/base_layer/chat_ffi/src/application_config.rs
@@ -20,15 +20,15 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{ffi::CStr, path::PathBuf, ptr, str::FromStr};
+use std::{convert::TryFrom, ffi::CStr, path::PathBuf, ptr, str::FromStr};
 
 use libc::{c_char, c_int};
 use tari_chat_client::{
     config::{ApplicationConfig, ChatClientConfig},
     networking::Multiaddr,
 };
-use tari_common::configuration::{MultiaddrList, Network};
-use tari_p2p::{PeerSeedsConfig, TransportConfig};
+use tari_common::configuration::{MultiaddrList, Network, StringList};
+use tari_p2p::{PeerSeedsConfig, TransportConfig, DEFAULT_DNS_NAME_SERVER};
 
 use crate::error::{InterfaceError, LibChatError};
 
@@ -53,6 +53,7 @@ pub unsafe extern "C" fn create_chat_config(
     identity_file_path: *const c_char,
     tor_transport_config: *mut TransportConfig,
     log_path: *const c_char,
+    log_verbosity: c_int,
     error_out: *mut c_int,
 ) -> *mut ApplicationConfig {
     let mut error = 0;
@@ -152,6 +153,8 @@ pub unsafe extern "C" fn create_chat_config(
     }
     let log_path = PathBuf::from(log_path_string);
 
+    let log_verbosity = u8::try_from(log_verbosity).unwrap_or(2); // 2 == WARN
+
     let mut bad_identity = |e| {
         error = LibChatError::from(InterfaceError::InvalidArgument(e)).code;
         ptr::swap(error_out, &mut error as *mut c_int);
@@ -170,13 +173,16 @@ pub unsafe extern "C" fn create_chat_config(
     chat_client_config.p2p.transport = (*tor_transport_config).clone();
     chat_client_config.p2p.public_addresses = MultiaddrList::from(vec![address]);
     chat_client_config.log_path = Some(log_path);
+    chat_client_config.log_verbosity = Some(log_verbosity);
     chat_client_config.identity_file = identity_path;
     chat_client_config.set_base_path(datastore_path);
 
     let config = ApplicationConfig {
         chat_client: chat_client_config,
         peer_seeds: PeerSeedsConfig {
-            dns_seeds_use_dnssec: true,
+            dns_seeds_use_dnssec: false,
+            dns_seeds_name_server: DEFAULT_DNS_NAME_SERVER.parse().unwrap(),
+            dns_seeds: StringList::from(vec![format!("seeds.{}.tari.com", network.as_key_str())]),
             ..PeerSeedsConfig::default()
         },
         ..ApplicationConfig::default()
@@ -246,6 +252,7 @@ mod test {
                 identity_path.as_ptr(),
                 transport_config,
                 log_path.as_ptr(),
+                5,
                 error_ptr,
             );
 

--- a/base_layer/chat_ffi/src/lib.rs
+++ b/base_layer/chat_ffi/src/lib.rs
@@ -90,7 +90,7 @@ pub unsafe extern "C" fn create_chat_client(
     }
 
     if let Some(log_path) = (*config).clone().chat_client.log_path {
-        init_logging(log_path, error_out);
+        init_logging(log_path, (*config).clone().chat_client.log_verbosity, error_out);
 
         if error > 0 {
             return ptr::null_mut();

--- a/base_layer/contacts/examples/chat_client/src/config.rs
+++ b/base_layer/contacts/examples/chat_client/src/config.rs
@@ -93,6 +93,8 @@ pub struct ChatClientConfig {
     pub metadata_auto_ping_interval: Duration,
     /// The location of the log path
     pub log_path: Option<PathBuf>,
+    /// The log verbosity
+    pub log_verbosity: Option<u8>,
 }
 
 impl Default for ChatClientConfig {
@@ -120,6 +122,7 @@ impl Default for ChatClientConfig {
             force_sync_peers: StringList::default(),
             metadata_auto_ping_interval: Duration::from_secs(30),
             log_path: None,
+            log_verbosity: Some(2), // Warn
         }
     }
 }
@@ -160,6 +163,7 @@ impl ChatClientConfig {
     pub fn default_local_test() -> Self {
         Self {
             network: Network::LocalNet,
+            log_verbosity: Some(5), // Trace
             p2p: P2pConfig {
                 datastore_path: PathBuf::from("peer_db/chat_client"),
                 user_agent: format!("tari/chat_client/{}", consts::APP_VERSION_NUMBER),


### PR DESCRIPTION
Description
---
Adds configuration options for verbosity levels of chatffi logging.

Motivation and Context
---
Default levels aren't enough for debugging problems.

How Has This Been Tested?
---
CI

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
