### PR TITLE
feat: dependency updates for curve library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1389,13 +1389,40 @@ checksum = "e89b8c6a2e4b1f45971ad09761aafb85514a84744b67a95e32c3cc1352d1f65c"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "curve25519-dalek-derive",
+ "curve25519-dalek-derive 0.1.1",
  "digest 0.10.7",
- "fiat-crypto 0.2.2",
+ "fiat-crypto",
  "platforms",
  "rustc_version",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.1"
+source = "git+https://github.com/AaronFeickert/curve25519-dalek?branch=TEST-rebase#e540021d100b028b715a3fef7277a7aa387fa836"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive 0.1.0",
+ "fiat-crypto",
+ "platforms",
+ "rand_core 0.6.4",
+ "rustc_version",
+ "serde",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.0"
+source = "git+https://github.com/AaronFeickert/curve25519-dalek?branch=TEST-rebase#e540021d100b028b715a3fef7277a7aa387fa836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -1717,7 +1744,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7277392b266383ef8396db7fdeb1e77b6c52fed775f5df15bb24f35b72156980"
 dependencies = [
- "curve25519-dalek 4.1.1",
+ "curve25519-dalek 4.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ed25519",
  "serde",
  "sha2 0.10.8",
@@ -1869,12 +1896,6 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
-
-[[package]]
-name = "fiat-crypto"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e825f6987101665dea6ec934c09ec6d721de7bc1bf92248e1d5810c8cd636b77"
 
 [[package]]
 name = "fiat-crypto"
@@ -4054,7 +4075,7 @@ dependencies = [
  "chrono",
  "cipher 0.4.4",
  "crc24",
- "curve25519-dalek 4.1.1",
+ "curve25519-dalek 4.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive_builder",
  "des",
  "digest 0.10.7",
@@ -5301,7 +5322,7 @@ dependencies = [
  "aes-gcm",
  "blake2",
  "chacha20poly1305",
- "curve25519-dalek 4.1.1",
+ "curve25519-dalek 4.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.6.4",
  "rustc_version",
  "sha2 0.10.8",
@@ -5541,42 +5562,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
-name = "tari-curve25519-dalek"
-version = "4.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b8e2644aae57a832e475ebc31199ab1114ebd7fe4d2621e67e89bdd9c8ac38"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "curve25519-dalek-derive",
- "fiat-crypto 0.1.20",
- "platforms",
- "rand_core 0.6.4",
- "rustc_version",
- "serde",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "tari_bulletproofs_plus"
 version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9abc9cbebffb1149112a80d6955498ed891f9b786e89c50e07de4b4f16290fd8"
+source = "git+https://github.com/AaronFeickert/bulletproofs-plus?branch=curve-library-update#fadf5d6dc8b047993b2ceecd3f45968ffc4177a5"
 dependencies = [
  "blake2",
  "byteorder",
+ "curve25519-dalek 4.1.1 (git+https://github.com/AaronFeickert/curve25519-dalek?branch=TEST-rebase)",
  "derivative",
  "derive_more",
  "digest 0.10.7",
  "itertools 0.6.5",
- "lazy_static",
  "merlin",
+ "once_cell",
  "rand",
  "rand_core 0.6.4",
  "serde",
  "sha3",
- "tari-curve25519-dalek",
  "thiserror",
  "zeroize",
 ]
@@ -5822,6 +5824,7 @@ dependencies = [
  "chrono",
  "config",
  "criterion 0.4.0",
+ "curve25519-dalek 4.1.1 (git+https://github.com/AaronFeickert/curve25519-dalek?branch=TEST-rebase)",
  "decimal-rs",
  "derivative",
  "digest 0.10.7",
@@ -5852,7 +5855,6 @@ dependencies = [
  "sha3",
  "strum",
  "strum_macros",
- "tari-curve25519-dalek",
  "tari_common",
  "tari_common_sqlite",
  "tari_common_types",
@@ -5881,11 +5883,11 @@ dependencies = [
 [[package]]
 name = "tari_crypto"
 version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c74907b0c0237bc545e1da9b3ad6654fff934bdbd291bbe2a0e57e61933d6fc4"
+source = "git+https://github.com/AaronFeickert/tari-crypto?branch=curve-library-update#8e5ee18e5e85b8e4afec5eaab8891b95bb373e70"
 dependencies = [
  "blake2",
  "borsh",
+ "curve25519-dalek 4.1.1 (git+https://github.com/AaronFeickert/curve25519-dalek?branch=TEST-rebase)",
  "digest 0.10.7",
  "log",
  "once_cell",
@@ -5894,7 +5896,6 @@ dependencies = [
  "serde",
  "sha3",
  "snafu",
- "tari-curve25519-dalek",
  "tari_bulletproofs_plus",
  "tari_utilities",
  "zeroize",
@@ -7308,7 +7309,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb66477291e7e8d2b0ff1bcb900bf29489a9692816d79874bea351e7a8b6de96"
 dependencies = [
- "curve25519-dalek 4.1.1",
+ "curve25519-dalek 4.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.6.4",
  "serde",
  "zeroize",

--- a/applications/minotari_app_grpc/Cargo.toml
+++ b/applications/minotari_app_grpc/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 tari_common_types = {  path = "../../base_layer/common_types" }
 tari_comms = { path = "../../comms/core" }
 tari_core = { path = "../../base_layer/core" }
-tari_crypto = { version = "0.19" }
+tari_crypto = { git = "https://github.com/AaronFeickert/tari-crypto", branch = "curve-library-update" }
 tari_script = { path = "../../infrastructure/tari_script" }
 tari_utilities = { version = "0.6" }
 

--- a/applications/minotari_console_wallet/Cargo.toml
+++ b/applications/minotari_console_wallet/Cargo.toml
@@ -13,7 +13,7 @@ tari_common_types = { path = "../../base_layer/common_types" }
 tari_comms = { path = "../../comms/core" }
 tari_comms_dht = { path = "../../comms/dht" }
 tari_contacts = { path = "../../base_layer/contacts" }
-tari_crypto = { version = "0.19" }
+tari_crypto = { git = "https://github.com/AaronFeickert/tari-crypto", branch = "curve-library-update" }
 tari_key_manager = { path = "../../base_layer/key_manager" }
 tari_libtor = { path = "../../infrastructure/libtor", optional = true }
 tari_p2p = { path = "../../base_layer/p2p", features = ["auto-update"] }

--- a/applications/minotari_miner/Cargo.toml
+++ b/applications/minotari_miner/Cargo.toml
@@ -14,7 +14,7 @@ tari_common_types = { path = "../../base_layer/common_types" }
 tari_comms = { path = "../../comms/core" }
 minotari_app_utilities = { path = "../minotari_app_utilities" }
 minotari_app_grpc = { path = "../minotari_app_grpc" }
-tari_crypto = { version = "0.19" }
+tari_crypto = { git = "https://github.com/AaronFeickert/tari-crypto", branch = "curve-library-update" }
 tari_utilities = { version = "0.6" }
 
 base64 = "0.13.0"

--- a/applications/minotari_node/Cargo.toml
+++ b/applications/minotari_node/Cargo.toml
@@ -15,7 +15,7 @@ tari_comms = { path = "../../comms/core", features = ["rpc"] }
 tari_common_types = { path = "../../base_layer/common_types" }
 tari_comms_dht = { path = "../../comms/dht" }
 tari_core = { path = "../../base_layer/core", default-features = false, features = ["transactions"] }
-tari_crypto = { version = "0.19" }
+tari_crypto = { git = "https://github.com/AaronFeickert/tari-crypto", branch = "curve-library-update" }
 tari_libtor = { path = "../../infrastructure/libtor", optional = true }
 tari_p2p = { path = "../../base_layer/p2p", features = ["auto-update"] }
 tari_storage = {path="../../infrastructure/storage"}

--- a/base_layer/chat_ffi/Cargo.toml
+++ b/base_layer/chat_ffi/Cargo.toml
@@ -32,7 +32,7 @@ crate-type = ["staticlib","cdylib"]
 [dev-dependencies]
 chrono = { version = "0.4.19", default-features = false }
 rand = "0.8"
-tari_crypto = { version = "0.19" }
+tari_crypto = { git = "https://github.com/AaronFeickert/tari-crypto", branch = "curve-library-update" }
 
 [build-dependencies]
 cbindgen = "0.24.3"

--- a/base_layer/common_types/Cargo.toml
+++ b/base_layer/common_types/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.53.0-pre.0"
 edition = "2018"
 
 [dependencies]
-tari_crypto = { version = "0.19" }
+tari_crypto = { git = "https://github.com/AaronFeickert/tari-crypto", branch = "curve-library-update" }
 tari_utilities = { version = "0.6" }
 tari_common = {  path = "../../common" }
 

--- a/base_layer/contacts/Cargo.toml
+++ b/base_layer/contacts/Cargo.toml
@@ -12,7 +12,7 @@ tari_common_sqlite = { path = "../../common_sqlite" }
 tari_common_types = {  path = "../../base_layer/common_types" }
 tari_comms = {  path = "../../comms/core" }
 tari_comms_dht = { path = "../../comms/dht" }
-tari_crypto = { version = "0.19" }
+tari_crypto = { git = "https://github.com/AaronFeickert/tari-crypto", branch = "curve-library-update" }
 tari_p2p = {  path = "../p2p", features = ["auto-update"] }
 tari_service_framework = {  path = "../service_framework" }
 tari_shutdown = {  path = "../../infrastructure/shutdown" }

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -24,7 +24,7 @@ tari_common_types = {  path = "../../base_layer/common_types" }
 tari_comms = {  path = "../../comms/core" }
 tari_comms_dht = {  path = "../../comms/dht" }
 tari_comms_rpc_macros = {  path = "../../comms/rpc_macros" }
-tari_crypto = { version = "0.19", features = ["borsh"] }
+tari_crypto = { git = "https://github.com/AaronFeickert/tari-crypto", branch = "curve-library-update", features = ["borsh"] }
 tari_metrics = { path = "../../infrastructure/metrics", optional = true }
 tari_mmr = {  path = "../../base_layer/mmr", optional = true}
 tari_p2p = {  path = "../../base_layer/p2p" }
@@ -81,7 +81,7 @@ primitive-types = { version = "0.12", features = ["serde"] }
 criterion = { version = "0.4.0" }
 tari_p2p = {  path = "../../base_layer/p2p", features = ["test-mocks"] }
 tari_test_utils = {  path = "../../infrastructure/test_utils" }
-curve25519-dalek = { package = "tari-curve25519-dalek", version = "4.0.3" }
+curve25519-dalek = { git = "https://github.com/AaronFeickert/curve25519-dalek", branch = "TEST-rebase" }
 # SQLite required for the integration tests
 libsqlite3-sys = { version = "0.25.1", features = ["bundled"] }
 config = { version = "0.13.0" }

--- a/base_layer/key_manager/Cargo.toml
+++ b/base_layer/key_manager/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 crate-type = ["lib", "cdylib"]
 
 [dependencies]
-tari_crypto = { version = "0.19" }
+tari_crypto = { git = "https://github.com/AaronFeickert/tari-crypto", branch = "curve-library-update" }
 tari_utilities = { version = "0.6" }
 tari_common_sqlite = { path = "../../common_sqlite" }
 tari_common_types = {  path = "../../base_layer/common_types"}

--- a/base_layer/mmr/Cargo.toml
+++ b/base_layer/mmr/Cargo.toml
@@ -12,7 +12,7 @@ default = []
 
 [dependencies]
 tari_utilities = { version = "0.6" }
-tari_crypto = { version = "0.19" }
+tari_crypto = { git = "https://github.com/AaronFeickert/tari-crypto", branch = "curve-library-update" }
 tari_common = { path = "../../common" }
 thiserror = "1.0"
 borsh = "0.10"

--- a/base_layer/p2p/Cargo.toml
+++ b/base_layer/p2p/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 tari_comms = {  path = "../../comms/core" }
 tari_comms_dht = {  path = "../../comms/dht" }
 tari_common = {  path = "../../common" }
-tari_crypto = { version = "0.19" }
+tari_crypto = { git = "https://github.com/AaronFeickert/tari-crypto", branch = "curve-library-update" }
 tari_service_framework = {  path = "../service_framework" }
 tari_shutdown = {  path = "../../infrastructure/shutdown" }
 tari_storage = {  path = "../../infrastructure/storage" }

--- a/base_layer/tari_mining_helper_ffi/Cargo.toml
+++ b/base_layer/tari_mining_helper_ffi/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 tari_comms = {  path = "../../comms/core" }
-tari_crypto = { version = "0.19" }
+tari_crypto = { git = "https://github.com/AaronFeickert/tari-crypto", branch = "curve-library-update" }
 tari_common = {  path = "../../common" }
 tari_core = {  path = "../core", default-features = false, features = ["transactions"]}
 tari_utilities = { version = "0.6" }

--- a/base_layer/wallet/Cargo.toml
+++ b/base_layer/wallet/Cargo.toml
@@ -12,7 +12,7 @@ tari_common = { path = "../../common" }
 tari_common_types = {  path = "../../base_layer/common_types" }
 tari_comms = {  path = "../../comms/core" }
 tari_comms_dht = {  path = "../../comms/dht" }
-tari_crypto = { version = "0.19" }
+tari_crypto = { git = "https://github.com/AaronFeickert/tari-crypto", branch = "curve-library-update" }
 tari_key_manager = {  path = "../key_manager", features = ["key_manager_service"] }
 tari_p2p = {  path = "../p2p", features = ["auto-update"] }
 tari_script = { path = "../../infrastructure/tari_script" }

--- a/base_layer/wallet_ffi/Cargo.toml
+++ b/base_layer/wallet_ffi/Cargo.toml
@@ -12,7 +12,7 @@ tari_common = { path="../../common" }
 tari_common_types = { path="../common_types" }
 tari_comms = {  path = "../../comms/core", features = ["c_integration"]}
 tari_comms_dht = {  path = "../../comms/dht", default-features = false }
-tari_crypto = { version = "0.19" }
+tari_crypto = { git = "https://github.com/AaronFeickert/tari-crypto", branch = "curve-library-update" }
 tari_key_manager = {  path = "../key_manager" }
 tari_p2p = {  path = "../p2p" }
 tari_script = { path = "../../infrastructure/tari_script" }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -14,7 +14,7 @@ build = ["toml", "prost-build"]
 static-application-info = ["git2"]
 
 [dependencies]
-tari_crypto = { version = "0.19" }
+tari_crypto = { git = "https://github.com/AaronFeickert/tari-crypto", branch = "curve-library-update" }
 
 anyhow = "1.0.53"
 blake2 = "0.10"

--- a/comms/core/Cargo.toml
+++ b/comms/core/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.53.0-pre.0"
 edition = "2018"
 
 [dependencies]
-tari_crypto = { version = "0.19" }
+tari_crypto = { git = "https://github.com/AaronFeickert/tari-crypto", branch = "curve-library-update" }
 tari_metrics = { path = "../../infrastructure/metrics", optional = true }
 tari_storage = {  path = "../../infrastructure/storage" }
 tari_shutdown = {  path = "../../infrastructure/shutdown" }

--- a/comms/dht/Cargo.toml
+++ b/comms/dht/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 tari_comms = {  path = "../core", features = ["rpc"] }
 tari_common = { path = "../../common" }
 tari_comms_rpc_macros = {  path = "../rpc_macros" }
-tari_crypto = { version = "0.19" }
+tari_crypto = { git = "https://github.com/AaronFeickert/tari-crypto", branch = "curve-library-update" }
 tari_utilities = { version = "0.6" }
 tari_shutdown = {  path = "../../infrastructure/shutdown" }
 tari_storage = {  path = "../../infrastructure/storage" }

--- a/infrastructure/tari_script/Cargo.toml
+++ b/infrastructure/tari_script/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 license = "BSD-3-Clause"
 
 [dependencies]
-tari_crypto = { version = "0.19" }
+tari_crypto = { git = "https://github.com/AaronFeickert/tari-crypto", branch = "curve-library-update" }
 tari_utilities = { version = "0.6" }
 
 blake2 = "0.10"

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -13,7 +13,7 @@ minotari_node = { path = "../applications/minotari_node" }
 minotari_node_grpc_client = { path = "../clients/rust/base_node_grpc_client" }
 tari_chat_client = { path = "../base_layer/contacts/src/chat_client" }
 minotari_chat_ffi = { path = "../base_layer/chat_ffi" }
-tari_crypto = { version = "0.19" }
+tari_crypto = { git = "https://github.com/AaronFeickert/tari-crypto", branch = "curve-library-update" }
 tari_common = { path = "../common" }
 tari_common_types = { path = "../base_layer/common_types" }
 tari_comms = { path = "../comms/core" }


### PR DESCRIPTION
Description
---
Updates the `tari-crypto` dependency to reflect changes to the curve library fork.

This supersedes #5868, which was outdated.

Motivation and Context
---
An audit of the `bulletproofs-plus` library recommended an update to the curve library fork. This necessitated a `tari-crypto` update that is reflected here.

How Has This Been Tested?
---
Existing tests pass.

What process can a PR reviewer use to test or verify this change?
---
Confirm that CI passes.