### PR TITLE
feat: add ledger function to generate one sided metadata signature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3585,7 +3585,6 @@ dependencies = [
  "tari_contacts",
  "tari_core",
  "tari_crypto",
- "tari_hashing",
  "tari_key_manager",
  "tari_p2p",
  "tari_script",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3585,6 +3585,7 @@ dependencies = [
  "tari_contacts",
  "tari_core",
  "tari_crypto",
+ "tari_hashing",
  "tari_key_manager",
  "tari_p2p",
  "tari_script",

--- a/applications/minotari_ledger_wallet/common/src/common_types.rs
+++ b/applications/minotari_ledger_wallet/common/src/common_types.rs
@@ -118,7 +118,7 @@ pub enum Branch {
     Nonce = 0x03,
     KernelNonce = 0x04,
     SenderOffset = 0x05,
-    SenderOffsetLedger = 0x06,
+    OneSidedSenderOffset = 0x06,
     Spend = 0x07,
     RandomKey = 0x08,
 }
@@ -136,7 +136,7 @@ impl Branch {
             0x03 => Some(Branch::Nonce),
             0x04 => Some(Branch::KernelNonce),
             0x05 => Some(Branch::SenderOffset),
-            0x06 => Some(Branch::SenderOffsetLedger),
+            0x06 => Some(Branch::OneSidedSenderOffset),
             0x07 => Some(Branch::Spend),
             0x08 => Some(Branch::RandomKey),
             _ => None,
@@ -272,6 +272,10 @@ mod test {
                     assert_eq!(instruction.as_byte(), *expected_byte);
                     assert_eq!(Instruction::from_byte(*expected_byte), Some(*instruction));
                 },
+                Instruction::GetOneSidedMetadataSignature => {
+                    assert_eq!(instruction.as_byte(), *expected_byte);
+                    assert_eq!(Instruction::from_byte(*expected_byte), Some(*instruction));
+                },
             }
         }
     }
@@ -287,7 +291,7 @@ mod test {
             (0x03, Branch::Nonce),
             (0x04, Branch::KernelNonce),
             (0x05, Branch::SenderOffset),
-            (0x06, Branch::SenderOffsetLedger),
+            (0x06, Branch::OneSidedSenderOffset),
             (0x07, Branch::Spend),
             (0x08, Branch::RandomKey),
         ];
@@ -318,7 +322,7 @@ mod test {
                     assert_eq!(branch.as_byte(), *expected_byte);
                     assert_eq!(Branch::from_byte(*expected_byte), Some(*branch));
                 },
