### PR TITLE
feat: improve header validation speed

### DIFF
--- a/applications/minotari_ledger_wallet/comms/examples/ledger_demo/main.rs
+++ b/applications/minotari_ledger_wallet/comms/examples/ledger_demo/main.rs
@@ -391,15 +391,11 @@ fn main() {
     match ledger_get_view_key(account) {
         Ok(view_key_2) => {
             println!("view_key:       {}", view_key_2.to_hex());
-            return;
         },
         Err(e) => {
             println!("\nError: {}\n", e);
-            return;
         },
     }
-
-    println!("\nTest completed successfully\n");
 }
 
 pub fn get_random_nonce() -> PrivateKey {

--- a/base_layer/core/src/proof_of_work/monero_rx/helpers.rs
+++ b/base_layer/core/src/proof_of_work/monero_rx/helpers.rs
@@ -63,7 +63,7 @@ pub fn randomx_difficulty(
     consensus: &ConsensusManager,
 ) -> Result<Difficulty, MergeMineError> {
     let monero_pow_data = verify_header(header, genesis_block_hash, consensus)?;
-    debug!(target: LOG_TARGET, "Valid Monero data: {}", monero_pow_data);
+    trace!(target: LOG_TARGET, "Valid Monero data: {}", monero_pow_data);
     let blockhashing_blob = monero_pow_data.to_blockhashing_blob();
     let vm = randomx_factory.create(monero_pow_data.randomx_key())?;
     get_random_x_difficulty(&blockhashing_blob, &vm).map(|(diff, _)| diff)

--- a/base_layer/core/src/validation/header/header_full_validator.rs
+++ b/base_layer/core/src/validation/header/header_full_validator.rs
@@ -50,12 +50,11 @@ pub struct HeaderFullValidator {
 
 impl HeaderFullValidator {
     pub fn new(rules: ConsensusManager, difficulty_calculator: DifficultyCalculator) -> Self {
-
-        let gen_hash = rules.get_genesis_block().hash().clone();
+        let gen_hash = *rules.get_genesis_block().hash();
         Self {
             rules,
             difficulty_calculator,
-            gen_hash
+            gen_hash,
         }
     }
 }

--- a/base_layer/core/src/validation/header/header_full_validator.rs
+++ b/base_layer/core/src/validation/header/header_full_validator.rs
@@ -45,13 +45,17 @@ pub const LOG_TARGET: &str = "c::val::header_full_validator";
 pub struct HeaderFullValidator {
     rules: ConsensusManager,
     difficulty_calculator: DifficultyCalculator,
+    gen_hash: FixedHash,
 }
 
 impl HeaderFullValidator {
     pub fn new(rules: ConsensusManager, difficulty_calculator: DifficultyCalculator) -> Self {
+
+        let gen_hash = rules.get_genesis_block().hash().clone();
         Self {
             rules,
             difficulty_calculator,
+            gen_hash
         }
     }
 }
@@ -77,14 +81,13 @@ impl<B: BlockchainBackend> HeaderChainLinkedValidator<B> for HeaderFullValidator
 
         check_timestamp_ftl(header, &self.rules)?;
         check_pow_data(header, &self.rules, db)?;
-        let gen_hash = *self.rules.get_genesis_block().hash();
 
         let achieved_target = if let Some(target) = target_difficulty {
             check_target_difficulty(
                 header,
                 target,
                 &self.difficulty_calculator.randomx_factory,
-                &gen_hash,
+                &self.gen_hash,
                 &self.rules,
             )?
         } else {


### PR DESCRIPTION
Description
---
Improves the header validation speed by caching the gen block hash creation. 

Motivation and Context
---
This is very noticeable during sync, but it takes about 10ms to create the gen block, and if you only want the hash, this can speed up validation a lot if you do this repeatedly. 

After this pr, the validation of 
Sha3x: 10ms -> 10us
RandomX: 20ms -> 10ms

How Has This Been Tested?
---
Manual

