### PR TITLE
feat: change wallet birthday offset

### DIFF
--- a/base_layer/wallet/src/config.rs
+++ b/base_layer/wallet/src/config.rs
@@ -121,6 +121,8 @@ pub struct WalletConfig {
     /// responsiveness of the wallet with slightly delayed balance updates
     #[serde(with = "serializers::seconds")]
     pub balance_enquiry_cooldown_period: Duration,
+    // How many days do we need to start scanning before our actual birthday
+    pub birthday_offset: u16,
 }
 
 impl Default for WalletConfig {
@@ -160,6 +162,7 @@ impl Default for WalletConfig {
             use_libtor: true,
             identity_file: None,
             balance_enquiry_cooldown_period: Duration::from_secs(5),
+            birthday_offset: 2,
         }
     }
 }

--- a/base_layer/wallet/src/utxo_scanner_service/initializer.rs
+++ b/base_layer/wallet/src/utxo_scanner_service/initializer.rs
@@ -51,18 +51,20 @@ pub struct UtxoScannerServiceInitializer<T, TKeyManagerInterface> {
     backend: Option<WalletDatabase<T>>,
     factories: CryptoFactories,
     network: Network,
+    birthday_offset: u16,
     phantom: PhantomData<TKeyManagerInterface>,
 }
 
 impl<T, TKeyManagerInterface> UtxoScannerServiceInitializer<T, TKeyManagerInterface>
 where T: WalletBackend + 'static
 {
-    pub fn new(backend: WalletDatabase<T>, factories: CryptoFactories, network: Network) -> Self {
+    pub fn new(backend: WalletDatabase<T>, factories: CryptoFactories, network: Network, birthday_offset: u16) -> Self {
         Self {
             backend: Some(backend),
             factories,
             network,
             phantom: PhantomData,
+            birthday_offset,
         }
     }
 }
@@ -95,6 +97,7 @@ where
             .expect("Cannot start Utxo scanner service without setting a storage backend");
         let factories = self.factories.clone();
         let network = self.network;
+        let birthday_offset = self.birthday_offset;
 
         context.spawn_when_ready(move |handles| async move {
             let transaction_service = handles.expect_handle::<TransactionServiceHandle>();
@@ -136,6 +139,7 @@ where
                     base_node_service_handle,
                     one_sided_message_watch_receiver,
                     recovery_message_watch_receiver,
+                    birthday_offset,
                 )
                 .await
                 .run();

--- a/base_layer/wallet/src/utxo_scanner_service/service.rs
+++ b/base_layer/wallet/src/utxo_scanner_service/service.rs
@@ -102,6 +102,7 @@ where
             num_retries: 1,
             mode: self.mode.clone(),
             shutdown_signal,
+            birthday_offset: self.resources.birthday_offset,
         }
     }
 
@@ -197,6 +198,7 @@ pub struct UtxoScannerResources<TBackend, TWalletConnectivity> {
     pub factories: CryptoFactories,
     pub recovery_message: String,
     pub one_sided_payment_message: String,
+    pub birthday_offset: u16,
 }
 
 #[derive(Debug, Clone)]

--- a/base_layer/wallet/src/utxo_scanner_service/utxo_scanner_task.rs
+++ b/base_layer/wallet/src/utxo_scanner_service/utxo_scanner_task.rs
@@ -81,6 +81,7 @@ pub struct UtxoScannerTask<TBackend, TWalletConnectivity> {
     pub(crate) peer_index: usize,
     pub(crate) mode: UtxoScannerMode,
     pub(crate) shutdown_signal: ShutdownSignal,
+    pub birthday_offset: u16,
 }
 impl<TBackend, TWalletConnectivity> UtxoScannerTask<TBackend, TWalletConnectivity>
 where
@@ -759,9 +760,9 @@ where
                 warn!(target: LOG_TARGET, "Problem requesting `height_at_time` from Base Node: {}", e);
                 0
             });
-        // Calculate the unix epoch time of two weeks (14 days), in seconds, before the
+        // Calculate the unix epoch time of 2 days, in seconds, before the
         // wallet birthday. The latter avoids any possible issues with reorgs.
-        let epoch_time_scanning_start = get_birthday_from_unix_epoch_in_seconds(birthday, 14u16);
+        let epoch_time_scanning_start = get_birthday_from_unix_epoch_in_seconds(birthday, self.birthday_offset);
         let block_height_scanning_start = client
             .get_height_at_time(epoch_time_scanning_start)
             .await

--- a/base_layer/wallet/src/utxo_scanner_service/uxto_scanner_service_builder.rs
+++ b/base_layer/wallet/src/utxo_scanner_service/uxto_scanner_service_builder.rs
@@ -118,6 +118,7 @@ impl UtxoScannerServiceBuilder {
             factories: wallet.factories.clone(),
             recovery_message: self.recovery_message.clone(),
             one_sided_payment_message: self.one_sided_message.clone(),
+            birthday_offset: wallet.config.birthday_offset,
         };
 
         let (event_sender, _) = broadcast::channel(200);
