### PR TITLE
fix: oms validation

### DIFF
--- a/base_layer/wallet/src/output_manager_service/tasks/txo_validation_task.rs
+++ b/base_layer/wallet/src/output_manager_service/tasks/txo_validation_task.rs
@@ -321,6 +321,13 @@ where
             }
             for unmined_output in unmined {
                 if unmined_output.status == OutputStatus::UnspentMinedUnconfirmed {
+                    info!(
+                        target: LOG_TARGET,
+                            "Updating output comm:{}: hash {} as unmined(Operation ID: {})",
+                        unmined_output.output.commitment.to_hex(),
+                        unmined_output.output.hash.to_hex(),
+                        self.operation_id
+                    );
                     self.db
                         .set_output_to_unmined_and_invalid(unmined_output.hash)
                         .for_protocol(self.operation_id)?;

--- a/base_layer/wallet/src/output_manager_service/tasks/txo_validation_task.rs
+++ b/base_layer/wallet/src/output_manager_service/tasks/txo_validation_task.rs
@@ -324,8 +324,8 @@ where
                     info!(
                         target: LOG_TARGET,
                             "Updating output comm:{}: hash {} as unmined(Operation ID: {})",
-                        unmined_output.output.commitment.to_hex(),
-                        unmined_output.output.hash.to_hex(),
+                        unmined_output.commitment.to_hex(),
+                        unmined_output.hash.to_hex(),
                         self.operation_id
                     );
                     self.db

--- a/base_layer/wallet/src/output_manager_service/tasks/txo_validation_task.rs
+++ b/base_layer/wallet/src/output_manager_service/tasks/txo_validation_task.rs
@@ -46,6 +46,7 @@ use crate::{
         storage::{
             database::{OutputManagerBackend, OutputManagerDatabase},
             models::DbWalletOutput,
+            OutputStatus,
         },
     },
 };
@@ -317,6 +318,13 @@ where
                     mined_info.mined_timestamp,
                 )
                 .await?;
+            }
+            for unmined_output in unmined {
+                if unmined_output.status == OutputStatus::UnspentMinedUnconfirmed {
+                    self.db
+                        .set_output_to_unmined_and_invalid(unmined_output.hash)
+                        .for_protocol(self.operation_id)?;
+                }
             }
         }
 


### PR DESCRIPTION
Description
---
Fixes the OMS validation to invalidate unmined utxos and not keep them pending

Motivation and Context
---
Although these utxo would never reach spending, the wallet sees them as pending incoming or pending outgoing. We need to ensure their status is correctly set. 
