### PR TITLE
feat: broadcast one sided

### DIFF
--- a/base_layer/common_types/src/transaction.rs
+++ b/base_layer/common_types/src/transaction.rs
@@ -166,6 +166,8 @@ impl Display for TransactionStatus {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ImportStatus {
+    /// Special case where we import a tx received from broadcast
+    Broadcast,
     /// This transaction import status is used when importing a spendable UTXO
     Imported,
     /// This transaction import status is used when a one-sided transaction has been scanned but is unconfirmed
@@ -183,6 +185,7 @@ impl TryFrom<ImportStatus> for TransactionStatus {
 
     fn try_from(value: ImportStatus) -> Result<Self, Self::Error> {
         match value {
+            ImportStatus::Broadcast => Ok(TransactionStatus::Broadcast),
             ImportStatus::Imported => Ok(TransactionStatus::Imported),
             ImportStatus::OneSidedUnconfirmed => Ok(TransactionStatus::OneSidedUnconfirmed),
             ImportStatus::OneSidedConfirmed => Ok(TransactionStatus::OneSidedConfirmed),
@@ -197,6 +200,7 @@ impl TryFrom<TransactionStatus> for ImportStatus {
 
     fn try_from(value: TransactionStatus) -> Result<Self, Self::Error> {
         match value {
+            TransactionStatus::Broadcast => Ok(ImportStatus::Broadcast),
             TransactionStatus::Imported => Ok(ImportStatus::Imported),
             TransactionStatus::OneSidedUnconfirmed => Ok(ImportStatus::OneSidedUnconfirmed),
             TransactionStatus::OneSidedConfirmed => Ok(ImportStatus::OneSidedConfirmed),
@@ -210,6 +214,7 @@ impl TryFrom<TransactionStatus> for ImportStatus {
 impl fmt::Display for ImportStatus {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match self {
+            ImportStatus::Broadcast => write!(f, "Broadcast"),
             ImportStatus::Imported => write!(f, "Imported"),
             ImportStatus::OneSidedUnconfirmed => write!(f, "OneSidedUnconfirmed"),
             ImportStatus::OneSidedConfirmed => write!(f, "OneSidedConfirmed"),

--- a/base_layer/wallet/src/output_manager_service/handle.rs
+++ b/base_layer/wallet/src/output_manager_service/handle.rs
@@ -131,8 +131,8 @@ pub enum OutputManagerRequest {
         num_outputs: usize,
     },
 
-    ScanForRecoverableOutputs(Vec<TransactionOutput>),
-    ScanOutputs(Vec<TransactionOutput>),
+    ScanForRecoverableOutputs(Vec<(TransactionOutput, Option<TxId>)>),
+    ScanOutputs(Vec<(TransactionOutput, Option<TxId>)>),
     AddKnownOneSidedPaymentScript(KnownOneSidedPaymentScript),
     CreateOutputWithFeatures {
         value: MicroMinotari,
@@ -747,7 +747,7 @@ impl OutputManagerHandle {
 
     pub async fn scan_for_recoverable_outputs(
         &mut self,
-        outputs: Vec<TransactionOutput>,
+        outputs: Vec<(TransactionOutput, Option<TxId>)>,
     ) -> Result<Vec<RecoveredOutput>, OutputManagerError> {
         match self
             .handle
@@ -761,7 +761,7 @@ impl OutputManagerHandle {
 
     pub async fn scan_outputs_for_one_sided_payments(
         &mut self,
-        outputs: Vec<TransactionOutput>,
+        outputs: Vec<(TransactionOutput, Option<TxId>)>,
     ) -> Result<Vec<RecoveredOutput>, OutputManagerError> {
         match self.handle.call(OutputManagerRequest::ScanOutputs(outputs)).await?? {
             OutputManagerResponse::ScanOutputs(outputs) => Ok(outputs),

--- a/base_layer/wallet/src/output_manager_service/recovery/standard_outputs_recoverer.rs
+++ b/base_layer/wallet/src/output_manager_service/recovery/standard_outputs_recoverer.rs
@@ -73,16 +73,16 @@ where
     /// them to the database and increment the key manager index
     pub async fn scan_and_recover_outputs(
         &mut self,
-        outputs: Vec<TransactionOutput>,
+        outputs: Vec<(TransactionOutput, Option<TxId>)>,
     ) -> Result<Vec<RecoveredOutput>, OutputManagerError> {
         let start = Instant::now();
         let outputs_length = outputs.len();
 
         let known_scripts = self.db.get_all_known_one_sided_payment_scripts()?;
 
-        let mut rewound_outputs: Vec<(WalletOutput, bool, FixedHash)> = Vec::new();
+        let mut rewound_outputs: Vec<(WalletOutput, bool, FixedHash, Option<TxId>)> = Vec::new();
         let push_pub_key_script = script!(PushPubKey(Box::default()))?;
-        for output in outputs {
+        for (output, tx_id) in outputs {
             let known_script_index = known_scripts.iter().position(|s| s.script == output.script);
             if output.script != script!(Nop)? &&
                 known_script_index.is_none() &&
@@ -122,7 +122,7 @@ where
                 payment_id,
             );
 
-            rewound_outputs.push((uo, known_script_index.is_some(), hash));
+            rewound_outputs.push((uo, known_script_index.is_some(), hash, tx_id));
         }
 
         let rewind_time = start.elapsed();
@@ -134,7 +134,7 @@ where
         );
 
         let mut rewound_outputs_with_tx_id: Vec<RecoveredOutput> = Vec::new();
-        for (output, has_known_script, hash) in &mut rewound_outputs {
+        for (output, has_known_script, hash, tx_id) in &mut rewound_outputs {
             let db_output = DbWalletOutput::from_wallet_output(
                 output.clone(),
                 &self.master_key_manager,
@@ -144,7 +144,10 @@ where
                 None,
             )
             .await?;
-            let tx_id = TxId::new_random();
+            let tx_id = match tx_id {
+                Some(id) => id.clone(),
+                None => TxId::new_random(),
+            };
             let output_hex = db_output.commitment.to_hex();
             if let Err(e) = self.db.add_unspent_output_with_tx_id(tx_id, db_output) {
                 match e {

--- a/base_layer/wallet/src/output_manager_service/recovery/standard_outputs_recoverer.rs
+++ b/base_layer/wallet/src/output_manager_service/recovery/standard_outputs_recoverer.rs
@@ -145,7 +145,7 @@ where
             )
             .await?;
             let tx_id = match tx_id {
-                Some(id) => id.clone(),
+                Some(id) => *id,
                 None => TxId::new_random(),
             };
             let output_hex = db_output.commitment.to_hex();

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -3250,7 +3250,7 @@ where
         let mut rewound_outputs = Vec::with_capacity(scanned_outputs.len());
 
         for (output, output_source, tx_id) in scanned_outputs {
-            let tx_id = tx_id.unwrap_or_else(|| TxId::new_random());
+            let tx_id = tx_id.unwrap_or(TxId::new_random());
             let db_output = DbWalletOutput::from_wallet_output(
                 output.clone(),
                 &self.resources.key_manager,

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -3109,7 +3109,7 @@ where
     #[allow(clippy::too_many_lines)]
     async fn scan_outputs_for_one_sided_payments(
         &mut self,
-        outputs: Vec<TransactionOutput>,
+        outputs: Vec<(TransactionOutput, Option<TxId>)>,
     ) -> Result<Vec<RecoveredOutput>, OutputManagerError> {
         let mut known_keys = Vec::new();
         let known_scripts = self.resources.db.get_all_known_one_sided_payment_scripts()?;
@@ -3127,7 +3127,7 @@ where
 
         let mut scanned_outputs = vec![];
 
-        for output in outputs {
+        for (output, tx_id) in outputs {
             if let [Opcode::PushPubKey(scanned_pk)] = output.script.as_slice() {
                 if let Some(matched_key) = known_keys.iter().find(|x| &x.0 == scanned_pk.as_ref()) {
                     let shared_secret = self
@@ -3166,7 +3166,7 @@ where
                                 payment_id,
                             );
 
-                            scanned_outputs.push((rewound_output, OutputSource::OneSided));
+                            scanned_outputs.push((rewound_output, OutputSource::OneSided, tx_id));
                         }
                     }
                 }
@@ -3232,7 +3232,7 @@ where
                                 payment_id,
                             );
 
-                            scanned_outputs.push((rewound_output, OutputSource::StealthOneSided));
+                            scanned_outputs.push((rewound_output, OutputSource::StealthOneSided, tx_id));
                         }
                     }
                 }
@@ -3245,12 +3245,12 @@ where
     // Import scanned outputs into the wallet
     async fn import_onesided_outputs(
         &self,
-        scanned_outputs: Vec<(WalletOutput, OutputSource)>,
+        scanned_outputs: Vec<(WalletOutput, OutputSource, Option<TxId>)>,
     ) -> Result<Vec<RecoveredOutput>, OutputManagerError> {
         let mut rewound_outputs = Vec::with_capacity(scanned_outputs.len());
 
-        for (output, output_source) in scanned_outputs {
-            let tx_id = TxId::new_random();
+        for (output, output_source, tx_id) in scanned_outputs {
+            let tx_id = tx_id.unwrap_or_else(|| TxId::new_random());
             let db_output = DbWalletOutput::from_wallet_output(
                 output.clone(),
                 &self.resources.key_manager,

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -1855,7 +1855,7 @@ where
             CompletedTransaction::new(
                 tx_id,
                 self.resources.one_sided_tari_address.clone(),
-                dest_address,
+                dest_address.clone(),
                 amount,
                 fee,
                 tx.clone(),
@@ -1869,6 +1869,15 @@ where
             )?,
         )
         .await?;
+
+        tokio::spawn(send_finalized_transaction_message(
+            tx_id,
+            tx.clone(),
+            dest_address.comms_public_key().clone(),
+            self.resources.outbound_message_service.clone(),
+            self.resources.config.direct_send_timeout,
+            self.resources.config.transaction_routing_mechanism,
+        ));
 
         Ok(tx_id)
     }

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -2939,6 +2939,7 @@ where
     /// Accept the public reply from a recipient and apply the reply to the relevant transaction protocol
     /// # Arguments
     /// 'recipient_reply' - The public response from a recipient with data required to complete the transaction
+    #[allow(clippy::too_many_lines)]
     pub async fn accept_finalized_transaction(
         &mut self,
         source_pubkey: CommsPublicKey,

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -3519,9 +3519,7 @@ where
             payment_id,
         )?;
         let transaction_event = match import_status {
-            ImportStatus::Broadcast => TransactionEvent::TransactionBroadcast (
-                tx_id
-            ),
+            ImportStatus::Broadcast => TransactionEvent::TransactionBroadcast(tx_id),
             ImportStatus::Imported => TransactionEvent::DetectedTransactionUnconfirmed {
                 tx_id,
                 num_confirmations: 0,

--- a/base_layer/wallet/src/utxo_scanner_service/utxo_scanner_task.rs
+++ b/base_layer/wallet/src/utxo_scanner_service/utxo_scanner_task.rs
@@ -567,7 +567,7 @@ where
             &mut self
                 .resources
                 .output_manager_service
-                .scan_for_recoverable_outputs(outputs.clone())
+                .scan_for_recoverable_outputs(outputs.clone().into_iter().map(|o| (o, None)).collect())
                 .await?
                 .into_iter()
                 .map(|ro| -> Result<_, UtxoScannerError> {
@@ -593,7 +593,7 @@ where
             &mut self
                 .resources
                 .output_manager_service
-                .scan_outputs_for_one_sided_payments(outputs.clone())
+                .scan_outputs_for_one_sided_payments(outputs.clone().into_iter().map(|o| (o, None)).collect())
                 .await?
                 .into_iter()
                 .map(|ro| -> Result<_, UtxoScannerError> {

--- a/base_layer/wallet/tests/output_manager_service_tests/service.rs
+++ b/base_layer/wallet/tests/output_manager_service_tests/service.rs
@@ -2236,12 +2236,18 @@ async fn scan_for_recovery_test() {
     }
     let mut recoverable_outputs = Vec::new();
     for output in &recoverable_wallet_outputs {
-        recoverable_outputs.push(output.to_transaction_output(&oms.key_manager_handle).await.unwrap());
+        recoverable_outputs.push((
+            output.to_transaction_output(&oms.key_manager_handle).await.unwrap(),
+            None,
+        ));
     }
 
     let mut non_recoverable_outputs = Vec::new();
     for output in non_recoverable_wallet_outputs {
-        non_recoverable_outputs.push(output.to_transaction_output(&oms.key_manager_handle).await.unwrap());
+        non_recoverable_outputs.push((
+            output.to_transaction_output(&oms.key_manager_handle).await.unwrap(),
+            None,
+        ));
     }
 
     oms.output_manager_handle
@@ -2256,7 +2262,7 @@ async fn scan_for_recovery_test() {
                 .clone()
                 .into_iter()
                 .chain(non_recoverable_outputs.clone().into_iter())
-                .collect::<Vec<TransactionOutput>>(),
+                .collect::<Vec<(TransactionOutput, Option<TxId>)>>(),
         )
         .await
         .unwrap();
@@ -2291,7 +2297,7 @@ async fn recovered_output_key_not_in_keychain() {
 
     let result = oms
         .output_manager_handle
-        .scan_for_recoverable_outputs(vec![rewindable_output])
+        .scan_for_recoverable_outputs(vec![(rewindable_output, None)])
         .await;
     assert!(
         matches!(result.as_deref(), Ok([])),

--- a/base_layer/wallet/tests/support/output_manager_service_mock.rs
+++ b/base_layer/wallet/tests/support/output_manager_service_mock.rs
@@ -103,7 +103,7 @@ impl OutputManagerServiceMock {
                     .clone()
                     .into_iter()
                     .filter_map(|dbuo| {
-                        if requested_outputs.iter().any(|ro| dbuo.commitment == ro.commitment) {
+                        if requested_outputs.iter().any(|ro| dbuo.commitment == ro.0.commitment) {
                             Some(RecoveredOutput {
                                 output: dbuo.wallet_output,
                                 tx_id: TxId::new_random(),
@@ -127,7 +127,7 @@ impl OutputManagerServiceMock {
                     .clone()
                     .into_iter()
                     .filter_map(|dbuo| {
-                        if requested_outputs.iter().any(|ro| dbuo.commitment == ro.commitment) {
+                        if requested_outputs.iter().any(|ro| dbuo.commitment == ro.0.commitment) {
                             Some(RecoveredOutput {
                                 output: dbuo.wallet_output,
                                 tx_id: TxId::new_random(),

--- a/base_layer/wallet/tests/transaction_service_tests/service.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/service.rs
@@ -1795,7 +1795,7 @@ async fn recover_one_sided_transaction() {
     let outputs = completed_tx.transaction.body.outputs().clone();
 
     let recovered_outputs_1 = bob_oms
-        .scan_outputs_for_one_sided_payments(outputs.clone())
+        .scan_outputs_for_one_sided_payments(outputs.iter().map(|o| (o.clone(), None)).collect())
         .await
         .unwrap();
     // Bob should be able to claim 1 output.
@@ -1803,7 +1803,10 @@ async fn recover_one_sided_transaction() {
     assert_eq!(value, recovered_outputs_1[0].output.value);
 
     // Should ignore already existing outputs
-    let recovered_outputs_2 = bob_oms.scan_outputs_for_one_sided_payments(outputs).await.unwrap();
+    let recovered_outputs_2 = bob_oms
+        .scan_outputs_for_one_sided_payments(outputs.into_iter().map(|o| (o, None)).collect())
+        .await
+        .unwrap();
     assert!(recovered_outputs_2.is_empty());
 }
 
@@ -1919,7 +1922,7 @@ async fn recover_stealth_one_sided_transaction() {
     let outputs = completed_tx.transaction.body.outputs().clone();
 
     let recovered_outputs_1 = bob_oms
-        .scan_outputs_for_one_sided_payments(outputs.clone())
+        .scan_outputs_for_one_sided_payments(outputs.iter().map(|o| (o.clone(), None)).collect())
         .await
         .unwrap();
     // Bob should be able to claim 1 output.
@@ -1927,7 +1930,10 @@ async fn recover_stealth_one_sided_transaction() {
     assert_eq!(value, recovered_outputs_1[0].output.value);
 
     // Should ignore already existing outputs
-    let recovered_outputs_2 = bob_oms.scan_outputs_for_one_sided_payments(outputs).await.unwrap();
+    let recovered_outputs_2 = bob_oms
+        .scan_outputs_for_one_sided_payments(outputs.into_iter().map(|o| (o, None)).collect())
+        .await
+        .unwrap();
     assert!(recovered_outputs_2.is_empty());
 }
 

--- a/integration_tests/tests/features/WalletFFI.feature
+++ b/integration_tests/tests/features/WalletFFI.feature
@@ -202,10 +202,10 @@ Feature: Wallet FFI
         Then ffi wallet FFI_WALLET detects AT_LEAST 3 ffi transactions to be TRANSACTION_STATUS_BROADCAST
         When mining node MINER mines 2 blocks
         Then all nodes are at height 22
-        Then wallet RECEIVER has at least 1 transactions that are all TRANSACTION_STATUS_ONE_SIDED_UNCONFIRMED and not cancelled
+        Then wallet RECEIVER has at least 1 transactions that are all TRANSACTION_STATUS_MINED_UNCONFIRMED and not cancelled
         When mining node MINER mines 5 blocks
         Then all nodes are at height 27
-        Then wallet RECEIVER has at least 1 transactions that are all TRANSACTION_STATUS_ONE_SIDED_CONFIRMED and not cancelled
+        Then wallet RECEIVER has at least 1 transactions that are all TRANSACTION_STATUS_MINED_CONFIRMED and not cancelled
         And I stop ffi wallet FFI_WALLET
 
     @critical
@@ -221,12 +221,12 @@ Feature: Wallet FFI
         Then I send a one-sided transaction of 1000000 uT from SENDER to FFI_RECEIVER at fee 20
         When mining node MINER mines 2 blocks
         Then all nodes are at height 12
-        Then ffi wallet FFI_RECEIVER detects AT_LEAST 1 ffi transactions to be TRANSACTION_STATUS_ONE_SIDED_UNCONFIRMED
+        Then ffi wallet FFI_RECEIVER detects AT_LEAST 1 ffi transactions to be TRANSACTION_STATUS_MINED_UNCONFIRMED
         And I send 1000000 uT from wallet SENDER to wallet FFI_RECEIVER at fee 20
         Then ffi wallet FFI_RECEIVER detects AT_LEAST 1 ffi transactions to be TRANSACTION_STATUS_BROADCAST
         When mining node MINER mines 5 blocks
         Then all nodes are at height 17
-        Then ffi wallet FFI_RECEIVER detects AT_LEAST 1 ffi transactions to be TRANSACTION_STATUS_ONE_SIDED_CONFIRMED
+        Then ffi wallet FFI_RECEIVER detects AT_LEAST 1 ffi transactions to be TRANSACTION_STATUS_MINED_CONFIRMED
         And I stop ffi wallet FFI_RECEIVER
 
     Scenario: As a client I want to get fee per gram stats

--- a/integration_tests/tests/features/WalletFFI.feature
+++ b/integration_tests/tests/features/WalletFFI.feature
@@ -221,12 +221,12 @@ Feature: Wallet FFI
         Then I send a one-sided transaction of 1000000 uT from SENDER to FFI_RECEIVER at fee 20
         When mining node MINER mines 2 blocks
         Then all nodes are at height 12
-        Then ffi wallet FFI_RECEIVER detects AT_LEAST 1 ffi transactions to be TRANSACTION_STATUS_MINED_UNCONFIRMED
+        Then ffi wallet FFI_RECEIVER detects AT_LEAST 1 ffi transactions to be TRANSACTION_STATUS_ONE_SIDED_UNCONFIRMED
         And I send 1000000 uT from wallet SENDER to wallet FFI_RECEIVER at fee 20
         Then ffi wallet FFI_RECEIVER detects AT_LEAST 1 ffi transactions to be TRANSACTION_STATUS_BROADCAST
         When mining node MINER mines 5 blocks
         Then all nodes are at height 17
-        Then ffi wallet FFI_RECEIVER detects AT_LEAST 1 ffi transactions to be TRANSACTION_STATUS_MINED_CONFIRMED
+        Then ffi wallet FFI_RECEIVER detects AT_LEAST 1 ffi transactions to be TRANSACTION_STATUS_ONE_SIDED_CONFIRMED
         And I stop ffi wallet FFI_RECEIVER
 
     Scenario: As a client I want to get fee per gram stats

--- a/integration_tests/tests/steps/wallet_ffi_steps.rs
+++ b/integration_tests/tests/steps/wallet_ffi_steps.rs
@@ -432,8 +432,16 @@ async fn ffi_detects_transaction(
             "TRANSACTION_STATUS_BROADCAST" => ffi_wallet.get_counters().get_transaction_broadcast(),
             "TRANSACTION_STATUS_MINED_UNCONFIRMED" => ffi_wallet.get_counters().get_transaction_mined_unconfirmed(),
             "TRANSACTION_STATUS_MINED" => ffi_wallet.get_counters().get_transaction_mined(),
-            "TRANSACTION_STATUS_ONE_SIDED_UNCONFIRMED" => ffi_wallet.get_counters().get_transaction_faux_unconfirmed(),
-            "TRANSACTION_STATUS_ONE_SIDED_CONFIRMED" => ffi_wallet.get_counters().get_transaction_faux_confirmed(),
+            "TRANSACTION_STATUS_ONE_SIDED_UNCONFIRMED" => {
+                let mut count = ffi_wallet.get_counters().get_transaction_faux_unconfirmed();
+                count += ffi_wallet.get_counters().get_transaction_mined_unconfirmed();
+                count
+            },
+            "TRANSACTION_STATUS_ONE_SIDED_CONFIRMED" => {
+                let mut count = ffi_wallet.get_counters().get_transaction_faux_confirmed();
+                count += ffi_wallet.get_counters().get_transaction_mined();
+                count
+            },
             _ => unreachable!(),
         };
         if found_count >= count {


### PR DESCRIPTION
Description
---
Broadcast one-sided transactions

Motivation and Context
---
When a wallet sends a 1-sided tx it will now send it across the network to the peer as well. If the peer listens to the it, ti will register the tx immediately and show it to the user. 

How Has This Been Tested?
---
manual