### PR TITLE
chore: add minotari_mining_helper_ffi to build plus clean ups

### DIFF
--- a/.github/workflows/base_node_binaries.json
+++ b/.github/workflows/base_node_binaries.json
@@ -4,10 +4,7 @@
     "runs-on": "ubuntu-20.04",
     "rust": "nightly-2023-06-04",
     "target": "x86_64-unknown-linux-gnu",
-    "cross": false,
-    "target_cpu": "x86-64",
-    "target_bins": "--bin minotari_node --bin minotari_console_wallet --bin minotari_merge_mining_proxy --bin minotari_miner",
-    "features": "default, safe"
+    "cross": false
   },
   {
     "name": "linux-arm64",
@@ -15,31 +12,30 @@
     "rust": "stable",
     "target": "aarch64-unknown-linux-gnu",
     "cross": true,
-    "target_cpu": "generic",
-    "features": "safe",
-    "target_bins": "--bin minotari_node --bin minotari_console_wallet --bin minotari_merge_mining_proxy --bin minotari_miner",
     "flags": "--workspace --exclude minotari_mining_helper_ffi --exclude tari_integration_tests"
+  },
+  {
+    "name": "linux-riscv64",
+    "runs-on": "ubuntu-latest",
+    "rust": "stable",
+    "target": "riscv64gc-unknown-linux-gnu",
+    "cross": true,
+    "flags": "--workspace --exclude minotari_mining_helper_ffi --exclude tari_integration_tests",
+    "build_enabled": false
   },
   {
     "name": "macos-x86_64",
     "runs-on": "macos-11",
     "rust": "stable",
     "target": "x86_64-apple-darwin",
-    "cross": false,
-    "target_cpu": "x86-64",
-    "target_bins": "--bin minotari_node --bin minotari_console_wallet --bin minotari_merge_mining_proxy --bin minotari_miner",
-    "features": "default, safe"
+    "cross": false
   },
   {
     "name": "macos-arm64",
     "runs-on": "macos-14",
     "rust": "stable",
     "target": "aarch64-apple-darwin",
-    "cross": false,
-    "target_cpu": "generic",
-    "target_bins": "--bin minotari_node --bin minotari_console_wallet --bin minotari_merge_mining_proxy --bin minotari_miner",
-    "features": "default, safe",
-    "build_enabled": true
+    "cross": false
   },
   {
     "name": "windows-x64",
@@ -47,9 +43,7 @@
     "rust": "stable",
     "target": "x86_64-pc-windows-msvc",
     "cross": false,
-    "target_cpu": "x86-64",
     "features": "safe",
-    "target_bins": "--bin minotari_node --bin minotari_console_wallet --bin minotari_merge_mining_proxy --bin minotari_miner",
     "flags": "--workspace --exclude tari_libtor"
   },
   {
@@ -58,9 +52,9 @@
     "rust": "stable",
     "target": "aarch64-pc-windows-msvc",
     "cross": false,
-    "target_cpu": "generic",
     "features": "safe",
-    "target_bins": "--bin minotari_node --bin minotari_console_wallet --bin minotari_merge_mining_proxy --bin minotari_miner",
+    "target_bins": "minotari_node, minotari_console_wallet, minotari_merge_mining_proxy, minotari_miner",
+    "flags": "--workspace --exclude tari_libtor",
     "build_enabled": false
   }
 ]

--- a/.github/workflows/base_node_binaries.yml
+++ b/.github/workflows/base_node_binaries.yml
@@ -22,6 +22,8 @@ env:
   TBN_SIG_FN: "sha256-unsigned.txt"
   ## Must be a JSon string
   TBN_FILES: '["minotari_node","minotari_console_wallet","minotari_miner","minotari_merge_mining_proxy"]'
+  TBN_FEATURES: "default, safe"
+  TBN_LIBRARIES: "minotari_mining_helper_ffi"
   TARI_NETWORK_DIR: testnet
   toolchain: nightly-2023-06-04
   matrix-json-file: ".github/workflows/base_node_binaries.json"
@@ -54,7 +56,7 @@ jobs:
           #
           # build only single target image
           # matrix_selection=$( jq -c '.[] | select( ."name" == "windows-x64" )' ${{ env.matrix-json-file }} )
-          # matrix_selection=$( jq -c '.[] | select( ."name" == "macos-arm64" )' ${{ env.matrix-json-file }} )
+          # matrix_selection=$( jq -c '.[] | select( ."name" | contains("linux") )' ${{ env.matrix-json-file }} )
           #
           # build select target images - build_enabled
           matrix_selection=$( jq -c '.[] | select( ."build_enabled" != false )' ${{ env.matrix-json-file }} )
