### PR TITLE
fix: startup arg

### DIFF
--- a/applications/minotari_console_wallet/src/cli.rs
+++ b/applications/minotari_console_wallet/src/cli.rs
@@ -100,7 +100,7 @@ pub struct Cli {
     #[clap(long)]
     pub spend_key: Option<String>,
     /// Path to the libtor data directory
-    #[clap(short, long, parse(from_os_str))]
+    #[clap(short = 'z', long, parse(from_os_str))]
     pub libtor_data_dir: Option<PathBuf>,
 }
 


### PR DESCRIPTION
Description
---
Fixes the startup arg of libtor data dir. This clashes with the log dir by default. This changes libtor to rather use `-z`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved the command-line interface by introducing a dedicated shortcut for specifying the data directory. The option now requires using an explicit “-z” flag, enhancing clarity and consistency when launching the tool. Users will enjoy the same underlying functionality with a more intuitive flag for accessing the data directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->