### PR TITLE
feat: update codeowners (stagenet)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,10 @@
-@stringhandler @CjS77 @sdbondi
+# CI/CD-related files require a review by the devops team
+.github/**/* @tari-project/devops
+scripts/**/* @tari-project/devops
+CODEOWNERS @tari-project/devops
+
+# Consensus code requires approvals by lead maintainers
+base_layer/core/src/consensus/**/* @tari-project/lead-maintainers
+base_layer/core/src/**/* @tari-project/tari-core-developers
+base_layer/key_manager/src/**/* @tari-project/tari-core-developers
+base_layer/wallet/src/**/* @tari-project/tari-core-developers


### PR DESCRIPTION
Marks CI/CD files as sensitive and requiring a review by a DevOps team member.

Sensitive consensus needs a lead maintainer review.

other base layer code requires a review by core devs.

** REQUIRES "require reviews by codeowners" setting in branch protection rules **

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
