### PR TITLE
chore: suppress error

### DIFF
--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb.rs
@@ -82,7 +82,7 @@ where
             })
         },
         err @ Err(lmdb_zero::Error::Code(lmdb_zero::error::MAP_FULL)) => {
-            error!(
+            info!(
                 target: LOG_TARGET, "Could not insert {} bytes with key '{}' into '{}' ({:?})",
                 val_buf.len(), to_hex(key.as_lmdb_bytes()), table_name, err
             );


### PR DESCRIPTION
Description
---
Suppress error in size of lmdb if it gets a db to small error. This makes the user see the following log:
```
18:10 WARN  Check for updates has been called but auto update has been disabled in the config
18:10 WARN  0.0% of this node's 8 connections are using TCPv4. This node requires at least 10.0% of nodes to be TCP nodes.
18:10 v1.0.0-rc.4 nextnet State: Syncing headers: (133e3da09fefeb6a) 30786/39718 (77%) 87.46 blks/s, latency: 11.43ms Tip: 0 (Tue, 12 Dec 2023 16:10:00 +0000) Mempool: 0tx (0g, +/- 0blks) Connections: 8|0 Banned: 0 Messages (last 60s): 23 Rpc: 0/100 RandomX: #0 with flags FLAG_HARD_AES | FLAG_JIT | FLAG_SECURE
18:10 ERROR Could not insert 797 bytes with key '7e76000000000000' into 'headers_db' (Err(Error::Code(-30792, 'MDB_MAP_FULL: Environment mapsize limit reached')))
18:10 v1.0.0-rc.4 nextnet State: Syncing headers: (133e3da09fefeb6a) 31085/39718 (78%) 50.26 blks/s, latency: 19.90ms Tip: 0 (Tue, 12 Dec 2023 16:10:00 +0000) Mempool: 0tx (0g, +/- 0blks) Connections: 8|0 Banned: 0 Messages (last 60s): 22 Rpc: 0/100
18:10 v1.0.0-rc.4 nextnet State: Syncing headers: (133e3da09fefeb6a) 31396/39718 (79%) 54.31 blks/s, latency: 18.41ms Tip: 0 (Tue, 12 Dec 2023 16:10:00 +0000) Mempool: 0tx (0g, +/- 0blks) Connections: 8|0 Banned: 0 Messages (last 60s): 23 Rpc: 0/100
```

There is no actual error. The transaction wrapper correctly handles this and increases the db size and then reapplies the transaction 