### PR TITLE
chore: refactor current network handling and add test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5594,7 +5594,6 @@ dependencies = [
  "log",
  "log4rs",
  "multiaddr",
- "once_cell",
  "path-clean",
  "prost-build",
  "serde",

--- a/applications/minotari_app_utilities/src/network_check.rs
+++ b/applications/minotari_app_utilities/src/network_check.rs
@@ -20,10 +20,8 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::sync::{MutexGuard, PoisonError};
-
 use tari_common::{
-    configuration::{Network, CURRENT_NETWORK},
+    configuration::Network,
     exit_codes::{ExitCode, ExitError},
 };
 use tari_features::resolver::Target;
@@ -37,8 +35,11 @@ pub enum NetworkCheckError {
     NextNetBinary(Network),
     #[error("The network {0} is invalid for this binary built for TestNet")]
     TestNetBinary(Network),
-    #[error("Had a problem with the CURRENT_NETWORK guard: {0}")]
-    CurrentNetworkGuard(#[from] PoisonError<MutexGuard<'static, Network>>),
+    #[error("Could not set the network, tried to set to {attempted} but the current network is {current_network}")]
+    CouldNotSetNetwork {
+        attempted: Network,
+        current_network: Network,
+    },
 }
 
 impl From<NetworkCheckError> for ExitError {
@@ -71,11 +72,10 @@ pub fn is_network_choice_valid(network: Network) -> Result<Network, NetworkCheck
 
 pub fn set_network_if_choice_valid(network: Network) -> Result<(), NetworkCheckError> {
     match is_network_choice_valid(network) {
-        Ok(network) => {
-            let mut current_network = CURRENT_NETWORK.lock()?;
-            *current_network = network;
-            Ok(())
-        },
+        Ok(network) => Network::set_current(network).map_err(|instead_network| NetworkCheckError::CouldNotSetNetwork {
+            attempted: network,
+            current_network: instead_network,
+        }),
         Err(e) => Err(e),
     }
 }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -34,7 +34,6 @@ structopt = { version = "0.3.13", default_features = false }
 tempfile = "3.1.0"
 thiserror = "1.0.29"
 toml = { version = "0.5", optional = true }
-once_cell = "1.18.0"
 
 [dev-dependencies]
 tari_test_utils = {  path = "../infrastructure/test_utils"}

--- a/common/src/configuration/mod.rs
+++ b/common/src/configuration/mod.rs
@@ -41,7 +41,7 @@ pub mod bootstrap;
 pub mod error;
 pub mod loader;
 mod network;
-pub use network::{Network, CURRENT_NETWORK};
+pub use network::Network;
 mod common_config;
 mod multiaddr_list;
 pub mod name_server;

--- a/common/src/configuration/network.rs
+++ b/common/src/configuration/network.rs
@@ -25,15 +25,14 @@ use std::{
     fmt,
     fmt::{Display, Formatter},
     str::FromStr,
-    sync::Mutex,
+    sync::OnceLock,
 };
 
-use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 
 use crate::ConfigurationError;
 
-pub static CURRENT_NETWORK: Lazy<Mutex<Network>> = Lazy::new(|| Mutex::new(Network::default()));
+static CURRENT_NETWORK: OnceLock<Network> = OnceLock::new();
 
 /// Represents the available Tari p2p networks. Only nodes with matching byte values will be able to connect, so these
 /// should never be changed once released.
@@ -50,6 +49,17 @@ pub enum Network {
 }
 
 impl Network {
+    pub fn get_current_or_default() -> Self {
+        match CURRENT_NETWORK.get() {
+            Some(&network) => network,
+            None => Network::default(),
+        }
+    }
+
+    pub fn set_current(network: Network) -> Result<(), Network> {
+        CURRENT_NETWORK.set(network)
+    }
+
     pub fn as_byte(self) -> u8 {
         self as u8
     }


### PR DESCRIPTION
Description
---
Refactors the handling of network-based hashing operations introduced in #5980 to better handle read operations. Adds a sanity test for hash independence.

Supersedes #6014.

Closes #6003.

Motivation and Context
---
Recent work in #5980 binds the current network into consensus hashing. It uses a `Mutex`, which has two subtle issues. First, it allows the network to be set multiple times, which should not occur. Second, it locks on reads, which is unnecessary and inefficient.

This PR updates how the current network is handled. It adds `Network::get_current_or_default` that will return either the current network (if it has been set) or the default network (if it has not). It adds `Network:set_current` that attempts to set the network; if it has been set before, this operation will fail. Note that calling `Network::get_current_or_default` does _not_ set the network for this purpose.

It modifies the API for consensus hashing to add a wrapper that uses the current network. This wraps functionality allowing for specification of a network, which is useful for testing.

On top of this new API, a new test is added that checks for distinct hashes using the same input but different networks. This is not comprehensive, but will detect obvious issues.

How Has This Been Tested?
---
Existing tests pass. A new test passes.

What process can a PR reviewer use to test or verify this change?
---
Check that the tests do what they claim. Check that the updates to consensus hashing properly introduce the expected wrapping functionality. Check that the updated network API does what it is supposed to.