### PR TITLE
feat: add num connections to network state

### DIFF
--- a/applications/minotari_app_grpc/proto/base_node.proto
+++ b/applications/minotari_app_grpc/proto/base_node.proto
@@ -540,5 +540,8 @@ message GetNetworkStateResponse {
     uint64 sha3x_estimated_hash_rate = 6;
     // estimate randomx hash rate
     uint64 randomx_estimated_hash_rate = 7;
+    // number of connections
+    uint64 num_connections = 8;
+
 }
 

--- a/applications/minotari_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/minotari_node/src/grpc/base_node_grpc_server.rs
@@ -456,6 +456,13 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
         let status_watch = self.state_machine_handle.get_status_info_watch();
         let state: tari_rpc::BaseNodeState = (&status_watch.borrow().state_info).into();
 
+        let mut connectivity = self.comms.connectivity();
+        let peer_manager = self.comms.peer_manager();
+        let connected_peers = connectivity
+            .get_active_connections()
+            .await
+            .map_err(|err| obscure_error_if_true(report_error_flag, Status::internal(err.to_string())))?;
+
         let response = tari_rpc::GetNetworkStateResponse {
             metadata: Some(metadata.into()),
             initial_sync_achieved: status_watch.borrow().bootstrapped,
@@ -464,6 +471,7 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
             reward,
             sha3x_estimated_hash_rate,
             randomx_estimated_hash_rate,
+            num_connections: connected_peers.len() as u64,
         };
         trace!(target: LOG_TARGET, "Sending GetNetworkState response to client");
         Ok(Response::new(response))

--- a/applications/minotari_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/minotari_node/src/grpc/base_node_grpc_server.rs
@@ -457,7 +457,6 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
         let state: tari_rpc::BaseNodeState = (&status_watch.borrow().state_info).into();
 
         let mut connectivity = self.comms.connectivity();
-        let peer_manager = self.comms.peer_manager();
         let connected_peers = connectivity
             .get_active_connections()
             .await


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The network state now reports the current number of active peer connections, giving users improved visibility into connectivity.
  - A new field for the number of connections has been added to the network state response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->