### PR TITLE
feat: make libtor on by default for nix builds

### DIFF
--- a/.github/workflows/base_node_binaries.json
+++ b/.github/workflows/base_node_binaries.json
@@ -7,7 +7,7 @@
     "cross": false,
     "target_cpu": "x86-64",
     "target_bins": "--bin minotari_node --bin minotari_console_wallet --bin minotari_merge_mining_proxy --bin minotari_miner",
-    "features": "safe"
+    "features": "default, safe"
   },
   {
     "name": "linux-arm64",
@@ -28,7 +28,7 @@
     "cross": false,
     "target_cpu": "x86-64",
     "target_bins": "--bin minotari_node --bin minotari_console_wallet --bin minotari_merge_mining_proxy --bin minotari_miner",
-    "features": "libtor, safe"
+    "features": "default, safe"
   },
   {
     "name": "macos-arm64",
@@ -38,7 +38,7 @@
     "cross": false,
     "target_cpu": "generic",
     "target_bins": "--bin minotari_node --bin minotari_console_wallet --bin minotari_merge_mining_proxy --bin minotari_miner",
-    "features": "libtor, safe",
+    "features": "default, safe",
     "build_enabled": true
   },
   {

--- a/applications/minotari_console_wallet/Cargo.toml
+++ b/applications/minotari_console_wallet/Cargo.toml
@@ -70,6 +70,7 @@ features = ["crossterm"]
 tari_features = { path = "../../common/tari_features"}
 
 [features]
+default = ["libtor"]
 libtor = ["tari_libtor"]
 grpc = []
 

--- a/applications/minotari_node/Cargo.toml
+++ b/applications/minotari_node/Cargo.toml
@@ -52,7 +52,7 @@ tonic = { version = "0.6.2", features = ["tls", "tls-roots" ] }
 tari_metrics = { path = "../../infrastructure/metrics", optional = true, features = ["server"] }
 
 [features]
-default = ["metrics"]
+default = ["metrics", "libtor"]
 metrics = ["tari_metrics", "tari_comms/metrics"]
 safe = []
 libtor = ["tari_libtor"]

--- a/applications/minotari_node/src/config.rs
+++ b/applications/minotari_node/src/config.rs
@@ -168,7 +168,7 @@ impl Default for BaseNodeConfig {
             grpc_tls_enabled: false,
             mining_enabled: false,
             identity_file: PathBuf::from("config/base_node_id.json"),
-            use_libtor: false,
+            use_libtor: true,
             tor_identity_file: PathBuf::from("config/base_node_tor_id.json"),
             p2p,
             db_type: DatabaseType::Lmdb,

--- a/base_layer/wallet/src/config.rs
+++ b/base_layer/wallet/src/config.rs
@@ -154,7 +154,7 @@ impl Default for WalletConfig {
             recovery_retry_limit: 3,
             fee_per_gram: 5,
             num_required_confirmations: 3,
-            use_libtor: false,
+            use_libtor: true,
             identity_file: None,
         }
     }

--- a/common/config/presets/c_base_node_c.toml
+++ b/common/config/presets/c_base_node_c.toml
@@ -2,7 +2,7 @@
 #identity_file = "config/base_node_id.json"
 
 # Spin up and use a built-in Tor instance, only works on macos/linux and must comment out 'tor.control_address' below.
-# This requires that the base node was built with the optional "libtor" feature flag. (default = false)
+# This requires that the base node was built with the optional "libtor" feature flag. (default = true)
 #use_libtor = false
 
 # A path to the file that stores the tor hidden service private key, if using the tor transport.

--- a/common/config/presets/d_console_wallet.toml
+++ b/common/config/presets/d_console_wallet.toml
@@ -79,7 +79,7 @@
 #num_required_confirmations = 3
 
 # Spin up and use a built-in Tor instance, only works on macos/linux and must comment out 'tor.control_address' below.
-# This requires that the base node was built with the optional "libtor" feature flag. (default = false)
+# This requires that the base node was built with the optional "libtor" feature flag. (default = true)
 #use_libtor = false
 
 # A path to the file that stores your node identity and secret key (default = "none")

--- a/infrastructure/libtor/Cargo.toml
+++ b/infrastructure/libtor/Cargo.toml
@@ -14,10 +14,10 @@ log = "0.4.8"
 rand = "0.8"
 tempfile = "3.1.0"
 tor-hash-passwd = "1.0.1"
-openssl = { version = "0.10.61", features = ["vendored"] }
 
 [target.'cfg(unix)'.dependencies]
 libtor = { version="46.9.0"}
+openssl = { version = "0.10.61", features = ["vendored"] }
 
 [package.metadata.cargo-machete]
 ignored = ["openssl"] # this is so we can run cargo machete without getting false positive about macro dependancies


### PR DESCRIPTION
Description
---
This changes the defaults to include libtor for the MinoTari Node and Console wallet by default. Removing the need to run tor independently.

Closes #6050 

Motivation and Context
---
Make setup a smidge easier

How Has This Been Tested?
---
Locally: Ran the node and wallet without having a tor session started on the machine. Node and wallet used the built in libtor no problem. 

Changed `use_libtor` to `false` in the config. Started the node and received a `ExitError { exit_code: TorOffline` error as expected.
Turned on local tor session, and restarted node with no issue. Node is now running on provided tor, and not built in.

Windows built without error in CI: https://github.com/brianp/tari/actions/runs/7274136545

@Cifko did the windows testing for me. He could compile natively as usual without any libtor related problems. 
He also ran the installed package from the test builds with no issue.

This confirms that us setting a libtor default for *nix systems is not currently interfering with windows compilation or builds.

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
