### PR TITLE
feat: expose extra_data field to wallet ffi

### DIFF
--- a/base_layer/core/src/transactions/test_helpers.rs
+++ b/base_layer/core/src/transactions/test_helpers.rs
@@ -72,6 +72,7 @@ pub async fn create_test_input<
     amount: MicroMinotari,
     maturity: u64,
     key_manager: &TransactionKeyManagerWrapper<KeyManagerSqliteDatabase<TKeyManagerDbConnection>>,
+    coinbase_extra: Vec<u8>,
 ) -> WalletOutput {
     let params = TestParams::new(key_manager).await;
     params
@@ -80,6 +81,7 @@ pub async fn create_test_input<
                 value: amount,
                 features: OutputFeatures {
                     maturity,
+                    coinbase_extra,
                     ..Default::default()
                 },
                 ..Default::default()
@@ -354,12 +356,14 @@ pub async fn create_coinbase_wallet_output(
         .unwrap()
 }
 
-pub async fn create_wallet_output_with_data(
+pub async fn create_wallet_output_with_data<
+    TKeyManagerDbConnection: PooledDbConnection<Error = SqliteStorageError> + Clone + 'static,
+>(
     script: TariScript,
     output_features: OutputFeatures,
     test_params: &TestParams,
     value: MicroMinotari,
-    key_manager: &MemoryDbKeyManager,
+    key_manager: &TransactionKeyManagerWrapper<KeyManagerSqliteDatabase<TKeyManagerDbConnection>>,
 ) -> Result<WalletOutput, String> {
     test_params
         .create_output(

--- a/base_layer/core/src/transactions/transaction_components/output_features.rs
+++ b/base_layer/core/src/transactions/transaction_components/output_features.rs
@@ -59,7 +59,7 @@ pub struct OutputFeatures {
     /// transaction. This is enforced in [AggregatedBody::check_output_features].
     ///
     /// For coinbase outputs, the maximum length of this field is determined by the consensus constant,
-    /// `coinbase_output_features_metadata_max_length`.
+    /// `coinbase_output_features_extra_max_length`.
     pub coinbase_extra: Vec<u8>,
     /// Features that are specific to a side chain
     pub sidechain_feature: Option<SideChainFeature>,

--- a/base_layer/core/src/transactions/transaction_protocol/sender.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/sender.rs
@@ -1043,7 +1043,7 @@ mod test {
         let key_manager = create_memory_db_key_manager();
         let p1 = TestParams::new(&key_manager).await;
         let p2 = TestParams::new(&key_manager).await;
-        let input = create_test_input(MicroMinotari(1200), 0, &key_manager).await;
+        let input = create_test_input(MicroMinotari(1200), 0, &key_manager, vec![]).await;
         let mut builder = SenderTransactionProtocol::builder(create_consensus_constants(0), key_manager.clone());
         let script = TariScript::default();
         let output_features = OutputFeatures::default();
@@ -1106,7 +1106,7 @@ mod test {
         let a_change_key = TestParams::new(&key_manager).await;
         // Bob's parameters
         let bob_key = TestParams::new(&key_manager).await;
-        let input = create_test_input(MicroMinotari(1200), 0, &key_manager).await;
+        let input = create_test_input(MicroMinotari(1200), 0, &key_manager, vec![]).await;
         let utxo = input.to_transaction_input(&key_manager).await.unwrap();
         let script = script!(Nop);
         let consensus_constants = create_consensus_constants(0);
@@ -1213,7 +1213,7 @@ mod test {
         let alice_key = TestParams::new(&key_manager).await;
         // Bob's parameters
         let bob_key = TestParams::new(&key_manager).await;
-        let input = create_test_input(MicroMinotari(25000), 0, &key_manager).await;
+        let input = create_test_input(MicroMinotari(25000), 0, &key_manager, vec![]).await;
         let consensus_constants = create_consensus_constants(0);
         let mut builder = SenderTransactionProtocol::builder(consensus_constants.clone(), key_manager.clone());
         let script = script!(Nop);
@@ -1324,9 +1324,9 @@ mod test {
         let factories = CryptoFactories::default();
         // Bob's parameters
         let bob_key = TestParams::new(&key_manager).await;
-        let input = create_test_input(MicroMinotari(10000), 0, &key_manager).await;
-        let input2 = create_test_input(MicroMinotari(2000), 0, &key_manager).await;
-        let input3 = create_test_input(MicroMinotari(15000), 0, &key_manager).await;
+        let input = create_test_input(MicroMinotari(10000), 0, &key_manager, vec![]).await;
+        let input2 = create_test_input(MicroMinotari(2000), 0, &key_manager, vec![]).await;
+        let input3 = create_test_input(MicroMinotari(15000), 0, &key_manager, vec![]).await;
         let consensus_constants = create_consensus_constants(0);
         let mut builder = SenderTransactionProtocol::builder(consensus_constants.clone(), key_manager.clone());
         let script = script!(Nop);
@@ -1431,7 +1431,7 @@ mod test {
         // Alice's parameters
         let key_manager = create_memory_db_key_manager();
         let (utxo_amount, fee_per_gram, amount) = (MicroMinotari(2500), MicroMinotari(10), MicroMinotari(500));
-        let input = create_test_input(utxo_amount, 0, &key_manager).await;
+        let input = create_test_input(utxo_amount, 0, &key_manager, vec![]).await;
         let script = script!(Nop);
         let mut builder = SenderTransactionProtocol::builder(create_consensus_constants(0), key_manager.clone());
         let change = TestParams::new(&key_manager).await;
@@ -1469,7 +1469,7 @@ mod test {
         // Alice's parameters
         let key_manager = create_memory_db_key_manager();
         let (utxo_amount, fee_per_gram, amount) = (MicroMinotari(2500), MicroMinotari(10), MicroMinotari(500));
-        let input = create_test_input(utxo_amount, 0, &key_manager).await;
+        let input = create_test_input(utxo_amount, 0, &key_manager, vec![]).await;
         let script = script!(Nop);
         let mut builder = SenderTransactionProtocol::builder(create_consensus_constants(0), key_manager.clone());
         let change = TestParams::new(&key_manager).await;
@@ -1511,7 +1511,7 @@ mod test {
         // Bob's parameters
         let bob_test_params = TestParams::new(&key_manager_bob).await;
         let alice_value = MicroMinotari(25000);
-        let input = create_test_input(alice_value, 0, &key_manager_alice).await;
+        let input = create_test_input(alice_value, 0, &key_manager_alice, vec![]).await;
         let script = script!(Nop);
         let consensus_constants = create_consensus_constants(0);
 

--- a/base_layer/core/src/transactions/transaction_protocol/transaction_initializer.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/transaction_initializer.rs
@@ -691,7 +691,7 @@ mod test {
         // Create some inputs
         let key_manager = create_memory_db_key_manager();
         let p = TestParams::new(&key_manager).await;
-        let input = create_test_input(MicroMinotari(5000), 0, &key_manager).await;
+        let input = create_test_input(MicroMinotari(5000), 0, &key_manager, vec![]).await;
         let constants = create_consensus_constants(0);
         let expected_fee = Fee::from(*constants.transaction_weight_params()).calculate(
             MicroMinotari(4),
@@ -755,6 +755,7 @@ mod test {
             2000 * uT + tx_fee + fee_for_change_output - 1 * uT,
             0,
             &key_manager,
+            vec![],
         )
         .await;
         let output = p
@@ -815,7 +816,7 @@ mod test {
             .await
             .unwrap()
             .with_fee_per_gram(MicroMinotari(2));
-        let input_base = create_test_input(MicroMinotari(50), 0, &key_manager).await;
+        let input_base = create_test_input(MicroMinotari(50), 0, &key_manager, vec![]).await;
         for _ in 0..=MAX_TRANSACTION_INPUTS {
             builder.with_input(input_base.clone()).await.unwrap();
         }
@@ -836,7 +837,7 @@ mod test {
             p.get_size_for_default_features_and_scripts(1)
                 .expect("Failed to borsh serialized size"),
         );
-        let input = create_test_input(500 * uT + tx_fee, 0, &key_manager).await;
+        let input = create_test_input(500 * uT + tx_fee, 0, &key_manager, vec![]).await;
         let script = script!(Nop);
         // Start the builder
         let constants = create_consensus_constants(0);
@@ -873,7 +874,7 @@ mod test {
         // Create some inputs
         let key_manager = create_memory_db_key_manager();
         let p = TestParams::new(&key_manager).await;
-        let input = create_test_input(MicroMinotari(400), 0, &key_manager).await;
+        let input = create_test_input(MicroMinotari(400), 0, &key_manager, vec![]).await;
         let script = script!(Nop);
         let output = create_wallet_output_with_data(
             script.clone(),
@@ -925,8 +926,8 @@ mod test {
         // Create some inputs
         let key_manager = create_memory_db_key_manager();
         let p = TestParams::new(&key_manager).await;
-        let input1 = create_test_input(MicroMinotari(2000), 0, &key_manager).await;
-        let input2 = create_test_input(MicroMinotari(3000), 0, &key_manager).await;
+        let input1 = create_test_input(MicroMinotari(2000), 0, &key_manager, vec![]).await;
+        let input2 = create_test_input(MicroMinotari(3000), 0, &key_manager, vec![]).await;
         let fee_per_gram = MicroMinotari(6);
 
         let script = script!(Nop);

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -196,6 +196,8 @@ struct TransportConfig;
  */
 struct UnblindedOutput;
 
+struct Vec_u8;
+
 /**
  * -------------------------------- Vector ------------------------------------------------ ///
  */
@@ -347,6 +349,7 @@ struct TariUtxo {
   uint64_t mined_timestamp;
   uint64_t lock_height;
   uint8_t status;
+  struct Vec_u8 coinbase_extra;
 };
 
 #ifdef __cplusplus


### PR DESCRIPTION
Description
---
Added `extra_data` to wallet FFI for method `wallet_get_utxos`

Motivation and Context
---
The `extra_data` field is needed for display purposes in the client.

How Has This Been Tested?
---
Expanded test case `fn test_wallet_get_utxos()`

What process can a PR reviewer use to test or verify this change?
---
Review code and the test case

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
