### PR TITLE
fix: wallet address deserialize

### DIFF
--- a/base_layer/common_types/src/tari_address/dual_address.rs
+++ b/base_layer/common_types/src/tari_address/dual_address.rs
@@ -30,7 +30,13 @@ use tari_utilities::hex::{from_hex, Hex};
 use crate::{
     dammsum::{compute_checksum, validate_checksum},
     emoji::{EMOJI, REVERSE_EMOJI},
-    tari_address::{TariAddressError, TariAddressFeatures, INTERNAL_DUAL_SIZE},
+    tari_address::{
+        TariAddressError,
+        TariAddressFeatures,
+        INTERNAL_DUAL_BASE58_MAX_SIZE,
+        INTERNAL_DUAL_BASE58_MIN_SIZE,
+        INTERNAL_DUAL_SIZE,
+    },
     types::PublicKey,
 };
 
@@ -159,7 +165,7 @@ impl DualAddress {
     /// Construct Tari Address from Base58
     pub fn from_base58(hex_str: &str) -> Result<Self, TariAddressError> {
         // Due to the byte length, it can be encoded as 90 or 91
-        if hex_str.len() != 90 && hex_str.len() != 91 {
+        if hex_str.len() < INTERNAL_DUAL_BASE58_MIN_SIZE || hex_str.len() > INTERNAL_DUAL_BASE58_MAX_SIZE {
             return Err(TariAddressError::InvalidSize);
         }
         let result = panic::catch_unwind(|| hex_str.split_at(2));
@@ -426,7 +432,6 @@ mod test {
         assert_eq!(address_emoji.network(), address.network());
         assert_eq!(address_emoji.features(), address.features());
     }
-
     #[test]
     /// Test invalid size
     fn invalid_size() {

--- a/base_layer/common_types/src/tari_address/mod.rs
+++ b/base_layer/common_types/src/tari_address/mod.rs
@@ -45,6 +45,10 @@ use crate::{
 
 const INTERNAL_DUAL_SIZE: usize = 67; // number of bytes used for the internal representation
 const INTERNAL_SINGLE_SIZE: usize = 35; // number of bytes used for the internal representation
+const INTERNAL_DUAL_BASE58_MIN_SIZE: usize = 90; // number of bytes used for the internal representation
+const INTERNAL_DUAL_BASE58_MAX_SIZE: usize = 91; // number of bytes used for the internal representation
+const INTERNAL_SINGLE_MIN_BASE58_SIZE: usize = 45; // number of bytes used for the internal representation
+const INTERNAL_SINGLE_MAX_BASE58_SIZE: usize = 48; // number of bytes used for the internal representation
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TariAddressFeatures(u8);
@@ -246,7 +250,7 @@ impl TariAddress {
 
     /// Construct Tari Address from hex
     pub fn from_base58(hex_str: &str) -> Result<TariAddress, TariAddressError> {
-        if hex_str.len() < 45 {
+        if hex_str.len() < INTERNAL_SINGLE_MIN_BASE58_SIZE {
             return Err(TariAddressError::InvalidSize);
         }
         let result = panic::catch_unwind(|| hex_str.split_at(2));
@@ -715,7 +719,6 @@ mod test {
         );
         test_addres(address);
     }
-
     #[test]
     /// Test invalid size
     fn invalid_size() {

--- a/base_layer/common_types/src/tari_address/mod.rs
+++ b/base_layer/common_types/src/tari_address/mod.rs
@@ -247,7 +247,6 @@ impl TariAddress {
     /// Construct Tari Address from hex
     pub fn from_base58(hex_str: &str) -> Result<TariAddress, TariAddressError> {
         if hex_str.len() < 45 {
-            dbg!(hex_str.len());
             return Err(TariAddressError::InvalidSize);
         }
         let result = panic::catch_unwind(|| hex_str.split_at(2));

--- a/base_layer/common_types/src/tari_address/mod.rs
+++ b/base_layer/common_types/src/tari_address/mod.rs
@@ -246,7 +246,8 @@ impl TariAddress {
 
     /// Construct Tari Address from hex
     pub fn from_base58(hex_str: &str) -> Result<TariAddress, TariAddressError> {
-        if hex_str.len() < 47 {
+        if hex_str.len() < 45 {
+            dbg!(hex_str.len());
             return Err(TariAddressError::InvalidSize);
         }
         let result = panic::catch_unwind(|| hex_str.split_at(2));

--- a/base_layer/common_types/src/tari_address/mod.rs
+++ b/base_layer/common_types/src/tari_address/mod.rs
@@ -45,7 +45,7 @@ use crate::{
 
 const INTERNAL_DUAL_SIZE: usize = 67; // number of bytes used for the internal representation
 const INTERNAL_SINGLE_SIZE: usize = 35; // number of bytes used for the internal representation
-const INTERNAL_DUAL_BASE58_MIN_SIZE: usize = 90; // number of bytes used for the internal representation
+const INTERNAL_DUAL_BASE58_MIN_SIZE: usize = 89; // number of bytes used for the internal representation
 const INTERNAL_DUAL_BASE58_MAX_SIZE: usize = 91; // number of bytes used for the internal representation
 const INTERNAL_SINGLE_MIN_BASE58_SIZE: usize = 45; // number of bytes used for the internal representation
 const INTERNAL_SINGLE_MAX_BASE58_SIZE: usize = 48; // number of bytes used for the internal representation

--- a/base_layer/common_types/src/tari_address/single_address.rs
+++ b/base_layer/common_types/src/tari_address/single_address.rs
@@ -30,7 +30,13 @@ use tari_utilities::hex::{from_hex, Hex};
 use crate::{
     dammsum::{compute_checksum, validate_checksum},
     emoji::{EMOJI, REVERSE_EMOJI},
-    tari_address::{TariAddressError, TariAddressFeatures, INTERNAL_SINGLE_SIZE},
+    tari_address::{
+        TariAddressError,
+        TariAddressFeatures,
+        INTERNAL_SINGLE_MAX_BASE58_SIZE,
+        INTERNAL_SINGLE_MIN_BASE58_SIZE,
+        INTERNAL_SINGLE_SIZE,
+    },
     types::PublicKey,
 };
 
@@ -142,7 +148,7 @@ impl SingleAddress {
     /// Construct Tari Address from Base58
     pub fn from_base58(hex_str: &str) -> Result<Self, TariAddressError> {
         // Due to the byte length, it can be encoded as 46, 47 or 48 chars
-        if hex_str.len() != 46 && hex_str.len() != 47 && hex_str.len() != 48 {
+        if hex_str.len() < INTERNAL_SINGLE_MIN_BASE58_SIZE || hex_str.len() > INTERNAL_SINGLE_MAX_BASE58_SIZE {
             return Err(TariAddressError::InvalidSize);
         }
         let result = panic::catch_unwind(|| hex_str.split_at(2));


### PR DESCRIPTION
Description
---
Fixes single address deserialize. 

Motivation and Context
---
Its possible for the single address to be as small as 45 chars. 

How Has This Been Tested?
---
Fuzz testing
