### PR TITLE
chore: prevent spam logs

### DIFF
--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -1647,12 +1647,6 @@ impl LMDBDatabase {
         output_hash: &[u8],
     ) -> Result<Option<OutputMinedInfo>, ChainStorageError> {
         if let Some(key) = lmdb_get::<_, Vec<u8>>(txn, &self.txos_hash_to_index_db, output_hash)? {
-            debug!(
-                target: LOG_TARGET,
-                "Fetch output: {} Found ({})",
-                to_hex(output_hash),
-                key.to_hex()
-            );
             match lmdb_get::<_, TransactionOutputRowData>(txn, &self.utxos_db, &key)? {
                 Some(TransactionOutputRowData {
                     output: o,
@@ -1670,11 +1664,6 @@ impl LMDBDatabase {
                 _ => Ok(None),
             }
         } else {
-            debug!(
-                target: LOG_TARGET,
-                "Fetch output: {} NOT found in index",
-                to_hex(output_hash)
-            );
             Ok(None)
         }
     }
@@ -1685,12 +1674,6 @@ impl LMDBDatabase {
         output_hash: &[u8],
     ) -> Result<Option<InputMinedInfo>, ChainStorageError> {
         if let Some(key) = lmdb_get::<_, Vec<u8>>(txn, &self.deleted_txo_hash_to_header_index, output_hash)? {
-            debug!(
-                target: LOG_TARGET,
-                "Fetch input: {} Found ({})",
-                to_hex(output_hash),
-                key.to_hex()
-            );
             match lmdb_get::<_, TransactionInputRowData>(txn, &self.inputs_db, &key)? {
                 Some(TransactionInputRowData {
                     input: i,
@@ -1708,11 +1691,6 @@ impl LMDBDatabase {
                 _ => Ok(None),
             }
         } else {
-            debug!(
-                target: LOG_TARGET,
-                "Fetch input: {} NOT found in index",
-                to_hex(output_hash)
-            );
             Ok(None)
         }
     }


### PR DESCRIPTION
Description
---
Prevent spam logs from `lmdb_db.r`s when many inputs and outputs are present in the blockchain.

Motivation and Context
---
With many inputs and outputs in the blockchain the base node logs are filled up with logs fetching inputs and outputs. Important log messages go missing due to being _rolled over_ when the file and size limits are reached.

The image below illustrates this, where 200MB log files are rolled over in less than 10 minutes.

![image](https://github.com/tari-project/tari/assets/39146854/77f2dace-471f-4be9-859d-702044441b2f)


How Has This Been Tested?
---
System-level stress testing.

What process can a PR reviewer use to test or verify this change?
---
Review code change.

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
