### PR TITLE
feat!: fix key manager use of keys

### DIFF
--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -230,7 +230,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
     async fn get_address(&self, _: Request<tari_rpc::Empty>) -> Result<Response<GetAddressResponse>, Status> {
         let address = self
             .wallet
-            .get_wallet_address()
+            .get_wallet_interactive_address()
             .await
             .map_err(|e| Status::internal(format!("{:?}", e)))?;
         Ok(Response::new(GetAddressResponse {
@@ -662,7 +662,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
             .map_err(|err| Status::unknown(err.to_string()))?;
         let wallet_address = self
             .wallet
-            .get_wallet_address()
+            .get_wallet_interactive_address()
             .await
             .map_err(|e| Status::internal(format!("{:?}", e)))?;
         let transactions = transactions

--- a/applications/minotari_console_wallet/src/ui/app.rs
+++ b/applications/minotari_console_wallet/src/ui/app.rs
@@ -82,11 +82,11 @@ impl<B: Backend> App<B> {
         let wallet_address_interactive = wallet
             .get_wallet_interactive_address()
             .await
-            .map_err(|e| WalletError::KeyManagerServiceError(e))?;
+            .map_err(WalletError::KeyManagerServiceError)?;
         let wallet_address_one_sided = wallet
             .get_wallet_one_sided_address()
             .await
-            .map_err(|e| WalletError::KeyManagerServiceError(e))?;
+            .map_err(WalletError::KeyManagerServiceError)?;
         let wallet_id = WalletIdentity::new(
             wallet.comms.node_identity(),
             wallet_address_interactive,

--- a/applications/minotari_console_wallet/src/ui/app.rs
+++ b/applications/minotari_console_wallet/src/ui/app.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use minotari_wallet::{util::wallet_identity::WalletIdentity, WalletConfig, WalletSqlite};
+use minotari_wallet::{error::WalletError, util::wallet_identity::WalletIdentity, WalletConfig, WalletSqlite};
 use tari_common::exit_codes::ExitError;
 use tari_comms::peer_manager::Peer;
 use tokio::runtime::Handle;
@@ -29,7 +29,7 @@ use tui::{
     layout::{Constraint, Direction, Layout},
     Frame,
 };
-use minotari_wallet::error::WalletError;
+
 use crate::{
     notifier::Notifier,
     ui::{
@@ -79,8 +79,14 @@ impl<B: Backend> App<B> {
         base_node_config: PeerConfig,
         notifier: Notifier,
     ) -> Result<Self, ExitError> {
-        let wallet_address_interactive = wallet.get_wallet_interactive_address().await.map_err(|e| WalletError::KeyManagerServiceError(e))?;
-        let wallet_address_one_sided = wallet.get_wallet_one_sided_address().await.map_err(|e| WalletError::KeyManagerServiceError(e))?;
+        let wallet_address_interactive = wallet
+            .get_wallet_interactive_address()
+            .await
+            .map_err(|e| WalletError::KeyManagerServiceError(e))?;
+        let wallet_address_one_sided = wallet
+            .get_wallet_one_sided_address()
+            .await
+            .map_err(|e| WalletError::KeyManagerServiceError(e))?;
         let wallet_id = WalletIdentity::new(
             wallet.comms.node_identity(),
             wallet_address_interactive,

--- a/applications/minotari_console_wallet/src/ui/app.rs
+++ b/applications/minotari_console_wallet/src/ui/app.rs
@@ -79,8 +79,13 @@ impl<B: Backend> App<B> {
         base_node_config: PeerConfig,
         notifier: Notifier,
     ) -> Result<Self, ExitError> {
-        let wallet_address = wallet.get_wallet_address().await?;
-        let wallet_id = WalletIdentity::new(wallet.comms.node_identity(), wallet_address);
+        let wallet_address_interactive = wallet.get_wallet_interactive_address().await?;
+        let wallet_address_one_sided = wallet.get_wallet_one_sided_address().await?;
+        let wallet_id = WalletIdentity::new(
+            wallet.comms.node_identity(),
+            wallet_address_interactive,
+            wallet_address_one_sided,
+        );
         let app_state = AppState::new(
             &wallet_id,
             wallet,

--- a/applications/minotari_console_wallet/src/ui/app.rs
+++ b/applications/minotari_console_wallet/src/ui/app.rs
@@ -29,7 +29,7 @@ use tui::{
     layout::{Constraint, Direction, Layout},
     Frame,
 };
-
+use minotari_wallet::error::WalletError;
 use crate::{
     notifier::Notifier,
     ui::{
@@ -79,8 +79,8 @@ impl<B: Backend> App<B> {
         base_node_config: PeerConfig,
         notifier: Notifier,
     ) -> Result<Self, ExitError> {
-        let wallet_address_interactive = wallet.get_wallet_interactive_address().await?;
-        let wallet_address_one_sided = wallet.get_wallet_one_sided_address().await?;
+        let wallet_address_interactive = wallet.get_wallet_interactive_address().await.map_err(|e| WalletError::KeyManagerServiceError(e))?;
+        let wallet_address_one_sided = wallet.get_wallet_one_sided_address().await.map_err(|e| WalletError::KeyManagerServiceError(e))?;
         let wallet_id = WalletIdentity::new(
             wallet.comms.node_identity(),
             wallet_address_interactive,

--- a/applications/minotari_console_wallet/src/ui/components/receive_tab.rs
+++ b/applications/minotari_console_wallet/src/ui/components/receive_tab.rs
@@ -29,7 +29,7 @@ impl ReceiveTab {
 
         let chunks = Layout::default()
             .direction(Direction::Vertical)
-            .constraints([Constraint::Length(6), Constraint::Length(23)].as_ref())
+            .constraints([Constraint::Length(8), Constraint::Length(23)].as_ref())
             .margin(1)
             .split(area);
 
@@ -46,6 +46,8 @@ impl ReceiveTab {
                     Constraint::Length(1),
                     Constraint::Length(1),
                     Constraint::Length(1),
+                    Constraint::Length(1),
+                    Constraint::Length(1),
                 ]
                 .as_ref(),
             )
@@ -57,54 +59,76 @@ impl ReceiveTab {
             .title(Span::styled("Connection Details", Style::default().fg(Color::White)));
         f.render_widget(block, chunks[0]);
 
-        const ITEM_01: &str = "Tari Address:     ";
-        const ITEM_02: &str = "Node ID:        ";
-        const ITEM_03: &str = "Network Address: ";
-        const ITEM_04: &str = "Emoji ID:       ";
+        const ITEM_01: &str = "Tari Address interactive:   ";
+        const ITEM_02: &str = "Tari Address one-sided:     ";
+        const ITEM_03: &str = "Node ID:                    ";
+        const ITEM_04: &str = "Network Address:            ";
+        const ITEM_05: &str = "Interactive emoji address:  ";
+        const ITEM_06: &str = "One-sided emoji address:    ";
 
         // Tari address
-        let tari_address_text = Spans::from(vec![
+        let tari_address_interactive_text = Spans::from(vec![
             Span::styled(ITEM_01, Style::default().fg(Color::Magenta)),
             Span::styled(
-                app_state.get_identity().tari_address.clone(),
+                app_state.get_identity().tari_address_interactive.to_base58(),
                 Style::default().fg(Color::White),
             ),
         ]);
-        let paragraph = Paragraph::new(tari_address_text).block(Block::default());
+        let paragraph = Paragraph::new(tari_address_interactive_text).block(Block::default());
         f.render_widget(paragraph, details_chunks[0]);
+
+        let tari_address_one_sided_text = Spans::from(vec![
+            Span::styled(ITEM_02, Style::default().fg(Color::Magenta)),
+            Span::styled(
+                app_state.get_identity().tari_address_one_sided.to_base58(),
+                Style::default().fg(Color::White),
+            ),
+        ]);
+        let paragraph = Paragraph::new(tari_address_one_sided_text).block(Block::default());
+        f.render_widget(paragraph, details_chunks[1]);
 
         // NodeId
         let node_id_text = Spans::from(vec![
-            Span::styled(ITEM_02, Style::default().fg(Color::Magenta)),
+            Span::styled(ITEM_03, Style::default().fg(Color::Magenta)),
             Span::styled(
                 app_state.get_identity().node_id.clone(),
                 Style::default().fg(Color::White),
             ),
         ]);
         let paragraph = Paragraph::new(node_id_text).block(Block::default());
-        f.render_widget(paragraph, details_chunks[1]);
+        f.render_widget(paragraph, details_chunks[2]);
 
         // Public Address
         let public_address_text = Spans::from(vec![
-            Span::styled(ITEM_03, Style::default().fg(Color::Magenta)),
+            Span::styled(ITEM_04, Style::default().fg(Color::Magenta)),
             Span::styled(
                 app_state.get_identity().network_address.clone(),
                 Style::default().fg(Color::White),
             ),
         ]);
         let paragraph = Paragraph::new(public_address_text).block(Block::default());
-        f.render_widget(paragraph, details_chunks[2]);
+        f.render_widget(paragraph, details_chunks[3]);
 
         // Emoji ID
         let emoji_id_text = Spans::from(vec![
-            Span::styled(ITEM_04, Style::default().fg(Color::Magenta)),
+            Span::styled(ITEM_05, Style::default().fg(Color::Magenta)),
             Span::styled(
-                app_state.get_identity().emoji_id.clone(),
+                app_state.get_identity().tari_address_interactive.to_emoji_string(),
                 Style::default().fg(Color::White),
             ),
         ]);
         let paragraph = Paragraph::new(emoji_id_text).block(Block::default());
-        f.render_widget(paragraph, details_chunks[3]);
+        f.render_widget(paragraph, details_chunks[4]);
+
+        let emoji_id_text = Spans::from(vec![
+            Span::styled(ITEM_06, Style::default().fg(Color::Magenta)),
+            Span::styled(
+                app_state.get_identity().tari_address_one_sided.to_emoji_string(),
+                Style::default().fg(Color::White),
+            ),
+        ]);
+        let paragraph = Paragraph::new(emoji_id_text).block(Block::default());
+        f.render_widget(paragraph, details_chunks[5]);
     }
 }
 

--- a/applications/minotari_console_wallet/src/ui/state/app_state.rs
+++ b/applications/minotari_console_wallet/src/ui/state/app_state.rs
@@ -897,11 +897,10 @@ impl AppStateInner {
 
     pub async fn refresh_network_id(&mut self) -> Result<(), UiError> {
         let wallet_id = self.wallet.get_wallet_id().await?;
-        let eid = wallet_id.address.to_emoji_string();
         let qr_link = format!(
             "tari://{}/transactions/send?tariAddress={}",
             wallet_id.network(),
-            wallet_id.address.to_base58()
+            wallet_id.address_interactive.to_base58()
         );
         let code = QrCode::new(qr_link).unwrap();
         let image = code
@@ -913,7 +912,8 @@ impl AppStateInner {
             .skip(1)
             .fold("".to_string(), |acc, l| format!("{}{}\n", acc, l));
         let identity = MyIdentity {
-            tari_address: wallet_id.address.to_base58(),
+            tari_address_interactive: wallet_id.address_interactive.clone(),
+            tari_address_one_sided: wallet_id.address_one_sided.clone(),
             network_address: wallet_id
                 .node_identity
                 .public_addresses()
@@ -921,7 +921,6 @@ impl AppStateInner {
                 .map(|a| a.to_string())
                 .collect::<Vec<_>>()
                 .join(", "),
-            emoji_id: eid,
             qr_code: image,
             node_id: wallet_id.node_identity.node_id().to_string(),
         };
@@ -1234,11 +1233,10 @@ pub struct EventListItem {
 
 impl AppStateData {
     pub fn new(wallet_identity: &WalletIdentity, base_node_selected: Peer, base_node_config: PeerConfig) -> Self {
-        let eid = wallet_identity.address.to_emoji_string();
         let qr_link = format!(
             "tari://{}/transactions/send?tariAddress={}",
             wallet_identity.network(),
-            wallet_identity.address.to_base58()
+            wallet_identity.address_interactive.to_base58()
         );
         let code = QrCode::new(qr_link).unwrap();
         let image = code
@@ -1251,7 +1249,8 @@ impl AppStateData {
             .fold("".to_string(), |acc, l| format!("{}{}\n", acc, l));
 
         let identity = MyIdentity {
-            tari_address: wallet_identity.address.to_base58(),
+            tari_address_interactive: wallet_identity.address_interactive.clone(),
+            tari_address_one_sided: wallet_identity.address_one_sided.clone(),
             network_address: wallet_identity
                 .node_identity
                 .public_addresses()
@@ -1259,7 +1258,6 @@ impl AppStateData {
                 .map(|a| a.to_string())
                 .collect::<Vec<_>>()
                 .join(", "),
-            emoji_id: eid,
             qr_code: image,
             node_id: wallet_identity.node_identity.node_id().to_string(),
         };
@@ -1309,9 +1307,9 @@ impl AppStateData {
 
 #[derive(Clone)]
 pub struct MyIdentity {
-    pub tari_address: String,
+    pub tari_address_interactive: TariAddress,
+    pub tari_address_one_sided: TariAddress,
     pub network_address: String,
-    pub emoji_id: String,
     pub qr_code: String,
     pub node_id: String,
 }

--- a/base_layer/common_types/src/lib.rs
+++ b/base_layer/common_types/src/lib.rs
@@ -21,7 +21,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 // This is the string used to derive the comms/spend key of the wallet
-pub const COMMS: &str = "comms";
+pub const WALLET_COMMS_AND_SPEND_KEY_BRANCH: &str = "comms";
 
 pub mod burnt_proof;
 pub mod chain_metadata;

--- a/base_layer/common_types/src/lib.rs
+++ b/base_layer/common_types/src/lib.rs
@@ -20,6 +20,9 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+// This is the string used to derive the comms/spend key of the wallet
+pub const COMMS: &str = "comms";
+
 pub mod burnt_proof;
 pub mod chain_metadata;
 pub mod dammsum;

--- a/base_layer/common_types/src/wallet_types.rs
+++ b/base_layer/common_types/src/wallet_types.rs
@@ -32,6 +32,7 @@ use ledger_transport::APDUCommand;
 use minotari_ledger_wallet_comms::ledger_wallet::{Command, Instruction};
 use serde::{Deserialize, Serialize};
 use tari_common::configuration::Network;
+use tari_crypto::keys::PublicKey as PublicKeyTrait;
 
 use crate::types::{PrivateKey, PublicKey};
 
@@ -40,6 +41,7 @@ pub enum WalletType {
     #[default]
     Software,
     Ledger(LedgerWallet),
+    Imported(ImportedWallet),
 }
 
 impl Display for WalletType {
@@ -47,7 +49,23 @@ impl Display for WalletType {
         match self {
             WalletType::Software => write!(f, "Software"),
             WalletType::Ledger(ledger_wallet) => write!(f, "Ledger({ledger_wallet})"),
+            WalletType::Imported(imported_wallet) => write!(f, "Imported({imported_wallet})"),
         }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ImportedWallet {
+    pub public_spend_key: PublicKey,
+    pub private_spend_key: Option<PrivateKey>,
+    pub view_key: PrivateKey,
+}
+
+impl Display for ImportedWallet {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "public spend key {}", self.public_spend_key)?;
+        write!(f, "public view key{}", PublicKey::from_secret_key(&self.view_key))?;
+        Ok(())
     }
 }
 

--- a/base_layer/core/src/transactions/key_manager/inner.rs
+++ b/base_layer/core/src/transactions/key_manager/inner.rs
@@ -187,12 +187,6 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
         Ok((key_id, public_key))
     }
 
-    pub async fn create_key_pair(&mut self, branch: &str) -> Result<(TariKeyId, PublicKey), KeyManagerServiceError> {
-        self.add_key_manager_branch(branch)?;
-        let (key_id, public_key) = self.get_next_key(branch).await?;
-        Ok((key_id, public_key))
-    }
-
     pub async fn get_static_key(&self, branch: &str) -> Result<TariKeyId, KeyManagerServiceError> {
         match self.key_managers.get(branch) {
             None => Err(KeyManagerServiceError::UnknownKeyBranch),
@@ -260,23 +254,7 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
                 Ok(km.derive_public_key(*index)?.key)
             },
             KeyId::Derived { branch, label, index } => {
-                let public_alpha = match &self.wallet_type {
-                    WalletType::Software => {
-                        let km = self
-                            .key_managers
-                            .get(&TransactionKeyManagerBranch::Alpha.get_branch_key())
-                            .ok_or(KeyManagerServiceError::UnknownKeyBranch)?
-                            .read()
-                            .await;
-
-                        km.derive_public_key(0)?.key
-                    },
-                    WalletType::Ledger(ledger) => {
-                        ledger.public_alpha.clone().ok_or(KeyManagerServiceError::LedgerError(
-                            "Key manager set to use ledger, ledger alpha public key missing".to_string(),
-                        ))?
-                    },
-                };
+                let public_alpha = self.get_spend_key().await?.1;
                 let km = self
                     .key_managers
                     .get(branch)
@@ -300,18 +278,143 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
         }
     }
 
-    fn get_domain_hasher(
-        label: &str,
-    ) -> Result<DomainSeparatedHasher<Blake2b<U64>, KeyManagerTransactionsHashDomain>, KeyManagerServiceError> {
-        let tx_label = label.parse::<TransactionKeyManagerLabel>().map_err(|e| {
-            KeyManagerServiceError::UnknownError(format!("Could not retrieve label for derived key: {}", e))
-        })?;
-        match tx_label {
-            TransactionKeyManagerLabel::ScriptKey => Ok(DomainSeparatedHasher::<
-                Blake2b<U64>,
-                KeyManagerTransactionsHashDomain,
-            >::new_with_label("script key")),
+    pub(crate) async fn get_private_key(&self, key_id: &TariKeyId) -> Result<PrivateKey, KeyManagerServiceError> {
+        match key_id {
+            KeyId::Managed { branch, index } => {
+                // ledger has special rules here
+                if let WalletType::Ledger(wallet) = &self.wallet_type {
+                    // In the event we're asking for the view key, and we use a ledger, reference the stored key
+                    if &TransactionKeyManagerBranch::DataEncryption.get_branch_key() == branch {
+                        return wallet
+                            .view_key
+                            .clone()
+                            .ok_or(KeyManagerServiceError::LedgerViewKeyInaccessible);
+                    }
+
+                    // If we're trying to access any of the private keys, just say no bueno
+                    if &TransactionKeyManagerBranch::Spend.get_branch_key() == branch ||
+                        &TransactionKeyManagerBranch::SenderOffset.get_branch_key() == branch ||
+                        &TransactionKeyManagerBranch::MetadataEphemeralNonce.get_branch_key() == branch
+                    {
+                        return Err(KeyManagerServiceError::LedgerPrivateKeyInaccessible);
+                    }
+                };
+
+                // imported wallet type has special rules here
+                if let WalletType::Imported(wallet) = &self.wallet_type {
+                    if &TransactionKeyManagerBranch::DataEncryption.get_branch_key() == branch {
+                        return Ok(wallet.view_key.clone());
+                    }
+
+                    // If we're trying to access any of the private keys, just say no bueno
+                    if &TransactionKeyManagerBranch::Spend.get_branch_key() == branch {
+                        return wallet
+                            .private_spend_key
+                            .clone()
+                            .ok_or(KeyManagerServiceError::ImportedPrivateKeyInaccessible);
+                    }
+                };
+
+                let km = self
+                    .key_managers
+                    .get(branch)
+                    .ok_or(KeyManagerServiceError::UnknownKeyBranch)?
+                    .read()
+                    .await;
+                let key = km.get_private_key(*index)?;
+                Ok(key)
+            },
+            KeyId::Derived { branch, label, index } => match &self.wallet_type {
+                WalletType::Ledger(_) => Err(KeyManagerServiceError::LedgerPrivateKeyInaccessible),
+                WalletType::Software => {
+                    let km = self
+                        .key_managers
+                        .get(&TransactionKeyManagerBranch::Spend.get_branch_key())
+                        .ok_or(KeyManagerServiceError::UnknownKeyBranch)?
+                        .read()
+                        .await;
+                    let private_alpha = km.get_private_key(0)?;
+                    let km = self
+                        .key_managers
+                        .get(branch)
+                        .ok_or(KeyManagerServiceError::UnknownKeyBranch)?
+                        .read()
+                        .await;
+                    let branch_key = km.get_private_key(*index)?;
+                    let hasher = Self::get_domain_hasher(label)?;
+                    let hasher = hasher.chain(branch_key.as_bytes()).finalize();
+                    let private_key = PrivateKey::from_uniform_bytes(hasher.as_ref()).map_err(|_| {
+                        KeyManagerServiceError::UnknownError(format!("Invalid private key for {}", label))
+                    })?;
+                    let private_key = private_key + private_alpha;
+                    Ok(private_key)
+                },
+                WalletType::Imported(imported) => {
+                    let private_alpha = imported
+                        .private_spend_key
+                        .clone()
+                        .ok_or(KeyManagerServiceError::ImportedPrivateKeyInaccessible)?;
+
+                    let km = self
+                        .key_managers
+                        .get(branch)
+                        .ok_or(KeyManagerServiceError::UnknownKeyBranch)?
+                        .read()
+                        .await;
+                    let branch_key = km.get_private_key(*index)?;
+                    let hasher = Self::get_domain_hasher(label)?;
+                    let hasher = hasher.chain(branch_key.as_bytes()).finalize();
+                    let private_key = PrivateKey::from_uniform_bytes(hasher.as_ref()).map_err(|_| {
+                        KeyManagerServiceError::UnknownError(format!("Invalid private key for {}", label))
+                    })?;
+                    let private_key = private_key + private_alpha;
+                    Ok(private_key)
+                },
+            },
+            KeyId::Imported { key } => {
+                let pvt_key = self.db.get_imported_key(key)?;
+                Ok(pvt_key)
+            },
+            KeyId::Zero => Ok(PrivateKey::default()),
         }
+    }
+
+    pub async fn get_view_key(&self) -> Result<(TariKeyId, PublicKey), KeyManagerServiceError> {
+        let key_id = KeyId::Managed {
+            branch: TransactionKeyManagerBranch::DataEncryption.get_branch_key(),
+            index: 0,
+        };
+        let key = PublicKey::from_secret_key(&self.get_private_view_key().await?);
+        Ok((key_id, key))
+    }
+
+    pub async fn get_spend_key(&self) -> Result<(TariKeyId, PublicKey), KeyManagerServiceError> {
+        let key_id = KeyId::Managed {
+            branch: TransactionKeyManagerBranch::Spend.get_branch_key(),
+            index: 0,
+        };
+
+        let key = match &self.wallet_type {
+            WalletType::Software => {
+                let private_key = self.get_private_key(&key_id).await?;
+                PublicKey::from_secret_key(&private_key)
+            },
+            WalletType::Ledger(ledger) => ledger.public_alpha.clone().ok_or(KeyManagerServiceError::LedgerError(
+                "Key manager set to use ledger, ledger alpha public key missing".to_string(),
+            ))?,
+            WalletType::Imported(imported) => imported.public_spend_key.clone(),
+        };
+        Ok((key_id, key))
+    }
+
+    pub async fn get_comms_key(&self) -> Result<(TariKeyId, PublicKey), KeyManagerServiceError> {
+        let key_id = KeyId::Managed {
+            branch: TransactionKeyManagerBranch::Spend.get_branch_key(),
+            index: 0,
+        };
+        let private_key = self.get_private_comms_key().await?;
+        let key = PublicKey::from_secret_key(&private_key);
+        Ok((key_id, key))
     }
 
     pub async fn get_next_spend_and_script_key_ids(
@@ -330,6 +433,54 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
         };
         let script_public_key = self.get_public_key_at_key_id(&script_key_id).await?;
         Ok((spend_key_id, spend_public_key, script_key_id, script_public_key))
+    }
+
+    pub async fn import_key(&self, private_key: PrivateKey) -> Result<TariKeyId, KeyManagerServiceError> {
+        let public_key = PublicKey::from_secret_key(&private_key);
+        let hex_key = public_key.to_hex();
+        self.db.insert_imported_key(public_key.clone(), private_key)?;
+        trace!(target: LOG_TARGET, "Imported key {}", hex_key);
+        let key_id = KeyId::Imported { key: public_key };
+        Ok(key_id)
+    }
+
+    async fn get_private_view_key(&self) -> Result<PrivateKey, KeyManagerServiceError> {
+        match &self.wallet_type {
+            WalletType::Software => {
+                self.get_private_key(&TariKeyId::Managed {
+                    branch: TransactionKeyManagerBranch::DataEncryption.get_branch_key(),
+                    index: 0,
+                })
+                .await
+            },
+            WalletType::Ledger(ledger) => ledger
+                .view_key
+                .clone()
+                .ok_or(KeyManagerServiceError::LedgerViewKeyInaccessible),
+            WalletType::Imported(imported) => Ok(imported.view_key.clone()),
+        }
+    }
+
+    async fn get_private_comms_key(&self) -> Result<PrivateKey, KeyManagerServiceError> {
+        self.get_private_key(&TariKeyId::Managed {
+            branch: TransactionKeyManagerBranch::Spend.get_branch_key(),
+            index: 0,
+        })
+        .await
+    }
+
+    fn get_domain_hasher(
+        label: &str,
+    ) -> Result<DomainSeparatedHasher<Blake2b<U64>, KeyManagerTransactionsHashDomain>, KeyManagerServiceError> {
+        let tx_label = label.parse::<TransactionKeyManagerLabel>().map_err(|e| {
+            KeyManagerServiceError::UnknownError(format!("Could not retrieve label for derived key: {}", e))
+        })?;
+        match tx_label {
+            TransactionKeyManagerLabel::ScriptKey => Ok(DomainSeparatedHasher::<
+                Blake2b<U64>,
+                KeyManagerTransactionsHashDomain,
+            >::new_with_label("script key")),
+        }
     }
 
     /// Calculates a script key id from the spend key id, if a public key is provided, it will only return a result of
@@ -903,7 +1054,7 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
                     label: _,
                     index,
                 } => match &self.wallet_type {
-                    WalletType::Software => {
+                    WalletType::Software | WalletType::Imported(_) => {
                         total_script_private_key =
                             total_script_private_key + self.get_private_key(script_key_id).await?;
                     },
@@ -924,7 +1075,7 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
         }
 
         match &self.wallet_type {
-            WalletType::Software => {
+            WalletType::Software | WalletType::Imported(_) => {
                 let mut total_sender_offset_private_key = PrivateKey::default();
                 for sender_offset_key_id in sender_offset_key_ids {
                     total_sender_offset_private_key =
@@ -1278,14 +1429,6 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
     // Encrypted data section (transactions > transaction_components > encrypted_data)
     // -----------------------------------------------------------------------------------------------------------------
 
-    async fn get_view_key(&self) -> Result<PrivateKey, KeyManagerServiceError> {
-        self.get_private_key(&TariKeyId::Managed {
-            branch: TransactionKeyManagerBranch::DataEncryption.get_branch_key(),
-            index: 0,
-        })
-        .await
-    }
-
     pub async fn encrypt_data_for_recovery(
         &self,
         spend_key_id: &TariKeyId,
@@ -1296,7 +1439,7 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
         let recovery_key = if let Some(key_id) = custom_recovery_key_id {
             self.get_private_key(key_id).await?
         } else {
-            self.get_view_key().await?
+            self.get_private_view_key().await?
         };
         let value_key = value.into();
         let commitment = self.get_commitment(spend_key_id, &value_key).await?;
@@ -1313,7 +1456,7 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
         let recovery_key = if let Some(key_id) = custom_recovery_key_id {
             self.get_private_key(key_id).await?
         } else {
-            self.get_view_key().await?
+            self.get_private_view_key().await?
         };
         let (value, private_key, payment_id) =
             EncryptedData::decrypt_data(&recovery_key, output.commitment(), output.encrypted_data())?;

--- a/base_layer/core/src/transactions/key_manager/interface.rs
+++ b/base_layer/core/src/transactions/key_manager/interface.rs
@@ -28,6 +28,7 @@ use strum_macros::EnumIter;
 use tari_common_types::types::{ComAndPubSignature, Commitment, PrivateKey, PublicKey, RangeProof, Signature};
 use tari_comms::types::CommsDHKE;
 use tari_crypto::{hashing::DomainSeparatedHash, ristretto::RistrettoComSig};
+use tari_common_types::COMMS;
 use tari_key_manager::key_manager_service::{KeyId, KeyManagerInterface, KeyManagerServiceError};
 use tari_script::CheckSigSchnorrSignature;
 
@@ -65,6 +66,7 @@ pub enum TransactionKeyManagerBranch {
     KernelNonce = 0x05,
     SenderOffset = 0x06,
     SenderOffsetLedger = 0x07,
+    Spend = 0x07,
 }
 
 impl TransactionKeyManagerBranch {
@@ -80,6 +82,7 @@ impl TransactionKeyManagerBranch {
             TransactionKeyManagerBranch::KernelNonce => "kernel nonce".to_string(),
             TransactionKeyManagerBranch::SenderOffset => "sender offset".to_string(),
             TransactionKeyManagerBranch::SenderOffsetLedger => "sender offset ledger".to_string(),
+            TransactionKeyManagerBranch::Spend => COMMS.to_string(),
         }
     }
 
@@ -93,6 +96,7 @@ impl TransactionKeyManagerBranch {
             "sender offset" => TransactionKeyManagerBranch::SenderOffset,
             "sender offset ledger" => TransactionKeyManagerBranch::SenderOffsetLedger,
             "nonce" => TransactionKeyManagerBranch::Nonce,
+            COMMS => TransactionKeyManagerBranch::Spend,
             _ => TransactionKeyManagerBranch::Nonce,
         }
     }
@@ -144,7 +148,11 @@ pub trait TransactionKeyManagerInterface: KeyManagerInterface<PublicKey> {
         value: u64,
     ) -> Result<bool, KeyManagerServiceError>;
 
-    async fn get_view_key_id(&self) -> Result<TariKeyId, KeyManagerServiceError>;
+    async fn get_view_key(&self) -> Result<(TariKeyId, PublicKey), KeyManagerServiceError>;
+
+    async fn get_spend_key(&self) -> Result<(TariKeyId, PublicKey), KeyManagerServiceError>;
+
+    async fn get_comms_key(&self) -> Result<(TariKeyId, PublicKey), KeyManagerServiceError>;
 
     async fn get_next_spend_and_script_key_ids(
         &self,

--- a/base_layer/core/src/transactions/key_manager/interface.rs
+++ b/base_layer/core/src/transactions/key_manager/interface.rs
@@ -61,12 +61,12 @@ pub enum TxoStage {
 #[derive(Clone, Copy, EnumIter)]
 pub enum TransactionKeyManagerBranch {
     DataEncryption = 0x00,
-    MetadataEphemeralNonce = 0x02,
-    CommitmentMask = 0x03,
-    Nonce = 0x04,
-    KernelNonce = 0x05,
-    SenderOffset = 0x06,
-    SenderOffsetLedger = 0x07,
+    MetadataEphemeralNonce = 0x01,
+    CommitmentMask = 0x02,
+    Nonce = 0x03,
+    KernelNonce = 0x04,
+    SenderOffset = 0x05,
+    SenderOffsetLedger = 0x06,
     Spend = 0x07,
 }
 

--- a/base_layer/core/src/transactions/key_manager/interface.rs
+++ b/base_layer/core/src/transactions/key_manager/interface.rs
@@ -27,7 +27,7 @@ use digest::consts::U64;
 use strum_macros::EnumIter;
 use tari_common_types::{
     types::{ComAndPubSignature, Commitment, PrivateKey, PublicKey, RangeProof, Signature},
-    COMMS,
+    WALLET_COMMS_AND_SPEND_KEY_BRANCH,
 };
 use tari_comms::types::CommsDHKE;
 use tari_crypto::{hashing::DomainSeparatedHash, ristretto::RistrettoComSig};
@@ -82,7 +82,7 @@ impl TransactionKeyManagerBranch {
             TransactionKeyManagerBranch::KernelNonce => "kernel nonce".to_string(),
             TransactionKeyManagerBranch::SenderOffset => "sender offset".to_string(),
             TransactionKeyManagerBranch::SenderOffsetLedger => "sender offset ledger".to_string(),
-            TransactionKeyManagerBranch::Spend => COMMS.to_string(),
+            TransactionKeyManagerBranch::Spend => WALLET_COMMS_AND_SPEND_KEY_BRANCH.to_string(),
         }
     }
 
@@ -95,7 +95,7 @@ impl TransactionKeyManagerBranch {
             "sender offset" => TransactionKeyManagerBranch::SenderOffset,
             "sender offset ledger" => TransactionKeyManagerBranch::SenderOffsetLedger,
             "nonce" => TransactionKeyManagerBranch::Nonce,
-            COMMS => TransactionKeyManagerBranch::Spend,
+            WALLET_COMMS_AND_SPEND_KEY_BRANCH => TransactionKeyManagerBranch::Spend,
             _ => TransactionKeyManagerBranch::Nonce,
         }
     }

--- a/base_layer/core/src/transactions/key_manager/interface.rs
+++ b/base_layer/core/src/transactions/key_manager/interface.rs
@@ -25,10 +25,12 @@ use std::str::FromStr;
 use blake2::Blake2b;
 use digest::consts::U64;
 use strum_macros::EnumIter;
-use tari_common_types::types::{ComAndPubSignature, Commitment, PrivateKey, PublicKey, RangeProof, Signature};
+use tari_common_types::{
+    types::{ComAndPubSignature, Commitment, PrivateKey, PublicKey, RangeProof, Signature},
+    COMMS,
+};
 use tari_comms::types::CommsDHKE;
 use tari_crypto::{hashing::DomainSeparatedHash, ristretto::RistrettoComSig};
-use tari_common_types::COMMS;
 use tari_key_manager::key_manager_service::{KeyId, KeyManagerInterface, KeyManagerServiceError};
 use tari_script::CheckSigSchnorrSignature;
 
@@ -59,7 +61,6 @@ pub enum TxoStage {
 #[derive(Clone, Copy, EnumIter)]
 pub enum TransactionKeyManagerBranch {
     DataEncryption = 0x00,
-    Alpha = 0x01,
     MetadataEphemeralNonce = 0x02,
     CommitmentMask = 0x03,
     Nonce = 0x04,
@@ -75,7 +76,6 @@ impl TransactionKeyManagerBranch {
     pub fn get_branch_key(self) -> String {
         match self {
             TransactionKeyManagerBranch::DataEncryption => "data encryption".to_string(),
-            TransactionKeyManagerBranch::Alpha => "alpha".to_string(),
             TransactionKeyManagerBranch::CommitmentMask => "commitment mask".to_string(),
             TransactionKeyManagerBranch::Nonce => "nonce".to_string(),
             TransactionKeyManagerBranch::MetadataEphemeralNonce => "metadata ephemeral nonce".to_string(),
@@ -89,7 +89,6 @@ impl TransactionKeyManagerBranch {
     pub fn from_key(key: &str) -> Self {
         match key {
             "data encryption" => TransactionKeyManagerBranch::DataEncryption,
-            "alpha" => TransactionKeyManagerBranch::Alpha,
             "commitment mask" => TransactionKeyManagerBranch::CommitmentMask,
             "metadata ephemeral nonce" => TransactionKeyManagerBranch::MetadataEphemeralNonce,
             "kernel nonce" => TransactionKeyManagerBranch::KernelNonce,
@@ -315,11 +314,6 @@ pub trait TransactionKeyManagerInterface: KeyManagerInterface<PublicKey> {
         amount: &PrivateKey,
         claim_public_key: &PublicKey,
     ) -> Result<RistrettoComSig, TransactionError>;
-
-    async fn create_key_pair<T: Into<String> + Send>(
-        &self,
-        branch: T,
-    ) -> Result<(TariKeyId, PublicKey), KeyManagerServiceError>;
 }
 
 #[async_trait::async_trait]

--- a/base_layer/core/src/transactions/key_manager/wrapper.rs
+++ b/base_layer/core/src/transactions/key_manager/wrapper.rs
@@ -46,7 +46,6 @@ use crate::transactions::{
     key_manager::{
         interface::{SecretTransactionKeyManagerInterface, TxoStage},
         TariKeyId,
-        TransactionKeyManagerBranch,
         TransactionKeyManagerInner,
         TransactionKeyManagerInterface,
     },
@@ -203,22 +202,15 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
     }
 
     async fn get_view_key(&self) -> Result<(TariKeyId, PublicKey), KeyManagerServiceError> {
-        let key_id = self.get_static_key(TransactionKeyManagerBranch::DataEncryption.get_branch_key())
-            .await?;
-        let key = self.get_public_key_at_key_id(&key_id).await?;
-        Ok((key_id, key))
+        self.transaction_key_manager_inner.read().await.get_view_key().await
     }
+
     async fn get_spend_key(&self) -> Result<(TariKeyId, PublicKey), KeyManagerServiceError> {
-        let key_id = self.get_static_key(TransactionKeyManagerBranch::Spend.get_branch_key())
-            .await?;
-        let key = self.get_public_key_at_key_id(&key_id).await?;
-        Ok((key_id, key))
+        self.transaction_key_manager_inner.read().await.get_spend_key().await
     }
+
     async fn get_comms_key(&self) -> Result<(TariKeyId, PublicKey), KeyManagerServiceError> {
-        let key_id = self.get_static_key(TransactionKeyManagerBranch::Spend.get_branch_key())
-            .await?;
-        let key = self.get_public_key_at_key_id(&key_id).await?;
-        Ok((key_id, key))
+        self.transaction_key_manager_inner.read().await.get_comms_key().await
     }
 
     async fn get_next_spend_and_script_key_ids(
@@ -548,17 +540,6 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
             .read()
             .await
             .generate_burn_proof(spending_key, amount, claim_public_key)
-            .await
-    }
-
-    async fn create_key_pair<T: Into<String> + Send>(
-        &self,
-        branch: T,
-    ) -> Result<(TariKeyId, PublicKey), KeyManagerServiceError> {
-        self.transaction_key_manager_inner
-            .write()
-            .await
-            .create_key_pair(&branch.into())
             .await
     }
 }

--- a/base_layer/core/src/transactions/key_manager/wrapper.rs
+++ b/base_layer/core/src/transactions/key_manager/wrapper.rs
@@ -202,9 +202,23 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
             .await
     }
 
-    async fn get_view_key_id(&self) -> Result<TariKeyId, KeyManagerServiceError> {
-        self.get_static_key(TransactionKeyManagerBranch::DataEncryption.get_branch_key())
-            .await
+    async fn get_view_key(&self) -> Result<(TariKeyId, PublicKey), KeyManagerServiceError> {
+        let key_id = self.get_static_key(TransactionKeyManagerBranch::DataEncryption.get_branch_key())
+            .await?;
+        let key = self.get_public_key_at_key_id(&key_id).await?;
+        Ok((key_id, key))
+    }
+    async fn get_spend_key(&self) -> Result<(TariKeyId, PublicKey), KeyManagerServiceError> {
+        let key_id = self.get_static_key(TransactionKeyManagerBranch::Spend.get_branch_key())
+            .await?;
+        let key = self.get_public_key_at_key_id(&key_id).await?;
+        Ok((key_id, key))
+    }
+    async fn get_comms_key(&self) -> Result<(TariKeyId, PublicKey), KeyManagerServiceError> {
+        let key_id = self.get_static_key(TransactionKeyManagerBranch::Spend.get_branch_key())
+            .await?;
+        let key = self.get_public_key_at_key_id(&key_id).await?;
+        Ok((key_id, key))
     }
 
     async fn get_next_spend_and_script_key_ids(

--- a/base_layer/key_manager/src/key_manager_service/error.rs
+++ b/base_layer/key_manager/src/key_manager_service/error.rs
@@ -57,6 +57,8 @@ pub enum KeyManagerServiceError {
     LedgerViewKeyInaccessible,
     #[error("Tari Key Manager storage error: `{0}`")]
     StorageError(#[from] StorageError),
+    #[error("The imported private key cannot be accessed or read")]
+    ImportedPrivateKeyInaccessible,
 }
 
 impl From<RangeProofError> for KeyManagerServiceError {

--- a/base_layer/key_manager/src/key_manager_service/interface.rs
+++ b/base_layer/key_manager/src/key_manager_service/interface.rs
@@ -26,7 +26,7 @@ use std::{fmt, str::FromStr};
 
 use serde::{Deserialize, Serialize};
 use strum_macros::EnumIter;
-use tari_common_types::COMMS;
+use tari_common_types::WALLET_COMMS_AND_SPEND_KEY_BRANCH;
 use tari_crypto::keys::{PublicKey, SecretKey};
 use tari_utilities::{hex::Hex, ByteArray};
 
@@ -43,7 +43,7 @@ impl KeyManagerBranch {
     /// recovery.
     pub fn get_branch_key(self) -> String {
         match self {
-            KeyManagerBranch::Comms => COMMS.to_string(),
+            KeyManagerBranch::Comms => WALLET_COMMS_AND_SPEND_KEY_BRANCH.to_string(),
         }
     }
 }

--- a/base_layer/key_manager/src/key_manager_service/interface.rs
+++ b/base_layer/key_manager/src/key_manager_service/interface.rs
@@ -28,7 +28,7 @@ use serde::{Deserialize, Serialize};
 use strum_macros::EnumIter;
 use tari_crypto::keys::{PublicKey, SecretKey};
 use tari_utilities::{hex::Hex, ByteArray};
-
+use tari_common_types::COMMS;
 use crate::key_manager_service::error::KeyManagerServiceError;
 
 #[repr(u8)]
@@ -42,7 +42,7 @@ impl KeyManagerBranch {
     /// recovery.
     pub fn get_branch_key(self) -> String {
         match self {
-            KeyManagerBranch::Comms => "comms".to_string(),
+            KeyManagerBranch::Comms => COMMS.to_string(),
         }
     }
 }

--- a/base_layer/key_manager/src/key_manager_service/interface.rs
+++ b/base_layer/key_manager/src/key_manager_service/interface.rs
@@ -26,9 +26,10 @@ use std::{fmt, str::FromStr};
 
 use serde::{Deserialize, Serialize};
 use strum_macros::EnumIter;
+use tari_common_types::COMMS;
 use tari_crypto::keys::{PublicKey, SecretKey};
 use tari_utilities::{hex::Hex, ByteArray};
-use tari_common_types::COMMS;
+
 use crate::key_manager_service::error::KeyManagerServiceError;
 
 #[repr(u8)]

--- a/base_layer/key_manager/src/key_manager_service/service.rs
+++ b/base_layer/key_manager/src/key_manager_service/service.rs
@@ -31,7 +31,7 @@ use tari_crypto::{
     hashing::DomainSeparatedHasher,
     keys::{PublicKey, SecretKey},
 };
-use tari_utilities::{hex::Hex, ByteArray};
+use tari_utilities::ByteArray;
 
 use crate::{
     cipher_seed::CipherSeed,
@@ -217,9 +217,7 @@ where
 
     pub async fn import_key(&self, private_key: PK::K) -> Result<KeyId<PK>, KeyManagerServiceError> {
         let public_key = PK::from_secret_key(&private_key);
-        let hex_key = public_key.to_hex();
         self.db.insert_imported_key(public_key.clone(), private_key)?;
-        trace!(target: LOG_TARGET, "Imported key {}", hex_key);
         let key_id = KeyId::Imported { key: public_key };
         Ok(key_id)
     }

--- a/base_layer/wallet/src/output_manager_service/mod.rs
+++ b/base_layer/wallet/src/output_manager_service/mod.rs
@@ -33,7 +33,7 @@ pub mod service;
 pub mod storage;
 mod tasks;
 
-use std::{marker::PhantomData};
+use std::marker::PhantomData;
 
 use futures::future;
 use log::*;

--- a/base_layer/wallet/src/output_manager_service/resources.rs
+++ b/base_layer/wallet/src/output_manager_service/resources.rs
@@ -23,12 +23,10 @@
 use tari_core::{consensus::ConsensusConstants, transactions::CryptoFactories};
 use tari_shutdown::ShutdownSignal;
 
-use crate::{
-    output_manager_service::{
-        config::OutputManagerServiceConfig,
-        handle::OutputManagerEventSender,
-        storage::database::OutputManagerDatabase,
-    },
+use crate::output_manager_service::{
+    config::OutputManagerServiceConfig,
+    handle::OutputManagerEventSender,
+    storage::database::OutputManagerDatabase,
 };
 
 /// This struct is a collection of the common resources that a async task in the service requires.

--- a/base_layer/wallet/src/output_manager_service/resources.rs
+++ b/base_layer/wallet/src/output_manager_service/resources.rs
@@ -29,7 +29,6 @@ use crate::{
         handle::OutputManagerEventSender,
         storage::database::OutputManagerDatabase,
     },
-    util::wallet_identity::WalletIdentity,
 };
 
 /// This struct is a collection of the common resources that a async task in the service requires.
@@ -43,5 +42,4 @@ pub(crate) struct OutputManagerResources<TBackend, TWalletConnectivity, TKeyMana
     pub consensus_constants: ConsensusConstants,
     pub connectivity: TWalletConnectivity,
     pub shutdown_signal: ShutdownSignal,
-    pub wallet_identity: WalletIdentity,
 }

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -33,7 +33,7 @@ use tari_common_types::{
     transaction::TxId,
     types::{BlockHash, Commitment, HashOutput, PrivateKey, PublicKey},
 };
-use tari_comms::{types::CommsDHKE};
+use tari_comms::types::CommsDHKE;
 use tari_core::{
     borsh::SerializedSize,
     consensus::{ConsensusConstants, DomainSeparatedConsensusHasher},
@@ -170,7 +170,6 @@ where
     }
 
     pub async fn start(mut self) -> Result<(), OutputManagerError> {
-
         let request_stream = self
             .request_stream
             .take()
@@ -1236,10 +1235,7 @@ where
                     .key_manager
                     .sign_script_message(&self.resources.key_manager.get_spend_key().await?.0, &script_challange)
                     .await?;
-                script_input_shares.insert(
-                    self.resources.key_manager.get_spend_key().await?.1,
-                    self_signature,
-                );
+                script_input_shares.insert(self.resources.key_manager.get_spend_key().await?.1, self_signature);
 
                 // the order here is important, we need to add the signatures in the same order as public keys where
                 // added to the script originally

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -28,13 +28,12 @@ use digest::consts::U32;
 use futures::{pin_mut, StreamExt};
 use log::*;
 use rand::{rngs::OsRng, RngCore};
-use tari_common::configuration::Network;
 use tari_common_types::{
     tari_address::TariAddress,
     transaction::TxId,
     types::{BlockHash, Commitment, HashOutput, PrivateKey, PublicKey},
 };
-use tari_comms::{types::CommsDHKE, NodeIdentity};
+use tari_comms::{types::CommsDHKE};
 use tari_core::{
     borsh::SerializedSize,
     consensus::{ConsensusConstants, DomainSeparatedConsensusHasher},
@@ -111,7 +110,6 @@ use crate::{
         tasks::TxoValidationTask,
         TRANSACTION_INPUTS_LIMIT,
     },
-    util::wallet_identity::WalletIdentity,
 };
 
 const LOG_TARGET: &str = "wallet::output_manager_service";
@@ -149,15 +147,8 @@ where
         shutdown_signal: ShutdownSignal,
         base_node_service: BaseNodeServiceHandle,
         connectivity: TWalletConnectivity,
-        node_identity: Arc<NodeIdentity>,
-        network: Network,
         key_manager: TKeyManagerInterface,
     ) -> Result<Self, OutputManagerError> {
-        let view_key = key_manager.get_view_key_id().await?;
-        let view_key = key_manager.get_public_key_at_key_id(&view_key).await?;
-        let tari_address =
-            TariAddress::new_dual_address_with_default_features(view_key, node_identity.public_key().clone(), network);
-        let wallet_identity = WalletIdentity::new(node_identity.clone(), tari_address);
         let resources = OutputManagerResources {
             config,
             db,
@@ -167,7 +158,6 @@ where
             key_manager,
             consensus_constants,
             shutdown_signal,
-            wallet_identity,
         };
 
         Ok(Self {
@@ -180,12 +170,6 @@ where
     }
 
     pub async fn start(mut self) -> Result<(), OutputManagerError> {
-        // we need to ensure the wallet identity secret key is stored in the key manager
-        let _key_id = self
-            .resources
-            .key_manager
-            .import_key(self.resources.wallet_identity.node_identity.secret_key().clone())
-            .await?;
 
         let request_stream = self
             .request_stream
@@ -1250,10 +1234,10 @@ where
                 let self_signature = self
                     .resources
                     .key_manager
-                    .sign_script_message(&self.resources.wallet_identity.wallet_node_key_id, &script_challange)
+                    .sign_script_message(&self.resources.key_manager.get_spend_key().await?.0, &script_challange)
                     .await?;
                 script_input_shares.insert(
-                    self.resources.wallet_identity.address.public_spend_key().clone(),
+                    self.resources.key_manager.get_spend_key().await?.1,
                     self_signature,
                 );
 
@@ -1263,7 +1247,7 @@ where
                     if let Some(signature) = script_input_shares.get(&key) {
                         script_signatures.push(StackItem::Signature(signature.clone()));
                         // our own key should not be added yet, it will be added with the script signing
-                        if &key != self.resources.wallet_identity.address.public_spend_key() {
+                        if key != self.resources.key_manager.get_spend_key().await?.1 {
                             aggregated_script_public_key_shares = aggregated_script_public_key_shares + key;
                         }
                     }
@@ -1276,7 +1260,7 @@ where
                     output.features,
                     output.script,
                     ExecutionStack::new(script_signatures),
-                    self.resources.wallet_identity.wallet_node_key_id.clone(), // Only of the master wallet
+                    self.resources.key_manager.get_spend_key().await?.0, // Only of the master wallet
                     output.sender_offset_public_key,
                     output.metadata_signature,
                     0,
@@ -1435,7 +1419,7 @@ where
             .await?
             .with_input_data(ExecutionStack::default()) // Just a placeholder in the wallet
             .with_sender_offset_public_key(sender_offset_public_key)
-            .with_script_key(self.resources.wallet_identity.wallet_node_key_id.clone())
+            .with_script_key(self.resources.key_manager.get_spend_key().await?.0)
             .with_minimum_value_promise(minimum_value_promise)
             .sign_partial_as_sender_and_receiver(
                 &self.resources.key_manager,
@@ -2477,7 +2461,7 @@ where
             .resources
             .key_manager
             .get_diffie_hellman_shared_secret(
-                &self.resources.key_manager.get_view_key_id().await?,
+                &self.resources.key_manager.get_view_key().await?.0,
                 &output.sender_offset_public_key,
             )
             .await?;
@@ -2494,7 +2478,7 @@ where
                     output.features,
                     output.script,
                     inputs!(pre_image),
-                    self.resources.wallet_identity.wallet_node_key_id.clone(),
+                    self.resources.key_manager.get_spend_key().await?.0,
                     output.sender_offset_public_key,
                     output.metadata_signature,
                     // Although the technically the script does have a script lock higher than 0, this does not apply
@@ -2689,9 +2673,8 @@ where
             ));
         }
 
-        let wallet_sk = self.resources.wallet_identity.wallet_node_key_id.clone();
-        let wallet_pk = self.resources.key_manager.get_public_key_at_key_id(&wallet_sk).await?;
-        let wallet_view_key = self.resources.key_manager.get_view_key_id().await?;
+        let (wallet_sk, wallet_pk) = self.resources.key_manager.get_spend_key().await?;
+        let (wallet_view_key, _) = self.resources.key_manager.get_view_key().await?;
 
         let mut scanned_outputs = vec![];
 

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_receive_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_receive_protocol.rs
@@ -435,7 +435,7 @@ where
             let completed_transaction = CompletedTransaction::new(
                 self.id,
                 self.source_address.clone(),
-                self.resources.wallet_identity.address.clone(),
+                self.resources.tari_address.clone(),
                 inbound_tx.amount,
                 finalized_transaction
                     .body

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_send_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_send_protocol.rs
@@ -593,7 +593,7 @@ where
 
         let completed_transaction = CompletedTransaction::new(
             tx_id,
-            self.resources.wallet_identity.address.clone(),
+            self.resources.tari_address.clone(),
             outbound_tx.destination_address,
             outbound_tx.amount,
             outbound_tx.fee,

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -20,7 +20,12 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{collections::{HashMap, HashSet}, convert::TryInto, sync::Arc, time::{Duration, Instant}};
+use std::{
+    collections::{HashMap, HashSet},
+    convert::TryInto,
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 use chrono::{NaiveDateTime, Utc};
 use digest::Digest;
@@ -136,7 +141,7 @@ use crate::{
         },
         utc::utc_duration_since,
     },
-    util::{watch::Watch},
+    util::watch::Watch,
     utxo_scanner_service::RECOVERY_KEY,
     OperationId,
 };

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -20,12 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{
-    collections::{HashMap, HashSet},
-    convert::TryInto,
-    sync::Arc,
-    time::{Duration, Instant},
-};
+use std::{collections::{HashMap, HashSet}, convert::TryInto, sync::Arc, time::{Duration, Instant}};
 
 use chrono::{NaiveDateTime, Utc};
 use digest::Digest;
@@ -84,7 +79,6 @@ use tari_crypto::{
 use tari_key_manager::key_manager_service::KeyId;
 use tari_p2p::domain_message::DomainMessage;
 use tari_script::{
-    inputs,
     push_pubkey_script,
     script,
     slice_to_boxed_message,
@@ -142,7 +136,7 @@ use crate::{
         },
         utc::utc_duration_since,
     },
-    util::{wallet_identity::WalletIdentity, watch::Watch},
+    util::{watch::Watch},
     utxo_scanner_service::RECOVERY_KEY,
     OperationId,
 };
@@ -260,11 +254,9 @@ where
     ) -> Result<Self, TransactionServiceError> {
         // Collect the resources that all protocols will need so that they can be neatly cloned as the protocols are
         // spawned.
-        let view_key = core_key_manager_service.get_view_key_id().await?;
-        let view_key = core_key_manager_service.get_public_key_at_key_id(&view_key).await?;
+        let (_view_key_id, view_key) = core_key_manager_service.get_view_key().await?;
         let tari_address =
             TariAddress::new_dual_address_with_default_features(view_key, node_identity.public_key().clone(), network);
-        let wallet_identity = WalletIdentity::new(node_identity.clone(), tari_address);
         let resources = TransactionServiceResources {
             db: db.clone(),
             output_manager_service,
@@ -272,7 +264,8 @@ where
             outbound_message_service,
             connectivity,
             event_publisher: event_publisher.clone(),
-            wallet_identity,
+            tari_address,
+            node_identity: node_identity.clone(),
             factories,
             config: config.clone(),
             shutdown_signal,
@@ -313,13 +306,6 @@ where
 
     #[allow(clippy::too_many_lines)]
     pub async fn start(mut self) -> Result<(), TransactionServiceError> {
-        // we need to ensure the wallet identity secret key is stored in the key manager
-        let _key_id = self
-            .resources
-            .transaction_key_manager_service
-            .import_key(self.resources.wallet_identity.node_identity.secret_key().clone())
-            .await?;
-
         let request_stream = self
             .request_stream
             .take()
@@ -432,7 +418,7 @@ where
                         }
                         Err(e) => {
                             warn!(target: LOG_TARGET, "Failed to handle incoming Transaction message: {} for NodeID: {}, Trace: {}",
-                                e, self.resources.wallet_identity.node_identity.node_id().short_str(), msg.dht_header.message_tag);
+                                e, self.resources.node_identity.node_id().short_str(), msg.dht_header.message_tag);
                             let _size = self.event_publisher.send(Arc::new(TransactionEvent::Error(format!("Error handling \
                                 Transaction Sender message: {:?}", e).to_string())));
                         }
@@ -455,12 +441,12 @@ where
                         Err(TransactionServiceError::TransactionDoesNotExistError) => {
                             trace!(target: LOG_TARGET, "Unable to handle incoming Transaction Reply message from NodeId: \
                             {} due to Transaction not existing. This usually means the message was a repeated message \
-                            from Store and Forward, Trace: {}", self.resources.wallet_identity.node_identity.node_id().short_str(),
+                            from Store and Forward, Trace: {}", self.resources.node_identity.node_id().short_str(),
                             msg.dht_header.message_tag);
                         },
                         Err(e) => {
                             warn!(target: LOG_TARGET, "Failed to handle incoming Transaction Reply message: {} \
-                            for NodeId: {}, Trace: {}", e, self.resources.wallet_identity.node_identity.node_id().short_str(),
+                            for NodeId: {}, Trace: {}", e, self.resources.node_identity.node_id().short_str(),
                             msg.dht_header.message_tag);
                             let _size = self.event_publisher.send(Arc::new(TransactionEvent::Error("Error handling \
                             Transaction Recipient Reply message".to_string())));
@@ -491,12 +477,12 @@ where
                         Err(TransactionServiceError::TransactionDoesNotExistError) => {
                             trace!(target: LOG_TARGET, "Unable to handle incoming Finalized Transaction message from NodeId: \
                             {} due to Transaction not existing. This usually means the message was a repeated message \
-                            from Store and Forward, Trace: {}", self.resources.wallet_identity.node_identity.node_id().short_str(),
+                            from Store and Forward, Trace: {}", self.resources.node_identity.node_id().short_str(),
                             msg.dht_header.message_tag);
                         },
                        Err(e) => {
                             warn!(target: LOG_TARGET, "Failed to handle incoming Transaction Finalized message: {} \
-                            for NodeID: {}, Trace: {}", e , self.resources.wallet_identity.node_identity.node_id().short_str(),
+                            for NodeID: {}, Trace: {}", e , self.resources.node_identity.node_id().short_str(),
                             msg.dht_header.message_tag.as_value());
                             let _size = self.event_publisher.send(Arc::new(TransactionEvent::Error("Error handling Transaction \
                             Finalized message".to_string(),)));
@@ -516,7 +502,7 @@ where
                     trace!(target: LOG_TARGET, "Handling Base Node Response, Trace: {}", msg.dht_header.message_tag);
                     let _result = self.handle_base_node_response(inner_msg).await.map_err(|e| {
                         warn!(target: LOG_TARGET, "Error handling base node service response from {}: {:?} for \
-                        NodeID: {}, Trace: {}", origin_public_key, e, self.resources.wallet_identity.node_identity.node_id().short_str(),
+                        NodeID: {}, Trace: {}", origin_public_key, e, self.resources.node_identity.node_id().short_str(),
                         msg.dht_header.message_tag.as_value());
                         e
                     });
@@ -1086,7 +1072,7 @@ where
         reply_channel: oneshot::Sender<Result<TransactionServiceResponse, TransactionServiceError>>,
     ) -> Result<(), TransactionServiceError> {
         let tx_id = TxId::new_random();
-        if destination.network() != self.resources.wallet_identity.address.network() {
+        if destination.network() != self.resources.tari_address.network() {
             let _result = reply_channel
                 .send(Err(TransactionServiceError::InvalidNetwork))
                 .inspect_err(|_| {
@@ -1095,7 +1081,7 @@ where
             return Err(TransactionServiceError::InvalidNetwork);
         }
         // If we're paying ourselves, let's complete and submit the transaction immediately
-        if self.resources.wallet_identity.address.comms_public_key() == destination.comms_public_key() {
+        if &self.resources.transaction_key_manager_service.get_comms_key().await?.1 == destination.comms_public_key() {
             debug!(
                 target: LOG_TARGET,
                 "Received transaction with spend-to-self transaction"
@@ -1116,8 +1102,8 @@ where
                 transaction_broadcast_join_handles,
                 CompletedTransaction::new(
                     tx_id,
-                    self.resources.wallet_identity.address.clone(),
-                    self.resources.wallet_identity.address.clone(),
+                    self.resources.tari_address.clone(),
+                    self.resources.tari_address.clone(),
                     amount,
                     fee,
                     transaction,
@@ -1355,8 +1341,8 @@ where
             transaction_broadcast_join_handles,
             CompletedTransaction::new(
                 tx_id,
-                self.resources.wallet_identity.address.clone(),
-                self.resources.wallet_identity.address.clone(),
+                self.resources.tari_address.clone(),
+                self.resources.tari_address.clone(),
                 amount,
                 fee,
                 tx.clone(),
@@ -1450,7 +1436,7 @@ where
             )) => {
                 let completed_tx = CompletedTransaction::new(
                     tx_id,
-                    self.resources.wallet_identity.address.clone(),
+                    self.resources.tari_address.clone(),
                     recipient_address,
                     amount,
                     fee,
@@ -1595,7 +1581,7 @@ where
             HashSha256 PushHash(Box::new(hash)) Equal IfThen
                 PushPubKey(Box::new(destination.public_spend_key().clone()))
             Else
-                CheckHeightVerify(height) PushPubKey(Box::new(self.resources.wallet_identity.node_identity.public_key().clone()))
+                CheckHeightVerify(height) PushPubKey(Box::new(self.resources.node_identity.public_key().clone()))
             EndIf
         );
 
@@ -1709,7 +1695,7 @@ where
             .with_input_data(ExecutionStack::default())
             .with_covenant(covenant)
             .with_sender_offset_public_key(sender_offset_public_key)
-            .with_script_key(self.resources.wallet_identity.wallet_node_key_id.clone())
+            .with_script_key(self.resources.transaction_key_manager_service.get_spend_key().await?.0)
             .with_minimum_value_promise(minimum_value_promise)
             .sign_as_sender_and_receiver(
                 &self.resources.transaction_key_manager_service,
@@ -1772,7 +1758,7 @@ where
             transaction_broadcast_join_handles,
             CompletedTransaction::new(
                 tx_id,
-                self.resources.wallet_identity.address.clone(),
+                self.resources.tari_address.clone(),
                 destination,
                 amount,
                 fee,
@@ -1948,11 +1934,9 @@ where
                 payment_id.clone(),
             )
             .await?
-            .with_input_data(inputs!(PublicKey::from_secret_key(
-                self.resources.wallet_identity.node_identity.secret_key()
-            )))
+            .with_input_data(Default::default())
             .with_sender_offset_public_key(sender_offset_public_key)
-            .with_script_key(self.resources.wallet_identity.wallet_node_key_id.clone())
+            .with_script_key(KeyId::Zero)
             .with_minimum_value_promise(minimum_value_promise)
             .sign_as_sender_and_receiver(
                 &self.resources.transaction_key_manager_service,
@@ -2009,7 +1993,7 @@ where
             transaction_broadcast_join_handles,
             CompletedTransaction::new(
                 tx_id,
-                self.resources.wallet_identity.address.clone(),
+                self.resources.tari_address.clone(),
                 dest_address,
                 amount,
                 fee,
@@ -2046,14 +2030,8 @@ where
             JoinHandle<Result<TxId, TransactionServiceProtocolError<TxId>>>,
         >,
     ) -> Result<TxId, TransactionServiceError> {
-        if destination.network() != self.resources.wallet_identity.address.network() {
+        if destination.network() != self.resources.tari_address.network() {
             return Err(TransactionServiceError::InvalidNetwork);
-        }
-        if self.resources.wallet_identity.node_identity.public_key() == destination.comms_public_key() {
-            warn!(target: LOG_TARGET, "One-sided spend-to-self transactions not supported");
-            return Err(TransactionServiceError::OneSidedTransactionError(
-                "One-sided spend-to-self transactions not supported".to_string(),
-            ));
         }
         let dest_pubkey = destination.public_spend_key().clone();
         self.send_one_sided_or_stealth(
@@ -2137,7 +2115,7 @@ where
             .get_next_spend_and_script_key_ids()
             .await?;
 
-        let recovery_key_id = self.resources.transaction_key_manager_service.get_view_key_id().await?;
+        let recovery_key_id = self.resources.transaction_key_manager_service.get_view_key().await?.0;
 
         let recovery_key_id = match claim_public_key {
             Some(ref claim_public_key) => {
@@ -2186,9 +2164,7 @@ where
                 PaymentId::Empty,
             )
             .await?
-            .with_input_data(inputs!(PublicKey::from_secret_key(
-                self.resources.wallet_identity.node_identity.secret_key()
-            )))
+            .with_input_data(Default::default())
             .with_sender_offset_public_key(
                 sender_message
                     .single()
@@ -2199,7 +2175,7 @@ where
                     .sender_offset_public_key
                     .clone(),
             )
-            .with_script_key(self.resources.wallet_identity.wallet_node_key_id.clone())
+            .with_script_key(KeyId::Zero)
             .with_minimum_value_promise(
                 sender_message
                     .single()
@@ -2274,7 +2250,7 @@ where
             transaction_broadcast_join_handles,
             CompletedTransaction::new(
                 tx_id,
-                self.resources.wallet_identity.address.clone(),
+                self.resources.tari_address.clone(),
                 TariAddress::default(),
                 amount,
                 fee,
@@ -2319,7 +2295,7 @@ where
         let output_features =
             OutputFeatures::for_validator_node_registration(validator_node_public_key, validator_node_signature);
         self.send_transaction(
-            self.resources.wallet_identity.address.clone(),
+            self.resources.tari_address.clone(),
             amount,
             selection_criteria,
             output_features,
@@ -2348,7 +2324,7 @@ where
         reply_channel: oneshot::Sender<Result<TransactionServiceResponse, TransactionServiceError>>,
     ) -> Result<(), TransactionServiceError> {
         self.send_transaction(
-            self.resources.wallet_identity.address.clone(),
+            self.resources.tari_address.clone(),
             0.into(),
             selection_criteria,
             OutputFeatures::for_template_registration(template_registration),
@@ -2380,7 +2356,7 @@ where
             JoinHandle<Result<TxId, TransactionServiceProtocolError<TxId>>>,
         >,
     ) -> Result<TxId, TransactionServiceError> {
-        if destination.network() != self.resources.wallet_identity.address.network() {
+        if destination.network() != self.resources.tari_address.network() {
             return Err(TransactionServiceError::InvalidNetwork);
         }
 
@@ -2862,7 +2838,7 @@ where
             // interactive and its the same network
             let source_address = TariAddress::new_single_address(
                 source_pubkey,
-                self.resources.wallet_identity.network(),
+                self.resources.tari_address.network(),
                 TariAddressFeatures::INTERACTIVE,
             );
             let protocol = TransactionReceiveProtocol::new(
@@ -2922,7 +2898,7 @@ where
         // but we know its interactive, so make the view key 0, and the spend key the source public key.
         let source_address = TariAddress::new_single_address(
             source_pubkey,
-            self.resources.wallet_identity.address.network(),
+            self.resources.tari_address.network(),
             TariAddressFeatures::INTERACTIVE,
         );
         let sender = match self.finalized_transaction_senders.get_mut(&tx_id) {
@@ -3390,7 +3366,7 @@ where
             tx_id,
             value,
             source_address,
-            self.resources.wallet_identity.address.clone(),
+            self.resources.tari_address.clone(),
             message,
             import_status.clone(),
             current_height,
@@ -3489,8 +3465,8 @@ where
             transaction_broadcast_join_handles,
             CompletedTransaction::new(
                 tx_id,
-                self.resources.wallet_identity.address.clone(),
-                self.resources.wallet_identity.address.clone(),
+                self.resources.tari_address.clone(),
+                self.resources.tari_address.clone(),
                 amount,
                 fee,
                 tx,
@@ -3531,7 +3507,8 @@ pub struct TransactionServiceResources<TBackend, TWalletConnectivity, TKeyManage
     pub outbound_message_service: OutboundMessageRequester,
     pub connectivity: TWalletConnectivity,
     pub event_publisher: TransactionEventSender,
-    pub wallet_identity: WalletIdentity,
+    pub tari_address: TariAddress,
+    pub node_identity: Arc<NodeIdentity>,
     pub consensus_manager: ConsensusManager,
     pub factories: CryptoFactories,
     pub config: TransactionServiceConfig,

--- a/base_layer/wallet/src/util/wallet_identity.rs
+++ b/base_layer/wallet/src/util/wallet_identity.rs
@@ -30,32 +30,39 @@ use tari_core::transactions::key_manager::TariKeyId;
 #[derive(Clone, Debug)]
 pub struct WalletIdentity {
     pub node_identity: Arc<NodeIdentity>,
-    pub address: TariAddress,
+    pub address_interactive: TariAddress,
+    pub address_one_sided: TariAddress,
     pub wallet_node_key_id: TariKeyId,
 }
 
 impl WalletIdentity {
-    pub fn new(node_identity: Arc<NodeIdentity>, address: TariAddress) -> Self {
+    pub fn new(
+        node_identity: Arc<NodeIdentity>,
+        address_interactive: TariAddress,
+        address_one_sided: TariAddress,
+    ) -> Self {
         let wallet_node_key_id = TariKeyId::Imported {
             key: node_identity.public_key().clone(),
         };
         WalletIdentity {
             node_identity,
-            address,
+            address_interactive,
+            address_one_sided,
             wallet_node_key_id,
         }
     }
 
     pub fn network(&self) -> Network {
-        self.address.network()
+        self.address_interactive.network()
     }
 }
 
 impl Display for WalletIdentity {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "{}", self.node_identity)?;
-        writeln!(f, "Tari Address: {}", self.address)?;
-        writeln!(f, "Network: {:?}", self.address.network())?;
+        writeln!(f, "Tari Address interactive: {}", self.address_interactive)?;
+        writeln!(f, "Tari Address one-sided: {}", self.address_one_sided)?;
+        writeln!(f, "Network: {:?}", self.address_interactive.network())?;
         Ok(())
     }
 }

--- a/base_layer/wallet/src/utxo_scanner_service/initializer.rs
+++ b/base_layer/wallet/src/utxo_scanner_service/initializer.rs
@@ -20,16 +20,16 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{marker::PhantomData, sync::Arc};
+use std::{marker::PhantomData};
 
 use futures::future;
 use log::*;
 use tari_common::configuration::Network;
-use tari_comms::{connectivity::ConnectivityRequester, NodeIdentity};
+use tari_comms::{connectivity::ConnectivityRequester};
 use tari_core::transactions::{key_manager::TransactionKeyManagerInterface, CryptoFactories};
 use tari_service_framework::{async_trait, ServiceInitializationError, ServiceInitializer, ServiceInitializerContext};
 use tokio::sync::broadcast;
-
+use tari_common_types::tari_address::{TariAddress, TariAddressFeatures};
 use crate::{
     base_node_service::handle::BaseNodeServiceHandle,
     connectivity_service::WalletConnectivityHandle,
@@ -49,7 +49,6 @@ const LOG_TARGET: &str = "wallet::utxo_scanner_service::initializer";
 pub struct UtxoScannerServiceInitializer<T, TKeyManagerInterface> {
     backend: Option<WalletDatabase<T>>,
     factories: CryptoFactories,
-    node_identity: Arc<NodeIdentity>,
     network: Network,
     phantom: PhantomData<TKeyManagerInterface>,
 }
@@ -60,13 +59,11 @@ where T: WalletBackend + 'static
     pub fn new(
         backend: WalletDatabase<T>,
         factories: CryptoFactories,
-        node_identity: Arc<NodeIdentity>,
         network: Network,
     ) -> Self {
         Self {
             backend: Some(backend),
             factories,
-            node_identity,
             network,
             phantom: PhantomData,
         }
@@ -100,8 +97,8 @@ where
             .take()
             .expect("Cannot start Utxo scanner service without setting a storage backend");
         let factories = self.factories.clone();
-        let node_identity = self.node_identity.clone();
-        let network = self.network;
+        let network = self.network.clone();
+
 
         context.spawn_when_ready(move |handles| async move {
             let transaction_service = handles.expect_handle::<TransactionServiceHandle>();
@@ -111,19 +108,26 @@ where
             let base_node_service_handle = handles.expect_handle::<BaseNodeServiceHandle>();
             let key_manager = handles.expect_handle::<TKeyManagerInterface>();
 
+            let (_view_key_id, view_key) = key_manager.get_view_key().await.expect("Could not initialize UTXO scanner Service");
+            let (_spend_key_id, spend_key) = key_manager.get_spend_key().await.expect("Could not initialize UTXO scanner Service");
+            let one_sided_tari_address =TariAddress::new_dual_address(
+                view_key,
+                spend_key,
+                network,
+                TariAddressFeatures::create_one_sided_only(),
+            );
+
             let scanning_service = UtxoScannerService::<T, WalletConnectivityHandle>::builder()
                 .with_peers(vec![])
                 .with_retry_limit(2)
                 .with_mode(UtxoScannerMode::Scanning)
-                .build_with_resources(
+                .build_with_resources::<T,WalletConnectivityHandle,TKeyManagerInterface>(
                     backend,
                     comms_connectivity,
                     wallet_connectivity.clone(),
                     output_manager_service,
                     transaction_service,
-                    key_manager,
-                    node_identity,
-                    network,
+                    one_sided_tari_address,
                     factories,
                     handles.get_shutdown_signal(),
                     event_sender,
@@ -132,7 +136,6 @@ where
                     recovery_message_watch_receiver,
                 )
                 .await
-                .expect("Could not initialize UTXO scanner Service")
                 .run();
 
             futures::pin_mut!(scanning_service);

--- a/base_layer/wallet/src/utxo_scanner_service/initializer.rs
+++ b/base_layer/wallet/src/utxo_scanner_service/initializer.rs
@@ -94,7 +94,7 @@ where
             .take()
             .expect("Cannot start Utxo scanner service without setting a storage backend");
         let factories = self.factories.clone();
-        let network = self.network.clone();
+        let network = self.network;
 
         context.spawn_when_ready(move |handles| async move {
             let transaction_service = handles.expect_handle::<TransactionServiceHandle>();

--- a/base_layer/wallet/src/utxo_scanner_service/service.rs
+++ b/base_layer/wallet/src/utxo_scanner_service/service.rs
@@ -193,7 +193,7 @@ pub struct UtxoScannerResources<TBackend, TWalletConnectivity> {
     pub current_base_node_watcher: watch::Receiver<Option<Peer>>,
     pub output_manager_service: OutputManagerHandle,
     pub transaction_service: TransactionServiceHandle,
-    pub tari_address: TariAddress,
+    pub one_sided_tari_address: TariAddress,
     pub factories: CryptoFactories,
     pub recovery_message: String,
     pub one_sided_payment_message: String,

--- a/base_layer/wallet/src/utxo_scanner_service/service.rs
+++ b/base_layer/wallet/src/utxo_scanner_service/service.rs
@@ -31,7 +31,7 @@ use tokio::{
     sync::{broadcast, watch},
     task,
 };
-
+use tari_common_types::tari_address::TariAddress;
 use crate::{
     base_node_service::handle::{BaseNodeEvent, BaseNodeServiceHandle},
     connectivity_service::WalletConnectivityInterface,
@@ -39,7 +39,6 @@ use crate::{
     output_manager_service::handle::OutputManagerHandle,
     storage::database::{WalletBackend, WalletDatabase},
     transaction_service::handle::TransactionServiceHandle,
-    util::wallet_identity::WalletIdentity,
     utxo_scanner_service::{
         handle::UtxoScannerEvent,
         utxo_scanner_task::UtxoScannerTask,
@@ -194,7 +193,7 @@ pub struct UtxoScannerResources<TBackend, TWalletConnectivity> {
     pub current_base_node_watcher: watch::Receiver<Option<Peer>>,
     pub output_manager_service: OutputManagerHandle,
     pub transaction_service: TransactionServiceHandle,
-    pub wallet_identity: WalletIdentity,
+    pub tari_address: TariAddress,
     pub factories: CryptoFactories,
     pub recovery_message: String,
     pub one_sided_payment_message: String,

--- a/base_layer/wallet/src/utxo_scanner_service/service.rs
+++ b/base_layer/wallet/src/utxo_scanner_service/service.rs
@@ -23,7 +23,7 @@
 use chrono::NaiveDateTime;
 use futures::FutureExt;
 use log::*;
-use tari_common_types::types::HashOutput;
+use tari_common_types::{tari_address::TariAddress, types::HashOutput};
 use tari_comms::{connectivity::ConnectivityRequester, peer_manager::Peer, types::CommsPublicKey};
 use tari_core::transactions::{tari_amount::MicroMinotari, CryptoFactories};
 use tari_shutdown::{Shutdown, ShutdownSignal};
@@ -31,7 +31,7 @@ use tokio::{
     sync::{broadcast, watch},
     task,
 };
-use tari_common_types::tari_address::TariAddress;
+
 use crate::{
     base_node_service::handle::{BaseNodeEvent, BaseNodeServiceHandle},
     connectivity_service::WalletConnectivityInterface,

--- a/base_layer/wallet/src/utxo_scanner_service/utxo_scanner_task.rs
+++ b/base_layer/wallet/src/utxo_scanner_service/utxo_scanner_task.rs
@@ -636,7 +636,7 @@ where
         for (wo, message, import_status, tx_id, to) in utxos {
             let source_address = if wo.features.is_coinbase() {
                 // It's a coinbase, so we know we mined it (we do mining with cold wallets).
-                self.resources.wallet_identity.address.clone()
+                self.resources.tari_address.clone()
             } else {
                 // Because we do not know the source public key we are making it the default key of zeroes to make it
                 // clear this value is a placeholder.

--- a/base_layer/wallet/src/utxo_scanner_service/utxo_scanner_task.rs
+++ b/base_layer/wallet/src/utxo_scanner_service/utxo_scanner_task.rs
@@ -636,7 +636,7 @@ where
         for (wo, message, import_status, tx_id, to) in utxos {
             let source_address = if wo.features.is_coinbase() {
                 // It's a coinbase, so we know we mined it (we do mining with cold wallets).
-                self.resources.tari_address.clone()
+                self.resources.one_sided_tari_address.clone()
             } else {
                 // Because we do not know the source public key we are making it the default key of zeroes to make it
                 // clear this value is a placeholder.

--- a/base_layer/wallet/src/utxo_scanner_service/uxto_scanner_service_builder.rs
+++ b/base_layer/wallet/src/utxo_scanner_service/uxto_scanner_service_builder.rs
@@ -26,7 +26,7 @@ use tari_common::configuration::Network;
 use tari_common_types::tari_address::TariAddress;
 use tari_comms::{connectivity::ConnectivityRequester, types::CommsPublicKey, NodeIdentity};
 use tari_core::transactions::{key_manager::TransactionKeyManagerInterface, CryptoFactories};
-use tari_key_manager::key_manager_service::{KeyManagerServiceError};
+use tari_key_manager::key_manager_service::KeyManagerServiceError;
 use tari_shutdown::ShutdownSignal;
 use tokio::sync::{broadcast, watch};
 
@@ -107,7 +107,6 @@ impl UtxoScannerServiceBuilder {
         wallet: &WalletSqlite,
         shutdown_signal: ShutdownSignal,
     ) -> Result<UtxoScannerService<WalletSqliteDatabase, WalletConnectivityHandle>, KeyManagerServiceError> {
-
         let (_view_key_id, view_key) = wallet.key_manager_service.get_view_key().await?;
         let tari_address = TariAddress::new_dual_address_with_default_features(
             view_key,
@@ -163,7 +162,6 @@ impl UtxoScannerServiceBuilder {
         one_sided_message_watch: watch::Receiver<String>,
         recovery_message_watch: watch::Receiver<String>,
     ) -> Result<UtxoScannerService<TBackend, TWalletConnectivity>, KeyManagerServiceError> {
-
         let (_view_key_id, view_key) = key_manager.get_view_key().await?;
         let tari_address =
             TariAddress::new_dual_address_with_default_features(view_key, node_identity.public_key().clone(), network);

--- a/base_layer/wallet/src/utxo_scanner_service/uxto_scanner_service_builder.rs
+++ b/base_layer/wallet/src/utxo_scanner_service/uxto_scanner_service_builder.rs
@@ -20,7 +20,6 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-
 use tari_common_types::tari_address::TariAddress;
 use tari_comms::{connectivity::ConnectivityRequester, types::CommsPublicKey};
 use tari_core::transactions::{key_manager::TransactionKeyManagerInterface, CryptoFactories};

--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -81,7 +81,7 @@ use tari_script::{push_pubkey_script, ExecutionStack, TariScript};
 use tari_service_framework::StackBuilder;
 use tari_shutdown::ShutdownSignal;
 use tari_utilities::{hex::Hex, ByteArray};
-
+use tari_key_manager::key_manager_service::KeyManagerServiceError;
 use crate::{
     base_node_service::{handle::BaseNodeServiceHandle, BaseNodeServiceInitializer},
     config::WalletConfig,
@@ -242,7 +242,6 @@ where
             .add_initializer(UtxoScannerServiceInitializer::<T, TKeyManagerInterface>::new(
                 wallet_database.clone(),
                 factories.clone(),
-                node_identity.clone(),
                 config.network,
             ));
 
@@ -477,7 +476,7 @@ where
         }
     }
 
-    pub async fn get_wallet_interactive_address(&self) -> Result<TariAddress, WalletError> {
+    pub async fn get_wallet_interactive_address(&self) -> Result<TariAddress, KeyManagerServiceError> {
         let (_view_key_id, view_key) = self.key_manager_service.get_view_key().await?;
         let (_comms_key_id, comms_key) = self.key_manager_service.get_comms_key().await?;
         let features = match self.wallet_type {
@@ -492,7 +491,7 @@ where
         ))
     }
 
-    pub async fn get_wallet_one_sided_address(&self) -> Result<TariAddress, WalletError> {
+    pub async fn get_wallet_one_sided_address(&self) -> Result<TariAddress, KeyManagerServiceError> {
         let (_view_key_id, view_key) = self.key_manager_service.get_view_key().await?;
         let (_spend_key_id, spend_key) = self.key_manager_service.get_spend_key().await?;
         Ok(TariAddress::new_dual_address(

--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -476,7 +476,6 @@ where
     }
 
     pub async fn get_wallet_address(&self) -> Result<TariAddress, WalletError> {
-
         let (_view_key_id, view_key) = self.key_manager_service.get_view_key().await?;
         Ok(TariAddress::new_dual_address_with_default_features(
             view_key.clone(),
@@ -486,7 +485,6 @@ where
     }
 
     pub async fn get_wallet_id(&self) -> Result<WalletIdentity, WalletError> {
-
         let (_view_key_id, view_key) = self.key_manager_service.get_view_key().await?;
         let address = TariAddress::new_dual_address_with_default_features(
             view_key.clone(),

--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -64,7 +64,7 @@ use tari_crypto::{hash_domain, signatures::SchnorrSignatureError};
 use tari_key_manager::{
     cipher_seed::CipherSeed,
     key_manager::KeyManager,
-    key_manager_service::{storage::database::KeyManagerBackend, KeyDigest, KeyManagerBranch},
+    key_manager_service::{storage::database::KeyManagerBackend, KeyDigest, KeyManagerBranch, KeyManagerServiceError},
     mnemonic::{Mnemonic, MnemonicLanguage},
     SeedWords,
 };
@@ -81,7 +81,7 @@ use tari_script::{push_pubkey_script, ExecutionStack, TariScript};
 use tari_service_framework::StackBuilder;
 use tari_shutdown::ShutdownSignal;
 use tari_utilities::{hex::Hex, ByteArray};
-use tari_key_manager::key_manager_service::KeyManagerServiceError;
+
 use crate::{
     base_node_service::{handle::BaseNodeServiceHandle, BaseNodeServiceInitializer},
     config::WalletConfig,

--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -29,7 +29,7 @@ use log::*;
 use rand::rngs::OsRng;
 use tari_common::configuration::bootstrap::ApplicationType;
 use tari_common_types::{
-    tari_address::TariAddress,
+    tari_address::{TariAddress, TariAddressFeatures},
     transaction::{ImportStatus, TxId},
     types::{ComAndPubSignature, Commitment, PrivateKey, PublicKey, RangeProof, SignatureWithDomain},
     wallet_types::WalletType,
@@ -137,6 +137,7 @@ pub struct Wallet<T, U, V, W, TKeyManagerInterface> {
     pub db: WalletDatabase<T>,
     pub output_db: OutputManagerDatabase<V>,
     pub factories: CryptoFactories,
+    wallet_type: WalletType,
     _u: PhantomData<U>,
     _v: PhantomData<V>,
     _w: PhantomData<W>,
@@ -206,7 +207,7 @@ where
                 key_manager_backend,
                 master_seed,
                 factories.clone(),
-                wallet_type,
+                wallet_type.clone(),
             ))
             .add_initializer(TransactionServiceInitializer::<U, T, TKeyManagerInterface>::new(
                 config.transaction_service_config,
@@ -356,6 +357,7 @@ where
             db: wallet_database,
             output_db: output_manager_database,
             factories,
+            wallet_type,
             _u: PhantomData,
             _v: PhantomData,
             _w: PhantomData,
@@ -475,23 +477,40 @@ where
         }
     }
 
-    pub async fn get_wallet_address(&self) -> Result<TariAddress, WalletError> {
+    pub async fn get_wallet_interactive_address(&self) -> Result<TariAddress, WalletError> {
         let (_view_key_id, view_key) = self.key_manager_service.get_view_key().await?;
-        Ok(TariAddress::new_dual_address_with_default_features(
-            view_key.clone(),
-            self.comms.node_identity().public_key().clone(),
+        let (_comms_key_id, comms_key) = self.key_manager_service.get_comms_key().await?;
+        let features = match self.wallet_type {
+            WalletType::Software => TariAddressFeatures::default(),
+            WalletType::Ledger(_) | WalletType::Imported(_) => TariAddressFeatures::create_interactive_only(),
+        };
+        Ok(TariAddress::new_dual_address(
+            view_key,
+            comms_key,
             self.network.as_network(),
+            features,
+        ))
+    }
+
+    pub async fn get_wallet_one_sided_address(&self) -> Result<TariAddress, WalletError> {
+        let (_view_key_id, view_key) = self.key_manager_service.get_view_key().await?;
+        let (_spend_key_id, spend_key) = self.key_manager_service.get_spend_key().await?;
+        Ok(TariAddress::new_dual_address(
+            view_key,
+            spend_key,
+            self.network.as_network(),
+            TariAddressFeatures::create_one_sided_only(),
         ))
     }
 
     pub async fn get_wallet_id(&self) -> Result<WalletIdentity, WalletError> {
-        let (_view_key_id, view_key) = self.key_manager_service.get_view_key().await?;
-        let address = TariAddress::new_dual_address_with_default_features(
-            view_key.clone(),
-            self.comms.node_identity().public_key().clone(),
-            self.network.as_network(),
-        );
-        Ok(WalletIdentity::new(self.comms.node_identity(), address))
+        let address_interactive = self.get_wallet_interactive_address().await?;
+        let address_one_sided = self.get_wallet_one_sided_address().await?;
+        Ok(WalletIdentity::new(
+            self.comms.node_identity(),
+            address_interactive,
+            address_one_sided,
+        ))
     }
 
     pub fn get_software_updater(&self) -> Option<SoftwareUpdaterHandle> {

--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -201,7 +201,6 @@ where
                 output_manager_backend.clone(),
                 factories.clone(),
                 config.network.into(),
-                node_identity.clone(),
             ))
             .add_initializer(TransactionKeyManagerInitializer::new(
                 key_manager_backend,
@@ -477,8 +476,8 @@ where
     }
 
     pub async fn get_wallet_address(&self) -> Result<TariAddress, WalletError> {
-        let view_key_id = self.key_manager_service.get_view_key_id().await?;
-        let view_key = self.key_manager_service.get_public_key_at_key_id(&view_key_id).await?;
+
+        let (_view_key_id, view_key) = self.key_manager_service.get_view_key().await?;
         Ok(TariAddress::new_dual_address_with_default_features(
             view_key.clone(),
             self.comms.node_identity().public_key().clone(),
@@ -487,8 +486,8 @@ where
     }
 
     pub async fn get_wallet_id(&self) -> Result<WalletIdentity, WalletError> {
-        let view_key_id = self.key_manager_service.get_view_key_id().await?;
-        let view_key = self.key_manager_service.get_public_key_at_key_id(&view_key_id).await?;
+
+        let (_view_key_id, view_key) = self.key_manager_service.get_view_key().await?;
         let address = TariAddress::new_dual_address_with_default_features(
             view_key.clone(),
             self.comms.node_identity().public_key().clone(),

--- a/base_layer/wallet/tests/transaction_service_tests/service.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/service.rs
@@ -89,7 +89,7 @@ use tari_common_types::{
     tari_address::TariAddress,
     transaction::{ImportStatus, TransactionDirection, TransactionStatus, TxId},
     types::{FixedHash, PrivateKey, PublicKey, Signature},
-    wallet_types::WalletType,
+    wallet_types::{ImportedWallet, WalletType},
 };
 use tari_comms::{
     message::EnvelopeBody,
@@ -169,7 +169,7 @@ use tokio::{
     task,
     time::sleep,
 };
-use tari_common_types::wallet_types::ImportedWallet;
+
 use crate::support::{
     base_node_service_mock::MockBaseNodeService,
     comms_and_services::{create_dummy_message, setup_comms_services},
@@ -228,7 +228,7 @@ async fn setup_transaction_service<P: AsRef<Path>>(
     let db_cipher = XChaCha20Poly1305::new(key_ga);
     let kms_backend = KeyManagerSqliteDatabase::init(connection, db_cipher);
     let wallet_type = WalletType::Imported(ImportedWallet {
-        public_spend_key: PublicKey::from_secret_key(&node_identity.secret_key()),
+        public_spend_key: PublicKey::from_secret_key(node_identity.secret_key()),
         private_spend_key: Some(node_identity.secret_key().clone()),
         view_key: SK::random(&mut OsRng),
     });

--- a/base_layer/wallet/tests/transaction_service_tests/transaction_protocols.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/transaction_protocols.rs
@@ -169,7 +169,6 @@ pub async fn setup() -> (
         client_node_identity.public_key().clone(),
         network,
     );
-    let wallet_identity = WalletIdentity::new(client_node_identity.clone(), tari_address);
     let resources = TransactionServiceResources {
         db,
         output_manager_service: output_manager_service_handle,
@@ -177,7 +176,7 @@ pub async fn setup() -> (
         outbound_message_service: outbound_message_requester,
         connectivity: wallet_connectivity.clone(),
         event_publisher: ts_event_publisher,
-        wallet_identity,
+        tari_address,
         consensus_manager,
         factories: CryptoFactories::default(),
         config: TransactionServiceConfig {

--- a/base_layer/wallet/tests/transaction_service_tests/transaction_protocols.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/transaction_protocols.rs
@@ -47,7 +47,7 @@ use minotari_wallet::{
             sqlite_db::TransactionServiceSqliteDatabase,
         },
     },
-    util::{wallet_identity::WalletIdentity, watch::Watch},
+    util::watch::Watch,
 };
 use rand::{rngs::OsRng, RngCore};
 use tari_common::configuration::Network;
@@ -86,7 +86,6 @@ use tari_core::{
     },
     txn_schema,
 };
-use tari_key_manager::key_manager_service::KeyManagerInterface;
 use tari_service_framework::{reply_channel, reply_channel::Receiver};
 use tari_shutdown::Shutdown;
 use tari_test_utils::random;
@@ -159,11 +158,7 @@ pub async fn setup() -> (
     let shutdown = Shutdown::new();
     let network = Network::LocalNet;
     let consensus_manager = ConsensusManager::builder(network).build().unwrap();
-    let view_key = core_key_manager_service_handle.get_view_key_id().await.unwrap();
-    let view_key = core_key_manager_service_handle
-        .get_public_key_at_key_id(&view_key)
-        .await
-        .unwrap();
+    let view_key = core_key_manager_service_handle.get_view_key().await.unwrap().1;
     let tari_address = TariAddress::new_dual_address_with_default_features(
         view_key,
         client_node_identity.public_key().clone(),
@@ -177,6 +172,7 @@ pub async fn setup() -> (
         connectivity: wallet_connectivity.clone(),
         event_publisher: ts_event_publisher,
         tari_address,
+        node_identity: client_node_identity.clone(),
         consensus_manager,
         factories: CryptoFactories::default(),
         config: TransactionServiceConfig {

--- a/base_layer/wallet_ffi/src/error.rs
+++ b/base_layer/wallet_ffi/src/error.rs
@@ -33,9 +33,11 @@ use tari_crypto::{
     signatures::SchnorrSignatureError,
     tari_utilities::{hex::HexError, ByteArrayError},
 };
-use tari_key_manager::error::{KeyManagerError, MnemonicError};
+use tari_key_manager::{
+    error::{KeyManagerError, MnemonicError},
+    key_manager_service::KeyManagerServiceError,
+};
 use thiserror::Error;
-use tari_key_manager::key_manager_service::KeyManagerServiceError;
 
 const LOG_TARGET: &str = "wallet_ffi::error";
 

--- a/base_layer/wallet_ffi/src/error.rs
+++ b/base_layer/wallet_ffi/src/error.rs
@@ -35,6 +35,7 @@ use tari_crypto::{
 };
 use tari_key_manager::error::{KeyManagerError, MnemonicError};
 use thiserror::Error;
+use tari_key_manager::key_manager_service::KeyManagerServiceError;
 
 const LOG_TARGET: &str = "wallet_ffi::error";
 
@@ -522,6 +523,16 @@ impl From<MnemonicError> for LibWalletError {
         error!(target: LOG_TARGET, "{}", format!("{:?}", err));
         Self {
             code: 910,
+            message: format!("{:?}", err),
+        }
+    }
+}
+
+impl From<KeyManagerServiceError> for LibWalletError {
+    fn from(err: KeyManagerServiceError) -> Self {
+        error!(target: LOG_TARGET, "{}", format!("{:?}", err));
+        Self {
+            code: 458,
             message: format!("{:?}", err),
         }
     }

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -5945,7 +5945,7 @@ pub unsafe extern "C" fn wallet_create(
 
     match w {
         Ok(w) => {
-            let wallet_address = match runtime.block_on(async { w.get_wallet_address().await }) {
+            let wallet_address = match runtime.block_on(async { w.get_wallet_interactive_address().await }) {
                 Ok(address) => address,
                 Err(e) => {
                     error = LibWalletError::from(e).code;
@@ -7652,7 +7652,7 @@ pub unsafe extern "C" fn wallet_get_cancelled_transactions(
             return ptr::null_mut();
         },
     };
-    let wallet_address = match runtime.block_on(async { (*wallet).wallet.get_wallet_address().await }) {
+    let wallet_address = match runtime.block_on(async { (*wallet).wallet.get_wallet_interactive_address().await }) {
         Ok(address) => address,
         Err(e) => {
             error = LibWalletError::from(e).code;
@@ -7946,7 +7946,7 @@ pub unsafe extern "C" fn wallet_get_cancelled_transaction_by_id(
                 return ptr::null_mut();
             },
         };
-        let address = match runtime.block_on(async { (*wallet).wallet.get_wallet_address().await }) {
+        let address = match runtime.block_on(async { (*wallet).wallet.get_wallet_interactive_address().await }) {
             Ok(address) => address,
             Err(e) => {
                 error = LibWalletError::from(e).code;
@@ -8029,7 +8029,7 @@ pub unsafe extern "C" fn wallet_get_tari_address(
             return ptr::null_mut();
         },
     };
-    let address = match runtime.block_on(async { (*wallet).wallet.get_wallet_address().await }) {
+    let address = match runtime.block_on(async { (*wallet).wallet.get_wallet_interactive_address().await }) {
         Ok(address) => address,
         Err(e) => {
             error = LibWalletError::from(e).code;


### PR DESCRIPTION
Description
---
Fixes Key manager key use
Allows creating of scan only wallets that don't have access to the spend key
Allows more than one address

Motivation and Context
---
This allows us to display interactive and one-sided address for ledger type wallets, displaying the correct keys for use with each type. 
The new wallet type also allows users to create scan only wallets that have a private view key and not have access to the private key for spending. 

How Has This Been Tested?
---
Manual

Breaking change
---
Changes byte representation of keys which needs matching ledger wallet version to work correctly 