### PR TITLE
fix: tms validation correctly updating

### DIFF
--- a/applications/minotari_app_grpc/proto/block.proto
+++ b/applications/minotari_app_grpc/proto/block.proto
@@ -121,7 +121,6 @@ message NewBlockHeaderTemplate {
     bytes total_kernel_offset = 4;
     // Proof of work metadata
     ProofOfWork pow = 5;
-//    uint64 target_difficulty = 6;
     // Sum of script offsets for all kernels in this block.
     bytes total_script_offset = 7;
 }

--- a/applications/minotari_app_grpc/proto/wallet.proto
+++ b/applications/minotari_app_grpc/proto/wallet.proto
@@ -227,6 +227,8 @@ enum TransactionStatus {
     TRANSACTION_STATUS_COINBASE_UNCONFIRMED = 12;
     // This is Coinbase transaction that is detected from chain
     TRANSACTION_STATUS_COINBASE_CONFIRMED = 13;
+    // This is Coinbase transaction that is not currently detected as mined
+    TRANSACTION_STATUS_COINBASE_NOT_IN_BLOCK_CHAIN = 14;
 }
 
 message GetCompletedTransactionsRequest { }

--- a/applications/minotari_app_grpc/src/conversions/transaction.rs
+++ b/applications/minotari_app_grpc/src/conversions/transaction.rs
@@ -104,6 +104,7 @@ impl From<TransactionStatus> for grpc::TransactionStatus {
             OneSidedConfirmed => grpc::TransactionStatus::OneSidedConfirmed,
             CoinbaseUnconfirmed => grpc::TransactionStatus::CoinbaseUnconfirmed,
             CoinbaseConfirmed => grpc::TransactionStatus::CoinbaseConfirmed,
+            CoinbaseNotInBlockChain => grpc::TransactionStatus::CoinbaseNotInBlockChain,
             Queued => grpc::TransactionStatus::Queued,
         }
     }

--- a/base_layer/common_types/src/transaction.rs
+++ b/base_layer/common_types/src/transaction.rs
@@ -38,10 +38,13 @@ pub enum TransactionStatus {
     OneSidedConfirmed = 9,
     /// This transaction is still being queued for initial sending
     Queued = 10,
-    /// This transaction import status is used when a one-sided transaction has been scanned but is unconfirmed
+    /// This transaction import status is used when a coinbase transaction has been scanned but is unconfirmed
     CoinbaseUnconfirmed = 11,
-    /// This transaction import status is used when a one-sided transaction has been scanned and confirmed
+    /// This transaction import status is used when a coinbase transaction has been scanned and confirmed
     CoinbaseConfirmed = 12,
+    /// This transaction import status is used when a coinbase transaction has been scanned but the outputs are not
+    /// currently confirmed on the blockchain via the output manager
+    CoinbaseNotInBlockChain = 13,
 }
 
 impl TransactionStatus {
@@ -55,7 +58,9 @@ impl TransactionStatus {
     pub fn is_coinbase(&self) -> bool {
         matches!(
             self,
-            TransactionStatus::CoinbaseUnconfirmed | TransactionStatus::CoinbaseConfirmed
+            TransactionStatus::CoinbaseUnconfirmed |
+                TransactionStatus::CoinbaseConfirmed |
+                TransactionStatus::CoinbaseNotInBlockChain
         )
     }
 
@@ -81,9 +86,9 @@ impl TransactionStatus {
             TransactionStatus::Imported |
             TransactionStatus::OneSidedUnconfirmed |
             TransactionStatus::OneSidedConfirmed => TransactionStatus::OneSidedConfirmed,
-            TransactionStatus::CoinbaseConfirmed | TransactionStatus::CoinbaseUnconfirmed => {
-                TransactionStatus::CoinbaseConfirmed
-            },
+            TransactionStatus::CoinbaseNotInBlockChain |
+            TransactionStatus::CoinbaseConfirmed |
+            TransactionStatus::CoinbaseUnconfirmed => TransactionStatus::CoinbaseConfirmed,
         }
     }
 
@@ -100,9 +105,9 @@ impl TransactionStatus {
             TransactionStatus::Imported |
             TransactionStatus::OneSidedUnconfirmed |
             TransactionStatus::OneSidedConfirmed => TransactionStatus::OneSidedUnconfirmed,
-            TransactionStatus::CoinbaseConfirmed | TransactionStatus::CoinbaseUnconfirmed => {
-                TransactionStatus::CoinbaseUnconfirmed
-            },
+            TransactionStatus::CoinbaseConfirmed |
+            TransactionStatus::CoinbaseUnconfirmed |
+            TransactionStatus::CoinbaseNotInBlockChain => TransactionStatus::CoinbaseUnconfirmed,
         }
     }
 }
