### PR TITLE
chore: refactor key manager names

### DIFF
--- a/applications/minotari_console_wallet/src/automation/commands.rs
+++ b/applications/minotari_console_wallet/src/automation/commands.rs
@@ -839,10 +839,10 @@ pub async fn command_runner(
                 let out_dir = out_dir(&session_info.session_id)?;
                 let step_2_outputs_for_leader = Step2OutputsForLeader {
                     script_input_signature,
-                    wallet_public_spend_key: wallet_spend_key.key,
-                    public_script_nonce_key: script_nonce_key.key,
-                    public_sender_offset_key: sender_offset_key.key,
-                    public_sender_offset_nonce_key: sender_offset_nonce.key,
+                    wallet_public_spend_key: wallet_spend_key.pub_key,
+                    public_script_nonce_key: script_nonce_key.pub_key,
+                    public_sender_offset_key: sender_offset_key.pub_key,
+                    public_sender_offset_nonce_key: sender_offset_nonce.pub_key,
                     dh_shared_secret_public_key: shared_secret_public_key,
                 };
                 let out_file_leader = out_dir.join(get_file_name(STEP_2_LEADER, Some(args.alias.clone())));

--- a/applications/minotari_console_wallet/src/automation/commands.rs
+++ b/applications/minotari_console_wallet/src/automation/commands.rs
@@ -807,14 +807,10 @@ pub async fn command_runner(
                     continue;
                 }
 
-                let wallet_spend_key_id = wallet.get_wallet_id().await?.wallet_node_key_id.clone();
-                let wallet_public_spend_key = key_manager_service
-                    .get_public_key_at_key_id(&wallet_spend_key_id)
-                    .await?;
-                let (script_nonce_key_id, public_script_nonce_key) = key_manager_service.get_random_key().await?;
-                let (sender_offset_key_id, public_sender_offset_key) = key_manager_service.get_random_key().await?;
-                let (sender_offset_nonce_key_id, public_sender_offset_nonce_key) =
-                    key_manager_service.get_random_key().await?;
+                let wallet_spend_key = wallet.key_manager_service.get_spend_key().await?;
+                let script_nonce_key = key_manager_service.get_random_key().await?;
+                let sender_offset_key = key_manager_service.get_random_key().await?;
+                let sender_offset_nonce = key_manager_service.get_random_key().await?;
 
                 // Read session info
                 let session_info = read_session_info(args.input_file.clone())?;
@@ -827,7 +823,7 @@ pub async fn command_runner(
                         .into();
                 let shared_secret = key_manager_service
                     .get_diffie_hellman_shared_secret(
-                        &sender_offset_key_id,
+                        &sender_offset_key.key_id,
                         session_info
                             .recipient_address
                             .public_view_key()
@@ -837,16 +833,16 @@ pub async fn command_runner(
                 let shared_secret_public_key = PublicKey::from_canonical_bytes(shared_secret.as_bytes())?;
 
                 let script_input_signature = key_manager_service
-                    .sign_script_message(&wallet_spend_key_id, &commitment_hash)
+                    .sign_script_message(&wallet_spend_key.key_id, &commitment_hash)
                     .await?;
 
                 let out_dir = out_dir(&session_info.session_id)?;
                 let step_2_outputs_for_leader = Step2OutputsForLeader {
                     script_input_signature,
-                    wallet_public_spend_key,
-                    public_script_nonce_key,
-                    public_sender_offset_key,
-                    public_sender_offset_nonce_key,
+                    wallet_public_spend_key: wallet_spend_key.key,
+                    public_script_nonce_key: script_nonce_key.key,
+                    public_sender_offset_key: sender_offset_key.key,
+                    public_sender_offset_nonce_key: sender_offset_nonce.key,
                     dh_shared_secret_public_key: shared_secret_public_key,
                 };
                 let out_file_leader = out_dir.join(get_file_name(STEP_2_LEADER, Some(args.alias.clone())));
@@ -855,10 +851,10 @@ pub async fn command_runner(
 
                 let step_2_outputs_for_self = Step2OutputsForSelf {
                     alias: args.alias.clone(),
-                    wallet_spend_key_id,
-                    script_nonce_key_id,
-                    sender_offset_key_id,
-                    sender_offset_nonce_key_id,
+                    wallet_spend_key_id: wallet_spend_key.key_id,
+                    script_nonce_key_id: script_nonce_key.key_id,
+                    sender_offset_key_id: sender_offset_key.key_id,
+                    sender_offset_nonce_key_id: sender_offset_nonce.key_id,
                 };
                 let out_file_self = out_dir.join(get_file_name(STEP_2_SELF, None));
                 write_json_object_to_file_as_line(&out_file_self, true, session_info.clone())?;

--- a/applications/minotari_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/minotari_node/src/grpc/base_node_grpc_server.rs
@@ -866,13 +866,13 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
             .await
             .map_err(|e| obscure_error_if_true(report_error_flag, Status::internal(e.to_string())))?;
             new_template.body.add_output(coinbase_output);
-            let (new_private_nonce, pub_nonce) = key_manager
+            let new_nonce = key_manager
                 .get_next_key(TransactionKeyManagerBranch::KernelNonce.get_branch_key())
                 .await
                 .map_err(|e| obscure_error_if_true(report_error_flag, Status::internal(e.to_string())))?;
-            total_nonce = &total_nonce + &pub_nonce;
+            total_nonce = &total_nonce + &new_nonce.key;
             total_excess = &total_excess + &coinbase_kernel.excess;
-            private_keys.push((wallet_output.spending_key_id, new_private_nonce));
+            private_keys.push((wallet_output.spending_key_id, new_nonce.key_id));
             kernel_message = TransactionKernel::build_kernel_signature_message(
                 &TransactionKernelVersion::get_current_version(),
                 coinbase_kernel.fee,
@@ -1063,13 +1063,13 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
             .await
             .map_err(|e| obscure_error_if_true(report_error_flag, Status::internal(e.to_string())))?;
             block_template.body.add_output(coinbase_output);
-            let (new_private_nonce, pub_nonce) = key_manager
+            let new_nonce = key_manager
                 .get_next_key(TransactionKeyManagerBranch::KernelNonce.get_branch_key())
                 .await
                 .map_err(|e| obscure_error_if_true(report_error_flag, Status::internal(e.to_string())))?;
-            total_nonce = &total_nonce + &pub_nonce;
+            total_nonce = &total_nonce + &new_nonce.key;
             total_excess = &total_excess + &coinbase_kernel.excess;
-            private_keys.push((wallet_output.spending_key_id, new_private_nonce));
+            private_keys.push((wallet_output.spending_key_id, new_nonce.key_id));
             kernel_message = TransactionKernel::build_kernel_signature_message(
                 &TransactionKernelVersion::get_current_version(),
                 coinbase_kernel.fee,

--- a/applications/minotari_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/minotari_node/src/grpc/base_node_grpc_server.rs
@@ -870,7 +870,7 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
                 .get_next_key(TransactionKeyManagerBranch::KernelNonce.get_branch_key())
                 .await
                 .map_err(|e| obscure_error_if_true(report_error_flag, Status::internal(e.to_string())))?;
-            total_nonce = &total_nonce + &new_nonce.key;
+            total_nonce = &total_nonce + &new_nonce.pub_key;
             total_excess = &total_excess + &coinbase_kernel.excess;
             private_keys.push((wallet_output.spending_key_id, new_nonce.key_id));
             kernel_message = TransactionKernel::build_kernel_signature_message(
@@ -1067,7 +1067,7 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
                 .get_next_key(TransactionKeyManagerBranch::KernelNonce.get_branch_key())
                 .await
                 .map_err(|e| obscure_error_if_true(report_error_flag, Status::internal(e.to_string())))?;
-            total_nonce = &total_nonce + &new_nonce.key;
+            total_nonce = &total_nonce + &new_nonce.pub_key;
             total_excess = &total_excess + &coinbase_kernel.excess;
             private_keys.push((wallet_output.spending_key_id, new_nonce.key_id));
             kernel_message = TransactionKernel::build_kernel_signature_message(

--- a/base_layer/common_types/src/wallet_types.rs
+++ b/base_layer/common_types/src/wallet_types.rs
@@ -39,29 +39,29 @@ use crate::types::{PrivateKey, PublicKey};
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub enum WalletType {
     #[default]
-    Software,
+    DerivedKeys,
     Ledger(LedgerWallet),
-    Imported(ImportedWallet),
+    ProvidedKeys(ProvidedKeysWallet),
 }
 
 impl Display for WalletType {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            WalletType::Software => write!(f, "Software"),
+            WalletType::DerivedKeys => write!(f, "Derived wallet"),
             WalletType::Ledger(ledger_wallet) => write!(f, "Ledger({ledger_wallet})"),
-            WalletType::Imported(imported_wallet) => write!(f, "Imported({imported_wallet})"),
+            WalletType::ProvidedKeys(provided_keys_wallet) => write!(f, "Provided Keys ({provided_keys_wallet})"),
         }
     }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ImportedWallet {
+pub struct ProvidedKeysWallet {
     pub public_spend_key: PublicKey,
     pub private_spend_key: Option<PrivateKey>,
     pub view_key: PrivateKey,
 }
 
-impl Display for ImportedWallet {
+impl Display for ProvidedKeysWallet {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "public spend key {}", self.public_spend_key)?;
         write!(f, "public view key{}", PublicKey::from_secret_key(&self.view_key))?;

--- a/base_layer/core/src/blocks/faucets/mod.rs
+++ b/base_layer/core/src/blocks/faucets/mod.rs
@@ -84,13 +84,9 @@ mod test {
         let mut total_private_key = PrivateKey::default();
 
         for _ in 0..num_faucets {
-            let (commitment_mask, script_key) =
-                key_manager.get_next_commitment_mask_and_script_key().await.unwrap();
-            total_private_key = total_private_key +
-                &key_manager
-                    .get_private_key(&commitment_mask.key_id)
-                    .await
-                    .unwrap();
+            let (commitment_mask, script_key) = key_manager.get_next_commitment_mask_and_script_key().await.unwrap();
+            total_private_key =
+                total_private_key + &key_manager.get_private_key(&commitment_mask.key_id).await.unwrap();
             let commitment = key_manager
                 .get_commitment(&commitment_mask.key_id, &amount.into())
                 .await
@@ -100,7 +96,7 @@ mod test {
                 .finalize()
                 .into();
 
-            let sender_offset_key = key_manager
+            let sender_offset = key_manager
                 .get_next_key(TransactionKeyManagerBranch::SenderOffset.get_branch_key())
                 .await
                 .unwrap();
@@ -110,7 +106,7 @@ mod test {
                 list_of_spend_keys.clone(),
                 Box::new(com_hash),
             )]);
-            let output = WalletOutputBuilder::new(amount, commitment_mask_key_id.key_id)
+            let output = WalletOutputBuilder::new(amount, commitment_mask.key_id)
                 .with_features(OutputFeatures::new(
                     OutputFeaturesVersion::get_current_version(),
                     OutputType::Standard,
@@ -125,10 +121,10 @@ mod test {
                 .unwrap()
                 .with_input_data(ExecutionStack::default())
                 .with_version(TransactionOutputVersion::get_current_version())
-                .with_sender_offset_public_key(sender_offset_key.key)
+                .with_sender_offset_public_key(sender_offset.pub_key)
                 .with_script_key(script_key.key_id)
                 .with_minimum_value_promise(amount)
-                .sign_as_sender_and_receiver(&key_manager, &sender_offset_key.key_id)
+                .sign_as_sender_and_receiver(&key_manager, &sender_offset.key_id)
                 .await
                 .unwrap()
                 .try_build(&key_manager)

--- a/base_layer/core/src/blocks/faucets/mod.rs
+++ b/base_layer/core/src/blocks/faucets/mod.rs
@@ -84,15 +84,15 @@ mod test {
         let mut total_private_key = PrivateKey::default();
 
         for _ in 0..num_faucets {
-            let (commitment_mask_key_id, script_key) =
+            let (commitment_mask, script_key) =
                 key_manager.get_next_commitment_mask_and_script_key().await.unwrap();
             total_private_key = total_private_key +
                 &key_manager
-                    .get_private_key(&commitment_mask_key_id.key_id)
+                    .get_private_key(&commitment_mask.key_id)
                     .await
                     .unwrap();
             let commitment = key_manager
-                .get_commitment(&commitment_mask_key_id.key_id, &amount.into())
+                .get_commitment(&commitment_mask.key_id, &amount.into())
                 .await
                 .unwrap();
             let com_hash: [u8; 32] = DomainSeparatedConsensusHasher::<FaucetHashDomain, Blake2b<U32>>::new("com_hash")

--- a/base_layer/core/src/blocks/faucets/mod.rs
+++ b/base_layer/core/src/blocks/faucets/mod.rs
@@ -84,10 +84,15 @@ mod test {
         let mut total_private_key = PrivateKey::default();
 
         for _ in 0..num_faucets {
-            let (mask_key_id, script_key) = key_manager.get_next_spend_and_script_key_ids().await.unwrap();
-            total_private_key = total_private_key + &key_manager.get_private_key(&mask_key_id.key_id).await.unwrap();
+            let (commitment_mask_key_id, script_key) =
+                key_manager.get_next_commitment_mask_and_script_key().await.unwrap();
+            total_private_key = total_private_key +
+                &key_manager
+                    .get_private_key(&commitment_mask_key_id.key_id)
+                    .await
+                    .unwrap();
             let commitment = key_manager
-                .get_commitment(&mask_key_id.key_id, &amount.into())
+                .get_commitment(&commitment_mask_key_id.key_id, &amount.into())
                 .await
                 .unwrap();
             let com_hash: [u8; 32] = DomainSeparatedConsensusHasher::<FaucetHashDomain, Blake2b<U32>>::new("com_hash")
@@ -105,7 +110,7 @@ mod test {
                 list_of_spend_keys.clone(),
                 Box::new(com_hash),
             )]);
-            let output = WalletOutputBuilder::new(amount, mask_key_id.key_id)
+            let output = WalletOutputBuilder::new(amount, commitment_mask_key_id.key_id)
                 .with_features(OutputFeatures::new(
                     OutputFeaturesVersion::get_current_version(),
                     OutputType::Standard,

--- a/base_layer/core/src/mempool/unconfirmed_pool/unconfirmed_pool.rs
+++ b/base_layer/core/src/mempool/unconfirmed_pool/unconfirmed_pool.rs
@@ -991,7 +991,7 @@ mod test {
                 TariScript::default(),
                 ExecutionStack::default(),
                 change.script_key_id.clone(),
-                change.spend_key_id.clone(),
+                change.mask_key_id.clone(),
                 Covenant::default(),
             );
 

--- a/base_layer/core/src/mempool/unconfirmed_pool/unconfirmed_pool.rs
+++ b/base_layer/core/src/mempool/unconfirmed_pool/unconfirmed_pool.rs
@@ -991,7 +991,7 @@ mod test {
                 TariScript::default(),
                 ExecutionStack::default(),
                 change.script_key_id.clone(),
-                change.mask_key_id.clone(),
+                change.commitment_mask_key_id.clone(),
                 Covenant::default(),
             );
 

--- a/base_layer/core/src/transactions/coinbase_builder.rs
+++ b/base_layer/core/src/transactions/coinbase_builder.rs
@@ -297,7 +297,7 @@ where TKeyManagerInterface: TransactionKeyManagerInterface
             .get_partial_txo_kernel_signature(
                 &commitment_mask_key_id,
                 &public_nonce.key_id,
-                &public_nonce.key,
+                &public_nonce.pub_key,
                 &public_commitment_mask_key,
                 &kernel_version,
                 &kernel_message,
@@ -862,7 +862,7 @@ mod test {
             .get_partial_txo_kernel_signature(
                 &output.spending_key_id,
                 &new_nonce.key_id,
-                &new_nonce.key,
+                &new_nonce.pub_key,
                 &excess,
                 &TransactionKernelVersion::get_current_version(),
                 &kernel_message,
@@ -878,7 +878,7 @@ mod test {
             .unwrap();
         let sig_challenge = TransactionKernel::finalize_kernel_signature_challenge(
             &TransactionKernelVersion::get_current_version(),
-            &new_nonce.key,
+            &new_nonce.pub_key,
             &excess,
             &kernel_message,
         );
@@ -1005,7 +1005,7 @@ mod test {
             .get_next_key(TransactionKeyManagerBranch::KernelNonce.get_branch_key())
             .await
             .unwrap();
-        let nonce = &new_nonce1.key + &new_nonce2.key;
+        let nonce = &new_nonce1.pub_key + &new_nonce2.pub_key;
         let kernel_message = TransactionKernel::build_kernel_signature_message(
             &TransactionKernelVersion::get_current_version(),
             kernel_1.fee,

--- a/base_layer/core/src/transactions/coinbase_builder.rs
+++ b/base_layer/core/src/transactions/coinbase_builder.rs
@@ -135,7 +135,7 @@ pub struct CoinbaseBuilder<TKeyManagerInterface> {
     key_manager: TKeyManagerInterface,
     block_height: Option<u64>,
     fees: Option<MicroMinotari>,
-    spend_key_id: Option<TariKeyId>,
+    commitment_mask_key_id: Option<TariKeyId>,
     script_key_id: Option<TariKeyId>,
     encryption_key_id: Option<TariKeyId>,
     sender_offset_key_id: Option<TariKeyId>,
@@ -155,7 +155,7 @@ where TKeyManagerInterface: TransactionKeyManagerInterface
             key_manager,
             block_height: None,
             fees: None,
-            spend_key_id: None,
+            commitment_mask_key_id: None,
             script_key_id: None,
             encryption_key_id: None,
             sender_offset_key_id: None,
@@ -178,9 +178,9 @@ where TKeyManagerInterface: TransactionKeyManagerInterface
         self
     }
 
-    /// Provides the spend key ID for this transaction. This will usually be provided by a miner's wallet instance.
-    pub fn with_spend_key_id(mut self, key: TariKeyId) -> Self {
-        self.spend_key_id = Some(key);
+    /// Provides the commitment mask key ID for this transaction.
+    pub fn with_commitment_mask_id(mut self, key: TariKeyId) -> Self {
+        self.commitment_mask_key_id = Some(key);
         self
     }
 
@@ -261,7 +261,7 @@ where TKeyManagerInterface: TransactionKeyManagerInterface
         // gets tx details
         let height = self.block_height.ok_or(CoinbaseBuildError::MissingBlockHeight)?;
         let total_reward = block_reward + self.fees.ok_or(CoinbaseBuildError::MissingFees)?;
-        let spending_key_id = self.spend_key_id.ok_or(CoinbaseBuildError::MissingSpendKey)?;
+        let commitment_mask_key_id = self.commitment_mask_key_id.ok_or(CoinbaseBuildError::MissingSpendKey)?;
         let script_key_id = self.script_key_id.ok_or(CoinbaseBuildError::MissingScriptKey)?;
         let encryption_key_id = self.encryption_key_id.ok_or(CoinbaseBuildError::MissingEncryptionKey)?;
         let sender_offset_key_id = self
@@ -287,15 +287,18 @@ where TKeyManagerInterface: TransactionKeyManagerInterface
             .get_next_key(TransactionKeyManagerBranch::KernelNonce.get_branch_key())
             .await?;
 
-        let public_spend_key = self.key_manager.get_public_key_at_key_id(&spending_key_id).await?;
+        let public_commitment_mask_key = self
+            .key_manager
+            .get_public_key_at_key_id(&commitment_mask_key_id)
+            .await?;
 
         let kernel_signature = self
             .key_manager
             .get_partial_txo_kernel_signature(
-                &spending_key_id,
+                &commitment_mask_key_id,
                 &public_nonce.key_id,
                 &public_nonce.key,
-                &public_spend_key,
+                &public_commitment_mask_key,
                 &kernel_version,
                 &kernel_message,
                 &metadata.kernel_features,
@@ -303,7 +306,7 @@ where TKeyManagerInterface: TransactionKeyManagerInterface
             )
             .await?;
 
-        let excess = Commitment::from_public_key(&public_spend_key);
+        let excess = Commitment::from_public_key(&public_commitment_mask_key);
         // generate tx details
         let value: u64 = total_reward.into();
         let output_features =
@@ -311,7 +314,7 @@ where TKeyManagerInterface: TransactionKeyManagerInterface
         let encrypted_data = self
             .key_manager
             .encrypt_data_for_recovery(
-                &spending_key_id,
+                &commitment_mask_key_id,
                 Some(&encryption_key_id),
                 total_reward.into(),
                 payment_id.clone(),
@@ -337,7 +340,7 @@ where TKeyManagerInterface: TransactionKeyManagerInterface
         let metadata_sig = self
             .key_manager
             .get_metadata_signature(
-                &spending_key_id,
+                &commitment_mask_key_id,
                 &value.into(),
                 &sender_offset_key_id,
                 &output_version,
@@ -349,7 +352,7 @@ where TKeyManagerInterface: TransactionKeyManagerInterface
         let wallet_output = WalletOutput::new(
             output_version,
             total_reward,
-            spending_key_id,
+            commitment_mask_key_id,
             output_features,
             script,
             ExecutionStack::default(),
@@ -452,12 +455,12 @@ pub async fn generate_coinbase_with_wallet_output(
                 .ok_or(CoinbaseBuildError::MissingWalletPublicViewKey)?,
         )
         .await?;
-    let spending_key = shared_secret_to_output_spending_key(&shared_secret)?;
+    let commitment_mask = shared_secret_to_output_spending_key(&shared_secret)?;
 
     let encryption_private_key = shared_secret_to_output_encryption_key(&shared_secret)?;
     let encryption_key_id = key_manager.import_key(encryption_private_key).await?;
 
-    let spending_key_id = key_manager.import_key(spending_key).await?;
+    let commitment_mask_key_id = key_manager.import_key(commitment_mask).await?;
 
     let script_spending_pubkey = if stealth_payment {
         let c = key_manager
@@ -476,7 +479,7 @@ pub async fn generate_coinbase_with_wallet_output(
     let (transaction, wallet_output) = CoinbaseBuilder::new(key_manager.clone())
         .with_block_height(height)
         .with_fees(fee)
-        .with_spend_key_id(spending_key_id)
+        .with_commitment_mask_id(commitment_mask_key_id)
         .with_encryption_key_id(encryption_key_id)
         .with_sender_offset_key_id(sender_offset.key_id)
         .with_script_key_id(script_key_id.clone())
@@ -594,7 +597,7 @@ mod test {
         let builder = builder
             .with_block_height(42)
             .with_fees(145 * uT)
-            .with_spend_key_id(p.mask_key_id.clone())
+            .with_commitment_mask_id(p.commitment_mask_key_id.clone())
             .with_encryption_key_id(TariKeyId::default())
             .with_sender_offset_key_id(p.sender_offset_key_id)
             .with_script_key_id(p.script_key_id)
@@ -612,7 +615,7 @@ mod test {
         let block_reward = rules.emission_schedule().block_reward(42) + 145 * uT;
 
         let commitment = key_manager
-            .get_commitment(&p.mask_key_id, &block_reward.into())
+            .get_commitment(&p.commitment_mask_key_id, &block_reward.into())
             .await
             .unwrap();
         assert_eq!(&commitment, utxo.commitment());
@@ -649,7 +652,7 @@ mod test {
         let builder = builder
             .with_block_height(42)
             .with_fees(145 * uT)
-            .with_spend_key_id(p.mask_key_id)
+            .with_commitment_mask_id(p.commitment_mask_key_id)
             .with_encryption_key_id(TariKeyId::default())
             .with_sender_offset_key_id(p.sender_offset_key_id)
             .with_script_key_id(p.script_key_id)
@@ -688,7 +691,7 @@ mod test {
         let builder = builder
             .with_block_height(42)
             .with_fees(1 * uT)
-            .with_spend_key_id(p.mask_key_id.clone())
+            .with_commitment_mask_id(p.commitment_mask_key_id.clone())
             .with_encryption_key_id(TariKeyId::default())
             .with_sender_offset_key_id(p.sender_offset_key_id.clone())
             .with_script_key_id(p.script_key_id.clone())
@@ -707,7 +710,7 @@ mod test {
         let builder = builder
             .with_block_height(4_200_000)
             .with_fees(1 * uT)
-            .with_spend_key_id(p.mask_key_id.clone())
+            .with_commitment_mask_id(p.commitment_mask_key_id.clone())
             .with_encryption_key_id(TariKeyId::default())
             .with_sender_offset_key_id(p.sender_offset_key_id.clone())
             .with_script_key_id(p.script_key_id.clone())
@@ -743,7 +746,7 @@ mod test {
         let builder = builder
             .with_block_height(42)
             .with_fees(missing_fee)
-            .with_spend_key_id(p.mask_key_id)
+            .with_commitment_mask_id(p.commitment_mask_key_id)
             .with_encryption_key_id(TariKeyId::default())
             .with_sender_offset_key_id(p.sender_offset_key_id)
             .with_script_key_id(p.script_key_id)
@@ -797,7 +800,7 @@ mod test {
         let builder = builder
             .with_block_height(42)
             .with_fees(1 * uT)
-            .with_spend_key_id(p.mask_key_id.clone())
+            .with_commitment_mask_id(p.commitment_mask_key_id.clone())
             .with_encryption_key_id(TariKeyId::default())
             .with_sender_offset_key_id(p.sender_offset_key_id.clone())
             .with_script_key_id(p.script_key_id.clone())
@@ -818,7 +821,7 @@ mod test {
         let builder = builder
             .with_block_height(4200000)
             .with_fees(1 * uT)
-            .with_spend_key_id(p.mask_key_id.clone())
+            .with_commitment_mask_id(p.commitment_mask_key_id.clone())
             .with_encryption_key_id(TariKeyId::default())
             .with_sender_offset_key_id(p.sender_offset_key_id)
             .with_script_key_id(p.script_key_id)
@@ -937,7 +940,7 @@ mod test {
         let builder = builder
             .with_block_height(42)
             .with_fees(1 * uT)
-            .with_spend_key_id(p.mask_key_id.clone())
+            .with_commitment_mask_id(p.commitment_mask_key_id.clone())
             .with_encryption_key_id(TariKeyId::default())
             .with_sender_offset_key_id(p.sender_offset_key_id.clone())
             .with_script_key_id(p.script_key_id.clone())
@@ -958,7 +961,7 @@ mod test {
         let builder = builder
             .with_block_height(4200000)
             .with_fees(1 * uT)
-            .with_spend_key_id(p.mask_key_id.clone())
+            .with_commitment_mask_id(p.commitment_mask_key_id.clone())
             .with_encryption_key_id(TariKeyId::default())
             .with_sender_offset_key_id(p.sender_offset_key_id)
             .with_script_key_id(p.script_key_id)

--- a/base_layer/core/src/transactions/key_manager/inner.rs
+++ b/base_layer/core/src/transactions/key_manager/inner.rs
@@ -178,7 +178,7 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
             index,
         };
         let key = self.get_public_key_at_key_id(&key_id).await?;
-        Ok(KeyAndId { key_id, key })
+        Ok(KeyAndId { key_id, pub_key: key })
     }
 
     pub async fn get_random_key(&self) -> Result<KeyAndId<PublicKey>, KeyManagerServiceError> {
@@ -187,7 +187,7 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
         let public_key = self.get_public_key_at_key_id(&key_id).await?;
         Ok(KeyAndId {
             key_id,
-            key: public_key,
+            pub_key: public_key,
         })
     }
 
@@ -258,7 +258,7 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
                 Ok(km.derive_public_key(*index)?.key)
             },
             KeyId::Derived { branch, label, index } => {
-                let public_alpha = self.get_spend_key().await?.key;
+                let public_alpha = self.get_spend_key().await?.pub_key;
                 let km = self
                     .key_managers
                     .get(branch)
@@ -387,7 +387,7 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
             index: 0,
         };
         let key = PublicKey::from_secret_key(&self.get_private_view_key().await?);
-        Ok(KeyAndId { key_id, key })
+        Ok(KeyAndId { key_id, pub_key: key })
     }
 
     pub async fn get_spend_key(&self) -> Result<KeyAndId<PublicKey>, KeyManagerServiceError> {
@@ -406,7 +406,7 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
             ))?,
             WalletType::ProvidedKeys(wallet) => wallet.public_spend_key.clone(),
         };
-        Ok(KeyAndId { key_id, key })
+        Ok(KeyAndId { key_id, pub_key: key })
     }
 
     pub async fn get_comms_key(&self) -> Result<KeyAndId<PublicKey>, KeyManagerServiceError> {
@@ -416,7 +416,7 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
         };
         let private_key = self.get_private_comms_key().await?;
         let key = PublicKey::from_secret_key(&private_key);
-        Ok(KeyAndId { key_id, key })
+        Ok(KeyAndId { key_id, pub_key: key })
     }
 
     pub async fn get_next_commitment_mask_and_script_key(
@@ -437,7 +437,7 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
         let script_public_key = self.get_public_key_at_key_id(&script_key_id).await?;
         Ok((commitment_mask, KeyAndId {
             key_id: script_key_id,
-            key: script_public_key,
+            pub_key: script_public_key,
         }))
     }
 
@@ -1177,7 +1177,7 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
                 spending_key_id,
                 value_as_private_key,
                 &sender_offset_public_key,
-                &ephemeral_pubkey.key,
+                &ephemeral_pubkey.pub_key,
                 txo_version,
                 metadata_signature_message,
                 range_proof_type,

--- a/base_layer/core/src/transactions/key_manager/interface.rs
+++ b/base_layer/core/src/transactions/key_manager/interface.rs
@@ -31,7 +31,7 @@ use tari_common_types::{
 };
 use tari_comms::types::CommsDHKE;
 use tari_crypto::{hashing::DomainSeparatedHash, ristretto::RistrettoComSig};
-use tari_key_manager::key_manager_service::{KeyId, KeyManagerInterface, KeyManagerServiceError};
+use tari_key_manager::key_manager_service::{KeyAndId, KeyId, KeyManagerInterface, KeyManagerServiceError};
 use tari_script::CheckSigSchnorrSignature;
 
 use crate::transactions::{
@@ -147,15 +147,15 @@ pub trait TransactionKeyManagerInterface: KeyManagerInterface<PublicKey> {
         value: u64,
     ) -> Result<bool, KeyManagerServiceError>;
 
-    async fn get_view_key(&self) -> Result<(TariKeyId, PublicKey), KeyManagerServiceError>;
+    async fn get_view_key(&self) -> Result<KeyAndId<PublicKey>, KeyManagerServiceError>;
 
-    async fn get_spend_key(&self) -> Result<(TariKeyId, PublicKey), KeyManagerServiceError>;
+    async fn get_spend_key(&self) -> Result<KeyAndId<PublicKey>, KeyManagerServiceError>;
 
-    async fn get_comms_key(&self) -> Result<(TariKeyId, PublicKey), KeyManagerServiceError>;
+    async fn get_comms_key(&self) -> Result<KeyAndId<PublicKey>, KeyManagerServiceError>;
 
     async fn get_next_spend_and_script_key_ids(
         &self,
-    ) -> Result<(TariKeyId, PublicKey, TariKeyId, PublicKey), KeyManagerServiceError>;
+    ) -> Result<(KeyAndId<PublicKey>, KeyAndId<PublicKey>), KeyManagerServiceError>;
 
     async fn find_script_key_id_from_spend_key_id(
         &self,

--- a/base_layer/core/src/transactions/key_manager/interface.rs
+++ b/base_layer/core/src/transactions/key_manager/interface.rs
@@ -136,14 +136,14 @@ pub trait TransactionKeyManagerInterface: KeyManagerInterface<PublicKey> {
     /// Gets the pedersen commitment for the specified index
     async fn get_commitment(
         &self,
-        spend_key_id: &TariKeyId,
+        commitment_mask_key_id: &TariKeyId,
         value: &PrivateKey,
     ) -> Result<Commitment, KeyManagerServiceError>;
 
     async fn verify_mask(
         &self,
         commitment: &Commitment,
-        spend_key_id: &TariKeyId,
+        commitment_mask_key_id: &TariKeyId,
         value: u64,
     ) -> Result<bool, KeyManagerServiceError>;
 
@@ -153,13 +153,13 @@ pub trait TransactionKeyManagerInterface: KeyManagerInterface<PublicKey> {
 
     async fn get_comms_key(&self) -> Result<KeyAndId<PublicKey>, KeyManagerServiceError>;
 
-    async fn get_next_spend_and_script_key_ids(
+    async fn get_next_commitment_mask_and_script_key(
         &self,
     ) -> Result<(KeyAndId<PublicKey>, KeyAndId<PublicKey>), KeyManagerServiceError>;
 
-    async fn find_script_key_id_from_spend_key_id(
+    async fn find_script_key_id_from_commitment_mask_key_id(
         &self,
-        spend_key_id: &TariKeyId,
+        commitment_mask_key_id: &TariKeyId,
         public_script_key: Option<&PublicKey>,
     ) -> Result<Option<TariKeyId>, KeyManagerServiceError>;
 
@@ -185,7 +185,7 @@ pub trait TransactionKeyManagerInterface: KeyManagerInterface<PublicKey> {
 
     async fn construct_range_proof(
         &self,
-        spend_key_id: &TariKeyId,
+        commitment_mask_key_id: &TariKeyId,
         value: u64,
         min_value: u64,
     ) -> Result<RangeProof, TransactionError>;
@@ -193,7 +193,7 @@ pub trait TransactionKeyManagerInterface: KeyManagerInterface<PublicKey> {
     async fn get_script_signature(
         &self,
         script_key_id: &TariKeyId,
-        spend_key_id: &TariKeyId,
+        commitment_mask_key_id: &TariKeyId,
         value: &PrivateKey,
         txi_version: &TransactionInputVersion,
         script_message: &[u8; 32],
@@ -211,7 +211,7 @@ pub trait TransactionKeyManagerInterface: KeyManagerInterface<PublicKey> {
 
     async fn get_partial_txo_kernel_signature(
         &self,
-        spend_key_id: &TariKeyId,
+        commitment_mask_key_id: &TariKeyId,
         nonce_id: &TariKeyId,
         total_nonce: &PublicKey,
         total_excess: &PublicKey,
@@ -223,19 +223,19 @@ pub trait TransactionKeyManagerInterface: KeyManagerInterface<PublicKey> {
 
     async fn get_txo_kernel_signature_excess_with_offset(
         &self,
-        spend_key_id: &TariKeyId,
+        commitment_mask_key_id: &TariKeyId,
         nonce: &TariKeyId,
     ) -> Result<PublicKey, TransactionError>;
 
     async fn get_txo_private_kernel_offset(
         &self,
-        spend_key_id: &TariKeyId,
+        commitment_mask_key_id: &TariKeyId,
         nonce_id: &TariKeyId,
     ) -> Result<PrivateKey, TransactionError>;
 
     async fn encrypt_data_for_recovery(
         &self,
-        spend_key_id: &TariKeyId,
+        commitment_mask_key_id: &TariKeyId,
         custom_recovery_key_id: Option<&TariKeyId>,
         value: u64,
         payment_id: PaymentId,
@@ -286,7 +286,7 @@ pub trait TransactionKeyManagerInterface: KeyManagerInterface<PublicKey> {
 
     async fn get_receiver_partial_metadata_signature(
         &self,
-        spend_key_id: &TariKeyId,
+        commitment_mask_key_id: &TariKeyId,
         value: &PrivateKey,
         sender_offset_public_key: &PublicKey,
         ephemeral_pubkey: &PublicKey,

--- a/base_layer/core/src/transactions/key_manager/wrapper.rs
+++ b/base_layer/core/src/transactions/key_manager/wrapper.rs
@@ -179,26 +179,26 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
 {
     async fn get_commitment(
         &self,
-        spend_key_id: &TariKeyId,
+        commitment_mask_key_id: &TariKeyId,
         value: &PrivateKey,
     ) -> Result<Commitment, KeyManagerServiceError> {
         self.transaction_key_manager_inner
             .read()
             .await
-            .get_commitment(spend_key_id, value)
+            .get_commitment(commitment_mask_key_id, value)
             .await
     }
 
     async fn verify_mask(
         &self,
         commitment: &Commitment,
-        spending_key_id: &TariKeyId,
+        commitment_mask_key_id: &TariKeyId,
         value: u64,
     ) -> Result<bool, KeyManagerServiceError> {
         self.transaction_key_manager_inner
             .read()
             .await
-            .verify_mask(commitment, spending_key_id, value)
+            .verify_mask(commitment, commitment_mask_key_id, value)
             .await
     }
 
@@ -214,25 +214,25 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
         self.transaction_key_manager_inner.read().await.get_comms_key().await
     }
 
-    async fn get_next_spend_and_script_key_ids(
+    async fn get_next_commitment_mask_and_script_key(
         &self,
     ) -> Result<(KeyAndId<PublicKey>, KeyAndId<PublicKey>), KeyManagerServiceError> {
         self.transaction_key_manager_inner
             .read()
             .await
-            .get_next_spend_and_script_key_ids()
+            .get_next_commitment_mask_and_script_key()
             .await
     }
 
-    async fn find_script_key_id_from_spend_key_id(
+    async fn find_script_key_id_from_commitment_mask_key_id(
         &self,
-        spend_key_id: &TariKeyId,
+        commitment_mask_key_id: &TariKeyId,
         public_script_key: Option<&PublicKey>,
     ) -> Result<Option<TariKeyId>, KeyManagerServiceError> {
         self.transaction_key_manager_inner
             .read()
             .await
-            .find_script_key_id_from_spend_key_id(spend_key_id, public_script_key)
+            .find_script_key_id_from_commitment_mask_key_id(commitment_mask_key_id, public_script_key)
             .await
     }
 
@@ -282,21 +282,21 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
 
     async fn construct_range_proof(
         &self,
-        spend_key_id: &TariKeyId,
+        commitment_mask_key_id: &TariKeyId,
         value: u64,
         min_value: u64,
     ) -> Result<RangeProof, TransactionError> {
         self.transaction_key_manager_inner
             .read()
             .await
-            .construct_range_proof(spend_key_id, value, min_value)
+            .construct_range_proof(commitment_mask_key_id, value, min_value)
             .await
     }
 
     async fn get_script_signature(
         &self,
         script_key_id: &TariKeyId,
-        spend_key_id: &TariKeyId,
+        commitment_mask_key_id: &TariKeyId,
         value: &PrivateKey,
         txi_version: &TransactionInputVersion,
         script_message: &[u8; 32],
@@ -304,7 +304,13 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
         self.transaction_key_manager_inner
             .read()
             .await
-            .get_script_signature(script_key_id, spend_key_id, value, txi_version, script_message)
+            .get_script_signature(
+                script_key_id,
+                commitment_mask_key_id,
+                value,
+                txi_version,
+                script_message,
+            )
             .await
     }
 
@@ -333,7 +339,7 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
 
     async fn get_partial_txo_kernel_signature(
         &self,
-        spend_key_id: &TariKeyId,
+        commitment_mask_key_id: &TariKeyId,
         nonce_id: &TariKeyId,
         total_nonce: &PublicKey,
         total_excess: &PublicKey,
@@ -346,7 +352,7 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
             .read()
             .await
             .get_partial_txo_kernel_signature(
-                spend_key_id,
+                commitment_mask_key_id,
                 nonce_id,
                 total_nonce,
                 total_excess,
@@ -360,31 +366,31 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
 
     async fn get_txo_kernel_signature_excess_with_offset(
         &self,
-        spend_key_id: &TariKeyId,
+        commitment_mask_key_id: &TariKeyId,
         nonce_id: &TariKeyId,
     ) -> Result<PublicKey, TransactionError> {
         self.transaction_key_manager_inner
             .read()
             .await
-            .get_txo_kernel_signature_excess_with_offset(spend_key_id, nonce_id)
+            .get_txo_kernel_signature_excess_with_offset(commitment_mask_key_id, nonce_id)
             .await
     }
 
     async fn get_txo_private_kernel_offset(
         &self,
-        spend_key_id: &TariKeyId,
+        commitment_mask_key_id: &TariKeyId,
         nonce_id: &TariKeyId,
     ) -> Result<PrivateKey, TransactionError> {
         self.transaction_key_manager_inner
             .read()
             .await
-            .get_txo_private_kernel_offset(spend_key_id, nonce_id)
+            .get_txo_private_kernel_offset(commitment_mask_key_id, nonce_id)
             .await
     }
 
     async fn encrypt_data_for_recovery(
         &self,
-        spend_key_id: &TariKeyId,
+        commitment_mask_key_id: &TariKeyId,
         custom_recovery_key_id: Option<&TariKeyId>,
         value: u64,
         payment_id: PaymentId,
@@ -392,7 +398,7 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
         self.transaction_key_manager_inner
             .read()
             .await
-            .encrypt_data_for_recovery(spend_key_id, custom_recovery_key_id, value, payment_id)
+            .encrypt_data_for_recovery(commitment_mask_key_id, custom_recovery_key_id, value, payment_id)
             .await
     }
 
@@ -482,7 +488,7 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
 
     async fn get_receiver_partial_metadata_signature(
         &self,
-        spend_key_id: &TariKeyId,
+        commitment_mask_key_id: &TariKeyId,
         value: &PrivateKey,
         sender_offset_public_key: &PublicKey,
         ephemeral_pubkey: &PublicKey,
@@ -494,7 +500,7 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
             .read()
             .await
             .get_receiver_partial_metadata_signature(
-                spend_key_id,
+                commitment_mask_key_id,
                 value,
                 sender_offset_public_key,
                 ephemeral_pubkey,

--- a/base_layer/core/src/transactions/key_manager/wrapper.rs
+++ b/base_layer/core/src/transactions/key_manager/wrapper.rs
@@ -35,6 +35,7 @@ use tari_key_manager::{
     key_manager_service::{
         storage::database::{KeyManagerBackend, KeyManagerDatabase},
         AddResult,
+        KeyAndId,
         KeyManagerInterface,
         KeyManagerServiceError,
     },
@@ -111,7 +112,7 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
     async fn get_next_key<T: Into<String> + Send>(
         &self,
         branch: T,
-    ) -> Result<(TariKeyId, PublicKey), KeyManagerServiceError> {
+    ) -> Result<KeyAndId<PublicKey>, KeyManagerServiceError> {
         self.transaction_key_manager_inner
             .read()
             .await
@@ -119,7 +120,7 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
             .await
     }
 
-    async fn get_random_key(&self) -> Result<(TariKeyId, PublicKey), KeyManagerServiceError> {
+    async fn get_random_key(&self) -> Result<KeyAndId<PublicKey>, KeyManagerServiceError> {
         self.transaction_key_manager_inner.read().await.get_random_key().await
     }
 
@@ -201,21 +202,21 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
             .await
     }
 
-    async fn get_view_key(&self) -> Result<(TariKeyId, PublicKey), KeyManagerServiceError> {
+    async fn get_view_key(&self) -> Result<KeyAndId<PublicKey>, KeyManagerServiceError> {
         self.transaction_key_manager_inner.read().await.get_view_key().await
     }
 
-    async fn get_spend_key(&self) -> Result<(TariKeyId, PublicKey), KeyManagerServiceError> {
+    async fn get_spend_key(&self) -> Result<KeyAndId<PublicKey>, KeyManagerServiceError> {
         self.transaction_key_manager_inner.read().await.get_spend_key().await
     }
 
-    async fn get_comms_key(&self) -> Result<(TariKeyId, PublicKey), KeyManagerServiceError> {
+    async fn get_comms_key(&self) -> Result<KeyAndId<PublicKey>, KeyManagerServiceError> {
         self.transaction_key_manager_inner.read().await.get_comms_key().await
     }
 
     async fn get_next_spend_and_script_key_ids(
         &self,
-    ) -> Result<(TariKeyId, PublicKey, TariKeyId, PublicKey), KeyManagerServiceError> {
+    ) -> Result<(KeyAndId<PublicKey>, KeyAndId<PublicKey>), KeyManagerServiceError> {
         self.transaction_key_manager_inner
             .read()
             .await

--- a/base_layer/core/src/transactions/test_helpers.rs
+++ b/base_layer/core/src/transactions/test_helpers.rs
@@ -114,15 +114,15 @@ impl TestParams {
         key_manager: &TransactionKeyManagerWrapper<KeyManagerSqliteDatabase<TKeyManagerDbConnection>>,
     ) -> TestParams {
         let (commitment_mask_key, script_key) = key_manager.get_next_commitment_mask_and_script_key().await.unwrap();
-        let sender_offset_key = key_manager
+        let sender_offset = key_manager
             .get_next_key(TransactionKeyManagerBranch::SenderOffset.get_branch_key())
             .await
             .unwrap();
-        let kernel_nonce_key = key_manager
+        let kernel_nonce = key_manager
             .get_next_key(TransactionKeyManagerBranch::KernelNonce.get_branch_key())
             .await
             .unwrap();
-        let public_nonce_key = key_manager
+        let public_noncey = key_manager
             .get_next_key(TransactionKeyManagerBranch::Nonce.get_branch_key())
             .await
             .unwrap();
@@ -725,11 +725,11 @@ pub async fn create_stx_protocol_internal(
         stx_builder.with_input(tx_input.clone()).await.unwrap();
     }
     for val in schema.to {
-        let commitment_mask_key = key_manager
+        let commitment_mask = key_manager
             .get_next_key(TransactionKeyManagerBranch::CommitmentMask.get_branch_key())
             .await
             .unwrap();
-        let sender_offset_key = key_manager
+        let sender_offset = key_manager
             .get_next_key(TransactionKeyManagerBranch::SenderOffset.get_branch_key())
             .await
             .unwrap();
@@ -769,7 +769,7 @@ pub async fn create_stx_protocol_internal(
         stx_builder.with_output(output, sender_offset_key.key_id).await.unwrap();
     }
     for mut utxo in schema.to_outputs {
-        let sender_offset_key = key_manager
+        let sender_offset = key_manager
             .get_next_key(TransactionKeyManagerBranch::SenderOffset.get_branch_key())
             .await
             .unwrap();
@@ -853,7 +853,7 @@ pub async fn create_utxo(
     covenant: &Covenant,
     minimum_value_promise: MicroMinotari,
 ) -> (TransactionOutput, TariKeyId, TariKeyId) {
-    let commitment_mask_key = key_manager
+    let commitment_mask = key_manager
         .get_next_key(TransactionKeyManagerBranch::CommitmentMask.get_branch_key())
         .await
         .unwrap();
@@ -861,7 +861,7 @@ pub async fn create_utxo(
         .encrypt_data_for_recovery(&commitment_mask_key.key_id, None, value.into(), PaymentId::Empty)
         .await
         .unwrap();
-    let sender_offset_key = key_manager
+    let sender_offset = key_manager
         .get_next_key(TransactionKeyManagerBranch::SenderOffset.get_branch_key())
         .await
         .unwrap();

--- a/base_layer/core/src/transactions/test_helpers.rs
+++ b/base_layer/core/src/transactions/test_helpers.rs
@@ -122,7 +122,7 @@ impl TestParams {
             .get_next_key(TransactionKeyManagerBranch::KernelNonce.get_branch_key())
             .await
             .unwrap();
-        let public_noncey = key_manager
+        let public_nonce = key_manager
             .get_next_key(TransactionKeyManagerBranch::Nonce.get_branch_key())
             .await
             .unwrap();
@@ -134,15 +134,15 @@ impl TestParams {
         Self {
             commitment_mask_key_id: commitment_mask_key.key_id,
             script_key_id: script_key.key_id,
-            script_key_pk: script_key.key,
-            sender_offset_key_id: sender_offset_key.key_id,
-            sender_offset_key_pk: sender_offset_key.key,
-            kernel_nonce_key_id: kernel_nonce_key.key_id,
-            kernel_nonce_key_pk: kernel_nonce_key.key,
-            public_nonce_key_id: public_nonce_key.key_id,
-            public_nonce_key_pk: public_nonce_key.key,
+            script_key_pk: script_key.pub_key,
+            sender_offset_key_id: sender_offset.key_id,
+            sender_offset_key_pk: sender_offset.pub_key,
+            kernel_nonce_key_id: kernel_nonce.key_id,
+            kernel_nonce_key_pk: kernel_nonce.pub_key,
+            public_nonce_key_id: public_nonce.key_id,
+            public_nonce_key_pk: public_nonce.pub_key,
             ephemeral_public_nonce_key_id: ephemeral_public_nonce.key_id,
-            ephemeral_public_nonce_key_pk: ephemeral_public_nonce.key,
+            ephemeral_public_nonce_key_pk: ephemeral_public_nonce.pub_key,
             transaction_weight: TransactionWeight::v1(),
         }
     }
@@ -308,7 +308,7 @@ pub async fn create_random_signature_from_secret_key(
         .get_partial_txo_kernel_signature(
             &secret_key_id,
             &total_nonce.key_id,
-            &total_nonce.key,
+            &total_nonce.pub_key,
             &total_excess,
             &kernel_version,
             &kernel_message,
@@ -736,7 +736,7 @@ pub async fn create_stx_protocol_internal(
         let script_key_id = KeyId::Derived {
             branch: TransactionKeyManagerBranch::CommitmentMask.get_branch_key(),
             label: TransactionKeyManagerLabel::ScriptKey.get_branch_key(),
-            index: commitment_mask_key.key_id.managed_index().unwrap(),
+            index: commitment_mask.key_id.managed_index().unwrap(),
         };
         let script_public_key = key_manager.get_public_key_at_key_id(&script_key_id).await.unwrap();
         let input_data = match &schema.input_data {
@@ -747,7 +747,7 @@ pub async fn create_stx_protocol_internal(
             Some(data) => data,
             None => TransactionOutputVersion::get_current_version(),
         };
-        let output = WalletOutputBuilder::new(val, commitment_mask_key.key_id)
+        let output = WalletOutputBuilder::new(val, commitment_mask.key_id)
             .with_features(schema.features.clone())
             .with_script(schema.script.clone())
             .encrypt_data_for_recovery(key_manager, None, PaymentId::Empty)
@@ -756,9 +756,9 @@ pub async fn create_stx_protocol_internal(
             .with_input_data(input_data)
             .with_covenant(schema.covenant.clone())
             .with_version(version)
-            .with_sender_offset_public_key(sender_offset_key.key)
+            .with_sender_offset_public_key(sender_offset.pub_key)
             .with_script_key(script_key_id.clone())
-            .sign_as_sender_and_receiver(key_manager, &sender_offset_key.key_id)
+            .sign_as_sender_and_receiver(key_manager, &sender_offset.key_id)
             .await
             .unwrap()
             .try_build(key_manager)
@@ -766,7 +766,7 @@ pub async fn create_stx_protocol_internal(
             .unwrap();
 
         outputs.push(output.clone());
-        stx_builder.with_output(output, sender_offset_key.key_id).await.unwrap();
+        stx_builder.with_output(output, sender_offset.key_id).await.unwrap();
     }
     for mut utxo in schema.to_outputs {
         let sender_offset = key_manager
@@ -778,7 +778,7 @@ pub async fn create_stx_protocol_internal(
             .get_metadata_signature(
                 &utxo.spending_key_id,
                 &utxo.value.into(),
-                &sender_offset_key.key_id,
+                &sender_offset.key_id,
                 &utxo.version,
                 &metadata_message,
                 utxo.features.range_proof_type,
@@ -786,7 +786,7 @@ pub async fn create_stx_protocol_internal(
             .await
             .unwrap();
 
-        stx_builder.with_output(utxo, sender_offset_key.key_id).await.unwrap();
+        stx_builder.with_output(utxo, sender_offset.key_id).await.unwrap();
     }
 
     stx_builder
@@ -813,7 +813,7 @@ pub async fn create_coinbase_kernel(
         .get_partial_txo_kernel_signature(
             commitment_mask_key_id,
             &public_nonce.key_id,
-            &public_nonce.key,
+            &public_nonce.pub_key,
             &public_commitment_mask,
             &kernel_version,
             &kernel_message,
@@ -858,7 +858,7 @@ pub async fn create_utxo(
         .await
         .unwrap();
     let encrypted_data = key_manager
-        .encrypt_data_for_recovery(&commitment_mask_key.key_id, None, value.into(), PaymentId::Empty)
+        .encrypt_data_for_recovery(&commitment_mask.key_id, None, value.into(), PaymentId::Empty)
         .await
         .unwrap();
     let sender_offset = key_manager
@@ -875,9 +875,9 @@ pub async fn create_utxo(
     );
     let metadata_sig = key_manager
         .get_metadata_signature(
-            &commitment_mask_key.key_id,
+            &commitment_mask.key_id,
             &value.into(),
-            &sender_offset_key.key_id,
+            &sender_offset.key_id,
             &TransactionOutputVersion::get_current_version(),
             &metadata_message,
             features.range_proof_type,
@@ -885,13 +885,13 @@ pub async fn create_utxo(
         .await
         .unwrap();
     let commitment = key_manager
-        .get_commitment(&commitment_mask_key.key_id, &value.into())
+        .get_commitment(&commitment_mask.key_id, &value.into())
         .await
         .unwrap();
     let proof = if features.range_proof_type == RangeProofType::BulletProofPlus {
         Some(
             key_manager
-                .construct_range_proof(&commitment_mask_key.key_id, value.into(), minimum_value_promise.into())
+                .construct_range_proof(&commitment_mask.key_id, value.into(), minimum_value_promise.into())
                 .await
                 .unwrap(),
         )
@@ -904,7 +904,7 @@ pub async fn create_utxo(
         commitment,
         proof,
         script.clone(),
-        sender_offset_key.key,
+        sender_offset.pub_key,
         metadata_sig,
         covenant.clone(),
         encrypted_data,
@@ -912,7 +912,7 @@ pub async fn create_utxo(
     );
     utxo.verify_range_proof(&CryptoFactories::default().range_proof)
         .unwrap();
-    (utxo, commitment_mask_key.key_id, sender_offset_key.key_id)
+    (utxo, commitment_mask.key_id, sender_offset.key_id)
 }
 
 pub async fn schema_to_transaction(

--- a/base_layer/core/src/transactions/test_helpers.rs
+++ b/base_layer/core/src/transactions/test_helpers.rs
@@ -95,8 +95,8 @@ pub async fn create_test_input<
 
 #[derive(Clone)]
 pub struct TestParams {
-    pub spend_key_id: TariKeyId,
-    pub spend_key_pk: PublicKey,
+    pub mask_key_id: TariKeyId,
+    pub mask_key_pk: PublicKey,
     pub script_key_id: TariKeyId,
     pub script_key_pk: PublicKey,
     pub sender_offset_key_id: TariKeyId,
@@ -114,38 +114,37 @@ impl TestParams {
     pub async fn new<TKeyManagerDbConnection: PooledDbConnection<Error = SqliteStorageError> + Clone + 'static>(
         key_manager: &TransactionKeyManagerWrapper<KeyManagerSqliteDatabase<TKeyManagerDbConnection>>,
     ) -> TestParams {
-        let (spend_key_id, spend_key_pk, script_key_id, script_key_pk) =
-            key_manager.get_next_spend_and_script_key_ids().await.unwrap();
-        let (sender_offset_key_id, sender_offset_key_pk) = key_manager
+        let (mask_key, script_key) = key_manager.get_next_spend_and_script_key_ids().await.unwrap();
+        let sender_offset_key = key_manager
             .get_next_key(TransactionKeyManagerBranch::SenderOffset.get_branch_key())
             .await
             .unwrap();
-        let (kernel_nonce_key_id, kernel_nonce_key_pk) = key_manager
+        let kernel_nonce_key = key_manager
             .get_next_key(TransactionKeyManagerBranch::KernelNonce.get_branch_key())
             .await
             .unwrap();
-        let (public_nonce_key_id, public_nonce_key_pk) = key_manager
+        let public_nonce_key = key_manager
             .get_next_key(TransactionKeyManagerBranch::Nonce.get_branch_key())
             .await
             .unwrap();
-        let (ephemeral_public_nonce_key_id, ephemeral_public_nonce_key_pk) = key_manager
+        let ephemeral_public_nonce = key_manager
             .get_next_key(TransactionKeyManagerBranch::Nonce.get_branch_key())
             .await
             .unwrap();
 
         Self {
-            spend_key_id,
-            spend_key_pk,
-            script_key_id,
-            script_key_pk,
-            sender_offset_key_id,
-            sender_offset_key_pk,
-            kernel_nonce_key_id,
-            kernel_nonce_key_pk,
-            public_nonce_key_id,
-            public_nonce_key_pk,
-            ephemeral_public_nonce_key_id,
-            ephemeral_public_nonce_key_pk,
+            mask_key_id: mask_key.key_id,
+            mask_key_pk: mask_key.key,
+            script_key_id: script_key.key_id,
+            script_key_pk: script_key.key,
+            sender_offset_key_id: sender_offset_key.key_id,
+            sender_offset_key_pk: sender_offset_key.key,
+            kernel_nonce_key_id: kernel_nonce_key.key_id,
+            kernel_nonce_key_pk: kernel_nonce_key.key,
+            public_nonce_key_id: public_nonce_key.key_id,
+            public_nonce_key_pk: public_nonce_key.key,
+            ephemeral_public_nonce_key_id: ephemeral_public_nonce.key_id,
+            ephemeral_public_nonce_key_pk: ephemeral_public_nonce.key,
             transaction_weight: TransactionWeight::v1(),
         }
     }
@@ -167,7 +166,7 @@ impl TestParams {
         };
         let input_data = params.input_data.unwrap_or_else(|| inputs!(self.script_key_pk.clone()));
 
-        let output = WalletOutputBuilder::new(params.value, self.spend_key_id.clone())
+        let output = WalletOutputBuilder::new(params.value, self.mask_key_id.clone())
             .with_features(params.features)
             .with_script(params.script.clone())
             .encrypt_data_for_recovery(key_manager, None, PaymentId::Empty)
@@ -294,7 +293,7 @@ pub async fn create_random_signature_from_secret_key(
     txo_type: TxoStage,
 ) -> (PublicKey, Signature) {
     let tx_meta = TransactionMetadata::new_with_features(fee, lock_height, kernel_features);
-    let (nonce_id, total_nonce) = key_manager
+    let total_nonce = key_manager
         .get_next_key(TransactionKeyManagerBranch::KernelNonce.get_branch_key())
         .await
         .unwrap();
@@ -310,8 +309,8 @@ pub async fn create_random_signature_from_secret_key(
     let kernel_signature = key_manager
         .get_partial_txo_kernel_signature(
             &secret_key_id,
-            &nonce_id,
-            &total_nonce,
+            &total_nonce.key_id,
+            &total_nonce.key,
             &total_excess,
             &kernel_version,
             &kernel_message,
@@ -650,7 +649,7 @@ pub async fn create_transaction_with(
             TariScript::default(),
             ExecutionStack::default(),
             change.script_key_id,
-            change.spend_key_id,
+            change.mask_key_id,
             Covenant::default(),
         );
     for input in inputs {
@@ -720,7 +719,7 @@ pub async fn create_stx_protocol_internal(
             script!(PushPubKey(Box::new(script_public_key))),
             ExecutionStack::default(),
             change.script_key_id,
-            change.spend_key_id,
+            change.mask_key_id,
             Covenant::default(),
         );
 
@@ -728,18 +727,18 @@ pub async fn create_stx_protocol_internal(
         stx_builder.with_input(tx_input.clone()).await.unwrap();
     }
     for val in schema.to {
-        let (spending_key, _) = key_manager
+        let mask_key = key_manager
             .get_next_key(TransactionKeyManagerBranch::CommitmentMask.get_branch_key())
             .await
             .unwrap();
-        let (sender_offset_key_id, sender_offset_public_key) = key_manager
+        let sender_offset_key = key_manager
             .get_next_key(TransactionKeyManagerBranch::SenderOffset.get_branch_key())
             .await
             .unwrap();
         let script_key_id = KeyId::Derived {
             branch: TransactionKeyManagerBranch::CommitmentMask.get_branch_key(),
             label: TransactionKeyManagerLabel::ScriptKey.get_branch_key(),
-            index: spending_key.managed_index().unwrap(),
+            index: mask_key.key_id.managed_index().unwrap(),
         };
         let script_public_key = key_manager.get_public_key_at_key_id(&script_key_id).await.unwrap();
         let input_data = match &schema.input_data {
@@ -750,7 +749,7 @@ pub async fn create_stx_protocol_internal(
             Some(data) => data,
             None => TransactionOutputVersion::get_current_version(),
         };
-        let output = WalletOutputBuilder::new(val, spending_key)
+        let output = WalletOutputBuilder::new(val, mask_key.key_id)
             .with_features(schema.features.clone())
             .with_script(schema.script.clone())
             .encrypt_data_for_recovery(key_manager, None, PaymentId::Empty)
@@ -759,9 +758,9 @@ pub async fn create_stx_protocol_internal(
             .with_input_data(input_data)
             .with_covenant(schema.covenant.clone())
             .with_version(version)
-            .with_sender_offset_public_key(sender_offset_public_key)
+            .with_sender_offset_public_key(sender_offset_key.key)
             .with_script_key(script_key_id.clone())
-            .sign_as_sender_and_receiver(key_manager, &sender_offset_key_id)
+            .sign_as_sender_and_receiver(key_manager, &sender_offset_key.key_id)
             .await
             .unwrap()
             .try_build(key_manager)
@@ -769,10 +768,10 @@ pub async fn create_stx_protocol_internal(
             .unwrap();
 
         outputs.push(output.clone());
-        stx_builder.with_output(output, sender_offset_key_id).await.unwrap();
+        stx_builder.with_output(output, sender_offset_key.key_id).await.unwrap();
     }
     for mut utxo in schema.to_outputs {
-        let (sender_offset_key_id, _) = key_manager
+        let sender_offset_key = key_manager
             .get_next_key(TransactionKeyManagerBranch::SenderOffset.get_branch_key())
             .await
             .unwrap();
@@ -781,7 +780,7 @@ pub async fn create_stx_protocol_internal(
             .get_metadata_signature(
                 &utxo.spending_key_id,
                 &utxo.value.into(),
-                &sender_offset_key_id,
+                &sender_offset_key.key_id,
                 &utxo.version,
                 &metadata_message,
                 utxo.features.range_proof_type,
@@ -789,7 +788,7 @@ pub async fn create_stx_protocol_internal(
             .await
             .unwrap();
 
-        stx_builder.with_output(utxo, sender_offset_key_id).await.unwrap();
+        stx_builder.with_output(utxo, sender_offset_key.key_id).await.unwrap();
     }
 
     stx_builder
@@ -803,7 +802,7 @@ pub async fn create_coinbase_kernel(
     let kernel_features = KernelFeatures::COINBASE_KERNEL;
     let kernel_message =
         TransactionKernel::build_kernel_signature_message(&kernel_version, 0.into(), 0, &kernel_features, &None);
-    let (public_nonce_id, public_nonce) = key_manager
+    let public_nonce = key_manager
         .get_next_key(TransactionKeyManagerBranch::KernelNonce.get_branch_key())
         .await
         .unwrap();
@@ -812,8 +811,8 @@ pub async fn create_coinbase_kernel(
     let kernel_signature = key_manager
         .get_partial_txo_kernel_signature(
             spending_key_id,
-            &public_nonce_id,
-            &public_nonce,
+            &public_nonce.key_id,
+            &public_nonce.key,
             &public_spend_key,
             &kernel_version,
             &kernel_message,
@@ -853,15 +852,15 @@ pub async fn create_utxo(
     covenant: &Covenant,
     minimum_value_promise: MicroMinotari,
 ) -> (TransactionOutput, TariKeyId, TariKeyId) {
-    let (spending_key_id, _) = key_manager
+    let mask_key = key_manager
         .get_next_key(TransactionKeyManagerBranch::CommitmentMask.get_branch_key())
         .await
         .unwrap();
     let encrypted_data = key_manager
-        .encrypt_data_for_recovery(&spending_key_id, None, value.into(), PaymentId::Empty)
+        .encrypt_data_for_recovery(&mask_key.key_id, None, value.into(), PaymentId::Empty)
         .await
         .unwrap();
-    let (sender_offset_key_id, sender_offset_public_key) = key_manager
+    let sender_offset_key = key_manager
         .get_next_key(TransactionKeyManagerBranch::SenderOffset.get_branch_key())
         .await
         .unwrap();
@@ -875,9 +874,9 @@ pub async fn create_utxo(
     );
     let metadata_sig = key_manager
         .get_metadata_signature(
-            &spending_key_id,
+            &mask_key.key_id,
             &value.into(),
-            &sender_offset_key_id,
+            &sender_offset_key.key_id,
             &TransactionOutputVersion::get_current_version(),
             &metadata_message,
             features.range_proof_type,
@@ -885,13 +884,13 @@ pub async fn create_utxo(
         .await
         .unwrap();
     let commitment = key_manager
-        .get_commitment(&spending_key_id, &value.into())
+        .get_commitment(&mask_key.key_id, &value.into())
         .await
         .unwrap();
     let proof = if features.range_proof_type == RangeProofType::BulletProofPlus {
         Some(
             key_manager
-                .construct_range_proof(&spending_key_id, value.into(), minimum_value_promise.into())
+                .construct_range_proof(&mask_key.key_id, value.into(), minimum_value_promise.into())
                 .await
                 .unwrap(),
         )
@@ -904,7 +903,7 @@ pub async fn create_utxo(
         commitment,
         proof,
         script.clone(),
-        sender_offset_public_key,
+        sender_offset_key.key,
         metadata_sig,
         covenant.clone(),
         encrypted_data,
@@ -912,7 +911,7 @@ pub async fn create_utxo(
     );
     utxo.verify_range_proof(&CryptoFactories::default().range_proof)
         .unwrap();
-    (utxo, spending_key_id, sender_offset_key_id)
+    (utxo, mask_key.key_id, sender_offset_key.key_id)
 }
 
 pub async fn schema_to_transaction(

--- a/base_layer/core/src/transactions/transaction_components/test.rs
+++ b/base_layer/core/src/transactions/transaction_components/test.rs
@@ -127,22 +127,25 @@ async fn range_proof_verification() {
     let tx_output1 = wallet_output1.to_transaction_output(&key_manager).await.unwrap();
     tx_output1.verify_range_proof(&factories.range_proof).unwrap();
     let input_data = inputs!(test_params_2.script_key_pk.clone());
-    let wallet_output2 = WalletOutputBuilder::new((2u64.pow(32) + 1u64).into(), test_params_2.mask_key_id.clone())
-        .with_features(OutputFeatures::default())
-        .with_script(script![Nop])
-        .encrypt_data_for_recovery(&key_manager, None, PaymentId::Empty)
-        .await
-        .unwrap()
-        .with_input_data(input_data)
-        .with_covenant(Covenant::default())
-        .with_version(TransactionOutputVersion::get_current_version())
-        .with_sender_offset_public_key(test_params_2.sender_offset_key_pk.clone())
-        .with_script_key(test_params_2.script_key_id.clone())
-        .sign_as_sender_and_receiver(&key_manager, &test_params_2.sender_offset_key_id)
-        .await
-        .unwrap()
-        .try_build(&key_manager)
-        .await;
+    let wallet_output2 = WalletOutputBuilder::new(
+        (2u64.pow(32) + 1u64).into(),
+        test_params_2.commitment_mask_key_id.clone(),
+    )
+    .with_features(OutputFeatures::default())
+    .with_script(script![Nop])
+    .encrypt_data_for_recovery(&key_manager, None, PaymentId::Empty)
+    .await
+    .unwrap()
+    .with_input_data(input_data)
+    .with_covenant(Covenant::default())
+    .with_version(TransactionOutputVersion::get_current_version())
+    .with_sender_offset_public_key(test_params_2.sender_offset_key_pk.clone())
+    .with_script_key(test_params_2.script_key_id.clone())
+    .sign_as_sender_and_receiver(&key_manager, &test_params_2.sender_offset_key_id)
+    .await
+    .unwrap()
+    .try_build(&key_manager)
+    .await;
 
     match wallet_output2 {
         Ok(_) => panic!("Range proof should have failed to verify"),
@@ -566,7 +569,7 @@ async fn test_output_recover_openings() {
 
     let (mask, value, _) = key_manager.try_output_key_recovery(&output, None).await.unwrap();
     assert_eq!(value, wallet_output.value);
-    assert_eq!(mask, test_params.mask_key_id);
+    assert_eq!(mask, test_params.commitment_mask_key_id);
 }
 
 mod validate_internal_consistency {

--- a/base_layer/core/src/transactions/transaction_components/test.rs
+++ b/base_layer/core/src/transactions/transaction_components/test.rs
@@ -127,7 +127,7 @@ async fn range_proof_verification() {
     let tx_output1 = wallet_output1.to_transaction_output(&key_manager).await.unwrap();
     tx_output1.verify_range_proof(&factories.range_proof).unwrap();
     let input_data = inputs!(test_params_2.script_key_pk.clone());
-    let wallet_output2 = WalletOutputBuilder::new((2u64.pow(32) + 1u64).into(), test_params_2.spend_key_id.clone())
+    let wallet_output2 = WalletOutputBuilder::new((2u64.pow(32) + 1u64).into(), test_params_2.mask_key_id.clone())
         .with_features(OutputFeatures::default())
         .with_script(script![Nop])
         .encrypt_data_for_recovery(&key_manager, None, PaymentId::Empty)
@@ -566,7 +566,7 @@ async fn test_output_recover_openings() {
 
     let (mask, value, _) = key_manager.try_output_key_recovery(&output, None).await.unwrap();
     assert_eq!(value, wallet_output.value);
-    assert_eq!(mask, test_params.spend_key_id);
+    assert_eq!(mask, test_params.mask_key_id);
 }
 
 mod validate_internal_consistency {

--- a/base_layer/core/src/transactions/transaction_components/wallet_output.rs
+++ b/base_layer/core/src/transactions/transaction_components/wallet_output.rs
@@ -252,11 +252,11 @@ impl WalletOutput {
         let commitment = key_manager.get_commitment(&self.spending_key_id, &value).await?;
 
         let message = TransactionInput::build_script_signature_message(&version, &self.script, &self.input_data);
-        let (ephemeral_public_key_id, ephemeral_public_key_self) = key_manager.get_random_key().await?;
+        let ephemeral_public_key_self = key_manager.get_random_key().await?;
         let script_public_key_self = key_manager.get_public_key_at_key_id(&self.script_key_id).await?;
         let script_public_key = aggregated_script_public_key_shares + script_public_key_self;
 
-        let total_ephemeral_public_key = aggregated_script_signature_public_nonces + ephemeral_public_key_self;
+        let total_ephemeral_public_key = aggregated_script_signature_public_nonces + &ephemeral_public_key_self.key;
         let commitment_partial_script_signature = key_manager
             .get_partial_script_signature(
                 &self.spending_key_id,
@@ -276,7 +276,7 @@ impl WalletOutput {
             &message,
         );
         let script_key_partial_script_signature = key_manager
-            .sign_with_nonce_and_message(&self.script_key_id, &ephemeral_public_key_id, &challenge)
+            .sign_with_nonce_and_message(&self.script_key_id, &ephemeral_public_key_self.key_id, &challenge)
             .await?;
         let script_signature = &commitment_partial_script_signature + &script_key_partial_script_signature;
 

--- a/base_layer/core/src/transactions/transaction_components/wallet_output.rs
+++ b/base_layer/core/src/transactions/transaction_components/wallet_output.rs
@@ -256,7 +256,7 @@ impl WalletOutput {
         let script_public_key_self = key_manager.get_public_key_at_key_id(&self.script_key_id).await?;
         let script_public_key = aggregated_script_public_key_shares + script_public_key_self;
 
-        let total_ephemeral_public_key = aggregated_script_signature_public_nonces + &ephemeral_public_key_self.key;
+        let total_ephemeral_public_key = aggregated_script_signature_public_nonces + &ephemeral_public_key_self.pub_key;
         let commitment_partial_script_signature = key_manager
             .get_partial_script_signature(
                 &self.spending_key_id,

--- a/base_layer/core/src/transactions/transaction_components/wallet_output_builder.rs
+++ b/base_layer/core/src/transactions/transaction_components/wallet_output_builder.rs
@@ -46,7 +46,7 @@ use crate::{
 pub struct WalletOutputBuilder {
     version: TransactionOutputVersion,
     value: MicroMinotari,
-    spending_key_id: TariKeyId,
+    mask_key_id: TariKeyId,
     features: OutputFeatures,
     script: Option<TariScript>,
     script_lock_height: u64,
@@ -65,11 +65,11 @@ pub struct WalletOutputBuilder {
 
 #[allow(dead_code)]
 impl WalletOutputBuilder {
-    pub fn new(value: MicroMinotari, spending_key_id: TariKeyId) -> Self {
+    pub fn new(value: MicroMinotari, mask_key_id: TariKeyId) -> Self {
         Self {
             version: TransactionOutputVersion::get_current_version(),
             value,
-            spending_key_id,
+            mask_key_id,
             features: OutputFeatures::default(),
             script: None,
             script_lock_height: 0,
@@ -125,7 +125,7 @@ impl WalletOutputBuilder {
     ) -> Result<Self, TransactionError> {
         self.encrypted_data = key_manager
             .encrypt_data_for_recovery(
-                &self.spending_key_id,
+                &self.mask_key_id,
                 custom_recovery_key_id,
                 self.value.as_u64(),
                 payment_id,
@@ -185,7 +185,7 @@ impl WalletOutputBuilder {
         );
         let metadata_signature = key_manager
             .get_metadata_signature(
-                &self.spending_key_id,
+                &self.mask_key_id,
                 &self.value.into(),
                 sender_offset_key_id,
                 &self.version,
@@ -226,14 +226,14 @@ impl WalletOutputBuilder {
         let aggregate_sender_offset_public_key =
             aggregated_sender_offset_public_key_shares + &sender_offset_public_key_self;
 
-        let (ephemeral_private_nonce_id, ephemeral_pubkey_self) = key_manager
+        let ephemeral_pubkey_self = key_manager
             .get_next_key(TransactionKeyManagerBranch::MetadataEphemeralNonce.get_branch_key())
             .await?;
-        let aggregate_ephemeral_pubkey = aggregated_ephemeral_public_key_shares + ephemeral_pubkey_self;
+        let aggregate_ephemeral_pubkey = aggregated_ephemeral_public_key_shares + &ephemeral_pubkey_self.key;
 
         let receiver_partial_metadata_signature = key_manager
             .get_receiver_partial_metadata_signature(
-                &self.spending_key_id,
+                &self.mask_key_id,
                 &self.value.into(),
                 &aggregate_sender_offset_public_key,
                 &aggregate_ephemeral_pubkey,
@@ -244,7 +244,7 @@ impl WalletOutputBuilder {
             .await?;
 
         let commitment = key_manager
-            .get_commitment(&self.spending_key_id, &self.value.into())
+            .get_commitment(&self.mask_key_id, &self.value.into())
             .await?;
         let ephemeral_commitment = receiver_partial_metadata_signature.ephemeral_commitment();
         let challenge = TransactionOutput::finalize_metadata_signature_challenge(
@@ -256,7 +256,7 @@ impl WalletOutputBuilder {
             &metadata_message,
         );
         let sender_partial_metadata_signature_self = key_manager
-            .sign_with_nonce_and_message(sender_offset_key_id, &ephemeral_private_nonce_id, &challenge)
+            .sign_with_nonce_and_message(sender_offset_key_id, &ephemeral_pubkey_self.key_id, &challenge)
             .await?;
 
         let metadata_signature = &receiver_partial_metadata_signature + &sender_partial_metadata_signature_self;
@@ -285,7 +285,7 @@ impl WalletOutputBuilder {
         let ub = WalletOutput::new(
             self.version,
             self.value,
-            self.spending_key_id,
+            self.mask_key_id,
             self.features,
             self.script
                 .ok_or_else(|| TransactionError::BuilderError("script must be set".to_string()))?,
@@ -319,25 +319,25 @@ mod test {
     #[tokio::test]
     async fn test_try_build() {
         let key_manager = create_memory_db_key_manager().unwrap();
-        let (spending_key_id, _, script_key_id, _) = key_manager.get_next_spend_and_script_key_ids().await.unwrap();
+        let (mask_key, script_key_id) = key_manager.get_next_spend_and_script_key_ids().await.unwrap();
         let value = MicroMinotari(100);
-        let kmob = WalletOutputBuilder::new(value, spending_key_id.clone());
+        let kmob = WalletOutputBuilder::new(value, mask_key.key_id.clone());
         let kmob = kmob.with_script(TariScript::new(vec![]));
         assert!(kmob.clone().try_build(&key_manager).await.is_err());
-        let (sender_offset_private_key_id, sender_offset_public_key) = key_manager
+        let sender_offset_key = key_manager
             .get_next_key(TransactionKeyManagerBranch::SenderOffset.get_branch_key())
             .await
             .unwrap();
-        let kmob = kmob.with_sender_offset_public_key(sender_offset_public_key);
+        let kmob = kmob.with_sender_offset_public_key(sender_offset_key.key);
         assert!(kmob.clone().try_build(&key_manager).await.is_err());
         let kmob = kmob.with_input_data(ExecutionStack::new(vec![]));
-        let kmob = kmob.with_script_key(script_key_id);
+        let kmob = kmob.with_script_key(script_key_id.key_id);
         let kmob = kmob.with_features(OutputFeatures::default());
         let kmob = kmob
             .encrypt_data_for_recovery(&key_manager, None, PaymentId::Empty)
             .await
             .unwrap()
-            .sign_as_sender_and_receiver(&key_manager, &sender_offset_private_key_id)
+            .sign_as_sender_and_receiver(&key_manager, &sender_offset_key.key_id)
             .await
             .unwrap();
         match kmob.clone().try_build(&key_manager).await {
@@ -345,13 +345,13 @@ mod test {
                 let output = val.to_transaction_output(&key_manager).await.unwrap();
                 assert!(output.verify_metadata_signature().is_ok());
                 assert!(key_manager
-                    .verify_mask(output.commitment(), &spending_key_id, value.into())
+                    .verify_mask(output.commitment(), &mask_key.key_id, value.into())
                     .await
                     .unwrap());
 
                 let (recovered_key_id, recovered_value, _) =
                     key_manager.try_output_key_recovery(&output, None).await.unwrap();
-                assert_eq!(recovered_key_id, spending_key_id);
+                assert_eq!(recovered_key_id, mask_key.key_id);
                 assert_eq!(recovered_value, value);
             },
             Err(e) => panic!("{}", e),
@@ -361,23 +361,23 @@ mod test {
     #[tokio::test]
     async fn test_partial_metadata_signatures() {
         let key_manager = create_memory_db_key_manager().unwrap();
-        let (spending_key_id, _, script_key_id, _) = key_manager.get_next_spend_and_script_key_ids().await.unwrap();
+        let (mask_key, script_key) = key_manager.get_next_spend_and_script_key_ids().await.unwrap();
         let value = MicroMinotari(100);
-        let kmob = WalletOutputBuilder::new(value, spending_key_id.clone());
+        let kmob = WalletOutputBuilder::new(value, mask_key.key_id.clone());
         let kmob = kmob.with_script(TariScript::new(vec![]));
-        let (sender_offset_private_key_id, sender_offset_public_key) = key_manager
+        let sender_offset_key = key_manager
             .get_next_key(TransactionKeyManagerBranch::SenderOffset.get_branch_key())
             .await
             .unwrap();
-        let kmob = kmob.with_sender_offset_public_key(sender_offset_public_key);
+        let kmob = kmob.with_sender_offset_public_key(sender_offset_key.key);
         let kmob = kmob.with_input_data(ExecutionStack::new(vec![]));
-        let kmob = kmob.with_script_key(script_key_id);
+        let kmob = kmob.with_script_key(script_key.key_id);
         let kmob = kmob.with_features(OutputFeatures::default());
         let kmob = kmob
             .encrypt_data_for_recovery(&key_manager, None, PaymentId::Empty)
             .await
             .unwrap()
-            .sign_as_sender_and_receiver(&key_manager, &sender_offset_private_key_id)
+            .sign_as_sender_and_receiver(&key_manager, &sender_offset_key.key_id)
             .await
             .unwrap();
         match kmob.clone().try_build(&key_manager).await {
@@ -386,7 +386,7 @@ mod test {
                 assert!(output.verify_metadata_signature().is_ok());
 
                 // Now we can swap out the metadata signature for one built from partial sender and receiver signatures
-                let (ephemeral_pubkey_id, ephemeral_pubkey) = key_manager
+                let ephemeral_key = key_manager
                     .get_next_key(TransactionKeyManagerBranch::Nonce.get_branch_key())
                     .await
                     .unwrap();
@@ -397,7 +397,7 @@ mod test {
                         &wallet_output.spending_key_id,
                         &wallet_output.value.into(),
                         &wallet_output.sender_offset_public_key,
-                        &ephemeral_pubkey,
+                        &ephemeral_key.key,
                         &wallet_output.version,
                         &metadata_message,
                         wallet_output.features.range_proof_type,
@@ -411,8 +411,8 @@ mod test {
                     .unwrap();
                 let sender_metadata_signature = key_manager
                     .get_sender_partial_metadata_signature(
-                        &ephemeral_pubkey_id,
-                        &sender_offset_private_key_id,
+                        &ephemeral_key.key_id,
+                        &sender_offset_key.key_id,
                         &commitment,
                         receiver_metadata_signature.ephemeral_commitment(),
                         &wallet_output.version,

--- a/base_layer/core/src/transactions/transaction_protocol/recipient.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/recipient.rs
@@ -209,8 +209,8 @@ mod test {
         let msg = SingleRoundSenderData {
             tx_id: 15u64.into(),
             amount,
-            public_excess: sender_test_params.mask_key_pk, // any random key will do
-            public_nonce: sender_test_params.public_nonce_key_pk, // any random key will do
+            public_excess: sender_test_params.kernel_nonce_key_pk, // any random key will do
+            public_nonce: sender_test_params.public_nonce_key_pk,  // any random key will do
             metadata: m.clone(),
             message: "".to_string(),
             features,
@@ -236,7 +236,7 @@ mod test {
         assert!(receiver.is_finalized());
         let data = receiver.get_signed_data().unwrap();
         let pubkey = key_manager
-            .get_public_key_at_key_id(&receiver_test_params.mask_key_id)
+            .get_public_key_at_key_id(&receiver_test_params.commitment_mask_key_id)
             .await
             .unwrap();
         let offset = data.offset.clone();
@@ -245,7 +245,7 @@ mod test {
         assert_eq!(data.tx_id.as_u64(), 15);
         assert_eq!(data.public_spend_key, signing_pubkey);
         let commitment = key_manager
-            .get_commitment(&receiver_test_params.mask_key_id, &500.into())
+            .get_commitment(&receiver_test_params.commitment_mask_key_id, &500.into())
             .await
             .unwrap();
         assert_eq!(&commitment, &data.output.commitment);
@@ -270,15 +270,15 @@ mod test {
             &m.burn_commitment,
         );
         let p_nonce = key_manager.get_public_key_at_key_id(&nonce_id).await.unwrap();
-        let p_spend_key = key_manager
-            .get_txo_kernel_signature_excess_with_offset(&receiver_test_params.mask_key_id, &nonce_id)
+        let p_commitment_mask_key = key_manager
+            .get_txo_kernel_signature_excess_with_offset(&receiver_test_params.commitment_mask_key_id, &nonce_id)
             .await
             .unwrap();
         let r_sum = &msg.public_nonce + &p_nonce;
-        let excess = &msg.public_excess + &p_spend_key;
+        let excess = &msg.public_excess + &p_commitment_mask_key;
         let kernel_signature = key_manager
             .get_partial_txo_kernel_signature(
-                &receiver_test_params.mask_key_id,
+                &receiver_test_params.commitment_mask_key_id,
                 &nonce_id,
                 &r_sum,
                 &excess,

--- a/base_layer/core/src/transactions/transaction_protocol/recipient.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/recipient.rs
@@ -209,7 +209,7 @@ mod test {
         let msg = SingleRoundSenderData {
             tx_id: 15u64.into(),
             amount,
-            public_excess: sender_test_params.spend_key_pk, // any random key will do
+            public_excess: sender_test_params.mask_key_pk, // any random key will do
             public_nonce: sender_test_params.public_nonce_key_pk, // any random key will do
             metadata: m.clone(),
             message: "".to_string(),
@@ -236,7 +236,7 @@ mod test {
         assert!(receiver.is_finalized());
         let data = receiver.get_signed_data().unwrap();
         let pubkey = key_manager
-            .get_public_key_at_key_id(&receiver_test_params.spend_key_id)
+            .get_public_key_at_key_id(&receiver_test_params.mask_key_id)
             .await
             .unwrap();
         let offset = data.offset.clone();
@@ -245,7 +245,7 @@ mod test {
         assert_eq!(data.tx_id.as_u64(), 15);
         assert_eq!(data.public_spend_key, signing_pubkey);
         let commitment = key_manager
-            .get_commitment(&receiver_test_params.spend_key_id, &500.into())
+            .get_commitment(&receiver_test_params.mask_key_id, &500.into())
             .await
             .unwrap();
         assert_eq!(&commitment, &data.output.commitment);
@@ -271,14 +271,14 @@ mod test {
         );
         let p_nonce = key_manager.get_public_key_at_key_id(&nonce_id).await.unwrap();
         let p_spend_key = key_manager
-            .get_txo_kernel_signature_excess_with_offset(&receiver_test_params.spend_key_id, &nonce_id)
+            .get_txo_kernel_signature_excess_with_offset(&receiver_test_params.mask_key_id, &nonce_id)
             .await
             .unwrap();
         let r_sum = &msg.public_nonce + &p_nonce;
         let excess = &msg.public_excess + &p_spend_key;
         let kernel_signature = key_manager
             .get_partial_txo_kernel_signature(
-                &receiver_test_params.spend_key_id,
+                &receiver_test_params.mask_key_id,
                 &nonce_id,
                 &r_sum,
                 &excess,

--- a/base_layer/core/src/transactions/transaction_protocol/sender.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/sender.rs
@@ -958,12 +958,12 @@ mod test {
         let key_manager = create_memory_db_key_manager().unwrap();
 
         // Sender data
-        let (ephemeral_pubkey_id, ephemeral_pubkey) = key_manager
+        let ephemeral_key = key_manager
             .get_next_key(TransactionKeyManagerBranch::Nonce.get_branch_key())
             .await
             .unwrap();
         let value = 1000u64;
-        let (sender_offset_key_id, sender_offset_public_key) = key_manager
+        let sender_offset_key = key_manager
             .get_next_key(TransactionKeyManagerBranch::SenderOffset.get_branch_key())
             .await
             .unwrap();
@@ -974,21 +974,21 @@ mod test {
         let output_features = Default::default();
 
         // Receiver data
-        let (spending_key_id, _, _script_key_id, _) = key_manager.get_next_spend_and_script_key_ids().await.unwrap();
+        let (mask_key, _) = key_manager.get_next_spend_and_script_key_ids().await.unwrap();
         let commitment = key_manager
-            .get_commitment(&spending_key_id, &PrivateKey::from(value))
+            .get_commitment(&mask_key.key_id, &PrivateKey::from(value))
             .await
             .unwrap();
         let minimum_value_promise = MicroMinotari::zero();
         let proof = key_manager
-            .construct_range_proof(&spending_key_id, value, minimum_value_promise.into())
+            .construct_range_proof(&mask_key.key_id, value, minimum_value_promise.into())
             .await
             .unwrap();
         let covenant = Covenant::default();
 
         // Encrypted value
         let encrypted_data = key_manager
-            .encrypt_data_for_recovery(&spending_key_id, None, value, PaymentId::Empty)
+            .encrypt_data_for_recovery(&mask_key.key_id, None, value, PaymentId::Empty)
             .await
             .unwrap();
 
@@ -1002,10 +1002,10 @@ mod test {
         );
         let partial_metadata_signature = key_manager
             .get_receiver_partial_metadata_signature(
-                &spending_key_id,
+                &mask_key.key_id,
                 &value.into(),
-                &sender_offset_public_key,
-                &ephemeral_pubkey,
+                &sender_offset_key.key,
+                &ephemeral_key.key,
                 &txo_version,
                 &metadata_message,
                 output_features.range_proof_type,
@@ -1018,7 +1018,7 @@ mod test {
             commitment,
             Some(proof),
             script.clone(),
-            sender_offset_public_key,
+            sender_offset_key.key,
             partial_metadata_signature.clone(),
             covenant.clone(),
             encrypted_data,
@@ -1029,8 +1029,8 @@ mod test {
         // Sender finalize transaction output
         let partial_sender_metadata_signature = key_manager
             .get_sender_partial_metadata_signature(
-                &ephemeral_pubkey_id,
-                &sender_offset_key_id,
+                &ephemeral_key.key_id,
+                &sender_offset_key.key_id,
                 &output.commitment,
                 partial_metadata_signature.ephemeral_commitment(),
                 &txo_version,
@@ -1059,7 +1059,7 @@ mod test {
                 TariScript::default(),
                 inputs!(change.script_key_pk),
                 change.script_key_id.clone(),
-                change.spend_key_id.clone(),
+                change.mask_key_id.clone(),
                 Covenant::default(),
             )
             .with_input(input)
@@ -1136,7 +1136,7 @@ mod test {
                 script.clone(),
                 ExecutionStack::default(),
                 a_change_key.script_key_id,
-                a_change_key.spend_key_id,
+                a_change_key.mask_key_id,
                 Covenant::default(),
             );
         let mut alice = builder.build().await.unwrap();
@@ -1147,7 +1147,7 @@ mod test {
         let bob_public_key = msg.sender_offset_public_key.clone();
         let mut bob_output = WalletOutput::new_current_version(
             MicroMinotari(1200) - fee - MicroMinotari(10),
-            bob_key.spend_key_id,
+            bob_key.mask_key_id,
             OutputFeatures::default(),
             script.clone(),
             ExecutionStack::default(),
@@ -1239,7 +1239,7 @@ mod test {
                 script.clone(),
                 inputs!(change.script_key_pk),
                 change.script_key_id.clone(),
-                change.spend_key_id.clone(),
+                change.mask_key_id.clone(),
                 Covenant::default(),
             )
             .with_input(input)
@@ -1270,7 +1270,7 @@ mod test {
         let bob_public_key = msg.sender_offset_public_key.clone();
         let mut bob_output = WalletOutput::new_current_version(
             MicroMinotari(5000),
-            bob_key.spend_key_id,
+            bob_key.mask_key_id,
             OutputFeatures::default(),
             script.clone(),
             ExecutionStack::default(),
@@ -1344,7 +1344,7 @@ mod test {
                 script.clone(),
                 inputs!(change.script_key_pk),
                 change.script_key_id.clone(),
-                change.spend_key_id.clone(),
+                change.mask_key_id.clone(),
                 Covenant::default(),
             )
             .with_input(input)
@@ -1381,7 +1381,7 @@ mod test {
         let bob_public_key = msg.sender_offset_public_key.clone();
         let mut bob_output = WalletOutput::new_current_version(
             MicroMinotari(5000),
-            bob_key.spend_key_id,
+            bob_key.mask_key_id,
             OutputFeatures::default(),
             script.clone(),
             ExecutionStack::default(),
@@ -1449,7 +1449,7 @@ mod test {
                 script.clone(),
                 inputs!(change.script_key_pk),
                 change.script_key_id.clone(),
-                change.spend_key_id.clone(),
+                change.mask_key_id.clone(),
                 Covenant::default(),
             )
             .with_input(input)
@@ -1487,7 +1487,7 @@ mod test {
                 script.clone(),
                 inputs!(change.script_key_pk),
                 change.script_key_id.clone(),
-                change.spend_key_id.clone(),
+                change.mask_key_id.clone(),
                 Covenant::default(),
             )
             .with_input(input)
@@ -1532,7 +1532,7 @@ mod test {
                 script!(PushInt(1) Drop Nop),
                 inputs!(change_params.script_key_pk),
                 change_params.script_key_id.clone(),
-                change_params.spend_key_id.clone(),
+                change_params.mask_key_id.clone(),
                 Covenant::default(),
             )
             .with_input(input)
@@ -1568,7 +1568,7 @@ mod test {
         let bob_public_key = msg.sender_offset_public_key.clone();
         let bob_output = WalletOutput::new_current_version(
             MicroMinotari(5000),
-            bob_test_params.spend_key_id,
+            bob_test_params.mask_key_id,
             OutputFeatures::default(),
             script.clone(),
             ExecutionStack::default(),
@@ -1610,6 +1610,6 @@ mod test {
         let output = tx.body.outputs().iter().find(|o| o.script.size() > 1).unwrap();
 
         let (key, _value, _) = key_manager_alice.try_output_key_recovery(output, None).await.unwrap();
-        assert_eq!(key, change_params.spend_key_id);
+        assert_eq!(key, change_params.mask_key_id);
     }
 }

--- a/base_layer/core/src/transactions/transaction_protocol/sender.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/sender.rs
@@ -974,21 +974,21 @@ mod test {
         let output_features = Default::default();
 
         // Receiver data
-        let (mask_key, _) = key_manager.get_next_spend_and_script_key_ids().await.unwrap();
+        let (commitment_mask_key, _) = key_manager.get_next_commitment_mask_and_script_key().await.unwrap();
         let commitment = key_manager
-            .get_commitment(&mask_key.key_id, &PrivateKey::from(value))
+            .get_commitment(&commitment_mask_key.key_id, &PrivateKey::from(value))
             .await
             .unwrap();
         let minimum_value_promise = MicroMinotari::zero();
         let proof = key_manager
-            .construct_range_proof(&mask_key.key_id, value, minimum_value_promise.into())
+            .construct_range_proof(&commitment_mask_key.key_id, value, minimum_value_promise.into())
             .await
             .unwrap();
         let covenant = Covenant::default();
 
         // Encrypted value
         let encrypted_data = key_manager
-            .encrypt_data_for_recovery(&mask_key.key_id, None, value, PaymentId::Empty)
+            .encrypt_data_for_recovery(&commitment_mask_key.key_id, None, value, PaymentId::Empty)
             .await
             .unwrap();
 
@@ -1002,7 +1002,7 @@ mod test {
         );
         let partial_metadata_signature = key_manager
             .get_receiver_partial_metadata_signature(
-                &mask_key.key_id,
+                &commitment_mask_key.key_id,
                 &value.into(),
                 &sender_offset_key.key,
                 &ephemeral_key.key,
@@ -1059,7 +1059,7 @@ mod test {
                 TariScript::default(),
                 inputs!(change.script_key_pk),
                 change.script_key_id.clone(),
-                change.mask_key_id.clone(),
+                change.commitment_mask_key_id.clone(),
                 Covenant::default(),
             )
             .with_input(input)
@@ -1136,7 +1136,7 @@ mod test {
                 script.clone(),
                 ExecutionStack::default(),
                 a_change_key.script_key_id,
-                a_change_key.mask_key_id,
+                a_change_key.commitment_mask_key_id,
                 Covenant::default(),
             );
         let mut alice = builder.build().await.unwrap();
@@ -1147,7 +1147,7 @@ mod test {
         let bob_public_key = msg.sender_offset_public_key.clone();
         let mut bob_output = WalletOutput::new_current_version(
             MicroMinotari(1200) - fee - MicroMinotari(10),
-            bob_key.mask_key_id,
+            bob_key.commitment_mask_key_id,
             OutputFeatures::default(),
             script.clone(),
             ExecutionStack::default(),
@@ -1239,7 +1239,7 @@ mod test {
                 script.clone(),
                 inputs!(change.script_key_pk),
                 change.script_key_id.clone(),
-                change.mask_key_id.clone(),
+                change.commitment_mask_key_id.clone(),
                 Covenant::default(),
             )
             .with_input(input)
@@ -1270,7 +1270,7 @@ mod test {
         let bob_public_key = msg.sender_offset_public_key.clone();
         let mut bob_output = WalletOutput::new_current_version(
             MicroMinotari(5000),
-            bob_key.mask_key_id,
+            bob_key.commitment_mask_key_id,
             OutputFeatures::default(),
             script.clone(),
             ExecutionStack::default(),
@@ -1344,7 +1344,7 @@ mod test {
                 script.clone(),
                 inputs!(change.script_key_pk),
                 change.script_key_id.clone(),
-                change.mask_key_id.clone(),
+                change.commitment_mask_key_id.clone(),
                 Covenant::default(),
             )
             .with_input(input)
@@ -1381,7 +1381,7 @@ mod test {
         let bob_public_key = msg.sender_offset_public_key.clone();
         let mut bob_output = WalletOutput::new_current_version(
             MicroMinotari(5000),
-            bob_key.mask_key_id,
+            bob_key.commitment_mask_key_id,
             OutputFeatures::default(),
             script.clone(),
             ExecutionStack::default(),
@@ -1449,7 +1449,7 @@ mod test {
                 script.clone(),
                 inputs!(change.script_key_pk),
                 change.script_key_id.clone(),
-                change.mask_key_id.clone(),
+                change.commitment_mask_key_id.clone(),
                 Covenant::default(),
             )
             .with_input(input)
@@ -1487,7 +1487,7 @@ mod test {
                 script.clone(),
                 inputs!(change.script_key_pk),
                 change.script_key_id.clone(),
-                change.mask_key_id.clone(),
+                change.commitment_mask_key_id.clone(),
                 Covenant::default(),
             )
             .with_input(input)
@@ -1532,7 +1532,7 @@ mod test {
                 script!(PushInt(1) Drop Nop),
                 inputs!(change_params.script_key_pk),
                 change_params.script_key_id.clone(),
-                change_params.mask_key_id.clone(),
+                change_params.commitment_mask_key_id.clone(),
                 Covenant::default(),
             )
             .with_input(input)
@@ -1568,7 +1568,7 @@ mod test {
         let bob_public_key = msg.sender_offset_public_key.clone();
         let bob_output = WalletOutput::new_current_version(
             MicroMinotari(5000),
-            bob_test_params.mask_key_id,
+            bob_test_params.commitment_mask_key_id,
             OutputFeatures::default(),
             script.clone(),
             ExecutionStack::default(),
@@ -1610,6 +1610,6 @@ mod test {
         let output = tx.body.outputs().iter().find(|o| o.script.size() > 1).unwrap();
 
         let (key, _value, _) = key_manager_alice.try_output_key_recovery(output, None).await.unwrap();
-        assert_eq!(key, change_params.mask_key_id);
+        assert_eq!(key, change_params.commitment_mask_key_id);
     }
 }

--- a/base_layer/core/src/transactions/transaction_protocol/sender.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/sender.rs
@@ -963,7 +963,7 @@ mod test {
             .await
             .unwrap();
         let value = 1000u64;
-        let sender_offset_key = key_manager
+        let sender_offset = key_manager
             .get_next_key(TransactionKeyManagerBranch::SenderOffset.get_branch_key())
             .await
             .unwrap();
@@ -1004,8 +1004,8 @@ mod test {
             .get_receiver_partial_metadata_signature(
                 &commitment_mask_key.key_id,
                 &value.into(),
-                &sender_offset_key.key,
-                &ephemeral_key.key,
+                &sender_offset.pub_key,
+                &ephemeral_key.pub_key,
                 &txo_version,
                 &metadata_message,
                 output_features.range_proof_type,
@@ -1018,7 +1018,7 @@ mod test {
             commitment,
             Some(proof),
             script.clone(),
-            sender_offset_key.key,
+            sender_offset.pub_key,
             partial_metadata_signature.clone(),
             covenant.clone(),
             encrypted_data,
@@ -1030,7 +1030,7 @@ mod test {
         let partial_sender_metadata_signature = key_manager
             .get_sender_partial_metadata_signature(
                 &ephemeral_key.key_id,
-                &sender_offset_key.key_id,
+                &sender_offset.key_id,
                 &output.commitment,
                 partial_metadata_signature.ephemeral_commitment(),
                 &txo_version,

--- a/base_layer/core/src/transactions/transaction_protocol/single_receiver.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/single_receiver.rs
@@ -180,7 +180,7 @@ mod test {
         let info = SingleRoundSenderData::default();
         let bob_output = WalletOutput::new_current_version(
             MicroMinotari(5000),
-            test_params.mask_key_id,
+            test_params.commitment_mask_key_id,
             OutputFeatures::default(),
             script!(Nop),
             ExecutionStack::default(),
@@ -221,7 +221,7 @@ mod test {
 
         let bob_output = WalletOutput::new_current_version(
             MicroMinotari(5000),
-            test_params.mask_key_id,
+            test_params.commitment_mask_key_id,
             OutputFeatures::default(),
             script!(Nop),
             ExecutionStack::default(),
@@ -269,7 +269,7 @@ mod test {
             .await
             .unwrap();
         let pub_xs = key_manager
-            .get_public_key_at_key_id(&test_params.mask_key_id)
+            .get_public_key_at_key_id(&test_params.commitment_mask_key_id)
             .await
             .unwrap();
         let pub_rs = key_manager
@@ -298,7 +298,7 @@ mod test {
             .unwrap();
         let mut bob_output = WalletOutput::new_current_version(
             MicroMinotari(1500),
-            test_params2.mask_key_id.clone(),
+            test_params2.commitment_mask_key_id.clone(),
             OutputFeatures::default(),
             script.clone(),
             ExecutionStack::default(),
@@ -335,7 +335,7 @@ mod test {
         // Check the signature
 
         let pubkey = key_manager
-            .get_public_key_at_key_id(&test_params2.mask_key_id)
+            .get_public_key_at_key_id(&test_params2.commitment_mask_key_id)
             .await
             .unwrap();
         let offset = prot.offset.clone();

--- a/base_layer/core/src/transactions/transaction_protocol/single_receiver.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/single_receiver.rs
@@ -52,7 +52,7 @@ impl SingleReceiverTransactionProtocol {
         SingleReceiverTransactionProtocol::validate_sender_data(sender_info, consensus_constants)?;
         let transaction_output = output.to_transaction_output(key_manager).await?;
 
-        let (nonce_id, public_nonce) = key_manager
+        let public_nonce = key_manager
             .get_next_key(TransactionKeyManagerBranch::KernelNonce.get_branch_key())
             .await?;
         let tx_meta = if output.is_burned() {
@@ -63,7 +63,7 @@ impl SingleReceiverTransactionProtocol {
             sender_info.metadata.clone()
         };
         let public_excess = key_manager
-            .get_txo_kernel_signature_excess_with_offset(&output.spending_key_id, &nonce_id)
+            .get_txo_kernel_signature_excess_with_offset(&output.spending_key_id, &public_nonce.key_id)
             .await?;
 
         let kernel_message = TransactionKernel::build_kernel_signature_message(
@@ -76,8 +76,8 @@ impl SingleReceiverTransactionProtocol {
         let signature = key_manager
             .get_partial_txo_kernel_signature(
                 &output.spending_key_id,
-                &nonce_id,
-                &(&sender_info.public_nonce + &public_nonce),
+                &public_nonce.key_id,
+                &(&sender_info.public_nonce + &public_nonce.key),
                 &(&sender_info.public_excess + &public_excess),
                 &sender_info.kernel_version,
                 &kernel_message,
@@ -86,7 +86,7 @@ impl SingleReceiverTransactionProtocol {
             )
             .await?;
         let offset = key_manager
-            .get_txo_private_kernel_offset(&output.spending_key_id, &nonce_id)
+            .get_txo_private_kernel_offset(&output.spending_key_id, &public_nonce.key_id)
             .await?;
 
         let data = RecipientSignedMessage {
@@ -180,7 +180,7 @@ mod test {
         let info = SingleRoundSenderData::default();
         let bob_output = WalletOutput::new_current_version(
             MicroMinotari(5000),
-            test_params.spend_key_id,
+            test_params.mask_key_id,
             OutputFeatures::default(),
             script!(Nop),
             ExecutionStack::default(),
@@ -221,7 +221,7 @@ mod test {
 
         let bob_output = WalletOutput::new_current_version(
             MicroMinotari(5000),
-            test_params.spend_key_id,
+            test_params.mask_key_id,
             OutputFeatures::default(),
             script!(Nop),
             ExecutionStack::default(),
@@ -269,7 +269,7 @@ mod test {
             .await
             .unwrap();
         let pub_xs = key_manager
-            .get_public_key_at_key_id(&test_params.spend_key_id)
+            .get_public_key_at_key_id(&test_params.mask_key_id)
             .await
             .unwrap();
         let pub_rs = key_manager
@@ -298,7 +298,7 @@ mod test {
             .unwrap();
         let mut bob_output = WalletOutput::new_current_version(
             MicroMinotari(1500),
-            test_params2.spend_key_id.clone(),
+            test_params2.mask_key_id.clone(),
             OutputFeatures::default(),
             script.clone(),
             ExecutionStack::default(),
@@ -335,7 +335,7 @@ mod test {
         // Check the signature
 
         let pubkey = key_manager
-            .get_public_key_at_key_id(&test_params2.spend_key_id)
+            .get_public_key_at_key_id(&test_params2.mask_key_id)
             .await
             .unwrap();
         let offset = prot.offset.clone();

--- a/base_layer/core/src/transactions/transaction_protocol/single_receiver.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/single_receiver.rs
@@ -77,7 +77,7 @@ impl SingleReceiverTransactionProtocol {
             .get_partial_txo_kernel_signature(
                 &output.spending_key_id,
                 &public_nonce.key_id,
-                &(&sender_info.public_nonce + &public_nonce.key),
+                &(&sender_info.public_nonce + &public_nonce.pub_key),
                 &(&sender_info.public_excess + &public_excess),
                 &sender_info.kernel_version,
                 &kernel_message,

--- a/base_layer/core/src/transactions/transaction_protocol/transaction_initializer.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/transaction_initializer.rs
@@ -60,7 +60,7 @@ pub const LOG_TARGET: &str = "c::tx::tx_protocol::tx_initializer";
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub(super) struct ChangeDetails {
-    change_mask_key_id: TariKeyId,
+    change_commitment_mask_key_id: TariKeyId,
     change_script: TariScript,
     change_input_data: ExecutionStack,
     change_script_key_id: TariKeyId,
@@ -220,11 +220,11 @@ where KM: TransactionKeyManagerInterface
         change_script: TariScript,
         change_input_data: ExecutionStack,
         change_script_key_id: TariKeyId,
-        change_mask_key_id: TariKeyId,
+        change_commitment_mask_key_id: TariKeyId,
         change_covenant: Covenant,
     ) -> &mut Self {
         let details = ChangeDetails {
-            change_mask_key_id,
+            change_commitment_mask_key_id,
             change_script,
             change_input_data,
             change_script_key_id,
@@ -368,7 +368,7 @@ where KM: TransactionKeyManagerInterface
                         let change_data = self.change.as_ref().ok_or("Change data was not provided")?;
                         let change_script = change_data.change_script.clone();
                         let change_script_key_id = change_data.change_script_key_id.clone();
-                        let change_key_id = change_data.change_mask_key_id.clone();
+                        let change_key_id = change_data.change_commitment_mask_key_id.clone();
                         let sender_offset_public_key = self
                             .key_manager
                             .get_next_key(TransactionKeyManagerBranch::SenderOffset.get_branch_key())
@@ -661,7 +661,7 @@ mod test {
             script!(Nop),
             Default::default(),
             change.script_key_id.clone(),
-            change.mask_key_id.clone(),
+            change.commitment_mask_key_id.clone(),
             Covenant::default(),
         );
         let result = builder.build().await.unwrap();
@@ -846,7 +846,7 @@ mod test {
                 script!(Nop),
                 inputs!(change.script_key_pk),
                 change.script_key_id.clone(),
-                change.mask_key_id.clone(),
+                change.commitment_mask_key_id.clone(),
                 Covenant::default(),
             )
             .with_fee_per_gram(MicroMinotari(1))
@@ -895,7 +895,7 @@ mod test {
                 script!(Nop),
                 inputs!(change.script_key_pk),
                 change.script_key_id.clone(),
-                change.mask_key_id.clone(),
+                change.commitment_mask_key_id.clone(),
                 Covenant::default(),
             )
             .with_fee_per_gram(MicroMinotari(1))
@@ -961,7 +961,7 @@ mod test {
                 script!(Nop),
                 inputs!(change.script_key_pk),
                 change.script_key_id.clone(),
-                change.mask_key_id.clone(),
+                change.commitment_mask_key_id.clone(),
                 Covenant::default(),
             )
             .with_fee_per_gram(fee_per_gram)

--- a/base_layer/core/src/transactions/transaction_protocol/transaction_initializer.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/transaction_initializer.rs
@@ -60,7 +60,7 @@ pub const LOG_TARGET: &str = "c::tx::tx_protocol::tx_initializer";
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub(super) struct ChangeDetails {
-    change_spending_key_id: TariKeyId,
+    change_mask_key_id: TariKeyId,
     change_script: TariScript,
     change_input_data: ExecutionStack,
     change_script_key_id: TariKeyId,
@@ -152,21 +152,21 @@ where KM: TransactionKeyManagerInterface
         recipient_minimum_value_promise: MicroMinotari,
         amount: MicroMinotari,
     ) -> Result<&mut Self, KeyManagerServiceError> {
-        let (recipient_ephemeral_public_key_nonce, _) = self
+        let recipient_ephemeral_public_key_nonce = self
             .key_manager
             .get_next_key(TransactionKeyManagerBranch::MetadataEphemeralNonce.get_branch_key())
             .await?;
-        let (recipient_sender_offset_key_id, _) = self
+        let recipient_sender_offset = self
             .key_manager
             .get_next_key(TransactionKeyManagerBranch::SenderOffset.get_branch_key())
             .await?;
         let recipient_details = RecipientDetails {
             recipient_output_features,
             recipient_script,
-            recipient_sender_offset_key_id,
+            recipient_sender_offset_key_id: recipient_sender_offset.key_id,
             recipient_covenant,
             recipient_minimum_value_promise,
-            recipient_ephemeral_public_key_nonce,
+            recipient_ephemeral_public_key_nonce: recipient_ephemeral_public_key_nonce.key_id,
             amount,
         };
         self.recipient = Some(recipient_details);
@@ -181,13 +181,13 @@ where KM: TransactionKeyManagerInterface
 
     /// Adds an input to the transaction.
     pub async fn with_input(&mut self, input: WalletOutput) -> Result<&mut Self, KeyManagerServiceError> {
-        let (nonce_id, _) = self
+        let nonce = self
             .key_manager
             .get_next_key(TransactionKeyManagerBranch::KernelNonce.get_branch_key())
             .await?;
         let pair = OutputPair {
             output: input,
-            kernel_nonce: nonce_id,
+            kernel_nonce: nonce.key_id,
             sender_offset_key_id: None,
         };
         self.inputs.push(pair);
@@ -200,13 +200,13 @@ where KM: TransactionKeyManagerInterface
         output: WalletOutput,
         sender_offset_key_id: TariKeyId,
     ) -> Result<&mut Self, KeyManagerServiceError> {
-        let (nonce_id, _) = self
+        let nonce = self
             .key_manager
             .get_next_key(TransactionKeyManagerBranch::KernelNonce.get_branch_key())
             .await?;
         let pair = OutputPair {
             output,
-            kernel_nonce: nonce_id,
+            kernel_nonce: nonce.key_id,
             sender_offset_key_id: Some(sender_offset_key_id),
         };
         self.sender_custom_outputs.push(pair);
@@ -220,11 +220,11 @@ where KM: TransactionKeyManagerInterface
         change_script: TariScript,
         change_input_data: ExecutionStack,
         change_script_key_id: TariKeyId,
-        change_spending_key_id: TariKeyId,
+        change_mask_key_id: TariKeyId,
         change_covenant: Covenant,
     ) -> &mut Self {
         let details = ChangeDetails {
-            change_spending_key_id,
+            change_mask_key_id,
             change_script,
             change_input_data,
             change_script_key_id,
@@ -368,8 +368,8 @@ where KM: TransactionKeyManagerInterface
                         let change_data = self.change.as_ref().ok_or("Change data was not provided")?;
                         let change_script = change_data.change_script.clone();
                         let change_script_key_id = change_data.change_script_key_id.clone();
-                        let change_key_id = change_data.change_spending_key_id.clone();
-                        let (sender_offset_key_id, sender_offset_public_key) = self
+                        let change_key_id = change_data.change_mask_key_id.clone();
+                        let sender_offset_public_key = self
                             .key_manager
                             .get_next_key(TransactionKeyManagerBranch::SenderOffset.get_branch_key())
                             .await
@@ -408,7 +408,7 @@ where KM: TransactionKeyManagerInterface
                             .get_metadata_signature(
                                 &change_key_id,
                                 &v.into(),
-                                &sender_offset_key_id,
+                                &sender_offset_public_key.key_id,
                                 &output_version,
                                 &metadata_message,
                                 features.range_proof_type,
@@ -423,7 +423,7 @@ where KM: TransactionKeyManagerInterface
                             change_script,
                             input_data,
                             change_script_key_id,
-                            sender_offset_public_key.clone(),
+                            sender_offset_public_key.key.clone(),
                             metadata_sig,
                             0,
                             covenant,
@@ -437,7 +437,7 @@ where KM: TransactionKeyManagerInterface
                         Ok((
                             fee_without_change + change_fee,
                             v,
-                            Some((change_wallet_output, sender_offset_key_id)),
+                            Some((change_wallet_output, sender_offset_public_key.key_id)),
                         ))
                     },
                 }
@@ -509,7 +509,7 @@ where KM: TransactionKeyManagerInterface
                 if self.sender_custom_outputs.len() >= MAX_TRANSACTION_OUTPUTS {
                     return self.build_err("Too many outputs in transaction");
                 }
-                let (nonce_id, _) = match self
+                let nonce = match self
                     .key_manager
                     .get_next_key(TransactionKeyManagerBranch::KernelNonce.get_branch_key())
                     .await
@@ -519,7 +519,7 @@ where KM: TransactionKeyManagerInterface
                 };
                 Some(OutputPair {
                     output,
-                    kernel_nonce: nonce_id,
+                    kernel_nonce: nonce.key_id,
                     sender_offset_key_id: Some(sender_offset_key_id),
                 })
             },
@@ -661,7 +661,7 @@ mod test {
             script!(Nop),
             Default::default(),
             change.script_key_id.clone(),
-            change.spend_key_id.clone(),
+            change.mask_key_id.clone(),
             Covenant::default(),
         );
         let result = builder.build().await.unwrap();
@@ -846,7 +846,7 @@ mod test {
                 script!(Nop),
                 inputs!(change.script_key_pk),
                 change.script_key_id.clone(),
-                change.spend_key_id.clone(),
+                change.mask_key_id.clone(),
                 Covenant::default(),
             )
             .with_fee_per_gram(MicroMinotari(1))
@@ -895,7 +895,7 @@ mod test {
                 script!(Nop),
                 inputs!(change.script_key_pk),
                 change.script_key_id.clone(),
-                change.spend_key_id.clone(),
+                change.mask_key_id.clone(),
                 Covenant::default(),
             )
             .with_fee_per_gram(MicroMinotari(1))
@@ -961,7 +961,7 @@ mod test {
                 script!(Nop),
                 inputs!(change.script_key_pk),
                 change.script_key_id.clone(),
-                change.spend_key_id.clone(),
+                change.mask_key_id.clone(),
                 Covenant::default(),
             )
             .with_fee_per_gram(fee_per_gram)

--- a/base_layer/core/src/transactions/transaction_protocol/transaction_initializer.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/transaction_initializer.rs
@@ -369,7 +369,7 @@ where KM: TransactionKeyManagerInterface
                         let change_script = change_data.change_script.clone();
                         let change_script_key_id = change_data.change_script_key_id.clone();
                         let change_key_id = change_data.change_commitment_mask_key_id.clone();
-                        let sender_offset_public_key = self
+                        let sender_offset_public = self
                             .key_manager
                             .get_next_key(TransactionKeyManagerBranch::SenderOffset.get_branch_key())
                             .await
@@ -408,7 +408,7 @@ where KM: TransactionKeyManagerInterface
                             .get_metadata_signature(
                                 &change_key_id,
                                 &v.into(),
-                                &sender_offset_public_key.key_id,
+                                &sender_offset_public.key_id,
                                 &output_version,
                                 &metadata_message,
                                 features.range_proof_type,
@@ -423,7 +423,7 @@ where KM: TransactionKeyManagerInterface
                             change_script,
                             input_data,
                             change_script_key_id,
-                            sender_offset_public_key.key.clone(),
+                            sender_offset_public.pub_key.clone(),
                             metadata_sig,
                             0,
                             covenant,
@@ -437,7 +437,7 @@ where KM: TransactionKeyManagerInterface
                         Ok((
                             fee_without_change + change_fee,
                             v,
-                            Some((change_wallet_output, sender_offset_public_key.key_id)),
+                            Some((change_wallet_output, sender_offset_public.key_id)),
                         ))
                     },
                 }

--- a/base_layer/core/src/validation/block_body/test.rs
+++ b/base_layer/core/src/validation/block_body/test.rs
@@ -238,7 +238,7 @@ async fn it_allows_multiple_coinbases() {
     let (blockchain, validator) = setup(true).await;
 
     let (mut block, coinbase) = blockchain.create_unmined_block(block_spec!("A1", parent: "GB")).await;
-    let spend_key_id = KeyId::Managed {
+    let commitment_mask_key = KeyId::Managed {
         branch: TransactionKeyManagerBranch::CommitmentMask.get_branch_key(),
         index: 42,
     };
@@ -246,7 +246,7 @@ async fn it_allows_multiple_coinbases() {
     let (_, coinbase_output) = CoinbaseBuilder::new(blockchain.km.clone())
         .with_block_height(1)
         .with_fees(0.into())
-        .with_spend_key_id(spend_key_id.clone())
+        .with_commitment_mask_id(commitment_mask_key.clone())
         .with_encryption_key_id(TariKeyId::default())
         .with_sender_offset_key_id(TariKeyId::default())
         .with_script_key_id(TariKeyId::default())

--- a/base_layer/core/tests/helpers/block_builders.rs
+++ b/base_layer/core/tests/helpers/block_builders.rs
@@ -65,7 +65,10 @@ pub async fn create_coinbase(
     key_manager: &MemoryDbKeyManager,
 ) -> (TransactionOutput, TransactionKernel, WalletOutput) {
     let p = TestParams::new(key_manager).await;
-    let public_exess = key_manager.get_public_key_at_key_id(&p.mask_key_id).await.unwrap();
+    let public_exess = key_manager
+        .get_public_key_at_key_id(&p.commitment_mask_key_id)
+        .await
+        .unwrap();
     let nonce = key_manager
         .get_next_key(TransactionKeyManagerBranch::KernelNonce.get_branch_key())
         .await
@@ -83,7 +86,7 @@ pub async fn create_coinbase(
 
     let sig = key_manager
         .get_partial_txo_kernel_signature(
-            &p.mask_key_id,
+            &p.commitment_mask_key_id,
             &nonce.key_id,
             &nonce.key,
             &public_exess,

--- a/base_layer/core/tests/helpers/block_builders.rs
+++ b/base_layer/core/tests/helpers/block_builders.rs
@@ -65,8 +65,8 @@ pub async fn create_coinbase(
     key_manager: &MemoryDbKeyManager,
 ) -> (TransactionOutput, TransactionKernel, WalletOutput) {
     let p = TestParams::new(key_manager).await;
-    let public_exess = key_manager.get_public_key_at_key_id(&p.spend_key_id).await.unwrap();
-    let (nonce, public_nonce) = key_manager
+    let public_exess = key_manager.get_public_key_at_key_id(&p.mask_key_id).await.unwrap();
+    let nonce = key_manager
         .get_next_key(TransactionKeyManagerBranch::KernelNonce.get_branch_key())
         .await
         .unwrap();
@@ -83,9 +83,9 @@ pub async fn create_coinbase(
 
     let sig = key_manager
         .get_partial_txo_kernel_signature(
-            &p.spend_key_id,
-            &nonce,
-            &public_nonce,
+            &p.mask_key_id,
+            &nonce.key_id,
+            &nonce.key,
             &public_exess,
             &TransactionKernelVersion::get_current_version(),
             &kernel_message,

--- a/base_layer/core/tests/helpers/block_builders.rs
+++ b/base_layer/core/tests/helpers/block_builders.rs
@@ -88,7 +88,7 @@ pub async fn create_coinbase(
         .get_partial_txo_kernel_signature(
             &p.commitment_mask_key_id,
             &nonce.key_id,
-            &nonce.key,
+            &nonce.pub_key,
             &public_exess,
             &TransactionKernelVersion::get_current_version(),
             &kernel_message,

--- a/base_layer/core/tests/tests/block_validation.rs
+++ b/base_layer/core/tests/tests/block_validation.rs
@@ -283,7 +283,7 @@ async fn inputs_are_not_malleable() {
     let mut malicious_test_params = TestParams::new(&blockchain.key_manager).await;
 
     // Oh noes - they've managed to get hold of the private script and spend keys
-    malicious_test_params.spend_key_id = spent_output.spending_key_id;
+    malicious_test_params.mask_key_id = spent_output.spending_key_id;
     let modified_so = blockchain
         .key_manager
         .get_script_offset(&vec![spent_output.script_key_id.clone()], &vec![malicious_test_params

--- a/base_layer/core/tests/tests/block_validation.rs
+++ b/base_layer/core/tests/tests/block_validation.rs
@@ -283,7 +283,7 @@ async fn inputs_are_not_malleable() {
     let mut malicious_test_params = TestParams::new(&blockchain.key_manager).await;
 
     // Oh noes - they've managed to get hold of the private script and spend keys
-    malicious_test_params.mask_key_id = spent_output.spending_key_id;
+    malicious_test_params.commitment_mask_key_id = spent_output.spending_key_id;
     let modified_so = blockchain
         .key_manager
         .get_script_offset(&vec![spent_output.script_key_id.clone()], &vec![malicious_test_params

--- a/base_layer/core/tests/tests/mempool.rs
+++ b/base_layer/core/tests/tests/mempool.rs
@@ -1219,17 +1219,17 @@ async fn consensus_validation_large_tx() {
     let amount_per_output = (amount - fee) / output_count as u64;
     let amount_for_last_output = (amount - fee) - amount_per_output * (output_count as u64 - 1);
     let mut wallet_outputs = Vec::with_capacity(output_count);
-    let (input_kernel_nonce, mut pub_nonce) = key_manager
+    let input_kernel_nonce = key_manager
         .get_next_key(TransactionKeyManagerBranch::KernelNonce.get_branch_key())
         .await
         .unwrap();
     let mut pub_excess = PublicKey::default() -
         key_manager
-            .get_txo_kernel_signature_excess_with_offset(&input.spending_key_id, &input_kernel_nonce)
+            .get_txo_kernel_signature_excess_with_offset(&input.spending_key_id, &input_kernel_nonce.key_id)
             .await
             .unwrap();
     let mut sender_offsets = Vec::new();
-
+    let mut pub_nonce = input_kernel_nonce.key.clone();
     for i in 0..output_count {
         let test_params = TestParams::new(&key_manager).await;
         let output_amount = if i < output_count - 1 {
@@ -1294,13 +1294,13 @@ async fn consensus_validation_large_tx() {
 
     offset = &offset -
         &key_manager
-            .get_txo_private_kernel_offset(&input.spending_key_id, &input_kernel_nonce)
+            .get_txo_private_kernel_offset(&input.spending_key_id, &input_kernel_nonce.key_id)
             .await
             .unwrap();
     let sig = key_manager
         .get_partial_txo_kernel_signature(
             &input.spending_key_id,
-            &input_kernel_nonce,
+            &input_kernel_nonce.key_id,
             &pub_nonce,
             &pub_excess,
             &kernel_version,
@@ -1387,13 +1387,13 @@ async fn validation_reject_min_fee() {
 
     let fee = 0.into();
 
-    let (input_kernel_nonce, mut pub_nonce) = key_manager
+    let input_kernel_nonce = key_manager
         .get_next_key(TransactionKeyManagerBranch::KernelNonce.get_branch_key())
         .await
         .unwrap();
     let mut pub_excess = PublicKey::default() -
         key_manager
-            .get_txo_kernel_signature_excess_with_offset(&input.spending_key_id, &input_kernel_nonce)
+            .get_txo_kernel_signature_excess_with_offset(&input.spending_key_id, &input_kernel_nonce.key_id)
             .await
             .unwrap();
     let mut sender_offsets = Vec::new();
@@ -1416,7 +1416,7 @@ async fn validation_reject_min_fee() {
             )
             .await
             .unwrap();
-    pub_nonce = pub_nonce + test_params.kernel_nonce_key_pk;
+    let pub_nonce = input_kernel_nonce.key + test_params.kernel_nonce_key_pk;
     sender_offsets.push(test_params.sender_offset_key_id.clone());
 
     let mut agg_sig = Signature::default();
@@ -1454,13 +1454,13 @@ async fn validation_reject_min_fee() {
 
     offset = &offset -
         &key_manager
-            .get_txo_private_kernel_offset(&input.spending_key_id, &input_kernel_nonce)
+            .get_txo_private_kernel_offset(&input.spending_key_id, &input_kernel_nonce.key_id)
             .await
             .unwrap();
     let sig = key_manager
         .get_partial_txo_kernel_signature(
             &input.spending_key_id,
-            &input_kernel_nonce,
+            &input_kernel_nonce.key_id,
             &pub_nonce,
             &pub_excess,
             &kernel_version,

--- a/base_layer/core/tests/tests/mempool.rs
+++ b/base_layer/core/tests/tests/mempool.rs
@@ -1229,7 +1229,7 @@ async fn consensus_validation_large_tx() {
             .await
             .unwrap();
     let mut sender_offsets = Vec::new();
-    let mut pub_nonce = input_kernel_nonce.key.clone();
+    let mut pub_nonce = input_kernel_nonce.pub_key.clone();
     for i in 0..output_count {
         let test_params = TestParams::new(&key_manager).await;
         let output_amount = if i < output_count - 1 {
@@ -1416,7 +1416,7 @@ async fn validation_reject_min_fee() {
             )
             .await
             .unwrap();
-    let pub_nonce = input_kernel_nonce.key + test_params.kernel_nonce_key_pk;
+    let pub_nonce = input_kernel_nonce.pub_key + test_params.kernel_nonce_key_pk;
     sender_offsets.push(test_params.sender_offset_key_id.clone());
 
     let mut agg_sig = Signature::default();

--- a/base_layer/core/tests/tests/node_comms_interface.rs
+++ b/base_layer/core/tests/tests/node_comms_interface.rs
@@ -301,7 +301,7 @@ async fn initialize_sender_transaction_protocol_for_overflow_test(
             .get_next_key(TransactionKeyManagerBranch::CommitmentMask.get_branch_key())
             .await
             .unwrap();
-        let sender_offset_key = key_manager
+        let sender_offset = key_manager
             .get_next_key(TransactionKeyManagerBranch::SenderOffset.get_branch_key())
             .await
             .unwrap();
@@ -330,16 +330,16 @@ async fn initialize_sender_transaction_protocol_for_overflow_test(
             .with_input_data(input_data)
             .with_covenant(txn_schema.covenant.clone())
             .with_version(version)
-            .with_sender_offset_public_key(sender_offset_key.key)
+            .with_sender_offset_public_key(sender_offset.pub_key)
             .with_script_key(script_key_id.clone())
-            .sign_as_sender_and_receiver(key_manager, &sender_offset_key.key_id)
+            .sign_as_sender_and_receiver(key_manager, &sender_offset.key_id)
             .await
             .unwrap()
             .try_build(key_manager)
             .await
             .unwrap();
 
-        stx_builder.with_output(output, sender_offset_key.key_id).await.unwrap();
+        stx_builder.with_output(output, sender_offset.key_id).await.unwrap();
     }
     for mut utxo in txn_schema.to_outputs {
         let sender_offset_key = key_manager

--- a/base_layer/core/tests/tests/node_comms_interface.rs
+++ b/base_layer/core/tests/tests/node_comms_interface.rs
@@ -289,7 +289,7 @@ async fn initialize_sender_transaction_protocol_for_overflow_test(
             script!(PushPubKey(Box::new(script_public_key))),
             ExecutionStack::default(),
             change.script_key_id,
-            change.mask_key_id,
+            change.commitment_mask_key_id,
             Covenant::default(),
         );
 
@@ -297,7 +297,7 @@ async fn initialize_sender_transaction_protocol_for_overflow_test(
         stx_builder.with_input(tx_input.clone()).await.unwrap();
     }
     for tx_output in txn_schema.to {
-        let mask_key = key_manager
+        let commitment_mask_key = key_manager
             .get_next_key(TransactionKeyManagerBranch::CommitmentMask.get_branch_key())
             .await
             .unwrap();
@@ -309,7 +309,7 @@ async fn initialize_sender_transaction_protocol_for_overflow_test(
         let script_key_id = KeyId::Derived {
             branch: TransactionKeyManagerBranch::CommitmentMask.get_branch_key(),
             label: TransactionKeyManagerLabel::ScriptKey.get_branch_key(),
-            index: mask_key.key_id.managed_index().unwrap(),
+            index: commitment_mask_key.key_id.managed_index().unwrap(),
         };
 
         let script_public_key = key_manager.get_public_key_at_key_id(&script_key_id).await.unwrap();
@@ -321,7 +321,7 @@ async fn initialize_sender_transaction_protocol_for_overflow_test(
             Some(data) => data,
             None => TransactionOutputVersion::get_current_version(),
         };
-        let output = WalletOutputBuilder::new(tx_output, mask_key.key_id)
+        let output = WalletOutputBuilder::new(tx_output, commitment_mask_key.key_id)
             .with_features(txn_schema.features.clone())
             .with_script(txn_schema.script.clone())
             .encrypt_data_for_recovery(key_manager, None, PaymentId::Empty)

--- a/base_layer/key_manager/src/key_manager_service/handle.rs
+++ b/base_layer/key_manager/src/key_manager_service/handle.rs
@@ -29,6 +29,7 @@ use crate::{
     cipher_seed::CipherSeed,
     key_manager_service::{
         error::KeyManagerServiceError,
+        interface::KeyAndId,
         storage::database::{KeyManagerBackend, KeyManagerDatabase},
         AddResult,
         KeyId,
@@ -76,7 +77,7 @@ where
             .add_key_manager_branch(&branch.into())
     }
 
-    async fn get_next_key<T: Into<String> + Send>(&self, branch: T) -> Result<(KeyId<PK>, PK), KeyManagerServiceError> {
+    async fn get_next_key<T: Into<String> + Send>(&self, branch: T) -> Result<KeyAndId<PK>, KeyManagerServiceError> {
         (*self.key_manager_inner)
             .read()
             .await
@@ -85,7 +86,7 @@ where
     }
 
     /// Gets a randomly generated key, which the key manager will manage
-    async fn get_random_key(&self) -> Result<(KeyId<PK>, PK), KeyManagerServiceError> {
+    async fn get_random_key(&self) -> Result<KeyAndId<PK>, KeyManagerServiceError> {
         (*self.key_manager_inner).read().await.get_random_key().await
     }
 

--- a/base_layer/key_manager/src/key_manager_service/interface.rs
+++ b/base_layer/key_manager/src/key_manager_service/interface.rs
@@ -58,7 +58,7 @@ pub enum AddResult {
 
 #[derive(Debug, Eq, PartialEq)]
 pub struct KeyAndId<PK> {
-    pub key: PK,
+    pub pub_key: PK,
     pub key_id: KeyId<PK>,
 }
 

--- a/base_layer/key_manager/src/key_manager_service/interface.rs
+++ b/base_layer/key_manager/src/key_manager_service/interface.rs
@@ -56,6 +56,12 @@ pub enum AddResult {
     AlreadyExists,
 }
 
+#[derive(Debug, Eq, PartialEq)]
+pub struct KeyAndId<PK> {
+    pub key: PK,
+    pub key_id: KeyId<PK>,
+}
+
 #[derive(Default, Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub enum KeyId<PK> {
     Managed {
@@ -192,10 +198,10 @@ where
     async fn add_new_branch<T: Into<String> + Send>(&self, branch: T) -> Result<AddResult, KeyManagerServiceError>;
 
     /// Gets the next key id from the branch. This will auto-increment the branch key index by 1
-    async fn get_next_key<T: Into<String> + Send>(&self, branch: T) -> Result<(KeyId<PK>, PK), KeyManagerServiceError>;
+    async fn get_next_key<T: Into<String> + Send>(&self, branch: T) -> Result<KeyAndId<PK>, KeyManagerServiceError>;
 
     /// Gets a randomly generated key, which the key manager will manage
-    async fn get_random_key(&self) -> Result<(KeyId<PK>, PK), KeyManagerServiceError>;
+    async fn get_random_key(&self) -> Result<KeyAndId<PK>, KeyManagerServiceError>;
 
     /// Gets the fixed key id from the branch. This will use the branch key with index 0
     async fn get_static_key<T: Into<String> + Send>(&self, branch: T) -> Result<KeyId<PK>, KeyManagerServiceError>;

--- a/base_layer/key_manager/src/key_manager_service/mod.rs
+++ b/base_layer/key_manager/src/key_manager_service/mod.rs
@@ -51,4 +51,4 @@ pub use service::KeyManagerInner;
 mod interface;
 pub use interface::KeyId;
 pub mod storage;
-pub use interface::{AddResult, KeyManagerBranch, KeyManagerInterface};
+pub use interface::{AddResult, KeyAndId, KeyManagerBranch, KeyManagerInterface};

--- a/base_layer/key_manager/src/key_manager_service/service.rs
+++ b/base_layer/key_manager/src/key_manager_service/service.rs
@@ -38,6 +38,7 @@ use crate::{
     key_manager::KeyManager,
     key_manager_service::{
         error::KeyManagerServiceError,
+        interface::KeyAndId,
         storage::database::{KeyManagerBackend, KeyManagerDatabase, KeyManagerState},
         AddResult,
         KeyDigest,
@@ -97,7 +98,7 @@ where
         Ok(result)
     }
 
-    pub async fn get_next_key(&self, branch: &str) -> Result<(KeyId<PK>, PK), KeyManagerServiceError> {
+    pub async fn get_next_key(&self, branch: &str) -> Result<KeyAndId<PK>, KeyManagerServiceError> {
         let mut km = self
             .key_managers
             .get(branch)
@@ -107,20 +108,24 @@ where
         self.db.increment_key_index(branch)?;
         let index = km.increment_key_index(1);
         let key = km.derive_public_key(index)?.key;
-        Ok((
-            KeyId::Managed {
+
+        Ok(KeyAndId {
+            key_id: KeyId::Managed {
                 branch: branch.to_string(),
                 index,
             },
             key,
-        ))
+        })
     }
 
-    pub async fn get_random_key(&self) -> Result<(KeyId<PK>, PK), KeyManagerServiceError> {
+    pub async fn get_random_key(&self) -> Result<KeyAndId<PK>, KeyManagerServiceError> {
         let random_private_key = PK::K::random(&mut OsRng);
         let key_id = self.import_key(random_private_key).await?;
         let public_key = self.get_public_key_at_key_id(&key_id).await?;
-        Ok((key_id, public_key))
+        Ok(KeyAndId {
+            key_id,
+            key: public_key,
+        })
     }
 
     pub async fn get_static_key(&self, branch: &str) -> Result<KeyId<PK>, KeyManagerServiceError> {

--- a/base_layer/key_manager/src/key_manager_service/service.rs
+++ b/base_layer/key_manager/src/key_manager_service/service.rs
@@ -114,7 +114,7 @@ where
                 branch: branch.to_string(),
                 index,
             },
-            key,
+            pub_key: key,
         })
     }
 
@@ -124,7 +124,7 @@ where
         let public_key = self.get_public_key_at_key_id(&key_id).await?;
         Ok(KeyAndId {
             key_id,
-            key: public_key,
+            pub_key: public_key,
         })
     }
 

--- a/base_layer/wallet/src/output_manager_service/recovery/standard_outputs_recoverer.rs
+++ b/base_layer/wallet/src/output_manager_service/recovery/standard_outputs_recoverer.rs
@@ -227,7 +227,7 @@ where
                 if let Some(Opcode::PushPubKey(public_key)) = script.opcode(0) {
                     let result = self
                         .master_key_manager
-                        .find_script_key_id_from_spend_key_id(spending_key, Some(public_key))
+                        .find_script_key_id_from_commitment_mask_key_id(spending_key, Some(public_key))
                         .await?;
                     if let Some(script_key_id) = result {
                         (ExecutionStack::default(), script_key_id)

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -749,7 +749,7 @@ where
         let script = if single_round_sender_data.script == script!(Nop) {
             single_round_sender_data.script.clone()
         } else if single_round_sender_data.script == script!(PushPubKey(Box::default())) {
-            script!(PushPubKey(Box::new(script_public_key.key.clone())))
+            script!(PushPubKey(Box::new(script_public_key.pub_key.clone())))
         } else {
             return Err(OutputManagerError::InvalidScriptHash);
         };
@@ -996,7 +996,7 @@ where
             .get_next_commitment_mask_and_script_key()
             .await?;
         builder.with_change_data(
-            script!(PushPubKey(Box::new(change_script_key.key.clone()))),
+            script!(PushPubKey(Box::new(change_script_key.pub_key.clone()))),
             ExecutionStack::default(),
             change_script_key.key_id,
             change_commitment_mask_key.key_id,
@@ -1103,7 +1103,7 @@ where
                 .get_next_commitment_mask_and_script_key()
                 .await?;
             builder.with_change_data(
-                script!(PushPubKey(Box::new(change_script_key.key))),
+                script!(PushPubKey(Box::new(change_script_key.pub_key))),
                 ExecutionStack::default(),
                 change_script_key.key_id,
                 change_commitment_mask_key.key_id,
@@ -1250,7 +1250,10 @@ where
                         &script_challange,
                     )
                     .await?;
-                script_input_shares.insert(self.resources.key_manager.get_spend_key().await?.key, self_signature);
+                script_input_shares.insert(
+                    self.resources.key_manager.get_spend_key().await?.pub_key,
+                    self_signature,
+                );
 
                 // the order here is important, we need to add the signatures in the same order as public keys where
                 // added to the script originally
@@ -1258,7 +1261,7 @@ where
                     if let Some(signature) = script_input_shares.get(&key) {
                         script_signatures.push(StackItem::Signature(signature.clone()));
                         // our own key should not be added yet, it will be added with the script signing
-                        if key != self.resources.key_manager.get_spend_key().await?.key {
+                        if key != self.resources.key_manager.get_spend_key().await?.pub_key {
                             aggregated_script_public_key_shares = aggregated_script_public_key_shares + key;
                         }
                     }
@@ -1562,7 +1565,7 @@ where
             .get_next_commitment_mask_and_script_key()
             .await?;
         builder.with_change_data(
-            script!(PushPubKey(Box::new(change_script_public_key.key.clone()))),
+            script!(PushPubKey(Box::new(change_script_public_key.pub_key.clone()))),
             ExecutionStack::default(),
             change_script_public_key.key_id.clone(),
             change_commitment_mask_key_id.key_id,
@@ -2196,7 +2199,7 @@ where
                 .get_next_commitment_mask_and_script_key()
                 .await?;
             tx_builder.with_change_data(
-                script!(PushPubKey(Box::new(change_script.key))),
+                script!(PushPubKey(Box::new(change_script.pub_key))),
                 ExecutionStack::default(),
                 change_script.key_id,
                 change_mask.key_id,
@@ -2277,7 +2280,7 @@ where
             .key_manager
             .get_next_commitment_mask_and_script_key()
             .await?;
-        let script = script!(PushPubKey(Box::new(script_key.key.clone())));
+        let script = script!(PushPubKey(Box::new(script_key.pub_key.clone())));
 
         let encrypted_data = self
             .resources
@@ -2319,7 +2322,7 @@ where
                 script,
                 ExecutionStack::default(),
                 script_key.key_id,
-                sender_offset.key,
+                sender_offset.pub_key,
                 metadata_signature,
                 0,
                 covenant,
@@ -2535,7 +2538,7 @@ where
                     .get_next_commitment_mask_and_script_key()
                     .await?;
                 builder.with_change_data(
-                    script!(PushPubKey(Box::new(change_script_key.key.clone()))),
+                    script!(PushPubKey(Box::new(change_script_key.pub_key.clone()))),
                     ExecutionStack::default(),
                     change_script_key.key_id,
                     change_commitment_mask_key.key_id,
@@ -2619,7 +2622,7 @@ where
             .get_next_commitment_mask_and_script_key()
             .await?;
         builder.with_change_data(
-            script!(PushPubKey(Box::new(change_script_key.key.clone()))),
+            script!(PushPubKey(Box::new(change_script_key.pub_key.clone()))),
             ExecutionStack::default(),
             change_script_key.key_id,
             change_commitment_mask_key.key_id,
@@ -2727,7 +2730,7 @@ where
                         .get_diffie_hellman_stealth_domain_hasher(&view_key.key_id, &output.sender_offset_public_key)
                         .await?;
                     let script_spending_key =
-                        stealth_address_script_spending_key(&stealth_address_hasher, &spend_key.key);
+                        stealth_address_script_spending_key(&stealth_address_hasher, &spend_key.pub_key);
                     if &script_spending_key != scanned_pk.as_ref() {
                         continue;
                     }

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_receive_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_receive_protocol.rs
@@ -435,7 +435,7 @@ where
             let completed_transaction = CompletedTransaction::new(
                 self.id,
                 self.source_address.clone(),
-                self.resources.tari_address.clone(),
+                self.resources.interactive_tari_address.clone(),
                 inbound_tx.amount,
                 finalized_transaction
                     .body

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_send_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_send_protocol.rs
@@ -593,7 +593,7 @@ where
 
         let completed_transaction = CompletedTransaction::new(
             tx_id,
-            self.resources.tari_address.clone(),
+            self.resources.interactive_tari_address.clone(),
             outbound_tx.destination_address,
             outbound_tx.amount,
             outbound_tx.fee,

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -259,9 +259,22 @@ where
     ) -> Result<Self, TransactionServiceError> {
         // Collect the resources that all protocols will need so that they can be neatly cloned as the protocols are
         // spawned.
-        let (_view_key_id, view_key) = core_key_manager_service.get_view_key().await?;
-        let tari_address =
-            TariAddress::new_dual_address_with_default_features(view_key, node_identity.public_key().clone(), network);
+        let view_key = core_key_manager_service.get_view_key().await?;
+        let spend_key = core_key_manager_service.get_spend_key().await?;
+        let comms_key = core_key_manager_service.get_comms_key().await?;
+        let interactive_features = if spend_key == comms_key {
+            TariAddressFeatures::create_interactive_and_one_sided()
+        } else {
+            TariAddressFeatures::create_one_sided_only()
+        };
+        let one_sided_tari_address = TariAddress::new_dual_address(
+            view_key.key.clone(),
+            comms_key.key,
+            network,
+            TariAddressFeatures::create_one_sided_only(),
+        );
+        let interactive_tari_address =
+            TariAddress::new_dual_address(view_key.key, spend_key.key, network, interactive_features);
         let resources = TransactionServiceResources {
             db: db.clone(),
             output_manager_service,
@@ -269,7 +282,8 @@ where
             outbound_message_service,
             connectivity,
             event_publisher: event_publisher.clone(),
-            tari_address,
+            interactive_tari_address,
+            one_sided_tari_address,
             node_identity: node_identity.clone(),
             factories,
             config: config.clone(),
@@ -1077,7 +1091,7 @@ where
         reply_channel: oneshot::Sender<Result<TransactionServiceResponse, TransactionServiceError>>,
     ) -> Result<(), TransactionServiceError> {
         let tx_id = TxId::new_random();
-        if destination.network() != self.resources.tari_address.network() {
+        if destination.network() != self.resources.interactive_tari_address.network() {
             let _result = reply_channel
                 .send(Err(TransactionServiceError::InvalidNetwork))
                 .inspect_err(|_| {
@@ -1086,7 +1100,14 @@ where
             return Err(TransactionServiceError::InvalidNetwork);
         }
         // If we're paying ourselves, let's complete and submit the transaction immediately
-        if &self.resources.transaction_key_manager_service.get_comms_key().await?.1 == destination.comms_public_key() {
+        if &self
+            .resources
+            .transaction_key_manager_service
+            .get_comms_key()
+            .await?
+            .key ==
+            destination.comms_public_key()
+        {
             debug!(
                 target: LOG_TARGET,
                 "Received transaction with spend-to-self transaction"
@@ -1107,8 +1128,8 @@ where
                 transaction_broadcast_join_handles,
                 CompletedTransaction::new(
                     tx_id,
-                    self.resources.tari_address.clone(),
-                    self.resources.tari_address.clone(),
+                    self.resources.interactive_tari_address.clone(),
+                    self.resources.interactive_tari_address.clone(),
                     amount,
                     fee,
                     transaction,
@@ -1346,8 +1367,8 @@ where
             transaction_broadcast_join_handles,
             CompletedTransaction::new(
                 tx_id,
-                self.resources.tari_address.clone(),
-                self.resources.tari_address.clone(),
+                self.resources.interactive_tari_address.clone(),
+                self.resources.interactive_tari_address.clone(),
                 amount,
                 fee,
                 tx.clone(),
@@ -1441,7 +1462,7 @@ where
             )) => {
                 let completed_tx = CompletedTransaction::new(
                     tx_id,
-                    self.resources.tari_address.clone(),
+                    self.resources.interactive_tari_address.clone(),
                     recipient_address,
                     amount,
                     fee,
@@ -1700,7 +1721,13 @@ where
             .with_input_data(ExecutionStack::default())
             .with_covenant(covenant)
             .with_sender_offset_public_key(sender_offset_public_key)
-            .with_script_key(self.resources.transaction_key_manager_service.get_spend_key().await?.0)
+            .with_script_key(
+                self.resources
+                    .transaction_key_manager_service
+                    .get_spend_key()
+                    .await?
+                    .key_id,
+            )
             .with_minimum_value_promise(minimum_value_promise)
             .sign_as_sender_and_receiver(
                 &self.resources.transaction_key_manager_service,
@@ -1763,7 +1790,7 @@ where
             transaction_broadcast_join_handles,
             CompletedTransaction::new(
                 tx_id,
-                self.resources.tari_address.clone(),
+                self.resources.interactive_tari_address.clone(),
                 destination,
                 amount,
                 fee,
@@ -1831,13 +1858,13 @@ where
         // This call is needed to advance the state from `SingleRoundMessageReady` to `SingleRoundMessageReady`,
         // but the returned value is not used. We have to wait until the sender transaction protocol creates a
         // sender_offset_private_key for us, so we can use it to create the shared secret
-        let (key, _) = self
+        let key = self
             .resources
             .transaction_key_manager_service
             .get_next_key(TransactionKeyManagerBranch::SenderOffsetLedger.get_branch_key())
             .await?;
 
-        stp.change_recipient_sender_offset_private_key(key)?;
+        stp.change_recipient_sender_offset_private_key(key.key_id)?;
         let _single_round_sender_data = stp
             .build_single_round_message(&self.resources.transaction_key_manager_service)
             .await
@@ -1998,7 +2025,7 @@ where
             transaction_broadcast_join_handles,
             CompletedTransaction::new(
                 tx_id,
-                self.resources.tari_address.clone(),
+                self.resources.one_sided_tari_address.clone(),
                 dest_address,
                 amount,
                 fee,
@@ -2035,7 +2062,7 @@ where
             JoinHandle<Result<TxId, TransactionServiceProtocolError<TxId>>>,
         >,
     ) -> Result<TxId, TransactionServiceError> {
-        if destination.network() != self.resources.tari_address.network() {
+        if destination.network() != self.resources.one_sided_tari_address.network() {
             return Err(TransactionServiceError::InvalidNetwork);
         }
         let dest_pubkey = destination.public_spend_key().clone();
@@ -2114,13 +2141,18 @@ where
             stp.get_single_round_message(&self.resources.transaction_key_manager_service)
                 .await?,
         );
-        let (spend_key_id, public_spend_key, _script_key_id, _) = self
+        let (mask_key, _) = self
             .resources
             .transaction_key_manager_service
             .get_next_spend_and_script_key_ids()
             .await?;
 
-        let recovery_key_id = self.resources.transaction_key_manager_service.get_view_key().await?.0;
+        let recovery_key_id = self
+            .resources
+            .transaction_key_manager_service
+            .get_view_key()
+            .await?
+            .key_id;
 
         let recovery_key_id = match claim_public_key {
             Some(ref claim_public_key) => {
@@ -2130,7 +2162,7 @@ where
                 let shared_secret = self
                     .resources
                     .transaction_key_manager_service
-                    .get_diffie_hellman_shared_secret(&spend_key_id, claim_public_key)
+                    .get_diffie_hellman_shared_secret(&mask_key.key_id, claim_public_key)
                     .await?;
                 let encryption_key = shared_secret_to_output_encryption_key(&shared_secret)?;
                 self.resources
@@ -2151,7 +2183,7 @@ where
                 tx_id,
                 TransactionServiceError::InvalidKeyId("Missing sender offset keyid".to_string()),
             ))?;
-        let output = WalletOutputBuilder::new(amount, spend_key_id.clone())
+        let output = WalletOutputBuilder::new(amount, mask_key.key_id.clone())
             .with_features(
                 sender_message
                     .single()
@@ -2217,7 +2249,7 @@ where
             ownership_proof = Some(
                 self.resources
                     .transaction_key_manager_service
-                    .generate_burn_proof(&spend_key_id, &amount.into(), &claim_public_key)
+                    .generate_burn_proof(&mask_key.key_id, &amount.into(), &claim_public_key)
                     .await?,
             );
         }
@@ -2255,7 +2287,7 @@ where
             transaction_broadcast_join_handles,
             CompletedTransaction::new(
                 tx_id,
-                self.resources.tari_address.clone(),
+                self.resources.interactive_tari_address.clone(),
                 TariAddress::default(),
                 amount,
                 fee,
@@ -2274,7 +2306,7 @@ where
 
         Ok((tx_id, BurntProof {
             // Key used to claim the burn on L2
-            reciprocal_claim_public_key: public_spend_key,
+            reciprocal_claim_public_key: mask_key.key,
             commitment,
             ownership_proof,
             range_proof,
@@ -2300,7 +2332,7 @@ where
         let output_features =
             OutputFeatures::for_validator_node_registration(validator_node_public_key, validator_node_signature);
         self.send_transaction(
-            self.resources.tari_address.clone(),
+            self.resources.interactive_tari_address.clone(),
             amount,
             selection_criteria,
             output_features,
@@ -2329,7 +2361,7 @@ where
         reply_channel: oneshot::Sender<Result<TransactionServiceResponse, TransactionServiceError>>,
     ) -> Result<(), TransactionServiceError> {
         self.send_transaction(
-            self.resources.tari_address.clone(),
+            self.resources.interactive_tari_address.clone(),
             0.into(),
             selection_criteria,
             OutputFeatures::for_template_registration(template_registration),
@@ -2361,7 +2393,7 @@ where
             JoinHandle<Result<TxId, TransactionServiceProtocolError<TxId>>>,
         >,
     ) -> Result<TxId, TransactionServiceError> {
-        if destination.network() != self.resources.tari_address.network() {
+        if destination.network() != self.resources.one_sided_tari_address.network() {
             return Err(TransactionServiceError::InvalidNetwork);
         }
 
@@ -2843,7 +2875,7 @@ where
             // interactive and its the same network
             let source_address = TariAddress::new_single_address(
                 source_pubkey,
-                self.resources.tari_address.network(),
+                self.resources.interactive_tari_address.network(),
                 TariAddressFeatures::INTERACTIVE,
             );
             let protocol = TransactionReceiveProtocol::new(
@@ -2903,7 +2935,7 @@ where
         // but we know its interactive, so make the view key 0, and the spend key the source public key.
         let source_address = TariAddress::new_single_address(
             source_pubkey,
-            self.resources.tari_address.network(),
+            self.resources.interactive_tari_address.network(),
             TariAddressFeatures::INTERACTIVE,
         );
         let sender = match self.finalized_transaction_senders.get_mut(&tx_id) {
@@ -3371,7 +3403,7 @@ where
             tx_id,
             value,
             source_address,
-            self.resources.tari_address.clone(),
+            self.resources.interactive_tari_address.clone(),
             message,
             import_status.clone(),
             current_height,
@@ -3470,8 +3502,8 @@ where
             transaction_broadcast_join_handles,
             CompletedTransaction::new(
                 tx_id,
-                self.resources.tari_address.clone(),
-                self.resources.tari_address.clone(),
+                self.resources.interactive_tari_address.clone(),
+                self.resources.interactive_tari_address.clone(),
                 amount,
                 fee,
                 tx,
@@ -3512,7 +3544,8 @@ pub struct TransactionServiceResources<TBackend, TWalletConnectivity, TKeyManage
     pub outbound_message_service: OutboundMessageRequester,
     pub connectivity: TWalletConnectivity,
     pub event_publisher: TransactionEventSender,
-    pub tari_address: TariAddress,
+    pub interactive_tari_address: TariAddress,
+    pub one_sided_tari_address: TariAddress,
     pub node_identity: Arc<NodeIdentity>,
     pub consensus_manager: ConsensusManager,
     pub factories: CryptoFactories,

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -268,13 +268,13 @@ where
             TariAddressFeatures::create_one_sided_only()
         };
         let one_sided_tari_address = TariAddress::new_dual_address(
-            view_key.key.clone(),
-            comms_key.key,
+            view_key.pub_key.clone(),
+            comms_key.pub_key,
             network,
             TariAddressFeatures::create_one_sided_only(),
         );
         let interactive_tari_address =
-            TariAddress::new_dual_address(view_key.key, spend_key.key, network, interactive_features);
+            TariAddress::new_dual_address(view_key.pub_key, spend_key.pub_key, network, interactive_features);
         let resources = TransactionServiceResources {
             db: db.clone(),
             output_manager_service,
@@ -1105,7 +1105,7 @@ where
             .transaction_key_manager_service
             .get_comms_key()
             .await?
-            .key ==
+            .pub_key ==
             destination.comms_public_key()
         {
             debug!(
@@ -2306,7 +2306,7 @@ where
 
         Ok((tx_id, BurntProof {
             // Key used to claim the burn on L2
-            reciprocal_claim_public_key: commitment_mask_key.key,
+            reciprocal_claim_public_key: commitment_mask_key.pub_key,
             commitment,
             ownership_proof,
             range_proof,

--- a/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
@@ -2316,7 +2316,7 @@ mod test {
                 script!(Nop),
                 inputs!(change.script_key_pk),
                 change.script_key_id,
-                change.mask_key_id,
+                change.commitment_mask_key_id,
                 Default::default(),
             );
         let mut stp = builder.build().await.unwrap();

--- a/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
@@ -2316,7 +2316,7 @@ mod test {
                 script!(Nop),
                 inputs!(change.script_key_pk),
                 change.script_key_id,
-                change.spend_key_id,
+                change.mask_key_id,
                 Default::default(),
             );
         let mut stp = builder.build().await.unwrap();

--- a/base_layer/wallet/src/utxo_scanner_service/initializer.rs
+++ b/base_layer/wallet/src/utxo_scanner_service/initializer.rs
@@ -113,8 +113,8 @@ where
                 .await
                 .expect("Could not initialize UTXO scanner Service");
             let one_sided_tari_address = TariAddress::new_dual_address(
-                view_key.key,
-                spend_key.key,
+                view_key.pub_key,
+                spend_key.pub_key,
                 network,
                 TariAddressFeatures::create_one_sided_only(),
             );

--- a/base_layer/wallet/src/utxo_scanner_service/initializer.rs
+++ b/base_layer/wallet/src/utxo_scanner_service/initializer.rs
@@ -104,17 +104,17 @@ where
             let base_node_service_handle = handles.expect_handle::<BaseNodeServiceHandle>();
             let key_manager = handles.expect_handle::<TKeyManagerInterface>();
 
-            let (_view_key_id, view_key) = key_manager
+            let view_key = key_manager
                 .get_view_key()
                 .await
                 .expect("Could not initialize UTXO scanner Service");
-            let (_spend_key_id, spend_key) = key_manager
+            let spend_key = key_manager
                 .get_spend_key()
                 .await
                 .expect("Could not initialize UTXO scanner Service");
             let one_sided_tari_address = TariAddress::new_dual_address(
-                view_key,
-                spend_key,
+                view_key.key,
+                spend_key.key,
                 network,
                 TariAddressFeatures::create_one_sided_only(),
             );

--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -477,26 +477,26 @@ where
     }
 
     pub async fn get_wallet_interactive_address(&self) -> Result<TariAddress, KeyManagerServiceError> {
-        let (_view_key_id, view_key) = self.key_manager_service.get_view_key().await?;
-        let (_comms_key_id, comms_key) = self.key_manager_service.get_comms_key().await?;
+        let view_key = self.key_manager_service.get_view_key().await?;
+        let comms_key = self.key_manager_service.get_comms_key().await?;
         let features = match self.wallet_type {
-            WalletType::Software => TariAddressFeatures::default(),
-            WalletType::Ledger(_) | WalletType::Imported(_) => TariAddressFeatures::create_interactive_only(),
+            WalletType::DerivedKeys => TariAddressFeatures::default(),
+            WalletType::Ledger(_) | WalletType::ProvidedKeys(_) => TariAddressFeatures::create_interactive_only(),
         };
         Ok(TariAddress::new_dual_address(
-            view_key,
-            comms_key,
+            view_key.key,
+            comms_key.key,
             self.network.as_network(),
             features,
         ))
     }
 
     pub async fn get_wallet_one_sided_address(&self) -> Result<TariAddress, KeyManagerServiceError> {
-        let (_view_key_id, view_key) = self.key_manager_service.get_view_key().await?;
-        let (_spend_key_id, spend_key) = self.key_manager_service.get_spend_key().await?;
+        let view_key = self.key_manager_service.get_view_key().await?;
+        let spend_key = self.key_manager_service.get_spend_key().await?;
         Ok(TariAddress::new_dual_address(
-            view_key,
-            spend_key,
+            view_key.key,
+            spend_key.key,
             self.network.as_network(),
             TariAddressFeatures::create_one_sided_only(),
         ))

--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -484,8 +484,8 @@ where
             WalletType::Ledger(_) | WalletType::ProvidedKeys(_) => TariAddressFeatures::create_interactive_only(),
         };
         Ok(TariAddress::new_dual_address(
-            view_key.key,
-            comms_key.key,
+            view_key.pub_key,
+            comms_key.pub_key,
             self.network.as_network(),
             features,
         ))
@@ -495,8 +495,8 @@ where
         let view_key = self.key_manager_service.get_view_key().await?;
         let spend_key = self.key_manager_service.get_spend_key().await?;
         Ok(TariAddress::new_dual_address(
-            view_key.key,
-            spend_key.key,
+            view_key.pub_key,
+            spend_key.pub_key,
             self.network.as_network(),
             TariAddressFeatures::create_one_sided_only(),
         ))

--- a/base_layer/wallet/tests/key_manager_service_tests/service.rs
+++ b/base_layer/wallet/tests/key_manager_service_tests/service.rs
@@ -66,7 +66,7 @@ async fn get_key_at_test_with_encryption() {
         })
         .await
         .unwrap();
-    assert_eq!(key_1.1, key_1_2);
+    assert_eq!(key_1.key, key_1_2);
 }
 
 #[tokio::test]
@@ -147,7 +147,7 @@ async fn key_manager_find_index() {
     let _next_key = key_manager.get_next_key("branch1").await.unwrap();
     let _next_key = key_manager.get_next_key("branch1").await.unwrap();
     let key_1 = key_manager.get_next_key("branch1").await.unwrap();
-    let index = key_manager.find_key_index("branch1", &key_1.1).await.unwrap();
+    let index = key_manager.find_key_index("branch1", &key_1.key).await.unwrap();
 
     assert_eq!(index, 3);
 }
@@ -170,7 +170,7 @@ async fn key_manager_update_current_key_index_if_higher() {
     let _next_key_result = key_manager.get_next_key("branch1").await.unwrap();
     let _next_key_result = key_manager.get_next_key("branch1").await.unwrap();
     let key_1 = key_manager.get_next_key("branch1").await.unwrap();
-    let index = key_manager.find_key_index("branch1", &key_1.1).await.unwrap();
+    let index = key_manager.find_key_index("branch1", &key_1.key).await.unwrap();
 
     assert_eq!(index, 3);
 
@@ -188,7 +188,7 @@ async fn key_manager_update_current_key_index_if_higher() {
         .unwrap();
     let index = key_manager.find_key_index("branch1", &key_1_2).await.unwrap();
     assert_eq!(index, 7);
-    assert_eq!(key_1_2, key_1.1);
+    assert_eq!(key_1_2, key_1.key);
 }
 
 #[tokio::test]
@@ -213,17 +213,17 @@ async fn key_manager_test_index() {
     let key_2 = key_manager
         .get_public_key_at_key_id(&KeyId::Managed {
             branch: "branch2".to_string(),
-            index: result.0.managed_index().unwrap(),
+            index: result.key_id.managed_index().unwrap(),
         })
         .await
         .unwrap();
 
     assert_eq!(
-        result.0.managed_index().unwrap(),
-        key_manager.find_key_index("branch1", &result.1).await.unwrap()
+        result.key_id.managed_index().unwrap(),
+        key_manager.find_key_index("branch1", &result.key).await.unwrap()
     );
     assert_eq!(
-        result.0.managed_index().unwrap(),
+        result.key_id.managed_index().unwrap(),
         key_manager.find_key_index("branch2", &key_2).await.unwrap()
     );
 }

--- a/base_layer/wallet/tests/key_manager_service_tests/service.rs
+++ b/base_layer/wallet/tests/key_manager_service_tests/service.rs
@@ -66,7 +66,7 @@ async fn get_key_at_test_with_encryption() {
         })
         .await
         .unwrap();
-    assert_eq!(key_1.key, key_1_2);
+    assert_eq!(key_1.pub_key, key_1_2);
 }
 
 #[tokio::test]
@@ -147,7 +147,7 @@ async fn key_manager_find_index() {
     let _next_key = key_manager.get_next_key("branch1").await.unwrap();
     let _next_key = key_manager.get_next_key("branch1").await.unwrap();
     let key_1 = key_manager.get_next_key("branch1").await.unwrap();
-    let index = key_manager.find_key_index("branch1", &key_1.key).await.unwrap();
+    let index = key_manager.find_key_index("branch1", &key_1.pub_key).await.unwrap();
 
     assert_eq!(index, 3);
 }
@@ -170,7 +170,7 @@ async fn key_manager_update_current_key_index_if_higher() {
     let _next_key_result = key_manager.get_next_key("branch1").await.unwrap();
     let _next_key_result = key_manager.get_next_key("branch1").await.unwrap();
     let key_1 = key_manager.get_next_key("branch1").await.unwrap();
-    let index = key_manager.find_key_index("branch1", &key_1.key).await.unwrap();
+    let index = key_manager.find_key_index("branch1", &key_1.pub_key).await.unwrap();
 
     assert_eq!(index, 3);
 
@@ -188,7 +188,7 @@ async fn key_manager_update_current_key_index_if_higher() {
         .unwrap();
     let index = key_manager.find_key_index("branch1", &key_1_2).await.unwrap();
     assert_eq!(index, 7);
-    assert_eq!(key_1_2, key_1.key);
+    assert_eq!(key_1_2, key_1.pub_key);
 }
 
 #[tokio::test]
@@ -220,7 +220,7 @@ async fn key_manager_test_index() {
 
     assert_eq!(
         result.key_id.managed_index().unwrap(),
-        key_manager.find_key_index("branch1", &result.key).await.unwrap()
+        key_manager.find_key_index("branch1", &result.pub_key).await.unwrap()
     );
     assert_eq!(
         result.key_id.managed_index().unwrap(),

--- a/base_layer/wallet/tests/output_manager_service_tests/service.rs
+++ b/base_layer/wallet/tests/output_manager_service_tests/service.rs
@@ -278,7 +278,7 @@ async fn generate_sender_transaction_message(
         script!(Nop),
         inputs!(change.script_key_pk),
         change.script_key_id,
-        change.mask_key_id,
+        change.commitment_mask_key_id,
         Covenant::default(),
     );
 
@@ -2158,7 +2158,7 @@ async fn scan_for_recovery_test() {
     let mut recoverable_wallet_outputs = Vec::new();
 
     for i in 1..=NUM_RECOVERABLE {
-        let mask_key = oms
+        let commitment_mask_key = oms
             .key_manager_handle
             .get_next_key(TransactionKeyManagerBranch::CommitmentMask.get_branch_key())
             .await
@@ -2166,7 +2166,7 @@ async fn scan_for_recovery_test() {
         let script_key_id = KeyId::Derived {
             branch: TransactionKeyManagerBranch::CommitmentMask.get_branch_key(),
             label: TransactionKeyManagerLabel::ScriptKey.get_branch_key(),
-            index: mask_key.key_id.managed_index().unwrap(),
+            index: commitment_mask_key.key_id.managed_index().unwrap(),
         };
         let public_script_key = oms
             .key_manager_handle
@@ -2178,13 +2178,13 @@ async fn scan_for_recovery_test() {
         let features = OutputFeatures::default();
         let encrypted_data = oms
             .key_manager_handle
-            .encrypt_data_for_recovery(&mask_key.key_id, None, amount, PaymentId::Empty)
+            .encrypt_data_for_recovery(&commitment_mask_key.key_id, None, amount, PaymentId::Empty)
             .await
             .unwrap();
 
         let uo = WalletOutput::new_current_version(
             MicroMinotari::from(amount),
-            mask_key.key_id,
+            commitment_mask_key.key_id,
             features,
             script!(Nop),
             inputs!(public_script_key),

--- a/base_layer/wallet/tests/support/utils.rs
+++ b/base_layer/wallet/tests/support/utils.rs
@@ -57,8 +57,8 @@ pub async fn make_fake_input_from_copy(
     wallet_output: &mut WalletOutput,
     key_manager: &MemoryDbKeyManager,
 ) -> WalletOutput {
-    let (mask_key, script_key) = key_manager.get_next_spend_and_script_key_ids().await.unwrap();
-    wallet_output.spending_key_id = mask_key.key_id;
+    let (commitment_mask_key, script_key) = key_manager.get_next_commitment_mask_and_script_key().await.unwrap();
+    wallet_output.spending_key_id = commitment_mask_key.key_id;
     wallet_output.script_key_id = script_key.key_id;
     wallet_output.clone()
 }
@@ -75,7 +75,7 @@ pub async fn create_wallet_output_from_sender_data(
         .unwrap();
     let encrypted_data = key_manager
         .encrypt_data_for_recovery(
-            &test_params.mask_key_id,
+            &test_params.commitment_mask_key_id,
             None,
             sender_data.amount.as_u64(),
             PaymentId::Empty,
@@ -85,7 +85,7 @@ pub async fn create_wallet_output_from_sender_data(
     let mut utxo = WalletOutput::new(
         TransactionOutputVersion::get_current_version(),
         sender_data.amount,
-        test_params.mask_key_id.clone(),
+        test_params.commitment_mask_key_id.clone(),
         sender_data.features.clone(),
         sender_data.script.clone(),
         inputs!(public_script_key),
@@ -104,7 +104,7 @@ pub async fn create_wallet_output_from_sender_data(
     let output_message = TransactionOutput::metadata_signature_message(&utxo);
     utxo.metadata_signature = key_manager
         .get_receiver_partial_metadata_signature(
-            &test_params.mask_key_id,
+            &test_params.commitment_mask_key_id,
             &sender_data.amount.into(),
             &sender_data.sender_offset_public_key,
             &sender_data.ephemeral_public_nonce,

--- a/base_layer/wallet/tests/support/utils.rs
+++ b/base_layer/wallet/tests/support/utils.rs
@@ -57,10 +57,9 @@ pub async fn make_fake_input_from_copy(
     wallet_output: &mut WalletOutput,
     key_manager: &MemoryDbKeyManager,
 ) -> WalletOutput {
-    let (spend_key_id, _spend_key_pk, script_key_id, _script_key_pk) =
-        key_manager.get_next_spend_and_script_key_ids().await.unwrap();
-    wallet_output.spending_key_id = spend_key_id;
-    wallet_output.script_key_id = script_key_id;
+    let (mask_key, script_key) = key_manager.get_next_spend_and_script_key_ids().await.unwrap();
+    wallet_output.spending_key_id = mask_key.key_id;
+    wallet_output.script_key_id = script_key.key_id;
     wallet_output.clone()
 }
 
@@ -76,7 +75,7 @@ pub async fn create_wallet_output_from_sender_data(
         .unwrap();
     let encrypted_data = key_manager
         .encrypt_data_for_recovery(
-            &test_params.spend_key_id,
+            &test_params.mask_key_id,
             None,
             sender_data.amount.as_u64(),
             PaymentId::Empty,
@@ -86,7 +85,7 @@ pub async fn create_wallet_output_from_sender_data(
     let mut utxo = WalletOutput::new(
         TransactionOutputVersion::get_current_version(),
         sender_data.amount,
-        test_params.spend_key_id.clone(),
+        test_params.mask_key_id.clone(),
         sender_data.features.clone(),
         sender_data.script.clone(),
         inputs!(public_script_key),
@@ -105,7 +104,7 @@ pub async fn create_wallet_output_from_sender_data(
     let output_message = TransactionOutput::metadata_signature_message(&utxo);
     utxo.metadata_signature = key_manager
         .get_receiver_partial_metadata_signature(
-            &test_params.spend_key_id,
+            &test_params.mask_key_id,
             &sender_data.amount.into(),
             &sender_data.sender_offset_public_key,
             &sender_data.ephemeral_public_nonce,

--- a/base_layer/wallet/tests/transaction_service_tests/service.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/service.rs
@@ -1767,7 +1767,7 @@ async fn recover_one_sided_transaction() {
     let mut alice_ts_clone = alice_ts.clone();
     let bob_view_key = bob_key_manager_handle.get_view_key().await.unwrap();
     let bob_address = TariAddress::new_dual_address_with_default_features(
-        bob_view_key.key,
+        bob_view_key.pub_key,
         bob_node_identity.public_key().clone(),
         network,
     );
@@ -1891,7 +1891,7 @@ async fn recover_stealth_one_sided_transaction() {
     let mut alice_ts_clone = alice_ts.clone();
 
     let bob_address = TariAddress::new_dual_address_with_default_features(
-        bob_view_key.key,
+        bob_view_key.pub_key,
         bob_node_identity.public_key().clone(),
         network,
     );
@@ -2002,7 +2002,7 @@ async fn test_htlc_send_and_claim() {
     let bob_pubkey = bob_ts_interface.base_node_identity.public_key().clone();
     let bob_view_key = bob_ts_interface.key_manager_handle.get_view_key().await.unwrap();
     let bob_address =
-        TariAddress::new_dual_address_with_default_features(bob_view_key.key, bob_pubkey.clone(), network);
+        TariAddress::new_dual_address_with_default_features(bob_view_key.pub_key, bob_pubkey.clone(), network);
     let (tx_id, pre_image, output) = alice_ts
         .send_sha_atomic_swap_transaction(
             bob_address,
@@ -4225,7 +4225,7 @@ async fn test_restarting_transaction_protocols() {
 
     let bob_view_key = bob_ts_interface.key_manager_handle.get_view_key().await.unwrap();
     let bob_address = TariAddress::new_dual_address_with_default_features(
-        bob_view_key.key,
+        bob_view_key.pub_key,
         bob_identity.public_key().clone(),
         network,
     );
@@ -4251,7 +4251,7 @@ async fn test_restarting_transaction_protocols() {
         .unwrap();
     let alice_view_key = alice_ts_interface.key_manager_handle.get_view_key().await.unwrap();
     let alice_address = TariAddress::new_dual_address_with_default_features(
-        alice_view_key.key,
+        alice_view_key.pub_key,
         alice_identity.public_key().clone(),
         network,
     );

--- a/base_layer/wallet/tests/transaction_service_tests/service.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/service.rs
@@ -3331,7 +3331,7 @@ async fn test_transaction_cancellation() {
             script!(Nop),
             inputs!(change.script_key_pk),
             change.script_key_id.clone(),
-            change.mask_key_id.clone(),
+            change.commitment_mask_key_id.clone(),
             Covenant::default(),
         )
         .with_recipient_data(
@@ -3416,7 +3416,7 @@ async fn test_transaction_cancellation() {
             script!(Nop),
             inputs!(change.script_key_pk),
             change.script_key_id.clone(),
-            change.mask_key_id.clone(),
+            change.commitment_mask_key_id.clone(),
             Covenant::default(),
         )
         .with_recipient_data(
@@ -4196,7 +4196,7 @@ async fn test_restarting_transaction_protocols() {
             script!(Nop),
             inputs!(change.script_key_pk),
             change.script_key_id.clone(),
-            change.mask_key_id.clone(),
+            change.commitment_mask_key_id.clone(),
             Covenant::default(),
         );
     let mut bob_stp = builder.build().await.unwrap();
@@ -4617,7 +4617,7 @@ async fn test_resend_on_startup() {
             script!(Nop),
             inputs!(change.script_key_pk),
             change.script_key_id.clone(),
-            change.mask_key_id.clone(),
+            change.commitment_mask_key_id.clone(),
             Covenant::default(),
         )
         .with_recipient_data(
@@ -5145,7 +5145,7 @@ async fn test_transaction_timeout_cancellation() {
             script!(Nop),
             inputs!(change.script_key_pk),
             change.script_key_id.clone(),
-            change.mask_key_id.clone(),
+            change.commitment_mask_key_id.clone(),
             Covenant::default(),
         )
         .with_recipient_data(

--- a/base_layer/wallet/tests/transaction_service_tests/service.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/service.rs
@@ -89,7 +89,7 @@ use tari_common_types::{
     tari_address::TariAddress,
     transaction::{ImportStatus, TransactionDirection, TransactionStatus, TxId},
     types::{FixedHash, PrivateKey, PublicKey, Signature},
-    wallet_types::{ImportedWallet, WalletType},
+    wallet_types::{ProvidedKeysWallet, WalletType},
 };
 use tari_comms::{
     message::EnvelopeBody,
@@ -227,7 +227,7 @@ async fn setup_transaction_service<P: AsRef<Path>>(
     let key_ga = Key::from_slice(&key);
     let db_cipher = XChaCha20Poly1305::new(key_ga);
     let kms_backend = KeyManagerSqliteDatabase::init(connection, db_cipher);
-    let wallet_type = WalletType::Imported(ImportedWallet {
+    let wallet_type = WalletType::ProvidedKeys(ProvidedKeysWallet {
         public_spend_key: PublicKey::from_secret_key(node_identity.secret_key()),
         private_spend_key: Some(node_identity.secret_key().clone()),
         view_key: SK::random(&mut OsRng),
@@ -1765,9 +1765,9 @@ async fn recover_one_sided_transaction() {
     let message = "".to_string();
     let value = 10000.into();
     let mut alice_ts_clone = alice_ts.clone();
-    let bob_view_key = bob_key_manager_handle.get_view_key().await.unwrap().1;
+    let bob_view_key = bob_key_manager_handle.get_view_key().await.unwrap();
     let bob_address = TariAddress::new_dual_address_with_default_features(
-        bob_view_key,
+        bob_view_key.key,
         bob_node_identity.public_key().clone(),
         network,
     );
@@ -1870,7 +1870,7 @@ async fn recover_stealth_one_sided_transaction() {
         )
         .await;
 
-    let bob_view_key = bob_key_manager_handle.get_view_key().await.unwrap().1;
+    let bob_view_key = bob_key_manager_handle.get_view_key().await.unwrap();
 
     let initial_wallet_value = 25000.into();
     let uo1 = make_input(
@@ -1891,7 +1891,7 @@ async fn recover_stealth_one_sided_transaction() {
     let mut alice_ts_clone = alice_ts.clone();
 
     let bob_address = TariAddress::new_dual_address_with_default_features(
-        bob_view_key,
+        bob_view_key.key,
         bob_node_identity.public_key().clone(),
         network,
     );
@@ -2000,8 +2000,9 @@ async fn test_htlc_send_and_claim() {
     let message = "".to_string();
     let value = 10000.into();
     let bob_pubkey = bob_ts_interface.base_node_identity.public_key().clone();
-    let bob_view_key = bob_ts_interface.key_manager_handle.get_view_key().await.unwrap().1;
-    let bob_address = TariAddress::new_dual_address_with_default_features(bob_view_key, bob_pubkey.clone(), network);
+    let bob_view_key = bob_ts_interface.key_manager_handle.get_view_key().await.unwrap();
+    let bob_address =
+        TariAddress::new_dual_address_with_default_features(bob_view_key.key, bob_pubkey.clone(), network);
     let (tx_id, pre_image, output) = alice_ts
         .send_sha_atomic_swap_transaction(
             bob_address,
@@ -3330,7 +3331,7 @@ async fn test_transaction_cancellation() {
             script!(Nop),
             inputs!(change.script_key_pk),
             change.script_key_id.clone(),
-            change.spend_key_id.clone(),
+            change.mask_key_id.clone(),
             Covenant::default(),
         )
         .with_recipient_data(
@@ -3415,7 +3416,7 @@ async fn test_transaction_cancellation() {
             script!(Nop),
             inputs!(change.script_key_pk),
             change.script_key_id.clone(),
-            change.spend_key_id.clone(),
+            change.mask_key_id.clone(),
             Covenant::default(),
         )
         .with_recipient_data(
@@ -4195,7 +4196,7 @@ async fn test_restarting_transaction_protocols() {
             script!(Nop),
             inputs!(change.script_key_pk),
             change.script_key_id.clone(),
-            change.spend_key_id.clone(),
+            change.mask_key_id.clone(),
             Covenant::default(),
         );
     let mut bob_stp = builder.build().await.unwrap();
@@ -4222,9 +4223,12 @@ async fn test_restarting_transaction_protocols() {
     };
     let tx = bob_stp.get_transaction().unwrap().clone();
 
-    let bob_view_key = bob_ts_interface.key_manager_handle.get_view_key().await.unwrap().1;
-    let bob_address =
-        TariAddress::new_dual_address_with_default_features(bob_view_key, bob_identity.public_key().clone(), network);
+    let bob_view_key = bob_ts_interface.key_manager_handle.get_view_key().await.unwrap();
+    let bob_address = TariAddress::new_dual_address_with_default_features(
+        bob_view_key.key,
+        bob_identity.public_key().clone(),
+        network,
+    );
     let inbound_tx = InboundTransaction {
         tx_id,
         source_address: bob_address,
@@ -4245,9 +4249,9 @@ async fn test_restarting_transaction_protocols() {
             Box::new(inbound_tx),
         )))
         .unwrap();
-    let alice_view_key = alice_ts_interface.key_manager_handle.get_view_key().await.unwrap().1;
+    let alice_view_key = alice_ts_interface.key_manager_handle.get_view_key().await.unwrap();
     let alice_address = TariAddress::new_dual_address_with_default_features(
-        alice_view_key,
+        alice_view_key.key,
         alice_identity.public_key().clone(),
         network,
     );
@@ -4613,7 +4617,7 @@ async fn test_resend_on_startup() {
             script!(Nop),
             inputs!(change.script_key_pk),
             change.script_key_id.clone(),
-            change.spend_key_id.clone(),
+            change.mask_key_id.clone(),
             Covenant::default(),
         )
         .with_recipient_data(
@@ -5141,7 +5145,7 @@ async fn test_transaction_timeout_cancellation() {
             script!(Nop),
             inputs!(change.script_key_pk),
             change.script_key_id.clone(),
-            change.spend_key_id.clone(),
+            change.mask_key_id.clone(),
             Covenant::default(),
         )
         .with_recipient_data(

--- a/base_layer/wallet/tests/transaction_service_tests/storage.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/storage.rs
@@ -114,7 +114,7 @@ pub async fn test_db_backend<T: TransactionBackend + 'static>(backend: T) {
         script!(Nop),
         inputs!(change.script_key_pk),
         change.script_key_id.clone(),
-        change.mask_key_id.clone(),
+        change.commitment_mask_key_id.clone(),
         Covenant::default(),
     );
 
@@ -181,25 +181,30 @@ pub async fn test_db_backend<T: TransactionBackend + 'static>(backend: T) {
         panic!("Should have found outbound tx");
     }
     let sender = stp.clone().build_single_round_message(&key_manager).await.unwrap();
-    let mask_key = key_manager
+    let commitment_mask_key = key_manager
         .get_next_key(TransactionKeyManagerBranch::CommitmentMask.get_branch_key())
         .await
         .unwrap();
     let script_key_id = KeyId::Derived {
         branch: TransactionKeyManagerBranch::CommitmentMask.get_branch_key(),
         label: TransactionKeyManagerLabel::ScriptKey.get_branch_key(),
-        index: mask_key.key_id.managed_index().unwrap(),
+        index: commitment_mask_key.key_id.managed_index().unwrap(),
     };
     let public_script_key = key_manager.get_public_key_at_key_id(&script_key_id).await.unwrap();
 
     let encrypted_data = key_manager
-        .encrypt_data_for_recovery(&mask_key.key_id, None, sender.amount.as_u64(), PaymentId::Empty)
+        .encrypt_data_for_recovery(
+            &commitment_mask_key.key_id,
+            None,
+            sender.amount.as_u64(),
+            PaymentId::Empty,
+        )
         .await
         .unwrap();
     let mut output = WalletOutput::new(
         TransactionOutputVersion::get_current_version(),
         sender.amount,
-        mask_key.key_id.clone(),
+        commitment_mask_key.key_id.clone(),
         sender.features.clone(),
         sender.script.clone(),
         inputs!(public_script_key),
@@ -218,7 +223,7 @@ pub async fn test_db_backend<T: TransactionBackend + 'static>(backend: T) {
     let output_message = TransactionOutput::metadata_signature_message(&output);
     output.metadata_signature = key_manager
         .get_receiver_partial_metadata_signature(
-            &mask_key.key_id,
+            &commitment_mask_key.key_id,
             &sender.amount.into(),
             &sender.sender_offset_public_key,
             &sender.ephemeral_public_nonce,

--- a/base_layer/wallet/tests/transaction_service_tests/storage.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/storage.rs
@@ -114,7 +114,7 @@ pub async fn test_db_backend<T: TransactionBackend + 'static>(backend: T) {
         script!(Nop),
         inputs!(change.script_key_pk),
         change.script_key_id.clone(),
-        change.spend_key_id.clone(),
+        change.mask_key_id.clone(),
         Covenant::default(),
     );
 
@@ -181,25 +181,25 @@ pub async fn test_db_backend<T: TransactionBackend + 'static>(backend: T) {
         panic!("Should have found outbound tx");
     }
     let sender = stp.clone().build_single_round_message(&key_manager).await.unwrap();
-    let (spending_key_id, _) = key_manager
+    let mask_key = key_manager
         .get_next_key(TransactionKeyManagerBranch::CommitmentMask.get_branch_key())
         .await
         .unwrap();
     let script_key_id = KeyId::Derived {
         branch: TransactionKeyManagerBranch::CommitmentMask.get_branch_key(),
         label: TransactionKeyManagerLabel::ScriptKey.get_branch_key(),
-        index: spending_key_id.managed_index().unwrap(),
+        index: mask_key.key_id.managed_index().unwrap(),
     };
     let public_script_key = key_manager.get_public_key_at_key_id(&script_key_id).await.unwrap();
 
     let encrypted_data = key_manager
-        .encrypt_data_for_recovery(&spending_key_id, None, sender.amount.as_u64(), PaymentId::Empty)
+        .encrypt_data_for_recovery(&mask_key.key_id, None, sender.amount.as_u64(), PaymentId::Empty)
         .await
         .unwrap();
     let mut output = WalletOutput::new(
         TransactionOutputVersion::get_current_version(),
         sender.amount,
-        spending_key_id.clone(),
+        mask_key.key_id.clone(),
         sender.features.clone(),
         sender.script.clone(),
         inputs!(public_script_key),
@@ -218,7 +218,7 @@ pub async fn test_db_backend<T: TransactionBackend + 'static>(backend: T) {
     let output_message = TransactionOutput::metadata_signature_message(&output);
     output.metadata_signature = key_manager
         .get_receiver_partial_metadata_signature(
-            &spending_key_id,
+            &mask_key.key_id,
             &sender.amount.into(),
             &sender.sender_offset_public_key,
             &sender.ephemeral_public_nonce,

--- a/base_layer/wallet/tests/transaction_service_tests/transaction_protocols.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/transaction_protocols.rs
@@ -167,13 +167,13 @@ pub async fn setup() -> (
         TariAddressFeatures::create_one_sided_only()
     };
     let one_sided_tari_address = TariAddress::new_dual_address(
-        view_key.key.clone(),
-        comms_key.key,
+        view_key.pub_key.clone(),
+        comms_key.pub_key,
         network,
         TariAddressFeatures::create_one_sided_only(),
     );
     let interactive_tari_address =
-        TariAddress::new_dual_address(view_key.key, spend_key.key, network, interactive_features);
+        TariAddress::new_dual_address(view_key.pub_key, spend_key.pub_key, network, interactive_features);
     let resources = TransactionServiceResources {
         db,
         output_manager_service: output_manager_service_handle,

--- a/base_layer/wallet/tests/utxo_scanner/mod.rs
+++ b/base_layer/wallet/tests/utxo_scanner/mod.rs
@@ -193,9 +193,9 @@ async fn setup(
         scanner_service_builder.with_recovery_message(message);
     }
 
-    let (_view_key_id, view_key) = key_manager.get_view_key().await.unwrap();
+    let view_key = key_manager.get_view_key().await.unwrap();
     let tari_address = TariAddress::new_dual_address_with_default_features(
-        view_key,
+        view_key.key,
         node_identity.public_key().clone(),
         Network::default(),
     );

--- a/base_layer/wallet/tests/utxo_scanner/mod.rs
+++ b/base_layer/wallet/tests/utxo_scanner/mod.rs
@@ -195,7 +195,7 @@ async fn setup(
 
     let view_key = key_manager.get_view_key().await.unwrap();
     let tari_address = TariAddress::new_dual_address_with_default_features(
-        view_key.key,
+        view_key.pub_key,
         node_identity.public_key().clone(),
         Network::default(),
     );

--- a/integration_tests/src/transaction.rs
+++ b/integration_tests/src/transaction.rs
@@ -112,7 +112,7 @@ impl TestTransactionBuilder {
         let value = self.amount -
             self.estimate_fee(num_inputs, features.clone(), script.clone(), covenant.clone())
                 .expect("Failed to estimate fee");
-        let builder = WalletOutputBuilder::new(value, self.keys.spend_key_id.clone())
+        let builder = WalletOutputBuilder::new(value, self.keys.mask_key_id.clone())
             .with_features(features)
             .with_script(script)
             .with_script_key(self.keys.script_key_id.clone())

--- a/integration_tests/src/transaction.rs
+++ b/integration_tests/src/transaction.rs
@@ -112,7 +112,7 @@ impl TestTransactionBuilder {
         let value = self.amount -
             self.estimate_fee(num_inputs, features.clone(), script.clone(), covenant.clone())
                 .expect("Failed to estimate fee");
-        let builder = WalletOutputBuilder::new(value, self.keys.mask_key_id.clone())
+        let builder = WalletOutputBuilder::new(value, self.keys.commitment_mask_key_id.clone())
             .with_features(features)
             .with_script(script)
             .with_script_key(self.keys.script_key_id.clone())


### PR DESCRIPTION
Description
---
refactors the key manger names to ensure they are easier to read

Motivation and Context
---
the names are not correct and all over the place. This changes the names to make it easier to read the code.

How Has This Been Tested?
---
unit test
