### PR TITLE
ci(fix): docker build - limit perms to package write only

### DIFF
--- a/.github/workflows/build_dockers.yml
+++ b/.github/workflows/build_dockers.yml
@@ -50,8 +50,11 @@ env:
   toolchain_default: nightly-2023-06-04
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # https://docs.github.com/en/actions/examples/using-concurrency-expressions-and-a-test-matrix
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/v') || github.ref != 'refs/heads/development' || github.ref != 'refs/heads/nextnet' || github.ref != 'refs/heads/stagenet' }}
+
+permissions: {}
 
 jobs:
   builds_envs_setup:
@@ -107,6 +110,8 @@ jobs:
 
   builds_run:
     needs: builds_envs_setup
+    permissions:
+      packages: write
     uses: ./.github/workflows/build_dockers_workflow.yml
     secrets: inherit
     with:

--- a/.github/workflows/build_dockers_workflow.yml
+++ b/.github/workflows/build_dockers_workflow.yml
@@ -40,6 +40,8 @@ env:
   LAUNCHPAD_REPO: tari-project/tari-launchpad
   LAUNCHPAD_BRANCH: main
 
+permissions: {}
+
 jobs:
   envs_setup:
     runs-on: ubuntu-latest
@@ -96,6 +98,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.envs_setup.outputs.matrix) }}
+
+    permissions:
+      packages: write
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Description
Limit perms to package write only for docker builds
Limit runner concurrency, exclude tags and main branches

Motivation and Context
Make docker builds a little more secure
Reduce resources usage, but still run on tags and main branches 

How Has This Been Tested?
Built in local fork

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
