### PR TITLE
chore(api): get_sync_progress returns short_desc

### DIFF
--- a/applications/minotari_app_grpc/proto/base_node.proto
+++ b/applications/minotari_app_grpc/proto/base_node.proto
@@ -356,6 +356,7 @@ message SyncProgressResponse {
     uint64 tip_height = 1;
     uint64 local_height = 2;
     SyncState state = 3;
+    string short_desc = 4;
 }
 
 enum SyncState {

--- a/applications/minotari_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/minotari_node/src/grpc/base_node_grpc_server.rs
@@ -2003,26 +2003,32 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
             .borrow()
             .state_info
             .clone();
+        let short_desc = state.short_desc();
         let response = match state {
             StateInfo::HeaderSync(None) => tari_rpc::SyncProgressResponse {
                 tip_height: 0,
                 local_height: 0,
                 state: tari_rpc::SyncState::HeaderStarting.into(),
+                short_desc,
+
             },
             StateInfo::HeaderSync(Some(info)) => tari_rpc::SyncProgressResponse {
                 tip_height: info.tip_height,
                 local_height: info.local_height,
                 state: tari_rpc::SyncState::Header.into(),
+                short_desc,
             },
             StateInfo::Connecting(_) => tari_rpc::SyncProgressResponse {
                 tip_height: 0,
                 local_height: 0,
                 state: tari_rpc::SyncState::BlockStarting.into(),
+                short_desc,
             },
             StateInfo::BlockSync(info) => tari_rpc::SyncProgressResponse {
                 tip_height: info.tip_height,
                 local_height: info.local_height,
                 state: tari_rpc::SyncState::Block.into(),
+                short_desc,
             },
             _ => tari_rpc::SyncProgressResponse {
                 tip_height: 0,
@@ -2032,6 +2038,7 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
                 } else {
                     tari_rpc::SyncState::Startup.into()
                 },
+                short_desc
             },
         };
         Ok(Response::new(response))

--- a/applications/minotari_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/minotari_node/src/grpc/base_node_grpc_server.rs
@@ -2037,7 +2037,7 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
                 } else {
                     tari_rpc::SyncState::Startup.into()
                 },
-                short_desc
+                short_desc,
             },
         };
         Ok(Response::new(response))

--- a/applications/minotari_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/minotari_node/src/grpc/base_node_grpc_server.rs
@@ -2010,7 +2010,6 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
                 local_height: 0,
                 state: tari_rpc::SyncState::HeaderStarting.into(),
                 short_desc,
-
             },
             StateInfo::HeaderSync(Some(info)) => tari_rpc::SyncProgressResponse {
                 tip_height: info.tip_height,


### PR DESCRIPTION
Description
---
Add `short_desc` to the `SyncProgressResponse`

Motivation and Context
---
Using `short_desc` would be very handy for the Tari Universe

How Has This Been Tested?
---

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
