### PR TITLE
feat: consistent handling of edge cases for header sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4710,9 +4710,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.23"
+version = "0.37.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d69718bf81c6127a49dc64e44a742e8bb9213c0ff8869a22c308f84c1d4ab06"
+checksum = "84f3f8f960ed3b5a59055428714943298bf3fa2d4a1d53135084e0544829d995"
 dependencies = [
  "bitflags 1.3.2",
  "errno",
@@ -6026,7 +6026,7 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e6bf6f19e9f8ed8d4048dc22981458ebcf406d67e94cd422e5ecd73d63b3237"
 dependencies = [
- "rustix 0.37.23",
+ "rustix 0.37.26",
  "windows-sys 0.48.0",
 ]
 

--- a/applications/minotari_console_wallet/src/ui/components/transactions_tab.rs
+++ b/applications/minotari_console_wallet/src/ui/components/transactions_tab.rs
@@ -388,7 +388,6 @@ impl TransactionsTab {
             let status = Span::styled(status_msg, Style::default().fg(Color::White));
             let message = Span::styled(tx.message.as_str(), Style::default().fg(Color::White));
 
-            // let mined_time = DateTime::<Local>::from_utc(tx.mined_timestamp, Local::now().offset().to_owned());
             let mined_timestamp = Span::styled(
                 match tx.mined_timestamp {
                     None => String::new(),
@@ -398,7 +397,6 @@ impl TransactionsTab {
                             .format("%Y-%m-%d %H:%M:%S")
                     ),
                 },
-                // format!("{}", mined_time.format("%Y-%m-%d %H:%M:%S")),
                 Style::default().fg(Color::White),
             );
 

--- a/base_layer/core/src/base_node/proto/rpc.proto
+++ b/base_layer/core/src/base_node/proto/rpc.proto
@@ -49,10 +49,6 @@ message FindChainSplitResponse {
   // `FindChainSplitRequest::block_hashes`. This value could also be used to
   // know how far back a split occurs.
   uint64 fork_hash_index = 2;
-  // The current header height of this node
-  uint64 tip_height = 3;
-  // The current geometric mean of the pow of the chain tip, or `None` if there is no chain
-  bytes accumulated_difficulty = 4;
 }
 
 message SyncKernelsRequest {

--- a/base_layer/core/src/base_node/proto/rpc.proto
+++ b/base_layer/core/src/base_node/proto/rpc.proto
@@ -51,6 +51,8 @@ message FindChainSplitResponse {
   uint64 fork_hash_index = 2;
   // The current header height of this node
   uint64 tip_height = 3;
+  // The current geometric mean of the pow of the chain tip, or `None` if there is no chain
+  bytes accumulated_difficulty = 4;
 }
 
 message SyncKernelsRequest {

--- a/base_layer/core/src/base_node/state_machine_service/state_machine.rs
+++ b/base_layer/core/src/base_node/state_machine_service/state_machine.rs
@@ -153,7 +153,7 @@ impl<B: BlockchainBackend + 'static> BaseNodeStateMachine<B> {
                 db.set_disable_add_block_flag();
                 HeaderSync(HeaderSyncState::new(sync_peers, local_metadata))
             },
-            (HeaderSync(s), HeaderSyncFailed) => {
+            (HeaderSync(s), HeaderSyncFailed(_err)) => {
                 db.clear_disable_add_block_flag();
                 Waiting(s.into())
             },
@@ -161,7 +161,7 @@ impl<B: BlockchainBackend + 'static> BaseNodeStateMachine<B> {
                 db.clear_disable_add_block_flag();
                 Listening(s.into())
             },
-            (HeaderSync(s), HeadersSynchronized(_)) => DecideNextSync(s.into()),
+            (HeaderSync(s), HeadersSynchronized(..)) => DecideNextSync(s.into()),
 
             (DecideNextSync(_), ProceedToHorizonSync(peers)) => HorizonStateSync(peers.into()),
             (DecideNextSync(s), Continue) => {

--- a/base_layer/core/src/base_node/state_machine_service/states/events_and_states.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/events_and_states.rs
@@ -37,7 +37,7 @@ use crate::base_node::{
         Starting,
         Waiting,
     },
-    sync::{HorizonSyncInfo, SyncPeer},
+    sync::{AttemptSyncResult, HorizonSyncInfo, SyncPeer},
 };
 
 #[derive(Debug)]
@@ -57,8 +57,8 @@ pub enum BaseNodeState {
 #[derive(Debug, Clone, PartialEq)]
 pub enum StateEvent {
     Initialized,
-    HeadersSynchronized(SyncPeer),
-    HeaderSyncFailed,
+    HeadersSynchronized(SyncPeer, AttemptSyncResult),
+    HeaderSyncFailed(String),
     ProceedToHorizonSync(Vec<SyncPeer>),
     ProceedToBlockSync(Vec<SyncPeer>),
     HorizonStateSynchronized,
@@ -145,8 +145,8 @@ impl Display for StateEvent {
         match self {
             Initialized => write!(f, "Initialized"),
             BlocksSynchronized => write!(f, "Synchronised Blocks"),
-            HeadersSynchronized(peer) => write!(f, "Headers Synchronized from peer `{}`", peer),
-            HeaderSyncFailed => write!(f, "Header Synchronization Failed"),
+            HeadersSynchronized(peer, result) => write!(f, "Headers Synchronized from peer `{}` ({:?})", peer, result),
+            HeaderSyncFailed(err) => write!(f, "Header Synchronization Failed ({})", err),
             ProceedToHorizonSync(_) => write!(f, "Proceed to horizon sync"),
             ProceedToBlockSync(_) => write!(f, "Proceed to block sync"),
             HorizonStateSynchronized => write!(f, "Horizon State Synchronized"),

--- a/base_layer/core/src/base_node/state_machine_service/states/header_sync.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/header_sync.rs
@@ -24,6 +24,7 @@ use std::{cmp::Ordering, time::Instant};
 
 use log::*;
 use tari_common_types::chain_metadata::ChainMetadata;
+use tari_comms::peer_manager::NodeId;
 
 use crate::{
     base_node::{
@@ -35,7 +36,6 @@ use crate::{
     },
     chain_storage::BlockchainBackend,
 };
-
 const LOG_TARGET: &str = "c::bn::header_sync";
 
 #[derive(Clone, Debug)]
@@ -70,12 +70,42 @@ impl HeaderSyncState {
         self.sync_peers
     }
 
+    fn remove_sync_peer(&mut self, node_id: &NodeId) {
+        if let Some(pos) = self.sync_peers.iter().position(|p| p.node_id() == node_id) {
+            self.sync_peers.remove(pos);
+        }
+    }
+
     // converting u64 to i64 is okay as the future time limit is the hundreds so way below u32 even
+    #[allow(clippy::too_many_lines)]
     #[allow(clippy::cast_possible_wrap)]
     pub async fn next_event<B: BlockchainBackend + 'static>(
         &mut self,
         shared: &mut BaseNodeStateMachine<B>,
     ) -> StateEvent {
+        // Only sync to peers with better claimed accumulated difficulty than the local chain: this may be possible
+        // at this stage due to read-write lock race conditions in the database
+        match shared.db.get_chain_metadata().await {
+            Ok(best_block_metadata) => {
+                let mut remove = Vec::new();
+                for sync_peer in &self.sync_peers {
+                    if sync_peer.claimed_chain_metadata().accumulated_difficulty() <=
+                        best_block_metadata.accumulated_difficulty()
+                    {
+                        remove.push(sync_peer.node_id().clone());
+                    }
+                }
+                for node_id in remove {
+                    self.remove_sync_peer(&node_id);
+                }
+                if self.sync_peers.is_empty() {
+                    // Go back to Listening state
+                    return StateEvent::Continue;
+                }
+            },
+            Err(e) => return StateEvent::FatalError(format!("{}", e)),
+        }
+
         let mut synchronizer = HeaderSynchronizer::new(
             shared.config.blockchain_sync_config.clone(),
             shared.db.clone(),
@@ -128,7 +158,7 @@ impl HeaderSyncState {
         let mut mdc = vec![];
         log_mdc::iter(|k, v| mdc.push((k.to_owned(), v.to_owned())));
         match synchronizer.synchronize().await {
-            Ok(sync_peer) => {
+            Ok((sync_peer, sync_result)) => {
                 log_mdc::extend(mdc);
                 info!(
                     target: LOG_TARGET,
@@ -144,9 +174,10 @@ impl HeaderSyncState {
                     }
                 }
                 self.is_synced = true;
-                StateEvent::HeadersSynchronized(sync_peer)
+                StateEvent::HeadersSynchronized(sync_peer, sync_result)
             },
             Err(err) => {
+                println!("HeaderSyncState::next_event - {}", err);
                 let _ignore = shared.status_event_sender.send(StatusInfo {
                     bootstrapped,
                     state_info: StateInfo::SyncFailed("HeaderSyncFailed".to_string()),
@@ -163,7 +194,7 @@ impl HeaderSyncState {
                     _ => {
                         log_mdc::extend(mdc);
                         debug!(target: LOG_TARGET, "Header sync failed: {}", err);
-                        StateEvent::HeaderSyncFailed
+                        StateEvent::HeaderSyncFailed(err.to_string())
                     },
                 }
             },

--- a/base_layer/core/src/base_node/state_machine_service/states/header_sync.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/header_sync.rs
@@ -177,7 +177,6 @@ impl HeaderSyncState {
                 StateEvent::HeadersSynchronized(sync_peer, sync_result)
             },
             Err(err) => {
-                println!("HeaderSyncState::next_event - {}", err);
                 let _ignore = shared.status_event_sender.send(StatusInfo {
                     bootstrapped,
                     state_info: StateInfo::SyncFailed("HeaderSyncFailed".to_string()),

--- a/base_layer/core/src/base_node/sync/header_sync/error.rs
+++ b/base_layer/core/src/base_node/sync/header_sync/error.rs
@@ -56,6 +56,8 @@ pub enum BlockHeaderSyncError {
     ConnectivityError(#[from] ConnectivityError),
     #[error("Node is still not in sync. Sync will be retried with another peer if possible.")]
     NotInSync,
+    #[error("Internal data inconsistency found `{0}")]
+    InternalError(String),
     #[error("Unable to locate start hash `{0}`")]
     StartHashNotFound(String),
     #[error("Expected header height {expected} got {actual}")]
@@ -106,7 +108,8 @@ impl BlockHeaderSyncError {
             BlockHeaderSyncError::ConnectivityError(_) |
             BlockHeaderSyncError::NotInSync |
             BlockHeaderSyncError::PeerNotFound |
-            BlockHeaderSyncError::ChainStorageError(_) => None,
+            BlockHeaderSyncError::ChainStorageError(_) |
+            BlockHeaderSyncError::InternalError(_) => None,
 
             // short ban
             err @ BlockHeaderSyncError::MaxLatencyExceeded { .. } => Some(BanReason {

--- a/base_layer/core/src/base_node/sync/header_sync/error.rs
+++ b/base_layer/core/src/base_node/sync/header_sync/error.rs
@@ -56,8 +56,6 @@ pub enum BlockHeaderSyncError {
     ConnectivityError(#[from] ConnectivityError),
     #[error("Node is still not in sync. Sync will be retried with another peer if possible.")]
     NotInSync,
-    #[error("Internal data inconsistency found `{0}")]
-    InternalError(String),
     #[error("Unable to locate start hash `{0}`")]
     StartHashNotFound(String),
     #[error("Expected header height {expected} got {actual}")]
@@ -108,8 +106,7 @@ impl BlockHeaderSyncError {
             BlockHeaderSyncError::ConnectivityError(_) |
             BlockHeaderSyncError::NotInSync |
             BlockHeaderSyncError::PeerNotFound |
-            BlockHeaderSyncError::ChainStorageError(_) |
-            BlockHeaderSyncError::InternalError(_) => None,
+            BlockHeaderSyncError::ChainStorageError(_) => None,
 
             // short ban
             err @ BlockHeaderSyncError::MaxLatencyExceeded { .. } => Some(BanReason {

--- a/base_layer/core/src/base_node/sync/header_sync/mod.rs
+++ b/base_layer/core/src/base_node/sync/header_sync/mod.rs
@@ -26,4 +26,4 @@ pub use error::BlockHeaderSyncError;
 mod validator;
 
 mod synchronizer;
-pub use synchronizer::HeaderSynchronizer;
+pub use synchronizer::{AttemptSyncResult, HeaderSyncStatus, HeaderSynchronizer};

--- a/base_layer/core/src/base_node/sync/header_sync/synchronizer.rs
+++ b/base_layer/core/src/base_node/sync/header_sync/synchronizer.rs
@@ -278,8 +278,9 @@ impl<'a, B: BlockchainBackend + 'static> HeaderSynchronizer<'a, B> {
 
         match header_sync_status.clone() {
             HeaderSyncStatus::InSyncOrAhead => {
-                // Our POW is less than the peer's POW, as verified before attempted header sync, therefor, if the peer
-                // did not supply any headers and we know we are behind, then we can ban the peer.
+                // Our POW is less than the peer's POW, as verified before the attempted header sync, therefore, if the
+                // peer did not supply any headers and we know we are behind based on the peer's claimed metadata, then
+                // we can ban the peer.
                 if best_header.height() == best_block.height() {
                     warn!(
                         target: LOG_TARGET,
@@ -291,7 +292,7 @@ impl<'a, B: BlockchainBackend + 'static> HeaderSynchronizer<'a, B> {
                     );
                     return Err(BlockHeaderSyncError::PeerSentInaccurateChainMetadata {
                         claimed: sync_peer.claimed_chain_metadata().accumulated_difficulty(),
-                        actual: Some(peer_response.peer_accumulated_difficulty),
+                        actual: None,
                         local: best_block.accumulated_data().total_accumulated_difficulty,
                     });
                 }

--- a/base_layer/core/src/base_node/sync/header_sync/synchronizer.rs
+++ b/base_layer/core/src/base_node/sync/header_sync/synchronizer.rs
@@ -285,7 +285,7 @@ impl<'a, B: BlockchainBackend + 'static> HeaderSynchronizer<'a, B> {
                         target: LOG_TARGET,
                         "Peer `{}` did not provide any headers although they have a better chain and more headers: their \
                         difficulty: {}, our difficulty: {}. Peer will be banned.",
-                        sync_peer,
+                        sync_peer.node_id(),
                         peer_response.peer_accumulated_difficulty,
                         best_block.accumulated_data().total_accumulated_difficulty,
                     );
@@ -453,7 +453,7 @@ impl<'a, B: BlockchainBackend + 'static> HeaderSynchronizer<'a, B> {
                 target: LOG_TARGET,
                 "Peer `{}` lied about their chain metadata: previously claimed difficulty: {}, newly provided \
                 difficulty: {}. Peer will be banned.",
-                sync_peer,
+                sync_peer.node_id(),
                 sync_peer.claimed_chain_metadata().accumulated_difficulty(),
                 chain_split_result.peer_accumulated_difficulty,
             );
@@ -467,7 +467,7 @@ impl<'a, B: BlockchainBackend + 'static> HeaderSynchronizer<'a, B> {
         // If the peer returned no new headers, they may still have more blocks than we have, thus have a higher
         // accumulated difficulty.
         if chain_split_result.peer_headers.is_empty() {
-            debug!(target: LOG_TARGET, "Peer `{}` sent no headers; headers already in sync with peer.", sync_peer);
+            debug!(target: LOG_TARGET, "Peer `{}` sent no headers; headers already in sync with peer.", sync_peer.node_id());
             return Ok((HeaderSyncStatus::InSyncOrAhead, chain_split_result));
         }
 
@@ -492,7 +492,7 @@ impl<'a, B: BlockchainBackend + 'static> HeaderSynchronizer<'a, B> {
                 warn!(
                     target: LOG_TARGET,
                     "Peer `{}` lied about the start hash index ({}).  Peer will be banned.",
-                    sync_peer,
+                    sync_peer.node_id(),
                     chain_split_result.peer_fork_hash_index,
                 );
                 return Err(BlockHeaderSyncError::StartHashNotFound(format!(
@@ -516,7 +516,7 @@ impl<'a, B: BlockchainBackend + 'static> HeaderSynchronizer<'a, B> {
 
         debug!(
             target: LOG_TARGET,
-            "Peer {} has submitted {} valid header(s)", sync_peer, num_new_headers
+            "Peer `{}` has submitted {} valid header(s)", sync_peer.node_id(), num_new_headers
         );
 
         // Basic sanity check that the peer sent tip height greater than the split.
@@ -525,12 +525,12 @@ impl<'a, B: BlockchainBackend + 'static> HeaderSynchronizer<'a, B> {
             warn!(
                 target: LOG_TARGET,
                 "Peer `{}` sent invalid remote tip height ({}).  Peer will be banned.",
-                sync_peer,
+                sync_peer.node_id(),
                 chain_split_result.peer_best_block_height,
             );
             return Err(BlockHeaderSyncError::InvalidProtocolResponse(format!(
-                "Peer {} sent invalid remote tip height",
-                sync_peer
+                "Peer `{}` sent invalid remote tip height",
+                sync_peer.node_id()
             )));
         }
 

--- a/base_layer/core/src/base_node/sync/mod.rs
+++ b/base_layer/core/src/base_node/sync/mod.rs
@@ -36,7 +36,7 @@ pub use block_sync::{BlockSyncError, BlockSynchronizer};
 #[cfg(feature = "base_node")]
 mod header_sync;
 #[cfg(feature = "base_node")]
-pub use header_sync::{BlockHeaderSyncError, HeaderSynchronizer};
+pub use header_sync::{AttemptSyncResult, BlockHeaderSyncError, HeaderSyncStatus, HeaderSynchronizer};
 
 #[cfg(feature = "base_node")]
 mod horizon_state_sync;

--- a/base_layer/core/src/base_node/sync/rpc/service.rs
+++ b/base_layer/core/src/base_node/sync/rpc/service.rs
@@ -425,13 +425,10 @@ impl<B: BlockchainBackend + 'static> BaseNodeSyncService for BaseNodeSyncRpcServ
                     headers.len(),
                     peer
                 );
-                let metadata = db.get_chain_metadata().await.rpc_status_internal_error(LOG_TARGET)?;
 
                 Ok(Response::new(FindChainSplitResponse {
                     fork_hash_index: idx as u64,
                     headers: headers.into_iter().map(Into::into).collect(),
-                    tip_height: metadata.height_of_longest_chain(),
-                    accumulated_difficulty: metadata.accumulated_difficulty().to_le_bytes().to_vec(),
                 }))
             },
             None => {

--- a/base_layer/core/src/base_node/sync/rpc/service.rs
+++ b/base_layer/core/src/base_node/sync/rpc/service.rs
@@ -431,6 +431,7 @@ impl<B: BlockchainBackend + 'static> BaseNodeSyncService for BaseNodeSyncRpcServ
                     fork_hash_index: idx as u64,
                     headers: headers.into_iter().map(Into::into).collect(),
                     tip_height: metadata.height_of_longest_chain(),
+                    accumulated_difficulty: metadata.accumulated_difficulty().to_le_bytes().to_vec(),
                 }))
             },
             None => {

--- a/base_layer/core/tests/helpers/block_builders.rs
+++ b/base_layer/core/tests/helpers/block_builders.rs
@@ -311,6 +311,7 @@ pub fn chain_block_with_coinbase(
     coinbase_utxo: TransactionOutput,
     coinbase_kernel: TransactionKernel,
     consensus: &ConsensusManager,
+    achieved_difficulty: Option<Difficulty>,
 ) -> NewBlockTemplate {
     let mut header = BlockHeader::from_previous(prev_block.header());
     header.version = consensus.consensus_constants(header.height).blockchain_version();
@@ -321,7 +322,7 @@ pub fn chain_block_with_coinbase(
             .with_transactions(transactions)
             .with_coinbase_utxo(coinbase_utxo, coinbase_kernel)
             .build(),
-        Difficulty::min(),
+        achieved_difficulty.unwrap_or(Difficulty::min()),
         consensus.get_block_reward_at(height),
     )
     .unwrap()
@@ -403,7 +404,14 @@ pub async fn append_block_with_coinbase<B: BlockchainBackend>(
         key_manager,
     )
     .await;
-    let template = chain_block_with_coinbase(prev_block, txns, coinbase_utxo, coinbase_kernel, consensus_manager);
+    let template = chain_block_with_coinbase(
+        prev_block,
+        txns,
+        coinbase_utxo,
+        coinbase_kernel,
+        consensus_manager,
+        None,
+    );
     let mut block = db.prepare_new_block(template)?;
     block.header.nonce = OsRng.next_u64();
     find_header_with_achieved_difficulty(&mut block.header, achieved_difficulty);
@@ -479,7 +487,7 @@ pub async fn generate_new_block_with_coinbase<B: BlockchainBackend>(
     block_utxos.push(coinbase_output);
 
     outputs.push(block_utxos);
-    generate_block_with_coinbase(db, blocks, txns, coinbase_utxo, coinbase_kernel, consensus)
+    generate_block_with_coinbase(db, blocks, txns, coinbase_utxo, coinbase_kernel, consensus, None)
 }
 
 pub fn find_header_with_achieved_difficulty(header: &mut BlockHeader, achieved_difficulty: Difficulty) {
@@ -545,23 +553,25 @@ pub async fn generate_block_with_achieved_difficulty<B: BlockchainBackend>(
 /// with the correct MMR roots.
 pub fn generate_block_with_coinbase<B: BlockchainBackend>(
     db: &mut BlockchainDatabase<B>,
-    blocks: &mut Vec<ChainBlock>,
+    prev_blocks: &mut Vec<ChainBlock>,
     transactions: Vec<Transaction>,
     coinbase_utxo: TransactionOutput,
     coinbase_kernel: TransactionKernel,
     consensus: &ConsensusManager,
+    achieved_difficulty: Option<Difficulty>,
 ) -> Result<BlockAddResult, ChainStorageError> {
     let template = chain_block_with_coinbase(
-        blocks.last().unwrap(),
+        prev_blocks.last().unwrap(),
         transactions,
         coinbase_utxo,
         coinbase_kernel,
         consensus,
+        achieved_difficulty,
     );
     let new_block = db.prepare_new_block(template)?;
     let result = db.add_block(new_block.into())?;
     if let BlockAddResult::Ok(ref b) = result {
-        blocks.push(b.as_ref().clone());
+        prev_blocks.push(b.as_ref().clone());
     }
     Ok(result)
 }

--- a/base_layer/core/tests/helpers/mod.rs
+++ b/base_layer/core/tests/helpers/mod.rs
@@ -15,5 +15,6 @@ pub mod event_stream;
 pub mod mock_state_machine;
 pub mod nodes;
 pub mod sample_blockchains;
+pub mod sync;
 pub mod test_block_builder;
 pub mod test_blockchain;

--- a/base_layer/core/tests/helpers/sync.rs
+++ b/base_layer/core/tests/helpers/sync.rs
@@ -1,3 +1,25 @@
+// Copyright 2020. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 use std::time::Duration;
 
 use tari_common::configuration::Network;

--- a/base_layer/core/tests/helpers/sync.rs
+++ b/base_layer/core/tests/helpers/sync.rs
@@ -1,0 +1,245 @@
+use std::time::Duration;
+
+use tari_common::configuration::Network;
+use tari_common_types::types::HashOutput;
+use tari_comms::peer_manager::NodeId;
+use tari_core::{
+    base_node::{
+        chain_metadata_service::PeerChainMetadata,
+        state_machine_service::states::{HeaderSyncState, StateEvent, StatusInfo},
+        sync::SyncPeer,
+        BaseNodeStateMachine,
+        BaseNodeStateMachineConfig,
+        SyncValidators,
+    },
+    blocks::ChainBlock,
+    chain_storage::DbTransaction,
+    consensus::{ConsensusConstantsBuilder, ConsensusManager, ConsensusManagerBuilder},
+    mempool::MempoolServiceConfig,
+    proof_of_work::{randomx_factory::RandomXFactory, Difficulty},
+    test_helpers::blockchain::TempDatabase,
+    transactions::test_helpers::{create_test_core_key_manager_with_memory_db, TestKeyManager},
+    validation::mocks::MockValidator,
+};
+use tari_p2p::{services::liveness::LivenessConfig, P2pConfig};
+use tari_shutdown::Shutdown;
+use tempfile::tempdir;
+use tokio::sync::{broadcast, watch};
+
+use crate::helpers::{
+    block_builders::{append_block, create_genesis_block},
+    nodes::{create_network_with_2_base_nodes_with_config, NodeInterfaces},
+};
+
+static EMISSION: [u64; 2] = [10, 10];
+
+pub async fn sync_headers(
+    alice_state_machine: &mut BaseNodeStateMachine<TempDatabase>,
+    alice_node: &NodeInterfaces,
+    bob_node: &NodeInterfaces,
+) -> StateEvent {
+    let mut header_sync = sync_headers_initialize(alice_node, bob_node);
+    sync_headers_execute(alice_state_machine, &mut header_sync).await
+}
+
+pub fn sync_headers_initialize(alice_node: &NodeInterfaces, bob_node: &NodeInterfaces) -> HeaderSyncState {
+    HeaderSyncState::new(
+        vec![SyncPeer::from(PeerChainMetadata::new(
+            bob_node.node_identity.node_id().clone(),
+            bob_node.blockchain_db.get_chain_metadata().unwrap(),
+            None,
+        ))],
+        alice_node.blockchain_db.get_chain_metadata().unwrap(),
+    )
+}
+
+pub async fn sync_headers_execute(
+    alice_state_machine: &mut BaseNodeStateMachine<TempDatabase>,
+    header_sync: &mut HeaderSyncState,
+) -> StateEvent {
+    header_sync.next_event(alice_state_machine).await
+}
+
+pub async fn create_network_with_alice_and_bob_nodes() -> (
+    BaseNodeStateMachine<TempDatabase>,
+    NodeInterfaces,
+    NodeInterfaces,
+    ChainBlock,
+    ConsensusManager,
+    TestKeyManager,
+) {
+    let network = Network::LocalNet;
+    let temp_dir = tempdir().unwrap();
+    let key_manager = create_test_core_key_manager_with_memory_db();
+    let consensus_constants = ConsensusConstantsBuilder::new(network)
+        .with_emission_amounts(100_000_000.into(), &EMISSION, 100.into())
+        .build();
+    let (initial_block, _) = create_genesis_block(&consensus_constants, &key_manager).await;
+    let consensus_manager = ConsensusManagerBuilder::new(network)
+        .add_consensus_constants(consensus_constants)
+        .with_block(initial_block.clone())
+        .build()
+        .unwrap();
+    let (alice_node, bob_node, consensus_manager) = create_network_with_2_base_nodes_with_config(
+        MempoolServiceConfig::default(),
+        LivenessConfig {
+            auto_ping_interval: Some(Duration::from_millis(100)),
+            ..Default::default()
+        },
+        P2pConfig::default(),
+        consensus_manager,
+        temp_dir.path().to_str().unwrap(),
+    )
+    .await;
+    let shutdown = Shutdown::new();
+    let (state_change_event_publisher, _) = broadcast::channel(10);
+    let (status_event_sender, _status_event_receiver) = watch::channel(StatusInfo::new());
+
+    // Alice needs a state machine for header sync
+    let alice_state_machine = BaseNodeStateMachine::new(
+        alice_node.blockchain_db.clone().into(),
+        alice_node.local_nci.clone(),
+        alice_node.comms.connectivity(),
+        alice_node.comms.peer_manager(),
+        alice_node.chain_metadata_handle.get_event_stream(),
+        BaseNodeStateMachineConfig::default(),
+        SyncValidators::new(MockValidator::new(true), MockValidator::new(true)),
+        status_event_sender,
+        state_change_event_publisher,
+        RandomXFactory::default(),
+        consensus_manager.clone(),
+        shutdown.to_signal(),
+    );
+
+    (
+        alice_state_machine,
+        alice_node,
+        bob_node,
+        initial_block,
+        consensus_manager,
+        key_manager,
+    )
+}
+
+#[allow(dead_code)]
+#[derive(Debug)]
+pub enum WhatToDelete {
+    Blocks,
+    Headers,
+}
+
+// Delete blocks and headers in reverse order; the first block in the slice wil not be deleted
+pub fn delete_some_blocks_and_headers(
+    blocks_with_anchor: &[ChainBlock],
+    instruction: WhatToDelete,
+    node: &NodeInterfaces,
+    set_best_block: Option<bool>,
+) {
+    if blocks_with_anchor.is_empty() || blocks_with_anchor.len() < 2 {
+        panic!("blocks must have at least 2 elements");
+    }
+    let set_best_block = set_best_block.unwrap_or(false);
+    let mut blocks: Vec<_> = blocks_with_anchor.to_vec();
+    blocks.reverse();
+    for i in 0..blocks.len() - 1 {
+        let mut txn = DbTransaction::new();
+        match instruction {
+            WhatToDelete::Blocks => {
+                txn.delete_block(*blocks[i].hash());
+                txn.delete_orphan(*blocks[i].hash());
+                if set_best_block {
+                    txn.set_best_block(
+                        blocks[i + 1].height(),
+                        blocks[i + 1].accumulated_data().hash,
+                        blocks[i + 1].accumulated_data().total_accumulated_difficulty,
+                        *node.blockchain_db.get_chain_metadata().unwrap().best_block(),
+                        blocks[i + 1].to_chain_header().timestamp(),
+                    );
+                }
+            },
+            WhatToDelete::Headers => {
+                txn.delete_header(blocks[i].height());
+            },
+        }
+        node.blockchain_db.write(txn).unwrap();
+        // Note: Something is funny here... the block is deleted but the block exists in the db
+        // match instruction {
+        //     WhatToDelete::Blocks | WhatToDelete::BlocksAndHeaders => {
+        //         assert!(!node.blockchain_db.block_exists(*blocks[i].hash()).unwrap());
+        //     }
+        //     WhatToDelete::Headers => {}
+        // }
+    }
+}
+
+#[allow(dead_code)]
+pub fn set_best_block(block: &ChainBlock, previous_block_hash: &HashOutput, node: &NodeInterfaces) {
+    let mut txn = DbTransaction::new();
+    txn.set_best_block(
+        block.height(),
+        block.accumulated_data().hash,
+        block.accumulated_data().total_accumulated_difficulty,
+        *previous_block_hash,
+        block.to_chain_header().timestamp(),
+    );
+    node.blockchain_db.write(txn).unwrap();
+}
+
+pub fn add_some_existing_blocks(blocks: &[ChainBlock], node: &NodeInterfaces) {
+    for block in blocks {
+        let _res = node.blockchain_db.add_block(block.block().clone().into()).unwrap();
+    }
+}
+
+// Return blocks added, including the start block
+pub async fn create_and_add_some_blocks(
+    node: &NodeInterfaces,
+    start_block: &ChainBlock,
+    number_of_blocks: usize,
+    consensus_manager: &ConsensusManager,
+    key_manager: &TestKeyManager,
+    difficulties: &[u64],
+) -> Vec<ChainBlock> {
+    if number_of_blocks != difficulties.len() {
+        panic!(
+            "Number of blocks ({}) and difficulties length ({}) must be equal",
+            number_of_blocks,
+            difficulties.len()
+        );
+    }
+    let mut blocks = vec![start_block.clone()];
+    let mut prev_block = start_block.clone();
+    for item in difficulties.iter().take(number_of_blocks) {
+        prev_block = append_block(
+            &node.blockchain_db,
+            &prev_block,
+            vec![],
+            consensus_manager,
+            Difficulty::from_u64(*item).unwrap(),
+            key_manager,
+        )
+        .await
+        .unwrap();
+        blocks.push(prev_block.clone());
+    }
+    blocks
+}
+
+// We give some time for the peer to be banned as it is an async process
+pub async fn wait_for_is_peer_banned(this_node: &NodeInterfaces, peer_node_id: &NodeId, seconds: u64) -> bool {
+    let interval_ms = 100;
+    let intervals = seconds * 1000 / interval_ms;
+    for _ in 0..intervals {
+        tokio::time::sleep(Duration::from_millis(interval_ms)).await;
+        if this_node
+            .comms
+            .peer_manager()
+            .is_peer_banned(peer_node_id)
+            .await
+            .unwrap()
+        {
+            return true;
+        }
+    }
+    false
+}

--- a/base_layer/core/tests/helpers/sync.rs
+++ b/base_layer/core/tests/helpers/sync.rs
@@ -164,7 +164,7 @@ pub fn delete_some_blocks_and_headers(
         node.blockchain_db.write(txn).unwrap();
         // Note: Something is funny here... the block is deleted but the block exists in the db
         // match instruction {
-        //     WhatToDelete::Blocks | WhatToDelete::BlocksAndHeaders => {
+        //     WhatToDelete::Blocks => {
         //         assert!(!node.blockchain_db.block_exists(*blocks[i].hash()).unwrap());
         //     }
         //     WhatToDelete::Headers => {}

--- a/base_layer/core/tests/helpers/sync.rs
+++ b/base_layer/core/tests/helpers/sync.rs
@@ -178,7 +178,9 @@ pub fn delete_some_blocks_and_headers(
             },
         }
         node.blockchain_db.write(txn).unwrap();
-        // Note: Something is funny here... the block is deleted but the block exists in the db
+        // Note: Something is funny here... the block is deleted but the block exists in the db. This should be
+        //       investigated and fixed as it will enhance the tests. If we uncomment the following assertion, the
+        //       tests depending on this function will fail.
         // match instruction {
         //     WhatToDelete::Blocks => {
         //         assert!(!node.blockchain_db.block_exists(*blocks[i].hash()).unwrap());

--- a/base_layer/core/tests/helpers/sync.rs
+++ b/base_layer/core/tests/helpers/sync.rs
@@ -33,16 +33,10 @@ use crate::helpers::{
 
 static EMISSION: [u64; 2] = [10, 10];
 
-pub async fn sync_headers(
-    alice_state_machine: &mut BaseNodeStateMachine<TempDatabase>,
+pub fn sync_headers_initialize_with_ping_pong_data(
     alice_node: &NodeInterfaces,
     bob_node: &NodeInterfaces,
-) -> StateEvent {
-    let mut header_sync = sync_headers_initialize(alice_node, bob_node);
-    sync_headers_execute(alice_state_machine, &mut header_sync).await
-}
-
-pub fn sync_headers_initialize(alice_node: &NodeInterfaces, bob_node: &NodeInterfaces) -> HeaderSyncState {
+) -> HeaderSyncState {
     HeaderSyncState::new(
         vec![SyncPeer::from(PeerChainMetadata::new(
             bob_node.node_identity.node_id().clone(),

--- a/base_layer/core/tests/tests/block_validation.rs
+++ b/base_layer/core/tests/tests/block_validation.rs
@@ -413,6 +413,7 @@ async fn test_orphan_validator() {
         coinbase_utxo,
         coinbase_kernel,
         &rules,
+        None,
     );
     let new_block = db.prepare_new_block(template).unwrap();
     assert!(orphan_validator.validate_internal_consistency(&new_block).is_err());
@@ -431,6 +432,7 @@ async fn test_orphan_validator() {
         coinbase_utxo,
         coinbase_kernel,
         &rules,
+        None,
     );
     let new_block = db.prepare_new_block(template).unwrap();
     assert!(orphan_validator.validate_internal_consistency(&new_block).is_err());
@@ -983,6 +985,7 @@ async fn test_block_sync_body_validator() {
         coinbase_utxo,
         coinbase_kernel,
         &rules,
+        None,
     );
     let new_block = db.prepare_new_block(template).unwrap();
     {
@@ -1005,6 +1008,7 @@ async fn test_block_sync_body_validator() {
         coinbase_utxo,
         coinbase_kernel,
         &rules,
+        None,
     );
     let new_block = db.prepare_new_block(template).unwrap();
     {

--- a/base_layer/core/tests/tests/header_sync.rs
+++ b/base_layer/core/tests/tests/header_sync.rs
@@ -34,11 +34,12 @@ use tari_core::{
         sync::{HeaderSyncStatus, SyncPeer},
         SyncValidators,
     },
-    consensus::{ConsensusConstantsBuilder, ConsensusManagerBuilder},
+    blocks::ChainBlock,
+    consensus::{ConsensusConstantsBuilder, ConsensusManager, ConsensusManagerBuilder},
     mempool::MempoolServiceConfig,
     proof_of_work::{randomx_factory::RandomXFactory, Difficulty},
     test_helpers::blockchain::TempDatabase,
-    transactions::test_helpers::create_test_core_key_manager_with_memory_db,
+    transactions::test_helpers::{create_test_core_key_manager_with_memory_db, TestKeyManager},
     validation::mocks::MockValidator,
 };
 use tari_p2p::{services::liveness::config::LivenessConfig, P2pConfig};
@@ -53,10 +54,30 @@ use crate::helpers::{
 
 static EMISSION: [u64; 2] = [10, 10];
 
-#[allow(clippy::too_many_lines)]
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_header_sync() {
-    // Create the network with alice node and bob node
+async fn sync_headers(
+    alice_state_machine: &mut BaseNodeStateMachine<TempDatabase>,
+    alice_node: &NodeInterfaces,
+    bob_node: &NodeInterfaces,
+) -> StateEvent {
+    let mut header_sync = HeaderSyncState::new(
+        vec![SyncPeer::from(PeerChainMetadata::new(
+            bob_node.node_identity.node_id().clone(),
+            bob_node.blockchain_db.get_chain_metadata().unwrap(),
+            None,
+        ))],
+        alice_node.blockchain_db.get_chain_metadata().unwrap(),
+    );
+    header_sync.next_event(alice_state_machine).await
+}
+
+async fn create_network_with_alice_and_bob_nodes() -> (
+    BaseNodeStateMachine<TempDatabase>,
+    NodeInterfaces,
+    NodeInterfaces,
+    ChainBlock,
+    ConsensusManager,
+    TestKeyManager,
+) {
     let network = Network::LocalNet;
     let temp_dir = tempdir().unwrap();
     let key_manager = create_test_core_key_manager_with_memory_db();
@@ -85,7 +106,7 @@ async fn test_header_sync() {
     let (status_event_sender, _status_event_receiver) = watch::channel(StatusInfo::new());
 
     // Alice needs a state machine for header sync
-    let mut alice_state_machine = BaseNodeStateMachine::new(
+    let alice_state_machine = BaseNodeStateMachine::new(
         alice_node.blockchain_db.clone().into(),
         alice_node.local_nci.clone(),
         alice_node.comms.connectivity(),
@@ -100,7 +121,24 @@ async fn test_header_sync() {
         shutdown.to_signal(),
     );
 
-    // Add 1 block to bob's chain
+    (
+        alice_state_machine,
+        alice_node,
+        bob_node,
+        initial_block,
+        consensus_manager,
+        key_manager,
+    )
+}
+
+#[allow(clippy::too_many_lines)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_header_sync() {
+    // Create the network with Alice node and Bob node
+    let (mut alice_state_machine, alice_node, bob_node, initial_block, consensus_manager, key_manager) =
+        create_network_with_alice_and_bob_nodes().await;
+
+    // Add 1 block to Bob's chain
     let block_1_bob = append_block(
         &bob_node.blockchain_db,
         &initial_block,
@@ -118,14 +156,14 @@ async fn test_header_sync() {
     let event = sync_headers(&mut alice_state_machine, &alice_node, &bob_node).await;
     // "Lagging"
     match event.clone() {
-        StateEvent::HeadersSynchronized(val, sync_result) => {
-            assert_eq!(val.claimed_chain_metadata().height_of_longest_chain(), 1);
-            assert_eq!(val.claimed_chain_metadata().accumulated_difficulty(), 4);
+        StateEvent::HeadersSynchronized(_val, sync_result) => {
+            assert_eq!(sync_result.peer_best_block_height, 1);
+            assert_eq!(sync_result.peer_accumulated_difficulty, 4);
             assert_eq!(sync_result.headers_returned, 1);
-            assert_eq!(sync_result.fork_hash_index, 0);
+            assert_eq!(sync_result.peer_fork_hash_index, 0);
             if let HeaderSyncStatus::Lagging(val) = sync_result.header_sync_status {
                 assert_eq!(val.remote_tip_height, 1);
-                assert_eq!(val.best_block.height(), 0);
+                assert_eq!(val.best_block_header.height(), 0);
                 assert_eq!(val.reorg_steps_back, 0);
             } else {
                 panic!("Should be 'Lagging'");
@@ -138,11 +176,11 @@ async fn test_header_sync() {
     let event = sync_headers(&mut alice_state_machine, &alice_node, &bob_node).await;
     // "InSyncOrAhead"
     match event.clone() {
-        StateEvent::HeadersSynchronized(val, sync_result) => {
-            assert_eq!(val.claimed_chain_metadata().height_of_longest_chain(), 1);
-            assert_eq!(val.claimed_chain_metadata().accumulated_difficulty(), 4);
+        StateEvent::HeadersSynchronized(_val, sync_result) => {
+            assert_eq!(sync_result.peer_best_block_height, 1);
+            assert_eq!(sync_result.peer_accumulated_difficulty, 4);
             assert_eq!(sync_result.headers_returned, 0);
-            assert_eq!(sync_result.fork_hash_index, 0);
+            assert_eq!(sync_result.peer_fork_hash_index, 0);
             if let HeaderSyncStatus::InSyncOrAhead = sync_result.header_sync_status {
                 // Good, headers were in sync
             } else {
@@ -169,14 +207,14 @@ async fn test_header_sync() {
     let event = sync_headers(&mut alice_state_machine, &alice_node, &bob_node).await;
     // "Lagging"
     match event.clone() {
-        StateEvent::HeadersSynchronized(val, sync_result) => {
-            assert_eq!(val.claimed_chain_metadata().height_of_longest_chain(), 2);
-            assert_eq!(val.claimed_chain_metadata().accumulated_difficulty(), 7);
+        StateEvent::HeadersSynchronized(_val, sync_result) => {
+            assert_eq!(sync_result.peer_best_block_height, 2);
+            assert_eq!(sync_result.peer_accumulated_difficulty, 7);
             assert_eq!(sync_result.headers_returned, 1);
-            assert_eq!(sync_result.fork_hash_index, 0);
+            assert_eq!(sync_result.peer_fork_hash_index, 0);
             if let HeaderSyncStatus::Lagging(val) = sync_result.header_sync_status {
                 assert_eq!(val.remote_tip_height, 2);
-                assert_eq!(val.best_block.height(), 0);
+                assert_eq!(val.best_block_header.height(), 0);
                 assert_eq!(val.reorg_steps_back, 0);
             } else {
                 panic!("Should be 'Lagging'");
@@ -185,7 +223,7 @@ async fn test_header_sync() {
         _ => panic!("Expected StateEvent::HeadersSynchronized event"),
     }
 
-    // Alice adds 3 (different) blocks, with POW on par with bob's chain, but with greater height
+    // Alice adds 3 (different) blocks, with POW on par with Bob's chain, but with greater height
     let block_1_alice = append_block(
         &alice_node.blockchain_db,
         &initial_block,
@@ -206,7 +244,7 @@ async fn test_header_sync() {
     )
     .await
     .unwrap();
-    // Alice adds another block, with POW on par with bob's chain, but with greater height
+    // Alice adds another block, with POW on par with Bob's chain, but with greater height
     let block_3_alice = append_block(
         &alice_node.blockchain_db,
         &block_2_alice,
@@ -260,14 +298,14 @@ async fn test_header_sync() {
     let event = sync_headers(&mut alice_state_machine, &alice_node, &bob_node).await;
     // "Lagging"
     match event {
-        StateEvent::HeadersSynchronized(val, sync_result) => {
-            assert_eq!(val.claimed_chain_metadata().height_of_longest_chain(), 4);
-            assert_eq!(val.claimed_chain_metadata().accumulated_difficulty(), 13);
+        StateEvent::HeadersSynchronized(_val, sync_result) => {
+            assert_eq!(sync_result.peer_best_block_height, 4);
+            assert_eq!(sync_result.peer_accumulated_difficulty, 13);
             assert_eq!(sync_result.headers_returned, 4);
-            assert_eq!(sync_result.fork_hash_index, 3);
+            assert_eq!(sync_result.peer_fork_hash_index, 3);
             if let HeaderSyncStatus::Lagging(val) = sync_result.header_sync_status {
                 assert_eq!(val.remote_tip_height, 4);
-                assert_eq!(val.best_block.height(), 3);
+                assert_eq!(val.best_block_header.height(), 3);
                 assert_eq!(val.reorg_steps_back, 3);
             } else {
                 panic!("Should be 'Lagging'");
@@ -277,18 +315,61 @@ async fn test_header_sync() {
     }
 }
 
-async fn sync_headers(
-    alice_state_machine: &mut BaseNodeStateMachine<TempDatabase>,
-    alice_node: &NodeInterfaces,
-    bob_node: &NodeInterfaces,
-) -> StateEvent {
-    let mut header_sync = HeaderSyncState::new(
-        vec![SyncPeer::from(PeerChainMetadata::new(
-            bob_node.node_identity.node_id().clone(),
-            bob_node.blockchain_db.get_chain_metadata().unwrap(),
-            None,
-        ))],
-        alice_node.blockchain_db.get_chain_metadata().unwrap(),
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_header_sync_different_chains() {
+    // Create the network with Alice node and Bob node
+    let (_alice_state_machine, _alice_node, bob_node, initial_block, consensus_manager, key_manager) =
+        create_network_with_alice_and_bob_nodes().await;
+
+    // Add a block to Bob's chain
+    let _block_1_bob = append_block(
+        &bob_node.blockchain_db,
+        &initial_block,
+        vec![],
+        &consensus_manager,
+        Difficulty::from_u64(3).unwrap(),
+        &key_manager,
+    )
+    .await
+    .unwrap();
+    assert_eq!(bob_node.blockchain_db.get_height().unwrap(), 1);
+
+    // Create a different chain for Alice
+    let (mut alice_state_machine, alice_node, _bob_node, initial_block, consensus_manager, key_manager) =
+        create_network_with_alice_and_bob_nodes().await;
+
+    let _block_1_alice = append_block(
+        &alice_node.blockchain_db,
+        &initial_block,
+        vec![],
+        &consensus_manager,
+        Difficulty::from_u64(2).unwrap(),
+        &key_manager,
+    )
+    .await
+    .unwrap();
+    assert_eq!(alice_node.blockchain_db.get_height().unwrap(), 1);
+    assert!(
+        alice_node
+            .blockchain_db
+            .get_chain_metadata()
+            .unwrap()
+            .accumulated_difficulty() <
+            bob_node
+                .blockchain_db
+                .get_chain_metadata()
+                .unwrap()
+                .accumulated_difficulty()
     );
-    header_sync.next_event(alice_state_machine).await
+
+    // Alice attempts header sync, still on the genesys block, headers will be lagging
+    let event = sync_headers(&mut alice_state_machine, &alice_node, &bob_node).await;
+    println!("\nevent -> bob_node_1: {:?}", event);
+    // "Lagging"
+    match event {
+        StateEvent::HeaderSyncFailed(err) => {
+            assert_eq!(&err, "No more sync peers available: Header sync failed");
+        },
+        _ => panic!("Expected HeaderSyncFailed event"),
+    }
 }

--- a/base_layer/core/tests/tests/header_sync.rs
+++ b/base_layer/core/tests/tests/header_sync.rs
@@ -20,140 +20,26 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::time::Duration;
+use tari_core::base_node::{state_machine_service::states::StateEvent, sync::HeaderSyncStatus};
 
-use tari_common::configuration::Network;
-use tari_core::{
-    base_node::{
-        chain_metadata_service::PeerChainMetadata,
-        state_machine_service::{
-            states::{HeaderSyncState, StateEvent, StatusInfo},
-            BaseNodeStateMachine,
-            BaseNodeStateMachineConfig,
-        },
-        sync::{HeaderSyncStatus, SyncPeer},
-        SyncValidators,
-    },
-    blocks::ChainBlock,
-    consensus::{ConsensusConstantsBuilder, ConsensusManager, ConsensusManagerBuilder},
-    mempool::MempoolServiceConfig,
-    proof_of_work::{randomx_factory::RandomXFactory, Difficulty},
-    test_helpers::blockchain::TempDatabase,
-    transactions::test_helpers::{create_test_core_key_manager_with_memory_db, TestKeyManager},
-    validation::mocks::MockValidator,
-};
-use tari_p2p::{services::liveness::config::LivenessConfig, P2pConfig};
-use tari_shutdown::Shutdown;
-use tempfile::tempdir;
-use tokio::sync::{broadcast, watch};
-
-use crate::helpers::{
-    block_builders::{append_block, create_genesis_block},
-    nodes::{create_network_with_2_base_nodes_with_config, NodeInterfaces},
-};
-
-static EMISSION: [u64; 2] = [10, 10];
-
-async fn sync_headers(
-    alice_state_machine: &mut BaseNodeStateMachine<TempDatabase>,
-    alice_node: &NodeInterfaces,
-    bob_node: &NodeInterfaces,
-) -> StateEvent {
-    let mut header_sync = HeaderSyncState::new(
-        vec![SyncPeer::from(PeerChainMetadata::new(
-            bob_node.node_identity.node_id().clone(),
-            bob_node.blockchain_db.get_chain_metadata().unwrap(),
-            None,
-        ))],
-        alice_node.blockchain_db.get_chain_metadata().unwrap(),
-    );
-    header_sync.next_event(alice_state_machine).await
-}
-
-async fn create_network_with_alice_and_bob_nodes() -> (
-    BaseNodeStateMachine<TempDatabase>,
-    NodeInterfaces,
-    NodeInterfaces,
-    ChainBlock,
-    ConsensusManager,
-    TestKeyManager,
-) {
-    let network = Network::LocalNet;
-    let temp_dir = tempdir().unwrap();
-    let key_manager = create_test_core_key_manager_with_memory_db();
-    let consensus_constants = ConsensusConstantsBuilder::new(network)
-        .with_emission_amounts(100_000_000.into(), &EMISSION, 100.into())
-        .build();
-    let (initial_block, _) = create_genesis_block(&consensus_constants, &key_manager).await;
-    let consensus_manager = ConsensusManagerBuilder::new(network)
-        .add_consensus_constants(consensus_constants)
-        .with_block(initial_block.clone())
-        .build()
-        .unwrap();
-    let (alice_node, bob_node, consensus_manager) = create_network_with_2_base_nodes_with_config(
-        MempoolServiceConfig::default(),
-        LivenessConfig {
-            auto_ping_interval: Some(Duration::from_millis(100)),
-            ..Default::default()
-        },
-        P2pConfig::default(),
-        consensus_manager,
-        temp_dir.path().to_str().unwrap(),
-    )
-    .await;
-    let shutdown = Shutdown::new();
-    let (state_change_event_publisher, _) = broadcast::channel(10);
-    let (status_event_sender, _status_event_receiver) = watch::channel(StatusInfo::new());
-
-    // Alice needs a state machine for header sync
-    let alice_state_machine = BaseNodeStateMachine::new(
-        alice_node.blockchain_db.clone().into(),
-        alice_node.local_nci.clone(),
-        alice_node.comms.connectivity(),
-        alice_node.comms.peer_manager(),
-        alice_node.chain_metadata_handle.get_event_stream(),
-        BaseNodeStateMachineConfig::default(),
-        SyncValidators::new(MockValidator::new(true), MockValidator::new(true)),
-        status_event_sender,
-        state_change_event_publisher,
-        RandomXFactory::default(),
-        consensus_manager.clone(),
-        shutdown.to_signal(),
-    );
-
-    (
-        alice_state_machine,
-        alice_node,
-        bob_node,
-        initial_block,
-        consensus_manager,
-        key_manager,
-    )
-}
+use crate::helpers::{sync, sync::WhatToDelete};
 
 #[allow(clippy::too_many_lines)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_header_sync() {
+async fn test_header_sync_happy_path() {
+    // env_logger::init(); // Set `$env:RUST_LOG = "trace"`
+
     // Create the network with Alice node and Bob node
     let (mut alice_state_machine, alice_node, bob_node, initial_block, consensus_manager, key_manager) =
-        create_network_with_alice_and_bob_nodes().await;
+        sync::create_network_with_alice_and_bob_nodes().await;
 
     // Add 1 block to Bob's chain
-    let block_1_bob = append_block(
-        &bob_node.blockchain_db,
-        &initial_block,
-        vec![],
-        &consensus_manager,
-        Difficulty::from_u64(3).unwrap(),
-        &key_manager,
-    )
-    .await
-    .unwrap();
-    assert_eq!(block_1_bob.height(), 1);
+    let bob_blocks =
+        sync::create_and_add_some_blocks(&bob_node, &initial_block, 1, &consensus_manager, &key_manager, &[3]).await;
     assert_eq!(bob_node.blockchain_db.get_height().unwrap(), 1);
 
     // Alice attempts header sync, still on the genesys block, headers will be lagging
-    let event = sync_headers(&mut alice_state_machine, &alice_node, &bob_node).await;
+    let event = sync::sync_headers(&mut alice_state_machine, &alice_node, &bob_node).await;
     // "Lagging"
     match event.clone() {
         StateEvent::HeadersSynchronized(_val, sync_result) => {
@@ -173,7 +59,7 @@ async fn test_header_sync() {
     }
 
     // Alice attempts header sync again, still on the genesys block, headers will be in sync
-    let event = sync_headers(&mut alice_state_machine, &alice_node, &bob_node).await;
+    let event = sync::sync_headers(&mut alice_state_machine, &alice_node, &bob_node).await;
     // "InSyncOrAhead"
     match event.clone() {
         StateEvent::HeadersSynchronized(_val, sync_result) => {
@@ -191,20 +77,12 @@ async fn test_header_sync() {
     }
 
     // Bob adds another block
-    let block_2_bob = append_block(
-        &bob_node.blockchain_db,
-        &block_1_bob,
-        vec![],
-        &consensus_manager,
-        Difficulty::from_u64(3).unwrap(),
-        &key_manager,
-    )
-    .await
-    .unwrap();
-    assert_eq!(block_2_bob.height(), 2);
+    let bob_blocks =
+        sync::create_and_add_some_blocks(&bob_node, &bob_blocks[1], 1, &consensus_manager, &key_manager, &[3]).await;
+    assert_eq!(bob_node.blockchain_db.get_height().unwrap(), 2);
 
     // Alice attempts header sync, still on the genesys block, headers will be lagging
-    let event = sync_headers(&mut alice_state_machine, &alice_node, &bob_node).await;
+    let event = sync::sync_headers(&mut alice_state_machine, &alice_node, &bob_node).await;
     // "Lagging"
     match event.clone() {
         StateEvent::HeadersSynchronized(_val, sync_result) => {
@@ -224,78 +102,43 @@ async fn test_header_sync() {
     }
 
     // Alice adds 3 (different) blocks, with POW on par with Bob's chain, but with greater height
-    let block_1_alice = append_block(
-        &alice_node.blockchain_db,
-        &initial_block,
-        vec![],
-        &consensus_manager,
-        Difficulty::from_u64(3).unwrap(),
-        &key_manager,
-    )
-    .await
-    .unwrap();
-    let block_2_alice = append_block(
-        &alice_node.blockchain_db,
-        &block_1_alice,
-        vec![],
-        &consensus_manager,
-        Difficulty::from_u64(2).unwrap(),
-        &key_manager,
-    )
-    .await
-    .unwrap();
-    // Alice adds another block, with POW on par with Bob's chain, but with greater height
-    let block_3_alice = append_block(
-        &alice_node.blockchain_db,
-        &block_2_alice,
-        vec![],
-        &consensus_manager,
-        Difficulty::from_u64(1).unwrap(),
-        &key_manager,
-    )
-    .await
-    .unwrap();
-    assert_eq!(block_3_alice.height(), 3);
-    assert_eq!(block_3_alice.accumulated_data().total_accumulated_difficulty, 7);
+    let _alice_blocks =
+        sync::create_and_add_some_blocks(&alice_node, &initial_block, 3, &consensus_manager, &key_manager, &[
+            3, 2, 1,
+        ])
+        .await;
+    assert_eq!(alice_node.blockchain_db.get_height().unwrap(), 3);
     assert_eq!(
-        block_3_alice.accumulated_data().total_accumulated_difficulty,
-        block_2_bob.accumulated_data().total_accumulated_difficulty
+        alice_node
+            .blockchain_db
+            .get_chain_metadata()
+            .unwrap()
+            .accumulated_difficulty(),
+        bob_node
+            .blockchain_db
+            .get_chain_metadata()
+            .unwrap()
+            .accumulated_difficulty()
     );
 
     // Alice attempts header sync, but POW is on par
-    let event = sync_headers(&mut alice_state_machine, &alice_node, &bob_node).await;
+    let event = sync::sync_headers(&mut alice_state_machine, &alice_node, &bob_node).await;
     match event.clone() {
         StateEvent::Continue => {
             // Good - Header sync not attempted, sync peer does not have better POW
         },
         _ => panic!("Expected StateEvent::Continue event"),
     }
+    // All is good, Bob is not banned
+    assert!(!sync::wait_for_is_peer_banned(&alice_node, bob_node.node_identity.node_id(), 1).await);
 
     // Bob adds more blocks and draws ahead of Alice
-    let block_3_bob = append_block(
-        &bob_node.blockchain_db,
-        &block_2_bob,
-        vec![],
-        &consensus_manager,
-        Difficulty::from_u64(3).unwrap(),
-        &key_manager,
-    )
-    .await
-    .unwrap();
-    let block_4_bob = append_block(
-        &bob_node.blockchain_db,
-        &block_3_bob,
-        vec![],
-        &consensus_manager,
-        Difficulty::from_u64(3).unwrap(),
-        &key_manager,
-    )
-    .await
-    .unwrap();
-    assert_eq!(block_4_bob.height(), 4);
+    let _bob_blocks =
+        sync::create_and_add_some_blocks(&bob_node, &bob_blocks[1], 2, &consensus_manager, &key_manager, &[3; 2]).await;
+    assert_eq!(bob_node.blockchain_db.get_height().unwrap(), 4);
 
     // Alice attempts header sync, on a higher chain with less POW, headers will be lagging with reorg steps
-    let event = sync_headers(&mut alice_state_machine, &alice_node, &bob_node).await;
+    let event = sync::sync_headers(&mut alice_state_machine, &alice_node, &bob_node).await;
     // "Lagging"
     match event {
         StateEvent::HeadersSynchronized(_val, sync_result) => {
@@ -316,60 +159,119 @@ async fn test_header_sync() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_header_sync_different_chains() {
+async fn test_header_sync_uneven_headers_and_blocks() {
+    // env_logger::init(); // Set `$env:RUST_LOG = "trace"`
+
     // Create the network with Alice node and Bob node
-    let (_alice_state_machine, _alice_node, bob_node, initial_block, consensus_manager, key_manager) =
-        create_network_with_alice_and_bob_nodes().await;
+    let (mut alice_state_machine, alice_node, bob_node, initial_block, consensus_manager, key_manager) =
+        sync::create_network_with_alice_and_bob_nodes().await;
 
-    // Add a block to Bob's chain
-    let _block_1_bob = append_block(
-        &bob_node.blockchain_db,
+    // Add blocks and headers to Bob's chain, with more headers than blocks
+    let blocks = sync::create_and_add_some_blocks(
+        &bob_node,
         &initial_block,
-        vec![],
+        10,
         &consensus_manager,
-        Difficulty::from_u64(3).unwrap(),
         &key_manager,
+        &[3; 10],
     )
-    .await
-    .unwrap();
-    assert_eq!(bob_node.blockchain_db.get_height().unwrap(), 1);
+    .await;
+    sync::delete_some_blocks_and_headers(&blocks[5..=10], WhatToDelete::Blocks, &bob_node, Some(true));
+    sync::delete_some_blocks_and_headers(&blocks[7..=10], WhatToDelete::Headers, &bob_node, None);
+    assert_eq!(bob_node.blockchain_db.get_height().unwrap(), 5);
+    assert_eq!(bob_node.blockchain_db.fetch_last_header().unwrap().height, 7);
 
-    // Create a different chain for Alice
-    let (mut alice_state_machine, alice_node, _bob_node, initial_block, consensus_manager, key_manager) =
-        create_network_with_alice_and_bob_nodes().await;
+    // Add blocks and headers to Alice's chain, with more headers than blocks
+    sync::add_some_existing_blocks(&blocks[1..=10], &alice_node);
+    sync::delete_some_blocks_and_headers(&blocks[2..=10], WhatToDelete::Blocks, &alice_node, Some(true));
+    assert_eq!(alice_node.blockchain_db.get_height().unwrap(), 2);
+    assert_eq!(alice_node.blockchain_db.fetch_last_header().unwrap().height, 10);
 
-    let _block_1_alice = append_block(
-        &alice_node.blockchain_db,
-        &initial_block,
-        vec![],
-        &consensus_manager,
-        Difficulty::from_u64(2).unwrap(),
-        &key_manager,
-    )
-    .await
-    .unwrap();
-    assert_eq!(alice_node.blockchain_db.get_height().unwrap(), 1);
+    // Alice attempts header sync, but her headers are ahead
+    let event = sync::sync_headers(&mut alice_state_machine, &alice_node, &bob_node).await;
+    match event {
+        StateEvent::HeadersSynchronized(_val, sync_result) => {
+            assert_eq!(sync_result.peer_best_block_height, 5);
+            assert_eq!(sync_result.peer_accumulated_difficulty, 16);
+            assert_eq!(sync_result.headers_returned, 0);
+            assert_eq!(sync_result.peer_fork_hash_index, 3);
+            if let HeaderSyncStatus::InSyncOrAhead = sync_result.header_sync_status {
+                // Good, headers were in sync
+            } else {
+                panic!("Should be 'InSyncOrAhead'");
+            }
+        },
+        _ => panic!("Expected HeadersSynchronized event"),
+    }
+    // All is good, Bob is not banned
+    assert!(!sync::wait_for_is_peer_banned(&alice_node, bob_node.node_identity.node_id(), 1).await);
+
+    // Alice attempts header sync, her headers are ahead, but Bob will lie about his POW
+    let mut header_sync = sync::sync_headers_initialize(&alice_node, &bob_node);
+    sync::delete_some_blocks_and_headers(&blocks[4..=5], WhatToDelete::Blocks, &bob_node, Some(true));
     assert!(
-        alice_node
-            .blockchain_db
-            .get_chain_metadata()
-            .unwrap()
-            .accumulated_difficulty() <
+        header_sync.clone().into_sync_peers()[0]
+            .claimed_chain_metadata()
+            .accumulated_difficulty() >
             bob_node
                 .blockchain_db
                 .get_chain_metadata()
                 .unwrap()
                 .accumulated_difficulty()
     );
-
-    // Alice attempts header sync, still on the genesys block, headers will be lagging
-    let event = sync_headers(&mut alice_state_machine, &alice_node, &bob_node).await;
-    println!("\nevent -> bob_node_1: {:?}", event);
-    // "Lagging"
+    let event = sync::sync_headers_execute(&mut alice_state_machine, &mut header_sync).await;
     match event {
         StateEvent::HeaderSyncFailed(err) => {
             assert_eq!(&err, "No more sync peers available: Header sync failed");
         },
         _ => panic!("Expected HeaderSyncFailed event"),
     }
+    // Bob will be banned
+    assert!(sync::wait_for_is_peer_banned(&alice_node, bob_node.node_identity.node_id(), 1).await);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_header_sync_even_headers_and_blocks() {
+    env_logger::init(); // Set `$env:RUST_LOG = "trace"`
+
+    // Create the network with Alice node and Bob node
+    let (mut alice_state_machine, alice_node, bob_node, initial_block, consensus_manager, key_manager) =
+        sync::create_network_with_alice_and_bob_nodes().await;
+
+    // Add blocks and headers to Bob's chain, with more headers than blocks
+    let blocks =
+        sync::create_and_add_some_blocks(&bob_node, &initial_block, 6, &consensus_manager, &key_manager, &[3; 6]).await;
+    assert_eq!(bob_node.blockchain_db.get_height().unwrap(), 6);
+    assert_eq!(bob_node.blockchain_db.fetch_last_header().unwrap().height, 6);
+
+    // Add blocks and headers to Alice's chain, with more headers than blocks
+    sync::add_some_existing_blocks(&blocks[1..=5], &alice_node);
+    assert_eq!(alice_node.blockchain_db.get_height().unwrap(), 5);
+    assert_eq!(alice_node.blockchain_db.fetch_last_header().unwrap().height, 5);
+
+    // Alice attempts header sync, but Bob will lie about his POW
+    let mut header_sync = sync::sync_headers_initialize(&alice_node, &bob_node);
+    sync::delete_some_blocks_and_headers(&blocks[3..=6], WhatToDelete::Blocks, &bob_node, Some(true));
+    sync::delete_some_blocks_and_headers(&blocks[3..=6], WhatToDelete::Headers, &bob_node, None);
+    assert_eq!(bob_node.blockchain_db.get_height().unwrap(), 3);
+    assert_eq!(bob_node.blockchain_db.fetch_last_header().unwrap().height, 3);
+    assert!(
+        header_sync.clone().into_sync_peers()[0]
+            .claimed_chain_metadata()
+            .accumulated_difficulty() >
+            bob_node
+                .blockchain_db
+                .get_chain_metadata()
+                .unwrap()
+                .accumulated_difficulty()
+    );
+    let event = sync::sync_headers_execute(&mut alice_state_machine, &mut header_sync).await;
+    match event {
+        StateEvent::HeaderSyncFailed(err) => {
+            assert_eq!(&err, "No more sync peers available: Header sync failed");
+        },
+        _ => panic!("Expected HeaderSyncFailed event"),
+    }
+    // Bob will be banned
+    assert!(sync::wait_for_is_peer_banned(&alice_node, bob_node.node_identity.node_id(), 1).await);
 }

--- a/base_layer/core/tests/tests/header_sync.rs
+++ b/base_layer/core/tests/tests/header_sync.rs
@@ -1,0 +1,294 @@
+//  Copyright 2022. The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::time::Duration;
+
+use tari_common::configuration::Network;
+use tari_core::{
+    base_node::{
+        chain_metadata_service::PeerChainMetadata,
+        state_machine_service::{
+            states::{HeaderSyncState, StateEvent, StatusInfo},
+            BaseNodeStateMachine,
+            BaseNodeStateMachineConfig,
+        },
+        sync::{HeaderSyncStatus, SyncPeer},
+        SyncValidators,
+    },
+    consensus::{ConsensusConstantsBuilder, ConsensusManagerBuilder},
+    mempool::MempoolServiceConfig,
+    proof_of_work::{randomx_factory::RandomXFactory, Difficulty},
+    test_helpers::blockchain::TempDatabase,
+    transactions::test_helpers::create_test_core_key_manager_with_memory_db,
+    validation::mocks::MockValidator,
+};
+use tari_p2p::{services::liveness::config::LivenessConfig, P2pConfig};
+use tari_shutdown::Shutdown;
+use tempfile::tempdir;
+use tokio::sync::{broadcast, watch};
+
+use crate::helpers::{
+    block_builders::{append_block, create_genesis_block},
+    nodes::{create_network_with_2_base_nodes_with_config, NodeInterfaces},
+};
+
+static EMISSION: [u64; 2] = [10, 10];
+
+#[allow(clippy::too_many_lines)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_header_sync() {
+    // Create the network with alice node and bob node
+    let network = Network::LocalNet;
+    let temp_dir = tempdir().unwrap();
+    let key_manager = create_test_core_key_manager_with_memory_db();
+    let consensus_constants = ConsensusConstantsBuilder::new(network)
+        .with_emission_amounts(100_000_000.into(), &EMISSION, 100.into())
+        .build();
+    let (initial_block, _) = create_genesis_block(&consensus_constants, &key_manager).await;
+    let consensus_manager = ConsensusManagerBuilder::new(network)
+        .add_consensus_constants(consensus_constants)
+        .with_block(initial_block.clone())
+        .build()
+        .unwrap();
+    let (alice_node, bob_node, consensus_manager) = create_network_with_2_base_nodes_with_config(
+        MempoolServiceConfig::default(),
+        LivenessConfig {
+            auto_ping_interval: Some(Duration::from_millis(100)),
+            ..Default::default()
+        },
+        P2pConfig::default(),
+        consensus_manager,
+        temp_dir.path().to_str().unwrap(),
+    )
+    .await;
+    let shutdown = Shutdown::new();
+    let (state_change_event_publisher, _) = broadcast::channel(10);
+    let (status_event_sender, _status_event_receiver) = watch::channel(StatusInfo::new());
+
+    // Alice needs a state machine for header sync
+    let mut alice_state_machine = BaseNodeStateMachine::new(
+        alice_node.blockchain_db.clone().into(),
+        alice_node.local_nci.clone(),
+        alice_node.comms.connectivity(),
+        alice_node.comms.peer_manager(),
+        alice_node.chain_metadata_handle.get_event_stream(),
+        BaseNodeStateMachineConfig::default(),
+        SyncValidators::new(MockValidator::new(true), MockValidator::new(true)),
+        status_event_sender,
+        state_change_event_publisher,
+        RandomXFactory::default(),
+        consensus_manager.clone(),
+        shutdown.to_signal(),
+    );
+
+    // Add 1 block to bob's chain
+    let block_1_bob = append_block(
+        &bob_node.blockchain_db,
+        &initial_block,
+        vec![],
+        &consensus_manager,
+        Difficulty::from_u64(3).unwrap(),
+        &key_manager,
+    )
+    .await
+    .unwrap();
+    assert_eq!(block_1_bob.height(), 1);
+    assert_eq!(bob_node.blockchain_db.get_height().unwrap(), 1);
+
+    // Alice attempts header sync, still on the genesys block, headers will be lagging
+    let event = sync_headers(&mut alice_state_machine, &alice_node, &bob_node).await;
+    // "Lagging"
+    match event.clone() {
+        StateEvent::HeadersSynchronized(val, sync_result) => {
+            assert_eq!(val.claimed_chain_metadata().height_of_longest_chain(), 1);
+            assert_eq!(val.claimed_chain_metadata().accumulated_difficulty(), 4);
+            assert_eq!(sync_result.headers_returned, 1);
+            assert_eq!(sync_result.fork_hash_index, 0);
+            if let HeaderSyncStatus::Lagging(val) = sync_result.header_sync_status {
+                assert_eq!(val.remote_tip_height, 1);
+                assert_eq!(val.best_block.height(), 0);
+                assert_eq!(val.reorg_steps_back, 0);
+            } else {
+                panic!("Should be 'Lagging'");
+            }
+        },
+        _ => panic!("Expected HeadersSynchronized event"),
+    }
+
+    // Alice attempts header sync again, still on the genesys block, headers will be in sync
+    let event = sync_headers(&mut alice_state_machine, &alice_node, &bob_node).await;
+    // "InSyncOrAhead"
+    match event.clone() {
+        StateEvent::HeadersSynchronized(val, sync_result) => {
+            assert_eq!(val.claimed_chain_metadata().height_of_longest_chain(), 1);
+            assert_eq!(val.claimed_chain_metadata().accumulated_difficulty(), 4);
+            assert_eq!(sync_result.headers_returned, 0);
+            assert_eq!(sync_result.fork_hash_index, 0);
+            if let HeaderSyncStatus::InSyncOrAhead = sync_result.header_sync_status {
+                // Good, headers were in sync
+            } else {
+                panic!("Should be 'InSyncOrAhead'");
+            }
+        },
+        _ => panic!("Expected StateEvent::HeadersSynchronized event"),
+    }
+
+    // Bob adds another block
+    let block_2_bob = append_block(
+        &bob_node.blockchain_db,
+        &block_1_bob,
+        vec![],
+        &consensus_manager,
+        Difficulty::from_u64(3).unwrap(),
+        &key_manager,
+    )
+    .await
+    .unwrap();
+    assert_eq!(block_2_bob.height(), 2);
+
+    // Alice attempts header sync, still on the genesys block, headers will be lagging
+    let event = sync_headers(&mut alice_state_machine, &alice_node, &bob_node).await;
+    // "Lagging"
+    match event.clone() {
+        StateEvent::HeadersSynchronized(val, sync_result) => {
+            assert_eq!(val.claimed_chain_metadata().height_of_longest_chain(), 2);
+            assert_eq!(val.claimed_chain_metadata().accumulated_difficulty(), 7);
+            assert_eq!(sync_result.headers_returned, 1);
+            assert_eq!(sync_result.fork_hash_index, 0);
+            if let HeaderSyncStatus::Lagging(val) = sync_result.header_sync_status {
+                assert_eq!(val.remote_tip_height, 2);
+                assert_eq!(val.best_block.height(), 0);
+                assert_eq!(val.reorg_steps_back, 0);
+            } else {
+                panic!("Should be 'Lagging'");
+            }
+        },
+        _ => panic!("Expected StateEvent::HeadersSynchronized event"),
+    }
+
+    // Alice adds 3 (different) blocks, with POW on par with bob's chain, but with greater height
+    let block_1_alice = append_block(
+        &alice_node.blockchain_db,
+        &initial_block,
+        vec![],
+        &consensus_manager,
+        Difficulty::from_u64(3).unwrap(),
+        &key_manager,
+    )
+    .await
+    .unwrap();
+    let block_2_alice = append_block(
+        &alice_node.blockchain_db,
+        &block_1_alice,
+        vec![],
+        &consensus_manager,
+        Difficulty::from_u64(2).unwrap(),
+        &key_manager,
+    )
+    .await
+    .unwrap();
+    // Alice adds another block, with POW on par with bob's chain, but with greater height
+    let block_3_alice = append_block(
+        &alice_node.blockchain_db,
+        &block_2_alice,
+        vec![],
+        &consensus_manager,
+        Difficulty::from_u64(1).unwrap(),
+        &key_manager,
+    )
+    .await
+    .unwrap();
+    assert_eq!(block_3_alice.height(), 3);
+    assert_eq!(block_3_alice.accumulated_data().total_accumulated_difficulty, 7);
+    assert_eq!(
+        block_3_alice.accumulated_data().total_accumulated_difficulty,
+        block_2_bob.accumulated_data().total_accumulated_difficulty
+    );
+
+    // Alice attempts header sync, but POW is on par
+    let event = sync_headers(&mut alice_state_machine, &alice_node, &bob_node).await;
+    match event.clone() {
+        StateEvent::Continue => {
+            // Good - Header sync not attempted, sync peer does not have better POW
+        },
+        _ => panic!("Expected StateEvent::Continue event"),
+    }
+
+    // Bob adds more blocks and draws ahead of Alice
+    let block_3_bob = append_block(
+        &bob_node.blockchain_db,
+        &block_2_bob,
+        vec![],
+        &consensus_manager,
+        Difficulty::from_u64(3).unwrap(),
+        &key_manager,
+    )
+    .await
+    .unwrap();
+    let block_4_bob = append_block(
+        &bob_node.blockchain_db,
+        &block_3_bob,
+        vec![],
+        &consensus_manager,
+        Difficulty::from_u64(3).unwrap(),
+        &key_manager,
+    )
+    .await
+    .unwrap();
+    assert_eq!(block_4_bob.height(), 4);
+
+    // Alice attempts header sync, on a higher chain with less POW, headers will be lagging with reorg steps
+    let event = sync_headers(&mut alice_state_machine, &alice_node, &bob_node).await;
+    // "Lagging"
+    match event {
+        StateEvent::HeadersSynchronized(val, sync_result) => {
+            assert_eq!(val.claimed_chain_metadata().height_of_longest_chain(), 4);
+            assert_eq!(val.claimed_chain_metadata().accumulated_difficulty(), 13);
+            assert_eq!(sync_result.headers_returned, 4);
+            assert_eq!(sync_result.fork_hash_index, 3);
+            if let HeaderSyncStatus::Lagging(val) = sync_result.header_sync_status {
+                assert_eq!(val.remote_tip_height, 4);
+                assert_eq!(val.best_block.height(), 3);
+                assert_eq!(val.reorg_steps_back, 3);
+            } else {
+                panic!("Should be 'Lagging'");
+            }
+        },
+        _ => panic!("Expected StateEvent::HeadersSynchronized event"),
+    }
+}
+
+async fn sync_headers(
+    alice_state_machine: &mut BaseNodeStateMachine<TempDatabase>,
+    alice_node: &NodeInterfaces,
+    bob_node: &NodeInterfaces,
+) -> StateEvent {
+    let mut header_sync = HeaderSyncState::new(
+        vec![SyncPeer::from(PeerChainMetadata::new(
+            bob_node.node_identity.node_id().clone(),
+            bob_node.blockchain_db.get_chain_metadata().unwrap(),
+            None,
+        ))],
+        alice_node.blockchain_db.get_chain_metadata().unwrap(),
+    );
+    header_sync.next_event(alice_state_machine).await
+}

--- a/base_layer/core/tests/tests/mempool.rs
+++ b/base_layer/core/tests/tests/mempool.rs
@@ -69,7 +69,7 @@ use tari_core::{
     },
 };
 use tari_key_manager::key_manager_service::KeyManagerInterface;
-use tari_p2p::{services::liveness::LivenessConfig, tari_message::TariMessageType};
+use tari_p2p::{services::liveness::LivenessConfig, tari_message::TariMessageType, P2pConfig};
 use tari_script::script;
 use tari_test_utils::async_assert_eventually;
 use tempfile::tempdir;
@@ -1721,6 +1721,7 @@ async fn block_event_and_reorg_event_handling() {
     let (mut alice, mut bob, consensus_manager) = create_network_with_2_base_nodes_with_config(
         MempoolServiceConfig::default(),
         LivenessConfig::default(),
+        P2pConfig::default(),
         consensus_manager,
         temp_dir.path().to_str().unwrap(),
     )

--- a/base_layer/core/tests/tests/mod.rs
+++ b/base_layer/core/tests/tests/mod.rs
@@ -25,6 +25,7 @@ use tari_core::{blocks::ChainBlock, chain_storage::BlockAddResult};
 mod async_db;
 mod base_node_rpc;
 mod block_validation;
+mod header_sync;
 mod mempool;
 mod node_comms_interface;
 mod node_service;

--- a/base_layer/core/tests/tests/node_state_machine.rs
+++ b/base_layer/core/tests/tests/node_state_machine.rs
@@ -43,7 +43,7 @@ use tari_core::{
     transactions::test_helpers::create_test_core_key_manager_with_memory_db,
     validation::mocks::MockValidator,
 };
-use tari_p2p::services::liveness::config::LivenessConfig;
+use tari_p2p::{services::liveness::config::LivenessConfig, P2pConfig};
 use tari_shutdown::Shutdown;
 use tari_test_utils::unpack_enum;
 use tari_utilities::ByteArray;
@@ -81,6 +81,7 @@ async fn test_listening_lagging() {
             auto_ping_interval: Some(Duration::from_millis(100)),
             ..Default::default()
         },
+        P2pConfig::default(),
         consensus_manager,
         temp_dir.path().to_str().unwrap(),
     )

--- a/base_layer/p2p/tests/support/comms_and_services.rs
+++ b/base_layer/p2p/tests/support/comms_and_services.rs
@@ -22,7 +22,12 @@
 
 use std::{sync::Arc, time::Duration};
 
-use tari_comms::{peer_manager::NodeIdentity, protocol::messaging::MessagingEventSender, CommsNode};
+use tari_comms::{
+    peer_manager::NodeIdentity,
+    protocol::messaging::MessagingEventSender,
+    transports::MemoryTransport,
+    CommsNode,
+};
 use tari_comms_dht::Dht;
 use tari_p2p::{comms_connector::InboundDomainConnector, initialization::initialize_local_test_comms};
 use tari_shutdown::ShutdownSignal;
@@ -45,6 +50,12 @@ pub async fn setup_comms_services(
     )
     .await
     .unwrap();
+
+    let comms = comms.spawn_with_transport(MemoryTransport).await.unwrap();
+    // Set the public address for tests
+    comms
+        .node_identity()
+        .add_public_address(comms.listening_address().clone());
 
     (comms, dht, messaging_events)
 }

--- a/base_layer/wallet/tests/support/comms_and_services.rs
+++ b/base_layer/wallet/tests/support/comms_and_services.rs
@@ -26,6 +26,7 @@ use tari_comms::{
     message::MessageTag,
     net_address::MultiaddressesWithStats,
     peer_manager::{NodeId, NodeIdentity, Peer, PeerFeatures, PeerFlags},
+    transports::MemoryTransport,
     types::CommsPublicKey,
     CommsNode,
 };
@@ -56,6 +57,12 @@ pub async fn setup_comms_services(
     )
     .await
     .unwrap();
+
+    let comms = comms.spawn_with_transport(MemoryTransport).await.unwrap();
+    // Set the public address for tests
+    comms
+        .node_identity()
+        .add_public_address(comms.listening_address().clone());
 
     (comms, dht)
 }


### PR DESCRIPTION
Description
---
This PR fixes an edge case for header sync where the local node has more headers, but the remote node has better proof-of-work (accumulated difficulty), thus higher actual blockchain height. It also simplifies the attempted header sync logic and error handling when a peer does not return headers and introduces consistent naming, variable re-use and use of information

Supersedes #5756

Motivation and Context
---
When doing header sync, and determining from which peer to sync, we need to consider our actual blockchain state when comparing chains. It is possible that our node has valid block headers that will translate into a  higher proof of work when fully synced than the remote syncing peer, but lacking the blocks to back the block headers, thus the remote chain has an actual higher proof of work blockchain.
With the current implementation, race conditions can exist when determining if the peer is misbehaving, i.e. lying about their proof-of-work or not wanting to supply block headers, due to a mismatch in tip height used for the check.

This PR fixes the race conditions by always using the latest local chain metadata and block headers, ignoring all sync peers that do not exceed our own accumulated difficulty and using consistent information in all the checks.

How Has This Been Tested?
---
Added integration-level unit tests:
- `test_header_sync_happy_path`
- `test_header_sync_with_fork_happy_path`
- `test_header_sync_uneven_headers_and_blocks_happy_path`
- `test_header_sync_uneven_headers_and_blocks_peer_lies_about_pow_no_ban`
- `test_header_sync_even_headers_and_blocks_peer_lies_about_pow_with_ban`
- `test_header_sync_even_headers_and_blocks_peer_metadata_improve_with_reorg`

What process can a PR reviewer use to test or verify this change?
---
- Code walk-through
- Review unit tests

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
