### PR TITLE
feat: keep smt memory

### DIFF
--- a/applications/minotari_node/src/bootstrap.rs
+++ b/applications/minotari_node/src/bootstrap.rs
@@ -20,7 +20,12 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{cmp, str::FromStr, sync::Arc, time::Duration};
+use std::{
+    cmp,
+    str::FromStr,
+    sync::{Arc, RwLock},
+    time::Duration,
+};
 
 use log::*;
 use minotari_app_utilities::{consts, identity_management, identity_management::load_from_json};
@@ -52,6 +57,7 @@ use tari_core::{
     mempool::{service::MempoolHandle, Mempool, MempoolServiceInitializer, MempoolSyncInitializer},
     proof_of_work::randomx_factory::RandomXFactory,
     transactions::CryptoFactories,
+    OutputSmt,
 };
 use tari_p2p::{
     auto_update::SoftwareUpdaterService,
@@ -81,6 +87,7 @@ pub struct BaseNodeBootstrapper<'a, B> {
     pub factories: CryptoFactories,
     pub randomx_factory: RandomXFactory,
     pub interrupt_signal: ShutdownSignal,
+    pub smt: Arc<RwLock<OutputSmt>>,
 }
 
 impl<B> BaseNodeBootstrapper<'_, B>

--- a/base_layer/core/src/chain_storage/async_db.rs
+++ b/base_layer/core/src/chain_storage/async_db.rs
@@ -19,7 +19,12 @@
 // SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-use std::{mem, ops::RangeBounds, sync::Arc, time::Instant};
+use std::{
+    mem,
+    ops::RangeBounds,
+    sync::{Arc, RwLock},
+    time::Instant,
+};
 
 use log::*;
 use primitive_types::U256;
@@ -222,10 +227,6 @@ impl<B: BlockchainBackend + 'static> AsyncBlockchainDb<B> {
 
     make_async_fn!(fetch_tip_header() -> ChainHeader, "fetch_tip_header");
 
-    make_async_fn!(fetch_tip_smt() -> OutputSmt, "fetch_tip_smt");
-
-    make_async_fn!(set_tip_smt(smt: OutputSmt) -> (), "set_tip_smt");
-
     make_async_fn!(insert_valid_headers(headers: Vec<ChainHeader>) -> (), "insert_valid_headers");
 
     //---------------------------------- Block --------------------------------------------//
@@ -393,8 +394,8 @@ impl<'a, B: BlockchainBackend + 'static> AsyncDbTransaction<'a, B> {
         self
     }
 
-    pub fn insert_tip_block_body(&mut self, block: Arc<ChainBlock>) -> &mut Self {
-        self.transaction.insert_tip_block_body(block);
+    pub fn insert_tip_block_body(&mut self, block: Arc<ChainBlock>, smt: Arc<RwLock<OutputSmt>>) -> &mut Self {
+        self.transaction.insert_tip_block_body(block, smt);
         self
     }
 

--- a/base_layer/core/src/chain_storage/blockchain_backend.rs
+++ b/base_layer/core/src/chain_storage/blockchain_backend.rs
@@ -91,7 +91,7 @@ pub trait BlockchainBackend: Send + Sync {
     fn fetch_outputs_in_block_with_spend_state(
         &self,
         header_hash: &HashOutput,
-        spend_status_at_header: Option<HashOutput>,
+        spend_status_at_header: Option<&HashOutput>,
     ) -> Result<Vec<(TransactionOutput, bool)>, ChainStorageError>;
 
     /// Fetch a specific output. Returns the output
@@ -181,6 +181,6 @@ pub trait BlockchainBackend: Send + Sync {
         start_height: u64,
         end_height: u64,
     ) -> Result<Vec<TemplateRegistrationEntry>, ChainStorageError>;
-    /// Returns the tip utxo smt
-    fn fetch_tip_smt(&self) -> Result<OutputSmt, ChainStorageError>;
+    /// Calculates the tip utxo smt
+    fn calculate_tip_smt(&self) -> Result<OutputSmt, ChainStorageError>;
 }

--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -1332,6 +1332,7 @@ pub fn calculate_mmr_roots<T: BlockchainBackend>(
     db: &T,
     rules: &ConsensusManager,
     block: &Block,
+    // we dont want to clone the SMT, so we rather change it and change it back after we are done.
     output_smt: &mut OutputSmt,
 ) -> Result<MmrRoots, ChainStorageError> {
     let header = &block.header;
@@ -1421,7 +1422,8 @@ pub fn calculate_mmr_roots<T: BlockchainBackend>(
         validator_node_mr,
         validator_node_size: validator_node_size as u64,
     };
-    // lets rewind the smt back to tip again
+    // We have made changes to the SMT that we dont want, sp lets rewind the SMT back to tip again as we want to have
+    // the SMT at tip.
     for output in outputs_to_add {
         if output_smt.insert(output.0.clone(), output.1).is_err() {
             error!(
@@ -2013,7 +2015,7 @@ fn reorganize_chain<T: BlockchainBackend>(
             let mut write_smt = smt.write().map_err(|e| {
                 error!(
                     target: LOG_TARGET,
-                    "An attempt to get a write lock on the smt failed. {:?}", e
+                    "reorganize_chain could not get a write lock on the smt. {:?}", e
                 );
                 ChainStorageError::AccessError("write lock on smt".into())
             })?;

--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -917,7 +917,7 @@ where B: BlockchainBackend
         let mmr_roots = match calculate_mmr_roots(&*db, self.rules(), &block, &mut smt) {
             Ok(v) => v,
             Err(e) => {
-                // some error happend, lets rewind the smt
+                // some error happend, lets reset the smt to its starting state
                 *smt = db.calculate_tip_smt()?;
                 return Err(e);
             },

--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -208,6 +208,7 @@ pub struct BlockchainDatabase<B> {
     consensus_manager: ConsensusManager,
     difficulty_calculator: Arc<DifficultyCalculator>,
     disable_add_block_flag: Arc<AtomicBool>,
+    smt: Arc<RwLock<OutputSmt>>,
 }
 
 #[allow(clippy::ptr_arg)]
@@ -221,6 +222,7 @@ where B: BlockchainBackend
         validators: Validators<B>,
         config: BlockchainDatabaseConfig,
         difficulty_calculator: DifficultyCalculator,
+        smt: Arc<RwLock<OutputSmt>>,
     ) -> Result<Self, ChainStorageError> {
         debug!(target: LOG_TARGET, "BlockchainDatabase config: {:?}", config);
         let is_empty = db.is_empty()?;
@@ -231,6 +233,7 @@ where B: BlockchainBackend
             consensus_manager,
             difficulty_calculator: Arc::new(difficulty_calculator),
             disable_add_block_flag: Arc::new(AtomicBool::new(false)),
+            smt,
         };
         let genesis_block = Arc::new(blockchain_db.consensus_manager.get_genesis_block());
         if is_empty {
@@ -240,8 +243,6 @@ where B: BlockchainBackend
                 genesis_block.block().body.to_counts_string()
             );
             let mut txn = DbTransaction::new();
-            let smt = OutputSmt::new();
-            txn.insert_tip_smt(smt);
             blockchain_db.write(txn)?;
             txn = DbTransaction::new();
             blockchain_db.insert_block(genesis_block.clone())?;
@@ -271,7 +272,9 @@ where B: BlockchainBackend
                     .into(),
             ));
         } else {
-            // block has been added
+            // lets load the smt into memory
+            let mut smt = blockchain_db.smt_write_access()?;
+            *smt = blockchain_db.db_write_access()?.calculate_tip_smt()?;
         }
         if config.cleanup_orphans_at_startup {
             match blockchain_db.cleanup_all_orphans() {
@@ -324,6 +327,30 @@ where B: BlockchainBackend
                 "An attempt to get a read lock on the blockchain backend failed. {:?}", e
             );
             ChainStorageError::AccessError("Read lock on blockchain backend failed".into())
+        })
+    }
+
+    pub fn smt_write_access(&self) -> Result<RwLockWriteGuard<OutputSmt>, ChainStorageError> {
+        self.smt.write().map_err(|e| {
+            error!(
+                target: LOG_TARGET,
+                "An attempt to get a write lock on the smt failed. {:?}", e
+            );
+            ChainStorageError::AccessError("write lock on smt".into())
+        })
+    }
+
+    pub fn smt(&self) -> Arc<RwLock<OutputSmt>> {
+        self.smt.clone()
+    }
+
+    pub fn smt_read_access(&self) -> Result<RwLockReadGuard<OutputSmt>, ChainStorageError> {
+        self.smt.read().map_err(|e| {
+            error!(
+                target: LOG_TARGET,
+                "An attempt to get a read lock on the smt failed. {:?}", e
+            );
+            ChainStorageError::AccessError("read lock on smt".into())
         })
     }
 
@@ -413,8 +440,7 @@ where B: BlockchainBackend
         hashes: Vec<HashOutput>,
     ) -> Result<Vec<Option<(TransactionOutput, bool)>>, ChainStorageError> {
         let db = self.db_read_access()?;
-        let smt = db.fetch_tip_smt()?;
-
+        let smt = self.smt_read_access()?;
         let mut result = Vec::with_capacity(hashes.len());
         for hash in hashes {
             let output = db.fetch_output(&hash)?;
@@ -475,7 +501,7 @@ where B: BlockchainBackend
         spend_status_at_header: Option<HashOutput>,
     ) -> Result<Vec<(TransactionOutput, bool)>, ChainStorageError> {
         let db = self.db_read_access()?;
-        db.fetch_outputs_in_block_with_spend_state(&header_hash, spend_status_at_header)
+        db.fetch_outputs_in_block_with_spend_state(&header_hash, spend_status_at_header.as_ref())
     }
 
     pub fn fetch_outputs_in_block(&self, header_hash: HashOutput) -> Result<Vec<TransactionOutput>, ChainStorageError> {
@@ -672,18 +698,6 @@ where B: BlockchainBackend
         db.fetch_tip_header()
     }
 
-    pub fn fetch_tip_smt(&self) -> Result<OutputSmt, ChainStorageError> {
-        let db = self.db_read_access()?;
-        db.fetch_tip_smt()
-    }
-
-    pub fn set_tip_smt(&self, smt: OutputSmt) -> Result<(), ChainStorageError> {
-        let mut db = self.db_write_access()?;
-        let mut txn = DbTransaction::new();
-        txn.insert_tip_smt(smt);
-        db.write(txn)
-    }
-
     /// Fetches the last  header that was added, might be past the tip, as the block body between this last  header and
     /// actual tip might not have been added yet
     pub fn fetch_last_header(&self) -> Result<BlockHeader, ChainStorageError> {
@@ -872,7 +886,15 @@ where B: BlockchainBackend
                 .ok_or(ChainStorageError::UnexpectedResult("Timestamp overflowed".to_string()))?;
         }
         let mut block = Block { header, body };
-        let roots = calculate_mmr_roots(&*db, self.rules(), &block)?;
+        let mut smt = self.smt_write_access()?;
+        let roots = match calculate_mmr_roots(&*db, self.rules(), &block, &mut smt) {
+            Ok(v) => v,
+            Err(e) => {
+                // some error happend, lets rewind the smt
+                *smt = db.calculate_tip_smt()?;
+                return Err(e);
+            },
+        };
         block.header.kernel_mr = roots.kernel_mr;
         block.header.kernel_mmr_size = roots.kernel_mmr_size;
         block.header.input_mr = roots.input_mr;
@@ -891,7 +913,15 @@ where B: BlockchainBackend
                 "calculate_mmr_roots expected a sorted block body, however the block body was not sorted".to_string(),
             ));
         };
-        let mmr_roots = calculate_mmr_roots(&*db, self.rules(), &block)?;
+        let mut smt = self.smt_write_access()?;
+        let mmr_roots = match calculate_mmr_roots(&*db, self.rules(), &block, &mut smt) {
+            Ok(v) => v,
+            Err(e) => {
+                // some error happend, lets rewind the smt
+                *smt = db.calculate_tip_smt()?;
+                return Err(e);
+            },
+        };
         Ok((block, mmr_roots))
     }
 
@@ -998,6 +1028,7 @@ where B: BlockchainBackend
             &*self.validators.header,
             self.consensus_manager.chain_strength_comparer(),
             candidate_block,
+            self.smt(),
         )?;
 
         // If blocks were added and the node is in pruned mode, perform pruning
@@ -1047,7 +1078,7 @@ where B: BlockchainBackend
         let mut db = self.db_write_access()?;
 
         let mut txn = DbTransaction::new();
-        insert_best_block(&mut txn, block, &self.consensus_manager)?;
+        insert_best_block(&mut txn, block, &self.consensus_manager, self.smt())?;
         db.write(txn)
     }
 
@@ -1178,8 +1209,9 @@ where B: BlockchainBackend
     /// The operation will fail if
     /// * The block height is in the future
     pub fn rewind_to_height(&self, height: u64) -> Result<Vec<Arc<ChainBlock>>, ChainStorageError> {
+        let smt = self.smt().clone();
         let mut db = self.db_write_access()?;
-        rewind_to_height(&mut *db, height)
+        rewind_to_height(&mut *db, height, smt)
     }
 
     /// Rewind the blockchain state to the block hash making the block at that hash the new tip.
@@ -1190,7 +1222,7 @@ where B: BlockchainBackend
     /// * The block hash is before the horizon block height determined by the pruning horizon
     pub fn rewind_to_hash(&self, hash: BlockHash) -> Result<Vec<Arc<ChainBlock>>, ChainStorageError> {
         let mut db = self.db_write_access()?;
-        rewind_to_hash(&mut *db, hash)
+        rewind_to_hash(&mut *db, hash, self.smt.clone())
     }
 
     /// This method will compare all chain tips the node currently knows about. This includes
@@ -1206,6 +1238,7 @@ where B: BlockchainBackend
             &*self.validators.block,
             self.consensus_manager.chain_strength_comparer(),
             &self.consensus_manager,
+            self.smt(),
         )?;
         Ok(())
     }
@@ -1299,6 +1332,7 @@ pub fn calculate_mmr_roots<T: BlockchainBackend>(
     db: &T,
     rules: &ConsensusManager,
     block: &Block,
+    output_smt: &mut OutputSmt,
 ) -> Result<MmrRoots, ChainStorageError> {
     let header = &block.header;
     let body = &block.body;
@@ -1323,17 +1357,18 @@ pub fn calculate_mmr_roots<T: BlockchainBackend>(
             })?;
 
     let mut kernel_mmr = PrunedKernelMmr::new(kernels);
-    let mut output_smt = db.fetch_tip_smt()?;
     let mut input_mmr = PrunedInputMmr::new(PrunedHashSet::default());
 
     for kernel in body.kernels() {
         kernel_mmr.push(kernel.hash().to_vec())?;
     }
 
+    let mut outputs_to_remove = Vec::new();
     for output in body.outputs() {
         if !output.is_burned() {
             let smt_key = NodeKey::try_from(output.commitment.as_bytes())?;
             let smt_node = ValueHash::try_from(output.smt_hash(header.height).as_slice())?;
+            outputs_to_remove.push(smt_key.clone());
             if let Err(e) = output_smt.insert(smt_key, smt_node) {
                 error!(
                     target: LOG_TARGET,
@@ -1345,12 +1380,12 @@ pub fn calculate_mmr_roots<T: BlockchainBackend>(
         }
     }
 
+    let mut outputs_to_add = Vec::new();
     for input in body.inputs() {
         input_mmr.push(input.canonical_hash().to_vec())?;
-
         let smt_key = NodeKey::try_from(input.commitment()?.as_bytes())?;
         match output_smt.delete(&smt_key)? {
-            DeleteResult::Deleted(_value_hash) => {},
+            DeleteResult::Deleted(value_hash) => outputs_to_add.push((smt_key, value_hash)),
             DeleteResult::KeyNotFound => {
                 error!(
                     target: LOG_TARGET,
@@ -1386,6 +1421,36 @@ pub fn calculate_mmr_roots<T: BlockchainBackend>(
         validator_node_mr,
         validator_node_size: validator_node_size as u64,
     };
+    // lets rewind the smt back to tip again
+    for output in outputs_to_add {
+        if output_smt.insert(output.0.clone(), output.1).is_err() {
+            error!(
+                target: LOG_TARGET,
+                "Output commitment({}) already in SMT",
+                output.0,
+            );
+            return Err(ChainStorageError::AccessError(format!(
+                "Could not add output ({}) in SMT",
+                output.0
+            )));
+        }
+    }
+    for output in outputs_to_remove {
+        match output_smt.delete(&output)? {
+            DeleteResult::Deleted(_value_hash) => {},
+            DeleteResult::KeyNotFound => {
+                error!(
+                    target: LOG_TARGET,
+                    "Could not find input({}) in SMT when reseting back to tip",
+                    output,
+                );
+                return Err(ChainStorageError::AccessError(format!(
+                    "Could not find input({}) in SMT when reseting back to tip",
+                    output
+                )));
+            },
+        };
+    }
     Ok(mmr_roots)
 }
 
@@ -1490,6 +1555,7 @@ fn add_block<T: BlockchainBackend>(
     header_validator: &dyn HeaderChainLinkedValidator<T>,
     chain_strength_comparer: &dyn ChainStrengthComparer,
     candidate_block: Arc<Block>,
+    smt: Arc<RwLock<OutputSmt>>,
 ) -> Result<BlockAddResult, ChainStorageError> {
     handle_possible_reorg(
         db,
@@ -1499,6 +1565,7 @@ fn add_block<T: BlockchainBackend>(
         header_validator,
         chain_strength_comparer,
         candidate_block,
+        smt,
     )
 }
 
@@ -1507,6 +1574,7 @@ fn insert_best_block(
     txn: &mut DbTransaction,
     block: Arc<ChainBlock>,
     consensus: &ConsensusManager,
+    smt: Arc<RwLock<OutputSmt>>,
 ) -> Result<(), ChainStorageError> {
     let block_hash = block.accumulated_data().hash;
     debug!(
@@ -1530,7 +1598,7 @@ fn insert_best_block(
     let accumulated_difficulty = block.accumulated_data().total_accumulated_difficulty;
     let expected_prev_best_block = block.block().header.prev_hash;
     txn.insert_chain_header(block.to_chain_header())
-        .insert_tip_block_body(block)
+        .insert_tip_block_body(block, smt)
         .set_best_block(
             height,
             block_hash,
@@ -1706,6 +1774,7 @@ fn check_for_valid_height<T: BlockchainBackend>(db: &T, height: u64) -> Result<(
 fn rewind_to_height<T: BlockchainBackend>(
     db: &mut T,
     target_height: u64,
+    smt: Arc<RwLock<OutputSmt>>,
 ) -> Result<Vec<Arc<ChainBlock>>, ChainStorageError> {
     let last_header = db.fetch_last_header()?;
 
@@ -1775,7 +1844,7 @@ fn rewind_to_height<T: BlockchainBackend>(
         let block = fetch_block(db, last_block_height - h, false)?;
         let block = Arc::new(block.try_into_chain_block()?);
         let block_hash = *block.hash();
-        txn.delete_tip_block(block_hash);
+        txn.delete_tip_block(block_hash, smt.clone());
         txn.delete_header(last_block_height - h);
         if !prune_past_horizon && !db.contains(&DbKey::OrphanBlock(*block.hash()))? {
             // Because we know we will remove blocks we can't recover, this will be a destructive rewind, so we
@@ -1832,7 +1901,7 @@ fn rewind_to_height<T: BlockchainBackend>(
             let header = fetch_header(db, last_block_height - h - steps_back)?;
             // Although we do not have this full block, this method  will remove all remaining data that is linked to
             // the specific header hash
-            txn.delete_tip_block(header.hash());
+            txn.delete_tip_block(header.hash(), smt.clone());
             db.write(txn)?;
         }
     }
@@ -1843,6 +1912,7 @@ fn rewind_to_height<T: BlockchainBackend>(
 fn rewind_to_hash<T: BlockchainBackend>(
     db: &mut T,
     block_hash: BlockHash,
+    smt: Arc<RwLock<OutputSmt>>,
 ) -> Result<Vec<Arc<ChainBlock>>, ChainStorageError> {
     let block_hash_hex = block_hash.to_hex();
     let target_header = fetch_header_by_block_hash(&*db, block_hash)?.ok_or(ChainStorageError::ValueNotFound {
@@ -1850,7 +1920,7 @@ fn rewind_to_hash<T: BlockchainBackend>(
         field: "block_hash",
         value: block_hash_hex,
     })?;
-    rewind_to_height(db, target_header.height)
+    rewind_to_height(db, target_header.height, smt)
 }
 
 // Checks whether we should add the block as an orphan. If it is the case, the orphan block is added and the chain
@@ -1863,13 +1933,21 @@ fn handle_possible_reorg<T: BlockchainBackend>(
     header_validator: &dyn HeaderChainLinkedValidator<T>,
     chain_strength_comparer: &dyn ChainStrengthComparer,
     candidate_block: Arc<Block>,
+    smt: Arc<RwLock<OutputSmt>>,
 ) -> Result<BlockAddResult, ChainStorageError> {
     let timer = Instant::now();
     let height = candidate_block.header.height;
     let hash = candidate_block.header.hash();
     insert_orphan_and_find_new_tips(db, candidate_block, header_validator, consensus_manager)?;
     let after_orphans = timer.elapsed();
-    let res = swap_to_highest_pow_chain(db, config, block_validator, chain_strength_comparer, consensus_manager);
+    let res = swap_to_highest_pow_chain(
+        db,
+        config,
+        block_validator,
+        chain_strength_comparer,
+        consensus_manager,
+        smt,
+    );
     trace!(
         target: LOG_TARGET,
         "[handle_possible_reorg] block #{}, insert_orphans in {:.2?}, swap_to_highest in {:.2?} '{}'",
@@ -1889,8 +1967,9 @@ fn reorganize_chain<T: BlockchainBackend>(
     fork_hash: HashOutput,
     new_chain_from_fork: &VecDeque<Arc<ChainBlock>>,
     consensus: &ConsensusManager,
+    smt: Arc<RwLock<OutputSmt>>,
 ) -> Result<Vec<Arc<ChainBlock>>, ChainStorageError> {
-    let removed_blocks = rewind_to_hash(backend, fork_hash)?;
+    let removed_blocks = rewind_to_hash(backend, fork_hash, smt.clone())?;
     debug!(
         target: LOG_TARGET,
         "Validate and add {} chain block(s) from block {}. Rewound blocks: [{}]",
@@ -1907,7 +1986,7 @@ fn reorganize_chain<T: BlockchainBackend>(
         let block_hash = *block.hash();
         txn.delete_orphan(block_hash);
         let chain_metadata = backend.fetch_chain_metadata()?;
-        if let Err(e) = block_validator.validate_body_with_metadata(backend, block, &chain_metadata) {
+        if let Err(e) = block_validator.validate_body_with_metadata(backend, block, &chain_metadata, smt.clone()) {
             warn!(
                 target: LOG_TARGET,
                 "Orphan block {} ({}) failed validation during chain reorg: {:?}",
@@ -1926,11 +2005,21 @@ fn reorganize_chain<T: BlockchainBackend>(
             backend.write(txn)?;
 
             info!(target: LOG_TARGET, "Restoring previous chain after failed reorg.");
-            restore_reorged_chain(backend, fork_hash, removed_blocks, consensus)?;
+            restore_reorged_chain(backend, fork_hash, removed_blocks, consensus, smt.clone())?;
             return Err(e.into());
         }
 
-        insert_best_block(&mut txn, block.clone(), consensus)?;
+        if let Err(e) = insert_best_block(&mut txn, block.clone(), consensus, smt.clone()) {
+            let mut write_smt = smt.write().map_err(|e| {
+                error!(
+                    target: LOG_TARGET,
+                    "An attempt to get a write lock on the smt failed. {:?}", e
+                );
+                ChainStorageError::AccessError("write lock on smt".into())
+            })?;
+            *write_smt = backend.calculate_tip_smt()?;
+            return Err(e);
+        }
         // Failed to store the block - this should typically never happen unless there is a bug in the validator
         // (e.g. does not catch a double spend). In any case, we still need to restore the chain to a
         // good state before returning.
@@ -1940,7 +2029,7 @@ fn reorganize_chain<T: BlockchainBackend>(
                 "Failed to commit reorg chain: {:?}. Restoring last chain.", e
             );
 
-            restore_reorged_chain(backend, fork_hash, removed_blocks, consensus)?;
+            restore_reorged_chain(backend, fork_hash, removed_blocks, consensus, smt)?;
             return Err(e);
         }
     }
@@ -1954,12 +2043,13 @@ fn swap_to_highest_pow_chain<T: BlockchainBackend>(
     block_validator: &dyn CandidateBlockValidator<T>,
     chain_strength_comparer: &dyn ChainStrengthComparer,
     consensus: &ConsensusManager,
+    smt: Arc<RwLock<OutputSmt>>,
 ) -> Result<BlockAddResult, ChainStorageError> {
     let metadata = db.fetch_chain_metadata()?;
     // lets clear out all remaining headers that dont have a matching block
     // rewind to height will first delete the headers, then try delete from blocks, if we call this to the current
     // height it will only trim the extra headers with no blocks
-    rewind_to_height(db, metadata.best_block_height())?;
+    rewind_to_height(db, metadata.best_block_height(), smt.clone())?;
     let strongest_orphan_tips = db.fetch_strongest_orphan_chain_tips()?;
     if strongest_orphan_tips.is_empty() {
         // we have no orphan chain tips, we have trimmed remaining headers, we are on the best tip we have, so lets
@@ -2010,7 +2100,7 @@ fn swap_to_highest_pow_chain<T: BlockchainBackend>(
         .prev_hash;
 
     let num_added_blocks = reorg_chain.len();
-    let removed_blocks = reorganize_chain(db, block_validator, fork_hash, &reorg_chain, consensus)?;
+    let removed_blocks = reorganize_chain(db, block_validator, fork_hash, &reorg_chain, consensus, smt)?;
     let num_removed_blocks = removed_blocks.len();
 
     // reorg is required when any blocks are removed or more than one are added
@@ -2063,8 +2153,9 @@ fn restore_reorged_chain<T: BlockchainBackend>(
     to_hash: HashOutput,
     previous_chain: Vec<Arc<ChainBlock>>,
     consensus: &ConsensusManager,
+    smt: Arc<RwLock<OutputSmt>>,
 ) -> Result<(), ChainStorageError> {
-    let invalid_chain = rewind_to_hash(db, to_hash)?;
+    let invalid_chain = rewind_to_hash(db, to_hash, smt.clone())?;
     debug!(
         target: LOG_TARGET,
         "Removed {} blocks during chain restore: {:?}.",
@@ -2078,7 +2169,7 @@ fn restore_reorged_chain<T: BlockchainBackend>(
 
     for block in previous_chain.into_iter().rev() {
         txn.delete_orphan(block.accumulated_data().hash);
-        insert_best_block(&mut txn, block, consensus)?;
+        insert_best_block(&mut txn, block, consensus, smt.clone())?;
     }
     db.write(txn)?;
     Ok(())
@@ -2474,6 +2565,7 @@ impl<T> Clone for BlockchainDatabase<T> {
             consensus_manager: self.consensus_manager.clone(),
             difficulty_calculator: self.difficulty_calculator.clone(),
             disable_add_block_flag: self.disable_add_block_flag.clone(),
+            smt: self.smt.clone(),
         }
     }
 }
@@ -2573,7 +2665,7 @@ mod test {
                 .try_into_chain_block()
                 .map(Arc::new)
                 .unwrap();
-            let mut smt = db.fetch_tip_smt().unwrap();
+            let mut smt = db.smt_read_access().unwrap().clone();
             let (_, chain) = create_orphan_chain(
                 &db,
                 &[("A->GB", 1, 120), ("B->A", 1, 120), ("C->B", 1, 120)],
@@ -2603,7 +2695,7 @@ mod test {
             // Create reorg chain
             // we only need a smt, this one will not be technically correct, but due to the use of mockvalidators(true),
             // they will pass all mr tests
-            let mut smt = db.fetch_tip_smt().unwrap();
+            let mut smt = db.smt_read_access().unwrap().clone();
             let fork_root = mainchain.get("B").unwrap().clone();
             let (_, reorg_chain) = create_orphan_chain(
                 &db,
@@ -2649,7 +2741,7 @@ mod test {
                 .try_into_chain_block()
                 .map(Arc::new)
                 .unwrap();
-            let mut smt = db.fetch_tip_smt().unwrap();
+            let mut smt = db.smt_read_access().unwrap().clone();
             let (_, chain) = create_chained_blocks(&[("A->GB", 1u64, 120u64)], genesis_block, &mut smt).await;
             let block = chain.get("A").unwrap().clone();
             let mut access = db.db_write_access().unwrap();
@@ -2667,7 +2759,7 @@ mod test {
             let (_, main_chain) = create_main_chain(&db, &[("A->GB", 1, 120), ("B->A", 1, 120)]).await;
 
             let block_b = main_chain.get("B").unwrap().clone();
-            let mut smt = db.fetch_tip_smt().unwrap();
+            let mut smt = db.smt_read_access().unwrap().clone();
             let (_, orphan_chain) = create_chained_blocks(
                 &[("C2->GB", 1, 120), ("D2->C2", 1, 120), ("E2->D2", 1, 120)],
                 block_b,
@@ -2695,7 +2787,7 @@ mod test {
             let (_, main_chain) = create_main_chain(&db, &[("A->GB", 1, 120)]).await;
 
             let fork_root = main_chain.get("A").unwrap().clone();
-            let mut smt = db.fetch_tip_smt().unwrap();
+            let mut smt = db.smt_read_access().unwrap().clone();
             let (_, orphan_chain) = create_chained_blocks(&[("B2->GB", 1, 120)], fork_root, &mut smt).await;
             let mut access = db.db_write_access().unwrap();
 
@@ -2735,7 +2827,7 @@ mod test {
             let fork_root_1 = main_chain.get("A").unwrap().clone();
             // we only need a smt, this one will not be technically correct, but due to the use of mockvalidators(true),
             // they will pass all mr tests
-            let mut smt = db.fetch_tip_smt().unwrap();
+            let mut smt = db.smt_read_access().unwrap().clone();
 
             let (_, orphan_chain_1) = create_chained_blocks(
                 &[("B2->GB", 1, 120), ("C2->B2", 1, 120), ("D2->C2", 1, 120)],
@@ -2822,7 +2914,7 @@ mod test {
         #[tokio::test]
         async fn it_links_many_orphan_branches_to_main_chain() {
             let test = TestHarness::setup();
-            let mut smt = test.db.fetch_tip_smt().unwrap();
+            let mut smt = test.db.smt_read_access().unwrap().clone();
             let (_, main_chain) =
                 create_main_chain(&test.db, block_specs!(["1a->GB"], ["2a->1a"], ["3a->2a"], ["4a->3a"])).await;
             let genesis = main_chain.get("GB").unwrap().clone();
@@ -2918,7 +3010,7 @@ mod test {
             let test = TestHarness::setup();
             // This test assumes a MTC of 11
             assert_eq!(test.consensus.consensus_constants(0).median_timestamp_count(), 11);
-            let mut smt = test.db.fetch_tip_smt().unwrap();
+            let mut smt = test.db.smt_read_access().unwrap().clone();
             let (_, main_chain) = create_main_chain(
                 &test.db,
                 block_specs!(
@@ -3010,7 +3102,7 @@ mod test {
         #[tokio::test]
         async fn it_errors_if_reorging_to_an_invalid_height() {
             let test = TestHarness::setup();
-            let mut smt = test.db.fetch_tip_smt().unwrap();
+            let mut smt = test.db.smt_read_access().unwrap().clone();
             let (_, main_chain) =
                 create_main_chain(&test.db, block_specs!(["1a->GB"], ["2a->1a"], ["3a->2a"], ["4a->3a"])).await;
 
@@ -3032,7 +3124,7 @@ mod test {
         #[tokio::test]
         async fn it_allows_orphan_blocks_with_any_height() {
             let test = TestHarness::setup();
-            let mut smt = test.db.fetch_tip_smt().unwrap();
+            let mut smt = test.db.smt_read_access().unwrap().clone();
             let (_, main_chain) = create_main_chain(
                 &test.db,
                 block_specs!(["1a->GB", difficulty: Difficulty::from_u64(2).unwrap()]),
@@ -3150,7 +3242,7 @@ mod test {
     #[tokio::test]
     async fn test_handle_possible_reorg_case6_orphan_chain_link() {
         let db = create_new_blockchain();
-        let mut smt = db.fetch_tip_smt().unwrap();
+        let mut smt = db.smt_read_access().unwrap().clone();
         let (_, mainchain) = create_main_chain(&db, &[
             ("A->GB", 1, 120),
             ("B->A", 1, 120),
@@ -3176,6 +3268,7 @@ mod test {
 
         // Add true orphans
         let mut access = db.db_write_access().unwrap();
+        let smt = db.smt().clone();
         let result = handle_possible_reorg(
             &mut *access,
             &Default::default(),
@@ -3184,11 +3277,13 @@ mod test {
             &mock_validator,
             &*chain_strength_comparer,
             reorg_chain.get("E2").unwrap().to_arc_block(),
+            smt,
         )
         .unwrap();
         result.assert_orphaned();
 
         // Test adding a duplicate orphan
+        let smt = db.smt().clone();
         let result = handle_possible_reorg(
             &mut *access,
             &Default::default(),
@@ -3197,10 +3292,12 @@ mod test {
             &mock_validator,
             &*chain_strength_comparer,
             reorg_chain.get("E2").unwrap().to_arc_block(),
+            smt,
         )
         .unwrap();
         result.assert_orphaned();
 
+        let smt = db.smt().clone();
         let result = handle_possible_reorg(
             &mut *access,
             &Default::default(),
@@ -3209,6 +3306,7 @@ mod test {
             &mock_validator,
             &*chain_strength_comparer,
             reorg_chain.get("D2").unwrap().to_arc_block(),
+            smt,
         )
         .unwrap();
         result.assert_orphaned();
@@ -3216,6 +3314,7 @@ mod test {
         let tip = access.fetch_last_header().unwrap();
         assert_eq!(&tip, mainchain.get("D").unwrap().header());
 
+        let smt = db.smt().clone();
         let result = handle_possible_reorg(
             &mut *access,
             &Default::default(),
@@ -3224,6 +3323,7 @@ mod test {
             &mock_validator,
             &*chain_strength_comparer,
             reorg_chain.get("C2").unwrap().to_arc_block(),
+            smt,
         )
         .unwrap();
         result.assert_reorg(3, 2);
@@ -3248,13 +3348,14 @@ mod test {
         let chain_strength_comparer = strongest_chain().by_sha3x_difficulty().build();
         // we only need a smt, this one will not be technically correct, but due to the use of mockvalidators(true),
         // they will pass all mr tests
-        let mut smt = db.fetch_tip_smt().unwrap();
+        let mut smt = db.smt_read_access().unwrap().clone();
         let fork_block = mainchain.get("C").unwrap().clone();
         let (_, reorg_chain) =
             create_chained_blocks(&[("D2->GB", 1, 120), ("E2->D2", 2, 120)], fork_block, &mut smt).await;
 
         // Add true orphans
         let mut access = db.db_write_access().unwrap();
+        let smt = db.smt().clone();
         let result = handle_possible_reorg(
             &mut *access,
             &Default::default(),
@@ -3263,10 +3364,12 @@ mod test {
             &mock_validator,
             &*chain_strength_comparer,
             reorg_chain.get("E2").unwrap().to_arc_block(),
+            smt,
         )
         .unwrap();
         result.assert_orphaned();
 
+        let smt = db.smt().clone();
         let _error = handle_possible_reorg(
             &mut *access,
             &Default::default(),
@@ -3275,6 +3378,7 @@ mod test {
             &mock_validator,
             &*chain_strength_comparer,
             reorg_chain.get("D2").unwrap().to_arc_block(),
+            smt,
         )
         .unwrap_err();
 
@@ -3508,6 +3612,7 @@ mod test {
 
         pub fn handle_possible_reorg(&self, block: Arc<Block>) -> Result<BlockAddResult, ChainStorageError> {
             let mut access = self.db_write_access();
+            let smt = self.db.smt().clone();
             handle_possible_reorg(
                 &mut *access,
                 &self.config,
@@ -3516,6 +3621,7 @@ mod test {
                 &*self.header_validator,
                 &*self.chain_strength_comparer,
                 block,
+                smt,
             )
         }
     }
@@ -3532,8 +3638,10 @@ mod test {
             .try_into_chain_block()
             .map(Arc::new)
             .unwrap();
-        let mut smt = test.db.fetch_tip_smt().unwrap();
-        let (block_names, chain) = create_chained_blocks(blocks, genesis_block, &mut smt).await;
+        let (block_names, chain) = {
+            let mut smt = test.db.smt_read_access().unwrap().clone();
+            create_chained_blocks(blocks, genesis_block, &mut smt).await
+        };
 
         let mut results = vec![];
         for name in block_names {

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -20,18 +20,20 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{cmp::max, convert::TryFrom, fmt, fs, fs::File, ops::Deref, path::Path, sync::Arc, time::Instant};
+use std::{
+    cmp::max,
+    convert::TryFrom,
+    fmt,
+    fs,
+    fs::File,
+    ops::Deref,
+    path::Path,
+    sync::{Arc, RwLock},
+    time::Instant,
+};
 
 use fs2::FileExt;
-use lmdb_zero::{
-    open,
-    traits::AsLmdbBytes,
-    ConstTransaction,
-    Database,
-    Environment,
-    ReadTransaction,
-    WriteTransaction,
-};
+use lmdb_zero::{open, ConstTransaction, Database, Environment, ReadTransaction, WriteTransaction};
 use log::*;
 use primitive_types::U256;
 use serde::{Deserialize, Serialize};
@@ -147,7 +149,6 @@ const LMDB_DB_REORGS: &str = "reorgs";
 const LMDB_DB_VALIDATOR_NODES: &str = "validator_nodes";
 const LMDB_DB_VALIDATOR_NODES_MAPPING: &str = "validator_nodes_mapping";
 const LMDB_DB_TEMPLATE_REGISTRATIONS: &str = "template_registrations";
-const LMDB_DB_TIP_UTXO_SMT: &str = "tip_utxo_smt";
 
 /// HeaderHash(32), mmr_pos(8), hash(32)
 type KernelKey = CompositeKey<72>;
@@ -197,7 +198,6 @@ pub fn create_lmdb_database<P: AsRef<Path>>(
         .add_database(LMDB_DB_VALIDATOR_NODES, flags)
         .add_database(LMDB_DB_VALIDATOR_NODES_MAPPING, flags)
         .add_database(LMDB_DB_TEMPLATE_REGISTRATIONS, flags | db::DUPSORT)
-        .add_database(LMDB_DB_TIP_UTXO_SMT, flags)
         .build()
         .map_err(|err| ChainStorageError::CriticalError(format!("Could not create LMDB store:{}", err)))?;
     debug!(target: LOG_TARGET, "LMDB database creation successful");
@@ -256,8 +256,6 @@ pub struct LMDBDatabase {
     reorgs: DatabaseRef,
     /// Maps <Height, VN PK> -> ActiveValidatorNode
     validator_nodes: DatabaseRef,
-    /// Stores the sparse merkle tree of the utxo set on tip
-    tip_utxo_smt: DatabaseRef,
     /// Maps <Epoch, VN Public Key> -> VN Shard Key
     validator_nodes_mapping: DatabaseRef,
     /// Maps CodeTemplateRegistration <block_height, hash> -> TemplateRegistration
@@ -300,7 +298,6 @@ impl LMDBDatabase {
             reorgs: get_database(store, LMDB_DB_REORGS)?,
             validator_nodes: get_database(store, LMDB_DB_VALIDATOR_NODES)?,
             validator_nodes_mapping: get_database(store, LMDB_DB_VALIDATOR_NODES_MAPPING)?,
-            tip_utxo_smt: get_database(store, LMDB_DB_TIP_UTXO_SMT)?,
             template_registrations: get_database(store, LMDB_DB_TEMPLATE_REGISTRATIONS)?,
             env,
             env_config: store.env_config(),
@@ -339,8 +336,8 @@ impl LMDBDatabase {
                 InsertChainHeader { header } => {
                     self.insert_header(&write_txn, header.header(), header.accumulated_data())?;
                 },
-                InsertTipBlockBody { block } => {
-                    self.insert_tip_block_body(&write_txn, block.header(), block.block().body.clone())?;
+                InsertTipBlockBody { block, smt } => {
+                    self.insert_tip_block_body(&write_txn, block.header(), block.block().body.clone(), smt.clone())?;
                 },
                 InsertKernel {
                     header_hash,
@@ -383,8 +380,8 @@ impl LMDBDatabase {
                         "orphan_chain_tips_db",
                     )?;
                 },
-                DeleteTipBlock(hash) => {
-                    self.delete_tip_block_body(&write_txn, hash)?;
+                DeleteTipBlock(hash, smt) => {
+                    self.delete_tip_block_body(&write_txn, hash, smt.clone())?;
                 },
                 InsertMoneroSeedHeight(data, height) => {
                     self.insert_monero_seed_height(&write_txn, data, *height)?;
@@ -490,9 +487,6 @@ impl LMDBDatabase {
                 ClearAllReorgs => {
                     lmdb_clear(&write_txn, &self.reorgs)?;
                 },
-                InsertTipSmt { smt } => {
-                    self.insert_tip_smt(&write_txn, smt)?;
-                },
             }
         }
         write_txn.commit()?;
@@ -500,7 +494,7 @@ impl LMDBDatabase {
         Ok(())
     }
 
-    fn all_dbs(&self) -> [(&'static str, &DatabaseRef); 27] {
+    fn all_dbs(&self) -> [(&'static str, &DatabaseRef); 26] {
         [
             (LMDB_DB_METADATA, &self.metadata_db),
             (LMDB_DB_HEADERS, &self.headers_db),
@@ -532,7 +526,6 @@ impl LMDBDatabase {
             (LMDB_DB_BAD_BLOCK_LIST, &self.bad_blocks),
             (LMDB_DB_REORGS, &self.reorgs),
             (LMDB_DB_VALIDATOR_NODES, &self.validator_nodes),
-            (LMDB_DB_TIP_UTXO_SMT, &self.tip_utxo_smt),
             (LMDB_DB_VALIDATOR_NODES_MAPPING, &self.validator_nodes_mapping),
             (LMDB_DB_TEMPLATE_REGISTRATIONS, &self.template_registrations),
         ]
@@ -891,6 +884,7 @@ impl LMDBDatabase {
         &self,
         write_txn: &WriteTransaction<'_>,
         block_hash: &HashOutput,
+        smt: Arc<RwLock<OutputSmt>>,
     ) -> Result<(), ChainStorageError> {
         let hash_hex = block_hash.to_hex();
         debug!(target: LOG_TARGET, "Deleting block `{}`", hash_hex);
@@ -913,12 +907,19 @@ impl LMDBDatabase {
             &height,
             "block_accumulated_data_db",
         )?;
-        let mut smt = self.fetch_tip_smt()?;
 
-        self.delete_block_inputs_outputs(write_txn, block_hash.as_slice(), &mut smt)?;
+        let mut output_smt = smt.write().map_err(|e| {
+            error!(
+                target: LOG_TARGET,
+                "An attempt to get a write lock on the smt failed. {:?}", e
+            );
+            ChainStorageError::AccessError("write lock on smt".into())
+        })?;
+
+        self.delete_block_inputs_outputs(write_txn, block_hash.as_slice(), &mut output_smt)?;
 
         let new_tip_header = self.fetch_chain_header_by_height(prev_height)?;
-        let root = FixedHash::try_from(smt.hash().as_slice())?;
+        let root = FixedHash::try_from(output_smt.hash().as_slice())?;
         if root != new_tip_header.header().output_mr {
             error!(
                 target: LOG_TARGET,
@@ -931,7 +932,6 @@ impl LMDBDatabase {
             ));
         }
 
-        self.insert_tip_smt(write_txn, &smt)?;
         self.delete_block_kernels(write_txn, block_hash.as_slice())?;
 
         Ok(())
@@ -1171,7 +1171,15 @@ impl LMDBDatabase {
         txn: &WriteTransaction<'_>,
         header: &BlockHeader,
         body: AggregateBody,
+        smt: Arc<RwLock<OutputSmt>>,
     ) -> Result<(), ChainStorageError> {
+        let mut output_smt = smt.write().map_err(|e| {
+            error!(
+                target: LOG_TARGET,
+                "An attempt to get a write lock on the smt failed. {:?}", e
+            );
+            ChainStorageError::AccessError("write lock on smt".into())
+        })?;
         if self.fetch_block_accumulated_data(txn, header.height + 1)?.is_some() {
             return Err(ChainStorageError::InvalidOperation(format!(
                 "Attempted to insert block at height {} while next block already exists",
@@ -1236,13 +1244,6 @@ impl LMDBDatabase {
             );
             self.insert_kernel(txn, &block_hash, &kernel, pos)?;
         }
-        let k = MetadataKey::TipSmt;
-        let mut output_smt: OutputSmt =
-            lmdb_get(txn, &self.tip_utxo_smt, &k.as_u32())?.ok_or_else(|| ChainStorageError::ValueNotFound {
-                entity: "Output_smt",
-                field: "tip",
-                value: "".to_string(),
-            })?;
 
         for output in outputs {
             trace!(
@@ -1339,7 +1340,6 @@ impl LMDBDatabase {
             header.height,
             &BlockAccumulatedData::new(kernel_mmr.get_pruned_hash_set()?, total_kernel_sum),
         )?;
-        self.insert_tip_smt(txn, &output_smt)?;
 
         Ok(())
     }
@@ -1404,49 +1404,6 @@ impl LMDBDatabase {
             data,
             "block_accumulated_data_db",
         )
-    }
-
-    fn insert_tip_smt(&self, txn: &WriteTransaction<'_>, smt: &OutputSmt) -> Result<(), ChainStorageError> {
-        let start = Instant::now();
-        let k = MetadataKey::TipSmt;
-
-        // This is best effort, if it fails (typically when the entry does not yet exist) we just log it
-        if let Err(e) = lmdb_delete(txn, &self.tip_utxo_smt, &k.as_u32(), LMDB_DB_TIP_UTXO_SMT) {
-            debug!(
-                "Could NOT delete '{}' db with key '{}' ({})",
-                LMDB_DB_TIP_UTXO_SMT,
-                to_hex(k.as_u32().as_lmdb_bytes()),
-                e
-            );
-        }
-
-        #[allow(clippy::cast_possible_truncation)]
-        let estimated_bytes = smt.size().saturating_mul(225) as usize;
-        match lmdb_replace(txn, &self.tip_utxo_smt, &k.as_u32(), smt, Some(estimated_bytes)) {
-            Ok(_) => {
-                trace!(
-                    "Inserted ~{} MB with key '{}' into '{}' (size {}) in {:.2?}",
-                    estimated_bytes / BYTES_PER_MB,
-                    to_hex(k.as_u32().as_lmdb_bytes()),
-                    LMDB_DB_TIP_UTXO_SMT,
-                    smt.size(),
-                    start.elapsed()
-                );
-                Ok(())
-            },
-            Err(e) => {
-                if let ChainStorageError::DbResizeRequired(Some(val)) = e {
-                    trace!(
-                        "Could NOT insert {} MB with key '{}' into '{}' (size {})",
-                        val / BYTES_PER_MB,
-                        to_hex(k.as_u32().as_lmdb_bytes()),
-                        LMDB_DB_TIP_UTXO_SMT,
-                        smt.size()
-                    );
-                }
-                Err(e)
-            },
-        }
     }
 
     fn update_block_accumulated_data(
@@ -2086,19 +2043,19 @@ impl BlockchainBackend for LMDBDatabase {
 
     fn fetch_outputs_in_block_with_spend_state(
         &self,
-        previous_header_hash: &HashOutput,
-        spend_status_at_header: Option<HashOutput>,
+        header_hash: &HashOutput,
+        spend_status_at_header: Option<&HashOutput>,
     ) -> Result<Vec<(TransactionOutput, bool)>, ChainStorageError> {
         let txn = self.read_transaction()?;
 
         let mut outputs: Vec<(TransactionOutput, bool)> =
-            lmdb_fetch_matching_after::<TransactionOutputRowData>(&txn, &self.utxos_db, previous_header_hash.deref())?
+            lmdb_fetch_matching_after::<TransactionOutputRowData>(&txn, &self.utxos_db, header_hash.deref())?
                 .into_iter()
                 .map(|row| (row.output, false))
                 .collect();
         if let Some(header_hash) = spend_status_at_header {
             let header_height =
-                self.fetch_height_from_hash(&txn, &header_hash)?
+                self.fetch_height_from_hash(&txn, header_hash)?
                     .ok_or(ChainStorageError::ValueNotFound {
                         entity: "Header",
                         field: "hash",
@@ -2567,18 +2524,29 @@ impl BlockchainBackend for LMDBDatabase {
         Ok(result)
     }
 
-    fn fetch_tip_smt(&self) -> Result<OutputSmt, ChainStorageError> {
-        let txn = self.read_transaction()?;
-        let k = MetadataKey::TipSmt;
-        let val: Option<OutputSmt> = lmdb_get(&txn, &self.tip_utxo_smt, &k.as_u32())?;
-        match val {
-            Some(smt) => Ok(smt),
-            _ => Err(ChainStorageError::ValueNotFound {
-                entity: "TipSmt",
-                field: "TipSmt",
-                value: "".to_string(),
-            }),
+    fn calculate_tip_smt(&self) -> Result<OutputSmt, ChainStorageError> {
+        let metadata = self.fetch_chain_metadata()?;
+        let mut smt = OutputSmt::new();
+        for height in 0..=metadata.best_block_height() {
+            let header = self.fetch_chain_header_by_height(height)?;
+            let outputs =
+                self.fetch_outputs_in_block_with_spend_state(header.hash(), Some(metadata.best_block_hash()))?;
+            for output in outputs {
+                if !output.1 && !output.0.is_burned() {
+                    let smt_key = NodeKey::try_from(output.0.commitment.as_bytes())?;
+                    let smt_node = ValueHash::try_from(output.0.smt_hash(header.header().height).as_slice())?;
+                    if let Err(e) = smt.insert(smt_key, smt_node) {
+                        error!(
+                            target: LOG_TARGET,
+                            "Output commitment({}) already in SMT",
+                            output.0.commitment.to_hex(),
+                        );
+                        return Err(e.into());
+                    }
+                }
+            }
         }
+        Ok(smt)
     }
 }
 
@@ -2704,7 +2672,6 @@ enum MetadataKey {
     HorizonData,
     BestBlockTimestamp,
     MigrationVersion,
-    TipSmt,
 }
 
 impl MetadataKey {
@@ -2725,7 +2692,6 @@ impl fmt::Display for MetadataKey {
             MetadataKey::HorizonData => write!(f, "Database info"),
             MetadataKey::BestBlockTimestamp => write!(f, "Chain tip block timestamp"),
             MetadataKey::MigrationVersion => write!(f, "Migration version"),
-            MetadataKey::TipSmt => write!(f, "Chain tip Sparse Merkle Tree version"),
         }
     }
 }

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -2555,7 +2555,7 @@ impl BlockchainBackend for LMDBDatabase {
         trace!(
             target: LOG_TARGET,
             "Finished calculating new smt (size: {}), took: #{}s",
-            smt.size,
+            smt.size(),
             start.elapsed().as_millis()
         );
         Ok(smt)

--- a/base_layer/core/src/validation/block_body/block_body_full_validator.rs
+++ b/base_layer/core/src/validation/block_body/block_body_full_validator.rs
@@ -20,13 +20,16 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use std::sync::{Arc, RwLock};
+
+use log::error;
 use tari_common_types::chain_metadata::ChainMetadata;
 use tari_utilities::hex::Hex;
 
 use super::BlockBodyInternalConsistencyValidator;
 use crate::{
     blocks::{Block, ChainBlock},
-    chain_storage::{self, BlockchainBackend},
+    chain_storage::{self, BlockchainBackend, ChainStorageError},
     consensus::ConsensusManager,
     transactions::CryptoFactories,
     validation::{
@@ -36,7 +39,10 @@ use crate::{
         CandidateBlockValidator,
         ValidationError,
     },
+    OutputSmt,
 };
+
+const LOG_TARGET: &str = "c::val::block_body_full_validator";
 
 pub struct BlockBodyFullValidator {
     consensus_manager: ConsensusManager,
@@ -62,6 +68,7 @@ impl BlockBodyFullValidator {
         backend: &B,
         block: &Block,
         metadata_option: Option<&ChainMetadata>,
+        smt: Arc<RwLock<OutputSmt>>,
     ) -> Result<Block, ValidationError> {
         if let Some(metadata) = metadata_option {
             validate_block_metadata(block, metadata)?;
@@ -78,8 +85,15 @@ impl BlockBodyFullValidator {
         // validate the internal consistency of the block body
         self.block_internal_validator.validate(&block)?;
 
-        // validate the merkle mountain range roots
-        let mmr_roots = chain_storage::calculate_mmr_roots(backend, &self.consensus_manager, &block)?;
+        // validate the merkle mountain range roots+
+        let mut output_smt = smt.write().map_err(|e| {
+            error!(
+                target: LOG_TARGET,
+                "An attempt to get a write lock on the smt failed. {:?}", e
+            );
+            ChainStorageError::AccessError("write lock on smt".into())
+        })?;
+        let mmr_roots = chain_storage::calculate_mmr_roots(backend, &self.consensus_manager, &block, &mut output_smt)?;
         check_mmr_roots(&block.header, &mmr_roots)?;
 
         Ok(block)
@@ -92,15 +106,16 @@ impl<B: BlockchainBackend> CandidateBlockValidator<B> for BlockBodyFullValidator
         backend: &B,
         block: &ChainBlock,
         metadata: &ChainMetadata,
+        smt: Arc<RwLock<OutputSmt>>,
     ) -> Result<(), ValidationError> {
-        self.validate(backend, block.block(), Some(metadata))?;
+        self.validate(backend, block.block(), Some(metadata), smt)?;
         Ok(())
     }
 }
 
 impl<B: BlockchainBackend> BlockBodyValidator<B> for BlockBodyFullValidator {
-    fn validate_body(&self, backend: &B, block: &Block) -> Result<Block, ValidationError> {
-        self.validate(backend, block, None)
+    fn validate_body(&self, backend: &B, block: &Block, smt: Arc<RwLock<OutputSmt>>) -> Result<Block, ValidationError> {
+        self.validate(backend, block, None, smt)
     }
 }
 

--- a/base_layer/core/src/validation/block_body/block_body_full_validator.rs
+++ b/base_layer/core/src/validation/block_body/block_body_full_validator.rs
@@ -89,7 +89,7 @@ impl BlockBodyFullValidator {
         let mut output_smt = smt.write().map_err(|e| {
             error!(
                 target: LOG_TARGET,
-                "An attempt to get a write lock on the smt failed. {:?}", e
+                "Validator could not get a write lock on the smt {:?}", e
             );
             ChainStorageError::AccessError("write lock on smt".into())
         })?;

--- a/base_layer/core/src/validation/block_body/test.rs
+++ b/base_layer/core/src/validation/block_body/test.rs
@@ -99,7 +99,8 @@ async fn it_passes_if_large_output_block_is_valid() {
 
     let txn = blockchain.db().db_read_access().unwrap();
     let start = Instant::now();
-    assert!(validator.validate_body(&*txn, &block).is_ok());
+    let smt = blockchain.db().smt().clone();
+    assert!(validator.validate_body(&*txn, &block, smt).is_ok());
     let finished = start.elapsed();
     // this here here for benchmarking purposes.
     // we can extrapolate full block validation by multiplying the time by 4.6, this we get from the max_weight /weight
@@ -133,7 +134,8 @@ async fn it_validates_when_a_coinbase_is_spent() {
     block.header.validator_node_size = mmr_roots.validator_node_size;
 
     let txn = blockchain.db().db_read_access().unwrap();
-    assert!(validator.validate_body(&*txn, &block).is_ok());
+    let smt = blockchain.db().smt().clone();
+    assert!(validator.validate_body(&*txn, &block, smt).is_ok());
 }
 
 #[tokio::test]
@@ -175,7 +177,8 @@ async fn it_passes_if_large_block_is_valid() {
 
     let txn = blockchain.db().db_read_access().unwrap();
     let start = Instant::now();
-    validator.validate_body(&*txn, &block).unwrap();
+    let smt = blockchain.db().smt();
+    validator.validate_body(&*txn, &block, smt).unwrap();
     // assert!(validator.validate_body(&*txn, &block).is_ok());
     let finished = start.elapsed();
     // this here here for benchmarking purposes.
@@ -203,7 +206,8 @@ async fn it_passes_if_block_is_valid() {
     block.header.validator_node_size = mmr_roots.validator_node_size;
 
     let txn = blockchain.db().db_read_access().unwrap();
-    assert!(validator.validate_body(&*txn, &block).is_ok());
+    let smt = blockchain.db().smt();
+    assert!(validator.validate_body(&*txn, &block, smt).is_ok());
 }
 
 #[tokio::test]
@@ -214,7 +218,8 @@ async fn it_checks_the_coinbase_reward() {
         .create_chained_block(block_spec!("A", parent: "GB", reward: 10 * T, ))
         .await;
     let txn = blockchain.db().db_read_access().unwrap();
-    let err = validator.validate_body(&*txn, block.block()).unwrap_err();
+    let smt = blockchain.db().smt();
+    let err = validator.validate_body(&*txn, block.block(), smt).unwrap_err();
     println!("err {:?}", err);
     assert!(matches!(
         err,
@@ -256,9 +261,9 @@ async fn it_allows_multiple_coinbases() {
         .create_unmined_block(block_spec!("A2", parent: "GB", skip_coinbase: true,))
         .await;
     let block = blockchain.mine_block("GB", block, Difficulty::min());
-
+    let smt = blockchain.db().smt();
     let txn = blockchain.db().db_read_access().unwrap();
-    let err = validator.validate_body(&*txn, block.block()).unwrap_err();
+    let err = validator.validate_body(&*txn, block.block(), smt).unwrap_err();
     assert!(matches!(
         err,
         ValidationError::BlockError(BlockValidationError::TransactionError(TransactionError::NoCoinbase))
@@ -288,7 +293,8 @@ async fn it_checks_duplicate_kernel() {
         )
         .await;
     let txn = blockchain.db().db_read_access().unwrap();
-    let err = validator.validate_body(&*txn, block.block()).unwrap_err();
+    let smt = blockchain.db().smt();
+    let err = validator.validate_body(&*txn, block.block(), smt).unwrap_err();
     assert!(matches!(err, ValidationError::DuplicateKernelError(_)));
 }
 
@@ -321,7 +327,8 @@ async fn it_checks_double_spends() {
         )
         .await;
     let txn = blockchain.db().db_read_access().unwrap();
-    let err = validator.validate_body(&*txn, block.block()).unwrap_err();
+    let smt = blockchain.db().smt();
+    let err = validator.validate_body(&*txn, block.block(), smt).unwrap_err();
     assert!(matches!(err, ValidationError::ContainsSTxO));
 }
 
@@ -342,7 +349,8 @@ async fn it_checks_input_maturity() {
         )
         .await;
     let txn = blockchain.db().db_read_access().unwrap();
-    let err = validator.validate_body(&*txn, block.block()).unwrap_err();
+    let smt = blockchain.db().smt();
+    let err = validator.validate_body(&*txn, block.block(), smt).unwrap_err();
     assert!(matches!(
         err,
         ValidationError::TransactionError(TransactionError::InputMaturity)
@@ -370,7 +378,8 @@ async fn it_checks_txo_sort_order() {
     let block = blockchain.mine_block("A", block, Difficulty::min());
 
     let txn = blockchain.db().db_read_access().unwrap();
-    let err = validator.validate_body(&*txn, block.block()).unwrap_err();
+    let smt = blockchain.db().smt();
+    let err = validator.validate_body(&*txn, block.block(), smt).unwrap_err();
     assert!(matches!(err, ValidationError::UnsortedOrDuplicateOutput));
 }
 
@@ -396,7 +405,8 @@ async fn it_limits_the_script_byte_size() {
     let (block, _) = blockchain.create_next_tip(block_spec!("B", transactions: txs)).await;
 
     let txn = blockchain.db().db_read_access().unwrap();
-    let err = validator.validate_body(&*txn, block.block()).unwrap_err();
+    let smt = blockchain.db().smt();
+    let err = validator.validate_body(&*txn, block.block(), smt).unwrap_err();
     assert!(matches!(err, ValidationError::TariScriptExceedsMaxSize { .. }));
 }
 
@@ -421,7 +431,8 @@ async fn it_rejects_invalid_input_metadata() {
     let (block, _) = blockchain.create_next_tip(block_spec!("B", transactions: txs)).await;
 
     let txn = blockchain.db().db_read_access().unwrap();
-    let err = validator.validate_body(&*txn, block.block()).unwrap_err();
+    let smt = blockchain.db().smt();
+    let err = validator.validate_body(&*txn, block.block(), smt).unwrap_err();
     assert!(matches!(err, ValidationError::UnknownInputs(_)));
 }
 
@@ -449,8 +460,9 @@ async fn it_rejects_zero_conf_double_spends() {
     let (unmined, _) = blockchain
         .create_unmined_block(block_spec!("2", parent: "1", transactions: transactions))
         .await;
+    let smt = blockchain.db().smt();
     let txn = blockchain.db().db_read_access().unwrap();
-    let err = validator.validate_body(&*txn, &unmined).unwrap_err();
+    let err = validator.validate_body(&*txn, &unmined, smt).unwrap_err();
     assert!(matches!(err, ValidationError::UnsortedOrDuplicateInput));
 }
 
@@ -484,7 +496,10 @@ mod body_only {
         let metadata = blockchain.db().get_chain_metadata().unwrap();
 
         let db = blockchain.db().db_read_access().unwrap();
-        let err = validator.validate(&*db, block.block(), Some(&metadata)).unwrap_err();
+        let smt = blockchain.db().smt();
+        let err = validator
+            .validate(&*db, block.block(), Some(&metadata), smt)
+            .unwrap_err();
         assert!(matches!(err, ValidationError::UnknownInputs(_)));
     }
 }

--- a/base_layer/core/src/validation/mocks.rs
+++ b/base_layer/core/src/validation/mocks.rs
@@ -23,6 +23,7 @@
 use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc,
+    RwLock,
 };
 
 use tari_common_types::{chain_metadata::ChainMetadata, types::Commitment};
@@ -42,6 +43,7 @@ use crate::{
     test_helpers::create_consensus_rules,
     transactions::transaction_components::Transaction,
     validation::{error::ValidationError, DifficultyCalculator, FinalHorizonStateValidation},
+    OutputSmt,
 };
 
 #[derive(Clone)]
@@ -70,7 +72,7 @@ impl MockValidator {
 }
 
 impl<B: BlockchainBackend> BlockBodyValidator<B> for MockValidator {
-    fn validate_body(&self, _: &B, block: &Block) -> Result<Block, ValidationError> {
+    fn validate_body(&self, _: &B, block: &Block, _: Arc<RwLock<OutputSmt>>) -> Result<Block, ValidationError> {
         if self.is_valid.load(Ordering::SeqCst) {
             Ok(block.clone())
         } else {
@@ -82,7 +84,13 @@ impl<B: BlockchainBackend> BlockBodyValidator<B> for MockValidator {
 }
 
 impl<B: BlockchainBackend> CandidateBlockValidator<B> for MockValidator {
-    fn validate_body_with_metadata(&self, _: &B, _: &ChainBlock, _: &ChainMetadata) -> Result<(), ValidationError> {
+    fn validate_body_with_metadata(
+        &self,
+        _: &B,
+        _: &ChainBlock,
+        _: &ChainMetadata,
+        _: Arc<RwLock<OutputSmt>>,
+    ) -> Result<(), ValidationError> {
         if self.is_valid.load(Ordering::SeqCst) {
             Ok(())
         } else {

--- a/base_layer/core/src/validation/traits.rs
+++ b/base_layer/core/src/validation/traits.rs
@@ -1,9 +1,12 @@
+use std::sync::{Arc, RwLock};
+
 // Copyright 2019. The Tari Project
 //
 // Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
 // following conditions are met:
 //
-// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
+//    following
 // disclaimer.
 //
 // 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
@@ -12,13 +15,14 @@
 // 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
 // products derived from this software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
-// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
-// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
-// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+// WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+// PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
 use tari_common_types::{chain_metadata::ChainMetadata, types::Commitment};
 use tari_utilities::epoch_time::EpochTime;
 
@@ -28,12 +32,13 @@ use crate::{
     proof_of_work::{AchievedTargetDifficulty, Difficulty},
     transactions::transaction_components::Transaction,
     validation::error::ValidationError,
+    OutputSmt,
 };
 
 /// A validator that determines if a block body is valid, assuming that the header has already been
 /// validated
 pub trait BlockBodyValidator<B>: Send + Sync {
-    fn validate_body(&self, backend: &B, block: &Block) -> Result<Block, ValidationError>;
+    fn validate_body(&self, backend: &B, block: &Block, smt: Arc<RwLock<OutputSmt>>) -> Result<Block, ValidationError>;
 }
 
 /// A validator that validates a body after it has been determined to be a valid orphan
@@ -43,6 +48,7 @@ pub trait CandidateBlockValidator<B>: Send + Sync {
         backend: &B,
         block: &ChainBlock,
         metadata: &ChainMetadata,
+        smt: Arc<RwLock<OutputSmt>>,
     ) -> Result<(), ValidationError>;
 }
 

--- a/base_layer/core/tests/helpers/sample_blockchains.rs
+++ b/base_layer/core/tests/helpers/sample_blockchains.rs
@@ -21,6 +21,8 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 
+use std::sync::{Arc, RwLock};
+
 use tari_common::configuration::Network;
 use tari_core::{
     blocks::ChainBlock,
@@ -34,6 +36,7 @@ use tari_core::{
     },
     txn_schema,
     validation::DifficultyCalculator,
+    OutputSmt,
 };
 
 use crate::helpers::block_builders::{create_genesis_block, generate_new_block};
@@ -254,12 +257,14 @@ pub async fn create_new_blockchain_lmdb(
         .build()
         .unwrap();
     let db = TempDatabase::new();
+    let smt = Arc::new(RwLock::new(OutputSmt::new()));
     let db = BlockchainDatabase::new(
         db,
         consensus_manager.clone(),
         validators,
         config,
         DifficultyCalculator::new(consensus_manager.clone(), Default::default()),
+        smt,
     )
     .unwrap();
     (db, vec![block0], vec![vec![output]], consensus_manager, key_manager)

--- a/base_layer/core/tests/tests/node_comms_interface.rs
+++ b/base_layer/core/tests/tests/node_comms_interface.rs
@@ -20,6 +20,8 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use std::sync::{Arc, RwLock};
+
 use tari_common::configuration::Network;
 use tari_comms::test_utils::mocks::create_connectivity_mock;
 use tari_core::{
@@ -59,6 +61,7 @@ use tari_core::{
     },
     txn_schema,
     validation::{mocks::MockValidator, transaction::TransactionChainLinkedValidator},
+    OutputSmt,
 };
 use tari_key_manager::key_manager_service::KeyManagerInterface;
 use tari_script::{inputs, script, ExecutionStack};
@@ -441,7 +444,9 @@ async fn inbound_fetch_blocks_before_horizon_height() {
         pruning_interval: 1,
         ..Default::default()
     };
-    let store = create_store_with_consensus_and_validators_and_config(consensus_manager.clone(), validators, config);
+    let smt = Arc::new(RwLock::new(OutputSmt::new()));
+    let store =
+        create_store_with_consensus_and_validators_and_config(consensus_manager.clone(), validators, config, smt);
     let mempool_validator = TransactionChainLinkedValidator::new(store.clone(), consensus_manager.clone());
     let mempool = Mempool::new(
         MempoolConfig::default(),


### PR DESCRIPTION
Description
---
This only keeps only a single copy of the smt in memory

Motivation and Context
---
Writing and load the smt from disc every time is inefficient and take long, this keeps in in memory. 
Keeping a single copy in an `Arc<RwLock<>>` alles the node to keep a single copy and use it. 

How Has This Been Tested?
---
unit tests and manual. 
