### PR TITLE
fix: ban peer if it sends bad liveness data

### DIFF
--- a/base_layer/core/src/base_node/chain_metadata_service/initializer.rs
+++ b/base_layer/core/src/base_node/chain_metadata_service/initializer.rs
@@ -21,6 +21,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use log::*;
+use tari_comms::connectivity::ConnectivityRequester;
 use tari_p2p::services::liveness::LivenessHandle;
 use tari_service_framework::{async_trait, ServiceInitializationError, ServiceInitializer, ServiceInitializerContext};
 use tokio::sync::broadcast;
@@ -42,10 +43,11 @@ impl ServiceInitializer for ChainMetadataServiceInitializer {
         context.register_handle(handle);
 
         context.spawn_until_shutdown(|handles| {
+            let connectivity = handles.expect_handle::<ConnectivityRequester>();
             let liveness = handles.expect_handle::<LivenessHandle>();
             let base_node = handles.expect_handle::<LocalNodeCommsInterface>();
 
-            ChainMetadataService::new(liveness, base_node, publisher).run()
+            ChainMetadataService::new(liveness, base_node, connectivity, publisher).run()
         });
 
         debug!(target: LOG_TARGET, "Chain Metadata Service initialized");

--- a/comms/core/src/lib.rs
+++ b/comms/core/src/lib.rs
@@ -52,6 +52,7 @@ pub mod utils;
 pub mod peer_validator;
 
 mod bans;
+pub use bans::{BAN_DURATION_LONG, BAN_DURATION_SHORT};
 pub mod test_utils;
 pub mod traits;
 


### PR DESCRIPTION
Description
---
Bans the peer if they sent invalid liveness data.

Motivation and Context
---
I think there was a change to the chainmetadata struct recently, and this resulted in a bunch of warnings on my igor node. This PR now bans the node if they sent data that doesn't deserialize.

How Has This Been Tested?
---
Tested with igor trying to connect to old nodes

What process can a PR reviewer use to test or verify this change?
---
Try to connect to an igor node running 0.52.0-pre.1

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
