### PR TITLE
feat: split message to have dedicated to and from fields

### DIFF
--- a/base_layer/chat_ffi/chat.h
+++ b/base_layer/chat_ffi/chat.h
@@ -608,7 +608,7 @@ struct ChatByteVector *read_chat_message_body(struct Message *message, int *erro
  * `message` should be destroyed eventually
  * the returned `TariAddress` should be destroyed eventually
  */
-struct TariAddress *read_chat_message_from_address(struct Message *message, int *error_out);
+struct TariAddress *read_chat_message_sender_address(struct Message *message, int *error_out);
 
 /**
  * Returns a pointer to a TariAddress
@@ -624,7 +624,7 @@ struct TariAddress *read_chat_message_from_address(struct Message *message, int 
  * `message` should be destroyed eventually
  * the returned `TariAddress` should be destroyed eventually
  */
-struct TariAddress *read_chat_message_to_address(struct Message *message, int *error_out);
+struct TariAddress *read_chat_message_receiver_address(struct Message *message, int *error_out);
 
 /**
  * Returns a c_uchar representation of the Direction enum

--- a/base_layer/chat_ffi/chat.h
+++ b/base_layer/chat_ffi/chat.h
@@ -490,6 +490,7 @@ void destroy_conversationalists_vector(struct ConversationalistsVector *ptr);
  * The ```Message``` received should be destroyed after use
  */
 struct Message *create_chat_message(struct TariAddress *receiver,
+                                    struct TariAddress *sender,
                                     const char *message,
                                     int *error_out);
 
@@ -607,7 +608,23 @@ struct ChatByteVector *read_chat_message_body(struct Message *message, int *erro
  * `message` should be destroyed eventually
  * the returned `TariAddress` should be destroyed eventually
  */
-struct TariAddress *read_chat_message_address(struct Message *message, int *error_out);
+struct TariAddress *read_chat_message_from_address(struct Message *message, int *error_out);
+
+/**
+ * Returns a pointer to a TariAddress
+ *
+ * ## Arguments
+ * `message` - A pointer to a Message
+ * `error_out` - Pointer to an int which will be modified
+ *
+ * ## Returns
+ * `*mut TariAddress` - A ptr to a TariAddress
+ *
+ * ## Safety
+ * `message` should be destroyed eventually
+ * the returned `TariAddress` should be destroyed eventually
+ */
+struct TariAddress *read_chat_message_to_address(struct Message *message, int *error_out);
 
 /**
  * Returns a c_uchar representation of the Direction enum

--- a/base_layer/chat_ffi/src/callback_handler.rs
+++ b/base_layer/chat_ffi/src/callback_handler.rs
@@ -134,7 +134,7 @@ impl CallbackHandler {
         debug!(
             target: LOG_TARGET,
             "Calling MessageReceived callback function for sender {}",
-            message.from_address,
+            message.sender_address,
         );
 
         unsafe {

--- a/base_layer/chat_ffi/src/callback_handler.rs
+++ b/base_layer/chat_ffi/src/callback_handler.rs
@@ -134,7 +134,7 @@ impl CallbackHandler {
         debug!(
             target: LOG_TARGET,
             "Calling MessageReceived callback function for sender {}",
-            message.address,
+            message.from_address,
         );
 
         unsafe {

--- a/base_layer/chat_ffi/src/message.rs
+++ b/base_layer/chat_ffi/src/message.rs
@@ -50,6 +50,7 @@ use crate::{
 #[no_mangle]
 pub unsafe extern "C" fn create_chat_message(
     receiver: *mut TariAddress,
+    sender: *mut TariAddress,
     message: *const c_char,
     error_out: *mut c_int,
 ) -> *mut Message {
@@ -58,6 +59,10 @@ pub unsafe extern "C" fn create_chat_message(
 
     if receiver.is_null() {
         error = LibChatError::from(InterfaceError::NullError("receiver".to_string())).code;
+        ptr::swap(error_out, &mut error as *mut c_int);
+    }
+    if sender.is_null() {
+        error = LibChatError::from(InterfaceError::NullError("sender".to_string())).code;
         ptr::swap(error_out, &mut error as *mut c_int);
     }
 
@@ -71,7 +76,8 @@ pub unsafe extern "C" fn create_chat_message(
     };
 
     let message_out = MessageBuilder::new()
-        .address((*receiver).clone())
+        .to_address((*receiver).clone())
+        .from_address((*sender).clone())
         .message(message_str)
         .build();
 
@@ -306,7 +312,10 @@ pub unsafe extern "C" fn read_chat_message_body(message: *mut Message, error_out
 /// `message` should be destroyed eventually
 /// the returned `TariAddress` should be destroyed eventually
 #[no_mangle]
-pub unsafe extern "C" fn read_chat_message_address(message: *mut Message, error_out: *mut c_int) -> *mut TariAddress {
+pub unsafe extern "C" fn read_chat_message_from_address(
+    message: *mut Message,
+    error_out: *mut c_int,
+) -> *mut TariAddress {
     let mut error = 0;
     ptr::swap(error_out, &mut error as *mut c_int);
 
@@ -316,7 +325,37 @@ pub unsafe extern "C" fn read_chat_message_address(message: *mut Message, error_
         return ptr::null_mut();
     }
 
-    let address = (*message).address.clone();
+    let address = (*message).from_address.clone();
+    Box::into_raw(Box::new(address))
+}
+
+/// Returns a pointer to a TariAddress
+///
+/// ## Arguments
+/// `message` - A pointer to a Message
+/// `error_out` - Pointer to an int which will be modified
+///
+/// ## Returns
+/// `*mut TariAddress` - A ptr to a TariAddress
+///
+/// ## Safety
+/// `message` should be destroyed eventually
+/// the returned `TariAddress` should be destroyed eventually
+#[no_mangle]
+pub unsafe extern "C" fn read_chat_message_to_address(
+    message: *mut Message,
+    error_out: *mut c_int,
+) -> *mut TariAddress {
+    let mut error = 0;
+    ptr::swap(error_out, &mut error as *mut c_int);
+
+    if message.is_null() {
+        error = LibChatError::from(InterfaceError::NullError("message".to_string())).code;
+        ptr::swap(error_out, &mut error as *mut c_int);
+        return ptr::null_mut();
+    }
+
+    let address = (*message).to_address.clone();
     Box::into_raw(Box::new(address))
 }
 
@@ -560,17 +599,22 @@ mod test {
 
     #[test]
     fn test_reading_message_address() {
-        let address =
+        let to_address =
             TariAddress::from_hex("0c017c5cd01385f34ac065e3b05948326dc55d2494f120c6f459a07389011b4ec1").unwrap();
-        let message = MessageBuilder::new().address(address.clone()).build();
+        let from_address =
+            TariAddress::from_hex("3e596f98f6904f0fc1c8685e2274bd8b2c445d5dac284a9398d09a0e9a760436d0").unwrap();
+        let message = MessageBuilder::new()
+            .to_address(to_address.clone())
+            .from_address(from_address.clone())
+            .build();
 
         let message_ptr = Box::into_raw(Box::new(message));
         let error_out = Box::into_raw(Box::new(0));
 
         unsafe {
-            let address_ptr = read_chat_message_address(message_ptr, error_out);
+            let address_ptr = read_chat_message_from_address(message_ptr, error_out);
 
-            assert_eq!(address.to_bytes(), (*address_ptr).to_bytes());
+            assert_eq!(from_address.to_bytes(), (*address_ptr).to_bytes());
 
             destroy_chat_message(message_ptr);
             destroy_tari_address(address_ptr);

--- a/base_layer/chat_ffi/src/message.rs
+++ b/base_layer/chat_ffi/src/message.rs
@@ -76,8 +76,8 @@ pub unsafe extern "C" fn create_chat_message(
     };
 
     let message_out = MessageBuilder::new()
-        .to_address((*receiver).clone())
-        .from_address((*sender).clone())
+        .receiver_address((*receiver).clone())
+        .sender_address((*sender).clone())
         .message(message_str)
         .build();
 
@@ -312,7 +312,7 @@ pub unsafe extern "C" fn read_chat_message_body(message: *mut Message, error_out
 /// `message` should be destroyed eventually
 /// the returned `TariAddress` should be destroyed eventually
 #[no_mangle]
-pub unsafe extern "C" fn read_chat_message_from_address(
+pub unsafe extern "C" fn read_chat_message_sender_address(
     message: *mut Message,
     error_out: *mut c_int,
 ) -> *mut TariAddress {
@@ -325,7 +325,7 @@ pub unsafe extern "C" fn read_chat_message_from_address(
         return ptr::null_mut();
     }
 
-    let address = (*message).from_address.clone();
+    let address = (*message).sender_address.clone();
     Box::into_raw(Box::new(address))
 }
 
@@ -342,7 +342,7 @@ pub unsafe extern "C" fn read_chat_message_from_address(
 /// `message` should be destroyed eventually
 /// the returned `TariAddress` should be destroyed eventually
 #[no_mangle]
-pub unsafe extern "C" fn read_chat_message_to_address(
+pub unsafe extern "C" fn read_chat_message_receiver_address(
     message: *mut Message,
     error_out: *mut c_int,
 ) -> *mut TariAddress {
@@ -355,7 +355,7 @@ pub unsafe extern "C" fn read_chat_message_to_address(
         return ptr::null_mut();
     }
 
-    let address = (*message).to_address.clone();
+    let address = (*message).receiver_address.clone();
     Box::into_raw(Box::new(address))
 }
 
@@ -599,22 +599,22 @@ mod test {
 
     #[test]
     fn test_reading_message_address() {
-        let to_address =
+        let receiver_address =
             TariAddress::from_hex("0c017c5cd01385f34ac065e3b05948326dc55d2494f120c6f459a07389011b4ec1").unwrap();
-        let from_address =
+        let sender_address =
             TariAddress::from_hex("3e596f98f6904f0fc1c8685e2274bd8b2c445d5dac284a9398d09a0e9a760436d0").unwrap();
         let message = MessageBuilder::new()
-            .to_address(to_address.clone())
-            .from_address(from_address.clone())
+            .receiver_address(receiver_address.clone())
+            .sender_address(sender_address.clone())
             .build();
 
         let message_ptr = Box::into_raw(Box::new(message));
         let error_out = Box::into_raw(Box::new(0));
 
         unsafe {
-            let address_ptr = read_chat_message_from_address(message_ptr, error_out);
+            let address_ptr = read_chat_message_sender_address(message_ptr, error_out);
 
-            assert_eq!(from_address.to_bytes(), (*address_ptr).to_bytes());
+            assert_eq!(sender_address.to_bytes(), (*address_ptr).to_bytes());
 
             destroy_chat_message(message_ptr);
             destroy_tari_address(address_ptr);

--- a/base_layer/chat_ffi/src/message_metadata.rs
+++ b/base_layer/chat_ffi/src/message_metadata.rs
@@ -211,8 +211,8 @@ mod test {
         let message_ptr = Box::into_raw(Box::new(
             MessageBuilder::new()
                 .message("hello".to_string())
-                .to_address(address.clone())
-                .from_address(address)
+                .receiver_address(address.clone())
+                .sender_address(address)
                 .build(),
         ));
         let error_out = Box::into_raw(Box::new(0));

--- a/base_layer/chat_ffi/src/message_metadata.rs
+++ b/base_layer/chat_ffi/src/message_metadata.rs
@@ -211,7 +211,8 @@ mod test {
         let message_ptr = Box::into_raw(Box::new(
             MessageBuilder::new()
                 .message("hello".to_string())
-                .address(address)
+                .to_address(address.clone())
+                .from_address(address)
                 .build(),
         ));
         let error_out = Box::into_raw(Box::new(0));

--- a/base_layer/contacts/migrations/2024-05-27-145200_add_from_to_fields/up.sql
+++ b/base_layer/contacts/migrations/2024-05-27-145200_add_from_to_fields/up.sql
@@ -2,8 +2,8 @@ DROP INDEX idx_messages_address;
 
 ALTER TABLE messages DROP address;
 
-ALTER TABLE messages ADD to_address BLOB NOT NULL;
-ALTER TABLE messages ADD from_address BLOB NOT NULL;
+ALTER TABLE messages ADD receiver_address BLOB NOT NULL;
+ALTER TABLE messages ADD sender_address BLOB NOT NULL;
 
-CREATE INDEX idx_messages_receiver_address ON messages (to_address);
-CREATE INDEX idx_messages_sender_address ON messages (from_address);
+CREATE INDEX idx_messages_receiver_address ON messages (receiver_address);
+CREATE INDEX idx_messages_sender_address ON messages (sender_address);

--- a/base_layer/contacts/migrations/2024-05-27-145200_add_from_to_fields/up.sql
+++ b/base_layer/contacts/migrations/2024-05-27-145200_add_from_to_fields/up.sql
@@ -5,5 +5,5 @@ ALTER TABLE messages DROP address;
 ALTER TABLE messages ADD to_address BLOB NOT NULL;
 ALTER TABLE messages ADD from_address BLOB NOT NULL;
 
-CREATE INDEX idx_messages_to_address ON messages (to_address);
-CREATE INDEX idx_messages_from_address ON messages (from_address);
+CREATE INDEX idx_messages_receiver_address ON messages (to_address);
+CREATE INDEX idx_messages_sender_address ON messages (from_address);

--- a/base_layer/contacts/migrations/2024-05-27-145200_add_from_to_fields/up.sql
+++ b/base_layer/contacts/migrations/2024-05-27-145200_add_from_to_fields/up.sql
@@ -1,0 +1,9 @@
+DROP INDEX idx_messages_address;
+
+ALTER TABLE messages DROP address;
+
+ALTER TABLE messages ADD to_address BLOB NOT NULL;
+ALTER TABLE messages ADD from_address BLOB NOT NULL;
+
+CREATE INDEX idx_messages_to_address ON messages (to_address);
+CREATE INDEX idx_messages_from_address ON messages (from_address);

--- a/base_layer/contacts/proto/message.proto
+++ b/base_layer/contacts/proto/message.proto
@@ -7,9 +7,10 @@ package tari.contacts.chat;
 message Message {
   bytes body = 1;
   repeated MessageMetadata metadata = 2;
-  bytes address = 3;
-  DirectionEnum direction = 4;
-  bytes message_id = 5;
+  bytes to_address = 3;
+  bytes from_address = 4;
+  DirectionEnum direction = 5;
+  bytes message_id = 6;
 }
 
 enum DirectionEnum {

--- a/base_layer/contacts/proto/message.proto
+++ b/base_layer/contacts/proto/message.proto
@@ -7,8 +7,8 @@ package tari.contacts.chat;
 message Message {
   bytes body = 1;
   repeated MessageMetadata metadata = 2;
-  bytes to_address = 3;
-  bytes from_address = 4;
+  bytes receiver_address = 3;
+  bytes sender_address = 4;
   DirectionEnum direction = 5;
   bytes message_id = 6;
 }

--- a/base_layer/contacts/src/chat_client/src/client.rs
+++ b/base_layer/contacts/src/chat_client/src/client.rs
@@ -168,6 +168,14 @@ impl ChatClient for Client {
         message
     }
 
+    fn create_message(&self, receiver: &TariAddress, message: String) -> Message {
+        MessageBuilder::new()
+            .to_address(receiver.clone())
+            .from_address(self.address().clone())
+            .message(message)
+            .build()
+    }
+
     async fn check_online_status(&self, address: &TariAddress) -> Result<ContactOnlineStatus, Error> {
         if let Some(mut contacts_service) = self.contacts.clone() {
             let contact = contacts_service.get_contact(address.clone()).await?;
@@ -176,10 +184,6 @@ impl ChatClient for Client {
         }
 
         Ok(ContactOnlineStatus::Offline)
-    }
-
-    fn create_message(&self, receiver: &TariAddress, message: String) -> Message {
-        MessageBuilder::new().address(receiver.clone()).message(message).build()
     }
 
     async fn get_messages(&self, sender: &TariAddress, limit: u64, page: u64) -> Result<Vec<Message>, Error> {
@@ -211,7 +215,7 @@ impl ChatClient for Client {
     async fn send_read_receipt(&self, message: Message) -> Result<(), Error> {
         if let Some(mut contacts_service) = self.contacts.clone() {
             contacts_service
-                .send_read_confirmation(message.address.clone(), message.message_id)
+                .send_read_confirmation(message.from_address.clone(), message.message_id)
                 .await?;
         }
 

--- a/base_layer/contacts/src/chat_client/src/client.rs
+++ b/base_layer/contacts/src/chat_client/src/client.rs
@@ -170,8 +170,8 @@ impl ChatClient for Client {
 
     fn create_message(&self, receiver: &TariAddress, message: String) -> Message {
         MessageBuilder::new()
-            .to_address(receiver.clone())
-            .from_address(self.address().clone())
+            .receiver_address(receiver.clone())
+            .sender_address(self.address().clone())
             .message(message)
             .build()
     }
@@ -215,7 +215,7 @@ impl ChatClient for Client {
     async fn send_read_receipt(&self, message: Message) -> Result<(), Error> {
         if let Some(mut contacts_service) = self.contacts.clone() {
             contacts_service
-                .send_read_confirmation(message.to_address.clone(), message.message_id)
+                .send_read_confirmation(message.receiver_address.clone(), message.message_id)
                 .await?;
         }
 

--- a/base_layer/contacts/src/chat_client/src/client.rs
+++ b/base_layer/contacts/src/chat_client/src/client.rs
@@ -215,7 +215,7 @@ impl ChatClient for Client {
     async fn send_read_receipt(&self, message: Message) -> Result<(), Error> {
         if let Some(mut contacts_service) = self.contacts.clone() {
             contacts_service
-                .send_read_confirmation(message.from_address.clone(), message.message_id)
+                .send_read_confirmation(message.to_address.clone(), message.message_id)
                 .await?;
         }
 

--- a/base_layer/contacts/src/contacts_service/handle.rs
+++ b/base_layer/contacts/src/contacts_service/handle.rs
@@ -293,7 +293,7 @@ impl ContactsServiceHandle {
     pub async fn send_message(&mut self, message: Message) -> Result<(), ContactsServiceError> {
         match self
             .request_response_service
-            .call(ContactsServiceRequest::SendMessage(message.address.clone(), message))
+            .call(ContactsServiceRequest::SendMessage(message.to_address.clone(), message))
             .await??
         {
             ContactsServiceResponse::MessageSent => Ok(()),

--- a/base_layer/contacts/src/contacts_service/handle.rs
+++ b/base_layer/contacts/src/contacts_service/handle.rs
@@ -293,7 +293,10 @@ impl ContactsServiceHandle {
     pub async fn send_message(&mut self, message: Message) -> Result<(), ContactsServiceError> {
         match self
             .request_response_service
-            .call(ContactsServiceRequest::SendMessage(message.to_address.clone(), message))
+            .call(ContactsServiceRequest::SendMessage(
+                message.receiver_address.clone(),
+                message,
+            ))
             .await??
         {
             ContactsServiceResponse::MessageSent => Ok(()),

--- a/base_layer/contacts/src/contacts_service/service.rs
+++ b/base_layer/contacts/src/contacts_service/service.rs
@@ -586,7 +586,7 @@ where T: ContactsBackend + 'static
         message: Message,
         source_public_key: CommsPublicKey,
     ) -> Result<(), ContactsServiceError> {
-        if source_public_key != *message.from_address.public_key() {
+        if source_public_key != *message.sender_address.public_key() {
             return Err(ContactsServiceError::MessageSourceDoesNotMatchOrigin);
         }
         let our_message = Message {
@@ -620,7 +620,7 @@ where T: ContactsBackend + 'static
         &mut self,
         message: &Message,
     ) -> Result<(), ContactsServiceError> {
-        let address = &message.from_address;
+        let address = &message.sender_address;
         let confirmation = MessageDispatch::DeliveryConfirmation(Confirmation {
             message_id: message.message_id.clone(),
             timestamp: message.stored_at,

--- a/base_layer/contacts/src/contacts_service/service.rs
+++ b/base_layer/contacts/src/contacts_service/service.rs
@@ -586,8 +586,10 @@ where T: ContactsBackend + 'static
         message: Message,
         source_public_key: CommsPublicKey,
     ) -> Result<(), ContactsServiceError> {
+        if source_public_key != *message.from_address.public_key() {
+            return Err(ContactsServiceError::MessageSourceDoesNotMatchOrigin);
+        }
         let our_message = Message {
-            address: TariAddress::from_public_key(&source_public_key, message.address.network()),
             stored_at: EpochTime::now().as_u64(),
             ..message
         };
@@ -618,7 +620,7 @@ where T: ContactsBackend + 'static
         &mut self,
         message: &Message,
     ) -> Result<(), ContactsServiceError> {
-        let address = &message.address;
+        let address = &message.from_address;
         let confirmation = MessageDispatch::DeliveryConfirmation(Confirmation {
             message_id: message.message_id.clone(),
             timestamp: message.stored_at,

--- a/base_layer/contacts/src/contacts_service/storage/types/messages.rs
+++ b/base_layer/contacts/src/contacts_service/storage/types/messages.rs
@@ -154,7 +154,11 @@ impl MessagesSql {
     pub fn find_all_conversationlists(
         conn: &mut SqliteConnection,
     ) -> Result<Vec<Vec<u8>>, ContactsServiceStorageError> {
-        Ok(messages::table.select(messages::from_address).distinct().load(conn)?)
+        Ok(messages::table
+            .select(messages::from_address)
+            .select(messages::to_address)
+            .distinct()
+            .load(conn)?)
     }
 }
 

--- a/base_layer/contacts/src/contacts_service/types/message.rs
+++ b/base_layer/contacts/src/contacts_service/types/message.rs
@@ -88,8 +88,8 @@ impl TryFrom<proto::Message> for Message {
         Ok(Self {
             body: message.body,
             metadata,
-            to_address: TariAddress::from_bytes(&message.to_address).map_err(|e| e.to_string())?,
-            from_address: TariAddress::from_bytes(&message.from_address).map_err(|e| e.to_string())?,
+            receiver_address: TariAddress::from_bytes(&message.receiver_address).map_err(|e| e.to_string())?,
+            sender_address: TariAddress::from_bytes(&message.sender_address).map_err(|e| e.to_string())?,
             // A Message from a proto::Message will always be an inbound message
             direction: Direction::Inbound,
             message_id: message.message_id,
@@ -107,8 +107,8 @@ impl From<Message> for proto::Message {
                 .iter()
                 .map(|m| proto::MessageMetadata::from(m.clone()))
                 .collect(),
-            to_address: message.to_address.to_bytes().to_vec(),
-            from_address: message.from_address.to_bytes().to_vec(),
+            receiver_address: message.receiver_address.to_bytes().to_vec(),
+            sender_address: message.sender_address.to_bytes().to_vec(),
             direction: i32::from(message.direction.as_byte()),
             message_id: message.message_id,
         }

--- a/base_layer/contacts/src/contacts_service/types/message.rs
+++ b/base_layer/contacts/src/contacts_service/types/message.rs
@@ -36,8 +36,8 @@ use crate::contacts_service::proto;
 pub struct Message {
     pub body: Vec<u8>,
     pub metadata: Vec<MessageMetadata>,
-    pub to_address: TariAddress,
-    pub from_address: TariAddress,
+    pub receiver_address: TariAddress,
+    pub sender_address: TariAddress,
     pub direction: Direction,
     pub sent_at: u64,
     pub stored_at: u64,

--- a/base_layer/contacts/src/contacts_service/types/message.rs
+++ b/base_layer/contacts/src/contacts_service/types/message.rs
@@ -36,7 +36,8 @@ use crate::contacts_service::proto;
 pub struct Message {
     pub body: Vec<u8>,
     pub metadata: Vec<MessageMetadata>,
-    pub address: TariAddress,
+    pub to_address: TariAddress,
+    pub from_address: TariAddress,
     pub direction: Direction,
     pub sent_at: u64,
     pub stored_at: u64,
@@ -87,7 +88,8 @@ impl TryFrom<proto::Message> for Message {
         Ok(Self {
             body: message.body,
             metadata,
-            address: TariAddress::from_bytes(&message.address).map_err(|e| e.to_string())?,
+            to_address: TariAddress::from_bytes(&message.to_address).map_err(|e| e.to_string())?,
+            from_address: TariAddress::from_bytes(&message.from_address).map_err(|e| e.to_string())?,
             // A Message from a proto::Message will always be an inbound message
             direction: Direction::Inbound,
             message_id: message.message_id,
@@ -105,7 +107,8 @@ impl From<Message> for proto::Message {
                 .iter()
                 .map(|m| proto::MessageMetadata::from(m.clone()))
                 .collect(),
-            address: message.address.to_bytes().to_vec(),
+            to_address: message.to_address.to_bytes().to_vec(),
+            from_address: message.from_address.to_bytes().to_vec(),
             direction: i32::from(message.direction.as_byte()),
             message_id: message.message_id,
         }

--- a/base_layer/contacts/src/contacts_service/types/message_builder.rs
+++ b/base_layer/contacts/src/contacts_service/types/message_builder.rs
@@ -44,10 +44,19 @@ impl MessageBuilder {
         }
     }
 
-    pub fn address(&self, address: TariAddress) -> Self {
+    pub fn to_address(&self, to_address: TariAddress) -> Self {
         Self {
             inner: Message {
-                address,
+                to_address,
+                ..self.inner.clone()
+            },
+        }
+    }
+
+    pub fn from_address(&self, from_address: TariAddress) -> Self {
+        Self {
+            inner: Message {
+                from_address,
                 ..self.inner.clone()
             },
         }

--- a/base_layer/contacts/src/contacts_service/types/message_builder.rs
+++ b/base_layer/contacts/src/contacts_service/types/message_builder.rs
@@ -44,19 +44,19 @@ impl MessageBuilder {
         }
     }
 
-    pub fn to_address(&self, to_address: TariAddress) -> Self {
+    pub fn receiver_address(&self, receiver_address: TariAddress) -> Self {
         Self {
             inner: Message {
-                to_address,
+                receiver_address,
                 ..self.inner.clone()
             },
         }
     }
 
-    pub fn from_address(&self, from_address: TariAddress) -> Self {
+    pub fn sender_address(&self, sender_address: TariAddress) -> Self {
         Self {
             inner: Message {
-                from_address,
+                sender_address,
                 ..self.inner.clone()
             },
         }

--- a/base_layer/contacts/src/schema.rs
+++ b/base_layer/contacts/src/schema.rs
@@ -13,8 +13,8 @@ diesel::table! {
 
 diesel::table! {
     messages (message_id) {
-        to_address -> Binary,
-        from_address -> Binary,
+        receiver_address -> Binary,
+        sender_address -> Binary,
         message_id -> Binary,
         body -> Binary,
         metadata -> Binary,

--- a/base_layer/contacts/src/schema.rs
+++ b/base_layer/contacts/src/schema.rs
@@ -13,7 +13,8 @@ diesel::table! {
 
 diesel::table! {
     messages (message_id) {
-        address -> Binary,
+        to_address -> Binary,
+        from_address -> Binary,
         message_id -> Binary,
         body -> Binary,
         metadata -> Binary,

--- a/base_layer/contacts/tests/contacts_service.rs
+++ b/base_layer/contacts/tests/contacts_service.rs
@@ -243,7 +243,8 @@ pub fn test_message_pagination() {
         for num in 0..8 {
             let message = MessageBuilder::new()
                 .message(format!("Test {:?}", num))
-                .address(address.clone())
+                .to_address(address.clone())
+                .from_address(address.clone())
                 .build();
 
             contacts_db.save_message(message.clone()).expect("Message to be saved");
@@ -273,7 +274,8 @@ pub fn test_message_pagination() {
         for num in 0..3000 {
             let message = MessageBuilder::new()
                 .message(format!("Test {:?}", num))
-                .address(address.clone())
+                .to_address(address.clone())
+                .from_address(address.clone())
                 .build();
 
             contacts_db.save_message(message.clone()).expect("Message to be saved");

--- a/base_layer/contacts/tests/contacts_service.rs
+++ b/base_layer/contacts/tests/contacts_service.rs
@@ -243,8 +243,8 @@ pub fn test_message_pagination() {
         for num in 0..8 {
             let message = MessageBuilder::new()
                 .message(format!("Test {:?}", num))
-                .to_address(address.clone())
-                .from_address(address.clone())
+                .receiver_address(address.clone())
+                .sender_address(address.clone())
                 .build();
 
             contacts_db.save_message(message.clone()).expect("Message to be saved");
@@ -274,8 +274,8 @@ pub fn test_message_pagination() {
         for num in 0..3000 {
             let message = MessageBuilder::new()
                 .message(format!("Test {:?}", num))
-                .to_address(address.clone())
-                .from_address(address.clone())
+                .receiver_address(address.clone())
+                .sender_address(address.clone())
                 .build();
 
             contacts_db.save_message(message.clone()).expect("Message to be saved");

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -11584,8 +11584,8 @@ mod test {
                         alice_wallet_runtime.block_on(alice_wallet_contacts_service.send_message(Message {
                             body: vec![i],
                             metadata: vec![MessageMetadata::default()],
-                            to_address: alice_wallet_address.clone(),
-                            from_address: bob_wallet_address.clone(),
+                            receiver_address: alice_wallet_address.clone(),
+                            sender_address: bob_wallet_address.clone(),
                             direction: Direction::Outbound,
                             stored_at: u64::from(i),
                             sent_at: u64::from(i),
@@ -11602,8 +11602,8 @@ mod test {
                         bob_wallet_runtime.block_on(bob_wallet_contacts_service.send_message(Message {
                             body: vec![i],
                             metadata: vec![MessageMetadata::default()],
-                            from_address: alice_wallet_address.clone(),
-                            to_address: bob_wallet_address.clone(),
+                            sender_address: alice_wallet_address.clone(),
+                            receiver_address: bob_wallet_address.clone(),
                             direction: Direction::Outbound,
                             stored_at: u64::from(i),
                             sent_at: u64::from(i),

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -11584,7 +11584,8 @@ mod test {
                         alice_wallet_runtime.block_on(alice_wallet_contacts_service.send_message(Message {
                             body: vec![i],
                             metadata: vec![MessageMetadata::default()],
-                            address: bob_wallet_address.clone(),
+                            to_address: alice_wallet_address.clone(),
+                            from_address: bob_wallet_address.clone(),
                             direction: Direction::Outbound,
                             stored_at: u64::from(i),
                             sent_at: u64::from(i),
@@ -11601,7 +11602,8 @@ mod test {
                         bob_wallet_runtime.block_on(bob_wallet_contacts_service.send_message(Message {
                             body: vec![i],
                             metadata: vec![MessageMetadata::default()],
-                            address: alice_wallet_address.clone(),
+                            from_address: alice_wallet_address.clone(),
+                            to_address: bob_wallet_address.clone(),
                             direction: Direction::Outbound,
                             stored_at: u64::from(i),
                             sent_at: u64::from(i),


### PR DESCRIPTION
Description
---
split message to have dedicated to and from fields

Motivation and Context
---
This is needed for #6353 
When a chat client receives a message, it needs to know the complete address of the receiver, not just a part of it. This allows the user to get the complete address by saving what the sender said their address is