### PR TITLE
fix: remove extra range proof verifications

### DIFF
--- a/base_layer/core/src/transactions/transaction_components/transaction_output.rs
+++ b/base_layer/core/src/transactions/transaction_components/transaction_output.rs
@@ -547,27 +547,9 @@ pub fn batch_verify_range_proofs(
             });
             proofs.push(output.proof_result()?.as_vec());
         }
-        if let Err(err_1) = prover.verify_batch(proofs, statements.iter().collect()) {
-            for output in &bulletproof_plus_proofs {
-                if let Err(err_2) = output.verify_range_proof(prover) {
-                    return Err(RangeProofError::InvalidRangeProof {
-                        reason: format!(
-                            "commitment {}, minimum_value_promise {}, proof {} ({:?})",
-                            output.commitment.to_hex(),
-                            output.minimum_value_promise,
-                            output.proof_hex_display(false),
-                            err_2,
-                        ),
-                    });
-                }
-            }
-            Err(RangeProofError::InvalidRangeProof {
-                reason: format!(
-                    "Batch verification failed, but individual verification passed - {:?}",
-                    err_1
-                ),
-            })?
-        }
+
+        // Attempt to verify the range proofs in a batch
+        prover.verify_batch(proofs, statements.iter().collect())?;
     }
 
     let revealed_value_proofs = outputs


### PR DESCRIPTION
Description
---
Removes extra range proof verifications that are done if batch verification fails.

Motivation and Context
---
If a batch of range proofs fails verification, each proof is checked separately until an invalid proof is found; this is reported for debugging purposes, but is otherwise not used.

This is inefficient and can lead to denial of service.

Until (or unless) #6167 is implemented to provide a more efficient method of identifying an invalid proof, this PR removes the unused extra verification operations.

How Has This Been Tested?
---
Existing tests pass.

What process can a PR reviewer use to test or verify this change?
---
Confirm that the existing verification operations were unused (except for debugging purposes), and that batch verification continues to work as expected.