### PR TITLE
ci(feature): add auditable assets, build macOS-14 builds

### DIFF
--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -25,13 +25,16 @@ env:
   TS_FILES: '["minotari_node","minotari_console_wallet","minotari_miner","minotari_merge_mining_proxy"]'
   TS_FEATURES: "default, safe"
   TS_LIBRARIES: "minotari_mining_helper_ffi"
+  # For debug builds
+  # TS_BUILD: "debug"
+  TS_BUILD: "release"
   TARI_NETWORK_DIR: testnet
   toolchain: nightly-2024-07-07
   matrix-json-file: ".github/workflows/build_binaries.json"
   CARGO_HTTP_MULTIPLEXING: false
   CARGO_UNSTABLE_SPARSE_REGISTRY: true
   CARGO: cargo
-  CARGO_OPTIONS: "--release"
+  CARGO_OPTIONS: "--locked"
   CARGO_CACHE: true
 
 concurrency:
@@ -207,6 +210,11 @@ jobs:
           brew install zip coreutils automake protobuf
           rustup target add ${{ matrix.builds.target }}
 
+      - name: Install macOS-14 missing dependencies - hack
+        if: ${{ startsWith(runner.os,'macOS') && startsWith(runner.arch,'ARM64') }}
+        run: |
+          brew install libtool
+
       - name: Install Windows dependencies
         if: startsWith(runner.os,'Windows')
         run: |
@@ -288,13 +296,21 @@ jobs:
           echo "CARGO=cross" >> $GITHUB_ENV
 
       - name: Install and setup cargo-auditable
-        if: ${{ false }}
+        # if: ${{ ( startsWith(github.ref, 'refs/tags/v') ) && ( ! matrix.builds.cross ) }}
+        if: ${{ ( ! matrix.builds.cross ) }}
+        shell: bash
+        run: |
+          cargo install cargo-auditable cargo-audit
+          echo "CARGO=${{ env.CARGO }} auditable" >> $GITHUB_ENV
+
+      - name: Build release targets
         # if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         shell: bash
         run: |
-          cargo install cargo-auditable
-          echo "CARGO=${{ env.CARGO }} auditable" >> $GITHUB_ENV
-          echo "CARGO_OPTIONS=${{ env.CARGO_OPTIONS }} --release" >> $GITHUB_ENV
+          # echo "TS_BUILD=release" >> $GITHUB_ENV
+          if [[ "${{ env.TS_BUILD }}" == "release" ]]; then
+            echo "CARGO_OPTIONS=${{ env.CARGO_OPTIONS }} --${{ env.TS_BUILD }}" >> $GITHUB_ENV
+          fi
 
       - name: Show command used for Cargo
         shell: bash
@@ -310,7 +326,7 @@ jobs:
             --target ${{ matrix.builds.target }} \
             --features "${{ env.BUILD_FEATURES }}" \
             ${{ env.TARGET_BINS }} \
-            ${{ matrix.builds.flags }} --locked
+            ${{ matrix.builds.flags }}
 
       - name: Build release libraries
         shell: bash
@@ -318,7 +334,7 @@ jobs:
           ${{ env.CARGO }} build ${{ env.CARGO_OPTIONS }} \
             --target ${{ matrix.builds.target }} \
             --lib ${{ env.TARGET_LIBS }} \
-            ${{ matrix.builds.flags }} --locked
+            ${{ matrix.builds.flags }}
 
       - name: Copy binaries to folder for archiving
         shell: bash
@@ -330,12 +346,12 @@ jobs:
           echo "BINFILE=${BINFILE}" >> $GITHUB_ENV
           echo "Copying files for ${BINFILE} to $(pwd)"
           echo "MTS_SOURCE=$(pwd)" >> $GITHUB_ENV
-          ls -alht "$GITHUB_WORKSPACE/target/${{ matrix.builds.target }}/release/"
+          ls -alht "$GITHUB_WORKSPACE/target/${{ matrix.builds.target }}/${{ env.TS_BUILD }}/"
           ARRAY_FILES=( $(echo ${TS_FILES} | jq --raw-output '.[]' | awk '{ print $1 }') )
           for FILE in "${ARRAY_FILES[@]}"; do
             echo "checking for file - ${FILE}${TS_EXT}"
