### PR TITLE
fix: fix erroneous warning message

### DIFF
--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -1147,12 +1147,18 @@ impl LMDBDatabase {
                         parent_hash.to_hex()
                     );
                 }
-            } else {
+            } else if lmdb_exists(txn, &self.orphans_db, parent_hash.as_slice())? !=
+                lmdb_exists(txn, &self.orphan_header_accumulated_data_db, parent_hash.as_slice())?
+            {
                 warn!(
                     target: LOG_TARGET,
-                    "'orphans_db' and 'orphan_header_accumulated_data_db' out of sync, missing parent hash '{}' entry",
+                    "'orphans_db' ({}) and 'orphan_header_accumulated_data_db' ({}) out of sync, missing parent hash '{}' entry",
+                    lmdb_exists(txn, &self.orphans_db, parent_hash.as_slice())?,
+                    lmdb_exists(txn, &self.orphan_header_accumulated_data_db, parent_hash.as_slice())?,
                     parent_hash.to_hex()
                 );
+            } else {
+                // Nothing here
             }
         }
 

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -1121,44 +1121,52 @@ impl LMDBDatabase {
 
         // Orphan is a tip hash
         if lmdb_exists(txn, &self.orphan_chain_tips_db, hash.as_slice())? {
+            // We get rid of the orphan tip
             lmdb_delete(txn, &self.orphan_chain_tips_db, hash.as_slice(), "orphan_chain_tips_db")?;
-
-            // Parent becomes a tip hash
-            if lmdb_exists(txn, &self.orphans_db, parent_hash.as_slice())? &&
-                lmdb_exists(txn, &self.orphan_header_accumulated_data_db, parent_hash.as_slice())?
-            {
-                let orphan_parent_accum: Option<BlockHeaderAccumulatedData> =
-                    lmdb_get(txn, &self.orphan_header_accumulated_data_db, parent_hash.as_slice())?;
-                if let Some(val) = orphan_parent_accum {
-                    lmdb_insert(
-                        txn,
-                        &self.orphan_chain_tips_db,
-                        parent_hash.as_slice(),
-                        &ChainTipData {
-                            hash: parent_hash,
-                            total_accumulated_difficulty: val.total_accumulated_difficulty,
+            // If an orphan parent exists, it must be promoted
+            match (
+                lmdb_exists(txn, &self.orphans_db, parent_hash.as_slice())?,
+                lmdb_exists(txn, &self.orphan_header_accumulated_data_db, parent_hash.as_slice())?,
+            ) {
+                (true, true) => {
+                    // Parent becomes a tip hash
+                    let orphan_parent_accum: Option<BlockHeaderAccumulatedData> =
+                        lmdb_get(txn, &self.orphan_header_accumulated_data_db, parent_hash.as_slice())?;
+                    match orphan_parent_accum {
+                        Some(val) => {
+                            lmdb_insert(
+                                txn,
+                                &self.orphan_chain_tips_db,
+                                parent_hash.as_slice(),
+                                &ChainTipData {
+                                    hash: parent_hash,
+                                    total_accumulated_difficulty: val.total_accumulated_difficulty,
+                                },
+                                "orphan_chain_tips_db",
+                            )?;
                         },
-                        "orphan_chain_tips_db",
-                    )?;
-                } else {
+                        None => {
+                            warn!(
+                                target: LOG_TARGET,
+                                "Empty 'BlockHeaderAccumulatedData' for parent hash '{}'",
+                                parent_hash.to_hex()
+                            );
+                        },
+                    }
+                },
+                (false, false) => {
+                    // No entries, nothing here
+                },
+                _ => {
+                    // Some previous database operations were not atomic
                     warn!(
                         target: LOG_TARGET,
-                        "Empty 'BlockHeaderAccumulatedData' for parent hash '{}'",
+                        "'orphans_db' ({}) and 'orphan_header_accumulated_data_db' ({}) out of sync, missing parent hash '{}' entry",
+                        lmdb_exists(txn, &self.orphans_db, parent_hash.as_slice())?,
+                        lmdb_exists(txn, &self.orphan_header_accumulated_data_db, parent_hash.as_slice())?,
                         parent_hash.to_hex()
                     );
-                }
-            } else if lmdb_exists(txn, &self.orphans_db, parent_hash.as_slice())? !=
-                lmdb_exists(txn, &self.orphan_header_accumulated_data_db, parent_hash.as_slice())?
-            {
-                warn!(
-                    target: LOG_TARGET,
-                    "'orphans_db' ({}) and 'orphan_header_accumulated_data_db' ({}) out of sync, missing parent hash '{}' entry",
-                    lmdb_exists(txn, &self.orphans_db, parent_hash.as_slice())?,
-                    lmdb_exists(txn, &self.orphan_header_accumulated_data_db, parent_hash.as_slice())?,
-                    parent_hash.to_hex()
-                );
-            } else {
-                // Nothing here
+                },
             }
         }
 


### PR DESCRIPTION
Description
---
Fixed erroneous warning message about 'orphans_db' and 'orphan_header_accumulated_data_db' being out of sync - the difference was assumed instead of verified.

Motivation and Context
---
See above

How Has This Been Tested?
---
System-level test

What process can a PR reviewer use to test or verify this change?
---
Code review

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
