### PR TITLE
fix: fix grpc address format

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,7 +422,7 @@ the Minotari Base Node and the Minotari Wallet, if they are not enabled already.
 ```
 [wallet]
 
-grpc_address = "127.0.0.1:18143"
+grpc_address = "http://127.0.0.1:18143"
 ```
 
 ```
@@ -430,7 +430,7 @@ grpc_address = "127.0.0.1:18143"
 transport = "tor"
 allow_test_addresses = false
 grpc_enabled = true
-grpc_base_node_address = "127.0.0.1:18142"
+grpc_base_node_address = "http://127.0.0.1:18142"
 ```
 
 For the Minotari Miner there are some additional settings under section **`miner`** that can be changed:
@@ -445,11 +445,11 @@ For the Minotari Miner there are some additional settings under section **`miner
 
 # GRPC address of base node
 # Default: value from `base_node.grpc_base_node_address`
-#base_node_grpc_address = "127.0.0.1:18142"
+#base_node_grpc_address = "http://127.0.0.1:18142"
 
 # GRPC address of console wallet
 # Default: value from `wallet.grpc_address`
-#wallet_grpc_address = "127.0.0.1:18143"
+#wallet_grpc_address = "http://127.0.0.1:18143"
 
 # Start mining only when base node is bootstrapped
 # and current block height is on the tip of network
@@ -547,13 +547,13 @@ they are not enabled already:
 - For the Minotari Base Node and the Minotari Wallet, under sections **`base_node.esmeralda`** and **`wallet`** respectively
   ```
   [wallet]
-  grpc_address = "127.0.0.1:18143"
+  grpc_address = "http://127.0.0.1:18143"
   ```
   ```
   [base_node.esmeralda]
   transpo*_r_*t = "tor"
   allow_test_addresses = false
