### PR TITLE
ci: bump nightly version

### DIFF
--- a/.github/workflows/base_node_binaries.json
+++ b/.github/workflows/base_node_binaries.json
@@ -2,7 +2,7 @@
   {
     "name": "linux-x86_64",
     "runs-on": "ubuntu-20.04",
-    "rust": "nightly-2023-06-04",
+    "rust": "nightly-2024-02-01",
     "target": "x86_64-unknown-linux-gnu",
     "cross": false,
     "target_cpu": "x86-64",

--- a/.github/workflows/base_node_binaries.yml
+++ b/.github/workflows/base_node_binaries.yml
@@ -19,7 +19,7 @@ name: Build Matrix of Binaries
 env:
   TBN_FILENAME: "tari_suite"
   TBN_BUNDLE_ID_BASE: "com.tarilabs.pkg"
-  toolchain: nightly-2023-06-04
+  toolchain: nightly-2024-02-01
   matrix-json-file: ".github/workflows/base_node_binaries.json"
   CARGO_HTTP_MULTIPLEXING: false
   CARGO_UNSTABLE_SPARSE_REGISTRY: true

--- a/.github/workflows/build_dockers.yml
+++ b/.github/workflows/build_dockers.yml
@@ -47,7 +47,7 @@ name: Build docker images
           - xmrig
 
 env:
-  toolchain_default: nightly-2023-06-04
+  toolchain_default: nightly-2024-02-01
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/build_dockers_workflow.yml
+++ b/.github/workflows/build_dockers_workflow.yml
@@ -14,7 +14,7 @@ name: Build docker images - workflow_call/on-demand
       toolchain:
         type: string
         description: 'Rust toolchain'
-        default: nightly-2023-06-04
+        default: nightly-2024-02-01
       arch:
         type: string
         default: x86-64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ name: CI
   merge_group:
 
 env:
-  toolchain: nightly-2023-06-04
+  toolchain: nightly-2024-02-01
   CARGO_HTTP_MULTIPLEXING: false
   CARGO_TERM_COLOR: always
   CARGO_UNSTABLE_SPARSE_REGISTRY: true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,7 +11,7 @@ name: Source Coverage
       - ci-coverage-*
 
 env:
-  toolchain: nightly-2023-06-04
+  toolchain: nightly-2024-02-01
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -27,7 +27,7 @@ name: Integration tests
         type: string
 
 env:
-  toolchain: nightly-2023-06-04
+  toolchain: nightly-2024-02-01
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/applications/minotari_app_grpc/src/conversions/mod.rs
+++ b/applications/minotari_app_grpc/src/conversions/mod.rs
@@ -43,25 +43,6 @@ mod unblinded_output;
 
 use prost_types::Timestamp;
 
-pub use self::{
-    aggregate_body::*,
-    base_node_state::*,
-    block::*,
-    block_header::*,
-    chain_metadata::*,
-    com_and_pub_signature::*,
-    consensus_constants::*,
-    historical_block::*,
-    new_block_template::*,
-    output_features::*,
-    peer::*,
-    proof_of_work::*,
-    signature::*,
-    transaction::*,
-    transaction_input::*,
-    transaction_kernel::*,
-    transaction_output::*,
-};
 use crate::{tari_rpc as grpc, tari_rpc::BlockGroupRequest};
 
 /// Utility function that converts a `chrono::NaiveDateTime` to a `prost::Timestamp`

--- a/applications/minotari_console_wallet/src/ui/components/burn_tab.rs
+++ b/applications/minotari_console_wallet/src/ui/components/burn_tab.rs
@@ -250,7 +250,7 @@ impl BurnTab {
         let mut column0_items = Vec::new();
         let mut column1_items = Vec::new();
 
-        for item in windowed_view.iter() {
+        for item in windowed_view {
             column0_items.push(ListItem::new(Span::raw(item.reciprocal_claim_public_key.clone())));
             column1_items.push(ListItem::new(Span::raw(item.burned_at.to_string().clone())));
         }

--- a/applications/minotari_console_wallet/src/ui/components/contacts_tab.rs
+++ b/applications/minotari_console_wallet/src/ui/components/contacts_tab.rs
@@ -91,7 +91,7 @@ impl ContactsTab {
         let mut column2_items = Vec::new();
         let mut column3_items = Vec::new();
         let mut column4_items = Vec::new();
-        for c in windowed_view.iter() {
+        for c in windowed_view {
             column0_items.push(ListItem::new(Span::raw(c.alias.clone())));
             column1_items.push(ListItem::new(Span::raw(c.address.clone())));
             column2_items.push(ListItem::new(Span::raw(display_compressed_string(

--- a/applications/minotari_console_wallet/src/ui/components/network_tab.rs
+++ b/applications/minotari_console_wallet/src/ui/components/network_tab.rs
@@ -190,7 +190,7 @@ impl NetworkTab {
         let mut column0_items = Vec::with_capacity(peers.len());
         let mut column1_items = Vec::with_capacity(peers.len());
         let mut column2_items = Vec::with_capacity(peers.len());
-        for p in peers.iter() {
+        for p in peers {
             column0_items.push(ListItem::new(Span::raw(p.node_id.to_string())));
             column1_items.push(ListItem::new(Span::raw(p.public_key.to_string())));
             column2_items.push(ListItem::new(Span::raw(p.user_agent.clone())));
@@ -434,11 +434,7 @@ impl<B: Backend> Component<B> for NetworkTab {
                 // set the currently selected base node as a custom base node
                 let base_node = app_state.get_selected_base_node();
                 let public_key = base_node.public_key.to_hex();
-                let address = base_node
-                    .addresses
-                    .best()
-                    .map(|a| a.to_string())
-                    .unwrap_or_else(|| "".to_string());
+                let address = base_node.addresses.best().map(|a| a.to_string()).unwrap_or_default();
 
                 match Handle::current().block_on(app_state.set_custom_base_node(public_key, address)) {
                     Ok(peer) => {

--- a/applications/minotari_console_wallet/src/ui/components/transactions_tab.rs
+++ b/applications/minotari_console_wallet/src/ui/components/transactions_tab.rs
@@ -102,7 +102,7 @@ impl TransactionsTab {
         let mut column2_items = Vec::new();
         let mut column3_items = Vec::new();
 
-        for t in windowed_view.iter() {
+        for t in windowed_view {
             let text_color = text_colors
                 .get(&t.cancelled.is_some())
                 .unwrap_or(&Color::Reset)
@@ -205,7 +205,7 @@ impl TransactionsTab {
         let mut column2_items = Vec::new();
         let mut column3_items = Vec::new();
 
-        for t in windowed_view.iter() {
+        for t in windowed_view {
             let cancelled = t.cancelled.is_some();
             let text_color = text_colors.get(&cancelled).unwrap_or(&Color::Reset).to_owned();
             if t.direction == TransactionDirection::Outbound {

--- a/applications/minotari_console_wallet/src/ui/widgets/list_state.rs
+++ b/applications/minotari_console_wallet/src/ui/widgets/list_state.rs
@@ -191,7 +191,7 @@ mod test {
 
     #[test]
     fn test_list_offset_update() {
-        let slist = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        let slist = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
         let mut list_state = WindowedListState::new();
         list_state.set_num_items(slist.len());
         let height = 4;

--- a/applications/minotari_merge_mining_proxy/src/common/json_rpc.rs
+++ b/applications/minotari_merge_mining_proxy/src/common/json_rpc.rs
@@ -128,13 +128,13 @@ pub mod test {
 
     #[test]
     pub fn test_error_response() {
-        let req_id = Some(12);
+        let req_id = 12;
         let err_code = 200;
         let err_message = "error message";
-        let err_data = Some(json::json!({"test key":"test value"}));
-        let response = error_response(req_id, err_code, err_message, err_data.clone());
-        assert_eq!(response["id"], req_id.unwrap());
-        assert_eq!(response["error"]["data"], err_data.unwrap());
+        let err_data = json::json!({"test key":"test value"});
+        let response = error_response(Some(req_id), err_code, err_message, Some(err_data.clone()));
+        assert_eq!(response["id"], req_id);
+        assert_eq!(response["error"]["data"], err_data);
         assert_eq!(response["error"]["code"], err_code);
         assert_eq!(response["error"]["message"], err_message);
         let response = error_response(None, err_code, err_message, None);

--- a/applications/minotari_miner/src/miner.rs
+++ b/applications/minotari_miner/src/miner.rs
@@ -222,7 +222,7 @@ pub fn mining_task(
             // If we are mining in share mode, this share might not be a block, so we need to keep mining till we get a
             // new job
             if share_mode {
-                waker.clone().wake();
+                waker.wake_by_ref();
             } else {
                 waker.wake();
                 trace!(target: LOG_TARGET, "Mining thread {} stopped", miner);
@@ -240,7 +240,7 @@ pub fn mining_task(
                 height: hasher.height(),
                 target_difficulty,
             });
-            waker.clone().wake();
+            waker.wake_by_ref();
             trace!(target: LOG_TARGET, "Reporting from {} result {:?}", miner, res);
             if let Err(TrySendError::Disconnected(_)) = res {
                 info!(target: LOG_TARGET, "Mining thread {} disconnected", miner);

--- a/applications/minotari_miner/src/stratum/controller.rs
+++ b/applications/minotari_miner/src/stratum/controller.rs
@@ -236,10 +236,10 @@ impl Controller {
     }
 
     fn handle_error(&mut self, error: types::rpc_error::RpcError) {
-        if vec![-1, 24].contains(&error.code) {
+        if [-1, 24].contains(&error.code) {
             // unauthorized
             let _result = self.send_login();
-        } else if vec![21, 20, 22, 23, 25].contains(&error.code) {
+        } else if [21, 20, 22, 23, 25].contains(&error.code) {
             // problem with template
             let _result = self.send_message_get_job_template();
         } else {

--- a/applications/minotari_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/minotari_node/src/grpc/base_node_grpc_server.rs
@@ -120,7 +120,7 @@ impl BaseNodeGrpcServer {
     }
 
     fn is_method_enabled(&self, grpc_method: GrpcMethod) -> bool {
-        let mining_method = vec![
+        let mining_method = [
             GrpcMethod::GetNewBlockTemplate,
             GrpcMethod::GetNewBlock,
             GrpcMethod::GetNewBlockBlob,
@@ -1888,6 +1888,7 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
             };
 
             for template_registration in template_registrations {
+                #[allow(clippy::unnecessary_fallible_conversions)]
                 let registration = match template_registration.registration_data.try_into() {
                     Ok(t) => t,
                     Err(e) => {

--- a/base_layer/chat_ffi/src/confirmation.rs
+++ b/base_layer/chat_ffi/src/confirmation.rs
@@ -117,6 +117,7 @@ pub unsafe extern "C" fn read_confirmation_message_id(
 /// # Safety
 /// The ```confirmation``` When done with the Confirmation it should be destroyed
 #[no_mangle]
+#[allow(clippy::cast_possible_wrap)]
 pub unsafe extern "C" fn read_confirmation_timestamp(
     confirmation: *mut Confirmation,
     error_out: *mut c_int,

--- a/base_layer/chat_ffi/src/message.rs
+++ b/base_layer/chat_ffi/src/message.rs
@@ -187,6 +187,7 @@ pub unsafe extern "C" fn chat_metadata_get_at(
 /// ## Safety
 /// `message` should be destroyed eventually
 #[no_mangle]
+#[allow(clippy::cast_possible_wrap)]
 pub unsafe extern "C" fn chat_message_metadata_len(message: *mut Message, error_out: *mut c_int) -> c_longlong {
     let mut error = 0;
     ptr::swap(error_out, &mut error as *mut c_int);
@@ -289,7 +290,7 @@ pub unsafe extern "C" fn read_chat_message_direction(message: *mut Message, erro
         return -1;
     }
 
-    c_int::try_from((*message).direction.as_byte()).unwrap_or(-1)
+    c_int::from((*message).direction.as_byte())
 }
 
 /// Returns a c_ulonglong representation of the stored at timestamp as seconds since epoch

--- a/base_layer/chat_ffi/src/message_metadata.rs
+++ b/base_layer/chat_ffi/src/message_metadata.rs
@@ -120,7 +120,7 @@ pub unsafe extern "C" fn read_chat_metadata_type(msg_metadata: *mut MessageMetad
     }
 
     let md = &(*msg_metadata);
-    c_int::try_from(md.metadata_type.as_byte()).unwrap_or(-1)
+    c_int::from(md.metadata_type.as_byte())
 }
 
 /// Returns a ptr to a ByteVector

--- a/base_layer/common_types/src/tx_id.rs
+++ b/base_layer/common_types/src/tx_id.rs
@@ -66,7 +66,7 @@ impl Hash for TxId {
 
 impl PartialEq for TxId {
     fn eq(&self, other: &Self) -> bool {
-        self.0.eq(&other.0)
+        self.0 == other.0
     }
 }
 

--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -614,7 +614,7 @@ where B: BlockchainBackend + 'static
                 source_peer,
             );
             #[cfg(feature = "metrics")]
-            metrics::compact_block_tx_misses(header.height).set(excess_sigs.len() as i64);
+            metrics::compact_block_tx_misses(header.height).set(i64::try_from(excess_sigs.len()).unwrap_or(i64::MAX));
             let block = self.request_full_block_from_peer(source_peer, block_hash).await?;
             return Ok(block);
         }
@@ -624,7 +624,8 @@ where B: BlockchainBackend + 'static
         let known_transactions = known_transactions.into_iter().map(|tx| (*tx).clone()).collect();
 
         #[cfg(feature = "metrics")]
-        metrics::compact_block_tx_misses(header.height).set(missing_excess_sigs.len() as i64);
+        metrics::compact_block_tx_misses(header.height)
+            .set(i64::try_from(missing_excess_sigs.len()).unwrap_or(i64::MAX));
 
         let mut builder = BlockBuilder::new(header.version)
             .with_coinbase_utxo(coinbase_output, coinbase_kernel)

--- a/base_layer/core/src/base_node/proto/wallet_rpc.rs
+++ b/base_layer/core/src/base_node/proto/wallet_rpc.rs
@@ -226,7 +226,7 @@ impl From<TxQueryResponse> for proto::TxQueryResponse {
     fn from(response: TxQueryResponse) -> Self {
         Self {
             location: proto::TxLocation::from(response.location) as i32,
-            best_block_hash: response.best_block_hash.map(|v| v.to_vec()).unwrap_or(vec![]),
+            best_block_hash: response.best_block_hash.map(|v| v.to_vec()).unwrap_or_default(),
             confirmations: response.confirmations,
             is_synced: response.is_synced,
             best_block_height: response.best_block_height,

--- a/base_layer/core/src/base_node/sync/rpc/service.rs
+++ b/base_layer/core/src/base_node/sync/rpc/service.rs
@@ -101,7 +101,7 @@ impl<B: BlockchainBackend + 'static> BaseNodeSyncRpcService<B> {
         let token = Arc::new(peer);
         lock.push(Arc::downgrade(&token));
         #[cfg(feature = "metrics")]
-        metrics::active_sync_peers().set(lock.len() as i64);
+        metrics::active_sync_peers().set(i64::try_from(lock.len()).unwrap_or(i64::MAX));
         Ok(token)
     }
 }

--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -1326,11 +1326,11 @@ pub fn calculate_mmr_roots<T: BlockchainBackend>(
     let mut output_smt = db.fetch_tip_smt()?;
     let mut input_mmr = PrunedInputMmr::new(PrunedHashSet::default());
 
-    for kernel in body.kernels().iter() {
+    for kernel in body.kernels() {
         kernel_mmr.push(kernel.hash().to_vec())?;
     }
 
-    for output in body.outputs().iter() {
+    for output in body.outputs() {
         if !output.is_burned() {
             let smt_key = NodeKey::try_from(output.commitment.as_bytes())?;
             let smt_node = ValueHash::try_from(output.smt_hash(header.height).as_slice())?;
@@ -1338,7 +1338,7 @@ pub fn calculate_mmr_roots<T: BlockchainBackend>(
         }
     }
 
-    for input in body.inputs().iter() {
+    for input in body.inputs() {
         input_mmr.push(input.canonical_hash().to_vec())?;
 
         // Search the DB for the output leaf index so that it can be marked as spent/deleted.

--- a/base_layer/core/src/chain_storage/reorg.rs
+++ b/base_layer/core/src/chain_storage/reorg.rs
@@ -43,8 +43,8 @@ impl Reorg {
     pub fn from_reorged_blocks(added: &VecDeque<Arc<ChainBlock>>, removed: &[Arc<ChainBlock>]) -> Self {
         // Expects blocks to be ordered sequentially highest height to lowest (as in rewind_to_height)
         Self {
-            new_height: added.get(0).map(|b| b.header().height).unwrap_or_default(),
-            new_hash: added.get(0).map(|b| *b.hash()).unwrap_or_default(),
+            new_height: added.front().map(|b| b.header().height).unwrap_or_default(),
+            new_hash: added.front().map(|b| *b.hash()).unwrap_or_default(),
             prev_height: removed.first().map(|b| b.header().height).unwrap_or_default(),
             prev_hash: removed.first().map(|b| *b.hash()).unwrap_or_default(),
             num_blocks_added: added.len() as u64,

--- a/base_layer/core/src/consensus/consensus_encoding.rs
+++ b/base_layer/core/src/consensus/consensus_encoding.rs
@@ -24,7 +24,7 @@ mod bytes;
 mod hashing;
 mod string;
 
-pub use hashing::{ConsensusHasher, DomainSeparatedConsensusHasher};
+pub use hashing::DomainSeparatedConsensusHasher;
 pub use string::MaxSizeString;
 
 pub use self::bytes::MaxSizeBytes;

--- a/base_layer/core/src/covenants/decoder.rs
+++ b/base_layer/core/src/covenants/decoder.rs
@@ -95,6 +95,7 @@ pub(super) trait CovenantReadExt: io::Read {
 
 impl<R: io::Read> CovenantReadExt for R {
     /// Reads next byte code
+    #[allow(clippy::unused_io_amount)]
     fn read_next_byte_code(&mut self) -> Result<Option<u8>, io::Error> {
         let mut buf = [0u8; 1];
         loop {

--- a/base_layer/core/src/covenants/output_set.rs
+++ b/base_layer/core/src/covenants/output_set.rs
@@ -163,7 +163,7 @@ impl<T> Eq for Indexed<T> {}
 
 impl<T> PartialOrd for Indexed<T> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.index.partial_cmp(&other.index)
+        Some(self.cmp(other))
     }
 }
 

--- a/base_layer/core/src/mempool/unconfirmed_pool/unconfirmed_pool.rs
+++ b/base_layer/core/src/mempool/unconfirmed_pool/unconfirmed_pool.rs
@@ -544,7 +544,7 @@ impl UnconfirmedPool {
             .flat_map(|tx| tx.body.inputs())
             .map(|i| i.output_hash())
             .collect::<HashSet<_>>();
-        for (_, transaction) in current_transactions.iter() {
+        for transaction in current_transactions.values() {
             for input in transaction.body.inputs() {
                 if insert_set.contains(&input.output_hash()) {
                     return true;
@@ -646,8 +646,7 @@ impl UnconfirmedPool {
                         Ok(Some(v)) => Some(Ok(v)),
                         Ok(None) => None,
                     })
-                    .collect::<Result<Vec<_>, _>>()?
-                    .into_iter(),
+                    .collect::<Result<Vec<_>, _>>()?,
             );
             debug!(
                 target: LOG_TARGET,
@@ -680,8 +679,7 @@ impl UnconfirmedPool {
                         Ok(Some(v)) => Some(Ok(v)),
                         Ok(None) => None,
                     })
-                    .collect::<Result<Vec<_>, _>>()?
-                    .into_iter(),
+                    .collect::<Result<Vec<_>, _>>()?,
             );
             debug!(
                 target: LOG_TARGET,

--- a/base_layer/core/src/proto/block_header.rs
+++ b/base_layer/core/src/proto/block_header.rs
@@ -70,7 +70,7 @@ impl TryFrom<proto::BlockHeader> for BlockHeader {
 impl From<BlockHeader> for proto::BlockHeader {
     fn from(header: BlockHeader) -> Self {
         Self {
-            version: u32::try_from(header.version).unwrap(),
+            version: u32::from(header.version),
             height: header.height,
             prev_hash: header.prev_hash.to_vec(),
             timestamp: header.timestamp.as_u64(),

--- a/base_layer/core/src/transactions/tari_amount.rs
+++ b/base_layer/core/src/transactions/tari_amount.rs
@@ -353,7 +353,7 @@ impl FromStr for Minotari {
 
 impl Display for Minotari {
     fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
-        let d1 = Decimal::try_from(self.0.as_u64()).expect("will succeed");
+        let d1 = Decimal::from(self.0.as_u64());
         let d2 = Decimal::try_from(1_000_000f64).expect("will succeed");
         let precision = f.precision().unwrap_or(6);
         write!(f, "{1:.*} T", precision, d1 / d2)

--- a/base_layer/core/src/transactions/transaction_components/transaction_input.rs
+++ b/base_layer/core/src/transactions/transaction_components/transaction_input.rs
@@ -553,7 +553,7 @@ impl Eq for TransactionInput {}
 
 impl PartialOrd for TransactionInput {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.output_hash().partial_cmp(&other.output_hash())
+        Some(self.cmp(other))
     }
 }
 

--- a/base_layer/core/src/transactions/transaction_components/transaction_kernel.rs
+++ b/base_layer/core/src/transactions/transaction_components/transaction_kernel.rs
@@ -258,7 +258,7 @@ impl Display for TransactionKernel {
 
 impl PartialOrd for TransactionKernel {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.excess_sig.partial_cmp(&other.excess_sig)
+        Some(self.cmp(other))
     }
 }
 

--- a/base_layer/core/src/transactions/transaction_components/transaction_output.rs
+++ b/base_layer/core/src/transactions/transaction_components/transaction_output.rs
@@ -515,7 +515,7 @@ impl Display for TransactionOutput {
 
 impl PartialOrd for TransactionOutput {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.commitment.partial_cmp(&other.commitment)
+        Some(self.cmp(other))
     }
 }
 

--- a/base_layer/core/src/transactions/transaction_components/unblinded_output.rs
+++ b/base_layer/core/src/transactions/transaction_components/unblinded_output.rs
@@ -191,7 +191,7 @@ impl PartialEq for UnblindedOutput {
 
 impl PartialOrd<UnblindedOutput> for UnblindedOutput {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.value.partial_cmp(&other.value)
+        Some(self.cmp(other))
     }
 }
 

--- a/base_layer/core/src/transactions/transaction_components/wallet_output.rs
+++ b/base_layer/core/src/transactions/transaction_components/wallet_output.rs
@@ -332,7 +332,7 @@ impl PartialEq for WalletOutput {
 
 impl PartialOrd<WalletOutput> for WalletOutput {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.value.partial_cmp(&other.value)
+        Some(self.cmp(other))
     }
 }
 

--- a/base_layer/core/src/transactions/transaction_protocol/transaction_initializer.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/transaction_initializer.rs
@@ -502,7 +502,7 @@ where KM: TransactionKeyManagerInterface
             return self.build_err("Fee is less than the minimum");
         }
 
-        let change_output_pair = match { change_output } {
+        let change_output_pair = match change_output {
             Some((output, sender_offset_key_id)) => {
                 if self.sender_custom_outputs.len() >= MAX_TRANSACTION_OUTPUTS {
                     return self.build_err("Too many outputs in transaction");

--- a/base_layer/core/tests/helpers/block_builders.rs
+++ b/base_layer/core/tests/helpers/block_builders.rs
@@ -368,9 +368,7 @@ pub async fn append_block<B: BlockchainBackend>(
     achieved_difficulty: Difficulty,
     key_manager: &MemoryDbKeyManager,
 ) -> Result<(ChainBlock, WalletOutput), ChainStorageError> {
-    append_block_with_coinbase(db, prev_block, txns, consensus, achieved_difficulty, key_manager)
-        .await
-        .map(|(b, wo)| (b, wo))
+    append_block_with_coinbase(db, prev_block, txns, consensus, achieved_difficulty, key_manager).await
 }
 
 /// Create a new block with the provided transactions and add a coinbase output. The new MMR roots are calculated, and

--- a/base_layer/core/tests/tests/block_validation.rs
+++ b/base_layer/core/tests/tests/block_validation.rs
@@ -1278,15 +1278,15 @@ async fn test_fee_overflow() {
             offset: txn.offset,
             body: {
                 let mut inputs = Vec::with_capacity(txn.body.inputs().len());
-                for input in txn.body.inputs().iter() {
+                for input in txn.body.inputs() {
                     inputs.push(input.clone());
                 }
                 let mut outputs = Vec::with_capacity(txn.body.outputs().len());
-                for output in txn.body.outputs().iter() {
+                for output in txn.body.outputs() {
                     outputs.push(output.clone());
                 }
                 let mut kernels = Vec::with_capacity(txn.body.kernels().len());
-                for kernel in txn.body.kernels().iter() {
+                for kernel in txn.body.kernels() {
                     kernels.push(TransactionKernel {
                         version: kernel.version,
                         features: kernel.features,

--- a/base_layer/key_manager/src/key_manager.rs
+++ b/base_layer/key_manager/src/key_manager.rs
@@ -104,7 +104,7 @@ where
         // input
         let derive_key = mac_domain_hasher::<D>(LABEL_DERIVE_KEY)
             .chain(self.seed.entropy())
-            .chain(self.branch_seed.as_str().as_bytes())
+            .chain(self.branch_seed.as_bytes())
             .chain(key_index.to_le_bytes())
             .finalize();
 

--- a/base_layer/key_manager/src/lib.rs
+++ b/base_layer/key_manager/src/lib.rs
@@ -139,7 +139,7 @@ mod tests {
             Hidden::hide("olá".to_string()),
         ]);
 
-        let vec_words = vec![
+        let vec_words = [
             "hi".to_string(),
             "niao".to_string(),
             "hola".to_string(),

--- a/base_layer/mmr/src/backend.rs
+++ b/base_layer/mmr/src/backend.rs
@@ -83,7 +83,7 @@ impl<T: Clone + PartialEq> ArrayLike for Vec<T> {
     }
 
     fn get(&self, index: usize) -> Result<Option<Self::Value>, Self::Error> {
-        Ok((self as &[Self::Value]).get(index).map(Clone::clone))
+        Ok((self as &[Self::Value]).get(index).cloned())
     }
 
     fn clear(&mut self) -> Result<(), Self::Error> {

--- a/base_layer/mmr/src/sparse_merkle_tree/bit_utils.rs
+++ b/base_layer/mmr/src/sparse_merkle_tree/bit_utils.rs
@@ -98,8 +98,6 @@ pub fn traverse_direction(
 
 #[cfg(test)]
 mod test {
-    use std::convert::TryFrom;
-
     use super::*;
     use crate::sparse_merkle_tree::{bit_utils::count_common_prefix, NodeKey};
 
@@ -120,9 +118,9 @@ mod test {
 
     #[test]
     fn traverse_directions() {
-        let parent_key = NodeKey::try_from(b"\xffbcdefgh12345678abcdefgh12345678").unwrap();
+        let parent_key = NodeKey::from(b"\xffbcdefgh12345678abcdefgh12345678");
         // 10111111 in hex is 0xBF
-        let child_key = NodeKey::try_from(b"\xBFbcdefgh12345678abcdefgh12345678").unwrap();
+        let child_key = NodeKey::from(b"\xBFbcdefgh12345678abcdefgh12345678");
         assert_eq!(
             traverse_direction(0, &parent_key, &child_key).unwrap(),
             TraverseDirection::Right
@@ -140,7 +138,7 @@ mod test {
         });
         assert_eq!(err, expected_err);
         // 11011111 in hex is 0xDF
-        let child_key = NodeKey::try_from(b"\xDFbcdefgh12345678abcdefgh12345678").unwrap();
+        let child_key = NodeKey::from(b"\xDFbcdefgh12345678abcdefgh12345678");
         assert_eq!(
             traverse_direction(0, &parent_key, &child_key).unwrap(),
             TraverseDirection::Right
@@ -156,8 +154,8 @@ mod test {
             TraverseDirection::Left
         );
 
-        let parent_key = NodeKey::try_from(b"abcdefgh\x082345678abcdefgh12345678").unwrap();
-        let child_key = NodeKey::try_from(b"abcdefgh\x0A2345678abcdefgh12345678").unwrap();
+        let parent_key = NodeKey::from(b"abcdefgh\x082345678abcdefgh12345678");
+        let child_key = NodeKey::from(b"abcdefgh\x0A2345678abcdefgh12345678");
         // 0x8 in binary is 00001000
         // 0xA in binary is 00001010
         // matches to 8*8 + 5 places, next is a 0, so is a left child
@@ -167,7 +165,7 @@ mod test {
         );
         // 0xC in binary is 00001100
         // matches to 8*8 + 5 places, next is a 1, so is a right child
-        let child_key = NodeKey::try_from(b"abcdefgh\x0C2345678abcdefgh12345678").unwrap();
+        let child_key = NodeKey::from(b"abcdefgh\x0C2345678abcdefgh12345678");
         assert_eq!(
             traverse_direction(69, &parent_key, &child_key).unwrap(),
             TraverseDirection::Right
@@ -185,7 +183,7 @@ mod test {
 
     #[test]
     fn height_keys() {
-        let key = NodeKey::try_from(b"abcdefgh12345678abcdefgh12345678").unwrap();
+        let key = NodeKey::from(b"abcdefgh12345678abcdefgh12345678");
         let hkey = height_key(&key, 0);
         assert_eq!(hkey.as_slice(), &[0u8; 32]);
         let hkey = height_key(&key, 3);

--- a/base_layer/mmr/src/sparse_merkle_tree/node.rs
+++ b/base_layer/mmr/src/sparse_merkle_tree/node.rs
@@ -660,7 +660,7 @@ mod test {
 
     #[test]
     fn hash_type_from_slice() {
-        let arr = vec![1u8; 32];
+        let arr = [1u8; 32];
         assert!(matches!(NodeKey::try_from(&arr[..3]), Err(SMTError::ArrayTooShort(3))));
         assert!(NodeKey::try_from(&arr[..]).is_ok());
         assert!(matches!(

--- a/base_layer/service_framework/src/context/handles.rs
+++ b/base_layer/service_framework/src/context/handles.rs
@@ -197,7 +197,7 @@ impl ServiceHandles {
         acquire_lock!(self.handles)
             .get(&type_id)
             .and_then(|b| b.downcast_ref::<H>())
-            .map(Clone::clone)
+            .cloned()
     }
 
     /// Returns the shutdown signal for this stack

--- a/base_layer/wallet/src/operation_id.rs
+++ b/base_layer/wallet/src/operation_id.rs
@@ -50,7 +50,7 @@ impl Hash for OperationId {
 
 impl PartialEq for OperationId {
     fn eq(&self, other: &Self) -> bool {
-        self.0.eq(&other.0)
+        self.0 == other.0
     }
 }
 

--- a/base_layer/wallet/src/output_manager_service/storage/models.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/models.rs
@@ -100,7 +100,7 @@ impl PartialEq for DbWalletOutput {
 
 impl PartialOrd<DbWalletOutput> for DbWalletOutput {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.wallet_output.value.partial_cmp(&other.wallet_output.value)
+        Some(self.cmp(other))
     }
 }
 

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_validation_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_validation_protocol.rs
@@ -249,7 +249,7 @@ where
         let mut unmined = vec![];
         #[allow(clippy::mutable_key_type)]
         let mut batch_signatures = HashMap::new();
-        for tx_info in batch.iter() {
+        for tx_info in batch {
             // Imported transactions do not have a signature; this is represented by the default signature in info
             if tx_info.signature != Signature::default() {
                 batch_signatures.insert(tx_info.signature.clone(), tx_info);

--- a/base_layer/wallet/tests/transaction_service_tests/storage.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/storage.rs
@@ -115,8 +115,8 @@ pub async fn test_db_backend<T: TransactionBackend + 'static>(backend: T) {
 
     let stp = builder.build().await.unwrap();
 
-    let messages = vec!["Hey!".to_string(), "Yo!".to_string(), "Sup!".to_string()];
-    let amounts = vec![
+    let messages = ["Hey!".to_string(), "Yo!".to_string(), "Sup!".to_string()];
+    let amounts = [
         MicroMinotari::from(10_000),
         MicroMinotari::from(23_000),
         MicroMinotari::from(5_000),

--- a/base_layer/wallet_ffi/README.md
+++ b/base_layer/wallet_ffi/README.md
@@ -132,8 +132,8 @@ Install [Rust](https://www.rust-lang.org/tools/install)
 
 Install the following tools and system images
 ```Shell Script
-rustup toolchain add nightly-2023-06-04
-rustup default nightly-2023-06-04
+rustup toolchain add nightly-2024-02-01
+rustup default nightly-2024-02-01
 rustup component add rustfmt --toolchain nightly
 rustup component add clippy
 rustup target add x86_64-apple-ios aarch64-apple-ios # iPhone and emulator cross compiling

--- a/base_layer/wallet_ffi/src/callback_handler_tests.rs
+++ b/base_layer/wallet_ffi/src/callback_handler_tests.rs
@@ -514,10 +514,7 @@ mod test {
                 node_id: Some(NodeId::new()),
                 chain_metadata: Some(chain_metadata),
                 is_synced: Some(true),
-                updated: Some(NaiveDateTime::from_timestamp_millis(
-                    ts_now.timestamp_millis() - (60 * 1000),
-                ))
-                .unwrap(),
+                updated: NaiveDateTime::from_timestamp_millis(ts_now.timestamp_millis() - (60 * 1000)),
                 latency: Some(Duration::from_micros(500)),
             })))
             .unwrap();

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -492,7 +492,7 @@ pub unsafe extern "C" fn create_tari_vector(tag: TariTypeTag) -> *mut TariVector
         tag,
         len: v.len(),
         cap: v.capacity(),
-        ptr: v.as_mut_ptr() as *mut c_void,
+        ptr: v.as_mut_ptr(),
     }))
 }
 
@@ -8191,7 +8191,7 @@ pub unsafe extern "C" fn wallet_set_one_sided_payment_message(
 pub unsafe extern "C" fn get_emoji_set() -> *mut EmojiSet {
     let current_emoji_set = emoji_set();
     let mut emoji_set: Vec<ByteVector> = Vec::with_capacity(current_emoji_set.len());
-    for emoji in current_emoji_set.iter() {
+    for emoji in current_emoji_set {
         let mut b = [0; 4]; // emojis are 4 bytes, unicode character
         let emoji_char = ByteVector(emoji.encode_utf8(&mut b).as_bytes().to_vec());
         emoji_set.push(emoji_char);
@@ -10251,7 +10251,7 @@ mod test {
                 .map(|x| CStr::from_ptr(x.commitment).to_str().unwrap().to_owned())
                 .collect::<Vec<String>>();
 
-            let commitments = Box::into_raw(Box::new(TariVector::from(payload))) as *mut TariVector;
+            let commitments = Box::into_raw(Box::new(TariVector::from(payload)));
             let result = wallet_coin_join(alice_wallet, commitments, 5, error_ptr);
             assert_eq!(error, 0);
             assert!(result > 0);
@@ -10389,7 +10389,7 @@ mod test {
                 .map(|x| CStr::from_ptr(x.commitment).to_str().unwrap().to_owned())
                 .collect::<Vec<String>>();
 
-            let commitments = Box::into_raw(Box::new(TariVector::from(payload))) as *mut TariVector;
+            let commitments = Box::into_raw(Box::new(TariVector::from(payload)));
             let preview = wallet_preview_coin_join(alice_wallet, commitments, 5, error_ptr);
             assert_eq!(error, 0);
 
@@ -10413,7 +10413,7 @@ mod test {
                 .map(|x| CStr::from_ptr(x.commitment).to_str().unwrap().to_owned())
                 .collect::<Vec<String>>();
 
-            let commitments = Box::into_raw(Box::new(TariVector::from(payload))) as *mut TariVector;
+            let commitments = Box::into_raw(Box::new(TariVector::from(payload)));
             let result = wallet_coin_join(alice_wallet, commitments, 5, error_ptr);
             assert_eq!(error, 0);
             assert!(result > 0);
@@ -10601,7 +10601,7 @@ mod test {
                 .map(|x| CStr::from_ptr(x.commitment).to_str().unwrap().to_owned())
                 .collect::<Vec<String>>();
 
-            let commitments = Box::into_raw(Box::new(TariVector::from(payload))) as *mut TariVector;
+            let commitments = Box::into_raw(Box::new(TariVector::from(payload)));
 
             let preview = wallet_preview_coin_split(alice_wallet, commitments, 3, 5, error_ptr);
             assert_eq!(error, 0);
@@ -10627,7 +10627,7 @@ mod test {
                 .map(|x| CStr::from_ptr(x.commitment).to_str().unwrap().to_owned())
                 .collect::<Vec<String>>();
 
-            let commitments = Box::into_raw(Box::new(TariVector::from(payload))) as *mut TariVector;
+            let commitments = Box::into_raw(Box::new(TariVector::from(payload)));
 
             let result = wallet_coin_split(alice_wallet, commitments, 3, 5, error_ptr);
             assert_eq!(error, 0);

--- a/buildtools/docker/base_node.Dockerfile
+++ b/buildtools/docker/base_node.Dockerfile
@@ -1,13 +1,13 @@
 # syntax=docker/dockerfile:1
 #FROM rust:1.42.0 as builder
-FROM quay.io/tarilabs/rust_tari-build-with-deps:nightly-2023-06-04 as builder
+FROM quay.io/tarilabs/rust_tari-build-with-deps:nightly-2024-02-01 as builder
 
 # Copy the dependency lists
 #ADD Cargo.toml ./
 ADD . /minotari_node
 WORKDIR /minotari_node
 
-# RUN rustup component add rustfmt --toolchain nightly-2023-06-04-x86_64-unknown-linux-gnu
+# RUN rustup component add rustfmt --toolchain nightly-2024-02-01-x86_64-unknown-linux-gnu
 #ARG TBN_ARCH=native
 ARG TBN_ARCH=x86-64
 #ARG TBN_FEATURES=avx2

--- a/comms/core/src/connection_manager/dialer.rs
+++ b/comms/core/src/connection_manager/dialer.rs
@@ -324,7 +324,7 @@ where
                 "Dial to peer '{}' already pending - adding to wait queue", peer.node_id
             );
             if let Some(reply_tx) = reply_tx {
-                let entry = self.pending_dial_requests.entry(peer.node_id).or_insert_with(Vec::new);
+                let entry = self.pending_dial_requests.entry(peer.node_id).or_default();
                 entry.push(reply_tx);
             }
             return;

--- a/comms/core/src/connectivity/manager.rs
+++ b/comms/core/src/connectivity/manager.rs
@@ -787,11 +787,12 @@ impl ConnectivityManagerActor {
 
         use super::metrics;
 
-        let total = self.pool.count_connected() as i64;
-        let num_inbound = self.pool.count_filtered(|state| match state.connection() {
+        let total = i64::try_from(self.pool.count_connected()).unwrap_or(i64::MAX);
+        let num_inbound = i64::try_from(self.pool.count_filtered(|state| match state.connection() {
             Some(conn) => conn.is_connected() && conn.direction().is_inbound(),
             None => false,
-        }) as i64;
+        }))
+        .unwrap_or(i64::MAX);
 
         metrics::connections(ConnectionDirection::Inbound).set(num_inbound);
         metrics::connections(ConnectionDirection::Outbound).set(total - num_inbound);

--- a/comms/core/src/multiplexing/mod.rs
+++ b/comms/core/src/multiplexing/mod.rs
@@ -26,4 +26,4 @@
 mod metrics;
 
 mod yamux;
-pub use self::yamux::{ConnectionError, Control, IncomingSubstreams, Substream, Yamux};
+pub use self::yamux::{Control, IncomingSubstreams, Substream, Yamux};

--- a/comms/core/src/peer_manager/manager.rs
+++ b/comms/core/src/peer_manager/manager.rs
@@ -79,8 +79,10 @@ impl PeerManager {
         let peer_id = lock.add_peer(peer)?;
         #[cfg(feature = "metrics")]
         {
+            use std::convert::TryFrom;
+
             let count = lock.count();
-            metrics::peer_list_size().set(count as i64);
+            metrics::peer_list_size().set(i64::try_from(count).unwrap_or(i64::MAX));
         }
         Ok(peer_id)
     }
@@ -91,8 +93,10 @@ impl PeerManager {
         lock.delete_peer(node_id)?;
         #[cfg(feature = "metrics")]
         {
+            use std::convert::TryFrom;
+
             let count = lock.count();
-            metrics::peer_list_size().set(count as i64);
+            metrics::peer_list_size().set(i64::try_from(count).unwrap_or(i64::MAX));
         }
         Ok(())
     }
@@ -389,7 +393,7 @@ mod test {
 
         // Create 1 to 4 random addresses
         for _i in 1..=rand::thread_rng().gen_range(1..4) {
-            let n = vec![
+            let n = [
                 rand::thread_rng().gen_range(1..9),
                 rand::thread_rng().gen_range(1..9),
                 rand::thread_rng().gen_range(1..9),

--- a/comms/core/src/peer_manager/migrations.rs
+++ b/comms/core/src/peer_manager/migrations.rs
@@ -31,7 +31,7 @@ pub(super) const MIGRATION_VERSION_KEY: u64 = u64::MAX;
 
 pub fn migrate(database: &LMDBDatabase) -> Result<(), LMDBError> {
     // Add migrations here in version order
-    let migrations = vec![v7::Migration.boxed()];
+    let migrations = [v7::Migration.boxed()];
     if migrations.is_empty() {
         return Ok(());
     }

--- a/comms/core/src/peer_manager/node_distance.rs
+++ b/comms/core/src/peer_manager/node_distance.rs
@@ -205,7 +205,7 @@ mod test {
                 let (_, pk) = CommsPublicKey::random_keypair(&mut OsRng);
                 let b = NodeId::from_public_key(&pk);
                 let dist = NodeDistance::from_node_ids(&a, &b);
-                let i = u32::try_from(dist.get_bucket_index()).unwrap();
+                let i = u32::from(dist.get_bucket_index());
                 let dist = dist.as_u128();
                 assert!(2u128.pow(i) <= dist, "Failed for {}, i = {}", dist, i);
                 assert!(dist < 2u128.pow(i + 1), "Failed for {}, i = {}", dist, i,);

--- a/comms/core/src/peer_manager/node_id.rs
+++ b/comms/core/src/peer_manager/node_id.rs
@@ -173,7 +173,7 @@ impl PartialEq for NodeId {
 
 impl PartialOrd<NodeId> for NodeId {
     fn partial_cmp(&self, other: &NodeId) -> Option<Ordering> {
-        self.0.partial_cmp(&other.0)
+        Some(self.cmp(other))
     }
 }
 

--- a/comms/core/src/protocol/rpc/body.rs
+++ b/comms/core/src/protocol/rpc/body.rs
@@ -165,7 +165,7 @@ impl BodyBytes {
     }
 
     pub fn into_bytes_mut(self) -> BytesMut {
-        self.0.map(|v| v.into_iter().collect()).unwrap_or_else(BytesMut::new)
+        self.0.map(|v| v.into_iter().collect()).unwrap_or_default()
     }
 
     pub fn len(&self) -> usize {
@@ -177,7 +177,7 @@ impl BodyBytes {
     }
 
     pub fn into_vec(self) -> Vec<u8> {
-        self.0.map(|bytes| bytes.into()).unwrap_or_else(Vec::new)
+        self.0.map(|bytes| bytes.into()).unwrap_or_default()
     }
 
     pub fn into_bytes(self) -> Option<Bytes> {
@@ -188,7 +188,7 @@ impl BodyBytes {
 #[allow(clippy::from_over_into)]
 impl Into<Bytes> for BodyBytes {
     fn into(self) -> Bytes {
-        self.0.map(Bytes::from).unwrap_or_else(Bytes::new)
+        self.0.map(Bytes::from).unwrap_or_default()
     }
 }
 

--- a/comms/core/src/protocol/rpc/test/smoke.rs
+++ b/comms/core/src/protocol/rpc/test/smoke.rs
@@ -186,7 +186,7 @@ async fn request_response_errors_and_streaming() {
     let stream = client.streaming_error2().await.unwrap();
     let results = stream.collect::<Vec<_>>().await;
     assert_eq!(results.len(), 2);
-    let first_reply = results.get(0).unwrap().as_ref().unwrap();
+    let first_reply = results.first().unwrap().as_ref().unwrap();
     assert_eq!(first_reply, "This is ok");
 
     let second_reply = results.get(1).unwrap().as_ref().unwrap_err();

--- a/comms/core/src/test_utils/mocks/connection_manager.rs
+++ b/comms/core/src/test_utils/mocks/connection_manager.rs
@@ -139,7 +139,7 @@ impl ConnectionManagerMock {
                     .lock()
                     .await
                     .get(&node_id)
-                    .map(Clone::clone)
+                    .cloned()
                     .ok_or(ConnectionManagerError::DialConnectFailedAllAddresses);
                 let _result = reply_tx.take().map(|tx| tx.send(result));
             },

--- a/comms/core/src/tor/control_client/commands/mod.rs
+++ b/comms/core/src/tor/control_client/commands/mod.rs
@@ -29,7 +29,7 @@ mod protocol_info;
 
 pub use add_onion::{AddOnion, AddOnionFlag, AddOnionResponse};
 pub use del_onion::DelOnion;
-pub use key_value::{get_conf, get_info, set_events, KeyValueCommand};
+pub use key_value::{get_conf, get_info, set_events};
 pub use protocol_info::{ProtocolInfo, ProtocolInfoResponse};
 
 pub trait TorCommand {

--- a/comms/core/src/tor/hidden_service/controller.rs
+++ b/comms/core/src/tor/hidden_service/controller.rs
@@ -365,7 +365,7 @@ impl HiddenServiceController {
             },
         };
 
-        let identity = self.identity.as_ref().map(Clone::clone).expect("already checked");
+        let identity = self.identity.as_ref().cloned().expect("already checked");
         debug!(
             target: LOG_TARGET,
             "Added hidden service with service id '{}' on port '{}'", identity.service_id, identity.onion_port

--- a/comms/dht/examples/memory_net/utilities.rs
+++ b/comms/dht/examples/memory_net/utilities.rs
@@ -306,7 +306,6 @@ pub async fn do_network_wide_propagation(nodes: &mut [TestNode], origin_node_ind
             let mut connectivity = node.comms.connectivity();
             let mut ims_rx = node.ims_rx.take().unwrap();
             let start = Instant::now();
-            let start_global = start_global;
             let node_name = node.name.clone();
 
             task::spawn(async move {

--- a/comms/dht/src/actor.rs
+++ b/comms/dht/src/actor.rs
@@ -336,7 +336,7 @@ impl DhtActor {
             "DhtActor started. {}",
             offline_ts
                 .map(|dt| format!("Dht has been offline since '{}'", dt))
-                .unwrap_or_else(String::new)
+                .unwrap_or_default()
         );
 
         let mut pending_jobs = FuturesUnordered::new();

--- a/comms/dht/src/connectivity/mod.rs
+++ b/comms/dht/src/connectivity/mod.rs
@@ -253,7 +253,7 @@ impl DhtConnectivity {
                         .high_failure_rate_cooldown
                         .saturating_sub(ts.elapsed())
                 ))
-                .unwrap_or_else(String::new),
+                .unwrap_or_default(),
             self.neighbours.len(),
             self.config.num_neighbouring_nodes,
             neighbour_connected.len(),

--- a/comms/dht/src/dedup/dedup_cache.rs
+++ b/comms/dht/src/dedup/dedup_cache.rs
@@ -20,6 +20,8 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use std::convert::TryFrom;
+
 use chrono::{NaiveDateTime, Utc};
 use diesel::{dsl, result::DatabaseErrorKind, sql_types, ExpressionMethods, OptionalExtension, QueryDsl, RunQueryDsl};
 use log::*;
@@ -85,7 +87,7 @@ impl DedupCacheDatabase {
 
     /// Trims the dedup cache to the configured limit by removing the oldest entries
     pub fn trim_entries(&self) -> Result<usize, StorageError> {
-        let capacity = self.capacity as i64;
+        let capacity = i64::try_from(self.capacity).unwrap_or(i64::MAX);
         let mut num_removed = 0;
         let mut conn = self.connection.get_pooled_connection()?;
         let msg_count = dedup_cache::table

--- a/comms/dht/src/envelope.rs
+++ b/comms/dht/src/envelope.rs
@@ -251,7 +251,7 @@ impl From<DhtMessageHeader> for DhtHeader {
                 .ephemeral_public_key
                 .as_ref()
                 .map(ByteArray::to_vec)
-                .unwrap_or_else(Vec::new),
+                .unwrap_or_default(),
             message_signature: header.message_signature,
             destination: Some(header.destination.into()),
             message_type: header.message_type as i32,

--- a/comms/dht/src/network_discovery/state_machine.rs
+++ b/comms/dht/src/network_discovery/state_machine.rs
@@ -299,6 +299,7 @@ pub struct DiscoveryParams {
 }
 
 impl Display for DiscoveryParams {
+    #[allow(clippy::format_collect)]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,

--- a/comms/dht/src/outbound/broadcast.rs
+++ b/comms/dht/src/outbound/broadcast.rs
@@ -431,7 +431,7 @@ where S: Service<DhtOutboundMessage, Response = (), Error = PipelineError>
         // Construct a DhtOutboundMessage for each recipient
         let messages = selected_peers.into_iter().map(|node_id| {
             let (reply_tx, reply_rx) = oneshot::channel();
-            let tag = tag.unwrap_or_else(MessageTag::new);
+            let tag = tag.unwrap_or_default();
             let send_state = MessageSendState::new(tag, reply_rx);
             (
                 DhtOutboundMessage {

--- a/comms/dht/src/storage/mod.rs
+++ b/comms/dht/src/storage/mod.rs
@@ -29,7 +29,7 @@ mod error;
 pub use error::StorageError;
 
 mod dht_setting_entry;
-pub use dht_setting_entry::{DhtMetadataEntry, DhtMetadataKey};
+pub use dht_setting_entry::DhtMetadataKey;
 
 mod database;
 pub use database::DhtDatabase;

--- a/comms/dht/src/store_forward/service.rs
+++ b/comms/dht/src/store_forward/service.rs
@@ -487,8 +487,8 @@ impl StoreAndForwardService {
         use SafResponseType::{Anonymous, Discovery, ForMe, Join};
         let limit = query
             .limit
-            .and_then(|v| i64::try_from(v).ok())
-            .unwrap_or(self.config.max_returned_messages as i64);
+            .map(i64::from)
+            .unwrap_or(i64::try_from(self.config.max_returned_messages).unwrap_or(i64::MAX));
         let db = &self.database;
         let messages = match query.response_type {
             ForMe => db.find_messages_for_peer(&query.public_key, &query.node_id, query.since, limit)?,

--- a/comms/dht/src/test_utils/dht_actor_mock.rs
+++ b/comms/dht/src/test_utils/dht_actor_mock.rs
@@ -72,7 +72,7 @@ impl DhtMockState {
     }
 
     pub fn get_setting(&self, key: DhtMetadataKey) -> Option<Vec<u8>> {
-        self.settings.read().unwrap().get(&key.to_string()).map(Clone::clone)
+        self.settings.read().unwrap().get(&key.to_string()).cloned()
     }
 }
 
@@ -124,13 +124,7 @@ impl DhtActorMock {
                     .unwrap();
             },
             GetMetadata(key, reply_tx) => {
-                let _result = reply_tx.send(Ok(self
-                    .state
-                    .settings
-                    .read()
-                    .unwrap()
-                    .get(&key.to_string())
-                    .map(Clone::clone)));
+                let _result = reply_tx.send(Ok(self.state.settings.read().unwrap().get(&key.to_string()).cloned()));
             },
             SetMetadata(key, value, reply_tx) => {
                 self.state.settings.write().unwrap().insert(key.to_string(), value);

--- a/comms/dht/src/test_utils/mod.rs
+++ b/comms/dht/src/test_utils/mod.rs
@@ -54,7 +54,7 @@ mod service;
 pub use service::service_spy;
 
 mod store_and_forward_mock;
-pub use store_and_forward_mock::{create_store_and_forward_mock, StoreAndForwardMockState};
+pub use store_and_forward_mock::create_store_and_forward_mock;
 
 pub fn assert_send_static_service<T, S>(_: &S)
 where

--- a/comms/dht/tests/dht.rs
+++ b/comms/dht/tests/dht.rs
@@ -244,7 +244,7 @@ async fn test_dht_store_forward() {
         .unwrap();
     // Wait for node C to and receive a response from the SAF request
     let event = collect_try_recv!(node_C_msg_events, take = 1, timeout = Duration::from_secs(20));
-    unpack_enum!(MessagingEvent::MessageReceived(_node_id, _msg) = event.get(0).unwrap());
+    unpack_enum!(MessagingEvent::MessageReceived(_node_id, _msg) = event.first().unwrap());
 
     let msg = node_C.next_inbound_message(Duration::from_secs(5)).await.unwrap();
     assert_eq!(
@@ -273,7 +273,7 @@ async fn test_dht_store_forward() {
 
     // Check that Node C emitted the StoreAndForwardMessagesReceived event when it went Online
     let event = collect_try_recv!(node_C_dht_events, take = 1, timeout = Duration::from_secs(20));
-    unpack_enum!(DhtEvent::StoreAndForwardMessagesReceived = event.get(0).unwrap().as_ref());
+    unpack_enum!(DhtEvent::StoreAndForwardMessagesReceived = event.first().unwrap().as_ref());
 
     node_A.shutdown().await;
     node_B.shutdown().await;
@@ -926,7 +926,7 @@ fn count_messages_received(events: &[MessagingEvent], node_ids: &[&NodeId]) -> u
 }
 
 async fn wait_for_connectivity(nodes: &[&TestNode]) {
-    for node in nodes.iter() {
+    for node in nodes {
         node.comms
             .connectivity()
             .wait_for_connectivity(Duration::from_secs(10))

--- a/infrastructure/test_utils/src/futures/mod.rs
+++ b/infrastructure/test_utils/src/futures/mod.rs
@@ -105,7 +105,7 @@ mod test {
     #[should_panic]
     fn panic_context() {
         let mut my_fut = future::poll_fn::<(), _>(|cx: &mut Context<'_>| {
-            cx.waker().clone().wake();
+            cx.waker().wake_by_ref();
             Poll::Pending
         });
         panic_context!(cx);

--- a/integration_tests/src/merge_mining_proxy.rs
+++ b/integration_tests/src/merge_mining_proxy.rs
@@ -112,7 +112,7 @@ impl MergeMiningProxyProcess {
                         ),
                         (
                             "merge_mining_proxy.monerod_url".to_string(),
-                            vec![
+                            [
                                 "http://stagenet.xmr-tw.org:38081",
                                 "http://stagenet.community.xmr.to:38081",
                                 "http://monero-stagenet.exan.tech:38081",

--- a/integration_tests/src/wallet_ffi.rs
+++ b/integration_tests/src/wallet_ffi.rs
@@ -145,8 +145,7 @@ impl WalletFFI {
     }
 
     pub fn get_counters(&self) -> &mut Callbacks {
-        let callback = Callbacks::instance();
-        callback
+        Callbacks::instance()
     }
 
     pub fn start_txo_validation(&self) -> u64 {

--- a/integration_tests/tests/steps/node_steps.rs
+++ b/integration_tests/tests/steps/node_steps.rs
@@ -129,7 +129,7 @@ async fn wait_for_node_have_x_connections(world: &mut TariWorld, node: String, n
 async fn all_nodes_on_same_chain_at_height(world: &mut TariWorld, height: u64) {
     let mut nodes_at_height: IndexMap<&String, (u64, Vec<u8>)> = IndexMap::new();
 
-    for (name, _) in world.base_nodes.iter() {
+    for (name, _) in &world.base_nodes {
         nodes_at_height.insert(name, (0, vec![]));
     }
 
@@ -168,7 +168,7 @@ async fn all_nodes_on_same_chain_at_height(world: &mut TariWorld, height: u64) {
 async fn all_nodes_are_at_height(world: &mut TariWorld, height: u64) {
     let mut nodes_at_height: IndexMap<&String, u64> = IndexMap::new();
 
-    for (name, _) in world.base_nodes.iter() {
+    for (name, _) in &world.base_nodes {
         nodes_at_height.insert(name, 0);
     }
 

--- a/integration_tests/tests/steps/wallet_ffi_steps.rs
+++ b/integration_tests/tests/steps/wallet_ffi_steps.rs
@@ -262,7 +262,7 @@ async fn ffi_check_number_of_outbound_transactions(world: &mut TariWorld, wallet
 #[then(expr = "I wait for ffi wallet {word} to have at least {int} contacts to be {word}")]
 async fn ffi_check_contacts(world: &mut TariWorld, wallet: String, cnt: u64, status: String) {
     assert!(
-        vec!["Online", "Offline", "NeverSeen"].contains(&status.as_str()),
+        ["Online", "Offline", "NeverSeen"].contains(&status.as_str()),
         "Unknown status: {}",
         status
     );
@@ -412,7 +412,7 @@ async fn ffi_detects_transaction(
     status: String,
 ) {
     let ffi_wallet = world.get_ffi_wallet(&wallet).unwrap();
-    assert!(vec![
+    assert!([
         "TRANSACTION_STATUS_BROADCAST",
         "TRANSACTION_STATUS_MINED_UNCONFIRMED",
         "TRANSACTION_STATUS_MINED",

--- a/lints.toml
+++ b/lints.toml
@@ -69,4 +69,8 @@ allow = [
     'clippy::too_many_arguments',
     # `assert!(!foo(bar))` is misread the majority of the time, while `assert_eq!(foo(bar), false)` is crystal clear
     'clippy::bool-assert-comparison',
+    # this seems unnecessary and would just lead to complex refactoring
+    'clippy::blocks_in_conditions',
+    # this can short circuit, which can lead to unexpected behavior
+    'clippy::manual_try_fold'
 ]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -13,4 +13,4 @@
 # - the CI files in .github folder
 # - the Makefile in base_layer/key_manager/Makefile
 [toolchain]
-channel = "nightly-2023-06-04"
+channel = "nightly-2024-02-01"

--- a/scripts/test_in_docker.sh
+++ b/scripts/test_in_docker.sh
@@ -2,8 +2,8 @@
 
 # Run the Tari test suite locally inside a suitable docker container
 
-IMAGE=quay.io/tarilabs/rust_tari-build-with-deps:nightly-2023-06-04
-TOOLCHAIN_VERSION=nightly-2023-06-04
+IMAGE=quay.io/tarilabs/rust_tari-build-with-deps:nightly-2024-02-01
+TOOLCHAIN_VERSION=nightly-2024-02-01
 CONTAINER=tari_test
 
 echo "Deleting old container"


### PR DESCRIPTION
Description
---
Consistent with other repositories in the ecosystem, this PR bumps the nightly toolchain to `nightly-2024-02-01`. It addresses many updated lints.

Motivation and Context
---
Other repositories are pinning their nightly toolchains at `nightly-2024-02-01` due to a curve library [issue](https://github.com/dalek-cryptography/curve25519-dalek/issues/618). It seems like a good time to bump the nightly version here as well.

How Has This Been Tested?
---
Tested via CI.

What process can a PR reviewer use to test or verify this change?
---
Ensure that CI and any other relevant build processes succeed.