### PR TITLE
feat: add scanned height

### DIFF
--- a/applications/minotari_console_wallet/src/ui/components/base_node.rs
+++ b/applications/minotari_console_wallet/src/ui/components/base_node.rs
@@ -69,6 +69,7 @@ impl<B: Backend> Component<B> for BaseNode {
                 let base_node_state = app_state.get_base_node_state();
                 if let Some(ref metadata) = base_node_state.chain_metadata {
                     let tip = metadata.best_block_height();
+                    let scanned_height = app_state.get_wallet_scanned_height();
 
                     let synced = base_node_state.is_synced.unwrap_or_default();
                     let (tip_color, sync_text) = if synced {
@@ -102,7 +103,7 @@ impl<B: Backend> Component<B> for BaseNode {
                     let mut tip_info = vec![
                         Span::styled("Chain Tip:", Style::default().fg(Color::Magenta)),
                         Span::raw(" "),
-                        Span::styled(format!("#{}", tip), Style::default().fg(tip_color)),
+                        Span::styled(format!("#{}({})", tip, scanned_height), Style::default().fg(tip_color)),
                         Span::raw("  "),
                         Span::styled(sync_text.to_string(), Style::default().fg(Color::White)),
                         Span::raw("  "),

--- a/applications/minotari_console_wallet/src/ui/state/wallet_event_monitor.rs
+++ b/applications/minotari_console_wallet/src/ui/state/wallet_event_monitor.rs
@@ -28,6 +28,7 @@ use minotari_wallet::{
     connectivity_service::WalletConnectivityInterface,
     output_manager_service::handle::OutputManagerEvent,
     transaction_service::handle::TransactionEvent,
+    utxo_scanner_service::handle::UtxoScannerEvent,
 };
 use tari_common_types::transaction::TxId;
 use tari_comms::{connectivity::ConnectivityEvent, peer_manager::Peer};
@@ -76,6 +77,12 @@ impl WalletEventMonitor {
         let mut base_node_events = self.app_state_inner.read().await.get_base_node_event_stream();
 
         let mut contacts_liveness_events = self.app_state_inner.read().await.get_contacts_liveness_event_stream();
+        let mut utxo_scanner_events = self
+            .app_state_inner
+            .read()
+            .await
+            .get_wallet_utxo_scanner()
+            .get_event_receiver();
 
         info!(target: LOG_TARGET, "Wallet Event Monitor starting");
         loop {
@@ -213,6 +220,27 @@ impl WalletEventMonitor {
                         Err(broadcast::error::RecvError::Closed) => {}
                     }
                 },
+                result = utxo_scanner_events.recv() => match result {
+                        Ok(event) => {
+                            match event {
+                                UtxoScannerEvent::Progress {
+                                    current_height,..
+                                }=> {
+                                    self.trigger_wallet_scanned_height_update(current_height).await;
+                                }
+                                UtxoScannerEvent::Completed {
+                                    final_height,
+                                    ..
+                                }=> {
+                                self.trigger_wallet_scanned_height_update(final_height).await;
+                                },
+                                _ => {}
+                            }
+                        },
+                        Err(e) => {
+                            warn!(target: LOG_TARGET, "Problem with utxo scanner: {}",e);
+                        },
+                },
                 _ = base_node_changed.changed() => {
                     let peer = base_node_changed.borrow().as_ref().cloned();
                     if let Some(peer) = peer {
@@ -330,6 +358,14 @@ impl WalletEventMonitor {
             if let Err(e) = self.balance_enquiry_debounce_tx.send(()) {
                 warn!(target: LOG_TARGET, "Error refresh app_state: {}", e);
             }
+        }
+    }
+
+    async fn trigger_wallet_scanned_height_update(&mut self, height: u64) {
+        let mut inner = self.app_state_inner.write().await;
+
+        if let Err(e) = inner.trigger_wallet_scanned_height_update(height).await {
+            warn!(target: LOG_TARGET, "Error refresh app_state: {}", e);
         }
     }
 

--- a/base_layer/wallet_ffi/src/callback_handler.rs
+++ b/base_layer/wallet_ffi/src/callback_handler.rs
@@ -55,7 +55,7 @@ use minotari_wallet::{
             models::{CompletedTransaction, InboundTransaction},
         },
     },
-    utxo_scanner_service::handle::{UtxoScannerEvent, UtxoScannerHandle},
+    utxo_scanner_service::handle::UtxoScannerEvent,
 };
 use tari_common_types::{tari_address::TariAddress, transaction::TxId, types::BlockHash};
 use tari_comms_dht::event::{DhtEvent, DhtEventReceiver};

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -5955,6 +5955,8 @@ pub unsafe extern "C" fn wallet_create(
                 },
             };
 
+            let mut utxo_scanner = w.utxo_scanner_service.clone();
+
             // Start Callback Handler
             let callback_handler = CallbackHandler::new(
                 TransactionDatabase::new(transaction_backend),
@@ -5962,7 +5964,7 @@ pub unsafe extern "C" fn wallet_create(
                 w.transaction_service.get_event_stream(),
                 w.output_manager_service.get_event_stream(),
                 w.output_manager_service.clone(),
-                w.utxo_scanner_service.get_event_receiver(),
+                utxo_scanner.get_event_receiver(),
                 w.dht_service.subscribe_dht_events(),
                 w.comms.shutdown_signal(),
                 wallet_address,
@@ -9470,6 +9472,10 @@ mod test {
         // assert!(true); //optimized out by compiler
     }
 
+    unsafe extern "C" fn wallet_scanned_height_callback(_height: u64) {
+        // assert!(true); //optimized out by compiler
+    }
+
     unsafe extern "C" fn base_node_state_callback(_state: *mut TariBaseNodeState) {
         // assert!(true); //optimized out by compiler
     }
@@ -10156,6 +10162,7 @@ mod test {
                 transaction_validation_complete_callback,
                 saf_messages_received_callback,
                 connectivity_status_callback,
+                wallet_scanned_height_callback,
                 base_node_state_callback,
                 recovery_in_progress_ptr,
                 error_ptr,
@@ -10202,6 +10209,7 @@ mod test {
                 transaction_validation_complete_callback,
                 saf_messages_received_callback,
                 connectivity_status_callback,
+                wallet_scanned_height_callback,
                 base_node_state_callback,
                 recovery_in_progress_ptr,
                 error_ptr,
@@ -10317,6 +10325,7 @@ mod test {
                 transaction_validation_complete_callback,
                 saf_messages_received_callback,
                 connectivity_status_callback,
+                wallet_scanned_height_callback,
                 base_node_state_callback,
                 recovery_in_progress_ptr,
                 error_ptr,
@@ -10543,6 +10552,7 @@ mod test {
                 transaction_validation_complete_callback,
                 saf_messages_received_callback,
                 connectivity_status_callback,
+                wallet_scanned_height_callback,
                 base_node_state_callback,
                 recovery_in_progress_ptr,
                 error_ptr,
@@ -10609,6 +10619,7 @@ mod test {
                 transaction_validation_complete_callback,
                 saf_messages_received_callback,
                 connectivity_status_callback,
+                wallet_scanned_height_callback,
                 base_node_state_callback,
                 recovery_in_progress_ptr,
                 error_ptr,
@@ -10687,6 +10698,7 @@ mod test {
                 transaction_validation_complete_callback,
                 saf_messages_received_callback,
                 connectivity_status_callback,
+                wallet_scanned_height_callback,
                 base_node_state_callback,
                 recovery_in_progress_ptr,
                 error_ptr,
@@ -10863,6 +10875,7 @@ mod test {
                 transaction_validation_complete_callback,
                 saf_messages_received_callback,
                 connectivity_status_callback,
+                wallet_scanned_height_callback,
                 base_node_state_callback,
                 recovery_in_progress_ptr,
                 error_ptr,
@@ -11000,6 +11013,7 @@ mod test {
                 transaction_validation_complete_callback,
                 saf_messages_received_callback,
                 connectivity_status_callback,
+                wallet_scanned_height_callback,
                 base_node_state_callback,
                 recovery_in_progress_ptr,
                 error_ptr,
@@ -11217,6 +11231,7 @@ mod test {
                 transaction_validation_complete_callback,
                 saf_messages_received_callback,
                 connectivity_status_callback,
+                wallet_scanned_height_callback,
                 base_node_state_callback,
                 recovery_in_progress_ptr,
                 error_ptr,
@@ -11442,6 +11457,7 @@ mod test {
                 transaction_validation_complete_callback,
                 saf_messages_received_callback,
                 connectivity_status_callback,
+                wallet_scanned_height_callback,
                 base_node_state_callback,
                 recovery_in_progress_ptr,
                 error_ptr,
@@ -11701,6 +11717,7 @@ mod test {
                 transaction_validation_complete_callback,
                 saf_messages_received_callback,
                 connectivity_status_callback,
+                wallet_scanned_height_callback,
                 base_node_state_callback,
                 recovery_in_progress_ptr,
                 error_ptr,
@@ -12078,6 +12095,7 @@ mod test {
                 transaction_validation_complete_callback,
                 saf_messages_received_callback,
                 connectivity_status_callback,
+                wallet_scanned_height_callback,
                 base_node_state_callback,
                 recovery_in_progress_ptr,
                 error_ptr,
@@ -12141,6 +12159,7 @@ mod test {
                 transaction_validation_complete_callback,
                 saf_messages_received_callback,
                 connectivity_status_callback,
+                wallet_scanned_height_callback,
                 base_node_state_callback,
                 recovery_in_progress_ptr,
                 error_ptr,

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -5693,6 +5693,7 @@ pub unsafe extern "C" fn wallet_create(
     callback_transaction_validation_complete: unsafe extern "C" fn(u64, u64),
     callback_saf_messages_received: unsafe extern "C" fn(),
     callback_connectivity_status: unsafe extern "C" fn(u64),
+    callback_wallet_scanned_height: unsafe extern "C" fn(u64),
     callback_base_node_state: unsafe extern "C" fn(*mut TariBaseNodeState),
     recovery_in_progress: *mut bool,
     error_out: *mut c_int,
@@ -5961,6 +5962,7 @@ pub unsafe extern "C" fn wallet_create(
                 w.transaction_service.get_event_stream(),
                 w.output_manager_service.get_event_stream(),
                 w.output_manager_service.clone(),
+                w.utxo_scanner_service.get_event_receiver(),
                 w.dht_service.subscribe_dht_events(),
                 w.comms.shutdown_signal(),
                 wallet_address,
@@ -5982,6 +5984,7 @@ pub unsafe extern "C" fn wallet_create(
                 callback_transaction_validation_complete,
                 callback_saf_messages_received,
                 callback_connectivity_status,
+                callback_wallet_scanned_height,
                 callback_base_node_state,
             );
 

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -2954,6 +2954,7 @@ struct TariWallet *wallet_create(TariCommsConfig *config,
                                  void (*callback_transaction_validation_complete)(uint64_t, uint64_t),
                                  void (*callback_saf_messages_received)(void),
                                  void (*callback_connectivity_status)(uint64_t),
+                                 void (*callback_wallet_scanned_height)(uint64_t),
                                  void (*callback_base_node_state)(struct TariBaseNodeState*),
                                  bool *recovery_in_progress,
                                  int *error_out);


### PR DESCRIPTION
Description
---
adds a callback to the FFI to get access to the height the wallet scanned blocks to
Adds a UI display to console wallet to view the displayed height

Motivation and Context
---
Just showing the tip height of the block chain does not have that high a meaning, its the scanned height that's important an we should show this.

How Has This Been Tested?
---
Manual + unit tests
