### PR TITLE
feat: improve lmdb dynamic growth

### DIFF
--- a/applications/minotari_console_wallet/src/ui/mod.rs
+++ b/applications/minotari_console_wallet/src/ui/mod.rs
@@ -108,6 +108,7 @@ fn crossterm_loop(mut app: App<CrosstermBackend<Stdout>>) -> Result<(), ExitErro
             error!(target: LOG_TARGET, "Error drawing interface. {}", e);
             ExitCode::InterfaceError
         })?;
+        #[allow(clippy::blocks_in_conditions)]
         match events.next().map_err(|e| {
             error!(target: LOG_TARGET, "Error reading input event: {}", e);
             ExitCode::InterfaceError

--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -344,6 +344,7 @@ where B: BlockchainBackend + 'static
                     "A peer has requested a block with hash {}", block_hex
                 );
 
+                #[allow(clippy::blocks_in_conditions)]
                 let maybe_block = match self
                     .blockchain_db
                     .fetch_block_by_hash(hash, true)

--- a/base_layer/core/src/base_node/sync/rpc/service.rs
+++ b/base_layer/core/src/base_node/sync/rpc/service.rs
@@ -110,6 +110,7 @@ impl<B: BlockchainBackend + 'static> BaseNodeSyncRpcService<B> {
 #[tari_comms::async_trait]
 impl<B: BlockchainBackend + 'static> BaseNodeSyncService for BaseNodeSyncRpcService<B> {
     #[instrument(level = "trace", name = "sync_rpc::sync_blocks", skip(self), err)]
+    #[allow(clippy::blocks_in_conditions)]
     async fn sync_blocks(
         &self,
         request: Request<SyncBlocksRequest>,
@@ -273,6 +274,7 @@ impl<B: BlockchainBackend + 'static> BaseNodeSyncService for BaseNodeSyncRpcServ
     }
 
     #[instrument(level = "trace", name = "sync_rpc::sync_headers", skip(self), err)]
+    #[allow(clippy::blocks_in_conditions)]
     async fn sync_headers(
         &self,
         request: Request<SyncHeadersRequest>,
@@ -373,6 +375,7 @@ impl<B: BlockchainBackend + 'static> BaseNodeSyncService for BaseNodeSyncRpcServ
     }
 
     #[instrument(level = "trace", skip(self), err)]
+    #[allow(clippy::blocks_in_conditions)]
     async fn get_header_by_height(
         &self,
         request: Request<u64>,
@@ -389,6 +392,7 @@ impl<B: BlockchainBackend + 'static> BaseNodeSyncService for BaseNodeSyncRpcServ
     }
 
     #[instrument(level = "debug", skip(self), err)]
+    #[allow(clippy::blocks_in_conditions)]
     async fn find_chain_split(
         &self,
         request: Request<FindChainSplitRequest>,
@@ -452,6 +456,7 @@ impl<B: BlockchainBackend + 'static> BaseNodeSyncService for BaseNodeSyncRpcServ
     }
 
     #[instrument(level = "trace", skip(self), err)]
+    #[allow(clippy::blocks_in_conditions)]
     async fn get_chain_metadata(&self, _: Request<()>) -> Result<Response<proto::base_node::ChainMetadata>, RpcStatus> {
         let chain_metadata = self
             .db()
@@ -462,6 +467,7 @@ impl<B: BlockchainBackend + 'static> BaseNodeSyncService for BaseNodeSyncRpcServ
     }
 
     #[instrument(level = "trace", skip(self), err)]
+    #[allow(clippy::blocks_in_conditions)]
     async fn sync_kernels(
         &self,
         request: Request<SyncKernelsRequest>,
@@ -588,6 +594,7 @@ impl<B: BlockchainBackend + 'static> BaseNodeSyncService for BaseNodeSyncRpcServ
     }
 
     #[instrument(level = "trace", skip(self), err)]
+    #[allow(clippy::blocks_in_conditions)]
     async fn sync_utxos(&self, request: Request<SyncUtxosRequest>) -> Result<Streaming<SyncUtxosResponse>, RpcStatus> {
         let req = request.message();
         let peer_node_id = request.context().peer_node_id();

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{convert::TryFrom, fmt, fs, fs::File, ops::Deref, path::Path, sync::Arc, time::Instant};
+use std::{cmp::max, convert::TryFrom, fmt, fs, fs::File, ops::Deref, path::Path, sync::Arc, time::Instant};
 
 use fs2::FileExt;
 use lmdb_zero::{
@@ -41,7 +41,7 @@ use tari_common_types::{
     types::{BlockHash, Commitment, FixedHash, HashOutput, PublicKey, Signature},
 };
 use tari_mmr::sparse_merkle_tree::{DeleteResult, NodeKey, ValueHash};
-use tari_storage::lmdb_store::{db, LMDBBuilder, LMDBConfig, LMDBStore};
+use tari_storage::lmdb_store::{db, LMDBBuilder, LMDBConfig, LMDBStore, BYTES_PER_MB};
 use tari_utilities::{
     hex::{to_hex, Hex},
     ByteArray,
@@ -331,23 +331,10 @@ impl LMDBDatabase {
         #[allow(clippy::enum_glob_use)]
         use WriteOperation::*;
 
-        // Ensure there will be enough space in the database to insert the block before it is attempted; this is more
-        // efficient than relying on an error if the LMDB environment map size was reached with each component's insert
-        // operation, with cleanup, resize and re-try. This will also prevent block sync from stalling due to LMDB
-        // environment map size being reached.
-        if txn.operations().iter().any(|op| {
-            matches!(op, InsertOrphanBlock { .. }) ||
-                matches!(op, InsertTipBlockBody { .. }) ||
-                matches!(op, InsertChainOrphanBlock { .. })
-        }) {
-            unsafe {
-                LMDBStore::resize_if_required(&self.env, &self.env_config)?;
-            }
-        }
-
+        let number_of_operations = txn.operations().len();
         let write_txn = self.write_transaction()?;
-        for op in txn.operations() {
-            trace!(target: LOG_TARGET, "[apply_db_transaction] WriteOperation: {}", op);
+        for (i, op) in txn.operations().iter().enumerate() {
+            trace!(target: LOG_TARGET, "[apply_db_transaction] WriteOperation: {} ({} of {})", op, i + 1, number_of_operations);
             match op {
                 InsertOrphanBlock(block) => self.insert_orphan_block(&write_txn, block)?,
                 InsertChainHeader { header } => {
@@ -514,40 +501,41 @@ impl LMDBDatabase {
         Ok(())
     }
 
-    fn all_dbs(&self) -> [(&'static str, &DatabaseRef); 26] {
+    fn all_dbs(&self) -> [(&'static str, &DatabaseRef); 27] {
         [
-            ("metadata_db", &self.metadata_db),
-            ("headers_db", &self.headers_db),
-            ("header_accumulated_data_db", &self.header_accumulated_data_db),
-            ("block_accumulated_data_db", &self.block_accumulated_data_db),
-            ("block_hashes_db", &self.block_hashes_db),
-            ("utxos_db", &self.utxos_db),
-            ("inputs_db", &self.inputs_db),
-            ("txos_hash_to_index_db", &self.txos_hash_to_index_db),
-            ("kernels_db", &self.kernels_db),
-            ("kernel_excess_index", &self.kernel_excess_index),
-            ("kernel_excess_sig_index", &self.kernel_excess_sig_index),
-            ("kernel_mmr_size_index", &self.kernel_mmr_size_index),
-            ("utxo_commitment_index", &self.utxo_commitment_index),
-            ("contract_index", &self.contract_index),
-            ("unique_id_index", &self.unique_id_index),
+            (LMDB_DB_METADATA, &self.metadata_db),
+            (LMDB_DB_HEADERS, &self.headers_db),
+            (LMDB_DB_HEADER_ACCUMULATED_DATA, &self.header_accumulated_data_db),
+            (LMDB_DB_BLOCK_ACCUMULATED_DATA, &self.block_accumulated_data_db),
+            (LMDB_DB_BLOCK_HASHES, &self.block_hashes_db),
+            (LMDB_DB_UTXOS, &self.utxos_db),
+            (LMDB_DB_INPUTS, &self.inputs_db),
+            (LMDB_DB_TXOS_HASH_TO_INDEX, &self.txos_hash_to_index_db),
+            (LMDB_DB_KERNELS, &self.kernels_db),
+            (LMDB_DB_KERNEL_EXCESS_INDEX, &self.kernel_excess_index),
+            (LMDB_DB_KERNEL_EXCESS_SIG_INDEX, &self.kernel_excess_sig_index),
+            (LMDB_DB_KERNEL_MMR_SIZE_INDEX, &self.kernel_mmr_size_index),
+            (LMDB_DB_UTXO_COMMITMENT_INDEX, &self.utxo_commitment_index),
+            (LMDB_DB_CONTRACT_ID_INDEX, &self.contract_index),
+            (LMDB_DB_UNIQUE_ID_INDEX, &self.unique_id_index),
             (
-                "deleted_txo_hash_to_header_index",
+                LMDB_DB_DELETED_TXO_HASH_TO_HEADER_INDEX,
                 &self.deleted_txo_hash_to_header_index,
             ),
-            ("orphans_db", &self.orphans_db),
+            (LMDB_DB_ORPHANS, &self.orphans_db),
             (
-                "orphan_header_accumulated_data_db",
+                LMDB_DB_ORPHAN_HEADER_ACCUMULATED_DATA,
                 &self.orphan_header_accumulated_data_db,
             ),
-            ("monero_seed_height_db", &self.monero_seed_height_db),
-            ("orphan_chain_tips_db", &self.orphan_chain_tips_db),
-            ("orphan_parent_map_index", &self.orphan_parent_map_index),
-            ("bad_blocks", &self.bad_blocks),
-            ("reorgs", &self.reorgs),
-            ("validator_nodes", &self.validator_nodes),
-            ("validator_nodes_mapping", &self.validator_nodes_mapping),
-            ("template_registrations", &self.template_registrations),
+            (LMDB_DB_MONERO_SEED_HEIGHT, &self.monero_seed_height_db),
+            (LMDB_DB_ORPHAN_CHAIN_TIPS, &self.orphan_chain_tips_db),
+            (LMDB_DB_ORPHAN_PARENT_MAP_INDEX, &self.orphan_parent_map_index),
+            (LMDB_DB_BAD_BLOCK_LIST, &self.bad_blocks),
+            (LMDB_DB_REORGS, &self.reorgs),
+            (LMDB_DB_VALIDATOR_NODES, &self.validator_nodes),
+            (LMDB_DB_TIP_UTXO_SMT, &self.tip_utxo_smt),
+            (LMDB_DB_VALIDATOR_NODES_MAPPING, &self.validator_nodes_mapping),
+            (LMDB_DB_TEMPLATE_REGISTRATIONS, &self.template_registrations),
         ]
     }
 
@@ -1420,24 +1408,38 @@ impl LMDBDatabase {
     }
 
     fn insert_tip_smt(&self, txn: &WriteTransaction<'_>, smt: &OutputSmt) -> Result<(), ChainStorageError> {
+        let start = Instant::now();
         let k = MetadataKey::TipSmt;
+
+        // This is best effort, if it fails (typically when the entry does not yet exist) we just log it
+        if let Err(e) = lmdb_delete(txn, &self.tip_utxo_smt, &k.as_u32(), LMDB_DB_TIP_UTXO_SMT) {
+            debug!(
+                "Could NOT delete '{}' db with key '{}' ({})",
+                LMDB_DB_TIP_UTXO_SMT,
+                to_hex(k.as_u32().as_lmdb_bytes()),
+                e
+            );
+        }
 
         match lmdb_replace(txn, &self.tip_utxo_smt, &k.as_u32(), smt) {
             Ok(_) => {
                 trace!(
-                    "Inserted {} bytes with key '{}' into 'tip_utxo_smt' (size {})",
-                    serialize(smt).unwrap_or_default().len(),
+                    "Inserted {} MB with key '{}' into '{}' (size {}) in {:.2?}",
+                    serialize(smt).unwrap_or_default().len() / BYTES_PER_MB,
                     to_hex(k.as_u32().as_lmdb_bytes()),
-                    smt.size()
+                    LMDB_DB_TIP_UTXO_SMT,
+                    smt.size(),
+                    start.elapsed()
                 );
                 Ok(())
             },
             Err(e) => {
                 if let ChainStorageError::DbResizeRequired(Some(val)) = e {
                     trace!(
-                        "Could NOT insert {} bytes with key '{}' into 'tip_utxo_smt' (size {})",
-                        val,
+                        "Could NOT insert {} MB with key '{}' into '{}' (size {})",
+                        val / BYTES_PER_MB,
                         to_hex(k.as_u32().as_lmdb_bytes()),
+                        LMDB_DB_TIP_UTXO_SMT,
                         smt.size()
                     );
                 }
@@ -1791,10 +1793,35 @@ impl BlockchainBackend for LMDBDatabase {
             return Ok(());
         }
 
+        // Ensure there will be enough space in the database to insert the block and replace the SMT before it is
+        // attempted; this is more efficient than relying on an error if the LMDB environment map size was reached with
+        // the write operation, with cleanup, resize and re-try afterwards.
+        let block_operations = txn.operations().iter().filter(|op| {
+            matches!(op, WriteOperation::InsertOrphanBlock { .. }) ||
+                matches!(op, WriteOperation::InsertTipBlockBody { .. }) ||
+                matches!(op, WriteOperation::InsertChainOrphanBlock { .. })
+        });
+        let count = block_operations.count();
+        if count > 0 {
+            let (mapsize, size_used_bytes, size_left_bytes) = LMDBStore::get_stats(&self.env)?;
+            trace!(
+                target: LOG_TARGET,
+                "[apply_db_transaction] Block insert operations: {}, mapsize: {} MB, used: {} MB, remaining: {} MB",
+                count, mapsize / BYTES_PER_MB, size_used_bytes / BYTES_PER_MB, size_left_bytes / BYTES_PER_MB
+            );
+            unsafe {
+                LMDBStore::resize_if_required(
+                    &self.env,
+                    &self.env_config,
+                    Some(max(self.env_config.grow_size_bytes(), 128 * BYTES_PER_MB)),
+                )?;
+            }
+        }
+
         let mark = Instant::now();
-        // Resize this many times before assuming something is not right
-        const MAX_RESIZES: usize = 5;
-        for i in 0..MAX_RESIZES {
+        // Resize this many times before assuming something is not right (up to 1 GB)
+        let max_resizes = 1024 * BYTES_PER_MB / self.env_config.grow_size_bytes();
+        for i in 0..max_resizes {
             let num_operations = txn.operations().len();
             match self.apply_db_transaction(&txn) {
                 Ok(_) => {
@@ -1807,7 +1834,7 @@ impl BlockchainBackend for LMDBDatabase {
 
                     return Ok(());
                 },
-                Err(ChainStorageError::DbResizeRequired(shortfall)) => {
+                Err(ChainStorageError::DbResizeRequired(size_that_could_not_be_written)) => {
                     info!(
                         target: LOG_TARGET,
                         "Database resize required (resized {} time(s) in this transaction)",
@@ -1818,7 +1845,7 @@ impl BlockchainBackend for LMDBDatabase {
                     // BlockchainDatabase, so we know there are no other threads taking out LMDB transactions when this
                     // is called.
                     unsafe {
-                        LMDBStore::resize(&self.env, &self.env_config, shortfall)?;
+                        LMDBStore::resize(&self.env, &self.env_config, size_that_could_not_be_written)?;
                     }
                 },
                 Err(e) => {

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -578,7 +578,7 @@ impl LMDBDatabase {
                 mined_height: header_height,
                 mined_timestamp: header_timestamp,
             },
-            "utxos_db",
+            LMDB_DB_UTXOS,
         )?;
 
         Ok(())
@@ -1533,7 +1533,7 @@ impl LMDBDatabase {
                 buffer.copy_from_slice(&key_bytes[0..32]);
                 let key = OutputKey::new(&FixedHash::from(buffer), &input.output_hash())?;
                 debug!(target: LOG_TARGET, "Pruning output from 'utxos_db': key '{}'", key.0);
-                lmdb_delete(write_txn, &self.utxos_db, &key.convert_to_comp_key(), "utxos_db")?;
+                lmdb_delete(write_txn, &self.utxos_db, &key.convert_to_comp_key(), LMDB_DB_UTXOS)?;
             };
             // From 'txos_hash_to_index_db::utxos_db'
             debug!(
@@ -1545,7 +1545,7 @@ impl LMDBDatabase {
                 write_txn,
                 &self.txos_hash_to_index_db,
                 input.output_hash().as_slice(),
-                "utxos_db",
+                LMDB_DB_UTXOS,
             )?;
         }
 
@@ -1575,14 +1575,14 @@ impl LMDBDatabase {
                     write_txn,
                     &self.txos_hash_to_index_db,
                     output_hash.as_slice(),
-                    "utxos_db",
+                    LMDB_DB_UTXOS,
                 )?;
 
                 let mut buffer = [0u8; 32];
                 buffer.copy_from_slice(&key_bytes[0..32]);
                 let key = OutputKey::new(&FixedHash::from(buffer), output_hash)?;
                 debug!(target: LOG_TARGET, "Pruning output from 'utxos_db': key '{}'", key.0);
-                lmdb_delete(write_txn, &self.utxos_db, &key.convert_to_comp_key(), "utxos_db")?;
+                lmdb_delete(write_txn, &self.utxos_db, &key.convert_to_comp_key(), LMDB_DB_UTXOS)?;
             },
             None => return Err(ChainStorageError::InvalidOperation("Output key not found".to_string())),
         }

--- a/base_layer/core/src/chain_storage/tests/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/tests/blockchain_database.rs
@@ -428,7 +428,7 @@ mod fetch_total_size_stats {
         let _block_and_outputs = add_many_chained_blocks(2, &db, &key_manager).await;
         let stats = db.fetch_total_size_stats().unwrap();
         assert_eq!(
-            stats.sizes().iter().find(|s| s.name == "utxos_db").unwrap().num_entries,
+            stats.sizes().iter().find(|s| s.name == "utxos").unwrap().num_entries,
             genesis_output_count + 2
         );
     }

--- a/base_layer/core/src/validation/aggregate_body/aggregate_body_chain_validator.rs
+++ b/base_layer/core/src/validation/aggregate_body/aggregate_body_chain_validator.rs
@@ -110,7 +110,6 @@ fn validate_input_not_pruned<B: BlockchainBackend>(
     db: &B,
 ) -> Result<Vec<TransactionInput>, ValidationError> {
     let mut inputs: Vec<TransactionInput> = body.inputs().clone();
-    let outputs: Vec<TransactionOutput> = body.outputs().clone();
     for input in &mut inputs {
         if input.is_compact() {
             let output = match db.fetch_output(&input.output_hash()) {
@@ -118,7 +117,7 @@ fn validate_input_not_pruned<B: BlockchainBackend>(
                     Some(output_mined_info) => output_mined_info.output,
                     None => {
                         let input_output_hash = input.output_hash();
-                        if let Some(found) = outputs.iter().find(|o| o.hash() == input_output_hash) {
+                        if let Some(found) = body.outputs().iter().find(|o| o.hash() == input_output_hash) {
                             found.clone()
                         } else {
                             warn!(

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -4924,6 +4924,7 @@ pub unsafe extern "C" fn comms_list_connected_public_keys(
     let mut connectivity = (*wallet).wallet.comms.connectivity();
     let peer_manager = (*wallet).wallet.comms.peer_manager();
 
+    #[allow(clippy::blocks_in_conditions)]
     match (*wallet).runtime.block_on(async move {
         let connections = connectivity.get_active_connections().await?;
         let mut public_keys = Vec::with_capacity(connections.len());
@@ -6412,6 +6413,7 @@ pub unsafe extern "C" fn wallet_get_seed_peers(wallet: *mut TariWallet, error_ou
     }
     let peer_manager = (*wallet).wallet.comms.peer_manager();
     let query = PeerQuery::new().select_where(|p| p.is_seed());
+    #[allow(clippy::blocks_in_conditions)]
     match (*wallet).runtime.block_on(async move {
         let peers = peer_manager.perform_query(query).await?;
         let mut public_keys = Vec::with_capacity(peers.len());

--- a/common/config/presets/g_miner.toml
+++ b/common/config/presets/g_miner.toml
@@ -42,11 +42,6 @@
 # Base node reconnect timeout after any GRPC or miner error (default: 10 s)
 #wait_timeout_on_error = 10
 
-# The extra data to store in the coinbase, usually some data about the mining pool.
-# Note that this data is publicly readable, but it is suggested you populate it so that
-# pool dominance can be seen before any one party has more than 51%. (default = "minotari_miner")
-#coinbase_extra = "minotari_miner"
-
 # The Tari wallet address (valid address in hex) where the mining funds will be sent to - must be assigned
 # e.g. "78e724f466d202abdee0f23c261289074e4a2fc9eb61e83e0179eead76ce2d3f17"
 #wallet_payment_address = "YOUR_WALLET_TARI_ADDRESS"

--- a/infrastructure/storage/src/lmdb_store/mod.rs
+++ b/infrastructure/storage/src/lmdb_store/mod.rs
@@ -28,4 +28,4 @@ pub use lmdb_zero::{
     db,
     traits::{AsLmdbBytes, FromLmdbBytes},
 };
-pub use store::{DatabaseRef, LMDBBuilder, LMDBConfig, LMDBDatabase, LMDBStore};
+pub use store::{DatabaseRef, LMDBBuilder, LMDBConfig, LMDBDatabase, LMDBStore, BYTES_PER_MB};

--- a/infrastructure/storage/src/lmdb_store/store.rs
+++ b/infrastructure/storage/src/lmdb_store/store.rs
@@ -9,6 +9,7 @@ use std::{
     convert::TryInto,
     path::{Path, PathBuf},
     sync::Arc,
+    time::Instant,
 };
 
 use lmdb_zero::{
@@ -41,7 +42,7 @@ use crate::{
 };
 
 const LOG_TARGET: &str = "lmdb";
-const BYTES_PER_MB: usize = 1024 * 1024;
+pub const BYTES_PER_MB: usize = 1024 * 1024;
 
 /// An atomic pointer to an LMDB database instance
 pub type DatabaseRef = Arc<Database<'static>>;
@@ -92,7 +93,8 @@ impl LMDBConfig {
 
 impl Default for LMDBConfig {
     fn default() -> Self {
-        Self::new_from_mb(16, 16, 8)
+        // Do not choose these values too small, as the entire SMT is replaced for every new block
+        Self::new_from_mb(128, 128, 64)
     }
 }
 
@@ -186,7 +188,7 @@ impl LMDBBuilder {
             let flags = self.env_flags | open::NOTLS;
             let env = builder.open(&path, flags, 0o600)?;
             // SAFETY: no transactions can be open at this point
-            LMDBStore::resize_if_required(&env, &self.env_config)?;
+            LMDBStore::resize_if_required(&env, &self.env_config, None)?;
             Arc::new(env)
         };
 
@@ -346,16 +348,15 @@ pub struct LMDBStore {
 }
 
 impl LMDBStore {
-    /// Close all databases and close the environment. You cannot be guaranteed that the dbs will be closed after
-    /// calling this function because there still may be threads accessing / writing to a database that will block
-    /// this call. However, in that case `shutdown` returns an error.
+    /// Force flush the data buffers to disk.
     pub fn flush(&self) -> Result<(), lmdb_zero::error::Error> {
-        trace!(target: LOG_TARGET, "Forcing flush of buffers to disk");
+        let start = Instant::now();
         self.env.sync(true)?;
-        debug!(target: LOG_TARGET, "LMDB Buffers have been flushed");
+        trace!(target: LOG_TARGET, "LMDB buffers flashed in {:.2?}", start.elapsed());
         Ok(())
     }
 
+    /// Write log information about the LMDB environment and databases to the log.
     pub fn log_info(&self) {
         match self.env.info() {
             Err(e) => warn!(
@@ -406,10 +407,12 @@ impl LMDBStore {
         self.databases.get(db_name).cloned()
     }
 
+    /// Returns the LMDB environment configuration
     pub fn env_config(&self) -> LMDBConfig {
         self.env_config.clone()
     }
 
+    /// Returns the LMDB environment with handle
     pub fn env(&self) -> Arc<Environment> {
         self.env.clone()
     }
@@ -421,20 +424,37 @@ impl LMDBStore {
     /// not check for this condition, the caller must ensure it explicitly.
     ///
     /// <http://www.lmdb.tech/doc/group__mdb.html#gaa2506ec8dab3d969b0e609cd82e619e5>
-    pub unsafe fn resize_if_required(env: &Environment, config: &LMDBConfig) -> Result<(), LMDBError> {
+    pub unsafe fn resize_if_required(
+        env: &Environment,
+        config: &LMDBConfig,
+        increase_threshold_by: Option<usize>,
+    ) -> Result<(), LMDBError> {
+        let (mapsize, size_used_bytes, size_left_bytes) = LMDBStore::get_stats(env)?;
+        if size_left_bytes <= config.resize_threshold_bytes + increase_threshold_by.unwrap_or_default() {
+            debug!(
+                target: LOG_TARGET,
+                "Resize required: mapsize: {} MB, used: {} MB, remaining: {} MB",
+                mapsize / BYTES_PER_MB,
+                size_used_bytes / BYTES_PER_MB,
+                size_left_bytes / BYTES_PER_MB
+            );
+            Self::resize(env, config, Some(increase_threshold_by.unwrap_or_default()))?;
+        }
+        Ok(())
+    }
+
+    /// Returns the LMDB environment statistics.
+    /// Note:
+    ///   In Windows and Ubuntu, this function does not always return the actual used size of the
+    ///   database on disk when the database has grown large (> 700MB), reason unknown (not tested
+    ///   on Mac).
+    pub fn get_stats(env: &Environment) -> Result<(usize, usize, usize), LMDBError> {
         let env_info = env.info()?;
         let stat = env.stat()?;
         let size_used_bytes = stat.psize as usize * env_info.last_pgno;
         let size_left_bytes = env_info.mapsize - size_used_bytes;
 
-        if size_left_bytes <= config.resize_threshold_bytes {
-            debug!(
-                target: LOG_TARGET,
-                "Resize required: Used bytes: {}, Remaining bytes: {}", size_used_bytes, size_left_bytes
-            );
-            Self::resize(env, config, None)?;
-        }
-        Ok(())
+        Ok((env_info.mapsize, size_used_bytes, size_left_bytes))
     }
 
     /// Grows the LMDB environment by the configured amount
@@ -444,19 +464,25 @@ impl LMDBStore {
     /// not check for this condition, the caller must ensure it explicitly.
     ///
     /// <http://www.lmdb.tech/doc/group__mdb.html#gaa2506ec8dab3d969b0e609cd82e619e5>
-    pub unsafe fn resize(env: &Environment, config: &LMDBConfig, shortfall: Option<usize>) -> Result<(), LMDBError> {
+    pub unsafe fn resize(
+        env: &Environment,
+        config: &LMDBConfig,
+        increase_threshold_by: Option<usize>,
+    ) -> Result<(), LMDBError> {
+        let start = Instant::now();
         let env_info = env.info()?;
         let current_mapsize = env_info.mapsize;
-        env.set_mapsize(current_mapsize + config.grow_size_bytes + shortfall.unwrap_or_default())?;
+        env.set_mapsize(current_mapsize + config.grow_size_bytes + increase_threshold_by.unwrap_or_default())?;
         let env_info = env.info()?;
         let new_mapsize = env_info.mapsize;
         debug!(
             target: LOG_TARGET,
-            "({}) LMDB MB, mapsize was grown from {:?} MB to {:?} MB, increased by {:?} MB",
+            "({}) LMDB MB, mapsize was grown from {} MB to {} MB, increased by {} MB, in {:.2?}",
             env.path()?.to_str()?,
             current_mapsize / BYTES_PER_MB,
             new_mapsize / BYTES_PER_MB,
-            (config.grow_size_bytes + shortfall.unwrap_or_default()) / BYTES_PER_MB,
+            (config.grow_size_bytes + increase_threshold_by.unwrap_or_default()) / BYTES_PER_MB,
+            start.elapsed()
         );
 
         Ok(())
@@ -479,15 +505,17 @@ impl LMDBDatabase {
         K: AsLmdbBytes + ?Sized,
         V: Serialize,
     {
-        const MAX_RESIZES: usize = 5;
+        // Resize this many times before assuming something is not right (up to 1 GB)
+        let max_resizes = 1024 * BYTES_PER_MB / self.env_config.grow_size_bytes();
         let value = LMDBWriteTransaction::convert_value(value)?;
-        for _ in 0..MAX_RESIZES {
+        for i in 0..max_resizes {
             match self.write(key, &value) {
                 Ok(txn) => return Ok(txn),
                 Err(error::Error::Code(error::MAP_FULL)) => {
                     info!(
                         target: LOG_TARGET,
-                        "Failed to obtain write transaction because the database needs to be resized"
+                        "Database resize required (resized {} time(s) in this transaction)",
+                        i + 1
                     );
                     unsafe {
                         LMDBStore::resize(&self.env, &self.env_config, Some(value.len()))?;

--- a/infrastructure/storage/src/lmdb_store/store.rs
+++ b/infrastructure/storage/src/lmdb_store/store.rs
@@ -352,7 +352,7 @@ impl LMDBStore {
     pub fn flush(&self) -> Result<(), lmdb_zero::error::Error> {
         let start = Instant::now();
         self.env.sync(true)?;
-        trace!(target: LOG_TARGET, "LMDB buffers flashed in {:.2?}", start.elapsed());
+        trace!(target: LOG_TARGET, "LMDB buffers flushed in {:.2?}", start.elapsed());
         Ok(())
     }
 


### PR DESCRIPTION
Description
---
- Improved the LMDB resizing during block sync of many consecutive full blocks; this is required due to how the SMT works currently as it is replaced for every new block.
- Added SMT database write profiling measurements.

Motivation and Context
---
See above.

How Has This Been Tested?
---
- System-level testing in Windows and Ubuntu - archival node fresh block sync of many full blocks as generated during a stress test on `esmeralda`.
- `fn insert_tip_smt(&self, txn: &WriteTransaction<'_>, smt: &OutputSmt)` always succeeded with these settings.

![image](https://github.com/tari-project/tari/assets/39146854/fadd5c51-f98b-43b3-8cae-1c4fcdf58850)

![image](https://github.com/tari-project/tari/assets/39146854/411a1ef2-663c-4c34-838b-fde74042da99)


What process can a PR reviewer use to test or verify this change?
---
Code review

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
