### PR TITLE
fix: force coinbase fee = 0

### DIFF
--- a/base_layer/core/src/transactions/aggregated_body.rs
+++ b/base_layer/core/src/transactions/aggregated_body.rs
@@ -332,6 +332,13 @@ impl AggregateBody {
         let mut coinbase_kernel_counter = 0; // there should be exactly 1 coinbase kernel as well
         for kernel in self.kernels() {
             if kernel.features.contains(KernelFeatures::COINBASE_KERNEL) {
+                if kernel.fee != 0 {
+                    warn!(
+                        target: LOG_TARGET,
+                        "Coinbase kernel {} found with fee set to {}. This should be 0", kernel, kernel.fee
+                    );
+                    return Err(TransactionError::InvalidCoinbase);
+                }
                 coinbase_kernel_counter += 1;
                 coinbase_kernel = Some(kernel);
             }

--- a/base_layer/core/src/transactions/aggregated_body.rs
+++ b/base_layer/core/src/transactions/aggregated_body.rs
@@ -332,7 +332,7 @@ impl AggregateBody {
         let mut coinbase_kernel_counter = 0; // there should be exactly 1 coinbase kernel as well
         for kernel in self.kernels() {
             if kernel.features.contains(KernelFeatures::COINBASE_KERNEL) {
-                if kernel.fee != 0 {
+                if kernel.fee != 0.into() {
                     warn!(
                         target: LOG_TARGET,
                         "Coinbase kernel {} found with fee set to {}. This should be 0", kernel, kernel.fee


### PR DESCRIPTION
Description
---
Although not exploitable per say, its better to have a fixed consensus checking that the fee = 0 for the coinbase. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Added validation to ensure coinbase kernels have a zero fee, improving transaction correctness and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->