### PR TITLE
chore: add better block sync logs

### DIFF
--- a/base_layer/core/src/base_node/sync/block_sync/synchronizer.rs
+++ b/base_layer/core/src/base_node/sync/block_sync/synchronizer.rs
@@ -434,7 +434,7 @@ impl<'a, B: BlockchainBackend + 'static> BlockSynchronizer<'a, B> {
         if metadata_after_sync.accumulated_difficulty() < sync_peer.claimed_chain_metadata().accumulated_difficulty() {
             return Err(BlockSyncError::PeerDidNotSupplyAllClaimedBlocks(format!(
                 "Their claim - height: {}, accumulated difficulty: {}. Our status after block sync - height: {}, \
-                accumulated difficulty: {}",
+                 accumulated difficulty: {}",
                 sync_peer.claimed_chain_metadata().best_block_height(),
                 sync_peer.claimed_chain_metadata().accumulated_difficulty(),
                 metadata_after_sync.best_block_height(),

--- a/base_layer/core/src/base_node/sync/block_sync/synchronizer.rs
+++ b/base_layer/core/src/base_node/sync/block_sync/synchronizer.rs
@@ -193,7 +193,6 @@ impl<'a, B: BlockchainBackend + 'static> BlockSynchronizer<'a, B> {
                             BanPeriod::Short => self.config.short_ban_period,
                             BanPeriod::Long => self.config.ban_period,
                         };
-                        warn!(target: LOG_TARGET, "{}", err);
                         self.peer_ban_manager
                             .ban_peer_if_required(&node_id, reason.reason, duration)
                             .await;
@@ -228,7 +227,7 @@ impl<'a, B: BlockchainBackend + 'static> BlockSynchronizer<'a, B> {
         mut client: rpc::BaseNodeSyncRpcClient,
         max_latency: Duration,
     ) -> Result<(), BlockSyncError> {
-        info!(target: LOG_TARGET, "Starting block sync from peer {}", sync_peer);
+        info!(target: LOG_TARGET, "Starting block sync from peer {}", sync_peer.node_id());
 
         let tip_header = self.db.fetch_last_header().await?;
         let local_metadata = self.db.get_chain_metadata().await?;
@@ -415,13 +414,31 @@ impl<'a, B: BlockchainBackend + 'static> BlockSynchronizer<'a, B> {
             current_block = Some(block);
             last_sync_timer = Instant::now();
         }
+        debug!(
+            "Sync peer claim at start  - height: {}, accumulated difficulty: {}",
+            sync_peer.claimed_chain_metadata().best_block_height(),
+            sync_peer.claimed_chain_metadata().accumulated_difficulty(),
+        );
+        debug!(
+            "Our best header at start  - height: {}, accumulated difficulty: {}",
+            best_height,
+            chain_header.accumulated_data().total_accumulated_difficulty,
+        );
+        let metadata_after_sync = self.db.get_chain_metadata().await?;
+        debug!(
+            "Our best block after sync - height: {}, accumulated difficulty: {}",
+            metadata_after_sync.best_block_height(),
+            metadata_after_sync.accumulated_difficulty(),
+        );
 
-        let accumulated_difficulty = self.db.get_chain_metadata().await?.accumulated_difficulty();
-        if accumulated_difficulty < sync_peer.claimed_chain_metadata().accumulated_difficulty() {
+        if metadata_after_sync.accumulated_difficulty() < sync_peer.claimed_chain_metadata().accumulated_difficulty() {
             return Err(BlockSyncError::PeerDidNotSupplyAllClaimedBlocks(format!(
-                "Their claimed difficulty: {}, our local difficulty after block sync: {}",
+                "Their claim - height: {}, accumulated difficulty: {}. Our status after block sync - height: {}, \
+                accumulated difficulty: {}",
+                sync_peer.claimed_chain_metadata().best_block_height(),
                 sync_peer.claimed_chain_metadata().accumulated_difficulty(),
-                accumulated_difficulty
+                metadata_after_sync.best_block_height(),
+                metadata_after_sync.accumulated_difficulty(),
             )));
         }
 


### PR DESCRIPTION
Description
---
Add better block sync logs.

Motivation and Context
---
A recent block sync exercise had a base node ban two sync peers consecutively due to incomplete sync. This is most likely due to bad connections as the sync request included the correct target block and the sync peers had no incentive to lie about their claims.

An extract of the analyzed logs is shown below. It is evident that block sync stopped unexpectedly in both cases. First sync got up to #13407, second sync got up to #18855, target was #26684.
```
2025-03-07 09:20:03.453515000 [c::bn::block_sync] [,] INFO  Attempting to synchronize blocks with `c7de4e45fcb1e0348c4265bafd` latency: 630.89ms
2025-03-07 09:20:03.453950000 [c::bn::block_sync] [,] DEBUG Starting block sync from peer `Node ID: c7de4e45fcb1e0348c4265bafd, Chain metadata: Best block height: 26683
Total accumulated difficulty: 8248590412229667520579601722187
Best block hash: 6aee80de353621a95d0a274f74a8e57bb198c5c8a190f55eb77eac8b81b947b6
Pruning horizon: 0
Pruned height: 0
, Latency: 630.89ms`. Current best block is #0 `6df34a9e6e40e0e28222aa36a668e17a1b8f5d62beca70dea96ac729104fa402`. Syncing to #26684 (76fb190f785590ff648142caf4164e8bfca09bce462538eac04097f808f7c9ab).

2025-03-07 09:20:04.073221000 [c::bn::block_sync] [,] DEBUG Block body #1 added in 1ms, Tot_acc_diff 1200001, Monero 1200001, SHA3 1, latency: 613.65ms
2025-03-07 09:20:04.076061000 [c::bn::block_sync] [,] DEBUG Block body #2 added in 788µs, Tot_acc_diff 2400001, Monero 2400001, SHA3 1, latency: 15.50µs
...

2025-03-07 09:59:38.405050000 [c::bn::block_sync] [,] DEBUG Block body #13406 added in 12ms, Tot_acc_diff 1960030690703271773824148497680, Monero 7306362232410, SHA3 268263552826446248, latency: 402.83ms
2025-03-07 09:59:38.407936000 [c::bn::block_sync] [,] DEBUG Block body #13407 added in 676µs, Tot_acc_diff 1960254114926614506927081120840, Monero 7306362232410, SHA3 268294132233302324, latency: 170.63µs

2025-03-07 10:03:43.313867000 [c::bn::block_sync] [,] WARN  Peer did not supply all the blocks they claimed they had: Their claimed difficulty: 8248590412229667520579601722187, our local difficulty after block sync: 1960254114926614506927081120840
2025-03-07 10:03:43.313961000 [c::bn::sync] [,] WARN  Banned sync peer c7de4e45fcb1e0348c4265bafd for 240s because Peer did not supply all the blocks they claimed they had: Their claimed difficulty: 8248590412229667520579601722187, our local difficulty after block sync: 1960254114926614506927081120840

2025-03-07 10:03:43.947646000 [c::bn::block_sync] [,] INFO  Attempting to synchronize blocks with `c5ce514135481b94a0cfb14d72` latency: 629.96ms
2025-03-07 10:03:43.948803000 [c::bn::block_sync] [,] DEBUG Starting block sync from peer `Node ID: c5ce514135481b94a0cfb14d72, Chain metadata: Best block height: 26683
Total accumulated difficulty: 8248590412229667520579601722187
Best block hash: 6aee80de353621a95d0a274f74a8e57bb198c5c8a190f55eb77eac8b81b947b6
Pruning horizon: 0
Pruned height: 0
, Latency: 629.96ms`. Current best block is #13407 `dccfc4d5cc9fae9423a0fb966f7725fe3ded45c7973f289a895cb6ae0dfd80c5`. Syncing to #26684 (76fb190f785590ff648142caf4164e8bfca09bce462538eac04097f808f7c9ab).

2025-03-07 10:03:45.103645000 [c::bn::block_sync] [,] DEBUG Block body #13408 added in 16ms, Tot_acc_diff 1960481137456826481087037798170, Monero 7306362232410, SHA3 268325204129683937, latency: 1.08s
2025-03-07 10:03:45.107539000 [c::bn::block_sync] [,] DEBUG Block body #13409 added in 1ms, Tot_acc_diff 1960819803803303150898337400935, Monero 7307624381255, SHA3 268325204129683937, latency: 56.46µs
...
2025-03-07 10:31:25.853831000 [c::bn::block_sync] [,] DEBUG Block body #18854 added in 2ms, Tot_acc_diff 3581665702084093881105552499983, Monero 9920928839499, SHA3 361021206787021517, latency: 52.58µs
2025-03-07 10:31:26.199761000 [c::bn::block_sync] [,] DEBUG Block body #18855 added in 16ms, Tot_acc_diff 3582077375219053365490120732845, Monero 9920928839499, SHA3 361062702209639655, latency: 291.76ms

2025-03-07 10:31:26.377554000 [c::bn::block_sync] [,] WARN  Peer did not supply all the blocks they claimed they had: Their claimed difficulty: 8248590412229667520579601722187, our local difficulty after block sync: 3582077375219053365490120732845
2025-03-07 10:31:26.377820000 [c::bn::sync] [,] WARN  Banned sync peer c5ce514135481b94a0cfb14d72 for 240s because Peer did not supply all the blocks they claimed they had: Their claimed difficulty: 8248590412229667520579601722187, our local difficulty after block sync: 3582077375219053365490120732845
```

How Has This Been Tested?
---
Not tested -> logs analyzed

What process can a PR reviewer use to test or verify this change?
---
Code review

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

This release introduces improvements in synchronization error handling and diagnostics. When synchronization issues occur, users receive clearer and more detailed feedback, which helps streamline troubleshooting and enhances overall system reliability.

- **Bug Fixes**
  - Improved error messages during data synchronization to provide clear, detailed feedback on discrepancies.
- **Refactor**
  - Enhanced logging within the synchronization process for better insights into progress and issue resolution, including updates to log messages and additional debug information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->