### PR TITLE
refactor(hashing): move borsh hasher into tari_hashing crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3138,7 +3138,7 @@ dependencies = [
  "tari_core",
  "tari_crypto",
  "tari_features",
- "tari_hash_domains",
+ "tari_hashing",
  "tari_key_manager",
  "tari_libtor",
  "tari_p2p",
@@ -5830,7 +5830,7 @@ dependencies = [
  "tari_comms_dht",
  "tari_comms_rpc_macros",
  "tari_crypto",
- "tari_hash_domains",
+ "tari_hashing",
  "tari_key_manager",
  "tari_metrics",
  "tari_mmr",
@@ -5877,9 +5877,12 @@ name = "tari_features"
 version = "1.0.0-dan.5"
 
 [[package]]
-name = "tari_hash_domains"
+name = "tari_hashing"
 version = "1.0.0-dan.5"
 dependencies = [
+ "blake2",
+ "borsh",
+ "digest 0.10.7",
  "tari_crypto",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ members = [
     "applications/minotari_merge_mining_proxy",
     "applications/minotari_miner",
     "integration_tests",
-    "hash_domains",
+    "hashing",
 ]
 
 # Add here until we move to edition=2021

--- a/applications/minotari_console_wallet/Cargo.toml
+++ b/applications/minotari_console_wallet/Cargo.toml
@@ -23,7 +23,7 @@ tari_utilities = { version = "0.7" }
 minotari_wallet = { path = "../../base_layer/wallet", features = [
   "bundled_sqlite",
 ] }
-tari_hash_domains = { path = "../../hash_domains" }
+tari_hashing = { path = "../../hashing" }
 
 # Uncomment for tokio tracing via tokio-console (needs "tracing" featurs)
 console-subscriber = "0.1.8"

--- a/applications/minotari_console_wallet/src/ui/components/register_template_tab.rs
+++ b/applications/minotari_console_wallet/src/ui/components/register_template_tab.rs
@@ -11,7 +11,7 @@ use regex::Regex;
 use reqwest::StatusCode;
 use tari_core::transactions::{tari_amount::MicroMinotari, transaction_components::TemplateType};
 use tari_crypto::hashing::DomainSeparation;
-use tari_hash_domains::TariEngineHashDomain;
+use tari_hashing::TariEngineHashDomain;
 use tari_utilities::hex::Hex;
 use tokio::{
     runtime::{Handle, Runtime},

--- a/applications/minotari_console_wallet/src/ui/state/tasks.rs
+++ b/applications/minotari_console_wallet/src/ui/state/tasks.rs
@@ -40,10 +40,10 @@ use tari_core::{
     transactions::{
         tari_amount::MicroMinotari,
         transaction_components::{BuildInfo, OutputFeatures, TemplateType},
-        TransactionHashDomain,
     },
 };
 use tari_crypto::{keys::PublicKey as PublicKeyTrait, ristretto::RistrettoPublicKey};
+use tari_hashing::TransactionHashDomain;
 use tari_key_manager::key_manager::KeyManager;
 use tari_utilities::{hex::Hex, ByteArray};
 use tokio::sync::{broadcast, watch};

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -45,7 +45,7 @@ tari_key_manager = { path = "../key_manager", features = [
   "key_manager_service",
 ] }
 tari_common_sqlite = { path = "../../common_sqlite" }
-tari_hash_domains = { path = "../../hash_domains" }
+tari_hashing = { path = "../../hashing" }
 
 async-trait = { version = "0.1.50" }
 bincode = "1.1.4"

--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -40,6 +40,7 @@ use tari_common_types::{
     chain_metadata::ChainMetadata,
     types::{BlockHash, Commitment, FixedHash, HashOutput, PublicKey, Signature},
 };
+use tari_hashing::TransactionHashDomain;
 use tari_mmr::{
     pruned_hashset::PrunedHashSet,
     sparse_merkle_tree::{DeleteResult, NodeKey, ValueHash},
@@ -89,10 +90,7 @@ use crate::{
         DomainSeparatedConsensusHasher,
     },
     proof_of_work::{monero_rx::MoneroPowData, PowAlgorithm, TargetDifficultyWindow},
-    transactions::{
-        transaction_components::{TransactionInput, TransactionKernel, TransactionOutput},
-        TransactionHashDomain,
-    },
+    transactions::transaction_components::{TransactionInput, TransactionKernel, TransactionOutput},
     validation::{
         helpers::calc_median_timestamp,
         CandidateBlockValidator,

--- a/base_layer/core/src/common/mod.rs
+++ b/base_layer/core/src/common/mod.rs
@@ -22,7 +22,7 @@
 
 use blake2::Blake2b;
 use digest::consts::U64;
-use tari_hash_domains::ConfidentialOutputHashDomain;
+use tari_hashing::ConfidentialOutputHashDomain;
 
 use crate::consensus::DomainSeparatedConsensusHasher;
 

--- a/base_layer/core/src/common/one_sided.rs
+++ b/base_layer/core/src/common/one_sided.rs
@@ -31,7 +31,7 @@ use tari_crypto::{
     hashing::{DomainSeparatedHash, DomainSeparatedHasher},
     keys::{PublicKey as PKtrait, SecretKey as SKtrait},
 };
-use tari_hash_domains::WalletOutputEncryptionKeysDomain;
+use tari_hashing::WalletOutputEncryptionKeysDomain;
 use tari_utilities::byte_array::ByteArrayError;
 
 hash_domain!(

--- a/base_layer/core/src/lib.rs
+++ b/base_layer/core/src/lib.rs
@@ -57,7 +57,7 @@ mod domain_hashing {
     use blake2::Blake2b;
     use digest::consts::U32;
     use tari_crypto::{hash_domain, hashing::DomainSeparatedHasher};
-    use tari_hash_domains::ValidatorNodeBmtHashDomain;
+    use tari_hashing::ValidatorNodeBmtHashDomain;
     use tari_mmr::{
         pruned_hashset::PrunedHashSet,
         sparse_merkle_tree::SparseMerkleTree,

--- a/base_layer/core/src/transactions/mod.rs
+++ b/base_layer/core/src/transactions/mod.rs
@@ -6,7 +6,6 @@ pub mod aggregated_body;
 mod crypto_factories;
 
 pub use crypto_factories::CryptoFactories;
-use tari_crypto::hash_domain;
 
 mod coinbase_builder;
 pub use coinbase_builder::{
@@ -33,7 +32,3 @@ pub mod key_manager;
 #[macro_use]
 #[cfg(feature = "base_node")]
 pub mod test_helpers;
-
-// Hash domain for all transaction-related hashes, including the script signature challenge, transaction hash and kernel
-// signature challenge
-hash_domain!(TransactionHashDomain, "com.tari.base_layer.core.transactions", 0);

--- a/base_layer/core/src/transactions/transaction_components/encrypted_data.rs
+++ b/base_layer/core/src/transactions/transaction_components/encrypted_data.rs
@@ -40,7 +40,7 @@ use digest::{consts::U32, generic_array::GenericArray, FixedOutput};
 use serde::{Deserialize, Serialize};
 use tari_common_types::types::{Commitment, PrivateKey};
 use tari_crypto::{hashing::DomainSeparatedHasher, keys::SecretKey};
-use tari_hash_domains::TransactionSecureNonceKdfDomain;
+use tari_hashing::TransactionSecureNonceKdfDomain;
 use tari_utilities::{
     hex::{from_hex, to_hex, Hex, HexError},
     safe_array::SafeArray,

--- a/base_layer/core/src/transactions/transaction_components/mod.rs
+++ b/base_layer/core/src/transactions/transaction_components/mod.rs
@@ -90,8 +90,10 @@ hidden_type!(EncryptedDataKey, SafeArray<u8, AEAD_KEY_LEN>);
 
 //----------------------------------------     Crate functions   ----------------------------------------------------//
 
+use tari_hashing::TransactionHashDomain;
+
 use super::tari_amount::MicroMinotari;
-use crate::{consensus::DomainSeparatedConsensusHasher, covenants::Covenant, transactions::TransactionHashDomain};
+use crate::{consensus::DomainSeparatedConsensusHasher, covenants::Covenant};
 
 /// Implement the canonical hashing function for TransactionOutput and WalletOutput for use in
 /// ordering as well as for the output hash calculation for TransactionInput.

--- a/base_layer/core/src/transactions/transaction_components/side_chain/validator_node_registration.rs
+++ b/base_layer/core/src/transactions/transaction_components/side_chain/validator_node_registration.rs
@@ -29,12 +29,10 @@ use tari_common_types::{
     epoch::VnEpoch,
     types::{FixedHash, PublicKey, Signature},
 };
+use tari_hashing::TransactionHashDomain;
 use tari_utilities::ByteArray;
 
-use crate::{
-    consensus::DomainSeparatedConsensusHasher,
-    transactions::{transaction_components::ValidatorNodeSignature, TransactionHashDomain},
-};
+use crate::{consensus::DomainSeparatedConsensusHasher, transactions::transaction_components::ValidatorNodeSignature};
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Deserialize, Serialize, BorshSerialize, BorshDeserialize)]
 pub struct ValidatorNodeRegistration {
@@ -98,6 +96,7 @@ fn generate_shard_key(public_key: &PublicKey, entropy: &[u8; 32]) -> [u8; 32] {
         .chain(public_key)
         .chain(entropy)
         .finalize()
+        .into()
 }
 
 #[cfg(test)]

--- a/base_layer/core/src/transactions/transaction_components/transaction_input.rs
+++ b/base_layer/core/src/transactions/transaction_components/transaction_input.rs
@@ -35,6 +35,7 @@ use rand::rngs::OsRng;
 use serde::{Deserialize, Serialize};
 use tari_common_types::types::{ComAndPubSignature, Commitment, CommitmentFactory, FixedHash, HashOutput, PublicKey};
 use tari_crypto::tari_utilities::hex::Hex;
+use tari_hashing::TransactionHashDomain;
 use tari_script::{ExecutionStack, ScriptContext, StackItem, TariScript};
 
 use super::{TransactionInputVersion, TransactionOutputVersion};
@@ -50,7 +51,6 @@ use crate::{
             OutputFeatures,
             TransactionError,
         },
-        TransactionHashDomain,
     },
 };
 
@@ -209,6 +209,7 @@ impl TransactionInput {
                     .chain(commitment)
                     .chain(&message)
                     .finalize()
+                    .into()
             },
         }
     }
@@ -227,6 +228,7 @@ impl TransactionInput {
                     .chain(script)
                     .chain(input_data)
                     .finalize()
+                    .into()
             },
         }
     }

--- a/base_layer/core/src/transactions/transaction_components/transaction_kernel.rs
+++ b/base_layer/core/src/transactions/transaction_components/transaction_kernel.rs
@@ -33,6 +33,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use digest::consts::{U32, U64};
 use serde::{Deserialize, Serialize};
 use tari_common_types::types::{Commitment, FixedHash, PublicKey, Signature};
+use tari_hashing::TransactionHashDomain;
 use tari_utilities::{hex::Hex, message_format::MessageFormat};
 
 use super::TransactionKernelVersion;
@@ -42,7 +43,6 @@ use crate::{
         tari_amount::MicroMinotari,
         transaction_components::{KernelFeatures, TransactionError},
         transaction_protocol::TransactionMetadata,
-        TransactionHashDomain,
     },
 };
 
@@ -211,7 +211,7 @@ impl TransactionKernel {
             .chain(total_excess)
             .chain(message);
         match version {
-            TransactionKernelVersion::V0 => common.finalize(),
+            TransactionKernelVersion::V0 => common.finalize().into(),
         }
     }
 
@@ -231,7 +231,7 @@ impl TransactionKernel {
             .chain(features)
             .chain(burn_commitment);
         match version {
-            TransactionKernelVersion::V0 => common.finalize(),
+            TransactionKernelVersion::V0 => common.finalize().into(),
         }
     }
 }

--- a/base_layer/core/src/transactions/transaction_components/transaction_output.rs
+++ b/base_layer/core/src/transactions/transaction_components/transaction_output.rs
@@ -51,6 +51,7 @@ use tari_crypto::{
     ristretto::bulletproofs_plus::RistrettoAggregatedPublicStatement,
     tari_utilities::{hex::Hex, ByteArray},
 };
+use tari_hashing::TransactionHashDomain;
 use tari_script::TariScript;
 
 use super::TransactionOutputVersion;
@@ -70,7 +71,6 @@ use crate::{
             TransactionInput,
             WalletOutput,
         },
-        TransactionHashDomain,
     },
 };
 
