### PR TITLE
feat: fix mempool out of sync

### DIFF
--- a/applications/minotari_merge_mining_proxy/src/proxy.rs
+++ b/applications/minotari_merge_mining_proxy/src/proxy.rs
@@ -920,14 +920,11 @@ impl InnerService {
 
         debug!(
             target: LOG_TARGET,
-            "request: {} ({})",
+            "request - method: {}, uri: {}, headers: {:?}, body: {}",
+            request.method(),
+            request.uri(),
+            request.headers(),
             String::from_utf8_lossy(&request.body().clone()[..]),
-            request
-                .headers()
-                .iter()
-                .map(|(k, v)| format!("{}={}", k, String::from_utf8_lossy(v.as_ref())))
-                .collect::<Vec<_>>()
-                .join(","),
         );
 
         match self.proxy_request_to_monerod(request).await {

--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -273,7 +273,7 @@ where B: BlockchainBackend + 'static
                 // We need to ensure the mempool has seen the latest base node height before we can be confident the
                 // template is correct
                 while !is_mempool_synced && start.elapsed().as_millis() < MAX_MEMPOOL_TIMEOUT.into() {
-                    if best_block_header.hash() == &last_seen_hash {
+                    if best_block_header.hash() == &last_seen_hash || last_seen_hash == FixedHash::default() {
                         is_mempool_synced = true;
                     } else {
                         tokio::time::sleep(std::time::Duration::from_millis(10)).await;


### PR DESCRIPTION
Description
---
Fixed mempool out-of-sync status when a mempool has just started with no information.

Motivation and Context
---
Merge mining does not start with a base node that has just started with an empty mempool.

How Has This Been Tested?
---
System-level testing (merge mining starts immediately after the merge mining proxy is ready)

What process can a PR reviewer use to test or verify this change?
---
Code review

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
