### PR TITLE
fix: sync peer ordering

### DIFF
--- a/base_layer/core/src/base_node/state_machine_service/states/header_sync.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/header_sync.rs
@@ -49,13 +49,21 @@ pub struct HeaderSyncState {
 impl HeaderSyncState {
     pub fn new(mut sync_peers: Vec<SyncPeer>, local_metadata: ChainMetadata) -> Self {
         // Sort by latency lowest to highest
-        sync_peers.sort_by(|a, b| match (a.latency(), b.latency()) {
-            (None, None) => Ordering::Equal,
+        sync_peers.sort_by(|a, b| match a.claimed_difficulty().cmp(&b.claimed_difficulty()) {
+            Ordering::Less => Ordering::Less,
             // No latency goes to the end
-            (Some(_), None) => Ordering::Less,
-            (None, Some(_)) => Ordering::Greater,
-            (Some(la), Some(lb)) => la.cmp(&lb),
-        });
+            Ordering::Greater => Ordering::Greater,
+            Ordering::Equal => {
+                match (a.latency(), b.latency()) {
+                    (None, None) => Ordering::Equal,
+                    // No latency goes to the end
+                    (Some(_), None) => Ordering::Less,
+                    (None, Some(_)) => Ordering::Greater,
+                    (Some(la), Some(lb)) => la.cmp(&lb),
+                }
+            }
+        }
+        );
         Self {
             sync_peers,
             is_synced: false,

--- a/base_layer/core/src/base_node/state_machine_service/states/header_sync.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/header_sync.rs
@@ -61,9 +61,8 @@ impl HeaderSyncState {
                     (None, Some(_)) => Ordering::Greater,
                     (Some(la), Some(lb)) => la.cmp(&lb),
                 }
-            }
-        }
-        );
+            },
+        });
         Self {
             sync_peers,
             is_synced: false,

--- a/base_layer/core/src/base_node/sync/sync_peer.rs
+++ b/base_layer/core/src/base_node/sync/sync_peer.rs
@@ -25,7 +25,7 @@ use std::{
     fmt::{Display, Formatter},
     time::Duration,
 };
-
+use primitive_types::U256;
 use tari_common_types::chain_metadata::ChainMetadata;
 use tari_comms::peer_manager::NodeId;
 
@@ -44,6 +44,10 @@ impl SyncPeer {
 
     pub fn claimed_chain_metadata(&self) -> &ChainMetadata {
         self.peer_metadata.claimed_chain_metadata()
+    }
+
+    pub fn claimed_difficulty(&self) -> U256 {
+        self.peer_metadata.claimed_chain_metadata().accumulated_difficulty()
     }
 
     pub fn latency(&self) -> Option<Duration> {

--- a/base_layer/core/src/base_node/sync/sync_peer.rs
+++ b/base_layer/core/src/base_node/sync/sync_peer.rs
@@ -25,6 +25,7 @@ use std::{
     fmt::{Display, Formatter},
     time::Duration,
 };
+
 use primitive_types::U256;
 use tari_common_types::chain_metadata::ChainMetadata;
 use tari_comms::peer_manager::NodeId;

--- a/base_layer/core/src/validation/helpers.rs
+++ b/base_layer/core/src/validation/helpers.rs
@@ -566,7 +566,7 @@ mod test {
             assert_eq!(median_timestamp, 3.into());
 
             let median_timestamp = calc_median_timestamp(&[0.into(), 100.into(), 0.into()]).unwrap();
-            assert_eq!(median_timestamp, 100.into());
+            assert_eq!(median_timestamp, 0.into());
 
             let median_timestamp = calc_median_timestamp(&[1.into(), 2.into(), 3.into(), 4.into()]).unwrap();
             assert_eq!(median_timestamp, 2.into());


### PR DESCRIPTION
Description
---
Fixes peer sync order. 
Currently, the syncing peers are ordered by latency. This is important, but we also need to sync to the highest node tip. 
This changes the order for the sync peers to first order by higher, then by latency. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced synchronization by updating peer prioritization to weigh difficulty claims before latency.
  - Introduced a new interface to retrieve each peer's claimed difficulty.

- **Tests**
  - Revised the expected outcome for median timestamp calculations to ensure consistency and accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->