### PR TITLE
feat!: remove user agent config option

### DIFF
--- a/applications/minotari_console_wallet/src/config.rs
+++ b/applications/minotari_console_wallet/src/config.rs
@@ -45,8 +45,6 @@ impl ApplicationConfig {
             peer_seeds: PeerSeedsConfig::load_from(cfg)?,
         };
 
-        config.wallet.p2p.user_agent = format!("tari/wallet/{}", consts::APP_VERSION_NUMBER);
-
         config.wallet.set_base_path(config.common.base_path());
         Ok(config)
     }

--- a/applications/minotari_console_wallet/src/init/mod.rs
+++ b/applications/minotari_console_wallet/src/init/mod.rs
@@ -27,7 +27,7 @@ use std::{fs, io, path::PathBuf, str::FromStr, sync::Arc, time::Instant};
 #[cfg(feature = "ledger")]
 use ledger_transport_hid::{hidapi::HidApi, TransportNativeHID};
 use log::*;
-use minotari_app_utilities::identity_management::setup_node_identity;
+use minotari_app_utilities::{consts, identity_management::setup_node_identity};
 use minotari_wallet::{
     error::{WalletError, WalletStorageError},
     output_manager_service::storage::database::OutputManagerDatabase,
@@ -449,7 +449,7 @@ pub async fn init_wallet(
     let factories = CryptoFactories::default();
 
     let now = Instant::now();
-
+    let user_agent = format!("tari/wallet/{}", consts::APP_VERSION_NUMBER);
     let mut wallet = Wallet::start(
         wallet_config,
         config.peer_seeds.clone(),
@@ -466,6 +466,7 @@ pub async fn init_wallet(
         shutdown_signal,
         master_seed,
         wallet_type.unwrap(),
+        user_agent,
     )
     .await
     .map_err(|e| match e {

--- a/applications/minotari_node/src/bootstrap.rs
+++ b/applications/minotari_node/src/bootstrap.rs
@@ -122,9 +122,11 @@ where B: BlockchainBackend + 'static
             .map_err(|e| ExitError::new(ExitCode::ConfigError, e))?;
         p2p_config.transport.tor.identity = tor_identity;
 
+        let user_agent = format!("tari/basenode/{}", consts::APP_VERSION_NUMBER);
         let mut handles = StackBuilder::new(self.interrupt_signal)
             .add_initializer(P2pInitializer::new(
                 p2p_config.clone(),
+                user_agent,
                 peer_seeds.clone(),
                 base_node_config.network,
                 self.node_identity.clone(),

--- a/applications/minotari_node/src/config.rs
+++ b/applications/minotari_node/src/config.rs
@@ -27,7 +27,6 @@ use std::{
 };
 
 use config::Config;
-use minotari_app_utilities::consts;
 use serde::{Deserialize, Serialize};
 use tari_common::{
     configuration::{serializers, CommonConfig, Network, StringList},
@@ -149,7 +148,6 @@ impl Default for BaseNodeConfig {
     fn default() -> Self {
         let p2p = P2pConfig {
             datastore_path: PathBuf::from("peer_db/base_node"),
-            user_agent: format!("tari/basenode/{}", consts::APP_VERSION_NUMBER),
             ..Default::default()
         };
         Self {

--- a/base_layer/chat_ffi/src/lib.rs
+++ b/base_layer/chat_ffi/src/lib.rs
@@ -147,8 +147,8 @@ pub unsafe extern "C" fn create_chat_client(
             return ptr::null_mut();
         },
     };
-
-    let mut client = Client::new(identity, (*config).clone());
+    let user_agent = format!("tari/chat_ffi/{}", env!("CARGO_PKG_VERSION"));
+    let mut client = Client::new(identity, (*config).clone(), user_agent);
 
     if let Ok(()) = runtime.block_on(client.initialize()) {
         let contacts_handler = match client.contacts.clone() {
@@ -247,8 +247,8 @@ pub unsafe extern "C" fn sideload_chat_client(
         ptr::swap(error_out, &mut error as *mut c_int);
         return ptr::null_mut();
     }
-
-    let mut client = Client::sideload((*config).clone(), (*contacts_handle).clone());
+    let user_agent = format!("tari/chat_ffi/{}", env!("CARGO_PKG_VERSION"));
+    let mut client = Client::sideload((*config).clone(), (*contacts_handle).clone(), user_agent);
     if let Ok(()) = runtime.block_on(client.initialize()) {
         let mut callback_handler = CallbackHandler::new(
             (*contacts_handle).clone(),

--- a/base_layer/contacts/src/chat_client/src/config.rs
+++ b/base_layer/contacts/src/chat_client/src/config.rs
@@ -26,7 +26,6 @@ use std::{
 };
 
 use config::Config;
-use minotari_app_utilities::consts;
 use serde::{Deserialize, Serialize};
 use tari_common::{
     configuration::{serializers, CommonConfig, Network, StringList},
@@ -100,7 +99,6 @@ impl Default for ChatClientConfig {
     fn default() -> Self {
         let p2p = P2pConfig {
             datastore_path: PathBuf::from("peer_db/chat_client"),
-            user_agent: format!("tari/chat_client/{}", consts::APP_VERSION_NUMBER),
             dht: DhtConfig {
                 database_url: DbConnectionUrl::file("data/chat_client/dht.sqlite"),
                 ..Default::default()
@@ -163,7 +161,6 @@ impl ChatClientConfig {
             log_verbosity: Some(5), // Trace
             p2p: P2pConfig {
                 datastore_path: PathBuf::from("peer_db/chat_client"),
-                user_agent: format!("tari/chat_client/{}", consts::APP_VERSION_NUMBER),
                 dht: DhtConfig {
                     database_url: DbConnectionUrl::file("data/chat_client/dht.sqlite"),
                     network_discovery: NetworkDiscoveryConfig {

--- a/base_layer/contacts/src/chat_client/src/networking.rs
+++ b/base_layer/contacts/src/chat_client/src/networking.rs
@@ -53,6 +53,7 @@ pub async fn start(
     node_identity: Arc<NodeIdentity>,
     config: ApplicationConfig,
     shutdown_signal: ShutdownSignal,
+    user_agent: String,
 ) -> Result<(ContactsServiceHandle, CommsNode), NetworkingError> {
     create_chat_storage(&config.chat_client.db_file)?;
     let backend = connect_to_db(config.chat_client.db_file)?;
@@ -69,6 +70,7 @@ pub async fn start(
     let fut = StackBuilder::new(shutdown_signal)
         .add_initializer(P2pInitializer::new(
             p2p_config.clone(),
+            user_agent,
             config.peer_seeds.clone(),
             config.chat_client.network,
             node_identity,

--- a/base_layer/contacts/tests/contacts_service.rs
+++ b/base_layer/contacts/tests/contacts_service.rs
@@ -93,16 +93,17 @@ pub fn setup_contacts_service<T: ContactsBackend + 'static>(
         allow_test_addresses: true,
         listener_liveness_allowlist_cidrs: StringList::new(),
         listener_liveness_max_sessions: 0,
-        user_agent: "tari/test-contacts-service".to_string(),
         rpc_max_simultaneous_sessions: 0,
         rpc_max_sessions_per_peer: 0,
         listener_self_liveness_check_interval: None,
     };
     let peer_message_subscription_factory = Arc::new(subscription_factory);
     let shutdown = Shutdown::new();
+    let user_agent = format!("tari/tests/{}", env!("CARGO_PKG_VERSION"));
     let fut = StackBuilder::new(shutdown.to_signal())
         .add_initializer(P2pInitializer::new(
             comms_config,
+            user_agent,
             PeerSeedsConfig::default(),
             Network::LocalNet,
             node_identity.clone(),

--- a/base_layer/p2p/src/config.rs
+++ b/base_layer/p2p/src/config.rs
@@ -115,8 +115,6 @@ pub struct P2pConfig {
     pub listener_self_liveness_check_interval: Option<Duration>,
     /// CIDR for addresses allowed to enter into liveness check mode on the listener.
     pub listener_liveness_allowlist_cidrs: StringList,
-    /// User agent string for this node
-    pub user_agent: String,
     /// The address to bind on using the TCP transport _in addition to_ the primary transport. This is typically useful
     /// for direct comms between a wallet and base node. If this is set to None, no listener will be bound.
     /// Default: None
@@ -148,7 +146,6 @@ impl Default for P2pConfig {
             listener_liveness_max_sessions: 0,
             listener_self_liveness_check_interval: None,
             listener_liveness_allowlist_cidrs: StringList::default(),
-            user_agent: String::new(),
             auxiliary_tcp_listener_address: None,
             rpc_max_simultaneous_sessions: 100,
             rpc_max_sessions_per_peer: 10,

--- a/base_layer/p2p/src/initialization.rs
+++ b/base_layer/p2p/src/initialization.rs
@@ -445,6 +445,7 @@ pub async fn add_seed_peers(
 
 pub struct P2pInitializer {
     config: P2pConfig,
+    user_agent: String,
     seed_config: PeerSeedsConfig,
     network: Network,
     node_identity: Arc<NodeIdentity>,
@@ -454,6 +455,7 @@ pub struct P2pInitializer {
 impl P2pInitializer {
     pub fn new(
         config: P2pConfig,
+        user_agent: String,
         seed_config: PeerSeedsConfig,
         network: Network,
         node_identity: Arc<NodeIdentity>,
@@ -461,6 +463,7 @@ impl P2pInitializer {
     ) -> Self {
         Self {
             config,
+            user_agent,
             seed_config,
             network,
             node_identity,
@@ -557,7 +560,7 @@ impl ServiceInitializer for P2pInitializer {
                 major_version: MAJOR_NETWORK_VERSION,
                 minor_version: MINOR_NETWORK_VERSION,
                 network_byte: self.network.as_byte(),
-                user_agent: config.user_agent.clone(),
+                user_agent: self.user_agent.clone(),
             })
             .set_self_liveness_check(config.listener_self_liveness_check_interval);
 

--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -167,6 +167,7 @@ where
         shutdown_signal: ShutdownSignal,
         master_seed: CipherSeed,
         wallet_type: WalletType,
+        user_agent: String,
     ) -> Result<Self, WalletError> {
         let buf_size = cmp::max(WALLET_BUFFER_MIN_SIZE, config.buffer_size);
         let (publisher, subscription_factory) = pubsub_connector(buf_size);
@@ -189,6 +190,7 @@ where
         let stack = StackBuilder::new(shutdown_signal)
             .add_initializer(P2pInitializer::new(
                 config.p2p.clone(),
+                user_agent,
                 peer_seeds,
                 config.network,
                 node_identity.clone(),

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -4869,7 +4869,6 @@ pub unsafe extern "C" fn comms_config_create(
                 allow_test_addresses: true,
                 listener_liveness_allowlist_cidrs: StringList::new(),
                 listener_liveness_max_sessions: 0,
-                user_agent: format!("tari/mobile_wallet/{}", env!("CARGO_PKG_VERSION")),
                 rpc_max_simultaneous_sessions: 0,
                 rpc_max_sessions_per_peer: 0,
                 listener_self_liveness_check_interval: None,
@@ -5521,6 +5520,7 @@ pub unsafe extern "C" fn wallet_create(
         },
     };
 
+    let user_agent = format!("tari/wallet_ffi/{}", env!("CARGO_PKG_VERSION"));
     let w = runtime.block_on(Wallet::start(
         wallet_config,
         peer_seeds,
@@ -5537,6 +5537,7 @@ pub unsafe extern "C" fn wallet_create(
         shutdown.to_signal(),
         master_seed,
         WalletType::Software,
+        user_agent,
     ));
 
     match w {

--- a/common/config/presets/c_base_node_c.toml
+++ b/common/config/presets/c_base_node_c.toml
@@ -150,9 +150,6 @@ track_reorgs = true
 # Enables periodic socket-level liveness checks. Default: Disabled
 listener_self_liveness_check_interval = 15
 
-# User agent string for this node
-#user_agent = ""
-
 # The maximum simultaneous comms RPC sessions allowed (default value = 100). Setting this to -1 will allow unlimited
 # sessions.
 #rpc_max_simultaneous_sessions = 100

--- a/integration_tests/src/chat_client.rs
+++ b/integration_tests/src/chat_client.rs
@@ -61,8 +61,8 @@ pub async fn spawn_chat_client(name: &str, seed_peers: Vec<Peer>, base_dir: Path
         .map(|p| p.to_short_string())
         .collect::<Vec<String>>()
         .into();
-
-    let mut client = Client::new(identity, config);
+    let user_agent = format!("tari/integration_tests/{}", env!("CARGO_PKG_VERSION"));
+    let mut client = Client::new(identity, config, user_agent);
 
     client.initialize().await.expect("the chat client to spawn");
     client


### PR DESCRIPTION
Description
---
Removes the user-controlled user_agent field from the config and makes this a coded option only. 

Motivation and Context
---
This field is used by the application to report its name to the network. By default for the desktop and mobile apps this option is filled in by the application and reports the name and version of the application. This is very helpful for the network to decern whom they are connection to. 

Leaving this option to user change, makes it very easy to remove this option on an individual bases. Currently Launchpad already does this and only reports like follows:
```
d59a25f5a6855360364af9c2c9 | 02b0d0e37aaded4eac745608fdd6c08ceb06209a4ef5af807560f8fb14b36477 | /onion3/5uatfvtqxoo553k5x7iuel7ezkl5y7c7zy7vhyd3fo24s2yfzepexfid:18141 | Outbound  | 8h 45m 34s   | Launchpad base node        | height: 39379, hnd: 1, ss: 2, rpc: 0 
e9f94287e9893c4934f89edce7 | 826eda735986db5e57b3fd0342f0d9feebacae9329dc40ee74abf20c1d21f46d | /ip4/54.78.252.60/tcp/18189                                            | Outbound  | 10h 31m 52s  | tari/basenode/1.0.0-rc.8   | height: 39378, hnd: 1, ss: 2, rpc: 0 
```

Although this does not stop a user from changing this field, it lifts the barrier to do this by requiring code changes. 


Breaking Changes
---
Removes config option. 
