### PR TITLE
feat: don't permit trying to send interactive transfers from hardware devices

### DIFF
--- a/applications/minotari_console_wallet/src/ui/app.rs
+++ b/applications/minotari_console_wallet/src/ui/app.rs
@@ -21,7 +21,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use minotari_wallet::{error::WalletError, util::wallet_identity::WalletIdentity, WalletConfig, WalletSqlite};
-use tari_common::exit_codes::ExitError;
+use tari_common::exit_codes::{ExitCode, ExitError};
 use tari_comms::peer_manager::Peer;
 use tokio::runtime::Handle;
 use tui::{
@@ -102,7 +102,16 @@ impl<B: Backend> App<B> {
 
         let tabs = TabsContainer::<B>::new(title.clone())
             .add("Transactions".into(), Box::new(TransactionsTab::new()))
-            .add("Send".into(), Box::new(SendTab::new(&app_state)))
+            .add(
+                "Send".into(),
+                Box::new(SendTab::new(
+                    &app_state,
+                    app_state
+                        .get_wallet_type()
+                        .await
+                        .map_err(|e| ExitError::new(ExitCode::WalletError, e))?,
+                )),
+            )
             .add("Receive".into(), Box::new(ReceiveTab::new()))
             .add("Burn".into(), Box::new(BurnTab::new(&app_state)))
             .add("Templates".into(), Box::new(RegisterTemplateTab::new(&app_state)))

--- a/applications/minotari_console_wallet/src/ui/state/app_state.rs
+++ b/applications/minotari_console_wallet/src/ui/state/app_state.rs
@@ -49,6 +49,7 @@ use tari_common_types::{
     tari_address::TariAddress,
     transaction::{TransactionDirection, TransactionStatus, TxId},
     types::PublicKey,
+    wallet_types::WalletType,
 };
 use tari_comms::{
     connectivity::ConnectivityEventRx,
@@ -650,6 +651,11 @@ impl AppState {
     pub async fn get_network(&self) -> Network {
         self.inner.read().await.get_network()
     }
+
+    pub async fn get_wallet_type(&self) -> Result<WalletType, UiError> {
+        let inner = self.inner.write().await;
+        inner.get_wallet_type()
+    }
 }
 pub struct AppStateInner {
     updated: bool,
@@ -671,6 +677,14 @@ impl AppStateInner {
             data,
             wallet,
         }
+    }
+
+    pub fn get_wallet_type(&self) -> Result<WalletType, UiError> {
+        self.wallet
+            .db
+            .get_wallet_type()
+            .map_err(UiError::WalletStorageError)
+            .and_then(|opt| opt.ok_or(UiError::WalletTypeError))
     }
 
     pub fn get_network(&self) -> Network {

--- a/applications/minotari_console_wallet/src/ui/ui_error.rs
+++ b/applications/minotari_console_wallet/src/ui/ui_error.rs
@@ -58,6 +58,8 @@ pub enum UiError {
     SendError(String),
     #[error("Transaction error: `{0}`")]
     TransactionError(String),
+    #[error("Couldn't read wallet type")]
+    WalletTypeError,
 }
 
 impl From<HexError> for UiError {


### PR DESCRIPTION
Description
---
Block the sending of interactive transfers from the UX, and remove instructions on how to do so.

Motivation and Context
---
We don't support interactive transfers from ledger, and the transaction will fail if you try.

How Has This Been Tested?
---
Manually

What process can a PR reviewer use to test or verify this change?
---
Create a ledger wallet, and note the instructions are gone and pressing "S" does nothing.

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
