### PR TITLE
feat: multi-network ci

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -3,3 +3,15 @@ slow-timeout = { period = "60s", terminate-after=2}
 
 [profile.ci.junit]  # this can be some other profile, too
 path = "junit.xml"
+
+[profile.intellij]
+retries = 0
+slow-timeout = { period = "30s" }
+failure-output = "immediate-final"
+fail-fast = false
+
+[profile.intellij.junit]  # this can be some other profile, too
+path = "junit.xml"
+
+
+

--- a/.github/workflows/base_node_binaries.yml
+++ b/.github/workflows/base_node_binaries.yml
@@ -109,8 +109,10 @@ jobs:
         run: |
           source buildtools/multinet_envs.sh ${{ env.GHA_NETWORK }}
           echo ${TARI_NETWORK}
+          echo ${TARI_TARGET_NETWORK}
           echo ${TARI_NETWORK_DIR}
           echo "TARI_NETWORK=${TARI_NETWORK}" >> $GITHUB_ENV
+          echo "TARI_TARGET_NETWORK=${TARI_TARGET_NETWORK}" >> $GITHUB_ENV
           echo "TARI_NETWORK_DIR=${TARI_NETWORK_DIR}" >> $GITHUB_ENV
           echo "TARI_NETWORK_DIR=${TARI_NETWORK_DIR}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/build_dockers_workflow.yml
+++ b/.github/workflows/build_dockers_workflow.yml
@@ -119,6 +119,8 @@ jobs:
           source tari/buildtools/multinet_envs.sh ${{github.ref_name}}
           echo ${TARI_NETWORK}
           echo "TARI_NETWORK=${TARI_NETWORK}" >> $GITHUB_ENV
+          echo ${TARI_TARGET_NETWORK}
+          echo "TARI_TARGET_NETWORK=${TARI_TARGET_NETWORK}" >> $GITHUB_ENV
 
       - name: environment setup
         shell: bash
@@ -225,6 +227,7 @@ jobs:
             APP_NAME=${{ matrix.builds.app_name }}
             APP_EXEC=${{ matrix.builds.app_exec }}
             TARI_NETWORK=${{ env.TARI_NETWORK }}
+            TARI_TARGET_NETWORK=${{ env.TARI_TARGET_NETWORK }}
             ${{ env.DOCKER_SUBTAG }}
           tags: |
             ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/build_libffis.yml
+++ b/.github/workflows/build_libffis.yml
@@ -102,8 +102,10 @@ jobs:
         run: |
           source buildtools/multinet_envs.sh ${{ github.ref_name }}
           echo ${TARI_NETWORK}
+          echo ${TARI_TARGET_NETWORK}
           echo ${TARI_NETWORK_CHANGELOG}
           echo "TARI_NETWORK=${TARI_NETWORK}" >> $GITHUB_ENV
+          echo "TARI_TARGET_NETWORK=${TARI_TARGET_NETWORK}" >> $GITHUB_ENV
           echo "TARI_NETWORK_CHANGELOG=${TARI_NETWORK_CHANGELOG}" >> $GITHUB_ENV
 
       - name: Declare Android/iOS envs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,17 @@ jobs:
     permissions:
       checks: write
       pull-requests: write
+    strategy:
+      matrix:
+        tari_target_network: [
+          { target: "testnet", network: "esmeralda" },
+          { target: "nextnet", network: "nextnet" },
+          { target: "mainnet", network: "stagenet" },
+        ]
+    env:
+      TARI_TARGET_NETWORK: ${{ matrix.tari_target_network.target }}
+      TARI_NETWORK: ${{ matrix.tari_target_network.network }}
+      RUST_LOG: debug
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -192,21 +203,22 @@ jobs:
             ~/.cargo/registry/CACHEDIR.TAG
             ~/.cargo/git
             target
-          key: tari-${{ runner.os }}-${{ runner.cpu-model }}-${{ env.toolchain }}-nightly-${{ hashFiles('**/Cargo.lock') }}
+          key: tari-${{ runner.os }}-${{ runner.cpu-model }}-${{ env.toolchain }}-nightly-${{ hashFiles('**/Cargo.lock') }}-${{ matrix.tari_target_network.target }}
           restore-keys: |
