### PR TITLE
chore(ci): ffi extend to build for none mobile platforms

### DIFF
--- a/.github/workflows/build_libffis.json
+++ b/.github/workflows/build_libffis.json
@@ -10,6 +10,24 @@
     "cross": true
   },
   {
+    "runs-on": "ubuntu-latest",
+    "target": "x86_64-unknown-linux-gnu",
+    "cross": false,
+    "build_enabled": true
+  },
+  {
+    "runs-on": "ubuntu-latest",
+    "target": "aarch64-unknown-linux-gnu",
+    "cross": false,
+    "build_enabled": false
+  },
+  {
+    "runs-on": "ubuntu-latest",
+    "target": "riscv64gc-unknown-linux-gnu",
+    "cross": false,
+    "build_enabled": false
+  },
+  {
     "runs-on": "macos-latest",
     "target": "x86_64-apple-ios",
     "cross": false
@@ -23,5 +41,29 @@
     "runs-on": "macos-latest",
     "target": "aarch64-apple-ios-sim",
     "cross": false
+  },
+  {
+    "runs-on": "macos-latest",
+    "target": "x86_64-apple-darwin",
+    "cross": false,
+    "build_enabled": true
+  },
+  {
+    "runs-on": "macos-latest",
+    "target": "aarch64-apple-darwin",
+    "cross": false,
+    "build_enabled": true
+  },
+  {
+    "runs-on": "windows-latest",
+    "target": "x86_64-pc-windows-msvc",
+    "cross": false,
+    "build_enabled": false
+  },
+  {
+    "runs-on": "windows-latest",
+    "target": "aarch64-pc-windows-msvc",
+    "cross": false,
+    "build_enabled": false
   }
 ]

--- a/.github/workflows/build_libffis.yml
+++ b/.github/workflows/build_libffis.yml
@@ -12,6 +12,9 @@ name: Build ffi libraries
 
 env:
   CARGO_UNSTABLE_SPARSE_REGISTRY: true
+  CARGO: cargo
+  # CARGO_OPTIONS: "--verbose"
+  CARGO_OPTIONS: "--release"
   TARI_NETWORK_CHANGELOG: 'development'
   TOOLCHAIN: 'stable'
   ## Must be a JSon string
@@ -30,28 +33,30 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
       libffiss: ${{ steps.set-matrix.outputs.libffiss }}
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout source code
+        uses: actions/checkout@v4
 
       - name: Set Matrix from JSon file
         id: set-matrix
         run: |
           ## build all targets images
-          # matrix=$( jq -s -c .[] .github/workflows/build_libffis_workflow.json )
-          matrix=$( jq -s -c .[] ${{ env.matrix-json-file }} )
+          # matrix=$( jq -s -c .[] ${{ env.matrix-json-file }} )
           #
           ## build only single target image
-          # matrix_selection=$( jq -c '.[] | select( ."runs-on" == "macos-latest" )' ${{ env.matrix-json-file }} )
+          # matrix_selection=$( jq -c '.[] | select( ."runs-on" == "ubuntu-latest" )' ${{ env.matrix-json-file }} )
           # matrix_selection=$( jq -c '.[] | select( ."runs-on" == "macos-latest" )' ${{ env.matrix-json-file }} )
           #
           ## buid select target images - build_enabled
-          # matrix_selection=$( jq -c '.[] | select( ."build_enabled" != false )' ${{ env.matrix-json-file }} )
+          matrix_selection=$( jq -c '.[] | select( ."build_enabled" != false )' ${{ env.matrix-json-file }} )
           #
           ## Setup json array
-          # matrix=$(echo ${matrix_selection} | jq -s -c)
+          matrix=$(echo ${matrix_selection} | jq -s -c)
           #
           ## Setup the json build matrix
           # matrix=$(echo ${matrix_selection} | jq -s -c '{"builds": .}')
           #
+          echo $matrix
+          echo $matrix | jq .
           echo "matrix=${matrix}" >> $GITHUB_OUTPUT
           echo "libffiss=${BUILD_LIBFFIS}" >> $GITHUB_OUTPUT
 
