### PR TITLE
feat: make the make_it_rain submission rate a float

### DIFF
--- a/applications/minotari_console_wallet/src/automation/commands.rs
+++ b/applications/minotari_console_wallet/src/automation/commands.rs
@@ -349,7 +349,7 @@ pub async fn discover_peer(
 pub async fn make_it_rain(
     wallet_transaction_service: TransactionServiceHandle,
     fee_per_gram: u64,
-    transactions_per_second: u32,
+    transactions_per_second: f64,
     duration: Duration,
     start_amount: MicroMinotari,
     increase_amount: MicroMinotari,
@@ -358,6 +358,13 @@ pub async fn make_it_rain(
     transaction_type: MakeItRainTransactionType,
     message: String,
 ) -> Result<(), CommandError> {
+    // Limit the transactions per second to a reasonable range
+    // Notes:
+    // - The 'transactions_per_second' is best effort and not guaranteed.
+    // - If a slower rate is requested as what is achievable, transactions will be delayed to match the rate.
+    // - If a faster rate is requested as what is achievable, the maximum rate will be that of the integrated system.
+    // - The default value of 25/s may not be achievable.
+    let transactions_per_second = transactions_per_second.abs().max(0.01).min(250.0);
     // We are spawning this command in parallel, thus not collecting transaction IDs
     tokio::task::spawn(async move {
         // Wait until specified test start time
@@ -378,7 +385,7 @@ pub async fn make_it_rain(
         );
         sleep(Duration::from_millis(delay_ms)).await;
 
-        let num_txs = (f64::from(transactions_per_second) * duration.as_secs() as f64) as usize;
+        let num_txs = (transactions_per_second * duration.as_secs() as f64) as usize;
         let started_at = Utc::now();
 
         struct TransactionSendStats {
@@ -409,7 +416,7 @@ pub async fn make_it_rain(
 
                 // Manage transaction submission rate
                 let actual_ms = (Utc::now() - started_at).num_milliseconds();
-                let target_ms = (i as f64 * (1000.0 / f64::from(transactions_per_second))) as i64;
+                let target_ms = (i as f64 * (1000.0 / transactions_per_second)) as i64;
                 trace!(
                     target: LOG_TARGET,
                     "make-it-rain {}: target {:?} ms vs. actual {:?} ms", i, target_ms, actual_ms

--- a/applications/minotari_console_wallet/src/cli.rs
+++ b/applications/minotari_console_wallet/src/cli.rs
@@ -163,8 +163,8 @@ pub struct MakeItRainArgs {
     pub destination: TariAddress,
     #[clap(short, long, alias="amount", default_value_t = tari_amount::T)]
     pub start_amount: MicroMinotari,
-    #[clap(short, long, alias = "tps", default_value_t = 25)]
-    pub transactions_per_second: u32,
+    #[clap(short, long, alias = "tps", default_value_t = 25.0)]
+    pub transactions_per_second: f64,
     #[clap(short, long, parse(try_from_str = parse_duration), default_value="60")]
     pub duration: Duration,
     #[clap(long, default_value_t=tari_amount::T)]

--- a/integration_tests/tests/features/StressTest.feature
+++ b/integration_tests/tests/features/StressTest.feature
@@ -22,7 +22,7 @@ Feature: Stress Test
         # When mining node MINER mines 3 blocks
         # When mining node MINER mines <NumCoinsplitsNeeded> blocks
         # Then all nodes are on the same chain tip
-        # Then wallet WALLET_A detects all transactions as Mined_or_Faux_Confirmed
+        # Then wallet WALLET_A detects all transactions as Mined_or_OneSidedConfirmed
         # When I send <NumTransactions> transactions of 1111 uT each from wallet WALLET_A to wallet WALLET_B at fee_per_gram 4
         # # Mine enough blocks for the first block of transactions to be confirmed.
         # When mining node MINER mines 4 blocks
@@ -30,9 +30,9 @@ Feature: Stress Test
         # # Now wait until all transactions are detected as confirmed in WALLET_A, continue to mine blocks if transactions
         # # are not found to be confirmed as sometimes the previous mining occurs faster than transactions are submitted
         # # to the mempool
-        # Then while mining via SHA3 miner MINER all transactions in wallet WALLET_A are found to be Mined_or_Faux_Confirmed
-        # # Then wallet WALLET_B detects all transactions as Mined_or_Faux_Confirmed
-        # Then while mining via node NODE1 all transactions in wallet WALLET_B are found to be Mined_or_Faux_Confirmed
+        # Then while mining via SHA3 miner MINER all transactions in wallet WALLET_A are found to be Mined_or_OneSidedConfirmed
+        # # Then wallet WALLET_B detects all transactions as Mined_or_OneSidedConfirmed
+        # Then while mining via node NODE1 all transactions in wallet WALLET_B are found to be Mined_or_OneSidedConfirmed
 
         # @flaky
         # Examples:
@@ -71,7 +71,7 @@ Feature: Stress Test
         # When mining node MINER mines 8 blocks
 
         # Then all nodes are on the same chain tip
-        # Then wallet WALLET_A detects all transactions as Mined_or_Faux_Confirmed
+        # Then wallet WALLET_A detects all transactions as Mined_or_OneSidedConfirmed
         # When I send 2000 transactions of 1111 uT each from wallet WALLET_A to wallet WALLET_B at fee_per_gram 4
         # # Mine enough blocks for the first block of transactions to be confirmed.
         # When mining node MINER mines 4 blocks
@@ -79,6 +79,6 @@ Feature: Stress Test
         # # Now wait until all transactions are detected as confirmed in WALLET_A, continue to mine blocks if transactions
         # # are not found to be confirmed as sometimes the previous mining occurs faster than transactions are submitted
         # # to the mempool
-        # Then while mining via SHA3 miner MINER all transactions in wallet WALLET_A are found to be Mined_or_Faux_Confirmed
-        # # Then wallet WALLET_B detects all transactions as Mined_or_Faux_Confirmed
-        # Then while mining via node NODE1 all transactions in wallet WALLET_B are found to be Mined_or_Faux_Confirmed
+        # Then while mining via SHA3 miner MINER all transactions in wallet WALLET_A are found to be Mined_or_OneSidedConfirmed
+        # # Then wallet WALLET_B detects all transactions as Mined_or_OneSidedConfirmed
+        # Then while mining via node NODE1 all transactions in wallet WALLET_B are found to be Mined_or_OneSidedConfirmed

--- a/integration_tests/tests/features/TransactionInfo.feature
+++ b/integration_tests/tests/features/TransactionInfo.feature
@@ -26,11 +26,11 @@ Scenario: Get Transaction Info
     Then wallet WALLET_B detects all transactions are at least Broadcast
     When mining node MINER2 mines 1 blocks
     Then all nodes are at height 5
-    Then wallet WALLET_A detects all transactions are at least Mined_or_Faux_Unconfirmed
-    Then wallet WALLET_B detects all transactions are at least Mined_or_Faux_Unconfirmed
+    Then wallet WALLET_A detects all transactions are at least Mined_or_OneSidedUnconfirmed
+    Then wallet WALLET_B detects all transactions are at least Mined_or_OneSidedUnconfirmed
     When mining node MINER2 mines 10 blocks
     Then all nodes are at height 15
-    Then wallet WALLET_A detects all transactions as Mined_or_Faux_Confirmed
-    Then wallet WALLET_B detects all transactions as Mined_or_Faux_Confirmed
+    Then wallet WALLET_A detects all transactions as Mined_or_OneSidedConfirmed
+    Then wallet WALLET_B detects all transactions as Mined_or_OneSidedConfirmed
     # This wait is needed to stop base nodes from shutting down
     When I wait 1 seconds

--- a/integration_tests/tests/features/WalletCli.feature
+++ b/integration_tests/tests/features/WalletCli.feature
@@ -82,9 +82,8 @@ Feature: Wallet CLI
         When I have mining node MINE connected to base node BASE and wallet SENDER
         When mining node MINE mines 15 blocks
         Then wallets SENDER should have AT_LEAST 12 spendable coinbase outputs
-        When I wait 30 seconds
         Then I stop wallet SENDER
-        When I make it rain from wallet SENDER 1 tx per sec 10 sec 8000 uT 100 increment to RECEIVER via command line
+        When I make-it-rain from SENDER rate 10 txns_per_sec duration 1 sec value 8000 uT increment 100 uT to RECEIVER via command line
         Then wallet SENDER has at least 10 transactions that are all TRANSACTION_STATUS_BROADCAST and not cancelled
         Then wallet RECEIVER has at least 10 transactions that are all TRANSACTION_STATUS_BROADCAST and not cancelled
         When mining node MINE mines 5 blocks

--- a/integration_tests/tests/features/WalletFFI.feature
+++ b/integration_tests/tests/features/WalletFFI.feature
@@ -202,10 +202,10 @@ Feature: Wallet FFI
         Then ffi wallet FFI_WALLET detects AT_LEAST 3 ffi transactions to be TRANSACTION_STATUS_BROADCAST
         When mining node MINER mines 2 blocks
         Then all nodes are at height 22
-        Then wallet RECEIVER has at least 1 transactions that are all TRANSACTION_STATUS_FAUX_UNCONFIRMED and not cancelled
+        Then wallet RECEIVER has at least 1 transactions that are all TRANSACTION_STATUS_ONE_SIDED_UNCONFIRMED and not cancelled
         When mining node MINER mines 5 blocks
         Then all nodes are at height 27
-        Then wallet RECEIVER has at least 1 transactions that are all TRANSACTION_STATUS_FAUX_CONFIRMED and not cancelled
+        Then wallet RECEIVER has at least 1 transactions that are all TRANSACTION_STATUS_ONE_SIDED_CONFIRMED and not cancelled
         And I stop ffi wallet FFI_WALLET
 
     @critical @brokenFFI @broken
@@ -221,12 +221,12 @@ Feature: Wallet FFI
         Then I send a one-sided transaction of 1000000 uT from SENDER to FFI_RECEIVER at fee 20
         When mining node MINER mines 2 blocks
         Then all nodes are at height 12
-        Then ffi wallet FFI_RECEIVER detects AT_LEAST 1 ffi transactions to be TRANSACTION_STATUS_FAUX_UNCONFIRMED
+        Then ffi wallet FFI_RECEIVER detects AT_LEAST 1 ffi transactions to be TRANSACTION_STATUS_ONE_SIDED_UNCONFIRMED
         And I send 1000000 uT from wallet SENDER to wallet FFI_RECEIVER at fee 20
         Then ffi wallet FFI_RECEIVER detects AT_LEAST 1 ffi transactions to be TRANSACTION_STATUS_BROADCAST
         When mining node MINER mines 5 blocks
         Then all nodes are at height 17
-        Then ffi wallet FFI_RECEIVER detects AT_LEAST 1 ffi transactions to be TRANSACTION_STATUS_FAUX_CONFIRMED
+        Then ffi wallet FFI_RECEIVER detects AT_LEAST 1 ffi transactions to be TRANSACTION_STATUS_ONE_SIDED_CONFIRMED
         And I stop ffi wallet FFI_RECEIVER
 
     Scenario: As a client I want to get fee per gram stats

--- a/integration_tests/tests/features/WalletMonitoring.feature
+++ b/integration_tests/tests/features/WalletMonitoring.feature
@@ -21,7 +21,7 @@ Feature: Wallet Monitoring
     # And I list all COINBASE transactions for wallet WALLET_A1
     # Then wallet WALLET_A1 has 10 coinbase transactions
     # Then all COINBASE transactions for wallet WALLET_A1 are valid
-    # Then wallet WALLET_A1 detects at least 7 coinbase transactions as Mined_or_Faux_Confirmed
+    # Then wallet WALLET_A1 detects at least 7 coinbase transactions as CoinbaseConfirmed
     #     #
     #     # Chain 2:
     #     #   Collects 10 coinbases into one wallet
@@ -36,7 +36,7 @@ Feature: Wallet Monitoring
     # And I list all COINBASE transactions for wallet WALLET_B1
     # Then wallet WALLET_B1 has 10 coinbase transactions
     # Then all COINBASE transactions for wallet WALLET_B1 are valid
-    # Then wallet WALLET_B1 detects at least 7 coinbase transactions as Mined_or_Faux_Confirmed
+    # Then wallet WALLET_B1 detects at least 7 coinbase transactions as CoinbaseConfirmed
     #     #
     #     # Connect Chain 1 and 2
     #     #
@@ -66,15 +66,15 @@ Feature: Wallet Monitoring
     # When mining node MINING_A mines 10 blocks with min difficulty 20 and max difficulty 9999999999
     # Then node SEED_A is at height 10
     # Then node NODE_A1 is at height 10
-    # Then wallet WALLET_A1 detects exactly 7 coinbase transactions as Mined_or_Faux_Confirmed
+    # Then wallet WALLET_A1 detects exactly 7 coinbase transactions as CoinbaseConfirmed
     #     # Use 7 of the 10 coinbase UTXOs in transactions (others require 3 confirmations)
     # And I multi-send 7 transactions of 1000000 uT from wallet WALLET_A1 to wallet WALLET_A2 at fee 100
     # When mining node MINING_A mines 10 blocks with min difficulty 20 and max difficulty 9999999999
     # Then node SEED_A is at height 20
     # Then node NODE_A1 is at height 20
-    # Then wallet WALLET_A2 detects all transactions as Mined_or_Faux_Confirmed
+    # Then wallet WALLET_A2 detects all transactions as Mined_or_OneSidedConfirmed
     # Then all NORMAL transactions for wallet WALLET_A1 are valid
-    # Then wallet WALLET_A1 detects exactly 17 coinbase transactions as Mined_or_Faux_Confirmed
+    # Then wallet WALLET_A1 detects exactly 17 coinbase transactions as CoinbaseConfirmed
     #     #
     #     # Chain 2:
     #     #   Collects 10 coinbases into one wallet, send 7 transactions
@@ -88,15 +88,15 @@ Feature: Wallet Monitoring
     # When mining node MINING_B mines 10 blocks with min difficulty 1 and max difficulty 2
     # Then node SEED_B is at height 10
     # Then node NODE_B1 is at height 10
-    # Then wallet WALLET_B1 detects exactly 7 coinbase transactions as Mined_or_Faux_Confirmed
+    # Then wallet WALLET_B1 detects exactly 7 coinbase transactions as CoinbaseConfirmed
     #     # Use 7 of the 10 coinbase UTXOs in transactions (others require 3 confirmations)
     # And I multi-send 7 transactions of 1000000 uT from wallet WALLET_B1 to wallet WALLET_B2 at fee 100
     # When mining node MINING_B mines 10 blocks with min difficulty 1 and max difficulty 2
     # Then node SEED_B is at height 20
     # Then node NODE_B1 is at height 20
-    # Then wallet WALLET_B2 detects all transactions as Mined_or_Faux_Confirmed
+    # Then wallet WALLET_B2 detects all transactions as Mined_or_OneSidedConfirmed
     # Then all NORMAL transactions for wallet WALLET_B1 are valid
-    # Then wallet WALLET_B1 detects exactly 17 coinbase transactions as Mined_or_Faux_Confirmed
+    # Then wallet WALLET_B1 detects exactly 17 coinbase transactions as CoinbaseConfirmed
     #     #
     #     # Connect Chain 1 and 2
     #     #
@@ -105,8 +105,8 @@ Feature: Wallet Monitoring
     #     # When tip advances past required confirmations, invalid coinbases still being monitored will be cancelled.
     # And mining node NODE_C mines 6 blocks
     # Then all nodes are at height 26
-    # Then wallet WALLET_A1 detects exactly 20 coinbase transactions as Mined_or_Faux_Confirmed
-    # Then wallet WALLET_B1 detects exactly 17 coinbase transactions as Mined_or_Faux_Confirmed
+    # Then wallet WALLET_A1 detects exactly 20 coinbase transactions as CoinbaseConfirmed
+    # Then wallet WALLET_B1 detects exactly 17 coinbase transactions as CoinbaseConfirmed
     # And I list all NORMAL transactions for wallet WALLET_A1
     # And I list all NORMAL transactions for wallet WALLET_B1
     # #  Uncomment this step when wallets can handle reorg

--- a/integration_tests/tests/features/WalletQuery.feature
+++ b/integration_tests/tests/features/WalletQuery.feature
@@ -12,7 +12,7 @@ Feature: Wallet Querying
     When mining node MINER mines 5 blocks
     Then all nodes are at height 5
     When I mine 5 blocks on NODE
-    Then all wallets detect all transactions as Mined_or_Faux_Confirmed
+    Then all wallets detect all transactions as Mined_or_OneSidedConfirmed
 
   @critical
   Scenario: As a wallet I want to submit a transaction
@@ -23,5 +23,5 @@ Feature: Wallet Querying
     When I wait 5 seconds
     When I transfer 5T from WALLET_A to WALLET_B
     When I mine 5 blocks on NODE
-    Then all wallets detect all transactions as Mined_or_Faux_Confirmed
+    Then all wallets detect all transactions as Mined_or_OneSidedConfirmed
 

--- a/integration_tests/tests/features/WalletRoutingMechanism.feature
+++ b/integration_tests/tests/features/WalletRoutingMechanism.feature
@@ -23,12 +23,12 @@ Feature: Wallet Routing Mechanism
       When I wait 1 seconds
       #   And mining node MINER mines 1 blocks
       #  Then all nodes are at height 21
-      #   Then all wallets detect all transactions as Mined_or_Faux_Unconfirmed
+      #   Then all wallets detect all transactions as Mined_or_OneSidedUnconfirmed
       #   # This wait is needed to stop next merge mining task from continuing
       When I wait 1 seconds
       #   And mining node MINER mines 11 blocks
       #  Then all nodes are at height 32
-      #   Then all wallets detect all transactions as Mined_or_Faux_Confirmed
+      #   Then all wallets detect all transactions as Mined_or_OneSidedConfirmed
       #   This wait is needed to stop base nodes from shutting down
       When I wait 1 seconds
       #   @long-running

--- a/integration_tests/tests/features/WalletTransactions.feature
+++ b/integration_tests/tests/features/WalletTransactions.feature
@@ -226,7 +226,7 @@ Feature: Wallet Transactions
   #   Then node SEED_A is at height 7
   #   Then node NODE_A1 is at height 7
   #   When I mine 3 blocks on SEED_A
-  #   Then wallet WALLET_A1 detects at least 7 coinbase transactions as Mined_or_Faux_Confirmed
+  #   Then wallet WALLET_A1 detects at least 7 coinbase transactions as CoinbaseConfirmed
   #   Then node SEED_A is at height 10
   #   Then node NODE_A1 is at height 10
   #   When I multi-send 7 transactions of 1000000 uT from wallet WALLET_A1 to wallet WALLET_A2 at fee 100
@@ -244,7 +244,7 @@ Feature: Wallet Transactions
   #   Then node SEED_B is at height 7
   #   Then node NODE_B1 is at height 7
   #   When I mine 5 blocks on SEED_B
-  #   Then wallet WALLET_B1 detects at least 7 coinbase transactions as Mined_or_Faux_Confirmed
+  #   Then wallet WALLET_B1 detects at least 7 coinbase transactions as CoinbaseConfirmed
   #   Then node SEED_B is at height 12
   #   Then node NODE_B1 is at height 12
   #   When I multi-send 7 transactions of 1000000 uT from wallet WALLET_B1 to wallet WALLET_B2 at fee 100
@@ -306,7 +306,7 @@ Feature: Wallet Transactions
   #   Then node SEED_A is at height 1
   #   Then node NODE_A1 is at height 1
   #   When I mine 3 blocks on SEED_A
-  #   Then wallet WALLET_A1 detects at least 1 coinbase transactions as Mined_or_Faux_Confirmed
+  #   Then wallet WALLET_A1 detects at least 1 coinbase transactions as CoinbaseConfirmed
   #   Then node SEED_A is at height 4
   #   Then node NODE_A1 is at height 4
   #   When I multi-send 1 transactions of 10000 uT from wallet WALLET_A1 to wallet WALLET_A2 at fee 20
@@ -324,7 +324,7 @@ Feature: Wallet Transactions
   #   Then node SEED_B is at height 2
   #   Then node NODE_B1 is at height 2
   #   When I mine 3 blocks on SEED_B
-  #   Then wallet WALLET_B1 detects at least 2 coinbase transactions as Mined_or_Faux_Confirmed
+  #   Then wallet WALLET_B1 detects at least 2 coinbase transactions as CoinbaseConfirmed
   #   Then node SEED_B is at height 5
   #   Then node NODE_B1 is at height 5
   #   When I multi-send 2 transactions of 10000 uT from wallet WALLET_B1 to wallet WALLET_B2 at fee 20
@@ -380,7 +380,7 @@ Feature: Wallet Transactions
   #   When I wait 30 seconds
   #   When mining node MINER mines 5 blocks
   #   Then all nodes are at height 15
-  #   When wallet WALLET_SENDER detects all transactions as Mined_or_Faux_Confirmed
+  #   When wallet WALLET_SENDER detects all transactions as Mined_or_OneSidedConfirmed
   #   When I start wallet WALLET_RECV
   #   When I wait 5 seconds
   #   Then I restart wallet WALLET_RECV
@@ -422,5 +422,5 @@ Feature: Wallet Transactions
     When I create a burn transaction of 201552500000 uT from WALLET_A at fee 100
     When mining node MINER_B mines 5 blocks
     Then all nodes are at height 20
-    Then wallet WALLET_A detects all transactions as Mined_or_Faux_Confirmed
+    Then wallet WALLET_A detects all transactions as Mined_or_OneSidedConfirmed
     When I wait for wallet WALLET_A to have at least 20000000000 uT

--- a/integration_tests/tests/features/WalletTransfer.feature
+++ b/integration_tests/tests/features/WalletTransfer.feature
@@ -40,7 +40,7 @@ Feature: Wallet Transfer
     When I transfer 50000 uT from WALLET_A to WALLET_B and WALLET_C at fee 20
     When mining node MINER mines 10 blocks
     Then all nodes are at height 20
-    Then all wallets detect all transactions as Mined_or_Faux_Confirmed
+    Then all wallets detect all transactions as Mined_or_OneSidedConfirmed
 
 
   Scenario: As a wallet I want to submit transfers to myself
@@ -55,7 +55,7 @@ Feature: Wallet Transfer
     When I transfer 50000 uT to self from wallet WALLET_A at fee 25
     When I mine 5 blocks on NODE
     Then all nodes are at height 15
-    Then all wallets detect all transactions as Mined_or_Faux_Confirmed
+    Then all wallets detect all transactions as Mined_or_OneSidedConfirmed
 
   Scenario: As a wallet I want to create a HTLC transaction
     Given I have a seed node NODE

--- a/integration_tests/tests/steps/wallet_cli_steps.rs
+++ b/integration_tests/tests/steps/wallet_cli_steps.rs
@@ -217,13 +217,13 @@ async fn send_one_sided_tx_via_cli(world: &mut TariWorld, amount: u64, wallet_a:
 }
 
 #[when(
-    expr = "I make it rain from wallet {word} {int} tx per sec {int} sec {int} uT {int} increment to {word} via \
-            command line"
+    expr = "I make-it-rain from {word} rate {int} txns_per_sec duration {int} sec value {int} uT increment {int} uT \
+            to {word} via command line"
 )]
 async fn make_it_rain(
     world: &mut TariWorld,
     wallet_a: String,
-    txs_per_second: u64,
+    txs_per_second: u32,
     duration: u64,
     start_amount: u64,
     increment_amount: u64,
@@ -248,7 +248,7 @@ async fn make_it_rain(
 
     let args = MakeItRainArgs {
         start_amount: MicroMinotari(start_amount),
-        transactions_per_second: u32::try_from(txs_per_second).unwrap(),
+        transactions_per_second: f64::from(txs_per_second),
         duration: Duration::from_secs(duration),
         message: format!(
             "Make it raing amount {} from {} to {}",

--- a/integration_tests/tests/steps/wallet_ffi_steps.rs
+++ b/integration_tests/tests/steps/wallet_ffi_steps.rs
@@ -416,8 +416,8 @@ async fn ffi_detects_transaction(
         "TRANSACTION_STATUS_BROADCAST",
         "TRANSACTION_STATUS_MINED_UNCONFIRMED",
         "TRANSACTION_STATUS_MINED",
-        "TRANSACTION_STATUS_FAUX_UNCONFIRMED",
-        "TRANSACTION_STATUS_FAUX_CONFIRMED"
+        "TRANSACTION_STATUS_ONE_SIDED_UNCONFIRMED",
+        "TRANSACTION_STATUS_ONE_SIDED_CONFIRMED"
     ]
     .contains(&status.as_str()));
     println!(
@@ -430,8 +430,8 @@ async fn ffi_detects_transaction(
             "TRANSACTION_STATUS_BROADCAST" => ffi_wallet.get_counters().get_transaction_broadcast(),
             "TRANSACTION_STATUS_MINED_UNCONFIRMED" => ffi_wallet.get_counters().get_transaction_mined_unconfirmed(),
             "TRANSACTION_STATUS_MINED" => ffi_wallet.get_counters().get_transaction_mined(),
-            "TRANSACTION_STATUS_FAUX_UNCONFIRMED" => ffi_wallet.get_counters().get_transaction_faux_unconfirmed(),
-            "TRANSACTION_STATUS_FAUX_CONFIRMED" => ffi_wallet.get_counters().get_transaction_faux_confirmed(),
+            "TRANSACTION_STATUS_ONE_SIDED_UNCONFIRMED" => ffi_wallet.get_counters().get_transaction_faux_unconfirmed(),
+            "TRANSACTION_STATUS_ONE_SIDED_CONFIRMED" => ffi_wallet.get_counters().get_transaction_faux_confirmed(),
             _ => unreachable!(),
         };
         if found_count >= count {


### PR DESCRIPTION
Description
---
- This PR will allow a wider transaction submission rate for the make-it-rain tests.
- Also fixed cucumber tests where it needed to detect transactions with a certain status. This was needed to fix the make-it-rain cucumber test.

Motivation and Context
---
A transaction submission fractional rate of between 1 and 2 txns/s is required for extended stress tests.

How Has This Been Tested?
---
Cucumber test `Scenario: As a user I want to make-it-rain via command line`

What process can a PR reviewer use to test or verify this change?
---
Cucumber test `Scenario: As a user I want to make-it-rain via command line`

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
