### PR TITLE
feat: change grpc address conversions to use from_str

### DIFF
--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -20,7 +20,10 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::convert::{TryFrom, TryInto};
+use std::{
+    convert::{TryFrom, TryInto},
+    str::FromStr,
+};
 
 use futures::{
     channel::mpsc::{self, Sender},
@@ -335,7 +338,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
             .into_inner()
             .recipient
             .ok_or_else(|| Status::internal("Request is malformed".to_string()))?;
-        let address = TariAddress::from_base58(&message.address)
+        let address = TariAddress::from_str(&message.address)
             .map_err(|_| Status::internal("Destination address is malformed".to_string()))?;
 
         let mut transaction_service = self.get_transaction_service();
@@ -496,7 +499,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
             .into_iter()
             .enumerate()
             .map(|(idx, dest)| -> Result<_, String> {
-                let address = TariAddress::from_base58(&dest.address)
+                let address = TariAddress::from_str(&dest.address)
                     .map_err(|_| format!("Destination address at index {} is malformed", idx))?;
                 Ok((
                     dest.address,

--- a/applications/minotari_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/minotari_node/src/grpc/base_node_grpc_server.rs
@@ -23,6 +23,7 @@
 use std::{
     cmp,
     convert::{TryFrom, TryInto},
+    str::FromStr,
 };
 
 use borsh::{BorshDeserialize, BorshSerialize};
@@ -843,7 +844,7 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
         let mut kernel_message = [0; 32];
         let mut last_kernel = Default::default();
         for coinbase in coinbases {
-            let address = TariAddress::from_base58(&coinbase.address)
+            let address = TariAddress::from_str(&coinbase.address)
                 .map_err(|e| obscure_error_if_true(report_error_flag, Status::internal(e.to_string())))?;
             let range_proof_type = if coinbase.revealed_value_proof {
                 RangeProofType::RevealedValue
@@ -1040,7 +1041,7 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
         let mut kernel_message = [0; 32];
         let mut last_kernel = Default::default();
         for coinbase in coinbases {
-            let address = TariAddress::from_base58(&coinbase.address)
+            let address = TariAddress::from_str(&coinbase.address)
                 .map_err(|e| obscure_error_if_true(report_error_flag, Status::internal(e.to_string())))?;
             let range_proof_type = if coinbase.revealed_value_proof {
                 RangeProofType::RevealedValue


### PR DESCRIPTION
Description
---
Chane string conversion to not assume base58. but tries all conversions using from_str. 

Motivation and Context
---
It allows users to give hex, base58 or emoji
