### PR TITLE
chore: add aliases and readme for nextest

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,3 +3,11 @@ linker = "aarch64-linux-gnu-gcc"
 
 [target.riscv64gc-unknown-linux-gnu]
 linker = "riscv64-linux-gnu-gcc"
+
+[alias]
+ci-fmt = "fmt --all -- --check"
+ci-fmt-fix = "fmt --all"
+ci-clippy = "lints clippy --all-targets --all-features"
+ci-test-compile = "test --no-run --workspace --all-features --no-default-features"
+ci-test = "nextest run --all-features --release --workspace --exclude tari_integration_tests --profile ci"
+ci-cucumber = "test  --release  --test cucumber --all-features  --package tari_integration_tests -- -t @critical"

--- a/README.md
+++ b/README.md
@@ -24,9 +24,24 @@ The recommended running versions of each network are:
 |-----------|----------------|
 | Stagenet  | 1.0.0-alpha.0a |
 | Nextnet   | 1.0.0-rc.8     |
-| Esmeralda | 1.1.0-pre.2    |
+| Esmeralda | 1.4.1-pre.0    |
 
 For more detail about versioning, see [Release Ideology](https://github.com/tari-project/tari/blob/development/docs/src/branching_releases.md).
+
+### Running test
+Tests can be run by install Nextest with the following command:
+
+```bash
+cargo install cargo-nextest
+```
+
+Then run the tests with:
+
+```bash
+cargo ci-test
+```
+
+
 
 ### Download
 


### PR DESCRIPTION
Description
---
Since PR: #6529 `cargo test` has been broken
This adds aliases to use with cargo nextest and a readme how to use it

