### PR TITLE
chore: reduce size of proxy logs

### DIFF
--- a/applications/minotari_merge_mining_proxy/log4rs_sample.yml
+++ b/applications/minotari_merge_mining_proxy/log4rs_sample.yml
@@ -26,7 +26,7 @@ appenders:
       kind: compound
       trigger:
         kind: size
-        limit: 200mb
+        limit: 10mb
       roller:
         kind: fixed_window
         base: 1


### PR DESCRIPTION
Proxy config would generate 200mb files that are impossible to read in an editor