### PR TITLE
feat: prevent possible division by zero in difficulty calculation

### DIFF
--- a/base_layer/core/src/proof_of_work/difficulty.rs
+++ b/base_layer/core/src/proof_of_work/difficulty.rs
@@ -76,6 +76,9 @@ impl Difficulty {
     }
 
     fn u256_scalar_to_difficulty(scalar: U256) -> Result<Difficulty, DifficultyError> {
+        if scalar == U256::zero() {
+            return Err(DifficultyError::DivideByZero);
+        }
         let result = U256::MAX / scalar;
         let result = result.min(u64::MAX.into());
         Difficulty::from_u64(result.low_u64())
@@ -284,5 +287,15 @@ mod test {
             Difficulty::little_endian_difficulty(&target.to_be_bytes()).unwrap(),
             Difficulty::from_u64(expected).unwrap()
         );
+    }
+
+    #[test]
+    fn u256_scalar_to_difficulty_division_by_zero() {
+        let bytes = [];
+        assert!(Difficulty::little_endian_difficulty(&bytes).is_err());
+        assert!(Difficulty::big_endian_difficulty(&bytes).is_err());
+        let bytes = [0u8; 32];
+        assert!(Difficulty::little_endian_difficulty(&bytes).is_err());
+        assert!(Difficulty::big_endian_difficulty(&bytes).is_err());
     }
 }

--- a/base_layer/core/src/proof_of_work/error.rs
+++ b/base_layer/core/src/proof_of_work/error.rs
@@ -60,4 +60,6 @@ pub enum DifficultyError {
     InvalidDifficulty,
     #[error("Maximum block time overflowed u64")]
     MaxBlockTimeOverflow,
+    #[error("Divide by zero")]
+    DivideByZero,
 }


### PR DESCRIPTION
Description
---
Prevented possible division by zero panic in `fn u256_scalar_to_difficulty(scalar: U256) -> Result<Difficulty, DifficultyError>`

Motivation and Context
---
Code should not be able to panic.

How Has This Been Tested?
---
Unit test added

What process can a PR reviewer use to test or verify this change?
---
Code walkthrough

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
