### PR TITLE
feat: change network behaviour defaults

### DIFF
--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -5951,7 +5951,7 @@ pub unsafe extern "C" fn comms_config_create(
                         ..Default::default()
                     },
                     network_discovery: NetworkDiscoveryConfig {
-                        min_desired_peers: 16,
+                        min_desired_peers: 12,
                         initial_peer_sync_delay: Some(Duration::from_secs(25)),
                         ..Default::default()
                     },

--- a/common/config/presets/c_base_node_c.toml
+++ b/common/config/presets/c_base_node_c.toml
@@ -228,8 +228,8 @@ database_url = "data/base_node/dht.db"
 #num_neighbouring_nodes = 8
 # Number of random peers to include. Default: 4
 #num_random_nodes = 4
-# Connections above the configured number of neighbouring and random nodes will be removed (default: false)
-#minimize_connections = false
+# Connections above the configured number of neighbouring and random nodes will be removed (default: true)
+#minimize_connections = true
 # Send to this many peers when using the broadcast strategy. Default: 8
 #broadcast_factor = 8
 # Send to this many peers when using the propagate strategy. Default: 4
@@ -289,8 +289,8 @@ database_url = "data/base_node/dht.db"
 # True to enable network discovery, false to disable it. Default: true
 #network_discovery.enabled = true
 # A threshold for the minimum number of peers this node should ideally be aware of. If below this threshold a
-# more "aggressive" strategy is employed. Default: 50
-#network_discovery.min_desired_peers = 50
+# more "aggressive" strategy is employed. Default: 12
+#network_discovery.min_desired_peers = 12
 # The period to wait once the number of rounds given by `idle_after_num_rounds` has completed. Default: 30 mins
 #network_discovery.idle_period = 1_800 # 30 * 60
 #  The minimum number of network discovery rounds to perform before idling (going to sleep). If there are less

--- a/common/config/presets/d_console_wallet.toml
+++ b/common/config/presets/d_console_wallet.toml
@@ -331,8 +331,8 @@ connectivity.minimum_desired_tcpv4_node_ratio = 0.0
 # True to enable network discovery, false to disable it. Default: true
 #network_discovery.enabled = true
 # A threshold for the minimum number of peers this node should ideally be aware of. If below this threshold a
-# more "aggressive" strategy is employed. Default: 50
-network_discovery.min_desired_peers = 16
+# more "aggressive" strategy is employed. Default: 12
+network_discovery.min_desired_peers = 12
 # The period to wait once the number of rounds given by `idle_after_num_rounds` has completed. Default: 30 mins
 #network_discovery.idle_period = 1_800 # 30 * 60
 #  The minimum number of network discovery rounds to perform before idling (going to sleep). If there are less

--- a/comms/dht/src/config.rs
+++ b/comms/dht/src/config.rs
@@ -178,7 +178,7 @@ impl Default for DhtConfig {
             protocol_version: DhtProtocolVersion::latest(),
             num_neighbouring_nodes: 8,
             num_random_nodes: 4,
-            minimize_connections: false,
+            minimize_connections: true,
             propagation_factor: 20,
             broadcast_factor: 8,
             outbound_buffer_size: 20,

--- a/comms/dht/src/network_discovery/config.rs
+++ b/comms/dht/src/network_discovery/config.rs
@@ -63,7 +63,7 @@ impl Default for NetworkDiscoveryConfig {
     fn default() -> Self {
         Self {
             enabled: true,
-            min_desired_peers: 50,
+            min_desired_peers: 12,
             idle_period: Duration::from_secs(30 * 60),
             idle_after_num_rounds: 10,
             on_failure_idle_period: Duration::from_secs(5),


### PR DESCRIPTION
Description
---
Changes the default behaviour of the base nodes to be more restrictive about dialing out to many many peers, and reducing their connections counts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Optimized network connectivity settings by lowering the minimum desired peers from previous higher defaults to 12 across multiple configurations.
	- Enabled automatic minimization of excessive connections for improved resource usage and streamlined performance.
	- These updates provide a more efficient network discovery process, enhancing overall operational consistency and responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->