### PR TITLE
ci(fix): windows github action remove strawberryperl install

### DIFF
--- a/.github/workflows/base_node_binaries.yml
+++ b/.github/workflows/base_node_binaries.yml
@@ -142,7 +142,8 @@ jobs:
           # psutils is out of date
           # choco upgrade psutils -y
           choco upgrade openssl -y
-          choco upgrade strawberryperl -y
+          # Should already be installed
+          # choco upgrade strawberryperl -y
 
       - name: Debugging - Upload logs if dependences failures
         if: failure()


### PR DESCRIPTION
Description
windows github action runner should already have perl installed, comment out ```strawberryperl```

Motivation and Context
Re-enable Windows binaries build.

How Has This Been Tested?
Built in local fork successfully

What process can a PR reviewer use to test or verify this change?
Check that the Windows binary build is successful

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
