### PR TITLE
feat!: add validator mmr size

### DIFF
--- a/applications/minotari_app_grpc/proto/block.proto
+++ b/applications/minotari_app_grpc/proto/block.proto
@@ -60,6 +60,8 @@ message BlockHeader {
     bytes total_script_offset = 15;
     // Merkle root of validator nodes
     bytes validator_node_mr = 16;
+    // Validator size
+    uint64 validator_node_size = 17;
 }
 
 // The proof of work data structure that is included in the block header.

--- a/applications/minotari_app_grpc/src/conversions/block_header.rs
+++ b/applications/minotari_app_grpc/src/conversions/block_header.rs
@@ -50,6 +50,7 @@ impl From<BlockHeader> for grpc::BlockHeader {
                 pow_data: h.pow.pow_data,
             }),
             validator_node_mr: h.validator_node_mr.to_vec(),
+            validator_node_size: h.validator_node_size,
         }
     }
 }
@@ -83,6 +84,7 @@ impl TryFrom<grpc::BlockHeader> for BlockHeader {
             nonce: header.nonce,
             pow,
             validator_node_mr: FixedHash::try_from(header.validator_node_mr).map_err(|err| err.to_string())?,
+            validator_node_size: header.validator_node_size,
         })
     }
 }

--- a/base_layer/core/src/blocks/block_header.rs
+++ b/base_layer/core/src/blocks/block_header.rs
@@ -113,6 +113,8 @@ pub struct BlockHeader {
     pub total_script_offset: PrivateKey,
     /// Merkle root of all active validator node.
     pub validator_node_mr: FixedHash,
+    /// The number of validator node hashes
+    pub validator_node_size: u64,
     /// Proof of work summary
     pub pow: ProofOfWork,
     /// Nonce increment used to mine this block.
@@ -137,6 +139,7 @@ impl BlockHeader {
             nonce: 0,
             pow: ProofOfWork::default(),
             validator_node_mr: FixedHash::zero(),
+            validator_node_size: 0,
         }
     }
 
@@ -169,6 +172,7 @@ impl BlockHeader {
             nonce: 0,
             pow: ProofOfWork::default(),
             validator_node_mr: FixedHash::zero(),
+            validator_node_size: prev.validator_node_size,
         }
     }
 
@@ -231,6 +235,7 @@ impl BlockHeader {
             .chain(&self.total_kernel_offset)
             .chain(&self.total_script_offset)
             .chain(&self.validator_node_mr)
+            .chain(&self.validator_node_size)
             .finalize()
             .into()
     }
@@ -277,6 +282,7 @@ impl From<NewBlockHeaderTemplate> for BlockHeader {
             nonce: 0,
             pow: header_template.pow,
             validator_node_mr: FixedHash::zero(),
+            validator_node_size: 0,
         }
     }
 }

