### PR TITLE
fix!: monero seed validation

### DIFF
--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -102,7 +102,7 @@ use crate::{
     input_mr_hash_from_pruned_mmr,
     kernel_mr_hash_from_pruned_mmr,
     output_mr_hash_from_smt,
-    proof_of_work::{monero_rx::MoneroPowData, PowAlgorithm, TargetDifficultyWindow},
+    proof_of_work::{PowAlgorithm, TargetDifficultyWindow},
     transactions::transaction_components::{TransactionInput, TransactionKernel, TransactionOutput},
     validation::{
         helpers::calc_median_timestamp,
@@ -1150,7 +1150,7 @@ where B: BlockchainBackend
         let mut db = self.db_write_access()?;
 
         let mut txn = DbTransaction::new();
-        insert_best_block(&mut txn, block, &self.consensus_manager, self.smt())?;
+        insert_best_block(&mut txn, block, self.smt())?;
         db.write(txn)
     }
 
@@ -1304,7 +1304,6 @@ where B: BlockchainBackend
             &self.config,
             &*self.validators.block,
             self.consensus_manager.chain_strength_comparer(),
-            &self.consensus_manager,
             self.smt(),
         )?;
         Ok(())
@@ -1662,7 +1661,6 @@ fn add_block<T: BlockchainBackend>(
 fn insert_best_block(
     txn: &mut DbTransaction,
     block: Arc<ChainBlock>,
-    consensus: &ConsensusManager,
     smt: Arc<RwLock<OutputSmt>>,
 ) -> Result<(), ChainStorageError> {
     let block_hash = block.accumulated_data().hash;
@@ -1672,16 +1670,6 @@ fn insert_best_block(
         block.header().height,
         block_hash,
     );
-    if block.header().pow_algo() == PowAlgorithm::RandomX {
-        let monero_header =
-            MoneroPowData::from_header(block.header(), consensus).map_err(|e| ChainStorageError::InvalidArguments {
-                func: "insert_best_block",
-                arg: "block",
-                message: format!("block contained invalid or malformed monero PoW data: {}", e),
-            })?;
-        txn.insert_monero_seed_height(monero_header.randomx_key.to_vec(), block.height());
-    }
-
     let height = block.height();
     let timestamp = block.header().timestamp().as_u64();
     let accumulated_difficulty = block.accumulated_data().total_accumulated_difficulty;
@@ -2030,14 +2018,7 @@ fn handle_possible_reorg<T: BlockchainBackend>(
     let hash = candidate_block.header.hash();
     insert_orphan_and_find_new_tips(db, candidate_block, header_validator, consensus_manager)?;
     let after_orphans = timer.elapsed();
-    let res = swap_to_highest_pow_chain(
-        db,
-        config,
-        block_validator,
-        chain_strength_comparer,
-        consensus_manager,
-        smt,
-    );
+    let res = swap_to_highest_pow_chain(db, config, block_validator, chain_strength_comparer, smt);
     trace!(
         target: LOG_TARGET,
         "[handle_possible_reorg] block #{}, insert_orphans in {:.2?}, swap_to_highest in {:.2?} '{}'",
@@ -2056,7 +2037,6 @@ fn reorganize_chain<T: BlockchainBackend>(
     block_validator: &dyn CandidateBlockValidator<T>,
     fork_hash: HashOutput,
     new_chain_from_fork: &VecDeque<Arc<ChainBlock>>,
-    consensus: &ConsensusManager,
     smt: Arc<RwLock<OutputSmt>>,
 ) -> Result<Vec<Arc<ChainBlock>>, ChainStorageError> {
     let removed_blocks = rewind_to_hash(backend, fork_hash, smt.clone())?;
@@ -2095,11 +2075,11 @@ fn reorganize_chain<T: BlockchainBackend>(
             backend.write(txn)?;
 
             info!(target: LOG_TARGET, "Restoring previous chain after failed reorg.");
-            restore_reorged_chain(backend, fork_hash, removed_blocks, consensus, smt.clone())?;
+            restore_reorged_chain(backend, fork_hash, removed_blocks, smt.clone())?;
             return Err(e.into());
         }
 
-        if let Err(e) = insert_best_block(&mut txn, block.clone(), consensus, smt.clone()) {
+        if let Err(e) = insert_best_block(&mut txn, block.clone(), smt.clone()) {
             let mut write_smt = smt.write().map_err(|e| {
                 error!(
                     target: LOG_TARGET,
@@ -2120,7 +2100,7 @@ fn reorganize_chain<T: BlockchainBackend>(
                 "Failed to commit reorg chain: {:?}. Restoring last chain.", e
             );
 
-            restore_reorged_chain(backend, fork_hash, removed_blocks, consensus, smt)?;
+            restore_reorged_chain(backend, fork_hash, removed_blocks, smt)?;
             return Err(e);
         }
     }
@@ -2133,7 +2113,6 @@ fn swap_to_highest_pow_chain<T: BlockchainBackend>(
     config: &BlockchainDatabaseConfig,
     block_validator: &dyn CandidateBlockValidator<T>,
     chain_strength_comparer: &dyn ChainStrengthComparer,
-    consensus: &ConsensusManager,
     smt: Arc<RwLock<OutputSmt>>,
 ) -> Result<BlockAddResult, ChainStorageError> {
     let metadata = db.fetch_chain_metadata()?;
@@ -2191,7 +2170,7 @@ fn swap_to_highest_pow_chain<T: BlockchainBackend>(
         .prev_hash;
 
     let num_added_blocks = reorg_chain.len();
-    let removed_blocks = reorganize_chain(db, block_validator, fork_hash, &reorg_chain, consensus, smt)?;
+    let removed_blocks = reorganize_chain(db, block_validator, fork_hash, &reorg_chain, smt)?;
     let num_removed_blocks = removed_blocks.len();
 
     // reorg is required when any blocks are removed or more than one are added
@@ -2243,7 +2222,6 @@ fn restore_reorged_chain<T: BlockchainBackend>(
     db: &mut T,
     to_hash: HashOutput,
     previous_chain: Vec<Arc<ChainBlock>>,
-    consensus: &ConsensusManager,
     smt: Arc<RwLock<OutputSmt>>,
 ) -> Result<(), ChainStorageError> {
     let invalid_chain = rewind_to_hash(db, to_hash, smt.clone())?;
@@ -2260,7 +2238,7 @@ fn restore_reorged_chain<T: BlockchainBackend>(
 
     for block in previous_chain.into_iter().rev() {
         txn.delete_orphan(block.accumulated_data().hash);
-        insert_best_block(&mut txn, block, consensus, smt.clone())?;
+        insert_best_block(&mut txn, block, smt.clone())?;
     }
     db.write(txn)?;
     Ok(())

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -19,7 +19,6 @@
 // SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
 use std::{
     cmp::max,
     convert::TryFrom,
@@ -126,6 +125,7 @@ use crate::{
     },
     consensus::{ConsensusConstants, ConsensusManager},
     output_mr_hash_from_smt,
+    proof_of_work::{monero_rx::MoneroPowData, PowAlgorithm},
     transactions::{
         aggregated_body::AggregateBody,
         transaction_components::{
@@ -860,6 +860,22 @@ impl LMDBDatabase {
             )));
         } else {
             // we can continue
+        }
+
+        if header.pow_algo() == PowAlgorithm::RandomX {
+            let monero_header = MoneroPowData::from_header(&header, &self.consensus_manager).map_err(|e| {
+                ChainStorageError::InvalidArguments {
+                    func: "insert_best_block",
+                    arg: "block",
+                    message: format!("block contained invalid or malformed monero PoW data: {}", e),
+                }
+            })?;
+            let vm_key = monero_header.randomx_key.to_vec();
+            trace!(
+                target: LOG_TARGET,
+                "inserting monero vm key: {} for height {}",vm_key.to_hex(), header.height
+            );
+            self.insert_monero_seed_height(&txn, &vm_key, header.height)?;
         }
 
         lmdb_insert(

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -863,7 +863,7 @@ impl LMDBDatabase {
         }
 
         if header.pow_algo() == PowAlgorithm::RandomX {
-            let monero_header = MoneroPowData::from_header(&header, &self.consensus_manager).map_err(|e| {
+            let monero_header = MoneroPowData::from_header(header, &self.consensus_manager).map_err(|e| {
                 ChainStorageError::InvalidArguments {
                     func: "insert_best_block",
                     arg: "block",
@@ -875,7 +875,7 @@ impl LMDBDatabase {
                 target: LOG_TARGET,
                 "inserting monero vm key: {} for height {}",vm_key.to_hex(), header.height
             );
-            self.insert_monero_seed_height(&txn, &vm_key, header.height)?;
+            self.insert_monero_seed_height(txn, &vm_key, header.height)?;
         }
 
         lmdb_insert(
@@ -2911,7 +2911,7 @@ impl fmt::Display for MetadataValue {
 }
 
 fn run_migrations(db: &LMDBDatabase) -> Result<(), ChainStorageError> {
-    const MIGRATION_VERSION: u64 = 2;
+    const MIGRATION_VERSION: u64 = 3;
     let txn = db.read_transaction()?;
 
     let k = MetadataKey::MigrationVersion;
@@ -2931,6 +2931,13 @@ fn run_migrations(db: &LMDBDatabase) -> Result<(), ChainStorageError> {
         if migrate_from_version == 1 {
             let txn = db.write_transaction()?;
             info!(target: LOG_TARGET, "Clearing bad blocks list due to median timestamp bug in nextnet");
+            let rows_affected = lmdb_clear(&txn, &db.bad_blocks)?;
+            txn.commit()?;
+            info!(target: LOG_TARGET, "Removed {} rows from bad blocks", rows_affected);
+        }
+        if migrate_from_version == 2 {
+            let txn = db.write_transaction()?;
+            info!(target: LOG_TARGET, "Clearing bad blocks list due to bypass validation of monero seed ");
             let rows_affected = lmdb_clear(&txn, &db.bad_blocks)?;
             txn.commit()?;
             info!(target: LOG_TARGET, "Removed {} rows from bad blocks", rows_affected);

--- a/base_layer/core/src/validation/header/header_full_validator.rs
+++ b/base_layer/core/src/validation/header/header_full_validator.rs
@@ -41,6 +41,14 @@ use crate::{
 
 pub const LOG_TARGET: &str = "c::val::header_full_validator";
 
+// 999785e3bb6a43189c7236de7c9720df27d56f6b9724cd22f5115a097d3f770e is a bad block that bypassed validation due to a bug
+// in saving Monero seeds. The block uses a randomX  VM key of
+// 91ef83186cefaa646dc4c6e950e68e4debab52b4f4a9b7f465891e91fe5f6ce4, this key was used between height 2729 and 843 which
+// is about what you would expect from the Monero consensus. This block reuses this key at height 26320, which is a
+// violation of the Monero consensus rules. But in order to keep the network on the same chain, we whitelist this block
+// to bypass validation as that is the only validation it has failed.
+pub const WHITELISTED_HEADERS: [&str; 1] = ["999785e3bb6a43189c7236de7c9720df27d56f6b9724cd22f5115a097d3f770e"];
+
 #[derive(Clone)]
 pub struct HeaderFullValidator {
     rules: ConsensusManager,
@@ -70,16 +78,19 @@ impl<B: BlockchainBackend> HeaderChainLinkedValidator<B> for HeaderFullValidator
     ) -> Result<AchievedTargetDifficulty, ValidationError> {
         let constants = self.rules.consensus_constants(header.height);
 
-        check_not_bad_block(db, header.hash())?;
-        check_blockchain_version(constants, header.version)?;
-        check_height(header, prev_header)?;
-        check_prev_hash(header, prev_header)?;
+        // dont run these checks for blocks we have whitelisted
+        if !WHITELISTED_HEADERS.contains(&header.hash().to_hex().as_str()) {
+            check_not_bad_block(db, header.hash())?;
+            check_blockchain_version(constants, header.version)?;
+            check_height(header, prev_header)?;
+            check_prev_hash(header, prev_header)?;
 
-        sanity_check_timestamp_count(header, prev_timestamps, constants)?;
-        check_header_timestamp_greater_than_median(header, prev_timestamps)?;
+            sanity_check_timestamp_count(header, prev_timestamps, constants)?;
+            check_header_timestamp_greater_than_median(header, prev_timestamps)?;
 
-        check_timestamp_ftl(header, &self.rules)?;
-        check_pow_data(header, &self.rules, db)?;
+            check_timestamp_ftl(header, &self.rules)?;
+            check_pow_data(header, &self.rules, db)?;
+        }
 
         let achieved_target = if let Some(target) = target_difficulty {
             check_target_difficulty(

--- a/base_layer/core/src/validation/header/header_full_validator.rs
+++ b/base_layer/core/src/validation/header/header_full_validator.rs
@@ -42,7 +42,7 @@ use crate::{
 pub const LOG_TARGET: &str = "c::val::header_full_validator";
 
 // 999785e3bb6a43189c7236de7c9720df27d56f6b9724cd22f5115a097d3f770e and
-// 39d1449e85bf2e3eb6986b05d7991ce1823cb3e1769f11cdc0c07192f344b408 is are bad blocks on NEXTNET that bypassed
+// 39d1449e85bf2e3eb6986b05d7991ce1823cb3e1769f11cdc0c07192f344b408 are bad blocks on NEXTNET that bypassed
 // validation due to a bug in saving Monero seeds. The block uses a randomX  VM key of
 // 91ef83186cefaa646dc4c6e950e68e4debab52b4f4a9b7f465891e91fe5f6ce4, this key was used between height 2729 and 843 which
 // is about what you would expect from the Monero consensus. These blocks (26320 and 26440) reuses this key, which is a

--- a/base_layer/core/src/validation/header/header_full_validator.rs
+++ b/base_layer/core/src/validation/header/header_full_validator.rs
@@ -22,7 +22,7 @@
 
 use std::cmp;
 
-use log::warn;
+use log::{debug, warn};
 use tari_common_types::types::FixedHash;
 use tari_utilities::{epoch_time::EpochTime, hex::Hex};
 
@@ -41,13 +41,21 @@ use crate::{
 
 pub const LOG_TARGET: &str = "c::val::header_full_validator";
 
-// 999785e3bb6a43189c7236de7c9720df27d56f6b9724cd22f5115a097d3f770e is a bad block that bypassed validation due to a bug
-// in saving Monero seeds. The block uses a randomX  VM key of
+// 999785e3bb6a43189c7236de7c9720df27d56f6b9724cd22f5115a097d3f770e and
+// 39d1449e85bf2e3eb6986b05d7991ce1823cb3e1769f11cdc0c07192f344b408 is are bad blocks on NEXTNET that bypassed
+// validation due to a bug in saving Monero seeds. The block uses a randomX  VM key of
 // 91ef83186cefaa646dc4c6e950e68e4debab52b4f4a9b7f465891e91fe5f6ce4, this key was used between height 2729 and 843 which
-// is about what you would expect from the Monero consensus. This block reuses this key at height 26320, which is a
+// is about what you would expect from the Monero consensus. These blocks (26320 and 26440) reuses this key, which is a
 // violation of the Monero consensus rules. But in order to keep the network on the same chain, we whitelist this block
 // to bypass validation as that is the only validation it has failed.
-pub const WHITELISTED_HEADERS: [&str; 1] = ["999785e3bb6a43189c7236de7c9720df27d56f6b9724cd22f5115a097d3f770e"];
+// ToDo empty out on each reset
+#[cfg(tari_target_network_nextnet)]
+pub const WHITELISTED_HEADERS: [&str; 2] = [
+    "999785e3bb6a43189c7236de7c9720df27d56f6b9724cd22f5115a097d3f770e",
+    "39d1449e85bf2e3eb6986b05d7991ce1823cb3e1769f11cdc0c07192f344b408",
+];
+#[cfg(not(tari_target_network_nextnet))]
+pub const WHITELISTED_HEADERS: [&str; 0] = [];
 
 #[derive(Clone)]
 pub struct HeaderFullValidator {
@@ -79,7 +87,13 @@ impl<B: BlockchainBackend> HeaderChainLinkedValidator<B> for HeaderFullValidator
         let constants = self.rules.consensus_constants(header.height);
 
         // dont run these checks for blocks we have whitelisted
-        if !WHITELISTED_HEADERS.contains(&header.hash().to_hex().as_str()) {
+        if WHITELISTED_HEADERS.contains(&header.hash().to_hex().as_str()) {
+            debug!(
+            target: LOG_TARGET,
+            "Bypassing checks for:{}({}) because block is whitelisted",
+            header.height,header.hash()
+            );
+        } else {
             check_not_bad_block(db, header.hash())?;
             check_blockchain_version(constants, header.version)?;
             check_height(header, prev_header)?;


### PR DESCRIPTION
Description
---
Fixes monero seed validation to always check seeds. 

Motivation and Context
---
Block 26320 is  bad block breaking consensus. It has a RandomX VM key of 91ef83186cefaa646dc4c6e950e68e4debab52b4f4a9b7f465891e91fe5f6ce4 
this key was used between height 2729 and 843, which is about what you would expect from the monero consensus but was reused only once on block 26320 with hash 999785e3bb6a43189c7236de7c9720df27d56f6b9724cd22f5115a097d3f770e. 

This PR will bypass the hash checking so that we can accept this block in the chain, but only this block. It also fixes the validation bug that caused the RandomX Seeds to not be added the database for tracking. 

How Has This Been Tested?
---
Manual sync

Breaking Changes
---

- [ ] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [X] Other - Please specify

Wil whitelist a bad block to be accepted into the chain, and clear out all bad blocks listed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined block processing and chain reorganization by removing legacy consensus parameters.

- **New Features**
  - Enhanced the handling and logging of specialized proof-of-work data in block headers.
  - Updated the migration process to support a new database schema version and to clear legacy records.
  - Introduced a mechanism to allow specific block headers to bypass certain validation checks, ensuring smoother validation flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->