### PR TITLE
fix(chat): chat client possible panics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5579,6 +5579,7 @@ dependencies = [
  "tari_service_framework",
  "tari_shutdown",
  "tari_storage",
+ "thiserror",
 ]
 
 [[package]]

--- a/base_layer/chat_ffi/src/confirmation.rs
+++ b/base_layer/chat_ffi/src/confirmation.rs
@@ -64,9 +64,14 @@ pub unsafe extern "C" fn send_read_confirmation_for_message(
         ptr::swap(error_out, &mut error as *mut c_int);
     }
 
-    (*client)
+    let result = (*client)
         .runtime
         .block_on((*client).client.send_read_receipt((*message).clone()));
+
+    if let Err(e) = result {
+        error = LibChatError::from(InterfaceError::ContactServiceError(e.to_string())).code;
+        ptr::swap(error_out, &mut error as *mut c_int);
+    }
 }
 
 /// Get a pointer to a ChatByteVector representation of the message id associated to the confirmation

--- a/base_layer/chat_ffi/src/conversationalists.rs
+++ b/base_layer/chat_ffi/src/conversationalists.rs
@@ -58,9 +58,16 @@ pub unsafe extern "C" fn get_conversationalists(
         ptr::swap(error_out, &mut error as *mut c_int);
     }
 
-    let conversationalists = (*client).runtime.block_on((*client).client.get_conversationalists());
+    let result = (*client).runtime.block_on((*client).client.get_conversationalists());
 
-    Box::into_raw(Box::new(ConversationalistsVector(conversationalists)))
+    match result {
+        Ok(conversationalists) => Box::into_raw(Box::new(ConversationalistsVector(conversationalists))),
+        Err(e) => {
+            error = LibChatError::from(InterfaceError::ContactServiceError(e.to_string())).code;
+            ptr::swap(error_out, &mut error as *mut c_int);
+            ptr::null_mut()
+        },
+    }
 }
 
 /// Returns the length of the ConversationalistsVector

--- a/base_layer/chat_ffi/src/error.rs
+++ b/base_layer/chat_ffi/src/error.rs
@@ -36,6 +36,8 @@ pub enum InterfaceError {
     AllocationError,
     #[error("An error because the supplied position was out of range")]
     PositionInvalidError,
+    #[error("The client had an error communication with contact services")]
+    ContactServiceError(String),
 }
 
 /// This struct is meant to hold an error for use by FFI client applications. The error has an integer code and string
@@ -68,6 +70,10 @@ impl From<InterfaceError> for LibChatError {
             },
             InterfaceError::InvalidArgument(_) => Self {
                 code: 7,
+                message: format!("{:?}", v),
+            },
+            InterfaceError::ContactServiceError(_) => Self {
+                code: 8,
                 message: format!("{:?}", v),
             },
         }

--- a/base_layer/chat_ffi/src/message.rs
+++ b/base_layer/chat_ffi/src/message.rs
@@ -122,9 +122,14 @@ pub unsafe extern "C" fn send_chat_message(client: *mut ChatClient, message: *mu
         ptr::swap(error_out, &mut error as *mut c_int);
     }
 
-    (*client)
+    let result = (*client)
         .runtime
         .block_on((*client).client.send_message((*message).clone()));
+
+    if let Err(e) = result {
+        error = LibChatError::from(InterfaceError::ContactServiceError(e.to_string())).code;
+        ptr::swap(error_out, &mut error as *mut c_int);
+    }
 }
 
 /// Reads the message metadata of a message and returns a ptr to the metadata at the given position