@@ -153,6 +154,7 @@ impl UtxoScannerServiceBuilder {
         base_node_service: BaseNodeServiceHandle,
         one_sided_message_watch: watch::Receiver<String>,
         recovery_message_watch: watch::Receiver<String>,
+        birthday_offset: u16,
     ) -> UtxoScannerService<TBackend, TWalletConnectivity> {
         let resources = UtxoScannerResources {
             db,
@@ -165,6 +167,7 @@ impl UtxoScannerServiceBuilder {
             factories,
             recovery_message: self.recovery_message.clone(),
             one_sided_payment_message: self.one_sided_message.clone(),
+            birthday_offset,
         };
 
         UtxoScannerService::new(

--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -160,6 +160,7 @@ pub struct Wallet<T, U, V, W, TKeyManagerInterface> {
     pub output_db: OutputManagerDatabase<V>,
     pub factories: CryptoFactories,
     wallet_type: Arc<WalletType>,
+    pub config: WalletConfig,
     _u: PhantomData<U>,
     _v: PhantomData<V>,
     _w: PhantomData<W>,
@@ -213,7 +214,7 @@ where
                 publisher,
             ))
             .add_initializer(OutputManagerServiceInitializer::<V, TKeyManagerInterface>::new(
-                config.output_manager_service_config,
+                config.output_manager_service_config.clone(),
                 output_manager_backend.clone(),
                 factories.clone(),
                 config.network.into(),
@@ -225,7 +226,7 @@ where
                 wallet_type.clone(),
             ))
             .add_initializer(TransactionServiceInitializer::<U, T, TKeyManagerInterface>::new(
-                config.transaction_service_config,
+                config.transaction_service_config.clone(),
                 peer_message_subscription_factory.clone(),
                 transaction_backend,
                 node_identity.clone(),
@@ -254,11 +255,14 @@ where
                 config.base_node_service_config.clone(),
                 wallet_database.clone(),
             ))
-            .add_initializer(WalletConnectivityInitializer::new(config.base_node_service_config))
+            .add_initializer(WalletConnectivityInitializer::new(
+                config.base_node_service_config.clone(),
+            ))
             .add_initializer(UtxoScannerServiceInitializer::<T, TKeyManagerInterface>::new(
                 wallet_database.clone(),
                 factories.clone(),
                 config.network,
+                config.birthday_offset,
             ));
 
         // Check if we have update config. FFI wallets don't do this, the update on mobile is done differently.
@@ -315,10 +319,10 @@ where
                     }
                 });
             };
-            initialization::spawn_comms_using_transport(comms, config.p2p.transport, after_comms).await?
+            initialization::spawn_comms_using_transport(comms, config.p2p.transport.clone(), after_comms).await?
         } else {
             let after_comms = |_identity| {};
-            initialization::spawn_comms_using_transport(comms, config.p2p.transport, after_comms).await?
+            initialization::spawn_comms_using_transport(comms, config.p2p.transport.clone(), after_comms).await?
         };
 
         let mut output_manager_handle = handles.expect_handle::<OutputManagerHandle>();
@@ -376,6 +380,7 @@ where
             output_db: output_manager_database,
             factories,
             wallet_type,
+            config,
             _u: PhantomData,
             _v: PhantomData,
             _w: PhantomData,

--- a/base_layer/wallet/tests/transaction_service_tests/service.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/service.rs
@@ -282,6 +282,7 @@ async fn setup_transaction_service<P: AsRef<Path>>(
             db,
             factories.clone(),
             Network::LocalNet,
+            14,
         ))
         .build()
         .await

--- a/base_layer/wallet/tests/utxo_scanner/mod.rs
+++ b/base_layer/wallet/tests/utxo_scanner/mod.rs
@@ -101,6 +101,7 @@ pub struct UtxoScannerTestInterface {
     _temp_dir: TempDir,
 }
 
+#[allow(clippy::too_many_lines)]
 async fn setup(
     key_manager: MemoryDbKeyManager,
     mode: UtxoScannerMode,

--- a/base_layer/wallet/tests/utxo_scanner/mod.rs
+++ b/base_layer/wallet/tests/utxo_scanner/mod.rs
@@ -213,6 +213,7 @@ async fn setup(
             base_node_service_handle,
             one_sided_message_watch_receiver,
             recovery_message_watch_receiver,
+            14,
         )
         .await;
 

--- a/common/config/presets/d_console_wallet.toml
+++ b/common/config/presets/d_console_wallet.toml
@@ -99,6 +99,8 @@
 # For specialized wallets processing many batch transactions this setting could be increased to 60 s to retain
 # responsiveness of the wallet with slightly delayed balance updates (default = 5):
 #balance_enquiry_cooldown_period = 5
+#The defaul offset for scanning from the birthday, it will start at the birthday - the offset
+#birthday_offset = 2
 
 [wallet.transactions]
 # This is the timeout period that will be used for base node broadcast monitoring tasks (default = 30)


### PR DESCRIPTION
Description
---
changes the wallet birthday offset from 2 weeks to 2 days. Allows users to set it to a custom number if so desired 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a configurable "birthday offset" setting that allows users to adjust how many days before the wallet's creation date scanning for transactions begins.
  - Added this new option to wallet configuration and included documentation for it in the sample configuration file.

- **Documentation**
  - Updated sample configuration file to describe the new "birthday offset" option.

- **Bug Fixes**
  - No user-facing bug fixes included in this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->