### PR TITLE
fix: hide unmined coinbase

### DIFF
--- a/applications/minotari_console_wallet/src/ui/components/transactions_tab.rs
+++ b/applications/minotari_console_wallet/src/ui/components/transactions_tab.rs
@@ -595,6 +595,7 @@ impl<B: Backend> Component<B> for TransactionsTab {
                     error!(target: LOG_TARGET, "Error rebroadcasting transactions: {}", e);
                 }
             },
+            'a' => app_state.toggle_abandoned_coinbase_filter(),
             '\n' => match self.selected_tx_list {
                 SelectedTransactionList::None => {},
                 SelectedTransactionList::PendingTxs => {

--- a/applications/minotari_console_wallet/src/ui/state/app_state.rs
+++ b/applications/minotari_console_wallet/src/ui/state/app_state.rs
@@ -565,9 +565,7 @@ impl AppState {
     }
 
     pub fn get_completed_txs(&self) -> Vec<&CompletedTransactionInfo> {
-        if self
-            .completed_tx_filter == TransactionFilter::AbandonedCoinbases
-        {
+        if self.completed_tx_filter == TransactionFilter::AbandonedCoinbases {
             self.cached_data
                 .completed_txs
                 .iter()
@@ -1391,7 +1389,7 @@ impl Default for AppStateConfig {
 }
 
 #[derive(Clone, PartialEq)]
-    pub enum TransactionFilter{
-        None,
-        AbandonedCoinbases,
-    }
+pub enum TransactionFilter {
+    None,
+    AbandonedCoinbases,
+}


### PR DESCRIPTION
Description
---
This reintroduced code to hide unmined coinbase transactions.

Motivation and Context
---
Will show and hide depending on the user preference all coinbases that are reorged out and not in the main chain anymore. 
