### PR TITLE
feat: add optional birthday

### DIFF
--- a/applications/minotari_console_wallet/src/automation/commands.rs
+++ b/applications/minotari_console_wallet/src/automation/commands.rs
@@ -2516,16 +2516,19 @@ pub async fn command_runner(
                 let private_view_key_hex = wallet.key_manager_service.get_private_view_key().await?.to_hex();
                 let spend_key_hex = spend_key.pub_key.to_hex();
                 let output_file = args.output_file;
+                let birthday = wallet.db.get_wallet_birthday()?;
                 #[derive(Serialize)]
                 struct ViewKeyFile {
                     view_key: String,
                     public_view_key: String,
                     spend_key: String,
+                    birthday: u16,
                 }
                 let view_key_file = ViewKeyFile {
                     view_key: private_view_key_hex.clone(),
                     public_view_key: view_key_hex.clone(),
                     spend_key: spend_key_hex.clone(),
+                    birthday,
                 };
                 let view_key_file_json =
                     serde_json::to_string(&view_key_file).map_err(|e| CommandError::JsonFile(e.to_string()))?;
@@ -2536,6 +2539,7 @@ pub async fn command_runner(
                 } else {
                     println!("View key: {}", private_view_key_hex);
                     println!("Spend key: {}", spend_key_hex);
+                    println!("Birthday: {}", birthday);
                 }
             },
             ImportPaperWallet(args) => {

--- a/applications/minotari_console_wallet/src/cli.rs
+++ b/applications/minotari_console_wallet/src/cli.rs
@@ -99,6 +99,8 @@ pub struct Cli {
     pub view_private_key: Option<String>,
     #[clap(long)]
     pub spend_key: Option<String>,
+    #[clap(long)]
+    pub birthday: Option<u16>,
     /// Path to the libtor data directory
     #[clap(short = 'z', long, parse(from_os_str))]
     pub libtor_data_dir: Option<PathBuf>,

--- a/applications/minotari_console_wallet/src/init/mod.rs
+++ b/applications/minotari_console_wallet/src/init/mod.rs
@@ -25,6 +25,7 @@
 use std::{fs, io, path::PathBuf, str::FromStr, sync::Arc, time::Instant};
 
 use crossterm::terminal::{disable_raw_mode, enable_raw_mode, is_raw_mode_enabled};
+use dialoguer::Input as InputPrompt;
 use digest::crypto_common::rand_core::OsRng;
 use log::*;
 use minotari_app_utilities::{consts, identity_management::setup_node_identity};
@@ -101,7 +102,7 @@ pub enum WalletBoot {
     New,
     Existing,
     Recovery,
-    ViewAndSpendKey,
+    ViewAndSpendKey { birthday: Option<u16> },
 }
 
 /// Get and confirm a passphrase from the user, with feedback
@@ -751,7 +752,7 @@ fn boot(cli: &Cli, wallet_config: &WalletConfig) -> Result<WalletBoot, ExitError
     }
 
     if !wallet_exists && cli.view_private_key.is_some() && cli.spend_key.is_some() {
-        return Ok(WalletBoot::ViewAndSpendKey);
+        return Ok(WalletBoot::ViewAndSpendKey { birthday: cli.birthday });
     }
 
     if wallet_exists {
@@ -791,7 +792,15 @@ fn boot(cli: &Cli, wallet_config: &WalletConfig) -> Result<WalletBoot, ExitError
                             return Ok(WalletBoot::Recovery);
                         },
                         "3" => {
-                            return Ok(WalletBoot::ViewAndSpendKey);
+                            let mut birthday = InputPrompt::<u16>::new()
+                                .with_prompt("Please enter wallet birth, or enter to skip ")
+                                .default(0)
+                                .interact()
+                                .unwrap_or(0);
+                            let birthday_option = if birthday == 0 { None } else { Some(birthday) };
+                            return Ok(WalletBoot::ViewAndSpendKey {
+                                birthday: birthday_option,
+                            });
                         },
                         _ => continue,
                     }
@@ -833,7 +842,7 @@ pub(crate) fn boot_with_password(
             debug!(target: LOG_TARGET, "Prompting for passphrase for existing wallet.");
             prompt_password("Enter wallet passphrase: ")?
         },
