### PR TITLE
chore: refactor key manager hasher

### DIFF
--- a/base_layer/key_manager/src/key_manager.rs
+++ b/base_layer/key_manager/src/key_manager.rs
@@ -26,13 +26,13 @@ use derivative::Derivative;
 use digest::{consts::U64, typenum::IsEqual, Digest};
 use serde::{Deserialize, Serialize};
 use tari_crypto::{
-    hashing::LengthExtensionAttackResistant,
+    hashing::{DomainSeparatedHasher, LengthExtensionAttackResistant},
     keys::{PublicKey, SecretKey},
     tari_utilities::byte_array::ByteArrayError,
 };
 use zeroize::Zeroize;
 
-use crate::{cipher_seed::CipherSeed, mac_domain_hasher, LABEL_DERIVE_KEY};
+use crate::{cipher_seed::CipherSeed, KeyManagerDomain, LABEL_DERIVE_KEY};
 
 #[derive(Clone, Derivative, Serialize, Deserialize, Zeroize)]
 #[derivative(Debug)]
@@ -102,7 +102,7 @@ where
         // apply domain separation to generate derive key. Under the hood, the hashing api prepends the length of each
         // piece of data for concatenation, reducing the risk of collisions due to redundancy of variable length
         // input
-        let derive_key = mac_domain_hasher::<D>(LABEL_DERIVE_KEY)
+        let derive_key = DomainSeparatedHasher::<D, KeyManagerDomain>::new_with_label(LABEL_DERIVE_KEY)
             .chain(self.seed.entropy())
             .chain(self.branch_seed.as_bytes())
             .chain(key_index.to_le_bytes())

--- a/base_layer/key_manager/src/lib.rs
+++ b/base_layer/key_manager/src/lib.rs
@@ -4,11 +4,7 @@
 use std::str::FromStr;
 
 use cipher_seed::BIRTHDAY_GENESIS_FROM_UNIX_EPOCH;
-use digest::Digest;
-use tari_crypto::{
-    hash_domain,
-    hashing::{DomainSeparatedHasher, LengthExtensionAttackResistant},
-};
+use tari_crypto::hash_domain;
 use tari_utilities::{hidden::Hidden, hidden_type, safe_array::SafeArray};
 use zeroize::Zeroize;
 
@@ -34,12 +30,6 @@ const LABEL_ARGON_ENCODING: &str = "argon2_encoding";
 const LABEL_CHACHA20_ENCODING: &str = "chacha20_encoding";
 const LABEL_MAC_GENERATION: &str = "mac_generation";
 const LABEL_DERIVE_KEY: &str = "derive_key";
-
-pub(crate) fn mac_domain_hasher<D: Digest + LengthExtensionAttackResistant>(
-    label: &'static str,
-) -> DomainSeparatedHasher<D, KeyManagerDomain> {
-    DomainSeparatedHasher::<D, KeyManagerDomain>::new_with_label(label)
-}
 
 hidden_type!(CipherSeedEncryptionKey, SafeArray<u8, CIPHER_SEED_ENCRYPTION_KEY_BYTES>);
 hidden_type!(CipherSeedMacKey, SafeArray< u8, CIPHER_SEED_MAC_KEY_BYTES>);


### PR DESCRIPTION
Description
---
Refactors the key manager hasher for clarity.

Closes #6327.

Motivation and Context
---
The key manager hasher is instantiated using a wrapper function that is poorly named, as it is reused in multiple contexts. This PR refactors for clarity.

How Has This Been Tested?
---
Tests pass.

What process can a PR reviewer use to test or verify this change?
---
Check the refactoring does not change behavior.