### PR TITLE
fix: script dependance on party order

### DIFF
--- a/applications/minotari_console_wallet/src/cli.rs
+++ b/applications/minotari_console_wallet/src/cli.rs
@@ -214,7 +214,7 @@ pub struct FaucetEncumberAggregateUtxoArgs {
     #[clap(long)]
     pub output_hash: String,
     #[clap(long)]
-    pub script_input_shares: Vec<UniSignature>,
+    pub script_input_shares: Vec<String>,
     #[clap(long)]
     pub script_public_key_shares: Vec<UniPublicKey>,
     #[clap(long)]

--- a/base_layer/wallet/src/output_manager_service/handle.rs
+++ b/base_layer/wallet/src/output_manager_service/handle.rs
@@ -20,12 +20,12 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{fmt, fmt::Formatter, sync::Arc};
+use std::{collections::HashMap, fmt, fmt::Formatter, sync::Arc};
 
 use tari_common_types::{
     tari_address::TariAddress,
     transaction::TxId,
-    types::{Commitment, FixedHash, HashOutput, PublicKey, Signature},
+    types::{Commitment, FixedHash, HashOutput, PublicKey},
 };
 use tari_core::{
     covenants::Covenant,
@@ -38,7 +38,7 @@ use tari_core::{
     },
 };
 use tari_crypto::ristretto::pedersen::PedersenCommitment;
-use tari_script::TariScript;
+use tari_script::{CheckSigSchnorrSignature, TariScript};
 use tari_service_framework::reply_channel::SenderService;
 use tari_utilities::hex::Hex;
 use tokio::sync::broadcast;
@@ -66,8 +66,7 @@ pub enum OutputManagerRequest {
         fee_per_gram: MicroMinotari,
         output_hash: String,
         expected_commitment: PedersenCommitment,
-        script_input_shares: Vec<Signature>,
-        script_public_key_shares: Vec<PublicKey>,
+        script_input_shares: HashMap<PublicKey, CheckSigSchnorrSignature>,
         script_signature_public_nonces: Vec<PublicKey>,
         sender_offset_public_key_shares: Vec<PublicKey>,
         metadata_ephemeral_public_key_shares: Vec<PublicKey>,
@@ -759,14 +758,14 @@ impl OutputManagerHandle {
         }
     }
 
+    #[allow(clippy::mutable_key_type)]
     pub async fn encumber_aggregate_utxo(
         &mut self,
         tx_id: TxId,
         fee_per_gram: MicroMinotari,
         output_hash: String,
         expected_commitment: PedersenCommitment,
-        script_input_shares: Vec<Signature>,
-        script_public_key_shares: Vec<PublicKey>,
+        script_input_shares: HashMap<PublicKey, CheckSigSchnorrSignature>,
         script_signature_public_nonces: Vec<PublicKey>,
         sender_offset_public_key_shares: Vec<PublicKey>,
         metadata_ephemeral_public_key_shares: Vec<PublicKey>,
@@ -791,7 +790,6 @@ impl OutputManagerHandle {
                 output_hash,
                 expected_commitment,
                 script_input_shares,
-                script_public_key_shares,
                 script_signature_public_nonces,
                 sender_offset_public_key_shares,
                 metadata_ephemeral_public_key_shares,

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -88,6 +88,7 @@ use tari_script::{
     push_pubkey_script,
     script,
     slice_to_boxed_message,
+    CheckSigSchnorrSignature,
     ExecutionStack,
     ScriptContext,
     TariScript,
@@ -723,7 +724,6 @@ where
                 output_hash,
                 expected_commitment,
                 script_input_shares,
-                script_public_key_shares,
                 script_signature_public_nonces,
                 sender_offset_public_key_shares,
                 metadata_ephemeral_public_key_shares,
@@ -735,7 +735,6 @@ where
                     output_hash,
                     expected_commitment,
                     script_input_shares,
-                    script_public_key_shares,
                     script_signature_public_nonces,
                     sender_offset_public_key_shares,
                     metadata_ephemeral_public_key_shares,
@@ -1377,13 +1376,13 @@ where
     }
 
     /// Creates an encumbered uninitialized transaction
+    #[allow(clippy::mutable_key_type)]
     pub async fn encumber_aggregate_tx(
         &mut self,
         fee_per_gram: MicroMinotari,
         output_hash: String,
         expected_commitment: PedersenCommitment,
-        script_input_shares: Vec<Signature>,
-        script_public_key_shares: Vec<PublicKey>,
+        script_input_shares: HashMap<PublicKey, CheckSigSchnorrSignature>,
         script_signature_public_nonces: Vec<PublicKey>,
         sender_offset_public_key_shares: Vec<PublicKey>,
         metadata_ephemeral_public_key_shares: Vec<PublicKey>,
@@ -1401,7 +1400,6 @@ where
                 output_hash,
                 expected_commitment,
                 script_input_shares,
-                script_public_key_shares,
                 script_signature_public_nonces,
                 sender_offset_public_key_shares,
                 metadata_ephemeral_public_key_shares,

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -9522,19 +9522,19 @@ mod test {
     #[test]
     fn test_emoji_convert() {
         unsafe {
-            let byte = 0 as u8;
+            let byte = 0u8;
             let emoji_ptr = byte_to_emoji(byte);
             let emoji = CStr::from_ptr(emoji_ptr);
 
             assert_eq!(emoji.to_str().unwrap(), EMOJI[0].to_string());
 
-            let byte = 50 as u8;
+            let byte = 50u8;
             let emoji_ptr = byte_to_emoji(byte);
             let emoji = CStr::from_ptr(emoji_ptr);
 
             assert_eq!(emoji.to_str().unwrap(), EMOJI[50].to_string());
 
-            let byte = 125 as u8;
+            let byte = 125u8;
             let emoji_ptr = byte_to_emoji(byte);
             let emoji = CStr::from_ptr(emoji_ptr);
 


### PR DESCRIPTION
Description
---
fixes script dependence on party order

Motivation and Context
---
Currently, the m-of-n ceremony is dependant on the leader selection to succeed or not. This fixes the process so that the leader correctly constructs the input stack for the script in the correct order. 

How Has This Been Tested?
---
manual

