### PR TITLE
feat: add one-sided addresses to grpc

### DIFF
--- a/applications/minotari_app_grpc/proto/wallet.proto
+++ b/applications/minotari_app_grpc/proto/wallet.proto
@@ -90,7 +90,8 @@ message GetVersionResponse {
 }
 
 message GetAddressResponse {
-  bytes address = 1;
+  bytes interactive_address = 1;
+  bytes one_sided_address = 2;
 }
 
 message TransferRequest {

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -231,13 +231,19 @@ impl wallet_server::Wallet for WalletGrpcServer {
     }
 
     async fn get_address(&self, _: Request<tari_rpc::Empty>) -> Result<Response<GetAddressResponse>, Status> {
-        let address = self
+        let interactive_address = self
             .wallet
             .get_wallet_interactive_address()
             .await
             .map_err(|e| Status::internal(format!("{:?}", e)))?;
+        let one_sided_address = self
+            .wallet
+            .get_wallet_one_sided_address()
+            .await
+            .map_err(|e| Status::internal(format!("{:?}", e)))?;
         Ok(Response::new(GetAddressResponse {
-            address: address.to_vec(),
+            interactive_address: interactive_address.to_vec(),
+            one_sided_address: one_sided_address.to_vec(),
         }))
     }
 

--- a/integration_tests/src/merge_mining_proxy.rs
+++ b/integration_tests/src/merge_mining_proxy.rs
@@ -88,7 +88,7 @@ impl MergeMiningProxyProcess {
             .await
             .unwrap()
             .into_inner()
-            .one_sided_address;
+            .interactive_address;
         let wallet_payment_address = TariAddress::from_bytes(wallet_address).unwrap();
         thread::spawn(move || {
             let cli = Cli {

--- a/integration_tests/src/merge_mining_proxy.rs
+++ b/integration_tests/src/merge_mining_proxy.rs
@@ -83,13 +83,13 @@ impl MergeMiningProxyProcess {
         let mut wallet_client = create_wallet_client(world, self.wallet_name.clone())
             .await
             .expect("wallet grpc client");
-        let wallet_public_key = &wallet_client
+        let wallet_address = &wallet_client
             .get_address(grpc::Empty {})
             .await
             .unwrap()
             .into_inner()
-            .address;
-        let wallet_payment_address = TariAddress::from_bytes(wallet_public_key).unwrap();
+            .one_sided_address;
+        let wallet_payment_address = TariAddress::from_bytes(wallet_address).unwrap();
         thread::spawn(move || {
             let cli = Cli {
                 common: CommonCliArgs {

--- a/integration_tests/src/miner.rs
+++ b/integration_tests/src/miner.rs
@@ -98,7 +98,7 @@ impl MinerProcess {
             .await
             .unwrap()
             .into_inner()
-            .one_sided_address;
+            .interactive_address;
         let wallet_payment_address = TariAddress::from_bytes(wallet_adress).unwrap();
 
         let node = world.get_node(&self.base_node_name).unwrap().grpc_port;

--- a/integration_tests/src/miner.rs
+++ b/integration_tests/src/miner.rs
@@ -93,13 +93,13 @@ impl MinerProcess {
             .await
             .expect("wallet grpc client");
 
-        let wallet_public_key = &wallet_client
+        let wallet_adress = &wallet_client
             .get_address(grpc::Empty {})
             .await
             .unwrap()
             .into_inner()
-            .address;
-        let wallet_payment_address = TariAddress::from_bytes(wallet_public_key).unwrap();
+            .one_sided_address;
+        let wallet_payment_address = TariAddress::from_bytes(wallet_adress).unwrap();
 
         let node = world.get_node(&self.base_node_name).unwrap().grpc_port;
         let temp_dir = world

--- a/integration_tests/src/world.rs
+++ b/integration_tests/src/world.rs
@@ -210,7 +210,7 @@ impl TariWorld {
                     .await
                     .unwrap()
                     .into_inner()
-                    .one_sided_address
+                    .interactive_address
             },
             Err(_) => {
                 let ffi_wallet = self.get_ffi_wallet(name).unwrap();

--- a/integration_tests/src/world.rs
+++ b/integration_tests/src/world.rs
@@ -210,7 +210,7 @@ impl TariWorld {
                     .await
                     .unwrap()
                     .into_inner()
-                    .address
+                    .one_sided_address
             },
             Err(_) => {
                 let ffi_wallet = self.get_ffi_wallet(name).unwrap();

--- a/integration_tests/tests/steps/wallet_cli_steps.rs
+++ b/integration_tests/tests/steps/wallet_cli_steps.rs
@@ -144,7 +144,7 @@ async fn send_from_cli(world: &mut TariWorld, amount: u64, wallet_a: String, wal
         .await
         .unwrap()
         .into_inner()
-        .address
+        .one_sided_address
         .to_hex();
     let wallet_b_address = TariAddress::from_base58(wallet_b_address.as_str()).unwrap();
 
@@ -208,7 +208,7 @@ async fn make_it_rain(
         .await
         .unwrap()
         .into_inner()
-        .address
+        .one_sided_address
         .to_hex();
     let wallet_b_address = TariAddress::from_base58(wallet_b_address.as_str()).unwrap();
 

--- a/integration_tests/tests/steps/wallet_cli_steps.rs
+++ b/integration_tests/tests/steps/wallet_cli_steps.rs
@@ -144,7 +144,7 @@ async fn send_from_cli(world: &mut TariWorld, amount: u64, wallet_a: String, wal
         .await
         .unwrap()
         .into_inner()
-        .one_sided_address
+        .interactive_address
         .to_hex();
     let wallet_b_address = TariAddress::from_base58(wallet_b_address.as_str()).unwrap();
 
@@ -208,7 +208,7 @@ async fn make_it_rain(
         .await
         .unwrap()
         .into_inner()
-        .one_sided_address
+        .interactive_address
         .to_hex();
     let wallet_b_address = TariAddress::from_base58(wallet_b_address.as_str()).unwrap();
 

--- a/integration_tests/tests/steps/wallet_steps.rs
+++ b/integration_tests/tests/steps/wallet_steps.rs
@@ -266,7 +266,7 @@ async fn wallet_detects_all_txs_are_at_least_in_some_status(
         .await
         .unwrap()
         .into_inner()
-        .one_sided_address
+        .interactive_address
         .to_hex();
     let tx_ids = world.wallet_tx_ids.get(&wallet_address).unwrap();
 
@@ -347,7 +347,7 @@ async fn wallet_detects_all_txs_as_broadcast(world: &mut TariWorld, wallet_name:
         .await
         .unwrap()
         .into_inner()
-        .one_sided_address
+        .interactive_address
         .to_hex();
     let tx_ids = world.wallet_tx_ids.get(&wallet_address).unwrap();
 
@@ -400,7 +400,7 @@ async fn wallet_detects_last_tx_as_pending(world: &mut TariWorld, wallet: String
         .await
         .unwrap()
         .into_inner()
-        .one_sided_address
+        .interactive_address
         .to_hex();
     let tx_ids = world.wallet_tx_ids.get(&wallet_address).unwrap();
     let tx_id = tx_ids.last().unwrap(); // get last transaction
@@ -446,7 +446,7 @@ async fn wallet_detects_last_tx_as_cancelled(world: &mut TariWorld, wallet: Stri
         .await
         .unwrap()
         .into_inner()
-        .one_sided_address
+        .interactive_address
         .to_hex();
     let tx_ids = world.wallet_tx_ids.get(&wallet_address).unwrap();
     let tx_id = tx_ids.last().unwrap(); // get last transaction
@@ -1116,7 +1116,7 @@ async fn stop_wallet(world: &mut TariWorld, wallet: String) {
         .await
         .unwrap()
         .into_inner()
-        .one_sided_address
+        .interactive_address
         .to_hex();
     let wallet_ps = world.wallets.get_mut(&wallet).unwrap();
     world.wallet_addresses.insert(wallet.clone(), wallet_address);
@@ -2116,7 +2116,7 @@ async fn send_one_sided_stealth_transaction(
         .await
         .unwrap()
         .into_inner()
-        .one_sided_address
+        .interactive_address
         .to_hex();
 
     let mut receiver_client = create_wallet_client(world, receiver.clone()).await.unwrap();
@@ -2125,7 +2125,7 @@ async fn send_one_sided_stealth_transaction(
         .await
         .unwrap()
         .into_inner()
-        .one_sided_address
+        .interactive_address
         .to_hex();
 
     let payment_recipient = PaymentRecipient {
@@ -2604,7 +2604,7 @@ async fn multi_send_txs_from_wallet(
         .await
         .unwrap()
         .into_inner()
-        .one_sided_address
+        .interactive_address
         .to_hex();
 
     let mut receiver_wallet_client = create_wallet_client(world, receiver.clone()).await.unwrap();
@@ -2613,7 +2613,7 @@ async fn multi_send_txs_from_wallet(
         .await
         .unwrap()
         .into_inner()
-        .one_sided_address
+        .interactive_address
         .to_hex();
 
     let mut transfer_res = vec![];
@@ -2766,7 +2766,7 @@ async fn cancel_last_transaction_in_wallet(world: &mut TariWorld, wallet: String
         .await
         .unwrap()
         .into_inner()
-        .one_sided_address
+        .interactive_address
         .to_hex();
 
     let wallet_tx_ids = world.wallet_tx_ids.get(&wallet_address).unwrap();

--- a/integration_tests/tests/steps/wallet_steps.rs
+++ b/integration_tests/tests/steps/wallet_steps.rs
@@ -266,7 +266,7 @@ async fn wallet_detects_all_txs_are_at_least_in_some_status(
         .await
         .unwrap()
         .into_inner()
-        .address
+        .one_sided_address
         .to_hex();
     let tx_ids = world.wallet_tx_ids.get(&wallet_address).unwrap();
 
@@ -347,7 +347,7 @@ async fn wallet_detects_all_txs_as_broadcast(world: &mut TariWorld, wallet_name:
         .await
         .unwrap()
         .into_inner()
-        .address
+        .one_sided_address
         .to_hex();
     let tx_ids = world.wallet_tx_ids.get(&wallet_address).unwrap();
 
@@ -400,7 +400,7 @@ async fn wallet_detects_last_tx_as_pending(world: &mut TariWorld, wallet: String
         .await
         .unwrap()
         .into_inner()
-        .address
+        .one_sided_address
         .to_hex();
     let tx_ids = world.wallet_tx_ids.get(&wallet_address).unwrap();
     let tx_id = tx_ids.last().unwrap(); // get last transaction
@@ -446,7 +446,7 @@ async fn wallet_detects_last_tx_as_cancelled(world: &mut TariWorld, wallet: Stri
         .await
         .unwrap()
         .into_inner()
-        .address
+        .one_sided_address
         .to_hex();
     let tx_ids = world.wallet_tx_ids.get(&wallet_address).unwrap();
     let tx_id = tx_ids.last().unwrap(); // get last transaction
@@ -1116,7 +1116,7 @@ async fn stop_wallet(world: &mut TariWorld, wallet: String) {
         .await
         .unwrap()
         .into_inner()
-        .address
+        .one_sided_address
         .to_hex();
     let wallet_ps = world.wallets.get_mut(&wallet).unwrap();
     world.wallet_addresses.insert(wallet.clone(), wallet_address);
@@ -2116,7 +2116,7 @@ async fn send_one_sided_stealth_transaction(
         .await
         .unwrap()
         .into_inner()
-        .address
+        .one_sided_address
         .to_hex();
 
     let mut receiver_client = create_wallet_client(world, receiver.clone()).await.unwrap();
@@ -2125,7 +2125,7 @@ async fn send_one_sided_stealth_transaction(
         .await
         .unwrap()
         .into_inner()
-        .address
+        .one_sided_address
         .to_hex();
 
     let payment_recipient = PaymentRecipient {
@@ -2604,7 +2604,7 @@ async fn multi_send_txs_from_wallet(
         .await
         .unwrap()
         .into_inner()
-        .address
+        .one_sided_address
         .to_hex();
 
     let mut receiver_wallet_client = create_wallet_client(world, receiver.clone()).await.unwrap();
@@ -2613,7 +2613,7 @@ async fn multi_send_txs_from_wallet(
         .await
         .unwrap()
         .into_inner()
-        .address
+        .one_sided_address
         .to_hex();
 
     let mut transfer_res = vec![];
@@ -2766,7 +2766,7 @@ async fn cancel_last_transaction_in_wallet(world: &mut TariWorld, wallet: String
         .await
         .unwrap()
         .into_inner()
-        .address
+        .one_sided_address
         .to_hex();
 
     let wallet_tx_ids = world.wallet_tx_ids.get(&wallet_address).unwrap();


### PR DESCRIPTION
Description
---
Currently get_address grpc call only returns the interactive address. This adds the one-sided address as well, showing both.
