### PR TITLE
feat: limit transaction size

### DIFF
--- a/base_layer/wallet/src/output_manager_service/handle.rs
+++ b/base_layer/wallet/src/output_manager_service/handle.rs
@@ -45,10 +45,7 @@ use tower::Service;
 use crate::output_manager_service::{
     error::OutputManagerError,
     service::{Balance, OutputInfoByTxId},
-    storage::{
-        database::OutputBackendQuery,
-        models::{DbWalletOutput, KnownOneSidedPaymentScript, SpendingPriority},
-    },
+    storage::models::{DbWalletOutput, KnownOneSidedPaymentScript, SpendingPriority},
     UtxoSelectionCriteria,
 };
 
@@ -90,7 +87,6 @@ pub enum OutputManagerRequest {
     CancelTransaction(TxId),
     GetSpentOutputs,
     GetUnspentOutputs,
-    GetOutputsBy(OutputBackendQuery),
     GetInvalidOutputs,
     ValidateUtxos,
     RevalidateTxos,
@@ -152,7 +148,6 @@ impl fmt::Display for OutputManagerRequest {
             CancelTransaction(v) => write!(f, "CancelTransaction ({})", v),
             GetSpentOutputs => write!(f, "GetSpentOutputs"),
             GetUnspentOutputs => write!(f, "GetUnspentOutputs"),
-            GetOutputsBy(q) => write!(f, "GetOutputs({:#?})", q),
             GetInvalidOutputs => write!(f, "GetInvalidOutputs"),
             ValidateUtxos => write!(f, "ValidateUtxos"),
             RevalidateTxos => write!(f, "RevalidateTxos"),

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -306,10 +306,6 @@ where
                 let outputs = self.fetch_unspent_outputs()?;
                 Ok(OutputManagerResponse::UnspentOutputs(outputs))
             },
-            OutputManagerRequest::GetOutputsBy(q) => {
-                let outputs = self.fetch_outputs_by(q)?.into_iter().map(|v| v.into()).collect();
-                Ok(OutputManagerResponse::Outputs(outputs))
-            },
             OutputManagerRequest::ValidateUtxos => {
                 self.validate_outputs().map(OutputManagerResponse::TxoValidationStarted)
             },
@@ -1381,8 +1377,8 @@ where
         Ok(self.resources.db.fetch_all_unspent_outputs()?)
     }
 
-    pub fn fetch_outputs_by(&self, q: OutputBackendQuery) -> Result<Vec<DbWalletOutput>, OutputManagerError> {
-        Ok(self.resources.db.fetch_outputs_by(q)?)
+    pub fn fetch_outputs_by_query(&self, q: OutputBackendQuery) -> Result<Vec<DbWalletOutput>, OutputManagerError> {
+        Ok(self.resources.db.fetch_outputs_by_query(q)?)
     }
 
     pub fn fetch_invalid_outputs(&self) -> Result<Vec<DbWalletOutput>, OutputManagerError> {

--- a/base_layer/wallet/src/output_manager_service/storage/database/backend.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/database/backend.rs
@@ -101,5 +101,5 @@ pub trait OutputManagerBackend: Send + Sync + Clone {
         current_tip_height: Option<u64>,
     ) -> Result<Vec<DbWalletOutput>, OutputManagerStorageError>;
     fn fetch_outputs_by_tx_id(&self, tx_id: TxId) -> Result<Vec<DbWalletOutput>, OutputManagerStorageError>;
-    fn fetch_outputs_by(&self, q: OutputBackendQuery) -> Result<Vec<DbWalletOutput>, OutputManagerStorageError>;
+    fn fetch_outputs_by_query(&self, q: OutputBackendQuery) -> Result<Vec<DbWalletOutput>, OutputManagerStorageError>;
 }

--- a/base_layer/wallet/src/output_manager_service/storage/database/mod.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/database/mod.rs
@@ -434,8 +434,11 @@ where T: OutputManagerBackend + 'static
         Ok(outputs)
     }
 
-    pub fn fetch_outputs_by(&self, q: OutputBackendQuery) -> Result<Vec<DbWalletOutput>, OutputManagerStorageError> {
-        self.db.fetch_outputs_by(q)
+    pub fn fetch_outputs_by_query(
+        &self,
+        q: OutputBackendQuery,
+    ) -> Result<Vec<DbWalletOutput>, OutputManagerStorageError> {
+        self.db.fetch_outputs_by_query(q)
     }
 }
 

--- a/base_layer/wallet/src/output_manager_service/storage/sqlite_db/mod.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/sqlite_db/mod.rs
@@ -1037,9 +1037,9 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
             .collect::<Result<Vec<_>, _>>()
     }
 
