### PR TITLE
feat: add tari address as valid string for discovering a peer

### DIFF
--- a/applications/minotari_app_utilities/src/utilities.rs
+++ b/applications/minotari_app_utilities/src/utilities.rs
@@ -27,6 +27,7 @@ use log::*;
 use tari_common::exit_codes::{ExitCode, ExitError};
 use tari_common_types::{
     emoji::EmojiId,
+    tari_address::TariAddress,
     types::{BlockHash, PublicKey},
 };
 use tari_comms::{peer_manager::NodeId, types::CommsPublicKey};
@@ -82,6 +83,8 @@ impl FromStr for UniPublicKey {
             Ok(Self(emoji_id.to_public_key()))
         } else if let Ok(public_key) = PublicKey::from_hex(key) {
             Ok(Self(public_key))
+        } else if let Ok(tari_address) = TariAddress::from_hex(key) {
+            Ok(Self(tari_address.public_key().clone()))
         } else {
             Err(UniIdError::UnknownIdType)
         }
@@ -98,6 +101,7 @@ impl From<UniPublicKey> for PublicKey {
 pub enum UniNodeId {
     PublicKey(PublicKey),
     NodeId(NodeId),
+    TariAddress(TariAddress),
 }
 
 #[derive(Debug, Error)]
@@ -118,6 +122,8 @@ impl FromStr for UniNodeId {
             Ok(Self::PublicKey(public_key))
         } else if let Ok(node_id) = NodeId::from_hex(key) {
             Ok(Self::NodeId(node_id))
+        } else if let Ok(tari_address) = TariAddress::from_hex(key) {
+            Ok(Self::TariAddress(tari_address))
         } else {
             Err(UniIdError::UnknownIdType)
         }
@@ -130,6 +136,7 @@ impl TryFrom<UniNodeId> for PublicKey {
     fn try_from(id: UniNodeId) -> Result<Self, Self::Error> {
         match id {
             UniNodeId::PublicKey(public_key) => Ok(public_key),
+            UniNodeId::TariAddress(tari_address) => Ok(tari_address.public_key().clone()),
             UniNodeId::NodeId(_) => Err(UniIdError::Nonconvertible),
         }
     }
@@ -140,6 +147,7 @@ impl From<UniNodeId> for NodeId {
         match id {
             UniNodeId::PublicKey(public_key) => NodeId::from_public_key(&public_key),
             UniNodeId::NodeId(node_id) => node_id,
+            UniNodeId::TariAddress(tari_address) => NodeId::from_public_key(tari_address.public_key()),
         }
     }
 }

--- a/applications/minotari_console_wallet/README.md
+++ b/applications/minotari_console_wallet/README.md
@@ -226,7 +226,7 @@ Maximum value UTXO   : 5538.616395 T
 
 Discover a peer on the network by public key or emoji id.
 
-`minotari_console_wallet --command "discover-peer <public key or emoji id>"`
+`minotari_console_wallet --command "discover-peer <public key or emoji id or tari address>"`
 
 example output:
 


### PR DESCRIPTION
Description
---
Allow the use of a TariAddress as well as public key or node id when discovering new peers in the wallet or base node.

Motivation and Context
---
Easier to manage expectations. When selecting your wallet address it's shows as a TariAddress, so someone needs to be able to do something with that.

How Has This Been Tested?
---
locally

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
