### PR TITLE
fix: avoid cloning range proofs during verification

### DIFF
--- a/base_layer/common_types/src/types/bullet_rangeproofs.rs
+++ b/base_layer/common_types/src/types/bullet_rangeproofs.rs
@@ -48,6 +48,11 @@ impl BulletRangeProof {
             .expect("This should be 32 bytes for a Blake 256 hash")
             .into()
     }
+
+    /// Get the range proof as a vector reference, which is useful to satisfy the verification API without cloning
+    pub fn as_vec(&self) -> &Vec<u8> {
+        &self.0
+    }
 }
 
 impl ByteArray for BulletRangeProof {

--- a/base_layer/core/src/transactions/transaction_components/transaction_output.rs
+++ b/base_layer/core/src/transactions/transaction_components/transaction_output.rs
@@ -49,7 +49,7 @@ use tari_crypto::{
     extended_range_proof::{ExtendedRangeProofService, Statement},
     keys::SecretKey,
     ristretto::bulletproofs_plus::RistrettoAggregatedPublicStatement,
-    tari_utilities::{hex::Hex, ByteArray},
+    tari_utilities::hex::Hex,
 };
 use tari_script::TariScript;
 
@@ -545,9 +545,9 @@ pub fn batch_verify_range_proofs(
                     minimum_value_promise: output.minimum_value_promise.into(),
                 }],
             });
-            proofs.push(output.proof_result()?.to_vec().clone());
+            proofs.push(output.proof_result()?.as_vec());
         }
-        if let Err(err_1) = prover.verify_batch(proofs.iter().collect(), statements.iter().collect()) {
+        if let Err(err_1) = prover.verify_batch(proofs, statements.iter().collect()) {
             for output in &bulletproof_plus_proofs {
                 if let Err(err_2) = output.verify_range_proof(prover) {
                     return Err(RangeProofError::InvalidRangeProof {


### PR DESCRIPTION
Description
---
Removes unnecessary cloning of range proofs during batch verification.

Motivation and Context
---
Currently, range proofs exist in transaction outputs as byte vectors. When parsing outputs to collect these proofs for batch verification, the byte vectors are cloned. This is done because the verification API requires that the vector of proofs contain a vector reference to each proof, but the `BulletRangeProof` type wrapper provides a slice instead as part of its `ByteArray` implementation. Because proofs are several hundred bytes and batches can be large, this cloning is wasteful.

This PR adds `BulletRangeProof::as_vec`, which returns the underlying range proof as a vector reference. Doing so lets us avoid the clone while collecting the range proofs.

How Has This Been Tested?
---
Existing tests pass.

What process can a PR reviewer use to test or verify this change?
---
Confirm that the change removes the cloning.
