### PR TITLE
feat: add kdf as optional

### DIFF
--- a/base_layer/core/src/transactions/transaction_components/mod.rs
+++ b/base_layer/core/src/transactions/transaction_components/mod.rs
@@ -85,7 +85,6 @@ pub const MAX_TRANSACTION_RECIPIENTS: usize = 15;
 pub(crate) const AEAD_KEY_LEN: usize = std::mem::size_of::<Key>();
 
 // Type for hiding aead key encryption
-hidden_type!(EncryptedValueKey, SafeArray<u8, AEAD_KEY_LEN>);
 hidden_type!(EncryptedDataKey, SafeArray<u8, AEAD_KEY_LEN>);
 
 //----------------------------------------     Crate functions   ----------------------------------------------------//


### PR DESCRIPTION
Description
---
Added optional KDF calculation for the encrypted data field, when encrypting or decrypting. The interface stayed the same ('EncryptedData::encrypt_data' and 'EncryptedData::decrypt_data'), but additional interfaces 'EncryptedData::encrypt_data_no_kdf' and 'EncryptedData::decrypt_data_no_kdf' has been added for clients that need optimal code execution. The performance hit to calculate the KDF has been quantified as ~125%.

```
    // This unit test quantifies the performance hit due to calculating a KDF. The flag `do_performance_testing` must be
    // set to `false` otherwise the test will fail; this is to ensure that profiling is not run for CI.
    //
    // Some consecutive results running in release mode on a Core i7-12700H (with no other processes running):
    //
    // Variance:                131.7726303 %
    // Total time no kdf:       971827 microseconds
    // Total time with kdf:     2252429 microseconds
    // Average time no kdf:     3.887308 microseconds
    // Average time with kdf:   9.0097159 microseconds
    //
    // Variance:                114.5347296 %
    // Total time no kdf:       1026156 microseconds
    // Total time with kdf:     2201461 microseconds
    // Average time no kdf:     4.104624 microseconds
    // Average time with kdf:   8.805844 microseconds
    //
    // Variance:                127.8624748 %
    // Total time no kdf:       981144 microseconds
    // Total time with kdf:     2235659 microseconds
    // Average time no kdf:     3.924576 microseconds
    // Average time with kdf:   8.942636 microseconds
```

Motivation and Context
---
See #5393

How Has This Been Tested?
---
All existing unit tests pass
Additional unit testing added

What process can a PR reviewer use to test or verify this change?
---
Code review
Unit tests

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
