### PR TITLE
fix: horizon sync

### DIFF
--- a/base_layer/core/src/base_node/sync/rpc/sync_utxos_task.rs
+++ b/base_layer/core/src/base_node/sync/rpc/sync_utxos_task.rs
@@ -192,6 +192,9 @@ where B: BlockchainBackend + 'static
 
             let mut outputs = Vec::with_capacity(outputs_with_statuses.len());
             for (output, spent) in outputs_with_statuses {
+                if output.is_burned() {
+                    continue;
+                }
                 if !spent {
                     match proto::types::TransactionOutput::try_from(output.clone()) {
                         Ok(tx_ouput) => {


### PR DESCRIPTION
Description
---
Fixes horizon sync

Motivation and Context
---
Burned outputs are counted as spent, so we should not sync them when doing horizon sync. 

How Has This Been Tested?
---
manual 

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
