### PR TITLE
chore: sync FFI and Console Wallet payment Id display options

### DIFF
--- a/applications/minotari_console_wallet/src/ui/components/transactions_tab.rs
+++ b/applications/minotari_console_wallet/src/ui/components/transactions_tab.rs
@@ -437,7 +437,7 @@ impl TransactionsTab {
                 Some(v) => {
                     if let PaymentId::Open(bytes) = v {
                         String::from_utf8(bytes)
-                            .unwrap_or_else(|_| "Invalid".to_string())
+                            .unwrap_or_else(|_| "Invalid string".to_string())
                             .to_string()
                     } else {
                         format!("#{}", v)

--- a/applications/minotari_console_wallet/src/ui/state/app_state.rs
+++ b/applications/minotari_console_wallet/src/ui/state/app_state.rs
@@ -329,10 +329,8 @@ impl AppState {
         let payment_id = if payment_id_str.is_empty() {
             PaymentId::Empty
         } else {
-            let payment_id_u64: u64 = payment_id_str
-                .parse::<u64>()
-                .map_err(|_| UiError::HexError("Could not convert payment_id to bytes".to_string()))?;
-            PaymentId::U64(payment_id_u64)
+            let bytes = payment_id_str.as_bytes().to_vec();
+            PaymentId::Open(bytes)
         };
 
         let output_features = OutputFeatures { ..Default::default() };

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -7147,7 +7147,8 @@ pub unsafe extern "C" fn wallet_send_transaction(
         } else {
             match CStr::from_ptr(payment_id_string).to_str() {
                 Ok(v) => {
-                    let bytes = v.as_bytes().to_vec();
+                    let rust_str = v.to_owned();
+                    let bytes = rust_str.as_bytes().to_vec();
                     PaymentId::Open(bytes)
                 },
                 _ => {

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -7100,7 +7100,6 @@ pub unsafe extern "C" fn wallet_send_transaction(
         ptr::swap(error_out, &mut error as *mut c_int);
         return 0;
     }
-
     if destination.is_null() {
         error = LibWalletError::from(InterfaceError::NullError("dest_public_key".to_string())).code;
         ptr::swap(error_out, &mut error as *mut c_int);
@@ -7121,8 +7120,6 @@ pub unsafe extern "C" fn wallet_send_transaction(
 
     let message_string;
     if message.is_null() {
-        error = LibWalletError::from(InterfaceError::NullError("message".to_string())).code;
-        ptr::swap(error_out, &mut error as *mut c_int);
         message_string = CString::new("")
             .expect("Blank CString will not fail")
             .to_str()


### PR DESCRIPTION
Description
---
chore: sync FFI and Console Wallet payment Id display options

Motivation and Context
---
Ensures that the payment id's are displayed in the same way between the console wallet and FFI

How Has This Been Tested?
---
Manual 
