### PR TITLE
ci(fix): add env RUSTUP_PERMIT_COPY_RENAME to fix cross-device link errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,8 @@ jobs:
     #  on stable Rust.
     name: cargo check with stable
     runs-on: [self-hosted, ubuntu-high-cpu]
+    env:
+      RUSTUP_PERMIT_COPY_RENAME: true
     steps:
       - name: checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Description
add env RUSTUP_PERMIT_COPY_RENAME to fix cross-device link errors for ci-stable builds test

Motivation and Context
Fix ci stable build test which has the following error
```bash
error: could not rename component file from ...
... Invalid cross-device link (os error 18)
```

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
