### PR TITLE
feat: compile out the metrics

### DIFF
--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -16,6 +16,7 @@ mempool_proto = []
 base_node = ["tari_mmr", "transactions", "mempool_proto", "base_node_proto", "monero", "randomx-rs"]
 base_node_proto = []
 benches = ["base_node"]
+metrics = ["tari_metrics"]
 
 [dependencies]
 tari_common = {  path = "../../common" }
@@ -24,7 +25,7 @@ tari_comms = {  path = "../../comms/core" }
 tari_comms_dht = {  path = "../../comms/dht" }
 tari_comms_rpc_macros = {  path = "../../comms/rpc_macros" }
 tari_crypto = { version = "0.19", features = ["borsh"] }
-tari_metrics = { path = "../../infrastructure/metrics" }
+tari_metrics = { path = "../../infrastructure/metrics", optional = true }
 tari_mmr = {  path = "../../base_layer/mmr", optional = true, features = ["native_bitmap"] }
 tari_p2p = {  path = "../../base_layer/p2p" }
 tari_script = { path = "../../infrastructure/tari_script" }

--- a/base_layer/core/src/base_node/mod.rs
+++ b/base_layer/core/src/base_node/mod.rs
@@ -39,7 +39,7 @@ pub mod chain_metadata_service;
 pub mod comms_interface;
 #[cfg(feature = "base_node")]
 pub use comms_interface::LocalNodeCommsInterface;
-#[cfg(feature = "base_node")]
+#[cfg(feature = "metrics")]
 mod metrics;
 
 #[cfg(feature = "base_node")]

--- a/base_layer/core/src/base_node/state_machine_service/states/block_sync.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/block_sync.rs
@@ -24,10 +24,11 @@ use std::time::Instant;
 
 use log::*;
 
