### PR TITLE
feat: add pre-mine spend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "version_check",
- "zerocopy 0.7.32",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1250,7 +1250,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "740fe28e594155f10cfc383984cbefd529d7396050557148f79cb0f621204124"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
  "zeroize",
 ]
@@ -1262,7 +1262,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
+ "rand_core",
  "typenum",
 ]
 
@@ -1394,7 +1394,7 @@ dependencies = [
  "digest 0.10.7",
  "fiat-crypto",
  "group",
- "rand_core 0.6.4",
+ "rand_core",
  "rustc_version",
  "serde",
  "subtle",
@@ -1797,7 +1797,7 @@ dependencies = [
  "hkdf",
  "pem-rfc7468",
  "pkcs8",
- "rand_core 0.6.4",
+ "rand_core",
  "sec1",
  "subtle",
  "zeroize",
@@ -1931,7 +1931,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -1948,7 +1948,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
- "rand 0.8.5",
+ "rand",
  "rustc-hex",
  "static_assertions",
 ]
@@ -2267,7 +2267,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -2957,7 +2957,7 @@ dependencies = [
  "libtor-derive",
  "libtor-sys",
  "log",
- "rand 0.8.5",
+ "rand",
  "sha1 0.6.0",
 ]
 
@@ -3072,7 +3072,7 @@ dependencies = [
  "log-mdc",
  "once_cell",
  "parking_lot 0.12.1",
- "rand 0.8.5",
+ "rand",
  "serde",
  "serde-value",
  "serde_json",
@@ -3166,7 +3166,7 @@ checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
 dependencies = [
  "byteorder",
  "keccak",
- "rand_core 0.6.4",
+ "rand_core",
  "zeroize",
 ]
 
@@ -3233,7 +3233,7 @@ dependencies = [
  "log",
  "prost",
  "prost-types",
- "rand 0.8.5",
+ "rand",
  "rcgen",
  "subtle",
  "tari_common_types",
@@ -3260,7 +3260,7 @@ dependencies = [
  "json5",
  "log",
  "minotari_app_grpc",
- "rand 0.8.5",
+ "rand",
  "serde",
  "tari_common",
  "tari_common_types",
@@ -3284,7 +3284,7 @@ dependencies = [
  "log4rs",
  "minotari_app_utilities",
  "openssl",
- "rand 0.8.5",
+ "rand",
  "tari_chat_client",
  "tari_common",
  "tari_common_types",
@@ -3317,7 +3317,7 @@ dependencies = [
  "minotari_ledger_wallet_comms",
  "minotari_wallet",
  "qrcode",
- "rand 0.8.5",
+ "rand",
  "regex",
  "reqwest",
  "rpassword",
@@ -3366,7 +3366,7 @@ dependencies = [
  "log",
  "minotari_ledger_wallet_common",
  "once_cell",
- "rand 0.9.0-alpha.1",
+ "rand",
  "serde",
  "tari_common",
  "tari_common_types",
@@ -3439,7 +3439,7 @@ dependencies = [
  "native-tls",
  "num_cpus",
  "prost-types",
- "rand 0.8.5",
+ "rand",
  "serde",
  "serde_json",
  "tari_common",
@@ -3461,7 +3461,7 @@ dependencies = [
  "cbindgen",
  "hex",
  "libc",
- "rand 0.8.5",
+ "rand",
  "tari_common",
  "tari_common_types",
  "tari_comms",
@@ -3551,7 +3551,7 @@ dependencies = [
  "libsqlite3-sys",
  "log",
  "prost",
- "rand 0.8.5",
+ "rand",
  "serde",
  "serde_json",
  "sha2 0.10.8",
@@ -3597,7 +3597,7 @@ dependencies = [
  "num-traits",
  "once_cell",
  "openssl",
- "rand 0.8.5",
+ "rand",
  "serde_json",
  "tari_common",
  "tari_common_types",
@@ -3848,7 +3848,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand",
  "serde",
  "smallvec",
  "zeroize",
@@ -4148,7 +4148,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
 dependencies = [
  "base64ct",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -4319,7 +4319,7 @@ dependencies = [
  "num-traits",
  "p256",
  "p384",
- "rand 0.8.5",
+ "rand",
  "ripemd",
  "rsa",
  "sha1 0.10.6",
@@ -4369,7 +4369,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
 dependencies = [
  "phf_shared 0.10.0",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -4379,7 +4379,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
 dependencies = [
  "phf_shared 0.11.2",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -4764,7 +4764,7 @@ checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
 dependencies = [
  "env_logger 0.8.4",
  "log",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -4810,19 +4810,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
-version = "0.9.0-alpha.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d31e63ea85be51c423e52ba8f2e68a3efd53eed30203ee029dd09947333693e"
-dependencies = [
- "rand_chacha 0.9.0-alpha.1",
- "rand_core 0.9.0-alpha.1",
- "zerocopy 0.8.0-alpha.6",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -4832,17 +4821,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0-alpha.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78674ef918c19451dbd250f8201f8619b494f64c9aa6f3adb28fd8a0f1f6da46"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.0-alpha.1",
+ "rand_core",
 ]
 
 [[package]]
@@ -4852,16 +4831,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.0-alpha.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc89dffba8377c5ec847d12bb41492bda235dba31a25e8b695cd0fe6589eb8c9"
-dependencies = [
- "getrandom",
- "zerocopy 0.8.0-alpha.6",
 ]
 
 [[package]]
@@ -5107,7 +5076,7 @@ dependencies = [
  "num-traits",
  "pkcs1",
  "pkcs8",
- "rand_core 0.6.4",
+ "rand_core",
  "signature",
  "spki",
  "subtle",
@@ -5590,7 +5559,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
 dependencies = [
  "digest 0.10.7",
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -5663,7 +5632,7 @@ dependencies = [
  "blake2",
  "chacha20poly1305",
  "curve25519-dalek",
- "rand_core 0.6.4",
+ "rand_core",
  "rustc_version",
  "sha2 0.10.8",
  "subtle",
@@ -5969,7 +5938,7 @@ dependencies = [
  "itertools 0.12.1",
  "merlin",
  "once_cell",
- "rand_core 0.6.4",
+ "rand_core",
  "serde",
  "sha3",
  "thiserror-no-std",
@@ -5987,7 +5956,7 @@ dependencies = [
  "lmdb-zero",
  "log",
  "minotari_app_utilities",
- "rand 0.8.5",
+ "rand",
  "serde",
  "tari_common",
  "tari_common_sqlite",
@@ -6056,7 +6025,7 @@ dependencies = [
  "newtype-ops",
  "once_cell",
  "primitive-types",
- "rand 0.8.5",
+ "rand",
  "serde",
  "strum",
  "strum_macros",
@@ -6090,7 +6059,7 @@ dependencies = [
  "once_cell",
  "pin-project 1.1.3",
  "prost",
- "rand 0.8.5",
+ "rand",
  "serde",
  "serde_derive",
  "serde_json",
@@ -6140,7 +6109,7 @@ dependencies = [
  "petgraph 0.5.1",
  "pin-project 0.4.30",
  "prost",
- "rand 0.8.5",
+ "rand",
  "serde",
  "tari_common",
  "tari_common_sqlite",
@@ -6186,7 +6155,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "prost",
- "rand 0.8.5",
+ "rand",
  "serde",
  "serde_json",
  "tari_common",
@@ -6244,7 +6213,7 @@ dependencies = [
  "primitive-types",
  "prost",
  "quickcheck",
- "rand 0.8.5",
+ "rand",
  "randomx-rs",
  "serde",
  "serde_json",
@@ -6294,8 +6263,8 @@ dependencies = [
  "log",
  "merlin",
  "once_cell",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
+ "rand_chacha",
+ "rand_core",
  "serde",
  "sha3",
  "snafu",
@@ -6344,7 +6313,7 @@ dependencies = [
  "minotari_wallet",
  "minotari_wallet_ffi",
  "minotari_wallet_grpc_client",
- "rand 0.8.5",
+ "rand",
  "reqwest",
  "serde_json",
  "tari_chat_client",
@@ -6385,7 +6354,7 @@ dependencies = [
  "futures 0.3.29",
  "js-sys",
  "log",
- "rand 0.8.5",
+ "rand",
  "serde",
  "sha2 0.9.9",
  "strum",
@@ -6409,7 +6378,7 @@ dependencies = [
  "derivative",
  "libtor",
  "log",
- "rand 0.8.5",
+ "rand",
  "tari_common",
  "tari_p2p",
  "tempfile",
@@ -6441,7 +6410,7 @@ dependencies = [
  "criterion 0.5.1",
  "digest 0.10.7",
  "log",
- "rand 0.8.5",
+ "rand",
  "serde",
  "serde_json",
  "tari_crypto",
@@ -6462,7 +6431,7 @@ dependencies = [
  "log",
  "pgp",
  "prost",
- "rand 0.8.5",
+ "rand",
  "reqwest",
  "rustls",
  "semver",
@@ -6493,7 +6462,7 @@ dependencies = [
  "borsh",
  "digest 0.10.7",
  "integer-encoding",
- "rand 0.8.5",
+ "rand",
  "serde",
  "sha2 0.10.8",
  "sha3",
@@ -6534,7 +6503,7 @@ dependencies = [
  "bincode",
  "lmdb-zero",
  "log",
- "rand 0.8.5",
+ "rand",
  "serde",
  "tari_utilities",
  "thiserror",
@@ -6546,7 +6515,7 @@ version = "1.0.0-pre.18"
 dependencies = [
  "futures 0.3.29",
  "futures-test",
- "rand 0.8.5",
+ "rand",
  "tari_comms",
  "tari_shutdown",
  "tempfile",
@@ -7025,7 +6994,7 @@ checksum = "8b83cd43a176c0c19d5db4401283e8f5c296b9c6c7fa29029de15cc445f26e12"
 dependencies = [
  "hex",
  "hex-literal 0.3.4",
- "rand 0.8.5",
+ "rand",
  "sha1 0.6.0",
  "thiserror",
 ]
@@ -7042,7 +7011,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project 1.1.3",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand",
  "slab",
  "tokio",
  "tokio-util 0.7.10",
@@ -7134,7 +7103,7 @@ dependencies = [
  "lazy_static",
  "log",
  "radix_trie",
- "rand 0.8.5",
+ "rand",
  "ring 0.16.20",
  "rustls",
  "thiserror",
@@ -7161,7 +7130,7 @@ dependencies = [
  "ipnet",
  "lazy_static",
  "log",
- "rand 0.8.5",
+ "rand",
  "ring 0.16.20",
  "rustls",
  "rustls-pemfile 0.3.0",
@@ -7847,7 +7816,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb66477291e7e8d2b0ff1bcb900bf29489a9692816d79874bea351e7a8b6de96"
 dependencies = [
  "curve25519-dalek",
- "rand_core 0.6.4",
+ "rand_core",
  "serde",
  "zeroize",
 ]
@@ -7873,7 +7842,7 @@ dependencies = [
  "nohash-hasher",
  "parking_lot 0.12.1",
  "pin-project 1.1.3",
- "rand 0.8.5",
+ "rand",
  "static_assertions",
 ]
 
@@ -7892,16 +7861,7 @@ version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
 dependencies = [
- "zerocopy-derive 0.7.32",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db678a6ee512bd06adf35c35be471cae2f9c82a5aed2b5d15e03628c98bddd57"
-dependencies = [
- "zerocopy-derive 0.8.0-alpha.6",
+ "zerocopy-derive",
 ]
 
 [[package]]
@@ -7909,17 +7869,6 @@ name = "zerocopy-derive"
 version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.38",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201585ea96d37ee69f2ac769925ca57160cef31acb137c16f38b02b76f4c1e62"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/applications/minotari_ledger_wallet/common/src/common_types.rs
+++ b/applications/minotari_ledger_wallet/common/src/common_types.rs
@@ -232,7 +232,8 @@ mod test {
             (0x08, Instruction::GetDHSharedSecret),
             (0x09, Instruction::GetRawSchnorrSignature),
             (0x10, Instruction::GetScriptSchnorrSignature),
-            (0x11, Instruction::GetScriptSignatureManaged),
+            (0x11, Instruction::GetOneSidedMetadataSignature),
+            (0x12, Instruction::GetScriptSignatureManaged),
         ];
 
         for (expected_byte, instruction) in &mappings {

--- a/applications/minotari_ledger_wallet/common/src/common_types.rs
+++ b/applications/minotari_ledger_wallet/common/src/common_types.rs
@@ -76,13 +76,14 @@ pub enum Instruction {
     GetAppName = 0x02,
     GetPublicSpendKey = 0x03,
     GetPublicKey = 0x04,
-    GetScriptSignature = 0x05,
+    GetScriptSignatureDerived = 0x05,
     GetScriptOffset = 0x06,
     GetViewKey = 0x07,
     GetDHSharedSecret = 0x08,
     GetRawSchnorrSignature = 0x09,
     GetScriptSchnorrSignature = 0x10,
     GetOneSidedMetadataSignature = 0x11,
+    GetScriptSignatureManaged = 0x12,
 }
 
 impl Instruction {
@@ -96,13 +97,14 @@ impl Instruction {
             0x02 => Some(Instruction::GetAppName),
             0x03 => Some(Instruction::GetPublicSpendKey),
             0x04 => Some(Instruction::GetPublicKey),
-            0x05 => Some(Instruction::GetScriptSignature),
+            0x05 => Some(Instruction::GetScriptSignatureDerived),
             0x06 => Some(Instruction::GetScriptOffset),
             0x07 => Some(Instruction::GetViewKey),
             0x08 => Some(Instruction::GetDHSharedSecret),
             0x09 => Some(Instruction::GetRawSchnorrSignature),
             0x10 => Some(Instruction::GetScriptSchnorrSignature),
             0x11 => Some(Instruction::GetOneSidedMetadataSignature),
+            0x12 => Some(Instruction::GetScriptSignatureManaged),
             _ => None,
         }
     }
@@ -224,12 +226,13 @@ mod test {
             (0x02, Instruction::GetAppName),
             (0x03, Instruction::GetPublicSpendKey),
             (0x04, Instruction::GetPublicKey),
-            (0x05, Instruction::GetScriptSignature),
+            (0x05, Instruction::GetScriptSignatureDerived),
             (0x06, Instruction::GetScriptOffset),
             (0x07, Instruction::GetViewKey),
             (0x08, Instruction::GetDHSharedSecret),
             (0x09, Instruction::GetRawSchnorrSignature),
             (0x10, Instruction::GetScriptSchnorrSignature),
+            (0x11, Instruction::GetScriptSignatureManaged),
         ];
 
         for (expected_byte, instruction) in &mappings {
@@ -250,7 +253,7 @@ mod test {
                     assert_eq!(instruction.as_byte(), *expected_byte);
                     assert_eq!(Instruction::from_byte(*expected_byte), Some(*instruction));
                 },
-                Instruction::GetScriptSignature => {
+                Instruction::GetScriptSignatureDerived => {
                     assert_eq!(instruction.as_byte(), *expected_byte);
                     assert_eq!(Instruction::from_byte(*expected_byte), Some(*instruction));
                 },
@@ -275,6 +278,10 @@ mod test {
                     assert_eq!(Instruction::from_byte(*expected_byte), Some(*instruction));
                 },
                 Instruction::GetOneSidedMetadataSignature => {
+                    assert_eq!(instruction.as_byte(), *expected_byte);
+                    assert_eq!(Instruction::from_byte(*expected_byte), Some(*instruction));
+                },
+                Instruction::GetScriptSignatureManaged => {
                     assert_eq!(instruction.as_byte(), *expected_byte);
                     assert_eq!(Instruction::from_byte(*expected_byte), Some(*instruction));
                 },

--- a/applications/minotari_ledger_wallet/comms/Cargo.toml
+++ b/applications/minotari_ledger_wallet/comms/Cargo.toml
@@ -20,6 +20,6 @@ ledger-transport-hid = { git = "https://github.com/Zondax/ledger-rs", rev = "20e
 serde = { version = "1.0.106", features = ["derive"] }
 thiserror = "1.0.26"
 
-rand = "0.9.0-alpha.1"
+rand = "0.8"
 once_cell = "1.19.0"
 log = "0.4.20"

--- a/applications/minotari_ledger_wallet/comms/examples/ledger_demo/main.rs
+++ b/applications/minotari_ledger_wallet/comms/examples/ledger_demo/main.rs
@@ -3,6 +3,18 @@
 
 //! # Multi-party Ledger - command line example
 
+/// This example demonstrates how to use the Ledger Nano S/X for the Tari wallet. In order to run the example, you
+/// need to have the `MinoTari Wallet` application installed on your Ledger device. For that, please follow the
+/// instructions in the [README](../../wallet/README.md) file.
+/// With this example, you can:
+/// - Detect the hardware wallet
+/// - Verify that the Ledger application is installed and the version is correct
+/// - TBD
+///
+/// -----------------------------------------------------------------------------------------------
+/// Example use:
+/// `cargo run --release --example ledger_demo`
+/// -----------------------------------------------------------------------------------------------
 use dialoguer::{theme::ColorfulTheme, Select};
 use minotari_ledger_wallet_comms::{
     accessor_methods::{
@@ -21,20 +33,7 @@ use minotari_ledger_wallet_comms::{
     error::LedgerDeviceError,
     ledger_wallet::get_transport,
 };
-use rand::rngs::OsRng;
-/// This example demonstrates how to use the Ledger Nano S/X for the Tari wallet. In order to run the example, you
-/// need to have the `MinoTari Wallet` application installed on your Ledger device. For that, please follow the
-/// instructions in the [README](../../wallet/README.md) file.
-/// With this example, you can:
-/// - Detect the hardware wallet
-/// - Verify that the Ledger application is installed and the version is correct
-/// - TBD
-///
-/// -----------------------------------------------------------------------------------------------
-/// Example use:
-/// `cargo run --release --example ledger_demo`
-/// -----------------------------------------------------------------------------------------------
-use rand::RngCore;
+use rand::{rngs::OsRng, RngCore};
 use tari_common::configuration::Network;
 use tari_common_types::{
     key_branches::TransactionKeyManagerBranch,
@@ -181,18 +180,24 @@ fn main() {
 
     // GetScriptOffset
     println!("\ntest: GetScriptOffset");
-    let total_script_private_key = PrivateKey::default();
-    let mut derived_key_commitments = Vec::new();
+    let partial_script_offset = PrivateKey::default();
+    let mut derived_script_keys = Vec::new();
+    let mut script_key_indexes = Vec::new();
+    let mut derived_sender_offsets = Vec::new();
     let mut sender_offset_indexes = Vec::new();
     for _i in 0..5 {
-        derived_key_commitments.push(get_random_nonce());
-        sender_offset_indexes.push(OsRng.next_u64());
+        derived_script_keys.push(get_random_nonce());
+        script_key_indexes.push((TransactionKeyManagerBranch::Spend, OsRng.next_u64()));
+        derived_sender_offsets.push(get_random_nonce());
+        sender_offset_indexes.push((TransactionKeyManagerBranch::OneSidedSenderOffset, OsRng.next_u64()));
     }
 
     match ledger_get_script_offset(
         account,
-        &total_script_private_key,
-        &derived_key_commitments,
+        &partial_script_offset,
+        &derived_script_keys,
+        &script_key_indexes,
+        &derived_sender_offsets,
         &sender_offset_indexes,
     ) {
         Ok(script_offset) => println!("script_offset:  {}", script_offset.to_hex()),

--- a/applications/minotari_ledger_wallet/comms/src/accessor_methods.rs
+++ b/applications/minotari_ledger_wallet/comms/src/accessor_methods.rs
@@ -33,7 +33,7 @@ use tari_common_types::{
 };
 use tari_crypto::dhke::DiffieHellmanSharedSecret;
 use tari_script::CheckSigSchnorrSignature;
-use tari_utilities::ByteArray;
+use tari_utilities::{hex::Hex, ByteArray};
 
 use crate::{
     error::LedgerDeviceError,
@@ -187,7 +187,7 @@ pub fn ledger_get_version() -> Result<String, LedgerDeviceError> {
 
 /// Get the public alpha key from the ledger device
 pub fn ledger_get_public_spend_key(account: u64) -> Result<PublicKey, LedgerDeviceError> {
-    debug!(target: LOG_TARGET, "ledger_get_public_spend_key: account {}", account);
+    debug!(target: LOG_TARGET, "ledger_get_public_spend_key: account '{}'", account);
     verify_ledger_application()?;
 
     match Command::<Vec<u8>>::build_command(account, Instruction::GetPublicSpendKey, vec![]).execute() {
@@ -212,7 +212,11 @@ pub fn ledger_get_public_key(
     index: u64,
     branch: TransactionKeyManagerBranch,
 ) -> Result<PublicKey, LedgerDeviceError> {
-    debug!(target: LOG_TARGET, "ledger_get_public_key: account {}, index {}, branch {:?}", account, index, branch);
+    debug!(
+        target: LOG_TARGET,
+        "ledger_get_public_key: account '{}', index '{}', branch '{:?}'",
+        account, index, branch
+    );
     verify_ledger_application()?;
 
     let mut data = Vec::new();
@@ -245,9 +249,9 @@ pub fn ledger_get_script_signature(
     value: &PrivateKey,
     commitment_private_key: &PrivateKey,
     commitment: &Commitment,
-    script_message: [u8; 32],
+    message: [u8; 32],
 ) -> Result<ComAndPubSignature, LedgerDeviceError> {
-    debug!(target: LOG_TARGET, "ledger_get_script_signature: account {}", account);
+    debug!(target: LOG_TARGET, "ledger_get_script_signature: account '{}', message '{}'", account, message.to_hex());
     verify_ledger_application()?;
 
     let mut data = Vec::new();
@@ -263,7 +267,7 @@ pub fn ledger_get_script_signature(
     data.extend_from_slice(&commitment_private_key);
     let commitment = commitment.to_vec();
     data.extend_from_slice(&commitment);
-    data.extend_from_slice(&script_message);
+    data.extend_from_slice(&message);
 
     match Command::<Vec<u8>>::build_command(account, Instruction::GetScriptSignature, data).execute() {
         Ok(result) => {
@@ -291,28 +295,55 @@ pub fn ledger_get_script_signature(
 /// Get the script offset from the ledger device
 pub fn ledger_get_script_offset(
     account: u64,
-    total_script_private_key: &PrivateKey,
-    derived_key_commitments: &[PrivateKey],
-    sender_offset_indexes: &[u64],
+    partial_script_offset: &PrivateKey,
+    derived_script_keys: &[PrivateKey],
+    script_key_indexes: &[(TransactionKeyManagerBranch, u64)],
+    derived_sender_offsets: &[PrivateKey],
+    sender_offset_indexes: &[(TransactionKeyManagerBranch, u64)],
 ) -> Result<PrivateKey, LedgerDeviceError> {
-    debug!(target: LOG_TARGET, "ledger_get_script_offset: account {}", account);
+    debug!(
+        target: LOG_TARGET,
+        "ledger_get_script_offset: account '{}', partial_script_offset '{}', derived_script_keys: '{:?}', \
+        script_key_indexes: '{:?}', derived_sender_offsets '{:?}', sender_offset_indexes '{:?}'",
+        account,
+        partial_script_offset.to_hex(),
+        derived_script_keys,
+        script_key_indexes,
+        derived_sender_offsets,
+        sender_offset_indexes
+    );
     verify_ledger_application()?;
 
-    let num_commitments = derived_key_commitments.len() as u64;
-    let num_offset_key = sender_offset_indexes.len() as u64;
-
-    let mut instructions = num_offset_key.to_le_bytes().to_vec();
-    instructions.extend_from_slice(&num_commitments.to_le_bytes());
-
+    // 1. data sizes
+    let mut instructions: Vec<u8> = Vec::new();
+    instructions.extend_from_slice(&(sender_offset_indexes.len() as u64).to_le_bytes());
+    instructions.extend_from_slice(&(script_key_indexes.len() as u64).to_le_bytes());
+    instructions.extend_from_slice(&(derived_sender_offsets.len() as u64).to_le_bytes());
+    instructions.extend_from_slice(&(derived_script_keys.len() as u64).to_le_bytes());
     let mut data: Vec<Vec<u8>> = vec![instructions.to_vec()];
-    data.push(total_script_private_key.to_vec());
 
-    for sender_offset_index in sender_offset_indexes {
-        data.push(sender_offset_index.to_le_bytes().to_vec());
+    // 2. partial_script_offset
+    data.push(partial_script_offset.to_vec());
+
+    // 3. sender_offset_indexes
+    for (branch, index) in sender_offset_indexes {
+        let mut payload = u64::from(branch.as_byte()).to_le_bytes().to_vec();
+        payload.extend_from_slice(&index.to_le_bytes());
+        data.push(payload);
     }
-
-    for derived_key_commitment in derived_key_commitments {
-        data.push(derived_key_commitment.to_vec());
+    // 4. script_key_indexes
+    for (branch, index) in script_key_indexes {
+        let mut payload = u64::from(branch.as_byte()).to_le_bytes().to_vec();
+        payload.extend_from_slice(&index.to_le_bytes());
+        data.push(payload);
+    }
+    // 5. derived_sender_offsets
+    for sender_offset in derived_sender_offsets {
+        data.push(sender_offset.to_vec());
+    }
+    // 6. derived_script_keys
+    for script_key in derived_script_keys {
+        data.push(script_key.to_vec());
     }
 
     let commands = Command::<Vec<u8>>::chunk_command(account, Instruction::GetScriptOffset, data);
@@ -343,7 +374,7 @@ pub fn ledger_get_script_offset(
 
 /// Get the view key from the ledger device
 pub fn ledger_get_view_key(account: u64) -> Result<PrivateKey, LedgerDeviceError> {
-    debug!(target: LOG_TARGET, "ledger_get_view_key: account {}", account);
+    debug!(target: LOG_TARGET, "ledger_get_view_key: account '{}'", account);
     verify_ledger_application()?;
 
     match Command::<Vec<u8>>::build_command(account, Instruction::GetViewKey, vec![]).execute() {
@@ -369,7 +400,11 @@ pub fn ledger_get_dh_shared_secret(
     branch: TransactionKeyManagerBranch,
     public_key: &PublicKey,
 ) -> Result<DiffieHellmanSharedSecret<PublicKey>, LedgerDeviceError> {
-    debug!(target: LOG_TARGET, "ledger_get_dh_shared_secret: account {}, index {}, branch {:?}", account, index, branch);
+    debug!(
+        target: LOG_TARGET,
+        "ledger_get_dh_shared_secret: account '{}', index '{}', branch '{:?}'",
+        account, index, branch
+    );
     verify_ledger_application()?;
 
     let mut data = Vec::new();
@@ -402,8 +437,12 @@ pub fn ledger_get_raw_schnorr_signature(
     nonce_branch: TransactionKeyManagerBranch,
     challenge: &[u8; 64],
 ) -> Result<Signature, LedgerDeviceError> {
-    debug!(target: LOG_TARGET, "ledger_get_raw_schnorr_signature: account {}, pk index {}, pk branch {:?}, nonce index {}, nonce branch {:?}",
-        account, private_key_index, private_key_branch, nonce_index, nonce_branch);
+    debug!(
+        target: LOG_TARGET,
+        "ledger_get_raw_schnorr_signature: account '{}', pk index '{}', pk branch '{:?}', nonce index '{}', \
+        nonce branch' {:?}', challenge '{}'",
+        account, private_key_index, private_key_branch, nonce_index, nonce_branch, challenge.to_hex()
+    );
     verify_ledger_application()?;
 
     let mut data = Vec::new();
@@ -440,8 +479,11 @@ pub fn ledger_get_script_schnorr_signature(
     private_key_branch: TransactionKeyManagerBranch,
     nonce: &[u8],
 ) -> Result<CheckSigSchnorrSignature, LedgerDeviceError> {
-    debug!(target: LOG_TARGET, "ledger_get_raw_schnorr_signature: account {}, pk index {}, pk branch {:?}",
-        account, private_key_index, private_key_branch);
+    debug!(
+        target: LOG_TARGET,
+        "ledger_get_raw_schnorr_signature: account '{}', pk index '{}', pk branch '{:?}'",
+        account, private_key_index, private_key_branch
+    );
     verify_ledger_application()?;
 
     let mut data = Vec::new();
@@ -483,8 +525,13 @@ pub fn ledger_get_one_sided_metadata_signature(
     value: u64,
     sender_offset_key_index: u64,
     commitment_mask: &PrivateKey,
-    metadata_signature_message: &[u8; 32],
+    message: &[u8; 32],
 ) -> Result<ComAndPubSignature, LedgerDeviceError> {
+    debug!(
+        target: LOG_TARGET,
+        "ledger_get_one_sided_metadata_signature: account '{}', message '{}'",
+        account, message.to_hex()
+    );
     verify_ledger_application()?;
 
     let mut data = Vec::new();
@@ -493,7 +540,7 @@ pub fn ledger_get_one_sided_metadata_signature(
     data.extend_from_slice(&sender_offset_key_index.to_le_bytes());
     data.extend_from_slice(&value.to_le_bytes());
     data.extend_from_slice(&commitment_mask.to_vec());
-    data.extend_from_slice(&metadata_signature_message.to_vec());
+    data.extend_from_slice(&message.to_vec());
 
     match Command::<Vec<u8>>::build_command(account, Instruction::GetOneSidedMetadataSignature, data).execute() {
         Ok(result) => {

--- a/applications/minotari_ledger_wallet/wallet/src/handlers/get_script_offset.rs
+++ b/applications/minotari_ledger_wallet/wallet/src/handlers/get_script_offset.rs
@@ -19,11 +19,13 @@ use crate::{
 const MIN_UNIQUE_KEYS: usize = 2;
 
 pub struct ScriptOffsetCtx {
-    total_sender_offset_private_key: Zeroizing<RistrettoSecretKey>,
-    total_script_private_key: Zeroizing<RistrettoSecretKey>,
+    sender_offset_sum: Zeroizing<RistrettoSecretKey>,
+    script_private_key_sum: Zeroizing<RistrettoSecretKey>,
     account: u64,
     total_offset_indexes: u64,
-    total_commitment_keys: u64,
+    total_script_indexes: u64,
+    total_derived_offset_keys: u64,
+    total_derived_script_keys: u64,
     unique_keys: Vec<Zeroizing<RistrettoSecretKey>>,
 }
 
@@ -31,22 +33,26 @@ pub struct ScriptOffsetCtx {
 impl ScriptOffsetCtx {
     pub fn new() -> Self {
         Self {
-            total_sender_offset_private_key: Zeroizing::new(RistrettoSecretKey::default()),
-            total_script_private_key: Zeroizing::new(RistrettoSecretKey::default()),
+            sender_offset_sum: Zeroizing::new(RistrettoSecretKey::default()),
+            script_private_key_sum: Zeroizing::new(RistrettoSecretKey::default()),
             account: 0,
             total_offset_indexes: 0,
-            total_commitment_keys: 0,
+            total_script_indexes: 0,
+            total_derived_offset_keys: 0,
+            total_derived_script_keys: 0,
             unique_keys: Vec::new(),
         }
     }
 
     // Implement reset for TxInfo
     fn reset(&mut self) {
-        self.total_sender_offset_private_key = Zeroizing::new(RistrettoSecretKey::default());
-        self.total_script_private_key = Zeroizing::new(RistrettoSecretKey::default());
+        self.sender_offset_sum = Zeroizing::new(RistrettoSecretKey::default());
+        self.script_private_key_sum = Zeroizing::new(RistrettoSecretKey::default());
         self.account = 0;
         self.total_offset_indexes = 0;
-        self.total_commitment_keys = 0;
+        self.total_script_indexes = 0;
+        self.total_derived_offset_keys = 0;
+        self.total_derived_script_keys = 0;
         self.unique_keys = Vec::new();
     }
 
@@ -57,47 +63,83 @@ impl ScriptOffsetCtx {
     }
 }
 
-fn read_instructions(offset_ctx: &mut ScriptOffsetCtx, data: &[u8]) {
+fn read_instructions(offset_ctx: &mut ScriptOffsetCtx, data: &[u8]) -> Result<(), AppSW> {
+    if data.len() != 40 {
+        return Err(AppSW::WrongApduLength);
+    }
+
     let mut account_bytes = [0u8; 8];
     account_bytes.clone_from_slice(&data[0..8]);
     offset_ctx.account = u64::from_le_bytes(account_bytes);
 
-    if data.len() < 16 {
-        offset_ctx.total_offset_indexes = 0;
-    } else {
-        let mut total_offset_keys = [0u8; 8];
-        total_offset_keys.clone_from_slice(&data[8..16]);
-        offset_ctx.total_offset_indexes = u64::from_le_bytes(total_offset_keys);
-    }
+    let mut total_offset_keys = [0u8; 8];
+    total_offset_keys.clone_from_slice(&data[8..16]);
+    offset_ctx.total_offset_indexes = u64::from_le_bytes(total_offset_keys);
 
-    if data.len() < 24 {
-        offset_ctx.total_commitment_keys = 0;
-    } else {
-        let mut total_commitment_keys = [0u8; 8];
-        total_commitment_keys.clone_from_slice(&data[16..24]);
-        offset_ctx.total_commitment_keys = u64::from_le_bytes(total_commitment_keys);
+    let mut total_script_indexes = [0u8; 8];
+    total_script_indexes.clone_from_slice(&data[16..24]);
+    offset_ctx.total_script_indexes = u64::from_le_bytes(total_script_indexes);
+
+    let mut total_derived_offset_keys = [0u8; 8];
+    total_derived_offset_keys.clone_from_slice(&data[24..32]);
+    offset_ctx.total_derived_offset_keys = u64::from_le_bytes(total_derived_offset_keys);
+
+    let mut total_derived_script_keys = [0u8; 8];
+    total_derived_script_keys.clone_from_slice(&data[32..40]);
+    offset_ctx.total_derived_script_keys = u64::from_le_bytes(total_derived_script_keys);
+
+    Ok(())
+}
+
+fn extract_branch_and_index(data: &[u8]) -> Result<(KeyType, u64), AppSW> {
+    if data.len() != 16 {
+        return Err(AppSW::WrongApduLength);
     }
+    let mut branch_bytes = [0u8; 8];
+    branch_bytes.clone_from_slice(&data[0..8]);
+    let branch_int = u64::from_le_bytes(branch_bytes);
+    let branch = KeyType::from_branch_key(branch_int)?;
+
+    let mut index_bytes = [0u8; 8];
+    index_bytes.clone_from_slice(&data[8..16]);
+    let index = u64::from_le_bytes(index_bytes);
+
+    Ok((branch, index))
+}
+
+fn derive_key_from_alpha(account: u64, data: &[u8]) -> Result<Zeroizing<RistrettoSecretKey>, AppSW> {
+    if data.len() != 32 {
+        return Err(AppSW::WrongApduLength);
+    }
+    let alpha = derive_from_bip32_key(account, STATIC_SPEND_INDEX, KeyType::Spend)?;
+    let blinding_factor: Zeroizing<RistrettoSecretKey> =
+        get_key_from_canonical_bytes::<RistrettoSecretKey>(&data[0..32])?.into();
+
+    alpha_hasher(alpha, blinding_factor)
 }
 
 pub fn handler_get_script_offset(
     comm: &mut Comm,
-    chunk: u8,
+    chunk_number: u8,
     more: bool,
     offset_ctx: &mut ScriptOffsetCtx,
 ) -> Result<(), AppSW> {
     let data = comm.get_data().map_err(|_| AppSW::WrongApduLength)?;
 
-    if chunk == 0 {
+    // 1. data sizes
+    if chunk_number == 0 {
         // Reset offset context
         offset_ctx.reset();
-        read_instructions(offset_ctx, data);
+        read_instructions(offset_ctx, data)?;
         return Ok(());
     }
 
-    if chunk == 1 {
-        // The sum of managed private keys
-        let k: Zeroizing<RistrettoSecretKey> = get_key_from_canonical_bytes::<RistrettoSecretKey>(&data[0..32])?.into();
-        offset_ctx.total_script_private_key = Zeroizing::new(offset_ctx.total_script_private_key.deref() + k.deref());
+    // 2. partial_script_offset
+    if chunk_number == 1 {
+        // Initialize 'script_private_key_sum' with 'partial_script_offset'
+        let partial_script_offset: Zeroizing<RistrettoSecretKey> =
+            get_key_from_canonical_bytes::<RistrettoSecretKey>(&data[0..32])?.into();
+        offset_ctx.script_private_key_sum = partial_script_offset;
 
         return Ok(());
     }
@@ -105,41 +147,55 @@ pub fn handler_get_script_offset(
     let payload_offset = 2;
     let end_offset_indexes = payload_offset + offset_ctx.total_offset_indexes;
 
-    if (payload_offset..end_offset_indexes).contains(&(chunk as u64)) {
-        let mut index_bytes = [0u8; 8];
-        index_bytes.clone_from_slice(&data[0..8]);
-        let index = u64::from_le_bytes(index_bytes);
+    // 3. Indexed Sender offset
+    if (payload_offset..end_offset_indexes).contains(&(chunk_number as u64)) {
+        let (branch, index) = extract_branch_and_index(data)?;
+        let offset = derive_from_bip32_key(offset_ctx.account, index, branch)?;
 
-        let offset = derive_from_bip32_key(offset_ctx.account, index, KeyType::OneSidedSenderOffset)?;
         offset_ctx.add_unique_key(offset.clone());
-        offset_ctx.total_sender_offset_private_key =
-            Zeroizing::new(offset_ctx.total_sender_offset_private_key.deref() + offset.deref());
+        offset_ctx.sender_offset_sum = Zeroizing::new(offset_ctx.sender_offset_sum.deref() + offset.deref());
     }
 
-    let end_commitment_keys = end_offset_indexes + offset_ctx.total_commitment_keys;
+    // 4. Indexed Script key
+    let end_script_indexes = end_offset_indexes + offset_ctx.total_script_indexes;
+    if (end_offset_indexes..end_script_indexes).contains(&(chunk_number as u64)) {
+        let (branch, index) = extract_branch_and_index(data)?;
+        let script_key = derive_from_bip32_key(offset_ctx.account, index, branch)?;
 
-    if (end_offset_indexes..end_commitment_keys).contains(&(chunk as u64)) {
-        let alpha = derive_from_bip32_key(offset_ctx.account, STATIC_SPEND_INDEX, KeyType::Spend)?;
-        let blinding_factor: Zeroizing<RistrettoSecretKey> =
-            get_key_from_canonical_bytes::<RistrettoSecretKey>(&data[0..32])?.into();
+        offset_ctx.add_unique_key(script_key.clone());
+        offset_ctx.script_private_key_sum =
+            Zeroizing::new(offset_ctx.script_private_key_sum.deref() + script_key.deref());
+    }
 
-        let k = alpha_hasher(alpha, blinding_factor)?;
+    // 5. Derived sender offsets key
+    let end_derived_offset_keys = end_script_indexes + offset_ctx.total_derived_offset_keys;
+    if (end_script_indexes..end_derived_offset_keys).contains(&(chunk_number as u64)) {
+        let k = derive_key_from_alpha(offset_ctx.account, data)?;
 
         offset_ctx.add_unique_key(k.clone());
-        offset_ctx.total_script_private_key = Zeroizing::new(offset_ctx.total_script_private_key.deref() + k.deref());
+        offset_ctx.sender_offset_sum = Zeroizing::new(offset_ctx.sender_offset_sum.deref() + k.deref());
+    }
+
+    // 6. Derived script key
+    let end_derived_script_keys = end_derived_offset_keys + offset_ctx.total_derived_script_keys;
+    if (end_derived_offset_keys..end_derived_script_keys).contains(&(chunk_number as u64)) {
+        let k = derive_key_from_alpha(offset_ctx.account, data)?;
+
+        offset_ctx.add_unique_key(k.clone());
+        offset_ctx.script_private_key_sum = Zeroizing::new(offset_ctx.script_private_key_sum.deref() + k.deref());
     }
 
     if more {
         return Ok(());
     }
 
+    // Guard against attacks to extract the spending private key
     if offset_ctx.unique_keys.len() < MIN_UNIQUE_KEYS {
         return Err(AppSW::ScriptOffsetNotUnique);
     }
 
-    let script_offset = Zeroizing::new(
-        offset_ctx.total_script_private_key.deref() - offset_ctx.total_sender_offset_private_key.deref(),
-    );
+    let script_offset =
+        Zeroizing::new(offset_ctx.script_private_key_sum.deref() - offset_ctx.sender_offset_sum.deref());
 
     comm.append(&[RESPONSE_VERSION]); // version
     comm.append(&script_offset.to_vec());

--- a/applications/minotari_ledger_wallet/wallet/src/main.rs
+++ b/applications/minotari_ledger_wallet/wallet/src/main.rs
@@ -125,7 +125,7 @@ pub enum Instruction {
     GetPublicKey,
     GetPublicSpendKey,
     GetScriptSignature,
-    GetScriptOffset { chunk: u8, more: bool },
+    GetScriptOffset { chunk_number: u8, more: bool },
     GetViewKey,
     GetDHSharedSecret,
     GetRawSchnorrSignature,
@@ -139,7 +139,7 @@ const STATIC_VIEW_INDEX: u64 = 57311; // No significance, just a random number b
 const MAX_PAYLOADS: u8 = 250;
 
 #[repr(u8)]
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum KeyType {
     Spend = 0x01,
     Nonce = 0x02,
@@ -195,7 +195,7 @@ impl TryFrom<ApduHeader> for Instruction {
             (InstructionMapping::GetPublicKey, 0, 0) => Ok(Instruction::GetPublicKey),
             (InstructionMapping::GetScriptSignature, 0, 0) => Ok(Instruction::GetScriptSignature),
             (InstructionMapping::GetScriptOffset, 0..=MAX_PAYLOADS, 0 | P2_MORE) => Ok(Instruction::GetScriptOffset {
-                chunk: value.p1,
+                chunk_number: value.p1,
                 more: value.p2 == P2_MORE,
             }),
             (InstructionMapping::GetViewKey, 0, 0) => Ok(Instruction::GetViewKey),
@@ -247,7 +247,9 @@ fn handle_apdu(comm: &mut Comm, ins: Instruction, offset_ctx: &mut ScriptOffsetC
         Instruction::GetPublicKey => handler_get_public_key(comm),
         Instruction::GetPublicSpendKey => handler_get_public_spend_key(comm),
         Instruction::GetScriptSignature => handler_get_script_signature(comm),
-        Instruction::GetScriptOffset { chunk, more } => handler_get_script_offset(comm, chunk, more, offset_ctx),
+        Instruction::GetScriptOffset { chunk_number, more } => {
+            handler_get_script_offset(comm, chunk_number, more, offset_ctx)
+        },
         Instruction::GetViewKey => handler_get_view_key(comm),
         Instruction::GetDHSharedSecret => handler_get_dh_shared_secret(comm),
         Instruction::GetRawSchnorrSignature => handler_get_raw_schnorr_signature(comm),

--- a/applications/minotari_ledger_wallet/wallet/src/main.rs
+++ b/applications/minotari_ledger_wallet/wallet/src/main.rs
@@ -36,7 +36,7 @@ use handlers::{
     get_public_spend_key::handler_get_public_spend_key,
     get_schnorr_signature::{handler_get_raw_schnorr_signature, handler_get_script_schnorr_signature},
     get_script_offset::{handler_get_script_offset, ScriptOffsetCtx},
-    get_script_signature::handler_get_script_signature,
+    get_script_signature::{handler_get_script_signature_derived, handler_get_script_signature_managed},
     get_version::handler_get_version,
     get_view_key::handler_get_view_key,
 };
@@ -124,7 +124,8 @@ pub enum Instruction {
     GetAppName,
     GetPublicKey,
     GetPublicSpendKey,
-    GetScriptSignature,
+    GetScriptSignatureManaged,
+    GetScriptSignatureDerived,
     GetScriptOffset { chunk_number: u8, more: bool },
     GetViewKey,
     GetDHSharedSecret,
@@ -193,7 +194,8 @@ impl TryFrom<ApduHeader> for Instruction {
             (InstructionMapping::GetAppName, 0, 0) => Ok(Instruction::GetAppName),
             (InstructionMapping::GetPublicSpendKey, 0, 0) => Ok(Instruction::GetPublicSpendKey),
             (InstructionMapping::GetPublicKey, 0, 0) => Ok(Instruction::GetPublicKey),
-            (InstructionMapping::GetScriptSignature, 0, 0) => Ok(Instruction::GetScriptSignature),
+            (InstructionMapping::GetScriptSignatureManaged, 0, 0) => Ok(Instruction::GetScriptSignatureManaged),
+            (InstructionMapping::GetScriptSignatureDerived, 0, 0) => Ok(Instruction::GetScriptSignatureDerived),
             (InstructionMapping::GetScriptOffset, 0..=MAX_PAYLOADS, 0 | P2_MORE) => Ok(Instruction::GetScriptOffset {
                 chunk_number: value.p1,
                 more: value.p2 == P2_MORE,
@@ -246,7 +248,8 @@ fn handle_apdu(comm: &mut Comm, ins: Instruction, offset_ctx: &mut ScriptOffsetC
         },
         Instruction::GetPublicKey => handler_get_public_key(comm),
         Instruction::GetPublicSpendKey => handler_get_public_spend_key(comm),
-        Instruction::GetScriptSignature => handler_get_script_signature(comm),
+        Instruction::GetScriptSignatureManaged => handler_get_script_signature_managed(comm),
+        Instruction::GetScriptSignatureDerived => handler_get_script_signature_derived(comm),
         Instruction::GetScriptOffset { chunk_number, more } => {
             handler_get_script_offset(comm, chunk_number, more, offset_ctx)
         },

--- a/base_layer/core/src/transactions/key_manager/inner.rs
+++ b/base_layer/core/src/transactions/key_manager/inner.rs
@@ -173,7 +173,7 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
             let mut km = self
                 .key_managers
                 .get(branch)
-                .ok_or(self.unknown_key_branch_error(branch))?
+                .ok_or_else(|| self.unknown_key_branch_error("get_next_key", branch))?
                 .write()
                 .await;
             self.db.increment_key_index(branch)?;
@@ -188,9 +188,9 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
     }
 
     pub async fn get_random_key(&self) -> Result<KeyAndId<PublicKey>, KeyManagerServiceError> {
+        debug!(target: LOG_TARGET, "get_random_key: wallet type {}", self.wallet_type);
         match &self.wallet_type {
             WalletType::Ledger(ledger) => {
-                debug!(target: LOG_TARGET, "get_random_key: {}", self.wallet_type);
                 #[cfg(not(feature = "ledger"))]
                 {
                     Err(KeyManagerServiceError::LedgerError(format!(
@@ -202,9 +202,9 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
                 {
                     let random_index = OsRng.next_u64();
 
-                    let public_key =
-                        ledger_get_public_key(ledger.account, random_index, TransactionKeyManagerBranch::RandomKey)
-                            .map_err(|e| KeyManagerServiceError::LedgerError(e.to_string()))?;
+                    let branch = TransactionKeyManagerBranch::RandomKey;
+                    let public_key = ledger_get_public_key(ledger.account, random_index, branch)
+                        .map_err(|e| KeyManagerServiceError::LedgerError(e.to_string()))?;
                     Ok(KeyAndId {
                         key_id: KeyId::Managed {
                             branch: TransactionKeyManagerBranch::RandomKey.get_branch_key(),
@@ -228,7 +228,7 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
 
     pub async fn get_static_key(&self, branch: &str) -> Result<TariKeyId, KeyManagerServiceError> {
         match self.key_managers.get(branch) {
-            None => Err(self.unknown_key_branch_error(branch)),
+            None => Err(self.unknown_key_branch_error("get_static_key", branch)),
             Some(_) => Ok(KeyId::Managed {
                 branch: branch.to_string(),
                 index: 0,
@@ -237,12 +237,14 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
     }
 
     pub async fn get_public_key_at_key_id(&self, key_id: &TariKeyId) -> Result<PublicKey, KeyManagerServiceError> {
+        debug!(target: LOG_TARGET, "get_public_key_at_key_id: key_id {}, wallet type {}", key_id, self.wallet_type);
         match key_id {
             KeyId::Managed { branch, index } => {
                 if let WalletType::Ledger(ledger) = &self.wallet_type {
                     match TransactionKeyManagerBranch::from_key(branch) {
-                        TransactionKeyManagerBranch::OneSidedSenderOffset | TransactionKeyManagerBranch::RandomKey => {
-                            debug!(target: LOG_TARGET, "get_public_key_at_key_id: {}", self.wallet_type);
+                        TransactionKeyManagerBranch::OneSidedSenderOffset |
+                        TransactionKeyManagerBranch::RandomKey |
+                        TransactionKeyManagerBranch::PreMine => {
                             #[cfg(not(feature = "ledger"))]
                             {
                                 Err(KeyManagerServiceError::LedgerError(format!(
@@ -266,14 +268,14 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
                             let view_key = ledger
                                 .view_key
                                 .clone()
-                                .ok_or(KeyManagerServiceError::LedgerViewKeyInaccessible)?;
+                                .ok_or(KeyManagerServiceError::LedgerViewKeyInaccessible(key_id.to_string()))?;
                             Ok(PublicKey::from_secret_key(&view_key))
                         },
                         _ => {
                             let km = self
                                 .key_managers
                                 .get(branch)
-                                .ok_or_else(|| self.unknown_key_branch_error(branch))?
+                                .ok_or_else(|| self.unknown_key_branch_error("get_public_key_at_key_id", branch))?
                                 .read()
                                 .await;
                             Ok(km.derive_public_key(*index)?.key)
@@ -283,7 +285,7 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
                     let km = self
                         .key_managers
                         .get(branch)
-                        .ok_or_else(|| self.unknown_key_branch_error(branch))?
+                        .ok_or_else(|| self.unknown_key_branch_error("get_public_key_at_key_id", branch))?
                         .read()
                         .await;
                     Ok(km.derive_public_key(*index)?.key)
@@ -312,12 +314,25 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
         }
     }
 
-    fn unknown_key_branch_error(&self, branch: &str) -> KeyManagerServiceError {
-        KeyManagerServiceError::UnknownKeyBranch(format!("{}, {}", branch, self.wallet_type))
+    fn unknown_key_branch_error(&self, caller: &str, branch: &str) -> KeyManagerServiceError {
+        KeyManagerServiceError::UnknownKeyBranch(format!(
+            "{}: branch: {}, wallet_type: {}",
+            caller, branch, self.wallet_type
+        ))
     }
 
-    fn branch_not_supported_error(&self, branch: &str) -> KeyManagerServiceError {
-        KeyManagerServiceError::BranchNotSupported(format!("{}, {}", branch, self.wallet_type))
+    fn branch_not_supported_error(&self, caller: &str, branch: &str) -> KeyManagerServiceError {
+        KeyManagerServiceError::BranchNotSupported(format!(
+            "{}: branch: {}, wallet_type: {}",
+            caller, branch, self.wallet_type
+        ))
+    }
+
+    fn key_id_not_supported_error(&self, caller: &str, expected: &str, key_id: &TariKeyId) -> TransactionError {
+        TransactionError::UnsupportedTariKeyId(format!(
+            "{}: Expected '{}', got {}, wallet_type: {}",
+            caller, expected, key_id, self.wallet_type
+        ))
     }
 
     #[allow(clippy::too_many_lines)]
@@ -336,14 +351,16 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
                             return wallet
                                 .view_key
                                 .clone()
-                                .ok_or(KeyManagerServiceError::LedgerViewKeyInaccessible);
+                                .ok_or(KeyManagerServiceError::LedgerViewKeyInaccessible(key_id.to_string()));
                         }
 
                         // If we're trying to access any of the private keys, just say no bueno
                         if &TransactionKeyManagerBranch::Spend.get_branch_key() == branch ||
-                            &TransactionKeyManagerBranch::OneSidedSenderOffset.get_branch_key() == branch
+                            &TransactionKeyManagerBranch::OneSidedSenderOffset.get_branch_key() == branch ||
+                            &TransactionKeyManagerBranch::PreMine.get_branch_key() == branch ||
+                            &TransactionKeyManagerBranch::RandomKey.get_branch_key() == branch
                         {
-                            return Err(KeyManagerServiceError::LedgerPrivateKeyInaccessible);
+                            return Err(KeyManagerServiceError::LedgerPrivateKeyInaccessible(key_id.to_string()));
                         }
                     },
                     WalletType::ProvidedKeys(wallet) => {
@@ -353,10 +370,9 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
 
                         // If we're trying to access any of the private keys, just say no bueno
                         if &TransactionKeyManagerBranch::Spend.get_branch_key() == branch {
-                            return wallet
-                                .private_spend_key
-                                .clone()
-                                .ok_or(KeyManagerServiceError::ImportedPrivateKeyInaccessible);
+                            return wallet.private_spend_key.clone().ok_or(
+                                KeyManagerServiceError::ImportedPrivateKeyInaccessible(key_id.to_string()),
+                            );
                         }
                     },
                 }
@@ -364,7 +380,7 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
                 let km = self
                     .key_managers
                     .get(branch)
-                    .ok_or(self.unknown_key_branch_error(branch))?
+                    .ok_or_else(|| self.unknown_key_branch_error("get_private_key", branch))?
                     .read()
                     .await;
                 let key = km.get_private_key(*index)?;
@@ -377,13 +393,18 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
                 let commitment_mask = Box::pin(self.get_private_key(&key)).await?;
 
                 match &self.wallet_type {
-                    WalletType::Ledger(_) => Err(KeyManagerServiceError::LedgerPrivateKeyInaccessible),
+                    WalletType::Ledger(_) => {
+                        Err(KeyManagerServiceError::LedgerPrivateKeyInaccessible(key_id.to_string()))
+                    },
                     WalletType::DerivedKeys => {
                         let km = self
                             .key_managers
                             .get(&TransactionKeyManagerBranch::Spend.get_branch_key())
                             .ok_or_else(|| {
-                                self.unknown_key_branch_error(&TransactionKeyManagerBranch::Spend.get_branch_key())
+                                self.unknown_key_branch_error(
+                                    "get_private_key",
+                                    &TransactionKeyManagerBranch::Spend.get_branch_key(),
+                                )
                             })?
                             .read()
                             .await;
@@ -400,10 +421,9 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
                         Ok(private_key)
                     },
                     WalletType::ProvidedKeys(wallet) => {
-                        let private_alpha = wallet
-                            .private_spend_key
-                            .clone()
-                            .ok_or(KeyManagerServiceError::ImportedPrivateKeyInaccessible)?;
+                        let private_alpha = wallet.private_spend_key.clone().ok_or(
+                            KeyManagerServiceError::ImportedPrivateKeyInaccessible(key_id.to_string()),
+                        )?;
 
                         let hasher =
                             DomainSeparatedHasher::<Blake2b<U64>, KeyManagerTransactionsHashDomain>::new_with_label(
@@ -498,7 +518,7 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
             WalletType::Ledger(ledger) => ledger
                 .view_key
                 .clone()
-                .ok_or(KeyManagerServiceError::LedgerViewKeyInaccessible),
+                .ok_or(KeyManagerServiceError::LedgerViewKeyInaccessible(format!("{}", ledger))),
             WalletType::ProvidedKeys(wallet) => Ok(wallet.view_key.clone()),
         }
     }
@@ -519,7 +539,7 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
                 let km = self
                     .key_managers
                     .get(&branch)
-                    .ok_or_else(|| self.unknown_key_branch_error(&branch))?
+                    .ok_or_else(|| self.unknown_key_branch_error("get_private_comms_key", &branch))?
                     .read()
                     .await;
                 let key = km.get_private_key(index)?;
@@ -554,7 +574,7 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
         let km = self
             .key_managers
             .get(branch)
-            .ok_or(self.unknown_key_branch_error(branch))?
+            .ok_or_else(|| self.unknown_key_branch_error("find_key_index", branch))?
             .read()
             .await;
 
@@ -585,7 +605,7 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
         let km = self
             .key_managers
             .get(branch)
-            .ok_or(self.unknown_key_branch_error(branch))?
+            .ok_or_else(|| self.unknown_key_branch_error("find_private_key_index", branch))?
             .read()
             .await;
 
@@ -621,7 +641,7 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
         let mut km = self
             .key_managers
             .get(branch)
-            .ok_or(self.unknown_key_branch_error(branch))?
+            .ok_or_else(|| self.unknown_key_branch_error("update_current_key_index_if_higher", branch))?
             .write()
             .await;
         let current_index = km.key_index();
@@ -665,11 +685,16 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
         secret_key_id: &TariKeyId,
         public_key: &PublicKey,
     ) -> Result<CommsDHKE, TransactionError> {
+        debug!(
+            target: LOG_TARGET,
+            "get_diffie_hellman_shared_secret: secret_key_id {}, wallet type {}",
+            secret_key_id,
+            self.wallet_type
+        );
         if let WalletType::Ledger(ledger) = &self.wallet_type {
             if let KeyId::Managed { branch, index } = secret_key_id {
                 match TransactionKeyManagerBranch::from_key(branch) {
                     TransactionKeyManagerBranch::OneSidedSenderOffset | TransactionKeyManagerBranch::RandomKey => {
-                        debug!(target: LOG_TARGET, "get_diffie_hellman_shared_secret: {}", self.wallet_type);
                         #[cfg(not(feature = "ledger"))]
                         {
                             return Err(TransactionError::LedgerNotSupported(format!(
@@ -704,6 +729,12 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
         secret_key_id: &TariKeyId,
         public_key: &PublicKey,
     ) -> Result<DomainSeparatedHash<Blake2b<U64>>, TransactionError> {
+        debug!(
+            target: LOG_TARGET,
+            "get_diffie_hellman_stealth_domain_hasher: secret_key_id {}, wallet type {}",
+            secret_key_id,
+            self.wallet_type
+        );
         match &self.wallet_type {
             WalletType::Ledger(ledger) => match secret_key_id {
                 KeyId::Managed { branch, index } => match TransactionKeyManagerBranch::from_key(branch) {
@@ -729,12 +760,16 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
                             .map(diffie_hellman_stealth_domain_hasher)
                         }
                     },
-                    _ => Err(TransactionError::from(self.branch_not_supported_error(branch))),
+                    _ => Err(TransactionError::from(self.branch_not_supported_error(
+                        "get_diffie_hellman_stealth_domain_hasher",
+                        branch,
+                    ))),
                 },
-                _ => Err(TransactionError::UnsupportedTariKeyId(format!(
-                    "Expected 'KeyId::Managed', got {}",
-                    secret_key_id
-                ))),
+                _ => Err(self.key_id_not_supported_error(
+                    "get_diffie_hellman_stealth_domain_hasher",
+                    "KeyId::Managed",
+                    secret_key_id,
+                )),
             },
             _ => {
                 let secret_key = self.get_private_key(secret_key_id).await?;
@@ -787,31 +822,57 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
         txi_version: &TransactionInputVersion,
         script_message: &[u8; 32],
     ) -> Result<ComAndPubSignature, TransactionError> {
+        debug!(
+            target: LOG_TARGET,
+            "get_script_signature: script_key_id {}, wallet type {}",
+            script_key_id,
+            self.wallet_type
+        );
         let commitment = self.get_commitment(commitment_mask_key_id, value).await?;
         let commitment_private_key = self.get_private_key(commitment_mask_key_id).await?;
 
-        match (&self.wallet_type, script_key_id) {
-            (WalletType::Ledger(ledger), KeyId::Derived { key }) => {
-                debug!(target: LOG_TARGET, "get_script_signature: {}", self.wallet_type);
+        match &self.wallet_type {
+            WalletType::Ledger(ledger) => {
                 #[cfg(not(feature = "ledger"))]
                 {
                     Err(TransactionError::LedgerNotSupported(format!(
                         "{} 'get_script_signature' was called. ({} (has key {}))",
-                        LEDGER_NOT_SUPPORTED, ledger, key
+                        LEDGER_NOT_SUPPORTED, ledger, key_str
                     )))
                 }
 
                 #[cfg(feature = "ledger")]
                 {
-                    let key = TariKeyId::from_str(key.to_string().as_str())
-                        .map_err(|_| KeyManagerServiceError::KeySerializationError)?;
-                    let key = self.get_private_key(&key).await?;
+                    let branch_key = match script_key_id {
+                        TariKeyId::Managed { branch, index } => {
+                            let km = self
+                                .key_managers
+                                .get(branch)
+                                .ok_or_else(|| self.unknown_key_branch_error("get_script_signature", branch))?
+                                .read()
+                                .await;
+                            km.get_private_key(*index)
+                                .map_err(|e| TransactionError::KeyManagerError(e.to_string()))?
+                        },
+                        TariKeyId::Derived { key: key_str } => {
+                            let key = TariKeyId::from_str(key_str.to_string().as_str())
+                                .map_err(|_| KeyManagerServiceError::KeySerializationError)?;
+                            self.get_private_key(&key).await?
+                        },
+                        _ => {
+                            return Err(self.key_id_not_supported_error(
+                                "get_script_signature",
+                                "KeyId::Managed or KeyId::Derived",
+                                script_key_id,
+                            ));
+                        },
+                    };
 
                     let signature = ledger_get_script_signature(
                         ledger.account,
                         ledger.network,
                         txi_version.as_u8(),
-                        &key,
+                        &branch_key,
                         value,
                         &commitment_private_key,
                         &commitment,
@@ -821,11 +882,7 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
                     Ok(signature)
                 }
             },
-            (WalletType::Ledger(_ledger), key_id) => Err(TransactionError::UnsupportedTariKeyId(format!(
-                "Expected 'KeyId::Derived', got {}",
-                key_id
-            ))),
-            (_, _) => {
+            _ => {
                 let r_a = PrivateKey::random(&mut OsRng);
                 let r_x = PrivateKey::random(&mut OsRng);
                 let r_y = PrivateKey::random(&mut OsRng);
@@ -958,31 +1015,42 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
         script_key_ids: &[TariKeyId],
         sender_offset_key_ids: &[TariKeyId],
     ) -> Result<PrivateKey, TransactionError> {
-        let mut total_script_private_key = PrivateKey::default();
-        let mut derived_key_commitments = vec![];
-        for script_key_id in script_key_ids {
-            match script_key_id {
-                KeyId::Imported { .. } | KeyId::Managed { .. } | KeyId::Zero => {
-                    total_script_private_key = &total_script_private_key + self.get_private_key(script_key_id).await?
-                },
-                KeyId::Derived { key } => match &self.wallet_type {
-                    WalletType::DerivedKeys | WalletType::ProvidedKeys(_) => {
-                        total_script_private_key =
-                            &total_script_private_key + self.get_private_key(script_key_id).await?;
-                    },
-                    WalletType::Ledger(_) => {
-                        let key = TariKeyId::from_str(key.to_string().as_str())
-                            .map_err(|_| KeyManagerServiceError::KeySerializationError)?;
-
-                        let key = self.get_private_key(&key).await?;
-                        derived_key_commitments.push(key);
-                    },
-                },
-            }
-        }
+        debug!(
+            target: LOG_TARGET,
+            "get_script_offset: script_key_ids {:?}, sender_offset_key_ids {:?}, wallet type {}",
+            script_key_ids,
+            sender_offset_key_ids,
+            self.wallet_type
+        );
+        // let mut total_script_private_key = PrivateKey::default();
+        // let mut derived_key_commitments = vec![];
+        // for script_key_id in script_key_ids {
+        //     match script_key_id {
+        //         KeyId::Imported { .. } | KeyId::Managed { .. } | KeyId::Zero => {
+        //             total_script_private_key = &total_script_private_key + self.get_private_key(script_key_id).await?
+        //         },
+        //         KeyId::Derived { key } => match &self.wallet_type {
+        //             WalletType::DerivedKeys | WalletType::ProvidedKeys(_) => {
+        //                 total_script_private_key =
+        //                     &total_script_private_key + self.get_private_key(script_key_id).await?;
+        //             },
+        //             WalletType::Ledger(_) => {
+        //                 let key = TariKeyId::from_str(key.to_string().as_str())
+        //                     .map_err(|_| KeyManagerServiceError::KeySerializationError)?;
+        //
+        //                 let key = self.get_private_key(&key).await?;
+        //                 derived_key_commitments.push(key);
+        //             },
+        //         },
+        //     }
+        // }
 
         match &self.wallet_type {
             WalletType::DerivedKeys | WalletType::ProvidedKeys(_) => {
+                let mut total_script_private_key = PrivateKey::default();
+                for script_key_id in script_key_ids {
+                    total_script_private_key = &total_script_private_key + self.get_private_key(script_key_id).await?
+                }
                 let mut total_sender_offset_private_key = PrivateKey::default();
                 for sender_offset_key_id in sender_offset_key_ids {
                     total_sender_offset_private_key =
@@ -992,7 +1060,6 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
                 Ok(script_offset)
             },
             WalletType::Ledger(ledger) => {
-                debug!(target: LOG_TARGET, "get_script_offset: {}", self.wallet_type);
                 #[cfg(not(feature = "ledger"))]
                 {
                     Err(TransactionError::LedgerNotSupported(format!(
@@ -1003,26 +1070,92 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
 
                 #[cfg(feature = "ledger")]
                 {
-                    let mut total_script_private_key = PrivateKey::default();
+                    let mut partial_script_offset = PrivateKey::default();
+                    let mut derived_script_keys = vec![];
+                    let mut script_key_indexes = vec![];
+                    for script_key_id in script_key_ids {
+                        match script_key_id {
+                            TariKeyId::Managed { branch, index } => {
+                                match TransactionKeyManagerBranch::from_key(branch) {
+                                    TransactionKeyManagerBranch::Spend | TransactionKeyManagerBranch::PreMine => {
+                                        script_key_indexes
+                                            .push((TransactionKeyManagerBranch::from_key(branch), *index));
+                                    },
+                                    _ => {
+                                        return Err(TransactionError::from(
+                                            self.branch_not_supported_error("get_script_offset", branch),
+                                        ));
+                                    },
+                                }
+                            },
+                            TariKeyId::Derived { key } => {
+                                // TODO: What about if the derived key is a TariKeyId::Managed, but
+                                // TODO: `self.get_private_key(...)` will error?
+                                let key_id = TariKeyId::from_str(key.to_string().as_str())
+                                    .map_err(|_| KeyManagerServiceError::KeySerializationError)?;
+                                let k = self.get_private_key(&key_id).await?;
+                                derived_script_keys.push(k);
+                            },
+                            TariKeyId::Imported { .. } => {
+                                partial_script_offset =
+                                    &partial_script_offset + self.get_private_key(script_key_id).await?
+                            },
+                            TariKeyId::Zero => {
+                                return Err(self.key_id_not_supported_error(
+                                    "get_script_offset",
+                                    "KeyId::Managed or TariKeyId::Imported",
+                                    script_key_id,
+                                ));
+                            },
+                        }
+                    }
+
+                    let mut derived_offset_keys = vec![];
                     let mut sender_offset_indexes = vec![];
                     for sender_offset_key_id in sender_offset_key_ids {
                         match sender_offset_key_id {
                             TariKeyId::Managed { branch, index } => {
-                                if &TransactionKeyManagerBranch::OneSidedSenderOffset.get_branch_key() == branch {
-                                    sender_offset_indexes.push(*index);
-                                } else {
-                                    total_script_private_key =
-                                        total_script_private_key - self.get_private_key(sender_offset_key_id).await?;
+                                match TransactionKeyManagerBranch::from_key(branch) {
+                                    TransactionKeyManagerBranch::OneSidedSenderOffset |
+                                    TransactionKeyManagerBranch::RandomKey => {
+                                        sender_offset_indexes
+                                            .push((TransactionKeyManagerBranch::from_key(branch), *index));
+                                    },
+                                    _ => {
+                                        return Err(TransactionError::from(
+                                            self.branch_not_supported_error("get_script_offset", branch),
+                                        ));
+                                    },
                                 }
                             },
-                            TariKeyId::Derived { .. } | TariKeyId::Imported { .. } | TariKeyId::Zero => {},
+                            TariKeyId::Derived { key } => {
+                                // TODO: What about if the derived key is a TariKeyId::Managed, but
+                                // TODO: `self.get_private_key(...)` will error?
+                                let key_id = TariKeyId::from_str(key.to_string().as_str())
+                                    .map_err(|_| KeyManagerServiceError::KeySerializationError)?;
+                                let k = self.get_private_key(&key_id).await?;
+                                derived_offset_keys.push(k);
+                            },
+                            TariKeyId::Imported { .. } => {
+                                partial_script_offset =
+                                    partial_script_offset - self.get_private_key(sender_offset_key_id).await?;
+                            },
+                            TariKeyId::Zero => {
+                                return Err(self.key_id_not_supported_error(
+                                    "get_script_offset",
+                                    "KeyId::Managed or TariKeyId::Imported",
+                                    sender_offset_key_id,
+                                ));
+                            },
                         }
                     }
 
                     let script_offset = ledger_get_script_offset(
                         ledger.account,
-                        &total_script_private_key,
-                        &derived_key_commitments,
+                        &partial_script_offset,
+                        &derived_script_keys,
+                        &script_key_indexes,
+                        &derived_offset_keys,
                         &sender_offset_indexes,
                     )
                     .map_err(|e| TransactionError::InvalidSignatureError(e.to_string()))?;
@@ -1079,9 +1212,14 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
         private_key_id: &TariKeyId,
         challenge: &[u8],
     ) -> Result<CheckSigSchnorrSignature, TransactionError> {
+        debug!(
+            target: LOG_TARGET,
+            "sign_script_message: private_key_id {}, wallet type {}",
+            private_key_id,
+            self.wallet_type
+        );
         match &self.wallet_type {
             WalletType::Ledger(ledger) => {
-                debug!(target: LOG_TARGET, "sign_script_message: {}", self.wallet_type);
                 #[cfg(not(feature = "ledger"))]
                 {
                     Err(TransactionError::LedgerNotSupported(format!(
@@ -1102,10 +1240,11 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
                             )?;
                             Ok(signature)
                         },
-                        _ => Err(TransactionError::UnsupportedTariKeyId(format!(
-                            "Expected 'KeyId::Managed', got {}",
-                            private_key_id
-                        ))),
+                        _ => Err(self.key_id_not_supported_error(
+                            "sign_script_message",
+                            "KeyId::Managed",
+                            private_key_id,
+                        )),
                     }
                 }
             },
@@ -1124,9 +1263,15 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
         nonce_key_id: &TariKeyId,
         challenge: &[u8; 64],
     ) -> Result<Signature, TransactionError> {
+        debug!(
+            target: LOG_TARGET,
+            "sign_with_nonce_and_challenge: private_key_id {}, nonce_key_id {}, wallet type {}",
+            private_key_id,
+            nonce_key_id,
+            self.wallet_type
+        );
         match &self.wallet_type {
             WalletType::Ledger(ledger) => {
-                debug!(target: LOG_TARGET, "sign_with_nonce_and_challenge: {}", self.wallet_type);
                 #[cfg(not(feature = "ledger"))]
                 {
                     Err(TransactionError::LedgerNotSupported(format!(
@@ -1157,15 +1302,17 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
                                 .map_err(|e| KeyManagerServiceError::LedgerError(e.to_string()))?;
                                 Ok(signature)
                             },
-                            _ => Err(TransactionError::UnsupportedTariKeyId(format!(
-                                "Expected 'KeyId::Managed', got {}",
-                                nonce_key_id
-                            ))),
+                            _ => Err(self.key_id_not_supported_error(
+                                "sign_with_nonce_and_challenge",
+                                "KeyId::Managed",
+                                nonce_key_id,
+                            )),
                         },
-                        _ => Err(TransactionError::UnsupportedTariKeyId(format!(
-                            "Expected 'KeyId::Managed', got {}",
-                            private_key_id
-                        ))),
+                        _ => Err(self.key_id_not_supported_error(
+                            "sign_with_nonce_and_challenge",
+                            "KeyId::Managed",
+                            private_key_id,
+                        )),
                     }
                 }
             },
@@ -1230,6 +1377,13 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
         metadata_signature_message: &[u8; 32],
         range_proof_type: RangeProofType,
     ) -> Result<ComAndPubSignature, TransactionError> {
+        debug!(
+            target: LOG_TARGET,
+            "get_one_sided_metadata_signature: commitment_mask_key_id {}, sender_offset_key_id {}, wallet type {}",
+            commitment_mask_key_id,
+            sender_offset_key_id,
+            self.wallet_type
+        );
         match &self.wallet_type {
             WalletType::DerivedKeys | WalletType::ProvidedKeys(_) => {
                 let value = value.into();
@@ -1244,7 +1398,6 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
                 .await
             },
             WalletType::Ledger(ledger) => {
-                debug!(target: LOG_TARGET, "get_one_sided_metadata_signature: {}", self.wallet_type);
                 #[cfg(not(feature = "ledger"))]
                 {
                     Err(TransactionError::LedgerNotSupported(format!(
@@ -1262,6 +1415,11 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
 
                     let commitment_mask = self.get_private_key(commitment_mask_key_id).await?;
 
+                    debug!(
+                        target: LOG_TARGET,
+                        "get_one_sided_metadata_signature: (ledger) account {}",
+                        ledger.account,
+                    );
                     let comm_and_pub_sig = ledger_get_one_sided_metadata_signature(
                         ledger.account,
                         ledger.network,

--- a/base_layer/core/src/transactions/key_manager/inner.rs
+++ b/base_layer/core/src/transactions/key_manager/inner.rs
@@ -852,8 +852,8 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
                 #[cfg(not(feature = "ledger"))]
                 {
                     Err(TransactionError::LedgerNotSupported(format!(
-                        "{} 'get_script_signature' was called. ({} (has key {}))",
-                        LEDGER_NOT_SUPPORTED, ledger, key_str
+                        "{} 'get_script_signature' was called. ({})",
+                        LEDGER_NOT_SUPPORTED, ledger
                     )))
                 }
 

--- a/base_layer/key_manager/src/key_manager_service/error.rs
+++ b/base_layer/key_manager/src/key_manager_service/error.rs
@@ -57,14 +57,14 @@ pub enum KeyManagerServiceError {
     UnknownError(String),
     #[error("Ledger error: `{0}`")]
     LedgerError(String),
-    #[error("The Ledger private key cannot be accessed or read")]
-    LedgerPrivateKeyInaccessible,
-    #[error("The Ledger view key cannot be accessed or read")]
-    LedgerViewKeyInaccessible,
+    #[error("The Ledger private key cannot be accessed or read: `{0}`")]
+    LedgerPrivateKeyInaccessible(String),
+    #[error("The Ledger view key cannot be accessed or read: `{0}`")]
+    LedgerViewKeyInaccessible(String),
     #[error("Tari Key Manager storage error: `{0}`")]
     StorageError(#[from] StorageError),
-    #[error("The imported private key cannot be accessed or read")]
-    ImportedPrivateKeyInaccessible,
+    #[error("The imported private key cannot be accessed or read: `{0}")]
+    ImportedPrivateKeyInaccessible(String),
 }
 
 impl From<RangeProofError> for KeyManagerServiceError {


### PR DESCRIPTION
Description
---
Added pre-mine spend with improved logging for fault finding

Motivation and Context
---
Pre-mine spending did not work.

How Has This Been Tested?
---
A new esmeralda genesis block that includes pre-mine with a 2-of-3 scheme and a backup spending wallet was created, utilizing 4x ledger console wallets. Those wallets were then used to spend the 1st pre-mine UTXO. The UTXO was successfully mined and imported into the target wallet.

Leader's ledger console wallet console:
```
PS C:\Users\pluto\.tari-Hansie\node_01> .\minotari_console_wallet.exe --base-path . --network esmeralda --config $pwd"\config\config.toml" --log-config $pwd"\config\log4rs_console_wallet.yml" pre-mine-spend-session-info --fee-per-gram 5 --output-index 0 --recipient-address f27jozcSQjY2QfopvAeuNMDJX5z9T6vThdBRSteaanwecG1F31ez7vUUCVCihFL6UrJHLVY9EPxkRrgHJLwdPJNxtz4 --verify-unspent-outputs
Initializing logging according to "C:\\Users\\pluto\\.tari-Hansie\\node_01\\config\\log4rs_console_wallet.yml"
Minotari Console Wallet running... (Command mode started)
==============
Command Runner
==============

1. PreMineSpendSessionInfo(PreMineSpendSessionInfoArgs { fee_per_gram: MicroMinotari(5), output_index: 0, recipient_address: Dual(DualAddress { network: Esmeralda, features: TariAddressFeatures(1), public_view_key: 4c5b2793fc2504965138bebf97862af0865ff249e3b8e69b06d441dab0f70346, public_spend_key: b492d5ddf85688c452765180b6e18cc31a0a3ee401ec275d67118145d97cbd67 }), verify_unspent_outputs: true })


Concluded step 1 'pre-mine-generate-session-info'
Your session ID is:                 '8Tj5eMbr7Z3NXUs3'
Your session's output directory is: 'C:\Users\pluto\Documents\tari_pre_mine\spend\8Tj5eMbr7Z3NXUs3'
Session info saved to:              'C:\Users\pluto\Documents\tari_pre_mine\spend\8Tj5eMbr7Z3NXUs3\step_1_session_info.json'
Send 'step_1_session_info.json' to parties for step 2

Minotari Console Wallet running... (Command mode completed)

Shutting down wallet... Done.
PS C:\Users\pluto\.tari-Hansie\node_01> .\minotari_console_wallet.exe --base-path . --network esmeralda --config $pwd"\config\config.toml" --log-config $pwd"\config\log4rs_console_wallet.yml" pre-mine-spend-encumber-aggregate-utxo --session-id 8Tj5eMbr7Z3NXUs3 --input-file-names=step_2_for_leader_from_carol.json
Initializing logging according to "C:\\Users\\pluto\\.tari-Hansie\\node_01\\config\\log4rs_console_wallet.yml"
Minotari Console Wallet running... (Command mode started)
==============
Command Runner
==============

1. PreMineSpendEncumberAggregateUtxo(PreMineSpendEncumberAggregateUtxoArgs { session_id: "8Tj5eMbr7Z3NXUs3", input_file_names: ["step_2_for_leader_from_carol.json"] })


Concluded step 3 'pre-mine-encumber-aggregate-utxo'
Send 'step_3_for_parties.json' to parties for step 4

Minotari Console Wallet running... (Command mode completed)

Shutting down wallet... Done.
PS C:\Users\pluto\.tari-Hansie\node_01> .\minotari_console_wallet.exe --base-path . --network esmeralda --config $pwd"\config\config.toml" --log-config $pwd"\config\log4rs_console_wallet.yml" pre-mine-spend-aggregate-transaction --session-id 8Tj5eMbr7Z3NXUs3 --input-file-names=step_4_for_leader_from_carol.json
Initializing logging according to "C:\\Users\\pluto\\.tari-Hansie\\node_01\\config\\log4rs_console_wallet.yml"
Minotari Console Wallet running... (Command mode started)
==============
Command Runner
==============

1. PreMineSpendAggregateTransaction(PreMineSpendAggregateTransactionArgs { session_id: "8Tj5eMbr7Z3NXUs3", input_file_names: ["step_4_for_leader_from_carol.json"] })


Concluded step 5 'pre-mine-spend-aggregate-utxo'

Minotari Console Wallet running... (Command mode completed)

Shutting down wallet... Done.
PS C:\Users\pluto\.tari-Hansie\node_01>
```
Party member's ledger console wallet console:
```
PS C:\Users\pluto\.tari-Hansie\node_03> .\minotari_console_wallet.exe --base-path . --network esmeralda --config $pwd"\config\config.toml" --log-config $pwd"\config\log4rs_console_wallet.yml" pre-mine-spend-party-details --alias carol --output-index 0 --input-file "C:\Users\pluto\Documents\tari_pre_mine\spend\8Tj5eMbr7Z3NXUs3\step_1_session_info.json"
Initializing logging according to "C:\\Users\\pluto\\.tari-Hansie\\node_03\\config\\log4rs_console_wallet.yml"
Minotari Console Wallet running... (Command mode started)
==============
Command Runner
==============

1. PreMineSpendPartyDetails(PreMineSpendPartyDetailsArgs { input_file: "C:\\Users\\pluto\\Documents\\tari_pre_mine\\spend\\8Tj5eMbr7Z3NXUs3\\step_1_session_info.json", output_index: 0, alias: "carol" })


Concluded step 2 'pre-mine-create-party-details'
Your session's output directory is 'C:\Users\pluto\Documents\tari_pre_mine\spend\8Tj5eMbr7Z3NXUs3'
Send 'step_2_for_leader_from_carol.json' to leader for step 3

Minotari Console Wallet running... (Command mode completed)

Shutting down wallet... Done.
PS C:\Users\pluto\.tari-Hansie\node_03> .\minotari_console_wallet.exe --base-path . --network esmeralda --config $pwd"\config\config.toml" --log-config $pwd"\config\log4rs_console_wallet.yml" pre-mine-spend-input-output-sigs --session-id 8Tj5eMbr7Z3NXUs3
Initializing logging according to "C:\\Users\\pluto\\.tari-Hansie\\node_03\\config\\log4rs_console_wallet.yml"
Minotari Console Wallet running... (Command mode started)
==============
Command Runner
==============

1. PreMineSpendInputOutputSigs(PreMineSpendInputOutputSigArgs { session_id: "8Tj5eMbr7Z3NXUs3" })


Concluded step 4 'pre-mine-create-input-output-sigs'
Send 'step_4_for_leader_from_carol.json' to leader for step 5

Minotari Console Wallet running... (Command mode completed)

Shutting down wallet... Done.
PS C:\Users\pluto\.tari-Hansie\node_03>
```

What process can a PR reviewer use to test or verify this change?
---
Code review
System-level testing

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
