### PR TITLE
chore(metrics): remove peer-id label from metrics

### DIFF
--- a/base_layer/core/src/mempool/metrics.rs
+++ b/base_layer/core/src/mempool/metrics.rs
@@ -21,35 +21,30 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use once_cell::sync::Lazy;
-use tari_comms::peer_manager::NodeId;
-use tari_metrics::{IntCounter, IntCounterVec, IntGauge};
+use tari_metrics::{IntCounter, IntGauge};
 
-pub fn inbound_transactions(sent_by: Option<&NodeId>) -> IntCounter {
-    static METER: Lazy<IntCounterVec> = Lazy::new(|| {
-        tari_metrics::register_int_counter_vec(
+pub fn inbound_transactions() -> IntCounter {
+    static METER: Lazy<IntCounter> = Lazy::new(|| {
+        tari_metrics::register_int_counter(
             "base_node::mempool::inbound_transactions",
             "Number of valid inbound transactions in the mempool",
-            &["peer_id"],
         )
         .unwrap()
     });
 
-    let sent_by = sent_by.map(|n| n.to_string()).unwrap_or_else(|| "local".to_string());
-    METER.with_label_values(&[&sent_by])
+    METER.clone()
 }
 
-pub fn rejected_inbound_transactions(sent_by: Option<&NodeId>) -> IntCounter {
-    static METER: Lazy<IntCounterVec> = Lazy::new(|| {
-        tari_metrics::register_int_counter_vec(
+pub fn rejected_inbound_transactions() -> IntCounter {
+    static METER: Lazy<IntCounter> = Lazy::new(|| {
+        tari_metrics::register_int_counter(
             "base_node::mempool::rejected_inbound_transactions",
             "Number of valid inbound transactions in the mempool",
-            &["peer_id"],
         )
         .unwrap()
     });
 
-    let sent_by = sent_by.map(|n| n.to_string()).unwrap_or_else(|| "local".to_string());
-    METER.with_label_values(&[&sent_by])
+    METER.clone()
 }
 
 pub fn unconfirmed_pool_size() -> IntGauge {

--- a/base_layer/core/src/mempool/service/inbound_handlers.rs
+++ b/base_layer/core/src/mempool/service/inbound_handlers.rs
@@ -138,9 +138,9 @@ impl MempoolInboundHandlers {
             Ok(tx_storage) => {
                 #[cfg(feature = "metrics")]
                 if tx_storage.is_stored() {
-                    metrics::inbound_transactions(source_peer.as_ref()).inc();
+                    metrics::inbound_transactions().inc();
                 } else {
-                    metrics::rejected_inbound_transactions(source_peer.as_ref()).inc();
+                    metrics::rejected_inbound_transactions().inc();
                 }
                 self.update_pool_size_metrics().await;
 

--- a/base_layer/core/src/mempool/sync_protocol/mod.rs
+++ b/base_layer/core/src/mempool/sync_protocol/mod.rs
@@ -584,7 +584,7 @@ where TSubstream: AsyncRead + AsyncWrite + Unpin
         let stored_result = self.mempool.insert(txn).await?;
         if stored_result.is_stored() {
             #[cfg(feature = "metrics")]
-            metrics::inbound_transactions(Some(&self.peer_node_id)).inc();
+            metrics::inbound_transactions().inc();
             debug!(
                 target: LOG_TARGET,
                 "Inserted transaction `{}` from peer `{}`",
@@ -593,7 +593,7 @@ where TSubstream: AsyncRead + AsyncWrite + Unpin
             );
         } else {
             #[cfg(feature = "metrics")]
-            metrics::rejected_inbound_transactions(Some(&self.peer_node_id)).inc();
+            metrics::rejected_inbound_transactions().inc();
             debug!(
                 target: LOG_TARGET,
                 "Did not store new transaction `{}` in mempool: {}", excess_sig_hex, stored_result

--- a/comms/core/src/connectivity/manager.rs
+++ b/comms/core/src/connectivity/manager.rs
@@ -1116,7 +1116,7 @@ impl ConnectivityManagerActor {
         self.peer_manager.ban_peer_by_node_id(node_id, duration, reason).await?;
 
         #[cfg(feature = "metrics")]
-        super::metrics::banned_peers_counter(node_id).inc();
+        super::metrics::banned_peers_counter().inc();
 
         self.publish_event(ConnectivityEvent::PeerBanned(node_id.clone()));
 

--- a/comms/core/src/connectivity/metrics.rs
+++ b/comms/core/src/connectivity/metrics.rs
@@ -21,9 +21,9 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use once_cell::sync::Lazy;
-use tari_metrics::{IntCounter, IntCounterVec, IntGauge, IntGaugeVec};
+use tari_metrics::{IntCounter, IntGauge, IntGaugeVec};
 
-use crate::{connection_manager::ConnectionDirection, peer_manager::NodeId};
+use crate::connection_manager::ConnectionDirection;
 
 pub fn connections(direction: ConnectionDirection) -> IntGauge {
     static METER: Lazy<IntGaugeVec> = Lazy::new(|| {
@@ -45,15 +45,11 @@ pub fn uptime() -> IntGauge {
     METER.clone()
 }
 
-pub fn banned_peers_counter(peer: &NodeId) -> IntCounter {
-    static METER: Lazy<IntCounterVec> = Lazy::new(|| {
-        tari_metrics::register_int_counter_vec(
-            "comms::connectivity::banned_peers",
-            "The number of peer bans by peer",
-            &["peer_id"],
-        )
-        .unwrap()
+pub fn banned_peers_counter() -> IntCounter {
+    static METER: Lazy<IntCounter> = Lazy::new(|| {
+        tari_metrics::register_int_counter("comms::connectivity::banned_peers", "The number of peer bans by peer")
+            .unwrap()
     });
 
-    METER.with_label_values(&[peer.to_string().as_str()])
+    METER.clone()
 }


### PR DESCRIPTION
Description
---

Motivation and Context
---

How Has This Been Tested?
---

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Simplified metrics counters by removing peer-specific labels from transaction and banned peer metrics. Metrics now aggregate counts without differentiating by peer ID.
- **Chores**
  - Updated internal usage and imports to reflect changes in metrics handling. No changes to user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->