### PR TITLE
fix:  libtor cli option

### DIFF
--- a/applications/minotari_node/src/cli.rs
+++ b/applications/minotari_node/src/cli.rs
@@ -61,7 +61,7 @@ pub struct Cli {
     #[clap(long)]
     pub disable_splash_screen: bool,
     /// Path to the libtor data directory
-    #[clap(short, long, parse(from_os_str))]
+    #[clap(short = 'z', long, parse(from_os_str))]
     pub libtor_data_dir: Option<PathBuf>,
 }
 

--- a/base_layer/core/src/base_node/chain_metadata_service/service.rs
+++ b/base_layer/core/src/base_node/chain_metadata_service/service.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{convert::TryFrom, sync::Arc};
+use std::{convert::TryFrom, sync::Arc, thread::sleep};
 
 use log::*;
 use prost::Message;
@@ -77,6 +77,9 @@ impl ChainMetadataService {
         let mut liveness_event_stream = self.liveness.get_event_stream();
         let mut block_event_stream = self.base_node.get_block_event_stream();
 
+        // just wait till the base node can create the chain metadata. This is to suppresses a warning about it not
+        // being found. If this passes before the base node has created the chain metadata, the warning will be logged.
+        sleep(std::time::Duration::from_secs(2));
         log_if_error!(
             target: LOG_TARGET,
             "Error when updating liveness chain metadata: '{}'",


### PR DESCRIPTION
Description
---
fix libtor data dir override, which clashed with the log dir short option `-l`
Suppress warning about chain metadata not existing on startup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated a command-line option to now use a distinct short flag, enhancing clarity in the CLI interface.

- **Bug Fixes**
  - Introduced a brief delay before error messaging for chain metadata, reducing premature warnings during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->