### PR TITLE
chore: replace txtm

### DIFF
--- a/applications/minotari_node/windows/README.md
+++ b/applications/minotari_node/windows/README.md
@@ -125,7 +125,7 @@ depending on the choices you make when prompted:
 
 - To delete log files, delete the `.\log` folder.
 - To re-sync the blockchain, delete the `.\stibbons` folder.
-- To destroy your wallet and loose all your hard-earned tXTR Tari coins, delete
+- To destroy your wallet and loose all your hard-earned XTM Tari coins, delete
   the `.\wallet` folder.
 
 ## Manual Installation

--- a/base_layer/core/src/consensus/consensus_constants.rs
+++ b/base_layer/core/src/consensus/consensus_constants.rs
@@ -478,7 +478,7 @@ impl ConsensusConstants {
     /// *
     /// Esmeralda testnet has the following characteristics:
     /// * 2 min blocks on average (5 min SHA-3, 3 min MM)
-    /// * 21 billion tXTR with a 2.76-year half-life
+    /// * 21 billion tXTM with a 2.76-year half-life
     /// * 800 T tail emission (± 1% inflation after initial 21 billion has been mined)
     /// * Coinbase lock height - 12 hours = 360 blocks
     pub fn esmeralda() -> Vec<Self> {
@@ -535,7 +535,7 @@ impl ConsensusConstants {
     /// *
     /// Stagenet has the following characteristics:
     /// * 2 min blocks on average (5 min SHA-3, 3 min MM)
-    /// * 21 billion tXTR with a 3-year half-life
+    /// * 21 billion tXTM with a 3-year half-life
     /// * 800 T tail emission (± 1% inflation after initial 21 billion has been mined)
     /// * Coinbase lock height - 12 hours = 360 blocks
     pub fn stagenet() -> Vec<Self> {


### PR DESCRIPTION
Description
---
replace mentions of txtm/txtr with XTM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the cryptocurrency naming in the wallet guide to "XTM Tari coins" for improved clarity.
	- Revised testnet documentation to consistently reflect the updated token terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

fixes: #6927 