### PR TITLE
feat: close rpc connections when not in use - without close on dial requests

### DIFF
--- a/applications/minotari_merge_mining_proxy/src/monero_fail.rs
+++ b/applications/minotari_merge_mining_proxy/src/monero_fail.rs
@@ -478,7 +478,7 @@ mod test {
             }
             println!("{}: {:?}", i, entry);
         }
-        assert_eq!(ordered_entries.len(), 2);
+        assert!(ordered_entries.len() <= 2);
     }
 
     #[tokio::test]

--- a/applications/minotari_node/src/bootstrap.rs
+++ b/applications/minotari_node/src/bootstrap.rs
@@ -230,6 +230,7 @@ where B: BlockchainBackend + 'static
         let rpc_server = RpcServer::builder()
             .with_maximum_simultaneous_sessions(config.rpc_max_simultaneous_sessions)
             .with_maximum_sessions_per_client(config.rpc_max_sessions_per_peer)
+            .with_cull_oldest_peer_rpc_connection_on_full(config.cull_oldest_peer_rpc_connection_on_full)
             .finish();
 
         // Add your RPC services here ‍🏴‍☠️️☮️🌊

--- a/base_layer/contacts/tests/contacts_service.rs
+++ b/base_layer/contacts/tests/contacts_service.rs
@@ -96,6 +96,7 @@ pub fn setup_contacts_service<T: ContactsBackend + 'static>(
         rpc_max_simultaneous_sessions: 0,
         rpc_max_sessions_per_peer: 0,
         listener_self_liveness_check_interval: None,
+        cull_oldest_peer_rpc_connection_on_full: true,
     };
     let peer_message_subscription_factory = Arc::new(subscription_factory);
     let shutdown = Shutdown::new();

--- a/base_layer/core/src/consensus/consensus_constants.rs
+++ b/base_layer/core/src/consensus/consensus_constants.rs
@@ -656,7 +656,7 @@ impl ConsensusConstants {
 
         let consensus_constants = vec![con_1, con_2];
         #[cfg(any(test, debug_assertions))]
-        assert_hybrid_pow_constants(&consensus_constants, &[120], &[50], &[50]);
+        assert_hybrid_pow_constants(&consensus_constants, &[120, 120], &[50, 50], &[50, 50]);
         consensus_constants
     }
 

--- a/base_layer/core/tests/helpers/nodes.rs
+++ b/base_layer/core/tests/helpers/nodes.rs
@@ -383,6 +383,7 @@ async fn setup_base_node_services(
     let rpc_server = RpcServer::builder()
         .with_maximum_simultaneous_sessions(p2p_config.rpc_max_simultaneous_sessions)
         .with_maximum_sessions_per_client(p2p_config.rpc_max_sessions_per_peer)
+        .with_cull_oldest_peer_rpc_connection_on_full(p2p_config.cull_oldest_peer_rpc_connection_on_full)
         .finish();
     let rpc_server = rpc_server.add_service(base_node::create_base_node_sync_rpc_service(
         blockchain_db.clone().into(),

--- a/base_layer/p2p/src/config.rs
+++ b/base_layer/p2p/src/config.rs
@@ -139,6 +139,9 @@ pub struct P2pConfig {
     /// The maximum allowed RPC sessions per peer.
     /// Default: 10
     pub rpc_max_sessions_per_peer: usize,
+    /// Cull the oldest peer RPC connection when the maximum number of sessions is reached.
+    /// Default: true
+    pub cull_oldest_peer_rpc_connection_on_full: bool,
 }
 
 impl Default for P2pConfig {
@@ -163,6 +166,7 @@ impl Default for P2pConfig {
             auxiliary_tcp_listener_address: None,
             rpc_max_simultaneous_sessions: 100,
             rpc_max_sessions_per_peer: 10,
+            cull_oldest_peer_rpc_connection_on_full: true,
         }
     }
 }

--- a/base_layer/p2p/src/config.rs
+++ b/base_layer/p2p/src/config.rs
@@ -139,8 +139,9 @@ pub struct P2pConfig {
     /// The maximum allowed RPC sessions per peer.
     /// Default: 10
     pub rpc_max_sessions_per_peer: usize,
-    /// Cull the oldest peer RPC connection when the maximum number of sessions is reached.
-    /// Default: true
+    /// If true, and the maximum per peer RPC sessions is reached, the RPC server will close an old session and replace
+    /// it with a new session. If false, the RPC server will reject the new session and preserve the older session.
+    /// (default value = true).
     pub cull_oldest_peer_rpc_connection_on_full: bool,
 }
 

--- a/base_layer/wallet/src/base_node_service/monitor.rs
+++ b/base_layer/wallet/src/base_node_service/monitor.rs
@@ -106,6 +106,9 @@ where
                         latency: None,
                     })
                     .await;
+                    if let Some(node_id) = self.wallet_connectivity.get_current_base_node_peer_node_id() {
+                        self.wallet_connectivity.disconnect_base_node(node_id).await;
+                    }
                     continue;
                 },
                 Err(e @ BaseNodeMonitorError::InvalidBaseNodeResponse(_)) |