@@ -429,7 +429,7 @@ impl TransactionOutput {
             .chain(commitment)
             .chain(&message);
         match version {
-            TransactionOutputVersion::V0 | TransactionOutputVersion::V1 => common.finalize(),
+            TransactionOutputVersion::V0 | TransactionOutputVersion::V1 => common.finalize().into(),
         }
     }
 
@@ -464,7 +464,7 @@ impl TransactionOutput {
             .chain(encrypted_data)
             .chain(minimum_value_promise);
         match version {
-            TransactionOutputVersion::V0 | TransactionOutputVersion::V1 => common.finalize(),
+            TransactionOutputVersion::V0 | TransactionOutputVersion::V1 => common.finalize().into(),
         }
     }
 

--- a/hashing/Cargo.toml
+++ b/hashing/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "tari_hash_domains"
+name = "tari_hashing"
 version = "1.0.0-dan.5"
 edition = "2021"
 
@@ -7,3 +7,8 @@ edition = "2021"
 
 [dependencies]
 tari_crypto = "0.20.0"
+digest = "0.10"
+borsh = "1.2"
+
+[dev-dependencies]
+blake2 = "0.10"

--- a/hashing/src/domains.rs
+++ b/hashing/src/domains.rs
@@ -1,0 +1,30 @@
+// Copyright 2024 The Tari Project
+// SPDX-License-Identifier: BSD-3-Clause
+
+use tari_crypto::hash_domain;
+
+// These are the hash domains that are also used in tari-dan.
+
+hash_domain!(ConfidentialOutputHashDomain, "com.tari.dan.confidential_output", 1);
+hash_domain!(TariEngineHashDomain, "com.tari.dan.engine", 0);
+
+// Hash domain used to derive the final AEAD encryption key for encrypted data in UTXOs
+hash_domain!(
+    TransactionSecureNonceKdfDomain,
+    "com.tari.base_layer.core.transactions.secure_nonce_kdf",
+    0
+);
+hash_domain!(
+    ValidatorNodeBmtHashDomain,
+    "com.tari.base_layer.core.validator_node_mmr",
+    1
+);
+hash_domain!(
+    WalletOutputEncryptionKeysDomain,
+    "com.tari.base_layer.wallet.output_encryption_keys",
+    1
+);
+
+// Hash domain for all transaction-related hashes, including the script signature challenge, transaction hash and kernel
+// signature challenge
+hash_domain!(TransactionHashDomain, "com.tari.base_layer.core.transactions", 0);

