### PR TITLE
feat: print warning for wallets in direct send only

### DIFF
--- a/applications/minotari_console_wallet/src/init/mod.rs
+++ b/applications/minotari_console_wallet/src/init/mod.rs
@@ -656,6 +656,35 @@ pub(crate) fn confirm_seed_words(wallet: &mut WalletSqlite) -> Result<(), ExitEr
     }
 }
 
+pub(crate) fn confirm_direct_only_send(wallet: &mut WalletSqlite) -> Result<(), ExitError> {
+    let seed_words = wallet.get_seed_words(&MnemonicLanguage::English)?;
+
+    println!();
+    println!("=========================");
+    println!("       IMPORTANT!        ");
+    println!("=========================");
+    println!("This wallet is set to use DirectOnly.");
+    println!("This is primarily used for testing and can result in not all messages being sent.");
+    println!();
+    println!("\x07"); // beep!
+
+    let mut rl = Editor::<()>::new();
+    loop {
+        println!("I confirm this warning.");
+        println!(r#"Type the word "confirm" , "yes" or "y" to continue."#);
+        let readline = rl.readline(">> ");
+        match readline {
+            Ok(line) => match line.to_lowercase().as_ref() {
+                "confirm" | "yes" | "y" => return Ok(()),
+                _ => continue,
+            },
+            Err(e) => {
+                return Err(ExitError::new(ExitCode::IOError, e));
+            },
+        }
+    }
+}
+
 /// Clear the terminal and print the Tari splash
 pub fn tari_splash_screen(heading: &str) {
     // clear the terminal

--- a/applications/minotari_console_wallet/src/lib.rs
+++ b/applications/minotari_console_wallet/src/lib.rs
@@ -103,6 +103,7 @@ pub fn run_wallet(shutdown: &mut Shutdown, runtime: Runtime, config: &mut Applic
     run_wallet_with_cli(shutdown, runtime, config, cli)
 }
 
+#[allow(clippy::too_many_lines)]
 pub fn run_wallet_with_cli(
     shutdown: &mut Shutdown,
     runtime: Runtime,


### PR DESCRIPTION
Description
---
Prints out a warning for wallets set to use direct send only

Motivation and Context
---
See: #5861 

How Has This Been Tested?
---
Manual

Fixes: #5861 