### PR TITLE
fix(minotari node): add get_sync_progress to allow list if mining is enabled

### DIFF
--- a/applications/minotari_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/minotari_node/src/grpc/base_node_grpc_server.rs
@@ -150,6 +150,7 @@ impl BaseNodeGrpcServer {
             GrpcMethod::SubmitBlockBlob,
             GrpcMethod::GetTipInfo,
             GrpcMethod::Identify,
+            GrpcMethod::GetSyncProgress,
         ];
 
         let second_layer_methods = [


### PR DESCRIPTION
Description
---
Allows to call GetSyncProgress if node is in mining node.

Motivation and Context
---
Tari Universe V1 needs to know what's the progress of node sync to display it to the user. Right now it's not possible as nodes refuses to response `GetSyncProgress` call and manually adding this through CLI throws exit code 101 (invalid config).

How Has This Been Tested?
---
Run command `cargo test`

What process can a PR reviewer use to test or verify this change?
---
Same as above


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
