### PR TITLE
chore: rename chain metadata fields to be consistent with its meaning

### DIFF
--- a/applications/minotari_app_grpc/proto/base_node.proto
+++ b/applications/minotari_app_grpc/proto/base_node.proto
@@ -310,9 +310,9 @@ enum Sorting {
 
 message MetaData {
     // The current chain height, or the block number of the longest valid chain, or `None` if there is no chain
-    uint64 height_of_longest_chain = 1;
+    uint64 best_block_height = 1;
     // The block hash of the current tip of the longest valid chain, or `None` for an empty chain
-    bytes best_block = 2;
+    bytes best_block_hash = 2;
     // This is the min height this node can provide complete blocks for. A 0 here means this node is archival and can provide complete blocks for every height.
     uint64 pruned_height = 6;
     // The current geometric mean of the pow of the chain tip, or `None` if there is no chain

--- a/applications/minotari_app_grpc/src/conversions/chain_metadata.rs
+++ b/applications/minotari_app_grpc/src/conversions/chain_metadata.rs
@@ -29,8 +29,8 @@ impl From<ChainMetadata> for grpc::MetaData {
         let mut diff = [0u8; 32];
         meta.accumulated_difficulty().to_big_endian(&mut diff);
         Self {
-            height_of_longest_chain: meta.height_of_longest_chain(),
-            best_block: meta.best_block().to_vec(),
+            best_block_height: meta.best_block_height(),
+            best_block_hash: meta.best_block_hash().to_vec(),
             pruned_height: meta.pruned_height(),
             accumulated_difficulty: diff.to_vec(),
         }

--- a/applications/minotari_console_wallet/src/automation/commands.rs
+++ b/applications/minotari_console_wallet/src/automation/commands.rs
@@ -1106,7 +1106,7 @@ async fn get_tip_height(wallet: &WalletSqlite) -> Option<u64> {
             .await
             .ok()
             .and_then(|t| t.metadata)
-            .map(|m| m.height_of_longest_chain),
+            .map(|m| m.best_block_height),
         None => None,
     }
 }

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -165,7 +165,7 @@ impl WalletGrpcServer {
             .wallet
             .db
             .get_chain_metadata()?
-            .map(|m| m.height_of_longest_chain())
+            .map(|m| m.best_block_height())
             .unwrap_or_default();
         Ok(self.rules.consensus_constants(height))
     }

--- a/applications/minotari_console_wallet/src/ui/components/base_node.rs
+++ b/applications/minotari_console_wallet/src/ui/components/base_node.rs
@@ -68,7 +68,7 @@ impl<B: Backend> Component<B> for BaseNode {
             OnlineStatus::Online => {
                 let base_node_state = app_state.get_base_node_state();
                 if let Some(ref metadata) = base_node_state.chain_metadata {
-                    let tip = metadata.height_of_longest_chain();
+                    let tip = metadata.best_block_height();
 
                     let synced = base_node_state.is_synced.unwrap_or_default();
                     let (tip_color, sync_text) = if synced {

--- a/applications/minotari_console_wallet/src/ui/components/transactions_tab.rs
+++ b/applications/minotari_console_wallet/src/ui/components/transactions_tab.rs
@@ -198,10 +198,7 @@ impl TransactionsTab {
             .collect();
 
         let base_node_state = app_state.get_base_node_state();
-        let chain_height = base_node_state
-            .chain_metadata
-            .as_ref()
-            .map(|cm| cm.height_of_longest_chain());
+        let chain_height = base_node_state.chain_metadata.as_ref().map(|cm| cm.best_block_height());
 
         let mut column0_items = Vec::new();
         let mut column1_items = Vec::new();

--- a/applications/minotari_merge_mining_proxy/src/block_template_protocol.rs
+++ b/applications/minotari_merge_mining_proxy/src/block_template_protocol.rs
@@ -179,7 +179,7 @@ impl BlockTemplateProtocol<'_> {
             .get_tip_info(grpc::Empty {})
             .await?
             .into_inner();
-        let tip_height = tip.metadata.as_ref().map(|m| m.height_of_longest_chain).unwrap_or(0);
+        let tip_height = tip.metadata.as_ref().map(|m| m.best_block_height).unwrap_or(0);
 
         if height <= tip_height {
             warn!(

--- a/applications/minotari_merge_mining_proxy/src/proxy.rs
+++ b/applications/minotari_merge_mining_proxy/src/proxy.rs
@@ -195,7 +195,7 @@ impl InnerService {
             .get_ref()
             .metadata
             .as_ref()
-            .map(|meta| meta.height_of_longest_chain)
+            .map(|meta| meta.best_block_height)
             .ok_or(MmProxyError::GrpcResponseMissingField("base node metadata"))?;
         if result.get_ref().initial_sync_achieved != self.initial_sync_achieved.load(Ordering::SeqCst) {
             self.initial_sync_achieved
@@ -416,7 +416,7 @@ impl InnerService {
                 self.initial_sync_achieved.store(true, Ordering::SeqCst);
                 let msg = format!(
                     "Initial base node sync achieved. Ready to mine at height #{}",
-                    metadata.as_ref().map(|h| h.height_of_longest_chain).unwrap_or_default(),
+                    metadata.as_ref().map(|h| h.best_block_height).unwrap_or_default(),
                 );
                 debug!(target: LOG_TARGET, "{}", msg);
                 println!("{}", msg);
@@ -424,7 +424,7 @@ impl InnerService {
             } else {
                 let msg = format!(
                     "Initial base node sync not achieved, current height at #{} ... (waiting = {})",
-                    metadata.as_ref().map(|h| h.height_of_longest_chain).unwrap_or_default(),
+                    metadata.as_ref().map(|h| h.best_block_height).unwrap_or_default(),
                     self.config.wait_for_initial_sync_at_startup,
                 );
                 debug!(target: LOG_TARGET, "{}", msg);
@@ -590,7 +590,7 @@ impl InnerService {
 
         let tip_header = client
             .get_header_by_hash(grpc::GetHeaderByHashRequest {
-                hash: chain_metadata.best_block,
+                hash: chain_metadata.best_block_hash,
             })
             .await?;
 

--- a/applications/minotari_miner/src/run_miner.rs
+++ b/applications/minotari_miner/src/run_miner.rs
@@ -417,7 +417,7 @@ async fn validate_tip(
         .get_tip_info(minotari_app_grpc::tari_rpc::Empty {})
         .await?
         .into_inner();
-    let longest_height = tip.clone().metadata.unwrap().height_of_longest_chain;
+    let longest_height = tip.clone().metadata.unwrap().best_block_height;
     if let Some(height) = mine_until_height {
         if longest_height >= height {
             return Err(MinerError::MineUntilHeightReached(height));

--- a/applications/minotari_node/src/commands/command/check_db.rs
+++ b/applications/minotari_node/src/commands/command/check_db.rs
@@ -43,7 +43,7 @@ impl CommandContext {
     /// Function to process the check-db command
     pub async fn check_db(&mut self) -> Result<(), Error> {
         let meta = self.node_service.get_metadata().await?;
-        let mut height = meta.height_of_longest_chain();
+        let mut height = meta.best_block_height();
         let mut missing_blocks = Vec::new();
         let mut missing_headers = Vec::new();
         print!("Searching for height: ");

--- a/applications/minotari_node/src/commands/command/list_connections.rs
+++ b/applications/minotari_node/src/commands/command/list_connections.rs
@@ -64,7 +64,7 @@ impl CommandContext {
             let chain_height = peer
                 .get_metadata(1)
                 .and_then(|v| bincode::deserialize::<PeerMetadata>(v).ok())
-                .map(|metadata| format!("height: {}", metadata.metadata.height_of_longest_chain()));
+                .map(|metadata| format!("height: {}", metadata.metadata.best_block_height()));
 
             let ua = peer.user_agent;
             let rpc_sessions = self

--- a/applications/minotari_node/src/commands/command/list_peers.rs
+++ b/applications/minotari_node/src/commands/command/list_peers.rs
@@ -86,7 +86,7 @@ impl CommandContext {
                     .get_metadata(1)
                     .and_then(|v| bincode::deserialize::<PeerMetadata>(v).ok())
                 {
-                    s.push(format!("chain height: {}", metadata.metadata.height_of_longest_chain()));
+                    s.push(format!("chain height: {}", metadata.metadata.best_block_height()));
                 }
 
                 if let Some(last_seen) = peer.addresses.last_seen() {

--- a/applications/minotari_node/src/commands/command/list_validator_nodes.rs
+++ b/applications/minotari_node/src/commands/command/list_validator_nodes.rs
@@ -62,13 +62,11 @@ impl CommandContext {
     /// Function to process the list-connections command
     pub async fn list_validator_nodes(&mut self, args: Args) -> Result<(), Error> {
         let metadata = self.blockchain_db.get_chain_metadata().await?;
-        let constants = self
-            .consensus_rules
-            .consensus_constants(metadata.height_of_longest_chain());
+        let constants = self.consensus_rules.consensus_constants(metadata.best_block_height());
         let height = args
             .epoch
             .map(|epoch| constants.epoch_to_block_height(epoch))
-            .unwrap_or_else(|| metadata.height_of_longest_chain());
+            .unwrap_or_else(|| metadata.best_block_height());
         let current_epoch = constants.block_height_to_epoch(height);
         let next_epoch = VnEpoch(current_epoch.as_u64() + 1);
         let next_epoch_height = constants.epoch_to_block_height(next_epoch);

--- a/applications/minotari_node/src/commands/command/period_stats.rs
+++ b/applications/minotari_node/src/commands/command/period_stats.rs
@@ -58,7 +58,7 @@ impl CommandContext {
     ) -> Result<(), Error> {
         let meta = self.node_service.get_metadata().await?;
 
-        let mut height = meta.height_of_longest_chain();
+        let mut height = meta.best_block_height();
         // Currently gets the stats for: tx count, hash rate estimation, target difficulty, solvetime.
         let mut results: Vec<(usize, f64, u64, u64, usize)> = Vec::new();
 

--- a/applications/minotari_node/src/commands/command/status.rs
+++ b/applications/minotari_node/src/commands/command/status.rs
@@ -64,7 +64,7 @@ impl CommandContext {
         status_line.add_field("State", self.state_machine_info.borrow().state_info.short_desc());
 
         let metadata = self.node_service.get_metadata().await?;
-        let height = metadata.height_of_longest_chain();
+        let height = metadata.best_block_height();
         let last_header = self
             .node_service
             .get_header(height)
@@ -76,16 +76,10 @@ impl CommandContext {
         );
         status_line.add_field(
             "Tip",
-            format!(
-                "{} ({})",
-                metadata.height_of_longest_chain(),
-                last_block_time.to_rfc2822()
-            ),
+            format!("{} ({})", metadata.best_block_height(), last_block_time.to_rfc2822()),
         );
 
-        let constants = self
-            .consensus_rules
-            .consensus_constants(metadata.height_of_longest_chain());
+        let constants = self.consensus_rules.consensus_constants(metadata.best_block_height());
         let fut = self.mempool_service.get_mempool_stats();
         if let Ok(mempool_stats) = time::timeout(Duration::from_secs(5), fut).await? {
             status_line.add_field(

--- a/applications/minotari_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/minotari_node/src/grpc/base_node_grpc_server.rs
@@ -379,7 +379,7 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
                     Status::internal(err.to_string()),
                 ));
             },
-            Ok(data) => data.height_of_longest_chain(),
+            Ok(data) => data.best_block_height(),
         };
 
         let sorting: Sorting = request.sorting();

--- a/applications/minotari_node/src/grpc/blocks.rs
+++ b/applications/minotari_node/src/grpc/blocks.rs
@@ -55,7 +55,7 @@ pub async fn block_heights(
             .get_metadata()
             .await
             .map_err(|e| Status::internal(e.to_string()))?;
-        let tip = metadata.height_of_longest_chain();
+        let tip = metadata.best_block_height();
         // Avoid overflow
         let height_from_tip = cmp::min(tip, from_tip);
         let start = cmp::max(tip - height_from_tip, 0);

--- a/applications/minotari_node/src/recovery.rs
+++ b/applications/minotari_node/src/recovery.rs
@@ -152,7 +152,7 @@ async fn do_recovery<D: BlockchainBackend + 'static>(
     let max_height = source_database
         .get_chain_metadata()
         .map_err(|e| anyhow!("Could not get max chain height: {}", e))?
-        .height_of_longest_chain();
+        .best_block_height();
     // we start at height 1
     let mut counter = 1;
     print!("Starting recovery at height: ");

--- a/base_layer/common_types/src/chain_metadata.rs
+++ b/base_layer/common_types/src/chain_metadata.rs
@@ -30,16 +30,16 @@ use crate::types::{BlockHash, FixedHash};
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Hash)]
 pub struct ChainMetadata {
     /// The current chain height, or the block number of the longest valid chain, or `None` if there is no chain
-    height_of_longest_chain: u64,
+    best_block_height: u64,
     /// The block hash of the current tip of the longest valid chain
-    best_block: BlockHash,
+    best_block_hash: BlockHash,
     /// The configured number of blocks back from the tip that this database tracks. A value of 0 indicates that
     /// pruning mode is disabled and the node will keep full blocks from the time it was set. If pruning horizon
     /// was previously enabled, previously pruned blocks will remain pruned. If set from initial sync, full blocks
     /// are preserved from genesis (i.e. the database is in full archival mode).
     pruning_horizon: u64,
     /// The height of the pruning horizon. This indicates from what height a full block can be provided
-    /// (exclusive). If `pruned_height` is equal to the `height_of_longest_chain` no blocks can be
+    /// (exclusive). If `pruned_height` is equal to the `best_block_height` no blocks can be
     /// provided. Archival nodes wil always have an `pruned_height` of zero.
     pruned_height: u64,
     /// The total accumulated proof of work of the longest chain
@@ -50,16 +50,16 @@ pub struct ChainMetadata {
 
 impl ChainMetadata {
     pub fn new(
-        height: u64,
-        hash: BlockHash,
+        best_block_height: u64,
+        best_block_hash: BlockHash,
         pruning_horizon: u64,
         pruned_height: u64,
         accumulated_difficulty: U256,
         timestamp: u64,
     ) -> ChainMetadata {
         ChainMetadata {
-            height_of_longest_chain: height,
-            best_block: hash,
+            best_block_height,
+            best_block_hash,
             pruning_horizon,
             pruned_height,
             accumulated_difficulty,
@@ -69,8 +69,8 @@ impl ChainMetadata {
 
     pub fn empty() -> ChainMetadata {
         ChainMetadata {
-            height_of_longest_chain: 0,
-            best_block: FixedHash::zero(),
+            best_block_height: 0,
+            best_block_hash: FixedHash::zero(),
             pruning_horizon: 0,
             pruned_height: 0,
             accumulated_difficulty: 0.into(),
@@ -117,12 +117,12 @@ impl ChainMetadata {
     }
 
     /// Returns the height of longest chain.
-    pub fn height_of_longest_chain(&self) -> u64 {
-        self.height_of_longest_chain
+    pub fn best_block_height(&self) -> u64 {
+        self.best_block_height
     }
 
     /// The height of the pruning horizon. This indicates from what height a full block can be provided
-    /// (exclusive). If `pruned_height` is equal to the `height_of_longest_chain` no blocks can be
+    /// (exclusive). If `pruned_height` is equal to the `best_block_height` no blocks can be
     /// provided. Archival nodes wil always have an `pruned_height` of zero.
     pub fn pruned_height(&self) -> u64 {
         self.pruned_height
@@ -132,8 +132,8 @@ impl ChainMetadata {
         self.accumulated_difficulty
     }
 
-    pub fn best_block(&self) -> &BlockHash {
-        &self.best_block
+    pub fn best_block_hash(&self) -> &BlockHash {
+        &self.best_block_hash
     }
 
     pub fn timestamp(&self) -> u64 {
@@ -143,8 +143,8 @@ impl ChainMetadata {
 
 impl Display for ChainMetadata {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
-        let height = self.height_of_longest_chain;
-        let best_block = self.best_block;
+        let height = self.best_block_height;
+        let best_block = self.best_block_hash;
         let accumulated_difficulty = self.accumulated_difficulty;
         writeln!(f, "Height of longest chain: {}", height)?;
         writeln!(f, "Total accumulated difficulty: {}", accumulated_difficulty)?;

--- a/base_layer/core/src/base_node/chain_metadata_service/service.rs
+++ b/base_layer/core/src/base_node/chain_metadata_service/service.rs
@@ -202,7 +202,7 @@ impl ChainMetadataService {
             target: LOG_TARGET,
             "Received chain metadata from NodeId '{}' #{}, Acc_diff {}",
             event.node_id,
-            chain_metadata.height_of_longest_chain(),
+            chain_metadata.best_block_height(),
             chain_metadata.accumulated_difficulty(),
         );
 
@@ -257,8 +257,8 @@ mod test {
         let mut bytes = [0u8; 32];
         diff.to_big_endian(&mut bytes);
         proto::ChainMetadata {
-            height_of_longest_chain: 1,
-            best_block: vec![
+            best_block_height: 1,
+            best_block_hash: vec![
                 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27,
                 28, 29, 30, 31,
             ],
@@ -293,7 +293,7 @@ mod test {
         let (mut service, liveness_mock_state, mut base_node_receiver, _) = setup();
 
         let mut proto_chain_metadata = create_sample_proto_chain_metadata();
-        proto_chain_metadata.height_of_longest_chain = 123;
+        proto_chain_metadata.best_block_height = 123;
         let chain_metadata = proto_chain_metadata.clone().try_into().unwrap();
 
         task::spawn(async move {
@@ -311,7 +311,7 @@ mod test {
         unpack_enum!(LivenessRequest::SetMetadataEntry(metadata_key, data) = last_call);
         assert_eq!(metadata_key, MetadataKey::ChainMetadata);
         let chain_metadata = proto::ChainMetadata::decode(data.as_slice()).unwrap();
-        assert_eq!(chain_metadata.height_of_longest_chain, 123);
+        assert_eq!(chain_metadata.best_block_height, 123);
     }
     #[tokio::test]
     async fn handle_liveness_event_ok() {
@@ -333,8 +333,8 @@ mod test {
         let metadata = events_rx.recv().await.unwrap().peer_metadata().unwrap();
         assert_eq!(*metadata.node_id(), node_id);
         assert_eq!(
-            metadata.claimed_chain_metadata().height_of_longest_chain(),
-            proto_chain_metadata.height_of_longest_chain
+            metadata.claimed_chain_metadata().best_block_height(),
+            proto_chain_metadata.best_block_height
         );
     }
 

--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -602,15 +602,15 @@ where B: BlockchainBackend + 'static
         // We check the current tip and orphan status of the block because we cannot guarantee that mempool state is
         // correct and the mmr root calculation is only valid if the block is building on the tip.
         let current_meta = self.blockchain_db.get_chain_metadata().await?;
-        if header.prev_hash != *current_meta.best_block() {
+        if header.prev_hash != *current_meta.best_block_hash() {
             debug!(
                 target: LOG_TARGET,
                 "Orphaned block #{}: ({}), current tip is: #{} ({}). We need to fetch the complete block from peer: \
                  ({})",
                 header.height,
                 block_hash.to_hex(),
-                current_meta.height_of_longest_chain(),
-                current_meta.best_block().to_hex(),
+                current_meta.best_block_height(),
+                current_meta.best_block_hash().to_hex(),
                 source_peer,
             );
             #[cfg(feature = "metrics")]

--- a/base_layer/core/src/base_node/proto/chain_metadata.proto
+++ b/base_layer/core/src/base_node/proto/chain_metadata.proto
@@ -9,14 +9,14 @@ package tari.base_node;
 
 message ChainMetadata {
     // The current chain height, or the block number of the longest valid chain, or `None` if there is no chain
-    uint64 height_of_longest_chain = 1;
+    uint64 best_block_height = 1;
     // The block hash of the current tip of the longest valid chain, or `None` for an empty chain
-    bytes best_block = 2;
+    bytes best_block_hash = 2;
     // The current geometric mean of the pow of the chain tip, or `None` if there is no chain
     bytes accumulated_difficulty = 5;
     // The effective height of the pruning horizon. This indicates from what height
     // a full block can be provided (exclusive).
-    // If `pruned_height` is equal to the `height_of_longest_chain` no blocks can be provided.
+    // If `pruned_height` is equal to the `best_block_height` no blocks can be provided.
     // Archival nodes wil always have an `pruned_height` of zero.
     uint64 pruned_height = 6;
     // Timestamp of the last block in the chain, or `None` if there is no chain

--- a/base_layer/core/src/base_node/proto/chain_metadata.rs
+++ b/base_layer/core/src/base_node/proto/chain_metadata.rs
@@ -41,23 +41,23 @@ impl TryFrom<proto::ChainMetadata> for ChainMetadata {
         }
 
         let accumulated_difficulty = U256::from_big_endian(&metadata.accumulated_difficulty);
-        let height_of_longest_chain = metadata.height_of_longest_chain;
+        let best_block_height = metadata.best_block_height;
 
         let pruning_horizon = if metadata.pruned_height == 0 {
             metadata.pruned_height
         } else {
-            height_of_longest_chain.saturating_sub(metadata.pruned_height)
+            best_block_height.saturating_sub(metadata.pruned_height)
         };
 
-        if metadata.best_block.is_empty() {
+        if metadata.best_block_hash.is_empty() {
             return Err("Best block is missing".to_string());
         }
         let hash: FixedHash = metadata
-            .best_block
+            .best_block_hash
             .try_into()
             .map_err(|e| format!("Malformed best block: {}", e))?;
         Ok(ChainMetadata::new(
-            height_of_longest_chain,
+            best_block_height,
             hash,
             pruning_horizon,
             metadata.pruned_height,
@@ -74,8 +74,8 @@ impl From<ChainMetadata> for proto::ChainMetadata {
             .accumulated_difficulty()
             .to_big_endian(&mut accumulated_difficulty);
         Self {
-            height_of_longest_chain: metadata.height_of_longest_chain(),
-            best_block: metadata.best_block().to_vec(),
+            best_block_height: metadata.best_block_height(),
+            best_block_hash: metadata.best_block_hash().to_vec(),
             pruned_height: metadata.pruned_height(),
             accumulated_difficulty: accumulated_difficulty.to_vec(),
             timestamp: metadata.timestamp(),
@@ -84,7 +84,7 @@ impl From<ChainMetadata> for proto::ChainMetadata {
 }
 
 impl proto::ChainMetadata {
-    pub fn height_of_longest_chain(&self) -> u64 {
-        self.height_of_longest_chain
+    pub fn best_block_height(&self) -> u64 {
+        self.best_block_height
     }
 }

--- a/base_layer/core/src/base_node/proto/wallet_rpc.proto
+++ b/base_layer/core/src/base_node/proto/wallet_rpc.proto
@@ -35,27 +35,27 @@ enum TxLocation {
 
 message TxQueryResponse {
   TxLocation location = 1;
-  bytes block_hash = 2;
+  bytes best_block_hash = 2;
   uint64 confirmations = 3;
   bool is_synced = 4;
-  uint64 height_of_longest_chain = 5;
+  uint64 best_block_height = 5;
   uint64 mined_timestamp = 6;
 }
 
 message TxQueryBatchResponse {
   tari.types.Signature signature = 1;
   TxLocation location = 2;
-  bytes block_hash = 3;
+  bytes best_block_hash = 3;
   uint64 confirmations = 4;
-  uint64 block_height = 5;
+  uint64 best_block_height = 5;
   uint64 mined_timestamp = 6;
 }
 
 message TxQueryBatchResponses {
   repeated TxQueryBatchResponse responses = 1;
   bool is_synced = 2;
-  bytes tip_hash = 3;
-  uint64 height_of_longest_chain = 4;
+  bytes best_block_hash = 3;
+  uint64 best_block_height = 4;
   uint64 tip_mined_timestamp = 5;
 }
 

--- a/base_layer/core/src/base_node/proto/wallet_rpc.rs
+++ b/base_layer/core/src/base_node/proto/wallet_rpc.rs
@@ -128,10 +128,10 @@ impl From<TxSubmissionResponse> for proto::TxSubmissionResponse {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct TxQueryResponse {
     pub location: TxLocation,
-    pub block_hash: Option<BlockHash>,
+    pub best_block_hash: Option<BlockHash>,
     pub confirmations: u64,
     pub is_synced: bool,
-    pub height_of_longest_chain: u64,
+    pub best_block_height: u64,
     pub mined_timestamp: Option<u64>,
 }
 
@@ -139,9 +139,9 @@ pub struct TxQueryResponse {
 pub struct TxQueryBatchResponse {
     pub signature: Signature,
     pub location: TxLocation,
-    pub block_hash: Option<BlockHash>,
+    pub best_block_hash: Option<BlockHash>,
     pub confirmations: u64,
-    pub block_height: u64,
+    pub best_block_height: u64,
     pub mined_timestamp: Option<u64>,
 }
 
@@ -192,10 +192,10 @@ impl TryFrom<proto::TxQueryResponse> for TxQueryResponse {
     type Error = String;
 
     fn try_from(proto_response: proto::TxQueryResponse) -> Result<Self, Self::Error> {
-        let hash = if proto_response.block_hash.is_empty() {
+        let hash = if proto_response.best_block_hash.is_empty() {
             None
         } else {
-            Some(match BlockHash::try_from(proto_response.block_hash.clone()) {
+            Some(match BlockHash::try_from(proto_response.best_block_hash.clone()) {
                 Ok(h) => h,
                 Err(e) => {
                     return Err(format!("Malformed block hash: {}", e));
@@ -213,10 +213,10 @@ impl TryFrom<proto::TxQueryResponse> for TxQueryResponse {
                 proto::TxLocation::from_i32(proto_response.location)
                     .ok_or_else(|| "Invalid or unrecognised `TxLocation` enum".to_string())?,
             )?,
-            block_hash: hash,
+            best_block_hash: hash,
             confirmations: proto_response.confirmations,
             is_synced: proto_response.is_synced,
-            height_of_longest_chain: proto_response.height_of_longest_chain,
+            best_block_height: proto_response.best_block_height,
             mined_timestamp,
         })
     }
@@ -226,10 +226,10 @@ impl From<TxQueryResponse> for proto::TxQueryResponse {
     fn from(response: TxQueryResponse) -> Self {
         Self {
             location: proto::TxLocation::from(response.location) as i32,
-            block_hash: response.block_hash.map(|v| v.to_vec()).unwrap_or(vec![]),
+            best_block_hash: response.best_block_hash.map(|v| v.to_vec()).unwrap_or(vec![]),
             confirmations: response.confirmations,
             is_synced: response.is_synced,
-            height_of_longest_chain: response.height_of_longest_chain,
+            best_block_height: response.best_block_height,
             mined_timestamp: response.mined_timestamp.unwrap_or_default(),
         }
     }
@@ -239,10 +239,10 @@ impl TryFrom<proto::TxQueryBatchResponse> for TxQueryBatchResponse {
     type Error = String;
 
     fn try_from(proto_response: proto::TxQueryBatchResponse) -> Result<Self, Self::Error> {
-        let hash = if proto_response.block_hash.is_empty() {
+        let hash = if proto_response.best_block_hash.is_empty() {
             None
         } else {
-            Some(match BlockHash::try_from(proto_response.block_hash.clone()) {
+            Some(match BlockHash::try_from(proto_response.best_block_hash.clone()) {
                 Ok(h) => h,
                 Err(e) => {
                     return Err(format!("Malformed block hash: {}", e));
@@ -263,8 +263,8 @@ impl TryFrom<proto::TxQueryBatchResponse> for TxQueryBatchResponse {
                 proto::TxLocation::from_i32(proto_response.location)
                     .ok_or_else(|| "Invalid or unrecognised `TxLocation` enum".to_string())?,
             )?,
-            block_hash: hash,
-            block_height: proto_response.block_height,
+            best_block_hash: hash,
+            best_block_height: proto_response.best_block_height,
             confirmations: proto_response.confirmations,
             mined_timestamp,
         })

--- a/base_layer/core/src/base_node/state_machine_service/states/events_and_states.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/events_and_states.rs
@@ -126,7 +126,7 @@ impl Display for SyncStatus {
                 f,
                 "Lagging behind {} peers (#{}, Difficulty: {})",
                 sync_peers.len(),
-                network.height_of_longest_chain(),
+                network.best_block_height(),
                 network.accumulated_difficulty(),
             ),
             UpToDate => f.write_str("UpToDate"),

--- a/base_layer/core/src/base_node/state_machine_service/states/horizon_state_sync.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/horizon_state_sync.rs
@@ -69,7 +69,7 @@ impl HorizonStateSync {
         }
 
         // We're already synced because we have full blocks higher than our target pruned height
-        if local_metadata.height_of_longest_chain() >= horizon_sync_height {
+        if local_metadata.best_block_height() >= horizon_sync_height {
             info!(
                 target: LOG_TARGET,
                 "Tip height is higher than our pruned height. Horizon state is already synchronized."

--- a/base_layer/core/src/base_node/state_machine_service/states/listening.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/listening.rs
@@ -330,8 +330,8 @@ fn determine_sync_mode(
     let network_tip_accum_difficulty = network.claimed_chain_metadata().accumulated_difficulty();
     let local_tip_accum_difficulty = local.accumulated_difficulty();
     if local_tip_accum_difficulty < network_tip_accum_difficulty {
-        let local_tip_height = local.height_of_longest_chain();
-        let network_tip_height = network.claimed_chain_metadata().height_of_longest_chain();
+        let local_tip_height = local.best_block_height();
+        let network_tip_height = network.claimed_chain_metadata().best_block_height();
         info!(
             target: LOG_TARGET,
             "Our local blockchain accumulated difficulty is a little behind that of the network. We're at block #{} \
@@ -350,7 +350,7 @@ fn determine_sync_mode(
         let pruned_mode = local.pruning_horizon() > 0;
         let pruning_horizon_check = network.claimed_chain_metadata().pruning_horizon() > 0 &&
             network.claimed_chain_metadata().pruning_horizon() < local.pruning_horizon();
-        let pruning_height_check = network.claimed_chain_metadata().pruned_height() > local.height_of_longest_chain();
+        let pruning_height_check = network.claimed_chain_metadata().pruned_height() > local.best_block_height();
         let sync_able_peer = match (pruned_mode, pruning_horizon_check, pruning_height_check) {
             (true, true, _) => {
                 info!(
@@ -366,7 +366,7 @@ fn determine_sync_mode(
                     target: LOG_TARGET,
                     "The remote peer is a pruned node, and it cannot supply the blocks we need. Remote pruned height # {}, current local tip #{}",
                     network.claimed_chain_metadata().pruned_height(),
-                    local.height_of_longest_chain(),
+                    local.best_block_height(),
                 );
                 false
             },
@@ -421,9 +421,9 @@ fn determine_sync_mode(
                 // Equals
                 "Our blockchain is up-to-date."
             },
-            local.height_of_longest_chain(),
+            local.best_block_height(),
             local_tip_accum_difficulty,
-            network.claimed_chain_metadata().height_of_longest_chain(),
+            network.claimed_chain_metadata().best_block_height(),
             network_tip_accum_difficulty,
         );
         UpToDate

--- a/base_layer/core/src/base_node/state_machine_service/states/sync_decide.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/sync_decide.rs
@@ -74,7 +74,7 @@ impl DecideNextSync {
                 .drain(..)
                 .filter(|sync_peer| {
                     let remote_metadata = sync_peer.claimed_chain_metadata();
-                    remote_metadata.height_of_longest_chain() >= horizon_sync_height
+                    remote_metadata.best_block_height() >= horizon_sync_height
                 })
                 .collect::<Vec<_>>();
 
@@ -99,7 +99,7 @@ impl DecideNextSync {
                 .sync_peers
                 .drain(..)
                 .filter(|sync_peer| {
-                    sync_peer.claimed_chain_metadata().pruned_height() <= local_metadata.height_of_longest_chain()
+                    sync_peer.claimed_chain_metadata().pruned_height() <= local_metadata.best_block_height()
                 })
                 .collect::<Vec<_>>();
 

--- a/base_layer/core/src/base_node/sync/block_sync/synchronizer.rs
+++ b/base_layer/core/src/base_node/sync/block_sync/synchronizer.rs
@@ -233,7 +233,7 @@ impl<'a, B: BlockchainBackend + 'static> BlockSynchronizer<'a, B> {
         let tip_header = self.db.fetch_last_header().await?;
         let local_metadata = self.db.get_chain_metadata().await?;
 
-        if tip_header.height <= local_metadata.height_of_longest_chain() {
+        if tip_header.height <= local_metadata.best_block_height() {
             debug!(
                 target: LOG_TARGET,
                 "Blocks already synchronized to height {}.", tip_header.height
@@ -243,7 +243,7 @@ impl<'a, B: BlockchainBackend + 'static> BlockSynchronizer<'a, B> {
 
         let tip_hash = tip_header.hash();
         let tip_height = tip_header.height;
-        let best_height = local_metadata.height_of_longest_chain();
+        let best_height = local_metadata.best_block_height();
         let chain_header = self.db.fetch_chain_header(best_height).await?;
 
         let best_full_block_hash = chain_header.accumulated_data().hash;

--- a/base_layer/core/src/base_node/sync/header_sync/synchronizer.rs
+++ b/base_layer/core/src/base_node/sync/header_sync/synchronizer.rs
@@ -259,13 +259,12 @@ impl<'a, B: BlockchainBackend + 'static> HeaderSynchronizer<'a, B> {
         let best_header = self.db.fetch_last_chain_header().await?;
         let best_block_header = self
             .db
-            .fetch_chain_header(best_block_metadata.height_of_longest_chain())
+            .fetch_chain_header(best_block_metadata.best_block_height())
             .await?;
         let best_header_height = best_header.height();
         let best_block_height = best_block_header.height();
 
-        if best_header_height < best_block_height ||
-            best_block_height < self.local_cached_metadata.height_of_longest_chain()
+        if best_header_height < best_block_height || best_block_height < self.local_cached_metadata.best_block_height()
         {
             return Err(BlockHeaderSyncError::ChainStorageError(
                 ChainStorageError::CorruptedDatabase("Inconsistent block and header data".to_string()),
@@ -301,7 +300,7 @@ impl<'a, B: BlockchainBackend + 'static> HeaderSynchronizer<'a, B> {
                         .height()
                         .checked_sub(split_info.reorg_steps_back)
                         .unwrap_or_default(),
-                    sync_peer.claimed_chain_metadata().height_of_longest_chain(),
+                    sync_peer.claimed_chain_metadata().best_block_height(),
                     sync_peer,
                 );
                 self.synchronize_headers(sync_peer.clone(), &mut client, *split_info, max_latency)
@@ -694,7 +693,7 @@ impl<'a, B: BlockchainBackend + 'static> HeaderSynchronizer<'a, B> {
             sync_peer.add_sample(last_sync_timer.elapsed());
             self.hooks.call_on_progress_header_hooks(
                 current_height,
-                sync_peer.claimed_chain_metadata().height_of_longest_chain(),
+                sync_peer.claimed_chain_metadata().best_block_height(),
                 &sync_peer,
             );
 

--- a/base_layer/core/src/base_node/sync/horizon_state_sync/synchronizer.rs
+++ b/base_layer/core/src/base_node/sync/horizon_state_sync/synchronizer.rs
@@ -289,7 +289,7 @@ impl<'a, B: BlockchainBackend + 'static> HorizonStateSynchronization<'a, B> {
         let db = self.db();
         let local_metadata = db.get_chain_metadata().await?;
 
-        let new_prune_height = cmp::min(local_metadata.height_of_longest_chain(), self.horizon_sync_height);
+        let new_prune_height = cmp::min(local_metadata.best_block_height(), self.horizon_sync_height);
         if local_metadata.pruned_height() < new_prune_height {
             debug!(target: LOG_TARGET, "Pruning block chain to height {}", new_prune_height);
             db.prune_to_height(new_prune_height).await?;
@@ -647,7 +647,7 @@ impl<'a, B: BlockchainBackend + 'static> HorizonStateSynchronization<'a, B> {
                 header.height(),
                 *header.hash(),
                 header.accumulated_data().total_accumulated_difficulty,
-                *metadata.best_block(),
+                *metadata.best_block_hash(),
                 header.timestamp(),
             )
             .set_pruned_height(header.height())

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -1421,7 +1421,7 @@ impl LMDBDatabase {
         // Clean up bad blocks that are far from the tip
         let metadata = fetch_metadata(txn, &self.metadata_db)?;
         let deleted_before_height = metadata
-            .height_of_longest_chain()
+            .best_block_height()
             .saturating_sub(CLEAN_BAD_BLOCKS_BEFORE_REL_HEIGHT);
         if deleted_before_height == 0 {
             return Ok(());
@@ -1957,14 +1957,14 @@ impl BlockchainBackend for LMDBDatabase {
         let txn = self.read_transaction()?;
 
         let metadata = self.fetch_chain_metadata()?;
-        let height = metadata.height_of_longest_chain();
+        let height = metadata.best_block_height();
         let header = lmdb_get(&txn, &self.headers_db, &height)?.ok_or_else(|| ChainStorageError::ValueNotFound {
             entity: "Header",
             field: "height",
             value: height.to_string(),
         })?;
         let accumulated_data = self
-            .fetch_header_accumulated_data_by_height(&txn, metadata.height_of_longest_chain())?
+            .fetch_header_accumulated_data_by_height(&txn, metadata.best_block_height())?
             .ok_or_else(|| ChainStorageError::ValueNotFound {
                 entity: "BlockHeaderAccumulatedData",
                 field: "height",
@@ -2225,11 +2225,11 @@ impl BlockchainBackend for LMDBDatabase {
         };
         let metadata = fetch_metadata(&txn, &self.metadata_db)?;
 
-        if metadata.height_of_longest_chain() == last_header.height {
+        if metadata.best_block_height() == last_header.height {
             return Ok(0);
         }
 
-        let start = metadata.height_of_longest_chain() + 1;
+        let start = metadata.best_block_height() + 1;
         let end = last_header.height;
 
         let mut num_deleted = 0;

--- a/base_layer/core/src/validation/block_body/block_body_full_validator.rs
+++ b/base_layer/core/src/validation/block_body/block_body_full_validator.rs
@@ -105,15 +105,15 @@ impl<B: BlockchainBackend> BlockBodyValidator<B> for BlockBodyFullValidator {
 }
 
 fn validate_block_metadata(block: &Block, metadata: &ChainMetadata) -> Result<(), ValidationError> {
-    if block.header.prev_hash != *metadata.best_block() {
+    if block.header.prev_hash != *metadata.best_block_hash() {
         return Err(ValidationError::IncorrectPreviousHash {
-            expected: metadata.best_block().to_hex(),
+            expected: metadata.best_block_hash().to_hex(),
             block_hash: block.hash().to_hex(),
         });
     }
-    if block.header.height != metadata.height_of_longest_chain() + 1 {
+    if block.header.height != metadata.best_block_height() + 1 {
         return Err(ValidationError::IncorrectHeight {
-            expected: metadata.height_of_longest_chain() + 1,
+            expected: metadata.best_block_height() + 1,
             block_height: block.header.height,
         });
     }

--- a/base_layer/core/src/validation/transaction/transaction_chain_validator.rs
+++ b/base_layer/core/src/validation/transaction/transaction_chain_validator.rs
@@ -62,7 +62,7 @@ impl<B: BlockchainBackend> TransactionValidator for TransactionChainLinkedValida
 
         {
             let db = self.db.db_read_access()?;
-            let tip_height = db.fetch_chain_metadata()?.height_of_longest_chain();
+            let tip_height = db.fetch_chain_metadata()?.best_block_height();
             self.aggregate_body_validator.validate(&tx.body, tip_height, &*db)?;
         };
 

--- a/base_layer/core/src/validation/transaction/transaction_internal_validator.rs
+++ b/base_layer/core/src/validation/transaction/transaction_internal_validator.rs
@@ -86,8 +86,8 @@ impl TransactionInternalConsistencyValidator {
             &tx.offset,
             &tx.script_offset,
             None,
-            Some(*tip_metadata.best_block()),
-            tip_metadata.height_of_longest_chain(),
+            Some(*tip_metadata.best_block_hash()),
+            tip_metadata.best_block_height(),
         )
     }
 }

--- a/base_layer/core/tests/helpers/sync.rs
+++ b/base_layer/core/tests/helpers/sync.rs
@@ -169,7 +169,7 @@ fn delete_block(txn: &mut DbTransaction, node: &NodeInterfaces, blocks: &[ChainB
         blocks[index + 1].height(),
         blocks[index + 1].accumulated_data().hash,
         blocks[index + 1].accumulated_data().total_accumulated_difficulty,
-        *node.blockchain_db.get_chain_metadata().unwrap().best_block(),
+        *node.blockchain_db.get_chain_metadata().unwrap().best_block_hash(),
         blocks[index + 1].to_chain_header().timestamp(),
     );
 }

--- a/base_layer/core/tests/tests/base_node_rpc.rs
+++ b/base_layer/core/tests/tests/base_node_rpc.rs
@@ -160,7 +160,7 @@ async fn test_base_node_wallet_rpc() {
     let resp = TxQueryResponse::try_from(resp).unwrap();
 
     assert_eq!(resp.confirmations, 0);
-    assert_eq!(resp.block_hash, None);
+    assert_eq!(resp.best_block_hash, None);
     assert_eq!(resp.location, TxLocation::NotStored);
 
     // First lets try submit tx2 which will be an orphan tx
@@ -178,7 +178,7 @@ async fn test_base_node_wallet_rpc() {
     let resp = TxQueryResponse::try_from(service.transaction_query(req).await.unwrap().into_message()).unwrap();
 
     assert_eq!(resp.confirmations, 0);
-    assert_eq!(resp.block_hash, None);
+    assert_eq!(resp.best_block_hash, None);
     assert_eq!(resp.location, TxLocation::NotStored);
 
     // Now submit a block with Tx1 in it so that Tx2 is no longer an orphan
@@ -201,7 +201,7 @@ async fn test_base_node_wallet_rpc() {
     let resp = TxQueryResponse::try_from(service.transaction_query(req).await.unwrap().into_message()).unwrap();
 
     assert_eq!(resp.confirmations, 0);
-    assert_eq!(resp.block_hash, None);
+    assert_eq!(resp.best_block_hash, None);
     assert_eq!(resp.location, TxLocation::InMempool);
 
     // Now if we submit Tx1 is should return as rejected as AlreadyMined as Tx1's kernel is present
@@ -245,7 +245,7 @@ async fn test_base_node_wallet_rpc() {
     let resp = TxQueryResponse::try_from(service.transaction_query(req).await.unwrap().into_message()).unwrap();
 
     assert_eq!(resp.confirmations, 1);
-    assert_eq!(resp.block_hash, Some(block1.hash()));
+    assert_eq!(resp.best_block_hash, Some(block1.hash()));
     assert_eq!(resp.location, TxLocation::Mined);
     // try a batch query
     let msg = SignaturesProto {

--- a/base_layer/core/tests/tests/node_comms_interface.rs
+++ b/base_layer/core/tests/tests/node_comms_interface.rs
@@ -100,8 +100,8 @@ async fn inbound_get_metadata() {
     if let Ok(NodeCommsResponse::ChainMetadata(received_metadata)) =
         inbound_nch.handle_request(NodeCommsRequest::GetChainMetadata).await
     {
-        assert_eq!(received_metadata.height_of_longest_chain(), 0);
-        assert_eq!(received_metadata.best_block(), &block.hash());
+        assert_eq!(received_metadata.best_block_height(), 0);
+        assert_eq!(received_metadata.best_block_hash(), &block.hash());
         assert_eq!(received_metadata.pruning_horizon(), 0);
     } else {
         panic!();

--- a/base_layer/core/tests/tests/node_service.rs
+++ b/base_layer/core/tests/tests/node_service.rs
@@ -497,8 +497,8 @@ async fn local_get_metadata() {
         .unwrap();
 
     let metadata = node.local_nci.get_metadata().await.unwrap();
-    assert_eq!(metadata.height_of_longest_chain(), 2);
-    assert_eq!(metadata.best_block(), block2.hash());
+    assert_eq!(metadata.best_block_height(), 2);
+    assert_eq!(metadata.best_block_hash(), block2.hash());
 
     node.shutdown().await;
 }

--- a/base_layer/wallet/src/base_node_service/monitor.rs
+++ b/base_layer/wallet/src/base_node_service/monitor.rs
@@ -175,7 +175,7 @@ where
             self.db.set_chain_metadata(chain_metadata.clone())?;
 
             let is_synced = tip_info.is_synced;
-            let height_of_longest_chain = chain_metadata.height_of_longest_chain();
+            let best_block_height = chain_metadata.best_block_height();
 
             let new_block = self
                 .update_state(BaseNodeState {
@@ -191,7 +191,7 @@ where
                 target: LOG_TARGET,
                 "Base node {} Tip: {} ({}) Latency: {} ms",
                 base_node_id,
-                height_of_longest_chain,
+                best_block_height,
                 if is_synced { "Synced" } else { "Syncing..." },
                 latency.as_millis()
             );
@@ -221,11 +221,11 @@ where
         let mut lock = self.state.write().await;
         let (new_block_detected, height, hash) = match (new_state.chain_metadata.clone(), lock.chain_metadata.clone()) {
             (Some(new_metadata), Some(old_metadata)) => (
-                new_metadata.best_block() != old_metadata.best_block(),
-                new_metadata.height_of_longest_chain(),
-                *new_metadata.best_block(),
+                new_metadata.best_block_hash() != old_metadata.best_block_hash(),
+                new_metadata.best_block_height(),
+                *new_metadata.best_block_hash(),
             ),
-            (Some(new_metadata), _) => (true, new_metadata.height_of_longest_chain(), *new_metadata.best_block()),
+            (Some(new_metadata), _) => (true, new_metadata.best_block_height(), *new_metadata.best_block_hash()),
             (None, _) => (false, 0, BlockHashType::default()),
         };
 

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -226,7 +226,7 @@ where
                 .map(|_| OutputManagerResponse::OutputMetadataSignatureUpdated),
             OutputManagerRequest::GetBalance => {
                 let current_tip_for_time_lock_calculation = match self.base_node_service.get_chain_metadata().await {
-                    Ok(metadata) => metadata.map(|m| m.height_of_longest_chain()),
+                    Ok(metadata) => metadata.map(|m| m.best_block_height()),
                     Err(_) => None,
                 };
                 self.get_balance(current_tip_for_time_lock_calculation)
@@ -1284,7 +1284,7 @@ where
             target: LOG_TARGET,
             "select_utxos selection criteria: {}", selection_criteria
         );
-        let tip_height = chain_metadata.as_ref().map(|m| m.height_of_longest_chain());
+        let tip_height = chain_metadata.as_ref().map(|m| m.best_block_height());
         let uo = self
             .resources
             .db
@@ -1352,7 +1352,7 @@ where
         let enough_spendable = utxos_total_value > amount + fee_with_change;
 
         if !perfect_utxo_selection && !enough_spendable {
-            let current_tip_for_time_lock_calculation = chain_metadata.map(|cm| cm.height_of_longest_chain());
+            let current_tip_for_time_lock_calculation = chain_metadata.map(|cm| cm.best_block_height());
             let balance = self.get_balance(current_tip_for_time_lock_calculation)?;
             let pending_incoming = balance.pending_incoming_balance;
             if utxos_total_value + pending_incoming >= amount + fee_with_change {

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_validation_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_validation_protocol.rs
@@ -286,13 +286,13 @@ where
             let sig = response.signature;
             if let Some(unconfirmed_tx) = batch_signatures.get(&sig) {
                 if response.location == TxLocation::Mined &&
-                    response.block_hash.is_some() &&
+                    response.best_block_hash.is_some() &&
                     response.mined_timestamp.is_some()
                 {
                     mined.push((
                         (*unconfirmed_tx).clone(),
-                        response.block_height,
-                        response.block_hash.unwrap(),
+                        response.best_block_height,
+                        response.best_block_hash.unwrap(),
                         response.confirmations,
                         response.mined_timestamp.unwrap(),
                     ));
@@ -308,13 +308,13 @@ where
             }
         }
 
-        let tip = batch_response.tip_hash.try_into()?;
+        let tip = batch_response.best_block_hash.try_into()?;
 
         Ok((
             mined,
             unmined,
             Some((
-                batch_response.height_of_longest_chain,
+                batch_response.best_block_height,
                 tip,
                 batch_response.tip_mined_timestamp,
             )),

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -924,7 +924,7 @@ where
                 Err(_) => None,
             };
             let tip_height = match metadata {
-                Some(val) => val.height_of_longest_chain(),
+                Some(val) => val.best_block_height(),
                 None => 0u64,
             };
             let event_publisher = self.event_publisher.clone();

--- a/base_layer/wallet/src/utxo_scanner_service/utxo_scanner_task.rs
+++ b/base_layer/wallet/src/utxo_scanner_service/utxo_scanner_task.rs
@@ -327,7 +327,7 @@ where
         client: &mut BaseNodeWalletRpcClient,
     ) -> Result<BlockHeader, UtxoScannerError> {
         let tip_info = client.get_tip_info().await?;
-        let chain_height = tip_info.metadata.map(|m| m.height_of_longest_chain()).unwrap_or(0);
+        let chain_height = tip_info.metadata.map(|m| m.best_block_height()).unwrap_or(0);
         let end_header = client.get_header_by_height(chain_height).await?;
         let end_header = BlockHeader::try_from(end_header).map_err(UtxoScannerError::ConversionError)?;
 

--- a/base_layer/wallet/tests/support/comms_rpc.rs
+++ b/base_layer/wallet/tests/support/comms_rpc.rs
@@ -134,23 +134,23 @@ impl BaseNodeWalletRpcMockState {
             })),
             transaction_query_response: Arc::new(Mutex::new(TxQueryResponse {
                 location: TxLocation::InMempool,
-                block_hash: None,
+                best_block_hash: None,
                 confirmations: 0,
                 is_synced: true,
-                height_of_longest_chain: 0,
+                best_block_height: 0,
                 mined_timestamp: None,
             })),
             transaction_query_batch_response: Arc::new(Mutex::new(TxQueryBatchResponsesProto {
                 responses: vec![],
-                tip_hash: FixedHash::zero().to_vec(),
+                best_block_hash: FixedHash::zero().to_vec(),
                 is_synced: true,
-                height_of_longest_chain: 0,
+                best_block_height: 0,
                 tip_mined_timestamp: EpochTime::now().as_u64(),
             })),
             tip_info_response: Arc::new(Mutex::new(TipInfoResponse {
                 metadata: Some(ChainMetadataProto {
-                    height_of_longest_chain: std::i64::MAX as u64,
-                    best_block: FixedHash::zero().to_vec(),
+                    best_block_height: std::i64::MAX as u64,
+                    best_block_hash: FixedHash::zero().to_vec(),
                     accumulated_difficulty: Vec::new(),
                     pruned_height: 0,
                     timestamp: EpochTime::now().as_u64(),
@@ -930,8 +930,8 @@ mod test {
         assert_eq!(calls.len(), 1);
 
         let chain_metadata = ChainMetadata {
-            height_of_longest_chain: 444,
-            best_block: vec![],
+            best_block_height: 444,
+            best_block_hash: vec![],
             accumulated_difficulty: vec![],
             pruned_height: 0,
             timestamp: EpochTime::now().as_u64(),
@@ -943,6 +943,6 @@ mod test {
 
         let resp = client.get_tip_info().await.unwrap();
         assert!(!resp.is_synced);
-        assert_eq!(resp.metadata.unwrap().height_of_longest_chain(), 444);
+        assert_eq!(resp.metadata.unwrap().best_block_height(), 444);
     }
 }

--- a/base_layer/wallet/tests/transaction_service_tests/service.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/service.rs
@@ -2588,10 +2588,10 @@ async fn test_power_mode_updates() {
         .base_node_rpc_mock_state
         .set_transaction_query_response(TxQueryResponse {
             location: TxLocation::NotStored,
-            block_hash: None,
+            best_block_hash: None,
             confirmations: 0,
             is_synced: true,
-            height_of_longest_chain: 10,
+            best_block_height: 10,
             mined_timestamp: None,
         });
 
@@ -4995,10 +4995,10 @@ async fn transaction_service_tx_broadcast() {
         .base_node_rpc_mock_state
         .set_transaction_query_response(TxQueryResponse {
             location: TxLocation::Mined,
-            block_hash: None,
+            best_block_hash: None,
             confirmations: TransactionServiceConfig::default().num_confirmations_required,
             is_synced: true,
-            height_of_longest_chain: 0,
+            best_block_height: 0,
             mined_timestamp: None,
         });
 
@@ -5064,10 +5064,10 @@ async fn transaction_service_tx_broadcast() {
         .base_node_rpc_mock_state
         .set_transaction_query_response(TxQueryResponse {
             location: TxLocation::NotStored,
-            block_hash: None,
+            best_block_hash: None,
             confirmations: TransactionServiceConfig::default().num_confirmations_required,
             is_synced: true,
-            height_of_longest_chain: 0,
+            best_block_height: 0,
             mined_timestamp: None,
         });
 
@@ -5208,10 +5208,10 @@ async fn broadcast_all_completed_transactions_on_startup() {
         .base_node_rpc_mock_state
         .set_transaction_query_response(TxQueryResponse {
             location: TxLocation::Mined,
-            block_hash: None,
+            best_block_hash: None,
             confirmations: TransactionServiceConfig::default().num_confirmations_required,
             is_synced: true,
-            height_of_longest_chain: 0,
+            best_block_height: 0,
             mined_timestamp: None,
         });
 

--- a/base_layer/wallet/tests/transaction_service_tests/transaction_protocols.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/transaction_protocols.rs
@@ -417,10 +417,10 @@ async fn tx_broadcast_protocol_restart_protocol_as_query() {
     // Set Base Node query response to be not stored, as if the base node does not have the tx in its pool
     rpc_service_state.set_transaction_query_response(TxQueryResponse {
         location: TxLocation::NotStored,
-        block_hash: None,
+        best_block_hash: None,
         confirmations: 0,
         is_synced: true,
-        height_of_longest_chain: 0,
+        best_block_height: 0,
         mined_timestamp: None,
     });
 
@@ -447,10 +447,10 @@ async fn tx_broadcast_protocol_restart_protocol_as_query() {
     // Set Base Node query response to be InMempool as if the base node does not have the tx in its pool
     rpc_service_state.set_transaction_query_response(TxQueryResponse {
         location: TxLocation::InMempool,
-        block_hash: None,
+        best_block_hash: None,
         confirmations: 0,
         is_synced: true,
-        height_of_longest_chain: 0,
+        best_block_height: 0,
         mined_timestamp: None,
     });
 
@@ -469,10 +469,10 @@ async fn tx_broadcast_protocol_restart_protocol_as_query() {
     // Set base node response to mined and confirmed
     rpc_service_state.set_transaction_query_response(TxQueryResponse {
         location: TxLocation::Mined,
-        block_hash: None,
+        best_block_hash: None,
         confirmations: resources.config.num_confirmations_required,
         is_synced: true,
-        height_of_longest_chain: 0,
+        best_block_height: 0,
         mined_timestamp: None,
     });
 
@@ -526,10 +526,10 @@ async fn tx_broadcast_protocol_submit_success_followed_by_rejection() {
     // Accepted in the mempool on submit but not query
     rpc_service_state.set_transaction_query_response(TxQueryResponse {
         location: TxLocation::NotStored,
-        block_hash: None,
+        best_block_hash: None,
         confirmations: 0,
         is_synced: true,
-        height_of_longest_chain: 0,
+        best_block_height: 0,
         mined_timestamp: None,
     });
 
@@ -629,10 +629,10 @@ async fn tx_broadcast_protocol_submit_already_mined() {
     // Set base node response to mined and confirmed
     rpc_service_state.set_transaction_query_response(TxQueryResponse {
         location: TxLocation::Mined,
-        block_hash: None,
+        best_block_hash: None,
         confirmations: resources.config.num_confirmations_required,
         is_synced: true,
-        height_of_longest_chain: 10,
+        best_block_height: 10,
         mined_timestamp: None,
     });
 
@@ -667,10 +667,10 @@ async fn tx_broadcast_protocol_submit_and_base_node_gets_changed() {
 
     rpc_service_state.set_transaction_query_response(TxQueryResponse {
         location: TxLocation::NotStored,
-        block_hash: None,
+        best_block_hash: None,
         confirmations: 1,
         is_synced: true,
-        height_of_longest_chain: 0,
+        best_block_height: 0,
         mined_timestamp: None,
     });
 
@@ -711,10 +711,10 @@ async fn tx_broadcast_protocol_submit_and_base_node_gets_changed() {
     // Set new Base Node response to be accepted
     new_rpc_service_state.set_transaction_query_response(TxQueryResponse {
         location: TxLocation::InMempool,
-        block_hash: None,
+        best_block_hash: None,
         confirmations: resources.config.num_confirmations_required,
         is_synced: true,
-        height_of_longest_chain: 0,
+        best_block_height: 0,
         mined_timestamp: None,
     });
 
@@ -787,17 +787,17 @@ async fn tx_validation_protocol_tx_becomes_mined_unconfirmed_then_confirmed() {
             tx2.transaction.first_kernel_excess_sig().unwrap().clone(),
         )),
         location: TxLocationProto::from(TxLocation::Mined) as i32,
-        block_hash: [1u8; 32].to_vec(),
+        best_block_hash: [1u8; 32].to_vec(),
         confirmations: 0,
-        block_height: 1,
+        best_block_height: 1,
         mined_timestamp: timestamp,
     }];
 
     let mut batch_query_response = TxQueryBatchResponsesProto {
         responses: transaction_query_batch_responses.clone(),
         is_synced: true,
-        tip_hash: [1u8; 32].to_vec(),
-        height_of_longest_chain: 1,
+        best_block_hash: [1u8; 32].to_vec(),
+        best_block_height: 1,
         tip_mined_timestamp: timestamp,
     };
 
@@ -859,17 +859,17 @@ async fn tx_validation_protocol_tx_becomes_mined_unconfirmed_then_confirmed() {
             tx2.transaction.first_kernel_excess_sig().unwrap().clone(),
         )),
         location: TxLocationProto::from(TxLocation::Mined) as i32,
-        block_hash: [5u8; 32].to_vec(),
+        best_block_hash: [5u8; 32].to_vec(),
         confirmations: 4,
-        block_height: 5,
+        best_block_height: 5,
         mined_timestamp: timestamp,
     }];
 
     let batch_query_response = TxQueryBatchResponsesProto {
         responses: transaction_query_batch_responses.clone(),
         is_synced: true,
-        tip_hash: [5u8; 32].to_vec(),
-        height_of_longest_chain: 5,
+        best_block_hash: [5u8; 32].to_vec(),
+        best_block_height: 5,
         tip_mined_timestamp: timestamp,
     };
 
@@ -940,17 +940,17 @@ async fn tx_revalidation() {
             tx2.transaction.first_kernel_excess_sig().unwrap().clone(),
         )),
         location: TxLocationProto::from(TxLocation::Mined) as i32,
-        block_hash: [5u8; 32].to_vec(),
+        best_block_hash: [5u8; 32].to_vec(),
         confirmations: 4,
-        block_height: 5,
+        best_block_height: 5,
         mined_timestamp: timestamp,
     }];
 
     let batch_query_response = TxQueryBatchResponsesProto {
         responses: transaction_query_batch_responses.clone(),
         is_synced: true,
-        tip_hash: [5u8; 32].to_vec(),
-        height_of_longest_chain: 5,
+        best_block_hash: [5u8; 32].to_vec(),
+        best_block_height: 5,
         tip_mined_timestamp: timestamp,
     };
 
@@ -981,17 +981,17 @@ async fn tx_revalidation() {
             tx2.transaction.first_kernel_excess_sig().unwrap().clone(),
         )),
         location: TxLocationProto::from(TxLocation::Mined) as i32,
-        block_hash: [5u8; 32].to_vec(),
+        best_block_hash: [5u8; 32].to_vec(),
         confirmations: 8,
-        block_height: 10,
+        best_block_height: 10,
         mined_timestamp: timestamp,
     }];
 
     let batch_query_response = TxQueryBatchResponsesProto {
         responses: transaction_query_batch_responses.clone(),
         is_synced: true,
-        tip_hash: [5u8; 32].to_vec(),
-        height_of_longest_chain: 10,
+        best_block_hash: [5u8; 32].to_vec(),
+        best_block_height: 10,
         tip_mined_timestamp: timestamp,
     };
 
@@ -1101,9 +1101,9 @@ async fn tx_validation_protocol_reorg() {
                 tx1.transaction.first_kernel_excess_sig().unwrap().clone(),
             )),
             location: TxLocationProto::from(TxLocation::Mined) as i32,
-            block_hash: block_headers.get(&5).unwrap().hash().to_vec(),
+            best_block_hash: block_headers.get(&5).unwrap().hash().to_vec(),
             confirmations: 5,
-            block_height: 5,
+            best_block_height: 5,
             mined_timestamp: timestamp,
         },
         TxQueryBatchResponseProto {
@@ -1111,9 +1111,9 @@ async fn tx_validation_protocol_reorg() {
                 tx2.transaction.first_kernel_excess_sig().unwrap().clone(),
             )),
             location: TxLocationProto::from(TxLocation::Mined) as i32,
-            block_hash: block_headers.get(&6).unwrap().hash().to_vec(),
+            best_block_hash: block_headers.get(&6).unwrap().hash().to_vec(),
             confirmations: 4,
-            block_height: 6,
+            best_block_height: 6,
             mined_timestamp: timestamp,
         },
         TxQueryBatchResponseProto {
@@ -1121,9 +1121,9 @@ async fn tx_validation_protocol_reorg() {
                 tx3.transaction.first_kernel_excess_sig().unwrap().clone(),
             )),
             location: TxLocationProto::from(TxLocation::Mined) as i32,
-            block_hash: block_headers.get(&7).unwrap().hash().to_vec(),
+            best_block_hash: block_headers.get(&7).unwrap().hash().to_vec(),
             confirmations: 3,
-            block_height: 7,
+            best_block_height: 7,
             mined_timestamp: timestamp,
         },
         TxQueryBatchResponseProto {
@@ -1131,9 +1131,9 @@ async fn tx_validation_protocol_reorg() {
                 tx4.transaction.first_kernel_excess_sig().unwrap().clone(),
             )),
             location: TxLocationProto::from(TxLocation::Mined) as i32,
-            block_hash: block_headers.get(&8).unwrap().hash().to_vec(),
+            best_block_hash: block_headers.get(&8).unwrap().hash().to_vec(),
             confirmations: 2,
-            block_height: 8,
+            best_block_height: 8,
             mined_timestamp: timestamp,
         },
         TxQueryBatchResponseProto {
@@ -1141,9 +1141,9 @@ async fn tx_validation_protocol_reorg() {
                 tx5.transaction.first_kernel_excess_sig().unwrap().clone(),
             )),
             location: TxLocationProto::from(TxLocation::Mined) as i32,
-            block_hash: block_headers.get(&9).unwrap().hash().to_vec(),
+            best_block_hash: block_headers.get(&9).unwrap().hash().to_vec(),
             confirmations: 1,
-            block_height: 9,
+            best_block_height: 9,
             mined_timestamp: timestamp,
         },
         TxQueryBatchResponseProto {
@@ -1151,9 +1151,9 @@ async fn tx_validation_protocol_reorg() {
                 tx6.transaction.first_kernel_excess_sig().unwrap().clone(),
             )),
             location: TxLocationProto::from(TxLocation::Mined) as i32,
-            block_hash: block_headers.get(&8).unwrap().hash().to_vec(),
+            best_block_hash: block_headers.get(&8).unwrap().hash().to_vec(),
             confirmations: 2,
-            block_height: 8,
+            best_block_height: 8,
             mined_timestamp: timestamp,
         },
         TxQueryBatchResponseProto {
@@ -1161,9 +1161,9 @@ async fn tx_validation_protocol_reorg() {
                 tx7.transaction.first_kernel_excess_sig().unwrap().clone(),
             )),
             location: TxLocationProto::from(TxLocation::Mined) as i32,
-            block_hash: block_headers.get(&9).unwrap().hash().to_vec(),
+            best_block_hash: block_headers.get(&9).unwrap().hash().to_vec(),
             confirmations: 1,
-            block_height: 9,
+            best_block_height: 9,
             mined_timestamp: timestamp,
         },
     ];
@@ -1171,8 +1171,8 @@ async fn tx_validation_protocol_reorg() {
     let batch_query_response = TxQueryBatchResponsesProto {
         responses: transaction_query_batch_responses.clone(),
         is_synced: true,
-        tip_hash: block_headers.get(&10).unwrap().hash().to_vec(),
-        height_of_longest_chain: 10,
+        best_block_hash: block_headers.get(&10).unwrap().hash().to_vec(),
+        best_block_height: 10,
         tip_mined_timestamp: timestamp,
     };
 
@@ -1220,9 +1220,9 @@ async fn tx_validation_protocol_reorg() {
                 tx1.transaction.first_kernel_excess_sig().unwrap().clone(),
             )),
             location: TxLocationProto::from(TxLocation::Mined) as i32,
-            block_hash: block_headers.get(&5).unwrap().hash().to_vec(),
+            best_block_hash: block_headers.get(&5).unwrap().hash().to_vec(),
             confirmations: 4,
-            block_height: 5,
+            best_block_height: 5,
             mined_timestamp: timestamp,
         },
         TxQueryBatchResponseProto {
@@ -1230,9 +1230,9 @@ async fn tx_validation_protocol_reorg() {
                 tx2.transaction.first_kernel_excess_sig().unwrap().clone(),
             )),
             location: TxLocationProto::from(TxLocation::Mined) as i32,
-            block_hash: block_headers.get(&6).unwrap().hash().to_vec(),
+            best_block_hash: block_headers.get(&6).unwrap().hash().to_vec(),
             confirmations: 3,
-            block_height: 6,
+            best_block_height: 6,
             mined_timestamp: timestamp,
         },
         TxQueryBatchResponseProto {
@@ -1240,9 +1240,9 @@ async fn tx_validation_protocol_reorg() {
                 tx3.transaction.first_kernel_excess_sig().unwrap().clone(),
             )),
             location: TxLocationProto::from(TxLocation::Mined) as i32,
-            block_hash: block_headers.get(&7).unwrap().hash().to_vec(),
+            best_block_hash: block_headers.get(&7).unwrap().hash().to_vec(),
             confirmations: 2,
-            block_height: 7,
+            best_block_height: 7,
             mined_timestamp: timestamp,
         },
         TxQueryBatchResponseProto {
@@ -1250,9 +1250,9 @@ async fn tx_validation_protocol_reorg() {
                 tx5.transaction.first_kernel_excess_sig().unwrap().clone(),
             )),
             location: TxLocationProto::from(TxLocation::Mined) as i32,
-            block_hash: block_headers.get(&8).unwrap().hash().to_vec(),
+            best_block_hash: block_headers.get(&8).unwrap().hash().to_vec(),
             confirmations: 1,
-            block_height: 8,
+            best_block_height: 8,
             mined_timestamp: timestamp,
         },
         TxQueryBatchResponseProto {
@@ -1260,9 +1260,9 @@ async fn tx_validation_protocol_reorg() {
                 tx6.transaction.first_kernel_excess_sig().unwrap().clone(),
             )),
             location: TxLocationProto::from(TxLocation::NotStored) as i32,
-            block_hash: vec![],
+            best_block_hash: vec![],
             confirmations: 0,
-            block_height: 0,
+            best_block_height: 0,
             mined_timestamp: 0,
         },
         TxQueryBatchResponseProto {
@@ -1270,9 +1270,9 @@ async fn tx_validation_protocol_reorg() {
                 tx7.transaction.first_kernel_excess_sig().unwrap().clone(),
             )),
             location: TxLocationProto::from(TxLocation::NotStored) as i32,
-            block_hash: vec![],
+            best_block_hash: vec![],
             confirmations: 0,
-            block_height: 0,
+            best_block_height: 0,
             mined_timestamp: 0,
         },
     ];
@@ -1280,8 +1280,8 @@ async fn tx_validation_protocol_reorg() {
     let batch_query_response = TxQueryBatchResponsesProto {
         responses: transaction_query_batch_responses.clone(),
         is_synced: true,
-        tip_hash: block_headers.get(&8).unwrap().hash().to_vec(),
-        height_of_longest_chain: 8,
+        best_block_hash: block_headers.get(&8).unwrap().hash().to_vec(),
+        best_block_height: 8,
         tip_mined_timestamp: timestamp,
     };
 

--- a/base_layer/wallet/tests/utxo_scanner/mod.rs
+++ b/base_layer/wallet/tests/utxo_scanner/mod.rs
@@ -313,8 +313,8 @@ async fn test_utxo_scanner_recovery() {
     test_interface.rpc_service_state.set_blocks(block_headers.clone());
 
     let chain_metadata = ChainMetadata {
-        height_of_longest_chain: NUM_BLOCKS - 1,
-        best_block: block_headers.get(&(NUM_BLOCKS - 1)).unwrap().clone().hash().to_vec(),
+        best_block_height: NUM_BLOCKS - 1,
+        best_block_hash: block_headers.get(&(NUM_BLOCKS - 1)).unwrap().clone().hash().to_vec(),
         accumulated_difficulty: Vec::new(),
         pruned_height: 0,
         timestamp: 0,
@@ -412,8 +412,8 @@ async fn test_utxo_scanner_recovery_with_restart() {
     test_interface.rpc_service_state.set_blocks(block_headers.clone());
 
     let chain_metadata = ChainMetadata {
-        height_of_longest_chain: NUM_BLOCKS - 1,
-        best_block: block_headers.get(&(NUM_BLOCKS - 1)).unwrap().clone().hash().to_vec(),
+        best_block_height: NUM_BLOCKS - 1,
+        best_block_hash: block_headers.get(&(NUM_BLOCKS - 1)).unwrap().clone().hash().to_vec(),
         accumulated_difficulty: Vec::new(),
         pruned_height: 0,
         timestamp: 0,
@@ -578,8 +578,8 @@ async fn test_utxo_scanner_recovery_with_restart_and_reorg() {
     test_interface.rpc_service_state.set_blocks(block_headers.clone());
 
     let chain_metadata = ChainMetadata {
-        height_of_longest_chain: NUM_BLOCKS - 1,
-        best_block: block_headers.get(&(NUM_BLOCKS - 1)).unwrap().clone().hash().to_vec(),
+        best_block_height: NUM_BLOCKS - 1,
+        best_block_hash: block_headers.get(&(NUM_BLOCKS - 1)).unwrap().clone().hash().to_vec(),
         accumulated_difficulty: Vec::new(),
         pruned_height: 0,
         timestamp: 0,
@@ -651,8 +651,8 @@ async fn test_utxo_scanner_recovery_with_restart_and_reorg() {
         .set_utxos_by_block(utxos_by_block.clone());
     test_interface2.rpc_service_state.set_blocks(block_headers.clone());
     let chain_metadata = ChainMetadata {
-        height_of_longest_chain: 9,
-        best_block: block_headers.get(&9).unwrap().clone().hash().to_vec(),
+        best_block_height: 9,
+        best_block_hash: block_headers.get(&9).unwrap().clone().hash().to_vec(),
         accumulated_difficulty: Vec::new(),
         pruned_height: 0,
         timestamp: 0,
@@ -776,8 +776,8 @@ async fn test_utxo_scanner_scanned_block_cache_clearing() {
     test_interface.rpc_service_state.set_blocks(block_headers.clone());
 
     let chain_metadata = ChainMetadata {
-        height_of_longest_chain: 800 + NUM_BLOCKS - 1,
-        best_block: block_headers
+        best_block_height: 800 + NUM_BLOCKS - 1,
+        best_block_hash: block_headers
             .get(&(800 + NUM_BLOCKS - 1))
             .unwrap()
             .clone()
@@ -878,8 +878,8 @@ async fn test_utxo_scanner_one_sided_payments() {
     test_interface.rpc_service_state.set_blocks(block_headers.clone());
 
     let chain_metadata = ChainMetadata {
-        height_of_longest_chain: NUM_BLOCKS - 1,
-        best_block: block_headers.get(&(NUM_BLOCKS - 1)).unwrap().clone().hash().to_vec(),
+        best_block_height: NUM_BLOCKS - 1,
+        best_block_hash: block_headers.get(&(NUM_BLOCKS - 1)).unwrap().clone().hash().to_vec(),
         accumulated_difficulty: Vec::new(),
         pruned_height: 0,
         timestamp: 0,
@@ -998,8 +998,8 @@ async fn test_utxo_scanner_one_sided_payments() {
         .set_one_sided_payment_message("new one-sided message".to_string());
 
     let chain_metadata = ChainMetadata {
-        height_of_longest_chain: NUM_BLOCKS,
-        best_block: block_headers.get(&(NUM_BLOCKS)).unwrap().clone().hash().to_vec(),
+        best_block_height: NUM_BLOCKS,
+        best_block_hash: block_headers.get(&(NUM_BLOCKS)).unwrap().clone().hash().to_vec(),
         accumulated_difficulty: Vec::new(),
         pruned_height: 0,
         timestamp: 0,
@@ -1014,7 +1014,7 @@ async fn test_utxo_scanner_one_sided_payments() {
     test_interface
         .base_node_service_event_publisher
         .send(Arc::new(BaseNodeEvent::NewBlockDetected(
-            chain_metadata.best_block.try_into().unwrap(),
+            chain_metadata.best_block_hash.try_into().unwrap(),
             11,
         )))
         .unwrap();
@@ -1085,8 +1085,8 @@ async fn test_birthday_timestamp_over_chain() {
     test_interface.rpc_service_state.set_blocks(block_headers.clone());
 
     let chain_metadata = ChainMetadata {
-        height_of_longest_chain: NUM_BLOCKS - 1,
-        best_block: block_headers.get(&(NUM_BLOCKS - 1)).unwrap().clone().hash().to_vec(),
+        best_block_height: NUM_BLOCKS - 1,
+        best_block_hash: block_headers.get(&(NUM_BLOCKS - 1)).unwrap().clone().hash().to_vec(),
         accumulated_difficulty: Vec::new(),
         pruned_height: 0,
         timestamp: 0,

--- a/base_layer/wallet_ffi/src/callback_handler.rs
+++ b/base_layer/wallet_ffi/src/callback_handler.rs
@@ -660,8 +660,8 @@ where TBackend: TransactionBackend + 'static
         let state = match state.chain_metadata {
             None => TariBaseNodeState {
                 node_id: state.node_id,
-                height_of_longest_chain: 0,
-                best_block: BlockHash::zero(),
+                best_block_height: 0,
+                best_block_hash: BlockHash::zero(),
                 best_block_timestamp: 0,
                 pruning_horizon: 0,
                 pruned_height: 0,
@@ -672,8 +672,8 @@ where TBackend: TransactionBackend + 'static
 
             Some(chain_metadata) => TariBaseNodeState {
                 node_id: state.node_id,
-                height_of_longest_chain: chain_metadata.height_of_longest_chain(),
-                best_block: *chain_metadata.best_block(),
+                best_block_height: chain_metadata.best_block_height(),
+                best_block_hash: *chain_metadata.best_block_hash(),
                 best_block_timestamp: chain_metadata.timestamp(),
                 pruning_horizon: chain_metadata.pruning_horizon(),
                 pruned_height: chain_metadata.pruned_height(),

--- a/base_layer/wallet_ffi/src/ffi_basenode_state.rs
+++ b/base_layer/wallet_ffi/src/ffi_basenode_state.rs
@@ -41,10 +41,10 @@ pub struct TariBaseNodeState {
     pub node_id: Option<NodeId>,
 
     /// The current chain height, or the block number of the longest valid chain, or zero if there is no chain
-    pub height_of_longest_chain: u64,
+    pub best_block_height: u64,
 
     /// The block hash of the current tip of the longest valid chain
-    pub best_block: BlockHash,
+    pub best_block_hash: BlockHash,
 
     /// Timestamp of the tip block in the longest valid chain
     pub best_block_timestamp: u64,
@@ -56,7 +56,7 @@ pub struct TariBaseNodeState {
     pub pruning_horizon: u64,
 
     /// The height of the pruning horizon. This indicates from what height a full block can be provided
-    /// (exclusive). If `pruned_height` is equal to the `height_of_longest_chain` no blocks can be
+    /// (exclusive). If `pruned_height` is equal to the `best_block_height` no blocks can be
     /// provided. Archival nodes wil always have an `pruned_height` of zero.
     pub pruned_height: u64,
 
@@ -124,7 +124,7 @@ pub unsafe extern "C" fn basenode_state_get_height_of_the_longest_chain(
         return 0;
     }
 
-    (*ptr).height_of_longest_chain
+    (*ptr).best_block_height
 }
 
 /// Extracts a best block hash [`FixedHash`] represented as a vector of bytes wrapped into a `ByteVector`
@@ -154,7 +154,7 @@ pub unsafe extern "C" fn basenode_state_get_best_block(
         return ptr::null_mut();
     }
 
-    Box::into_raw(Box::new(ByteVector((*ptr).best_block.to_vec())))
+    Box::into_raw(Box::new(ByteVector((*ptr).best_block_hash.to_vec())))
 }
 
 /// Extracts a timestamp of the best block
@@ -227,7 +227,7 @@ pub unsafe extern "C" fn basenode_state_get_pruning_horizon(
 ///
 /// ## Returns
 /// `c_ulonglong` - The height of the pruning horizon. This indicates from what height a full block can be provided
-/// (exclusive). If `pruned_height` is equal to the `height_of_longest_chain` no blocks can be
+/// (exclusive). If `pruned_height` is equal to the `best_block_height` no blocks can be
 /// provided. Archival nodes wil always have an `pruned_height` of zero.
 ///
 /// # Safety
@@ -345,8 +345,8 @@ mod tests {
 
         let boxed_state = Box::into_raw(Box::new(TariBaseNodeState {
             node_id: Some(original_node_id.clone()),
-            height_of_longest_chain: 123,
-            best_block: original_best_block,
+            best_block_height: 123,
+            best_block_hash: original_best_block,
             best_block_timestamp: 12345,
             pruning_horizon: 456,
             pruned_height: 789,

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -4058,7 +4058,7 @@ unsigned long long basenode_state_get_pruning_horizon(struct TariBaseNodeState *
  *
  * ## Returns
  * `c_ulonglong` - The height of the pruning horizon. This indicates from what height a full block can be provided
- * (exclusive). If `pruned_height` is equal to the `height_of_longest_chain` no blocks can be
+ * (exclusive). If `pruned_height` is equal to the `best_block_height` no blocks can be
  * provided. Archival nodes wil always have an `pruned_height` of zero.
  *
  * # Safety

--- a/clients/nodejs/base_node_grpc_client/src/index.test.js
+++ b/clients/nodejs/base_node_grpc_client/src/index.test.js
@@ -20,5 +20,5 @@ test("getTipInfo", async () => {
   const response = await baseNode.getTipInfo();
   expect(response.metadata).toBeDefined();
   const metadata = response.metadata;
-  expect(metadata.height_of_longest_chain).toMatch(/\d+/);
+  expect(metadata.best_block_height).toMatch(/\d+/);
 });

--- a/integration_tests/tests/steps/node_steps.rs
+++ b/integration_tests/tests/steps/node_steps.rs
@@ -144,7 +144,7 @@ async fn all_nodes_on_same_chain_at_height(world: &mut TariWorld, height: u64) {
             let chain_tip = client.get_tip_info(Empty {}).await.unwrap().into_inner();
             let metadata = chain_tip.metadata.unwrap();
 
-            nodes_at_height.insert(name, (metadata.height_of_longest_chain, metadata.best_block));
+            nodes_at_height.insert(name, (metadata.best_block_height, metadata.best_block_hash));
         }
 
         if nodes_at_height
@@ -182,7 +182,7 @@ async fn all_nodes_are_at_height(world: &mut TariWorld, height: u64) {
             let mut client = world.get_node_client(name).await.unwrap();
 
             let chain_tip = client.get_tip_info(Empty {}).await.unwrap().into_inner();
-            let chain_hgt = chain_tip.metadata.unwrap().height_of_longest_chain;
+            let chain_hgt = chain_tip.metadata.unwrap().best_block_height;
 
             nodes_at_height.insert(name, chain_hgt);
         }
@@ -208,7 +208,7 @@ async fn node_is_at_height(world: &mut TariWorld, base_node: String, height: u64
 
     for _ in 0..=(TWO_MINUTES_WITH_HALF_SECOND_SLEEP) {
         let chain_tip = client.get_tip_info(Empty {}).await.unwrap().into_inner();
-        chain_hgt = chain_tip.metadata.unwrap().height_of_longest_chain;
+        chain_hgt = chain_tip.metadata.unwrap().best_block_height;
 
         if chain_hgt >= height {
             return;
@@ -506,7 +506,7 @@ async fn base_node_is_at_same_height_as_node(world: &mut TariWorld, base_node: S
         .into_inner()
         .metadata
         .unwrap()
-        .height_of_longest_chain;
+        .best_block_height;
 
     let mut base_node_client = world.get_node_client(&base_node).await.unwrap();
     let mut current_height = 0;
@@ -521,7 +521,7 @@ async fn base_node_is_at_same_height_as_node(world: &mut TariWorld, base_node: S
                 .into_inner()
                 .metadata
                 .unwrap()
-                .height_of_longest_chain;
+                .best_block_height;
             if current_height >= expected_height {
                 break 'inner;
             }
@@ -536,7 +536,7 @@ async fn base_node_is_at_same_height_as_node(world: &mut TariWorld, base_node: S
             .into_inner()
             .metadata
             .unwrap()
-            .height_of_longest_chain;
+            .best_block_height;
 
         current_height = base_node_client
             .get_tip_info(req.clone())
@@ -545,7 +545,7 @@ async fn base_node_is_at_same_height_as_node(world: &mut TariWorld, base_node: S
             .into_inner()
             .metadata
             .unwrap()
-            .height_of_longest_chain;
+            .best_block_height;
 
         if current_height == expected_height {
             break 'outer;
@@ -644,7 +644,7 @@ async fn no_meddling_with_data(world: &mut TariWorld, node: String) {
 
     // No meddling
     let chain_tip = client.get_tip_info(Empty {}).await.unwrap().into_inner();
-    let current_height = chain_tip.metadata.unwrap().height_of_longest_chain;
+    let current_height = chain_tip.metadata.unwrap().best_block_height;
     let script_key_id = &world.script_key_id().await;
     let block = mine_block_before_submit(
         &mut client,
@@ -658,7 +658,7 @@ async fn no_meddling_with_data(world: &mut TariWorld, node: String) {
     let _sumbmit_res = client.submit_block(block).await.unwrap();
 
     let chain_tip = client.get_tip_info(Empty {}).await.unwrap().into_inner();
-    let new_height = chain_tip.metadata.unwrap().height_of_longest_chain;
+    let new_height = chain_tip.metadata.unwrap().best_block_height;
     assert_eq!(
         current_height + 1,
         new_height,
@@ -736,7 +736,7 @@ async fn node_reached_sync(world: &mut TariWorld, node: String) {
     for _ in 0..(TWO_MINUTES_WITH_HALF_SECOND_SLEEP * 11) {
         let tip_info = client.get_tip_info(Empty {}).await.unwrap().into_inner();
         let metadata = tip_info.metadata.unwrap();
-        longest_chain = metadata.height_of_longest_chain;
+        longest_chain = metadata.best_block_height;
 
         if tip_info.initial_sync_achieved {
             return;

--- a/integration_tests/tests/steps/wallet_steps.rs
+++ b/integration_tests/tests/steps/wallet_steps.rs
@@ -1545,7 +1545,7 @@ async fn wallet_with_tari_connected_to_base_node(
 
     let mut base_node_client = world.get_node_client(&base_node).await.unwrap();
     let tip_info_res = base_node_client.get_tip_info(Empty {}).await.unwrap().into_inner();
-    let mut current_height = tip_info_res.metadata.unwrap().height_of_longest_chain;
+    let mut current_height = tip_info_res.metadata.unwrap().best_block_height;
 
     let mut num_blocks = 0;
     let mut reward = 0;


### PR DESCRIPTION
Description
---
Renamed `best_block` and `height_of_longest_chain` in `ChainMetadata` to be technically more correct and assist with future maintenance tasks:

```rust
pub struct ChainMetadata {
    height_of_longest_chain: u64,     ->   best_block_height: u64,
    best_block: BlockHash,            ->   best_block_hash: BlockHash,
    pruning_horizon: u64,
    pruned_height: u64,
    accumulated_difficulty: U256,
    timestamp: u64,
}
```

Motivation and Context
---
- `best_block` can easily be confused with the actual best block and not the hash;
- `height_of_longest_chain` is technically not the same as `best_block_height`; in some re-org cases they may not be the same;
- using `best_block_hash` and `best_block_height` consistently also remove any confusion that may exist that `best_block` and `height_of_longest_chain` may not refer to metadata of the same entity on the blockchain.

How Has This Been Tested?
---
- `cargo clippy`

What process can a PR reviewer use to test or verify this change?
---
Code walk through - no technical changes were made

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
