### PR TITLE
chore: add panics to cucumber tests

### DIFF
--- a/integration_tests/src/ffi/balance.rs
+++ b/integration_tests/src/ffi/balance.rs
@@ -48,6 +48,7 @@ impl Balance {
             available = ffi_import::balance_get_available(self.ptr, &mut error);
             if error > 0 {
                 println!("balance_get_available error {}", error);
+                panic!("balance_get_available error");
             }
         }
         available
@@ -60,6 +61,7 @@ impl Balance {
             time_locked = ffi_import::balance_get_time_locked(self.ptr, &mut error);
             if error > 0 {
                 println!("balance_get_time_locked error {}", error);
+                panic!("balance_get_time_locked error");
             }
         }
         time_locked
@@ -72,6 +74,7 @@ impl Balance {
             pending_incoming = ffi_import::balance_get_pending_incoming(self.ptr, &mut error);
             if error > 0 {
                 println!("balance_get_pending_incoming error {}", error);
+                panic!("balance_get_pending_incoming error");
             }
         }
         pending_incoming
@@ -84,6 +87,7 @@ impl Balance {
             pending_outgoing = ffi_import::balance_get_pending_outgoing(self.ptr, &mut error);
             if error > 0 {
                 println!("balance_get_pending_outgoing error {}", error);
+                panic!("balance_get_pending_outgoing error");
             }
         }
         pending_outgoing

--- a/integration_tests/src/ffi/completed_transaction.rs
+++ b/integration_tests/src/ffi/completed_transaction.rs
@@ -48,6 +48,7 @@ impl CompletedTransaction {
             tx_id = ffi_import::completed_transaction_get_transaction_id(self.ptr, &mut error);
             if error > 0 {
                 println!("completed_transaction_get_transaction_id error {}", error);
+                panic!("completed_transaction_get_transaction_id error");
             }
         }
         tx_id
@@ -61,6 +62,7 @@ impl CompletedTransaction {
             ptr = ffi_import::completed_transaction_get_destination_tari_address(self.ptr, &mut error);
             if error > 0 {
                 println!("completed_transaction_get_destination_tari_address error {}", error);
+                panic!("completed_transaction_get_destination_tari_address error");
             }
         }
         WalletAddress::from_ptr(ptr)
@@ -74,6 +76,7 @@ impl CompletedTransaction {
             ptr = ffi_import::completed_transaction_get_source_tari_address(self.ptr, &mut error);
             if error > 0 {
                 println!("completed_transaction_get_source_tari_address error {}", error);
+                panic!("completed_transaction_get_source_tari_address error");
             }
         }
         WalletAddress::from_ptr(ptr)
@@ -86,6 +89,7 @@ impl CompletedTransaction {
             ptr = ffi_import::completed_transaction_get_transaction_kernel(self.ptr, &mut error);
             if error > 0 {
                 println!("completed_transaction_get_transaction_kernel error {}", error);
+                panic!("completed_transaction_get_transaction_kernel error");
             }
         }
         Kernel::from_ptr(ptr)
@@ -99,6 +103,7 @@ impl CompletedTransaction {
             amount = ffi_import::completed_transaction_get_amount(self.ptr, &mut error);
             if error > 0 {
                 println!("completed_transaction_get_amount error {}", error);
+                panic!("completed_transaction_get_amount error");
             }
         }
         amount
@@ -112,6 +117,7 @@ impl CompletedTransaction {
             fee = ffi_import::completed_transaction_get_fee(self.ptr, &mut error);
             if error > 0 {
                 println!("completed_transaction_get_fee error {}", error);
+                panic!("completed_transaction_get_fee error");
             }
         }
         fee
@@ -125,6 +131,7 @@ impl CompletedTransaction {
             timestamp = ffi_import::completed_transaction_get_timestamp(self.ptr, &mut error);
             if error > 0 {
                 println!("completed_transaction_get_timestamp error {}", error);
+                panic!("completed_transaction_get_timestamp error");
             }
         }
         timestamp
