### PR TITLE
fix(comms): always send disconnect notification to conn manager

### DIFF
--- a/comms/core/src/connection_manager/peer_connection.rs
+++ b/comms/core/src/connection_manager/peer_connection.rs
@@ -532,7 +532,6 @@ impl PeerConnectionActor {
                         self.peer_node_id.short_str(),
                         e
                     );
-                    return Ok(());
                 },
                 e => trace!(target: LOG_TARGET, "On disconnect: ({})", e),
             }

--- a/comms/core/src/connectivity/connection_pool.rs
+++ b/comms/core/src/connectivity/connection_pool.rs
@@ -37,6 +37,12 @@ pub enum ConnectionStatus {
     Disconnected(Minimized),
 }
 
+impl ConnectionStatus {
+    pub fn is_connected(self) -> bool {
+        matches!(self, ConnectionStatus::Connected)
+    }
+}
+
 impl fmt::Display for ConnectionStatus {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:?}", self)
@@ -58,7 +64,7 @@ impl PeerConnectionState {
 
     /// Return true if the underlying connection exists and is connected, otherwise false
     pub fn is_connected(&self) -> bool {
-        self.connection().filter(|c| c.is_connected()).is_some()
+        self.status.is_connected() && self.connection().map_or(false, |c| c.is_connected())
     }
 
     pub fn connection_mut(&mut self) -> Option<&mut PeerConnection> {

--- a/comms/core/src/connectivity/manager.rs
+++ b/comms/core/src/connectivity/manager.rs
@@ -188,11 +188,9 @@ impl ConnectivityManagerActor {
                     self.handle_request(req).await;
                 },
 
-                event = connection_manager_events.recv() => {
-                    if let Ok(event) = event {
-                        if let Err(err) = self.handle_connection_manager_event(&event).await {
-                            error!(target:LOG_TARGET, "Error handling connection manager event: {:?}", err);
-                        }
+                Ok(event) = connection_manager_events.recv() => {
+                    if let Err(err) = self.handle_connection_manager_event(&event).await {
+                        error!(target:LOG_TARGET, "Error handling connection manager event: {:?}", err);
                     }
                 },
 
@@ -738,24 +736,37 @@ impl ConnectivityManagerActor {
     }
 
     async fn on_new_connection(&mut self, new_conn: &PeerConnection) -> TieBreak {
-        match self.pool.get_connection(new_conn.peer_node_id()).cloned() {
-            Some(existing_conn) if !existing_conn.is_connected() => {
+        match self.pool.get(new_conn.peer_node_id()).cloned() {
+            Some(existing_state) if !existing_state.is_connected() => {
                 debug!(
                     target: LOG_TARGET,
                     "Tie break: Existing connection (id: {}, peer: {}, direction: {}) was not connected, resolving \
                      tie break by using the new connection. (New: id: {}, peer: {}, direction: {})",
-                    existing_conn.id(),
-                    existing_conn.peer_node_id(),
-                    existing_conn.direction(),
+                    existing_state.connection().map(|c| c.id()).unwrap_or_default(),
+                    existing_state.node_id(),
+                    existing_state.connection().map(|c| c.direction().as_str()).unwrap_or("--"),
                     new_conn.id(),
                     new_conn.peer_node_id(),
                     new_conn.direction(),
                 );
-                self.pool.remove(existing_conn.peer_node_id());
+                self.pool.remove(existing_state.node_id());
                 TieBreak::UseNew
             },
-            Some(mut existing_conn) => {
-                if self.tie_break_existing_connection(&existing_conn, new_conn) {
+            Some(mut existing_state) => {
+                let Some(existing_conn) = existing_state.connection_mut() else {
+                    error!(
+                        target: LOG_TARGET,
+                        "INVARIANT ERROR in Tie break: PeerConnection is None but state is CONNECTED: Existing connection (id: {}, peer: {}, direction: {}), new connection. (id: {}, peer: {}, direction: {})",
+                        existing_state.connection().map(|c| c.id()).unwrap_or_default(),
+                        existing_state.node_id(),
+                        existing_state.connection().map(|c| c.direction().as_str()).unwrap_or("--"),
+                        new_conn.id(),
+                        new_conn.peer_node_id(),
+                        new_conn.direction(),
+                    );
+                    return TieBreak::UseNew;
+                };
+                if self.tie_break_existing_connection(existing_conn, new_conn) {
                     warn!(
                         target: LOG_TARGET,
                         "Tie break: Keep new connection (id: {}, peer: {}, direction: {}). Disconnect existing \


### PR DESCRIPTION
Description
---
fix(comms): always send disconnect notification to conn manager
fix(comms): take the connection state into account when determining connectedness for tie-breaking

Motivation and Context
---
Previously, if Yamux detected that we were disconnected, the connectivity manager `Disconnected` notification would not be sent. A race condition with disconnects on a connection and the remote disconnecting happen at almost the same time. If the latter happens first, then the notification of the disconnect would not be sent to the connection manager. When a new connection is attempted, the connection manager would think that a previous connection exists.

Ref #6512 
Ref https://github.com/tari-project/tari/issues/6513

How Has This Been Tested?
---
Not explicitly tested, difficult to reproduce.

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
