### PR TITLE
feat: improve grpc get_balance response

### DIFF
--- a/applications/minotari_app_grpc/proto/wallet.proto
+++ b/applications/minotari_app_grpc/proto/wallet.proto
@@ -47,7 +47,7 @@ service Wallet {
   rpc GetTransactionInfo (GetTransactionInfoRequest) returns (GetTransactionInfoResponse);
   // Returns all transactions' details
   rpc GetCompletedTransactions (GetCompletedTransactionsRequest) returns (stream GetCompletedTransactionsResponse);
-  // Returns the balance
+  // Returns the balance, but uses a debouncer in the background to prevent spamming the wallet
   rpc GetBalance (GetBalanceRequest) returns (GetBalanceResponse);
   // Returns unspent amounts
   rpc GetUnspentAmounts (Empty) returns (GetUnspentAmountsResponse);

--- a/applications/minotari_console_wallet/src/grpc/get_balance_debounced.rs
+++ b/applications/minotari_console_wallet/src/grpc/get_balance_debounced.rs
@@ -1,0 +1,186 @@
+//  Copyright 2021. The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::sync::Arc;
+
+use log::{info, trace, warn};
+use minotari_app_grpc::tari_rpc::GetBalanceResponse;
+use minotari_wallet::{
+    connectivity_service::WalletConnectivityInterface,
+    output_manager_service::{handle::OutputManagerEvent, service::Balance},
+    transaction_service::handle::TransactionEvent,
+    WalletSqlite,
+};
+use tokio::sync::Mutex;
+use tonic::Status;
+
+const LOG_TARGET: &str = "wallet::ui::grpc::get_balance_debounced";
+
+/// This struct is used to get the balance of the wallet, implementing a debouncer. When the `get_balance` method is
+/// called the first time, the balance will be fetched from the backend after starting a task to monitor wallet events
+/// that could change the balance. When these wallet events are received, a flag will be set to indicate that the
+/// balance needs to be updated. When ever a client requests the balance, it will be fetched from the backend if the
+/// flag is set and clear the flag, otherwise the cached balance will be returned.
+#[derive(Clone)]
+pub struct GetBalanceDebounced {
+    balance: Arc<Mutex<Balance>>,
+    refresh_needed: Arc<Mutex<bool>>,
+    wallet: WalletSqlite,
+    event_monitor_started: Arc<Mutex<bool>>,
+}
+
+impl GetBalanceDebounced {
+    /// Create a new GetBalanceDebounced instance.
+    pub fn new(wallet: WalletSqlite) -> Self {
+        Self {
+            balance: Arc::new(Mutex::new(Balance {
+                available_balance: 0.into(),
+                pending_incoming_balance: 0.into(),
+                pending_outgoing_balance: 0.into(),
+                time_locked_balance: None,
+            })),
+            refresh_needed: Arc::new(Mutex::new(true)),
+            wallet,
+            event_monitor_started: Arc::new(Mutex::new(false)),
+        }
+    }
+
+    async fn start_event_monitor(&mut self) {
+        trace!(target: LOG_TARGET, "start_event_monitor");
+        let self_clone = self.clone();
+        tokio::spawn(async move {
+            self_clone.monitor_events().await;
+        });
+        let mut lock = self.event_monitor_started.lock().await;
+        *lock = true;
+    }
+
+    async fn is_event_monitor_started(&self) -> bool {
+        *self.event_monitor_started.lock().await
+    }
+
+    /// Get the balance of the wallet. This function will return the cached balance of the wallet if it is current, or
+    /// fetch the balance from the output manager service if new wallet events were received that could change the
+    /// balance.
+    pub async fn get_balance(&mut self) -> Result<GetBalanceResponse, Status> {
+        if !self.is_event_monitor_started().await {
+            self.start_event_monitor().await;
+        }
+        let balance = if self.is_refresh_needed().await {
+            let mut output_manager_service = self.wallet.output_manager_service.clone();
+            let balance = match output_manager_service.get_balance().await {
+                Ok(b) => b,
+                Err(e) => return Err(Status::not_found(format!("GetBalance error! {}", e))),
+            };
+            self.update_balance(balance.clone()).await;
+            self.set_refresh_needed(false).await;
+            balance
+        } else {
+            (*self.balance.lock().await).clone()
+        };
+        Ok(GetBalanceResponse {
+            available_balance: balance.available_balance.into(),
+            pending_incoming_balance: balance.pending_incoming_balance.into(),
+            pending_outgoing_balance: balance.pending_outgoing_balance.into(),
+            timelocked_balance: balance.time_locked_balance.unwrap_or_default().into(),
+        })
+    }
+
+    async fn update_balance(&mut self, balance: Balance) {
+        let mut lock = self.balance.lock().await;
+        *lock = balance;
+    }
+
+    async fn is_refresh_needed(&self) -> bool {
+        let refresh_needed = *self.refresh_needed.lock().await;
+        trace!(target: LOG_TARGET, "is_refresh_needed '{}'", refresh_needed);
+        refresh_needed
+    }
+
+    async fn set_refresh_needed(&self, refresh_needed: bool) {
+        let mut lock = self.refresh_needed.lock().await;
+        if *lock != refresh_needed {
+            trace!(target: LOG_TARGET, "set_refresh_needed '{}'", refresh_needed);
+            *lock = refresh_needed;
+        }
+    }
+
+    async fn monitor_events(&self) {
+        let mut shutdown_signal = self.wallet.comms.shutdown_signal();
+        let mut transaction_service_events = self.wallet.transaction_service.get_event_stream();
+        let mut base_node_changed = self.wallet.wallet_connectivity.clone().get_current_base_node_watcher();
+        let mut output_manager_service_events = self.wallet.output_manager_service.get_event_stream();
+
+        loop {
+            tokio::select! {
+                result = transaction_service_events.recv() => {
+                    match result {
+                        Ok(msg) => {
+                            match (*msg).clone() {
+                                TransactionEvent::ReceivedTransaction(..) |
+                                TransactionEvent::ReceivedTransactionReply(..) |
+                                TransactionEvent::ReceivedFinalizedTransaction(_) |
+                                TransactionEvent::TransactionSendResult(..) |
+                                TransactionEvent::TransactionCompletedImmediately(..) |
+                                TransactionEvent::TransactionCancelled(..) |
+                                TransactionEvent::TransactionBroadcast(..) |
+                                TransactionEvent::DetectedTransactionUnconfirmed { .. } |
+                                TransactionEvent::DetectedTransactionConfirmed { .. } |
+                                TransactionEvent::TransactionMinedUnconfirmed { .. } |
+                                TransactionEvent::TransactionMined { .. } |
+                                TransactionEvent::TransactionValidationStateChanged(..) => {
+                                    self.set_refresh_needed(true).await;
+                                },
+                                _ => (),
+                            }
+                        },
+                        Err(e) => {
+                            warn!(target: LOG_TARGET, "transaction_service_events '{}'", e);
+                        },
+                    }
+                },
+                _ = base_node_changed.changed() => {
+                    self.set_refresh_needed(true).await;
+                },
+                result = output_manager_service_events.recv() => {
+                    match result {
+                        Ok(msg) => {
+                            if let OutputManagerEvent::TxoValidationSuccess(_) = &*msg {
+                                self.set_refresh_needed(true).await;
+                            }
+                        },
+                        Err(e) => {
+                            warn!(target: LOG_TARGET, "output_manager_service_events '{}'", e);
+                        },
+                    }
+                },
+                _ = shutdown_signal.wait() => {
+                    info!(
+                        target: LOG_TARGET,
+                        "get_balance_debounced event monitor shutting down because the shutdown signal was received"
+                    );
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/applications/minotari_console_wallet/src/grpc/get_balance_debounced.rs
+++ b/applications/minotari_console_wallet/src/grpc/get_balance_debounced.rs
@@ -25,11 +25,14 @@ use std::sync::Arc;
 use log::{info, trace, warn};
 use minotari_app_grpc::tari_rpc::GetBalanceResponse;
 use minotari_wallet::{
-    connectivity_service::WalletConnectivityInterface,
-    output_manager_service::{handle::OutputManagerEvent, service::Balance},
-    transaction_service::handle::TransactionEvent,
-    WalletSqlite,
+    connectivity_service::{WalletConnectivityHandle, WalletConnectivityInterface},
+    output_manager_service::{
+        handle::{OutputManagerEvent, OutputManagerHandle},
+        service::Balance,
+    },
+    transaction_service::handle::{TransactionEvent, TransactionServiceHandle},
 };
+use tari_shutdown::ShutdownSignal;
 use tokio::sync::Mutex;
 use tonic::Status;
 
@@ -44,13 +47,21 @@ const LOG_TARGET: &str = "wallet::ui::grpc::get_balance_debounced";
 pub struct GetBalanceDebounced {
     balance: Arc<Mutex<Balance>>,
     refresh_needed: Arc<Mutex<bool>>,
-    wallet: WalletSqlite,
+    output_manager_service: OutputManagerHandle,
+    transaction_service: TransactionServiceHandle,
+    wallet_connectivity: WalletConnectivityHandle,
+    shutdown_signal: ShutdownSignal,
     event_monitor_started: Arc<Mutex<bool>>,
 }
 
 impl GetBalanceDebounced {
     /// Create a new GetBalanceDebounced instance.
-    pub fn new(wallet: WalletSqlite) -> Self {
+    pub fn new(
+        output_manager_service: OutputManagerHandle,
+        transaction_service: TransactionServiceHandle,
+        wallet_connectivity: WalletConnectivityHandle,
+        shutdown_signal: ShutdownSignal,
+    ) -> Self {
         Self {
             balance: Arc::new(Mutex::new(Balance {
                 available_balance: 0.into(),
@@ -59,7 +70,10 @@ impl GetBalanceDebounced {
                 time_locked_balance: None,
             })),
             refresh_needed: Arc::new(Mutex::new(true)),
-            wallet,
+            output_manager_service,
+            transaction_service,
+            wallet_connectivity,
+            shutdown_signal,
             event_monitor_started: Arc::new(Mutex::new(false)),
         }
     }
@@ -86,7 +100,7 @@ impl GetBalanceDebounced {
             self.start_event_monitor().await;
         }
         let balance = if self.is_refresh_needed().await {
-            let mut output_manager_service = self.wallet.output_manager_service.clone();
+            let mut output_manager_service = self.output_manager_service.clone();
             let balance = match output_manager_service.get_balance().await {
                 Ok(b) => b,
                 Err(e) => return Err(Status::not_found(format!("GetBalance error! {}", e))),
@@ -125,10 +139,10 @@ impl GetBalanceDebounced {
     }
 
     async fn monitor_events(&self) {
-        let mut shutdown_signal = self.wallet.comms.shutdown_signal();
-        let mut transaction_service_events = self.wallet.transaction_service.get_event_stream();
-        let mut base_node_changed = self.wallet.wallet_connectivity.clone().get_current_base_node_watcher();
-        let mut output_manager_service_events = self.wallet.output_manager_service.get_event_stream();
+        let mut shutdown_signal = self.shutdown_signal.clone();
+        let mut transaction_service_events = self.transaction_service.get_event_stream();
+        let mut base_node_changed = self.wallet_connectivity.clone().get_current_base_node_watcher();
+        let mut output_manager_service_events = self.output_manager_service.get_event_stream();
 
         loop {
             tokio::select! {

--- a/applications/minotari_console_wallet/src/grpc/mod.rs
+++ b/applications/minotari_console_wallet/src/grpc/mod.rs
@@ -1,6 +1,7 @@
 // Copyright 2022 The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
 
+mod get_balance_debounced;
 mod wallet_grpc_server;
 
 use minotari_app_grpc::tari_rpc::TransactionEvent;

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -153,7 +153,12 @@ impl WalletGrpcServer {
     #[allow(dead_code)]
     pub fn new(wallet: WalletSqlite) -> Result<Self, ConsensusBuilderError> {
         let rules = ConsensusManager::builder(wallet.network.as_network()).build()?;
-        let get_balance = GetBalanceDebounced::new(wallet.clone());
+        let get_balance = GetBalanceDebounced::new(
+            wallet.output_manager_service.clone(),
+            wallet.transaction_service.clone(),
+            wallet.wallet_connectivity.clone(),
+            wallet.comms.shutdown_signal(),
+        );
         Ok(Self {
             wallet,
             rules,

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -23,6 +23,7 @@
 use std::{
     convert::{TryFrom, TryInto},
     str::FromStr,
+    sync::Arc,
 };
 
 use futures::{
@@ -83,7 +84,7 @@ use minotari_app_grpc::tari_rpc::{
     ValidateResponse,
 };
 use minotari_wallet::{
-    connectivity_service::{OnlineStatus, WalletConnectivityInterface},
+    connectivity_service::WalletConnectivityInterface,
     error::WalletStorageError,
     output_manager_service::{handle::OutputManagerHandle, UtxoSelectionCriteria},
     transaction_service::{
@@ -114,11 +115,14 @@ use tari_core::{
 };
 use tari_script::script;
 use tari_utilities::{hex::Hex, ByteArray};
-use tokio::{sync::broadcast, task};
+use tokio::{
+    sync::{broadcast, Mutex},
+    task,
+};
 use tonic::{Request, Response, Status};
 
 use crate::{
-    grpc::{convert_to_transaction_event, TransactionWrapper},
+    grpc::{convert_to_transaction_event, get_balance_debounced::GetBalanceDebounced, TransactionWrapper},
     notifier::{CANCELLED, CONFIRMATION, MINED, QUEUED, RECEIVED, SENT},
 };
 
@@ -142,13 +146,19 @@ async fn send_transaction_event(
 pub struct WalletGrpcServer {
     wallet: WalletSqlite,
     rules: ConsensusManager,
+    get_balance_debounced: Arc<Mutex<GetBalanceDebounced>>,
 }
 
 impl WalletGrpcServer {
     #[allow(dead_code)]
     pub fn new(wallet: WalletSqlite) -> Result<Self, ConsensusBuilderError> {
         let rules = ConsensusManager::builder(wallet.network.as_network()).build()?;
-        Ok(Self { wallet, rules })
+        let get_balance = GetBalanceDebounced::new(wallet.clone());
+        Ok(Self {
+            wallet,
+            rules,
+            get_balance_debounced: Arc::new(Mutex::new(get_balance)),
+        })
     }
 
     fn get_transaction_service(&self) -> TransactionServiceHandle {
@@ -193,14 +203,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
     ) -> Result<Response<CheckConnectivityResponse>, Status> {
         let mut connectivity = self.wallet.wallet_connectivity.clone();
         let status = connectivity.get_connectivity_status();
-        let grpc_connectivity = match status {
-            minotari_wallet::connectivity_service::OnlineStatus::Connecting => OnlineStatus::Connecting,
-            minotari_wallet::connectivity_service::OnlineStatus::Online => OnlineStatus::Online,
-            minotari_wallet::connectivity_service::OnlineStatus::Offline => OnlineStatus::Offline,
-        };
-        Ok(Response::new(CheckConnectivityResponse {
-            status: grpc_connectivity as i32,
-        }))
+        Ok(Response::new(CheckConnectivityResponse { status: status as i32 }))
     }
 
     async fn check_for_updates(
@@ -271,28 +274,29 @@ impl wallet_server::Wallet for WalletGrpcServer {
     }
 
     async fn get_balance(&self, _request: Request<GetBalanceRequest>) -> Result<Response<GetBalanceResponse>, Status> {
-        let mut output_service = self.get_output_manager_service();
-        let balance = match output_service.get_balance().await {
-            Ok(b) => b,
-            Err(e) => return Err(Status::not_found(format!("GetBalance error! {}", e))),
+        let start = std::time::Instant::now();
+        let balance = {
+            let mut get_balance = self.get_balance_debounced.lock().await;
+            match get_balance.get_balance().await {
+                Ok(b) => b,
+                Err(e) => return Err(Status::not_found(format!("GetBalanceDebounced error! {}", e))),
+            }
         };
-        Ok(Response::new(GetBalanceResponse {
-            available_balance: balance.available_balance.0,
-            pending_incoming_balance: balance.pending_incoming_balance.0,
-            pending_outgoing_balance: balance.pending_outgoing_balance.0,
-            timelocked_balance: balance.time_locked_balance.unwrap_or_default().0,
-        }))
+        trace!(target: LOG_TARGET, "'get_balance' completed in {:.2?}", start.elapsed());
+        Ok(Response::new(balance))
     }
 
     async fn get_unspent_amounts(
         &self,
         _: Request<tari_rpc::Empty>,
     ) -> Result<Response<GetUnspentAmountsResponse>, Status> {
+        let start = std::time::Instant::now();
         let mut output_service = self.get_output_manager_service();
         let unspent_amounts = match output_service.get_unspent_outputs().await {
             Ok(uo) => uo,
             Err(e) => return Err(Status::not_found(format!("GetUnspentAmounts error! {}", e))),
         };
+        trace!(target: LOG_TARGET, "'get_unspent_amounts' completed in {:.2?}", start.elapsed());
         Ok(Response::new(GetUnspentAmountsResponse {
             amount: unspent_amounts
                 .into_iter()
@@ -306,6 +310,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
         &self,
         _request: Request<RevalidateRequest>,
     ) -> Result<Response<RevalidateResponse>, Status> {
+        let start = std::time::Instant::now();
         let mut output_service = self.get_output_manager_service();
         output_service
             .revalidate_all_outputs()
@@ -316,6 +321,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
             .revalidate_all_transactions()
             .await
             .map_err(|e| Status::unknown(e.to_string()))?;
+        trace!(target: LOG_TARGET, "'revalidate_all_transactions' completed in {:.2?}", start.elapsed());
         Ok(Response::new(RevalidateResponse {}))
     }
 
@@ -323,6 +329,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
         &self,
         _request: Request<ValidateRequest>,
     ) -> Result<Response<ValidateResponse>, Status> {
+        let start = std::time::Instant::now();
         let mut output_service = self.get_output_manager_service();
         output_service
             .validate_txos()
@@ -333,6 +340,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
             .validate_transactions()
             .await
             .map_err(|e| Status::unknown(e.to_string()))?;
+        trace!(target: LOG_TARGET, "'validate_all_transactions' completed in {:.2?}", start.elapsed());
         Ok(Response::new(ValidateResponse {}))
     }
 
@@ -690,61 +698,66 @@ impl wallet_server::Wallet for WalletGrpcServer {
     ) -> Result<Response<Self::StreamTransactionEventsStream>, Status> {
         let (mut sender, receiver) = mpsc::channel(100);
 
-        // let event_listener = self.events_channel.clone();
-
-        // let mut shutdown_signal = self.wallet;
+        let mut shutdown_signal = self.wallet.comms.shutdown_signal();
         let mut transaction_service = self.wallet.transaction_service.clone();
         let mut transaction_service_events = self.wallet.transaction_service.get_event_stream();
 
         task::spawn(async move {
             loop {
                 tokio::select! {
-                        result = transaction_service_events.recv() => {
-                            match result {
-                                Ok(msg) => {
-                                    use minotari_wallet::transaction_service::handle::TransactionEvent::*;
-                                    match (*msg).clone() {
-                                        ReceivedFinalizedTransaction(tx_id) => handle_completed_tx(tx_id, RECEIVED, &mut transaction_service, &mut sender).await,
-                                        TransactionMinedUnconfirmed{tx_id, num_confirmations: _, is_valid: _} | DetectedTransactionUnconfirmed{tx_id, num_confirmations: _, is_valid: _}=> handle_completed_tx(tx_id, CONFIRMATION, &mut transaction_service, &mut sender).await,
-                                        TransactionMined{tx_id, is_valid: _} | DetectedTransactionConfirmed{tx_id, is_valid: _} => handle_completed_tx(tx_id, MINED, &mut transaction_service, &mut sender).await,
-                                        TransactionCancelled(tx_id, _) => {
-                                            match transaction_service.get_any_transaction(tx_id).await{
-                                                Ok(Some(wallet_tx)) => {
-                                                    use WalletTransaction::*;
-                                                    let transaction_event = match wallet_tx {
-                                                        Completed(tx)  => convert_to_transaction_event(CANCELLED.to_string(), TransactionWrapper::Completed(Box::new(tx))),
-                                                        PendingInbound(tx) => convert_to_transaction_event(CANCELLED.to_string(), TransactionWrapper::Inbound(Box::new(tx))),
-                                                        PendingOutbound(tx) => convert_to_transaction_event(CANCELLED.to_string(), TransactionWrapper::Outbound(Box::new(tx))),
-                                                    };
-                                                    send_transaction_event(transaction_event, &mut sender).await;
-                                                },
-                                                Err(e) => error!(target: LOG_TARGET, "Transaction service error: {}", e),
-                                                _ => error!(target: LOG_TARGET, "Transaction not found tx_id: {}", tx_id),
-                                            }
-                                        },
-                                        TransactionCompletedImmediately(tx_id) => handle_pending_outbound(tx_id, SENT, &mut transaction_service, &mut sender).await,
-                                        TransactionSendResult(tx_id, status) => {
-                                            let is_sent = status.direct_send_result || status.store_and_forward_send_result;
-                                            let event = if is_sent { SENT } else { QUEUED };
-                                            handle_pending_outbound(tx_id, event, &mut transaction_service, &mut sender).await;
-                                        },
-                                        TransactionValidationStateChanged(_t_operation_id) => {
-                                            send_transaction_event(simple_event("unknown"), &mut sender).await;
-                                        },
-                                        ReceivedTransaction(_) | ReceivedTransactionReply(_)  | TransactionBroadcast(_) | TransactionMinedRequestTimedOut(_) | TransactionImported(_) => {
-                                            send_transaction_event(simple_event("not_supported"), &mut sender).await;
-                                        },
-                                        // Only the above variants trigger state refresh
-                                        _ => (),
-                                    }
-                                },
-                                Err(broadcast::error::RecvError::Lagged(n)) => {
-                                    warn!(target: LOG_TARGET, "Missed {} from Transaction events", n);
+                    result = transaction_service_events.recv() => {
+                        match result {
+                            Ok(msg) => {
+                                use minotari_wallet::transaction_service::handle::TransactionEvent::*;
+                                match (*msg).clone() {
+                                    ReceivedFinalizedTransaction(tx_id) => handle_completed_tx(tx_id, RECEIVED, &mut transaction_service, &mut sender).await,
+                                    TransactionMinedUnconfirmed{tx_id, num_confirmations: _, is_valid: _} | DetectedTransactionUnconfirmed{tx_id, num_confirmations: _, is_valid: _}=> handle_completed_tx(tx_id, CONFIRMATION, &mut transaction_service, &mut sender).await,
+                                    TransactionMined{tx_id, is_valid: _} | DetectedTransactionConfirmed{tx_id, is_valid: _} => handle_completed_tx(tx_id, MINED, &mut transaction_service, &mut sender).await,
+                                    TransactionCancelled(tx_id, _) => {
+                                        match transaction_service.get_any_transaction(tx_id).await{
+                                            Ok(Some(wallet_tx)) => {
+                                                use WalletTransaction::*;
+                                                let transaction_event = match wallet_tx {
+                                                    Completed(tx)  => convert_to_transaction_event(CANCELLED.to_string(), TransactionWrapper::Completed(Box::new(tx))),
+                                                    PendingInbound(tx) => convert_to_transaction_event(CANCELLED.to_string(), TransactionWrapper::Inbound(Box::new(tx))),
+                                                    PendingOutbound(tx) => convert_to_transaction_event(CANCELLED.to_string(), TransactionWrapper::Outbound(Box::new(tx))),
+                                                };
+                                                send_transaction_event(transaction_event, &mut sender).await;
+                                            },
+                                            Err(e) => error!(target: LOG_TARGET, "Transaction service error: {}", e),
+                                            _ => error!(target: LOG_TARGET, "Transaction not found tx_id: {}", tx_id),
+                                        }
+                                    },
+                                    TransactionCompletedImmediately(tx_id) => handle_pending_outbound(tx_id, SENT, &mut transaction_service, &mut sender).await,
+                                    TransactionSendResult(tx_id, status) => {
+                                        let is_sent = status.direct_send_result || status.store_and_forward_send_result;
+                                        let event = if is_sent { SENT } else { QUEUED };
+                                        handle_pending_outbound(tx_id, event, &mut transaction_service, &mut sender).await;
+                                    },
+                                    TransactionValidationStateChanged(_t_operation_id) => {
+                                        send_transaction_event(simple_event("unknown"), &mut sender).await;
+                                    },
+                                    ReceivedTransaction(_) | ReceivedTransactionReply(_)  | TransactionBroadcast(_) => {
+                                        send_transaction_event(simple_event("not_supported"), &mut sender).await;
+                                    },
+                                    // Only the above variants trigger state refresh
+                                    _ => (),
                                 }
-                                Err(broadcast::error::RecvError::Closed) => {}
+                            },
+                            Err(broadcast::error::RecvError::Lagged(n)) => {
+                                warn!(target: LOG_TARGET, "Missed {} from Transaction events", n);
                             }
-                }
+                            Err(broadcast::error::RecvError::Closed) => {}
+                        }
                     }
+                    _ = shutdown_signal.wait() => {
+                        info!(
+                            target: LOG_TARGET,
+                            "gRPC stream_transaction_events shutting down because the shutdown signal was received"
+                        );
+                        break;
+                    },
+                }
             }
         });
         Ok(Response::new(receiver))
@@ -754,6 +767,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
         &self,
         _request: Request<GetCompletedTransactionsRequest>,
     ) -> Result<Response<Self::GetCompletedTransactionsStream>, Status> {
+        let start = std::time::Instant::now();
         debug!(
             target: LOG_TARGET,
             "GetAllCompletedTransactions: Incoming GRPC request"
@@ -816,6 +830,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
                 }
             }
         });
+        trace!(target: LOG_TARGET, "'get_completed_transactions' completed in {:.2?}", start.elapsed());
 
         Ok(Response::new(receiver))
     }

--- a/applications/minotari_console_wallet/src/ui/state/wallet_event_monitor.rs
+++ b/applications/minotari_console_wallet/src/ui/state/wallet_event_monitor.rs
@@ -154,11 +154,6 @@ impl WalletEventMonitor {
                                         format!("Transaction Broadcast to Mempool - TxId: {}", tx_id)
                                     ).await;
                                 },
-                                TransactionEvent::TransactionMinedRequestTimedOut(tx_id) |
-                                TransactionEvent::TransactionImported(tx_id)  => {
-                                    self.trigger_tx_state_refresh(tx_id).await;
-                                    self.trigger_balance_refresh();
-                                },
                                 TransactionEvent::TransactionCompletedImmediately(tx_id) => {
                                     self.trigger_tx_state_refresh(tx_id).await;
                                     self.trigger_balance_refresh();

--- a/base_layer/wallet/src/transaction_service/handle.rs
+++ b/base_layer/wallet/src/transaction_service/handle.rs
@@ -456,7 +456,6 @@ impl Display for TransactionSendStatus {
 /// Events that can be published on the Text Message Service Event Stream
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub enum TransactionEvent {
-    MempoolBroadcastTimedOut(TxId),
     ReceivedTransaction(TxId),
     ReceivedTransactionReply(TxId),
     ReceivedFinalizedTransaction(TxId),
@@ -465,7 +464,6 @@ pub enum TransactionEvent {
     TransactionCompletedImmediately(TxId),
     TransactionCancelled(TxId, TxCancellationReason),
     TransactionBroadcast(TxId),
-    TransactionImported(TxId),
     DetectedTransactionUnconfirmed {
         tx_id: TxId,
         num_confirmations: u64,
@@ -479,7 +477,6 @@ pub enum TransactionEvent {
         tx_id: TxId,
         is_valid: bool,
     },
-    TransactionMinedRequestTimedOut(TxId),
     TransactionMinedUnconfirmed {
         tx_id: TxId,
         num_confirmations: u64,
@@ -494,9 +491,6 @@ pub enum TransactionEvent {
 impl fmt::Display for TransactionEvent {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            TransactionEvent::MempoolBroadcastTimedOut(tx_id) => {
-                write!(f, "MempoolBroadcastTimedOut for tx:{tx_id}")
-            },
             TransactionEvent::ReceivedTransaction(tx) => {
                 write!(f, "ReceivedTransaction for {tx}")
             },
@@ -521,9 +515,6 @@ impl fmt::Display for TransactionEvent {
             TransactionEvent::TransactionBroadcast(tx) => {
                 write!(f, "TransactionBroadcast for {tx}")
             },
-            TransactionEvent::TransactionImported(tx) => {
-                write!(f, "TransactionImported for {tx}")
-            },
             TransactionEvent::DetectedTransactionUnconfirmed {
                 tx_id,
                 num_confirmations,
@@ -540,9 +531,6 @@ impl fmt::Display for TransactionEvent {
             },
             TransactionEvent::TransactionMined { tx_id, is_valid } => {
                 write!(f, "TransactionMined for {tx_id}. is_valid: {is_valid}")
-            },
-            TransactionEvent::TransactionMinedRequestTimedOut(tx) => {
-                write!(f, "TransactionMinedRequestTimedOut for {tx}")
             },
             TransactionEvent::TransactionMinedUnconfirmed {
                 tx_id,

--- a/base_layer/wallet_ffi/src/callback_handler.rs
+++ b/base_layer/wallet_ffi/src/callback_handler.rs
@@ -324,8 +324,6 @@ where TBackend: TransactionBackend + 'static
                                     self.transaction_validation_complete_event(request_key.as_u64(), reason);
                                     self.trigger_balance_refresh().await;
                                 },
-                                TransactionEvent::TransactionMinedRequestTimedOut(_tx_id) |
-                                TransactionEvent::TransactionImported(_tx_id)|
                                 TransactionEvent::TransactionCompletedImmediately(_tx_id)
                                 => {
                                     self.trigger_balance_refresh().await;


### PR DESCRIPTION
Description
---
- Improved the wallet grpc method `get_balance` response by implementing an event-driven balance cache update. All events that could change the balance are monitored and consecutive calls to the wallet backend are only made when the balance changed.
- Cleaned up unused events (events that were monitored somewhere but never set) in  `pub enum TransactionEvent`.
- Added a missing shutdown signal to grpc method `async fn stream_transaction_events` in the wallet grpc server.

Closes #6754

Motivation and Context
---
When calling the wallet grpc method `get_balance` repeatedly and quickly in succession on wallets with many outputs, resources are wasted in the wallet when nothing changes, and the client experiences unnecessary long response times.

How Has This Been Tested?
---
System-level testing on a large wallet with an external grpc client. See logs with response times below.

```
[wallet::ui::grpc::get_balance_debounced] TRACE start_event_monitor
[wallet::ui::grpc::get_balance_debounced] TRACE is_refresh_needed 'true'
[wallet::ui::grpc::get_balance_debounced] TRACE set_refresh_needed 'false'
[wallet::ui::grpc] TRACE 'get_balance' completed in 172.28ms
[wallet::ui::grpc::get_balance_debounced] TRACE is_refresh_needed 'false'
[wallet::ui::grpc] TRACE 'get_balance' completed in 29.40µs
[wallet::ui::grpc::get_balance_debounced] TRACE is_refresh_needed 'false'
[wallet::ui::grpc] TRACE 'get_balance' completed in 36.00µs
[wallet::ui::grpc::get_balance_debounced] TRACE is_refresh_needed 'false'
[wallet::ui::grpc] TRACE 'get_balance' completed in 26.40µs
[wallet::ui::grpc::get_balance_debounced] TRACE set_refresh_needed 'true'
[wallet::ui::grpc::get_balance_debounced] TRACE is_refresh_needed 'true'
[wallet::ui::grpc::get_balance_debounced] TRACE set_refresh_needed 'false'
[wallet::ui::grpc] TRACE 'get_balance' completed in 145.39ms
[wallet::ui::grpc::get_balance_debounced] TRACE is_refresh_needed 'false'
[wallet::ui::grpc] TRACE 'get_balance' completed in 22.00µs
[wallet::ui::grpc::get_balance_debounced] TRACE is_refresh_needed 'false'
[wallet::ui::grpc] TRACE 'get_balance' completed in 33.70µs
[wallet::ui::grpc::get_balance_debounced] TRACE is_refresh_needed 'false'
[wallet::ui::grpc] TRACE 'get_balance' completed in 25.40µs
[wallet::ui::grpc::get_balance_debounced] TRACE set_refresh_needed 'true'
[wallet::ui::grpc::get_balance_debounced] TRACE is_refresh_needed 'true'
[wallet::ui::grpc::get_balance_debounced] TRACE set_refresh_needed 'false'
[wallet::ui::grpc] TRACE 'get_balance' completed in 156.75ms
[wallet::ui::grpc::get_balance_debounced] TRACE is_refresh_needed 'false'
[wallet::ui::grpc] TRACE 'get_balance' completed in 35.70µs
[wallet::ui::grpc::get_balance_debounced] TRACE is_refresh_needed 'false'
[wallet::ui::grpc] TRACE 'get_balance' completed in 23.40µs
```

What process can a PR reviewer use to test or verify this change?
---
System-level testing with an external grpc client.

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