-  base_node_grpc_address = "127.0.0.1:18142"
+  base_node_grpc_address = "http://127.0.0.1:18142"
   ```
 
 Depending on if you are using solo mining or self-select mining, you will use one of the following:

--- a/common/config/presets/c_base_node_b_mining_allow_methods.toml
+++ b/common/config/presets/c_base_node_b_mining_allow_methods.toml
@@ -4,8 +4,8 @@
 # Set to false to disable the base node GRPC server (default = true)
 grpc_enabled = true
 
-# The socket to expose for the gRPC base node server (default = "/ip4/127.0.0.1/tcp/18142")
-#grpc_address = "/ip4/127.0.0.1/tcp/18142"
+# The socket to expose for the gRPC base node server (default = "http://127.0.0.1:18142")
+#grpc_address = "http://127.0.0.1:18142"
 
 # gRPC authentication method (default = "none")
 #grpc_authentication = { username = "admin", password = "xxxx" }

--- a/common/config/presets/c_base_node_b_non_mining_allow_methods.toml
+++ b/common/config/presets/c_base_node_b_non_mining_allow_methods.toml
@@ -4,8 +4,8 @@
 # Set to false to disable the base node GRPC server (default = true)
 grpc_enabled = false
 
-# The socket to expose for the gRPC base node server (default = "/ip4/127.0.0.1/tcp/18142")
-#grpc_address = "/ip4/127.0.0.1/tcp/18142"
+# The socket to expose for the gRPC base node server (default = "http://127.0.0.1:18142")
+#grpc_address = "http://127.0.0.1:18142"
 
 # gRPC authentication method (default = "none")
 #grpc_authentication = { username = "admin", password = "xxxx" }

--- a/common/config/presets/d_console_wallet.toml
+++ b/common/config/presets/d_console_wallet.toml
@@ -55,8 +55,8 @@
 
 # Set to true to enable grpc. (default = false)
 #grpc_enabled = false
-# The socket to expose for the gRPC base node server (default = "/ip4/127.0.0.1/tcp/18143")
-#grpc_address = "/ip4/127.0.0.1/tcp/18143"
+# The socket to expose for the gRPC base node server (default = "http://127.0.0.1:18143")
+#grpc_address = "http://127.0.0.1:18143"
 # gRPC authentication method (default = "none")
 #grpc_authentication = { username = "admin", password = "xxxx" }
 

--- a/common/config/presets/e_validator_node.toml
+++ b/common/config/presets/e_validator_node.toml
@@ -20,10 +20,10 @@
 # automatically configured (default = )
 #public_address =
 
-# The Minotari base node's GRPC address. (default = "127.0.0.1/<port>" the <port> value is based on network)
-#base_node_grpc_address = "127.0.0.1/tcp/18142"
+# The Minotari base node's GRPC address. (default = "http://127.0.0.1:<port>" the <port> value is based on network)
+#base_node_grpc_address = "http://127.0.0.1:18142"
 
-# The Minotari console wallet's GRPC address. (default = "127.0.0.1/<port>" the <port> value is based on network)
+# The Minotari console wallet's GRPC address. (default = "http://127.0.0.1:<port>" the <port> value is based on network)
 #wallet_grpc_address = "127.0.0.1/tcp/18143"
 
 # How often do we want to scan the base layer for changes. (default = 10)

--- a/common/config/presets/f_merge_mining_proxy.toml
+++ b/common/config/presets/f_merge_mining_proxy.toml
@@ -74,8 +74,8 @@
 # If authentication is being used for curl. (default = false)
 #monerod_use_auth = false
 
-# The Minotari base node's GRPC address. (default = "/ip4/127.0.0.1/tcp/18142")
-#base_node_grpc_address = "/ip4/127.0.0.1/tcp/18142"
+# The Minotari base node's GRPC address. (default = "http://127.0.0.1:18142")
+#base_node_grpc_address = "http://127.0.0.1:18142"
 
 # GRPC authentication for the base node (default = "none")
 #base_node_grpc_authentication = { username = "miner", password = "xxxx" }

--- a/common/config/presets/g_miner.toml
+++ b/common/config/presets/g_miner.toml
@@ -7,8 +7,8 @@
 
 [miner]
 
-# GRPC address of base node (default = "/ip4/127.0.0.1/tcp/18142")
-#base_node_grpc_address = "/ip4/127.0.0.1/tcp/18142"
+# GRPC address of base node (default = "http://127.0.0.1:18142")
+#base_node_grpc_address = "http://127.0.0.1:18142"
 # GRPC authentication for the base node (default = "none")
 #base_node_grpc_authentication = { username = "miner", password = "xxxx" }
 # GRPC TLS communication is turned on by defining the domain name for the service (default = "none")

--- a/common/config/presets/h_collectibles.toml
+++ b/common/config/presets/h_collectibles.toml
@@ -7,11 +7,11 @@
 
 [collectibles]
 
-# GRPC address of validator node (default = "/ip4/127.0.0.1/tcp/18144")
-#validator_node_grpc_address = "/ip4/127.0.0.1/tcp/18144"
+# GRPC address of validator node (default = "http://127.0.0.1:18144")
+#validator_node_grpc_address = "http://127.0.0.1:18144"
 
-# GRPC address of base node (default = "/ip4/127.0.0.1/tcp/18142")
-#base_node_grpc_address = "/ip4/127.0.0.1/tcp/18142"
+# GRPC address of base node (default = "http://127.0.0.1:18142")
+#base_node_grpc_address = "http://127.0.0.1:18142"
 
-# GRPC address of wallet (default = "/ip4/127.0.0.1/tcp/18143")
-#wallet_grpc_address = "/ip4/127.0.0.1/tcp/18143"
+# GRPC address of wallet (default = "http://127.0.0.1:18143")
+#wallet_grpc_address = "http://127.0.0.1:18143"

--- a/common/config/presets/i_indexer.toml
+++ b/common/config/presets/i_indexer.toml
@@ -20,8 +20,8 @@
 # automatically configured (default = )
 #public_address =
 
-# The Minotari base node's GRPC address. (default = "127.0.0.1/<port>" the <port> value is based on network)
-#base_node_grpc_address = "127.0.0.1/tcp/18142"
+# The Minotari base node's GRPC address. (default = "http://127.0.0.1:<port>" the <port> value is based on network)
+#base_node_grpc_address = "http://127.0.0.1:18142"
 
 # How often do we want to scan the base layer for changes. (default = 10)
 #base_layer_scanning_interval = 10


### PR DESCRIPTION
Description
---
Fixed grpc address format in the sample config files

Motivation and Context
---
The format changed recently, but it was not corrected in the toml files.

How Has This Been Tested?
---
System-level testing

What process can a PR reviewer use to test or verify this change?
---
Code review

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated configuration examples and comments to use HTTP URL format (e.g., "http://127.0.0.1:port") for gRPC addresses across the README and various preset configuration files. This change improves clarity and consistency in setup instructions for the base node, wallet, miner, validator node, collectibles, and indexer configurations. No other documentation or configuration options were modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->