@@ -125,6 +127,33 @@ jobs:
           TARI_VERSION=$(awk -F ' = ' '$1 ~ /version/ { gsub(/["]/, "", $2); printf("%s",$2) }' "$GITHUB_WORKSPACE/applications/minotari_node/Cargo.toml")
           echo "TARI_VERSION=${TARI_VERSION}" >> $GITHUB_ENV
           echo "TARI_VERSION=${TARI_VERSION}" >> $GITHUB_OUTPUT
+          if [[ "${{ matrix.builds.features }}" == "" ]]; then
+            echo "BUILD_FEATURES=${{ env.TBN_FEATURES }}" >> $GITHUB_ENV
+          else
+            echo "BUILD_FEATURES=${{ matrix.builds.features }}" >> $GITHUB_ENV
+          fi
+          TARGET_BINS=""
+          if [[ "${{ matrix.builds.target_bins }}" == "" ]]; then
+            ARRAY_BINS=( $(echo ${TBN_FILES} | jq --raw-output '.[]' | awk '{ print $1 }') )
+          else
+            ARRAY_BINS=( $(echo "${{ matrix.builds.target_bins }}" | tr ', ' '\n') )
+          fi
+          for BIN_FILE in "${ARRAY_BINS[@]}"; do
+            echo "Adding ${BIN_FILE} to Builds"
+            TARGET_BINS+="--bin ${BIN_FILE} "
+          done
+          echo "TARGET_BINS=${TARGET_BINS}" >> $GITHUB_ENV
+          TARGET_LIBS=""
+          if [[ "${{ matrix.builds.target_libs }}" == "" ]]; then
+            ARRAY_LIBS=( $(echo ${TBN_LIBRARIES} | tr ', ' '\n') )
+          else
+            ARRAY_LIBS=( $(echo "${{ matrix.builds.target_libs }}" | tr ', ' '\n') )
+          fi
+          for LIB_FILE in "${ARRAY_LIBS[@]}"; do
+            echo "Adding ${LIB_FILE} to library Builds"
+            TARGET_LIBS+="--package ${LIB_FILE} "
+          done
+          echo "TARGET_LIBS=${TARGET_LIBS}" >> $GITHUB_ENV
 
       - name: Scheduled Destination Folder Override
         if: ${{ github.event_name == 'schedule' && github.event.schedule == '05 00 * * *' }}
@@ -258,29 +287,49 @@ jobs:
         run: |
           ${{ env.CARGO }} build ${{ env.CARGO_OPTIONS }} \
             --target ${{ matrix.builds.target }} \
-            --features "${{ matrix.builds.features }}" \
-            ${{ matrix.builds.target_bins }} \
+            --features "${{ env.BUILD_FEATURES }}" \
+            ${{ env.TARGET_BINS }} \
+            ${{ matrix.builds.flags }} --locked
+
+      - name: Build release libraries
+        shell: bash
+        run: |
+          ${{ env.CARGO }} build ${{ env.CARGO_OPTIONS }} \
+            --target ${{ matrix.builds.target }} \
+            --lib ${{ env.TARGET_LIBS }} \
             ${{ matrix.builds.flags }} --locked
 
       - name: Copy binaries to folder for archiving
         shell: bash
         run: |
+          set -xo pipefail
           mkdir -p "$GITHUB_WORKSPACE${TBN_DIST}"
           cd "$GITHUB_WORKSPACE${TBN_DIST}"
           BINFILE="${TBN_FILENAME}-${TARI_VERSION}-${VSHA_SHORT}-${{ matrix.builds.name }}${TBN_EXT}"
           echo "BINFILE=${BINFILE}" >> $GITHUB_ENV
           echo "Copying files for ${BINFILE} to $(pwd)"
           echo "MTS_SOURCE=$(pwd)" >> $GITHUB_ENV
-          ls -alhtR "$GITHUB_WORKSPACE/target/${{ matrix.builds.target }}/release/"
+          ls -alht "$GITHUB_WORKSPACE/target/${{ matrix.builds.target }}/release/"
           ARRAY_FILES=( $(echo ${TBN_FILES} | jq --raw-output '.[]' | awk '{ print $1 }') )
           for FILE in "${ARRAY_FILES[@]}"; do
             echo "checking for file - ${FILE}${TBN_EXT}"
-            if [ -f "$GITHUB_WORKSPACE/target/${{ matrix.builds.target }}/release/${FILE}${TBN_EXT}" ]; then
-              cp -vf "$GITHUB_WORKSPACE/target/${{ matrix.builds.target }}/release/${FILE}${TBN_EXT}" .
+            if [ -f "${GITHUB_WORKSPACE}/target/${{ matrix.builds.target }}/release/${FILE}${TBN_EXT}" ]; then
+              cp -vf "${GITHUB_WORKSPACE}/target/${{ matrix.builds.target }}/release/${FILE}${TBN_EXT}" .
             fi
           done
