### PR TITLE
fix(shutdown): is_triggered returns up-to-date value without first polling

### DIFF
--- a/infrastructure/shutdown/src/oneshot_trigger.rs
+++ b/infrastructure/shutdown/src/oneshot_trigger.rs
@@ -90,7 +90,7 @@ impl<T: Clone> Future for OneshotSignal<T> {
     type Output = Option<T>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        if self.inner.is_terminated() {
+        if self.is_terminated() {
             return Poll::Ready(None);
         }
 


### PR DESCRIPTION
Description
---

fix: always return correct value from is_triggered without first requiring the signal to be polled

Motivation and Context
---
OneshotSignal uses the `futures::Shared<Fut>` combinator to allow a single future to be cloned and awaited on in multiple places. Previously we used FuseFuture::is_terminated to determine if the signal is triggered. However the semantics of is_terminated and is_triggered are subtly different. is_terminated indicates whether a future should be polled again, which is true even if the trigger has fired. 

This PR uses an AtomicBool that is set to true at the time the trigger is fired so that polling first is not required.

Thanks to @hansieodendaal for discovering this issue

How Has This Been Tested?
---
Updated existing test to check is_triggered, previously failed and now passes.

What process can a PR reviewer use to test or verify this change?
---
N/A

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
