### PR TITLE
feat: enable multiple coinbase utxos

### DIFF
--- a/base_layer/core/src/transactions/aggregated_body.rs
+++ b/base_layer/core/src/transactions/aggregated_body.rs
@@ -266,7 +266,7 @@ impl AggregateBody {
         let mut coinbase_kernel_counter = 0; // there should be exactly 1 coinbase kernel as well
         for kernel in self.kernels() {
             if kernel.features.contains(KernelFeatures::COINBASE_KERNEL) {
-                coinbase_counter += 1;
+                coinbase_kernel_counter += 1;
                 coinbase_kernel = Some(kernel);
             }
         }

--- a/base_layer/core/src/transactions/aggregated_body.rs
+++ b/base_layer/core/src/transactions/aggregated_body.rs
@@ -263,19 +263,19 @@ impl AggregateBody {
             "{} coinbases found in body.", coinbase_counter,
         );
 
-        let mut coinbase_counter = 0; // there should be exactly 1 coinbase kernel as well
+        let mut coinbase_kernel_counter = 0; // there should be exactly 1 coinbase kernel as well
         for kernel in self.kernels() {
             if kernel.features.contains(KernelFeatures::COINBASE_KERNEL) {
                 coinbase_counter += 1;
                 coinbase_kernel = Some(kernel);
             }
         }
-        if coinbase_kernel.is_none() || coinbase_counter != 1 {
+        if coinbase_kernel.is_none() || coinbase_kernel_counter != 1 {
             warn!(
                 target: LOG_TARGET,
                 "{} coinbase kernels found in body. Only a single coinbase kernel is permitted.", coinbase_counter,
             );
-            return Err(TransactionError::MoreThanOneCoinbase);
+            return Err(TransactionError::MoreThanOneCoinbaseKernel);
         }
 
         let coinbase_kernel = coinbase_kernel.expect("coinbase_kernel: none checked");

--- a/base_layer/core/src/transactions/aggregated_body.rs
+++ b/base_layer/core/src/transactions/aggregated_body.rs
@@ -27,9 +27,8 @@ use std::{
 use borsh::{BorshDeserialize, BorshSerialize};
 use log::*;
 use serde::{Deserialize, Serialize};
-use tari_common_types::types::PrivateKey;
+use tari_common_types::types::{Commitment, PrivateKey};
 use tari_crypto::commitment::HomomorphicCommitmentFactory;
-use tari_common_types::types::Commitment;
 
 use crate::transactions::{
     crypto_factories::CryptoFactories,
@@ -255,16 +254,14 @@ impl AggregateBody {
             }
         }
 
-        if  coinbase_counter == 0 {
+        if coinbase_counter == 0 {
             return Err(TransactionError::NoCoinbase);
         }
 
         debug!(
-                target: LOG_TARGET,
-                "{} coinbases found in body.", coinbase_counter,
-            );
-
-
+            target: LOG_TARGET,
+            "{} coinbases found in body.", coinbase_counter,
+        );
 
         let mut coinbase_counter = 0; // there should be exactly 1 coinbase kernel as well
         for kernel in self.kernels() {

--- a/base_layer/core/src/transactions/coinbase_builder.rs
+++ b/base_layer/core/src/transactions/coinbase_builder.rs
@@ -616,7 +616,7 @@ mod test {
         tx.offset = tx.offset + offset;
         tx.body.sort();
 
-        // lets add duplciate coinbase kernel
+        // lets add duplicate coinbase kernel
         let mut coinbase2 = tx2.body.outputs()[0].clone();
         coinbase2.features = OutputFeatures::default();
         let coinbase_kernel2 = tx2.body.kernels()[0].clone();

--- a/base_layer/core/src/transactions/coinbase_builder.rs
+++ b/base_layer/core/src/transactions/coinbase_builder.rs
@@ -625,16 +625,6 @@ mod test {
 
         tx_kernel_test.body.sort();
 
-        // test catches that coinbase count on the utxo is wrong
-        assert!(matches!(
-            tx.body.check_coinbase_output(
-                block_reward,
-                rules.consensus_constants(0).coinbase_min_maturity(),
-                &factories,
-                42
-            ),
-            Err(TransactionError::MoreThanOneCoinbase)
-        ));
         // test catches that coinbase count on the kernel is wrong
         assert!(matches!(
             tx_kernel_test.body.check_coinbase_output(

--- a/base_layer/core/src/transactions/coinbase_builder.rs
+++ b/base_layer/core/src/transactions/coinbase_builder.rs
@@ -633,7 +633,7 @@ mod test {
                 &factories,
                 42
             ),
-            Err(TransactionError::MoreThanOneCoinbase)
+            Err(TransactionError::MoreThanOneCoinbaseKernel)
         ));
         // testing that "block" is still valid
         let body_validator = AggregateBodyInternalConsistencyValidator::new(false, rules, factories);

--- a/base_layer/core/src/transactions/transaction_components/error.rs
+++ b/base_layer/core/src/transactions/transaction_components/error.rs
@@ -51,8 +51,8 @@ pub enum TransactionError {
     InvalidCoinbase,
     #[error("Invalid coinbase maturity in body")]
     InvalidCoinbaseMaturity,
-    #[error("More than one coinbase in body")]
-    MoreThanOneCoinbase,
+    #[error("More than one coinbase kernel in body")]
+    MoreThanOneCoinbaseKernel,
     #[error("No coinbase in body")]
     NoCoinbase,
     #[error("Input maturity not reached")]

--- a/base_layer/core/src/validation/block_body/test.rs
+++ b/base_layer/core/src/validation/block_body/test.rs
@@ -220,12 +220,6 @@ async fn it_checks_exactly_one_coinbase() {
         let err = validator.validate_body(&*txn, block.block()).unwrap_err();
         err
     };
-    assert!(matches!(
-        err,
-        ValidationError::BlockError(BlockValidationError::TransactionError(
-            TransactionError::MoreThanOneCoinbase
-        ))
-    ));
 
     let (block, _) = blockchain
         .create_unmined_block(block_spec!("A2", parent: "GB", skip_coinbase: true,))

--- a/base_layer/core/src/validation/block_body/test.rs
+++ b/base_layer/core/src/validation/block_body/test.rs
@@ -191,7 +191,7 @@ async fn it_checks_the_coinbase_reward() {
 }
 
 #[tokio::test]
-async fn it_checks_exactly_one_coinbase() {
+async fn it_allows_multiple_coinbases() {
     let (blockchain, validator) = setup(true);
 
     let (mut block, coinbase) = blockchain.create_unmined_block(block_spec!("A1", parent: "GB")).await;

--- a/base_layer/core/src/validation/block_body/test.rs
+++ b/base_layer/core/src/validation/block_body/test.rs
@@ -212,14 +212,6 @@ async fn it_checks_exactly_one_coinbase() {
         .body
         .add_output(coinbase_output.to_transaction_output(&blockchain.km).await.unwrap());
     block.body.sort();
-    let block = blockchain.mine_block("GB", block, Difficulty::min());
-
-    let err = {
-        // `MutexGuard` cannot be held across an `await` point
-        let txn = blockchain.db().db_read_access().unwrap();
-        let err = validator.validate_body(&*txn, block.block()).unwrap_err();
-        err
-    };
 
     let (block, _) = blockchain
         .create_unmined_block(block_spec!("A2", parent: "GB", skip_coinbase: true,))


### PR DESCRIPTION
Description
---
This allows multiple coinbase utxos in a block

Motivation and Context
---
If we want to implement p2pool, implementing multiple coinbases is the easiest way to enable multiple parties to have their own verified UTXOs mined. There are other ways of doing this, but this approach is the simplest and requires the least overall utxos. 

How Has This Been Tested?
---
unit tests
