### PR TITLE
fix: update curve library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1384,9 +1384,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.2"
+version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1394,7 +1394,6 @@ dependencies = [
  "digest 0.10.7",
  "fiat-crypto",
  "group",
- "platforms",
  "rand_core",
  "rustc_version",
  "serde",
@@ -4454,12 +4453,6 @@ name = "pkg-config"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
-
-[[package]]
-name = "platforms"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14e6ab3f592e6fb464fc9712d8d6e6912de6473954635fd76a589d832cffcbb0"
 
 [[package]]
 name = "plotters"


### PR DESCRIPTION
Description
---
Updates the curve library dependency.

Motivation and Context
---
The curve library has a [timing vulnerability](https://github.com/advisories/GHSA-x4gp-pqpj-f43q) that was recently fixed. This PR updates the main lock file to pull in the patched version.

How Has This Been Tested?
---
Existing tests pass.

What process can a PR reviewer use to test or verify this change?
---
Confirm that the updated version is consistent with the security advisory.