### PR TITLE
fix: improve wallet connection response time

### DIFF
--- a/base_layer/wallet/src/connectivity_service/service.rs
+++ b/base_layer/wallet/src/connectivity_service/service.rs
@@ -43,6 +43,7 @@ use crate::{
 };
 
 const LOG_TARGET: &str = "wallet::connectivity";
+const CONNECTIVITY_WAIT: u64 = 5;
 
 /// Connection status of the Base Node
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -270,7 +271,7 @@ impl WalletConnectivityService {
                         self.config.base_node_monitor_max_refresh_interval.as_secs()
                     );
                     self.set_online_status(OnlineStatus::Offline);
-                    time::sleep(self.config.base_node_monitor_max_refresh_interval).await;
+                    time::sleep(Duration::from_secs(CONNECTIVITY_WAIT)).await;
                     continue;
                 },
                 Err(e) => {
@@ -278,7 +279,7 @@ impl WalletConnectivityService {
                     if self.current_base_node().as_ref() == Some(&node_id) {
                         self.disconnect_base_node(node_id).await;
                         self.set_online_status(OnlineStatus::Offline);
-                        time::sleep(self.config.base_node_monitor_max_refresh_interval).await;
+                        time::sleep(Duration::from_secs(CONNECTIVITY_WAIT)).await;
                     }
                     continue;
                 },


### PR DESCRIPTION
Description
---
Improve the time a wallet will detect that the base node its connecting to is up and running

Motivation and Context
---
The time between tries here was 3 secs previously, but an unrelated change to the reuse of time variables bumped this up to 90 secs. This means that even thou the wallet is technically connected to the base node, the wallet service will wait for up to 90 secs before confirm this is the case. This bumps it down to 5 secs. 

How Has This Been Tested?
---
Manual
