### PR TITLE
feat: create new payment_id enabled address format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6974,6 +6974,7 @@ dependencies = [
  "strum_macros",
  "tari_common",
  "tari_crypto",
+ "tari_max_size",
  "tari_utilities",
  "thiserror 1.0.69",
 ]

--- a/applications/minotari_app_grpc/proto/wallet.proto
+++ b/applications/minotari_app_grpc/proto/wallet.proto
@@ -44,7 +44,7 @@ service Wallet {
   // This returns the tari address
   rpc GetAddress (Empty) returns (GetAddressResponse);
   // This returns the payment id tari address
-  rpc GetPaymentIdAddress (GetPaymentIdAddressRequest) returns (GetAddressResponse);
+  rpc GetPaymentIdAddress (GetPaymentIdAddressRequest) returns (GetCompleteAddressResponse);
   // Returns the address in multiple formats (binary, base58, and emoji)
   rpc GetCompleteAddress (Empty) returns (GetCompleteAddressResponse);
   // Send Minotari to a number of recipients

--- a/applications/minotari_app_grpc/proto/wallet.proto
+++ b/applications/minotari_app_grpc/proto/wallet.proto
@@ -43,6 +43,8 @@ service Wallet {
   rpc Identify (GetIdentityRequest) returns (GetIdentityResponse);
   // This returns the tari address
   rpc GetAddress (Empty) returns (GetAddressResponse);
+  // This returns the payment id tari address
+  rpc GetPaymentIdAddress (GetPaymentIdAddressRequest) returns (GetAddressResponse);
   // Returns the address in multiple formats (binary, base58, and emoji)
   rpc GetCompleteAddress (Empty) returns (GetCompleteAddressResponse);
   // Send Minotari to a number of recipients
@@ -96,6 +98,10 @@ message GetVersionResponse {
 message GetAddressResponse {
   bytes interactive_address = 1;
   bytes one_sided_address = 2;
+}
+
+message GetPaymentIdAddressRequest {
+  bytes payment_id = 1;
 }
 
 message GetCompleteAddressResponse {

--- a/applications/minotari_console_wallet/src/automation/commands.rs
+++ b/applications/minotari_console_wallet/src/automation/commands.rs
@@ -816,7 +816,7 @@ pub async fn command_runner(
                     transaction_service.clone(),
                     config.fee_per_gram,
                     args.amount,
-                    PaymentId::open(&args.payment_id, TxType::Burn),
+                    PaymentId::open_from_string(&args.payment_id, TxType::Burn),
                 )
                 .await
                 {
@@ -994,7 +994,7 @@ pub async fn command_runner(
                     output_hash,
                     commitment.clone(),
                     args.recipient_address.clone(),
-                    PaymentId::open(
+                    PaymentId::open_from_string(
                         &args.payment_id,
                         detect_tx_metadata(&wallet, args.recipient_address).await,
                     ),
@@ -1357,7 +1357,7 @@ pub async fn command_runner(
                         } else {
                             UseOutput::FromBlockchain(embedded_output.hash())
                         },
-                        PaymentId::open(
+                        PaymentId::open_from_string(
                             &args.payment_id,
                             detect_tx_metadata(&wallet, current_recipient_address).await,
                         ),
@@ -2035,7 +2035,7 @@ pub async fn command_runner(
                     config.fee_per_gram,
                     args.amount,
                     args.destination.clone(),
-                    PaymentId::open(&args.payment_id, detect_tx_metadata(&wallet, args.destination).await),
+                    PaymentId::open_from_string(&args.payment_id, detect_tx_metadata(&wallet, args.destination).await),
                 )
                 .await
                 {
@@ -2053,7 +2053,7 @@ pub async fn command_runner(
                     args.amount,
                     UtxoSelectionCriteria::default(),
                     args.destination.clone(),
-                    PaymentId::open(&args.payment_id, detect_tx_metadata(&wallet, args.destination).await),
+                    PaymentId::open_from_string(&args.payment_id, detect_tx_metadata(&wallet, args.destination).await),
                 )
                 .await
                 {
@@ -2079,7 +2079,7 @@ pub async fn command_runner(
                     args.start_time.unwrap_or_else(Utc::now),
                     args.destination.clone(),
                     transaction_type,
-                    PaymentId::open(&args.payment_id, detect_tx_metadata(&wallet, args.destination).await),
+                    PaymentId::open_from_string(&args.payment_id, detect_tx_metadata(&wallet, args.destination).await),
                 )
                 .await
                 {
@@ -2091,7 +2091,7 @@ pub async fn command_runner(
                     args.amount_per_split,
                     args.num_splits,
                     args.fee_per_gram,
-                    PaymentId::open(&args.payment_id, TxType::CoinSplit),
+                    PaymentId::open_from_string(&args.payment_id, TxType::CoinSplit),
                     &mut output_service,
                     &mut transaction_service.clone(),
                 )
@@ -2293,7 +2293,7 @@ pub async fn command_runner(
                     args.amount,
                     UtxoSelectionCriteria::default(),
                     args.destination,
-                    PaymentId::open(&args.payment_id, TxType::ClaimAtomicSwap),
+                    PaymentId::open_from_string(&args.payment_id, TxType::ClaimAtomicSwap),
                 )
                 .await
                 {
@@ -2316,7 +2316,7 @@ pub async fn command_runner(
                         hash,
                         args.pre_image.into(),
                         config.fee_per_gram.into(),
-                        PaymentId::open(&args.payment_id, TxType::ClaimAtomicSwap),
+                        PaymentId::open_from_string(&args.payment_id, TxType::ClaimAtomicSwap),
                     )
                     .await
                     {
@@ -2336,7 +2336,7 @@ pub async fn command_runner(
                         transaction_service.clone(),
                         hash,
                         config.fee_per_gram.into(),
-                        PaymentId::open(&args.payment_id, TxType::HtlcAtomicSwapRefund),
+                        PaymentId::open_from_string(&args.payment_id, TxType::HtlcAtomicSwapRefund),
                     )
                     .await
                     {
@@ -2377,7 +2377,7 @@ pub async fn command_runner(
                     ),
                     UtxoSelectionCriteria::default(),
                     config.fee_per_gram * uT,
-                    PaymentId::open(&args.payment_id, TxType::ValidatorNodeRegistration),
+                    PaymentId::open_from_string(&args.payment_id, TxType::ValidatorNodeRegistration),
                 )
                 .await?;
                 debug!(target: LOG_TARGET, "Registering VN tx_id {}", tx_id);

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -263,7 +263,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
     async fn get_payment_id_address(
         &self,
         request: Request<GetPaymentIdAddressRequest>,
-    ) -> Result<Response<GetAddressResponse>, Status> {
+    ) -> Result<Response<GetCompleteAddressResponse>, Status> {
         let message = request.into_inner();
 
         let interactive_address = self
@@ -282,9 +282,13 @@ impl wallet_server::Wallet for WalletGrpcServer {
         let one_sided_address = one_sided_address
             .create_payment_id_address(message.payment_id)
             .map_err(|e| Status::internal(format!("{:?}", e)))?;
-        Ok(Response::new(GetAddressResponse {
+        Ok(Response::new(GetCompleteAddressResponse {
             interactive_address: interactive_address.to_vec(),
             one_sided_address: one_sided_address.to_vec(),
+            interactive_address_base58: interactive_address.to_base58(),
+            one_sided_address_base58: one_sided_address.to_base58(),
+            interactive_address_emoji: interactive_address.to_emoji_string(),
+            one_sided_address_emoji: one_sided_address.to_emoji_string(),
         }))
     }
 

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -49,6 +49,7 @@ use minotari_app_grpc::tari_rpc::{
     CreateTemplateRegistrationRequest,
     CreateTemplateRegistrationResponse,
     GetAddressResponse,
+    GetPaymentIdAddressRequest,
     GetBalanceRequest,
     GetBalanceResponse,
     GetCompleteAddressResponse,
@@ -253,6 +254,28 @@ impl wallet_server::Wallet for WalletGrpcServer {
             .get_wallet_one_sided_address()
             .await
             .map_err(|e| Status::internal(format!("{:?}", e)))?;
+        Ok(Response::new(GetAddressResponse {
+            interactive_address: interactive_address.to_vec(),
+            one_sided_address: one_sided_address.to_vec(),
+        }))
+    }
+
+    async fn get_payment_id_address(&self, request: Request<GetPaymentIdAddressRequest>) -> Result<Response<GetAddressResponse>, Status> {
+        let message = request.into_inner();
+
+
+        let interactive_address = self
+            .wallet
+            .get_wallet_interactive_address()
+            .await
+            .map_err(|e| Status::internal(format!("{:?}", e)))?;
+        let interactive_address = interactive_address.create_payment_id_address(message.payment_id.clone()).map_err(|e| Status::internal(format!("{:?}", e)))?;
+        let one_sided_address = self
+            .wallet
+            .get_wallet_one_sided_address()
+            .await
+            .map_err(|e| Status::internal(format!("{:?}", e)))?;
+        let one_sided_address = one_sided_address.create_payment_id_address(message.payment_id).map_err(|e| Status::internal(format!("{:?}", e)))?;
         Ok(Response::new(GetAddressResponse {
             interactive_address: interactive_address.to_vec(),
             one_sided_address: one_sided_address.to_vec(),

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -496,7 +496,10 @@ impl wallet_server::Wallet for WalletGrpcServer {
                         tx_id,
                         tx,
                         amount,
-                        PaymentId::open("Claiming HTLC transaction with pre-image", TxType::ClaimAtomicSwap),
+                        PaymentId::open_from_string(
+                            "Claiming HTLC transaction with pre-image",
+                            TxType::ClaimAtomicSwap,
+                        ),
                     )
                     .await
                 {
@@ -551,7 +554,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
                         tx_id,
                         tx,
                         amount,
-                        PaymentId::open("Creating HTLC refund transaction", TxType::HtlcAtomicSwapRefund),
+                        PaymentId::open_from_string("Creating HTLC refund transaction", TxType::HtlcAtomicSwapRefund),
                     )
                     .await
                 {
@@ -921,7 +924,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
                 usize::try_from(message.split_count)
                     .map_err(|_| Status::internal("Count not convert u64 to usize".to_string()))?,
                 MicroMinotari::from(message.fee_per_gram),
-                PaymentId::open("Creating coin-split transaction", TxType::CoinSplit),
+                PaymentId::open_from_string("Creating coin-split transaction", TxType::CoinSplit),
             )
             .await
             .map_err(|e| Status::internal(format!("{:?}", e)))?;
@@ -1072,7 +1075,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
             .map_err(|e| Status::internal(e.to_string()))?;
 
         output = output.with_script(script![Nop].map_err(|e| Status::invalid_argument(e.to_string()))?);
-        let payment_id = PaymentId::open(
+        let payment_id = PaymentId::open_from_string(
             &format!("Template registration '{}'", template_name),
             TxType::CodeTemplateRegistration,
         );

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -49,7 +49,6 @@ use minotari_app_grpc::tari_rpc::{
     CreateTemplateRegistrationRequest,
     CreateTemplateRegistrationResponse,
     GetAddressResponse,
-    GetPaymentIdAddressRequest,
     GetBalanceRequest,
     GetBalanceResponse,
     GetCompleteAddressResponse,
@@ -58,6 +57,7 @@ use minotari_app_grpc::tari_rpc::{
     GetConnectivityRequest,
     GetIdentityRequest,
     GetIdentityResponse,
+    GetPaymentIdAddressRequest,
     GetStateRequest,
     GetStateResponse,
     GetTransactionInfoRequest,
@@ -260,22 +260,28 @@ impl wallet_server::Wallet for WalletGrpcServer {
         }))
     }
 
-    async fn get_payment_id_address(&self, request: Request<GetPaymentIdAddressRequest>) -> Result<Response<GetAddressResponse>, Status> {
+    async fn get_payment_id_address(
+        &self,
+        request: Request<GetPaymentIdAddressRequest>,
+    ) -> Result<Response<GetAddressResponse>, Status> {
         let message = request.into_inner();
-
 
         let interactive_address = self
             .wallet
             .get_wallet_interactive_address()
             .await
             .map_err(|e| Status::internal(format!("{:?}", e)))?;
-        let interactive_address = interactive_address.create_payment_id_address(message.payment_id.clone()).map_err(|e| Status::internal(format!("{:?}", e)))?;
+        let interactive_address = interactive_address
+            .create_payment_id_address(message.payment_id.clone())
+            .map_err(|e| Status::internal(format!("{:?}", e)))?;
         let one_sided_address = self
             .wallet
             .get_wallet_one_sided_address()
             .await
             .map_err(|e| Status::internal(format!("{:?}", e)))?;
-        let one_sided_address = one_sided_address.create_payment_id_address(message.payment_id).map_err(|e| Status::internal(format!("{:?}", e)))?;
+        let one_sided_address = one_sided_address
+            .create_payment_id_address(message.payment_id)
+            .map_err(|e| Status::internal(format!("{:?}", e)))?;
         Ok(Response::new(GetAddressResponse {
             interactive_address: interactive_address.to_vec(),
             one_sided_address: one_sided_address.to_vec(),

--- a/applications/minotari_console_wallet/src/ui/components/burn_tab.rs
+++ b/applications/minotari_console_wallet/src/ui/components/burn_tab.rs
@@ -314,7 +314,7 @@ impl BurnTab {
                                 amount.into(),
                                 UtxoSelectionCriteria::default(),
                                 fee_per_gram,
-                                PaymentId::open(&self.payment_id_field, TxType::Burn),
+                                PaymentId::open_from_string(&self.payment_id_field, TxType::Burn),
                                 tx,
                             )) {
                                 Err(e) => {

--- a/applications/minotari_console_wallet/src/ui/components/send_tab.rs
+++ b/applications/minotari_console_wallet/src/ui/components/send_tab.rs
@@ -287,7 +287,7 @@ impl SendTab {
                                             amount.into(),
                                             UtxoSelectionCriteria::default(),
                                             fee_per_gram,
-                                            PaymentId::open(&self.payment_id_field, TxType::PaymentToOther),
+                                            PaymentId::open_from_string(&self.payment_id_field, TxType::PaymentToOther),
                                             tx,
                                         ),
                                     ) {
@@ -307,7 +307,7 @@ impl SendTab {
                                         amount.into(),
                                         UtxoSelectionCriteria::default(),
                                         fee_per_gram,
-                                        PaymentId::open(&self.payment_id_field, TxType::PaymentToOther),
+                                        PaymentId::open_from_string(&self.payment_id_field, TxType::PaymentToOther),
                                         tx,
                                     )) {
                                         Err(e) => {

--- a/base_layer/chat_ffi/src/conversationalists.rs
+++ b/base_layer/chat_ffi/src/conversationalists.rs
@@ -177,7 +177,7 @@ mod test {
     #[test]
     fn test_retrieving_conversationalists_from_vector() {
         let (_, pk) = CompressedPublicKey::random_keypair(&mut OsRng);
-        let a = TariAddress::new_single_address_with_interactive_only(pk, Network::LocalNet);
+        let a = TariAddress::new_single_address_with_interactive_only(pk, Network::LocalNet).unwrap();
         let conversationalists =
             ConversationalistsVector(vec![TariAddress::default(), TariAddress::default(), a.clone()]);
 

--- a/base_layer/common_types/Cargo.toml
+++ b/base_layer/common_types/Cargo.toml
@@ -14,6 +14,7 @@ tari_common = { workspace = true }
 # TODO: This is mainly to reference the Branch structure. This should be moved to a crate that does not 
 # reference ledger, or at least does not have ledger in the name.
 minotari_ledger_wallet_common = { workspace = true }
+tari_max_size = { workspace = true }
 chacha20poly1305 = "0.10.1"
 bitflags = { version = "2.4", features = ["serde"] }
 borsh = "1.5.7"

--- a/base_layer/common_types/src/tari_address/dual_address.rs
+++ b/base_layer/common_types/src/tari_address/dual_address.rs
@@ -89,6 +89,15 @@ impl DualAddress {
         Self::new(view_key, spend_key, network, TariAddressFeatures::default(), None)
     }
 
+    pub fn add_payment_id(&mut self, data: Vec<u8>) -> Result<(), TariAddressError> {
+        if data.len() > MAX_ENCRYPTED_DATA_SIZE {
+            return Err(TariAddressError::PaymentIdTooLarge);
+        }
+        self.features.set(TariAddressFeatures::PAYMENT_ID, true);
+        self.payment_id_user_data = MaxSizeBytes::from_bytes_truncate(data);
+        Ok(())
+    }
+
     /// helper function to convert emojis to u8
     pub fn emoji_to_bytes(emoji: &str) -> Result<Vec<u8>, TariAddressError> {
         // The string must be the correct size, including the checksum

--- a/base_layer/common_types/src/tari_address/dual_address.rs
+++ b/base_layer/common_types/src/tari_address/dual_address.rs
@@ -64,7 +64,7 @@ impl DualAddress {
         let payment_id_user_data = match payment_id_user_data {
             Some(data) => {
                 if data.len() > MAX_ENCRYPTED_DATA_SIZE {
-                    return Err(TariAddressError::InvalidSize);
+                    return Err(TariAddressError::PaymentIdTooLarge);
                 }
                 features.set(TariAddressFeatures::PAYMENT_ID, true);
                 MaxSizeBytes::from_bytes_truncate(data)
@@ -93,8 +93,8 @@ impl DualAddress {
     pub fn emoji_to_bytes(emoji: &str) -> Result<Vec<u8>, TariAddressError> {
         // The string must be the correct size, including the checksum
         let length = emoji.chars().count();
-        if length < TARI_ADDRESS_INTERNAL_DUAL_SIZE ||
-            length > TARI_ADDRESS_INTERNAL_DUAL_SIZE + MAX_ENCRYPTED_DATA_SIZE
+        if !(TARI_ADDRESS_INTERNAL_DUAL_SIZE..=TARI_ADDRESS_INTERNAL_DUAL_SIZE + MAX_ENCRYPTED_DATA_SIZE)
+            .contains(&length)
         {
             return Err(TariAddressError::InvalidSize);
         }
@@ -152,8 +152,8 @@ impl DualAddress {
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, TariAddressError>
     where Self: Sized {
         let length = bytes.len();
-        if length < TARI_ADDRESS_INTERNAL_DUAL_SIZE ||
-            length > TARI_ADDRESS_INTERNAL_DUAL_SIZE + MAX_ENCRYPTED_DATA_SIZE
+        if !(TARI_ADDRESS_INTERNAL_DUAL_SIZE..=TARI_ADDRESS_INTERNAL_DUAL_SIZE + MAX_ENCRYPTED_DATA_SIZE)
+            .contains(&length)
         {
             return Err(TariAddressError::InvalidSize);
         }

--- a/base_layer/common_types/src/tari_address/dual_address.rs
+++ b/base_layer/common_types/src/tari_address/dual_address.rs
@@ -25,6 +25,7 @@ use std::convert::TryFrom;
 use serde::{Deserialize, Serialize};
 use tari_common::configuration::Network;
 use tari_crypto::tari_utilities::ByteArray;
+use tari_max_size::MaxSizeBytes;
 use tari_utilities::hex::{from_hex, Hex};
 
 use crate::{
@@ -35,6 +36,7 @@ use crate::{
         TariAddressFeatures,
         INTERNAL_DUAL_BASE58_MAX_SIZE,
         INTERNAL_DUAL_BASE58_MIN_SIZE,
+        MAX_ENCRYPTED_DATA_SIZE,
         TARI_ADDRESS_INTERNAL_DUAL_SIZE,
     },
     types::CompressedPublicKey,
@@ -46,6 +48,7 @@ pub struct DualAddress {
     features: TariAddressFeatures,
     public_view_key: CompressedPublicKey,
     public_spend_key: CompressedPublicKey,
+    payment_id_user_data: MaxSizeBytes<MAX_ENCRYPTED_DATA_SIZE>,
 }
 
 impl DualAddress {
@@ -55,13 +58,26 @@ impl DualAddress {
         spend_key: CompressedPublicKey,
         network: Network,
         features: TariAddressFeatures,
-    ) -> DualAddress {
-        Self {
+        payment_id_user_data: Option<Vec<u8>>,
+    ) -> Result<DualAddress, TariAddressError> {
+        let mut features = features;
+        let payment_id_user_data = match payment_id_user_data {
+            Some(data) => {
+                if data.len() > MAX_ENCRYPTED_DATA_SIZE {
+                    return Err(TariAddressError::InvalidSize);
+                }
+                features.set(TariAddressFeatures::PAYMENT_ID, true);
+                MaxSizeBytes::from_bytes_truncate(data)
+            },
+            None => MaxSizeBytes::empty(),
+        };
+        Ok(Self {
             network,
             features,
             public_view_key: view_key,
             public_spend_key: spend_key,
-        }
+            payment_id_user_data,
+        })
     }
 
     /// Creates a new Tari Address from the provided public keys and network while using the default features
@@ -69,22 +85,19 @@ impl DualAddress {
         view_key: CompressedPublicKey,
         spend_key: CompressedPublicKey,
         network: Network,
-    ) -> DualAddress {
-        Self {
-            network,
-            features: TariAddressFeatures::default(),
-            public_view_key: view_key,
-            public_spend_key: spend_key,
-        }
+    ) -> Result<DualAddress, TariAddressError> {
+        Self::new(view_key, spend_key, network, TariAddressFeatures::default(), None)
     }
 
     /// helper function to convert emojis to u8
     pub fn emoji_to_bytes(emoji: &str) -> Result<Vec<u8>, TariAddressError> {
         // The string must be the correct size, including the checksum
-        if emoji.chars().count() != TARI_ADDRESS_INTERNAL_DUAL_SIZE {
+        let length = emoji.chars().count();
+        if length < TARI_ADDRESS_INTERNAL_DUAL_SIZE ||
+            length > TARI_ADDRESS_INTERNAL_DUAL_SIZE + MAX_ENCRYPTED_DATA_SIZE
+        {
             return Err(TariAddressError::InvalidSize);
         }
-
         // Convert the emoji string to a byte array
         let mut bytes = Vec::<u8>::with_capacity(TARI_ADDRESS_INTERNAL_DUAL_SIZE);
         for c in emoji.chars() {
@@ -104,6 +117,10 @@ impl DualAddress {
         Self::from_bytes(&bytes)
     }
 
+    pub fn get_payment_id_bytes(&self) -> Vec<u8> {
+        self.payment_id_user_data.as_ref().to_vec()
+    }
+
     /// Gets the network from the Tari Address
     pub fn network(&self) -> Network {
         self.network
@@ -117,7 +134,7 @@ impl DualAddress {
     /// Convert Tari Address to an emoji string
     pub fn to_emoji_string(&self) -> String {
         // Convert the public key to bytes and compute the checksum
-        let bytes = self.to_bytes();
+        let bytes = self.to_vec();
         bytes.iter().map(|b| EMOJI[*b as usize]).collect::<String>()
     }
 
@@ -134,7 +151,10 @@ impl DualAddress {
     /// Construct Tari Address from bytes
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, TariAddressError>
     where Self: Sized {
-        if bytes.len() != TARI_ADDRESS_INTERNAL_DUAL_SIZE {
+        let length = bytes.len();
+        if length < TARI_ADDRESS_INTERNAL_DUAL_SIZE ||
+            length > TARI_ADDRESS_INTERNAL_DUAL_SIZE + MAX_ENCRYPTED_DATA_SIZE
+        {
             return Err(TariAddressError::InvalidSize);
         }
         if validate_checksum(bytes).is_err() {
@@ -146,23 +166,27 @@ impl DualAddress {
             .map_err(|_| TariAddressError::CannotRecoverPublicKey)?;
         let public_spend_key = CompressedPublicKey::from_canonical_bytes(&bytes[34..66])
             .map_err(|_| TariAddressError::CannotRecoverPublicKey)?;
+        let payment_id_user_data = MaxSizeBytes::from_bytes_truncate(&bytes[66..length - 1]);
         Ok(Self {
             network,
             features,
             public_view_key,
             public_spend_key,
+            payment_id_user_data,
         })
     }
 
     /// Convert Tari Address to bytes
-    pub fn to_bytes(&self) -> [u8; TARI_ADDRESS_INTERNAL_DUAL_SIZE] {
-        let mut buf = [0u8; TARI_ADDRESS_INTERNAL_DUAL_SIZE];
+    pub fn to_vec(&self) -> Vec<u8> {
+        let length = TARI_ADDRESS_INTERNAL_DUAL_SIZE + self.payment_id_user_data.len();
+        let mut buf = vec![0; length];
         buf[0] = self.network.as_byte();
         buf[1] = self.features.0;
         buf[2..34].copy_from_slice(self.public_view_key.as_bytes());
         buf[34..66].copy_from_slice(self.public_spend_key.as_bytes());
-        let checksum = compute_checksum(&buf[0..66]);
-        buf[66] = checksum;
+        buf[66..(length - 1)].copy_from_slice(self.payment_id_user_data.as_bytes());
+        let checksum = compute_checksum(&buf[0..(length - 1)]);
+        buf[length - 1] = checksum;
         buf
     }
 
@@ -191,7 +215,7 @@ impl DualAddress {
 
     /// Convert Tari Address to Base58 string
     pub fn to_base58(&self) -> String {
-        let bytes = self.to_bytes();
+        let bytes = self.to_vec();
         let mut base58 = "".to_string();
         base58.push_str(&bs58::encode(&bytes[0..1]).into_string());
         base58.push_str(&bs58::encode(&bytes[1..2].to_vec()).into_string());
@@ -201,7 +225,7 @@ impl DualAddress {
 
     /// Convert Tari dual Address to hex
     pub fn to_hex(&self) -> String {
-        let buf = self.to_bytes();
+        let buf = self.to_vec();
         buf.to_hex()
     }
 
@@ -229,7 +253,7 @@ mod test {
 
         // Generate an emoji ID from the public key and ensure we recover it
         let emoji_id_from_public_key =
-            DualAddress::new_with_default_features(view_key.clone(), spend_key.clone(), Network::Esmeralda);
+            DualAddress::new_with_default_features(view_key.clone(), spend_key.clone(), Network::Esmeralda).unwrap();
         assert_eq!(emoji_id_from_public_key.public_spend_key(), &spend_key);
         assert_eq!(emoji_id_from_public_key.public_view_key(), &view_key);
 
@@ -257,7 +281,9 @@ mod test {
             spend_key.clone(),
             Network::Esmeralda,
             TariAddressFeatures::create_interactive_only(),
-        );
+            None,
+        )
+        .unwrap();
         assert_eq!(emoji_id_from_public_key.public_spend_key(), &spend_key);
         assert_eq!(emoji_id_from_public_key.public_view_key(), &view_key);
 
@@ -286,7 +312,9 @@ mod test {
             spend_key.clone(),
             Network::Esmeralda,
             TariAddressFeatures::create_one_sided_only(),
-        );
+            None,
+        )
+        .unwrap();
         assert_eq!(emoji_id_from_public_key.public_spend_key(), &spend_key);
         assert_eq!(emoji_id_from_public_key.public_view_key(), &view_key);
 
@@ -315,9 +343,10 @@ mod test {
         let spend_key = CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut rng));
 
         // Generate an emoji ID from the public key and ensure we recover it
-        let address = DualAddress::new_with_default_features(view_key.clone(), spend_key.clone(), Network::Esmeralda);
+        let address =
+            DualAddress::new_with_default_features(view_key.clone(), spend_key.clone(), Network::Esmeralda).unwrap();
 
-        let buff = address.to_bytes();
+        let buff = address.to_vec();
         let base58 = address.to_base58();
         let hex = address.to_hex();
         let emoji = address.to_emoji_string();
@@ -355,9 +384,11 @@ mod test {
             spend_key.clone(),
             Network::Esmeralda,
             TariAddressFeatures::create_interactive_only(),
-        );
+            None,
+        )
+        .unwrap();
 
-        let buff = address.to_bytes();
+        let buff = address.to_vec();
         let base58 = address.to_base58();
         let hex = address.to_hex();
         let emoji = address.to_emoji_string();
@@ -395,9 +426,11 @@ mod test {
             spend_key.clone(),
             Network::Esmeralda,
             TariAddressFeatures::create_one_sided_only(),
-        );
+            None,
+        )
+        .unwrap();
 
-        let buff = address.to_bytes();
+        let buff = address.to_vec();
         let base58 = address.to_base58();
         let hex = address.to_hex();
         let emoji = address.to_emoji_string();
@@ -436,7 +469,7 @@ mod test {
             Err(TariAddressError::InvalidSize)
         );
         // This emoji string is too long to be a valid emoji ID
-        let emoji_string = "🍗🌊🦂🍎🐛🔱🍟🚦🦆👃🐛🎼🛵🔮💋👙💦🍷👠🦀🐺🍪🚀🎮🎩👅🐔🐉🍍🥑💔📌🚧🐊💄🎥🎓🚗🎳🐛🚿💉🌴🧢🐵🎩👾👽🎃🤡👍🔮👒👽🎵👀🚨😷🎒👂👶🍄🏰🚑🌸🍁👂🎒";
+        let emoji_string = "🍗🌊🦂🍎🐛🔱🍟🚦🦆👅🐔🐉🍍🥑💔📌🚧🐊💄🎥🎓🚗🐛👅🐔🐉🍍🥑🥑💔🚧💄🎥🎳🐛📌🚧🐊💄🎥🎓🐛👅🐔🐉🍍🥑💔📌🚧🐊💄🎥🎓🚗🎳🐛👅🐔🐉🍍🥑💔📌🚧🐊🎥🎓🎳🐛👅🐔🐉🍍🥑💔📌🚧🐊💄🎥🎓🚗🎳🐛👅🐔🐉🍍🥑💔📌🚧🐊💄🎥🎓🚗🎳🐛👅🐔🐉🍍🥑💔📌🚧🐊💄🎥🎓🚗🎳🐛👅🐔🐉🍍🥑💔📌🚧🐊💄🎥🎓🚗🎳🐛👅🐔🐉🍍🥑💔📌🚧🐊💄🎥🎓🚗🎳🐛👅🐔🐉🍍🥑💔📌🚧🐊💄🎥🎓🚗🎳🐛👅🐔🐉🍍🥑💔📌🚧🐊💄🎥🎓🚗🎳🐛👃🐛🎼🛵🔮💋👙💦🍷👠🦀👅🐔🐉🍍🥑💔📌🚧🐊💄🎥🎓🚗🎳🐛👅🐔🐉🍍🥑💔📌🚧🐊💄🎥🎓🚗🎳🐛👅🐔🐉🍍🥑💔📌🚧🐊💄🎥🎓🚗🎳🐛🐺🍪🚀🎮🎩👅🐔🐉🍍🥑💔📌🚧🐊💄🎥🎓🚗🎳🐛👅🐔🐉🍍🥑💔📌🚧🐊💄🎥🎓🚗🎳🐛👅🐔🐉🍍🥑💔📌🚧🐊💄🎥🎓🚗🎳🐛👅🐔🐉🍍🥑💔📌🚧🐊💄🎥🎓🚗🎳🐛🚿💉🌴🧢🐵🎩👾👽🎃🤡👍🔮👒👽🎵👀🚨😷🎒👂👶🍄🏰🚑🌸🍁👂🎒";
         assert_eq!(
             DualAddress::from_emoji_string(emoji_string),
             Err(TariAddressError::InvalidSize)
@@ -472,8 +505,8 @@ mod test {
         let view_key = CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut rng));
         let spend_key = CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut rng));
         let mut address =
-            DualAddress::new_with_default_features(view_key.clone(), spend_key.clone(), Network::Esmeralda);
-        address.features = TariAddressFeatures(5);
+            DualAddress::new_with_default_features(view_key.clone(), spend_key.clone(), Network::Esmeralda).unwrap();
+        address.features = TariAddressFeatures(8);
 
         let emoji_string = address.to_emoji_string();
         assert_eq!(
@@ -490,12 +523,55 @@ mod test {
         let spend_key = CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut rng));
 
         // Generate an address using a valid network and ensure it's not valid on another network
-        let address = DualAddress::new_with_default_features(view_key, spend_key, Network::Esmeralda);
-        let mut bytes = address.to_bytes();
+        let address = DualAddress::new_with_default_features(view_key, spend_key, Network::Esmeralda).unwrap();
+        let mut bytes = address.to_vec();
         // this is an invalid network
         bytes[0] = 123;
         let checksum = compute_checksum(&bytes[0..66]);
         bytes[66] = checksum;
         assert_eq!(DualAddress::from_bytes(&bytes), Err(TariAddressError::InvalidNetwork));
+    }
+
+    #[test]
+    fn valid_payment_id() {
+        // Generate random public key
+        let mut rng = rand::thread_rng();
+        let view_key = CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut rng));
+        let spend_key = CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut rng));
+
+        // Generate an emoji ID from the public key and ensure we recover it
+        let payment_id = vec![1u8, 2, 3, 4, 5, 6, 7, 8];
+        let emoji_id_from_public_key = DualAddress::new(
+            view_key.clone(),
+            spend_key.clone(),
+            Network::Esmeralda,
+            TariAddressFeatures::default(),
+            Some(payment_id.clone()),
+        )
+        .unwrap();
+        assert_eq!(emoji_id_from_public_key.public_spend_key(), &spend_key);
+        assert_eq!(emoji_id_from_public_key.public_view_key(), &view_key);
+        assert_eq!(
+            emoji_id_from_public_key.payment_id_user_data.as_bytes(),
+            payment_id.as_slice()
+        );
+
+        // Check the size of the corresponding emoji string
+        let emoji_string = emoji_id_from_public_key.to_emoji_string();
+        assert_eq!(emoji_string.chars().count(), TARI_ADDRESS_INTERNAL_DUAL_SIZE + 8);
+
+        let features = emoji_id_from_public_key.features();
+        assert_eq!(features, TariAddressFeatures(7));
+        // Generate an emoji ID from the emoji string and ensure we recover it
+        let emoji_id_from_emoji_string = DualAddress::from_emoji_string(&emoji_string).unwrap();
+        assert_eq!(emoji_id_from_emoji_string.to_emoji_string(), emoji_string);
+
+        // Return to the original public keys for good measure
+        assert_eq!(emoji_id_from_emoji_string.public_spend_key(), &spend_key);
+        assert_eq!(emoji_id_from_emoji_string.public_view_key(), &view_key);
+        assert_eq!(
+            emoji_id_from_emoji_string.payment_id_user_data.as_bytes(),
+            payment_id.as_slice()
+        );
     }
 }

--- a/base_layer/common_types/src/tari_address/mod.rs
+++ b/base_layer/common_types/src/tari_address/mod.rs
@@ -32,7 +32,6 @@ use std::{
 use bitflags::bitflags;
 use serde::{Deserialize, Serialize};
 use tari_common::configuration::Network;
-use tari_crypto::tari_utilities::ByteArray;
 use tari_utilities::hex::{from_hex, Hex};
 use thiserror::Error;
 
@@ -48,15 +47,18 @@ const INTERNAL_DUAL_BASE58_MIN_SIZE: usize = 89; // number of bytes used for the
 const INTERNAL_DUAL_BASE58_MAX_SIZE: usize = 91; // number of bytes used for the internal representation
 const INTERNAL_SINGLE_MIN_BASE58_SIZE: usize = 45; // number of bytes used for the internal representation
 const INTERNAL_SINGLE_MAX_BASE58_SIZE: usize = 48; // number of bytes used for the internal representation
+const MAX_ENCRYPTED_DATA_SIZE: usize = 256; // max size of the payment_id_ bytes
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TariAddressFeatures(u8);
 
 bitflags! {
     impl TariAddressFeatures: u8 {
-        const INTERACTIVE = 2u8;
+        // this forces a transaction to include the following payment id
+        const PAYMENT_ID = 0b0000_0100;
+        const INTERACTIVE = 0b0000_0010;
         ///one sided payment
-        const ONE_SIDED = 1u8;
+        const ONE_SIDED = 0b0000_0001;
     }
 }
 
@@ -124,6 +126,8 @@ pub enum TariAddressError {
     InvalidAddressString,
     #[error("Could not create TariAddress: {0}")]
     CreationError(String),
+    #[error("Too large payment_id")]
+    PaymentIdTooLarge,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -139,13 +143,30 @@ impl TariAddress {
         spend_key: CompressedPublicKey,
         network: Network,
         features: TariAddressFeatures,
-    ) -> Self {
-        TariAddress::Dual(Box::new(DualAddress::new(view_key, spend_key, network, features)))
+        payment_id_user_data: Option<Vec<u8>>,
+    ) -> Result<TariAddress, TariAddressError> {
+        Ok(TariAddress::Dual(Box::new(DualAddress::new(
+            view_key,
+            spend_key,
+            network,
+            features,
+            payment_id_user_data,
+        )?)))
     }
 
     /// Creates a new Tari Address from the provided public keys, network and features
-    pub fn new_single_address(spend_key: CompressedPublicKey, network: Network, features: TariAddressFeatures) -> Self {
-        TariAddress::Single(Box::new(SingleAddress::new(spend_key, network, features)))
+    pub fn new_single_address(
+        spend_key: CompressedPublicKey,
+        network: Network,
+        features: TariAddressFeatures,
+        payment_id_user_data: Option<Vec<u8>>,
+    ) -> Result<TariAddress, TariAddressError> {
+        Ok(TariAddress::Single(Box::new(SingleAddress::new(
+            spend_key,
+            network,
+            features,
+            payment_id_user_data,
+        )?)))
     }
 
     /// Creates a new Tari Address from the provided public keys and network while using the default features
@@ -153,15 +174,20 @@ impl TariAddress {
         view_key: CompressedPublicKey,
         spend_key: CompressedPublicKey,
         network: Network,
-    ) -> Self {
-        TariAddress::Dual(Box::new(DualAddress::new_with_default_features(
+    ) -> Result<TariAddress, TariAddressError> {
+        Ok(TariAddress::Dual(Box::new(DualAddress::new_with_default_features(
             view_key, spend_key, network,
-        )))
+        )?)))
     }
 
     /// Creates a new Tari Address from the provided public keys, network and features
-    pub fn new_single_address_with_interactive_only(spend_key: CompressedPublicKey, network: Network) -> Self {
-        TariAddress::Single(Box::new(SingleAddress::new_with_interactive_only(spend_key, network)))
+    pub fn new_single_address_with_interactive_only(
+        spend_key: CompressedPublicKey,
+        network: Network,
+    ) -> Result<TariAddress, TariAddressError> {
+        Ok(TariAddress::Single(Box::new(SingleAddress::new_with_interactive_only(
+            spend_key, network,
+        )?)))
     }
 
     pub fn combine_addresses(one: &TariAddress, two: &TariAddress) -> Result<TariAddress, TariAddressError> {
@@ -179,23 +205,26 @@ impl TariAddress {
             }
         }
         match (one, two) {
-            (TariAddress::Dual(one), _) => Ok(TariAddress::new_dual_address(
+            (TariAddress::Dual(one), _) => TariAddress::new_dual_address(
                 one.public_view_key().clone(),
                 one.public_spend_key().clone(),
                 one.network(),
                 one.features().combine_features(two.features()),
-            )),
-            (_, TariAddress::Dual(two)) => Ok(TariAddress::new_dual_address(
+                None,
+            ),
+            (_, TariAddress::Dual(two)) => TariAddress::new_dual_address(
                 two.public_view_key().clone(),
                 one.public_spend_key().clone(),
                 one.network(),
                 one.features().combine_features(two.features()),
-            )),
-            (_, _) => Ok(TariAddress::new_single_address(
+                None,
+            ),
+            (_, _) => TariAddress::new_single_address(
                 one.public_spend_key().clone(),
                 one.network(),
                 one.features().combine_features(two.features()),
-            )),
+                None,
+            ),
         }
     }
 
@@ -204,6 +233,13 @@ impl TariAddress {
         match self {
             TariAddress::Dual(_) => TARI_ADDRESS_INTERNAL_DUAL_SIZE,
             TariAddress::Single(_) => TARI_ADDRESS_INTERNAL_SINGLE_SIZE,
+        }
+    }
+
+    pub fn get_payment_id_bytes(&self) -> Vec<u8> {
+        match self {
+            TariAddress::Dual(v) => v.get_payment_id_bytes(),
+            TariAddress::Single(v) => v.get_payment_id_bytes(),
         }
     }
 
@@ -299,8 +335,8 @@ impl TariAddress {
     /// Convert Tari Address to bytes
     pub fn to_vec(&self) -> Vec<u8> {
         match self {
-            TariAddress::Dual(v) => v.to_bytes().to_vec(),
-            TariAddress::Single(v) => v.to_bytes().to_vec(),
+            TariAddress::Dual(v) => v.to_vec(),
+            TariAddress::Single(v) => v.to_vec(),
         }
     }
 
@@ -458,7 +494,7 @@ mod test {
 
         // Generate an emoji ID from the public key and ensure we recover it
         let emoji_id_from_public_key =
-            TariAddress::new_single_address_with_interactive_only(public_key.clone(), Network::Esmeralda);
+            TariAddress::new_single_address_with_interactive_only(public_key.clone(), Network::Esmeralda).unwrap();
         assert_eq!(emoji_id_from_public_key.public_spend_key(), &public_key);
 
         let features = emoji_id_from_public_key.features();
@@ -483,7 +519,9 @@ mod test {
             public_key.clone(),
             Network::Esmeralda,
             TariAddressFeatures::create_interactive_only(),
-        );
+            None,
+        )
+        .unwrap();
         assert_eq!(emoji_id_from_public_key.public_spend_key(), &public_key);
 
         let features = emoji_id_from_public_key.features();
@@ -508,7 +546,9 @@ mod test {
             public_key.clone(),
             Network::Esmeralda,
             TariAddressFeatures::create_one_sided_only(),
-        );
+            None,
+        )
+        .unwrap();
         assert_eq!(emoji_id_from_public_key.public_spend_key(), &public_key);
 
         let features = emoji_id_from_public_key.features();
@@ -539,7 +579,8 @@ mod test {
             view_key.clone(),
             spend_key.clone(),
             Network::Esmeralda,
-        );
+        )
+        .unwrap();
         assert_eq!(emoji_id_from_public_key.public_spend_key(), &spend_key);
         assert_eq!(emoji_id_from_public_key.public_view_key(), Some(&view_key));
 
@@ -568,7 +609,9 @@ mod test {
             spend_key.clone(),
             Network::Esmeralda,
             TariAddressFeatures::create_interactive_only(),
-        );
+            None,
+        )
+        .unwrap();
         assert_eq!(emoji_id_from_public_key.public_spend_key(), &spend_key);
         assert_eq!(emoji_id_from_public_key.public_view_key(), Some(&view_key));
 
@@ -597,7 +640,9 @@ mod test {
             spend_key.clone(),
             Network::Esmeralda,
             TariAddressFeatures::create_one_sided_only(),
-        );
+            None,
+        )
+        .unwrap();
         assert_eq!(emoji_id_from_public_key.public_spend_key(), &spend_key);
         assert_eq!(emoji_id_from_public_key.public_view_key(), Some(&view_key));
 
@@ -625,7 +670,8 @@ mod test {
         let public_key = CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut rng));
 
         // Generate an emoji ID from the public key and ensure we recover it
-        let address = TariAddress::new_single_address_with_interactive_only(public_key.clone(), Network::Esmeralda);
+        let address =
+            TariAddress::new_single_address_with_interactive_only(public_key.clone(), Network::Esmeralda).unwrap();
 
         let buff = address.to_vec();
         let base58 = address.to_base58();
@@ -670,7 +716,9 @@ mod test {
             public_key.clone(),
             Network::Esmeralda,
             TariAddressFeatures::create_interactive_only(),
-        );
+            None,
+        )
+        .unwrap();
 
         let buff = address.to_vec();
         let base58 = address.to_base58();
@@ -714,7 +762,9 @@ mod test {
             public_key.clone(),
             Network::Esmeralda,
             TariAddressFeatures::create_one_sided_only(),
-        );
+            None,
+        )
+        .unwrap();
 
         let buff = address.to_vec();
         let base58 = address.to_base58();
@@ -802,7 +852,8 @@ mod test {
             view_key.clone(),
             spend_key.clone(),
             Network::Esmeralda,
-        );
+        )
+        .unwrap();
         test_addres(address);
 
         let view_key = CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut rng));
@@ -814,7 +865,9 @@ mod test {
             spend_key.clone(),
             Network::Esmeralda,
             TariAddressFeatures::create_interactive_only(),
-        );
+            None,
+        )
+        .unwrap();
         test_addres(address);
 
         let view_key = CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut rng));
@@ -826,7 +879,9 @@ mod test {
             spend_key.clone(),
             Network::Esmeralda,
             TariAddressFeatures::create_one_sided_only(),
-        );
+            None,
+        )
+        .unwrap();
         test_addres(address);
     }
     #[test]
@@ -895,8 +950,8 @@ mod test {
         let public_key = CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut rng));
 
         // Generate an address using a valid network and ensure it's not valid on another network
-        let address = SingleAddress::new_with_interactive_only(public_key, Network::Esmeralda);
-        let mut bytes = address.to_bytes();
+        let address = SingleAddress::new_with_interactive_only(public_key, Network::Esmeralda).unwrap();
+        let mut bytes = address.to_vec();
         // this is an invalid network
         bytes[0] = 123;
         let checksum = compute_checksum(&bytes[0..34]);
@@ -907,7 +962,8 @@ mod test {
         let spend_key = CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut rng));
 
         // Generate an address using a valid network and ensure it's not valid on another network
-        let address = TariAddress::new_dual_address_with_default_features(view_key, spend_key, Network::Esmeralda);
+        let address =
+            TariAddress::new_dual_address_with_default_features(view_key, spend_key, Network::Esmeralda).unwrap();
         let mut bytes = address.to_vec();
         // this is an invalid network
         bytes[0] = 123;

--- a/base_layer/common_types/src/tari_address/mod.rs
+++ b/base_layer/common_types/src/tari_address/mod.rs
@@ -678,6 +678,7 @@ mod test {
     }
 
     #[test]
+    #[allow(clippy::too_many_lines)]
     /// Test encoding for single tari address
     fn encoding_single() {
         // Generate random public key

--- a/base_layer/common_types/src/tari_address/mod.rs
+++ b/base_layer/common_types/src/tari_address/mod.rs
@@ -243,6 +243,21 @@ impl TariAddress {
         }
     }
 
+    pub fn create_payment_id_address(&self, data: Vec<u8>) -> Result<Self, TariAddressError> {
+        match self {
+            TariAddress::Dual(v) => {
+                let mut address = v.clone();
+                address.add_payment_id(data)?;
+                Ok(TariAddress::Dual(address))
+            },
+            TariAddress::Single(v) => {
+                let mut address = v.clone();
+                address.add_payment_id(data)?;
+                Ok(TariAddress::Single(address))
+            },
+        }
+    }
+
     /// helper function to convert emojis to u8
     fn emoji_to_bytes(emoji: &str) -> Result<Vec<u8>, TariAddressError> {
         // The string must be the correct size, including the checksum

--- a/base_layer/common_types/src/tari_address/single_address.rs
+++ b/base_layer/common_types/src/tari_address/single_address.rs
@@ -62,7 +62,7 @@ impl SingleAddress {
         let payment_id_user_data = match payment_id_user_data {
             Some(data) => {
                 if data.len() > MAX_ENCRYPTED_DATA_SIZE {
-                    return Err(TariAddressError::InvalidSize);
+                    return Err(TariAddressError::PaymentIdTooLarge);
                 }
                 features.set(TariAddressFeatures::PAYMENT_ID, true);
                 MaxSizeBytes::from_bytes_truncate(data)
@@ -89,8 +89,8 @@ impl SingleAddress {
     pub fn emoji_to_bytes(emoji: &str) -> Result<Vec<u8>, TariAddressError> {
         // The string must be the correct size, including the checksum
         let length = emoji.chars().count();
-        if length < TARI_ADDRESS_INTERNAL_SINGLE_SIZE ||
-            length > TARI_ADDRESS_INTERNAL_SINGLE_SIZE + MAX_ENCRYPTED_DATA_SIZE
+        if !(TARI_ADDRESS_INTERNAL_SINGLE_SIZE..=TARI_ADDRESS_INTERNAL_SINGLE_SIZE + MAX_ENCRYPTED_DATA_SIZE)
+            .contains(&length)
         {
             return Err(TariAddressError::InvalidSize);
         }
@@ -143,8 +143,8 @@ impl SingleAddress {
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, TariAddressError>
     where Self: Sized {
         let length = bytes.len();
-        if length < TARI_ADDRESS_INTERNAL_SINGLE_SIZE ||
-            length > TARI_ADDRESS_INTERNAL_SINGLE_SIZE + MAX_ENCRYPTED_DATA_SIZE
+        if !(TARI_ADDRESS_INTERNAL_SINGLE_SIZE..=TARI_ADDRESS_INTERNAL_SINGLE_SIZE + MAX_ENCRYPTED_DATA_SIZE)
+            .contains(&length)
         {
             return Err(TariAddressError::InvalidSize);
         }

--- a/base_layer/common_types/src/tari_address/single_address.rs
+++ b/base_layer/common_types/src/tari_address/single_address.rs
@@ -85,6 +85,15 @@ impl SingleAddress {
         Self::new(spend_key, network, TariAddressFeatures::create_interactive_only(), None)
     }
 
+    pub fn add_payment_id(&mut self, data: Vec<u8>) -> Result<(), TariAddressError> {
+        if data.len() > MAX_ENCRYPTED_DATA_SIZE {
+            return Err(TariAddressError::PaymentIdTooLarge);
+        }
+        self.features.set(TariAddressFeatures::PAYMENT_ID, true);
+        self.payment_id_user_data = MaxSizeBytes::from_bytes_truncate(data);
+        Ok(())
+    }
+
     /// helper function to convert emojis to u8
     pub fn emoji_to_bytes(emoji: &str) -> Result<Vec<u8>, TariAddressError> {
         // The string must be the correct size, including the checksum

--- a/base_layer/common_types/src/tari_address/single_address.rs
+++ b/base_layer/common_types/src/tari_address/single_address.rs
@@ -25,6 +25,7 @@ use std::convert::TryFrom;
 use serde::{Deserialize, Serialize};
 use tari_common::configuration::Network;
 use tari_crypto::tari_utilities::ByteArray;
+use tari_max_size::MaxSizeBytes;
 use tari_utilities::hex::{from_hex, Hex};
 
 use crate::{
@@ -35,6 +36,7 @@ use crate::{
         TariAddressFeatures,
         INTERNAL_SINGLE_MAX_BASE58_SIZE,
         INTERNAL_SINGLE_MIN_BASE58_SIZE,
+        MAX_ENCRYPTED_DATA_SIZE,
         TARI_ADDRESS_INTERNAL_SINGLE_SIZE,
     },
     types::CompressedPublicKey,
@@ -45,31 +47,51 @@ pub struct SingleAddress {
     network: Network,
     features: TariAddressFeatures,
     public_spend_key: CompressedPublicKey,
+    payment_id_user_data: MaxSizeBytes<MAX_ENCRYPTED_DATA_SIZE>,
 }
 
 impl SingleAddress {
     /// Creates a new Tari Address from the provided public keys, network and features
-    pub fn new(spend_key: CompressedPublicKey, network: Network, features: TariAddressFeatures) -> SingleAddress {
-        Self {
+    pub fn new(
+        spend_key: CompressedPublicKey,
+        network: Network,
+        features: TariAddressFeatures,
+        payment_id_user_data: Option<Vec<u8>>,
+    ) -> Result<SingleAddress, TariAddressError> {
+        let mut features = features;
+        let payment_id_user_data = match payment_id_user_data {
+            Some(data) => {
+                if data.len() > MAX_ENCRYPTED_DATA_SIZE {
+                    return Err(TariAddressError::InvalidSize);
+                }
+                features.set(TariAddressFeatures::PAYMENT_ID, true);
+                MaxSizeBytes::from_bytes_truncate(data)
+            },
+            None => MaxSizeBytes::empty(),
+        };
+        Ok(Self {
             network,
             features,
             public_spend_key: spend_key,
-        }
+            payment_id_user_data,
+        })
     }
 
     /// Creates a new Tari Address from the provided public keys and network while using the default features
-    pub fn new_with_interactive_only(spend_key: CompressedPublicKey, network: Network) -> SingleAddress {
-        Self {
-            network,
-            features: TariAddressFeatures::create_interactive_only(),
-            public_spend_key: spend_key,
-        }
+    pub fn new_with_interactive_only(
+        spend_key: CompressedPublicKey,
+        network: Network,
+    ) -> Result<SingleAddress, TariAddressError> {
+        Self::new(spend_key, network, TariAddressFeatures::create_interactive_only(), None)
     }
 
     /// helper function to convert emojis to u8
     pub fn emoji_to_bytes(emoji: &str) -> Result<Vec<u8>, TariAddressError> {
         // The string must be the correct size, including the checksum
-        if emoji.chars().count() != TARI_ADDRESS_INTERNAL_SINGLE_SIZE {
+        let length = emoji.chars().count();
+        if length < TARI_ADDRESS_INTERNAL_SINGLE_SIZE ||
+            length > TARI_ADDRESS_INTERNAL_SINGLE_SIZE + MAX_ENCRYPTED_DATA_SIZE
+        {
             return Err(TariAddressError::InvalidSize);
         }
 
@@ -88,8 +110,11 @@ impl SingleAddress {
     /// Construct an TariAddress from an emoji string
     pub fn from_emoji_string(emoji: &str) -> Result<Self, TariAddressError> {
         let bytes = Self::emoji_to_bytes(emoji)?;
-
         Self::from_bytes(&bytes)
+    }
+
+    pub fn get_payment_id_bytes(&self) -> Vec<u8> {
+        self.payment_id_user_data.as_ref().to_vec()
     }
 
     /// Gets the network from the Tari Address
@@ -105,7 +130,7 @@ impl SingleAddress {
     /// Convert Tari Address to an emoji string
     pub fn to_emoji_string(&self) -> String {
         // Convert the public key to bytes and compute the checksum
-        let bytes = self.to_bytes();
+        let bytes = self.to_vec();
         bytes.iter().map(|b| EMOJI[*b as usize]).collect::<String>()
     }
 
@@ -117,7 +142,10 @@ impl SingleAddress {
     /// Construct Tari Address from bytes
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, TariAddressError>
     where Self: Sized {
-        if bytes.len() != TARI_ADDRESS_INTERNAL_SINGLE_SIZE {
+        let length = bytes.len();
+        if length < TARI_ADDRESS_INTERNAL_SINGLE_SIZE ||
+            length > TARI_ADDRESS_INTERNAL_SINGLE_SIZE + MAX_ENCRYPTED_DATA_SIZE
+        {
             return Err(TariAddressError::InvalidSize);
         }
         if validate_checksum(bytes).is_err() {
@@ -127,21 +155,25 @@ impl SingleAddress {
         let features = TariAddressFeatures::from_bits(bytes[1]).ok_or(TariAddressError::InvalidFeatures)?;
         let public_spend_key = CompressedPublicKey::from_canonical_bytes(&bytes[2..34])
             .map_err(|_| TariAddressError::CannotRecoverPublicKey)?;
+        let payment_id_user_data = MaxSizeBytes::from_bytes_truncate(&bytes[34..length - 1]);
         Ok(Self {
             network,
             features,
             public_spend_key,
+            payment_id_user_data,
         })
     }
 
     /// Convert Tari Address to bytes
-    pub fn to_bytes(&self) -> [u8; TARI_ADDRESS_INTERNAL_SINGLE_SIZE] {
-        let mut buf = [0u8; TARI_ADDRESS_INTERNAL_SINGLE_SIZE];
+    pub fn to_vec(&self) -> Vec<u8> {
+        let length = TARI_ADDRESS_INTERNAL_SINGLE_SIZE + self.payment_id_user_data.len();
+        let mut buf = vec![0; length];
         buf[0] = self.network.as_byte();
         buf[1] = self.features.0;
         buf[2..34].copy_from_slice(self.public_spend_key.as_bytes());
-        let checksum = compute_checksum(&buf[0..34]);
-        buf[34] = checksum;
+        buf[34..(length - 1)].copy_from_slice(self.payment_id_user_data.as_bytes());
+        let checksum = compute_checksum(&buf[0..(length - 1)]);
+        buf[length - 1] = checksum;
         buf
     }
 
@@ -170,7 +202,7 @@ impl SingleAddress {
 
     /// Convert Tari Address to Base58
     pub fn to_base58(&self) -> String {
-        let bytes = self.to_bytes();
+        let bytes = self.to_vec();
         let mut network = bs58::encode(&bytes[0..1]).into_string();
         let features = bs58::encode(&bytes[1..2].to_vec()).into_string();
         let rest = bs58::encode(&bytes[2..]).into_string();
@@ -181,7 +213,7 @@ impl SingleAddress {
 
     /// Convert Tari single Address to hex
     pub fn to_hex(&self) -> String {
-        let buf = self.to_bytes();
+        let buf = self.to_vec();
         buf.to_hex()
     }
 
@@ -206,7 +238,8 @@ mod test {
         let public_key = CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut rng));
 
         // Generate an emoji ID from the public key and ensure we recover it
-        let emoji_id_from_public_key = SingleAddress::new_with_interactive_only(public_key.clone(), Network::Esmeralda);
+        let emoji_id_from_public_key =
+            SingleAddress::new_with_interactive_only(public_key.clone(), Network::Esmeralda).unwrap();
         assert_eq!(emoji_id_from_public_key.public_spend_key(), &public_key);
 
         let features = emoji_id_from_public_key.features();
@@ -231,7 +264,9 @@ mod test {
             public_key.clone(),
             Network::Esmeralda,
             TariAddressFeatures::create_interactive_only(),
-        );
+            None,
+        )
+        .unwrap();
         assert_eq!(emoji_id_from_public_key.public_spend_key(), &public_key);
 
         let features = emoji_id_from_public_key.features();
@@ -255,7 +290,9 @@ mod test {
             public_key.clone(),
             Network::Esmeralda,
             TariAddressFeatures::create_one_sided_only(),
-        );
+            None,
+        )
+        .unwrap();
         assert_eq!(emoji_id_from_public_key.public_spend_key(), &public_key);
 
         let features = emoji_id_from_public_key.features();
@@ -281,9 +318,9 @@ mod test {
         let public_key = CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut rng));
 
         // Generate an emoji ID from the public key and ensure we recover it
-        let address = SingleAddress::new_with_interactive_only(public_key.clone(), Network::Esmeralda);
+        let address = SingleAddress::new_with_interactive_only(public_key.clone(), Network::Esmeralda).unwrap();
 
-        let buff = address.to_bytes();
+        let buff = address.to_vec();
         let base58 = address.to_base58();
         let hex = address.to_hex();
         let emoji = address.to_emoji_string();
@@ -316,9 +353,11 @@ mod test {
             public_key.clone(),
             Network::Esmeralda,
             TariAddressFeatures::create_interactive_only(),
-        );
+            None,
+        )
+        .unwrap();
 
-        let buff = address.to_bytes();
+        let buff = address.to_vec();
         let base58 = address.to_base58();
         let hex = address.to_hex();
         let emoji = address.to_emoji_string();
@@ -351,9 +390,11 @@ mod test {
             public_key.clone(),
             Network::Esmeralda,
             TariAddressFeatures::create_one_sided_only(),
-        );
+            None,
+        )
+        .unwrap();
 
-        let buff = address.to_bytes();
+        let buff = address.to_vec();
         let base58 = address.to_base58();
         let hex = address.to_hex();
         let emoji = address.to_emoji_string();
@@ -389,7 +430,7 @@ mod test {
             Err(TariAddressError::InvalidSize)
         );
         // This emoji string is too long to be a valid emoji ID
-        let emoji_string = "🌴🦀🔌📌🚑🌰🎓🌴🐊🐌🔒💡🐜📜👛🍵👛🐽🎂🐻🦋🍓👶🐭🐼🏀🎪💔💵🥑🔋🎒🎒🎒🎒🎒";
+        let emoji_string = "🌴🦀🔌📌🚑🔒💡🐜📜👛🍵👛🐽🎂🐻🦋🍓🔒💡🐜📜👛🍵👛🐽🎂🐻🦋🍓🍓👶🔒💡🐜📜👛🍵👶🔒💡🐜📜👛🍵👛🐽🎂🐻🦋🍓👶🔒💡🐜📜👛🍵👛🐽🎂🐻🦋🍓👶🔒💡🐜📜👛🍵🍓👛🐽🎂🐻🦋🍓👶👶🔒💡🐜📜👛🍵👛🐽🎂🐻🦋🍓👶🌰🎓🌴🐊🔒💡🐜📜👛🍵👛🐽🎂🐻🦋🍓👶🔒💡🐜🔒💡🐜📜👛🍵👛🐽🎂🐻🦋🍓👶🔒💡🐜📜👛🍵👛🐽🎂🐻🦋🍓👶📜👛🍵👛🐽🎂🐻🦋🍓👶🔒💡🐜📜👛🍵👛🐽🎂🐻🦋🍓👶🐌🔒💡🐜📜👛🍵🔒💡🐜📜👛🍵👛🐽🎂🐻🦋🍓👶👛🐽🎂🐻🦋🍓👶🔒💡🐜📜👛🍵👛🐽🎂🐻🦋🍓👶🔒💡🐜📜👛🍵👛🐽🎂🐻🦋🍓👶🔒💡🐜📜👛🍵👛🐽🎂🐻🦋🍓👶🔒💡🐜📜👛🍵👛🐽🎂🐻🦋🍓👶🔒💡🐜📜👛🍵👛🐽🎂🐻🦋🍓👶🔒💡🐜📜👛🍵👛🐽🎂🐻🦋🍓👶🔒💡🐜📜👛🍵👛🐽🎂🐻🦋🍓👶🐭🐼🏀🎪💔💵🥑🔋🎒🎒🎒🎒🎒";
         assert_eq!(
             SingleAddress::from_emoji_string(emoji_string),
             Err(TariAddressError::InvalidSize)
@@ -412,8 +453,8 @@ mod test {
     fn invalid_features() {
         let mut rng = rand::thread_rng();
         let spend_key = CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut rng));
-        let mut address = SingleAddress::new_with_interactive_only(spend_key.clone(), Network::Esmeralda);
-        address.features = TariAddressFeatures(5);
+        let mut address = SingleAddress::new_with_interactive_only(spend_key.clone(), Network::Esmeralda).unwrap();
+        address.features = TariAddressFeatures(8);
 
         let emoji_string = address.to_emoji_string();
         assert_eq!(
@@ -440,12 +481,51 @@ mod test {
         let public_key = CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut rng));
 
         // Generate an address using a valid network and ensure it's not valid on another network
-        let address = SingleAddress::new_with_interactive_only(public_key, Network::Esmeralda);
-        let mut bytes = address.to_bytes();
+        let address = SingleAddress::new_with_interactive_only(public_key, Network::Esmeralda).unwrap();
+        let mut bytes = address.to_vec();
         // this is an invalid network
         bytes[0] = 123;
         let checksum = compute_checksum(&bytes[0..34]);
         bytes[34] = checksum;
         assert_eq!(SingleAddress::from_bytes(&bytes), Err(TariAddressError::InvalidNetwork));
+    }
+
+    #[test]
+    fn valid_payment_id() {
+        // Generate random public key
+        let mut rng = rand::thread_rng();
+        let spend_key = CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut rng));
+
+        // Generate an emoji ID from the public key and ensure we recover it
+        let payment_id = vec![1u8, 2, 3, 4, 5, 6, 7, 8];
+        let emoji_id_from_public_key = SingleAddress::new(
+            spend_key.clone(),
+            Network::Esmeralda,
+            TariAddressFeatures::default(),
+            Some(payment_id.clone()),
+        )
+        .unwrap();
+        assert_eq!(emoji_id_from_public_key.public_spend_key(), &spend_key);
+        assert_eq!(
+            emoji_id_from_public_key.payment_id_user_data.as_bytes(),
+            payment_id.as_slice()
+        );
+
+        // Check the size of the corresponding emoji string
+        let emoji_string = emoji_id_from_public_key.to_emoji_string();
+        assert_eq!(emoji_string.chars().count(), TARI_ADDRESS_INTERNAL_SINGLE_SIZE + 8);
+
+        let features = emoji_id_from_public_key.features();
+        assert_eq!(features, TariAddressFeatures(7));
+        // Generate an emoji ID from the emoji string and ensure we recover it
+        let emoji_id_from_emoji_string = SingleAddress::from_emoji_string(&emoji_string).unwrap();
+        assert_eq!(emoji_id_from_emoji_string.to_emoji_string(), emoji_string);
+
+        // Return to the original public keys for good measure
+        assert_eq!(emoji_id_from_emoji_string.public_spend_key(), &spend_key);
+        assert_eq!(
+            emoji_id_from_emoji_string.payment_id_user_data.as_bytes(),
+            payment_id.as_slice()
+        );
     }
 }

--- a/base_layer/contacts/src/contacts_service/storage/sqlite_db.rs
+++ b/base_layer/contacts/src/contacts_service/storage/sqlite_db.rs
@@ -255,7 +255,8 @@ mod test {
             let mut contacts = Vec::new();
             for i in 0..names.len() {
                 let pub_key = CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng));
-                let address = TariAddress::new_single_address_with_interactive_only(pub_key, Network::default());
+                let address =
+                    TariAddress::new_single_address_with_interactive_only(pub_key, Network::default()).unwrap();
                 contacts.push(Contact::new(names[i].clone(), address, None, None, false));
                 ContactSql::from(contacts[i].clone()).commit(&mut conn).unwrap();
             }

--- a/base_layer/contacts/tests/contacts_service.rs
+++ b/base_layer/contacts/tests/contacts_service.rs
@@ -147,7 +147,8 @@ pub fn test_contacts_service() {
         let mut contacts = Vec::new();
         for i in 0..5 {
             let (_secret_key, public_key) = CompressedPublicKey::random_keypair(&mut OsRng);
-            let address = TariAddress::new_single_address_with_interactive_only(public_key, Network::default());
+            let address =
+                TariAddress::new_single_address_with_interactive_only(public_key, Network::default()).unwrap();
 
             contacts.push(Contact::new(random::string(8), address, None, None, false));
 
@@ -165,7 +166,7 @@ pub fn test_contacts_service() {
         assert_eq!(contact, contacts[0]);
 
         let (_secret_key, public_key) = CompressedPublicKey::random_keypair(&mut OsRng);
-        let address = TariAddress::new_single_address_with_interactive_only(public_key, Network::default());
+        let address = TariAddress::new_single_address_with_interactive_only(public_key, Network::default()).unwrap();
 
         let contact = runtime.block_on(contacts_service.get_contact(address.clone()));
         match contact {
@@ -230,7 +231,7 @@ pub fn test_message_pagination() {
         let (mut contacts_service, _node_identity, _shutdown) = setup_contacts_service(&mut runtime, backend);
 
         let (_secret_key, public_key) = CompressedPublicKey::random_keypair(&mut OsRng);
-        let address = TariAddress::new_single_address_with_interactive_only(public_key, Network::default());
+        let address = TariAddress::new_single_address_with_interactive_only(public_key, Network::default()).unwrap();
 
         let contact = Contact::new(random::string(8), address.clone(), None, None, false);
         runtime.block_on(contacts_service.upsert_contact(contact)).unwrap();

--- a/base_layer/core/src/test_helpers/mod.rs
+++ b/base_layer/core/src/test_helpers/mod.rs
@@ -80,7 +80,8 @@ pub async fn default_coinbase_entities(key_manager: &MemoryDbKeyManager) -> (Tar
         CompressedPublicKey::from_secret_key(&wallet_private_view_key),
         CompressedPublicKey::from_secret_key(&wallet_private_spend_key),
         Network::LocalNet,
-    );
+    )
+    .unwrap();
     (script_key_id, wallet_payment_address)
 }
 

--- a/base_layer/core/src/transactions/transaction_components/encrypted_data.rs
+++ b/base_layer/core/src/transactions/transaction_components/encrypted_data.rs
@@ -551,9 +551,17 @@ impl PaymentId {
     }
 
     /// Helper function to create a `PaymentId::Open` from a string and the transaction type
-    pub fn open(s: &str, tx_type: TxType) -> Self {
+    pub fn open_from_string(s: &str, tx_type: TxType) -> Self {
         PaymentId::Open {
             user_data: s.as_bytes().to_vec(),
+            tx_type,
+        }
+    }
+
+    /// Helper function to create a `PaymentId::Open` from a bytes and the transaction type
+    pub fn open(bytes: Vec<u8>, tx_type: TxType) -> Self {
+        PaymentId::Open {
+            user_data: bytes,
             tx_type,
         }
     }

--- a/base_layer/core/src/transactions/transaction_key_manager/error.rs
+++ b/base_layer/core/src/transactions/transaction_key_manager/error.rs
@@ -22,6 +22,7 @@
 
 use diesel::result::Error as DieselError;
 use tari_common_sqlite::error::{SqliteStorageError, StorageError};
+use tari_common_types::tari_address::TariAddressError;
 use tari_crypto::{errors::RangeProofError, signatures::CommitmentAndPublicKeySignatureError};
 use tari_key_manager::error::{KeyManagerError, KeyManagerError as KMError};
 use tari_utilities::{hex::HexError, ByteArrayError};
@@ -83,6 +84,8 @@ pub enum KeyManagerServiceError {
     StorageError(#[from] StorageError),
     #[error("The imported private key cannot be accessed or read: `{0}")]
     ImportedPrivateKeyInaccessible(String),
+    #[error("Tari address error: `{0}`")]
+    TariAddressError(#[from] TariAddressError),
 }
 
 impl From<RangeProofError> for KeyManagerServiceError {

--- a/base_layer/wallet/src/output_manager_service/error.rs
+++ b/base_layer/wallet/src/output_manager_service/error.rs
@@ -23,6 +23,7 @@
 use diesel::result::Error as DieselError;
 use tari_common::exit_codes::{ExitCode, ExitError};
 use tari_common_sqlite::error::SqliteStorageError;
+use tari_common_types::tari_address::TariAddressError;
 use tari_comms::{connectivity::ConnectivityError, peer_manager::node_id::NodeIdError, protocol::rpc::RpcError};
 use tari_comms_dht::outbound::DhtOutboundError;
 use tari_core::transactions::{
@@ -150,6 +151,8 @@ pub enum OutputManagerError {
     TooManyInputsToFulfillTransaction(String),
     #[error("Std I/O error: {0}")]
     StdIoError(#[from] std::io::Error),
+    #[error("Tari address error: `{0}`")]
+    TariAddressError(#[from] TariAddressError),
 }
 
 impl From<RangeProofError> for OutputManagerError {

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -170,9 +170,10 @@ where
             comms_key.pub_key,
             network,
             TariAddressFeatures::create_one_sided_only(),
-        );
+            None,
+        )?;
         let interactive_tari_address =
-            TariAddress::new_dual_address(view_key.pub_key, spend_key.pub_key, network, interactive_features);
+            TariAddress::new_dual_address(view_key.pub_key, spend_key.pub_key, network, interactive_features, None)?;
         let resources = OutputManagerResources {
             config,
             db,
@@ -2057,7 +2058,10 @@ where
                 Covenant::default(),
                 self.resources.interactive_tari_address.clone(),
             )
-            .with_payment_id(PaymentId::open("Pay to self transaction", TxType::PaymentToSelf));
+            .with_payment_id(PaymentId::open_from_string(
+                "Pay to self transaction",
+                TxType::PaymentToSelf,
+            ));
 
         let mut stp = builder
             .build()
@@ -2487,7 +2491,7 @@ where
             self.resources.key_manager.clone(),
         );
         tx_builder
-            .with_payment_id(PaymentId::open(
+            .with_payment_id(PaymentId::open_from_string(
                 &format!(
                     "Coin split transaction, {} into {} outputs",
                     accumulated_amount, number_of_splits
@@ -2521,7 +2525,7 @@ where
                     OutputFeatures::default(),
                     amount_per_split,
                     Covenant::default(),
-                    PaymentId::open(&format!("{} even coin splits", number_of_splits), TxType::CoinSplit),
+                    PaymentId::open_from_string(&format!("{} even coin splits", number_of_splits), TxType::CoinSplit),
                     fee,
                 )
                 .await?;
@@ -2658,7 +2662,7 @@ where
             self.resources.consensus_constants.clone(),
             self.resources.key_manager.clone(),
         );
-        let payment_id = PaymentId::open(
+        let payment_id = PaymentId::open_from_string(
             &format!("Coin split, {} into {} outputs", accumulated_amount, number_of_splits),
             TxType::CoinSplit,
         );
@@ -3015,7 +3019,7 @@ where
             )
             .await?
             .with_sender_address(self.resources.interactive_tari_address.clone())
-            .with_payment_id(PaymentId::open("scraping wallet", TxType::PaymentToOther))
+            .with_payment_id(PaymentId::open_from_string("scraping wallet", TxType::PaymentToOther))
             .with_prevent_fee_gt_amount(self.resources.config.prevent_fee_gt_amount)
             .with_lock_height(tx_meta.lock_height)
             .with_kernel_features(tx_meta.kernel_features)
@@ -3127,7 +3131,10 @@ where
                 builder
                     .with_lock_height(0)
                     .with_fee_per_gram(fee_per_gram)
-                    .with_payment_id(PaymentId::open("SHA-XTR atomic swap", TxType::ClaimAtomicSwap))
+                    .with_payment_id(PaymentId::open_from_string(
+                        "SHA-XTR atomic swap",
+                        TxType::ClaimAtomicSwap,
+                    ))
                     .with_kernel_features(KernelFeatures::empty())
                     .with_prevent_fee_gt_amount(self.resources.config.prevent_fee_gt_amount)
                     .with_input(rewound_output)
@@ -3210,7 +3217,10 @@ where
         builder
             .with_lock_height(0)
             .with_fee_per_gram(fee_per_gram)
-            .with_payment_id(PaymentId::open("SHA-XTR atomic refund", TxType::HtlcAtomicSwapRefund))
+            .with_payment_id(PaymentId::open_from_string(
+                "SHA-XTR atomic refund",
+                TxType::HtlcAtomicSwapRefund,
+            ))
             .with_kernel_features(KernelFeatures::empty())
             .with_prevent_fee_gt_amount(self.resources.config.prevent_fee_gt_amount)
             .with_input(output)

--- a/base_layer/wallet/src/transaction_service/error.rs
+++ b/base_layer/wallet/src/transaction_service/error.rs
@@ -198,6 +198,8 @@ pub enum TransactionServiceError {
     NotSupported(String),
     #[error("Tari script error: {0}")]
     ScriptError(#[from] ScriptError),
+    #[error("Tari address error: `{0}`")]
+    TariAddressError(#[from] TariAddressError),
 }
 
 impl From<RangeProofError> for TransactionServiceError {

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -280,9 +280,10 @@ where
             comms_key.pub_key,
             network,
             TariAddressFeatures::create_one_sided_only(),
-        );
+            None,
+        )?;
         let interactive_tari_address =
-            TariAddress::new_dual_address(view_key.pub_key, spend_key.pub_key, network, interactive_features);
+            TariAddress::new_dual_address(view_key.pub_key, spend_key.pub_key, network, interactive_features, None)?;
         let resources = TransactionServiceResources {
             db: db.clone(),
             output_manager_service,
@@ -850,7 +851,7 @@ where
                         binary_url,
                     },
                     UtxoSelectionCriteria::default(),
-                    PaymentId::open(
+                    PaymentId::open_from_string(
                         &format!("Template Registration: {}", template_name),
                         TxType::CodeTemplateRegistration,
                     ),
@@ -1119,7 +1120,7 @@ where
         selection_criteria: UtxoSelectionCriteria,
         output_features: OutputFeatures,
         fee_per_gram: MicroMinotari,
-        payment_id: PaymentId,
+        mut payment_id: PaymentId,
         tx_meta: TransactionMetadata,
         join_handles: &mut FuturesUnordered<
             JoinHandle<Result<TransactionSendResult, TransactionServiceProtocolError<TxId>>>,
@@ -1198,7 +1199,10 @@ where
 
             return Ok(());
         }
-
+        // let override the payment_id if the address says we should
+        if destination.features().contains(TariAddressFeatures::PAYMENT_ID) {
+            payment_id = PaymentId::open(destination.get_payment_id_bytes(), TxType::PaymentToOther);
+        }
         let (tx_reply_sender, tx_reply_receiver) = mpsc::channel(100);
         let (cancellation_sender, cancellation_receiver) = oneshot::channel();
         self.pending_transaction_reply_senders.insert(tx_id, tx_reply_sender);
@@ -1747,9 +1751,13 @@ where
             JoinHandle<Result<TxId, TransactionServiceProtocolError<TxId>>>,
         >,
         recipient_script: Option<TariScript>,
-        payment_id: PaymentId,
+        mut payment_id: PaymentId,
     ) -> Result<TxId, TransactionServiceError> {
         let tx_id = TxId::new_random();
+        // let override the payment_id if the address says we should
+        if dest_address.features().contains(TariAddressFeatures::PAYMENT_ID) {
+            payment_id = PaymentId::open(dest_address.get_payment_id_bytes(), TxType::PaymentToOther);
+        }
         let payment_id = match payment_id.clone() {
             PaymentId::Open { .. } | PaymentId::Empty => PaymentId::add_sender_address(
                 payment_id,
@@ -3028,7 +3036,8 @@ where
                     source_pubkey,
                     self.resources.interactive_tari_address.network(),
                     TariAddressFeatures::INTERACTIVE,
-                )
+                    None,
+                )?
             };
             let (tx_finalized_sender, tx_finalized_receiver) = mpsc::channel(100);
             let (cancellation_sender, cancellation_receiver) = oneshot::channel();

--- a/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
@@ -2269,7 +2269,7 @@ mod test {
         builder
             .with_lock_height(0)
             .with_fee_per_gram(MicroMinotari::from(177 / 5))
-            .with_payment_id(PaymentId::open("Yo!", TxType::PaymentToOther))
+            .with_payment_id(PaymentId::open_from_string("Yo!", TxType::PaymentToOther))
             .with_input(input)
             .await
             .unwrap()
@@ -2296,7 +2296,8 @@ mod test {
         let address = TariAddress::new_single_address_with_interactive_only(
             CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
             Network::LocalNet,
-        );
+        )
+        .unwrap();
         let outbound_tx1 = OutboundTransaction {
             tx_id: 1u64.into(),
             destination_address: address,
@@ -2304,7 +2305,7 @@ mod test {
             fee: stp.get_fee_amount().unwrap(),
             sender_protocol: stp.clone(),
             status: TransactionStatus::Pending,
-            payment_id: PaymentId::open("Yo!", TxType::PaymentToOther),
+            payment_id: PaymentId::open_from_string("Yo!", TxType::PaymentToOther),
             timestamp: Utc::now(),
             cancelled: false,
             direct_send_success: false,
@@ -2314,7 +2315,8 @@ mod test {
         let address = TariAddress::new_single_address_with_interactive_only(
             CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
             Network::LocalNet,
-        );
+        )
+        .unwrap();
         let outbound_tx2 = OutboundTransactionSql::try_from(
             OutboundTransaction {
                 tx_id: 2u64.into(),
@@ -2323,7 +2325,7 @@ mod test {
                 fee: stp.get_fee_amount().unwrap(),
                 sender_protocol: stp.clone(),
                 status: TransactionStatus::Pending,
-                payment_id: PaymentId::open("Yo!", TxType::PaymentToOther),
+                payment_id: PaymentId::open_from_string("Yo!", TxType::PaymentToOther),
                 timestamp: Utc::now(),
                 cancelled: false,
                 direct_send_success: false,
@@ -2382,14 +2384,15 @@ mod test {
             CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
             CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
             Network::LocalNet,
-        );
+        )
+        .unwrap();
         let inbound_tx1 = InboundTransaction {
             tx_id: 2u64.into(),
             source_address: address,
             amount,
             receiver_protocol: rtp.clone(),
             status: TransactionStatus::Pending,
-            payment_id: PaymentId::open("Yo!", TxType::PaymentToOther),
+            payment_id: PaymentId::open_from_string("Yo!", TxType::PaymentToOther),
             timestamp: Utc::now(),
             cancelled: false,
             direct_send_success: false,
@@ -2400,14 +2403,15 @@ mod test {
             CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
             CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
             Network::LocalNet,
-        );
+        )
+        .unwrap();
         let inbound_tx2 = InboundTransaction {
             tx_id: 3u64.into(),
             source_address: address,
             amount,
             receiver_protocol: rtp,
             status: TransactionStatus::Pending,
-            payment_id: PaymentId::open("Yo!", TxType::PaymentToOther),
+            payment_id: PaymentId::open_from_string("Yo!", TxType::PaymentToOther),
             timestamp: Utc::now(),
             cancelled: false,
             direct_send_success: false,
@@ -2454,12 +2458,14 @@ mod test {
             CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
             CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
             Network::LocalNet,
-        );
+        )
+        .unwrap();
         let destination_address = TariAddress::new_dual_address_with_default_features(
             CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
             CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
             Network::LocalNet,
-        );
+        )
+        .unwrap();
         let completed_tx1 = CompletedTransaction {
             tx_id: 2u64.into(),
             source_address,
@@ -2478,18 +2484,20 @@ mod test {
             mined_height: None,
             mined_in_block: None,
             mined_timestamp: None,
-            payment_id: PaymentId::open("Yo!", TxType::PaymentToOther),
+            payment_id: PaymentId::open_from_string("Yo!", TxType::PaymentToOther),
         };
         let source_address = TariAddress::new_dual_address_with_default_features(
             CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
             CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
             Network::LocalNet,
-        );
+        )
+        .unwrap();
         let destination_address = TariAddress::new_dual_address_with_default_features(
             CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
             CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
             Network::LocalNet,
-        );
+        )
+        .unwrap();
         let completed_tx2 = CompletedTransaction {
             tx_id: 3u64.into(),
             source_address,
@@ -2508,7 +2516,7 @@ mod test {
             mined_height: None,
             mined_in_block: None,
             mined_timestamp: None,
-            payment_id: PaymentId::open("Yo!", TxType::PaymentToOther),
+            payment_id: PaymentId::open_from_string("Yo!", TxType::PaymentToOther),
         };
 
         CompletedTransactionSql::try_from(completed_tx1.clone(), &cipher)
@@ -2661,14 +2669,15 @@ mod test {
             CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
             CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
             Network::LocalNet,
-        );
+        )
+        .unwrap();
         let inbound_tx = InboundTransaction {
             tx_id: 1u64.into(),
             source_address,
             amount: MicroMinotari::from(100),
             receiver_protocol: ReceiverTransactionProtocol::new_placeholder(),
             status: TransactionStatus::Pending,
-            payment_id: PaymentId::open("Yo!", TxType::PaymentToOther),
+            payment_id: PaymentId::open_from_string("Yo!", TxType::PaymentToOther),
             timestamp: Utc::now(),
             cancelled: false,
             direct_send_success: false,
@@ -2688,7 +2697,8 @@ mod test {
             CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
             CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
             Network::LocalNet,
-        );
+        )
+        .unwrap();
         let outbound_tx = OutboundTransaction {
             tx_id: 2u64.into(),
             destination_address,
@@ -2696,7 +2706,7 @@ mod test {
             fee: MicroMinotari::from(10),
             sender_protocol: SenderTransactionProtocol::new_placeholder(),
             status: TransactionStatus::Pending,
-            payment_id: PaymentId::open("Yo!", TxType::PaymentToOther),
+            payment_id: PaymentId::open_from_string("Yo!", TxType::PaymentToOther),
             timestamp: Utc::now(),
             cancelled: false,
             direct_send_success: false,
@@ -2717,12 +2727,14 @@ mod test {
             CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
             CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
             Network::LocalNet,
-        );
+        )
+        .unwrap();
         let destination_address = TariAddress::new_dual_address_with_default_features(
             CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
             CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
             Network::LocalNet,
-        );
+        )
+        .unwrap();
         let completed_tx = CompletedTransaction {
             tx_id: 3u64.into(),
             source_address,
@@ -2747,7 +2759,7 @@ mod test {
             mined_height: None,
             mined_in_block: None,
             mined_timestamp: None,
-            payment_id: PaymentId::open("Yo!", TxType::PaymentToOther),
+            payment_id: PaymentId::open_from_string("Yo!", TxType::PaymentToOther),
         };
 
         let completed_tx_sql = CompletedTransactionSql::try_from(completed_tx.clone(), &cipher).unwrap();
@@ -2804,14 +2816,15 @@ mod test {
                 CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
                 CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
                 Network::LocalNet,
-            );
+            )
+            .unwrap();
             let inbound_tx = InboundTransaction {
                 tx_id: 1u64.into(),
                 source_address,
                 amount: MicroMinotari::from(100),
                 receiver_protocol: ReceiverTransactionProtocol::new_placeholder(),
                 status: TransactionStatus::Pending,
-                payment_id: PaymentId::open("Yo!", TxType::PaymentToOther),
+                payment_id: PaymentId::open_from_string("Yo!", TxType::PaymentToOther),
                 timestamp: Utc::now(),
                 cancelled: false,
                 direct_send_success: false,
@@ -2826,7 +2839,8 @@ mod test {
                 CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
                 CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
                 Network::LocalNet,
-            );
+            )
+            .unwrap();
             let outbound_tx = OutboundTransaction {
                 tx_id: 2u64.into(),
                 destination_address,
@@ -2834,7 +2848,7 @@ mod test {
                 fee: MicroMinotari::from(10),
                 sender_protocol: SenderTransactionProtocol::new_placeholder(),
                 status: TransactionStatus::Pending,
-                payment_id: PaymentId::open("Yo!", TxType::PaymentToOther),
+                payment_id: PaymentId::open_from_string("Yo!", TxType::PaymentToOther),
                 timestamp: Utc::now(),
                 cancelled: false,
                 direct_send_success: false,
@@ -2849,12 +2863,14 @@ mod test {
                 CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
                 CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
                 Network::LocalNet,
-            );
+            )
+            .unwrap();
             let destination_address = TariAddress::new_dual_address_with_default_features(
                 CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
                 CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
                 Network::LocalNet,
-            );
+            )
+            .unwrap();
             let completed_tx = CompletedTransaction {
                 tx_id: 3u64.into(),
                 source_address,
@@ -2879,7 +2895,7 @@ mod test {
                 mined_height: None,
                 mined_in_block: None,
                 mined_timestamp: None,
-                payment_id: PaymentId::open("Yo!", TxType::PaymentToOther),
+                payment_id: PaymentId::open_from_string("Yo!", TxType::PaymentToOther),
             };
             let completed_tx_sql = CompletedTransactionSql::try_from(completed_tx, &cipher).unwrap();
 
@@ -2991,12 +3007,14 @@ mod test {
                 CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
                 CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
                 Network::LocalNet,
-            );
+            )
+            .unwrap();
             let destination_address = TariAddress::new_dual_address_with_default_features(
                 CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
                 CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
                 Network::LocalNet,
-            );
+            )
+            .unwrap();
             let completed_tx = CompletedTransaction {
                 tx_id: TxId::from(i as u64),
                 source_address,
@@ -3021,7 +3039,7 @@ mod test {
                 mined_height: None,
                 mined_in_block: None,
                 mined_timestamp: None,
-                payment_id: PaymentId::open("Yo!", TxType::PaymentToOther),
+                payment_id: PaymentId::open_from_string("Yo!", TxType::PaymentToOther),
             };
             let completed_tx_sql = CompletedTransactionSql::try_from(completed_tx.clone(), &cipher).unwrap();
 

--- a/base_layer/wallet/src/utxo_scanner_service/initializer.rs
+++ b/base_layer/wallet/src/utxo_scanner_service/initializer.rs
@@ -120,7 +120,9 @@ where
                 spend_key.pub_key,
                 network,
                 TariAddressFeatures::create_one_sided_only(),
-            );
+                None,
+            )
+            .expect("Could not create one-sided Tari address");
 
             let scanning_service = UtxoScannerService::<T, WalletConnectivityHandle>::builder()
                 .with_peers(vec![])

--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -537,7 +537,8 @@ where
             comms_key.pub_key,
             self.network.as_network(),
             features,
-        ))
+            None,
+        )?)
     }
 
     pub async fn get_wallet_one_sided_address(&self) -> Result<TariAddress, KeyManagerServiceError> {
@@ -548,7 +549,8 @@ where
             spend_key.pub_key,
             self.network.as_network(),
             TariAddressFeatures::create_one_sided_only(),
-        ))
+            None,
+        )?)
     }
 
     pub async fn get_wallet_id(&self) -> Result<WalletIdentity, WalletError> {
@@ -784,7 +786,7 @@ where
         fee_per_gram: MicroMinotari,
         payment_id: Option<PaymentId>,
     ) -> Result<TxId, WalletError> {
-        let payment_id = payment_id.unwrap_or(PaymentId::open(
+        let payment_id = payment_id.unwrap_or(PaymentId::open_from_string(
             &format!("Coin join {} outputs", commitments.len()),
             TxType::CoinJoin,
         ));

--- a/base_layer/wallet/tests/transaction_service_tests/service.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/service.rs
@@ -621,7 +621,7 @@ async fn manage_single_transaction() {
     )
     .await;
     let bob_address =
-        TariAddress::new_single_address_with_interactive_only(bob_node_identity.public_key().clone(), network);
+        TariAddress::new_single_address_with_interactive_only(bob_node_identity.public_key().clone(), network).unwrap();
     assert!(alice_ts
         .send_transaction(
             bob_address.clone(),
@@ -646,7 +646,7 @@ async fn manage_single_transaction() {
             UtxoSelectionCriteria::default(),
             OutputFeatures::default(),
             MicroMinotari::from(4),
-            PaymentId::open("TAKE MAH MONEYS!", TxType::PaymentToOther),
+            PaymentId::open_from_string("TAKE MAH MONEYS!", TxType::PaymentToOther),
         )
         .await
         .expect("Alice sending tx");
@@ -794,7 +794,7 @@ async fn large_interactive_transaction() {
     alice_db.mark_outputs_as_unspent(unspent).unwrap();
     let transaction_value = output_value * (outputs_count as u64 - 1);
     let bob_address =
-        TariAddress::new_single_address_with_interactive_only(bob_node_identity.public_key().clone(), network);
+        TariAddress::new_single_address_with_interactive_only(bob_node_identity.public_key().clone(), network).unwrap();
 
     alice_ts
         .send_transaction(
@@ -803,7 +803,7 @@ async fn large_interactive_transaction() {
             UtxoSelectionCriteria::default(),
             OutputFeatures::default(),
             MicroMinotari::from(1),
-            PaymentId::open("TAKE MAH MONEYS!", TxType::PaymentToOther),
+            PaymentId::open_from_string("TAKE MAH MONEYS!", TxType::PaymentToOther),
         )
         .await
         .expect("Alice sending large tx");
@@ -958,7 +958,8 @@ async fn test_spend_dust_to_self_in_oversized_transaction() {
     let fee_per_gram = MicroMinotari::from(1);
     let value = balance.available_balance - amount_per_output * 10;
     let alice_address =
-        TariAddress::new_single_address_with_interactive_only(alice_node_identity.public_key().clone(), network);
+        TariAddress::new_single_address_with_interactive_only(alice_node_identity.public_key().clone(), network)
+            .unwrap();
     assert!(alice_ts
         .send_transaction(
             alice_address,
@@ -966,7 +967,7 @@ async fn test_spend_dust_to_self_in_oversized_transaction() {
             UtxoSelectionCriteria::default(),
             OutputFeatures::default(),
             fee_per_gram,
-            PaymentId::open("TAKE MAH _OWN_ MONEYS!", TxType::PaymentToOther),
+            PaymentId::open_from_string("TAKE MAH _OWN_ MONEYS!", TxType::PaymentToOther),
         )
         .await
         .is_err());
@@ -1056,7 +1057,7 @@ async fn test_spend_dust_to_other_in_oversized_transaction() {
     let fee_per_gram = MicroMinotari::from(1);
     let value = balance.available_balance - amount_per_output * 10;
     let bob_address =
-        TariAddress::new_single_address_with_interactive_only(bob_node_identity.public_key().clone(), network);
+        TariAddress::new_single_address_with_interactive_only(bob_node_identity.public_key().clone(), network).unwrap();
     let tx_id = alice_ts
         .send_transaction(
             bob_address,
@@ -1064,7 +1065,7 @@ async fn test_spend_dust_to_other_in_oversized_transaction() {
             UtxoSelectionCriteria::default(),
             OutputFeatures::default(),
             fee_per_gram,
-            PaymentId::open("GIVE MAH _OWN_ MONEYS AWAY!", TxType::PaymentToOther),
+            PaymentId::open_from_string("GIVE MAH _OWN_ MONEYS AWAY!", TxType::PaymentToOther),
         )
         .await
         .unwrap();
@@ -1171,7 +1172,8 @@ async fn test_spend_dust_happy_path() {
 
     let value_self = (number_of_outputs / 3) * amount_per_output;
     let alice_address =
-        TariAddress::new_single_address_with_interactive_only(alice_node_identity.public_key().clone(), network);
+        TariAddress::new_single_address_with_interactive_only(alice_node_identity.public_key().clone(), network)
+            .unwrap();
     let tx_id = alice_ts
         .send_transaction(
             alice_address,
@@ -1179,7 +1181,7 @@ async fn test_spend_dust_happy_path() {
             UtxoSelectionCriteria::default(),
             OutputFeatures::default(),
             fee_per_gram,
-            PaymentId::open("TAKE MAH _OWN_ MONEYS!", TxType::PaymentToOther),
+            PaymentId::open_from_string("TAKE MAH _OWN_ MONEYS!", TxType::PaymentToOther),
         )
         .await
         .unwrap();
@@ -1215,7 +1217,7 @@ async fn test_spend_dust_happy_path() {
 
     let value_bob = (number_of_outputs / 3) * amount_per_output;
     let bob_address =
-        TariAddress::new_single_address_with_interactive_only(bob_node_identity.public_key().clone(), network);
+        TariAddress::new_single_address_with_interactive_only(bob_node_identity.public_key().clone(), network).unwrap();
     let tx_id = alice_ts
         .send_transaction(
             bob_address,
@@ -1223,7 +1225,7 @@ async fn test_spend_dust_happy_path() {
             UtxoSelectionCriteria::default(),
             OutputFeatures::default(),
             fee_per_gram,
-            PaymentId::open("GIVE MAH _OWN_ MONEYS AWAY!", TxType::PaymentToOther),
+            PaymentId::open_from_string("GIVE MAH _OWN_ MONEYS AWAY!", TxType::PaymentToOther),
         )
         .await
         .unwrap();
@@ -1315,7 +1317,8 @@ async fn single_transaction_to_self() {
         .unwrap();
     let value = 10000.into();
     let alice_address =
-        TariAddress::new_single_address_with_interactive_only(alice_node_identity.public_key().clone(), network);
+        TariAddress::new_single_address_with_interactive_only(alice_node_identity.public_key().clone(), network)
+            .unwrap();
     let tx_id = alice_ts
         .send_transaction(
             alice_address,
@@ -1323,7 +1326,7 @@ async fn single_transaction_to_self() {
             UtxoSelectionCriteria::default(),
             OutputFeatures::default(),
             20.into(),
-            PaymentId::open("TAKE MAH _OWN_ MONEYS!", TxType::PaymentToOther),
+            PaymentId::open_from_string("TAKE MAH _OWN_ MONEYS!", TxType::PaymentToOther),
         )
         .await
         .expect("Alice sending tx");
@@ -1412,7 +1415,7 @@ async fn large_coin_split_transaction() {
             tx_id,
             coin_split_tx,
             amount,
-            PaymentId::open("large coin-split", TxType::CoinSplit),
+            PaymentId::open_from_string("large coin-split", TxType::CoinSplit),
         )
         .await
         .expect("Alice sending coin-split tx");
@@ -1648,7 +1651,8 @@ async fn send_one_sided_transaction_to_other() {
         bob_view_key,
         bob_node_identity.public_key().clone(),
         network,
-    );
+    )
+    .unwrap();
     let tx_id = alice_ts_clone
         .send_one_sided_transaction(
             bob_address,
@@ -1656,7 +1660,7 @@ async fn send_one_sided_transaction_to_other() {
             UtxoSelectionCriteria::default(),
             OutputFeatures::default(),
             20.into(),
-            PaymentId::open("SEE IF YOU CAN CATCH THIS ONE..... SIDED TX!", TxType::PaymentToOther),
+            PaymentId::open_from_string("SEE IF YOU CAN CATCH THIS ONE..... SIDED TX!", TxType::PaymentToOther),
         )
         .await
         .expect("Alice sending one-sided tx to Bob");
@@ -1795,7 +1799,8 @@ async fn recover_one_sided_transaction() {
         bob_view_key.pub_key,
         bob_node_identity.public_key().clone(),
         network,
-    );
+    )
+    .unwrap();
     let tx_id = alice_ts_clone
         .send_one_sided_transaction(
             bob_address,
@@ -1920,7 +1925,8 @@ async fn recover_stealth_one_sided_transaction() {
         bob_view_key.pub_key,
         bob_node_identity.public_key().clone(),
         network,
-    );
+    )
+    .unwrap();
     let tx_id = alice_ts_clone
         .send_one_sided_to_stealth_address_transaction(
             bob_address,
@@ -2029,7 +2035,7 @@ async fn test_htlc_send_and_claim() {
     let bob_pubkey = bob_ts_interface.base_node_identity.public_key().clone();
     let bob_view_key = bob_ts_interface.key_manager_handle.get_view_key().await.unwrap();
     let bob_address =
-        TariAddress::new_dual_address_with_default_features(bob_view_key.pub_key, bob_pubkey.clone(), network);
+        TariAddress::new_dual_address_with_default_features(bob_view_key.pub_key, bob_pubkey.clone(), network).unwrap();
     let (tx_id, pre_image, output) = alice_ts
         .send_sha_atomic_swap_transaction(
             bob_address,
@@ -2267,7 +2273,8 @@ async fn manage_multiple_transactions() {
     let bob_address = TariAddress::new_single_address_with_interactive_only(
         bob_node_identity.public_key().clone(),
         Network::LocalNet,
-    );
+    )
+    .unwrap();
     let tx_id_a_to_b_1 = alice_ts
         .send_transaction(
             bob_address.clone(),
@@ -2275,7 +2282,7 @@ async fn manage_multiple_transactions() {
             UtxoSelectionCriteria::default(),
             OutputFeatures::default(),
             MicroMinotari::from(20),
-            PaymentId::open("a to b 1", TxType::PaymentToOther),
+            PaymentId::open_from_string("a to b 1", TxType::PaymentToOther),
         )
         .await
         .unwrap();
@@ -2284,7 +2291,8 @@ async fn manage_multiple_transactions() {
     let carol_address = TariAddress::new_single_address_with_interactive_only(
         carol_node_identity.public_key().clone(),
         Network::LocalNet,
-    );
+    )
+    .unwrap();
     let tx_id_a_to_c_1 = alice_ts
         .send_transaction(
             carol_address,
@@ -2292,7 +2300,7 @@ async fn manage_multiple_transactions() {
             UtxoSelectionCriteria::default(),
             OutputFeatures::default(),
             MicroMinotari::from(20),
-            PaymentId::open("a to c 1", TxType::PaymentToOther),
+            PaymentId::open_from_string("a to c 1", TxType::PaymentToOther),
         )
         .await
         .unwrap();
@@ -2303,7 +2311,8 @@ async fn manage_multiple_transactions() {
     let alice_address = TariAddress::new_single_address_with_interactive_only(
         alice_node_identity.public_key().clone(),
         Network::LocalNet,
-    );
+    )
+    .unwrap();
     bob_ts
         .send_transaction(
             alice_address,
@@ -2311,7 +2320,7 @@ async fn manage_multiple_transactions() {
             UtxoSelectionCriteria::default(),
             OutputFeatures::default(),
             MicroMinotari::from(20),
-            PaymentId::open("b to a 1", TxType::PaymentToOther),
+            PaymentId::open_from_string("b to a 1", TxType::PaymentToOther),
         )
         .await
         .unwrap();
@@ -2322,7 +2331,7 @@ async fn manage_multiple_transactions() {
             UtxoSelectionCriteria::default(),
             OutputFeatures::default(),
             MicroMinotari::from(20),
-            PaymentId::open("a to b 2", TxType::PaymentToOther),
+            PaymentId::open_from_string("a to b 2", TxType::PaymentToOther),
         )
         .await
         .unwrap();
@@ -2458,7 +2467,8 @@ async fn test_accepting_unknown_tx_id_and_malformed_reply() {
     let bob_address = TariAddress::new_single_address_with_interactive_only(
         bob_node_identity.public_key().clone(),
         Network::LocalNet,
-    );
+    )
+    .unwrap();
     alice_ts_interface
         .transaction_service_handle
         .send_transaction(
@@ -2892,7 +2902,7 @@ async fn discovery_async_return_test() {
 
     let value_a_to_c_1 = MicroMinotari::from(14000);
     let bob_address =
-        TariAddress::new_single_address_with_interactive_only(bob_node_identity.public_key().clone(), network);
+        TariAddress::new_single_address_with_interactive_only(bob_node_identity.public_key().clone(), network).unwrap();
     let tx_id = alice_ts
         .send_transaction(
             bob_address,
@@ -2900,7 +2910,7 @@ async fn discovery_async_return_test() {
             UtxoSelectionCriteria::default(),
             OutputFeatures::default(),
             MicroMinotari::from(20),
-            PaymentId::open("Discovery Tx!", TxType::PaymentToOther),
+            PaymentId::open_from_string("Discovery Tx!", TxType::PaymentToOther),
         )
         .await
         .unwrap();
@@ -2931,7 +2941,8 @@ async fn discovery_async_return_test() {
     assert!(!is_direct_send);
 
     let carol_address =
-        TariAddress::new_single_address_with_interactive_only(carol_node_identity.public_key().clone(), network);
+        TariAddress::new_single_address_with_interactive_only(carol_node_identity.public_key().clone(), network)
+            .unwrap();
     let tx_id2 = alice_ts
         .send_transaction(
             carol_address,
@@ -2939,7 +2950,7 @@ async fn discovery_async_return_test() {
             UtxoSelectionCriteria::default(),
             OutputFeatures::default(),
             MicroMinotari::from(20),
-            PaymentId::open("Discovery Tx2!", TxType::PaymentToOther),
+            PaymentId::open_from_string("Discovery Tx2!", TxType::PaymentToOther),
         )
         .await
         .unwrap();
@@ -3016,12 +3027,14 @@ async fn test_power_mode_updates() {
         CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
         CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
         Network::LocalNet,
-    );
+    )
+    .unwrap();
     let destination_address = TariAddress::new_dual_address_with_default_features(
         CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
         CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
         Network::LocalNet,
-    );
+    )
+    .unwrap();
     let completed_tx1 = CompletedTransaction {
         tx_id: 1u64.into(),
         source_address,
@@ -3040,19 +3053,21 @@ async fn test_power_mode_updates() {
         mined_height: None,
         mined_in_block: None,
         mined_timestamp: None,
-        payment_id: PaymentId::open("Yo!", TxType::PaymentToOther),
+        payment_id: PaymentId::open_from_string("Yo!", TxType::PaymentToOther),
     };
 
     let source_address = TariAddress::new_dual_address_with_default_features(
         CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
         CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
         Network::LocalNet,
-    );
+    )
+    .unwrap();
     let destination_address = TariAddress::new_dual_address_with_default_features(
         CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
         CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
         Network::LocalNet,
-    );
+    )
+    .unwrap();
     let completed_tx2 = CompletedTransaction {
         tx_id: 2u64.into(),
         source_address,
@@ -3071,7 +3086,7 @@ async fn test_power_mode_updates() {
         mined_height: None,
         mined_in_block: None,
         mined_timestamp: None,
-        payment_id: PaymentId::open("Yo!", TxType::PaymentToOther),
+        payment_id: PaymentId::open_from_string("Yo!", TxType::PaymentToOther),
     };
 
     tx_backend
@@ -3236,7 +3251,8 @@ async fn test_transaction_cancellation() {
     let bob_address = TariAddress::new_single_address_with_interactive_only(
         bob_node_identity.public_key().clone(),
         Network::LocalNet,
-    );
+    )
+    .unwrap();
     let tx_id = alice_ts_interface
         .transaction_service_handle
         .send_transaction(
@@ -3245,7 +3261,7 @@ async fn test_transaction_cancellation() {
             UtxoSelectionCriteria::default(),
             OutputFeatures::default(),
             100 * uT,
-            PaymentId::open("Testing Message", TxType::PaymentToOther),
+            PaymentId::open_from_string("Testing Message", TxType::PaymentToOther),
         )
         .await
         .unwrap();
@@ -3352,7 +3368,7 @@ async fn test_transaction_cancellation() {
     builder
         .with_lock_height(0)
         .with_fee_per_gram(MicroMinotari::from(5))
-        .with_payment_id(PaymentId::open("Yo!", TxType::PaymentToOther))
+        .with_payment_id(PaymentId::open_from_string("Yo!", TxType::PaymentToOther))
         .with_input(input)
         .await
         .unwrap()
@@ -3439,7 +3455,7 @@ async fn test_transaction_cancellation() {
     builder
         .with_lock_height(0)
         .with_fee_per_gram(MicroMinotari::from(5))
-        .with_payment_id(PaymentId::open("Yo!", TxType::PaymentToOther))
+        .with_payment_id(PaymentId::open_from_string("Yo!", TxType::PaymentToOther))
         .with_input(input)
         .await
         .unwrap()
@@ -3587,7 +3603,8 @@ async fn test_direct_vs_saf_send_of_tx_reply_and_finalize() {
     let bob_address = TariAddress::new_single_address_with_interactive_only(
         bob_node_identity.public_key().clone(),
         Network::LocalNet,
-    );
+    )
+    .unwrap();
     let tx_id = alice_ts_interface
         .transaction_service_handle
         .send_transaction(
@@ -3596,7 +3613,7 @@ async fn test_direct_vs_saf_send_of_tx_reply_and_finalize() {
             UtxoSelectionCriteria::default(),
             OutputFeatures::default(),
             100 * uT,
-            PaymentId::open("Testing Message", TxType::PaymentToOther),
+            PaymentId::open_from_string("Testing Message", TxType::PaymentToOther),
         )
         .await
         .unwrap();
@@ -3789,7 +3806,8 @@ async fn test_direct_vs_saf_send_of_tx_reply_and_finalize() {
     let bob_address = TariAddress::new_single_address_with_interactive_only(
         bob_node_identity.public_key().clone(),
         Network::LocalNet,
-    );
+    )
+    .unwrap();
     let _tx_id2 = alice_ts_interface
         .transaction_service_handle
         .send_transaction(
@@ -3798,7 +3816,7 @@ async fn test_direct_vs_saf_send_of_tx_reply_and_finalize() {
             UtxoSelectionCriteria::default(),
             OutputFeatures::default(),
             100 * uT,
-            PaymentId::open("Testing Message", TxType::PaymentToOther),
+            PaymentId::open_from_string("Testing Message", TxType::PaymentToOther),
         )
         .await
         .unwrap();
@@ -3978,7 +3996,8 @@ async fn test_tx_direct_send_behaviour() {
     let bob_address = TariAddress::new_single_address_with_interactive_only(
         bob_node_identity.public_key().clone(),
         Network::LocalNet,
-    );
+    )
+    .unwrap();
     let _tx_id = alice_ts_interface
         .transaction_service_handle
         .send_transaction(
@@ -3987,7 +4006,7 @@ async fn test_tx_direct_send_behaviour() {
             UtxoSelectionCriteria::default(),
             OutputFeatures::default(),
             100 * uT,
-            PaymentId::open("Testing Message1", TxType::PaymentToOther),
+            PaymentId::open_from_string("Testing Message1", TxType::PaymentToOther),
         )
         .await
         .unwrap();
@@ -4031,7 +4050,7 @@ async fn test_tx_direct_send_behaviour() {
             UtxoSelectionCriteria::default(),
             OutputFeatures::default(),
             100 * uT,
-            PaymentId::open("Testing Message2", TxType::PaymentToOther),
+            PaymentId::open_from_string("Testing Message2", TxType::PaymentToOther),
         )
         .await
         .unwrap();
@@ -4080,7 +4099,7 @@ async fn test_tx_direct_send_behaviour() {
             UtxoSelectionCriteria::default(),
             OutputFeatures::default(),
             100 * uT,
-            PaymentId::open("Testing Message3", TxType::PaymentToOther),
+            PaymentId::open_from_string("Testing Message3", TxType::PaymentToOther),
         )
         .await
         .unwrap();
@@ -4129,7 +4148,7 @@ async fn test_tx_direct_send_behaviour() {
             UtxoSelectionCriteria::default(),
             OutputFeatures::default(),
             100 * uT,
-            PaymentId::open("Testing Message4", TxType::PaymentToOther),
+            PaymentId::open_from_string("Testing Message4", TxType::PaymentToOther),
         )
         .await
         .unwrap();
@@ -4263,7 +4282,8 @@ async fn test_restarting_transaction_protocols() {
         bob_view_key.pub_key,
         bob_identity.public_key().clone(),
         network,
-    );
+    )
+    .unwrap();
     let inbound_tx = InboundTransaction {
         tx_id,
         source_address: bob_address,
@@ -4289,7 +4309,8 @@ async fn test_restarting_transaction_protocols() {
         alice_view_key.pub_key,
         alice_identity.public_key().clone(),
         network,
-    );
+    )
+    .unwrap();
     let outbound_tx = OutboundTransaction {
         tx_id,
         destination_address: alice_address,
@@ -4447,7 +4468,8 @@ async fn test_transaction_resending() {
     let bob_address = TariAddress::new_single_address_with_interactive_only(
         bob_node_identity.public_key().clone(),
         Network::LocalNet,
-    );
+    )
+    .unwrap();
     let tx_id = alice_ts_interface
         .transaction_service_handle
         .send_transaction(
@@ -4456,7 +4478,7 @@ async fn test_transaction_resending() {
             UtxoSelectionCriteria::default(),
             OutputFeatures::default(),
             100 * uT,
-            PaymentId::open("Testing Message", TxType::PaymentToOther),
+            PaymentId::open_from_string("Testing Message", TxType::PaymentToOther),
         )
         .await
         .unwrap();
@@ -4644,7 +4666,7 @@ async fn test_resend_on_startup() {
     builder
         .with_lock_height(0)
         .with_fee_per_gram(MicroMinotari::from(177 / 5))
-        .with_payment_id(PaymentId::open("Yo!", TxType::PaymentToOther))
+        .with_payment_id(PaymentId::open_from_string("Yo!", TxType::PaymentToOther))
         .with_input(input)
         .await
         .unwrap()
@@ -4676,7 +4698,8 @@ async fn test_resend_on_startup() {
         CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
         CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
         Network::LocalNet,
-    );
+    )
+    .unwrap();
     let mut outbound_tx = OutboundTransaction {
         tx_id,
         destination_address: address,
@@ -4684,7 +4707,7 @@ async fn test_resend_on_startup() {
         fee: stp.get_fee_amount().unwrap(),
         sender_protocol: stp,
         status: TransactionStatus::Pending,
-        payment_id: PaymentId::open("Yo!", TxType::PaymentToOther),
+        payment_id: PaymentId::open_from_string("Yo!", TxType::PaymentToOther),
         timestamp: Utc::now(),
         cancelled: false,
         direct_send_success: false,
@@ -4810,14 +4833,15 @@ async fn test_resend_on_startup() {
         CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
         CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
         Network::LocalNet,
-    );
+    )
+    .unwrap();
     let mut inbound_tx = InboundTransaction {
         tx_id,
         source_address: address,
         amount,
         receiver_protocol: rtp,
         status: TransactionStatus::Pending,
-        payment_id: PaymentId::open("Yo2", TxType::PaymentToOther),
+        payment_id: PaymentId::open_from_string("Yo2", TxType::PaymentToOther),
         timestamp: Utc::now(),
         cancelled: false,
         direct_send_success: false,
@@ -4970,7 +4994,8 @@ async fn test_replying_to_cancelled_tx() {
     let bob_address = TariAddress::new_single_address_with_interactive_only(
         bob_node_identity.public_key().clone(),
         Network::LocalNet,
-    );
+    )
+    .unwrap();
     let tx_id = alice_ts_interface
         .transaction_service_handle
         .send_transaction(
@@ -4979,7 +5004,7 @@ async fn test_replying_to_cancelled_tx() {
             UtxoSelectionCriteria::default(),
             OutputFeatures::default(),
             100 * uT,
-            PaymentId::open("Testing Message", TxType::PaymentToOther),
+            PaymentId::open_from_string("Testing Message", TxType::PaymentToOther),
         )
         .await
         .unwrap();
@@ -5110,7 +5135,8 @@ async fn test_transaction_timeout_cancellation() {
     let bob_address = TariAddress::new_single_address_with_interactive_only(
         bob_node_identity.public_key().clone(),
         Network::LocalNet,
-    );
+    )
+    .unwrap();
     let tx_id = alice_ts_interface
         .transaction_service_handle
         .send_transaction(
@@ -5119,7 +5145,7 @@ async fn test_transaction_timeout_cancellation() {
             UtxoSelectionCriteria::default(),
             OutputFeatures::default(),
             20 * uT,
-            PaymentId::open("Testing Message", TxType::PaymentToOther),
+            PaymentId::open_from_string("Testing Message", TxType::PaymentToOther),
         )
         .await
         .unwrap();
@@ -5174,7 +5200,7 @@ async fn test_transaction_timeout_cancellation() {
     builder
         .with_lock_height(0)
         .with_fee_per_gram(MicroMinotari::from(177 / 5))
-        .with_payment_id(PaymentId::open("Yo!", TxType::PaymentToOther))
+        .with_payment_id(PaymentId::open_from_string("Yo!", TxType::PaymentToOther))
         .with_input(input)
         .await
         .unwrap()
@@ -5206,7 +5232,8 @@ async fn test_transaction_timeout_cancellation() {
         CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
         CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
         Network::LocalNet,
-    );
+    )
+    .unwrap();
     let outbound_tx = OutboundTransaction {
         tx_id,
         destination_address: address,
@@ -5214,7 +5241,7 @@ async fn test_transaction_timeout_cancellation() {
         fee: stp.get_fee_amount().unwrap(),
         sender_protocol: stp,
         status: TransactionStatus::Pending,
-        payment_id: PaymentId::open("Yo!", TxType::PaymentToOther),
+        payment_id: PaymentId::open_from_string("Yo!", TxType::PaymentToOther),
         timestamp: Utc::now().checked_sub_signed(ChronoDuration::seconds(20)).unwrap(),
         cancelled: false,
         direct_send_success: false,
@@ -5404,7 +5431,8 @@ async fn transaction_service_tx_broadcast() {
     let bob_address = TariAddress::new_single_address_with_interactive_only(
         bob_node_identity.public_key().clone(),
         Network::LocalNet,
-    );
+    )
+    .unwrap();
     // Send Tx1
     let tx_id1 = alice_ts_interface
         .transaction_service_handle
@@ -5414,7 +5442,7 @@ async fn transaction_service_tx_broadcast() {
             UtxoSelectionCriteria::default(),
             OutputFeatures::default(),
             100 * uT,
-            PaymentId::open("Testing Message", TxType::PaymentToOther),
+            PaymentId::open_from_string("Testing Message", TxType::PaymentToOther),
         )
         .await
         .unwrap();
@@ -5475,7 +5503,7 @@ async fn transaction_service_tx_broadcast() {
             UtxoSelectionCriteria::default(),
             OutputFeatures::default(),
             20 * uT,
-            PaymentId::open("Testing Message2", TxType::PaymentToOther),
+            PaymentId::open_from_string("Testing Message2", TxType::PaymentToOther),
         )
         .await
         .unwrap();
@@ -5746,12 +5774,14 @@ async fn broadcast_all_completed_transactions_on_startup() {
         CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
         CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
         Network::LocalNet,
-    );
+    )
+    .unwrap();
     let destination_address = TariAddress::new_dual_address_with_default_features(
         CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
         CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
         Network::LocalNet,
-    );
+    )
+    .unwrap();
     let completed_tx1 = CompletedTransaction {
         tx_id: 1u64.into(),
         source_address,
@@ -5770,7 +5800,7 @@ async fn broadcast_all_completed_transactions_on_startup() {
         mined_height: None,
         mined_in_block: None,
         mined_timestamp: None,
-        payment_id: PaymentId::open("Yo!", TxType::PaymentToOther),
+        payment_id: PaymentId::open_from_string("Yo!", TxType::PaymentToOther),
     };
 
     let completed_tx2 = CompletedTransaction {
@@ -5872,7 +5902,8 @@ async fn test_update_faux_tx_on_oms_validation() {
     let alice_address = TariAddress::new_single_address_with_interactive_only(
         alice_ts_interface.base_node_identity.public_key().clone(),
         Network::LocalNet,
-    );
+    )
+    .unwrap();
 
     let uo_1 = make_input(
         &mut OsRng.clone(),
@@ -5908,7 +5939,7 @@ async fn test_update_faux_tx_on_oms_validation() {
             uo_1.to_transaction_output(&alice_ts_interface.key_manager_handle)
                 .await
                 .unwrap(),
-            PaymentId::open("blah", TxType::PaymentToOther),
+            PaymentId::open_from_string("blah", TxType::PaymentToOther),
         )
         .await
         .unwrap();
@@ -5924,7 +5955,7 @@ async fn test_update_faux_tx_on_oms_validation() {
             uo_2.to_transaction_output(&alice_ts_interface.key_manager_handle)
                 .await
                 .unwrap(),
-            PaymentId::open("one-sided 1", TxType::PaymentToOther),
+            PaymentId::open_from_string("one-sided 1", TxType::PaymentToOther),
         )
         .await
         .unwrap();
@@ -5940,7 +5971,7 @@ async fn test_update_faux_tx_on_oms_validation() {
             uo_3.to_transaction_output(&alice_ts_interface.key_manager_handle)
                 .await
                 .unwrap(),
-            PaymentId::open("one-sided 2", TxType::PaymentToOther),
+            PaymentId::open_from_string("one-sided 2", TxType::PaymentToOther),
         )
         .await
         .unwrap();
@@ -6047,7 +6078,8 @@ async fn test_update_coinbase_tx_on_oms_validation() {
     let alice_address = TariAddress::new_single_address_with_interactive_only(
         alice_ts_interface.base_node_identity.public_key().clone(),
         Network::LocalNet,
-    );
+    )
+    .unwrap();
 
     let uo_1 = make_input(
         &mut OsRng.clone(),
@@ -6083,7 +6115,7 @@ async fn test_update_coinbase_tx_on_oms_validation() {
             uo_1.to_transaction_output(&alice_ts_interface.key_manager_handle)
                 .await
                 .unwrap(),
-            PaymentId::open("coinbase_confirmed", TxType::PaymentToOther),
+            PaymentId::open_from_string("coinbase_confirmed", TxType::PaymentToOther),
         )
         .await
         .unwrap();
@@ -6099,7 +6131,7 @@ async fn test_update_coinbase_tx_on_oms_validation() {
             uo_2.to_transaction_output(&alice_ts_interface.key_manager_handle)
                 .await
                 .unwrap(),
-            PaymentId::open("one-coinbase_unconfirmed 1", TxType::PaymentToOther),
+            PaymentId::open_from_string("one-coinbase_unconfirmed 1", TxType::PaymentToOther),
         )
         .await
         .unwrap();
@@ -6115,7 +6147,7 @@ async fn test_update_coinbase_tx_on_oms_validation() {
             uo_3.to_transaction_output(&alice_ts_interface.key_manager_handle)
                 .await
                 .unwrap(),
-            PaymentId::open("Coinbase_not_mined", TxType::PaymentToOther),
+            PaymentId::open_from_string("Coinbase_not_mined", TxType::PaymentToOther),
         )
         .await
         .unwrap();
@@ -6258,12 +6290,14 @@ async fn test_completed_transactions_ordering() {
         CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
         CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
         Network::LocalNet,
-    );
+    )
+    .unwrap();
     let destination_address = TariAddress::new_dual_address_with_default_features(
         CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
         CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
         Network::LocalNet,
-    );
+    )
+    .unwrap();
 
     for i in 1u32..5u32 {
         let random_timestamp = i64::from(OsRng.next_u32());
@@ -6285,7 +6319,7 @@ async fn test_completed_transactions_ordering() {
             mined_height: None,
             mined_in_block: None,
             mined_timestamp: DateTime::<Utc>::from_timestamp(random_timestamp + 100i64, 0),
-            payment_id: PaymentId::open("Yo!", TxType::PaymentToOther),
+            payment_id: PaymentId::open_from_string("Yo!", TxType::PaymentToOther),
         };
 
         tx_backend

--- a/base_layer/wallet/tests/transaction_service_tests/storage.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/storage.rs
@@ -91,7 +91,7 @@ pub async fn test_db_backend<T: TransactionBackend + 'static>(backend: T) {
     builder
         .with_lock_height(0)
         .with_fee_per_gram(MicroMinotari::from(177 / 5))
-        .with_payment_id(PaymentId::open("Yo!", TxType::PaymentToOther))
+        .with_payment_id(PaymentId::open_from_string("Yo!", TxType::PaymentToOther))
         .with_input(input)
         .await
         .unwrap()
@@ -132,7 +132,8 @@ pub async fn test_db_backend<T: TransactionBackend + 'static>(backend: T) {
             CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
             CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
             Network::LocalNet,
-        );
+        )
+        .unwrap();
         outbound_txs.push(OutboundTransaction {
             tx_id,
             destination_address: address,
@@ -140,7 +141,7 @@ pub async fn test_db_backend<T: TransactionBackend + 'static>(backend: T) {
             fee: stp.clone().get_fee_amount().unwrap(),
             sender_protocol: stp.clone(),
             status: TransactionStatus::Pending,
-            payment_id: PaymentId::open(messages[i], TxType::PaymentToOther),
+            payment_id: PaymentId::open_from_string(messages[i], TxType::PaymentToOther),
             timestamp: Utc::now(),
             cancelled: false,
             direct_send_success: false,
@@ -244,7 +245,8 @@ pub async fn test_db_backend<T: TransactionBackend + 'static>(backend: T) {
             CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
             CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
             Network::LocalNet,
-        );
+        )
+        .unwrap();
         let tx_id = TxId::from(i);
         inbound_txs.push(InboundTransaction {
             tx_id,
@@ -252,7 +254,7 @@ pub async fn test_db_backend<T: TransactionBackend + 'static>(backend: T) {
             amount: amounts[i],
             receiver_protocol: rtp.clone(),
             status: TransactionStatus::Pending,
-            payment_id: PaymentId::open(messages[i], TxType::PaymentToOther),
+            payment_id: PaymentId::open_from_string(messages[i], TxType::PaymentToOther),
             timestamp: Utc::now(),
             cancelled: false,
             direct_send_success: false,
@@ -314,12 +316,14 @@ pub async fn test_db_backend<T: TransactionBackend + 'static>(backend: T) {
             CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
             CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
             Network::LocalNet,
-        );
+        )
+        .unwrap();
         let dest_address = TariAddress::new_dual_address_with_default_features(
             CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
             CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
             Network::LocalNet,
-        );
+        )
+        .unwrap();
         completed_txs.push(CompletedTransaction {
             tx_id: outbound_txs[i].tx_id,
             source_address,
@@ -343,7 +347,7 @@ pub async fn test_db_backend<T: TransactionBackend + 'static>(backend: T) {
             mined_height: None,
             mined_in_block: None,
             mined_timestamp: None,
-            payment_id: PaymentId::open(messages[i], TxType::PaymentToOther),
+            payment_id: PaymentId::open_from_string(messages[i], TxType::PaymentToOther),
         });
         db.complete_outbound_transaction(outbound_txs[i].tx_id, completed_txs[i].clone())
             .unwrap();
@@ -440,7 +444,8 @@ pub async fn test_db_backend<T: TransactionBackend + 'static>(backend: T) {
         CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
         CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
         Network::LocalNet,
-    );
+    )
+    .unwrap();
     db.add_pending_inbound_transaction(
         999u64.into(),
         InboundTransaction::new(
@@ -449,7 +454,7 @@ pub async fn test_db_backend<T: TransactionBackend + 'static>(backend: T) {
             22 * uT,
             rtp,
             TransactionStatus::Pending,
-            PaymentId::open("To be cancelled", TxType::PaymentToOther),
+            PaymentId::open_from_string("To be cancelled", TxType::PaymentToOther),
             Utc::now(),
         ),
     )
@@ -492,7 +497,8 @@ pub async fn test_db_backend<T: TransactionBackend + 'static>(backend: T) {
         CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
         CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
         Network::LocalNet,
-    );
+    )
+    .unwrap();
     db.add_pending_outbound_transaction(
         998u64.into(),
         OutboundTransaction::new(
@@ -502,7 +508,7 @@ pub async fn test_db_backend<T: TransactionBackend + 'static>(backend: T) {
             stp.get_fee_amount().unwrap(),
             stp,
             TransactionStatus::Pending,
-            PaymentId::open("To be cancelled", TxType::PaymentToOther),
+            PaymentId::open_from_string("To be cancelled", TxType::PaymentToOther),
             Utc::now(),
             false,
         ),
@@ -599,7 +605,7 @@ async fn import_tx_and_read_it_from_db() {
         TransactionDirection::Inbound,
         Some(5),
         Some(DateTime::from_timestamp(0, 0).unwrap()),
-        PaymentId::open("message", TxType::PaymentToOther),
+        PaymentId::open_from_string("message", TxType::PaymentToOther),
     )
     .unwrap();
 
@@ -628,7 +634,7 @@ async fn import_tx_and_read_it_from_db() {
         TransactionDirection::Inbound,
         Some(6),
         Some(DateTime::from_timestamp(0, 0).unwrap()),
-        PaymentId::open("message", TxType::PaymentToOther),
+        PaymentId::open_from_string("message", TxType::PaymentToOther),
     )
     .unwrap();
 
@@ -657,7 +663,7 @@ async fn import_tx_and_read_it_from_db() {
         TransactionDirection::Inbound,
         Some(7),
         Some(DateTime::from_timestamp(0, 0).unwrap()),
-        PaymentId::open("message", TxType::PaymentToOther),
+        PaymentId::open_from_string("message", TxType::PaymentToOther),
     )
     .unwrap();
 

--- a/base_layer/wallet/tests/transaction_service_tests/transaction_protocols.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/transaction_protocols.rs
@@ -175,9 +175,12 @@ pub async fn setup() -> (
         comms_key.pub_key,
         network,
         TariAddressFeatures::create_one_sided_only(),
-    );
+        None,
+    )
+    .unwrap();
     let interactive_tari_address =
-        TariAddress::new_dual_address(view_key.pub_key, spend_key.pub_key, network, interactive_features);
+        TariAddress::new_dual_address(view_key.pub_key, spend_key.pub_key, network, interactive_features, None)
+            .unwrap();
     let wallet_type = core_key_manager_service_handle.get_wallet_type().await;
     let (event_sender, _) = broadcast::channel(200);
     let recovery_message_watch = Watch::new("unset".to_string());
@@ -246,7 +249,7 @@ pub async fn add_transaction_to_database(
         TransactionDirection::Outbound,
         None,
         None,
-        PaymentId::open("Test", TxType::PaymentToOther),
+        PaymentId::open_from_string("Test", TxType::PaymentToOther),
     )
     .unwrap();
     db.insert_completed_transaction(tx_id, completed_tx1).unwrap();

--- a/base_layer/wallet/tests/utxo_scanner/mod.rs
+++ b/base_layer/wallet/tests/utxo_scanner/mod.rs
@@ -199,7 +199,8 @@ async fn setup(
         view_key.pub_key,
         node_identity.public_key().clone(),
         Network::default(),
-    );
+    )
+    .unwrap();
     let scanner_service = scanner_service_builder
         .build_with_resources::<WalletSqliteDatabase, WalletConnectivityMock, MemoryDbKeyManager>(
             wallet_db.clone(),

--- a/base_layer/wallet_ffi/src/callback_handler_tests.rs
+++ b/base_layer/wallet_ffi/src/callback_handler_tests.rs
@@ -315,14 +315,15 @@ mod test {
             CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
             CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
             Network::LocalNet,
-        );
+        )
+        .unwrap();
         let inbound_tx = InboundTransaction::new(
             1u64.into(),
             source_address,
             22 * uT,
             rtp,
             TransactionStatus::Pending,
-            PaymentId::open("1", TxType::PaymentToOther),
+            PaymentId::open_from_string("1", TxType::PaymentToOther),
             Utc::now(),
         );
         db.add_pending_inbound_transaction(1u64.into(), inbound_tx.clone())
@@ -332,12 +333,14 @@ mod test {
             CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
             CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
             Network::LocalNet,
-        );
+        )
+        .unwrap();
         let destination_address = TariAddress::new_dual_address_with_default_features(
             CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
             CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
             Network::LocalNet,
-        );
+        )
+        .unwrap();
         let completed_tx = CompletedTransaction::new(
             2u64.into(),
             source_address,
@@ -356,7 +359,7 @@ mod test {
             TransactionDirection::Inbound,
             None,
             None,
-            PaymentId::open("2", TxType::PaymentToOther),
+            PaymentId::open_from_string("2", TxType::PaymentToOther),
         )
         .unwrap();
         db.insert_completed_transaction(2u64.into(), completed_tx.clone())
@@ -367,7 +370,8 @@ mod test {
             CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
             CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
             Network::LocalNet,
-        );
+        )
+        .unwrap();
         let outbound_tx = OutboundTransaction::new(
             3u64.into(),
             destination_address,
@@ -375,7 +379,7 @@ mod test {
             23 * uT,
             stp,
             TransactionStatus::Pending,
-            PaymentId::open("3", TxType::PaymentToOther),
+            PaymentId::open_from_string("3", TxType::PaymentToOther),
             Utc::now(),
             false,
         );
@@ -403,12 +407,14 @@ mod test {
             CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
             CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
             Network::LocalNet,
-        );
+        )
+        .unwrap();
         let destination_address = TariAddress::new_dual_address_with_default_features(
             CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
             CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
             Network::LocalNet,
-        );
+        )
+        .unwrap();
         let faux_unconfirmed_tx = CompletedTransaction::new(
             6u64.into(),
             source_address,
@@ -427,7 +433,7 @@ mod test {
             TransactionDirection::Inbound,
             Some(2),
             Some(DateTime::from_timestamp(0, 0).unwrap_or(DateTime::<Utc>::MIN_UTC)),
-            PaymentId::open("6", TxType::PaymentToOther),
+            PaymentId::open_from_string("6", TxType::PaymentToOther),
         )
         .unwrap();
         db.insert_completed_transaction(6u64.into(), faux_unconfirmed_tx.clone())
@@ -437,12 +443,14 @@ mod test {
             CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
             CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
             Network::LocalNet,
-        );
+        )
+        .unwrap();
         let destination_address = TariAddress::new_dual_address_with_default_features(
             CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
             CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
             Network::LocalNet,
-        );
+        )
+        .unwrap();
         let faux_confirmed_tx = CompletedTransaction::new(
             7u64.into(),
             source_address,
@@ -461,7 +469,7 @@ mod test {
             TransactionDirection::Inbound,
             Some(5),
             Some(DateTime::from_timestamp(0, 0).unwrap()),
-            PaymentId::open("7", TxType::PaymentToOther),
+            PaymentId::open_from_string("7", TxType::PaymentToOther),
         )
         .unwrap();
         db.insert_completed_transaction(7u64.into(), faux_confirmed_tx.clone())
@@ -501,7 +509,8 @@ mod test {
             CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
             CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
             Network::LocalNet,
-        );
+        )
+        .unwrap();
         let void_ptr: *mut c_void = &mut (5) as *mut _ as *mut c_void;
         let callback_handler = CallbackHandler::new(
             Context(void_ptr),

--- a/base_layer/wallet_ffi/src/error.rs
+++ b/base_layer/wallet_ffi/src/error.rs
@@ -440,6 +440,10 @@ impl From<TariAddressError> for LibWalletError {
                 code: 708,
                 message: format!("{:?}", e),
             },
+            TariAddressError::PaymentIdTooLarge => Self {
+                code: 709,
+                message: format!("{:?}", e),
+            },
         }
     }
 }

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -2481,7 +2481,7 @@ pub unsafe extern "C" fn wallet_import_external_utxo_as_non_rewindable(
         .block_on((*wallet).wallet.import_unblinded_output_as_non_rewindable(
             (*output).clone(),
             source_address,
-            PaymentId::open(&payment_id_string, TxType::ImportedUtxoNoneRewindable),
+            PaymentId::open_from_string(&payment_id_string, TxType::ImportedUtxoNoneRewindable),
         )) {
         Ok(tx_id) => tx_id.as_u64(),
         Err(e) => {
@@ -7094,7 +7094,7 @@ pub unsafe extern "C" fn wallet_coin_split(
         commitments,
         number_of_splits,
         MicroMinotari(fee_per_gram),
-        PaymentId::open(
+        PaymentId::open_from_string(
             &format!("{} even coin splits", number_of_splits),
             if number_of_splits > 1 {
                 TxType::CoinSplit
@@ -7170,7 +7170,7 @@ pub unsafe extern "C" fn wallet_coin_join(
     match (*wallet).runtime.block_on((*wallet).wallet.coin_join(
         commitments,
         fee_per_gram.into(),
-        Some(PaymentId::open(
+        Some(PaymentId::open_from_string(
             &format!("Coin join {} outputs", commitments_len),
             TxType::CoinJoin,
         )),
@@ -7892,10 +7892,10 @@ pub unsafe extern "C" fn wallet_send_transaction(
     };
 
     let payment_id = if payment_id_string.is_null() {
-        PaymentId::open("", TxType::PaymentToOther)
+        PaymentId::open_from_string("", TxType::PaymentToOther)
     } else {
         match CStr::from_ptr(payment_id_string).to_str() {
-            Ok(v) => PaymentId::open(v, TxType::PaymentToOther),
+            Ok(v) => PaymentId::open_from_string(v, TxType::PaymentToOther),
             _ => {
                 *error_out = LibWalletError::from(InterfaceError::NullError("payment_id".to_string())).code;
                 return 0;
@@ -10420,7 +10420,9 @@ mod test {
                 spend_key.clone(),
                 Network::Esmeralda,
                 TariAddressFeatures::create_one_sided_only(),
-            );
+                None,
+            )
+            .unwrap();
             let test_address = Box::into_raw(Box::new(address.clone()));
 
             let mut error = 0;
@@ -10897,10 +10899,9 @@ mod test {
             let error_ptr = &mut error as *mut c_int;
             let test_contact_private_key = private_key_generate();
             let key = CompressedPublicKey::from_secret_key(&(*test_contact_private_key));
-            let test_address = Box::into_raw(Box::new(TariWalletAddress::new_single_address_with_interactive_only(
-                key,
-                Network::default(),
-            )));
+            let test_address = Box::into_raw(Box::new(
+                TariWalletAddress::new_single_address_with_interactive_only(key, Network::default()).unwrap(),
+            ));
             let test_str = "Test Contact";
             let test_contact_str = CString::new(test_str).unwrap();
             let test_contact_alias: *const c_char = CString::into_raw(test_contact_str) as *const c_char;
@@ -10930,7 +10931,7 @@ mod test {
             let test_contact_private_key = private_key_generate();
             let key = CompressedPublicKey::from_secret_key(&(*test_contact_private_key));
             let test_contact_address = Box::into_raw(Box::new(
-                TariWalletAddress::new_single_address_with_interactive_only(key, Network::default()),
+                TariWalletAddress::new_single_address_with_interactive_only(key, Network::default()).unwrap(),
             ));
             let test_str = "Test Contact";
             let test_contact_str = CString::new(test_str).unwrap();
@@ -13440,7 +13441,8 @@ mod test {
             let bob_wallet_address = TariWalletAddress::new_single_address_with_interactive_only(
                 bob_node_identity.public_key().clone(),
                 Network::LocalNet,
-            );
+            )
+            .unwrap();
             let alice_contact_alias_ptr: *const c_char =
                 CString::into_raw(CString::new("bob").unwrap()) as *const c_char;
             let alice_contact_address_ptr = Box::into_raw(Box::new(bob_wallet_address.clone()));
@@ -13452,7 +13454,8 @@ mod test {
             let alice_wallet_address = TariWalletAddress::new_single_address_with_interactive_only(
                 alice_node_identity.public_key().clone(),
                 Network::LocalNet,
-            );
+            )
+            .unwrap();
             let bob_contact_alias_ptr: *const c_char =
                 CString::into_raw(CString::new("alice").unwrap()) as *const c_char;
             let bob_contact_address_ptr = Box::into_raw(Box::new(alice_wallet_address.clone()));

--- a/infrastructure/max_size/src/bytes.rs
+++ b/infrastructure/max_size/src/bytes.rs
@@ -70,6 +70,10 @@ impl<const MAX: usize> MaxSizeBytes<MAX> {
         }
     }
 
+    pub fn empty() -> Self {
+        Self { inner: Vec::new() }
+    }
+
     pub fn from_bytes_truncate<T: AsRef<[u8]>>(bytes: T) -> Self {
         let b = bytes.as_ref();
         let len = cmp::min(b.len(), MAX);

--- a/integration_tests/src/chat_client.rs
+++ b/integration_tests/src/chat_client.rs
@@ -64,7 +64,8 @@ pub async fn spawn_chat_client(name: &str, seed_peers: Vec<Peer>, base_dir: Path
         .into();
     let user_agent = format!("tari/integration_tests/{}", env!("CARGO_PKG_VERSION"));
     let address =
-        TariAddress::new_single_address_with_interactive_only(identity.public_key().clone(), config.network());
+        TariAddress::new_single_address_with_interactive_only(identity.public_key().clone(), config.network())
+            .expect("Failed to create one-sided address");
     let mut client = Client::new(identity, address, config, user_agent);
 
     client.initialize().await.expect("the chat client to spawn");

--- a/integration_tests/src/chat_ffi.rs
+++ b/integration_tests/src/chat_ffi.rs
@@ -384,7 +384,8 @@ pub async fn spawn_ffi_chat_client(name: &str, seed_peers: Vec<Peer>, base_dir: 
 
     let error_out = Box::into_raw(Box::new(0));
     let address =
-        TariAddress::new_single_address_with_interactive_only(identity.public_key().clone(), Network::LocalNet);
+        TariAddress::new_single_address_with_interactive_only(identity.public_key().clone(), Network::LocalNet)
+            .expect("Failed to create one-sided address");
     let address_ptr = Box::into_raw(Box::new(address.clone())) as *mut c_void;
     unsafe {
         *ChatCallback::instance().contact_status_change.lock().unwrap() = 0;

--- a/integration_tests/src/world.rs
+++ b/integration_tests/src/world.rs
@@ -119,7 +119,8 @@ impl Default for TariWorld {
             CompressedPublicKey::from_secret_key(&wallet_private_key),
             CompressedPublicKey::from_secret_key(&wallet_private_key),
             Network::LocalNet,
-        );
+        )
+        .unwrap();
         Self {
             current_scenario_name: None,
             current_feature_name: None,

--- a/integration_tests/tests/steps/wallet_ffi_steps.rs
+++ b/integration_tests/tests/steps/wallet_ffi_steps.rs
@@ -210,7 +210,7 @@ async fn ffi_check_no_contact(world: &mut TariWorld, alias: String, wallet: Stri
 async fn ffi_send_transaction(world: &mut TariWorld, amount: u64, wallet: String, dest: String, fee: u64) {
     let ffi_wallet = world.get_ffi_wallet(&wallet).unwrap();
     let dest_pub_key = world.get_wallet_address(&dest).await.unwrap();
-    let payment_id = PaymentId::open(
+    let payment_id = PaymentId::open_from_string(
         &format!("Send from ffi {} to ${} at fee ${}", wallet, dest, fee),
         TxType::PaymentToOther,
     );
@@ -223,7 +223,7 @@ async fn ffi_send_transaction(world: &mut TariWorld, amount: u64, wallet: String
 async fn ffi_send_one_sided_transaction(world: &mut TariWorld, amount: u64, wallet: String, dest: String, fee: u64) {
     let ffi_wallet = world.get_ffi_wallet(&wallet).unwrap();
     let dest_pub_key = world.get_wallet_address(&dest).await.unwrap();
-    let payment_id = PaymentId::open(
+    let payment_id = PaymentId::open_from_string(
         &format!("Send from ffi {} to ${} at fee ${}", wallet, dest, fee),
         TxType::PaymentToOther,
     );

--- a/integration_tests/tests/steps/wallet_steps.rs
+++ b/integration_tests/tests/steps/wallet_steps.rs
@@ -705,7 +705,7 @@ async fn send_amount_from_source_wallet_to_dest_wallet_without_broadcast(
         amount,
         fee_per_gram: fee,
         payment_type: 0, // normal mimblewimble payment type
-        payment_id: PaymentId::open(
+        payment_id: PaymentId::open_from_string(
             &format!(
                 "transfer amount {} from {} to {}",
                 amount,
@@ -769,7 +769,7 @@ async fn send_one_sided_transaction_from_source_wallet_to_dest_wallt(
         amount,
         fee_per_gram: fee,
         payment_type: 1, // one sided transaction
-        payment_id: PaymentId::open(
+        payment_id: PaymentId::open_from_string(
             &format!(
                 "One sided transfer amount {} from {} to {}",
                 amount,
@@ -871,7 +871,7 @@ async fn send_amount_from_wallet_to_wallet_at_fee(
         amount,
         fee_per_gram,
         payment_type: 0, // mimblewimble transaction
-        payment_id: PaymentId::open(
+        payment_id: PaymentId::open_from_string(
             &format!(
                 "Transfer amount {} from {} to {} as fee {}",
                 amount,
@@ -1305,7 +1305,7 @@ async fn send_num_transactions_to_wallets_at_fee(
             amount,
             fee_per_gram,
             payment_type: 0, // standard mimblewimble transaction
-            payment_id: PaymentId::open(
+            payment_id: PaymentId::open_from_string(
                 &format!(
                     "transfer amount {} from {} to {}",
                     amount,
@@ -1450,7 +1450,7 @@ async fn transfer_tari_from_wallet_to_receiver(world: &mut TariWorld, amount: u6
         amount: amount * 1_000_000_u64, // 1T = 1_000_000uT
         fee_per_gram: 10,               // as in the js cucumber tests
         payment_type: 0,                // normal mimblewimble payment type
-        payment_id: PaymentId::open(
+        payment_id: PaymentId::open_from_string(
             &format!(
                 "transfer amount {} from {} to {}",
                 amount,
@@ -1649,7 +1649,7 @@ async fn transfer_from_wallet_to_two_recipients_at_fee(
         amount,
         fee_per_gram,
         payment_type: 0, // normal mimblewimble payment type
-        payment_id: PaymentId::open(
+        payment_id: PaymentId::open_from_string(
             &format!(
                 "transfer amount {} from {} to {}",
                 amount,
@@ -1666,7 +1666,7 @@ async fn transfer_from_wallet_to_two_recipients_at_fee(
         amount,
         fee_per_gram,
         payment_type: 0, // normal mimblewimble payment type
-        payment_id: PaymentId::open(
+        payment_id: PaymentId::open_from_string(
             &format!(
                 "transfer amount {} from {} to {}",
                 amount,
@@ -1786,7 +1786,7 @@ async fn transfer_tari_to_self(world: &mut TariWorld, amount: u64, sender: Strin
         amount,
         fee_per_gram,
         payment_type: 0, // normal mimblewimble payment type
-        payment_id: PaymentId::open(
+        payment_id: PaymentId::open_from_string(
             &format!("transfer amount {} from {} to self", amount, sender.as_str()),
             TxType::PaymentToSelf,
         )
@@ -1869,7 +1869,7 @@ async fn htlc_transaction(world: &mut TariWorld, amount: u64, sender: String, re
         amount,
         fee_per_gram,
         payment_type: 0, // normal mimblewimble transaction
-        payment_id: PaymentId::open(
+        payment_id: PaymentId::open_from_string(
             &format!(
                 "Atomic Swap from {} to {} with amount {} at fee {}",
                 sender.as_str(),
@@ -2163,7 +2163,7 @@ async fn send_one_sided_stealth_transaction(
         amount,
         fee_per_gram,
         payment_type: 2, // one sided stealth transaction
-        payment_id: PaymentId::open(
+        payment_id: PaymentId::open_from_string(
             &format!(
                 "One sided stealth transfer amount {} from {} to {}",
                 amount,
@@ -2357,7 +2357,7 @@ async fn import_wallet_unspent_outputs(world: &mut TariWorld, wallet_a: String, 
             .iter()
             .map(|o| grpc::UnblindedOutput::try_from(o.clone()).expect("Unable to make grpc conversion"))
             .collect::<Vec<grpc::UnblindedOutput>>(),
-        payment_id: PaymentId::open(
+        payment_id: PaymentId::open_from_string(
             &format!("I import {} unspent outputs to {}", wallet_a, wallet_b),
             TxType::ImportedUtxoNoneRewindable,
         )
@@ -2481,7 +2481,7 @@ async fn import_wallet_spent_outputs(world: &mut TariWorld, wallet_a: String, wa
             .iter()
             .map(|o| grpc::UnblindedOutput::try_from(o.clone()).expect("Unable to make grpc conversion"))
             .collect::<Vec<grpc::UnblindedOutput>>(),
-        payment_id: PaymentId::open(
+        payment_id: PaymentId::open_from_string(
             &format!("I import {} spent outputs to {}", wallet_a, wallet_b),
             TxType::ImportedUtxoNoneRewindable,
         )
@@ -2604,7 +2604,7 @@ async fn import_unspent_outputs_as_pre_mine(world: &mut TariWorld, wallet_a: Str
             .iter()
             .map(|o| grpc::UnblindedOutput::try_from(o.clone()).expect("Unable to make grpc conversion"))
             .collect::<Vec<grpc::UnblindedOutput>>(),
-        payment_id: PaymentId::open(
+        payment_id: PaymentId::open_from_string(
             &format!(
                 "I import {} unspent outputs as pre_mine outputs to {}",
                 wallet_a, wallet_b
@@ -2698,7 +2698,7 @@ async fn multi_send_txs_from_wallet(
             amount,
             fee_per_gram,
             payment_type: 0, // mimblewimble transaction
-            payment_id: PaymentId::open(
+            payment_id: PaymentId::open_from_string(
                 &format!(
                     "I send multi-transfers with amount {} from {} to {} with fee per gram {}",
                     amount,
@@ -2868,7 +2868,7 @@ async fn burn_transaction(world: &mut TariWorld, amount: u64, wallet: String, fe
         amount,
         fee_per_gram: fee,
         claim_public_key: identity.public_key,
-        payment_id: PaymentId::open("Burning some tari", TxType::Burn).to_bytes(),
+        payment_id: PaymentId::open_from_string("Burning some tari", TxType::Burn).to_bytes(),
     };
 
     let result = client.create_burn_transaction(req).await.unwrap();


### PR DESCRIPTION
Description
---
Expands Tari Address to carry a payment_id
This allows receivers to set a payment id they want to receive inside of the tari address. Effectivly making sub addresses. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for embedding optional encrypted payment ID data within wallet addresses, allowing transactions to include additional user-defined information.
  - Introduced a new gRPC method to retrieve wallet addresses associated with specific payment IDs.
  - Wallet addresses now indicate when a payment ID is required for transactions.

- **Bug Fixes**
  - Improved error handling for address creation and payment ID size limits, providing clearer feedback on invalid input.

- **Refactor**
  - Updated wallet and transaction services to consistently use a new method for creating payment IDs from strings.
  - Enhanced error propagation in address construction and transaction service initialization.
  - Replaced all calls to payment ID creation from strings with a new, more explicit method.

- **Tests**
  - Enhanced test coverage and reliability by enforcing explicit error handling and updating test cases to use new address and payment ID APIs.
  - Updated tests to unwrap results from fallible constructors and use the updated payment ID creation method.

- **Chores**
  - Updated dependencies and internal APIs to support new payment ID features and improved error propagation.
  - Added utility methods for handling empty payment ID data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->