@@ -138,6 +145,7 @@ impl CompletedTransaction {
             ptr = ffi_import::completed_transaction_get_message(self.ptr, &mut error);
             if error > 0 {
                 println!("completed_transaction_get_message error {}", error);
+                panic!("completed_transaction_get_message error");
             }
         }
         FFIString::from_ptr(ptr as *mut i8).as_string()
@@ -151,6 +159,7 @@ impl CompletedTransaction {
             status = ffi_import::completed_transaction_get_status(self.ptr, &mut error);
             if error > 0 {
                 println!("completed_transaction_get_status error {}", error);
+                panic!("completed_transaction_get_status error");
             }
         }
         status
@@ -163,6 +172,7 @@ impl CompletedTransaction {
             is_outbound = ffi_import::completed_transaction_is_outbound(self.ptr, &mut error);
             if error > 0 {
                 println!("completed_transaction_is_outbound error {}", error);
+                panic!("completed_transaction_is_outbound error");
             }
         }
         is_outbound
@@ -176,6 +186,7 @@ impl CompletedTransaction {
             confirmations_cnt = ffi_import::completed_transaction_get_confirmations(self.ptr, &mut error);
             if error > 0 {
                 println!("completed_transaction_get_confirmations error {}", error);
+                panic!("completed_transaction_get_confirmations error");
             }
         }
         confirmations_cnt
@@ -189,6 +200,7 @@ impl CompletedTransaction {
             reason = ffi_import::completed_transaction_get_cancellation_reason(self.ptr, &mut error);
             if error > 0 {
                 println!("completed_transaction_get_cancellation_reason error {}", error);
+                panic!("completed_transaction_get_cancellation_reason error");
             }
         }
         reason

--- a/integration_tests/src/ffi/completed_transactions.rs
+++ b/integration_tests/src/ffi/completed_transactions.rs
@@ -48,6 +48,7 @@ impl CompletedTransactions {
             length = ffi_import::completed_transactions_get_length(self.ptr, &mut error);
             if error > 0 {
                 println!("completed_transactions_get_length error {}", error);
+                panic!("completed_transactions_get_length error");
             }
         }
         length
@@ -60,6 +61,7 @@ impl CompletedTransactions {
             ptr = ffi_import::completed_transactions_get_at(self.ptr, position, &mut error);
             if error > 0 {
                 println!("completed_transactions_get_at error {}", error);
+                panic!("completed_transactions_get_at error");
             }
         }
         CompletedTransaction::from_ptr(ptr)

--- a/integration_tests/src/ffi/contact.rs
+++ b/integration_tests/src/ffi/contact.rs
@@ -58,6 +58,7 @@ impl Contact {
             );
             if error > 0 {
                 println!("contact_create error {}", error);
+                panic!("contact_create error");
             }
         }
         Self { ptr }
@@ -70,6 +71,7 @@ impl Contact {
             alias = FFIString::from_ptr(ffi_import::contact_get_alias(self.ptr, &mut error));
             if error > 0 {
                 println!("contact_get_alias error {}", error);
+                panic!("contact_get_alias error");
             }
         }
         alias.as_string()
@@ -82,6 +84,7 @@ impl Contact {
             ptr = ffi_import::contact_get_tari_address(self.ptr, &mut error);
             if error > 0 {
                 println!("contact_get_tari_address error {}", error);
+                panic!("contact_get_tari_address error");
             }
         }
         WalletAddress::from_ptr(ptr)

--- a/integration_tests/src/ffi/contacts.rs
+++ b/integration_tests/src/ffi/contacts.rs
@@ -49,6 +49,7 @@ impl Contacts {
             length = ffi_import::contacts_get_length(self.ptr, &mut error);
             if error > 0 {
                 println!("contacts_get_length error {}", error);
+                panic!("contacts_get_length error");
             }
         }
         length
@@ -61,6 +62,7 @@ impl Contacts {
             ptr = ffi_import::contacts_get_at(self.ptr, position, &mut error);
             if error > 0 {
                 println!("contacts_get_at error {}", error);
+                panic!("contacts_get_at error");
             }
         }
         Contact::from_ptr(ptr)