+            tari-${{ runner.os }}-${{ runner.cpu-model }}-${{ env.toolchain }}-nightly-${{ hashFiles('**/Cargo.lock') }}-${{ matrix.tari_target_network.network }}
             tari-${{ runner.os }}-${{ runner.cpu-model }}-${{ env.toolchain }}-nightly-${{ hashFiles('**/Cargo.lock') }}
             tari-${{ runner.os }}-${{ runner.cpu-model }}-${{ env.toolchain }}-nightly
       - name: Install cargo-nextest
         run: cargo install cargo-nextest --locked --force
       - name: cargo test compile
-        run: cargo test --no-run --locked --all-features --release
+        run: cargo test -vv --no-run --locked --all-features --release
       - name: cargo test
         run: cargo nextest run --all-features --release -E "not package(tari_integration_tests)" --profile ci
       - name: upload artifact
         uses: actions/upload-artifact@v4  # upload test results as artifact
         if: always()
         with:
-          name: test-results
+          name: test-results-${{ matrix.tari_target_network.target }}.${{ matrix.tari_target_network.network }}
           path: ${{ github.workspace }}/target/nextest/ci/junit.xml
 
   # Allows other workflows to know the PR number

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3046,6 +3046,7 @@ dependencies = [
  "tari_comms",
  "tari_core",
  "tari_crypto",
+ "tari_features",
  "tari_script",
  "tari_utilities",
  "thiserror",
@@ -3243,6 +3244,7 @@ dependencies = [
  "tari_comms",
  "tari_core",
  "tari_crypto",
+ "tari_features",
  "tari_utilities",
  "thiserror",
 ]
@@ -5841,6 +5843,7 @@ dependencies = [
  "tari_comms_dht",
  "tari_comms_rpc_macros",
  "tari_crypto",
+ "tari_features",
  "tari_hash_domains",
  "tari_key_manager",
  "tari_metrics",

--- a/applications/minotari_app_grpc/Cargo.toml
+++ b/applications/minotari_app_grpc/Cargo.toml
@@ -31,6 +31,7 @@ tonic = { version = "0.8.3", features = ["tls"]}
 zeroize = "1"
 
 [build-dependencies]
+tari_features = { path = "../../common/tari_features", version = "1.0.0-pre.9" }
 tonic-build = "0.8.4"
 
 [package.metadata.cargo-machete]

--- a/applications/minotari_app_grpc/build.rs
+++ b/applications/minotari_app_grpc/build.rs
@@ -1,7 +1,10 @@
 // Copyright 2022 The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
 
+use tari_features::resolver::build_features;
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    build_features();
     tonic_build::configure().build_client(true).build_server(true).compile(
         &[
             "proto/base_node.proto",

--- a/applications/minotari_app_utilities/Cargo.toml
+++ b/applications/minotari_app_utilities/Cargo.toml
@@ -9,7 +9,7 @@ license = "BSD-3-Clause"
 tari_common = { path = "../../common" }
 tari_common_types = { path = "../../base_layer/common_types" }
 tari_comms = { path = "../../comms/core" }
-tari_features = { path = "../../common/tari_features" }
+tari_features = { path = "../../common/tari_features", version = "1.0.0-pre.9" }
 tari_utilities = { version = "0.7" }
 minotari_app_grpc = { path = "../minotari_app_grpc", optional = true }
 
@@ -27,7 +27,7 @@ tonic = "0.8.3"
 
 [build-dependencies]
 tari_common = { path = "../../common", features = ["build", "static-application-info"] }
-tari_features = { path = "../../common/tari_features" }
+tari_features = { path = "../../common/tari_features", version = "1.0.0-pre.9" }
 
 [features]
 miner_input = ["minotari_app_grpc"]

--- a/applications/minotari_app_utilities/src/network_check.rs
+++ b/applications/minotari_app_utilities/src/network_check.rs
@@ -48,13 +48,13 @@ impl From<NetworkCheckError> for ExitError {
     }
 }
 
-#[cfg(tari_network_mainnet)]
+#[cfg(tari_target_network_mainnet)]
 pub const TARGET_NETWORK: Target = Target::MainNet;
 
-#[cfg(tari_network_nextnet)]
+#[cfg(tari_target_network_nextnet)]
 pub const TARGET_NETWORK: Target = Target::NextNet;
 
-#[cfg(all(not(tari_network_mainnet), not(tari_network_nextnet)))]
+#[cfg(all(not(tari_target_network_mainnet), not(tari_target_network_nextnet)))]
 pub const TARGET_NETWORK: Target = Target::TestNet;
 
 pub fn is_network_choice_valid(network: Network) -> Result<Network, NetworkCheckError> {

--- a/applications/minotari_console_wallet/Cargo.toml
+++ b/applications/minotari_console_wallet/Cargo.toml
@@ -82,7 +82,7 @@ default-features = false
 features = ["crossterm"]
 
 [build-dependencies]
-tari_features = { path = "../../common/tari_features" }
+tari_features = { path = "../../common/tari_features", version = "1.0.0-pre.9" }
 
 [features]
 default = ["libtor"]

--- a/applications/minotari_merge_mining_proxy/Cargo.toml
+++ b/applications/minotari_merge_mining_proxy/Cargo.toml
@@ -46,4 +46,4 @@ tracing = "0.1"
 url = "2.1.1"
 
 [build-dependencies]
-tari_features = { path = "../../common/tari_features"}
+tari_features = { path = "../../common/tari_features", version = "1.0.0-pre.9"}

--- a/applications/minotari_node/Cargo.toml
+++ b/applications/minotari_node/Cargo.toml
@@ -58,7 +58,7 @@ safe = []
 libtor = ["tari_libtor"]
 
 [build-dependencies]
-tari_features = { path = "../../common/tari_features"}
+tari_features = { path = "../../common/tari_features", version = "1.0.0-pre.9"}
 
 [package.metadata.cargo-machete]
 ignored = [

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -105,6 +105,7 @@ quickcheck = "1.0"
 
 [build-dependencies]
 tari_common = { path = "../../common", features = ["build"], version = "1.0.0-pre.9" }
+tari_features = { path = "../../common/tari_features", version = "1.0.0-pre.9" }
 
 [[bench]]
 name = "mempool"

--- a/base_layer/core/src/blocks/genesis_block.rs
+++ b/base_layer/core/src/blocks/genesis_block.rs
@@ -111,7 +111,7 @@ pub fn get_stagenet_genesis_block() -> ChainBlock {
     if add_faucet_utxos {
         // NB! Update 'consensus_constants.rs/pub fn igor()/ConsensusConstants {faucet_value: ?}' with total value
         // NB: `stagenet_genesis_sanity_check` must pass
-        let file_contents = include_str!("faucets/esmeralda_faucet.json");
+        let file_contents = include_str!("faucets/stagenet_faucet.json");
         add_faucet_utxos_to_genesis_block(file_contents, &mut block);
         // Enable print only if you need to generate new Merkle roots, then disable it again
         let print_values = false;
@@ -119,9 +119,9 @@ pub fn get_stagenet_genesis_block() -> ChainBlock {
 
         // Hardcode the Merkle roots once they've been computed above
         block.header.kernel_mr =
-            FixedHash::from_hex("3f4011ec1e8ddfbd66fb7331c5623b38f529a66e81233d924df85f2070b2aacb").unwrap();
+            FixedHash::from_hex("a08ff15219beea81d4131465290443fb3bd99d28b8af85975dbb2c77cb4cb5a0").unwrap();
         block.header.output_mr =
-            FixedHash::from_hex("3e40efda288a57d3319c63388dd47ffe4b682baaf6a3b58622ec94d77ad712a2").unwrap();
+            FixedHash::from_hex("435f13e21be06b0d0ae9ad3869ac7c723edd933983fa2e26df843c82594b3245").unwrap();
         block.header.validator_node_mr =
             FixedHash::from_hex("277da65c40b2cf99db86baedb903a3f0a38540f3a94d40c826eecac7e27d5dfc").unwrap();
     }
@@ -163,7 +163,7 @@ pub fn get_nextnet_genesis_block() -> ChainBlock {
     if add_faucet_utxos {
         // NB! Update 'consensus_constants.rs/pub fn igor()/ConsensusConstants {faucet_value: ?}' with total value
         // NB: `nextnet_genesis_sanity_check` must pass
-        let file_contents = include_str!("faucets/esmeralda_faucet.json");
+        let file_contents = include_str!("faucets/nextnet_faucet.json");
         add_faucet_utxos_to_genesis_block(file_contents, &mut block);
         // Enable print only if you need to generate new Merkle roots, then disable it again
         let print_values = false;
@@ -171,9 +171,9 @@ pub fn get_nextnet_genesis_block() -> ChainBlock {
 
         // Hardcode the Merkle roots once they've been computed above
         block.header.kernel_mr =
-            FixedHash::from_hex("3f4011ec1e8ddfbd66fb7331c5623b38f529a66e81233d924df85f2070b2aacb").unwrap();
+            FixedHash::from_hex("36881d87e25183f5189d2dca5f7da450c399e7006dafd9bd9240f73a5fb3f0ad").unwrap();
         block.header.output_mr =
-            FixedHash::from_hex("3e40efda288a57d3319c63388dd47ffe4b682baaf6a3b58622ec94d77ad712a2").unwrap();
+            FixedHash::from_hex("7b65d5140485b44e33eef3690d46c41e4dc5c4520ad7464d7740f376f4f0a728").unwrap();
         block.header.validator_node_mr =
             FixedHash::from_hex("277da65c40b2cf99db86baedb903a3f0a38540f3a94d40c826eecac7e27d5dfc").unwrap();
     }
@@ -368,6 +368,7 @@ mod test {
 
     use tari_common_types::{epoch::VnEpoch, types::Commitment};
     use tari_utilities::ByteArray;
+    use Network;
 
     use super::*;
     use crate::{
@@ -383,14 +384,7 @@ mod test {
     };
 
     #[test]
-    fn stagenet_genesis_sanity_check() {
-        // Note: Generate new data for `pub fn get_stagenet_genesis_block()` and `fn get_stagenet_genesis_block_raw()`
-        // if consensus values change, e.g. new faucet or other
-        let block = get_stagenet_genesis_block();
-        check_block(Network::StageNet, &block, 100, 1);
-    }
-
-    #[test]
+    #[cfg(tari_target_network_nextnet)]
     fn nextnet_genesis_sanity_check() {
         // Note: Generate new data for `pub fn get_nextnet_genesis_block()` and `fn get_stagenet_genesis_block_raw()`
         // if consensus values change, e.g. new faucet or other
@@ -399,11 +393,13 @@ mod test {
     }
 
     #[test]
-    fn esmeralda_genesis_sanity_check() {
+    #[cfg(tari_target_network_mainnet)]
+    fn stagenet_genesis_sanity_check() {
+        Network::set_current(Network::StageNet).unwrap();
         // Note: Generate new data for `pub fn get_esmeralda_genesis_block()` and `fn get_esmeralda_genesis_block_raw()`
         // if consensus values change, e.g. new faucet or other
-        let block = get_esmeralda_genesis_block();
-        check_block(Network::Esmeralda, &block, 100, 1);
+        let block = get_stagenet_genesis_block();
+        check_block(Network::StageNet, &block, 100, 1);
     }
 
     #[test]

--- a/base_layer/core/src/blocks/genesis_block.rs
+++ b/base_layer/core/src/blocks/genesis_block.rs
@@ -384,6 +384,15 @@ mod test {
     };
 
     #[test]
+    #[cfg(tari_target_network_testnet)]
+    fn esme_genesis_sanity_check() {
+        // Note: Generate new data for `pub fn get_esmeralda_genesis_block()` and `fn get_esmeralda_genesis_block_raw()`
+        // if consensus values change, e.g. new faucet or other
+        let block = get_esmeralda_genesis_block();
+        check_block(Network::Esmeralda, &block, 100, 1);
+    }
+
+    #[test]
     #[cfg(tari_target_network_nextnet)]
     fn nextnet_genesis_sanity_check() {
         // Note: Generate new data for `pub fn get_nextnet_genesis_block()` and `fn get_stagenet_genesis_block_raw()`
@@ -396,7 +405,7 @@ mod test {
     #[cfg(tari_target_network_mainnet)]
     fn stagenet_genesis_sanity_check() {
         Network::set_current(Network::StageNet).unwrap();
-        // Note: Generate new data for `pub fn get_esmeralda_genesis_block()` and `fn get_esmeralda_genesis_block_raw()`
+        // Note: Generate new data for `pub fn get_stagenet_genesis_block()` and `fn get_stagenet_genesis_block_raw()`
         // if consensus values change, e.g. new faucet or other
         let block = get_stagenet_genesis_block();
         check_block(Network::StageNet, &block, 100, 1);
@@ -404,8 +413,7 @@ mod test {
 
     #[test]
     fn igor_genesis_sanity_check() {
-        // Note: Generate new data for `pub fn get_igor_genesis_block()` and `fn get_igor_genesis_block_raw()`
-        // if consensus values change, e.g. new faucet or other
+        // Note: If outputs and kernels are added, this test will fail unless you explicitly check that network == Igor
         let block = get_igor_genesis_block();
         check_block(Network::Igor, &block, 0, 0);
     }

--- a/base_layer/core/src/proof_of_work/sha3x_pow.rs
+++ b/base_layer/core/src/proof_of_work/sha3x_pow.rs
@@ -96,6 +96,7 @@ pub mod test {
     }
 
     #[test]
+    #[cfg(tari_target_network_testnet)]
     fn validate_max_target() {
         let mut header = get_header();
         header.nonce = 631;

--- a/base_layer/core/src/transactions/coinbase_builder.rs
+++ b/base_layer/core/src/transactions/coinbase_builder.rs
@@ -662,7 +662,7 @@ mod test {
         let block_reward = rules.emission_schedule().block_reward(42) + missing_fee;
         let builder = CoinbaseBuilder::new(key_manager.clone());
         let builder = builder
-            .with_block_height(4200000)
+            .with_block_height(4_200_000)
             .with_fees(1 * uT)
             .with_spend_key_id(p.spend_key_id.clone())
             .with_encryption_key_id(TariKeyId::default())

--- a/base_layer/core/src/transactions/transaction_components/test.rs
+++ b/base_layer/core/src/transactions/transaction_components/test.rs
@@ -280,6 +280,11 @@ async fn sender_signature_verification() {
 
 #[test]
 fn kernel_hash() {
+    #[cfg(tari_target_network_mainnet)]
+    if let Network::MainNet = Network::get_current_or_default() {
+        eprintln!("This test is configured for stagenet only");
+        return;
+    }
     let s = PrivateKey::from_hex("6c6eebc5a9c02e1f3c16a69ba4331f9f63d0718401dea10adc4f9d3b879a2c09").unwrap();
     let r = PublicKey::from_hex("28e8efe4e5576aac931d358d0f6ace43c55fa9d4186d1d259d1436caa876d43b").unwrap();
     let sig = Signature::new(r, s);
@@ -291,6 +296,17 @@ fn kernel_hash() {
         .with_lock_height(500)
         .build()
         .unwrap();
+    #[cfg(tari_target_network_nextnet)]
+    assert_eq!(
+        &k.hash().to_hex(),
+        "c1f6174935d08358809fcf244a9a1edb078b74a1ae18ab4c7dd501b0294a2a94"
+    );
+    #[cfg(tari_target_network_mainnet)]
+    assert_eq!(
+        &k.hash().to_hex(),
+        "b94992cb59695ebad3786e9f51a220e91c627f8b38f51bcf6c87297325d1b410"
+    );
+    #[cfg(tari_target_network_testnet)]
     assert_eq!(
         &k.hash().to_hex(),
         "38b03d013f941e86c027969fbbc190ca2a28fa2d7ac075d50dbfb6232deee646"
@@ -310,6 +326,24 @@ fn kernel_metadata() {
         .with_lock_height(500)
         .build()
         .unwrap();
+    #[cfg(tari_target_network_mainnet)]
+    match Network::get_current_or_default() {
+        Network::MainNet => {
+            eprintln!("This test is configured for stagenet only");
+        },
+        Network::StageNet => assert_eq!(
+            &k.hash().to_hex(),
+            "75a357c2769098b19a6aedc7e46f6be305f4f1a1831556cd380b0b0f20bfdf12"
+        ),
+        n => panic!("Only mainnet networks should target mainnet. Network was {}", n),
+    }
+
+    #[cfg(tari_target_network_nextnet)]
+    assert_eq!(
+        &k.hash().to_hex(),
+        "22e39392dfeae9653c73437880be71e99f4b8a2b23289d54f57b8931deebfeed"
+    );
+    #[cfg(tari_target_network_testnet)]
     assert_eq!(
         &k.hash().to_hex(),
         "ebc852fbac798c25ce497b416f69ec11a97e186aacaa10e2bb4ca5f5a0f197f2"

--- a/base_layer/tari_mining_helper_ffi/Cargo.toml
+++ b/base_layer/tari_mining_helper_ffi/Cargo.toml
@@ -19,8 +19,10 @@ hex = "0.4.2"
 
 [dev-dependencies]
 tari_core = { path = "../core", features = ["transactions", "base_node"]}
-
 rand = "0.8"
+
+[build-dependencies]
+tari_features = { path = "../../common/tari_features", version = "1.0.0-pre.9" }
 
 [lib]
 crate-type = ["staticlib","cdylib"]

--- a/base_layer/tari_mining_helper_ffi/build.rs
+++ b/base_layer/tari_mining_helper_ffi/build.rs
@@ -24,14 +24,4 @@ use tari_features::resolver::build_features;
 
 fn main() {
     build_features();
-    tari_common::build::ProtobufCompiler::new()
-        .include_paths(&["src/proto"])
-        .proto_paths(&[
-            "src/mempool/proto",
-            "src/base_node/proto",
-            "src/transactions/transaction_protocol/proto",
-        ])
-        .emit_rerun_if_changed_directives()
-        .compile()
-        .unwrap();
 }

--- a/base_layer/tari_mining_helper_ffi/src/lib.rs
+++ b/base_layer/tari_mining_helper_ffi/src/lib.rs
@@ -386,8 +386,16 @@ mod tests {
 
     #[test]
     fn detect_change_in_consensus_encoding() {
-        const NONCE: u64 = 3926968094459426389;
-        let difficulty = Difficulty::from_u64(1817).expect("Failed to create difficulty");
+        #[cfg(tari_target_network_mainnet)]
+        let (nonce, difficulty) = match Network::get_current_or_default() {
+            Network::MainNet => (9205754023158580549, Difficulty::from_u64(1015).unwrap()),
+            Network::StageNet => (12022341430563186162, Difficulty::from_u64(1011).unwrap()),
+            _ => panic!("Invalid network for mainnet target"),
+        };
+        #[cfg(tari_target_network_nextnet)]
+        let (nonce, difficulty) = (8721374869059089110, Difficulty::from_u64(3037).unwrap());
+        #[cfg(not(any(tari_target_network_mainnet, tari_target_network_nextnet)))]
+        let (nonce, difficulty) = (9860518124890236943, Difficulty::from_u64(2724).unwrap());
         unsafe {
             let mut error = -1;
             let error_ptr = &mut error as *mut c_int;
@@ -396,13 +404,15 @@ mod tests {
             #[allow(clippy::cast_possible_truncation)]
             let len = header_bytes.len() as u32;
             let byte_vec = byte_vector_create(header_bytes.as_ptr(), len, error_ptr);
-            inject_nonce(byte_vec, NONCE, error_ptr);
+            inject_nonce(byte_vec, nonce, error_ptr);
             assert_eq!(error, 0);
             let result = share_difficulty(byte_vec, error_ptr);
             if result != difficulty.as_u64() {
                 // Use this to generate new NONCE and DIFFICULTY
                 // Use ONLY if you know encoding has changed
                 let (difficulty, nonce) = generate_nonce_with_min_difficulty(min_difficulty()).unwrap();
+                let network = Network::get_current_or_default();
+                eprintln!("network = {network:?}");
                 eprintln!("nonce = {:?}", nonce);
                 eprintln!("difficulty = {:?}", difficulty);
                 panic!(

--- a/buildtools/multinet_envs.sh
+++ b/buildtools/multinet_envs.sh
@@ -7,21 +7,25 @@ case "$tagnet" in
 v*-pre.*)
   echo "esme"
   export TARI_NETWORK=esme
+  export TARI_TARGET_NETWORK=testnet
   export TARI_NETWORK_DIR=testnet
   ;;
 v*-rc.*)
   echo "nextnet"
   export TARI_NETWORK=nextnet
+  export TARI_TARGET_NETWORK=nextnet
   export TARI_NETWORK_DIR=nextnet
   ;;
 v*-dan.*)
   echo "dan"
   export TARI_NETWORK=igor
+  export TARI_TARGET_NETWORK=testnet
   export TARI_NETWORK_DIR=testnetdan
   ;;
 *)
   echo "mainnet"
   export TARI_NETWORK=mainnet
+  export TARI_TARGET_NETWORK=mainnet
   export TARI_NETWORK_DIR=mainnet
   ;;
 esac

--- a/common/src/configuration/network.rs
+++ b/common/src/configuration/network.rs
@@ -80,17 +80,20 @@ impl Network {
 
 /// The default network for all applications
 impl Default for Network {
-    #[cfg(tari_network_mainnet)]
+    #[cfg(tari_target_network_mainnet)]
     fn default() -> Self {
-        Network::StageNet
+        match std::env::var("TARI_NETWORK") {
+            Ok(network) => Network::from_str(network.as_str()).unwrap_or(Network::MainNet),
+            Err(_) => Network::MainNet,
+        }
     }
 
-    #[cfg(tari_network_nextnet)]
+    #[cfg(tari_target_network_nextnet)]
     fn default() -> Self {
         Network::NextNet
     }
 
-    #[cfg(all(not(tari_network_mainnet), not(tari_network_nextnet)))]
+    #[cfg(not(any(tari_target_network_mainnet, tari_target_network_nextnet)))]
     fn default() -> Self {
         Network::Esmeralda
     }
@@ -191,6 +194,11 @@ mod test {
     #[test]
     fn network_default() {
         let network = Network::default();
+        #[cfg(tari_target_network_mainnet)]
+        assert!(matches!(network, Network::MainNet | Network::StageNet));
+        #[cfg(tari_target_network_nextnet)]
+        assert_eq!(network, Network::NextNet);
+        #[cfg(not(any(tari_target_network_mainnet, tari_target_network_nextnet)))]
         assert_eq!(network, Network::Esmeralda);
     }
 

--- a/common/tari_features/Cargo.toml
+++ b/common/tari_features/Cargo.toml
@@ -13,4 +13,4 @@ edition = "2018"
 
 # So you're thinking about adding a dependency here?
 # This crate is utilized in the compilation of _most_ of our other crates. You're probably about
-# to create a cyclic depedency. Please think hard whether this change is actually required.
+# to create a cyclic dependency. Please think hard whether this change is actually required.

--- a/common/tari_features/README.md
+++ b/common/tari_features/README.md
@@ -1,5 +1,107 @@
-# tari_features
+# Feature gating
 
-Implementation of `tari features` for Tari.
+## Step 1: define features
 
-This crate is part of the [Tari Cryptocurrency](https://tari.com) project.
+In build.rs, we define our features.
+
+Features have a
+* name - will also be the attribute name you use in code
+* description - a short description of the features
+* issue tracking number on Github
+* The current status.
+
+#### Status
+
+* New: New feature, may not even be working or compiling. Will be present on `testnet`
+* Testing: Feature is undergoing testing on `nextnet`. Does not exist on `mainnet` or `stagenet`.
+* Active: Feature is live and gate has been removed. Will be running on all networks.
+* Removed: Feature has been cancelled. Can not be invoked anywhere.
+
+In `build.rs`, we maintain the list of feature flags. For example:
+
+```rust
+const FEATURE_LIST: [Feature; 4] = [
+    Feature::new("add_pair", "Allows you to add two numbers together", Some(123), Status::New),
+    Feature::new("about_to_launch", "Live in NextNet. If we stabilise, will go to mainnet", Some(123), Status::Testing),
+    Feature::new("live_feature", "This feature has been stabilised and is live!", Some(150), Status::Active),
+    Feature::new("old_feature", "We decided not to go with this featuree", Some(145), Status::Removed),
+];
+```
+
+## Step 2: Demarcate feature flag code
+
+In your code, you can now use any of the flags as attributes to mark code belonging to a feature.
+
+Example
+
+```rust
+#[cfg(tari_feature_add_pair)]
+use add_pair::add_pair;
+
+fn main() {
+    println!("Hello world!");
+    #[cfg(tari_feature_add_pair)]
+    println!("40 + 2 = {}", add_pair(40, 2));
+    println!("foo={}", foo());
+    println!("Bye, world!");
+}
+
+#[cfg(tari_feature_add_pair)]
+fn foo() -> usize {
+    1
+}
+
+#[cfg(not(tari_feature_add_pair))]
+fn foo() -> usize {
+    2
+}
+```
+
+## Step 3: Specify the target network when building
+
+This PoC uses the `TARI_NETWORK` envar to specify the target network, but in principle, we can also read the `Cargo.toml`
+file, or compiler flags.
+
+`$ TARI_NETWORK=dibbler cargo run -vv`
+
+Filtered output:
+
+```text
+Building for Dibbler
+These features are ACTIVE on mainnet (no special code handling is done)
+live_feature. This feature has been stabilised and is live!. Tracking issue: https://github.com/tari-project/tari/issues/150
+
+These features are DEPRECATED and will never be compiled
+old_feature. We decided not to go with this featuree. Tracking issue: https://github.com/tari-project/tari/issues/145
+
+** Activating add_pair. Allows you to add two numbers together. Tracking issue: https://github.com/tari-project/tari/issues/123 **
+** Activating about_to_launch. Live in NextNet. If we stabilise, will go to mainnet. Tracking issue: https://github.com/tari-project/tari/issues/123 **
+
+Finished dev [unoptimized + debuginfo] target(s) in 7.44s
+     Running `target/debug/feature_gates`
+Hello world!
+40 + 2 = 42
+foo=1
+Bye, world!
+```
+
+Or compiling for MainNet:
+
+`$ TARI_NETWORK=mainnet cargo run -vv`
+
+Filtered output:
+
+```text
+Building for MainNet
+
+These features are ACTIVE on mainnet (no special code handling is done)
+live_feature. This feature has been stabilised and is live!. Tracking issue: https://github.com/tari-project/tari/issues/150
+
+These features are DEPRECATED and will never be compiled
+old_feature. We decided not to go with this featuree. Tracking issue: https://github.com/tari-project/tari/issues/145
+    Finished dev [unoptimized + debuginfo] target(s) in 6.15s
+     Running `target/debug/feature_gates`
+Hello world!
+foo=2
+Bye, world!
+```

--- a/common/tari_features/src/resolver.rs
+++ b/common/tari_features/src/resolver.rs
@@ -64,10 +64,10 @@ impl Display for Target {
 // Identify the target network by
 // 1. Checking whether --config tari-network=xxx was passed in as a config flag to cargo (or from Cargo.toml)
 // 2. Checking the environment variable TARI_NETWORK is set
-// 3. default to mainnet
+// 3. default to testnet (should be mainnet after launch)
 pub fn identify_target() -> Target {
-    check_envar("CARGO_CFG_TARI_NETWORK")
-        .or_else(|| check_envar("TARI_NETWORK"))
+    check_envar("CARGO_CFG_TARI_TARGET_NETWORK")
+        .or_else(|| check_envar("TARI_TARGET_NETWORK"))
         .unwrap_or(Target::TestNet)
 }
 
@@ -79,19 +79,21 @@ pub fn check_envar(envar: &str) -> Option<Target> {
 }
 
 pub fn list_active_features() {
-    println!("These features are ACTIVE on mainnet (no special code handling is done)");
+    println!("tari_feature:These features are ACTIVE on mainnet (no special code handling is done)");
     FEATURE_LIST
         .iter()
         .filter(|f| f.is_active())
-        .for_each(|f| println!("{}", f));
+        .for_each(|f| println!("tari_feature:{f}"));
+    println!("tari_feature:End of ACTIVE feature list");
 }
 
 pub fn list_removed_features() {
-    println!("These features are DEPRECATED and will never be compiled");
+    println!("tari_feature:These features are DEPRECATED and will never be compiled");
     FEATURE_LIST
         .iter()
         .filter(|f| f.was_removed())
-        .for_each(|f| println!("{}", f));
+        .for_each(|f| println!("tari_feature:{f}"));
+    println!("tari_feature:End of DEPRECATED feature list");
 }
 
 pub fn resolve_features(target: Target) -> Result<(), String> {
@@ -110,17 +112,17 @@ pub fn resolve_features(target: Target) -> Result<(), String> {
 }
 
 pub fn activate_feature(feature: &Feature) {
-    println!("** Activating {} **", feature);
+    println!("tari_feature:** Activating {feature} **");
     println!("cargo:rustc-cfg={}", feature.attr_name());
 }
 
 pub fn build_features() {
     // Make sure to rebuild when the network changes
-    println!("cargo:rerun-if-env-changed=TARI_NETWORK");
+    println!("cargo:rerun-if-env-changed=TARI_TARGET_NETWORK");
 
     let target = identify_target();
-    println!("cargo:rustc-cfg=tari_network_{}", target.as_key_str());
-    println!("Building for {}", target);
+    println!("cargo:rustc-cfg=tari_target_network_{}", target.as_key_str());
+    println!("tari_feature:Building for {target}");
     list_active_features();
     list_removed_features();
     if let Err(e) = resolve_features(target) {


### PR DESCRIPTION
When formally implementing compiler features, the setting of the `TARI_NETWORK` and (from now) `TARI_TARGET_NETWORK` envar and the related compiler flags matter.

These changes require that when tests run, the correct network flags are set.

For example, `blocks::genesis_block::test::stagenet_genesis_sanity_check` should only run when `TARI_NETWORK=stagenet`.

The current setup reveals a problem:
There is not a 1:1 mapping between the build _target_ and the actual network the binary may run on. E.g. the mainnet build can run on either stagenet or mainnet.

Unfortunately the `TARI_NETWORK` envar was used to set both of these variables.

Since these are 2 different things, this commit introduced `TARI_TARGET_NETWORK` which sets the **build target**. In most contexts, this then decouples the configured network, which is specified by the `TARI_NETWORK` envar  as usual.

The other changes in this commit revolve around updating merkle roots and the correct faucet sets to make the target/network/faucet combination consistent.

The CI is configured to run tests for each of `{target} ({network})`
* Testnet (Esme)
* Nextnet (Nextnet)
* Mainnet (Stagenet)

Description
---

This replaces part of #6131 

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
