### PR TITLE
fix(comms/yamux): dont poll the substream after closing/error

### DIFF
--- a/comms/core/src/multiplexing/yamux.rs
+++ b/comms/core/src/multiplexing/yamux.rs
@@ -243,6 +243,7 @@ struct YamuxWorker<TSocket> {
     counter: AtomicRefCounter,
     _phantom: PhantomData<TSocket>,
     peer_connection_info: PeerConnectionInfo,
+    is_closed: bool,
 }
 
 impl<TSocket> YamuxWorker<TSocket>
@@ -260,6 +261,7 @@ where TSocket: futures::AsyncRead + futures::AsyncWrite + Unpin + Send + Sync + 
             counter,
             _phantom: PhantomData,
             peer_connection_info,
+            is_closed: false,
         }
     }
 
@@ -276,8 +278,8 @@ where TSocket: futures::AsyncRead + futures::AsyncWrite + Unpin + Send + Sync + 
                         self.counter.get(),
                         self.peer_connection_info,
                     );
-                    // Ignore: we already log the error variant in Self::close
-                    let _ignore = Self::close(&mut connection).await;
+                    // Ignore: we already log the error variant in self.close
+                    let _ignore = self.close(&mut connection).await;
                     break
                 },
 
@@ -347,18 +349,27 @@ where TSocket: futures::AsyncRead + futures::AsyncWrite + Unpin + Send + Sync + 
                                     );
                                 },
                             }
-                            // Ignore: we already log the error variant in Self::close
-                            let _ignore = Self::close(&mut connection).await;
+                            self.is_closed = true;
                             break;
                         },
                     }
                 }
             }
+
+            if self.is_closed {
+                debug!(
+                    target: LOG_TARGET,
+                    "{} Incoming peer ({}) substream task is stopping because the connection was closed",
+                    self.counter.get(),
+                    self.peer_connection_info,
+                );
+                break;
+            }
         }
     }
 
     async fn handle_request(
-        &self,
+        &mut self,
         connection_mut: &mut yamux::Connection<TSocket>,
         request: YamuxRequest,
     ) -> io::Result<()> {
@@ -376,7 +387,7 @@ where TSocket: futures::AsyncRead + futures::AsyncWrite + Unpin + Send + Sync + 
                 }
             },
             YamuxRequest::Close { reply } => {
-                if reply.send(Self::close(connection_mut).await).is_err() {
+                if reply.send(self.close(connection_mut).await).is_err() {
                     warn!(target: LOG_TARGET, "Request to close substream was aborted before reply was sent");
                 }
             },
@@ -390,7 +401,12 @@ where TSocket: futures::AsyncRead + futures::AsyncWrite + Unpin + Send + Sync + 
         poll_fn(|cx| connection_mut.poll_next_inbound(cx)).await
     }
 
-    async fn close(connection: &mut yamux::Connection<TSocket>) -> yamux::Result<()> {
+    async fn close(&mut self, connection: &mut yamux::Connection<TSocket>) -> yamux::Result<()> {
+        if self.is_closed {
+            return Ok(());
+        }
+
+        self.is_closed = true;
         if let Err(err) = poll_fn(|cx| connection.poll_close(cx)).await {
             match err {
                 ConnectionError::Io(ref io_err)


### PR DESCRIPTION
Description
---
fix(comms/yamux): dont poll the substream after closing/error

Motivation and Context
---
We inadvertently polled the connection after closing it/after an error. This is not correct and results in a panic

Ref https://github.com/libp2p/rust-yamux/pull/199
The PR above prevents the panic and sets the connection state to closed.

This related PR can also be merged before/after this one:
https://github.com/tari-project/tari/pull/6909

How Has This Been Tested?
---
Not explicitly tested

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved connection handling to prevent further processing once a connection is closed, enhancing reliability by ensuring that operations halt gracefully when encountering a closed state.
  - Added tracking for the closed state of the worker, enhancing robustness in connection management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->