--- a/integration_tests/src/ffi/contacts_liveness_data.rs
+++ b/integration_tests/src/ffi/contacts_liveness_data.rs
@@ -49,6 +49,7 @@ impl ContactsLivenessData {
             ptr = ffi_import::liveness_data_get_public_key(self.ptr, &mut error);
             if error > 0 {
                 println!("liveness_data_get_public_key error {}", error);
+                panic!("liveness_data_get_public_key error");
             }
         }
         WalletAddress::from_ptr(ptr)
@@ -61,6 +62,7 @@ impl ContactsLivenessData {
             latency = ffi_import::liveness_data_get_latency(self.ptr, &mut error);
             if error > 0 {
                 println!("liveness_data_get_latency error {}", error);
+                panic!("liveness_data_get_latency error");
             }
         }
         latency
@@ -73,6 +75,7 @@ impl ContactsLivenessData {
             ptr = ffi_import::liveness_data_get_last_seen(self.ptr, &mut error);
             if error > 0 {
                 println!("liveness_data_get_last_seen error {}", error);
+                panic!("liveness_data_get_last_seen error");
             }
         }
         FFIString::from_ptr(ptr).as_string()
@@ -85,6 +88,7 @@ impl ContactsLivenessData {
             message_type = ffi_import::liveness_data_get_message_type(self.ptr, &mut error);
             if error > 0 {
                 println!("liveness_data_get_message_type error {}", error);
+                panic!("liveness_data_get_message_type error");
             }
         }
         message_type
@@ -97,6 +101,7 @@ impl ContactsLivenessData {
             ptr = ffi_import::liveness_data_get_online_status(self.ptr, &mut error);
             if error > 0 {
                 println!("liveness_data_get_online_status error {}", error);
+                panic!("liveness_data_get_online_status error");
             }
         }
         FFIString::from_ptr(ptr as *mut i8).as_string()

--- a/integration_tests/src/ffi/fee_per_gram_stat.rs
+++ b/integration_tests/src/ffi/fee_per_gram_stat.rs
@@ -48,6 +48,7 @@ impl FeePerGramStat {
             order = ffi_import::fee_per_gram_stat_get_order(self.ptr, &mut error);
             if error > 0 {
                 println!("fee_per_gram_stat_get_order error {}", error);
+                panic!("fee_per_gram_stat_get_order error");
             }
         }
         order
@@ -60,6 +61,7 @@ impl FeePerGramStat {
             min = ffi_import::fee_per_gram_stat_get_min_fee_per_gram(self.ptr, &mut error);
             if error > 0 {
                 println!("fee_per_gram_stat_get_min_fee_per_gram error {}", error);
+                panic!("fee_per_gram_stat_get_min_fee_per_gram error");
             }
         }
         min
@@ -72,6 +74,7 @@ impl FeePerGramStat {
             avg = ffi_import::fee_per_gram_stat_get_avg_fee_per_gram(self.ptr, &mut error);
             if error > 0 {
                 println!("fee_per_gram_stat_get_avg_fee_per_gram error {}", error);
+                panic!("fee_per_gram_stat_get_avg_fee_per_gram error");
             }
         }
         avg
@@ -84,6 +87,7 @@ impl FeePerGramStat {
             max = ffi_import::fee_per_gram_stat_get_max_fee_per_gram(self.ptr, &mut error);
             if error > 0 {
                 println!("fee_per_gram_stat_get_max_fee_per_gram error {}", error);
+                panic!("fee_per_gram_stat_get_max_fee_per_gram error");
             }
         }
         max

--- a/integration_tests/src/ffi/fee_per_gram_stats.rs
+++ b/integration_tests/src/ffi/fee_per_gram_stats.rs
@@ -48,6 +48,7 @@ impl FeePerGramStats {
             length = ffi_import::fee_per_gram_stats_get_length(self.ptr, &mut error);
             if error > 0 {
                 println!("fee_per_gram_stats_get_length error {}", error);
+                panic!("fee_per_gram_stats_get_length error");
             }
         }
         length
