### PR TITLE
feat: update peer liveness

### DIFF
--- a/applications/minotari_node/src/cli.rs
+++ b/applications/minotari_node/src/cli.rs
@@ -43,14 +43,21 @@ pub struct Cli {
     /// Watch a command in the non-interactive mode.
     #[clap(long)]
     pub watch: Option<String>,
+    /// Run in test profile mode
     #[clap(long, alias = "profile")]
     pub profile_with_tokio_console: bool,
+    /// Enable gRPC
     #[clap(long, env = "MINOTARI_NODE_ENABLE_GRPC", alias = "enable-grpc")]
     pub grpc_enabled: bool,
+    /// Enable mining
     #[clap(long, env = "MINOTARI_NODE_ENABLE_MINING", alias = "enable-mining")]
     pub mining_enabled: bool,
+    /// Enable the second layer gRPC server
     #[clap(long, env = "MINOTARI_NODE_SECOND_LAYER_GRPC_ENABLED", alias = "enable-second-layer")]
     pub second_layer_grpc_enabled: bool,
+    /// Disable the splash screen
+    #[clap(long)]
+    pub disable_splash_screen: bool,
 }
 
 impl ConfigOverrideProvider for Cli {

--- a/applications/minotari_node/src/commands/cli_loop.rs
+++ b/applications/minotari_node/src/commands/cli_loop.rs
@@ -79,8 +79,10 @@ impl CliLoop {
     ///
     /// ## Returns
     /// Doesn't return anything
-    pub async fn cli_loop(mut self) {
-        cli::print_banner(self.commands.clone(), 3);
+    pub async fn cli_loop(mut self, disable_splash_screen: bool) {
+        if !disable_splash_screen {
+            cli::print_banner(self.commands.clone(), 3);
+        }
 
         if self.non_interactive {
             self.watch_loop_non_interactive().await;

--- a/applications/minotari_node/src/lib.rs
+++ b/applications/minotari_node/src/lib.rs
@@ -91,6 +91,7 @@ pub async fn run_base_node(
         grpc_enabled: false,
         mining_enabled: false,
         second_layer_grpc_enabled: false,
+        disable_splash_screen: false,
     };
 
     run_base_node_with_cli(node_identity, config, cli, shutdown).await
@@ -170,7 +171,7 @@ pub async fn run_base_node_with_cli(
     }
 
     info!(target: LOG_TARGET, "Minotari base node has STARTED");
-    main_loop.cli_loop().await;
+    main_loop.cli_loop(cli.disable_splash_screen).await;
 
     ctx.wait_for_shutdown().await;
 


### PR DESCRIPTION
Description
---
- Updated peer liveness to print test results to the console, one item per row.
- Added a command-line arg option to disable the splash screen; this is useful for screen scraping in an automated test environment.

Motivation and Context
---
These changes will simplify automated monitoring.

How Has This Been Tested?
---
System-level testing
```
.\minotari_node.exe --non-interactive-mode --watch "test-peer-liveness 8a24a7fb8ff2f1183c02ac52d488a13cc1104f970cc9a6fb3dd5f17ea1d85212 /ip4/3.248.103.200/tcp/18189 true true false" -p esmeralda.p2p.seeds.dns_seeds="" -p esmeralda.p2p.seeds.peer_seeds="" --network esmeralda --disable-splash-screen
Initializing logging according to "C:\\Users\\hansie\\.tari\\esmeralda\\config\\base_node\\log4rs.yml"
Node started in non-interactive mode (pid = 17156)

Testing peer liveness...

🏓 Peer (b7ed45c971da86409939de9397, 8a24a7fb8ff2f1183c02ac52d488a13cc1104f970cc9a6fb3dd5f17ea1d85212) dialed successfully
☎️  Dialing peer...
🏓 Pinging peer (b7ed45c971da86409939de9397, 8a24a7fb8ff2f1183c02ac52d488a13cc1104f970cc9a6fb3dd5f17ea1d85212) with nonce 3324112300086574482 ...
⚡️ Peer connected in 1537ms!
Connection: Id: 0, Node ID: b7ed45c971da8640, Direction: Outbound, Peer Address: /ip4/3.248.103.200/tcp/18189, Age: 276µs, #Substreams: 2, #Refs: 5
🏓️ Pong: peer (b7ed45c971da86409939de9397, 8a24a7fb8ff2f1183c02ac52d488a13cc1104f970cc9a6fb3dd5f17ea1d85212) responded with nonce 3324112300086574482, round-trip-time is 2.19s!

✅ Peer is responsive
  Date Time:     2024-12-11 18:20:40
  Public Key:    8a24a7fb8ff2f1183c02ac52d488a13cc1104f970cc9a6fb3dd5f17ea1d85212
  Node ID:       b7ed45c971da86409939de9397
  Address:       /ip4/3.248.103.200/tcp/18189
  Result:        Success
  Test Duration: 2.19s

📝 Test result written to file: peer_liveness_test.csv
The liveness test is complete and base node will now exit
```

What process can a PR reviewer use to test or verify this change?
---
Code review
System-level testing

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
