### PR TITLE
chore: force pre mine file path

### DIFF
--- a/applications/minotari_console_wallet/src/automation/commands.rs
+++ b/applications/minotari_console_wallet/src/automation/commands.rs
@@ -1037,6 +1037,7 @@ pub async fn command_runner(
                     break;
                 }
                 let mut input_file_path = args.input_file.clone();
+
                 while input_file_path.is_none() {
                     eprintln!("\nError: Missing input file path!\n");
                     input_file_path = Some(
@@ -1047,7 +1048,10 @@ pub async fn command_runner(
                     );
                 }
 
-                let file_path = PathBuf::from(input_file_path.unwrap());
+                let file_path = match input_file_path {
+                    Some(path) => PathBuf::from(path),
+                    None => PathBuf::from("step_1_session_info.json"),
+                };
 
                 // Read session info
                 let session_info = read_session_info::<PreMineSpendStep1SessionInfo>(file_path.clone())?;


### PR DESCRIPTION
Description
---
remove the ability to ask for the file path in premine party start, and use a static file name/path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced input file handling to automatically use a default file when no file path is provided, improving system stability and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->