### PR TITLE
Feat (Doc): add gRPC method for generating address with paymentid and address structure

### DIFF
--- a/docs/src/API_GRPC_Explanation.md
+++ b/docs/src/API_GRPC_Explanation.md
@@ -68,12 +68,15 @@ Tari addresses is a address scheme used by Tari. Each address includes the neces
 
 The optional Payment ID feature allows an exchange, merchant or other service to append a payment ID to the address in a manner that preserves privacy while still allowing the service to track payments, withdrawals and other activity against a particular user. This is done by requesting an address from the existing wallet via the gRPC method `GetPaymentIdAddress`, described later in the document.
 
-
-When included, the `payment_id` is **encrypted using the public keys** of the address. The `Features` byte uses **bitflag 3** (8) to indicate optional fields. For example:
+When included, the payment_id is encrypted using the public keys of the address. The Features byte uses bitflag 2 (value 4) to indicate the presence of a payment ID. For example::
    
-   ```rust
-    const PAYMENT_ID_PRESENT: u8 = 0b00000001;
-   ```
+   impl TariAddressFeatures: u8 {
+        // this forces a transaction to include the following payment id
+        const PAYMENT_ID = 0b0000_0100;
+        const INTERACTIVE = 0b0000_0010;
+        ///one sided payment
+        const ONE_SIDED = 0b0000_0001;
+    }
 
 The maximum allowed size for `payment_id` is **256 bytes**. Larger values will raise:
   ```rust

--- a/docs/src/API_GRPC_Explanation.md
+++ b/docs/src/API_GRPC_Explanation.md
@@ -51,7 +51,7 @@ message GetBalanceResponse {
 ```
 
 ### Tari Address Structure (with Optional Payment ID)
