### PR TITLE
feat: delete stale peers for the peer database

### DIFF
--- a/comms/core/src/connectivity/manager.rs
+++ b/comms/core/src/connectivity/manager.rs
@@ -63,11 +63,16 @@ use crate::{
 };
 
 const LOG_TARGET: &str = "comms::connectivity::manager";
+// Maximum time allowed for deleting stale peers from database
 
 const STALE_PEER_DELETE_TIMEOUT: Duration = Duration::from_millis(1500);
+// Maximum time allowed for refreshing the connection pool
 const POOL_REFRESH_TIMEOUT: Duration = Duration::from_millis(2500);
+// Maximum time allowed to disconnect a single peer
 const PEER_DISCONNECT_TIMEOUT: Duration = Duration::from_millis(250);
+// Warning threshold for request processing time
 const REQUEST_TIME_LAPSE_WARNING: Duration = Duration::from_millis(500);
+// Warning threshold for event processing time
 const EVENT_TIME_LAPSE_WARNING: Duration = Duration::from_millis(500);
 
 /// # Connectivity Manager

--- a/comms/core/src/connectivity/manager.rs
+++ b/comms/core/src/connectivity/manager.rs
@@ -432,7 +432,12 @@ impl ConnectivityManagerActor {
 
     async fn delete_all_stale_peers_from_db(&mut self, task_id: u64) {
         let start = Instant::now();
-        match tokio::time::timeout(PEER_DELETE_TIMEOUT, self.peer_manager.delete_all_stale_peers()).await {
+        match tokio::time::timeout(
+            PEER_DELETE_TIMEOUT,
+            self.peer_manager.delete_all_stale_peers(self.node_identity.node_id()),
+        )
+        .await
+        {
             Ok(res) => match res {
                 Ok(deleted) => {
                     let len = deleted.len();

--- a/comms/core/src/connectivity/manager.rs
+++ b/comms/core/src/connectivity/manager.rs
@@ -64,7 +64,11 @@ use crate::{
 
 const LOG_TARGET: &str = "comms::connectivity::manager";
 
-const PEER_DELETE_TIMEOUT: Duration = Duration::from_millis(1000);
+const STALE_PEER_DELETE_TIMEOUT: Duration = Duration::from_millis(1500);
+const POOL_REFRESH_TIMEOUT: Duration = Duration::from_millis(2500);
+const PEER_DISCONNECT_TIMEOUT: Duration = Duration::from_millis(250);
+const REQUEST_TIME_LAPSE_WARNING: Duration = Duration::from_millis(500);
+const EVENT_TIME_LAPSE_WARNING: Duration = Duration::from_millis(500);
 
 /// # Connectivity Manager
 ///
@@ -169,54 +173,73 @@ impl ConnectivityManagerActor {
         let mut connection_manager_events = self.connection_manager.get_event_subscription();
 
         let interval = self.config.connection_pool_refresh_interval;
-        let mut ticker = time::interval_at(
+        let mut connection_pool_timer = time::interval_at(
             Instant::now()
                 .checked_add(interval)
                 .expect("connection_pool_refresh_interval cause overflow")
                 .into(),
             interval,
         );
-        ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
+        connection_pool_timer.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
         self.publish_event(ConnectivityEvent::ConnectivityStateInitialized);
 
         loop {
             tokio::select! {
                 Some(req) = self.request_rx.recv() => {
-                    let request_id = rand::random::<u64>();
-                    trace!(target: LOG_TARGET, "Request ({}): {:?}", request_id, req);
+                    let timer = Instant::now();
+                    let task_id = rand::random::<u64>();
+                    trace!(target: LOG_TARGET, "Request ({}): {:?}", task_id, req);
                     self.handle_request(req).await;
-                    trace!(target: LOG_TARGET, "Request ({}) done", request_id);
+                    if timer.elapsed() > REQUEST_TIME_LAPSE_WARNING {
+                        warn!(
+                            target: LOG_TARGET,
+                            "Request ({}) took too long to process: {:.2?}",
+                            task_id,
+                            format_duration(timer.elapsed())
+                        );
+                    }
+                    trace!(target: LOG_TARGET, "Request ({}) done", task_id);
                 },
 
                 Ok(event) = connection_manager_events.recv() => {
-                    let event_id = rand::random::<u64>();
-                    trace!(target: LOG_TARGET, "Event ({}): {:?}", event_id, event);
+                    let timer = Instant::now();
+                    let task_id = rand::random::<u64>();
+                    trace!(target: LOG_TARGET, "Event ({}): {:?}", task_id, event);
                     if let Err(err) = self.handle_connection_manager_event(&event).await {
-                        error!(target:LOG_TARGET, "Error handling connection manager event ({}): {:?}", event_id, err);
+                        error!(target:LOG_TARGET, "Error handling connection manager event ({}): {:?}", task_id, err);
                     }
-                    trace!(target: LOG_TARGET, "Event ({}) done", event_id);
+                    if timer.elapsed() > EVENT_TIME_LAPSE_WARNING {
+                        warn!(
+                            target: LOG_TARGET,
+                            "Event ({}) took too long to process: {:.2?}",
+                            task_id,
+                            format_duration(timer.elapsed())
+                        );
+                    }
+                    trace!(target: LOG_TARGET, "Event ({}) done", task_id);
                 },
 
-                _ = ticker.tick() => {
-                    let ticker_id = rand::random::<u64>();
-                    trace!(target: LOG_TARGET, "Ticker ({})", ticker_id);
+                _ = connection_pool_timer.tick() => {
+                    let task_id = rand::random::<u64>();
+                    trace!(target: LOG_TARGET, "Pool refresh & delete stale peers task ({})", task_id);
+                    self.delete_stale_peers_from_db(task_id).await;
                     self.cleanup_connection_stats();
-                    match tokio::time::timeout(Duration::from_millis(2500), self.refresh_connection_pool(ticker_id)).await {
+                    match tokio::time::timeout(POOL_REFRESH_TIMEOUT, self.refresh_connection_pool(task_id)).await {
                         Ok(res) => {
                             if let Err(err) = res {
-                                error!(target: LOG_TARGET, "Error refreshing connection pools ({}): {:?}", ticker_id, err);
+                                error!(target: LOG_TARGET, "Error refreshing connection pools ({}): {:?}", task_id, err);
                             }
                         },
                         Err(_) => {
                             warn!(
                                 target: LOG_TARGET,
-                                "Timeout refreshing connection pool ({})",
-                                ticker_id,
+                                "Pool refresh task ({}) timeout",
+                                task_id,
                             );
                         },
                     }
-                    trace!(target: LOG_TARGET, "Ticker ({}) done", ticker_id);
+                    trace!(target: LOG_TARGET, "Pool refresh & delete stale peers task ({}) done", task_id);
                 },
 
                 _ = self.shutdown_signal.wait() => {
@@ -383,7 +406,7 @@ impl ConnectivityManagerActor {
                 if !conn.is_connected() {
                     continue;
                 }
-                match disconnect_silent_with_timeout(conn, Minimized::No, Duration::from_millis(250), None).await {
+                match disconnect_silent_with_timeout(conn, Minimized::No, None).await {
                     Ok(_) => {
                         node_ids.push(conn.peer_node_id().clone());
                     },
@@ -424,16 +447,15 @@ impl ConnectivityManagerActor {
         if let Some(threshold) = self.config.maintain_n_closest_connections_only {
             self.maintain_n_closest_peer_connections_only(threshold, task_id).await;
         }
-        self.delete_all_stale_peers_from_db(task_id).await;
         self.update_connectivity_status();
         self.update_connectivity_metrics();
         Ok(())
     }
 
-    async fn delete_all_stale_peers_from_db(&mut self, task_id: u64) {
+    async fn delete_stale_peers_from_db(&mut self, task_id: u64) {
         let start = Instant::now();
         match tokio::time::timeout(
-            PEER_DELETE_TIMEOUT,
+            STALE_PEER_DELETE_TIMEOUT,
             self.peer_manager.delete_all_stale_peers(self.node_identity.node_id()),
         )
         .await
@@ -504,7 +526,7 @@ impl ConnectivityManagerActor {
                 conn.peer_node_id(),
                 threshold
             );
-            match disconnect_with_timeout(conn, Minimized::Yes, Duration::from_millis(250), Some(task_id)).await {
+            match disconnect_with_timeout(conn, Minimized::Yes, Some(task_id)).await {
                 Ok(_) => {
                     self.pool.remove(conn.peer_node_id());
                 },
@@ -556,7 +578,7 @@ impl ConnectivityManagerActor {
                 conn.peer_node_id().short_str(),
                 conn.handle_count()
             );
-            match disconnect_with_timeout(conn, Minimized::Yes, Duration::from_millis(250), Some(task_id)).await {
+            match disconnect_with_timeout(conn, Minimized::Yes, Some(task_id)).await {
                 Ok(_) => {
                     nodes_to_remove.push(conn.peer_node_id().clone());
                 },
@@ -762,7 +784,7 @@ impl ConnectivityManagerActor {
                         msg
                     );
                     let mut conn = conn.clone();
-                    disconnect_with_timeout(&mut conn, Minimized::No, Duration::from_millis(250), None).await?;
+                    disconnect_with_timeout(&mut conn, Minimized::No, None).await?;
                 }
                 (node_id, ConnectionStatus::Failed, None)
             },
@@ -886,9 +908,7 @@ impl ConnectivityManagerActor {
                         existing_conn.direction(),
                     );
 
-                    let _result =
-                        disconnect_silent_with_timeout(existing_conn, Minimized::Yes, Duration::from_millis(250), None)
-                            .await;
+                    let _result = disconnect_silent_with_timeout(existing_conn, Minimized::Yes, None).await;
                     self.pool.remove(existing_conn.peer_node_id());
                     TieBreak::UseNew
                 } else {
@@ -904,13 +924,7 @@ impl ConnectivityManagerActor {
                         existing_conn.direction(),
                     );
 
-                    let _result = disconnect_silent_with_timeout(
-                        &mut new_conn.clone(),
-                        Minimized::Yes,
-                        Duration::from_millis(250),
-                        None,
-                    )
-                    .await;
+                    let _result = disconnect_silent_with_timeout(&mut new_conn.clone(), Minimized::Yes, None).await;
                     TieBreak::KeepExisting
                 }
             },
@@ -1089,7 +1103,7 @@ impl ConnectivityManagerActor {
         self.publish_event(ConnectivityEvent::PeerBanned(node_id.clone()));
 
         if let Some(conn) = self.pool.get_connection_mut(node_id) {
-            disconnect_with_timeout(conn, Minimized::Yes, Duration::from_millis(250), None).await?;
+            disconnect_with_timeout(conn, Minimized::Yes, None).await?;
             let status = self.pool.get_connection_status(node_id);
             debug!(
                 target: LOG_TARGET,
@@ -1125,10 +1139,9 @@ enum TieBreak {
 async fn disconnect_with_timeout(
     connection: &mut PeerConnection,
     minimized: Minimized,
-    timeout: Duration,
     task_id: Option<u64>,
 ) -> Result<(), PeerConnectionError> {
-    match tokio::time::timeout(timeout, connection.disconnect(minimized)).await {
+    match tokio::time::timeout(PEER_DISCONNECT_TIMEOUT, connection.disconnect(minimized)).await {
         Ok(res) => res,
         Err(_) => {
             warn!(
@@ -1145,10 +1158,9 @@ async fn disconnect_with_timeout(
 async fn disconnect_silent_with_timeout(
     connection: &mut PeerConnection,
     minimized: Minimized,
-    timeout: Duration,
     task_id: Option<u64>,
 ) -> Result<(), PeerConnectionError> {
-    match tokio::time::timeout(timeout, connection.disconnect_silent(minimized)).await {
+    match tokio::time::timeout(PEER_DISCONNECT_TIMEOUT, connection.disconnect_silent(minimized)).await {
         Ok(res) => res,
         Err(_) => {
             warn!(

--- a/comms/core/src/connectivity/manager.rs
+++ b/comms/core/src/connectivity/manager.rs
@@ -71,9 +71,9 @@ const POOL_REFRESH_TIMEOUT: Duration = Duration::from_millis(2500);
 // Maximum time allowed to disconnect a single peer
 const PEER_DISCONNECT_TIMEOUT: Duration = Duration::from_millis(250);
 // Warning threshold for request processing time
-const REQUEST_TIME_LAPSE_WARNING: Duration = Duration::from_millis(500);
+const ACCEPTABLE_CONNECTIVITY_REQUEST_PROCESSING_TIME: Duration = Duration::from_millis(500);
 // Warning threshold for event processing time
-const EVENT_TIME_LAPSE_WARNING: Duration = Duration::from_millis(500);
+const ACCEPTABLE_EVENT_PROCESSING_TIME: Duration = Duration::from_millis(500);
 
 /// # Connectivity Manager
 ///
@@ -196,7 +196,7 @@ impl ConnectivityManagerActor {
                     let task_id = rand::random::<u64>();
                     trace!(target: LOG_TARGET, "Request ({}): {:?}", task_id, req);
                     self.handle_request(req).await;
-                    if timer.elapsed() > REQUEST_TIME_LAPSE_WARNING {
+                    if timer.elapsed() > ACCEPTABLE_CONNECTIVITY_REQUEST_PROCESSING_TIME {
                         warn!(
                             target: LOG_TARGET,
                             "Request ({}) took too long to process: {:.2?}",
@@ -214,7 +214,7 @@ impl ConnectivityManagerActor {
                     if let Err(err) = self.handle_connection_manager_event(&event).await {
                         error!(target:LOG_TARGET, "Error handling connection manager event ({}): {:?}", task_id, err);
                     }
-                    if timer.elapsed() > EVENT_TIME_LAPSE_WARNING {
+                    if timer.elapsed() > ACCEPTABLE_EVENT_PROCESSING_TIME {
                         warn!(
                             target: LOG_TARGET,
                             "Event ({}) took too long to process: {:.2?}",
@@ -470,7 +470,13 @@ impl ConnectivityManagerActor {
                     let len = deleted.len();
                     if len > 0 {
                         for node_id in deleted {
-                            self.pool.remove(&node_id);
+                            if let Some(removed) = self.pool.remove(&node_id) {
+                                warn!(
+                                    target: LOG_TARGET,
+                                    "Stale connection {} encountered - removed",
+                                    removed.peer_node_id()
+                                );
+                            }
                         }
                         debug!(
                             target: LOG_TARGET,

--- a/comms/core/src/connectivity/manager.rs
+++ b/comms/core/src/connectivity/manager.rs
@@ -64,6 +64,8 @@ use crate::{
 
 const LOG_TARGET: &str = "comms::connectivity::manager";
 
+const PEER_DELETE_TIMEOUT: Duration = Duration::from_millis(1000);
+
 /// # Connectivity Manager
 ///
 /// The ConnectivityManager actor is responsible for tracking the state of all peer
@@ -402,12 +404,12 @@ impl ConnectivityManagerActor {
         }
     }
 
-    async fn refresh_connection_pool(&mut self, ticker_id: u64) -> Result<(), ConnectivityError> {
+    async fn refresh_connection_pool(&mut self, task_id: u64) -> Result<(), ConnectivityError> {
         debug!(
             target: LOG_TARGET,
             "Performing connection pool cleanup/refresh ({}). (#Peers = {}, #Connected={}, #Failed={}, #Disconnected={}, \
              #Clients={})",
-            ticker_id,
+            task_id,
             self.pool.count_entries(),
             self.pool.count_connected_nodes(),
             self.pool.count_failed(),
@@ -417,18 +419,46 @@ impl ConnectivityManagerActor {
 
         self.clean_connection_pool();
         if self.config.is_connection_reaping_enabled {
-            self.reap_inactive_connections(ticker_id).await;
+            self.reap_inactive_connections(task_id).await;
         }
         if let Some(threshold) = self.config.maintain_n_closest_connections_only {
-            self.maintain_n_closest_peer_connections_only(threshold, ticker_id)
-                .await;
+            self.maintain_n_closest_peer_connections_only(threshold, task_id).await;
         }
+        self.delete_all_stale_peers_from_db(task_id).await;
         self.update_connectivity_status();
         self.update_connectivity_metrics();
         Ok(())
     }
 
+    async fn delete_all_stale_peers_from_db(&mut self, task_id: u64) {
+        let start = Instant::now();
+        match tokio::time::timeout(PEER_DELETE_TIMEOUT, self.peer_manager.delete_all_stale_peers()).await {
+            Ok(res) => match res {
+                Ok(deleted) => {
+                    let len = deleted.len();
+                    if len > 0 {
+                        for node_id in deleted {
+                            self.pool.remove(&node_id);
+                        }
+                        debug!(
+                            target: LOG_TARGET,
+                            "({}) Deleted {} stale peers from the db in {:.2?}",
+                            task_id, len, start.elapsed()
+                        );
+                    }
+                },
+                Err(err) => {
+                    error!(target: LOG_TARGET, "({}) Error deleting stale peers from the db: {:?}", task_id, err);
+                },
+            },
+            Err(_) => {
+                warn!(target: LOG_TARGET, "({}) Timeout deleting all stale peers from the db", task_id);
+            },
+        }
+    }
+
     async fn maintain_n_closest_peer_connections_only(&mut self, threshold: usize, task_id: u64) {
+        let start = Instant::now();
         // Select all active peer connections (that are communication nodes)
         let mut connections = match self.select_connections(ConnectivitySelection::closest_to(
             self.node_identity.node_id().clone(),
@@ -460,6 +490,7 @@ impl ConnectivityManagerActor {
         );
 
         // Disconnect all remaining peers above the threshold
+        let len = connections.len();
         for conn in connections.iter_mut().skip(threshold) {
             debug!(
                 target: LOG_TARGET,
@@ -483,9 +514,18 @@ impl ConnectivityManagerActor {
                 },
             }
         }
+        if len > 0 {
+            debug!(
+                "minimize_connections: ({}) Minimized {} connections in {:.2?}",
+                task_id,
+                len,
+                start.elapsed()
+            );
+        }
     }
 
     async fn reap_inactive_connections(&mut self, task_id: u64) {
+        let start = Instant::now();
         let excess_connections = self
             .pool
             .count_connected()
@@ -526,8 +566,17 @@ impl ConnectivityManagerActor {
                 },
             }
         }
-        for node_id in nodes_to_remove {
-            self.pool.remove(&node_id);
+        let len = nodes_to_remove.len();
+        if len > 0 {
+            for node_id in nodes_to_remove {
+                self.pool.remove(&node_id);
+            }
+            debug!(
+                "({}) Reaped {} inactive connections in {:.2?}",
+                task_id,
+                len,
+                start.elapsed()
+            );
         }
     }
 

--- a/comms/core/src/peer_manager/manager.rs
+++ b/comms/core/src/peer_manager/manager.rs
@@ -100,9 +100,9 @@ impl PeerManager {
     }
 
     /// Delete all stale peers, removing them from the database and returning their node_ids
-    pub async fn delete_all_stale_peers(&self) -> Result<Vec<NodeId>, PeerManagerError> {
+    pub async fn delete_all_stale_peers(&self, self_node_id: &NodeId) -> Result<Vec<NodeId>, PeerManagerError> {
         let mut lock = self.peer_storage.write().await;
-        let deleted_peers = lock.delete_all_stale_peers()?;
+        let deleted_peers = lock.delete_all_stale_peers(self_node_id)?;
         Ok(deleted_peers)
     }
 

--- a/comms/core/src/peer_manager/manager.rs
+++ b/comms/core/src/peer_manager/manager.rs
@@ -99,6 +99,13 @@ impl PeerManager {
         Ok(())
     }
 
+    /// Delete all stale peers, removing them from the database and returning their node_ids
+    pub async fn delete_all_stale_peers(&self) -> Result<Vec<NodeId>, PeerManagerError> {
+        let mut lock = self.peer_storage.write().await;
+        let deleted_peers = lock.delete_all_stale_peers()?;
+        Ok(deleted_peers)
+    }
+
     /// Performs the given [PeerQuery].
     ///
     /// [PeerQuery]: crate::peer_manager::PeerQuery

--- a/comms/core/src/peer_manager/peer_storage.rs
+++ b/comms/core/src/peer_manager/peer_storage.rs
@@ -48,11 +48,12 @@ use crate::{
 const LOG_TARGET: &str = "comms::peer_manager::peer_storage";
 // The maximum number of peers to return in peer manager
 const PEER_MANAGER_SYNC_PEERS: usize = 100;
-// The maximum amount of time a peer can be inactive before being considered stale (5 days, 24h, 60m, 60s = 5 days)
-const STALE_PEER_THRESHOLD_DURATION: Duration = Duration::from_secs(5 * 24 * 60 * 60);
+// The maximum amount of time a peer can be inactive before being considered stale:
+// ((5 days, 24h, 60m, 60s)/2 = 2.5 days)
+const STALE_PEER_THRESHOLD_DURATION: Duration = Duration::from_secs(5 * 24 * 60 * 60 / 2);
 // Wallet peer connections are not verified in the way node peer connections are, thus a stale wallet connection may be
 // totally valid, just not verified. Any stale wallet peers that are not neighbours will be deleted.
-const NEIGHBOUR_WALLET_PEER_COUNT: usize = 25;
+const MAX_NEIGHBOUR_WALLET_PEER_COUNT: usize = 25;
 
 /// PeerStorage provides a mechanism to keep a datastore and a local copy of all peers in sync and allow fast searches
 /// using the node_id, public key or net_address of a peer.
@@ -384,7 +385,7 @@ where DS: KeyValueStore<PeerId, Peer>
         let query = PeerQuery::new()
             .select_where(|peer| peer.features.is_client())
             .sort_by(PeerQuerySortBy::DistanceFrom(self_node_id))
-            .limit(NEIGHBOUR_WALLET_PEER_COUNT);
+            .limit(MAX_NEIGHBOUR_WALLET_PEER_COUNT);
         let closest_wallet_peers = self.perform_query(query)?;
         wallet_peers.retain(|(_, peer)| !closest_wallet_peers.contains(peer));
         let neighbours_query_time = neighbour_peers_query_time.elapsed();

--- a/comms/core/src/peer_manager/peer_storage.rs
+++ b/comms/core/src/peer_manager/peer_storage.rs
@@ -45,7 +45,7 @@ use crate::{
 const LOG_TARGET: &str = "comms::peer_manager::peer_storage";
 /// The maximum number of peers to return in peer manager
 const PEER_MANAGER_SYNC_PEERS: usize = 100;
-const PEER_ACTIVE_WITHIN_DURATION: u64 = 7 * 24 * 60 * 60; // 7 days, 24h, 60m, 60s = 1 week
+const STALE_PEER_THRESHOLD_DURATION: Duration = Duration::from_secs(5 * 24 * 60 * 60); // 5 days, 24h, 60m, 60s = 5 days
 
 /// PeerStorage provides a mechanism to keep a datastore and a local copy of all peers in sync and allow fast searches
 /// using the node_id, public key or net_address of a peer.
@@ -282,7 +282,7 @@ where DS: KeyValueStore<PeerId, Peer>
     /// Return "good" peers for syncing
     /// Criteria:
     ///  - Peer is not banned
-    ///  - Peer has been seen within a defined time span (1 week)
+    ///  - Peer has been seen within a defined time span (within the threshold)
     ///  - Only returns a maximum number of syncable peers (corresponds with the max possible number of requestable
     ///    peers to sync)
     ///  - Uses 0 as max PEER_MANAGER_SYNC_PEERS
@@ -338,18 +338,19 @@ where DS: KeyValueStore<PeerId, Peer>
 
     /// Delete all stale peers, removing them from the database and returning their node_ids
     /// - Stale Nodes:
-    ///   - A node is considered stale if all its addresses have failed or if it has not been seen for more than 5 days.
+    ///   - A node is considered stale if all its addresses have failed or if it has not been seen for more than the
+    ///     threshold number of days.
     ///   - The node must not be a seed node and be identified as a node (not a client).
     /// - Stale Wallets:
     ///   - A wallet is considered stale if it has never been seen, all its addresses have failed, or it has not been
-    ///     seen for more than 5 days.
+    ///     seen for more than the threshold number of days.
     ///   - The wallet must be identified as a client (not a node).
     pub fn delete_all_stale_peers(&mut self) -> Result<Vec<NodeId>, PeerManagerError> {
         // All stale nodes (except seed nodes)
         let node_peers = self
             .peer_db
             .filter(|(_, peer)| {
-                (peer.all_addresses_failed() || peer.last_seen_since() > Some(Duration::from_secs(5 * 24 * 60 * 60))) &&
+                (peer.all_addresses_failed() || peer.last_seen_since() > Some(STALE_PEER_THRESHOLD_DURATION)) &&
                     peer.features.is_node() &&
                     !peer.is_seed()
             })
@@ -361,7 +362,7 @@ where DS: KeyValueStore<PeerId, Peer>
             .filter(|(_, peer)| {
                 (peer.last_seen().is_none() ||
                     peer.all_addresses_failed() ||
-                    peer.last_seen_since() > Some(Duration::from_secs(5 * 24 * 60 * 60))) &&
+                    peer.last_seen_since() > Some(STALE_PEER_THRESHOLD_DURATION)) &&
                     peer.features.is_client()
             })
             .map(|pairs| pairs.into_iter().collect::<Vec<_>>())
@@ -372,6 +373,13 @@ where DS: KeyValueStore<PeerId, Peer>
             self.peer_db.delete(&peer.0).map_err(PeerManagerError::DatabaseError)?;
             self.remove_index_links(peer.0);
             all_deleted_peers.push(peer.1.node_id.clone());
+        }
+        if !all_deleted_peers.is_empty() {
+            trace!(
+                target: LOG_TARGET,
+                "{} stale node peers and {} stale wallet peers deleted.",
+                node_peers.len(), wallet_peers.len(),
+            );
         }
 
         Ok(all_deleted_peers)
@@ -563,7 +571,7 @@ fn is_active_peer(peer: &Peer, features: Option<PeerFeatures>, excluded_peers: &
         !peer.is_banned() &&
         peer.deleted_at.is_none() &&
         peer.last_seen_since().is_some() &&
-        peer.last_seen_since().expect("Last seen to exist") <= Duration::from_secs(PEER_ACTIVE_WITHIN_DURATION)
+        peer.last_seen_since().expect("Last seen to exist") <= STALE_PEER_THRESHOLD_DURATION
 }
 
 #[cfg(test)]
@@ -893,8 +901,10 @@ mod test {
     #[test]
     fn discovery_syncing_returns_correct_peers() {
         let mut peer_storage = PeerStorage::new_indexed(HashmapDatabase::new()).unwrap();
+
+        // Threshold duration + a minute
         #[allow(clippy::cast_possible_wrap)] // Won't wrap around, numbers are static
-        let a_week_ago = Utc::now().timestamp() - (PEER_ACTIVE_WITHIN_DURATION + 60) as i64; // A week ago + a minute
+        let above_the_threshold = Utc::now().timestamp() - (STALE_PEER_THRESHOLD_DURATION.as_secs() + 60) as i64;
 
         let never_seen_peer = create_test_peer(PeerFeatures::COMMUNICATION_NODE, false);
         let banned_peer = create_test_peer(PeerFeatures::COMMUNICATION_NODE, true);
@@ -902,7 +912,7 @@ mod test {
         let mut not_active_peer = create_test_peer(PeerFeatures::COMMUNICATION_NODE, false);
         let address = not_active_peer.addresses.best().unwrap();
         let mut address = MultiaddrWithStats::new(address.address().clone(), PeerAddressSource::Config);
-        address.mark_last_attempted(DateTime::from_timestamp(a_week_ago, 0).unwrap().naive_utc());
+        address.mark_last_attempted(DateTime::from_timestamp(above_the_threshold, 0).unwrap().naive_utc());
         not_active_peer
             .addresses
             .merge(&MultiaddressesWithStats::from(vec![address]));

--- a/comms/core/src/peer_manager/peer_storage.rs
+++ b/comms/core/src/peer_manager/peer_storage.rs
@@ -345,10 +345,8 @@ where DS: KeyValueStore<PeerId, Peer>
     ///     seen for more than 5 days.
     ///   - The wallet must be identified as a client (not a node).
     pub fn delete_all_stale_peers(&mut self) -> Result<Vec<NodeId>, PeerManagerError> {
-        let mut all_deleted_peers = Vec::new();
-
         // All stale nodes (except seed nodes)
-        let peers = self
+        let node_peers = self
             .peer_db
             .filter(|(_, peer)| {
                 (peer.all_addresses_failed() || peer.last_seen_since() > Some(Duration::from_secs(5 * 24 * 60 * 60))) &&
@@ -357,12 +355,8 @@ where DS: KeyValueStore<PeerId, Peer>
             })
             .map(|pairs| pairs.into_iter().collect::<Vec<_>>())
             .map_err(PeerManagerError::DatabaseError)?;
-        for peer in &peers {
-            self.peer_db.delete(&peer.0).map_err(PeerManagerError::DatabaseError)?;
-            all_deleted_peers.push(peer.1.node_id.clone());
-        }
         // All stale wallets
-        let peers = self
+        let wallet_peers = self
             .peer_db
             .filter(|(_, peer)| {
                 (peer.last_seen().is_none() ||
@@ -372,8 +366,11 @@ where DS: KeyValueStore<PeerId, Peer>
             })
             .map(|pairs| pairs.into_iter().collect::<Vec<_>>())
             .map_err(PeerManagerError::DatabaseError)?;
-        for peer in &peers {
+        // Remove
+        let mut all_deleted_peers = Vec::new();
+        for peer in node_peers.iter().chain(wallet_peers.iter()) {
             self.peer_db.delete(&peer.0).map_err(PeerManagerError::DatabaseError)?;
+            self.remove_index_links(peer.0);
             all_deleted_peers.push(peer.1.node_id.clone());
         }
 

--- a/comms/core/src/peer_manager/peer_storage.rs
+++ b/comms/core/src/peer_manager/peer_storage.rs
@@ -35,7 +35,6 @@ use crate::{
         NodeDistance,
         NodeId,
         PeerFeatures,
-        PeerFlags,
         PeerManagerError,
         PeerQuery,
         PeerQuerySortBy,
@@ -346,21 +345,21 @@ where DS: KeyValueStore<PeerId, Peer>
     ///     seen for more than 5 days.
     ///   - The wallet must be identified as a client (not a node).
     pub fn delete_all_stale_peers(&mut self) -> Result<Vec<NodeId>, PeerManagerError> {
-+    let mut all_deleted_peers = Vec::new();
-+
+        let mut all_deleted_peers = Vec::new();
+
         // All stale nodes (except seed nodes)
         let peers = self
             .peer_db
             .filter(|(_, peer)| {
                 (peer.all_addresses_failed() || peer.last_seen_since() > Some(Duration::from_secs(5 * 24 * 60 * 60))) &&
                     peer.features.is_node() &&
-                    peer.flags.contains(PeerFlags::NONE)
+                    !peer.is_seed()
             })
             .map(|pairs| pairs.into_iter().collect::<Vec<_>>())
             .map_err(PeerManagerError::DatabaseError)?;
         for peer in &peers {
             self.peer_db.delete(&peer.0).map_err(PeerManagerError::DatabaseError)?;
-+        all_deleted_peers.push(peer.1.node_id.clone());
+            all_deleted_peers.push(peer.1.node_id.clone());
         }
         // All stale wallets
         let peers = self
@@ -375,11 +374,10 @@ where DS: KeyValueStore<PeerId, Peer>
             .map_err(PeerManagerError::DatabaseError)?;
         for peer in &peers {
             self.peer_db.delete(&peer.0).map_err(PeerManagerError::DatabaseError)?;
-+        all_deleted_peers.push(peer.1.node_id.clone());
+            all_deleted_peers.push(peer.1.node_id.clone());
         }
-    
--    Ok(peers.iter().map(|p| p.1.node_id.clone()).collect())
-+    Ok(all_deleted_peers)
+
+        Ok(all_deleted_peers)
     }
 
     /// Compile a random list of communication node peers of size _n_ that are not banned or offline

--- a/comms/core/src/peer_manager/peer_storage.rs
+++ b/comms/core/src/peer_manager/peer_storage.rs
@@ -46,10 +46,13 @@ use crate::{
 };
 
 const LOG_TARGET: &str = "comms::peer_manager::peer_storage";
-/// The maximum number of peers to return in peer manager
+// The maximum number of peers to return in peer manager
 const PEER_MANAGER_SYNC_PEERS: usize = 100;
-const STALE_PEER_THRESHOLD_DURATION: Duration = Duration::from_secs(5 * 24 * 60 * 60); // 5 days, 24h, 60m, 60s = 5 days
-const NEIGHBOUR_WALLET_PEER_COUNT: usize = 8;
+// The maximum amount of time a peer can be inactive before being considered stale (5 days, 24h, 60m, 60s = 5 days)
+const STALE_PEER_THRESHOLD_DURATION: Duration = Duration::from_secs(5 * 24 * 60 * 60);
+// Wallet peer connections are not verified in the way node peer connections are, thus a stale wallet connection may be
+// totally valid, just not verified. Any stale wallet peers that are not neighbours will be deleted.
+const NEIGHBOUR_WALLET_PEER_COUNT: usize = 25;
 
 /// PeerStorage provides a mechanism to keep a datastore and a local copy of all peers in sync and allow fast searches
 /// using the node_id, public key or net_address of a peer.

--- a/comms/core/src/peer_manager/peer_storage.rs
+++ b/comms/core/src/peer_manager/peer_storage.rs
@@ -35,6 +35,7 @@ use crate::{
         NodeDistance,
         NodeId,
         PeerFeatures,
+        PeerFlags,
         PeerManagerError,
         PeerQuery,
         PeerQuerySortBy,
@@ -334,6 +335,46 @@ where DS: KeyValueStore<PeerId, Peer>
             .limit(n);
 
         self.perform_query(query)
+    }
+
+    /// Delete all stale peers, removing them from the database and returning their node_ids
+    /// - Stale Nodes:
+    ///   - A node is considered stale if all its addresses have failed or if it has not been seen for more than 5 days.
+    ///   - The node must not be a seed node and be identified as a node (not a client).
+    /// - Stale Wallets:
+    ///   - A wallet is considered stale if it has never been seen, all its addresses have failed, or it has not been
+    ///     seen for more than 5 days.
+    ///   - The wallet must be identified as a client (not a node).
+    pub fn delete_all_stale_peers(&mut self) -> Result<Vec<NodeId>, PeerManagerError> {
+        // All stale nodes (except seed nodes)
+        let peers = self
+            .peer_db
+            .filter(|(_, peer)| {
+                (peer.all_addresses_failed() || peer.last_seen_since() > Some(Duration::from_secs(5 * 24 * 60 * 60))) &&
+                    peer.features.is_node() &&
+                    peer.flags.contains(PeerFlags::NONE)
+            })
+            .map(|pairs| pairs.into_iter().collect::<Vec<_>>())
+            .map_err(PeerManagerError::DatabaseError)?;
+        for peer in &peers {
+            self.peer_db.delete(&peer.0).map_err(PeerManagerError::DatabaseError)?;
+        }
+        // All stale wallets
+        let peers = self
+            .peer_db
+            .filter(|(_, peer)| {
+                (peer.last_seen().is_none() ||
+                    peer.all_addresses_failed() ||
+                    peer.last_seen_since() > Some(Duration::from_secs(5 * 24 * 60 * 60))) &&
+                    peer.features.is_client()
+            })
+            .map(|pairs| pairs.into_iter().collect::<Vec<_>>())
+            .map_err(PeerManagerError::DatabaseError)?;
+        for peer in &peers {
+            self.peer_db.delete(&peer.0).map_err(PeerManagerError::DatabaseError)?;
+        }
+
+        Ok(peers.iter().map(|p| p.1.node_id.clone()).collect())
     }
 
     /// Compile a random list of communication node peers of size _n_ that are not banned or offline

--- a/comms/core/src/peer_manager/peer_storage.rs
+++ b/comms/core/src/peer_manager/peer_storage.rs
@@ -20,7 +20,10 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{collections::HashMap, time::Duration};
+use std::{
+    collections::HashMap,
+    time::{Duration, Instant},
+};
 
 use chrono::Utc;
 use log::*;
@@ -349,6 +352,7 @@ where DS: KeyValueStore<PeerId, Peer>
     ///   - Wallets that are considered neighbours should not be deleted.
     pub fn delete_all_stale_peers(&mut self, self_node_id: &NodeId) -> Result<Vec<NodeId>, PeerManagerError> {
         // All stale nodes (except seed nodes)
+        let nodes_query_time = Instant::now();
         let node_peers = self
             .peer_db
             .filter(|(_, peer)| {
@@ -358,7 +362,9 @@ where DS: KeyValueStore<PeerId, Peer>
             })
             .map(|pairs| pairs.into_iter().collect::<Vec<_>>())
             .map_err(PeerManagerError::DatabaseError)?;
+        let nodes_query_time = nodes_query_time.elapsed();
         // All stale wallets
+        let wallets_query_time = Instant::now();
         let mut wallet_peers = self
             .peer_db
             .filter(|(_, peer)| {
@@ -369,25 +375,46 @@ where DS: KeyValueStore<PeerId, Peer>
             })
             .map(|pairs| pairs.into_iter().collect::<Vec<_>>())
             .map_err(PeerManagerError::DatabaseError)?;
+        let wallets_query_time = wallets_query_time.elapsed();
         // Stale wallet peers that are considered neighbours should not be deleted
+        let neighbour_peers_query_time = Instant::now();
         let query = PeerQuery::new()
             .select_where(|peer| peer.features.is_client())
             .sort_by(PeerQuerySortBy::DistanceFrom(self_node_id))
             .limit(NEIGHBOUR_WALLET_PEER_COUNT);
         let closest_wallet_peers = self.perform_query(query)?;
         wallet_peers.retain(|(_, peer)| !closest_wallet_peers.contains(peer));
+        let neighbours_query_time = neighbour_peers_query_time.elapsed();
         // Remove
+        let delete_peers_time = Instant::now();
         let mut all_deleted_peers = Vec::new();
         for peer in node_peers.iter().chain(wallet_peers.iter()) {
             self.peer_db.delete(&peer.0).map_err(PeerManagerError::DatabaseError)?;
             self.remove_index_links(peer.0);
             all_deleted_peers.push(peer.1.node_id.clone());
         }
-        if !all_deleted_peers.is_empty() {
+        let delete_peers_time = delete_peers_time.elapsed();
+        if all_deleted_peers.is_empty() {
             trace!(
                 target: LOG_TARGET,
-                "{} stale node peers and {} stale wallet peers deleted.",
-                node_peers.len(), wallet_peers.len(),
+                "node peers (query: {:.2?}), stale wallet peers (query: {:.2?} + {:.2?}) - {:.2?} total time.",
+                nodes_query_time,
+                wallets_query_time,
+                neighbours_query_time,
+                nodes_query_time + wallets_query_time + neighbours_query_time + delete_peers_time,
+            );
+        } else {
+            trace!(
+                target: LOG_TARGET,
+                "{} stale node peers (query: {:.2?}), {} stale wallet peers (query: {:.2?} + {:.2?}), deleted ({:.2?}) \
+                - {:.2?} total time.",
+                node_peers.len(),
+                nodes_query_time,
+                wallet_peers.len(),
+                wallets_query_time,
+                neighbours_query_time,
+                delete_peers_time,
+                nodes_query_time + wallets_query_time + neighbours_query_time + delete_peers_time,
             );
         }
 

--- a/comms/core/src/peer_manager/peer_storage.rs
+++ b/comms/core/src/peer_manager/peer_storage.rs
@@ -46,6 +46,7 @@ const LOG_TARGET: &str = "comms::peer_manager::peer_storage";
 /// The maximum number of peers to return in peer manager
 const PEER_MANAGER_SYNC_PEERS: usize = 100;
 const STALE_PEER_THRESHOLD_DURATION: Duration = Duration::from_secs(5 * 24 * 60 * 60); // 5 days, 24h, 60m, 60s = 5 days
+const NEIGHBOUR_WALLET_PEER_COUNT: usize = 8;
 
 /// PeerStorage provides a mechanism to keep a datastore and a local copy of all peers in sync and allow fast searches
 /// using the node_id, public key or net_address of a peer.
@@ -345,7 +346,8 @@ where DS: KeyValueStore<PeerId, Peer>
     ///   - A wallet is considered stale if it has never been seen, all its addresses have failed, or it has not been
     ///     seen for more than the threshold number of days.
     ///   - The wallet must be identified as a client (not a node).
-    pub fn delete_all_stale_peers(&mut self) -> Result<Vec<NodeId>, PeerManagerError> {
+    ///   - Wallets that are considered neighbours should not be deleted.
+    pub fn delete_all_stale_peers(&mut self, self_node_id: &NodeId) -> Result<Vec<NodeId>, PeerManagerError> {
         // All stale nodes (except seed nodes)
         let node_peers = self
             .peer_db
@@ -357,7 +359,7 @@ where DS: KeyValueStore<PeerId, Peer>
             .map(|pairs| pairs.into_iter().collect::<Vec<_>>())
             .map_err(PeerManagerError::DatabaseError)?;
         // All stale wallets
-        let wallet_peers = self
+        let mut wallet_peers = self
             .peer_db
             .filter(|(_, peer)| {
                 (peer.last_seen().is_none() ||
@@ -367,6 +369,13 @@ where DS: KeyValueStore<PeerId, Peer>
             })
             .map(|pairs| pairs.into_iter().collect::<Vec<_>>())
             .map_err(PeerManagerError::DatabaseError)?;
+        // Stale wallet peers that are considered neighbours should not be deleted
+        let query = PeerQuery::new()
+            .select_where(|peer| peer.features.is_client())
+            .sort_by(PeerQuerySortBy::DistanceFrom(self_node_id))
+            .limit(NEIGHBOUR_WALLET_PEER_COUNT);
+        let closest_wallet_peers = self.perform_query(query)?;
+        wallet_peers.retain(|(_, peer)| !closest_wallet_peers.contains(peer));
         // Remove
         let mut all_deleted_peers = Vec::new();
         for peer in node_peers.iter().chain(wallet_peers.iter()) {

--- a/comms/core/src/peer_manager/peer_storage.rs
+++ b/comms/core/src/peer_manager/peer_storage.rs
@@ -346,6 +346,8 @@ where DS: KeyValueStore<PeerId, Peer>
     ///     seen for more than 5 days.
     ///   - The wallet must be identified as a client (not a node).
     pub fn delete_all_stale_peers(&mut self) -> Result<Vec<NodeId>, PeerManagerError> {
++    let mut all_deleted_peers = Vec::new();
++
         // All stale nodes (except seed nodes)
         let peers = self
             .peer_db
@@ -358,6 +360,7 @@ where DS: KeyValueStore<PeerId, Peer>
             .map_err(PeerManagerError::DatabaseError)?;
         for peer in &peers {
             self.peer_db.delete(&peer.0).map_err(PeerManagerError::DatabaseError)?;
++        all_deleted_peers.push(peer.1.node_id.clone());
         }
         // All stale wallets
         let peers = self
@@ -372,9 +375,11 @@ where DS: KeyValueStore<PeerId, Peer>
             .map_err(PeerManagerError::DatabaseError)?;
         for peer in &peers {
             self.peer_db.delete(&peer.0).map_err(PeerManagerError::DatabaseError)?;
++        all_deleted_peers.push(peer.1.node_id.clone());
         }
-
-        Ok(peers.iter().map(|p| p.1.node_id.clone()).collect())
+    
+-    Ok(peers.iter().map(|p| p.1.node_id.clone()).collect())
++    Ok(all_deleted_peers)
     }
 
     /// Compile a random list of communication node peers of size _n_ that are not banned or offline


### PR DESCRIPTION
Description
---
Delete all stale peers from the peer database:
- Stale Nodes:
  - A node is considered stale if all its addresses have failed or not been seen for more than 5 days.
  - The node must not be a seed node and be identified as a node (not a client).
- Stale Wallets:
  - A wallet is considered stale if it has never been seen, all its addresses have failed, or it has not been seen for more than 5 days.
 - The wallet must be identified as a client (not a node).

Motivation and Context
---
The peer database is growing unwieldy with peer identities that can be created for free and it gets filled up with stale data; this impacts performance. 

How Has This Been Tested?
---
Performed system-level testing.

These peers are in the process of being filtered and removed for a nextnet seed node:

[list_peers_base_node.log](https://github.com/user-attachments/files/19634367/list_peers_base_node.log)
[list_peers_wallet.log](https://github.com/user-attachments/files/19634368/list_peers_wallet.log)

What process can a PR reviewer use to test or verify this change?

---
Code review
System-level testing.

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced an automatic cleanup mechanism for outdated network peers, helping maintain a more stable and reliable connection environment.
	- Added a timeout mechanism for deleting stale peers from the database.
	- Enhanced logging in connection maintenance now provides better visibility into connection performance, contributing to improved network responsiveness.
	- Implemented a method to identify and remove stale wallets from the database, further improving peer management.
	- Updated criteria for determining stale peers to enhance accuracy in peer management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->