### PR TITLE
fix: add shard_key to ValidatorNodeChange

### DIFF
--- a/applications/minotari_app_grpc/proto/base_node.proto
+++ b/applications/minotari_app_grpc/proto/base_node.proto
@@ -503,6 +503,7 @@ message ValidatorNodeChangeAdd {
   uint64 activation_epoch = 1;
   ValidatorNodeRegistration registration = 2;
   uint64 minimum_value_promise = 3;
+  bytes shard_key = 4;
 }
 
 message ValidatorNodeChangeRemove {

--- a/applications/minotari_app_grpc/src/conversions/sidechain_feature.rs
+++ b/applications/minotari_app_grpc/src/conversions/sidechain_feature.rs
@@ -644,11 +644,17 @@ impl TryFrom<grpc::ValidatorNodeChange> for ValidatorNodeChange {
                 let activation_epoch = VnEpoch(add.activation_epoch);
                 let registration = add.registration.ok_or("registration not provided")?.try_into()?;
                 let minimum_value_promise = MicroMinotari(add.minimum_value_promise);
+                if add.shard_key.len() != 32 {
+                    return Err(format!("shard_key length is not 32 (len:{})", add.shard_key.len()));
+                }
+                let mut shard_key = [0u8; 32];
+                shard_key.copy_from_slice(&add.shard_key);
 
                 Ok(ValidatorNodeChange::Add {
                     registration,
                     activation_epoch,
                     minimum_value_promise,
+                    shard_key,
                 })
             },
             grpc::validator_node_change::Change::Remove(remove) => {
@@ -666,11 +672,13 @@ impl From<&ValidatorNodeChange> for grpc::ValidatorNodeChange {
                 registration,
                 activation_epoch,
                 minimum_value_promise,
+                shard_key,
             } => Self {
                 change: Some(grpc::validator_node_change::Change::Add(grpc::ValidatorNodeChangeAdd {
                     activation_epoch: activation_epoch.as_u64(),
                     registration: Some(registration.into()),
                     minimum_value_promise: (*minimum_value_promise).into(),
+                    shard_key: shard_key.to_vec(),
                 })),
             },
             ValidatorNodeChange::Remove { public_key } => Self {

--- a/base_layer/core/src/base_node/comms_interface/comms_response.rs
+++ b/base_layer/core/src/base_node/comms_interface/comms_response.rs
@@ -122,6 +122,7 @@ pub enum ValidatorNodeChange {
         registration: ValidatorNodeRegistration,
         activation_epoch: VnEpoch,
         minimum_value_promise: MicroMinotari,
+        shard_key: [u8; 32],
     },
     Remove {
         public_key: PublicKey,

--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -463,6 +463,7 @@ where B: BlockchainBackend + 'static
                     registration: vn.original_registration,
                     activation_epoch: vn.activation_epoch,
                     minimum_value_promise: vn.minimum_value_promise,
+                    shard_key: vn.shard_key,
                 }));
 
                 node_changes.extend(exit_validators.into_iter().map(|vn| ValidatorNodeChange::Remove {


### PR DESCRIPTION
Description
---
fix: add shard_key to ValidatorNodeChange

Motivation and Context
---
This is useful for the validator node base layer scanner.

How Has This Been Tested?
---

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved validator node management by introducing a new field for specifying a shard key. This enhancement helps streamline node identification in sharded network contexts and ensures the correct format is maintained for better data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->