### PR TITLE
feat: upgrade min fee

### DIFF
--- a/base_layer/core/src/mempool/unconfirmed_pool/unconfirmed_pool.rs
+++ b/base_layer/core/src/mempool/unconfirmed_pool/unconfirmed_pool.rs
@@ -68,7 +68,7 @@ impl Default for UnconfirmedPoolConfig {
         Self {
             storage_capacity: 40_000,
             weight_tx_skip_count: 20,
-            min_fee: 0,
+            min_fee: 50,
         }
     }
 }

--- a/common/config/presets/c_base_node_c.toml
+++ b/common/config/presets/c_base_node_c.toml
@@ -72,7 +72,7 @@ track_reorgs = true
 # skipping over large transactions are performed in an attempt to fit more transactions into the remaining space.
 #unconfirmed_pool.weight_tx_skip_count = 20
 # The minimum fee accepted by the mempool
-#unconfirmed_pool.min_fee = 0,
+#unconfirmed_pool.min_fee = 50,
 
 # The height horizon to clear transactions from the reorg pool.
 #reorg_pool.expiry_height = 5


### PR DESCRIPTION
upgrades the min fee from 0 to 50uT

fixes: #6890 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The default minimum fee for transaction inclusion has been increased from 0 to 50. This update ensures that only transactions meeting the enhanced fee threshold will be accepted, potentially improving transaction prioritization and network efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->