### PR TITLE
feat!: add custom noise prologue to comms nodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5451,6 +5451,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0bccbcf40c8938196944a3da0e133e031a33f4d6b72db3bda3cc556e361905d"
+dependencies = [
+ "lazy_static",
+ "parking_lot 0.11.2",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2acd6defeddb41eb60bb468f8825d0cfd0c2a76bc03bfd235b6a1dc4f6a1ad5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "servo_arc"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6223,6 +6245,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_repr",
+ "serial_test",
  "sha2 0.10.8",
  "sha3",
  "strum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5972,6 +5972,7 @@ dependencies = [
  "tari_service_framework",
  "tari_shutdown",
  "tari_storage",
+ "tari_utilities",
  "thiserror",
 ]
 

--- a/base_layer/contacts/src/chat_client/Cargo.toml
+++ b/base_layer/contacts/src/chat_client/Cargo.toml
@@ -19,6 +19,7 @@ tari_p2p = { path = "../../../p2p" }
 tari_service_framework= { path = "../../../service_framework" }
 tari_shutdown = { path = "../../../../infrastructure/shutdown" }
 tari_storage = { path = "../../../../infrastructure/storage" }
+tari_utilities = { version = "0.7" }
 
 anyhow = "1.0.41"
 async-trait = "0.1.52"

--- a/base_layer/contacts/src/chat_client/src/error.rs
+++ b/base_layer/contacts/src/chat_client/src/error.rs
@@ -30,6 +30,7 @@ use tari_comms::peer_manager::PeerManagerError;
 use tari_contacts::contacts_service::error::ContactsServiceError;
 use tari_p2p::initialization::CommsInitializationError;
 use tari_storage::lmdb_store::LMDBError;
