### PR TITLE
feat(grpc): return best block height from synced node

### DIFF
--- a/applications/minotari_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/minotari_node/src/grpc/base_node_grpc_server.rs
@@ -2268,6 +2268,14 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
             .state_info
             .clone();
         let short_desc = state.short_desc();
+
+        let mut handler = self.node_service.clone();
+        let report_error_flag = self.report_error_flag();
+        let meta = handler
+            .get_metadata()
+            .await
+            .map_err(|e| obscure_error_if_true(report_error_flag, Status::internal(e.to_string())))?;
+
         let response = match state {
             StateInfo::HeaderSync(None) => tari_rpc::SyncProgressResponse {
                 tip_height: 0,
@@ -2298,8 +2306,8 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
                 initial_connected_peers: 0,
             },
             _ => tari_rpc::SyncProgressResponse {
-                tip_height: 0,
-                local_height: 0,
+                tip_height: if state.is_synced() { meta.best_block_height() } else { 0 },
+                local_height: if state.is_synced() { meta.best_block_height() } else { 0 },
                 state: if state.is_synced() {
                     tari_rpc::SyncState::Done.into()
                 } else {


### PR DESCRIPTION
Description
---
Adds `tip_height` and `local_height` to `get_sync_status`

Motivation and Context
---
TU checks flag `initial_sync_achieved` from `get_tip_info` and also calls `get_sync_progress` to get `tip_height` but if `initial_sync_achieved` is true then these 2 fields are 0 and we can't check tip after syncing.

How Has This Been Tested?
---

What process can a PR reviewer use to test or verify this change?
---



Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accuracy of sync progress reporting by displaying the actual best block height when the node is synced, instead of showing zero values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->