### PR TITLE
feat: allow ffi to see lock height

### DIFF
--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -288,6 +288,7 @@ pub struct TariUtxo {
     pub value: u64,
     pub mined_height: u64,
     pub mined_timestamp: u64,
+    pub lock_height: u64,
     pub status: u8,
 }
 
@@ -299,6 +300,7 @@ impl From<DbWalletOutput> for TariUtxo {
                 .into_raw(),
             value: x.wallet_output.value.as_u64(),
             mined_height: x.mined_height.unwrap_or(0),
+            lock_height: x.wallet_output.features.maturity,
             mined_timestamp: x
                 .mined_timestamp
                 .map(|ts| ts.timestamp_millis() as u64)

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -345,6 +345,7 @@ struct TariUtxo {
   uint64_t value;
   uint64_t mined_height;
   uint64_t mined_timestamp;
+  uint64_t lock_height;
   uint8_t status;
 };
 


### PR DESCRIPTION
Description
---
Allows the FFI to see the lockheight of utxos

Motivation and Context
---
This will allow the FFI to not select coinbases that are still time locked. 
