### PR TITLE
feat: add monerod detection as an option to the merge mining proxy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if",
+ "getrandom",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -196,15 +209,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.38",
-]
-
-[[package]]
-name = "atomic-polyfill"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
-dependencies = [
- "critical-section",
 ]
 
 [[package]]
@@ -1254,6 +1258,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "cssparser"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b3df4f93e5fbbe73ec01ec8d3f68bba73107993a5b1e7519273c32db9b0d5be"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa",
+ "phf 0.11.2",
+ "smallvec",
+]
+
+[[package]]
+name = "cssparser-macros"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
+dependencies = [
+ "quote",
+ "syn 2.0.38",
+]
+
+[[package]]
 name = "csv"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1668,6 +1695,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "669a445ee724c5c69b1b06fe0b63e70a1c84bc9bb7d9696cd4f4e3ec45050408"
 
 [[package]]
+name = "dtoa"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcbb2bf8e87535c23f7a8a321e364ce21462d0ff10cb6407820e8e96dfff6653"
+
+[[package]]
+name = "dtoa-short"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbaceec3c6e4211c79e7b1800fb9680527106beb2f9c51904a3210c03a448c74"
+dependencies = [
+ "dtoa",
+]
+
+[[package]]
 name = "ecdsa"
 version = "0.16.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1703,6 +1745,12 @@ dependencies = [
  "sha2 0.10.8",
  "zeroize",
 ]
+
+[[package]]
+name = "ego-tree"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a68a4904193147e0a8dec3314640e6db742afd5f6e634f428a6af230d9b3591"
 
 [[package]]
 name = "either"
@@ -1962,6 +2010,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
+name = "futf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
+dependencies = [
+ "mac",
+ "new_debug_unreachable",
+]
+
+[[package]]
 name = "futures"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2075,6 +2133,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2083,6 +2150,15 @@ dependencies = [
  "typenum",
  "version_check",
  "zeroize",
+]
+
+[[package]]
+name = "getopts"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -2342,6 +2418,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
 dependencies = [
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bea68cab48b8459f17cf1c944c67ddc572d272d9f2b274140f223ecb1da4a3b7"
+dependencies = [
+ "log",
+ "mac",
+ "markup5ever",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2976,6 +3066,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "mac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
+name = "markup5ever"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2629bb1404f3d34c2e921f21fd34ba00b206124c81f65c50b43b6aaefeb016"
+dependencies = [
+ "log",
+ "phf 0.10.1",
+ "phf_codegen",
+ "string_cache",
+ "string_cache_codegen",
+ "tendril",
+]
+
+[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3241,12 +3351,14 @@ dependencies = [
  "hyper",
  "jsonrpc",
  "log",
+ "markup5ever",
  "minotari_app_grpc",
  "minotari_app_utilities",
  "minotari_node_grpc_client",
  "minotari_wallet_grpc_client",
  "monero",
  "reqwest",
+ "scraper",
  "serde",
  "serde_json",
  "tari_common",
@@ -3595,6 +3707,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
 name = "newtype-ops"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3788,12 +3906,12 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 dependencies = [
- "atomic-polyfill",
  "critical-section",
+ "portable-atomic",
 ]
 
 [[package]]
@@ -4178,6 +4296,86 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
+dependencies = [
+ "phf_shared 0.10.0",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
+dependencies = [
+ "phf_macros",
+ "phf_shared 0.11.2",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb1c3a8bc4dd4e5cfce29b44ffc14bedd2ee294559a294e2a4d4c9e9a6a13cd"
+dependencies = [
+ "phf_generator 0.10.0",
+ "phf_shared 0.10.0",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
+dependencies = [
+ "phf_shared 0.10.0",
+ "rand",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
+dependencies = [
+ "phf_shared 0.11.2",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3444646e286606587e49f3bcf1679b8cef1dc2c5ecc29ddacaffc305180d464b"
+dependencies = [
+ "phf_generator 0.11.2",
+ "phf_shared 0.11.2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4314,6 +4512,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4324,6 +4528,12 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "prettyplease"
@@ -5019,6 +5229,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scraper"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b80b33679ff7a0ea53d37f3b39de77ea0c75b12c5805ac43ec0c33b3051af1b"
+dependencies = [
+ "ahash",
+ "cssparser",
+ "ego-tree",
+ "getopts",
+ "html5ever",
+ "once_cell",
+ "selectors",
+ "tendril",
+]
+
+[[package]]
 name = "sct"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5075,6 +5301,25 @@ checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "selectors"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eb30575f3638fc8f6815f448d50cb1a2e255b0897985c8c59f4d37b72a07b06"
+dependencies = [
+ "bitflags 2.4.1",
+ "cssparser",
+ "derive_more",
+ "fxhash",
+ "log",
+ "new_debug_unreachable",
+ "phf 0.10.1",
+ "phf_codegen",
+ "precomputed-hash",
+ "servo_arc",
+ "smallvec",
 ]
 
 [[package]]
@@ -5167,6 +5412,15 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "servo_arc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d036d71a959e00c77a63538b90a6c2390969f9772b096ea837205c6bd0491a44"
+dependencies = [
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -5275,6 +5529,12 @@ dependencies = [
  "digest 0.10.7",
  "rand_core",
 ]
+
+[[package]]
+name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "slab"
@@ -5389,6 +5649,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "stack-buf"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5405,6 +5671,32 @@ name = "str-buf"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
+
+[[package]]
+name = "string_cache"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f91138e76242f575eb1d3b38b4f1362f10d3a43f47d182a5b359af488a02293b"
+dependencies = [
+ "new_debug_unreachable",
+ "once_cell",
+ "parking_lot 0.12.1",
+ "phf_shared 0.10.0",
+ "precomputed-hash",
+ "serde",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bb30289b722be4ff74a408c3cc27edeaad656e06cb1fe8fa9231fa59c728988"
+dependencies = [
+ "phf_generator 0.10.0",
+ "phf_shared 0.10.0",
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "strip-ansi-escapes"
@@ -6251,6 +6543,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tendril"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
+dependencies = [
+ "futf",
+ "mac",
+ "utf-8",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6996,6 +7299,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7508,6 +7817,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 dependencies = [
  "time",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
 ]
 
 [[package]]

--- a/applications/minotari_merge_mining_proxy/Cargo.toml
+++ b/applications/minotari_merge_mining_proxy/Cargo.toml
@@ -44,6 +44,10 @@ tokio = { version = "1.36", features = ["macros"] }
 tonic = "0.8.3"
 tracing = "0.1"
 url = "2.1.1"
+scraper = "0.19.0"
 
 [build-dependencies]
 tari_features = { path = "../../common/tari_features", version = "1.0.0-pre.11a"}
+
+[dev-dependencies]
+markup5ever = "0.11.0"

--- a/applications/minotari_merge_mining_proxy/log4rs_sample.yml
+++ b/applications/minotari_merge_mining_proxy/log4rs_sample.yml
@@ -55,4 +55,15 @@ loggers:
       - stdout
       - proxy
     additive: false
-  
+  html5ever:
+    level: error
+    appenders:
+      - stdout
+      - proxy
+    additive: false
+  selectors:
+    level: error
+    appenders:
+      - stdout
+      - proxy
+    additive: false

--- a/applications/minotari_merge_mining_proxy/src/block_template_data.rs
+++ b/applications/minotari_merge_mining_proxy/src/block_template_data.rs
@@ -20,7 +20,7 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//! Provides methods for for building template data and storing them with timestamps.
+//! Provides methods for building template data and storing them with timestamps.
 
 use std::{collections::HashMap, convert::TryFrom, sync::Arc};
 

--- a/applications/minotari_merge_mining_proxy/src/config.rs
+++ b/applications/minotari_merge_mining_proxy/src/config.rs
@@ -32,11 +32,22 @@ use tari_common_types::tari_address::TariAddress;
 use tari_comms::multiaddr::Multiaddr;
 use tari_core::transactions::transaction_components::RangeProofType;
 
+// The default Monero fail URL for mainnet
+const MONERO_FAIL_MAINNET_URL: &str = "https://monero.fail/?chain=monero&network=mainnet&all=true";
+
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 #[allow(clippy::struct_excessive_bools)]
 pub struct MergeMiningProxyConfig {
     override_from: Option<String>,
+    /// Use dynamic monerod URL obtained form the official Monero website (https://monero.fail/)
+    pub use_dynamic_fail_data: bool,
+    /// The monero fail URL to get the monerod URLs from - must be pointing to the official Monero website.
+    /// Valid alternatives are:
+    /// - mainnet:  'https://monero.fail/?chain=monero&network=mainnet&all=true'
+    /// - stagenet: `https://monero.fail/?chain=monero&network=stagenet&all=true`
+    /// - testnet:  `https://monero.fail/?chain=monero&network=testnet&all=true`
+    pub monero_fail_url: String,
     /// URL to monerod (you can add your own server here or use public nodes from https://monero.fail/)
     pub monerod_url: StringList,
     /// Username for curl
@@ -83,14 +94,14 @@ pub struct MergeMiningProxyConfig {
     pub stealth_payment: bool,
     /// Range proof type - revealed_value or bullet_proof_plus: (default = revealed_value)
     pub range_proof_type: RangeProofType,
-    /// Use dynamic monerod URL obtained form the official Monero website (https://monero.fail/)
-    pub use_dynamic_monerod_url: bool,
 }
 
 impl Default for MergeMiningProxyConfig {
     fn default() -> Self {
         Self {
             override_from: None,
+            use_dynamic_fail_data: true,
+            monero_fail_url: MONERO_FAIL_MAINNET_URL.into(),
             monerod_url: StringList::default(),
             monerod_username: String::new(),
             monerod_password: String::new(),
@@ -110,7 +121,6 @@ impl Default for MergeMiningProxyConfig {
             wallet_payment_address: TariAddress::default().to_hex(),
             stealth_payment: true,
             range_proof_type: RangeProofType::RevealedValue,
-            use_dynamic_monerod_url: true,
         }
     }
 }

--- a/applications/minotari_merge_mining_proxy/src/config.rs
+++ b/applications/minotari_merge_mining_proxy/src/config.rs
@@ -37,7 +37,7 @@ use tari_core::transactions::transaction_components::RangeProofType;
 #[allow(clippy::struct_excessive_bools)]
 pub struct MergeMiningProxyConfig {
     override_from: Option<String>,
-    /// URL to monerod
+    /// URL to monerod (you can add your own server here or use public nodes from https://monero.fail/)
     pub monerod_url: StringList,
     /// Username for curl
     pub monerod_username: String,
@@ -83,6 +83,8 @@ pub struct MergeMiningProxyConfig {
     pub stealth_payment: bool,
     /// Range proof type - revealed_value or bullet_proof_plus: (default = revealed_value)
     pub range_proof_type: RangeProofType,
+    /// Use dynamic monerod URL obtained form the official Monero website (https://monero.fail/)
+    pub use_dynamic_monerod_url: bool,
 }
 
 impl Default for MergeMiningProxyConfig {
@@ -108,6 +110,7 @@ impl Default for MergeMiningProxyConfig {
             wallet_payment_address: TariAddress::default().to_hex(),
             stealth_payment: true,
             range_proof_type: RangeProofType::RevealedValue,
+            use_dynamic_monerod_url: true,
         }
     }
 }

--- a/applications/minotari_merge_mining_proxy/src/error.rs
+++ b/applications/minotari_merge_mining_proxy/src/error.rs
@@ -77,7 +77,7 @@ pub enum MmProxyError {
     },
     #[error("HTTP error: {0}")]
     HttpError(#[from] hyper::http::Error),
-    #[error("Grpc authentication error: {0}")]
+    #[error("HTML parse error: {0}")]
     HtmlParseError(String),
     #[error("Could not parse URL: {0}")]
     UrlParseError(#[from] url::ParseError),

--- a/applications/minotari_merge_mining_proxy/src/error.rs
+++ b/applications/minotari_merge_mining_proxy/src/error.rs
@@ -77,6 +77,8 @@ pub enum MmProxyError {
     },
     #[error("HTTP error: {0}")]
     HttpError(#[from] hyper::http::Error),
+    #[error("Grpc authentication error: {0}")]
+    HtmlParseError(String),
     #[error("Could not parse URL: {0}")]
     UrlParseError(#[from] url::ParseError),
     #[error("Bincode error: {0}")]

--- a/applications/minotari_merge_mining_proxy/src/lib.rs
+++ b/applications/minotari_merge_mining_proxy/src/lib.rs
@@ -33,7 +33,7 @@ mod error;
 mod proxy;
 mod run_merge_miner;
 use run_merge_miner::start_merge_miner;
-mod monerod_detect;
+mod monero_fail;
 
 pub async fn merge_miner(cli: Cli) -> Result<(), anyhow::Error> {
     start_merge_miner(cli).await

--- a/applications/minotari_merge_mining_proxy/src/lib.rs
+++ b/applications/minotari_merge_mining_proxy/src/lib.rs
@@ -33,6 +33,7 @@ mod error;
 mod proxy;
 mod run_merge_miner;
 use run_merge_miner::start_merge_miner;
+mod monerod_detect;
 
 pub async fn merge_miner(cli: Cli) -> Result<(), anyhow::Error> {
     start_merge_miner(cli).await

--- a/applications/minotari_merge_mining_proxy/src/main.rs
+++ b/applications/minotari_merge_mining_proxy/src/main.rs
@@ -28,6 +28,7 @@ mod cli;
 mod common;
 mod config;
 mod error;
+mod monerod_detect;
 mod proxy;
 mod run_merge_miner;
 

--- a/applications/minotari_merge_mining_proxy/src/main.rs
+++ b/applications/minotari_merge_mining_proxy/src/main.rs
@@ -28,7 +28,7 @@ mod cli;
 mod common;
 mod config;
 mod error;
-mod monerod_detect;
+mod monero_fail;
 mod proxy;
 mod run_merge_miner;
 

--- a/applications/minotari_merge_mining_proxy/src/monerod_detect.rs
+++ b/applications/minotari_merge_mining_proxy/src/monerod_detect.rs
@@ -1,0 +1,333 @@
+//  Copyright 2020, The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::time::Duration;
+
+use log::*;
+use scraper::{Html, Selector};
+use tokio::time::timeout;
+use url::Url;
+
+use crate::error::MmProxyError;
+
+const LOG_TARGET: &str = "minotari_mm_proxy::monero_detect";
+/// The public available Monero nodes
+pub const MONERO_FAIL_URL: &str = "https://monero.fail/?chain=monero&network=mainnet&all=true";
+
+/// Monero public server information
+#[derive(Debug)]
+pub struct MonerodEntry {
+    /// The type of address
+    pub address_type: String,
+    /// The URL of the server
+    pub url: String,
+    /// The monero blockchain height reported by the server
+    pub height: u64,
+    /// Whether the server is currently up
+    pub up: bool,
+    /// Whether the server is web compatible
+    pub web_compatible: bool,
+    /// The network the server is on (mainnet, stagenet, testnet)
+    pub network: String,
+    /// Time since the server was checked
+    pub last_checked: String,
+    /// The history of the server being up
+    pub up_history: Vec<bool>,
+    /// Response time
+    pub response_time: Option<Duration>,
+}
+
+/// Get the latest monerod public nodes (by scraping the HTML frm the monero.fail website) that are
+/// currently up and has a full history of being up all the time.
+#[allow(clippy::too_many_lines)]
+pub async fn get_monerod_info(
+    number_of_entries: usize,
+    connection_test_timeout: Duration,
+) -> Result<Vec<MonerodEntry>, MmProxyError> {
+    let document = get_monerod_html(MONERO_FAIL_URL).await?;
+
+    // The HTML table definition and an example entry looks like this:
+    //   <table class="pure-table pure-table-horizontal pure-table-striped js-sort-table">
+    //       <thead>
+    //           <tr>
+    //               <th class="js-sort-string">Type</th>
+    //               <th class="js-sort-string">URL</th>
+    //               <th class="js-sort-number">Height</th>
+    //               <th class="js-sort-none">Up</th>
+    //               <th class="js-sort-none">Web<br/>Compatible</th>
+    //               <th class="js-sort-none">Network</th>
+    //               <th class="js-sort-none">Last Checked</th>
+    //               <th class="js-sort-none">History</th>
+    //           </tr>
+    //       </thead>
+    //       <tbody>
+    //
+    //           <tr class="js-sort-table">
+    //               <td>
+    //                   <img src="/static/images/tor.svg" height="20px">
+    //                   <span class="hidden">tor</span>
+    //               </td>
+    //               <td>
+    //                   <span class="nodeURL">http://node.liumin.io:18089</span>
+    //               </td>
+    //               <td>3119644</td>
+    //               <td>
+    //                   <span class="dot glowing-green"></span>
+    //               </td>
+    //               <td>
+    //                   <img src="/static/images/error.svg" class="filter-red" width=16px>
+    //               </td>
+    //               <td>mainnet</td>
+    //               <td>5 hours ago</td>
+    //               <td>
+    //                   <span class="dot glowing-green"></span>
+    //                   <span class="dot glowing-green"></span>
+    //                   <span class="dot glowing-green"></span>
+    //                   <span class="dot glowing-green"></span>
+    //                   <span class="dot glowing-green"></span>
+    //                   <span class="dot glowing-green"></span>
+    //               </td>
+    //           </tr>
+
+    // Define selectors for table elements
+    let row_selector =
+        Selector::parse("tr.js-sort-table").map_err(|e| MmProxyError::HtmlParseError(format!("{}", e)))?;
+    let type_selector =
+        Selector::parse("td:nth-child(1)").map_err(|e| MmProxyError::HtmlParseError(format!("{}", e)))?;
+    let url_selector =
+        Selector::parse("td:nth-child(2) .nodeURL").map_err(|e| MmProxyError::HtmlParseError(format!("{}", e)))?;
+    let height_selector =
+        Selector::parse("td:nth-child(3)").map_err(|e| MmProxyError::HtmlParseError(format!("{}", e)))?;
+    let up_selector = Selector::parse("td:nth-child(4) .dot.glowing-green, td:nth-child(4) .dot.glowing-red")
+        .map_err(|e| MmProxyError::HtmlParseError(format!("{}", e)))?;
+    let web_compatible_selector = Selector::parse("td:nth-child(5) img.filter-green, td:nth-child(5) img.filter-red")
+        .map_err(|e| MmProxyError::HtmlParseError(format!("{}", e)))?;
+    let network_selector =
+        Selector::parse("td:nth-child(6)").map_err(|e| MmProxyError::HtmlParseError(format!("{}", e)))?;
+    let last_checked_selector =
+        Selector::parse("td:nth-child(7)").map_err(|e| MmProxyError::HtmlParseError(format!("{}", e)))?;
+    let history_selector = Selector::parse("td:nth-child(8) .dot.glowing-green, td:nth-child(8) .dot.glowing-red")
+        .map_err(|e| MmProxyError::HtmlParseError(format!("{}", e)))?;
+
+    let mut entries = Vec::new();
+
+    // Iterate over table rows and extract data
+    for row in document.select(&row_selector) {
+        let address_type = match row.select(&type_selector).next() {
+            Some(val) => val.text().collect::<String>().trim().to_string(),
+            None => return Err(MmProxyError::HtmlParseError("address type".to_string())),
+        };
+
+        let url = match row.select(&url_selector).next() {
+            Some(val) => val.text().collect::<String>().trim().to_string(),
+            None => return Err(MmProxyError::HtmlParseError("url".to_string())),
+        };
+
+        let height = match row.select(&height_selector).next() {
+            Some(val) => val.text().collect::<String>().trim().parse::<u64>().unwrap_or_default(),
+            None => return Err(MmProxyError::HtmlParseError("height".to_string())),
+        };
+
+        let mut up = false;
+        let iter = row.select(&up_selector);
+        for item in iter {
+            let class = item.value().attr("class").unwrap_or("");
+            if class.contains("dot glowing-green") {
+                up = true;
+                break;
+            }
+        }
+
+        let mut web_compatible = false;
+        let iter = row.select(&web_compatible_selector);
+        for item in iter {
+            let class = item.value().attr("class").unwrap_or("");
+            if class.contains("filter-green") {
+                web_compatible = true;
+                break;
+            }
+        }
+
+        let network = match row.select(&network_selector).next() {
+            Some(val) => val.text().collect::<String>().trim().to_string(),
+            None => return Err(MmProxyError::HtmlParseError("network".to_string())),
+        };
+
+        let last_checked = match row.select(&last_checked_selector).next() {
+            Some(val) => val.text().collect::<String>().trim().to_string(),
+            None => return Err(MmProxyError::HtmlParseError("last checked".to_string())),
+        };
+
+        let mut up_history = Vec::new();
+        let iter = row.select(&history_selector);
+        for item in iter {
+            let class = item.value().attr("class").unwrap_or("");
+            up_history.push(class.contains("dot glowing-green"));
+        }
+
+        let entry = MonerodEntry {
+            address_type: address_type.to_lowercase(),
+            url,
+            height,
+            up,
+            web_compatible,
+            network: network.to_lowercase(),
+            last_checked,
+            up_history,
+            response_time: None,
+        };
+        entries.push(entry);
+    }
+
+    // Only retain nodes that are currently up and has a full history of being up all the time
+    let max_history_length = entries.iter().map(|entry| entry.up_history.len()).max().unwrap_or(0);
+    entries.retain(|entry| {
+        entry.up && entry.up_history.iter().filter(|&&v| v).collect::<Vec<_>>().len() == max_history_length
+    });
+    // Only retain non-tor and non-i2p nodes
+    entries.retain(|entry| entry.address_type != *"tor" && entry.address_type != *"i2p");
+    // Give preference to nodes with the best height
+    entries.sort_by(|a, b| b.height.cmp(&a.height));
+    // Determine connection times - use slightly more nodes than requested
+    entries.truncate(number_of_entries + 10);
+    for entry in &mut entries {
+        let uri = format!("{}/getheight", entry.url).parse::<Url>()?;
+        let start = std::time::Instant::now();
+        if (timeout(connection_test_timeout, reqwest::get(uri.clone())).await).is_ok() {
+            entry.response_time = Some(start.elapsed());
+            debug!(target: LOG_TARGET, "Response time '{:.2?}' for Monerod server at: {}", entry.response_time, uri.as_str());
+        } else {
+            debug!(target: LOG_TARGET, "Response time 'n/a' for Monerod server at: {}, timed out", uri.as_str());
+        }
+    }
+    // Sort by response time
+    entries.sort_by(|a, b| {
+        a.response_time
+            .unwrap_or_else(|| Duration::from_secs(100))
+            .cmp(&b.response_time.unwrap_or_else(|| Duration::from_secs(100)))
+    });
+    // Truncate to the requested number of entries
+    entries.truncate(number_of_entries);
+
+    if entries.is_empty() {
+        return Err(MmProxyError::HtmlParseError(
+            "No public monero servers available".to_string(),
+        ));
+    }
+    Ok(entries)
+}
+
+async fn get_monerod_html(url: &str) -> Result<Html, MmProxyError> {
+    let body = match reqwest::get(url).await {
+        Ok(resp) => match resp.text().await {
+            Ok(html) => html,
+            Err(e) => {
+                error!("Failed to fetch monerod info: {}", e);
+                return Err(MmProxyError::MonerodRequestFailed(e));
+            },
+        },
+        Err(e) => {
+            error!("Failed to fetch monerod info: {}", e);
+            return Err(MmProxyError::MonerodRequestFailed(e));
+        },
+    };
+
+    Ok(Html::parse_document(&body))
+}
+
+#[cfg(test)]
+mod test {
+    use std::{ops::Deref, time::Duration};
+
+    use markup5ever::{local_name, namespace_url, ns, QualName};
+    use scraper::Html;
+
+    use crate::monerod_detect::{get_monerod_html, get_monerod_info, MONERO_FAIL_URL};
+
+    #[tokio::test]
+    async fn test_get_monerod_info() {
+        let entries = get_monerod_info(5, Duration::from_secs(2)).await.unwrap();
+        for (i, entry) in entries.iter().enumerate() {
+            assert!(entry.up && entry.up_history.iter().all(|&v| v));
+            if i > 0 {
+                assert!(
+                    entry.response_time.unwrap_or_else(|| Duration::from_secs(100)) >=
+                        entries[i - 1].response_time.unwrap_or_else(|| Duration::from_secs(100))
+                );
+            }
+            println!("{}: {:?}", i, entry);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_table_structure() {
+        let html_content = get_monerod_html(MONERO_FAIL_URL).await.unwrap();
+
+        let table_structure = extract_table_structure(&html_content);
+
+        let expected_structure = vec![
+            "Type",
+            "URL",
+            "Height",
+            "Up",
+            "Web",
+            "Compatible",
+            "Network",
+            "Last Checked",
+            "History",
+        ];
+
+        // Compare the actual and expected table structures
+        assert_eq!(table_structure, expected_structure);
+    }
+
+    // Function to extract table structure from the document
+    fn extract_table_structure(html_document: &Html) -> Vec<&str> {
+        let mut table_structure = Vec::new();
+        if let Some(table) = html_document.tree.root().descendants().find(|n| {
+            n.value().is_element() &&
+                n.value().as_element().unwrap().name == QualName::new(None, ns!(html), local_name!("table"))
+        }) {
+            if let Some(thead) = table.descendants().find(|n| {
+                n.value().is_element() &&
+                    n.value().as_element().unwrap().name == QualName::new(None, ns!(html), local_name!("thead"))
+            }) {
+                if let Some(tr) = thead.descendants().find(|n| {
+                    n.value().is_element() &&
+                        n.value().as_element().unwrap().name == QualName::new(None, ns!(html), local_name!("tr"))
+                }) {
+                    for th in tr.descendants().filter(|n| {
+                        n.value().is_element() &&
+                            n.value().as_element().unwrap().name == QualName::new(None, ns!(html), local_name!("th"))
+                    }) {
+                        for child in th.children() {
+                            if let Some(text) = child.value().as_text() {
+                                table_structure.push(text.deref().trim());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        table_structure
+    }
+}

--- a/applications/minotari_merge_mining_proxy/src/run_merge_miner.rs
+++ b/applications/minotari_merge_mining_proxy/src/run_merge_miner.rs
@@ -34,7 +34,7 @@ use minotari_app_utilities::parse_miner_input::{
 };
 use minotari_node_grpc_client::{grpc, grpc::base_node_client::BaseNodeClient};
 use minotari_wallet_grpc_client::ClientAuthenticationInterceptor;
-use tari_common::{load_configuration, DefaultConfigLoader};
+use tari_common::{configuration::StringList, load_configuration, DefaultConfigLoader};
 use tari_comms::utils::multiaddr::multiaddr_to_socketaddr;
 use tari_core::proof_of_work::randomx_factory::RandomXFactory;
 use tokio::time::Duration;
@@ -44,6 +44,7 @@ use crate::{
     block_template_data::BlockTemplateRepository,
     config::MergeMiningProxyConfig,
     error::MmProxyError,
+    monerod_detect::get_monerod_info,
     proxy::MergeMiningProxyService,
     Cli,
 };
@@ -55,6 +56,10 @@ pub async fn start_merge_miner(cli: Cli) -> Result<(), anyhow::Error> {
     let cfg = load_configuration(&config_path, true, cli.non_interactive_mode, &cli)?;
     let mut config = MergeMiningProxyConfig::load_from(&cfg)?;
     config.set_base_path(cli.common.get_base_path());
+    if config.use_dynamic_monerod_url {
+        let entries = get_monerod_info(15, Duration::from_secs(5)).await?;
+        config.monerod_url = StringList::from(entries.into_iter().map(|entry| entry.url).collect::<Vec<_>>());
+    }
 
     info!(target: LOG_TARGET, "Configuration: {:?}", config);
     let client = reqwest::Client::builder()

--- a/applications/minotari_merge_mining_proxy/src/run_merge_miner.rs
+++ b/applications/minotari_merge_mining_proxy/src/run_merge_miner.rs
@@ -44,7 +44,7 @@ use crate::{
     block_template_data::BlockTemplateRepository,
     config::MergeMiningProxyConfig,
     error::MmProxyError,
-    monerod_detect::get_monerod_info,
+    monero_fail::get_monerod_info,
     proxy::MergeMiningProxyService,
     Cli,
 };
@@ -56,9 +56,11 @@ pub async fn start_merge_miner(cli: Cli) -> Result<(), anyhow::Error> {
     let cfg = load_configuration(&config_path, true, cli.non_interactive_mode, &cli)?;
     let mut config = MergeMiningProxyConfig::load_from(&cfg)?;
     config.set_base_path(cli.common.get_base_path());
-    if config.use_dynamic_monerod_url {
-        let entries = get_monerod_info(15, Duration::from_secs(5)).await?;
-        config.monerod_url = StringList::from(entries.into_iter().map(|entry| entry.url).collect::<Vec<_>>());
+    if config.use_dynamic_fail_data {
+        let entries = get_monerod_info(15, Duration::from_secs(5), &config.monero_fail_url).await?;
+        if !entries.is_empty() {
+            config.monerod_url = StringList::from(entries.into_iter().map(|entry| entry.url).collect::<Vec<_>>());
+        }
     }
 
     info!(target: LOG_TARGET, "Configuration: {:?}", config);

--- a/common/config/presets/f_merge_mining_proxy.toml
+++ b/common/config/presets/f_merge_mining_proxy.toml
@@ -7,7 +7,19 @@
 
 [merge_mining_proxy]
 
-# URL to monerod (you can add your own server here or use public nodes from https://monero.fail/) (default = "")
+
+# Use dynamic monerod URL obtained form the official Monero website (https://monero.fail/) (default: true)
+#use_dynamic_fail_data = true
+
+# The monero fail URL to get the monerod URLs from - must be pointing to the official Monero website.
+# Valid alternatives are:
+# - mainnet:  'https://monero.fail/?chain=monero&network=mainnet&all=true' (default)
+# - stagenet: `https://monero.fail/?chain=monero&network=stagenet&all=true`
+# - testnet:  `https://monero.fail/?chain=monero&network=testnet&all=true`
+#monero_fail_url = "https://monero.fail/?chain=monero&network=mainnet&all=true"
+
+# URL to monerod (you can add your own server here or use public nodes from https://monero.fail/), only if
+# 'use_dynamic_fail_data = false' (default = "")
 
 #monerod_url = [# stagenet
 #    "http://stagenet.xmr-tw.org:38081",
@@ -77,6 +89,3 @@ monerod_url = [ # mainnet
 #stealth_payment = true
 # Range proof type - revealed_value or bullet_proof_plus: (default = "revealed_value")
 #range_proof_type = "revealed_value"
-
-# Use dynamic monerod URL obtained form the official Monero website (https://monero.fail/) (default: true)
-#use_dynamic_monerod_url = true

--- a/common/config/presets/f_merge_mining_proxy.toml
+++ b/common/config/presets/f_merge_mining_proxy.toml
@@ -7,24 +7,25 @@
 
 [merge_mining_proxy]
 
-# URL to monerod (default = "")
+# URL to monerod (you can add your own server here or use public nodes from https://monero.fail/) (default = "")
+
 #monerod_url = [# stagenet
 #    "http://stagenet.xmr-tw.org:38081",
-#    "http://stagenet.community.xmr.to:38081",
-#    "http://monero-stagenet.exan.tech:38081",
+#    "http://node.monerodevs.org:38089",
+#    "http://node3.monerodevs.org:38089",
 #    "http://xmr-lux.boldsuck.org:38081",
 #    "http://singapore.node.xmr.pm:38081",
 #]
 
 monerod_url = [ # mainnet
-    # more reliable
-    "http://xmr.support:18081",
     "http://node1.xmr-tw.org:18081",
+    "https://monero.homeqloud.com:443",
+    "http://monero1.com:18089",
+    "http://node.c3pool.org:18081",
+    "http://xmr-full.p2pool.uk:18089",
+    "https://monero.stackwallet.com:18081",
+    "http://xmr.support:18081",
     "http://xmr.nthrow.nyc:18081",
-    # not so reliable
-    "http://node.xmrig.com:18081",
-    "http://monero.exan.tech:18081",
-    "http://18.132.124.81:18081",
 ]
 
 # Username for curl. (default = "")
@@ -76,3 +77,6 @@ monerod_url = [ # mainnet
 #stealth_payment = true
 # Range proof type - revealed_value or bullet_proof_plus: (default = "revealed_value")
 #range_proof_type = "revealed_value"
+
+# Use dynamic monerod URL obtained form the official Monero website (https://monero.fail/) (default: true)
+#use_dynamic_monerod_url = true

--- a/integration_tests/src/merge_mining_proxy.rs
+++ b/integration_tests/src/merge_mining_proxy.rs
@@ -117,8 +117,8 @@ impl MergeMiningProxyProcess {
                             "merge_mining_proxy.monerod_url".to_string(),
                             [
                                 "http://stagenet.xmr-tw.org:38081",
-                                "http://stagenet.community.xmr.to:38081",
-                                "http://monero-stagenet.exan.tech:38081",
+                                "http://node.monerodevs.org:38089",
+                                "http://node3.monerodevs.org:38089",
                                 "http://xmr-lux.boldsuck.org:38081",
                                 "http://singapore.node.xmr.pm:38081",
                             ]
@@ -140,6 +140,10 @@ impl MergeMiningProxyProcess {
                             wallet_payment_address.to_hex(),
                         ),
                         ("merge_mining_proxy.stealth_payment".to_string(), stealth.to_string()),
+                        (
+                            "merge_mining_proxy.use_dynamic_monerod_url".to_string(),
+                            "false".to_string(),
+                        ),
                     ],
                 },
                 non_interactive_mode: false,

--- a/integration_tests/src/merge_mining_proxy.rs
+++ b/integration_tests/src/merge_mining_proxy.rs
@@ -141,7 +141,7 @@ impl MergeMiningProxyProcess {
                         ),
                         ("merge_mining_proxy.stealth_payment".to_string(), stealth.to_string()),
                         (
-                            "merge_mining_proxy.use_dynamic_monerod_url".to_string(),
+                            "merge_mining_proxy.use_dynamic_fail_data".to_string(),
                             "false".to_string(),
                         ),
                     ],


### PR DESCRIPTION
Description
---
- Fixed an error where the monerod server connection attempt would not timeout if it did not succeed.
- Added dynamic and robust monerod detection to the merge mining proxy as an optional alternative to the monerod URLs specified in the config. If enabled, dynamically detected monerod servers will be ordered according to the best response times.

Motivation and Context
---
Merge mining with monero mining recently had issues (stopped) due to a configured public monerod server not stopped being responsive anymore.

How Has This Been Tested?
---
- Added new unit tests for dynamic monerod detection
- Performed system-level testing

Example unit test output:
```rust
0: MonerodEntry { address_type: "clear", url: "http://213.227.135.106:18081", height: 3119866, up: true, web_compatible: false, network: "mainnet", last_checked: "5 hours ago", up_history: [true, true, true, true, true, true], response_time: Some(429.0735ms) }
1: MonerodEntry { address_type: "clear", url: "http://hatchi-home.ddns.net:18089", height: 3119865, up: true, web_compatible: false, network: "mainnet", last_checked: "5 hours ago", up_history: [true, true, true, true, true, true], response_time: Some(492.1296ms) }
2: MonerodEntry { address_type: "clear", url: "http://01.its-a-node.org:18081", height: 3119865, up: true, web_compatible: false, network: "mainnet", last_checked: "5 hours ago", up_history: [true, true, true, true, true, true], response_time: Some(526.3674ms) }
3: MonerodEntry { address_type: "clear", url: "http://moneronode.xyz:18089", height: 3119865, up: true, web_compatible: false, network: "mainnet", last_checked: "5 hours ago", up_history: [true, true, true, true, true, true], response_time: Some(679.1088ms) }
4: MonerodEntry { address_type: "clear", url: "http://23.137.254.9:18081", height: 3119866, up: true, web_compatible: false, network: "mainnet", last_checked: "5 hours ago", up_history: [true, true, true, true, true, true], response_time: Some(704.3092ms) }
```

Example merge mining proxy startup log:
```rust
2024-04-04 15:45:59.087723700 [reqwest::connect] DEBUG starting new connection: https://monero.fail/
2024-04-04 15:46:02.023687700 [reqwest::connect] DEBUG starting new connection: http://213.227.135.106:18081/
2024-04-04 15:46:02.454594200 [minotari_mm_proxy::monero_detect] DEBUG Response time 'Some(430.95ms)' for Monerod server at: http://213.227.135.106:18081/getheight
2024-04-04 15:46:02.454749300 [reqwest::connect] DEBUG starting new connection: https://monero.homeqloud.com/
2024-04-04 15:46:03.452241100 [minotari_mm_proxy::monero_detect] DEBUG Response time 'Some(997.53ms)' for Monerod server at: https://monero.homeqloud.com/getheight
2024-04-04 15:46:03.452339500 [reqwest::connect] DEBUG starting new connection: http://23.137.254.9:18081/
2024-04-04 15:46:04.147777700 [minotari_mm_proxy::monero_detect] DEBUG Response time 'Some(695.48ms)' for Monerod server at: http://23.137.254.9:18081/getheight
2024-04-04 15:46:04.147896500 [reqwest::connect] DEBUG starting new connection: http://dudeistnl.duckdns.org:18089/
2024-04-04 15:46:04.836452600 [minotari_mm_proxy::monero_detect] DEBUG Response time 'Some(688.62ms)' for Monerod server at: http://dudeistnl.duckdns.org:18089/getheight
2024-04-04 15:46:04.836536800 [reqwest::connect] DEBUG starting new connection: http://monero1.com:18089/
2024-04-04 15:46:05.681670400 [minotari_mm_proxy::monero_detect] DEBUG Response time 'Some(845.16ms)' for Monerod server at: http://monero1.com:18089/getheight
2024-04-04 15:46:05.681869000 [reqwest::connect] DEBUG starting new connection: http://xmr-pruned.p2pool.uk:18089/
2024-04-04 15:46:06.257987100 [minotari_mm_proxy::monero_detect] DEBUG Response time 'Some(576.16ms)' for Monerod server at: http://xmr-pruned.p2pool.uk:18089/getheight
2024-04-04 15:46:06.258112500 [reqwest::connect] DEBUG starting new connection: https://xmr-au-1.cryptovps.io/
2024-04-04 15:46:08.079965500 [minotari_mm_proxy::monero_detect] DEBUG Response time 'Some(1.82s)' for Monerod server at: https://xmr-au-1.cryptovps.io/getheight
2024-04-04 15:46:08.080055500 [reqwest::connect] DEBUG starting new connection: http://l4nk0r.dev:18089/
2024-04-04 15:46:09.128763700 [minotari_mm_proxy::monero_detect] DEBUG Response time 'Some(1.05s)' for Monerod server at: http://l4nk0r.dev:18089/getheight
2024-04-04 15:46:09.128873200 [reqwest::connect] DEBUG starting new connection: http://nexper-xmr-node.tplinkdns.com:18081/
2024-04-04 15:46:09.893416200 [minotari_mm_proxy::monero_detect] DEBUG Response time 'Some(764.58ms)' for Monerod server at: http://nexper-xmr-node.tplinkdns.com:18081/getheight
2024-04-04 15:46:09.893494700 [reqwest::connect] DEBUG starting new connection: http://202.169.99.195:18089/
2024-04-04 15:46:11.131535500 [minotari_mm_proxy::monero_detect] DEBUG Response time 'Some(1.24s)' for Monerod server at: http://202.169.99.195:18089/getheight
2024-04-04 15:46:11.131644200 [reqwest::connect] DEBUG starting new connection: http://node0-eu.monero.love:18089/
2024-04-04 15:46:11.795190600 [minotari_mm_proxy::monero_detect] DEBUG Response time 'Some(663.59ms)' for Monerod server at: http://node0-eu.monero.love:18089/getheight
2024-04-04 15:46:11.795278100 [reqwest::connect] DEBUG starting new connection: http://01.its-a-node.org:18081/
2024-04-04 15:46:12.524508500 [minotari_mm_proxy::monero_detect] DEBUG Response time 'Some(729.26ms)' for Monerod server at: http://01.its-a-node.org:18081/getheight
2024-04-04 15:46:12.524641700 [reqwest::connect] DEBUG starting new connection: http://rucknium.me:18081/
2024-04-04 15:46:12.971353900 [minotari_mm_proxy::monero_detect] DEBUG Response time 'Some(446.77ms)' for Monerod server at: http://rucknium.me:18081/getheight
2024-04-04 15:46:12.971458900 [reqwest::connect] DEBUG starting new connection: http://node.sethforprivacy.com:18089/
2024-04-04 15:46:13.770796600 [minotari_mm_proxy::monero_detect] DEBUG Response time 'Some(799.37ms)' for Monerod server at: http://node.sethforprivacy.com:18089/getheight
2024-04-04 15:46:13.770910900 [reqwest::connect] DEBUG starting new connection: http://nihilism.network:18081/
2024-04-04 15:46:14.230763700 [minotari_mm_proxy::monero_detect] DEBUG Response time 'Some(459.89ms)' for Monerod server at: http://nihilism.network:18081/getheight
2024-04-04 15:46:14.230878600 [reqwest::connect] DEBUG starting new connection: http://xmr.godz.co.uk:18081/
2024-04-04 15:46:15.087522500 [minotari_mm_proxy::monero_detect] DEBUG Response time 'Some(856.68ms)' for Monerod server at: http://xmr.godz.co.uk:18081/getheight
2024-04-04 15:46:15.087649000 [reqwest::connect] DEBUG starting new connection: https://datura.network:18081/
2024-04-04 15:46:15.783401900 [minotari_mm_proxy::monero_detect] DEBUG Response time 'Some(695.80ms)' for Monerod server at: https://datura.network:18081/getheight
2024-04-04 15:46:15.783478600 [reqwest::connect] DEBUG starting new connection: http://nodexmr.rctrusts.com:18089/
2024-04-04 15:46:17.400284700 [minotari_mm_proxy::monero_detect] DEBUG Response time 'Some(1.62s)' for Monerod server at: http://nodexmr.rctrusts.com:18089/getheight
2024-04-04 15:46:17.400376500 [reqwest::connect] DEBUG starting new connection: https://node-xmr.encryp.ch:18089/
2024-04-04 15:46:18.352391400 [minotari_mm_proxy::monero_detect] DEBUG Response time 'Some(952.04ms)' for Monerod server at: https://node-xmr.encryp.ch:18089/getheight
2024-04-04 15:46:18.352499100 [reqwest::connect] DEBUG starting new connection: http://moneropay.techthis.online:18089/
2024-04-04 15:46:19.560547300 [minotari_mm_proxy::monero_detect] DEBUG Response time 'Some(1.21s)' for Monerod server at: http://moneropay.techthis.online:18089/getheight
2024-04-04 15:46:19.560642800 [reqwest::connect] DEBUG starting new connection: http://node.monero.love:18089/
2024-04-04 15:46:20.226728400 [minotari_mm_proxy::monero_detect] DEBUG Response time 'Some(666.12ms)' for Monerod server at: http://node.monero.love:18089/getheight
2024-04-04 15:46:20.226892600 [reqwest::connect] DEBUG starting new connection: http://hatchi-home.ddns.net:18089/
2024-04-04 15:46:20.699821700 [minotari_mm_proxy::monero_detect] DEBUG Response time 'Some(472.97ms)' for Monerod server at: http://hatchi-home.ddns.net:18089/getheight
2024-04-04 15:46:20.699945900 [reqwest::connect] DEBUG starting new connection: http://moneronode.xyz:18089/
2024-04-04 15:46:21.382450000 [minotari_mm_proxy::monero_detect] DEBUG Response time 'Some(682.55ms)' for Monerod server at: http://moneronode.xyz:18089/getheight
2024-04-04 15:46:21.382544100 [reqwest::connect] DEBUG starting new connection: http://node.c3pool.org:18081/
2024-04-04 15:46:22.229697200 [minotari_mm_proxy::monero_detect] DEBUG Response time 'Some(847.18ms)' for Monerod server at: http://node.c3pool.org:18081/getheight
2024-04-04 15:46:22.229821600 [reqwest::connect] DEBUG starting new connection: https://node.chaoswg.dev/
2024-04-04 15:46:23.233010600 [minotari_mm_proxy::monero_detect] DEBUG Response time 'Some(1.00s)' for Monerod server at: https://node.chaoswg.dev/getheight
```

What process can a PR reviewer use to test or verify this change?
---
- Review code changes
- Run system-level tests

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