--- a/hashing/src/lib.rs
+++ b/hashing/src/lib.rs
@@ -20,26 +20,8 @@
 //   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use tari_crypto::hash_domain;
+mod domains;
+pub use domains::*;
 
-// These are the hash domains that are also used in tari-dan.
-
-hash_domain!(ConfidentialOutputHashDomain, "com.tari.dan.confidential_output", 1);
-hash_domain!(TariEngineHashDomain, "com.tari.dan.engine", 0);
-
-// Hash domain used to derive the final AEAD encryption key for encrypted data in UTXOs
-hash_domain!(
-    TransactionSecureNonceKdfDomain,
-    "com.tari.base_layer.core.transactions.secure_nonce_kdf",
-    0
-);
-hash_domain!(
-    ValidatorNodeBmtHashDomain,
-    "com.tari.base_layer.core.validator_node_mmr",
-    1
-);
-hash_domain!(
-    WalletOutputEncryptionKeysDomain,
-    "com.tari.base_layer.wallet.output_encryption_keys",
-    1
-);
+mod borsh_hasher;
+pub use borsh_hasher::*;


### PR DESCRIPTION
Description
---
Move common hashers and domains required to interact with base layer into common crate

Motivation and Context
---
In L2 we have a a borsh hasher that duplicates the functionality of the consensus hasher in tari_core. 
This crate allows us to use a common hasher implementation without depending on tari_core.

TransactionHashDomain is also used in L1 and L2 so was moved into the common crate.

This could go into the development branch however to reduce churn on that branch I've targeted feature-dan2

How Has This Been Tested?
---
CI

What process can a PR reviewer use to test or verify this change?
---
CI

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
