### PR TITLE
feat: various safety improvements to ledger wallet code

### DIFF
--- a/applications/minotari_ledger_wallet/common/src/lib.rs
+++ b/applications/minotari_ledger_wallet/common/src/lib.rs
@@ -11,7 +11,7 @@ extern crate alloc;
 pub mod common_types;
 mod utils;
 pub use utils::{
-    get_public_spend_key_from_tari_dual_address,
+    get_public_spend_key_bytes_from_tari_dual_address,
     hex_to_bytes_serialized,
     tari_dual_address_display,
     PUSH_PUBKEY_IDENTIFIER,

--- a/applications/minotari_ledger_wallet/common/src/utils.rs
+++ b/applications/minotari_ledger_wallet/common/src/utils.rs
@@ -68,13 +68,13 @@ pub fn tari_dual_address_display(address_bytes: &[u8; TARI_DUAL_ADDRESS_SIZE]) -
 }
 
 /// Get the public spend key bytes from a serialized Tari dual address
-pub fn get_public_spend_key_from_tari_dual_address(
+pub fn get_public_spend_key_bytes_from_tari_dual_address(
     address_bytes: &[u8; TARI_DUAL_ADDRESS_SIZE],
 ) -> Result<[u8; 32], String> {
     validate_checksum(address_bytes.as_ref())?;
-    let mut public_spend_key = [0u8; 32];
-    public_spend_key.copy_from_slice(&address_bytes[34..66]);
-    Ok(public_spend_key)
+    let mut public_spend_key_bytes = [0u8; 32];
+    public_spend_key_bytes.copy_from_slice(&address_bytes[34..66]);
+    Ok(public_spend_key_bytes)
 }
 
 // Determine whether a byte slice ends with a valid checksum

--- a/applications/minotari_ledger_wallet/comms/examples/ledger_demo/main.rs
+++ b/applications/minotari_ledger_wallet/comms/examples/ledger_demo/main.rs
@@ -222,13 +222,14 @@ fn main() {
     // GetViewKey
     println!("\ntest: GetViewKey");
 
-    match ledger_get_view_key(account) {
-        Ok(view_key) => println!("view_key:       {}", view_key.to_hex()),
+    let view_key_1 = match ledger_get_view_key(account) {
+        Ok(val) => val,
         Err(e) => {
             println!("\nError: {}\n", e);
             return;
         },
-    }
+    };
+    println!("view_key:       {}", view_key_1.to_hex());
 
     // GetDHSharedSecret
     println!("\ntest: GetDHSharedSecret");
@@ -384,7 +385,10 @@ fn main() {
     println!("\ntest: Ledger app restart");
     prompt_with_message("Start the 'MinoTari Wallet' Ledger app and press Enter to continue..");
     match ledger_get_view_key(account) {
-        Ok(view_key) => println!("view_key:       {}", view_key.to_hex()),
+        Ok(view_key_2) => {
+            println!("view_key:       {}", view_key_2.to_hex());
+            assert_eq!(view_key_1, view_key_2, "View key not repeatable")
+        },
         Err(e) => {
             println!("\nError: {}\n", e);
             return;

--- a/applications/minotari_ledger_wallet/comms/src/accessor_methods.rs
+++ b/applications/minotari_ledger_wallet/comms/src/accessor_methods.rs
@@ -126,8 +126,8 @@ fn verify() -> Result<(), LedgerDeviceError> {
             Ok(public_key) => {
                 if !signature.verify(&public_key, nonce) {
                     return Err(LedgerDeviceError::Processing(
-                        "'Minotari Wallet' application could not create a valid signature. Please update the firmware \
-                         on your device."
+                        "Error 1: 'Minotari Wallet' application could not create a valid signature. Please update the \
+                         firmware on your device."
                             .to_string(),
                     ));
                 }
@@ -135,16 +135,16 @@ fn verify() -> Result<(), LedgerDeviceError> {
             },
             Err(e) => {
                 return Err(LedgerDeviceError::Processing(format!(
-                    "'Minotari Wallet' application could not retrieve a public key ({:?}). Please update the firmware \
-                     on your device.",
+                    "Error 2: 'Minotari Wallet' application could not retrieve a public key ({:?}). Please update the \
+                     firmware on your device.",
                     e
                 )))
             },
         },
         Err(e) => {
             return Err(LedgerDeviceError::Processing(format!(
-                "'Minotari Wallet' application could not create a signature ({:?}). Please update the firmware on \
-                 your device.",
+                "Error 3: 'Minotari Wallet' application could not create a signature ({:?}). Please update the \
+                 firmware on your device.",
                 e
             )))
         },
@@ -153,16 +153,16 @@ fn verify() -> Result<(), LedgerDeviceError> {
         Ok(signature_b) => {
             if signature_a == signature_b {
                 return Err(LedgerDeviceError::Processing(
-                    "'Minotari Wallet' application is not creating unique signatures. Please update the firmware on \
-                     your device."
+                    "Error 4: 'Minotari Wallet' application is not creating unique signatures. Please update the \
+                     firmware on your device."
                         .to_string(),
                 ));
             }
         },
         Err(e) => {
             return Err(LedgerDeviceError::Processing(format!(
-                "'Minotari Wallet' application could not create a signature ({:?}). Please update the firmware on \
-                 your device.",
+                "Error 5: 'Minotari Wallet' application could not create a signature ({:?}). Please update the \
+                 firmware on your device.",
                 e
             )))
         },

--- a/applications/minotari_ledger_wallet/comms/src/lib.rs
+++ b/applications/minotari_ledger_wallet/comms/src/lib.rs
@@ -28,7 +28,7 @@ pub mod ledger_wallet;
 mod test {
     use borsh::BorshSerialize;
     use minotari_ledger_wallet_common::{
-        get_public_spend_key_from_tari_dual_address,
+        get_public_spend_key_bytes_from_tari_dual_address,
         hex_to_bytes_serialized,
         tari_dual_address_display,
         PUSH_PUBKEY_IDENTIFIER,
@@ -111,7 +111,7 @@ mod test {
         );
         // Getting the public spend key from the address
         assert_eq!(
-            get_public_spend_key_from_tari_dual_address(&tari_address_bytes)
+            get_public_spend_key_bytes_from_tari_dual_address(&tari_address_bytes)
                 .unwrap()
                 .to_vec(),
             tari_address.public_spend_key().to_vec()

--- a/applications/minotari_ledger_wallet/wallet/Cargo.toml
+++ b/applications/minotari_ledger_wallet/wallet/Cargo.toml
@@ -39,7 +39,7 @@ default = []
 pending_review_screen = []
 
 [package.metadata.ledger]
-curve = ["ed25519"]
+curve = ["ed25519", "secp256k1"]
 flags = "0"
 path = ["44'/535348'"]
 name = "MinoTari Wallet"

--- a/applications/minotari_ledger_wallet/wallet/Cargo.toml
+++ b/applications/minotari_ledger_wallet/wallet/Cargo.toml
@@ -39,7 +39,7 @@ default = []
 pending_review_screen = []
 
 [package.metadata.ledger]
-curve = ["ed25519", "secp256k1"]
+curve = ["secp256k1"]
 flags = "0"
 path = ["44'/535348'"]
 name = "MinoTari Wallet"

--- a/applications/minotari_ledger_wallet/wallet/src/handlers/get_dh_shared_secret.rs
+++ b/applications/minotari_ledger_wallet/wallet/src/handlers/get_dh_shared_secret.rs
@@ -1,8 +1,11 @@
 // Copyright 2024 The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
 
+use core::ops::Deref;
+
 use ledger_device_sdk::{io::Comm, ui::gadgets::SingleMessage};
 use tari_crypto::{ristretto::RistrettoPublicKey, tari_utilities::ByteArray};
+use zeroize::Zeroizing;
 
 use crate::{
     utils::{derive_from_bip32_key, get_key_from_canonical_bytes},
@@ -34,12 +37,12 @@ pub fn handler_get_dh_shared_secret(comm: &mut Comm) -> Result<(), AppSW> {
     let public_key: RistrettoPublicKey = get_key_from_canonical_bytes(&data[24..56])?;
 
     let shared_secret_key = match derive_from_bip32_key(account, index, key) {
-        Ok(k) => k * public_key,
+        Ok(k) => Zeroizing::new(k * public_key),
         Err(e) => return Err(e),
     };
 
     comm.append(&[RESPONSE_VERSION]); // version
-    comm.append(shared_secret_key.as_bytes());
+    comm.append(shared_secret_key.deref().as_bytes());
     comm.reply_ok();
 
     Ok(())

--- a/applications/minotari_ledger_wallet/wallet/src/handlers/get_dh_shared_secret.rs
+++ b/applications/minotari_ledger_wallet/wallet/src/handlers/get_dh_shared_secret.rs
@@ -1,8 +1,6 @@
 // Copyright 2024 The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
 
-use core::ops::Deref;
-
 use ledger_device_sdk::{io::Comm, ui::gadgets::SingleMessage};
 use tari_crypto::{ristretto::RistrettoPublicKey, tari_utilities::ByteArray};
 
@@ -36,7 +34,7 @@ pub fn handler_get_dh_shared_secret(comm: &mut Comm) -> Result<(), AppSW> {
     let public_key: RistrettoPublicKey = get_key_from_canonical_bytes(&data[24..56])?;
 
     let shared_secret_key = match derive_from_bip32_key(account, index, key) {
-        Ok(k) => k.deref() * public_key,
+        Ok(k) => k * public_key,
         Err(e) => return Err(e),
     };
 

--- a/applications/minotari_ledger_wallet/wallet/src/handlers/get_script_signature.rs
+++ b/applications/minotari_ledger_wallet/wallet/src/handlers/get_script_signature.rs
@@ -17,7 +17,6 @@ use tari_crypto::{
     },
 };
 use tari_hashing::TransactionHashDomain;
-use zeroize::Zeroizing;
 
 use crate::{
     alloc::string::ToString,
@@ -77,7 +76,7 @@ pub fn handler_get_script_signature_derived(comm: &mut Comm) -> Result<(), AppSW
         extract_common_values(data)?;
 
     let alpha = derive_from_bip32_key(account, STATIC_SPEND_INDEX, KeyType::Spend)?;
-    let blinding_factor: Zeroizing<RistrettoSecretKey> =
+    let blinding_factor: RistrettoSecretKey =
         get_key_from_canonical_bytes::<RistrettoSecretKey>(&data[152..184])?.into();
     let script_private_key = alpha_hasher(alpha, blinding_factor)?;
     let script_public_key = RistrettoPublicKey::from_secret_key(&script_private_key);
@@ -107,8 +106,8 @@ fn extract_common_values(
         u64,
         u64,
         u64,
-        Zeroizing<RistrettoSecretKey>,
-        Zeroizing<RistrettoSecretKey>,
+        RistrettoSecretKey,
+        RistrettoSecretKey,
         PedersenCommitment,
         [u8; 32],
     ),
@@ -129,9 +128,8 @@ fn extract_common_values(
     txi_version_bytes.clone_from_slice(&data[16..24]);
     let txi_version = u64::from_le_bytes(txi_version_bytes);
 
-    let value: Zeroizing<RistrettoSecretKey> =
-        get_key_from_canonical_bytes::<RistrettoSecretKey>(&data[24..56])?.into();
-    let commitment_private_key: Zeroizing<RistrettoSecretKey> =
+    let value: RistrettoSecretKey = get_key_from_canonical_bytes::<RistrettoSecretKey>(&data[24..56])?.into();
+    let commitment_private_key: RistrettoSecretKey =
         get_key_from_canonical_bytes::<RistrettoSecretKey>(&data[56..88])?.into();
 
     let commitment: PedersenCommitment = get_key_from_canonical_bytes(&data[88..120])?;
@@ -153,9 +151,9 @@ fn extract_common_values(
 fn get_script_signature(
     txi_version: u64,
     network: u64,
-    value: Zeroizing<RistrettoSecretKey>,
-    commitment_private_key: Zeroizing<RistrettoSecretKey>,
-    script_private_key: Zeroizing<RistrettoSecretKey>,
+    value: RistrettoSecretKey,
+    commitment_private_key: RistrettoSecretKey,
+    script_private_key: RistrettoSecretKey,
     script_public_key: RistrettoPublicKey,
     commitment: PedersenCommitment,
     script_message: [u8; 32],

--- a/applications/minotari_ledger_wallet/wallet/src/main.rs
+++ b/applications/minotari_ledger_wallet/wallet/src/main.rs
@@ -95,6 +95,7 @@ unsafe impl critical_section::Impl for MyCriticalSection {
 
 // Application status words.
 #[repr(u16)]
+#[derive(Debug)]
 pub enum AppSW {
     Deny = AppSWMapping::Deny as u16,
     WrongP1P2 = AppSWMapping::WrongP1P2 as u16,

--- a/applications/minotari_ledger_wallet/wallet/src/utils.rs
+++ b/applications/minotari_ledger_wallet/wallet/src/utils.rs
@@ -2,13 +2,11 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 use alloc::format;
-use core::ops::Deref;
 
 use blake2::Blake2b;
 use digest::{consts::U64, Digest};
 use ledger_device_sdk::{
     ecc::{bip32_derive, make_bip32_path, CurvesId, CxError},
-    io::SyscallError,
     random::LedgerRng,
     ui::gadgets::{MessageScroller, SingleMessage},
 };
@@ -75,8 +73,7 @@ impl<const S: usize> TryFrom<&[u8]> for Bip32Path<S> {
 
         // We cannot have too many elements in the path, and must have `u32` path elements
         let input_path_len = (data.len() - 1) / 4;
-        if input_path_len > S || data[0] as usize * 4 != data.len() - 1
-        {
+        if input_path_len > S || data[0] as usize * 4 != data.len() - 1 {
             return Err(AppSW::WrongApduLength);
         }
 
@@ -147,32 +144,32 @@ fn cx_error_to_string(e: CxError) -> String {
 }
 
 // Get a raw 64 byte key hash from the BIP32 path.
-// - The wrapper function for the syscall `os_perso_derive_node_bip32`, `bip32_derive`, requires a 96 byte buffer when
-//   called with `CurvesId::Ed25519` as it checks the consistency of the curve choice and key length in order to prevent
-//   the underlying syscall from panicking.
-// - The syscall `os_perso_derive_node_bip32` returns 96 bytes as:
-//     private key: 64 bytes
-//     chain: 32 bytes
-//   Example:
-//     d8a57c1be0c52e9643485e77aac56d72fa6c4eb831466c2abd2d320c82d3d14929811c598c13d431bad433e037dbd97265492cea42bc2e3aad15440210a20a2d0000000000000000000000000000000000000000000000000000000000000000
-//  - This function applies domain separated hashing to the 64 byte private key of the returned buffer to get 64
-//    uniformly distributed random bytes.
-fn get_raw_key_hash(path: &[u32]) -> Result<Zeroizing<[u8; 64]>, String> {
-    let mut key_buffer = Zeroizing::new([0u8; 96]);
-    const BIP32_KEY_LENGTH: usize = 64;
-    let raw_key_64 = match bip32_derive(CurvesId::Ed25519, path, key_buffer.as_mut(), Some(&mut [])) {
+fn get_raw_bip32_key(path: &[u32], curve: CurvesId) -> Result<Zeroizing<[u8; 64]>, String> {
+    match curve {
+        CurvesId::Secp256k1 | CurvesId::Ed25519 => {},
+        _ => return Err("Unsupported curve".to_string()),
+    }
+    let mut key_buffer = Zeroizing::new([0u8; 64]);
+
+    match bip32_derive(curve, path, key_buffer.as_mut(), Some(&mut [])) {
         Ok(_) => {
-            let binding = &key_buffer.as_ref()[..BIP32_KEY_LENGTH];
-            if binding == &[0u8; BIP32_KEY_LENGTH] {
+            let binding = &key_buffer.as_ref();
+            if binding == &[0u8; 64] {
                 return Err(cx_error_to_string(CxError::InternalError));
             }
-            let mut key_bytes = Zeroizing::new([0u8; BIP32_KEY_LENGTH]);
+            let mut key_bytes = Zeroizing::new([0u8; 64]);
             // `copy_from_slice` will not panic as the length of the slice is equal to the length of the array
             key_bytes.as_mut().copy_from_slice(binding);
-            key_bytes
+            Ok(key_bytes)
         },
         Err(e) => return Err(cx_error_to_string(e)),
-    };
+    }
+}
+
+//  This function applies domain separated hashing to the 64 byte private key of the returned buffer to get 64
+//  uniformly distributed random bytes.
+fn get_raw_key_hash(path: &[u32], curve: CurvesId) -> Result<Zeroizing<[u8; 64]>, String> {
+    let raw_key_64 = get_raw_bip32_key(path, curve)?;
 
     let mut raw_key_hashed = Zeroizing::new([0u8; 64]);
     DomainSeparatedHasher::<Blake2b<U64>, LedgerHashDomain>::new_with_label("raw_key")
@@ -182,23 +179,45 @@ fn get_raw_key_hash(path: &[u32]) -> Result<Zeroizing<[u8; 64]>, String> {
     Ok(raw_key_hashed)
 }
 
-/// Get a raw 64 byte key hash from the BIP32 path. In cas of an error, display an interactive message on the device.
-pub fn get_raw_key(path: &[u32]) -> Result<Zeroizing<[u8; 64]>, SyscallError> {
-    match get_raw_key_hash(&path) {
-        Ok(val) => Ok(val),
+/// Derive a secret key from a BIP32 path. In case of an error, display an interactive message on the device.
+pub fn derive_from_bip32_key(
+    u64_account: u64,
+    u64_index: u64,
+    u64_key_type: KeyType,
+) -> Result<RistrettoSecretKey, AppSW> {
+    let account = u64_to_string(u64_account);
+    let index = u64_to_string(u64_index);
+    let key_type = u64_to_string(u64_key_type.as_byte() as u64);
+
+    let mut bip32_path = "m/44'/".to_string();
+    bip32_path.push_str(&BIP32_COIN_TYPE.to_string());
+    bip32_path.push_str(&"'/");
+    bip32_path.push_str(&account);
+    bip32_path.push_str(&"'/0/");
+    bip32_path.push_str(&index);
+    bip32_path.push_str(&"'/");
+    bip32_path.push_str(&key_type);
+    let path: [u32; 6] = make_bip32_path(bip32_path.as_bytes());
+
+    // We use `CurvesId::Secp256k1` as the curve for the bip32 key derivation because it provides better entropy when
+    // compared to `CurvesId::Ed25519`. There is also no need for compatibility to `tari_crypto` as the output is only
+    // ever used in a subsequent key derivation function.
+    match get_raw_key_hash(&path, CurvesId::Secp256k1) {
+        Ok(val) => get_key_from_uniform_bytes(&val),
         Err(e) => {
             let mut msg = "".to_string();
             msg.push_str("Err: raw key >>...");
             SingleMessage::new(&msg).show_and_wait();
             SingleMessage::new(&e).show_and_wait();
-            Err(SyscallError::InvalidParameter.into())
+            return Err(AppSW::KeyDeriveFail);
         },
     }
 }
 
-pub fn get_key_from_uniform_bytes(bytes: &[u8]) -> Result<Zeroizing<RistrettoSecretKey>, AppSW> {
-    match RistrettoSecretKey::from_uniform_bytes(bytes) {
-        Ok(val) => Ok(Zeroizing::new(val)),
+/// Get a 32 byte secret key from 64 uniform bytes
+pub fn get_key_from_uniform_bytes(bytes: &Zeroizing<[u8; 64]>) -> Result<RistrettoSecretKey, AppSW> {
+    match RistrettoSecretKey::from_uniform_bytes(bytes.as_ref()) {
+        Ok(val) => Ok(val),
         Err(e) => {
             MessageScroller::new(&format!(
                 "Err: key conversion {:?}. Length: {:?}",
@@ -212,6 +231,7 @@ pub fn get_key_from_uniform_bytes(bytes: &[u8]) -> Result<Zeroizing<RistrettoSec
     }
 }
 
+/// Get a 32 byte secret key from 32 canonical bytes
 pub fn get_key_from_canonical_bytes<T: ByteArray>(bytes: &[u8]) -> Result<T, AppSW> {
     match T::from_canonical_bytes(bytes) {
         Ok(val) => Ok(val),
@@ -228,52 +248,26 @@ pub fn get_key_from_canonical_bytes<T: ByteArray>(bytes: &[u8]) -> Result<T, App
     }
 }
 
+/// Get the domain separated alpha key hasher
 pub fn alpha_hasher(
-    alpha: Zeroizing<RistrettoSecretKey>,
-    blinding_factor: Zeroizing<RistrettoSecretKey>,
-) -> Result<Zeroizing<RistrettoSecretKey>, AppSW> {
-    let hasher = DomainSeparatedHasher::<Blake2b<U64>, KeyManagerTransactionsHashDomain>::new_with_label("script key");
-    let hasher = hasher.chain(blinding_factor.as_bytes()).finalize();
-    let private_key = get_key_from_uniform_bytes(hasher.as_ref())?;
+    alpha: RistrettoSecretKey,
+    blinding_factor: RistrettoSecretKey,
+) -> Result<RistrettoSecretKey, AppSW> {
+    let mut raw_key_hashed = Zeroizing::new([0u8; 64]);
+    DomainSeparatedHasher::<Blake2b<U64>, KeyManagerTransactionsHashDomain>::new_with_label("script key")
+        .chain(blinding_factor.as_bytes())
+        .finalize_into(raw_key_hashed.as_mut().into());
+    let private_key = get_key_from_uniform_bytes(&raw_key_hashed)?;
 
-    Ok(Zeroizing::new(private_key.deref() + alpha.deref()))
+    Ok(private_key + alpha)
 }
 
-pub fn derive_from_bip32_key(
-    u64_account: u64,
-    u64_index: u64,
-    u64_key_type: KeyType,
-) -> Result<Zeroizing<RistrettoSecretKey>, AppSW> {
-    let account = u64_to_string(u64_account);
-    let index = u64_to_string(u64_index);
-    let key_type = u64_to_string(u64_key_type.as_byte() as u64);
-
-    let mut bip32_path = "m/44'/".to_string();
-    bip32_path.push_str(&BIP32_COIN_TYPE.to_string());
-    bip32_path.push_str(&"'/");
-    bip32_path.push_str(&account);
-    bip32_path.push_str(&"'/0/");
-    bip32_path.push_str(&index);
-    bip32_path.push_str(&"'/");
-    bip32_path.push_str(&key_type);
-    let path: [u32; 6] = make_bip32_path(bip32_path.as_bytes());
-
-    match get_raw_key(&path) {
-        Ok(val) => get_key_from_uniform_bytes(&val.as_ref()),
-        Err(e) => {
-            SingleMessage::new(&format!("Key error {:?}", e)).show_and_wait();
-            return Err(AppSW::KeyDeriveFail);
-        },
-    }
-}
-
-pub fn get_random_nonce() -> Result<Zeroizing<RistrettoSecretKey>, AppSW> {
+/// Get a uniform random nonce
+pub fn get_random_nonce() -> Result<RistrettoSecretKey, AppSW> {
     let mut raw_bytes = [0u8; 64];
     LedgerRng.fill_bytes(&mut raw_bytes);
     if raw_bytes == [0u8; 64] {
         return Err(AppSW::RandomNonceFail);
     }
-    Ok(Zeroizing::new(
-        RistrettoSecretKey::from_uniform_bytes(&raw_bytes).expect("will not fail"),
-    ))
+    Ok(RistrettoSecretKey::from_uniform_bytes(&raw_bytes).expect("will not fail"))
 }


### PR DESCRIPTION
Description
---
- Applied proper random nonces in the one-sided metadata signature to be collision resistant.
- Removed double zeroizing on 'RistrettoSecretKey'.
- Ensured hasher output is zeroized.
- Changed Ledger BIP32 derivation to use 'secp256k1'.

Motivation and Context
---
See #6484, #6485, #6488 and #6490.

How Has This Been Tested?
---
System-level testing using a ledger device with `cargo run --release --example ledger_demo`

What process can a PR reviewer use to test or verify this change?
---
- Code review
- `cargo run --release --example ledger_demo`

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [ ] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [X] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
BREAKING CHANGE: All ledger derived keys and signatures will be different.
