### PR TITLE
fix: update `ToRistrettoPoint` handling

### DIFF
--- a/infrastructure/tari_script/src/op_codes.rs
+++ b/infrastructure/tari_script/src/op_codes.rs
@@ -262,9 +262,11 @@ pub enum Opcode {
     /// Identical to CheckMultiSig, except that the aggregate of the public keys is pushed to the stack if multiple
     /// signature validation succeeds. Fails with `VerifyFailed` if any signature is invalid.
     CheckMultiSigVerifyAggregatePubKey(u8, u8, Vec<RistrettoPublicKey>, Box<Message>),
-    /// Pops the top element from the stack, either a scalar or a hash, calculates the corresponding Ristretto point,
-    /// and pushes the result to the stack. Fails with `StackUnderflow` if the stack is empty. Fails with
-    /// `IncompatibleTypes` if the stack item is not a valid 32 byte sequence.
+    /// Pops the top element from the stack (either a scalar or a hash), parses it canonically as a Ristretto secret
+    /// key if possible, computes the corresponding Ristretto public key, and pushes this value to the stack.
+    /// Fails with `StackUnderflow` if the stack is empty.
+    /// Fails with `IncompatibleTypes` if the stack item is not either a scalar or a hash.
+    /// Fails with `InvalidInput` if the stack item cannot be canonically parsed as a Ristretto secret key.
     ToRistrettoPoint,
 
     // Miscellaneous


### PR DESCRIPTION
Description
---
Updates the handling of the `ToRistrettoPoint` opcode.

Closes #5818.

Motivation and Context
---
The `ToRistrettoPoint` opcode now requires that stack input be the canonical encoding of a Ristretto secret key. This PR updates the opcode documentation and adds a test for proper handling of invalid encoding. It also corrects the error returned on invalid stack input.

There is a [separate PR](https://github.com/tari-project/rfcs/pull/113) that updates the RFC documentation.

How Has This Been Tested?
---
Existing tests pass. A modified test passes.

What process can a PR reviewer use to test or verify this change?
---
Check that the updated documentation reflects the opcode handling. Check that the modified test correctly detects invalid input. Check that the error returned on invalid input is correct.