-            if [ -f "${GITHUB_WORKSPACE}/target/${{ matrix.builds.target }}/release/${FILE}${TS_EXT}" ]; then
-              cp -vf "${GITHUB_WORKSPACE}/target/${{ matrix.builds.target }}/release/${FILE}${TS_EXT}" .
+            if [ -f "${GITHUB_WORKSPACE}/target/${{ matrix.builds.target }}/${{ env.TS_BUILD }}/${FILE}${TS_EXT}" ]; then
+              cp -vf "${GITHUB_WORKSPACE}/target/${{ matrix.builds.target }}/${{ env.TS_BUILD }}/${FILE}${TS_EXT}" .
             fi
           done
           if [[ "${{ matrix.builds.target_libs }}" == "" ]]; then
@@ -346,12 +362,12 @@ jobs:
           for FILE in "${ARRAY_LIBS[@]}"; do
             echo "checking for file - ${FILE}${TS_EXT}"
             # Check on Nix for libs
-            if [ -f "${GITHUB_WORKSPACE}/target/${{ matrix.builds.target }}/release/lib${FILE}${LIB_EXT}" ]; then
-              cp -vf "${GITHUB_WORKSPACE}/target/${{ matrix.builds.target }}/release/lib${FILE}${LIB_EXT}" .
+            if [ -f "${GITHUB_WORKSPACE}/target/${{ matrix.builds.target }}/${{ env.TS_BUILD }}/lib${FILE}${LIB_EXT}" ]; then
+              cp -vf "${GITHUB_WORKSPACE}/target/${{ matrix.builds.target }}/${{ env.TS_BUILD }}/lib${FILE}${LIB_EXT}" .
             fi
             # Check on Windows libs
-            if [ -f "${GITHUB_WORKSPACE}/target/${{ matrix.builds.target }}/release/${FILE}${LIB_EXT}" ]; then
-              cp -vf "${GITHUB_WORKSPACE}/target/${{ matrix.builds.target }}/release/${FILE}${LIB_EXT}" .
+            if [ -f "${GITHUB_WORKSPACE}/target/${{ matrix.builds.target }}/${{ env.TS_BUILD }}/${FILE}${LIB_EXT}" ]; then
+              cp -vf "${GITHUB_WORKSPACE}/target/${{ matrix.builds.target }}/${{ env.TS_BUILD }}/${FILE}${LIB_EXT}" .
             fi
           done
           if [ -f "${GITHUB_WORKSPACE}/applications/minotari_node/${PLATFORM_SPECIFIC_DIR}/runtime/start_tor${SHELL_EXT}" ]; then
@@ -367,8 +383,8 @@ jobs:
             --target ${{ matrix.builds.target }} \
             --features "${{ env.BUILD_FEATURES }}, metrics" \
             --bin minotari_node \
-            ${{ matrix.builds.flags }} --locked
-          cp -vf "$GITHUB_WORKSPACE/target/${{ matrix.builds.target }}/release/minotari_node${TS_EXT}" \
+            ${{ matrix.builds.flags }}
+          cp -vf "$GITHUB_WORKSPACE/target/${{ matrix.builds.target }}/${{ env.TS_BUILD }}/minotari_node${TS_EXT}" \
             "${{ env.MTS_SOURCE }}/minotari_node-metrics${TS_EXT}"
 
       - name: Build targeted miners
@@ -384,8 +400,8 @@ jobs:
               --target ${{ matrix.builds.target }} \
               --features "${{ env.BUILD_FEATURES }}" \
               --bin minotari_miner \
-              ${{ matrix.builds.flags }} --locked
-            cp -vf "$GITHUB_WORKSPACE/target/${{ matrix.builds.target }}/release/minotari_miner" \
+              ${{ matrix.builds.flags }}
+            cp -vf "$GITHUB_WORKSPACE/target/${{ matrix.builds.target }}/${{ env.TS_BUILD }}/minotari_miner" \
               "${{ env.MTS_SOURCE }}/minotari_miner-${CPU_TARGET}"
           done
 
@@ -427,7 +443,7 @@ jobs:
             OSX_CODESIGN_EXTRAS="--entitlements ${GITHUB_WORKSPACE}/applications/minotari_node/osx-pkg/entitlements.xml"
           fi
           cd buildtools
-          export target_release="target/${{ matrix.builds.target }}/release"
+          export target_release="target/${{ matrix.builds.target }}/${{ env.TS_BUILD }}"
           mkdir -p "${{ runner.temp }}/osxpkg"
           export tarball_parent="${{ runner.temp }}/osxpkg"
           export tarball_source="${{ env.TARI_NETWORK_DIR }}"
@@ -524,6 +540,15 @@ jobs:
           name: "${{ env.TS_FILENAME }}_windows_installer"
           path: "${{ github.workspace }}/buildtools/Output/*"
 
