### PR TITLE
chore(ci): fix docker builds with a work around

### DIFF
--- a/buildtools/docker_rig/tarilabs.Dockerfile
+++ b/buildtools/docker_rig/tarilabs.Dockerfile
@@ -60,6 +60,9 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     sh /tari/scripts/install_ubuntu_dependencies.sh
 
+# Work around - Error: Not a git repository or CARGO_MANIFEST_DIR nested deeper than 10 from the root
+RUN git init -q
+
 RUN if [ "${BUILDARCH}" != "${TARGETARCH}" ] ; then \
       # Run script to help setup cross-compile environment
       . /tari/scripts/cross_compile_tooling.sh ; \


### PR DESCRIPTION
Description
Work around - 'CARGO_MANIFEST_DIR nested deeper than 10 from the root'

Motivation and Context
Fix docker builds

How Has This Been Tested?
Builds locally and in fork


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Refined the container build configuration to improve initialization reliability and reduce potential build errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->