### PR TITLE
chore(ci): binaries build continue-on-error when release

### DIFF
--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -38,6 +38,7 @@ env:
   CARGO: cargo
   CARGO_OPTIONS: "--locked"
   CARGO_CACHE: true
+  RUSTUP_PERMIT_COPY_RENAME: true
 
 concurrency:
   # https://docs.github.com/en/actions/examples/using-concurrency-expressions-and-a-test-matrix
@@ -96,7 +97,7 @@ jobs:
   builds:
     name: Building ${{ matrix.builds.name }} on ${{ matrix.builds.runs-on }}
     needs: matrix-prep
-    continue-on-error: ${{ matrix.builds.best_effort || true }}
+    continue-on-error: ${{ startsWith(github.ref, 'refs/tags/') || matrix.builds.best_effort || false }}
     outputs:
       TARI_NETWORK_DIR: ${{ steps.set-tari-network.outputs.TARI_NETWORK_DIR }}
       TARI_VERSION: ${{ steps.set-tari-vars.outputs.TARI_VERSION }}


### PR DESCRIPTION
Description
continue-on-error when release or set in build matrix, else defaults to false

Motivation and Context
Make release happen no matter build status


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved build reliability with refined error handling in critical release workflows.
  - Optimized build configurations to support smoother file operations during compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->