### PR TITLE
feat: remove panics from applications

### DIFF
--- a/applications/minotari_console_wallet/src/main.rs
+++ b/applications/minotari_console_wallet/src/main.rs
@@ -20,7 +20,7 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{panic, process};
+use std::process;
 
 use clap::Parser;
 use log::*;
@@ -47,14 +47,6 @@ mod utils;
 mod wallet_modes;
 
 fn main() {
-    // Setup a panic hook which prints the default rust panic message but also exits the process. This makes a panic in
-    // any thread "crash" the system instead of silently continuing.
-    let default_hook = panic::take_hook();
-    panic::set_hook(Box::new(move |info| {
-        default_hook(info);
-        process::exit(1);
-    }));
-
     match main_inner() {
         Ok(_) => process::exit(0),
         Err(err) => {

--- a/applications/minotari_node/src/main.rs
+++ b/applications/minotari_node/src/main.rs
@@ -69,7 +69,7 @@
 /// `whoami` - Displays identity information about this Base Node and it's wallet
 /// `quit` - Exits the Base Node
 /// `exit` - Same as quit
-use std::{panic, process, sync::Arc};
+use std::{process, sync::Arc};
 
 use clap::Parser;
 use log::*;
@@ -85,14 +85,6 @@ const LOG_TARGET: &str = "minotari::base_node::app";
 
 /// Application entry point
 fn main() {
-    // Setup a panic hook which prints the default rust panic message but also exits the process. This makes a panic in
-    // any thread "crash" the system instead of silently continuing.
-    let default_hook = panic::take_hook();
-    panic::set_hook(Box::new(move |info| {
-        default_hook(info);
-        process::exit(1);
-    }));
-
     if let Err(err) = main_inner() {
         eprintln!("{:?}", err);
         let exit_code = err.exit_code;


### PR DESCRIPTION
Description
---
Applications currently panic on any thread panic. Remove this so that applications will not panic. 

Motivation and Context
---
See: #5940 

This is somewhat debatable if this is desired or not behaviour. But currently, the favoured approach is to only panic the thread. 

Fixes: #5940 