### PR TITLE
[wip]fix: chat sending using wrong address

### DIFF
--- a/base_layer/contacts/src/chat_client/src/client.rs
+++ b/base_layer/contacts/src/chat_client/src/client.rs
@@ -228,7 +228,7 @@ impl ChatClient for Client {
     async fn send_read_receipt(&self, message: Message) -> Result<(), Error> {
         if let Some(mut contacts_service) = self.contacts.clone() {
             contacts_service
-                .send_read_confirmation(message.receiver_address.clone(), message.message_id)
+                .send_read_confirmation(message.sender_address.clone(), message.message_id)
                 .await?;
         }
 

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -3149,7 +3149,7 @@ unsigned long long wallet_send_transaction(struct TariWallet *wallet,
                                            unsigned long long fee_per_gram,
                                            const char *message,
                                            bool one_sided,
-                                           unsigned long long payment_id,
+                                           const char *payment_id_string,
                                            int *error_out);
 
 /**


### PR DESCRIPTION
Description
---
Fixes chat using the wrong destination, and this getting the peer banned. 