### PR TITLE
feat:  peer health check

### DIFF
--- a/applications/minotari_app_grpc/proto/base_node.proto
+++ b/applications/minotari_app_grpc/proto/base_node.proto
@@ -542,6 +542,16 @@ message GetNetworkStateResponse {
     uint64 randomx_estimated_hash_rate = 7;
     // number of connections
     uint64 num_connections = 8;
+    //liveness results
+    repeated LivenessResult liveness_results = 9;
+}
 
+message LivenessResult{
+    // node id
+    bytes peer_node_id = 1;
+    // time to discover
+    uint64 discover_latency = 2;
+    // Dial latency
+    uint64 dial_latency = 3;
 }
 

--- a/applications/minotari_app_grpc/proto/base_node.proto
+++ b/applications/minotari_app_grpc/proto/base_node.proto
@@ -552,6 +552,6 @@ message LivenessResult{
     // time to discover
     uint64 discover_latency = 2;
     // Dial latency
-    uint64 dial_latency = 3;
+    uint64 ping_latency = 3;
 }
 

--- a/applications/minotari_node/src/bootstrap.rs
+++ b/applications/minotari_node/src/bootstrap.rs
@@ -172,6 +172,7 @@ where B: BlockchainBackend + 'static
             ))
             .add_initializer(TariPulseServiceInitializer::new(
                 base_node_config.tari_pulse_interval,
+                base_node_config.tari_pulse_health_check,
                 base_node_config.network,
             ))
             .build()

--- a/applications/minotari_node/src/config.rs
+++ b/applications/minotari_node/src/config.rs
@@ -144,7 +144,9 @@ pub struct BaseNodeConfig {
     pub report_grpc_error: bool,
     // Interval to check if the base node is still in sync with the network
     #[serde(with = "serializers::seconds")]
-    pub tari_pulse_interval: Duration,
+    pub tari_pulse_interval: Duration,// Interval to check if the base node is still in sync with the network
+    #[serde(with = "serializers::seconds")]
+    pub tari_pulse_health_check: Duration,
 }
 
 impl Default for BaseNodeConfig {
@@ -184,6 +186,7 @@ impl Default for BaseNodeConfig {
             state_machine: Default::default(),
             report_grpc_error: false,
             tari_pulse_interval: Duration::from_secs(120),
+            tari_pulse_health_check: Duration::from_secs(60 * 10),
         }
     }
 }

--- a/applications/minotari_node/src/config.rs
+++ b/applications/minotari_node/src/config.rs
@@ -144,7 +144,7 @@ pub struct BaseNodeConfig {
     pub report_grpc_error: bool,
     // Interval to check if the base node is still in sync with the network
     #[serde(with = "serializers::seconds")]
-    pub tari_pulse_interval: Duration,// Interval to check if the base node is still in sync with the network
+    pub tari_pulse_interval: Duration, // Interval to check if the base node is still in sync with the network
     #[serde(with = "serializers::seconds")]
     pub tari_pulse_health_check: Duration,
 }

--- a/applications/minotari_node/src/config.rs
+++ b/applications/minotari_node/src/config.rs
@@ -144,7 +144,8 @@ pub struct BaseNodeConfig {
     pub report_grpc_error: bool,
     // Interval to check if the base node is still in sync with the network
     #[serde(with = "serializers::seconds")]
-    pub tari_pulse_interval: Duration, // Interval to check if the base node is still in sync with the network
+    pub tari_pulse_interval: Duration,
+    // Interval to check if the base node is still in sync with the network
     #[serde(with = "serializers::seconds")]
     pub tari_pulse_health_check: Duration,
 }

--- a/applications/minotari_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/minotari_node/src/grpc/base_node_grpc_server.rs
@@ -462,6 +462,17 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
             .await
             .map_err(|err| obscure_error_if_true(report_error_flag, Status::internal(err.to_string())))?;
 
+        let liveness_results = (*self.tari_pulse.get_liveness_checks()).clone();
+        let mut liveness = Vec::new();
+        for data in liveness_results {
+            let liveness_check = tari_rpc::LivenessResult {
+                peer_node_id: data.peer.to_string().into_bytes(),
+                discover_latency: data.discovery_latency.map(|v| v.as_secs()).unwrap_or_else(|| u64::MAX),
+                dial_latency: data.ping_latency.map(|v| v.as_secs()).unwrap_or_else(|| u64::MAX),
+            };
+            liveness.push(liveness_check);
+        }
+
         let response = tari_rpc::GetNetworkStateResponse {
             metadata: Some(metadata.into()),
             initial_sync_achieved: status_watch.borrow().bootstrapped,
@@ -471,6 +482,7 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
             sha3x_estimated_hash_rate,
             randomx_estimated_hash_rate,
             num_connections: connected_peers.len() as u64,
+            liveness_results: liveness,
         };
         trace!(target: LOG_TARGET, "Sending GetNetworkState response to client");
         Ok(Response::new(response))

--- a/applications/minotari_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/minotari_node/src/grpc/base_node_grpc_server.rs
@@ -468,7 +468,7 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
             let liveness_check = tari_rpc::LivenessResult {
                 peer_node_id: data.peer.to_string().into_bytes(),
                 discover_latency: data.discovery_latency.map(|v| v.as_secs()).unwrap_or_else(|| u64::MAX),
-                dial_latency: data.dial_latency.map(|v| v.as_secs()).unwrap_or_else(|| u64::MAX),
+                ping_latency: data.ping_latency.map(|v| v.as_secs()).unwrap_or_else(|| u64::MAX),
             };
             liveness.push(liveness_check);
         }

--- a/applications/minotari_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/minotari_node/src/grpc/base_node_grpc_server.rs
@@ -468,7 +468,7 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
             let liveness_check = tari_rpc::LivenessResult {
                 peer_node_id: data.peer.to_string().into_bytes(),
                 discover_latency: data.discovery_latency.map(|v| v.as_secs()).unwrap_or_else(|| u64::MAX),
-                dial_latency: data.ping_latency.map(|v| v.as_secs()).unwrap_or_else(|| u64::MAX),
+                dial_latency: data.dial_latency.map(|v| v.as_secs()).unwrap_or_else(|| u64::MAX),
             };
             liveness.push(liveness_check);
         }

