### PR TITLE
docs: fix Ledger hash documentation

### DIFF
--- a/applications/minotari_ledger_wallet/wallet/src/utils.rs
+++ b/applications/minotari_ledger_wallet/wallet/src/utils.rs
@@ -143,7 +143,7 @@ fn cx_error_to_string(e: CxError) -> String {
     err.to_string()
 }
 
-// Get a raw 32 byte key hash from the BIP32 path.
+// Get a raw 64 byte key hash from the BIP32 path.
 // - The wrapper function for the syscall `os_perso_derive_node_bip32`, `bip32_derive`, requires a 96 byte buffer when
 //   called with `CurvesId::Ed25519` as it checks the consistency of the curve choice and key length in order to prevent
 //   the underlying syscall from panicking.
@@ -152,7 +152,7 @@ fn cx_error_to_string(e: CxError) -> String {
 //     chain: 32 bytes
 //   Example:
 //     d8a57c1be0c52e9643485e77aac56d72fa6c4eb831466c2abd2d320c82d3d14929811c598c13d431bad433e037dbd97265492cea42bc2e3aad15440210a20a2d0000000000000000000000000000000000000000000000000000000000000000
-//  - This function applies domain separated hashing to the 64 byte private key of the returned buffer to get 32
+//  - This function applies domain separated hashing to the 64 byte private key of the returned buffer to get 64
 //    uniformly distributed random bytes.
 fn get_raw_key_hash(path: &[u32]) -> Result<Zeroizing<[u8; 64]>, String> {
     let mut key_buffer = Zeroizing::new([0u8; 96]);
@@ -179,7 +179,7 @@ fn get_raw_key_hash(path: &[u32]) -> Result<Zeroizing<[u8; 64]>, String> {
     Ok(raw_key_hashed)
 }
 
-/// Get a raw 32 byte key hash from the BIP32 path. In cas of an error, display an interactive message on the device.
+/// Get a raw 64 byte key hash from the BIP32 path. In cas of an error, display an interactive message on the device.
 pub fn get_raw_key(path: &[u32]) -> Result<Zeroizing<[u8; 64]>, SyscallError> {
     match get_raw_key_hash(&path) {
         Ok(val) => Ok(val),


### PR DESCRIPTION
Description
---
Fixes documentation for Ledger hashing functionality.

Motivation and Context
---
Ledger utility functions are used to produce secure 64-byte hashes from BIP32 paths. The documentation incorrectly reports them as being 32 bytes. This PR updates the documentation to help avoid confusion.

How Has This Been Tested?
---
No testing needed.

What process can a PR reviewer use to test or verify this change?
---
Check that the documentation changes match the corresponding functionality.