### PR TITLE
fix: downgrade crossterm for windows compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1172,11 +1172,11 @@ dependencies = [
 
 [[package]]
 name = "crossterm"
-version = "0.27.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
+checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 1.3.2",
  "crossterm_winapi 0.9.1",
  "futures-core",
  "libc",
@@ -3096,7 +3096,7 @@ dependencies = [
  "clap 3.2.25",
  "config",
  "console-subscriber",
- "crossterm 0.27.0",
+ "crossterm 0.25.0",
  "digest 0.10.7",
  "futures 0.3.29",
  "log",
@@ -3152,7 +3152,7 @@ dependencies = [
  "chrono",
  "clap 3.2.25",
  "config",
- "crossterm 0.27.0",
+ "crossterm 0.25.0",
  "futures 0.3.29",
  "hex",
  "hyper",
@@ -3191,7 +3191,7 @@ dependencies = [
  "clap 3.2.25",
  "config",
  "crossbeam",
- "crossterm 0.27.0",
+ "crossterm 0.25.0",
  "derivative",
  "futures 0.3.29",
  "hex",
@@ -3248,7 +3248,7 @@ dependencies = [
  "clap 3.2.25",
  "config",
  "console-subscriber",
- "crossterm 0.27.0",
+ "crossterm 0.25.0",
  "derive_more",
  "either",
  "futures 0.3.29",

--- a/applications/minotari_console_wallet/Cargo.toml
+++ b/applications/minotari_console_wallet/Cargo.toml
@@ -34,7 +34,7 @@ tokio = { version = "1.36", features = ["signal"] }
 chrono = { version = "0.4.19", default-features = false }
 clap = { version = "3.2", features = ["derive", "env"] }
 config = "0.13.0"
-crossterm = { version = "0.27.0" }
+crossterm = { version = "0.25.0" }
 digest = "0.10"
 futures = { version = "^0.3.16", default-features = false, features = [
   "alloc",

--- a/applications/minotari_merge_mining_proxy/Cargo.toml
+++ b/applications/minotari_merge_mining_proxy/Cargo.toml
@@ -29,7 +29,7 @@ bytes = "1.1"
 chrono = { version = "0.4.19", default-features = false }
 clap = { version = "3.2", features = ["derive", "env"] }
 config = { version = "0.13.0" }
-crossterm = { version = "0.27.0" }
+crossterm = { version = "0.25.0" }
 futures = { version = "^0.3.16", features = ["async-await"] }
 hex = "0.4.2"
 hyper = "0.14.12"

--- a/applications/minotari_miner/Cargo.toml
+++ b/applications/minotari_miner/Cargo.toml
@@ -23,7 +23,7 @@ bufstream = "0.1"
 chrono = { version = "0.4.19", default-features = false }
 clap = { version = "3.2", features = ["derive"] }
 crossbeam = "0.8"
-crossterm = { version = "0.27.0" }
+crossterm = { version = "0.25.0" }
 derivative = "2.2.0"
 futures = "0.3"
 hex = "0.4.2"

--- a/applications/minotari_node/Cargo.toml
+++ b/applications/minotari_node/Cargo.toml
@@ -31,7 +31,7 @@ chrono = { version = "0.4.19", default-features = false }
 clap = { version = "3.2", features = ["derive", "env"] }
 console-subscriber = "0.1.8"
 config = { version = "0.13.0" }
-crossterm = { version = "0.27.0", features = ["event-stream"] }
+crossterm = { version = "0.25.0", features = ["event-stream"] }
 derive_more = "0.99.17"
 either = "1.6.1"
 futures = { version = "^0.3.16", default-features = false, features = ["alloc"] }


### PR DESCRIPTION
Description
---
A recent PR updated `crossterm` to the latest version, `0.27.0`, from version `0.25.0`. The behaviour of keyboard events on Windows changed from version `0.26.0` upwards, making the use of the console wallet and to a lesser degree the base node in Windows Console unusable as multiple keystrokes events are generated for each keystroke.

This PR did not seek to find a solution for upgrading to the latest version of `crossterm`, but merely to revert the change.

Motivation and Context
---
See above.

How Has This Been Tested?
---
System-level testing

What process can a PR reviewer use to test or verify this change?
---
Review code changes
System-level testing

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
