### PR TITLE
feat: add use transaction output as provided with encumber_aggregate_utxo

### DIFF
--- a/applications/minotari_console_wallet/src/automation/commands.rs
+++ b/applications/minotari_console_wallet/src/automation/commands.rs
@@ -199,7 +199,6 @@ pub async fn burn_tari(
 async fn encumber_aggregate_utxo(
     mut wallet_transaction_service: TransactionServiceHandle,
     fee_per_gram: MicroMinotari,
-    output_hash: HashOutput,
     expected_commitment: PedersenCommitment,
     script_input_shares: HashMap<PublicKey, CheckSigSchnorrSignature>,
     script_signature_public_nonces: Vec<PublicKey>,
@@ -213,7 +212,6 @@ async fn encumber_aggregate_utxo(
     wallet_transaction_service
         .encumber_aggregate_utxo(
             fee_per_gram,
-            output_hash,
             expected_commitment,
             script_input_shares,
             script_signature_public_nonces,
@@ -1255,7 +1253,6 @@ pub async fn command_runner(
                     match encumber_aggregate_utxo(
                         transaction_service.clone(),
                         session_info.fee_per_gram,
-                        embedded_output.hash(),
                         embedded_output.commitment.clone(),
                         input_shares,
                         script_signature_public_nonces,
@@ -1267,7 +1264,7 @@ pub async fn command_runner(
                         if pre_mine_from_file.is_some() {
                             UseOutput::AsProvided(embedded_output)
                         } else {
-                            UseOutput::FromBlockchain
+                            UseOutput::FromBlockchain(embedded_output.hash())
                         },
                     )
                     .await

--- a/applications/minotari_console_wallet/src/automation/commands.rs
+++ b/applications/minotari_console_wallet/src/automation/commands.rs
@@ -42,6 +42,7 @@ use minotari_wallet::{
     connectivity_service::WalletConnectivityInterface,
     output_manager_service::{
         handle::{OutputManagerEvent, OutputManagerHandle},
+        service::UseOutput,
         UtxoSelectionCriteria,
     },
     transaction_service::{
@@ -207,6 +208,7 @@ async fn encumber_aggregate_utxo(
     dh_shared_secret_shares: Vec<PublicKey>,
     recipient_address: TariAddress,
     original_maturity: u64,
+    use_output: UseOutput,
 ) -> Result<(TxId, Transaction, PublicKey, PublicKey, PublicKey), CommandError> {
     wallet_transaction_service
         .encumber_aggregate_utxo(
@@ -220,6 +222,7 @@ async fn encumber_aggregate_utxo(
             dh_shared_secret_shares,
             recipient_address,
             original_maturity,
+            use_output,
         )
         .await
         .map_err(CommandError::TransactionServiceError)
@@ -1261,6 +1264,11 @@ pub async fn command_runner(
                         dh_shared_secret_shares,
                         current_recipient_address,
                         original_maturity,
+                        if pre_mine_from_file.is_some() {
+                            UseOutput::AsProvided(embedded_output)
+                        } else {
+                            UseOutput::FromBlockchain
+                        },
                     )
                     .await
                     {

--- a/base_layer/wallet/src/output_manager_service/handle.rs
+++ b/base_layer/wallet/src/output_manager_service/handle.rs
@@ -64,7 +64,6 @@ pub enum OutputManagerRequest {
     EncumberAggregateUtxo {
         tx_id: TxId,
         fee_per_gram: MicroMinotari,
-        output_hash: HashOutput,
         expected_commitment: PedersenCommitment,
         script_input_shares: HashMap<PublicKey, CheckSigSchnorrSignature>,
         script_signature_public_nonces: Vec<PublicKey>,
@@ -173,18 +172,24 @@ impl fmt::Display for OutputManagerRequest {
             },
             EncumberAggregateUtxo {
                 tx_id,
-                output_hash,
                 expected_commitment,
                 original_maturity,
+                use_output,
                 ..
-            } => write!(
-                f,
-                "Encumber aggregate utxo with tx_id: {} and output: ({},{}) with original maturity: {}",
-                tx_id,
-                expected_commitment.to_hex(),
-                output_hash,
-                original_maturity,
-            ),
+            } => {
+                let output_hash = match use_output {
+                    UseOutput::FromBlockchain(hash) => *hash,
+                    UseOutput::AsProvided(output) => output.hash(),
+                };
+                write!(
+                    f,
+                    "Encumber aggregate utxo with tx_id: {} and output: ({},{}) with original maturity: {}",
+                    tx_id,
+                    expected_commitment.to_hex(),
+                    output_hash,
+                    original_maturity,
+                )
+            },
             SpendBackupPreMineUtxo {
                 tx_id,
                 output_hash,
@@ -809,7 +814,6 @@ impl OutputManagerHandle {
         &mut self,
         tx_id: TxId,
         fee_per_gram: MicroMinotari,
-        output_hash: HashOutput,
         expected_commitment: PedersenCommitment,
         script_input_shares: HashMap<PublicKey, CheckSigSchnorrSignature>,
         script_signature_public_nonces: Vec<PublicKey>,
@@ -835,7 +839,6 @@ impl OutputManagerHandle {
             .call(OutputManagerRequest::EncumberAggregateUtxo {
                 tx_id,
                 fee_per_gram,
-                output_hash,
                 expected_commitment,
                 script_input_shares,
                 script_signature_public_nonces,

--- a/base_layer/wallet/src/output_manager_service/handle.rs
+++ b/base_layer/wallet/src/output_manager_service/handle.rs
@@ -46,7 +46,7 @@ use tower::Service;
 
 use crate::output_manager_service::{
     error::OutputManagerError,
-    service::{Balance, OutputInfoByTxId},
+    service::{Balance, OutputInfoByTxId, UseOutput},
     storage::models::{DbWalletOutput, KnownOneSidedPaymentScript, SpendingPriority},
     UtxoSelectionCriteria,
 };
@@ -73,6 +73,7 @@ pub enum OutputManagerRequest {
         dh_shared_secret_shares: Vec<PublicKey>,
         recipient_address: TariAddress,
         original_maturity: u64,
+        use_output: UseOutput,
     },
     SpendBackupPreMineUtxo {
         tx_id: TxId,
@@ -817,6 +818,7 @@ impl OutputManagerHandle {
         dh_shared_secret_shares: Vec<PublicKey>,
         recipient_address: TariAddress,
         original_maturity: u64,
+        use_output: UseOutput,
     ) -> Result<
         (
             Transaction,
@@ -842,6 +844,7 @@ impl OutputManagerHandle {
                 dh_shared_secret_shares,
                 recipient_address,
                 original_maturity,
+                use_output,
             })
             .await??
         {

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -249,7 +249,6 @@ where
             OutputManagerRequest::EncumberAggregateUtxo {
                 tx_id,
                 fee_per_gram,
-                output_hash,
                 expected_commitment,
                 script_input_shares,
                 script_signature_public_nonces,
@@ -263,7 +262,6 @@ where
                 .encumber_aggregate_utxo(
                     tx_id,
                     fee_per_gram,
-                    output_hash,
                     expected_commitment,
                     script_input_shares,
                     script_signature_public_nonces,
@@ -1245,7 +1243,6 @@ where
         &mut self,
         tx_id: TxId,
         fee_per_gram: MicroMinotari,
-        output_hash: HashOutput,
         expected_commitment: PedersenCommitment,
         mut script_input_shares: HashMap<PublicKey, CheckSigSchnorrSignature>,
         script_signature_public_nonces: Vec<PublicKey>,
@@ -1272,7 +1269,7 @@ where
         trace!(target: LOG_TARGET, "encumber_aggregate_utxo: start");
         // Fetch the output from the blockchain or use provided
         let output = match use_output {
-            UseOutput::FromBlockchain => self
+            UseOutput::FromBlockchain(output_hash) => self
                 .fetch_unspent_outputs_from_node(vec![output_hash])
                 .await?
                 .pop()
@@ -3310,7 +3307,7 @@ where
 #[derive(Clone)]
 pub enum UseOutput {
     /// The transaction output will be fetched from the blockchain
-    FromBlockchain,
+    FromBlockchain(HashOutput),
     /// The transaction output must be provided
     AsProvided(TransactionOutput),
 }

--- a/base_layer/wallet/src/transaction_service/handle.rs
+++ b/base_layer/wallet/src/transaction_service/handle.rs
@@ -60,7 +60,7 @@ use tokio::sync::broadcast;
 use tower::Service;
 
 use crate::{
-    output_manager_service::UtxoSelectionCriteria,
+    output_manager_service::{service::UseOutput, UtxoSelectionCriteria},
     transaction_service::{
         error::TransactionServiceError,
         storage::models::{
@@ -113,6 +113,7 @@ pub enum TransactionServiceRequest {
         dh_shared_secret_shares: Vec<PublicKey>,
         recipient_address: TariAddress,
         original_maturity: u64,
+        use_output: UseOutput,
     },
     SpendBackupPreMineUtxo {
         fee_per_gram: MicroMinotari,
@@ -756,6 +757,7 @@ impl TransactionServiceHandle {
         dh_shared_secret_shares: Vec<PublicKey>,
         recipient_address: TariAddress,
         original_maturity: u64,
+        use_output: UseOutput,
     ) -> Result<(TxId, Transaction, PublicKey, PublicKey, PublicKey), TransactionServiceError> {
         match self
             .handle
@@ -770,6 +772,7 @@ impl TransactionServiceHandle {
                 dh_shared_secret_shares,
                 recipient_address,
                 original_maturity,
+                use_output,
             })
             .await??
         {

--- a/base_layer/wallet/src/transaction_service/handle.rs
+++ b/base_layer/wallet/src/transaction_service/handle.rs
@@ -104,7 +104,6 @@ pub enum TransactionServiceRequest {
     },
     EncumberAggregateUtxo {
         fee_per_gram: MicroMinotari,
-        output_hash: HashOutput,
         expected_commitment: PedersenCommitment,
         script_input_shares: HashMap<PublicKey, CheckSigSchnorrSignature>,
         script_signature_public_nonces: Vec<PublicKey>,
@@ -247,7 +246,6 @@ impl fmt::Display for TransactionServiceRequest {
             )),
             Self::EncumberAggregateUtxo {
                 fee_per_gram,
-                output_hash,
                 expected_commitment,
                 script_input_shares,
                 script_signature_public_nonces,
@@ -256,43 +254,50 @@ impl fmt::Display for TransactionServiceRequest {
                 dh_shared_secret_shares,
                 recipient_address,
                 original_maturity,
+                use_output,
                 ..
-            } => f.write_str(&format!(
-                "Creating encumber n-of-m utxo with: fee_per_gram = {}, output_hash = {}, commitment = {}, \
-                 script_input_shares = {:?}, script_signature_shares = {:?}, sender_offset_public_key_shares = {:?}, \
-                 metadata_ephemeral_public_key_shares = {:?}, dh_shared_secret_shares = {:?}, recipient_address = {}, \
-                 original_maturity: {}",
-                fee_per_gram,
-                output_hash,
-                expected_commitment.to_hex(),
-                script_input_shares
-                    .iter()
-                    .map(|v| format!(
-                        "(public_key: {}, sig: {}, nonce: {})",
-                        v.0.to_hex(),
-                        v.1.get_signature().to_hex(),
-                        v.1.get_public_nonce().to_hex()
-                    ))
-                    .collect::<Vec<String>>(),
-                script_signature_public_nonces
-                    .iter()
-                    .map(|v| format!("(public nonce: {})", v.to_hex(),))
-                    .collect::<Vec<String>>(),
-                sender_offset_public_key_shares
-                    .iter()
-                    .map(|v| v.to_hex())
-                    .collect::<Vec<String>>(),
-                metadata_ephemeral_public_key_shares
-                    .iter()
-                    .map(|v| v.to_hex())
-                    .collect::<Vec<String>>(),
-                dh_shared_secret_shares
-                    .iter()
-                    .map(|v| v.to_hex())
-                    .collect::<Vec<String>>(),
-                recipient_address,
-                original_maturity,
-            )),
+            } => {
+                let output_hash = match use_output {
+                    UseOutput::FromBlockchain(hash) => *hash,
+                    UseOutput::AsProvided(output) => output.hash(),
+                };
+                f.write_str(&format!(
+                    "Creating encumber n-of-m utxo with: fee_per_gram = {}, output_hash = {}, commitment = {}, \
+                     script_input_shares = {:?}, script_signature_shares = {:?}, sender_offset_public_key_shares = \
+                     {:?}, metadata_ephemeral_public_key_shares = {:?}, dh_shared_secret_shares = {:?}, \
+                     recipient_address = {}, original_maturity: {}",
+                    fee_per_gram,
+                    output_hash,
+                    expected_commitment.to_hex(),
+                    script_input_shares
+                        .iter()
+                        .map(|v| format!(
+                            "(public_key: {}, sig: {}, nonce: {})",
+                            v.0.to_hex(),
+                            v.1.get_signature().to_hex(),
+                            v.1.get_public_nonce().to_hex()
+                        ))
+                        .collect::<Vec<String>>(),
+                    script_signature_public_nonces
+                        .iter()
+                        .map(|v| format!("(public nonce: {})", v.to_hex(),))
+                        .collect::<Vec<String>>(),
+                    sender_offset_public_key_shares
+                        .iter()
+                        .map(|v| v.to_hex())
+                        .collect::<Vec<String>>(),
+                    metadata_ephemeral_public_key_shares
+                        .iter()
+                        .map(|v| v.to_hex())
+                        .collect::<Vec<String>>(),
+                    dh_shared_secret_shares
+                        .iter()
+                        .map(|v| v.to_hex())
+                        .collect::<Vec<String>>(),
+                    recipient_address,
+                    original_maturity,
+                ))
+            },
             Self::FetchUnspentOutputs { output_hashes } => {
                 write!(
                     f,
@@ -748,7 +753,6 @@ impl TransactionServiceHandle {
     pub async fn encumber_aggregate_utxo(
         &mut self,
         fee_per_gram: MicroMinotari,
-        output_hash: HashOutput,
         expected_commitment: PedersenCommitment,
         script_input_shares: HashMap<PublicKey, CheckSigSchnorrSignature>,
         script_signature_public_nonces: Vec<PublicKey>,
@@ -763,7 +767,6 @@ impl TransactionServiceHandle {
             .handle
             .call(TransactionServiceRequest::EncumberAggregateUtxo {
                 fee_per_gram,
-                output_hash,
                 expected_commitment,
                 script_input_shares,
                 script_signature_public_nonces,

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -703,7 +703,6 @@ where
                 }),
             TransactionServiceRequest::EncumberAggregateUtxo {
                 fee_per_gram,
-                output_hash,
                 expected_commitment,
                 script_input_shares,
                 script_signature_public_nonces,
@@ -716,7 +715,6 @@ where
             } => self
                 .encumber_aggregate_tx(
                     fee_per_gram,
-                    output_hash,
                     expected_commitment,
                     script_input_shares,
                     script_signature_public_nonces,
@@ -1202,7 +1200,6 @@ where
     pub async fn encumber_aggregate_tx(
         &mut self,
         fee_per_gram: MicroMinotari,
-        output_hash: HashOutput,
         expected_commitment: PedersenCommitment,
         script_input_shares: HashMap<PublicKey, CheckSigSchnorrSignature>,
         script_signature_public_nonces: Vec<PublicKey>,
@@ -1221,7 +1218,6 @@ where
             .encumber_aggregate_utxo(
                 tx_id,
                 fee_per_gram,
-                output_hash,
                 expected_commitment,
                 script_input_shares,
                 script_signature_public_nonces,

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -92,6 +92,7 @@ use crate::{
     connectivity_service::WalletConnectivityInterface,
     output_manager_service::{
         handle::{OutputManagerEvent, OutputManagerHandle},
+        service::UseOutput,
         storage::models::SpendingPriority,
         UtxoSelectionCriteria,
     },
@@ -711,6 +712,7 @@ where
                 dh_shared_secret_shares,
                 recipient_address,
                 original_maturity,
+                use_output,
             } => self
                 .encumber_aggregate_tx(
                     fee_per_gram,
@@ -723,6 +725,7 @@ where
                     dh_shared_secret_shares,
                     recipient_address,
                     original_maturity,
+                    use_output,
                 )
                 .await
                 .map(
@@ -1208,6 +1211,7 @@ where
         dh_shared_secret_shares: Vec<PublicKey>,
         recipient_address: TariAddress,
         original_maturity: u64,
+        use_output: UseOutput,
     ) -> Result<(TxId, Transaction, PublicKey, PublicKey, PublicKey), TransactionServiceError> {
         let tx_id = TxId::new_random();
 
@@ -1226,6 +1230,7 @@ where
                 dh_shared_secret_shares,
                 recipient_address.clone(),
                 original_maturity,
+                use_output,
             )
             .await
         {


### PR DESCRIPTION
Description
---
Added an option to `fn encumber_aggregate_utxo` to use the transaction output from the blockchain or as provided from file.

Motivation and Context
---
When reading pre-mine from file for genesis block immediate spends, the output manager service should use the provided transaction output and not fetch it from a base node.

How Has This Been Tested?
---
System-level testing

What process can a PR reviewer use to test or verify this change?
---
Code review

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
