### PR TITLE
feat: increase pipeline concurrency

### DIFF
--- a/base_layer/p2p/src/config.rs
+++ b/base_layer/p2p/src/config.rs
@@ -154,8 +154,8 @@ impl Default for P2pConfig {
             transport: Default::default(),
             datastore_path: PathBuf::from("peer_db"),
             peer_database_name: "peers".to_string(),
-            max_concurrent_inbound_tasks: 4,
-            max_concurrent_outbound_tasks: 4,
+            max_concurrent_inbound_tasks: 100,
+            max_concurrent_outbound_tasks: 100,
             dht: DhtConfig {
                 database_url: DbConnectionUrl::file("dht.sqlite"),
                 auto_join: true,

--- a/common/config/presets/c_base_node_c.toml
+++ b/common/config/presets/c_base_node_c.toml
@@ -145,10 +145,10 @@ blockchain_sync_config.rpc_deadline = 240
 #peer_database_name = "peers"
 
 # The maximum number of concurrent Inbound tasks allowed before back-pressure is applied to peers
-#max_concurrent_inbound_tasks = 4
+#max_concurrent_inbound_tasks = 100
 
 # The maximum number of concurrent outbound tasks allowed before back-pressure is applied to outbound messaging queue
-#max_concurrent_outbound_tasks = 4
+#max_concurrent_outbound_tasks = 100
 
 # Set to true to allow peers to provide test addresses (loopback, memory etc.). If set to false, memory
 # addresses, loopback, local-link (i.e addresses used in local tests) will not be accepted from peers. This

--- a/common/config/presets/d_console_wallet.toml
+++ b/common/config/presets/d_console_wallet.toml
@@ -185,10 +185,10 @@ event_channel_size = 3500
 #peer_database_name = "peers"
 
 # The maximum number of concurrent Inbound tasks allowed before back-pressure is applied to peers
-#max_concurrent_inbound_tasks = 4
+#max_concurrent_inbound_tasks = 100
 
 # The maximum number of concurrent outbound tasks allowed before back-pressure is applied to outbound messaging queue
-#max_concurrent_outbound_tasks = 4
+#max_concurrent_outbound_tasks = 100
 
 # Set to true to allow peers to provide test addresses (loopback, memory etc.). If set to false, memory
 # addresses, loopback, local-link (i.e addresses used in local tests) will not be accepted from peers. This


### PR DESCRIPTION
Description
---
Increased default values for inbound and outbound pipeline concurrency to alleviate pressure when pipelines are kept busy.

**Note:** The peer_db must still be ported to SQLite, as many queries in a big network will keep the pipelines busy.

Motivation and Context
---
When a base node gets busy, the inboud and outbound pipelines can time-out with this message:
```
ERROR Inbound pipeline 243 timed out and was aborted. THIS SHOULD NOT HAPPEN: there was a deadlock or excessive delay in processing this pipeline.
```

How Has This Been Tested?
---
System-level testing.

What process can a PR reviewer use to test or verify this change?
---
Code review.
System-level testing.

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Increased the default and preset limits for maximum concurrent inbound and outbound peer-to-peer tasks from 4 to 100 in configuration settings. This allows higher concurrency for network operations before back-pressure is applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->