### PR TITLE
fix: the smt cache height

### DIFF
--- a/applications/minotari_node/src/builder.rs
+++ b/applications/minotari_node/src/builder.rs
@@ -188,6 +188,7 @@ pub async fn configure_and_initialize_node(
                 app_config.base_node.lmdb_path.as_path(),
                 app_config.base_node.lmdb.clone(),
                 app_config.base_node.storage.pruning_interval,
+                app_config.base_node.storage.pruning_horizon,
                 rules,
             )
             .map_err(|e| ExitError::new(ExitCode::DatabaseError, e))?;

--- a/applications/minotari_node/src/recovery.rs
+++ b/applications/minotari_node/src/recovery.rs
@@ -85,6 +85,7 @@ pub async fn run_recovery(node_config: &BaseNodeConfig) -> Result<(), anyhow::Er
                 &node_config.lmdb_path,
                 node_config.lmdb.clone(),
                 node_config.storage.pruning_interval,
+                node_config.storage.pruning_horizon,
                 rules.clone(),
             )
             .map_err(|e| {
@@ -97,6 +98,7 @@ pub async fn run_recovery(node_config: &BaseNodeConfig) -> Result<(), anyhow::Er
                 &temp_path,
                 node_config.lmdb.clone(),
                 node_config.storage.pruning_interval,
+                node_config.storage.pruning_horizon,
                 rules.clone(),
             )
             .map_err(|e| {

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -301,14 +301,10 @@ impl LMDBDatabase {
         pruning_horizon: u64,
     ) -> Result<Self, ChainStorageError> {
         let env = store.env();
-        let smt_cache_period = if pruning_horizon == 0 {
+        let smt_cache_period = if pruning_horizon == 0 || prune_interval == 0 {
             SMT_CACHE_PERIOD
         } else {
-            if prune_interval == 0 {
-                SMT_CACHE_PERIOD
-            } else {
-                prune_interval / 2
-            }
+            prune_interval / 2
         };
 
         let db = Self {

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -163,7 +163,7 @@ const LMDB_DB_VALIDATOR_NODES: &str = "validator_nodes";
 const LMDB_DB_VALIDATOR_NODES_MAPPING: &str = "validator_nodes_mapping";
 const LMDB_DB_TEMPLATE_REGISTRATIONS: &str = "template_registrations";
 const LMDB_DB_UTXO_SMT: &str = "utxo_smt";
-const SMT_CACHE_PERIOD: u64 = 1000;
+const SMT_CACHE_PERIOD: u64 = 500;
 
 /// HeaderHash(32), mmr_pos(8), hash(32)
 type KernelKey = CompositeKey<72>;
@@ -174,6 +174,7 @@ pub fn create_lmdb_database<P: AsRef<Path>>(
     path: P,
     config: LMDBConfig,
     prune_interval: u64,
+    pruning_horizon: u64,
     consensus_manager: ConsensusManager,
 ) -> Result<LMDBDatabase, ChainStorageError> {
     let flags = db::CREATE;
@@ -218,7 +219,13 @@ pub fn create_lmdb_database<P: AsRef<Path>>(
         .build()
         .map_err(|err| ChainStorageError::CriticalError(format!("Could not create LMDB store:{}", err)))?;
     debug!(target: LOG_TARGET, "LMDB database creation successful");
-    LMDBDatabase::new(&lmdb_store, file_lock, consensus_manager, prune_interval)
+    LMDBDatabase::new(
+        &lmdb_store,
+        file_lock,
+        consensus_manager,
+        prune_interval,
+        pruning_horizon,
+    )
 }
 
 /// This is a lmdb-based blockchain database for persistent storage of the chain state.
@@ -291,12 +298,17 @@ impl LMDBDatabase {
         file_lock: File,
         consensus_manager: ConsensusManager,
         prune_interval: u64,
+        pruning_horizon: u64,
     ) -> Result<Self, ChainStorageError> {
         let env = store.env();
-        let smt_cache_period = if prune_interval == 0 {
+        let smt_cache_period = if pruning_horizon == 0 {
             SMT_CACHE_PERIOD
         } else {
-            prune_interval / 2
+            if prune_interval == 0 {
+                SMT_CACHE_PERIOD
+            } else {
+                prune_interval / 2
+            }
         };
 
         let db = Self {

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -469,6 +469,10 @@ impl LMDBDatabase {
                     // for security we check that the best block does exist, and we check the previous value
                     // we dont want to check this if the prev block has never been set, this means a empty hash of 32
                     // bytes.
+                    debug!(target: LOG_TARGET,
+                        "Setting new best block as height: {}",
+                        height
+                    );
                     if *height > 0 {
                         let prev = fetch_best_block(&write_txn, &self.metadata_db)?;
                         if *expected_prev_best_block != prev {
@@ -1779,7 +1783,7 @@ impl LMDBDatabase {
 
         match lmdb_replace(txn, &self.utxo_smt, &k.as_u32(), smt, Some(estimated_bytes)) {
             Ok(_) => {
-                trace!(
+                debug!(
                 target: LOG_TARGET,
                     "Inserted ~{} MB with key '{}' into '{}' (size {}) in {:.2?}",
                     estimated_bytes / BYTES_PER_MB,

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -304,6 +304,7 @@ impl LMDBDatabase {
         let smt_cache_period = if pruning_horizon == 0 || prune_interval == 0 {
             SMT_CACHE_PERIOD
         } else {
+            // we make sure we run this in the pruning interval, 2 is just a same number here.
             prune_interval / 2
         };
 

--- a/base_layer/core/src/test_helpers/blockchain.rs
+++ b/base_layer/core/src/test_helpers/blockchain.rs
@@ -168,7 +168,7 @@ impl TempDatabase {
         let rules = create_consensus_rules();
 
         Self {
-            db: Some(create_lmdb_database(&temp_path, LMDBConfig::default(), 0, rules).unwrap()),
+            db: Some(create_lmdb_database(&temp_path, LMDBConfig::default(), 0, 0, rules).unwrap()),
             path: temp_path,
             delete_on_drop: true,
         }
@@ -177,7 +177,7 @@ impl TempDatabase {
     pub fn from_path<P: AsRef<Path>>(temp_path: P) -> Self {
         let rules = create_consensus_rules();
         Self {
-            db: Some(create_lmdb_database(&temp_path, LMDBConfig::default(), 0, rules).unwrap()),
+            db: Some(create_lmdb_database(&temp_path, LMDBConfig::default(), 0, 0, rules).unwrap()),
             path: temp_path.as_ref().to_path_buf(),
             delete_on_drop: true,
         }


### PR DESCRIPTION
Description
---
Currently, the smt by default is cached every 25 blocks, which is too much. reduce this down to 500 by default for archival nodes. 