### PR TITLE
ci(fix): improve cross-compile, add x86_64 target from aarch64

### DIFF
--- a/.github/workflows/build_binaries.json
+++ b/.github/workflows/build_binaries.json
@@ -28,7 +28,7 @@
   },
   {
     "name": "macos-x86_64",
-    "runs-on": "macos-11",
+    "runs-on": "macos-12",
     "rust": "stable",
     "target": "x86_64-apple-darwin",
     "cross": false

--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -203,7 +203,8 @@ jobs:
       - name: Install macOS dependencies
         if: startsWith(runner.os,'macOS')
         run: |
-          brew install openssl cmake zip coreutils automake autoconf protobuf
+          # openssl and cmake already installed
+          brew install zip coreutils automake autoconf protobuf
           rustup target add ${{ matrix.builds.target }}
 
       - name: Install Windows dependencies

--- a/.github/workflows/build_dockers.yml
+++ b/.github/workflows/build_dockers.yml
@@ -88,6 +88,12 @@ jobs:
             echo "tag_alias=latest" >> $GITHUB_OUTPUT
             echo "build_items=all" >> $GITHUB_OUTPUT
           fi
+          if [[ "${{ github.ref }}" =~ ^refs/heads/build-dockers-* ]] || [[ "${{ github.ref }}" =~ ^refs/heads/build-all-* ]] ; then
+            echo "Branch Build - limited dual arch"
+            echo "platforms=linux/arm64, linux/amd64" >> $GITHUB_OUTPUT
+            echo "tag_alias=latest-weekly" >> $GITHUB_OUTPUT
+            echo "build_items=minotari_all" >> $GITHUB_OUTPUT
+          fi
           if [ "${{ github.event_name }}" == "workflow_dispatch" ] ; then
             echo "Manual Build - selective"
             echo "platforms=${{ github.event.inputs.platforms }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/build_libffis.yml
+++ b/.github/workflows/build_libffis.yml
@@ -150,7 +150,8 @@ jobs:
       - name: Install macOS dependencies
         if: startsWith(runner.os,'macOS')
         run: |
-          brew install openssl cmake coreutils automake autoconf protobuf
+          # openssl and cmake already installed
+          brew install coreutils automake autoconf protobuf
           rustup target add ${{ matrix.builds.target }}
 
       - name: Setup Rust toolchain

--- a/Cross.toml
+++ b/Cross.toml
@@ -18,8 +18,6 @@ passthrough = [
   "TARI_NETWORK_DIR",
 ]
 
-# Don't forget export:
-#  CFLAGS=-DMDB_USE_ROBUST=0
 [target.x86_64-linux-android]
 image = "ghcr.io/cross-rs/x86_64-linux-android:edge"
 pre-build = [ """
@@ -27,10 +25,15 @@ export DEBIAN_FRONTEND=noninteractive && \
 apt-get update && \
 apt-get --assume-yes --no-install-recommends install \
  curl unzip && \
-curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v25.2/protoc-25.2-linux-x86_64.zip && \
-unzip -o protoc-25.2-linux-x86_64.zip -d /usr/ && \
+curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v26.1/protoc-26.1-linux-x86_64.zip && \
+unzip -o protoc-26.1-linux-x86_64.zip -d /usr/ && \
 /usr/bin/protoc --version
 """ ]
+
+[target.x86_64-linux-android.env]
+passthrough = [
+  "CFLAGS=-DMDB_USE_ROBUST=0",
+]
 
 [target.aarch64-linux-android]
 image = "ghcr.io/cross-rs/aarch64-linux-android:edge"
@@ -39,45 +42,23 @@ export DEBIAN_FRONTEND=noninteractive && \
 apt-get update && \
 apt-get --assume-yes --no-install-recommends install \
  curl unzip && \
-curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v25.2/protoc-25.2-linux-x86_64.zip && \
-unzip -o protoc-25.2-linux-x86_64.zip -d /usr/ && \
+curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v26.1/protoc-26.1-linux-x86_64.zip && \
+unzip -o protoc-26.1-linux-x86_64.zip -d /usr/ && \
 /usr/bin/protoc --version
 """ ]
 
+[target.aarch64-linux-android.env]
+passthrough = [
+  "CFLAGS=-DMDB_USE_ROBUST=0",
+]
+
 [target.aarch64-unknown-linux-gnu]
 image = "ubuntu:18.04"
-# Mergered all scripts/install_ubuntu_dependencies*.sh scripts
-pre-build = [ """
-apt-get update && \
-apt-get -y install \
-  openssl \
-  libssl-dev \
-  pkg-config \
-  libsqlite3-dev \
-  clang-10 \
-  git \
-  cmake \
-  dh-autoreconf \
-  libc++-dev \
-  libc++abi-dev \
-  libprotobuf-dev \
-  protobuf-compiler \
-  libncurses5-dev \
-  libncursesw5-dev \
-  zip \
-  curl \
-  pkg-config-aarch64-linux-gnu \
-  gcc-aarch64-linux-gnu \
-  g++-aarch64-linux-gnu && \
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && \
-export PATH="$HOME/.cargo/bin:$PATH" && \
-rustup target add aarch64-unknown-linux-gnu && \
-rustup toolchain install stable-aarch64-unknown-linux-gnu
-""" ]
+# Need to use native aarch64 on Apple silicon
+#image.name = "ubuntu:18.04"
+#image.toolchain = ["linux/arm64=aarch64-unknown-linux-gnu"]
+pre-build = "./scripts/cross_compile_ubuntu_18-pre-build.sh"
 
-[target.aarch64-unknown-linux-gnu.env]
-passthrough = [
-  "CARGO_BUILD_TARGET",
-  "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc",
-  "BINDGEN_EXTRA_CLANG_ARGS=--sysroot /usr/aarch64-linux-gnu/include/",
-]
+[target.x86_64-unknown-linux-gnu]
+image = "ubuntu:18.04"
+pre-build = "./scripts/cross_compile_ubuntu_18-pre-build.sh"

--- a/applications/minotari_miner/linux/start_minotari_miner
+++ b/applications/minotari_miner/linux/start_minotari_miner
@@ -1,1 +1,1 @@
-./runtime/start_tari_miner.sh
+./runtime/start_minotari_miner.sh

--- a/applications/minotari_miner/osx/start_minotari_miner
+++ b/applications/minotari_miner/osx/start_minotari_miner
@@ -1,1 +1,1 @@
-./runtime/start_tari_miner.sh
+./runtime/start_minotari_miner.sh

--- a/scripts/cross_compile_ubuntu_18-pre-build.sh
+++ b/scripts/cross_compile_ubuntu_18-pre-build.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+#
+# Single script for Ubuntu 18.04 package setup, mostly used for cross-compiling
+#
+
+set -e
+
+USAGE="Usage: $0 target build ie: x86_64-unknown-linux-gnu or aarch64-unknown-linux-gnu"
+
+if [ "$#" == "0" ]; then
+  echo "$USAGE"
+  exit 1
+fi
+
+if [ -z "${CROSS_DEB_ARCH}" ]; then
+  echo "Should be run from cross, which sets the env CROSS_DEB_ARCH"
+  exit 1
+fi
+
+targetBuild="${1}"
+nativeRunTime=$(uname -m)
+echo "Native RunTime is ${nativeRunTime}"
+
+if [ "${nativeRunTime}" == "x86_64" ]; then
+  nativeArch=amd64
+  if [ "${targetBuild}" == "aarch64-unknown-linux-gnu" ]; then
+    targetArch=arm64
+    targetPlatform=aarch64
+  else
+    targetArch=amd64
+    targetPlatform=x86-64
+  fi
+elif [ "${nativeRunTime}" == "aarch64" ]; then
+  nativeArch=arm64
+  if [ "${targetBuild}" == "x86_64-unknown-linux-gnu" ]; then
+    targetArch=amd64
+    targetPlatform=x86-64
+  fi
+elif [ "${nativeRunTime}" == "riscv64" ]; then
+  nativeArch=riscv64
+  echo "ToDo!"
+else
+  echo "!!Unsupport platform!!"
+  exit 1
+fi
+
+crossArch=${CROSS_DEB_ARCH}
+apt-get update
+
+# Base install packages
+# scripts/install_ubuntu_dependencies.sh
+apt-get install --no-install-recommends --assume-yes \
+  apt-transport-https \
+  ca-certificates \
+  curl \
+  gpg \
+  bash \
+  less \
+  openssl \
+  libssl-dev \
+  pkg-config \
+  libsqlite3-dev \
+  libsqlite3-0 \
+  libreadline-dev \
+  git \
+  cmake \
+  dh-autoreconf \
+  clang \
+  g++ \
+  g++-7 \
+  libc++-dev \
+  libc++abi-dev \
+  libprotobuf-dev \
+  protobuf-compiler \
+  libncurses5-dev \
+  libncursesw5-dev \
+  libudev-dev \
+  zip
+
+echo "Installing rust ..."
+mkdir -p "$HOME/.cargo/bin/"
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+export PATH="$HOME/.cargo/bin:$PATH"
+. "$HOME/.cargo/env"
+
+# Cross-CPU compile setup
+if [ "${CROSS_DEB_ARCH}" != "${nativeArch}" ]; then
+  echo "Setup Cross CPU Compile ..."
+  sed -i.save -e "s/^deb\ http/deb [arch="${nativeArch}"] http/g" /etc/apt/sources.list
+
+  . /etc/lsb-release
+  ubuntu_tag=${DISTRIB_CODENAME}
+
+  if [ "${crossArch}" == "arm64" ]; then
+    cat << EoF > /etc/apt/sources.list.d/${ubuntu_tag}-${crossArch}.list
+deb [arch=${crossArch}] http://ports.ubuntu.com/ubuntu-ports ${ubuntu_tag} main restricted universe multiverse
+# deb-src [arch=${crossArch}] http://ports.ubuntu.com/ubuntu-ports ${ubuntu_tag} main restricted universe multiverse
+
+deb [arch=${crossArch}] http://ports.ubuntu.com/ubuntu-ports ${ubuntu_tag}-updates main restricted universe multiverse
+# deb-src [arch=${crossArch}] http://ports.ubuntu.com/ubuntu-ports ${ubuntu_tag}-updates main restricted universe multiverse
+
+deb [arch=${crossArch}] http://ports.ubuntu.com/ubuntu-ports ${ubuntu_tag}-backports main restricted universe multiverse
+# deb-src [arch=${crossArch}] http://ports.ubuntu.com/ubuntu-ports ${ubuntu_tag}-backports main restricted universe multiverse
+
+deb [arch=${crossArch}] http://ports.ubuntu.com/ubuntu-ports ${ubuntu_tag}-security main restricted universe multiverse
+# deb-src [arch=${crossArch}] http://ports.ubuntu.com/ubuntu-ports ${ubuntu_tag}-security main restricted universe multiverse
+
+deb [arch=${crossArch}] http://archive.canonical.com/ubuntu ${ubuntu_tag} partner
+# deb-src [arch=${crossArch}] http://archive.canonical.com/ubuntu ${ubuntu_tag} partner
+EoF
+  fi
+
+  if [ "${crossArch}" == "amd64" ]; then
+    cat << EoF > /etc/apt/sources.list.d/${ubuntu_tag}-${crossArch}.list
+deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ ${ubuntu_tag} main restricted
+# deb-src http://archive.ubuntu.com/ubuntu/ ${ubuntu_tag} main restricted
+
+deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ ${ubuntu_tag}-updates main restricted
+# deb-src http://archive.ubuntu.com/ubuntu/ ${ubuntu_tag}-updates main restricted
+
+deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ ${ubuntu_tag} universe
+# deb-src http://archive.ubuntu.com/ubuntu/ ${ubuntu_tag} universe
+deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ ${ubuntu_tag}-updates universe
+# deb-src http://archive.ubuntu.com/ubuntu/ ${ubuntu_tag}-updates universe
+
+deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ ${ubuntu_tag} multiverse
+# deb-src http://archive.ubuntu.com/ubuntu/ ${ubuntu_tag} multiverse
+deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ ${ubuntu_tag}-updates multiverse
+# deb-src http://archive.ubuntu.com/ubuntu/ ${ubuntu_tag}-updates multiverse
+
+deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ ${ubuntu_tag}-backports main restricted universe multiverse
+# deb-src http://archive.ubuntu.com/ubuntu/ ${ubuntu_tag}-backports main restricted universe multiverse
+
+# deb http://archive.canonical.com/ubuntu ${ubuntu_tag} partner
+# deb-src http://archive.canonical.com/ubuntu ${ubuntu_tag} partner
+
+deb [arch=amd64] http://security.ubuntu.com/ubuntu/ ${ubuntu_tag}-security main restricted
+# deb-src http://security.ubuntu.com/ubuntu/ ${ubuntu_tag}-security main restricted
+deb [arch=amd64] http://security.ubuntu.com/ubuntu/ ${ubuntu_tag}-security universe
+# deb-src http://security.ubuntu.com/ubuntu/ ${ubuntu_tag}-security universe
+deb [arch=amd64] http://security.ubuntu.com/ubuntu/ ${ubuntu_tag}-security multiverse
+# deb-src http://security.ubuntu.com/ubuntu/ ${ubuntu_tag}-security multiverse
+EoF
+  fi
+
+  dpkg --add-architecture ${CROSS_DEB_ARCH}
+  apt-get update
+
+  # scripts/install_ubuntu_dependencies-cross_compile.sh x86-64
+  apt-get --assume-yes install \
+    pkg-config-${targetPlatform}-linux-gnu \
+    gcc-${targetPlatform}-linux-gnu \
+    g++-${targetPlatform}-linux-gnu
+
+  # packages needed for Ledger and hidapi
+  apt-get --assume-yes install \
+    libhidapi-dev:${CROSS_DEB_ARCH} \
+    libudev-dev:${CROSS_DEB_ARCH}
+
+fi
+
+rustup target add ${targetBuild}
+rustup toolchain install stable-${targetBuild} --force-non-host
+
+rustup target list
+rustup toolchain list


### PR DESCRIPTION
Description
Move the cross-rs image setup into a shared script, should improve support for cross compiling to Linux
Bump macos build host from 11 to 12
Remove macos install packages that are pre-install, keep a note
Bump protobuf to 26.1 for Android ffis builds with cross-rs
Add the default ```CFLAGS``` to build Android ffis with cross-rs
Add a limited dual arch build for docker images with ```build-dockers-``` branches

Motivation and Context
Improve general build support, with focus on cross compiling from macos devices
cross-rs pre-built image requires a single script to build from

How Has This Been Tested?
Build locally and in fork

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
