### PR TITLE
fix:  prune mode validation

### DIFF
--- a/base_layer/core/src/base_node/sync/horizon_state_sync/synchronizer.rs
+++ b/base_layer/core/src/base_node/sync/horizon_state_sync/synchronizer.rs
@@ -59,12 +59,14 @@ use crate::{
         TransactionKernel,
         TransactionOutput,
     },
-    validation::{FinalHorizonStateValidation},
+    validation::{
+        aggregate_body::validate_individual_output,
+        helpers::validate_output_version,
+        FinalHorizonStateValidation,
+    },
     OutputSmt,
     PrunedKernelMmr,
 };
-use crate::validation::aggregate_body::validate_individual_output;
-use crate::validation::helpers::validate_output_version;
 
 const LOG_TARGET: &str = "c::bn::state_machine_service::states::horizon_state_sync";
 

--- a/base_layer/core/src/base_node/sync/horizon_state_sync/synchronizer.rs
+++ b/base_layer/core/src/base_node/sync/horizon_state_sync/synchronizer.rs
@@ -59,10 +59,12 @@ use crate::{
         TransactionKernel,
         TransactionOutput,
     },
-    validation::{helpers, FinalHorizonStateValidation},
+    validation::{FinalHorizonStateValidation},
     OutputSmt,
     PrunedKernelMmr,
 };
+use crate::validation::aggregate_body::validate_individual_output;
+use crate::validation::helpers::validate_output_version;
 
 const LOG_TARGET: &str = "c::bn::state_machine_service::states::horizon_state_sync";
 
@@ -663,7 +665,8 @@ impl<'a, B: BlockchainBackend + 'static> HorizonStateSynchronization<'a, B> {
                             utxo_counter,
                             self.num_outputs,
                         );
-                        helpers::check_tari_script_byte_size(&output.script, constants.max_script_byte_size())?;
+                        validate_output_version(&constants, &output)?;
+                        validate_individual_output(&output, &constants)?;
 
                         batch_verify_range_proofs(&self.prover, &[&output])?;
                         let smt_key = NodeKey::try_from(output.commitment.as_bytes())?;

--- a/base_layer/core/src/transactions/transaction_components/transaction_output.rs
+++ b/base_layer/core/src/transactions/transaction_components/transaction_output.rs
@@ -600,8 +600,6 @@ pub(crate) fn batch_verify_range_proofs(
 
 #[cfg(test)]
 mod test {
-    use tari_crypto::errors::RangeProofError;
-
     use super::{batch_verify_range_proofs, TransactionOutput};
     use crate::transactions::{
         tari_amount::MicroMinotari,

--- a/base_layer/core/src/validation/aggregate_body/aggregate_body_internal_validator.rs
+++ b/base_layer/core/src/validation/aggregate_body/aggregate_body_internal_validator.rs
@@ -149,7 +149,6 @@ pub fn validate_individual_output(
     output: &TransactionOutput,
     consensus_constants: &ConsensusConstants,
 ) -> Result<(), ValidationError> {
-
     check_permitted_output_types(consensus_constants, output)?;
     check_script_size(output, consensus_constants.max_script_byte_size())?;
     check_encrypted_data_byte_size(output, consensus_constants.max_extra_encrypted_data_byte_size())?;

--- a/base_layer/core/src/validation/aggregate_body/aggregate_body_internal_validator.rs
+++ b/base_layer/core/src/validation/aggregate_body/aggregate_body_internal_validator.rs
@@ -117,12 +117,7 @@ impl AggregateBodyInternalConsistencyValidator {
         validate_versions(body, constants)?;
 
         for output in body.outputs() {
-            check_permitted_output_types(constants, output)?;
-            check_script_size(output, constants.max_script_byte_size())?;
-            check_encrypted_data_byte_size(output, constants.max_extra_encrypted_data_byte_size())?;
-            check_covenant_length(&output.covenant, constants.max_covenant_length())?;
-            check_permitted_range_proof_types(constants, output)?;
-            check_validator_node_registration_utxo(constants, output)?;
+            validate_individual_output(output, constants)?;
         }
 
         check_weight(body, height, constants)?;
@@ -139,7 +134,6 @@ impl AggregateBodyInternalConsistencyValidator {
         if !self.bypass_range_proof_verification {
             validate_range_proofs(body, &self.factories.range_proof)?;
         }
-        verify_metadata_signatures(body)?;
 
         let script_offset_g = CompressedPublicKey::from_secret_key(script_offset);
         validate_script_and_script_offset(body, script_offset_g, &self.factories.commitment, prev_header, height)?;
@@ -149,6 +143,22 @@ impl AggregateBodyInternalConsistencyValidator {
 
         Ok(())
     }
+}
+
+pub fn validate_individual_output(
+    output: &TransactionOutput,
+    consensus_constants: &ConsensusConstants,
+) -> Result<(), ValidationError> {
+
+    check_permitted_output_types(consensus_constants, output)?;
+    check_script_size(output, consensus_constants.max_script_byte_size())?;
+    check_encrypted_data_byte_size(output, consensus_constants.max_extra_encrypted_data_byte_size())?;
+    check_covenant_length(&output.covenant, consensus_constants.max_covenant_length())?;
+    check_permitted_range_proof_types(consensus_constants, output)?;
+    check_validator_node_registration_utxo(consensus_constants, output)?;
+    output.verify_metadata_signature()?;
+
+    Ok(())
 }
 
 /// Verify the signatures in all kernels contained in this aggregate body. Clients must provide an offset that
@@ -273,14 +283,6 @@ fn validate_range_proofs(
     trace!(target: LOG_TARGET, "Checking range proofs");
     let outputs = body.outputs().iter().collect::<Vec<_>>();
     batch_verify_range_proofs(range_proof_service, &outputs)?;
-    Ok(())
-}
-
-fn verify_metadata_signatures(body: &AggregateBody) -> Result<(), ValidationError> {
-    trace!(target: LOG_TARGET, "Checking sender signatures");
-    for o in body.outputs() {
-        o.verify_metadata_signature()?;
-    }
     Ok(())
 }
 

--- a/base_layer/core/src/validation/aggregate_body/mod.rs
+++ b/base_layer/core/src/validation/aggregate_body/mod.rs
@@ -21,6 +21,6 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 mod aggregate_body_internal_validator;
-pub use aggregate_body_internal_validator::{AggregateBodyInternalConsistencyValidator, validate_individual_output};
+pub use aggregate_body_internal_validator::{validate_individual_output, AggregateBodyInternalConsistencyValidator};
 mod aggregate_body_chain_validator;
 pub use aggregate_body_chain_validator::AggregateBodyChainLinkedValidator;

--- a/base_layer/core/src/validation/aggregate_body/mod.rs
+++ b/base_layer/core/src/validation/aggregate_body/mod.rs
@@ -21,6 +21,6 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 mod aggregate_body_internal_validator;
-pub use aggregate_body_internal_validator::AggregateBodyInternalConsistencyValidator;
+pub use aggregate_body_internal_validator::{AggregateBodyInternalConsistencyValidator, validate_individual_output};
 mod aggregate_body_chain_validator;
 pub use aggregate_body_chain_validator::AggregateBodyChainLinkedValidator;


### PR DESCRIPTION
Description
---
Adds output validation to the prune mode sync. 
Prune mode does not currently validate outputs, which they should do as they receive them. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined internal validation and synchronization processes for improved clarity and maintainability.
  - Reorganized exposure of internal components to ensure consistent access across modules.
- **Chore**
  - Removed redundant elements and applied minor formatting updates to enhance code efficiency and overall quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->