### PR TITLE
chore: add versions to all hash domains

### DIFF
--- a/base_layer/common_types/src/types/mod.rs
+++ b/base_layer/common_types/src/types/mod.rs
@@ -91,7 +91,8 @@ hasher!(
 
 hash_domain!(
     BulletRangeProofHashDomain,
-    "com.tari.base_layer.common_types.bullet_rangeproofs"
+    "com.tari.base_layer.common_types.bullet_rangeproofs",
+    1
 );
 
 pub type BulletRangeProofHasherBlake256 = DomainSeparatedHasher<Blake2b<U32>, BulletRangeProofHashDomain>;

--- a/base_layer/core/src/transactions/key_manager/inner.rs
+++ b/base_layer/core/src/transactions/key_manager/inner.rs
@@ -86,7 +86,8 @@ use crate::{
 
 hash_domain!(
     KeyManagerHashingDomain,
-    "com.tari.base_layer.core.transactions.key_manager"
+    "com.tari.base_layer.core.transactions.key_manager",
+    1
 );
 
 pub struct TransactionKeyManagerInner<TBackend> {

--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -108,7 +108,11 @@ const LOG_TARGET: &str = "wallet";
 const WALLET_BUFFER_MIN_SIZE: usize = 300;
 
 // Domain separator for signing arbitrary messages with a wallet secret key
-hash_domain!(WalletMessageSigningDomain, "com.tari.base_layer.wallet.message_signing");
+hash_domain!(
+    WalletMessageSigningDomain,
+    "com.tari.base_layer.wallet.message_signing",
+    1
+);
 
 /// A structure containing the config and services that a Wallet application will require. This struct will start up all
 /// the services and provide the APIs that applications will use to interact with the services

--- a/comms/dht/src/lib.rs
+++ b/comms/dht/src/lib.rs
@@ -126,7 +126,7 @@ use blake2::Blake2b;
 use digest::consts::{U32, U64};
 use tari_crypto::{hash_domain, hashing::DomainSeparatedHasher};
 
-hash_domain!(DHTCommsHashDomain, "com.tari.comms.dht");
+hash_domain!(DHTCommsHashDomain, "com.tari.comms.dht", 1);
 
 /// Hash domain used to produce binding message hashes
 pub fn comms_dht_hash_domain_challenge() -> DomainSeparatedHasher<Blake2b<U32>, DHTCommsHashDomain> {


### PR DESCRIPTION
Description
---
Adds versioning to all hash domains.

Closes #5970.

Motivation and Context
---
Some hash function definitions rely on a default version number that is added during macro invocation. This isn't inherently a problem, but reduces clarity and could result in breaking changes if this default is ever changed. It seems prudent to add a specific version in all cases.

How Has This Been Tested?
---
Existing tests pass.

What process can a PR reviewer use to test or verify this change?
---
Confirm that the added version numbers correspond to the [default](https://github.com/tari-project/tari-crypto/blob/91d1e779e565dc816a54ab78368d44efcae78a23/src/hashing.rs#L616).