+use tari_utilities::hex::HexError;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -73,4 +74,12 @@ pub enum NetworkingError {
     ServiceInitializerError(#[from] anyhow::Error),
     #[error("Comms failed to spawn")]
     CommsSpawnError,
+    #[error("Hex error: `{0}`")]
+    HexError(String),
+}
+
+impl From<HexError> for NetworkingError {
+    fn from(err: HexError) -> Self {
+        NetworkingError::HexError(err.to_string())
+    }
 }

--- a/base_layer/contacts/src/chat_client/src/networking.rs
+++ b/base_layer/contacts/src/chat_client/src/networking.rs
@@ -24,6 +24,8 @@ use std::{str::FromStr, sync::Arc, time::Duration};
 
 use log::{error, trace};
 use minotari_app_utilities::{identity_management, identity_management::load_from_json};
+use tari_common::{configuration::Network, get_static_genesis_block_hash};
+use tari_common_types::types::FixedHash;
 // Re-exports
 pub use tari_comms::{
     multiaddr::{Error as MultiaddrError, Multiaddr},
@@ -40,6 +42,7 @@ use tari_p2p::{
 };
 use tari_service_framework::StackBuilder;
 use tari_shutdown::ShutdownSignal;
+use tari_utilities::hex::Hex;
 
 use crate::{
     config::ApplicationConfig,
@@ -75,6 +78,10 @@ pub async fn start(
             config.chat_client.network,
             node_identity,
             publisher,
+            FixedHash::from_hex(get_static_genesis_block_hash(
+                Network::get_current_or_user_setting_or_default(),
+            ))?
+            .to_vec(),
         ))
         .add_initializer(LivenessInitializer::new(
             LivenessConfig {

--- a/base_layer/contacts/tests/contacts_service.rs
+++ b/base_layer/contacts/tests/contacts_service.rs
@@ -108,7 +108,7 @@ pub fn setup_contacts_service<T: ContactsBackend + 'static>(
             Network::LocalNet,
             node_identity.clone(),
             publisher,
-            b"tari.contats_service.testing.prologue".to_vec(),
+            b"tari.contacts_service.testing.prologue".to_vec(),
         ))
         .add_initializer(LivenessInitializer::new(
             LivenessConfig {

--- a/base_layer/contacts/tests/contacts_service.rs
+++ b/base_layer/contacts/tests/contacts_service.rs
@@ -108,6 +108,7 @@ pub fn setup_contacts_service<T: ContactsBackend + 'static>(
             Network::LocalNet,
             node_identity.clone(),
             publisher,
+            b"tari.contats_service.testing.prologue".to_vec(),
         ))
         .add_initializer(LivenessInitializer::new(
             LivenessConfig {

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -106,6 +106,7 @@ env_logger = "0.7.0"
 tempfile = "3.1.0"
 toml = { version = "0.5" }
 quickcheck = "1.0"
+serial_test = "0.5"
 
 [build-dependencies]
 tari_common = { path = "../../common", features = ["build"], version = "1.3.0-pre.0" }

--- a/base_layer/core/src/blocks/genesis_block.rs
+++ b/base_layer/core/src/blocks/genesis_block.rs
@@ -492,7 +492,6 @@ mod test {
     };
 
     #[test]
-    // #[cfg(tari_target_network_testnet)]
     #[serial]
     fn esmeralda_genesis_sanity_check() {
         let network = Network::Esmeralda;
@@ -510,7 +509,6 @@ mod test {
 
     #[test]
     #[serial]
-    // #[cfg(tari_target_network_nextnet)]
     fn nextnet_genesis_sanity_check() {
         let network = Network::NextNet;
         set_network_by_env_var_or_force_set(network);
@@ -527,7 +525,6 @@ mod test {
 
     #[test]
     #[serial]
-    // #[cfg(tari_target_network_mainnet)]
     fn mainnet_genesis_sanity_check() {
         let network = Network::MainNet;
         set_network_by_env_var_or_force_set(network);
@@ -544,7 +541,6 @@ mod test {
 
     #[test]
     #[serial]
-    // #[cfg(tari_target_network_mainnet)]
     fn stagenet_genesis_sanity_check() {
         let network = Network::StageNet;
         set_network_by_env_var_or_force_set(network);
@@ -561,7 +557,6 @@ mod test {
 
     #[test]
     #[serial]
-    // #[cfg(tari_target_network_testnet)]
     fn igor_genesis_sanity_check() {
         let network = Network::Igor;
         set_network_by_env_var_or_force_set(network);
@@ -577,7 +572,6 @@ mod test {
 
     #[test]
     #[serial]
-    // #[cfg(tari_target_network_testnet)]
     fn localnet_genesis_sanity_check() {
         let network = Network::LocalNet;
         set_network_by_env_var_or_force_set(network);

--- a/base_layer/core/src/blocks/genesis_block.rs
+++ b/base_layer/core/src/blocks/genesis_block.rs
@@ -49,6 +49,11 @@ pub fn get_genesis_block(network: Network) -> ChainBlock {
     }
 }
 
+/// Returns the genesis block hash for the selected network.
+pub fn get_genesis_block_hash(network: Network) -> FixedHash {
+    *get_genesis_block(network).hash()
+}
+
 fn add_pre_mine_utxos_to_genesis_block(file: &str, block: &mut Block) {
     let mut utxos = Vec::new();
     let mut counter = 1;
@@ -473,6 +478,7 @@ fn get_raw_block(genesis_timestamp: &DateTime<FixedOffset>, not_before_proof: &P
 mod test {
     use std::convert::TryFrom;
 
+    use tari_common::get_static_genesis_block_hash;
     use tari_common_types::{epoch::VnEpoch, types::Commitment};
 
     use super::*;
@@ -623,5 +629,37 @@ mod test {
         ChainBalanceValidator::new(ConsensusManager::builder(network).build().unwrap(), Default::default())
             .validate(&*lock, 0, &utxo_sum, &kernel_sum, &Commitment::default())
             .unwrap();
+    }
+
+    // Update `tari_common::get_static_genesis_block_hash` with the correct values if the genesis block change
+    #[test]
+    fn test_get_static_genesis_block_hash() {
+        for network in [
+            Network::MainNet,
+            Network::StageNet,
+            Network::NextNet,
+            Network::Igor,
+            Network::Esmeralda,
+            Network::LocalNet,
+        ] {
+            match network {
+                Network::MainNet => assert_genesis_block_hash(network),
+                Network::StageNet => assert_genesis_block_hash(network),
+                Network::NextNet => assert_genesis_block_hash(network),
+                Network::Igor => assert_genesis_block_hash(network),
+                Network::Esmeralda => assert_genesis_block_hash(network),
+                Network::LocalNet => assert_genesis_block_hash(network),
+            }
+        }
+    }
+
+    fn assert_genesis_block_hash(network: Network) {
+        assert_eq!(
+            get_genesis_block_hash(network),
+            FixedHash::from_hex(get_static_genesis_block_hash(network)).unwrap(),
+            "network: {}, expected hash: {} (update `tari_common::get_static_genesis_block_hash`)",
+            network,
+            get_genesis_block_hash(network)
+        );
     }
 }

--- a/base_layer/core/src/consensus/consensus_encoding/hashing.rs
+++ b/base_layer/core/src/consensus/consensus_encoding/hashing.rs
@@ -145,44 +145,59 @@ mod tests {
 
     #[test]
     fn it_uses_the_network_environment_variable_if_set() {
-        // This test will not pass if `Network::set_current(<NETWORK>)` is called before the test
-        if !Network::is_set() {
-            let label = "test";
-            let input = [1u8; 32];
+        // Targeted network compilations will override inferred network hashes; this only has effect if
+        // `Network::set_current(<NETWORK>)` has not been called. The test may also not run if
+        // `std::env::var("TARI_NETWORK")` has been set by some other test.
+        if Network::is_set() {
+            println!(
+                "\nNote!! Static network constant is set, cannot run \
+                 `it_uses_the_network_environment_variable_if_set`\n"
+            );
+            return;
+        }
+        if std::env::var("TARI_NETWORK").is_ok() {
+            println!(
+                "\nNote!! env_var 'TARI_NETWORK' in use, cannot run \
+                 `it_uses_the_network_environment_variable_if_set`\n"
+            );
+            return;
+        }
 
-            for network in [
-                Network::MainNet,
-                Network::StageNet,
-                Network::NextNet,
-                Network::LocalNet,
-                Network::Igor,
-                Network::Esmeralda,
-            ] {
-                println!("Testing network: {:?}", network);
-                // Generate a specific network hash
-                let hash_specify_network =
-                    DomainSeparatedConsensusHasher::<TestHashDomain, Blake2b<U32>>::new_with_network(label, network)
-                        .chain(&input)
-                        .finalize();
+        let label = "test";
+        let input = [1u8; 32];
 
-                // Generate an inferred network hash
-                std::env::set_var("TARI_NETWORK", network.as_key_str());
-                println!(
-                    "TARI_NETWORK:    {:?}",
-                    std::env::var("TARI_NETWORK").unwrap_or_default()
-                );
-                println!(
-                    "Network:         {:?}\n",
-                    Network::get_current_or_user_setting_or_default()
-                );
-                let inferred_network_hash = DomainSeparatedConsensusHasher::<TestHashDomain, Blake2b<U32>>::new(label)
+        for network in [
+            Network::MainNet,
+            Network::StageNet,
+            Network::NextNet,
+            Network::LocalNet,
+            Network::Igor,
+            Network::Esmeralda,
+        ] {
+            println!("Testing network: {:?}", network);
+            // Generate a specific network hash
+            let hash_specify_network =
+                DomainSeparatedConsensusHasher::<TestHashDomain, Blake2b<U32>>::new_with_network(label, network)
                     .chain(&input)
                     .finalize();
-                std::env::remove_var("TARI_NETWORK");
 
-                // They should be equal
-                assert_eq!(hash_specify_network, inferred_network_hash);
-            }
+            // Generate an inferred network hash
+            std::env::set_var("TARI_NETWORK", network.as_key_str());
+            println!(
+                "TARI_NETWORK:    {:?}",
+                std::env::var("TARI_NETWORK").unwrap_or_default()
+            );
+            println!(
+                "Network:         {:?}\n",
+                Network::get_current_or_user_setting_or_default()
+            );
+            let inferred_network_hash = DomainSeparatedConsensusHasher::<TestHashDomain, Blake2b<U32>>::new(label)
+                .chain(&input)
+                .finalize();
+            std::env::remove_var("TARI_NETWORK");
+
+            // They should be equal
+            assert_eq!(hash_specify_network, inferred_network_hash);
         }
     }
 }

--- a/base_layer/p2p/src/initialization.rs
+++ b/base_layer/p2p/src/initialization.rs
@@ -464,6 +464,11 @@ impl P2pInitializer {
         connector: PubsubDomainConnector,
         noise_prologue: Vec<u8>,
     ) -> Self {
+        const PREFIX: &[u8] = b"com.tari.comms.noise.";
+        let mut noise_prologue_buf = vec![0u8; PREFIX.len() + noise_prologue.len()];
+        noise_prologue_buf[..PREFIX.len()].copy_from_slice(PREFIX);
+        noise_prologue_buf[PREFIX.len()..].copy_from_slice(&noise_prologue);
+
         Self {
             config,
             user_agent,
@@ -471,7 +476,7 @@ impl P2pInitializer {
             network,
             node_identity,
             connector: Some(connector),
-            noise_prologue,
+            noise_prologue: noise_prologue_buf,
         }
     }
 

--- a/base_layer/p2p/src/initialization.rs
+++ b/base_layer/p2p/src/initialization.rs
@@ -174,6 +174,7 @@ pub async fn initialize_local_test_comms<P: AsRef<Path>>(
         .with_dial_backoff(ConstantBackoff::new(Duration::from_millis(500)))
         .with_min_connectivity(1)
         .with_network_byte(Network::LocalNet.as_byte())
+        .with_noise_prologue(b"let us test the network".to_vec())
         .with_shutdown_signal(shutdown_signal)
         .build()?;
 
@@ -450,6 +451,7 @@ pub struct P2pInitializer {
     network: Network,
     node_identity: Arc<NodeIdentity>,
     connector: Option<PubsubDomainConnector>,
+    noise_prologue: Vec<u8>,
 }
 
 impl P2pInitializer {
@@ -460,6 +462,7 @@ impl P2pInitializer {
         network: Network,
         node_identity: Arc<NodeIdentity>,
         connector: PubsubDomainConnector,
+        noise_prologue: Vec<u8>,
     ) -> Self {
         Self {
             config,
@@ -468,6 +471,7 @@ impl P2pInitializer {
             network,
             node_identity,
             connector: Some(connector),
+            noise_prologue,
         }
     }
 
@@ -555,6 +559,7 @@ impl ServiceInitializer for P2pInitializer {
 
         let mut builder = CommsBuilder::new()
             .with_shutdown_signal(context.get_shutdown_signal())
+            .with_noise_prologue(self.noise_prologue.clone())
             .with_node_identity(self.node_identity.clone())
             .with_node_info(NodeNetworkInfo {
                 major_version: MAJOR_NETWORK_VERSION,

--- a/base_layer/wallet/src/error.rs
+++ b/base_layer/wallet/src/error.rs
@@ -103,6 +103,8 @@ pub enum WalletError {
     UnexpectedApiResponse { method: String, api: String },
     #[error("Public address not set for this wallet")]
     PublicAddressNotSet,
+    #[error("Hex error: `{0}`")]
+    HexError(String),
 }
 
 pub const LOG_TARGET: &str = "minotari::application";
@@ -116,6 +118,12 @@ impl From<WalletError> for ExitError {
     fn from(err: WalletError) -> Self {
         log::error!(target: LOG_TARGET, "{}", err);
         Self::new(ExitCode::WalletError, err.to_string())
+    }
+}
+
+impl From<HexError> for WalletError {
+    fn from(err: HexError) -> Self {
+        WalletError::HexError(err.to_string())
     }
 }
 

--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -27,11 +27,14 @@ use digest::consts::U32;
 use futures::executor::block_on;
 use log::*;
 use rand::rngs::OsRng;
-use tari_common::configuration::bootstrap::ApplicationType;
+use tari_common::{
+    configuration::{bootstrap::ApplicationType, Network},
+    get_static_genesis_block_hash,
+};
 use tari_common_types::{
     tari_address::{TariAddress, TariAddressFeatures},
     transaction::{ImportStatus, TxId},
-    types::{ComAndPubSignature, Commitment, PrivateKey, PublicKey, RangeProof, SignatureWithDomain},
+    types::{ComAndPubSignature, Commitment, FixedHash, PrivateKey, PublicKey, RangeProof, SignatureWithDomain},
     wallet_types::WalletType,
 };
 use tari_comms::{
@@ -196,6 +199,10 @@ where
                 config.network,
                 node_identity.clone(),
                 publisher,
+                FixedHash::from_hex(get_static_genesis_block_hash(
+                    Network::get_current_or_user_setting_or_default(),
+                ))?
+                .to_vec(),
             ))
             .add_initializer(OutputManagerServiceInitializer::<V, TKeyManagerInterface>::new(
                 config.output_manager_service_config,

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -68,6 +68,8 @@ pub mod dir_utils;
 
 pub use logging::initialize_logging;
 
+use crate::configuration::Network;
+
 pub const DEFAULT_CONFIG: &str = "config/config.toml";
 pub const DEFAULT_BASE_NODE_LOG_CONFIG: &str = "config/log4rs_base_node.yml";
 pub const DEFAULT_WALLET_LOG_CONFIG: &str = "config/log4rs_console_wallet.yml";
@@ -77,3 +79,18 @@ pub const DEFAULT_MINER_LOG_CONFIG: &str = "config/log4rs_miner.yml";
 pub const DEFAULT_COLLECTIBLES_LOG_CONFIG: &str = "config/log4rs_collectibles.yml";
 
 pub(crate) const LOG_TARGET: &str = "common::config";
+
+/// This is a static function that returns the genesis block hash for the specified network. This is useful for
+/// applications that need to know the genesis block hash for a specific network, but do not have access to the
+/// genesis block in tari_core. Test `fn test_get_static_genesis_block_hash()` in tari_core will fail if these values
+/// are wrong.
+pub fn get_static_genesis_block_hash<'a>(network: Network) -> &'a str {
+    match network {
+        Network::MainNet => "54537be28b5d91b58d27fc52b7dc0cc8cea1977f199eb509d8b4978b0d6630c9",
+        Network::StageNet => "40afb45c7f10a2dd7bcdd3802273518aba20ac468a75cdfd0c85342a82096557",
+        Network::NextNet => "fed55ccea50122f9bc7ca913e4bbc0fcbd6913c10cb77bf08f98486ec88d5f02",
+        Network::Igor => "6cf2950380c69c991612f4ba0afb80281a41bb016239adc642c78817c2e1dbd4",
+        Network::Esmeralda => "6598d13c5dcb398f5cad294473421bc2fed69071b56fada4387a6ad03a44df08",
+        Network::LocalNet => "7a32e20ebaf29f7cd67f59a7894050488c350f9d97fcea0765b7a4723e2d0bf7",
+    }
+}

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -86,11 +86,11 @@ pub(crate) const LOG_TARGET: &str = "common::config";
 /// are wrong.
 pub fn get_static_genesis_block_hash<'a>(network: Network) -> &'a str {
     match network {
-        Network::MainNet => "54537be28b5d91b58d27fc52b7dc0cc8cea1977f199eb509d8b4978b0d6630c9",
-        Network::StageNet => "40afb45c7f10a2dd7bcdd3802273518aba20ac468a75cdfd0c85342a82096557",
-        Network::NextNet => "fed55ccea50122f9bc7ca913e4bbc0fcbd6913c10cb77bf08f98486ec88d5f02",
-        Network::Igor => "6cf2950380c69c991612f4ba0afb80281a41bb016239adc642c78817c2e1dbd4",
+        Network::MainNet => "ba4379a1319a6315d5262f61761d3f609f5b8eb9fa30a05f0d18a80c25d6bae9",
+        Network::StageNet => "cd073787a0bd8803a2546919523c687ccd88c8f0b39d652783530502e101f351",
+        Network::NextNet => "5ae9384d705f8df49d7e5b5988297440a53bc8be48b8792f8bc0a2c3d17c3479",
+        Network::Igor => "50ed5847a5b4b88dfd86fd48597801b72565a0e1ba14701fddbeaca356e8b4c3",
         Network::Esmeralda => "6598d13c5dcb398f5cad294473421bc2fed69071b56fada4387a6ad03a44df08",
-        Network::LocalNet => "7a32e20ebaf29f7cd67f59a7894050488c350f9d97fcea0765b7a4723e2d0bf7",
+        Network::LocalNet => "b693c14804ceaafaee77c2d01310a221960383128de6b0f36c581fb706332bb3",
     }
 }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -84,7 +84,7 @@ pub(crate) const LOG_TARGET: &str = "common::config";
 /// applications that need to know the genesis block hash for a specific network, but do not have access to the
 /// genesis block in tari_core. Test `fn test_get_static_genesis_block_hash()` in tari_core will fail if these values
 /// are wrong.
-pub fn get_static_genesis_block_hash<'a>(network: Network) -> &'a str {
+pub fn get_static_genesis_block_hash(network: Network) -> &'static str {
     match network {
         Network::MainNet => "ba4379a1319a6315d5262f61761d3f609f5b8eb9fa30a05f0d18a80c25d6bae9",
         Network::StageNet => "cd073787a0bd8803a2546919523c687ccd88c8f0b39d652783530502e101f351",

--- a/comms/core/src/builder/comms_node.rs
+++ b/comms/core/src/builder/comms_node.rs
@@ -132,6 +132,7 @@ impl UnspawnedCommsNode {
         TTransport: Transport + Unpin + Send + Sync + Clone + 'static,
         TTransport::Output: AsyncRead + AsyncWrite + Send + Sync + Unpin + 'static,
     {
+        let noise_prologue = self.builder.get_noise_prologue();
         let UnspawnedCommsNode {
             builder,
             connection_manager_request_rx,
@@ -187,6 +188,7 @@ impl UnspawnedCommsNode {
             peer_manager.clone(),
             connection_manager_requester.get_event_publisher(),
             shutdown_signal.clone(),
+            &noise_prologue,
         );
 
         ext_context.register_complete_signal(connection_manager.complete_signal());

--- a/comms/core/src/builder/mod.rs
+++ b/comms/core/src/builder/mod.rs
@@ -128,6 +128,7 @@ pub struct CommsBuilder {
     connectivity_config: ConnectivityConfig,
     shutdown_signal: Option<ShutdownSignal>,
     maintain_n_closest_connections_only: Option<usize>,
+    noise_prologue: Vec<u8>,
 }
 
 impl Default for CommsBuilder {
@@ -142,6 +143,7 @@ impl Default for CommsBuilder {
             connectivity_config: ConnectivityConfig::default(),
             shutdown_signal: None,
             maintain_n_closest_connections_only: None,
+            noise_prologue: b"com.tari.comms.noise.prologue".to_vec(),
         }
     }
 }
@@ -176,6 +178,16 @@ impl CommsBuilder {
     pub fn with_network_byte(mut self, network_byte: u8) -> Self {
         self.connection_manager_config.network_info.network_byte = network_byte;
         self
+    }
+
+    /// Set the noise prologue for this comms instance.
+    pub fn with_noise_prologue(mut self, prologue: Vec<u8>) -> Self {
+        self.noise_prologue = prologue;
+        self
+    }
+
+    pub fn get_noise_prologue(&self) -> Vec<u8> {
+        self.noise_prologue.clone()
     }
 
     /// Set a network info (versions etc) as per [RFC-173 Versioning](https://rfc.tari.com/RFC-0173_Versioning.html)

--- a/comms/core/src/connection_manager/error.rs
+++ b/comms/core/src/connection_manager/error.rs
@@ -68,6 +68,8 @@ pub enum ConnectionManagerError {
     // send the same response to multiple requesters
     #[error("Noise error: {0}")]
     NoiseError(String),
+    #[error("Noise handshake error: {0}")]
+    NoiseHandshakeError(String),
     #[error("Peer is banned, denying connection")]
     PeerBanned,
     #[error("Identity protocol failed: {0}")]
@@ -94,7 +96,10 @@ impl From<yamux::ConnectionError> for ConnectionManagerError {
 
 impl From<noise::NoiseError> for ConnectionManagerError {
     fn from(err: noise::NoiseError) -> Self {
-        ConnectionManagerError::NoiseError(err.to_string())
+        match err {
+            noise::NoiseError::HandshakeFailed(_) => ConnectionManagerError::NoiseHandshakeError(err.to_string()),
+            _ => ConnectionManagerError::NoiseError(err.to_string()),
+        }
     }
 }
 

--- a/comms/core/src/connection_manager/manager.rs
+++ b/comms/core/src/connection_manager/manager.rs
@@ -210,12 +210,13 @@ where
         peer_manager: Arc<PeerManager>,
         connection_manager_events_tx: broadcast::Sender<Arc<ConnectionManagerEvent>>,
         shutdown_signal: ShutdownSignal,
+        noise_prologue: &[u8],
     ) -> Self {
         let (internal_event_tx, internal_event_rx) = mpsc::channel(EVENT_CHANNEL_SIZE);
         let (dialer_tx, dialer_rx) = mpsc::channel(DIALER_REQUEST_CHANNEL_SIZE);
 
-        let noise_config =
-            NoiseConfig::new(node_identity.clone()).with_recv_timeout(config.noise_handshake_recv_timeout);
+        let noise_config = NoiseConfig::new(node_identity.clone(), noise_prologue)
+            .with_recv_timeout(config.noise_handshake_recv_timeout);
 
         let listener = PeerListener::new(
             config.clone(),

--- a/comms/core/src/connection_manager/tests/listener_dialer.rs
+++ b/comms/core/src/connection_manager/tests/listener_dialer.rs
@@ -55,7 +55,7 @@ async fn listen() -> Result<(), Box<dyn Error>> {
     let mut shutdown = Shutdown::new();
     let peer_manager = build_peer_manager();
     let node_identity = build_node_identity(PeerFeatures::COMMUNICATION_NODE);
-    let noise_config = NoiseConfig::new(node_identity.clone());
+    let noise_config = NoiseConfig::new(node_identity.clone(), &[1]);
     let listener = PeerListener::new(
         Default::default(),
         "/memory/0".parse()?,
@@ -84,9 +84,10 @@ async fn smoke() {
     // receives and checks the message and then disconnects and shuts down.
     let (event_tx, mut event_rx) = mpsc::channel(10);
     let mut shutdown = Shutdown::new();
+    let noise_prologue = [1, 2, 3];
 
     let node_identity1 = build_node_identity(PeerFeatures::COMMUNICATION_NODE);
-    let noise_config1 = NoiseConfig::new(node_identity1.clone());
+    let noise_config1 = NoiseConfig::new(node_identity1.clone(), &noise_prologue);
     let expected_proto = ProtocolId::from_static(b"/tari/test-proto");
     let supported_protocols = vec![expected_proto.clone()];
     let peer_manager1 = build_peer_manager();
@@ -106,7 +107,7 @@ async fn smoke() {
     let address = listener.listen().await.unwrap();
 
     let node_identity2 = build_node_identity(PeerFeatures::COMMUNICATION_NODE);
-    let noise_config2 = NoiseConfig::new(node_identity2.clone());
+    let noise_config2 = NoiseConfig::new(node_identity2.clone(), &noise_prologue);
     let (request_tx, request_rx) = mpsc::channel(1);
     let peer_manager2 = build_peer_manager();
     let mut dialer = Dialer::new(
@@ -187,9 +188,10 @@ async fn smoke() {
 async fn banned() {
     let (event_tx, mut event_rx) = mpsc::channel(10);
     let mut shutdown = Shutdown::new();
+    let noise_prologue = [1, 2, 3, 4];
 
     let node_identity1 = build_node_identity(PeerFeatures::COMMUNICATION_NODE);
-    let noise_config1 = NoiseConfig::new(node_identity1.clone());
+    let noise_config1 = NoiseConfig::new(node_identity1.clone(), &noise_prologue);
     let expected_proto = ProtocolId::from_static(b"/tari/test-proto");
     let supported_protocols = vec![expected_proto.clone()];
     let peer_manager1 = build_peer_manager();
@@ -214,7 +216,7 @@ async fn banned() {
     peer.ban_for(Duration::from_secs(60 * 60), "".to_string());
     peer_manager1.add_peer(peer).await.unwrap();
 
-    let noise_config2 = NoiseConfig::new(node_identity2.clone());
+    let noise_config2 = NoiseConfig::new(node_identity2.clone(), &noise_prologue);
     let (request_tx, request_rx) = mpsc::channel(1);
     let peer_manager2 = build_peer_manager();
     let mut dialer = Dialer::new(

--- a/comms/core/src/connection_manager/tests/manager.rs
+++ b/comms/core/src/connection_manager/tests/manager.rs
@@ -72,6 +72,7 @@ async fn connect_to_nonexistent_peer() {
         peer_manager,
         event_tx,
         shutdown.to_signal(),
+        &[0, 0, 0, 0],
     );
 
     rt_handle.spawn(connection_manager.run());

--- a/comms/core/src/connection_manager/wire_mode.rs
+++ b/comms/core/src/connection_manager/wire_mode.rs
@@ -22,7 +22,7 @@
 
 use std::convert::TryFrom;
 
-pub(crate) const LIVENESS_WIRE_MODE: u8 = 0xa7;
+pub(crate) const LIVENESS_WIRE_MODE: u8 = 0xa6;
 
 #[derive(Debug, Clone, Copy)]
 pub enum WireMode {

--- a/comms/core/src/connectivity/manager.rs
+++ b/comms/core/src/connectivity/manager.rs
@@ -605,7 +605,7 @@ impl ConnectivityManagerActor {
     async fn on_peer_handshake_failure(&mut self, node_id: &NodeId) -> Result<(), ConnectivityError> {
         let num_failed = self.mark_peer_failed(node_id.clone());
 
-        if (self.peer_manager.find_by_node_id(node_id).await?).is_some() {
+        if self.peer_manager.exists_node_id(node_id).await {
             debug!(
                 target: LOG_TARGET,
                 "Peer `{}` was marked as offline after {} attempts due to incompatible handshake noise prologue. \

--- a/comms/core/src/test_utils/test_node.rs
+++ b/comms/core/src/test_utils/test_node.rs
@@ -94,6 +94,7 @@ where
         peer_manager,
         event_tx,
         shutdown,
+        &[1, 1, 1, 1]
     );
     connection_manager.add_protocols(protocols);
 

--- a/comms/dht/examples/propagation/node.rs
+++ b/comms/dht/examples/propagation/node.rs
@@ -79,6 +79,7 @@ pub async fn create<P: AsRef<Path>>(
     let builder = CommsBuilder::new()
         .allow_test_addresses()
         .with_network_byte(0x25)
+        .with_noise_prologue(b"dht propagation example".to_vec())
         .with_shutdown_signal(shutdown_signal)
         .with_node_info(NodeNetworkInfo {
             major_version: 0,


### PR DESCRIPTION
Description
---
Added a custom noise prologue to the noise protocol to be hashed into the handshake hash value. This enables an application to specify a unique identifier like the genesis block hash as the noise prologue, effectively stopping any communication handshake from succeeding with nodes not on the same genesis block.

_Thanks to @sdbondi for brainstorming and suggesting the way this requirement could be implemented._

Motivation and Context
---
Base nodes and wallets maintained numerous connections from which they could not sync or obtain useful information. This caused base nodes to try and follow other base nodes that were on a higher proof of work but on a different genesis block, and caused wallets to query base nodes that supplied information from a different blockchain.

How Has This Been Tested?
---
Passed all unit tests.
Passed system-level testing.

What process can a PR reviewer use to test or verify this change?
---
Code review.
System-level testing.

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [ ] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [X] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
BREAKING CHANGE: Communication between base nodes and wallets will be exclusively linked to the genesis block hash once this PR is implemented. They will not be able to communicate to any previous release.
