### PR TITLE
feat: change ffi wallet recovery interface

### DIFF
--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -8901,7 +8901,7 @@ pub unsafe extern "C" fn wallet_is_recovery_in_progress(wallet: *mut TariWallet,
 ///
 /// ## Arguments
 /// `wallet` - The TariWallet pointer.
-/// `base_node_public_key` - The TariPublicKey pointer of the Base Node the recovery process will use
+/// `base_node_public_keys` - An optional TariPublicKeys pointer of the Base Nodes the recovery process must use
 /// `recovery_progress_callback` - The callback function pointer that will be used to asynchronously communicate
 /// progress to the client. The first argument of the callback is an event enum encoded as a u8 as follows:
 /// ```
@@ -8968,14 +8968,30 @@ pub unsafe extern "C" fn wallet_start_recovery(
         ptr::swap(error_out, &mut error as *mut c_int);
         return false;
     }
-    if base_node_public_keys.is_null() {
-        error = LibWalletError::from(InterfaceError::NullError("base_node_public_keys".to_string())).code;
-        ptr::swap(error_out, &mut error as *mut c_int);
-        return false;
-    }
 
     let shutdown_signal = (*wallet).shutdown.to_signal();
-    let peer_public_keys = (*base_node_public_keys).0.clone();
+    let peer_public_keys = if base_node_public_keys.is_null() {
+        let peer_manager = (*wallet).wallet.comms.peer_manager();
+        let query = PeerQuery::new().select_where(|p| p.is_seed());
+        #[allow(clippy::blocks_in_conditions)]
+        match (*wallet).runtime.block_on(async move {
+            let peers = peer_manager.perform_query(query).await?;
+            let mut public_keys = Vec::with_capacity(peers.len());
+            for peer in peers {
+                public_keys.push(peer.public_key);
+            }
+            Result::<_, WalletError>::Ok(public_keys)
+        }) {
+            Ok(public_keys) => public_keys,
+            Err(e) => {
+                error = LibWalletError::from(InterfaceError::NullError(format!("{}", e))).code;
+                ptr::swap(error_out, &mut error as *mut c_int);
+                return false;
+            },
+        }
+    } else {
+        (*base_node_public_keys).0.clone()
+    };
     let mut recovery_task_builder = UtxoScannerService::<WalletSqliteDatabase, WalletConnectivityHandle>::builder();
 
     if !recovered_output_message.is_null() {

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -4021,7 +4021,7 @@ bool wallet_is_recovery_in_progress(struct TariWallet *wallet,
  * None
  */
 bool wallet_start_recovery(struct TariWallet *wallet,
-                           TariPublicKey *base_node_public_key,
+                           struct TariPublicKeys *base_node_public_keys,
                            void (*recovery_progress_callback)(void *context,
                                                               uint8_t,
                                                               uint64_t,

--- a/integration_tests/src/ffi/ffi_import.rs
+++ b/integration_tests/src/ffi/ffi_import.rs
@@ -579,7 +579,7 @@ extern "C" {
     pub fn wallet_is_recovery_in_progress(wallet: *mut TariWallet, error_out: *mut c_int) -> bool;
     pub fn wallet_start_recovery(
         wallet: *mut TariWallet,
-        base_node_public_key: *mut TariPublicKey,
+        base_node_public_keys: *mut TariPublicKeys,
         recovery_progress_callback: unsafe extern "C" fn(context: *mut c_void, u8, u64, u64),
         recovered_output_message: *const c_char,
         error_out: *mut c_int,


### PR DESCRIPTION
Description
---
Changed the FFI wallet recovery interface to accept a list of base node peers for recovery instead of only a single peer. This will enable the mobile wallet to pass all seed peers to the recovery process instead of only a single peer.

Motivation and Context
---
The recovery process for the mobile wallet should work in the same way that the console wallet does.

How Has This Been Tested?
---
Must be tested with system-level tests with the mobile wallet.

What process can a PR reviewer use to test or verify this change?
---
Code review.

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [ ] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [X] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
BREAKING CHANGE: Wallet FFI method `pub unsafe extern "C" fn wallet_start_recovery(` had an interface update.
