### PR TITLE
feat: remove memory allocation for max_size_vec

### DIFF
--- a/infrastructure/max_size/src/vec.rs
+++ b/infrastructure/max_size/src/vec.rs
@@ -47,7 +47,7 @@ impl<T, const MAX_SIZE: usize> MaxSizeVec<T, MAX_SIZE> {
     /// Creates a new `MaxSizeVec` with a capacity of `MAX_SIZE`.
     pub fn new() -> Self {
         Self {
-            vec: Vec::with_capacity(MAX_SIZE),
+            vec: Vec::new(),
             _marker: PhantomData,
         }
     }
@@ -179,7 +179,7 @@ impl<T, const MAX_SIZE: usize> Iterator for MaxSizeVec<T, MAX_SIZE> {
 impl<T, const MAX_SIZE: usize> FromIterator<T> for MaxSizeVec<T, MAX_SIZE> {
     /// Creates a `MaxSizeVec` from an iterator.
     fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
-        let mut vec = Vec::with_capacity(MAX_SIZE);
+        let mut vec = Vec::new();
         for item in iter {
             if vec.len() >= MAX_SIZE {
                 break;


### PR DESCRIPTION
Description
---
Removed memory allocation for MaxSizeVec

Motivation and Context
---
Inefficient memory use when loading many blocks - see below memory usage of empty covenants
- `tari_core::covenants::covenant::Covenant::from_bytes`
- `tari_script::script::TariScript::from_bytes`
```
▼ PP 1/1 (2 children) {
    Total:     41,432,753,986 bytes (100%, 69,571,652.29/s) in 108,158,114 blocks (100%, 181,613.29/s), avg size 383.08 bytes, avg lifetime 120,597,513.57 µs (20.25% of program duration)
    At t-gmax: 22,499,253,266 bytes (100%) in 49,275,839 blocks (100%), avg size 456.6 bytes
    At t-end:  282,701 bytes (100%) in 422 blocks (100%), avg size 669.91 bytes
    Allocated at {
      #0: [root]
    }
  }
  ├─▼ PP 1.1/2 (10 children) {
  │     Total:     41,432,474,135 bytes (100%, 69,571,182.38/s) in 108,121,152 blocks (99.97%, 181,551.22/s), avg size 383.2 bytes, avg lifetime 120,638,475.88 µs (20.26% of program duration)
  │     At t-gmax: 22,499,250,494 bytes (100%) in 49,275,795 blocks (100%), avg size 456.6 bytes
  │     At t-end:  279,339 bytes (98.81%) in 375 blocks (88.86%), avg size 744.9 bytes
  │     Allocated at {
  │       #1: 0x7ff6654e0148: <dhat::Alloc as core::alloc::global::GlobalAlloc>::alloc (???:0:0)
  │     }
  │   }
  │   ├─▶ PP 1.1.1/10 (5 children) {
  │   │     Total:     1,150,169,792 bytes (2.78%, 1,931,303.26/s) in 35,942,806 blocks (33.23%, 60,353.23/s), avg size 32 bytes, avg lifetime 144,977,955.4 µs (24.34% of program duration)
  │   │     At t-gmax: 629,866,560 bytes (2.8%) in 19,683,330 blocks (39.95%), avg size 32 bytes
  │   │     At t-end:  0 bytes (0%) in 0 blocks (0%), avg size 0 bytes
  │   │     Allocated at {
  │   │       ^1: 0x7ff6654e0148: <dhat::Alloc as core::alloc::global::GlobalAlloc>::alloc (???:0:0)
  │   │       #2: 0x7ff66563b67f: <&mut bincode::de::Deserializer<R,O> as serde::de::Deserializer>::deserialize_bytes (???:0:0)
  │   │     }
  │   │   }
  │   ├─▶ PP 1.1.2/10 (2 children) {
  │   │     Total:     1,438,330,674 bytes (3.47%, 2,415,167.52/s) in 9,113,613 blocks (8.43%, 15,303.09/s), avg size 157.82 bytes, avg lifetime 142,637,345.13 µs (23.95% of program duration)
  │   │     At t-gmax: 785,612,379 bytes (3.49%) in 4,908,440 blocks (9.96%), avg size 160.05 bytes
  │   │     At t-end:  1,651 bytes (0.58%) in 14 blocks (3.32%), avg size 117.93 bytes
  │   │     Allocated at {
  │   │       ^1: 0x7ff6654e0148: <dhat::Alloc as core::alloc::global::GlobalAlloc>::alloc (???:0:0)
  │   │       #2: 0x7ff6654e8117: alloc::raw_vec::finish_grow (???:0:0)
  │   │     }
  │   │   }
  │   ├── PP 1.1.3/10 {
  │   │     Total:     18,365,476,864 bytes (44.33%, 30,838,321.08/s) in 8,967,518 blocks (8.29%, 15,057.77/s), avg size 2,048 bytes, avg lifetime 144,960,289.92 µs (24.34% of program duration)
  │   │     Max:       10,052,458,496 bytes in 4,908,427 blocks, avg size 2,048 bytes
  │   │     At t-gmax: 10,052,458,496 bytes (44.68%) in 4,908,427 blocks (9.96%), avg size 2,048 bytes
  │   │     At t-end:  0 bytes (0%) in 0 blocks (0%), avg size 0 bytes
  │   │     Allocated at {
  │   │       ^1: 0x7ff6654e0148: <dhat::Alloc as core::alloc::global::GlobalAlloc>::alloc (???:0:0)
  │   │       #2: 0x7ff6659959a6: tari_core::covenants::covenant::Covenant::from_bytes (???:0:0)
  │   │       #3: 0x7ff665639f18: <tari_core::covenants::serde::CovenantVisitor as serde::de::Visitor>::visit_bytes (???:0:0)
  │   │       #4: 0x7ff66563b986: <&mut bincode::de::Deserializer<R,O> as serde::de::Deserializer>::deserialize_bytes (???:0:0)
  │   │       #5: 0x7ff665637075: serde::de::Visitor::visit_i128 (???:0:0)
  │   │       #6: 0x7ff66563e2bf: <&mut bincode::de::Deserializer<R,O> as serde::de::Deserializer>::deserialize_struct (???:0:0)
  │   │       #7: 0x7ff66563aae0: <&mut bincode::de::Deserializer<R,O> as serde::de::Deserializer>::deserialize_seq (???:0:0)
  │   │       #8: 0x7ff6656375c5: serde::de::Visitor::visit_i128 (???:0:0)
  │   │       #9: 0x7ff66563f149: <&mut bincode::de::Deserializer<R,O> as serde::de::Deserializer>::deserialize_struct (???:0:0)
  │   │       #10: 0x7ff665644452: <sha_p2pool::sharechain::lmdb_block_storage::LmdbBlockStorage as sha_p2pool::sharechain::lmdb_block_storage::BlockCache>::all_blocks (???:0:0)
  │   │     }
  │   │   }
  │   ├── PP 1.1.4/10 {
  │   │     Total:     2,080,464,176 bytes (5.02%, 3,493,403.56/s) in 8,967,518 blocks (8.29%, 15,057.77/s), avg size 232 bytes, avg lifetime 144,960,301.43 µs (24.34% of program duration)
  │   │     Max:       1,138,755,064 bytes in 4,908,427 blocks, avg size 232 bytes
  │   │     At t-gmax: 1,138,755,064 bytes (5.06%) in 4,908,427 blocks (9.96%), avg size 232 bytes
  │   │     At t-end:  0 bytes (0%) in 0 blocks (0%), avg size 0 bytes
  │   │     Allocated at {
  │   │       ^1: 0x7ff6654e0148: <dhat::Alloc as core::alloc::global::GlobalAlloc>::alloc (???:0:0)
  │   │       #2: 0x7ff6659bff4d: tari_script::op_codes::Opcode::parse (???:0:0)
  │   │       #3: 0x7ff6659be753: tari_script::script::TariScript::from_bytes (???:0:0)
  │   │       #4: 0x7ff66552d7b9: <tari_script::serde::<impl serde::de::Deserialize for tari_script::script::TariScript>::deserialize::ScriptVisitor as serde::de::Visitor>::visit_bytes (???:0:0)
  │   │       #5: 0x7ff66563bac6: <&mut bincode::de::Deserializer<R,O> as serde::de::Deserializer>::deserialize_bytes (???:0:0)
  │   │       #6: 0x7ff66563e0df: <&mut bincode::de::Deserializer<R,O> as serde::de::Deserializer>::deserialize_struct (???:0:0)
  │   │       #7: 0x7ff66563aae0: <&mut bincode::de::Deserializer<R,O> as serde::de::Deserializer>::deserialize_seq (???:0:0)
  │   │       #8: 0x7ff6656375c5: serde::de::Visitor::visit_i128 (???:0:0)
  │   │       #9: 0x7ff66563f149: <&mut bincode::de::Deserializer<R,O> as serde::de::Deserializer>::deserialize_struct (???:0:0)
  │   │       #10: 0x7ff665644452: <sha_p2pool::sharechain::lmdb_block_storage::LmdbBlockStorage as sha_p2pool::sharechain::lmdb_block_storage::BlockCache>::all_blocks (???:0:0)
  │   │     }
  │   │   }
```

How Has This Been Tested?
---
Not tested

What process can a PR reviewer use to test or verify this change?
---
Code review

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved dynamic memory handling to optimize resource utilization as new data is added.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->