### PR TITLE
feat(network): implement basic peer banning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3901,7 +3901,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-messaging"
-version = "1.7.0-pre.2"
+version = "1.8.0-pre.0"
 dependencies = [
  "async-trait",
  "futures-bounded",
@@ -4058,7 +4058,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-substream"
-version = "1.7.0-pre.2"
+version = "1.8.0-pre.0"
 dependencies = [
  "libp2p",
  "smallvec 1.13.2",
@@ -6219,7 +6219,7 @@ dependencies = [
 
 [[package]]
 name = "proto_builder"
-version = "1.7.0-pre.2"
+version = "1.8.0-pre.0"
 dependencies = [
  "prost-build 0.13.3",
  "sha2 0.10.8",
@@ -8144,7 +8144,7 @@ dependencies = [
 
 [[package]]
 name = "tari_network"
-version = "1.7.0-pre.2"
+version = "1.8.0-pre.0"
 dependencies = [
  "anyhow",
  "humantime 2.1.0",
@@ -8198,7 +8198,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_framework"
-version = "1.7.0-pre.2"
+version = "1.8.0-pre.0"
 dependencies = [
  "async-trait",
  "bitflags 2.6.0",
@@ -8223,7 +8223,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_macros"
-version = "1.7.0-pre.2"
+version = "1.8.0-pre.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8288,7 +8288,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm"
-version = "1.7.0-pre.2"
+version = "1.8.0-pre.0"
 dependencies = [
  "libp2p",
  "libp2p-messaging",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["The Tari Development Community"]
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "1.7.0-pre.2"
+version = "1.8.0-pre.0"
 edition = "2021"
 
 [workspace]

--- a/applications/minotari_console_wallet/log4rs_sample.yml
+++ b/applications/minotari_console_wallet/log4rs_sample.yml
@@ -97,6 +97,13 @@ appenders:
     encoder:
       pattern: "{d(%Y-%m-%d %H:%M:%S.%f)} [{t}] [Thread:{I}] {l:5} {m}{n}"
 
+  # An appender named "fail2ban" that writes to a file with a custom pattern encoder
+  fail2ban:
+    kind: file
+    path: "{{log_dir}}/log/wallet/fail2ban.log"
+    encoder:
+      pattern: "{d(%Y-%m-%d %H:%M:%S.%f)} [{t}] [Thread:{I}] {l:5} {m}{n}"
+
 # root (to base_layer)
 root:
   level: debug
@@ -174,3 +181,10 @@ loggers:
     appenders:
       - other
     additive: false
+  # fail2ban logs
+  fail2ban:
+    level: info
+    appenders:
+      - fail2ban
+    additive: false
+

--- a/applications/minotari_console_wallet/src/ui/components/network_tab.rs
+++ b/applications/minotari_console_wallet/src/ui/components/network_tab.rs
@@ -126,7 +126,7 @@ impl NetworkTab {
             .heading_style(Style::default().fg(Color::Magenta))
             .max_width(MAX_WIDTH)
             .add_column(Some("Type"), Some(17), column0_items)
-            .add_column(Some("NodeID"), Some(57), column1_items)
+            .add_column(Some("PeerID"), Some(57), column1_items)
             .add_column(Some("Public Key"), Some(65), column2_items);
         column_list.render(f, areas[1], &mut base_node_list_state);
     }
@@ -215,7 +215,7 @@ impl NetworkTab {
         let column_list = MultiColumnList::new()
             .heading_style(Style::default().fg(Color::Magenta))
             .max_width(MAX_WIDTH)
-            .add_column(Some("NodeID"), Some(27), column0_items)
+            .add_column(Some("PeerID"), Some(53), column0_items)
             .add_column(Some("Public Key"), Some(65), column1_items)
             .add_column(Some("User Agent"), Some(MAX_WIDTH.saturating_sub(93)), column2_items);
         column_list.render(f, list_areas[0], &mut ListState::default());

--- a/applications/minotari_node/log4rs_sample.yml
+++ b/applications/minotari_node/log4rs_sample.yml
@@ -104,6 +104,13 @@ appenders:
     encoder:
       pattern: "{d(%Y-%m-%d %H:%M:%S.%f)} [{t}] [Thread:{I}] {l:5} {m}{n} // {f}:{L} "
 
+  # An appender named "fail2ban" that writes to a file with a custom pattern encoder
+  fail2ban:
+    kind: file
+    path: "{{log_dir}}/log/base_node/fail2ban.log"
+    encoder:
+      pattern: "{d(%Y-%m-%d %H:%M:%S.%f)} [{t}] [Thread:{I}] {l:5} {m}{n}"
+
 # Set the default logging level to "info"
 root:
   level: warn
@@ -195,3 +202,9 @@ loggers:
     level: warn
     appenders:
       - message_logging
+  # fail2ban logs
+  fail2ban:
+    level: info
+    appenders:
+      - fail2ban
+    additive: false

--- a/applications/minotari_node/src/commands/command/whoami.rs
+++ b/applications/minotari_node/src/commands/command/whoami.rs
@@ -24,46 +24,66 @@ use anyhow::Error;
 use async_trait::async_trait;
 use clap::Parser;
 use qrcode::{render::unicode, QrCode};
-use tari_network::multiaddr::{Multiaddr, Protocol};
+use tari_network::GlobalIp;
 
 use super::{CommandContext, HandleCommand};
 
 /// Display identity information about this node,
 /// including: public key, node ID and the public address
 #[derive(Debug, Parser)]
-pub struct Args {}
+pub struct Args {
+    /// Number of addresses to show
+    #[clap(default_value_t = 5)]
+    num_show_addrs: usize,
+}
 
 #[async_trait]
 impl HandleCommand<Args> for CommandContext {
-    async fn handle_command(&mut self, _: Args) -> Result<(), Error> {
-        self.whoami().await
+    async fn handle_command(&mut self, args: Args) -> Result<(), Error> {
+        self.whoami(args).await
     }
 }
 
 impl CommandContext {
     /// Function to process the whoami command
-    pub async fn whoami(&self) -> Result<(), Error> {
+    pub async fn whoami(&self, args: Args) -> Result<(), Error> {
         let peer_info = self.network.get_local_peer_info().await?;
-        let peer = format!(
-            "{}::{}",
-            peer_info.public_key.try_into_sr25519()?.inner_key(),
-            peer_info
-                .listen_addrs
-                .iter()
-                .filter(|addr| !is_loopback(addr))
-                .map(|addr| addr.to_string())
-                .collect::<Vec<_>>()
-                .join("::")
-        );
 
-        println!("{}", peer);
+        let pk = peer_info.public_key.try_into_sr25519()?;
+        let num_addrs = peer_info.listen_addrs.len();
+        let (global, local) = peer_info
+            .listen_addrs
+            .iter()
+            .partition::<Vec<_>, _>(|addr| addr.is_global_ip());
+        let qr_addresses = global
+            .iter()
+            .chain(Some(&local).filter(|_| !global.is_empty()).into_iter().flatten())
+            .take(args.num_show_addrs)
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join("::");
+
+        let peer_str = format!("{}::{}", pk.inner_key(), qr_addresses);
+
+        println!("🔑 Public Key:  {}", pk.inner_key());
+        println!("🪪 Peer ID:  {}", peer_info.peer_id);
+        println!("🏠️ Addresses ({num_addrs})");
+        for addr in global.into_iter().chain(local).take(args.num_show_addrs) {
+            println!("- {addr}");
+        }
+        if num_addrs > 0 && num_addrs > args.num_show_addrs {
+            println!("{} more...", num_addrs - args.num_show_addrs);
+        }
+
+        println!();
+        println!("{peer_str}");
         println!();
         let network = self.config.network();
         let qr_link = format!(
-            "tari://{}/base_nodes/add?name={}&peer={}",
-            network, peer_info.peer_id, peer
+            "tari://{}/base_nodes/add?name={}&peer_str={}",
+            network, peer_info.peer_id, peer_str
         );
-        let code = QrCode::new(qr_link).unwrap();
+        let code = QrCode::new(qr_link)?;
         let image = code
             .render::<unicode::Dense1x2>()
             .dark_color(unicode::Dense1x2::Dark)
@@ -74,13 +94,5 @@ impl CommandContext {
             .fold("".to_string(), |acc, l| format!("{}{}\n", acc, l));
         println!("{}", image);
         Ok(())
-    }
-}
-
-fn is_loopback(addr: &Multiaddr) -> bool {
-    match addr.iter().next() {
-        Some(Protocol::Ip4(ip)) => ip.is_loopback(),
-        Some(Protocol::Ip6(ip)) => ip.is_loopback(),
-        _ => false,
     }
 }

--- a/base_layer/wallet_ffi/src/error.rs
+++ b/base_layer/wallet_ffi/src/error.rs
@@ -559,6 +559,10 @@ impl From<NetworkError> for LibWalletError {
                 code: 912,
                 message: value.to_string(),
             },
+            NetworkError::RefuseDialPeerBanned { .. } => Self {
+                code: 913,
+                message: value.to_string(),
+            },
         }
     }
 }

--- a/network/core/src/error.rs
+++ b/network/core/src/error.rs
@@ -65,6 +65,8 @@ pub enum NetworkError {
     MessagingDisabled,
     #[error("Failed to add peer: {details}")]
     FailedToAddPeer { details: String },
+    #[error("Refusing to dial peer {peer_id} because it is banned")]
+    RefuseDialPeerBanned { peer_id: PeerId },
 }
 
 impl From<oneshot::error::RecvError> for NetworkError {

--- a/network/core/src/global_ip.rs
+++ b/network/core/src/global_ip.rs
@@ -5,7 +5,7 @@
 
 use tari_swarm::libp2p::{multiaddr::Protocol, Multiaddr};
 
-pub(crate) trait GlobalIp {
+pub trait GlobalIp {
     fn is_global_ip(&self) -> bool;
 }
 

--- a/network/core/src/lib.rs
+++ b/network/core/src/lib.rs
@@ -26,6 +26,7 @@ pub use autonat::*;
 pub use config::*;
 pub use connection::*;
 pub use event::*;
+pub use global_ip::*;
 pub use gossip::*;
 pub use handle::*;
 pub use message::*;

--- a/network/core/src/messaging.rs
+++ b/network/core/src/messaging.rs
@@ -16,12 +16,12 @@ pub enum MessagingRequest<TMsg: MessageSpec> {
     SendMessage {
         peer: PeerId,
         message: TMsg::Message,
-        reply_tx: Reply<()>,
+        reply: Reply<()>,
     },
     SendMulticast {
         destination: MulticastDestination,
         message: TMsg::Message,
-        reply_tx: Reply<usize>,
+        reply: Reply<usize>,
     },
 }
 
@@ -47,7 +47,7 @@ impl<TMsg: MessageSpec> OutboundMessager<TMsg> for OutboundMessaging<TMsg> {
             .send(MessagingRequest::SendMessage {
                 peer,
                 message: message.into(),
-                reply_tx: tx,
+                reply: tx,
             })
             .await
             .map_err(|_| NetworkingHandleError::ServiceHasShutdown)?;
@@ -64,7 +64,7 @@ impl<TMsg: MessageSpec> OutboundMessager<TMsg> for OutboundMessaging<TMsg> {
             .send(MessagingRequest::SendMulticast {
                 destination: dest.into(),
                 message: message.into(),
-                reply_tx: tx,
+                reply: tx,
             })
             .await
             .map_err(|_| NetworkingHandleError::ServiceHasShutdown)?;


### PR DESCRIPTION
Description
---
feat(network): implement basic peer banning
feat(network): basic impl of fail2ban logs
fix: improve whois command

Motivation and Context
---
Peers were marked as banned but the ban was not enforced.

This PR also includes logs that can be used to implement fail2ban.

Note bans are not enforced in the application on restart (no persistence). However if fail2ban is implemented the ban will continue to be enforced there.

How Has This Been Tested?
---
Manually

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release
notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think
about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
