### PR TITLE
fix: wallet validation during reorgs

### DIFF
--- a/base_layer/wallet/src/output_manager_service/storage/database/backend.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/database/backend.rs
@@ -59,7 +59,7 @@ pub trait OutputManagerBackend: Send + Sync + Clone {
         confirmed: bool,
     ) -> Result<(), OutputManagerStorageError>;
 
-    fn mark_output_as_unspent(&self, hash: FixedHash) -> Result<(), OutputManagerStorageError>;
+    fn mark_output_as_unspent(&self, hash: FixedHash, confirmed: bool) -> Result<(), OutputManagerStorageError>;
     /// This method encumbers the specified outputs into a `PendingTransactionOutputs` record. This is a short term
     /// encumberance in case the app is closed or crashes before transaction neogtiation is complete. These will be
     /// cleared on startup of the service.

--- a/base_layer/wallet/src/output_manager_service/storage/database/mod.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/database/mod.rs
@@ -423,9 +423,9 @@ where T: OutputManagerBackend + 'static
         Ok(())
     }
 
-    pub fn mark_output_as_unspent(&self, hash: HashOutput) -> Result<(), OutputManagerStorageError> {
+    pub fn mark_output_as_unspent(&self, hash: HashOutput, confirmed: bool) -> Result<(), OutputManagerStorageError> {
         let db = self.db.clone();
-        db.mark_output_as_unspent(hash)?;
+        db.mark_output_as_unspent(hash, confirmed)?;
         Ok(())
     }
 

--- a/base_layer/wallet/src/output_manager_service/tasks/txo_validation_task.rs
+++ b/base_layer/wallet/src/output_manager_service/tasks/txo_validation_task.rs
@@ -236,7 +236,7 @@ where
                 if data.height_deleted_at == 0 && output.marked_deleted_at_height.is_some() {
                     // this is mined but not yet spent
                     self.db
-                        .mark_output_as_unspent(output.hash)
+                        .mark_output_as_unspent(output.hash, true)
                         .for_protocol(self.operation_id)?;
                     info!(
                         target: LOG_TARGET,
@@ -395,8 +395,10 @@ where
                     last_spent_output.commitment.to_hex(),
                     self.operation_id
                 );
+                // we mark the output as UnspentMinedUnconfirmed so it wont get picked it by the OMS to be spendable
+                // immediately as we first need to find out if this output is unspent, in a mempool, or spent.
                 self.db
-                    .mark_output_as_unspent(last_spent_output.hash)
+                    .mark_output_as_unspent(last_spent_output.hash, false)
                     .for_protocol(self.operation_id)?;
             } else {
                 debug!(

--- a/base_layer/wallet/tests/output_manager_service_tests/service.rs
+++ b/base_layer/wallet/tests/output_manager_service_tests/service.rs
@@ -311,7 +311,7 @@ async fn fee_estimate() {
     .await;
     oms.output_manager_handle.add_output(uo.clone(), None).await.unwrap();
     backend
-        .mark_output_as_unspent(uo.hash(&oms.key_manager_handle).await.unwrap())
+        .mark_output_as_unspent(uo.hash(&oms.key_manager_handle).await.unwrap(), true)
         .unwrap();
 
     let fee_calc = Fee::new(*create_consensus_constants(0).transaction_weight_params());
@@ -430,7 +430,7 @@ async fn test_utxo_selection_no_chain_metadata() {
         .await;
         oms.add_output(uo.clone(), None).await.unwrap();
         backend
-            .mark_output_as_unspent(uo.hash(&key_manager).await.unwrap())
+            .mark_output_as_unspent(uo.hash(&key_manager).await.unwrap(), true)
             .unwrap();
     }
 
@@ -562,7 +562,7 @@ async fn test_utxo_selection_with_chain_metadata() {
         .await;
         oms.add_output(uo.clone(), None).await.unwrap();
         backend
-            .mark_output_as_unspent(uo.hash(&key_manager).await.unwrap())
+            .mark_output_as_unspent(uo.hash(&key_manager).await.unwrap(), true)
             .unwrap();
     }
 
@@ -710,7 +710,7 @@ async fn test_utxo_selection_with_tx_priority() {
         .await
         .unwrap();
     backend
-        .mark_output_as_unspent(uo_high.hash(&key_manager).await.unwrap())
+        .mark_output_as_unspent(uo_high.hash(&key_manager).await.unwrap(), true)
         .unwrap();
     // Low priority
     let uo_low_2 = make_input_with_features(
@@ -725,7 +725,7 @@ async fn test_utxo_selection_with_tx_priority() {
     .await;
     oms.add_output(uo_low_2.clone(), None).await.unwrap();
     backend
-        .mark_output_as_unspent(uo_low_2.hash(&key_manager).await.unwrap())
+        .mark_output_as_unspent(uo_low_2.hash(&key_manager).await.unwrap(), true)
         .unwrap();
 
     let utxos = oms.get_unspent_outputs().await.unwrap();
@@ -780,7 +780,7 @@ async fn send_not_enough_funds() {
         .await;
         oms.output_manager_handle.add_output(uo.clone(), None).await.unwrap();
         backend
-            .mark_output_as_unspent(uo.hash(&oms.key_manager_handle).await.unwrap())
+            .mark_output_as_unspent(uo.hash(&oms.key_manager_handle).await.unwrap(), true)
             .unwrap();
     }
 
@@ -834,7 +834,7 @@ async fn send_no_change() {
     oms.output_manager_handle.add_output(uo_1.clone(), None).await.unwrap();
 
     backend
-        .mark_output_as_unspent(uo_1.hash(&oms.key_manager_handle).await.unwrap())
+        .mark_output_as_unspent(uo_1.hash(&oms.key_manager_handle).await.unwrap(), true)
         .unwrap();
     let value2 = 8000;
     let uo_2 = create_wallet_output_with_data(
@@ -848,7 +848,7 @@ async fn send_no_change() {
     .unwrap();
     oms.output_manager_handle.add_output(uo_2.clone(), None).await.unwrap();
     backend
-        .mark_output_as_unspent(uo_2.hash(&oms.key_manager_handle).await.unwrap())
+        .mark_output_as_unspent(uo_2.hash(&oms.key_manager_handle).await.unwrap(), true)
         .unwrap();
 
     let stp = oms
@@ -900,7 +900,7 @@ async fn send_not_enough_for_change() {
     .unwrap();
     oms.output_manager_handle.add_output(uo_1.clone(), None).await.unwrap();
     backend
-        .mark_output_as_unspent(uo_1.hash(&oms.key_manager_handle).await.unwrap())
+        .mark_output_as_unspent(uo_1.hash(&oms.key_manager_handle).await.unwrap(), true)
         .unwrap();
     let value2 = MicroMinotari(800);
     let uo_2 = create_wallet_output_with_data(
@@ -914,7 +914,7 @@ async fn send_not_enough_for_change() {
     .unwrap();
     oms.output_manager_handle.add_output(uo_2.clone(), None).await.unwrap();
     backend
-        .mark_output_as_unspent(uo_2.hash(&oms.key_manager_handle).await.unwrap())
+        .mark_output_as_unspent(uo_2.hash(&oms.key_manager_handle).await.unwrap(), true)
         .unwrap();
 
     match oms
@@ -955,7 +955,7 @@ async fn cancel_transaction() {
         .await;
         oms.output_manager_handle.add_output(uo.clone(), None).await.unwrap();
         backend
-            .mark_output_as_unspent(uo.hash(&oms.key_manager_handle).await.unwrap())
+            .mark_output_as_unspent(uo.hash(&oms.key_manager_handle).await.unwrap(), true)
             .unwrap();
     }
     let stp = oms
@@ -1046,7 +1046,7 @@ async fn test_get_balance() {
     total += uo.value;
     oms.output_manager_handle.add_output(uo.clone(), None).await.unwrap();
     backend
-        .mark_output_as_unspent(uo.hash(&oms.key_manager_handle).await.unwrap())
+        .mark_output_as_unspent(uo.hash(&oms.key_manager_handle).await.unwrap(), true)
         .unwrap();
 
     let uo = make_input(
@@ -1059,7 +1059,7 @@ async fn test_get_balance() {
     total += uo.value;
     oms.output_manager_handle.add_output(uo.clone(), None).await.unwrap();
     backend
-        .mark_output_as_unspent(uo.hash(&oms.key_manager_handle).await.unwrap())
+        .mark_output_as_unspent(uo.hash(&oms.key_manager_handle).await.unwrap(), true)
         .unwrap();
 
     let send_value = MicroMinotari::from(1000);
@@ -1114,7 +1114,7 @@ async fn sending_transaction_persisted_while_offline() {
     .await;
     oms.output_manager_handle.add_output(uo.clone(), None).await.unwrap();
     backend
-        .mark_output_as_unspent(uo.hash(&oms.key_manager_handle).await.unwrap())
+        .mark_output_as_unspent(uo.hash(&oms.key_manager_handle).await.unwrap(), true)
         .unwrap();
     let uo = make_input(
         &mut OsRng.clone(),
@@ -1125,7 +1125,7 @@ async fn sending_transaction_persisted_while_offline() {
     .await;
     oms.output_manager_handle.add_output(uo.clone(), None).await.unwrap();
     backend
-        .mark_output_as_unspent(uo.hash(&oms.key_manager_handle).await.unwrap())
+        .mark_output_as_unspent(uo.hash(&oms.key_manager_handle).await.unwrap(), true)
         .unwrap();
 
     let balance = oms.output_manager_handle.get_balance().await.unwrap();
@@ -1215,13 +1215,13 @@ async fn coin_split_with_change() {
     assert!(oms.output_manager_handle.add_output(uo3.clone(), None).await.is_ok());
     // lets mark them as unspent so we can use them
     backend
-        .mark_output_as_unspent(uo1.hash(&oms.key_manager_handle).await.unwrap())
+        .mark_output_as_unspent(uo1.hash(&oms.key_manager_handle).await.unwrap(), true)
         .unwrap();
     backend
-        .mark_output_as_unspent(uo2.hash(&oms.key_manager_handle).await.unwrap())
+        .mark_output_as_unspent(uo2.hash(&oms.key_manager_handle).await.unwrap(), true)
         .unwrap();
     backend
-        .mark_output_as_unspent(uo3.hash(&oms.key_manager_handle).await.unwrap())
+        .mark_output_as_unspent(uo3.hash(&oms.key_manager_handle).await.unwrap(), true)
         .unwrap();
 
     let fee_per_gram = MicroMinotari::from(5);
@@ -1279,13 +1279,13 @@ async fn coin_split_no_change() {
     assert!(oms.output_manager_handle.add_output(uo3.clone(), None).await.is_ok());
     // lets mark then as unspent so we can use them
     backend
-        .mark_output_as_unspent(uo1.hash(&oms.key_manager_handle).await.unwrap())
+        .mark_output_as_unspent(uo1.hash(&oms.key_manager_handle).await.unwrap(), true)
         .unwrap();
     backend
-        .mark_output_as_unspent(uo2.hash(&oms.key_manager_handle).await.unwrap())
+        .mark_output_as_unspent(uo2.hash(&oms.key_manager_handle).await.unwrap(), true)
         .unwrap();
     backend
-        .mark_output_as_unspent(uo3.hash(&oms.key_manager_handle).await.unwrap())
+        .mark_output_as_unspent(uo3.hash(&oms.key_manager_handle).await.unwrap(), true)
         .unwrap();
     let (_tx_id, coin_split_tx, amount) = oms
         .output_manager_handle
@@ -1309,7 +1309,7 @@ async fn it_handles_large_coin_splits() {
     assert!(oms.output_manager_handle.add_output(uo.clone(), None).await.is_ok());
     // lets mark them as unspent so we can use them
     backend
-        .mark_output_as_unspent(uo.hash(&oms.key_manager_handle).await.unwrap())
+        .mark_output_as_unspent(uo.hash(&oms.key_manager_handle).await.unwrap(), true)
         .unwrap();
 
     let fee_per_gram = MicroMinotari::from(1);
@@ -1355,7 +1355,7 @@ async fn test_txo_validation() {
         .await
         .unwrap();
     oms_db
-        .mark_output_as_unspent(output1.hash(&oms.key_manager_handle).await.unwrap())
+        .mark_output_as_unspent(output1.hash(&oms.key_manager_handle).await.unwrap(), true)
         .unwrap();
 
     let output2_value = 2_000_000;
@@ -1373,7 +1373,7 @@ async fn test_txo_validation() {
         .await
         .unwrap();
     oms_db
-        .mark_output_as_unspent(output2.hash(&oms.key_manager_handle).await.unwrap())
+        .mark_output_as_unspent(output2.hash(&oms.key_manager_handle).await.unwrap(), true)
         .unwrap();
 
     let output3_value = 4_000_000;
@@ -1391,7 +1391,7 @@ async fn test_txo_validation() {
         .unwrap();
 
     oms_db
-        .mark_output_as_unspent(output3.hash(&oms.key_manager_handle).await.unwrap())
+        .mark_output_as_unspent(output3.hash(&oms.key_manager_handle).await.unwrap(), true)
         .unwrap();
 
     let mut block1_header = BlockHeader::new(1);

--- a/base_layer/wallet/tests/output_manager_service_tests/storage.rs
+++ b/base_layer/wallet/tests/output_manager_service_tests/storage.rs
@@ -60,7 +60,7 @@ pub async fn test_db_backend<T: OutputManagerBackend + 'static>(backend: T) {
             .unwrap();
         kmo.wallet_output.features.maturity = i;
         db.add_unspent_output(kmo.clone()).unwrap();
-        db.mark_output_as_unspent(kmo.hash).unwrap();
+        db.mark_output_as_unspent(kmo.hash, true).unwrap();
         unspent_outputs.push(kmo);
     }
 
@@ -111,7 +111,7 @@ pub async fn test_db_backend<T: OutputManagerBackend + 'static>(backend: T) {
                 .await
                 .unwrap();
             db.add_unspent_output(kmo.clone()).unwrap();
-            db.mark_output_as_unspent(kmo.hash).unwrap();
+            db.mark_output_as_unspent(kmo.hash, true).unwrap();
             pending_tx.outputs_to_be_spent.push(kmo);
         }
         for _ in 0..2 {
@@ -356,7 +356,7 @@ pub async fn test_short_term_encumberance() {
             .unwrap();
         kmo.wallet_output.features.maturity = i;
         db.add_unspent_output(kmo.clone()).unwrap();
-        db.mark_output_as_unspent(kmo.hash).unwrap();
+        db.mark_output_as_unspent(kmo.hash, true).unwrap();
         unspent_outputs.push(kmo);
     }
 

--- a/base_layer/wallet/tests/transaction_service_tests/service.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/service.rs
@@ -595,7 +595,7 @@ async fn manage_single_transaction() {
 
     alice_oms.add_output(uo1.clone(), None).await.unwrap();
     alice_db
-        .mark_output_as_unspent(uo1.hash(&alice_key_manager_handle).await.unwrap())
+        .mark_output_as_unspent(uo1.hash(&alice_key_manager_handle).await.unwrap(), true)
         .unwrap();
 
     let message = "TAKE MAH MONEYS!".to_string();
@@ -749,7 +749,7 @@ async fn large_interactive_transaction() {
         .await;
         alice_oms.add_output(uo.clone(), None).await.unwrap();
         alice_db
-            .mark_output_as_unspent(uo.hash(&alice_key_manager_handle).await.unwrap())
+            .mark_output_as_unspent(uo.hash(&alice_key_manager_handle).await.unwrap(), true)
             .unwrap();
     }
     let transaction_value = output_value * (outputs_count - 1);
@@ -893,7 +893,7 @@ async fn single_transaction_to_self() {
 
     alice_oms.add_output(uo1.clone(), None).await.unwrap();
     alice_db
-        .mark_output_as_unspent(uo1.hash(&key_manager_handle).await.unwrap())
+        .mark_output_as_unspent(uo1.hash(&key_manager_handle).await.unwrap(), true)
         .unwrap();
     let message = "TAKE MAH _OWN_ MONEYS!".to_string();
     let value = 10000.into();
@@ -977,7 +977,7 @@ async fn large_coin_split_transaction() {
 
     alice_oms.add_output(uo1.clone(), None).await.unwrap();
     alice_db
-        .mark_output_as_unspent(uo1.hash(&key_manager_handle).await.unwrap())
+        .mark_output_as_unspent(uo1.hash(&key_manager_handle).await.unwrap(), true)
         .unwrap();
 
     let fee_per_gram = MicroMinotari::from(1);
@@ -1064,7 +1064,7 @@ async fn single_transaction_burn_tari() {
 
     alice_oms.add_output(uo1.clone(), None).await.unwrap();
     alice_db
-        .mark_output_as_unspent(uo1.hash(&key_manager_handle).await.unwrap())
+        .mark_output_as_unspent(uo1.hash(&key_manager_handle).await.unwrap(), true)
         .unwrap();
     let message = "BURN MAH _OWN_ MONEYS!".to_string();
     let burn_value = 10000.into();
@@ -1212,7 +1212,7 @@ async fn send_one_sided_transaction_to_other() {
     let mut alice_oms_clone = alice_oms.clone();
     alice_oms_clone.add_output(uo1.clone(), None).await.unwrap();
     alice_db
-        .mark_output_as_unspent(uo1.hash(&key_manager_handle).await.unwrap())
+        .mark_output_as_unspent(uo1.hash(&key_manager_handle).await.unwrap(), true)
         .unwrap();
 
     let message = "SEE IF YOU CAN CATCH THIS ONE..... SIDED TX!".to_string();
@@ -1355,7 +1355,7 @@ async fn recover_one_sided_transaction() {
     let mut alice_oms_clone = alice_oms;
     alice_oms_clone.add_output(uo1.clone(), None).await.unwrap();
     alice_db
-        .mark_output_as_unspent(uo1.hash(&alice_key_manager_handle).await.unwrap())
+        .mark_output_as_unspent(uo1.hash(&alice_key_manager_handle).await.unwrap(), true)
         .unwrap();
 
     let message = "".to_string();
@@ -1460,7 +1460,7 @@ async fn test_htlc_send_and_claim() {
     .await;
     alice_oms.add_output(uo1.clone(), None).await.unwrap();
     alice_db
-        .mark_output_as_unspent(uo1.hash(&key_manager_handle).await.unwrap())
+        .mark_output_as_unspent(uo1.hash(&key_manager_handle).await.unwrap(), true)
         .unwrap();
 
     let message = "".to_string();
@@ -1584,7 +1584,7 @@ async fn send_one_sided_transaction_to_self() {
     let mut alice_oms_clone = alice_oms;
     alice_oms_clone.add_output(uo1.clone(), None).await.unwrap();
     alice_db
-        .mark_output_as_unspent(uo1.hash(&key_manager_handle).await.unwrap())
+        .mark_output_as_unspent(uo1.hash(&key_manager_handle).await.unwrap(), true)
         .unwrap();
 
     let message = "SEE IF YOU CAN CATCH THIS ONE..... SIDED TX!".to_string();
@@ -1727,7 +1727,7 @@ async fn manage_multiple_transactions() {
     .await;
     bob_oms.add_output(uo2.clone(), None).await.unwrap();
     bob_db
-        .mark_output_as_unspent(uo2.hash(&bob_key_manager_handle).await.unwrap())
+        .mark_output_as_unspent(uo2.hash(&bob_key_manager_handle).await.unwrap(), true)
         .unwrap();
     let uo3 = make_input(
         &mut OsRng,
@@ -1738,7 +1738,7 @@ async fn manage_multiple_transactions() {
     .await;
     carol_oms.add_output(uo3.clone(), None).await.unwrap();
     carol_db
-        .mark_output_as_unspent(uo3.hash(&key_manager_handle).await.unwrap())
+        .mark_output_as_unspent(uo3.hash(&key_manager_handle).await.unwrap(), true)
         .unwrap();
 
     // Add some funds to Alices wallet
@@ -1751,7 +1751,7 @@ async fn manage_multiple_transactions() {
     .await;
     alice_oms.add_output(uo1a.clone(), None).await.unwrap();
     alice_db
-        .mark_output_as_unspent(uo1a.hash(&alice_key_manager_handle).await.unwrap())
+        .mark_output_as_unspent(uo1a.hash(&alice_key_manager_handle).await.unwrap(), true)
         .unwrap();
     let uo1b = make_input(
         &mut OsRng,
@@ -1762,7 +1762,7 @@ async fn manage_multiple_transactions() {
     .await;
     alice_oms.add_output(uo1b.clone(), None).await.unwrap();
     alice_db
-        .mark_output_as_unspent(uo1b.hash(&alice_key_manager_handle).await.unwrap())
+        .mark_output_as_unspent(uo1b.hash(&alice_key_manager_handle).await.unwrap(), true)
         .unwrap();
     let uo1c = make_input(
         &mut OsRng,
@@ -1773,7 +1773,7 @@ async fn manage_multiple_transactions() {
     .await;
     alice_oms.add_output(uo1c.clone(), None).await.unwrap();
     alice_db
-        .mark_output_as_unspent(uo1c.hash(&alice_key_manager_handle).await.unwrap())
+        .mark_output_as_unspent(uo1c.hash(&alice_key_manager_handle).await.unwrap(), true)
         .unwrap();
 
     // A series of interleaved transactions. First with Bob and Carol offline and then two with them online
@@ -1958,7 +1958,7 @@ async fn test_accepting_unknown_tx_id_and_malformed_reply() {
         .unwrap();
     alice_ts_interface
         .oms_db
-        .mark_output_as_unspent(uo.hash(&alice_ts_interface.key_manager_handle).await.unwrap())
+        .mark_output_as_unspent(uo.hash(&alice_ts_interface.key_manager_handle).await.unwrap(), true)
         .unwrap();
 
     let bob_address = TariAddress::new(bob_node_identity.public_key().clone(), Network::LocalNet);
@@ -2057,7 +2057,7 @@ async fn finalize_tx_with_incorrect_pubkey() {
         .unwrap();
     bob_ts_interface
         .oms_db
-        .mark_output_as_unspent(uo.hash(&bob_ts_interface.key_manager_handle).await.unwrap())
+        .mark_output_as_unspent(uo.hash(&bob_ts_interface.key_manager_handle).await.unwrap(), true)
         .unwrap();
     let mut stp = bob_ts_interface
         .output_manager_service_handle
@@ -2182,7 +2182,7 @@ async fn finalize_tx_with_missing_output() {
         .unwrap();
     bob_ts_interface
         .oms_db
-        .mark_output_as_unspent(uo.hash(&bob_ts_interface.key_manager_handle).await.unwrap())
+        .mark_output_as_unspent(uo.hash(&bob_ts_interface.key_manager_handle).await.unwrap(), true)
         .unwrap();
 
     let mut stp = bob_ts_interface
@@ -2358,7 +2358,7 @@ async fn discovery_async_return_test() {
     .await;
     alice_oms.add_output(uo1a.clone(), None).await.unwrap();
     alice_db
-        .mark_output_as_unspent(uo1a.hash(&alice_key_manager_handle).await.unwrap())
+        .mark_output_as_unspent(uo1a.hash(&alice_key_manager_handle).await.unwrap(), true)
         .unwrap();
     let uo1b = make_input(
         &mut OsRng,
@@ -2369,7 +2369,7 @@ async fn discovery_async_return_test() {
     .await;
     alice_oms.add_output(uo1b.clone(), None).await.unwrap();
     alice_db
-        .mark_output_as_unspent(uo1b.hash(&alice_key_manager_handle).await.unwrap())
+        .mark_output_as_unspent(uo1b.hash(&alice_key_manager_handle).await.unwrap(), true)
         .unwrap();
     let uo1c = make_input(
         &mut OsRng,
@@ -2380,7 +2380,7 @@ async fn discovery_async_return_test() {
     .await;
     alice_oms.add_output(uo1c.clone(), None).await.unwrap();
     alice_db
-        .mark_output_as_unspent(uo1c.hash(&alice_key_manager_handle).await.unwrap())
+        .mark_output_as_unspent(uo1c.hash(&alice_key_manager_handle).await.unwrap(), true)
         .unwrap();
 
     let initial_balance = alice_oms.get_balance().await.unwrap();
@@ -2713,7 +2713,7 @@ async fn test_transaction_cancellation() {
         .unwrap();
     alice_ts_interface
         .oms_db
-        .mark_output_as_unspent(uo.hash(&alice_ts_interface.key_manager_handle).await.unwrap())
+        .mark_output_as_unspent(uo.hash(&alice_ts_interface.key_manager_handle).await.unwrap(), true)
         .unwrap();
 
     let amount_sent = 100000 * uT;
@@ -3053,7 +3053,7 @@ async fn test_direct_vs_saf_send_of_tx_reply_and_finalize() {
         .unwrap();
     alice_ts_interface
         .oms_db
-        .mark_output_as_unspent(uo.hash(&alice_ts_interface.key_manager_handle).await.unwrap())
+        .mark_output_as_unspent(uo.hash(&alice_ts_interface.key_manager_handle).await.unwrap(), true)
         .unwrap();
 
     let amount_sent = 100000 * uT;
@@ -3248,7 +3248,7 @@ async fn test_direct_vs_saf_send_of_tx_reply_and_finalize() {
         .unwrap();
     alice_ts_interface
         .oms_db
-        .mark_output_as_unspent(uo.hash(&alice_ts_interface.key_manager_handle).await.unwrap())
+        .mark_output_as_unspent(uo.hash(&alice_ts_interface.key_manager_handle).await.unwrap(), true)
         .unwrap();
 
     let amount_sent = 20000 * uT;
@@ -3366,7 +3366,7 @@ async fn test_tx_direct_send_behaviour() {
         .unwrap();
     alice_ts_interface
         .oms_db
-        .mark_output_as_unspent(uo.hash(&alice_ts_interface.key_manager_handle).await.unwrap())
+        .mark_output_as_unspent(uo.hash(&alice_ts_interface.key_manager_handle).await.unwrap(), true)
         .unwrap();
     let uo = make_input(
         &mut OsRng,
@@ -3382,7 +3382,7 @@ async fn test_tx_direct_send_behaviour() {
         .unwrap();
     alice_ts_interface
         .oms_db
-        .mark_output_as_unspent(uo.hash(&alice_ts_interface.key_manager_handle).await.unwrap())
+        .mark_output_as_unspent(uo.hash(&alice_ts_interface.key_manager_handle).await.unwrap(), true)
         .unwrap();
     let uo = make_input(
         &mut OsRng,
@@ -3398,7 +3398,7 @@ async fn test_tx_direct_send_behaviour() {
         .unwrap();
     alice_ts_interface
         .oms_db
-        .mark_output_as_unspent(uo.hash(&alice_ts_interface.key_manager_handle).await.unwrap())
+        .mark_output_as_unspent(uo.hash(&alice_ts_interface.key_manager_handle).await.unwrap(), true)
         .unwrap();
     let uo = make_input(
         &mut OsRng,
@@ -3414,7 +3414,7 @@ async fn test_tx_direct_send_behaviour() {
         .unwrap();
     alice_ts_interface
         .oms_db
-        .mark_output_as_unspent(uo.hash(&alice_ts_interface.key_manager_handle).await.unwrap())
+        .mark_output_as_unspent(uo.hash(&alice_ts_interface.key_manager_handle).await.unwrap(), true)
         .unwrap();
 
     let amount_sent = 100000 * uT;
@@ -3874,7 +3874,7 @@ async fn test_transaction_resending() {
         .unwrap();
     alice_ts_interface
         .oms_db
-        .mark_output_as_unspent(uo.hash(&alice_ts_interface.key_manager_handle).await.unwrap())
+        .mark_output_as_unspent(uo.hash(&alice_ts_interface.key_manager_handle).await.unwrap(), true)
         .unwrap();
 
     let amount_sent = 100000 * uT;
@@ -4389,7 +4389,7 @@ async fn test_replying_to_cancelled_tx() {
         .unwrap();
     alice_ts_interface
         .oms_db
-        .mark_output_as_unspent(uo.hash(&alice_ts_interface.key_manager_handle).await.unwrap())
+        .mark_output_as_unspent(uo.hash(&alice_ts_interface.key_manager_handle).await.unwrap(), true)
         .unwrap();
     let amount_sent = 100000 * uT;
     let bob_address = TariAddress::new(bob_node_identity.public_key().clone(), Network::LocalNet);
@@ -4521,7 +4521,7 @@ async fn test_transaction_timeout_cancellation() {
         .unwrap();
     alice_ts_interface
         .oms_db
-        .mark_output_as_unspent(uo.hash(&alice_ts_interface.key_manager_handle).await.unwrap())
+        .mark_output_as_unspent(uo.hash(&alice_ts_interface.key_manager_handle).await.unwrap(), true)
         .unwrap();
 
     let amount_sent = 10000 * uT;
@@ -4789,7 +4789,7 @@ async fn transaction_service_tx_broadcast() {
         .unwrap();
     alice_ts_interface
         .oms_db
-        .mark_output_as_unspent(uo.hash(&alice_ts_interface.key_manager_handle).await.unwrap())
+        .mark_output_as_unspent(uo.hash(&alice_ts_interface.key_manager_handle).await.unwrap(), true)
         .unwrap();
 
     let uo2 = make_input(
@@ -4806,7 +4806,7 @@ async fn transaction_service_tx_broadcast() {
         .unwrap();
     alice_ts_interface
         .oms_db
-        .mark_output_as_unspent(uo2.hash(&alice_ts_interface.key_manager_handle).await.unwrap())
+        .mark_output_as_unspent(uo2.hash(&alice_ts_interface.key_manager_handle).await.unwrap(), true)
         .unwrap();
 
     let amount_sent1 = 100000 * uT;
@@ -5354,7 +5354,7 @@ async fn test_update_faux_tx_on_oms_validation() {
             .unwrap();
         let _result = alice_ts_interface
             .oms_db
-            .mark_output_as_unspent(uo.hash(&alice_ts_interface.key_manager_handle).await.unwrap());
+            .mark_output_as_unspent(uo.hash(&alice_ts_interface.key_manager_handle).await.unwrap(), true);
         alice_ts_interface
             .oms_db
             .set_received_output_mined_height_and_status(

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -10232,6 +10232,7 @@ mod test {
                             .runtime
                             .block_on(uo.hash(&(*alice_wallet).wallet.key_manager_service))
                             .unwrap(),
+                        true,
                     )
                     .unwrap();
             }
@@ -10365,6 +10366,7 @@ mod test {
                             .runtime
                             .block_on(uo.hash(&(*alice_wallet).wallet.key_manager_service))
                             .unwrap(),
+                        true,
                     )
                     .unwrap();
             }
@@ -10577,6 +10579,7 @@ mod test {
                             .runtime
                             .block_on(uo.hash(&(*alice_wallet).wallet.key_manager_service))
                             .unwrap(),
+                        true,
                     )
                     .unwrap();
             }


### PR DESCRIPTION
Description
---
Fixes wallet validation during reorgs.

Motivation and Context
---
spent outputs that have been reorged, should not be marked as unspent. They should be marked as unspen_mined_unconfirmed
If they are marked as unspent it means the wallet can immeadatly grab the output and use it in a new transaction. The validation service first needs to find out what the status of that output is, allthou the wallet knows the original block the transaction was mined in was reorged out, it needs to figure out if the transaction is still mined, unmined or mempool.  
