### PR TITLE
feat: prevent mempool panic

### DIFF
--- a/base_layer/core/src/mempool/priority/prioritized_transaction.rs
+++ b/base_layer/core/src/mempool/priority/prioritized_transaction.rs
@@ -42,7 +42,13 @@ pub struct FeePriority(Vec<u8>);
 
 impl FeePriority {
     pub fn new(transaction: &Transaction, insert_epoch: u64, weight: u64) -> Result<Self, TransactionError> {
-        let fee_per_byte = transaction.body.get_total_fee()?.as_u64().saturating_mul(1000) / weight;
+        let fee_per_byte = transaction
+            .body
+            .get_total_fee()?
+            .as_u64()
+            .saturating_mul(1000)
+            .checked_div(weight)
+            .ok_or(TransactionError::ZeroWeight)?;
         // Big-endian used here, the MSB is in the starting index. The ordering for Vec<u8> is taken from elements left
         // to right and the unconfirmed pool expects the lowest priority to be sorted lowest to highest in the
         // BTreeMap
@@ -88,9 +94,6 @@ impl PrioritizedTransaction {
         dependent_outputs: Option<Vec<HashOutput>>,
     ) -> Result<PrioritizedTransaction, TransactionError> {
         let weight = transaction.calculate_weight(weighting)?;
-        if weight == 0 {
-            return Err(TransactionError::ZeroWeight);
-        }
         let insert_epoch = match SystemTime::now().duration_since(UNIX_EPOCH) {
             Ok(n) => n.as_secs(),
             Err(_) => 0,
@@ -98,7 +101,13 @@ impl PrioritizedTransaction {
         Ok(Self {
             key,
             priority: FeePriority::new(&transaction, insert_epoch, weight)?,
-            fee_per_byte: transaction.body.get_total_fee()?.as_u64().saturating_mul(1000) / weight,
+            fee_per_byte: transaction
+                .body
+                .get_total_fee()?
+                .as_u64()
+                .saturating_mul(1000)
+                .checked_div(weight)
+                .ok_or(TransactionError::ZeroWeight)?,
             weight,
             transaction,
             dependent_output_hashes: dependent_outputs.unwrap_or_default(),
@@ -167,7 +176,7 @@ mod tests {
     }
 
     #[test]
-    fn empty_transaction() {
+    fn prioritized_from_empty_transaction() {
         let weighting = TransactionWeight::latest();
         match PrioritizedTransaction::new(
             0,
@@ -180,6 +189,19 @@ mod tests {
                 Default::default(),
             )),
             None,
+        ) {
+            Ok(_) => panic!("Empty transaction should not be valid"),
+            Err(e) => assert_eq!(e, TransactionError::ZeroWeight),
+        }
+    }
+
+    #[test]
+    fn fee_priority_with_zero_weight() {
+        let weight = 0;
+        match FeePriority::new(
+            &Transaction::new(vec![], vec![], vec![], Default::default(), Default::default()),
+            SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs(),
+            weight,
         ) {
             Ok(_) => panic!("Empty transaction should not be valid"),
             Err(e) => assert_eq!(e, TransactionError::ZeroWeight),

--- a/base_layer/core/src/transactions/transaction_components/error.rs
+++ b/base_layer/core/src/transactions/transaction_components/error.rs
@@ -75,6 +75,8 @@ pub enum TransactionError {
     EncryptedDataError(String),
     #[error("Ledger device error: {0}")]
     LedgerDeviceError(#[from] LedgerDeviceError),
+    #[error("Transaction has a zero weight, not possible")]
+    ZeroWeight,
 }
 
 impl From<KeyManagerServiceError> for TransactionError {

--- a/base_layer/core/src/transactions/weight.rs
+++ b/base_layer/core/src/transactions/weight.rs
@@ -163,4 +163,11 @@ mod test {
             );
         }
     }
+
+    #[test]
+    fn empty_body_weight() {
+        let weighting = TransactionWeight::latest();
+        let body = AggregateBody::empty();
+        assert_eq!(weighting.calculate_body(&body).unwrap(), 0);
+    }
 }


### PR DESCRIPTION
Description
---
Under certain conditions, it is possible to let the mempool panic when is inserting an empty transaction. This PR prevents it.

Motivation and Context
---
HAZOP finding

How Has This Been Tested?
---
Unit tests added

What process can a PR reviewer use to test or verify this change?
---
Review code changes and unit tests

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
