### PR TITLE
fix: wait until higher than initial_sync_load_peers before marking up-to-date

### DIFF
--- a/base_layer/core/src/base_node/state_machine_service/states/listening.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/listening.rs
@@ -38,7 +38,13 @@ use crate::{
         chain_metadata_service::{ChainMetadataEvent, PeerChainMetadata},
         state_machine_service::{
             states::{
-                BlockSync, DecideNextSync, HeaderSyncState, StateEvent, StateEvent::FatalError, StateInfo, SyncStatus,
+                BlockSync,
+                DecideNextSync,
+                HeaderSyncState,
+                StateEvent,
+                StateEvent::FatalError,
+                StateInfo,
+                SyncStatus,
                 Waiting,
             },
             BaseNodeStateMachine,
@@ -261,7 +267,7 @@ impl Listening {
                             self.set_synced_response(shared);
                             debug!(target: LOG_TARGET, "Initial sync achieved");
                         } else {
-                            debug!(target: LOG_TARGET, "We are ahead of at least {} peers, waiting for more info", initial_sync_counter);
+                            debug!(target: LOG_TARGET, "We are ahead of at least {} peers, waiting for more info", ahead_of_peers_counter);
                         }
                     }
 
@@ -367,6 +373,7 @@ impl From<DecideNextSync> for Listening {
 }
 
 /// Given a local and the network chain state respectively, figure out what synchronisation state we should be in.
+#[allow(clippy::too_many_lines)]
 fn determine_sync_mode(
     blocks_behind_before_considered_lagging: u64,
     local: &ChainMetadata,
@@ -393,8 +400,8 @@ fn determine_sync_mode(
         // we only require some data from it, we need to ensure that they can supply the data we need, as in their
         // effective pruned horizon is greater than our local current chain tip.
         let pruned_mode = local.pruning_horizon() > 0;
-        let pruning_horizon_check = network.claimed_chain_metadata().pruning_horizon() > 0
-            && network.claimed_chain_metadata().pruning_horizon() < local.pruning_horizon();
+        let pruning_horizon_check = network.claimed_chain_metadata().pruning_horizon() > 0 &&
+            network.claimed_chain_metadata().pruning_horizon() < local.pruning_horizon();
         let pruning_height_check = network.claimed_chain_metadata().pruned_height() > local.best_block_height();
         let sync_able_peer = match (pruned_mode, pruning_horizon_check, pruning_height_check) {
             (true, true, _) => {
@@ -429,8 +436,8 @@ fn determine_sync_mode(
         if blocks_behind_before_considered_lagging > 0 {
             // Otherwise, only wait when the tip is above us, otherwise
             // chains with a lower height will never be reorged to.
-            if network_tip_height > local_tip_height
-                && local_tip_height.saturating_add(blocks_behind_before_considered_lagging) > network_tip_height
+            if network_tip_height > local_tip_height &&
+                local_tip_height.saturating_add(blocks_behind_before_considered_lagging) > network_tip_height
             {
                 info!(
                     target: LOG_TARGET,

--- a/base_layer/core/src/base_node/state_machine_service/states/listening.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/listening.rs
@@ -38,13 +38,7 @@ use crate::{
         chain_metadata_service::{ChainMetadataEvent, PeerChainMetadata},
         state_machine_service::{
             states::{
-                BlockSync,
-                DecideNextSync,
-                HeaderSyncState,
-                StateEvent,
-                StateEvent::FatalError,
-                StateInfo,
-                SyncStatus,
+                BlockSync, DecideNextSync, HeaderSyncState, StateEvent, StateEvent::FatalError, StateInfo, SyncStatus,
                 Waiting,
             },
             BaseNodeStateMachine,
@@ -158,6 +152,7 @@ impl Listening {
         }
         let mut time_since_better_block = None;
         let mut initial_sync_counter = 0;
+        let mut ahead_of_peers_counter = 0;
         let mut initial_sync_peer_list = Vec::new();
         loop {
             let metadata_event = shared.metadata_event_stream.recv().await;
@@ -192,6 +187,7 @@ impl Listening {
                             return FatalError(format!("Error checking if peer is banned: {}", e));
                         },
                     }
+
                     let peer_data = PeerMetadata {
                         metadata: peer_metadata.claimed_chain_metadata().clone(),
                         last_updated: EpochTime::now(),
@@ -260,8 +256,13 @@ impl Listening {
                     }
 
                     if !self.is_synced && sync_mode.is_up_to_date() {
-                        self.set_synced_response(shared);
-                        debug!(target: LOG_TARGET, "Initial sync achieved");
+                        ahead_of_peers_counter += 1;
+                        if ahead_of_peers_counter >= shared.config.initial_sync_peer_count {
+                            self.set_synced_response(shared);
+                            debug!(target: LOG_TARGET, "Initial sync achieved");
+                        } else {
+                            debug!(target: LOG_TARGET, "We are ahead of at least {} peers, waiting for more info", initial_sync_counter);
+                        }
                     }
 
                     // If we have already reached initial sync before, as indicated by the `is_synced` flagged we can
@@ -392,8 +393,8 @@ fn determine_sync_mode(
         // we only require some data from it, we need to ensure that they can supply the data we need, as in their
         // effective pruned horizon is greater than our local current chain tip.
         let pruned_mode = local.pruning_horizon() > 0;
-        let pruning_horizon_check = network.claimed_chain_metadata().pruning_horizon() > 0 &&
-            network.claimed_chain_metadata().pruning_horizon() < local.pruning_horizon();
+        let pruning_horizon_check = network.claimed_chain_metadata().pruning_horizon() > 0
+            && network.claimed_chain_metadata().pruning_horizon() < local.pruning_horizon();
         let pruning_height_check = network.claimed_chain_metadata().pruned_height() > local.best_block_height();
         let sync_able_peer = match (pruned_mode, pruning_horizon_check, pruning_height_check) {
             (true, true, _) => {
@@ -428,8 +429,8 @@ fn determine_sync_mode(
         if blocks_behind_before_considered_lagging > 0 {
             // Otherwise, only wait when the tip is above us, otherwise
             // chains with a lower height will never be reorged to.
-            if network_tip_height > local_tip_height &&
-                local_tip_height.saturating_add(blocks_behind_before_considered_lagging) > network_tip_height
+            if network_tip_height > local_tip_height
+                && local_tip_height.saturating_add(blocks_behind_before_considered_lagging) > network_tip_height
             {
                 info!(
                     target: LOG_TARGET,
@@ -462,6 +463,21 @@ fn determine_sync_mode(
             sync_peers: vec![network.clone().into()],
         }
     } else {
+        if local_tip_accum_difficulty / 2 > network_tip_accum_difficulty {
+            // We are ahead of the network, but not by much. We should be in listening mode.
+            info!(
+                target: LOG_TARGET,
+                "Received a metadata update from a peer that is very far behind us. Disregarding. We are at block #{} with an \
+                 accumulated difficulty of {} and the network chain tip is at #{} with an accumulated difficulty of {}",
+                local.best_block_height(),
+                local_tip_accum_difficulty,
+                network.claimed_chain_metadata().best_block_height(),
+                network_tip_accum_difficulty,
+            );
+            return SyncStatus::SyncNotPossible {
+                peers: vec![network.clone().into()],
+            };
+        }
         debug!(
             target: LOG_TARGET,
             "{} We're at block {} with an accumulated difficulty of {} and the network chain tip is at {} with an \


### PR DESCRIPTION
Try to wait until we are higher than all `initial_sync_peers` before saying we are up to date. 
Currently as soon as we are higher than any of the peers, we say sync is completed, even if we know there are other network peers that are higher.

Background: found this in the logs:

```
2025-04-16 18:19:03.277795700 [c::bn::state_machine_service::states::listening] [,] INFO  Our local blockchain 
  accumulated difficulty is a little behind that of the network. We're at block #21999 with an accumulated 
  difficulty of 19445116522178206716662802593610, and the network chain tip is at #25927 with an 
  accumulated difficulty of 26953380919107152762289939335357 // base_layer\core\src\base_node\state_machine_service\states\listening.rs:379
2025-04-16 18:19:03.277820200 [c::bn::state_machine_service::states::listening] [,] DEBUG Lagging (local 
  height = 21999, network height = 25927, peer = 9ae73989bb93b741f0a7f2df50 (3.27s)) // base_layer\core\src\base_node\state_machine_service\states\listening.rs:448
2025-04-16 18:19:03.314401100 [c::bn::chain_state_sync_service] [,] DEBUG Received chain metadata from 
  NodeId '9b7352fb62fed89deae70c1672' #25927, Acc_diff 26953380919107152762289939335357 // base_layer\core\src\base_node\chain_metadata_service\service.rs:195
2025-04-16 18:19:03.336207700 [c::bn::chain_state_sync_service] [,] DEBUG Received chain metadata 
  from NodeId 'f233055913b876102b5a4e9ae4' #25927, Acc_diff 26953380919107152762289939335357 // base_layer\core\src\base_node\chain_metadata_service\service.rs:195
2025-04-16 18:19:03.337783600 [c::bn::state_machine_service::states::listening] [,] DEBUG Our blockchain 
  is ahead of the network. We're at block 21999 with an accumulated difficulty of 19445116522178206716662802593610 
  and the network chain tip is at 0 with an accumulated difficulty of 1 // base_layer\core\src\base_node\state_machine_service\states\listening.rs:465
2025-04-16 18:19:03.337811300 [c::bn::base_node] [,] DEBUG Node has bootstrapped // 
```

tl;dr: we set as synced when we received the metadata of a peer at 0 height, even though we know we are still behind

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **New Features**
  - Improved syncing logic by introducing a counter to track when the node is ahead of peers, ensuring the node only marks itself as synced after reaching a configured peer threshold.
- **Bug Fixes**
  - Enhanced peer filtering to ignore peers that are significantly behind in chain progress, resulting in more accurate sync decisions.
- **Other**
  - Minor improvements to internal logging and condition formatting for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->