### PR TITLE
fix: db resize issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5868,7 +5868,6 @@ dependencies = [
  "log",
  "rand",
  "serde",
- "serde_derive",
  "serde_json",
  "tari_common",
  "tari_crypto",

--- a/base_layer/core/src/base_node/sync/horizon_state_sync/synchronizer.rs
+++ b/base_layer/core/src/base_node/sync/horizon_state_sync/synchronizer.rs
@@ -598,6 +598,12 @@ impl<'a, B: BlockchainBackend + 'static> HorizonStateSynchronization<'a, B> {
         );
         let root = FixedHash::try_from(output_smt.hash().as_slice())?;
         if root != to_header.output_mr {
+            warn!(
+                target: LOG_TARGET,
+                "Final target root(#{}) did not match expected (#{})",
+                    to_header.output_mr.to_hex(),
+                    root.to_hex(),
+            );
             return Err(HorizonSyncError::InvalidMrRoot {
                 mr_tree: "UTXO SMT".to_string(),
                 at_height: to_header.height,
@@ -605,10 +611,7 @@ impl<'a, B: BlockchainBackend + 'static> HorizonStateSynchronization<'a, B> {
                 actual_hex: root.to_hex(),
             });
         }
-
         db.set_tip_smt(output_smt).await?;
-        self.check_latency(sync_peer.node_id(), &avg_latency)?;
-
         Ok(())
     }
 

--- a/base_layer/core/src/chain_storage/blockchain_backend.rs
+++ b/base_layer/core/src/chain_storage/blockchain_backend.rs
@@ -183,6 +183,4 @@ pub trait BlockchainBackend: Send + Sync {
     ) -> Result<Vec<TemplateRegistrationEntry>, ChainStorageError>;
     /// Returns the tip utxo smt
     fn fetch_tip_smt(&self) -> Result<OutputSmt, ChainStorageError>;
-    /// Sets the tip utxo smt
-    fn set_tip_smt(&self, smt: OutputSmt) -> Result<(), ChainStorageError>;
 }

--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -661,8 +661,10 @@ where B: BlockchainBackend
     }
 
     pub fn set_tip_smt(&self, smt: OutputSmt) -> Result<(), ChainStorageError> {
-        let db = self.db_write_access()?;
-        db.set_tip_smt(smt)
+        let mut db = self.db_write_access()?;
+        let mut txn = DbTransaction::new();
+        txn.insert_tip_smt(smt);
+        db.write(txn)
     }
 
     /// Fetches the last  header that was added, might be past the tip, as the block body between this last  header and

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -2300,11 +2300,6 @@ impl BlockchainBackend for LMDBDatabase {
             }),
         }
     }
-
-    fn set_tip_smt(&self, smt: OutputSmt) -> Result<(), ChainStorageError> {
-        let txn = self.write_transaction()?;
-        self.insert_tip_smt(&txn, &smt)
-    }
 }
 
 // Fetch the chain metadata

--- a/base_layer/core/src/test_helpers/blockchain.rs
+++ b/base_layer/core/src/test_helpers/blockchain.rs
@@ -413,10 +413,6 @@ impl BlockchainBackend for TempDatabase {
     fn fetch_tip_smt(&self) -> Result<OutputSmt, ChainStorageError> {
         self.db.as_ref().unwrap().fetch_tip_smt()
     }
-
-    fn set_tip_smt(&self, smt: OutputSmt) -> Result<(), ChainStorageError> {
-        self.db.as_ref().unwrap().set_tip_smt(smt)
-    }
 }
 
 pub async fn create_chained_blocks<T: Into<BlockSpecs>>(

--- a/base_layer/mmr/Cargo.toml
+++ b/base_layer/mmr/Cargo.toml
@@ -20,7 +20,6 @@ borsh = "0.10"
 digest = "0.10"
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
-serde_derive = "1.0.119"
 croaring = { version = "0.9", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Description
---
Fixes a resize issue with horizon sync mode

Motivation and Context
---
Lmdb only resizes on transactions, and not pure table changes in our code, this changes the tip smt to always use the transactions, as this call might be large. 

How Has This Been Tested?
---
manual 