### PR TITLE
fix(dns): off by one error when reading TXT record

### DIFF
--- a/base_layer/p2p/src/dns/client.rs
+++ b/base_layer/p2p/src/dns/client.rs
@@ -103,7 +103,7 @@ impl DnsClient {
                     if len == 0 {
                         return None;
                     }
-                    if len > txt.len() {
+                    if len >= txt.len() {
                         warn!(
                             target: LOG_TARGET,
                             "Length byte {} is greater than the length of the TXT record {}",
@@ -113,7 +113,7 @@ impl DnsClient {
                         return None;
                     }
                     // Exclude the first length byte from the string result
-                    Some(String::from_utf8_lossy(&txt[1..len]).to_string())
+                    Some(String::from_utf8_lossy(&txt[1..=len]).to_string())
                 })
                 .transpose()
             })

--- a/base_layer/p2p/src/peer_seeds.rs
+++ b/base_layer/p2p/src/peer_seeds.rs
@@ -27,6 +27,7 @@ use std::{
 };
 
 use anyhow::anyhow;
+use log::*;
 use serde::{Deserialize, Serialize};
 use tari_common::DnsNameServer;
 use tari_comms::{
@@ -39,6 +40,8 @@ use tari_utilities::hex::Hex;
 
 use super::dns::DnsClientError;
 use crate::dns::DnsClient;
+
+const LOG_TARGET: &str = "tari::p2p::dns::client";
 
 #[derive(Clone)]
 pub struct DnsSeedResolver {
@@ -73,7 +76,19 @@ impl DnsSeedResolver {
     /// ```
     pub async fn resolve(&mut self, addr: &str) -> Result<Vec<SeedPeer>, DnsClientError> {
         let records = self.client.query_txt(addr).await?;
-        let peers = records.into_iter().filter_map(|txt| txt.parse().ok()).collect();
+        let peers = records
+            .into_iter()
+            .filter_map(|txt| {
+                txt.parse()
+                    .inspect(|err| {
+                        warn!(
+                            target: LOG_TARGET,
+                            "Failed to parse DNS seed peer string: {}. Error: {}", txt, err
+                        );
+                    })
+                    .ok()
+            })
+            .collect();
         Ok(peers)
     }
 }


### PR DESCRIPTION
Description
---
fix(dns): off by one error when reading TXT record
Log warning if a seed peer cannot be parsed

Motivation and Context
---
When decoding the TXT record, the length byte was not accounted for resulting in the last byte being omitted.


How Has This Been Tested?
---

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved boundary checks when extracting strings from DNS TXT records to prevent potential out-of-bounds errors.
- **New Features**
  - Added warning logs for failed parsing of DNS TXT records, providing better visibility into parsing issues during DNS seed resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->