### PR TITLE
chore: remove panic abort

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,8 +39,6 @@ members = [
 resolver = "2"
 
 [profile.release]
-# Shutdown when panicking so we can see the error, specifically for the wallet
-panic = "abort"
 # By default, Rust will wrap an integer in release mode instead of throwing the overflow error
 # seen in debug mode. Panicking at this time is better than silently using the wrong value.
 overflow-checks = true


### PR DESCRIPTION
Description
---
remove panic abort

Motivation and Context
---
panic abort in the cargo file shutdowns the program after a panic occurred. In places we need to swallow a panic and continue. This cannot be done if panic abort is enabled. 
