### PR TITLE
chore: remove unnecessary commitment hashing

### DIFF
--- a/applications/minotari_console_wallet/src/automation/commands.rs
+++ b/applications/minotari_console_wallet/src/automation/commands.rs
@@ -31,9 +31,8 @@ use std::{
     time::{Duration, Instant},
 };
 
-use blake2::Blake2b;
 use chrono::{DateTime, Utc};
-use digest::{consts::U32, crypto_common::rand_core::OsRng, Digest};
+use digest::{crypto_common::rand_core::OsRng, Digest};
 use futures::FutureExt;
 use log::*;
 use minotari_app_grpc::tls::certs::{generate_self_signed_certs, print_warning, write_cert_to_disk};
@@ -64,9 +63,7 @@ use tari_comms::{
 };
 use tari_comms_dht::{envelope::NodeDestination, DhtDiscoveryRequester};
 use tari_core::{
-    consensus::DomainSeparatedConsensusHasher,
     covenants::Covenant,
-    one_sided::FaucetHashDomain,
     transactions::{
         key_manager::TransactionKeyManagerInterface,
         tari_amount::{uT, MicroMinotari, Minotari},
@@ -816,11 +813,6 @@ pub async fn command_runner(
                 let session_info = read_session_info(args.input_file.clone())?;
 
                 let commitment = Commitment::from_hex(&session_info.commitment_to_spend)?;
-                let commitment_hash: [u8; 32] =
-                    DomainSeparatedConsensusHasher::<FaucetHashDomain, Blake2b<U32>>::new("com_hash")
-                        .chain(&commitment)
-                        .finalize()
-                        .into();
                 let shared_secret = key_manager_service
                     .get_diffie_hellman_shared_secret(
                         &sender_offset_key.key_id,
@@ -833,7 +825,7 @@ pub async fn command_runner(
                 let shared_secret_public_key = PublicKey::from_canonical_bytes(shared_secret.as_bytes())?;
 
                 let script_input_signature = key_manager_service
-                    .sign_script_message(&wallet_spend_key.key_id, &commitment_hash)
+                    .sign_script_message(&wallet_spend_key.key_id, commitment.as_bytes())
                     .await?;
 
                 let out_dir = out_dir(&session_info.session_id)?;

--- a/base_layer/core/src/common/one_sided.rs
+++ b/base_layer/core/src/common/one_sided.rs
@@ -44,8 +44,6 @@ hash_domain!(
     1
 );
 
-hash_domain!(FaucetHashDomain, "com.tari.base_layer.wallet.faucet", 0);
-
 type WalletOutputEncryptionKeysDomainHasher = DomainSeparatedHasher<Blake2b<U64>, WalletOutputEncryptionKeysDomain>;
 type WalletOutputSpendingKeysDomainHasher = DomainSeparatedHasher<Blake2b<U64>, WalletOutputSpendingKeysDomain>;
 


### PR DESCRIPTION
Description
---
Removes unnecessary hashing of commitments used in faucet-related signatures.

Motivation and Context
---
Signatures used for faucet functionality unnecessarily hash commitments before passing them as an input message. This may have been done on the assumption that the signing functions often refer to the message as a challenge, despite this not being the case.

This PR removes the unnecessary hashing operations.

It may be worthwhile to refactor the associated signing functions to avoid any possible confusion about the nature of messages and challenges (as suggested in #6418).

How Has This Been Tested?
---
Existing tests pass.

What process can a PR reviewer use to test or verify this change?
---
Check that the commitment data is being passed into the signing functions correctly, and that those functions do in fact assume the input is an arbitrary message and not a challenge.