### PR TITLE
fix: clear bad blocks after last monero seed migration

### DIFF
--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -2900,7 +2900,6 @@ fn run_migrations(db: &LMDBDatabase) -> Result<(), ChainStorageError> {
             info!(target: LOG_TARGET, "added RX vm key 91ef83186cefaa646dc4c6e950e68e4debab52b4f4a9b7f465891e91fe5f6ce4");
         }
         if migrate_from_version == 4 {
-            let txn = db.write_transaction()?;
             info!(target: LOG_TARGET, "Clearing bad blocks list missed in migration v3");
             clear_bad_blocks = true;
         }

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -22,28 +22,20 @@
 use std::{
     cmp::max,
     convert::TryFrom,
-    fmt,
-    fs,
+    fmt, fs,
     fs::File,
     ops::Deref,
     path::Path,
     sync::{
         atomic::{AtomicBool, Ordering},
-        Arc,
-        RwLock,
+        Arc, RwLock,
     },
     time::Instant,
 };
 
 use fs2::FileExt;
 use lmdb_zero::{
-    open,
-    traits::AsLmdbBytes,
-    ConstTransaction,
-    Database,
-    Environment,
-    ReadTransaction,
-    WriteTransaction,
+    open, traits::AsLmdbBytes, ConstTransaction, Database, Environment, ReadTransaction, WriteTransaction,
 };
 use log::*;
 use primitive_types::U256;
@@ -52,13 +44,7 @@ use tari_common_types::{
     chain_metadata::ChainMetadata,
     epoch::VnEpoch,
     types::{
-        BadBlock,
-        BlockHash,
-        CompressedCommitment,
-        CompressedPublicKey,
-        FixedHash,
-        HashOutput,
-        Signature,
+        BadBlock, BlockHash, CompressedCommitment, CompressedPublicKey, FixedHash, HashOutput, Signature,
         UncompressedCommitment,
     },
 };
