### PR TITLE
ci: bump nightly version

### DIFF
--- a/.github/workflows/base_node_binaries.json
+++ b/.github/workflows/base_node_binaries.json
@@ -2,7 +2,7 @@
   {
     "name": "linux-x86_64",
     "runs-on": "ubuntu-20.04",
-    "rust": "nightly-2023-12-12",
+    "rust": "nightly-2024-02-04",
     "target": "x86_64-unknown-linux-gnu",
     "cross": false
   },

--- a/.github/workflows/base_node_binaries.yml
+++ b/.github/workflows/base_node_binaries.yml
@@ -26,7 +26,7 @@ env:
   TBN_FEATURES: "default, safe"
   TBN_LIBRARIES: "minotari_mining_helper_ffi"
   TARI_NETWORK_DIR: testnet
-  toolchain: nightly-2023-12-12
+  toolchain: nightly-2024-02-04
   matrix-json-file: ".github/workflows/base_node_binaries.json"
   CARGO_HTTP_MULTIPLEXING: false
   CARGO_UNSTABLE_SPARSE_REGISTRY: true

--- a/.github/workflows/build_dockers.yml
+++ b/.github/workflows/build_dockers.yml
@@ -48,7 +48,7 @@ name: Build docker images
           - xmrig
 
 env:
-  toolchain_default: nightly-2023-12-12
+  toolchain_default: nightly-2024-02-04
 
 concurrency:
   # https://docs.github.com/en/actions/examples/using-concurrency-expressions-and-a-test-matrix

--- a/.github/workflows/build_dockers_workflow.yml
+++ b/.github/workflows/build_dockers_workflow.yml
@@ -14,7 +14,7 @@ name: Build docker images - workflow_call/on-demand
       toolchain:
         type: string
         description: 'Rust toolchain'
-        default: nightly-2023-12-12
+        default: nightly-2024-02-04
       arch:
         type: string
         default: x86-64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ name: CI
   merge_group:
 
 env:
-  toolchain: nightly-2023-12-12
+  toolchain: nightly-2024-02-04
   CARGO_HTTP_MULTIPLEXING: false
   CARGO_TERM_COLOR: always
   CARGO_UNSTABLE_SPARSE_REGISTRY: true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,7 +11,7 @@ name: Source Coverage
       - ci-coverage-*
 
 env:
-  toolchain: nightly-2023-12-12
+  toolchain: nightly-2024-02-04
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -27,7 +27,7 @@ name: Integration tests
         type: string
 
 env:
-  toolchain: nightly-2023-12-12
+  toolchain: nightly-2024-02-04
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/applications/minotari_ledger_wallet/rust-toolchain.toml
+++ b/applications/minotari_ledger_wallet/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2023-05-17"
+channel = "nightly-2024-02-04"