--- a/base_layer/wallet/src/connectivity_service/handle.rs
+++ b/base_layer/wallet/src/connectivity_service/handle.rs
@@ -37,6 +37,7 @@ use crate::{
 pub enum WalletConnectivityRequest {
     ObtainBaseNodeWalletRpcClient(oneshot::Sender<RpcClientLease<BaseNodeWalletRpcClient>>),
     ObtainBaseNodeSyncRpcClient(oneshot::Sender<RpcClientLease<BaseNodeSyncRpcClient>>),
+    DisconnectBaseNode(NodeId),
 }
 
 #[derive(Clone)]
@@ -116,6 +117,13 @@ impl WalletConnectivityInterface for WalletConnectivityHandle {
             .ok()?;
 
         reply_rx.await.ok()
+    }
+
+    async fn disconnect_base_node(&mut self, node_id: NodeId) {
+        let _unused = self
+            .sender
+            .send(WalletConnectivityRequest::DisconnectBaseNode(node_id))
+            .await;
     }
 
     fn get_connectivity_status(&mut self) -> OnlineStatus {

--- a/base_layer/wallet/src/connectivity_service/interface.rs
+++ b/base_layer/wallet/src/connectivity_service/interface.rs
@@ -64,6 +64,8 @@ pub trait WalletConnectivityInterface: Clone + Send + Sync + 'static {
     /// BaseNodeSyncRpcClient RPC session.
     async fn obtain_base_node_sync_rpc_client(&mut self) -> Option<RpcClientLease<BaseNodeSyncRpcClient>>;
 
+    async fn disconnect_base_node(&mut self, node_id: NodeId);
+
     fn get_connectivity_status(&mut self) -> OnlineStatus;
 
     fn get_connectivity_status_watch(&self) -> watch::Receiver<OnlineStatus>;

--- a/base_layer/wallet/src/connectivity_service/mock.rs
+++ b/base_layer/wallet/src/connectivity_service/mock.rs
@@ -116,6 +116,10 @@ impl WalletConnectivityInterface for WalletConnectivityMock {
         borrow.as_ref().cloned()
     }
 
+    async fn disconnect_base_node(&mut self, _node_id: NodeId) {
+        self.send_shutdown();
+    }
+
     fn get_connectivity_status(&mut self) -> OnlineStatus {
         *self.online_status_watch.borrow()
     }

--- a/base_layer/wallet/src/connectivity_service/service.rs
+++ b/base_layer/wallet/src/connectivity_service/service.rs
@@ -64,6 +64,7 @@ pub struct WalletConnectivityService {
     pools: HashMap<NodeId, ClientPoolContainer>,
     online_status_watch: Watch<OnlineStatus>,
     pending_requests: Vec<ReplyOneshot>,
+    busy_acquiring_connection_watch: Watch<bool>,
 }
 
 struct ClientPoolContainer {
@@ -79,6 +80,7 @@ impl WalletConnectivityService {
         online_status_watch: Watch<OnlineStatus>,
         connectivity: ConnectivityRequester,
     ) -> Self {
+        let busy_acquiring_connection_watch = Watch::new(false);
         Self {
             config,
             request_receiver,
@@ -88,6 +90,7 @@ impl WalletConnectivityService {
             pools: HashMap::new(),
             pending_requests: Vec::new(),
             online_status_watch,
+            busy_acquiring_connection_watch,
         }
     }
 
@@ -161,13 +164,20 @@ impl WalletConnectivityService {
     }
 
     async fn handle_request(&mut self, request: WalletConnectivityRequest) {
-        use WalletConnectivityRequest::{ObtainBaseNodeSyncRpcClient, ObtainBaseNodeWalletRpcClient};
+        use WalletConnectivityRequest::{
+            DisconnectBaseNode,
+            ObtainBaseNodeSyncRpcClient,
+            ObtainBaseNodeWalletRpcClient,
+        };
         match request {
             ObtainBaseNodeWalletRpcClient(reply) => {
                 self.handle_pool_request(reply.into()).await;
             },
             ObtainBaseNodeSyncRpcClient(reply) => {
                 self.handle_pool_request(reply.into()).await;
+            },
+            DisconnectBaseNode(node_id) => {
+                self.disconnect_base_node(node_id).await;
             },
         }
     }
@@ -184,6 +194,7 @@ impl WalletConnectivityService {
         &mut self,
         reply: oneshot::Sender<RpcClientLease<BaseNodeWalletRpcClient>>,
     ) {
+        self.wait_for_base_node_connection("wallet").await;
         let node_id = if let Some(val) = self.current_base_node() {
             val
         } else {
@@ -195,18 +206,17 @@ impl WalletConnectivityService {
         match self.pools.get(&node_id) {
             Some(pools) => match pools.base_node_wallet_rpc_client.get().await {
                 Ok(client) => {
+                    debug!(target: LOG_TARGET, "Obtained pool RPC 'wallet' connection to base node '{}'", node_id);
                     let _result = reply.send(client);
                 },
                 Err(e) => {
                     warn!(
                         target: LOG_TARGET,
-                        "Base node '{}' wallet RPC pool connection failed ({}). Reconnecting...",
+                        "Base node '{}' pool RPC 'wallet' connection failed ({}). Reconnecting...",
                         node_id,
                         e
                     );
-                    if let Some(node_id) = self.current_base_node() {
-                        self.disconnect_base_node(node_id).await;
-                    };
+                    self.disconnect_base_node(node_id).await;
                     self.pending_requests.push(reply.into());
                 },
             },
@@ -226,6 +236,7 @@ impl WalletConnectivityService {
         &mut self,
         reply: oneshot::Sender<RpcClientLease<BaseNodeSyncRpcClient>>,
     ) {
+        self.wait_for_base_node_connection("sync").await;
         let node_id = if let Some(val) = self.current_base_node() {
             val
         } else {
@@ -237,18 +248,17 @@ impl WalletConnectivityService {
         match self.pools.get(&node_id) {
             Some(pools) => match pools.base_node_sync_rpc_client.get().await {
                 Ok(client) => {
+                    debug!(target: LOG_TARGET, "Obtained pool RPC 'sync' connection to base node '{}'", node_id);
                     let _result = reply.send(client);
                 },
                 Err(e) => {
                     warn!(
                         target: LOG_TARGET,
-                        "Base node '{}' sync RPC pool connection failed ({}). Reconnecting...",
+                        "Base node '{}' pool RPC 'sync' connection failed ({}). Reconnecting...",
                         node_id,
                         e
                     );
-                    if let Some(node_id) = self.current_base_node() {
-                        self.disconnect_base_node(node_id).await;
-                    };
+                    self.disconnect_base_node(node_id).await;
                     self.pending_requests.push(reply.into());
                 },
             },
@@ -291,11 +301,16 @@ impl WalletConnectivityService {
         } else {
             return;
         };
+        self.set_busy_acquiring_connection(true);
         loop {
             let node_id = if let Some(time) = peer_manager.time_since_last_connection_attempt() {
                 if time < Duration::from_secs(COOL_OFF_PERIOD) {
                     if peer_manager.get_current_peer().node_id == peer_manager.get_next_peer().node_id {
                         // If we only have one peer in the list, wait a bit before retrying
+                        debug!(target: LOG_TARGET,
+                            "Retrying after {}s ...",
+                            Duration::from_secs(CONNECTIVITY_WAIT).as_secs()
+                        );
                         time::sleep(Duration::from_secs(CONNECTIVITY_WAIT)).await;
                     }
                     peer_manager.get_current_peer().node_id
@@ -321,18 +336,19 @@ impl WalletConnectivityService {
                             target: LOG_TARGET,
                             "The peer list has changed while connecting, aborting connection attempt."
                         );
+                        self.set_busy_acquiring_connection(false);
                         self.set_online_status(OnlineStatus::Offline);
                         break;
                     }
                     self.base_node_watch.send(Some(peer_manager.clone()));
-                    if let Err(e) = self.notify_pending_requests().await {
-                        warn!(target: LOG_TARGET, "Error notifying pending RPC requests: {}", e);
+                    self.set_busy_acquiring_connection(false);
+                    if let Ok(true) = self.notify_pending_requests().await {
+                        self.set_online_status(OnlineStatus::Online);
+                        debug!(
+                            target: LOG_TARGET,
+                            "Wallet is ONLINE and connected to base node '{}'", node_id
+                        );
                     }
-                    self.set_online_status(OnlineStatus::Online);
-                    debug!(
-                        target: LOG_TARGET,
-                        "Wallet is ONLINE and connected to base node '{}'", node_id
-                    );
                     break;
                 },
                 Ok(false) => {
@@ -340,21 +356,15 @@ impl WalletConnectivityService {
                         target: LOG_TARGET,
                         "The peer has changed while connecting. Attempting to connect to new base node."
                     );
+                    self.disconnect_base_node(node_id).await;
                 },
                 Err(WalletConnectivityError::ConnectivityError(ConnectivityError::DialCancelled)) => {
-                    debug!(
-                        target: LOG_TARGET,
-                        "Dial was cancelled. Retrying after {}s ...",
-                        Duration::from_secs(CONNECTIVITY_WAIT).as_secs()
-                    );
-                    time::sleep(Duration::from_secs(CONNECTIVITY_WAIT)).await;
+                    debug!(target: LOG_TARGET, "Dial was cancelled.");
+                    self.disconnect_base_node(node_id).await;
                 },
                 Err(e) => {
                     warn!(target: LOG_TARGET, "{}", e);
-                    if self.current_base_node().as_ref() == Some(&node_id) {
-                        self.disconnect_base_node(node_id).await;
-                        time::sleep(Duration::from_secs(CONNECTIVITY_WAIT)).await;
-                    }
+                    self.disconnect_base_node(node_id).await;
                 },
             }
             if self.peer_list_change_detected(&peer_manager) {
@@ -362,6 +372,7 @@ impl WalletConnectivityService {
                     target: LOG_TARGET,
                     "The peer list has changed while connecting, aborting connection attempt."
                 );
+                self.set_busy_acquiring_connection(false);
                 self.set_online_status(OnlineStatus::Offline);
                 break;
             }
@@ -391,6 +402,31 @@ impl WalletConnectivityService {
         self.online_status_watch.send(status);
     }
 
+    fn set_busy_acquiring_connection(&mut self, value: bool) {
+        self.busy_acquiring_connection_watch.send(value);
+        trace!(target: LOG_TARGET, "Busy acquiring base node connection: '{}'", value);
+    }
+
+    fn busy_acquiring_connection(&self) -> bool {
+        *self.busy_acquiring_connection_watch.borrow()
+    }
+
+    async fn wait_for_base_node_connection(&mut self, rpc_service: &str) {
+        loop {
+            if self.busy_acquiring_connection() {
+                trace!(
+                    target: LOG_TARGET,
+                    "Busy acquiring base node connection, obtaining the '{}' RPC client will wait for {} s",
+                    rpc_service,
+                    CONNECTIVITY_WAIT
+                );
+                tokio::time::sleep(Duration::from_secs(CONNECTIVITY_WAIT)).await;
+            } else {
+                break;
+            }
+        }
+    }
+
     async fn try_setup_rpc_pool(&mut self, peer_node_id: NodeId) -> Result<bool, WalletConnectivityError> {
         let conn = match self.try_dial_peer(peer_node_id.clone()).await? {
             Some(c) => c,
@@ -401,7 +437,7 @@ impl WalletConnectivityService {
         };
         debug!(
             target: LOG_TARGET,
-            "Successfully established peer connection to base node '{}'",
+            "Established peer connection to base node '{}'",
             conn.peer_node_id()
         );
         self.pools.insert(peer_node_id.clone(), ClientPoolContainer {
@@ -409,7 +445,7 @@ impl WalletConnectivityService {
             base_node_wallet_rpc_client: conn
                 .create_rpc_client_pool(self.config.base_node_rpc_pool_size, Default::default()),
         });
-        debug!(target: LOG_TARGET, "Successfully established RPC connection to base node '{}'", peer_node_id);
+        trace!(target: LOG_TARGET, "Created RPC pools for '{}'", peer_node_id);
         Ok(true)
     }
 
@@ -426,16 +462,24 @@ impl WalletConnectivityService {
         }
     }
 
-    async fn notify_pending_requests(&mut self) -> Result<(), WalletConnectivityError> {
+    async fn notify_pending_requests(&mut self) -> Result<bool, WalletConnectivityError> {
         let current_pending = mem::take(&mut self.pending_requests);
+        let mut count = 1;
+        let current_pending_len = current_pending.len();
         for reply in current_pending {
             if reply.is_canceled() {
                 continue;
             }
-
+            trace!(target: LOG_TARGET, "Handle {} of {} pending RPC pool requests", count, current_pending_len);
             self.handle_pool_request(reply).await;
+            count += 1;
         }
-        Ok(())
+        if self.pending_requests.is_empty() {
+            Ok(true)
+        } else {
+            warn!(target: LOG_TARGET, "{} of {} pending RPC pool requests not handled", count, current_pending_len);
+            Ok(false)
+        }
     }
 }
 

--- a/base_layer/wallet/src/connectivity_service/service.rs
+++ b/base_layer/wallet/src/connectivity_service/service.rs
@@ -45,7 +45,6 @@ use crate::{
 
 const LOG_TARGET: &str = "wallet::connectivity";
 pub(crate) const CONNECTIVITY_WAIT: u64 = 5;
-pub(crate) const COOL_OFF_PERIOD: u64 = 60;
 
 /// Connection status of the Base Node
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -299,20 +298,17 @@ impl WalletConnectivityService {
             return;
         };
         loop {
-            let node_id = if let Some(time) = peer_manager.time_since_last_connection_attempt() {
-                if time < Duration::from_secs(COOL_OFF_PERIOD) {
-                    if peer_manager.get_current_peer().node_id == peer_manager.get_next_peer().node_id {
-                        // If we only have one peer in the list, wait a bit before retrying
-                        debug!(target: LOG_TARGET,
-                            "Retrying after {}s ...",
-                            Duration::from_secs(CONNECTIVITY_WAIT).as_secs()
-                        );
-                        time::sleep(Duration::from_secs(CONNECTIVITY_WAIT)).await;
-                    }
-                    peer_manager.get_current_peer().node_id
-                } else {
-                    peer_manager.get_current_peer().node_id
+            let node_id = if let Some(_time) = peer_manager.time_since_last_connection_attempt() {
+                if peer_manager.get_current_peer().node_id == peer_manager.get_next_peer().node_id {
+                    // If we only have one peer in the list, wait a bit before retrying
+                    debug!(target: LOG_TARGET,
+                        "Retrying after {}s ...",
+                        Duration::from_secs(CONNECTIVITY_WAIT).as_secs()
+                    );
+                    time::sleep(Duration::from_secs(CONNECTIVITY_WAIT)).await;
                 }
+                // If 'peer_manager.get_next_peer()' is called, 'current_peer' is advanced to the next peer
+                peer_manager.get_current_peer().node_id
             } else {
                 peer_manager.get_current_peer().node_id
             };
@@ -432,15 +428,15 @@ impl WalletConnectivityService {
 
     async fn notify_pending_requests(&mut self) -> Result<bool, WalletConnectivityError> {
         let current_pending = mem::take(&mut self.pending_requests);
-        let mut count = 1;
+        let mut count = 0;
         let current_pending_len = current_pending.len();
         for reply in current_pending {
             if reply.is_canceled() {
                 continue;
             }
+            count += 1;
             trace!(target: LOG_TARGET, "Handle {} of {} pending RPC pool requests", count, current_pending_len);
             self.handle_pool_request(reply).await;
-            count += 1;
         }
         if self.pending_requests.is_empty() {
             Ok(true)

--- a/base_layer/wallet/src/connectivity_service/service.rs
+++ b/base_layer/wallet/src/connectivity_service/service.rs
@@ -287,6 +287,8 @@ impl WalletConnectivityService {
                 Err(e) => error!(target: LOG_TARGET, "Failed to disconnect base node: {}", e),
             }
             self.pools.remove(&node_id);
+            // We want to ensure any active RPC clients are dropped when this connection (a clone) is dropped
+            connection.set_force_disconnect_rpc_clients_when_clone_drops();
         };
     }
 

--- a/base_layer/wallet/src/connectivity_service/service.rs
+++ b/base_layer/wallet/src/connectivity_service/service.rs
@@ -64,7 +64,6 @@ pub struct WalletConnectivityService {
     pools: HashMap<NodeId, ClientPoolContainer>,
     online_status_watch: Watch<OnlineStatus>,
     pending_requests: Vec<ReplyOneshot>,
-    busy_acquiring_connection_watch: Watch<bool>,
 }
 
 struct ClientPoolContainer {
@@ -80,7 +79,6 @@ impl WalletConnectivityService {
         online_status_watch: Watch<OnlineStatus>,
         connectivity: ConnectivityRequester,
     ) -> Self {
-        let busy_acquiring_connection_watch = Watch::new(false);
         Self {
             config,
             request_receiver,
@@ -90,7 +88,6 @@ impl WalletConnectivityService {
             pools: HashMap::new(),
             pending_requests: Vec::new(),
             online_status_watch,
-            busy_acquiring_connection_watch,
         }
     }
 
@@ -194,7 +191,6 @@ impl WalletConnectivityService {
         &mut self,
         reply: oneshot::Sender<RpcClientLease<BaseNodeWalletRpcClient>>,
     ) {
-        self.wait_for_base_node_connection("wallet").await;
         let node_id = if let Some(val) = self.current_base_node() {
             val
         } else {
@@ -236,7 +232,6 @@ impl WalletConnectivityService {
         &mut self,
         reply: oneshot::Sender<RpcClientLease<BaseNodeSyncRpcClient>>,
     ) {
-        self.wait_for_base_node_connection("sync").await;
         let node_id = if let Some(val) = self.current_base_node() {
             val
         } else {
@@ -301,7 +296,6 @@ impl WalletConnectivityService {
         } else {
             return;
         };
-        self.set_busy_acquiring_connection(true);
         loop {
             let node_id = if let Some(time) = peer_manager.time_since_last_connection_attempt() {
                 if time < Duration::from_secs(COOL_OFF_PERIOD) {
@@ -336,12 +330,10 @@ impl WalletConnectivityService {
                             target: LOG_TARGET,
                             "The peer list has changed while connecting, aborting connection attempt."
                         );
-                        self.set_busy_acquiring_connection(false);
                         self.set_online_status(OnlineStatus::Offline);
                         break;
                     }
                     self.base_node_watch.send(Some(peer_manager.clone()));
-                    self.set_busy_acquiring_connection(false);
                     if let Ok(true) = self.notify_pending_requests().await {
                         self.set_online_status(OnlineStatus::Online);
                         debug!(
@@ -372,7 +364,6 @@ impl WalletConnectivityService {
                     target: LOG_TARGET,
                     "The peer list has changed while connecting, aborting connection attempt."
                 );
-                self.set_busy_acquiring_connection(false);
                 self.set_online_status(OnlineStatus::Offline);
                 break;
             }
@@ -400,31 +391,6 @@ impl WalletConnectivityService {
 
     fn set_online_status(&self, status: OnlineStatus) {
         self.online_status_watch.send(status);
-    }
-
-    fn set_busy_acquiring_connection(&mut self, value: bool) {
-        self.busy_acquiring_connection_watch.send(value);
-        trace!(target: LOG_TARGET, "Busy acquiring base node connection: '{}'", value);
-    }
-
-    fn busy_acquiring_connection(&self) -> bool {
-        *self.busy_acquiring_connection_watch.borrow()
-    }
-
-    async fn wait_for_base_node_connection(&mut self, rpc_service: &str) {
-        loop {
-            if self.busy_acquiring_connection() {
-                trace!(
-                    target: LOG_TARGET,
-                    "Busy acquiring base node connection, obtaining the '{}' RPC client will wait for {} s",
-                    rpc_service,
-                    CONNECTIVITY_WAIT
-                );
-                tokio::time::sleep(Duration::from_secs(CONNECTIVITY_WAIT)).await;
-            } else {
-                break;
-            }
-        }
     }
 
     async fn try_setup_rpc_pool(&mut self, peer_node_id: NodeId) -> Result<bool, WalletConnectivityError> {

--- a/base_layer/wallet/src/utxo_scanner_service/utxo_scanner_task.rs
+++ b/base_layer/wallet/src/utxo_scanner_service/utxo_scanner_task.rs
@@ -179,7 +179,7 @@ where
         Ok(())
     }
 
-    async fn connect_to_peer(&mut self, peer: NodeId) -> Result<PeerConnection, UtxoScannerError> {
+    async fn new_connection_to_peer(&mut self, peer: NodeId) -> Result<PeerConnection, UtxoScannerError> {
         debug!(
             target: LOG_TARGET,
             "Attempting UTXO sync with seed peer {} ({})", self.peer_index, peer,
@@ -333,7 +333,7 @@ where
         &mut self,
         peer: &NodeId,
     ) -> Result<RpcClientLease<BaseNodeWalletRpcClient>, UtxoScannerError> {
-        let mut connection = self.connect_to_peer(peer.clone()).await?;
+        let mut connection = self.new_connection_to_peer(peer.clone()).await?;
         let client = connection
             .connect_rpc_using_builder(BaseNodeWalletRpcClient::builder().with_deadline(Duration::from_secs(60)))
             .await?;

--- a/base_layer/wallet/tests/output_manager_service_tests/service.rs
+++ b/base_layer/wallet/tests/output_manager_service_tests/service.rs
@@ -1927,6 +1927,7 @@ async fn test_txo_validation() {
 #[tokio::test]
 #[allow(clippy::too_many_lines)]
 async fn test_txo_revalidation() {
+    // env_logger::init(); // Set `$env:RUST_LOG = "trace"`
     let (connection, _tempdir) = get_temp_sqlite_database_connection();
     let backend = OutputManagerSqliteDatabase::new(connection.clone());
 

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -5452,6 +5452,7 @@ pub unsafe extern "C" fn comms_config_create(
                 rpc_max_simultaneous_sessions: 0,
                 rpc_max_sessions_per_peer: 0,
                 listener_self_liveness_check_interval: None,
+                cull_oldest_peer_rpc_connection_on_full: true,
             };
 
             Box::into_raw(Box::new(config))

--- a/common/config/presets/c_base_node_c.toml
+++ b/common/config/presets/c_base_node_c.toml
@@ -162,7 +162,9 @@ listener_self_liveness_check_interval = 15
 #rpc_max_simultaneous_sessions = 100
 # The maximum comms RPC sessions allowed per peer (default value = 10).
 #rpc_max_sessions_per_peer = 10
-# Cull the oldest peer RPC connection when the maximum number of sessions is reached (default value = true).
+# If true, and the maximum per peer RPC sessions is reached, the RPC server will close an old session and replace it
+# with a new session. If false, the RPC server will reject the new session and preserve the older session.
+# (default value = true).
 #pub cull_oldest_peer_rpc_connection_on_full = true
 
 [base_node.p2p.transport]

--- a/common/config/presets/c_base_node_c.toml
+++ b/common/config/presets/c_base_node_c.toml
@@ -162,6 +162,8 @@ listener_self_liveness_check_interval = 15
 #rpc_max_simultaneous_sessions = 100
 # The maximum comms RPC sessions allowed per peer (default value = 10).
 #rpc_max_sessions_per_peer = 10
+# Cull the oldest peer RPC connection when the maximum number of sessions is reached (default value = true).
+#pub cull_oldest_peer_rpc_connection_on_full = true
 
 [base_node.p2p.transport]
 # -------------- Transport configuration --------------

--- a/common/config/presets/d_console_wallet.toml
+++ b/common/config/presets/d_console_wallet.toml
@@ -209,7 +209,9 @@ event_channel_size = 3500
 # The maximum comms RPC sessions allowed per peer (default value = 10).
 #rpc_max_sessions_per_peer = 10
 #rpc_max_sessions_per_peer = 10
-# Cull the oldest peer RPC connection when the maximum number of sessions is reached (default value = true).
+# If true, and the maximum per peer RPC sessions is reached, the RPC server will close an old session and replace it
+# with a new session. If false, the RPC server will reject the new session and preserve the older session.
+# (default value = true).
 #pub cull_oldest_peer_rpc_connection_on_full = true
 
 [wallet.p2p.transport]

--- a/common/config/presets/d_console_wallet.toml
+++ b/common/config/presets/d_console_wallet.toml
@@ -208,6 +208,9 @@ event_channel_size = 3500
 #rpc_max_simultaneous_sessions = 100
 # The maximum comms RPC sessions allowed per peer (default value = 10).
 #rpc_max_sessions_per_peer = 10
+#rpc_max_sessions_per_peer = 10
+# Cull the oldest peer RPC connection when the maximum number of sessions is reached (default value = true).
+#pub cull_oldest_peer_rpc_connection_on_full = true
 
 [wallet.p2p.transport]
 # -------------- Transport configuration --------------

--- a/comms/core/src/connection_manager/peer_connection.rs
+++ b/comms/core/src/connection_manager/peer_connection.rs
@@ -266,7 +266,7 @@ impl PeerConnection {
         let rpc_client = builder
             .with_protocol_id(protocol)
             .with_node_id(self.peer_node_id.clone())
-            .with_drop_receiver(self.drop_notifier.clone())
+            .with_terminate_signal(self.drop_notifier.to_signal())
             .connect(framed)
             .await?;
         {

--- a/comms/core/src/connection_manager/peer_connection.rs
+++ b/comms/core/src/connection_manager/peer_connection.rs
@@ -26,7 +26,6 @@ use std::{
     sync::{
         atomic::{AtomicBool, AtomicUsize, Ordering},
         Arc,
-        Mutex,
     },
     time::{Duration, Instant},
 };
@@ -140,7 +139,7 @@ pub struct PeerConnection {
     substream_counter: AtomicRefCounter,
     handle_counter: Arc<()>,
     drop_notifier: OneshotTrigger<NodeId>,
-    number_of_rpc_clients: Arc<Mutex<Option<usize>>>,
+    number_of_rpc_clients: Arc<AtomicUsize>,
     force_disconnect_rpc_clients_when_clone_drops: Arc<AtomicBool>,
 }
 
@@ -165,7 +164,7 @@ impl PeerConnection {
             substream_counter,
             handle_counter: Arc::new(()),
             drop_notifier: OneshotTrigger::<NodeId>::new(),
-            number_of_rpc_clients: Arc::new(Mutex::new(None)),
+            number_of_rpc_clients: Arc::new(AtomicUsize::new(0)),
             force_disconnect_rpc_clients_when_clone_drops: Arc::new(Default::default()),
         }
     }
@@ -269,10 +268,7 @@ impl PeerConnection {
             .with_terminate_signal(self.drop_notifier.to_signal())
             .connect(framed)
             .await?;
-        {
-            let mut rpc_clients = self.number_of_rpc_clients.lock().unwrap();
-            *rpc_clients = Some(rpc_clients.unwrap_or_default() + 1);
-        }
+        self.number_of_rpc_clients.fetch_add(1, Ordering::Relaxed);
 
         Ok(rpc_client)
     }
@@ -327,7 +323,7 @@ impl Drop for PeerConnection {
             self.force_disconnect_rpc_clients_when_clone_drops
                 .load(Ordering::Relaxed)
         {
-            let number_of_rpc_clients = self.number_of_rpc_clients.lock().unwrap().unwrap_or(0);
+            let number_of_rpc_clients = self.number_of_rpc_clients.load(Ordering::Relaxed);
             if number_of_rpc_clients > 0 {
                 self.drop_notifier.broadcast(self.peer_node_id.clone());
                 trace!(

--- a/comms/core/src/connection_manager/peer_connection.rs
+++ b/comms/core/src/connection_manager/peer_connection.rs
@@ -24,8 +24,9 @@ use std::{
     fmt,
     future::Future,
     sync::{
-        atomic::{AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
         Arc,
+        Mutex,
     },
     time::{Duration, Instant},
 };
@@ -33,6 +34,7 @@ use std::{
 use futures::{future::BoxFuture, stream::FuturesUnordered};
 use log::*;
 use multiaddr::Multiaddr;
+use tari_shutdown::oneshot_trigger::OneshotTrigger;
 use tokio::{
     sync::{mpsc, oneshot},
     time,
@@ -137,6 +139,9 @@ pub struct PeerConnection {
     started_at: Instant,
     substream_counter: AtomicRefCounter,
     handle_counter: Arc<()>,
+    drop_notifier: OneshotTrigger<NodeId>,
+    number_of_rpc_clients: Arc<Mutex<Option<usize>>>,
+    force_disconnect_rpc_clients_when_clone_drops: Arc<AtomicBool>,
 }
 
 impl PeerConnection {
@@ -159,6 +164,9 @@ impl PeerConnection {
             started_at: Instant::now(),
             substream_counter,
             handle_counter: Arc::new(()),
+            drop_notifier: OneshotTrigger::<NodeId>::new(),
+            number_of_rpc_clients: Arc::new(Mutex::new(None)),
+            force_disconnect_rpc_clients_when_clone_drops: Arc::new(Default::default()),
         }
     }
 
@@ -254,11 +262,19 @@ impl PeerConnection {
             self.peer_node_id
         );
         let framed = self.open_framed_substream(&protocol, RPC_MAX_FRAME_SIZE).await?;
-        builder
+
+        let rpc_client = builder
             .with_protocol_id(protocol)
             .with_node_id(self.peer_node_id.clone())
+            .with_drop_receiver(self.drop_notifier.clone())
             .connect(framed)
-            .await
+            .await?;
+        {
+            let mut rpc_clients = self.number_of_rpc_clients.lock().unwrap();
+            *rpc_clients = Some(rpc_clients.unwrap_or_default() + 1);
+        }
+
+        Ok(rpc_client)
     }
 
     /// Creates a new RpcClientPool that can be shared between tasks. The client pool will lazily establish up to
@@ -295,6 +311,39 @@ impl PeerConnection {
         reply_rx
             .await
             .map_err(|_| PeerConnectionError::InternalReplyCancelled)?
+    }
+
+    /// Forcefully disconnect all RPC clients when any clone is dropped - if not set (the default behaviour) all RPC
+    /// clients will be disconnected when the last instance is dropped. i.e. when `self.handle_counter == 1`
+    pub fn set_force_disconnect_rpc_clients_when_clone_drops(&mut self) {
+        self.force_disconnect_rpc_clients_when_clone_drops
+            .store(true, Ordering::Relaxed);
+    }
+}
+
+impl Drop for PeerConnection {
+    fn drop(&mut self) {
+        if self.handle_count() <= 1 ||
+            self.force_disconnect_rpc_clients_when_clone_drops
+                .load(Ordering::Relaxed)
+        {
+            let number_of_rpc_clients = self.number_of_rpc_clients.lock().unwrap().unwrap_or(0);
+            if number_of_rpc_clients > 0 {
+                self.drop_notifier.broadcast(self.peer_node_id.clone());
+                trace!(
+                    target: LOG_TARGET,
+                    "PeerConnection `{}` drop called, open sub-streams: {}, notified {} potential RPC clients to drop \
+                    connection",
+                    self.peer_node_id.clone(), self.substream_count(), number_of_rpc_clients,
+                );
+            } else {
+                trace!(
+                    target: LOG_TARGET,
+                    "PeerConnection `{}` drop called, open sub-streams: {}, RPC clients: {}",
+                    self.peer_node_id, self.substream_count(), number_of_rpc_clients
+                );
+            }
+        }
     }
 }
 

--- a/comms/core/src/protocol/rpc/client/mod.rs
+++ b/comms/core/src/protocol/rpc/client/mod.rs
@@ -49,7 +49,11 @@ use futures::{
 };
 use log::*;
 use prost::Message;
-use tari_shutdown::{Shutdown, ShutdownSignal};
+use tari_shutdown::{
+    oneshot_trigger::{OneshotSignal, OneshotTrigger},
+    Shutdown,
+    ShutdownSignal,
+};
 use tokio::{
     io::{AsyncRead, AsyncWrite},
     sync::{mpsc, oneshot, watch, Mutex},
@@ -101,10 +105,12 @@ impl RpcClient {
         node_id: NodeId,
         framed: CanonicalFraming<TSubstream>,
         protocol_name: ProtocolId,
+        drop_receiver: Option<OneshotTrigger<NodeId>>,
     ) -> Result<Self, RpcError>
     where
         TSubstream: AsyncRead + AsyncWrite + Unpin + Send + StreamId + 'static,
     {
+        trace!(target: LOG_TARGET,"connect to {:?} with {:?}", node_id, config);
         let (request_tx, request_rx) = mpsc::channel(1);
         let shutdown = Shutdown::new();
         let shutdown_signal = shutdown.to_signal();
@@ -112,6 +118,11 @@ impl RpcClient {
         let connector = ClientConnector::new(request_tx, last_request_latency_rx, shutdown);
         let (ready_tx, ready_rx) = oneshot::channel();
         let tracing_id = tracing::Span::current().id();
+        let drop_signal = if let Some(val) = drop_receiver.as_ref() {
+            val.to_signal()
+        } else {
+            OneshotTrigger::<NodeId>::new().to_signal()
+        };
         tokio::spawn({
             let span = span!(Level::TRACE, "start_rpc_worker");
             span.follows_from(tracing_id);
@@ -125,6 +136,7 @@ impl RpcClient {
                 ready_tx,
                 protocol_name,
                 shutdown_signal,
+                drop_signal,
             )
             .run()
             .instrument(span)
@@ -207,6 +219,7 @@ pub struct RpcClientBuilder<TClient> {
     config: RpcClientConfig,
     protocol_id: Option<ProtocolId>,
     node_id: Option<NodeId>,
+    drop_receiver: Option<OneshotTrigger<NodeId>>,
     _client: PhantomData<TClient>,
 }
 
@@ -216,6 +229,7 @@ impl<TClient> Default for RpcClientBuilder<TClient> {
             config: Default::default(),
             protocol_id: None,
             node_id: None,
+            drop_receiver: None,
             _client: PhantomData,
         }
     }
@@ -266,6 +280,12 @@ impl<TClient> RpcClientBuilder<TClient> {
         self.node_id = Some(node_id);
         self
     }
+
+    /// Set the drop receiver to be used to trigger the client to close
+    pub fn with_drop_receiver(mut self, drop_receiver: OneshotTrigger<NodeId>) -> Self {
+        self.drop_receiver = Some(drop_receiver);
+        self
+    }
 }
 
 impl<TClient> RpcClientBuilder<TClient>
@@ -282,6 +302,7 @@ where TClient: From<RpcClient> + NamedProtocolService
                 .as_ref()
                 .cloned()
                 .unwrap_or_else(|| ProtocolId::from_static(TClient::PROTOCOL_NAME)),
+            self.drop_receiver,
         )
         .await
         .map(Into::into)
@@ -404,6 +425,7 @@ struct RpcClientWorker<TSubstream> {
     ready_tx: Option<oneshot::Sender<Result<(), RpcError>>>,
     protocol_id: ProtocolId,
     shutdown_signal: ShutdownSignal,
+    drop_signal: OneshotSignal<NodeId>,
 }
 
 impl<TSubstream> RpcClientWorker<TSubstream>
@@ -418,6 +440,7 @@ where TSubstream: AsyncRead + AsyncWrite + Unpin + Send + StreamId
         ready_tx: oneshot::Sender<Result<(), RpcError>>,
         protocol_id: ProtocolId,
         shutdown_signal: ShutdownSignal,
+        drop_signal: OneshotSignal<NodeId>,
     ) -> Self {
         Self {
             config,
@@ -429,6 +452,7 @@ where TSubstream: AsyncRead + AsyncWrite + Unpin + Send + StreamId
             last_request_latency_tx,
             protocol_id,
             shutdown_signal,
+            drop_signal,
         }
     }
 
@@ -486,18 +510,33 @@ where TSubstream: AsyncRead + AsyncWrite + Unpin + Send + StreamId
                 _ = &mut self.shutdown_signal => {
                     break;
                 }
+                node_id = &mut self.drop_signal => {
+                    debug!(
+                        target: LOG_TARGET, "(stream={}) Peer '{}' connection has dropped. Worker is terminating.",
+                        self.stream_id(), node_id.unwrap_or_default()
+                    );
+                    break;
+                }
                 req = self.request_rx.recv() => {
                     match req {
                         Some(req) => {
                             if let Err(err) = self.handle_request(req).await {
                                 #[cfg(feature = "metrics")]
                                 metrics::client_errors(&self.node_id, &self.protocol_id).inc();
-                                error!(target: LOG_TARGET, "(stream={}) Unexpected error: {}. Worker is terminating.", self.stream_id(), err);
+                                error!(
+                                    target: LOG_TARGET,
+                                    "(stream={}) Unexpected error: {}. Worker is terminating.",
+                                    self.stream_id(), err
+                                );
                                 break;
                             }
                         }
                         None => {
-                            debug!(target: LOG_TARGET, "(stream={}) Request channel closed. Worker is terminating.", self.stream_id());
+                            debug!(
+                                target: LOG_TARGET,
+                                "(stream={}) Request channel closed. Worker is terminating.",
+                                self.stream_id()
+                            );
                             break
                         },
                     }

--- a/comms/core/src/protocol/rpc/client/mod.rs
+++ b/comms/core/src/protocol/rpc/client/mod.rs
@@ -49,11 +49,7 @@ use futures::{
 };
 use log::*;
 use prost::Message;
-use tari_shutdown::{
-    oneshot_trigger::{OneshotSignal, OneshotTrigger},
-    Shutdown,
-    ShutdownSignal,
-};
+use tari_shutdown::{oneshot_trigger::OneshotSignal, Shutdown, ShutdownSignal};
 use tokio::{
     io::{AsyncRead, AsyncWrite},
     sync::{mpsc, oneshot, watch, Mutex},
@@ -105,7 +101,7 @@ impl RpcClient {
         node_id: NodeId,
         framed: CanonicalFraming<TSubstream>,
         protocol_name: ProtocolId,
-        drop_receiver: Option<OneshotTrigger<NodeId>>,
+        terminate_signal: Option<OneshotSignal<NodeId>>,
     ) -> Result<Self, RpcError>
     where
         TSubstream: AsyncRead + AsyncWrite + Unpin + Send + StreamId + 'static,
@@ -118,11 +114,7 @@ impl RpcClient {
         let connector = ClientConnector::new(request_tx, last_request_latency_rx, shutdown);
         let (ready_tx, ready_rx) = oneshot::channel();
         let tracing_id = tracing::Span::current().id();
-        let drop_signal = if let Some(val) = drop_receiver.as_ref() {
-            val.to_signal()
-        } else {
-            OneshotTrigger::<NodeId>::new().to_signal()
-        };
+
         tokio::spawn({
             let span = span!(Level::TRACE, "start_rpc_worker");
             span.follows_from(tracing_id);
@@ -136,7 +128,7 @@ impl RpcClient {
                 ready_tx,
                 protocol_name,
                 shutdown_signal,
-                drop_signal,
+                terminate_signal,
             )
             .run()
             .instrument(span)
@@ -219,7 +211,7 @@ pub struct RpcClientBuilder<TClient> {
     config: RpcClientConfig,
     protocol_id: Option<ProtocolId>,
     node_id: Option<NodeId>,
-    drop_receiver: Option<OneshotTrigger<NodeId>>,
+    terminate_signal: Option<OneshotSignal<NodeId>>,
     _client: PhantomData<TClient>,
 }
 
@@ -229,7 +221,7 @@ impl<TClient> Default for RpcClientBuilder<TClient> {
             config: Default::default(),
             protocol_id: None,
             node_id: None,
-            drop_receiver: None,
+            terminate_signal: None,
             _client: PhantomData,
         }
     }
@@ -281,9 +273,9 @@ impl<TClient> RpcClientBuilder<TClient> {
         self
     }
 
-    /// Set the drop receiver to be used to trigger the client to close
-    pub fn with_drop_receiver(mut self, drop_receiver: OneshotTrigger<NodeId>) -> Self {
-        self.drop_receiver = Some(drop_receiver);
+    /// Set a signal that indicates if this client should be immediately closed
+    pub fn with_terminate_signal(mut self, terminate_signal: OneshotSignal<NodeId>) -> Self {
+        self.terminate_signal = Some(terminate_signal);
         self
     }
 }
@@ -302,7 +294,7 @@ where TClient: From<RpcClient> + NamedProtocolService
                 .as_ref()
                 .cloned()
                 .unwrap_or_else(|| ProtocolId::from_static(TClient::PROTOCOL_NAME)),
-            self.drop_receiver,
+            self.terminate_signal,
         )
         .await
         .map(Into::into)
@@ -425,7 +417,7 @@ struct RpcClientWorker<TSubstream> {
     ready_tx: Option<oneshot::Sender<Result<(), RpcError>>>,
     protocol_id: ProtocolId,
     shutdown_signal: ShutdownSignal,
-    drop_signal: OneshotSignal<NodeId>,
+    terminate_signal: Option<OneshotSignal<NodeId>>,
 }
 
 impl<TSubstream> RpcClientWorker<TSubstream>
@@ -440,7 +432,7 @@ where TSubstream: AsyncRead + AsyncWrite + Unpin + Send + StreamId
         ready_tx: oneshot::Sender<Result<(), RpcError>>,
         protocol_id: ProtocolId,
         shutdown_signal: ShutdownSignal,
-        drop_signal: OneshotSignal<NodeId>,
+        terminate_signal: Option<OneshotSignal<NodeId>>,
     ) -> Self {
         Self {
             config,
@@ -452,7 +444,7 @@ where TSubstream: AsyncRead + AsyncWrite + Unpin + Send + StreamId
             last_request_latency_tx,
             protocol_id,
             shutdown_signal,
-            drop_signal,
+            terminate_signal,
         }
     }
 
@@ -501,6 +493,12 @@ where TSubstream: AsyncRead + AsyncWrite + Unpin + Send + StreamId
             },
         }
 
+        let mut terminate_signal = self
+            .terminate_signal
+            .take()
+            .map(|f| f.boxed())
+            .unwrap_or_else(|| future::pending::<Option<NodeId>>().boxed());
+
         #[cfg(feature = "metrics")]
         metrics::num_sessions(&self.node_id, &self.protocol_id).inc();
         loop {
@@ -510,7 +508,7 @@ where TSubstream: AsyncRead + AsyncWrite + Unpin + Send + StreamId
                 _ = &mut self.shutdown_signal => {
                     break;
                 }
-                node_id = &mut self.drop_signal => {
+                node_id = &mut terminate_signal => {
                     debug!(
                         target: LOG_TARGET, "(stream={}) Peer '{}' connection has dropped. Worker is terminating.",
                         self.stream_id(), node_id.unwrap_or_default()

--- a/comms/core/src/protocol/rpc/client/pool.rs
+++ b/comms/core/src/protocol/rpc/client/pool.rs
@@ -100,7 +100,7 @@ where T: RpcPoolClient + From<RpcClient> + NamedProtocolService + Clone
                 Some(c) => {
                     trace!(
                         target: LOG_TARGET,
-                        "used existing RPC client session for connection '{}'",
+                        "Used existing RPC client session for connection '{}'",
                         self.connection.peer_node_id(),
                     );
                     c
@@ -122,7 +122,7 @@ where T: RpcPoolClient + From<RpcClient> + NamedProtocolService + Clone
                             .ok_or(RpcClientPoolError::NoMoreRemoteServerRpcSessions(val.clone()))?;
                         trace!(
                             target: LOG_TARGET,
-                            "used existing RPC client session for connection '{}', protocol: {:?} ({})",
+                            "Used existing RPC client session for connection '{}', protocol: {:?} ({})",
                             peer_node_id, protocol_id, RpcClientPoolError::NoMoreRemoteServerRpcSessions(val),
                         );
                         c

--- a/comms/core/src/protocol/rpc/client/pool.rs
+++ b/comms/core/src/protocol/rpc/client/pool.rs
@@ -90,10 +90,12 @@ where T: RpcPoolClient + From<RpcClient> + NamedProtocolService + Clone
     }
 
     pub async fn get_least_used_or_connect(&mut self) -> Result<RpcClientLease<T>, RpcClientPoolError> {
-        loop {
+        {
             self.check_peer_connection()?;
             let peer_node_id = self.connection.peer_node_id().clone();
 
+            let clients_capacity = self.clients.capacity();
+            let protocol_id = self.client_config.protocol_id.clone();
             let client = match self.get_next_lease() {
                 Some(c) => {
                     trace!(
@@ -104,11 +106,11 @@ where T: RpcPoolClient + From<RpcClient> + NamedProtocolService + Clone
                     c
                 },
                 None => match self.add_new_client_session().await {
-                    Ok(c) => {
+                    Ok((c, len)) => {
                         trace!(
                             target: LOG_TARGET,
-                            "Added new RPC client session for connection '{}'",
-                            peer_node_id,
+                            "Added new RPC client session for connection '{}' ({} of {}, protocol: {:?})",
+                            peer_node_id, len, clients_capacity, protocol_id,
                         );
                         c
                     },
@@ -120,9 +122,8 @@ where T: RpcPoolClient + From<RpcClient> + NamedProtocolService + Clone
                             .ok_or(RpcClientPoolError::NoMoreRemoteServerRpcSessions(val.clone()))?;
                         trace!(
                             target: LOG_TARGET,
-                            "used existing RPC client session for connection '{}' ({})",
-                            peer_node_id,
-                            RpcClientPoolError::NoMoreRemoteServerRpcSessions(val),
+                            "used existing RPC client session for connection '{}', protocol: {:?} ({})",
+                            peer_node_id, protocol_id, RpcClientPoolError::NoMoreRemoteServerRpcSessions(val),
                         );
                         c
                     },
@@ -132,9 +133,8 @@ where T: RpcPoolClient + From<RpcClient> + NamedProtocolService + Clone
                             .ok_or(RpcClientPoolError::NoMoreRemoteClientRpcSessions(val.clone()))?;
                         trace!(
                             target: LOG_TARGET,
-                            "used existing RPC client session for connection '{}' ({})",
-                            peer_node_id,
-                            RpcClientPoolError::NoMoreRemoteClientRpcSessions(val),
+                            "used existing RPC client session for connection '{}', protocol: {:?} ({})",
+                            peer_node_id, protocol_id, RpcClientPoolError::NoMoreRemoteClientRpcSessions(val),
                         );
                         c
                     },
@@ -151,11 +151,11 @@ where T: RpcPoolClient + From<RpcClient> + NamedProtocolService + Clone
                     peer_node_id
                 );
                 self.prune();
-                continue;
+                return Err(RpcClientPoolError::CouldNotObtainRpcConnection);
             }
 
             // Clone is what actually takes the lease out (increments the Arc)
-            return Ok(client.clone());
+            Ok(client.clone())
         }
     }
 
@@ -222,7 +222,7 @@ where T: RpcPoolClient + From<RpcClient> + NamedProtocolService + Clone
         self.clients.len() == self.clients.capacity()
     }
 
-    async fn add_new_client_session(&mut self) -> Result<&RpcClientLease<T>, RpcClientPoolError> {
+    async fn add_new_client_session(&mut self) -> Result<(&RpcClientLease<T>, usize), RpcClientPoolError> {
         debug_assert!(!self.is_full(), "add_new_client called when pool is full");
         let client = self
             .connection
@@ -230,7 +230,7 @@ where T: RpcPoolClient + From<RpcClient> + NamedProtocolService + Clone
             .await?;
         let client = RpcClientLease::new(client);
         self.clients.push(client);
-        Ok(self.clients.last().unwrap())
+        Ok((self.clients.last().unwrap(), self.clients.len()))
     }
 
     fn prune(&mut self) {
@@ -305,6 +305,8 @@ pub enum RpcClientPoolError {
     NoMoreRemoteClientRpcSessions(String),
     #[error("Failed to create client connection: {0}")]
     FailedToConnect(RpcError),
+    #[error("Could not obtain RPC connection")]
+    CouldNotObtainRpcConnection,
 }
 
 impl From<RpcError> for RpcClientPoolError {

--- a/comms/core/src/protocol/rpc/handshake.rs
+++ b/comms/core/src/protocol/rpc/handshake.rs
@@ -86,7 +86,7 @@ where T: AsyncRead + AsyncWrite + Unpin
                     .iter()
                     .find(|v| msg.supported_versions.contains(v));
                 if let Some(version) = version {
-                    debug!(target: LOG_TARGET, "Server accepted version: {}", version);
+                    debug!(target: LOG_TARGET, "Local server accepted version: {}", version);
                     let reply = proto::rpc::RpcSessionReply {
                         session_result: Some(proto::rpc::rpc_session_reply::SessionResult::AcceptedVersion(*version)),
                         ..Default::default()
@@ -152,7 +152,7 @@ where T: AsyncRead + AsyncWrite + Unpin
             Ok(Some(Ok(msg))) => {
                 let msg = proto::rpc::RpcSessionReply::decode(&mut msg.freeze())?;
                 let version = msg.result()?;
-                debug!(target: LOG_TARGET, "Server accepted version {}", version);
+                debug!(target: LOG_TARGET, "Remote server accepted version {}", version);
                 Ok(())
             },
             Ok(Some(Err(err))) => {

--- a/comms/core/src/protocol/rpc/server/mod.rs
+++ b/comms/core/src/protocol/rpc/server/mod.rs
@@ -89,7 +89,7 @@ use crate::{
         ProtocolNotification,
         ProtocolNotificationRx,
     },
-    stream_id::StreamId,
+    stream_id::{Id, StreamId},
     Bytes,
     Substream,
 };
@@ -239,8 +239,13 @@ pub(super) struct PeerRpcServer<TSvc, TCommsProvider> {
     protocol_notifications: Option<ProtocolNotificationRx<Substream>>,
     comms_provider: TCommsProvider,
     request_rx: mpsc::Receiver<RpcServerRequest>,
-    sessions: HashMap<NodeId, usize>,
-    tasks: FuturesUnordered<JoinHandle<NodeId>>,
+    sessions: HashMap<NodeId, Vec<SessionInfo>>,
+    tasks: FuturesUnordered<JoinHandle<(NodeId, Id)>>,
+}
+
+struct SessionInfo {
+    pub(crate) peer_watch: tokio::sync::watch::Sender<()>,
+    pub(crate) stream_id: Id,
 }
 
 impl<TSvc, TCommsProvider> PeerRpcServer<TSvc, TCommsProvider>
@@ -297,8 +302,8 @@ where
                     }
                 }
 
-                Some(Ok(node_id)) = self.tasks.next() => {
-                    self.on_session_complete(&node_id);
+                Some(Ok((node_id, stream_id))) = self.tasks.next() => {
+                    self.on_session_complete(&node_id, stream_id);
                 },
 
                 Some(req) = self.request_rx.recv() => {
@@ -315,7 +320,7 @@ where
         Ok(())
     }
 
-    async fn handle_request(&self, req: RpcServerRequest) {
+    async fn handle_request(&mut self, req: RpcServerRequest) {
         #[allow(clippy::enum_glob_use)]
         use RpcServerRequest::*;
         match req {
@@ -328,8 +333,12 @@ where
                 let _ = reply.send(num_active);
             },
             GetNumActiveSessionsForPeer(node_id, reply) => {
-                let num_active = self.sessions.get(&node_id).copied().unwrap_or(0);
+                let num_active = self.sessions.get(&node_id).map(|v| v.len()).unwrap_or(0);
                 let _ = reply.send(num_active);
+            },
+            CloseAllSessionsForPeer(node_id, reply) => {
+                let num_closed = self.close_all_sessions(&node_id);
+                let _ = reply.send(num_closed);
             },
         }
     }
@@ -368,35 +377,60 @@ where
         Ok(())
     }
 
-    fn new_session_for(&mut self, node_id: NodeId) -> Result<usize, RpcServerError> {
-        let count = self.sessions.entry(node_id.clone()).or_insert(0);
+    fn new_session_possible_for(&mut self, node_id: &NodeId) -> Result<(), RpcServerError> {
         match self.config.maximum_sessions_per_client {
             Some(max) if max > 0 => {
-                debug_assert!(*count <= max);
-                if *count >= max {
-                    return Err(RpcServerError::MaxSessionsPerClientReached {
-                        node_id,
-                        max_sessions: max,
-                    });
+                if let Some(session_info) = self.sessions.get(node_id) {
+                    if max > session_info.len() {
+                        Ok(())
+                    } else {
+                        if max <= session_info.len() {
+                            warn!(
+                                target: LOG_TARGET,
+                                "Maximum RPC sessions for peer {} met or exceeded. Max: {}, Current: {}",
+                                node_id, max, session_info.len()
+                            );
+                        }
+                        Err(RpcServerError::MaxSessionsPerClientReached {
+                            node_id: node_id.clone(),
+                            max_sessions: max,
+                        })
+                    }
+                } else {
+                    Ok(())
                 }
             },
-            Some(_) | None => {},
+            Some(_) | None => Ok(()),
         }
-
-        *count += 1;
-        Ok(*count)
     }
 
-    fn on_session_complete(&mut self, node_id: &NodeId) {
-        info!(target: LOG_TARGET, "Session complete for {}", node_id);
-        if let Some(v) = self.sessions.get_mut(node_id) {
-            *v -= 1;
-            if *v == 0 {
+    fn close_all_sessions(&mut self, node_id: &NodeId) -> usize {
+        let mut count = 0;
+        if let Some(session_info) = self.sessions.get_mut(node_id) {
+            for info in session_info.iter_mut() {
+                count += 1;
+                info!(target: LOG_TARGET, "Closing RPC session {} for peer `{}`", info.stream_id, node_id);
+                let _ = info.peer_watch.send(());
+            }
+            self.sessions.remove(node_id);
+        }
+        count
+    }
+
+    fn on_session_complete(&mut self, node_id: &NodeId, stream_id: Id) {
+        if let Some(session_info) = self.sessions.get_mut(node_id) {
+            if let Some(info) = session_info.iter_mut().find(|info| info.stream_id == stream_id) {
+                info!(target: LOG_TARGET, "Session complete for {} (stream id {})", node_id, stream_id);
+                let _ = info.peer_watch.send(());
+            };
+            session_info.retain(|info| info.stream_id != stream_id);
+            if session_info.is_empty() {
                 self.sessions.remove(node_id);
             }
         }
     }
 
+    #[allow(clippy::too_many_lines)]
     async fn try_initiate_service(
         &mut self,
         protocol: ProtocolId,
@@ -437,14 +471,16 @@ where
             },
         };
 
-        match self.new_session_for(node_id.clone()) {
-            Ok(num_sessions) => {
-                info!(
-                    target: LOG_TARGET,
-                    "NEW SESSION for {} ({} active) ", node_id, num_sessions
-                );
-            },
+        let version = handshake.perform_server_handshake().await?;
+        debug!(
+            target: LOG_TARGET,
+            "Server negotiated RPC v{} with client node `{}`", version, node_id
+        );
 
+        match self.new_session_possible_for(node_id) {
+            Ok(_) => {
+                trace!(target: LOG_TARGET, "NEW SESSION can be created for {}", node_id);
+            },
             Err(err) => {
                 handshake
                     .reject_with_reason(HandshakeRejectReason::NoServerSessionsAvailable(
@@ -455,12 +491,8 @@ where
             },
         }
 
-        let version = handshake.perform_server_handshake().await?;
-        debug!(
-            target: LOG_TARGET,
-            "Server negotiated RPC v{} with client node `{}`", version, node_id
-        );
-
+        let stream_id = framed.stream_id();
+        let (stop_tx, stop_rx) = tokio::sync::watch::channel(());
         let service = ActivePeerRpcService::new(
             self.config.clone(),
             protocol,
@@ -468,26 +500,48 @@ where
             service,
             framed,
             self.comms_provider.clone(),
+            stop_rx,
         );
 
-        let node_id = node_id.clone();
+        let node_id_clone = node_id.clone();
         let handle = self
             .executor
             .try_spawn(async move {
                 #[cfg(feature = "metrics")]
-                let num_sessions = metrics::num_sessions(&node_id, &service.protocol);
+                let num_sessions = metrics::num_sessions(&node_id_clone, &service.protocol);
                 #[cfg(feature = "metrics")]
                 num_sessions.inc();
                 service.start().await;
-                info!(target: LOG_TARGET, "END OF SESSION for {} ", node_id,);
+                info!(target: LOG_TARGET, "END OF SESSION for {} ", node_id_clone,);
                 #[cfg(feature = "metrics")]
                 num_sessions.dec();
 
-                node_id
+                (node_id_clone, stream_id)
             })
             .map_err(|e| RpcServerError::MaximumSessionsReached(format!("{:?}", e)))?;
 
         self.tasks.push(handle);
+        let mut peer_stop = vec![SessionInfo {
+            peer_watch: stop_tx,
+            stream_id,
+        }];
+        self.sessions
+            .entry(node_id.clone())
+            .and_modify(|entry| entry.append(&mut peer_stop))
+            .or_insert(peer_stop);
+        if let Some(info) = self.sessions.get(&node_id.clone()) {
+            info!(
+                target: LOG_TARGET,
+                "NEW SESSION created for {} ({} active) ", node_id.clone(), info.len()
+            );
+            // Warn if `stream_id` is already in use
+            if info.iter().filter(|session| session.stream_id == stream_id).count() > 1 {
+                warn!(
+                    target: LOG_TARGET,
+                    "Stream ID {} already in use for peer {}. This should not happen.", stream_id, node_id
+                );
+            }
+        }
 
         Ok(())
     }
@@ -501,6 +555,7 @@ struct ActivePeerRpcService<TSvc, TCommsProvider> {
     framed: EarlyClose<CanonicalFraming<Substream>>,
     comms_provider: TCommsProvider,
     logging_context_string: Arc<String>,
+    stop_rx: tokio::sync::watch::Receiver<()>,
 }
 
 impl<TSvc, TCommsProvider> ActivePeerRpcService<TSvc, TCommsProvider>
@@ -515,12 +570,14 @@ where
         service: TSvc,
         framed: CanonicalFraming<Substream>,
         comms_provider: TCommsProvider,
+        stop_rx: tokio::sync::watch::Receiver<()>,
     ) -> Self {
         Self {
             logging_context_string: Arc::new(format!(
-                "stream_id: {}, peer: {}, protocol: {}",
+                "stream_id: {}, peer: {}, protocol: {}, stream_id: {}",
                 framed.stream_id(),
                 node_id,
+                framed.stream_id(),
                 String::from_utf8_lossy(&protocol)
             )),
 
@@ -530,6 +587,7 @@ where
             service,
             framed: EarlyClose::new(framed),
             comms_provider,
+            stop_rx,
         }
     }
 
@@ -557,55 +615,64 @@ where
     }
 
     async fn run(&mut self) -> Result<(), RpcServerError> {
-        while let Some(result) = self.framed.next().await {
-            match result {
-                Ok(frame) => {
-                    #[cfg(feature = "metrics")]
-                    metrics::inbound_requests_bytes(&self.node_id, &self.protocol).observe(frame.len() as f64);
+        loop {
+            tokio::select! {
+                _ = self.stop_rx.changed() => {
+                    debug!(target: LOG_TARGET, "({}) Stop signal received, closing substream.", self.logging_context_string);
+                    break;
+                }
+                result = self.framed.next() => {
+                    match result {
+                        Some(Ok(frame)) => {
+                            #[cfg(feature = "metrics")]
+                            metrics::inbound_requests_bytes(&self.node_id, &self.protocol).observe(frame.len() as f64);
 
-                    let start = Instant::now();
+                            let start = Instant::now();
 
-                    if let Err(err) = self.handle_request(frame.freeze()).await {
-                        if let Err(err) = self.framed.close().await {
-                            let level = err.io().map(err_to_log_level).unwrap_or(log::Level::Error);
+                            if let Err(err) = self.handle_request(frame.freeze()).await {
+                                if let Err(err) = self.framed.close().await {
+                                    let level = err.io().map(err_to_log_level).unwrap_or(log::Level::Error);
 
-                            log!(
+                                    log!(
+                                        target: LOG_TARGET,
+                                        level,
+                                        "({}) Failed to close substream after socket error: {}",
+                                        self.logging_context_string,
+                                        err,
+                                    );
+                                }
+                                let level = err.early_close_io().map(err_to_log_level).unwrap_or(log::Level::Error);
+                                log!(
+                                    target: LOG_TARGET,
+                                    level,
+                                    "(peer: {}, protocol: {}) Failed to handle request: {}",
+                                    self.node_id,
+                                    self.protocol_name(),
+                                    err
+                                );
+                                return Err(err);
+                            }
+                            let elapsed = start.elapsed();
+                            trace!(
                                 target: LOG_TARGET,
-                                level,
-                                "({}) Failed to close substream after socket error: {}",
+                                "({}) RPC request completed in {:.0?}{}",
                                 self.logging_context_string,
-                                err,
+                                elapsed,
+                                if elapsed.as_secs() > 5 { " (LONG REQUEST)" } else { "" }
                             );
-                        }
-                        let level = err.early_close_io().map(err_to_log_level).unwrap_or(log::Level::Error);
-                        log!(
-                            target: LOG_TARGET,
-                            level,
-                            "(peer: {}, protocol: {}) Failed to handle request: {}",
-                            self.node_id,
-                            self.protocol_name(),
-                            err
-                        );
-                        return Err(err);
+                        },
+                        Some(Err(err)) => {
+                            if let Err(err) = self.framed.close().await {
+                                error!(
+                                    target: LOG_TARGET,
+                                    "({}) Failed to close substream after socket error: {}", self.logging_context_string, err
+                                );
+                            }
+                            return Err(err.into());
+                        },
+                        None => break,
                     }
-                    let elapsed = start.elapsed();
-                    trace!(
-                        target: LOG_TARGET,
-                        "({}) RPC request completed in {:.0?}{}",
-                        self.logging_context_string,
-                        elapsed,
-                        if elapsed.as_secs() > 5 { " (LONG REQUEST)" } else { "" }
-                    );
-                },
-                Err(err) => {
-                    if let Err(err) = self.framed.close().await {
-                        error!(
-                            target: LOG_TARGET,
-                            "({}) Failed to close substream after socket error: {}", self.logging_context_string, err
-                        );
-                    }
-                    return Err(err.into());
-                },
+                }
             }
         }
 

--- a/comms/core/src/protocol/rpc/server/mod.rs
+++ b/comms/core/src/protocol/rpc/server/mod.rs
@@ -377,30 +377,28 @@ where
         Ok(())
     }
 
-    fn new_session_possible_for(&mut self, node_id: &NodeId) -> Result<(), RpcServerError> {
+    fn new_session_possible_for(&mut self, node_id: &NodeId) -> Result<usize, RpcServerError> {
         match self.config.maximum_sessions_per_client {
             Some(max) if max > 0 => {
                 if let Some(session_info) = self.sessions.get(node_id) {
                     if max > session_info.len() {
-                        Ok(())
+                        Ok(session_info.len())
                     } else {
-                        if max <= session_info.len() {
-                            warn!(
-                                target: LOG_TARGET,
-                                "Maximum RPC sessions for peer {} met or exceeded. Max: {}, Current: {}",
-                                node_id, max, session_info.len()
-                            );
-                        }
+                        warn!(
+                            target: LOG_TARGET,
+                            "Maximum RPC sessions for peer {} met or exceeded. Max: {}, Current: {}",
+                            node_id, max, session_info.len()
+                        );
                         Err(RpcServerError::MaxSessionsPerClientReached {
                             node_id: node_id.clone(),
                             max_sessions: max,
                         })
                     }
                 } else {
-                    Ok(())
+                    Ok(0)
                 }
             },
-            Some(_) | None => Ok(()),
+            Some(_) | None => Ok(0),
         }
     }
 
@@ -471,16 +469,14 @@ where
             },
         };
 
-        let version = handshake.perform_server_handshake().await?;
-        debug!(
-            target: LOG_TARGET,
-            "Server negotiated RPC v{} with client node `{}`", version, node_id
-        );
-
-        match self.new_session_possible_for(node_id) {
-            Ok(_) => {
-                trace!(target: LOG_TARGET, "NEW SESSION can be created for {}", node_id);
+        match self.new_session_possible_for(&node_id) {
+            Ok(num_sessions) => {
+                info!(
+                    target: LOG_TARGET,
+                    "NEW SESSION for {} ({} currently active) ", node_id, num_sessions
+                );
             },
+
             Err(err) => {
                 handshake
                     .reject_with_reason(HandshakeRejectReason::NoServerSessionsAvailable(
@@ -491,6 +487,11 @@ where
             },
         }
 
+        let version = handshake.perform_server_handshake().await?;
+        debug!(
+            target: LOG_TARGET,
+            "Server negotiated RPC v{} with client node `{}`", version, node_id
+        );
         let stream_id = framed.stream_id();
         let (stop_tx, stop_rx) = tokio::sync::watch::channel(());
         let service = ActivePeerRpcService::new(

--- a/comms/core/src/protocol/rpc/server/mod.rs
+++ b/comms/core/src/protocol/rpc/server/mod.rs
@@ -469,7 +469,7 @@ where
             },
         };
 
-        match self.new_session_possible_for(&node_id) {
+        match self.new_session_possible_for(node_id) {
             Ok(num_sessions) => {
                 info!(
                     target: LOG_TARGET,

--- a/comms/core/src/protocol/rpc/server/mod.rs
+++ b/comms/core/src/protocol/rpc/server/mod.rs
@@ -179,6 +179,7 @@ pub struct RpcServerBuilder {
     maximum_sessions_per_client: Option<usize>,
     minimum_client_deadline: Duration,
     handshake_timeout: Duration,
+    cull_oldest_peer_rpc_connection_on_full: bool,
 }
 
 impl RpcServerBuilder {
@@ -198,6 +199,11 @@ impl RpcServerBuilder {
 
     pub fn with_maximum_sessions_per_client(mut self, limit: usize) -> Self {
         self.maximum_sessions_per_client = Some(cmp::min(limit, BoundedExecutor::max_theoretical_tasks()));
+        self
+    }
+
+    pub fn with_cull_oldest_peer_rpc_connection_on_full(mut self, cull: bool) -> Self {
+        self.cull_oldest_peer_rpc_connection_on_full = cull;
         self
     }
 
@@ -228,6 +234,7 @@ impl Default for RpcServerBuilder {
             maximum_sessions_per_client: None,
             minimum_client_deadline: Duration::from_secs(1),
             handshake_timeout: Duration::from_secs(15),
+            cull_oldest_peer_rpc_connection_on_full: false,
         }
     }
 }
@@ -380,8 +387,17 @@ where
     fn new_session_possible_for(&mut self, node_id: &NodeId) -> Result<usize, RpcServerError> {
         match self.config.maximum_sessions_per_client {
             Some(max) if max > 0 => {
-                if let Some(session_info) = self.sessions.get(node_id) {
+                if let Some(session_info) = self.sessions.get_mut(node_id) {
                     if max > session_info.len() {
+                        Ok(session_info.len())
+                    } else if self.config.cull_oldest_peer_rpc_connection_on_full {
+                        // Remove the oldest session(s) until we have space for a new one
+                        let num_to_remove = session_info.len() - max + 1;
+                        for _ in 0..num_to_remove {
+                            let info = session_info.remove(0);
+                            info!(target: LOG_TARGET, "Culling oldest RPC session for peer `{}`", node_id);
+                            let _ = info.peer_watch.send(());
+                        }
                         Ok(session_info.len())
                     } else {
                         warn!(

--- a/comms/core/src/protocol/rpc/test/greeting_service.rs
+++ b/comms/core/src/protocol/rpc/test/greeting_service.rs
@@ -406,6 +406,7 @@ impl GreetingClient {
             Default::default(),
             framed,
             Self::PROTOCOL_NAME.into(),
+            Default::default(),
         )
         .await?;
         Ok(Self { inner })

--- a/comms/core/src/protocol/rpc/test/smoke.rs
+++ b/comms/core/src/protocol/rpc/test/smoke.rs
@@ -541,7 +541,8 @@ async fn max_global_sessions() {
 async fn max_per_client_sessions() {
     let builder = RpcServer::builder()
         .with_maximum_simultaneous_sessions(3)
-        .with_maximum_sessions_per_client(1);
+        .with_maximum_sessions_per_client(1)
+        .with_cull_oldest_peer_rpc_connection_on_full(false);
     let (muxer, _outbound, context, _shutdown) = setup_service_with_builder(GreetingService::default(), builder).await;
     let (_, inbound, outbound) = build_multiplexed_connections().await;
 

--- a/comms/core/tests/tests/rpc.rs
+++ b/comms/core/tests/tests/rpc.rs
@@ -63,6 +63,32 @@ async fn spawn_node(signal: ShutdownSignal) -> (CommsNode, RpcServerHandle) {
     (comms, rpc_server_hnd)
 }
 
+async fn spawn_culling_node(signal: ShutdownSignal, sessions: usize, culling: bool) -> (CommsNode, RpcServerHandle) {
+    let rpc_server = RpcServer::builder()
+        .with_maximum_sessions_per_client(sessions)
+        .with_cull_oldest_peer_rpc_connection_on_full(culling)
+        .finish()
+        .add_service(GreetingServer::new(GreetingService::default()));
+
+    let rpc_server_hnd = rpc_server.get_handle();
+    let mut comms = create_comms(signal)
+        .add_rpc_server(rpc_server)
+        .spawn_with_transport(TcpTransport::new())
+        .await
+        .unwrap();
+
+    let address = comms
+        .connection_manager_requester()
+        .wait_until_listening()
+        .await
+        .unwrap();
+    comms
+        .node_identity()
+        .set_public_addresses(vec![address.bind_address().clone()]);
+
+    (comms, rpc_server_hnd)
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn rpc_server_can_request_drop_sessions() {
     // env_logger::init(); // Set `$env:RUST_LOG = "trace"`
@@ -129,6 +155,119 @@ async fn rpc_server_can_request_drop_sessions() {
             })
             .await
             .is_err());
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn rpc_server_can_prioritize_new_connections() {
+    // env_logger::init(); // Set `$env:RUST_LOG = "trace"`
+    let shutdown = Shutdown::new();
+    let (numer_of_clients, maximum_sessions, cull_oldest) = (3, 2, true);
+    let (node1, _node2, _conn1_2, mut rpc_server2, mut clients) = {
+        let (node1, _rpc_server1) = spawn_node(shutdown.to_signal()).await;
+        let (node2, rpc_server2) = spawn_culling_node(shutdown.to_signal(), maximum_sessions, cull_oldest).await;
+
+        node1
+            .peer_manager()
+            .add_peer(node2.node_identity().to_peer())
+            .await
+            .unwrap();
+
+        let mut conn1_2 = node1
+            .connectivity()
+            .dial_peer(node2.node_identity().node_id().clone())
+            .await
+            .unwrap();
+
+        let mut clients = Vec::new();
+        for _ in 0..numer_of_clients {
+            clients.push(conn1_2.connect_rpc::<GreetingClient>().await.unwrap());
+        }
+
+        (node1, node2, conn1_2, rpc_server2, clients)
+    };
+
+    // Verify only the latest RPC connections are active
+    let num_sessions = rpc_server2
+        .get_num_active_sessions_for(node1.node_identity().node_id().clone())
+        .await
+        .unwrap();
+    assert_eq!(num_sessions, 2);
+    assert!(clients[0]
+        .say_hello(SayHelloRequest {
+            name: "Bob".to_string(),
+            language: 0
+        })
+        .await
+        .is_err());
+    for client in clients.iter_mut().skip(1) {
+        assert!(client
+            .say_hello(SayHelloRequest {
+                name: "Bob".to_string(),
+                language: 0
+            })
+            .await
+            .is_ok());
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn rpc_server_can_prioritize_old_connections() {
+    // env_logger::init(); // Set `$env:RUST_LOG = "trace"`
+    let shutdown = Shutdown::new();
+    let (numer_of_clients, maximum_sessions, cull_oldest) = (3, 2, false);
+    let (node1, _node2, _conn1_2, mut rpc_server2, clients) = {
+        let (node1, _rpc_server1) = spawn_node(shutdown.to_signal()).await;
+        let (node2, rpc_server2) = spawn_culling_node(shutdown.to_signal(), maximum_sessions, cull_oldest).await;
+
+        node1
+            .peer_manager()
+            .add_peer(node2.node_identity().to_peer())
+            .await
+            .unwrap();
+
+        let mut conn1_2 = node1
+            .connectivity()
+            .dial_peer(node2.node_identity().node_id().clone())
+            .await
+            .unwrap();
+
+        let mut clients = Vec::new();
+        for _ in 0..numer_of_clients {
+            clients.push(conn1_2.connect_rpc::<GreetingClient>().await);
+        }
+
+        (node1, node2, conn1_2, rpc_server2, clients)
+    };
+
+    // Verify only the initial RPC connections are active
+    let num_sessions = rpc_server2
+        .get_num_active_sessions_for(node1.node_identity().node_id().clone())
+        .await
+        .unwrap();
+    assert_eq!(num_sessions, 2);
+    for (i, mut client_result) in clients.into_iter().enumerate() {
+        match client_result {
+            Ok(ref mut client) => {
+                assert!(i < 2);
+                assert!(client
+                    .say_hello(SayHelloRequest {
+                        name: "Bob".to_string(),
+                        language: 0
+                    })
+                    .await
+                    .is_ok());
+            },
+            Err(e) => {
+                assert_eq!(i, 2);
+                assert_eq!(
+                    e.to_string(),
+                    "Handshake error: RPC handshake was explicitly rejected: no more RPC server sessions available: \
+                     session limit reached"
+                        .to_string()
+                )
+            },
+        }
     }
 }
 

--- a/comms/core/tests/tests/rpc.rs
+++ b/comms/core/tests/tests/rpc.rs
@@ -27,13 +27,14 @@ use tari_comms::{
     protocol::rpc::{RpcServer, RpcServerHandle},
     transports::TcpTransport,
     CommsNode,
+    Minimized,
 };
 use tari_shutdown::{Shutdown, ShutdownSignal};
 use tari_test_utils::async_assert_eventually;
 use tokio::time;
 
 use crate::tests::{
-    greeting_service::{GreetingClient, GreetingServer, GreetingService, StreamLargeItemsRequest},
+    greeting_service::{GreetingClient, GreetingServer, GreetingService, SayHelloRequest, StreamLargeItemsRequest},
     helpers::create_comms,
 };
 
@@ -60,6 +61,287 @@ async fn spawn_node(signal: ShutdownSignal) -> (CommsNode, RpcServerHandle) {
         .set_public_addresses(vec![address.bind_address().clone()]);
 
     (comms, rpc_server_hnd)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn rpc_server_can_request_drop_sessions() {
+    // env_logger::init(); // Set `$env:RUST_LOG = "trace"`
+    let shutdown = Shutdown::new();
+    let numer_of_clients = 3;
+    let (node1, _node2, _conn1_2, mut rpc_server2, mut clients) = {
+        let (node1, _rpc_server1) = spawn_node(shutdown.to_signal()).await;
+        let (node2, rpc_server2) = spawn_node(shutdown.to_signal()).await;
+
+        node1
+            .peer_manager()
+            .add_peer(node2.node_identity().to_peer())
+            .await
+            .unwrap();
+
+        let mut conn1_2 = node1
+            .connectivity()
+            .dial_peer(node2.node_identity().node_id().clone())
+            .await
+            .unwrap();
+
+        let mut clients = Vec::new();
+        for _ in 0..numer_of_clients {
+            clients.push(conn1_2.connect_rpc::<GreetingClient>().await.unwrap());
+        }
+
+        (node1, node2, conn1_2, rpc_server2, clients)
+    };
+
+    // Verify all RPC connections are active
+    let num_sessions = rpc_server2
+        .get_num_active_sessions_for(node1.node_identity().node_id().clone())
+        .await
+        .unwrap();
+    assert_eq!(num_sessions, 3);
+    for client in &mut clients {
+        assert!(client
+            .say_hello(SayHelloRequest {
+                name: "Bob".to_string(),
+                language: 0
+            })
+            .await
+            .is_ok());
+    }
+
+    // The RPC server closes all RPC connections
+    let num_closed = rpc_server2
+        .close_all_sessions_for(node1.node_identity().node_id().clone())
+        .await
+        .unwrap();
+    assert_eq!(num_closed, 3);
+
+    // Verify the RPC connections are closed
+    let num_sessions = rpc_server2
+        .get_num_active_sessions_for(node1.node_identity().node_id().clone())
+        .await
+        .unwrap();
+    assert_eq!(num_sessions, 0);
+    for client in &mut clients {
+        assert!(client
+            .say_hello(SayHelloRequest {
+                name: "Bob".to_string(),
+                language: 0
+            })
+            .await
+            .is_err());
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn rpc_server_drop_sessions_when_peer_is_disconnected() {
+    // env_logger::init(); // Set `$env:RUST_LOG = "trace"`
+    let shutdown = Shutdown::new();
+    let numer_of_clients = 3;
+    let (node1, _node2, mut conn1_2, mut rpc_server2, mut clients) = {
+        let (node1, _rpc_server1) = spawn_node(shutdown.to_signal()).await;
+        let (node2, rpc_server2) = spawn_node(shutdown.to_signal()).await;
+
+        node1
+            .peer_manager()
+            .add_peer(node2.node_identity().to_peer())
+            .await
+            .unwrap();
+
+        let mut conn1_2 = node1
+            .connectivity()
+            .dial_peer(node2.node_identity().node_id().clone())
+            .await
+            .unwrap();
+
+        let mut clients = Vec::new();
+        for _ in 0..numer_of_clients {
+            clients.push(conn1_2.connect_rpc::<GreetingClient>().await.unwrap());
+        }
+
+        (node1, node2, conn1_2, rpc_server2, clients)
+    };
+
+    // Verify all RPC connections are active
+    let num_sessions = rpc_server2
+        .get_num_active_sessions_for(node1.node_identity().node_id().clone())
+        .await
+        .unwrap();
+    assert_eq!(num_sessions, 3);
+    for client in &mut clients {
+        assert!(client
+            .say_hello(SayHelloRequest {
+                name: "Bob".to_string(),
+                language: 0
+            })
+            .await
+            .is_ok());
+    }
+
+    // RPC connections are closed when the peer is disconnected
+    conn1_2.disconnect(Minimized::No).await.unwrap();
+
+    // Verify the RPC connections are closed
+    async_assert_eventually!(
+        rpc_server2
+            .get_num_active_sessions_for(node1.node_identity().node_id().clone())
+            .await
+            .unwrap(),
+        expect = 0,
+        max_attempts = 20,
+        interval = Duration::from_millis(1000)
+    );
+    for client in &mut clients {
+        assert!(client
+            .say_hello(SayHelloRequest {
+                name: "Bob".to_string(),
+                language: 0
+            })
+            .await
+            .is_err());
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn rpc_server_drop_sessions_when_peer_connection_clone_is_dropped() {
+    // env_logger::init(); // Set `$env:RUST_LOG = "trace"`
+    let shutdown = Shutdown::new();
+    let numer_of_clients = 3;
+    let (node1, _node2, mut conn1_2, mut rpc_server2, mut clients) = {
+        let (node1, _rpc_server1) = spawn_node(shutdown.to_signal()).await;
+        let (node2, rpc_server2) = spawn_node(shutdown.to_signal()).await;
+
+        node1
+            .peer_manager()
+            .add_peer(node2.node_identity().to_peer())
+            .await
+            .unwrap();
+
+        let mut conn1_2 = node1
+            .connectivity()
+            .dial_peer(node2.node_identity().node_id().clone())
+            .await
+            .unwrap();
+
+        let mut clients = Vec::new();
+        for _ in 0..numer_of_clients {
+            clients.push(conn1_2.connect_rpc::<GreetingClient>().await.unwrap());
+        }
+
+        (node1, node2, conn1_2, rpc_server2, clients)
+    };
+
+    // Verify all RPC connections are active
+    let num_sessions = rpc_server2
+        .get_num_active_sessions_for(node1.node_identity().node_id().clone())
+        .await
+        .unwrap();
+    assert_eq!(num_sessions, 3);
+    for client in &mut clients {
+        assert!(client
+            .say_hello(SayHelloRequest {
+                name: "Bob".to_string(),
+                language: 0
+            })
+            .await
+            .is_ok());
+    }
+
+    // RPC connections are closed when the first peer connection clone is dropped
+    conn1_2.set_force_disconnect_rpc_clients_when_clone_drops();
+    assert!(conn1_2.handle_count() > 1);
+    drop(conn1_2);
+
+    let num_sessions = rpc_server2
+        .get_num_active_sessions_for(node1.node_identity().node_id().clone())
+        .await
+        .unwrap();
+    assert!(num_sessions >= 1);
+
+    // Verify the RPC connections are closed eventually
+    async_assert_eventually!(
+        rpc_server2
+            .get_num_active_sessions_for(node1.node_identity().node_id().clone())
+            .await
+            .unwrap(),
+        expect = 0,
+        max_attempts = 10,
+        interval = Duration::from_millis(1000)
+    );
+    for client in &mut clients {
+        assert!(client
+            .say_hello(SayHelloRequest {
+                name: "Bob".to_string(),
+                language: 0
+            })
+            .await
+            .is_err());
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn rpc_server_drop_sessions_when_peer_connection_is_dropped() {
+    // env_logger::init(); // Set `$env:RUST_LOG = "trace"`
+    let shutdown = Shutdown::new();
+    let numer_of_clients = 3;
+    let (node1, node2, mut rpc_server2) = {
+        let (node1, _rpc_server1) = spawn_node(shutdown.to_signal()).await;
+        let (node2, rpc_server2) = spawn_node(shutdown.to_signal()).await;
+
+        node1
+            .peer_manager()
+            .add_peer(node2.node_identity().to_peer())
+            .await
+            .unwrap();
+
+        (node1, node2, rpc_server2)
+    };
+
+    // Some peer connection clones still exist at the end of this scope, but they are eventually dropped
+    {
+        let mut clients = Vec::new();
+        let mut conn1_2 = node1
+            .connectivity()
+            .dial_peer(node2.node_identity().node_id().clone())
+            .await
+            .unwrap();
+
+        for _ in 0..numer_of_clients {
+            clients.push(conn1_2.connect_rpc::<GreetingClient>().await.unwrap());
+        }
+
+        // Verify all RPC connections are active
+        let num_sessions = rpc_server2
+            .get_num_active_sessions_for(node1.node_identity().node_id().clone())
+            .await
+            .unwrap();
+        assert_eq!(num_sessions, 3);
+        for client in &mut clients {
+            assert!(client
+                .say_hello(SayHelloRequest {
+                    name: "Bob".to_string(),
+                    language: 0
+                })
+                .await
+                .is_ok());
+        }
+        assert!(conn1_2.handle_count() > 1);
+    }
+    let num_sessions = rpc_server2
+        .get_num_active_sessions_for(node1.node_identity().node_id().clone())
+        .await
+        .unwrap();
+    assert!(num_sessions >= 1);
+
+    // Verify the RPC connections are eventually closed
+    async_assert_eventually!(
+        rpc_server2
+            .get_num_active_sessions_for(node1.node_identity().node_id().clone())
+            .await
+            .unwrap(),
+        expect = 0,
+        max_attempts = 10,
+        interval = Duration::from_millis(1000)
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/comms/dht/src/store_forward/service.rs
+++ b/comms/dht/src/store_forward/service.rs
@@ -264,6 +264,11 @@ impl StoreAndForwardService {
                 warn!(target: LOG_TARGET, "Failed to get the minimize connections threshold: {:?}", err);
                 None
             });
+        if self.ignore_saf_threshold.is_some() {
+            let delay = Duration::from_secs(60);
+            tokio::time::sleep(delay).await;
+            debug!(target: LOG_TARGET, "SAF connectivity starting after delayed for {:.0?}", delay);
+        }
         self.node_id = self.connectivity.get_node_identity().await.map_or_else(
             |err| {
                 warn!(target: LOG_TARGET, "Failed to get the node identity: {:?}", err);

--- a/comms/dht/src/store_forward/service.rs
+++ b/comms/dht/src/store_forward/service.rs
@@ -264,6 +264,8 @@ impl StoreAndForwardService {
                 warn!(target: LOG_TARGET, "Failed to get the minimize connections threshold: {:?}", err);
                 None
             });
+        // If the comms node is configured to minimize connections, delay the SAF connectivity to prioritize other
+        // higher priority connections
         if self.ignore_saf_threshold.is_some() {
             let delay = Duration::from_secs(60);
             tokio::time::sleep(delay).await;

--- a/comms/rpc_macros/src/generator.rs
+++ b/comms/rpc_macros/src/generator.rs
@@ -198,7 +198,7 @@ impl RpcCodeGenerator {
             pub async fn connect<TSubstream>(framed: #dep_mod::CanonicalFraming<TSubstream>) -> Result<Self, #dep_mod::RpcError>
               where TSubstream: #dep_mod::AsyncRead + #dep_mod::AsyncWrite + Unpin + Send + #dep_mod::StreamId + 'static {
                 use #dep_mod::NamedProtocolService;
-                let inner = #dep_mod::RpcClient::connect(Default::default(), Default::default(), framed, Self::PROTOCOL_NAME.into()).await?;
+                let inner = #dep_mod::RpcClient::connect(Default::default(), Default::default(), framed, Self::PROTOCOL_NAME.into(), Default::default()).await?;
                 Ok(Self { inner })
             }
 

--- a/comms/rpc_macros/src/generator.rs
+++ b/comms/rpc_macros/src/generator.rs
@@ -198,7 +198,7 @@ impl RpcCodeGenerator {
             pub async fn connect<TSubstream>(framed: #dep_mod::CanonicalFraming<TSubstream>) -> Result<Self, #dep_mod::RpcError>
               where TSubstream: #dep_mod::AsyncRead + #dep_mod::AsyncWrite + Unpin + Send + #dep_mod::StreamId + 'static {
                 use #dep_mod::NamedProtocolService;
-                let inner = #dep_mod::RpcClient::connect(Default::default(), Default::default(), framed, Self::PROTOCOL_NAME.into(), Default::default()).await?;
+                let inner = #dep_mod::RpcClient::connect(Default::default(), Default::default(), framed, Self::PROTOCOL_NAME.into(), None).await?;
                 Ok(Self { inner })
             }
 


### PR DESCRIPTION
Description
---
Added the ability to close RPC connections for a given peer:
- The RPC server can request sessions to be dropped.
- RPC session counts on the server are atomically managed with RPC server sessions.
- When a client peer connection (final clone) drops, as a safety precaution, all client RPC connections will be signalled to drop, resulting in the server RPC sessions closing.
- Improved management of wallet connectivity to base nodes.
- **Edit:** Introduced an optional culling of the oldest client RPC connection(s) into an RPC server for a given peer (_default: true_). This will allow all new RPC connections to succeed. If older RPC sessions are dropped by the server while the client is in use, the client can re-request an RPC connection, but many times the clients are not aware of the RPC sessions held on the server.

Motivation and Context
---
Wallets keep on hitting their maximum allowed RPC sessions in the server.

How Has This Been Tested?
---
- Added new unit tests.
- System-level testing.

What process can a PR reviewer use to test or verify this change?
---
Code review

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