--- a/base_layer/core/src/base_node/tari_pulse_service/mod.rs
+++ b/base_layer/core/src/base_node/tari_pulse_service/mod.rs
@@ -58,7 +58,7 @@ pub struct TariPulseConfig {
 pub struct LivenessCheckResult {
     pub peer: NodeId,
     pub discovery_latency: Option<Duration>,
-    pub ping_latency: Option<Duration>,
+    pub dial_latency: Option<Duration>,
 }
 
 impl Default for TariPulseConfig {
@@ -271,11 +271,13 @@ pub struct TariPulseServiceInitializer {
 
 impl TariPulseServiceInitializer {
     pub fn new(dns_interval: Duration, liveness_interval: Duration, network: Network) -> Self {
-        Self { dns_interval, liveness_interval, network }
+        Self {
+            dns_interval,
+            liveness_interval,
+            network,
+        }
     }
 }
-
-
 
 #[async_trait]
 impl ServiceInitializer for TariPulseServiceInitializer {
@@ -299,10 +301,11 @@ impl ServiceInitializer for TariPulseServiceInitializer {
             let base_node_service = handles.expect_handle::<LocalNodeCommsInterface>();
             let node_comms = handles.expect_handle::<ConnectivityRequester>();
             let base_node_dht = handles.expect_handle::<Dht>();
-            let node_discovery =  base_node_dht.discovery_service_requester();
-            let mut tari_pulse_service = TariPulseService::new(config, node_comms, node_discovery, shutdown_signal.clone())
-                .await
-                .expect("Should be able to get the service");
+            let node_discovery = base_node_dht.discovery_service_requester();
+            let mut tari_pulse_service =
+                TariPulseService::new(config, node_comms, node_discovery, shutdown_signal.clone())
+                    .await
+                    .expect("Should be able to get the service");
             let tari_pulse_service = tari_pulse_service.run(base_node_service, dns_sender, liveness_sender);
             futures::pin_mut!(tari_pulse_service);
             future::select(tari_pulse_service, shutdown_signal).await;
@@ -326,28 +329,27 @@ async fn check_health(
         let mut result = LivenessCheckResult {
             peer: peer.node_id.clone(),
             discovery_latency: None,
-            ping_latency: None,
+            dial_latency: None,
         };
         let dest_key = peer.public_key.clone();
         let mut discovery = node_discovery.clone();
         let comms = node_comms.clone();
         handles.push(task::spawn(async move {
             let start = Instant::now();
-            println!("🌎 Peer discovery started.");
             if let Ok(_) = discovery
-                .discover_peer(
-                    dest_key.clone(),
-                    NodeDestination::PublicKey(dest_key.into()),
-                )
+                .discover_peer(dest_key.clone(), NodeDestination::PublicKey(dest_key.into()))
                 .await
             {
                 result.discovery_latency = Some(start.elapsed());
+            } else {
+                dbg!("failed discovery");
             }
-            let start = Instant::now();
-            println!("☎️  Dialing peer...");
+            let start2 = Instant::now();
 
             if let Ok(_) = comms.dial_peer(result.peer.clone()).await {
-                result.ping_latency = Some(start.elapsed());
+                result.dial_latency = Some(start2.elapsed());
+            } else {
+                dbg!("failed dial");
             };
             (*result_clone).write().await.push(result);
         }));

--- a/base_layer/core/src/base_node/tari_pulse_service/mod.rs
+++ b/base_layer/core/src/base_node/tari_pulse_service/mod.rs
@@ -341,21 +341,16 @@ async fn check_health(
                 .await
             {
                 result.discovery_latency = Some(start.elapsed());
-            } else {
-                dbg!("failed discovery");
             }
             let start2 = Instant::now();
 
             if let Ok(_) = comms.dial_peer(result.peer.clone()).await {
                 result.dial_latency = Some(start2.elapsed());
-            } else {
-                dbg!("failed dial");
-            };
+            }
             (*result_clone).write().await.push(result);
         }));
     }
     futures::future::join_all(handles).await;
     let inner_result = (*(*results).read().await).clone();
-    dbg!(&inner_result);
     notify_comms_health.send(inner_result).expect("Channel should be open");
 }

--- a/base_layer/core/src/base_node/tari_pulse_service/mod.rs
+++ b/base_layer/core/src/base_node/tari_pulse_service/mod.rs
@@ -21,7 +21,8 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use std::{cmp::min, time::Duration};
-
+use std::sync::{Arc};
+use tokio::sync::Mutex;
 use futures::future;
 use log::{debug, info, trace, warn};
 use serde::{Deserialize, Serialize};
@@ -31,7 +32,9 @@ use tari_service_framework::{async_trait, ServiceInitializationError, ServiceIni
 use tari_shutdown::ShutdownSignal;
 use tari_utilities::hex::Hex;
 use tokio::{net::TcpStream as TokioTcpStream, sync::watch, time, time::MissedTickBehavior};
+use tari_comms::connectivity::ConnectivityRequester;
 use tari_comms::peer_manager::NodeId;
+use tari_comms_dht::DhtDiscoveryRequester;
 use super::LocalNodeCommsInterface;
 use crate::base_node::comms_interface::CommsInterfaceError;
 
@@ -39,8 +42,8 @@ const LOG_TARGET: &str = "c::bn::tari_pulse";
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct TariPulseConfig {
-    pub check_interval: Duration,
-    pub liveness_internal: Duration,
+    pub dns_check_interval: Duration,
+    pub liveness_interval: Duration,
     pub network: Network,
 }
 
@@ -53,8 +56,8 @@ pub struct LivenessCheckResult{
 impl Default for TariPulseConfig {
     fn default() -> Self {
         Self {
-            check_interval: Duration::from_secs(120),
-            liveness_internal: Duration::from_secs(60 * 10),
+            dns_check_interval: Duration::from_secs(120),
+            liveness_interval: Duration::from_secs(60 * 10),
             network: Network::default(),
         }
     }
@@ -75,15 +78,19 @@ pub struct TariPulseService {
     dns_name: &'static str,
     config: TariPulseConfig,
     shutdown_signal: ShutdownSignal,
+    node_comms: ConnectivityRequester,
+    node_discovery: DhtDiscoveryRequester,
 }
 
 impl TariPulseService {
-    pub async fn new(config: TariPulseConfig, shutdown_signal: ShutdownSignal) -> Result<Self, anyhow::Error> {
+    pub async fn new(config: TariPulseConfig, node_comms: ConnectivityRequester, node_discovery: DhtDiscoveryRequester, shutdown_signal: ShutdownSignal) -> Result<Self, anyhow::Error> {
         let dns_name = get_network_dns_name(config.clone().network);
         info!(target: LOG_TARGET, "Tari Pulse Service initialized with DNS name: {}", dns_name);
         Ok(Self {
             dns_name,
             config,
+            node_comms,
+            node_discovery,
             shutdown_signal,
         })
     }
@@ -97,21 +104,43 @@ impl TariPulseService {
         &mut self,
         mut base_node_service: LocalNodeCommsInterface,
         notify_passed_checkpoints: watch::Sender<bool>,
-
+        notify_comms_health: watch::Sender<Vec<LivenessCheckResult>>,
     ) {
-        let mut interval = time::interval(self.config.check_interval);
-        interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
-        tokio::pin!(interval);
+        let mut dns_check_interval = time::interval(self.config.dns_check_interval);
+        dns_check_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+        tokio::pin!(dns_check_interval);
+
+        let mut health_check_interval = time::interval(self.config.liveness_interval);
+        health_check_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+        tokio::pin!(health_check_interval);
+
         let mut shutdown_signal = self.shutdown_signal.clone();
         let mut count = 0u64;
         let mut skip_ticks = 0;
         let mut skipped_ticks = 0;
+        let health_check_in_progress = Arc::new(Mutex::new(()));
 
         loop {
             tokio::select! {
-                _ = interval.tick() => {
+                _ = health_check_in_progress.tick() => {
+                    tokio::spawn(async move {
+                        let mut h_check = health_check_in_progress.clone();
+                        let mut _lock = match h_check.try_lock() {
+                            Ok(val) => val,
+                            _ => {
+                                debug!(
+                                    target: LOG_TARGET,
+                                    "Could not acquire lock for health check, skipping this tick"
+                                );
+                                return;
+                            },
+                        };
+
+                    });
+                }
+                _ = dns_check_interval.tick() => {
                     count += 1;
-                    trace!(target: LOG_TARGET, "Interval tick: {}", count);
+                    trace!(target: LOG_TARGET, "DNS Checkpoint interval tick: {}", count);
                     if skipped_ticks < skip_ticks {
                         skipped_ticks += 1;
                         debug!(target: LOG_TARGET, "Skipping {} of {} ticks", skipped_ticks, skip_ticks);
@@ -222,6 +251,12 @@ impl TariPulseServiceInitializer {
     pub fn new(interval: Duration, network: Network) -> Self {
         Self { interval, network }
     }
+}
+
+fn check_health (node_comms: ConnectivityRequester, node_discovery: DhtDiscoveryRequester, notify_comms_health: watch::Sender<Vec<LivenessCheckResult>>)
+{
+    let peers = node_comms.dial_peer()
+
 }
 
 #[async_trait]

--- a/base_layer/core/src/base_node/tari_pulse_service/mod.rs
+++ b/base_layer/core/src/base_node/tari_pulse_service/mod.rs
@@ -30,8 +30,8 @@ use tari_p2p::{dns::DnsClient, Network};
 use tari_service_framework::{async_trait, ServiceInitializationError, ServiceInitializer, ServiceInitializerContext};
 use tari_shutdown::ShutdownSignal;
 use tari_utilities::hex::Hex;
-use tokio::{sync::watch, time, time::MissedTickBehavior};
-
+use tokio::{net::TcpStream as TokioTcpStream, sync::watch, time, time::MissedTickBehavior};
+use tari_comms::peer_manager::NodeId;
 use super::LocalNodeCommsInterface;
 use crate::base_node::comms_interface::CommsInterfaceError;
 
@@ -40,13 +40,21 @@ const LOG_TARGET: &str = "c::bn::tari_pulse";
 #[serde(deny_unknown_fields)]
 pub struct TariPulseConfig {
     pub check_interval: Duration,
+    pub liveness_internal: Duration,
     pub network: Network,
+}
+
+pub struct LivenessCheckResult{
+    pub peer: NodeId,
+    pub discovery_latency: Option<Duration>,
+    pub ping_latency: Option<Duration>,
 }
 
 impl Default for TariPulseConfig {
     fn default() -> Self {
         Self {
             check_interval: Duration::from_secs(120),
+            liveness_internal: Duration::from_secs(60 * 10),
             network: Network::default(),
         }
     }
@@ -89,6 +97,7 @@ impl TariPulseService {
         &mut self,
         mut base_node_service: LocalNodeCommsInterface,
         notify_passed_checkpoints: watch::Sender<bool>,
+
     ) {
         let mut interval = time::interval(self.config.check_interval);
         interval.set_missed_tick_behavior(MissedTickBehavior::Delay);

--- a/base_layer/core/src/base_node/tari_pulse_service/mod.rs
+++ b/base_layer/core/src/base_node/tari_pulse_service/mod.rs
@@ -31,12 +31,16 @@ use serde::{Deserialize, Serialize};
 use tari_common::DnsNameServer;
 use tari_comms::{connectivity::ConnectivityRequester, peer_manager::NodeId};
 use tari_comms_dht::{envelope::NodeDestination, Dht, DhtDiscoveryRequester};
-use tari_p2p::{dns::DnsClient, Network};
+use tari_p2p::{
+    dns::DnsClient,
+    services::liveness::{LivenessEvent, LivenessHandle},
+    Network,
+};
 use tari_service_framework::{async_trait, ServiceInitializationError, ServiceInitializer, ServiceInitializerContext};
 use tari_shutdown::ShutdownSignal;
 use tari_utilities::hex::Hex;
 use tokio::{
-    sync::{watch, Mutex, RwLock},
+    sync::{broadcast::error::RecvError, watch, Mutex, RwLock},
     task,
     time,
     time::MissedTickBehavior,
@@ -44,7 +48,6 @@ use tokio::{
 
 use super::LocalNodeCommsInterface;
 use crate::base_node::comms_interface::CommsInterfaceError;
-
 const LOG_TARGET: &str = "c::bn::tari_pulse";
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -58,7 +61,7 @@ pub struct TariPulseConfig {
 pub struct LivenessCheckResult {
     pub peer: NodeId,
     pub discovery_latency: Option<Duration>,
-    pub dial_latency: Option<Duration>,
+    pub ping_latency: Option<Duration>,
 }
 
 impl Default for TariPulseConfig {
@@ -87,6 +90,7 @@ pub struct TariPulseService {
     config: TariPulseConfig,
     shutdown_signal: ShutdownSignal,
     node_comms: ConnectivityRequester,
+    liveness_handle: LivenessHandle,
     node_discovery: DhtDiscoveryRequester,
 }
 
@@ -94,6 +98,7 @@ impl TariPulseService {
     pub async fn new(
         config: TariPulseConfig,
         node_comms: ConnectivityRequester,
+        liveness_handle: LivenessHandle,
         node_discovery: DhtDiscoveryRequester,
         shutdown_signal: ShutdownSignal,
     ) -> Result<Self, anyhow::Error> {
@@ -103,6 +108,7 @@ impl TariPulseService {
             dns_name,
             config,
             node_comms,
+            liveness_handle,
             node_discovery,
             shutdown_signal,
         })
@@ -137,6 +143,7 @@ impl TariPulseService {
             tokio::select! {
                 _ = health_check_interval.tick() => {
                     let h_check = health_check_in_progress.clone();
+                    let liveness_handle = self.liveness_handle.clone();
                     let comms = self.node_comms.clone();
                     let discovery = self.node_discovery.clone();
                     let notify_channel = notify_comms_health.clone();
@@ -151,7 +158,7 @@ impl TariPulseService {
                                 return;
                             },
                         };
-                    check_health(comms, discovery, notify_channel).await;
+                        check_health(comms, liveness_handle, discovery, notify_channel).await;
                     });
                 }
                 _ = dns_check_interval.tick() => {
@@ -300,10 +307,11 @@ impl ServiceInitializer for TariPulseServiceInitializer {
         context.spawn_when_ready(move |handles| async move {
             let base_node_service = handles.expect_handle::<LocalNodeCommsInterface>();
             let node_comms = handles.expect_handle::<ConnectivityRequester>();
+            let liveness = handles.expect_handle::<LivenessHandle>();
             let base_node_dht = handles.expect_handle::<Dht>();
             let node_discovery = base_node_dht.discovery_service_requester();
             let mut tari_pulse_service =
-                TariPulseService::new(config, node_comms, node_discovery, shutdown_signal.clone())
+                TariPulseService::new(config, node_comms, liveness, node_discovery, shutdown_signal.clone())
                     .await
                     .expect("Should be able to get the service");
             let tari_pulse_service = tari_pulse_service.run(base_node_service, dns_sender, liveness_sender);
@@ -318,6 +326,7 @@ impl ServiceInitializer for TariPulseServiceInitializer {
 
 async fn check_health(
     mut node_comms: ConnectivityRequester,
+    liveness_handle: LivenessHandle,
     node_discovery: DhtDiscoveryRequester,
     notify_comms_health: watch::Sender<Vec<LivenessCheckResult>>,
 ) {
@@ -329,11 +338,12 @@ async fn check_health(
         let mut result = LivenessCheckResult {
             peer: peer.node_id.clone(),
             discovery_latency: None,
-            dial_latency: None,
+            ping_latency: None,
         };
         let dest_key = peer.public_key.clone();
         let mut discovery = node_discovery.clone();
-        let comms = node_comms.clone();
+        let mut liveness_events = liveness_handle.get_event_stream();
+        let mut liveness = liveness_handle.clone();
         handles.push(task::spawn(async move {
             let start = Instant::now();
             if discovery
@@ -344,8 +354,23 @@ async fn check_health(
                 result.discovery_latency = Some(start.elapsed());
             }
             let start2 = Instant::now();
-            if comms.dial_peer(result.peer.clone()).await.is_ok() {
-                result.dial_latency = Some(start2.elapsed());
+            if let Ok(nonce) = liveness.send_ping(result.peer.clone()).await {
+                loop {
+                    match liveness_events.recv().await {
+                        Ok(event) => {
+                            if let LivenessEvent::ReceivedPong(pong) = &*event {
+                                if pong.node_id == result.peer && pong.nonce == nonce {
+                                    result.ping_latency = Some(start2.elapsed());
+                                    break;
+                                }
+                            }
+                        },
+                        Err(RecvError::Closed) => {
+                            break;
+                        },
+                        Err(RecvError::Lagged(_)) => {},
+                    }
+                }
             }
             (*result_clone).write().await.push(result);
         }));

--- a/base_layer/core/src/base_node/tari_pulse_service/mod.rs
+++ b/base_layer/core/src/base_node/tari_pulse_service/mod.rs
@@ -19,22 +19,29 @@
 // SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+use std::{
+    cmp::min,
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
-use std::{cmp::min, time::Duration};
-use std::sync::{Arc};
-use tokio::sync::Mutex;
 use futures::future;
 use log::{debug, info, trace, warn};
 use serde::{Deserialize, Serialize};
 use tari_common::DnsNameServer;
+use tari_comms::{connectivity::ConnectivityRequester, peer_manager::NodeId};
+use tari_comms_dht::{envelope::NodeDestination, DhtDiscoveryRequester};
 use tari_p2p::{dns::DnsClient, Network};
 use tari_service_framework::{async_trait, ServiceInitializationError, ServiceInitializer, ServiceInitializerContext};
 use tari_shutdown::ShutdownSignal;
 use tari_utilities::hex::Hex;
-use tokio::{net::TcpStream as TokioTcpStream, sync::watch, time, time::MissedTickBehavior};
-use tari_comms::connectivity::ConnectivityRequester;
-use tari_comms::peer_manager::NodeId;
-use tari_comms_dht::DhtDiscoveryRequester;
+use tokio::{
+    sync::{watch, Mutex, RwLock},
+    task,
+    time,
+    time::MissedTickBehavior,
+};
+
 use super::LocalNodeCommsInterface;
 use crate::base_node::comms_interface::CommsInterfaceError;
 
@@ -47,7 +54,8 @@ pub struct TariPulseConfig {
     pub network: Network,
 }
 
-pub struct LivenessCheckResult{
+#[derive(Debug, Clone)]
+pub struct LivenessCheckResult {
     pub peer: NodeId,
     pub discovery_latency: Option<Duration>,
     pub ping_latency: Option<Duration>,
@@ -83,7 +91,12 @@ pub struct TariPulseService {
 }
 
 impl TariPulseService {
-    pub async fn new(config: TariPulseConfig, node_comms: ConnectivityRequester, node_discovery: DhtDiscoveryRequester, shutdown_signal: ShutdownSignal) -> Result<Self, anyhow::Error> {
+    pub async fn new(
+        config: TariPulseConfig,
+        node_comms: ConnectivityRequester,
+        node_discovery: DhtDiscoveryRequester,
+        shutdown_signal: ShutdownSignal,
+    ) -> Result<Self, anyhow::Error> {
         let dns_name = get_network_dns_name(config.clone().network);
         info!(target: LOG_TARGET, "Tari Pulse Service initialized with DNS name: {}", dns_name);
         Ok(Self {
@@ -122,9 +135,12 @@ impl TariPulseService {
 
         loop {
             tokio::select! {
-                _ = health_check_in_progress.tick() => {
+                _ = health_check_interval.tick() => {
+                    let h_check = health_check_in_progress.clone();
+                    let comms = self.node_comms.clone();
+                    let discovery = self.node_discovery.clone();
+                    let notify_channel = notify_comms_health.clone();
                     tokio::spawn(async move {
-                        let mut h_check = health_check_in_progress.clone();
                         let mut _lock = match h_check.try_lock() {
                             Ok(val) => val,
                             _ => {
@@ -135,7 +151,7 @@ impl TariPulseService {
                                 return;
                             },
                         };
-
+                    check_health(comms, discovery, notify_channel).await;
                     });
                 }
                 _ = dns_check_interval.tick() => {
@@ -155,7 +171,7 @@ impl TariPulseService {
                             },
                             Err(err) => {
                                 warn!(target: LOG_TARGET, "Failed to check if node has passed checkpoints: {}", err);
-                                skip_ticks = min(skip_ticks + 1, 30 * 60 / self.config.check_interval.as_secs());
+                                skip_ticks = min(skip_ticks + 1, 30 * 60 / self.config.dns_check_interval.as_secs());
                                 skipped_ticks = 0;
                                 continue;
                             },
@@ -234,6 +250,7 @@ impl TariPulseService {
 pub struct TariPulseHandle {
     pub shutdown_signal: ShutdownSignal,
     pub failed_checkpoints_notifier: watch::Receiver<bool>,
+    pub liveness_checks: watch::Receiver<Vec<LivenessCheckResult>>,
 }
 
 impl TariPulseHandle {
@@ -243,20 +260,60 @@ impl TariPulseHandle {
 }
 
 pub struct TariPulseServiceInitializer {
-    interval: Duration,
+    dns_interval: Duration,
+    liveness_interval: Duration,
     network: Network,
+    discovery_service: DhtDiscoveryRequester,
 }
 
 impl TariPulseServiceInitializer {
-    pub fn new(interval: Duration, network: Network) -> Self {
-        Self { interval, network }
+    pub fn new(dns_interval: Duration, liveness_interval: Duration,discovery_service: DhtDiscoveryRequester, network: Network) -> Self {
+        Self { dns_interval, liveness_interval, network, discovery_service }
     }
 }
 
-fn check_health (node_comms: ConnectivityRequester, node_discovery: DhtDiscoveryRequester, notify_comms_health: watch::Sender<Vec<LivenessCheckResult>>)
-{
-    let peers = node_comms.dial_peer()
+async fn check_health(
+    mut node_comms: ConnectivityRequester,
+    node_discovery: DhtDiscoveryRequester,
+    notify_comms_health: watch::Sender<Vec<LivenessCheckResult>>,
+) {
+    let results = Arc::new(RwLock::new(Vec::new()));
+    let peers = node_comms.get_seeds().await.unwrap_or_else(|_| vec![]);
+    let mut handles = vec![];
+    for peer in peers {
+        let result_clone = results.clone();
+        let mut result = LivenessCheckResult {
+            peer: peer.node_id.clone(),
+            discovery_latency: None,
+            ping_latency: None,
+        };
+        let dest_key = peer.public_key.clone();
+        let mut discovery = node_discovery.clone();
+        let comms = node_comms.clone();
+        handles.push(task::spawn(async move {
+            let start = Instant::now();
+            println!("🌎 Peer discovery started.");
+            if let Ok(_) = discovery
+                .discover_peer(
+                    dest_key.clone(),
+                    NodeDestination::PublicKey(dest_key.into()),
+                )
+                .await
+            {
+                result.discovery_latency = Some(start.elapsed());
+            }
+            let start = Instant::now();
+            println!("☎️  Dialing peer...");
 
+            if let Ok(_) = comms.dial_peer(result.peer.clone()).await {
+                result.ping_latency = Some(start.elapsed());
+            };
+            (*result_clone).write().await.push(result);
+        }));
+    }
+    futures::future::join_all(handles).await;
+    let inner_result = (*(*results).read().await).clone();
+    notify_comms_health.send(inner_result).expect("Channel should be open");
 }
 
 #[async_trait]
@@ -264,22 +321,27 @@ impl ServiceInitializer for TariPulseServiceInitializer {
     async fn initialize(&mut self, context: ServiceInitializerContext) -> Result<(), ServiceInitializationError> {
         info!(target: LOG_TARGET, "Initializing Tari Pulse Service");
         let shutdown_signal = context.get_shutdown_signal();
-        let (sender, receiver) = watch::channel(false);
+        let (dns_sender, dns_receiver) = watch::channel(false);
+        let (liveness_sender, liveness_receiver) = watch::channel(vec![]);
         context.register_handle(TariPulseHandle {
             shutdown_signal: shutdown_signal.clone(),
-            failed_checkpoints_notifier: receiver,
+            failed_checkpoints_notifier: dns_receiver,
+            liveness_checks: liveness_receiver,
         });
         let config = TariPulseConfig {
-            check_interval: self.interval,
+            dns_check_interval: self.dns_interval,
+            liveness_interval: self.liveness_interval,
             network: self.network,
         };
+        let node_discovery = self.discovery_service.clone();
 
         context.spawn_when_ready(move |handles| async move {
             let base_node_service = handles.expect_handle::<LocalNodeCommsInterface>();
-            let mut tari_pulse_service = TariPulseService::new(config, shutdown_signal.clone())
+            let node_comms = handles.expect_handle::<ConnectivityRequester>();
+            let mut tari_pulse_service = TariPulseService::new(config, node_comms, node_discovery, shutdown_signal.clone())
                 .await
                 .expect("Should be able to get the service");
-            let tari_pulse_service = tari_pulse_service.run(base_node_service, sender);
+            let tari_pulse_service = tari_pulse_service.run(base_node_service, dns_sender, liveness_sender);
             futures::pin_mut!(tari_pulse_service);
             future::select(tari_pulse_service, shutdown_signal).await;
             info!(target: LOG_TARGET, "Tari Pulse Service shutdown");

--- a/base_layer/core/src/base_node/tari_pulse_service/mod.rs
+++ b/base_layer/core/src/base_node/tari_pulse_service/mod.rs
@@ -30,7 +30,7 @@ use log::{debug, info, trace, warn};
 use serde::{Deserialize, Serialize};
 use tari_common::DnsNameServer;
 use tari_comms::{connectivity::ConnectivityRequester, peer_manager::NodeId};
-use tari_comms_dht::{envelope::NodeDestination, DhtDiscoveryRequester};
+use tari_comms_dht::{envelope::NodeDestination, Dht, DhtDiscoveryRequester};
 use tari_p2p::{dns::DnsClient, Network};
 use tari_service_framework::{async_trait, ServiceInitializationError, ServiceInitializer, ServiceInitializerContext};
 use tari_shutdown::ShutdownSignal;
@@ -257,18 +257,59 @@ impl TariPulseHandle {
     pub fn get_failed_checkpoints_notifier(&self) -> watch::Ref<'_, bool> {
         self.failed_checkpoints_notifier.borrow()
     }
+
+    pub fn get_liveness_checks(&self) -> watch::Ref<'_, Vec<LivenessCheckResult>> {
+        self.liveness_checks.borrow()
+    }
 }
 
 pub struct TariPulseServiceInitializer {
     dns_interval: Duration,
     liveness_interval: Duration,
     network: Network,
-    discovery_service: DhtDiscoveryRequester,
 }
 
 impl TariPulseServiceInitializer {
-    pub fn new(dns_interval: Duration, liveness_interval: Duration,discovery_service: DhtDiscoveryRequester, network: Network) -> Self {
-        Self { dns_interval, liveness_interval, network, discovery_service }
+    pub fn new(dns_interval: Duration, liveness_interval: Duration, network: Network) -> Self {
+        Self { dns_interval, liveness_interval, network }
+    }
+}
+
+
+
+#[async_trait]
+impl ServiceInitializer for TariPulseServiceInitializer {
+    async fn initialize(&mut self, context: ServiceInitializerContext) -> Result<(), ServiceInitializationError> {
+        info!(target: LOG_TARGET, "Initializing Tari Pulse Service");
+        let shutdown_signal = context.get_shutdown_signal();
+        let (dns_sender, dns_receiver) = watch::channel(false);
+        let (liveness_sender, liveness_receiver) = watch::channel(vec![]);
+        context.register_handle(TariPulseHandle {
+            shutdown_signal: shutdown_signal.clone(),
+            failed_checkpoints_notifier: dns_receiver,
+            liveness_checks: liveness_receiver,
+        });
+        let config = TariPulseConfig {
+            dns_check_interval: self.dns_interval,
+            liveness_interval: self.liveness_interval,
+            network: self.network,
+        };
+
+        context.spawn_when_ready(move |handles| async move {
+            let base_node_service = handles.expect_handle::<LocalNodeCommsInterface>();
+            let node_comms = handles.expect_handle::<ConnectivityRequester>();
+            let base_node_dht = handles.expect_handle::<Dht>();
+            let node_discovery =  base_node_dht.discovery_service_requester();
+            let mut tari_pulse_service = TariPulseService::new(config, node_comms, node_discovery, shutdown_signal.clone())
+                .await
+                .expect("Should be able to get the service");
+            let tari_pulse_service = tari_pulse_service.run(base_node_service, dns_sender, liveness_sender);
+            futures::pin_mut!(tari_pulse_service);
+            future::select(tari_pulse_service, shutdown_signal).await;
+            info!(target: LOG_TARGET, "Tari Pulse Service shutdown");
+        });
+        info!(target: LOG_TARGET, "Tari Pulse Service initialized");
+        Ok(())
     }
 }
 
@@ -313,40 +354,6 @@ async fn check_health(
     }
     futures::future::join_all(handles).await;
     let inner_result = (*(*results).read().await).clone();
+    dbg!(&inner_result);
     notify_comms_health.send(inner_result).expect("Channel should be open");
-}
-
-#[async_trait]
-impl ServiceInitializer for TariPulseServiceInitializer {
-    async fn initialize(&mut self, context: ServiceInitializerContext) -> Result<(), ServiceInitializationError> {
-        info!(target: LOG_TARGET, "Initializing Tari Pulse Service");
-        let shutdown_signal = context.get_shutdown_signal();
-        let (dns_sender, dns_receiver) = watch::channel(false);
-        let (liveness_sender, liveness_receiver) = watch::channel(vec![]);
-        context.register_handle(TariPulseHandle {
-            shutdown_signal: shutdown_signal.clone(),
-            failed_checkpoints_notifier: dns_receiver,
-            liveness_checks: liveness_receiver,
-        });
-        let config = TariPulseConfig {
-            dns_check_interval: self.dns_interval,
-            liveness_interval: self.liveness_interval,
-            network: self.network,
-        };
-        let node_discovery = self.discovery_service.clone();
-
-        context.spawn_when_ready(move |handles| async move {
-            let base_node_service = handles.expect_handle::<LocalNodeCommsInterface>();
-            let node_comms = handles.expect_handle::<ConnectivityRequester>();
-            let mut tari_pulse_service = TariPulseService::new(config, node_comms, node_discovery, shutdown_signal.clone())
-                .await
-                .expect("Should be able to get the service");
-            let tari_pulse_service = tari_pulse_service.run(base_node_service, dns_sender, liveness_sender);
-            futures::pin_mut!(tari_pulse_service);
-            future::select(tari_pulse_service, shutdown_signal).await;
-            info!(target: LOG_TARGET, "Tari Pulse Service shutdown");
-        });
-        info!(target: LOG_TARGET, "Tari Pulse Service initialized");
-        Ok(())
-    }
 }

--- a/base_layer/core/src/base_node/tari_pulse_service/mod.rs
+++ b/base_layer/core/src/base_node/tari_pulse_service/mod.rs
@@ -29,7 +29,7 @@ use futures::future;
 use log::{debug, info, trace, warn};
 use serde::{Deserialize, Serialize};
 use tari_common::DnsNameServer;
-use tari_comms::{connectivity::ConnectivityRequester, peer_manager::NodeId};
+use tari_comms::{connectivity::ConnectivityRequester, peer_manager::NodeId, Minimized};
 use tari_comms_dht::{envelope::NodeDestination, Dht, DhtDiscoveryRequester};
 use tari_p2p::{
     dns::DnsClient,
@@ -344,6 +344,7 @@ async fn check_health(
         let mut discovery = node_discovery.clone();
         let mut liveness_events = liveness_handle.get_event_stream();
         let mut liveness = liveness_handle.clone();
+        let mut comms = node_comms.clone();
         handles.push(task::spawn(async move {
             let start = Instant::now();
             if discovery
@@ -370,6 +371,11 @@ async fn check_health(
                         },
                         Err(RecvError::Lagged(_)) => {},
                     }
+                }
+            }
+            if let Ok(Some(mut conn)) = comms.get_connection(result.peer.clone()).await {
+                if let Err(err) = conn.disconnect(Minimized::No).await {
+                    warn!(target: LOG_TARGET, "Failed to disconnect peer {} ({})", result.peer, err);
                 }
             }
             (*result_clone).write().await.push(result);

--- a/base_layer/core/src/base_node/tari_pulse_service/mod.rs
+++ b/base_layer/core/src/base_node/tari_pulse_service/mod.rs
@@ -336,15 +336,15 @@ async fn check_health(
         let comms = node_comms.clone();
         handles.push(task::spawn(async move {
             let start = Instant::now();
-            if let Ok(_) = discovery
+            if discovery
                 .discover_peer(dest_key.clone(), NodeDestination::PublicKey(dest_key.into()))
                 .await
+                .is_ok()
             {
                 result.discovery_latency = Some(start.elapsed());
             }
             let start2 = Instant::now();
-
-            if let Ok(_) = comms.dial_peer(result.peer.clone()).await {
+            if comms.dial_peer(result.peer.clone()).await.is_ok() {
                 result.dial_latency = Some(start2.elapsed());
             }
             (*result_clone).write().await.push(result);

--- a/base_layer/core/src/blocks/pre_mine/mod.rs
+++ b/base_layer/core/src/blocks/pre_mine/mod.rs
@@ -1356,6 +1356,7 @@ mod test {
         );
     }
 
+    #[ignore]
     #[tokio::test]
     async fn test_create_genesis_block_info() {
         for network in [

--- a/common/config/presets/c_base_node_c.toml
+++ b/common/config/presets/c_base_node_c.toml
@@ -48,6 +48,9 @@
 # Interval between each request to the dns server for hte checkpoints to compare it with the local blockchain (default = 120 s)
 # tari_pulse_interval = 120
 
+# Interval which the node will use to discover and dial the seed peers.
+# tari_pulse_health_check = 600 # 10 mins
+
 [base_node.lmdb]
 #init_size_bytes = 16_777_216 # 16 *1024 * 1024
 #grow_size_bytes = 16_777_216 # 16 *1024 * 1024

--- a/comms/core/src/connection_manager/listener.rs
+++ b/comms/core/src/connection_manager/listener.rs
@@ -287,7 +287,7 @@ where
                     }
                 },
                 Ok(WireMode::Comms(byte)) => {
-                    warn!(
+                    debug!(
                         target: LOG_TARGET,
                         "Peer at address '{}' sent invalid wire format byte. Expected {:x?} got: {:x?} ",
                         peer_addr,

--- a/comms/core/src/connectivity/manager.rs
+++ b/comms/core/src/connectivity/manager.rs
@@ -332,6 +332,10 @@ impl ConnectivityManagerActor {
                 let allow_list = self.allow_list.clone();
                 let _result = reply.send(allow_list);
             },
+            GetSeeds(reply) => {
+                let allow_list = self.allow_list.clone();
+                888let _result = reply.send(allow_list);
+            },
             GetActiveConnections(reply) => {
                 let _result = reply.send(
                     self.pool

--- a/comms/core/src/connectivity/manager.rs
+++ b/comms/core/src/connectivity/manager.rs
@@ -333,8 +333,11 @@ impl ConnectivityManagerActor {
                 let _result = reply.send(allow_list);
             },
             GetSeeds(reply) => {
-                let allow_list = self.allow_list.clone();
-                888let _result = reply.send(allow_list);
+                let seeds = self.peer_manager.get_seed_peers().await.unwrap_or_else(|e| {
+                    error!(target: LOG_TARGET, "Error when retrieving seed peers: {:?}", e);
+                    vec![]
+                });
+                let _result = reply.send(seeds);
             },
             GetActiveConnections(reply) => {
                 let _result = reply.send(

--- a/comms/core/src/connectivity/requester.rs
+++ b/comms/core/src/connectivity/requester.rs
@@ -104,7 +104,7 @@ pub enum ConnectivityRequest {
     AddPeerToAllowList(NodeId),
     RemovePeerFromAllowList(NodeId),
     GetAllowList(oneshot::Sender<Vec<NodeId>>),
-    GetSeeds(oneshot::Sender<Vec<NodeId>>),
+    GetSeeds(oneshot::Sender<Vec<Peer>>),
     GetPeerStats(NodeId, oneshot::Sender<Option<Peer>>),
     GetNodeIdentity(oneshot::Sender<NodeIdentity>),
 }
@@ -298,13 +298,13 @@ impl ConnectivityRequester {
         reply_rx.await.map_err(|_| ConnectivityError::ActorResponseCancelled)
     }
 
-    pub async fn get_seeds(&mut self) -> Result<Vec<NodeId>, ConnectivityError> {
-    let (reply_tx, reply_rx) = oneshot::channel();
-    self.sender
-    .send(ConnectivityRequest::GetSeeds(reply_tx))
-    .await
-    .map_err(|_| ConnectivityError::ActorDisconnected)?;
-    reply_rx.await.map_err(|_| ConnectivityError::ActorResponseCancelled)
+    pub async fn get_seeds(&mut self) -> Result<Vec<Peer>, ConnectivityError> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.sender
+            .send(ConnectivityRequest::GetSeeds(reply_tx))
+            .await
+            .map_err(|_| ConnectivityError::ActorDisconnected)?;
+        reply_rx.await.map_err(|_| ConnectivityError::ActorResponseCancelled)
     }
 
     /// Retrieve self's node identity.

--- a/comms/core/src/connectivity/requester.rs
+++ b/comms/core/src/connectivity/requester.rs
@@ -104,6 +104,7 @@ pub enum ConnectivityRequest {
     AddPeerToAllowList(NodeId),
     RemovePeerFromAllowList(NodeId),
     GetAllowList(oneshot::Sender<Vec<NodeId>>),
+    GetSeeds(oneshot::Sender<Vec<NodeId>>),
     GetPeerStats(NodeId, oneshot::Sender<Option<Peer>>),
     GetNodeIdentity(oneshot::Sender<NodeIdentity>),
 }
@@ -295,6 +296,15 @@ impl ConnectivityRequester {
             .await
             .map_err(|_| ConnectivityError::ActorDisconnected)?;
         reply_rx.await.map_err(|_| ConnectivityError::ActorResponseCancelled)
+    }
+
+    pub async fn get_seeds(&mut self) -> Result<Vec<NodeId>, ConnectivityError> {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    self.sender
+    .send(ConnectivityRequest::GetSeeds(reply_tx))
+    .await
+    .map_err(|_| ConnectivityError::ActorDisconnected)?;
+    reply_rx.await.map_err(|_| ConnectivityError::ActorResponseCancelled)
     }
 
     /// Retrieve self's node identity.

--- a/comms/core/src/peer_manager/manager.rs
+++ b/comms/core/src/peer_manager/manager.rs
@@ -119,6 +119,11 @@ impl PeerManager {
         self.peer_storage.read().await.find_by_node_id(node_id)
     }
 
+    /// gets all seed peers
+    pub async fn get_seed_peers(&self) -> Result<Vec<Peer>, PeerManagerError> {
+        self.peer_storage.read().await.get_seed_peers()
+    }
+
     /// Find the peer with the provided PublicKey
     pub async fn find_by_public_key(&self, public_key: &CommsPublicKey) -> Result<Option<Peer>, PeerManagerError> {
         self.peer_storage.read().await.find_by_public_key(public_key)

--- a/comms/core/src/peer_manager/peer_storage.rs
+++ b/comms/core/src/peer_manager/peer_storage.rs
@@ -955,7 +955,6 @@ mod test {
             peer
         })
         .take(5)
-        .chain(repeat_with(|| create_test_peer(PeerFeatures::COMMUNICATION_CLIENT, false)).take(4))
         .collect::<Vec<_>>();
 
         for p in &seeds {
@@ -964,7 +963,6 @@ mod test {
 
         let nodes = repeat_with(|| create_test_peer(PeerFeatures::COMMUNICATION_NODE, false))
             .take(5)
-            .chain(repeat_with(|| create_test_peer(PeerFeatures::COMMUNICATION_CLIENT, false)).take(4))
             .collect::<Vec<_>>();
 
         for p in &nodes {

--- a/comms/core/src/peer_manager/peer_storage.rs
+++ b/comms/core/src/peer_manager/peer_storage.rs
@@ -344,6 +344,13 @@ where DS: KeyValueStore<PeerId, Peer>
         self.perform_query(query)
     }
 
+    pub fn get_seed_peers(&self) -> Result<Vec<Peer>, PeerManagerError> {
+        self.peer_db
+            .filter(|(_, peer)| peer.is_seed())
+            .map(|pairs| pairs.into_iter().map(|(_, peer)| peer).collect())
+            .map_err(PeerManagerError::DatabaseError)
+    }
+
     /// Delete all stale peers, removing them from the database and returning their node_ids
     /// - Stale Nodes:
     ///   - A node is considered stale if all its addresses have failed or if it has not been seen for more than the
@@ -936,6 +943,38 @@ mod test {
 
         let is_in_region = peer_storage.in_network_region(far_node, &main_peer_node_id, 3).unwrap();
         assert!(!is_in_region);
+    }
+
+    #[test]
+    fn get_just_seeds() {
+        let mut peer_storage = PeerStorage::new_indexed(HashmapDatabase::new()).unwrap();
+
+        let seeds = repeat_with(|| {
+            let mut peer = create_test_peer(PeerFeatures::COMMUNICATION_NODE, false);
+            peer.add_flags(PeerFlags::SEED);
+            peer
+        })
+        .take(5)
+        .chain(repeat_with(|| create_test_peer(PeerFeatures::COMMUNICATION_CLIENT, false)).take(4))
+        .collect::<Vec<_>>();
+
+        for p in &seeds {
+            peer_storage.add_peer(p.clone()).unwrap();
+        }
+
+        let nodes = repeat_with(|| create_test_peer(PeerFeatures::COMMUNICATION_NODE, false))
+            .take(5)
+            .chain(repeat_with(|| create_test_peer(PeerFeatures::COMMUNICATION_CLIENT, false)).take(4))
+            .collect::<Vec<_>>();
+
+        for p in &nodes {
+            peer_storage.add_peer(p.clone()).unwrap();
+        }
+        let retrieved_seeds = peer_storage.get_seed_peers().unwrap();
+        assert_eq!(retrieved_seeds.len(), seeds.len());
+        for seed in seeds {
+            assert!(retrieved_seeds.iter().any(|p| p.node_id == seed.node_id));
+        }
     }
 
     #[test]

--- a/comms/core/src/test_utils/mocks/connectivity_manager.rs
+++ b/comms/core/src/test_utils/mocks/connectivity_manager.rs
@@ -297,6 +297,7 @@ impl ConnectivityManagerMock {
             },
             WaitStarted(reply) => reply.send(()).unwrap(),
             GetNodeIdentity(_) => unimplemented!(),
+            GetSeeds(_) => unimplemented!(),
             GetAllowList(reply) => {
                 let _result = reply.send(vec![]);
             },


### PR DESCRIPTION
Description
---
This adds in a health check whereby the node checks if it can discover a peer and dial a peer. 
It discover, then dials the seed peers 

fixes: #6944 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced liveness health checks that monitor and report peer discovery and dial latencies for seed peers.
  - Added detailed liveness metrics to the network state gRPC response, providing enhanced visibility into peer connectivity.

- **Configuration**
  - Added a new configuration option for setting the liveness health check interval, with a default of 10 minutes.

- **Bug Fixes**
  - Improved logging by lowering the log level for certain connection errors to reduce unnecessary warnings.

- **Tests**
  - Added unit tests for seed peer retrieval logic.
  - Marked a specific block creation test to be ignored by default during test runs.

- **Chores**
  - Updated documentation and configuration presets to reflect new liveness health check settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->