### PR TITLE
feat: fix base node shutdown

### DIFF
--- a/applications/minotari_node/src/commands/command/mod.rs
+++ b/applications/minotari_node/src/commands/command/mod.rs
@@ -97,6 +97,12 @@ pub struct Args {
     pub command: Command,
 }
 
+impl Args {
+    pub fn is_quit(&self) -> bool {
+        matches!(self.command, Command::Quit(_) | Command::Exit(_))
+    }
+}
+
 #[derive(Debug, Subcommand, EnumVariantNames)]
 #[strum(serialize_all = "kebab-case")]
 pub enum Command {

--- a/applications/minotari_node/src/config.rs
+++ b/applications/minotari_node/src/config.rs
@@ -142,7 +142,8 @@ pub struct BaseNodeConfig {
     pub state_machine: BaseNodeStateMachineConfig,
     /// Obscure GRPC error responses
     pub report_grpc_error: bool,
-    // Interval to check if the base node is still in sync with the network
+    /// Interval to check if the base node is still in sync with the network
+    #[serde(with = "serializers::seconds")]
     pub tari_pulse_interval: Duration,
 }
 

--- a/base_layer/core/src/base_node/tari_pulse_service/mod.rs
+++ b/base_layer/core/src/base_node/tari_pulse_service/mod.rs
@@ -118,6 +118,7 @@ impl TariPulseService {
         let mut interval = time::interval(self.config.check_interval);
         let mut interval_failed = time::interval(Duration::from_millis(100));
         loop {
+            interval.tick().await;
             let passed_checkpoints = match self.passed_checkpoints(&mut base_node_service).await {
                 Ok(passed) => passed,
                 Err(err) => {
@@ -130,7 +131,6 @@ impl TariPulseService {
             notify_passed_checkpoints
                 .send(!passed_checkpoints)
                 .expect("Channel should be open");
-            interval.tick().await;
         }
     }
 


### PR DESCRIPTION
Description
---
Fixed the base node shutdown on Ubuntu (and hopefully on MacOS) whereas pressing Ctrl-C multiple times rendered the command line interface in an undefined state. This was not issue on Windows.

**Note:** The change to 'base_layer\core\src\base_node\tari_pulse_service\mod.rs' is an interim change to enable testing (getting rid of the repeated command-line spam) but not required for the base node to shut down. More changes in #6696.

Motivation and Context
---
The base node did not shut down properly on Ubuntu and MacOs.

How Has This Been Tested?
---
System-level testing on Windows and Ubuntu (WSL).

What process can a PR reviewer use to test or verify this change?
---
System-level testing - still outstanding on MacOS

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
