### PR TITLE
feat: change default random/dht split

### DIFF
--- a/common/config/presets/c_base_node_c.toml
+++ b/common/config/presets/c_base_node_c.toml
@@ -225,9 +225,9 @@ database_url = "data/base_node/dht.db"
 # The size of the buffer (channel) which holds pending outbound message requests. Default: 20
 #outbound_buffer_size = 20
 # The maximum number of peer nodes that a message has to be closer to, to be considered a neighbour. Default: 8
-#num_neighbouring_nodes = 8
+#num_neighbouring_nodes = 6
 # Number of random peers to include. Default: 4
-#num_random_nodes = 4
+#num_random_nodes = 6
 # Connections above the configured number of neighbouring and random nodes will be removed (default: false)
 #minimize_connections = false
 # Send to this many peers when using the broadcast strategy. Default: 8

--- a/comms/dht/src/config.rs
+++ b/comms/dht/src/config.rs
@@ -166,8 +166,8 @@ impl Default for DhtConfig {
         // NB: please remember to update field comments to reflect these defaults
         Self {
             protocol_version: DhtProtocolVersion::latest(),
-            num_neighbouring_nodes: 8,
-            num_random_nodes: 4,
+            num_neighbouring_nodes: 6,
+            num_random_nodes: 6,
             minimize_connections: false,
             propagation_factor: 20,
             broadcast_factor: 8,


### PR DESCRIPTION
Description
---
change default random dht peer selection split

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Adjusted network configuration parameters to fine-tune peer connectivity. The number of primary neighbor connections has been reduced while the pool of random peers has been expanded, potentially enhancing network resilience and message routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->