### PR TITLE
feat: add tari_utxo ffi de-structure methods

### DIFF
--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -4553,7 +4553,7 @@ pub unsafe extern "C" fn completed_transaction_get_mined_height(
 pub unsafe extern "C" fn completed_transaction_get_mined_in_block(
     transaction: *mut TariCompletedTransaction,
     error_out: *mut c_int,
-) -> *const c_char {
+) -> *mut c_char {
     let result = CString::new("").expect("Blank CString will not fail.");
     if transaction.is_null() {
         let mut error = LibWalletError::from(InterfaceError::NullError("transaction".to_string())).code;

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -324,6 +324,7 @@ pub struct TariUtxo {
     pub status: u8,
     pub coinbase_extra: *const c_char,
     pub payment_id: *const c_char,
+    pub mined_in_block: *const c_char,
 }
 
 impl From<DbWalletOutput> for TariUtxo {
@@ -357,6 +358,9 @@ impl From<DbWalletOutput> for TariUtxo {
                 .into_raw(),
             payment_id: CString::new(format!("{}", x.payment_id))
                 .expect("failed to obtain string from a payment id")
+                .into_raw(),
+            mined_in_block: CString::new(x.mined_in_block.unwrap_or_default().to_hex())
+                .expect("failed to obtain hex from a hash")
                 .into_raw(),
         }
     }
@@ -651,7 +655,263 @@ pub unsafe extern "C" fn string_destroy(ptr: *mut c_char) {
     }
 }
 
-/// -------------------------------------------------------------------------------------------- ///
+/// -------------------------------- TariUtxo -=------------------------------------------------ ///
+/// Get the commitment from a TariUtxo
+///
+/// ## Arguments
+/// `utxo` - The pointer to a TariUtxo.
+/// `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
+/// as an out parameter.
+///
+/// ## Returns
+/// `*mut c_char` - Returns a pointer to a char array (that contains the commitment). Note that it returns empty if
+/// there was an error
+///
+/// # Safety
+/// The ```string_destroy``` method must be called when finished with a string from rust to prevent a memory leak
+#[no_mangle]
+pub unsafe extern "C" fn tari_utxo_get_commitment(utxo: *const TariUtxo, error_out: *mut c_int) -> *mut c_char {
+    let result = CString::new("").expect("Blank CString will not fail.");
+    if utxo.is_null() {
+        let mut error = LibWalletError::from(InterfaceError::NullError("utxo".to_string())).code;
+        ptr::swap(error_out, &mut error as *mut c_int);
+        return CString::into_raw(result);
+    }
+    let commitment_str = match CStr::from_ptr((*utxo).commitment).to_str() {
+        Ok(s) => s,
+        Err(_) => {
+            let mut error = LibWalletError::from(InterfaceError::PointerError("commitment".to_string())).code;
+            ptr::swap(error_out, &mut error as *mut c_int);
+            return CString::into_raw(result);
+        },
+    };
+    let result = CString::new(commitment_str).expect("Commitment will not fail.");
+    CString::into_raw(result)
+}
+
+/// Get the value from a TariUtxo
+///
+/// ## Arguments
+/// `utxo` - The pointer to a TariUtxo.
+/// `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
+/// as an out parameter.
+///
+/// ## Returns
+/// `c_ulonglong` -  Returns the value.
+///
+/// # Safety
+/// None
+#[no_mangle]
+pub unsafe extern "C" fn tari_utxo_get_value(utxo: *const TariUtxo, error_out: *mut c_int) -> c_ulonglong {
+    if utxo.is_null() {
+        let mut error = LibWalletError::from(InterfaceError::NullError("utxo".to_string())).code;
+        ptr::swap(error_out, &mut error as *mut c_int);
+        return 0;
+    }
+    (*utxo).value
+}
+
+/// Get the mined height from a TariUtxo
+///
+/// ## Arguments
+/// `utxo` - The pointer to a TariUtxo.
+/// `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
+/// as an out parameter.
+///
+/// ## Returns
+/// `c_ulonglong` -  Returns the mined height.
+///
+/// # Safety
+/// None
+#[no_mangle]
+pub unsafe extern "C" fn tari_utxo_get_mined_height(utxo: *const TariUtxo, error_out: *mut c_int) -> c_ulonglong {
+    if utxo.is_null() {
+        let mut error = LibWalletError::from(InterfaceError::NullError("utxo".to_string())).code;
+        ptr::swap(error_out, &mut error as *mut c_int);
+        return 0;
+    }
+    (*utxo).mined_height
+}
+
+/// Get the mine timestamp from a TariUtxo
+///
+/// ## Arguments
+/// `utxo` - The pointer to a TariUtxo.
+/// `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
+/// as an out parameter.
+///
+/// ## Returns
+/// `c_ulonglong` -  Returns the mined timestamp.
+///
+/// # Safety
+/// None
+#[no_mangle]
+pub unsafe extern "C" fn tari_utxo_get_mined_timestamp(utxo: *const TariUtxo, error_out: *mut c_int) -> c_ulonglong {
+    if utxo.is_null() {
+        let mut error = LibWalletError::from(InterfaceError::NullError("utxo".to_string())).code;
+        ptr::swap(error_out, &mut error as *mut c_int);
+        return 0;
+    }
+    (*utxo).mined_timestamp
+}
+
+/// Get the lock height from a TariUtxo
+///
+/// ## Arguments
+/// `utxo` - The pointer to a lock height.
+/// `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
+/// as an out parameter.
+///
+/// ## Returns
+/// `c_ulonglong` -  Returns the value.
+///
+/// # Safety
+/// None
+#[no_mangle]
+pub unsafe extern "C" fn tari_utxo_get_lock_height(utxo: *const TariUtxo, error_out: *mut c_int) -> c_ulonglong {
+    if utxo.is_null() {
+        let mut error = LibWalletError::from(InterfaceError::NullError("utxo".to_string())).code;
+        ptr::swap(error_out, &mut error as *mut c_int);
+        return 0;
+    }
+    (*utxo).lock_height
+}
+
+/// Get the value from a TariUtxo
+///
+/// ## Arguments
+/// `utxo` - The pointer to a TariUtxo.
+/// `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
+/// as an out parameter.
+///
+/// ## Returns
+/// `u8` -  Returns the status:
+///     0: Unspent
+///     1: Spent
+///     2: EncumberedToBeReceived
+///     3: EncumberedToBeSpent
+///     4: Invalid
+///     5: CancelledInbound
+///     6: UnspentMinedUnconfirmed
+///     7: ShortTermEncumberedToBeReceived
+///     8: ShortTermEncumberedToBeSpent
+///     9: SpentMinedUnconfirmed
+///     10: NotStored
+///
+/// # Safety
+/// None
+#[no_mangle]
+pub unsafe extern "C" fn tari_utxo_get_status(utxo: *const TariUtxo, error_out: *mut c_int) -> u8 {
+    if utxo.is_null() {
+        let mut error = LibWalletError::from(InterfaceError::NullError("utxo".to_string())).code;
+        ptr::swap(error_out, &mut error as *mut c_int);
+        return 0;
+    }
+    (*utxo).status
+}
+
+/// Get the coinbase extra from a TariUtxo
+///
+/// ## Arguments
+/// `utxo` - The pointer to a TariUtxo.
+/// `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
+/// as an out parameter.
+///
+/// ## Returns
+/// `*mut c_char` - Returns a pointer to a char array (that contains the coinbase extra). Note that it returns empty if
+/// there was an error
+///
+/// # Safety
+/// The ```string_destroy``` method must be called when finished with a string from rust to prevent a memory leak
+#[no_mangle]
+pub unsafe extern "C" fn tari_utxo_get_coinbase_extra(utxo: *const TariUtxo, error_out: *mut c_int) -> *mut c_char {
+    let result = CString::new("").expect("Blank CString will not fail.");
+    if utxo.is_null() {
+        let mut error = LibWalletError::from(InterfaceError::NullError("utxo".to_string())).code;
+        ptr::swap(error_out, &mut error as *mut c_int);
+        return CString::into_raw(result);
+    }
+
+    let coinbase_extra_str = match CStr::from_ptr((*utxo).coinbase_extra).to_str() {
+        Ok(s) => s,
+        Err(_) => {
+            let mut error = LibWalletError::from(InterfaceError::PointerError("coinbase_extra".to_string())).code;
+            ptr::swap(error_out, &mut error as *mut c_int);
+            return CString::into_raw(result);
+        },
+    };
+    let result = CString::new(coinbase_extra_str).expect("Commitment will not fail.");
+    CString::into_raw(result)
+}
+
+/// Get the payment id from a TariUtxo
+///
+/// ## Arguments
+/// `utxo` - The pointer to a TariUtxo.
+/// `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
+/// as an out parameter.
+///
+/// ## Returns
+/// `*mut c_char` - Returns a pointer to a char array (that contains the payment id). Note that it returns empty if
+/// there was an error
+///
+/// # Safety
+/// The ```string_destroy``` method must be called when finished with a string from rust to prevent a memory leak
+#[no_mangle]
+pub unsafe extern "C" fn tari_utxo_get_payment_id(utxo: *const TariUtxo, error_out: *mut c_int) -> *mut c_char {
+    let result = CString::new("").expect("Blank CString will not fail.");
+    if utxo.is_null() {
+        let mut error = LibWalletError::from(InterfaceError::NullError("utxo".to_string())).code;
+        ptr::swap(error_out, &mut error as *mut c_int);
+        return CString::into_raw(result);
+    }
+
+    let payment_id_str = match CStr::from_ptr((*utxo).payment_id).to_str() {
+        Ok(s) => s,
+        Err(_) => {
+            let mut error = LibWalletError::from(InterfaceError::PointerError("payment_id".to_string())).code;
+            ptr::swap(error_out, &mut error as *mut c_int);
+            return CString::into_raw(result);
+        },
+    };
+    let result = CString::new(payment_id_str).expect("Commitment will not fail.");
+    CString::into_raw(result)
+}
+
+/// Get the mined in block hash from a TariUtxo
+///
+/// ## Arguments
+/// `utxo` - The pointer to a TariUtxo.
+/// `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
+/// as an out parameter.
+///
+/// ## Returns
+/// `*mut c_char` - Returns a pointer to a char array (that contains the mined in block hash). Note that it returns
+/// empty if there was an error
+///
+/// # Safety
+/// The ```string_destroy``` method must be called when finished with a string from rust to prevent a memory leak
+#[no_mangle]
+pub unsafe extern "C" fn tari_utxo_get_mined_in_block(utxo: *const TariUtxo, error_out: *mut c_int) -> *mut c_char {
+    let result = CString::new("").expect("Blank CString will not fail.");
+    if utxo.is_null() {
+        let mut error = LibWalletError::from(InterfaceError::NullError("utxo".to_string())).code;
+        ptr::swap(error_out, &mut error as *mut c_int);
+        return CString::into_raw(result);
+    }
+
+    let mined_in_block_str = match CStr::from_ptr((*utxo).mined_in_block).to_str() {
+        Ok(s) => s,
+        Err(_) => {
+            let mut error = LibWalletError::from(InterfaceError::PointerError("mined_in_block".to_string())).code;
+            ptr::swap(error_out, &mut error as *mut c_int);
+            return CString::into_raw(result);
+        },
+    };
+    let result = CString::new(mined_in_block_str).expect("Commitment will not fail.");
+    CString::into_raw(result)
+}
+
 /// ----------------------------------- Transaction Kernel ------------------------------------- ///
 /// Gets the excess for a TariTransactionKernel
 ///
@@ -11178,6 +11438,42 @@ mod test {
                     output.features.coinbase_extra.to_hex(),
                     CStr::from_ptr(utxo.coinbase_extra).to_str().unwrap()
                 );
+
+                // Test TariUtxo accessor methods
+                let commitment = tari_utxo_get_commitment(utxo, error_ptr);
+                assert_eq!(
+                    CStr::from_ptr(commitment).to_str().unwrap(),
+                    CStr::from_ptr(utxo.commitment).to_str().unwrap()
+                );
+                string_destroy(commitment);
+                let value = tari_utxo_get_value(utxo, error_ptr);
+                assert_eq!(value, utxo.value);
+                let mined_height = tari_utxo_get_mined_height(utxo, error_ptr);
+                assert_eq!(mined_height, utxo.mined_height);
+                let mined_timestamp = tari_utxo_get_mined_timestamp(utxo, error_ptr);
+                assert_eq!(mined_timestamp, utxo.mined_timestamp);
+                let lock_height = tari_utxo_get_lock_height(utxo, error_ptr);
+                assert_eq!(lock_height, utxo.lock_height);
+                let status = tari_utxo_get_status(utxo, error_ptr);
+                assert_eq!(status, utxo.status);
+                let coinbase_extra = tari_utxo_get_coinbase_extra(utxo, error_ptr);
+                assert_eq!(
+                    CStr::from_ptr(coinbase_extra).to_str().unwrap(),
+                    CStr::from_ptr(utxo.coinbase_extra).to_str().unwrap()
+                );
+                string_destroy(coinbase_extra);
+                let payment_id = tari_utxo_get_payment_id(utxo, error_ptr);
+                assert_eq!(
+                    CStr::from_ptr(payment_id).to_str().unwrap(),
+                    CStr::from_ptr(utxo.payment_id).to_str().unwrap()
+                );
+                string_destroy(payment_id);
+                let mined_in_block = tari_utxo_get_mined_in_block(utxo, error_ptr);
+                assert_eq!(
+                    CStr::from_ptr(mined_in_block).to_str().unwrap(),
+                    CStr::from_ptr(utxo.mined_in_block).to_str().unwrap()
+                );
+                string_destroy(mined_in_block);
             }
             println!();
             destroy_tari_vector(outputs);

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -4479,6 +4479,93 @@ pub unsafe extern "C" fn completed_transaction_get_timestamp(
     (*transaction).timestamp.timestamp() as c_ulonglong
 }
 
+/// Gets the mined timestamp of a TariCompletedTransaction
+///
+/// ## Arguments
+/// `transaction` - The pointer to a TariCompletedTransaction
+/// `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
+/// as an out parameter.
+///
+/// ## Returns
+/// `c_ulonglong` - Returns the timestamp, note that it will be zero if transaction is null or not mined yet
+///
+/// # Safety
+/// None
+#[no_mangle]
+pub unsafe extern "C" fn completed_transaction_get_mined_timestamp(
+    transaction: *mut TariCompletedTransaction,
+    error_out: *mut c_int,
+) -> c_ulonglong {
+    let mut error = 0;
+    ptr::swap(error_out, &mut error as *mut c_int);
+    if transaction.is_null() {
+        error = LibWalletError::from(InterfaceError::NullError("transaction".to_string())).code;
+        ptr::swap(error_out, &mut error as *mut c_int);
+        return 0;
+    }
+    match (*transaction).mined_timestamp {
+        Some(mined_timestamp) => mined_timestamp.timestamp() as c_ulonglong,
+        None => 0,
+    }
+}
+
+/// Gets the mined height of a TariCompletedTransaction
+///
+/// ## Arguments
+/// `transaction` - The pointer to a TariCompletedTransaction
+/// `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
+/// as an out parameter.
+///
+/// ## Returns
+/// `c_ulonglong` - Returns the timestamp, note that it will be zero if transaction is null or not mined yet
+///
+/// # Safety
+/// None
+#[no_mangle]
+pub unsafe extern "C" fn completed_transaction_get_mined_height(
+    transaction: *mut TariCompletedTransaction,
+    error_out: *mut c_int,
+) -> c_ulonglong {
+    let mut error = 0;
+    ptr::swap(error_out, &mut error as *mut c_int);
+    if transaction.is_null() {
+        error = LibWalletError::from(InterfaceError::NullError("transaction".to_string())).code;
+        ptr::swap(error_out, &mut error as *mut c_int);
+        return 0;
+    }
+    (*transaction).mined_height.unwrap_or_default()
+}
+
+/// Gets the mined in block hash of a TariCompletedTransaction
+///
+/// ## Arguments
+/// `transaction` - The pointer to a TariCompletedTransaction
+/// `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
+/// as an out parameter.
+///
+/// ## Returns
+/// `*const c_char` - Returns the pointer to the char array, note that it will return a pointer
+/// to an empty char array if transaction is null
+///
+/// # Safety
+/// The ```string_destroy``` method must be called when finished with string coming from rust to prevent a memory leak
+#[no_mangle]
+pub unsafe extern "C" fn completed_transaction_get_mined_in_block(
+    transaction: *mut TariCompletedTransaction,
+    error_out: *mut c_int,
+) -> *const c_char {
+    let result = CString::new("").expect("Blank CString will not fail.");
+    if transaction.is_null() {
+        let mut error = LibWalletError::from(InterfaceError::NullError("transaction".to_string())).code;
+        ptr::swap(error_out, &mut error as *mut c_int);
+        return CString::into_raw(result);
+    }
+    let mined_in_block = (*transaction).mined_in_block.unwrap_or_default();
+    let result = CString::new(mined_in_block.to_hex().as_str()).expect("Commitment will not fail.");
+
+    CString::into_raw(result)
+}
+
 /// Gets the payment ID of a TariCompletedTransaction
 ///
 /// ## Arguments

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -4583,7 +4583,7 @@ pub unsafe extern "C" fn completed_transaction_get_mined_in_block(
 pub unsafe extern "C" fn completed_transaction_get_payment_id(
     transaction: *mut TariCompletedTransaction,
     error_out: *mut c_int,
-) -> *const c_char {
+) -> *mut c_char {
     let mut error = 0;
     ptr::swap(error_out, &mut error as *mut c_int);
     let payment_id = (*transaction).payment_id.clone();

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -2324,8 +2324,8 @@ unsigned long long completed_transaction_get_mined_height(TariCompletedTransacti
  * # Safety
  * The ```string_destroy``` method must be called when finished with string coming from rust to prevent a memory leak
  */
-const char *completed_transaction_get_mined_in_block(TariCompletedTransaction *transaction,
-                                                     int *error_out);
+char *completed_transaction_get_mined_in_block(TariCompletedTransaction *transaction,
+                                               int *error_out);
 
 /**
  * Gets the payment ID of a TariCompletedTransaction

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -2276,6 +2276,58 @@ unsigned long long completed_transaction_get_timestamp(TariCompletedTransaction 
                                                        int *error_out);
 
 /**
+ * Gets the mined timestamp of a TariCompletedTransaction
+ *
+ * ## Arguments
+ * `transaction` - The pointer to a TariCompletedTransaction
+ * `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
+ * as an out parameter.
+ *
+ * ## Returns
+ * `c_ulonglong` - Returns the timestamp, note that it will be zero if transaction is null or not mined yet
+ *
+ * # Safety
+ * None
+ */
+unsigned long long completed_transaction_get_mined_timestamp(TariCompletedTransaction *transaction,
+                                                             int *error_out);
+
+/**
+ * Gets the mined height of a TariCompletedTransaction
+ *
+ * ## Arguments
+ * `transaction` - The pointer to a TariCompletedTransaction
+ * `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
+ * as an out parameter.
+ *
+ * ## Returns
+ * `c_ulonglong` - Returns the timestamp, note that it will be zero if transaction is null or not mined yet
+ *
+ * # Safety
+ * None
+ */
+unsigned long long completed_transaction_get_mined_height(TariCompletedTransaction *transaction,
+                                                          int *error_out);
+
+/**
+ * Gets the mined in block hash of a TariCompletedTransaction
+ *
+ * ## Arguments
+ * `transaction` - The pointer to a TariCompletedTransaction
+ * `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
+ * as an out parameter.
+ *
+ * ## Returns
+ * `*const c_char` - Returns the pointer to the char array, note that it will return a pointer
+ * to an empty char array if transaction is null
+ *
+ * # Safety
+ * The ```string_destroy``` method must be called when finished with string coming from rust to prevent a memory leak
+ */
+const char *completed_transaction_get_mined_in_block(TariCompletedTransaction *transaction,
+                                                     int *error_out);
+
+/**
  * Gets the payment ID of a TariCompletedTransaction
  *
  * ## Arguments

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -165,6 +165,18 @@ struct TariCoinPreview {
   uint64_t fee;
 };
 
+struct TariUtxo {
+  const char *commitment;
+  uint64_t value;
+  uint64_t mined_height;
+  uint64_t mined_timestamp;
+  uint64_t lock_height;
+  uint8_t status;
+  const char *coinbase_extra;
+  const char *payment_id;
+  const char *mined_in_block;
+};
+
 typedef struct TransactionKernel TariTransactionKernel;
 
 /**
@@ -231,17 +243,6 @@ typedef struct Balance TariBalance;
 typedef struct FeePerGramStatsResponse TariFeePerGramStats;
 
 typedef struct FeePerGramStat TariFeePerGramStat;
-
-struct TariUtxo {
-  const char *commitment;
-  uint64_t value;
-  uint64_t mined_height;
-  uint64_t mined_timestamp;
-  uint64_t lock_height;
-  uint8_t status;
-  const char *coinbase_extra;
-  const char *payment_id;
-};
 
 #ifdef __cplusplus
 extern "C" {
@@ -319,7 +320,175 @@ void destroy_tari_coin_preview(struct TariCoinPreview *p);
 void string_destroy(char *ptr);
 
 /**
- * -------------------------------------------------------------------------------------------- ///
+ * -------------------------------- TariUtxo -=------------------------------------------------ ///
+ * Get the commitment from a TariUtxo
+ *
+ * ## Arguments
+ * `utxo` - The pointer to a TariUtxo.
+ * `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
+ * as an out parameter.
+ *
+ * ## Returns
+ * `*mut c_char` - Returns a pointer to a char array (that contains the commitment). Note that it returns empty if
+ * there was an error
+ *
+ * # Safety
+ * The ```string_destroy``` method must be called when finished with a string from rust to prevent a memory leak
+ */
+char *tari_utxo_get_commitment(const struct TariUtxo *utxo,
+                               int *error_out);
+
+/**
+ * Get the value from a TariUtxo
+ *
+ * ## Arguments
+ * `utxo` - The pointer to a TariUtxo.
+ * `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
+ * as an out parameter.
+ *
+ * ## Returns
+ * `c_ulonglong` -  Returns the value.
+ *
+ * # Safety
+ * None
+ */
+unsigned long long tari_utxo_get_value(const struct TariUtxo *utxo,
+                                       int *error_out);
+
+/**
+ * Get the mined height from a TariUtxo
+ *
+ * ## Arguments
+ * `utxo` - The pointer to a TariUtxo.
+ * `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
+ * as an out parameter.
+ *
+ * ## Returns
+ * `c_ulonglong` -  Returns the mined height.
+ *
+ * # Safety
+ * None
+ */
+unsigned long long tari_utxo_get_mined_height(const struct TariUtxo *utxo,
+                                              int *error_out);
+
+/**
+ * Get the mine timestamp from a TariUtxo
+ *
+ * ## Arguments
+ * `utxo` - The pointer to a TariUtxo.
+ * `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
+ * as an out parameter.
+ *
+ * ## Returns
+ * `c_ulonglong` -  Returns the mined timestamp.
+ *
+ * # Safety
+ * None
+ */
+unsigned long long tari_utxo_get_mined_timestamp(const struct TariUtxo *utxo,
+                                                 int *error_out);
+
+/**
+ * Get the lock height from a TariUtxo
+ *
+ * ## Arguments
+ * `utxo` - The pointer to a lock height.
+ * `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
+ * as an out parameter.
+ *
+ * ## Returns
+ * `c_ulonglong` -  Returns the value.
+ *
+ * # Safety
+ * None
+ */
+unsigned long long tari_utxo_get_lock_height(const struct TariUtxo *utxo,
+                                             int *error_out);
+
+/**
+ * Get the value from a TariUtxo
+ *
+ * ## Arguments
+ * `utxo` - The pointer to a TariUtxo.
+ * `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
+ * as an out parameter.
+ *
+ * ## Returns
+ * `u8` -  Returns the status:
+ *     0: Unspent
+ *     1: Spent
+ *     2: EncumberedToBeReceived
+ *     3: EncumberedToBeSpent
+ *     4: Invalid
+ *     5: CancelledInbound
+ *     6: UnspentMinedUnconfirmed
+ *     7: ShortTermEncumberedToBeReceived
+ *     8: ShortTermEncumberedToBeSpent
+ *     9: SpentMinedUnconfirmed
+ *     10: NotStored
+ *
+ * # Safety
+ * None
+ */
+uint8_t tari_utxo_get_status(const struct TariUtxo *utxo,
+                             int *error_out);
+
+/**
+ * Get the coinbase extra from a TariUtxo
+ *
+ * ## Arguments
+ * `utxo` - The pointer to a TariUtxo.
+ * `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
+ * as an out parameter.
+ *
+ * ## Returns
+ * `*mut c_char` - Returns a pointer to a char array (that contains the coinbase extra). Note that it returns empty if
+ * there was an error
+ *
+ * # Safety
+ * The ```string_destroy``` method must be called when finished with a string from rust to prevent a memory leak
+ */
+char *tari_utxo_get_coinbase_extra(const struct TariUtxo *utxo,
+                                   int *error_out);
+
+/**
+ * Get the payment id from a TariUtxo
+ *
+ * ## Arguments
+ * `utxo` - The pointer to a TariUtxo.
+ * `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
+ * as an out parameter.
+ *
+ * ## Returns
+ * `*mut c_char` - Returns a pointer to a char array (that contains the payment id). Note that it returns empty if
+ * there was an error
+ *
+ * # Safety
+ * The ```string_destroy``` method must be called when finished with a string from rust to prevent a memory leak
+ */
+char *tari_utxo_get_payment_id(const struct TariUtxo *utxo,
+                               int *error_out);
+
+/**
+ * Get the mined in block hash from a TariUtxo
+ *
+ * ## Arguments
+ * `utxo` - The pointer to a TariUtxo.
+ * `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
+ * as an out parameter.
+ *
+ * ## Returns
+ * `*mut c_char` - Returns a pointer to a char array (that contains the mined in block hash). Note that it returns
+ * empty if there was an error
+ *
+ * # Safety
+ * The ```string_destroy``` method must be called when finished with a string from rust to prevent a memory leak
+ */
+char *tari_utxo_get_mined_in_block(const struct TariUtxo *utxo,
+                                   int *error_out);
+
+/**
  * ----------------------------------- Transaction Kernel ------------------------------------- ///
  * Gets the excess for a TariTransactionKernel
  *

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -2342,8 +2342,8 @@ char *completed_transaction_get_mined_in_block(TariCompletedTransaction *transac
  * # Safety
  * The ```string_destroy``` method must be called when finished with string coming from rust to prevent a memory leak
  */
-const char *completed_transaction_get_payment_id(TariCompletedTransaction *transaction,
-                                                 int *error_out);
+char *completed_transaction_get_payment_id(TariCompletedTransaction *transaction,
+                                           int *error_out);
 
 /**
  * This function checks to determine if a TariCompletedTransaction was originally a TariPendingOutboundTransaction

--- a/integration_tests/src/ffi/completed_transaction.rs
+++ b/integration_tests/src/ffi/completed_transaction.rs
@@ -148,7 +148,7 @@ impl CompletedTransaction {
                 panic!("completed_transaction_get_payment_id error");
             }
         }
-        FFIString::from_ptr(ptr as *mut i8).as_string()
+        FFIString::from_ptr(ptr).as_string()
     }
 
     #[allow(dead_code)]

--- a/integration_tests/src/ffi/ffi_import.rs
+++ b/integration_tests/src/ffi/ffi_import.rs
@@ -292,6 +292,18 @@ extern "C" {
         transaction: *mut TariCompletedTransaction,
         error_out: *mut c_int,
     ) -> c_ulonglong;
+    pub fn completed_transaction_get_mined_timestamp(
+        transaction: *mut TariCompletedTransaction,
+        error_out: *mut c_int,
+    ) -> c_ulonglong;
+    pub fn completed_transaction_get_mined_height(
+        transaction: *mut TariCompletedTransaction,
+        error_out: *mut c_int,
+    ) -> c_ulonglong;
+    pub fn completed_transaction_get_mined_in_block(
+        transaction: *mut TariCompletedTransaction,
+        error_out: *mut c_int,
+    ) -> *const c_char;
     pub fn completed_transaction_get_payment_id(
         transaction: *mut TariCompletedTransaction,
         error_out: *mut c_int,

--- a/integration_tests/src/ffi/ffi_import.rs
+++ b/integration_tests/src/ffi/ffi_import.rs
@@ -303,7 +303,7 @@ extern "C" {
     pub fn completed_transaction_get_mined_in_block(
         transaction: *mut TariCompletedTransaction,
         error_out: *mut c_int,
-    ) -> *const c_char;
+    ) -> *mut c_char;
     pub fn completed_transaction_get_payment_id(
         transaction: *mut TariCompletedTransaction,
         error_out: *mut c_int,

--- a/integration_tests/src/ffi/ffi_import.rs
+++ b/integration_tests/src/ffi/ffi_import.rs
@@ -307,7 +307,7 @@ extern "C" {
     pub fn completed_transaction_get_payment_id(
         transaction: *mut TariCompletedTransaction,
         error_out: *mut c_int,
-    ) -> *const c_char;
+    ) -> *mut c_char;
     pub fn completed_transaction_is_outbound(tx: *mut TariCompletedTransaction, error_out: *mut c_int) -> bool;
     pub fn completed_transaction_get_confirmations(
         tx: *mut TariCompletedTransaction,

--- a/integration_tests/src/ffi/ffi_import.rs
+++ b/integration_tests/src/ffi/ffi_import.rs
@@ -22,6 +22,7 @@
 
 use libc::{c_char, c_int, c_uchar, c_uint, c_ulonglong, c_ushort, c_void};
 
+pub type TariUtxo = c_void;
 pub type TariTransportConfig = c_void;
 pub type TariCommsConfig = c_void;
 pub type TariSeedWords = c_void;
@@ -80,6 +81,15 @@ extern "C" {
     pub fn destroy_tari_vector(v: *mut TariVector);
     pub fn destroy_tari_coin_preview(p: *mut TariCoinPreview);
     pub fn string_destroy(ptr: *mut c_char);
+    pub fn tari_utxo_get_commitment(utxo: *const TariUtxo, error_out: *mut c_int) -> *mut c_char;
+    pub fn tari_utxo_get_value(utxo: *const TariUtxo, error_out: *mut c_int) -> c_ulonglong;
+    pub fn tari_utxo_get_mined_height(utxo: *const TariUtxo, error_out: *mut c_int) -> c_ulonglong;
+    pub fn tari_utxo_get_mined_timestamp(utxo: *const TariUtxo, error_out: *mut c_int) -> c_ulonglong;
+    pub fn tari_utxo_get_lock_height(utxo: *const TariUtxo, error_out: *mut c_int) -> c_ulonglong;
+    pub fn tari_utxo_get_status(utxo: *const TariUtxo, error_out: *mut c_int) -> u8;
+    pub fn tari_utxo_get_coinbase_extra(utxo: *const TariUtxo, error_out: *mut c_int) -> *mut c_char;
+    pub fn tari_utxo_get_payment_id(utxo: *const TariUtxo, error_out: *mut c_int) -> *mut c_char;
+    pub fn tari_utxo_get_mined_in_block(utxo: *const TariUtxo, error_out: *mut c_int) -> *mut c_char;
     pub fn transaction_kernel_get_excess_hex(kernel: *mut TariTransactionKernel, error_out: *mut c_int) -> *mut c_char;
     pub fn transaction_kernel_get_excess_public_nonce_hex(
         kernel: *mut TariTransactionKernel,

--- a/integration_tests/tests/cucumber.rs
+++ b/integration_tests/tests/cucumber.rs
@@ -19,6 +19,7 @@
 //   SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
 //   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#![feature(internal_output_capture)]
 
 use std::{
     fs,
@@ -57,6 +58,8 @@ fn main() {
     )
     .expect("logging not configured");
     let stdout_buffer = Arc::new(Mutex::new(Vec::<u8>::new()));
+    #[cfg(test)]
+    std::io::set_output_capture(Some(stdout_buffer.clone()));
     // Never move this line below the runtime creation!!! It will cause that any new thread created via task::spawn will
     // not be affected by the output capture.
     let stdout_buffer_clone = stdout_buffer.clone();

--- a/integration_tests/tests/cucumber.rs
+++ b/integration_tests/tests/cucumber.rs
@@ -19,7 +19,6 @@
 //   SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
 //   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-#![feature(internal_output_capture)]
 
 use std::{
     fs,
@@ -58,8 +57,6 @@ fn main() {
     )
     .expect("logging not configured");
     let stdout_buffer = Arc::new(Mutex::new(Vec::<u8>::new()));
-    #[cfg(test)]
-    std::io::set_output_capture(Some(stdout_buffer.clone()));
     // Never move this line below the runtime creation!!! It will cause that any new thread created via task::spawn will
     // not be affected by the output capture.
     let stdout_buffer_clone = stdout_buffer.clone();


### PR DESCRIPTION
Description
---
- Added `mined_in_block` to the `TariUtxo` FFI struct.
- Added `TariUtxo` de-structure methods to the wallet FFI to access all its components.
- Added additional `TariCompletedTransaction` methods to access `mined_timestamp`, `mined_in_block` and `mined_height`.

Closes #6833

Motivation and Context
---
See #6833

How Has This Been Tested?
---
Expanded unit test `fn test_wallet_get_utxos()` to test all the de-structure methods.

What process can a PR reviewer use to test or verify this change?
---
Code review.

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->



