### PR TITLE
feat: remove ablity to send 1-sided tx

### DIFF
--- a/applications/minotari_console_wallet/src/automation/commands.rs
+++ b/applications/minotari_console_wallet/src/automation/commands.rs
@@ -224,30 +224,6 @@ pub async fn register_validator_node(
         .map_err(CommandError::TransactionServiceError)
 }
 
-/// Send a one-sided transaction to a recipient
-pub async fn send_one_sided(
-    mut wallet_transaction_service: TransactionServiceHandle,
-    fee_per_gram: u64,
-    amount: MicroMinotari,
-    selection_criteria: UtxoSelectionCriteria,
-    dest_address: TariAddress,
-    message: String,
-    payment_id: PaymentId,
-) -> Result<TxId, CommandError> {
-    wallet_transaction_service
-        .send_one_sided_transaction(
-            dest_address,
-            amount,
-            selection_criteria,
-            OutputFeatures::default(),
-            fee_per_gram * uT,
-            message,
-            payment_id,
-        )
-        .await
-        .map_err(CommandError::TransactionServiceError)
-}
-
 pub async fn send_one_sided_to_stealth_address(
     mut wallet_transaction_service: TransactionServiceHandle,
     fee_per_gram: u64,
@@ -447,18 +423,6 @@ pub async fn make_it_rain(
                     let tx_id = match transaction_type {
                         MakeItRainTransactionType::Interactive => {
                             send_tari(tx_service, fee, amount, address.clone(), msg.clone()).await
-                        },
-                        MakeItRainTransactionType::OneSided => {
-                            send_one_sided(
-                                tx_service,
-                                fee,
-                                amount,
-                                UtxoSelectionCriteria::default(),
-                                address.clone(),
-                                msg.clone(),
-                                PaymentId::Empty,
-                            )
-                            .await
                         },
                         MakeItRainTransactionType::StealthOneSided => {
                             send_one_sided_to_stealth_address(
@@ -721,25 +685,6 @@ pub async fn command_runner(
                         tx_ids.push(tx_id);
                     },
                     Err(e) => eprintln!("SendMinotari error! {}", e),
-                }
-            },
-            SendOneSided(args) => {
-                match send_one_sided(
-                    transaction_service.clone(),
-                    config.fee_per_gram,
-                    args.amount,
-                    UtxoSelectionCriteria::default(),
-                    args.destination,
-                    args.message,
-                    PaymentId::Empty,
-                )
-                .await
-                {
-                    Ok(tx_id) => {
-                        debug!(target: LOG_TARGET, "send-one-sided concluded with tx_id {}", tx_id);
-                        tx_ids.push(tx_id);
-                    },
-                    Err(e) => eprintln!("SendOneSided error! {}", e),
                 }
             },
             SendOneSidedToStealthAddress(args) => {

--- a/applications/minotari_console_wallet/src/cli.rs
+++ b/applications/minotari_console_wallet/src/cli.rs
@@ -116,7 +116,6 @@ pub enum CliCommands {
     GetBalance,
     SendMinotari(SendMinotariArgs),
     BurnMinotari(BurnMinotariArgs),
-    SendOneSided(SendMinotariArgs),
     SendOneSidedToStealthAddress(SendMinotariArgs),
     MakeItRain(MakeItRainArgs),
     CoinSplit(CoinSplitArgs),
@@ -185,8 +184,6 @@ impl MakeItRainArgs {
     pub fn transaction_type(&self) -> MakeItRainTransactionType {
         if self.stealth {
             MakeItRainTransactionType::StealthOneSided
-        } else if self.one_sided {
-            MakeItRainTransactionType::OneSided
         } else if self.burn_tari {
             MakeItRainTransactionType::BurnTari
         } else {
@@ -198,7 +195,6 @@ impl MakeItRainArgs {
 #[derive(Debug, Clone, Copy)]
 pub enum MakeItRainTransactionType {
     Interactive,
-    OneSided,
     StealthOneSided,
     BurnTari,
 }

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -142,6 +142,7 @@ pub struct WalletGrpcServer {
 }
 
 impl WalletGrpcServer {
+    #[allow(dead_code)]
     pub fn new(wallet: WalletSqlite) -> Result<Self, ConsensusBuilderError> {
         let rules = ConsensusManager::builder(wallet.network.as_network()).build()?;
         Ok(Self { wallet, rules })

--- a/applications/minotari_console_wallet/src/ui/components/send_tab.rs
+++ b/applications/minotari_console_wallet/src/ui/components/send_tab.rs
@@ -115,9 +115,7 @@ impl SendTab {
                 Span::styled("S", Style::default().add_modifier(Modifier::BOLD)),
                 Span::raw(" to send a normal transaction, "),
                 Span::styled("O", Style::default().add_modifier(Modifier::BOLD)),
-                Span::raw(" to send a one-sided transaction, "),
-                Span::styled("X", Style::default().add_modifier(Modifier::BOLD)),
-                Span::raw(" to send a one-sided transaction to a stealth address."),
+                Span::raw(" to send a one-sided transaction"),
             ]),
         ])
         .wrap(Wrap { trim: false })
@@ -260,9 +258,7 @@ impl SendTab {
             } else if 'y' == c {
                 match self.confirmation_dialog {
                     None => (),
-                    Some(ConfirmationDialogType::Normal) |
-                    Some(ConfirmationDialogType::OneSided) |
-                    Some(ConfirmationDialogType::StealthAddress) => {
+                    Some(ConfirmationDialogType::Normal) | Some(ConfirmationDialogType::StealthAddress) => {
                         if 'y' == c {
                             let amount = if let Ok(v) = self.amount_field.parse::<MicroMinotari>() {
                                 v
@@ -287,25 +283,6 @@ impl SendTab {
 
                             let mut reset_fields = false;
                             match self.confirmation_dialog {
-                                Some(ConfirmationDialogType::OneSided) => {
-                                    match Handle::current().block_on(app_state.send_one_sided_transaction(
-                                        self.to_field.clone(),
-                                        amount.into(),
-                                        UtxoSelectionCriteria::default(),
-                                        fee_per_gram,
-                                        self.message_field.clone(),
-                                        self.payment_id_field.clone(),
-                                        tx,
-                                    )) {
-                                        Err(e) => {
-                                            self.error_message = Some(format!(
-                                                "Error sending one-sided transaction:\n{}\nPress Enter to continue.",
-                                                e
-                                            ))
-                                        },
-                                        Ok(_) => reset_fields = true,
-                                    }
-                                },
                                 Some(ConfirmationDialogType::StealthAddress) => {
                                     match Handle::current().block_on(
                                         app_state.send_one_sided_to_stealth_address_transaction(
@@ -534,24 +511,12 @@ impl<B: Backend> Component<B> for SendTab {
                     9,
                 );
             },
-            Some(ConfirmationDialogType::OneSided) => {
-                draw_dialog(
-                    f,
-                    area,
-                    "Confirm Sending Transaction".to_string(),
-                    "Are you sure you want to send this one-sided transaction?\n(Y)es / (N)o".to_string(),
-                    Color::Red,
-                    120,
-                    9,
-                );
-            },
             Some(ConfirmationDialogType::StealthAddress) => {
                 draw_dialog(
                     f,
                     area,
                     "Confirm Sending Transaction".to_string(),
-                    "Are you sure you want to send this one-sided transaction to a stealth address?\n(Y)es / (N)o"
-                        .to_string(),
+                    "Are you sure you want to send this one-sided transaction?\n(Y)es / (N)o".to_string(),
                     Color::Red,
                     120,
                     9,
@@ -608,8 +573,7 @@ impl<B: Backend> Component<B> for SendTab {
             },
             'f' => self.send_input_mode = SendInputMode::Fee,
             'm' => self.send_input_mode = SendInputMode::Message,
-            'p' => self.send_input_mode = SendInputMode::PaymentId,
-            's' | 'o' | 'x' => {
+            's' | 'o' => {
                 if self.to_field.is_empty() {
                     self.error_message =
                         Some("Destination Tari Address/Emoji ID\nPress Enter to continue.".to_string());
@@ -626,8 +590,7 @@ impl<B: Backend> Component<B> for SendTab {
                 }
 
                 self.confirmation_dialog = Some(match c {
-                    'o' => ConfirmationDialogType::OneSided,
-                    'x' => ConfirmationDialogType::StealthAddress,
+                    'o' => ConfirmationDialogType::StealthAddress,
                     _ => ConfirmationDialogType::Normal,
                 });
             },
@@ -702,6 +665,5 @@ pub enum SendInputMode {
 #[derive(PartialEq, Debug)]
 pub enum ConfirmationDialogType {
     Normal,
-    OneSided,
     StealthAddress,
 }

--- a/applications/minotari_console_wallet/src/ui/state/app_state.rs
+++ b/applications/minotari_console_wallet/src/ui/state/app_state.rs
@@ -73,12 +73,7 @@ use crate::{
     ui::{
         state::{
             debouncer::BalanceEnquiryDebouncer,
-            tasks::{
-                send_burn_transaction_task,
-                send_one_sided_transaction_task,
-                send_register_template_transaction_task,
-                send_transaction_task,
-            },
+            tasks::{send_burn_transaction_task, send_register_template_transaction_task, send_transaction_task},
             wallet_event_monitor::WalletEventMonitor,
         },
         ui_burnt_proof::UiBurntProof,
@@ -323,43 +318,6 @@ impl AppState {
             output_features,
             message,
             fee_per_gram,
-            tx_service_handle,
-            result_tx,
-        ));
-
-        Ok(())
-    }
-
-    pub async fn send_one_sided_transaction(
-        &mut self,
-        address: String,
-        amount: u64,
-        selection_criteria: UtxoSelectionCriteria,
-        fee_per_gram: u64,
-        message: String,
-        payment_id: String,
-        result_tx: watch::Sender<UiTransactionSendStatus>,
-    ) -> Result<(), UiError> {
-        let inner = self.inner.write().await;
-        let address = match TariAddress::from_emoji_string(&address) {
-            Ok(address) => address,
-            Err(_) => TariAddress::from_bytes(&from_hex(&address).map_err(|_| UiError::PublicKeyParseError)?)
-                .map_err(|_| UiError::PublicKeyParseError)?,
-        };
-        let output_features = OutputFeatures { ..Default::default() };
-        let payment_id_bytes: Vec<u8> = payment_id.as_bytes().to_vec();
-        let payment_id = PaymentId::Open(payment_id_bytes);
-
-        let fee_per_gram = fee_per_gram * uT;
-        let tx_service_handle = inner.wallet.transaction_service.clone();
-        tokio::spawn(send_one_sided_transaction_task(
-            address,
-            MicroMinotari::from(amount),
-            selection_criteria,
-            output_features,
-            message,
-            fee_per_gram,
-            payment_id,
             tx_service_handle,
             result_tx,
         ));

--- a/applications/minotari_console_wallet/src/ui/state/tasks.rs
+++ b/applications/minotari_console_wallet/src/ui/state/tasks.rs
@@ -131,62 +131,6 @@ pub async fn send_transaction_task(
     }
 }
 
-pub async fn send_one_sided_transaction_task(
-    address: TariAddress,
-    amount: MicroMinotari,
-    selection_criteria: UtxoSelectionCriteria,
-    output_features: OutputFeatures,
-    message: String,
-    fee_per_gram: MicroMinotari,
-    payment_id: PaymentId,
-    mut transaction_service_handle: TransactionServiceHandle,
-    result_tx: watch::Sender<UiTransactionSendStatus>,
-) {
-    let _result = result_tx.send(UiTransactionSendStatus::Initiated);
-    let mut event_stream = transaction_service_handle.get_event_stream();
-    match transaction_service_handle
-        .send_one_sided_transaction(
-            address,
-            amount,
-            selection_criteria,
-            output_features,
-            fee_per_gram,
-            message,
-            payment_id,
-        )
-        .await
-    {
-        Err(e) => {
-            let _result = result_tx.send(UiTransactionSendStatus::Error(UiError::from(e).to_string()));
-        },
-        Ok(our_tx_id) => {
-            loop {
-                match event_stream.recv().await {
-                    Ok(event) => {
-                        if let TransactionEvent::TransactionCompletedImmediately(tx_id) = &*event {
-                            if our_tx_id == *tx_id {
-                                let _result = result_tx.send(UiTransactionSendStatus::TransactionComplete);
-                                return;
-                            }
-                        }
-                    },
-                    Err(e @ broadcast::error::RecvError::Lagged(_)) => {
-                        log::warn!(target: LOG_TARGET, "Error reading from event broadcast channel {:?}", e);
-                        continue;
-                    },
-                    Err(broadcast::error::RecvError::Closed) => {
-                        break;
-                    },
-                }
-            }
-
-            let _result = result_tx.send(UiTransactionSendStatus::Error(
-                "One-sided transaction could not be sent".to_string(),
-            ));
-        },
-    }
-}
-
 pub async fn send_one_sided_to_stealth_address_transaction(
     address: TariAddress,
     amount: MicroMinotari,

--- a/applications/minotari_console_wallet/src/wallet_modes.rs
+++ b/applications/minotari_console_wallet/src/wallet_modes.rs
@@ -525,7 +525,6 @@ mod test {
                 CliCommands::GetBalance => get_balance = true,
                 CliCommands::SendMinotari(_) => send_tari = true,
                 CliCommands::BurnMinotari(_) => burn_tari = true,
-                CliCommands::SendOneSided(_) => {},
                 CliCommands::SendOneSidedToStealthAddress(_) => {},
                 CliCommands::MakeItRain(_) => make_it_rain = true,
                 CliCommands::CoinSplit(_) => coin_split = true,

--- a/base_layer/tari_mining_helper_ffi/src/error.rs
+++ b/base_layer/tari_mining_helper_ffi/src/error.rs
@@ -49,6 +49,7 @@ pub enum InterfaceError {
 /// This struct is meant to hold an error for use by Miningcore. The error has an integer code and string
 /// message
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 pub struct MiningHelperError {
     pub code: i32,
     pub message: String,

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -3149,7 +3149,7 @@ unsigned long long wallet_send_transaction(struct TariWallet *wallet,
                                            unsigned long long fee_per_gram,
                                            const char *message,
                                            bool one_sided,
-                                           unsigned long long payment_id,
+                                           const char *payment_id_string,
                                            int *error_out);
 
 /**

--- a/integration_tests/tests/features/WalletCli.feature
+++ b/integration_tests/tests/features/WalletCli.feature
@@ -56,22 +56,6 @@ Feature: Wallet CLI
         When I mine 5 blocks on BASE
         Then all nodes are at height 20
         Then I get balance of wallet WALLET is at least 20000000000 uT via command line
-        #
-    @long-running
-    Scenario: As a user I want to send one-sided via command line
-        Given I have a seed node SEED
-        When I have a base node BASE connected to seed SEED
-        When I have wallet SENDER connected to base node BASE
-        When I have wallet RECEIVER connected to base node BASE
-        When I have mining node MINE connected to base node BASE and wallet SENDER
-        When mining node MINE mines 5 blocks
-        Then I wait for wallet SENDER to have at least 1100000 uT
-        When I wait 30 seconds
-        Then I stop wallet SENDER
-        Then I send one-sided 1000000 uT from SENDER to RECEIVER via command line
-        Then wallet SENDER has at least 1 transactions that are all TRANSACTION_STATUS_BROADCAST and not cancelled
-        When mining node MINE mines 5 blocks
-        Then I wait for wallet RECEIVER to have at least 1000000 uT
 
     @long-running
     Scenario: As a user I want to make-it-rain via command line

--- a/integration_tests/tests/steps/wallet_cli_steps.rs
+++ b/integration_tests/tests/steps/wallet_cli_steps.rs
@@ -184,38 +184,6 @@ async fn create_burn_tx_via_cli(world: &mut TariWorld, amount: u64, wallet: Stri
     spawn_wallet(world, wallet, Some(base_node.clone()), seed_nodes, None, Some(cli)).await;
 }
 
-#[then(expr = "I send one-sided {int} uT from {word} to {word} via command line")]
-async fn send_one_sided_tx_via_cli(world: &mut TariWorld, amount: u64, wallet_a: String, wallet_b: String) {
-    let wallet_ps = world.wallets.get_mut(&wallet_a).unwrap();
-    wallet_ps.kill();
-
-    tokio::time::sleep(Duration::from_secs(5)).await;
-
-    let mut wallet_b_client = create_wallet_client(world, wallet_b.clone()).await.unwrap();
-    let wallet_b_address = wallet_b_client
-        .get_address(Empty {})
-        .await
-        .unwrap()
-        .into_inner()
-        .address
-        .to_hex();
-    let wallet_b_address = TariAddress::from_hex(wallet_b_address.as_str()).unwrap();
-
-    let mut cli = get_default_cli();
-
-    let args = SendMinotariArgs {
-        amount: MicroMinotari(amount),
-        message: format!("Send one sided amount {} from {} to {}", amount, wallet_a, wallet_b),
-        destination: wallet_b_address,
-    };
-    cli.command2 = Some(CliCommands::SendOneSided(args));
-
-    let base_node = world.wallet_connected_to_base_node.get(&wallet_a).unwrap();
-    let seed_nodes = world.base_nodes.get(base_node).unwrap().seed_nodes.clone();
-
-    spawn_wallet(world, wallet_a, Some(base_node.clone()), seed_nodes, None, Some(cli)).await;
-}
-
 #[when(
     expr = "I make-it-rain from {word} rate {int} txns_per_sec duration {int} sec value {int} uT increment {int} uT \
             to {word} via command line"


### PR DESCRIPTION
Description
---
Removes the ability to send one-sided transactions from the CW, preferring to only send stealth one-sided

Motivation and Context
---
There is no benefit for sending normal one-sided, only negatives in regard to privacy 
