### PR TITLE
feat: lazily evaluate for new random_x template

### DIFF
--- a/applications/minotari_app_grpc/proto/base_node.proto
+++ b/applications/minotari_app_grpc/proto/base_node.proto
@@ -173,6 +173,7 @@ message NewBlockTemplateResponse {
     NewBlockTemplate new_block_template = 1;
     bool initial_sync_achieved = 3;
     MinerData miner_data = 4;
+    bytes best_previous_block_hash = 5;
 }
 
 /// return type of NewBlockTemplateRequest

--- a/applications/minotari_app_grpc/proto/base_node.proto
+++ b/applications/minotari_app_grpc/proto/base_node.proto
@@ -173,7 +173,6 @@ message NewBlockTemplateResponse {
     NewBlockTemplate new_block_template = 1;
     bool initial_sync_achieved = 3;
     MinerData miner_data = 4;
-    bytes best_previous_block_hash = 5;
 }
 
 /// return type of NewBlockTemplateRequest

--- a/applications/minotari_app_utilities/Cargo.toml
+++ b/applications/minotari_app_utilities/Cargo.toml
@@ -9,7 +9,6 @@ license = "BSD-3-Clause"
 tari_common = { path = "../../common" }
 tari_common_types = { path = "../../base_layer/common_types" }
 tari_comms = { path = "../../comms/core" }
-tari_features = { path = "../../common/tari_features", version = "1.0.0-pre.9" }
 tari_utilities = { version = "0.7" }
 minotari_app_grpc = { path = "../minotari_app_grpc", optional = true }
 

--- a/applications/minotari_app_utilities/src/common_cli_args.rs
+++ b/applications/minotari_app_utilities/src/common_cli_args.rs
@@ -105,7 +105,7 @@ impl CommonCliArgs {
 }
 
 impl ConfigOverrideProvider for CommonCliArgs {
-    fn get_config_property_overrides(&self, _default_network: Network) -> Vec<(String, String)> {
+    fn get_config_property_overrides(&self, _network: &mut Network) -> Vec<(String, String)> {
         let mut overrides = self.config_property_overrides.clone();
         overrides.push((
             "common.base_path".to_string(),

--- a/applications/minotari_app_utilities/src/lib.rs
+++ b/applications/minotari_app_utilities/src/lib.rs
@@ -22,7 +22,6 @@
 
 pub mod common_cli_args;
 pub mod identity_management;
-pub mod network_check;
 #[cfg(feature = "miner_input")]
 pub mod parse_miner_input;
 pub mod utilities;

--- a/applications/minotari_console_wallet/src/cli.rs
+++ b/applications/minotari_console_wallet/src/cli.rs
@@ -91,9 +91,9 @@ pub struct Cli {
 }
 
 impl ConfigOverrideProvider for Cli {
-    fn get_config_property_overrides(&self, default_network: Network) -> Vec<(String, String)> {
-        let mut overrides = self.common.get_config_property_overrides(default_network);
-        let network = self.common.network.unwrap_or(default_network);
+    fn get_config_property_overrides(&self, network: &mut Network) -> Vec<(String, String)> {
+        let mut overrides = self.common.get_config_property_overrides(network);
+        *network = self.common.network.unwrap_or(*network);
         overrides.push(("wallet.network".to_string(), network.to_string()));
         overrides.push(("wallet.override_from".to_string(), network.to_string()));
         overrides.push(("p2p.seeds.override_from".to_string(), network.to_string()));

--- a/applications/minotari_console_wallet/src/lib.rs
+++ b/applications/minotari_console_wallet/src/lib.rs
@@ -48,7 +48,7 @@ pub use cli::{
 };
 use init::{change_password, get_base_node_peer_config, init_wallet, start_wallet, tari_splash_screen, WalletBoot};
 use log::*;
-use minotari_app_utilities::{common_cli_args::CommonCliArgs, consts, network_check::set_network_if_choice_valid};
+use minotari_app_utilities::{common_cli_args::CommonCliArgs, consts};
 use minotari_wallet::transaction_service::config::TransactionRoutingMechanism;
 use recovery::{get_seed_from_seed_words, prompt_private_key_from_seed_words};
 use tari_common::{
@@ -116,8 +116,6 @@ pub fn run_wallet_with_cli(
         ApplicationType::ConsoleWallet,
         consts::APP_VERSION
     );
-
-    set_network_if_choice_valid(config.wallet.network)?;
 
     let password = get_password(config, &cli);
 

--- a/applications/minotari_merge_mining_proxy/Cargo.toml
+++ b/applications/minotari_merge_mining_proxy/Cargo.toml
@@ -11,33 +11,33 @@ edition = "2018"
 default = []
 
 [dependencies]
+minotari_app_grpc = { path = "../minotari_app_grpc" }
+minotari_app_utilities = { path = "../minotari_app_utilities", features = ["miner_input"] }
+minotari_node_grpc_client = { path = "../../clients/rust/base_node_grpc_client" }
+minotari_wallet_grpc_client = { path = "../../clients/rust/wallet_grpc_client" }
 tari_common = { path = "../../common" }
 tari_common_types = { path = "../../base_layer/common_types" }
 tari_comms = { path = "../../comms/core" }
 tari_core = { path = "../../base_layer/core", default-features = false, features = ["transactions"] }
-minotari_app_utilities = { path = "../minotari_app_utilities", features = ["miner_input"] }
-tari_utilities = { version = "0.7" }
-minotari_node_grpc_client = { path = "../../clients/rust/base_node_grpc_client" }
-minotari_wallet_grpc_client = { path = "../../clients/rust/wallet_grpc_client" }
-minotari_app_grpc = { path = "../minotari_app_grpc" }
 tari_key_manager = {  path = "../../base_layer/key_manager", features = ["key_manager_service"] }
+tari_utilities = { version = "0.7" }
 
 anyhow = "1.0.53"
-crossterm = { version = "0.25.0" }
 bincode = "1.3.1"
 borsh = "1.2"
 bytes = "1.1"
-chrono = { version = "0.4.6", default-features = false }
+chrono = { version = "0.4.19", default-features = false }
 clap = { version = "3.2", features = ["derive", "env"] }
 config = { version = "0.13.0" }
-futures = "0.3.5"
+crossterm = { version = "0.25.0" }
+futures = { version = "^0.3.16", features = ["async-await"] }
 hex = "0.4.2"
 hyper = "0.14.12"
 jsonrpc = "0.12.0"
 log = { version = "0.4.8", features = ["std"] }
 monero = { version = "0.20.0" }
 reqwest = { version = "0.11.4", features = ["json"] }
-serde = { version = "1.0.106", features = ["derive"] }
+serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.57"
 thiserror = "1.0.26"
 tokio = { version = "1.23", features = ["macros"] }

--- a/applications/minotari_merge_mining_proxy/src/cli.rs
+++ b/applications/minotari_merge_mining_proxy/src/cli.rs
@@ -35,9 +35,9 @@ pub struct Cli {
 }
 
 impl ConfigOverrideProvider for Cli {
-    fn get_config_property_overrides(&self, default_network: Network) -> Vec<(String, String)> {
-        let mut overrides = self.common.get_config_property_overrides(default_network);
-        let network = self.common.network.unwrap_or(default_network);
+    fn get_config_property_overrides(&self, network: &mut Network) -> Vec<(String, String)> {
+        let mut overrides = self.common.get_config_property_overrides(network);
+        *network = self.common.network.unwrap_or(*network);
         overrides.push(("merge_mining_proxy.override_from".to_string(), network.to_string()));
         overrides.push(("merge_mining_proxy.network".to_string(), network.to_string()));
         overrides

--- a/applications/minotari_merge_mining_proxy/src/error.rs
+++ b/applications/minotari_merge_mining_proxy/src/error.rs
@@ -111,6 +111,8 @@ pub enum MmProxyError {
     ParseInputError(#[from] ParseInputError),
     #[error("Base node not responding to gRPC requests: {0}")]
     BaseNodeNotResponding(String),
+    #[error("Unexpected missing data: {0}")]
+    UnexpectedMissingData(String),
 }
 
 impl From<tonic::Status> for MmProxyError {

--- a/applications/minotari_miner/src/cli.rs
+++ b/applications/minotari_miner/src/cli.rs
@@ -42,9 +42,9 @@ pub struct Cli {
 }
 
 impl ConfigOverrideProvider for Cli {
-    fn get_config_property_overrides(&self, default_network: Network) -> Vec<(String, String)> {
-        let mut overrides = self.common.get_config_property_overrides(default_network);
-        let network = self.common.network.unwrap_or(default_network);
+    fn get_config_property_overrides(&self, network: &mut Network) -> Vec<(String, String)> {
+        let mut overrides = self.common.get_config_property_overrides(network);
+        *network = self.common.network.unwrap_or(*network);
         overrides.push(("miner.network".to_string(), network.to_string()));
         overrides
     }

--- a/applications/minotari_miner/src/run_miner.rs
+++ b/applications/minotari_miner/src/run_miner.rs
@@ -29,14 +29,11 @@ use minotari_app_grpc::{
     tari_rpc::{base_node_client::BaseNodeClient, TransactionOutput as GrpcTransactionOutput},
     tls::protocol_string,
 };
-use minotari_app_utilities::{
-    network_check::set_network_if_choice_valid,
-    parse_miner_input::{
-        base_node_socket_address,
-        verify_base_node_grpc_mining_responses,
-        wallet_payment_address,
-        BaseNodeGrpcClient,
-    },
+use minotari_app_utilities::parse_miner_input::{
+    base_node_socket_address,
+    verify_base_node_grpc_mining_responses,
+    wallet_payment_address,
+    BaseNodeGrpcClient,
 };
 use tari_common::{
     exit_codes::{ExitCode, ExitError},
@@ -75,8 +72,6 @@ pub async fn start_miner(cli: Cli) -> Result<(), ExitError> {
     let cfg = load_configuration(config_path.as_path(), true, cli.non_interactive_mode, &cli)?;
     let mut config = MinerConfig::load_from(&cfg).expect("Failed to load config");
     config.set_base_path(cli.common.get_base_path());
-
-    set_network_if_choice_valid(config.network)?;
 
     debug!(target: LOG_TARGET_FILE, "{:?}", config);
     let key_manager = create_memory_db_key_manager();

--- a/applications/minotari_node/src/cli.rs
+++ b/applications/minotari_node/src/cli.rs
@@ -52,9 +52,9 @@ pub struct Cli {
 }
 
 impl ConfigOverrideProvider for Cli {
-    fn get_config_property_overrides(&self, default_network: Network) -> Vec<(String, String)> {
-        let mut overrides = self.common.get_config_property_overrides(default_network);
-        let network = self.common.network.unwrap_or(default_network);
+    fn get_config_property_overrides(&self, network: &mut Network) -> Vec<(String, String)> {
+        let mut overrides = self.common.get_config_property_overrides(network);
+        *network = self.common.network.unwrap_or(*network);
         overrides.push(("base_node.network".to_string(), network.to_string()));
         overrides.push(("base_node.override_from".to_string(), network.to_string()));
         overrides.push(("p2p.seeds.override_from".to_string(), network.to_string()));

--- a/applications/minotari_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/minotari_node/src/grpc/base_node_grpc_server.rs
@@ -570,14 +570,6 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
                 );
                 obscure_error_if_true(report_error_flag, Status::internal(e.to_string()))
             })?;
-        let metadata = handler.get_metadata().await.map_err(|e| {
-            warn!(
-                target: LOG_TARGET,
-                "Could not get metadata for new block template: {}",
-                e.to_string()
-            );
-            obscure_error_if_true(report_error_flag, Status::internal(e.to_string()))
-        })?;
 
         let status_watch = self.state_machine_handle.get_status_info_watch();
         let pow = algo as i32;
@@ -594,7 +586,6 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
                     .map_err(|e| obscure_error_if_true(report_error_flag, Status::internal(e)))?,
             ),
             initial_sync_achieved: status_watch.borrow().bootstrapped,
-            best_previous_block_hash: metadata.best_block_hash().to_vec(),
         };
 
         debug!(target: LOG_TARGET, "Sending GetNewBlockTemplate response to client");

--- a/applications/minotari_node/src/lib.rs
+++ b/applications/minotari_node/src/lib.rs
@@ -43,7 +43,7 @@ use commands::{cli_loop::CliLoop, command::CommandContext};
 use futures::FutureExt;
 use log::*;
 use minotari_app_grpc::{authentication::ServerAuthenticationInterceptor, tls::identity::read_identity};
-use minotari_app_utilities::{common_cli_args::CommonCliArgs, network_check::set_network_if_choice_valid};
+use minotari_app_utilities::common_cli_args::CommonCliArgs;
 use tari_common::{
     configuration::bootstrap::{grpc_default_port, ApplicationType},
     exit_codes::{ExitCode, ExitError},
@@ -100,8 +100,6 @@ pub async fn run_base_node_with_cli(
     cli: Cli,
     shutdown: Shutdown,
 ) -> Result<(), ExitError> {
-    set_network_if_choice_valid(config.network())?;
-
     #[cfg(feature = "metrics")]
     {
         metrics::install(

--- a/base_layer/core/src/consensus/consensus_encoding/hashing.rs
+++ b/base_layer/core/src/consensus/consensus_encoding/hashing.rs
@@ -42,7 +42,7 @@ where D: Default
 {
     #[allow(clippy::new_ret_no_self)]
     pub fn new(label: &'static str) -> ConsensusHasher<D> {
-        Self::new_with_network(label, Network::get_current_or_default())
+        Self::new_with_network(label, Network::get_current_or_user_setting_or_default())
     }
 
     pub fn new_with_network(label: &'static str, network: Network) -> ConsensusHasher<D> {
@@ -174,7 +174,7 @@ mod tests {
 
     #[test]
     fn it_hashes_using_the_domain_hasher() {
-        let network = Network::get_current_or_default();
+        let network = Network::get_current_or_user_setting_or_default();
 
         // Script is chosen because the consensus encoding impl for TariScript has 2 writes
         let mut hasher = Blake2b::<U32>::default();
@@ -190,7 +190,7 @@ mod tests {
 
     #[test]
     fn it_adds_to_hash_challenge_in_complete_chunks() {
-        let network = Network::get_current_or_default();
+        let network = Network::get_current_or_user_setting_or_default();
 
         // Script is chosen because the consensus encoding impl for TariScript has 2 writes
         let test_subject = script!(Nop);
@@ -214,5 +214,36 @@ mod tests {
         let default_consensus_hash = default_consensus_hasher.chain(b"").finalize();
 
         assert_ne!(blake_hash.as_slice(), default_consensus_hash.as_slice());
+    }
+
+    #[test]
+    fn it_uses_the_network_environment_variable_if_set() {
+        let label = "test";
+        let input = [1u8; 32];
+
+        for network in [
+            Network::MainNet,
+            Network::StageNet,
+            Network::NextNet,
+            Network::LocalNet,
+            Network::Igor,
+            Network::Esmeralda,
+        ] {
+            // Generate a specific network hash
+            let hash_specify_network =
+                DomainSeparatedConsensusHasher::<TestHashDomain, Blake2b<U32>>::new_with_network(label, network)
+                    .chain(&input)
+                    .finalize();
+
+            // Generate an inferred network hash
+            std::env::set_var("TARI_NETWORK", network.as_key_str());
+            let inferred_network_hash = DomainSeparatedConsensusHasher::<TestHashDomain, Blake2b<U32>>::new(label)
+                .chain(&input)
+                .finalize();
+            std::env::remove_var("TARI_NETWORK");
+
+            // They should be equal
+            assert_eq!(hash_specify_network, inferred_network_hash);
+        }
     }
 }

--- a/base_layer/core/src/proof_of_work/monero_rx/mod.rs
+++ b/base_layer/core/src/proof_of_work/monero_rx/mod.rs
@@ -29,7 +29,7 @@ pub use helpers::{
     create_ordered_transaction_hashes_from_block,
     deserialize_monero_block_from_hex,
     extract_aux_merkle_root_from_block,
-    insert_merge_mining_tag_and_aux_chain_merkle_root_into_block,
+    insert_aux_chain_mr_and_info_into_block,
     randomx_difficulty,
     serialize_monero_block_to_hex,
     verify_header,

--- a/base_layer/core/src/transactions/aggregated_body.rs
+++ b/base_layer/core/src/transactions/aggregated_body.rs
@@ -351,7 +351,7 @@ impl AggregateBody {
     /// Lists the number of inputs, outputs, and kernels in the block
     pub fn to_counts_string(&self) -> String {
         format!(
-            "{} input(s), {} output(s), {} kernel(s)",
+            "input(s): {}, output(s): {}, kernel(s): {}",
             self.inputs.len(),
             self.outputs.len(),
             self.kernels.len()

--- a/base_layer/core/src/transactions/transaction_components/test.rs
+++ b/base_layer/core/src/transactions/transaction_components/test.rs
@@ -281,7 +281,7 @@ async fn sender_signature_verification() {
 #[test]
 fn kernel_hash() {
     #[cfg(tari_target_network_mainnet)]
-    if let Network::MainNet = Network::get_current_or_default() {
+    if let Network::MainNet = Network::get_current_or_user_setting_or_default() {
         eprintln!("This test is configured for stagenet only");
         return;
     }
@@ -327,7 +327,7 @@ fn kernel_metadata() {
         .build()
         .unwrap();
     #[cfg(tari_target_network_mainnet)]
-    match Network::get_current_or_default() {
+    match Network::get_current_or_user_setting_or_default() {
         Network::MainNet => {
             eprintln!("This test is configured for stagenet only");
         },

--- a/base_layer/tari_mining_helper_ffi/src/lib.rs
+++ b/base_layer/tari_mining_helper_ffi/src/lib.rs
@@ -387,7 +387,7 @@ mod tests {
     #[test]
     fn detect_change_in_consensus_encoding() {
         #[cfg(tari_target_network_mainnet)]
-        let (nonce, difficulty) = match Network::get_current_or_default() {
+        let (nonce, difficulty) = match Network::get_current_or_user_setting_or_default() {
             Network::MainNet => (9205754023158580549, Difficulty::from_u64(1015).unwrap()),
             Network::StageNet => (12022341430563186162, Difficulty::from_u64(1011).unwrap()),
             _ => panic!("Invalid network for mainnet target"),
@@ -411,7 +411,7 @@ mod tests {
                 // Use this to generate new NONCE and DIFFICULTY
                 // Use ONLY if you know encoding has changed
                 let (difficulty, nonce) = generate_nonce_with_min_difficulty(min_difficulty()).unwrap();
-                let network = Network::get_current_or_default();
+                let network = Network::get_current_or_user_setting_or_default();
                 eprintln!("network = {network:?}");
                 eprintln!("nonce = {:?}", nonce);
                 eprintln!("difficulty = {:?}", difficulty);

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -15,6 +15,7 @@ static-application-info = ["git2"]
 
 [dependencies]
 tari_crypto = { version = "0.20" }
+tari_features = { path = "./tari_features", version = "1.0.0-pre.9"}
 
 anyhow = "1.0.53"
 blake2 = "0.10"

--- a/common/src/configuration/error.rs
+++ b/common/src/configuration/error.rs
@@ -5,6 +5,8 @@ use std::fmt;
 
 use structopt::clap::Error as ClapError;
 
+use crate::network_check::NetworkCheckError;
+
 #[derive(Debug)]
 pub struct ConfigError {
     pub(crate) cause: &'static str,
@@ -14,6 +16,15 @@ pub struct ConfigError {
 impl ConfigError {
     pub(crate) fn new(cause: &'static str, source: Option<String>) -> Self {
         Self { cause, source }
+    }
+}
+
+impl From<NetworkCheckError> for ConfigError {
+    fn from(err: NetworkCheckError) -> Self {
+        Self {
+            cause: "Failed to set the network",
+            source: Some(err.to_string()),
+        }
     }
 }
 

--- a/common/src/configuration/mod.rs
+++ b/common/src/configuration/mod.rs
@@ -69,13 +69,13 @@ pub fn socket_or_multi(addr: &str) -> Result<Multiaddr, Error> {
 
 /// Implement this trait to specify custom configuration overrides for a network when loading the config
 pub trait ConfigOverrideProvider {
-    fn get_config_property_overrides(&self, default_network: Network) -> Vec<(String, String)>;
+    fn get_config_property_overrides(&self, network: &mut Network) -> Vec<(String, String)>;
 }
 
 pub struct NoConfigOverrides;
 
 impl ConfigOverrideProvider for NoConfigOverrides {
-    fn get_config_property_overrides(&self, _default_network: Network) -> Vec<(String, String)> {
+    fn get_config_property_overrides(&self, _network: &mut Network) -> Vec<(String, String)> {
         Vec::new()
     }
 }

--- a/common/src/configuration/network.rs
+++ b/common/src/configuration/network.rs
@@ -49,10 +49,16 @@ pub enum Network {
 }
 
 impl Network {
-    pub fn get_current_or_default() -> Self {
+    pub fn get_current_or_user_setting_or_default() -> Self {
         match CURRENT_NETWORK.get() {
             Some(&network) => network,
-            None => Network::default(),
+            None => {
+                // Check to see if the network has been set by the environment, otherwise use the default
+                match std::env::var("TARI_NETWORK") {
+                    Ok(network) => Network::from_str(network.as_str()).unwrap_or(Network::default()),
+                    Err(_) => Network::default(),
+                }
+            },
         }
     }
 

--- a/common/src/configuration/utils.rs
+++ b/common/src/configuration/utils.rs
@@ -14,6 +14,7 @@ use serde::{
 
 use crate::{
     configuration::{bootstrap::prompt, ConfigOverrideProvider, Network},
+    network_check::set_network_if_choice_valid,
     ConfigError,
     LOG_TARGET,
 };
@@ -83,9 +84,9 @@ pub fn load_configuration_with_overrides<P: AsRef<Path>, TOverride: ConfigOverri
 
     info!(target: LOG_TARGET, "Configuration file loaded.");
     let overrides = overrides.get_config_property_overrides(&mut network);
-    // Set the network environment variable according to the chosen network (this is to ensure that
-    // `get_current_or_user_setting_or_default()` uses the environment variable if the static network is not set)
-    std::env::set_var("TARI_NETWORK", network.as_key_str());
+    // Set the static network variable according to the user chosen network (for use with
+    // `get_current_or_user_setting_or_default()`) -
+    set_network_if_choice_valid(network)?;
 
     if overrides.is_empty() {
         return Ok(cfg);

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -53,6 +53,7 @@
 #[cfg(any(feature = "build", feature = "static-application-info"))]
 pub mod build;
 pub mod exit_codes;
+pub mod network_check;
 #[macro_use]
 mod logging;
 pub mod configuration;

--- a/common/src/network_check.rs
+++ b/common/src/network_check.rs
@@ -20,12 +20,13 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use tari_common::{
+use tari_features::resolver::Target;
+use thiserror::Error;
+
+use crate::{
     configuration::Network,
     exit_codes::{ExitCode, ExitError},
 };
-use tari_features::resolver::Target;
-use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum NetworkCheckError {


### PR DESCRIPTION
Description
---
- Changed the merge mining proxy to evaluate RandomX block template changes lazily, similar to the strategy employed for the SHA3 miner. Evaluating this often is very expensive, especially during busy network times with a highly volatile mempool.
- Removed _new template_ spam from logging
- Fixed a bug where the command-line network argument `igor` specified for the merge mining proxy was not recognized in the network-aware 'DomainSeparatedConsensusHasher'
- Updated the merge mining proxy `config.toml` to be in line with core

Motivation and Context
---
- With recent stress tests on `nextnet` that lasted multiple hours, RandomX mining virtually ground to a halt during the stress test, whereas SHAR3 mining was able to continue. 
- One merge mining proxy that was monitored for 45 min went up to 4.5 GB in memory usage. During that time the connected base node only advanced one block, while the merge mining proxy requested 428 new block templates from the base node, all of them unique. This could account for ~1 GB in memory usage as block templates are discarded after 20 minutes.

How Has This Been Tested?
---
- System-level testing during low network activity (_on `igor`_)
- System-level stress testing:
  - coin split stress test (_on `igor`_)
  - one-side stealth transaction stress test (_on `igor`_)

What process can a PR reviewer use to test or verify this change?
---
Code walk-through, system-level testing 

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
