### PR TITLE
feat!: add pool and tari difficulties to sha3 miner and merge mining proxy

### DIFF
--- a/applications/minotari_app_grpc/proto/base_node.proto
+++ b/applications/minotari_app_grpc/proto/base_node.proto
@@ -398,10 +398,16 @@ message GetNewBlockBlobResult{
 // This is mining data for the miner asking for a new block
 message MinerData{
     PowAlgo algo = 1;
-    uint64 target_difficulty = 2;
+    uint64 tari_target_difficulty = 2;
     uint64 reward = 3;
 //    bytes merge_mining_hash =4;
     uint64 total_fees = 5;
+    PoolDifficulty p2pool_target_difficulty = 6;
+}
+
+// Pool difficulty
+message PoolDifficulty {
+    uint64 difficulty = 1;
 }
 
 // This is the request type for the Search Kernels rpc

--- a/applications/minotari_app_grpc/proto/base_node.proto
+++ b/applications/minotari_app_grpc/proto/base_node.proto
@@ -160,6 +160,7 @@ message TipInfoResponse {
     MetaData metadata = 1;
     bool initial_sync_achieved = 2;
     BaseNodeState base_node_state = 3;
+    bytes parent_hash = 4;
 }
 
 enum BaseNodeState{
@@ -191,13 +192,13 @@ message GetNewBlockTemplateWithCoinbasesRequest{
     PowAlgo algo = 1;
     //This field should be moved to optional once optional keyword is standard
     uint64 max_weight = 2;
-    repeated  NewBlockCoinbase coinbases = 3;
+    repeated NewBlockCoinbase coinbases = 3;
 }
 
-/// request  type of GetNewBlockWithCoinbasesRequest
+/// request type of GetNewBlockWithCoinbasesRequest
 message GetNewBlockWithCoinbasesRequest{
     NewBlockTemplate new_template = 1;
-    repeated  NewBlockCoinbase coinbases = 2;
+    repeated NewBlockCoinbase coinbases = 2;
 }
 
 message NewBlockCoinbase{
@@ -218,7 +219,7 @@ message NetworkDifficultyResponse {
     uint64 sha3x_estimated_hash_rate = 6;
     uint64 randomx_estimated_hash_rate = 7;
     uint64 num_coinbases = 8;
-    repeated  bytes coinbase_extras = 9;
+    repeated bytes coinbase_extras = 9;
 }
 
 // A generic single value response for a specific height
@@ -252,7 +253,7 @@ message BlockGroupRequest {
     CalcType calc_type = 4;
 }
 
-/// GetBlockSize / GetBlockFees  Response
+/// GetBlockSize / GetBlockFees Response
 message BlockGroupResponse {
     repeated double value = 1;
     CalcType calc_type = 2;
@@ -436,7 +437,7 @@ message GetPeersResponse{
 message GetPeersRequest{}
 
 message SubmitTransactionRequest {
-    Transaction transaction  = 1;
+    Transaction transaction = 1;
 }
 
 message SubmitTransactionResponse {
@@ -447,7 +448,7 @@ enum SubmitTransactionResult {
     NONE = 0;
     ACCEPTED = 1;
     NOT_PROCESSABLE_AT_THIS_TIME = 2;
-    ALREADY_MINED =  3;
+    ALREADY_MINED = 3;
     REJECTED = 4;
 
 }
@@ -461,7 +462,7 @@ message GetMempoolTransactionsResponse {
 }
 
 message TransactionStateRequest {
-    Signature excess_sig  = 1;
+    Signature excess_sig = 1;
 }
 
 message TransactionStateResponse {

--- a/applications/minotari_app_grpc/proto/base_node.proto
+++ b/applications/minotari_app_grpc/proto/base_node.proto
@@ -160,7 +160,6 @@ message TipInfoResponse {
     MetaData metadata = 1;
     bool initial_sync_achieved = 2;
     BaseNodeState base_node_state = 3;
-    bytes parent_hash = 4;
 }
 
 enum BaseNodeState{

--- a/applications/minotari_app_grpc/proto/p2pool.proto
+++ b/applications/minotari_app_grpc/proto/p2pool.proto
@@ -39,10 +39,16 @@ message GetNewBlockRequest {
 
 message GetNewBlockResponse {
   tari.rpc.GetNewBlockResult block = 1;
-  uint64 target_difficulty = 2;
+  uint64 tari_target_difficulty = 2;
+  uint64 p2pool_target_difficulty = 3;
 }
 
 message SubmitBlockRequest {
   tari.rpc.Block block = 1;
   string wallet_payment_address = 2;
+  Difficulty achieved_difficulty = 3;
+}
+
+message Difficulty {
+  uint64 difficulty = 1;
 }

--- a/applications/minotari_merge_mining_proxy/src/block_template_protocol.rs
+++ b/applications/minotari_merge_mining_proxy/src/block_template_protocol.rs
@@ -196,10 +196,7 @@ impl BlockTemplateProtocol<'_> {
                     .cloned()
                     .ok_or_else(|| MmProxyError::GrpcResponseMissingField("miner_data"))?;
 
-                (
-                    add_monero_data(block, monero_mining_data.clone(), miner_data)?,
-                    height,
-                )
+                (add_monero_data(block, monero_mining_data.clone(), miner_data)?, height)
             };
 
             block_templates
@@ -214,10 +211,7 @@ impl BlockTemplateProtocol<'_> {
                 .remove_new_block_template(best_block_hash.to_vec())
                 .await;
 
-            if !self
-                .check_expected_tip_and_parent(best_block_hash.as_slice())
-                .await?
-            {
+            if !self.check_expected_tip_and_parent(best_block_hash.as_slice()).await? {
                 debug!(
                     target: LOG_TARGET,
                     "Template (height {}) not based on current chain tip anymore (with hash {}), fetching a new block \
@@ -349,10 +343,7 @@ impl BlockTemplateProtocol<'_> {
 
     /// Check if the height and parent hash is still as expected, so that it still makes sense to compute the block for
     /// that height.
-    async fn check_expected_tip_and_parent(
-        &mut self,
-        best_block_hash: &[u8],
-    ) -> Result<bool, MmProxyError> {
+    async fn check_expected_tip_and_parent(&mut self, best_block_hash: &[u8]) -> Result<bool, MmProxyError> {
         let tip = self
             .base_node_client
             .clone()

--- a/applications/minotari_merge_mining_proxy/src/config.rs
+++ b/applications/minotari_merge_mining_proxy/src/config.rs
@@ -69,8 +69,9 @@ pub struct MergeMiningProxyConfig {
     /// Address of the minotari_merge_mining_proxy application
     pub listener_address: Multiaddr,
     /// In sole merged mining, the block solution is usually submitted to the Monero blockchain (monerod) as well as to
-    /// the Minotari blockchain, then this setting should be "true". With pool merged mining, there is no sense in
-    /// submitting the solution to the Monero blockchain as thepool does that, then this setting should be "false".
+    /// the Minotari blockchain, then this setting should be "true". With Monero pool merged mining, there is no sense
+    /// in submitting the solution to the Monero blockchain as the Monero pool does that, then this setting should be
+    /// "false".
     pub submit_to_origin: bool,
     /// The merge mining proxy can either wait for the base node to achieve initial sync at startup before it enables
     /// mining, or not. If merge mining starts before the base node has achieved initial sync, those Minotari mined

--- a/applications/minotari_merge_mining_proxy/src/error.rs
+++ b/applications/minotari_merge_mining_proxy/src/error.rs
@@ -122,6 +122,8 @@ pub enum MmProxyError {
     MaxSizeBytesError(#[from] MaxSizeBytesError),
     #[error("Max sized vector error: {0}")]
     MaxSizeVecError(#[from] MaxSizeVecError),
+    #[error("Logical process error: {0}")]
+    LogicalError(String),
 }
 
 impl From<tonic::Status> for MmProxyError {

--- a/applications/minotari_miner/src/errors.rs
+++ b/applications/minotari_miner/src/errors.rs
@@ -57,8 +57,10 @@ pub enum MinerError {
     ParseInputError(#[from] ParseInputError),
     #[error("Base node not responding to gRPC requests: {0}")]
     BaseNodeNotResponding(String),
-    #[error("Limit error {0}")]
+    #[error("Limit error :{0}")]
     MaxSizeBytesError(#[from] MaxSizeBytesError),
+    #[error("Logical process error: {0}")]
+    LogicalError(String),
 }
 
 pub fn err_empty(name: &str) -> MinerError {

--- a/applications/minotari_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/minotari_node/src/grpc/base_node_grpc_server.rs
@@ -639,7 +639,8 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
         let response = tari_rpc::NewBlockTemplateResponse {
             miner_data: Some(tari_rpc::MinerData {
                 reward: new_template.reward.into(),
-                target_difficulty: new_template.target_difficulty.as_u64(),
+                tari_target_difficulty: new_template.target_difficulty.as_u64(),
+                p2pool_target_difficulty: None,
                 total_fees: new_template.total_fees.into(),
                 algo: Some(tari_rpc::PowAlgo { pow_algo: pow }),
             }),
@@ -743,7 +744,8 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
 
         let miner_data = tari_rpc::MinerData {
             reward: new_template.reward.into(),
-            target_difficulty: new_template.target_difficulty.as_u64(),
+            tari_target_difficulty: new_template.target_difficulty.as_u64(),
+            p2pool_target_difficulty: None,
             total_fees: fees.as_u64(),
             algo: Some(tari_rpc::PowAlgo { pow_algo: pow }),
         };
@@ -814,7 +816,8 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
 
         let miner_data = tari_rpc::MinerData {
             reward: new_template.reward.into(),
-            target_difficulty: new_template.target_difficulty.as_u64(),
+            tari_target_difficulty: new_template.target_difficulty.as_u64(),
+            p2pool_target_difficulty: None,
             total_fees: new_template.total_fees.into(),
             algo: Some(tari_rpc::PowAlgo { pow_algo: pow }),
         };
@@ -1213,7 +1216,8 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
 
         let miner_data = tari_rpc::MinerData {
             reward: new_template.reward.into(),
-            target_difficulty: new_template.target_difficulty.as_u64(),
+            tari_target_difficulty: new_template.target_difficulty.as_u64(),
+            p2pool_target_difficulty: None,
             total_fees: fees.as_u64(),
             algo: Some(tari_rpc::PowAlgo { pow_algo: pow }),
         };

--- a/applications/minotari_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/minotari_node/src/grpc/base_node_grpc_server.rs
@@ -1647,19 +1647,6 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
             .await
             .map_err(|e| obscure_error_if_true(report_error_flag, Status::internal(e.to_string())))?;
 
-        let parent_hash = if let Some(tip_header) = handler
-            .get_header_by_hash(*meta.best_block_hash())
-            .await
-            .map_err(|e| obscure_error_if_true(report_error_flag, Status::internal(e.to_string())))?
-        {
-            tip_header.header().prev_hash
-        } else {
-            return Err(obscure_error_if_true(
-                report_error_flag,
-                Status::not_found("Tip header not found".to_string()),
-            ));
-        };
-
         // Determine if we are bootstrapped
         let status_watch = self.state_machine_handle.get_status_info_watch();
         let state: tari_rpc::BaseNodeState = (&status_watch.borrow().state_info).into();
@@ -1667,7 +1654,6 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
             metadata: Some(meta.into()),
             initial_sync_achieved: status_watch.borrow().bootstrapped,
             base_node_state: state.into(),
-            parent_hash: parent_hash.to_vec(),
         };
 
         trace!(target: LOG_TARGET, "Sending MetaData response to client");

--- a/common/config/presets/f_merge_mining_proxy.toml
+++ b/common/config/presets/f_merge_mining_proxy.toml
@@ -60,9 +60,9 @@ monerod_url = [ # mainnet
 #listener_address = "/ip4/127.0.0.1/tcp/18081"
 
 # In sole merged mining, the block solution is usually submitted to the Monero blockchain
-# (monerod) as well as to the Minotari blockchain, then this setting should be "true". With pool
+# (monerod) as well as to the Minotari blockchain, then this setting should be "true". With Monero pool
 # merged mining, there is no sense in submitting the solution to the Monero blockchain as the
-# pool does that, then this setting should be "false". (default = true)
+# Monero pool does that, then this setting should be "false". (default = true)
 #submit_to_origin = true
 
 # The merge mining proxy can either wait for the base node to achieve initial sync at startup before it enables mining,


### PR DESCRIPTION
Description
---
- Added pool and tari difficulties to the p2pool request.
- In p2pool mode, the SHA3 miner and the merge mining proxy will submit the block to the base node if the achieved difficulty equals or exceeds the Tari target difficulty.
- Since the SHA3 miner and the merge mining proxy (_the latter only if enabled in config_) always calculate the achieved difficulty; it is now included in the `SubmitBlockRequest` as an option so that the local p2pool node does not have to recalculate it if provided.

**Edit** 
- For the merge mining proxy, evaluate the best block hash to decide if a new tari template must be requested. In re-orgs where the height will be the same as before the re-org, only checking height is insufficient.
- Added pertinent information to proxy log messages.

Motivation and Context
---
When implemented fully in sha-p2pool:
- Improved efficiency overall in submitting blocks to the base node.
- Improved efficiency for the p2pool node internally when evaluating local blocks.

**Edit** 
- Many orphans were observed in the Tari blockchain when doing merged mining with sha-p2pool.

How Has This Been Tested?
---
Currently, all unit and cucumber tests pass as those run without p2pool mode. A combined system-level test is required when this is implemented.

What process can a PR reviewer use to test or verify this change?
---
Code review.

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [ ] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [X] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
BREAKING CHANGE: gRPC `SubmitBlockRequest` interface change that will impact sha-p2pool.
