### PR TITLE
feat: pin hickory-client and hickory-resolver

### DIFF
--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -93,7 +93,7 @@ tiny-keccak = { package = "tari-tiny-keccak", version = "2.0.2", features = [
     "keccak",
 ] }
 dirs-next = "1.0.2"
-hickory-client = { version = "0.25.0-alpha.2", features = ["dns-over-rustls", "dnssec-openssl"] }
+hickory-client = { version = "=0.25.0-alpha.2", features = ["dns-over-rustls", "dnssec-openssl"] }
 anyhow = "1.0.53"
 
 [dev-dependencies]

--- a/base_layer/p2p/Cargo.toml
+++ b/base_layer/p2p/Cargo.toml
@@ -37,8 +37,8 @@ tokio-stream = { version = "0.1.9", default-features = false, features = [
     "time",
 ] }
 tower = "0.4.11"
-hickory-client = { version = "0.25.0-alpha.2", features = ["dns-over-rustls"] }
-hickory-resolver = "0.25.0-alpha.2"
+hickory-client = { version = "=0.25.0-alpha.2", features = ["dns-over-rustls"] }
+hickory-resolver = "=0.25.0-alpha.2"
 webpki-roots = "0.26.6"
 
 [dev-dependencies]


### PR DESCRIPTION
Description
---
Pined hickory-client and hickory-resolver

Motivation and Context
---
There was an interface change between 
- `hickory-client v0.25.0-alpha.2` and `hickory-client v0.25.0-alpha.3`
- `hickory-resolver v0.25.0-alpha.2` and `hickory-resolver v0.25.0-alpha.3`
and other projects that use `"https://github.com/tari-project/tari.git"` as dependency will resolve to the latter and not the former due to its lock file being generated after that of `"https://github.com/tari-project/tari.git"`.

How Has This Been Tested?
---
All builds succeed

What process can a PR reviewer use to test or verify this change?
---
Review CI builds

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
