### PR TITLE
fix(dns): fix Display impl to match from_str

### DIFF
--- a/common/src/configuration/name_server.rs
+++ b/common/src/configuration/name_server.rs
@@ -48,7 +48,7 @@ impl DnsNameServer {
 impl Display for DnsNameServer {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            DnsNameServer::System => write!(f, "SystemDns"),
+            DnsNameServer::System => write!(f, "system"),
             DnsNameServer::Custom {
                 addr,
                 dns_name: Some(dns_name),
@@ -104,5 +104,18 @@ mod test {
 
         // default
         assert_eq!(DnsNameServer::default(), DnsNameServer::System);
+    }
+
+    #[test]
+    fn to_string_from_str() {
+        let ipv4 = Ipv4Addr::new(127, 0, 0, 1);
+        let ip = IpAddr::V4(ipv4);
+        let socket = SocketAddr::new(ip, 8080);
+        let dns = DnsNameServer::custom(socket, Some(String::from("my_dns")));
+        let parsed = dns.to_string().parse::<DnsNameServer>().unwrap();
+        assert_eq!(dns, parsed);
+
+        let parsed = DnsNameServer::System.to_string().parse::<DnsNameServer>().unwrap();
+        assert_eq!(parsed, DnsNameServer::System);
     }
 }


### PR DESCRIPTION
Description
---
fix(dns): fix Display impl to match from_str

Motivation and Context
---
Display impl had "SystemDns" which is not a valid DnsNameServer string. "system" (case insensitive) is the correct string to use system dns

How Has This Been Tested?
---

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
