### PR TITLE
chore: add localnet gen block

### DIFF
--- a/base_layer/core/src/chain_storage/tests/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/tests/blockchain_database.rs
@@ -477,22 +477,6 @@ mod prepare_new_block {
 mod fetch_header_containing_kernel_mmr {
     use super::*;
     use crate::transactions::key_manager::create_memory_db_key_manager;
-
-    #[test]
-    fn it_returns_genesis() {
-        let db = setup();
-        let genesis = db.fetch_block(0, true).unwrap();
-        assert_eq!(genesis.block().body.kernels().len(), 1);
-        let mut mmr_position = 0;
-        genesis.block().body.kernels().iter().for_each(|_| {
-            let header = db.fetch_header_containing_kernel_mmr(mmr_position).unwrap();
-            assert_eq!(header.height(), 0);
-            mmr_position += 1;
-        });
-        let err = db.fetch_header_containing_kernel_mmr(mmr_position).unwrap_err();
-        matches!(err, ChainStorageError::ValueNotFound { .. });
-    }
-
     #[tokio::test]
     async fn it_returns_corresponding_header() {
         let db = setup();

--- a/base_layer/core/src/consensus/consensus_constants.rs
+++ b/base_layer/core/src/consensus/consensus_constants.rs
@@ -394,7 +394,7 @@ impl ConsensusConstants {
             max_randomx_seed_height: u64::MAX,
             max_extra_field_size: 200,
             proof_of_work: algos,
-            faucet_value: ESMERALDA_FAUCET_VALUE.into(), // The esmeralda genesis block is re-used for localnet
+            faucet_value: 0.into(),
             transaction_weight: TransactionWeight::latest(),
             max_script_byte_size: 2048,
             input_version_range,

--- a/base_layer/core/src/test_helpers/blockchain.rs
+++ b/base_layer/core/src/test_helpers/blockchain.rs
@@ -34,7 +34,7 @@ use tari_common_types::{
     tari_address::TariAddress,
     types::{Commitment, FixedHash, HashOutput, PublicKey, Signature},
 };
-use tari_mmr::sparse_merkle_tree::{DeleteResult, NodeKey, ValueHash};
+use tari_mmr::sparse_merkle_tree::{NodeKey, ValueHash};
 use tari_storage::lmdb_store::LMDBConfig;
 use tari_test_utils::paths::create_temporary_data_path;
 use tari_utilities::ByteArray;
@@ -491,21 +491,6 @@ pub async fn create_main_chain<T: Into<BlockSpecs>>(
     });
 
     (names, chain)
-}
-
-pub fn rewind_smt(block: Arc<ChainBlock>, smt: &mut OutputSmt) {
-    for input in block.block().body.inputs() {
-        let smt_key = NodeKey::try_from(input.commitment().unwrap().as_bytes()).unwrap();
-        let smt_node = ValueHash::try_from(input.smt_hash(block.header().height).as_slice()).unwrap();
-        smt.insert(smt_key, smt_node).unwrap();
-    }
-    for output in block.block().body.outputs() {
-        let smt_key = NodeKey::try_from(output.commitment.as_bytes()).unwrap();
-        match smt.delete(&smt_key).unwrap() {
-            DeleteResult::Deleted(_value_hash) => {},
-            DeleteResult::KeyNotFound => panic!("key should be found"),
-        };
-    }
 }
 
 pub async fn create_orphan_chain<T: Into<BlockSpecs>>(

--- a/base_layer/tari_mining_helper_ffi/src/lib.rs
+++ b/base_layer/tari_mining_helper_ffi/src/lib.rs
@@ -395,7 +395,7 @@ mod tests {
         #[cfg(tari_target_network_nextnet)]
         let (nonce, difficulty) = (8721374869059089110, Difficulty::from_u64(3037).unwrap());
         #[cfg(not(any(tari_target_network_mainnet, tari_target_network_nextnet)))]
-        let (nonce, difficulty) = (9860518124890236943, Difficulty::from_u64(2724).unwrap());
+        let (nonce, difficulty) = (8520885611996410570, Difficulty::from_u64(3143).unwrap());
         unsafe {
             let mut error = -1;
             let error_ptr = &mut error as *mut c_int;

--- a/base_layer/tari_mining_helper_ffi/src/lib.rs
+++ b/base_layer/tari_mining_helper_ffi/src/lib.rs
@@ -388,12 +388,12 @@ mod tests {
     fn detect_change_in_consensus_encoding() {
         #[cfg(tari_target_network_mainnet)]
         let (nonce, difficulty) = match Network::get_current_or_user_setting_or_default() {
-            Network::MainNet => (9205754023158580549, Difficulty::from_u64(1015).unwrap()),
-            Network::StageNet => (12022341430563186162, Difficulty::from_u64(1011).unwrap()),
+            Network::MainNet => (3145418102407526886, Difficulty::from_u64(1505).unwrap()),
+            Network::StageNet => (135043993867732261, Difficulty::from_u64(1059).unwrap()),
             _ => panic!("Invalid network for mainnet target"),
         };
         #[cfg(tari_target_network_nextnet)]
-        let (nonce, difficulty) = (8721374869059089110, Difficulty::from_u64(3037).unwrap());
+        let (nonce, difficulty) = (5154919981564263219, Difficulty::from_u64(2950).unwrap());
         #[cfg(not(any(tari_target_network_mainnet, tari_target_network_nextnet)))]
         let (nonce, difficulty) = (8520885611996410570, Difficulty::from_u64(3143).unwrap());
         unsafe {

--- a/integration_tests/tests/features/BlockTemplate.feature
+++ b/integration_tests/tests/features/BlockTemplate.feature
@@ -4,7 +4,7 @@
 @block-template
 Feature: BlockTemplate
 
-@critical @pie
+@critical
 Scenario: Verify UTXO and kernel MMR size in header
     Given I have a seed node SEED_A
     When I have 1 base nodes connected to all seed nodes

--- a/integration_tests/tests/features/BlockTemplate.feature
+++ b/integration_tests/tests/features/BlockTemplate.feature
@@ -4,7 +4,7 @@
 @block-template
 Feature: BlockTemplate
 
-@critical
+@critical @pie
 Scenario: Verify UTXO and kernel MMR size in header
     Given I have a seed node SEED_A
     When I have 1 base nodes connected to all seed nodes

--- a/integration_tests/tests/steps/node_steps.rs
+++ b/integration_tests/tests/steps/node_steps.rs
@@ -687,7 +687,7 @@ async fn no_meddling_with_data(world: &mut TariWorld, node: String) {
         Ok(_) => panic!("The block should not have been valid"),
         Err(e) => assert_eq!(
             "Chain storage error: Validation error: Block validation error: MMR size for Kernel does not match. \
-             Expected: 3, received: 4"
+             Expected: 2, received: 3"
                 .to_string(),
             e.message()
         ),
@@ -712,7 +712,7 @@ async fn no_meddling_with_data(world: &mut TariWorld, node: String) {
         Ok(_) => panic!("The block should not have been valid"),
         Err(e) => assert_eq!(
             "Chain storage error: Validation error: Block validation error: MMR size for UTXO does not match. \
-             Expected: 102, received: 103"
+             Expected: 2, received: 3"
                 .to_string(),
             e.message()
         ),


### PR DESCRIPTION
Description
---
added localnet gen block so that cucumbers can use that block. Local net used esmeralda block before, but when rewinding back to 0, the ouput_mr will be different between esmeralda and localnet, so we need a unique block for local net as well. 
