### PR TITLE
fix: make tx id random

### DIFF
--- a/base_layer/core/src/transactions/transaction_protocol/mod.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/mod.rs
@@ -85,9 +85,7 @@
 
 // #![allow(clippy::op_ref)]
 
-use blake2::Blake2b;
 use derivative::Derivative;
-use digest::consts::U32;
 use serde::{Deserialize, Serialize};
 use tari_common_types::types::PrivateKey;
 use tari_crypto::{errors::RangeProofError, signatures::SchnorrSignatureError};
@@ -101,7 +99,6 @@ pub mod sender;
 pub mod single_receiver;
 pub mod transaction_initializer;
 use tari_common_types::types::Commitment;
-use tari_crypto::{hash_domain, hashing::DomainSeparatedHasher};
 use tari_key_manager::key_manager_service::KeyManagerServiceError;
 
 use crate::transactions::transaction_components::KernelFeatures;
@@ -198,13 +195,3 @@ impl TransactionMetadata {
 pub struct RecoveryData {
     pub encryption_key: PrivateKey,
 }
-
-// hash domain
-hash_domain!(
-    CalculateTxIdTransactionProtocolHashDomain,
-    "com.tari.base_layer.core.transactions.transaction_protocol.calculate_tx_id",
-    1
-);
-
-pub type CalculateTxIdTransactionProtocolHasherBlake256 =
-    DomainSeparatedHasher<Blake2b<U32>, CalculateTxIdTransactionProtocolHashDomain>;

--- a/base_layer/core/src/transactions/transaction_protocol/sender.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/sender.rs
@@ -27,7 +27,7 @@ use tari_common_types::{
     transaction::TxId,
     types::{ComAndPubSignature, PrivateKey, PublicKey, Signature},
 };
-use tari_crypto::{ristretto::pedersen::PedersenCommitment};
+use tari_crypto::ristretto::pedersen::PedersenCommitment;
 pub use tari_key_manager::key_manager_service::KeyId;
 use tari_script::TariScript;
 

--- a/base_layer/core/src/transactions/transaction_protocol/sender.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/sender.rs
@@ -27,11 +27,10 @@ use tari_common_types::{
     transaction::TxId,
     types::{ComAndPubSignature, PrivateKey, PublicKey, Signature},
 };
-use tari_crypto::{ristretto::pedersen::PedersenCommitment, tari_utilities::ByteArray};
+use tari_crypto::{ristretto::pedersen::PedersenCommitment};
 pub use tari_key_manager::key_manager_service::KeyId;
 use tari_script::TariScript;
 
-use super::CalculateTxIdTransactionProtocolHasherBlake256;
 use crate::{
     consensus::ConsensusConstants,
     covenants::Covenant,
@@ -774,16 +773,6 @@ impl fmt::Display for SenderTransactionProtocol {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.state)
     }
-}
-
-pub fn calculate_tx_id(pub_nonce: &PublicKey, index: usize) -> TxId {
-    let hash = CalculateTxIdTransactionProtocolHasherBlake256::new()
-        .chain(pub_nonce.as_bytes())
-        .chain(index.to_le_bytes())
-        .finalize();
-    let mut bytes: [u8; 8] = [0u8; 8];
-    bytes.copy_from_slice(&hash.as_ref()[..8]);
-    u64::from_le_bytes(bytes).into()
 }
 
 //----------------------------------------      Sender State      ----------------------------------------------------//

--- a/base_layer/core/src/transactions/transaction_protocol/transaction_initializer.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/transaction_initializer.rs
@@ -49,7 +49,7 @@ use crate::{
             MAX_TRANSACTION_OUTPUTS,
         },
         transaction_protocol::{
-            sender::{calculate_tx_id, OutputPair, RawTransactionInfo, SenderState, SenderTransactionProtocol},
+            sender::{OutputPair, RawTransactionInfo, SenderState, SenderTransactionProtocol},
             KernelFeatures,
             TransactionMetadata,
         },
@@ -526,18 +526,10 @@ where KM: TransactionKeyManagerInterface
             None => None,
         };
 
-        let spending_key = match self
-            .key_manager
-            .get_public_key_at_key_id(&self.inputs[0].output.spending_key_id)
-            .await
-        {
-            Ok(key) => key,
-            Err(e) => return self.build_err(&e.to_string()),
-        };
         // we need some random data here, the public excess of the commitment is random.
         let tx_id = match self.tx_id {
             Some(id) => id,
-            None => calculate_tx_id(&spending_key, 0),
+            None => TxId::new_random(),
         };
 
         // The fee should be less than the amount being sent. This isn't a protocol requirement, but it's what you want

--- a/base_layer/wallet/src/output_manager_service/recovery/standard_outputs_recoverer.rs
+++ b/base_layer/wallet/src/output_manager_service/recovery/standard_outputs_recoverer.rs
@@ -128,7 +128,7 @@ where
         let rewind_time = start.elapsed();
         trace!(
             target: LOG_TARGET,
-            "bulletproof rewind profile - rewound {} outputs in {} ms",
+            "UTXO recovery - checked {} outputs in {} ms",
             outputs_length,
             rewind_time.as_millis(),
         );


### PR DESCRIPTION
Description
---
Force tx_id to be random

Motivation and Context
---
If some apparent reason a transaction fails to be submitted after creation using any method that does not supply a random tx_id, the tx_id is created using the first output. But this will create deterministically create a tx_id. This mean you can never rerun that transaction as it will always create the same tx_id which results in a db unique constraint failure. 
