### PR TITLE
fix(grpc): return bool if mempool is out of sync instead of returning…

### DIFF
--- a/applications/minotari_app_grpc/proto/block.proto
+++ b/applications/minotari_app_grpc/proto/block.proto
@@ -134,5 +134,8 @@ message NewBlockTemplate {
     // This flag indicates if the inputs, outputs and kernels have been sorted internally, that is, the sort() method
     // has been called. This may be false even if all components are sorted.
     AggregateBody body = 2;
+    // Sometimes the mempool has not synced to the latest tip, this flag indicates if the mempool is out of sync.
+    // In most cases the next call to get_new_block_template will return a block with the mempool in sync.
+    bool is_mempool_in_sync = 3;
 }
 

--- a/applications/minotari_app_grpc/src/conversions/new_block_template.rs
+++ b/applications/minotari_app_grpc/src/conversions/new_block_template.rs
@@ -68,6 +68,7 @@ impl TryFrom<NewBlockTemplate> for grpc::NewBlockTemplate {
                     .collect(),
             }),
             header: Some(header),
+            is_mempool_in_sync: block.is_mempool_in_sync,
         })
     }
 }
@@ -105,6 +106,7 @@ impl TryFrom<grpc::NewBlockTemplate> for NewBlockTemplate {
             target_difficulty: Default::default(),
             reward: Default::default(),
             total_fees: Default::default(),
+            is_mempool_in_sync: block.is_mempool_in_sync,
         })
     }
 }

--- a/base_layer/core/src/blocks/new_block_template.rs
+++ b/base_layer/core/src/blocks/new_block_template.rs
@@ -51,6 +51,9 @@ pub struct NewBlockTemplate {
     pub reward: MicroMinotari,
     /// The total fees is the sum of all the fees in the block.
     pub total_fees: MicroMinotari,
+    /// Sometimes the mempool has not synced to the latest tip, this flag indicates if the mempool is out of sync.
+    /// In most cases the next call to get_new_block_template will return a block with the mempool in sync.
+    pub is_mempool_in_sync: bool,
 }
 
 impl NewBlockTemplate {
@@ -58,6 +61,7 @@ impl NewBlockTemplate {
         block: Block,
         target_difficulty: Difficulty,
         reward: MicroMinotari,
+        is_mempool_in_sync: bool,
     ) -> Result<Self, TransactionError> {
         let Block { header, body } = block;
         let total_fees = body.get_total_fee()?;
@@ -67,6 +71,7 @@ impl NewBlockTemplate {
             target_difficulty,
             reward,
             total_fees,
+            is_mempool_in_sync,
         })
     }
 }

--- a/base_layer/core/src/chain_storage/tests/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/tests/blockchain_database.rs
@@ -441,7 +441,8 @@ mod prepare_new_block {
     fn it_errors_for_genesis_block() {
         let db = setup();
         let genesis = db.fetch_block(0, true).unwrap();
-        let template = NewBlockTemplate::from_block(genesis.block().clone(), Difficulty::min(), 5000 * T).unwrap();
+        let template =
+            NewBlockTemplate::from_block(genesis.block().clone(), Difficulty::min(), 5000 * T, true).unwrap();
         let err = db.prepare_new_block(template).unwrap_err();
         assert!(matches!(err, ChainStorageError::InvalidArguments { .. }));
     }
@@ -452,7 +453,7 @@ mod prepare_new_block {
         let genesis = db.fetch_block(0, true).unwrap();
         let next_block = BlockHeader::from_previous(genesis.header());
         let mut template =
-            NewBlockTemplate::from_block(next_block.into_builder().build(), Difficulty::min(), 5000 * T).unwrap();
+            NewBlockTemplate::from_block(next_block.into_builder().build(), Difficulty::min(), 5000 * T, true).unwrap();
         // This would cause a panic if the sanity checks were not there
         template.header.height = 100;
         let err = db.prepare_new_block(template.clone()).unwrap_err();
@@ -468,7 +469,7 @@ mod prepare_new_block {
         let genesis = db.fetch_block(0, true).unwrap();
         let next_block = BlockHeader::from_previous(genesis.header());
         let template =
-            NewBlockTemplate::from_block(next_block.into_builder().build(), Difficulty::min(), 5000 * T).unwrap();
+            NewBlockTemplate::from_block(next_block.into_builder().build(), Difficulty::min(), 5000 * T, true).unwrap();
         let block = db.prepare_new_block(template).unwrap();
         assert_eq!(block.header.height, 1);
     }

--- a/base_layer/core/tests/helpers/block_builders.rs
+++ b/base_layer/core/tests/helpers/block_builders.rs
@@ -149,6 +149,7 @@ async fn genesis_template(
         header.into_builder().with_coinbase_utxo(utxo, kernel).build(),
         Difficulty::min(),
         coinbase_value,
+        true,
     )
     .unwrap();
     (block, output)
@@ -315,6 +316,7 @@ pub async fn chain_block(
             .build(),
         Difficulty::min(),
         reward,
+        true,
     )
     .unwrap()
 }
@@ -339,6 +341,7 @@ pub fn chain_block_with_coinbase(
             .build(),
         achieved_difficulty.unwrap_or(Difficulty::min()),
         consensus.get_block_reward_at(height),
+        true,
     )
     .unwrap()
 }
@@ -377,6 +380,7 @@ pub async fn chain_block_with_new_coinbase(
             .build(),
         Difficulty::min(),
         reward,
+        true,
     )
     .unwrap();
     (template, coinbase_output)

--- a/base_layer/core/tests/helpers/database.rs
+++ b/base_layer/core/tests/helpers/database.rs
@@ -59,6 +59,7 @@ pub async fn create_orphan_block(
             .build(),
         Difficulty::min(),
         coinbase_value,
+        true,
     )
     .unwrap();
     Block::new(template.header.into(), template.body)

--- a/base_layer/core/tests/tests/block_validation.rs
+++ b/base_layer/core/tests/tests/block_validation.rs
@@ -1351,6 +1351,7 @@ async fn test_fee_overflow() {
             .build(),
         Difficulty::min(),
         consensus_manager.get_block_reward_at(height),
+        true,
     );
     assert!(template_result.is_err());
     assert_eq!(

--- a/base_layer/tari_mining_helper_ffi/src/lib.rs
+++ b/base_layer/tari_mining_helper_ffi/src/lib.rs
@@ -804,7 +804,7 @@ mod tests {
             let error_ptr = &mut error as *mut c_int;
             let header = BlockHeader::new(0);
             let block =
-                NewBlockTemplate::from_block(header.into_builder().build(), Difficulty::min(), 0.into()).unwrap();
+                NewBlockTemplate::from_block(header.into_builder().build(), Difficulty::min(), 0.into(), true).unwrap();
 
             let block_bytes = borsh::to_vec(&block).unwrap();
             #[allow(clippy::cast_possible_truncation)]


### PR DESCRIPTION
… an error

Removed the error "Mempool out of sync, blockchain db advanced passed current tip in mempool storage;" when getting a block template and instead return a bool that indicates such. 

The clients that are worried about this can check the flag and request a new template, while clients that are not worried about this can accept the data for what it is
