### PR TITLE
chore(ci): fix windows envs with bash shell for s3 uploads

### DIFF
--- a/.github/workflows/base_node_binaries.yml
+++ b/.github/workflows/base_node_binaries.yml
@@ -115,6 +115,7 @@ jobs:
 
       - name: Scheduled Destination Folder Override
         if: ${{ github.event_name == 'schedule' && github.event.schedule == '05 00 * * *' }}
+        shell: bash
         run: |
           echo "S3_DEST_OVERRIDE=daily/" >> $GITHUB_ENV
 
@@ -218,6 +219,7 @@ jobs:
           echo "CARGO_OPTIONS=${{ env.CARGO_OPTIONS }} --release" >> $GITHUB_ENV
 
       - name: Show command used for Cargo
+        shell: bash
         run: |
           echo "cargo command is: ${{ env.CARGO }}"
           echo "cargo options is: ${{ env.CARGO_OPTIONS }}"


### PR DESCRIPTION
Description
Use the bash shell to update GitHub Action Workflows envs for later use in S3 upload step.

Motivation and Context
Finally find out why env not updating for Windows workflows, seems that we need to use the bash shell to make changes.

How Has This Been Tested?
Run workflows in test branch from the repo

What process can a PR reviewer use to test or verify this change?
Check the s3 upload on Windows for any errors.

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
