### PR TITLE
fix: contact service tari address support

### DIFF
--- a/applications/minotari_console_wallet/src/ui/components/contacts_tab.rs
+++ b/applications/minotari_console_wallet/src/ui/components/contacts_tab.rs
@@ -145,7 +145,7 @@ impl ContactsTab {
             Span::raw(" field, "),
             Span::styled("K", Style::default().add_modifier(Modifier::BOLD)),
             Span::raw(" to edit "),
-            Span::styled("Emoji ID", Style::default().add_modifier(Modifier::BOLD)),
+            Span::styled("Tari Address", Style::default().add_modifier(Modifier::BOLD)),
             Span::raw(" field, "),
             Span::styled("Enter", Style::default().add_modifier(Modifier::BOLD)),
             Span::raw(" to save Contact."),
@@ -239,12 +239,10 @@ impl ContactsTab {
                         self.edit_contact_mode = ContactInputMode::None;
                         self.show_edit_contact = false;
 
-                        if let Err(_e) = Handle::current()
+                        if let Err(e) = Handle::current()
                             .block_on(app_state.upsert_contact(self.alias_field.clone(), self.address_field.clone()))
                         {
-                            self.error_message = Some(
-                                "Invalid Tari address or Emoji ID provided\n Press Enter to continue.".to_string(),
-                            );
+                            self.error_message = Some(e.to_string() + "\nPress Enter to continue.");
                         }
 
                         self.alias_field = "".to_string();

--- a/base_layer/contacts/src/contacts_service/storage/sqlite_db.rs
+++ b/base_layer/contacts/src/contacts_service/storage/sqlite_db.rs
@@ -167,8 +167,10 @@ where TContactServiceDbConnection: PooledDbConnection<Error = SqliteStorageError
                         ContactSql::from(c).commit(&mut conn)?;
                     } else {
                         let stored_contact = ContactSql::find_by_node_id(&c.node_id.to_vec(), &mut conn)?;
-                        let stored_address = TariAddress::from_bytes(stored_contact.address.as_slice()).map_err(|_| ContactsServiceStorageError::ConversionError)?;
-                        let new_address = TariAddress::combine_addresses(&stored_address, &k).map_err(|_| ContactsServiceStorageError::ConversionError)?;
+                        let stored_address = TariAddress::from_bytes(stored_contact.address.as_slice())
+                            .map_err(|_| ContactsServiceStorageError::ConversionError)?;
+                        let new_address = TariAddress::combine_addresses(&stored_address, &k)
+                            .map_err(|_| ContactsServiceStorageError::ConversionError)?;
                         ContactSql::set_address_of_node_id(&c.node_id.to_vec(), &new_address.to_vec(), &mut conn)?;
                     }
                 },
@@ -279,7 +281,7 @@ mod test {
                 .iter()
                 .any(|v| v == &ContactSql::from(contacts[0].clone())));
 
-            let _c = ContactSql::find_by_address_and_update(&mut conn, &contacts[1].address.to_vec(), UpdateContact {
+            let _c = ContactSql::find_by_node_id_and_update(&mut conn, &contacts[1].node_id.to_vec(), UpdateContact {
                 alias: Some("Fred".to_string()),
                 last_seen: None,
                 latency: None,

--- a/base_layer/contacts/src/contacts_service/storage/sqlite_db.rs
+++ b/base_layer/contacts/src/contacts_service/storage/sqlite_db.rs
@@ -156,7 +156,7 @@ where TContactServiceDbConnection: PooledDbConnection<Error = SqliteStorageError
                     }
                 },
                 DbKeyValuePair::Contact(k, c) => {
-                    if ContactSql::find_by_address_and_update(&mut conn, &k.to_vec(), UpdateContact {
+                    if ContactSql::find_by_node_id_and_update(&mut conn, &c.node_id.to_vec(), UpdateContact {
                         alias: Some(c.clone().alias),
                         last_seen: None,
                         latency: None,
@@ -165,6 +165,11 @@ where TContactServiceDbConnection: PooledDbConnection<Error = SqliteStorageError
                     .is_err()
                     {
                         ContactSql::from(c).commit(&mut conn)?;
+                    } else {
+                        let stored_contact = ContactSql::find_by_node_id(&c.node_id.to_vec(), &mut conn)?;
+                        let stored_address = TariAddress::from_bytes(stored_contact.address.as_slice()).map_err(|_| ContactsServiceStorageError::ConversionError)?;
+                        let new_address = TariAddress::combine_addresses(&stored_address, &k).map_err(|_| ContactsServiceStorageError::ConversionError)?;
+                        ContactSql::set_address_of_node_id(&c.node_id.to_vec(), &new_address.to_vec(), &mut conn)?;
                     }
                 },
                 DbKeyValuePair::LastSeen(..) => return Err(ContactsServiceStorageError::OperationNotSupported),

--- a/base_layer/contacts/src/contacts_service/storage/types/contacts.rs
+++ b/base_layer/contacts/src/contacts_service/storage/types/contacts.rs
@@ -80,18 +80,16 @@ impl ContactSql {
             .first::<ContactSql>(conn)?)
     }
 
-    /// Find a particular Contact by their address, and update it if it exists, returning the affected record
-    pub fn find_by_address_and_update(
-        conn: &mut SqliteConnection,
+    /// updates the address field of the contact
+    pub fn set_address_of_node_id(
+        node_id: &[u8],
         address: &[u8],
-        updated_contact: UpdateContact,
-    ) -> Result<ContactSql, ContactsServiceStorageError> {
-        // Note: `get_result` not implemented for SQLite
-        diesel::update(contacts::table.filter(contacts::address.eq(address)))
-            .set(updated_contact)
-            .execute(conn)
-            .num_rows_affected_or_not_found(1)?;
-        ContactSql::find_by_address(address, conn)
+        conn: &mut SqliteConnection,
+    ) -> Result<(), ContactsServiceStorageError> {
+        diesel::update(contacts::table.filter(contacts::node_id.eq(node_id)))
+            .set(contacts::address.eq(address))
+            .execute(conn)?;
+        Ok(())
     }
 
     /// Find a particular Contact by their address, and delete it if it exists, returning the affected record

--- a/base_layer/contacts/src/contacts_service/types/contact.rs
+++ b/base_layer/contacts/src/contacts_service/types/contact.rs
@@ -44,7 +44,7 @@ impl Contact {
     ) -> Self {
         Self {
             alias,
-            node_id: NodeId::from_key(address.public_spend_key()),
+            node_id: NodeId::from_key(address.comms_public_key()),
             address,
             last_seen,
             latency,

--- a/base_layer/wallet_ffi/src/error.rs
+++ b/base_layer/wallet_ffi/src/error.rs
@@ -437,6 +437,10 @@ impl From<TariAddressError> for LibWalletError {
                 code: 708,
                 message: format!("{:?}", e),
             },
+            TariAddressError::CreationError(_) => Self {
+                code: 708,
+                message: format!("{:?}", e),
+            },
         }
     }
 }


### PR DESCRIPTION
Description
---
Contact service still assumes that the node_id and tari address are the same. This changes contact service to check the tari address.

Motivation and Context
---
This allows a user to update the address of a contact without having to delete the contact. It will look at the address given and update the address accordingly. 

How Has This Been Tested?
---
Manual 
