### PR TITLE
fix(comms): ensure that inbound messaging terminates on disconnect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7891,6 +7891,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.26.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8215,18 +8225,18 @@ dependencies = [
 
 [[package]]
 name = "yamux"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f97202f6b125031b95d83e01dc57292b529384f80bfae4677e4bbc10178cf72"
+checksum = "a31b5e376a8b012bee9c423acdbb835fc34d45001cfa3106236a624e4b738028"
 dependencies = [
  "futures 0.3.29",
- "instant",
  "log",
  "nohash-hasher",
  "parking_lot 0.12.1",
  "pin-project 1.1.3",
  "rand",
  "static_assertions",
+ "web-time",
 ]
 
 [[package]]

--- a/comms/core/src/protocol/messaging/error.rs
+++ b/comms/core/src/protocol/messaging/error.rs
@@ -53,6 +53,8 @@ pub enum MessagingProtocolError {
     PeerConnectionError(#[from] PeerConnectionError),
     #[error("Failed to dial peer: {0}")]
     PeerDialFailed(ConnectivityError),
+    #[error("Connectivity error: {0}")]
+    ConnectivityError(#[from] ConnectivityError),
     #[error("IO Error: {0}")]
     Io(io::Error),
     #[error("Sender error: {0}")]


### PR DESCRIPTION
Description
---
fix(comms): ensure that inbound messaging terminates on disconnect

Motivation and Context
---
Ensure that the inbound messaging worker terminates when the peer connection is disconnected.
This PR ensures this by using the `PeerConnection::on_disconnect` future. It has not been confirmed 
that the inbound worker would not terminate before however this PR will guarantee it.

How Has This Been Tested?
---
Updated unit tests. 

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
