### PR TITLE
feat(wallet): add command to create owner proof

### DIFF
--- a/applications/minotari_app_utilities/src/utilities.rs
+++ b/applications/minotari_app_utilities/src/utilities.rs
@@ -91,6 +91,12 @@ impl FromStr for UniPublicKey {
     }
 }
 
+impl UniPublicKey {
+    pub fn as_public_key(&self) -> &PublicKey {
+        &self.0
+    }
+}
+
 impl From<UniPublicKey> for PublicKey {
     fn from(id: UniPublicKey) -> Self {
         id.0

--- a/applications/minotari_console_wallet/src/cli.rs
+++ b/applications/minotari_console_wallet/src/cli.rs
@@ -136,6 +136,7 @@ pub enum CliCommands {
     RevalidateWalletDb,
     RegisterValidatorNode(RegisterValidatorNodeArgs),
     CreateTlsCerts,
+    CreateOwnerProof(CreateOwnerProofArgs),
 }
 
 #[derive(Debug, Args, Clone)]
@@ -303,5 +304,11 @@ pub struct RegisterValidatorNodeArgs {
     pub validator_node_public_nonce: UniPublicKey,
     pub validator_node_signature: Vec<u8>,
     #[clap(short, long, default_value = "Registering VN")]
+    pub message: String,
+}
+
+#[derive(Debug, Args, Clone)]
+pub struct CreateOwnerProofArgs {
+    pub commitment: UniPublicKey,
     pub message: String,
 }

--- a/base_layer/wallet/src/output_manager_service/mod.rs
+++ b/base_layer/wallet/src/output_manager_service/mod.rs
@@ -19,7 +19,7 @@
 // SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
+use tari_core::transactions::key_manager::SecretTransactionKeyManagerInterface;
 pub mod config;
 pub mod error;
 pub mod handle;
@@ -103,7 +103,7 @@ where T: OutputManagerBackend + 'static
 impl<T, TKeyManagerInterface> ServiceInitializer for OutputManagerServiceInitializer<T, TKeyManagerInterface>
 where
     T: OutputManagerBackend + 'static,
-    TKeyManagerInterface: TransactionKeyManagerInterface,
+    TKeyManagerInterface: SecretTransactionKeyManagerInterface,
 {
     async fn initialize(&mut self, context: ServiceInitializerContext) -> Result<(), ServiceInitializationError> {
         let (sender, receiver) = reply_channel::unbounded();


### PR DESCRIPTION
Description
---
Create a wallet command to create a proof (commitment signature) that you own a commitment

Motivation and Context
---
In some scenarios you want to prove that you own or can spend a commitment on chain, without actually spending it. 

How Has This Been Tested?
---
Tested with `cargo run --release --bin minotari_console_wallet -- -b . create-owner-proof 6234f3569a9dac7acf690348468d1fd87f59db7273f3851641c12417d4efea2b hello`


What process can a PR reviewer use to test or verify this change?
---
as above

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