-        WalletBoot::ViewAndSpendKey => {
+        WalletBoot::ViewAndSpendKey { .. } => {
             debug!(target: LOG_TARGET, "Prompting for passphrase for view key wallet.");
             get_new_passphrase("Create wallet passphrase: ", "Confirm wallet passphrase: ")?
         },
@@ -849,12 +858,12 @@ pub fn prompt_wallet_type(
     view_private_key: Option<String>,
     spend_key: Option<String>,
 ) -> Option<WalletType> {
-    if non_interactive && !matches!(boot_mode, WalletBoot::ViewAndSpendKey) {
+    if non_interactive && !matches!(boot_mode, WalletBoot::ViewAndSpendKey { .. }) {
         return Some(WalletType::default());
     }
 
     match boot_mode {
-        WalletBoot::ViewAndSpendKey => {
+        WalletBoot::ViewAndSpendKey { birthday } => {
             let view_key = if let Some(vk) = view_private_key {
                 match PrivateKey::from_hex(&vk) {
                     Ok(pk) => pk,
@@ -883,6 +892,7 @@ pub fn prompt_wallet_type(
                 public_spend_key: spend_key,
                 private_spend_key: None,
                 private_comms_key: None,
+                birthday,
             }))
         },
         WalletBoot::New | WalletBoot::Recovery => {

--- a/applications/minotari_console_wallet/src/lib.rs
+++ b/applications/minotari_console_wallet/src/lib.rs
@@ -107,6 +107,7 @@ pub fn run_wallet(shutdown: &mut Shutdown, runtime: Runtime, config: &mut Applic
         profile_with_tokio_console: false,
         view_private_key: None,
         spend_key: None,
+        birthday: None,
         libtor_data_dir: None,
     };
 

--- a/base_layer/common_types/src/wallet_types.rs
+++ b/base_layer/common_types/src/wallet_types.rs
@@ -54,6 +54,7 @@ pub struct ProvidedKeysWallet {
     pub private_spend_key: Option<PrivateKey>,
     pub private_comms_key: Option<PrivateKey>,
     pub view_key: PrivateKey,
+    pub birthday: Option<u16>,
 }
 
 impl Display for ProvidedKeysWallet {

--- a/base_layer/wallet/src/utxo_scanner_service/utxo_scanner_task.rs
+++ b/base_layer/wallet/src/utxo_scanner_service/utxo_scanner_task.rs
@@ -267,15 +267,11 @@ where
                 // wallet birthday
                 self.resources.db.clear_scanned_blocks()?;
                 let scanning_start_height_hash = match self.resources.db.get_wallet_type()? {
-                    Some(WalletType::ProvidedKeys(_)) => {
-                        let header_proto = client.get_header_by_height(0).await?;
-                        let header = BlockHeader::try_from(header_proto).map_err(UtxoScannerError::ConversionError)?;
-                        HeightHash {
-                            height: 0,
-                            header_hash: header.hash(),
-                        }
+                    Some(WalletType::ProvidedKeys(wallet)) => {
+                        self.get_scanning_start_header_height_hash(&mut client, wallet.birthday)
+                            .await?
                     },
-                    _ => self.get_scanning_start_header_height_hash(&mut client).await?,
+                    _ => self.get_scanning_start_header_height_hash(&mut client, None).await?,
                 };
 
                 ScannedBlock {
@@ -749,8 +745,12 @@ where
     async fn get_scanning_start_header_height_hash(
         &self,
         client: &mut BaseNodeWalletRpcClient,
+        option_birthday: Option<u16>,
     ) -> Result<HeightHash, UtxoScannerError> {
-        let birthday = self.resources.db.get_wallet_birthday()?;
+        let birthday = match option_birthday {
+            Some(birthday) => birthday,
+            None => self.resources.db.get_wallet_birthday()?,
+        };
         let epoch_time_birthday = get_birthday_from_unix_epoch_in_seconds(birthday, 0);
         let block_height_birthday = client
             .get_height_at_time(epoch_time_birthday)

--- a/base_layer/wallet/tests/transaction_service_tests/service.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/service.rs
@@ -234,6 +234,7 @@ async fn setup_transaction_service<P: AsRef<Path>>(
         private_spend_key: Some(node_identity.secret_key().clone()),
         view_key: SK::random(&mut OsRng),
         private_comms_key: Some(node_identity.secret_key().clone()),
+        birthday: None
     }));
     let handles = StackBuilder::new(shutdown_signal)
         .add_initializer(RegisterHandle::new(dht))

--- a/base_layer/wallet/tests/transaction_service_tests/service.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/service.rs
@@ -234,7 +234,7 @@ async fn setup_transaction_service<P: AsRef<Path>>(
         private_spend_key: Some(node_identity.secret_key().clone()),
         view_key: SK::random(&mut OsRng),
         private_comms_key: Some(node_identity.secret_key().clone()),
-        birthday: None
+        birthday: None,
     }));
     let handles = StackBuilder::new(shutdown_signal)
         .add_initializer(RegisterHandle::new(dht))

--- a/integration_tests/src/wallet_process.rs
+++ b/integration_tests/src/wallet_process.rs
@@ -235,6 +235,7 @@ pub fn get_default_cli() -> Cli {
         command2: None,
         profile_with_tokio_console: false,
         view_private_key: None,
+        birthday: None,
         spend_key: None,
         libtor_data_dir: None,
     }


### PR DESCRIPTION
Description
---
Allows users to specify the wallet birthday

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for specifying an optional wallet birthday when creating or exporting wallets using view and spend keys.
  - Wallet birthday can be set via a command-line argument or interactively during wallet setup.
  - Exported view and spend key files now include the wallet birthday.
- **Refactor**
  - Improved logic for determining the scanning start point during wallet initialization, now considering the wallet birthday.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->