### PR TITLE
fix: comms key managedment

### DIFF
--- a/applications/minotari_console_wallet/src/init/mod.rs
+++ b/applications/minotari_console_wallet/src/init/mod.rs
@@ -892,6 +892,7 @@ pub fn prompt_wallet_type(
                 view_key,
                 public_spend_key: spend_key,
                 private_spend_key: None,
+                private_comms_key: None,
             }))
         },
         WalletBoot::New | WalletBoot::Recovery => {

--- a/base_layer/common_types/src/wallet_types.rs
+++ b/base_layer/common_types/src/wallet_types.rs
@@ -53,6 +53,7 @@ impl Display for WalletType {
 pub struct ProvidedKeysWallet {
     pub public_spend_key: PublicKey,
     pub private_spend_key: Option<PrivateKey>,
+    pub private_comms_key: Option<PrivateKey>,
     pub view_key: PrivateKey,
 }
 

--- a/base_layer/core/src/transactions/key_manager/inner.rs
+++ b/base_layer/core/src/transactions/key_manager/inner.rs
@@ -380,7 +380,7 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
                             // return wallet.private_spend_key.clone().ok_or(
                             //     KeyManagerServiceError::ImportedPrivateKeyInaccessible(key_id.to_string()),
                             // );
-                            return Ok(PrivateKey::default())
+                            return Ok(PrivateKey::default());
                         }
                     },
                 }
@@ -536,14 +536,14 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
         let index = 0;
 
         match self.wallet_type {
-            WalletType::DerivedKeys | WalletType::ProvidedKeys(_) => {
+            WalletType::DerivedKeys => {
                 self.get_private_key(&TariKeyId::Managed {
                     branch: branch.clone(),
                     index,
                 })
                 .await
             },
-            WalletType::Ledger(_) => {
+            WalletType::Ledger(_) | WalletType::ProvidedKeys(_) => {
                 let km = self
                     .key_managers
                     .get(&branch)

--- a/base_layer/core/src/transactions/key_manager/inner.rs
+++ b/base_layer/core/src/transactions/key_manager/inner.rs
@@ -377,10 +377,9 @@ where TBackend: KeyManagerBackend<PublicKey> + 'static
 
                         // If we're trying to access any of the private keys, just say no bueno
                         if &TransactionKeyManagerBranch::Spend.get_branch_key() == branch {
-                            // return wallet.private_spend_key.clone().ok_or(
-                            //     KeyManagerServiceError::ImportedPrivateKeyInaccessible(key_id.to_string()),
-                            // );
-                            return Ok(PrivateKey::default());
+                            return wallet.private_spend_key.clone().ok_or(
+                                KeyManagerServiceError::ImportedPrivateKeyInaccessible(key_id.to_string()),
+                            );
                         }
                     },
                 }

--- a/base_layer/wallet/tests/transaction_service_tests/service.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/service.rs
@@ -231,6 +231,7 @@ async fn setup_transaction_service<P: AsRef<Path>>(
         public_spend_key: PublicKey::from_secret_key(node_identity.secret_key()),
         private_spend_key: Some(node_identity.secret_key().clone()),
         view_key: SK::random(&mut OsRng),
+        private_comms_key: Some(node_identity.secret_key().clone()),
     });
     let handles = StackBuilder::new(shutdown_signal)
         .add_initializer(RegisterHandle::new(dht))


### PR DESCRIPTION
Description
---
Separates comms key and spend key into two key types with the same derive value

Motivation and Context
---
The comms key and spend may be the same, or it may be different depending on the type of wallet. This means the key manager needs to handle the key differently depending on what is asked.

How Has This Been Tested?
---
Manual + unit tests

