### PR TITLE
feat!: add dns resiliency

### DIFF
--- a/base_layer/p2p/src/config.rs
+++ b/base_layer/p2p/src/config.rs
@@ -22,19 +22,21 @@
 
 use std::{
     path::{Path, PathBuf},
+    str::FromStr,
     time::Duration,
 };
 
 use serde::{Deserialize, Serialize};
 use tari_common::{
     configuration::{
+        deserialize_dns_name_server_list,
         serializers,
-        utils::{deserialize_string_or_struct, serialize_string},
+        utils::serialize_string,
+        DnsNameServerList,
         MultiaddrList,
         Network,
         StringList,
     },
-    DnsNameServer,
     SubConfigPath,
 };
 use tari_comms::multiaddr::Multiaddr;
@@ -54,13 +56,13 @@ pub struct PeerSeedsConfig {
     /// peer list.
     #[serde(default)]
     pub dns_seeds: StringList,
+    /// DNS name server to use for DNS seeds.
     #[serde(
         default,
-        deserialize_with = "deserialize_string_or_struct",
+        deserialize_with = "deserialize_dns_name_server_list",
         serialize_with = "serialize_string"
     )]
-    /// DNS name server to use for DNS seeds.
-    pub dns_seeds_name_server: DnsNameServer,
+    pub dns_seed_name_servers: DnsNameServerList,
     /// All DNS seed records must pass DNSSEC validation
     #[serde(default)]
     pub dns_seeds_use_dnssec: bool,
@@ -76,7 +78,10 @@ impl Default for PeerSeedsConfig {
                 Network::get_current_or_user_setting_or_default().as_key_str()
             )]
             .into(),
-            dns_seeds_name_server: DnsNameServer::default(),
+            dns_seed_name_servers: DnsNameServerList::from_str(
+                "system, 1.1.1.1:853/cloudflare-dns.com, 8.8.8.8:853/dns.google, 9.9.9.9:853/dns.quad9.net",
+            )
+            .expect("string is valid"),
             dns_seeds_use_dnssec: false,
         }
     }