-          if [ -f "$GITHUB_WORKSPACE/applications/minotari_node/${PLATFORM_SPECIFIC_DIR}/runtime/start_tor${SHELL_EXT}" ]; then
-            cp -vf "$GITHUB_WORKSPACE/applications/minotari_node/${PLATFORM_SPECIFIC_DIR}/runtime/start_tor${SHELL_EXT}" .
+          if [[ "${{ matrix.builds.target_libs }}" == "" ]]; then
+            ARRAY_LIBS=( $(echo ${TBN_LIBRARIES} | tr ', ' '\n') )
+          else
+            ARRAY_LIBS=( $(echo "${{ matrix.builds.target_libs }}" | tr ', ' '\n') )
+          fi
+          for FILE in "${ARRAY_LIBS[@]}"; do
+            echo "checking for file - ${FILE}${TBN_EXT}"
+            if [ -f "${GITHUB_WORKSPACE}/target/${{ matrix.builds.target }}/release/lib${FILE}${LIB_EXT}" ]; then
+              cp -vf "${GITHUB_WORKSPACE}/target/${{ matrix.builds.target }}/release/lib${FILE}${LIB_EXT}" .
+            fi
+          done
+          if [ -f "${GITHUB_WORKSPACE}/applications/minotari_node/${PLATFORM_SPECIFIC_DIR}/runtime/start_tor${SHELL_EXT}" ]; then
+            cp -vf "${GITHUB_WORKSPACE}/applications/minotari_node/${PLATFORM_SPECIFIC_DIR}/runtime/start_tor${SHELL_EXT}" .
           fi
           ls -alhtR ${{ env.MTS_SOURCE }}
 
@@ -290,10 +339,27 @@ jobs:
         run: |
           ${{ env.CARGO }} build ${{ env.CARGO_OPTIONS }} \
             --target ${{ matrix.builds.target }} \
-            --features "${{ matrix.builds.features }}, metrics" \
+            --features "${{ env.BUILD_FEATURES }}, metrics" \
             --bin minotari_node \
             ${{ matrix.builds.flags }} --locked
           cp -vf "$GITHUB_WORKSPACE/target/${{ matrix.builds.target }}/release/minotari_node" "${{ env.MTS_SOURCE }}/minotari_node-metrics"
+
+      - name: Build targeted miners
+        # if: ${{ ( startsWith(github.ref, 'refs/tags/v') ) && ( matrix.builds.miner_cpu_targets != '' ) }}
+        if: ${{ matrix.builds.miner_cpu_targets != '' }}
+        shell: bash
+        run: |
+          ARRAY_TARGETS=( $(echo "${{ matrix.builds.miner_cpu_targets }}" | tr ', ' '\n') )
+          for CPU_TARGET in "${ARRAY_TARGETS[@]}"; do
+            echo "Target CPU ${CPU_TARGET} for miner"
+            export RUSTFLAGS="-C target-cpu=${CPU_TARGET}"
+            ${{ env.CARGO }} build ${{ env.CARGO_OPTIONS }} \
+              --target ${{ matrix.builds.target }} \
+              --features "${{ env.BUILD_FEATURES }}" \
+              --bin minotari_miner \
+              ${{ matrix.builds.flags }} --locked
+            cp -vf "$GITHUB_WORKSPACE/target/${{ matrix.builds.target }}/release/minotari_miner" "${{ env.MTS_SOURCE }}/minotari_miner-${CPU_TARGET}"
+          done
 
       - name: Pre/unsigned OSX Artifact upload for Archive
         # Debug

--- a/base_layer/tari_mining_helper_ffi/Cargo.toml
+++ b/base_layer/tari_mining_helper_ffi/Cargo.toml
@@ -7,10 +7,10 @@ version = "1.0.0-pre.9"
 edition = "2018"
 
 [dependencies]
-tari_comms = {  path = "../../comms/core" }
+tari_comms = { path = "../../comms/core" }
 tari_crypto = { version = "0.20" }
-tari_common = {  path = "../../common" }
-tari_core = {  path = "../core", default-features = false, features = ["transactions"]}
+tari_common = { path = "../../common" }
+tari_core = { path = "../core", default-features = false, features = ["transactions", "base_node_proto", "base_node"] }
 tari_utilities = { version = "0.7" }
 libc = "0.2.65"
 thiserror = "1.0.26"
@@ -18,7 +18,7 @@ borsh = "1.2"
 hex = "0.4.2"
 
 [dev-dependencies]
-tari_core = { path = "../core", features = ["transactions", "base_node"]}
+tari_core = { path = "../core", features = ["transactions", "base_node"] }
 rand = "0.8"
 
 [build-dependencies]


### PR DESCRIPTION
Description
add ```minotari_mining_helper_ffi``` to build
move default build options into workflow as envs
clean up old envs that are defaults from json matrix

Motivation and Context
Cleaner workflow matrixes

How Has This Been Tested?
Built and run in local fork

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
