### PR TITLE
fix: recovery passphrase flow

### DIFF
--- a/applications/minotari_console_wallet/src/init/mod.rs
+++ b/applications/minotari_console_wallet/src/init/mod.rs
@@ -757,13 +757,19 @@ pub(crate) fn boot_with_password(
     }
 
     let password = match boot_mode {
+        // A new wallet requires entering and confirming a passphrase
         WalletBoot::New => {
-            // Get a new passphrase
-            debug!(target: LOG_TARGET, "Prompting for passphrase.");
+            debug!(target: LOG_TARGET, "Prompting for passphrase for new wallet.");
             get_new_passphrase("Create wallet passphrase: ", "Confirm wallet passphrase: ")?
         },
-        WalletBoot::Existing | WalletBoot::Recovery => {
-            debug!(target: LOG_TARGET, "Prompting for passphrase.");
+        // Recovery from a seed requires entering and confirming a passphrase
+        WalletBoot::Recovery => {
+            debug!(target: LOG_TARGET, "Prompting for passphrase for wallet recovery.");
+            get_new_passphrase("Create wallet passphrase: ", "Confirm wallet passphrase: ")?
+        },
+        // Opening an existing wallet only requires entering a passphrase
+        WalletBoot::Existing => {
+            debug!(target: LOG_TARGET, "Prompting for passphrase for existing wallet.");
             prompt_password("Enter wallet passphrase: ")?
         },
     };


### PR DESCRIPTION
Description
---
Switches the handling of wallet recovery passphrase entry to require confirmation and provide complexity analysis.

Closes #5859.

Motivation and Context
---
When recovering a wallet from a seed, the user is prompted to enter a passphrase without confirming it, and the passphrase complexity is not checked. That is, the flow is the same for wallet recovery as for opening an existing wallet, which is incorrect.

This PR switches the flow to that of a new wallet. When the user enters a passphrase, they must confirm it, and its complexity is analyzed to ensure the user is informed of the safety of their chosen passphrase.

Note that each case (new wallet, wallet recovery, existing wallet) is now handled separately. This is mildly redundant, but allows for better logging and makes the intent more clear.

How Has This Been Tested?
---
Tested manually.

What process can a PR reviewer use to test or verify this change?
---
Assert that the passphrase handling logic is now correct. Manually test empty, weak, and strong passphrases in the interface, including the case where the user has a weak or empty passphrase and confirms this is their intent.