### PR TITLE
fix: horizon sync

### DIFF
--- a/base_layer/core/src/base_node/sync/horizon_state_sync/synchronizer.rs
+++ b/base_layer/core/src/base_node/sync/horizon_state_sync/synchronizer.rs
@@ -606,6 +606,7 @@ impl<'a, B: BlockchainBackend + 'static> HorizonStateSynchronization<'a, B> {
             });
         }
 
+        db.set_tip_smt(output_smt).await?;
         self.check_latency(sync_peer.node_id(), &avg_latency)?;
 
         Ok(())

--- a/base_layer/core/src/base_node/sync/horizon_state_sync/synchronizer.rs
+++ b/base_layer/core/src/base_node/sync/horizon_state_sync/synchronizer.rs
@@ -57,7 +57,6 @@ use crate::{
         TransactionOutput,
     },
     validation::{helpers, FinalHorizonStateValidation},
-    OutputSmt,
     PrunedKernelMmr,
 };
 
@@ -502,7 +501,8 @@ impl<'a, B: BlockchainBackend + 'static> HorizonStateSynchronization<'a, B> {
 
         let end = remote_num_outputs;
         let end_hash = to_header.hash();
-        let start_hash = db.fetch_chain_header(0).await?;
+        let start_hash = db.fetch_chain_header(1).await?;
+        let gen_block = db.fetch_chain_header(0).await?;
 
         let latency = client.get_last_request_latency();
         debug!(
@@ -520,9 +520,9 @@ impl<'a, B: BlockchainBackend + 'static> HorizonStateSynchronization<'a, B> {
         let mut output_stream = client.sync_utxos(req).await?;
 
         let mut txn = db.write_transaction();
-        let mut utxo_counter = 0u64;
+        let mut utxo_counter = gen_block.header().output_smt_size;
         let timer = Instant::now();
-        let mut output_smt = OutputSmt::new();
+        let mut output_smt = db.fetch_tip_smt().await?;
         let mut last_sync_timer = Instant::now();
         let mut avg_latency = RollingAverageTime::new(20);
 

--- a/base_layer/core/src/chain_storage/async_db.rs
+++ b/base_layer/core/src/chain_storage/async_db.rs
@@ -211,6 +211,8 @@ impl<B: BlockchainBackend + 'static> AsyncBlockchainDb<B> {
 
     make_async_fn!(fetch_tip_smt() -> OutputSmt, "fetch_tip_smt");
 
+    make_async_fn!(set_tip_smt(smt: OutputSmt) -> (), "set_tip_smt");
+
     make_async_fn!(insert_valid_headers(headers: Vec<ChainHeader>) -> (), "insert_valid_headers");
 
     //---------------------------------- Block --------------------------------------------//

--- a/base_layer/core/src/chain_storage/async_db.rs
+++ b/base_layer/core/src/chain_storage/async_db.rs
@@ -59,6 +59,7 @@ use crate::{
     common::rolling_vec::RollingVec,
     proof_of_work::{PowAlgorithm, TargetDifficultyWindow},
     transactions::transaction_components::{TransactionKernel, TransactionOutput},
+    OutputSmt,
 };
 const LOG_TARGET: &str = "c::bn::async_db";
 
@@ -207,6 +208,8 @@ impl<B: BlockchainBackend + 'static> AsyncBlockchainDb<B> {
     make_async_fn!(fetch_last_chain_header() -> ChainHeader, "fetch_last_chain_header");
 
     make_async_fn!(fetch_tip_header() -> ChainHeader, "fetch_tip_header");
+
+    make_async_fn!(fetch_tip_smt() -> OutputSmt, "fetch_tip_smt");
 
     make_async_fn!(insert_valid_headers(headers: Vec<ChainHeader>) -> (), "insert_valid_headers");
 

--- a/base_layer/core/src/chain_storage/blockchain_backend.rs
+++ b/base_layer/core/src/chain_storage/blockchain_backend.rs
@@ -181,5 +181,8 @@ pub trait BlockchainBackend: Send + Sync {
         start_height: u64,
         end_height: u64,
     ) -> Result<Vec<TemplateRegistrationEntry>, ChainStorageError>;
+    /// Returns the tip utxo smt
     fn fetch_tip_smt(&self) -> Result<OutputSmt, ChainStorageError>;
+    /// Sets the tip utxo smt
+    fn set_tip_smt(&self, smt: OutputSmt) -> Result<(), ChainStorageError>;
 }

--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -660,6 +660,11 @@ where B: BlockchainBackend
         db.fetch_tip_smt()
     }
 
+    pub fn set_tip_smt(&self, smt: OutputSmt) -> Result<(), ChainStorageError> {
+        let db = self.db_write_access()?;
+        db.set_tip_smt(smt)
+    }
+
     /// Fetches the last  header that was added, might be past the tip, as the block body between this last  header and
     /// actual tip might not have been added yet
     pub fn fetch_last_header(&self) -> Result<BlockHeader, ChainStorageError> {

--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -655,6 +655,11 @@ where B: BlockchainBackend
         db.fetch_tip_header()
     }
 
+    pub fn fetch_tip_smt(&self) -> Result<OutputSmt, ChainStorageError> {
+        let db = self.db_read_access()?;
+        db.fetch_tip_smt()
+    }
+
     /// Fetches the last  header that was added, might be past the tip, as the block body between this last  header and
     /// actual tip might not have been added yet
     pub fn fetch_last_header(&self) -> Result<BlockHeader, ChainStorageError> {

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -2287,6 +2287,11 @@ impl BlockchainBackend for LMDBDatabase {
             }),
         }
     }
+
+    fn set_tip_smt(&self, smt: OutputSmt) -> Result<(), ChainStorageError> {
+        let txn = self.write_transaction()?;
+        self.insert_tip_smt(&txn, &smt)
+    }
 }
 
 // Fetch the chain metadata

--- a/base_layer/core/src/test_helpers/blockchain.rs
+++ b/base_layer/core/src/test_helpers/blockchain.rs
@@ -413,6 +413,10 @@ impl BlockchainBackend for TempDatabase {
     fn fetch_tip_smt(&self) -> Result<OutputSmt, ChainStorageError> {
         self.db.as_ref().unwrap().fetch_tip_smt()
     }
+
+    fn set_tip_smt(&self, smt: OutputSmt) -> Result<(), ChainStorageError> {
+        self.db.as_ref().unwrap().set_tip_smt(smt)
+    }
 }
 
 pub async fn create_chained_blocks<T: Into<BlockSpecs>>(


### PR DESCRIPTION
Description
---
Fixes horizon sync by selecting the correct tip smt and sending the correct starting header

Motivation and Context
---
Horizon sync starts at height 1 technically as the node already has the genesis block. 

How Has This Been Tested?
---
Manual 