### PR TITLE
fix: new monero release for mr support in monero

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3624,9 +3624,9 @@ dependencies = [
 
 [[package]]
 name = "monero"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b205707fd34b01a547f2fe77e687b40fed05966fb82e955b86ac55cd8ee31b5"
+checksum = "f25218523ad4a171ddda05251669afb788cdc2f0df94082aab856a2b09541c3f"
 dependencies = [
  "base58-monero 2.0.0",
  "curve25519-dalek",

--- a/applications/minotari_merge_mining_proxy/Cargo.toml
+++ b/applications/minotari_merge_mining_proxy/Cargo.toml
@@ -35,7 +35,7 @@ hex = "0.4.2"
 hyper = "0.14.12"
 jsonrpc = "0.12.0"
 log = { version = "0.4.8", features = ["std"] }
-monero = { version = "0.20.0" }
+monero = { version = "0.21.0" }
 reqwest = { version = "0.11.4", features = ["json"] }
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.57"

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -71,7 +71,7 @@ ledger-transport-hid = { git = "https://github.com/Zondax/ledger-rs", rev = "20e
 lmdb-zero = "0.4.4"
 log = "0.4"
 log-mdc = "0.1.0"
-monero = { version = "0.20.0", features = ["serde-crate"], optional = true }
+monero = { version = "0.21.0", features = ["serde-crate"], optional = true }
 newtype-ops = "0.1.4"
 num-traits = "0.2.15"
 num-derive = "0.3.3"

--- a/base_layer/core/src/proof_of_work/monero_rx/helpers.rs
+++ b/base_layer/core/src/proof_of_work/monero_rx/helpers.rs
@@ -117,7 +117,7 @@ pub fn verify_header(
     let mut is_found = false;
     let mut already_seen_mmfield = false;
     for item in extra_field.0 {
-        if let SubField::MergeMining(Some(depth), merge_mining_hash) = item {
+        if let SubField::MergeMining(depth, merge_mining_hash) = item {
             if already_seen_mmfield {
                 return Err(MergeMineError::ValidationError(
                     "More than one merge mining tag found in coinbase".to_string(),
@@ -327,7 +327,7 @@ pub fn insert_aux_chain_mr_and_info_into_block<T: AsRef<[u8]>>(
 
     // Adding more than one merge mining tag is not allowed
     for item in &extra_field.0 {
-        if let SubField::MergeMining(Some(_), _) = item {
+        if let SubField::MergeMining(_, _) = item {
             return Err(MergeMineError::ValidationError(
                 "More than one merge mining tag in coinbase not allowed".to_string(),
             ));
@@ -348,7 +348,7 @@ pub fn insert_aux_chain_mr_and_info_into_block<T: AsRef<[u8]>>(
         };
         mt_params.to_varint()
     };
-    extra_field.0.insert(0, SubField::MergeMining(Some(encoded), hash));
+    extra_field.0.insert(0, SubField::MergeMining(encoded, hash));
     debug!(target: LOG_TARGET, "Inserted extra field: {:?}", extra_field);
 
     block.miner_tx.prefix.extra = extra_field.into();

--- a/base_layer/core/src/proof_of_work/monero_rx/helpers.rs
+++ b/base_layer/core/src/proof_of_work/monero_rx/helpers.rs
@@ -901,7 +901,7 @@ mod test {
         // like trying to sneek it in. Later on, when we call `verify_header(&block_header)`, it should fail.
         let mut extra_field = ExtraField::try_parse(&block.miner_tx.prefix.extra).unwrap();
         let hash = monero::Hash::from_slice(hash.as_ref());
-        extra_field.0.insert(0, SubField::MergeMining(Some(VarInt(0)), hash));
+        extra_field.0.insert(0, SubField::MergeMining(VarInt(0), hash));
         block.miner_tx.prefix.extra = extra_field.into();
 
         // Trying to extract the Tari hash will fail because there are more than one merge mining tag
@@ -1267,7 +1267,7 @@ mod test {
         assert!(res.is_err());
         let field = res.unwrap_err();
         let mm_tag = SubField::MergeMining(
-            Some(VarInt(0)),
+            VarInt(0),
             Hash::from_slice(
                 hex::decode("9505c642ae2771f344caddde740ad1c238f7fc17f81c2c515b2cd6d3f2030c46")
                     .unwrap()

--- a/base_layer/core/src/proof_of_work/monero_rx/helpers.rs
+++ b/base_layer/core/src/proof_of_work/monero_rx/helpers.rs
@@ -1009,7 +1009,7 @@ mod test {
         let extra_field_after_tag = ExtraField::try_parse(&block.miner_tx.prefix.extra.clone()).unwrap();
         assert_eq!(
             &format!(
-                "ExtraField([MergeMining(Some(0), 0x{}), \
+                "ExtraField([MergeMining(0, 0x{}), \
                  TxPublicKey(06225b7ec0a6544d8da39abe68d8bd82619b4a7c5bdae89c3783b256a8fa4782), Nonce([246, 58, 168, \
                  109, 46, 133, 127, 7])])",
                 hex::encode(hash)


### PR DESCRIPTION
Description
---
New monero rs release with mr support

Motivation and Context
---
The latest monero rs release now includes the correct support for merge mining by the field not being a simple hash, but rather an encoded u64. This simply bumps the version of monero rs so that we can support multiple merged mined coins. 
