### PR TITLE
ci(fix): enable libtor for osx builds

### DIFF
--- a/.github/workflows/base_node_binaries.json
+++ b/.github/workflows/base_node_binaries.json
@@ -28,7 +28,7 @@
     "cross": false,
     "target_cpu": "x86-64",
     "target_bins": "--bin minotari_node --bin minotari_console_wallet --bin minotari_merge_mining_proxy --bin minotari_miner",
-    "features": "safe"
+    "features": "libtor, safe"
   },
   {
     "name": "macos-arm64",
@@ -38,7 +38,7 @@
     "cross": false,
     "target_cpu": "generic",
     "target_bins": "--bin minotari_node --bin minotari_console_wallet --bin minotari_merge_mining_proxy --bin minotari_miner",
-    "features": "safe",
+    "features": "libtor, safe",
     "build_enabled": false
   },
   {

--- a/.github/workflows/base_node_binaries.yml
+++ b/.github/workflows/base_node_binaries.yml
@@ -204,14 +204,14 @@ jobs:
           if [ "${{ matrix.builds.cross }}" != "true" ]; then
             cargo build --release \
               --target ${{ matrix.builds.target }} \
-              --features ${{ matrix.builds.features }} \
+              --features "${{ matrix.builds.features }}" \
               ${{ matrix.builds.target_bins }} \
               ${{ matrix.builds.flags }} --locked
           else
             cargo install cross
             cross build --release \
               --target ${{ matrix.builds.target }} \
-              --features ${{ matrix.builds.features }} \
+              --features "${{ matrix.builds.features }}" \
               ${{ matrix.builds.target_bins }} \
               ${{ matrix.builds.flags }} --locked
           fi


### PR DESCRIPTION
Description
Enable libtor for OSX builds in CI

Motivation and Context
Add libtor as internal dependancy, so that we don't require tor setup as a proxy.

How Has This Been Tested?
Testing locally build OSX base node.

What process can a PR reviewer use to test or verify this change?
Download OSX binary and run with libtor enabled.

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