@@ -60,6 +61,7 @@ impl FeePerGramStats {
             ptr = ffi_import::fee_per_gram_stats_get_at(self.ptr, position, &mut error);
             if error > 0 {
                 println!("fee_per_gram_stats_get_at error {}", error);
+                panic!("fee_per_gram_stats_get_at error");
             }
         }
         FeePerGramStat::from_ptr(ptr)

--- a/integration_tests/src/ffi/ffi_bytes.rs
+++ b/integration_tests/src/ffi/ffi_bytes.rs
@@ -50,6 +50,7 @@ impl FFIBytes {
             length = ffi_import::byte_vector_get_length(self.ptr, &mut error) as usize;
             if error > 0 {
                 println!("byte_vector_get_length error {}", error);
+                panic!("byte_vector_get_length error");
             }
         }
         length
@@ -62,6 +63,7 @@ impl FFIBytes {
             byte = ffi_import::byte_vector_get_at(self.ptr, i, &mut error);
             if error > 0 {
                 println!("byte_vector_get_at error {}", error);
+                panic!("byte_vector_get_at error");
             }
         }
         byte

--- a/integration_tests/src/ffi/kernel.rs
+++ b/integration_tests/src/ffi/kernel.rs
@@ -48,6 +48,7 @@ impl Kernel {
             ptr = ffi_import::transaction_kernel_get_excess_hex(self.ptr, &mut error);
             if error > 0 {
                 println!("transaction_kernel_get_excess_hex error {}", error);
+                panic!("transaction_kernel_get_excess_hex error");
             }
         }
         FFIString::from_ptr(ptr).as_string()
@@ -60,6 +61,7 @@ impl Kernel {
             ptr = ffi_import::transaction_kernel_get_excess_public_nonce_hex(self.ptr, &mut error);
             if error > 0 {
                 println!("transaction_kernel_get_excess_public_nonce_hex error {}", error);
+                panic!("transaction_kernel_get_excess_public_nonce_hex error");
             }
         }
         FFIString::from_ptr(ptr).as_string()
@@ -72,6 +74,7 @@ impl Kernel {
             ptr = ffi_import::transaction_kernel_get_excess_signature_hex(self.ptr, &mut error);
             if error > 0 {
                 println!("transaction_kernel_get_excess_signature_hex error {}", error);
+                panic!("transaction_kernel_get_excess_signature_hex error");
             }
         }
         FFIString::from_ptr(ptr).as_string()

--- a/integration_tests/src/ffi/pending_inbound_transaction.rs
+++ b/integration_tests/src/ffi/pending_inbound_transaction.rs
@@ -48,6 +48,7 @@ impl PendingInboundTransaction {
             tx_id = ffi_import::pending_inbound_transaction_get_transaction_id(self.ptr, &mut error);
             if error > 0 {
                 println!("pending_inbound_transaction_get_transaction_id error {}", error);
+                panic!("pending_inbound_transaction_get_transaction_id error");
             }
         }
         tx_id
@@ -61,6 +62,7 @@ impl PendingInboundTransaction {
             ptr = ffi_import::pending_inbound_transaction_get_source_tari_address(self.ptr, &mut error);
             if error > 0 {
                 println!("pending_inbound_transaction_get_source_tari_address error {}", error);
+                panic!("pending_inbound_transaction_get_source_tari_address error");
             }
         }
         WalletAddress::from_ptr(ptr)
@@ -74,6 +76,7 @@ impl PendingInboundTransaction {
             amount = ffi_import::pending_inbound_transaction_get_amount(self.ptr, &mut error);
             if error > 0 {
                 println!("pending_inbound_transaction_get_amount error {}", error);
+                panic!("pending_inbound_transaction_get_amount error");
             }
         }
         amount
@@ -87,6 +90,7 @@ impl PendingInboundTransaction {
             timestamp = ffi_import::pending_inbound_transaction_get_timestamp(self.ptr, &mut error);
             if error > 0 {
                 println!("pending_inbound_transaction_get_timestamp error {}", error);
+                panic!("pending_inbound_transaction_get_timestamp error");
             }
         }
         timestamp
