### PR TITLE
chore: move domain hash names to separate crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3163,6 +3163,7 @@ dependencies = [
  "tari_core",
  "tari_crypto",
  "tari_features",
+ "tari_hash_domains",
  "tari_key_manager",
  "tari_libtor",
  "tari_p2p",
@@ -5834,6 +5835,7 @@ dependencies = [
  "tari_comms_dht",
  "tari_comms_rpc_macros",
  "tari_crypto",
+ "tari_hash_domains",
  "tari_key_manager",
  "tari_metrics",
  "tari_mmr",
@@ -5876,6 +5878,14 @@ dependencies = [
 [[package]]
 name = "tari_features"
 version = "0.53.0-dan.0"
+
+[[package]]
+name = "tari_hash_domains"
+version = "0.1.0"
+source = "git+https://github.com/tari-project/tari_hash_domains.git#e6de826a47b60e102f8b5e02203b15980193b4c0"
+dependencies = [
+ "tari_crypto",
+]
 
 [[package]]
 name = "tari_integration_tests"

--- a/applications/minotari_console_wallet/Cargo.toml
+++ b/applications/minotari_console_wallet/Cargo.toml
@@ -20,7 +20,10 @@ tari_p2p = { path = "../../base_layer/p2p", features = ["auto-update"] }
 tari_script = { path = "../../infrastructure/tari_script" }
 tari_shutdown = { path = "../../infrastructure/shutdown" }
 tari_utilities = { version = "0.6" }
-minotari_wallet = { path = "../../base_layer/wallet", features = ["bundled_sqlite"] }
+minotari_wallet = { path = "../../base_layer/wallet", features = [
+  "bundled_sqlite",
+] }
+tari_hash_domains = { git = "https://github.com/tari-project/tari_hash_domains.git" }
 
 # Uncomment for tokio tracing via tokio-console (needs "tracing" featurs)
 console-subscriber = "0.1.8"
@@ -34,8 +37,20 @@ clap = { version = "3.2", features = ["derive", "env"] }
 config = "0.13.0"
 crossterm = { version = "0.25.0" }
 digest = "0.10"
-futures = { version = "^0.3.16", default-features = false, features = ["alloc"] }
-log4rs = { git = "https://github.com/tari-project/log4rs.git", default_features = false, features = ["config_parsing", "threshold_filter", "yaml_format", "console_appender", "rolling_file_appender", "compound_policy", "size_trigger", "fixed_window_roller", "delete_roller"] }
+futures = { version = "^0.3.16", default-features = false, features = [
+  "alloc",
+] }
+log4rs = { git = "https://github.com/tari-project/log4rs.git", default_features = false, features = [
+  "config_parsing",
+  "threshold_filter",
+  "yaml_format",
+  "console_appender",
+  "rolling_file_appender",
+  "compound_policy",
+  "size_trigger",
+  "fixed_window_roller",
+  "delete_roller",
+] }
 log = { version = "0.4.8", features = ["std"] }
 qrcode = { version = "0.12" }
 rand = "0.8"
@@ -68,7 +83,7 @@ default-features = false
 features = ["crossterm"]
 
 [build-dependencies]
-tari_features = { path = "../../common/tari_features"}
+tari_features = { path = "../../common/tari_features" }
 
 [features]
 libtor = ["tari_libtor"]

--- a/applications/minotari_console_wallet/src/ui/components/register_template_tab.rs
+++ b/applications/minotari_console_wallet/src/ui/components/register_template_tab.rs
@@ -10,7 +10,8 @@ use minotari_wallet::output_manager_service::UtxoSelectionCriteria;
 use regex::Regex;
 use reqwest::StatusCode;
 use tari_core::transactions::{tari_amount::MicroMinotari, transaction_components::TemplateType};
-use tari_crypto::{hash_domain, hashing::DomainSeparation};
+use tari_crypto::hashing::DomainSeparation;
+use tari_hash_domains::TariEngineHashDomain;
 use tari_utilities::hex::Hex;
 use tokio::{
     runtime::{Handle, Runtime},
@@ -537,7 +538,6 @@ impl RegisterTemplateTab {
                                     StatusCode::OK => match data.bytes().await {
                                         Ok(bytes) => {
                                             let mut hasher = Blake2b::<U32>::default();
-                                            hash_domain!(TariEngineHashDomain, "com.tari.dan.engine", 0);
                                             TariEngineHashDomain::add_domain_separation_tag(&mut hasher, "Template");
                                             let hash: [u8; 32] = hasher.chain_update(bytes).finalize().into();
                                             hex_string = hash.to_hex();

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -13,31 +13,41 @@ edition = "2018"
 default = ["base_node"]
 transactions = []
 mempool_proto = []
-base_node = ["tari_mmr", "transactions", "mempool_proto", "base_node_proto", "monero", "randomx-rs"]
+base_node = [
+  "tari_mmr",
+  "transactions",
+  "mempool_proto",
+  "base_node_proto",
+  "monero",
+  "randomx-rs",
+]
 base_node_proto = []
 benches = ["base_node"]
 metrics = ["tari_metrics"]
 
 [dependencies]
-tari_common = {  path = "../../common" }
-tari_common_types = {  path = "../../base_layer/common_types" }
-tari_comms = {  path = "../../comms/core" }
-tari_comms_dht = {  path = "../../comms/dht" }
-tari_comms_rpc_macros = {  path = "../../comms/rpc_macros" }
+tari_common = { path = "../../common" }
+tari_common_types = { path = "../../base_layer/common_types" }
+tari_comms = { path = "../../comms/core" }
+tari_comms_dht = { path = "../../comms/dht" }
+tari_comms_rpc_macros = { path = "../../comms/rpc_macros" }
 tari_crypto = { version = "0.19", features = ["borsh"] }
 tari_metrics = { path = "../../infrastructure/metrics", optional = true }
-tari_mmr = {  path = "../../base_layer/mmr", optional = true}
-tari_p2p = {  path = "../../base_layer/p2p" }
+tari_mmr = { path = "../../base_layer/mmr", optional = true }
+tari_p2p = { path = "../../base_layer/p2p" }
 tari_script = { path = "../../infrastructure/tari_script" }
-tari_service_framework = {  path = "../service_framework" }
-tari_shutdown = {  path = "../../infrastructure/shutdown" }
-tari_storage = {  path = "../../infrastructure/storage" }
-tari_test_utils = {  path = "../../infrastructure/test_utils" }
+tari_service_framework = { path = "../service_framework" }
+tari_shutdown = { path = "../../infrastructure/shutdown" }
+tari_storage = { path = "../../infrastructure/storage" }
+tari_test_utils = { path = "../../infrastructure/test_utils" }
 tari_utilities = { version = "0.6", features = ["borsh"] }
-tari_key_manager = {  path = "../key_manager", features = ["key_manager_service"] }
+tari_key_manager = { path = "../key_manager", features = [
+  "key_manager_service",
+] }
 tari_common_sqlite = { path = "../../common_sqlite" }
+tari_hash_domains = { git = "https://github.com/tari-project/tari_hash_domains.git" }
 
-async-trait = {version = "0.1.50"}
+async-trait = { version = "0.1.50" }
 bincode = "1.1.4"
 bitflags = { version = "2.4", features = ["serde"] }
 blake2 = "0.10"
@@ -78,8 +88,8 @@ primitive-types = { version = "0.12", features = ["serde"] }
 
 [dev-dependencies]
 criterion = { version = "0.4.0" }
-tari_p2p = {  path = "../../base_layer/p2p", features = ["test-mocks"] }
-tari_test_utils = {  path = "../../infrastructure/test_utils" }
+tari_p2p = { path = "../../base_layer/p2p", features = ["test-mocks"] }
+tari_test_utils = { path = "../../infrastructure/test_utils" }
 curve25519-dalek = { package = "tari-curve25519-dalek", version = "4.0.3" }
 # SQLite required for the integration tests
 libsqlite3-sys = { version = "0.25.1", features = ["bundled"] }
@@ -88,7 +98,7 @@ env_logger = "0.7.0"
 tempfile = "3.1.0"
 
 [build-dependencies]
-tari_common = {  path = "../../common", features = ["build"] }
+tari_common = { path = "../../common", features = ["build"] }
 
 [[bench]]
 name = "mempool"

--- a/base_layer/core/src/common/mod.rs
+++ b/base_layer/core/src/common/mod.rs
@@ -22,7 +22,7 @@
 
 use blake2::Blake2b;
 use digest::consts::U64;
-use tari_crypto::hash_domain;
+use tari_hash_domains::ConfidentialOutputHashDomain;
 
 use crate::consensus::DomainSeparatedConsensusHasher;
 
@@ -35,7 +35,6 @@ pub mod rolling_avg;
 #[cfg(feature = "base_node")]
 pub mod rolling_vec;
 
-hash_domain!(ConfidentialOutputHashDomain, "com.tari.dan.confidential_output", 1);
 /// Hasher used in the DAN to derive masks and encrypted value keys
 pub type ConfidentialOutputHasher = DomainSeparatedConsensusHasher<ConfidentialOutputHashDomain, Blake2b<U64>>;
 

--- a/base_layer/core/src/common/one_sided.rs
+++ b/base_layer/core/src/common/one_sided.rs
@@ -31,17 +31,12 @@ use tari_crypto::{
     hashing::{DomainSeparatedHash, DomainSeparatedHasher},
     keys::{PublicKey as PKtrait, SecretKey as SKtrait},
 };
+use tari_hash_domains::WalletOutputEncryptionKeysDomain;
 use tari_utilities::byte_array::ByteArrayError;
 
 hash_domain!(
     WalletOutputRewindKeysDomain,
     "com.tari.base_layer.wallet.output_rewind_keys",
-    1
-);
-
-hash_domain!(
-    WalletOutputEncryptionKeysDomain,
-    "com.tari.base_layer.wallet.output_encryption_keys",
     1
 );
 

--- a/base_layer/core/src/lib.rs
+++ b/base_layer/core/src/lib.rs
@@ -57,6 +57,7 @@ mod domain_hashing {
     use blake2::Blake2b;
     use digest::consts::U32;
     use tari_crypto::{hash_domain, hashing::DomainSeparatedHasher};
+    use tari_hash_domains::ValidatorNodeBmtHashDomain;
     use tari_mmr::{
         pruned_hashset::PrunedHashSet,
         sparse_merkle_tree::SparseMerkleTree,
@@ -80,11 +81,6 @@ mod domain_hashing {
 
     pub type OutputSmt = SparseMerkleTree<OutputSmtHasherBlake256>;
 
-    hash_domain!(
-        ValidatorNodeBmtHashDomain,
-        "com.tari.base_layer.core.validator_node_mmr",
-        1
-    );
     pub type ValidatorNodeBmtHasherBlake256 = DomainSeparatedHasher<Blake2b<U32>, ValidatorNodeBmtHashDomain>;
     pub type ValidatorNodeBMT = BalancedBinaryMerkleTree<ValidatorNodeBmtHasherBlake256>;
 }

--- a/base_layer/core/src/transactions/mod.rs
+++ b/base_layer/core/src/transactions/mod.rs
@@ -32,10 +32,3 @@ pub mod test_helpers;
 // Hash domain for all transaction-related hashes, including the script signature challenge, transaction hash and kernel
 // signature challenge
 hash_domain!(TransactionHashDomain, "com.tari.base_layer.core.transactions", 0);
-
-// Hash domain used to derive the final AEAD encryption key for encrypted data in UTXOs
-hash_domain!(
-    TransactionSecureNonceKdfDomain,
-    "com.tari.base_layer.core.transactions.secure_nonce_kdf",
-    0
-);

--- a/base_layer/core/src/transactions/transaction_components/encrypted_data.rs
+++ b/base_layer/core/src/transactions/transaction_components/encrypted_data.rs
@@ -40,6 +40,7 @@ use digest::{consts::U32, generic_array::GenericArray, FixedOutput};
 use serde::{Deserialize, Serialize};
 use tari_common_types::types::{Commitment, PrivateKey};
 use tari_crypto::{hashing::DomainSeparatedHasher, keys::SecretKey};
+use tari_hash_domains::TransactionSecureNonceKdfDomain;
 use tari_utilities::{
     hex::{from_hex, to_hex, Hex, HexError},
     safe_array::SafeArray,
@@ -50,7 +51,7 @@ use thiserror::Error;
 use zeroize::{Zeroize, Zeroizing};
 
 use super::EncryptedDataKey;
-use crate::transactions::{tari_amount::MicroMinotari, TransactionSecureNonceKdfDomain};
+use crate::transactions::tari_amount::MicroMinotari;
 
 // Useful size constants, each in bytes
 const SIZE_NONCE: usize = size_of::<XNonce>();


### PR DESCRIPTION
Description
---
Refactor out the common hash domain names between `tari` and `tari-dan` repos.

Motivation and Context
---
Constants should always be defined at one place.

How Has This Been Tested?
---

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
