### PR TITLE
feat!: move kernel MMR position to `u64`

### DIFF
--- a/base_layer/core/src/base_node/sync/horizon_state_sync/synchronizer.rs
+++ b/base_layer/core/src/base_node/sync/horizon_state_sync/synchronizer.rs
@@ -373,11 +373,7 @@ impl<'a, B: BlockchainBackend + 'static> HorizonStateSynchronization<'a, B> {
                 ));
             }
 
-            let mmr_position_u32 = u32::try_from(mmr_position).map_err(|_| HorizonSyncError::InvalidMmrPosition {
-                at_height: current_header.height(),
-                mmr_position,
-            })?;
-            txn.insert_kernel_via_horizon_sync(kernel, *current_header.hash(), mmr_position_u32);
+            txn.insert_kernel_via_horizon_sync(kernel, *current_header.hash(), mmr_position);
             if mmr_position == current_header.header().kernel_mmr_size - 1 {
                 let num_kernels = kernel_hashes.len();
                 debug!(

--- a/base_layer/core/src/chain_storage/async_db.rs
+++ b/base_layer/core/src/chain_storage/async_db.rs
@@ -330,7 +330,7 @@ impl<'a, B: BlockchainBackend + 'static> AsyncDbTransaction<'a, B> {
         &mut self,
         kernel: TransactionKernel,
         header_hash: HashOutput,
-        mmr_position: u32,
+        mmr_position: u64,
     ) -> &mut Self {
         self.transaction.insert_kernel(kernel, header_hash, mmr_position);
         self

--- a/base_layer/core/src/chain_storage/db_transaction.rs
+++ b/base_layer/core/src/chain_storage/db_transaction.rs
@@ -91,7 +91,7 @@ impl DbTransaction {
         &mut self,
         kernel: TransactionKernel,
         header_hash: HashOutput,
-        mmr_position: u32,
+        mmr_position: u64,
     ) -> &mut Self {
         self.operations.push(WriteOperation::InsertKernel {
             header_hash,
@@ -279,7 +279,7 @@ pub enum WriteOperation {
     InsertKernel {
         header_hash: HashOutput,
         kernel: Box<TransactionKernel>,
-        mmr_position: u32,
+        mmr_position: u64,
     },
     InsertOutput {
         header_hash: HashOutput,

--- a/base_layer/core/src/chain_storage/lmdb_db/mod.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/mod.rs
@@ -70,7 +70,7 @@ pub(crate) struct TransactionInputRowData {
 pub(crate) struct TransactionKernelRowData {
     pub kernel: TransactionKernel,
     pub header_hash: HashOutput,
-    pub mmr_position: u32,
+    pub mmr_position: u64,
     pub hash: HashOutput,
 }
 


### PR DESCRIPTION
Description
---
Switches the handling of kernel MMR positions from `u32` to `u64`.

Closes #5924.

Motivation and Context
---
Internally, MMR positions are handled as either `usize` or `u64`. However, they are eventually parsed and handled as `u32` for storage. While it doesn't address the internal `usize` handling, it switches storage operations to be `u64`.

How Has This Been Tested?
---
Existing tests pass.

What process can a PR reviewer use to test or verify this change?
---
Assert that the logic, especially around LMDB operations, is correct.

BREAKING CHANGE: Modifies the handling of kernel MMR data in LMDB.