### PR TITLE
fix: excess sig order in the tx tab

### DIFF
--- a/applications/minotari_console_wallet/src/ui/components/transactions_tab.rs
+++ b/applications/minotari_console_wallet/src/ui/components/transactions_tab.rs
@@ -335,7 +335,7 @@ impl TransactionsTab {
         let constraints = [Constraint::Length(1); 13];
         let label_layout = Layout::default().constraints(constraints).split(columns[0]);
 
-        let excess_sig = Span::styled("Excess sig(nonce, sig):", Style::default().fg(Color::Magenta));
+        let excess_sig = Span::styled("Excess sig(sig, nonce):", Style::default().fg(Color::Magenta));
         let source_address = Span::styled("Source Address:", Style::default().fg(Color::Magenta));
         let destination_address = Span::styled("Destination address:", Style::default().fg(Color::Magenta));
         let direction = Span::styled("Direction:", Style::default().fg(Color::Magenta));


### PR DESCRIPTION
Description
---
In the minotari_console_wallet, the excess signature was displayed in the incorrect order, with the nonce appearing as the signature and the signature appearing as the nonce

* from _applications/minotari_console_wallet/src/ui/state/app_state.rs_ (https://github.com/tari-project/tari/blob/61eda049cdd8a437cd673897816e8d4628a6fa31/applications/minotari_console_wallet/src/ui/state/app_state.rs#L1195)
```
        let excess_signature = format!(
            "{},{}",
            tx.transaction
                .first_kernel_excess_sig()
                .map(|s| s.get_signature().to_hex())
                .unwrap_or_default(),
            tx.transaction
                .first_kernel_excess_sig()
                .map(|s| s.get_compressed_public_nonce().to_hex())
                .unwrap_or_default()
        );
```

* from _applications/minotari_console_wallet/src/ui/components/transactions_tab_ (https://github.com/tari-project/tari/blob/development/applications/minotari_console_wallet/src/ui/components/transactions_tab.rs#L338)
```
let excess_sig = Span::styled("Excess sig(nonce, sig):", Style::default().fg(Color::Magenta));
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated a label in the transactions view to display parameters in a clearer, more logical order (“Excess sig(sig, nonce):”), enhancing the overall readability of transaction details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->