### PR TITLE
feat: failure of min difficulty should not add block to list of bad blocks

### DIFF
--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -514,12 +514,6 @@ where B: BlockchainBackend + 'static
             PowAlgorithm::Sha3x => sha3x_difficulty(&new_block.header)?,
         };
         if achieved < min_difficulty {
-            self.blockchain_db
-                .add_bad_block(
-                    new_block.header.hash(),
-                    self.blockchain_db.get_chain_metadata().await?.height_of_longest_chain(),
-                )
-                .await?;
             return Err(CommsInterfaceError::InvalidBlockHeader(
                 BlockHeaderValidationError::ProofOfWorkError(PowError::AchievedDifficultyBelowMin),
             ));


### PR DESCRIPTION
Description
---
Blocks that fail min difficulty should not be added to the list of bad blocks.

Motivation and Context
---
By adding the blocks to the list of bad blocks we open up the local node to be spammed to write bad block hashes into the database. These waste space and they require a write lock on the database. Checking the difficulty is a very quick and inexpensive check. 
