### PR TITLE
fix!: median timestamp check

### DIFF
--- a/base_layer/core/src/base_node/sync/header_sync/validator.rs
+++ b/base_layer/core/src/base_node/sync/header_sync/validator.rs
@@ -326,11 +326,13 @@ mod test {
             let (mut validator, _, tip) = setup_with_headers(1).await;
             validator.initialize_state(tip.hash()).await.unwrap();
             assert!(validator.valid_headers().is_empty());
-            let next = BlockHeader::from_previous(tip.header());
+            let mut next = BlockHeader::from_previous(tip.header());
+            next.timestamp = tip.header().timestamp.checked_add(EpochTime::from(1)).unwrap();
             validator.validate(next).await.unwrap();
             assert_eq!(validator.valid_headers().len(), 1);
             let tip = validator.valid_headers().last().cloned().unwrap();
-            let next = BlockHeader::from_previous(tip.header());
+            let mut next = BlockHeader::from_previous(tip.header());
+            next.timestamp = tip.header().timestamp.checked_add(EpochTime::from(1)).unwrap();
             validator.validate(next).await.unwrap();
             assert_eq!(validator.valid_headers().len(), 2);
         }

--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -940,8 +940,8 @@ where B: BlockchainBackend
         let median_timestamp = calc_median_timestamp(&timestamps)?;
         // If someone advanced the median timestamp such that the local time is less than the median timestamp, we need
         // to increase the timestamp to be greater than the median timestamp otherwise the block wont be accepted by
-        // nodes
-        if median_timestamp > header.timestamp {
+        // nodes, they cannot increase it by more than the FTL so there is an upperbound here
+        while median_timestamp >= header.timestamp {
             header.timestamp = median_timestamp
                 .checked_add(EpochTime::from(1))
                 .ok_or(ChainStorageError::UnexpectedResult("Timestamp overflowed".to_string()))?;

--- a/base_layer/core/src/validation/helpers.rs
+++ b/base_layer/core/src/validation/helpers.rs
@@ -106,17 +106,17 @@ pub fn check_header_timestamp_greater_than_median(
     }
 
     let median_timestamp = calc_median_timestamp(timestamps)?;
-    if block_header.timestamp < median_timestamp {
+    if block_header.timestamp <= median_timestamp {
         warn!(
             target: LOG_TARGET,
-            "Block header timestamp {} is less than median timestamp: {} for block:{}",
+            "Block header timestamp {} is less or equal than median timestamp: {} for block:{}",
             block_header.timestamp,
             median_timestamp,
             block_header.hash().to_hex()
         );
         return Err(ValidationError::BlockHeaderError(
             BlockHeaderValidationError::InvalidTimestamp(format!(
-                "The timestamp `{}` was less than the median timestamp `{}`",
+                "The timestamp `{}` was less or equal than the median timestamp `{}`",
                 block_header.timestamp, median_timestamp
             )),
         ));


### PR DESCRIPTION
Description
---
Fixes the median timestamp check to correctly check the that the timestamp needs to be > than he median

Motivation and Context
---
If the check is only >=, then it allows an attacked to keep the chain at the median timestamp, thus descreasing the minining difficulty 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved block header timestamp validations to ensure headers are appropriately incremented compared to network medians.
	- Enhanced the logic to iteratively adjust timestamps until they meet stricter criteria.
	- Updated warning and error messages to provide clearer feedback when timestamp conditions are not met.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->