### PR TITLE
fix: hot for removing breaking change in wallet, new release for nexnet v1.0.0-rc.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3206,7 +3206,7 @@ dependencies = [
 
 [[package]]
 name = "minotari_app_grpc"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 dependencies = [
  "argon2",
  "base64 0.13.1",
@@ -3234,7 +3234,7 @@ dependencies = [
 
 [[package]]
 name = "minotari_app_utilities"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 dependencies = [
  "clap 3.2.25",
  "dialoguer",
@@ -3256,7 +3256,7 @@ dependencies = [
 
 [[package]]
 name = "minotari_chat_ffi"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 dependencies = [
  "cbindgen",
  "chrono",
@@ -3281,7 +3281,7 @@ dependencies = [
 
 [[package]]
 name = "minotari_console_wallet"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 dependencies = [
  "blake2",
  "chrono",
@@ -3336,7 +3336,7 @@ dependencies = [
 
 [[package]]
 name = "minotari_merge_mining_proxy"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3377,7 +3377,7 @@ dependencies = [
 
 [[package]]
 name = "minotari_miner"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 dependencies = [
  "base64 0.13.1",
  "borsh",
@@ -3413,7 +3413,7 @@ dependencies = [
 
 [[package]]
 name = "minotari_mining_helper_ffi"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 dependencies = [
  "borsh",
  "cbindgen",
@@ -3433,7 +3433,7 @@ dependencies = [
 
 [[package]]
 name = "minotari_node"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3489,7 +3489,7 @@ dependencies = [
 
 [[package]]
 name = "minotari_wallet"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 dependencies = [
  "argon2",
  "async-trait",
@@ -3539,7 +3539,7 @@ dependencies = [
 
 [[package]]
 name = "minotari_wallet_ffi"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 dependencies = [
  "borsh",
  "cbindgen",
@@ -5935,7 +5935,7 @@ dependencies = [
 
 [[package]]
 name = "tari_chat_client"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5961,7 +5961,7 @@ dependencies = [
 
 [[package]]
 name = "tari_common"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 dependencies = [
  "anyhow",
  "blake2",
@@ -5988,7 +5988,7 @@ dependencies = [
 
 [[package]]
 name = "tari_common_sqlite"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -6002,7 +6002,7 @@ dependencies = [
 
 [[package]]
 name = "tari_common_types"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 dependencies = [
  "base64 0.21.5",
  "blake2",
@@ -6024,7 +6024,7 @@ dependencies = [
 
 [[package]]
 name = "tari_comms"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6073,7 +6073,7 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_dht"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 dependencies = [
  "anyhow",
  "bitflags 2.4.1",
@@ -6117,7 +6117,7 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_rpc_macros"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 dependencies = [
  "futures 0.3.29",
  "proc-macro2",
@@ -6132,7 +6132,7 @@ dependencies = [
 
 [[package]]
 name = "tari_contacts"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 dependencies = [
  "chrono",
  "diesel",
@@ -6165,7 +6165,7 @@ dependencies = [
 
 [[package]]
 name = "tari_core"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 dependencies = [
  "async-trait",
  "bincode",
@@ -6262,11 +6262,11 @@ dependencies = [
 
 [[package]]
 name = "tari_features"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 
 [[package]]
 name = "tari_hashing"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 dependencies = [
  "blake2",
  "borsh",
@@ -6324,7 +6324,7 @@ dependencies = [
 
 [[package]]
 name = "tari_key_manager"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 dependencies = [
  "argon2",
  "async-trait",
@@ -6359,7 +6359,7 @@ dependencies = [
 
 [[package]]
 name = "tari_libtor"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 dependencies = [
  "derivative",
  "libtor",
@@ -6374,7 +6374,7 @@ dependencies = [
 
 [[package]]
 name = "tari_metrics"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 dependencies = [
  "anyhow",
  "futures 0.3.29",
@@ -6389,7 +6389,7 @@ dependencies = [
 
 [[package]]
 name = "tari_mmr"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 dependencies = [
  "bincode",
  "blake2",
@@ -6408,7 +6408,7 @@ dependencies = [
 
 [[package]]
 name = "tari_p2p"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 dependencies = [
  "anyhow",
  "clap 3.2.25",
@@ -6444,7 +6444,7 @@ dependencies = [
 
 [[package]]
 name = "tari_script"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 dependencies = [
  "blake2",
  "borsh",
@@ -6461,7 +6461,7 @@ dependencies = [
 
 [[package]]
 name = "tari_service_framework"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6478,7 +6478,7 @@ dependencies = [
 
 [[package]]
 name = "tari_shutdown"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 dependencies = [
  "futures 0.3.29",
  "tokio",
@@ -6486,7 +6486,7 @@ dependencies = [
 
 [[package]]
 name = "tari_storage"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 dependencies = [
  "bincode",
  "lmdb-zero",
@@ -6499,7 +6499,7 @@ dependencies = [
 
 [[package]]
 name = "tari_test_utils"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 dependencies = [
  "futures 0.3.29",
  "futures-test",

--- a/applications/minotari_app_grpc/Cargo.toml
+++ b/applications/minotari_app_grpc/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "This crate is to provide a single source for all cross application grpc files and conversions to and from tari::core"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 edition = "2018"
 
 [dependencies]
@@ -31,7 +31,7 @@ tonic = { version = "0.8.3", features = ["tls"]}
 zeroize = "1"
 
 [build-dependencies]
-tari_features = { path = "../../common/tari_features", version = "1.0.0-rc.7" }
+tari_features = { path = "../../common/tari_features", version = "1.0.0-rc.8" }
 tonic-build = "0.8.4"
 
 [package.metadata.cargo-machete]

--- a/applications/minotari_app_utilities/Cargo.toml
+++ b/applications/minotari_app_utilities/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "minotari_app_utilities"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 authors = ["The Tari Development Community"]
 edition = "2018"
 license = "BSD-3-Clause"
@@ -26,7 +26,7 @@ tonic = "0.8.3"
 
 [build-dependencies]
 tari_common = { path = "../../common", features = ["build", "static-application-info"] }
-tari_features = { path = "../../common/tari_features", version = "1.0.0-rc.7" }
+tari_features = { path = "../../common/tari_features", version = "1.0.0-rc.8" }
 
 [features]
 miner_input = ["minotari_app_grpc"]

--- a/applications/minotari_console_wallet/Cargo.toml
+++ b/applications/minotari_console_wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "minotari_console_wallet"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 authors = ["The Tari Development Community"]
 edition = "2018"
 license = "BSD-3-Clause"
@@ -83,7 +83,7 @@ default-features = false
 features = ["crossterm"]
 
 [build-dependencies]
-tari_features = { path = "../../common/tari_features", version = "1.0.0-rc.7" }
+tari_features = { path = "../../common/tari_features", version = "1.0.0-rc.8" }
 
 [features]
 default = ["libtor"]

--- a/applications/minotari_console_wallet/src/init/mod.rs
+++ b/applications/minotari_console_wallet/src/init/mod.rs
@@ -419,7 +419,7 @@ pub async fn init_wallet(
     };
 
     let master_seed = read_or_create_master_seed(recovery_seed.clone(), &wallet_db)?;
-    let wallet_type = read_or_create_wallet_type(wallet_type, &wallet_db);
+    let wallet_type = WalletType::Software;
 
     let node_identity = match config.wallet.identity_file.as_ref() {
         Some(identity_file) => {
@@ -465,7 +465,7 @@ pub async fn init_wallet(
         key_manager_backend,
         shutdown_signal,
         master_seed,
-        wallet_type.unwrap(),
+        wallet_type,
     )
     .await
     .map_err(|e| match e {

--- a/applications/minotari_merge_mining_proxy/Cargo.toml
+++ b/applications/minotari_merge_mining_proxy/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "The Tari merge mining proxy for xmrig"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 edition = "2018"
 
 [features]
@@ -47,7 +47,7 @@ url = "2.1.1"
 scraper = "0.19.0"
 
 [build-dependencies]
-tari_features = { path = "../../common/tari_features", version = "1.0.0-rc.7"}
+tari_features = { path = "../../common/tari_features", version = "1.0.0-rc.8"}
 
 [dev-dependencies]
 markup5ever = "0.11.0"

--- a/applications/minotari_miner/Cargo.toml
+++ b/applications/minotari_miner/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "The tari miner implementation"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 edition = "2018"
 
 [dependencies]

--- a/applications/minotari_node/Cargo.toml
+++ b/applications/minotari_node/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "The tari full base node implementation"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 edition = "2018"
 
 [dependencies]
@@ -24,7 +24,7 @@ tari_shutdown = { path = "../../infrastructure/shutdown" }
 tari_utilities = { version = "0.7" }
 tari_key_manager = { path = "../../base_layer/key_manager", features = [
     "key_manager_service",
-], version = "1.0.0-rc.7" }
+], version = "1.0.0-rc.8" }
 
 anyhow = "1.0.53"
 async-trait = "0.1.52"
@@ -61,7 +61,7 @@ safe = []
 libtor = ["tari_libtor"]
 
 [build-dependencies]
-tari_features = { path = "../../common/tari_features", version = "1.0.0-rc.7"}
+tari_features = { path = "../../common/tari_features", version = "1.0.0-rc.8"}
 
 [package.metadata.cargo-machete]
 ignored = [

--- a/base_layer/chat_ffi/Cargo.toml
+++ b/base_layer/chat_ffi/Cargo.toml
@@ -3,7 +3,7 @@ name = "minotari_chat_ffi"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency chat C FFI bindings"
 license = "BSD-3-Clause"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 edition = "2018"
 
 [dependencies]

--- a/base_layer/common_types/Cargo.toml
+++ b/base_layer/common_types/Cargo.toml
@@ -3,13 +3,13 @@ name = "tari_common_types"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency common types"
 license = "BSD-3-Clause"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 edition = "2018"
 
 [dependencies]
 tari_crypto = { version = "0.20" }
 tari_utilities = { version = "0.7" }
-tari_common = {  path = "../../common", version = "1.0.0-rc.7" }
+tari_common = {  path = "../../common", version = "1.0.0-rc.8" }
 
 
 chacha20poly1305 = "0.10.1"

--- a/base_layer/contacts/Cargo.toml
+++ b/base_layer/contacts/Cargo.toml
@@ -3,19 +3,19 @@ name = "tari_contacts"
 authors = ["The Tari Development Community"]
 description = "Tari contacts library"
 license = "BSD-3-Clause"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 edition = "2018"
 
 [dependencies]
-tari_common = { path = "../../common", version = "1.0.0-rc.7" }
-tari_common_sqlite = { path = "../../common_sqlite", version = "1.0.0-rc.7" }
-tari_common_types = {  path = "../../base_layer/common_types", version = "1.0.0-rc.7" }
-tari_comms = {  path = "../../comms/core", version = "1.0.0-rc.7" }
-tari_comms_dht = { path = "../../comms/dht", version = "1.0.0-rc.7" }
+tari_common = { path = "../../common", version = "1.0.0-rc.8" }
+tari_common_sqlite = { path = "../../common_sqlite", version = "1.0.0-rc.8" }
+tari_common_types = {  path = "../../base_layer/common_types", version = "1.0.0-rc.8" }
+tari_comms = {  path = "../../comms/core", version = "1.0.0-rc.8" }
+tari_comms_dht = { path = "../../comms/dht", version = "1.0.0-rc.8" }
 tari_crypto = { version = "0.20" }
-tari_p2p = {  path = "../p2p", features = ["auto-update"], version = "1.0.0-rc.7" }
-tari_service_framework = {  path = "../service_framework", version = "1.0.0-rc.7" }
-tari_shutdown = {  path = "../../infrastructure/shutdown", version = "1.0.0-rc.7" }
+tari_p2p = {  path = "../p2p", features = ["auto-update"], version = "1.0.0-rc.8" }
+tari_service_framework = {  path = "../service_framework", version = "1.0.0-rc.8" }
+tari_shutdown = {  path = "../../infrastructure/shutdown", version = "1.0.0-rc.8" }
 tari_utilities = { version = "0.7" }
 
 chrono = { version = "0.4.19", default-features = false, features = ["serde"] }
@@ -40,7 +40,7 @@ tari_test_utils = {  path = "../../infrastructure/test_utils" }
 tempfile = "3.1.0"
 
 [build-dependencies]
-tari_common = { path = "../../common", version = "1.0.0-rc.7" }
+tari_common = { path = "../../common", version = "1.0.0-rc.8" }
 
 [package.metadata.cargo-machete]
 ignored = ["prost"] # this is so we can run cargo machete without getting false positive about macro dependancies

--- a/base_layer/contacts/src/chat_client/Cargo.toml
+++ b/base_layer/contacts/src/chat_client/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_chat_client"
 authors = ["The Tari Development Community"]
 description = "Tari cucumber chat client"
 license = "BSD-3-Clause"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 
 edition = "2018"
 

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 edition = "2018"
 
 [features]
@@ -30,24 +30,24 @@ ledger = [
 metrics = ["tari_metrics"]
 
 [dependencies]
-tari_common = { path = "../../common", version = "1.0.0-rc.7" }
-tari_common_types = { path = "../../base_layer/common_types", version = "1.0.0-rc.7" }
-tari_comms = { path = "../../comms/core", version = "1.0.0-rc.7" }
-tari_comms_dht = { path = "../../comms/dht", version = "1.0.0-rc.7" }
-tari_comms_rpc_macros = { path = "../../comms/rpc_macros", version = "1.0.0-rc.7" }
+tari_common = { path = "../../common", version = "1.0.0-rc.8" }
+tari_common_types = { path = "../../base_layer/common_types", version = "1.0.0-rc.8" }
+tari_comms = { path = "../../comms/core", version = "1.0.0-rc.8" }
+tari_comms_dht = { path = "../../comms/dht", version = "1.0.0-rc.8" }
+tari_comms_rpc_macros = { path = "../../comms/rpc_macros", version = "1.0.0-rc.8" }
 tari_crypto = { version = "0.20", features = ["borsh"] }
-tari_metrics = { path = "../../infrastructure/metrics", optional = true, version = "1.0.0-rc.7" }
-tari_mmr = { path = "../../base_layer/mmr", optional = true , version = "1.0.0-rc.7"}
-tari_p2p = { path = "../../base_layer/p2p", version = "1.0.0-rc.7" }
-tari_script = { path = "../../infrastructure/tari_script", version = "1.0.0-rc.7" }
-tari_service_framework = { path = "../service_framework", version = "1.0.0-rc.7" }
-tari_shutdown = { path = "../../infrastructure/shutdown", version = "1.0.0-rc.7" }
-tari_storage = { path = "../../infrastructure/storage", version = "1.0.0-rc.7" }
-tari_test_utils = { path = "../../infrastructure/test_utils", version = "1.0.0-rc.7" }
+tari_metrics = { path = "../../infrastructure/metrics", optional = true, version = "1.0.0-rc.8" }
+tari_mmr = { path = "../../base_layer/mmr", optional = true , version = "1.0.0-rc.8"}
+tari_p2p = { path = "../../base_layer/p2p", version = "1.0.0-rc.8" }
+tari_script = { path = "../../infrastructure/tari_script", version = "1.0.0-rc.8" }
+tari_service_framework = { path = "../service_framework", version = "1.0.0-rc.8" }
+tari_shutdown = { path = "../../infrastructure/shutdown", version = "1.0.0-rc.8" }
+tari_storage = { path = "../../infrastructure/storage", version = "1.0.0-rc.8" }
+tari_test_utils = { path = "../../infrastructure/test_utils", version = "1.0.0-rc.8" }
 tari_utilities = { version = "0.7", features = ["borsh"] }
 tari_key_manager = { path = "../key_manager", features = [
   "key_manager_service",
-], version = "1.0.0-rc.7" }
+], version = "1.0.0-rc.8" }
 tari_common_sqlite = { path = "../../common_sqlite" }
 tari_hashing = { path = "../../hashing" }
 
@@ -110,8 +110,8 @@ toml = { version = "0.5" }
 quickcheck = "1.0"
 
 [build-dependencies]
-tari_common = { path = "../../common", features = ["build"], version = "1.0.0-rc.7" }
-tari_features = { path = "../../common/tari_features", version = "1.0.0-rc.7" }
+tari_common = { path = "../../common", features = ["build"], version = "1.0.0-rc.8" }
+tari_features = { path = "../../common/tari_features", version = "1.0.0-rc.8" }
 
 [[bench]]
 name = "mempool"

--- a/base_layer/key_manager/Cargo.toml
+++ b/base_layer/key_manager/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency wallet key management"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 edition = "2021"
 
 [lib]
@@ -13,9 +13,9 @@ crate-type = ["lib", "cdylib"]
 [dependencies]
 tari_crypto = { version = "0.20" }
 tari_utilities = { version = "0.7" }
-tari_common_sqlite = { path = "../../common_sqlite", version = "1.0.0-rc.7" }
-tari_common_types = {  path = "../../base_layer/common_types", version = "1.0.0-rc.7"}
-tari_service_framework = {  path = "../service_framework", version = "1.0.0-rc.7" }
+tari_common_sqlite = { path = "../../common_sqlite", version = "1.0.0-rc.8" }
+tari_common_types = {  path = "../../base_layer/common_types", version = "1.0.0-rc.8"}
+tari_service_framework = {  path = "../service_framework", version = "1.0.0-rc.8" }
 
 async-trait = {version = "0.1.50"}
 chrono = { version = "0.4.19", default-features = false, features = ["serde"] }

--- a/base_layer/mmr/Cargo.toml
+++ b/base_layer/mmr/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "A Merkle Mountain Range implementation"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 edition = "2018"
 
 [features]
@@ -13,7 +13,7 @@ default = []
 [dependencies]
 tari_utilities = { version = "0.7" }
 tari_crypto = { version = "0.20" }
-tari_common = { path = "../../common", version = "1.0.0-rc.7" }
+tari_common = { path = "../../common", version = "1.0.0-rc.8" }
 thiserror = "1.0"
 borsh = "1.2"
 digest = "0.10"

--- a/base_layer/p2p/Cargo.toml
+++ b/base_layer/p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_p2p"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 authors = ["The Tari Development community"]
 description = "Tari base layer-specific peer-to-peer communication features"
 repository = "https://github.com/tari-project/tari"
@@ -10,13 +10,13 @@ license = "BSD-3-Clause"
 edition = "2018"
 
 [dependencies]
-tari_comms = {  path = "../../comms/core", version = "1.0.0-rc.7" }
-tari_comms_dht = {  path = "../../comms/dht", version = "1.0.0-rc.7" }
-tari_common = {  path = "../../common", version = "1.0.0-rc.7" }
+tari_comms = {  path = "../../comms/core", version = "1.0.0-rc.8" }
+tari_comms_dht = {  path = "../../comms/dht", version = "1.0.0-rc.8" }
+tari_common = {  path = "../../common", version = "1.0.0-rc.8" }
 tari_crypto = { version = "0.20" }
-tari_service_framework = {  path = "../service_framework", version = "1.0.0-rc.7" }
-tari_shutdown = {  path = "../../infrastructure/shutdown", version = "1.0.0-rc.7" }
-tari_storage = {  path = "../../infrastructure/storage", version = "1.0.0-rc.7" }
+tari_service_framework = {  path = "../service_framework", version = "1.0.0-rc.8" }
+tari_shutdown = {  path = "../../infrastructure/shutdown", version = "1.0.0-rc.8" }
+tari_storage = {  path = "../../infrastructure/storage", version = "1.0.0-rc.8" }
 tari_utilities = { version = "0.7" }
 
 anyhow = "1.0.53"
@@ -46,7 +46,7 @@ clap = "3.2"
 tempfile = "3.1.0"
 
 [build-dependencies]
-tari_common = {  path = "../../common", features = ["build"], version = "1.0.0-rc.7" }
+tari_common = {  path = "../../common", features = ["build"], version = "1.0.0-rc.8" }
 
 [features]
 test-mocks = []

--- a/base_layer/service_framework/Cargo.toml
+++ b/base_layer/service_framework/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_service_framework"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 authors = ["The Tari Development Community"]
 description = "The Tari communication stack service framework"
 repository = "https://github.com/tari-project/tari"
@@ -10,7 +10,7 @@ license = "BSD-3-Clause"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tari_shutdown = {  path = "../../infrastructure/shutdown", version = "1.0.0-rc.7" }
+tari_shutdown = {  path = "../../infrastructure/shutdown", version = "1.0.0-rc.8" }
 
 anyhow = "1.0.53"
 async-trait = "0.1.50"

--- a/base_layer/tari_mining_helper_ffi/Cargo.toml
+++ b/base_layer/tari_mining_helper_ffi/Cargo.toml
@@ -3,7 +3,7 @@ name = "minotari_mining_helper_ffi"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency miningcore C FFI bindings"
 license = "BSD-3-Clause"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 edition = "2018"
 
 [dependencies]
@@ -11,7 +11,7 @@ tari_comms = { path = "../../comms/core" }
 tari_crypto = { version = "0.20" }
 tari_common = { path = "../../common" }
 tari_core = { path = "../core", default-features = false, features = ["transactions", "base_node_proto", "base_node"] }
-tari_common_types = {  path = "../../base_layer/common_types", version = "1.0.0-rc.7" }
+tari_common_types = {  path = "../../base_layer/common_types", version = "1.0.0-rc.8" }
 tari_utilities = { version = "0.7" }
 libc = "0.2.65"
 thiserror = "1.0.26"
@@ -24,7 +24,7 @@ tari_core = { path = "../core", features = ["transactions", "base_node"] }
 rand = "0.8"
 
 [build-dependencies]
-tari_features = { path = "../../common/tari_features", version = "1.0.0-rc.7" }
+tari_features = { path = "../../common/tari_features", version = "1.0.0-rc.8" }
 cbindgen = "0.24.3"
 tari_common = { path = "../../common", features = ["build", "static-application-info"] }
 

--- a/base_layer/wallet/Cargo.toml
+++ b/base_layer/wallet/Cargo.toml
@@ -3,24 +3,24 @@ name = "minotari_wallet"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency wallet library"
 license = "BSD-3-Clause"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 edition = "2018"
 
 [dependencies]
-tari_core = { path = "../../base_layer/core",  default-features = false, features = ["transactions", "mempool_proto", "base_node_proto"], version = "1.0.0-rc.7" }
-tari_common = { path = "../../common", version = "1.0.0-rc.7" }
-tari_common_types = {  path = "../../base_layer/common_types", version = "1.0.0-rc.7" }
-tari_comms = {  path = "../../comms/core", version = "1.0.0-rc.7" }
-tari_comms_dht = {  path = "../../comms/dht", version = "1.0.0-rc.7" }
+tari_core = { path = "../../base_layer/core",  default-features = false, features = ["transactions", "mempool_proto", "base_node_proto"], version = "1.0.0-rc.8" }
+tari_common = { path = "../../common", version = "1.0.0-rc.8" }
+tari_common_types = {  path = "../../base_layer/common_types", version = "1.0.0-rc.8" }
+tari_comms = {  path = "../../comms/core", version = "1.0.0-rc.8" }
+tari_comms_dht = {  path = "../../comms/dht", version = "1.0.0-rc.8" }
 tari_crypto = { version = "0.20" }
-tari_key_manager = {  path = "../key_manager", features = ["key_manager_service"], version = "1.0.0-rc.7" }
-tari_p2p = {  path = "../p2p", features = ["auto-update"], version = "1.0.0-rc.7"}
-tari_script = { path = "../../infrastructure/tari_script", version = "1.0.0-rc.7" }
-tari_service_framework = {  path = "../service_framework", version = "1.0.0-rc.7" }
-tari_shutdown = {  path = "../../infrastructure/shutdown", version = "1.0.0-rc.7" }
-tari_common_sqlite = { path = "../../common_sqlite", version = "1.0.0-rc.7" }
+tari_key_manager = {  path = "../key_manager", features = ["key_manager_service"], version = "1.0.0-rc.8" }
+tari_p2p = {  path = "../p2p", features = ["auto-update"], version = "1.0.0-rc.8"}
+tari_script = { path = "../../infrastructure/tari_script", version = "1.0.0-rc.8" }
+tari_service_framework = {  path = "../service_framework", version = "1.0.0-rc.8" }
+tari_shutdown = {  path = "../../infrastructure/shutdown", version = "1.0.0-rc.8" }
+tari_common_sqlite = { path = "../../common_sqlite", version = "1.0.0-rc.8" }
 tari_utilities = { version = "0.7" }
-tari_contacts = { path = "../../base_layer/contacts", version = "1.0.0-rc.7" }
+tari_contacts = { path = "../../base_layer/contacts", version = "1.0.0-rc.8" }
 
 # Uncomment for tokio tracing via tokio-console (needs "tracing" features)
 #console-subscriber = "0.1.3"
@@ -57,7 +57,7 @@ chacha20poly1305 = "0.10.1"
 zeroize = "1"
 
 [build-dependencies]
-tari_common = { path = "../../common", features = ["build", "static-application-info"], version = "1.0.0-rc.7" }
+tari_common = { path = "../../common", features = ["build", "static-application-info"], version = "1.0.0-rc.8" }
 
 [dev-dependencies]
 tari_p2p = {  path = "../p2p", features = ["test-mocks"] }

--- a/base_layer/wallet_ffi/Cargo.toml
+++ b/base_layer/wallet_ffi/Cargo.toml
@@ -3,7 +3,7 @@ name = "minotari_wallet_ffi"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency wallet C FFI bindings"
 license = "BSD-3-Clause"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 edition = "2018"
 
 [dependencies]
@@ -54,4 +54,4 @@ borsh = "1.2"
 [build-dependencies]
 cbindgen = "0.24.3"
 tari_common = { path = "../../common", features = ["build", "static-application-info"] }
-tari_features = { path = "../../common/tari_features", version = "1.0.0-rc.7" }
+tari_features = { path = "../../common/tari_features", version = "1.0.0-rc.8" }

--- a/changelog-nextnet.md
+++ b/changelog-nextnet.md
@@ -2,12 +2,18 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.0.0-rc.8](https://github.com/tari-project/tari/compare/v1.0.0-rc.7...v1.0.0-rc.8) (2024-04-23)
+
+### Bug Fixes
+
+* Hot fix to remove breaking change of wallet type saved in db. 
+
 ## [1.0.0-rc.7](https://github.com/tari-project/tari/compare/v1.0.0-rc.6a...v1.0.0-rc.7) (2024-04-22)
 
 
 ### ⚠ BREAKING CHANGES
 
-* update new block proto to support multiple coinbases (#6266)
+* change grpc deny to allow (#6218)
 
 ### Features
 
@@ -27,7 +33,6 @@ All notable changes to this project will be documented in this file. See [standa
 * prevent mempool panic ([#6239](https://github.com/tari-project/tari/issues/6239)) ([5380e1f](https://github.com/tari-project/tari/commit/5380e1face2799f762145bfa238f1c719d831f2e))
 * remove template blocking call ([#6220](https://github.com/tari-project/tari/issues/6220)) ([01d79e0](https://github.com/tari-project/tari/commit/01d79e09aed7e3cf256b1f8a5caad391736ea78c))
 * show warning when GRPC method is disallowed ([#6246](https://github.com/tari-project/tari/issues/6246)) ([0019c11](https://github.com/tari-project/tari/commit/0019c1128db5dfaea1a63c2807b9c845d5e0ef09))
-* update new block proto to support multiple coinbases ([#6266](https://github.com/tari-project/tari/issues/6266)) ([f58ef12](https://github.com/tari-project/tari/commit/f58ef129177b653bf4b40d675b8977537a720235))
 
 
 ### Bug Fixes
@@ -37,6 +42,7 @@ All notable changes to this project will be documented in this file. See [standa
 * improve wallet connection response time ([#6286](https://github.com/tari-project/tari/issues/6286)) ([8f1eac6](https://github.com/tari-project/tari/commit/8f1eac60598f16a4839f594d50d8fc6fbf25e92d))
 * potential in panic message_vector_get_at ([#6233](https://github.com/tari-project/tari/issues/6233)) ([2867454](https://github.com/tari-project/tari/commit/2867454f7480edd6b23e1430efa9af57d6b43c61))
 * wallet ffi type incorrect ([#6290](https://github.com/tari-project/tari/issues/6290)) ([b5bda7c](https://github.com/tari-project/tari/commit/b5bda7ccffd569f627ed41cb65d060032a58510f))
+* change grpc deny to allow ([#6218](https://github.com/tari-project/tari/issues/6218)) ([7665067](https://github.com/tari-project/tari/commit/7665067ef99893fc0d33996f5acbaa8fa164e844))
 
 ## [1.0.0-rc.6a](https://github.com/tari-project/tari/compare/v1.0.0-rc.6...v1.0.0-rc.6a) (2024-03-12)
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 edition = "2018"
 
 [features]
@@ -15,7 +15,7 @@ static-application-info = ["git2"]
 
 [dependencies]
 tari_crypto = { version = "0.20" }
-tari_features = { path = "./tari_features", version = "1.0.0-rc.7"}
+tari_features = { path = "./tari_features", version = "1.0.0-rc.8"}
 
 anyhow = "1.0.53"
 blake2 = "0.10"
@@ -41,4 +41,4 @@ tari_test_utils = {  path = "../infrastructure/test_utils"}
 toml = "0.5.8"
 
 [build-dependencies]
-tari_features = { path = "./tari_features", version = "1.0.0-rc.7"}
+tari_features = { path = "./tari_features", version = "1.0.0-rc.8"}

--- a/common/tari_features/Cargo.toml
+++ b/common/tari_features/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/common_sqlite/Cargo.toml
+++ b/common_sqlite/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_common_sqlite"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency wallet library"
 license = "BSD-3-Clause"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/comms/core/Cargo.toml
+++ b/comms/core/Cargo.toml
@@ -6,14 +6,14 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 edition = "2018"
 
 [dependencies]
 tari_crypto = { version = "0.20" }
-tari_metrics = { path = "../../infrastructure/metrics", optional = true, version = "1.0.0-rc.7" }
-tari_storage = {  path = "../../infrastructure/storage", version = "1.0.0-rc.7" }
-tari_shutdown = {  path = "../../infrastructure/shutdown" , version = "1.0.0-rc.7"}
+tari_metrics = { path = "../../infrastructure/metrics", optional = true, version = "1.0.0-rc.8" }
+tari_storage = {  path = "../../infrastructure/storage", version = "1.0.0-rc.8" }
+tari_shutdown = {  path = "../../infrastructure/shutdown" , version = "1.0.0-rc.8"}
 tari_utilities = { version = "0.7" }
 
 anyhow = "1.0.53"
@@ -58,7 +58,7 @@ serde_json = "1.0.39"
 tempfile = "3.1.0"
 
 [build-dependencies]
-tari_common = {  path = "../../common", features = ["build"], version = "1.0.0-rc.7" }
+tari_common = {  path = "../../common", features = ["build"], version = "1.0.0-rc.8" }
 
 [features]
 c_integration = []

--- a/comms/dht/Cargo.toml
+++ b/comms/dht/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_comms_dht"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 authors = ["The Tari Development Community"]
 description = "Tari comms DHT module"
 repository = "https://github.com/tari-project/tari"
@@ -10,14 +10,14 @@ license = "BSD-3-Clause"
 edition = "2018"
 
 [dependencies]
-tari_comms = {  path = "../core", features = ["rpc"], version = "1.0.0-rc.7" }
-tari_common = { path = "../../common", version = "1.0.0-rc.7" }
-tari_comms_rpc_macros = {  path = "../rpc_macros" , version = "1.0.0-rc.7"}
+tari_comms = {  path = "../core", features = ["rpc"], version = "1.0.0-rc.8" }
+tari_common = { path = "../../common", version = "1.0.0-rc.8" }
+tari_comms_rpc_macros = {  path = "../rpc_macros" , version = "1.0.0-rc.8"}
 tari_crypto = { version = "0.20" }
 tari_utilities = { version = "0.7" }
-tari_shutdown = {  path = "../../infrastructure/shutdown", version = "1.0.0-rc.7" }
-tari_storage = {  path = "../../infrastructure/storage", version = "1.0.0-rc.7" }
-tari_common_sqlite = { path = "../../common_sqlite", version = "1.0.0-rc.7" }
+tari_shutdown = {  path = "../../infrastructure/shutdown", version = "1.0.0-rc.8" }
+tari_storage = {  path = "../../infrastructure/storage", version = "1.0.0-rc.8" }
+tari_common_sqlite = { path = "../../common_sqlite", version = "1.0.0-rc.8" }
 
 anyhow = "1.0.53"
 bitflags = { version = "2.4", features = ["serde"] }
@@ -62,7 +62,7 @@ clap = "3.2"
 
 
 [build-dependencies]
-tari_common = {  path = "../../common", version = "1.0.0-rc.7" }
+tari_common = {  path = "../../common", version = "1.0.0-rc.8" }
 
 [features]
 test-mocks = []

--- a/comms/rpc_macros/Cargo.toml
+++ b/comms/rpc_macros/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 edition = "2018"
 
 [lib]

--- a/hashing/Cargo.toml
+++ b/hashing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_hashing"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 edition = "2021"
 description = "Tari hash domains"
 authors = ["The Tari Development Community"]

--- a/infrastructure/derive/Cargo.toml
+++ b/infrastructure/derive/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 edition = "2018"
 
 [lib]

--- a/infrastructure/libtor/Cargo.toml
+++ b/infrastructure/libtor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_libtor"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 edition = "2021"
 license = "BSD-3-Clause"
 

--- a/infrastructure/metrics/Cargo.toml
+++ b/infrastructure/metrics/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_metrics"
 description = "Tari metrics"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 edition = "2021"
 authors = ["The Tari Development Community"]
 repository = "https://github.com/tari-project/tari"

--- a/infrastructure/shutdown/Cargo.toml
+++ b/infrastructure/shutdown/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/infrastructure/storage/Cargo.toml
+++ b/infrastructure/storage/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 edition = "2018"
 
 [dependencies]

--- a/infrastructure/tari_script/Cargo.toml
+++ b/infrastructure/tari_script/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_script"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 edition = "2021"
 description = "Tari script library"
 authors = ["The Tari Development Community"]

--- a/infrastructure/test_utils/Cargo.toml
+++ b/infrastructure/test_utils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_test_utils"
 description = "Utility functions used in Tari test functions"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 authors = ["The Tari Development Community"]
 edition = "2018"
 license = "BSD-3-Clause"
@@ -9,8 +9,8 @@ license = "BSD-3-Clause"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tari_shutdown = { path = "../shutdown", version = "1.0.0-rc.7" }
-tari_comms = { path = "../../comms/core", version = "1.0.0-rc.7" }
+tari_shutdown = { path = "../shutdown", version = "1.0.0-rc.8" }
+tari_comms = { path = "../../comms/core", version = "1.0.0-rc.8" }
 
 futures = { version = "^0.3.1" }
 rand = "0.8"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tari",
-  "version": "1.0.0-rc.7",
+  "version": "1.0.0-rc.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {}


### PR DESCRIPTION
Description
---
Removed breaking change of wallet db type
Release new nextnet version

Motivation and Context
--
Release v1.0.0-rc.7 accidentally included an unmarked breaking change. This change is for future ledger support in with saving the wallet type as software or ledger in the wallet db. This is a breaking change. This forces a wallet to be software as ledger is currently in dev and not yet functioning. 

How Has This Been Tested?
---
Manual