@@ -100,6 +104,7 @@ impl PendingInboundTransaction {
             ptr = ffi_import::pending_inbound_transaction_get_message(self.ptr, &mut error);
             if error > 0 {
                 println!("pending_inbound_transaction_get_message error {}", error);
+                panic!("pending_inbound_transaction_get_message error");
             }
         }
         FFIString::from_ptr(ptr as *mut i8).as_string()
@@ -113,6 +118,7 @@ impl PendingInboundTransaction {
             status = ffi_import::pending_inbound_transaction_get_status(self.ptr, &mut error);
             if error > 0 {
                 println!("pending_inbound_transaction_get_status error {}", error);
+                panic!("pending_inbound_transaction_get_status error");
             }
         }
         status

--- a/integration_tests/src/ffi/pending_inbound_transactions.rs
+++ b/integration_tests/src/ffi/pending_inbound_transactions.rs
@@ -48,6 +48,7 @@ impl PendingInboundTransactions {
             length = ffi_import::pending_inbound_transactions_get_length(self.ptr, &mut error);
             if error > 0 {
                 println!("pending_inbound_transactions_get_length error {}", error);
+                panic!("pending_inbound_transactions_get_length error");
             }
         }
         length
@@ -61,6 +62,7 @@ impl PendingInboundTransactions {
             ptr = ffi_import::pending_inbound_transactions_get_at(self.ptr, position, &mut error);
             if error > 0 {
                 println!("pending_inbound_transactions_get_at error {}", error);
+                panic!("pending_inbound_transactions_get_at error");
             }
         }
         PendingInboundTransaction::from_ptr(ptr)

--- a/integration_tests/src/ffi/pending_outbound_transaction.rs
+++ b/integration_tests/src/ffi/pending_outbound_transaction.rs
@@ -48,6 +48,7 @@ impl PendingOutboundTransaction {
             tx_id = ffi_import::pending_outbound_transaction_get_transaction_id(self.ptr, &mut error);
             if error > 0 {
                 println!("pending_outbound_transaction_get_transaction_id error {}", error);
+                panic!("pending_outbound_transaction_get_transaction_id error");
             }
         }
         tx_id
@@ -64,6 +65,7 @@ impl PendingOutboundTransaction {
                     "pending_outbound_transaction_get_destination_tari_address error {}",
                     error
                 );
+                panic!("pending_outbound_transaction_get_destination_tari_address error");
             }
         }
         WalletAddress::from_ptr(ptr)
@@ -77,6 +79,7 @@ impl PendingOutboundTransaction {
             amount = ffi_import::pending_outbound_transaction_get_amount(self.ptr, &mut error);
             if error > 0 {
                 println!("pending_outbound_transaction_get_amount error {}", error);
+                panic!("pending_outbound_transaction_get_amount error");
             }
         }
         amount
@@ -90,6 +93,7 @@ impl PendingOutboundTransaction {
             fee = ffi_import::pending_outbound_transaction_get_fee(self.ptr, &mut error);
             if error > 0 {
                 println!("pending_outbound_transaction_get_fee error {}", error);
+                panic!("pending_outbound_transaction_get_fee error");
             }
         }
         fee
@@ -103,6 +107,7 @@ impl PendingOutboundTransaction {
             timestamp = ffi_import::pending_outbound_transaction_get_timestamp(self.ptr, &mut error);
             if error > 0 {
                 println!("pending_outbound_transaction_get_timestamp error {}", error);
+                panic!("pending_outbound_transaction_get_timestamp error");
             }
         }
         timestamp
@@ -116,6 +121,7 @@ impl PendingOutboundTransaction {
             ptr = ffi_import::pending_outbound_transaction_get_message(self.ptr, &mut error);
             if error > 0 {
                 println!("pending_outbound_transaction_get_message error {}", error);
+                panic!("pending_outbound_transaction_get_message error");
             }
         }
         FFIString::from_ptr(ptr as *mut i8).as_string()
