### PR TITLE
chore: use safer slice splitting

### DIFF
--- a/comms/core/src/peer_validator/helpers.rs
+++ b/comms/core/src/peer_validator/helpers.rs
@@ -171,8 +171,13 @@ fn validate_onion3_address(addr: &multiaddr::Onion3Addr<'_>) -> Result<(), PeerV
     const ONION3_PUBKEY_SIZE: usize = 32;
     const ONION3_CHECKSUM_SIZE: usize = 2;
 
-    let (pub_key, checksum_version) = addr.hash().split_at(ONION3_PUBKEY_SIZE);
-    let (checksum, version) = checksum_version.split_at(ONION3_CHECKSUM_SIZE);
+    let (pub_key, checksum_version) = addr
+        .hash()
+        .split_at_checked(ONION3_PUBKEY_SIZE)
+        .ok_or(PeerValidatorError::InvalidMultiaddr("Unable to split data".to_string()))?;
+    let (checksum, version) = checksum_version
+        .split_at_checked(ONION3_CHECKSUM_SIZE)
+        .ok_or(PeerValidatorError::InvalidMultiaddr("Unable to split data".to_string()))?;
 
     if version != b"\x03" {
         return Err(PeerValidatorError::InvalidMultiaddr(

--- a/docs/src/reviewing_guide.md
+++ b/docs/src/reviewing_guide.md
@@ -122,4 +122,4 @@ Here is a good example of nice semantic rust code, but the code has the potentia
 
 #### Behind-the-scenes panics
 
-Not all methods in the standard and other libraries that return values are guaranteed not to panic, for example, `pub const fn split_at(&self, mid: usize) -> (&[T], &[T])` will panic if `mid` > `self.len()`. Create custom wrappers that will return an error before the underlying function will panic, for example, `pub fn split_at_checked<T>(vec: &[T], n: usize) -> Result<(&[T], &[T]), Error>`.
+Not all methods in the standard and other libraries that return values are guaranteed not to panic. Create custom wrappers that will return an error before the underlying function will panic.


### PR DESCRIPTION
Description
---
Ensures that all slice splitting is properly checked to avoid panics.

Motivation and Context
---
There are a few remaining uses of [`slice::split_at`](https://doc.rust-lang.org/std/primitive.slice.html#method.split_at) that are used to split slices. Because this can panic on a bad index, this PR moves each use to [`slice::split_at_checked`](https://doc.rust-lang.org/std/primitive.slice.html#method.split_at_checked), which cannot panic.

How Has This Been Tested?
---
Existing tests pass.

What process can a PR reviewer use to test or verify this change?
---
Ensure that each split is still being done at the same index, and that the error handling is done properly.