### PR TITLE
feat: reduce timeouts and increase bans

### DIFF
--- a/base_layer/core/src/base_node/sync/config.rs
+++ b/base_layer/core/src/base_node/sync/config.rs
@@ -56,13 +56,13 @@ pub struct BlockchainSyncConfig {
 impl Default for BlockchainSyncConfig {
     fn default() -> Self {
         Self {
-            initial_max_sync_latency: Duration::from_secs(30),
+            initial_max_sync_latency: Duration::from_secs(15),
             max_latency_increase: Duration::from_secs(2),
-            ban_period: Duration::from_secs(30 * 60),
-            short_ban_period: Duration::from_secs(60),
+            ban_period: Duration::from_secs(60 * 60 * 2), // 2 hours
+            short_ban_period: Duration::from_secs(240),   // 4 mins
             forced_sync_peers: Default::default(),
             validation_concurrency: 6,
-            rpc_deadline: Duration::from_secs(30),
+            rpc_deadline: Duration::from_secs(15),
         }
     }
 }

--- a/common/config/presets/c_base_node.toml
+++ b/common/config/presets/c_base_node.toml
@@ -120,13 +120,13 @@ track_reorgs = true
 [base_node.state_machine]
 # The initial max sync latency. If a peer fails to stream a header/block within this deadline another sync peer will be
 # selected. If there are no further peers the sync will be restarted with an increased by `max_latency_increase`.
-#blockchain_sync_config.initial_max_sync_latency = 30
+#blockchain_sync_config.initial_max_sync_latency = 15
 # If all sync peers exceed latency increase allowed latency by this value
 #blockchain_sync_config.max_latency_increase =2
 # Longer ban period for potentially malicious infractions (protocol violations etc.)
-#blockchain_sync_config.ban_period = 1_800 # 30 * 60
+#blockchain_sync_config.ban_period = 7_200 # 2 * 60 * 60
 # Short ban period for infractions that are likely not malicious (slow to respond spotty connections etc)
-#blockchain_sync_config.short_ban_period = 60
+#blockchain_sync_config.short_ban_period = 240
 # An allowlist of sync peers from which to sync. No other peers will be selected for sync. If empty sync peers
 # are chosen based on their advertised chain metadata.
 #blockchain_sync_config.forced_sync_peers = []


### PR DESCRIPTION
Description
---
Reduces the latency of timeouts from 30 seconds to 15 seconds
Increases the ban periods

Motivation and Context
---
Reduces the latency of the timeouts from 30 secs to 15 secs: #5860 

Increase the short ban to 4 mins up from 30 seconds. The short ban is used for timeouts etc. and is used to ensure the base node can select a new node to sync from etc. But if this is too short, or under the block time, timeouts can be used maliciously by nodes. For example a node can say it has a better pow, let your node try and sync to it, wait for the timeouts, get banned for 30 seconds. This means your node waits the 30 seconds -> 1 mins if needs more than 1 call, which is likely. This means you node rejects all new blocks for 1 min, and then you ban the peer for 30 secs. They can then submit their new block to you after the 30 secs. This makes it longer than the block time. This means the bad node is excluded from all new nodes for 2 blocks on avg. 


Fixes: : #5860 
Fixes: #5867 
