### PR TITLE
fix: header sync timestamp validation

### DIFF
--- a/base_layer/core/src/validation/helpers.rs
+++ b/base_layer/core/src/validation/helpers.rs
@@ -114,11 +114,6 @@ pub fn check_header_timestamp_greater_than_median(
             median_timestamp,
             block_header.hash().to_hex()
         );
-        warn!(
-            target: LOG_TARGET,
-            "{:?}",
-            timestamps
-        );
         return Err(ValidationError::BlockHeaderError(
             BlockHeaderValidationError::InvalidTimestamp(format!(
                 "The timestamp `{}` was less than the median timestamp `{}`",

--- a/base_layer/core/src/validation/helpers.rs
+++ b/base_layer/core/src/validation/helpers.rs
@@ -60,6 +60,8 @@ pub const LOG_TARGET: &str = "c::val::helpers";
 /// When an empty slice is given as this is undefined for median average.
 /// https://math.stackexchange.com/a/3451015
 pub fn calc_median_timestamp(timestamps: &[EpochTime]) -> Result<EpochTime, ValidationError> {
+    let mut timestamps: Vec<EpochTime> = timestamps.to_vec();
+    timestamps.sort();
     trace!(
         target: LOG_TARGET,
         "Calculate the median timestamp from {} timestamps",
@@ -111,6 +113,11 @@ pub fn check_header_timestamp_greater_than_median(
             block_header.timestamp,
             median_timestamp,
             block_header.hash().to_hex()
+        );
+        warn!(
+            target: LOG_TARGET,
+            "{:?}",
+            timestamps
         );
         return Err(ValidationError::BlockHeaderError(
             BlockHeaderValidationError::InvalidTimestamp(format!(


### PR DESCRIPTION
Description
---
Fixes validation by sorting the timestamps during syncing

Block timestamps are supposed to be after the median of the past 11 blocks. Median is supposed to be ordered, this was not ordered for syncing but was ordered for propagation. This PR makes sure the list is always sorted. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved accuracy of time-related computations by ensuring the median is calculated correctly through sorting.
	- Added enhanced logging to provide clearer diagnostics for timing discrepancies when block header timestamps are less than the median.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->