### PR TITLE
feat!: add multiaddr with range checks for use with universe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6174,6 +6174,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util 0.6.10",
+ "toml 0.5.11",
  "tower",
  "tracing",
  "yamux",

--- a/base_layer/contacts/tests/contacts_service.rs
+++ b/base_layer/contacts/tests/contacts_service.rs
@@ -88,7 +88,6 @@ pub fn setup_contacts_service<T: ContactsBackend + 'static>(
                 auto_request: true,
                 ..Default::default()
             },
-            excluded_dial_addresses: vec![],
             ..Default::default()
         },
         allow_test_addresses: true,

--- a/base_layer/p2p/src/initialization.rs
+++ b/base_layer/p2p/src/initialization.rs
@@ -332,7 +332,7 @@ async fn configure_comms_and_dht(
         .with_listener_liveness_allowlist_cidrs(listener_liveness_allowlist_cidrs)
         .with_dial_backoff(ConstantBackoff::new(Duration::from_millis(500)))
         .with_peer_storage(peer_database, Some(file_lock))
-        .with_excluded_dial_addresses(config.dht.excluded_dial_addresses.clone());
+        .with_excluded_dial_addresses(config.dht.excluded_dial_addresses.clone().into_vec().clone());
 
     let mut comms = match config.auxiliary_tcp_listener_address {
         Some(ref addr) => builder.with_auxiliary_tcp_listener_address(addr.clone()).build()?,

--- a/base_layer/wallet_ffi/src/error.rs
+++ b/base_layer/wallet_ffi/src/error.rs
@@ -57,6 +57,8 @@ pub enum InterfaceError {
     InvalidEmojiId,
     #[error("An error has occurred due to an invalid argument: `{0}`")]
     InvalidArgument(String),
+    #[error("An internal error has occurred: `{0}`")]
+    InternalError(String),
     #[error("Balance Unavailable")]
     BalanceError,
 }
@@ -105,6 +107,10 @@ impl From<InterfaceError> for LibWalletError {
             InterfaceError::PointerError(ref p) => Self {
                 code: 9,
                 message: format!("Pointer error on {}:{:?}", p, v),
+            },
+            InterfaceError::InternalError(_) => Self {
+                code: 10,
+                message: format!("{:?}", v),
             },
         }
     }

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -126,6 +126,7 @@ use tari_common_types::{
 };
 use tari_comms::{
     multiaddr::Multiaddr,
+    net_address::IP4_TCP_TEST_ADDR_RANGE,
     peer_manager::{NodeIdentity, PeerQuery},
     transports::MemoryTransport,
     types::CommsPublicKey,
@@ -5326,7 +5327,7 @@ pub unsafe extern "C" fn comms_config_create(
                         minimum_desired_tcpv4_node_ratio: 0.0,
                         ..Default::default()
                     },
-                    excluded_dial_addresses: vec![],
+                    excluded_dial_addresses: vec![IP4_TCP_TEST_ADDR_RANGE.parse().expect("valid address range")],
                     ..Default::default()
                 },
                 allow_test_addresses: true,

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -126,6 +126,7 @@ use tari_common_types::{
 };
 use tari_comms::{
     multiaddr::Multiaddr,
+    net_address::{MultiaddrRange, MultiaddrRangeList, IP4_TCP_TEST_ADDR_RANGE},
     peer_manager::{NodeIdentity, PeerQuery},
     transports::MemoryTransport,
     types::CommsPublicKey,
@@ -5199,6 +5200,7 @@ pub unsafe extern "C" fn transport_config_destroy(transport: *mut TariTransportC
 /// `database_path` - The database path char array pointer which. This is the folder path where the
 /// database files will be created and the application has write access to
 /// `discovery_timeout_in_secs`: specify how long the Discovery Timeout for the wallet is.
+/// `exclude_dial_test_addresses`: exclude dialing of test addresses; this should be 'true' for production wallets
 /// `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
 /// as an out parameter.
 ///
@@ -5217,6 +5219,7 @@ pub unsafe extern "C" fn comms_config_create(
     datastore_path: *const c_char,
     discovery_timeout_in_secs: c_ulonglong,
     saf_message_duration_in_secs: c_ulonglong,
+    exclude_dial_test_addresses: bool,
     error_out: *mut c_int,
 ) -> *mut TariCommsConfig {
     let mut error = 0;
@@ -5294,6 +5297,20 @@ pub unsafe extern "C" fn comms_config_create(
                 MultiaddrList::from(vec![public_address])
             };
 
+            let excluded_dial_addresses = if exclude_dial_test_addresses {
+                let multi_addr_range = match MultiaddrRange::from_str(IP4_TCP_TEST_ADDR_RANGE) {
+                    Ok(val) => val,
+                    Err(e) => {
+                        error = LibWalletError::from(InterfaceError::InternalError(e)).code;
+                        ptr::swap(error_out, &mut error as *mut c_int);
+                        return ptr::null_mut();
+                    },
+                };
+                MultiaddrRangeList::from(vec![multi_addr_range])
+            } else {
+                MultiaddrRangeList::from(vec![])
+            };
+
             let config = TariCommsConfig {
                 override_from: None,
                 public_addresses: addresses,
@@ -5326,8 +5343,7 @@ pub unsafe extern "C" fn comms_config_create(
                         minimum_desired_tcpv4_node_ratio: 0.0,
                         ..Default::default()
                     },
-                    // FIXME: This should be set to 'IP4_TCP_TEST_ADDR_RANGE', but cucumber tests need to use that range
-                    excluded_dial_addresses: vec![].into(),
+                    excluded_dial_addresses,
                     ..Default::default()
                 },
                 allow_test_addresses: true,
@@ -10238,6 +10254,7 @@ mod test {
                 db_path_alice_str,
                 20,
                 10800,
+                false,
                 error_ptr,
             );
 
@@ -10402,6 +10419,7 @@ mod test {
                 db_path_alice_str,
                 20,
                 10800,
+                false,
                 error_ptr,
             );
 
@@ -10629,6 +10647,7 @@ mod test {
                 db_path_str,
                 20,
                 10800,
+                false,
                 error_ptr,
             );
 
@@ -10692,6 +10711,7 @@ mod test {
                 db_path_str,
                 20,
                 10800,
+                false,
                 error_ptr,
             );
 
@@ -10775,6 +10795,7 @@ mod test {
                 db_path_alice_str,
                 20,
                 10800,
+                false,
                 error_ptr,
             );
 
@@ -10952,6 +10973,7 @@ mod test {
                 db_path_alice_str,
                 20,
                 10800,
+                false,
                 error_ptr,
             );
 
@@ -11090,6 +11112,7 @@ mod test {
                 db_path_alice_str,
                 20,
                 10800,
+                false,
                 error_ptr,
             );
 
@@ -11309,6 +11332,7 @@ mod test {
                 db_path_alice_str,
                 20,
                 10800,
+                false,
                 error_ptr,
             );
 
@@ -11535,6 +11559,7 @@ mod test {
                 db_path_alice_str,
                 20,
                 10800,
+                false,
                 error_ptr,
             );
 
@@ -11796,6 +11821,7 @@ mod test {
                 db_path_str,
                 20,
                 10800,
+                false,
                 error_ptr,
             );
             let passphrase: *const c_char = CString::into_raw(CString::new("niao").unwrap()) as *const c_char;
@@ -12176,6 +12202,7 @@ mod test {
                 alice_db_path_str,
                 20,
                 10800,
+                false,
                 error_ptr,
             );
             let passphrase: *const c_char = CString::into_raw(CString::new("niao").unwrap()) as *const c_char;
@@ -12240,6 +12267,7 @@ mod test {
                 bob_db_path_str,
                 20,
                 10800,
+                false,
                 error_ptr,
             );
             let passphrase: *const c_char = CString::into_raw(CString::new("niao").unwrap()) as *const c_char;

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -5327,7 +5327,7 @@ pub unsafe extern "C" fn comms_config_create(
                         minimum_desired_tcpv4_node_ratio: 0.0,
                         ..Default::default()
                     },
-                    excluded_dial_addresses: vec![IP4_TCP_TEST_ADDR_RANGE.parse().expect("valid address range")],
+                    excluded_dial_addresses: vec![IP4_TCP_TEST_ADDR_RANGE.parse().expect("valid address range")].into(),
                     ..Default::default()
                 },
                 allow_test_addresses: true,

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -126,7 +126,6 @@ use tari_common_types::{
 };
 use tari_comms::{
     multiaddr::Multiaddr,
-    net_address::IP4_TCP_TEST_ADDR_RANGE,
     peer_manager::{NodeIdentity, PeerQuery},
     transports::MemoryTransport,
     types::CommsPublicKey,
@@ -5327,7 +5326,8 @@ pub unsafe extern "C" fn comms_config_create(
                         minimum_desired_tcpv4_node_ratio: 0.0,
                         ..Default::default()
                     },
-                    excluded_dial_addresses: vec![IP4_TCP_TEST_ADDR_RANGE.parse().expect("valid address range")].into(),
+                    // FIXME: This should be set to 'IP4_TCP_TEST_ADDR_RANGE', but cucumber tests need to use that range
+                    excluded_dial_addresses: vec![].into(),
                     ..Default::default()
                 },
                 allow_test_addresses: true,

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -2758,6 +2758,7 @@ void transport_config_destroy(TariTransportConfig *transport);
  * `database_path` - The database path char array pointer which. This is the folder path where the
  * database files will be created and the application has write access to
  * `discovery_timeout_in_secs`: specify how long the Discovery Timeout for the wallet is.
+ * `exclude_dial_test_addresses`: exclude dialing of test addresses; this should be 'true' for production wallets
  * `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
  * as an out parameter.
  *
@@ -2774,6 +2775,7 @@ TariCommsConfig *comms_config_create(const char *public_address,
                                      const char *datastore_path,
                                      unsigned long long discovery_timeout_in_secs,
                                      unsigned long long saf_message_duration_in_secs,
+                                     bool exclude_dial_test_addresses,
                                      int *error_out);
 
 /**

--- a/clients/ffi_client/index.js
+++ b/clients/ffi_client/index.js
@@ -39,6 +39,7 @@ try {
     "./wallet",
     30,
     600,
+    false,
     err
   );
 

--- a/clients/ffi_client/recovery.js
+++ b/clients/ffi_client/recovery.js
@@ -53,6 +53,7 @@ try {
     "./recovery",
     30,
     600,
+    false,
     err
   );
 

--- a/common/config/presets/c_base_node_c.toml
+++ b/common/config/presets/c_base_node_c.toml
@@ -303,8 +303,6 @@ database_url = "data/base_node/dht.db"
 #ban_duration = 21_600 # 6 * 60 * 60
 # Length of time to ban a peer for a "short" duration. Default: 60 mins
 #ban_duration_short = 3_600 # 60 * 60
-# This allows the use of test addresses in the network like 127.0.0.1. Default: false
-#allow_test_addresses = false
 # The maximum number of messages over `flood_ban_timespan` to allow before banning the peer (for `ban_duration_short`)
 # Default: 100_000 messages
 #flood_ban_max_msg_count = 100_000
@@ -316,5 +314,9 @@ database_url = "data/base_node/dht.db"
 # In a situation where a node is not well-connected and many nodes are locally marked as offline, we can retry
 # peers that were previously tried. Default: 2 hours
 #offline_peer_cooldown = 7_200 # 2 * 60 * 60
-# Addresses that should never be dialed (default value = [])
-#excluded_dial_addresses = ["/ip4/x.x.x.x/tcp/xxxx", "/ip4/x.y.x.y/tcp/xyxy"]
+# Addresses that should never be dialed (default value = []). This can be a specific address or an IPv4/TCP range.
+# Example: When used in conjunction with `allow_test_addresses = true` (but it could be any other range)
+#   `excluded_dial_addresses = ["/ip4/127.*.0:49.*/tcp/*", "/ip4/127.*.101:255.*/tcp/*"]`
+#                or
+#   `excluded_dial_addresses = ["/ip4/127.0:0.1/tcp/122", "/ip4/127.0:0.1/tcp/1000:2000"]`
+#excluded_dial_addresses = []

--- a/common/config/presets/d_console_wallet.toml
+++ b/common/config/presets/d_console_wallet.toml
@@ -347,8 +347,6 @@ network_discovery.initial_peer_sync_delay = 25
 #ban_duration = 21_600 # 6 * 60 * 60
 # Length of time to ban a peer for a "short" duration. Default: 60 mins
 #ban_duration_short = 3_600 # 60 * 60
-# This allows the use of test addresses in the network like 127.0.0.1. Default: false
-#allow_test_addresses = false
 # The maximum number of messages over `flood_ban_timespan` to allow before banning the peer (for `ban_duration_short`)
 # Default: 100_000 messages
 #flood_ban_max_msg_count = 100_000
@@ -360,5 +358,9 @@ network_discovery.initial_peer_sync_delay = 25
 # In a situation where a node is not well-connected and many nodes are locally marked as offline, we can retry
 # peers that were previously tried. Default: 2 hours
 #offline_peer_cooldown = 7_200 # 2 * 60 * 60
-# Addresses that should never be dialed (default value = [])
-#excluded_dial_addresses = ["/ip4/x.x.x.x/tcp/xxxx", "/ip4/x.y.x.y/tcp/xyxy"]
+# Addresses that should never be dialed (default value = []). This can be a specific address or an IPv4/TCP range.
+# Example: When used in conjunction with `allow_test_addresses = true` (but it could be any other range)
+#   `excluded_dial_addresses = ["/ip4/127.*.0:49.*/tcp/*", "/ip4/127.*.101:255.*/tcp/*"]`
+#                or
+#   `excluded_dial_addresses = ["/ip4/127.0:0.1/tcp/122", "/ip4/127.0:0.1/tcp/1000:2000"]`
+#excluded_dial_addresses = []

--- a/comms/core/Cargo.toml
+++ b/comms/core/Cargo.toml
@@ -52,6 +52,7 @@ zeroize = "1"
 [dev-dependencies]
 tari_test_utils = { path = "../../infrastructure/test_utils" }
 tari_comms_rpc_macros = { path = "../rpc_macros" }
+toml = { version = "0.5"}
 
 env_logger = "0.7.0"
 serde_json = "1.0.39"

--- a/comms/core/src/builder/mod.rs
+++ b/comms/core/src/builder/mod.rs
@@ -45,6 +45,7 @@ use crate::{
     connection_manager::{ConnectionManagerConfig, ConnectionManagerRequester},
     connectivity::{ConnectivityConfig, ConnectivityRequester},
     multiaddr::Multiaddr,
+    net_address::MultiaddrRange,
     peer_manager::{NodeIdentity, PeerManager},
     peer_validator::PeerValidatorConfig,
     protocol::{NodeNetworkInfo, ProtocolExtensions},
@@ -242,7 +243,7 @@ impl CommsBuilder {
         self
     }
 
-    pub fn with_excluded_dial_addresses(mut self, excluded_addresses: Vec<Multiaddr>) -> Self {
+    pub fn with_excluded_dial_addresses(mut self, excluded_addresses: Vec<MultiaddrRange>) -> Self {
         self.connection_manager_config.excluded_dial_addresses = excluded_addresses;
         self
     }

--- a/comms/core/src/connection_manager/dialer.rs
+++ b/comms/core/src/connection_manager/dialer.rs
@@ -55,7 +55,7 @@ use crate::{
     },
     multiaddr::Multiaddr,
     multiplexing::Yamux,
-    net_address::PeerAddressSource,
+    net_address::{MultiaddrRange, PeerAddressSource},
     noise::{NoiseConfig, NoiseSocket},
     peer_manager::{NodeId, NodeIdentity, Peer, PeerManager},
     protocol::ProtocolId,
@@ -557,7 +557,7 @@ where
         noise_config: &NoiseConfig,
         transport: &TTransport,
         network_byte: u8,
-        excluded_dial_addresses: Vec<Multiaddr>,
+        excluded_dial_addresses: Vec<MultiaddrRange>,
     ) -> (
         DialState,
         Result<(NoiseSocket<TTransport::Output>, Multiaddr), ConnectionManagerError>,
@@ -568,7 +568,7 @@ where
             .clone()
             .into_vec()
             .iter()
-            .filter(|&a| !excluded_dial_addresses.iter().any(|excluded| a == excluded))
+            .filter(|&a| !excluded_dial_addresses.iter().any(|excluded| excluded.contains(a)))
             .cloned()
             .collect::<Vec<_>>();
         if addresses.is_empty() {

--- a/comms/core/src/connection_manager/manager.rs
+++ b/comms/core/src/connection_manager/manager.rs
@@ -49,6 +49,7 @@ use crate::{
     backoff::Backoff,
     connection_manager::ConnectionId,
     multiplexing::Substream,
+    net_address::MultiaddrRange,
     noise::NoiseConfig,
     peer_manager::{NodeId, NodeIdentity, PeerManagerError},
     peer_validator::PeerValidatorConfig,
@@ -134,7 +135,7 @@ pub struct ConnectionManagerConfig {
     /// Peer validation configuration. See [PeerValidatorConfig]
     pub peer_validation_config: PeerValidatorConfig,
     /// Addresses that should never be dialed
-    pub excluded_dial_addresses: Vec<Multiaddr>,
+    pub excluded_dial_addresses: Vec<MultiaddrRange>,
 }
 
 impl Default for ConnectionManagerConfig {

--- a/comms/core/src/connection_manager/tests/listener_dialer.rs
+++ b/comms/core/src/connection_manager/tests/listener_dialer.rs
@@ -287,7 +287,7 @@ async fn excluded_yes() {
     let (request_tx, request_rx) = mpsc::channel(1);
     let peer_manager2 = build_peer_manager();
     let connection_manager_config = ConnectionManagerConfig {
-        excluded_dial_addresses: vec![address.clone()],
+        excluded_dial_addresses: vec![address.to_string().parse().unwrap()],
         ..Default::default()
     };
     let mut dialer = Dialer::new(

--- a/comms/core/src/net_address/mod.rs
+++ b/comms/core/src/net_address/mod.rs
@@ -29,4 +29,4 @@ mod mutliaddresses_with_stats;
 pub use mutliaddresses_with_stats::MultiaddressesWithStats;
 
 mod multiaddr_range;
-pub use multiaddr_range::{serde_multiaddr_range, MultiaddrRange, MultiaddrRangeList, IP4_TCP_TEST_ADDR_RANGE};
+pub use multiaddr_range::{MultiaddrRange, MultiaddrRangeList, IP4_TCP_TEST_ADDR_RANGE};

--- a/comms/core/src/net_address/mod.rs
+++ b/comms/core/src/net_address/mod.rs
@@ -27,3 +27,6 @@ pub use multiaddr_with_stats::{MultiaddrWithStats, PeerAddressSource};
 
 mod mutliaddresses_with_stats;
 pub use mutliaddresses_with_stats::MultiaddressesWithStats;
+
+mod multiaddr_range;
+pub use multiaddr_range::{MultiaddrRange, IP4_TCP_TEST_ADDR_RANGE};

--- a/comms/core/src/net_address/mod.rs
+++ b/comms/core/src/net_address/mod.rs
@@ -29,4 +29,4 @@ mod mutliaddresses_with_stats;
 pub use mutliaddresses_with_stats::MultiaddressesWithStats;
 
 mod multiaddr_range;
-pub use multiaddr_range::{MultiaddrRange, IP4_TCP_TEST_ADDR_RANGE};
+pub use multiaddr_range::{serde_multiaddr_range, MultiaddrRange, MultiaddrRangeList, IP4_TCP_TEST_ADDR_RANGE};

--- a/comms/core/src/net_address/multiaddr_range.rs
+++ b/comms/core/src/net_address/multiaddr_range.rs
@@ -1,0 +1,333 @@
+// Copyright 2022 The Tari Project
+// SPDX-License-Identifier: BSD-3-Clause
+
+use std::{fmt, net::Ipv4Addr, str::FromStr};
+
+use multiaddr::{Multiaddr, Protocol};
+use serde_derive::{Deserialize, Serialize};
+
+/// A MultiaddrRange for testing purposes that matches any IPv4 address and any port
+pub const IP4_TCP_TEST_ADDR_RANGE: &str = "/ip4/127.*.*.*/tcp/*";
+
+/// ----------------- MultiaddrRange -----------------
+/// A struct containing either an Ipv4AddrRange or a Multiaddr. If a range of IP addresses and/or ports needs to be
+/// specified, the MultiaddrRange can be used, but it only supports IPv4 addresses with the TCP protocol.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MultiaddrRange {
+    ipv4_addr_range: Option<Ipv4AddrRange>,
+    multiaddr: Option<Multiaddr>,
+}
+
+impl FromStr for MultiaddrRange {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Ok(multiaddr) = Multiaddr::from_str(s) {
+            Ok(MultiaddrRange {
+                ipv4_addr_range: None,
+                multiaddr: Some(multiaddr),
+            })
+        } else if let Ok(ipv4_addr_range) = Ipv4AddrRange::from_str(s) {
+            Ok(MultiaddrRange {
+                ipv4_addr_range: Some(ipv4_addr_range),
+                multiaddr: None,
+            })
+        } else {
+            Err("Invalid format for both Multiaddr and Ipv4AddrRange".to_string())
+        }
+    }
+}
+
+impl fmt::Display for MultiaddrRange {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(ipv4_addr_range) = &self.ipv4_addr_range {
+            write!(f, "{}", ipv4_addr_range)
+        } else if let Some(multiaddr) = &self.multiaddr {
+            write!(f, "{}", multiaddr)
+        } else {
+            write!(f, "None")
+        }
+    }
+}
+
+impl MultiaddrRange {
+    /// Check if the given Multiaddr is contained within the MultiaddrRange range
+    pub fn contains(&self, addr: &Multiaddr) -> bool {
+        if let Some(ipv4_addr_range) = &self.ipv4_addr_range {
+            return ipv4_addr_range.contains(addr);
+        }
+        if let Some(multiaddr) = &self.multiaddr {
+            return multiaddr == addr;
+        }
+        false
+    }
+}
+
+// ----------------- Ipv4AddrRange -----------------
+// A struct containing an Ipv4Range and a PortRange
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Ipv4AddrRange {
+    ip_range: Ipv4Range,
+    port_range: PortRange,
+}
+
+impl FromStr for Ipv4AddrRange {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let parts: Vec<&str> = s.split('/').collect();
+        if parts.len() != 5 {
+            return Err("Invalid multiaddr format".to_string());
+        }
+
+        if parts[1] != "ip4" {
+            return Err("Only IPv4 addresses are supported".to_string());
+        }
+
+        let ip_range = Ipv4Range::new(parts[2])?;
+        if parts[3] != "tcp" {
+            return Err("Only TCP protocol is supported".to_string());
+        }
+
+        let port_range = PortRange::new(parts[4])?;
+        Ok(Ipv4AddrRange { ip_range, port_range })
+    }
+}
+
+impl Ipv4AddrRange {
+    fn contains(&self, addr: &Multiaddr) -> bool {
+        let mut ip = None;
+        let mut port = None;
+
+        for protocol in addr {
+            match protocol {
+                Protocol::Ip4(ipv4) => ip = Some(ipv4),
+                Protocol::Tcp(tcp_port) => port = Some(tcp_port),
+                _ => {},
+            }
+        }
+
+        if let (Some(ip), Some(port)) = (ip, port) {
+            return self.ip_range.contains(ip) && self.port_range.contains(port);
+        }
+
+        false
+    }
+}
+
+impl fmt::Display for Ipv4AddrRange {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "/ip4/{}/tcp/{}", self.ip_range, self.port_range)
+    }
+}
+
+// ----------------- Ipv4Range -----------------
+// A struct containing the start and end Ipv4Addr
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Ipv4Range {
+    start: Ipv4Addr,
+    end: Ipv4Addr,
+}
+
+impl Ipv4Range {
+    fn new(range_str: &str) -> Result<Self, String> {
+        let parts: Vec<&str> = range_str.split('.').collect();
+        if parts.len() != 4 {
+            return Err("Invalid IP range format".to_string());
+        }
+
+        let mut start_octets = [0u8; 4];
+        let mut end_octets = [0u8; 4];
+
+        for (i, part) in parts.iter().enumerate() {
+            if i == 0 {
+                start_octets[i] = part.parse().map_err(|_| "Invalid first octet".to_string())?;
+                end_octets[i] = start_octets[i];
+            } else if part == &"*" {
+                start_octets[i] = 0;
+                end_octets[i] = u8::MAX;
+            } else if part.contains(':') {
+                let range_parts: Vec<&str> = part.split(':').collect();
+                if range_parts.len() != 2 {
+                    return Err("Invalid range format".to_string());
+                }
+                start_octets[i] = range_parts[0].parse().map_err(|_| "Invalid range start".to_string())?;
+                end_octets[i] = range_parts[1].parse().map_err(|_| "Invalid range end".to_string())?;
+            } else {
+                start_octets[i] = part.parse().map_err(|_| "Invalid octet".to_string())?;
+                end_octets[i] = start_octets[i];
+            }
+        }
+
+        Ok(Ipv4Range {
+            start: Ipv4Addr::new(start_octets[0], start_octets[1], start_octets[2], start_octets[3]),
+            end: Ipv4Addr::new(end_octets[0], end_octets[1], end_octets[2], end_octets[3]),
+        })
+    }
+
+    fn contains(&self, addr: Ipv4Addr) -> bool {
+        let octets = addr.octets();
+        let start_octets = self.start.octets();
+        let end_octets = self.end.octets();
+
+        for i in 0..4 {
+            if octets[i] < start_octets[i] || octets[i] > end_octets[i] {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+impl fmt::Display for Ipv4Range {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let start_octets = self.start.octets();
+        let end_octets = self.end.octets();
+        write!(
+            f,
+            "{}.{}.{}.{}",
+            start_octets[0],
+            if start_octets[1] == 0 && end_octets[1] == u8::MAX {
+                "*".to_string()
+            } else if start_octets[1] == end_octets[1] {
+                start_octets[1].to_string()
+            } else {
+                format!("{}:{}", start_octets[1], end_octets[1])
+            },
+            if start_octets[2] == 0 && end_octets[2] == u8::MAX {
+                "*".to_string()
+            } else if start_octets[2] == end_octets[2] {
+                start_octets[2].to_string()
+            } else {
+                format!("{}:{}", start_octets[2], end_octets[2])
+            },
+            if start_octets[3] == 0 && end_octets[3] == u8::MAX {
+                "*".to_string()
+            } else if start_octets[3] == end_octets[3] {
+                start_octets[3].to_string()
+            } else {
+                format!("{}:{}", start_octets[3], end_octets[3])
+            }
+        )
+    }
+}
+
+// ----------------- PortRange -----------------
+// A struct containing the start and end port
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PortRange {
+    start: u16,
+    end: u16,
+}
+
+impl PortRange {
+    fn new(range_str: &str) -> Result<Self, String> {
+        if range_str == "*" {
+            return Ok(PortRange {
+                start: 0,
+                end: u16::MAX,
+            });
+        }
+
+        if range_str.contains(':') {
+            let parts: Vec<&str> = range_str.split(':').collect();
+            if parts.len() != 2 {
+                return Err("Invalid port range format".to_string());
+            }
+            let start = parts[0].parse().map_err(|_| "Invalid port range start".to_string())?;
+            let end = parts[1].parse().map_err(|_| "Invalid port range end".to_string())?;
+            return Ok(PortRange { start, end });
+        }
+
+        let port = range_str.parse().map_err(|_| "Invalid port".to_string())?;
+        Ok(PortRange { start: port, end: port })
+    }
+
+    fn contains(&self, port: u16) -> bool {
+        port >= self.start && port <= self.end
+    }
+}
+
+impl fmt::Display for PortRange {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.start == 0 && self.end == u16::MAX {
+            write!(f, "*")
+        } else if self.start == self.end {
+            write!(f, "{}", self.start)
+        } else {
+            write!(f, "{}:{}", self.start, self.end)
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::net::{IpAddr, Ipv6Addr};
+
+    use crate::{
+        multiaddr::Multiaddr,
+        net_address::{multiaddr_range::IP4_TCP_TEST_ADDR_RANGE, MultiaddrRange},
+    };
+
+    #[test]
+    fn it_parses_properly_and_verify_inclusion() {
+        // MultiaddrRange for ip4 with tcp
+
+        let my_addr_range: MultiaddrRange = "/ip4/127.*.100:200.*/tcp/18000:19000".parse().unwrap();
+        let addr: Multiaddr = "/ip4/127.0.150.1/tcp/18500".parse().unwrap();
+        assert!(my_addr_range.contains(&addr));
+        let addr: Multiaddr = "/ip4/127.0.150.1/tcp/17500".parse().unwrap();
+        assert!(!my_addr_range.contains(&addr));
+        let addr: Multiaddr = "/ip4/127.0.50.1/tcp/18500".parse().unwrap();
+        assert!(!my_addr_range.contains(&addr));
+
+        let my_addr_range: MultiaddrRange = "/ip4/127.*.100:200.*/tcp/*".parse().unwrap();
+        let addr: Multiaddr = "/ip4/127.0.150.1/tcp/18500".parse().unwrap();
+        assert!(my_addr_range.contains(&addr));
+        let addr: Multiaddr = "/ip4/127.0.150.1/tcp/17500".parse().unwrap();
+        assert!(my_addr_range.contains(&addr));
+        let addr: Multiaddr = "/ip4/127.0.50.1/tcp/17500".parse().unwrap();
+        assert!(!my_addr_range.contains(&addr));
+
+        let my_addr_range: MultiaddrRange = "/ip4/127.0.0.1/tcp/18000:19000".parse().unwrap();
+        let addr: Multiaddr = "/ip4/127.0.0.1/tcp/18500".parse().unwrap();
+        assert!(my_addr_range.contains(&addr));
+        let addr: Multiaddr = "/ip4/127.0.1.1/tcp/18500".parse().unwrap();
+        assert!(!my_addr_range.contains(&addr));
+        let addr: Multiaddr = "/ip4/127.0.0.1/tcp/17500".parse().unwrap();
+        assert!(!my_addr_range.contains(&addr));
+
+        let my_addr_range: MultiaddrRange = "/ip4/127.0.0.1/tcp/18188".parse().unwrap();
+        let addr: Multiaddr = "/ip4/127.0.0.1/tcp/18188".parse().unwrap();
+        assert!(my_addr_range.contains(&addr));
+        let addr: Multiaddr = "/ip4/127.0.1.1/tcp/18188".parse().unwrap();
+        assert!(!my_addr_range.contains(&addr));
+        let addr: Multiaddr = "/ip4/127.0.0.1/tcp/18189".parse().unwrap();
+        assert!(!my_addr_range.contains(&addr));
+
+        let my_addr_range: MultiaddrRange = IP4_TCP_TEST_ADDR_RANGE.parse().unwrap();
+        let addr: Multiaddr = "/ip4/127.0.0.1/tcp/18188".parse().unwrap();
+        assert!(my_addr_range.contains(&addr));
+        let addr: Multiaddr = "/ip4/127.0.0.1/tcp/18189".parse().unwrap();
+        assert!(my_addr_range.contains(&addr));
+        let addr: Multiaddr = "/ip4/127.1.2.3/tcp/555".parse().unwrap();
+        assert!(my_addr_range.contains(&addr));
+
+        // MultiaddrRange for other protocols
+
+        let my_addr_range: MultiaddrRange = "/ip4/127.0.0.1/udt/sctp/5678".parse().unwrap();
+        let addr: Multiaddr = "/ip4/127.0.0.1/udt/sctp/5678".parse().unwrap();
+        assert!(my_addr_range.contains(&addr));
+        let addr: Multiaddr = "/ip4/127.0.0.1/udt/sctp/5679".parse().unwrap();
+        assert!(!my_addr_range.contains(&addr));
+
+        let my_addr_range: MultiaddrRange = Multiaddr::from(IpAddr::V6(Ipv6Addr::new(0x2001, 0x2, 0, 0, 0x1, 0, 0, 0)))
+            .to_string()
+            .parse()
+            .unwrap();
+        let addr = Multiaddr::from(IpAddr::V6(Ipv6Addr::new(0x2001, 0x2, 0, 0, 0x1, 0, 0, 0)));
+        assert!(my_addr_range.contains(&addr));
+        let addr = Multiaddr::from(IpAddr::V6(Ipv6Addr::new(0x2001, 0x2, 0, 0, 0, 0, 0, 0)));
+        assert!(!my_addr_range.contains(&addr));
+    }
+}

--- a/comms/dht/src/actor.rs
+++ b/comms/dht/src/actor.rs
@@ -419,7 +419,7 @@ impl DhtActor {
                 Box::pin(Self::broadcast_join(
                     node_identity,
                     peer_manager,
-                    excluded_dial_addresses,
+                    excluded_dial_addresses.into_vec(),
                     outbound_requester,
                 ))
             },
@@ -502,7 +502,7 @@ impl DhtActor {
 
                 Box::pin(async move {
                     DhtActor::check_if_addresses_excluded(
-                        excluded_dial_addresses,
+                        excluded_dial_addresses.into_vec(),
                         &peer_manager,
                         node_identity.node_id().clone(),
                     )

--- a/comms/dht/src/actor.rs
+++ b/comms/dht/src/actor.rs
@@ -35,7 +35,7 @@ use log::*;
 use tari_comms::{
     connection_manager::ConnectionManagerError,
     connectivity::{ConnectivityError, ConnectivityRequester, ConnectivitySelection},
-    multiaddr::Multiaddr,
+    net_address::MultiaddrRange,
     peer_manager::{NodeId, NodeIdentity, PeerFeatures, PeerManager, PeerManagerError, PeerQuery, PeerQuerySortBy},
     types::CommsPublicKey,
     PeerConnection,
@@ -386,7 +386,7 @@ impl DhtActor {
 
     // Helper function to check if all peer addresses are excluded
     async fn check_if_addresses_excluded(
-        excluded_dial_addresses: Vec<Multiaddr>,
+        excluded_dial_addresses: Vec<MultiaddrRange>,
         peer_manager: &PeerManager,
         node_id: NodeId,
     ) -> Result<(), DhtActorError> {
@@ -394,7 +394,7 @@ impl DhtActor {
             let addresses = peer_manager.get_peer_multi_addresses(&node_id).await?;
             if addresses
                 .iter()
-                .all(|addr| excluded_dial_addresses.contains(addr.address()))
+                .all(|addr| excluded_dial_addresses.iter().any(|v| v.contains(addr.address())))
             {
                 warn!(
                     target: LOG_TARGET,
@@ -533,7 +533,7 @@ impl DhtActor {
     async fn broadcast_join(
         node_identity: Arc<NodeIdentity>,
         peer_manager: Arc<PeerManager>,
-        excluded_dial_addresses: Vec<Multiaddr>,
+        excluded_dial_addresses: Vec<MultiaddrRange>,
         mut outbound_requester: OutboundMessageRequester,
     ) -> Result<(), DhtActorError> {
         DhtActor::check_if_addresses_excluded(
@@ -748,10 +748,12 @@ impl DhtActor {
         let mut filtered_peers = Vec::with_capacity(peers.len());
         for id in &peers {
             let addresses = peer_manager.get_peer_multi_addresses(id).await?;
-            if addresses
-                .iter()
-                .all(|addr| config.excluded_dial_addresses.contains(addr.address()))
-            {
+            if addresses.iter().all(|addr| {
+                config
+                    .excluded_dial_addresses
+                    .iter()
+                    .any(|v| v.contains(addr.address()))
+            }) {
                 trace!(target: LOG_TARGET, "Peer '{}' has only excluded addresses. Skipping.", id);
             } else {
                 filtered_peers.push(id.clone());

--- a/comms/dht/src/config.rs
+++ b/comms/dht/src/config.rs
@@ -24,7 +24,7 @@ use std::{path::Path, time::Duration};
 
 use serde::{Deserialize, Serialize};
 use tari_common::configuration::serializers;
-use tari_comms::{net_address::MultiaddrRange, peer_validator::PeerValidatorConfig};
+use tari_comms::{net_address::MultiaddrRangeList, peer_validator::PeerValidatorConfig};
 
 use crate::{
     actor::OffenceSeverity,
@@ -94,7 +94,6 @@ pub struct DhtConfig {
     /// Default: 10 mins
     #[serde(with = "serializers::seconds")]
     pub ban_duration_short: Duration,
-
     /// The maximum number of messages over `flood_ban_timespan` to allow before banning the peer (for
     /// `ban_duration_short`) Default: 100_000 messages
     pub flood_ban_max_msg_count: usize,
@@ -115,8 +114,12 @@ pub struct DhtConfig {
     /// Configuration for peer validation
     /// See [PeerValidatorConfig]
     pub peer_validator_config: PeerValidatorConfig,
-    /// Addresses that should never be dialed
-    pub excluded_dial_addresses: Vec<MultiaddrRange>,
+    /// Addresses that should never be dialed (default value = []). This can be a specific address or an IPv4/TCP
+    /// range. Example: When used in conjunction with `allow_test_addresses = true` (but it could be any other
+    /// range)   `excluded_dial_addresses = ["/ip4/127.*.0:49.*/tcp/*", "/ip4/127.*.101:255.*/tcp/*"]`
+    ///                or
+    ///   `excluded_dial_addresses = ["/ip4/127.0:0.1/tcp/122", "/ip4/127.0:0.1/tcp/1000:2000"]`
+    pub excluded_dial_addresses: MultiaddrRangeList,
 }
 
 impl DhtConfig {
@@ -195,7 +198,7 @@ impl Default for DhtConfig {
             max_permitted_peer_claims: 5,
             offline_peer_cooldown: Duration::from_secs(24 * 60 * 60),
             peer_validator_config: Default::default(),
-            excluded_dial_addresses: vec![],
+            excluded_dial_addresses: vec![].into(),
         }
     }
 }

--- a/comms/dht/src/config.rs
+++ b/comms/dht/src/config.rs
@@ -24,7 +24,7 @@ use std::{path::Path, time::Duration};
 
 use serde::{Deserialize, Serialize};
 use tari_common::configuration::serializers;
-use tari_comms::{multiaddr::Multiaddr, peer_validator::PeerValidatorConfig};
+use tari_comms::{net_address::MultiaddrRange, peer_validator::PeerValidatorConfig};
 
 use crate::{
     actor::OffenceSeverity,
@@ -116,7 +116,7 @@ pub struct DhtConfig {
     /// See [PeerValidatorConfig]
     pub peer_validator_config: PeerValidatorConfig,
     /// Addresses that should never be dialed
-    pub excluded_dial_addresses: Vec<Multiaddr>,
+    pub excluded_dial_addresses: Vec<MultiaddrRange>,
 }
 
 impl DhtConfig {

--- a/comms/dht/src/connectivity/mod.rs
+++ b/comms/dht/src/connectivity/mod.rs
@@ -870,10 +870,12 @@ impl DhtConnectivity {
             let mut neighbours = Vec::with_capacity(self.neighbours.len());
             for peer in &self.neighbours {
                 let addresses = self.peer_manager.get_peer_multi_addresses(peer).await?;
-                if !addresses
-                    .iter()
-                    .all(|addr| self.config.excluded_dial_addresses.contains(addr.address()))
-                {
+                if !addresses.iter().all(|addr| {
+                    self.config
+                        .excluded_dial_addresses
+                        .iter()
+                        .any(|v| v.contains(addr.address()))
+                }) {
                     neighbours.push(peer.clone());
                 }
             }
@@ -882,10 +884,12 @@ impl DhtConnectivity {
             let mut random_pool = Vec::with_capacity(self.random_pool.len());
             for peer in &self.random_pool {
                 let addresses = self.peer_manager.get_peer_multi_addresses(peer).await?;
-                if !addresses
-                    .iter()
-                    .all(|addr| self.config.excluded_dial_addresses.contains(addr.address()))
-                {
+                if !addresses.iter().all(|addr| {
+                    self.config
+                        .excluded_dial_addresses
+                        .iter()
+                        .any(|v| v.contains(addr.address()))
+                }) {
                     random_pool.push(peer.clone());
                 }
             }

--- a/integration_tests/src/ffi/comms_config.rs
+++ b/integration_tests/src/ffi/comms_config.rs
@@ -49,6 +49,7 @@ impl CommsConfig {
                 CString::new(base_dir).unwrap().into_raw(),
                 30,
                 600,
+                false, // This needs to be 'false' for the tests to pass
                 &mut error,
             );
             if error > 0 {

--- a/integration_tests/src/ffi/ffi_import.rs
+++ b/integration_tests/src/ffi/ffi_import.rs
@@ -367,6 +367,7 @@ extern "C" {
         datastore_path: *const c_char,
         discovery_timeout_in_secs: c_ulonglong,
         saf_message_duration_in_secs: c_ulonglong,
+        exclude_dial_test_addresses: bool,
         error_out: *mut c_int,
     ) -> *mut TariCommsConfig;
     pub fn comms_config_destroy(wc: *mut TariCommsConfig);


### PR DESCRIPTION
Description
---
Added `MultiaddrRange`, which implements range checks for `Multiaddr`, when using IP4 with TCP. This enables specifying a range of IP4 with TCP addresses. As an exmple, any communication node can enable test addresses to connect to them (`allow_test_addresses = true`), but refrain from dialling any test addresses in return (`excluded_dial_addresses = ["/ip4/127.*.*.*/tcp/*"]`). 

With application to universe:
- TCP seed node settings:
   ```
   allow_test_addresses = true
   excluded_dial_addresses = [
         "/ip4/127.*.*.*/tcp/0:18188", 
         "/ip4/127.*.*.*/tcp/18190:65534",
         "/ip4/127.0.0.0/tcp/18189",
         "/ip4/127.1:255.1:255.2:255/tcp/18189"
   ] # Only '/ip4/127.0.0.1/tcp/0:18189' allowed
   ```
- Universe base node settings:
   ```
   type = "tcp"
   public_addresses = ["/ip4/127.0.0.1/tcp/18189"]
   tcp.listener_address = "/ip4/0.0.0.0/tcp/18189"
   allow_test_addresses = true
   #excluded_dial_addresses = []
   ```
- Universe wallet settings:
   ```
   dns_seeds = []
   custom_base_node = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx::/ip4/127.0.0.1/tcp/18189"
   type = "tcp"
   public_addresses = ["/ip4/127.0.0.1/tcp/18188"]
   tcp.listener_address = "/ip4/0.0.0.0/tcp/18188"
   allow_test_addresses = true
   #excluded_dial_addresses = []
   ```

Motivation and Context
---
Currently, Universe base nodes and wallets use `/ip4/172.2.3.4/tcp/18189` and `/ip4/172.2.3.4/tcp/18188` as their public addresses respectively, but any node trying to contact them is not able to. This results in many wasted resources. The Universe wallets also maintain connections with the seed nodes, which is not ideal.

How Has This Been Tested?
---
- Added new unit tests
- System-level testing using the suggested settings^ (simulated seed node, simulated universe base node, simulated universe wallet)

**From the seed node to the universe wallet**
```
>> add-peer 4602fb85883fec887e6b5e5a93cbc9547f19817685e78ff0a9e585826e322b44 /ip4/127.0.0.1/tcp/18188
Peer with node id '9a7764f742bf4e4bae6c5bd4f6' was added to the base node.
>> ☎️  Dialing peer...
☠️ ConnectionFailed: All peer addresses are excluded for peer 9a7764f742bf4e4bae6c5bd4f6
```
**From the seed node to the universe base node**
```
>> add-peer ee9ad9dce31a2d4a9225f4965e50df98ae4f85b58f94b34b9db9cc44f2aa2921 /ip4/127.0.0.1/tcp/18189
Peer with node id '998eb49cf4f2dd3b3d5a394c8e' was added to the base node.
☎️  Dialing peer...
⚡️ Peer connected in 0ms!
Connection: Id: 1, Node ID: 998eb49cf4f2dd3b, Direction: Inbound, Peer Address: /ip4/192.168.5.114/tcp/62398, Age: 1913s, #Substreams: 2, #Refs: 2
```
**From the universe base node to the universe wallet**
```
>> add-peer 4602fb85883fec887e6b5e5a93cbc9547f19817685e78ff0a9e585826e322b44 /ip4/127.0.0.1/tcp/18188
Peer with node id '9a7764f742bf4e4bae6c5bd4f6' was added to the base node.
☎️  Dialing peer...
⚡️ Peer connected in 0ms!
Connection: Id: 8, Node ID: 9a7764f742bf4e4b, Direction: Inbound, Peer Address: /ip4/127.0.0.1/tcp/62412, Age: 2054s, #Substreams: 6, #Refs: 2
```
**From the universe base node to the seed node**
```
>> add-peer 6677c4d401b98f403de671712a98ad8bf2976db27a1d411b08bedfd86751e048 /ip4/192.168.5.114/tcp/9991
Peer with node id '85d605836f02951c65651f99d0' was added to the base node.
☎️  Dialing peer...
>> ⚡️ Peer connected in 0ms!
Connection: Id: 0, Node ID: 85d605836f02951c, Direction: Outbound, Peer Address: /ip4/192.168.5.114/tcp/9991, Age: 2050s, #Substreams: 2, #Refs: 3
```

What process can a PR reviewer use to test or verify this change?
---
- Code review
- System-level testing

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [ ] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [X] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
**BREAKING CHANGE:** The wallet FFI interface changed (in `fn comms_config_create`)