--- a/base_layer/core/src/blocks/genesis_block.rs
+++ b/base_layer/core/src/blocks/genesis_block.rs
@@ -344,6 +344,7 @@ fn get_raw_block(genesis_timestamp: &DateTime<FixedOffset>, not_before_proof: &[
             kernel_mmr_size: 0,
             validator_node_mr: FixedHash::from_hex("277da65c40b2cf99db86baedb903a3f0a38540f3a94d40c826eecac7e27d5dfc")
                 .unwrap(),
+            validator_node_size: 0,
             input_mr: FixedHash::zero(),
             total_kernel_offset: PrivateKey::from_hex(
                 "0000000000000000000000000000000000000000000000000000000000000000",

--- a/base_layer/core/src/chain_storage/tests/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/tests/blockchain_database.rs
@@ -71,6 +71,7 @@ fn apply_mmr_to_block(db: &BlockchainDatabase<TempDatabase>, block: Block) -> Bl
     block.header.kernel_mr = mmr_roots.kernel_mr;
     block.header.kernel_mmr_size = mmr_roots.kernel_mmr_size;
     block.header.validator_node_mr = mmr_roots.validator_node_mr;
+    block.header.validator_node_size = mmr_roots.validator_node_size;
     block
 }
 

--- a/base_layer/core/src/proof_of_work/monero_rx/helpers.rs
+++ b/base_layer/core/src/proof_of_work/monero_rx/helpers.rs
@@ -674,7 +674,7 @@ mod test {
             prev_hash: FixedHash::zero(),
             timestamp: EpochTime::now(),
             output_mr: FixedHash::zero(),
-            output_mmr_size: 0,
+            output_smt_size: 0,
             kernel_mr: FixedHash::zero(),
             kernel_mmr_size: 0,
             input_mr: FixedHash::zero(),
@@ -683,6 +683,7 @@ mod test {
             nonce: 0,
             pow: ProofOfWork::default(),
             validator_node_mr: FixedHash::zero(),
+            validator_node_size: 2,
         };
 
         // Let us manipulate the extra field to make it invalid

--- a/base_layer/core/src/proof_of_work/monero_rx/helpers.rs
+++ b/base_layer/core/src/proof_of_work/monero_rx/helpers.rs
@@ -388,6 +388,7 @@ mod test {
             nonce: 0,
             pow: ProofOfWork::default(),
             validator_node_mr: FixedHash::zero(),
+            validator_node_size: 0,
         };
         let hash = block_header.merge_mining_hash();
         insert_merge_mining_tag_into_block(&mut block, hash).unwrap();
@@ -444,6 +445,7 @@ mod test {
             nonce: 0,
             pow: ProofOfWork::default(),
             validator_node_mr: FixedHash::zero(),
+            validator_node_size: 0,
         };
         let hash = block_header.merge_mining_hash();
         insert_merge_mining_tag_into_block(&mut block, hash).unwrap();
@@ -496,6 +498,7 @@ mod test {
             nonce: 0,
             pow: ProofOfWork::default(),
             validator_node_mr: FixedHash::zero(),
+            validator_node_size: 0,
         };
         let count = 1 + (u16::try_from(block.tx_hashes.len()).unwrap());
         let mut hashes = Vec::with_capacity(count as usize);
@@ -547,6 +550,7 @@ mod test {
             nonce: 0,
             pow: ProofOfWork::default(),
             validator_node_mr: FixedHash::zero(),
+            validator_node_size: 0,
         };
         let hash = Hash::null();
         insert_merge_mining_tag_into_block(&mut block, hash).unwrap();
@@ -602,6 +606,7 @@ mod test {
             nonce: 0,
             pow: ProofOfWork::default(),
             validator_node_mr: FixedHash::zero(),
+            validator_node_size: 0,
         };
         let hash = block_header.merge_mining_hash();
         insert_merge_mining_tag_into_block(&mut block, hash).unwrap();
@@ -736,6 +741,7 @@ mod test {
             nonce: 0,
             pow: ProofOfWork::default(),
             validator_node_mr: FixedHash::zero(),
+            validator_node_size: 0,
         };
         let hash = block_header.merge_mining_hash();
         insert_merge_mining_tag_into_block(&mut block, hash).unwrap();
@@ -787,6 +793,7 @@ mod test {
             nonce: 0,
             pow: ProofOfWork::default(),
             validator_node_mr: FixedHash::zero(),
+            validator_node_size: 0,
         };
         let monero_data = MoneroPowData {
             header: Default::default(),
@@ -829,6 +836,7 @@ mod test {
             nonce: 0,
             pow: ProofOfWork::default(),
             validator_node_mr: FixedHash::zero(),
+            validator_node_size: 0,
         };
         let hash = block_header.merge_mining_hash();
         insert_merge_mining_tag_into_block(&mut block, hash).unwrap();

--- a/base_layer/core/src/proof_of_work/sha3x_pow.rs
+++ b/base_layer/core/src/proof_of_work/sha3x_pow.rs
@@ -98,8 +98,8 @@ pub mod test {
     #[test]
     fn validate_max_target() {
         let mut header = get_header();
-        header.nonce = 154;
+        header.nonce = 631;
         println!("{:?}", header);
-        assert_eq!(sha3x_difficulty(&header).unwrap(), Difficulty::from_u64(6564).unwrap());
+        assert_eq!(sha3x_difficulty(&header).unwrap(), Difficulty::from_u64(3347).unwrap());
     }
 }

--- a/base_layer/core/src/proto/block.proto
+++ b/base_layer/core/src/proto/block.proto
@@ -53,6 +53,8 @@ message BlockHeader {
     bytes total_script_offset = 15;
     // Merkle root of validator nodes
     bytes validator_node_merkle_root = 16;
+    // Validator size
+    uint64 validator_node_size = 17;
 }
 
 // A Tari block. Blocks are linked together into a blockchain.

--- a/base_layer/core/src/proto/block_header.rs
+++ b/base_layer/core/src/proto/block_header.rs
@@ -62,6 +62,7 @@ impl TryFrom<proto::BlockHeader> for BlockHeader {
             nonce: header.nonce,
             pow,
             validator_node_mr: FixedHash::try_from(header.validator_node_merkle_root).map_err(|err| err.to_string())?,
+            validator_node_size: header.validator_node_size,
         })
     }
 }
@@ -83,6 +84,7 @@ impl From<BlockHeader> for proto::BlockHeader {
             kernel_mmr_size: header.kernel_mmr_size,
             output_mmr_size: header.output_smt_size,
             validator_node_merkle_root: header.validator_node_mr.to_vec(),
+            validator_node_size: header.validator_node_size,
         }
     }
 }