@@ -106,11 +111,15 @@ jobs:
           if [[ "${{ matrix.builds.target }}" =~ "android" ]]; then
             echo "CFLAGS=-DMDB_USE_ROBUST=0" >> $GITHUB_ENV
             echo "TARGET_PLATFORM=android" >> $GITHUB_ENV
-          else
+          elif [[ "${{ matrix.builds.target }}" =~ "ios" ]]; then
             echo "TARGET_PLATFORM=ios" >> $GITHUB_ENV
             if [[ "${{ matrix.builds.target }}" =~ "-sim" ]]; then
               echo "TARGET_SIM=-sim" >> $GITHUB_ENV
             fi
+          elif [[ "${{ matrix.builds.target }}" =~ "linux-gnu" ]]; then
+            echo "TARGET_PLATFORM=linux" >> $GITHUB_ENV
+          elif [[ "${{ matrix.builds.target }}" =~ "apple-darwin" ]]; then
+            echo "TARGET_PLATFORM=macos" >> $GITHUB_ENV
           fi
           # Strip begining
           tempEnv="${{ matrix.builds.target }}"
@@ -121,35 +130,47 @@ jobs:
           echo "TARGET_NAME=${tempEnv%_*}" >> $GITHUB_ENV
 
       - name: Setup Rust toolchain
+        if: ${{ ! matrix.builds.cross }}
         uses: dtolnay/rust-toolchain@master
         with:
           components: rustfmt, clippy
           toolchain: ${{ env.TOOLCHAIN }}
           targets: ${{ matrix.builds.target }}
 
-      # Don't use caches for binary builds when releasing. Start from a clean slate.
       - name: Cache cargo files and outputs
-        if: ${{ ! startsWith(github.ref, 'refs/tags/v') }}
+        if: ${{ ( ! startsWith(github.ref, 'refs/tags/v') ) && ( ! matrix.builds.cross ) }}
         uses: Swatinem/rust-cache@v2
+
+      - name: Install and setup cargo cross
+        if: ${{ matrix.builds.cross }}
+        shell: bash
+        run: |
+          cargo install cross
+          echo "CARGO=cross" >> $GITHUB_ENV
+
+      - name: Install rust target/toolchain for native/local cross-compile builds
+        if: ${{ ! matrix.builds.cross  }}
+        # if: ${{ ( ! matrix.builds.cross ) && env.TARGET_PLATFORM != 'ios' }}
+        run: |
+          rustup target add ${{ matrix.builds.target }}
+          # rustup toolchain install stable-${{ matrix.builds.target }} --force-non-host
+          rustup target list
+          rustup toolchain list
+          rustup show
+
+      - name: Show command used for Cargo
+        run: |
+          echo "cargo command is: ${{ env.CARGO }}"
+          echo "cargo options is: ${{ env.CARGO_OPTIONS }}"
+          echo "cross flag: ${{ matrix.builds.cross }}"
 
       - name: Build ${{ matrix.libffis }} libraries
         shell: bash
         run: |
-          # rustup target list
-          # rustup toolchain list
-          # rustup show
-          if [ "${{ matrix.builds.cross }}" == "true" ]; then
-            cargo install cross
-            cross build --lib --release --locked \
-              --package ${{ matrix.libffis }} \
-              --target=${{ matrix.builds.target }}
-          else
-            rustup target add ${{ matrix.builds.target }}
-            # rustup toolchain install stable-aarch64-unknown-linux-gnu --force-non-host
-            cargo build --lib --release --locked \
-              --package ${{ matrix.libffis }} \
-              --target=${{ matrix.builds.target }}
-          fi
+          ${{ env.CARGO }} build --lib ${{ env.CARGO_OPTIONS }} \
+            --package ${{ matrix.libffis }} \
+            --target=${{ matrix.builds.target }} \
+            --locked
 
       - name: Prepare ${{ matrix.libffis }} libraries
         shell: bash


### PR DESCRIPTION
Description
Extend and fix ffi lib builds to include none ```mobile platforms```

Motivation and Context
Tools like CakeWallet are not mobile only tools, which might need ffi libs.

How Has This Been Tested?
Built in local fork.

What process can a PR reviewer use to test or verify this change?
Note workflow build artefacts.

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
