### PR TITLE
feat!: completed transaction use bytes for transaction protocol (not hex string) in wallet database

### DIFF
--- a/base_layer/core/src/mempool/service/inbound_handlers.rs
+++ b/base_layer/core/src/mempool/service/inbound_handlers.rs
@@ -93,10 +93,15 @@ impl MempoolInboundHandlers {
         tx: Transaction,
         source_peer: Option<NodeId>,
     ) -> Result<(), MempoolServiceError> {
+        let first_tx_kernel_excess_sig = tx
+            .first_kernel_excess_sig()
+            .ok_or(MempoolServiceError::TransactionNoKernels)?
+            .get_signature()
+            .to_hex();
         debug!(
             target: LOG_TARGET,
             "Transaction ({}) received from {}.",
-            tx.body.kernels()[0].excess_sig.get_signature().to_hex(),
+            first_tx_kernel_excess_sig,
             source_peer
                 .as_ref()
                 .map(|p| format!("remote peer: {}", p))

--- a/base_layer/core/src/transactions/transaction_components/transaction_output.rs
+++ b/base_layer/core/src/transactions/transaction_components/transaction_output.rs
@@ -293,7 +293,7 @@ impl TransactionOutput {
         let e = PrivateKey::from_uniform_bytes(&e_bytes).unwrap();
         let value_as_private_key = PrivateKey::from(self.minimum_value_promise.as_u64());
         let commit_nonce_a = PrivateKey::default(); // This is the deterministic nonce `r_a` of zero
-        if self.metadata_signature.u_a().to_hex() == (commit_nonce_a + e * value_as_private_key).to_hex() {
+        if self.metadata_signature.u_a() == &(commit_nonce_a + e * value_as_private_key) {
             Ok(())
         } else {
             Err(RangeProofError::InvalidRangeProof {

--- a/base_layer/wallet/migrations/2023-11-03-161500_transaction_protocol/down.sql
+++ b/base_layer/wallet/migrations/2023-11-03-161500_transaction_protocol/down.sql
@@ -1,0 +1,1 @@
+-- This file should undo anything in `up.sql`

--- a/base_layer/wallet/migrations/2023-11-03-161500_transaction_protocol/up.sql
+++ b/base_layer/wallet/migrations/2023-11-03-161500_transaction_protocol/up.sql
@@ -1,0 +1,27 @@
+-- Any old 'completed_transactions' will not be valid due to the change in 'transaction_protocol' to
+-- 'BLOB', so we drop and recreate the table.
+
+DROP TABLE completed_transactions;
+CREATE TABLE completed_transactions
+(
+    tx_id                       BIGINT PRIMARY KEY NOT NULL,
+    source_address              BLOB               NOT NULL,
+    destination_address         BLOB               NOT NULL,
+    amount                      BIGINT             NOT NULL,
+    fee                         BIGINT             NOT NULL,
+    transaction_protocol        BLOB               NOT NULL,
+    status                      INTEGER            NOT NULL,
+    message                     TEXT               NOT NULL,
+    timestamp                   DATETIME           NOT NULL,
+    cancelled                   INTEGER            NULL,
+    direction                   INTEGER            NULL,
+    coinbase_block_height       BIGINT             NULL,
+    send_count                  INTEGER DEFAULT 0  NOT NULL,
+    last_send_timestamp         DATETIME           NULL,
+    confirmations               BIGINT             NULL,
+    mined_height                BIGINT             NULL,
+    mined_in_block              BLOB               NULL,
+    mined_timestamp             DATETIME           NULL,
+    transaction_signature_nonce BLOB    DEFAULT 0  NOT NULL,
+    transaction_signature_key   BLOB    DEFAULT 0  NOT NULL
+);

--- a/base_layer/wallet/src/schema.rs
+++ b/base_layer/wallet/src/schema.rs
@@ -1,6 +1,4 @@
-// @generated automatically by Diesel CLI.
-
-diesel::table! {
+table! {
     burnt_proofs (id) {
         id -> Integer,
         reciprocal_claim_public_key -> Text,
@@ -9,21 +7,21 @@ diesel::table! {
     }
 }
 
-diesel::table! {
+table! {
     client_key_values (key) {
         key -> Text,
         value -> Text,
     }
 }
 
-diesel::table! {
+table! {
     completed_transactions (tx_id) {
         tx_id -> BigInt,
         source_address -> Binary,
         destination_address -> Binary,
         amount -> BigInt,
         fee -> BigInt,
-        transaction_protocol -> Text,
+        transaction_protocol -> Binary,
         status -> Integer,
         message -> Text,
         timestamp -> Timestamp,
@@ -41,7 +39,7 @@ diesel::table! {
     }
 }
 
-diesel::table! {
+table! {
     inbound_transactions (tx_id) {
         tx_id -> BigInt,
         source_address -> Binary,
@@ -56,7 +54,7 @@ diesel::table! {
     }
 }
 
-diesel::table! {
+table! {
     known_one_sided_payment_scripts (script_hash) {
         script_hash -> Binary,
         private_key -> Text,
@@ -66,7 +64,7 @@ diesel::table! {
     }
 }
 
-diesel::table! {
+table! {
     outbound_transactions (tx_id) {
         tx_id -> BigInt,
         destination_address -> Binary,
@@ -82,7 +80,7 @@ diesel::table! {
     }
 }
 
-diesel::table! {
+table! {
     outputs (id) {
         id -> Integer,
         commitment -> Binary,
@@ -122,7 +120,7 @@ diesel::table! {
     }
 }
 
-diesel::table! {
+table! {
     scanned_blocks (header_hash) {
         header_hash -> Binary,
         height -> BigInt,
@@ -132,14 +130,14 @@ diesel::table! {
     }
 }
 
-diesel::table! {
+table! {
     wallet_settings (key) {
         key -> Text,
         value -> Text,
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(
+allow_tables_to_appear_in_same_query!(
     burnt_proofs,
     client_key_values,
     completed_transactions,

--- a/base_layer/wallet/src/transaction_service/error.rs
+++ b/base_layer/wallet/src/transaction_service/error.rs
@@ -229,6 +229,8 @@ pub enum TransactionStorageError {
     ValueNotFound(DbKey),
     #[error("Unexpected result: `{0}`")]
     UnexpectedResult(String),
+    #[error("Bincode error: `{0}`")]
+    BincodeSerialize(String),
     #[error("This write operation is not supported for provided DbKey")]
     OperationNotSupported,
     #[error("Could not find all values specified for batch operation")]

--- a/integration_tests/tests/features/WalletCli.feature
+++ b/integration_tests/tests/features/WalletCli.feature
@@ -105,6 +105,21 @@ Feature: Wallet CLI
         Then wallet WALLET has at least 1 transactions that are all TRANSACTION_STATUS_MINED_CONFIRMED and not cancelled
         Then I get count of utxos of wallet WALLET and it's at least 10 via command line
 
+    @long-running
+    Scenario: As a user I want to large coin-split via command line
+        Given I have a seed node SEED
+        When I have a base node BASE connected to seed SEED
+        When I have wallet WALLET connected to base node BASE
+        When I have mining node MINE connected to base node BASE and wallet WALLET
+        When mining node MINE mines 4 blocks
+        Then I wait for wallet WALLET to have at least 1100000 uT
+        When I wait 30 seconds
+        When I do coin split on wallet WALLET to 10000 uT 499 coins via command line
+        Then wallet WALLET has at least 1 transactions that are all TRANSACTION_STATUS_BROADCAST and not cancelled
+        When mining node MINE mines 5 blocks
+        Then wallet WALLET has at least 1 transactions that are all TRANSACTION_STATUS_MINED_CONFIRMED and not cancelled
+        Then I get count of utxos of wallet WALLET and it's at least 499 via command line
+
     Scenario: As a user I want to count utxos via command line
         Given I have a base node BASE
         When I have wallet WALLET connected to base node BASE


### PR DESCRIPTION
Description
---
Changed the transaction protocol in the wallet database to use bytes instead of a hex string, as the underlying data type is encrypted bytes. This issue was highlighted due to the `to_hex` function in `tari_utilities` not being able to convert large transactions into hex strings (returned `**String to large**`) for saving in the wallet database during system-level coin-split stress testing.

Motivation and Context
---
See above.

How Has This Been Tested?
---
Existing unit tests and cucumber tests passed
Added two new unit tests and a cucumber test (long-running)
System-level test creating a coin-split transaction with 499 outputs passed

What process can a PR reviewer use to test or verify this change?
---
Code walk-through
Run the new unit tests
Perform a system-level test creating a coin-split transaction with 499 outputs and wait for it to be mined and confirmed, 

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [ ] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [X] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
BREAKING CHANGE: All completed transactions in the wallet database will be deleted at startup, while subsequent output validation will re-allocate outputs that were encumbered to be spent as available and invalidate outputs that were encumbered to be received.