+      - name: Audit tree and feedback for binaries
+        # if: ${{ ( ! matrix.builds.cross ) }}
+        continue-on-error: true
+        shell: bash
+        run: |
+          cd "${{ env.MTS_SOURCE }}"
+          echo "Audit binaries ..."
+          cargo audit bin *minotari*
+
       - name: Archive and Checksum Binaries
         shell: bash
         run: |
@@ -556,7 +581,7 @@ jobs:
           mkdir -p "${{ env.MTS_SOURCE }}-diag-utils"
           cd "${{ env.MTS_SOURCE }}-diag-utils"
           # Find RandomX built tools for testing
-          find "$GITHUB_WORKSPACE/target/${{ matrix.builds.target }}/release/" \
+          find "$GITHUB_WORKSPACE/target/${{ matrix.builds.target }}/${{ env.TS_BUILD }}/" \
             -name "randomx-*${{ env.TS_EXT}}" -type f -perm -+x -exec cp -vf {} . \;
           echo "Compute diag utils shasum"
           ${SHARUN} * \
@@ -676,7 +701,7 @@ jobs:
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k $MACOS_KEYCHAIN_PASS build.keychain
           OSX_CODESIGN_EXTRAS="--entitlements ${GITHUB_WORKSPACE}/applications/minotari_node/osx-pkg/entitlements.xml"
           cd buildtools
-          # export target_release="target/${{ matrix.builds.target }}/release"
+          # export target_release="target/${{ matrix.builds.target }}/${{ env.TS_BUILD }}"
           # matrix.builds.target=macos-universal
           # matrix.builds.name=macos-universal
           export target_release="osxuni/macos-universal"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2958,9 +2958,9 @@ dependencies = [
 
 [[package]]
 name = "libtor"
-version = "46.9.0+0.4.6.x"
+version = "47.13.0+0.4.7.x"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18ca40c5090fd84877853f509dce8f906922e6c6fb0be12f4b61f6116710d457"
+checksum = "1be588c6a2f02b860a1c0e3b2a59edcb171058f8da71b8ca0ddd7bb40f102c5c"
 dependencies = [
  "libtor-derive",
  "libtor-sys",
@@ -2981,14 +2981,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "libtor-sys"
-version = "46.9.1+0.4.6.9"
+name = "libtor-src"
+version = "47.13.0+0.4.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52bf218e9764d77c16b77b9a26f219c5302bf7be010fd82aba63b019dea41fea"
+checksum = "e73bef51ecfbe7e63ce5cb8757ebc59d09dca6985da7f7470931ac22eab00719"
+dependencies = [
+ "fs_extra",
+]
+
+[[package]]
+name = "libtor-sys"
+version = "47.13.0+0.4.7.x"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb0bc2cfc5d03851617d33508acc511e46f0c2b3cbc3cda85defcb50efa628bb"
 dependencies = [
  "autotools",
  "cc",
- "fs_extra",
+ "libtor-src",
  "libz-sys",
  "openssl-sys",
 ]
@@ -6374,7 +6383,6 @@ dependencies = [
  "derivative",
  "libtor",
  "log",
- "openssl",
  "rand",
  "tari_common",
  "tari_p2p",

--- a/README.md
+++ b/README.md
@@ -114,8 +114,8 @@ First you'll need to make sure you have a full development environment set up:
 
 ```
 brew update
-brew install openssl cmake coreutils automake autoconf protobuf tor
-brew install --cask powershell
+brew install coreutils tor openssl \
+  cmake make libtool autoconf automake protobuf
 ```
 
 #### (macOS M1 chipset)

--- a/infrastructure/libtor/Cargo.toml
+++ b/infrastructure/libtor/Cargo.toml
@@ -15,8 +15,7 @@ tempfile = "3.1.0"
 tor-hash-passwd = "1.0.1"
 
 [target.'cfg(unix)'.dependencies]
-libtor = { version = "46.9.0" }
-openssl = { version = "0.10.66", features = ["vendored"] }
+libtor = { version = "47.13.0", features = ["vendored-openssl"] }
 
 [package.metadata.cargo-machete]
 ignored = ["openssl"] # this is so we can run cargo machete without getting false positive about macro dependancies


### PR DESCRIPTION
Description
All native binary builds have auditable info embedded
Fix macOS-14 build missing github runner missing build dependency
Add CI build debug option (disabled by default)

Motivation and Context
Better auditing and some debugging tools

How Has This Been Tested?
Builds in local fork, needs local run testing for all platforms and builds.

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
