### PR TITLE
chore: make MAC equality check more idiomatic

### DIFF
--- a/base_layer/key_manager/src/cipher_seed.rs
+++ b/base_layer/key_manager/src/cipher_seed.rs
@@ -283,16 +283,16 @@ impl CipherSeed {
         let expected_mac = Self::generate_mac(&birthday_bytes, entropy.reveal(), version, salt.as_ref(), &mac_key)?;
 
         // Verify the MAC in constant time to avoid leaking data
-        if mac.ct_eq(&expected_mac).unwrap_u8() == 0 {
-            return Err(KeyManagerError::DecryptionFailed);
+        if mac.ct_eq(&expected_mac).into() {
+            Ok(Self {
+                version,
+                birthday,
+                entropy: Box::from(*entropy.reveal()),
+                salt,
+            })
+        } else {
+            Err(KeyManagerError::DecryptionFailed)
         }
-
-        Ok(Self {
-            version,
-            birthday,
-            entropy: Box::from(*entropy.reveal()),
-            salt,
-        })
     }
 
     /// Encrypt or decrypt data using ChaCha20


### PR DESCRIPTION
Description
---
Cleans up the handling of cipher seed message authentication codes (MACs) to be more idiomatic.

Motivation and Context
---
A cipher seed has an associated MAC that is checked during decryption in constant time. Rather than using `Choice::unwrap_u8` as is currently done, this PR uses the more idiomatic `Into<bool>` on `Choice` to be more resistant to mistakes or misuse. It also changes the logic slightly to avoid "failing open" by no longer returning an `Ok` at the end of the function by default, which helps to simplify the code and make the intent more clear.

How Has This Been Tested?
---
Existing tests pass.

What process can a PR reviewer use to test or verify this change?
---
Check that the updated logic matches the existing logic.