+#[cfg(feature = "metrics")]
+use crate::base_node::metrics;
 use crate::{
     base_node::{
         comms_interface::BlockEvent,
-        metrics,
         state_machine_service::states::{BlockSyncInfo, HorizonStateSync, StateEvent, StateInfo, StatusInfo},
         sync::{BlockSynchronizer, SyncPeer},
         BaseNodeStateMachine,
@@ -63,6 +64,7 @@ impl BlockSync {
         let local_nci = shared.local_node_interface.clone();
         let randomx_vm_cnt = shared.get_randomx_vm_cnt();
         let randomx_vm_flags = shared.get_randomx_vm_flags();
+        #[cfg(feature = "metrics")]
         let tip_height_metric = metrics::tip_height();
         synchronizer.on_starting(move |sync_peer| {
             let _result = status_event_sender.send(StatusInfo {
@@ -81,6 +83,7 @@ impl BlockSync {
                 BlockAddResult::Ok(block),
             ));
 
+            #[cfg(feature = "metrics")]
             tip_height_metric.set(local_height as i64);
             let _result = status_event_sender.send(StatusInfo {
                 bootstrapped,

--- a/base_layer/core/src/base_node/state_machine_service/states/header_sync.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/header_sync.rs
@@ -26,10 +26,11 @@ use log::*;
 use tari_common_types::chain_metadata::ChainMetadata;
 use tari_comms::peer_manager::NodeId;
 
+#[cfg(feature = "metrics")]
+use crate::base_node::metrics;
 use crate::{
     base_node::{
         comms_interface::BlockEvent,
-        metrics,
         state_machine_service::states::{BlockSyncInfo, StateEvent, StateInfo, StatusInfo},
         sync::{BlockHeaderSyncError, HeaderSynchronizer, SyncPeer},
         BaseNodeStateMachine,
@@ -146,6 +147,7 @@ impl HeaderSyncState {
 
         let local_nci = shared.local_node_interface.clone();
         synchronizer.on_rewind(move |removed| {
+            #[cfg(feature = "metrics")]
             if let Some(fork_height) = removed.last().map(|b| b.height().saturating_sub(1)) {
                 metrics::tip_height().set(fork_height as i64);
                 metrics::reorg(fork_height, 0, removed.len()).inc();

--- a/base_layer/core/src/base_node/sync/rpc/service.rs
+++ b/base_layer/core/src/base_node/sync/rpc/service.rs
@@ -40,10 +40,11 @@ use tokio::{
 };
 use tracing::{instrument, span, Instrument, Level};
 
+#[cfg(feature = "metrics")]
+use crate::base_node::metrics;
 use crate::{
     base_node::{
         comms_interface::{BlockEvent, BlockEvent::BlockSyncRewind},
-        metrics,
         sync::{
             header_sync::HEADER_SYNC_INITIAL_MAX_HEADERS,
             rpc::{sync_utxos_task::SyncUtxosTask, BaseNodeSyncService},
@@ -99,6 +100,7 @@ impl<B: BlockchainBackend + 'static> BaseNodeSyncRpcService<B> {
 
         let token = Arc::new(peer);
         lock.push(Arc::downgrade(&token));
+        #[cfg(feature = "metrics")]
         metrics::active_sync_peers().set(lock.len() as i64);
         Ok(token)
     }
@@ -256,6 +258,7 @@ impl<B: BlockchainBackend + 'static> BaseNodeSyncService for BaseNodeSyncRpcServ
                     }
                 }
 
+                #[cfg(feature = "metrics")]
                 metrics::active_sync_peers().dec();
                 debug!(
                     target: LOG_TARGET,
@@ -355,6 +358,7 @@ impl<B: BlockchainBackend + 'static> BaseNodeSyncService for BaseNodeSyncRpcServ
                     }
                 }
 
+                #[cfg(feature = "metrics")]
                 metrics::active_sync_peers().dec();
                 debug!(
                     target: LOG_TARGET,
@@ -572,6 +576,7 @@ impl<B: BlockchainBackend + 'static> BaseNodeSyncService for BaseNodeSyncRpcServ
                 }
             }
 
+            #[cfg(feature = "metrics")]
             metrics::active_sync_peers().dec();
             debug!(
                 target: LOG_TARGET,

--- a/base_layer/core/src/base_node/sync/rpc/sync_utxos_task.rs
+++ b/base_layer/core/src/base_node/sync/rpc/sync_utxos_task.rs
@@ -31,8 +31,9 @@ use tari_comms::{
 use tari_utilities::hex::Hex;
 use tokio::{sync::mpsc, task};
 
+#[cfg(feature = "metrics")]
+use crate::base_node::metrics;
 use crate::{
-    base_node::metrics,
     blocks::BlockHeader,
     chain_storage::{async_db::AsyncBlockchainDb, BlockchainBackend},
     proto::base_node::{SyncUtxosRequest, SyncUtxosResponse},
@@ -106,6 +107,7 @@ where B: BlockchainBackend + 'static
                 target: LOG_TARGET,
                 "UTXO stream completed for peer '{}'", self.peer_node_id
             );
+            #[cfg(feature = "metrics")]
             metrics::active_sync_peers().dec();
         });
 

--- a/base_layer/core/src/mempool/mod.rs
+++ b/base_layer/core/src/mempool/mod.rs
@@ -42,7 +42,7 @@ mod rpc;
 pub use rpc::create_mempool_rpc_service;
 #[cfg(feature = "base_node")]
 pub use rpc::{MempoolRpcClient, MempoolRpcServer, MempoolRpcService, MempoolService};
-#[cfg(feature = "base_node")]
+#[cfg(feature = "metrics")]
 mod metrics;
 #[cfg(feature = "base_node")]
 mod shrink_hashmap;

--- a/base_layer/core/src/mempool/service/inbound_handlers.rs
+++ b/base_layer/core/src/mempool/service/inbound_handlers.rs
@@ -26,11 +26,12 @@ use log::*;
 use tari_comms::peer_manager::NodeId;
 use tari_utilities::hex::Hex;
 
+#[cfg(feature = "metrics")]
+use crate::mempool::metrics;
 use crate::{
     base_node::comms_interface::{BlockEvent, BlockEvent::AddBlockErrored},
     chain_storage::BlockAddResult,
     mempool::{
-        metrics,
         service::{MempoolRequest, MempoolResponse, MempoolServiceError, OutboundMempoolServiceInterface},
         Mempool,
         TxStorageResponse,
@@ -135,6 +136,7 @@ impl MempoolInboundHandlers {
         }
         match self.mempool.insert(tx.clone()).await {
             Ok(tx_storage) => {
+                #[cfg(feature = "metrics")]
                 if tx_storage.is_stored() {
                     metrics::inbound_transactions(source_peer.as_ref()).inc();
                 } else {
@@ -164,6 +166,7 @@ impl MempoolInboundHandlers {
 
     #[allow(clippy::cast_possible_wrap)]
     async fn update_pool_size_metrics(&self) {
+        #[cfg(feature = "metrics")]
         if let Ok(stats) = self.mempool.stats().await {
             metrics::unconfirmed_pool_size().set(stats.unconfirmed_txs as i64);
             metrics::reorg_pool_size().set(stats.reorg_txs as i64);

--- a/base_layer/core/src/mempool/sync_protocol/mod.rs
+++ b/base_layer/core/src/mempool/sync_protocol/mod.rs
@@ -96,10 +96,12 @@ use tokio::{
     time,
 };
 
+#[cfg(feature = "metrics")]
+use crate::mempool::metrics;
 use crate::{
     base_node::comms_interface::{BlockEvent, BlockEventReceiver},
     chain_storage::BlockAddResult,
-    mempool::{metrics, proto, Mempool, MempoolServiceConfig},
+    mempool::{proto, Mempool, MempoolServiceConfig},
     proto as shared_proto,
     transactions::transaction_components::Transaction,
 };
@@ -544,6 +546,7 @@ where TSubstream: AsyncRead + AsyncWrite + Unpin
 
         #[allow(clippy::cast_possible_truncation)]
         #[allow(clippy::cast_possible_wrap)]
+        #[cfg(feature = "metrics")]
         {
             let stats = self.mempool.stats().await?;
             metrics::unconfirmed_pool_size().set(stats.unconfirmed_txs as i64);
@@ -580,6 +583,7 @@ where TSubstream: AsyncRead + AsyncWrite + Unpin
 
         let stored_result = self.mempool.insert(txn).await?;
         if stored_result.is_stored() {
+            #[cfg(feature = "metrics")]
             metrics::inbound_transactions(Some(&self.peer_node_id)).inc();
             debug!(
                 target: LOG_TARGET,
@@ -588,6 +592,7 @@ where TSubstream: AsyncRead + AsyncWrite + Unpin
                 self.peer_node_id.short_str()
             );
         } else {
+            #[cfg(feature = "metrics")]
             metrics::rejected_inbound_transactions(Some(&self.peer_node_id)).inc();
             debug!(
                 target: LOG_TARGET,

--- a/comms/core/Cargo.toml
+++ b/comms/core/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 tari_crypto = { version = "0.19" }
-tari_metrics = { path = "../../infrastructure/metrics" }
+tari_metrics = { path = "../../infrastructure/metrics", optional = true }
 tari_storage = {  path = "../../infrastructure/storage" }
 tari_shutdown = {  path = "../../infrastructure/shutdown" }
 tari_utilities = { version = "0.6" }
@@ -63,5 +63,5 @@ tari_common = {  path = "../../common", features = ["build"] }
 
 [features]
 c_integration = []
-metrics = []
+metrics = ["tari_metrics"]
 rpc = ["tower/make", "tower/util"]

--- a/comms/core/src/connection_manager/listener.rs
+++ b/comms/core/src/connection_manager/listener.rs
@@ -50,11 +50,12 @@ use super::{
     ConnectionManagerConfig,
     ConnectionManagerEvent,
 };
+#[cfg(feature = "metrics")]
+use crate::connection_manager::metrics;
 use crate::{
     bounded_executor::BoundedExecutor,
     connection_manager::{
         liveness::LivenessSession,
-        metrics,
         wire_mode::{WireMode, LIVENESS_WIRE_MODE},
     },
     multiaddr::Multiaddr,
@@ -240,6 +241,7 @@ where
 
         let span = span!(Level::TRACE, "connection_mann::listener::inbound_task",);
         let inbound_fut = async move {
+            #[cfg(feature = "metrics")]
             metrics::pending_connections(None, ConnectionDirection::Inbound).inc();
             match Self::read_wire_format(&mut socket, config.time_to_first_byte).await {
                 Ok(WireMode::Comms(byte)) if byte == config.network_info.network_byte => {
@@ -325,6 +327,7 @@ where
                 },
             }
 
+            #[cfg(feature = "metrics")]
             metrics::pending_connections(None, ConnectionDirection::Inbound).dec();
         }
         .instrument(span);

--- a/comms/core/src/connection_manager/mod.rs
+++ b/comms/core/src/connection_manager/mod.rs
@@ -30,6 +30,7 @@
 mod dial_state;
 mod dialer;
 mod listener;
+#[cfg(feature = "metrics")]
 mod metrics;
 
 mod common;

--- a/comms/core/src/protocol/messaging/mod.rs
+++ b/comms/core/src/protocol/messaging/mod.rs
@@ -34,6 +34,7 @@ pub use extension::MessagingProtocolExtension;
 mod error;
 mod forward;
 mod inbound;
+#[cfg(feature = "metrics")]
 mod metrics;
 mod outbound;
 mod protocol;

--- a/comms/core/src/protocol/rpc/message.rs
+++ b/comms/core/src/protocol/rpc/message.rs
@@ -128,6 +128,7 @@ impl<T> BaseRequest<T> {
         self.message
     }
 
+    #[allow(dead_code)]
     pub fn get_ref(&self) -> &T {
         &self.message
     }

--- a/comms/core/src/protocol/rpc/server/metrics.rs
+++ b/comms/core/src/protocol/rpc/server/metrics.rs
@@ -21,6 +21,7 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use once_cell::sync::Lazy;
+#[cfg(feature = "metrics")]
 use tari_metrics::{Histogram, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec};
 
 use crate::{


### PR DESCRIPTION
Description
---

## Do not merge until testing is complete

We made metric features in the applications a compiler option but core was still including it all by default.

I had wanted to do something more elegant like swap in a mock for the metrics system which would have hopefully required less sprinkles of changes, but the metrics are currently being used to return types from the metrics system and operate on them. This is still possible to phase out but would take more time due to the need to refactor all the existing metrics modules.

Motivation and Context
---
Metrics should be opt-in, and not on by default.

How Has This Been Tested?
---
Mobile team is testing it now.

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
