### PR TITLE
feat: add getCompleteAddress to GRPC

### DIFF
--- a/applications/minotari_app_grpc/proto/wallet.proto
+++ b/applications/minotari_app_grpc/proto/wallet.proto
@@ -43,6 +43,8 @@ service Wallet {
   rpc Identify (GetIdentityRequest) returns (GetIdentityResponse);
   // This returns the tari address
   rpc GetAddress (Empty) returns (GetAddressResponse);
+  // Returns the address in multiple formats (binary, base58, and emoji)
+  rpc GetCompleteAddress (Empty) returns (GetCompleteAddressResponse);
   // Send Minotari to a number of recipients
   rpc Transfer (TransferRequest)  returns (TransferResponse);
   // Returns the transaction details for the given transaction IDs
@@ -94,6 +96,18 @@ message GetVersionResponse {
 message GetAddressResponse {
   bytes interactive_address = 1;
   bytes one_sided_address = 2;
+}
+
+message GetCompleteAddressResponse {
+  // Binary format addresses
+  bytes interactive_address = 1;
+  bytes one_sided_address = 2;
+  // Base58 encoded addresses
+  string interactive_address_base58 = 3;
+  string one_sided_address_base58 = 4;
+  // Emoji encoded addresses
+  string interactive_address_emoji = 5;
+  string one_sided_address_emoji = 6;
 }
 
 message TransferRequest {

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -84,6 +84,7 @@ use minotari_app_grpc::tari_rpc::{
     TransferResult,
     ValidateRequest,
     ValidateResponse,
+    GetCompleteAddressResponse,
 };
 use minotari_wallet::{
     connectivity_service::WalletConnectivityInterface,
@@ -255,6 +256,28 @@ impl wallet_server::Wallet for WalletGrpcServer {
         Ok(Response::new(GetAddressResponse {
             interactive_address: interactive_address.to_vec(),
             one_sided_address: one_sided_address.to_vec(),
+        }))
+    }
+
+    async fn get_complete_address(&self, _: Request<tari_rpc::Empty>) -> Result<Response<GetCompleteAddressResponse>, Status> {
+        let interactive_address = self
+            .wallet
+            .get_wallet_interactive_address()
+            .await
+            .map_err(|e| Status::internal(format!("{:?}", e)))?;
+        let one_sided_address = self
+            .wallet
+            .get_wallet_one_sided_address()
+            .await
+            .map_err(|e| Status::internal(format!("{:?}", e)))?;
+
+        Ok(Response::new(GetCompleteAddressResponse {
+            interactive_address: interactive_address.to_vec(),
+            one_sided_address: one_sided_address.to_vec(),
+            interactive_address_base58: interactive_address.to_base58(),
+            one_sided_address_base58: one_sided_address.to_base58(),
+            interactive_address_emoji: interactive_address.to_emoji_string(),
+            one_sided_address_emoji: one_sided_address.to_emoji_string(),
         }))
     }
 

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -51,6 +51,7 @@ use minotari_app_grpc::tari_rpc::{
     GetAddressResponse,
     GetBalanceRequest,
     GetBalanceResponse,
+    GetCompleteAddressResponse,
     GetCompletedTransactionsRequest,
     GetCompletedTransactionsResponse,
     GetConnectivityRequest,
@@ -84,7 +85,6 @@ use minotari_app_grpc::tari_rpc::{
     TransferResult,
     ValidateRequest,
     ValidateResponse,
-    GetCompleteAddressResponse,
 };
 use minotari_wallet::{
     connectivity_service::WalletConnectivityInterface,
@@ -259,7 +259,10 @@ impl wallet_server::Wallet for WalletGrpcServer {
         }))
     }
 
-    async fn get_complete_address(&self, _: Request<tari_rpc::Empty>) -> Result<Response<GetCompleteAddressResponse>, Status> {
+    async fn get_complete_address(
+        &self,
+        _: Request<tari_rpc::Empty>,
+    ) -> Result<Response<GetCompleteAddressResponse>, Status> {
         let interactive_address = self
             .wallet
             .get_wallet_interactive_address()


### PR DESCRIPTION
Description
---

Adds getCompleteAddress to the wallet GRPC interface which returns a complete set of address data:
```json
address: {
  interactiveAddress: <Buffer 02 03 8a ba 62 f2 56 e0 58 d6 29 b4 e8 26 b8 8d 74 0d 41 ff bb b4 2b 60 7d 11 4e 66 1a c1 7c c5 c8 34 44 c3 cb 8b bc ad ef 30 47 75 e7 72 a0 9c 7a 94 ... 17 more bytes>,
  oneSidedAddress: <Buffer 02 01 8a ba 62 f2 56 e0 58 d6 29 b4 e8 26 b8 8d 74 0d 41 ff bb b4 2b 60 7d 11 4e 66 1a c1 7c c5 c8 34 44 c3 cb 8b bc ad ef 30 47 75 e7 72 a0 9c 7a 94 ... 17 more bytes>,
  interactiveAddressBase58: '34DF3gsz43FKz3K1XoBTtwTuTrqCjXYNvFJYefRvdCcoFiNsW31WXab7WZb3aYMMPLPze6ptCc62rHhVVKo2Y4qr2NU',
  oneSidedAddressBase58: '32DF3gsz43FKz3K1XoBTtwTuTrqCjXYNvFJYefRvdCcoFiNsW31WXab7WZb3aYMMPLPze6ptCc62rHhVVKo2Y4qr2Ny',
  interactiveAddressEmoji: '🌈🌊🐵💤🏁🚓🎳🗽🎷🔦🍟💐😷🍗💡🐸🙈🌵🤖🧲💦💐🍣🎿🦋🌻🎩🏠🍉💳🐞💼📌🍳🎒💺📿🐶💨💈🚚🍬🎡🐗😱🐑👞👘🐜👅👂🎲🍄🐛👟🎵🐼⭐🎋👃😷👠🤠😎🎵⚽📎',
  oneSidedAddressEmoji: '🌈📟🐵💤🏁🚓🎳🗽🎷🔦🍟💐😷🍗💡🐸🙈🌵🤖🧲💦💐🍣🎿🦋🌻🎩🏠🍉💳🐞💼📌🍳🎒💺📿🐶💨💈🚚🍬🎡🐗😱🐑👞👘🐜👅👂🎲🍄🐛👟🎵🐼⭐🎋👃😷👠🤠😎🎵⚽😎'
}
```
Motivation and Context
---

Using the GRPC interface to extract address information required a lot of post-processing to get the same values that are presented in the console wallet.

How Has This Been Tested?
---

I ran the the wallet with grpc enabled and extracted the address and compared it to the console wallet.

What process can a PR reviewer use to test or verify this change?
---

Run the console wallet with grpc enabled and request the getCompleteAddress rpc endpoint.
<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new option to retrieve wallet addresses in multiple formats (binary, Base58, and emoji) via the gRPC API.
  - Users can now view both interactive and one-sided wallet addresses in all supported formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->