### PR TITLE
chore: despam mm proxy logs

### DIFF
--- a/applications/minotari_merge_mining_proxy/src/proxy.rs
+++ b/applications/minotari_merge_mining_proxy/src/proxy.rs
@@ -164,7 +164,7 @@ struct InnerService {
 }
 
 impl InnerService {
-    #[instrument]
+    #[instrument(level = "trace")]
     #[allow(clippy::cast_possible_wrap)]
     async fn handle_get_height(&self, monerod_resp: Response<json::Value>) -> Result<Response<Body>, MmProxyError> {
         let (parts, mut json) = monerod_resp.into_parts();
@@ -177,7 +177,7 @@ impl InnerService {
         }
 
         let mut base_node_client = self.base_node_client.clone();
-        trace!(target: LOG_TARGET, "Successful connection to base node GRPC");
+        info!(target: LOG_TARGET, "Successful connection to base node GRPC");
 
         let result =
             base_node_client
@@ -203,7 +203,7 @@ impl InnerService {
             );
         }
 
-        debug!(
+        info!(
             target: LOG_TARGET,
             "Monero height = #{}, Minotari base node height = #{}", json["height"], height
         );

--- a/base_layer/core/src/base_node/sync/rpc/service.rs
+++ b/base_layer/core/src/base_node/sync/rpc/service.rs
@@ -371,7 +371,7 @@ impl<B: BlockchainBackend + 'static> BaseNodeSyncService for BaseNodeSyncRpcServ
         Ok(Streaming::new(rx))
     }
 
-    #[instrument(skip(self), err)]
+    #[instrument(level = "trace", skip(self), err)]
     async fn get_header_by_height(
         &self,
         request: Request<u64>,
@@ -450,7 +450,7 @@ impl<B: BlockchainBackend + 'static> BaseNodeSyncService for BaseNodeSyncRpcServ
         }
     }
 
-    #[instrument(skip(self), err)]
+    #[instrument(level = "trace", skip(self), err)]
     async fn get_chain_metadata(&self, _: Request<()>) -> Result<Response<proto::base_node::ChainMetadata>, RpcStatus> {
         let chain_metadata = self
             .db()
@@ -460,7 +460,7 @@ impl<B: BlockchainBackend + 'static> BaseNodeSyncService for BaseNodeSyncRpcServ
         Ok(Response::new(chain_metadata.into()))
     }
 
-    #[instrument(skip(self), err)]
+    #[instrument(level = "trace", skip(self), err)]
     async fn sync_kernels(
         &self,
         request: Request<SyncKernelsRequest>,
@@ -586,7 +586,7 @@ impl<B: BlockchainBackend + 'static> BaseNodeSyncService for BaseNodeSyncRpcServ
         Ok(Streaming::new(rx))
     }
 
-    #[instrument(skip(self), err)]
+    #[instrument(level = "trace", skip(self), err)]
     async fn sync_utxos(&self, request: Request<SyncUtxosRequest>) -> Result<Streaming<SyncUtxosResponse>, RpcStatus> {
         let req = request.message();
         let peer_node_id = request.context().peer_node_id();

--- a/comms/core/src/protocol/rpc/server/mod.rs
+++ b/comms/core/src/protocol/rpc/server/mod.rs
@@ -605,7 +605,7 @@ where
         Ok(())
     }
 
-    #[instrument(name = "rpc::server::handle_req", skip(self, request), err, fields(request_size = request.len()))]
+    #[instrument(name = "rpc::server::handle_req", level="trace", skip(self, request), err, fields(request_size = request.len ()))]
     async fn handle_request(&mut self, mut request: Bytes) -> Result<(), RpcServerError> {
         let decoded_msg = proto::rpc::RpcRequest::decode(&mut request)?;
 


### PR DESCRIPTION
The MM proxy logs are completely blotted at the info level by instrumentation calls, rendering them effectively useless at the info level.

This moves instrumentation down to DEBUG and TRACE levels, so they're still available, without spamming hundreds of MB in user-facing logs.

What process can a PR reviewer use to test or verify this change?
---

Logs will be much cleaner at INFO level now,

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
