### PR TITLE
feat: add default message tag

### DIFF
--- a/comms/dht/src/outbound/message_params.rs
+++ b/comms/dht/src/outbound/message_params.rs
@@ -84,7 +84,7 @@ impl Default for FinalSendMessageParams {
             is_discovery_enabled: false,
             dht_header: None,
             debug_info: None,
-            tag: None,
+            tag: Some(MessageTag::new()),
         }
     }
 }


### PR DESCRIPTION
Description
---
Add a default message tag to `FinalSendMessageParams`. This enables the tracing of ping-pong and other messages across nodes.

Motivation and Context
---
- We have a related issue with ping-pong, see #6356. This tracing will assist in analysing the issue.
- With transaction testing, we noticed that some messages have a zero tag; this will also help that tracing.

How Has This Been Tested?
---
System-level tests.

What process can a PR reviewer use to test or verify this change?
---
Review code.

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
