### PR TITLE
fix: fix rust analyser bug

### DIFF
--- a/infrastructure/test_utils/Cargo.toml
+++ b/infrastructure/test_utils/Cargo.toml
@@ -9,8 +9,8 @@ license = "BSD-3-Clause"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tari_shutdown = { path = "../shutdown", version = "1.11.6-pre.0" }
-tari_comms = { path = "../../comms/core", version = "1.11.6-pre.0" }
+tari_shutdown = { workspace = true }
+tari_comms = { workspace = true }
 
 futures = { version = "^0.3.1" }
 rand = "0.8"


### PR DESCRIPTION
Fixes an error I was seeing in rust analyzer. 

```
2025-03-03T14:41:07.7737338+02:00 ERROR Flycheck failed to run the following command: CommandHandle { program: "C:\\Users\\xxxxxx\\.cargo\\bin\\cargo.exe", arguments: ["check", "--workspace", "--message-format=json-diagnostic-rendered-ansi", "--manifest-path", "D:\\xxxxxxx\\tari\\Cargo.toml", "--keep-going", "--all-targets"], current_dir: Some("D:\\xxxxxxxxx\\tari") }, error=Cargo watcher failed, the command produced no valid metadata (exit code: ExitStatus(ExitStatus(101))):
warning: D:\xxxxx\tari\infrastructure\shutdown\Cargo.toml: no edition set: defaulting to the 2015 edition while the latest is 2021
warning: D:\xxxxxx\tari\hashing\Cargo.toml: `default-features` is ignored for tari_crypto, since `default-features` was not specified for `workspace.dependencies.tari_crypto`, this could become a hard error in the future
error: failed to select a version for the requirement `tari_shutdown = "^1.11.6-pre.0"`
candidate versions found which didn't match: 0.0.0

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved internal dependency management by shifting to a workspace-based configuration for streamlined version handling and greater consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->