### PR TITLE
fix: fix crossterm compile for windows

### DIFF
--- a/applications/minotari_node/Cargo.toml
+++ b/applications/minotari_node/Cargo.toml
@@ -37,6 +37,7 @@ crossterm = { version = "0.28.1", default-features = false, features = [
     # we do not need libc feature however 0.28.1 has a bug that requires it
     # https://github.com/crossterm-rs/crossterm/issues/935
     "libc",
+    "windows",
 ] }
 derive_more = "0.99.17"
 either = "1.6.1"


### PR DESCRIPTION
Description
---
Fix crossterm compile for Windows

Motivation and Context
---
If default features are disabled, `windows` has to be added explicitly back into the selected features,

```
error: Compiling on Windows with "windows" feature disabled. Feature "windows" should only be disabled when project will never be compiled on Windows.
   --> C:\Users\pluto\.cargo\registry\src\index.crates.io-6f17d22bba15001f\crossterm-0.28.1\src/lib.rs:254:1
    |
254 | compile_error!("Compiling on Windows with \"windows\" feature disabled. Feature \"windows\" should only be disabled when project will never be compiled on Windows.");
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

How Has This Been Tested?
---
Compile test

What process can a PR reviewer use to test or verify this change?
---
Code review

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced terminal functionality for Windows, improving the user experience on that platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->