### PR TITLE
ci(fix): disable osx arm64 build

### DIFF
--- a/.github/workflows/base_node_binaries.json
+++ b/.github/workflows/base_node_binaries.json
@@ -38,7 +38,8 @@
     "cross": false,
     "target_cpu": "generic",
     "target_bins": "--bin minotari_node --bin minotari_console_wallet --bin minotari_merge_mining_proxy --bin minotari_miner",
-    "features": "safe"
+    "features": "safe",
+    "build_enabled": false
   },
   {
     "name": "windows-x64",


### PR DESCRIPTION
Description
Temporarily disable the OSX ARM64 builds

Motivation and Context
Allow other binaries to be built

How Has This Been Tested?
Disabled in local fork.

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
