### PR TITLE
fix: don't ban a peer for sending a banned peer

### DIFF
--- a/comms/dht/src/discovery/service.rs
+++ b/comms/dht/src/discovery/service.rs
@@ -282,12 +282,6 @@ impl DhtDiscoveryService {
     ) -> Result<T, DhtPeerValidatorError> {
         match result {
             Ok(peer) => Ok(peer),
-            // Banned is an interesting case - if the peer is banned and we reban them, it will modify the original
-            // ban either longer or shorter. It is possible for a banned peer to send a secret message to us
-            // through another peer.
-            // TODO: perhaps connectivity manager should only make longer bans when this is called, or do nothing if
-            // shorter.
-            Err(err @ DhtPeerValidatorError::Banned { .. }) => Err(err),
             Err(err @ DhtPeerValidatorError::IdentityTooManyClaims { .. }) |
             Err(err @ DhtPeerValidatorError::ValidatorError(_)) => {
                 self.dht.ban_peer(public_key.clone(), OffenceSeverity::High, &err).await;

--- a/comms/dht/src/inbound/dht_handler/task.rs
+++ b/comms/dht/src/inbound/dht_handler/task.rs
@@ -464,7 +464,6 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
             Err(err) => {
                 match &err {
                     DhtInboundError::PeerValidatorError(err) => match err {
-                        DhtPeerValidatorError::Banned { .. } => {},
                         err @ DhtPeerValidatorError::ValidatorError(_) |
                         err @ DhtPeerValidatorError::IdentityTooManyClaims { .. } => {
                             self.dht

--- a/comms/dht/src/peer_validator.rs
+++ b/comms/dht/src/peer_validator.rs
@@ -75,15 +75,6 @@ impl<'a> PeerValidator<'a> {
             });
         }
 
-        if let Some(ref peer) = existing_peer {
-            if peer.is_banned() {
-                return Err(DhtPeerValidatorError::Banned {
-                    peer: peer.node_id.clone(),
-                    reason: peer.banned_reason.clone(),
-                });
-            }
-        }
-
         let most_recent_claim = find_most_recent_claim(&new_peer.claims).expect("new_peer.claims is not empty");
 
         let node_id = NodeId::from_public_key(&new_peer.public_key);

--- a/comms/dht/src/peer_validator.rs
+++ b/comms/dht/src/peer_validator.rs
@@ -35,8 +35,6 @@ const _LOG_TARGET: &str = "dht::network_discovery::peer_validator";
 /// Validation errors for peers shared on the network
 #[derive(Debug, thiserror::Error)]
 pub enum DhtPeerValidatorError {
-    #[error("Peer '{peer}' is banned: {reason}")]
-    Banned { peer: NodeId, reason: String },
     #[error(transparent)]
     ValidatorError(#[from] PeerValidatorError),
     #[error("Peer provided too many claims: expected max {max} but got {length}")]


### PR DESCRIPTION
Description
---
Removes a check that would ban a peer if they sent a peer that we have banned. 

Motivation and Context
---
The check would ban the source peer during peer sync if they sent a peer to us that we have banned. This is IMO exploitable, since a peer may not have connected to the banned peer in question and thus not know if it should be banned or not. 

You could also get a peer banned in this manner:
1. As an evil peer, I connect to a target node A. 
2. I then connect to a number of other nodes and get myself banned. 
3. The nodes I connect to then will ban node A when they send my node address during sync

How Has This Been Tested?
---
CI

What process can a PR reviewer use to test or verify this change?
---
Not sure it's quite a mission to replicate this.

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
