### PR TITLE
feat!: implement inflating tail emission

### DIFF
--- a/applications/minotari_app_grpc/proto/types.proto
+++ b/applications/minotari_app_grpc/proto/types.proto
@@ -119,7 +119,7 @@ message ConsensusConstants {
     uint64 median_timestamp_count = 9;
     uint64 emission_initial = 10;
     repeated uint64 emission_decay = 11;
-    uint64 emission_tail = 12;
+    uint64 emission_tail = 12 [deprecated=true];
     uint64 min_sha3x_pow_difficulty = 13;
     uint64 block_weight_inputs = 14;
     uint64 block_weight_outputs = 15;
@@ -141,4 +141,6 @@ message ConsensusConstants {
     uint64 validator_node_registration_min_lock_height = 32;
     uint64 validator_node_registration_shuffle_interval_epoch = 33;
     repeated PermittedRangeProofs permitted_range_proof_types = 34;
+    uint64 inflation_bips = 35;
+    uint64 tail_epoch_length = 36;
 }

--- a/applications/minotari_app_grpc/src/conversions/consensus_constants.rs
+++ b/applications/minotari_app_grpc/src/conversions/consensus_constants.rs
@@ -100,6 +100,7 @@ impl From<ConsensusConstants> for grpc::ConsensusConstants {
 
         let proof_of_work = HashMap::from_iter([(0u32, randomx_pow), (1u32, sha3x_pow)]);
 
+        #[allow(deprecated)]
         Self {
             coinbase_min_maturity: cc.coinbase_min_maturity(),
             blockchain_version: cc.blockchain_version().into(),

--- a/applications/minotari_app_grpc/src/conversions/consensus_constants.rs
+++ b/applications/minotari_app_grpc/src/conversions/consensus_constants.rs
@@ -29,7 +29,7 @@ use crate::tari_rpc as grpc;
 impl From<ConsensusConstants> for grpc::ConsensusConstants {
     #[allow(clippy::too_many_lines)]
     fn from(cc: ConsensusConstants) -> Self {
-        let (emission_initial, emission_decay, emission_tail) = cc.emission_amounts();
+        let (emission_initial, emission_decay, inflation_bips, tail_epoch_length) = cc.emission_amounts();
         let weight_params = cc.transaction_weight_params().params();
         let input_version_range = cc.input_version_range().clone().into_inner();
         let input_version_range = grpc::Range {
@@ -110,7 +110,9 @@ impl From<ConsensusConstants> for grpc::ConsensusConstants {
             median_timestamp_count: u64::try_from(cc.median_timestamp_count()).unwrap_or(0),
             emission_initial: emission_initial.into(),
             emission_decay: emission_decay.to_vec(),
-            emission_tail: emission_tail.into(),
+            emission_tail: 0,
+            inflation_bips,
+            tail_epoch_length,
             min_sha3x_pow_difficulty: cc.min_pow_difficulty(PowAlgorithm::Sha3x).into(),
             block_weight_inputs: weight_params.input_weight,
             block_weight_outputs: weight_params.output_weight,

--- a/base_layer/core/src/consensus/consensus_constants.rs
+++ b/base_layer/core/src/consensus/consensus_constants.rs
@@ -36,7 +36,7 @@ use crate::{
     consensus::network::NetworkConsensus,
     proof_of_work::{Difficulty, PowAlgorithm},
     transactions::{
-        tari_amount::{uT, MicroMinotari, T},
+        tari_amount::{uT, MicroMinotari},
         transaction_components::{
             OutputFeatures,
             OutputFeaturesVersion,
@@ -49,6 +49,8 @@ use crate::{
         weight::TransactionWeight,
     },
 };
+
+const ANNUAL_BLOCKS: u64 = 30 /* blocks/hr */ * 24 /* hr /d */ * 366 /* days / yr */;
 
 /// This is the inner struct used to control all consensus values.
 #[derive(Debug, Clone)]
@@ -77,8 +79,10 @@ pub struct ConsensusConstants {
     /// This is the emission curve decay factor as a sum of fraction powers of two. e.g. [1,2] would be 1/2 + 1/4. [2]
     /// would be 1/4
     pub(in crate::consensus) emission_decay: &'static [u64],
-    /// This is the emission curve tail amount
-    pub(in crate::consensus) emission_tail: MicroMinotari,
+    /// The tail emission inflation rate in basis points (bips). 100 bips = 1 percentage_point
+    pub(in crate::consensus) inflation_bips: u64,
+    /// The length, in blocks of each tail emission epoch (where the reward is held constant)
+    pub(in crate::consensus) tail_epoch_length: u64,
     /// This is the maximum age a Monero merge mined seed can be reused
     /// Monero forces a change every height mod 2048 blocks
     max_randomx_seed_height: u64,
@@ -165,9 +169,14 @@ impl ConsensusConstants {
         self.effective_from_height
     }
 
-    /// This gets the emission curve values as (initial, decay, tail)
-    pub fn emission_amounts(&self) -> (MicroMinotari, &'static [u64], MicroMinotari) {
-        (self.emission_initial, self.emission_decay, self.emission_tail)
+    /// This gets the emission curve values as (initial, decay, inflation_bips, epoch_length)
+    pub fn emission_amounts(&self) -> (MicroMinotari, &'static [u64], u64, u64) {
+        (
+            self.emission_initial,
+            self.emission_decay,
+            self.inflation_bips,
+            self.tail_epoch_length,
+        )
     }
 
     /// The min height maturity a coinbase utxo must have.
@@ -380,7 +389,8 @@ impl ConsensusConstants {
             median_timestamp_count: 11,
             emission_initial: 18_462_816_327 * uT,
             emission_decay: &ESMERALDA_DECAY_PARAMS,
-            emission_tail: 800 * T,
+            inflation_bips: 1000,
+            tail_epoch_length: 100,
             max_randomx_seed_height: u64::MAX,
             max_extra_field_size: 200,
             proof_of_work: algos,
@@ -443,7 +453,8 @@ impl ConsensusConstants {
             median_timestamp_count: 11,
             emission_initial: 5_538_846_115 * uT,
             emission_decay: &EMISSION_DECAY,
-            emission_tail: 100.into(),
+            inflation_bips: 100,
+            tail_epoch_length: ANNUAL_BLOCKS,
             max_randomx_seed_height: u64::MAX,
             max_extra_field_size: 200,
             proof_of_work: algos,
@@ -499,7 +510,8 @@ impl ConsensusConstants {
             median_timestamp_count: 11,
             emission_initial: ESMERALDA_INITIAL_EMISSION,
             emission_decay: &ESMERALDA_DECAY_PARAMS,
-            emission_tail: 800 * T,
+            inflation_bips: 100,
+            tail_epoch_length: ANNUAL_BLOCKS,
             max_randomx_seed_height: 3000,
             max_extra_field_size: 200,
             proof_of_work: algos,
@@ -554,7 +566,8 @@ impl ConsensusConstants {
             median_timestamp_count: 11,
             emission_initial: INITIAL_EMISSION,
             emission_decay: &EMISSION_DECAY,
-            emission_tail: 800 * T,
+            inflation_bips: 100,
+            tail_epoch_length: ANNUAL_BLOCKS,
             max_randomx_seed_height: 3000,
             max_extra_field_size: 200,
             proof_of_work: algos,
@@ -603,7 +616,8 @@ impl ConsensusConstants {
             median_timestamp_count: 11,
             emission_initial: INITIAL_EMISSION,
             emission_decay: &EMISSION_DECAY,
-            emission_tail: 800 * T,
+            inflation_bips: 100,
+            tail_epoch_length: ANNUAL_BLOCKS,
             max_randomx_seed_height: 3000,
             max_extra_field_size: 200,
             proof_of_work: algos,
@@ -654,7 +668,8 @@ impl ConsensusConstants {
             median_timestamp_count: 11,
             emission_initial: 10_000_000.into(),
             emission_decay: &EMISSION_DECAY,
-            emission_tail: 100.into(),
+            inflation_bips: 100,
+            tail_epoch_length: ANNUAL_BLOCKS,
             max_randomx_seed_height: u64::MAX,
             max_extra_field_size: 200,
             proof_of_work: algos,
@@ -835,11 +850,13 @@ impl ConsensusConstantsBuilder {
         mut self,
         intial_amount: MicroMinotari,
         decay: &'static [u64],
-        tail_amount: MicroMinotari,
+        inflation_bips: u64,
+        epoch_length: u64,
     ) -> Self {
         self.consensus.emission_initial = intial_amount;
         self.consensus.emission_decay = decay;
-        self.consensus.emission_tail = tail_amount;
+        self.consensus.inflation_bips = inflation_bips;
+        self.consensus.tail_epoch_length = epoch_length;
         self
     }
 
@@ -868,15 +885,13 @@ impl ConsensusConstantsBuilder {
 
 #[cfg(test)]
 mod test {
-    use std::convert::TryFrom;
-
     use crate::{
         consensus::{
             emission::{Emission, EmissionSchedule},
             ConsensusConstants,
         },
         transactions::{
-            tari_amount::{uT, MicroMinotari},
+            tari_amount::{uT, MicroMinotari, T},
             transaction_components::{OutputType, RangeProofType},
         },
     };
@@ -940,33 +955,41 @@ mod test {
         let schedule = EmissionSchedule::new(
             esmeralda[0].emission_initial,
             esmeralda[0].emission_decay,
-            esmeralda[0].emission_tail,
+            esmeralda[0].inflation_bips,
+            esmeralda[0].tail_epoch_length,
+            esmeralda[0].faucet_value(),
         );
         // No genesis block coinbase
         assert_eq!(schedule.block_reward(0), MicroMinotari(0));
         // Coinbases starts at block 1
         let coinbase_offset = 1;
         let first_reward = schedule.block_reward(coinbase_offset);
-        assert_eq!(first_reward, esmeralda[0].emission_initial * uT);
-        assert_eq!(schedule.supply_at_block(coinbase_offset), first_reward);
+        assert_eq!(first_reward, esmeralda[0].emission_initial);
+        assert_eq!(
+            schedule.supply_at_block(coinbase_offset),
+            first_reward + esmeralda[0].faucet_value()
+        );
         // 'half_life_block' at approximately '(total supply - faucet value) / 2'
         #[allow(clippy::cast_possible_truncation)]
-        let half_life_block = (365.0 * 24.0 * 30.0 * 2.76) as u64;
+        let half_life_block = 365 * 24 * 30 * 3;
         assert_eq!(
             schedule.supply_at_block(half_life_block + coinbase_offset),
-            7_483_280_506_356_578 * uT
+            7_935_818_494_624_306 * uT + esmeralda[0].faucet_value()
         );
-        // Tail emission starts after block 3,255,552 + coinbase_offset
-        let mut rewards = schedule
-            .iter()
-            .skip(3255552 + usize::try_from(coinbase_offset).unwrap());
+        // 21 billion
+        let mut rewards = schedule.iter().skip(3255552 + coinbase_offset as usize);
         let (block_num, reward, supply) = rewards.next().unwrap();
         assert_eq!(block_num, 3255553 + coinbase_offset);
         assert_eq!(reward, 800_000_415 * uT);
-        let total_supply_up_to_tail_emission = supply + esmeralda[0].faucet_value;
-        assert_eq!(total_supply_up_to_tail_emission, 20_999_999_999_819_869 * uT);
+        assert_eq!(supply, 20_999_999_999_819_869 * uT);
         let (_, reward, _) = rewards.next().unwrap();
-        assert_eq!(reward, esmeralda[0].emission_tail);
+        assert_eq!(reward, 799_999_715 * uT);
+        // Inflating tail emission
+        let mut rewards = schedule.iter().skip(3259845);
+        let (block_num, reward, supply) = rewards.next().unwrap();
+        assert_eq!(block_num, 3259846);
+        assert_eq!(reward, 797 * T);
+        assert_eq!(supply, 21_003_427_156_818_122 * uT);
     }
 
     #[test]
@@ -975,7 +998,9 @@ mod test {
         let schedule = EmissionSchedule::new(
             nextnet[0].emission_initial,
             nextnet[0].emission_decay,
-            nextnet[0].emission_tail,
+            nextnet[0].inflation_bips,
+            nextnet[0].tail_epoch_length,
+            nextnet[0].faucet_value(),
         );
         // No genesis block coinbase
         assert_eq!(schedule.block_reward(0), MicroMinotari(0));
@@ -983,25 +1008,23 @@ mod test {
         let coinbase_offset = 1;
         let first_reward = schedule.block_reward(coinbase_offset);
         assert_eq!(first_reward, nextnet[0].emission_initial * uT);
-        assert_eq!(schedule.supply_at_block(coinbase_offset), first_reward);
+        assert_eq!(
+            schedule.supply_at_block(coinbase_offset),
+            first_reward + nextnet[0].faucet_value()
+        );
         // 'half_life_block' at approximately '(total supply - faucet value) / 2'
         #[allow(clippy::cast_possible_truncation)]
         let half_life_block = (365.0 * 24.0 * 30.0 * 2.76) as u64;
         assert_eq!(
             schedule.supply_at_block(half_life_block + coinbase_offset),
-            7_483_280_506_356_578 * uT
+            7_483_280_506_356_578 * uT + nextnet[0].faucet_value()
         );
-        // Tail emission starts after block 3,255,552 + coinbase_offset
-        let mut rewards = schedule
-            .iter()
-            .skip(3255552 + usize::try_from(coinbase_offset).unwrap());
+        // Tail emission
+        let mut rewards = schedule.iter().skip(3259845);
         let (block_num, reward, supply) = rewards.next().unwrap();
-        assert_eq!(block_num, 3255553 + coinbase_offset);
-        assert_eq!(reward, 800_000_415 * uT);
-        let total_supply_up_to_tail_emission = supply + nextnet[0].faucet_value;
-        assert_eq!(total_supply_up_to_tail_emission, 20_999_999_999_819_869 * uT);
-        let (_, reward, _) = rewards.next().unwrap();
-        assert_eq!(reward, nextnet[0].emission_tail);
+        assert_eq!(block_num, 3259846);
+        assert_eq!(reward, 797 * T);
+        assert_eq!(supply, 21_003_427_156_818_122 * uT);
     }
 
     #[test]
@@ -1010,7 +1033,9 @@ mod test {
         let schedule = EmissionSchedule::new(
             stagenet[0].emission_initial,
             stagenet[0].emission_decay,
-            stagenet[0].emission_tail,
+            stagenet[0].inflation_bips,
+            stagenet[0].tail_epoch_length,
+            stagenet[0].faucet_value(),
         );
         // No genesis block coinbase
         assert_eq!(schedule.block_reward(0), MicroMinotari(0));
@@ -1018,31 +1043,35 @@ mod test {
         let coinbase_offset = 1;
         let first_reward = schedule.block_reward(coinbase_offset);
         assert_eq!(first_reward, stagenet[0].emission_initial * uT);
-        assert_eq!(schedule.supply_at_block(coinbase_offset), first_reward);
+        assert_eq!(
+            schedule.supply_at_block(coinbase_offset),
+            first_reward + stagenet[0].faucet_value()
+        );
         // 'half_life_block' at approximately '(total supply - faucet value) / 2'
         #[allow(clippy::cast_possible_truncation)]
         let half_life_block = (365.0 * 24.0 * 30.0 * 2.76) as u64;
         assert_eq!(
             schedule.supply_at_block(half_life_block + coinbase_offset),
-            7_483_280_506_356_578 * uT
+            7_483_280_506_356_578 * uT + stagenet[0].faucet_value()
         );
-        // Tail emission starts after block 3,255,552 + coinbase_offset
-        let mut rewards = schedule
-            .iter()
-            .skip(3255552 + usize::try_from(coinbase_offset).unwrap());
+        // Tail emission
+        let mut rewards = schedule.iter().skip(3259845);
         let (block_num, reward, supply) = rewards.next().unwrap();
-        assert_eq!(block_num, 3255553 + coinbase_offset);
-        assert_eq!(reward, 800_000_415 * uT);
-        let total_supply_up_to_tail_emission = supply + stagenet[0].faucet_value;
-        assert_eq!(total_supply_up_to_tail_emission, 20_999_999_999_819_869 * uT);
-        let (_, reward, _) = rewards.next().unwrap();
-        assert_eq!(reward, stagenet[0].emission_tail);
+        assert_eq!(block_num, 3259846);
+        assert_eq!(reward, 797 * T);
+        assert_eq!(supply, 21_003_427_156_818_122 * uT);
     }
 
     #[test]
     fn igor_schedule() {
         let igor = ConsensusConstants::igor();
-        let schedule = EmissionSchedule::new(igor[0].emission_initial, igor[0].emission_decay, igor[0].emission_tail);
+        let schedule = EmissionSchedule::new(
+            igor[0].emission_initial,
+            igor[0].emission_decay,
+            igor[0].inflation_bips,
+            igor[0].tail_epoch_length,
+            igor[0].faucet_value(),
+        );
         // No genesis block coinbase
         assert_eq!(schedule.block_reward(0), MicroMinotari(0));
         // Coinbases starts at block 1
@@ -1055,11 +1084,9 @@ mod test {
         let mut previous_reward = MicroMinotari(0);
         for (block_num, reward, supply) in rewards {
             if reward == previous_reward {
-                assert_eq!(block_num, 11_084_819 + 1);
-                assert_eq!(supply, MicroMinotari(6_326_198_792_915_738));
-                // These set of constants does not result in a tail emission equal to the specified tail emission
-                assert_ne!(reward, igor[0].emission_tail);
-                assert_eq!(reward, MicroMinotari(2_097_151));
+                assert_eq!(block_num, 11_084_796);
+                assert_eq!(supply, MicroMinotari(8_010_884_615_082_026));
+                assert_eq!(reward, MicroMinotari(303_000_000));
                 break;
             }
             previous_reward = reward;

--- a/base_layer/core/src/consensus/consensus_constants.rs
+++ b/base_layer/core/src/consensus/consensus_constants.rs
@@ -885,6 +885,8 @@ impl ConsensusConstantsBuilder {
 
 #[cfg(test)]
 mod test {
+    use std::convert::TryFrom;
+
     use crate::{
         consensus::{
             emission::{Emission, EmissionSchedule},
@@ -977,7 +979,9 @@ mod test {
             7_935_818_494_624_306 * uT + esmeralda[0].faucet_value()
         );
         // 21 billion
-        let mut rewards = schedule.iter().skip(3255552 + coinbase_offset as usize);
+        let mut rewards = schedule
+            .iter()
+            .skip(3255552 + usize::try_from(coinbase_offset).unwrap());
         let (block_num, reward, supply) = rewards.next().unwrap();
         assert_eq!(block_num, 3255553 + coinbase_offset);
         assert_eq!(reward, 800_000_415 * uT);

--- a/base_layer/core/src/consensus/consensus_manager.rs
+++ b/base_layer/core/src/consensus/consensus_manager.rs
@@ -82,9 +82,7 @@ impl ConsensusManager {
         }
     }
 
-    /// Get a pointer to the emission schedule
-    /// The height provided here, decides the emission curve to use. It swaps to the integer curve upon reaching
-    /// 1_000_000_000
+    /// Get a reference to the emission parameters
     pub fn emission_schedule(&self) -> &EmissionSchedule {
         &self.inner.emission
     }
@@ -241,8 +239,11 @@ impl ConsensusManagerBuilder {
         let emission = EmissionSchedule::new(
             self.consensus_constants[0].emission_initial,
             self.consensus_constants[0].emission_decay,
-            self.consensus_constants[0].emission_tail,
+            self.consensus_constants[0].inflation_bips,
+            self.consensus_constants[0].tail_epoch_length,
+            self.consensus_constants[0].faucet_value(),
         );
+
         let inner = ConsensusManagerInner {
             consensus_constants: self.consensus_constants,
             network: self.network,

--- a/base_layer/core/src/transactions/tari_amount.rs
+++ b/base_layer/core/src/transactions/tari_amount.rs
@@ -148,6 +148,11 @@ impl MicroMinotari {
         self.0
     }
 
+    #[inline]
+    pub fn as_u128(&self) -> u128 {
+        u128::from(self.0)
+    }
+
     pub fn to_currency_string(&self, sep: char) -> String {
         format!("{} µT", format_currency(&self.as_u64().to_string(), sep))
     }

--- a/base_layer/core/src/validation/chain_balance.rs
+++ b/base_layer/core/src/validation/chain_balance.rs
@@ -92,8 +92,9 @@ impl<B: BlockchainBackend> ChainBalanceValidator<B> {
     }
 
     fn get_emission_commitment_at(&self, height: u64) -> Commitment {
-        let total_supply =
-            self.rules.get_total_emission_at(height) + self.rules.consensus_constants(height).faucet_value();
+        // With inflating tail emission, we **must** know the value of the premine as part of the supply calc in order
+        // to determine the correct inflation curve. Therefore, the premine is already included in the supply
+        let total_supply = self.rules.get_total_emission_at(height);
         debug!(
             target: LOG_TARGET,
             "Expected emission at height {} is {}", height, total_supply

--- a/base_layer/core/tests/helpers/sample_blockchains.rs
+++ b/base_layer/core/tests/helpers/sample_blockchains.rs
@@ -170,6 +170,12 @@ pub async fn create_blockchain_db_no_cut_through() -> (
     (db, blocks, outputs, consensus_manager, key_manager)
 }
 
+pub fn consensus_constants(network: Network) -> ConsensusConstantsBuilder {
+    ConsensusConstantsBuilder::new(network)
+        .with_emission_amounts(100_000_000.into(), &EMISSION, 10, 1000)
+        .with_coinbase_lockheight(1)
+}
+
 /// Create a new blockchain database containing only the Genesis block
 #[allow(dead_code)]
 pub async fn create_new_blockchain(
@@ -182,10 +188,7 @@ pub async fn create_new_blockchain(
     MemoryDbKeyManager,
 ) {
     let key_manager = create_memory_db_key_manager();
-    let consensus_constants = ConsensusConstantsBuilder::new(network)
-        .with_emission_amounts(100_000_000.into(), &EMISSION, 100.into())
-        .with_coinbase_lockheight(1)
-        .build();
+    let consensus_constants = consensus_constants(network).build();
     let (block0, output) = create_genesis_block(&consensus_constants, &key_manager).await;
     let consensus_manager = ConsensusManagerBuilder::new(network)
         .add_consensus_constants(consensus_constants)
@@ -243,10 +246,7 @@ pub async fn create_new_blockchain_lmdb(
     MemoryDbKeyManager,
 ) {
     let key_manager = create_memory_db_key_manager();
-    let consensus_constants = ConsensusConstantsBuilder::new(network)
-        .with_emission_amounts(100_000_000.into(), &EMISSION, 100.into())
-        .with_coinbase_lockheight(1)
-        .build();
+    let consensus_constants = consensus_constants(network).build();
     let (block0, output) = create_genesis_block(&consensus_constants, &key_manager).await;
     let consensus_manager = ConsensusManagerBuilder::new(network)
         .add_consensus_constants(consensus_constants)

--- a/base_layer/core/tests/helpers/sync.rs
+++ b/base_layer/core/tests/helpers/sync.rs
@@ -43,7 +43,7 @@ use tari_core::{
     },
     blocks::ChainBlock,
     chain_storage::{BlockchainDatabaseConfig, DbTransaction},
-    consensus::{ConsensusConstantsBuilder, ConsensusManager, ConsensusManagerBuilder},
+    consensus::{ConsensusManager, ConsensusManagerBuilder},
     mempool::MempoolServiceConfig,
     proof_of_work::{randomx_factory::RandomXFactory, Difficulty},
     test_helpers::blockchain::TempDatabase,
@@ -64,9 +64,8 @@ use tokio::sync::{broadcast, watch};
 use crate::helpers::{
     block_builders::{append_block, create_genesis_block},
     nodes::{create_network_with_multiple_base_nodes_with_config, NodeInterfaces},
+    sample_blockchains,
 };
-
-static EMISSION: [u64; 2] = [10, 10];
 
 /// Helper function to initialize header sync with a single peer
 pub fn initialize_sync_headers_with_ping_pong_data(
@@ -152,9 +151,7 @@ pub async fn create_network_with_multiple_nodes(
     let network = Network::LocalNet;
     let temp_dir = tempdir().unwrap();
     let key_manager = create_memory_db_key_manager();
-    let consensus_constants = ConsensusConstantsBuilder::new(network)
-        .with_emission_amounts(100_000_000.into(), &EMISSION, 100.into())
-        .build();
+    let consensus_constants = sample_blockchains::consensus_constants(network).build();
     let (initial_block, coinbase_wallet_output) = create_genesis_block(&consensus_constants, &key_manager).await;
     let consensus_manager = ConsensusManagerBuilder::new(network)
         .add_consensus_constants(consensus_constants)

--- a/base_layer/core/tests/tests/mempool.rs
+++ b/base_layer/core/tests/tests/mempool.rs
@@ -1036,16 +1036,14 @@ async fn test_reorg() {
     mempool.process_reorg(vec![], vec![reorg_block4.into()]).await.unwrap();
 }
 
-static EMISSION: [u64; 2] = [10, 10];
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 #[allow(clippy::too_many_lines)]
 #[allow(clippy::identity_op)]
 async fn receive_and_propagate_transaction() {
     let temp_dir = tempdir().unwrap();
     let network = Network::LocalNet;
-    let consensus_constants = ConsensusConstantsBuilder::new(network)
+    let consensus_constants = crate::helpers::sample_blockchains::consensus_constants(network)
         .with_coinbase_lockheight(100)
-        .with_emission_amounts(100_000_000.into(), &EMISSION, 100.into())
         .build();
     let key_manager = create_memory_db_key_manager();
     let (block0, utxo) = create_genesis_block(&consensus_constants, &key_manager).await;
@@ -1171,10 +1169,8 @@ async fn receive_and_propagate_transaction() {
 #[allow(clippy::too_many_lines)]
 async fn consensus_validation_large_tx() {
     let network = Network::LocalNet;
-    // We dont want to compute the 19500 limit of local net, so we create smaller blocks
-    let consensus_constants = ConsensusConstantsBuilder::new(network)
-        .with_emission_amounts(100_000_000.into(), &EMISSION, 100.into())
-        .with_coinbase_lockheight(1)
+    // We don't want to compute the 19500 limit of local net, so we create smaller blocks
+    let consensus_constants = crate::helpers::sample_blockchains::consensus_constants(network)
         .with_max_block_transaction_weight(500)
         .build();
     let (mut store, mut blocks, mut outputs, consensus_manager, key_manager) =
@@ -1357,9 +1353,7 @@ async fn consensus_validation_large_tx() {
 async fn validation_reject_min_fee() {
     let network = Network::LocalNet;
     // We dont want to compute the 19500 limit of local net, so we create smaller blocks
-    let consensus_constants = ConsensusConstantsBuilder::new(network)
-        .with_emission_amounts(100_000_000.into(), &EMISSION, 100.into())
-        .with_coinbase_lockheight(1)
+    let consensus_constants = crate::helpers::sample_blockchains::consensus_constants(network)
         .with_max_block_transaction_weight(500)
         .build();
     let (mut store, mut blocks, mut outputs, consensus_manager, key_manager) =

--- a/base_layer/core/tests/tests/node_service.rs
+++ b/base_layer/core/tests/tests/node_service.rs
@@ -32,7 +32,7 @@ use tari_core::{
     },
     blocks::{ChainBlock, NewBlock},
     chain_storage::BlockchainDatabaseConfig,
-    consensus::{ConsensusConstantsBuilder, ConsensusManager, ConsensusManagerBuilder, NetworkConsensus},
+    consensus::{ConsensusManager, ConsensusManagerBuilder, NetworkConsensus},
     mempool::TxStorageResponse,
     proof_of_work::{randomx_factory::RandomXFactory, Difficulty, PowAlgorithm},
     transactions::{
@@ -88,9 +88,7 @@ async fn propagate_and_forward_many_valid_blocks() {
     let carol_node_identity = random_node_identity();
     let dan_node_identity = random_node_identity();
     let network = Network::LocalNet;
-    let consensus_constants = ConsensusConstantsBuilder::new(network)
-        .with_emission_amounts(100_000_000.into(), &EMISSION, 100.into())
-        .build();
+    let consensus_constants = crate::helpers::sample_blockchains::consensus_constants(network).build();
     let (block0, outputs) = create_genesis_block_with_utxos(&[T, T], &consensus_constants, &key_manager).await;
 
     let (tx01, _tx01_out) = spend_utxos(
@@ -222,7 +220,6 @@ async fn propagate_and_forward_many_valid_blocks() {
     dan_node.shutdown().await;
 }
 
-static EMISSION: [u64; 2] = [10, 10];
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 #[allow(clippy::too_many_lines)]
 async fn propagate_and_forward_invalid_block_hash() {
@@ -237,9 +234,7 @@ async fn propagate_and_forward_invalid_block_hash() {
     let carol_node_identity = random_node_identity();
     let network = Network::LocalNet;
     let key_manager = create_memory_db_key_manager();
-    let consensus_constants = ConsensusConstantsBuilder::new(network)
-        .with_emission_amounts(100_000_000.into(), &EMISSION, 100.into())
-        .build();
+    let consensus_constants = crate::helpers::sample_blockchains::consensus_constants(network).build();
     let (block0, genesis_coinbase) = create_genesis_block(&consensus_constants, &key_manager).await;
     let rules = ConsensusManager::builder(network)
         .add_consensus_constants(consensus_constants)
@@ -370,9 +365,7 @@ async fn propagate_and_forward_invalid_block() {
     let dan_node_identity = random_node_identity();
     let key_manager = create_memory_db_key_manager();
     let network = Network::LocalNet;
-    let consensus_constants = ConsensusConstantsBuilder::new(network)
-        .with_emission_amounts(100_000_000.into(), &EMISSION, 100.into())
-        .build();
+    let consensus_constants = crate::helpers::sample_blockchains::consensus_constants(network).build();
     let (block0, _) = create_genesis_block(&consensus_constants, &key_manager).await;
     let rules = ConsensusManager::builder(network)
         .add_consensus_constants(consensus_constants)

--- a/base_layer/core/tests/tests/node_state_machine.rs
+++ b/base_layer/core/tests/tests/node_state_machine.rs
@@ -37,7 +37,7 @@ use tari_core::{
         SyncValidators,
     },
     chain_storage::BlockchainDatabaseConfig,
-    consensus::{ConsensusConstantsBuilder, ConsensusManagerBuilder},
+    consensus::ConsensusManagerBuilder,
     mempool::MempoolServiceConfig,
     proof_of_work::{randomx_factory::RandomXFactory, Difficulty},
     test_helpers::blockchain::create_test_blockchain_db,
@@ -66,15 +66,12 @@ use crate::helpers::{
     },
 };
 
-static EMISSION: [u64; 2] = [10, 10];
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_listening_lagging() {
     let network = Network::LocalNet;
     let temp_dir = tempdir().unwrap();
     let key_manager = create_memory_db_key_manager();
-    let consensus_constants = ConsensusConstantsBuilder::new(network)
-        .with_emission_amounts(100_000_000.into(), &EMISSION, 100.into())
-        .build();
+    let consensus_constants = crate::helpers::sample_blockchains::consensus_constants(network).build();
     let (prev_block, _) = create_genesis_block(&consensus_constants, &key_manager).await;
     let consensus_manager = ConsensusManagerBuilder::new(network)
         .add_consensus_constants(consensus_constants)
@@ -158,9 +155,7 @@ async fn test_listening_initial_fallen_behind() {
     let network = Network::LocalNet;
     let temp_dir = tempdir().unwrap();
     let key_manager = create_memory_db_key_manager();
-    let consensus_constants = ConsensusConstantsBuilder::new(network)
-        .with_emission_amounts(100_000_000.into(), &EMISSION, 100.into())
-        .build();
+    let consensus_constants = crate::helpers::sample_blockchains::consensus_constants(network).build();
     let (gen_block, _) = create_genesis_block(&consensus_constants, &key_manager).await;
     let consensus_manager = ConsensusManagerBuilder::new(network)
         .add_consensus_constants(consensus_constants)


### PR DESCRIPTION
## Summary

Adds a feature `tari_feature_mainnet_emission` to allow for tail emission
inflation. See #6122 

This change necessitates the addition of 2 new consensus constants:
`inflation_bips` -- the annual inflation rate of the total supply.
and `tail_emission_epoch_length`, which controls the tail emission
inflation. These replace `tail_emission`.

We update the Protobuf definition for `ConsensusConstants` to account for
the new fields.

Note: Replaces part of #6131 

