### PR TITLE
chore(ci): add latest tag and multiNet label on release for docker 

### DIFF
--- a/.github/workflows/build_dockers_workflow.yml
+++ b/.github/workflows/build_dockers_workflow.yml
@@ -20,7 +20,7 @@ name: Build docker images - workflow_call/on-demand
         default: x86-64
       features:
         type: string
-        default: 'safe,grpc'
+        default: 'safe,grpc,libtor'
       version:
         type: string
         description: 'build tag/version'
@@ -183,9 +183,10 @@ jobs:
         with:
           images: |
             #name/${{ matrix.builds.image_name }}
-            #ghcr.io/${{ github.repository }}
             ghcr.io/${{ github.repository_owner }}/${{ matrix.builds.image_name }}
           tags: |
+            type=raw,value=latest-${{ env.TARI_NETWORK }},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=ref,event=tag
             type=ref,event=branch
             type=ref,event=pr
             type=semver,pattern={{version}}
@@ -197,7 +198,6 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          #username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to Docker Image Provider

--- a/.github/workflows/build_dockers_workflow.yml
+++ b/.github/workflows/build_dockers_workflow.yml
@@ -20,7 +20,7 @@ name: Build docker images - workflow_call/on-demand
         default: x86-64
       features:
         type: string
-        default: 'safe,grpc,libtor'
+        default: 'safe,grpc'
       version:
         type: string
         description: 'build tag/version'


### PR DESCRIPTION
Description
Add latest tag and multiNet label on release for docker 

Motivation and Context
Useful docker tags for launchpad usage.

How Has This Been Tested?
Verified in local fork

What process can a PR reviewer use to test or verify this change?
GHCR and Quay latest tags per multiNet on tagged releases.
