### PR TITLE
feat: support tls-based auth for grpc (WIP)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ pie/
 integration_tests/cucumber-output-junit.xml
 
 integration_tests/log/
+
+# Ignore the generated keys for grpc
+applications/minotari_app_grpc/keys/

--- a/applications/minotari_app_grpc/src/authentication/client_interceptor.rs
+++ b/applications/minotari_app_grpc/src/authentication/client_interceptor.rs
@@ -43,6 +43,9 @@ impl ClientAuthenticationInterceptor {
             GrpcAuthentication::Basic { username, password } => {
                 Some(BasicAuthCredentials::generate_header(username, password.reveal())?)
             },
+            GrpcAuthentication::Tls {} => {
+                todo!()
+            },
         };
         Ok(Self { authorization_header })
     }

--- a/applications/minotari_app_grpc/src/authentication/server_interceptor.rs
+++ b/applications/minotari_app_grpc/src/authentication/server_interceptor.rs
@@ -66,6 +66,9 @@ impl Interceptor for ServerAuthenticationInterceptor {
                 username,
                 password: hashed_password,
             } => self.handle_basic_auth(request, username, hashed_password.reveal()),
+            GrpcAuthentication::Tls {} => {
+                todo!()
+            },
         }
     }
 }

--- a/base_layer/common_types/src/grpc_authentication.rs
+++ b/base_layer/common_types/src/grpc_authentication.rs
@@ -33,6 +33,7 @@ pub enum GrpcAuthentication {
         #[serde(deserialize_with = "deserialize_safe_password")]
         password: SafePassword,
     },
+    Tls {},
 }
 
 impl GrpcAuthentication {

--- a/scripts/keygen.sh
+++ b/scripts/keygen.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# generate self-signed certificate for Tari server
+# usage: bash scripts/keygen.sh [hostname]
+set -e
+
+HOSTNAME=${1:-"tari.local"}
+KEY_LOCATION="applications/minotari_app_grpc/keys"
+mkdir --parent "${KEY_LOCATION}"
+
+# Tari CA certificate configuration
+cat > ca-cert.conf << EOT
+[req]
+distinguished_name = req_distinguished_name
+req_extensions = v3_req
+prompt = no
+utf8 = yes
+
+[req_distinguished_name]
+C = US
+ST = California
+L = Oakland
+O = Tari
+CN = Tari CA Cert
+
+[v3_req]
+basicConstraints = critical, CA:TRUE, pathlen: 0
+authorityKeyIdentifier = keyid, issuer
+subjectKeyIdentifier = hash
+keyUsage = critical, cRLSign, digitalSignature, keyCertSign
+EOT
+
+# Tari server certificate configuration
+cat > server-csr.conf << EOT
+[req]
+distinguished_name = req_distinguished_name
+prompt = no
+utf8 = yes
+
+[req_distinguished_name]
+C = US
+ST = California
+L = Oakland 
+O = Tari
+CN = Tari Server Cert
+EOT
+
+# Standard server X509v3 extensions - https://www.openssl.org/docs/man3.0/man5/x509v3_config.html
+cat > server-ext.conf << EOT
+basicConstraints = critical, CA:FALSE
+authorityKeyIdentifier = keyid, issuer
+subjectKeyIdentifier = hash
+keyUsage = critical, nonRepudiation, digitalSignature, keyEncipherment, keyAgreement
+extendedKeyUsage = critical, serverAuth
+EOT
+echo "subjectAltName = DNS: ${HOSTNAME}" >> server-ext.conf
+
+# Generate a Tari CA private key
+openssl ecparam -name prime256v1 -genkey -noout -out "${KEY_LOCATION}/tari-ca-key.pem"
+# Issue self-signed certificate for Tari CA
+openssl req -new -x509 -key "${KEY_LOCATION}/tari-ca-key.pem" -out "${KEY_LOCATION}/tari-ca-cert.pem" -days 730 -config ca-cert.conf -nodes -extensions v3_req
+
+# Generate a private key for Tari server
+openssl ecparam -name prime256v1 -genkey -noout -out "${KEY_LOCATION}/tari-server-key-ec.pem"
+openssl pkcs8 -topk8 -nocrypt -in "${KEY_LOCATION}/tari-server-key-ec.pem" -out "${KEY_LOCATION}/tari-server-key.pem"
+rm "${KEY_LOCATION}/tari-server-key-ec.pem"
+# Generate a CSR for Tari server using its private key and the server configuration file
+openssl req -new -key "${KEY_LOCATION}/tari-server-key.pem" -out csr.pem -config server-csr.conf
+# Generate a Tari server certificate using the CSR and the Tari CA priv and cert
+openssl x509 -req -days 365 -in csr.pem -CA "${KEY_LOCATION}/tari-ca-cert.pem" -CAkey "${KEY_LOCATION}/tari-ca-key.pem" -CAcreateserial -out "${KEY_LOCATION}/tari-server-cert.pem" -extfile server-ext.conf
+
+# Cleanup
+rm ca-cert.conf server-csr.conf server-ext.conf csr.pem
+


### PR DESCRIPTION
Description
---
Added support SSL/TLS based authentication and transport security for gRPC.
Resolving #5808 

Motivation and Context
---
See #5808 

How Has This Been Tested?
---
- Pass unit tests.
- Add more unit test.
- 

What process can a PR reviewer use to test or verify this change?
---
- Code walkthrough.
- Running bash script from the root project: `$ bash scripts/keygen.sh [hostname]`, default is `tari.local` if no argument is provided.
- Manual gRPC queries.


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
