### PR TITLE
chore(ci): fix arm64 builds

### DIFF
--- a/.github/workflows/build_binaries.json
+++ b/.github/workflows/build_binaries.json
@@ -13,7 +13,7 @@
     "rust": "stable",
     "target": "aarch64-unknown-linux-gnu",
     "cross": true,
-    "flags": "--features libtor --workspace --exclude minotari_mining_helper_ffi --exclude tari_integration_tests",
+    "flags": "--workspace --exclude minotari_mining_helper_ffi --exclude tari_integration_tests",
     "build_metric": true
   },
   {
@@ -23,7 +23,7 @@
     "target": "riscv64gc-unknown-linux-gnu",
     "cross": true,
     "features": "safe",
-    "flags": "--features libtor --workspace --exclude minotari_mining_helper_ffi --exclude tari_integration_tests",
+    "flags": "--workspace --exclude minotari_mining_helper_ffi --exclude tari_integration_tests",
     "build_metric": true,
     "build_enabled": true,
     "best_effort": true


### PR DESCRIPTION
Description
Remove libtor feature and fix arm64 builds

Motivation and Context
Re-enabled arm64 builds

How Has This Been Tested?
Builds local fork as well as locally