@@ -129,6 +135,7 @@ impl PendingOutboundTransaction {
             status = ffi_import::pending_outbound_transaction_get_status(self.ptr, &mut error);
             if error > 0 {
                 println!("pending_outbound_transaction_get_status error {}", error);
+                panic!("pending_outbound_transaction_get_status error");
             }
         }
         status

--- a/integration_tests/src/ffi/pending_outbound_transactions.rs
+++ b/integration_tests/src/ffi/pending_outbound_transactions.rs
@@ -48,6 +48,7 @@ impl PendingOutboundTransactions {
             length = ffi_import::pending_outbound_transactions_get_length(self.ptr, &mut error);
             if error > 0 {
                 println!("pending_outbound_transactions_get_length error {}", error);
+                panic!("pending_outbound_transactions_get_length error");
             }
         }
         length
@@ -60,6 +61,7 @@ impl PendingOutboundTransactions {
             ptr = ffi_import::pending_outbound_transactions_get_at(self.ptr, position, &mut error);
             if error > 0 {
                 println!("pending_outbound_transactions_get_at error {}", error);
+                panic!("pending_outbound_transactions_get_at error");
             }
         }
         PendingOutboundTransaction::from_ptr(ptr)

--- a/integration_tests/src/ffi/private_key.rs
+++ b/integration_tests/src/ffi/private_key.rs
@@ -46,6 +46,7 @@ impl PrivateKey {
             ptr = ffi_import::private_key_create(bytes.get_ptr(), &mut error);
             if error > 0 {
                 println!("private_key_create error {}", error);
+                panic!("private_key_create error");
             }
         }
         Self { ptr }
@@ -68,6 +69,7 @@ impl PrivateKey {
             ptr = ffi_import::private_key_from_hex(CString::new(key).unwrap().into_raw(), &mut error);
             if error > 0 {
                 println!("private_key_from_hex error {}", error);
+                panic!("private_key_from_hex error");
             }
         }
         Self { ptr }
@@ -85,6 +87,7 @@ impl PrivateKey {
             ptr = ffi_import::private_key_get_bytes(self.ptr, &mut error);
             if error > 0 {
                 println!("private_key_get_bytes error {}", error);
+                panic!("private_key_get_bytes error");
             }
         }
         FFIBytes::from_ptr(ptr)

--- a/integration_tests/src/ffi/public_keys.rs
+++ b/integration_tests/src/ffi/public_keys.rs
@@ -49,6 +49,7 @@ impl PublicKeys {
             length = ffi_import::public_keys_get_length(self.ptr, &mut error);
             if error > 0 {
                 println!("public_keys_get_length error {}", error);
+                panic!("public_keys_get_length error");
             }
         }
         length as usize
@@ -61,6 +62,7 @@ impl PublicKeys {
             ptr = ffi_import::public_keys_get_at(self.ptr, position, &mut error);
             if error > 0 {
                 println!("public_keys_get_length error {}", error);
+                panic!("public_keys_get_length error");
             }
         }
         PublicKey::from_ptr(ptr)

--- a/integration_tests/src/ffi/seed_words.rs
+++ b/integration_tests/src/ffi/seed_words.rs
@@ -60,6 +60,7 @@ impl SeedWords {
             );
             if error > 0 {
                 println!("seed_words_get_mnemonic_word_list_for_language error {}", error);
+                panic!("seed_words_get_mnemonic_word_list_for_language error");
             }
         }
         Self { ptr }
@@ -72,6 +73,7 @@ impl SeedWords {
             length = ffi_import::seed_words_get_length(self.ptr, &mut error);
             if error > 0 {
                 println!("seed_words_get_length error {}", error);
+                panic!("seed_words_get_length error");
             }
         }
         length as usize
@@ -84,6 +86,7 @@ impl SeedWords {
             ptr = ffi_import::seed_words_get_at(self.ptr, position, &mut error);
             if error > 0 {
                 println!("seed_words_get_at error {}", error);
+                panic!("seed_words_get_at error");
             }
         }
         FFIString::from_ptr(ptr)