--- a/base_layer/core/src/validation/block_body/test.rs
+++ b/base_layer/core/src/validation/block_body/test.rs
@@ -94,6 +94,7 @@ async fn it_passes_if_large_output_block_is_valid() {
     block.header.kernel_mr = mmr_roots.kernel_mr;
     block.header.kernel_mmr_size = mmr_roots.kernel_mmr_size;
     block.header.validator_node_mr = mmr_roots.validator_node_mr;
+    block.header.validator_node_size = mmr_roots.validator_node_size;
 
     let txn = blockchain.db().db_read_access().unwrap();
     let start = Instant::now();
@@ -140,6 +141,7 @@ async fn it_passes_if_large_block_is_valid() {
     block.header.kernel_mr = mmr_roots.kernel_mr;
     block.header.kernel_mmr_size = mmr_roots.kernel_mmr_size;
     block.header.validator_node_mr = mmr_roots.validator_node_mr;
+    block.header.validator_node_size = mmr_roots.validator_node_size;
 
     let txn = blockchain.db().db_read_access().unwrap();
     let start = Instant::now();
@@ -167,6 +169,7 @@ async fn it_passes_if_block_is_valid() {
     block.header.kernel_mr = mmr_roots.kernel_mr;
     block.header.kernel_mmr_size = mmr_roots.kernel_mmr_size;
     block.header.validator_node_mr = mmr_roots.validator_node_mr;
+    block.header.validator_node_size = mmr_roots.validator_node_size;
 
     let txn = blockchain.db().db_read_access().unwrap();
     assert!(validator.validate_body(&*txn, &block).is_ok());

--- a/base_layer/core/src/validation/helpers.rs
+++ b/base_layer/core/src/validation/helpers.rs
@@ -319,6 +319,22 @@ pub fn check_mmr_roots(header: &BlockHeader, mmr_roots: &MmrRoots) -> Result<(),
             kind: "Validator Node",
         }));
     }
+
+    if header.validator_node_size != mmr_roots.validator_node_size {
+        warn!(
+            target: LOG_TARGET,
+            "Block header validator size in #{} {} does not match. Expected: {}, Actual:{}",
+            header.height,
+            header.hash().to_hex(),
+            header.validator_node_size,
+            mmr_roots.validator_node_size
+        );
+        return Err(ValidationError::BlockError(BlockValidationError::MismatchedMmrSize {
+            mmr_tree: "Validator_node".to_string(),
+            expected: mmr_roots.validator_node_size,
+            actual: header.validator_node_size,
+        }));
+    }
     Ok(())
 }
 

--- a/base_layer/tari_mining_helper_ffi/src/lib.rs
+++ b/base_layer/tari_mining_helper_ffi/src/lib.rs
@@ -386,8 +386,8 @@ mod tests {
 
     #[test]
     fn detect_change_in_consensus_encoding() {
-        const NONCE: u64 = 14899013610631730383;
-        let difficulty = Difficulty::from_u64(9313).expect("Failed to create difficulty");
+        const NONCE: u64 = 7597942135203888660;
+        let difficulty = Difficulty::from_u64(1490).expect("Failed to create difficulty");
         unsafe {
             let mut error = -1;
             let error_ptr = &mut error as *mut c_int;

--- a/base_layer/tari_mining_helper_ffi/src/lib.rs
+++ b/base_layer/tari_mining_helper_ffi/src/lib.rs
@@ -386,8 +386,8 @@ mod tests {
 
     #[test]
     fn detect_change_in_consensus_encoding() {
-        const NONCE: u64 = 7688822913895845419;
-        let difficulty = Difficulty::from_u64(4881).expect("Failed to create difficulty");
+        const NONCE: u64 = 14899013610631730383;
+        let difficulty = Difficulty::from_u64(9313).expect("Failed to create difficulty");
         unsafe {
             let mut error = -1;
             let error_ptr = &mut error as *mut c_int;


### PR DESCRIPTION
Description
---
Adds in the size of the validator balance tree to the header. 

Motivation and Context
---
The validator size needs to be committed too like the other Merkle roots as well. A peer syncing will have no way of verifying the validator merkle root is it does not know the size. 

How Has This Been Tested?
---
Unit tests

What process can a PR reviewer use to test or verify this change?
---
ensure its committed to and not malleable. 
