### PR TITLE
feat: limit wallet base node peer outbound connections

### DIFF
--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -160,7 +160,7 @@ impl WalletGrpcServer {
 
     fn get_consensus_constants(&self) -> Result<&ConsensusConstants, WalletStorageError> {
         // If we don't have the chain metadata, we hope that VNReg consensus constants did not change - worst case, we
-        // spend more than we need to or the the transaction is rejected.
+        // spend more than we need to or the transaction is rejected.
         let height = self
             .wallet
             .db

--- a/applications/minotari_console_wallet/src/ui/state/wallet_event_monitor.rs
+++ b/applications/minotari_console_wallet/src/ui/state/wallet_event_monitor.rs
@@ -200,7 +200,7 @@ impl WalletEventMonitor {
                             );
                             match msg {
                                 ConnectivityEvent::PeerConnected(_) |
-                                ConnectivityEvent::PeerDisconnected(_) => {
+                                ConnectivityEvent::PeerDisconnected(..) => {
                                     self.trigger_peer_state_refresh().await;
                                 },
                                 // Only the above variants trigger state refresh

--- a/base_layer/chat_ffi/src/byte_vector.rs
+++ b/base_layer/chat_ffi/src/byte_vector.rs
@@ -100,7 +100,7 @@ pub unsafe extern "C" fn chat_byte_vector_destroy(bytes: *mut ChatByteVector) {
 ///
 /// # Safety
 /// None
-// converting between here is fine as its used to clamp the the array to length
+// converting between here is fine as its used to clamp the array to length
 #[allow(clippy::cast_possible_wrap)]
 #[no_mangle]
 pub unsafe extern "C" fn chat_byte_vector_get_at(

--- a/base_layer/contacts/src/contacts_service/service.rs
+++ b/base_layer/contacts/src/contacts_service/service.rs
@@ -564,7 +564,7 @@ where T: ContactsBackend + 'static
     fn handle_connectivity_event(&mut self, event: ConnectivityEvent) {
         use ConnectivityEvent::{PeerBanned, PeerDisconnected};
         match event {
-            PeerDisconnected(node_id) | PeerBanned(node_id) => {
+            PeerDisconnected(node_id, _) | PeerBanned(node_id) => {
                 if let Some(pos) = self.liveness_data.iter().position(|p| *p.node_id() == node_id) {
                     debug!(
                         target: LOG_TARGET,

--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -2407,7 +2407,7 @@ fn get_previous_timestamps<T: BlockchainBackend>(
     Ok(timestamps)
 }
 
-/// Gets all blocks ordered from the the block that connects (via prev_hash) to the main chain, to the orphan tip.
+/// Gets all blocks ordered from the block that connects (via prev_hash) to the main chain, to the orphan tip.
 #[allow(clippy::ptr_arg)]
 fn get_orphan_link_main_chain<T: BlockchainBackend>(
     db: &T,

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -2530,9 +2530,9 @@ impl BlockchainBackend for LMDBDatabase {
         }
         trace!(
             target: LOG_TARGET,
-            "Finished calculating new smt (size: {}), took: #{}s",
+            "Finished calculating new smt (size: {}), took: {:.2?}",
             smt.size(),
-            start.elapsed().as_millis()
+            start.elapsed()
         );
         Ok(smt)
     }

--- a/base_layer/core/src/mempool/priority/prioritized_transaction.rs
+++ b/base_layer/core/src/mempool/priority/prioritized_transaction.rs
@@ -35,7 +35,7 @@ use crate::transactions::{
 };
 
 /// Create a unique unspent transaction priority based on the transaction fee, maturity of the oldest input UTXO and the
-/// excess_sig. The excess_sig is included to ensure the the priority key unique so it can be used with a BTreeMap.
+/// excess_sig. The excess_sig is included to ensure the priority key unique so it can be used with a BTreeMap.
 /// Normally, duplicate keys will be overwritten in a BTreeMap.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Debug, Clone)]
 pub struct FeePriority(Vec<u8>);

--- a/base_layer/core/src/transactions/crypto_factories.rs
+++ b/base_layer/core/src/transactions/crypto_factories.rs
@@ -31,7 +31,7 @@ impl CryptoFactories {
     ///
     /// ## Parameters
     ///
-    /// * `max_proof_range`: Sets the the maximum value in range proofs, where `max = 2^max_proof_range`
+    /// * `max_proof_range`: Sets the maximum value in range proofs, where `max = 2^max_proof_range`
     pub fn new(max_proof_range: usize) -> Self {
         Self {
             commitment: Arc::new(CommitmentFactory::default()),

--- a/base_layer/core/src/transactions/transaction_components/encrypted_data.rs
+++ b/base_layer/core/src/transactions/transaction_components/encrypted_data.rs
@@ -23,7 +23,7 @@
 // Portions of this file were originally copyrighted (c) 2018 The Grin Developers, issued under the Apache License,
 // Version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0.
 
-//! Encrypted data using the the extended-nonce variant XChaCha20-Poly1305 encryption with secure random nonce.
+//! Encrypted data using the extended-nonce variant XChaCha20-Poly1305 encryption with secure random nonce.
 
 use std::mem::size_of;
 

--- a/base_layer/core/src/transactions/transaction_protocol/sender.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/sender.rs
@@ -472,7 +472,7 @@ impl SenderTransactionProtocol {
         Ok((public_nonce, public_excess))
     }
 
-    /// Add partial signatures, add the the recipient info to sender state and move to the Finalizing state
+    /// Add partial signatures, add the recipient info to sender state and move to the Finalizing state
     pub async fn add_single_recipient_info<KM: TransactionKeyManagerInterface>(
         &mut self,
         mut rec: RecipientSignedMessage,

--- a/base_layer/mmr/src/backend.rs
+++ b/base_layer/mmr/src/backend.rs
@@ -41,7 +41,7 @@ pub trait ArrayLike {
     /// Return the item at the given index
     fn get(&self, index: usize) -> Result<Option<Self::Value>, Self::Error>;
 
-    /// Remove all stored items from the the backend.
+    /// Remove all stored items from the backend.
     fn clear(&mut self) -> Result<(), Self::Error>;
 
     /// Finds the index of the specified stored item, it will return None if the object could not be found.

--- a/base_layer/mmr/src/sparse_merkle_tree/proofs.rs
+++ b/base_layer/mmr/src/sparse_merkle_tree/proofs.rs
@@ -98,7 +98,7 @@ pub struct InclusionProof<H> {
 /// ```
 pub struct ExclusionProof<H> {
     siblings: Vec<NodeHash>,
-    // The terminal node of the tree proof, or `None` if the the node is `Empty`.
+    // The terminal node of the tree proof, or `None` if the node is `Empty`.
     leaf: Option<LeafNode<H>>,
     phantom: std::marker::PhantomData<H>,
 }

--- a/base_layer/p2p/src/initialization.rs
+++ b/base_layer/p2p/src/initialization.rs
@@ -562,6 +562,11 @@ impl ServiceInitializer for P2pInitializer {
                 network_byte: self.network.as_byte(),
                 user_agent: self.user_agent.clone(),
             })
+            .with_minimize_connections(if self.config.dht.minimize_connections {
+                Some(self.config.dht.num_neighbouring_nodes + self.config.dht.num_random_nodes)
+            } else {
+                None
+            })
             .set_self_liveness_check(config.listener_self_liveness_check_interval);
 
         if config.allow_test_addresses || config.dht.peer_validator_config.allow_test_addresses {

--- a/base_layer/p2p/src/services/liveness/service.rs
+++ b/base_layer/p2p/src/services/liveness/service.rs
@@ -28,6 +28,7 @@ use tari_comms::{
     connectivity::{ConnectivityRequester, ConnectivitySelection},
     peer_manager::NodeId,
     types::CommsPublicKey,
+    Minimized,
     PeerManager,
 };
 use tari_comms_dht::{
@@ -360,7 +361,7 @@ where
                     target: LOG_TARGET,
                     "Disconnecting peer {} that failed {} rounds of pings", node_id, max_allowed_ping_failures
                 );
-                conn.disconnect().await?;
+                conn.disconnect(Minimized::No).await?;
             }
         }
         self.state.clear_failed_pings();

--- a/base_layer/p2p/src/transport.rs
+++ b/base_layer/p2p/src/transport.rs
@@ -147,7 +147,7 @@ pub struct TorTransportConfig {
     /// When set to true, outbound TCP connections bypass the tor proxy. Defaults to false for better privacy, setting
     /// to true may improve network performance for TCP nodes.
     pub proxy_bypass_for_outbound_tcp: bool,
-    /// If set, instructs tor to forward traffic the the provided address. Otherwise, an OS-assigned port on 127.0.0.1
+    /// If set, instructs tor to forward traffic the provided address. Otherwise, an OS-assigned port on 127.0.0.1
     /// is used.
     pub forward_address: Option<Multiaddr>,
     /// If set, the listener will bind to this address instead of the forward_address.

--- a/base_layer/wallet/src/connectivity_service/service.rs
+++ b/base_layer/wallet/src/connectivity_service/service.rs
@@ -27,6 +27,7 @@ use tari_comms::{
     connectivity::{ConnectivityError, ConnectivityRequester},
     peer_manager::{NodeId, Peer},
     protocol::rpc::{RpcClientLease, RpcClientPool},
+    Minimized,
     PeerConnection,
 };
 use tari_core::base_node::{rpc::BaseNodeWalletRpcClient, sync::rpc::BaseNodeSyncRpcClient};
@@ -225,7 +226,7 @@ impl WalletConnectivityService {
 
     async fn disconnect_base_node(&mut self, node_id: NodeId) {
         if let Ok(Some(mut connection)) = self.connectivity.get_connection(node_id.clone()).await {
-            match connection.disconnect().await {
+            match connection.disconnect(Minimized::No).await {
                 Ok(_) => debug!(target: LOG_TARGET, "Disconnected base node peer {}", node_id),
                 Err(e) => error!(target: LOG_TARGET, "Failed to disconnect base node: {}", e),
             }

--- a/base_layer/wallet/src/connectivity_service/test.rs
+++ b/base_layer/wallet/src/connectivity_service/test.rs
@@ -34,6 +34,7 @@ use tari_comms::{
         mocks::{create_connectivity_mock, ConnectivityManagerMockState},
         node_identity::build_node_identity,
     },
+    Minimized,
 };
 use tari_shutdown::Shutdown;
 use tari_test_utils::runtime::spawn_until_shutdown;
@@ -177,7 +178,7 @@ async fn it_gracefully_handles_connect_fail_reconnect() {
     mock_state.add_active_connection(conn.clone()).await;
     // Empty out all the calls
     let _result = mock_state.take_calls().await;
-    conn.disconnect().await.unwrap();
+    conn.disconnect(Minimized::No).await.unwrap();
 
     let barrier = Arc::new(Barrier::new(2));
     let pending_request = task::spawn({

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -1293,7 +1293,7 @@ where
         let uo_len = uo.len();
         trace!(
             target: LOG_TARGET,
-            "select_utxos profile - fetch_unspent_outputs_for_spending: {} outputs, {} ms (at {})",
+            "select_utxos profile - fetch_unspent_outputs_for_spending: {} outputs, {} ms (at {} ms)",
             uo_len,
             start_new.elapsed().as_millis(),
             start.elapsed().as_millis(),
@@ -1362,7 +1362,7 @@ where
         let enough_spendable = utxos_total_value > amount + fee_with_change;
         trace!(
             target: LOG_TARGET,
-            "select_utxos profile - final_selection: {} outputs from {}, {} ms (at {})",
+            "select_utxos profile - final_selection: {} outputs from {}, {} ms (at {} ms)",
             utxos.len(),
             uo_len,
             start_new.elapsed().as_millis(),

--- a/base_layer/wallet/src/utxo_scanner_service/utxo_scanner_task.rs
+++ b/base_layer/wallet/src/utxo_scanner_service/utxo_scanner_task.rs
@@ -38,6 +38,7 @@ use tari_comms::{
     protocol::rpc::RpcClientLease,
     traits::OrOptional,
     types::CommsPublicKey,
+    Minimized,
     PeerConnection,
 };
 use tari_core::{
@@ -193,7 +194,7 @@ where
                 });
 
                 if let Ok(Some(connection)) = self.resources.comms_connectivity.get_connection(peer.clone()).await {
-                    if connection.clone().disconnect().await.is_ok() {
+                    if connection.clone().disconnect(Minimized::No).await.is_ok() {
                         debug!(target: LOG_TARGET, "Disconnected base node peer {}", peer);
                     }
                 }

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -27,7 +27,7 @@
 //!    becoming a `CompletedTransaction` with the `Completed` status. This means that the transaction has been
 //!    negotiated between the parties and is now ready to be broadcast to the Base Layer. The funds are still encumbered
 //!    as pending because the transaction has not been mined yet.
-//! 3. The finalized `CompletedTransaction` will be sent back to the the receiver so that they have a copy.
+//! 3. The finalized `CompletedTransaction` will be sent back to the receiver so that they have a copy.
 //! 4. The wallet will broadcast the `CompletedTransaction` to a Base Node to be added to the mempool. Its status will
 //!    move from `Completed` to `Broadcast`.
 //! 5. Wait until the transaction is mined. The `CompleteTransaction` status will then move from `Broadcast` to `Mined`
@@ -131,7 +131,13 @@ use tari_comms::{
     transports::MemoryTransport,
     types::CommsPublicKey,
 };
-use tari_comms_dht::{store_forward::SafConfig, DbConnectionUrl, DhtConfig, NetworkDiscoveryConfig};
+use tari_comms_dht::{
+    store_forward::SafConfig,
+    DbConnectionUrl,
+    DhtConfig,
+    DhtConnectivityConfig,
+    NetworkDiscoveryConfig,
+};
 use tari_contacts::contacts_service::{handle::ContactsServiceHandle, types::Contact};
 use tari_core::{
     borsh::FromBytes,
@@ -818,7 +824,7 @@ pub unsafe extern "C" fn byte_vector_destroy(bytes: *mut ByteVector) {
 ///
 /// # Safety
 /// None
-// converting between here is fine as its used to clamp the the array to length
+// converting between here is fine as its used to clamp the array to length
 #[allow(clippy::cast_possible_wrap)]
 #[no_mangle]
 pub unsafe extern "C" fn byte_vector_get_at(ptr: *mut ByteVector, position: c_uint, error_out: *mut c_int) -> c_uchar {
@@ -1778,7 +1784,7 @@ pub unsafe extern "C" fn unblinded_outputs_get_length(
 ///
 /// # Safety
 /// The ```contact_destroy``` method must be called when finished with a TariContact to prevent a memory leak
-// converting between here is fine as its used to clamp the the array to length
+// converting between here is fine as its used to clamp the array to length
 #[allow(clippy::cast_possible_wrap)]
 #[no_mangle]
 pub unsafe extern "C" fn unblinded_outputs_get_at(
@@ -2884,7 +2890,7 @@ pub unsafe extern "C" fn contacts_get_length(contacts: *mut TariContacts, error_
 ///
 /// # Safety
 /// The ```contact_destroy``` method must be called when finished with a TariContact to prevent a memory leak
-// converting between here is fine as its used to clamp the the array to length
+// converting between here is fine as its used to clamp the array to length
 #[allow(clippy::cast_possible_wrap)]
 #[no_mangle]
 pub unsafe extern "C" fn contacts_get_at(
@@ -3185,7 +3191,7 @@ pub unsafe extern "C" fn completed_transactions_get_length(
 /// # Safety
 /// The ```completed_transaction_destroy``` method must be called when finished with a TariCompletedTransaction to
 /// prevent a memory leak
-// converting between here is fine as its used to clamp the the array to length
+// converting between here is fine as its used to clamp the array to length
 #[allow(clippy::cast_possible_wrap)]
 #[no_mangle]
 pub unsafe extern "C" fn completed_transactions_get_at(
@@ -3278,7 +3284,7 @@ pub unsafe extern "C" fn pending_outbound_transactions_get_length(
 /// # Safety
 /// The ```pending_outbound_transaction_destroy``` method must be called when finished with a
 /// TariPendingOutboundTransaction to prevent a memory leak
-// converting between here is fine as its used to clamp the the array to length
+// converting between here is fine as its used to clamp the array to length
 #[allow(clippy::cast_possible_wrap)]
 #[no_mangle]
 pub unsafe extern "C" fn pending_outbound_transactions_get_at(
@@ -3370,7 +3376,7 @@ pub unsafe extern "C" fn pending_inbound_transactions_get_length(
 /// # Safety
 /// The ```pending_inbound_transaction_destroy``` method must be called when finished with a
 /// TariPendingOutboundTransaction to prevent a memory leak
-// converting between here is fine as its used to clamp the the array to length
+// converting between here is fine as its used to clamp the array to length
 #[allow(clippy::cast_possible_wrap)]
 #[no_mangle]
 pub unsafe extern "C" fn pending_inbound_transactions_get_at(
@@ -4851,6 +4857,9 @@ pub unsafe extern "C" fn comms_config_create(
                 max_concurrent_inbound_tasks: 25,
                 max_concurrent_outbound_tasks: 50,
                 dht: DhtConfig {
+                    num_neighbouring_nodes: 5,
+                    num_random_nodes: 1,
+                    minimize_connections: true,
                     discovery_request_timeout: Duration::from_secs(discovery_timeout_in_secs),
                     database_url: DbConnectionUrl::File(dht_database_path),
                     auto_join: true,
@@ -4861,7 +4870,13 @@ pub unsafe extern "C" fn comms_config_create(
                         ..Default::default()
                     },
                     network_discovery: NetworkDiscoveryConfig {
+                        min_desired_peers: 16,
                         initial_peer_sync_delay: Some(Duration::from_secs(25)),
+                        ..Default::default()
+                    },
+                    connectivity: DhtConnectivityConfig {
+                        update_interval: Duration::from_secs(5 * 60),
+                        minimum_desired_tcpv4_node_ratio: 0.0,
                         ..Default::default()
                     },
                     ..Default::default()

--- a/common/config/presets/c_base_node_c.toml
+++ b/common/config/presets/c_base_node_c.toml
@@ -189,7 +189,7 @@ listener_self_liveness_check_interval = 15
 # When using the tor transport and set to true, outbound TCP connections bypass the tor proxy. Defaults to false for
 # better privacy
 #tor.proxy_bypass_for_outbound_tcp = false
-# If set, instructs tor to forward traffic the the provided address. (e.g. "/dns4/my-base-node/tcp/32123") (default = OS-assigned port)
+# If set, instructs tor to forward traffic the provided address. (e.g. "/dns4/my-base-node/tcp/32123") (default = OS-assigned port)
 #tor.forward_address =
 # If set, the listener will bind to this address instead of the forward_address. You need to make sure that this listener is connectable from the forward_address.
 #tor.listener_address_override =
@@ -213,7 +213,9 @@ database_url = "data/base_node/dht.db"
 # The maximum number of peer nodes that a message has to be closer to, to be considered a neighbour. Default: 8
 #num_neighbouring_nodes = 8
 # Number of random peers to include. Default: 4
-#num_random_nodes=  4
+#num_random_nodes = 4
+# Connections above the configured number of neighbouring and random nodes will be removed (default: false)
+#minimize_connections = false
 # Send to this many peers when using the broadcast strategy. Default: 8
 #broadcast_factor = 8
 # Send to this many peers when using the propagate strategy. Default: 4

--- a/common/config/presets/d_console_wallet.toml
+++ b/common/config/presets/d_console_wallet.toml
@@ -242,7 +242,7 @@ event_channel_size = 3500
 # When using the tor transport and set to true, outbound TCP connections bypass the tor proxy. Defaults to false for
 # better privacy
 #tor.proxy_bypass_for_outbound_tcp = false
-# If set, instructs tor to forward traffic the the provided address. (e.g. "/ip4/127.0.0.1/tcp/0") (default = )
+# If set, instructs tor to forward traffic the provided address. (e.g. "/ip4/127.0.0.1/tcp/0") (default = )
 #tor.forward_address =
 
 # Use a SOCKS5 proxy transport. This transport recognises any addresses supported by the proxy.
@@ -262,9 +262,11 @@ database_url = "data/wallet/dht.db"
 # The size of the buffer (channel) which holds pending outbound message requests. Default: 20
 #outbound_buffer_size = 20
 # The maximum number of peer nodes that a message has to be closer to, to be considered a neighbour. Default: 8
-#num_neighbouring_nodes = 8
+num_neighbouring_nodes = 5
 # Number of random peers to include. Default: 4
-#num_random_nodes=  4
+num_random_nodes = 1
+# Connections above the configured number of neighbouring and random nodes will be removed (default: false)
+minimize_connections = true
 # Send to this many peers when using the broadcast strategy. Default: 8
 #broadcast_factor = 8
 # Send to this many peers when using the propagate strategy. Default: 4
@@ -311,7 +313,7 @@ database_url = "data/wallet/dht.db"
 #join_cooldown_interval = 120 # 10 * 60
 
 # The interval to update the neighbouring and random pools, if necessary. Default: 2 minutes
-#connectivity.update_interval = 120 # 2 * 60
+connectivity.update_interval = 300 # 2 * 60
 # The interval to change the random pool peers. Default = 2 hours
 #connectivity.random_pool_refresh_interval = 7_200 # 2 * 60 * 60
 # Length of cooldown when high connection failure rates are encountered. Default: 45s
@@ -319,13 +321,13 @@ database_url = "data/wallet/dht.db"
 # The minimum desired ratio of TCPv4 to Tor connections. TCPv4 addresses have some significant cost to create,
 # making sybil attacks costly. This setting does not guarantee this ratio is maintained.
 # Currently, it only emits a warning if the ratio is below this setting. Default: 0.1 (10%)
-#connectivity.minimum_desired_tcpv4_node_ratio = 0.1
+connectivity.minimum_desired_tcpv4_node_ratio = 0.0
 
 # True to enable network discovery, false to disable it. Default: true
 #network_discovery.enabled = true
 # A threshold for the minimum number of peers this node should ideally be aware of. If below this threshold a
 # more "aggressive" strategy is employed. Default: 50
-network_discovery.min_desired_peers = 8
+network_discovery.min_desired_peers = 16
 # The period to wait once the number of rounds given by `idle_after_num_rounds` has completed. Default: 30 mins
 #network_discovery.idle_period = 1_800 # 30 * 60
 #  The minimum number of network discovery rounds to perform before idling (going to sleep). If there are less
@@ -339,7 +341,7 @@ network_discovery.min_desired_peers = 8
 # The maximum number of peers we allow per round of sync. (Default: 500)
 #network_discovery.max_peers_to_sync_per_round = 500
 # Initial refresh sync peers delay period, when a configured connection needs preference. (Default: Disabled)
-network_discovery.initial_peer_sync_delay = 15
+network_discovery.initial_peer_sync_delay = 25
 
 # Length of time to ban a peer if the peer misbehaves at the DHT-level. Default: 6 hrs
 #ban_duration = 21_600 # 6 * 60 * 60

--- a/comms/core/src/connection_manager/error.rs
+++ b/comms/core/src/connection_manager/error.rs
@@ -74,7 +74,7 @@ pub enum ConnectionManagerError {
     IdentityProtocolError(#[from] IdentityProtocolError),
     #[error("The dial was cancelled")]
     DialCancelled,
-    #[error("Invalid multiaddr: {0}")]
+    #[error("Invalid multiaddr")]
     InvalidMultiaddr(String),
     #[error("Failed to send wire format byte")]
     WireFormatSendFailed,
@@ -82,6 +82,8 @@ pub enum ConnectionManagerError {
     ListenerOneshotCancelled,
     #[error("Peer validation error: {0}")]
     PeerValidationError(#[from] PeerValidatorError),
+    #[error("No contactable addresses for peer {0} left")]
+    NoContactableAddressesForPeer(String),
 }
 
 impl From<yamux::ConnectionError> for ConnectionManagerError {

--- a/comms/core/src/connection_manager/manager.rs
+++ b/comms/core/src/connection_manager/manager.rs
@@ -54,6 +54,7 @@ use crate::{
     peer_validator::PeerValidatorConfig,
     protocol::{NodeNetworkInfo, ProtocolEvent, ProtocolId, Protocols},
     transports::{TcpTransport, Transport},
+    Minimized,
     PeerManager,
 };
 
@@ -67,7 +68,7 @@ const DIALER_REQUEST_CHANNEL_SIZE: usize = 32;
 pub enum ConnectionManagerEvent {
     // Peer connection
     PeerConnected(Box<PeerConnection>),
-    PeerDisconnected(ConnectionId, NodeId),
+    PeerDisconnected(ConnectionId, NodeId, Minimized),
     PeerConnectFailed(NodeId, ConnectionManagerError),
     PeerInboundConnectFailed(ConnectionManagerError),
 
@@ -84,7 +85,9 @@ impl fmt::Display for ConnectionManagerEvent {
         use ConnectionManagerEvent::*;
         match self {
             PeerConnected(conn) => write!(f, "PeerConnected({})", conn),
-            PeerDisconnected(id, node_id) => write!(f, "PeerDisconnected({}, {})", id, node_id.short_str()),
+            PeerDisconnected(id, node_id, minimized) => {
+                write!(f, "PeerDisconnected({}, {}, {:?})", id, node_id.short_str(), minimized)
+            },
             PeerConnectFailed(node_id, err) => write!(f, "PeerConnectFailed({}, {:?})", node_id.short_str(), err),
             PeerInboundConnectFailed(err) => write!(f, "PeerInboundConnectFailed({:?})", err),
             NewInboundSubstream(node_id, protocol, _) => write!(

--- a/comms/core/src/connection_manager/tests/listener_dialer.rs
+++ b/comms/core/src/connection_manager/tests/listener_dialer.rs
@@ -46,6 +46,7 @@ use crate::{
     protocol::ProtocolId,
     test_utils::{build_peer_manager, node_identity::build_node_identity},
     transports::MemoryTransport,
+    Minimized,
 };
 
 #[tokio::test]
@@ -161,7 +162,7 @@ async fn smoke() {
         assert_eq!(buf, *b"HELLO");
     }
 
-    conn1.disconnect().await.unwrap();
+    conn1.disconnect(Minimized::No).await.unwrap();
 
     shutdown.trigger();
 

--- a/comms/core/src/connectivity/config.rs
+++ b/comms/core/src/connectivity/config.rs
@@ -49,6 +49,9 @@ pub struct ConnectivityConfig {
     /// next connection attempt.
     /// Default: 24 hours
     pub expire_peer_last_seen_duration: Duration,
+    /// The closest number of peer connections to maintain; connections above the threshold will be removed
+    /// (default: disabled)
+    pub maintain_n_closest_connections_only: Option<usize>,
 }
 
 impl Default for ConnectivityConfig {
@@ -62,6 +65,7 @@ impl Default for ConnectivityConfig {
             max_failures_mark_offline: 1,
             connection_tie_break_linger: Duration::from_secs(2),
             expire_peer_last_seen_duration: Duration::from_secs(24 * 60 * 60),
+            maintain_n_closest_connections_only: None,
         }
     }
 }

--- a/comms/core/src/connectivity/connection_pool.rs
+++ b/comms/core/src/connectivity/connection_pool.rs
@@ -237,10 +237,7 @@ impl ConnectionPool {
     }
 
     pub fn count_disconnected(&self) -> usize {
-        self.count_filtered(|c| {
-            c.status() == ConnectionStatus::Disconnected(Minimized::Yes) ||
-                c.status() == ConnectionStatus::Disconnected(Minimized::No)
-        })
+        self.count_filtered(|c| matches!(c.status(), ConnectionStatus::Disconnected(_)))
     }
 
     pub fn count_entries(&self) -> usize {

--- a/comms/core/src/connectivity/connection_pool.rs
+++ b/comms/core/src/connectivity/connection_pool.rs
@@ -24,7 +24,7 @@ use std::{collections::HashMap, fmt, time::Duration};
 
 use nom::lib::std::collections::hash_map::Entry;
 
-use crate::{peer_manager::NodeId, PeerConnection};
+use crate::{peer_manager::NodeId, Minimized, PeerConnection};
 
 /// Status type for connections
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -34,7 +34,7 @@ pub enum ConnectionStatus {
     Connected,
     Retrying,
     Failed,
-    Disconnected,
+    Disconnected(Minimized),
 }
 
 impl fmt::Display for ConnectionStatus {
@@ -124,7 +124,7 @@ impl ConnectionPool {
                 entry_mut.status = if conn.is_connected() {
                     ConnectionStatus::Connected
                 } else {
-                    ConnectionStatus::Disconnected
+                    ConnectionStatus::Disconnected(Minimized::No)
                 };
                 entry_mut.set_connection(conn);
                 entry_mut.status
@@ -237,7 +237,10 @@ impl ConnectionPool {
     }
 
     pub fn count_disconnected(&self) -> usize {
-        self.count_filtered(|c| c.status() == ConnectionStatus::Disconnected)
+        self.count_filtered(|c| {
+            c.status() == ConnectionStatus::Disconnected(Minimized::Yes) ||
+                c.status() == ConnectionStatus::Disconnected(Minimized::No)
+        })
     }
 
     pub fn count_entries(&self) -> usize {

--- a/comms/core/src/connectivity/manager.rs
+++ b/comms/core/src/connectivity/manager.rs
@@ -501,9 +501,10 @@ impl ConnectivityManagerActor {
 
     fn clean_connection_pool(&mut self) {
         let cleared_states = self.pool.filter_drain(|state| {
-            state.status() == ConnectionStatus::Failed ||
-                state.status() == ConnectionStatus::Disconnected(Minimized::Yes) ||
-                state.status() == ConnectionStatus::Disconnected(Minimized::No)
+            matches!(
+                state.status(),
+                ConnectionStatus::Failed | ConnectionStatus::Disconnected(_)
+            )
         });
 
         if !cleared_states.is_empty() {

--- a/comms/core/src/connectivity/manager.rs
+++ b/comms/core/src/connectivity/manager.rs
@@ -55,6 +55,7 @@ use crate::{
     },
     peer_manager::NodeId,
     utils::datetime::format_duration,
+    Minimized,
     NodeIdentity,
     PeerConnection,
     PeerManager,
@@ -226,7 +227,7 @@ impl ConnectivityManagerActor {
                 let tracing_id = tracing::Span::current().id();
                 let span = span!(Level::TRACE, "handle_dial_peer");
                 span.follows_from(tracing_id);
-                self.handle_dial_peer(node_id, reply_tx).instrument(span).await;
+                self.handle_dial_peer(node_id.clone(), reply_tx).instrument(span).await;
             },
             SelectConnections(selection, reply) => {
                 let _result = reply.send(self.select_connections(selection).await);
@@ -255,6 +256,10 @@ impl ConnectivityManagerActor {
                 let states = self.pool.all().into_iter().cloned().collect();
                 let _result = reply.send(states);
             },
+            GetMinimizeConnectionsThreshold(reply) => {
+                let minimize_connections_threshold = self.config.maintain_n_closest_connections_only;
+                let _result = reply.send(minimize_connections_threshold);
+            },
             BanPeer(node_id, duration, reason) => {
                 if self.allow_list.contains(&node_id) {
                     info!(
@@ -269,13 +274,17 @@ impl ConnectivityManagerActor {
             },
             AddPeerToAllowList(node_id) => {
                 if !self.allow_list.contains(&node_id) {
-                    self.allow_list.push(node_id)
+                    self.allow_list.push(node_id.clone());
                 }
             },
             RemovePeerFromAllowList(node_id) => {
                 if let Some(index) = self.allow_list.iter().position(|x| *x == node_id) {
                     self.allow_list.remove(index);
                 }
+            },
+            GetAllowList(reply) => {
+                let allow_list = self.allow_list.clone();
+                let _result = reply.send(allow_list);
             },
             GetActiveConnections(reply) => {
                 let _result = reply.send(
@@ -285,6 +294,10 @@ impl ConnectivityManagerActor {
                         .cloned()
                         .collect(),
                 );
+            },
+            GetNodeIdentity(reply) => {
+                let identity = self.node_identity.as_ref();
+                let _result = reply.send(identity.clone());
             },
         }
     }
@@ -352,7 +365,7 @@ impl ConnectivityManagerActor {
                 if !conn.is_connected() {
                     continue;
                 }
-                match conn.disconnect_silent().await {
+                match conn.disconnect_silent(Minimized::No).await {
                     Ok(_) => {
                         node_ids.push(conn.peer_node_id().clone());
                     },
@@ -369,7 +382,7 @@ impl ConnectivityManagerActor {
         }
 
         for node_id in node_ids {
-            self.publish_event(ConnectivityEvent::PeerDisconnected(node_id));
+            self.publish_event(ConnectivityEvent::PeerDisconnected(node_id, Minimized::No));
         }
     }
 
@@ -389,9 +402,65 @@ impl ConnectivityManagerActor {
         if self.config.is_connection_reaping_enabled {
             self.reap_inactive_connections().await;
         }
+        if let Some(threshold) = self.config.maintain_n_closest_connections_only {
+            self.maintain_n_closest_peer_connections_only(threshold).await;
+        }
         self.update_connectivity_status();
         self.update_connectivity_metrics();
         Ok(())
+    }
+
+    async fn maintain_n_closest_peer_connections_only(&mut self, threshold: usize) {
+        // Select all active peer connections (that are communication nodes)
+        let mut connections = match self
+            .select_connections(ConnectivitySelection::closest_to(
+                self.node_identity.node_id().clone(),
+                self.pool.count_connected_nodes(),
+                vec![],
+            ))
+            .await
+        {
+            Ok(peers) => peers,
+            Err(e) => {
+                warn!(
+                    target: LOG_TARGET,
+                    "Connectivity error trying to maintain {} closest peers ({:?})",
+                    threshold,
+                    e
+                );
+                return;
+            },
+        };
+        let num_connections = connections.len();
+
+        // Remove peers that are on the allow list
+        connections.retain(|conn| !self.allow_list.contains(conn.peer_node_id()));
+        debug!(
+            target: LOG_TARGET,
+            "minimize_connections: Filtered peers: {}, Handles: {}",
+            connections.len(),
+            num_connections,
+        );
+
+        // Disconnect all remaining peers above the threshold
+        for conn in connections.iter_mut().skip(threshold) {
+            debug!(
+                target: LOG_TARGET,
+                "minimize_connections: Disconnecting '{}' because the node is not among the {} closest peers",
+                conn.peer_node_id(),
+                threshold
+            );
+            if let Err(err) = conn.disconnect(Minimized::Yes).await {
+                // Already disconnected
+                debug!(
+                    target: LOG_TARGET,
+                    "Peer '{}' already disconnected. Error: {:?}",
+                    conn.peer_node_id().short_str(),
+                    err
+                );
+            }
+            self.pool.remove(conn.peer_node_id());
+        }
     }
 
     async fn reap_inactive_connections(&mut self) {
@@ -418,7 +487,7 @@ impl ConnectivityManagerActor {
                 conn.peer_node_id().short_str(),
                 conn.handle_count()
             );
-            if let Err(err) = conn.disconnect().await {
+            if let Err(err) = conn.disconnect(Minimized::Yes).await {
                 // Already disconnected
                 debug!(
                     target: LOG_TARGET,
@@ -432,7 +501,9 @@ impl ConnectivityManagerActor {
 
     fn clean_connection_pool(&mut self) {
         let cleared_states = self.pool.filter_drain(|state| {
-            state.status() == ConnectionStatus::Failed || state.status() == ConnectionStatus::Disconnected
+            state.status() == ConnectionStatus::Failed ||
+                state.status() == ConnectionStatus::Disconnected(Minimized::Yes) ||
+                state.status() == ConnectionStatus::Disconnected(Minimized::No)
         });
 
         if !cleared_states.is_empty() {
@@ -560,7 +631,7 @@ impl ConnectivityManagerActor {
                     TieBreak::UseNew | TieBreak::None => {},
                 }
             },
-            PeerDisconnected(id, node_id) => {
+            PeerDisconnected(id, node_id, _minimized) => {
                 if let Some(conn) = self.pool.get_connection(node_id) {
                     if conn.id() != *id {
                         debug!(
@@ -586,7 +657,7 @@ impl ConnectivityManagerActor {
         }
 
         let (node_id, mut new_status, connection) = match event {
-            PeerDisconnected(_, node_id) => (node_id, ConnectionStatus::Disconnected, None),
+            PeerDisconnected(_, node_id, minimized) => (node_id, ConnectionStatus::Disconnected(*minimized), None),
             PeerConnected(conn) => (conn.peer_node_id(), ConnectionStatus::Connected, Some(conn.clone())),
 
             PeerConnectFailed(node_id, ConnectionManagerError::DialCancelled) => {
@@ -632,7 +703,7 @@ impl ConnectivityManagerActor {
 
         use ConnectionStatus::{Connected, Disconnected, Failed};
         match (old_status, new_status) {
-            (_, Connected) => match self.pool.get_connection(&node_id).cloned() {
+            (_, Connected) => match self.pool.get_connection_mut(&node_id).cloned() {
                 Some(conn) => {
                     self.mark_connection_success(conn.peer_node_id().clone());
                     self.publish_event(ConnectivityEvent::PeerConnected(conn.into()));
@@ -642,11 +713,14 @@ impl ConnectivityManagerActor {
                      ConnectionPool::get_connection is Some"
                 ),
             },
-            (Connected, Disconnected) => {
-                self.publish_event(ConnectivityEvent::PeerDisconnected(node_id));
+            (Connected, Disconnected(..)) => {
+                self.publish_event(ConnectivityEvent::PeerDisconnected(node_id, match new_status {
+                    ConnectionStatus::Disconnected(reason) => reason,
+                    _ => Minimized::No,
+                }));
             },
             // Was not connected so don't broadcast event
-            (_, Disconnected) => {},
+            (_, Disconnected(..)) => {},
             (_, Failed) => {
                 self.publish_event(ConnectivityEvent::PeerConnectFailed(node_id));
             },
@@ -692,7 +766,7 @@ impl ConnectivityManagerActor {
                         existing_conn.direction(),
                     );
 
-                    let _result = existing_conn.disconnect_silent().await;
+                    let _result = existing_conn.disconnect_silent(Minimized::Yes).await;
                     self.pool.remove(existing_conn.peer_node_id());
                     TieBreak::UseNew
                 } else {
@@ -708,7 +782,7 @@ impl ConnectivityManagerActor {
                         existing_conn.direction(),
                     );
 
-                    let _result = new_conn.clone().disconnect_silent().await;
+                    let _result = new_conn.clone().disconnect_silent(Minimized::Yes).await;
                     TieBreak::KeepExisting
                 }
             },
@@ -887,7 +961,7 @@ impl ConnectivityManagerActor {
         self.publish_event(ConnectivityEvent::PeerBanned(node_id.clone()));
 
         if let Some(conn) = self.pool.get_connection_mut(node_id) {
-            conn.disconnect().await?;
+            conn.disconnect(Minimized::Yes).await?;
             let status = self.pool.get_connection_status(node_id);
             debug!(
                 target: LOG_TARGET,
@@ -903,7 +977,7 @@ impl ConnectivityManagerActor {
             let status = self.pool.get_connection_status(node_id);
             if matches!(
                 status,
-                ConnectionStatus::NotConnected | ConnectionStatus::Failed | ConnectionStatus::Disconnected
+                ConnectionStatus::NotConnected | ConnectionStatus::Failed | ConnectionStatus::Disconnected(_)
             ) {
                 to_remove.push(node_id.clone());
             }

--- a/comms/core/src/connectivity/test.rs
+++ b/comms/core/src/connectivity/test.rs
@@ -43,6 +43,7 @@ use crate::{
         mocks::{create_connection_manager_mock, create_peer_connection_mock_pair, ConnectionManagerMockState},
         node_identity::{build_many_node_identities, build_node_identity},
     },
+    Minimized,
     NodeIdentity,
     PeerManager,
 };
@@ -203,6 +204,7 @@ async fn online_then_offline_then_online() {
         cm_mock_state.publish_event(ConnectionManagerEvent::PeerDisconnected(
             conn.id(),
             conn.peer_node_id().clone(),
+            Minimized::No,
         ));
     }
 
@@ -224,6 +226,7 @@ async fn online_then_offline_then_online() {
         cm_mock_state.publish_event(ConnectionManagerEvent::PeerDisconnected(
             conn.id(),
             conn.peer_node_id().clone(),
+            Minimized::No,
         ));
     }
 
@@ -420,10 +423,11 @@ async fn pool_management() {
         if conn != important_connection {
             assert_eq!(conn.handle_count(), 2);
             // The peer connection mock does not "automatically" publish event to connectivity manager
-            conn.disconnect().await.unwrap();
+            conn.disconnect(Minimized::No).await.unwrap();
             cm_mock_state.publish_event(ConnectionManagerEvent::PeerDisconnected(
                 conn.id(),
                 conn.peer_node_id().clone(),
+                Minimized::No,
             ));
         }
     }
@@ -432,7 +436,7 @@ async fn pool_management() {
 
     let events = collect_try_recv!(event_stream, take = 9, timeout = Duration::from_secs(10));
     for event in events {
-        unpack_enum!(ConnectivityEvent::PeerDisconnected(_) = event);
+        unpack_enum!(ConnectivityEvent::PeerDisconnected(..) = event);
     }
 
     assert_eq!(important_connection.handle_count(), 2);
@@ -440,15 +444,16 @@ async fn pool_management() {
     let conns = connectivity.get_active_connections().await.unwrap();
 
     assert_eq!(conns.len(), 1);
-    important_connection.disconnect().await.unwrap();
+    important_connection.disconnect(Minimized::No).await.unwrap();
     cm_mock_state.publish_event(ConnectionManagerEvent::PeerDisconnected(
         important_connection.id(),
         important_connection.peer_node_id().clone(),
+        Minimized::No,
     ));
     drop(important_connection);
 
     let mut events = collect_try_recv!(event_stream, take = 1, timeout = Duration::from_secs(10));
-    unpack_enum!(ConnectivityEvent::PeerDisconnected(_) = events.remove(0));
+    unpack_enum!(ConnectivityEvent::PeerDisconnected(..) = events.remove(0));
     let conns = connectivity.get_active_connections().await.unwrap();
     assert!(conns.is_empty());
 }

--- a/comms/core/src/lib.rs
+++ b/comms/core/src/lib.rs
@@ -64,3 +64,10 @@ pub use async_trait::async_trait;
 pub use bytes::{Buf, BufMut, Bytes, BytesMut};
 #[cfg(feature = "rpc")]
 pub use tower::make::MakeService;
+
+/// Was the connection closed due to minimize_connections
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum Minimized {
+    Yes,
+    No,
+}

--- a/comms/core/src/net_address/multiaddr_with_stats.rs
+++ b/comms/core/src/net_address/multiaddr_with_stats.rs
@@ -183,6 +183,7 @@ impl MultiaddrWithStats {
     /// Reset the connection attempts on this net address for a later session of retries
     pub fn reset_connection_attempts(&mut self) {
         self.connection_attempts = 0;
+        self.last_failed_reason = None;
     }
 
     /// Mark that a connection could not be established with this net address

--- a/comms/core/src/net_address/mutliaddresses_with_stats.rs
+++ b/comms/core/src/net_address/mutliaddresses_with_stats.rs
@@ -467,9 +467,15 @@ mod test {
         assert_eq!(net_addresses.addresses[0].connection_attempts(), 2);
         assert_eq!(net_addresses.addresses[1].connection_attempts(), 1);
         assert_eq!(net_addresses.addresses[2].connection_attempts(), 1);
+        assert!(net_addresses.addresses[0].last_failed_reason().is_some());
+        assert!(net_addresses.addresses[1].last_failed_reason().is_some());
+        assert!(net_addresses.addresses[2].last_failed_reason().is_some());
         net_addresses.reset_connection_attempts();
         assert_eq!(net_addresses.addresses[0].connection_attempts(), 0);
         assert_eq!(net_addresses.addresses[1].connection_attempts(), 0);
         assert_eq!(net_addresses.addresses[2].connection_attempts(), 0);
+        assert!(net_addresses.addresses[0].last_failed_reason().is_none());
+        assert!(net_addresses.addresses[1].last_failed_reason().is_none());
+        assert!(net_addresses.addresses[2].last_failed_reason().is_none());
     }
 }

--- a/comms/core/src/peer_manager/peer.rs
+++ b/comms/core/src/peer_manager/peer.rs
@@ -208,6 +208,11 @@ impl Peer {
         self.addresses.last_seen()
     }
 
+    /// Provides info about the failure status of all addresses
+    pub fn all_addresses_failed(&self) -> bool {
+        self.addresses.iter().all(|a| a.last_failed_reason().is_some())
+    }
+
     /// Provides that length of time since the last successful interaction with the peer
     pub fn last_seen_since(&self) -> Option<Duration> {
         self.last_seen()

--- a/comms/core/src/peer_manager/peer_query.rs
+++ b/comms/core/src/peer_manager/peer_query.rs
@@ -246,7 +246,7 @@ mod test {
 
     #[test]
     fn limit_query() {
-        // Create 20 peers were the 1st and last one is bad
+        // Create some good peers
         let db = HashmapDatabase::new();
         let mut id_counter = 0;
 
@@ -262,11 +262,7 @@ mod test {
 
     #[test]
     fn select_where_query() {
-        // Create peer manager with random peers
-        let mut sample_peers = Vec::new();
-        // Create 20 peers were the 1st and last one is bad
-        let _rng = rand::rngs::OsRng;
-        sample_peers.push(create_test_peer(true));
+        // Create some good and bad peers
         let db = HashmapDatabase::new();
         let mut id_counter = 0;
 
@@ -292,11 +288,7 @@ mod test {
 
     #[test]
     fn select_where_limit_query() {
-        // Create peer manager with random peers
-        let mut sample_peers = Vec::new();
-        // Create 20 peers were the 1st and last one is bad
-        let _rng = rand::rngs::OsRng;
-        sample_peers.push(create_test_peer(true));
+        // Create some good and bad peers
         let db = HashmapDatabase::new();
         let mut id_counter = 0;
 
@@ -333,11 +325,7 @@ mod test {
 
     #[test]
     fn sort_by_query() {
-        // Create peer manager with random peers
-        let mut sample_peers = Vec::new();
-        // Create 20 peers were the 1st and last one is bad
-        let _rng = rand::rngs::OsRng;
-        sample_peers.push(create_test_peer(true));
+        // Create some good and bad peers
         let db = HashmapDatabase::new();
         let mut id_counter = 0;
 

--- a/comms/core/src/protocol/rpc/client/tests.rs
+++ b/comms/core/src/protocol/rpc/client/tests.rs
@@ -76,7 +76,10 @@ async fn setup(num_concurrent_sessions: usize) -> (PeerConnection, PeerConnectio
 
 mod lazy_pool {
     use super::*;
-    use crate::protocol::rpc::client::pool::{LazyPool, RpcClientPoolError};
+    use crate::{
+        protocol::rpc::client::pool::{LazyPool, RpcClientPoolError},
+        Minimized,
+    };
 
     #[tokio::test]
     async fn it_connects_lazily() {
@@ -168,7 +171,7 @@ mod lazy_pool {
         let (mut peer_conn, _, _shutdown) = setup(2).await;
         let mut pool = LazyPool::<GreetingClient>::new(peer_conn.clone(), 2, Default::default());
         let mut _conn1 = pool.get_least_used_or_connect().await.unwrap();
-        peer_conn.disconnect().await.unwrap();
+        peer_conn.disconnect(Minimized::No).await.unwrap();
         let err = pool.get_least_used_or_connect().await.unwrap_err();
         unpack_enum!(RpcClientPoolError::PeerConnectionDropped { .. } = err);
     }

--- a/comms/core/src/test_utils/mocks/connection_manager.rs
+++ b/comms/core/src/test_utils/mocks/connection_manager.rs
@@ -131,9 +131,7 @@ impl ConnectionManagerMock {
         self.state.inc_call_count();
         self.state.add_call(format!("{:?}", req)).await;
         match req {
-            DialPeer {
-                node_id, mut reply_tx, ..
-            } => {
+            DialPeer { node_id, mut reply_tx } => {
                 // Send Ok(&mut conn) if we have an active connection, otherwise Err(DialConnectFailedAllAddresses)
                 let result = self
                     .state

--- a/comms/core/src/test_utils/mocks/connection_manager.rs
+++ b/comms/core/src/test_utils/mocks/connection_manager.rs
@@ -131,7 +131,9 @@ impl ConnectionManagerMock {
         self.state.inc_call_count();
         self.state.add_call(format!("{:?}", req)).await;
         match req {
-            DialPeer { node_id, mut reply_tx } => {
+            DialPeer {
+                node_id, mut reply_tx, ..
+            } => {
                 // Send Ok(&mut conn) if we have an active connection, otherwise Err(DialConnectFailedAllAddresses)
                 let result = self
                     .state

--- a/comms/core/src/test_utils/mocks/connectivity_manager.rs
+++ b/comms/core/src/test_utils/mocks/connectivity_manager.rs
@@ -293,6 +293,11 @@ impl ConnectivityManagerMock {
                     .await;
             },
             WaitStarted(reply) => reply.send(()).unwrap(),
+            GetNodeIdentity(_) => unimplemented!(),
+            GetAllowList(reply) => {
+                let _result = reply.send(vec![]);
+            },
+            GetMinimizeConnectionsThreshold(_) => unimplemented!(),
         }
     }
 }

--- a/comms/core/src/test_utils/mocks/peer_connection.rs
+++ b/comms/core/src/test_utils/mocks/peer_connection.rs
@@ -221,7 +221,7 @@ impl PeerConnectionMock {
                     reply_tx.send(Err(err)).unwrap();
                 },
             },
-            Disconnect(_, reply_tx) => {
+            Disconnect(_, reply_tx, _minimized) => {
                 self.receiver.close();
                 reply_tx.send(self.state.disconnect().await).unwrap();
             },

--- a/comms/dht/examples/memory_net/utilities.rs
+++ b/comms/dht/examples/memory_net/utilities.rs
@@ -631,8 +631,13 @@ fn connection_manager_logger(
                     println!("'{}' connected to '{}'", node_name, get_name(conn.peer_node_id()),);
                 },
             },
-            PeerDisconnected(_, node_id) => {
-                println!("'{}' disconnected from '{}'", get_name(node_id), node_name);
+            PeerDisconnected(_, node_id, minimized) => {
+                println!(
+                    "'{}' disconnected from '{}', {:?}",
+                    get_name(node_id),
+                    node_name,
+                    minimized
+                );
             },
             PeerConnectFailed(node_id, err) => {
                 println!(

--- a/comms/dht/src/config.rs
+++ b/comms/dht/src/config.rs
@@ -50,6 +50,9 @@ pub struct DhtConfig {
     /// Number of random peers to include
     /// Default: 4
     pub num_random_nodes: usize,
+    /// Connections above the configured number of neighbouring and random nodes will be removed
+    /// (default: false)
+    pub minimize_connections: bool,
     /// Send to this many peers when using the broadcast strategy
     /// Default: 8
     pub broadcast_factor: usize,
@@ -169,6 +172,7 @@ impl Default for DhtConfig {
             protocol_version: DhtProtocolVersion::latest(),
             num_neighbouring_nodes: 8,
             num_random_nodes: 4,
+            minimize_connections: false,
             propagation_factor: 4,
             broadcast_factor: 8,
             outbound_buffer_size: 20,

--- a/comms/dht/src/connectivity/mod.rs
+++ b/comms/dht/src/connectivity/mod.rs
@@ -47,7 +47,8 @@ use tari_comms::{
         ConnectivitySelection,
     },
     multiaddr,
-    peer_manager::{NodeDistance, NodeId, PeerManagerError, PeerQuery, PeerQuerySortBy},
+    peer_manager::{NodeDistance, NodeId, Peer, PeerManagerError, PeerQuery, PeerQuerySortBy},
+    Minimized,
     NodeIdentity,
     PeerConnection,
     PeerManager,
@@ -84,6 +85,8 @@ pub(crate) struct DhtConnectivity {
     neighbours: Vec<NodeId>,
     /// A randomly-selected set of peers, excluding neighbouring peers.
     random_pool: Vec<NodeId>,
+    /// The random pool history.
+    previous_random: Vec<NodeId>,
     /// Used to track when the random peer pool was last refreshed
     random_pool_last_refresh: Option<Instant>,
     /// Holds references to peer connections that should be kept alive
@@ -121,6 +124,7 @@ impl DhtConnectivity {
             dht_events,
             cooldown_in_effect: None,
             shutdown_signal,
+            previous_random: vec![],
         }
     }
 
@@ -356,11 +360,12 @@ impl DhtConnectivity {
             .count()
     }
 
-    fn connected_peers_iter(&self) -> impl Iterator<Item = &NodeId> {
+    fn connected_pool_peers_iter(&self) -> impl Iterator<Item = &NodeId> {
         self.connection_handles.iter().map(|c| c.peer_node_id())
     }
 
     async fn refresh_neighbour_pool(&mut self) -> Result<(), DhtConnectivityError> {
+        self.remove_allow_list_peers_from_pools().await?;
         let mut new_neighbours = self
             .fetch_neighbouring_peers(self.config.num_neighbouring_nodes, &[])
             .await?;
@@ -385,14 +390,9 @@ impl DhtConnectivity {
 
         debug!(
             target: LOG_TARGET,
-            "Adding {} neighbouring peer(s), removing {} peers",
+            "Adding {} neighbouring peer(s), removing {} peers: {}",
             new_neighbours.len(),
-            difference.len()
-        );
-        debug!(
-            target: LOG_TARGET,
-            "Adding {} peer(s) to DHT connectivity manager: {}",
-            new_neighbours.len(),
+            difference.len(),
             new_neighbours
                 .iter()
                 .map(ToString::to_string)
@@ -401,14 +401,17 @@ impl DhtConnectivity {
         );
 
         new_neighbours.iter().cloned().for_each(|peer| {
-            self.insert_neighbour(peer);
+            self.insert_neighbour_ordered_by_distance(peer);
         });
+        self.dial_multiple_peers(&new_neighbours).await?;
 
-        if !new_neighbours.is_empty() {
-            self.connectivity.request_many_dials(new_neighbours).await?;
+        Ok(())
+    }
+
+    async fn dial_multiple_peers(&self, peers_to_dial: &[NodeId]) -> Result<(), DhtConnectivityError> {
+        if !peers_to_dial.is_empty() {
+            self.connectivity.request_many_dials(peers_to_dial.to_vec()).await?;
         }
-
-        self.redial_neighbours_as_required().await?;
 
         Ok(())
     }
@@ -432,7 +435,7 @@ impl DhtConnectivity {
                 "Redialling {} disconnected peer(s)",
                 to_redial.len()
             );
-            self.connectivity.request_many_dials(to_redial).await?;
+            self.dial_multiple_peers(&to_redial).await?;
         }
 
         Ok(())
@@ -451,9 +454,12 @@ impl DhtConnectivity {
     }
 
     async fn refresh_random_pool(&mut self) -> Result<(), DhtConnectivityError> {
-        let mut random_peers = self
-            .fetch_random_peers(self.config.num_random_nodes, &self.neighbours)
-            .await?;
+        self.remove_allow_list_peers_from_pools().await?;
+        let mut exclude = self.neighbours.clone();
+        if self.config.minimize_connections {
+            exclude.extend(self.previous_random.iter().cloned());
+        }
+        let mut random_peers = self.fetch_random_peers(self.config.num_random_nodes, &exclude).await?;
         if random_peers.is_empty() {
             info!(
                 target: LOG_TARGET,
@@ -482,18 +488,21 @@ impl DhtConnectivity {
             random_peers,
             difference
         );
-        self.random_pool.extend(random_peers.clone());
+        for peer in &random_peers {
+            self.insert_random_peer_ordered_by_distance(peer.clone());
+        }
         // Drop any connection handles that removed from the random pool
         difference.iter().for_each(|peer| {
             self.remove_connection_handle(peer);
         });
-        self.connectivity.request_many_dials(random_peers).await?;
+        self.dial_multiple_peers(&random_peers).await?;
 
         self.random_pool_last_refresh = Some(Instant::now());
         Ok(())
     }
 
     async fn handle_new_peer_connected(&mut self, conn: PeerConnection) -> Result<(), DhtConnectivityError> {
+        self.remove_allow_list_peers_from_pools().await?;
         if conn.peer_features().is_client() {
             debug!(
                 target: LOG_TARGET,
@@ -503,10 +512,19 @@ impl DhtConnectivity {
             return Ok(());
         }
 
+        if self.is_allow_list_peer(conn.peer_node_id()).await? {
+            debug!(
+                target: LOG_TARGET,
+                "Unmanaged peer '{}' connected",
+                conn.peer_node_id()
+            );
+            return Ok(());
+        }
+
         if self.is_pool_peer(conn.peer_node_id()) {
             debug!(
                 target: LOG_TARGET,
-                "Added peer {} to connection handles",
+                "Added pool peer '{}' to connection handles",
                 conn.peer_node_id()
             );
             self.insert_connection_handle(conn);
@@ -523,20 +541,56 @@ impl DhtConnectivity {
             );
 
             let peer_to_insert = conn.peer_node_id().clone();
-            self.insert_connection_handle(conn);
-            if let Some(node_id) = self.insert_neighbour(peer_to_insert.clone()) {
-                // If we kicked a neighbour out of our neighbour pool but the random pool is not full.
-                // Add the neighbour to the random pool, otherwise remove the handle from the connection pool
-                if self.random_pool.len() < self.config.num_random_nodes {
-                    debug!(
-                        target: LOG_TARGET,
-                        "Moving peer '{}' from neighbouring pool to random pool", peer_to_insert
-                    );
-                    self.random_pool.push(node_id);
-                } else {
-                    self.remove_connection_handle(&node_id)
-                }
+            if let Some(node_id) = self.insert_neighbour_ordered_by_distance(peer_to_insert.clone()) {
+                // If we kicked a neighbour out of our neighbour pool, add it to the random pool if
+                // it is not full or if it is closer than the furthest random peer.
+                debug!(
+                    target: LOG_TARGET,
+                    "Moving peer '{}' from neighbouring pool to random pool if not full or closer", peer_to_insert
+                );
+                self.insert_random_peer_ordered_by_distance(node_id)
             }
+            self.insert_connection_handle(conn);
+        }
+
+        Ok(())
+    }
+
+    async fn pool_peers_with_active_connections_by_distance(&self) -> Result<Vec<Peer>, DhtConnectivityError> {
+        let query = PeerQuery::new()
+            .select_where(|peer| {
+                self.connection_handles
+                    .iter()
+                    .any(|conn| conn.peer_node_id() == &peer.node_id)
+            })
+            .sort_by(PeerQuerySortBy::DistanceFrom(self.node_identity.node_id()));
+        let peers_by_distance = self.peer_manager.perform_query(query).await?;
+        debug!(
+            target: LOG_TARGET,
+            "minimize_connections: Filtered peers: {}, Handles: {}",
+            peers_by_distance.len(),
+            self.connection_handles.len(),
+        );
+        Ok(peers_by_distance)
+    }
+
+    async fn minimize_connections(&mut self) -> Result<(), DhtConnectivityError> {
+        // Retrieve all communication node peers with an active connection status
+        let mut peers_by_distance = self.pool_peers_with_active_connections_by_distance().await?;
+        let peer_allow_list = self.peer_allow_list().await?;
+        peers_by_distance.retain(|p| !peer_allow_list.contains(&p.node_id));
+
+        // Remove all above threshold connections
+        let threshold = self.config.num_neighbouring_nodes + self.config.num_random_nodes;
+        for peer in peers_by_distance.iter_mut().skip(threshold) {
+            debug!(
+                target: LOG_TARGET,
+                "minimize_connections: Disconnecting '{}' because the node is not among the {} closest peers",
+                peer.node_id,
+                threshold
+            );
+            self.replace_pool_peer(&peer.node_id).await?;
+            self.remove_connection_handle(&peer.node_id);
         }
 
         Ok(())
@@ -562,7 +616,18 @@ impl DhtConnectivity {
         debug!(target: LOG_TARGET, "Connectivity event: {}", event);
         match event {
             PeerConnected(conn) => {
-                self.handle_new_peer_connected(*conn).await?;
+                self.handle_new_peer_connected(*conn.clone()).await?;
+                debug!(
+                    target: LOG_TARGET,
+                    "Peer: node_id '{}', allow_list '{}', connected '{}'",
+                    conn.peer_node_id(),
+                    self.is_allow_list_peer(conn.peer_node_id()).await?,
+                    conn.is_connected(),
+                );
+
+                if self.config.minimize_connections {
+                    self.minimize_connections().await?;
+                }
             },
             PeerConnectFailed(node_id) => {
                 self.connection_handles.retain(|c| *c.peer_node_id() != node_id);
@@ -572,6 +637,7 @@ impl DhtConnectivity {
                         "Failed to clear metrics for peer `{}`. Metric collector is shut down.", node_id
                     );
                 };
+                self.remove_allow_list_peers_from_pools().await?;
                 if !self.is_pool_peer(&node_id) {
                     debug!(target: LOG_TARGET, "{} is not managed by the DHT. Ignoring", node_id);
                     return Ok(());
@@ -579,7 +645,13 @@ impl DhtConnectivity {
                 self.replace_pool_peer(&node_id).await?;
                 self.log_status();
             },
-            PeerDisconnected(node_id) => {
+            PeerDisconnected(node_id, minimized) => {
+                debug!(
+                    target: LOG_TARGET,
+                    "Peer: node_id '{}', allow_list '{}', connected 'false'",
+                    node_id,
+                    self.is_allow_list_peer(&node_id).await?,
+                );
                 self.connection_handles.retain(|c| *c.peer_node_id() != node_id);
                 if self.metrics_collector.clear_metrics(node_id.clone()).await.is_err() {
                     debug!(
@@ -587,14 +659,27 @@ impl DhtConnectivity {
                         "Failed to clear metrics for peer `{}`. Metric collector is shut down.", node_id
                     );
                 };
+                self.remove_allow_list_peers_from_pools().await?;
                 if !self.is_pool_peer(&node_id) {
                     debug!(target: LOG_TARGET, "{} is not managed by the DHT. Ignoring", node_id);
+                    return Ok(());
+                }
+                if minimized == Minimized::Yes || self.config.minimize_connections {
+                    debug!(
+                        target: LOG_TARGET,
+                        "Peer '{}' was disconnected because it was minimized, will not reconnect.",
+                        node_id
+                    );
+                    // Remove from managed pool if applicable
+                    self.replace_pool_peer(&node_id).await?;
+                    // In case the connections was not managed, remove the connection handle
+                    self.remove_connection_handle(&node_id);
                     return Ok(());
                 }
                 debug!(target: LOG_TARGET, "Pool peer {} disconnected. Redialling...", node_id);
                 // Attempt to reestablish the lost connection to the pool peer. If reconnection fails,
                 // it is replaced with another peer (replace_pool_peer via PeerConnectFailed)
-                self.connectivity.request_many_dials([node_id]).await?;
+                self.dial_multiple_peers(&[node_id]).await?;
             },
             ConnectivityStateOnline(n) => {
                 self.refresh_peer_pools().await?;
@@ -621,15 +706,47 @@ impl DhtConnectivity {
         Ok(())
     }
 
+    async fn peer_allow_list(&mut self) -> Result<Vec<NodeId>, DhtConnectivityError> {
+        Ok(self.connectivity.get_allow_list().await?)
+    }
+
+    async fn all_connected_comms_nodes(&mut self) -> Result<Vec<NodeId>, DhtConnectivityError> {
+        let all_connections = self
+            .connectivity
+            .select_connections(ConnectivitySelection::closest_to(
+                self.node_identity.node_id().clone(),
+                usize::MAX,
+                vec![],
+            ))
+            .await?;
+        let comms_nodes = all_connections
+            .iter()
+            .filter(|p| p.peer_features().is_node())
+            .map(|p| p.peer_node_id().clone())
+            .collect();
+        Ok(comms_nodes)
+    }
+
     async fn replace_pool_peer(&mut self, current_peer: &NodeId) -> Result<(), DhtConnectivityError> {
+        self.remove_allow_list_peers_from_pools().await?;
+        if self.is_allow_list_peer(current_peer).await? {
+            debug!(
+                target: LOG_TARGET,
+                "Peer '{}' is on the allow list, ignoring replacement.",
+                current_peer
+            );
+            return Ok(());
+        }
+
         if self.random_pool.contains(current_peer) {
-            let exclude = self.get_pool_peers();
-            let pos = self
-                .random_pool
-                .iter()
-                .position(|n| n == current_peer)
-                .expect("unreachable panic");
-            self.random_pool.swap_remove(pos);
+            let mut exclude = self.get_pool_peers();
+            if self.config.minimize_connections {
+                exclude.extend(self.previous_random.iter().cloned());
+                self.previous_random.push(current_peer.clone());
+            }
+
+            self.random_pool.retain(|n| n != current_peer);
+            self.remove_connection_handle(current_peer);
 
             debug!(
                 target: LOG_TARGET,
@@ -637,12 +754,8 @@ impl DhtConnectivity {
             );
             match self.fetch_random_peers(1, &exclude).await?.pop() {
                 Some(new_peer) => {
-                    self.remove_connection_handle(current_peer);
-                    if let Some(pos) = self.random_pool.iter().position(|n| n == current_peer) {
-                        self.random_pool.swap_remove(pos);
-                    }
-                    self.random_pool.push(new_peer.clone());
-                    self.connectivity.request_many_dials([new_peer]).await?;
+                    self.insert_random_peer_ordered_by_distance(new_peer.clone());
+                    self.dial_multiple_peers(&[new_peer]).await?;
                 },
                 None => {
                     debug!(
@@ -658,25 +771,18 @@ impl DhtConnectivity {
 
         if self.neighbours.contains(current_peer) {
             let exclude = self.get_pool_peers();
-            let pos = self
-                .neighbours
-                .iter()
-                .position(|n| n == current_peer)
-                .expect("unreachable panic");
-            self.neighbours.remove(pos);
+
+            self.neighbours.retain(|n| n != current_peer);
+            self.remove_connection_handle(current_peer);
 
             debug!(
                 target: LOG_TARGET,
                 "Peer '{}' in neighbour pool is offline. Adding a new peer if possible", current_peer
             );
             match self.fetch_neighbouring_peers(1, &exclude).await?.pop() {
-                Some(node_id) => {
-                    self.remove_connection_handle(current_peer);
-                    if let Some(pos) = self.neighbours.iter().position(|n| n == current_peer) {
-                        self.neighbours.remove(pos);
-                    }
-                    self.insert_neighbour(node_id.clone());
-                    self.connectivity.request_many_dials([node_id]).await?;
+                Some(new_peer) => {
+                    self.insert_neighbour_ordered_by_distance(new_peer.clone());
+                    self.dial_multiple_peers(&[new_peer]).await?;
                 },
                 None => {
                     info!(
@@ -690,21 +796,17 @@ impl DhtConnectivity {
             }
         }
 
+        self.log_status();
+
         Ok(())
     }
 
-    fn insert_neighbour(&mut self, node_id: NodeId) -> Option<NodeId> {
+    fn insert_neighbour_ordered_by_distance(&mut self, node_id: NodeId) -> Option<NodeId> {
         let dist = node_id.distance(self.node_identity.node_id());
         let pos = self
             .neighbours
             .iter()
             .position(|node_id| node_id.distance(self.node_identity.node_id()) > dist);
-
-        let removed_peer = if self.neighbours.len() + 1 > self.config.num_neighbouring_nodes {
-            self.neighbours.pop()
-        } else {
-            None
-        };
 
         match pos {
             Some(idx) => {
@@ -715,7 +817,47 @@ impl DhtConnectivity {
             },
         }
 
-        removed_peer
+        if self.neighbours.len() > self.config.num_neighbouring_nodes {
+            self.neighbours.pop()
+        } else {
+            None
+        }
+    }
+
+    fn insert_random_peer_ordered_by_distance(&mut self, node_id: NodeId) {
+        let dist = node_id.distance(self.node_identity.node_id());
+        let pos = self
+            .random_pool
+            .iter()
+            .position(|node_id| node_id.distance(self.node_identity.node_id()) > dist);
+
+        match pos {
+            Some(idx) => {
+                self.random_pool.insert(idx, node_id);
+            },
+            None => {
+                self.random_pool.push(node_id);
+            },
+        }
+
+        if self.random_pool.len() > self.config.num_random_nodes {
+            if let Some(removed_peer) = self.random_pool.pop() {
+                if self.config.minimize_connections {
+                    self.previous_random.push(removed_peer.clone());
+                }
+            }
+        }
+    }
+
+    async fn remove_allow_list_peers_from_pools(&mut self) -> Result<(), DhtConnectivityError> {
+        let allow_list = self.peer_allow_list().await?;
+        self.neighbours.retain(|n| !allow_list.contains(n));
+        self.random_pool.retain(|n| !allow_list.contains(n));
+        Ok(())
+    }
+
+    async fn is_allow_list_peer(&mut self, node_id: &NodeId) -> Result<bool, DhtConnectivityError> {
+        Ok(self.peer_allow_list().await?.contains(node_id))
     }
 
     fn is_pool_peer(&self, node_id: &NodeId) -> bool {
@@ -742,18 +884,37 @@ impl DhtConnectivity {
             .expect("already checked")
     }
 
+    async fn max_neighbour_distance_all_conncetions(&mut self) -> Result<NodeDistance, DhtConnectivityError> {
+        let mut distance = self.get_neighbour_max_distance();
+        if self.config.minimize_connections {
+            let all_connected_comms_nodes = self.all_connected_comms_nodes().await?;
+            if let Some(node_id) = all_connected_comms_nodes.get(self.config.num_neighbouring_nodes - 1) {
+                let node_distance = self.node_identity.node_id().distance(node_id);
+                if node_distance < distance {
+                    distance = node_distance;
+                }
+            }
+        }
+        Ok(distance)
+    }
+
     async fn fetch_neighbouring_peers(
-        &self,
+        &mut self,
         n: usize,
         excluded: &[NodeId],
     ) -> Result<Vec<NodeId>, DhtConnectivityError> {
+        let peer_allow_list = self.peer_allow_list().await?;
+        let neighbour_distance = self.max_neighbour_distance_all_conncetions().await?;
         let peer_manager = &self.peer_manager;
-        let node_id = self.node_identity.node_id();
-        let connected = self.connected_peers_iter().collect::<Vec<_>>();
+        let self_node_id = self.node_identity.node_id();
+        let connected_pool_peers = self.connected_pool_peers_iter().collect::<Vec<_>>();
+
+        let mut excluded = excluded.to_vec();
+        excluded.extend(peer_allow_list);
 
         // Fetch to all n nearest neighbour Communication Nodes
         // which are eligible for connection.
-        // Currently that means:
+        // Currently, that means:
         // - The peer isn't banned,
         // - it has the required features
         // - it didn't recently fail to connect, and
@@ -769,7 +930,7 @@ impl DhtConnectivity {
                     return false;
                 }
 
-                if connected.contains(&&peer.node_id) {
+                if connected_pool_peers.contains(&&peer.node_id) {
                     return false;
                 }
 
@@ -781,7 +942,7 @@ impl DhtConnectivity {
                     return false;
                 }
                 // we have tried to connect to this peer, and we have never made a successful attempt at connection
-                if peer.last_connect_attempt().is_some() && peer.last_seen().is_none() {
+                if peer.all_addresses_failed() {
                     return false;
                 }
 
@@ -790,9 +951,16 @@ impl DhtConnectivity {
                     return false;
                 }
 
+                if self.config.minimize_connections {
+                    // If the peer is not closer, return false
+                    if self_node_id.distance(&peer.node_id) >= neighbour_distance {
+                        return false;
+                    }
+                }
+
                 true
             })
-            .sort_by(PeerQuerySortBy::DistanceFrom(node_id))
+            .sort_by(PeerQuerySortBy::DistanceFrom(self_node_id))
             .limit(n);
 
         let peers = peer_manager.perform_query(query).await?;
@@ -800,8 +968,10 @@ impl DhtConnectivity {
         Ok(peers.into_iter().map(|p| p.node_id).take(n).collect())
     }
 
-    async fn fetch_random_peers(&self, n: usize, excluded: &[NodeId]) -> Result<Vec<NodeId>, DhtConnectivityError> {
-        let peers = self.peer_manager.random_peers(n, excluded).await?;
+    async fn fetch_random_peers(&mut self, n: usize, excluded: &[NodeId]) -> Result<Vec<NodeId>, DhtConnectivityError> {
+        let mut excluded = excluded.to_vec();
+        excluded.extend(self.peer_allow_list().await?);
+        let peers = self.peer_manager.random_peers(n, &excluded).await?;
         Ok(peers.into_iter().map(|p| p.node_id).collect())
     }
 

--- a/comms/dht/src/connectivity/test.rs
+++ b/comms/dht/src/connectivity/test.rs
@@ -31,6 +31,7 @@ use tari_comms::{
         mocks::{create_connectivity_mock, create_dummy_peer_connection, ConnectivityManagerMockState},
         node_identity::ordered_node_identities_by_distance,
     },
+    Minimized,
     NodeIdentity,
     PeerManager,
 };
@@ -192,6 +193,7 @@ async fn replace_peer_when_peer_goes_offline() {
 
     connectivity.publish_event(ConnectivityEvent::PeerDisconnected(
         node_identities[4].node_id().clone(),
+        Minimized::No,
     ));
 
     async_assert!(
@@ -242,12 +244,16 @@ async fn insert_neighbour() {
 
     // First 8 inserts should not remove a peer (because num_neighbouring_nodes == 8)
     for ni in shuffled.iter().take(8) {
-        assert!(dht_connectivity.insert_neighbour(ni.node_id().clone()).is_none());
+        assert!(dht_connectivity
+            .insert_neighbour_ordered_by_distance(ni.node_id().clone())
+            .is_none());
     }
 
     // Next 2 inserts will always remove a node id
     for ni in shuffled.iter().skip(8) {
-        assert!(dht_connectivity.insert_neighbour(ni.node_id().clone()).is_some())
+        assert!(dht_connectivity
+            .insert_neighbour_ordered_by_distance(ni.node_id().clone())
+            .is_some())
     }
 
     // Check the first 7 node ids match our neighbours, the last element depends on distance and ordering of inserts

--- a/comms/dht/src/network_discovery/state_machine.rs
+++ b/comms/dht/src/network_discovery/state_machine.rs
@@ -308,7 +308,7 @@ impl Display for DiscoveryParams {
                 let _ = write!(peers, "{p}, ");
                 peers
             }),
-            self.num_peers_to_request
+            self.num_peers_to_request,
         )
     }
 }

--- a/comms/dht/src/store_forward/error.rs
+++ b/comms/dht/src/store_forward/error.rs
@@ -24,6 +24,7 @@ use std::time::Duration;
 
 use prost::DecodeError;
 use tari_comms::{
+    connectivity::ConnectivityError,
     message::MessageError,
     peer_manager::{NodeId, PeerManagerError},
 };
@@ -89,4 +90,6 @@ pub enum StoreAndForwardError {
     StoredAtWasInFuture,
     #[error("Invariant error (POSSIBLE BUG): {0}")]
     InvariantError(String),
+    #[error("ConnectivityError: {0}")]
+    ConnectivityError(#[from] ConnectivityError),
 }

--- a/comms/dht/src/store_forward/saf_handler/task.rs
+++ b/comms/dht/src/store_forward/saf_handler/task.rs
@@ -632,7 +632,8 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
             Err(err @ StoreAndForwardError::RequesterChannelClosed) |
             Err(err @ StoreAndForwardError::DhtOutboundError(_)) |
             Err(err @ StoreAndForwardError::StorageError(_)) |
-            Err(err @ StoreAndForwardError::PeerManagerError(_)) => {
+            Err(err @ StoreAndForwardError::PeerManagerError(_)) |
+            Err(err @ StoreAndForwardError::ConnectivityError(_)) => {
                 error!(target: LOG_TARGET, "Internal error: {}", err);
                 None
             },

--- a/comms/dht/src/store_forward/service.rs
+++ b/comms/dht/src/store_forward/service.rs
@@ -407,10 +407,6 @@ impl StoreAndForwardService {
                             })
                             .collect::<Vec<_>>();
                         active_connections_with_distance.sort_by(|a, b| a.1.cmp(&b.1));
-                        // TODO: Hansie remove this assert!
-                        for i in 1..active_connections_with_distance.len() - 1 {
-                            assert!(active_connections_with_distance[i].1 >= active_connections_with_distance[i - 1].1);
-                        }
                         let saf_ignore_distance = active_connections_with_distance
                             .get(threshold - 1)
                             .map(|(_, distance)| distance)


### PR DESCRIPTION
Description
---
Added functionality to limit the number of base node peer connections that a wallet can have, based on a config setting. The furtherest nodes will be disconnected, but nodes on the allow list (e.g. connected base node) will be ignored. Request to a newly connected base node for SAF messages will also be limited to the closest connections only.

Motivation and Context
---
Wallets do not need to be as aggressive in establishing and keeping many connections compared to a base node.

How Has This Been Tested?
---
System-level testing on `nextnet`

Some results for a fresh wallet are below with using these settings:
```rust
[wallet.p2p.dht]
# The maximum number of peer nodes that a message has to be closer to, to be considered a neighbour. Default: 8
num_neighbouring_nodes = 5
# Number of random peers to include. Default: 4
num_random_nodes = 1
# Connections above the configured number of neighbouring nodes (minimum of 1) will be removed (default: false)
minimize_connections = true
# The interval to update the neighbouring and random pools, if necessary. Default: 2 minutes
connectivity.update_interval = 300 # 2 * 60
# The minimum desired ratio of TCPv4 to Tor connections. TCPv4 addresses have some significant cost to create,
# making sybil attacks costly. This setting does not guarantee this ratio is maintained.
# Currently, it only emits a warning if the ratio is below this setting. Default: 0.1 (10%)
connectivity.minimum_desired_tcpv4_node_ratio = 0.0
# A threshold for the minimum number of peers this node should ideally be aware of. If below this threshold a
# more "aggressive" strategy is employed. Default: 50
network_discovery.min_desired_peers = 16
```
```rust
2024-05-09 16:59:18.051376500 [comms::dht::connectivity] DEBUG minimize_connections: Filtered peers: 1, Handles: 1
2024-05-09 16:59:23.846098200 [comms::dht::connectivity] DEBUG minimize_connections: Filtered peers: 2, Handles: 2
2024-05-09 16:59:25.141738700 [comms::dht::connectivity] DEBUG minimize_connections: Filtered peers: 2, Handles: 2
2024-05-09 16:59:26.526939300 [comms::dht::connectivity] DEBUG minimize_connections: Filtered peers: 2, Handles: 2
2024-05-09 16:59:31.890309600 [comms::dht::connectivity] DEBUG minimize_connections: Filtered peers: 3, Handles: 3
2024-05-09 16:59:34.875531400 [comms::dht::connectivity] DEBUG minimize_connections: Filtered peers: 4, Handles: 4
2024-05-09 16:59:40.211479200 [comms::dht::connectivity] DEBUG minimize_connections: Filtered peers: 5, Handles: 5
2024-05-09 16:59:51.798007000 [comms::dht::connectivity] DEBUG minimize_connections: Filtered peers: 5, Handles: 5
2024-05-09 17:00:06.424634900 [comms::dht::connectivity] DEBUG minimize_connections: Filtered peers: 5, Handles: 5
2024-05-09 17:00:15.098731700 [comms::dht::connectivity] DEBUG minimize_connections: Filtered peers: 5, Handles: 5
2024-05-09 17:01:34.202148100 [comms::dht::connectivity] DEBUG minimize_connections: Filtered peers: 6, Handles: 6
2024-05-09 17:01:48.869645800 [comms::connectivity::manager] DEBUG minimize_connections: Filtered peers: 10, Handles: 11
2024-05-09 17:01:48.869650900 [comms::connectivity::manager] DEBUG minimize_connections: Disconnecting 'b93ca6de3f1cabbd3a40581224' because the node is not among the 6 closest peers
2024-05-09 17:01:48.869876100 [comms::connectivity::manager] DEBUG minimize_connections: Disconnecting 'b12bdf00bfb5d3c32c235fd2cb' because the node is not among the 6 closest peers
2024-05-09 17:01:48.870090800 [comms::connectivity::manager] DEBUG minimize_connections: Disconnecting '305cd9f487aa9e58f884f534c4' because the node is not among the 6 closest peers
2024-05-09 17:01:48.870431900 [comms::connectivity::manager] DEBUG minimize_connections: Disconnecting '54e1ea3aa6646c75f3247aeab1' because the node is not among the 6 closest peers
2024-05-09 17:04:48.868549100 [comms::connectivity::manager] DEBUG minimize_connections: Filtered peers: 6, Handles: 7
2024-05-09 17:07:48.870620800 [comms::connectivity::manager] DEBUG minimize_connections: Filtered peers: 6, Handles: 7
2024-05-09 17:10:48.883504000 [comms::connectivity::manager] DEBUG minimize_connections: Filtered peers: 6, Handles: 7
2024-05-09 17:13:48.885640800 [comms::connectivity::manager] DEBUG minimize_connections: Filtered peers: 6, Handles: 7
2024-05-09 17:16:48.895746200 [comms::connectivity::manager] DEBUG minimize_connections: Filtered peers: 6, Handles: 7
2024-05-09 17:19:48.909768500 [comms::connectivity::manager] DEBUG minimize_connections: Filtered peers: 6, Handles: 7
2024-05-09 17:20:13.246169600 [comms::dht::connectivity] DEBUG minimize_connections: Filtered peers: 6, Handles: 6
2024-05-09 17:22:48.910592100 [comms::connectivity::manager] DEBUG minimize_connections: Filtered peers: 7, Handles: 8
2024-05-09 17:22:48.910598000 [comms::connectivity::manager] DEBUG minimize_connections: Disconnecting 'e9f94287e9893c4934f89edce7' because the node is not among the 6 closest peers
2024-05-09 17:25:48.919283400 [comms::connectivity::manager] DEBUG minimize_connections: Filtered peers: 6, Handles: 7
```
```rust
2024-05-09 16:59:13.888003200 [comms::dht::connectivity] DEBUG DHT connectivity status: neighbour pool: 4/5 (0 connected), random pool: 1/1 (0 connected, last refreshed 900ns ago), active DHT connections: 0/6
2024-05-09 17:00:35.789826900 [comms::dht::connectivity] DEBUG DHT connectivity status: neighbour pool: 5/5 (4 connected), random pool: 1/1 (0 connected, last refreshed 78s ago), active DHT connections: 5/6
2024-05-09 17:00:35.789851700 [comms::dht::connectivity] DEBUG DHT connectivity status: neighbour pool: 5/5 (4 connected), random pool: 1/1 (0 connected, last refreshed 78s ago), active DHT connections: 5/6
2024-05-09 17:02:42.134128800 [comms::dht::connectivity] DEBUG DHT connectivity status: neighbour pool: 5/5 (0 connected), random pool: 1/1 (0 connected, last refreshed 59s ago), active DHT connections: 6/6
2024-05-09 17:02:42.134163900 [comms::dht::connectivity] DEBUG DHT connectivity status: neighbour pool: 5/5 (0 connected), random pool: 1/1 (0 connected, last refreshed 59s ago), active DHT connections: 6/6
2024-05-09 17:03:11.289312400 [comms::dht::connectivity] DEBUG DHT connectivity status: neighbour pool: 5/5 (0 connected), random pool: 1/1 (0 connected, last refreshed 88s ago), active DHT connections: 6/6
2024-05-09 17:03:11.289348400 [comms::dht::connectivity] DEBUG DHT connectivity status: neighbour pool: 5/5 (0 connected), random pool: 1/1 (0 connected, last refreshed 88s ago), active DHT connections: 6/6
2024-05-09 17:03:15.884240000 [comms::dht::connectivity] DEBUG DHT connectivity status: neighbour pool: 5/5 (0 connected), random pool: 1/1 (1 connected, last refreshed 93s ago), active DHT connections: 6/6
2024-05-09 17:03:15.884288100 [comms::dht::connectivity] DEBUG DHT connectivity status: neighbour pool: 5/5 (0 connected), random pool: 1/1 (1 connected, last refreshed 93s ago), active DHT connections: 6/6
2024-05-09 17:03:17.350056500 [comms::dht::connectivity] DEBUG DHT connectivity status: neighbour pool: 5/5 (0 connected), random pool: 1/1 (1 connected, last refreshed 94s ago), active DHT connections: 6/6
2024-05-09 17:03:17.350087200 [comms::dht::connectivity] DEBUG DHT connectivity status: neighbour pool: 5/5 (0 connected), random pool: 1/1 (1 connected, last refreshed 94s ago), active DHT connections: 6/6
2024-05-09 17:03:21.324948500 [comms::dht::connectivity] DEBUG DHT connectivity status: neighbour pool: 5/5 (0 connected), random pool: 1/1 (1 connected, last refreshed 98s ago), active DHT connections: 6/6
2024-05-09 17:03:21.324980600 [comms::dht::connectivity] DEBUG DHT connectivity status: neighbour pool: 5/5 (0 connected), random pool: 1/1 (1 connected, last refreshed 98s ago), active DHT connections: 6/6
2024-05-09 17:03:36.180570200 [comms::dht::connectivity] DEBUG DHT connectivity status: neighbour pool: 5/5 (0 connected), random pool: 1/1 (1 connected, last refreshed 113s ago), active DHT connections: 6/6
2024-05-09 17:03:36.180604500 [comms::dht::connectivity] DEBUG DHT connectivity status: neighbour pool: 5/5 (0 connected), random pool: 1/1 (1 connected, last refreshed 113s ago), active DHT connections: 6/6
2024-05-09 17:03:47.654100000 [comms::dht::connectivity] DEBUG DHT connectivity status: neighbour pool: 4/5 (0 connected), random pool: 1/1 (1 connected, last refreshed 124s ago), active DHT connections: 6/6
2024-05-09 17:03:47.654120200 [comms::dht::connectivity] DEBUG DHT connectivity status: neighbour pool: 4/5 (0 connected), random pool: 1/1 (1 connected, last refreshed 124s ago), active DHT connections: 6/6
2024-05-09 17:04:13.887169600 [comms::dht::connectivity] DEBUG DHT connectivity status: neighbour pool: 4/5 (0 connected), random pool: 1/1 (1 connected, last refreshed 151s ago), active DHT connections: 6/6
2024-05-09 17:04:14.062651100 [comms::dht::connectivity] DEBUG DHT connectivity status: neighbour pool: 3/5 (0 connected), random pool: 1/1 (1 connected, last refreshed 151s ago), active DHT connections: 6/6
2024-05-09 17:04:14.062669400 [comms::dht::connectivity] DEBUG DHT connectivity status: neighbour pool: 3/5 (0 connected), random pool: 1/1 (1 connected, last refreshed 151s ago), active DHT connections: 6/6
2024-05-09 17:04:17.893635900 [comms::dht::connectivity] DEBUG DHT connectivity status: neighbour pool: 2/5 (0 connected), random pool: 1/1 (1 connected, last refreshed 155s ago), active DHT connections: 6/6
2024-05-09 17:04:17.893652200 [comms::dht::connectivity] DEBUG DHT connectivity status: neighbour pool: 2/5 (0 connected), random pool: 1/1 (1 connected, last refreshed 155s ago), active DHT connections: 6/6
2024-05-09 17:04:59.589188600 [comms::dht::connectivity] DEBUG DHT connectivity status: neighbour pool: 1/5 (0 connected), random pool: 1/1 (1 connected, last refreshed 196s ago), active DHT connections: 6/6
2024-05-09 17:04:59.589202800 [comms::dht::connectivity] DEBUG DHT connectivity status: neighbour pool: 1/5 (0 connected), random pool: 1/1 (1 connected, last refreshed 196s ago), active DHT connections: 6/6
2024-05-09 17:05:00.693970600 [comms::dht::connectivity] DEBUG DHT connectivity status: neighbour pool: 0/5 (0 connected), random pool: 1/1 (1 connected, last refreshed 197s ago), active DHT connections: 6/6
2024-05-09 17:05:00.693978600 [comms::dht::connectivity] DEBUG DHT connectivity status: neighbour pool: 0/5 (0 connected), random pool: 1/1 (1 connected, last refreshed 197s ago), active DHT connections: 6/6
2024-05-09 17:09:13.888616000 [comms::dht::connectivity] DEBUG DHT connectivity status: neighbour pool: 0/5 (0 connected), random pool: 1/1 (1 connected, last refreshed 451s ago), active DHT connections: 6/6
2024-05-09 17:14:13.888027100 [comms::dht::connectivity] DEBUG DHT connectivity status: neighbour pool: 0/5 (0 connected), random pool: 1/1 (1 connected, last refreshed 751s ago), active DHT connections: 6/6
2024-05-09 17:19:13.887787200 [comms::dht::connectivity] DEBUG DHT connectivity status: neighbour pool: 0/5 (0 connected), random pool: 1/1 (1 connected, last refreshed 1051s ago), active DHT connections: 6/6
2024-05-09 17:24:13.885459600 [comms::dht::connectivity] DEBUG DHT connectivity status: neighbour pool: 0/5 (0 connected), random pool: 1/1 (1 connected, last refreshed 1351s ago), active DHT connections: 6/6
```
In contrast to the wallet, these results for a fresh base node during the same period:
```rust
2024-05-09 16:58:48.018109100 [comms::dht::connectivity] DEBUG DHT connectivity status: neighbour pool: 8/8 (0 connected), random pool: 4/4 (0 connected, last refreshed 11µs ago), active DHT connections: 0/12
2024-05-09 17:00:06.125021800 [comms::dht::connectivity] DEBUG DHT connectivity status: neighbour pool: 8/8 (7 connected), random pool: 4/4 (3 connected, last refreshed 65s ago), active DHT connections: 11/12
2024-05-09 17:00:06.125044000 [comms::dht::connectivity] DEBUG DHT connectivity status: neighbour pool: 8/8 (7 connected), random pool: 4/4 (3 connected, last refreshed 65s ago), active DHT connections: 11/12
2024-05-09 17:00:35.062813300 [comms::dht::connectivity] DEBUG DHT connectivity status: neighbour pool: 8/8 (0 connected), random pool: 4/4 (1 connected, last refreshed 10s ago), active DHT connections: 10/12
2024-05-09 17:00:35.062849200 [comms::dht::connectivity] DEBUG DHT connectivity status: neighbour pool: 8/8 (0 connected), random pool: 4/4 (1 connected, last refreshed 10s ago), active DHT connections: 10/12
2024-05-09 17:00:38.762475500 [comms::dht::connectivity] DEBUG DHT connectivity status: neighbour pool: 8/8 (0 connected), random pool: 4/4 (1 connected, last refreshed 14s ago), active DHT connections: 10/12
2024-05-09 17:00:38.762518300 [comms::dht::connectivity] DEBUG DHT connectivity status: neighbour pool: 8/8 (0 connected), random pool: 4/4 (1 connected, last refreshed 14s ago), active DHT connections: 10/12
2024-05-09 17:00:48.026914700 [comms::dht::connectivity] DEBUG DHT connectivity status: neighbour pool: 8/8 (0 connected), random pool: 4/4 (1 connected, last refreshed 23s ago), active DHT connections: 12/12
2024-05-09 17:01:26.772288600 [comms::dht::connectivity] DEBUG DHT connectivity status: neighbour pool: 8/8 (2 connected), random pool: 4/4 (4 connected, last refreshed 62s ago), active DHT connections: 17/12
2024-05-09 17:01:26.772317900 [comms::dht::connectivity] DEBUG DHT connectivity status: neighbour pool: 8/8 (2 connected), random pool: 4/4 (4 connected, last refreshed 62s ago), active DHT connections: 17/12
2024-05-09 17:02:48.023292100 [comms::dht::connectivity] DEBUG DHT connectivity status: neighbour pool: 8/8 (0 connected), random pool: 4/4 (4 connected, last refreshed 143s ago), active DHT connections: 18/12
2024-05-09 17:04:48.025758700 [comms::dht::connectivity] DEBUG DHT connectivity status: neighbour pool: 8/8 (0 connected), random pool: 4/4 (4 connected, last refreshed 263s ago), active DHT connections: 18/12
2024-05-09 17:06:48.023565000 [comms::dht::connectivity] DEBUG DHT connectivity status: neighbour pool: 8/8 (0 connected), random pool: 4/4 (4 connected, last refreshed 383s ago), active DHT connections: 18/12
2024-05-09 17:08:48.023885600 [comms::dht::connectivity] DEBUG DHT connectivity status: neighbour pool: 8/8 (0 connected), random pool: 4/4 (4 connected, last refreshed 503s ago), active DHT connections: 18/12
2024-05-09 17:10:48.026087000 [comms::dht::connectivity] DEBUG DHT connectivity status: neighbour pool: 8/8 (0 connected), random pool: 4/4 (4 connected, last refreshed 623s ago), active DHT connections: 18/12
2024-05-09 17:12:48.025937800 [comms::dht::connectivity] DEBUG DHT connectivity status: neighbour pool: 8/8 (0 connected), random pool: 4/4 (4 connected, last refreshed 743s ago), active DHT connections: 18/12
2024-05-09 17:14:48.022341700 [comms::dht::connectivity] DEBUG DHT connectivity status: neighbour pool: 8/8 (0 connected), random pool: 4/4 (3 connected, last refreshed 863s ago), active DHT connections: 19/12
2024-05-09 17:16:48.016408600 [comms::dht::connectivity] DEBUG DHT connectivity status: neighbour pool: 8/8 (0 connected), random pool: 4/4 (3 connected, last refreshed 983s ago), active DHT connections: 19/12
2024-05-09 17:18:48.021984800 [comms::dht::connectivity] DEBUG DHT connectivity status: neighbour pool: 8/8 (0 connected), random pool: 4/4 (3 connected, last refreshed 1103s ago), active DHT connections: 19/12
2024-05-09 17:20:48.018004600 [comms::dht::connectivity] DEBUG DHT connectivity status: neighbour pool: 8/8 (0 connected), random pool: 4/4 (3 connected, last refreshed 1223s ago), active DHT connections: 20/12
2024-05-09 17:20:52.757274600 [comms::dht::connectivity] DEBUG DHT connectivity status: neighbour pool: 8/8 (0 connected), random pool: 4/4 (3 connected, last refreshed 1228s ago), active DHT connections: 20/12
2024-05-09 17:20:52.757311800 [comms::dht::connectivity] DEBUG DHT connectivity status: neighbour pool: 8/8 (0 connected), random pool: 4/4 (3 connected, last refreshed 1228s ago), active DHT connections: 20/12
2024-05-09 17:22:48.022367900 [comms::dht::connectivity] DEBUG DHT connectivity status: neighbour pool: 8/8 (0 connected), random pool: 4/4 (3 connected, last refreshed 1343s ago), active DHT connections: 21/12
2024-05-09 17:24:48.026643700 [comms::dht::connectivity] DEBUG DHT connectivity status: neighbour pool: 8/8 (0 connected), random pool: 4/4 (3 connected, last refreshed 1463s ago), active DHT connections: 22/12
2024-05-09 17:26:48.025649400 [comms::dht::connectivity] DEBUG DHT connectivity status: neighbour pool: 8/8 (0 connected), random pool: 4/4 (3 connected, last refreshed 1583s ago), active DHT connections: 22/12
2024-05-09 17:28:48.015161100 [comms::dht::connectivity] DEBUG DHT connectivity status: neighbour pool: 8/8 (0 connected), random pool: 4/4 (3 connected, last refreshed 1703s ago), active DHT connections: 22/12
```

What process can a PR reviewer use to test or verify this change?
---
- Code review
- System-level testing on `nextnet`

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