@@ -180,9 +185,22 @@ impl P2pConfig {
 
 #[cfg(test)]
 mod test {
+    use std::str::FromStr;
+
     use tari_common::DnsNameServer;
 
     use crate::PeerSeedsConfig;
+
+    #[test]
+    fn default_dns_seed_name_servers_test() {
+        let dns_seed_name_servers = PeerSeedsConfig::default().dns_seed_name_servers;
+        assert_eq!(dns_seed_name_servers.into_vec(), vec![
+            DnsNameServer::from_str("system").unwrap(),
+            DnsNameServer::from_str("1.1.1.1:853/cloudflare-dns.com").unwrap(),
+            DnsNameServer::from_str("8.8.8.8:853/dns.google").unwrap(),
+            DnsNameServer::from_str("9.9.9.9:853/dns.quad9.net").unwrap()
+        ]);
+    }
 
     #[test]
     fn it_deserializes_from_toml() {
@@ -190,7 +208,7 @@ mod test {
         let config_str = r#"
             dns_seeds = ["seeds.esmeralda.tari.com"]
             peer_seeds = ["20605a28047938f851e3d0cd3f0ff771b2fb23036f0ab8eaa57947dccc834d15::/onion3/e4dsii6vc5f7frao23syonalgikd5kcd7fddrdjhab6bdo3cu47n3kyd:18141"]
-            dns_seeds_name_server = "1.1.1.1:853/cloudflare-dns.com"
+            dns_seed_name_servers = ["1.1.1.1:853/cloudflare-dns.com"]
             dns_seeds_use_dnssec = false
          "#;
         let config = toml::from_str::<PeerSeedsConfig>(config_str).unwrap();
@@ -200,7 +218,7 @@ mod test {
              e4dsii6vc5f7frao23syonalgikd5kcd7fddrdjhab6bdo3cu47n3kyd:18141"
         ]);
         assert_eq!(
-            config.dns_seeds_name_server.to_string(),
+            config.dns_seed_name_servers.to_string(),
             "1.1.1.1:853/cloudflare-dns.com".to_string()
         );
         assert!(!config.dns_seeds_use_dnssec);
@@ -209,7 +227,7 @@ mod test {
         let config_str = r#"
             dns_seeds = ["seeds.esmeralda.tari.com"]
             peer_seeds = ["20605a28047938f851e3d0cd3f0ff771b2fb23036f0ab8eaa57947dccc834d15::/onion3/e4dsii6vc5f7frao23syonalgikd5kcd7fddrdjhab6bdo3cu47n3kyd:18141"]
-            dns_seeds_name_server = ""
+            dns_seed_name_servers = ""
             #dns_seeds_use_dnssec = false
          "#;
         match toml::from_str::<PeerSeedsConfig>(config_str) {
@@ -224,29 +242,32 @@ mod test {
         let config_str = r#"
             dns_seeds = []
             peer_seeds = []
-            dns_seeds_name_server = "1.1.1.1:853/cloudflare-dns.com"
+            dns_seed_name_servers = ["system", "1.1.1.1:853/cloudflare-dns.com"]
             dns_seeds_use_dnssec = false
          "#;
         let config = toml::from_str::<PeerSeedsConfig>(config_str).unwrap();
         assert_eq!(config.dns_seeds.into_vec(), Vec::<String>::new());
         assert_eq!(config.peer_seeds.into_vec(), Vec::<String>::new());
-        assert_eq!(
-            config.dns_seeds_name_server.to_string(),
-            "1.1.1.1:853/cloudflare-dns.com".to_string()
-        );
+        assert_eq!(config.dns_seed_name_servers.into_vec(), vec![
+            DnsNameServer::from_str("system").unwrap(),
+            DnsNameServer::from_str("1.1.1.1:853/cloudflare-dns.com").unwrap(),
+        ]);
         assert!(!config.dns_seeds_use_dnssec);
 
         // Omitted config fields
         let config_str = r#"
             #dns_seeds = []
             #peer_seeds = []
-            #dns_seeds_name_server = "1.1.1.1:853/cloudflare-dns.com"
+            #dns_seed_name_servers = ["system", "1.1.1.1:853/cloudflare-dns.com"]
             #dns_seeds_use_dnssec = false
          "#;
         let config = toml::from_str::<PeerSeedsConfig>(config_str).unwrap();
         assert_eq!(config.dns_seeds.into_vec(), Vec::<String>::new());
         assert_eq!(config.peer_seeds.into_vec(), Vec::<String>::new());
-        assert!(matches!(config.dns_seeds_name_server, DnsNameServer::System));
+        assert_eq!(config.dns_seed_name_servers.into_vec(), vec![
+            DnsNameServer::from_str("system").unwrap(),
+            DnsNameServer::from_str("1.1.1.1:853/cloudflare-dns.com").unwrap(),
+        ]);
         assert!(!config.dns_seeds_use_dnssec);
 
         // System
@@ -257,6 +278,9 @@ mod test {
             #dns_seeds_use_dnssec = false
          "#;
         let config = toml::from_str::<PeerSeedsConfig>(config_str).unwrap();
-        assert!(matches!(config.dns_seeds_name_server, DnsNameServer::System));
+        assert_eq!(config.dns_seed_name_servers.into_vec(), vec![DnsNameServer::from_str(
+            "system"
+        )
+        .unwrap(),]);
     }
 }

--- a/base_layer/p2p/src/config.rs
+++ b/base_layer/p2p/src/config.rs
@@ -227,14 +227,14 @@ mod test {
         let config_str = r#"
             dns_seeds = ["seeds.esmeralda.tari.com"]
             peer_seeds = ["20605a28047938f851e3d0cd3f0ff771b2fb23036f0ab8eaa57947dccc834d15::/onion3/e4dsii6vc5f7frao23syonalgikd5kcd7fddrdjhab6bdo3cu47n3kyd:18141"]
-            dns_seed_name_servers = ""
+            dns_seed_name_servers = "111"
             #dns_seeds_use_dnssec = false
          "#;
         match toml::from_str::<PeerSeedsConfig>(config_str) {
             Ok(_) => panic!("Should fail"),
             Err(e) => assert_eq!(
                 e.to_string(),
-                "invalid socket address syntax for key `dns_seeds_name_server` at line 4 column 37"
+                "invalid socket address syntax for key `dns_seed_name_servers` at line 4 column 37"
             ),
         }
 
@@ -258,23 +258,20 @@ mod test {
         let config_str = r#"
             #dns_seeds = []
             #peer_seeds = []
-            #dns_seed_name_servers = ["system", "1.1.1.1:853/cloudflare-dns.com"]
+            #dns_seed_name_servers = []
             #dns_seeds_use_dnssec = false
          "#;
         let config = toml::from_str::<PeerSeedsConfig>(config_str).unwrap();
         assert_eq!(config.dns_seeds.into_vec(), Vec::<String>::new());
         assert_eq!(config.peer_seeds.into_vec(), Vec::<String>::new());
-        assert_eq!(config.dns_seed_name_servers.into_vec(), vec![
-            DnsNameServer::from_str("system").unwrap(),
-            DnsNameServer::from_str("1.1.1.1:853/cloudflare-dns.com").unwrap(),
-        ]);
+        assert_eq!(config.dns_seed_name_servers.into_vec(), vec![]);
         assert!(!config.dns_seeds_use_dnssec);
 
         // System
         let config_str = r#"
             #dns_seeds = []
             #peer_seeds = []
-            dns_seeds_name_server = "system"
+            dns_seed_name_servers = "system"
             #dns_seeds_use_dnssec = false
          "#;
         let config = toml::from_str::<PeerSeedsConfig>(config_str).unwrap();

--- a/base_layer/p2p/src/dns/error.rs
+++ b/base_layer/p2p/src/dns/error.rs
@@ -43,4 +43,6 @@ pub enum DnsClientError {
     SystemHasNoDnsServers,
     #[error("DNS server name was not provided for DNSSEC connection e.g.1.1.1.1:853/cloudflare-dns.com")]
     DnsNameRequiredForDnsSec,
+    #[error("Connection error: {0}")]
+    Connection(String),
 }

--- a/base_layer/p2p/src/initialization.rs
+++ b/base_layer/p2p/src/initialization.rs
@@ -562,7 +562,7 @@ impl P2pInitializer {
                 Err(err) => {
                     warn!(
                         target: LOG_TARGET,
-                        "DNS entry '{}' did not respond, trying the next one. You can edit 'dns_seeds_name_servers' in \
+                        "DNS entry '{}' did not respond, trying the next one. You can edit 'dns_seed_name_servers' in \
                         the config file. (Error: {})",
                         dns,
                         err.to_string(),

--- a/base_layer/p2p/src/initialization.rs
+++ b/base_layer/p2p/src/initialization.rs
@@ -36,8 +36,9 @@ use lmdb_zero::open;
 use log::*;
 use rand::{distributions::Alphanumeric, thread_rng, Rng};
 use tari_common::{
-    configuration::Network,
+    configuration::{DnsNameServerList, Network},
     exit_codes::{ExitCode, ExitError},
+    DnsNameServer,
 };
 use tari_comms::{
     backoff::ConstantBackoff,
@@ -81,12 +82,14 @@ use tower::ServiceBuilder;
 use crate::{
     comms_connector::{InboundDomainConnector, PubsubDomainConnector},
     config::{P2pConfig, PeerSeedsConfig},
+    dns::DnsClientError,
     peer_seeds::{DnsSeedResolver, SeedPeer},
     transport::{TorTransportConfig, TransportType},
     TransportConfig,
     MAJOR_NETWORK_VERSION,
     MINOR_NETWORK_VERSION,
 };
+
 const LOG_TARGET: &str = "p2p::initialization";
 
 /// ProtocolId for minotari messaging protocol
@@ -490,8 +493,9 @@ impl P2pInitializer {
 
         debug!(
             target: LOG_TARGET,
-            "Resolving DNS seeds (NS:{}, addresses: {})...",
-            config.dns_seeds_name_server,
+            "Resolving DNS seeds (DNSSEC is enabled: {}, name servers: {}, addresses: {}) ...",
+            config.dns_seeds_use_dnssec,
+            config.dns_seed_name_servers,
             config
                 .dns_seeds
                 .iter()
@@ -501,19 +505,8 @@ impl P2pInitializer {
         );
         let start = Instant::now();
 
-        let resolver = if config.dns_seeds_use_dnssec {
-            debug!(
-                target: LOG_TARGET,
-                "Using {} to resolve DNS seeds. DNSSEC is enabled", config.dns_seeds_name_server
-            );
-            DnsSeedResolver::connect_secure(config.dns_seeds_name_server.clone()).await?
-        } else {
-            debug!(
-                target: LOG_TARGET,
-                "Using {} to resolve DNS seeds. DNSSEC is disabled", config.dns_seeds_name_server
-            );
-            DnsSeedResolver::connect(config.dns_seeds_name_server.clone()).await?
-        };
+        let resolver =
+            P2pInitializer::get_dns_seed_resolver(config.dns_seeds_use_dnssec, &config.dns_seed_name_servers).await?;
         let resolving = config.dns_seeds.iter().map(|addr| {
             let mut resolver = resolver.clone();
             async move { (resolver.resolve(addr).await, addr) }
@@ -544,6 +537,44 @@ impl P2pInitializer {
             .collect::<Vec<_>>();
 
         Ok(peers)
+    }
+
+    async fn get_dns_seed_resolver(
+        dns_seeds_use_dnssec: bool,
+        dns_seed_name_servers: &DnsNameServerList,
+    ) -> Result<DnsSeedResolver, ServiceInitializationError> {
+        if dns_seed_name_servers.is_empty() {
+            return Err(ServiceInitializationError::from(DnsClientError::Connection(
+                "No DNS name servers configured!".to_string(),
+            )));
+        }
+        let mut dns_errors = Vec::new();
+        for dns in dns_seed_name_servers {
+            let res = match (dns_seeds_use_dnssec, dns == &DnsNameServer::System) {
+                (true, false) => DnsSeedResolver::connect_secure(dns.clone()).await,
+                (_, _) => DnsSeedResolver::connect(dns.clone()).await,
+            };
+            match res {
+                Ok(val) => {
+                    trace!(target: LOG_TARGET, "Found DNS client at '{}'", dns);
+                    return Ok(val);
+                },
+                Err(err) => {
+                    warn!(
+                        target: LOG_TARGET,
+                        "DNS entry '{}' did not respond, trying the next one. You can edit 'dns_seeds_name_servers' in \
+                        the config file. (Error: {})",
+                        dns,
+                        err.to_string(),
+                    );
+                    dns_errors.push(err.to_string())
+                },
+            }
+        }
+        Err(ServiceInitializationError::from(DnsClientError::Connection(format!(
+            "{:?}",
+            dns_errors
+        ))))
     }
 }
 

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -114,9 +114,8 @@ use minotari_wallet::{
 use num_traits::FromPrimitive;
 use rand::{prelude::SliceRandom, rngs::OsRng};
 use tari_common::{
-    configuration::{MultiaddrList, StringList},
+    configuration::{DnsNameServerList, MultiaddrList, StringList},
     network_check::set_network_if_choice_valid,
-    DnsNameServer,
 };
 use tari_common_types::{
     emoji::{emoji_set, EMOJI},
@@ -2810,27 +2809,30 @@ pub unsafe extern "C" fn seed_words_create_from_cipher(
     passphrase: *const c_char,
     error_out: *mut c_int,
 ) -> *mut TariSeedWords {
+    let mut error = 0;
+    ptr::swap(error_out, &mut error as *mut c_int);
+
     let passphrase = if passphrase.is_null() {
         None
     } else {
         match CStr::from_ptr(passphrase).to_str() {
             Ok(v) => Some(SafePassword::from(v.to_owned())),
             _ => {
-                let mut error = LibWalletError::from(InterfaceError::PointerError("passphrase".to_string())).code;
+                error = LibWalletError::from(InterfaceError::PointerError("passphrase".to_string())).code;
                 ptr::swap(error_out, &mut error as *mut c_int);
                 return ptr::null_mut();
             },
         }
     };
     if cipher_bytes.is_null() {
-        let mut error = LibWalletError::from(InterfaceError::NullError("cipher_bytes".to_string())).code;
+        error = LibWalletError::from(InterfaceError::NullError("cipher_bytes".to_string())).code;
         ptr::swap(error_out, &mut error as *mut c_int);
         return ptr::null_mut();
     }
     let base_58_cipher = match CStr::from_ptr(cipher_bytes).to_str() {
         Ok(v) => v.to_owned(),
         _ => {
-            let mut error = LibWalletError::from(InterfaceError::PointerError("cipher_bytes".to_string())).code;
+            error = LibWalletError::from(InterfaceError::PointerError("cipher_bytes".to_string())).code;
             ptr::swap(error_out, &mut error as *mut c_int);
             return ptr::null_mut();
         },
@@ -2839,7 +2841,7 @@ pub unsafe extern "C" fn seed_words_create_from_cipher(
         Ok(v) => v,
         Err(_) => {
             // code for invalid cipher bytes
-            let mut error = 420;
+            error = 420;
             ptr::swap(error_out, &mut error as *mut c_int);
             return ptr::null_mut();
         },
@@ -2848,7 +2850,7 @@ pub unsafe extern "C" fn seed_words_create_from_cipher(
         Ok(v) => v,
         Err(_) => {
             // code for invalid cipher bytes
-            let mut error = 421;
+            error = 421;
             ptr::swap(error_out, &mut error as *mut c_int);
             return ptr::null_mut();
         },
@@ -2858,7 +2860,7 @@ pub unsafe extern "C" fn seed_words_create_from_cipher(
         Ok(v) => v,
         Err(_) => {
             // code for invalid cipher bytes
-            let mut error = 420;
+            error = 420;
             ptr::swap(error_out, &mut error as *mut c_int);
             return ptr::null_mut();
         },
@@ -5762,6 +5764,8 @@ unsafe fn init_logging(
 /// `seed_passphrase` - an optional string, if present this will derypt the seed words
 /// `seed_words` - An optional instance of TariSeedWords, used to create a wallet for recovery purposes.
 /// If this is null, then a new master key is created for the wallet.
+/// `dns_seed_name_servers_str` - An optional list of DNS servers to query to get hold of the seed peer list.
+/// `use_dns_sec` - Use DNSSEC when querying the DNS servers.
 /// `callback_received_transaction` - The callback function pointer matching the function signature. This will be
 /// called when an inbound transaction is received.
 /// `callback_received_transaction_reply` - The callback function
@@ -5853,8 +5857,9 @@ pub unsafe extern "C" fn wallet_create(
     seed_passphrase: *const c_char,
     seed_words: *const TariSeedWords,
     network_str: *const c_char,
-    peer_seed_str: *const c_char,
-    dns_sec: bool,
+    dns_seeds_str: *const c_char,
+    dns_seed_name_servers_str: *const c_char,
+    use_dns_sec: bool,
 
     callback_received_transaction: unsafe extern "C" fn(context: *mut c_void, *mut TariPendingInboundTransaction),
     callback_received_transaction_reply: unsafe extern "C" fn(context: *mut c_void, *mut TariCompletedTransaction),
@@ -5930,16 +5935,32 @@ pub unsafe extern "C" fn wallet_create(
         SafePassword::from(pf)
     };
 
-    let peer_seed = if peer_seed_str.is_null() {
-        error = LibWalletError::from(InterfaceError::NullError("peer seed dns".to_string())).code;
+    let dns_seeds = if dns_seeds_str.is_null() {
+        error = LibWalletError::from(InterfaceError::NullError("peer seeds".to_string())).code;
         ptr::swap(error_out, &mut error as *mut c_int);
         return ptr::null_mut();
     } else {
-        let peer_seed = CStr::from_ptr(peer_seed_str)
+        let peer_seed = CStr::from_ptr(dns_seeds_str)
             .to_str()
             .expect("A non-null peer seed should be able to be converted to string");
-        info!(target: LOG_TARGET, "peer seed dns {}", peer_seed);
+        info!(target: LOG_TARGET, "peer seed dns '{}'", peer_seed);
         peer_seed
+    };
+
+    let dns_seed_name_servers = if dns_seed_name_servers_str.is_null() {
+        PeerSeedsConfig::default().dns_seed_name_servers
+    } else {
+        let list = CStr::from_ptr(dns_seed_name_servers_str)
+            .to_str()
+            .expect("A non-null peer seed should be able to be converted to string");
+        match DnsNameServerList::from_str(list) {
+            Ok(dns) => dns,
+            Err(e) => {
+                error = LibWalletError::from(InterfaceError::InvalidArgument(format!("dns_list_str: {}", e))).code;
+                ptr::swap(error_out, &mut error as *mut c_int);
+                return ptr::null_mut();
+            },
+        }
     };
 
     let seed_passphrase = if seed_passphrase.is_null() {
@@ -6109,9 +6130,9 @@ pub unsafe extern "C" fn wallet_create(
     ptr::swap(recovery_in_progress, &mut recovery_lookup as *mut bool);
 
     let peer_seeds = PeerSeedsConfig {
-        dns_seeds_name_server: DnsNameServer::System,
-        dns_seeds_use_dnssec: dns_sec,
-        dns_seeds: StringList::from(vec![peer_seed.to_string()]),
+        dns_seed_name_servers,
+        dns_seeds_use_dnssec: use_dns_sec,
+        dns_seeds: StringList::from(vec![dns_seeds.to_string()]),
         ..Default::default()
     };
 
@@ -9560,7 +9581,7 @@ mod test {
     use tari_p2p::initialization::MESSAGING_PROTOCOL_ID;
     use tari_script::script;
     use tari_test_utils::random;
-    use tari_utilities::encoding::Base58;
+    use tari_utilities::encoding::MBase58;
     use tempfile::tempdir;
 
     use crate::*;
@@ -9935,7 +9956,7 @@ mod test {
         unsafe {
             let cipher = CipherSeed::new();
             let ciper_bytes = cipher.encipher(None).unwrap();
-            let cipher_string = ciper_bytes.to_base58();
+            let cipher_string = ciper_bytes.to_monero_base58();
 
             let cipher_cstring = CString::new(cipher_string).unwrap();
             let cipher_char: *const c_char = CString::into_raw(cipher_cstring) as *const c_char;
@@ -10524,7 +10545,8 @@ mod test {
                 ptr::null(),
                 alice_network_str,
                 dns_string,
-                false,
+                ptr::null(),
+                true,
                 received_tx_callback,
                 received_tx_reply_callback,
                 received_tx_finalized_callback,
@@ -10574,7 +10596,8 @@ mod test {
                 ptr::null(),
                 alice_network_str,
                 dns_string,
-                false,
+                ptr::null(),
+                true,
                 received_tx_callback,
                 received_tx_reply_callback,
                 received_tx_finalized_callback,
@@ -10694,7 +10717,8 @@ mod test {
                 ptr::null(),
                 network_str,
                 dns_string,
-                false,
+                ptr::null(),
+                true,
                 received_tx_callback,
                 received_tx_reply_callback,
                 received_tx_finalized_callback,
@@ -10925,7 +10949,8 @@ mod test {
                 ptr::null(),
                 network_str,
                 dns_string,
-                false,
+                ptr::null(),
+                true,
                 received_tx_callback,
                 received_tx_reply_callback,
                 received_tx_finalized_callback,
@@ -10997,7 +11022,8 @@ mod test {
                 seed_words,
                 network_str,
                 dns_string,
-                false,
+                ptr::null(),
+                true,
                 received_tx_callback,
                 received_tx_reply_callback,
                 received_tx_finalized_callback,
@@ -11080,7 +11106,8 @@ mod test {
                 ptr::null(),
                 network_str,
                 dns_string,
-                false,
+                ptr::null(),
+                true,
                 received_tx_callback,
                 received_tx_reply_callback,
                 received_tx_finalized_callback,
@@ -11261,7 +11288,8 @@ mod test {
                 ptr::null(),
                 network_str,
                 dns_string,
-                false,
+                ptr::null(),
+                true,
                 received_tx_callback,
                 received_tx_reply_callback,
                 received_tx_finalized_callback,
@@ -11403,7 +11431,8 @@ mod test {
                 ptr::null(),
                 network_str,
                 dns_string,
-                false,
+                ptr::null(),
+                true,
                 received_tx_callback,
                 received_tx_reply_callback,
                 received_tx_finalized_callback,
@@ -11626,7 +11655,8 @@ mod test {
                 ptr::null(),
                 network_str,
                 dns_string,
-                false,
+                ptr::null(),
+                true,
                 received_tx_callback,
                 received_tx_reply_callback,
                 received_tx_finalized_callback,
@@ -11856,7 +11886,8 @@ mod test {
                 ptr::null(),
                 network_str,
                 dns_string,
-                false,
+                ptr::null(),
+                true,
                 received_tx_callback,
                 received_tx_reply_callback,
                 received_tx_finalized_callback,
@@ -12120,7 +12151,8 @@ mod test {
                 ptr::null(),
                 network_str,
                 dns_string,
-                false,
+                ptr::null(),
+                true,
                 received_tx_callback,
                 received_tx_reply_callback,
                 received_tx_finalized_callback,
@@ -12504,7 +12536,8 @@ mod test {
                 ptr::null(),
                 alice_network_str,
                 dns_string,
-                false,
+                ptr::null(),
+                true,
                 received_tx_callback,
                 received_tx_reply_callback,
                 received_tx_finalized_callback,
@@ -12572,7 +12605,8 @@ mod test {
                 ptr::null(),
                 bob_network_str,
                 dns_string,
-                false,
+                ptr::null(),
+                true,
                 received_tx_callback,
                 received_tx_reply_callback,
                 received_tx_finalized_callback,

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -2889,6 +2889,8 @@ TariPublicKey *public_keys_get_at(const struct TariPublicKeys *public_keys,
  * `seed_passphrase` - an optional string, if present this will derypt the seed words
  * `seed_words` - An optional instance of TariSeedWords, used to create a wallet for recovery purposes.
  * If this is null, then a new master key is created for the wallet.
+ * `dns_seed_name_servers_str` - An optional list of DNS servers to query to get hold of the seed peer list.
+ * `use_dns_sec` - Use DNSSEC when querying the DNS servers.
  * `callback_received_transaction` - The callback function pointer matching the function signature. This will be
  * called when an inbound transaction is received.
  * `callback_received_transaction_reply` - The callback function
@@ -2977,8 +2979,9 @@ struct TariWallet *wallet_create(void *context,
                                  const char *seed_passphrase,
                                  const struct TariSeedWords *seed_words,
                                  const char *network_str,
-                                 const char *peer_seed_str,
-                                 bool dns_sec,
+                                 const char *dns_seeds_str,
+                                 const char *dns_seed_name_servers_str,
+                                 bool use_dns_sec,
                                  void (*callback_received_transaction)(void *context,
                                                                        TariPendingInboundTransaction*),
                                  void (*callback_received_transaction_reply)(void *context,

--- a/common/config/presets/b_peer_seeds.toml
+++ b/common/config/presets/b_peer_seeds.toml
@@ -5,6 +5,24 @@
 #                                                                                                                      #
 ########################################################################################################################
 
+[p2p.seeds]
+# DNS name servers to use for DNS seeds, in order of preference.
+# (default: dns_seed_name_servers = [
+#    "system",
+#    "1.1.1.1:853/cloudflare-dns.com",
+#    "8.8.8.8:853/dns.google",
+#    "9.9.9.9:853/dns.quad9.net"
+#]
+#dns_seed_name_servers = [
+#    "system",
+#    "1.1.1.1:853/cloudflare-dns.com",
+#    "8.8.8.8:853/dns.google",
+#    "9.9.9.9:853/dns.quad9.net"
+#]
+
+# All DNS seed records must pass DNSSEC validation (default: dns_seeds_use_dnssec = false)
+#dns_seeds_use_dnssec = false
+
 [nextnet.p2p.seeds]
 # DNS seeds hosts - DNS TXT records are queried from these hosts and the resulting peers added to the comms peer list.
 # (Default: peer_seeds = [])

--- a/common/src/configuration/dns_name_server_list.rs
+++ b/common/src/configuration/dns_name_server_list.rs
@@ -1,0 +1,187 @@
+//  Copyright 2022. The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::{fmt, str::FromStr};
+
+use serde::{de, de::Visitor, Deserializer};
+
+use crate::{configuration::ConfigList, DnsNameServer};
+
+pub type DnsNameServerList = ConfigList<DnsNameServer>;
+
+impl FromStr for DnsNameServerList {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let dns_list = s
+            .split(',')
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+            .map(DnsNameServer::from_str)
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(DnsNameServerList::from(dns_list))
+    }
+}
+
+pub fn deserialize_dns_name_server_list<'de, D>(deserializer: D) -> Result<DnsNameServerList, D::Error>
+where D: Deserializer<'de> {
+    struct DnsNameServerVisitor;
+
+    impl<'de> Visitor<'de> for DnsNameServerVisitor {
+        type Value = DnsNameServerList;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("a valid DNS name server list string or sequence")
+        }
+
+        fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+        where E: de::Error {
+            DnsNameServerList::from_str(value).map_err(de::Error::custom)
+        }
+
+        fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+        where A: de::SeqAccess<'de> {
+            let mut dns_list = Vec::new();
+            while let Some(value) = seq.next_element::<String>()? {
+                let dns_name_server = DnsNameServer::from_str(&value).map_err(de::Error::custom)?;
+                dns_list.push(dns_name_server);
+            }
+            Ok(DnsNameServerList::from(dns_list))
+        }
+    }
+
+    deserializer.deserialize_any(DnsNameServerVisitor)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{str::FromStr, vec};
+
+    use config::Config;
+    use serde::Deserialize;
+
+    use crate::{
+        configuration::{dns_name_server_list::deserialize_dns_name_server_list, DnsNameServerList},
+        DnsNameServer,
+    };
+
+    #[derive(Deserialize, Debug)]
+    struct Test {
+        #[serde(deserialize_with = "deserialize_dns_name_server_list")]
+        something: DnsNameServerList,
+    }
+
+    #[test]
+    fn with_capacity_test() {
+        let new_str_lst = DnsNameServerList::with_capacity(3);
+        assert_eq!(new_str_lst.into_vec().capacity(), 3);
+    }
+
+    #[test]
+    fn default_test() {
+        let dns_list = DnsNameServerList::default();
+        assert_eq!(dns_list.into_vec(), vec![]);
+    }
+
+    #[test]
+    fn from_vec_string_list() {
+        let vec_dns_list = vec![
+            DnsNameServer::from_str("127.0.0.1:8080/my_dns").unwrap(),
+            DnsNameServer::from_str("system").unwrap(),
+            DnsNameServer::from_str("1.1.1.1:853/cloudflare-dns.com").unwrap(),
+        ];
+        let dns_list = DnsNameServerList::from(vec_dns_list);
+        assert_eq!(dns_list.into_vec(), vec![
+            DnsNameServer::from_str("127.0.0.1:8080/my_dns").unwrap(),
+            DnsNameServer::from_str("system").unwrap(),
+            DnsNameServer::from_str("1.1.1.1:853/cloudflare-dns.com").unwrap(),
+        ]);
+    }
+
+    #[test]
+    fn as_ref_dns_list() {
+        let vec_dns_list = vec![DnsNameServer::from_str("127.0.0.1:8080/my_dns").unwrap()];
+        let vec_as_ref: &[DnsNameServer] = vec_dns_list.as_ref();
+        let dns_list = DnsNameServerList::from(vec![DnsNameServer::from_str("127.0.0.1:8080/my_dns").unwrap()]);
+        assert_eq!(dns_list.as_ref(), vec_as_ref);
+    }
+
+    #[test]
+    fn into_iter_dns_list() {
+        let vec_dns_list = vec![
+            DnsNameServer::from_str("127.0.0.1:8080/my_dns").unwrap(),
+            DnsNameServer::from_str("system").unwrap(),
+            DnsNameServer::from_str("1.1.1.1:853/cloudflare-dns.com").unwrap(),
+        ];
+        let dns_list = DnsNameServerList::from(vec_dns_list);
+        let mut res_iter = dns_list.into_iter();
+
+        assert_eq!(
+            Some(DnsNameServer::from_str("127.0.0.1:8080/my_dns").unwrap()),
+            res_iter.next()
+        );
+        assert_eq!(Some(DnsNameServer::from_str("system").unwrap()), res_iter.next());
+        assert_eq!(
+            Some(DnsNameServer::from_str("1.1.1.1:853/cloudflare-dns.com").unwrap()),
+            res_iter.next()
+        );
+        assert_eq!(None, res_iter.next());
+    }
+
+    #[test]
+    fn it_deserializes_from_toml() {
+        let config_str = r#"" 127.0.0.1:8080/my_dns", 'SYSTEM', 1.1.1.1:853/cloudflare-dns.COM ""#;
+        DnsNameServerList::from_str(config_str).unwrap();
+
+        let config_str = r#"something = ["127.0.0.1:8080/my_dns", "system", "1.1.1.1:853/cloudflare-dns.com"]"#;
+        let test = toml::from_str::<Test>(config_str).unwrap();
+        assert_eq!(test.something.into_vec(), vec![
+            DnsNameServer::from_str("127.0.0.1:8080/my_dns").unwrap(),
+            DnsNameServer::from_str("system").unwrap(),
+            DnsNameServer::from_str("1.1.1.1:853/cloudflare-dns.com").unwrap(),
+        ]);
+    }
+
+    #[test]
+    fn it_returns_error() {
+        let config_str = r#"something = ["Not dns","system","1.1.1.1:853/cloudflare-dns.com"]"#;
+        assert!(toml::from_str::<Test>(config_str).is_err());
+    }
+
+    #[test]
+    fn it_deserializes_from_config_comma_delimited() {
+        let config = Config::builder()
+            .set_override(
+                "something",
+                "127.0.0.1:8080/my_dns, system, 1.1.1.1:853/cloudflare-dns.com,",
+            )
+            .unwrap()
+            .build()
+            .unwrap();
+        let test = config.try_deserialize::<Test>().unwrap();
+        assert_eq!(test.something.into_vec(), vec![
+            DnsNameServer::from_str("127.0.0.1:8080/my_dns").unwrap(),
+            DnsNameServer::from_str("system").unwrap(),
+            DnsNameServer::from_str("1.1.1.1:853/cloudflare-dns.com").unwrap(),
+        ]);
+    }
+}

--- a/common/src/configuration/dns_name_server_list.rs
+++ b/common/src/configuration/dns_name_server_list.rs
@@ -86,7 +86,7 @@ mod tests {
 
     #[derive(Deserialize, Debug)]
     struct Test {
-        #[serde(deserialize_with = "deserialize_dns_name_server_list")]
+        #[serde(default, deserialize_with = "deserialize_dns_name_server_list")]
         something: DnsNameServerList,
     }
 
@@ -149,8 +149,13 @@ mod tests {
 
     #[test]
     fn it_deserializes_from_toml() {
-        let config_str = r#"" 127.0.0.1:8080/my_dns", 'SYSTEM', 1.1.1.1:853/cloudflare-dns.COM ""#;
-        DnsNameServerList::from_str(config_str).unwrap();
+        let config_str = r#"#"#;
+        let test = toml::from_str::<Test>(config_str).unwrap();
+        assert_eq!(test.something.into_vec(), vec![]);
+
+        let config_str = r#"something = []"#;
+        let test = toml::from_str::<Test>(config_str).unwrap();
+        assert_eq!(test.something.into_vec(), vec![]);
 
         let config_str = r#"something = ["127.0.0.1:8080/my_dns", "system", "1.1.1.1:853/cloudflare-dns.com"]"#;
         let test = toml::from_str::<Test>(config_str).unwrap();

--- a/common/src/configuration/mod.rs
+++ b/common/src/configuration/mod.rs
@@ -44,15 +44,18 @@ mod network;
 pub use network::Network;
 mod common_config;
 mod config_list;
+mod dns_name_server_list;
 mod multiaddr_list;
 pub mod name_server;
 pub mod serializers;
 mod string_list;
 pub mod utils;
+
 use std::{iter::FromIterator, net::SocketAddr};
 
 pub use common_config::CommonConfig;
 pub use config_list::ConfigList;
+pub use dns_name_server_list::{deserialize_dns_name_server_list, DnsNameServerList};
 use multiaddr::{Error, Multiaddr, Protocol};
 pub use multiaddr_list::MultiaddrList;
 pub use string_list::StringList;

--- a/integration_tests/src/ffi/ffi_import.rs
+++ b/integration_tests/src/ffi/ffi_import.rs
@@ -389,8 +389,9 @@ extern "C" {
         seed_passphrase: *const c_char,
         seed_words: *const TariSeedWords,
         network_str: *const c_char,
-        peer_seed_str: *const c_char,
-        dns_sec: bool,
+        dns_seeds_str: *const c_char,
+        dns_seed_name_servers_str: *const c_char,
+        use_dns_sec: bool,
         callback_received_transaction: unsafe extern "C" fn(context: *mut c_void, *mut TariPendingInboundTransaction),
         callback_received_transaction_reply: unsafe extern "C" fn(context: *mut c_void, *mut TariCompletedTransaction),
         callback_received_finalized_transaction: unsafe extern "C" fn(

--- a/integration_tests/src/ffi/wallet.rs
+++ b/integration_tests/src/ffi/wallet.rs
@@ -211,6 +211,7 @@ impl Wallet {
                 seed_words_ptr,
                 CString::new("localnet").unwrap().into_raw(),
                 CString::new("").unwrap().into_raw(),
+                ptr::null(),
                 false,
                 callback_received_transaction,
                 callback_received_transaction_reply,


### PR DESCRIPTION
Description
---
Added DNS resiliency to the DNS resolver. The config setting now accepts a list of DNS servers, including system, and will try them one after the other in case of failure to connect.

Motivation and Context
---
The DNS connection using system did not work on iPhone.

How Has This Been Tested?
---
System-level testing.

What process can a PR reviewer use to test or verify this change?
---
Code review.

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [ ] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [X] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
BREAKING CHANGE: Wallet FFI method `wallet_create` has one additional parameter, which can be set as null ptr.
