### PR TITLE
fix: reload old wallets

### DIFF
--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -772,7 +772,10 @@ pub fn read_or_create_wallet_type<T: WalletBackend + 'static>(
 
     match (db_wallet_type, wallet_type) {
         (None, None) => {
-            panic!("Something is very wrong, no wallet type was found in the DB, or provided (on first run)")
+            // this is most likely an older wallet pre ledger support, lets put it in software
+            let wallet_type = WalletType::Software;
+            db.set_wallet_type(wallet_type)?;
+            Ok(wallet_type)
         },
         (None, Some(t)) => {
             db.set_wallet_type(t)?;


### PR DESCRIPTION
Description
---
This allows older wallets that dont have a type stored in the DB to load up as software wallets.

Motivation and Context
---
If this type is not stored, either the entire DB is corrupted or its an older wallet without a type stored. 
If the DB is corrupted it would very likely fail earlier, or if not later. But older correct wallets should not be blocked from booting up

How Has This Been Tested?
---
Manual
