### PR TITLE
fix: panic in from_base58 fn

### DIFF
--- a/applications/minotari_merge_mining_proxy/src/proxy.rs
+++ b/applications/minotari_merge_mining_proxy/src/proxy.rs
@@ -648,7 +648,7 @@ impl InnerService {
             .iter()
             .position(|x| x == &last_used_url)
             .unwrap_or(0);
-        let (left, right) = self.config.monerod_url.split_at(pos);
+        let (left, right) = self.config.monerod_url.split_at_checked(pos).ok_or(MmProxyError::ConversionError("Invalid utf 8 url".to_string()))?;
         let left = left.to_vec();
         let right = right.to_vec();
         let iter = right.iter().chain(left.iter()).chain(right.iter()).chain(left.iter());

--- a/applications/minotari_merge_mining_proxy/src/proxy.rs
+++ b/applications/minotari_merge_mining_proxy/src/proxy.rs
@@ -648,7 +648,11 @@ impl InnerService {
             .iter()
             .position(|x| x == &last_used_url)
             .unwrap_or(0);
-        let (left, right) = self.config.monerod_url.split_at_checked(pos).ok_or(MmProxyError::ConversionError("Invalid utf 8 url".to_string()))?;
+        let (left, right) = self
+            .config
+            .monerod_url
+            .split_at_checked(pos)
+            .ok_or(MmProxyError::ConversionError("Invalid utf 8 url".to_string()))?;
         let left = left.to_vec();
         let right = right.to_vec();
         let iter = right.iter().chain(left.iter()).chain(right.iter()).chain(left.iter());

--- a/base_layer/common_types/src/tari_address/dual_address.rs
+++ b/base_layer/common_types/src/tari_address/dual_address.rs
@@ -162,8 +162,8 @@ impl DualAddress {
         if hex_str.len() != 90 && hex_str.len() != 91 {
             return Err(TariAddressError::InvalidSize);
         }
-        let (first, rest) = hex_str.split_at(2);
-        let (network, features) = first.split_at(1);
+        let (first, rest) = hex_str.split_at_checked(2).ok_or(TariAddressError::InvalidCharacter)?;
+        let (network, features) = first.split_at_checked(1).ok_or(TariAddressError::InvalidCharacter)?;
         let mut result = bs58::decode(network)
             .into_vec()
             .map_err(|_| TariAddressError::CannotRecoverNetwork)?;

--- a/base_layer/common_types/src/tari_address/mod.rs
+++ b/base_layer/common_types/src/tari_address/mod.rs
@@ -827,7 +827,9 @@ mod test {
     /// Test invalid emoji
     fn invalid_utf8_char() {
         // This emoji string contains an invalid utf8 character
-        let emoji_string = "🦊 | 🦊 | 🦊 | 🦊 | 🦊 | 🦊| 🦊 | 🦊| 🦊 | 🦊| 🦊 | 🦊| 🦊 | 🦊| 🦊 | 🦊| 🦊 | 🦊| 🦊 | 🦊| 🦊 | 🦊| 🦊 | 🦊| 🦊 | 🦊| 🦊 | 🦊| 🦊 | 🦊| 🦊 | 🦊| 🦊 | 🦊| 🦊 | 🦊| 🦊 | 🦊| 🦊 | 🦊| 🦊 | 🦊| 🦊 | 🦊";
+        let emoji_string = "🦊 | 🦊 | 🦊 | 🦊 | 🦊 | 🦊| 🦊 | 🦊| 🦊 | 🦊| 🦊 | 🦊| 🦊 | 🦊| 🦊 | 🦊| 🦊 | 🦊| 🦊 | \
+                            🦊| 🦊 | 🦊| 🦊 | 🦊| 🦊 | 🦊| 🦊 | 🦊| 🦊 | 🦊| 🦊 | 🦊| 🦊 | 🦊| 🦊 | 🦊| 🦊 | 🦊| 🦊 | \
+                            🦊| 🦊 | 🦊| 🦊 | 🦊";
         assert_eq!(
             TariAddress::from_base58(emoji_string),
             Err(TariAddressError::InvalidCharacter)
@@ -841,5 +843,4 @@ mod test {
             Err(TariAddressError::InvalidAddressString)
         );
     }
-
 }

--- a/base_layer/common_types/src/tari_address/single_address.rs
+++ b/base_layer/common_types/src/tari_address/single_address.rs
@@ -145,8 +145,8 @@ impl SingleAddress {
         if hex_str.len() != 46 && hex_str.len() != 47 && hex_str.len() != 48 {
             return Err(TariAddressError::InvalidSize);
         }
-        let (first, rest) = hex_str.split_at(2);
-        let (network, features) = first.split_at(1);
+        let (first, rest) = hex_str.split_at_checked(2).ok_or(TariAddressError::InvalidCharacter)?;
+        let (network, features) = first.split_at_checked(1).ok_or(TariAddressError::InvalidCharacter)?;
         let mut result = bs58::decode(network)
             .into_vec()
             .map_err(|_| TariAddressError::CannotRecoverNetwork)?;

--- a/base_layer/wallet_ffi/src/error.rs
+++ b/base_layer/wallet_ffi/src/error.rs
@@ -430,7 +430,11 @@ impl From<TariAddressError> for LibWalletError {
                 message: format!("{:?}", e),
             },
             TariAddressError::InvalidAddressString => Self {
-                code: 706,
+                code: 707,
+                message: format!("{:?}", e),
+            },
+            TariAddressError::InvalidCharacter => Self {
+                code: 708,
                 message: format!("{:?}", e),
             },
         }

--- a/common/src/build/application.rs
+++ b/common/src/build/application.rs
@@ -128,7 +128,8 @@ fn get_commit() -> Result<String, anyhow::Error> {
     let repo = git2::Repository::open(git_root)?;
     let head = repo.revparse_single("HEAD")?;
     let id = format!("{:?}", head.id());
-    id.split_at(7).0.to_string();
+    id.split_at_checked(7).ok_or(anyhow::anyhow!(
+                "invalid utf8 in commit id"))?.0.to_string();
     Ok(id)
 }
 

--- a/common/src/build/application.rs
+++ b/common/src/build/application.rs
@@ -128,8 +128,10 @@ fn get_commit() -> Result<String, anyhow::Error> {
     let repo = git2::Repository::open(git_root)?;
     let head = repo.revparse_single("HEAD")?;
     let id = format!("{:?}", head.id());
-    id.split_at_checked(7).ok_or(anyhow::anyhow!(
-                "invalid utf8 in commit id"))?.0.to_string();
+    id.split_at_checked(7)
+        .ok_or(anyhow::anyhow!("invalid utf8 in commit id"))?
+        .0
+        .to_string();
     Ok(id)
 }
 


### PR DESCRIPTION
Description
---
Fixes potential panic in: `from_base58` function
Removes uses of `split_at` and replaces with checked version where user strings are used as input

Motivation and Context
---
Code should not panic
