### PR TITLE
feat: add config for grpc server methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3270,6 +3270,7 @@ dependencies = [
  "tari_utilities",
  "thiserror",
  "tokio",
+ "toml 0.5.11",
  "tonic 0.6.2",
 ]
 

--- a/applications/minotari_node/Cargo.toml
+++ b/applications/minotari_node/Cargo.toml
@@ -65,3 +65,6 @@ ignored = [
     # We need to specify extra features for log4rs even though it is not used directly in this crate
     "log4rs"
 ]
+
+[dev-dependencies]
+toml = { version = "0.5" }

--- a/applications/minotari_node/src/config.rs
+++ b/applications/minotari_node/src/config.rs
@@ -87,6 +87,8 @@ pub struct BaseNodeConfig {
     pub grpc_enabled: bool,
     /// GRPC address of base node
     pub grpc_address: Option<Multiaddr>,
+    /// GRPC server config - which methods are active and which not
+    pub grpc_server_config: BaseNodeGrpcServerConfig,
     /// A path to the file that stores the base node identity and secret key
     pub identity_file: PathBuf,
     /// Spin up and use a built-in Tor instance. This only works on macos/linux - requires that the wallet was built
@@ -143,6 +145,44 @@ impl Default for BaseNodeConfig {
             network: Network::default(),
             grpc_enabled: true,
             grpc_address: None,
+            grpc_server_config: BaseNodeGrpcServerConfig {
+                // These gRPC server methods will not share sensitive information, thus enabled by default
+                enable_list_headers: true,
+                enable_get_header_by_hash: true,
+                enable_get_blocks: true,
+                enable_get_block_timing: true,
+                enable_get_constants: true,
+                enable_get_block_size: true,
+                enable_get_block_fees: true,
+                enable_get_tokens_in_circulation: true,
+                enable_get_network_difficulty: true,
+                enable_get_new_block_template: true,
+                enable_get_new_block: true,
+                enable_get_new_block_blob: true,
+                enable_submit_block: true,
+                enable_submit_block_blob: true,
+                enable_submit_transaction: true,
+                enable_search_kernels: true,
+                enable_search_utxos: true,
+                enable_fetch_matching_utxos: true,
+                enable_get_peers: true,
+                enable_get_mempool_transactions: true,
+                enable_transaction_state: true,
+                enable_list_connected_peers: true,
+                enable_get_mempool_stats: true,
+                enable_get_active_validator_nodes: true,
+                enable_get_shard_key: true,
+                enable_get_template_registrations: true,
+                enable_get_side_chain_utxos: true,
+                // These gRPC server methods share sensitive information, thus disabled by default
+                enable_get_version: false,
+                enable_check_for_updates: false,
+                enable_get_sync_info: false,
+                enable_get_sync_progress: false,
+                enable_get_tip_info: false,
+                enable_identify: false,
+                enable_get_network_status: false,
+            },
             identity_file: PathBuf::from("config/base_node_id.json"),
             use_libtor: false,
             tor_identity_file: PathBuf::from("config/base_node_tor_id.json"),
@@ -194,4 +234,78 @@ impl BaseNodeConfig {
 #[serde(rename_all = "snake_case")]
 pub enum DatabaseType {
     Lmdb,
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+#[allow(clippy::struct_excessive_bools)]
+pub struct BaseNodeGrpcServerConfig {
+    /// Enable the ListHeaders gRPC server method
+    pub enable_list_headers: bool,
+    /// Enable the GetHeaderByHash gRPC server method
+    pub enable_get_header_by_hash: bool,
+    /// Enable the GetBlocks gRPC server method
+    pub enable_get_blocks: bool,
+    /// Enable the GetBlockTiming gRPC server method
+    pub enable_get_block_timing: bool,
+    /// Enable the GetConstants gRPC server method
+    pub enable_get_constants: bool,
+    /// Enable the GetBlockSize gRPC server method
+    pub enable_get_block_size: bool,
+    /// Enable the GetBlockFees gRPC server method
+    pub enable_get_block_fees: bool,
+    /// Enable the GetVersion gRPC server method
+    pub enable_get_version: bool,
+    /// Enable the CheckForUpdates gRPC server method
+    pub enable_check_for_updates: bool,
+    /// Enable the GetTokensInCirculation gRPC server method
+    pub enable_get_tokens_in_circulation: bool,
+    /// Enable the GetNetworkDifficulty gRPC server method
+    pub enable_get_network_difficulty: bool,
+    /// Enable the GetNewBlockTemplate gRPC server method
+    pub enable_get_new_block_template: bool,
+    /// Enable the GetNewBlock gRPC server method
+    pub enable_get_new_block: bool,
+    /// Enable the GetNewBlockBlob gRPC server method
+    pub enable_get_new_block_blob: bool,
+    /// Enable the SubmitBlock gRPC server method
+    pub enable_submit_block: bool,
+    /// Enable the SubmitBlockBlob gRPC server method
+    pub enable_submit_block_blob: bool,
+    /// Enable the SubmitTransaction gRPC server method
+    pub enable_submit_transaction: bool,
+    /// Enable the GetSyncInfo gRPC server method
+    pub enable_get_sync_info: bool,
+    /// Enable the GetSyncProgress gRPC server method
+    pub enable_get_sync_progress: bool,
+    /// Enable the GetTipInfo gRPC server method
+    pub enable_get_tip_info: bool,
+    /// Enable the SearchKernels gRPC server method
+    pub enable_search_kernels: bool,
+    /// Enable the SearchUtxos gRPC server method
+    pub enable_search_utxos: bool,
+    /// Enable the FetchMatchingUtxos gRPC server method
+    pub enable_fetch_matching_utxos: bool,
+    /// Enable the GetPeers gRPC server method
+    pub enable_get_peers: bool,
+    /// Enable the GetMempoolTransactions gRPC server method
+    pub enable_get_mempool_transactions: bool,
+    /// Enable the TransactionState gRPC server method
+    pub enable_transaction_state: bool,
+    /// Enable the Identify gRPC server method
+    pub enable_identify: bool,
+    /// Enable the GetNetworkStatus gRPC server method
+    pub enable_get_network_status: bool,
+    /// Enable the ListConnectedPeers gRPC server method
+    pub enable_list_connected_peers: bool,
+    /// Enable the GetMempoolState gRPC server method
+    pub enable_get_mempool_stats: bool,
+    /// Enable the GetActiveValidatorNodes gRPC server method
+    pub enable_get_active_validator_nodes: bool,
+    /// Enable the GetShardKey gRPC server method
+    pub enable_get_shard_key: bool,
+    /// Enable the GetTemplateRegistrations gRPC server method
+    pub enable_get_template_registrations: bool,
+    /// Enable the GetSideChainUtxos gRPC server method
+    pub enable_get_side_chain_utxos: bool,
 }

--- a/applications/minotari_node/src/lib.rs
+++ b/applications/minotari_node/src/lib.rs
@@ -133,7 +133,10 @@ pub async fn run_base_node_with_cli(
             format!("/ip4/127.0.0.1/tcp/{}", port).parse().unwrap()
         });
         // Go, GRPC, go go
-        let grpc = grpc::base_node_grpc_server::BaseNodeGrpcServer::from_base_node_context(&ctx);
+        let grpc = grpc::base_node_grpc_server::BaseNodeGrpcServer::from_base_node_context(
+            &ctx,
+            config.base_node.grpc_server_config.clone(),
+        );
         task::spawn(run_grpc(grpc, grpc_address, shutdown.to_signal()));
     }
 

--- a/applications/minotari_node/src/lib.rs
+++ b/applications/minotari_node/src/lib.rs
@@ -135,7 +135,7 @@ pub async fn run_base_node_with_cli(
         // Go, GRPC, go go
         let grpc = grpc::base_node_grpc_server::BaseNodeGrpcServer::from_base_node_context(
             &ctx,
-            config.base_node.grpc_server_config.clone(),
+            config.base_node.grpc_server_deny_methods.clone(),
         );
         task::spawn(run_grpc(grpc, grpc_address, shutdown.to_signal()));
     }

--- a/common/config/presets/c_base_node.toml
+++ b/common/config/presets/c_base_node.toml
@@ -33,6 +33,44 @@ identity_file = "config/base_node_id_nextnet.json"
 # Set to false to disable the base node GRPC server (default = true)
 #grpc_enabled = true
 
+# Uncomment all gRPC server methods that should be denied default (only active when `grpc_enabled = true`)
+grpc_server_deny_methods = [
+    "get_version",
+    "check_for_updates",
+    "get_sync_info",
+    "get_sync_progress",
+    "get_tip_info",
+    "identify",
+    "get_network_status",
+    #"list_headers"
+    #"get_header_by_hash"
+    #"get_blocks"
+    #"get_block_timing"
+    #"get_constants"
+    #"get_block_size"
+    #"get_block_fees"
+    #"get_tokens_in_circulation"
+    #"get_network_difficulty"
+    #"get_new_block_template"
+    #"get_new_block"
+    #"get_new_block_blob"
+    #"submit_block"
+    #"submit_block_blob"
+    #"submit_transaction"
+    #"search_kernels"
+    #"search_utxos"
+    #"fetch_matching_utxos"
+    #"get_peers"
+    #"get_mempool_transactions"
+    #"transaction_state"
+    #"list_connected_peers"
+    #"get_mempool_stats"
+    #"get_active_validator_nodes"
+    #"get_shard_key"
+    #"get_template_registrations"
+    #"get_side_chain_utxos"
+]
+
 # A path to the file that stores your node identity and secret key (default = "config/base_node_id.json")
 #identity_file = "config/base_node_id.json"
 
@@ -79,48 +117,6 @@ identity_file = "config/base_node_id_nextnet.json"
 
 # Obscure GRPC error responses (default = false)
 #report_grpc_error = false
-
-[base_node.grpc_server_config]
-#
-# These gRPC server methods will not share sensitive information, thus enabled by default
-#
-#enable_list_headers = true
-#enable_get_header_by_hash = true
-#enable_get_blocks = true
-#enable_get_block_timing = true
-#enable_get_constants = true
-#enable_get_block_size = true
-#enable_get_block_fees = true
-#enable_get_tokens_in_circulation = true
-#enable_get_network_difficulty = true
-#enable_get_new_block_template = true
-#enable_get_new_block = true
-#enable_get_new_block_blob = true
-#enable_submit_block = true
-#enable_submit_block_blob = true
-#enable_submit_transaction = true
-#enable_search_kernels = true
-#enable_search_utxos = true
-#enable_fetch_matching_utxos = true
-#enable_get_peers = true
-#enable_get_mempool_transactions = true
-#enable_transaction_state = true
-#enable_list_connected_peers = true
-#enable_get_mempool_stats = true
-#enable_get_active_validator_nodes = true
-#enable_get_shard_key = true
-#enable_get_template_registrations = true
-#enable_get_side_chain_utxos = true
-#
-# These gRPC server methods share sensitive information, thus disabled by default
-#
-#enable_get_version = false
-#enable_check_for_updates = false
-#enable_get_sync_info = false
-#enable_get_sync_progress = false
-#enable_get_tip_info = false
-#enable_identify = false
-#enable_get_network_status = false
 
 [base_node.lmdb]
 #init_size_bytes = 16_777_216 # 16 *1024 * 1024

--- a/common/config/presets/c_base_node.toml
+++ b/common/config/presets/c_base_node.toml
@@ -80,6 +80,48 @@ identity_file = "config/base_node_id_nextnet.json"
 # Obscure GRPC error responses (default = false)
 #report_grpc_error = false
 
+[base_node.grpc_server_config]
+#
+# These gRPC server methods will not share sensitive information, thus enabled by default
+#
+#enable_list_headers = true
+#enable_get_header_by_hash = true
+#enable_get_blocks = true
+#enable_get_block_timing = true
+#enable_get_constants = true
+#enable_get_block_size = true
+#enable_get_block_fees = true
+#enable_get_tokens_in_circulation = true
+#enable_get_network_difficulty = true
+#enable_get_new_block_template = true
+#enable_get_new_block = true
+#enable_get_new_block_blob = true
+#enable_submit_block = true
+#enable_submit_block_blob = true
+#enable_submit_transaction = true
+#enable_search_kernels = true
+#enable_search_utxos = true
+#enable_fetch_matching_utxos = true
+#enable_get_peers = true
+#enable_get_mempool_transactions = true
+#enable_transaction_state = true
+#enable_list_connected_peers = true
+#enable_get_mempool_stats = true
+#enable_get_active_validator_nodes = true
+#enable_get_shard_key = true
+#enable_get_template_registrations = true
+#enable_get_side_chain_utxos = true
+#
+# These gRPC server methods share sensitive information, thus disabled by default
+#
+#enable_get_version = false
+#enable_check_for_updates = false
+#enable_get_sync_info = false
+#enable_get_sync_progress = false
+#enable_get_tip_info = false
+#enable_identify = false
+#enable_get_network_status = false
+
 [base_node.lmdb]
 #init_size_bytes = 16_777_216 # 16 *1024 * 1024
 #grow_size_bytes = 16_777_216 # 16 *1024 * 1024

--- a/integration_tests/src/base_node_process.rs
+++ b/integration_tests/src/base_node_process.rs
@@ -80,6 +80,7 @@ pub async fn spawn_base_node(world: &mut TariWorld, is_seed_node: bool, bn_name:
     spawn_base_node_with_config(world, is_seed_node, bn_name, peers, BaseNodeConfig::default()).await;
 }
 
+#[allow(clippy::too_many_lines)]
 pub async fn spawn_base_node_with_config(
     world: &mut TariWorld,
     is_seed_node: bool,
@@ -184,13 +185,7 @@ pub async fn spawn_base_node_with_config(
             base_node_config.base_node.storage.pruning_interval = 1;
         };
 
-        base_node_config.base_node.grpc_server_config.enable_get_version = true;
-        base_node_config.base_node.grpc_server_config.enable_check_for_updates = true;
-        base_node_config.base_node.grpc_server_config.enable_get_sync_info = true;
-        base_node_config.base_node.grpc_server_config.enable_get_sync_progress = true;
-        base_node_config.base_node.grpc_server_config.enable_get_tip_info = true;
-        base_node_config.base_node.grpc_server_config.enable_identify = true;
-        base_node_config.base_node.grpc_server_config.enable_get_network_status = true;
+        base_node_config.base_node.grpc_server_deny_methods = vec![];
 
         // Heirachically set the base path for all configs
         base_node_config.base_node.set_base_path(temp_dir_path.clone());

--- a/integration_tests/src/base_node_process.rs
+++ b/integration_tests/src/base_node_process.rs
@@ -184,6 +184,14 @@ pub async fn spawn_base_node_with_config(
             base_node_config.base_node.storage.pruning_interval = 1;
         };
 
+        base_node_config.base_node.grpc_server_config.enable_get_version = true;
+        base_node_config.base_node.grpc_server_config.enable_check_for_updates = true;
+        base_node_config.base_node.grpc_server_config.enable_get_sync_info = true;
+        base_node_config.base_node.grpc_server_config.enable_get_sync_progress = true;
+        base_node_config.base_node.grpc_server_config.enable_get_tip_info = true;
+        base_node_config.base_node.grpc_server_config.enable_identify = true;
+        base_node_config.base_node.grpc_server_config.enable_get_network_status = true;
+
         // Heirachically set the base path for all configs
         base_node_config.base_node.set_base_path(temp_dir_path.clone());
 


### PR DESCRIPTION
Description
---
Added configuration options for the base node's gRPC methods whereby each method can be enabled or disabled with the startup-config settings.

Closing #5858

Some BloomRPC screenshots:

![image](https://github.com/tari-project/tari/assets/39146854/356cbe44-d3ff-46c8-9215-57e9f24da815)

![image](https://github.com/tari-project/tari/assets/39146854/8bf225b8-1b00-439b-96be-93c8040bf8d4)


Motivation and Context
---
See #5858

How Has This Been Tested?
---
- Pass existing unit tests
- Added unit test `fn it_deserializes_enums`
- Pass cucumber tests on CI
- Manual gRPC queries to the base node (with BloomRPC)

What process can a PR reviewer use to test or verify this change?
---
- Code walkthrough
- Manual gRPC queries to the base node

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
