### PR TITLE
feat: generate script challenge on the ledger

### DIFF
--- a/applications/minotari_ledger_wallet/wallet/Cargo.toml
+++ b/applications/minotari_ledger_wallet/wallet/Cargo.toml
@@ -6,6 +6,9 @@ license = "BSD-3-Clause"
 edition = "2021"
 
 [dependencies]
+tari_crypto = { version = "0.20.1", default-features = false, features = ["borsh"]}
+tari_hashing = { path = "../../../hashing", version = "1.0.0-pre.13" }
+
 blake2 = { version = "0.10", default-features = false  }
 borsh = { version = "1.2", default-features = false }
 critical-section = { version = "1.1.1" }
@@ -13,7 +16,6 @@ digest = { version = "0.10", default-features = false }
 embedded-alloc = "0.5.0"
 include_gif = "1.0.1"
 ledger_device_sdk = "1.7.1"
-tari_crypto = { version = "0.20.1", default-features = false, features = ["borsh"]}
 zeroize = { version = "1" , default-features = false }
 
 # once_cell defined here just to lock the version. Other dependencies may try to go to 1.19 which is incompatabile with

--- a/applications/minotari_ledger_wallet/wallet/src/handlers/get_metadata_signature.rs
+++ b/applications/minotari_ledger_wallet/wallet/src/handlers/get_metadata_signature.rs
@@ -15,10 +15,11 @@ use tari_crypto::{
         RistrettoSecretKey,
     },
 };
+use tari_hashing::TransactionHashDomain;
 
 use crate::{
     alloc::string::ToString,
-    hashing::{DomainSeparatedConsensusHasher, TransactionHashDomain},
+    hashing::DomainSeparatedConsensusHasher,
     utils::{derive_from_bip32_key, get_key_from_canonical_bytes},
     AppSW,
     KeyType,

--- a/applications/minotari_ledger_wallet/wallet/src/handlers/get_metadata_signature.rs
+++ b/applications/minotari_ledger_wallet/wallet/src/handlers/get_metadata_signature.rs
@@ -13,7 +13,6 @@ use tari_crypto::{
         RistrettoSecretKey,
     },
 };
