### PR TITLE
fix(dns): switch from relative to absolute DNS record for checkpoints

### DIFF
--- a/base_layer/core/src/base_node/tari_pulse_service/mod.rs
+++ b/base_layer/core/src/base_node/tari_pulse_service/mod.rs
@@ -74,12 +74,13 @@ impl Default for TariPulseConfig {
 
 fn get_network_dns_name(network: Network) -> &'static str {
     match network {
-        Network::NextNet => "checkpoints-nextnet.tari.com",
-        Network::MainNet => "checkpoints-mainnet.tari.com",
-        Network::Esmeralda => "checkpoints-esmeralda.tari.com",
-        Network::StageNet => "checkpoints-stagenet.tari.com",
-        Network::Igor => "checkpoints-igor.tari.com",
-        Network::LocalNet => "checkpoints-localnet.tari.com",
+        Network::NextNet => "checkpoints-nextnet.tari.com.",
+        Network::MainNet => "checkpoints-mainnet.tari.com.",
+        // Network::Esmeralda => "checkpoints-esmeralda.tari.com.",
+        Network::Esmeralda => "checkpoints-esme.tari.com.",
+        Network::StageNet => "checkpoints-stagenet.tari.com.",
+        Network::Igor => "checkpoints-igor.tari.com.",
+        Network::LocalNet => "checkpoints-localnet.tari.com.",
     }
 }
 


### PR DESCRIPTION
Description
fix(dns): switch from relative to absolute DNS record to ensure proper resolution for checkpoints

Motivation and Context
Reduce DNS warnings in node
```
09:42 WARN  Failed to fetch DNS checkpoints: Resolve error: proto error: no records found for Query { name: Name("checkpoints-esmeralda.tari.com.mynetwork.lan."), query_type: TXT, query_class: IN }
09:42 WARN  Failed to check if node has passed checkpoints: Resolve error: proto error: no records found for Query { name: Name("checkpoints-esmeralda.tari.com.mynetwork.lan."), query_type: TXT, query_class: IN }
```

How Has This Been Tested?
Builds and runs locally without warnings

Background
Computers that have search suffix in ``` /etc/resolv.conf``` or similar offered by DHCP or network provision services, might run into this problem.
```
search eu-west-1.compute.internal
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated network DNS names to consistently include a trailing dot.
  - Changed the DNS name for the Esmeralda network to "checkpoints-esme.tari.com." for improved accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->