### PR TITLE
fix: wallet ffi type incorrect

### DIFF
--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -294,7 +294,7 @@ pub struct TariUtxo {
     pub mined_timestamp: u64,
     pub lock_height: u64,
     pub status: u8,
-    pub coinbase_extra: Vec<u8>,
+    pub coinbase_extra: *const c_char,
 }
 
 impl From<DbWalletOutput> for TariUtxo {
@@ -323,7 +323,9 @@ impl From<DbWalletOutput> for TariUtxo {
                 OutputStatus::SpentMinedUnconfirmed => 9,
                 OutputStatus::NotStored => 10,
             },
-            coinbase_extra: x.wallet_output.features.coinbase_extra,
+            coinbase_extra: CString::new(x.wallet_output.features.coinbase_extra.to_hex())
+                .expect("failed to obtain hex from a commitment")
+                .into_raw(),
         }
     }
 }
@@ -10193,7 +10195,10 @@ mod test {
                     .unwrap();
                 assert_eq!(output.value.as_u64(), utxo.value);
                 assert_eq!(output.features.maturity, utxo.lock_height);
-                assert_eq!(output.features.coinbase_extra, utxo.coinbase_extra);
+                assert_eq!(
+                    output.features.coinbase_extra.to_hex(),
+                    CStr::from_ptr(utxo.coinbase_extra).to_str().unwrap()
+                );
             }
             println!();
             destroy_tari_vector(outputs);

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -196,8 +196,6 @@ struct TransportConfig;
  */
 struct UnblindedOutput;
 
-struct Vec_u8;
-
 /**
  * -------------------------------- Vector ------------------------------------------------ ///
  */
@@ -349,7 +347,7 @@ struct TariUtxo {
   uint64_t mined_timestamp;
   uint64_t lock_height;
   uint8_t status;
-  struct Vec_u8 coinbase_extra;
+  const char *coinbase_extra;
 };
 
 #ifdef __cplusplus


### PR DESCRIPTION
Description
---
Fixes FFI type to hex, and away from vec<u8>

Motivation and Context
---
c does not support vec<u8>