-Tari addresses is a address scheme used by Tari. Each address includes the necessary information for identifying the network, verifying integrity, and optionally embedding an **encrypted payment identifier**.
+Tari addresses are an address scheme used by Tari. Each address includes the necessary information for identifying the network, verifying integrity, and optionally embedding an **encrypted payment identifier**. The [RFC-0155 TariAddress](https://rfc.tari.com/RFC-0155_TariAddress) can be reviewed for more information.
 
 #### Binary Structure
 
@@ -68,7 +68,7 @@ Tari addresses is a address scheme used by Tari. Each address includes the neces
 
 The optional Payment ID feature allows an exchange, merchant or other service to append a payment ID to the address in a manner that preserves privacy while still allowing the service to track payments, withdrawals and other activity against a particular user. This is done by requesting an address from the existing wallet via the gRPC method `GetPaymentIdAddress`, described later in the document.
 
-When included, the payment_id is encrypted using the public keys of the address. The Features byte uses bitflag 2 (value 4) to indicate the presence of a payment ID. For example::
+When included, the payment_id is encrypted using the public keys of the address. The Features byte uses bitflag 2 (value 4) to indicate the presence of a payment ID. For example:
    
    impl TariAddressFeatures: u8 {
         // this forces a transaction to include the following payment id
@@ -86,7 +86,7 @@ The maximum allowed size for `payment_id` is **256 bytes**. Larger values will r
 Please note that fees will be applicable for every bit used in the `payment_id`.
 
 #### Encoding
-After serialization, the complete byte array is encoded using **Base58**, resulting in a human-readable Tari address. The [RFC-0155 TariAddress](https://rfc.tari.com/RFC-0155_TariAddress) can be reviewed for more information.
+After serialization, the complete byte array is encoded using **Base58**, resulting in a human-readable Tari address.
 
 ### Understanding Code Generation from `.proto` Files
 The `.proto` file, such as [`wallet.proto`][wallet-proto], acts as a **shared contract** that defines all available services, methods, and message structures for the Minotari Wallet's gRPC API. However, it is not executable code by itself.
@@ -351,7 +351,7 @@ client.GetPaymentIdAddress({ payment_id: paymentId }, (error, response) => {
   "interactive_address_base58": "14HVCEeZC2RGE4SDn3yG.....6xouGvS5SXwEvXKwK3zLz2rgReh",
   "one_sided_address_base58": "12HVCEeZC2RGE4SDn3yGwqz.....obB1a6xouGvS5SXwEvXKwK3zLz2rgReL",
   "interactive_address_emoji": "🐢🌊💤🔌🚑🐛🏦⚽🍓🐭🚁🎢🔪🥐👛🍞.....🍐🍟💵🎉🍯🎁🎾🎼💻💄🍳🍐🤔🥝🍫👅🚀🐬🎭",
-  "one_sided_address_emoji": "🐢📟💤🔌🚑🐛🏦⚽🍓🐭🚁🎢🔪🥐👛🍞📜.....🍐🍟💵🎉🍯🎁🎾🎼💻💄🍳🍐🤔🥝🍫👅🚀🐬🎭 "
+  "one_sided_address_emoji": "🐢📟💤🔌🚑🐛🏦⚽🍓🐭🚁🎢🔪🥐👛🍞📜.....🍐🍟💵🎉🍯🎁🎾🎼💻💄🍳🍐🤔🥝🍫👅🚀🐬🎭"
 }
 ```
 

--- a/docs/src/API_GRPC_Explanation.md
+++ b/docs/src/API_GRPC_Explanation.md
@@ -5,6 +5,7 @@ Below is documentation regarding various gRPC methods available for the Minotari
 
 - [Introduction](#introduction)
   - [General Structure](#general-structure)
+  - [Tari Address Structure](#tari-address-structure-with-optional-payment-id)
   - [Code Generation from .proto files](#understanding-code-generation-from-proto-files)
   - [Loading the Protocol Buffer Definition](#loading-the-protocol-buffer-definition)
   - [Instantiating the Client](#instantiating-the-client)
@@ -46,6 +47,88 @@ message GetBalanceResponse {
   uint64 available_balance = 1;
   uint64 pending_incoming_balance = 2;
   uint64 pending_outgoing_balance = 3;
+}
+```
+
+### Tari Address Structure (with Optional Payment ID)
+Tari addresses are **Base58-encoded strings** representing a serialized binary format. Each address includes the necessary information for identifying the network, verifying integrity, and optionally embedding an **encrypted payment identifier**.
+
+#### Binary Structure
+
+| Offset | Field            | Rule/Use                                                                 |
+|--------|------------------|---------------------------------------------------------------------------|
+| 0      | Network ID       | Indicates which network the address belongs to (e.g., Mainnet/Testnet).   |
+| 1      | Features         | Flags whether it's a one-sided or interactive address, and if payment ID is used. |
+| 2–33   | Public View Key  | Used by receivers to detect payments addressed to them.                   |
+| 34–65  | Public Spend Key | Required to authorize spending from the wallet.                           |
+| 66–N   | Payment ID       | *(Optional)* Encrypted tag embedded for tracking the purpose of payment. |
+| N+1    | Checksum         | Calculated using the [Damm algorithm](https://en.wikipedia.org/wiki/Damm_algorithm). |
+
+#### Payment ID Feature (Optional)
+
+The Payment ID optional feature allows an exchange, merchant or other service to append a payment ID to the address in a manner that preserves privacy while still allowing the service to track payments, withdrawals and other activity against a particular user. This is done by requesting an address from the existing wallet via the gRPC method `GetPaymentIdAddress`, described later in the document.
+
+
+When included, the `payment_id` is **encrypted using the public keys** of the address. The `Features` byte uses **bitflags** to indicate optional fields.
+  - For example:
+    ```rust
+    const PAYMENT_ID_PRESENT: u8 = 0b00000001;
+    ```
+
+Maximum allowed size for `payment_id` is **256 bytes**. Larger values will raise:
+  ```rust
+  TariAddressError::PaymentIdTooLarge
+  ```
+
+Please note that fees will be applicable for every bit used in the `payment_id`, so it is best to standardise on something minimal but one 
+
+#### Encoding
+
+After serialization, the complete byte array is encoded using **Base58**, resulting in a human-readable Tari address.
+
+#### Example: JavaScript Decoder
+
+Here’s a working decoder stub using `bs58`:
+
+```javascript
+const bs58 = require('bs58');
+
+/**
+ * Decodes a Tari address and extracts its components, including an optional payment_id.
+ * @param {string} tariAddress - Base58 encoded Tari address.
+ * @returns {Object} Decoded components.
+ */
+function decodeTariAddress(tariAddress) {
+  const bytes = bs58.decode(tariAddress);
+
+  if (bytes.length < 67) {
+    throw new Error('Address is too short to be valid');
+  }
+
+  const networkId = bytes[0];
+  const features = bytes[1];
+  const viewKey = bytes.slice(2, 34);
+  const spendKey = bytes.slice(34, 66);
+
+  let paymentId = null;
+  let checksumIndex = 66;
+
+  if (features & 0b00000001) {
+    // payment_id is present
+    paymentId = bytes.slice(66, bytes.length - 1);
+    checksumIndex = bytes.length - 1;
+  }
+
+  const checksum = bytes[checksumIndex];
+
+  return {
+    networkId,
+    features,
+    viewKey,
+    spendKey,
+    paymentId,
+    checksum,
+  };
 }
 ```
 
@@ -274,6 +357,42 @@ const userPaymentId = {
   "timelocked_balance": 0,
 }
 ```
+
+### Retrieve Payment ID Address
+The `GetPaymentIdAddress` gRPC method returns an address appended with a payment ID, derived from an existing address. The payment ID is an optional, additional piece of metadata (like an invoice number or customer reference).
+
+- `payment_id` (optional) must be passed as a UTF-8 encoded byte array. If derived from a string, the `payment_id` must be encoded in UTF-8 and should not contain invalid UTF-8 characters.
+
+**Example:**
+```javascript
+const crypto = require('crypto');
+
+// Generate a 32-byte random payment_id
+const paymentId = crypto.randomBytes(32); // This will be a Buffer
+
+client.getPaymentIdAddress({ payment_id: paymentId }, (error, response) => {
+  if (error) {
+    console.error('gRPC Error:', error);
+    return;
+  }
+
+  console.log('Received Address Response:');
+  console.log({
+    interactive_address: Buffer.from(response.interactive_address).toString('hex'),
+    one_sided_address: Buffer.from(response.one_sided_address).toString('hex'),
+  });
+});
+```
+
+**Example of JSON response**:
+```json
+{
+  "interactive_address": "b3a5d4f2a1d2c3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8",
+  "one_sided_address": "f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8b3a5d4f2a1d2c3e4f5a6b7c8d9e0"
+}
+```
+
+
 
 ### Get Transactions by Payment ID
 The `GetCompletedTransactions` method retrieves all completed transactions against a particular wallet, which can be optionally filtered by passing the `payment_id` to show only completed transactions associated with the payment ID.

--- a/docs/src/API_GRPC_Explanation.md
+++ b/docs/src/API_GRPC_Explanation.md
@@ -329,19 +329,26 @@ client.GetPaymentIdAddress({ payment_id: paymentId }, (error, response) => {
     return;
   }
 
-  console.log('Received Address Response:');
-  console.log({
+  console.log(JSON.stringify({
     interactive_address: Buffer.from(response.interactive_address).toString('hex'),
     one_sided_address: Buffer.from(response.one_sided_address).toString('hex'),
-  });
+    interactive_address_base58: response.interactive_address_base58,
+    one_sided_address_base58: response.one_sided_address_base58,
+    interactive_address_emoji: response.interactive_address_emoji,
+    one_sided_address_emoji: response.one_sided_address_emoji
+  }, null, 2));
 });
 ```
 
 **Example of JSON response**:
 ```json
 {
-  "interactive_address": "14HVCEeZC2RGE4SDn3yGwqzXepJ2LDqXva7kb4fherYMQR9dF7341T3TjMZobB1a6xouGvS5SXwEvXKwK3zLz2rgReh",
-  "one_sided_address": "12HVCEeZC2RGE4SDn3yGwqzXepJ2LDqXva7kb4fherYMQR9dF7341T3TjMZobB1a6xouGvS5SXwEvXKwK3zLz2rgReL"
+  "interactive_address": "0411aabbccddeeff00112233445566778899aabbccddeeff0011223344556677",
+  "one_sided_address": "02ff8899aabbccddeeff00112233445566778899aabbccddeeff001122334455",
+  "interactive_address_base58": "14HVCEeZC2RGE4SDn3yG.....6xouGvS5SXwEvXKwK3zLz2rgReh",
+  "one_sided_address_base58": "12HVCEeZC2RGE4SDn3yGwqz.....obB1a6xouGvS5SXwEvXKwK3zLz2rgReL",
+  "interactive_address_emoji": "🐢🌊💤🔌🚑🐛🏦⚽🍓🐭🚁🎢🔪🥐👛🍞.....🍐🍟💵🎉🍯🎁🎾🎼💻💄🍳🍐🤔🥝🍫👅🚀🐬🎭",
+  "one_sided_address_emoji": "🐢📟💤🔌🚑🐛🏦⚽🍓🐭🚁🎢🔪🥐👛🍞📜.....🍐🍟💵🎉🍯🎁🎾🎼💻💄🍳🍐🤔🥝🍫👅🚀🐬🎭 "
 }
 ```
 

--- a/docs/src/API_GRPC_Explanation.md
+++ b/docs/src/API_GRPC_Explanation.md
@@ -86,7 +86,7 @@ The maximum allowed size for `payment_id` is **256 bytes**. Larger values will r
 Please note that fees will be applicable for every bit used in the `payment_id`.
 
 #### Encoding
-After serialization, the complete byte array is encoded using **Base58**, resulting in a human-readable Tari address. The RFC https://rfc.tari.com/RFC-0155_TariAddress is suitable for this.
+After serialization, the complete byte array is encoded using **Base58**, resulting in a human-readable Tari address. The [RFC-0155 TariAddress](https://rfc.tari.com/RFC-0155_TariAddress) can be reviewed for more information.
 
 ### Understanding Code Generation from `.proto` Files
 The `.proto` file, such as [`wallet.proto`][wallet-proto], acts as a **shared contract** that defines all available services, methods, and message structures for the Minotari Wallet's gRPC API. However, it is not executable code by itself.

--- a/docs/src/API_GRPC_Explanation.md
+++ b/docs/src/API_GRPC_Explanation.md
@@ -66,21 +66,20 @@ Tari addresses are **Base58-encoded strings** representing a serialized binary f
 
 #### Payment ID Feature (Optional)
 
-The Payment ID optional feature allows an exchange, merchant or other service to append a payment ID to the address in a manner that preserves privacy while still allowing the service to track payments, withdrawals and other activity against a particular user. This is done by requesting an address from the existing wallet via the gRPC method `GetPaymentIdAddress`, described later in the document.
+The optional Payment ID feature allows an exchange, merchant or other service to append a payment ID to the address in a manner that preserves privacy while still allowing the service to track payments, withdrawals and other activity against a particular user. This is done by requesting an address from the existing wallet via the gRPC method `GetPaymentIdAddress`, described later in the document.
 
 
-When included, the `payment_id` is **encrypted using the public keys** of the address. The `Features` byte uses **bitflags** to indicate optional fields.
-  - For example:
-    ```rust
+When included, the `payment_id` is **encrypted using the public keys** of the address. The `Features` byte uses **bitflags** to indicate optional fields. For example:
+   ```rust
     const PAYMENT_ID_PRESENT: u8 = 0b00000001;
-    ```
+   ```
 
-Maximum allowed size for `payment_id` is **256 bytes**. Larger values will raise:
+The maximum allowed size for `payment_id` is **256 bytes**. Larger values will raise:
   ```rust
   TariAddressError::PaymentIdTooLarge
   ```
 
-Please note that fees will be applicable for every bit used in the `payment_id`, so it is best to standardise on something minimal but one 
+Please note that fees will be applicable for every bit used in the `payment_id`.
 
 #### Encoding
 
@@ -358,7 +357,7 @@ const userPaymentId = {
 }
 ```
 
-### Retrieve Payment ID Address
+### Get Payment ID Address
 The `GetPaymentIdAddress` gRPC method returns an address appended with a payment ID, derived from an existing address. The payment ID is an optional, additional piece of metadata (like an invoice number or customer reference).
 
 - `payment_id` (optional) must be passed as a UTF-8 encoded byte array. If derived from a string, the `payment_id` must be encoded in UTF-8 and should not contain invalid UTF-8 characters.
@@ -370,7 +369,7 @@ const crypto = require('crypto');
 // Generate a 32-byte random payment_id
 const paymentId = crypto.randomBytes(32); // This will be a Buffer
 
-client.getPaymentIdAddress({ payment_id: paymentId }, (error, response) => {
+client.GetPaymentIdAddress({ payment_id: paymentId }, (error, response) => {
   if (error) {
     console.error('gRPC Error:', error);
     return;
@@ -391,8 +390,6 @@ client.getPaymentIdAddress({ payment_id: paymentId }, (error, response) => {
   "one_sided_address": "f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8b3a5d4f2a1d2c3e4f5a6b7c8d9e0"
 }
 ```
-
-
 
 ### Get Transactions by Payment ID
 The `GetCompletedTransactions` method retrieves all completed transactions against a particular wallet, which can be optionally filtered by passing the `payment_id` to show only completed transactions associated with the payment ID.

--- a/docs/src/API_GRPC_Explanation.md
+++ b/docs/src/API_GRPC_Explanation.md
@@ -476,9 +476,6 @@ Example:
      console.log('Transfer successful:', transferResponse);
 ```
 
-
-
-
 ## Unrelated functions not available in the gRPC but useful
 ### Fetch UTXOs by Block ID
 The `fetch_unspent_utxos_in_block` function is used to fetch unspent transaction outputs (UTXOs) within a specific block by its hash. You will need to interact with the base node directly via the `BaseNodeCommsInterface`.

--- a/docs/src/API_GRPC_Explanation.md
+++ b/docs/src/API_GRPC_Explanation.md
@@ -51,7 +51,7 @@ message GetBalanceResponse {
 ```
 
 ### Tari Address Structure (with Optional Payment ID)
-Tari addresses are **Base58-encoded strings** representing a serialized binary format. Each address includes the necessary information for identifying the network, verifying integrity, and optionally embedding an **encrypted payment identifier**.
+Tari addresses is a address scheme used by Tari. Each address includes the necessary information for identifying the network, verifying integrity, and optionally embedding an **encrypted payment identifier**.
 
 #### Binary Structure
 
@@ -69,7 +69,8 @@ Tari addresses are **Base58-encoded strings** representing a serialized binary f
 The optional Payment ID feature allows an exchange, merchant or other service to append a payment ID to the address in a manner that preserves privacy while still allowing the service to track payments, withdrawals and other activity against a particular user. This is done by requesting an address from the existing wallet via the gRPC method `GetPaymentIdAddress`, described later in the document.
 
 
-When included, the `payment_id` is **encrypted using the public keys** of the address. The `Features` byte uses **bitflags** to indicate optional fields. For example:
+When included, the `payment_id` is **encrypted using the public keys** of the address. The `Features` byte uses **bitflag 3** (8) to indicate optional fields. For example:
+   
    ```rust
     const PAYMENT_ID_PRESENT: u8 = 0b00000001;
    ```
@@ -82,54 +83,7 @@ The maximum allowed size for `payment_id` is **256 bytes**. Larger values will r
 Please note that fees will be applicable for every bit used in the `payment_id`.
 
 #### Encoding
-
-After serialization, the complete byte array is encoded using **Base58**, resulting in a human-readable Tari address.
-
-#### Example: JavaScript Decoder
-
-Here’s a working decoder stub using `bs58`:
-
-```javascript
-const bs58 = require('bs58');
-
-/**
- * Decodes a Tari address and extracts its components, including an optional payment_id.
- * @param {string} tariAddress - Base58 encoded Tari address.
- * @returns {Object} Decoded components.
- */
-function decodeTariAddress(tariAddress) {
-  const bytes = bs58.decode(tariAddress);
-
-  if (bytes.length < 67) {
-    throw new Error('Address is too short to be valid');
-  }
-
-  const networkId = bytes[0];
-  const features = bytes[1];
-  const viewKey = bytes.slice(2, 34);
-  const spendKey = bytes.slice(34, 66);
-
-  let paymentId = null;
-  let checksumIndex = 66;
-
-  if (features & 0b00000001) {
-    // payment_id is present
-    paymentId = bytes.slice(66, bytes.length - 1);
-    checksumIndex = bytes.length - 1;
-  }
-
-  const checksum = bytes[checksumIndex];
-
-  return {
-    networkId,
-    features,
-    viewKey,
-    spendKey,
-    paymentId,
-    checksum,
-  };
-}
-```
+After serialization, the complete byte array is encoded using **Base58**, resulting in a human-readable Tari address. The RFC https://rfc.tari.com/RFC-0155_TariAddress is suitable for this.
 
 ### Understanding Code Generation from `.proto` Files
 The `.proto` file, such as [`wallet.proto`][wallet-proto], acts as a **shared contract** that defines all available services, methods, and message structures for the Minotari Wallet's gRPC API. However, it is not executable code by itself.
@@ -360,7 +314,7 @@ const userPaymentId = {
 ### Get Payment ID Address
 The `GetPaymentIdAddress` gRPC method returns an address appended with a payment ID, derived from an existing address. The payment ID is an optional, additional piece of metadata (like an invoice number or customer reference).
 
-- `payment_id` (optional) must be passed as a UTF-8 encoded byte array. If derived from a string, the `payment_id` must be encoded in UTF-8 and should not contain invalid UTF-8 characters.
+- `payment_id` (optional) must be passed as a UTF-8 encoded byte array. If derived from a string, the `payment_id` must be encoded in UTF-8.
 
 **Example:**
 ```javascript
@@ -386,8 +340,8 @@ client.GetPaymentIdAddress({ payment_id: paymentId }, (error, response) => {
 **Example of JSON response**:
 ```json
 {
-  "interactive_address": "b3a5d4f2a1d2c3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8",
-  "one_sided_address": "f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8b3a5d4f2a1d2c3e4f5a6b7c8d9e0"
+  "interactive_address": "14HVCEeZC2RGE4SDn3yGwqzXepJ2LDqXva7kb4fherYMQR9dF7341T3TjMZobB1a6xouGvS5SXwEvXKwK3zLz2rgReh",
+  "one_sided_address": "12HVCEeZC2RGE4SDn3yGwqzXepJ2LDqXva7kb4fherYMQR9dF7341T3TjMZobB1a6xouGvS5SXwEvXKwK3zLz2rgReL"
 }
 ```
 


### PR DESCRIPTION
Description
---
Added the new gRPC method `getPaymentIdAddress` as well as detailed the amended address structure to the gRPC methods documentation, based on the changes introduced in this PR: https://github.com/tari-project/tari/pull/6997

gRPC method includes example and JSON response.

Motivation and Context
---
Allow exchanges to call on gRPC methods to retrieve transactions related to specific payments, filtered by the payment ID used in the address.

How Has This Been Tested?
---

What process can a PR reviewer use to test or verify this change?
---
None. @stringhandler or @SWvheerden to confirm for accuracy of material.

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added detailed explanation of Tari address structure with optional encrypted payment IDs.
  - Documented a new gRPC method for generating addresses that include payment IDs, with usage examples.
  - Included JavaScript samples demonstrating payment ID generation and address retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->