### PR TITLE
fix: randomX seed management

### DIFF
--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -3001,12 +3001,9 @@ fn run_migrations(db: &LMDBDatabase) -> Result<(), ChainStorageError> {
             let vm_key: Vec<u8> = from_hex("91ef83186cefaa646dc4c6e950e68e4debab52b4f4a9b7f465891e91fe5f6ce4")
                 .expect("should be valid hex");
             let _not_used = lmdb_delete(&txn, &db.monero_seed_height_db, &vm_key, "seed heights");
-            let height: u64 = 843;
-            lmdb_replace(&txn, &db.monero_seed_height_db, &vm_key, &height, None)?;
             info!(target: LOG_TARGET, "Clearing bad blocks list due to bypass validation of monero seed ");
             let rows_affected = lmdb_clear(&txn, &db.bad_blocks)?;
             txn.commit()?;
-            info!(target: LOG_TARGET, "added RX vm key 91ef83186cefaa646dc4c6e950e68e4debab52b4f4a9b7f465891e91fe5f6ce4");
             info!(target: LOG_TARGET, "Removed {} rows from bad blocks", rows_affected);
         }
         if migrate_from_version == 5 {

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -218,6 +218,7 @@ pub fn create_lmdb_database<P: AsRef<Path>>(
         .add_database(LMDB_DB_ORPHANS, flags)
         .add_database(LMDB_DB_ORPHAN_HEADER_ACCUMULATED_DATA, flags)
         .add_database(LMDB_DB_MONERO_SEED_HEIGHT, flags)
+        .add_database(LMDB_DB_MONERO_SEED_HEIGHT_INDEX, flags)
         .add_database(LMDB_DB_ORPHAN_CHAIN_TIPS, flags)
         .add_database(LMDB_DB_ORPHAN_PARENT_MAP_INDEX, flags | db::DUPSORT)
         .add_database(LMDB_DB_BAD_BLOCK_LIST, flags)

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -960,6 +960,22 @@ impl LMDBDatabase {
             "kernel_mmr_size_index",
         )?;
 
+        let monero_seed: Option<Vec<u8>> = lmdb_get(txn, &self.monero_seed_height_index_db, &height)?;
+        if let Some(seed) = monero_seed{
+            lmdb_delete(
+                txn,
+                &self.monero_seed_height_index_db,
+                &height,
+                "monero_seed_height_index_db",
+            )?;
+            lmdb_delete(
+                txn,
+                &self.monero_seed_height_db,
+                &seed,
+                "monero_seed_height_db",
+            )?;
+        }
+
         Ok(())
     }
 
@@ -1548,12 +1564,12 @@ impl LMDBDatabase {
                 lmdb_delete(
                     write_txn,
                     &self.monero_seed_height_index_db,
-                    current_height,
+                    &current_height,
                     "monero_seed_height_index_db",
                 )?;
             },
             None => {
-                lmdb_insert(write_txn, &self.monero_seed_height_db, seed, &height, None)?;
+                lmdb_insert(write_txn, &self.monero_seed_height_db, seed, &height, "monero_seed_height_db")?;
             },
         }
         lmdb_insert(
@@ -3004,17 +3020,17 @@ fn run_migrations(db: &LMDBDatabase) -> Result<(), ChainStorageError> {
                 let txn = db.write_transaction()?;
                 let heights: Vec<u64> = lmdb_filter_map_values(&txn, &db.monero_seed_height_db, Some)?;
                 let mut seeds = Vec::new();
-                for height in heights{
-                    let header = lmdb_get::<_, BlockHeader>(txn, &db.headers_db, &height)?.ok_or_else(|| {
+                for height in &heights{
+                    let header = lmdb_get::<_, BlockHeader>(&txn, &db.headers_db, height)?.ok_or_else(|| {
                         ChainStorageError::ValueNotFound {
                             entity: "Header",
                             field: "height",
                             value: height.to_string(),
                         }
                     })?;
-                    let mut pow_bytes = header.pow.pow_data.to_vec();
+                    let pow_bytes = header.pow.pow_data.to_vec();
                     let pow_data = MoneroPowData::deserialize(&mut pow_bytes.as_slice()).unwrap();
-                    let seed = pow_data.randomx_key;
+                    let seed = pow_data.randomx_key.to_vec();
                     seeds.push(seed);
                 }
                 for (i, seed) in seeds.iter().enumerate(){

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -34,7 +34,7 @@ use std::{
     },
     time::Instant,
 };
-
+use borsh::BorshDeserialize;
 use fs2::FileExt;
 use lmdb_zero::{
     open,
@@ -163,6 +163,7 @@ const LMDB_DB_UNIQUE_ID_INDEX: &str = "unique_id_index";
 const LMDB_DB_CONTRACT_ID_INDEX: &str = "contract_index";
 const LMDB_DB_ORPHANS: &str = "orphans";
 const LMDB_DB_MONERO_SEED_HEIGHT: &str = "monero_seed_height";
+const LMDB_DB_MONERO_SEED_HEIGHT_INDEX: &str = "monero_seed_height_index";
 const LMDB_DB_ORPHAN_HEADER_ACCUMULATED_DATA: &str = "orphan_accumulated_data";
 const LMDB_DB_ORPHAN_CHAIN_TIPS: &str = "orphan_chain_tips";
 const LMDB_DB_ORPHAN_PARENT_MAP_INDEX: &str = "orphan_parent_map_index";
@@ -277,6 +278,8 @@ pub struct LMDBDatabase {
     orphans_db: DatabaseRef,
     /// Maps randomx_seed -> height
     monero_seed_height_db: DatabaseRef,
+    /// Maps block height -> randomx_seed
+    monero_seed_height_index_db: DatabaseRef,
     /// Maps block_hash -> BlockHeaderAccumulatedData
     orphan_header_accumulated_data_db: DatabaseRef,
     /// Stores the orphan tip block hashes
@@ -337,6 +340,7 @@ impl LMDBDatabase {
             orphans_db: get_database(store, LMDB_DB_ORPHANS)?,
             orphan_header_accumulated_data_db: get_database(store, LMDB_DB_ORPHAN_HEADER_ACCUMULATED_DATA)?,
             monero_seed_height_db: get_database(store, LMDB_DB_MONERO_SEED_HEIGHT)?,
+            monero_seed_height_index_db: get_database(store, LMDB_DB_MONERO_SEED_HEIGHT_INDEX)?,
             orphan_chain_tips_db: get_database(store, LMDB_DB_ORPHAN_CHAIN_TIPS)?,
             orphan_parent_map_index: get_database(store, LMDB_DB_ORPHAN_PARENT_MAP_INDEX)?,
             bad_blocks: get_database(store, LMDB_DB_BAD_BLOCK_LIST)?,
@@ -555,7 +559,7 @@ impl LMDBDatabase {
         Ok(())
     }
 
-    fn all_dbs(&self) -> [(&'static str, &DatabaseRef); 27] {
+    fn all_dbs(&self) -> [(&'static str, &DatabaseRef); 28] {
         [
             (LMDB_DB_METADATA, &self.metadata_db),
             (LMDB_DB_HEADERS, &self.headers_db),
@@ -582,6 +586,7 @@ impl LMDBDatabase {
                 &self.orphan_header_accumulated_data_db,
             ),
             (LMDB_DB_MONERO_SEED_HEIGHT, &self.monero_seed_height_db),
+            (LMDB_DB_MONERO_SEED_HEIGHT_INDEX, &self.monero_seed_height_index_db),
             (LMDB_DB_ORPHAN_CHAIN_TIPS, &self.orphan_chain_tips_db),
             (LMDB_DB_ORPHAN_PARENT_MAP_INDEX, &self.orphan_parent_map_index),
             (LMDB_DB_BAD_BLOCK_LIST, &self.bad_blocks),
@@ -1534,10 +1539,30 @@ impl LMDBDatabase {
         seed: &[u8],
         height: u64,
     ) -> Result<(), ChainStorageError> {
-        let current_height = lmdb_get(write_txn, &self.monero_seed_height_db, seed)?.unwrap_or(u64::MAX);
-        if height < current_height {
-            lmdb_replace(write_txn, &self.monero_seed_height_db, seed, &height, None)?;
-        };
+        let current_height = lmdb_get(write_txn, &self.monero_seed_height_db, seed)?;
+        match current_height {
+            Some(current_height) => {
+                if height < current_height {
+                    lmdb_replace(write_txn, &self.monero_seed_height_db, seed, &height, None)?;
+                };
+                lmdb_delete(
+                    write_txn,
+                    &self.monero_seed_height_index_db,
+                    current_height,
+                    "monero_seed_height_index_db",
+                )?;
+            },
+            None => {
+                lmdb_insert(write_txn, &self.monero_seed_height_db, seed, &height, None)?;
+            },
+        }
+        lmdb_insert(
+            write_txn,
+            &self.monero_seed_height_db,
+            seed,
+            &height,
+            "monero_seed_height_db",
+        )?;
         Ok(())
     }
 
@@ -2911,7 +2936,7 @@ impl fmt::Display for MetadataValue {
 }
 
 fn run_migrations(db: &LMDBDatabase) -> Result<(), ChainStorageError> {
-    const MIGRATION_VERSION: u64 = 5;
+    const MIGRATION_VERSION: u64 = 6;
     let txn = db.read_transaction()?;
 
     let k = MetadataKey::MigrationVersion;
@@ -2964,6 +2989,45 @@ fn run_migrations(db: &LMDBDatabase) -> Result<(), ChainStorageError> {
             txn.commit()?;
             info!(target: LOG_TARGET, "added RX vm key 91ef83186cefaa646dc4c6e950e68e4debab52b4f4a9b7f465891e91fe5f6ce4");
             info!(target: LOG_TARGET, "Removed {} rows from bad blocks", rows_affected);
+        }
+        if migrate_from_version == 5{
+            // lets clear the list of bad blocks
+            {
+                let txn = db.write_transaction()?;
+                info!(target: LOG_TARGET, "Clearing bad blocks list due reorg issue with morero seed heights");
+                let rows_affected = lmdb_clear(&txn, &db.bad_blocks)?;
+                txn.commit()?;
+                info!(target: LOG_TARGET, "Removed {} rows from bad blocks", rows_affected);
+            }
+            // lets create the monero seed height indexes
+            {
+                let txn = db.write_transaction()?;
+                let heights: Vec<u64> = lmdb_filter_map_values(&txn, &db.monero_seed_height_db, Some)?;
+                let mut seeds = Vec::new();
+                for height in heights{
+                    let header = lmdb_get::<_, BlockHeader>(txn, &db.headers_db, &height)?.ok_or_else(|| {
+                        ChainStorageError::ValueNotFound {
+                            entity: "Header",
+                            field: "height",
+                            value: height.to_string(),
+                        }
+                    })?;
+                    let mut pow_bytes = header.pow.pow_data.to_vec();
+                    let pow_data = MoneroPowData::deserialize(&mut pow_bytes.as_slice()).unwrap();
+                    let seed = pow_data.randomx_key;
+                    seeds.push(seed);
+                }
+                for (i, seed) in seeds.iter().enumerate(){
+                    let txn = db.write_transaction()?;
+                    lmdb_insert(
+                        &txn,
+                        &db.monero_seed_height_index_db,
+                        &heights[i],
+                        &seed,
+                        "monero_seed_height_index_db",
+                    )?;
+                }
+            }
         }
     }
     if last_migrated_version != MIGRATION_VERSION {

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -1557,13 +1557,20 @@ impl LMDBDatabase {
             Some(current_height) => {
                 if height < current_height {
                     lmdb_replace(write_txn, &self.monero_seed_height_db, seed, &height, None)?;
+                    lmdb_delete(
+                        write_txn,
+                        &self.monero_seed_height_index_db,
+                        &current_height,
+                        "monero_seed_height_index_db",
+                    )?;
+                    lmdb_insert(
+                        write_txn,
+                        &self.monero_seed_height_index_db,
+                        &height,
+                        seed,
+                        "monero_seed_height_index_db",
+                    )?;
                 };
-                lmdb_delete(
-                    write_txn,
-                    &self.monero_seed_height_index_db,
-                    &current_height,
-                    "monero_seed_height_index_db",
-                )?;
             },
             None => {
                 lmdb_insert(
@@ -1573,15 +1580,16 @@ impl LMDBDatabase {
                     &height,
                     "monero_seed_height_db",
                 )?;
+                lmdb_insert(
+                    write_txn,
+                    &self.monero_seed_height_index_db,
+                    &height,
+                    seed,
+                    "monero_seed_height_index_db",
+                )?;
             },
         }
-        lmdb_insert(
-            write_txn,
-            &self.monero_seed_height_index_db,
-            &height,
-            seed,
-            "monero_seed_height_index_db",
-        )?;
+
         Ok(())
     }
 

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -2952,7 +2952,7 @@ impl fmt::Display for MetadataValue {
 }
 
 fn run_migrations(db: &LMDBDatabase) -> Result<(), ChainStorageError> {
-    const MIGRATION_VERSION: u64 = 6;
+    const MIGRATION_VERSION: u64 = 5;
     let txn = db.read_transaction()?;
 
     let k = MetadataKey::MigrationVersion;
@@ -3005,45 +3005,6 @@ fn run_migrations(db: &LMDBDatabase) -> Result<(), ChainStorageError> {
             txn.commit()?;
             info!(target: LOG_TARGET, "added RX vm key 91ef83186cefaa646dc4c6e950e68e4debab52b4f4a9b7f465891e91fe5f6ce4");
             info!(target: LOG_TARGET, "Removed {} rows from bad blocks", rows_affected);
-        }
-        if migrate_from_version == 5{
-            // lets clear the list of bad blocks
-            {
-                let txn = db.write_transaction()?;
-                info!(target: LOG_TARGET, "Clearing bad blocks list due reorg issue with morero seed heights");
-                let rows_affected = lmdb_clear(&txn, &db.bad_blocks)?;
-                txn.commit()?;
-                info!(target: LOG_TARGET, "Removed {} rows from bad blocks", rows_affected);
-            }
-            // lets create the monero seed height indexes
-            {
-                let txn = db.write_transaction()?;
-                let heights: Vec<u64> = lmdb_filter_map_values(&txn, &db.monero_seed_height_db, Some)?;
-                let mut seeds = Vec::new();
-                for height in &heights{
-                    let header = lmdb_get::<_, BlockHeader>(&txn, &db.headers_db, height)?.ok_or_else(|| {
-                        ChainStorageError::ValueNotFound {
-                            entity: "Header",
-                            field: "height",
-                            value: height.to_string(),
-                        }
-                    })?;
-                    let pow_bytes = header.pow.pow_data.to_vec();
-                    let pow_data = MoneroPowData::deserialize(&mut pow_bytes.as_slice()).unwrap();
-                    let seed = pow_data.randomx_key.to_vec();
-                    seeds.push(seed);
-                }
-                for (i, seed) in seeds.iter().enumerate(){
-                    let txn = db.write_transaction()?;
-                    lmdb_insert(
-                        &txn,
-                        &db.monero_seed_height_index_db,
-                        &heights[i],
-                        &seed,
-                        "monero_seed_height_index_db",
-                    )?;
-                }
-            }
         }
     }
     if last_migrated_version != MIGRATION_VERSION {

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -34,6 +34,7 @@ use std::{
     },
     time::Instant,
 };
+
 use borsh::BorshDeserialize;
 use fs2::FileExt;
 use lmdb_zero::{
@@ -962,19 +963,14 @@ impl LMDBDatabase {
         )?;
 
         let monero_seed: Option<Vec<u8>> = lmdb_get(txn, &self.monero_seed_height_index_db, &height)?;
-        if let Some(seed) = monero_seed{
+        if let Some(seed) = monero_seed {
             lmdb_delete(
                 txn,
                 &self.monero_seed_height_index_db,
                 &height,
                 "monero_seed_height_index_db",
             )?;
-            lmdb_delete(
-                txn,
-                &self.monero_seed_height_db,
-                &seed,
-                "monero_seed_height_db",
-            )?;
+            lmdb_delete(txn, &self.monero_seed_height_db, &seed, "monero_seed_height_db")?;
         }
 
         Ok(())
@@ -1570,7 +1566,13 @@ impl LMDBDatabase {
                 )?;
             },
             None => {
-                lmdb_insert(write_txn, &self.monero_seed_height_db, seed, &height, "monero_seed_height_db")?;
+                lmdb_insert(
+                    write_txn,
+                    &self.monero_seed_height_db,
+                    seed,
+                    &height,
+                    "monero_seed_height_db",
+                )?;
             },
         }
         lmdb_insert(
@@ -3007,7 +3009,7 @@ fn run_migrations(db: &LMDBDatabase) -> Result<(), ChainStorageError> {
             info!(target: LOG_TARGET, "added RX vm key 91ef83186cefaa646dc4c6e950e68e4debab52b4f4a9b7f465891e91fe5f6ce4");
             info!(target: LOG_TARGET, "Removed {} rows from bad blocks", rows_affected);
         }
-        if migrate_from_version == 5{
+        if migrate_from_version == 5 {
             // lets clear the list of bad blocks
             {
                 let txn = db.write_transaction()?;
@@ -3021,7 +3023,7 @@ fn run_migrations(db: &LMDBDatabase) -> Result<(), ChainStorageError> {
                 let txn = db.write_transaction()?;
                 let heights: Vec<u64> = lmdb_filter_map_values(&txn, &db.monero_seed_height_db, Some)?;
                 let mut seeds = Vec::new();
-                for height in &heights{
+                for height in &heights {
                     let header = lmdb_get::<_, BlockHeader>(&txn, &db.headers_db, height)?.ok_or_else(|| {
                         ChainStorageError::ValueNotFound {
                             entity: "Header",
@@ -3034,7 +3036,7 @@ fn run_migrations(db: &LMDBDatabase) -> Result<(), ChainStorageError> {
                     let seed = pow_data.randomx_key.to_vec();
                     seeds.push(seed);
                 }
-                for (i, seed) in seeds.iter().enumerate(){
+                for (i, seed) in seeds.iter().enumerate() {
                     let txn = db.write_transaction()?;
                     lmdb_insert(
                         &txn,

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -1553,7 +1553,7 @@ impl LMDBDatabase {
     fn insert_monero_seed_height(
         &self,
         write_txn: &WriteTransaction<'_>,
-        seed: &[u8],
+        seed: &Vec<u8>,
         height: u64,
     ) -> Result<(), ChainStorageError> {
         let current_height = lmdb_get(write_txn, &self.monero_seed_height_db, seed)?;
@@ -1575,10 +1575,10 @@ impl LMDBDatabase {
         }
         lmdb_insert(
             write_txn,
-            &self.monero_seed_height_db,
-            seed,
+            &self.monero_seed_height_index_db,
             &height,
-            "monero_seed_height_db",
+            seed,
+            "monero_seed_height_index_db",
         )?;
         Ok(())
     }
@@ -2953,7 +2953,7 @@ impl fmt::Display for MetadataValue {
 }
 
 fn run_migrations(db: &LMDBDatabase) -> Result<(), ChainStorageError> {
-    const MIGRATION_VERSION: u64 = 5;
+    const MIGRATION_VERSION: u64 = 6;
     let txn = db.read_transaction()?;
 
     let k = MetadataKey::MigrationVersion;
@@ -3006,6 +3006,45 @@ fn run_migrations(db: &LMDBDatabase) -> Result<(), ChainStorageError> {
             txn.commit()?;
             info!(target: LOG_TARGET, "added RX vm key 91ef83186cefaa646dc4c6e950e68e4debab52b4f4a9b7f465891e91fe5f6ce4");
             info!(target: LOG_TARGET, "Removed {} rows from bad blocks", rows_affected);
+        }
+        if migrate_from_version == 5{
+            // lets clear the list of bad blocks
+            {
+                let txn = db.write_transaction()?;
+                info!(target: LOG_TARGET, "Clearing bad blocks list due reorg issue with morero seed heights");
+                let rows_affected = lmdb_clear(&txn, &db.bad_blocks)?;
+                txn.commit()?;
+                info!(target: LOG_TARGET, "Removed {} rows from bad blocks", rows_affected);
+            }
+            // lets create the monero seed height indexes
+            {
+                let txn = db.write_transaction()?;
+                let heights: Vec<u64> = lmdb_filter_map_values(&txn, &db.monero_seed_height_db, Some)?;
+                let mut seeds = Vec::new();
+                for height in &heights{
+                    let header = lmdb_get::<_, BlockHeader>(&txn, &db.headers_db, height)?.ok_or_else(|| {
+                        ChainStorageError::ValueNotFound {
+                            entity: "Header",
+                            field: "height",
+                            value: height.to_string(),
+                        }
+                    })?;
+                    let pow_bytes = header.pow.pow_data.to_vec();
+                    let pow_data = MoneroPowData::deserialize(&mut pow_bytes.as_slice()).unwrap();
+                    let seed = pow_data.randomx_key.to_vec();
+                    seeds.push(seed);
+                }
+                for (i, seed) in seeds.iter().enumerate(){
+                    let txn = db.write_transaction()?;
+                    lmdb_insert(
+                        &txn,
+                        &db.monero_seed_height_index_db,
+                        &heights[i],
+                        &seed,
+                        "monero_seed_height_index_db",
+                    )?;
+                }
+            }
         }
     }
     if last_migrated_version != MIGRATION_VERSION {

--- a/base_layer/core/src/proof_of_work/monero_rx/fixed_array.rs
+++ b/base_layer/core/src/proof_of_work/monero_rx/fixed_array.rs
@@ -93,7 +93,7 @@ impl FixedByteArray {
         self.len == 0
     }
 
-    pub fn to_vec(&self)-> Vec<u8> {
+    pub fn to_vec(&self) -> Vec<u8> {
         self.as_slice().to_vec()
     }
 }

--- a/base_layer/core/src/proof_of_work/monero_rx/fixed_array.rs
+++ b/base_layer/core/src/proof_of_work/monero_rx/fixed_array.rs
@@ -92,6 +92,10 @@ impl FixedByteArray {
     pub fn is_empty(&self) -> bool {
         self.len == 0
     }
+
+    pub fn to_vec(&self)-> Vec<u8> {
+        self.elems.to_vec()
+    }
 }
 
 impl Deref for FixedByteArray {

--- a/base_layer/core/src/proof_of_work/monero_rx/fixed_array.rs
+++ b/base_layer/core/src/proof_of_work/monero_rx/fixed_array.rs
@@ -94,7 +94,7 @@ impl FixedByteArray {
     }
 
     pub fn to_vec(&self)-> Vec<u8> {
-        self.elems.to_vec()
+        self.as_slice().to_vec()
     }
 }
 

--- a/base_layer/core/src/validation/block_body/block_body_full_validator.rs
+++ b/base_layer/core/src/validation/block_body/block_body_full_validator.rs
@@ -31,7 +31,7 @@ use crate::{
     blocks::{Block, BlockHeader, BlockHeaderValidationError, ChainBlock},
     chain_storage::{self, BlockchainBackend, ChainStorageError},
     consensus::ConsensusManager,
-    proof_of_work::monero_rx::MoneroPowData,
+    proof_of_work::{monero_rx::MoneroPowData, PowAlgorithm},
     transactions::CryptoFactories,
     validation::{
         aggregate_body::AggregateBodyChainLinkedValidator,
@@ -107,15 +107,17 @@ impl BlockBodyFullValidator {
         rules: &ConsensusManager,
         backend: &B,
     ) -> Result<(), ValidationError> {
-        let monero_data = MoneroPowData::from_header(header, rules)?;
-        let seed_height = backend.fetch_monero_seed_first_seen_height(&monero_data.randomx_key)?;
-        if seed_height != 0 {
-            // Saturating sub: subtraction can underflow in reorgs / rewind-blockchain command
-            let seed_used_height = header.height.saturating_sub(seed_height);
-            if seed_used_height > rules.consensus_constants(header.height).max_randomx_seed_height() {
-                return Err(ValidationError::BlockHeaderError(
-                    BlockHeaderValidationError::OldSeedHash,
-                ));
+        if header.pow.pow_algo == PowAlgorithm::RandomX {
+            let monero_data = MoneroPowData::from_header(header, rules)?;
+            let seed_height = backend.fetch_monero_seed_first_seen_height(&monero_data.randomx_key)?;
+            if seed_height != 0 {
+                // Saturating sub: subtraction can underflow in reorgs / rewind-blockchain command
+                let seed_used_height = header.height.saturating_sub(seed_height);
+                if seed_used_height > rules.consensus_constants(header.height).max_randomx_seed_height() {
+                    return Err(ValidationError::BlockHeaderError(
+                        BlockHeaderValidationError::OldSeedHash,
+                    ));
+                }
             }
         }
         Ok(())

--- a/base_layer/core/src/validation/block_body/block_body_full_validator.rs
+++ b/base_layer/core/src/validation/block_body/block_body_full_validator.rs
@@ -28,9 +28,10 @@ use tari_utilities::hex::Hex;
 
 use super::BlockBodyInternalConsistencyValidator;
 use crate::{
-    blocks::{Block, ChainBlock},
+    blocks::{Block, BlockHeader, BlockHeaderValidationError, ChainBlock},
     chain_storage::{self, BlockchainBackend, ChainStorageError},
     consensus::ConsensusManager,
+    proof_of_work::monero_rx::MoneroPowData,
     transactions::CryptoFactories,
     validation::{
         aggregate_body::AggregateBodyChainLinkedValidator,
@@ -96,7 +97,28 @@ impl BlockBodyFullValidator {
         let mmr_roots = chain_storage::calculate_mmr_roots(backend, &self.consensus_manager, &block, &mut output_smt)?;
         check_mmr_roots(&block.header, &mmr_roots)?;
 
+        BlockBodyFullValidator::check_monero_seed_height(&block.header, &self.consensus_manager, backend)?;
+
         Ok(block)
+    }
+
+    fn check_monero_seed_height<B: BlockchainBackend>(
+        header: &BlockHeader,
+        rules: &ConsensusManager,
+        backend: &B,
+    ) -> Result<(), ValidationError> {
+        let monero_data = MoneroPowData::from_header(header, rules)?;
+        let seed_height = backend.fetch_monero_seed_first_seen_height(&monero_data.randomx_key)?;
+        if seed_height != 0 {
+            // Saturating sub: subtraction can underflow in reorgs / rewind-blockchain command
+            let seed_used_height = header.height.saturating_sub(seed_height);
+            if seed_used_height > rules.consensus_constants(header.height).max_randomx_seed_height() {
+                return Err(ValidationError::BlockHeaderError(
+                    BlockHeaderValidationError::OldSeedHash,
+                ));
+            }
+        }
+        Ok(())
     }
 }
 

--- a/base_layer/core/src/validation/header/header_full_validator.rs
+++ b/base_layer/core/src/validation/header/header_full_validator.rs
@@ -30,7 +30,7 @@ use crate::{
     blocks::{BlockHeader, BlockHeaderValidationError},
     chain_storage::BlockchainBackend,
     consensus::{ConsensusConstants, ConsensusManager},
-    proof_of_work::{monero_rx::MoneroPowData, AchievedTargetDifficulty, Difficulty, PowAlgorithm, PowError},
+    proof_of_work::{AchievedTargetDifficulty, Difficulty, PowAlgorithm, PowError},
     validation::{
         helpers::{check_header_timestamp_greater_than_median, check_target_difficulty},
         DifficultyCalculator,
@@ -78,7 +78,7 @@ impl<B: BlockchainBackend> HeaderChainLinkedValidator<B> for HeaderFullValidator
         check_header_timestamp_greater_than_median(header, prev_timestamps)?;
 
         check_timestamp_ftl(header, &self.rules)?;
-        check_pow_data(header, &self.rules, db)?;
+        check_pow_data(header)?;
 
         let achieved_target = if let Some(target) = target_difficulty {
             check_target_difficulty(
@@ -186,11 +186,7 @@ fn check_not_bad_block<B: BlockchainBackend>(db: &B, hash: FixedHash) -> Result<
 }
 
 /// Check the PoW data in the BlockHeader. This currently only applies to blocks merged mined with Monero.
-fn check_pow_data<B: BlockchainBackend>(
-    block_header: &BlockHeader,
-    rules: &ConsensusManager,
-    db: &B,
-) -> Result<(), ValidationError> {
+fn check_pow_data(block_header: &BlockHeader) -> Result<(), ValidationError> {
     use PowAlgorithm::{RandomX, Sha3x};
     match block_header.pow.pow_algo {
         RandomX => {
@@ -199,18 +195,6 @@ fn check_pow_data<B: BlockchainBackend>(
                     BlockHeaderValidationError::InvalidNonce,
                 ));
             }
-            let monero_data = MoneroPowData::from_header(block_header, rules)?;
-            let seed_height = db.fetch_monero_seed_first_seen_height(&monero_data.randomx_key)?;
-            if seed_height != 0 {
-                // Saturating sub: subtraction can underflow in reorgs / rewind-blockchain command
-                let seed_used_height = block_header.height.saturating_sub(seed_height);
-                if seed_used_height > rules.consensus_constants(block_header.height).max_randomx_seed_height() {
-                    return Err(ValidationError::BlockHeaderError(
-                        BlockHeaderValidationError::OldSeedHash,
-                    ));
-                }
-            }
-
             Ok(())
         },
         Sha3x => {

--- a/base_layer/core/tests/tests/block_validation.rs
+++ b/base_layer/core/tests/tests/block_validation.rs
@@ -126,10 +126,11 @@ async fn test_monero_blocks() {
     let gen_hash = *cm.get_genesis_block().hash();
     let difficulty_calculator = DifficultyCalculator::new(cm.clone(), RandomXFactory::default());
     let header_validator = HeaderFullValidator::new(cm.clone(), difficulty_calculator);
+    let block_validator = BlockBodyFullValidator::new(cm.clone(), true);
     let smt = Arc::new(RwLock::new(OutputSmt::new()));
     let db = create_store_with_consensus_and_validators(
         cm.clone(),
-        Validators::new(MockValidator::new(true), header_validator, MockValidator::new(true)),
+        Validators::new(block_validator, header_validator, MockValidator::new(true)),
         smt,
     );
     let block_0 = db.fetch_block(0, true).unwrap().try_into_chain_block().unwrap();


### PR DESCRIPTION
Description
---
Atm we dont remove old seeds if we reorg the chain. 
If we mine a block while syncing it might be that we insert the first seen height of the monero seed way too early and thus cause the node to think the seed is too old when verifying the chain. This PR will remove seeds for blocks that have been reorged out of the chain. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new database index for improved seed height tracking, ensuring consistent management during block header deletions and insertions.
  - Added a conversion method to transform internal byte arrays into more flexible vector formats.
  - Enhanced block validation by incorporating additional checks on Monero seed height to maintain protocol integrity.

- **Refactor**
  - Streamlined proof-of-work data verification by removing legacy logic and unnecessary parameters for a cleaner validation process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->