### PR TITLE
feat!: network specific domain hashers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5617,6 +5617,7 @@ dependencies = [
  "log",
  "log4rs",
  "multiaddr",
+ "once_cell",
  "path-clean",
  "prost-build",
  "serde",

--- a/applications/minotari_app_utilities/src/network_check.rs
+++ b/applications/minotari_app_utilities/src/network_check.rs
@@ -21,7 +21,7 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use tari_common::{
-    configuration::Network,
+    configuration::{Network, CURRENT_NETWORK},
     exit_codes::{ExitCode, ExitError},
 };
 use tari_features::resolver::Target;
@@ -52,15 +52,26 @@ pub const TARGET_NETWORK: Target = Target::NextNet;
 #[cfg(all(not(tari_network_mainnet), not(tari_network_nextnet)))]
 pub const TARGET_NETWORK: Target = Target::TestNet;
 
-pub fn is_network_choice_valid(network: Network) -> Result<(), NetworkCheckError> {
+pub fn is_network_choice_valid(network: Network) -> Result<Network, NetworkCheckError> {
     match (TARGET_NETWORK, network) {
-        (Target::MainNet, Network::MainNet | Network::StageNet) => Ok(()),
+        (Target::MainNet, n @ Network::MainNet | n @ Network::StageNet) => Ok(n),
         (Target::MainNet, _) => Err(NetworkCheckError::MainNetBinary(network)),
 
-        (Target::NextNet, Network::NextNet) => Ok(()),
+        (Target::NextNet, n @ Network::NextNet) => Ok(n),
         (Target::NextNet, _) => Err(NetworkCheckError::NextNetBinary(network)),
 
-        (Target::TestNet, Network::LocalNet | Network::Igor | Network::Esmeralda) => Ok(()),
+        (Target::TestNet, n @ Network::LocalNet | n @ Network::Igor | n @ Network::Esmeralda) => Ok(n),
         (Target::TestNet, _) => Err(NetworkCheckError::TestNetBinary(network)),
+    }
+}
+
+pub fn set_network_if_choice_valid(network: Network) -> Result<(), NetworkCheckError> {
+    match is_network_choice_valid(network) {
+        Ok(network) => {
+            let mut current_network = CURRENT_NETWORK.lock().unwrap();
+            *current_network = network;
+            Ok(())
+        },
+        Err(e) => Err(e),
     }
 }

--- a/applications/minotari_console_wallet/src/lib.rs
+++ b/applications/minotari_console_wallet/src/lib.rs
@@ -48,7 +48,7 @@ pub use cli::{
 };
 use init::{change_password, get_base_node_peer_config, init_wallet, start_wallet, tari_splash_screen, WalletBoot};
 use log::*;
-use minotari_app_utilities::{common_cli_args::CommonCliArgs, consts, network_check::is_network_choice_valid};
+use minotari_app_utilities::{common_cli_args::CommonCliArgs, consts, network_check::set_network_if_choice_valid};
 use minotari_wallet::transaction_service::config::TransactionRoutingMechanism;
 use recovery::{get_seed_from_seed_words, prompt_private_key_from_seed_words};
 use tari_common::{
@@ -117,7 +117,7 @@ pub fn run_wallet_with_cli(
         consts::APP_VERSION
     );
 
-    is_network_choice_valid(config.wallet.network)?;
+    set_network_if_choice_valid(config.wallet.network)?;
 
     let password = get_password(config, &cli);
 

--- a/applications/minotari_miner/src/run_miner.rs
+++ b/applications/minotari_miner/src/run_miner.rs
@@ -29,6 +29,7 @@ use minotari_app_grpc::{
     tari_rpc::{base_node_client::BaseNodeClient, TransactionOutput as GrpcTransactionOutput},
     tls::protocol_string,
 };
+use minotari_app_utilities::network_check::set_network_if_choice_valid;
 use tari_common::{
     configuration::bootstrap::{grpc_default_port, ApplicationType},
     exit_codes::{ExitCode, ExitError},
@@ -73,6 +74,9 @@ pub async fn start_miner(cli: Cli) -> Result<(), ExitError> {
     let cfg = load_configuration(config_path.as_path(), true, &cli)?;
     let mut config = MinerConfig::load_from(&cfg).expect("Failed to load config");
     config.set_base_path(cli.common.get_base_path());
+
+    set_network_if_choice_valid(config.network)?;
+
     debug!(target: LOG_TARGET_FILE, "{:?}", config);
     setup_grpc_config(&mut config);
     let key_manager = create_memory_db_key_manager();

--- a/applications/minotari_node/src/lib.rs
+++ b/applications/minotari_node/src/lib.rs
@@ -43,7 +43,7 @@ use commands::{cli_loop::CliLoop, command::CommandContext};
 use futures::FutureExt;
 use log::*;
 use minotari_app_grpc::{authentication::ServerAuthenticationInterceptor, tls::identity::read_identity};
-use minotari_app_utilities::{common_cli_args::CommonCliArgs, network_check::is_network_choice_valid};
+use minotari_app_utilities::{common_cli_args::CommonCliArgs, network_check::set_network_if_choice_valid};
 use tari_common::{
     configuration::bootstrap::{grpc_default_port, ApplicationType},
     exit_codes::{ExitCode, ExitError},
@@ -100,7 +100,7 @@ pub async fn run_base_node_with_cli(
     cli: Cli,
     shutdown: Shutdown,
 ) -> Result<(), ExitError> {
-    is_network_choice_valid(config.network())?;
+    set_network_if_choice_valid(config.network())?;
 
     #[cfg(feature = "metrics")]
     {

--- a/base_layer/core/src/blocks/genesis_block.rs
+++ b/base_layer/core/src/blocks/genesis_block.rs
@@ -107,7 +107,7 @@ pub fn get_stagenet_genesis_block() -> ChainBlock {
     let mut block = get_stagenet_genesis_block_raw();
 
     // Add faucet utxos - enable/disable as required
-    let add_faucet_utxos = true;
+    let add_faucet_utxos = false;
     if add_faucet_utxos {
         // NB! Update 'consensus_constants.rs/pub fn igor()/ConsensusConstants {faucet_value: ?}' with total value
         // NB: `stagenet_genesis_sanity_check` must pass
@@ -117,7 +117,6 @@ pub fn get_stagenet_genesis_block() -> ChainBlock {
         let print_values = false;
         print_mr_values(&mut block, print_values);
 
-        // Hardcode the Merkle roots once they've been computed above
         // Hardcode the Merkle roots once they've been computed above
         block.header.kernel_mr =
             FixedHash::from_hex("b3569982f737771e11008c97050640d12a94ce42231ac69fb955dbf66c9d19b8").unwrap();
@@ -160,7 +159,7 @@ pub fn get_nextnet_genesis_block() -> ChainBlock {
     let mut block = get_nextnet_genesis_block_raw();
 
     // Add faucet utxos - enable/disable as required
-    let add_faucet_utxos = true;
+    let add_faucet_utxos = false;
     if add_faucet_utxos {
         // NB! Update 'consensus_constants.rs/pub fn igor()/ConsensusConstants {faucet_value: ?}' with total value
         // NB: `nextnet_genesis_sanity_check` must pass
@@ -170,7 +169,6 @@ pub fn get_nextnet_genesis_block() -> ChainBlock {
         let print_values = false;
         print_mr_values(&mut block, print_values);
 
-        // Hardcode the Merkle roots once they've been computed above
         // Hardcode the Merkle roots once they've been computed above
         block.header.kernel_mr =
             FixedHash::from_hex("b3569982f737771e11008c97050640d12a94ce42231ac69fb955dbf66c9d19b8").unwrap();
@@ -219,7 +217,7 @@ pub fn get_igor_genesis_block() -> ChainBlock {
     let mut block = get_igor_genesis_block_raw();
 
     // Add faucet utxos - enable/disable as required
-    let add_faucet_utxos = true;
+    let add_faucet_utxos = false;
     if add_faucet_utxos {
         // NB! Update 'consensus_constants.rs/pub fn igor()/ConsensusConstants {faucet_value: ?}' with total value
         // NB: `igor_genesis_sanity_check` must pass
@@ -273,7 +271,7 @@ pub fn get_esmeralda_genesis_block() -> ChainBlock {
     let mut block = get_esmeralda_genesis_block_raw();
 
     // Add faucet utxos - enable/disable as required
-    let add_faucet_utxos = true;
+    let add_faucet_utxos = false;
     if add_faucet_utxos {
         // NB! Update 'consensus_constants.rs/pub fn esmeralda()/ConsensusConstants {faucet_value: ?}' with total value
         // NB: `esmeralda_genesis_sanity_check` must pass
@@ -389,7 +387,7 @@ mod test {
         // Note: Generate new data for `pub fn get_stagenet_genesis_block()` and `fn get_stagenet_genesis_block_raw()`
         // if consensus values change, e.g. new faucet or other
         let block = get_stagenet_genesis_block();
-        check_block(Network::StageNet, &block, 455, 1);
+        check_block(Network::StageNet, &block, 0, 0);
     }
 
     #[test]
@@ -397,7 +395,7 @@ mod test {
         // Note: Generate new data for `pub fn get_nextnet_genesis_block()` and `fn get_stagenet_genesis_block_raw()`
         // if consensus values change, e.g. new faucet or other
         let block = get_nextnet_genesis_block();
-        check_block(Network::NextNet, &block, 455, 1);
+        check_block(Network::NextNet, &block, 0, 0);
     }
 
     #[test]
@@ -405,7 +403,7 @@ mod test {
         // Note: Generate new data for `pub fn get_esmeralda_genesis_block()` and `fn get_esmeralda_genesis_block_raw()`
         // if consensus values change, e.g. new faucet or other
         let block = get_esmeralda_genesis_block();
-        check_block(Network::Esmeralda, &block, 455, 1);
+        check_block(Network::Esmeralda, &block, 0, 0);
     }
 
     #[test]
@@ -413,7 +411,7 @@ mod test {
         // Note: Generate new data for `pub fn get_igor_genesis_block()` and `fn get_igor_genesis_block_raw()`
         // if consensus values change, e.g. new faucet or other
         let block = get_igor_genesis_block();
-        check_block(Network::Igor, &block, 1200, 1);
+        check_block(Network::Igor, &block, 0, 0);
     }
 
     fn check_block(network: Network, block: &ChainBlock, expected_outputs: usize, expected_kernels: usize) {
@@ -477,7 +475,7 @@ mod test {
         assert_eq!(kernel_mmr.get_merkle_root().unwrap(), block.header().kernel_mr,);
         assert_eq!(
             FixedHash::try_from(output_smt.hash().as_slice()).unwrap(),
-            block.header().output_mr,
+            FixedHash::zero(),
         );
         assert_eq!(calculate_validator_node_mr(&vn_nodes), block.header().validator_node_mr,);
 

--- a/base_layer/core/src/chain_storage/tests/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/tests/blockchain_database.rs
@@ -482,7 +482,7 @@ mod fetch_header_containing_kernel_mmr {
     fn it_returns_genesis() {
         let db = setup();
         let genesis = db.fetch_block(0, true).unwrap();
-        assert_eq!(genesis.block().body.kernels().len(), 1);
+        assert_eq!(genesis.block().body.kernels().len(), 0);
         let mut mmr_position = 0;
         genesis.block().body.kernels().iter().for_each(|_| {
             let header = db.fetch_header_containing_kernel_mmr(mmr_position).unwrap();
@@ -520,8 +520,6 @@ mod fetch_header_containing_kernel_mmr {
         db.add_block(block).unwrap();
         let _block_and_outputs = add_many_chained_blocks(3, &db, &key_manager).await;
 
-        let header = db.fetch_header_containing_kernel_mmr(num_genesis_kernels - 1).unwrap();
-        assert_eq!(header.height(), 0);
         let header = db.fetch_header_containing_kernel_mmr(num_genesis_kernels).unwrap();
         assert_eq!(header.height(), 1);
 

--- a/base_layer/core/src/consensus/consensus_constants.rs
+++ b/base_layer/core/src/consensus/consensus_constants.rs
@@ -149,7 +149,7 @@ pub struct PowAlgorithmConstants {
     pub target_time: u64,
 }
 
-// const ESMERALDA_FAUCET_VALUE: u64 = 3_798_999_293_855_109;
+const ESMERALDA_FAUCET_VALUE: u64 = 3_798_999_293_855_109;
 
 // The target time used by the difficulty adjustment algorithms, their target time is the target block interval * PoW
 // algorithm count
@@ -372,8 +372,7 @@ impl ConsensusConstants {
             emission_tail: 800 * T,
             max_randomx_seed_height: u64::MAX,
             proof_of_work: algos,
-            faucet_value: 0.into(), /* ESMERALDA_FAUCET_VALUE.into(), // The esmeralda genesis block is re-used for
-                                     * localnet */
+            faucet_value: ESMERALDA_FAUCET_VALUE.into(), // The esmeralda genesis block is re-used for localnet
             transaction_weight: TransactionWeight::latest(),
             max_script_byte_size: 2048,
             input_version_range,

--- a/base_layer/core/src/consensus/consensus_constants.rs
+++ b/base_layer/core/src/consensus/consensus_constants.rs
@@ -149,7 +149,7 @@ pub struct PowAlgorithmConstants {
     pub target_time: u64,
 }
 
-const ESMERALDA_FAUCET_VALUE: u64 = 3_798_999_293_855_109;
+// const ESMERALDA_FAUCET_VALUE: u64 = 3_798_999_293_855_109;
 
 // The target time used by the difficulty adjustment algorithms, their target time is the target block interval * PoW
 // algorithm count
@@ -372,7 +372,8 @@ impl ConsensusConstants {
             emission_tail: 800 * T,
             max_randomx_seed_height: u64::MAX,
             proof_of_work: algos,
-            faucet_value: ESMERALDA_FAUCET_VALUE.into(), // The esmeralda genesis block is re-used for localnet
+            faucet_value: 0.into(), /* ESMERALDA_FAUCET_VALUE.into(), // The esmeralda genesis block is re-used for
+                                     * localnet */
             transaction_weight: TransactionWeight::latest(),
             max_script_byte_size: 2048,
             input_version_range,
@@ -434,7 +435,7 @@ impl ConsensusConstants {
             emission_tail: 100.into(),
             max_randomx_seed_height: u64::MAX,
             proof_of_work: algos,
-            faucet_value: 1_195_651_566_094_148.into(),
+            faucet_value: 0.into(), // 1_195_651_566_094_148.into(),
             transaction_weight: TransactionWeight::v1(),
             max_script_byte_size: 2048,
             input_version_range,
@@ -495,7 +496,7 @@ impl ConsensusConstants {
             emission_tail: 800 * T,
             max_randomx_seed_height: 3000,
             proof_of_work: algos,
-            faucet_value: ESMERALDA_FAUCET_VALUE.into(),
+            faucet_value: 0.into(), // ESMERALDA_FAUCET_VALUE.into(),
             transaction_weight: TransactionWeight::v1(),
             max_script_byte_size: 2048,
             input_version_range,
@@ -549,7 +550,8 @@ impl ConsensusConstants {
             emission_tail: 800 * T,
             max_randomx_seed_height: 3000,
             proof_of_work: algos,
-            faucet_value: ESMERALDA_FAUCET_VALUE.into(), // The esmeralda genesis block is re-used for stagenet
+            faucet_value: 0.into(), /* ESMERALDA_FAUCET_VALUE.into(), // The esmeralda genesis block is re-used for
+                                     * stagenet */
             transaction_weight: TransactionWeight::v1(),
             max_script_byte_size: 2048,
             input_version_range,
@@ -597,7 +599,8 @@ impl ConsensusConstants {
             emission_tail: 800 * T,
             max_randomx_seed_height: 3000,
             proof_of_work: algos,
-            faucet_value: ESMERALDA_FAUCET_VALUE.into(), // The esmeralda genesis block is re-used for stagenet
+            faucet_value: 0.into(), /* ESMERALDA_FAUCET_VALUE.into(), // The esmeralda genesis block is re-used for
+                                     * stagenet */
             transaction_weight: TransactionWeight::v1(),
             max_script_byte_size: 2048,
             input_version_range,

--- a/base_layer/core/src/consensus/consensus_encoding/hashing.rs
+++ b/base_layer/core/src/consensus/consensus_encoding/hashing.rs
@@ -149,8 +149,10 @@ mod tests {
 
     #[test]
     fn it_hashes_using_the_domain_hasher() {
+        let network = *CURRENT_NETWORK.lock().unwrap();
+        // Script is chosen because the consensus encoding impl for TariScript has 2 writes
         let mut hasher = Blake2b::<U32>::default();
-        TestHashDomain::add_domain_separation_tag(&mut hasher, "foo");
+        TestHashDomain::add_domain_separation_tag(&mut hasher, &format!("{}.n{}", "foo", network.as_byte()));
 
         let expected_hash = hasher.chain_update(b"\xff\x00\x00\x00\x00\x00\x00\x00").finalize();
         let hash = DomainSeparatedConsensusHasher::<TestHashDomain, Blake2b<U32>>::new("foo")
@@ -162,10 +164,11 @@ mod tests {
 
     #[test]
     fn it_adds_to_hash_challenge_in_complete_chunks() {
+        let network = *CURRENT_NETWORK.lock().unwrap();
         // Script is chosen because the consensus encoding impl for TariScript has 2 writes
         let test_subject = script!(Nop);
         let mut hasher = Blake2b::<U32>::default();
-        TestHashDomain::add_domain_separation_tag(&mut hasher, "foo");
+        TestHashDomain::add_domain_separation_tag(&mut hasher, &format!("{}.n{}", "foo", network.as_byte()));
 
         let expected_hash = hasher.chain_update(b"\x01\x73").finalize();
         let hash = DomainSeparatedConsensusHasher::<TestHashDomain, Blake2b<U32>>::new("foo")

--- a/base_layer/core/src/consensus/consensus_encoding/hashing.rs
+++ b/base_layer/core/src/consensus/consensus_encoding/hashing.rs
@@ -28,6 +28,7 @@ use digest::{
     consts::{U32, U64},
     Digest,
 };
+use tari_common::configuration::CURRENT_NETWORK;
 use tari_crypto::{hash_domain, hashing::DomainSeparation};
 
 /// Domain separated consensus encoding hasher.
@@ -41,8 +42,9 @@ where D: Default
 {
     #[allow(clippy::new_ret_no_self)]
     pub fn new(label: &'static str) -> ConsensusHasher<D> {
+        let network = *CURRENT_NETWORK.lock().unwrap();
         let mut digest = D::default();
-        M::add_domain_separation_tag(&mut digest, label);
+        M::add_domain_separation_tag(&mut digest, &format!("{}.n{}", label, network.as_byte()));
         ConsensusHasher::from_digest(digest)
     }
 }

--- a/base_layer/core/src/proof_of_work/sha3x_pow.rs
+++ b/base_layer/core/src/proof_of_work/sha3x_pow.rs
@@ -100,6 +100,6 @@ pub mod test {
         let mut header = get_header();
         header.nonce = 631;
         println!("{:?}", header);
-        assert_eq!(sha3x_difficulty(&header).unwrap(), Difficulty::from_u64(3347).unwrap());
+        assert_eq!(sha3x_difficulty(&header).unwrap(), Difficulty::from_u64(28).unwrap());
     }
 }

--- a/base_layer/core/src/transactions/transaction_components/test.rs
+++ b/base_layer/core/src/transactions/transaction_components/test.rs
@@ -293,7 +293,7 @@ fn kernel_hash() {
         .unwrap();
     assert_eq!(
         &k.hash().to_hex(),
-        "d99f6c45b0c1051987eb5ce8f4434fbd88ae44c2d0f3a066ebc7f64114d33df8"
+        "38b03d013f941e86c027969fbbc190ca2a28fa2d7ac075d50dbfb6232deee646"
     );
 }
 
@@ -312,7 +312,7 @@ fn kernel_metadata() {
         .unwrap();
     assert_eq!(
         &k.hash().to_hex(),
-        "ee7ff5ebcdc66757411afb2dced7d1bd7c09373f1717a7b6eb618fbda849ab4d"
+        "ebc852fbac798c25ce497b416f69ec11a97e186aacaa10e2bb4ca5f5a0f197f2"
     )
 }
 

--- a/base_layer/tari_mining_helper_ffi/src/lib.rs
+++ b/base_layer/tari_mining_helper_ffi/src/lib.rs
@@ -386,8 +386,8 @@ mod tests {
 
     #[test]
     fn detect_change_in_consensus_encoding() {
-        const NONCE: u64 = 9517441887467162514;
-        let difficulty = Difficulty::from_u64(5354).expect("Failed to create difficulty");
+        const NONCE: u64 = 16685442580080948032;
+        let difficulty = Difficulty::from_u64(1828).expect("Failed to create difficulty");
         unsafe {
             let mut error = -1;
             let error_ptr = &mut error as *mut c_int;

--- a/base_layer/tari_mining_helper_ffi/src/lib.rs
+++ b/base_layer/tari_mining_helper_ffi/src/lib.rs
@@ -386,8 +386,8 @@ mod tests {
 
     #[test]
     fn detect_change_in_consensus_encoding() {
-        const NONCE: u64 = 15659498815241072292;
-        let difficulty = Difficulty::from_u64(2817).expect("Failed to create difficulty");
+        const NONCE: u64 = 9517441887467162514;
+        let difficulty = Difficulty::from_u64(5354).expect("Failed to create difficulty");
         unsafe {
             let mut error = -1;
             let error_ptr = &mut error as *mut c_int;

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -34,6 +34,7 @@ structopt = { version = "0.3.13", default_features = false }
 tempfile = "3.1.0"
 thiserror = "1.0.29"
 toml = { version = "0.5", optional = true }
+once_cell = "1.18.0"
 
 [dev-dependencies]
 tari_test_utils = {  path = "../infrastructure/test_utils"}

--- a/common/src/configuration/mod.rs
+++ b/common/src/configuration/mod.rs
@@ -41,7 +41,7 @@ pub mod bootstrap;
 pub mod error;
 pub mod loader;
 mod network;
-pub use network::Network;
+pub use network::{Network, CURRENT_NETWORK};
 mod common_config;
 mod multiaddr_list;
 pub mod name_server;

--- a/common/src/configuration/network.rs
+++ b/common/src/configuration/network.rs
@@ -25,11 +25,17 @@ use std::{
     fmt,
     fmt::{Display, Formatter},
     str::FromStr,
+    sync::Mutex,
 };
 
 use serde::{Deserialize, Serialize};
+use structopt::lazy_static::lazy_static;
 
 use crate::ConfigurationError;
+
+lazy_static! {
+    pub static ref CURRENT_NETWORK: Mutex<Network> = Mutex::new(Network::default());
+}
 
 /// Represents the available Tari p2p networks. Only nodes with matching byte values will be able to connect, so these
 /// should never be changed once released.

--- a/common/src/configuration/network.rs
+++ b/common/src/configuration/network.rs
@@ -28,14 +28,12 @@ use std::{
     sync::Mutex,
 };
 
+use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
-use structopt::lazy_static::lazy_static;
 
 use crate::ConfigurationError;
 
-lazy_static! {
-    pub static ref CURRENT_NETWORK: Mutex<Network> = Mutex::new(Network::default());
-}
+pub static CURRENT_NETWORK: Lazy<Mutex<Network>> = Lazy::new(|| Mutex::new(Network::default()));
 
 /// Represents the available Tari p2p networks. Only nodes with matching byte values will be able to connect, so these
 /// should never be changed once released.

--- a/integration_tests/tests/steps/node_steps.rs
+++ b/integration_tests/tests/steps/node_steps.rs
@@ -687,7 +687,7 @@ async fn no_meddling_with_data(world: &mut TariWorld, node: String) {
         Ok(_) => panic!("The block should not have been valid"),
         Err(e) => assert_eq!(
             "Chain storage error: Validation error: Block validation error: MMR size for Kernel does not match. \
-             Expected: 3, received: 4"
+             Expected: 2, received: 3"
                 .to_string(),
             e.message()
         ),

--- a/integration_tests/tests/steps/node_steps.rs
+++ b/integration_tests/tests/steps/node_steps.rs
@@ -712,7 +712,7 @@ async fn no_meddling_with_data(world: &mut TariWorld, node: String) {
         Ok(_) => panic!("The block should not have been valid"),
         Err(e) => assert_eq!(
             "Chain storage error: Validation error: Block validation error: MMR size for UTXO does not match. \
-             Expected: 457, received: 458"
+             Expected: 2, received: 3"
                 .to_string(),
             e.message()
         ),


### PR DESCRIPTION
Description
---
Add a lazy static value that allows us to access what the current network is globally, so we can use the network byte to create network & domain-specific hashers.

Motivation and Context
---
This prevents the spending of duplicated UTXO's across networks as the hashes would compute differently based on the network byte.

Closes: #5652 

How Has This Been Tested?
---
CI

Breaking Changes
---

- [ ] None
- [x] Requires data directory on base node to be deleted
- [x] Requires hard fork
- [x] Other - Please specify

This will invalidate all previous hashes on the network, and require both a network reset, with full data directory deletion.