### PR TITLE
fix: keep alpha key constant

### DIFF
--- a/applications/minotari_console_wallet/src/init/mod.rs
+++ b/applications/minotari_console_wallet/src/init/mod.rs
@@ -430,7 +430,6 @@ pub async fn init_wallet(
     };
 
     let master_seed = read_or_create_master_seed(recovery_seed.clone(), &wallet_db)?;
-    let wallet_type = read_or_create_wallet_type(wallet_type, &wallet_db);
 
     let node_identity = match config.wallet.identity_file.as_ref() {
         Some(identity_file) => {
@@ -476,7 +475,7 @@ pub async fn init_wallet(
         key_manager_backend,
         shutdown_signal,
         master_seed,
-        wallet_type.unwrap(),
+        wallet_type,
         user_agent,
     )
     .await
@@ -839,7 +838,7 @@ pub fn prompt_wallet_type(
 
             #[cfg(feature = "ledger")]
             {
-                if prompt("\r\nWould you like to use a connected hardware wallet? (Supported types: Ledger)") {
+                if prompt("\r\nWould you like to use a connected hardware wallet? (Supported types: Ledger) (Y/n)") {
                     print!("Scanning for connected Ledger hardware device... ");
                     match get_transport() {
                         Ok(hid) => {

--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -166,9 +166,10 @@ where
         key_manager_backend: TKeyManagerBackend,
         shutdown_signal: ShutdownSignal,
         master_seed: CipherSeed,
-        wallet_type: WalletType,
+        wallet_type: Option<WalletType>,
         user_agent: String,
     ) -> Result<Self, WalletError> {
+        let wallet_type = read_or_create_wallet_type(wallet_type, &wallet_database)?;
         let buf_size = cmp::max(WALLET_BUFFER_MIN_SIZE, config.buffer_size);
         let (publisher, subscription_factory) = pubsub_connector(buf_size);
         let peer_message_subscription_factory = Arc::new(subscription_factory);

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -5713,7 +5713,7 @@ pub unsafe extern "C" fn wallet_create(
         key_manager_backend,
         shutdown.to_signal(),
         master_seed,
-        WalletType::default(),
+        Some(WalletType::default()),
         user_agent,
     ));
 


### PR DESCRIPTION
Description
---
FFI now re-uses alpha from previous runs. 
Move DB read of the alpha key from console wallet to wallet lib

Motivation and Context
---
The alpha key should be constant across starts, the FFI creates a new alpha key on each startup