-use zeroize::Zeroizing;
 
 use crate::{
     alloc::string::ToString,
@@ -55,11 +54,7 @@ pub fn handler_get_metadata_signature(comm: &mut Comm) -> Result<(), AppSW> {
     let ephemeral_private_key = derive_from_bip32_key(account, ephemeral_private_nonce_index, KeyType::Nonce)?;
     let ephemeral_pubkey = RistrettoPublicKey::from_secret_key(&ephemeral_private_key);
 
-    let sender_offset_private_key = Zeroizing::new(derive_from_bip32_key(
-        account,
-        sender_offset_key_index,
-        KeyType::SenderOffset,
-    )?);
+    let sender_offset_private_key = derive_from_bip32_key(account, sender_offset_key_index, KeyType::SenderOffset)?;
     let sender_offset_public_key = RistrettoPublicKey::from_secret_key(&sender_offset_private_key);
 
     let challenge = finalize_metadata_signature_challenge(

--- a/applications/minotari_ledger_wallet/wallet/src/handlers/get_metadata_signature.rs
+++ b/applications/minotari_ledger_wallet/wallet/src/handlers/get_metadata_signature.rs
@@ -3,6 +3,8 @@
 
 use alloc::format;
 
+use blake2::Blake2b;
+use digest::consts::U64;
 use ledger_device_sdk::{io::Comm, ui::gadgets::SingleMessage};
 use tari_crypto::{
     keys::PublicKey,
@@ -16,7 +18,8 @@ use tari_crypto::{
 
 use crate::{
     alloc::string::ToString,
-    utils::{derive_from_bip32_key, finalize_metadata_signature_challenge, get_key_from_canonical_bytes},
+    hashing::{DomainSeparatedConsensusHasher, TransactionHashDomain},
+    utils::{derive_from_bip32_key, get_key_from_canonical_bytes},
     AppSW,
     KeyType,
     RESPONSE_VERSION,
@@ -91,4 +94,25 @@ pub fn handler_get_metadata_signature(comm: &mut Comm) -> Result<(), AppSW> {
     comm.reply_ok();
 
     Ok(())
+}
+
+fn finalize_metadata_signature_challenge(
+    _version: u64,
+    network: u64,
+    sender_offset_public_key: &RistrettoPublicKey,
+    ephemeral_commitment: &PedersenCommitment,
+    ephemeral_pubkey: &RistrettoPublicKey,
+    commitment: &PedersenCommitment,
+    message: &[u8; 32],
+) -> [u8; 64] {
+    let challenge =
+        DomainSeparatedConsensusHasher::<TransactionHashDomain, Blake2b<U64>>::new("metadata_signature", network)
+            .chain(ephemeral_pubkey)
+            .chain(ephemeral_commitment)
+            .chain(sender_offset_public_key)
+            .chain(commitment)
+            .chain(&message)
+            .finalize();
+
+    challenge.into()
 }

--- a/applications/minotari_ledger_wallet/wallet/src/handlers/get_script_signature.rs
+++ b/applications/minotari_ledger_wallet/wallet/src/handlers/get_script_signature.rs
@@ -20,8 +20,8 @@ use zeroize::Zeroizing;
 
 use crate::{
     alloc::string::ToString,
-    hashing::DomainSeparatedConsensusHasher,
-    utils::{alpha_hasher, derive_from_bip32_key, get_key_from_canonical_bytes, TransactionHashDomain},
+    hashing::{DomainSeparatedConsensusHasher, TransactionHashDomain},
+    utils::{alpha_hasher, derive_from_bip32_key, get_key_from_canonical_bytes},
     AppSW,
     KeyType,
     RESPONSE_VERSION,

--- a/applications/minotari_ledger_wallet/wallet/src/handlers/get_script_signature.rs
+++ b/applications/minotari_ledger_wallet/wallet/src/handlers/get_script_signature.rs
@@ -16,11 +16,12 @@ use tari_crypto::{
         RistrettoSecretKey,
     },
 };
+use tari_hashing::TransactionHashDomain;
 use zeroize::Zeroizing;
 
 use crate::{
     alloc::string::ToString,
-    hashing::{DomainSeparatedConsensusHasher, TransactionHashDomain},
+    hashing::DomainSeparatedConsensusHasher,
     utils::{alpha_hasher, derive_from_bip32_key, get_key_from_canonical_bytes},
     AppSW,
     KeyType,

--- a/applications/minotari_ledger_wallet/wallet/src/handlers/get_script_signature.rs
+++ b/applications/minotari_ledger_wallet/wallet/src/handlers/get_script_signature.rs
@@ -3,97 +3,80 @@
 
 use alloc::format;
 
-use ledger_device_sdk::{io::Comm, ui::gadgets::SingleMessage};
-use tari_crypto::ristretto::{
-    pedersen::extended_commitment_factory::ExtendedPedersenCommitmentFactory,
-    RistrettoComAndPubSig,
-    RistrettoSecretKey,
+use blake2::Blake2b;
+use digest::consts::U64;
+use ledger_device_sdk::{io::Comm, random::Random, ui::gadgets::SingleMessage};
+use tari_crypto::{
+    commitment::HomomorphicCommitmentFactory,
+    keys::PublicKey,
+    ristretto::{
+        pedersen::{extended_commitment_factory::ExtendedPedersenCommitmentFactory, PedersenCommitment},
+        RistrettoComAndPubSig,
+        RistrettoPublicKey,
+        RistrettoSecretKey,
+    },
 };
 use zeroize::Zeroizing;
 
 use crate::{
     alloc::string::ToString,
-    utils::{alpha_hasher, derive_from_bip32_key, get_key_from_canonical_bytes},
+    hashing::DomainSeparatedConsensusHasher,
+    utils::{alpha_hasher, derive_from_bip32_key, get_key_from_canonical_bytes, TransactionHashDomain},
     AppSW,
     KeyType,
     RESPONSE_VERSION,
     STATIC_ALPHA_INDEX,
 };
 
-const MAX_TRANSACTION_LEN: usize = 312;
-pub struct ScriptSignatureCtx {
-    payload: [u8; MAX_TRANSACTION_LEN],
-    payload_len: usize,
-    account: u64,
-}
-
-// Implement constructor for TxInfo with default values
-impl ScriptSignatureCtx {
-    pub fn new() -> Self {
-        Self {
-            payload: [0u8; MAX_TRANSACTION_LEN],
-            payload_len: 0,
-            account: 0,
-        }
-    }
-
-    // Implement reset for TxInfo
-    fn reset(&mut self) {
-        self.payload = [0u8; MAX_TRANSACTION_LEN];
-        self.payload_len = 0;
-        self.account = 0;
-    }
-}
-
-pub fn handler_get_script_signature(
-    comm: &mut Comm,
-    chunk: u8,
-    more: bool,
-    signer_ctx: &mut ScriptSignatureCtx,
-) -> Result<(), AppSW> {
+pub fn handler_get_script_signature(comm: &mut Comm) -> Result<(), AppSW> {
     let data = comm.get_data().map_err(|_| AppSW::WrongApduLength)?;
 
-    if chunk == 0 {
-        // Reset transaction context
-        signer_ctx.reset();
-    }
-
-    if signer_ctx.payload_len + data.len() > MAX_TRANSACTION_LEN {
-        return Err(AppSW::ScriptSignatureFail);
-    }
-
-    // Append data to signer_ctx
-    signer_ctx.payload[signer_ctx.payload_len..signer_ctx.payload_len + data.len()].copy_from_slice(data);
-    signer_ctx.payload_len += data.len();
-
-    // If we expect more chunks, return
-    if more {
-        return Ok(());
-    }
-
-    // Set the account for the transaction
     let mut account_bytes = [0u8; 8];
-    account_bytes.clone_from_slice(&signer_ctx.payload[0..8]);
-    signer_ctx.account = u64::from_le_bytes(account_bytes);
+    account_bytes.clone_from_slice(&data[0..8]);
+    let account = u64::from_le_bytes(account_bytes);
 
-    let alpha = derive_from_bip32_key(signer_ctx.account, STATIC_ALPHA_INDEX, KeyType::Alpha)?;
+    let mut network_bytes = [0u8; 8];
+    network_bytes.clone_from_slice(&data[8..16]);
+    let network = u64::from_le_bytes(network_bytes);
+
+    let mut txi_version_bytes = [0u8; 8];
+    txi_version_bytes.clone_from_slice(&data[16..24]);
+    let txi_version = u64::from_le_bytes(txi_version_bytes);
+
+    let alpha = derive_from_bip32_key(account, STATIC_ALPHA_INDEX, KeyType::Alpha)?;
     let blinding_factor: Zeroizing<RistrettoSecretKey> =
-        get_key_from_canonical_bytes::<RistrettoSecretKey>(&signer_ctx.payload[8..40])?.into();
+        get_key_from_canonical_bytes::<RistrettoSecretKey>(&data[24..56])?.into();
     let script_private_key = alpha_hasher(alpha, blinding_factor)?;
+    let script_public_key = RistrettoPublicKey::from_secret_key(&script_private_key);
 
     let value: Zeroizing<RistrettoSecretKey> =
-        get_key_from_canonical_bytes::<RistrettoSecretKey>(&signer_ctx.payload[40..72])?.into();
+        get_key_from_canonical_bytes::<RistrettoSecretKey>(&data[56..88])?.into();
     let spend_private_key: Zeroizing<RistrettoSecretKey> =
-        get_key_from_canonical_bytes::<RistrettoSecretKey>(&signer_ctx.payload[72..104])?.into();
-    let r_a: Zeroizing<RistrettoSecretKey> =
-        get_key_from_canonical_bytes::<RistrettoSecretKey>(&signer_ctx.payload[104..136])?.into();
-    let r_x: Zeroizing<RistrettoSecretKey> =
-        get_key_from_canonical_bytes::<RistrettoSecretKey>(&signer_ctx.payload[136..168])?.into();
-    let r_y: Zeroizing<RistrettoSecretKey> =
-        get_key_from_canonical_bytes::<RistrettoSecretKey>(&signer_ctx.payload[168..200])?.into();
-    let challenge = &signer_ctx.payload[200..264];
+        get_key_from_canonical_bytes::<RistrettoSecretKey>(&data[88..120])?.into();
+
+    let commitment: PedersenCommitment = get_key_from_canonical_bytes(&data[120..152])?;
+
+    let mut script_message = [0u8; 32];
+    script_message.clone_from_slice(&data[152..184]);
+
+    let r_a = derive_from_bip32_key(account, u32::random().into(), KeyType::Nonce)?;
+    let r_x = derive_from_bip32_key(account, u32::random().into(), KeyType::Nonce)?;
+    let r_y = derive_from_bip32_key(account, u32::random().into(), KeyType::Nonce)?;
 
     let factory = ExtendedPedersenCommitmentFactory::default();
+
+    let ephemeral_commitment = factory.commit(&r_x, &r_a);
+    let ephemeral_pubkey = RistrettoPublicKey::from_secret_key(&r_y);
+
+    let challenge = finalize_script_signature_challenge(
+        txi_version,
+        network,
+        &ephemeral_commitment,
+        &ephemeral_pubkey,
+        &script_public_key,
+        &commitment,
+        &script_message,
+    );
 
     let script_signature = match RistrettoComAndPubSig::sign(
         &value,
@@ -114,8 +97,26 @@ pub fn handler_get_script_signature(
 
     comm.append(&[RESPONSE_VERSION]); // version
     comm.append(&script_signature.to_vec());
-    signer_ctx.reset();
     comm.reply_ok();
 
     Ok(())
+}
+
+fn finalize_script_signature_challenge(
+    _version: u64,
+    network: u64,
+    ephemeral_commitment: &PedersenCommitment,
+    ephemeral_pubkey: &RistrettoPublicKey,
+    script_public_key: &RistrettoPublicKey,
+    commitment: &PedersenCommitment,
+    message: &[u8; 32],
+) -> [u8; 64] {
+    DomainSeparatedConsensusHasher::<TransactionHashDomain, Blake2b<U64>>::new("script_challenge", network)
+        .chain(ephemeral_commitment)
+        .chain(ephemeral_pubkey)
+        .chain(script_public_key)
+        .chain(commitment)
+        .chain(message)
+        .finalize()
+        .into()
 }

--- a/applications/minotari_ledger_wallet/wallet/src/hashing.rs
+++ b/applications/minotari_ledger_wallet/wallet/src/hashing.rs
@@ -6,7 +6,15 @@ use core::marker::PhantomData;
 
 use borsh::{io, io::Write, BorshSerialize};
 use digest::Digest;
-use tari_crypto::hashing::DomainSeparation;
+use tari_crypto::{hash_domain, hashing::DomainSeparation};
+
+hash_domain!(LedgerHashDomain, "com.tari.minotari_ledger_wallet", 0);
+hash_domain!(
+    KeyManagerTransactionsHashDomain,
+    "com.tari.base_layer.core.transactions.key_manager",
+    1
+);
+hash_domain!(TransactionHashDomain, "com.tari.base_layer.core.transactions", 0);
 
 pub struct DomainSeparatedConsensusHasher<M, D> {
     hasher: DomainSeparatedBorshHasher<M, D>,

--- a/applications/minotari_ledger_wallet/wallet/src/hashing.rs
+++ b/applications/minotari_ledger_wallet/wallet/src/hashing.rs
@@ -6,15 +6,7 @@ use core::marker::PhantomData;
 
 use borsh::{io, io::Write, BorshSerialize};
 use digest::Digest;
-use tari_crypto::{hash_domain, hashing::DomainSeparation};
-
-hash_domain!(LedgerHashDomain, "com.tari.minotari_ledger_wallet", 0);
-hash_domain!(
-    KeyManagerTransactionsHashDomain,
-    "com.tari.base_layer.core.transactions.key_manager",
-    1
-);
-hash_domain!(TransactionHashDomain, "com.tari.base_layer.core.transactions", 0);
+use tari_crypto::hashing::DomainSeparation;
 
 pub struct DomainSeparatedConsensusHasher<M, D> {
     hasher: DomainSeparatedBorshHasher<M, D>,

--- a/applications/minotari_ledger_wallet/wallet/src/utils.rs
+++ b/applications/minotari_ledger_wallet/wallet/src/utils.rs
@@ -17,11 +17,11 @@ use tari_crypto::{
     ristretto::RistrettoSecretKey,
     tari_utilities::ByteArray,
 };
+use tari_hashing::{KeyManagerTransactionsHashDomain, LedgerHashDomain};
 use zeroize::Zeroizing;
 
 use crate::{
     alloc::string::{String, ToString},
-    hashing::{KeyManagerTransactionsHashDomain, LedgerHashDomain},
     AppSW,
     KeyType,
     BIP32_COIN_TYPE,

--- a/applications/minotari_ledger_wallet/wallet/src/utils.rs
+++ b/applications/minotari_ledger_wallet/wallet/src/utils.rs
@@ -4,37 +4,28 @@
 use alloc::format;
 use core::ops::Deref;
 
-use blake2::{Blake2b, Digest};
-use digest::consts::U64;
+use blake2::Blake2b;
+use digest::{consts::U64, Digest};
 use ledger_device_sdk::{
     ecc::{bip32_derive, make_bip32_path, CurvesId, CxError},
     io::SyscallError,
     ui::gadgets::SingleMessage,
 };
 use tari_crypto::{
-    hash_domain,
     hashing::DomainSeparatedHasher,
     keys::SecretKey,
-    ristretto::{pedersen::PedersenCommitment, RistrettoPublicKey, RistrettoSecretKey},
+    ristretto::RistrettoSecretKey,
     tari_utilities::ByteArray,
 };
 use zeroize::Zeroizing;
 
 use crate::{
     alloc::string::{String, ToString},
-    hashing::DomainSeparatedConsensusHasher,
+    hashing::{KeyManagerTransactionsHashDomain, LedgerHashDomain},
     AppSW,
     KeyType,
     BIP32_COIN_TYPE,
 };
-
-hash_domain!(LedgerHashDomain, "com.tari.minotari_ledger_wallet", 0);
-hash_domain!(
-    KeyManagerTransactionsHashDomain,
-    "com.tari.base_layer.core.transactions.key_manager",
-    1
-);
-hash_domain!(TransactionHashDomain, "com.tari.base_layer.core.transactions", 0);
 
 /// BIP32 path stored as an array of [`u32`].
 ///

--- a/applications/minotari_ledger_wallet/wallet/src/utils.rs
+++ b/applications/minotari_ledger_wallet/wallet/src/utils.rs
@@ -267,24 +267,3 @@ pub fn derive_from_bip32_key(
         },
     }
 }
-
-pub fn finalize_metadata_signature_challenge(
-    _version: u64,
-    network: u64,
-    sender_offset_public_key: &RistrettoPublicKey,
-    ephemeral_commitment: &PedersenCommitment,
-    ephemeral_pubkey: &RistrettoPublicKey,
-    commitment: &PedersenCommitment,
-    message: &[u8; 32],
-) -> [u8; 64] {
-    let challenge =
-        DomainSeparatedConsensusHasher::<TransactionHashDomain, Blake2b<U64>>::new("metadata_signature", network)
-            .chain(ephemeral_pubkey)
-            .chain(ephemeral_commitment)
-            .chain(sender_offset_public_key)
-            .chain(commitment)
-            .chain(&message)
-            .finalize();
-
-    challenge.into()
-}

--- a/base_layer/core/src/transactions/key_manager/inner.rs
+++ b/base_layer/core/src/transactions/key_manager/inner.rs
@@ -538,7 +538,6 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
     // Transaction input section (transactions > transaction_components > transaction_input)
     // -----------------------------------------------------------------------------------------------------------------
 
-    #[allow(clippy::too_many_lines)]
     pub async fn get_script_signature(
         &self,
         script_key_id: &TariKeyId,

--- a/base_layer/core/src/transactions/key_manager/inner.rs
+++ b/base_layer/core/src/transactions/key_manager/inner.rs
@@ -39,7 +39,6 @@ use tari_comms::types::CommsDHKE;
 use tari_crypto::{
     commitment::{ExtensionDegree, HomomorphicCommitmentFactory},
     extended_range_proof::ExtendedRangeProofService,
-    hash_domain,
     hashing::{DomainSeparatedHash, DomainSeparatedHasher},
     keys::{PublicKey as PublicKeyTrait, SecretKey},
     range_proof::RangeProofService as RPService,
@@ -48,6 +47,7 @@ use tari_crypto::{
         RistrettoComSig,
     },
 };
+use tari_hashing::KeyManagerTransactionsHashDomain;
 #[cfg(feature = "ledger")]
 use tari_key_manager::error::KeyManagerError;
 use tari_key_manager::{
@@ -91,12 +91,6 @@ use crate::{
         CryptoFactories,
     },
 };
-
-hash_domain!(
-    KeyManagerTransactionsHashDomain,
-    "com.tari.base_layer.core.transactions.key_manager",
-    1
-);
 
 pub struct TransactionKeyManagerInner<TBackend> {
     key_managers: HashMap<String, RwLock<KeyManager<PublicKey, KeyDigest>>>,

--- a/hashing/Cargo.toml
+++ b/hashing/Cargo.toml
@@ -12,9 +12,9 @@ license = "BSD-3-Clause"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tari_crypto = { version = "0.20.1" }
-digest = "0.10"
-borsh = "1.2"
+tari_crypto = { version = "0.20.1", default-features = false, features = ["borsh"]}
+borsh = { version = "1.2", default-features = false }
+digest = { version = "0.10", default-features = false }
 
 [dev-dependencies]
 blake2 = "0.10"

--- a/hashing/src/borsh_hasher.rs
+++ b/hashing/src/borsh_hasher.rs
@@ -23,9 +23,9 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{io, io::Write, marker::PhantomData};
+use core::marker::PhantomData;
 
-use borsh::BorshSerialize;
+use borsh::{io, io::Write, BorshSerialize};
 use digest::Digest;
 use tari_crypto::hashing::DomainSeparation;
 
@@ -79,6 +79,9 @@ impl<D: Digest> Write for WriteHashWrapper<D> {
 
 #[cfg(test)]
 mod tests {
+    extern crate alloc;
+    use alloc::vec::Vec;
+
     use blake2::Blake2b;
     use digest::consts::U32;
     use tari_crypto::hash_domain;

--- a/hashing/src/domains.rs
+++ b/hashing/src/domains.rs
@@ -28,3 +28,11 @@ hash_domain!(
 // Hash domain for all transaction-related hashes, including the script signature challenge, transaction hash and kernel
 // signature challenge
 hash_domain!(TransactionHashDomain, "com.tari.base_layer.core.transactions", 0);
+
+hash_domain!(LedgerHashDomain, "com.tari.minotari_ledger_wallet", 0);
+
+hash_domain!(
+    KeyManagerTransactionsHashDomain,
+    "com.tari.base_layer.core.transactions.key_manager",
+    1
+);

--- a/hashing/src/lib.rs
+++ b/hashing/src/lib.rs
@@ -20,6 +20,9 @@
 //   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+// This library is no_std because it's used everywhere including ledger devices.
+#![no_std]
+
 mod domains;
 pub use domains::*;
 


### PR DESCRIPTION
Description
---
This generates the entire challenge for the script signature on the ledger.
Move signature signing functions into respective handler files.
Move hash domains into the hashing file.

Motivation and Context
---
The total payload size is smaller than before, and can now be done in a single message. With no batching needed I've removed the script signature context struct on the ledger side to reduce complexity, remove persisted state, and free up a bit of memory.

How Has This Been Tested?
---
Manually with new wallets

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify