### PR TITLE
feat: add display info to yamux

### DIFF
--- a/comms/core/src/connection_manager/common.rs
+++ b/comms/core/src/connection_manager/common.rs
@@ -22,10 +22,12 @@
 
 use std::{
     convert::{TryFrom, TryInto},
+    fmt::{Display, Formatter},
     time::Duration,
 };
 
 use log::*;
+use tari_utilities::hex::Hex;
 use tokio::io::{AsyncRead, AsyncWrite};
 
 use crate::{
@@ -47,6 +49,26 @@ const LOG_TARGET: &str = "comms::connection_manager::common";
 pub struct ValidatedPeerIdentityExchange {
     pub claim: PeerIdentityClaim,
     pub metadata: PeerIdentityMetadata,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PeerConnectionInfo {
+    pub public_key: Option<CommsPublicKey>,
+    pub features: Option<PeerFeatures>,
+    pub user_agent: Option<String>,
+}
+
+impl Display for PeerConnectionInfo {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "PeerConnectionInfo(public_key: {}, node_id: {}, features: {}, user_agent: {})",
+            self.public_key.clone().unwrap_or_default().to_hex(),
+            NodeId::from_public_key(&self.public_key.clone().unwrap_or_default()),
+            self.features.unwrap_or_default(),
+            self.user_agent.clone().unwrap_or_default()
+        )
+    }
 }
 
 impl ValidatedPeerIdentityExchange {

--- a/comms/core/src/connection_manager/common.rs
+++ b/comms/core/src/connection_manager/common.rs
@@ -51,11 +51,28 @@ pub struct ValidatedPeerIdentityExchange {
     pub metadata: PeerIdentityMetadata,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+/// Contains information about a peer connection that can be displayed for debugging purposes.
+#[derive(Clone, Default, Debug, Eq, PartialEq)]
 pub struct PeerConnectionInfo {
-    pub public_key: Option<CommsPublicKey>,
-    pub features: Option<PeerFeatures>,
-    pub user_agent: Option<String>,
+    /// The public key of the connected peer, if available
+    public_key: Option<CommsPublicKey>,
+    /// The node id of the connected peer, if available
+    node_if: Option<NodeId>,
+    /// The features supported by the peer, if available
+    features: Option<PeerFeatures>,
+    /// The user agent string of the peer, if available
+    user_agent: Option<String>,
+}
+
+impl PeerConnectionInfo {
+    pub fn new(public_key: Option<CommsPublicKey>, features: Option<PeerFeatures>, user_agent: Option<String>) -> Self {
+        Self {
+            public_key: public_key.clone(),
+            node_if: public_key.as_ref().map(NodeId::from_public_key),
+            features,
+            user_agent,
+        }
+    }
 }
 
 impl Display for PeerConnectionInfo {
@@ -64,7 +81,7 @@ impl Display for PeerConnectionInfo {
             f,
             "PeerConnectionInfo(public_key: {}, node_id: {}, features: {}, user_agent: {})",
             self.public_key.as_ref().unwrap_or(&CommsPublicKey::default()).to_hex(),
-            NodeId::from_public_key(self.public_key.as_ref().unwrap_or(&CommsPublicKey::default())),
+            self.node_if.as_ref().unwrap_or(&NodeId::default()),
             self.features.unwrap_or_default(),
             self.user_agent.as_deref().unwrap_or_default()
         )

--- a/comms/core/src/connection_manager/common.rs
+++ b/comms/core/src/connection_manager/common.rs
@@ -63,10 +63,10 @@ impl Display for PeerConnectionInfo {
         write!(
             f,
             "PeerConnectionInfo(public_key: {}, node_id: {}, features: {}, user_agent: {})",
-            self.public_key.clone().unwrap_or_default().to_hex(),
-            NodeId::from_public_key(&self.public_key.clone().unwrap_or_default()),
+            self.public_key.as_ref().unwrap_or(&CommsPublicKey::default()).to_hex(),
+            NodeId::from_public_key(self.public_key.as_ref().unwrap_or(&CommsPublicKey::default())),
             self.features.unwrap_or_default(),
-            self.user_agent.clone().unwrap_or_default()
+            self.user_agent.as_deref().unwrap_or_default()
         )
     }
 }

--- a/comms/core/src/connection_manager/dialer.rs
+++ b/comms/core/src/connection_manager/dialer.rs
@@ -467,11 +467,11 @@ where
             return Err(ConnectionManagerError::DialCancelled);
         }
 
-        let peer_connection_info = PeerConnectionInfo {
-            public_key: Some(authenticated_public_key.clone()),
-            features: Some(peer_identity.claim.features),
-            user_agent: Some(peer_identity.metadata.user_agent.clone()),
-        };
+        let peer_connection_info = PeerConnectionInfo::new(
+            Some(authenticated_public_key.clone()),
+            Some(peer_identity.claim.features),
+            Some(peer_identity.metadata.user_agent.clone()),
+        );
         let muxer = Yamux::upgrade_connection(socket, CONNECTION_DIRECTION, peer_connection_info)
             .map_err(|err| ConnectionManagerError::YamuxUpgradeFailure(err.to_string()))?;
 

--- a/comms/core/src/connection_manager/dialer.rs
+++ b/comms/core/src/connection_manager/dialer.rs
@@ -41,7 +41,12 @@ use tokio::{
 use tokio_stream::StreamExt;
 use tracing::{span, Instrument, Level};
 
-use super::{direction::ConnectionDirection, error::ConnectionManagerError, peer_connection::PeerConnection};
+use super::{
+    direction::ConnectionDirection,
+    error::ConnectionManagerError,
+    peer_connection::PeerConnection,
+    PeerConnectionInfo,
+};
 #[cfg(feature = "metrics")]
 use crate::connection_manager::metrics;
 use crate::{
@@ -462,7 +467,12 @@ where
             return Err(ConnectionManagerError::DialCancelled);
         }
 
-        let muxer = Yamux::upgrade_connection(socket, CONNECTION_DIRECTION)
+        let peer_connection_info = PeerConnectionInfo {
+            public_key: Some(authenticated_public_key.clone()),
+            features: Some(peer_identity.claim.features),
+            user_agent: Some(peer_identity.metadata.user_agent.clone()),
+        };
+        let muxer = Yamux::upgrade_connection(socket, CONNECTION_DIRECTION, peer_connection_info)
             .map_err(|err| ConnectionManagerError::YamuxUpgradeFailure(err.to_string()))?;
 
         if cancel_signal.is_terminated() {

--- a/comms/core/src/connection_manager/listener.rs
+++ b/comms/core/src/connection_manager/listener.rs
@@ -49,6 +49,7 @@ use super::{
     peer_connection::{self, PeerConnection},
     ConnectionManagerConfig,
     ConnectionManagerEvent,
+    PeerConnectionInfo,
 };
 #[cfg(feature = "metrics")]
 use crate::connection_manager::metrics;
@@ -411,12 +412,17 @@ where
 
         let peer = common::create_or_update_peer_from_validated_peer_identity(
             known_peer,
-            authenticated_public_key,
+            authenticated_public_key.clone(),
             &valid_peer_identity,
             latency,
         );
 
-        let muxer = Yamux::upgrade_connection(noise_socket, CONNECTION_DIRECTION)
+        let peer_connection_info = PeerConnectionInfo {
+            public_key: Some(authenticated_public_key.clone()),
+            features: Some(valid_peer_identity.clone().claim.features),
+            user_agent: Some(valid_peer_identity.clone().metadata.user_agent.clone()),
+        };
+        let muxer = Yamux::upgrade_connection(noise_socket, CONNECTION_DIRECTION, peer_connection_info)
             .map_err(|err| ConnectionManagerError::YamuxUpgradeFailure(err.to_string()))?;
 
         let conn = peer_connection::create(

--- a/comms/core/src/connection_manager/listener.rs
+++ b/comms/core/src/connection_manager/listener.rs
@@ -419,8 +419,8 @@ where
 
         let peer_connection_info = PeerConnectionInfo {
             public_key: Some(authenticated_public_key.clone()),
-            features: Some(valid_peer_identity.clone().claim.features),
-            user_agent: Some(valid_peer_identity.clone().metadata.user_agent.clone()),
+            features: Some(valid_peer_identity.claim.features),
+            user_agent: Some(valid_peer_identity.metadata.user_agent.clone()),
         };
         let muxer = Yamux::upgrade_connection(noise_socket, CONNECTION_DIRECTION, peer_connection_info)
             .map_err(|err| ConnectionManagerError::YamuxUpgradeFailure(err.to_string()))?;

--- a/comms/core/src/connection_manager/listener.rs
+++ b/comms/core/src/connection_manager/listener.rs
@@ -417,11 +417,11 @@ where
             latency,
         );
 
-        let peer_connection_info = PeerConnectionInfo {
-            public_key: Some(authenticated_public_key.clone()),
-            features: Some(valid_peer_identity.claim.features),
-            user_agent: Some(valid_peer_identity.metadata.user_agent.clone()),
-        };
+        let peer_connection_info = PeerConnectionInfo::new(
+            Some(authenticated_public_key.clone()),
+            Some(valid_peer_identity.claim.features),
+            Some(valid_peer_identity.metadata.user_agent.clone()),
+        );
         let muxer = Yamux::upgrade_connection(noise_socket, CONNECTION_DIRECTION, peer_connection_info)
             .map_err(|err| ConnectionManagerError::YamuxUpgradeFailure(err.to_string()))?;
 

--- a/comms/core/src/connection_manager/mod.rs
+++ b/comms/core/src/connection_manager/mod.rs
@@ -34,6 +34,7 @@ mod listener;
 mod metrics;
 
 mod common;
+pub use common::PeerConnectionInfo;
 
 mod direction;
 pub use direction::ConnectionDirection;

--- a/comms/core/src/multiplexing/yamux.rs
+++ b/comms/core/src/multiplexing/yamux.rs
@@ -30,7 +30,7 @@ use tokio::{
 use tokio_util::compat::{Compat, FuturesAsyncReadCompatExt, TokioAsyncReadCompatExt};
 use tracing::{debug, error, warn};
 // Reexport
-use yamux::Mode;
+use yamux::{ConnectionError, FrameDecodeError, Mode};
 
 use crate::{
     connection_manager::{ConnectionDirection, PeerConnectionInfo},
@@ -312,13 +312,43 @@ where TSocket: futures::AsyncRead + futures::AsyncWrite + Unpin + Send + Sync + 
                             break;
                         }
                         Some(Err(err)) => {
-                            error!(
-                                target: LOG_TARGET,
-                                "{} Incoming peer ({}) substream task received an error because '{}'",
-                                self.counter.get(),
-                                self.peer_connection_info,
-                                err
-                            );
+                            match err {
+                                ConnectionError::Io(ref io_err) if
+                                    io_err.kind() == io::ErrorKind::ConnectionReset ||
+                                    io_err.kind() == io::ErrorKind::ConnectionAborted =>
+                                {
+                                    debug!(
+                                        target: LOG_TARGET,
+                                        "{} Incoming peer ({}) substream closed by the remote host '{}'",
+                                        self.counter.get(),
+                                        self.peer_connection_info,
+                                        err
+                                    );
+                                },
+                                ConnectionError::Decode(FrameDecodeError::Io(ref io_err)) if
+                                    io_err.kind() == io::ErrorKind::ConnectionReset ||
+                                    io_err.kind() == io::ErrorKind::ConnectionAborted =>
+                                {
+                                    debug!(
+                                        target: LOG_TARGET,
+                                        "{} Incoming peer ({}) substream closed by the remote host '{}'",
+                                        self.counter.get(),
+                                        self.peer_connection_info,
+                                        err
+                                    );
+                                },
+                                _ => {
+                                    error!(
+                                        target: LOG_TARGET,
+                                        "{} Incoming peer ({}) substream task received an error because '{}'",
+                                        self.counter.get(),
+                                        self.peer_connection_info,
+                                        err
+                                    );
+                                },
+                            }
+                            // Ignore: we already log the error variant in Self::close
+                            let _ignore = Self::close(&mut connection).await;
                             break;
                         },
                     }
@@ -362,8 +392,18 @@ where TSocket: futures::AsyncRead + futures::AsyncWrite + Unpin + Send + Sync + 
 
     async fn close(connection: &mut yamux::Connection<TSocket>) -> yamux::Result<()> {
         if let Err(err) = poll_fn(|cx| connection.poll_close(cx)).await {
-            error!(target: LOG_TARGET, "Error while closing yamux connection: {}", err);
-            return Err(err);
+            match err {
+                ConnectionError::Io(ref io_err)
+                    if io_err.kind() == io::ErrorKind::ConnectionReset ||
+                        io_err.kind() == io::ErrorKind::ConnectionAborted =>
+                {
+                    debug!(target: LOG_TARGET, "Substream closed by the remote host '{}'", err);
+                },
+                _ => {
+                    error!(target: LOG_TARGET, "Error while closing yamux connection: {}", err);
+                    return Err(err);
+                },
+            }
         }
         debug!(target: LOG_TARGET, "Yamux connection has closed");
         Ok(())

--- a/comms/core/src/multiplexing/yamux.rs
+++ b/comms/core/src/multiplexing/yamux.rs
@@ -392,12 +392,7 @@ mod test {
         let (dialer, listener) = MemorySocket::new_pair();
         let msg = b"The Way of Kings";
 
-        let peer_connection_info = PeerConnectionInfo {
-            public_key: None,
-            features: None,
-            user_agent: None,
-        };
-        let dialer = Yamux::upgrade_connection(dialer, ConnectionDirection::Outbound, peer_connection_info.clone())?;
+        let dialer = Yamux::upgrade_connection(dialer, ConnectionDirection::Outbound, PeerConnectionInfo::default())?;
         let mut dialer_control = dialer.get_yamux_control();
 
         tokio::spawn(async move {
@@ -407,7 +402,8 @@ mod test {
             substream.shutdown().await.unwrap();
         });
 
-        let mut listener = Yamux::upgrade_connection(listener, ConnectionDirection::Inbound, peer_connection_info)?;
+        let mut listener =
+            Yamux::upgrade_connection(listener, ConnectionDirection::Inbound, PeerConnectionInfo::default())?;
         let mut substream = listener
             .incoming
             .next()
@@ -426,13 +422,8 @@ mod test {
         const NUM_SUBSTREAMS: usize = 10;
         let (dialer, listener) = MemorySocket::new_pair();
 
-        let peer_connection_info = PeerConnectionInfo {
-            public_key: None,
-            features: None,
-            user_agent: None,
-        };
         let dialer =
-            Yamux::upgrade_connection(dialer, ConnectionDirection::Outbound, peer_connection_info.clone()).unwrap();
+            Yamux::upgrade_connection(dialer, ConnectionDirection::Outbound, PeerConnectionInfo::default()).unwrap();
         let mut dialer_control = dialer.get_yamux_control();
 
         let substreams_out = tokio::spawn(async move {
@@ -447,7 +438,7 @@ mod test {
         });
 
         let mut listener =
-            Yamux::upgrade_connection(listener, ConnectionDirection::Inbound, peer_connection_info).unwrap();
+            Yamux::upgrade_connection(listener, ConnectionDirection::Inbound, PeerConnectionInfo::default()).unwrap();
 
         let substreams_in = collect_stream!(
             &mut listener.incoming,
@@ -470,12 +461,7 @@ mod test {
         let (dialer, listener) = MemorySocket::new_pair();
         let msg = b"Words of Radiance";
 
-        let peer_connection_info = PeerConnectionInfo {
-            public_key: None,
-            features: None,
-            user_agent: None,
-        };
-        let dialer = Yamux::upgrade_connection(dialer, ConnectionDirection::Outbound, peer_connection_info.clone())?;
+        let dialer = Yamux::upgrade_connection(dialer, ConnectionDirection::Outbound, PeerConnectionInfo::default())?;
         let mut dialer_control = dialer.get_yamux_control();
 
         tokio::spawn(async move {
@@ -489,7 +475,8 @@ mod test {
             assert_eq!(buf, b"");
         });
 
-        let mut listener = Yamux::upgrade_connection(listener, ConnectionDirection::Inbound, peer_connection_info)?;
+        let mut listener =
+            Yamux::upgrade_connection(listener, ConnectionDirection::Inbound, PeerConnectionInfo::default())?;
         let mut substream = listener.incoming.next().await.unwrap();
 
         let mut buf = vec![0; msg.len()];
@@ -515,23 +502,18 @@ mod test {
         let barrier = Arc::new(Barrier::new(2));
         let b = barrier.clone();
 
-        let peer_connection_info = PeerConnectionInfo {
-            public_key: None,
-            features: None,
-            user_agent: None,
-        };
-        let peer_connection_info_clone = peer_connection_info.clone();
         tokio::spawn(async move {
             // Drop immediately
             let incoming =
-                Yamux::upgrade_connection(listener, ConnectionDirection::Inbound, peer_connection_info_clone)
+                Yamux::upgrade_connection(listener, ConnectionDirection::Inbound, PeerConnectionInfo::default())
                     .unwrap()
                     .into_incoming();
             drop(incoming);
             b.wait().await;
         });
 
-        let dialer = Yamux::upgrade_connection(dialer, ConnectionDirection::Outbound, peer_connection_info).unwrap();
+        let dialer =
+            Yamux::upgrade_connection(dialer, ConnectionDirection::Outbound, PeerConnectionInfo::default()).unwrap();
         let mut dialer_control = dialer.get_yamux_control();
         let mut substream = dialer_control.open_stream().await.unwrap();
         barrier.wait().await;
@@ -551,12 +533,7 @@ mod test {
 
         let (dialer, listener) = MemorySocket::new_pair();
 
-        let peer_connection_info = PeerConnectionInfo {
-            public_key: None,
-            features: None,
-            user_agent: None,
-        };
-        let dialer = Yamux::upgrade_connection(dialer, ConnectionDirection::Outbound, peer_connection_info.clone())?;
+        let dialer = Yamux::upgrade_connection(dialer, ConnectionDirection::Outbound, PeerConnectionInfo::default())?;
         let substream_counter = dialer.substream_counter();
         let mut dialer_control = dialer.get_yamux_control();
 
@@ -576,7 +553,8 @@ mod test {
             assert_eq!(buf, vec![0xAAu8; MSG_LEN]);
         });
 
-        let mut listener = Yamux::upgrade_connection(listener, ConnectionDirection::Inbound, peer_connection_info)?;
+        let mut listener =
+            Yamux::upgrade_connection(listener, ConnectionDirection::Inbound, PeerConnectionInfo::default())?;
         assert_eq!(listener.substream_count(), 0);
         let mut substream = listener.incoming.next().await.unwrap();
         assert_eq!(listener.substream_count(), 1);

--- a/comms/core/src/multiplexing/yamux.rs
+++ b/comms/core/src/multiplexing/yamux.rs
@@ -33,7 +33,7 @@ use tracing::{debug, error, warn};
 use yamux::Mode;
 
 use crate::{
-    connection_manager::ConnectionDirection,
+    connection_manager::{ConnectionDirection, PeerConnectionInfo},
     multiplexing::YamuxControlError,
     stream_id,
     stream_id::StreamId,
@@ -50,8 +50,14 @@ pub struct Yamux {
 
 impl Yamux {
     /// Upgrade the underlying socket to use yamux
-    pub fn upgrade_connection<TSocket>(socket: TSocket, direction: ConnectionDirection) -> io::Result<Self>
-    where TSocket: AsyncRead + AsyncWrite + Send + Sync + Unpin + 'static {
+    pub fn upgrade_connection<TSocket>(
+        socket: TSocket,
+        direction: ConnectionDirection,
+        peer_connection_info: PeerConnectionInfo,
+    ) -> io::Result<Self>
+    where
+        TSocket: AsyncRead + AsyncWrite + Send + Sync + Unpin + 'static,
+    {
         let mode = match direction {
             ConnectionDirection::Inbound => Mode::Server,
             ConnectionDirection::Outbound => Mode::Client,
@@ -61,7 +67,8 @@ impl Yamux {
 
         let substream_counter = AtomicRefCounter::new();
         let connection = yamux::Connection::new(socket.compat(), config, mode);
-        let (control, incoming) = Self::spawn_incoming_stream_worker(connection, substream_counter.clone());
+        let (control, incoming) =
+            Self::spawn_incoming_stream_worker(connection, substream_counter.clone(), peer_connection_info);
 
         Ok(Self {
             control,
@@ -75,13 +82,14 @@ impl Yamux {
     fn spawn_incoming_stream_worker<TSocket>(
         connection: yamux::Connection<TSocket>,
         counter: AtomicRefCounter,
+        peer_connection_info: PeerConnectionInfo,
     ) -> (Control, IncomingSubstreams)
     where
         TSocket: futures::AsyncRead + futures::AsyncWrite + Unpin + Send + Sync + 'static,
     {
         let (incoming_tx, incoming_rx) = mpsc::channel(10);
         let (request_tx, request_rx) = mpsc::channel(1);
-        let incoming = YamuxWorker::new(incoming_tx, request_rx, counter.clone());
+        let incoming = YamuxWorker::new(incoming_tx, request_rx, counter.clone(), peer_connection_info);
         let control = Control::new(request_tx);
         tokio::spawn(incoming.run(connection));
         (control, IncomingSubstreams::new(incoming_rx, counter))
@@ -234,6 +242,7 @@ struct YamuxWorker<TSocket> {
     request_rx: mpsc::Receiver<YamuxRequest>,
     counter: AtomicRefCounter,
     _phantom: PhantomData<TSocket>,
+    peer_connection_info: PeerConnectionInfo,
 }
 
 impl<TSocket> YamuxWorker<TSocket>
@@ -243,12 +252,14 @@ where TSocket: futures::AsyncRead + futures::AsyncWrite + Unpin + Send + Sync + 
         incoming_substreams: mpsc::Sender<yamux::Stream>,
         request_rx: mpsc::Receiver<YamuxRequest>,
         counter: AtomicRefCounter,
+        peer_connection_info: PeerConnectionInfo,
     ) -> Self {
         Self {
             incoming_substreams,
             request_rx,
             counter,
             _phantom: PhantomData,
+            peer_connection_info,
         }
     }
 
@@ -260,9 +271,10 @@ where TSocket: futures::AsyncRead + futures::AsyncWrite + Unpin + Send + Sync + 
                 _ = self.incoming_substreams.closed() => {
                     debug!(
                         target: LOG_TARGET,
-                        "{} Incoming peer substream task is stopping because the internal stream sender channel was \
+                        "{} Incoming peer ({}) substream task is stopping because the internal stream sender channel was \
                          closed",
-                        self.counter.get()
+                        self.counter.get(),
+                        self.peer_connection_info,
                     );
                     // Ignore: we already log the error variant in Self::close
                     let _ignore = Self::close(&mut connection).await;
@@ -271,7 +283,7 @@ where TSocket: futures::AsyncRead + futures::AsyncWrite + Unpin + Send + Sync + 
 
                 Some(request) = self.request_rx.recv() => {
                     if let Err(err) = self.handle_request(&mut connection, request).await {
-                        error!(target: LOG_TARGET, "Error handling request: {err}");
+                        error!(target: LOG_TARGET, "Error handling request from {}: {err}", self.peer_connection_info);
                         break;
                     }
                 },
@@ -282,8 +294,10 @@ where TSocket: futures::AsyncRead + futures::AsyncWrite + Unpin + Send + Sync + 
                             if self.incoming_substreams.send(stream).await.is_err() {
                                 debug!(
                                     target: LOG_TARGET,
-                                    "{} Incoming peer substream task is stopping because the internal stream sender channel was closed",
-                                    self.counter.get()
+                                    "{} Incoming peer ({}) substream task is stopping because the internal stream \
+                                    sender channel was closed",
+                                    self.counter.get(),
+                                    self.peer_connection_info,
                                 );
                                 break;
                             }
@@ -291,16 +305,18 @@ where TSocket: futures::AsyncRead + futures::AsyncWrite + Unpin + Send + Sync + 
                         None =>{
                             debug!(
                                 target: LOG_TARGET,
-                                "{} Incoming peer substream ended.",
-                                self.counter.get()
+                                "{} Incoming peer ({}) substream ended.",
+                                self.counter.get(),
+                                self.peer_connection_info,
                             );
                             break;
                         }
                         Some(Err(err)) => {
                             error!(
                                 target: LOG_TARGET,
-                                "{} Incoming peer substream task received an error because '{}'",
+                                "{} Incoming peer ({}) substream task received an error because '{}'",
                                 self.counter.get(),
+                                self.peer_connection_info,
                                 err
                             );
                             break;
@@ -365,14 +381,23 @@ mod test {
     };
     use tokio_stream::StreamExt;
 
-    use crate::{connection_manager::ConnectionDirection, memsocket::MemorySocket, multiplexing::yamux::Yamux};
+    use crate::{
+        connection_manager::{ConnectionDirection, PeerConnectionInfo},
+        memsocket::MemorySocket,
+        multiplexing::yamux::Yamux,
+    };
 
     #[tokio::test]
     async fn open_substream() -> io::Result<()> {
         let (dialer, listener) = MemorySocket::new_pair();
         let msg = b"The Way of Kings";
 
-        let dialer = Yamux::upgrade_connection(dialer, ConnectionDirection::Outbound)?;
+        let peer_connection_info = PeerConnectionInfo {
+            public_key: None,
+            features: None,
+            user_agent: None,
+        };
+        let dialer = Yamux::upgrade_connection(dialer, ConnectionDirection::Outbound, peer_connection_info.clone())?;
         let mut dialer_control = dialer.get_yamux_control();
 
         tokio::spawn(async move {
@@ -382,7 +407,7 @@ mod test {
             substream.shutdown().await.unwrap();
         });
 
-        let mut listener = Yamux::upgrade_connection(listener, ConnectionDirection::Inbound)?;
+        let mut listener = Yamux::upgrade_connection(listener, ConnectionDirection::Inbound, peer_connection_info)?;
         let mut substream = listener
             .incoming
             .next()
@@ -401,7 +426,13 @@ mod test {
         const NUM_SUBSTREAMS: usize = 10;
         let (dialer, listener) = MemorySocket::new_pair();
 
-        let dialer = Yamux::upgrade_connection(dialer, ConnectionDirection::Outbound).unwrap();
+        let peer_connection_info = PeerConnectionInfo {
+            public_key: None,
+            features: None,
+            user_agent: None,
+        };
+        let dialer =
+            Yamux::upgrade_connection(dialer, ConnectionDirection::Outbound, peer_connection_info.clone()).unwrap();
         let mut dialer_control = dialer.get_yamux_control();
 
         let substreams_out = tokio::spawn(async move {
@@ -415,7 +446,8 @@ mod test {
             substreams
         });
 
-        let mut listener = Yamux::upgrade_connection(listener, ConnectionDirection::Inbound).unwrap();
+        let mut listener =
+            Yamux::upgrade_connection(listener, ConnectionDirection::Inbound, peer_connection_info).unwrap();
 
         let substreams_in = collect_stream!(
             &mut listener.incoming,
@@ -438,7 +470,12 @@ mod test {
         let (dialer, listener) = MemorySocket::new_pair();
         let msg = b"Words of Radiance";
 
-        let dialer = Yamux::upgrade_connection(dialer, ConnectionDirection::Outbound)?;
+        let peer_connection_info = PeerConnectionInfo {
+            public_key: None,
+            features: None,
+            user_agent: None,
+        };
+        let dialer = Yamux::upgrade_connection(dialer, ConnectionDirection::Outbound, peer_connection_info.clone())?;
         let mut dialer_control = dialer.get_yamux_control();
 
         tokio::spawn(async move {
@@ -452,7 +489,7 @@ mod test {
             assert_eq!(buf, b"");
         });
 
-        let mut listener = Yamux::upgrade_connection(listener, ConnectionDirection::Inbound)?;
+        let mut listener = Yamux::upgrade_connection(listener, ConnectionDirection::Inbound, peer_connection_info)?;
         let mut substream = listener.incoming.next().await.unwrap();
 
         let mut buf = vec![0; msg.len()];
@@ -478,16 +515,23 @@ mod test {
         let barrier = Arc::new(Barrier::new(2));
         let b = barrier.clone();
 
+        let peer_connection_info = PeerConnectionInfo {
+            public_key: None,
+            features: None,
+            user_agent: None,
+        };
+        let peer_connection_info_clone = peer_connection_info.clone();
         tokio::spawn(async move {
             // Drop immediately
-            let incoming = Yamux::upgrade_connection(listener, ConnectionDirection::Inbound)
-                .unwrap()
-                .into_incoming();
+            let incoming =
+                Yamux::upgrade_connection(listener, ConnectionDirection::Inbound, peer_connection_info_clone)
+                    .unwrap()
+                    .into_incoming();
             drop(incoming);
             b.wait().await;
         });
 
-        let dialer = Yamux::upgrade_connection(dialer, ConnectionDirection::Outbound).unwrap();
+        let dialer = Yamux::upgrade_connection(dialer, ConnectionDirection::Outbound, peer_connection_info).unwrap();
         let mut dialer_control = dialer.get_yamux_control();
         let mut substream = dialer_control.open_stream().await.unwrap();
         barrier.wait().await;
@@ -507,7 +551,12 @@ mod test {
 
         let (dialer, listener) = MemorySocket::new_pair();
 
-        let dialer = Yamux::upgrade_connection(dialer, ConnectionDirection::Outbound)?;
+        let peer_connection_info = PeerConnectionInfo {
+            public_key: None,
+            features: None,
+            user_agent: None,
+        };
+        let dialer = Yamux::upgrade_connection(dialer, ConnectionDirection::Outbound, peer_connection_info.clone())?;
         let substream_counter = dialer.substream_counter();
         let mut dialer_control = dialer.get_yamux_control();
 
@@ -527,7 +576,7 @@ mod test {
             assert_eq!(buf, vec![0xAAu8; MSG_LEN]);
         });
 
-        let mut listener = Yamux::upgrade_connection(listener, ConnectionDirection::Inbound)?;
+        let mut listener = Yamux::upgrade_connection(listener, ConnectionDirection::Inbound, peer_connection_info)?;
         assert_eq!(listener.substream_count(), 0);
         let mut substream = listener.incoming.next().await.unwrap();
         assert_eq!(listener.substream_count(), 1);

--- a/comms/core/src/pipeline/inbound.rs
+++ b/comms/core/src/pipeline/inbound.rs
@@ -64,7 +64,6 @@ where
             executor,
             service,
             stream,
-
             shutdown_signal,
         }
     }

--- a/comms/core/src/test_utils/transport.rs
+++ b/comms/core/src/test_utils/transport.rs
@@ -23,7 +23,7 @@
 use futures::{future, StreamExt};
 
 use crate::{
-    connection_manager::ConnectionDirection,
+    connection_manager::{ConnectionDirection, PeerConnectionInfo},
     memsocket::MemorySocket,
     multiaddr::Multiaddr,
     multiplexing::Yamux,
@@ -39,7 +39,13 @@ pub async fn build_connected_sockets() -> (Multiaddr, MemorySocket, MemorySocket
 
 pub async fn build_multiplexed_connections() -> (Multiaddr, Yamux, Yamux) {
     let (addr, socket_out, socket_in) = build_connected_sockets().await;
-    let muxer_out = Yamux::upgrade_connection(socket_out, ConnectionDirection::Outbound).unwrap();
-    let muxer_in = Yamux::upgrade_connection(socket_in, ConnectionDirection::Inbound).unwrap();
+    let peer_connection_info = PeerConnectionInfo {
+        public_key: None,
+        features: None,
+        user_agent: None,
+    };
+    let muxer_out =
+        Yamux::upgrade_connection(socket_out, ConnectionDirection::Outbound, peer_connection_info.clone()).unwrap();
+    let muxer_in = Yamux::upgrade_connection(socket_in, ConnectionDirection::Inbound, peer_connection_info).unwrap();
     (addr, muxer_out, muxer_in)
 }

--- a/comms/core/src/test_utils/transport.rs
+++ b/comms/core/src/test_utils/transport.rs
@@ -39,13 +39,9 @@ pub async fn build_connected_sockets() -> (Multiaddr, MemorySocket, MemorySocket
 
 pub async fn build_multiplexed_connections() -> (Multiaddr, Yamux, Yamux) {
     let (addr, socket_out, socket_in) = build_connected_sockets().await;
-    let peer_connection_info = PeerConnectionInfo {
-        public_key: None,
-        features: None,
-        user_agent: None,
-    };
     let muxer_out =
-        Yamux::upgrade_connection(socket_out, ConnectionDirection::Outbound, peer_connection_info.clone()).unwrap();
-    let muxer_in = Yamux::upgrade_connection(socket_in, ConnectionDirection::Inbound, peer_connection_info).unwrap();
+        Yamux::upgrade_connection(socket_out, ConnectionDirection::Outbound, PeerConnectionInfo::default()).unwrap();
+    let muxer_in =
+        Yamux::upgrade_connection(socket_in, ConnectionDirection::Inbound, PeerConnectionInfo::default()).unwrap();
     (addr, muxer_out, muxer_in)
 }


### PR DESCRIPTION
Description
---
Added display info to yamux worker.

Motivation and Context
---
We need more info on yamux stream errors.

How Has This Been Tested?
---
System-level testing

This
```
2025-04-01 16:02:10.204741000 [comms::multiplexing::yamux] DEBUG 0 Incoming peer substream ended.
```
now changed to
```
2025-04-01 16:03:58.580227900 [comms::multiplexing::yamux] DEBUG 2 Incoming peer (PeerConnectionInfo(
public_key: 248e3bcc174d0a8e63a6fe611dcb4ecb814edd84b5503be3edbe5a79475ae760, node_id: 
074b18bfd54e1680907e7da588, features: PeerFeatures(MESSAGE_PROPAGATION | DHT_STORE_FORWARD), 
user_agent: tari/basenode/1.13.0-rc.0)) substream ended.
```

What process can a PR reviewer use to test or verify this change?
---
Code review.

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Enhanced the connection upgrade process by integrating additional connection metadata, including public key, features, and user agent, providing clearer diagnostics and logging for better visibility during peer communication.

- **Refactor**
  - Streamlined connection handling to seamlessly incorporate the enriched metadata throughout the connection upgrade workflow.
  
- **Bug Fixes**
  - Removed the `shutdown_signal` from the `Inbound` struct initialization, refining its shutdown management behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->