--- a/base_layer/contacts/src/chat_client/Cargo.toml
+++ b/base_layer/contacts/src/chat_client/Cargo.toml
@@ -27,3 +27,4 @@ diesel = { version = "2.0.3", features = ["sqlite", "r2d2", "serde_json", "chron
 lmdb-zero = "0.4.4"
 log = "0.4.17"
 serde = "1.0.136"
+thiserror = "1.0.50"

--- a/base_layer/contacts/src/chat_client/src/client.rs
+++ b/base_layer/contacts/src/chat_client/src/client.rs
@@ -43,14 +43,14 @@ const LOG_TARGET: &str = "contacts::chat_client";
 
 #[async_trait]
 pub trait ChatClient {
-    async fn add_contact(&self, address: &TariAddress);
+    async fn add_contact(&self, address: &TariAddress) -> Result<(), Error>;
     fn add_metadata(&self, message: Message, metadata_type: MessageMetadataType, data: String) -> Message;
-    async fn check_online_status(&self, address: &TariAddress) -> ContactOnlineStatus;
+    async fn check_online_status(&self, address: &TariAddress) -> Result<ContactOnlineStatus, Error>;
     fn create_message(&self, receiver: &TariAddress, message: String) -> Message;
-    async fn get_messages(&self, sender: &TariAddress, limit: u64, page: u64) -> Vec<Message>;
-    async fn send_message(&self, message: Message);
-    async fn send_read_receipt(&self, message: Message);
-    async fn get_conversationalists(&self) -> Vec<TariAddress>;
+    async fn get_messages(&self, sender: &TariAddress, limit: u64, page: u64) -> Result<Vec<Message>, Error>;
+    async fn send_message(&self, message: Message) -> Result<(), Error>;
+    async fn send_read_receipt(&self, message: Message) -> Result<(), Error>;
+    async fn get_conversationalists(&self) -> Result<Vec<TariAddress>, Error>;
     fn identity(&self) -> &NodeIdentity;
     fn shutdown(&mut self);
 }
@@ -129,59 +129,49 @@ impl ChatClient for Client {
         self.shutdown.trigger();
     }
 
-    async fn add_contact(&self, address: &TariAddress) {
+    async fn add_contact(&self, address: &TariAddress) -> Result<(), Error> {
         if let Some(mut contacts_service) = self.contacts.clone() {
-            contacts_service
-                .upsert_contact(address.into())
-                .await
-                .expect("Contact wasn't added");
-        }
-    }
-
-    async fn check_online_status(&self, address: &TariAddress) -> ContactOnlineStatus {
-        if let Some(mut contacts_service) = self.contacts.clone() {
-            let contact = contacts_service
-                .get_contact(address.clone())
-                .await
-                .expect("Client does not have contact");
-
-            return contacts_service
-                .get_contact_online_status(contact)
-                .await
-                .expect("Failed to get status");
+            contacts_service.upsert_contact(address.into()).await?;
         }
 
-        ContactOnlineStatus::Offline
+        Ok(())
     }
 
-    async fn send_message(&self, message: Message) {
+    async fn check_online_status(&self, address: &TariAddress) -> Result<ContactOnlineStatus, Error> {
         if let Some(mut contacts_service) = self.contacts.clone() {
-            contacts_service
-                .send_message(message)
-                .await
-                .expect("Message wasn't sent");
+            let contact = contacts_service.get_contact(address.clone()).await?;
+
+            return Ok(contacts_service.get_contact_online_status(contact).await?);
         }
+
+        Ok(ContactOnlineStatus::Offline)
     }
 
-    async fn get_messages(&self, sender: &TariAddress, limit: u64, page: u64) -> Vec<Message> {
+    async fn send_message(&self, message: Message) -> Result<(), Error> {
+        if let Some(mut contacts_service) = self.contacts.clone() {
+            contacts_service.send_message(message).await?;
+        }
+
+        Ok(())
+    }
+
+    async fn get_messages(&self, sender: &TariAddress, limit: u64, page: u64) -> Result<Vec<Message>, Error> {
         let mut messages = vec![];
         if let Some(mut contacts_service) = self.contacts.clone() {
-            messages = contacts_service
-                .get_messages(sender.clone(), limit, page)
-                .await
-                .expect("Messages not fetched");
+            messages = contacts_service.get_messages(sender.clone(), limit, page).await?;
         }
 
-        messages
+        Ok(messages)
     }
 
-    async fn send_read_receipt(&self, message: Message) {
+    async fn send_read_receipt(&self, message: Message) -> Result<(), Error> {
         if let Some(mut contacts_service) = self.contacts.clone() {
             contacts_service
                 .send_read_confirmation(message.address.clone(), message.message_id)
-                .await
-                .expect("Read receipt not sent");
+                .await?;
         }
+
+        Ok(())
     }
 
     fn create_message(&self, receiver: &TariAddress, message: String) -> Message {
@@ -198,16 +188,13 @@ impl ChatClient for Client {
         message
     }
 
-    async fn get_conversationalists(&self) -> Vec<TariAddress> {
+    async fn get_conversationalists(&self) -> Result<Vec<TariAddress>, Error> {
         let mut addresses = vec![];
         if let Some(mut contacts_service) = self.contacts.clone() {
-            addresses = contacts_service
-                .get_conversationalists()
-                .await
-                .expect("Addresses from conversations not fetched");
+            addresses = contacts_service.get_conversationalists().await?;
         }
 
-        addresses
+        Ok(addresses)
     }
 }
 

--- a/base_layer/contacts/src/chat_client/src/client.rs
+++ b/base_layer/contacts/src/chat_client/src/client.rs
@@ -37,7 +37,7 @@ use tari_contacts::contacts_service::{
 };
 use tari_shutdown::Shutdown;
 
-use crate::{config::ApplicationConfig, error::ChatClientError, networking};
+use crate::{config::ApplicationConfig, error::Error, networking};
 
 const LOG_TARGET: &str = "contacts::chat_client";
 
@@ -88,14 +88,14 @@ impl Client {
         }
     }
 
-    pub async fn initialize(&mut self) -> Result<(), ChatClientError> {
+    pub async fn initialize(&mut self) -> Result<(), Error> {
         debug!(target: LOG_TARGET, "initializing chat");
 
         let signal = self.shutdown.to_signal();
 
         let (contacts, comms_node) = networking::start(self.identity.clone(), self.config.clone(), signal)
             .await
-            .map_err(|e| ChatClientError::InitializationError(e.to_string()))?;
+            .map_err(|e| Error::InitializationError(e.to_string()))?;
 
         if !self.config.peer_seeds.peer_seeds.is_empty() {
             loop {

--- a/base_layer/contacts/src/chat_client/src/config.rs
+++ b/base_layer/contacts/src/chat_client/src/config.rs
@@ -22,7 +22,6 @@
 
 use std::{
     path::{Path, PathBuf},
-    str::FromStr,
     time::Duration,
 };
 
@@ -115,7 +114,7 @@ impl Default for ChatClientConfig {
             tor_identity_file: PathBuf::from("config/chat_client_tor_id.json"),
             p2p,
             db_type: DatabaseType::Lmdb,
-            db_file: PathBuf::from_str("db/chat_client.db").unwrap(),
+            db_file: PathBuf::from("db/chat_client.db"),
             lmdb: Default::default(),
             data_dir: PathBuf::from("data/chat_client"),
             lmdb_path: PathBuf::from("db"),

--- a/base_layer/contacts/src/chat_client/src/config.rs
+++ b/base_layer/contacts/src/chat_client/src/config.rs
@@ -149,12 +149,10 @@ impl ChatClientConfig {
         if !self.db_file.is_absolute() {
             self.db_file = self.data_dir.join(self.db_file.as_path());
         }
-        if self.log_path.is_some() && !self.log_path.as_ref().expect("There to be a path").is_absolute() {
-            self.log_path = Some(
-                base_path
-                    .as_ref()
-                    .join(self.log_path.as_ref().expect("There to be a path").as_path()),
-            );
+        if let Some(path) = self.log_path.as_ref() {
+            if path.is_absolute() {
+                self.log_path = Some(base_path.as_ref().join(path));
+            }
         }
         self.p2p.set_base_path(base_path);
     }

--- a/base_layer/contacts/src/chat_client/src/error.rs
+++ b/base_layer/contacts/src/chat_client/src/error.rs
@@ -26,6 +26,7 @@ use diesel::ConnectionError;
 use minotari_app_utilities::identity_management::IdentityError;
 use tari_common_sqlite::error::StorageError as SqliteStorageError;
 use tari_comms::peer_manager::PeerManagerError;
+use tari_contacts::contacts_service::error::ContactsServiceError;
 use tari_p2p::initialization::CommsInitializationError;
 use tari_storage::lmdb_store::LMDBError;
 
@@ -35,6 +36,8 @@ pub enum Error {
     InitializationError(String),
     #[error("Networking error: {0}")]
     NetworkingError(#[from] NetworkingError),
+    #[error("The client had a problem communication with the contacts service: {0}")]
+    ContactsServiceError(#[from] ContactsServiceError),
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -63,4 +66,8 @@ pub enum NetworkingError {
     PeerManagerError(#[from] PeerManagerError),
     #[error("Storage error: {0}")]
     StorageError(#[from] StorageError),
+    #[error("Service initializer error: {0}")]
+    ServiceInitializerError(#[from] anyhow::Error),
+    #[error("Comms failed to spawn")]
+    CommsSpawnError,
 }

--- a/base_layer/contacts/src/chat_client/src/lib.rs
+++ b/base_layer/contacts/src/chat_client/src/lib.rs
@@ -25,4 +25,5 @@ pub use client::{ChatClient, Client};
 
 pub mod config;
 pub mod database;
+pub mod error;
 pub mod networking;

--- a/base_layer/contacts/src/chat_client/src/networking.rs
+++ b/base_layer/contacts/src/chat_client/src/networking.rs
@@ -85,11 +85,11 @@ pub async fn start(
         ))
         .build();
 
-    let mut handles = fut.await.expect("Service initialization failed");
+    let mut handles = fut.await?;
 
     let comms = handles
         .take_handle::<UnspawnedCommsNode>()
-        .expect("P2pInitializer was not added to the stack or did not add UnspawnedCommsNode");
+        .ok_or(NetworkingError::CommsSpawnError)?;
 
     let peer_manager = comms.peer_manager();
 

--- a/base_layer/contacts/src/contacts_service/storage/types/messages.rs
+++ b/base_layer/contacts/src/contacts_service/storage/types/messages.rs
@@ -144,7 +144,7 @@ impl TryFrom<MessagesSql> for Message {
             direction: Direction::from_byte(
                 u8::try_from(o.direction).map_err(|_| ContactsServiceStorageError::ConversionError)?,
             )
-            .unwrap_or_else(|| panic!("Direction from byte {}", o.direction)),
+            .ok_or(ContactsServiceStorageError::ConversionError)?,
             stored_at: o.stored_at.timestamp() as u64,
             delivery_confirmation_at: Some(o.stored_at.timestamp() as u64),
             read_confirmation_at: Some(o.stored_at.timestamp() as u64),

--- a/integration_tests/src/chat_client.rs
+++ b/integration_tests/src/chat_client.rs
@@ -64,7 +64,7 @@ pub async fn spawn_chat_client(name: &str, seed_peers: Vec<Peer>, base_dir: Path
 
     let mut client = Client::new(identity, config);
 
-    client.initialize().await;
+    client.initialize().await.expect("the chat client to spawn");
     client
 }
 

--- a/integration_tests/src/chat_client.rs
+++ b/integration_tests/src/chat_client.rs
@@ -53,8 +53,8 @@ pub async fn spawn_chat_client(name: &str, seed_peers: Vec<Peer>, base_dir: Path
     )
     .unwrap();
 
-    database::create_chat_storage(&config.chat_client.db_file);
-    database::create_peer_storage(&config.chat_client.data_dir);
+    database::create_chat_storage(&config.chat_client.db_file).unwrap();
+    database::create_peer_storage(&config.chat_client.data_dir).unwrap();
 
     config.peer_seeds.peer_seeds = seed_peers
         .iter()

--- a/integration_tests/src/chat_ffi.rs
+++ b/integration_tests/src/chat_ffi.rs
@@ -258,8 +258,8 @@ pub async fn spawn_ffi_chat_client(name: &str, seed_peers: Vec<Peer>, base_dir: 
     )
     .unwrap();
 
-    database::create_chat_storage(&config.chat_client.db_file);
-    database::create_peer_storage(&config.chat_client.data_dir);
+    database::create_chat_storage(&config.chat_client.db_file).unwrap();
+    database::create_peer_storage(&config.chat_client.data_dir).unwrap();
 
     config.peer_seeds.peer_seeds = seed_peers
         .iter()

--- a/integration_tests/src/chat_ffi.rs
+++ b/integration_tests/src/chat_ffi.rs
@@ -34,7 +34,7 @@ type ClientFFI = c_void;
 
 use libc::{c_char, c_int, c_uchar, c_uint};
 use minotari_app_utilities::identity_management::setup_node_identity;
-use tari_chat_client::{database, ChatClient};
+use tari_chat_client::{database, error::Error as ClientError, ChatClient};
 use tari_common_types::tari_address::TariAddress;
 use tari_comms::{
     multiaddr::Multiaddr,
@@ -121,16 +121,20 @@ struct MessagesVector(Vec<Message>);
 
 #[async_trait]
 impl ChatClient for ChatFFI {
-    async fn add_contact(&self, address: &TariAddress) {
+    async fn add_contact(&self, address: &TariAddress) -> Result<(), ClientError> {
         let client = self.ptr.lock().unwrap();
 
         let address_ptr = Box::into_raw(Box::new(address.to_owned())) as *mut c_void;
 
         let error_out = Box::into_raw(Box::new(0));
-        unsafe { add_chat_contact(client.0, address_ptr, error_out) }
+
+        let result;
+        unsafe { result = add_chat_contact(client.0, address_ptr, error_out) }
+
+        Ok(result)
     }
 
-    async fn check_online_status(&self, address: &TariAddress) -> ContactOnlineStatus {
+    async fn check_online_status(&self, address: &TariAddress) -> Result<ContactOnlineStatus, ClientError> {
         let client = self.ptr.lock().unwrap();
 
         let address_ptr = Box::into_raw(Box::new(address.clone())) as *mut c_void;
@@ -139,10 +143,10 @@ impl ChatClient for ChatFFI {
         let error_out = Box::into_raw(Box::new(0));
         unsafe { result = check_online_status(client.0, address_ptr, error_out) }
 
-        ContactOnlineStatus::from_byte(u8::try_from(result).unwrap()).expect("A valid u8 from FFI status")
+        Ok(ContactOnlineStatus::from_byte(u8::try_from(result).unwrap()).expect("A valid u8 from FFI status"))
     }
 
-    async fn send_message(&self, message: Message) {
+    async fn send_message(&self, message: Message) -> Result<(), ClientError> {
         let client = self.ptr.lock().unwrap();
 
         let error_out = Box::into_raw(Box::new(0));
@@ -151,9 +155,11 @@ impl ChatClient for ChatFFI {
         unsafe {
             send_chat_message(client.0, message_ptr, error_out);
         }
+
+        Ok(())
     }
 
-    async fn get_messages(&self, address: &TariAddress, limit: u64, page: u64) -> Vec<Message> {
+    async fn get_messages(&self, address: &TariAddress, limit: u64, page: u64) -> Result<Vec<Message>, ClientError> {
         let client = self.ptr.lock().unwrap();
 
         let address_ptr = Box::into_raw(Box::new(address.clone())) as *mut c_void;
@@ -167,7 +173,7 @@ impl ChatClient for ChatFFI {
             messages = (*all_messages).0.clone();
         }
 
-        messages
+        Ok(messages)
     }
 
     fn create_message(&self, receiver: &TariAddress, message: String) -> Message {
@@ -205,7 +211,7 @@ impl ChatClient for ChatFFI {
         }
     }
 
-    async fn send_read_receipt(&self, message: Message) {
+    async fn send_read_receipt(&self, message: Message) -> Result<(), ClientError> {
         let client = self.ptr.lock().unwrap();
         let message_ptr = Box::into_raw(Box::new(message)) as *mut c_void;
         let error_out = Box::into_raw(Box::new(0));
@@ -213,9 +219,11 @@ impl ChatClient for ChatFFI {
         unsafe {
             send_read_confirmation_for_message(client.0, message_ptr, error_out);
         }
+
+        Ok(())
     }
 
-    async fn get_conversationalists(&self) -> Vec<TariAddress> {
+    async fn get_conversationalists(&self) -> Result<Vec<TariAddress>, ClientError> {
         let client = self.ptr.lock().unwrap();
 
         let addresses;
@@ -225,7 +233,7 @@ impl ChatClient for ChatFFI {
             addresses = (*vector).0.clone();
         }
 
-        addresses
+        Ok(addresses)
     }
 
     fn identity(&self) -> &NodeIdentity {


### PR DESCRIPTION
Description
---
This cleans up chat, and the contacts service of possible panic points. Instead managing Err results and attempting to propagate errors better.

Motivation and Context
---
Make the service friendlier, and more importantly don't cause panics that will crush the Mobile apps over ffi.

How Has This Been Tested?
---
Cucumber locally

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify