### PR TITLE
feat: turn off node metrics by default

### DIFF
--- a/applications/minotari_node/Cargo.toml
+++ b/applications/minotari_node/Cargo.toml
@@ -52,7 +52,7 @@ tonic = { version = "0.6.2", features = ["tls", "tls-roots" ] }
 tari_metrics = { path = "../../infrastructure/metrics", optional = true, features = ["server"] }
 
 [features]
-default = ["metrics", "libtor"]
+default = ["libtor"]
 metrics = ["tari_metrics", "tari_comms/metrics"]
 safe = []
 libtor = ["tari_libtor"]

--- a/applications/minotari_node/src/commands/command/get_network_stats.rs
+++ b/applications/minotari_node/src/commands/command/get_network_stats.rs
@@ -25,6 +25,7 @@ use async_trait::async_trait;
 use clap::Parser;
 
 use super::{CommandContext, HandleCommand};
+#[cfg(feature = "metrics")]
 use crate::table::Table;
 
 /// Displays network stats

--- a/applications/minotari_node/src/lib.rs
+++ b/applications/minotari_node/src/lib.rs
@@ -55,10 +55,9 @@ use tokio::task;
 use tonic::transport::{Identity, Server, ServerTlsConfig};
 
 use crate::cli::Cli;
-pub use crate::{
-    config::{ApplicationConfig, BaseNodeConfig, DatabaseType},
-    metrics::MetricsConfig,
-};
+pub use crate::config::{ApplicationConfig, BaseNodeConfig, DatabaseType};
+#[cfg(feature = "metrics")]
+pub use crate::metrics::MetricsConfig;
 
 const LOG_TARGET: &str = "minotari::base_node::app";
 

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 minotari_app_grpc = { path = "../applications/minotari_app_grpc" }
 minotari_app_utilities = { path = "../applications/minotari_app_utilities" }
-minotari_node = { path = "../applications/minotari_node" }
+minotari_node = { path = "../applications/minotari_node", features = ["metrics"] }
 minotari_node_grpc_client = { path = "../clients/rust/base_node_grpc_client" }
 tari_chat_client = { path = "../base_layer/contacts/src/chat_client" }
 minotari_chat_ffi = { path = "../base_layer/chat_ffi" }


### PR DESCRIPTION
Description
---
This make the node metrics opt-in instead of opt-out at compile time.

It is strange we need to leave metrics on in the integration tests. This
is mostly because clippy is often run with `--all-features` which means
metrics would be on in the node, and then required in the integration
configuration.

Closes: #5787 

Motivation and Context
---
Mostly the metrics library has a chance of failure (panics) and it's generally better (and more private) if we just have metrics off by default.

How Has This Been Tested?
---
CI

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
