### PR TITLE
feat!: change split to 50-50

### DIFF
--- a/applications/minotari_node/src/grpc/hash_rate.rs
+++ b/applications/minotari_node/src/grpc/hash_rate.rs
@@ -138,26 +138,26 @@ mod test {
 
     // Checks that the moving average hash rate at every block is correct
     // We use larger sample data than the SHA window size (12 periods) to check bounds
-    // We assumed a constant target block time of 300 secs (the SHA3 target time for Esmeralda)
+    // We assumed a constant target block time of 240 secs (the SHA3 target time for Esmeralda)
     // These expected hash rate values where calculated in a spreadsheet
     #[test]
     fn correct_moving_average_calculation() {
         let mut hash_rate_ma = create_hash_rate_ma(PowAlgorithm::Sha3x);
 
-        assert_hash_rate(&mut hash_rate_ma, 0, 100_000, 333);
-        assert_hash_rate(&mut hash_rate_ma, 1, 120_100, 366);
-        assert_hash_rate(&mut hash_rate_ma, 2, 110_090, 366);
-        assert_hash_rate(&mut hash_rate_ma, 3, 121_090, 375);
-        assert_hash_rate(&mut hash_rate_ma, 4, 150_000, 400);
-        assert_hash_rate(&mut hash_rate_ma, 5, 155_000, 419);
-        assert_hash_rate(&mut hash_rate_ma, 6, 159_999, 435);
-        assert_hash_rate(&mut hash_rate_ma, 7, 160_010, 448);
-        assert_hash_rate(&mut hash_rate_ma, 8, 159_990, 457);
-        assert_hash_rate(&mut hash_rate_ma, 9, 140_000, 458);
-        assert_hash_rate(&mut hash_rate_ma, 10, 137_230, 458);
-        assert_hash_rate(&mut hash_rate_ma, 11, 130_000, 456);
-        assert_hash_rate(&mut hash_rate_ma, 12, 120_000, 461);
-        assert_hash_rate(&mut hash_rate_ma, 13, 140_000, 467);
+        assert_hash_rate(&mut hash_rate_ma, 0, 100_000, 416);
+        assert_hash_rate(&mut hash_rate_ma, 1, 120_100, 458);
+        assert_hash_rate(&mut hash_rate_ma, 2, 110_090, 458);
+        assert_hash_rate(&mut hash_rate_ma, 3, 121_090, 469);
+        assert_hash_rate(&mut hash_rate_ma, 4, 150_000, 500);
+        assert_hash_rate(&mut hash_rate_ma, 5, 155_000, 524);
+        assert_hash_rate(&mut hash_rate_ma, 6, 159_999, 544);
+        assert_hash_rate(&mut hash_rate_ma, 7, 160_010, 560);
+        assert_hash_rate(&mut hash_rate_ma, 8, 159_990, 571);
+        assert_hash_rate(&mut hash_rate_ma, 9, 140_000, 572);
+        assert_hash_rate(&mut hash_rate_ma, 10, 137_230, 572);
+        assert_hash_rate(&mut hash_rate_ma, 11, 130_000, 570);
+        assert_hash_rate(&mut hash_rate_ma, 12, 120_000, 577);
+        assert_hash_rate(&mut hash_rate_ma, 13, 140_000, 584);
     }
 
     // Our moving average windows are very small (12 and 15 depending on PoW algorithm)

--- a/base_layer/core/src/consensus/consensus_constants.rs
+++ b/base_layer/core/src/consensus/consensus_constants.rs
@@ -370,12 +370,12 @@ impl ConsensusConstants {
         algos.insert(PowAlgorithm::Sha3x, PowAlgorithmConstants {
             min_difficulty: Difficulty::min(),
             max_difficulty: Difficulty::min(),
-            target_time: 300,
+            target_time: 240,
         });
         algos.insert(PowAlgorithm::RandomX, PowAlgorithmConstants {
             min_difficulty: Difficulty::min(),
             max_difficulty: Difficulty::min(),
-            target_time: 200,
+            target_time: 240,
         });
         let (input_version_range, output_version_range, kernel_version_range) = version_zero();
         let consensus_constants = vec![ConsensusConstants {
@@ -411,13 +411,13 @@ impl ConsensusConstants {
             coinbase_output_features_extra_max_length: 64,
         }];
         #[cfg(any(test, debug_assertions))]
-        assert_hybrid_pow_constants(&consensus_constants, &[120], &[60], &[40]);
+        assert_hybrid_pow_constants(&consensus_constants, &[120], &[50], &[50]);
         consensus_constants
     }
 
     pub fn igor() -> Vec<Self> {
         // `igor` is a test network, so calculating these constants are allowed rather than being hardcoded.
-        let randomx_split: u64 = 60;
+        let randomx_split: u64 = 50;
         let sha3x_split: u64 = 100 - randomx_split;
         let randomx_target_time = 20;
         let sha3x_target_time = randomx_target_time * (100 - sha3x_split) / sha3x_split;
@@ -491,12 +491,12 @@ impl ConsensusConstants {
         algos.insert(PowAlgorithm::Sha3x, PowAlgorithmConstants {
             min_difficulty: Difficulty::from_u64(60_000_000).expect("valid difficulty"),
             max_difficulty: Difficulty::max(),
-            target_time: 300,
+            target_time: 240,
         });
         algos.insert(PowAlgorithm::RandomX, PowAlgorithmConstants {
             min_difficulty: Difficulty::from_u64(60_000).expect("valid difficulty"),
             max_difficulty: Difficulty::max(),
-            target_time: 200,
+            target_time: 240,
         });
         let (input_version_range, output_version_range, kernel_version_range) = version_zero();
         let consensus_constants = vec![ConsensusConstants {
@@ -532,7 +532,7 @@ impl ConsensusConstants {
             coinbase_output_features_extra_max_length: 64,
         }];
         #[cfg(any(test, debug_assertions))]
-        assert_hybrid_pow_constants(&consensus_constants, &[120], &[60], &[40]);
+        assert_hybrid_pow_constants(&consensus_constants, &[120], &[50], &[50]);
         consensus_constants
     }
 
@@ -547,12 +547,12 @@ impl ConsensusConstants {
         algos.insert(PowAlgorithm::Sha3x, PowAlgorithmConstants {
             min_difficulty: Difficulty::from_u64(1_200_000_000).expect("valid difficulty"),
             max_difficulty: Difficulty::max(),
-            target_time: 300,
+            target_time: 240,
         });
         algos.insert(PowAlgorithm::RandomX, PowAlgorithmConstants {
             min_difficulty: Difficulty::from_u64(1_200_000).expect("valid difficulty"),
             max_difficulty: Difficulty::max(),
-            target_time: 200,
+            target_time: 240,
         });
         let (input_version_range, output_version_range, kernel_version_range) = version_zero();
         let consensus_constants = vec![ConsensusConstants {
@@ -588,7 +588,7 @@ impl ConsensusConstants {
             coinbase_output_features_extra_max_length: 64,
         }];
         #[cfg(any(test, debug_assertions))]
-        assert_hybrid_pow_constants(&consensus_constants, &[120], &[60], &[40]);
+        assert_hybrid_pow_constants(&consensus_constants, &[120], &[50], &[50]);
         consensus_constants
     }
 
@@ -597,12 +597,12 @@ impl ConsensusConstants {
         algos.insert(PowAlgorithm::Sha3x, PowAlgorithmConstants {
             min_difficulty: Difficulty::from_u64(1_200_000_000).expect("valid difficulty"),
             max_difficulty: Difficulty::max(),
-            target_time: 300,
+            target_time: 240,
         });
         algos.insert(PowAlgorithm::RandomX, PowAlgorithmConstants {
             min_difficulty: Difficulty::from_u64(1_200_000).expect("valid difficulty"),
             max_difficulty: Difficulty::max(),
-            target_time: 200,
+            target_time: 240,
         });
         let (input_version_range, output_version_range, kernel_version_range) = version_zero();
         let consensus_constants = vec![ConsensusConstants {
@@ -638,7 +638,7 @@ impl ConsensusConstants {
             coinbase_output_features_extra_max_length: 64,
         }];
         #[cfg(any(test, debug_assertions))]
-        assert_hybrid_pow_constants(&consensus_constants, &[120], &[60], &[40]);
+        assert_hybrid_pow_constants(&consensus_constants, &[120], &[50], &[50]);
         consensus_constants
     }
 
@@ -649,12 +649,12 @@ impl ConsensusConstants {
         algos.insert(PowAlgorithm::Sha3x, PowAlgorithmConstants {
             min_difficulty: Difficulty::from_u64(1_200_000_000).expect("valid difficulty"),
             max_difficulty: Difficulty::max(),
-            target_time: 300,
+            target_time: 240,
         });
         algos.insert(PowAlgorithm::RandomX, PowAlgorithmConstants {
             min_difficulty: Difficulty::from_u64(1_200_000).expect("valid difficulty"),
             max_difficulty: Difficulty::max(),
-            target_time: 200,
+            target_time: 240,
         });
         let (input_version_range, output_version_range, kernel_version_range) = version_zero();
         let consensus_constants = vec![ConsensusConstants {
@@ -690,7 +690,7 @@ impl ConsensusConstants {
             coinbase_output_features_extra_max_length: 64,
         }];
         #[cfg(any(test, debug_assertions))]
-        assert_hybrid_pow_constants(&consensus_constants, &[120], &[60], &[40]);
+        assert_hybrid_pow_constants(&consensus_constants, &[120], &[50], &[50]);
         consensus_constants
     }
 

--- a/base_layer/core/tests/tests/node_state_machine.rs
+++ b/base_layer/core/tests/tests/node_state_machine.rs
@@ -248,6 +248,7 @@ async fn test_listening_initial_fallen_behind() {
         shutdown.to_signal(),
     );
 
+    assert_eq!(alice_node.blockchain_db.get_height().unwrap(), 0);
     let await_event_task = task::spawn(async move { Listening::new().next_event(&mut alice_state_machine).await });
 
     let next_event = time::timeout(Duration::from_secs(10), await_event_task)


### PR DESCRIPTION
Description
---
Change the algo split to 50-50

Motivation and Context
---
Change the split not to favor any algorithm. Having the split not be exactly 50-50, it slightly favors the less one if they arrive within the same block period. 


Fixes: #6187 