### PR TITLE
feat: handle outbound pipeline interlock due to connection cleanup

### DIFF
--- a/comms/core/src/connection_manager/error.rs
+++ b/comms/core/src/connection_manager/error.rs
@@ -130,6 +130,8 @@ pub enum PeerConnectionError {
     ProtocolError(#[from] ProtocolError),
     #[error("Protocol negotiation timeout")]
     ProtocolNegotiationTimeout,
+    #[error("Timeout disconnecting peer")]
+    DisconnectTimeout,
 }
 
 impl From<Elapsed> for PeerConnectionError {

--- a/comms/core/src/connectivity/manager.rs
+++ b/comms/core/src/connectivity/manager.rs
@@ -180,24 +180,47 @@ impl ConnectivityManagerActor {
         loop {
             tokio::select! {
                 Some(req) = self.request_rx.recv() => {
+                    let request_id = rand::random::<u64>();
+                    trace!(target: LOG_TARGET, "Request ({}): {:?}", request_id, req);
                     self.handle_request(req).await;
+                    trace!(target: LOG_TARGET, "Request ({}) done", request_id);
                 },
 
                 Ok(event) = connection_manager_events.recv() => {
+                    let event_id = rand::random::<u64>();
+                    trace!(target: LOG_TARGET, "Event ({}): {:?}", event_id, event);
                     if let Err(err) = self.handle_connection_manager_event(&event).await {
-                        error!(target:LOG_TARGET, "Error handling connection manager event: {:?}", err);
+                        error!(target:LOG_TARGET, "Error handling connection manager event ({}): {:?}", event_id, err);
                     }
+                    trace!(target: LOG_TARGET, "Event ({}) done", event_id);
                 },
 
                 _ = ticker.tick() => {
+                    let ticker_id = rand::random::<u64>();
+                    trace!(target: LOG_TARGET, "Ticker ({})", ticker_id);
                     self.cleanup_connection_stats();
-                    if let Err(err) = self.refresh_connection_pool().await {
-                        error!(target: LOG_TARGET, "Error when refreshing connection pools: {:?}", err);
+                    match tokio::time::timeout(Duration::from_millis(2500), self.refresh_connection_pool(ticker_id)).await {
+                        Ok(res) => {
+                            if let Err(err) = res {
+                                error!(target: LOG_TARGET, "Error refreshing connection pools ({}): {:?}", ticker_id, err);
+                            }
+                        },
+                        Err(_) => {
+                            warn!(
+                                target: LOG_TARGET,
+                                "Timeout refreshing connection pool ({})",
+                                ticker_id,
+                            );
+                        },
                     }
+                    trace!(target: LOG_TARGET, "Ticker ({}) done", ticker_id);
                 },
 
                 _ = self.shutdown_signal.wait() => {
-                    info!(target: LOG_TARGET, "ConnectivityManager is shutting down because it received the shutdown signal");
+                    info!(
+                        target: LOG_TARGET,
+                        "ConnectivityManager is shutting down because it received the shutdown signal"
+                    );
                     self.disconnect_all().await;
                     break;
                 }
@@ -208,7 +231,6 @@ impl ConnectivityManagerActor {
     async fn handle_request(&mut self, req: ConnectivityRequest) {
         #[allow(clippy::enum_glob_use)]
         use ConnectivityRequest::*;
-        trace!(target: LOG_TARGET, "Request: {:?}", req);
         match req {
             WaitStarted(reply) => {
                 let _ = reply.send(());
@@ -223,7 +245,7 @@ impl ConnectivityManagerActor {
                 self.handle_dial_peer(node_id.clone(), reply_tx).instrument(span).await;
             },
             SelectConnections(selection, reply) => {
-                let _result = reply.send(self.select_connections(selection).await);
+                let _result = reply.send(self.select_connections(selection));
             },
             GetConnection(node_id, reply) => {
                 let _result = reply.send(
@@ -379,11 +401,12 @@ impl ConnectivityManagerActor {
         }
     }
 
-    async fn refresh_connection_pool(&mut self) -> Result<(), ConnectivityError> {
+    async fn refresh_connection_pool(&mut self, ticker_id: u64) -> Result<(), ConnectivityError> {
         debug!(
             target: LOG_TARGET,
-            "Performing connection pool cleanup/refresh. (#Peers = {}, #Connected={}, #Failed={}, #Disconnected={}, \
+            "Performing connection pool cleanup/refresh ({}). (#Peers = {}, #Connected={}, #Failed={}, #Disconnected={}, \
              #Clients={})",
+            ticker_id,
             self.pool.count_entries(),
             self.pool.count_connected_nodes(),
             self.pool.count_failed(),
@@ -393,32 +416,31 @@ impl ConnectivityManagerActor {
 
         self.clean_connection_pool();
         if self.config.is_connection_reaping_enabled {
-            self.reap_inactive_connections().await;
+            self.reap_inactive_connections(ticker_id).await;
         }
         if let Some(threshold) = self.config.maintain_n_closest_connections_only {
-            self.maintain_n_closest_peer_connections_only(threshold).await;
+            self.maintain_n_closest_peer_connections_only(threshold, ticker_id)
+                .await;
         }
         self.update_connectivity_status();
         self.update_connectivity_metrics();
         Ok(())
     }
 
-    async fn maintain_n_closest_peer_connections_only(&mut self, threshold: usize) {
+    async fn maintain_n_closest_peer_connections_only(&mut self, threshold: usize, ticker_id: u64) {
         // Select all active peer connections (that are communication nodes)
-        let mut connections = match self
-            .select_connections(ConnectivitySelection::closest_to(
-                self.node_identity.node_id().clone(),
-                self.pool.count_connected_nodes(),
-                vec![],
-            ))
-            .await
-        {
+        let mut connections = match self.select_connections(ConnectivitySelection::closest_to(
+            self.node_identity.node_id().clone(),
+            self.pool.count_connected_nodes(),
+            vec![],
+        )) {
             Ok(peers) => peers,
             Err(e) => {
                 warn!(
                     target: LOG_TARGET,
-                    "Connectivity error trying to maintain {} closest peers ({:?})",
+                    "Connectivity error trying to maintain {} closest peers ({}) ({:?})",
                     threshold,
+                    ticker_id,
                     e
                 );
                 return;
@@ -430,7 +452,8 @@ impl ConnectivityManagerActor {
         connections.retain(|conn| !self.allow_list.contains(conn.peer_node_id()));
         debug!(
             target: LOG_TARGET,
-            "minimize_connections: Filtered peers: {}, Handles: {}",
+            "minimize_connections: ({}) Filtered peers: {}, Handles: {}",
+            ticker_id,
             connections.len(),
             num_connections,
         );
@@ -439,24 +462,50 @@ impl ConnectivityManagerActor {
         for conn in connections.iter_mut().skip(threshold) {
             debug!(
                 target: LOG_TARGET,
-                "minimize_connections: Disconnecting '{}' because the node is not among the {} closest peers",
+                "minimize_connections: ({}) Disconnecting '{}' because the node is not among the {} closest peers",
+                ticker_id,
                 conn.peer_node_id(),
                 threshold
             );
-            if let Err(err) = conn.disconnect(Minimized::Yes).await {
-                // Already disconnected
-                debug!(
-                    target: LOG_TARGET,
-                    "Peer '{}' already disconnected. Error: {:?}",
-                    conn.peer_node_id().short_str(),
-                    err
-                );
+            if (ConnectivityManagerActor::disconnect_with_timeout(conn, Duration::from_millis(250), ticker_id).await)
+                .is_ok()
+            {
+                self.pool.remove(conn.peer_node_id());
             }
-            self.pool.remove(conn.peer_node_id());
         }
     }
 
-    async fn reap_inactive_connections(&mut self) {
+    async fn disconnect_with_timeout(
+        connection: &mut PeerConnection,
+        timeout: Duration,
+        ticker_id: u64,
+    ) -> Result<(), ()> {
+        match tokio::time::timeout(timeout, connection.disconnect(Minimized::Yes)).await {
+            Ok(res) => {
+                if let Err(err) = res {
+                    // Already disconnected
+                    debug!(
+                        target: LOG_TARGET,
+                        "Peer '{}' already disconnected. Error: {:?}",
+                        connection.peer_node_id().short_str(),
+                        err
+                    );
+                }
+                Ok(())
+            },
+            Err(_) => {
+                warn!(
+                    target: LOG_TARGET,
+                    "Timeout disconnecting peer ({}) '{}'",
+                    ticker_id,
+                    connection.peer_node_id().short_str(),
+                );
+                Err(())
+            },
+        }
+    }
+
+    async fn reap_inactive_connections(&mut self, ticker_id: u64) {
         let excess_connections = self
             .pool
             .count_connected()
@@ -476,19 +525,13 @@ impl ConnectivityManagerActor {
 
             debug!(
                 target: LOG_TARGET,
-                "Disconnecting '{}' because connection was inactive ({} handles)",
+                "({}) Disconnecting '{}' because connection was inactive ({} handles)",
+                ticker_id,
                 conn.peer_node_id().short_str(),
                 conn.handle_count()
             );
-            if let Err(err) = conn.disconnect(Minimized::Yes).await {
-                // Already disconnected
-                debug!(
-                    target: LOG_TARGET,
-                    "Peer '{}' already disconnected. Error: {:?}",
-                    conn.peer_node_id().short_str(),
-                    err
-                );
-            }
+            let _unused =
+                ConnectivityManagerActor::disconnect_with_timeout(conn, Duration::from_millis(250), ticker_id).await;
         }
     }
 
@@ -513,10 +556,7 @@ impl ConnectivityManagerActor {
         }
     }
 
-    async fn select_connections(
-        &self,
-        selection: ConnectivitySelection,
-    ) -> Result<Vec<PeerConnection>, ConnectivityError> {
+    fn select_connections(&self, selection: ConnectivitySelection) -> Result<Vec<PeerConnection>, ConnectivityError> {
         trace!(target: LOG_TARGET, "Selection query: {:?}", selection);
         trace!(
             target: LOG_TARGET,

--- a/comms/core/src/connectivity/manager.rs
+++ b/comms/core/src/connectivity/manager.rs
@@ -58,6 +58,7 @@ use crate::{
     Minimized,
     NodeIdentity,
     PeerConnection,
+    PeerConnectionError,
     PeerManager,
 };
 
@@ -380,7 +381,7 @@ impl ConnectivityManagerActor {
                 if !conn.is_connected() {
                     continue;
                 }
-                match conn.disconnect_silent(Minimized::No).await {
+                match disconnect_silent_with_timeout(conn, Minimized::No, Duration::from_millis(250), None).await {
                     Ok(_) => {
                         node_ids.push(conn.peer_node_id().clone());
                     },
@@ -427,7 +428,7 @@ impl ConnectivityManagerActor {
         Ok(())
     }
 
-    async fn maintain_n_closest_peer_connections_only(&mut self, threshold: usize, ticker_id: u64) {
+    async fn maintain_n_closest_peer_connections_only(&mut self, threshold: usize, task_id: u64) {
         // Select all active peer connections (that are communication nodes)
         let mut connections = match self.select_connections(ConnectivitySelection::closest_to(
             self.node_identity.node_id().clone(),
@@ -440,7 +441,7 @@ impl ConnectivityManagerActor {
                     target: LOG_TARGET,
                     "Connectivity error trying to maintain {} closest peers ({}) ({:?})",
                     threshold,
-                    ticker_id,
+                    task_id,
                     e
                 );
                 return;
@@ -453,7 +454,7 @@ impl ConnectivityManagerActor {
         debug!(
             target: LOG_TARGET,
             "minimize_connections: ({}) Filtered peers: {}, Handles: {}",
-            ticker_id,
+            task_id,
             connections.len(),
             num_connections,
         );
@@ -463,49 +464,28 @@ impl ConnectivityManagerActor {
             debug!(
                 target: LOG_TARGET,
                 "minimize_connections: ({}) Disconnecting '{}' because the node is not among the {} closest peers",
-                ticker_id,
+                task_id,
                 conn.peer_node_id(),
                 threshold
             );
-            if (ConnectivityManagerActor::disconnect_with_timeout(conn, Duration::from_millis(250), ticker_id).await)
-                .is_ok()
-            {
-                self.pool.remove(conn.peer_node_id());
+            match disconnect_with_timeout(conn, Minimized::Yes, Duration::from_millis(250), Some(task_id)).await {
+                Ok(_) => {
+                    self.pool.remove(conn.peer_node_id());
+                },
+                Err(err) => {
+                    debug!(
+                        target: LOG_TARGET,
+                        "Peer '{}' already disconnected ({:?}). Error: {:?}",
+                        conn.peer_node_id().short_str(),
+                        task_id,
+                        err
+                    );
+                },
             }
         }
     }
 
-    async fn disconnect_with_timeout(
-        connection: &mut PeerConnection,
-        timeout: Duration,
-        ticker_id: u64,
-    ) -> Result<(), ()> {
-        match tokio::time::timeout(timeout, connection.disconnect(Minimized::Yes)).await {
-            Ok(res) => {
-                if let Err(err) = res {
-                    // Already disconnected
-                    debug!(
-                        target: LOG_TARGET,
-                        "Peer '{}' already disconnected. Error: {:?}",
-                        connection.peer_node_id().short_str(),
-                        err
-                    );
-                }
-                Ok(())
-            },
-            Err(_) => {
-                warn!(
-                    target: LOG_TARGET,
-                    "Timeout disconnecting peer ({}) '{}'",
-                    ticker_id,
-                    connection.peer_node_id().short_str(),
-                );
-                Err(())
-            },
-        }
-    }
-
-    async fn reap_inactive_connections(&mut self, ticker_id: u64) {
+    async fn reap_inactive_connections(&mut self, task_id: u64) {
         let excess_connections = self
             .pool
             .count_connected()
@@ -518,7 +498,8 @@ impl ConnectivityManagerActor {
             .pool
             .get_inactive_outbound_connections_mut(self.config.reaper_min_inactive_age);
         connections.truncate(excess_connections);
-        for conn in connections {
+        let mut nodes_to_remove = Vec::new();
+        for conn in &mut connections {
             if !conn.is_connected() {
                 continue;
             }
@@ -526,12 +507,27 @@ impl ConnectivityManagerActor {
             debug!(
                 target: LOG_TARGET,
                 "({}) Disconnecting '{}' because connection was inactive ({} handles)",
-                ticker_id,
+                task_id,
                 conn.peer_node_id().short_str(),
                 conn.handle_count()
             );
-            let _unused =
-                ConnectivityManagerActor::disconnect_with_timeout(conn, Duration::from_millis(250), ticker_id).await;
+            match disconnect_with_timeout(conn, Minimized::Yes, Duration::from_millis(250), Some(task_id)).await {
+                Ok(_) => {
+                    nodes_to_remove.push(conn.peer_node_id().clone());
+                },
+                Err(err) => {
+                    debug!(
+                        target: LOG_TARGET,
+                        "Peer '{}' already disconnected ({:?}). Error: {:?}",
+                        conn.peer_node_id().short_str(),
+                        task_id,
+                        err
+                    );
+                },
+            }
+        }
+        for node_id in nodes_to_remove {
+            self.pool.remove(&node_id);
         }
     }
 
@@ -712,7 +708,7 @@ impl ConnectivityManagerActor {
                         msg
                     );
                     let mut conn = conn.clone();
-                    conn.disconnect(Minimized::No).await?;
+                    disconnect_with_timeout(&mut conn, Minimized::No, Duration::from_millis(250), None).await?;
                 }
                 (node_id, ConnectionStatus::Failed, None)
             },
@@ -812,7 +808,8 @@ impl ConnectivityManagerActor {
                 let Some(existing_conn) = existing_state.connection_mut() else {
                     error!(
                         target: LOG_TARGET,
-                        "INVARIANT ERROR in Tie break: PeerConnection is None but state is CONNECTED: Existing connection (id: {}, peer: {}, direction: {}), new connection. (id: {}, peer: {}, direction: {})",
+                        "INVARIANT ERROR in Tie break: PeerConnection is None but state is CONNECTED: Existing \
+                        connection (id: {}, peer: {}, direction: {}), new connection. (id: {}, peer: {}, direction: {})",
                         existing_state.connection().map(|c| c.id()).unwrap_or_default(),
                         existing_state.node_id(),
                         existing_state.connection().map(|c| c.direction().as_str()).unwrap_or("--"),
@@ -835,7 +832,9 @@ impl ConnectivityManagerActor {
                         existing_conn.direction(),
                     );
 
-                    let _result = existing_conn.disconnect_silent(Minimized::Yes).await;
+                    let _result =
+                        disconnect_silent_with_timeout(existing_conn, Minimized::Yes, Duration::from_millis(250), None)
+                            .await;
                     self.pool.remove(existing_conn.peer_node_id());
                     TieBreak::UseNew
                 } else {
@@ -851,7 +850,13 @@ impl ConnectivityManagerActor {
                         existing_conn.direction(),
                     );
 
-                    let _result = new_conn.clone().disconnect_silent(Minimized::Yes).await;
+                    let _result = disconnect_silent_with_timeout(
+                        &mut new_conn.clone(),
+                        Minimized::Yes,
+                        Duration::from_millis(250),
+                        None,
+                    )
+                    .await;
                     TieBreak::KeepExisting
                 }
             },
@@ -1030,7 +1035,7 @@ impl ConnectivityManagerActor {
         self.publish_event(ConnectivityEvent::PeerBanned(node_id.clone()));
 
         if let Some(conn) = self.pool.get_connection_mut(node_id) {
-            conn.disconnect(Minimized::Yes).await?;
+            disconnect_with_timeout(conn, Minimized::Yes, Duration::from_millis(250), None).await?;
             let status = self.pool.get_connection_status(node_id);
             debug!(
                 target: LOG_TARGET,
@@ -1061,4 +1066,44 @@ enum TieBreak {
     None,
     UseNew,
     KeepExisting,
+}
+
+async fn disconnect_with_timeout(
+    connection: &mut PeerConnection,
+    minimized: Minimized,
+    timeout: Duration,
+    task_id: Option<u64>,
+) -> Result<(), PeerConnectionError> {
+    match tokio::time::timeout(timeout, connection.disconnect(minimized)).await {
+        Ok(res) => res,
+        Err(_) => {
+            warn!(
+                target: LOG_TARGET,
+                "Timeout disconnecting peer ({:?}) '{}'",
+                task_id,
+                connection.peer_node_id().short_str(),
+            );
+            Err(PeerConnectionError::DisconnectTimeout)
+        },
+    }
+}
+
+async fn disconnect_silent_with_timeout(
+    connection: &mut PeerConnection,
+    minimized: Minimized,
+    timeout: Duration,
+    task_id: Option<u64>,
+) -> Result<(), PeerConnectionError> {
+    match tokio::time::timeout(timeout, connection.disconnect_silent(minimized)).await {
+        Ok(res) => res,
+        Err(_) => {
+            warn!(
+                target: LOG_TARGET,
+                "Timeout disconnecting peer ({:?}) '{}'",
+                task_id,
+                connection.peer_node_id().short_str(),
+            );
+            Err(PeerConnectionError::DisconnectTimeout)
+        },
+    }
 }

--- a/comms/core/src/peer_manager/node_distance.rs
+++ b/comms/core/src/peer_manager/node_distance.rs
@@ -210,40 +210,5 @@ mod test {
                 assert!(dist < 2u128.pow(i + 1), "Failed for {}, i = {}", dist, i,);
             }
         }
-
-        #[test]
-        #[ignore]
-        fn pockets() {
-            const N: usize = 100;
-            let mut nodes = Vec::with_capacity(N);
-            for i in 0..N {
-                let (_, pk) = CommsPublicKey::random_keypair(&mut OsRng);
-                nodes.push((format!("node_{}", i), NodeId::from_public_key(&pk)));
-            }
-            let mut distance_map = Vec::with_capacity(N * N);
-            for (node_i_str, node_i) in &nodes {
-                for (node_j_str, node_j) in &nodes {
-                    if node_i == node_j {
-                        continue;
-                    }
-                    let dist = NodeDistance::from_node_ids(node_i, node_j);
-                    distance_map.push((node_i_str.clone(), node_j_str.clone(), dist.clone()));
-                }
-            }
-            println!("Sorted");
-            println!();
-            for (node_str, _node) in &nodes {
-                let mut sorted_map = distance_map
-                    .iter()
-                    .filter(|(node_i_str, _, _)| node_str == node_i_str)
-                    .collect::<Vec<_>>();
-                // Sort by distance
-                sorted_map.sort_by(|(_, _, dist_i), (_, _, dist_j)| dist_i.cmp(dist_j));
-                for (node_i_str, node_j_str, dist) in &sorted_map {
-                    println!("{}, {}, dist: {}", node_i_str, node_j_str, dist);
-                }
-                println!();
-            }
-        }
     }
 }

--- a/comms/core/src/peer_manager/node_distance.rs
+++ b/comms/core/src/peer_manager/node_distance.rs
@@ -210,5 +210,40 @@ mod test {
                 assert!(dist < 2u128.pow(i + 1), "Failed for {}, i = {}", dist, i,);
             }
         }
+
+        #[test]
+        #[ignore]
+        fn pockets() {
+            const N: usize = 100;
+            let mut nodes = Vec::with_capacity(N);
+            for i in 0..N {
+                let (_, pk) = CommsPublicKey::random_keypair(&mut OsRng);
+                nodes.push((format!("node_{}", i), NodeId::from_public_key(&pk)));
+            }
+            let mut distance_map = Vec::with_capacity(N * N);
+            for (node_i_str, node_i) in &nodes {
+                for (node_j_str, node_j) in &nodes {
+                    if node_i == node_j {
+                        continue;
+                    }
+                    let dist = NodeDistance::from_node_ids(node_i, node_j);
+                    distance_map.push((node_i_str.clone(), node_j_str.clone(), dist.clone()));
+                }
+            }
+            println!("Sorted");
+            println!();
+            for (node_str, _node) in &nodes {
+                let mut sorted_map = distance_map
+                    .iter()
+                    .filter(|(node_i_str, _, _)| node_str == node_i_str)
+                    .collect::<Vec<_>>();
+                // Sort by distance
+                sorted_map.sort_by(|(_, _, dist_i), (_, _, dist_j)| dist_i.cmp(dist_j));
+                for (node_i_str, node_j_str, dist) in &sorted_map {
+                    println!("{}, {}, dist: {}", node_i_str, node_j_str, dist);
+                }
+                println!();
+            }
+        }
     }
 }

--- a/comms/dht/src/actor.rs
+++ b/comms/dht/src/actor.rs
@@ -571,6 +571,7 @@ impl DhtActor {
         mut connectivity: ConnectivityRequester,
         broadcast_strategy: BroadcastStrategy,
     ) -> Result<Vec<NodeId>, DhtActorError> {
+        trace!(target: LOG_TARGET, "Select peers broadcast strategy: {}", broadcast_strategy);
         #[allow(clippy::enum_glob_use)]
         use BroadcastStrategy::*;
         let peers = match broadcast_strategy {


### PR DESCRIPTION
Description
---
Some times disconnecting a peer can go stale and cause undue lock-ups for the calling thread. With `comms\core\src\connectivity\manager.rs`:
- Mitigated the outbound pipeline lockup that can occur when peers are being disconnected. The clean-up loop runs regularly with a 1 min default interval.
- Ensured all disconnecting tasks are wrapped in a `tokio::time::timeout(` future.

**Note:** Other unwanted lock-up/interlock behaviour may still be related to the outbound pipeline.

Motivation and Context
---
In a recent system-level test the cleanup performed in `async fn refresh_connection_pool(&mut self, ticker_id: u64)` took 18 min to return, which held up the tokio select loop, with the further knock-on effect to block all `ConnectivityRequest` sent via the outbound pipeline.

How Has This Been Tested?
---
Performed system-level testing.
(_Supportive evidence has been found in the log files for a correlation between the console message `Watched command status failed: deadline has elapsed` and the peer disconnect timeouts._)

What process can a PR reviewer use to test or verify this change?
---
- Code review
- System-level testing

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced connection management with improved logging and error handling for better traceability.
  - Introduced a timeout mechanism for refreshing connections to mitigate delays.
  - Added safe disconnection procedures to prevent operations from hanging.
  - Improved peer selection logging to provide clearer insights into broadcast strategies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->