@@ -131,6 +136,7 @@ impl TryFrom<i32> for TransactionStatus {
             10 => Ok(TransactionStatus::Queued),
             11 => Ok(TransactionStatus::CoinbaseUnconfirmed),
             12 => Ok(TransactionStatus::CoinbaseConfirmed),
+            13 => Ok(TransactionStatus::CoinbaseNotInBlockChain),
             code => Err(TransactionConversionError { code }),
         }
     }
@@ -152,6 +158,7 @@ impl Display for TransactionStatus {
             TransactionStatus::OneSidedConfirmed => write!(f, "One-Sided Confirmed"),
             TransactionStatus::CoinbaseUnconfirmed => write!(f, "Coinbase Unconfirmed"),
             TransactionStatus::CoinbaseConfirmed => write!(f, "Coinbase Confirmed"),
+            TransactionStatus::CoinbaseNotInBlockChain => write!(f, "Coinbase not mined"),
             TransactionStatus::Queued => write!(f, "Queued"),
         }
     }
@@ -165,9 +172,9 @@ pub enum ImportStatus {
     OneSidedUnconfirmed,
     /// This transaction import status is used when a one-sided transaction has been scanned and confirmed
     OneSidedConfirmed,
-    /// This transaction import status is used when a one-sided transaction has been scanned but is unconfirmed
+    /// This transaction import status is used when a coinbasetransaction has been scanned but is unconfirmed
     CoinbaseUnconfirmed,
-    /// This transaction import status is used when a one-sided transaction has been scanned and confirmed
+    /// This transaction import status is used when a coinbase transaction has been scanned and confirmed
     CoinbaseConfirmed,
 }
 

--- a/base_layer/core/src/base_node/rpc/service.rs
+++ b/base_layer/core/src/base_node/rpc/service.rs
@@ -313,7 +313,7 @@ impl<B: BlockchainBackend + 'static> BaseNodeWalletService for BaseNodeWalletRpc
                 location: response.location,
                 block_hash: response.block_hash,
                 confirmations: response.confirmations,
