### PR TITLE
feat: upgrade utils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -369,15 +369,6 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base58-monero"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "935c90240f9b7749c80746bf88ad9cb346f34b01ee30ad4d566dfdecd6e3cc6a"
-dependencies = [
- "thiserror",
-]
-
-[[package]]
-name = "base58-monero"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978e81a45367d2409ecd33369a45dda2e9a3ca516153ec194de1fbda4b9fb79d"
@@ -548,9 +539,9 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.2.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf617fabf5cdbdc92f774bfe5062d870f228b80056d41180797abf48bed4056e"
+checksum = "a6362ed55def622cddc70a4746a68554d7b687713770de539e59a739b249f8ed"
 dependencies = [
  "borsh-derive",
  "cfg_aliases",
@@ -558,12 +549,12 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "1.2.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f404657a7ea7b5249e36808dff544bc88a28f26e0ac40009f674b7a009d14be3"
+checksum = "c3ef8005764f53cd4dca619f5bf64cafd4664dada50ece25e4d81de54c80cc0b"
 dependencies = [
  "once_cell",
- "proc-macro-crate 2.0.0",
+ "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
  "syn 2.0.79",
@@ -734,9 +725,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.1.1"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
@@ -2404,7 +2395,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.9",
- "indexmap 2.1.0",
+ "indexmap 2.6.0",
  "slab",
  "tokio",
  "tokio-util 0.7.10",
@@ -2423,7 +2414,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.1.0",
- "indexmap 2.1.0",
+ "indexmap 2.6.0",
  "slab",
  "tokio",
  "tokio-util 0.7.10",
@@ -2450,9 +2441,9 @@ checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
+checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
 
 [[package]]
 name = "hdrhistogram"
@@ -2994,12 +2985,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.1.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
+checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.2",
+ "hashbrown 0.15.0",
 ]
 
 [[package]]
@@ -4016,7 +4007,7 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f25218523ad4a171ddda05251669afb788cdc2f0df94082aab856a2b09541c3f"
 dependencies = [
- "base58-monero 2.0.0",
+ "base58-monero",
  "curve25519-dalek",
  "fixed-hash",
  "hex",
@@ -4623,7 +4614,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset 0.4.2",
- "indexmap 2.1.0",
+ "indexmap 2.6.0",
 ]
 
 [[package]]
@@ -4965,11 +4956,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "2.0.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
+checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
 dependencies = [
- "toml_edit 0.20.7",
+ "toml_edit 0.22.22",
 ]
 
 [[package]]
@@ -5854,7 +5845,7 @@ version = "0.9.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cc7a1570e38322cfe4154732e5110f887ea57e22b76f4bfd32b5bdd3368666c"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap 2.6.0",
  "itoa",
  "ryu",
  "serde",
@@ -6712,9 +6703,9 @@ dependencies = [
 
 [[package]]
 name = "tari_crypto"
-version = "0.20.3"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22b761f7cf1754eb2223286c9d437c81737526f393f09f69b2456bf49ba25a5b"
+checksum = "f2c126518e7d09ec8a95de51921c17430b85b3a729375310326bb95cfaa1d12b"
 dependencies = [
  "blake2",
  "borsh",
@@ -6997,11 +6988,11 @@ dependencies = [
 
 [[package]]
 name = "tari_utilities"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1bb0e5d1d812f2be2d6ad861caad68f75adb5b2e8376264850300deb16ddc7"
+checksum = "539470532a8ca1a8a1aa26f6240586f7d0f7d90ab94ae67f092bcd75a1bb4060"
 dependencies = [
- "base58-monero 0.3.2",
+ "base58-monero",
  "base64 0.13.1",
  "bincode",
  "borsh",
@@ -7327,22 +7318,11 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.5"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.20.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
-dependencies = [
- "indexmap 2.1.0",
- "toml_datetime",
- "winnow",
 ]
 
 [[package]]
@@ -7351,11 +7331,22 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap 2.6.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.18",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+dependencies = [
+ "indexmap 2.6.0",
+ "toml_datetime",
+ "winnow 0.6.20",
 ]
 
 [[package]]
@@ -8169,6 +8160,15 @@ name = "winnow"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "176b6138793677221d420fd2f0aeeced263f197688b36484660da767bca2fa32"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
 dependencies = [
  "memchr",
 ]

--- a/applications/minotari_app_grpc/Cargo.toml
+++ b/applications/minotari_app_grpc/Cargo.toml
@@ -11,14 +11,14 @@ edition = "2021"
 tari_common_types = { path = "../../base_layer/common_types" }
 tari_comms = { path = "../../comms/core" }
 tari_core = { path = "../../base_layer/core" }
-tari_crypto = { version = "0.20.3" }
+tari_crypto = { version = "0.21.0" }
 tari_script = { path = "../../infrastructure/tari_script" }
 tari_max_size = { path = "../../infrastructure/max_size" }
-tari_utilities = { version = "0.7" }
+tari_utilities = { version = "0.8" }
 
 argon2 = { version = "0.4.1", features = ["std", "password-hash"] }
 base64 = "0.13.0"
-borsh = "1.2"
+borsh = "1.5"
 chrono = { version = "0.4.19", default-features = false }
 log = "0.4"
 prost = "0.13.3"

--- a/applications/minotari_app_utilities/Cargo.toml
+++ b/applications/minotari_app_utilities/Cargo.toml
@@ -9,7 +9,7 @@ license = "BSD-3-Clause"
 tari_common = { path = "../../common" }
 tari_common_types = { path = "../../base_layer/common_types" }
 tari_comms = { path = "../../comms/core" }
-tari_utilities = { version = "0.7" }
+tari_utilities = { version = "0.8" }
 minotari_app_grpc = { path = "../minotari_app_grpc", optional = true }
 
 clap = { version = "3.2", features = ["derive", "env"] }

--- a/applications/minotari_console_wallet/Cargo.toml
+++ b/applications/minotari_console_wallet/Cargo.toml
@@ -14,14 +14,14 @@ tari_common_types = { path = "../../base_layer/common_types" }
 tari_comms = { path = "../../comms/core" }
 tari_comms_dht = { path = "../../comms/dht" }
 tari_contacts = { path = "../../base_layer/contacts" }
-tari_crypto = { version = "0.20.3" }
+tari_crypto = { version = "0.21.0" }
 tari_key_manager = { path = "../../base_layer/key_manager" }
 tari_libtor = { path = "../../infrastructure/libtor", optional = true }
 tari_max_size = { path = "../../infrastructure/max_size" }
 tari_p2p = { path = "../../base_layer/p2p", features = ["auto-update"] }
 tari_script = { path = "../../infrastructure/tari_script" }
 tari_shutdown = { path = "../../infrastructure/shutdown" }
-tari_utilities = { version = "0.7" }
+tari_utilities = { version = "0.8" }
 minotari_wallet = { path = "../../base_layer/wallet", features = [
     "bundled_sqlite",
 ] }

--- a/applications/minotari_console_wallet/src/automation/commands.rs
+++ b/applications/minotari_console_wallet/src/automation/commands.rs
@@ -109,7 +109,7 @@ use tari_key_manager::{
 use tari_p2p::{auto_update::AutoUpdateConfig, peer_seeds::SeedPeer, PeerSeedsConfig};
 use tari_script::{push_pubkey_script, CheckSigSchnorrSignature};
 use tari_shutdown::Shutdown;
-use tari_utilities::{encoding::Base58, hex::Hex, ByteArray, SafePassword};
+use tari_utilities::{encoding::MBase58, hex::Hex, ByteArray, SafePassword};
 use tokio::{
     sync::{broadcast, mpsc},
     time::{sleep, timeout},
@@ -2500,7 +2500,7 @@ pub async fn command_runner(
                                 .map_err(|e| CommandError::General(e.to_string()))?
                         },
                         (false, true) => {
-                            let bytes = Vec::<u8>::from_base58(args.cipher_seed.as_str())
+                            let bytes = Vec::<u8>::from_monero_base58(args.cipher_seed.as_str())
                                 .map_err(|e| CommandError::General(e.to_string()))?;
                             CipherSeed::from_enciphered_bytes(&bytes, passphrase)
                                 .map_err(|e| CommandError::General(e.to_string()))?

--- a/applications/minotari_console_wallet/src/automation/utils.rs
+++ b/applications/minotari_console_wallet/src/automation/utils.rs
@@ -31,7 +31,7 @@ use digest::crypto_common::rand_core::OsRng;
 use serde::{de::DeserializeOwned, Serialize};
 use tari_common_types::types::PrivateKey;
 use tari_crypto::keys::SecretKey;
-use tari_utilities::encoding::Base58;
+use tari_utilities::encoding::MBase58;
 
 use crate::automation::{
     commands::{FILE_EXTENSION, SPEND_SESSION_INFO},
@@ -133,7 +133,7 @@ fn append_to_json_file<P: AsRef<Path>, T: Serialize>(file: P, data: T) -> Result
 
 /// Create a unique session-based output directory
 pub(crate) fn create_pre_mine_output_dir(alias: Option<&str>) -> Result<(String, PathBuf), CommandError> {
-    let mut session_id = PrivateKey::random(&mut OsRng).to_base58();
+    let mut session_id = PrivateKey::random(&mut OsRng).to_monero_base58();
     session_id.truncate(if alias.is_some() { 8 } else { 16 });
     if let Some(alias) = alias {
         session_id.push('_');

--- a/applications/minotari_console_wallet/src/init/mod.rs
+++ b/applications/minotari_console_wallet/src/init/mod.rs
@@ -80,7 +80,7 @@ use tari_key_manager::{
 };
 use tari_p2p::{auto_update::AutoUpdateConfig, peer_seeds::SeedPeer, PeerSeedsConfig, TransportType};
 use tari_shutdown::ShutdownSignal;
-use tari_utilities::{encoding::Base58, hex::Hex, ByteArray, SafePassword};
+use tari_utilities::{encoding::MBase58, hex::Hex, ByteArray, SafePassword};
 use zxcvbn::zxcvbn;
 
 use crate::{
@@ -972,7 +972,7 @@ pub fn prompt_public_key(prompt: &str) -> Option<PublicKey> {
     let input = input.trim();
     match PublicKey::from_hex(input) {
         Ok(pk) => Some(pk),
-        Err(_) => match PublicKey::from_base58(input) {
+        Err(_) => match PublicKey::from_monero_base58(input) {
             Ok(pk) => Some(pk),
             Err(_) => None,
         },

--- a/applications/minotari_ledger_wallet/comms/Cargo.toml
+++ b/applications/minotari_ledger_wallet/comms/Cargo.toml
@@ -6,15 +6,15 @@ license = "BSD-3-Clause"
 edition = "2021"
 
 [dependencies]
-tari_crypto = { version = "0.20.2", default-features = false }
-tari_utilities = { version = "0.7" }
+tari_crypto = { version = "0.21.0", default-features = false }
+tari_utilities = { version = "0.8" }
 tari_common = { path = "../../../common" }
 tari_common_types = { path = "../../../base_layer/common_types" }
 tari_script = { path = "../../../infrastructure/tari_script" }
 
 minotari_ledger_wallet_common = { path = "../common" }
 semver = "1.0"
-borsh = "1.2"
+borsh = "1.5"
 dialoguer = { version = "0.11" }
 ledger-transport = { git = "https://github.com/Zondax/ledger-rs", rev = "20e2a20" }
 ledger-transport-hid = { git = "https://github.com/Zondax/ledger-rs", rev = "20e2a20" }

--- a/applications/minotari_ledger_wallet/wallet/Cargo.toml
+++ b/applications/minotari_ledger_wallet/wallet/Cargo.toml
@@ -6,7 +6,7 @@ license = "BSD-3-Clause"
 edition = "2021"
 
 [dependencies]
-tari_crypto = { version = "0.20.3", default-features = false, features = [
+tari_crypto = { version = "0.21.0", default-features = false, features = [
     "borsh",
 ] }
 tari_hashing = { path = "../../../hashing", version = "1.6.0-pre.0" }
@@ -14,7 +14,7 @@ tari_hashing = { path = "../../../hashing", version = "1.6.0-pre.0" }
 minotari_ledger_wallet_common = { path = "../common" }
 
 blake2 = { version = "0.10", default-features = false }
-borsh = { version = "1.2", default-features = false }
+borsh = { version = "1.5", default-features = false }
 digest = { version = "0.10", default-features = false }
 include_gif = "1.0.1"
 ledger_device_sdk = "1.15"

--- a/applications/minotari_merge_mining_proxy/Cargo.toml
+++ b/applications/minotari_merge_mining_proxy/Cargo.toml
@@ -27,11 +27,11 @@ tari_key_manager = { path = "../../base_layer/key_manager", features = [
     "key_manager_service",
 ] }
 tari_max_size = { path = "../../infrastructure/max_size" }
-tari_utilities = { version = "0.7" }
+tari_utilities = { version = "0.8" }
 
 anyhow = "1.0.53"
 bincode = "1.3.1"
-borsh = "1.2"
+borsh = "1.5"
 bytes = "1.1"
 chrono = { version = "0.4.19", default-features = false }
 clap = { version = "3.2", features = ["derive", "env"] }

--- a/applications/minotari_miner/Cargo.toml
+++ b/applications/minotari_miner/Cargo.toml
@@ -17,11 +17,11 @@ minotari_app_utilities = { path = "../minotari_app_utilities", features = [
     "miner_input",
 ] }
 minotari_app_grpc = { path = "../minotari_app_grpc" }
-tari_crypto = { version = "0.20.3" }
-tari_utilities = { version = "0.7" }
+tari_crypto = { version = "0.21.0" }
+tari_utilities = { version = "0.8" }
 
 base64 = "0.13.0"
-borsh = "1.2"
+borsh = "1.5"
 bufstream = "0.1"
 chrono = { version = "0.4.19", default-features = false }
 clap = { version = "3.2", features = ["derive"] }

--- a/applications/minotari_node/Cargo.toml
+++ b/applications/minotari_node/Cargo.toml
@@ -17,13 +17,13 @@ tari_comms_dht = { path = "../../comms/dht" }
 tari_core = { path = "../../base_layer/core", default-features = false, features = [
     "transactions",
 ] }
-tari_crypto = { version = "0.20.3" }
+tari_crypto = { version = "0.21.0" }
 tari_libtor = { path = "../../infrastructure/libtor", optional = true }
 tari_p2p = { path = "../../base_layer/p2p", features = ["auto-update"] }
 tari_storage = { path = "../../infrastructure/storage" }
 tari_service_framework = { path = "../../base_layer/service_framework" }
 tari_shutdown = { path = "../../infrastructure/shutdown" }
-tari_utilities = { version = "0.7" }
+tari_utilities = { version = "0.8" }
 tari_key_manager = { path = "../../base_layer/key_manager", features = [
     "key_manager_service",
 ], version = "1.6.0-pre.0" }
@@ -31,7 +31,7 @@ tari_key_manager = { path = "../../base_layer/key_manager", features = [
 anyhow = "1.0.53"
 async-trait = "0.1.52"
 bincode = "1.3.1"
-borsh = "1.2"
+borsh = "1.5"
 chrono = { version = "0.4.19", default-features = false }
 clap = { version = "3.2", features = ["derive", "env"] }
 console-subscriber = "0.1.8"

--- a/base_layer/chat_ffi/Cargo.toml
+++ b/base_layer/chat_ffi/Cargo.toml
@@ -14,7 +14,7 @@ tari_common_types = { path = "../common_types" }
 tari_contacts = { path = "../contacts" }
 tari_p2p = { path = "../p2p" }
 tari_shutdown = { path = "../../infrastructure/shutdown" }
-tari_utilities = { version = "0.7" }
+tari_utilities = { version = "0.8" }
 
 libc = "0.2.65"
 libsqlite3-sys = { version = "0.25.1", features = ["bundled"], optional = true }
@@ -36,7 +36,7 @@ crate-type = ["staticlib", "cdylib"]
 [dev-dependencies]
 chrono = { version = "0.4.19", default-features = false }
 rand = "0.8"
-tari_crypto = { version = "0.20.3" }
+tari_crypto = { version = "0.21.0" }
 
 [build-dependencies]
 cbindgen = "0.24.3"

--- a/base_layer/common_types/Cargo.toml
+++ b/base_layer/common_types/Cargo.toml
@@ -7,13 +7,13 @@ version = "1.6.0-pre.0"
 edition = "2018"
 
 [dependencies]
-tari_crypto = { version = "0.20.3" }
-tari_utilities = { version = "0.7" }
+tari_crypto = { version = "0.21.0" }
+tari_utilities = { version = "0.8" }
 tari_common = { path = "../../common", version = "1.6.0-pre.0" }
 minotari_ledger_wallet_common = { path = "../../applications/minotari_ledger_wallet/common" }
 chacha20poly1305 = "0.10.1"
 bitflags = { version = "2.4", features = ["serde"] }
-borsh = "1.2"
+borsh = "1.5"
 bs58 = "0.5.1"
 digest = "0.10"
 newtype-ops = "0.1"

--- a/base_layer/contacts/Cargo.toml
+++ b/base_layer/contacts/Cargo.toml
@@ -12,14 +12,14 @@ tari_common_sqlite = { path = "../../common_sqlite", version = "1.6.0-pre.0" }
 tari_common_types = { path = "../../base_layer/common_types", version = "1.6.0-pre.0" }
 tari_comms = { path = "../../comms/core", version = "1.6.0-pre.0" }
 tari_comms_dht = { path = "../../comms/dht", version = "1.6.0-pre.0" }
-tari_crypto = { version = "0.20.3" }
+tari_crypto = { version = "0.21.0" }
 tari_max_size = { path = "../../infrastructure/max_size" }
 tari_p2p = { path = "../p2p", features = [
     "auto-update",
 ], version = "1.6.0-pre.0" }
 tari_service_framework = { path = "../service_framework", version = "1.6.0-pre.0" }
 tari_shutdown = { path = "../../infrastructure/shutdown", version = "1.6.0-pre.0" }
-tari_utilities = { version = "0.7" }
+tari_utilities = { version = "0.8" }
 
 chrono = { version = "0.4.19", default-features = false, features = ["serde"] }
 diesel = { version = "2.2.4", features = [

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -33,7 +33,7 @@ tari_common_types = { path = "../../base_layer/common_types", version = "1.6.0-p
 tari_comms = { path = "../../comms/core", version = "1.6.0-pre.0" }
 tari_comms_dht = { path = "../../comms/dht", version = "1.6.0-pre.0" }
 tari_comms_rpc_macros = { path = "../../comms/rpc_macros", version = "1.6.0-pre.0" }
-tari_crypto = { version = "0.20.3", features = ["borsh"] }
+tari_crypto = { version = "0.21.0", features = ["borsh"] }
 tari_max_size = { path = "../../infrastructure/max_size" }
 tari_metrics = { path = "../../infrastructure/metrics", optional = true, version = "1.6.0-pre.0" }
 tari_mmr = { path = "../../base_layer/mmr", optional = true, version = "1.6.0-pre.0" }
@@ -43,7 +43,7 @@ tari_service_framework = { path = "../service_framework", version = "1.6.0-pre.0
 tari_shutdown = { path = "../../infrastructure/shutdown", version = "1.6.0-pre.0" }
 tari_storage = { path = "../../infrastructure/storage", version = "1.6.0-pre.0" }
 tari_test_utils = { path = "../../infrastructure/test_utils", version = "1.6.0-pre.0" }
-tari_utilities = { version = "0.7", features = ["borsh"] }
+tari_utilities = { version = "0.8", features = ["borsh"] }
 tari_key_manager = { path = "../key_manager", features = [
     "key_manager_service",
 ], version = "1.6.0-pre.0" }
@@ -54,7 +54,7 @@ async-trait = { version = "0.1.50" }
 bincode = "1.1.4"
 bitflags = { version = "2.4", features = ["serde"] }
 blake2 = "0.10"
-borsh = { version = "1.2", features = ["derive"] }
+borsh = { version = "1.5", features = ["derive"] }
 bytes = "0.5"
 chacha20poly1305 = "0.10.1"
 chrono = { version = "0.4.19", default-features = false, features = ["serde"] }

--- a/base_layer/key_manager/Cargo.toml
+++ b/base_layer/key_manager/Cargo.toml
@@ -11,8 +11,8 @@ edition = "2021"
 crate-type = ["lib", "cdylib"]
 
 [dependencies]
-tari_crypto = { version = "0.20.3" }
-tari_utilities = { version = "0.7" }
+tari_crypto = { version = "0.21.0" }
+tari_utilities = { version = "0.8" }
 tari_common_sqlite = { path = "../../common_sqlite", version = "1.6.0-pre.0" }
 tari_common_types = { path = "../../base_layer/common_types", version = "1.6.0-pre.0" }
 tari_service_framework = { path = "../service_framework", version = "1.6.0-pre.0" }

--- a/base_layer/mmr/Cargo.toml
+++ b/base_layer/mmr/Cargo.toml
@@ -11,10 +11,10 @@ edition = "2018"
 default = []
 
 [dependencies]
-tari_utilities = { version = "0.7" }
-tari_crypto = { version = "0.20.3" }
+tari_utilities = { version = "0.8" }
+tari_crypto = { version = "0.21.0" }
 thiserror = "1.0"
-borsh = "1.2"
+borsh = "1.5"
 digest = "0.10"
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }

--- a/base_layer/p2p/Cargo.toml
+++ b/base_layer/p2p/Cargo.toml
@@ -13,11 +13,11 @@ edition = "2021"
 tari_comms = { path = "../../comms/core", version = "1.6.0-pre.0" }
 tari_comms_dht = { path = "../../comms/dht", version = "1.6.0-pre.0" }
 tari_common = { path = "../../common", version = "1.6.0-pre.0" }
-tari_crypto = { version = "0.20.3" }
+tari_crypto = { version = "0.21.0" }
 tari_service_framework = { path = "../service_framework", version = "1.6.0-pre.0" }
 tari_shutdown = { path = "../../infrastructure/shutdown", version = "1.6.0-pre.0" }
 tari_storage = { path = "../../infrastructure/storage", version = "1.6.0-pre.0" }
-tari_utilities = { version = "0.7" }
+tari_utilities = { version = "0.8" }
 
 anyhow = "1.0.53"
 fs2 = "0.4.0"

--- a/base_layer/tari_mining_helper_ffi/Cargo.toml
+++ b/base_layer/tari_mining_helper_ffi/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 tari_comms = { path = "../../comms/core" }
-tari_crypto = { version = "0.20.3" }
+tari_crypto = { version = "0.21.0" }
 tari_common = { path = "../../common" }
 tari_core = { path = "../core", default-features = false, features = [
     "transactions",
@@ -16,10 +16,10 @@ tari_core = { path = "../core", default-features = false, features = [
     "base_node",
 ] }
 tari_common_types = { path = "../../base_layer/common_types", version = "1.6.0-pre.0" }
-tari_utilities = { version = "0.7" }
+tari_utilities = { version = "0.8" }
 libc = "0.2.65"
 thiserror = "1.0.26"
-borsh = "1.2"
+borsh = "1.5"
 tokio = { version = "1.36", features = ["rt"] }
 
 [dev-dependencies]

--- a/base_layer/wallet/Cargo.toml
+++ b/base_layer/wallet/Cargo.toml
@@ -18,7 +18,7 @@ tari_core = { path = "../../base_layer/core", default-features = false, features
     "mempool_proto",
     "base_node_proto",
 ], version = "1.6.0-pre.0" }
-tari_crypto = { version = "0.20.3" }
+tari_crypto = { version = "0.21.0" }
 tari_max_size = { path = "../../infrastructure/max_size" }
 tari_key_manager = { path = "../key_manager", features = [
     "key_manager_service",
@@ -29,7 +29,7 @@ tari_p2p = { path = "../p2p", features = [
 tari_script = { path = "../../infrastructure/tari_script", version = "1.6.0-pre.0" }
 tari_service_framework = { path = "../service_framework", version = "1.6.0-pre.0" }
 tari_shutdown = { path = "../../infrastructure/shutdown", version = "1.6.0-pre.0" }
-tari_utilities = { version = "0.7" }
+tari_utilities = { version = "0.8" }
 
 # Uncomment for tokio tracing via tokio-console (needs "tracing" features)
 #console-subscriber = "0.1.3"
@@ -41,7 +41,7 @@ async-trait = "0.1.50"
 argon2 = "0.4.1"
 bincode = "1.3.1"
 blake2 = "0.10"
-borsh = "1.2"
+borsh = "1.5"
 sha2 = "0.10"
 chrono = { version = "0.4.19", default-features = false, features = ["serde"] }
 derivative = "2.2.0"

--- a/base_layer/wallet_ffi/Cargo.toml
+++ b/base_layer/wallet_ffi/Cargo.toml
@@ -15,12 +15,12 @@ tari_common = { path = "../../common" }
 tari_common_types = { path = "../common_types" }
 tari_comms = { path = "../../comms/core", features = ["c_integration"] }
 tari_comms_dht = { path = "../../comms/dht", default-features = false }
-tari_crypto = { version = "0.20.3" }
+tari_crypto = { version = "0.21.0" }
 tari_key_manager = { path = "../key_manager" }
 tari_p2p = { path = "../p2p" }
 tari_script = { path = "../../infrastructure/tari_script" }
 tari_shutdown = { path = "../../infrastructure/shutdown" }
-tari_utilities = { version = "0.7" }
+tari_utilities = { version = "0.8" }
 minotari_wallet = { path = "../wallet", features = ["c_integration"] }
 tari_contacts = { path = "../../base_layer/contacts" }
 
@@ -58,7 +58,7 @@ tari_service_framework = { path = "../../base_layer/service_framework" }
 tari_core = { path = "../../base_layer/core", default-features = false, features = [
     "base_node",
 ] }
-borsh = "1.2"
+borsh = "1.5"
 env_logger = "0.7.1"
 
 [build-dependencies]

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -181,7 +181,7 @@ use tari_p2p::{
 use tari_script::TariScript;
 use tari_shutdown::Shutdown;
 use tari_utilities::{
-    encoding::Base58,
+    encoding::MBase58,
     hex,
     hex::{Hex, HexError},
     SafePassword,
@@ -2835,7 +2835,7 @@ pub unsafe extern "C" fn seed_words_create_from_cipher(
             return ptr::null_mut();
         },
     };
-    let bytes = match Vec::<u8>::from_base58(&base_58_cipher) {
+    let bytes = match Vec::<u8>::from_monero_base58(&base_58_cipher) {
         Ok(v) => v,
         Err(_) => {
             // code for invalid cipher bytes

--- a/common/config/presets/c_base_node_c.toml
+++ b/common/config/presets/c_base_node_c.toml
@@ -319,4 +319,4 @@ database_url = "data/base_node/dht.db"
 #   `excluded_dial_addresses = ["/ip4/127.*.0:49.*/tcp/*", "/ip4/127.*.101:255.*/tcp/*"]`
 #                or
 #   `excluded_dial_addresses = ["/ip4/127.0:0.1/tcp/122", "/ip4/127.0:0.1/tcp/1000:2000"]`
-excluded_dial_addresses = ["/ip4/127.*.*.*/tcp/*"]
+excluded_dial_addresses = []

--- a/common/config/presets/d_console_wallet.toml
+++ b/common/config/presets/d_console_wallet.toml
@@ -363,4 +363,4 @@ network_discovery.initial_peer_sync_delay = 25
 #   `excluded_dial_addresses = ["/ip4/127.*.0:49.*/tcp/*", "/ip4/127.*.101:255.*/tcp/*"]`
 #                or
 #   `excluded_dial_addresses = ["/ip4/127.0:0.1/tcp/122", "/ip4/127.0:0.1/tcp/1000:2000"]`
-excluded_dial_addresses = ["/ip4/127.*.*.*/tcp/*"]
+excluded_dial_addresses = []

--- a/common_sqlite/Cargo.toml
+++ b/common_sqlite/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tari_utilities = { version = "0.7" }
+tari_utilities = { version = "0.8" }
 
 diesel = { version = "2.2.4", features = [
     "sqlite",

--- a/comms/core/Cargo.toml
+++ b/comms/core/Cargo.toml
@@ -10,11 +10,11 @@ version = "1.6.0-pre.0"
 edition = "2021"
 
 [dependencies]
-tari_crypto = { version = "0.20.3" }
+tari_crypto = { version = "0.21.0" }
 tari_metrics = { path = "../../infrastructure/metrics", optional = true, version = "1.6.0-pre.0" }
 tari_storage = { path = "../../infrastructure/storage", version = "1.6.0-pre.0" }
 tari_shutdown = { path = "../../infrastructure/shutdown", version = "1.6.0-pre.0" }
-tari_utilities = { version = "0.7" }
+tari_utilities = { version = "0.8" }
 
 anyhow = "1.0.53"
 async-trait = "0.1.36"

--- a/comms/dht/Cargo.toml
+++ b/comms/dht/Cargo.toml
@@ -13,8 +13,8 @@ edition = "2021"
 tari_comms = { path = "../core", features = ["rpc"], version = "1.6.0-pre.0" }
 tari_common = { path = "../../common", version = "1.6.0-pre.0" }
 tari_comms_rpc_macros = { path = "../rpc_macros", version = "1.6.0-pre.0" }
-tari_crypto = { version = "0.20.3" }
-tari_utilities = { version = "0.7" }
+tari_crypto = { version = "0.21.0" }
+tari_utilities = { version = "0.8" }
 tari_shutdown = { path = "../../infrastructure/shutdown", version = "1.6.0-pre.0" }
 tari_storage = { path = "../../infrastructure/storage", version = "1.6.0-pre.0" }
 tari_common_sqlite = { path = "../../common_sqlite", version = "1.6.0-pre.0" }

--- a/hashing/Cargo.toml
+++ b/hashing/Cargo.toml
@@ -12,10 +12,10 @@ license = "BSD-3-Clause"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tari_crypto = { version = "0.20.3", default-features = false, features = [
+tari_crypto = { version = "0.21.0", default-features = false, features = [
     "borsh",
 ] }
-borsh = { version = "1.2", default-features = false }
+borsh = { version = "1.5", default-features = false }
 digest = { version = "0.10", default-features = false }
 
 [dev-dependencies]

--- a/infrastructure/max_size/Cargo.toml
+++ b/infrastructure/max_size/Cargo.toml
@@ -11,8 +11,8 @@ readme = "README.md"
 license = "BSD-3-Clause"
 
 [dependencies]
-tari_utilities = { version = "0.7" }
+tari_utilities = { version = "0.8" }
 
-borsh = "1.2"
+borsh = "1.5"
 serde = { version = "1.0.136", features = ["derive"] }
 thiserror = "1.0.30"

--- a/infrastructure/storage/Cargo.toml
+++ b/infrastructure/storage/Cargo.toml
@@ -18,4 +18,4 @@ serde = { version = "1.0.80", features = ["derive"] }
 
 [dev-dependencies]
 rand = "0.8"
-tari_utilities = { version = "0.7", features = ["borsh"] }
+tari_utilities = { version = "0.8", features = ["borsh"] }

--- a/infrastructure/tari_script/Cargo.toml
+++ b/infrastructure/tari_script/Cargo.toml
@@ -11,12 +11,12 @@ readme = "README.md"
 license = "BSD-3-Clause"
 
 [dependencies]
-tari_crypto = { version = "0.20.3" }
+tari_crypto = { version = "0.21.0" }
 tari_max_size = { path = "../../infrastructure/max_size" }
-tari_utilities = { version = "0.7" }
+tari_utilities = { version = "0.8" }
 
 blake2 = "0.10"
-borsh = "1.2"
+borsh = "1.5"
 digest = "0.10"
 integer-encoding = "3.0.2"
 serde = "1.0.136"

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -13,7 +13,7 @@ minotari_node = { path = "../applications/minotari_node", features = ["metrics"]
 minotari_node_grpc_client = { path = "../clients/rust/base_node_grpc_client" }
 tari_chat_client = { path = "../base_layer/contacts/src/chat_client" }
 minotari_chat_ffi = { path = "../base_layer/chat_ffi" }
-tari_crypto = { version = "0.20.3" }
+tari_crypto = { version = "0.21.0" }
 tari_common = { path = "../common" }
 tari_common_types = { path = "../base_layer/common_types" }
 tari_comms = { path = "../comms/core" }
@@ -26,7 +26,7 @@ minotari_miner = { path = "../applications/minotari_miner" }
 tari_p2p = { path = "../base_layer/p2p" }
 tari_script = { path = "../infrastructure/tari_script" }
 tari_shutdown = { path = "../infrastructure/shutdown" }
-tari_utilities = { version = "0.7" }
+tari_utilities = { version = "0.8" }
 minotari_wallet = { path = "../base_layer/wallet" }
 minotari_wallet_ffi = { path = "../base_layer/wallet_ffi" }
 minotari_wallet_grpc_client = { path = "../clients/rust/wallet_grpc_client" }


### PR DESCRIPTION
Description
---
upgrades tari utilties and tari crypto
upgrades borsh
removes blocking of `127.0.0.1` address by default

Motivation and Context
---
blocking of `127.0.0.1` blocks universe connections between the wallet and base node by default. 
