### PR TITLE
fix: make monero extra data less strict

### DIFF
--- a/base_layer/core/src/base_node/sync/header_sync/synchronizer.rs
+++ b/base_layer/core/src/base_node/sync/header_sync/synchronizer.rs
@@ -646,6 +646,11 @@ impl<'a, B: BlockchainBackend + 'static> HeaderSynchronizer<'a, B> {
                 header.hash().to_hex(),
                 latency
             );
+            trace!(
+                target: LOG_TARGET,
+                "{}",
+                header
+            );
             if let Some(prev_header_height) = prev_height {
                 if header.height != prev_header_height.saturating_add(1) {
                     warn!(

--- a/base_layer/core/src/proof_of_work/monero_rx/helpers.rs
+++ b/base_layer/core/src/proof_of_work/monero_rx/helpers.rs
@@ -105,8 +105,11 @@ pub fn verify_header(
 ) -> Result<MoneroPowData, MergeMineError> {
     let monero_data = MoneroPowData::from_header(header, consensus)?;
     let expected_merge_mining_hash = header.merge_mining_hash();
-    let extra_field = ExtraField::try_parse(&monero_data.coinbase_tx_extra)
-        .map_err(|_| MergeMineError::DeserializeError("Invalid extra field".to_string()))?;
+    let extra_field = ExtraField::try_parse(&monero_data.coinbase_tx_extra);
+    let extra_field = extra_field.unwrap_or_else(|ex_field| {
+        warn!(target: LOG_TARGET, "Error deserializing, Monero extra field");
+        ex_field
+    });
     // Check that the Tari MM hash is found in the Monero coinbase transaction
     // and that only 1 Tari header is found
 

--- a/base_layer/core/src/proof_of_work/monero_rx/helpers.rs
+++ b/base_layer/core/src/proof_of_work/monero_rx/helpers.rs
@@ -1251,4 +1251,27 @@ mod test {
         );
         assert_eq!(difficulty.as_u64(), 430603);
     }
+
+    #[test]
+    fn test_extra_field_deserialize() {
+        let bytes = vec![
+            3, 33, 0, 149, 5, 198, 66, 174, 39, 113, 243, 68, 202, 221, 222, 116, 10, 209, 194, 56, 247, 252, 23, 248,
+            28, 44, 81, 91, 44, 214, 211, 242, 3, 12, 70, 0, 0, 0, 1, 251, 88, 0, 0, 96, 49, 163, 82, 175, 205, 74,
+            138, 126, 250, 226, 106, 10, 255, 139, 49, 41, 168, 110, 203, 150, 252, 208, 234, 140, 2, 17, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        ];
+        let raw_extra_field = RawExtraField(bytes);
+        let res = ExtraField::try_parse(&raw_extra_field);
+        assert!(res.is_err());
+        let field = res.unwrap_err();
+        let mm_tag = SubField::MergeMining(
+            Some(VarInt(0)),
+            Hash::from_slice(
+                hex::decode("9505c642ae2771f344caddde740ad1c238f7fc17f81c2c515b2cd6d3f2030c46")
+                    .unwrap()
+                    .as_slice(),
+            ),
+        );
+        assert_eq!(field.0[0], mm_tag);
+    }
 }


### PR DESCRIPTION
Description
---
It reverts a change to make the extra field acceptance less strict. 
Motivation and Context
---
Tari only cares about the Merge mining field and not the rest. As long as that deserializes correct we are secure. 
