### PR TITLE
chore: upgrade deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4701,9 +4701,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.70"
+version = "0.10.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61cfb4e166a8bb8c9b55c500bc2308550148ece889be90f609377e58140f42c6"
+checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if",
@@ -4742,9 +4742,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.105"
+version = "0.9.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b22d5b84be05a8d6947c7cb71f7c849aa0f112acd4bf51c2a7c1c988ac0a9dc"
+checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
 dependencies = [
  "cc",
  "libc",
@@ -7722,9 +7722,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.42.0"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes 1.9.0",
@@ -7750,9 +7750,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/applications/minotari_app_grpc/Cargo.toml
+++ b/applications/minotari_app_grpc/Cargo.toml
@@ -27,7 +27,7 @@ rand = "0.8"
 rcgen = "0.12.1"
 subtle = "2.5.0"
 thiserror = "1"
-tokio = { version = "1.36", features = ["fs"] }
+tokio = { version = "1.42", features = ["fs"] }
 tonic = { version = "0.12.3", features = ["tls"] }
 zeroize = "1"
 

--- a/applications/minotari_app_utilities/Cargo.toml
+++ b/applications/minotari_app_utilities/Cargo.toml
@@ -20,7 +20,7 @@ futures = { version = "^0.3.16", default-features = false, features = [
 json5 = "0.4"
 log = { version = "0.4.8", features = ["std"] }
 rand = "0.8"
-tokio = { version = "1.36", features = ["signal"] }
+tokio = { version = "1.42", features = ["signal"] }
 serde = "1.0.126"
 thiserror = "^1.0.26"
 dialoguer = { version = "0.10" }

--- a/applications/minotari_console_wallet/Cargo.toml
+++ b/applications/minotari_console_wallet/Cargo.toml
@@ -31,7 +31,7 @@ tari_hashing = { workspace = true }
 console-subscriber = "0.1.8"
 #tokio = { version = "1.36", features = ["signal", "tracing"] }
 # Uncomment for normal use (non tokio-console tracing)
-tokio = { version = "1.36", features = ["signal"] }
+tokio = { version = "1.42", features = ["signal"] }
 
 blake2 = "0.10"
 chrono = { version = "0.4.39", default-features = false }

--- a/applications/minotari_merge_mining_proxy/Cargo.toml
+++ b/applications/minotari_merge_mining_proxy/Cargo.toml
@@ -45,7 +45,7 @@ reqwest = { version = "0.11.4", features = ["json"] }
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.57"
 thiserror = "1.0.26"
-tokio = { version = "1.36", features = ["macros"] }
+tokio = { version = "1.42", features = ["macros"] }
 url = "2.1.1"
 scraper = "0.19.0"
 rand = "0.8"

--- a/applications/minotari_miner/Cargo.toml
+++ b/applications/minotari_miner/Cargo.toml
@@ -45,7 +45,7 @@ rand = "0.8"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = "1.0.57"
 thiserror = "1.0"
-tokio = { version = "1.36", default-features = false, features = [
+tokio = { version = "1.42", default-features = false, features = [
     "rt-multi-thread",
 ] }
 tonic = { version = "0.12.3", features = ["tls", "tls-roots"] }

--- a/applications/minotari_node/Cargo.toml
+++ b/applications/minotari_node/Cargo.toml
@@ -62,7 +62,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 strum = { version = "0.22", features = ["derive"] }
 thiserror = "^1.0.26"
-tokio = { version = "1.36", features = ["signal"] }
+tokio = { version = "1.42", features = ["signal"] }
 tonic = { version = "0.12.3", features = ["tls", "tls-roots"] }
 tari_metrics = { workspace = true, optional = true, features = ["server"] }
 

--- a/base_layer/chat_ffi/Cargo.toml
+++ b/base_layer/chat_ffi/Cargo.toml
@@ -26,10 +26,10 @@ log4rs = { version = "1.3.0", features = [
     "yaml_format",
 ] }
 thiserror = "1.0.26"
-tokio = "1.23"
+tokio = "1.42"
 
 [target.'cfg(target_os="android")'.dependencies]
-openssl = { version = "0.10.70", features = ["vendored"] }
+openssl = { version = "0.10.72", features = ["vendored"] }
 
 [lib]
 crate-type = ["staticlib", "cdylib"]

--- a/base_layer/contacts/Cargo.toml
+++ b/base_layer/contacts/Cargo.toml
@@ -37,7 +37,7 @@ rand = "0.8"
 serde = "1.0.136"
 serde_json = "1.0.79"
 thiserror = "1.0.26"
-tokio = { version = "1.36", features = ["sync", "macros"] }
+tokio = { version = "1.42", features = ["sync", "macros"] }
 tower = "0.4"
 uuid = { version = "1.3", features = ["v4"] }
 

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -88,7 +88,7 @@ sha2 = "0.10"
 strum = "0.22"
 strum_macros = "0.22"
 thiserror = "1.0.26"
-tokio = { version = "1.36", features = ["time", "sync", "macros"] }
+tokio = { version = "1.42", features = ["time", "sync", "macros"] }
 tracing = "0.1.26"
 zeroize = "1"
 primitive-types = { version = "0.12", features = ["serde"] }

--- a/base_layer/key_manager/Cargo.toml
+++ b/base_layer/key_manager/Cargo.toml
@@ -20,7 +20,7 @@ tari_service_framework = { workspace = true }
 async-trait = { version = "0.1.50" }
 chrono = { version = "0.4.39", default-features = false, features = ["serde"] }
 chacha20poly1305 = "0.10.1"
-tokio = { version = "1.36", features = ["sync", "macros"] }
+tokio = { version = "1.42", features = ["sync", "macros"] }
 futures = { version = "^0.3.1", features = ["compat", "std"] }
 log = { version = "0.4.6" }
 diesel = { version = "2.2.4", features = [

--- a/base_layer/p2p/Cargo.toml
+++ b/base_layer/p2p/Cargo.toml
@@ -29,7 +29,7 @@ reqwest = { version = "0.11", optional = true, default-features = false }
 semver = { version = "1.0.1", optional = true }
 serde = "1.0.90"
 thiserror = "1.0.26"
-tokio = { version = "1.36", features = ["macros"] }
+tokio = { version = "1.42", features = ["macros"] }
 tokio-stream = { version = "0.1.9", default-features = false, features = [
     "time",
 ] }

--- a/base_layer/service_framework/Cargo.toml
+++ b/base_layer/service_framework/Cargo.toml
@@ -17,12 +17,12 @@ async-trait = "0.1.50"
 futures = { version = "^0.3.16", features = ["async-await"] }
 log = "0.4.8"
 thiserror = "1.0.26"
-tokio = { version = "1.36", features = ["rt", "sync"] }
+tokio = { version = "1.42", features = ["rt", "sync"] }
 tower-service = { version = "0.3" }
 
 [dev-dependencies]
 tari_test_utils = { workspace = true }
 
-tokio = { version = "1.36", features = ["rt-multi-thread", "macros", "time"] }
+tokio = { version = "1.42", features = ["rt-multi-thread", "macros", "time"] }
 futures-test = { version = "0.3.3" }
 tower = "0.4"

--- a/base_layer/tari_mining_helper_ffi/Cargo.toml
+++ b/base_layer/tari_mining_helper_ffi/Cargo.toml
@@ -21,7 +21,7 @@ tari_utilities = { workspace = true }
 libc = "0.2.65"
 thiserror = "1.0.26"
 borsh = "1.5"
-tokio = { version = "1.36", features = ["rt"] }
+tokio = { version = "1.42", features = ["rt"] }
 
 [dev-dependencies]
 tari_core = { workspace = true, features = ["transactions", "base_node"] }

--- a/base_layer/wallet/Cargo.toml
+++ b/base_layer/wallet/Cargo.toml
@@ -32,7 +32,7 @@ tari_utilities = { workspace = true }
 #console-subscriber = "0.1.3"
 #tokio = { version = "1.36", features = ["sync", "macros", "tracing"] }
 # Uncomment for normal use (non tokio-console tracing)
-tokio = { version = "1.36", features = ["sync", "macros"] }
+tokio = { version = "1.42", features = ["sync", "macros"] }
 
 async-trait = "0.1.50"
 argon2 = "0.4.1"

--- a/base_layer/wallet_ffi/Cargo.toml
+++ b/base_layer/wallet_ffi/Cargo.toml
@@ -37,14 +37,14 @@ log4rs = { version = "1.3.0", features = [
 ] }
 rand = "0.8"
 thiserror = "1.0.26"
-tokio = "1.23"
+tokio = "1.42"
 num-traits = "0.2.15"
 itertools = "0.10.3"
 zeroize = "1"
 serde_json = "1.0"
 
 [target.'cfg(target_os="android")'.dependencies]
-openssl = { version = "0.10.70", features = ["vendored"] }
+openssl = { version = "0.10.72", features = ["vendored"] }
 
 [lib]
 crate-type = ["staticlib", "cdylib"]

--- a/common_sqlite/Cargo.toml
+++ b/common_sqlite/Cargo.toml
@@ -21,7 +21,7 @@ diesel_migrations = "2.2"
 log = "0.4.6"
 serde = "1.0.90"
 thiserror = "1.0.26"
-tokio = { version = "1.36", features = ["sync", "macros", "rt"] }
+tokio = { version = "1.42", features = ["sync", "macros", "rt"] }
 
 [dev-dependencies]
 tari_test_utils = { workspace = true }

--- a/comms/core/Cargo.toml
+++ b/comms/core/Cargo.toml
@@ -42,7 +42,7 @@ serde_derive = "1.0.119"
 sha3 = "0.10"
 snow = { version = "0.9.5", features = ["default-resolver"] }
 thiserror = "1.0.26"
-tokio = { version = "1.36", features = [
+tokio = { version = "1.42", features = [
     "rt-multi-thread",
     "time",
     "sync",

--- a/comms/dht/Cargo.toml
+++ b/comms/dht/Cargo.toml
@@ -45,7 +45,7 @@ zeroize = "1"
 #console-subscriber = "0.1.3"
 #tokio = { version = "1.36", features = ["rt", "macros", "tracing"] }
 # Uncomment for normal use (non tokio-console tracing)
-tokio = { version = "1.36", features = ["rt", "macros"] }
+tokio = { version = "1.43", features = ["rt", "macros"] }
 
 # tower-filter dependencies
 pin-project = "0.4"

--- a/infrastructure/test_utils/Cargo.toml
+++ b/infrastructure/test_utils/Cargo.toml
@@ -14,7 +14,7 @@ tari_comms = { workspace = true }
 
 futures = { version = "^0.3.1" }
 rand = "0.8"
-tokio = { version = "1.36", features = ["rt-multi-thread", "time", "sync"] }
+tokio = { version = "1.42", features = ["rt-multi-thread", "time", "sync"] }
 tempfile = "3.1.0"
 
 [dev-dependencies]

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -47,7 +47,7 @@ serde_json = "1.0.64"
 tempfile = "3.3.0"
 thiserror = "^1.0.20"
 time = "0.3.36"
-tokio = { version = "1.36", features = ["macros", "time", "sync", "rt-multi-thread"] }
+tokio = { version = "1.42", features = ["macros", "time", "sync", "rt-multi-thread"] }
 tonic = "0.12.3"
 
 [package.metadata.cargo-machete]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -1383,6 +1383,10 @@ criteria = "safe-to-deploy"
 version = "0.9.105"
 criteria = "safe-to-deploy"
 
+[[exemptions.openssl-sys]]
+version = "0.9.107"
+criteria = "safe-to-deploy"
+
 [[exemptions.ordered-float]]
 version = "2.10.1"
 criteria = "safe-to-deploy"
@@ -2169,6 +2173,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.tokio]]
 version = "1.42.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.tokio]]
+version = "1.44.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.tokio-io-timeout]]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -2176,6 +2176,10 @@ version = "1.42.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.tokio]]
+version = "1.43.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.tokio]]
 version = "1.44.2"
 criteria = "safe-to-deploy"
 
@@ -2185,6 +2189,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.tokio-macros]]
 version = "2.4.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.tokio-macros]]
+version = "2.5.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.tokio-rustls]]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -1372,7 +1372,7 @@ version = "1.20.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.openssl]]
-version = "0.10.70"
+version = "0.10.72"
 criteria = "safe-to-deploy"
 
 [[exemptions.openssl-src]]
@@ -2168,7 +2168,7 @@ version = "2.0.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.tokio]]
-version = "1.42.0"
+version = "1.42.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.tokio-io-timeout]]


### PR DESCRIPTION
upgrade openssl and tokio

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Upgraded the asynchronous runtime library across multiple components to version 1.42 for improved performance and stability.
  - Updated cryptographic libraries to enhance security and reliability, including updates to OpenSSL.
  - Refined configuration settings to ensure consistency with these dependency enhancements. 
  - Introduced new versions for `tokio` and `openssl` dependencies in the configuration file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->