### PR TITLE
feat(node grpc): add grpc authentication to the node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3162,6 +3162,7 @@ dependencies = [
  "hyper",
  "jsonrpc",
  "log",
+ "minotari_app_grpc",
  "minotari_app_utilities",
  "minotari_node_grpc_client",
  "minotari_wallet_grpc_client",

--- a/applications/minotari_merge_mining_proxy/Cargo.toml
+++ b/applications/minotari_merge_mining_proxy/Cargo.toml
@@ -16,8 +16,9 @@ tari_comms = { path = "../../comms/core" }
 tari_core = { path = "../../base_layer/core", default-features = false, features = ["transactions"] }
 minotari_app_utilities = { path = "../minotari_app_utilities" }
 tari_utilities = { version = "0.6" }
-minotari_node_grpc_client = {path="../../clients/rust/base_node_grpc_client" }
-minotari_wallet_grpc_client = {path="../../clients/rust/wallet_grpc_client" }
+minotari_node_grpc_client = { path = "../../clients/rust/base_node_grpc_client" }
+minotari_wallet_grpc_client = { path = "../../clients/rust/wallet_grpc_client" }
+minotari_app_grpc = { path = "../minotari_app_grpc" }
 
 anyhow = "1.0.53"
 crossterm = { version = "0.25.0" }

--- a/applications/minotari_merge_mining_proxy/src/block_template_protocol.rs
+++ b/applications/minotari_merge_mining_proxy/src/block_template_protocol.rs
@@ -25,9 +25,13 @@
 use std::{cmp, sync::Arc};
 
 use log::*;
-use minotari_node_grpc_client::{grpc, BaseNodeGrpcClient};
-use minotari_wallet_grpc_client::WalletGrpcClient;
+use minotari_app_grpc::{
+    authentication::ClientAuthenticationInterceptor,
+    tari_rpc::{base_node_client::BaseNodeClient, wallet_client::WalletClient},
+};
+use minotari_node_grpc_client::grpc;
 use tari_core::proof_of_work::{monero_rx, monero_rx::FixedByteArray, Difficulty};
+use tonic::{codegen::InterceptedService, transport::Channel};
 
 use crate::{
     block_template_data::{BlockTemplateData, BlockTemplateDataBuilder},
@@ -41,14 +45,14 @@ const LOG_TARGET: &str = "minotari_mm_proxy::proxy::block_template_protocol";
 /// Structure holding grpc connections.
 pub struct BlockTemplateProtocol<'a> {
     config: Arc<MergeMiningProxyConfig>,
-    base_node_client: &'a mut BaseNodeGrpcClient<tonic::transport::Channel>,
-    wallet_client: &'a mut WalletGrpcClient<tonic::transport::Channel>,
+    base_node_client: &'a mut BaseNodeClient<InterceptedService<Channel, ClientAuthenticationInterceptor>>,
+    wallet_client: &'a mut WalletClient<InterceptedService<Channel, ClientAuthenticationInterceptor>>,
 }
 
 impl<'a> BlockTemplateProtocol<'a> {
     pub fn new(
-        base_node_client: &'a mut BaseNodeGrpcClient<tonic::transport::Channel>,
-        wallet_client: &'a mut WalletGrpcClient<tonic::transport::Channel>,
+        base_node_client: &'a mut BaseNodeClient<InterceptedService<Channel, ClientAuthenticationInterceptor>>,
+        wallet_client: &'a mut WalletClient<InterceptedService<Channel, ClientAuthenticationInterceptor>>,
         config: Arc<MergeMiningProxyConfig>,
     ) -> Self {
         Self {

--- a/applications/minotari_merge_mining_proxy/src/config.rs
+++ b/applications/minotari_merge_mining_proxy/src/config.rs
@@ -43,6 +43,8 @@ pub struct MergeMiningProxyConfig {
     pub monerod_use_auth: bool,
     /// The Minotari base node's GRPC address
     pub base_node_grpc_address: Option<Multiaddr>,
+    /// GRPC authentication for base node
+    pub base_node_grpc_authentication: GrpcAuthentication,
     /// The Minotari wallet's GRPC address
     pub console_wallet_grpc_address: Option<Multiaddr>,
     /// GRPC authentication for console wallet
@@ -80,6 +82,7 @@ impl Default for MergeMiningProxyConfig {
             monerod_password: String::new(),
             monerod_use_auth: false,
             base_node_grpc_address: None,
+            base_node_grpc_authentication: GrpcAuthentication::default(),
             console_wallet_grpc_address: None,
             console_wallet_grpc_authentication: GrpcAuthentication::default(),
             listener_address: "/ip4/127.0.0.1/tcp/18081".parse().unwrap(),

--- a/applications/minotari_merge_mining_proxy/src/proxy.rs
+++ b/applications/minotari_merge_mining_proxy/src/proxy.rs
@@ -39,8 +39,8 @@ use bytes::Bytes;
 use hyper::{header::HeaderValue, service::Service, Body, Method, Request, Response, StatusCode, Uri};
 use json::json;
 use jsonrpc::error::StandardError;
-use minotari_node_grpc_client::{grpc, BaseNodeGrpcClient};
-use minotari_wallet_grpc_client::WalletGrpcClient;
+use minotari_node_grpc_client::{grpc, grpc::base_node_client::BaseNodeClient};
+use minotari_wallet_grpc_client::{grpc::wallet_client::WalletClient, ClientAuthenticationInterceptor};
 use reqwest::{ResponseBuilderExt, Url};
 use serde_json as json;
 use tari_core::proof_of_work::{
@@ -50,6 +50,7 @@ use tari_core::proof_of_work::{
     randomx_factory::RandomXFactory,
 };
 use tari_utilities::hex::Hex;
+use tonic::{codegen::InterceptedService, transport::Channel};
 use tracing::{debug, error, info, instrument, trace, warn};
 
 use crate::{
@@ -75,8 +76,8 @@ impl MergeMiningProxyService {
     pub fn new(
         config: MergeMiningProxyConfig,
         http_client: reqwest::Client,
-        base_node_client: BaseNodeGrpcClient<tonic::transport::Channel>,
-        wallet_client: WalletGrpcClient<tonic::transport::Channel>,
+        base_node_client: BaseNodeClient<InterceptedService<Channel, ClientAuthenticationInterceptor>>,
+        wallet_client: WalletClient<InterceptedService<Channel, ClientAuthenticationInterceptor>>,
         block_templates: BlockTemplateRepository,
         randomx_factory: RandomXFactory,
     ) -> Self {
@@ -157,8 +158,8 @@ struct InnerService {
     config: Arc<MergeMiningProxyConfig>,
     block_templates: BlockTemplateRepository,
     http_client: reqwest::Client,
-    base_node_client: BaseNodeGrpcClient<tonic::transport::Channel>,
-    wallet_client: WalletGrpcClient<tonic::transport::Channel>,
+    base_node_client: BaseNodeClient<InterceptedService<Channel, ClientAuthenticationInterceptor>>,
+    wallet_client: WalletClient<InterceptedService<Channel, ClientAuthenticationInterceptor>>,
     initial_sync_achieved: Arc<AtomicBool>,
     current_monerod_server: Arc<RwLock<Option<String>>>,
     last_assigned_monerod_server: Arc<RwLock<Option<String>>>,

--- a/applications/minotari_miner/src/config.rs
+++ b/applications/minotari_miner/src/config.rs
@@ -49,6 +49,8 @@ use tari_comms::multiaddr::Multiaddr;
 pub struct MinerConfig {
     /// GRPC address of base node
     pub base_node_grpc_address: Option<Multiaddr>,
+    /// GRPC authentication for base node
+    pub base_node_grpc_authentication: GrpcAuthentication,
     /// GRPC address of console wallet
     pub wallet_grpc_address: Option<Multiaddr>,
     /// GRPC authentication for console wallet
@@ -97,6 +99,7 @@ impl Default for MinerConfig {
     fn default() -> Self {
         Self {
             base_node_grpc_address: None,
+            base_node_grpc_authentication: GrpcAuthentication::default(),
             wallet_grpc_address: None,
             wallet_grpc_authentication: GrpcAuthentication::default(),
             num_mining_threads: num_cpus::get(),

--- a/applications/minotari_node/src/cli.rs
+++ b/applications/minotari_node/src/cli.rs
@@ -45,6 +45,8 @@ pub struct Cli {
     pub watch: Option<String>,
     #[clap(long, alias = "profile")]
     pub profile_with_tokio_console: bool,
+    #[clap(long, env = "MINOTARI_NODE_ENABLE_GRPC", alias = "enable-grpc")]
+    pub grpc_enabled: bool,
 }
 
 impl ConfigOverrideProvider for Cli {

--- a/applications/minotari_node/src/commands/command/hash_grpc_password.rs
+++ b/applications/minotari_node/src/commands/command/hash_grpc_password.rs
@@ -1,0 +1,69 @@
+//  Copyright 2023, The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use anyhow::{anyhow, Error};
+use async_trait::async_trait;
+use clap::Parser;
+use minotari_app_grpc::authentication::salted_password::create_salted_hashed_password;
+
+use super::{CommandContext, HandleCommand};
+
+/// Hashes the GRPC authentication password from the config and returns an argon2 hash
+#[derive(Debug, Parser)]
+pub struct Args {}
+
+#[async_trait]
+impl HandleCommand<Args> for CommandContext {
+    async fn handle_command(&mut self, _: Args) -> Result<(), Error> {
+        self.hash_grpc_password().await
+    }
+}
+
+impl CommandContext {
+    pub async fn hash_grpc_password(&mut self) -> Result<(), Error> {
+        match self
+            .config
+            .base_node
+            .grpc_authentication
+            .username_password()
+            .ok_or_else(|| anyhow!("GRPC basic auth is not configured"))
+        {
+            Ok((username, password)) => {
+                match create_salted_hashed_password(password.reveal()).map_err(|e| anyhow!(e.to_string())) {
+                    Ok(hashed_password) => {
+                        println!("Your hashed password is:");
+                        println!("{}", *hashed_password);
+                        println!();
+                        println!(
+                            "Use HTTP basic auth with username '{}' and the hashed password to make GRPC requests",
+                            username
+                        );
+                    },
+                    Err(e) => eprintln!("HashGrpcPassword error! {}", e),
+                }
+            },
+            Err(e) => eprintln!("HashGrpcPassword error! {}", e),
+        }
+
+        Ok(())
+    }
+}

--- a/applications/minotari_node/src/commands/command/mod.rs
+++ b/applications/minotari_node/src/commands/command/mod.rs
@@ -35,6 +35,7 @@ mod get_mempool_stats;
 mod get_network_stats;
 mod get_peer;
 mod get_state_info;
+mod hash_grpc_password;
 mod header_stats;
 mod list_banned_peers;
 mod list_connections;
@@ -136,6 +137,7 @@ pub enum Command {
     Quit(quit::Args),
     Exit(quit::Args),
     Watch(watch_command::Args),
+    HashGrpcPassword(hash_grpc_password::Args),
 }
 
 impl Command {
@@ -228,6 +230,7 @@ impl CommandContext {
                 Command::Status(_) |
                 Command::Watch(_) |
                 Command::ListValidatorNodes(_) |
+                Command::HashGrpcPassword(_) |
                 Command::Quit(_) |
                 Command::Exit(_) => 30,
                 // These commands involve intense blockchain db operations and needs a lot of time to complete
@@ -293,6 +296,7 @@ impl HandleCommand<Command> for CommandContext {
             Command::Quit(args) | Command::Exit(args) => self.handle_command(args).await,
             Command::Watch(args) => self.handle_command(args).await,
             Command::ListValidatorNodes(args) => self.handle_command(args).await,
+            Command::HashGrpcPassword(args) => self.handle_command(args).await,
         }
     }
 }

--- a/applications/minotari_node/src/config.rs
+++ b/applications/minotari_node/src/config.rs
@@ -34,6 +34,7 @@ use tari_common::{
     DefaultConfigLoader,
     SubConfigPath,
 };
+use tari_common_types::grpc_authentication::GrpcAuthentication;
 use tari_comms::multiaddr::Multiaddr;
 use tari_core::{
     base_node::BaseNodeStateMachineConfig,
@@ -89,6 +90,8 @@ pub struct BaseNodeConfig {
     pub grpc_address: Option<Multiaddr>,
     /// GRPC server config - which methods are active and which not
     pub grpc_server_deny_methods: Vec<GrpcMethod>,
+    /// GRPC authentication mode
+    pub grpc_authentication: GrpcAuthentication,
     /// A path to the file that stores the base node identity and secret key
     pub identity_file: PathBuf,
     /// Spin up and use a built-in Tor instance. This only works on macos/linux - requires that the wallet was built
@@ -155,6 +158,7 @@ impl Default for BaseNodeConfig {
                 GrpcMethod::Identify,
                 GrpcMethod::GetNetworkStatus,
             ],
+            grpc_authentication: GrpcAuthentication::default(),
             identity_file: PathBuf::from("config/base_node_id.json"),
             use_libtor: false,
             tor_identity_file: PathBuf::from("config/base_node_tor_id.json"),

--- a/applications/minotari_node/src/lib.rs
+++ b/applications/minotari_node/src/lib.rs
@@ -42,11 +42,13 @@ use std::{process, sync::Arc};
 use commands::{cli_loop::CliLoop, command::CommandContext};
 use futures::FutureExt;
 use log::*;
+use minotari_app_grpc::authentication::ServerAuthenticationInterceptor;
 use minotari_app_utilities::{common_cli_args::CommonCliArgs, network_check::is_network_choice_valid};
 use tari_common::{
     configuration::bootstrap::{grpc_default_port, ApplicationType},
     exit_codes::{ExitCode, ExitError},
 };
+use tari_common_types::grpc_authentication::GrpcAuthentication;
 use tari_comms::{multiaddr::Multiaddr, utils::multiaddr::multiaddr_to_socketaddr, NodeIdentity};
 use tari_shutdown::{Shutdown, ShutdownSignal};
 use tokio::task;
@@ -85,6 +87,7 @@ pub async fn run_base_node(
         non_interactive_mode: true,
         watch: None,
         profile_with_tokio_console: false,
+        grpc_enabled: false,
     };
 
     run_base_node_with_cli(node_identity, config, cli, shutdown).await
@@ -137,7 +140,8 @@ pub async fn run_base_node_with_cli(
             &ctx,
             config.base_node.grpc_server_deny_methods.clone(),
         );
-        task::spawn(run_grpc(grpc, grpc_address, shutdown.to_signal()));
+        let auth = config.base_node.grpc_authentication.clone();
+        task::spawn(run_grpc(grpc, grpc_address, auth, shutdown.to_signal()));
     }
 
     // Run, node, run!
@@ -171,13 +175,17 @@ pub async fn run_base_node_with_cli(
 async fn run_grpc(
     grpc: grpc::base_node_grpc_server::BaseNodeGrpcServer,
     grpc_address: Multiaddr,
+    auth_config: GrpcAuthentication,
     interrupt_signal: ShutdownSignal,
 ) -> Result<(), anyhow::Error> {
     info!(target: LOG_TARGET, "Starting GRPC on {}", grpc_address);
 
     let grpc_address = multiaddr_to_socketaddr(&grpc_address)?;
+    let auth = ServerAuthenticationInterceptor::new(auth_config);
+    let service = minotari_app_grpc::tari_rpc::base_node_server::BaseNodeServer::with_interceptor(grpc, auth);
+
     Server::builder()
-        .add_service(minotari_app_grpc::tari_rpc::base_node_server::BaseNodeServer::new(grpc))
+        .add_service(service)
         .serve_with_shutdown(grpc_address, interrupt_signal.map(|_| ()))
         .await
         .map_err(|err| {

--- a/common/config/presets/c_base_node.toml
+++ b/common/config/presets/c_base_node.toml
@@ -33,6 +33,9 @@ identity_file = "config/base_node_id_nextnet.json"
 # Set to false to disable the base node GRPC server (default = true)
 #grpc_enabled = true
 
+# gRPC authentication method (default = "none")
+#grpc_authentication = { username = "admin", password = "xxxx" }
+
 # Uncomment all gRPC server methods that should be denied default (only active when `grpc_enabled = true`)
 grpc_server_deny_methods = [
     "get_version",

--- a/common/config/presets/f_merge_mining_proxy.toml
+++ b/common/config/presets/f_merge_mining_proxy.toml
@@ -40,13 +40,13 @@ monerod_url = [# stagenet
 #base_node_grpc_address = "/ip4/127.0.0.1/tcp/18142"
 
 # GRPC authentication for the base node (default = "none")
-#base_node_grpc_authentication = { username: "miner", password: "$argon..." }
+#base_node_grpc_authentication = { username = "miner", password = "$argon..." }
 
 # The Minotari wallet's GRPC address. (default = "/ip4/127.0.0.1/tcp/18143")
 #console_wallet_grpc_address = "/ip4/127.0.0.1/tcp/18143"
 
 # GRPC authentication for the Minotari wallet (default = "none")
-#wallet_grpc_authentication = { username: "miner", password: "$argon..." }
+#wallet_grpc_authentication = { username = "miner", password = "$argon..." }
 
 # Address of the minotari_merge_mining_proxy application. (default = "/ip4/127.0.0.1/tcp/18081")
 #listener_address = "/ip4/127.0.0.1/tcp/18081"

--- a/common/config/presets/f_merge_mining_proxy.toml
+++ b/common/config/presets/f_merge_mining_proxy.toml
@@ -39,6 +39,9 @@ monerod_url = [# stagenet
 # The Minotari base node's GRPC address. (default = "/ip4/127.0.0.1/tcp/18142")
 #base_node_grpc_address = "/ip4/127.0.0.1/tcp/18142"
 
+# GRPC authentication for the base node (default = "none")
+#base_node_grpc_authentication = { username: "miner", password: "$argon..." }
+
 # The Minotari wallet's GRPC address. (default = "/ip4/127.0.0.1/tcp/18143")
 #console_wallet_grpc_address = "/ip4/127.0.0.1/tcp/18143"
 

--- a/common/config/presets/g_miner.toml
+++ b/common/config/presets/g_miner.toml
@@ -10,12 +10,12 @@
 # GRPC address of base node (default = "/ip4/127.0.0.1/tcp/18142")
 #base_node_grpc_address = "/ip4/127.0.0.1/tcp/18142"
 # GRPC authentication for the base node (default = "none")
-#base_node_grpc_authentication = { username: "miner", password: "$argon..." }
+#base_node_grpc_authentication = { username = "miner", password = "$argon..." }
 
 # GRPC address of console wallet (default = "/ip4/127.0.0.1/tcp/18143")
 #wallet_grpc_address = "/ip4/127.0.0.1/tcp/18143"
 # GRPC authentication for the console wallet (default = "none")
-#wallet_grpc_authentication = { username: "miner", password: "$argon..." }
+#wallet_grpc_authentication = { username = "miner", password = "$argon..." }
 
 # Number of mining threads (default: number of logical CPU cores)
 #num_mining_threads = 8

--- a/common/config/presets/g_miner.toml
+++ b/common/config/presets/g_miner.toml
@@ -9,6 +9,8 @@
 
 # GRPC address of base node (default = "/ip4/127.0.0.1/tcp/18142")
 #base_node_grpc_address = "/ip4/127.0.0.1/tcp/18142"
+# GRPC authentication for the base node (default = "none")
+#base_node_grpc_authentication = { username: "miner", password: "$argon..." }
 
 # GRPC address of console wallet (default = "/ip4/127.0.0.1/tcp/18143")
 #wallet_grpc_address = "/ip4/127.0.0.1/tcp/18143"


### PR DESCRIPTION
Description
---
Adds basic auth to the minotari node.
Adds support on the Miner, and MergeMiner Proxy for node basic auth credentials.

Motivation and Context
---
Make things just that much more secure.

How Has This Been Tested?
---
Locally running a node, wallet, and miner. (MergeMiner untested).

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify