### PR TITLE
feat!: update new block proto to support multiple coinbases

### DIFF
--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -594,15 +594,16 @@ where B: BlockchainBackend + 'static
     ) -> Result<Block, CommsInterfaceError> {
         let NewBlock {
             header,
-            coinbase_kernel,
-            coinbase_output,
+            coinbase_kernels,
+            coinbase_outputs,
             kernel_excess_sigs: excess_sigs,
         } = new_block;
         // If the block is empty, we dont have to ask for the block, as we already have the full block available
         // to us.
         if excess_sigs.is_empty() {
             let block = BlockBuilder::new(header.version)
-                .with_coinbase_utxo(coinbase_output, coinbase_kernel)
+                .add_outputs(coinbase_outputs)
+                .add_kernels(coinbase_kernels)
                 .with_header(header)
                 .build();
             return Ok(block);
@@ -639,7 +640,8 @@ where B: BlockchainBackend + 'static
         metrics::compact_block_tx_misses(header.height).set(missing_excess_sigs.len() as i64);
 
         let mut builder = BlockBuilder::new(header.version)
-            .with_coinbase_utxo(coinbase_output, coinbase_kernel)
+            .add_outputs(coinbase_outputs)
+            .add_kernels(coinbase_kernels)
             .with_transactions(known_transactions);
 
         if missing_excess_sigs.is_empty() {

--- a/base_layer/core/src/blocks/block.rs
+++ b/base_layer/core/src/blocks/block.rs
@@ -247,34 +247,34 @@ pub struct NewBlock {
     /// The block header.
     pub header: BlockHeader,
     /// Coinbase kernel of the block
-    pub coinbase_kernel: TransactionKernel,
+    pub coinbase_kernels: Vec<TransactionKernel>,
     /// Coinbase output of the block
-    pub coinbase_output: TransactionOutput,
+    pub coinbase_outputs: Vec<TransactionOutput>,
     /// The scalar `s` component of the kernel excess signatures of the transactions contained in the block.
     pub kernel_excess_sigs: Vec<PrivateKey>,
 }
 
 impl From<&Block> for NewBlock {
     fn from(block: &Block) -> Self {
-        let coinbase_kernel = block
+        let coinbase_kernels = block
             .body
             .kernels()
-            .iter()
-            .find(|k| k.features.contains(KernelFeatures::COINBASE_KERNEL))
-            .cloned()
-            .expect("Invalid block given to NewBlock::from, no coinbase kernel");
-        let coinbase_output = block
+            .clone()
+            .into_iter()
+            .filter(|k| k.features.contains(KernelFeatures::COINBASE_KERNEL))
+            .collect();
+        let coinbase_outputs = block
             .body
             .outputs()
-            .iter()
-            .find(|o| o.features.output_type == OutputType::Coinbase)
-            .cloned()
-            .expect("Invalid block given to NewBlock::from, no coinbase output");
+            .clone()
+            .into_iter()
+            .filter(|o| o.features.output_type == OutputType::Coinbase)
+            .collect();
 
         Self {
             header: block.header.clone(),
-            coinbase_kernel,
-            coinbase_output,
+            coinbase_kernels,
+            coinbase_outputs,
             kernel_excess_sigs: block
                 .body
                 .kernels()

--- a/base_layer/core/src/proto/block.proto
+++ b/base_layer/core/src/proto/block.proto
@@ -73,9 +73,9 @@ message NewBlock {
     // The block header.
     BlockHeader header = 1;
     // Coinbase kernel of the block.
-    tari.types.TransactionKernel coinbase_kernel = 2;
+    repeated tari.types.TransactionKernel coinbase_kernels = 2;
     // Coinbase output of the block.
-    tari.types.TransactionOutput coinbase_output = 3;
+    repeated tari.types.TransactionOutput coinbase_outputs = 3;
     // The scalar `s` component of the kernel excess signatures of the transactions contained in the block.
     repeated bytes kernel_excess_sigs = 4;
 }

--- a/base_layer/core/src/proto/block.rs
+++ b/base_layer/core/src/proto/block.rs
@@ -184,16 +184,18 @@ impl TryFrom<proto::NewBlock> for NewBlock {
     type Error = String;
 
     fn try_from(new_block: proto::NewBlock) -> Result<Self, Self::Error> {
+        let mut coinbase_kernels = Vec::new();
+        for coinbase_kernel in new_block.coinbase_kernels {
+            coinbase_kernels.push(coinbase_kernel.try_into()?)
+        }
+        let mut coinbase_outputs = Vec::new();
+        for coinbase_output in new_block.coinbase_outputs {
+            coinbase_outputs.push(coinbase_output.try_into()?)
+        }
         Ok(Self {
             header: new_block.header.ok_or("No new block header provided")?.try_into()?,
-            coinbase_kernel: new_block
-                .coinbase_kernel
-                .ok_or("No coinbase kernel given")?
-                .try_into()?,
-            coinbase_output: new_block
-                .coinbase_output
-                .ok_or("No coinbase kernel given")?
-                .try_into()?,
+            coinbase_kernels,
+            coinbase_outputs,
             kernel_excess_sigs: new_block
                 .kernel_excess_sigs
                 .iter()
@@ -208,10 +210,18 @@ impl TryFrom<NewBlock> for proto::NewBlock {
     type Error = String;
 
     fn try_from(new_block: NewBlock) -> Result<Self, Self::Error> {
+        let mut coinbase_kernels = Vec::new();
+        for coinbase_kernel in new_block.coinbase_kernels {
+            coinbase_kernels.push(coinbase_kernel.into())
+        }
+        let mut coinbase_outputs = Vec::new();
+        for coinbase_output in new_block.coinbase_outputs {
+            coinbase_outputs.push(coinbase_output.try_into()?)
+        }
         Ok(Self {
             header: Some(new_block.header.into()),
-            coinbase_kernel: Some(new_block.coinbase_kernel.into()),
-            coinbase_output: Some(new_block.coinbase_output.try_into()?),
+            coinbase_kernels,
+            coinbase_outputs,
             kernel_excess_sigs: new_block.kernel_excess_sigs.into_iter().map(|s| s.to_vec()).collect(),
         })
     }


### PR DESCRIPTION
Description
---
This changes the new block proto to allow multiple coinbases

Motivation and Context
---
Tari supports multiple coinbases and the new block proto only supports a single coinbase. 


Breaking Changes
---
Changes block propagation API 

Fixes: #6189 