### PR TITLE
feat!: update status

### DIFF
--- a/applications/minotari_app_grpc/proto/wallet.proto
+++ b/applications/minotari_app_grpc/proto/wallet.proto
@@ -214,13 +214,17 @@ enum TransactionStatus {
     // The transaction was rejected by the mempool
     TRANSACTION_STATUS_REJECTED = 7;
     // This is faux transaction mainly for one-sided transaction outputs or wallet recovery outputs have been found
-    TRANSACTION_STATUS_FAUX_UNCONFIRMED = 8;
+    TRANSACTION_STATUS_ONE_SIDED_UNCONFIRMED = 8;
     // All Imported and FauxUnconfirmed transactions will end up with this status when the outputs have been confirmed
-    TRANSACTION_STATUS_FAUX_CONFIRMED = 9;
+    TRANSACTION_STATUS_ONE_SIDED_CONFIRMED = 9;
     // This transaction is still being queued for sending
     TRANSACTION_STATUS_QUEUED = 10;
     // The transaction was not found by the wallet its in transaction database
     TRANSACTION_STATUS_NOT_FOUND = 11;
+    // This is Coinbase transaction that is detected from chain
+    TRANSACTION_STATUS_COINBASE_UNCONFIRMED = 12;
+    // This is Coinbase transaction that is detected from chain
+    TRANSACTION_STATUS_COINBASE_CONFIRMED = 13;
 }
 
 message GetCompletedTransactionsRequest { }

--- a/applications/minotari_app_grpc/src/conversions/transaction.rs
+++ b/applications/minotari_app_grpc/src/conversions/transaction.rs
@@ -100,8 +100,10 @@ impl From<TransactionStatus> for grpc::TransactionStatus {
             Coinbase => grpc::TransactionStatus::Coinbase,
             MinedConfirmed => grpc::TransactionStatus::MinedConfirmed,
             Rejected => grpc::TransactionStatus::Rejected,
-            FauxUnconfirmed => grpc::TransactionStatus::FauxUnconfirmed,
-            FauxConfirmed => grpc::TransactionStatus::FauxConfirmed,
+            OneSidedUnconfirmed => grpc::TransactionStatus::OneSidedUnconfirmed,
+            OneSidedConfirmed => grpc::TransactionStatus::OneSidedConfirmed,
+            CoinbaseUnconfirmed => grpc::TransactionStatus::CoinbaseUnconfirmed,
+            CoinbaseConfirmed => grpc::TransactionStatus::CoinbaseConfirmed,
             Queued => grpc::TransactionStatus::Queued,
         }
     }

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -682,8 +682,8 @@ impl wallet_server::Wallet for WalletGrpcServer {
                                             }
                                         },
                                         ReceivedFinalizedTransaction(tx_id) => handle_completed_tx(tx_id, RECEIVED, &mut transaction_service, &mut sender).await,
