### PR TITLE
feat: update pre-mine specification and allow multiple spends

### DIFF
--- a/applications/minotari_console_wallet/src/automation/mod.rs
+++ b/applications/minotari_console_wallet/src/automation/mod.rs
@@ -44,10 +44,13 @@ use tari_script::{CheckSigSchnorrSignature, ExecutionStack, TariScript};
 struct PreMineSpendStep1SessionInfo {
     session_id: String,
     fee_per_gram: MicroMinotari,
-    commitment_to_spend: String,
-    output_hash: String,
+    recipient_info: Vec<RecipientInfo>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+struct RecipientInfo {
+    output_to_be_spend: usize,
     recipient_address: TariAddress,
-    output_index: usize,
 }
 
 impl SessionId for PreMineSpendStep1SessionInfo {
@@ -59,8 +62,14 @@ impl SessionId for PreMineSpendStep1SessionInfo {
 // Step 2 outputs for self with `PreMineSpendPartyDetails`
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
 struct PreMineSpendStep2OutputsForSelf {
+    outputs_for_self: Vec<Step2OutputsForSelf>,
     alias: String,
-    wallet_spend_key_id: TariKeyId,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Step2OutputsForSelf {
+    output_index: usize,
+    recipient_address: TariAddress,
     script_nonce_key_id: TariKeyId,
     sender_offset_key_id: TariKeyId,
     sender_offset_nonce_key_id: TariKeyId,
@@ -70,6 +79,14 @@ struct PreMineSpendStep2OutputsForSelf {
 // Step 2 outputs for leader with `PreMineSpendPartyDetails`
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
 struct PreMineSpendStep2OutputsForLeader {
+    outputs_for_leader: Vec<Step2OutputsForLeader>,
+    alias: String,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Step2OutputsForLeader {
+    output_index: usize,
+    recipient_address: TariAddress,
     script_input_signature: CheckSigSchnorrSignature,
     public_script_nonce_key: PublicKey,
     public_sender_offset_key: PublicKey,
@@ -81,12 +98,24 @@ struct PreMineSpendStep2OutputsForLeader {
 // Step 3 outputs for self with `PreMineSpendEncumberAggregateUtxo`
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
 struct PreMineSpendStep3OutputsForSelf {
+    outputs_for_self: Vec<Step3OutputsForSelf>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+struct Step3OutputsForSelf {
+    output_index: usize,
     tx_id: TxId,
 }
 
 // Step 3 outputs for parties with `PreMineSpendEncumberAggregateUtxo`
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
 struct PreMineSpendStep3OutputsForParties {
+    outputs_for_parties: Vec<Step3OutputsForParties>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+struct Step3OutputsForParties {
+    output_index: usize,
     input_stack: ExecutionStack,
     input_script: TariScript,
     total_script_key: PublicKey,
@@ -103,6 +132,13 @@ struct PreMineSpendStep3OutputsForParties {
 // Step 4 outputs for leader with `PreMineSpendInputOutputSigs`
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
 struct PreMineSpendStep4OutputsForLeader {
+    outputs_for_leader: Vec<Step4OutputsForLeader>,
+    alias: String,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+struct Step4OutputsForLeader {
+    output_index: usize,
     script_signature: Signature,
     metadata_signature: Signature,
     script_offset: PrivateKey,

--- a/applications/minotari_console_wallet/src/automation/mod.rs
+++ b/applications/minotari_console_wallet/src/automation/mod.rs
@@ -45,6 +45,7 @@ struct PreMineSpendStep1SessionInfo {
     session_id: String,
     fee_per_gram: MicroMinotari,
     recipient_info: Vec<RecipientInfo>,
+    use_pre_mine_input_file: bool,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]

--- a/applications/minotari_console_wallet/src/cli.rs
+++ b/applications/minotari_console_wallet/src/cli.rs
@@ -194,6 +194,8 @@ pub struct PreMineSpendSessionInfoArgs {
     pub recipient_info: Vec<CliRecipientInfo>,
     #[clap(long)]
     pub verify_unspent_outputs: bool,
+    #[clap(long)]
+    pub use_pre_mine_input_file: bool,
 }
 
 #[derive(Debug, Args, Clone)]
@@ -248,6 +250,8 @@ pub struct PreMineSpendPartyDetailsArgs {
     #[clap(long)]
     pub input_file: PathBuf,
     #[clap(long)]
+    pub pre_mine_file_path: Option<PathBuf>,
+    #[clap(long)]
     pub recipient_info: Vec<CliRecipientInfo>,
     #[clap(long)]
     pub alias: String,
@@ -259,12 +263,16 @@ pub struct PreMineSpendEncumberAggregateUtxoArgs {
     pub session_id: String,
     #[clap(long)]
     pub input_file_names: Vec<String>,
+    #[clap(long)]
+    pub pre_mine_file_path: Option<PathBuf>,
 }
 
 #[derive(Debug, Args, Clone)]
 pub struct PreMineSpendInputOutputSigArgs {
     #[clap(long)]
     pub session_id: String,
+    #[clap(long)]
+    pub pre_mine_file_path: Option<PathBuf>,
 }
 
 #[derive(Debug, Args, Clone)]

--- a/applications/minotari_console_wallet/src/cli.rs
+++ b/applications/minotari_console_wallet/src/cli.rs
@@ -23,6 +23,7 @@
 use std::{
     fmt::{Debug, Display, Formatter},
     path::PathBuf,
+    str::FromStr,
     time::Duration,
 };
 
@@ -190,11 +191,56 @@ pub struct PreMineSpendSessionInfoArgs {
     #[clap(long)]
     pub fee_per_gram: MicroMinotari,
     #[clap(long)]
-    pub output_index: usize,
-    #[clap(long)]
-    pub recipient_address: TariAddress,
+    pub recipient_info: Vec<CliRecipientInfo>,
     #[clap(long)]
     pub verify_unspent_outputs: bool,
+}
+
+#[derive(Debug, Args, Clone)]
+pub struct CliRecipientInfo {
+    pub output_indexes: Vec<usize>,
+    pub recipient_address: TariAddress,
+}
+
+impl FromStr for CliRecipientInfo {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // Parse 'RecipientInfo' from "[<v1>,<v2>,<v3>]:<recipient_address>"
+        if !s.contains(':') {
+            return Err("Invalid 'recipient-info', could not find address separator ':'".to_string());
+        }
+        let parts: Vec<&str> = s.split(':').collect();
+        if parts.len() != 2 {
+            return Err(format!(
+                "Invalid 'recipient-info', needs exactly 2 parts, found {}",
+                parts.len()
+            ));
+        }
+
+        // Parse output indexes
+        if !parts[0].starts_with('[') && !parts[0].ends_with(']') {
+            return Err("Invalid 'recipient-info' part 1; array bounds must be indicated with '[' and ']'".to_string());
+        }
+        let binding = parts[0].replace("[", "").replace("]", "");
+        let parts_0 = binding.split(',').collect::<Vec<&str>>();
+        let output_indexes = parts_0
+            .iter()
+            .map(|v| {
+                v.parse()
+                    .map_err(|e| format!("'recipient_info' - invalid output_index: {}", e))
+            })
+            .collect::<Result<Vec<usize>, String>>()?;
+
+        // Parse recipient address
+        let recipient_address = TariAddress::from_base58(parts[1])
+            .map_err(|e| format!("'recipient_info' - invalid recipient address: {}", e))?;
+
+        Ok(CliRecipientInfo {
+            output_indexes,
+            recipient_address,
+        })
+    }
 }
 
 #[derive(Debug, Args, Clone)]
@@ -202,7 +248,7 @@ pub struct PreMineSpendPartyDetailsArgs {
     #[clap(long)]
     pub input_file: PathBuf,
     #[clap(long)]
-    pub output_index: usize,
+    pub recipient_info: Vec<CliRecipientInfo>,
     #[clap(long)]
     pub alias: String,
 }
@@ -227,6 +273,10 @@ pub struct PreMineSpendAggregateTransactionArgs {
     pub session_id: String,
     #[clap(long)]
     pub input_file_names: Vec<String>,
+    #[clap(long)]
+    pub save_to_file: bool,
+    #[clap(long)]
+    pub print_to_console: bool,
 }
 
 #[derive(Debug, Args, Clone)]

--- a/applications/minotari_console_wallet/src/wallet_modes.rs
+++ b/applications/minotari_console_wallet/src/wallet_modes.rs
@@ -543,11 +543,14 @@ mod test {
 
             pre-mine-spend-get-output-status
 
-            pre-mine-spend-session-info --fee-per-gram 2 --output-index 123 --recipient-address \
+            pre-mine-spend-session-info --fee-per-gram 2 \
+             --recipient-info=[1,123,313]:\
              f4LR9f6WwwcPiKJjK5ciTkU1ocNhANa3FPw1wkyVUwbuKpgiihawCXy6PFszunUWQ4Te8KVFnyWVHHwsk9x5Cg7ZQiA \
              --verify-unspent-outputs
 
-            pre-mine-spend-party-details --input-file ./step_1_session_info.txt --output-index 123 --alias alice
+            pre-mine-spend-party-details --input-file ./step_1_session_info.txt --alias alice \
+             --recipient-info=[1,123,313]:\
+             f4LR9f6WwwcPiKJjK5ciTkU1ocNhANa3FPw1wkyVUwbuKpgiihawCXy6PFszunUWQ4Te8KVFnyWVHHwsk9x5Cg7ZQiA
 
             pre-mine-spend-encumber-aggregate-utxo --session-id ee1643655c \
              --input-file-names=step_2_for_leader_from_alice.txt --input-file-names=step_2_for_leader_from_bob.txt \

--- a/applications/minotari_console_wallet/src/wallet_modes.rs
+++ b/applications/minotari_console_wallet/src/wallet_modes.rs
@@ -546,11 +546,12 @@ mod test {
             pre-mine-spend-session-info --fee-per-gram 2 \
              --recipient-info=[1,123,313]:\
              f4LR9f6WwwcPiKJjK5ciTkU1ocNhANa3FPw1wkyVUwbuKpgiihawCXy6PFszunUWQ4Te8KVFnyWVHHwsk9x5Cg7ZQiA \
-             --verify-unspent-outputs
+             --verify-unspent-outputs --use-pre-mine-input-file
 
             pre-mine-spend-party-details --input-file ./step_1_session_info.txt --alias alice \
              --recipient-info=[1,123,313]:\
-             f4LR9f6WwwcPiKJjK5ciTkU1ocNhANa3FPw1wkyVUwbuKpgiihawCXy6PFszunUWQ4Te8KVFnyWVHHwsk9x5Cg7ZQiA
+             f4LR9f6WwwcPiKJjK5ciTkU1ocNhANa3FPw1wkyVUwbuKpgiihawCXy6PFszunUWQ4Te8KVFnyWVHHwsk9x5Cg7ZQiA \
+             --pre-mine-file-path ./pre_mine_file.txt
 
             pre-mine-spend-encumber-aggregate-utxo --session-id ee1643655c \
              --input-file-names=step_2_for_leader_from_alice.txt --input-file-names=step_2_for_leader_from_bob.txt \

--- a/base_layer/core/src/transactions/tari_amount.rs
+++ b/base_layer/core/src/transactions/tari_amount.rs
@@ -264,7 +264,7 @@ impl Sub<Minotari> for MicroMinotari {
 }
 
 /// A convenience struct for representing full Tari.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd)]
+#[derive(Copy, Clone, Default, Debug, PartialEq, Eq, PartialOrd)]
 pub struct Minotari(MicroMinotari);
 
 newtype_ops! { [Minotari] {add sub mul div} {:=} Self Self }
@@ -307,6 +307,11 @@ impl Minotari {
         // UNWRAP: MAX_I128_REPR > u64::MAX and scale is within bounds (see Decimal::from_parts)
         let d = Decimal::from_parts(u128::from(self.0.as_u64()), 6, false).unwrap();
         format!("{} T", format_currency(&d.to_string(), sep))
+    }
+
+    #[allow(non_snake_case)]
+    pub fn uT(&self) -> MicroMinotari {
+        self.0
     }
 }
 

--- a/base_layer/wallet/src/output_manager_service/handle.rs
+++ b/base_layer/wallet/src/output_manager_service/handle.rs
@@ -72,6 +72,7 @@ pub enum OutputManagerRequest {
         metadata_ephemeral_public_key_shares: Vec<PublicKey>,
         dh_shared_secret_shares: Vec<PublicKey>,
         recipient_address: TariAddress,
+        original_maturity: u64,
     },
     SpendBackupPreMineUtxo {
         tx_id: TxId,
@@ -173,13 +174,15 @@ impl fmt::Display for OutputManagerRequest {
                 tx_id,
                 output_hash,
                 expected_commitment,
+                original_maturity,
                 ..
             } => write!(
                 f,
-                "Encumber aggregate utxo with tx_id: {} and output: ({},{})",
+                "Encumber aggregate utxo with tx_id: {} and output: ({},{}) with original maturity: {}",
                 tx_id,
                 expected_commitment.to_hex(),
-                output_hash
+                output_hash,
+                original_maturity,
             ),
             SpendBackupPreMineUtxo {
                 tx_id,
@@ -813,6 +816,7 @@ impl OutputManagerHandle {
         metadata_ephemeral_public_key_shares: Vec<PublicKey>,
         dh_shared_secret_shares: Vec<PublicKey>,
         recipient_address: TariAddress,
+        original_maturity: u64,
     ) -> Result<
         (
             Transaction,
@@ -837,6 +841,7 @@ impl OutputManagerHandle {
                 metadata_ephemeral_public_key_shares,
                 dh_shared_secret_shares,
                 recipient_address,
+                original_maturity,
             })
             .await??
         {

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -257,6 +257,7 @@ where
                 metadata_ephemeral_public_key_shares,
                 dh_shared_secret_shares,
                 recipient_address,
+                original_maturity,
             } => self
                 .encumber_aggregate_utxo(
                     tx_id,
@@ -270,7 +271,7 @@ where
                     dh_shared_secret_shares,
                     recipient_address,
                     PaymentId::Empty,
-                    0,
+                    original_maturity,
                     RangeProofType::BulletProofPlus,
                     0.into(),
                 )
@@ -1251,7 +1252,7 @@ where
         dh_shared_secret_shares: Vec<PublicKey>,
         recipient_address: TariAddress,
         payment_id: PaymentId,
-        maturity: u64,
+        original_maturity: u64,
         range_proof_type: RangeProofType,
         minimum_value_promise: MicroMinotari,
     ) -> Result<
@@ -1365,7 +1366,7 @@ where
 
         // The entire input will be spent to a single recipient with no change
         let output_features = OutputFeatures {
-            maturity,
+            maturity: original_maturity,
             range_proof_type,
             ..Default::default()
         };

--- a/base_layer/wallet/src/transaction_service/handle.rs
+++ b/base_layer/wallet/src/transaction_service/handle.rs
@@ -112,6 +112,7 @@ pub enum TransactionServiceRequest {
         metadata_ephemeral_public_key_shares: Vec<PublicKey>,
         dh_shared_secret_shares: Vec<PublicKey>,
         recipient_address: TariAddress,
+        original_maturity: u64,
     },
     SpendBackupPreMineUtxo {
         fee_per_gram: MicroMinotari,
@@ -253,11 +254,13 @@ impl fmt::Display for TransactionServiceRequest {
                 metadata_ephemeral_public_key_shares,
                 dh_shared_secret_shares,
                 recipient_address,
+                original_maturity,
                 ..
             } => f.write_str(&format!(
                 "Creating encumber n-of-m utxo with: fee_per_gram = {}, output_hash = {}, commitment = {}, \
-                 script_input_shares = {:?},, script_signature_shares = {:?}, sender_offset_public_key_shares = {:?}, \
-                 metadata_ephemeral_public_key_shares = {:?}, dh_shared_secret_shares = {:?}, recipient_address = {}",
+                 script_input_shares = {:?}, script_signature_shares = {:?}, sender_offset_public_key_shares = {:?}, \
+                 metadata_ephemeral_public_key_shares = {:?}, dh_shared_secret_shares = {:?}, recipient_address = {}, \
+                 original_maturity: {}",
                 fee_per_gram,
                 output_hash,
                 expected_commitment.to_hex(),
@@ -287,6 +290,7 @@ impl fmt::Display for TransactionServiceRequest {
                     .map(|v| v.to_hex())
                     .collect::<Vec<String>>(),
                 recipient_address,
+                original_maturity,
             )),
             Self::FetchUnspentOutputs { output_hashes } => {
                 write!(
@@ -751,6 +755,7 @@ impl TransactionServiceHandle {
         metadata_ephemeral_public_key_shares: Vec<PublicKey>,
         dh_shared_secret_shares: Vec<PublicKey>,
         recipient_address: TariAddress,
+        original_maturity: u64,
     ) -> Result<(TxId, Transaction, PublicKey, PublicKey, PublicKey), TransactionServiceError> {
         match self
             .handle
@@ -764,6 +769,7 @@ impl TransactionServiceHandle {
                 metadata_ephemeral_public_key_shares,
                 dh_shared_secret_shares,
                 recipient_address,
+                original_maturity,
             })
             .await??
         {

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -710,6 +710,7 @@ where
                 metadata_ephemeral_public_key_shares,
                 dh_shared_secret_shares,
                 recipient_address,
+                original_maturity,
             } => self
                 .encumber_aggregate_tx(
                     fee_per_gram,
@@ -721,6 +722,7 @@ where
                     metadata_ephemeral_public_key_shares,
                     dh_shared_secret_shares,
                     recipient_address,
+                    original_maturity,
                 )
                 .await
                 .map(
@@ -1205,6 +1207,7 @@ where
         metadata_ephemeral_public_key_shares: Vec<PublicKey>,
         dh_shared_secret_shares: Vec<PublicKey>,
         recipient_address: TariAddress,
+        original_maturity: u64,
     ) -> Result<(TxId, Transaction, PublicKey, PublicKey, PublicKey), TransactionServiceError> {
         let tx_id = TxId::new_random();
 
@@ -1222,6 +1225,7 @@ where
                 metadata_ephemeral_public_key_shares,
                 dh_shared_secret_shares,
                 recipient_address.clone(),
+                original_maturity,
             )
             .await
         {


### PR DESCRIPTION
Description
---
- Updated the pre-mine specification to cater for different upfront release strategies.
- Update pre-mine spending to consider spending multiples of multiple outputs to a single wallet.
- Updated pre-mine spend to output immediate genesis block spends to json for inclusion in the genesis block.
- Added reading pre-mine input from file as an option for immediate genesis block spends, instead of reading the embedded pre-mine file.

Motivation and Context
---
Catering for new requirements.

How Has This Been Tested?
---
System-level testing [**TBD**]

What process can a PR reviewer use to test or verify this change?
---
Code review

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
