### PR TITLE
Update README.md with correct discord link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1017,4 +1017,4 @@ to generate the documentation. The generated html sits in `target/doc/`. Alterna
 
 ## Conversation channels
 
-We're generally on [Discord](https://discord.gg/q3Sfzb8S2V).
+We're generally on [Discord](https://discord.gg/tari).


### PR DESCRIPTION
Looks like the old Tari discord link was expired. Updated it with the non-expiring link.

Description
---
Old Discord link was an expired link. Updated it with a new non-expiring discord link.

Motivation and Context
---
Want to make sure that people reading the Tari README.md are able to get correctly directed to the Tari Discord.

How Has This Been Tested?
---
The new, suggested Tari Discord link works.

What process can a PR reviewer use to test or verify this change?
---
Try the new, suggested Tari Discord link.

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