@@ -96,6 +99,7 @@ impl SeedWords {
             result = ffi_import::seed_words_push_word(self.ptr, CString::new(word).unwrap().into_raw(), &mut error);
             if error > 0 {
                 println!("seed_words_push_word error {}", error);
+                panic!("seed_words_push_word error");
             }
         }
         result

--- a/integration_tests/src/ffi/transaction_send_status.rs
+++ b/integration_tests/src/ffi/transaction_send_status.rs
@@ -48,6 +48,7 @@ impl TransactionSendStatus {
             status = ffi_import::transaction_send_status_decode(self.ptr, &mut error);
             if error > 0 {
                 println!("transaction_send_status_decode error {}", error);
+                panic!("transaction_send_status_decode error");
             }
         }
         status

--- a/integration_tests/src/ffi/vector.rs
+++ b/integration_tests/src/ffi/vector.rs
@@ -52,6 +52,7 @@ impl Vector {
             ffi_import::tari_vector_push_string(self.ptr, CString::new(s).unwrap().into_raw(), &mut error);
             if error > 0 {
                 println!("tari_vector_push_string error {}", error);
+                panic!("tari_vector_push_string error");
             }
         }
     }

--- a/integration_tests/src/ffi/wallet.rs
+++ b/integration_tests/src/ffi/wallet.rs
@@ -282,6 +282,10 @@ impl Wallet {
         let mut error = 0;
         unsafe {
             ptr = ffi_import::comms_list_connected_public_keys(self.ptr, &mut error);
+            if error > 0 {
+                println!("comms_list_connected_public_keys error {}", error);
+                panic!("comms_list_connected_public_keys error");
+            }
         }
         PublicKeys::from_ptr(ptr)
     }

--- a/integration_tests/src/ffi/wallet_address.rs
+++ b/integration_tests/src/ffi/wallet_address.rs
@@ -49,6 +49,7 @@ impl WalletAddress {
             ptr = ffi_import::tari_address_from_base58(CString::new(address).unwrap().into_raw(), &mut error);
             if error > 0 {
                 println!("wallet_get_tari_address error {}", error);
+                panic!("wallet_get_tari_address error");
             }
         }
         Self { ptr }
@@ -62,6 +63,7 @@ impl WalletAddress {
             ptr = ffi_import::emoji_id_to_tari_address(CString::new(emoji_id).unwrap().into_raw(), &mut error);
             if error > 0 {
                 println!("wallet_get_tari_address error {}", error);
+                panic!("wallet_get_tari_address error");
             }
         }
         Self { ptr }
@@ -74,6 +76,7 @@ impl WalletAddress {
             ptr = ffi_import::tari_address_get_bytes(self.ptr, &mut error);
             if error > 0 {
                 println!("wallet_get_tari_address error {}", error);
+                panic!("wallet_get_tari_address error");
             }
         }
         FFIBytes::from_ptr(ptr)
@@ -86,6 +89,7 @@ impl WalletAddress {
             ptr = ffi_import::tari_address_to_emoji_id(self.ptr, &mut error);
             if error > 0 {
                 println!("tari_address_to_emoji_id error {}", error);
+                panic!("tari_address_to_emoji_id error");
             }
         }
         FFIString::from_ptr(ptr)

--- a/integration_tests/src/merge_mining_proxy.rs
+++ b/integration_tests/src/merge_mining_proxy.rs
@@ -141,6 +141,7 @@ impl MergeMiningProxyProcess {
             let rt = runtime::Builder::new_multi_thread().enable_all().build().unwrap();
             if let Err(e) = rt.block_on(merge_miner(cli)) {
                 println!("Error running merge mining proxy : {:?}", e);
+                panic!("Error running merge mining proxy");
             }
         });
     }


### PR DESCRIPTION
Description
---
Adds panics to cucumber tests to induce a panic in the FFI layer if an error occurs right away rather than getting a null pointer ref later on.  