### PR TITLE
feat: add import tx method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1300,7 +1300,7 @@ dependencies = [
  "globwalk",
  "humantime 2.1.0",
  "inventory",
- "itertools 0.12.0",
+ "itertools 0.12.1",
  "junit-report",
  "lazy-regex",
  "linked-hash-map",
@@ -1321,7 +1321,7 @@ checksum = "01091e28d1f566c8b31b67948399d2efd6c0a8f6228a9785519ed7b73f7f0aef"
 dependencies = [
  "cucumber-expressions",
  "inflections",
- "itertools 0.12.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "regex",
@@ -2591,9 +2591,9 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "inventory"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8573b2b1fb643a372c73b23f4da5f888677feef3305146d68a539250a9bccc7"
+checksum = "f958d3d68f4167080a18141e10381e7634563984a537f2a49a30fd8e53ac5767"
 
 [[package]]
 name = "ipnet"
@@ -2632,9 +2632,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25db6b064527c5d482d0423354fcd07a89a2dfe07b67892e62411946db7f07b0"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]

--- a/applications/minotari_console_wallet/src/cli.rs
+++ b/applications/minotari_console_wallet/src/cli.rs
@@ -124,6 +124,7 @@ pub enum CliCommands {
     Whois(WhoisArgs),
     ExportUtxos(ExportUtxosArgs),
     ExportTx(ExportTxArgs),
+    ImportTx(ImportTxArgs),
     ExportSpentUtxos(ExportUtxosArgs),
     CountUtxos,
     SetBaseNode(SetBaseNodeArgs),
@@ -247,6 +248,12 @@ pub struct ExportTxArgs {
     pub tx_id: u64,
     #[clap(short, long)]
     pub output_file: Option<PathBuf>,
+}
+
+#[derive(Debug, Args, Clone)]
+pub struct ImportTxArgs {
+    #[clap(short, long)]
+    pub input_file: PathBuf,
 }
 
 #[derive(Debug, Args, Clone)]

--- a/applications/minotari_console_wallet/src/wallet_modes.rs
+++ b/applications/minotari_console_wallet/src/wallet_modes.rs
@@ -475,6 +475,7 @@ async fn run_grpc(
 
 #[cfg(test)]
 mod test {
+    use std::path::Path;
 
     use crate::{cli::CliCommands, wallet_modes::parse_command_file};
 
@@ -501,6 +502,8 @@ mod test {
 
             export-tx 123456789 --output-file pie.txt
 
+            import-tx --input-file pie_this_message.txt
+
             # End of script file
             "
         .to_string();
@@ -514,6 +517,7 @@ mod test {
         let mut coin_split = false;
         let mut discover_peer = false;
         let mut export_tx = false;
+        let mut import_tx = false;
         let mut whois = false;
         for command in commands {
             match command {
@@ -532,6 +536,11 @@ mod test {
                         export_tx = true
                     }
                 },
+                CliCommands::ImportTx(args) => {
+                    if args.input_file == Path::new("pie_this_message.txt") {
+                        import_tx = true
+                    }
+                },
                 CliCommands::ExportSpentUtxos(_) => {},
                 CliCommands::CountUtxos => {},
                 CliCommands::SetBaseNode(_) => {},
@@ -546,7 +555,15 @@ mod test {
             }
         }
         assert!(
-            get_balance && send_tari && burn_tari && make_it_rain && coin_split && discover_peer && whois && export_tx
+            get_balance &&
+                send_tari &&
+                burn_tari &&
+                make_it_rain &&
+                coin_split &&
+                discover_peer &&
+                whois &&
+                export_tx &&
+                import_tx
         );
     }
 }

--- a/base_layer/wallet/src/transaction_service/storage/database.rs
+++ b/base_layer/wallet/src/transaction_service/storage/database.rs
@@ -320,6 +320,30 @@ where T: TransactionBackend + 'static
             )))
     }
 
+    pub fn insert_pending_inbound_transaction(
+        &self,
+        tx_id: TxId,
+        transaction: InboundTransaction,
+    ) -> Result<Option<DbValue>, TransactionStorageError> {
+        self.db
+            .write(WriteOperation::Insert(DbKeyValuePair::PendingInboundTransaction(
+                tx_id,
+                Box::new(transaction),
+            )))
+    }
+
+    pub fn insert_pending_outbound_transaction(
+        &self,
+        tx_id: TxId,
+        transaction: OutboundTransaction,
+    ) -> Result<Option<DbValue>, TransactionStorageError> {
+        self.db
+            .write(WriteOperation::Insert(DbKeyValuePair::PendingOutboundTransaction(
+                tx_id,
+                Box::new(transaction),
+            )))
+    }
+
     pub fn get_pending_outbound_transaction(
         &self,
         tx_id: TxId,

--- a/base_layer/wallet/src/transaction_service/storage/models.rs
+++ b/base_layer/wallet/src/transaction_service/storage/models.rs
@@ -303,7 +303,7 @@ impl From<InboundTransaction> for CompletedTransaction {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[allow(clippy::large_enum_variant)]
 pub enum WalletTransaction {
     PendingInbound(InboundTransaction),


### PR DESCRIPTION
Description
---
Allows users to import an exported transaction to their wallet. 

Motivation and Context
---
This allows true cold mining. A wallet can export any transaction, and it can then be imported to any transaction which will monitor and ensure the transaction is broadcasted to the network. 

How Has This Been Tested?
---
unit tests and manual