-                block_height: response.height_of_longest_chain - response.confirmations,
+                block_height: response.height_of_longest_chain.saturating_sub(response.confirmations),
                 mined_timestamp: response.mined_timestamp,
             });
         }

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_validation_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_validation_protocol.rs
@@ -285,7 +285,10 @@ where
                 .map_err(TransactionServiceError::ProtobufConversionError)?;
             let sig = response.signature;
             if let Some(unconfirmed_tx) = batch_signatures.get(&sig) {
-                if response.location == TxLocation::Mined && response.block_hash.is_some() {
+                if response.location == TxLocation::Mined &&
+                    response.block_hash.is_some() &&
+                    response.mined_timestamp.is_some()
+                {
                     mined.push((
                         (*unconfirmed_tx).clone(),
                         response.block_height,
@@ -296,10 +299,8 @@ where
                 } else {
                     warn!(
                         target: LOG_TARGET,
-                        "Marking transaction {} as unmined and confirmed '{}' with block '{}' (Operation ID: {})",
+                        "Transaction {} is unmined (Operation ID: {})",
                         &unconfirmed_tx.tx_id,
-                        response.confirmations >= self.config.num_confirmations_required,
-                        response.block_hash.is_some(),
                         self.operation_id,
                     );
                     unmined.push((*unconfirmed_tx).clone());

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -2530,7 +2530,7 @@ where
             JoinHandle<Result<OperationId, TransactionServiceProtocolError<OperationId>>>,
         >,
     ) -> Result<OperationId, TransactionServiceError> {
-        self.resources.db.mark_all_transactions_as_unvalidated()?;
+        self.resources.db.mark_all_non_coinbases_transactions_as_unvalidated()?;
         self.start_transaction_validation_protocol(join_handles).await
     }
 

--- a/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
@@ -1883,13 +1883,6 @@ impl CompletedTransactionSql {
             .ok_or(TransactionStorageError::DieselError(DieselError::NotFound))?;
         let current_status = TransactionStatus::try_from(current_status)
             .map_err(|_| TransactionStorageError::UnexpectedResult("Unknown status".to_string()))?;
-        // let current_mined_height = *completed_transactions::table
-        //     .filter(completed_transactions::tx_id.eq(tx_id.as_u64() as i64))
-        //     .select(completed_transactions::mined_height)
-        //     .load::<Option<i64>>(conn)?
-        //     .first()
-        //     .ok_or(TransactionStorageError::DieselError(DieselError::NotFound))?;
-        // This query uses two sub-queries to retrieve existing values in the table
         diesel::update(completed_transactions::table.filter(completed_transactions::tx_id.eq(tx_id.as_u64() as i64)))
             .set(UpdateCompletedTransactionSql {
                 status: match current_status {

--- a/base_layer/wallet/src/transaction_service/tasks/check_faux_transaction_status.rs
+++ b/base_layer/wallet/src/transaction_service/tasks/check_faux_transaction_status.rs
@@ -137,7 +137,7 @@ pub async fn check_detected_transactions<TBackend: 'static + TransactionBackend>
         let previously_confirmed = tx.status.is_confirmed();
         let must_be_confirmed =
             tip_height.saturating_sub(mined_height) >= TransactionServiceConfig::default().num_confirmations_required;
-        let num_confirmations = tip_height - mined_height;
+        let num_confirmations = tip_height.saturating_sub(mined_height);
         debug!(
             target: LOG_TARGET,
             "Updating faux transaction: TxId({}), mined_height({}), must_be_confirmed({}), num_confirmations({}), \

--- a/base_layer/wallet/src/transaction_service/tasks/check_faux_transaction_status.rs
+++ b/base_layer/wallet/src/transaction_service/tasks/check_faux_transaction_status.rs
@@ -20,10 +20,12 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+const SAFETY_HEIGHT_MARGIN: u64 = 1000;
+
 use std::sync::Arc;
 
 use log::*;
-use tari_common_types::types::{BlockHash, FixedHash};
+use tari_common_types::types::FixedHash;
 
 use crate::{
     output_manager_service::handle::OutputManagerHandle,
@@ -46,6 +48,20 @@ pub async fn check_detected_transactions<TBackend: 'static + TransactionBackend>
     event_publisher: TransactionEventSender,
     tip_height: u64,
 ) {
+    // Reorged faux transactions cannot be detected by excess signature, thus use last known confirmed transaction
+    // height or current tip height with safety margin to determine if these should be returned
+    let last_mined_transaction = match db.fetch_last_mined_transaction() {
+        Ok(tx) => tx,
+        Err(_) => None,
+    };
+
+    let height_with_margin = tip_height.saturating_sub(SAFETY_HEIGHT_MARGIN);
+    let check_height = if let Some(tx) = last_mined_transaction {
+        tx.mined_height.unwrap_or(height_with_margin)
+    } else {
+        height_with_margin
+    };
+
     let mut all_detected_transactions: Vec<CompletedTransaction> = match db.get_imported_transactions() {
         Ok(txs) => txs,
         Err(e) => {
@@ -64,18 +80,19 @@ pub async fn check_detected_transactions<TBackend: 'static + TransactionBackend>
         },
     };
     all_detected_transactions.append(&mut unconfirmed_detected);
-    // Reorged faux transactions cannot be detected by excess signature, thus use last known confirmed transaction
-    // height or current tip height with safety margin to determine if these should be returned
-    let last_mined_transaction = match db.fetch_last_mined_transaction() {
-        Ok(tx) => tx,
-        Err(_) => None,
+
+    let mut unmined_coinbases_detected = match db.get_unmined_coinbase_transactions(height_with_margin) {
+        Ok(txs) => txs,
+        Err(e) => {
+            error!(
+                target: LOG_TARGET,
+                "Problem retrieving unmined coinbase transactions: {}", e
+            );
+            return;
+        },
     };
-    let height_with_margin = tip_height.saturating_sub(100);
-    let check_height = if let Some(tx) = last_mined_transaction {
-        tx.mined_height.unwrap_or(height_with_margin)
-    } else {
-        height_with_margin
-    };
+    all_detected_transactions.append(&mut unmined_coinbases_detected);
+
     let mut confirmed_dectected = match db.get_confirmed_detected_transactions_from_height(check_height) {
         Ok(txs) => txs,
         Err(e) => {
@@ -101,17 +118,21 @@ pub async fn check_detected_transactions<TBackend: 'static + TransactionBackend>
                 return;
             },
         };
+        // Its safe to assume that statuses should be the same as they are all in the same transaction and they cannot
+        // be different.
         let output_status = output_info_for_tx_id.statuses[0];
-        let mined_height = if let Some(height) = output_info_for_tx_id.mined_height {
-            height
-        } else {
-            tip_height
-        };
-        let mined_in_block: BlockHash = if let Some(hash) = output_info_for_tx_id.block_hash {
-            hash
-        } else {
-            FixedHash::zero()
-        };
+        if output_info_for_tx_id.mined_height.is_none() || output_info_for_tx_id.block_hash.is_none() {
+            // this means the transaction is not detected as mined
+            if let Err(e) = db.set_transaction_as_unmined(tx.tx_id) {
+                error!(
+                    target: LOG_TARGET,
+                    "Error setting faux transaction to unmined: {}", e
+                );
+            }
+            continue;
+        }
+        let mined_height = output_info_for_tx_id.mined_height.unwrap_or(0);
+        let mined_in_block = output_info_for_tx_id.block_hash.unwrap_or(FixedHash::zero());
         let is_valid = tip_height >= mined_height;
         let previously_confirmed = tx.status.is_confirmed();
         let must_be_confirmed =

--- a/base_layer/wallet/tests/transaction_service_tests/service.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/service.rs
@@ -304,9 +304,7 @@ async fn setup_transaction_service_no_comms(
     factories: CryptoFactories,
     db_connection: WalletDbConnection,
     config: Option<TransactionServiceConfig>,
-) ->
-    TransactionServiceNoCommsInterface
-{
+) -> TransactionServiceNoCommsInterface {
     let (oms_request_sender, oms_request_receiver) = reply_channel::unbounded();
 
     let (output_manager_service_event_publisher, _) = broadcast::channel(200);
@@ -1943,8 +1941,7 @@ async fn test_accepting_unknown_tx_id_and_malformed_reply() {
     let bob_node_identity =
         NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE);
 
-    let mut alice_ts_interface=
-        setup_transaction_service_no_comms(factories.clone(), connection_alice, None).await;
+    let mut alice_ts_interface = setup_transaction_service_no_comms(factories.clone(), connection_alice, None).await;
 
     let uo = make_input(
         &mut OsRng,
@@ -2039,8 +2036,7 @@ async fn finalize_tx_with_incorrect_pubkey() {
     let connection_alice = run_migration_and_create_sqlite_connection(&alice_db_path, 16).unwrap();
     let connection_bob = run_migration_and_create_sqlite_connection(&bob_db_path, 16).unwrap();
 
-    let mut alice_ts_interface =
-        setup_transaction_service_no_comms(factories.clone(), connection_alice, None).await;
+    let mut alice_ts_interface = setup_transaction_service_no_comms(factories.clone(), connection_alice, None).await;
     let mut alice_event_stream = alice_ts_interface.transaction_service_handle.get_event_stream();
 
     let bob_node_identity =
@@ -2164,8 +2160,7 @@ async fn finalize_tx_with_missing_output() {
     let connection_alice = run_migration_and_create_sqlite_connection(&alice_db_path, 16).unwrap();
     let connection_bob = run_migration_and_create_sqlite_connection(&bob_db_path, 16).unwrap();
 
-    let mut alice_ts_interface =
-        setup_transaction_service_no_comms(factories.clone(), connection_alice, None).await;
+    let mut alice_ts_interface = setup_transaction_service_no_comms(factories.clone(), connection_alice, None).await;
     let mut alice_event_stream = alice_ts_interface.transaction_service_handle.get_event_stream();
 
     let bob_node_identity =
@@ -3623,8 +3618,7 @@ async fn test_restarting_transaction_protocols() {
     let factories = CryptoFactories::default();
     let (alice_connection, _temp_dir) = make_wallet_database_connection(None);
 
-    let mut alice_ts_interface =
-        setup_transaction_service_no_comms(factories.clone(), alice_connection, None).await;
+    let mut alice_ts_interface = setup_transaction_service_no_comms(factories.clone(), alice_connection, None).await;
 
     let alice_backend = alice_ts_interface.ts_db;
 
@@ -5275,8 +5269,7 @@ async fn test_update_faux_tx_on_oms_validation() {
 
     let (connection, _temp_dir) = make_wallet_database_connection(None);
 
-    let mut alice_ts_interface =
-        setup_transaction_service_no_comms(factories.clone(), connection, None).await;
+    let mut alice_ts_interface = setup_transaction_service_no_comms(factories.clone(), connection, None).await;
     let alice_address = TariAddress::new(
         alice_ts_interface.base_node_identity.public_key().clone(),
         Network::LocalNet,
@@ -5359,10 +5352,11 @@ async fn test_update_faux_tx_on_oms_validation() {
             .add_output_with_tx_id(tx_id, uo.clone(), None)
             .await
             .unwrap();
+        let _result = alice_ts_interface
+            .oms_db
+            .mark_output_as_unspent(uo.hash(&alice_ts_interface.key_manager_handle).await.unwrap());
         alice_ts_interface
             .oms_db
-            .mark_output_as_unspent(uo.hash(&alice_ts_interface.key_manager_handle).await.unwrap())
-        alice_db
             .set_received_output_mined_height_and_status(
                 uo.hash(&alice_ts_interface.key_manager_handle).await.unwrap(),
                 5,
@@ -5428,7 +5422,6 @@ async fn test_update_faux_tx_on_oms_validation() {
                 if tx_id == tx_id_2 && tx.status == TransactionStatus::OneSidedUnconfirmed && !found_faux_unconfirmed {
                     found_faux_unconfirmed = true;
                 }
-                dbg!(&tx.status);
                 if tx_id == tx_id_3 && tx.status == TransactionStatus::OneSidedConfirmed && !found_faux_confirmed {
                     found_faux_confirmed = true;
                 }
@@ -5450,8 +5443,7 @@ async fn test_update_coinbase_tx_on_oms_validation() {
 
     let (connection, _temp_dir) = make_wallet_database_connection(None);
 
-    let mut alice_ts_interface =
-        setup_transaction_service_no_comms(factories.clone(), connection, None).await;
+    let mut alice_ts_interface = setup_transaction_service_no_comms(factories.clone(), connection, None).await;
     let alice_address = TariAddress::new(
         alice_ts_interface.base_node_identity.public_key().clone(),
         Network::LocalNet,
@@ -5535,7 +5527,8 @@ async fn test_update_coinbase_tx_on_oms_validation() {
             .await
             .unwrap();
         if uo.value != MicroMinotari::from(30000) {
-            let _ = alice_ts_interface.oms_db
+            let _ = alice_ts_interface
+                .oms_db
                 .set_received_output_mined_height_and_status(
                     uo.hash(&alice_ts_interface.key_manager_handle).await.unwrap(),
                     5,

--- a/base_layer/wallet/tests/transaction_service_tests/service.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/service.rs
@@ -5362,6 +5362,14 @@ async fn test_update_faux_tx_on_oms_validation() {
         alice_ts_interface
             .oms_db
             .mark_output_as_unspent(uo.hash(&alice_ts_interface.key_manager_handle).await.unwrap())
+        alice_db
+            .set_received_output_mined_height_and_status(
+                uo.hash(&alice_ts_interface.key_manager_handle).await.unwrap(),
+                5,
+                HashOutput::zero(),
+                false,
+                0,
+            )
             .unwrap();
     }
 

--- a/base_layer/wallet/tests/transaction_service_tests/service.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/service.rs
@@ -5527,7 +5527,7 @@ async fn test_update_coinbase_tx_on_oms_validation() {
             .await
             .unwrap();
         if uo.value != MicroMinotari::from(30000) {
-            let _ = alice_ts_interface
+            alice_ts_interface
                 .oms_db
                 .set_received_output_mined_height_and_status(
                     uo.hash(&alice_ts_interface.key_manager_handle).await.unwrap(),

--- a/base_layer/wallet/tests/transaction_service_tests/transaction_protocols.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/transaction_protocols.rs
@@ -997,7 +997,10 @@ async fn tx_revalidation() {
 
     rpc_service_state.set_transaction_query_batch_responses(batch_query_response.clone());
     // revalidate sets all to unvalidated, so lets check that thay are
-    resources.db.mark_all_transactions_as_unvalidated().unwrap();
+    resources
+        .db
+        .mark_all_non_coinbases_transactions_as_unvalidated()
+        .unwrap();
     let completed_txs = resources.db.get_completed_transactions().unwrap();
     assert_eq!(
         completed_txs.get(&2u64.into()).unwrap().status,

--- a/integration_tests/tests/features/Sync.feature
+++ b/integration_tests/tests/features/Sync.feature
@@ -30,7 +30,7 @@ Feature: Block Sync
     When I have 2 base nodes connected to all seed nodes
     Then all nodes are at height 20
 
-  @critical @pie
+  @critical
   Scenario: Sync burned output
     Given I have a seed node NODE
     When I have a base node NODE1 connected to all seed nodes

--- a/integration_tests/tests/features/WalletTransactions.feature
+++ b/integration_tests/tests/features/WalletTransactions.feature
@@ -407,7 +407,7 @@ Feature: Wallet Transactions
   #   When I wait 15 seconds
   #   When wallet WALLET_RECV detects last transaction is Cancelled
 
-  @critical
+  @critical  @flaky
   Scenario: Create burn transaction
     Given I have a seed node NODE
     When I have 2 base nodes connected to all seed nodes

--- a/integration_tests/tests/steps/wallet_steps.rs
+++ b/integration_tests/tests/steps/wallet_steps.rs
@@ -239,8 +239,7 @@ async fn wallet_detects_all_txs_as_mined_status(world: &mut TariWorld, wallet_na
                     _ => (),
                 },
                 "Coinbase" => match tx_info.status() {
-                    grpc::TransactionStatus::CoinbaseConfirmed |
-                    grpc::TransactionStatus::CoinbaseUnconfirmed => {
+                    grpc::TransactionStatus::CoinbaseConfirmed | grpc::TransactionStatus::CoinbaseUnconfirmed => {
                         break;
                     },
                     _ => (),

--- a/integration_tests/tests/steps/wallet_steps.rs
+++ b/integration_tests/tests/steps/wallet_steps.rs
@@ -153,7 +153,7 @@ async fn have_wallet_connect_to_seed_node(world: &mut TariWorld, wallet: String,
 
 #[when(expr = "wallet {word} detects all transactions as {word}")]
 #[then(expr = "wallet {word} detects all transactions as {word}")]
-async fn wallet_detects_all_txs_as_mined_confirmed(world: &mut TariWorld, wallet_name: String, status: String) {
+async fn wallet_detects_all_txs_as_mined_status(world: &mut TariWorld, wallet_name: String, status: String) {
     let mut client = create_wallet_client(world, wallet_name.clone()).await.unwrap();
 
     let mut completed_tx_stream = client
@@ -239,11 +239,6 @@ async fn wallet_detects_all_txs_as_mined_confirmed(world: &mut TariWorld, wallet
                     _ => (),
                 },
                 "Coinbase" => match tx_info.status() {
-                    grpc::TransactionStatus::Pending |
-                    grpc::TransactionStatus::Completed |
-                    grpc::TransactionStatus::Broadcast |
-                    grpc::TransactionStatus::MinedUnconfirmed |
-                    grpc::TransactionStatus::MinedConfirmed |
                     grpc::TransactionStatus::CoinbaseConfirmed |
                     grpc::TransactionStatus::CoinbaseUnconfirmed => {
                         break;


### PR DESCRIPTION
Description
---
Fixes TMS validation to not keep updating the mined height of coinbase transactions

Motivation and Context
---
Currently, there is a bug in the coinbase validation where if its not mined, it keeps increasing the mined height. 
This changes it to use the OMS to track coinbases as they need to be tracked from the output via the OMS. 
