### PR TITLE
chore: use log4rs 1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2883,8 +2883,9 @@ checksum = "a94d21414c1f4a51209ad204c1776a3d0765002c76c6abcb602a6f09f1e881c7"
 
 [[package]]
 name = "log4rs"
-version = "1.2.0"
-source = "git+https://github.com/tari-project/log4rs.git#e1051fd3a1bec9c55d055f60176a96cf11e58505"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0816135ae15bd0391cf284eab37e6e3ee0a6ee63d2ceeb659862bd8d0a984ca6"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2895,11 +2896,13 @@ dependencies = [
  "libc",
  "log",
  "log-mdc",
+ "once_cell",
  "parking_lot 0.12.1",
+ "rand",
  "serde",
  "serde-value",
  "serde_json",
- "serde_yaml 0.8.26",
+ "serde_yaml",
  "thiserror",
  "thread-id",
  "typemap-ors",
@@ -5074,18 +5077,6 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
-dependencies = [
- "indexmap 1.9.3",
- "ryu",
- "serde",
- "yaml-rust",
-]
-
-[[package]]
-name = "serde_yaml"
 version = "0.9.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cc7a1570e38322cfe4154732e5110f887ea57e22b76f4bfd32b5bdd3368666c"
@@ -5601,7 +5592,7 @@ dependencies = [
  "prost-build",
  "serde",
  "serde_json",
- "serde_yaml 0.9.27",
+ "serde_yaml",
  "sha2 0.10.8",
  "structopt",
  "tari_crypto",

--- a/applications/minotari_console_wallet/Cargo.toml
+++ b/applications/minotari_console_wallet/Cargo.toml
@@ -39,7 +39,7 @@ digest = "0.10"
 futures = { version = "^0.3.16", default-features = false, features = [
   "alloc",
 ] }
-log4rs = { git = "https://github.com/tari-project/log4rs.git", default_features = false, features = [
+log4rs = { version = "1.3.0", default_features = false, features = [
   "config_parsing",
   "threshold_filter",
   "yaml_format",

--- a/applications/minotari_miner/Cargo.toml
+++ b/applications/minotari_miner/Cargo.toml
@@ -28,7 +28,7 @@ derivative = "2.2.0"
 futures = "0.3"
 hex = "0.4.2"
 log = { version = "0.4", features = ["std"] }
-log4rs = { git = "https://github.com/tari-project/log4rs.git", default_features = false, features = ["config_parsing", "threshold_filter", "yaml_format", "console_appender", "rolling_file_appender", "compound_policy", "size_trigger", "fixed_window_roller"] }
+log4rs = { version = "1.3.0", default_features = false, features = ["config_parsing", "threshold_filter", "yaml_format", "console_appender", "rolling_file_appender", "compound_policy", "size_trigger", "fixed_window_roller"] }
 native-tls = "0.2"
 num_cpus = "1.13"
 rand = "0.8"

--- a/applications/minotari_node/Cargo.toml
+++ b/applications/minotari_node/Cargo.toml
@@ -38,7 +38,7 @@ futures = { version = "^0.3.16", default-features = false, features = ["alloc"] 
 qrcode = { version = "0.12" }
 log = { version = "0.4.8", features = ["std"] }
 log-mdc = "0.1.0"
-log4rs = { git = "https://github.com/tari-project/log4rs.git", default_features = false, features = ["config_parsing", "threshold_filter", "yaml_format", "console_appender", "rolling_file_appender", "compound_policy", "size_trigger", "fixed_window_roller"] }
+log4rs = { version = "1.3.0", default_features = false, features = ["config_parsing", "threshold_filter", "yaml_format", "console_appender", "rolling_file_appender", "compound_policy", "size_trigger", "fixed_window_roller"] }
 nom = "7.1"
 rustyline = "9.0"
 rustyline-derive = "0.5"

--- a/base_layer/chat_ffi/Cargo.toml
+++ b/base_layer/chat_ffi/Cargo.toml
@@ -19,7 +19,7 @@ tari_utilities = { version = "0.7" }
 libc = "0.2.65"
 libsqlite3-sys = { version = "0.25.1", features = ["bundled"], optional = true }
 log = "0.4.6"
-log4rs = { git = "https://github.com/tari-project/log4rs.git", features = ["console_appender", "file_appender", "yaml_format"] }
+log4rs = { version = "1.3.0", features = ["console_appender", "file_appender", "yaml_format"] }
 thiserror = "1.0.26"
 tokio = "1.23"
 

--- a/base_layer/wallet_ffi/Cargo.toml
+++ b/base_layer/wallet_ffi/Cargo.toml
@@ -26,7 +26,7 @@ chrono = { version = "0.4.19", default-features = false, features = ["serde"] }
 futures =  { version = "^0.3.1", features =["compat", "std"]}
 libc = "0.2.65"
 log = "0.4.6"
-log4rs = { git = "https://github.com/tari-project/log4rs.git", features = ["console_appender", "file_appender", "yaml_format"] }
+log4rs = { version = "1.3.0", features = ["console_appender", "file_appender", "yaml_format"] }
 rand = "0.8"
 thiserror = "1.0.26"
 tokio = "1.23"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -22,7 +22,7 @@ config = { version = "0.13.0", default_features = false, features = ["toml"] }
 dirs-next = "1.0.2"
 git2 = { version = "0.18", default_features = false, optional = true }
 log = "0.4.8"
-log4rs = { git = "https://github.com/tari-project/log4rs.git", default_features = false, features = ["config_parsing", "threshold_filter", "yaml_format"] }
+log4rs = { version = "1.3.0", default_features = false, features = ["config_parsing", "threshold_filter", "yaml_format"] }
 multiaddr = { version = "0.14.0" }
 path-clean = "0.1.0"
 prost-build = { version = "0.11.9", optional = true }


### PR DESCRIPTION
Description
---
Switch to log4rs 1.3

Motivation and Context
---
https://github.com/tari-project/log4rs/pull/1
https://github.com/estk/log4rs/pull/345

It appears that the log4rs commits arent used since the cargo.lock rev was set to commit [`e1051fd3a1bec9c55d055f60176a96cf11e58505`](https://github.com/tari-project/log4rs/commit/e1051fd3a1bec9c55d055f60176a96cf11e58505) https://github.com/tari-project/log4rs/commits/master/#:r3d:-listview-node-:r3e: and the crate was renamed to tari_log4rs. This rename will only break the current build if the cargo.lock is updated. Since no rev or tag is used, current `master` would be used.

@SWvheerden Please verify the changes are in log4rs@1.3 that were required. Just this right? https://github.com/estk/log4rs/blob/c981ca4e2126c5728505c562b34926f9a9fad00b/Cargo.toml#L59

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