--- a/applications/minotari_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/minotari_node/src/grpc/base_node_grpc_server.rs
@@ -140,7 +140,7 @@ impl BaseNodeGrpcServer {
     }
 
     fn is_method_enabled(&self, grpc_method: GrpcMethod) -> bool {
-        let mining_method = vec![
+        let mining_method = [
             GrpcMethod::GetVersion,
             GrpcMethod::GetNewBlockTemplate,
             GrpcMethod::GetNewBlockWithCoinbases,
@@ -152,7 +152,7 @@ impl BaseNodeGrpcServer {
             GrpcMethod::GetTipInfo,
         ];
 
-        let second_layer_methods = vec![
+        let second_layer_methods = [
             GrpcMethod::GetVersion,
             GrpcMethod::GetConstants,
             GrpcMethod::GetMempoolTransactions,

--- a/base_layer/common_types/src/tx_id.rs
+++ b/base_layer/common_types/src/tx_id.rs
@@ -66,7 +66,7 @@ impl Hash for TxId {
 
 impl PartialEq for TxId {
     fn eq(&self, other: &Self) -> bool {
-        self.0.eq(&other.0)
+        self.0 == other.0
     }
 }
 

--- a/base_layer/core/src/covenants/decoder.rs
+++ b/base_layer/core/src/covenants/decoder.rs
@@ -95,6 +95,7 @@ pub(super) trait CovenantReadExt: io::Read {
 
 impl<R: io::Read> CovenantReadExt for R {
     /// Reads next byte code
+    #[allow(clippy::unused_io_amount)]
     fn read_next_byte_code(&mut self) -> Result<Option<u8>, io::Error> {
         let mut buf = [0u8; 1];
         loop {

--- a/base_layer/core/src/transactions/transaction_protocol/transaction_initializer.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/transaction_initializer.rs
@@ -502,7 +502,7 @@ where KM: TransactionKeyManagerInterface
             return self.build_err("Fee is less than the minimum");
         }
 
-        let change_output_pair = match { change_output } {
+        let change_output_pair = match change_output {
             Some((output, sender_offset_key_id)) => {
                 if self.sender_custom_outputs.len() >= MAX_TRANSACTION_OUTPUTS {
                     return self.build_err("Too many outputs in transaction");

--- a/base_layer/key_manager/src/lib.rs
+++ b/base_layer/key_manager/src/lib.rs
@@ -139,7 +139,7 @@ mod tests {
             Hidden::hide("olá".to_string()),
         ]);
 
-        let vec_words = vec![
+        let vec_words = [
             "hi".to_string(),
             "niao".to_string(),
             "hola".to_string(),

--- a/base_layer/mmr/src/backend.rs
+++ b/base_layer/mmr/src/backend.rs
@@ -83,7 +83,7 @@ impl<T: Clone + PartialEq> ArrayLike for Vec<T> {
     }
 
     fn get(&self, index: usize) -> Result<Option<Self::Value>, Self::Error> {
-        Ok((self as &[Self::Value]).get(index).map(Clone::clone))
+        Ok((self as &[Self::Value]).get(index).cloned())
     }
 
     fn clear(&mut self) -> Result<(), Self::Error> {

--- a/base_layer/service_framework/src/context/handles.rs
+++ b/base_layer/service_framework/src/context/handles.rs
@@ -197,7 +197,7 @@ impl ServiceHandles {
         acquire_lock!(self.handles)
             .get(&type_id)
             .and_then(|b| b.downcast_ref::<H>())
-            .map(Clone::clone)
+            .cloned()
     }
 
     /// Returns the shutdown signal for this stack

--- a/base_layer/wallet/src/operation_id.rs
+++ b/base_layer/wallet/src/operation_id.rs
@@ -50,7 +50,7 @@ impl Hash for OperationId {
 
 impl PartialEq for OperationId {
     fn eq(&self, other: &Self) -> bool {
-        self.0.eq(&other.0)
+        self.0 == other.0
     }
 }
 

--- a/base_layer/wallet/tests/transaction_service_tests/storage.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/storage.rs
@@ -115,7 +115,7 @@ pub async fn test_db_backend<T: TransactionBackend + 'static>(backend: T) {
 
     let stp = builder.build().await.unwrap();
 
-    let messages = vec!["Hey!".to_string(), "Yo!".to_string(), "Sup!".to_string()];
+    let messages = ["Hey!".to_string(), "Yo!".to_string(), "Sup!".to_string()];
     let amounts = [
         MicroMinotari::from(10_000),
         MicroMinotari::from(23_000),

--- a/base_layer/wallet_ffi/README.md
+++ b/base_layer/wallet_ffi/README.md
@@ -132,8 +132,8 @@ Install [Rust](https://www.rust-lang.org/tools/install)
 
 Install the following tools and system images
 ```Shell Script
-rustup toolchain add nightly-2023-12-12
-rustup default nightly-2023-12-12
+rustup toolchain add nightly-2024-02-04
+rustup default nightly-2024-02-04
 rustup component add rustfmt --toolchain nightly
 rustup component add clippy
 rustup target add x86_64-apple-ios aarch64-apple-ios # iPhone and emulator cross compiling

--- a/buildtools/docker/base_node.Dockerfile
+++ b/buildtools/docker/base_node.Dockerfile
@@ -1,13 +1,13 @@
 # syntax=docker/dockerfile:1
 #FROM rust:1.42.0 as builder
-FROM quay.io/tarilabs/rust_tari-build-with-deps:nightly-2023-12-12 as builder
+FROM quay.io/tarilabs/rust_tari-build-with-deps:nightly-2024-02-04 as builder
 
 # Copy the dependency lists
 #ADD Cargo.toml ./
 ADD . /minotari_node
 WORKDIR /minotari_node
 
-# RUN rustup component add rustfmt --toolchain nightly-2023-12-12-x86_64-unknown-linux-gnu
+# RUN rustup component add rustfmt --toolchain nightly-2024-02-04-x86_64-unknown-linux-gnu
 #ARG TBN_ARCH=native
 ARG TBN_ARCH=x86-64
 #ARG TBN_FEATURES=avx2

--- a/comms/core/src/peer_manager/migrations.rs
+++ b/comms/core/src/peer_manager/migrations.rs
@@ -31,7 +31,7 @@ pub(super) const MIGRATION_VERSION_KEY: u64 = u64::MAX;
 
 pub fn migrate(database: &LMDBDatabase) -> Result<(), LMDBError> {
     // Add migrations here in version order
-    let migrations = vec![v7::Migration.boxed()];
+    let migrations = [v7::Migration.boxed()];
     if migrations.is_empty() {
         return Ok(());
     }

--- a/comms/core/src/test_utils/mocks/connection_manager.rs
+++ b/comms/core/src/test_utils/mocks/connection_manager.rs
@@ -139,7 +139,7 @@ impl ConnectionManagerMock {
                     .lock()
                     .await
                     .get(&node_id)
-                    .map(Clone::clone)
+                    .cloned()
                     .ok_or(ConnectionManagerError::DialConnectFailedAllAddresses);
                 let _result = reply_tx.take().map(|tx| tx.send(result));
             },

--- a/comms/core/src/tor/hidden_service/controller.rs
+++ b/comms/core/src/tor/hidden_service/controller.rs
@@ -365,7 +365,7 @@ impl HiddenServiceController {
             },
         };
 
-        let identity = self.identity.as_ref().map(Clone::clone).expect("already checked");
+        let identity = self.identity.clone().expect("already checked");
         debug!(
             target: LOG_TARGET,
             "Added hidden service with service id '{}' on port '{}'", identity.service_id, identity.onion_port

--- a/comms/dht/src/test_utils/dht_actor_mock.rs
+++ b/comms/dht/src/test_utils/dht_actor_mock.rs
@@ -72,7 +72,7 @@ impl DhtMockState {
     }
 
     pub fn get_setting(&self, key: DhtMetadataKey) -> Option<Vec<u8>> {
-        self.settings.read().unwrap().get(&key.to_string()).map(Clone::clone)
+        self.settings.read().unwrap().get(&key.to_string()).cloned()
     }
 }
 
@@ -124,13 +124,7 @@ impl DhtActorMock {
                     .unwrap();
             },
             GetMetadata(key, reply_tx) => {
-                let _result = reply_tx.send(Ok(self
-                    .state
-                    .settings
-                    .read()
-                    .unwrap()
-                    .get(&key.to_string())
-                    .map(Clone::clone)));
+                let _result = reply_tx.send(Ok(self.state.settings.read().unwrap().get(&key.to_string()).cloned()));
             },
             SetMetadata(key, value, reply_tx) => {
                 self.state.settings.write().unwrap().insert(key.to_string(), value);

--- a/lints.toml
+++ b/lints.toml
@@ -69,4 +69,5 @@ allow = [
     'clippy::too_many_arguments',
     # `assert!(!foo(bar))` is misread the majority of the time, while `assert_eq!(foo(bar), false)` is crystal clear
     'clippy::bool-assert-comparison',
+    'clippy::blocks_in_conditions',
 ]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -13,4 +13,4 @@
 # - the CI files in .github folder
 # - the Makefile in base_layer/key_manager/Makefile
 [toolchain]
-channel = "nightly-2023-12-12"
+channel = "nightly-2024-02-04"

--- a/scripts/test_in_docker.sh
+++ b/scripts/test_in_docker.sh
@@ -2,8 +2,8 @@
 
 # Run the Tari test suite locally inside a suitable docker container
 
-IMAGE=quay.io/tarilabs/rust_tari-build-with-deps:nightly-2023-12-12
-TOOLCHAIN_VERSION=nightly-2023-12-12
+IMAGE=quay.io/tarilabs/rust_tari-build-with-deps:nightly-2024-02-04
+TOOLCHAIN_VERSION=nightly-2024-02-04
 CONTAINER=tari_test
 
 echo "Deleting old container"


### PR DESCRIPTION
Description
---
Bumps the nightly toolchain to `nightly-2024-02-04` in preparation for a curve library update.

Motivation and Context
---
An upcoming curve library update in #6228 will require moving the nightly toolchain. In preparation, this PR moves it as far as it can go without breaking. This lets us take care of lints now.

How Has This Been Tested?
---
Existing CI (but with the updated toolchain) passes.

What process can a PR reviewer use to test or verify this change?
---
Check that CI passes, that the nightly toolchain update is consistently applied, and that all code changes reflect only lint fixes.