### PR TITLE
test: fix cucumber merge mining tests

### DIFF
--- a/integration_tests/log4rs/cucumber.yml
+++ b/integration_tests/log4rs/cucumber.yml
@@ -107,9 +107,25 @@ appenders:
         kind: fixed_window
         base: 1
         count: 5
-        pattern: "{{log_dir}}/log/miner/miner.{}.log"
+        pattern: "{{log_dir}}/log/miner.{}.log"
     encoder:
-      pattern: "{d(%Y-%m-%d %H:%M:%S.%f)} [{t}] [Thread:{I}] {l:5} {m}{n}"
+      pattern: "{d(%Y-%m-%d %H:%M:%S.%f)} [{X(grpc)}] {f}.{L} {i} [{t}] {l:5} {m}{n}"
+  # An appender named "proxy" that writes to a file with a custom pattern encoder
+  proxy:
+    kind: rolling_file
+    path: "{{log_dir}}/log/proxy.log"
+    policy:
+      kind: compound
+      trigger:
+        kind: size
+        limit: 200mb
+      roller:
+        kind: fixed_window
+        base: 1
+        count: 50
+        pattern: "{{log_dir}}/log/proxy.{}.log"
+    encoder:
+      pattern: "{d(%Y-%m-%d %H:%M:%S.%f)} [{X(grpc)}] {f}.{L} {i} [{t}] {l:5} {m}{n}"
 
 # We don't want prints during cucumber test, everything useful will in logs.
 # root:
@@ -125,6 +141,7 @@ loggers:
       - base_layer_wallet
       - base_layer_base_node
       - miner
+      - proxy
     additive: true
   stdout:
     level: info # we have only single print, and it's info
@@ -167,6 +184,12 @@ loggers:
     level: debug
     appenders:
       - miner
+    additive: false
+  # merge mining proxy
+  minotari_mm_proxy::proxy:
+    level: debug
+    appenders:
+      - proxy
     additive: false
   # Route log events sent to the "comms" logger to the "network" appender
   comms:

--- a/integration_tests/src/merge_mining_proxy.rs
+++ b/integration_tests/src/merge_mining_proxy.rs
@@ -133,10 +133,10 @@ impl MergeMiningProxyProcess {
                             origin_submission.to_string(),
                         ),
                         (
-                            "miner.wallet_payment_address".to_string(),
+                            "merge_mining_proxy.wallet_payment_address".to_string(),
                             wallet_payment_address.to_hex(),
                         ),
-                        ("miner.stealth_payment".to_string(), stealth.to_string()),
+                        ("merge_mining_proxy.stealth_payment".to_string(), stealth.to_string()),
                     ],
                 },
             };

--- a/integration_tests/tests/features/MergeMining.feature
+++ b/integration_tests/tests/features/MergeMining.feature
@@ -4,7 +4,6 @@
 @merge-mining @base-node
 Feature: Merge Mining
 
-  @broken
   Scenario: Merge Mining Functionality Test Without Submitting To Origin
     Given I have a seed node NODE
     When I have wallet WALLET connected to all seed nodes
@@ -17,7 +16,6 @@ Feature: Merge Mining
     When I submit a block through proxy PROXY
     Then Proxy response block submission is valid without submitting to origin
 
-  @broken
   Scenario: Merge Mining Functionality Test With Submitting To Origin
     Given I have a seed node NODE
     When I have wallet WALLET connected to all seed nodes
@@ -33,12 +31,10 @@ Feature: Merge Mining
     When I ask for a block header by hash using last block header from proxy PROXY
     Then Proxy response for block header by hash is valid
 
-  # BROKEN: get_block_template returns error 500
-  @critical @broken
+  @critical
   Scenario: Simple Merge Mining
     Given I have a seed node NODE
     When I have wallet WALLET connected to all seed nodes
     And I have a merge mining proxy PROXY connected to NODE and WALLET with default config
     When I merge mine 2 blocks via PROXY
     Then all nodes are at height 2
-


### PR DESCRIPTION
Description
---
Fixed cucumber "Merge Mining" tests after merging the one-sided coinbase PR; I just fixed one simple thing but all three tests are now working fine.


Motivation and Context
---
The one-sided coinbase PR did not properly initialize the merge mining proxy.

How Has This Been Tested?
---
`cargo test --release --test cucumber -- --name "Merge Mining"`

What process can a PR reviewer use to test or verify this change?
---
`cargo test --release --test cucumber -- --name "Merge Mining"`

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
