### PR TITLE
feat: do validation after adding utxos and txs

### DIFF
--- a/base_layer/wallet/src/utxo_scanner_service/utxo_scanner_task.rs
+++ b/base_layer/wallet/src/utxo_scanner_service/utxo_scanner_task.rs
@@ -606,6 +606,10 @@ where
                 })
                 .collect::<Result<Vec<_>, _>>()?,
         );
+        if !found_outputs.is_empty() {
+            // this is best effort, if this fails, its very likely that its already busy with a validation.
+            let _result = self.resources.output_manager_service.validate_txos().await;
+        }
         Ok(found_outputs)
     }
 
@@ -655,6 +659,10 @@ where
                 },
                 Err(e) => return Err(UtxoScannerError::UtxoImportError(e.to_string())),
             }
+        }
+        if num_recovered > 0 {
+            // this is best effort, if this fails, its very likely that its already busy with a validation.
+            let _result = self.resources.transaction_service.validate_transactions().await;
         }
         Ok((num_recovered, total_amount))
     }

--- a/base_layer/wallet/src/utxo_scanner_service/utxo_scanner_task.rs
+++ b/base_layer/wallet/src/utxo_scanner_service/utxo_scanner_task.rs
@@ -107,7 +107,8 @@ where
                 Some(peer) => match self.attempt_sync(peer.clone()).await {
                     Ok((num_outputs_recovered, final_height, final_amount, elapsed)) => {
                         debug!(target: LOG_TARGET, "Scanned to height #{}", final_height);
-                        self.finalize(num_outputs_recovered, final_height, final_amount, elapsed)?;
+                        self.finalize(num_outputs_recovered, final_height, final_amount, elapsed)
+                            .await?;
                         return Ok(());
                     },
                     Err(e) => {
@@ -146,13 +147,18 @@ where
         }
     }
 
-    fn finalize(
-        &self,
+    async fn finalize(
+        &mut self,
         num_outputs_recovered: u64,
         final_height: u64,
         total_value: MicroMinotari,
         elapsed: Duration,
     ) -> Result<(), UtxoScannerError> {
+        if num_outputs_recovered > 0 {
+            // this is a best effort, if this fails, its very likely that it's already busy with a validation.
+            let _result = self.resources.output_manager_service.validate_txos().await;
+            let _result = self.resources.transaction_service.validate_transactions().await;
+        }
         self.publish_event(UtxoScannerEvent::Progress {
             current_height: final_height,
             tip_height: final_height,
@@ -606,10 +612,6 @@ where
                 })
                 .collect::<Result<Vec<_>, _>>()?,
         );
-        if !found_outputs.is_empty() {
-            // this is best effort, if this fails, its very likely that its already busy with a validation.
-            let _result = self.resources.output_manager_service.validate_txos().await;
-        }
         Ok(found_outputs)
     }
 
@@ -659,10 +661,6 @@ where
                 },
                 Err(e) => return Err(UtxoScannerError::UtxoImportError(e.to_string())),
             }
-        }
-        if num_recovered > 0 {
-            // this is best effort, if this fails, its very likely that its already busy with a validation.
-            let _result = self.resources.transaction_service.validate_transactions().await;
         }
         Ok((num_recovered, total_amount))
     }

--- a/base_layer/wallet/tests/support/output_manager_service_mock.rs
+++ b/base_layer/wallet/tests/support/output_manager_service_mock.rs
@@ -146,6 +146,7 @@ impl OutputManagerServiceMock {
                         e
                     });
             },
+            OutputManagerRequest::ValidateUtxos => {},
             _ => panic!("Output Manager Service Mock does not support this call"),
         }
     }

--- a/base_layer/wallet/tests/support/transaction_service_mock.rs
+++ b/base_layer/wallet/tests/support/transaction_service_mock.rs
@@ -110,6 +110,7 @@ impl TransactionServiceMock {
                         e
                     });
             },
+            TransactionServiceRequest::ValidateTransactions => {},
             _ => panic!("Transaction Service Mock does not support this call"),
         }
     }


### PR DESCRIPTION
Description
---
Trigger a validation task after recovery of outputs

Motivation and Context
---
During testing, new outputs are added slower than validation and an edge case occurs where outputs will only be validated after a new block is added again. 