-                Branch::SenderOffsetLedger => {
+                Branch::OneSidedSenderOffset => {
                     assert_eq!(branch.as_byte(), *expected_byte);
                     assert_eq!(Branch::from_byte(*expected_byte), Some(*branch));
                 },

--- a/applications/minotari_ledger_wallet/common/src/common_types.rs
+++ b/applications/minotari_ledger_wallet/common/src/common_types.rs
@@ -82,6 +82,7 @@ pub enum Instruction {
     GetDHSharedSecret = 0x08,
     GetRawSchnorrSignature = 0x09,
     GetScriptSchnorrSignature = 0x10,
+    GetOneSidedMetadataSignature = 0x11,
 }
 
 impl Instruction {
@@ -101,6 +102,7 @@ impl Instruction {
             0x08 => Some(Instruction::GetDHSharedSecret),
             0x09 => Some(Instruction::GetRawSchnorrSignature),
             0x10 => Some(Instruction::GetScriptSchnorrSignature),
+            0x11 => Some(Instruction::GetOneSidedMetadataSignature),
             _ => None,
         }
     }

--- a/applications/minotari_ledger_wallet/comms/examples/ledger_demo/main.rs
+++ b/applications/minotari_ledger_wallet/comms/examples/ledger_demo/main.rs
@@ -161,6 +161,7 @@ fn main() {
 
     // GetScriptOffset
     println!("\ntest: GetScriptOffset");
+    let total_script_private_key = PrivateKey::default();
     let mut derived_key_commitments = Vec::new();
     let mut sender_offset_indexes = Vec::new();
     for _i in 0..5 {
@@ -168,7 +169,12 @@ fn main() {
         sender_offset_indexes.push(OsRng.next_u64());
     }
 
-    match ledger_get_script_offset(account, &derived_key_commitments, &sender_offset_indexes) {
+    match ledger_get_script_offset(
+        account,
+        &total_script_private_key,
+        &derived_key_commitments,
+        &sender_offset_indexes,
+    ) {
         Ok(script_offset) => println!("script_offset:  {}", script_offset.to_hex()),
         Err(e) => {
             println!("\nError: {}\n", e);

--- a/applications/minotari_ledger_wallet/comms/examples/ledger_demo/main.rs
+++ b/applications/minotari_ledger_wallet/comms/examples/ledger_demo/main.rs
@@ -190,7 +190,7 @@ fn main() {
     // GetDHSharedSecret
     println!("\ntest: GetDHSharedSecret");
     let index = OsRng.next_u64();
-    let branch = TransactionKeyManagerBranch::SenderOffsetLedger;
+    let branch = TransactionKeyManagerBranch::OneSidedSenderOffset;
     let public_key = PublicKey::from_secret_key(&get_random_nonce());
 
     match ledger_get_dh_shared_secret(account, index, branch, &public_key) {

--- a/applications/minotari_ledger_wallet/comms/src/accessor_methods.rs
+++ b/applications/minotari_ledger_wallet/comms/src/accessor_methods.rs
@@ -285,6 +285,7 @@ pub fn ledger_get_script_signature(
 /// Get the script offset from the ledger device
 pub fn ledger_get_script_offset(
     account: u64,
+    total_script_private_key: &PrivateKey,
     derived_key_commitments: &[PrivateKey],
     sender_offset_indexes: &[u64],
 ) -> Result<PrivateKey, LedgerDeviceError> {
@@ -297,7 +298,6 @@ pub fn ledger_get_script_offset(
     instructions.extend_from_slice(&num_commitments.to_le_bytes());
 
     let mut data: Vec<Vec<u8>> = vec![instructions.to_vec()];
-    let total_script_private_key = PrivateKey::default();
     data.push(total_script_private_key.to_vec());
 
     for sender_offset_index in sender_offset_indexes {

--- a/applications/minotari_ledger_wallet/comms/src/accessor_methods.rs
+++ b/applications/minotari_ledger_wallet/comms/src/accessor_methods.rs
@@ -467,8 +467,8 @@ pub fn ledger_get_one_sided_metadata_signature(
     account: u64,
     network: Network,
     txo_version: u8,
-    spend_key_id: u64,
     sender_offset_key_index: u64,
+    commitment_mask: &PrivateKey,
     value_as_private_key: &PrivateKey,
     metadata_signature_message: &[u8; 32],
 ) -> Result<ComAndPubSignature, LedgerDeviceError> {
@@ -477,8 +477,8 @@ pub fn ledger_get_one_sided_metadata_signature(
     let mut data = Vec::new();
     data.extend_from_slice(&u64::from(network.as_byte()).to_le_bytes());
     data.extend_from_slice(&u64::from(txo_version).to_le_bytes());
-    data.extend_from_slice(&spend_key_id.to_le_bytes());
     data.extend_from_slice(&sender_offset_key_index.to_le_bytes());
+    data.extend_from_slice(&commitment_mask.to_vec());
     data.extend_from_slice(&value_as_private_key.to_vec());
     data.extend_from_slice(&metadata_signature_message.to_vec());
 

--- a/applications/minotari_ledger_wallet/comms/src/error.rs
+++ b/applications/minotari_ledger_wallet/comms/src/error.rs
@@ -48,6 +48,8 @@ pub enum LedgerDeviceError {
     /// Not yet supported
     #[error("Ledger is not fully supported")]
     NotSupported,
+    #[error("User cancelled the transaction")]
+    UserCancelled,
 }
 
 impl From<ByteArrayError> for LedgerDeviceError {

--- a/applications/minotari_ledger_wallet/comms/src/ledger_wallet.rs
+++ b/applications/minotari_ledger_wallet/comms/src/ledger_wallet.rs
@@ -31,7 +31,7 @@ use tari_utilities::ByteArray;
 use crate::error::LedgerDeviceError;
 
 pub const EXPECTED_NAME: &str = "minotari_ledger_wallet";
-pub const EXPECTED_VERSION: &str = "1.0.0-pre.16";
+pub const EXPECTED_VERSION: &str = env!("CARGO_PKG_VERSION");
 const WALLET_CLA: u8 = 0x80;
 
 pub fn get_transport() -> Result<TransportNativeHID, LedgerDeviceError> {

--- a/applications/minotari_ledger_wallet/wallet/src/handlers/get_one_sided_metadata_signature.rs
+++ b/applications/minotari_ledger_wallet/wallet/src/handlers/get_one_sided_metadata_signature.rs
@@ -1,0 +1,129 @@
+// Copyright 2024 The Tari Project
+// SPDX-License-Identifier: BSD-3-Clause
+
+use alloc::format;
+use core::ops::Deref;
+
+use blake2::Blake2b;
+use digest::consts::U64;
+use ledger_device_sdk::{io::Comm, random::Random, ui::gadgets::SingleMessage};
+use tari_crypto::{
+    commitment::HomomorphicCommitmentFactory,
+    keys::PublicKey,
+    ristretto::{
+        pedersen::{extended_commitment_factory::ExtendedPedersenCommitmentFactory, PedersenCommitment},
+        RistrettoComAndPubSig,
+        RistrettoPublicKey,
+        RistrettoSecretKey,
+    },
+};
+use tari_hashing::TransactionHashDomain;
+use zeroize::Zeroizing;
+
+use crate::{
+    alloc::string::ToString,
+    hashing::DomainSeparatedConsensusHasher,
+    utils::{derive_from_bip32_key, get_key_from_canonical_bytes},
+    AppSW,
+    KeyType,
+    RESPONSE_VERSION,
+};
+
+pub fn handler_get_one_sided_metadata_signature(comm: &mut Comm) -> Result<(), AppSW> {
+    let data = comm.get_data().map_err(|_| AppSW::WrongApduLength)?;
+
+    let mut account_bytes = [0u8; 8];
+    account_bytes.clone_from_slice(&data[0..8]);
+    let account = u64::from_le_bytes(account_bytes);
+
+    let mut network_bytes = [0u8; 8];
+    network_bytes.clone_from_slice(&data[8..16]);
+    let network = u64::from_le_bytes(network_bytes);
+
+    let mut txo_version_bytes = [0u8; 8];
+    txo_version_bytes.clone_from_slice(&data[16..24]);
+    let txo_version = u64::from_le_bytes(txo_version_bytes);
+
+    let mut spend_key_index_bytes = [0u8; 8];
+    spend_key_index_bytes.clone_from_slice(&data[24..32]);
+    let spend_key_index = u64::from_le_bytes(spend_key_index_bytes);
+    let spend_private_key = derive_from_bip32_key(account, spend_key_index, KeyType::Spend)?;
+
+    let mut sender_offset_key_index_bytes = [0u8; 8];
+    sender_offset_key_index_bytes.clone_from_slice(&data[32..40]);
+    let sender_offset_key_index = u64::from_le_bytes(sender_offset_key_index_bytes);
+
+    let sender_offset_private_key =
+        derive_from_bip32_key(account, sender_offset_key_index, KeyType::OneSidedSenderOffset)?;
+    let sender_offset_public_key = RistrettoPublicKey::from_secret_key(&sender_offset_private_key);
+
+    let value: Zeroizing<RistrettoSecretKey> =
+        get_key_from_canonical_bytes::<RistrettoSecretKey>(&data[40..72])?.into();
+
+    let r_a = derive_from_bip32_key(account, u32::random().into(), KeyType::Nonce)?;
+    let r_x = derive_from_bip32_key(account, u32::random().into(), KeyType::Nonce)?;
+    let ephemeral_private_key = derive_from_bip32_key(account, u32::random().into(), KeyType::Nonce)?;
+
+    let factory = ExtendedPedersenCommitmentFactory::default();
+
+    let commitment = factory.commit(&spend_private_key, value.deref());
+    let ephemeral_commitment = factory.commit(&r_x, &r_a);
+    let ephemeral_pubkey = RistrettoPublicKey::from_secret_key(&ephemeral_private_key);
+
+    let mut metadata_signature_message = [0u8; 32];
+    metadata_signature_message.clone_from_slice(&data[72..104]);
+
+    let challenge = finalize_metadata_signature_challenge(
+        txo_version,
+        network,
+        &sender_offset_public_key,
+        &ephemeral_commitment,
+        &ephemeral_pubkey,
+        &commitment,
+        &metadata_signature_message,
+    );
+
+    let metadata_signature = match RistrettoComAndPubSig::sign(
+        &value,
+        &spend_private_key,
+        &sender_offset_private_key,
+        &r_a,
+        &r_x,
+        &ephemeral_private_key,
+        &challenge,
+        &factory,
+    ) {
+        Ok(sig) => sig,
+        Err(e) => {
+            SingleMessage::new(&format!("Signing error: {:?}", e.to_string())).show_and_wait();
+            return Err(AppSW::ScriptSignatureFail);
+        },
+    };
+
+    comm.append(&[RESPONSE_VERSION]); // version
+    comm.append(&metadata_signature.to_vec());
+    comm.reply_ok();
+
+    Ok(())
+}
+
+fn finalize_metadata_signature_challenge(
+    _version: u64,
+    network: u64,
+    sender_offset_public_key: &RistrettoPublicKey,
+    ephemeral_commitment: &PedersenCommitment,
+    ephemeral_pubkey: &RistrettoPublicKey,
+    commitment: &PedersenCommitment,
+    message: &[u8; 32],
+) -> [u8; 64] {
+    let challenge =
+        DomainSeparatedConsensusHasher::<TransactionHashDomain, Blake2b<U64>>::new("metadata_signature", network)
+            .chain(ephemeral_pubkey)
+            .chain(ephemeral_commitment)
+            .chain(sender_offset_public_key)
+            .chain(commitment)
+            .chain(&message)
+            .finalize();
+
+    challenge.into()
+}

--- a/applications/minotari_ledger_wallet/wallet/src/main.rs
+++ b/applications/minotari_ledger_wallet/wallet/src/main.rs
@@ -159,7 +159,7 @@ impl KeyType {
         }
         if let Some(branch) = BranchMapping::from_byte(n as u8) {
             match branch {
-                BranchMapping::SenderOffsetLedger => Ok(Self::OneSidedSenderOffset),
+                BranchMapping::OneSidedSenderOffset => Ok(Self::OneSidedSenderOffset),
                 BranchMapping::Spend => Ok(Self::Spend),
                 BranchMapping::RandomKey => Ok(Self::Random),
                 _ => Err(AppSW::BadBranchKey),

--- a/applications/minotari_ledger_wallet/wallet/src/main.rs
+++ b/applications/minotari_ledger_wallet/wallet/src/main.rs
@@ -15,6 +15,7 @@ mod app_ui {
 }
 mod handlers {
     pub mod get_dh_shared_secret;
+    pub mod get_one_sided_metadata_signature;
     pub mod get_public_key;
     pub mod get_public_spend_key;
     pub mod get_schnorr_signature;
@@ -30,6 +31,8 @@ use app_ui::menu::ui_menu_main;
 use critical_section::RawRestoreState;
 use handlers::{
     get_dh_shared_secret::handler_get_dh_shared_secret,
+    get_one_sided_metadata_signature::handler_get_one_sided_metadata_signature,
+    get_public_alpha::handler_get_public_alpha,
     get_public_key::handler_get_public_key,
     get_public_spend_key::handler_get_public_spend_key,
     get_schnorr_signature::{handler_get_raw_schnorr_signature, handler_get_script_schnorr_signature},
@@ -242,6 +245,7 @@ fn handle_apdu(comm: &mut Comm, ins: Instruction, offset_ctx: &mut ScriptOffsetC
         Instruction::GetPublicSpendKey => handler_get_public_spend_key(comm),
         Instruction::GetScriptSignature => handler_get_script_signature(comm),
         Instruction::GetScriptOffset { chunk, more } => handler_get_script_offset(comm, chunk, more, offset_ctx),
+        Instruction::GetScriptSignatureFromChallenge => handler_get_one_sided_metadata_signature(comm),
         Instruction::GetViewKey => handler_get_view_key(comm),
         Instruction::GetDHSharedSecret => handler_get_dh_shared_secret(comm),
         Instruction::GetRawSchnorrSignature => handler_get_raw_schnorr_signature(comm),

--- a/applications/minotari_ledger_wallet/wallet/src/main.rs
+++ b/applications/minotari_ledger_wallet/wallet/src/main.rs
@@ -130,6 +130,7 @@ pub enum Instruction {
     GetDHSharedSecret,
     GetRawSchnorrSignature,
     GetScriptSchnorrSignature,
+    GetOneSidedMetadataSignature,
 }
 
 const P2_MORE: u8 = 0x01;
@@ -200,6 +201,7 @@ impl TryFrom<ApduHeader> for Instruction {
             (InstructionMapping::GetRawSchnorrSignature, 0, 0) => Ok(Instruction::GetRawSchnorrSignature),
             (InstructionMapping::GetScriptSchnorrSignature, 0, 0) => Ok(Instruction::GetScriptSchnorrSignature),
             (InstructionMapping::GetScriptSchnorrSignature, _, _) => Err(AppSW::WrongP1P2),
+            (InstructionMapping::GetOneSidedMetadataSignature, 0, 0) => Err(Instruction::GetOneSidedMetadataSignature),
             (_, _, _) => Err(AppSW::InsNotSupported),
         }
     }
@@ -244,10 +246,10 @@ fn handle_apdu(comm: &mut Comm, ins: Instruction, offset_ctx: &mut ScriptOffsetC
         Instruction::GetPublicSpendKey => handler_get_public_spend_key(comm),
         Instruction::GetScriptSignature => handler_get_script_signature(comm),
         Instruction::GetScriptOffset { chunk, more } => handler_get_script_offset(comm, chunk, more, offset_ctx),
-        Instruction::GetScriptSignatureFromChallenge => handler_get_one_sided_metadata_signature(comm),
         Instruction::GetViewKey => handler_get_view_key(comm),
         Instruction::GetDHSharedSecret => handler_get_dh_shared_secret(comm),
         Instruction::GetRawSchnorrSignature => handler_get_raw_schnorr_signature(comm),
         Instruction::GetScriptSchnorrSignature => handler_get_script_schnorr_signature(comm),
+        Instruction::GetOneSidedMetadataSignature => handler_get_one_sided_metadata_signature(comm),
     }
 }

--- a/applications/minotari_ledger_wallet/wallet/src/main.rs
+++ b/applications/minotari_ledger_wallet/wallet/src/main.rs
@@ -200,8 +200,8 @@ impl TryFrom<ApduHeader> for Instruction {
             (InstructionMapping::GetDHSharedSecret, 0, 0) => Ok(Instruction::GetDHSharedSecret),
             (InstructionMapping::GetRawSchnorrSignature, 0, 0) => Ok(Instruction::GetRawSchnorrSignature),
             (InstructionMapping::GetScriptSchnorrSignature, 0, 0) => Ok(Instruction::GetScriptSchnorrSignature),
+            (InstructionMapping::GetOneSidedMetadataSignature, 0, 0) => Ok(Instruction::GetOneSidedMetadataSignature),
             (InstructionMapping::GetScriptSchnorrSignature, _, _) => Err(AppSW::WrongP1P2),
-            (InstructionMapping::GetOneSidedMetadataSignature, 0, 0) => Err(Instruction::GetOneSidedMetadataSignature),
             (_, _, _) => Err(AppSW::InsNotSupported),
         }
     }

--- a/applications/minotari_ledger_wallet/wallet/src/main.rs
+++ b/applications/minotari_ledger_wallet/wallet/src/main.rs
@@ -32,7 +32,6 @@ use critical_section::RawRestoreState;
 use handlers::{
     get_dh_shared_secret::handler_get_dh_shared_secret,
     get_one_sided_metadata_signature::handler_get_one_sided_metadata_signature,
-    get_public_alpha::handler_get_public_alpha,
     get_public_key::handler_get_public_key,
     get_public_spend_key::handler_get_public_spend_key,
     get_schnorr_signature::{handler_get_raw_schnorr_signature, handler_get_script_schnorr_signature},

--- a/applications/minotari_ledger_wallet/wallet/src/utils.rs
+++ b/applications/minotari_ledger_wallet/wallet/src/utils.rs
@@ -10,7 +10,7 @@ use ledger_device_sdk::{
     ecc::{bip32_derive, make_bip32_path, CurvesId, CxError},
     io::SyscallError,
     random::LedgerRng,
-    ui::gadgets::SingleMessage,
+    ui::gadgets::{MessageScroller, SingleMessage},
 };
 use rand_core::RngCore;
 use tari_crypto::{
@@ -197,12 +197,12 @@ pub fn get_key_from_uniform_bytes(bytes: &[u8]) -> Result<Zeroizing<RistrettoSec
     match RistrettoSecretKey::from_uniform_bytes(bytes) {
         Ok(val) => Ok(Zeroizing::new(val)),
         Err(e) => {
-            SingleMessage::new(&format!(
+            MessageScroller::new(&format!(
                 "Err: key conversion {:?}. Length: {:?}",
                 e.to_string(),
                 &bytes.len()
             ))
-            .show_and_wait();
+            .event_loop();
             SingleMessage::new(&format!("Error Length: {:?}", &bytes.len())).show_and_wait();
             return Err(AppSW::KeyDeriveFromUniform);
         },
@@ -213,12 +213,12 @@ pub fn get_key_from_canonical_bytes<T: ByteArray>(bytes: &[u8]) -> Result<T, App
     match T::from_canonical_bytes(bytes) {
         Ok(val) => Ok(val),
         Err(e) => {
-            SingleMessage::new(&format!(
+            MessageScroller::new(&format!(
                 "Err: key conversion {:?}. Length: {:?}",
                 e.to_string(),
                 &bytes.len()
             ))
-            .show_and_wait();
+            .event_loop();
             SingleMessage::new(&format!("Error Length: {:?}", &bytes.len())).show_and_wait();
             return Err(AppSW::KeyDeriveFromCanonical);
         },

--- a/base_layer/common_types/src/key_branches.rs
+++ b/base_layer/common_types/src/key_branches.rs
@@ -36,7 +36,7 @@ pub enum TransactionKeyManagerBranch {
     Nonce = Branch::Nonce as u8,
     KernelNonce = Branch::KernelNonce as u8,
     SenderOffset = Branch::SenderOffset as u8,
-    SenderOffsetLedger = Branch::SenderOffsetLedger as u8,
+    OneSidedSenderOffset = Branch::OneSidedSenderOffset as u8,
     Spend = Branch::Spend as u8,
     RandomKey = Branch::RandomKey as u8,
 }
@@ -47,7 +47,7 @@ const COMMITMENT_MASK: &str = "commitment mask";
 const NONCE: &str = "nonce";
 const KERNEL_NONCE: &str = "kernel nonce";
 const SENDER_OFFSET: &str = "sender offset";
-const SENDER_OFFSET_LEDGER: &str = "sender offset ledger";
+const ONE_SIDED_SENDER_OFFSET: &str = "one sided sender offset";
 const RANDOM_KEY: &str = "random key";
 
 impl TransactionKeyManagerBranch {
@@ -61,7 +61,7 @@ impl TransactionKeyManagerBranch {
             TransactionKeyManagerBranch::Nonce => NONCE.to_string(),
             TransactionKeyManagerBranch::KernelNonce => KERNEL_NONCE.to_string(),
             TransactionKeyManagerBranch::SenderOffset => SENDER_OFFSET.to_string(),
-            TransactionKeyManagerBranch::SenderOffsetLedger => SENDER_OFFSET_LEDGER.to_string(),
+            TransactionKeyManagerBranch::OneSidedSenderOffset => ONE_SIDED_SENDER_OFFSET.to_string(),
             TransactionKeyManagerBranch::RandomKey => RANDOM_KEY.to_string(),
             TransactionKeyManagerBranch::Spend => WALLET_COMMS_AND_SPEND_KEY_BRANCH.to_string(),
         }
@@ -75,7 +75,7 @@ impl TransactionKeyManagerBranch {
             NONCE => TransactionKeyManagerBranch::Nonce,
             KERNEL_NONCE => TransactionKeyManagerBranch::KernelNonce,
             SENDER_OFFSET => TransactionKeyManagerBranch::SenderOffset,
-            SENDER_OFFSET_LEDGER => TransactionKeyManagerBranch::SenderOffsetLedger,
+            ONE_SIDED_SENDER_OFFSET => TransactionKeyManagerBranch::OneSidedSenderOffset,
             RANDOM_KEY => TransactionKeyManagerBranch::RandomKey,
             WALLET_COMMS_AND_SPEND_KEY_BRANCH => TransactionKeyManagerBranch::Spend,
             _ => TransactionKeyManagerBranch::Nonce,

--- a/base_layer/core/src/common/one_sided.rs
+++ b/base_layer/core/src/common/one_sided.rs
@@ -27,9 +27,9 @@ use tari_comms::types::CommsDHKE;
 use tari_crypto::{
     hash_domain,
     hashing::{DomainSeparatedHash, DomainSeparatedHasher},
-    keys::{PublicKey as PKtrait, SecretKey as SKtrait},
+    keys::SecretKey as SKtrait,
 };
-use tari_hashing::{KeyManagerTransactionsHashDomain, WalletOutputEncryptionKeysDomain};
+use tari_hashing::WalletOutputEncryptionKeysDomain;
 use tari_utilities::{byte_array::ByteArrayError, ByteArray};
 
 hash_domain!(
@@ -92,17 +92,4 @@ pub fn diffie_hellman_stealth_domain_hasher(diffie_hellman: CommsDHKE) -> Domain
     WalletHasher::new_with_label("stealth_address")
         .chain(diffie_hellman.as_bytes())
         .finalize()
-}
-
-/// Stealth payment script spending key
-pub fn stealth_address_script_spending_key(
-    commitment_mask_private_key: &PrivateKey,
-    spend_key: &PublicKey,
-) -> Result<PublicKey, ByteArrayError> {
-    let hasher = DomainSeparatedHasher::<Blake2b<U64>, KeyManagerTransactionsHashDomain>::new_with_label("script key");
-    let hasher = hasher.chain(commitment_mask_private_key.as_bytes()).finalize();
-    let private_key = PrivateKey::from_uniform_bytes(hasher.as_ref())?;
-    let public_key = PublicKey::from_secret_key(&private_key);
-    let public_key = spend_key + &public_key;
-    Ok(public_key)
 }

--- a/base_layer/core/src/transactions/coinbase_builder.rs
+++ b/base_layer/core/src/transactions/coinbase_builder.rs
@@ -44,14 +44,7 @@ use crate::{
         stealth_address_script_spending_key,
     },
     transactions::{
-        key_manager::{
-            CoreKeyManagerError,
-            MemoryDbKeyManager,
-            SecretTransactionKeyManagerInterface,
-            TariKeyId,
-            TransactionKeyManagerInterface,
-            TxoStage,
-        },
+        key_manager::{CoreKeyManagerError, MemoryDbKeyManager, TariKeyId, TransactionKeyManagerInterface, TxoStage},
         tari_amount::{uT, MicroMinotari},
         transaction_components::{
             encrypted_data::PaymentId,
@@ -457,15 +450,13 @@ pub async fn generate_coinbase_with_wallet_output(
         )
         .await?;
     let commitment_mask = shared_secret_to_output_spending_key(&shared_secret)?;
+    let commitment_mask_key_id = key_manager.import_key(commitment_mask.clone()).await?;
 
     let encryption_private_key = shared_secret_to_output_encryption_key(&shared_secret)?;
     let encryption_key_id = key_manager.import_key(encryption_private_key).await?;
 
-    let commitment_mask_key_id = key_manager.import_key(commitment_mask).await?;
-    let commitment_mask_private_key = key_manager.get_private_key(&commitment_mask_key_id).await?;
-
     let script_spending_pubkey = if stealth_payment {
-        stealth_address_script_spending_key(&commitment_mask_private_key, wallet_payment_address.public_spend_key())?
+        stealth_address_script_spending_key(&commitment_mask, wallet_payment_address.public_spend_key())?
     } else {
         wallet_payment_address.public_spend_key().clone()
     };

--- a/base_layer/core/src/transactions/coinbase_builder.rs
+++ b/base_layer/core/src/transactions/coinbase_builder.rs
@@ -38,11 +38,7 @@ use crate::{
         ConsensusConstants,
     },
     covenants::Covenant,
-    one_sided::{
-        shared_secret_to_output_encryption_key,
-        shared_secret_to_output_spending_key,
-        stealth_address_script_spending_key,
-    },
+    one_sided::{shared_secret_to_output_encryption_key, shared_secret_to_output_spending_key},
     transactions::{
         key_manager::{CoreKeyManagerError, MemoryDbKeyManager, TariKeyId, TransactionKeyManagerInterface, TxoStage},
         tari_amount::{uT, MicroMinotari},
@@ -456,7 +452,9 @@ pub async fn generate_coinbase_with_wallet_output(
     let encryption_key_id = key_manager.import_key(encryption_private_key).await?;
 
     let script_spending_pubkey = if stealth_payment {
-        stealth_address_script_spending_key(&commitment_mask, wallet_payment_address.public_spend_key())?
+        key_manager
+            .stealth_address_script_spending_key(&commitment_mask_key_id, wallet_payment_address.public_spend_key())
+            .await?
     } else {
         wallet_payment_address.public_spend_key().clone()
     };

--- a/base_layer/core/src/transactions/key_manager/inner.rs
+++ b/base_layer/core/src/transactions/key_manager/inner.rs
@@ -765,15 +765,6 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
         }
     }
 
-    pub async fn import_add_offset_to_private_key(
-        &self,
-        secret_key_id: &TariKeyId,
-        offset: PrivateKey,
-    ) -> Result<TariKeyId, KeyManagerServiceError> {
-        let secret_key = self.get_private_key(secret_key_id).await?;
-        self.import_key(secret_key + offset).await
-    }
-
     pub async fn generate_burn_proof(
         &self,
         commitment_mask_key_id: &TariKeyId,

--- a/base_layer/core/src/transactions/key_manager/inner.rs
+++ b/base_layer/core/src/transactions/key_manager/inner.rs
@@ -1232,7 +1232,7 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
     pub async fn get_one_sided_metadata_signature(
         &self,
         commitment_mask_key_id: &TariKeyId,
-        value_as_private_key: &PrivateKey,
+        value: MicroMinotari,
         sender_offset_key_id: &TariKeyId,
         txo_version: &TransactionOutputVersion,
         metadata_signature_message: &[u8; 32],
@@ -1240,9 +1240,10 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
     ) -> Result<ComAndPubSignature, TransactionError> {
         match &self.wallet_type {
             WalletType::DerivedKeys | WalletType::ProvidedKeys(_) => {
+                let value = value.into();
                 self.get_metadata_signature(
                     commitment_mask_key_id,
-                    value_as_private_key,
+                    &value,
                     sender_offset_key_id,
                     txo_version,
                     metadata_signature_message,
@@ -1271,9 +1272,9 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
                         ledger.account,
                         ledger.network,
                         txo_version.as_u8(),
+                        value.into(),
                         sender_offset_key_index,
                         &commitment_mask,
-                        value_as_private_key,
                         metadata_signature_message,
                     )
                     .map_err(TransactionError::LedgerDeviceError)?;

--- a/base_layer/core/src/transactions/key_manager/inner.rs
+++ b/base_layer/core/src/transactions/key_manager/inner.rs
@@ -283,16 +283,8 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
             KeyId::Derived { key } => {
                 let key = TariKeyId::from_str(key.to_string().as_str())
                     .map_err(|_| KeyManagerServiceError::KeySerializationError)?;
-                let branch = key.managed_branch().ok_or(KeyManagerServiceError::KeyIdWithoutBranch)?;
-                let index = key.managed_index().ok_or(KeyManagerServiceError::KeyIdWithoutIndex)?;
                 let public_alpha = self.get_spend_key().await?.pub_key;
-                let km = self
-                    .key_managers
-                    .get(&branch)
-                    .ok_or(self.unknown_key_branch_error(&branch))?
-                    .read()
-                    .await;
-                let branch_key = km.get_private_key(index)?;
+                let branch_key = self.get_private_key(&key).await?;
                 let hasher = DomainSeparatedHasher::<Blake2b<U64>, KeyManagerTransactionsHashDomain>::new_with_label(
                     HASHER_LABEL_STEALTH_KEY,
                 );

--- a/base_layer/core/src/transactions/key_manager/inner.rs
+++ b/base_layer/core/src/transactions/key_manager/inner.rs
@@ -764,9 +764,10 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
 
     pub async fn import_add_offset_to_private_key(
         &self,
+        secret_key_id: &TariKeyId,
         offset: PrivateKey,
     ) -> Result<TariKeyId, KeyManagerServiceError> {
-        let secret_key = self.get_private_comms_key().await?;
+        let secret_key = self.get_private_key(secret_key_id).await?;
         self.import_key(secret_key + offset).await
     }
 

--- a/base_layer/core/src/transactions/key_manager/inner.rs
+++ b/base_layer/core/src/transactions/key_manager/inner.rs
@@ -329,9 +329,7 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
                         }
 
                         // If we're trying to access any of the private keys, just say no bueno
-                        if &TransactionKeyManagerBranch::Spend.get_branch_key() == branch ||
-                            &TransactionKeyManagerBranch::SenderOffset.get_branch_key() == branch
-                        {
+                        if &TransactionKeyManagerBranch::Spend.get_branch_key() == branch {
                             return Err(KeyManagerServiceError::LedgerPrivateKeyInaccessible);
                         }
                     },
@@ -766,10 +764,9 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
 
     pub async fn import_add_offset_to_private_key(
         &self,
-        secret_key_id: &TariKeyId,
         offset: PrivateKey,
     ) -> Result<TariKeyId, KeyManagerServiceError> {
-        let secret_key = self.get_private_key(secret_key_id).await?;
+        let secret_key = self.get_private_comms_key().await?;
         self.import_key(secret_key + offset).await
     }
 

--- a/base_layer/core/src/transactions/key_manager/inner.rs
+++ b/base_layer/core/src/transactions/key_manager/inner.rs
@@ -302,7 +302,6 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
                 Ok(public_key)
             },
             KeyId::Imported { key } => Ok(key.clone()),
-            KeyId::Offset { key_id, offset } => Err(KeyManagerServiceError::KeyNotFoundInKeyChain),
             KeyId::Zero => Ok(PublicKey::default()),
         }
     }
@@ -409,7 +408,6 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
                 let pvt_key = self.db.get_imported_key(key)?;
                 Ok(pvt_key)
             },
-            KeyId::Offset { .. } => Ok(PrivateKey::default()),
             KeyId::Zero => Ok(PrivateKey::default()),
         }
     }
@@ -548,7 +546,6 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
             KeyId::Managed { index, .. } => *index,
             KeyId::Derived { .. } => return Ok(None),
             KeyId::Imported { .. } => return Ok(None),
-            KeyId::Offset { .. } => return Ok(None),
             KeyId::Zero => return Ok(None),
         };
         let script_key_id = KeyId::Derived {
@@ -1004,7 +1001,6 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
         let mut derived_key_commitments = vec![];
         for script_key_id in script_key_ids {
             match script_key_id {
-                KeyId::Offset { .. } => {},
                 KeyId::Imported { .. } | KeyId::Managed { .. } | KeyId::Zero => {
                     total_script_private_key = total_script_private_key + self.get_private_key(script_key_id).await?
                 },
@@ -1065,7 +1061,7 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
                             } => {
                                 sender_offset_indexes.push(*index);
                             },
-                            TariKeyId::Imported { .. } | TariKeyId::Offset { .. } | TariKeyId::Zero => {},
+                            TariKeyId::Imported { .. } | TariKeyId::Zero => {},
                         }
                     }
 

--- a/base_layer/core/src/transactions/key_manager/inner.rs
+++ b/base_layer/core/src/transactions/key_manager/inner.rs
@@ -281,7 +281,7 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
                 }
             },
             KeyId::Derived { key } => {
-                let key = KeyId::<PublicKey>::from_str(key.to_string().as_str())
+                let key = TariKeyId::from_str(key.to_string().as_str())
                     .map_err(|_| KeyManagerServiceError::KeySerializationError)?;
                 let branch = key.managed_branch().ok_or(KeyManagerServiceError::KeyIdWithoutBranch)?;
                 let index = key.managed_index().ok_or(KeyManagerServiceError::KeyIdWithoutIndex)?;
@@ -368,7 +368,7 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
                 Ok(key)
             },
             KeyId::Derived { key } => {
-                let key = KeyId::<PublicKey>::from_str(key.to_string().as_str())
+                let key = TariKeyId::from_str(key.to_string().as_str())
                     .map_err(|_| KeyManagerServiceError::KeySerializationError)?;
                 let branch = key.managed_branch().ok_or(KeyManagerServiceError::KeyIdWithoutBranch)?;
                 let index = key.managed_index().ok_or(KeyManagerServiceError::KeyIdWithoutIndex)?;
@@ -479,7 +479,7 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
             .ok_or(KeyManagerServiceError::KeyIdWithoutIndex)?;
         let script_key_id = KeyId::Derived {
             key: SerializedKeyString::from(
-                KeyId::<PublicKey>::Managed {
+                TariKeyId::Managed {
                     branch: TransactionKeyManagerBranch::CommitmentMask.get_branch_key(),
                     index,
                 }
@@ -557,7 +557,7 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
         };
         let script_key_id = KeyId::Derived {
             key: SerializedKeyString::from(
-                KeyId::<PublicKey>::Managed {
+                TariKeyId::Managed {
                     branch: TransactionKeyManagerBranch::CommitmentMask.get_branch_key(),
                     index,
                 }
@@ -830,7 +830,7 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
 
         match (&self.wallet_type, script_key_id) {
             (WalletType::Ledger(ledger), KeyId::Derived { key }) => {
-                let key = KeyId::<PublicKey>::from_str(key.to_string().as_str())
+                let key = TariKeyId::from_str(key.to_string().as_str())
                     .map_err(|_| KeyManagerServiceError::KeySerializationError)?;
                 let branch = key.managed_branch().ok_or(KeyManagerServiceError::KeyIdWithoutBranch)?;
                 let index = key.managed_index().ok_or(KeyManagerServiceError::KeyIdWithoutIndex)?;
@@ -1014,7 +1014,7 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
                     total_script_private_key = &total_script_private_key + self.get_private_key(script_key_id).await?
                 },
                 KeyId::Derived { key } => {
-                    let key = KeyId::<PublicKey>::from_str(key.to_string().as_str())
+                    let key = TariKeyId::from_str(key.to_string().as_str())
                         .map_err(|_| KeyManagerServiceError::KeySerializationError)?;
                     let branch = key.managed_branch().ok_or(KeyManagerServiceError::KeyIdWithoutBranch)?;
                     let index = key.managed_index().ok_or(KeyManagerServiceError::KeyIdWithoutIndex)?;
@@ -1068,7 +1068,7 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
                                 sender_offset_indexes.push(*index);
                             },
                             TariKeyId::Derived { key } => {
-                                let key = KeyId::<PublicKey>::from_str(key.to_string().as_str())
+                                let key = TariKeyId::from_str(key.to_string().as_str())
                                     .map_err(|_| KeyManagerServiceError::KeySerializationError)?;
                                 let index = key.managed_index().ok_or(KeyManagerServiceError::KeyIdWithoutIndex)?;
                                 sender_offset_indexes.push(index);

--- a/base_layer/core/src/transactions/key_manager/interface.rs
+++ b/base_layer/core/src/transactions/key_manager/interface.rs
@@ -217,7 +217,7 @@ pub trait TransactionKeyManagerInterface: KeyManagerInterface<PublicKey> {
     async fn get_one_sided_metadata_signature(
         &self,
         spending_key_id: &TariKeyId,
-        value_as_private_key: &PrivateKey,
+        value: MicroMinotari,
         sender_offset_key_id: &TariKeyId,
         txo_version: &TransactionOutputVersion,
         metadata_signature_message: &[u8; 32],

--- a/base_layer/core/src/transactions/key_manager/interface.rs
+++ b/base_layer/core/src/transactions/key_manager/interface.rs
@@ -124,11 +124,7 @@ pub trait TransactionKeyManagerInterface: KeyManagerInterface<PublicKey> {
         public_key: &PublicKey,
     ) -> Result<DomainSeparatedHash<Blake2b<U64>>, TransactionError>;
 
-    async fn import_add_offset_to_private_key(
-        &self,
-        secret_key_id: &TariKeyId,
-        offset: PrivateKey,
-    ) -> Result<TariKeyId, KeyManagerServiceError>;
+    async fn import_add_offset_to_private_key(&self, offset: PrivateKey) -> Result<TariKeyId, KeyManagerServiceError>;
 
     async fn get_spending_key_id(&self, public_spending_key: &PublicKey) -> Result<TariKeyId, TransactionError>;
 

--- a/base_layer/core/src/transactions/key_manager/interface.rs
+++ b/base_layer/core/src/transactions/key_manager/interface.rs
@@ -323,8 +323,6 @@ mod test {
         let zero_key_id_str = zero_key_id.to_string();
         let derived_key_id_str = derived_key_id.to_string();
 
-        println!("{:?}", derived_key_id_str);
-
         assert_eq!(managed_key_id, TariKeyId::from_str(&managed_key_id_str).unwrap());
         assert_eq!(imported_key_id, TariKeyId::from_str(&imported_key_id_str).unwrap());
         assert_eq!(zero_key_id, TariKeyId::from_str(&zero_key_id_str).unwrap());

--- a/base_layer/core/src/transactions/key_manager/interface.rs
+++ b/base_layer/core/src/transactions/key_manager/interface.rs
@@ -124,7 +124,11 @@ pub trait TransactionKeyManagerInterface: KeyManagerInterface<PublicKey> {
         public_key: &PublicKey,
     ) -> Result<DomainSeparatedHash<Blake2b<U64>>, TransactionError>;
 
-    async fn import_add_offset_to_private_key(&self, offset: PrivateKey) -> Result<TariKeyId, KeyManagerServiceError>;
+    async fn import_add_offset_to_private_key(
+        &self,
+        secret_key_id: &TariKeyId,
+        offset: PrivateKey,
+    ) -> Result<TariKeyId, KeyManagerServiceError>;
 
     async fn get_spending_key_id(&self, public_spending_key: &PublicKey) -> Result<TariKeyId, TransactionError>;
 

--- a/base_layer/core/src/transactions/key_manager/interface.rs
+++ b/base_layer/core/src/transactions/key_manager/interface.rs
@@ -267,6 +267,12 @@ pub trait TransactionKeyManagerInterface: KeyManagerInterface<PublicKey> {
         amount: &PrivateKey,
         claim_public_key: &PublicKey,
     ) -> Result<RistrettoComSig, TransactionError>;
+
+    async fn stealth_address_script_spending_key(
+        &self,
+        commitment_mask_key_id: &TariKeyId,
+        spend_key: &PublicKey,
+    ) -> Result<PublicKey, TransactionError>;
 }
 
 #[async_trait::async_trait]

--- a/base_layer/core/src/transactions/key_manager/interface.rs
+++ b/base_layer/core/src/transactions/key_manager/interface.rs
@@ -124,12 +124,6 @@ pub trait TransactionKeyManagerInterface: KeyManagerInterface<PublicKey> {
         public_key: &PublicKey,
     ) -> Result<DomainSeparatedHash<Blake2b<U64>>, TransactionError>;
 
-    async fn import_add_offset_to_private_key(
-        &self,
-        secret_key_id: &TariKeyId,
-        offset: PrivateKey,
-    ) -> Result<TariKeyId, KeyManagerServiceError>;
-
     async fn get_spending_key_id(&self, public_spending_key: &PublicKey) -> Result<TariKeyId, TransactionError>;
 
     async fn construct_range_proof(

--- a/base_layer/core/src/transactions/key_manager/interface.rs
+++ b/base_layer/core/src/transactions/key_manager/interface.rs
@@ -216,6 +216,16 @@ pub trait TransactionKeyManagerInterface: KeyManagerInterface<PublicKey> {
         range_proof_type: RangeProofType,
     ) -> Result<ComAndPubSignature, TransactionError>;
 
+    async fn get_one_sided_metadata_signature(
+        &self,
+        spending_key_id: &TariKeyId,
+        value_as_private_key: &PrivateKey,
+        sender_offset_key_id: &TariKeyId,
+        txo_version: &TransactionOutputVersion,
+        metadata_signature_message: &[u8; 32],
+        range_proof_type: RangeProofType,
+    ) -> Result<ComAndPubSignature, TransactionError>;
+
     async fn sign_script_message(
         &self,
         private_key_id: &TariKeyId,

--- a/base_layer/core/src/transactions/key_manager/interface.rs
+++ b/base_layer/core/src/transactions/key_manager/interface.rs
@@ -283,7 +283,7 @@ mod test {
     use rand::{distributions::Alphanumeric, rngs::OsRng, Rng};
     use tari_common_types::types::{PrivateKey, PublicKey};
     use tari_crypto::keys::{PublicKey as PK, SecretKey as SK};
-    use tari_key_manager::key_manager_service::{KeyId, SerializedKeyString};
+    use tari_key_manager::key_manager_service::KeyId;
 
     use crate::transactions::key_manager::TariKeyId;
 
@@ -309,7 +309,7 @@ mod test {
         };
         let zero_key_id: TariKeyId = TariKeyId::Zero;
         let derived_key_id: KeyId<PublicKey> = KeyId::Derived {
-            key: SerializedKeyString::from(managed_key_id.clone().to_string()),
+            key: managed_key_id.clone().into(),
         };
 
         let managed_key_id_str = managed_key_id.to_string();

--- a/base_layer/core/src/transactions/key_manager/interface.rs
+++ b/base_layer/core/src/transactions/key_manager/interface.rs
@@ -289,6 +289,7 @@ mod test {
     use rand::{distributions::Alphanumeric, rngs::OsRng, Rng};
     use tari_common_types::types::{PrivateKey, PublicKey};
     use tari_crypto::keys::{PublicKey as PK, SecretKey as SK};
+    use tari_key_manager::key_manager_service::{KeyId, SerializedKeyString};
 
     use crate::transactions::key_manager::TariKeyId;
 
@@ -313,14 +314,20 @@ mod test {
             key: PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
         };
         let zero_key_id: TariKeyId = TariKeyId::Zero;
+        let derived_key_id: KeyId<PublicKey> = KeyId::Derived {
+            key: SerializedKeyString::from(managed_key_id.clone().to_string()),
+        };
 
         let managed_key_id_str = managed_key_id.to_string();
         let imported_key_id_str = imported_key_id.to_string();
         let zero_key_id_str = zero_key_id.to_string();
+        let derived_key_id_str = derived_key_id.to_string();
+
+        println!("{:?}", derived_key_id_str);
 
         assert_eq!(managed_key_id, TariKeyId::from_str(&managed_key_id_str).unwrap());
-        println!("imported_key_id_str: {}", imported_key_id_str);
         assert_eq!(imported_key_id, TariKeyId::from_str(&imported_key_id_str).unwrap());
         assert_eq!(zero_key_id, TariKeyId::from_str(&zero_key_id_str).unwrap());
+        assert_eq!(derived_key_id, TariKeyId::from_str(&derived_key_id_str).unwrap());
     }
 }

--- a/base_layer/core/src/transactions/key_manager/wrapper.rs
+++ b/base_layer/core/src/transactions/key_manager/wrapper.rs
@@ -451,7 +451,7 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
 
     async fn get_one_sided_metadata_signature(
         &self,
-        spending_key_id: &TariKeyId,
+        commitment_mask_key_id: &TariKeyId,
         value_as_private_key: &PrivateKey,
         sender_offset_key_id: &TariKeyId,
         txo_version: &TransactionOutputVersion,
@@ -462,7 +462,7 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
             .read()
             .await
             .get_one_sided_metadata_signature(
-                spending_key_id,
+                commitment_mask_key_id,
                 value_as_private_key,
                 sender_offset_key_id,
                 txo_version,

--- a/base_layer/core/src/transactions/key_manager/wrapper.rs
+++ b/base_layer/core/src/transactions/key_manager/wrapper.rs
@@ -457,6 +457,29 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
             .await
     }
 
+    async fn get_one_sided_metadata_signature(
+        &self,
+        spending_key_id: &TariKeyId,
+        value_as_private_key: &PrivateKey,
+        sender_offset_key_id: &TariKeyId,
+        txo_version: &TransactionOutputVersion,
+        metadata_signature_message: &[u8; 32],
+        range_proof_type: RangeProofType,
+    ) -> Result<ComAndPubSignature, TransactionError> {
+        self.transaction_key_manager_inner
+            .read()
+            .await
+            .get_one_sided_metadata_signature(
+                spending_key_id,
+                value_as_private_key,
+                sender_offset_key_id,
+                txo_version,
+                metadata_signature_message,
+                range_proof_type,
+            )
+            .await
+    }
+
     async fn sign_script_message(
         &self,
         private_key_id: &TariKeyId,

--- a/base_layer/core/src/transactions/key_manager/wrapper.rs
+++ b/base_layer/core/src/transactions/key_manager/wrapper.rs
@@ -260,18 +260,6 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
             .await
     }
 
-    async fn import_add_offset_to_private_key(
-        &self,
-        secret_key_id: &TariKeyId,
-        offset: PrivateKey,
-    ) -> Result<TariKeyId, KeyManagerServiceError> {
-        self.transaction_key_manager_inner
-            .read()
-            .await
-            .import_add_offset_to_private_key(secret_key_id, offset)
-            .await
-    }
-
     async fn get_spending_key_id(&self, public_spending_key: &PublicKey) -> Result<TariKeyId, TransactionError> {
         self.transaction_key_manager_inner
             .read()

--- a/base_layer/core/src/transactions/key_manager/wrapper.rs
+++ b/base_layer/core/src/transactions/key_manager/wrapper.rs
@@ -452,7 +452,7 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
     async fn get_one_sided_metadata_signature(
         &self,
         commitment_mask_key_id: &TariKeyId,
-        value_as_private_key: &PrivateKey,
+        value: MicroMinotari,
         sender_offset_key_id: &TariKeyId,
         txo_version: &TransactionOutputVersion,
         metadata_signature_message: &[u8; 32],
@@ -463,7 +463,7 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
             .await
             .get_one_sided_metadata_signature(
                 commitment_mask_key_id,
-                value_as_private_key,
+                value,
                 sender_offset_key_id,
                 txo_version,
                 metadata_signature_message,

--- a/base_layer/core/src/transactions/key_manager/wrapper.rs
+++ b/base_layer/core/src/transactions/key_manager/wrapper.rs
@@ -260,15 +260,11 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
             .await
     }
 
-    async fn import_add_offset_to_private_key(
-        &self,
-        secret_key_id: &TariKeyId,
-        offset: PrivateKey,
-    ) -> Result<TariKeyId, KeyManagerServiceError> {
+    async fn import_add_offset_to_private_key(&self, offset: PrivateKey) -> Result<TariKeyId, KeyManagerServiceError> {
         self.transaction_key_manager_inner
             .read()
             .await
-            .import_add_offset_to_private_key(secret_key_id, offset)
+            .import_add_offset_to_private_key(offset)
             .await
     }
 

--- a/base_layer/core/src/transactions/key_manager/wrapper.rs
+++ b/base_layer/core/src/transactions/key_manager/wrapper.rs
@@ -260,11 +260,15 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
             .await
     }
 
-    async fn import_add_offset_to_private_key(&self, offset: PrivateKey) -> Result<TariKeyId, KeyManagerServiceError> {
+    async fn import_add_offset_to_private_key(
+        &self,
+        secret_key_id: &TariKeyId,
+        offset: PrivateKey,
+    ) -> Result<TariKeyId, KeyManagerServiceError> {
         self.transaction_key_manager_inner
             .read()
             .await
-            .import_add_offset_to_private_key(offset)
+            .import_add_offset_to_private_key(secret_key_id, offset)
             .await
     }
 

--- a/base_layer/core/src/transactions/key_manager/wrapper.rs
+++ b/base_layer/core/src/transactions/key_manager/wrapper.rs
@@ -560,6 +560,18 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
             .generate_burn_proof(spending_key, amount, claim_public_key)
             .await
     }
+
+    async fn stealth_address_script_spending_key(
+        &self,
+        commitment_mask_key_id: &TariKeyId,
+        spend_key: &PublicKey,
+    ) -> Result<PublicKey, TransactionError> {
+        self.transaction_key_manager_inner
+            .read()
+            .await
+            .stealth_address_script_spending_key(commitment_mask_key_id, spend_key)
+            .await
+    }
 }
 
 #[async_trait::async_trait]

--- a/base_layer/core/src/transactions/test_helpers.rs
+++ b/base_layer/core/src/transactions/test_helpers.rs
@@ -30,7 +30,12 @@ use tari_common_types::{
     types::{Commitment, PrivateKey, PublicKey, Signature},
 };
 use tari_crypto::keys::{PublicKey as PK, SecretKey};
-use tari_key_manager::key_manager_service::{storage::sqlite_db::KeyManagerSqliteDatabase, KeyId, KeyManagerInterface};
+use tari_key_manager::key_manager_service::{
+    storage::sqlite_db::KeyManagerSqliteDatabase,
+    KeyId,
+    KeyManagerInterface,
+    SerializedKeyString,
+};
 use tari_script::{inputs, script, ExecutionStack, TariScript};
 
 use super::transaction_components::{TransactionInputVersion, TransactionOutputVersion};
@@ -46,7 +51,6 @@ use crate::{
             MemoryDbKeyManager,
             TariKeyId,
             TransactionKeyManagerInterface,
-            TransactionKeyManagerLabel,
             TransactionKeyManagerWrapper,
             TxoStage,
         },
@@ -736,9 +740,13 @@ pub async fn create_stx_protocol_internal(
             .await
             .unwrap();
         let script_key_id = KeyId::Derived {
-            branch: TransactionKeyManagerBranch::CommitmentMask.get_branch_key(),
-            label: TransactionKeyManagerLabel::ScriptKey.get_branch_key(),
-            index: commitment_mask.key_id.managed_index().unwrap(),
+            key: SerializedKeyString::from(
+                KeyId::<PublicKey>::Managed {
+                    branch: TransactionKeyManagerBranch::CommitmentMask.get_branch_key(),
+                    index: commitment_mask.key_id.managed_index().unwrap(),
+                }
+                .to_string(),
+            ),
         };
         let script_public_key = key_manager.get_public_key_at_key_id(&script_key_id).await.unwrap();
         let input_data = match &schema.input_data {

--- a/base_layer/core/src/transactions/test_helpers.rs
+++ b/base_layer/core/src/transactions/test_helpers.rs
@@ -741,7 +741,7 @@ pub async fn create_stx_protocol_internal(
             .unwrap();
         let script_key_id = KeyId::Derived {
             key: SerializedKeyString::from(
-                KeyId::<PublicKey>::Managed {
+                TariKeyId::Managed {
                     branch: TransactionKeyManagerBranch::CommitmentMask.get_branch_key(),
                     index: commitment_mask.key_id.managed_index().unwrap(),
                 }

--- a/base_layer/core/src/transactions/test_helpers.rs
+++ b/base_layer/core/src/transactions/test_helpers.rs
@@ -30,12 +30,7 @@ use tari_common_types::{
     types::{Commitment, PrivateKey, PublicKey, Signature},
 };
 use tari_crypto::keys::{PublicKey as PK, SecretKey};
-use tari_key_manager::key_manager_service::{
-    storage::sqlite_db::KeyManagerSqliteDatabase,
-    KeyId,
-    KeyManagerInterface,
-    SerializedKeyString,
-};
+use tari_key_manager::key_manager_service::{storage::sqlite_db::KeyManagerSqliteDatabase, KeyId, KeyManagerInterface};
 use tari_script::{inputs, script, ExecutionStack, TariScript};
 
 use super::transaction_components::{TransactionInputVersion, TransactionOutputVersion};
@@ -740,13 +735,7 @@ pub async fn create_stx_protocol_internal(
             .await
             .unwrap();
         let script_key_id = KeyId::Derived {
-            key: SerializedKeyString::from(
-                TariKeyId::Managed {
-                    branch: TransactionKeyManagerBranch::CommitmentMask.get_branch_key(),
-                    index: commitment_mask.key_id.managed_index().unwrap(),
-                }
-                .to_string(),
-            ),
+            key: (&commitment_mask.key_id).into(),
         };
         let script_public_key = key_manager.get_public_key_at_key_id(&script_key_id).await.unwrap();
         let input_data = match &schema.input_data {

--- a/base_layer/core/src/transactions/transaction_components/wallet_output_builder.rs
+++ b/base_layer/core/src/transactions/transaction_components/wallet_output_builder.rs
@@ -203,6 +203,41 @@ impl WalletOutputBuilder {
         Ok(self)
     }
 
+    pub async fn sign_as_sender_and_receiver_verified<KM: TransactionKeyManagerInterface>(
+        mut self,
+        key_manager: &KM,
+        sender_offset_key_id: &TariKeyId,
+    ) -> Result<Self, TransactionError> {
+        let script = self
+            .script
+            .as_ref()
+            .ok_or_else(|| TransactionError::BuilderError("Cannot sign metadata without a script".to_string()))?;
+        let sender_offset_public_key = key_manager.get_public_key_at_key_id(sender_offset_key_id).await?;
+        let metadata_message = TransactionOutput::metadata_signature_message_from_parts(
+            &self.version,
+            script,
+            &self.features,
+            &self.covenant,
+            &self.encrypted_data,
+            &self.minimum_value_promise,
+        );
+        let metadata_signature = key_manager
+            .get_one_sided_metadata_signature(
+                &self.commitment_mask_key_id,
+                &self.value.into(),
+                sender_offset_key_id,
+                &self.version,
+                &metadata_message,
+                self.features.range_proof_type,
+            )
+            .await?;
+        self.metadata_signature = Some(metadata_signature);
+        self.metadata_signed_by_receiver = true;
+        self.metadata_signed_by_sender = true;
+        self.sender_offset_public_key = Some(sender_offset_public_key);
+        Ok(self)
+    }
+
     /// Sign a partial multi-party metadata signature as the sender and receiver - `sender_offset_public_key_shares` and
     /// `ephemeral_pubkey_shares` from other participants are combined to enable creation of the challenge.
     pub async fn sign_partial_as_sender_and_receiver<KM: TransactionKeyManagerInterface>(

--- a/base_layer/core/src/transactions/transaction_components/wallet_output_builder.rs
+++ b/base_layer/core/src/transactions/transaction_components/wallet_output_builder.rs
@@ -224,7 +224,7 @@ impl WalletOutputBuilder {
         let metadata_signature = key_manager
             .get_one_sided_metadata_signature(
                 &self.commitment_mask_key_id,
-                &self.value.into(),
+                self.value,
                 sender_offset_key_id,
                 &self.version,
                 &metadata_message,

--- a/base_layer/core/tests/tests/node_comms_interface.rs
+++ b/base_layer/core/tests/tests/node_comms_interface.rs
@@ -23,7 +23,7 @@
 use std::sync::{Arc, RwLock};
 
 use tari_common::configuration::Network;
-use tari_common_types::key_branches::TransactionKeyManagerBranch;
+use tari_common_types::{key_branches::TransactionKeyManagerBranch, types::PublicKey};
 use tari_comms::test_utils::mocks::create_connectivity_mock;
 use tari_core::{
     base_node::comms_interface::{
@@ -42,12 +42,7 @@ use tari_core::{
         create_consensus_rules,
     },
     transactions::{
-        key_manager::{
-            create_memory_db_key_manager,
-            MemoryDbKeyManager,
-            TransactionKeyManagerInterface,
-            TransactionKeyManagerLabel,
-        },
+        key_manager::{create_memory_db_key_manager, MemoryDbKeyManager, TransactionKeyManagerInterface},
         tari_amount::MicroMinotari,
         test_helpers::{create_utxo, TestParams, TransactionSchema},
         transaction_components::{
@@ -65,7 +60,7 @@ use tari_core::{
     validation::{mocks::MockValidator, transaction::TransactionChainLinkedValidator},
     OutputSmt,
 };
-use tari_key_manager::key_manager_service::{KeyId, KeyManagerInterface};
+use tari_key_manager::key_manager_service::{KeyId, KeyManagerInterface, SerializedKeyString};
 use tari_script::{inputs, script, ExecutionStack};
 use tari_service_framework::reply_channel;
 use tokio::sync::{broadcast, mpsc};
@@ -307,9 +302,13 @@ async fn initialize_sender_transaction_protocol_for_overflow_test(
             .unwrap();
 
         let script_key_id = KeyId::Derived {
-            branch: TransactionKeyManagerBranch::CommitmentMask.get_branch_key(),
-            label: TransactionKeyManagerLabel::ScriptKey.get_branch_key(),
-            index: commitment_mask_key.key_id.managed_index().unwrap(),
+            key: SerializedKeyString::from(
+                KeyId::<PublicKey>::Managed {
+                    branch: TransactionKeyManagerBranch::CommitmentMask.get_branch_key(),
+                    index: commitment_mask_key.key_id.managed_index().unwrap(),
+                }
+                .to_string(),
+            ),
         };
 
         let script_public_key = key_manager.get_public_key_at_key_id(&script_key_id).await.unwrap();

--- a/base_layer/core/tests/tests/node_comms_interface.rs
+++ b/base_layer/core/tests/tests/node_comms_interface.rs
@@ -23,7 +23,7 @@
 use std::sync::{Arc, RwLock};
 
 use tari_common::configuration::Network;
-use tari_common_types::{key_branches::TransactionKeyManagerBranch, types::PublicKey};
+use tari_common_types::key_branches::TransactionKeyManagerBranch;
 use tari_comms::test_utils::mocks::create_connectivity_mock;
 use tari_core::{
     base_node::comms_interface::{
@@ -42,7 +42,7 @@ use tari_core::{
         create_consensus_rules,
     },
     transactions::{
-        key_manager::{create_memory_db_key_manager, MemoryDbKeyManager, TransactionKeyManagerInterface},
+        key_manager::{create_memory_db_key_manager, MemoryDbKeyManager, TariKeyId, TransactionKeyManagerInterface},
         tari_amount::MicroMinotari,
         test_helpers::{create_utxo, TestParams, TransactionSchema},
         transaction_components::{
@@ -303,7 +303,7 @@ async fn initialize_sender_transaction_protocol_for_overflow_test(
 
         let script_key_id = KeyId::Derived {
             key: SerializedKeyString::from(
-                KeyId::<PublicKey>::Managed {
+                TariKeyId::Managed {
                     branch: TransactionKeyManagerBranch::CommitmentMask.get_branch_key(),
                     index: commitment_mask_key.key_id.managed_index().unwrap(),
                 }

--- a/base_layer/core/tests/tests/node_comms_interface.rs
+++ b/base_layer/core/tests/tests/node_comms_interface.rs
@@ -42,7 +42,7 @@ use tari_core::{
         create_consensus_rules,
     },
     transactions::{
-        key_manager::{create_memory_db_key_manager, MemoryDbKeyManager, TariKeyId, TransactionKeyManagerInterface},
+        key_manager::{create_memory_db_key_manager, MemoryDbKeyManager, TransactionKeyManagerInterface},
         tari_amount::MicroMinotari,
         test_helpers::{create_utxo, TestParams, TransactionSchema},
         transaction_components::{
@@ -60,7 +60,7 @@ use tari_core::{
     validation::{mocks::MockValidator, transaction::TransactionChainLinkedValidator},
     OutputSmt,
 };
-use tari_key_manager::key_manager_service::{KeyId, KeyManagerInterface, SerializedKeyString};
+use tari_key_manager::key_manager_service::{KeyId, KeyManagerInterface};
 use tari_script::{inputs, script, ExecutionStack};
 use tari_service_framework::reply_channel;
 use tokio::sync::{broadcast, mpsc};
@@ -302,13 +302,7 @@ async fn initialize_sender_transaction_protocol_for_overflow_test(
             .unwrap();
 
         let script_key_id = KeyId::Derived {
-            key: SerializedKeyString::from(
-                TariKeyId::Managed {
-                    branch: TransactionKeyManagerBranch::CommitmentMask.get_branch_key(),
-                    index: commitment_mask_key.key_id.managed_index().unwrap(),
-                }
-                .to_string(),
-            ),
+            key: (&commitment_mask_key.key_id).into(),
         };
 
         let script_public_key = key_manager.get_public_key_at_key_id(&script_key_id).await.unwrap();

--- a/base_layer/key_manager/src/key_manager_service/error.rs
+++ b/base_layer/key_manager/src/key_manager_service/error.rs
@@ -36,13 +36,15 @@ pub enum KeyManagerServiceError {
     #[error("Branch does not exist: `{0}`")]
     UnknownKeyBranch(String),
     #[error("Key ID without an index, most likely `Imported`")]
-    KyeIdWithoutIndex,
+    KeyIdWithoutIndex,
     #[error("Master seed does not match stored version")]
     MasterSeedMismatch,
     #[error("Could not find key in key manager")]
     KeyNotFoundInKeyChain,
     #[error("Storage error: `{0}`")]
     KeyManagerStorageError(#[from] KeyManagerStorageError),
+    #[error("Could not be serialized from string")]
+    KeySerializationError,
     #[error("Byte array error: `{0}`")]
     ByteArrayError(String),
     #[error("Invalid range proof: `{0}`")]

--- a/base_layer/key_manager/src/key_manager_service/error.rs
+++ b/base_layer/key_manager/src/key_manager_service/error.rs
@@ -37,6 +37,8 @@ pub enum KeyManagerServiceError {
     UnknownKeyBranch(String),
     #[error("Key ID without an index, most likely `Imported`")]
     KeyIdWithoutIndex,
+    #[error("Key ID without a branch, most likely `Imported`")]
+    KeyIdWithoutBranch,
     #[error("Master seed does not match stored version")]
     MasterSeedMismatch,
     #[error("Could not find key in key manager")]

--- a/base_layer/key_manager/src/key_manager_service/interface.rs
+++ b/base_layer/key_manager/src/key_manager_service/interface.rs
@@ -281,8 +281,6 @@ mod test {
         let zero_key_id_str = zero_key_id.to_string();
         let derived_key_id_str = derived_key_id.to_string();
 
-        println!("{:?}", derived_key_id_str);
-
         assert_eq!(managed_key_id, KeyId::from_str(&managed_key_id_str).unwrap());
         assert_eq!(imported_key_id, KeyId::from_str(&imported_key_id_str).unwrap());
         assert_eq!(zero_key_id, KeyId::from_str(&zero_key_id_str).unwrap());

--- a/base_layer/key_manager/src/key_manager_service/interface.rs
+++ b/base_layer/key_manager/src/key_manager_service/interface.rs
@@ -26,8 +26,8 @@ use std::{fmt, str::FromStr};
 
 use serde::{Deserialize, Serialize};
 use strum_macros::EnumIter;
-use tari_common_types::{types::PrivateKey, WALLET_COMMS_AND_SPEND_KEY_BRANCH};
-use tari_crypto::keys::{PublicKey as PublicKeyTrait, SecretKey as SecretKeyTrait};
+use tari_common_types::WALLET_COMMS_AND_SPEND_KEY_BRANCH;
+use tari_crypto::keys::{PublicKey, SecretKey};
 use tari_utilities::{hex::Hex, ByteArray};
 
 use crate::key_manager_service::error::KeyManagerServiceError;
@@ -76,10 +76,6 @@ pub enum KeyId<PK> {
     Imported {
         key: PK,
     },
-    Offset {
-        key_id: Box<KeyId<PK>>,
-        offset: PrivateKey,
-    },
     #[default]
     Zero,
 }
@@ -92,7 +88,6 @@ where PK: Clone
             KeyId::Managed { index, .. } => Some(*index),
             KeyId::Derived { index, .. } => Some(*index),
             KeyId::Imported { .. } => None,
-            KeyId::Offset { .. } => None,
             KeyId::Zero => None,
         }
     }
@@ -102,7 +97,6 @@ where PK: Clone
             KeyId::Managed { branch, .. } => Some(branch.clone()),
             KeyId::Derived { branch, .. } => Some(branch.clone()),
             KeyId::Imported { .. } => None,
-            KeyId::Offset { .. } => None,
             KeyId::Zero => None,
         }
     }
@@ -112,7 +106,6 @@ where PK: Clone
             KeyId::Managed { .. } => None,
             KeyId::Derived { .. } => None,
             KeyId::Imported { key } => Some(key.clone()),
-            KeyId::Offset { .. } => None,
             KeyId::Zero => None,
         }
     }
@@ -135,8 +128,7 @@ where PK: ByteArray
                 label: l,
                 index: i,
             } => write!(f, "{}.{}.{}.{}", DERIVED_KEY_BRANCH, b, l, i),
-            KeyId::Imported { key } => write!(f, "{}.{}", IMPORTED_KEY_BRANCH, key.to_hex()),
-            KeyId::Offset { key_id, offset } => write!(f, "offset key id.{}.{}", key_id, offset.to_hex()),
+            KeyId::Imported { key: public_key } => write!(f, "{}.{}", IMPORTED_KEY_BRANCH, public_key.to_hex()),
             KeyId::Zero => write!(f, "{}", ZERO_KEY_BRANCH),
         }
     }
@@ -195,8 +187,8 @@ where PK: ByteArray
 #[async_trait::async_trait]
 pub trait KeyManagerInterface<PK>: Clone + Send + Sync + 'static
 where
-    PK: PublicKeyTrait + Send + Sync + 'static,
-    PK::K: SecretKeyTrait + Send + Sync + 'static,
+    PK: PublicKey + Send + Sync + 'static,
+    PK::K: SecretKey + Send + Sync + 'static,
 {
     /// Creates a new branch for the key manager service to track
     /// If this is an existing branch, that is not yet tracked in memory, the key manager service will load the key

--- a/base_layer/key_manager/src/key_manager_service/interface.rs
+++ b/base_layer/key_manager/src/key_manager_service/interface.rs
@@ -67,8 +67,14 @@ pub struct SerializedKeyString {
     inner: String,
 }
 
-impl SerializedKeyString {
-    pub fn from<T: Into<String>>(inner: T) -> Self {
+impl From<String> for SerializedKeyString {
+    fn from(inner: String) -> Self {
+        Self { inner }
+    }
+}
+
+impl From<&str> for SerializedKeyString {
+    fn from(inner: &str) -> Self {
         Self { inner: inner.into() }
     }
 }
@@ -83,6 +89,14 @@ impl<PK> From<KeyId<PK>> for SerializedKeyString
 where PK: ByteArray
 {
     fn from(key_id: KeyId<PK>) -> Self {
+        Self::from(key_id.to_string())
+    }
+}
+
+impl<PK> From<&KeyId<PK>> for SerializedKeyString
+where PK: ByteArray
+{
+    fn from(key_id: &KeyId<PK>) -> Self {
         Self::from(key_id.to_string())
     }
 }
@@ -249,7 +263,7 @@ mod test {
     use tari_common_types::types::{PrivateKey, PublicKey};
     use tari_crypto::keys::{PublicKey as PK, SecretKey as SK};
 
-    use crate::key_manager_service::{KeyId, SerializedKeyString};
+    use crate::key_manager_service::KeyId;
 
     fn random_string(len: usize) -> String {
         iter::repeat(())
@@ -273,7 +287,7 @@ mod test {
         };
         let zero_key_id: KeyId<PublicKey> = KeyId::Zero;
         let derived_key_id: KeyId<PublicKey> = KeyId::Derived {
-            key: SerializedKeyString::from(managed_key_id.clone().to_string()),
+            key: (&managed_key_id).into(),
         };
 
         let managed_key_id_str = managed_key_id.to_string();

--- a/base_layer/key_manager/src/key_manager_service/interface.rs
+++ b/base_layer/key_manager/src/key_manager_service/interface.rs
@@ -165,7 +165,7 @@ where PK: ByteArray
             Some(val) => match *val {
                 MANAGED_KEY_BRANCH => {
                     if parts.len() != 3 {
-                        return Err("Wrong format".to_string());
+                        return Err("Wrong managed format".to_string());
                     }
                     let index = parts[2]
                         .parse()
@@ -177,22 +177,24 @@ where PK: ByteArray
                 },
                 IMPORTED_KEY_BRANCH => {
                     if parts.len() != 2 {
-                        return Err("Wrong format".to_string());
+                        return Err("Wrong imported format".to_string());
                     }
                     let key = PK::from_hex(parts[1]).map_err(|_| "Invalid public key".to_string())?;
                     Ok(KeyId::Imported { key })
                 },
                 ZERO_KEY_BRANCH => Ok(KeyId::Zero),
                 DERIVED_KEY_BRANCH => {
-                    if parts.len() != 3 | 4 {
-                        return Err("Wrong format".to_string());
+                    match parts.len() {
+                        4 | 3 => (),
+                        _ => return Err("Wrong derived format".to_string()),
                     }
+
                     let key = parts[1..].join(".");
                     Ok(KeyId::Derived {
                         key: SerializedKeyString::from(key),
                     })
                 },
-                _ => Err("Wrong format".to_string()),
+                _ => Err("Wrong generic format".to_string()),
             },
         }
     }
@@ -247,7 +249,7 @@ mod test {
     use tari_common_types::types::{PrivateKey, PublicKey};
     use tari_crypto::keys::{PublicKey as PK, SecretKey as SK};
 
-    use crate::key_manager_service::KeyId;
+    use crate::key_manager_service::{KeyId, SerializedKeyString};
 
     fn random_string(len: usize) -> String {
         iter::repeat(())
@@ -270,13 +272,20 @@ mod test {
             key: PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
         };
         let zero_key_id: KeyId<PublicKey> = KeyId::Zero;
+        let derived_key_id: KeyId<PublicKey> = KeyId::Derived {
+            key: SerializedKeyString::from(managed_key_id.clone().to_string()),
+        };
 
         let managed_key_id_str = managed_key_id.to_string();
         let imported_key_id_str = imported_key_id.to_string();
         let zero_key_id_str = zero_key_id.to_string();
+        let derived_key_id_str = derived_key_id.to_string();
+
+        println!("{:?}", derived_key_id_str);
 
         assert_eq!(managed_key_id, KeyId::from_str(&managed_key_id_str).unwrap());
         assert_eq!(imported_key_id, KeyId::from_str(&imported_key_id_str).unwrap());
         assert_eq!(zero_key_id, KeyId::from_str(&zero_key_id_str).unwrap());
+        assert_eq!(derived_key_id, KeyId::from_str(&derived_key_id_str).unwrap());
     }
 }

--- a/base_layer/key_manager/src/key_manager_service/mod.rs
+++ b/base_layer/key_manager/src/key_manager_service/mod.rs
@@ -49,6 +49,6 @@ mod service;
 pub use service::KeyManagerInner;
 
 mod interface;
-pub use interface::KeyId;
+pub use interface::{KeyId, SerializedKeyString};
 pub mod storage;
 pub use interface::{AddResult, KeyAndId, KeyManagerBranch, KeyManagerInterface};

--- a/base_layer/key_manager/src/key_manager_service/service.rs
+++ b/base_layer/key_manager/src/key_manager_service/service.rs
@@ -152,7 +152,9 @@ where
             KeyId::Derived { key } => {
                 let key = KeyId::<PK>::from_str(key.to_string().as_str())
                     .map_err(|_| KeyManagerServiceError::KeySerializationError)?;
-                let branch = key.managed_branch().ok_or(KeyManagerServiceError::KeyIdWithoutBranch)?;
+                let branch = key.managed_branch().ok_or_else(|| {
+                    KeyManagerServiceError::KeyIdWithoutBranch
+                })?;
                 let index = key.managed_index().ok_or(KeyManagerServiceError::KeyIdWithoutIndex)?;
                 let km = self
                     .key_managers

--- a/base_layer/key_manager/src/key_manager_service/service.rs
+++ b/base_layer/key_manager/src/key_manager_service/service.rs
@@ -152,7 +152,7 @@ where
             KeyId::Derived { key } => {
                 let key = KeyId::<PK>::from_str(key.to_string().as_str())
                     .map_err(|_| KeyManagerServiceError::KeySerializationError)?;
-                let branch = key.managed_branch().ok_or(KeyManagerServiceError::UnknownKeyBranch)?;
+                let branch = key.managed_branch().ok_or(KeyManagerServiceError::KeyIdWithoutBranch)?;
                 let index = key.managed_index().ok_or(KeyManagerServiceError::KeyIdWithoutIndex)?;
                 let km = self
                     .key_managers

--- a/base_layer/key_manager/src/key_manager_service/service.rs
+++ b/base_layer/key_manager/src/key_manager_service/service.rs
@@ -173,6 +173,7 @@ where
                 Ok(public_key)
             },
             KeyId::Imported { key } => Ok(key.clone()),
+            KeyId::Offset { .. } => Err(KeyManagerServiceError::KeyNotFoundInKeyChain),
             KeyId::Zero => Ok(PK::default()),
         }
     }

--- a/base_layer/key_manager/src/key_manager_service/service.rs
+++ b/base_layer/key_manager/src/key_manager_service/service.rs
@@ -173,7 +173,6 @@ where
                 Ok(public_key)
             },
             KeyId::Imported { key } => Ok(key.clone()),
-            KeyId::Offset { .. } => Err(KeyManagerServiceError::KeyNotFoundInKeyChain),
             KeyId::Zero => Ok(PK::default()),
         }
     }

--- a/base_layer/key_manager/src/key_manager_service/service.rs
+++ b/base_layer/key_manager/src/key_manager_service/service.rs
@@ -19,7 +19,7 @@
 //  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-use std::collections::HashMap;
+use std::{collections::HashMap, str::FromStr};
 
 use argon2::password_hash::rand_core::OsRng;
 use blake2::Blake2b;
@@ -149,14 +149,18 @@ where
                     .await;
                 Ok(km.derive_public_key(*index)?.key)
             },
-            KeyId::Derived { branch, index, .. } => {
+            KeyId::Derived { key } => {
+                let key = KeyId::<PK>::from_str(key.to_string().as_str())
+                    .map_err(|_| KeyManagerServiceError::KeySerializationError)?;
+                let branch = key.managed_branch().ok_or(KeyManagerServiceError::UnknownKeyBranch)?;
+                let index = key.managed_index().ok_or(KeyManagerServiceError::KeyIdWithoutIndex)?;
                 let km = self
                     .key_managers
-                    .get(branch)
+                    .get(&branch)
                     .ok_or(KeyManagerServiceError::UnknownKeyBranch(branch.to_string()))?
                     .lock()
                     .await;
-                let branch_key = km.get_private_key(*index)?;
+                let branch_key = km.get_private_key(index)?;
 
                 let public_key = {
                     let hasher = DomainSeparatedHasher::<Blake2b<U64>, KeyManagerHashingDomain>::new_with_label(

--- a/base_layer/key_manager/src/key_manager_service/service.rs
+++ b/base_layer/key_manager/src/key_manager_service/service.rs
@@ -152,9 +152,9 @@ where
             KeyId::Derived { key } => {
                 let key = KeyId::<PK>::from_str(key.to_string().as_str())
                     .map_err(|_| KeyManagerServiceError::KeySerializationError)?;
-                let branch = key.managed_branch().ok_or_else(|| {
-                    KeyManagerServiceError::KeyIdWithoutBranch
-                })?;
+                let branch = key
+                    .managed_branch()
+                    .ok_or_else(|| KeyManagerServiceError::KeyIdWithoutBranch)?;
                 let index = key.managed_index().ok_or(KeyManagerServiceError::KeyIdWithoutIndex)?;
                 let km = self
                     .key_managers

--- a/base_layer/wallet/Cargo.toml
+++ b/base_layer/wallet/Cargo.toml
@@ -15,7 +15,6 @@ tari_comms_dht = { path = "../../comms/dht", version = "1.0.0-pre.18" }
 tari_contacts = { path = "../../base_layer/contacts", version = "1.0.0-pre.18" }
 tari_core = { path = "../../base_layer/core", default-features = false, features = ["transactions", "mempool_proto", "base_node_proto"], version = "1.0.0-pre.18" }
 tari_crypto = { version = "0.20.3" }
-tari_hashing = { path = "../../hashing", version = "1.0.0-pre.18" }
 tari_key_manager = { path = "../key_manager", features = ["key_manager_service"], version = "1.0.0-pre.18" }
 tari_p2p = { path = "../p2p", features = ["auto-update"], version = "1.0.0-pre.18" }
 tari_script = { path = "../../infrastructure/tari_script", version = "1.0.0-pre.18" }

--- a/base_layer/wallet/Cargo.toml
+++ b/base_layer/wallet/Cargo.toml
@@ -7,20 +7,21 @@ version = "1.0.0-pre.18"
 edition = "2018"
 
 [dependencies]
-tari_core = { path = "../../base_layer/core", default-features = false, features = ["transactions", "mempool_proto", "base_node_proto"], version = "1.0.0-pre.18" }
 tari_common = { path = "../../common", version = "1.0.0-pre.18" }
-tari_common_types = {  path = "../../base_layer/common_types", version = "1.0.0-pre.18" }
-tari_comms = {  path = "../../comms/core", version = "1.0.0-pre.18" }
-tari_comms_dht = {  path = "../../comms/dht", version = "1.0.0-pre.18" }
+tari_common_sqlite = { path = "../../common_sqlite", version = "1.0.0-pre.18" }
+tari_common_types = { path = "../../base_layer/common_types", version = "1.0.0-pre.18" }
+tari_comms = { path = "../../comms/core", version = "1.0.0-pre.18" }
+tari_comms_dht = { path = "../../comms/dht", version = "1.0.0-pre.18" }
+tari_contacts = { path = "../../base_layer/contacts", version = "1.0.0-pre.18" }
+tari_core = { path = "../../base_layer/core", default-features = false, features = ["transactions", "mempool_proto", "base_node_proto"], version = "1.0.0-pre.18" }
 tari_crypto = { version = "0.20.3" }
-tari_key_manager = {  path = "../key_manager", features = ["key_manager_service"], version = "1.0.0-pre.18" }
-tari_p2p = {  path = "../p2p", features = ["auto-update"], version = "1.0.0-pre.18"}
+tari_hashing = { path = "../../hashing", version = "1.0.0-pre.18" }
+tari_key_manager = { path = "../key_manager", features = ["key_manager_service"], version = "1.0.0-pre.18" }
+tari_p2p = { path = "../p2p", features = ["auto-update"], version = "1.0.0-pre.18" }
 tari_script = { path = "../../infrastructure/tari_script", version = "1.0.0-pre.18" }
 tari_service_framework = { path = "../service_framework", version = "1.0.0-pre.18" }
 tari_shutdown = { path = "../../infrastructure/shutdown", version = "1.0.0-pre.18" }
-tari_common_sqlite = { path = "../../common_sqlite", version = "1.0.0-pre.18" }
 tari_utilities = { version = "0.7" }
-tari_contacts = { path = "../../base_layer/contacts", version = "1.0.0-pre.18" }
 
 # Uncomment for tokio tracing via tokio-console (needs "tracing" features)
 #console-subscriber = "0.1.3"

--- a/base_layer/wallet/src/output_manager_service/recovery/standard_outputs_recoverer.rs
+++ b/base_layer/wallet/src/output_manager_service/recovery/standard_outputs_recoverer.rs
@@ -20,11 +20,10 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::time::Instant;
+use std::{str::FromStr, time::Instant};
 
 use log::*;
 use tari_common_types::{
-    key_branches::TransactionKeyManagerBranch,
     transaction::TxId,
     types::{FixedHash, PrivateKey},
 };
@@ -40,7 +39,7 @@ use tari_core::transactions::{
     },
 };
 use tari_crypto::keys::SecretKey;
-use tari_key_manager::key_manager_service::{KeyId, SerializedKeyString};
+use tari_key_manager::key_manager_service::KeyId;
 use tari_script::{inputs, script, ExecutionStack, Opcode, TariScript};
 use tari_utilities::hex::Hex;
 
@@ -204,16 +203,8 @@ where
     ) -> Result<Option<(ExecutionStack, TariKeyId)>, OutputManagerError> {
         let (input_data, script_key) = if script == &script!(Nop) {
             // This is a nop, so we can just create a new key for the input stack.
-            let key = if let Some(index) = spending_key.managed_index() {
-                KeyId::Derived {
-                    key: SerializedKeyString::from(
-                        TariKeyId::Managed {
-                            branch: TransactionKeyManagerBranch::CommitmentMask.get_branch_key(),
-                            index,
-                        }
-                        .to_string(),
-                    ),
-                }
+            let key = if let KeyId::Derived { key } = spending_key {
+                TariKeyId::from_str(&key.to_string()).map_err(OutputManagerError::BuildError)?
             } else {
                 let private_key = PrivateKey::random(&mut rand::thread_rng());
                 self.master_key_manager.import_key(private_key).await?

--- a/base_layer/wallet/src/output_manager_service/recovery/standard_outputs_recoverer.rs
+++ b/base_layer/wallet/src/output_manager_service/recovery/standard_outputs_recoverer.rs
@@ -26,7 +26,7 @@ use log::*;
 use tari_common_types::{
     key_branches::TransactionKeyManagerBranch,
     transaction::TxId,
-    types::{FixedHash, PrivateKey, PublicKey},
+    types::{FixedHash, PrivateKey},
 };
 use tari_core::transactions::{
     key_manager::{TariKeyId, TransactionKeyManagerInterface},
@@ -207,7 +207,7 @@ where
             let key = if let Some(index) = spending_key.managed_index() {
                 KeyId::Derived {
                     key: SerializedKeyString::from(
-                        KeyId::<PublicKey>::Managed {
+                        TariKeyId::Managed {
                             branch: TransactionKeyManagerBranch::CommitmentMask.get_branch_key(),
                             index,
                         }

--- a/base_layer/wallet/src/output_manager_service/recovery/standard_outputs_recoverer.rs
+++ b/base_layer/wallet/src/output_manager_service/recovery/standard_outputs_recoverer.rs
@@ -26,10 +26,10 @@ use log::*;
 use tari_common_types::{
     key_branches::TransactionKeyManagerBranch,
     transaction::TxId,
-    types::{FixedHash, PrivateKey},
+    types::{FixedHash, PrivateKey, PublicKey},
 };
 use tari_core::transactions::{
-    key_manager::{TariKeyId, TransactionKeyManagerInterface, TransactionKeyManagerLabel},
+    key_manager::{TariKeyId, TransactionKeyManagerInterface},
     tari_amount::MicroMinotari,
     transaction_components::{
         encrypted_data::PaymentId,
@@ -40,7 +40,7 @@ use tari_core::transactions::{
     },
 };
 use tari_crypto::keys::SecretKey;
-use tari_key_manager::key_manager_service::KeyId;
+use tari_key_manager::key_manager_service::{KeyId, SerializedKeyString};
 use tari_script::{inputs, script, ExecutionStack, Opcode, TariScript};
 use tari_utilities::hex::Hex;
 
@@ -206,9 +206,13 @@ where
             // This is a nop, so we can just create a new key for the input stack.
             let key = if let Some(index) = spending_key.managed_index() {
                 KeyId::Derived {
-                    branch: TransactionKeyManagerBranch::CommitmentMask.get_branch_key(),
-                    label: TransactionKeyManagerLabel::ScriptKey.get_branch_key(),
-                    index,
+                    key: SerializedKeyString::from(
+                        KeyId::<PublicKey>::Managed {
+                            branch: TransactionKeyManagerBranch::CommitmentMask.get_branch_key(),
+                            index,
+                        }
+                        .to_string(),
+                    ),
                 }
             } else {
                 let private_key = PrivateKey::random(&mut rand::thread_rng());

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -2992,7 +2992,7 @@ where
                     let stealth_key = self
                         .resources
                         .key_manager
-                        .import_add_offset_to_private_key(&spend_key.key_id, stealth_address_offset)
+                        .import_add_offset_to_private_key(stealth_address_offset)
                         .await?;
 
                     let shared_secret = self

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -2992,7 +2992,7 @@ where
                     let stealth_key = self
                         .resources
                         .key_manager
-                        .import_add_offset_to_private_key(stealth_address_offset)
+                        .import_add_offset_to_private_key(&spend_key.key_id, stealth_address_offset)
                         .await?;
 
                     let shared_secret = self

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -2989,10 +2989,11 @@ where
                     // Compute the stealth address offset
                     let stealth_address_offset = PrivateKey::from_uniform_bytes(stealth_address_hasher.as_ref())
                         .expect("'DomainSeparatedHash<Blake2b<U64>>' has correct size");
-                    let stealth_key = TariKeyId::Offset {
-                        key_id: Box::new(spend_key.key_id.clone()),
-                        offset: stealth_address_offset.clone(),
-                    };
+                    let stealth_key = self
+                        .resources
+                        .key_manager
+                        .import_add_offset_to_private_key(&spend_key.key_id, stealth_address_offset)
+                        .await?;
 
                     let shared_secret = self
                         .resources
@@ -3019,7 +3020,7 @@ where
     ) -> Result<Vec<RecoveredOutput>, OutputManagerError> {
         let mut rewound_outputs = Vec::with_capacity(scanned_outputs.len());
 
-        for (output, output_source, script_private_key_id, shared_secret) in scanned_outputs {
+        for (output, output_source, script_private_key, shared_secret) in scanned_outputs {
             let encryption_key = shared_secret_to_output_encryption_key(&shared_secret)?;
             if let Ok((committed_value, spending_key, payment_id)) =
                 EncryptedData::decrypt_data(&encryption_key, &output.commitment, &output.encrypted_data)
@@ -3038,7 +3039,7 @@ where
                         output.features,
                         output.script,
                         tari_script::ExecutionStack::new(vec![]),
-                        script_private_key_id,
+                        script_private_key,
                         output.sender_offset_public_key,
                         output.metadata_signature,
                         0,

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -2025,7 +2025,7 @@ where
             .with_sender_offset_public_key(sender_offset_public_key)
             .with_script_key(KeyId::Zero)
             .with_minimum_value_promise(minimum_value_promise)
-            .sign_as_sender_and_receiver(
+            .sign_as_sender_and_receiver_verified(
                 &self.resources.transaction_key_manager_service,
                 &sender_offset_private_key,
             )

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -1916,7 +1916,7 @@ where
         let key = self
             .resources
             .transaction_key_manager_service
-            .get_next_key(TransactionKeyManagerBranch::SenderOffsetLedger.get_branch_key())
+            .get_next_key(TransactionKeyManagerBranch::OneSidedSenderOffset.get_branch_key())
             .await?;
 
         stp.change_recipient_sender_offset_private_key(key.key_id)?;

--- a/base_layer/wallet/tests/output_manager_service_tests/service.rs
+++ b/base_layer/wallet/tests/output_manager_service_tests/service.rs
@@ -60,7 +60,7 @@ use tari_core::{
     proto::base_node::{QueryDeletedData, QueryDeletedResponse, UtxoQueryResponse, UtxoQueryResponses},
     transactions::{
         fee::Fee,
-        key_manager::{create_memory_db_key_manager, MemoryDbKeyManager, TariKeyId, TransactionKeyManagerInterface},
+        key_manager::{create_memory_db_key_manager, MemoryDbKeyManager, TransactionKeyManagerInterface},
         tari_amount::{uT, MicroMinotari, T},
         test_helpers::{create_wallet_output_with_data, TestParams},
         transaction_components::{encrypted_data::PaymentId, OutputFeatures, TransactionOutput, WalletOutput},
@@ -70,7 +70,7 @@ use tari_core::{
         SenderTransactionProtocol,
     },
 };
-use tari_key_manager::key_manager_service::{KeyId, KeyManagerInterface, SerializedKeyString};
+use tari_key_manager::key_manager_service::{KeyId, KeyManagerInterface};
 use tari_script::{inputs, script, TariScript};
 use tari_service_framework::reply_channel;
 use tari_shutdown::Shutdown;
@@ -2159,13 +2159,7 @@ async fn scan_for_recovery_test() {
             .await
             .unwrap();
         let script_key_id = KeyId::Derived {
-            key: SerializedKeyString::from(
-                TariKeyId::Managed {
-                    branch: TransactionKeyManagerBranch::CommitmentMask.get_branch_key(),
-                    index: commitment_mask_key.key_id.managed_index().unwrap(),
-                }
-                .to_string(),
-            ),
+            key: (&commitment_mask_key.key_id).into(),
         };
         let public_script_key = oms
             .key_manager_handle

--- a/base_layer/wallet/tests/output_manager_service_tests/service.rs
+++ b/base_layer/wallet/tests/output_manager_service_tests/service.rs
@@ -60,11 +60,7 @@ use tari_core::{
     proto::base_node::{QueryDeletedData, QueryDeletedResponse, UtxoQueryResponse, UtxoQueryResponses},
     transactions::{
         fee::Fee,
-        key_manager::{
-            create_memory_db_key_manager,
-            MemoryDbKeyManager,
-            TransactionKeyManagerInterface,
-        },
+        key_manager::{create_memory_db_key_manager, MemoryDbKeyManager, TariKeyId, TransactionKeyManagerInterface},
         tari_amount::{uT, MicroMinotari, T},
         test_helpers::{create_wallet_output_with_data, TestParams},
         transaction_components::{encrypted_data::PaymentId, OutputFeatures, TransactionOutput, WalletOutput},
@@ -2164,7 +2160,7 @@ async fn scan_for_recovery_test() {
             .unwrap();
         let script_key_id = KeyId::Derived {
             key: SerializedKeyString::from(
-                KeyId::<PublicKey>::Managed {
+                TariKeyId::Managed {
                     branch: TransactionKeyManagerBranch::CommitmentMask.get_branch_key(),
                     index: commitment_mask_key.key_id.managed_index().unwrap(),
                 }

--- a/base_layer/wallet/tests/output_manager_service_tests/service.rs
+++ b/base_layer/wallet/tests/output_manager_service_tests/service.rs
@@ -64,7 +64,6 @@ use tari_core::{
             create_memory_db_key_manager,
             MemoryDbKeyManager,
             TransactionKeyManagerInterface,
-            TransactionKeyManagerLabel,
         },
         tari_amount::{uT, MicroMinotari, T},
         test_helpers::{create_wallet_output_with_data, TestParams},
@@ -75,7 +74,7 @@ use tari_core::{
         SenderTransactionProtocol,
     },
 };
-use tari_key_manager::key_manager_service::{KeyId, KeyManagerInterface};
+use tari_key_manager::key_manager_service::{KeyId, KeyManagerInterface, SerializedKeyString};
 use tari_script::{inputs, script, TariScript};
 use tari_service_framework::reply_channel;
 use tari_shutdown::Shutdown;
@@ -2164,9 +2163,13 @@ async fn scan_for_recovery_test() {
             .await
             .unwrap();
         let script_key_id = KeyId::Derived {
-            branch: TransactionKeyManagerBranch::CommitmentMask.get_branch_key(),
-            label: TransactionKeyManagerLabel::ScriptKey.get_branch_key(),
-            index: commitment_mask_key.key_id.managed_index().unwrap(),
+            key: SerializedKeyString::from(
+                KeyId::<PublicKey>::Managed {
+                    branch: TransactionKeyManagerBranch::CommitmentMask.get_branch_key(),
+                    index: commitment_mask_key.key_id.managed_index().unwrap(),
+                }
+                .to_string(),
+            ),
         };
         let public_script_key = oms
             .key_manager_handle

--- a/base_layer/wallet/tests/transaction_service_tests/storage.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/storage.rs
@@ -50,7 +50,7 @@ use tari_common_types::{
 use tari_core::{
     covenants::Covenant,
     transactions::{
-        key_manager::{create_memory_db_key_manager, TransactionKeyManagerInterface},
+        key_manager::{create_memory_db_key_manager, TariKeyId, TransactionKeyManagerInterface},
         tari_amount::{uT, MicroMinotari},
         test_helpers::{create_wallet_output_with_data, TestParams},
         transaction_components::{
@@ -183,7 +183,7 @@ pub async fn test_db_backend<T: TransactionBackend + 'static>(backend: T) {
         .unwrap();
     let script_key_id = KeyId::Derived {
         key: SerializedKeyString::from(
-            KeyId::<PublicKey>::Managed {
+            TariKeyId::Managed {
                 branch: TransactionKeyManagerBranch::CommitmentMask.get_branch_key(),
                 index: commitment_mask_key.key_id.managed_index().unwrap(),
             }

--- a/base_layer/wallet/tests/transaction_service_tests/storage.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/storage.rs
@@ -50,7 +50,7 @@ use tari_common_types::{
 use tari_core::{
     covenants::Covenant,
     transactions::{
-        key_manager::{create_memory_db_key_manager, TransactionKeyManagerInterface, TransactionKeyManagerLabel},
+        key_manager::{create_memory_db_key_manager, TransactionKeyManagerInterface},
         tari_amount::{uT, MicroMinotari},
         test_helpers::{create_wallet_output_with_data, TestParams},
         transaction_components::{
@@ -68,7 +68,7 @@ use tari_core::{
     },
 };
 use tari_crypto::keys::{PublicKey as PublicKeyTrait, SecretKey as SecretKeyTrait};
-use tari_key_manager::key_manager_service::{KeyId, KeyManagerInterface};
+use tari_key_manager::key_manager_service::{KeyId, KeyManagerInterface, SerializedKeyString};
 use tari_script::{inputs, script};
 use tari_test_utils::random;
 use tempfile::tempdir;
@@ -182,10 +182,15 @@ pub async fn test_db_backend<T: TransactionBackend + 'static>(backend: T) {
         .await
         .unwrap();
     let script_key_id = KeyId::Derived {
-        branch: TransactionKeyManagerBranch::CommitmentMask.get_branch_key(),
-        label: TransactionKeyManagerLabel::ScriptKey.get_branch_key(),
-        index: commitment_mask_key.key_id.managed_index().unwrap(),
+        key: SerializedKeyString::from(
+            KeyId::<PublicKey>::Managed {
+                branch: TransactionKeyManagerBranch::CommitmentMask.get_branch_key(),
+                index: commitment_mask_key.key_id.managed_index().unwrap(),
+            }
+            .to_string(),
+        ),
     };
+
     let public_script_key = key_manager.get_public_key_at_key_id(&script_key_id).await.unwrap();
 
     let encrypted_data = key_manager

--- a/base_layer/wallet/tests/transaction_service_tests/storage.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/storage.rs
@@ -50,7 +50,7 @@ use tari_common_types::{
 use tari_core::{
     covenants::Covenant,
     transactions::{
-        key_manager::{create_memory_db_key_manager, TariKeyId, TransactionKeyManagerInterface},
+        key_manager::{create_memory_db_key_manager, TransactionKeyManagerInterface},
         tari_amount::{uT, MicroMinotari},
         test_helpers::{create_wallet_output_with_data, TestParams},
         transaction_components::{
@@ -68,7 +68,7 @@ use tari_core::{
     },
 };
 use tari_crypto::keys::{PublicKey as PublicKeyTrait, SecretKey as SecretKeyTrait};
-use tari_key_manager::key_manager_service::{KeyId, KeyManagerInterface, SerializedKeyString};
+use tari_key_manager::key_manager_service::{KeyId, KeyManagerInterface};
 use tari_script::{inputs, script};
 use tari_test_utils::random;
 use tempfile::tempdir;
@@ -182,13 +182,7 @@ pub async fn test_db_backend<T: TransactionBackend + 'static>(backend: T) {
         .await
         .unwrap();
     let script_key_id = KeyId::Derived {
-        key: SerializedKeyString::from(
-            TariKeyId::Managed {
-                branch: TransactionKeyManagerBranch::CommitmentMask.get_branch_key(),
-                index: commitment_mask_key.key_id.managed_index().unwrap(),
-            }
-            .to_string(),
-        ),
+        key: (&commitment_mask_key.key_id).into(),
     };
 
     let public_script_key = key_manager.get_public_key_at_key_id(&script_key_id).await.unwrap();


### PR DESCRIPTION
Description
---
- Add the one sided metadata signature to the ledger, with on ledger verification. 
- Block script offset generation when less than two unique keys are used on the ledger to prevent the receiver from exposing the sender private key. This blocks ledger wallets from sending interactive transactions.

Motivation and Context
---
Make ledger wallets more secure.

How Has This Been Tested?
---
Manually

Ledger wallet:
✅ Mine to one sided ledger address
✅ Receive interactive from software
✅ Receive one sided from software
✅ Spend received interactive
✅ Spend received one sided
✅ Spend coin bases from one sided mining
✅ Send one sided to software
✅ Send one sided to ledger wallet
❌ Send interactive to ledger wallet
❌ Send interactive to software

Software wallet:
✅ Mine to one sided address
✅ Receive interactive from software
✅ Receive one sided from software
❌ Receive interactive from ledger
✅ Receive one sided from ledger
✅ Spend received interactive
✅ Spend received one sided
✅ Spend coin bases from one sided mining
✅ Send interactive to software
✅ Send interactive to ledger
✅ Send one sided to software
✅ Send one sided to ledger wallet

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
