### PR TITLE
feat: new grpc method

### DIFF
--- a/applications/minotari_app_grpc/proto/base_node.proto
+++ b/applications/minotari_app_grpc/proto/base_node.proto
@@ -99,6 +99,7 @@ service BaseNode {
     // Get templates
     rpc GetTemplateRegistrations(GetTemplateRegistrationsRequest) returns (stream GetTemplateRegistrationResponse);
     rpc GetSideChainUtxos(GetSideChainUtxosRequest) returns (stream GetSideChainUtxosResponse);
+    rpc GetNetworkHashRate(GetNetworkHashRateRequest) returns (GetNetworkHashRateResponse);
 }
 
 message GetAssetMetadataRequest {
@@ -519,5 +520,17 @@ message GetSideChainUtxosRequest {
 message GetSideChainUtxosResponse {
     BlockInfo block_info = 1;
     repeated TransactionOutput outputs = 2;
+}
+
+message GetNetworkHashRateRequest {
+}
+
+message GetNetworkHashRateResponse {
+    // The block reward of the next tip
+    uint64 reward = 1;
+    // estimate sha3x hash rate
+    uint64 sha3x_estimated_hash_rate = 2;
+    // estimate randomx hash rate
+    uint64 randomx_estimated_hash_rate = 3;
 }
 

--- a/applications/minotari_app_grpc/proto/base_node.proto
+++ b/applications/minotari_app_grpc/proto/base_node.proto
@@ -99,7 +99,7 @@ service BaseNode {
     // Get templates
     rpc GetTemplateRegistrations(GetTemplateRegistrationsRequest) returns (stream GetTemplateRegistrationResponse);
     rpc GetSideChainUtxos(GetSideChainUtxosRequest) returns (stream GetSideChainUtxosResponse);
-    rpc GetNetworkHashRate(GetNetworkHashRateRequest) returns (GetNetworkHashRateResponse);
+    rpc GetNetworkState(GetNetworkStateRequest) returns (GetNetworkStateResponse);
 }
 
 message GetAssetMetadataRequest {
@@ -522,15 +522,23 @@ message GetSideChainUtxosResponse {
     repeated TransactionOutput outputs = 2;
 }
 
-message GetNetworkHashRateRequest {
+message GetNetworkStateRequest {
 }
 
-message GetNetworkHashRateResponse {
+message GetNetworkStateResponse {
+   // metadata
+    MetaData metadata = 1;
+    // has the base node synced
+    bool initial_sync_achieved = 2;
+    //current state of the base node
+    BaseNodeState base_node_state = 3;
+    // do we have failed checkpoints
+    bool failed_checkpoints = 4;
     // The block reward of the next tip
-    uint64 reward = 1;
+    uint64 reward = 5;
     // estimate sha3x hash rate
-    uint64 sha3x_estimated_hash_rate = 2;
+    uint64 sha3x_estimated_hash_rate = 6;
     // estimate randomx hash rate
-    uint64 randomx_estimated_hash_rate = 3;
+    uint64 randomx_estimated_hash_rate = 7;
 }
 

--- a/applications/minotari_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/minotari_node/src/grpc/base_node_grpc_server.rs
@@ -689,6 +689,7 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
         Ok(Response::new(rx))
     }
 
+    #[allow(clippy::too_many_lines)]
     async fn get_new_block_template(
         &self,
         request: Request<tari_rpc::NewBlockTemplateRequest>,

--- a/applications/minotari_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/minotari_node/src/grpc/base_node_grpc_server.rs
@@ -367,42 +367,49 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
     async fn get_network_hash_rate(
         &self,
         _request: Request<tari_rpc::GetNetworkHashRateRequest>,
-    ) -> Result<Response<tari_rpc::GetNetworkHashRateResponse>, Status>{
+    ) -> Result<Response<tari_rpc::GetNetworkHashRateResponse>, Status> {
         trace!(target: LOG_TARGET, "Incoming GRPC request for get network hash rate");
         let report_error_flag = self.report_error_flag();
         let mut handler = self.node_service.clone();
         let metadata = handler.get_metadata().await.map_err(|e| {
             warn!(
-                    target: LOG_TARGET,
-                    "Could not get node tip: {}",
-                    e.to_string()
-                );
+                target: LOG_TARGET,
+                "Could not get node tip: {}",
+                e.to_string()
+            );
             obscure_error_if_true(report_error_flag, Status::internal(e.to_string()))
         })?;
-        let reward = self.consensus_rules.get_block_reward_at(metadata.best_block_height()).as_u64();
+        let reward = self
+            .consensus_rules
+            .get_block_reward_at(metadata.best_block_height())
+            .as_u64();
         let constants = self.consensus_rules.consensus_constants(metadata.best_block_height());
-        let sha_target_difficulty = handler.get_target_difficulty_for_next_block(PowAlgorithm::Sha3x).await.map_err(|e| {
-            warn!(
+        let sha_target_difficulty = handler
+            .get_target_difficulty_for_next_block(PowAlgorithm::Sha3x)
+            .await
+            .map_err(|e| {
+                warn!(
                     target: LOG_TARGET,
                     "Could not get target difficulty for Sha3x: {}",
                     e.to_string()
                 );
-            obscure_error_if_true(report_error_flag, Status::internal(e.to_string()))
-        })?;
-        let sha_target_time = constants
-            .pow_target_block_interval(PowAlgorithm::Sha3x);
-        let sha3x_estimated_hash_rate = sha_target_difficulty.as_u64()/sha_target_time;
-        let rx_target_difficulty = handler.get_target_difficulty_for_next_block(PowAlgorithm::RandomX).await.map_err(|e| {
-            warn!(
+                obscure_error_if_true(report_error_flag, Status::internal(e.to_string()))
+            })?;
+        let sha_target_time = constants.pow_target_block_interval(PowAlgorithm::Sha3x);
+        let sha3x_estimated_hash_rate = sha_target_difficulty.as_u64() / sha_target_time;
+        let rx_target_difficulty = handler
+            .get_target_difficulty_for_next_block(PowAlgorithm::RandomX)
+            .await
+            .map_err(|e| {
+                warn!(
                     target: LOG_TARGET,
                     "Could not get target difficulty for Rx: {}",
                     e.to_string()
                 );
-            obscure_error_if_true(report_error_flag, Status::internal(e.to_string()))
-        })?;
-        let rx_target_time = constants
-            .pow_target_block_interval(PowAlgorithm::RandomX);
-        let randomx_estimated_hash_rate = rx_target_difficulty.as_u64()/rx_target_time;
+                obscure_error_if_true(report_error_flag, Status::internal(e.to_string()))
+            })?;
+        let rx_target_time = constants.pow_target_block_interval(PowAlgorithm::RandomX);
+        let randomx_estimated_hash_rate = rx_target_difficulty.as_u64() / rx_target_time;
 
         let response = tari_rpc::GetNetworkHashRateResponse {
             reward,

--- a/applications/minotari_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/minotari_node/src/grpc/base_node_grpc_server.rs
@@ -78,6 +78,7 @@ use tonic::{Request, Response, Status};
 use crate::{
     builder::BaseNodeContext,
     grpc::{
+        data_cache::DataCache,
         blocks::{block_fees, block_heights, block_size, GET_BLOCKS_MAX_HEIGHTS, GET_BLOCKS_PAGE_SIZE},
         hash_rate::HashRateMovingAverage,
         helpers::{mean, median},
@@ -117,6 +118,7 @@ pub struct BaseNodeGrpcServer {
     report_grpc_error: bool,
     tari_pulse: TariPulseHandle,
     config: BaseNodeConfig,
+    data_cache: DataCache,
 }
 
 impl BaseNodeGrpcServer {
@@ -133,6 +135,7 @@ impl BaseNodeGrpcServer {
             report_grpc_error: ctx.get_report_grpc_error(),
             tari_pulse: ctx.tari_pulse(),
             config,
+            data_cache: DataCache::new(),
         }
     }
 
@@ -364,10 +367,10 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
         Ok(Response::new(rx))
     }
 
-    async fn get_network_hash_rate(
+    async fn get_network_state(
         &self,
-        _request: Request<tari_rpc::GetNetworkHashRateRequest>,
-    ) -> Result<Response<tari_rpc::GetNetworkHashRateResponse>, Status> {
+        _request: Request<tari_rpc::GetNetworkStateRequest>,
+    ) -> Result<Response<tari_rpc::GetNetworkStateResponse>, Status> {
         trace!(target: LOG_TARGET, "Incoming GRPC request for get network hash rate");
         let report_error_flag = self.report_error_flag();
         let mut handler = self.node_service.clone();
@@ -384,39 +387,69 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
             .get_block_reward_at(metadata.best_block_height())
             .as_u64();
         let constants = self.consensus_rules.consensus_constants(metadata.best_block_height());
-        let sha_target_difficulty = handler
-            .get_target_difficulty_for_next_block(PowAlgorithm::Sha3x)
+        let sha3x_estimated_hash_rate = match self.data_cache.get_sha3x_estimated_hash_rate(metadata.best_block_hash())
             .await
-            .map_err(|e| {
-                warn!(
-                    target: LOG_TARGET,
-                    "Could not get target difficulty for Sha3x: {}",
-                    e.to_string()
-                );
-                obscure_error_if_true(report_error_flag, Status::internal(e.to_string()))
-            })?;
-        let sha_target_time = constants.pow_target_block_interval(PowAlgorithm::Sha3x);
-        let sha3x_estimated_hash_rate = sha_target_difficulty.as_u64() / sha_target_time;
-        let rx_target_difficulty = handler
-            .get_target_difficulty_for_next_block(PowAlgorithm::RandomX)
+        {
+            Some(hash_rate) => hash_rate,
+            None => {
+                let target_difficulty = handler
+                    .get_target_difficulty_for_next_block(PowAlgorithm::Sha3x)
+                    .await
+                    .map_err(|e| {
+                        warn!(
+                            target: LOG_TARGET,
+                            "Could not get target difficulty for Sha3x: {}",
+                            e.to_string()
+                        );
+                        obscure_error_if_true(report_error_flag, Status::internal(e.to_string()))
+                    })?;
+                let target_time = constants.pow_target_block_interval(PowAlgorithm::Sha3x);
+                let estimated_hash_rate = target_difficulty.as_u64() / target_time;
+                self.data_cache
+                    .set_sha3x_estimated_hash_rate(estimated_hash_rate, metadata.best_block_hash().clone())
+                    .await;
+                estimated_hash_rate
+            },
+        };
+        let randomx_estimated_hash_rate = match self.data_cache.get_randomx_estimated_hash_rate(metadata.best_block_hash())
             .await
-            .map_err(|e| {
-                warn!(
-                    target: LOG_TARGET,
-                    "Could not get target difficulty for Rx: {}",
-                    e.to_string()
-                );
-                obscure_error_if_true(report_error_flag, Status::internal(e.to_string()))
-            })?;
-        let rx_target_time = constants.pow_target_block_interval(PowAlgorithm::RandomX);
-        let randomx_estimated_hash_rate = rx_target_difficulty.as_u64() / rx_target_time;
+        {
+            Some(hash_rate) => hash_rate,
+            None => {
+                let target_difficulty = handler
+                    .get_target_difficulty_for_next_block(PowAlgorithm::RandomX)
+                    .await
+                    .map_err(|e| {
+                        warn!(
+                            target: LOG_TARGET,
+                            "Could not get target difficulty for RandomX: {}",
+                            e.to_string()
+                        );
+                        obscure_error_if_true(report_error_flag, Status::internal(e.to_string()))
+                    })?;
+                let target_time = constants.pow_target_block_interval(PowAlgorithm::RandomX);
+                let estimated_hash_rate = target_difficulty.as_u64() / target_time;
+                self.data_cache
+                    .set_randomx_estimated_hash_rate(estimated_hash_rate, metadata.best_block_hash().clone())
+                    .await;
+                estimated_hash_rate
+            },
+        };
 
-        let response = tari_rpc::GetNetworkHashRateResponse {
+        let failed_checkpoints = *self.tari_pulse.get_failed_checkpoints_notifier();
+        let status_watch = self.state_machine_handle.get_status_info_watch();
+        let state: tari_rpc::BaseNodeState = (&status_watch.borrow().state_info).into();
+
+        let response = tari_rpc::GetNetworkStateResponse {
+            metadata: Some(metadata.into()),
+            initial_sync_achieved: status_watch.borrow().bootstrapped,
+            base_node_state: state.into(),
+            failed_checkpoints,
             reward,
             sha3x_estimated_hash_rate,
             randomx_estimated_hash_rate,
         };
-        trace!(target: LOG_TARGET, "Sending GetNetworkHashRate response to client");
+        trace!(target: LOG_TARGET, "Sending GetNetworkState response to client");
         Ok(Response::new(response))
     }
 
@@ -680,18 +713,57 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
         })?;
 
         let mut handler = self.node_service.clone();
+        let metadata = handler.get_metadata().await.map_err(|e| {
+            warn!(
+                target: LOG_TARGET,
+                "Could not get node tip: {}",
+                e.to_string()
+            );
+            obscure_error_if_true(report_error_flag, Status::internal(e.to_string()))
+        })?;
 
-        let new_template = handler
-            .get_new_block_template(algo, request.max_weight)
-            .await
-            .map_err(|e| {
-                warn!(
+        let new_template = match algo{
+            PowAlgorithm::Sha3x => {
+                match self.data_cache.get_sha3x_new_block_template(metadata.best_block_hash()).await{
+                    Some(template) => {template},
+                    None => {
+                        let new_template = handler
+                            .get_new_block_template(algo, request.max_weight)
+                            .await
+                            .map_err(|e| {
+                                warn!(
                     target: LOG_TARGET,
                     "Could not get new block template: {}",
                     e.to_string()
                 );
-                obscure_error_if_true(report_error_flag, Status::internal(e.to_string()))
-            })?;
+                                obscure_error_if_true(report_error_flag, Status::internal(e.to_string()))
+                            })?;
+                        self.data_cache.set_sha3x_new_block_template(new_template.clone(), metadata.best_block_hash().clone()).await;
+                        new_template
+                    }
+                }
+                },
+            PowAlgorithm::RandomX => {
+                match self.data_cache.get_randomx_new_block_template(metadata.best_block_hash()).await{
+                    Some(template) => {template},
+                    None => {
+                        let new_template = handler
+                            .get_new_block_template(algo, request.max_weight)
+                            .await
+                            .map_err(|e| {
+                                warn!(
+                    target: LOG_TARGET,
+                    "Could not get new block template: {}",
+                    e.to_string()
+                );
+                                obscure_error_if_true(report_error_flag, Status::internal(e.to_string()))
+                            })?;
+                        self.data_cache.set_randomx_new_block_template(new_template.clone(), metadata.best_block_hash().clone()).await;
+                        new_template
+                    }
+                }
+            },
+        };
 
         let status_watch = self.state_machine_handle.get_status_info_watch();
         let pow = algo as i32;

--- a/applications/minotari_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/minotari_node/src/grpc/base_node_grpc_server.rs
@@ -364,6 +364,55 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
         Ok(Response::new(rx))
     }
 
+    async fn get_network_hash_rate(
+        &self,
+        _request: Request<tari_rpc::GetNetworkHashRateRequest>,
+    ) -> Result<Response<tari_rpc::GetNetworkHashRateResponse>, Status>{
+        trace!(target: LOG_TARGET, "Incoming GRPC request for get network hash rate");
+        let report_error_flag = self.report_error_flag();
+        let mut handler = self.node_service.clone();
+        let metadata = handler.get_metadata().await.map_err(|e| {
+            warn!(
+                    target: LOG_TARGET,
+                    "Could not get node tip: {}",
+                    e.to_string()
+                );
+            obscure_error_if_true(report_error_flag, Status::internal(e.to_string()))
+        })?;
+        let reward = self.consensus_rules.get_block_reward_at(metadata.best_block_height()).as_u64();
+        let constants = self.consensus_rules.consensus_constants(metadata.best_block_height());
+        let sha_target_difficulty = handler.get_target_difficulty_for_next_block(PowAlgorithm::Sha3x).await.map_err(|e| {
+            warn!(
+                    target: LOG_TARGET,
+                    "Could not get target difficulty for Sha3x: {}",
+                    e.to_string()
+                );
+            obscure_error_if_true(report_error_flag, Status::internal(e.to_string()))
+        })?;
+        let sha_target_time = constants
+            .pow_target_block_interval(PowAlgorithm::Sha3x);
+        let sha3x_estimated_hash_rate = sha_target_difficulty.as_u64()/sha_target_time;
+        let rx_target_difficulty = handler.get_target_difficulty_for_next_block(PowAlgorithm::RandomX).await.map_err(|e| {
+            warn!(
+                    target: LOG_TARGET,
+                    "Could not get target difficulty for Rx: {}",
+                    e.to_string()
+                );
+            obscure_error_if_true(report_error_flag, Status::internal(e.to_string()))
+        })?;
+        let rx_target_time = constants
+            .pow_target_block_interval(PowAlgorithm::RandomX);
+        let randomx_estimated_hash_rate = rx_target_difficulty.as_u64()/rx_target_time;
+
+        let response = tari_rpc::GetNetworkHashRateResponse {
+            reward,
+            sha3x_estimated_hash_rate,
+            randomx_estimated_hash_rate,
+        };
+        trace!(target: LOG_TARGET, "Sending GetNetworkHashRate response to client");
+        Ok(Response::new(response))
+    }
+
     async fn get_mempool_transactions(
         &self,
         request: Request<tari_rpc::GetMempoolTransactionsRequest>,

--- a/applications/minotari_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/minotari_node/src/grpc/base_node_grpc_server.rs
@@ -78,8 +78,8 @@ use tonic::{Request, Response, Status};
 use crate::{
     builder::BaseNodeContext,
     grpc::{
-        data_cache::DataCache,
         blocks::{block_fees, block_heights, block_size, GET_BLOCKS_MAX_HEIGHTS, GET_BLOCKS_PAGE_SIZE},
+        data_cache::DataCache,
         hash_rate::HashRateMovingAverage,
         helpers::{mean, median},
     },
@@ -387,7 +387,9 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
             .get_block_reward_at(metadata.best_block_height())
             .as_u64();
         let constants = self.consensus_rules.consensus_constants(metadata.best_block_height());
-        let sha3x_estimated_hash_rate = match self.data_cache.get_sha3x_estimated_hash_rate(metadata.best_block_hash())
+        let sha3x_estimated_hash_rate = match self
+            .data_cache
+            .get_sha3x_estimated_hash_rate(metadata.best_block_hash())
             .await
         {
             Some(hash_rate) => hash_rate,
@@ -406,12 +408,14 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
                 let target_time = constants.pow_target_block_interval(PowAlgorithm::Sha3x);
                 let estimated_hash_rate = target_difficulty.as_u64() / target_time;
                 self.data_cache
-                    .set_sha3x_estimated_hash_rate(estimated_hash_rate, metadata.best_block_hash().clone())
+                    .set_sha3x_estimated_hash_rate(estimated_hash_rate, *metadata.best_block_hash())
                     .await;
                 estimated_hash_rate
             },
         };
-        let randomx_estimated_hash_rate = match self.data_cache.get_randomx_estimated_hash_rate(metadata.best_block_hash())
+        let randomx_estimated_hash_rate = match self
+            .data_cache
+            .get_randomx_estimated_hash_rate(metadata.best_block_hash())
             .await
         {
             Some(hash_rate) => hash_rate,
@@ -430,7 +434,7 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
                 let target_time = constants.pow_target_block_interval(PowAlgorithm::RandomX);
                 let estimated_hash_rate = target_difficulty.as_u64() / target_time;
                 self.data_cache
-                    .set_randomx_estimated_hash_rate(estimated_hash_rate, metadata.best_block_hash().clone())
+                    .set_randomx_estimated_hash_rate(estimated_hash_rate, *metadata.best_block_hash())
                     .await;
                 estimated_hash_rate
             },
@@ -722,45 +726,59 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
             obscure_error_if_true(report_error_flag, Status::internal(e.to_string()))
         })?;
 
-        let new_template = match algo{
+        let new_template = match algo {
             PowAlgorithm::Sha3x => {
-                match self.data_cache.get_sha3x_new_block_template(metadata.best_block_hash()).await{
-                    Some(template) => {template},
+                match self
+                    .data_cache
+                    .get_sha3x_new_block_template(metadata.best_block_hash())
+                    .await
+                {
+                    Some(template) => template,
                     None => {
-                        let new_template = handler
-                            .get_new_block_template(algo, request.max_weight)
-                            .await
-                            .map_err(|e| {
-                                warn!(
-                    target: LOG_TARGET,
-                    "Could not get new block template: {}",
-                    e.to_string()
-                );
-                                obscure_error_if_true(report_error_flag, Status::internal(e.to_string()))
-                            })?;
-                        self.data_cache.set_sha3x_new_block_template(new_template.clone(), metadata.best_block_hash().clone()).await;
+                        let new_template =
+                            handler
+                                .get_new_block_template(algo, request.max_weight)
+                                .await
+                                .map_err(|e| {
+                                    warn!(
+                                        target: LOG_TARGET,
+                                        "Could not get new block template: {}",
+                                        e.to_string()
+                                    );
+                                    obscure_error_if_true(report_error_flag, Status::internal(e.to_string()))
+                                })?;
+                        self.data_cache
+                            .set_sha3x_new_block_template(new_template.clone(), *metadata.best_block_hash())
+                            .await;
                         new_template
-                    }
+                    },
                 }
-                },
+            },
             PowAlgorithm::RandomX => {
-                match self.data_cache.get_randomx_new_block_template(metadata.best_block_hash()).await{
-                    Some(template) => {template},
+                match self
+                    .data_cache
+                    .get_randomx_new_block_template(metadata.best_block_hash())
+                    .await
+                {
+                    Some(template) => template,
                     None => {
-                        let new_template = handler
-                            .get_new_block_template(algo, request.max_weight)
-                            .await
-                            .map_err(|e| {
-                                warn!(
-                    target: LOG_TARGET,
-                    "Could not get new block template: {}",
-                    e.to_string()
-                );
-                                obscure_error_if_true(report_error_flag, Status::internal(e.to_string()))
-                            })?;
-                        self.data_cache.set_randomx_new_block_template(new_template.clone(), metadata.best_block_hash().clone()).await;
+                        let new_template =
+                            handler
+                                .get_new_block_template(algo, request.max_weight)
+                                .await
+                                .map_err(|e| {
+                                    warn!(
+                                        target: LOG_TARGET,
+                                        "Could not get new block template: {}",
+                                        e.to_string()
+                                    );
+                                    obscure_error_if_true(report_error_flag, Status::internal(e.to_string()))
+                                })?;
+                        self.data_cache
+                            .set_randomx_new_block_template(new_template.clone(), *metadata.best_block_hash())
+                            .await;
                         new_template
-                    }
+                    },
                 }
             },
         };

--- a/applications/minotari_node/src/grpc/data_cache.rs
+++ b/applications/minotari_node/src/grpc/data_cache.rs
@@ -38,35 +38,35 @@ impl DataCache {
     }
 
     pub async fn get_randomx_estimated_hash_rate(&self, current_tip: &FixedHash) -> Option<u64> {
-        let res = self.inner_data_cache.read().await.randomx_estimated_hash_rate;
-        if res.1 == *current_tip {
-            Some(res.0)
+        let res = &self.inner_data_cache.read().await.randomx_estimated_hash_rate;
+        if res.tip == *current_tip {
+            Some(res.data)
         } else {
             None
         }
     }
 
     pub async fn get_sha3x_estimated_hash_rate(&self, current_tip: &FixedHash) -> Option<u64> {
-        let res = self.inner_data_cache.read().await.sha3x_estimated_hash_rate;
-        if res.1 == *current_tip {
-            Some(res.0)
+        let res = &self.inner_data_cache.read().await.sha3x_estimated_hash_rate;
+        if res.tip == *current_tip {
+            Some(res.data)
         } else {
             None
         }
     }
 
     pub async fn set_randomx_estimated_hash_rate(&self, hash_rate: u64, current_tip: FixedHash) {
-        self.inner_data_cache.write().await.randomx_estimated_hash_rate = (hash_rate, current_tip);
+        self.inner_data_cache.write().await.randomx_estimated_hash_rate = DataCacheData::new(hash_rate, current_tip);
     }
 
     pub async fn set_sha3x_estimated_hash_rate(&self, hash_rate: u64, current_tip: FixedHash) {
-        self.inner_data_cache.write().await.sha3x_estimated_hash_rate = (hash_rate, current_tip);
+        self.inner_data_cache.write().await.sha3x_estimated_hash_rate = DataCacheData::new(hash_rate, current_tip);
     }
 
     pub async fn get_randomx_new_block_template(&self, current_tip: &FixedHash) -> Option<NewBlockTemplate> {
         let res = &self.inner_data_cache.read().await.randomx_new_block_template;
-        if res.1 == *current_tip {
-            Some(res.0.clone())
+        if res.tip == *current_tip {
+            Some(res.data.clone())
         } else {
             None
         }
@@ -74,35 +74,55 @@ impl DataCache {
 
     pub async fn get_sha3x_new_block_template(&self, current_tip: &FixedHash) -> Option<NewBlockTemplate> {
         let res = &self.inner_data_cache.read().await.sha3x_new_block_template;
-        if res.1 == *current_tip {
-            Some(res.0.clone())
+        if res.tip == *current_tip {
+            Some(res.data.clone())
         } else {
             None
         }
     }
 
     pub async fn set_randomx_new_block_template(&self, new_block_template: NewBlockTemplate, current_tip: FixedHash) {
-        self.inner_data_cache.write().await.randomx_new_block_template = (new_block_template, current_tip);
+        self.inner_data_cache.write().await.randomx_new_block_template =
+            DataCacheData::new(new_block_template, current_tip);
     }
 
     pub async fn set_sha3x_new_block_template(&self, new_block_template: NewBlockTemplate, current_tip: FixedHash) {
-        self.inner_data_cache.write().await.sha3x_new_block_template = (new_block_template, current_tip);
+        self.inner_data_cache.write().await.sha3x_new_block_template =
+            DataCacheData::new(new_block_template, current_tip);
     }
 }
 
 struct InnerDataCache {
-    pub randomx_estimated_hash_rate: (u64, FixedHash),
-    pub sha3x_estimated_hash_rate: (u64, FixedHash),
-    pub sha3x_new_block_template: (NewBlockTemplate, FixedHash),
-    pub randomx_new_block_template: (NewBlockTemplate, FixedHash),
+    pub randomx_estimated_hash_rate: DataCacheData<u64>,
+    pub sha3x_estimated_hash_rate: DataCacheData<u64>,
+    pub sha3x_new_block_template: DataCacheData<NewBlockTemplate>,
+    pub randomx_new_block_template: DataCacheData<NewBlockTemplate>,
 }
 impl Default for InnerDataCache {
     fn default() -> Self {
         Self {
-            randomx_estimated_hash_rate: (0, FixedHash::default()),
-            sha3x_estimated_hash_rate: (0, FixedHash::default()),
-            sha3x_new_block_template: (NewBlockTemplate::empty(), FixedHash::default()),
-            randomx_new_block_template: (NewBlockTemplate::empty(), FixedHash::default()),
+            randomx_estimated_hash_rate: DataCacheData::new_empty(0),
+            sha3x_estimated_hash_rate: DataCacheData::new_empty(0),
+            sha3x_new_block_template: DataCacheData::new_empty(NewBlockTemplate::empty()),
+            randomx_new_block_template: DataCacheData::new_empty(NewBlockTemplate::empty()),
+        }
+    }
+}
+
+struct DataCacheData<T> {
+    pub data: T,
+    pub tip: FixedHash,
+}
+
+impl<T> DataCacheData<T> {
+    pub fn new(data: T, tip: FixedHash) -> Self {
+        Self { data, tip }
+    }
+
+    pub fn new_empty(data: T) -> Self {
+        Self {
+            data,
+            tip: FixedHash::default(),
         }
     }
 }

--- a/applications/minotari_node/src/grpc/data_cache.rs
+++ b/applications/minotari_node/src/grpc/data_cache.rs
@@ -20,11 +20,11 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::sync::{Arc};
-use tokio::sync::RwLock;
+use std::sync::Arc;
 
 use tari_common_types::types::FixedHash;
 use tari_core::blocks::NewBlockTemplate;
+use tokio::sync::RwLock;
 
 pub struct DataCache {
     inner_data_cache: Arc<RwLock<InnerDataCache>>,
@@ -84,6 +84,7 @@ impl DataCache {
     pub async fn set_randomx_new_block_template(&self, new_block_template: NewBlockTemplate, current_tip: FixedHash) {
         self.inner_data_cache.write().await.randomx_new_block_template = (new_block_template, current_tip);
     }
+
     pub async fn set_sha3x_new_block_template(&self, new_block_template: NewBlockTemplate, current_tip: FixedHash) {
         self.inner_data_cache.write().await.sha3x_new_block_template = (new_block_template, current_tip);
     }
@@ -92,17 +93,16 @@ impl DataCache {
 struct InnerDataCache {
     pub randomx_estimated_hash_rate: (u64, FixedHash),
     pub sha3x_estimated_hash_rate: (u64, FixedHash),
-    pub sha3x_new_block_template: (NewBlockTemplate,FixedHash),
-    pub randomx_new_block_template: (NewBlockTemplate,FixedHash),
+    pub sha3x_new_block_template: (NewBlockTemplate, FixedHash),
+    pub randomx_new_block_template: (NewBlockTemplate, FixedHash),
 }
 impl Default for InnerDataCache {
     fn default() -> Self {
         Self {
             randomx_estimated_hash_rate: (0, FixedHash::default()),
             sha3x_estimated_hash_rate: (0, FixedHash::default()),
-            sha3x_new_block_template: (NewBlockTemplate::empty(),FixedHash::default()),
-            randomx_new_block_template: (NewBlockTemplate::empty(),FixedHash::default()),
+            sha3x_new_block_template: (NewBlockTemplate::empty(), FixedHash::default()),
+            randomx_new_block_template: (NewBlockTemplate::empty(), FixedHash::default()),
         }
     }
 }
-

--- a/applications/minotari_node/src/grpc/data_cache.rs
+++ b/applications/minotari_node/src/grpc/data_cache.rs
@@ -1,0 +1,108 @@
+// Copyright 2025. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::sync::{Arc};
+use tokio::sync::RwLock;
+
+use tari_common_types::types::FixedHash;
+use tari_core::blocks::NewBlockTemplate;
+
+pub struct DataCache {
+    inner_data_cache: Arc<RwLock<InnerDataCache>>,
+}
+
+impl DataCache {
+    pub fn new() -> Self {
+        Self {
+            inner_data_cache: Arc::new(RwLock::new(InnerDataCache::default())),
+        }
+    }
+
+    pub async fn get_randomx_estimated_hash_rate(&self, current_tip: &FixedHash) -> Option<u64> {
+        let res = self.inner_data_cache.read().await.randomx_estimated_hash_rate;
+        if res.1 == *current_tip {
+            Some(res.0)
+        } else {
+            None
+        }
+    }
+
+    pub async fn get_sha3x_estimated_hash_rate(&self, current_tip: &FixedHash) -> Option<u64> {
+        let res = self.inner_data_cache.read().await.sha3x_estimated_hash_rate;
+        if res.1 == *current_tip {
+            Some(res.0)
+        } else {
+            None
+        }
+    }
+
+    pub async fn set_randomx_estimated_hash_rate(&self, hash_rate: u64, current_tip: FixedHash) {
+        self.inner_data_cache.write().await.randomx_estimated_hash_rate = (hash_rate, current_tip);
+    }
+
+    pub async fn set_sha3x_estimated_hash_rate(&self, hash_rate: u64, current_tip: FixedHash) {
+        self.inner_data_cache.write().await.sha3x_estimated_hash_rate = (hash_rate, current_tip);
+    }
+
+    pub async fn get_randomx_new_block_template(&self, current_tip: &FixedHash) -> Option<NewBlockTemplate> {
+        let res = &self.inner_data_cache.read().await.randomx_new_block_template;
+        if res.1 == *current_tip {
+            Some(res.0.clone())
+        } else {
+            None
+        }
+    }
+
+    pub async fn get_sha3x_new_block_template(&self, current_tip: &FixedHash) -> Option<NewBlockTemplate> {
+        let res = &self.inner_data_cache.read().await.sha3x_new_block_template;
+        if res.1 == *current_tip {
+            Some(res.0.clone())
+        } else {
+            None
+        }
+    }
+
+    pub async fn set_randomx_new_block_template(&self, new_block_template: NewBlockTemplate, current_tip: FixedHash) {
+        self.inner_data_cache.write().await.randomx_new_block_template = (new_block_template, current_tip);
+    }
+    pub async fn set_sha3x_new_block_template(&self, new_block_template: NewBlockTemplate, current_tip: FixedHash) {
+        self.inner_data_cache.write().await.sha3x_new_block_template = (new_block_template, current_tip);
+    }
+}
+
+struct InnerDataCache {
+    pub randomx_estimated_hash_rate: (u64, FixedHash),
+    pub sha3x_estimated_hash_rate: (u64, FixedHash),
+    pub sha3x_new_block_template: (NewBlockTemplate,FixedHash),
+    pub randomx_new_block_template: (NewBlockTemplate,FixedHash),
+}
+impl Default for InnerDataCache {
+    fn default() -> Self {
+        Self {
+            randomx_estimated_hash_rate: (0, FixedHash::default()),
+            sha3x_estimated_hash_rate: (0, FixedHash::default()),
+            sha3x_new_block_template: (NewBlockTemplate::empty(),FixedHash::default()),
+            randomx_new_block_template: (NewBlockTemplate::empty(),FixedHash::default()),
+        }
+    }
+}
+

--- a/applications/minotari_node/src/grpc/mod.rs
+++ b/applications/minotari_node/src/grpc/mod.rs
@@ -22,5 +22,6 @@
 
 pub mod base_node_grpc_server;
 pub mod blocks;
+pub mod data_cache;
 pub mod hash_rate;
 pub mod helpers;

--- a/base_layer/core/src/base_node/comms_interface/comms_request.rs
+++ b/base_layer/core/src/base_node/comms_interface/comms_request.rs
@@ -43,6 +43,7 @@ pub struct MmrStateRequest {
 #[derive(Debug, Serialize, Deserialize)]
 pub enum NodeCommsRequest {
     GetChainMetadata,
+    GetTargetDifficultyNextBlock(PowAlgorithm),
     FetchHeaders(RangeInclusive<u64>),
     FetchHeadersByHashes(Vec<HashOutput>),
     FetchMatchingUtxos(Vec<HashOutput>),
@@ -74,6 +75,7 @@ impl Display for NodeCommsRequest {
         use NodeCommsRequest::*;
         match self {
             GetChainMetadata => write!(f, "GetChainMetadata"),
+            GetTargetDifficultyNextBlock(algo) => write!(f, "GetTargetDifficultyNextBlock ({:?})", algo),
             FetchHeaders(range) => {
                 write!(f, "FetchHeaders ({:?})", range)
             },

--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -128,11 +128,10 @@ where B: BlockchainBackend + 'static
             NodeCommsRequest::GetTargetDifficultyNextBlock(algo) => {
                 let header = self.blockchain_db.fetch_tip_header().await?;
                 let constants = self.consensus_manager.consensus_constants(header.header().height);
-                let target_difficulty = self.get_target_difficulty_for_next_block(algo, constants, *header.hash())
+                let target_difficulty = self
+                    .get_target_difficulty_for_next_block(algo, constants, *header.hash())
                     .await?;
-                Ok(NodeCommsResponse::TargetDifficulty(
-                    target_difficulty
-                ))
+                Ok(NodeCommsResponse::TargetDifficulty(target_difficulty))
             },
             NodeCommsRequest::FetchHeaders(range) => {
                 let headers = self.blockchain_db.fetch_chain_headers(range).await?;

--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -125,6 +125,15 @@ where B: BlockchainBackend + 'static
             NodeCommsRequest::GetChainMetadata => Ok(NodeCommsResponse::ChainMetadata(
                 self.blockchain_db.get_chain_metadata().await?,
             )),
+            NodeCommsRequest::GetTargetDifficultyNextBlock(algo) => {
+                let header = self.blockchain_db.fetch_tip_header().await?;
+                let constants = self.consensus_manager.consensus_constants(header.header().height);
+                let target_difficulty = self.get_target_difficulty_for_next_block(algo, constants, *header.hash())
+                    .await?;
+                Ok(NodeCommsResponse::TargetDifficulty(
+                    target_difficulty
+                ))
+            },
             NodeCommsRequest::FetchHeaders(range) => {
                 let headers = self.blockchain_db.fetch_chain_headers(range).await?;
                 Ok(NodeCommsResponse::BlockHeaders(headers))

--- a/base_layer/core/src/base_node/comms_interface/local_interface.rs
+++ b/base_layer/core/src/base_node/comms_interface/local_interface.rs
@@ -39,10 +39,9 @@ use crate::{
     },
     blocks::{Block, ChainHeader, HistoricalBlock, NewBlockTemplate},
     chain_storage::TemplateRegistrationEntry,
-    proof_of_work::PowAlgorithm,
+    proof_of_work::{Difficulty, PowAlgorithm},
     transactions::transaction_components::{TransactionKernel, TransactionOutput},
 };
-use crate::proof_of_work::Difficulty;
 
 pub type BlockEventSender = broadcast::Sender<Arc<BlockEvent>>;
 pub type BlockEventReceiver = broadcast::Receiver<Arc<BlockEvent>>;
@@ -82,8 +81,15 @@ impl LocalNodeCommsInterface {
         }
     }
 
-    pub async fn get_target_difficulty_for_next_block(&mut self, algo: PowAlgorithm) -> Result<Difficulty, CommsInterfaceError> {
-        match self.request_sender.call(NodeCommsRequest::GetTargetDifficultyNextBlock(algo)).await?? {
+    pub async fn get_target_difficulty_for_next_block(
+        &mut self,
+        algo: PowAlgorithm,
+    ) -> Result<Difficulty, CommsInterfaceError> {
+        match self
+            .request_sender
+            .call(NodeCommsRequest::GetTargetDifficultyNextBlock(algo))
+            .await??
+        {
             NodeCommsResponse::TargetDifficulty(target_difficulty) => Ok(target_difficulty),
             _ => Err(CommsInterfaceError::UnexpectedApiResponse),
         }

--- a/base_layer/core/src/base_node/comms_interface/local_interface.rs
+++ b/base_layer/core/src/base_node/comms_interface/local_interface.rs
@@ -42,6 +42,7 @@ use crate::{
     proof_of_work::PowAlgorithm,
     transactions::transaction_components::{TransactionKernel, TransactionOutput},
 };
+use crate::proof_of_work::Difficulty;
 
 pub type BlockEventSender = broadcast::Sender<Arc<BlockEvent>>;
 pub type BlockEventReceiver = broadcast::Receiver<Arc<BlockEvent>>;
@@ -77,6 +78,13 @@ impl LocalNodeCommsInterface {
     pub async fn get_metadata(&mut self) -> Result<ChainMetadata, CommsInterfaceError> {
         match self.request_sender.call(NodeCommsRequest::GetChainMetadata).await?? {
             NodeCommsResponse::ChainMetadata(metadata) => Ok(metadata),
+            _ => Err(CommsInterfaceError::UnexpectedApiResponse),
+        }
+    }
+
+    pub async fn get_target_difficulty_for_next_block(&mut self, algo: PowAlgorithm) -> Result<Difficulty, CommsInterfaceError> {
+        match self.request_sender.call(NodeCommsRequest::GetTargetDifficultyNextBlock(algo)).await?? {
+            NodeCommsResponse::TargetDifficulty(target_difficulty) => Ok(target_difficulty),
             _ => Err(CommsInterfaceError::UnexpectedApiResponse),
         }
     }

--- a/base_layer/core/src/blocks/new_block_template.rs
+++ b/base_layer/core/src/blocks/new_block_template.rs
@@ -74,6 +74,17 @@ impl NewBlockTemplate {
             is_mempool_in_sync,
         })
     }
+
+    pub fn empty() -> Self {
+        Self {
+            header: NewBlockHeaderTemplate::empty(),
+            body: AggregateBody::empty(),
+            target_difficulty: Difficulty::default(),
+            reward: MicroMinotari::default(),
+            total_fees: MicroMinotari::default(),
+            is_mempool_in_sync: false,
+        }
+    }
 }
 
 impl Display for NewBlockTemplate {

--- a/base_layer/core/src/blocks/new_blockheader_template.rs
+++ b/base_layer/core/src/blocks/new_blockheader_template.rs
@@ -58,6 +58,17 @@ impl NewBlockHeaderTemplate {
             pow: header.pow,
         }
     }
+
+    pub fn empty() -> Self {
+        Self {
+            version: 0,
+            height: 0,
+            prev_hash: Default::default(),
+            total_kernel_offset: Default::default(),
+            total_script_offset: Default::default(),
+            pow: Default::default(),
+        }
+    }
 }
 
 impl Display for NewBlockHeaderTemplate {


### PR DESCRIPTION
Description
---
Creates a new grpc method to get the reward of the nextblock, the sha + rx estimate hash rates and metadata tip info
Adds caching to grpc calls

Motivation and Context
---
Currently, universe calls get_template to just read the reward which is an expensive operation. 
It also streams up to 100 headers to calculate the estimated hash rate. 

Both of these operations can be made much simpler and faster. This PR provides a call to do just that. 
This Pr also adds cahcing to the calls to only update if an update is required. 
