### PR TITLE
refactor: better network global

### DIFF
--- a/applications/minotari_app_utilities/src/network_check.rs
+++ b/applications/minotari_app_utilities/src/network_check.rs
@@ -79,3 +79,28 @@ pub fn set_network_if_choice_valid(network: Network) -> Result<(), NetworkCheckE
         Err(e) => Err(e),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn set_network() {
+        assert_eq!(*CURRENT_NETWORK.lock().unwrap(), Network::Esmeralda);
+
+        // Invalid networks
+        for network in [Network::MainNet, Network::StageNet, Network::NextNet] {
+            assert!(set_network_if_choice_valid(network).is_err());
+            assert_eq!(*CURRENT_NETWORK.lock().unwrap(), Network::Esmeralda);
+        }
+
+        // Valid networks (we can't test against other binary configurations)
+        for network in [Network::LocalNet, Network::Igor, Network::Esmeralda] {
+            assert!(set_network_if_choice_valid(network).is_ok());
+            assert_eq!(*CURRENT_NETWORK.lock().unwrap(), network);
+        }
+
+        // Ensure we've restored the network for other tests
+        assert_eq!(*CURRENT_NETWORK.lock().unwrap(), Network::Esmeralda);
+    }
+}

--- a/base_layer/core/src/consensus/consensus_encoding/hashing.rs
+++ b/base_layer/core/src/consensus/consensus_encoding/hashing.rs
@@ -175,8 +175,6 @@ mod tests {
         // They should be distinct
         assert_ne!(hash_mainnet, hash_stagenet);
 
-        // Restore the network for other tests
-        //        *CURRENT_NETWORK.lock().unwrap() = Network::Esmeralda;
     }
 
     #[test]

--- a/common/src/configuration/mod.rs
+++ b/common/src/configuration/mod.rs
@@ -41,7 +41,7 @@ pub mod bootstrap;
 pub mod error;
 pub mod loader;
 mod network;
-pub use network::{Network, CURRENT_NETWORK};
+pub use network::Network;
 mod common_config;
 mod multiaddr_list;
 pub mod name_server;

--- a/common/src/configuration/network.rs
+++ b/common/src/configuration/network.rs
@@ -25,15 +25,14 @@ use std::{
     fmt,
     fmt::{Display, Formatter},
     str::FromStr,
-    sync::Mutex,
+    sync::OnceLock,
 };
 
-use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 
 use crate::ConfigurationError;
 
-pub static CURRENT_NETWORK: Lazy<Mutex<Network>> = Lazy::new(|| Mutex::new(Network::default()));
+static CURRENT_NETWORK: OnceLock<Network> = OnceLock::new();
 
 /// Represents the available Tari p2p networks. Only nodes with matching byte values will be able to connect, so these
 /// should never be changed once released.
@@ -50,6 +49,14 @@ pub enum Network {
 }
 
 impl Network {
+    pub fn current() -> Self {
+        *CURRENT_NETWORK.get_or_init(Network::default)
+    }
+
+    pub fn set_current(network: Network) -> Result<(), Network> {
+        CURRENT_NETWORK.set(network)
+    }
+
     pub fn as_byte(self) -> u8 {
         self as u8
     }

--- a/common/src/configuration/network.rs
+++ b/common/src/configuration/network.rs
@@ -54,7 +54,16 @@ impl Network {
     }
 
     pub fn set_current(network: Network) -> Result<(), Network> {
-        CURRENT_NETWORK.set(network)
+        match CURRENT_NETWORK.set(network) {
+            Ok(_) => Ok(()),
+            Err(other) => {
+                if other == network {
+                    Ok(())
+                } else {
+                    Err(other)
+                }
+            }
+        }
     }
 
     pub fn as_byte(self) -> u8 {


### PR DESCRIPTION
Description
---
Removes the mutex and allows tests to run in parallel

Motivation and Context
---
Built on #6004 

The previous versions of these test relied on setting the Network globally. If other tests are running at the same time, these tests can fail because the network is switched. I investigated using ThreadLocalStorage and TaskLocalStorage from tokio, but these could result threads having different networks set and it would be hard to confirm that the entire process was using the correct network.

I opted instead to ignore the `set_network` test and add a parameter to the DomainSeparatedHasher to allow a different network to be tested.


How Has This Been Tested?
---
Ran cargo test

What process can a PR reviewer use to test or verify this change?
---
This fixes tests and provides a cleaner interface

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
