### PR TITLE
test: fix cucumber network environment

### DIFF
--- a/integration_tests/src/base_node_process.rs
+++ b/integration_tests/src/base_node_process.rs
@@ -33,7 +33,10 @@ use minotari_app_utilities::identity_management::save_as_json;
 use minotari_node::{run_base_node, BaseNodeConfig, MetricsConfig};
 use minotari_node_grpc_client::BaseNodeGrpcClient;
 use rand::rngs::OsRng;
-use tari_common::configuration::{CommonConfig, MultiaddrList};
+use tari_common::{
+    configuration::{CommonConfig, MultiaddrList},
+    network_check::set_network_if_choice_valid,
+};
 use tari_comms::{multiaddr::Multiaddr, peer_manager::PeerFeatures, NodeIdentity};
 use tari_comms_dht::{DbConnectionUrl, DhtConfig};
 use tari_p2p::{auto_update::AutoUpdateConfig, Network, PeerSeedsConfig, TransportType};
@@ -88,6 +91,9 @@ pub async fn spawn_base_node_with_config(
     peers: Vec<String>,
     mut base_node_config: BaseNodeConfig,
 ) {
+    std::env::set_var("TARI_NETWORK", "localnet");
+    set_network_if_choice_valid(Network::LocalNet).unwrap();
+
     let port: u64;
     let grpc_port: u64;
     let temp_dir_path: PathBuf;

--- a/integration_tests/src/merge_mining_proxy.rs
+++ b/integration_tests/src/merge_mining_proxy.rs
@@ -27,7 +27,7 @@ use minotari_app_utilities::common_cli_args::CommonCliArgs;
 use minotari_merge_mining_proxy::{merge_miner, Cli};
 use minotari_wallet_grpc_client::WalletGrpcClient;
 use serde_json::{json, Value};
-use tari_common::configuration::Network;
+use tari_common::{configuration::Network, network_check::set_network_if_choice_valid};
 use tari_common_types::{tari_address::TariAddress, types::PublicKey};
 use tari_utilities::ByteArray;
 use tempfile::tempdir;
@@ -74,6 +74,9 @@ pub async fn register_merge_mining_proxy_process(
 
 impl MergeMiningProxyProcess {
     pub async fn start(&self, world: &mut TariWorld) {
+        std::env::set_var("TARI_NETWORK", "localnet");
+        set_network_if_choice_valid(Network::LocalNet).unwrap();
+
         let temp_dir = tempdir().unwrap();
         let data_dir = temp_dir.path().join("data/miner");
         let data_dir_str = data_dir.clone().into_os_string().into_string().unwrap();

--- a/integration_tests/src/miner.rs
+++ b/integration_tests/src/miner.rs
@@ -35,7 +35,7 @@ use minotari_app_utilities::common_cli_args::CommonCliArgs;
 use minotari_miner::{run_miner, Cli};
 use minotari_node_grpc_client::BaseNodeGrpcClient;
 use minotari_wallet_grpc_client::WalletGrpcClient;
-use tari_common::configuration::Network;
+use tari_common::{configuration::Network, network_check::set_network_if_choice_valid};
 use tari_common_types::{tari_address::TariAddress, types::PublicKey};
 use tari_core::{
     consensus::ConsensusManager,
@@ -88,6 +88,9 @@ impl MinerProcess {
         miner_min_diff: Option<u64>,
         miner_max_diff: Option<u64>,
     ) {
+        std::env::set_var("TARI_NETWORK", "localnet");
+        set_network_if_choice_valid(Network::LocalNet).unwrap();
+
         let mut wallet_client = create_wallet_client(world, self.wallet_name.clone())
             .await
             .expect("wallet grpc client");

--- a/integration_tests/src/wallet_process.rs
+++ b/integration_tests/src/wallet_process.rs
@@ -27,7 +27,10 @@ use minotari_app_utilities::common_cli_args::CommonCliArgs;
 use minotari_console_wallet::{run_wallet_with_cli, Cli};
 use minotari_wallet::{transaction_service::config::TransactionRoutingMechanism, WalletConfig};
 use minotari_wallet_grpc_client::WalletGrpcClient;
-use tari_common::configuration::{CommonConfig, MultiaddrList};
+use tari_common::{
+    configuration::{CommonConfig, MultiaddrList},
+    network_check::set_network_if_choice_valid,
+};
 use tari_comms::multiaddr::Multiaddr;
 use tari_comms_dht::{DbConnectionUrl, DhtConfig};
 use tari_p2p::{auto_update::AutoUpdateConfig, Network, PeerSeedsConfig, TransportType};
@@ -62,6 +65,9 @@ pub async fn spawn_wallet(
     routing_mechanism: Option<TransactionRoutingMechanism>,
     cli: Option<Cli>,
 ) {
+    std::env::set_var("TARI_NETWORK", "localnet");
+    set_network_if_choice_valid(Network::LocalNet).unwrap();
+
     let port: u64;
     let grpc_port: u64;
     let temp_dir_path: PathBuf;


### PR DESCRIPTION
Description
---
Fixed cucumber network environment

Motivation and Context
---
The cucumber environment uses a single runtime environment and the network should be set prior to use.
Fixes cucumber test failures introduced by #6170.

How Has This Been Tested?
---
Applicable cucumber pass

What process can a PR reviewer use to test or verify this change?
---
Verify that `Scenario: Clear out mempool` passes
**Note:** #6172 also introduced other cucumber errors

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
