### PR TITLE
feat: side load chat

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5653,6 +5653,7 @@ dependencies = [
  "lmdb-zero",
  "log",
  "minotari_app_utilities",
+ "rand",
  "serde",
  "tari_common",
  "tari_common_sqlite",

--- a/base_layer/chat_ffi/chat.h
+++ b/base_layer/chat_ffi/chat.h
@@ -18,6 +18,8 @@ struct Confirmation;
 
 struct ContactsLivenessData;
 
+struct ContactsServiceHandle;
+
 struct ConversationalistsVector;
 
 struct Message;
@@ -70,6 +72,37 @@ struct ChatClient *create_chat_client(struct ApplicationConfig *config,
                                       CallbackMessageReceived callback_message_received,
                                       CallbackDeliveryConfirmationReceived callback_delivery_confirmation_received,
                                       CallbackReadConfirmationReceived callback_read_confirmation_received);
+
+/**
+ * Side loads a chat client
+ *
+ * ## Arguments
+ * `config` - The ApplicationConfig pointer
+ * `contacts_handler` - A pointer to a contacts handler extracted from the wallet ffi
+ * `error_out` - Pointer to an int which will be modified
+ * `callback_contact_status_change` - A callback function pointer. this is called whenever a
+ * contacts liveness event comes in.
+ * `callback_message_received` - A callback function pointer. This is called whenever a chat
+ * message is received.
+ * `callback_delivery_confirmation_received` - A callback function pointer. This is called when the
+ * client receives a confirmation of message delivery.
+ * `callback_read_confirmation_received` - A callback function pointer. This is called when the
+ * client receives a confirmation of message read.
+ *
+ * ## Returns
+ * `*mut ChatClient` - Returns a pointer to a ChatClient, note that it returns ptr::null_mut()
+ * if any error was encountered or if the runtime could not be created.
+ *
+ * # Safety
+ * The ```destroy_chat_client``` method must be called when finished with a ClientFFI to prevent a memory leak
+ */
+struct ChatClient *sideload_chat_client(struct ApplicationConfig *config,
+                                        struct ContactsServiceHandle *contacts_handle,
+                                        int *error_out,
+                                        CallbackContactStatusChange callback_contact_status_change,
+                                        CallbackMessageReceived callback_message_received,
+                                        CallbackDeliveryConfirmationReceived callback_delivery_confirmation_received,
+                                        CallbackReadConfirmationReceived callback_read_confirmation_received);
 
 /**
  * Frees memory for a ChatClient

--- a/base_layer/chat_ffi/src/lib.rs
+++ b/base_layer/chat_ffi/src/lib.rs
@@ -29,6 +29,7 @@ use libc::c_int;
 use log::info;
 use minotari_app_utilities::identity_management::setup_node_identity;
 use tari_chat_client::{config::ApplicationConfig, networking::PeerFeatures, ChatClient as ChatClientTrait, Client};
+use tari_contacts::contacts_service::handle::ContactsServiceHandle;
 use tokio::runtime::Runtime;
 
 use crate::{
@@ -148,9 +149,108 @@ pub unsafe extern "C" fn create_chat_client(
     };
 
     let mut client = Client::new(identity, (*config).clone());
+
+    let contacts_handler = match client.contacts.clone() {
+        Some(contacts_handler) => contacts_handler,
+        None => {
+            error = LibChatError::from(InterfaceError::NullError("No contacts service loaded yet".to_string())).code;
+            ptr::swap(error_out, &mut error as *mut c_int);
+            return ptr::null_mut();
+        },
+    };
+
     if let Ok(()) = runtime.block_on(client.initialize()) {
         let mut callback_handler = CallbackHandler::new(
-            client.contacts.clone().expect("No contacts service loaded yet"),
+            contacts_handler,
+            client.shutdown.to_signal(),
+            callback_contact_status_change,
+            callback_message_received,
+            callback_delivery_confirmation_received,
+            callback_read_confirmation_received,
+        );
+
+        runtime.spawn(async move {
+            callback_handler.start().await;
+        });
+    }
+
+    let client = ChatClient { client, runtime };
+
+    Box::into_raw(Box::new(client))
+}
+
+/// Side loads a chat client
+///
+/// ## Arguments
+/// `config` - The ApplicationConfig pointer
+/// `contacts_handler` - A pointer to a contacts handler extracted from the wallet ffi
+/// `error_out` - Pointer to an int which will be modified
+/// `callback_contact_status_change` - A callback function pointer. this is called whenever a
+/// contacts liveness event comes in.
+/// `callback_message_received` - A callback function pointer. This is called whenever a chat
+/// message is received.
+/// `callback_delivery_confirmation_received` - A callback function pointer. This is called when the
+/// client receives a confirmation of message delivery.
+/// `callback_read_confirmation_received` - A callback function pointer. This is called when the
+/// client receives a confirmation of message read.
+///
+/// ## Returns
+/// `*mut ChatClient` - Returns a pointer to a ChatClient, note that it returns ptr::null_mut()
+/// if any error was encountered or if the runtime could not be created.
+///
+/// # Safety
+/// The ```destroy_chat_client``` method must be called when finished with a ClientFFI to prevent a memory leak
+#[no_mangle]
+pub unsafe extern "C" fn sideload_chat_client(
+    config: *mut ApplicationConfig,
+    contacts_handle: *mut ContactsServiceHandle,
+    error_out: *mut c_int,
+    callback_contact_status_change: CallbackContactStatusChange,
+    callback_message_received: CallbackMessageReceived,
+    callback_delivery_confirmation_received: CallbackDeliveryConfirmationReceived,
+    callback_read_confirmation_received: CallbackReadConfirmationReceived,
+) -> *mut ChatClient {
+    let mut error = 0;
+    ptr::swap(error_out, &mut error as *mut c_int);
+
+    if config.is_null() {
+        error = LibChatError::from(InterfaceError::NullError("config".to_string())).code;
+        ptr::swap(error_out, &mut error as *mut c_int);
+        return ptr::null_mut();
+    }
+
+    if let Some(log_path) = (*config).clone().chat_client.log_path {
+        init_logging(log_path, (*config).clone().chat_client.log_verbosity, error_out);
+
+        if error > 0 {
+            return ptr::null_mut();
+        }
+    }
+    info!(
+        target: LOG_TARGET,
+        "Sideloading Tari Chat FFI version: {}",
+        consts::APP_VERSION
+    );
+
+    let runtime = match Runtime::new() {
+        Ok(r) => r,
+        Err(e) => {
+            error = LibChatError::from(InterfaceError::TokioError(e.to_string())).code;
+            ptr::swap(error_out, &mut error as *mut c_int);
+            return ptr::null_mut();
+        },
+    };
+
+    if contacts_handle.is_null() {
+        error = LibChatError::from(InterfaceError::NullError("contacts_handle".to_string())).code;
+        ptr::swap(error_out, &mut error as *mut c_int);
+        return ptr::null_mut();
+    }
+
+    let mut client = Client::sideload((*config).clone(), (*contacts_handle).clone());
+    if let Ok(()) = runtime.block_on(client.initialize()) {
+        let mut callback_handler = CallbackHandler::new(
+            (*contacts_handle).clone(),
             client.shutdown.to_signal(),
             callback_contact_status_change,
             callback_message_received,

--- a/base_layer/chat_ffi/src/lib.rs
+++ b/base_layer/chat_ffi/src/lib.rs
@@ -150,16 +150,17 @@ pub unsafe extern "C" fn create_chat_client(
 
     let mut client = Client::new(identity, (*config).clone());
 
-    let contacts_handler = match client.contacts.clone() {
-        Some(contacts_handler) => contacts_handler,
-        None => {
-            error = LibChatError::from(InterfaceError::NullError("No contacts service loaded yet".to_string())).code;
-            ptr::swap(error_out, &mut error as *mut c_int);
-            return ptr::null_mut();
-        },
-    };
-
     if let Ok(()) = runtime.block_on(client.initialize()) {
+        let contacts_handler = match client.contacts.clone() {
+            Some(contacts_handler) => contacts_handler,
+            None => {
+                error =
+                    LibChatError::from(InterfaceError::NullError("No contacts service loaded yet".to_string())).code;
+                ptr::swap(error_out, &mut error as *mut c_int);
+                return ptr::null_mut();
+            },
+        };
+
         let mut callback_handler = CallbackHandler::new(
             contacts_handler,
             client.shutdown.to_signal(),

--- a/base_layer/contacts/src/chat_client/Cargo.toml
+++ b/base_layer/contacts/src/chat_client/Cargo.toml
@@ -26,5 +26,6 @@ config = { version = "0.13.0" }
 diesel = { version = "2.0.3", features = ["sqlite", "r2d2", "serde_json", "chrono", "64-column-tables"] }
 lmdb-zero = "0.4.4"
 log = "0.4.17"
+rand = "0.8"
 serde = "1.0.136"
 thiserror = "1.0.50"

--- a/base_layer/contacts/src/chat_client/src/client.rs
+++ b/base_layer/contacts/src/chat_client/src/client.rs
@@ -52,7 +52,7 @@ pub trait ChatClient {
     async fn send_message(&self, message: Message) -> Result<(), Error>;
     async fn send_read_receipt(&self, message: Message) -> Result<(), Error>;
     async fn get_conversationalists(&self) -> Result<Vec<TariAddress>, Error>;
-    fn identity(&self) -> &NodeIdentity;
+    fn address(&self) -> TariAddress;
     fn shutdown(&mut self);
 }
 
@@ -141,8 +141,8 @@ impl Client {
 
 #[async_trait]
 impl ChatClient for Client {
-    fn identity(&self) -> &NodeIdentity {
-        &self.identity
+    fn address(&self) -> TariAddress {
+        TariAddress::from_public_key(self.identity.public_key(), self.config.chat_client.network)
     }
 
     fn shutdown(&mut self) {

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -8641,7 +8641,6 @@ pub unsafe extern "C" fn contacts_handle_destroy(contacts_handle: *mut ContactsS
         drop(Box::from_raw(contacts_handle))
     }
 }
-
 /// ------------------------------------------------------------------------------------------ ///
 #[cfg(test)]
 mod test {

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -2584,6 +2584,13 @@ TariPublicKey *public_keys_get_at(const struct TariPublicKeys *public_keys,
  * `config` - The TariCommsConfig pointer
  * `log_path` - An optional file path to the file where the logs will be written. If no log is required pass *null*
  * pointer.
+ * `log_verbosity` - how verbose should logging be as a c_int 0-5, or 11
+ *        0 => Off
+ *        1 => Error
+ *        2 => Warn
+ *        3 => Info
+ *        4 => Debug
+ *        5 | 11 => Trace // Cranked up to 11
  * `num_rolling_log_files` - Specifies how many rolling log files to produce, if no rolling files are wanted then set
  * this to 0
  * `size_per_log_file_bytes` - Specifies the size, in bytes, at which the logs files will roll over, if no
@@ -2673,6 +2680,7 @@ TariPublicKey *public_keys_get_at(const struct TariPublicKeys *public_keys,
  */
 struct TariWallet *wallet_create(TariCommsConfig *config,
                                  const char *log_path,
+                                 int log_verbosity,
                                  unsigned int num_rolling_log_files,
                                  unsigned int size_per_log_file_bytes,
                                  const char *passphrase,

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -72,6 +72,8 @@ struct Contact;
 
 struct ContactsLivenessData;
 
+struct ContactsServiceHandle;
+
 /**
  * A covenant allows a UTXO to specify some restrictions on how it is spent in a future transaction.
  * See https://rfc.tari.com/RFC-0250_Covenants.html for details.
@@ -3925,6 +3927,36 @@ unsigned long long fee_per_gram_stat_get_max_fee_per_gram(TariFeePerGramStat *fe
  * None
  */
 void fee_per_gram_stat_destroy(TariFeePerGramStat *fee_per_gram_stat);
+
+/**
+ * Returns a ptr to the ContactsServiceHandle for use with chat
+ *
+ * ## Arguments
+ * `wallet` - The wallet instance
+ * `error_out` - Pointer to an int which will be modified
+ *
+ * ## Returns
+ * `*mut ContactsServiceHandle` an opaque pointer used in chat sideloading initialization
+ *
+ * # Safety
+ * You should release the returned pointer after it's been used to initialize chat using `contacts_handle_destroy`
+ */
+struct ContactsServiceHandle *contacts_handle(struct TariWallet *wallet,
+                                              int *error_out);
+
+/**
+ * Frees memory for a ContactsServiceHandle
+ *
+ * ## Arguments
+ * `contacts_handle` - The pointer to a ContactsServiceHandle
+ *
+ * ## Returns
+ * `()` - Does not return a value, equivalent to void in C
+ *
+ * # Safety
+ * None
+ */
+void contacts_handle_destroy(struct ContactsServiceHandle *contacts_handle);
 
 /**
  * Extracts a `NodeId` represented as a vector of bytes wrapped into a `ByteVector`

--- a/integration_tests/src/chat_ffi.rs
+++ b/integration_tests/src/chat_ffi.rs
@@ -79,6 +79,15 @@ extern "C" {
         callback_delivery_confirmation_received: unsafe extern "C" fn(*mut c_void),
         callback_read_confirmation_received: unsafe extern "C" fn(*mut c_void),
     ) -> *mut ClientFFI;
+    pub fn sideload_chat_client(
+        config: *mut c_void,
+        contact_handle: *mut c_void,
+        error_out: *const c_int,
+        callback_contact_status_change: unsafe extern "C" fn(*mut c_void),
+        callback_message_received: unsafe extern "C" fn(*mut c_void),
+        callback_delivery_confirmation_received: unsafe extern "C" fn(*mut c_void),
+        callback_read_confirmation_received: unsafe extern "C" fn(*mut c_void),
+    ) -> *mut ClientFFI;
     pub fn create_chat_message(receiver: *mut c_void, message: *const c_char, error_out: *const c_int) -> *mut c_void;
     pub fn send_chat_message(client: *mut ClientFFI, message: *mut c_void, error_out: *const c_int);
     pub fn add_chat_message_metadata(
@@ -300,6 +309,37 @@ pub async fn spawn_ffi_chat_client(name: &str, seed_peers: Vec<Peer>, base_dir: 
     }
 }
 
+pub async fn sideload_ffi_chat_client(
+    address: TariAddress,
+    base_dir: PathBuf,
+    contacts_handle_ptr: *mut c_void,
+) -> ChatFFI {
+    let mut config = test_config(Multiaddr::empty());
+    config.chat_client.set_base_path(base_dir);
+
+    let config_ptr = Box::into_raw(Box::new(config)) as *mut c_void;
+
+    let client_ptr;
+    let error_out = Box::into_raw(Box::new(0));
+    unsafe {
+        *ChatCallback::instance().contact_status_change.lock().unwrap() = 0;
+
+        client_ptr = sideload_chat_client(
+            config_ptr,
+            contacts_handle_ptr,
+            error_out,
+            callback_contact_status_change,
+            callback_message_received,
+            callback_delivery_confirmation_received,
+            callback_read_confirmation_received,
+        );
+    }
+
+    ChatFFI {
+        ptr: Arc::new(Mutex::new(PtrWrapper(client_ptr))),
+        address,
+    }
+}
 static mut INSTANCE: Option<ChatCallback> = None;
 static START: Once = Once::new();
 

--- a/integration_tests/src/chat_ffi.rs
+++ b/integration_tests/src/chat_ffi.rs
@@ -35,11 +35,11 @@ type ClientFFI = c_void;
 use libc::{c_char, c_int, c_uchar, c_uint};
 use minotari_app_utilities::identity_management::setup_node_identity;
 use tari_chat_client::{database, error::Error as ClientError, ChatClient};
+use tari_common::configuration::Network;
 use tari_common_types::tari_address::TariAddress;
 use tari_comms::{
     multiaddr::Multiaddr,
     peer_manager::{Peer, PeerFeatures},
-    NodeIdentity,
 };
 use tari_contacts::contacts_service::{
     service::ContactOnlineStatus,
@@ -113,7 +113,7 @@ unsafe impl Send for PtrWrapper {}
 #[derive(Debug)]
 pub struct ChatFFI {
     ptr: Arc<Mutex<PtrWrapper>>,
-    pub identity: Arc<NodeIdentity>,
+    pub address: TariAddress,
 }
 
 struct Conversationalists(Vec<TariAddress>);
@@ -236,8 +236,8 @@ impl ChatClient for ChatFFI {
         Ok(addresses)
     }
 
-    fn identity(&self) -> &NodeIdentity {
-        &self.identity
+    fn address(&self) -> TariAddress {
+        self.address.clone()
     }
 
     fn shutdown(&mut self) {
@@ -296,7 +296,7 @@ pub async fn spawn_ffi_chat_client(name: &str, seed_peers: Vec<Peer>, base_dir: 
 
     ChatFFI {
         ptr: Arc::new(Mutex::new(PtrWrapper(client_ptr))),
-        identity,
+        address: TariAddress::from_public_key(identity.public_key(), Network::LocalNet),
     }
 }
 

--- a/integration_tests/src/ffi/ffi_import.rs
+++ b/integration_tests/src/ffi/ffi_import.rs
@@ -591,4 +591,5 @@ extern "C" {
         error_out: *mut c_int,
     ) -> c_ulonglong;
     pub fn fee_per_gram_stat_destroy(fee_per_gram_stat: *mut TariFeePerGramStat);
+    pub fn contacts_handle(wallet: *mut TariWallet, error_out: *mut c_int) -> *mut c_void;
 }

--- a/integration_tests/src/ffi/ffi_import.rs
+++ b/integration_tests/src/ffi/ffi_import.rs
@@ -380,6 +380,7 @@ extern "C" {
     pub fn wallet_create(
         config: *mut TariCommsConfig,
         log_path: *const c_char,
+        log_level: c_int,
         num_rolling_log_files: c_uint,
         size_per_log_file_bytes: c_uint,
         passphrase: *const c_char,

--- a/integration_tests/src/ffi/wallet.rs
+++ b/integration_tests/src/ffi/wallet.rs
@@ -172,6 +172,7 @@ impl Wallet {
             ptr = wallet_create(
                 comms_config.get_ptr(),
                 CString::new(log_path).unwrap().into_raw(),
+                11,
                 50,
                 104857600, // 100 MB
                 CString::new("kensentme").unwrap().into_raw(),

--- a/integration_tests/src/ffi/wallet.rs
+++ b/integration_tests/src/ffi/wallet.rs
@@ -433,4 +433,16 @@ impl Wallet {
         }
         FeePerGramStats::from_ptr(ptr)
     }
+
+    pub fn contacts_handle(&self) -> *mut c_void {
+        let ptr;
+        let mut error = 0;
+        unsafe {
+            ptr = ffi_import::contacts_handle(self.ptr, &mut error);
+            if error > 0 {
+                println!("contacts_handle error {}", error);
+            }
+        }
+        ptr
+    }
 }

--- a/integration_tests/src/wallet_ffi.rs
+++ b/integration_tests/src/wallet_ffi.rs
@@ -55,8 +55,7 @@ use crate::{
 pub struct WalletFFI {
     pub name: String,
     pub port: u64,
-    // pub grpc_port: u64,
-    // pub temp_dir_path: String,
+    pub base_dir: PathBuf,
     pub wallet: Arc<Mutex<ffi::Wallet>>,
 }
 
@@ -76,7 +75,12 @@ impl WalletFFI {
             .unwrap()
             .into();
         let wallet = ffi::Wallet::create(comms_config, log_path, seed_words_ptr);
-        Self { name, port, wallet }
+        Self {
+            name,
+            port,
+            base_dir: base_dir_path,
+            wallet,
+        }
     }
 
     pub fn identify(&self) -> String {
@@ -185,6 +189,10 @@ impl WalletFFI {
 
     pub fn get_fee_per_gram_stats(&self, count: u32) -> FeePerGramStats {
         self.wallet.lock().unwrap().get_fee_per_gram_stats(count)
+    }
+
+    pub fn contacts_handle(&self) -> *mut c_void {
+        self.wallet.lock().unwrap().contacts_handle()
     }
 }
 

--- a/integration_tests/tests/features/ChatFFI.feature
+++ b/integration_tests/tests/features/ChatFFI.feature
@@ -105,3 +105,11 @@ Feature: Chat FFI messaging
     When CHAT_A will have 1 message with CHAT_C
     When CHAT_A will have 1 message with CHAT_D
     Then CHAT_A will have 3 conversationalists
+
+  Scenario: A message is propagated between side loaded chat and client via 3rd party
+    Given I have a seed node SEED_A
+    Given I have a ffi wallet WALLET_A connected to base node SEED_A
+    When I have a sideloaded chat FFI client CHAT_A from WALLET_A
+    When I have a chat FFI client CHAT_B connected to seed node SEED_A
+    When I use CHAT_A to send a message 'Hey there' to CHAT_B
+    Then CHAT_B will have 1 message with CHAT_A

--- a/integration_tests/tests/steps/chat_ffi_steps.rs
+++ b/integration_tests/tests/steps/chat_ffi_steps.rs
@@ -25,7 +25,7 @@ use std::time::Duration;
 use cucumber::{then, when};
 use tari_common_types::tari_address::TariAddress;
 use tari_integration_tests::{
-    chat_ffi::{spawn_ffi_chat_client, ChatCallback},
+    chat_ffi::{sideload_ffi_chat_client, spawn_ffi_chat_client, ChatCallback},
     TariWorld,
 };
 
@@ -42,6 +42,16 @@ async fn chat_ffi_client_connected_to_base_node(world: &mut TariWorld, name: Str
     )
     .await;
     world.chat_clients.insert(name, Box::new(client));
+}
+
+#[when(expr = "I have a sideloaded chat FFI client {word} from {word}")]
+async fn sideloaded_chat_ffi_client_connected_to_wallet(world: &mut TariWorld, chat_name: String, wallet_name: String) {
+    let wallet = world.get_ffi_wallet(&wallet_name).unwrap();
+    let pubkey = world.get_wallet_address(&wallet_name).await.unwrap();
+    let address = TariAddress::from_hex(&pubkey).unwrap();
+
+    let client = sideload_ffi_chat_client(address, wallet.base_dir.clone(), wallet.contacts_handle()).await;
+    world.chat_clients.insert(chat_name, Box::new(client));
 }
 
 #[then(expr = "there will be a contact status update callback of at least {int}")]

--- a/integration_tests/tests/steps/chat_ffi_steps.rs
+++ b/integration_tests/tests/steps/chat_ffi_steps.rs
@@ -23,6 +23,7 @@
 use std::time::Duration;
 
 use cucumber::{then, when};
+use tari_common_types::tari_address::TariAddress;
 use tari_integration_tests::{
     chat_ffi::{spawn_ffi_chat_client, ChatCallback},
     TariWorld,


### PR DESCRIPTION
Description
---
Chat, and the Chat FFI were designed to operate as an independent functioning node on the network. It brings up it's own p2p and comms stack, and has it's own identity.

This is great but wallets like Aurora already have this functionality, and currently to run chat it operates two entire stacks. In the case of having a wallet already we don't need to run two entire stacks. We can utilize the wallet resources and sideload chat from an existing node.

Motivation and Context
---
Share resources, lower memory usage, increase network stability, make chat easier to utilize within Aurora.

How Has This Been Tested?
---
CI

What process can a PR reviewer use to test or verify this change?
---
Inspect the FFI changes for proper error handling and returns.


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
