### PR TITLE
feat!: update key manager hasher labels

### DIFF
--- a/base_layer/key_manager/src/key_manager.rs
+++ b/base_layer/key_manager/src/key_manager.rs
@@ -32,7 +32,7 @@ use tari_crypto::{
 };
 use zeroize::Zeroize;
 
-use crate::{cipher_seed::CipherSeed, KeyManagerDomain, LABEL_DERIVE_KEY};
+use crate::{cipher_seed::CipherSeed, KeyManagerDomain, HASHER_LABEL_DERIVE_KEY};
 
 #[derive(Clone, Derivative, Serialize, Deserialize, Zeroize)]
 #[derivative(Debug)]
@@ -102,7 +102,7 @@ where
         // apply domain separation to generate derive key. Under the hood, the hashing api prepends the length of each
         // piece of data for concatenation, reducing the risk of collisions due to redundancy of variable length
         // input
-        let derive_key = DomainSeparatedHasher::<D, KeyManagerDomain>::new_with_label(LABEL_DERIVE_KEY)
+        let derive_key = DomainSeparatedHasher::<D, KeyManagerDomain>::new_with_label(HASHER_LABEL_DERIVE_KEY)
             .chain(self.seed.entropy())
             .chain(self.branch_seed.as_bytes())
             .chain(key_index.to_le_bytes())

--- a/base_layer/key_manager/src/lib.rs
+++ b/base_layer/key_manager/src/lib.rs
@@ -26,10 +26,10 @@ pub mod schema;
 
 hash_domain!(KeyManagerDomain, "com.tari.base_layer.key_manager", 1);
 
-const LABEL_ARGON_ENCODING: &str = "argon2_encoding";
-const LABEL_CHACHA20_ENCODING: &str = "chacha20_encoding";
-const LABEL_MAC_GENERATION: &str = "mac_generation";
-const LABEL_DERIVE_KEY: &str = "derive_key";
+const HASHER_LABEL_CIPHER_SEED_PBKDF_SALT: &str = "cipher_seed_pbkdf_salt";
+const HASHER_LABEL_CIPHER_SEED_ENCRYPTION_NONCE: &str = "cipher_seed_encryption_nonce";
+const HASHER_LABEL_CIPHER_SEED_MAC: &str = "cipher_seed_mac";
+const HASHER_LABEL_DERIVE_KEY: &str = "derive_key";
 
 hidden_type!(CipherSeedEncryptionKey, SafeArray<u8, CIPHER_SEED_ENCRYPTION_KEY_BYTES>);
 hidden_type!(CipherSeedMacKey, SafeArray< u8, CIPHER_SEED_MAC_KEY_BYTES>);


### PR DESCRIPTION
Description
---
Updates key manager hasher labels used in cipher seeds. Improves the ordering of MAC input data.

Closes #6328.

Motivation and Context
---
The hasher labels used for cipher seeds are vaguely named, which seems like an unnecessary footgun. This PR updates them, incrementing to a new cipher seed version.

We also take the opportunity of a new version to reorganize how cipher seed MAC input data is ordered; specifically, we move the version byte to the front, which is more in line with its use elsewhere. This doesn't impose any particular security concerns (the MAC input data is never directly parsed), but had a bad smell.

How Has This Been Tested?
---
Tests pass.

What process can a PR reviewer use to test or verify this change?
---
Check that the naming change and reordering do what they say on the tin.

Breaking Changes
---
Because the library only supports the most recent cipher seed version, existing cipher seeds will fail to decrypt.

BREAKING CHANGE: Changes the construction of cipher seeds via a new version; older cipher seeds will fail to decrypt.