### PR TITLE
chore(ci): fix other linux builds for merge mining proxy

### DIFF
--- a/applications/minotari_merge_mining_proxy/src/common/proxy.rs
+++ b/applications/minotari_merge_mining_proxy/src/common/proxy.rs
@@ -25,8 +25,8 @@
 use std::convert::TryInto;
 
 use bytes::BytesMut;
-use futures::StreamExt;
 use hyper::{header, header::HeaderValue, http::response, Body, Response, StatusCode, Version};
+use hyper::body::HttpBody;
 use reqwest::{ResponseBuilderExt, Url};
 use serde_json as json;
 
@@ -86,7 +86,7 @@ pub fn into_body_from_response(resp: Response<json::Value>) -> Response<Body> {
 /// Reads the body until there is no more to read.
 pub async fn read_body_until_end(body: &mut Body) -> Result<BytesMut, MmProxyError> {
     let mut bytes = BytesMut::new();
-    while let Some(data) = body.next().await {
+    while let Some(data) = body.data().await {
         let data = data?;
         bytes.extend(data);
     }

--- a/applications/minotari_merge_mining_proxy/src/common/proxy.rs
+++ b/applications/minotari_merge_mining_proxy/src/common/proxy.rs
@@ -25,8 +25,7 @@
 use std::convert::TryInto;
 
 use bytes::BytesMut;
-use hyper::{header, header::HeaderValue, http::response, Body, Response, StatusCode, Version};
-use hyper::body::HttpBody;
+use hyper::{body::HttpBody, header, header::HeaderValue, http::response, Body, Response, StatusCode, Version};
 use reqwest::{ResponseBuilderExt, Url};
 use serde_json as json;
 


### PR DESCRIPTION
Description
Fix linux arm64/riscv builds for minotari_merge_mining_proxy 
by using .data().await instead of .next().await

Motivation and Context
Fix linux-arm64 / linux-riscv builds

How Has This Been Tested?
Builds locally and in local fork

Additional information that should possible be kept. When compiling minotari_merge_mining_proxy with libtor feature, build on linux-arm64 and linux-riscv64 fails with the following
```
error[E0599]: the method `next` exists for mutable reference `&mut Body`, but its trait bounds were not satisfied
  --> applications/minotari_merge_mining_proxy/src/common/proxy.rs:89:33
   |
89 |     while let Some(data) = body.next().await {
   |                                 ^^^^ method cannot be called on `&mut Body` due to unsatisfied trait bounds
   |
  ::: /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/hyper-0.14.31/src/body/body.rs:38:1
   |
38 | pub struct Body {
   | --------------- doesn't satisfy `hyper::Body: Iterator`, `hyper::Body: Stream` or `hyper::Body: futures::StreamExt`
   |
   = note: the following trait bounds were not satisfied:
           `hyper::Body: Stream`
           which is required by `hyper::Body: futures::StreamExt`
           `&mut hyper::Body: Stream`
           which is required by `&mut hyper::Body: futures::StreamExt`
           `hyper::Body: Iterator`
           which is required by `&mut hyper::Body: Iterator`

For more information about this error, try `rustc --explain E0599`.
error: could not compile `minotari_merge_mining_proxy` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
Error: Process completed with exit code 101.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated the method for reading HTTP body data to improve compatibility and maintainability. No changes to user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->