### PR TITLE
feat: updates the emoji ID API to be more idiomatic

### DIFF
--- a/applications/minotari_app_utilities/src/utilities.rs
+++ b/applications/minotari_app_utilities/src/utilities.rs
@@ -47,8 +47,8 @@ pub fn setup_runtime() -> Result<Runtime, ExitError> {
 
 /// Returns a CommsPublicKey from either a emoji id or a public key
 pub fn parse_emoji_id_or_public_key(key: &str) -> Option<CommsPublicKey> {
-    EmojiId::from_emoji_string(&key.trim().replace('|', ""))
-        .map(|emoji_id| emoji_id.to_public_key())
+    EmojiId::try_from(key.trim().replace('|', "").as_str())
+        .map(|emoji_id| PublicKey::from(&emoji_id))
         .or_else(|_| CommsPublicKey::from_hex(key))
         .ok()
 }
@@ -79,8 +79,8 @@ impl FromStr for UniPublicKey {
     type Err = UniIdError;
 
     fn from_str(key: &str) -> Result<Self, Self::Err> {
-        if let Ok(emoji_id) = EmojiId::from_emoji_string(&key.trim().replace('|', "")) {
-            Ok(Self(emoji_id.to_public_key()))
+        if let Ok(emoji_id) = EmojiId::try_from(key.trim().replace('|', "").as_str()) {
+            Ok(Self(PublicKey::from(&emoji_id)))
         } else if let Ok(public_key) = PublicKey::from_hex(key) {
             Ok(Self(public_key))
         } else if let Ok(tari_address) = TariAddress::from_hex(key) {
@@ -116,8 +116,8 @@ impl FromStr for UniNodeId {
     type Err = UniIdError;
 
     fn from_str(key: &str) -> Result<Self, Self::Err> {
-        if let Ok(emoji_id) = EmojiId::from_emoji_string(&key.trim().replace('|', "")) {
-            Ok(Self::PublicKey(emoji_id.to_public_key()))
+        if let Ok(emoji_id) = EmojiId::try_from(key.trim().replace('|', "").as_str()) {
+            Ok(Self::PublicKey(PublicKey::from(&emoji_id)))
         } else if let Ok(public_key) = PublicKey::from_hex(key) {
             Ok(Self::PublicKey(public_key))
         } else if let Ok(node_id) = NodeId::from_hex(key) {

--- a/applications/minotari_app_utilities/src/utilities.rs
+++ b/applications/minotari_app_utilities/src/utilities.rs
@@ -47,7 +47,7 @@ pub fn setup_runtime() -> Result<Runtime, ExitError> {
 
 /// Returns a CommsPublicKey from either a emoji id or a public key
 pub fn parse_emoji_id_or_public_key(key: &str) -> Option<CommsPublicKey> {
-    EmojiId::try_from(key.trim().replace('|', "").as_str())
+    EmojiId::from_str(&key.trim().replace('|', ""))
         .map(|emoji_id| PublicKey::from(&emoji_id))
         .or_else(|_| CommsPublicKey::from_hex(key))
         .ok()
@@ -79,7 +79,7 @@ impl FromStr for UniPublicKey {
     type Err = UniIdError;
 
     fn from_str(key: &str) -> Result<Self, Self::Err> {
-        if let Ok(emoji_id) = EmojiId::try_from(key.trim().replace('|', "").as_str()) {
+        if let Ok(emoji_id) = EmojiId::from_str(&key.trim().replace('|', "")) {
             Ok(Self(PublicKey::from(&emoji_id)))
         } else if let Ok(public_key) = PublicKey::from_hex(key) {
             Ok(Self(public_key))
@@ -116,7 +116,7 @@ impl FromStr for UniNodeId {
     type Err = UniIdError;
 
     fn from_str(key: &str) -> Result<Self, Self::Err> {
-        if let Ok(emoji_id) = EmojiId::try_from(key.trim().replace('|', "").as_str()) {
+        if let Ok(emoji_id) = EmojiId::from_str(&key.trim().replace('|', "")) {
             Ok(Self::PublicKey(PublicKey::from(&emoji_id)))
         } else if let Ok(public_key) = PublicKey::from_hex(key) {
             Ok(Self::PublicKey(public_key))

--- a/applications/minotari_console_wallet/src/automation/commands.rs
+++ b/applications/minotari_console_wallet/src/automation/commands.rs
@@ -796,7 +796,7 @@ pub async fn command_runner(
             },
             Whois(args) => {
                 let public_key = args.public_key.into();
-                let emoji_id = EmojiId::from_public_key(&public_key).to_emoji_string();
+                let emoji_id = EmojiId::from(&public_key).to_string();
 
                 println!("Public Key: {}", public_key.to_hex());
                 println!("Emoji ID  : {}", emoji_id);

--- a/applications/minotari_node/src/commands/command/get_peer.rs
+++ b/applications/minotari_node/src/commands/command/get_peer.rs
@@ -81,7 +81,7 @@ impl CommandContext {
         };
 
         for peer in peers {
-            let eid = EmojiId::from_public_key(&peer.public_key).to_emoji_string();
+            let eid = EmojiId::from(&peer.public_key).to_string();
             println!("Emoji ID: {}", eid);
             println!("Public Key: {}", peer.public_key);
             println!("NodeId: {}", peer.node_id);

--- a/base_layer/common_types/src/dammsum.rs
+++ b/base_layer/common_types/src/dammsum.rs
@@ -46,7 +46,7 @@ pub enum ChecksumError {
 const COEFFICIENTS: [u8; 3] = [4, 3, 1];
 
 /// Compute the DammSum checksum for an array, each of whose elements are in the range `[0, 2^8)`
-pub fn compute_checksum(data: &Vec<u8>) -> u8 {
+pub fn compute_checksum(data: &[u8]) -> u8 {
     let mut mask = 1u8;
 
     // Compute the bitmask (if possible)
@@ -71,7 +71,7 @@ pub fn compute_checksum(data: &Vec<u8>) -> u8 {
 }
 
 /// Determine whether the array ends with a valid checksum
-pub fn validate_checksum(data: &Vec<u8>) -> Result<(), ChecksumError> {
+pub fn validate_checksum(data: &[u8]) -> Result<(), ChecksumError> {
     // Empty data is not allowed, nor data only consisting of a checksum
     if data.len() < 2 {
         return Err(ChecksumError::InputDataTooShort);

--- a/base_layer/common_types/src/emoji.rs
+++ b/base_layer/common_types/src/emoji.rs
@@ -199,7 +199,10 @@ impl Display for EmojiId {
 mod test {
     use std::{iter, str::FromStr};
 
-    use tari_crypto::keys::{PublicKey as PublicKeyTrait, SecretKey};
+    use tari_crypto::{
+        keys::{PublicKey as PublicKeyTrait, SecretKey},
+        tari_utilities::ByteArray,
+    };
 
     use crate::{
         dammsum::compute_checksum,
@@ -260,6 +263,7 @@ mod test {
         // This byte representation does not represent a valid public key
         let mut bytes = vec![0u8; INTERNAL_SIZE];
         bytes[0] = 1;
+        assert!(PublicKey::from_canonical_bytes(&bytes).is_err());
 
         // Convert to an emoji string and manually add a valid checksum
         let emoji_set = emoji_set();

--- a/base_layer/common_types/src/tari_address.rs
+++ b/base_layer/common_types/src/tari_address.rs
@@ -148,7 +148,7 @@ impl TariAddress {
         if bytes.len() != INTERNAL_SIZE {
             return Err(TariAddressError::InvalidSize);
         }
-        let checksum = compute_checksum(&bytes[0..32].to_vec());
+        let checksum = compute_checksum(&bytes[0..32]);
         // if the network is a valid network number, we can assume that the checksum as valid
         let network =
             Network::try_from(checksum ^ bytes[32]).map_err(|_| TariAddressError::InvalidNetworkOrChecksum)?;
@@ -164,7 +164,7 @@ impl TariAddress {
     pub fn to_bytes(&self) -> [u8; INTERNAL_SIZE] {
         let mut buf = [0u8; INTERNAL_SIZE];
         buf[0..32].copy_from_slice(self.public_key.as_bytes());
-        let checksum = compute_checksum(&buf[0..32].to_vec());
+        let checksum = compute_checksum(&buf[0..32]);
         buf[32] = self.network.as_byte() ^ checksum;
         buf
     }
@@ -330,7 +330,7 @@ mod test {
     fn invalid_public_key() {
         let mut bytes = [0; 33].to_vec();
         bytes[0] = 1;
-        let checksum = compute_checksum(&bytes[0..32].to_vec());
+        let checksum = compute_checksum(&bytes[0..32]);
         bytes[32] = Network::Esmeralda.as_byte() ^ checksum;
         let emoji_string = bytes.iter().map(|b| EMOJI[*b as usize]).collect::<String>();
 


### PR DESCRIPTION
Description
---
Updates the emoji ID public API to be more idiomatic.

Motivation and Context
---
The emoji ID public API includes functionality to convert to and from types like `String` and `PublicKey`, but not idiomatically. This PR updates the API to use `From` and `FromStr` trait implementations where possible. It also makes some minor changes to checksum function signatures to avoid unnecessary vector cloning, and improves a test.

How Has This Been Tested?
---
Existing tests pass.

What process can a PR reviewer use to test or verify this change?
---
Check that the new API is, in fact, more idiomatic :)

While this doesn't affect consensus or existing databases, this public API change is technically breaking. For example, existing [documentation](https://www.tari.com/lessons/05_emoji_id) needs to be updated.