### PR TITLE
feat: fix windows installer

### DIFF
--- a/.github/workflows/base_node_binaries.yml
+++ b/.github/workflows/base_node_binaries.yml
@@ -361,13 +361,11 @@ jobs:
           name: ${{ env.TBN_FILENAME }}-${{ matrix.builds.name }}-${{ env.VERSION }}.pkg
           path: "${{ env.distDirPKG }}/${{ env.TBN_FILENAME }}-${{ matrix.builds.name }}-${{ env.VERSION }}*.pkg*"
 
-      # unlike inno script studio, iscc.exe doesn't run the [precompile] step generate_config.bat
       - name: Build the Windows installer
         shell: cmd
         if: startsWith(runner.os,'Windows')
         run: |
           cd buildtools
-          call generate_config.bat
           "%programfiles(x86)%\Inno Setup 6\iscc.exe" "/DMyAppVersion=${{ env.VERSION }}-${{ env.VSHA_SHORT }}-${{ matrix.builds.name }}-installer" "/DMinotariSuite=${{ env.TBN_FILENAME }}" "/DTariSuitePath=${{ github.workspace }}${{ env.TBN_DIST }}" "windows_inno_installer.iss"
           cd Output
           echo "Compute archive shasum"

--- a/applications/minotari_console_wallet/windows/runtime/source_minotari_console_wallet_env.bat
+++ b/applications/minotari_console_wallet/windows/runtime/source_minotari_console_wallet_env.bat
@@ -2,16 +2,6 @@
 title Minotari Wallet
 
 rem Verify arguments
