### PR TITLE
fix: dont poll yamux substream after an error

### DIFF
--- a/comms/core/src/multiplexing/yamux.rs
+++ b/comms/core/src/multiplexing/yamux.rs
@@ -327,7 +327,8 @@ where TSocket: futures::AsyncRead + futures::AsyncWrite + Unpin + Send + Sync + 
                                 },
                                 ConnectionError::Decode(FrameDecodeError::Io(ref io_err)) if
                                     io_err.kind() == io::ErrorKind::ConnectionReset ||
-                                    io_err.kind() == io::ErrorKind::ConnectionAborted =>
+                                    io_err.kind() == io::ErrorKind::ConnectionAborted ||
+                                    io_err.kind() == io::ErrorKind::UnexpectedEof =>
                                 {
                                     debug!(
                                         target: LOG_TARGET,
@@ -347,8 +348,6 @@ where TSocket: futures::AsyncRead + futures::AsyncWrite + Unpin + Send + Sync + 
                                     );
                                 },
                             }
-                            // Ignore: we already log the error variant in Self::close
-                            let _ignore = Self::close(&mut connection).await;
                             break;
                         },
                     }


### PR DESCRIPTION
Description
---
- Yamux should not poll after an error.
- Adds further specialization on error handling when the remote peer disconnects forcefully.

Motivation and Context
---
Tha yamux close was erroneously introduced in a previous PR #6904.

How Has This Been Tested?
---
Not tested - just reverting

What process can a PR reviewer use to test or verify this change?
---
Code review 

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced handling of connection issues to deliver more stable and reliable network interactions.
  - Updated the connection closure process to better manage unexpected interruptions and reduce disruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->