### PR TITLE
feat: add checked_sub

### DIFF
--- a/base_layer/core/src/proof_of_work/accumulated_difficulty.rs
+++ b/base_layer/core/src/proof_of_work/accumulated_difficulty.rs
@@ -59,6 +59,10 @@ impl AccumulatedDifficulty {
         self.0.checked_add(u128::from(d.as_u64())).map(AccumulatedDifficulty)
     }
 
+    pub fn checked_sub_difficulty(&self, d: Difficulty) -> Option<AccumulatedDifficulty> {
+        self.0.checked_sub(u128::from(d.as_u64())).map(AccumulatedDifficulty)
+    }
+
     pub fn to_be_bytes(&self) -> Vec<u8> {
         self.0.to_be_bytes().to_vec()
     }


### PR DESCRIPTION
Description
---
Add checked_sub implementation for accumulated difficulty struct. 

Motivation and Context
---
In a normal block chain world, you would never subtract difficulty, but in P2pool you only count the last X blocks. This means that when a block falls away and is not used anymore, we need to subtract its difficulty. 