-    fn fetch_outputs_by(&self, q: OutputBackendQuery) -> Result<Vec<DbWalletOutput>, OutputManagerStorageError> {
+    fn fetch_outputs_by_query(&self, q: OutputBackendQuery) -> Result<Vec<DbWalletOutput>, OutputManagerStorageError> {
         let mut conn = self.database_connection.get_pooled_connection()?;
-        Ok(OutputSql::fetch_outputs_by(q, &mut conn)?
+        Ok(OutputSql::fetch_outputs_by_query(q, &mut conn)?
             .into_iter()
             .filter_map(|x| {
                 x.to_db_wallet_output()

--- a/base_layer/wallet/src/output_manager_service/storage/sqlite_db/output_sql.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/sqlite_db/output_sql.rs
@@ -120,7 +120,7 @@ impl OutputSql {
 
     /// Retrieves UTXOs by a set of given rules
     #[allow(clippy::cast_sign_loss)]
-    pub fn fetch_outputs_by(
+    pub fn fetch_outputs_by_query(
         q: OutputBackendQuery,
         conn: &mut SqliteConnection,
     ) -> Result<Vec<OutputSql>, OutputManagerStorageError> {

--- a/base_layer/wallet/src/test_utils.rs
+++ b/base_layer/wallet/src/test_utils.rs
@@ -30,6 +30,7 @@ use tempfile::{tempdir, TempDir};
 
 use crate::storage::sqlite_utilities::{
     run_migration_and_create_sqlite_connection,
+    run_migration_and_create_sqlite_memory_connection,
     wallet_db_connection::WalletDbConnection,
 };
 
@@ -56,6 +57,11 @@ pub fn make_wallet_database_connection(path: Option<String>) -> (WalletDbConnect
     let connection =
         run_migration_and_create_sqlite_connection(db_path.to_str().expect("Should be able to make path"), 16).unwrap();
     (connection, temp_dir)
+}
+
+/// A test helper to create a temporary wallet service memory databases
+pub fn make_wallet_database_memory_connection() -> WalletDbConnection {
+    run_migration_and_create_sqlite_memory_connection(16).unwrap()
 }
 
 pub fn create_consensus_rules() -> ConsensusManager {

--- a/base_layer/wallet/src/transaction_service/error.rs
+++ b/base_layer/wallet/src/transaction_service/error.rs
@@ -185,6 +185,12 @@ pub enum TransactionServiceError {
     InvalidKeyId(String),
     #[error("Invalid key manager data: `{0}`")]
     KeyManagerServiceError(#[from] KeyManagerServiceError),
+    #[error("Serialization error: `{0}`")]
+    SerializationError(String),
+    #[error("Transaction exceed maximum byte size. Expected < {expected} but got {got}.")]
+    TransactionTooLarge { got: usize, expected: usize },
+    #[error("Pending Transaction was oversized")]
+    Oversized,
 }
 
 impl From<RangeProofError> for TransactionServiceError {

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_broadcast_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_broadcast_protocol.rs
@@ -47,6 +47,7 @@ use crate::{
     transaction_service::{
         error::{TransactionServiceError, TransactionServiceProtocolError},
         handle::TransactionEvent,
+        protocols::check_transaction_size,
         service::TransactionServiceResources,
         storage::{
             database::TransactionBackend,
@@ -126,6 +127,10 @@ where
                     "Transaction (TxId: {}) no longer in Completed state and will stop being broadcast", self.tx_id
                 );
                 return Ok(self.tx_id);
+            }
+            if let Err(e) = check_transaction_size(&completed_tx.transaction, self.tx_id) {
+                self.cancel_transaction(TxCancellationReason::Oversized).await;
+                return Err(e);
             }
 
             loop {

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_send_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_send_protocol.rs
@@ -63,6 +63,7 @@ use crate::{
         config::TransactionRoutingMechanism,
         error::{TransactionServiceError, TransactionServiceProtocolError},
         handle::{TransactionEvent, TransactionSendStatus, TransactionServiceResponse},
+        protocols::check_transaction_size,
         service::{TransactionSendResult, TransactionServiceResources},
         storage::{
             database::TransactionBackend,
@@ -281,17 +282,44 @@ where
             ));
         }
 
+        // Calculate the size of the transaction - initial send transaction to the peer (always a small message) should
+        // not be attempted if the final transaction size will be too large to be broadcast
+        let outbound_tx_check = OutboundTransaction::new(
+            tx_id,
+            self.dest_address.clone(),
+            self.amount,
+            MicroMinotari::zero(), // This does not matter for the check
+            sender_protocol.clone(),
+            TransactionStatus::Pending, // This does not matter for the check
+            self.message.clone(),
+            Utc::now().naive_utc(),
+            true, // This does not matter for the check
+        );
+
         // Attempt to send the initial transaction
         let SendResult {
             direct_send_result,
             store_and_forward_send_result,
             transaction_status,
-        } = match self.send_transaction(msg).await {
-            Ok(val) => val,
+        } = match check_transaction_size(&outbound_tx_check, self.id) {
+            Ok(_) => match self.send_transaction(msg).await {
+                Ok(val) => val,
+                Err(e) => {
+                    warn!(
+                        target: LOG_TARGET,
+                        "Problem sending Outbound Transaction TxId: {:?}: {:?}", self.id, e
+                    );
+                    SendResult {
+                        direct_send_result: false,
+                        store_and_forward_send_result: false,
+                        transaction_status: TransactionStatus::Queued,
+                    }
+                },
+            },
             Err(e) => {
-                warn!(
+                info!(
                     target: LOG_TARGET,
-                    "Problem sending Outbound Transaction TxId: {:?}: {:?}", self.id, e
+                    "Initial Transaction TxId: {:?} will not be sent due to it being oversize ({:?})", self.id, e
                 );
                 SendResult {
                     direct_send_result: false,
@@ -333,8 +361,12 @@ where
             );
             self.resources
                 .db
-                .add_pending_outbound_transaction(outbound_tx.tx_id, outbound_tx)
+                .add_pending_outbound_transaction(outbound_tx.tx_id, outbound_tx.clone())
                 .map_err(|e| TransactionServiceProtocolError::new(self.id, TransactionServiceError::from(e)))?;
+            if let Err(e) = check_transaction_size(&outbound_tx, self.id) {
+                self.cancel_oversized_transaction().await?;
+                return Err(e);
+            }
         }
         if transaction_status == TransactionStatus::Pending {
             self.resources
@@ -390,6 +422,12 @@ where
             .db
             .get_pending_outbound_transaction(tx_id)
             .map_err(|e| TransactionServiceProtocolError::new(self.id, TransactionServiceError::from(e)))?;
+
+        // Verify that the negotiated transaction is not too large to be broadcast
+        if let Err(e) = check_transaction_size(&outbound_tx, self.id) {
+            self.cancel_oversized_transaction().await?;
+            return Err(e);
+        }
 
         if !outbound_tx.sender_protocol.is_collecting_single_signature() {
             error!(
@@ -883,6 +921,33 @@ where
             target: LOG_TARGET,
             "Cancelling Transaction Send Protocol (TxId: {}) due to timeout after no counterparty response", self.id
         );
+
+        self.cancel_transaction(TxCancellationReason::Timeout).await?;
+
+        info!(
+            target: LOG_TARGET,
+            "Pending Transaction (TxId: {}) timed out after no response from counterparty", self.id
+        );
+
+        Err(TransactionServiceProtocolError::new(
+            self.id,
+            TransactionServiceError::Timeout,
+        ))
+    }
+
+    async fn cancel_oversized_transaction(&mut self) -> Result<(), TransactionServiceProtocolError<TxId>> {
+        info!(
+            target: LOG_TARGET,
+            "Cancelling Transaction Send Protocol (TxId: {}) due to transaction being oversized", self.id
+        );
+
+        self.cancel_transaction(TxCancellationReason::Oversized).await
+    }
+
+    async fn cancel_transaction(
+        &mut self,
+        cancel_reason: TxCancellationReason,
+    ) -> Result<(), TransactionServiceProtocolError<TxId>> {
         let _ = send_transaction_cancelled_message(
             self.id,
             self.dest_address.public_key().clone(),
@@ -917,10 +982,7 @@ where
         let _size = self
             .resources
             .event_publisher
-            .send(Arc::new(TransactionEvent::TransactionCancelled(
-                self.id,
-                TxCancellationReason::Timeout,
-            )))
+            .send(Arc::new(TransactionEvent::TransactionCancelled(self.id, cancel_reason)))
             .map_err(|e| {
                 trace!(
                     target: LOG_TARGET,
@@ -933,15 +995,7 @@ where
                 )
             });
 
-        info!(
-            target: LOG_TARGET,
-            "Pending Transaction (TxId: {}) timed out after no response from counterparty", self.id
-        );
-
-        Err(TransactionServiceProtocolError::new(
-            self.id,
-            TransactionServiceError::Timeout,
-        ))
+        Ok(())
     }
 }
 

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -107,6 +107,7 @@ use crate::{
             TransactionServiceResponse,
         },
         protocols::{
+            check_transaction_size,
             transaction_broadcast_protocol::TransactionBroadcastProtocol,
             transaction_receive_protocol::{TransactionReceiveProtocol, TransactionReceiveProtocolStage},
             transaction_send_protocol::{TransactionSendProtocol, TransactionSendProtocolStage},
@@ -782,16 +783,19 @@ where
                 let tx_id = match tx {
                     PendingInbound(inbound_tx) => {
                         let tx_id = inbound_tx.tx_id;
+                        check_transaction_size(&inbound_tx, tx_id)?;
                         self.db.insert_pending_inbound_transaction(tx_id, inbound_tx)?;
                         tx_id
                     },
                     PendingOutbound(outbound_tx) => {
                         let tx_id = outbound_tx.tx_id;
+                        check_transaction_size(&outbound_tx, tx_id)?;
                         self.db.insert_pending_outbound_transaction(tx_id, outbound_tx)?;
                         tx_id
                     },
                     Completed(completed_tx) => {
                         let tx_id = completed_tx.tx_id;
+                        check_transaction_size(&completed_tx.transaction, tx_id)?;
                         self.db.insert_completed_transaction(tx_id, completed_tx)?;
                         tx_id
                     },
@@ -822,6 +826,7 @@ where
                 .map(TransactionServiceResponse::UtxoImported),
             TransactionServiceRequest::SubmitTransactionToSelf(tx_id, tx, fee, amount, message) => self
                 .submit_transaction_to_self(transaction_broadcast_join_handles, tx_id, tx, fee, amount, message)
+                .await
                 .map(|_| TransactionServiceResponse::TransactionSubmitted),
             TransactionServiceRequest::SetLowPowerMode => {
                 self.set_power_mode(PowerMode::Low).await?;
@@ -1028,7 +1033,8 @@ where
                     None,
                     None,
                 )?,
-            )?;
+            )
+            .await?;
 
             let _result = reply_channel
                 .send(Ok(TransactionServiceResponse::TransactionSent(tx_id)))
@@ -1277,7 +1283,8 @@ where
                 None,
                 None,
             )?,
-        )?;
+        )
+        .await?;
 
         let tx_output = output
             .to_transaction_output(&self.resources.transaction_key_manager_service)
@@ -1465,7 +1472,8 @@ where
                 None,
                 None,
             )?,
-        )?;
+        )
+        .await?;
 
         Ok(tx_id)
     }
@@ -1726,7 +1734,8 @@ where
                 None,
                 None,
             )?,
-        )?;
+        )
+        .await?;
         info!(target: LOG_TARGET, "Submitted burning transaction - TxId: {}", tx_id);
 
         Ok((tx_id, BurntProof {
@@ -2860,7 +2869,7 @@ where
     }
 
     /// Submit a completed transaction to the Transaction Manager
-    fn submit_transaction(
+    async fn submit_transaction(
         &mut self,
         transaction_broadcast_join_handles: &mut FuturesUnordered<
             JoinHandle<Result<TxId, TransactionServiceProtocolError<TxId>>>,
@@ -2869,12 +2878,17 @@ where
     ) -> Result<(), TransactionServiceError> {
         let tx_id = completed_transaction.tx_id;
         trace!(target: LOG_TARGET, "Submit transaction ({}) to db.", tx_id);
-        self.db.insert_completed_transaction(tx_id, completed_transaction)?;
+        self.db
+            .insert_completed_transaction(tx_id, completed_transaction.clone())?;
         trace!(
             target: LOG_TARGET,
             "Launch the transaction broadcast protocol for submitted transaction ({}).",
             tx_id
         );
+        if let Err(e) = check_transaction_size(&completed_transaction.transaction, tx_id) {
+            self.cancel_transaction(tx_id, TxCancellationReason::Oversized).await;
+            return Err(e.into());
+        }
         self.complete_send_transaction_protocol(
             Ok(TransactionSendResult {
                 tx_id,
@@ -2885,9 +2899,24 @@ where
         Ok(())
     }
 
+    async fn cancel_transaction(&mut self, tx_id: TxId, reason: TxCancellationReason) {
+        if let Err(e) = self.resources.output_manager_service.cancel_transaction(tx_id).await {
+            warn!(
+                target: LOG_TARGET,
+                "Failed to Cancel outputs for TxId: {} after failed sending attempt with error {:?}", tx_id, e
+            );
+        }
+        if let Err(e) = self.resources.db.reject_completed_transaction(tx_id, reason) {
+            warn!(
+                target: LOG_TARGET,
+                "Failed to Cancel TxId: {} after failed sending attempt with error {:?}", tx_id, e
+            );
+        }
+    }
+
     /// Submit a completed coin split transaction to the Transaction Manager. This is different from
     /// `submit_transaction` in that it will expose less information about the completed transaction.
-    pub fn submit_transaction_to_self(
+    pub async fn submit_transaction_to_self(
         &mut self,
         transaction_broadcast_join_handles: &mut FuturesUnordered<
             JoinHandle<Result<TxId, TransactionServiceProtocolError<TxId>>>,
@@ -2914,7 +2943,8 @@ where
                 None,
                 None,
             )?,
-        )?;
+        )
+        .await?;
         Ok(())
     }
 

--- a/base_layer/wallet/src/transaction_service/storage/models.rs
+++ b/base_layer/wallet/src/transaction_service/storage/models.rs
@@ -330,6 +330,7 @@ pub enum TxCancellationReason {
     Orphan,             // 4
     TimeLocked,         // 5
     InvalidTransaction, // 6
+    Oversized,          // 7
 }
 
 impl TryFrom<u32> for TxCancellationReason {
@@ -344,6 +345,7 @@ impl TryFrom<u32> for TxCancellationReason {
             4 => Ok(TxCancellationReason::Orphan),
             5 => Ok(TxCancellationReason::TimeLocked),
             6 => Ok(TxCancellationReason::InvalidTransaction),
+            7 => Ok(TxCancellationReason::Oversized),
             code => Err(TransactionConversionError { code: code as i32 }),
         }
     }
@@ -361,6 +363,7 @@ impl Display for TxCancellationReason {
             Orphan => "Orphan",
             TimeLocked => "TimeLocked",
             InvalidTransaction => "Invalid Transaction",
+            Oversized => "Oversized",
         };
         fmt.write_str(response)
     }

--- a/base_layer/wallet/tests/support/utils.rs
+++ b/base_layer/wallet/tests/support/utils.rs
@@ -52,6 +52,17 @@ pub async fn make_input<R: Rng + CryptoRng>(
         .unwrap()
 }
 
+pub async fn make_fake_input_from_copy(
+    wallet_output: &mut WalletOutput,
+    key_manager: &MemoryDbKeyManager,
+) -> WalletOutput {
+    let (spend_key_id, _spend_key_pk, script_key_id, _script_key_pk) =
+        key_manager.get_next_spend_and_script_key_ids().await.unwrap();
+    wallet_output.spending_key_id = spend_key_id;
+    wallet_output.script_key_id = script_key_id;
+    wallet_output.clone()
+}
+
 pub async fn create_wallet_output_from_sender_data(
     info: &TransactionSenderMessage,
     key_manager: &MemoryDbKeyManager,

--- a/base_layer/wallet/tests/transaction_service_tests/service.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/service.rs
@@ -51,7 +51,7 @@ use minotari_wallet::{
         handle::{OutputManagerEvent, OutputManagerHandle},
         service::OutputManagerService,
         storage::{
-            database::{OutputBackendQuery, OutputManagerBackend, OutputManagerDatabase},
+            database::{OutputManagerBackend, OutputManagerDatabase},
             models::KnownOneSidedPaymentScript,
             sqlite_db::OutputManagerSqliteDatabase,
         },
@@ -845,10 +845,11 @@ async fn large_interactive_transaction() {
 #[allow(clippy::cast_possible_truncation)]
 #[allow(clippy::too_many_lines)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_spend_dust_in_oversized_transactions() {
-    //` cargo test --release --test  wallet_integration_tests transaction_service_tests::service::spend_dust_to_self >
-    //` .\target\output.txt 2>&1
-    env_logger::init(); // Set `$env:RUST_LOG = "trace"`
+async fn test_spend_dust_to_self_in_oversized_transaction() {
+    //` cargo test --release --test  wallet_integration_tests
+    //` transaction_service_tests::service::test_spend_dust_to_self_in_oversized_transaction > .\target\output.txt
+    //` 2>&1
+    // env_logger::init(); // Set `$env:RUST_LOG = "trace"`
 
     let network = Network::LocalNet;
     let consensus_manager = ConsensusManager::builder(network).build().unwrap();
@@ -892,17 +893,15 @@ async fn test_spend_dust_in_oversized_transactions() {
 
     // Alice create dust
 
-    let amount_per_split = 10_000 * uT;
-    let split_count = 499usize;
-    let initial_utxo_value = amount_per_split * (split_count as u64 + 1) + 28_518 * uT;
+    let amount_per_output = 10_000 * uT;
+    // This value was determined by running the test and evaluating the error message,
+    // e.g. `TransactionTooLarge { got: 3379097, expected: 3135488 }`
     let max_number_of_outputs_in_frame = (rpc::RPC_MAX_FRAME_SIZE as f64 / 700.0f64).ceil() as usize;
-    let number_of_splits = (max_number_of_outputs_in_frame as f64 / (split_count + 1) as f64).ceil() as usize;
-    let mut fees = MicroMinotari::zero();
-    let fee_per_gram = MicroMinotari::from(1);
-    for _ in 0..number_of_splits {
+    let number_of_outputs = max_number_of_outputs_in_frame + 100;
+    for _ in 0..number_of_outputs {
         let uo = make_input(
             &mut OsRng,
-            initial_utxo_value,
+            amount_per_output,
             &OutputFeatures::default(),
             &alice_key_manager_handle,
         )
@@ -912,67 +911,16 @@ async fn test_spend_dust_in_oversized_transactions() {
         alice_db
             .mark_output_as_unspent(uo.hash(&alice_key_manager_handle).await.unwrap())
             .unwrap();
-
-        let (tx_id, coin_split_tx, amount) = alice_oms
-            .create_coin_split(vec![], amount_per_split, split_count, fee_per_gram)
-            .await
-            .unwrap();
-        assert_eq!(coin_split_tx.body.inputs().len(), 1);
-        assert_eq!(coin_split_tx.body.outputs().len(), split_count + 1);
-
-        alice_ts
-            .submit_transaction(tx_id, coin_split_tx, amount, "large coin-split".to_string())
-            .await
-            .expect("Alice sending coin-split tx");
-
-        let completed_tx = alice_ts
-            .get_completed_transaction(tx_id)
-            .await
-            .expect("Could not find tx");
-        fees += completed_tx.fee;
-    }
-
-    assert_eq!(
-        alice_oms.get_balance().await.unwrap().pending_incoming_balance,
-        initial_utxo_value * number_of_splits as u64 - fees
-    );
-
-    let all_outputs = alice_db
-        .fetch_outputs_by_query(OutputBackendQuery {
-            tip_height: i64::MAX,
-            status: vec![],
-            commitments: vec![],
-            pagination: None,
-            value_min: None,
-            value_max: None,
-            sorting: vec![],
-        })
-        .unwrap();
-    for output in all_outputs {
-        if output.wallet_output.value <= amount_per_split {
-            alice_db
-                .mark_output_as_unspent(output.wallet_output.hash(&alice_key_manager_handle).await.unwrap())
-                .unwrap();
-        } else {
-            alice_db
-                .mark_output_as_spent(
-                    output.wallet_output.hash(&alice_key_manager_handle).await.unwrap(),
-                    1,
-                    FixedHash::default(),
-                    true,
-                )
-                .unwrap();
-        }
     }
 
     let balance = alice_oms.get_balance().await.unwrap();
-    let initial_available_balance = amount_per_split * number_of_splits as u64 * (split_count as u64 + 1);
-    assert_eq!(balance.available_balance, initial_available_balance);
+    let initial_available_balance = balance.available_balance;
 
     // Alice try to spend too much dust to self
 
+    let fee_per_gram = MicroMinotari::from(1);
     let message = "TAKE MAH _OWN_ MONEYS!".to_string();
-    let value = balance.available_balance - 100_000 * uT;
+    let value = balance.available_balance - amount_per_output * 10;
     let alice_address = TariAddress::new(alice_node_identity.public_key().clone(), network);
     assert!(alice_ts
         .send_transaction(
@@ -988,10 +936,87 @@ async fn test_spend_dust_in_oversized_transactions() {
     let balance = alice_oms.get_balance().await.unwrap();
     // Encumbered outputs are re-instated
     assert_eq!(balance.available_balance, initial_available_balance);
+}
+
+#[allow(clippy::cast_possible_truncation)]
+#[allow(clippy::too_many_lines)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_spend_dust_to_other_in_oversized_transaction() {
+    //` cargo test --release --test  wallet_integration_tests
+    //` transaction_service_tests::service::test_spend_dust_to_other_in_oversized_transaction > .\target\output.txt
+    //` 2>&1
+    // env_logger::init(); // Set `$env:RUST_LOG = "trace"`
+
+    let network = Network::LocalNet;
+    let consensus_manager = ConsensusManager::builder(network).build().unwrap();
+    let factories = CryptoFactories::default();
+    let shutdown = Shutdown::new();
+
+    // Alice's wallet parameters
+    let alice_node_identity = Arc::new(NodeIdentity::random(
+        &mut OsRng,
+        get_next_memory_address(),
+        PeerFeatures::COMMUNICATION_NODE,
+    ));
+
+    let bob_node_identity = Arc::new(NodeIdentity::random(
+        &mut OsRng,
+        get_next_memory_address(),
+        PeerFeatures::COMMUNICATION_NODE,
+    ));
+
+    log::info!(
+        "manage_single_transaction: Alice: '{}', Bob: '{}'",
+        alice_node_identity.node_id().short_str(),
+        bob_node_identity.node_id().short_str(),
+    );
+    let temp_dir = tempdir().unwrap();
+    let database_path = temp_dir.path().to_str().unwrap().to_string();
+    let (alice_connection, _tempdir) = make_wallet_database_connection(Some(database_path.clone()));
+
+    let (mut alice_ts, mut alice_oms, _alice_comms, _alice_connectivity, alice_key_manager_handle, alice_db) =
+        setup_transaction_service(
+            alice_node_identity.clone(),
+            vec![],
+            consensus_manager.clone(),
+            factories.clone(),
+            alice_connection,
+            database_path.clone(),
+            Duration::from_secs(0),
+            shutdown.to_signal(),
+        )
+        .await;
+
+    // Alice create dust
+
+    let amount_per_output = 10_000 * uT;
+    // This value was determined by running the test and evaluating the error message,
+    // e.g. `TransactionTooLarge { got: 3205068, expected: 3135488 }`
+    let max_number_of_outputs_in_frame = (rpc::RPC_MAX_FRAME_SIZE as f64 / 1175.0f64).ceil() as usize;
+    let number_of_outputs = max_number_of_outputs_in_frame + 100;
+    for _ in 0..number_of_outputs {
+        let uo = make_input(
+            &mut OsRng,
+            amount_per_output,
+            &OutputFeatures::default(),
+            &alice_key_manager_handle,
+        )
+        .await;
+
+        alice_oms.add_output(uo.clone(), None).await.unwrap();
+        alice_db
+            .mark_output_as_unspent(uo.hash(&alice_key_manager_handle).await.unwrap())
+            .unwrap();
+    }
+
+    let balance = alice_oms.get_balance().await.unwrap();
+    let initial_available_balance = balance.available_balance;
 
     // Alice try to spend too much dust to Bob
 
+    let fee_per_gram = MicroMinotari::from(1);
     let message = "GIVE MAH _OWN_ MONEYS AWAY!".to_string();
+    let value = balance.available_balance - amount_per_output * 10;
     let bob_address = TariAddress::new(bob_node_identity.public_key().clone(), network);
     let tx_id = alice_ts
         .send_transaction(
@@ -1028,12 +1053,84 @@ async fn test_spend_dust_in_oversized_transactions() {
     }
     // Encumbered outputs are re-instated
     assert_eq!(balance.available_balance, initial_available_balance);
+}
 
-    // Alice try to spend a smaller amount of dust to self [should succeed] (we just need to verify that the
+#[allow(clippy::cast_possible_truncation)]
+#[allow(clippy::too_many_lines)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_spend_dust_happy_path() {
+    //` cargo test --release --test  wallet_integration_tests
+    //` transaction_service_tests::service::test_spend_dust_happy_path > .\target\output.txt 2>&1
+    // env_logger::init(); // Set `$env:RUST_LOG = "trace"`
+
+    let network = Network::LocalNet;
+    let consensus_manager = ConsensusManager::builder(network).build().unwrap();
+    let factories = CryptoFactories::default();
+    let shutdown = Shutdown::new();
+
+    // Alice's wallet parameters
+    let alice_node_identity = Arc::new(NodeIdentity::random(
+        &mut OsRng,
+        get_next_memory_address(),
+        PeerFeatures::COMMUNICATION_NODE,
+    ));
+
+    let bob_node_identity = Arc::new(NodeIdentity::random(
+        &mut OsRng,
+        get_next_memory_address(),
+        PeerFeatures::COMMUNICATION_NODE,
+    ));
+
+    log::info!(
+        "manage_single_transaction: Alice: '{}', Bob: '{}'",
+        alice_node_identity.node_id().short_str(),
+        bob_node_identity.node_id().short_str(),
+    );
+    let temp_dir = tempdir().unwrap();
+    let database_path = temp_dir.path().to_str().unwrap().to_string();
+    let (alice_connection, _tempdir) = make_wallet_database_connection(Some(database_path.clone()));
+
+    let (mut alice_ts, mut alice_oms, _alice_comms, _alice_connectivity, alice_key_manager_handle, alice_db) =
+        setup_transaction_service(
+            alice_node_identity.clone(),
+            vec![],
+            consensus_manager.clone(),
+            factories.clone(),
+            alice_connection,
+            database_path.clone(),
+            Duration::from_secs(0),
+            shutdown.to_signal(),
+        )
+        .await;
+
+    // Alice create dust
+
+    let amount_per_output = 10_000 * uT;
+    let number_of_outputs = 1000;
+    let fee_per_gram = MicroMinotari::from(1);
+    for _ in 0..number_of_outputs {
+        let uo = make_input(
+            &mut OsRng,
+            amount_per_output,
+            &OutputFeatures::default(),
+            &alice_key_manager_handle,
+        )
+        .await;
+
+        alice_oms.add_output(uo.clone(), None).await.unwrap();
+        alice_db
+            .mark_output_as_unspent(uo.hash(&alice_key_manager_handle).await.unwrap())
+            .unwrap();
+    }
+
+    let balance = alice_oms.get_balance().await.unwrap();
+    let initial_available_balance = balance.available_balance;
+
+    // Alice try to spend a fair amount of dust to self [should succeed] (we just need to verify that the
     // transaction is created and that the available balance is correct)
 
     let message = "TAKE MAH _OWN_ MONEYS!".to_string();
-    let value_self = initial_available_balance / 20 - 100_000 * uT;
+    let value_self = (number_of_outputs / 3) * amount_per_output;
     let alice_address = TariAddress::new(alice_node_identity.public_key().clone(), network);
     let tx_id = alice_ts
         .send_transaction(
@@ -1046,6 +1143,7 @@ async fn test_spend_dust_in_oversized_transactions() {
         )
         .await
         .unwrap();
+    let mut count = 0;
     let mut fees_self = loop {
         match alice_ts.get_any_transaction(tx_id).await {
             Ok(None) => tokio::time::sleep(Duration::from_millis(100)).await,
@@ -1065,18 +1163,18 @@ async fn test_spend_dust_in_oversized_transactions() {
             panic!("waited {}ms but could not detect the transaction!", count * 100);
         }
     };
-    fees_self = (fees_self.0 as f64 / amount_per_split.0 as f64).ceil() as u64 * amount_per_split;
+    fees_self = (fees_self.0 as f64 / amount_per_output.0 as f64).ceil() as u64 * amount_per_output;
     let balance = alice_oms.get_balance().await.unwrap();
     assert_eq!(
         balance.available_balance,
         initial_available_balance - value_self - fees_self
     );
 
-    // Alice try to spend a smaller amount of dust to Bob [should succeed] (We do not need Bob to be present,
+    // Alice try to spend a fair amount of dust to Bob [should succeed] (We do not need Bob to be present,
     // we just need to verify that the transaction is created and that the available balance is correct)
 
     let message = "GIVE MAH _OWN_ MONEYS AWAY!".to_string();
-    let value_bob = initial_available_balance / 20 - 100_000 * uT;
+    let value_bob = (number_of_outputs / 3) * amount_per_output;
     let bob_address = TariAddress::new(bob_node_identity.public_key().clone(), network);
     let tx_id = alice_ts
         .send_transaction(
@@ -1111,7 +1209,7 @@ async fn test_spend_dust_in_oversized_transactions() {
             panic!("waited {}ms but could not detect the transaction!", count * 100);
         }
     };
-    fees_bob = (fees_bob.0 as f64 / amount_per_split.0 as f64).ceil() as u64 * amount_per_split;
+    fees_bob = (fees_bob.0 as f64 / amount_per_output.0 as f64).ceil() as u64 * amount_per_output;
     let balance = alice_oms.get_balance().await.unwrap();
     assert_eq!(
         balance.available_balance,

--- a/base_layer/wallet/tests/transaction_service_tests/service.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/service.rs
@@ -915,7 +915,7 @@ async fn test_spend_dust_to_self_in_oversized_transaction() {
 
         alice_oms.add_output(uo.clone(), None).await.unwrap();
         alice_db
-            .mark_output_as_unspent(uo.hash(&alice_key_manager_handle).await.unwrap())
+            .mark_output_as_unspent(uo.hash(&alice_key_manager_handle).await.unwrap(), true)
             .unwrap();
     }
 
@@ -1012,7 +1012,7 @@ async fn test_spend_dust_to_other_in_oversized_transaction() {
 
         alice_oms.add_output(uo.clone(), None).await.unwrap();
         alice_db
-            .mark_output_as_unspent(uo.hash(&alice_key_manager_handle).await.unwrap())
+            .mark_output_as_unspent(uo.hash(&alice_key_manager_handle).await.unwrap(), true)
             .unwrap();
     }
 
@@ -1127,7 +1127,7 @@ async fn test_spend_dust_happy_path() {
 
         alice_oms.add_output(uo.clone(), None).await.unwrap();
         alice_db
-            .mark_output_as_unspent(uo.hash(&alice_key_manager_handle).await.unwrap())
+            .mark_output_as_unspent(uo.hash(&alice_key_manager_handle).await.unwrap(), true)
             .unwrap();
     }
 

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -5739,7 +5739,7 @@ pub unsafe extern "C" fn wallet_get_utxos(
         }],
     };
 
-    match (*wallet).wallet.output_db.fetch_outputs_by(q) {
+    match (*wallet).wallet.output_db.fetch_outputs_by_query(q) {
         Ok(outputs) => {
             ptr::replace(error_ptr, 0);
             Box::into_raw(Box::new(TariVector::from(outputs)))
@@ -5809,7 +5809,7 @@ pub unsafe extern "C" fn wallet_get_all_utxos(wallet: *mut TariWallet, error_ptr
         sorting: vec![],
     };
 
-    match (*wallet).wallet.output_db.fetch_outputs_by(q) {
+    match (*wallet).wallet.output_db.fetch_outputs_by_query(q) {
         Ok(outputs) => {
             ptr::replace(error_ptr, 0);
             Box::into_raw(Box::new(TariVector::from(outputs)))
@@ -10425,7 +10425,7 @@ mod test {
             let unspent_outputs = (*alice_wallet)
                 .wallet
                 .output_db
-                .fetch_outputs_by(OutputBackendQuery {
+                .fetch_outputs_by_query(OutputBackendQuery {
                     status: vec![OutputStatus::Unspent],
                     ..Default::default()
                 })
@@ -10437,7 +10437,7 @@ mod test {
             let new_pending_outputs = (*alice_wallet)
                 .wallet
                 .output_db
-                .fetch_outputs_by(OutputBackendQuery {
+                .fetch_outputs_by_query(OutputBackendQuery {
                     status: vec![OutputStatus::EncumberedToBeReceived],
                     ..Default::default()
                 })
@@ -10641,7 +10641,7 @@ mod test {
             let unspent_outputs = (*alice_wallet)
                 .wallet
                 .output_db
-                .fetch_outputs_by(OutputBackendQuery {
+                .fetch_outputs_by_query(OutputBackendQuery {
                     status: vec![OutputStatus::Unspent],
                     ..Default::default()
                 })
@@ -10653,7 +10653,7 @@ mod test {
             let new_pending_outputs = (*alice_wallet)
                 .wallet
                 .output_db
-                .fetch_outputs_by(OutputBackendQuery {
+                .fetch_outputs_by_query(OutputBackendQuery {
                     status: vec![OutputStatus::EncumberedToBeReceived],
                     ..Default::default()
                 })


### PR DESCRIPTION
Description
---
Added checks to ensure that transactions negotiated between parties, transactions to self and imported transactions do not exceed the RPC frame size limit when the transaction is broadcast to the base node. This can easily happen when lots of dust inputs are collected to be spent. If a too-large transaction is detected in any of the transaction service protocols it will be cancelled so that the user can try to create a new transaction with different parameters, for example, to reduce the recipient amount.

**Edit:**
- Added a wallet sqlite memory type connection to speed up tests with large amounts of db activity
- Used fake outputs without valid bulletproof range proofs in the `spend_dust` tests to speed it up even more as suggested by @SWvheerden 

Motivation and Context
---
See #6108

How Has This Been Tested?
---
Added unit tests:
- `test_spend_dust_to_self_in_oversized_transaction`
- `test_spend_dust_to_other_in_oversized_transaction`
- `test_spend_dust_happy_path`

What process can a PR reviewer use to test or verify this change?
---
Code walk-through
Review unit tests

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