-                                        TransactionMinedUnconfirmed{tx_id, num_confirmations: _, is_valid: _} | FauxTransactionUnconfirmed{tx_id, num_confirmations: _, is_valid: _}=> handle_completed_tx(tx_id, CONFIRMATION, &mut transaction_service, &mut sender).await,
-                                        TransactionMined{tx_id, is_valid: _} | FauxTransactionConfirmed{tx_id, is_valid: _} => handle_completed_tx(tx_id, MINED, &mut transaction_service, &mut sender).await,
+                                        TransactionMinedUnconfirmed{tx_id, num_confirmations: _, is_valid: _} | DetectedTransactionUnconfirmed{tx_id, num_confirmations: _, is_valid: _}=> handle_completed_tx(tx_id, CONFIRMATION, &mut transaction_service, &mut sender).await,
+                                        TransactionMined{tx_id, is_valid: _} | DetectedTransactionConfirmed{tx_id, is_valid: _} => handle_completed_tx(tx_id, MINED, &mut transaction_service, &mut sender).await,
                                         TransactionCancelled(tx_id, _) => {
                                             match transaction_service.get_any_transaction(tx_id).await{
                                                 Ok(Some(wallet_tx)) => {

--- a/applications/minotari_console_wallet/src/ui/state/wallet_event_monitor.rs
+++ b/applications/minotari_console_wallet/src/ui/state/wallet_event_monitor.rs
@@ -109,7 +109,7 @@ impl WalletEventMonitor {
                                     ).await;
                                 },
                                 TransactionEvent::TransactionMinedUnconfirmed{tx_id, num_confirmations, is_valid: _}  |
-                                TransactionEvent::FauxTransactionUnconfirmed{tx_id, num_confirmations, is_valid: _}=> {
+                                TransactionEvent::DetectedTransactionUnconfirmed{tx_id, num_confirmations, is_valid: _}=> {
                                     self.trigger_confirmations_refresh(tx_id, num_confirmations).await;
                                     self.trigger_tx_state_refresh(tx_id).await;
                                     self.trigger_balance_refresh();
@@ -123,7 +123,7 @@ impl WalletEventMonitor {
                                     ).await;
                                 },
                                 TransactionEvent::TransactionMined{tx_id, is_valid: _} |
-                                TransactionEvent::FauxTransactionConfirmed{tx_id, is_valid: _}=> {
+                                TransactionEvent::DetectedTransactionConfirmed{tx_id, is_valid: _}=> {
                                     self.trigger_confirmations_cleanup(tx_id).await;
                                     self.trigger_tx_state_refresh(tx_id).await;
                                     self.trigger_balance_refresh();

--- a/base_layer/wallet/src/transaction_service/handle.rs
+++ b/base_layer/wallet/src/transaction_service/handle.rs
@@ -302,12 +302,12 @@ pub enum TransactionEvent {
     TransactionCancelled(TxId, TxCancellationReason),
     TransactionBroadcast(TxId),
     TransactionImported(TxId),
-    FauxTransactionUnconfirmed {
+    DetectedTransactionUnconfirmed {
         tx_id: TxId,
         num_confirmations: u64,
         is_valid: bool,
     },
-    FauxTransactionConfirmed {
+    DetectedTransactionConfirmed {
         tx_id: TxId,
         is_valid: bool,
     },
@@ -360,19 +360,19 @@ impl fmt::Display for TransactionEvent {
             TransactionEvent::TransactionImported(tx) => {
                 write!(f, "TransactionImported for {tx}")
             },
-            TransactionEvent::FauxTransactionUnconfirmed {
+            TransactionEvent::DetectedTransactionUnconfirmed {
                 tx_id,
                 num_confirmations,
                 is_valid,
             } => {
                 write!(
                     f,
-                    "FauxTransactionUnconfirmed for {tx_id} with num confirmations: {num_confirmations}. is_valid: \
-                     {is_valid}"
+                    "DetectedTransactionUnconfirmed for {tx_id} with num confirmations: {num_confirmations}. \
+                     is_valid: {is_valid}"
                 )
             },
-            TransactionEvent::FauxTransactionConfirmed { tx_id, is_valid } => {
-                write!(f, "FauxTransactionConfirmed for {tx_id}. is_valid: {is_valid}")
+            TransactionEvent::DetectedTransactionConfirmed { tx_id, is_valid } => {
+                write!(f, "DetectedTransactionConfirmed for {tx_id}. is_valid: {is_valid}")
             },
             TransactionEvent::TransactionMined { tx_id, is_valid } => {
                 write!(f, "TransactionMined for {tx_id}. is_valid: {is_valid}")

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_validation_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_validation_protocol.rs
@@ -371,18 +371,18 @@ where
                 mined_timestamp,
                 num_confirmations,
                 num_confirmations >= self.config.num_confirmations_required,
-                status.is_faux(),
+                status,
             )
             .for_protocol(self.operation_id)?;
 
         if num_confirmations >= self.config.num_confirmations_required {
-            if status.is_faux() {
-                self.publish_event(TransactionEvent::FauxTransactionConfirmed { tx_id, is_valid: true })
+            if status.is_coinbase() || status.is_imported_from_chain() {
+                self.publish_event(TransactionEvent::DetectedTransactionConfirmed { tx_id, is_valid: true })
             } else {
                 self.publish_event(TransactionEvent::TransactionMined { tx_id, is_valid: true })
             }
-        } else if status.is_faux() {
-            self.publish_event(TransactionEvent::FauxTransactionUnconfirmed {
+        } else if status.is_coinbase() || status.is_imported_from_chain() {
+            self.publish_event(TransactionEvent::DetectedTransactionUnconfirmed {
                 tx_id,
                 num_confirmations,
                 is_valid: true,

--- a/base_layer/wallet/src/transaction_service/storage/database.rs
+++ b/base_layer/wallet/src/transaction_service/storage/database.rs
@@ -131,7 +131,7 @@ pub trait TransactionBackend: Send + Sync + Clone {
         mined_timestamp: u64,
         num_confirmations: u64,
         must_be_confirmed: bool,
-        is_faux: bool,
+        status: &TransactionStatus,
     ) -> Result<(), TransactionStorageError>;
     /// Clears the mined block and height of a transaction
     fn set_transaction_as_unmined(&self, tx_id: TxId) -> Result<(), TransactionStorageError>;
@@ -142,8 +142,8 @@ pub trait TransactionBackend: Send + Sync + Clone {
         &self,
     ) -> Result<Vec<InboundTransactionSenderInfo>, TransactionStorageError>;
     fn fetch_imported_transactions(&self) -> Result<Vec<CompletedTransaction>, TransactionStorageError>;
-    fn fetch_unconfirmed_faux_transactions(&self) -> Result<Vec<CompletedTransaction>, TransactionStorageError>;
-    fn fetch_confirmed_faux_transactions_from_height(
+    fn fetch_unconfirmed_detected_transactions(&self) -> Result<Vec<CompletedTransaction>, TransactionStorageError>;
+    fn fetch_confirmed_detected_transactions_from_height(
         &self,
         height: u64,
     ) -> Result<Vec<CompletedTransaction>, TransactionStorageError>;
@@ -416,16 +416,16 @@ where T: TransactionBackend + 'static
         Ok(t)
     }
 
-    pub fn get_unconfirmed_faux_transactions(&self) -> Result<Vec<CompletedTransaction>, TransactionStorageError> {
-        let t = self.db.fetch_unconfirmed_faux_transactions()?;
+    pub fn get_unconfirmed_detected_transactions(&self) -> Result<Vec<CompletedTransaction>, TransactionStorageError> {
+        let t = self.db.fetch_unconfirmed_detected_transactions()?;
         Ok(t)
     }
 
-    pub fn get_confirmed_faux_transactions_from_height(
+    pub fn get_confirmed_detected_transactions_from_height(
         &self,
         height: u64,
     ) -> Result<Vec<CompletedTransaction>, TransactionStorageError> {
-        let t = self.db.fetch_confirmed_faux_transactions_from_height(height)?;
+        let t = self.db.fetch_confirmed_detected_transactions_from_height(height)?;
         Ok(t)
     }
 
@@ -695,7 +695,7 @@ where T: TransactionBackend + 'static
         mined_timestamp: u64,
         num_confirmations: u64,
         must_be_confirmed: bool,
-        is_faux: bool,
+        status: &TransactionStatus,
     ) -> Result<(), TransactionStorageError> {
         self.db.update_mined_height(
             tx_id,
@@ -704,7 +704,7 @@ where T: TransactionBackend + 'static
             mined_timestamp,
             num_confirmations,
             must_be_confirmed,
-            is_faux,
+            status,
         )
     }
 

--- a/base_layer/wallet/src/utxo_scanner_service/utxo_scanner_task.rs
+++ b/base_layer/wallet/src/utxo_scanner_service/utxo_scanner_task.rs
@@ -594,7 +594,10 @@ where
                             ImportStatus::CoinbaseUnconfirmed,
                         )
                     } else {
-                        (self.resources.recovery_message.clone(), ImportStatus::OneSidedUnconfirmed)
+                        (
+                            self.resources.recovery_message.clone(),
+                            ImportStatus::OneSidedUnconfirmed,
+                        )
                     };
                     let output = outputs.iter().find(|o| o.hash() == ro.hash).ok_or_else(|| {
                         UtxoScannerError::UtxoScanningError(format!("Output '{}' not found", ro.hash.to_hex()))

--- a/base_layer/wallet/tests/transaction_service_tests/service.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/service.rs
@@ -5200,7 +5200,7 @@ async fn test_update_faux_tx_on_oms_validation() {
             MicroMinotari::from(20000),
             alice_address.clone(),
             "one-sided 1".to_string(),
-            ImportStatus::FauxUnconfirmed,
+            ImportStatus::OneSidedUnconfirmed,
             None,
             None,
             None,
@@ -5216,7 +5216,7 @@ async fn test_update_faux_tx_on_oms_validation() {
             MicroMinotari::from(30000),
             alice_address,
             "one-sided 2".to_string(),
-            ImportStatus::FauxConfirmed,
+            ImportStatus::OneSidedConfirmed,
             None,
             None,
             None,
@@ -5251,14 +5251,14 @@ async fn test_update_faux_tx_on_oms_validation() {
         }
         if tx_id == tx_id_2 {
             if let WalletTransaction::Completed(tx) = &transaction {
-                assert_eq!(tx.status, TransactionStatus::FauxUnconfirmed);
+                assert_eq!(tx.status, TransactionStatus::OneSidedUnconfirmed);
             } else {
                 panic!("Should find a complete FauxUnconfirmed transaction");
             }
         }
         if tx_id == tx_id_3 {
             if let WalletTransaction::Completed(tx) = &transaction {
-                assert_eq!(tx.status, TransactionStatus::FauxConfirmed);
+                assert_eq!(tx.status, TransactionStatus::OneSidedConfirmed);
             } else {
                 panic!("Should find a complete FauxConfirmed transaction");
             }
@@ -5284,13 +5284,13 @@ async fn test_update_faux_tx_on_oms_validation() {
                 .unwrap()
                 .unwrap();
             if let WalletTransaction::Completed(tx) = transaction {
-                if tx_id == tx_id_1 && tx.status == TransactionStatus::FauxUnconfirmed && !found_imported {
+                if tx_id == tx_id_1 && tx.status == TransactionStatus::OneSidedUnconfirmed && !found_imported {
                     found_imported = true;
                 }
-                if tx_id == tx_id_2 && tx.status == TransactionStatus::FauxUnconfirmed && !found_faux_unconfirmed {
+                if tx_id == tx_id_2 && tx.status == TransactionStatus::OneSidedUnconfirmed && !found_faux_unconfirmed {
                     found_faux_unconfirmed = true;
                 }
-                if tx_id == tx_id_3 && tx.status == TransactionStatus::FauxConfirmed && !found_faux_confirmed {
+                if tx_id == tx_id_3 && tx.status == TransactionStatus::OneSidedConfirmed && !found_faux_confirmed {
                     found_faux_confirmed = true;
                 }
             }

--- a/base_layer/wallet/tests/utxo_scanner/mod.rs
+++ b/base_layer/wallet/tests/utxo_scanner/mod.rs
@@ -957,7 +957,7 @@ async fn test_utxo_scanner_one_sided_payments() {
             scanned_output: _,
         } = req
         {
-            assert_eq!(message, "one-sided non-default".to_string());
+            assert_eq!(message, "Output found on blockchain during Wallet Recovery".to_string());
         }
     }
 
@@ -1056,7 +1056,7 @@ async fn test_utxo_scanner_one_sided_payments() {
         } = req
         {
             println!("{:?}", h);
-            assert_eq!(message, "new one-sided message".to_string());
+            assert_eq!(message, "Output found on blockchain during Wallet Recovery".to_string());
         }
     }
 }

--- a/base_layer/wallet_ffi/src/callback_handler.rs
+++ b/base_layer/wallet_ffi/src/callback_handler.rs
@@ -277,11 +277,11 @@ where TBackend: TransactionBackend + 'static
                                     self.receive_transaction_mined_unconfirmed_event(tx_id, num_confirmations);
                                     self.trigger_balance_refresh().await;
                                 },
-                                TransactionEvent::FauxTransactionConfirmed{tx_id, is_valid: _} => {
+                                TransactionEvent::DetectedTransactionConfirmed{tx_id, is_valid: _} => {
                                     self.receive_faux_transaction_confirmed_event(tx_id);
                                     self.trigger_balance_refresh().await;
                                 },
-                                TransactionEvent::FauxTransactionUnconfirmed{tx_id, num_confirmations, is_valid: _} => {
+                                TransactionEvent::DetectedTransactionUnconfirmed{tx_id, num_confirmations, is_valid: _} => {
                                     self.receive_faux_transaction_unconfirmed_event(tx_id, num_confirmations);
                                     self.trigger_balance_refresh().await;
                                 },

--- a/base_layer/wallet_ffi/src/callback_handler_tests.rs
+++ b/base_layer/wallet_ffi/src/callback_handler_tests.rs
@@ -384,7 +384,7 @@ mod test {
                 PrivateKey::default(),
                 PrivateKey::default(),
             ),
-            TransactionStatus::FauxUnconfirmed,
+            TransactionStatus::OneSidedUnconfirmed,
             "6".to_string(),
             Utc::now().naive_utc(),
             TransactionDirection::Inbound,
@@ -416,7 +416,7 @@ mod test {
                 PrivateKey::default(),
                 PrivateKey::default(),
             ),
-            TransactionStatus::FauxConfirmed,
+            TransactionStatus::OneSidedConfirmed,
             "7".to_string(),
             Utc::now().naive_utc(),
             TransactionDirection::Inbound,
@@ -748,7 +748,7 @@ mod test {
         mock_output_manager_service_state.set_balance(balance.clone());
         // Balance updated should be detected with following event, total = 6 times
         transaction_event_sender
-            .send(Arc::new(TransactionEvent::FauxTransactionUnconfirmed {
+            .send(Arc::new(TransactionEvent::DetectedTransactionUnconfirmed {
                 tx_id: 6u64.into(),
                 num_confirmations: 2,
                 is_valid: true,
@@ -771,7 +771,7 @@ mod test {
         mock_output_manager_service_state.set_balance(balance.clone());
         // Balance updated should be detected with following event, total = 7 times
         transaction_event_sender
-            .send(Arc::new(TransactionEvent::FauxTransactionConfirmed {
+            .send(Arc::new(TransactionEvent::DetectedTransactionConfirmed {
                 tx_id: 7u64.into(),
                 is_valid: true,
             }))

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -8737,7 +8737,7 @@ mod test {
             type_of((*tx).clone()),
             std::any::type_name::<TariCompletedTransaction>()
         );
-        assert_eq!((*tx).status, TransactionStatus::FauxConfirmed);
+        assert_eq!((*tx).status, TransactionStatus::OneSidedConfirmed);
         let mut lock = CALLBACK_STATE_FFI.lock().unwrap();
         lock.scanned_tx_callback_called = true;
         drop(lock);
@@ -8750,7 +8750,7 @@ mod test {
             type_of((*tx).clone()),
             std::any::type_name::<TariCompletedTransaction>()
         );
-        assert_eq!((*tx).status, TransactionStatus::FauxUnconfirmed);
+        assert_eq!((*tx).status, TransactionStatus::OneSidedUnconfirmed);
         let mut lock = CALLBACK_STATE_FFI.lock().unwrap();
         lock.scanned_tx_unconfirmed_callback_called = true;
         let mut error = 0;

--- a/integration_tests/tests/steps/wallet_steps.rs
+++ b/integration_tests/tests/steps/wallet_steps.rs
@@ -190,8 +190,8 @@ async fn wallet_detects_all_txs_as_mined_confirmed(world: &mut TariWorld, wallet
                     grpc::TransactionStatus::Broadcast |
                     grpc::TransactionStatus::MinedUnconfirmed |
                     grpc::TransactionStatus::MinedConfirmed |
-                    grpc::TransactionStatus::FauxUnconfirmed |
-                    grpc::TransactionStatus::FauxConfirmed => {
+                    grpc::TransactionStatus::OneSidedUnconfirmed |
+                    grpc::TransactionStatus::OneSidedConfirmed => {
                         break;
                     },
                     _ => (),
@@ -201,8 +201,8 @@ async fn wallet_detects_all_txs_as_mined_confirmed(world: &mut TariWorld, wallet
                     grpc::TransactionStatus::Broadcast |
                     grpc::TransactionStatus::MinedUnconfirmed |
                     grpc::TransactionStatus::MinedConfirmed |
-                    grpc::TransactionStatus::FauxUnconfirmed |
-                    grpc::TransactionStatus::FauxConfirmed => {
+                    grpc::TransactionStatus::OneSidedUnconfirmed |
+                    grpc::TransactionStatus::OneSidedConfirmed => {
                         break;
                     },
                     _ => (),
@@ -211,8 +211,8 @@ async fn wallet_detects_all_txs_as_mined_confirmed(world: &mut TariWorld, wallet
                     grpc::TransactionStatus::Broadcast |
                     grpc::TransactionStatus::MinedUnconfirmed |
                     grpc::TransactionStatus::MinedConfirmed |
-                    grpc::TransactionStatus::FauxUnconfirmed |
-                    grpc::TransactionStatus::FauxConfirmed => {
+                    grpc::TransactionStatus::OneSidedUnconfirmed |
+                    grpc::TransactionStatus::OneSidedConfirmed => {
                         break;
                     },
                     _ => (),
@@ -220,14 +220,14 @@ async fn wallet_detects_all_txs_as_mined_confirmed(world: &mut TariWorld, wallet
                 "Mined_or_Faux_Unconfirmed" => match tx_info.status() {
                     grpc::TransactionStatus::MinedUnconfirmed |
                     grpc::TransactionStatus::MinedConfirmed |
-                    grpc::TransactionStatus::FauxUnconfirmed |
-                    grpc::TransactionStatus::FauxConfirmed => {
+                    grpc::TransactionStatus::OneSidedUnconfirmed |
+                    grpc::TransactionStatus::OneSidedConfirmed => {
                         break;
                     },
                     _ => (),
                 },
                 "Mined_or_Faux_Confirmed" => match tx_info.status() {
-                    grpc::TransactionStatus::MinedConfirmed | grpc::TransactionStatus::FauxConfirmed => {
+                    grpc::TransactionStatus::MinedConfirmed | grpc::TransactionStatus::OneSidedConfirmed => {
                         break;
                     },
                     _ => (),
@@ -294,8 +294,8 @@ async fn wallet_detects_all_txs_are_at_least_in_some_status(
                     grpc::TransactionStatus::Broadcast |
                     grpc::TransactionStatus::MinedUnconfirmed |
                     grpc::TransactionStatus::MinedConfirmed |
-                    grpc::TransactionStatus::FauxUnconfirmed |
-                    grpc::TransactionStatus::FauxConfirmed => {
+                    grpc::TransactionStatus::OneSidedUnconfirmed |
+                    grpc::TransactionStatus::OneSidedConfirmed => {
                         break;
                     },
                     _ => (),
@@ -305,8 +305,8 @@ async fn wallet_detects_all_txs_are_at_least_in_some_status(
                     grpc::TransactionStatus::Broadcast |
                     grpc::TransactionStatus::MinedUnconfirmed |
                     grpc::TransactionStatus::MinedConfirmed |
-                    grpc::TransactionStatus::FauxUnconfirmed |
-                    grpc::TransactionStatus::FauxConfirmed => {
+                    grpc::TransactionStatus::OneSidedUnconfirmed |
+                    grpc::TransactionStatus::OneSidedConfirmed => {
                         break;
                     },
                     _ => (),
@@ -315,8 +315,8 @@ async fn wallet_detects_all_txs_are_at_least_in_some_status(
                     grpc::TransactionStatus::Broadcast |
                     grpc::TransactionStatus::MinedUnconfirmed |
                     grpc::TransactionStatus::MinedConfirmed |
-                    grpc::TransactionStatus::FauxUnconfirmed |
-                    grpc::TransactionStatus::FauxConfirmed => {
+                    grpc::TransactionStatus::OneSidedUnconfirmed |
+                    grpc::TransactionStatus::OneSidedConfirmed => {
                         break;
                     },
                     _ => (),
@@ -324,8 +324,8 @@ async fn wallet_detects_all_txs_are_at_least_in_some_status(
                 "Mined_or_Faux_Unconfirmed" => match tx_info.status() {
                     grpc::TransactionStatus::MinedUnconfirmed |
                     grpc::TransactionStatus::MinedConfirmed |
-                    grpc::TransactionStatus::FauxUnconfirmed |
-                    grpc::TransactionStatus::FauxConfirmed => {
+                    grpc::TransactionStatus::OneSidedUnconfirmed |
+                    grpc::TransactionStatus::OneSidedConfirmed => {
                         break;
                     },
                     _ => (),
@@ -2707,7 +2707,7 @@ async fn check_if_last_imported_txs_are_valid_in_wallet(world: &mut TariWorld, w
         let tx_info = tx.unwrap().transaction.unwrap();
         for &tx_id in &world.last_imported_tx_ids {
             if tx_id == tx_info.tx_id {
-                assert_eq!(tx_info.status(), grpc::TransactionStatus::FauxConfirmed);
+                assert_eq!(tx_info.status(), grpc::TransactionStatus::OneSidedConfirmed);
                 imported_cnt += 1;
             }
         }


### PR DESCRIPTION
Description
---
Changes statuses of coinbase transactions and one-sided transactions

Motivation and Context
---
Transactions now show as one-sided or coinbase, not Faux anymore. This is more inline of what they are and shows more information to the user.

How Has This Been Tested?
---
manual + unit tests

Breaking Changes
---
Wallet database changes, and requires recovery to keep existing database. 