### PR TITLE
chore: handle seed words env var

### DIFF
--- a/applications/minotari_console_wallet/src/cli.rs
+++ b/applications/minotari_console_wallet/src/cli.rs
@@ -61,15 +61,15 @@ pub struct Cli {
     pub recovery: bool,
     /// Supply the optional wallet seed words for recovery on the command line. They should be in one string space
     /// separated. e.g. --seed-words "seed1 seed2 ..."
-    #[clap(long, alias = "seed-words", env = "MINOTARI_WALLET_SEED_WORDS", hide_env_values = true)]
-    pub seed_words: Option<SeedWords>,
-    /// Supply the optional file name to save the wallet seed words into
     #[clap(
         long,
         alias = "seed-words",
         env = "MINOTARI_WALLET_SEED_WORDS",
         hide_env_values = true
     )]
+    pub seed_words: Option<SeedWords>,
+    /// Supply the optional file name to save the wallet seed words into
+    #[clap(long, aliases = &["seed_words_file_name", "seed-words-file"], parse(from_os_str))]
     pub seed_words_file_name: Option<PathBuf>,
     /// Run in non-interactive mode, with no UI.
     #[clap(short, long, alias = "non-interactive")]

--- a/applications/minotari_console_wallet/src/cli.rs
+++ b/applications/minotari_console_wallet/src/cli.rs
@@ -61,7 +61,7 @@ pub struct Cli {
     pub recovery: bool,
     /// Supply the optional wallet seed words for recovery on the command line. They should be in one string space
     /// separated. e.g. --seed-words "seed1 seed2 ..."
-    #[clap(long, alias = "seed-words")]
+    #[clap(long, alias = "seed-words", env = "MINOTARI_WALLET_SEED_WORDS", hide_env_values = true)]
     pub seed_words: Option<SeedWords>,
     /// Supply the optional file name to save the wallet seed words into
     #[clap(long, aliases = &["seed_words_file_name", "seed-words-file"], parse(from_os_str))]

--- a/applications/minotari_console_wallet/src/cli.rs
+++ b/applications/minotari_console_wallet/src/cli.rs
@@ -64,7 +64,12 @@ pub struct Cli {
     #[clap(long, alias = "seed-words", env = "MINOTARI_WALLET_SEED_WORDS", hide_env_values = true)]
     pub seed_words: Option<SeedWords>,
     /// Supply the optional file name to save the wallet seed words into
-    #[clap(long, aliases = &["seed_words_file_name", "seed-words-file"], parse(from_os_str))]
+    #[clap(
+        long,
+        alias = "seed-words",
+        env = "MINOTARI_WALLET_SEED_WORDS",
+        hide_env_values = true
+    )]
     pub seed_words_file_name: Option<PathBuf>,
     /// Run in non-interactive mode, with no UI.
     #[clap(short, long, alias = "non-interactive")]


### PR DESCRIPTION
Description
---
Handle `MINOTARI_WALLET_SEED_WORDS` env var for safety. Previously, seed words could be seen using `ps ax` when running wallet recovery.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enabled configuring seed words via an environment variable (MINOTARI_WALLET_SEED_WORDS), allowing for dynamic configuration.
	- Enhanced security by ensuring that any sensitive values provided via the environment are concealed in help messages and logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->