### PR TITLE
feat: ledger reconnect

### DIFF
--- a/applications/minotari_ledger_wallet/comms/examples/ledger_demo/main.rs
+++ b/applications/minotari_ledger_wallet/comms/examples/ledger_demo/main.rs
@@ -355,7 +355,7 @@ fn main() {
         },
         Err(e) => {
             if e != LedgerDeviceError::Processing(
-                "GetViewKey: Native HID transport error `Ledger device: Io error`".to_string(),
+                "GetViewKey: Native HID transport error `Ledger device not found`".to_string(),
             ) {
                 println!("\nError: Unexpected response ({})\n", e);
                 return;

--- a/applications/minotari_ledger_wallet/comms/src/error.rs
+++ b/applications/minotari_ledger_wallet/comms/src/error.rs
@@ -33,6 +33,9 @@ pub enum LedgerDeviceError {
     /// Native HID transport error
     #[error("Native HID transport error `{0}`")]
     NativeTransport(String),
+    /// HID transport exchange error
+    #[error("Native HID transport exchange error `{0}`")]
+    NativeTransportExchange(String),
     /// Ledger application not started
     #[error("Ledger application not started")]
     ApplicationNotStarted,

--- a/applications/minotari_ledger_wallet/comms/src/error.rs
+++ b/applications/minotari_ledger_wallet/comms/src/error.rs
@@ -30,6 +30,9 @@ pub enum LedgerDeviceError {
     /// HID API error
     #[error("HID API error `{0}`")]
     HidApi(String),
+    /// HID API error
+    #[error("HID API error refresh `{0}`")]
+    HidApiRefresh(String),
     /// Native HID transport error
     #[error("Native HID transport error `{0}`")]
     NativeTransport(String),

--- a/applications/minotari_ledger_wallet/comms/src/ledger_wallet.rs
+++ b/applications/minotari_ledger_wallet/comms/src/ledger_wallet.rs
@@ -60,7 +60,7 @@ impl<D: Deref<Target = [u8]>> Command<D> {
     pub fn execute(&self) -> Result<APDUAnswer<Vec<u8>>, LedgerDeviceError> {
         get_transport()?
             .exchange(&self.inner)
-            .map_err(|e| LedgerDeviceError::NativeTransport(e.to_string()))
+            .map_err(|e| LedgerDeviceError::NativeTransportExchange(e.to_string()))
     }
 
     pub fn execute_with_transport(
@@ -69,7 +69,7 @@ impl<D: Deref<Target = [u8]>> Command<D> {
     ) -> Result<APDUAnswer<Vec<u8>>, LedgerDeviceError> {
         transport
             .exchange(&self.inner)
-            .map_err(|e| LedgerDeviceError::NativeTransport(e.to_string()))
+            .map_err(|e| LedgerDeviceError::NativeTransportExchange(e.to_string()))
     }
 
     pub fn build_command(account: u64, instruction: Instruction, data: Vec<u8>) -> Command<Vec<u8>> {


### PR DESCRIPTION
Description
---
If the HidApi disconnects, the instance will still exist but can no
longer be used. We need a new instance, but only a single one can
exist at a time. So we're locking it in a mutex to ensure mutable
safety. Then if at some point communication errors because the instance
is stale we will drop the existing instance by re-assignment of the
inner struct field, and create a new working instance.

Motivation and Context
---
Allow someone with an open console wallet to be able to connect and disconnect their ledger at will. Without the need to restart the wallet. If the connection to the ledger fails, it will re-establish the connection (only one attempt) and then proceed.

How Has This Been Tested?
---
Manually with the console wallet.
Using the ledger demo test file it *mostly* works but there's a weird error return on the reconnection of the ledger before opening the Tari app that could also use some more debugging.

What process can a PR reviewer use to test or verify this change?
---

- Open a console wallet supported by ledger
- Make a transaction successfully
- Unplug the ledger
- Make a failed transaction because the ledger is missing
- Plug the ledger back in
- Make a transaction successfully

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