@@ -72,12 +58,7 @@ use tari_utilities::{
 use super::{cursors::KeyPrefixCursor, lmdb::lmdb_get_prefix_cursor};
 use crate::{
     blocks::{
-        Block,
-        BlockAccumulatedData,
-        BlockHeader,
-        BlockHeaderAccumulatedData,
-        ChainBlock,
-        ChainHeader,
+        Block, BlockAccumulatedData, BlockHeader, BlockHeaderAccumulatedData, ChainBlock, ChainHeader,
         UpdateBlockAccumulatedData,
     },
     chain_storage::{
@@ -86,42 +67,18 @@ use crate::{
         lmdb_db::{
             composite_key::{CompositeKey, InputKey, OutputKey},
             lmdb::{
-                fetch_db_entry_sizes,
-                lmdb_clear,
-                lmdb_delete,
-                lmdb_delete_each_where,
-                lmdb_delete_key_value,
-                lmdb_delete_keys_starting_with,
-                lmdb_exists,
-                lmdb_fetch_matching_after,
-                lmdb_filter_map_values,
-                lmdb_first_after,
-                lmdb_get,
-                lmdb_get_multiple,
-                lmdb_insert,
-                lmdb_insert_dup,
-                lmdb_last,
-                lmdb_len,
+                fetch_db_entry_sizes, lmdb_clear, lmdb_delete, lmdb_delete_each_where, lmdb_delete_key_value,
+                lmdb_delete_keys_starting_with, lmdb_exists, lmdb_fetch_matching_after, lmdb_filter_map_values,
+                lmdb_first_after, lmdb_get, lmdb_get_multiple, lmdb_insert, lmdb_insert_dup, lmdb_last, lmdb_len,
                 lmdb_replace,
             },
             validator_node_store::ValidatorNodeStore,
-            TransactionInputRowData,
-            TransactionInputRowDataRef,
-            TransactionKernelRowData,
-            TransactionOutputRowData,
+            TransactionInputRowData, TransactionInputRowDataRef, TransactionKernelRowData, TransactionOutputRowData,
         },
         stats::DbTotalSizeStats,
         utxo_mined_info::OutputMinedInfo,
-        BlockchainBackend,
-        ChainTipData,
-        DbBasicStats,
-        DbSize,
-        HorizonData,
-        InputMinedInfo,
-        MmrTree,
-        Reorg,
-        TemplateRegistrationEntry,
-        ValidatorNodeEntry,
+        BlockchainBackend, ChainTipData, DbBasicStats, DbSize, HorizonData, InputMinedInfo, MmrTree, Reorg,
+        TemplateRegistrationEntry, ValidatorNodeEntry,
     },
     consensus::{ConsensusConstants, ConsensusManager},
     output_mr_hash_from_smt,
@@ -129,16 +86,10 @@ use crate::{
     transactions::{
         aggregated_body::AggregateBody,
         transaction_components::{
-            OutputType,
-            SpentOutput,
-            TransactionInput,
-            TransactionKernel,
-            TransactionOutput,
-            ValidatorNodeRegistration,
+            OutputType, SpentOutput, TransactionInput, TransactionKernel, TransactionOutput, ValidatorNodeRegistration,
         },
     },
-    OutputSmt,
-    PrunedKernelMmr,
+    OutputSmt, PrunedKernelMmr,
 };
 
 type DatabaseRef = Arc<Database<'static>>;
@@ -1454,8 +1405,8 @@ impl LMDBDatabase {
         let prev_shard_key = store.get_shard_key(
             current_epoch
                 .as_u64()
-                .saturating_sub(constants.validator_node_validity_period_epochs().as_u64()) *
-                constants.epoch_length(),
+                .saturating_sub(constants.validator_node_validity_period_epochs().as_u64())
+                * constants.epoch_length(),
             current_epoch.as_u64() * constants.epoch_length(),
             vn_reg.public_key(),
         )?;
@@ -1887,9 +1838,9 @@ impl BlockchainBackend for LMDBDatabase {
         // attempted; this is more efficient than relying on an error if the LMDB environment map size was reached with
         // the write operation, with cleanup, resize and re-try afterwards.
         let block_operations = txn.operations().iter().filter(|op| {
-            matches!(op, WriteOperation::InsertOrphanBlock { .. }) ||
-                matches!(op, WriteOperation::InsertTipBlockBody { .. }) ||
-                matches!(op, WriteOperation::InsertChainOrphanBlock { .. })
+            matches!(op, WriteOperation::InsertOrphanBlock { .. })
+                || matches!(op, WriteOperation::InsertTipBlockBody { .. })
+                || matches!(op, WriteOperation::InsertChainOrphanBlock { .. })
         });
         let count = block_operations.count();
         if count > 0 {
@@ -2926,21 +2877,18 @@ fn run_migrations(db: &LMDBDatabase) -> Result<(), ChainStorageError> {
     );
     drop(txn);
 
+    let mut clear_bad_blocks = false;
     for migrate_from_version in last_migrated_version..=MIGRATION_VERSION {
         // Add migrations here
         if migrate_from_version == 1 {
             let txn = db.write_transaction()?;
             info!(target: LOG_TARGET, "Clearing bad blocks list due to median timestamp bug in nextnet");
-            let rows_affected = lmdb_clear(&txn, &db.bad_blocks)?;
-            txn.commit()?;
-            info!(target: LOG_TARGET, "Removed {} rows from bad blocks", rows_affected);
+            clear_bad_blocks = true;
         }
         if migrate_from_version == 2 {
             let txn = db.write_transaction()?;
             info!(target: LOG_TARGET, "Clearing bad blocks list due to bypass validation of monero seed ");
-            let rows_affected = lmdb_clear(&txn, &db.bad_blocks)?;
-            txn.commit()?;
-            info!(target: LOG_TARGET, "Removed {} rows from bad blocks", rows_affected);
+            clear_bad_blocks = true;
         }
         if migrate_from_version == 3 {
             let txn = db.write_transaction()?;
@@ -2951,7 +2899,25 @@ fn run_migrations(db: &LMDBDatabase) -> Result<(), ChainStorageError> {
             txn.commit()?;
             info!(target: LOG_TARGET, "added RX vm key 91ef83186cefaa646dc4c6e950e68e4debab52b4f4a9b7f465891e91fe5f6ce4");
         }
+        if migrate_from_version == 4 {
+            let txn = db.write_transaction()?;
+            info!(target: LOG_TARGET, "Clearing bad blocks list missed in migration v3");
+            clear_bad_blocks = true;
+        }
     }
+
+    // NOTE: If you are adding a new migration, consider deleting bad blocks, even if there are none at the time.
+    // (There might be new ones by the time this is released.)
+    // If you change a validation rule, a bad block will still be banned even if the rule has changed. So in most
+    // cases you will want to clear it.
+    if clear_bad_blocks {
+        let txn = db.write_transaction()?;
+        info!(target: LOG_TARGET, "Clearing bad blocks list");
+        let rows_affected = lmdb_clear(&txn, &db.bad_blocks)?;
+        txn.commit()?;
+        info!(target: LOG_TARGET, "Removed {} rows from bad blocks", rows_affected);
+    }
+
     if last_migrated_version != MIGRATION_VERSION {
         let txn = db.write_transaction()?;
         info!(target: LOG_TARGET, "Migrated database to version {}", MIGRATION_VERSION);


### PR DESCRIPTION
Clear out bad blocks after last migration and add a comment for future migrations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Enhanced internal code organization for improved readability.
  - Updated the data migration process to include a new version and better handling of bad blocks for more reliable performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->