-if ["%config_path%"]==[""] (
-    echo Problem with "config_path" environment variable: '%config_path%'
-    pause
-    exit /b 10101
-)
-if not exist "%config_path%" (
-    echo Path as per "config_path" environment variable not found: '%config_path%'
-    pause
-    exit /b 10101
-)
 if ["%base_path%"]==[""] (
     echo Problem with "base_path" environment variable: '%base_path%'
     pause
@@ -61,19 +51,13 @@ if exist "%my_exe_path%\%my_exe%" (
 
 echo.
 echo.
-if not exist "%config_path%\log4rs_console_wallet.yml" (
-    echo Creating new "%config_path%\log4rs_console_wallet.yml".
-) else (
-    echo Using existing "%config_path%\log4rs_console_wallet.yml"
-)
-echo.
 
 cd "%base_path%"
 rem check if Windows Terminal is in path, if so, run it there, to see emojis properly.
 where /q wt
 if errorlevel 1 (
-    "%console_wallet%" --config "%config_path%\config.toml" --log_config "%config_path%\log4rs_console_wallet.yml" --base-path "%base_path%"
+    "%console_wallet%" --base-path "%base_path%"
 ) else (
-    wt "%console_wallet%" --config "%config_path%\config.toml" --log_config "%config_path%\log4rs_console_wallet.yml" --base-path "%base_path%"
+    wt "%console_wallet%" --base-path "%base_path%"
     exit
 )

--- a/applications/minotari_console_wallet/windows/runtime/start_minotari_console_wallet.bat
+++ b/applications/minotari_console_wallet/windows/runtime/start_minotari_console_wallet.bat
@@ -6,10 +6,6 @@ echo ----------------------------
 rem These are the console wallet executable and SQLite dynamic link library names
 set my_exe=minotari_console_wallet.exe
 
-rem This is the location of the configuration and identity files
-set config_path=%~dp0..\config
-echo config_path = %config_path%
-
 rem The default location for the console wallet executable
 set my_exe_path=%~dp0
 if %my_exe_path:~-1%==\ set my_exe_path=%my_exe_path:~0,-1%

--- a/applications/minotari_merge_mining_proxy/windows/runtime/source_merge_mining_proxy_env.bat
+++ b/applications/minotari_merge_mining_proxy/windows/runtime/source_merge_mining_proxy_env.bat
@@ -2,16 +2,6 @@
 title Minotari Merge Mining Proxy
 
 rem Verify arguments
-if ["%config_path%"]==[""] (
-    echo Problem with "config_path" environment variable: '%config_path%'
-    pause
-    exit /b 10101
-)
-if not exist "%config_path%" (
-    echo Path as per "config_path" environment variable not found: '%config_path%'
-    pause
-    exit /b 10101
-)
 if ["%base_path%"]==[""] (
     echo Problem with "base_path" environment variable: '%base_path%'
     pause
@@ -59,19 +49,4 @@ if exist "%my_exe_path%\%my_exe%" (
     )
 )
 
-rem First time run
-if not exist "%config_path%\log4rs_merge_mining_proxy.yml" (
-    "%merge_mining_proxy%" --init --config "%config_path%\config.toml" --log_config "%config_path%\log4rs_merge_mining_proxy.yml" --base-path "%base_path%"
-    echo.
-    echo.
-    echo Created "%config_path%\log4rs_merge_mining_proxy.yml".
-    echo.
-) else (
-    echo.
-    echo.
-    echo Using existing "%config_path%\log4rs_merge_mining_proxy.yml"
-    echo.
-)
-
-rem Consecutive runs
-"%merge_mining_proxy%" --config "%config_path%\config.toml" --log_config "%config_path%\log4rs_merge_mining_proxy.yml" --base-path "%base_path%"
+"%merge_mining_proxy%" --base-path "%base_path%"

--- a/applications/minotari_merge_mining_proxy/windows/runtime/source_xmrig_env.bat
+++ b/applications/minotari_merge_mining_proxy/windows/runtime/source_xmrig_env.bat
@@ -1,12 +1,12 @@
 @echo off
 rem Verify arguments
-if ["%config_path%"]==[""] (
-    echo Problem with "config_path" environment variable: '%config_path%'
+if ["%xmrig_config_path%"]==[""] (
+    echo Problem with "xmrig_config_path" environment variable: '%xmrig_config_path%'
     pause
     exit /b 10101
 )
-if not exist "%config_path%" (
-    echo Path as per "config_path" environment variable not found: '%config_path%'
+if not exist "%xmrig_config_path%" (
+    echo Path as per "xmrig_config_path" environment variable not found: '%xmrig_config_path%'
     pause
     exit /b 10101
 )
@@ -32,7 +32,9 @@ if exist "%TARI_XMRIG_DIR%\%my_exe%" (
 )
 
 rem Copy the config file to the XMRig folder
-copy /y /v "%config_path%\xmrig_config_example_stagenet.json" "%TARI_XMRIG_DIR%\config.json"
+if not exist "%TARI_XMRIG_DIR%\config.json" (
+    copy /y /v "%xmrig_config_path%\xmrig_config_example_mainnet.json" "%TARI_XMRIG_DIR%\config.json"
+)
 
 rem Run
 "%xmrig%"

--- a/applications/minotari_merge_mining_proxy/windows/runtime/start_minotari_merge_mining_proxy.bat
+++ b/applications/minotari_merge_mining_proxy/windows/runtime/start_minotari_merge_mining_proxy.bat
@@ -6,10 +6,6 @@ echo ----------------------------
 rem These is the merge mining proxy executable name
 set my_exe=minotari_merge_mining_proxy.exe
 
-rem This is the location of the configuration and identity files
-set config_path=%~dp0..\config
-echo config_path = %config_path%
-
 rem The default location for the merge mining proxy executable
 set my_exe_path=%~dp0
 if %my_exe_path:~-1%==\ set my_exe_path=%my_exe_path:~0,-1%

--- a/applications/minotari_merge_mining_proxy/windows/runtime/start_xmrig.bat
+++ b/applications/minotari_merge_mining_proxy/windows/runtime/start_xmrig.bat
@@ -7,8 +7,8 @@ rem This is the XMRig executable name
 set my_exe=xmrig.exe
 
 rem This is the location of the XMRig configuration file
-set config_path=%~dp0..\config
-echo config_path = %config_path%
+set xmrig_config_path=%~dp0..\xmrig_config
+echo xmrig_config_path = %xmrig_config_path%
 
 rem The default location for the XMRig start file
 set my_exe_path=%~dp0

--- a/applications/minotari_miner/windows/runtime/source_miner_env.bat
+++ b/applications/minotari_miner/windows/runtime/source_miner_env.bat
@@ -2,16 +2,6 @@
 title Minotari Miner
 
 rem Verify arguments
-if ["%config_path%"]==[""] (
-    echo Problem with "config_path" environment variable: '%config_path%'
-    pause
-    exit /b 10101
-)
-if not exist "%config_path%" (
-    echo Path as per "config_path" environment variable not found: '%config_path%'
-    pause
-    exit /b 10101
-)
 if ["%base_path%"]==[""] (
     echo Problem with "base_path" environment variable: '%base_path%'
     pause
@@ -61,12 +51,6 @@ if exist "%my_exe_path%\%my_exe%" (
 
 echo.
 echo.
-if not exist "%config_path%\log4rs_miner.yml" (
-    echo Creating new "%config_path%\log4rs_miner.yml".
-) else (
-    echo Using existing "%config_path%\log4rs_miner.yml"
-)
-echo.
 
 cd "%base_path%"
-"%miner%" --config "%config_path%\config.toml" --log_config "%config_path%\log4rs_miner.yml" --base-path "%base_path%"
+"%miner%" --base-path "%base_path%"

--- a/applications/minotari_miner/windows/runtime/start_minotari_miner.bat
+++ b/applications/minotari_miner/windows/runtime/start_minotari_miner.bat
@@ -6,10 +6,6 @@ echo ----------------------------
 rem These are the miner executable and SQLite dynamic link library names
 set my_exe=minotari_miner.exe
 
-rem This is the location of the configuration and identity files
-set config_path=%~dp0..\config
-echo config_path = %config_path%
-
 rem The default location for the miner executable
 set my_exe_path=%~dp0
 if %my_exe_path:~-1%==\ set my_exe_path=%my_exe_path:~0,-1%

--- a/applications/minotari_node/osx/install.sh
+++ b/applications/minotari_node/osx/install.sh
@@ -64,7 +64,6 @@ fi
 
 if [ ! -f "$DATA_DIR/config.toml" ]; then
   echo "Copying configuraton files"
-  cp tari_config_example.toml $DATA_DIR/config.toml
   cp log4rs_sample_base_node.yml $DATA_DIR/log4rs_base_node.yml
   echo "Configuration complete."
 fi

--- a/applications/minotari_node/osx/post_install.sh
+++ b/applications/minotari_node/osx/post_install.sh
@@ -193,7 +193,6 @@ fi
 
 if [ ! -f "$DATA_DIR/config.toml" ]; then
   echo "Copying configuraton files"
-#  cp tari_config_example.toml $DATA_DIR/config.toml
 #  cp log4rs_sample_base_node.yml $DATA_DIR/log4rs_base_node.yml
 
   # Configure Base Node

--- a/applications/minotari_node/windows/runtime/source_minotari_node_env.bat
+++ b/applications/minotari_node/windows/runtime/source_minotari_node_env.bat
@@ -2,16 +2,6 @@
 title Minotari Base Node
 
 rem Verify arguments
-if ["%config_path%"]==[""] (
-    echo Problem with "config_path" environment variable: '%config_path%'
-    pause
-    exit /b 10101
-)
-if not exist "%config_path%" (
-    echo Path as per "config_path" environment variable not found: '%config_path%'
-    pause
-    exit /b 10101
-)
 if ["%base_path%"]==[""] (
     echo Problem with "base_path" environment variable: '%base_path%'
     pause
@@ -59,33 +49,5 @@ if exist "%my_exe_path%\%my_exe%" (
     )
 )
 
-rem First time run
-if not exist "%config_path%\base_node_id.json" (
-    "%base_node%" --init --config "%config_path%\config.toml" --log_config "%config_path%\log4rs_base_node.yml" --base-path "%base_path%"
-    echo.
-    echo.
-    echo Created "%config_path%\base_node_id.json".
-    echo.
-) else (
-    echo.
-    echo.
-    echo Using existing "%config_path%\base_node_id.json"
-    echo.
-)
-if not exist "%config_path%\log4rs_base_node.yml" (
-    cd "%base_path%"
-    "%base_node%" --init --config "%config_path%\config.toml" --log_config "%config_path%\log4rs_base_node.yml" --base-path "%base_path%"
-    echo.
-    echo.
-    echo Created "%config_path%\log4rs_base_node.yml".
-    echo.
-) else (
-    echo.
-    echo.
-    echo Using existing "%config_path%\log4rs_base_node.yml"
-    echo.
-)
-
-rem Consecutive runs
 cd "%base_path%"
-"%base_node%" --config "%config_path%\config.toml" --log_config "%config_path%\log4rs_base_node.yml" --base-path "%base_path%"
+"%base_node%"  --base-path "%base_path%"

--- a/applications/minotari_node/windows/runtime/start_all.bat
+++ b/applications/minotari_node/windows/runtime/start_all.bat
@@ -1,9 +1,5 @@
 @echo off
 
-rem This is the location of the configuration and identity files
-set config_path=%~dp0..\config
-echo config_path = %config_path%
-
 rem The default runtime location
 set my_exe_path=%~dp0
 if %my_exe_path:~-1%==\ set my_exe_path=%my_exe_path:~0,-1%

--- a/applications/minotari_node/windows/runtime/start_minotari_node.bat
+++ b/applications/minotari_node/windows/runtime/start_minotari_node.bat
@@ -6,10 +6,6 @@ echo ----------------------------
 rem These are the base node executable and SQLite dynamic link library names
 set my_exe=minotari_node.exe
 
-rem This is the location of the configuration and identity files
-set config_path=%~dp0..\config
-echo config_path = %config_path%
-
 rem The default location for the base node executable
 set my_exe_path=%~dp0
 if %my_exe_path:~-1%==\ set my_exe_path=%my_exe_path:~0,-1%

--- a/buildtools/create_osx_install_zip.sh
+++ b/buildtools/create_osx_install_zip.sh
@@ -80,7 +80,7 @@ cp -f "${local_dir}/get_xmrig_osx.ps1" "${tarball_folder}/runtime/get_xmrig_osx.
 # Config
 cat "${project_dir}"/common/config/presets/*.toml >"${tarball_folder}/config/config.toml"
 cp -f "${project_dir}/common/xmrig_config/config_example_stagenet.json" "${tarball_folder}/config/xmrig_config_example_stagenet.json"
-cp -f "${project_dir}/common/xmrig_config/config_example_mainnet.json" "${tarball_folder}/config/xxmrig_config_example_mainnet.json"
+cp -f "${project_dir}/common/xmrig_config/config_example_mainnet.json" "${tarball_folder}/config/xmrig_config_example_mainnet.json"
 cp -f "${project_dir}/common/xmrig_config/config_example_mainnet_self_select.json" "${tarball_folder}/config/xmrig_config_example_mainnet_self_select.json"
 
 # Scripts

--- a/buildtools/create_ubuntu_install_zip.sh
+++ b/buildtools/create_ubuntu_install_zip.sh
@@ -79,7 +79,7 @@ cp -f "${local_dir}/install_powershell_ubuntu.sh" "${tarball_folder}/runtime/ins
 # Config
 cat "${project_dir}/common/config/presets/*.toml" >"${tarball_folder}/config/config.toml"
 cp -f "${project_dir}/common/xmrig_config/config_example_stagenet.json" "${tarball_folder}/config/xmrig_config_example_stagenet.json"
-cp -f "${project_dir}/common/xmrig_config/config_example_mainnet.json" "${tarball_folder}/config/xxmrig_config_example_mainnet.json"
+cp -f "${project_dir}/common/xmrig_config/config_example_mainnet.json" "${tarball_folder}/config/xmrig_config_example_mainnet.json"
 cp -f "${project_dir}/common/xmrig_config/config_example_mainnet_self_select.json" "${tarball_folder}/config/xmrig_config_example_mainnet_self_select.json"
 
 echo Files copied to "${tarball_folder}"

--- a/buildtools/generate_config.bat
+++ b/buildtools/generate_config.bat
@@ -1,1 +1,0 @@
-type ..\common\config\presets\*.toml >.\tari_config_example.toml

--- a/buildtools/generate_config.sh
+++ b/buildtools/generate_config.sh
@@ -1,1 +1,0 @@
-cat ../common/config/presets/*.toml >./tari_config_example.toml

--- a/buildtools/windows_inno_installer.iss
+++ b/buildtools/windows_inno_installer.iss
@@ -17,7 +17,6 @@
 ;          /p "<password used to create the certificate>" $f
 ;  (3) To run this script from the command line with Inno Setup console-mode compiler:
 ;      - change directory to "<project_root>/buildtools"
-;      - generate_config.bat      
 ;      - "<path to console-mode compiler>\ISCC.exe" "/SSignTool=signtool sign
 ;         /tr http://timestamp.digicert.com /f "<path and filename of the certificate>"
 ;         /p <password used to create the certificate> $f"
@@ -90,7 +89,6 @@ Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{
 Name: "quicklaunchicon"; Description: "{cm:CreateQuickLaunchIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked; OnlyBelowVersion: 0,6.1
 
 [PreCompile]
-Name: ".\generate_config.bat"; Flags: abortonerror cmdprompt redirectoutput
 
 [Files]
 Source: "..\LICENSE"; DestDir: "{app}"; DestName: "LICENSE.md"; Flags: ignoreversion
@@ -120,7 +118,6 @@ Source: "..\applications\minotari_merge_mining_proxy\windows\runtime\source_merg
 Source: "..\applications\minotari_merge_mining_proxy\windows\runtime\start_minotari_merge_mining_proxy.bat"; DestDir: "{app}\runtime"; Flags: ignoreversion
 Source: "..\applications\minotari_merge_mining_proxy\windows\runtime\source_xmrig_env.bat"; DestDir: "{app}\runtime"; Flags: ignoreversion
 Source: "..\applications\minotari_merge_mining_proxy\windows\runtime\start_xmrig.bat"; DestDir: "{app}\runtime"; Flags: ignoreversion
-Source: ".\tari_config_example.toml"; DestDir: "{app}\config"; DestName: "config.toml"; Flags: ignoreversion
 Source: "tari_logo_purple.ico"; DestDir: "{userdocs}\..\temp\tari_icons"; Flags: ignoreversion
 Source: "tor.ico"; DestDir: "{userdocs}\..\temp\tari_icons"; Flags: ignoreversion
 Source: "xmr_logo.ico"; DestDir: "{userdocs}\..\temp\tari_icons"; Flags: ignoreversion
@@ -128,9 +125,9 @@ Source: "install_tor_services.bat"; DestDir: "{app}\runtime"; Flags: ignoreversi
 Source: "install_vs2019_redist.bat"; DestDir: "{app}\runtime"; Flags: ignoreversion
 Source: "install_xmrig.bat"; DestDir: "{app}\runtime"; Flags: ignoreversion
 Source: "get_xmrig_win.ps1"; DestDir: "{app}\runtime"; Flags: ignoreversion
-Source: "..\common\xmrig_config\config_example_stagenet.json"; DestDir: "{app}\config"; DestName: "xmrig_config_example_stagenet.json"; Flags: ignoreversion
-Source: "..\common\xmrig_config\config_example_mainnet.json"; DestDir: "{app}\config"; DestName: "xmrig_config_example_mainnet.json"; Flags: ignoreversion
-Source: "..\common\xmrig_config\config_example_mainnet_self_select.json"; DestDir: "{app}\config"; DestName: "xmrig_config_example_mainnet_self_select.json"; Flags: ignoreversion
+Source: "..\common\xmrig_config\config_example_stagenet.json"; DestDir: "{app}\xmrig_config"; DestName: "xmrig_config_example_stagenet.json"; Flags: ignoreversion
+Source: "..\common\xmrig_config\config_example_mainnet.json"; DestDir: "{app}\xmrig_config"; DestName: "xmrig_config_example_mainnet.json"; Flags: ignoreversion
+Source: "..\common\xmrig_config\config_example_mainnet_self_select.json"; DestDir: "{app}\xmrig_config"; DestName: "xmrig_config_example_mainnet_self_select.json"; Flags: ignoreversion
 
 [Icons]
 Name: "{group}\Start {#AllName}"; Filename: "{app}\runtime\{#AllExeName}"; WorkingDir: "{app}"
@@ -162,7 +159,7 @@ Filename: "{app}\runtime\install_xmrig.bat"; Parameters: "NO_PAUSE"; Flags: runa
 Filename: "{app}\runtime\install_vs2019_redist.bat"; Parameters: "NO_PAUSE"; Flags: runascurrentuser postinstall; Description: "Install Redistributable for Visual Studio 2019"
 
 [InstallDelete]
-Type: filesandordirs; Name: "{app}\config"
+Type: filesandordirs; Name: "{app}\xmrig_config"
 Type: filesandordirs; Name: "{app}\log"
 Type: filesandordirs; Name: "{app}\runtime"
 Type: files; Name: "{app}\LICENSE.md"
@@ -185,6 +182,6 @@ Type: files; Name: "{userdesktop}\Tari XMRig.lnk"
 Type: files; Name: "{userdesktop}\Tari - Tor Services.lnk"
 
 [UninstallDelete]
-Type: filesandordirs; Name: "{app}\config"
+Type: filesandordirs; Name: "{app}\xmrig_config"
 Type: filesandordirs; Name: "{app}\log"
 Type: filesandordirs; Name: "{app}\runtime"

--- a/common/config/presets/f_merge_mining_proxy.toml
+++ b/common/config/presets/f_merge_mining_proxy.toml
@@ -8,24 +8,24 @@
 [merge_mining_proxy]
 
 # URL to monerod (default = "")
-monerod_url = [# stagenet
-    "http://stagenet.xmr-tw.org:38081",
-    "http://stagenet.community.xmr.to:38081",
-    "http://monero-stagenet.exan.tech:38081",
-    "http://xmr-lux.boldsuck.org:38081",
-    "http://singapore.node.xmr.pm:38081",
-]
-
-#monerod_url = [ # mainnet
-#    # more reliable
-#    "http://xmr.support:18081",
-#    "http://node1.xmr-tw.org:18081",
-#    "http://xmr.nthrow.nyc:18081",
-#    # not so reliable
-#    "http://node.xmrig.com:18081",
-#    "http://monero.exan.tech:18081",
-#    "http://18.132.124.81:18081",
+#monerod_url = [# stagenet
+#    "http://stagenet.xmr-tw.org:38081",
+#    "http://stagenet.community.xmr.to:38081",
+#    "http://monero-stagenet.exan.tech:38081",
+#    "http://xmr-lux.boldsuck.org:38081",
+#    "http://singapore.node.xmr.pm:38081",
 #]
+
+monerod_url = [ # mainnet
+    # more reliable
+    "http://xmr.support:18081",
+    "http://node1.xmr-tw.org:18081",
+    "http://xmr.nthrow.nyc:18081",
+    # not so reliable
+    "http://node.xmrig.com:18081",
+    "http://monero.exan.tech:18081",
+    "http://18.132.124.81:18081",
+]
 
 # Username for curl. (default = "")
 #monerod_username = ""

--- a/common/xmrig_config/config_example_mainnet.json
+++ b/common/xmrig_config/config_example_mainnet.json
@@ -3,11 +3,12 @@
     "cpu": true,
     "opencl": false,
     "cuda": false,
+    "log-file": ".\\xmrig.exe.log",
     "pools": [
         {
             "coin": "monero",
             "url": "127.0.0.1:18081",
-            "user": "YOUR MONERO WALLET ADDRESS HERE",
+            "user": "888tNkZrPN6JsEgekjMnABU4TBzc2Dt29EPAvkRxbANsAnjyPbb3iQ1YBRk1UXcdRsiKc9dhwMVgN5S9cQUiyoogDavup3H",
             "tls": false,
             "daemon": true
         }

--- a/common/xmrig_config/config_example_mainnet_self_select.json
+++ b/common/xmrig_config/config_example_mainnet_self_select.json
@@ -3,6 +3,7 @@
     "cpu": true,
     "opencl": false,
     "cuda": false,
+    "log-file": ".\\xmrig.exe.log",
     "pools": [
         {
             "coin": "monero",

--- a/common/xmrig_config/config_example_stagenet.json
+++ b/common/xmrig_config/config_example_stagenet.json
@@ -3,6 +3,7 @@
     "cpu": true,
     "opencl": false,
     "cuda": false,
+    "log-file": ".\\xmrig.exe.log",
     "pools": [
         {
             "coin": "monero",

--- a/scripts/build_dists_tarball.sh
+++ b/scripts/build_dists_tarball.sh
@@ -224,8 +224,6 @@ for COPY_FILE in "${COPY_FILES[@]}"; do
   cp -vr "$COPY_FILE" "$distDir/dist/"
 done
 
-cat common/config/presets/*.toml >"$distDir/dist/tari_config_example.toml"
-
 pushd $distDir/dist
 if [ "$osname" == "osx" ]  && [ -n "${osxsign}" ]; then
   echo "Setup OSX Binaries signing ..."

--- a/scripts/create_bundle.sh
+++ b/scripts/create_bundle.sh
@@ -19,7 +19,6 @@ fi
 BUNDLE='
 target/release/minotari_node
 scripts/install_tor.sh
-common/config/presets/tari_config_example.toml
 common/logging/log4rs_sample_base_node.yml
 applications/minotari_node/osx/install.sh
 applications/minotari_node/osx/osx_diag_report.sh


### PR DESCRIPTION
Description
---
A recent PR changed how the default `config.toml` file is created based on user input, so that it cannot be created ahead of time anymore. This PR applies that behaviour to the Windows installer.

Motivation and Context
---
See above

How Has This Been Tested?
---
Generated the install file, tested the installation as well as the runtime

What process can a PR reviewer use to test or verify this change?
---
As above

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
