### PR TITLE
feat: improve node and wallet connection times

### DIFF
--- a/applications/minotari_app_grpc/proto/network.proto
+++ b/applications/minotari_app_grpc/proto/network.proto
@@ -70,7 +70,11 @@ message Address{
     bytes address =1;
     string last_seen = 2;
     uint32 connection_attempts = 3;
-    uint64 avg_latency = 5;
+    AverageLatency avg_latency = 5;
+}
+
+message AverageLatency {
+    uint64 latency = 1;
 }
 
 message ListConnectedPeersResponse {

--- a/applications/minotari_app_grpc/src/conversions/peer.rs
+++ b/applications/minotari_app_grpc/src/conversions/peer.rs
@@ -72,7 +72,10 @@ impl From<MultiaddrWithStats> for grpc::Address {
             None => String::new(),
         };
         let connection_attempts = address_with_stats.connection_attempts();
-        let avg_latency = address_with_stats.avg_latency().as_secs();
+        let avg_latency = address_with_stats
+            .avg_latency()
+            .map(|val| grpc::AverageLatency { latency: val.as_secs() });
+
         Self {
             address,
             last_seen,

--- a/applications/minotari_node/src/bootstrap.rs
+++ b/applications/minotari_node/src/bootstrap.rs
@@ -24,7 +24,6 @@ use std::{
     cmp,
     str::FromStr,
     sync::{Arc, RwLock},
-    time::Duration,
 };
 
 use log::*;
@@ -122,7 +121,6 @@ where B: BlockchainBackend + 'static
         let tor_identity = load_from_json(&base_node_config.tor_identity_file)
             .map_err(|e| ExitError::new(ExitCode::ConfigError, e))?;
         p2p_config.transport.tor.identity = tor_identity;
-        p2p_config.listener_liveness_check_interval = Some(Duration::from_secs(15));
 
         let mut handles = StackBuilder::new(self.interrupt_signal)
             .add_initializer(P2pInitializer::new(

--- a/applications/minotari_node/src/commands/command/get_peer.rs
+++ b/applications/minotari_node/src/commands/command/get_peer.rs
@@ -88,7 +88,7 @@ impl CommandContext {
             println!("Addresses:");
             peer.addresses.addresses().iter().for_each(|a| {
                 println!(
-                    "- {} Score: {}  - Source: {} Latency: {:?} - Last Seen: {} - Last Failure:{}",
+                    "- {} Score: {:?}  - Source: {} Latency: {:?} - Last Seen: {} - Last Failure:{}",
                     a.address(),
                     a.quality_score(),
                     a.source(),

--- a/applications/minotari_node/src/commands/command/status.rs
+++ b/applications/minotari_node/src/commands/command/status.rs
@@ -27,7 +27,7 @@ use async_trait::async_trait;
 use chrono::{DateTime, NaiveDateTime, Utc};
 use clap::Parser;
 use minotari_app_utilities::consts;
-use tari_comms::connection_manager::LivenessStatus;
+use tari_comms::connection_manager::SelfLivenessStatus;
 use tokio::time;
 
 use super::{CommandContext, HandleCommand};
@@ -127,14 +127,14 @@ impl CommandContext {
         );
 
         match self.comms.liveness_status() {
-            LivenessStatus::Disabled => {},
-            LivenessStatus::Checking => {
+            SelfLivenessStatus::Disabled => {},
+            SelfLivenessStatus::Checking => {
                 status_line.add("⏳️️");
             },
-            LivenessStatus::Unreachable => {
+            SelfLivenessStatus::Unreachable => {
                 status_line.add("️🔌");
             },
-            LivenessStatus::Live(latency) => {
+            SelfLivenessStatus::Live(latency) => {
                 status_line.add(format!("⚡️ {:.2?}", latency));
             },
         }

--- a/base_layer/contacts/src/chat_client/src/config.rs
+++ b/base_layer/contacts/src/chat_client/src/config.rs
@@ -168,6 +168,7 @@ impl ChatClientConfig {
                     database_url: DbConnectionUrl::file("data/chat_client/dht.sqlite"),
                     network_discovery: NetworkDiscoveryConfig {
                         enabled: true,
+                        initial_peer_sync_delay: None,
                         ..NetworkDiscoveryConfig::default()
                     },
                     saf: SafConfig {

--- a/base_layer/contacts/tests/contacts_service.rs
+++ b/base_layer/contacts/tests/contacts_service.rs
@@ -96,7 +96,7 @@ pub fn setup_contacts_service<T: ContactsBackend + 'static>(
         user_agent: "tari/test-contacts-service".to_string(),
         rpc_max_simultaneous_sessions: 0,
         rpc_max_sessions_per_peer: 0,
-        listener_liveness_check_interval: None,
+        listener_self_liveness_check_interval: None,
     };
     let peer_message_subscription_factory = Arc::new(subscription_factory);
     let shutdown = Shutdown::new();

--- a/base_layer/core/tests/helpers/nodes.rs
+++ b/base_layer/core/tests/helpers/nodes.rs
@@ -357,6 +357,7 @@ async fn setup_base_node_services(
     let handles = StackBuilder::new(shutdown.to_signal())
         .add_initializer(RegisterHandle::new(dht))
         .add_initializer(RegisterHandle::new(comms.connectivity()))
+        .add_initializer(RegisterHandle::new(comms.peer_manager()))
         .add_initializer(LivenessInitializer::new(
             liveness_service_config,
             Arc::clone(&subscription_factory),

--- a/base_layer/p2p/src/config.rs
+++ b/base_layer/p2p/src/config.rs
@@ -112,7 +112,7 @@ pub struct P2pConfig {
     pub listener_liveness_max_sessions: usize,
     /// If Some, enables periodic socket-level liveness checks
     #[serde(with = "serializers::optional_seconds")]
-    pub listener_liveness_check_interval: Option<Duration>,
+    pub listener_self_liveness_check_interval: Option<Duration>,
     /// CIDR for addresses allowed to enter into liveness check mode on the listener.
     pub listener_liveness_allowlist_cidrs: StringList,
     /// User agent string for this node
@@ -146,7 +146,7 @@ impl Default for P2pConfig {
             },
             allow_test_addresses: false,
             listener_liveness_max_sessions: 0,
-            listener_liveness_check_interval: None,
+            listener_self_liveness_check_interval: None,
             listener_liveness_allowlist_cidrs: StringList::default(),
             user_agent: String::new(),
             auxiliary_tcp_listener_address: None,

--- a/base_layer/p2p/src/initialization.rs
+++ b/base_layer/p2p/src/initialization.rs
@@ -559,7 +559,7 @@ impl ServiceInitializer for P2pInitializer {
                 network_byte: self.network.as_byte(),
                 user_agent: config.user_agent.clone(),
             })
-            .set_liveness_check(config.listener_liveness_check_interval);
+            .set_self_liveness_check(config.listener_self_liveness_check_interval);
 
         if config.allow_test_addresses || config.dht.peer_validator_config.allow_test_addresses {
             // The default is false, so ensure that both settings are true in this case

--- a/base_layer/p2p/src/services/liveness/error.rs
+++ b/base_layer/p2p/src/services/liveness/error.rs
@@ -20,7 +20,12 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use tari_comms::{connectivity::ConnectivityError, message::MessageError, PeerConnectionError};
+use tari_comms::{
+    connectivity::ConnectivityError,
+    message::MessageError,
+    peer_manager::PeerManagerError,
+    PeerConnectionError,
+};
 use tari_comms_dht::{outbound::DhtOutboundError, DhtActorError};
 use tari_service_framework::reply_channel::TransportChannelError;
 use thiserror::Error;
@@ -53,4 +58,6 @@ pub enum LivenessError {
     NodeIdDoesNotExist,
     #[error("PingPongDecodeError: {0}")]
     PingPongDecodeError(#[from] prost::DecodeError),
+    #[error("Peer not found: `{0}`")]
+    PeerNotFoundError(#[from] PeerManagerError),
 }

--- a/base_layer/p2p/src/services/liveness/mod.rs
+++ b/base_layer/p2p/src/services/liveness/mod.rs
@@ -63,7 +63,7 @@ use std::sync::Arc;
 
 use futures::{Stream, StreamExt};
 use log::*;
-use tari_comms::connectivity::ConnectivityRequester;
+use tari_comms::{connectivity::ConnectivityRequester, PeerManager};
 use tari_comms_dht::Dht;
 use tari_service_framework::{
     async_trait,
@@ -136,6 +136,7 @@ impl ServiceInitializer for LivenessInitializer {
             let dht = handles.expect_handle::<Dht>();
             let connectivity = handles.expect_handle::<ConnectivityRequester>();
             let outbound_messages = dht.outbound_requester();
+            let peer_manager = handles.expect_handle::<Arc<PeerManager>>();
 
             let service = LivenessService::new(
                 config,
@@ -146,6 +147,7 @@ impl ServiceInitializer for LivenessInitializer {
                 outbound_messages,
                 publisher,
                 handles.get_shutdown_signal(),
+                peer_manager,
             );
             service.run().await;
             debug!(target: LOG_TARGET, "Liveness service has shut down");

--- a/base_layer/p2p/tests/services/liveness.rs
+++ b/base_layer/p2p/tests/services/liveness.rs
@@ -54,6 +54,7 @@ pub async fn setup_liveness_service(
     let handles = StackBuilder::new(comms.shutdown_signal())
         .add_initializer(RegisterHandle::new(dht.clone()))
         .add_initializer(RegisterHandle::new(comms.connectivity()))
+        .add_initializer(RegisterHandle::new(comms.peer_manager()))
         .add_initializer(LivenessInitializer::new(
             Default::default(),
             Arc::clone(&subscription_factory),

--- a/base_layer/wallet/src/config.rs
+++ b/base_layer/wallet/src/config.rs
@@ -131,7 +131,7 @@ impl Default for WalletConfig {
     fn default() -> Self {
         let p2p = P2pConfig {
             datastore_path: PathBuf::from("peer_db/wallet"),
-            listener_liveness_check_interval: None,
+            listener_self_liveness_check_interval: None,
             ..Default::default()
         };
         Self {

--- a/base_layer/wallet/tests/other/mod.rs
+++ b/base_layer/wallet/tests/other/mod.rs
@@ -154,7 +154,7 @@ async fn create_wallet(
         auxiliary_tcp_listener_address: None,
         rpc_max_simultaneous_sessions: 0,
         rpc_max_sessions_per_peer: 0,
-        listener_liveness_check_interval: None,
+        listener_self_liveness_check_interval: None,
     };
 
     let sql_database_path = comms_config
@@ -692,7 +692,7 @@ async fn test_import_utxo() {
         auxiliary_tcp_listener_address: None,
         rpc_max_simultaneous_sessions: 0,
         rpc_max_sessions_per_peer: 0,
-        listener_liveness_check_interval: None,
+        listener_self_liveness_check_interval: None,
     };
     let config = WalletConfig {
         p2p: comms_config,

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -131,7 +131,7 @@ use tari_comms::{
     transports::MemoryTransport,
     types::CommsPublicKey,
 };
-use tari_comms_dht::{store_forward::SafConfig, DbConnectionUrl, DhtConfig};
+use tari_comms_dht::{store_forward::SafConfig, DbConnectionUrl, DhtConfig, NetworkDiscoveryConfig};
 use tari_contacts::contacts_service::{handle::ContactsServiceHandle, types::Contact};
 use tari_core::{
     borsh::FromBytes,
@@ -4858,6 +4858,10 @@ pub unsafe extern "C" fn comms_config_create(
                         auto_request: true,
                         ..Default::default()
                     },
+                    network_discovery: NetworkDiscoveryConfig {
+                        initial_peer_sync_delay: Some(Duration::from_secs(25)),
+                        ..Default::default()
+                    },
                     ..Default::default()
                 },
                 allow_test_addresses: true,
@@ -4866,7 +4870,7 @@ pub unsafe extern "C" fn comms_config_create(
                 user_agent: format!("tari/mobile_wallet/{}", env!("CARGO_PKG_VERSION")),
                 rpc_max_simultaneous_sessions: 0,
                 rpc_max_sessions_per_peer: 0,
-                listener_liveness_check_interval: None,
+                listener_self_liveness_check_interval: None,
             };
 
             Box::into_raw(Box::new(config))

--- a/common/config/presets/c_base_node_c.toml
+++ b/common/config/presets/c_base_node_c.toml
@@ -148,7 +148,7 @@ track_reorgs = true
 # CIDR for addresses allowed to enter into liveness check mode on the listener.
 #listener_liveness_allowlist_cidrs = []
 # Enables periodic socket-level liveness checks. Default: Disabled
-listener_liveness_check_interval = 15
+listener_self_liveness_check_interval = 15
 
 # User agent string for this node
 #user_agent = ""
@@ -289,11 +289,9 @@ database_url = "data/base_node/dht.db"
 # Default: 5
 #network_discovery.max_sync_peers = 5
 # The maximum number of peers we allow per round of sync. (Default: 500)
-#max_peers_to_sync_per_round = 500
-# Initial refresh sync peers delay period if more than one peer needs to be synced, handy when a wallet needs to
-# give preference to its base node peer connection. (Default: 15)
-#[serde(with = "serializers::seconds")]
-#initial_peer_sync_dalay = 15
+#network_discovery.max_peers_to_sync_per_round = 500
+# Initial refresh sync peers delay period, when a configured connection needs preference. (Default: Disabled)
+#network_discovery.initial_peer_sync_delay = 0
 
 # Length of time to ban a peer if the peer misbehaves at the DHT-level. Default: 6 hrs
 #ban_duration = 21_600 # 6 * 60 * 60

--- a/common/config/presets/c_base_node_c.toml
+++ b/common/config/presets/c_base_node_c.toml
@@ -288,6 +288,12 @@ database_url = "data/base_node/dht.db"
 # The maximum number of sync peer to select for each round. The selection strategy varies depending on the current state.
 # Default: 5
 #network_discovery.max_sync_peers = 5
+# The maximum number of peers we allow per round of sync. (Default: 500)
+#max_peers_to_sync_per_round = 500
+# Initial refresh sync peers delay period if more than one peer needs to be synced, handy when a wallet needs to
+# give preference to its base node peer connection. (Default: 15)
+#[serde(with = "serializers::seconds")]
+#initial_peer_sync_dalay = 15
 
 # Length of time to ban a peer if the peer misbehaves at the DHT-level. Default: 6 hrs
 #ban_duration = 21_600 # 6 * 60 * 60

--- a/common/config/presets/d_console_wallet.toml
+++ b/common/config/presets/d_console_wallet.toml
@@ -323,7 +323,7 @@ database_url = "data/wallet/dht.db"
 #network_discovery.enabled = true
 # A threshold for the minimum number of peers this node should ideally be aware of. If below this threshold a
 # more "aggressive" strategy is employed. Default: 50
-#network_discovery.min_desired_peers = 50
+network_discovery.min_desired_peers = 8
 # The period to wait once the number of rounds given by `idle_after_num_rounds` has completed. Default: 30 mins
 #network_discovery.idle_period = 1_800 # 30 * 60
 #  The minimum number of network discovery rounds to perform before idling (going to sleep). If there are less
@@ -334,6 +334,12 @@ database_url = "data/wallet/dht.db"
 # The maximum number of sync peer to select for each round. The selection strategy varies depending on the current state.
 # Default: 5
 #network_discovery.max_sync_peers = 5
+# The maximum number of peers we allow per round of sync. (Default: 500)
+#max_peers_to_sync_per_round = 500
+# Initial refresh sync peers delay period if more than one peer needs to be synced, handy when a wallet needs to
+# give preference to its base node peer connection. (Default: 15)
+#[serde(with = "serializers::seconds")]
+#initial_peer_sync_dalay = 15
 
 # Length of time to ban a peer if the peer misbehaves at the DHT-level. Default: 6 hrs
 #ban_duration = 21_600 # 6 * 60 * 60

--- a/common/config/presets/d_console_wallet.toml
+++ b/common/config/presets/d_console_wallet.toml
@@ -198,7 +198,7 @@ event_channel_size = 3500
 # CIDR for addresses allowed to enter into liveness check mode on the listener.
 #listener_liveness_allowlist_cidrs = []
 # Enables periodic socket-level liveness checks. Default: Disabled
-# listener_liveness_check_interval = 15
+# listener_self_liveness_check_interval = 15
 
 # User agent string for this node
 #user_agent = ""
@@ -206,6 +206,8 @@ event_channel_size = 3500
 # The maximum simultaneous comms RPC sessions allowed (default value = 100). Setting this to -1 will allow unlimited
 # sessions.
 #rpc_max_simultaneous_sessions = 100
+# The maximum comms RPC sessions allowed per peer (default value = 10).
+#rpc_max_sessions_per_peer = 10
 
 [wallet.p2p.transport]
 # -------------- Transport configuration --------------
@@ -335,11 +337,9 @@ network_discovery.min_desired_peers = 8
 # Default: 5
 #network_discovery.max_sync_peers = 5
 # The maximum number of peers we allow per round of sync. (Default: 500)
-#max_peers_to_sync_per_round = 500
-# Initial refresh sync peers delay period if more than one peer needs to be synced, handy when a wallet needs to
-# give preference to its base node peer connection. (Default: 15)
-#[serde(with = "serializers::seconds")]
-#initial_peer_sync_dalay = 15
+#network_discovery.max_peers_to_sync_per_round = 500
+# Initial refresh sync peers delay period, when a configured connection needs preference. (Default: Disabled)
+network_discovery.initial_peer_sync_delay = 15
 
 # Length of time to ban a peer if the peer misbehaves at the DHT-level. Default: 6 hrs
 #ban_duration = 21_600 # 6 * 60 * 60

--- a/comms/core/src/builder/mod.rs
+++ b/comms/core/src/builder/mod.rs
@@ -125,7 +125,6 @@ pub struct CommsBuilder {
     hidden_service_ctl: Option<tor::HiddenServiceController>,
     connection_manager_config: ConnectionManagerConfig,
     connectivity_config: ConnectivityConfig,
-
     shutdown_signal: Option<ShutdownSignal>,
 }
 
@@ -288,8 +287,8 @@ impl CommsBuilder {
     }
 
     /// Enable and set interval for self-liveness checks, or None to disable it (default)
-    pub fn set_liveness_check(mut self, check_interval: Option<Duration>) -> Self {
-        self.connection_manager_config.liveness_self_check_interval = check_interval;
+    pub fn set_self_liveness_check(mut self, check_interval: Option<Duration>) -> Self {
+        self.connection_manager_config.self_liveness_self_check_interval = check_interval;
         self
     }
 

--- a/comms/core/src/connection_manager/listener.rs
+++ b/comms/core/src/connection_manager/listener.rs
@@ -359,11 +359,12 @@ where
         let authenticated_public_key = noise_socket
             .get_remote_public_key()
             .ok_or(ConnectionManagerError::InvalidStaticPublicKey)?;
+        let latency = timer.elapsed();
 
         debug!(
             target: LOG_TARGET,
             "Noise socket upgrade completed in {:.2?} with public key '{}'",
-            timer.elapsed(),
+            latency,
             authenticated_public_key
         );
 
@@ -399,6 +400,7 @@ where
             known_peer,
             authenticated_public_key,
             &valid_peer_identity,
+            latency,
         );
 
         let muxer = Yamux::upgrade_connection(noise_socket, CONNECTION_DIRECTION)

--- a/comms/core/src/connection_manager/listener.rs
+++ b/comms/core/src/connection_manager/listener.rs
@@ -55,7 +55,7 @@ use crate::connection_manager::metrics;
 use crate::{
     bounded_executor::BoundedExecutor,
     connection_manager::{
-        liveness::LivenessSession,
+        self_liveness::SelfLivenessSession,
         wire_mode::{WireMode, LIVENESS_WIRE_MODE},
     },
     multiaddr::Multiaddr,
@@ -221,7 +221,7 @@ where
         shutdown_signal: ShutdownSignal,
     ) {
         permit.fetch_sub(1, Ordering::SeqCst);
-        let liveness = LivenessSession::new(socket);
+        let liveness = SelfLivenessSession::new(socket);
         debug!(target: LOG_TARGET, "Started liveness session");
         tokio::spawn(async move {
             future::select(liveness.run(), shutdown_signal).await;
@@ -296,7 +296,7 @@ where
                     let _result = socket.shutdown().await;
                 },
                 Ok(WireMode::Liveness) => {
-                    if config.liveness_self_check_interval.is_some() ||
+                    if config.self_liveness_self_check_interval.is_some() ||
                         (liveness_session_count.load(Ordering::SeqCst) > 0 &&
                             Self::is_address_in_liveness_cidr_range(&peer_addr, &config.liveness_cidr_allowlist))
                     {

--- a/comms/core/src/connection_manager/manager.rs
+++ b/comms/core/src/connection_manager/manager.rs
@@ -124,7 +124,7 @@ pub struct ConnectionManagerConfig {
     /// CIDR blocks that allowlist liveness checks. Default: Localhost only (127.0.0.1/32)
     pub liveness_cidr_allowlist: Vec<cidr::AnyIpCidr>,
     /// Interval to perform self-liveness ping-pong tests. Default: None/disabled
-    pub liveness_self_check_interval: Option<Duration>,
+    pub self_liveness_self_check_interval: Option<Duration>,
     /// If set, an additional TCP-only p2p listener will be started. This is useful for local wallet connections.
     /// Default: None (disabled)
     pub auxiliary_tcp_listener_address: Option<Multiaddr>,
@@ -147,7 +147,7 @@ impl Default for ConnectionManagerConfig {
             liveness_max_sessions: 1,
             time_to_first_byte: Duration::from_secs(6),
             liveness_cidr_allowlist: vec![cidr::AnyIpCidr::V4("127.0.0.1/32".parse().unwrap())],
-            liveness_self_check_interval: None,
+            self_liveness_self_check_interval: None,
             auxiliary_tcp_listener_address: None,
             peer_validation_config: PeerValidatorConfig::default(),
             noise_handshake_recv_timeout: Duration::from_secs(6),
@@ -229,7 +229,7 @@ where
             info!(target: LOG_TARGET, "Starting auxiliary listener on {}", addr);
             let aux_config = ConnectionManagerConfig {
                 // Disable liveness checks on the auxiliary listener
-                liveness_self_check_interval: None,
+                self_liveness_self_check_interval: None,
                 ..config.clone()
             };
             PeerListener::new(

--- a/comms/core/src/connection_manager/mod.rs
+++ b/comms/core/src/connection_manager/mod.rs
@@ -51,9 +51,9 @@ pub use error::{ConnectionManagerError, PeerConnectionError};
 mod peer_connection;
 pub use peer_connection::{ConnectionId, NegotiatedSubstream, PeerConnection, PeerConnectionRequest};
 
-mod liveness;
-pub(crate) use liveness::LivenessCheck;
-pub use liveness::LivenessStatus;
+mod self_liveness;
+pub(crate) use self_liveness::SelfLivenessCheck;
+pub use self_liveness::SelfLivenessStatus;
 
 mod wire_mode;
 

--- a/comms/core/src/lib.rs
+++ b/comms/core/src/lib.rs
@@ -21,7 +21,6 @@ pub mod connectivity;
 
 pub mod peer_manager;
 pub use peer_manager::{NodeIdentity, OrNotFound, PeerManager};
-
 pub mod framing;
 
 mod multiplexing;

--- a/comms/core/src/net_address/mutliaddresses_with_stats.rs
+++ b/comms/core/src/net_address/mutliaddresses_with_stats.rs
@@ -371,7 +371,7 @@ mod test {
             .mark_last_attempted_now();
         assert_eq!(
             net_addresses.find_address_mut(&net_address1).unwrap().quality_score(),
-            Some(200)
+            Some(1000)
         );
         let address_12: MultiaddressesWithStats = MultiaddressesWithStats::from_addresses_with_source(
             vec![net_address12.clone()],

--- a/comms/core/src/net_address/mutliaddresses_with_stats.rs
+++ b/comms/core/src/net_address/mutliaddresses_with_stats.rs
@@ -378,11 +378,6 @@ mod test {
             &PeerAddressSource::Config,
         );
         net_addresses.merge(&address_12);
-        println!("net_address12: {:?}", address_12.addresses[0]);
-        println!(
-            "net_address1:  {:?}",
-            net_addresses.find_address_mut(&net_address1).unwrap()
-        );
         assert!(net_addresses.contains(&net_address1));
         assert!(!net_addresses.contains(&net_address12));
     }

--- a/comms/core/src/peer_manager/manager.rs
+++ b/comms/core/src/peer_manager/manager.rs
@@ -192,6 +192,26 @@ impl PeerManager {
         }
     }
 
+    pub async fn update_peer_address_latency_and_last_seen(
+        &self,
+        pubkey: &CommsPublicKey,
+        address: &Multiaddr,
+        latency: Option<Duration>,
+    ) -> Result<(), PeerManagerError> {
+        match self.find_by_public_key(pubkey).await {
+            Ok(Some(mut peer)) => {
+                if let Some(val) = latency {
+                    peer.addresses.update_latency(address, val);
+                }
+                peer.addresses.mark_last_seen_now(address);
+                self.add_peer(peer.clone()).await?;
+                Ok(())
+            },
+            Ok(None) => Err(PeerManagerError::PeerNotFoundError),
+            Err(err) => Err(err),
+        }
+    }
+
     /// Get a peer matching the given node ID
     pub async fn direct_identity_node_id(&self, node_id: &NodeId) -> Result<Option<Peer>, PeerManagerError> {
         match self.peer_storage.read().await.direct_identity_node_id(node_id) {
@@ -236,27 +256,6 @@ impl PeerManager {
             .read()
             .await
             .closest_peers(node_id, n, excluded_peers, features)
-    }
-
-    pub async fn mark_last_seen(&self, node_id: &NodeId, addr: &Multiaddr) -> Result<(), PeerManagerError> {
-        let mut lock = self.peer_storage.write().await;
-        let mut peer = lock
-            .find_by_node_id(node_id)?
-            .ok_or(PeerManagerError::PeerNotFoundError)?;
-        let source = peer
-            .addresses
-            .iter()
-            .find(|a| a.address() == addr)
-            .map(|a| a.source().clone())
-            .ok_or_else(|| PeerManagerError::AddressNotFoundError {
-                address: addr.clone(),
-                node_id: node_id.clone(),
-            })?;
-        // if we have an address, update it
-        peer.addresses.add_address(addr, &source);
-        peer.addresses.mark_last_seen_now(addr);
-        lock.add_peer(peer)?;
-        Ok(())
     }
 
     /// Fetch n random peers

--- a/comms/core/src/peer_manager/peer.rs
+++ b/comms/core/src/peer_manager/peer.rs
@@ -168,6 +168,15 @@ impl Peer {
             .and_then(|a| a.last_attempted())
     }
 
+    /// The last address used to connect to the peer
+    pub fn last_address_used(&self) -> Option<Multiaddr> {
+        self.addresses
+            .addresses()
+            .iter()
+            .max_by_key(|a| a.last_attempted())
+            .map(|a| a.address().clone())
+    }
+
     /// Returns true if the peer is marked as offline
     pub fn is_offline(&self) -> bool {
         self.addresses.offline_at().is_some()

--- a/comms/dht/src/config.rs
+++ b/comms/dht/src/config.rs
@@ -137,6 +137,7 @@ impl DhtConfig {
             network_discovery: NetworkDiscoveryConfig {
                 // If a test requires the peer probe they should explicitly enable it
                 enabled: false,
+                initial_peer_sync_delay: None,
                 ..Default::default()
             },
             peer_validator_config: PeerValidatorConfig {

--- a/comms/dht/src/connectivity/mod.rs
+++ b/comms/dht/src/connectivity/mod.rs
@@ -93,6 +93,7 @@ pub(crate) struct DhtConnectivity {
     metrics_collector: MetricsCollectorHandle,
     cooldown_in_effect: Option<Instant>,
     shutdown_signal: ShutdownSignal,
+    first_round_completed: bool,
 }
 
 impl DhtConnectivity {
@@ -121,6 +122,7 @@ impl DhtConnectivity {
             dht_events,
             cooldown_in_effect: None,
             shutdown_signal,
+            first_round_completed: false,
         }
     }
 
@@ -289,7 +291,7 @@ impl DhtConnectivity {
         match event {
             DhtEvent::NetworkDiscoveryPeersAdded(info) => {
                 if info.num_new_peers > 0 {
-                    self.refresh_peer_pools().await?;
+                    self.refresh_peer_pools_with_initial_delay().await?;
                 }
             },
             _ => {},
@@ -323,7 +325,8 @@ impl DhtConnectivity {
         Ok(())
     }
 
-    async fn refresh_peer_pools(&mut self) -> Result<(), DhtConnectivityError> {
+    async fn refresh_peer_pools_with_initial_delay(&mut self) -> Result<(), DhtConnectivityError> {
+        self.handle_initial_delay().await;
         info!(
             target: LOG_TARGET,
             "Reinitializing neighbour pool. (size={})",
@@ -334,6 +337,27 @@ impl DhtConnectivity {
         self.refresh_random_pool().await?;
 
         Ok(())
+    }
+
+    async fn request_many_dials_with_initial_delay<I: IntoIterator<Item = NodeId>>(
+        &mut self,
+        peers: I,
+    ) -> Result<(), DhtConnectivityError> {
+        self.handle_initial_delay().await;
+        self.connectivity.request_many_dials(peers).await?;
+        Ok(())
+    }
+
+    async fn handle_initial_delay(&mut self) {
+        if !self.first_round_completed {
+            self.first_round_completed = true;
+            tokio::time::sleep(self.config.network_discovery.initial_peer_sync_dalay).await;
+            debug!(
+                target: LOG_TARGET,
+                "Delayed {:.0?} before refreshing the neighbour pool for the first time",
+                self.config.network_discovery.initial_peer_sync_dalay
+            );
+        }
     }
 
     async fn refresh_neighbour_pool_if_required(&mut self) -> Result<(), DhtConnectivityError> {
@@ -400,7 +424,7 @@ impl DhtConnectivity {
         });
 
         if !new_neighbours.is_empty() {
-            self.connectivity.request_many_dials(new_neighbours).await?;
+            self.request_many_dials_with_initial_delay(new_neighbours).await?;
         }
 
         self.redial_neighbours_as_required().await?;
@@ -427,7 +451,7 @@ impl DhtConnectivity {
                 "Redialling {} disconnected peer(s)",
                 to_redial.len()
             );
-            self.connectivity.request_many_dials(to_redial).await?;
+            self.request_many_dials_with_initial_delay(to_redial).await?;
         }
 
         Ok(())
@@ -482,7 +506,7 @@ impl DhtConnectivity {
         difference.iter().for_each(|peer| {
             self.remove_connection_handle(peer);
         });
-        self.connectivity.request_many_dials(random_peers).await?;
+        self.request_many_dials_with_initial_delay(random_peers).await?;
 
         self.random_pool_last_refresh = Some(Instant::now());
         Ok(())
@@ -589,10 +613,10 @@ impl DhtConnectivity {
                 debug!(target: LOG_TARGET, "Pool peer {} disconnected. Redialling...", node_id);
                 // Attempt to reestablish the lost connection to the pool peer. If reconnection fails,
                 // it is replaced with another peer (replace_pool_peer via PeerConnectFailed)
-                self.connectivity.request_many_dials([node_id]).await?;
+                self.request_many_dials_with_initial_delay([node_id]).await?;
             },
             ConnectivityStateOnline(n) => {
-                self.refresh_peer_pools().await?;
+                self.refresh_peer_pools_with_initial_delay().await?;
                 if self.config.auto_join && self.should_send_join() {
                     debug!(
                         target: LOG_TARGET,
@@ -608,7 +632,7 @@ impl DhtConnectivity {
             },
             ConnectivityStateOffline => {
                 debug!(target: LOG_TARGET, "Node is OFFLINE");
-                self.refresh_peer_pools().await?;
+                self.refresh_peer_pools_with_initial_delay().await?;
             },
             _ => {},
         }
@@ -637,7 +661,7 @@ impl DhtConnectivity {
                         self.random_pool.swap_remove(pos);
                     }
                     self.random_pool.push(new_peer.clone());
-                    self.connectivity.request_many_dials([new_peer]).await?;
+                    self.request_many_dials_with_initial_delay([new_peer]).await?;
                 },
                 None => {
                     debug!(
@@ -671,7 +695,7 @@ impl DhtConnectivity {
                         self.neighbours.remove(pos);
                     }
                     self.insert_neighbour(node_id.clone());
-                    self.connectivity.request_many_dials([node_id]).await?;
+                    self.request_many_dials_with_initial_delay([node_id]).await?;
                 },
                 None => {
                     info!(

--- a/comms/dht/src/discovery/service.rs
+++ b/comms/dht/src/discovery/service.rs
@@ -282,6 +282,7 @@ impl DhtDiscoveryService {
     ) -> Result<T, DhtPeerValidatorError> {
         match result {
             Ok(peer) => Ok(peer),
+            Err(err @ DhtPeerValidatorError::NewAndExistingMismatch { .. }) => Err(err),
             Err(err @ DhtPeerValidatorError::IdentityTooManyClaims { .. }) |
             Err(err @ DhtPeerValidatorError::ValidatorError(_)) => {
                 self.dht.ban_peer(public_key.clone(), OffenceSeverity::High, &err).await;

--- a/comms/dht/src/inbound/dht_handler/task.rs
+++ b/comms/dht/src/inbound/dht_handler/task.rs
@@ -464,6 +464,7 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
             Err(err) => {
                 match &err {
                     DhtInboundError::PeerValidatorError(err) => match err {
+                        DhtPeerValidatorError::NewAndExistingMismatch { .. } => {},
                         err @ DhtPeerValidatorError::ValidatorError(_) |
                         err @ DhtPeerValidatorError::IdentityTooManyClaims { .. } => {
                             self.dht

--- a/comms/dht/src/network_discovery/config.rs
+++ b/comms/dht/src/network_discovery/config.rs
@@ -53,11 +53,10 @@ pub struct NetworkDiscoveryConfig {
     /// The maximum number of peers we allow per round of sync.
     /// Default: 500
     pub max_peers_to_sync_per_round: u32,
-    /// Initial refresh sync peers delay period if more than one peer needs to be synced, handy when a specific
-    /// connection needs preference.
-    /// Default: 15
-    #[serde(with = "serializers::seconds")]
-    pub initial_peer_sync_dalay: Duration,
+    /// Initial refresh sync peers delay period, when a configured connection needs preference.
+    /// Default: None
+    #[serde(with = "serializers::optional_seconds")]
+    pub initial_peer_sync_delay: Option<Duration>,
 }
 
 impl Default for NetworkDiscoveryConfig {
@@ -70,7 +69,7 @@ impl Default for NetworkDiscoveryConfig {
             on_failure_idle_period: Duration::from_secs(5),
             max_sync_peers: 5,
             max_peers_to_sync_per_round: 500,
-            initial_peer_sync_dalay: Duration::from_secs(15),
+            initial_peer_sync_delay: None,
         }
     }
 }

--- a/comms/dht/src/network_discovery/config.rs
+++ b/comms/dht/src/network_discovery/config.rs
@@ -53,6 +53,11 @@ pub struct NetworkDiscoveryConfig {
     /// The maximum number of peers we allow per round of sync.
     /// Default: 500
     pub max_peers_to_sync_per_round: u32,
+    /// Initial refresh sync peers delay period if more than one peer needs to be synced, handy when a specific
+    /// connection needs preference.
+    /// Default: 15
+    #[serde(with = "serializers::seconds")]
+    pub initial_peer_sync_dalay: Duration,
 }
 
 impl Default for NetworkDiscoveryConfig {
@@ -65,6 +70,7 @@ impl Default for NetworkDiscoveryConfig {
             on_failure_idle_period: Duration::from_secs(5),
             max_sync_peers: 5,
             max_peers_to_sync_per_round: 500,
+            initial_peer_sync_dalay: Duration::from_secs(15),
         }
     }
 }

--- a/comms/dht/src/network_discovery/initializing.rs
+++ b/comms/dht/src/network_discovery/initializing.rs
@@ -32,15 +32,11 @@ const LOG_TARGET: &str = "comms::dht::network_discovery";
 #[derive(Debug)]
 pub(super) struct Initializing<'a> {
     context: &'a mut NetworkDiscoveryContext,
-    initial_peer_sync_delay: Option<Duration>,
 }
 
 impl<'a> Initializing<'a> {
-    pub fn new(context: &'a mut NetworkDiscoveryContext, initial_peer_sync_delay: Option<Duration>) -> Self {
-        Self {
-            context,
-            initial_peer_sync_delay,
-        }
+    pub fn new(context: &'a mut NetworkDiscoveryContext) -> Self {
+        Self { context }
     }
 
     pub async fn next_event(&mut self) -> StateEvent {
@@ -59,7 +55,7 @@ impl<'a> Initializing<'a> {
 
         // Initial discovery and refresh sync peers delay period, when a configured connection needs preference,
         // usually needed for the wallet to connect to its own base node first.
-        if let Some(delay) = self.initial_peer_sync_delay {
+        if let Some(delay) = self.context.config.network_discovery.initial_peer_sync_delay {
             tokio::time::sleep(delay).await;
             debug!(target: LOG_TARGET, "Discovery starting after delayed for {:.0?}", delay);
         }

--- a/comms/dht/src/network_discovery/on_connect.rs
+++ b/comms/dht/src/network_discovery/on_connect.rs
@@ -121,7 +121,7 @@ impl OnConnect {
         StateEvent::Shutdown
     }
 
-    async fn sync_peers(&self, mut conn: PeerConnection) -> Result<(), NetworkDiscoveryError> {
+    async fn sync_peers(&mut self, mut conn: PeerConnection) -> Result<(), NetworkDiscoveryError> {
         let mut client = conn.connect_rpc::<rpc::DhtClient>().await?;
         let peer_stream = client
             .get_peers(GetPeersRequest {

--- a/comms/dht/src/network_discovery/state_machine.rs
+++ b/comms/dht/src/network_discovery/state_machine.rs
@@ -196,12 +196,7 @@ impl DhtNetworkDiscovery {
     async fn get_next_event(&mut self, state: &mut State) -> StateEvent {
         use State::{Discovering, Initializing, OnConnect, Ready, Waiting};
         match state {
-            Initializing => {
-                let initial_peer_sync_delay = self.config().network_discovery.initial_peer_sync_delay;
-                self::Initializing::new(&mut self.context, initial_peer_sync_delay)
-                    .next_event()
-                    .await
-            },
+            Initializing => self::Initializing::new(&mut self.context).next_event().await,
             Ready(ready) => ready.next_event().await,
             Discovering(discovering) => discovering.next_event().await,
             OnConnect(on_connect) => on_connect.next_event().await,

--- a/comms/dht/src/network_discovery/state_machine.rs
+++ b/comms/dht/src/network_discovery/state_machine.rs
@@ -196,7 +196,12 @@ impl DhtNetworkDiscovery {
     async fn get_next_event(&mut self, state: &mut State) -> StateEvent {
         use State::{Discovering, Initializing, OnConnect, Ready, Waiting};
         match state {
-            Initializing => self::Initializing::new(&mut self.context).next_event().await,
+            Initializing => {
+                let initial_peer_sync_delay = self.config().network_discovery.initial_peer_sync_delay;
+                self::Initializing::new(&mut self.context, initial_peer_sync_delay)
+                    .next_event()
+                    .await
+            },
             Ready(ready) => ready.next_event().await,
             Discovering(discovering) => discovering.next_event().await,
             OnConnect(on_connect) => on_connect.next_event().await,

--- a/comms/dht/src/network_discovery/test.rs
+++ b/comms/dht/src/network_discovery/test.rs
@@ -107,6 +107,7 @@ mod state_machine {
             num_neighbouring_nodes: 4,
             network_discovery: NetworkDiscoveryConfig {
                 min_desired_peers: NUM_PEERS,
+                initial_peer_sync_delay: None,
                 ..Default::default()
             },
             ..DhtConfig::default_local_test()
@@ -230,6 +231,7 @@ mod discovery_ready {
         let config = NetworkDiscoveryConfig {
             min_desired_peers: 0,
             idle_after_num_rounds: 0,
+            initial_peer_sync_delay: None,
             ..Default::default()
         };
         let (_, _, _, mut ready, context) = setup(config);
@@ -250,6 +252,7 @@ mod discovery_ready {
         let config = NetworkDiscoveryConfig {
             min_desired_peers: 0,
             idle_after_num_rounds: 0,
+            initial_peer_sync_delay: None,
             ..Default::default()
         };
         let (_, _, _, mut ready, context) = setup(config);

--- a/comms/dht/src/peer_validator.rs
+++ b/comms/dht/src/peer_validator.rs
@@ -27,10 +27,11 @@ use tari_comms::{
     peer_validator,
     peer_validator::{find_most_recent_claim, PeerValidatorError},
 };
+use tari_utilities::hex::Hex;
 
 use crate::{rpc::UnvalidatedPeerInfo, DhtConfig};
 
-const _LOG_TARGET: &str = "dht::network_discovery::peer_validator";
+const LOG_TARGET: &str = "dht::network_discovery::peer_validator";
 
 /// Validation errors for peers shared on the network
 #[derive(Debug, thiserror::Error)]
@@ -39,6 +40,8 @@ pub enum DhtPeerValidatorError {
     ValidatorError(#[from] PeerValidatorError),
     #[error("Peer provided too many claims: expected max {max} but got {length}")]
     IdentityTooManyClaims { length: usize, max: usize },
+    #[error("Optional existing peer does not match new peer: existing '{existing}', new '{new}'")]
+    NewAndExistingMismatch { existing: String, new: String },
 }
 
 /// Validator for Peers
@@ -73,9 +76,23 @@ impl<'a> PeerValidator<'a> {
             });
         }
 
+        if let Some(existing) = &existing_peer {
+            if existing.public_key != new_peer.public_key {
+                return Err(DhtPeerValidatorError::NewAndExistingMismatch {
+                    existing: format!("'{}' / '{}'", existing.node_id.to_hex(), existing.public_key.to_hex()),
+                    new: format!(
+                        "'{}' / '{}'",
+                        NodeId::from_public_key(&new_peer.public_key),
+                        new_peer.public_key.to_hex()
+                    ),
+                });
+            }
+        }
+
         let most_recent_claim = find_most_recent_claim(&new_peer.claims).expect("new_peer.claims is not empty");
 
         let node_id = NodeId::from_public_key(&new_peer.public_key);
+        let node_id_hex = node_id.to_hex();
 
         let mut peer = existing_peer.unwrap_or_else(|| {
             Peer::new(
@@ -98,7 +115,13 @@ impl<'a> PeerValidator<'a> {
             peer.update_addresses(&claim.addresses, &PeerAddressSource::FromDiscovery {
                 peer_identity_claim: claim.clone(),
             });
-            peer.addresses.mark_all_addresses_as_last_seen_now(&claim.addresses);
+            trace!(
+                target: LOG_TARGET,
+                "Peer '{}' / '{}' added with address(es) from claim: {:?}",
+                node_id_hex,
+                new_peer.public_key.to_hex(),
+                claim.addresses
+            );
         }
 
         Ok(peer)

--- a/comms/dht/src/peer_validator.rs
+++ b/comms/dht/src/peer_validator.rs
@@ -79,11 +79,11 @@ impl<'a> PeerValidator<'a> {
         if let Some(existing) = &existing_peer {
             if existing.public_key != new_peer.public_key {
                 return Err(DhtPeerValidatorError::NewAndExistingMismatch {
-                    existing: format!("'{}' / '{}'", existing.node_id.to_hex(), existing.public_key.to_hex()),
+                    existing: format!("BUG: '{}' / '{}'", existing.node_id, existing.public_key),
                     new: format!(
-                        "'{}' / '{}'",
+                        "BUG: '{}' / '{}'",
                         NodeId::from_public_key(&new_peer.public_key),
-                        new_peer.public_key.to_hex()
+                        new_peer.public_key
                     ),
                 });
             }
@@ -92,12 +92,11 @@ impl<'a> PeerValidator<'a> {
         let most_recent_claim = find_most_recent_claim(&new_peer.claims).expect("new_peer.claims is not empty");
 
         let node_id = NodeId::from_public_key(&new_peer.public_key);
-        let node_id_hex = node_id.to_hex();
 
         let mut peer = existing_peer.unwrap_or_else(|| {
             Peer::new(
                 new_peer.public_key.clone(),
-                node_id,
+                node_id.clone(),
                 MultiaddressesWithStats::default(),
                 PeerFlags::default(),
                 most_recent_claim.features,
@@ -118,7 +117,7 @@ impl<'a> PeerValidator<'a> {
             trace!(
                 target: LOG_TARGET,
                 "Peer '{}' / '{}' added with address(es) from claim: {:?}",
-                node_id_hex,
+                node_id,
                 new_peer.public_key.to_hex(),
                 claim.addresses
             );

--- a/comms/dht/src/rpc/service.rs
+++ b/comms/dht/src/rpc/service.rs
@@ -29,7 +29,7 @@ use tari_comms::{
     utils,
     PeerManager,
 };
-use tari_utilities::{hex::Hex, ByteArray};
+use tari_utilities::ByteArray;
 use tokio::{sync::mpsc, task};
 
 use crate::{
@@ -68,26 +68,8 @@ impl DhtRpcServiceImpl {
             let iter = peers
                 .into_iter()
                 .filter_map(|peer| {
-                    let mut peer_info =
+                    let peer_info =
                         UnvalidatedPeerInfo::from_peer_limited_claims(peer, max_claims, max_addresses_per_claim);
-
-                    // Filter out all identity claims with invalid signatures
-                    let count = peer_info.claims.len();
-                    let peer_public_key = peer_info.public_key.clone();
-                    peer_info.claims.retain(|claim| {
-                        claim
-                            .signature
-                            .is_valid(&peer_public_key, claim.features, claim.addresses.as_slice())
-                    });
-                    if count != peer_info.claims.len() {
-                        warn!(
-                            target: LOG_TARGET,
-                            "Peer `{}` provided {} claims but only {} were valid",
-                            peer_info.public_key.to_hex(),
-                            count,
-                            peer_info.claims.len()
-                        );
-                    }
 
                     if peer_info.claims.is_empty() {
                         None

--- a/comms/dht/src/rpc/service.rs
+++ b/comms/dht/src/rpc/service.rs
@@ -29,7 +29,7 @@ use tari_comms::{
     utils,
     PeerManager,
 };
-use tari_utilities::ByteArray;
+use tari_utilities::{hex::Hex, ByteArray};
 use tokio::{sync::mpsc, task};
 
 use crate::{
@@ -68,8 +68,26 @@ impl DhtRpcServiceImpl {
             let iter = peers
                 .into_iter()
                 .filter_map(|peer| {
-                    let peer_info =
+                    let mut peer_info =
                         UnvalidatedPeerInfo::from_peer_limited_claims(peer, max_claims, max_addresses_per_claim);
+
+                    // Filter out all identity claims with invalid signatures
+                    let count = peer_info.claims.len();
+                    let peer_public_key = peer_info.public_key.clone();
+                    peer_info.claims.retain(|claim| {
+                        claim
+                            .signature
+                            .is_valid(&peer_public_key, claim.features, claim.addresses.as_slice())
+                    });
+                    if count != peer_info.claims.len() {
+                        warn!(
+                            target: LOG_TARGET,
+                            "Peer `{}` provided {} claims but only {} were valid",
+                            peer_info.public_key.to_hex(),
+                            count,
+                            peer_info.claims.len()
+                        );
+                    }
 
                     if peer_info.claims.is_empty() {
                         None


### PR DESCRIPTION
Description
---
- Improved peer db stats to only update if the specific public address was successfully connected to. This alleviates issues where the node tries to connect to a peer's public address with a quality score > 0 where it should be 0.
- Update stats with ping-pong.
- Added a peer sync delay config option to let a preferred connection get a head start in trying to connect.
- Discarded all peer identity claims without valid signatures immediately when they are received.
- Reduced the minimum number of sync peers a wallet wants to connect to from 50 to 8.

Motivation and Context
---
Peer db connection stats were not reflected correctly.
Wallet connection/re-connection times were slow.

How Has This Been Tested?
---
System-level testing

**Wallet re-connection times** with many pre-connected peers.

![image](https://github.com/tari-project/tari/assets/39146854/50effe9b-f554-4e48-8b84-72ea4152dd3b)


What process can a PR reviewer use to test or verify this change?
---
Code walk-through

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
