### PR TITLE
feat: pre-mine introduce temp ban and add counters

### DIFF
--- a/applications/minotari_console_wallet/src/automation/commands.rs
+++ b/applications/minotari_console_wallet/src/automation/commands.rs
@@ -2674,12 +2674,12 @@ pub async fn command_runner(
 
 async fn temp_ban_peers(wallet: &WalletSqlite, peer_list: &mut Vec<Peer>) {
     for peer in peer_list {
-        let _ = wallet
+        let _unused = wallet
             .comms
             .connectivity()
             .remove_peer_from_allow_list(peer.node_id.clone())
             .await;
-        let _ = wallet
+        let _unused = wallet
             .comms
             .connectivity()
             .ban_peer_until(
@@ -2693,7 +2693,7 @@ async fn temp_ban_peers(wallet: &WalletSqlite, peer_list: &mut Vec<Peer>) {
 
 async fn lift_temp_ban_peers(wallet: &WalletSqlite, peer_list: &mut Vec<Peer>) {
     for peer in peer_list {
-        let _ = wallet
+        let _unused = wallet
             .comms
             .connectivity()
             .ban_peer_until(
@@ -2702,7 +2702,7 @@ async fn lift_temp_ban_peers(wallet: &WalletSqlite, peer_list: &mut Vec<Peer>) {
                 "Busy with pre-mine spend".to_string(),
             )
             .await;
-        let _ = wallet
+        let _unused = wallet
             .comms
             .connectivity()
             .add_peer_to_allow_list(peer.node_id.clone())

--- a/base_layer/wallet/src/connectivity_service/base_node_peer_manager.rs
+++ b/base_layer/wallet/src/connectivity_service/base_node_peer_manager.rs
@@ -65,6 +65,11 @@ impl BaseNodePeerManager {
         self.current_peer_index = (self.current_peer_index + 1) % self.peer_list.len();
         self.peer_list[self.current_peer_index].clone()
     }
+
+    /// Get the base node peer manager state
+    pub fn get_state(&self) -> (usize, Vec<Peer>) {
+        (self.current_peer_index, self.peer_list.clone())
+    }
 }
 
 impl Display for BaseNodePeerManager {

--- a/base_layer/wallet/src/connectivity_service/handle.rs
+++ b/base_layer/wallet/src/connectivity_service/handle.rs
@@ -62,17 +62,21 @@ impl WalletConnectivityHandle {
 
 #[async_trait::async_trait]
 impl WalletConnectivityInterface for WalletConnectivityHandle {
-    fn set_base_node(&mut self, base_node_peer: BaseNodePeerManager) {
+    fn set_base_node(&mut self, base_node_peer_manager: BaseNodePeerManager) {
         if let Some(selected_peer) = self.base_node_watch.borrow().as_ref() {
-            if selected_peer.get_current_peer().public_key == base_node_peer.get_current_peer().public_key {
+            if selected_peer.get_current_peer().public_key == base_node_peer_manager.get_current_peer().public_key {
                 return;
             }
         }
-        self.base_node_watch.send(Some(base_node_peer));
+        self.base_node_watch.send(Some(base_node_peer_manager));
     }
 
     fn get_current_base_node_watcher(&self) -> watch::Receiver<Option<BaseNodePeerManager>> {
         self.base_node_watch.get_receiver()
+    }
+
+    fn get_base_node_peer_manager_state(&self) -> Option<(usize, Vec<Peer>)> {
+        self.base_node_watch.borrow().as_ref().map(|p| p.get_state().clone())
     }
 
     /// Obtain a BaseNodeWalletRpcClient.

--- a/base_layer/wallet/src/connectivity_service/interface.rs
+++ b/base_layer/wallet/src/connectivity_service/interface.rs
@@ -75,4 +75,6 @@ pub trait WalletConnectivityInterface: Clone + Send + Sync + 'static {
     fn get_current_base_node_peer_node_id(&self) -> Option<NodeId>;
 
     fn is_base_node_set(&self) -> bool;
+
+    fn get_base_node_peer_manager_state(&self) -> Option<(usize, Vec<Peer>)>;
 }

--- a/base_layer/wallet/src/connectivity_service/mock.rs
+++ b/base_layer/wallet/src/connectivity_service/mock.rs
@@ -90,6 +90,10 @@ impl WalletConnectivityInterface for WalletConnectivityMock {
         self.base_node_watch.get_receiver()
     }
 
+    fn get_base_node_peer_manager_state(&self) -> Option<(usize, Vec<Peer>)> {
+        self.base_node_watch.borrow().as_ref().map(|p| p.get_state().clone())
+    }
+
     async fn obtain_base_node_wallet_rpc_client(&mut self) -> Option<RpcClientLease<BaseNodeWalletRpcClient>> {
         let mut receiver = self.base_node_wallet_rpc_client.get_receiver();
         if let Some(client) = receiver.borrow().as_ref() {


### PR DESCRIPTION
Description
---
- Added pre-mine counters so the progress could be displayed.
- Temporarily ban all base node peers when doing `pre-mine-spend-encumber-aggregate-utxo` and `pre-mine-spend-aggregate-transaction` to prevent the wallet from broadcasting the incomplete transactions.

Motivation and Context
---
Improved UX

How Has This Been Tested?
---
System-level testing

What process can a PR reviewer use to test or verify this change?
---
Code review

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
