### PR TITLE
fix: wallet clear short term output

### DIFF
--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -171,6 +171,8 @@ where
         let mut base_node_service_event_stream = self.base_node_service.get_event_stream();
 
         debug!(target: LOG_TARGET, "Output Manager Service started");
+        // Outputs marked as shorttermencumbered are not yet stored as transactions in the TMS, so lets clear them
+        self.resources.db.clear_short_term_encumberances()?;
         loop {
             tokio::select! {
                 event = base_node_service_event_stream.recv() => {

--- a/base_layer/wallet/tests/output_manager_service_tests/service.rs
+++ b/base_layer/wallet/tests/output_manager_service_tests/service.rs
@@ -1157,14 +1157,14 @@ async fn sending_transaction_persisted_while_offline() {
     assert_eq!(balance.pending_outgoing_balance, available_balance / 2);
 
     // This simulates an offline wallet with a  queued transaction that has not been sent to the receiving wallet
-    // yet
+    // This should be cleared as the transaction will be dropped.
     drop(oms.output_manager_handle);
     let mut oms = setup_output_manager_service(backend.clone(), true).await;
 
     let balance = oms.output_manager_handle.get_balance().await.unwrap();
-    assert_eq!(balance.available_balance, available_balance / 2);
+    assert_eq!(balance.available_balance, available_balance);
     assert_eq!(balance.time_locked_balance.unwrap(), MicroMinotari::from(0));
-    assert_eq!(balance.pending_outgoing_balance, available_balance / 2);
+    assert_eq!(balance.pending_outgoing_balance, MicroMinotari::from(0));
 
     // Check that is the pending tx is confirmed that the encumberance persists after restart
     let stp = oms
@@ -1193,9 +1193,9 @@ async fn sending_transaction_persisted_while_offline() {
     let mut oms = setup_output_manager_service(backend, true).await;
 
     let balance = oms.output_manager_handle.get_balance().await.unwrap();
-    assert_eq!(balance.available_balance, MicroMinotari::from(0));
+    assert_eq!(balance.available_balance, MicroMinotari::from(10000));
     assert_eq!(balance.time_locked_balance.unwrap(), MicroMinotari::from(0));
-    assert_eq!(balance.pending_outgoing_balance, available_balance);
+    assert_eq!(balance.pending_outgoing_balance, MicroMinotari::from(10000));
 }
 
 #[tokio::test]

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -6309,7 +6309,7 @@ pub unsafe extern "C" fn wallet_verify_message_signature(
 /// # Safety
 /// None
 #[no_mangle]
-pub unsafe extern "C" fn wallet_add_base_node_peer(
+pub unsafe extern "C" fn wallet_set_base_node_peer(
     wallet: *mut TariWallet,
     public_key: *mut TariPublicKey,
     address: *const c_char,

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -11032,7 +11032,7 @@ mod test {
             let base_node_peer_address_ptr =
                 CString::into_raw(CString::new(node_identity.first_public_address().unwrap().to_string()).unwrap())
                     as *const c_char;
-            wallet_add_base_node_peer(
+            wallet_set_base_node_peer(
                 wallet_ptr,
                 base_node_peer_public_key_ptr,
                 base_node_peer_address_ptr,
@@ -11340,7 +11340,7 @@ mod test {
             let bob_peer_address_ptr =
                 CString::into_raw(CString::new(bob_node_identity.first_public_address().unwrap().to_string()).unwrap())
                     as *const c_char;
-            wallet_add_base_node_peer(
+            wallet_set_base_node_peer(
                 alice_wallet_ptr,
                 bob_peer_public_key_ptr,
                 bob_peer_address_ptr,
@@ -11355,7 +11355,7 @@ mod test {
             let alice_peer_address_ptr = CString::into_raw(
                 CString::new(alice_node_identity.first_public_address().unwrap().to_string()).unwrap(),
             ) as *const c_char;
-            wallet_add_base_node_peer(
+            wallet_set_base_node_peer(
                 bob_wallet_ptr,
                 alice_peer_public_key_ptr,
                 alice_peer_address_ptr,

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -2994,7 +2994,7 @@ bool wallet_verify_message_signature(struct TariWallet *wallet,
  * # Safety
  * None
  */
-bool wallet_add_base_node_peer(struct TariWallet *wallet,
+bool wallet_set_base_node_peer(struct TariWallet *wallet,
                                TariPublicKey *public_key,
                                const char *address,
                                int *error_out);

--- a/clients/ffi_client/index.js
+++ b/clients/ffi_client/index.js
@@ -200,7 +200,7 @@ try {
   let publicKey = lib.public_key_create(publicKeyByteVector, err);
 
   console.log("Set base node peer...", publicKeyHex);
-  lib.wallet_add_base_node_peer(
+  lib.wallet_set_base_node_peer(
     wallet,
     publicKey,
     "/onion3/2m2xnylrsqbaozsndkbmfisxxbwh2vgvs6oyfak2qah4snnxykrf7zad:18141",

--- a/clients/ffi_client/lib/index.js
+++ b/clients/ffi_client/lib/index.js
@@ -44,7 +44,7 @@ const libWallet = ffi.Library("./libminotari_wallet_ffi.dylib", {
     transportRef,
     ["string", u8ArrayPtr, u16, "string", "string", errPtr],
   ],
-  wallet_add_base_node_peer: [bool, [walletRef, u8ArrayPtr, "string", errPtr]],
+  wallet_set_base_node_peer: [bool, [walletRef, u8ArrayPtr, "string", errPtr]],
   wallet_create: [
     walletRef,
     [

--- a/clients/ffi_client/recovery.js
+++ b/clients/ffi_client/recovery.js
@@ -186,7 +186,7 @@ try {
   let publicKey = lib.public_key_create(publicKeyByteVector, err);
 
   console.log("Set base node peer...", publicKeyHex);
-  lib.wallet_add_base_node_peer(
+  lib.wallet_set_base_node_peer(
     wallet,
     publicKey,
     "/onion3/2m2xnylrsqbaozsndkbmfisxxbwh2vgvs6oyfak2qah4snnxykrf7zad:18141",

--- a/integration_tests/src/ffi/ffi_import.rs
+++ b/integration_tests/src/ffi/ffi_import.rs
@@ -451,7 +451,7 @@ extern "C" {
         msg: *const c_char,
         error_out: *mut c_int,
     ) -> bool;
-    pub fn wallet_add_base_node_peer(
+    pub fn wallet_set_base_node_peer(
         wallet: *mut TariWallet,
         public_key: *mut TariPublicKey,
         address: *const c_char,

--- a/integration_tests/src/ffi/wallet.rs
+++ b/integration_tests/src/ffi/wallet.rs
@@ -235,14 +235,14 @@ impl Wallet {
         let mut error = 0;
         let success;
         unsafe {
-            success = ffi_import::wallet_add_base_node_peer(
+            success = ffi_import::wallet_set_base_node_peer(
                 self.ptr,
                 base_node.get_ptr(),
                 CString::new(address).unwrap().into_raw(),
                 &mut error,
             );
             if error > 0 {
-                println!("wallet_add_base_node_peer error {}", error);
+                println!("wallet_set_base_node_peer error {}", error);
             }
         }
         success


### PR DESCRIPTION
Description
---
This will clear short term encumbered outputs on startup

Motivation and Context
---
Its possible that the wallet if stopped at the right(wrong) moment it can leave encumbered outputs locked forever. 
This will cause the wallet to reset these outputs on startup, as they should only be encumbered for a short while. They will then be passed on to the validation task to revalidate them.

How Has This Been Tested?
---
manual

