### PR TITLE
feat: add private view key function

### DIFF
--- a/applications/minotari_app_utilities/src/utilities.rs
+++ b/applications/minotari_app_utilities/src/utilities.rs
@@ -120,7 +120,7 @@ impl FromStr for UniNodeId {
             Ok(Self::PublicKey(public_key))
         } else if let Ok(node_id) = NodeId::from_hex(key) {
             Ok(Self::NodeId(node_id))
-        } else if let Ok(tari_address) = TariAddress::from_base58(key) {
+        } else if let Ok(tari_address) = TariAddress::from_str(key) {
             Ok(Self::TariAddress(tari_address))
         } else {
             Err(UniIdError::UnknownIdType)

--- a/base_layer/core/src/transactions/key_manager/inner.rs
+++ b/base_layer/core/src/transactions/key_manager/inner.rs
@@ -513,7 +513,7 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
         Ok(key_id)
     }
 
-    async fn get_private_view_key(&self) -> Result<PrivateKey, KeyManagerServiceError> {
+    pub async fn get_private_view_key(&self) -> Result<PrivateKey, KeyManagerServiceError> {
         match &self.wallet_type {
             WalletType::DerivedKeys => {
                 self.get_private_key(&TariKeyId::Managed {

--- a/base_layer/core/src/transactions/key_manager/interface.rs
+++ b/base_layer/core/src/transactions/key_manager/interface.rs
@@ -98,6 +98,8 @@ pub trait TransactionKeyManagerInterface: KeyManagerInterface<PublicKey> {
 
     async fn get_view_key(&self) -> Result<KeyAndId<PublicKey>, KeyManagerServiceError>;
 
+    async fn get_private_view_key(&self) -> Result<PrivateKey, KeyManagerServiceError>;
+
     async fn get_spend_key(&self) -> Result<KeyAndId<PublicKey>, KeyManagerServiceError>;
 
     async fn get_comms_key(&self) -> Result<KeyAndId<PublicKey>, KeyManagerServiceError>;

--- a/base_layer/core/src/transactions/key_manager/wrapper.rs
+++ b/base_layer/core/src/transactions/key_manager/wrapper.rs
@@ -211,6 +211,14 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
         self.transaction_key_manager_inner.read().await.get_view_key().await
     }
 
+    async fn get_private_view_key(&self) -> Result<PrivateKey, KeyManagerServiceError> {
+        self.transaction_key_manager_inner
+            .read()
+            .await
+            .get_private_view_key()
+            .await
+    }
+
     async fn get_spend_key(&self) -> Result<KeyAndId<PublicKey>, KeyManagerServiceError> {
         self.transaction_key_manager_inner.read().await.get_spend_key().await
     }


### PR DESCRIPTION
Description
---
Adds a private view key function to transaction key manager service

Motivation and Context
---
We must be able to export the private view of the wallet. And to do this we should not be required to expose the secret trait giving access to all private keys in order to get this exported. 
