### PR TITLE
chore(ci): fix s3 uploads for none tagged builds

### DIFF
--- a/.github/workflows/base_node_binaries.yml
+++ b/.github/workflows/base_node_binaries.yml
@@ -26,6 +26,8 @@ env:
   CARGO: cargo
   # CARGO_OPTIONS: "--verbose"
   CARGO_OPTIONS: "--release"
+  # Needed for S3 as a default upload location
+  TARI_NETWORK_DIR: testnet
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Description
S3 upload job needs testNet location, but this is only added for tagged releases. Setting a default as testnet.

Motivation and Context
Fix ```line 11: 44746 Segmentation fault: 11``` error in the s3 upload job.

How Has This Been Tested?
Not checked.

What process can a PR reviewer use to test or verify this change?
Check there are no errors in the s3 upload job and also check that assets are upload into the s3 bucket.

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
