### PR TITLE
feat: add double spend check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3449,6 +3449,7 @@ dependencies = [
  "mirai-annotations",
  "num-derive 0.3.3",
  "num-traits",
+ "parking_lot 0.12.3",
  "serde",
  "sha2 0.10.8",
  "thiserror 1.0.69",

--- a/applications/minotari_node/src/grpc/hash_rate.rs
+++ b/applications/minotari_node/src/grpc/hash_rate.rs
@@ -180,8 +180,10 @@ mod test {
     }
 
     fn create_hash_rate_ma(pow_algo: PowAlgorithm) -> HashRateMovingAverage {
+        let mut constants = ConsensusConstants::esmeralda()[0].clone();
+        constants.set_pow_target_block_interval(pow_algo, 240);
         let consensus_manager = ConsensusManagerBuilder::new(Network::Esmeralda)
-            .add_consensus_constants(ConsensusConstants::esmeralda()[0].clone())
+            .add_consensus_constants(constants)
             .build()
             .unwrap();
         HashRateMovingAverage::new(pow_algo, consensus_manager)

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -97,7 +97,7 @@ tiny-keccak = { package = "tari-tiny-keccak", version = "2.0.2", features = [
 dirs-next = "1.0.2"
 hickory-proto = { version = "=0.25.0-alpha.4" }
 anyhow = "1.0.53"
-jmt = { version = "0.11.0" }
+jmt = { version = "0.11.0", features = ["mocks"] }
 
 [dev-dependencies]
 criterion = { version = "0.4.0" }

--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -28,10 +28,7 @@ use std::{
     ops::{Bound, RangeBounds},
     sync::{
         atomic::{self, AtomicBool},
-        Arc,
-        RwLock,
-        RwLockReadGuard,
-        RwLockWriteGuard,
+        Arc, RwLock, RwLockReadGuard, RwLockWriteGuard,
     },
     time::Instant,
 };
@@ -45,13 +42,7 @@ use serde::{Deserialize, Serialize};
 use tari_common_types::{
     chain_metadata::ChainMetadata,
     types::{
-        BadBlock,
-        BlockHash,
-        CompressedCommitment,
-        CompressedPublicKey,
-        FixedHash,
-        HashOutput,
-        Signature,
+        BadBlock, BlockHash, CompressedCommitment, CompressedPublicKey, FixedHash, HashOutput, Signature,
         UncompressedCommitment,
     },
 };
@@ -63,61 +54,33 @@ use super::{smt_hasher::SmtHasher, TemplateRegistrationEntry};
 use crate::{
     block_output_mr_hash_from_pruned_mmr,
     blocks::{
-        Block,
-        BlockAccumulatedData,
-        BlockHeader,
-        BlockHeaderAccumulatedData,
-        BlockHeaderValidationError,
-        ChainBlock,
-        ChainHeader,
-        HistoricalBlock,
-        NewBlockTemplate,
-        UpdateBlockAccumulatedData,
+        Block, BlockAccumulatedData, BlockHeader, BlockHeaderAccumulatedData, BlockHeaderValidationError, ChainBlock,
+        ChainHeader, HistoricalBlock, NewBlockTemplate, UpdateBlockAccumulatedData,
     },
     chain_storage::{
         consts::{
-            BLOCKCHAIN_DATABASE_ORPHAN_STORAGE_CAPACITY,
-            BLOCKCHAIN_DATABASE_PRUNED_MODE_PRUNING_INTERVAL,
+            BLOCKCHAIN_DATABASE_ORPHAN_STORAGE_CAPACITY, BLOCKCHAIN_DATABASE_PRUNED_MODE_PRUNING_INTERVAL,
             BLOCKCHAIN_DATABASE_PRUNING_HORIZON,
         },
         db_transaction::{DbKey, DbTransaction, DbValue},
         error::ChainStorageError,
         utxo_mined_info::OutputMinedInfo,
-        BlockAddResult,
-        BlockchainBackend,
-        DbBasicStats,
-        DbTotalSizeStats,
-        HorizonData,
-        InputMinedInfo,
-        MmrTree,
-        Optional,
-        OrNotFound,
-        Reorg,
-        TargetDifficulties,
+        BlockAddResult, BlockchainBackend, DbBasicStats, DbTotalSizeStats, HorizonData, InputMinedInfo, MmrTree,
+        Optional, OrNotFound, Reorg, TargetDifficulties,
     },
     common::{rolling_vec::RollingVec, BanPeriod},
     consensus::{
-        chain_strength_comparer::ChainStrengthComparer,
-        ConsensusConstants,
-        ConsensusManager,
+        chain_strength_comparer::ChainStrengthComparer, ConsensusConstants, ConsensusManager,
         DomainSeparatedConsensusHasher,
     },
-    input_mr_hash_from_pruned_mmr,
-    kernel_mr_hash_from_pruned_mmr,
+    input_mr_hash_from_pruned_mmr, kernel_mr_hash_from_pruned_mmr,
     proof_of_work::{PowAlgorithm, TargetDifficultyWindow},
     transactions::transaction_components::{TransactionInput, TransactionKernel, TransactionOutput},
     validation::{
-        helpers::calc_median_timestamp,
-        CandidateBlockValidator,
-        DifficultyCalculator,
-        HeaderChainLinkedValidator,
-        InternalConsistencyValidator,
-        ValidationError,
+        helpers::calc_median_timestamp, CandidateBlockValidator, DifficultyCalculator, HeaderChainLinkedValidator,
+        InternalConsistencyValidator, ValidationError,
     },
-    PrunedInputMmr,
-    PrunedKernelMmr,
-    PrunedOutputMmr,
-    ValidatorNodeBMT,
+    PrunedInputMmr, PrunedKernelMmr, PrunedOutputMmr, ValidatorNodeBMT,
 };
 
 const LOG_TARGET: &str = "c::cs::database";
@@ -227,7 +190,8 @@ pub struct BlockchainDatabase<B> {
 
 #[allow(clippy::ptr_arg)]
 impl<B> BlockchainDatabase<B>
-where B: BlockchainBackend
+where
+    B: BlockchainBackend,
 {
     /// Creates a new `BlockchainDatabase` using the provided backend.
     pub fn new(
@@ -299,10 +263,13 @@ where B: BlockchainBackend
             for kernel in body.kernels() {
                 kernel_sum = &kernel_sum + &kernel.excess.to_commitment()?;
             }
-            txn.update_block_accumulated_data(*genesis_block.hash(), UpdateBlockAccumulatedData {
-                kernel_sum: Some(CompressedCommitment::from_commitment(kernel_sum.clone())),
-                ..Default::default()
-            });
+            txn.update_block_accumulated_data(
+                *genesis_block.hash(),
+                UpdateBlockAccumulatedData {
+                    kernel_sum: Some(CompressedCommitment::from_commitment(kernel_sum.clone())),
+                    ..Default::default()
+                },
+            );
             txn.set_pruned_height(0);
             txn.set_horizon_data(CompressedCommitment::from_commitment(kernel_sum), total_utxo_sum);
             self.write(txn)?;
@@ -2592,19 +2559,14 @@ mod test {
     use crate::{
         block_specs,
         consensus::{
-            chain_strength_comparer::strongest_chain,
-            consensus_constants::PowAlgorithmConstants,
+            chain_strength_comparer::strongest_chain, consensus_constants::PowAlgorithmConstants,
             ConsensusConstantsBuilder,
         },
         proof_of_work::Difficulty,
         test_helpers::{
             blockchain::{
-                create_chained_blocks,
-                create_main_chain,
-                create_new_blockchain,
-                create_orphan_chain,
-                create_test_blockchain_db,
-                TempDatabase,
+                create_chained_blocks, create_main_chain, create_new_blockchain, create_orphan_chain,
+                create_test_blockchain_db, TempDatabase,
             },
             BlockSpecs,
         },
@@ -2668,12 +2630,10 @@ mod test {
         async fn it_selects_a_large_reorg_chain() {
             let db = create_new_blockchain();
             // Main chain
-            let (_, mainchain) = create_main_chain(&db, &[
-                ("A->GB", 1, 120),
-                ("B->A", 1, 120),
-                ("C->B", 1, 120),
-                ("D->C", 1, 120),
-            ])
+            let (_, mainchain) = create_main_chain(
+                &db,
+                &[("A->GB", 1, 120), ("B->A", 1, 120), ("C->B", 1, 120), ("D->C", 1, 120)],
+            )
             .await;
             // Create reorg chain
             let fork_root = mainchain.get("B").unwrap().clone();
@@ -2788,15 +2748,18 @@ mod test {
         async fn it_correctly_detects_strongest_orphan_tips() {
             let db = create_new_blockchain();
             let validator = MockValidator::new(true);
-            let (_, main_chain) = create_main_chain(&db, &[
-                ("A->GB", 1, 120),
-                ("B->A", 2, 120),
-                ("C->B", 1, 120),
-                ("D->C", 1, 120),
-                ("E->D", 1, 120),
-                ("F->E", 1, 120),
-                ("G->F", 1, 120),
-            ])
+            let (_, main_chain) = create_main_chain(
+                &db,
+                &[
+                    ("A->GB", 1, 120),
+                    ("B->A", 2, 120),
+                    ("C->B", 1, 120),
+                    ("D->C", 1, 120),
+                    ("E->D", 1, 120),
+                    ("F->E", 1, 120),
+                    ("G->F", 1, 120),
+                ],
+            )
             .await;
 
             // Fork 1 (with 3 blocks)
@@ -3206,12 +3169,10 @@ mod test {
     // \ JMT"]
     async fn test_handle_possible_reorg_case6_orphan_chain_link() {
         let db = create_new_blockchain();
-        let (_, mainchain) = create_main_chain(&db, &[
-            ("A->GB", 1, 120),
-            ("B->A", 1, 120),
-            ("C->B", 1, 120),
-            ("D->C", 1, 120),
-        ])
+        let (_, mainchain) = create_main_chain(
+            &db,
+            &[("A->GB", 1, 120), ("B->A", 1, 120), ("C->B", 1, 120), ("D->C", 1, 120)],
+        )
         .await;
 
         let mock_validator = MockValidator::new(true);
@@ -3287,12 +3248,10 @@ mod test {
     #[tokio::test]
     async fn test_handle_possible_reorg_case7_fail_reorg() {
         let db = create_new_blockchain();
-        let (_, mainchain) = create_main_chain(&db, &[
-            ("A->GB", 1, 120),
-            ("B->A", 1, 120),
-            ("C->B", 1, 120),
-            ("D->C", 1, 120),
-        ])
+        let (_, mainchain) = create_main_chain(
+            &db,
+            &[("A->GB", 1, 120), ("B->A", 1, 120), ("C->B", 1, 120), ("D->C", 1, 120)],
+        )
         .await;
 
         let mock_validator = MockValidator::new(true);
@@ -3602,11 +3561,14 @@ mod test {
             .add_consensus_constants(
                 ConsensusConstantsBuilder::new(Network::LocalNet)
                     .clear_proof_of_work()
-                    .add_proof_of_work(PowAlgorithm::Sha3x, PowAlgorithmConstants {
-                        min_difficulty: Difficulty::min(),
-                        max_difficulty: Difficulty::from_u64(100).expect("valid difficulty"),
-                        target_time: 120,
-                    })
+                    .add_proof_of_work(
+                        PowAlgorithm::Sha3x,
+                        PowAlgorithmConstants {
+                            min_difficulty: Difficulty::min(),
+                            max_difficulty: Difficulty::from_u64(100).expect("valid difficulty"),
+                            target_time: 120,
+                        },
+                    )
                     .build(),
             )
             .build()

--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -28,7 +28,10 @@ use std::{
     ops::{Bound, RangeBounds},
     sync::{
         atomic::{self, AtomicBool},
-        Arc, RwLock, RwLockReadGuard, RwLockWriteGuard,
+        Arc,
+        RwLock,
+        RwLockReadGuard,
+        RwLockWriteGuard,
     },
     time::Instant,
 };
@@ -42,7 +45,13 @@ use serde::{Deserialize, Serialize};
 use tari_common_types::{
     chain_metadata::ChainMetadata,
     types::{
-        BadBlock, BlockHash, CompressedCommitment, CompressedPublicKey, FixedHash, HashOutput, Signature,
+        BadBlock,
+        BlockHash,
+        CompressedCommitment,
+        CompressedPublicKey,
+        FixedHash,
+        HashOutput,
+        Signature,
         UncompressedCommitment,
     },
 };
@@ -54,33 +63,61 @@ use super::{smt_hasher::SmtHasher, TemplateRegistrationEntry};
 use crate::{
     block_output_mr_hash_from_pruned_mmr,
     blocks::{
-        Block, BlockAccumulatedData, BlockHeader, BlockHeaderAccumulatedData, BlockHeaderValidationError, ChainBlock,
-        ChainHeader, HistoricalBlock, NewBlockTemplate, UpdateBlockAccumulatedData,
+        Block,
+        BlockAccumulatedData,
+        BlockHeader,
+        BlockHeaderAccumulatedData,
+        BlockHeaderValidationError,
+        ChainBlock,
+        ChainHeader,
+        HistoricalBlock,
+        NewBlockTemplate,
+        UpdateBlockAccumulatedData,
     },
     chain_storage::{
         consts::{
-            BLOCKCHAIN_DATABASE_ORPHAN_STORAGE_CAPACITY, BLOCKCHAIN_DATABASE_PRUNED_MODE_PRUNING_INTERVAL,
+            BLOCKCHAIN_DATABASE_ORPHAN_STORAGE_CAPACITY,
+            BLOCKCHAIN_DATABASE_PRUNED_MODE_PRUNING_INTERVAL,
             BLOCKCHAIN_DATABASE_PRUNING_HORIZON,
         },
         db_transaction::{DbKey, DbTransaction, DbValue},
         error::ChainStorageError,
         utxo_mined_info::OutputMinedInfo,
-        BlockAddResult, BlockchainBackend, DbBasicStats, DbTotalSizeStats, HorizonData, InputMinedInfo, MmrTree,
-        Optional, OrNotFound, Reorg, TargetDifficulties,
+        BlockAddResult,
+        BlockchainBackend,
+        DbBasicStats,
+        DbTotalSizeStats,
+        HorizonData,
+        InputMinedInfo,
+        MmrTree,
+        Optional,
+        OrNotFound,
+        Reorg,
+        TargetDifficulties,
     },
     common::{rolling_vec::RollingVec, BanPeriod},
     consensus::{
-        chain_strength_comparer::ChainStrengthComparer, ConsensusConstants, ConsensusManager,
+        chain_strength_comparer::ChainStrengthComparer,
+        ConsensusConstants,
+        ConsensusManager,
         DomainSeparatedConsensusHasher,
     },
-    input_mr_hash_from_pruned_mmr, kernel_mr_hash_from_pruned_mmr,
+    input_mr_hash_from_pruned_mmr,
+    kernel_mr_hash_from_pruned_mmr,
     proof_of_work::{PowAlgorithm, TargetDifficultyWindow},
     transactions::transaction_components::{TransactionInput, TransactionKernel, TransactionOutput},
     validation::{
-        helpers::calc_median_timestamp, CandidateBlockValidator, DifficultyCalculator, HeaderChainLinkedValidator,
-        InternalConsistencyValidator, ValidationError,
+        helpers::calc_median_timestamp,
+        CandidateBlockValidator,
+        DifficultyCalculator,
+        HeaderChainLinkedValidator,
+        InternalConsistencyValidator,
+        ValidationError,
     },
-    PrunedInputMmr, PrunedKernelMmr, PrunedOutputMmr, ValidatorNodeBMT,
+    PrunedInputMmr,
+    PrunedKernelMmr,
+    PrunedOutputMmr,
+    ValidatorNodeBMT,
 };
 
 const LOG_TARGET: &str = "c::cs::database";
@@ -190,8 +227,7 @@ pub struct BlockchainDatabase<B> {
 
 #[allow(clippy::ptr_arg)]
 impl<B> BlockchainDatabase<B>
-where
-    B: BlockchainBackend,
+where B: BlockchainBackend
 {
     /// Creates a new `BlockchainDatabase` using the provided backend.
     pub fn new(
@@ -263,13 +299,10 @@ where
             for kernel in body.kernels() {
                 kernel_sum = &kernel_sum + &kernel.excess.to_commitment()?;
             }
-            txn.update_block_accumulated_data(
-                *genesis_block.hash(),
-                UpdateBlockAccumulatedData {
-                    kernel_sum: Some(CompressedCommitment::from_commitment(kernel_sum.clone())),
-                    ..Default::default()
-                },
-            );
+            txn.update_block_accumulated_data(*genesis_block.hash(), UpdateBlockAccumulatedData {
+                kernel_sum: Some(CompressedCommitment::from_commitment(kernel_sum.clone())),
+                ..Default::default()
+            });
             txn.set_pruned_height(0);
             txn.set_horizon_data(CompressedCommitment::from_commitment(kernel_sum), total_utxo_sum);
             self.write(txn)?;
@@ -2559,14 +2592,19 @@ mod test {
     use crate::{
         block_specs,
         consensus::{
-            chain_strength_comparer::strongest_chain, consensus_constants::PowAlgorithmConstants,
+            chain_strength_comparer::strongest_chain,
+            consensus_constants::PowAlgorithmConstants,
             ConsensusConstantsBuilder,
         },
         proof_of_work::Difficulty,
         test_helpers::{
             blockchain::{
-                create_chained_blocks, create_main_chain, create_new_blockchain, create_orphan_chain,
-                create_test_blockchain_db, TempDatabase,
+                create_chained_blocks,
+                create_main_chain,
+                create_new_blockchain,
+                create_orphan_chain,
+                create_test_blockchain_db,
+                TempDatabase,
             },
             BlockSpecs,
         },
@@ -2630,10 +2668,12 @@ mod test {
         async fn it_selects_a_large_reorg_chain() {
             let db = create_new_blockchain();
             // Main chain
-            let (_, mainchain) = create_main_chain(
-                &db,
-                &[("A->GB", 1, 120), ("B->A", 1, 120), ("C->B", 1, 120), ("D->C", 1, 120)],
-            )
+            let (_, mainchain) = create_main_chain(&db, &[
+                ("A->GB", 1, 120),
+                ("B->A", 1, 120),
+                ("C->B", 1, 120),
+                ("D->C", 1, 120),
+            ])
             .await;
             // Create reorg chain
             let fork_root = mainchain.get("B").unwrap().clone();
@@ -2748,18 +2788,15 @@ mod test {
         async fn it_correctly_detects_strongest_orphan_tips() {
             let db = create_new_blockchain();
             let validator = MockValidator::new(true);
-            let (_, main_chain) = create_main_chain(
-                &db,
-                &[
-                    ("A->GB", 1, 120),
-                    ("B->A", 2, 120),
-                    ("C->B", 1, 120),
-                    ("D->C", 1, 120),
-                    ("E->D", 1, 120),
-                    ("F->E", 1, 120),
-                    ("G->F", 1, 120),
-                ],
-            )
+            let (_, main_chain) = create_main_chain(&db, &[
+                ("A->GB", 1, 120),
+                ("B->A", 2, 120),
+                ("C->B", 1, 120),
+                ("D->C", 1, 120),
+                ("E->D", 1, 120),
+                ("F->E", 1, 120),
+                ("G->F", 1, 120),
+            ])
             .await;
 
             // Fork 1 (with 3 blocks)
@@ -3169,10 +3206,12 @@ mod test {
     // \ JMT"]
     async fn test_handle_possible_reorg_case6_orphan_chain_link() {
         let db = create_new_blockchain();
-        let (_, mainchain) = create_main_chain(
-            &db,
-            &[("A->GB", 1, 120), ("B->A", 1, 120), ("C->B", 1, 120), ("D->C", 1, 120)],
-        )
+        let (_, mainchain) = create_main_chain(&db, &[
+            ("A->GB", 1, 120),
+            ("B->A", 1, 120),
+            ("C->B", 1, 120),
+            ("D->C", 1, 120),
+        ])
         .await;
 
         let mock_validator = MockValidator::new(true);
@@ -3248,10 +3287,12 @@ mod test {
     #[tokio::test]
     async fn test_handle_possible_reorg_case7_fail_reorg() {
         let db = create_new_blockchain();
-        let (_, mainchain) = create_main_chain(
-            &db,
-            &[("A->GB", 1, 120), ("B->A", 1, 120), ("C->B", 1, 120), ("D->C", 1, 120)],
-        )
+        let (_, mainchain) = create_main_chain(&db, &[
+            ("A->GB", 1, 120),
+            ("B->A", 1, 120),
+            ("C->B", 1, 120),
+            ("D->C", 1, 120),
+        ])
         .await;
 
         let mock_validator = MockValidator::new(true);
@@ -3561,14 +3602,11 @@ mod test {
             .add_consensus_constants(
                 ConsensusConstantsBuilder::new(Network::LocalNet)
                     .clear_proof_of_work()
-                    .add_proof_of_work(
-                        PowAlgorithm::Sha3x,
-                        PowAlgorithmConstants {
-                            min_difficulty: Difficulty::min(),
-                            max_difficulty: Difficulty::from_u64(100).expect("valid difficulty"),
-                            target_time: 120,
-                        },
-                    )
+                    .add_proof_of_work(PowAlgorithm::Sha3x, PowAlgorithmConstants {
+                        min_difficulty: Difficulty::min(),
+                        max_difficulty: Difficulty::from_u64(100).expect("valid difficulty"),
+                        target_time: 120,
+                    })
                     .build(),
             )
             .build()

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb.rs
@@ -353,14 +353,14 @@ pub fn lmdb_fetch_matching_after<V>(
     txn: &ConstTransaction<'_>,
     db: &Database,
     key_prefix: &[u8],
-) -> Result<Vec<V>, ChainStorageError>
+) -> Result<Vec<(Vec<u8>, V)>, ChainStorageError>
 where
     V: DeserializeOwned,
 {
     let mut cursor = lmdb_get_prefix_cursor(txn, db, key_prefix)?;
     let mut result = vec![];
-    while let Some((_, val)) = cursor.next()? {
-        result.push(val);
+    while let Some((k, val)) = cursor.next()? {
+        result.push((k, val));
     }
     Ok(result)
 }

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb.rs
@@ -27,7 +27,13 @@ use lmdb_zero::{
     error::{self, LmdbResultExt},
     put,
     traits::{AsLmdbBytes, CreateCursor, FromLmdbBytes},
-    ConstTransaction, Cursor, CursorIter, Database, Error, MaybeOwned, WriteTransaction,
+    ConstTransaction,
+    Cursor,
+    CursorIter,
+    Database,
+    Error,
+    MaybeOwned,
+    WriteTransaction,
 };
 use log::*;
 use serde::{de::DeserializeOwned, Serialize};
@@ -281,9 +287,7 @@ where
 
 /// Retrieves the last value stored in the database
 pub fn lmdb_last<V>(txn: &ConstTransaction<'_>, db: &Database) -> Result<Option<V>, ChainStorageError>
-where
-    V: DeserializeOwned,
-{
+where V: DeserializeOwned {
     let mut cursor = txn.cursor(db)?;
     let access = txn.access();
     match cursor.last::<[u8], [u8]>(&access).to_opt() {
@@ -304,9 +308,7 @@ where
 
 /// Checks if the key exists in the database
 pub fn lmdb_exists<K>(txn: &ConstTransaction<'_>, db: &Database, key: &K) -> Result<bool, ChainStorageError>
-where
-    K: AsLmdbBytes + ?Sized,
-{
+where K: AsLmdbBytes + ?Sized {
     let access = txn.access();
     match access.get::<K, [u8]>(db, key).to_opt() {
         Ok(None) => Ok(false),
@@ -423,9 +425,7 @@ where
 
 #[allow(dead_code)]
 pub fn lmdb_all<V>(txn: &ConstTransaction<'_>, db: &Database) -> Result<Vec<(Vec<u8>, V)>, ChainStorageError>
-where
-    V: DeserializeOwned,
-{
+where V: DeserializeOwned {
     let access = txn.access();
     let mut cursor = txn.cursor(db).map_err(|e| {
         error!(target: LOG_TARGET, "Could not get read cursor from lmdb: {:?}", e);

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb.rs
@@ -27,13 +27,7 @@ use lmdb_zero::{
     error::{self, LmdbResultExt},
     put,
     traits::{AsLmdbBytes, CreateCursor, FromLmdbBytes},
-    ConstTransaction,
-    Cursor,
-    CursorIter,
-    Database,
-    Error,
-    MaybeOwned,
-    WriteTransaction,
+    ConstTransaction, Cursor, CursorIter, Database, Error, MaybeOwned, WriteTransaction,
 };
 use log::*;
 use serde::{de::DeserializeOwned, Serialize};
@@ -201,7 +195,7 @@ pub fn lmdb_delete_keys_starting_with<V>(
     txn: &WriteTransaction<'_>,
     db: &Database,
     key: &[u8],
-) -> Result<Vec<V>, ChainStorageError>
+) -> Result<Vec<(Vec<u8>, V)>, ChainStorageError>
 where
     V: DeserializeOwned,
 {
@@ -219,7 +213,7 @@ where
     let mut result = vec![];
     while row.0[..key.len()] == *key {
         let val = deserialize::<V>(row.1)?;
-        result.push(val);
+        result.push((row.0.to_vec(), val));
         cursor.del(&mut access, del::NODUPDATA)?;
         row = match cursor.next(&access).to_opt()? {
             Some(r) => r,
@@ -287,7 +281,9 @@ where
 
 /// Retrieves the last value stored in the database
 pub fn lmdb_last<V>(txn: &ConstTransaction<'_>, db: &Database) -> Result<Option<V>, ChainStorageError>
-where V: DeserializeOwned {
+where
+    V: DeserializeOwned,
+{
     let mut cursor = txn.cursor(db)?;
     let access = txn.access();
     match cursor.last::<[u8], [u8]>(&access).to_opt() {
@@ -308,7 +304,9 @@ where V: DeserializeOwned {
 
 /// Checks if the key exists in the database
 pub fn lmdb_exists<K>(txn: &ConstTransaction<'_>, db: &Database, key: &K) -> Result<bool, ChainStorageError>
-where K: AsLmdbBytes + ?Sized {
+where
+    K: AsLmdbBytes + ?Sized,
+{
     let access = txn.access();
     match access.get::<K, [u8]>(db, key).to_opt() {
         Ok(None) => Ok(false),
@@ -425,7 +423,9 @@ where
 
 #[allow(dead_code)]
 pub fn lmdb_all<V>(txn: &ConstTransaction<'_>, db: &Database) -> Result<Vec<(Vec<u8>, V)>, ChainStorageError>
-where V: DeserializeOwned {
+where
+    V: DeserializeOwned,
+{
     let access = txn.access();
     let mut cursor = txn.cursor(db).map_err(|e| {
         error!(target: LOG_TARGET, "Could not get read cursor from lmdb: {:?}", e);

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -40,7 +40,13 @@ use tari_common_types::{
     chain_metadata::ChainMetadata,
     epoch::VnEpoch,
     types::{
-        BadBlock, BlockHash, CompressedCommitment, CompressedPublicKey, FixedHash, HashOutput, Signature,
+        BadBlock,
+        BlockHash,
+        CompressedCommitment,
+        CompressedPublicKey,
+        FixedHash,
+        HashOutput,
+        Signature,
         UncompressedCommitment,
     },
 };
@@ -58,7 +64,12 @@ use super::{
 };
 use crate::{
     blocks::{
-        Block, BlockAccumulatedData, BlockHeader, BlockHeaderAccumulatedData, ChainBlock, ChainHeader,
+        Block,
+        BlockAccumulatedData,
+        BlockHeader,
+        BlockHeaderAccumulatedData,
+        ChainBlock,
+        ChainHeader,
         UpdateBlockAccumulatedData,
     },
     chain_storage::{
@@ -67,26 +78,55 @@ use crate::{
         lmdb_db::{
             composite_key::{CompositeKey, InputKey, OutputKey},
             lmdb::{
-                fetch_db_entry_sizes, lmdb_clear, lmdb_delete, lmdb_delete_each_where, lmdb_delete_key_value,
-                lmdb_delete_keys_starting_with, lmdb_exists, lmdb_fetch_matching_after, lmdb_filter_map_values,
-                lmdb_first_after, lmdb_get, lmdb_get_multiple, lmdb_insert, lmdb_insert_dup, lmdb_last, lmdb_len,
+                fetch_db_entry_sizes,
+                lmdb_clear,
+                lmdb_delete,
+                lmdb_delete_each_where,
+                lmdb_delete_key_value,
+                lmdb_delete_keys_starting_with,
+                lmdb_exists,
+                lmdb_fetch_matching_after,
+                lmdb_filter_map_values,
+                lmdb_first_after,
+                lmdb_get,
+                lmdb_get_multiple,
+                lmdb_insert,
+                lmdb_insert_dup,
+                lmdb_last,
+                lmdb_len,
                 lmdb_replace,
             },
             validator_node_store::ValidatorNodeStore,
-            TransactionInputRowData, TransactionInputRowDataRef, TransactionKernelRowData, TransactionOutputRowData,
+            TransactionInputRowData,
+            TransactionInputRowDataRef,
+            TransactionKernelRowData,
+            TransactionOutputRowData,
         },
         smt_hasher::SmtHasher,
         stats::DbTotalSizeStats,
         utxo_mined_info::OutputMinedInfo,
-        BlockchainBackend, ChainTipData, DbBasicStats, DbSize, HorizonData, InputMinedInfo, MmrTree, Reorg,
-        TemplateRegistrationEntry, ValidatorNodeEntry,
+        BlockchainBackend,
+        ChainTipData,
+        DbBasicStats,
+        DbSize,
+        HorizonData,
+        InputMinedInfo,
+        MmrTree,
+        Reorg,
+        TemplateRegistrationEntry,
+        ValidatorNodeEntry,
     },
     consensus::{ConsensusConstants, ConsensusManager},
     proof_of_work::{monero_rx::MoneroPowData, PowAlgorithm},
     transactions::{
         aggregated_body::AggregateBody,
         transaction_components::{
-            OutputType, SpentOutput, TransactionInput, TransactionKernel, TransactionOutput, ValidatorNodeRegistration,
+            OutputType,
+            SpentOutput,
+            TransactionInput,
+            TransactionKernel,
+            TransactionOutput,
+            ValidatorNodeRegistration,
         },
     },
     PrunedKernelMmr,
@@ -1380,9 +1420,10 @@ impl LMDBDatabase {
                 root.0.to_hex()
             );
             return Err(ChainStorageError::InvalidOperation(format!(
-                "The output merkle root in the header at height {} does not match the calculated root. Header: {}, calculated:
+                "The output merkle root in the header at height {} does not match the calculated root. Header: {}, \
+                 calculated:
             {}",
-            header.height,
+                header.height,
                 header.output_mr.to_hex(),
                 root.0.to_hex()
             )));
@@ -1430,8 +1471,8 @@ impl LMDBDatabase {
         let prev_shard_key = store.get_shard_key(
             current_epoch
                 .as_u64()
-                .saturating_sub(constants.validator_node_validity_period_epochs().as_u64())
-                * constants.epoch_length(),
+                .saturating_sub(constants.validator_node_validity_period_epochs().as_u64()) *
+                constants.epoch_length(),
             current_epoch.as_u64() * constants.epoch_length(),
             vn_reg.public_key(),
         )?;
@@ -1862,9 +1903,9 @@ impl BlockchainBackend for LMDBDatabase {
         // attempted; this is more efficient than relying on an error if the LMDB environment map size was reached with
         // the write operation, with cleanup, resize and re-try afterwards.
         let block_operations = txn.operations().iter().filter(|op| {
-            matches!(op, WriteOperation::InsertOrphanBlock { .. })
-                || matches!(op, WriteOperation::InsertTipBlockBody { .. })
-                || matches!(op, WriteOperation::InsertChainOrphanBlock { .. })
+            matches!(op, WriteOperation::InsertOrphanBlock { .. }) ||
+                matches!(op, WriteOperation::InsertTipBlockBody { .. }) ||
+                matches!(op, WriteOperation::InsertChainOrphanBlock { .. })
         });
         let count = block_operations.count();
         if count > 0 {

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -40,13 +40,7 @@ use tari_common_types::{
     chain_metadata::ChainMetadata,
     epoch::VnEpoch,
     types::{
-        BadBlock,
-        BlockHash,
-        CompressedCommitment,
-        CompressedPublicKey,
-        FixedHash,
-        HashOutput,
-        Signature,
+        BadBlock, BlockHash, CompressedCommitment, CompressedPublicKey, FixedHash, HashOutput, Signature,
         UncompressedCommitment,
     },
 };
@@ -64,12 +58,7 @@ use super::{
 };
 use crate::{
     blocks::{
-        Block,
-        BlockAccumulatedData,
-        BlockHeader,
-        BlockHeaderAccumulatedData,
-        ChainBlock,
-        ChainHeader,
+        Block, BlockAccumulatedData, BlockHeader, BlockHeaderAccumulatedData, ChainBlock, ChainHeader,
         UpdateBlockAccumulatedData,
     },
     chain_storage::{
@@ -78,55 +67,26 @@ use crate::{
         lmdb_db::{
             composite_key::{CompositeKey, InputKey, OutputKey},
             lmdb::{
-                fetch_db_entry_sizes,
-                lmdb_clear,
-                lmdb_delete,
-                lmdb_delete_each_where,
-                lmdb_delete_key_value,
-                lmdb_delete_keys_starting_with,
-                lmdb_exists,
-                lmdb_fetch_matching_after,
-                lmdb_filter_map_values,
-                lmdb_first_after,
-                lmdb_get,
-                lmdb_get_multiple,
-                lmdb_insert,
-                lmdb_insert_dup,
-                lmdb_last,
-                lmdb_len,
+                fetch_db_entry_sizes, lmdb_clear, lmdb_delete, lmdb_delete_each_where, lmdb_delete_key_value,
+                lmdb_delete_keys_starting_with, lmdb_exists, lmdb_fetch_matching_after, lmdb_filter_map_values,
+                lmdb_first_after, lmdb_get, lmdb_get_multiple, lmdb_insert, lmdb_insert_dup, lmdb_last, lmdb_len,
                 lmdb_replace,
             },
             validator_node_store::ValidatorNodeStore,
-            TransactionInputRowData,
-            TransactionInputRowDataRef,
-            TransactionKernelRowData,
-            TransactionOutputRowData,
+            TransactionInputRowData, TransactionInputRowDataRef, TransactionKernelRowData, TransactionOutputRowData,
         },
         smt_hasher::SmtHasher,
         stats::DbTotalSizeStats,
         utxo_mined_info::OutputMinedInfo,
-        BlockchainBackend,
-        ChainTipData,
-        DbBasicStats,
-        DbSize,
-        HorizonData,
-        InputMinedInfo,
-        MmrTree,
-        Reorg,
-        TemplateRegistrationEntry,
-        ValidatorNodeEntry,
+        BlockchainBackend, ChainTipData, DbBasicStats, DbSize, HorizonData, InputMinedInfo, MmrTree, Reorg,
+        TemplateRegistrationEntry, ValidatorNodeEntry,
     },
     consensus::{ConsensusConstants, ConsensusManager},
     proof_of_work::{monero_rx::MoneroPowData, PowAlgorithm},
     transactions::{
         aggregated_body::AggregateBody,
         transaction_components::{
-            OutputType,
-            SpentOutput,
-            TransactionInput,
-            TransactionKernel,
-            TransactionOutput,
-            ValidatorNodeRegistration,
+            OutputType, SpentOutput, TransactionInput, TransactionKernel, TransactionOutput, ValidatorNodeRegistration,
         },
     },
     PrunedKernelMmr,
@@ -166,6 +126,7 @@ const LMDB_DB_TEMPLATE_REGISTRATIONS: &str = "template_registrations";
 const LMDB_DB_UTXO_SMT: &str = "utxo_smt";
 const LMDB_DB_JMT_VALUE_DATA: &str = "jmt_value_data";
 const LMDB_DB_JMT_NODE_DATA: &str = "jmt_node_data";
+const LMDB_DB_JMT_UNIQUE_KEY_DATA: &str = "jmt_unique_key_data";
 
 /// HeaderHash(32), mmr_pos(8), hash(32)
 type KernelKey = CompositeKey<72>;
@@ -219,6 +180,7 @@ pub fn create_lmdb_database<P: AsRef<Path>>(
         .add_database(LMDB_DB_UTXO_SMT, flags)
         .add_database(LMDB_DB_JMT_VALUE_DATA, flags )
         .add_database(LMDB_DB_JMT_NODE_DATA, flags)
+        .add_database(LMDB_DB_JMT_UNIQUE_KEY_DATA, flags)
         .build()
         .map_err(|err| ChainStorageError::CriticalError(format!("Could not create LMDB store:{}", err)))?;
     debug!(target: LOG_TARGET, "LMDB database creation successful");
@@ -287,6 +249,7 @@ pub struct LMDBDatabase {
     utxo_smt: DatabaseRef,
     jmt_value_data: DatabaseRef,
     jmt_node_data: DatabaseRef,
+    jmt_unique_key_data: DatabaseRef,
     _file_lock: Arc<File>,
     consensus_manager: ConsensusManager,
 }
@@ -329,6 +292,7 @@ impl LMDBDatabase {
             utxo_smt: get_database(store, LMDB_DB_UTXO_SMT)?,
             jmt_value_data: get_database(store, LMDB_DB_JMT_VALUE_DATA)?,
             jmt_node_data: get_database(store, LMDB_DB_JMT_NODE_DATA)?,
+            jmt_unique_key_data: get_database(store, LMDB_DB_JMT_UNIQUE_KEY_DATA)?,
             env,
             env_config: store.env_config(),
             _file_lock: Arc::new(file_lock),
@@ -528,7 +492,7 @@ impl LMDBDatabase {
         Ok(())
     }
 
-    fn all_dbs(&self) -> [(&'static str, &DatabaseRef); 30] {
+    fn all_dbs(&self) -> [(&'static str, &DatabaseRef); 31] {
         [
             (LMDB_DB_METADATA, &self.metadata_db),
             (LMDB_DB_HEADERS, &self.headers_db),
@@ -566,6 +530,7 @@ impl LMDBDatabase {
             (LMDB_DB_UTXO_SMT, &self.utxo_smt),
             (LMDB_DB_JMT_VALUE_DATA, &self.jmt_value_data),
             (LMDB_DB_JMT_NODE_DATA, &self.jmt_node_data),
+            (LMDB_DB_JMT_UNIQUE_KEY_DATA, &self.jmt_unique_key_data),
         ]
     }
 
@@ -968,9 +933,8 @@ impl LMDBDatabase {
         let smt_writer = LmdbTreeWriter::new(
             write_txn,
             self.jmt_node_data.clone(),
-            LMDB_DB_JMT_NODE_DATA,
             self.jmt_value_data.clone(),
-            LMDB_DB_JMT_VALUE_DATA,
+            self.jmt_unique_key_data.clone(),
         );
         smt_writer
             .delete_all_for_version(height)
@@ -1021,7 +985,7 @@ impl LMDBDatabase {
         let inputs = lmdb_delete_keys_starting_with::<TransactionInputRowData>(txn, &self.inputs_db, block_hash)?;
         debug!(target: LOG_TARGET, "Deleted {} input(s)...", inputs.len());
 
-        for utxo in &output_rows {
+        for (_, utxo) in &output_rows {
             trace!(target: LOG_TARGET, "Deleting UTXO `{}`", to_hex(utxo.hash.as_slice()));
             lmdb_delete(
                 txn,
@@ -1033,7 +997,7 @@ impl LMDBDatabase {
             let output_hash = utxo.output.hash();
             // if an output was already spent in the block, it was never created as unspent, so dont delete it as it
             // does not exist here
-            if inputs.iter().any(|r| r.input.output_hash() == output_hash) {
+            if inputs.iter().any(|(_, r)| r.input.output_hash() == output_hash) {
                 continue;
             }
             // if an output was burned, it was never created as an unspent utxo
@@ -1062,7 +1026,7 @@ impl LMDBDatabase {
         }
         // Move inputs in this block back into the unspent set, any outputs spent within this block they will be removed
         // by deleting all the block's outputs below
-        for row in inputs {
+        for (_, row) in inputs {
             // If input spends an output in this block, don't add it to the utxo set
             let output_hash = row.input.output_hash();
 
@@ -1072,7 +1036,7 @@ impl LMDBDatabase {
                 output_hash.as_slice(),
                 "deleted_txo_hash_to_header_index",
             )?;
-            if output_rows.iter().any(|r| r.hash == output_hash) {
+            if output_rows.iter().any(|(_, r)| r.hash == output_hash) {
                 continue;
             }
 
@@ -1128,7 +1092,7 @@ impl LMDBDatabase {
     fn delete_block_kernels(&self, txn: &WriteTransaction<'_>, block_hash: &[u8]) -> Result<(), ChainStorageError> {
         let kernels = lmdb_delete_keys_starting_with::<TransactionKernelRowData>(txn, &self.kernels_db, block_hash)?;
         debug!(target: LOG_TARGET, "Deleted {} kernels...", kernels.len());
-        for kernel in kernels {
+        for (_, kernel) in kernels {
             trace!(
                 target: LOG_TARGET,
                 "Deleting excess `{}`",
@@ -1324,7 +1288,6 @@ impl LMDBDatabase {
                 output.hash()
             );
             if !output.is_burned() {
-                // let smt_key = NodeKey::try_from(output.commitment.as_bytes())?;
                 let smt_key = KeyHash(
                     output
                         .commitment
@@ -1333,14 +1296,7 @@ impl LMDBDatabase {
                         .expect("Key hash is always 32 bytes"),
                 );
                 let smt_node = output.smt_hash(header.height).to_vec();
-                // if let Err(e) = output_smt.insert(smt_key, smt_node) {
-                //     error!(
-                //         target: LOG_TARGET,
-                //         "Output commitment({}) already in SMT",
-                //         output.commitment.to_hex(),
-                //     );
-                //     return Err(e.into());
-                // }
+
                 batch.push((smt_key, Some(smt_node)));
             }
 
@@ -1383,19 +1339,6 @@ impl LMDBDatabase {
                     .expect("Key hash is always 32 bytes"),
             );
             batch.push((smt_key, None));
-            // if can_we_change_smt {
-            //     match output_smt.delete(&smt_key)? {
-            //         DeleteResult::Deleted(_value_hash) => {},
-            //         DeleteResult::KeyNotFound => {
-            //             error!(
-            //                 target: LOG_TARGET,
-            //                 "Could not find input({}) in SMT",
-            //                 input_with_output_data.commitment()?.to_hex(),
-            //             );
-            //             return Err(ChainStorageError::UnspendableInput);
-            //         },
-            //     };
-            // }
 
             let features = input_with_output_data.features()?;
             if let Some(vn_reg) = features
@@ -1427,28 +1370,29 @@ impl LMDBDatabase {
         let (root, ops) = output_smt
             .put_value_set(batch, header.height)
             .map_err(ChainStorageError::JellyfishMerkleTreeError)?;
-        let smt_writer = LmdbTreeWriter::new(
-            txn,
-            self.jmt_node_data.clone(),
-            LMDB_DB_JMT_NODE_DATA,
-            self.jmt_value_data.clone(),
-            LMDB_DB_JMT_VALUE_DATA,
-        );
 
         if header.output_mr.as_slice() != root.0.as_slice() {
             warn!(
                 target: LOG_TARGET,
-                "The output merkle root in the header does not match the calculated root. Header: {}, calculated: {}",
+                "The output merkle root in the header at height {} does not match the calculated root. Header: {}, calculated: {}",
+                header.height,
                 header.output_mr.to_hex(),
                 root.0.to_hex()
             );
             return Err(ChainStorageError::InvalidOperation(format!(
-                "The output merkle root in the header does not match the calculated root. Header: {}, calculated:
+                "The output merkle root in the header at height {} does not match the calculated root. Header: {}, calculated:
             {}",
+            header.height,
                 header.output_mr.to_hex(),
                 root.0.to_hex()
             )));
         }
+        let smt_writer = LmdbTreeWriter::new(
+            txn,
+            self.jmt_node_data.clone(),
+            self.jmt_value_data.clone(),
+            self.jmt_unique_key_data.clone(),
+        );
         smt_writer
             .write_node_batch(&ops.node_batch)
             .map_err(ChainStorageError::JellyfishMerkleTreeError)?;
@@ -1486,8 +1430,8 @@ impl LMDBDatabase {
         let prev_shard_key = store.get_shard_key(
             current_epoch
                 .as_u64()
-                .saturating_sub(constants.validator_node_validity_period_epochs().as_u64()) *
-                constants.epoch_length(),
+                .saturating_sub(constants.validator_node_validity_period_epochs().as_u64())
+                * constants.epoch_length(),
             current_epoch.as_u64() * constants.epoch_length(),
             vn_reg.public_key(),
         )?;
@@ -1854,6 +1798,22 @@ impl LMDBDatabase {
     fn get_consensus_constants(&self, height: u64) -> &ConsensusConstants {
         self.consensus_manager.consensus_constants(height)
     }
+
+    #[cfg(test)]
+    pub(crate) fn create_write_txn(&self) -> WriteTransaction<'_> {
+        self.write_transaction().expect("Failed to create write transaction")
+    }
+
+    #[cfg(test)]
+    pub(crate) fn create_lmdb_tree_writer<'a: 'b, 'b>(&self, txn: &'a WriteTransaction<'b>) -> LmdbTreeWriter<'a> {
+        let res = LmdbTreeWriter::new(
+            &txn,
+            self.jmt_node_data.clone(),
+            self.jmt_value_data.clone(),
+            self.jmt_unique_key_data.clone(),
+        );
+        res
+    }
 }
 
 pub fn create_recovery_lmdb_database<P: AsRef<Path>>(path: P) -> Result<(), ChainStorageError> {
@@ -1902,9 +1862,9 @@ impl BlockchainBackend for LMDBDatabase {
         // attempted; this is more efficient than relying on an error if the LMDB environment map size was reached with
         // the write operation, with cleanup, resize and re-try afterwards.
         let block_operations = txn.operations().iter().filter(|op| {
-            matches!(op, WriteOperation::InsertOrphanBlock { .. }) ||
-                matches!(op, WriteOperation::InsertTipBlockBody { .. }) ||
-                matches!(op, WriteOperation::InsertChainOrphanBlock { .. })
+            matches!(op, WriteOperation::InsertOrphanBlock { .. })
+                || matches!(op, WriteOperation::InsertTipBlockBody { .. })
+                || matches!(op, WriteOperation::InsertChainOrphanBlock { .. })
         });
         let count = block_operations.count();
         if count > 0 {

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -1610,7 +1610,7 @@ impl LMDBDatabase {
         let inputs =
             lmdb_fetch_matching_after::<TransactionInputRowData>(write_txn, &self.inputs_db, block_hash.as_slice())?;
 
-        for input_data in inputs {
+        for (_input_key, input_data) in inputs {
             let input = input_data.input;
             // From 'utxo_commitment_index::utxo_commitment_index'
             if let SpentOutput::OutputData { commitment, .. } = input.spent_output.clone() {
@@ -2156,7 +2156,7 @@ impl BlockchainBackend for LMDBDatabase {
         let txn = self.read_transaction()?;
         Ok(lmdb_fetch_matching_after(&txn, &self.kernels_db, header_hash.deref())?
             .into_iter()
-            .map(|f: TransactionKernelRowData| f.kernel)
+            .map(|(_, f): (Vec<u8>, TransactionKernelRowData)| f.kernel)
             .collect())
     }
 
@@ -2206,7 +2206,7 @@ impl BlockchainBackend for LMDBDatabase {
         let mut outputs: Vec<(TransactionOutput, bool)> =
             lmdb_fetch_matching_after::<TransactionOutputRowData>(&txn, &self.utxos_db, header_hash.deref())?
                 .into_iter()
-                .map(|row| (row.output, false))
+                .map(|(_, row)| (row.output, false))
                 .collect();
         if let Some(header_hash) = spend_status_at_header {
             let header_height =
@@ -2259,7 +2259,11 @@ impl BlockchainBackend for LMDBDatabase {
 
     fn fetch_outputs_in_block(&self, header_hash: &HashOutput) -> Result<Vec<TransactionOutput>, ChainStorageError> {
         let txn = self.read_transaction()?;
-        lmdb_fetch_matching_after(&txn, &self.utxos_db, header_hash.as_slice())
+        lmdb_fetch_matching_after(&txn, &self.utxos_db, header_hash.as_slice()).map(|rows| {
+            rows.into_iter()
+                .map(|(_, row): (Vec<u8>, TransactionOutputRowData)| row.output)
+                .collect()
+        })
     }
 
     fn fetch_inputs_in_block(
@@ -2270,7 +2274,7 @@ impl BlockchainBackend for LMDBDatabase {
         Ok(
             lmdb_fetch_matching_after(&txn, &self.inputs_db, previous_header_hash.as_slice())?
                 .into_iter()
-                .map(|f: TransactionInputRowData| f.input)
+                .map(|(_, f): (_, TransactionInputRowData)| f.input)
                 .collect(),
         )
     }

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_tree_writer.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_tree_writer.rs
@@ -23,7 +23,9 @@
 use jmt::storage::{Node, TreeWriter};
 use lmdb_zero::WriteTransaction;
 use log::{info, warn};
+use std::collections::HashMap;
 use tari_storage::lmdb_store::DatabaseRef;
+use tari_utilities::hex::Hex;
 
 use super::lmdb::lmdb_insert;
 use crate::chain_storage::lmdb_db::lmdb::{lmdb_delete, lmdb_delete_keys_starting_with};
@@ -84,12 +86,21 @@ impl TreeWriter for LmdbTreeWriter<'_> {
             borsh::BorshSerialize::serialize(&node_key.nibble_path(), &mut lmdb_key)?;
             lmdb_insert(self.txn, &self.node_db, &lmdb_key, &node, "jmt_node_table")?;
         }
+        // let mut duplicates = HashMap::new();
         for (value_key, value) in node_batch.values() {
             let mut lmdb_key: Vec<u8> = vec![];
             lmdb_key.extend_from_slice(&value_key.0.to_be_bytes());
             lmdb_key.extend_from_slice(&value_key.1 .0);
             let val_bytes = bincode::serialize(value)?;
             lmdb_insert(self.txn, &self.value_db, &lmdb_key, &val_bytes, "jmt_value_table")?;
+
+            // *duplicates.entry(value_key.1 .0.clone()).or_insert(0) += 1;
+            // if duplicates[&value_key.1 .0] > 1 {
+            //     dbg!(value_key.1 .0.clone());
+            //     todo!("Duplicate value key found in batch");
+            //     warn!(target: LOG_TARGET, "Duplicate value key found in batch");
+            // }
+
             match value {
                 Some(_v) => {
                     lmdb_insert(
@@ -101,15 +112,12 @@ impl TreeWriter for LmdbTreeWriter<'_> {
                     )?;
                 },
                 None => {
-                    xxx remove genesis check 
-                    
                     let version = value_key.0;
                     if version != 0 {
                         // No need to delete for the first version, zero conf spends are only allowed in first version.
                         lmdb_delete(&self.txn, &self.unique_key_db, &value_key.1 .0, "jmt_unique_key_table")?;
                     }
                 },
-                
             };
         }
         info!(target: LOG_TARGET, "Wrote JMT batch of {} nodes and {} values", node_batch.nodes().len(), node_batch.values().len());

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_tree_writer.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_tree_writer.rs
@@ -26,40 +26,50 @@ use log::{info, warn};
 use tari_storage::lmdb_store::DatabaseRef;
 
 use super::lmdb::lmdb_insert;
-use crate::chain_storage::lmdb_db::lmdb::lmdb_delete_keys_starting_with;
+use crate::chain_storage::lmdb_db::lmdb::{lmdb_delete, lmdb_delete_keys_starting_with};
 pub const LOG_TARGET: &str = "c::cs::lmdb_db::lmdb_tree_writer";
 
 pub(crate) struct LmdbTreeWriter<'a> {
     txn: &'a WriteTransaction<'a>,
     node_db: DatabaseRef,
-    node_table_name: &'static str,
     value_db: DatabaseRef,
-    value_table_name: &'static str,
+    unique_key_db: DatabaseRef,
 }
 
 impl<'a> LmdbTreeWriter<'a> {
     pub fn new(
         txn: &'a WriteTransaction<'a>,
         node_db: DatabaseRef,
-        node_table_name: &'static str,
         value_db: DatabaseRef,
-        value_table_name: &'static str,
+        unique_key_db: DatabaseRef,
     ) -> Self {
         Self {
             txn,
             node_db,
-            node_table_name,
             value_db,
-            value_table_name,
+            unique_key_db,
         }
     }
 
     pub fn delete_all_for_version(&self, version: u64) -> anyhow::Result<()> {
         let key = version.to_be_bytes();
-        let nodes = lmdb_delete_keys_starting_with::<Node>(self.txn, &self.node_db, &key)?;
+        let nodes = lmdb_delete_keys_starting_with::<Node>(&self.txn, &self.node_db, &key)?;
         warn!(target: LOG_TARGET, "Deleted {} nodes for version {}", nodes.len(), version);
-        let values = lmdb_delete_keys_starting_with::<Vec<u8>>(self.txn, &self.value_db, &key)?;
+        let values = lmdb_delete_keys_starting_with::<Vec<u8>>(&self.txn, &self.value_db, &key)?;
         warn!(target: LOG_TARGET, "Deleted {} values for version {}", values.len(), version);
+
+        for (value_key, _) in values {
+            let mut lmdb_key: Vec<u8> = vec![];
+            // version is first 8 bytes
+            if value_key.len() < 8 {
+                return Err(anyhow::anyhow!("Value key is too short"));
+            }
+            lmdb_key.extend_from_slice(&value_key[8..]);
+            // lmdb_key.extend_from_slice(&value_key.0.to_be_bytes());
+            // lmdb_key.extend_from_slice(&value_key.1 .0);
+            lmdb_delete(&self.txn, &self.unique_key_db, &lmdb_key, "jmt_unique_key_table")?;
+        }
+        // todo!("delete unique keys for version {}", version);
 
         Ok(())
         // todo!("implement delete all for version")
@@ -72,16 +82,156 @@ impl TreeWriter for LmdbTreeWriter<'_> {
             let mut lmdb_key: Vec<u8> = vec![];
             lmdb_key.extend_from_slice(&node_key.version().to_be_bytes());
             borsh::BorshSerialize::serialize(&node_key.nibble_path(), &mut lmdb_key)?;
-            lmdb_insert(self.txn, &self.node_db, &lmdb_key, &node, self.node_table_name)?;
+            lmdb_insert(self.txn, &self.node_db, &lmdb_key, &node, "jmt_node_table")?;
         }
         for (value_key, value) in node_batch.values() {
             let mut lmdb_key: Vec<u8> = vec![];
             lmdb_key.extend_from_slice(&value_key.0.to_be_bytes());
             lmdb_key.extend_from_slice(&value_key.1 .0);
             let val_bytes = bincode::serialize(value)?;
-            lmdb_insert(self.txn, &self.value_db, &lmdb_key, &val_bytes, self.value_table_name)?;
+            lmdb_insert(self.txn, &self.value_db, &lmdb_key, &val_bytes, "jmt_value_table")?;
+            match value {
+                Some(_v) => {
+                    lmdb_insert(
+                        &self.txn,
+                        &self.unique_key_db,
+                        &value_key.1 .0,
+                        &lmdb_key,
+                        "jmt_unique_key_table",
+                    )?;
+                },
+                None => {
+                    let version = value_key.0;
+                    if version != 0 {
+                        // No need to delete for the first version, zero conf spends are only allowed in first version.
+                        lmdb_delete(&self.txn, &self.unique_key_db, &value_key.1 .0, "jmt_unique_key_table")?;
+                    }
+                },
+            };
         }
         info!(target: LOG_TARGET, "Wrote JMT batch of {} nodes and {} values", node_batch.nodes().len(), node_batch.values().len());
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{
+        chain_storage::{BlockchainBackend, SmtHasher},
+        test_helpers::blockchain::TempDatabase,
+    };
+    use jmt::{JellyfishMerkleTree, KeyHash};
+    use rand::rngs::OsRng;
+    use tari_crypto::{keys::PublicKey, ristretto::RistrettoPublicKey};
+    use tari_utilities::ByteArray;
+
+    #[test]
+    fn test_jmt_does_not_accept_duplicates() {
+        let db = TempDatabase::new();
+        let txn = db.db().create_write_txn();
+        let tree_writer = db.db().create_lmdb_tree_writer(&txn);
+        let reader = db.db().create_smt_reader().unwrap();
+
+        let jmt = JellyfishMerkleTree::<_, SmtHasher>::new(&reader);
+        let (_sk, commitment) = RistrettoPublicKey::random_keypair(&mut OsRng);
+        let smt_key = KeyHash(commitment.as_bytes().try_into().expect("Key hash is always 32 bytes"));
+        let value = b"test_value".to_vec();
+        let (_root, updates) = jmt.put_value_set(vec![(smt_key, Some(value.clone()))], 0).unwrap();
+        tree_writer.write_node_batch(&updates.node_batch).unwrap();
+
+        txn.commit().unwrap();
+        // Try again for new version.
+        let txn = db.db().create_write_txn();
+        let tree_writer = db.db().create_lmdb_tree_writer(&txn);
+        let reader = db.db().create_smt_reader().unwrap();
+
+        let jmt = JellyfishMerkleTree::<_, SmtHasher>::new(&reader);
+
+        let (_root, update2) = jmt.put_value_set(vec![(smt_key, Some(value))], 1).unwrap();
+        assert!(
+            tree_writer.write_node_batch(&update2.node_batch).is_err(),
+            "Duplicate key error expected"
+        );
+    }
+
+    #[test]
+    fn test_jmt_does_accept_duplicate_if_deleted() {
+        // If a key in the jmt is deleted, it can be added later.
+        let db = TempDatabase::new();
+        let txn = db.db().create_write_txn();
+        let tree_writer = db.db().create_lmdb_tree_writer(&txn);
+        let reader = db.db().create_smt_reader().unwrap();
+
+        let jmt = JellyfishMerkleTree::<_, SmtHasher>::new(&reader);
+        let (_sk, commitment) = RistrettoPublicKey::random_keypair(&mut OsRng);
+        let smt_key = KeyHash(commitment.as_bytes().try_into().expect("Key hash is always 32 bytes"));
+        let value = b"test_value".to_vec();
+        let (root, updates) = jmt.put_value_set(vec![(smt_key, Some(value.clone()))], 0).unwrap();
+        tree_writer.write_node_batch(&updates.node_batch).unwrap();
+
+        txn.commit().unwrap();
+        // Try again for new version.
+        let txn = db.db().create_write_txn();
+        let tree_writer = db.db().create_lmdb_tree_writer(&txn);
+        let reader = db.db().create_smt_reader().unwrap();
+
+        let jmt = JellyfishMerkleTree::<_, SmtHasher>::new(&reader);
+
+        let (_root, update2) = jmt.put_value_set(vec![(smt_key, None)], 1).unwrap();
+        tree_writer.write_node_batch(&update2.node_batch).unwrap();
+
+        txn.commit().unwrap();
+
+        // Try again for version 2.
+        let txn = db.db().create_write_txn();
+        let tree_writer = db.db().create_lmdb_tree_writer(&txn);
+        let reader = db.db().create_smt_reader().unwrap();
+
+        let jmt = JellyfishMerkleTree::<_, SmtHasher>::new(&reader);
+
+        let (_root, update2) = jmt.put_value_set(vec![(smt_key, Some(value))], 2).unwrap();
+        tree_writer.write_node_batch(&update2.node_batch).unwrap();
+
+        txn.commit().unwrap();
+    }
+
+    #[test]
+    fn test_jmt_deletes_block_on_reorg() {
+        let db = TempDatabase::new();
+        let txn = db.db().create_write_txn();
+        let tree_writer = db.db().create_lmdb_tree_writer(&txn);
+        let reader = db.db().create_smt_reader().unwrap();
+
+        let jmt = JellyfishMerkleTree::<_, SmtHasher>::new(&reader);
+        let (_sk, commitment) = RistrettoPublicKey::random_keypair(&mut OsRng);
+        let smt_key = KeyHash(commitment.as_bytes().try_into().expect("Key hash is always 32 bytes"));
+        let value = b"test_value".to_vec();
+        let (root, updates) = jmt.put_value_set(vec![(smt_key, Some(value.clone()))], 0).unwrap();
+        tree_writer.write_node_batch(&updates.node_batch).unwrap();
+
+        txn.commit().unwrap();
+        // Try again for new version.
+        let txn = db.db().create_write_txn();
+        let tree_writer = db.db().create_lmdb_tree_writer(&txn);
+        let reader = db.db().create_smt_reader().unwrap();
+        let (_sk, commitment) = RistrettoPublicKey::random_keypair(&mut OsRng);
+        let smt_key2 = KeyHash(commitment.as_bytes().try_into().expect("Key hash is always 32 bytes"));
+        let jmt = JellyfishMerkleTree::<_, SmtHasher>::new(&reader);
+
+        let (_root1, update2) = jmt.put_value_set(vec![(smt_key2, Some(value))], 1).unwrap();
+        tree_writer.write_node_batch(&update2.node_batch).unwrap();
+        txn.commit().unwrap();
+
+        let txn = db.db().create_write_txn();
+        let tree_writer = db.db().create_lmdb_tree_writer(&txn);
+        tree_writer.delete_all_for_version(1).unwrap();
+        txn.commit().unwrap();
+
+        let reader = db.db().create_smt_reader().unwrap();
+        let jmt = JellyfishMerkleTree::<_, SmtHasher>::new(&reader);
+        let root2 = jmt.get_root_hash(0).unwrap();
+
+        assert_eq!(root, root2);
     }
 }

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_tree_writer.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_tree_writer.rs
@@ -113,11 +113,10 @@ impl TreeWriter for LmdbTreeWriter<'_> {
                     )?;
                 },
                 None => {
-                    let version = value_key.0;
-                    if version != 0 {
-                        // No need to delete for the first version, zero conf spends are only allowed in first version.
-                        lmdb_delete(&self.txn, &self.unique_key_db, &value_key.1 .0, "jmt_unique_key_table")?;
-                    }
+                    let _res = lmdb_delete(&self.txn, &self.unique_key_db, &value_key.1 .0, "jmt_unique_key_table")
+                        .inspect_err(|e| {
+                            warn!(target: LOG_TARGET, "Failed to delete unique key {}: {}", value_key.1 .0.to_hex(), e);
+                        });
                 },
             };
         }

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_tree_writer.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_tree_writer.rs
@@ -20,10 +20,11 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use std::collections::HashMap;
+
 use jmt::storage::{Node, TreeWriter};
 use lmdb_zero::WriteTransaction;
 use log::{info, warn};
-use std::collections::HashMap;
 use tari_storage::lmdb_store::DatabaseRef;
 use tari_utilities::hex::Hex;
 

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_tree_writer.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_tree_writer.rs
@@ -23,11 +23,17 @@
 use jmt::storage::{Node, TreeWriter};
 use lmdb_zero::WriteTransaction;
 use log::{info, warn};
+use tari_common_types::types::FixedHash;
 use tari_storage::lmdb_store::DatabaseRef;
 use tari_utilities::hex::Hex;
 
 use super::lmdb::lmdb_insert;
-use crate::chain_storage::lmdb_db::lmdb::{lmdb_delete, lmdb_delete_keys_starting_with};
+use crate::chain_storage::lmdb_db::lmdb::{
+    lmdb_delete,
+    lmdb_delete_keys_starting_with,
+    lmdb_fetch_matching_after,
+    lmdb_get_prefix_cursor,
+};
 pub const LOG_TARGET: &str = "c::cs::lmdb_db::lmdb_tree_writer";
 
 pub(crate) struct LmdbTreeWriter<'a> {
@@ -66,14 +72,18 @@ impl<'a> LmdbTreeWriter<'a> {
                 return Err(anyhow::anyhow!("Value key is too short"));
             }
             lmdb_key.extend_from_slice(&value_key[8..]);
-            // lmdb_key.extend_from_slice(&value_key.0.to_be_bytes());
-            // lmdb_key.extend_from_slice(&value_key.1 .0);
-            lmdb_delete(&self.txn, &self.unique_key_db, &lmdb_key, "jmt_unique_key_table")?;
+            lmdb_key.extend_from_slice(&value_key[0..8]);
+            match lmdb_delete(&self.txn, &self.unique_key_db, &lmdb_key, "jmt_unique_key_table") {
+                Ok(_) => {
+                    warn!(target: LOG_TARGET, "Deleted unique key {} for version {}", lmdb_key.to_hex(), version);
+                },
+                Err(e) => {
+                    warn!(target: LOG_TARGET, "Failed to delete unique key {} for version {}: {}", lmdb_key.to_hex(), version, e);
+                },
+            }
         }
-        // todo!("delete unique keys for version {}", version);
 
         Ok(())
-        // todo!("implement delete all for version")
     }
 }
 
@@ -93,28 +103,45 @@ impl TreeWriter for LmdbTreeWriter<'_> {
             let val_bytes = bincode::serialize(value)?;
             lmdb_insert(self.txn, &self.value_db, &lmdb_key, &val_bytes, "jmt_value_table")?;
 
-            // *duplicates.entry(value_key.1 .0.clone()).or_insert(0) += 1;
-            // if duplicates[&value_key.1 .0] > 1 {
-            //     dbg!(value_key.1 .0.clone());
-            //     todo!("Duplicate value key found in batch");
-            //     warn!(target: LOG_TARGET, "Duplicate value key found in batch");
-            // }
+            // see if there are any values already.
+            let existing_values: Vec<(Vec<u8>, Option<Vec<u8>>)> =
+                lmdb_fetch_matching_after(&self.txn, &self.unique_key_db, &value_key.1 .0)?;
+            let mut existing_history = vec![];
+            for (key, x) in existing_values {
+                dbg!(&key);
+                let version = u64::from_be_bytes(key[32..].try_into().unwrap());
+                existing_history.push((version, x));
+            }
+            // sort by version
+            existing_history.sort_by(|a, b| a.0.cmp(&b.0));
 
-            match value {
-                Some(_v) => {
-                    lmdb_insert(
-                        &self.txn,
-                        &self.unique_key_db,
-                        &value_key.1 .0,
-                        &lmdb_key,
-                        "jmt_unique_key_table",
-                    )?;
+            let latest_value = existing_history.last().map(|x| x.1.clone()).flatten();
+            match (value, &latest_value) {
+                (None, _) => {
+                    if latest_value.is_none() {
+                        warn!(target: LOG_TARGET, "Found no existing JMT unique key for version {}, creating it as None", value_key.0);
+                    }
+                    let mut lmdb_key: Vec<u8> = vec![];
+                    lmdb_key.extend_from_slice(value_key.1 .0.as_slice());
+                    lmdb_key.extend_from_slice(&value_key.0.to_be_bytes());
+                    lmdb_insert(self.txn, &self.unique_key_db, &lmdb_key, value, "jmt_unique_key_table")?;
+                    warn!(target: LOG_TARGET, "Deleted unique key {} effective from version {}", value_key.1 .0.to_hex(), value_key.0);
                 },
-                None => {
-                    let _res = lmdb_delete(&self.txn, &self.unique_key_db, &value_key.1 .0, "jmt_unique_key_table")
-                        .inspect_err(|e| {
-                            warn!(target: LOG_TARGET, "Failed to delete unique key {}: {}", value_key.1 .0.to_hex(), e);
-                        });
+                (Some(_v), Some(x)) => {
+                    warn!(target: LOG_TARGET, "Found existing unique key {} for version {}", value_key.1 .0.to_hex(), value_key.0);
+                    return Err(anyhow::anyhow!("Duplicate value key found in batch"));
+                },
+                // (None, None) => {
+                // warn!(target: LOG_TARGET, "Found no existing unique key for version {}", value_key.0);
+                // Technically this is allowed
+                // return Err(anyhow::anyhow!("Duplicate value key found in batch"));
+                // },
+                (Some(v), None) => {
+                    let mut lmdb_key: Vec<u8> = vec![];
+                    lmdb_key.extend_from_slice(value_key.1 .0.as_slice());
+                    lmdb_key.extend_from_slice(&value_key.0.to_be_bytes());
+                    lmdb_insert(self.txn, &self.unique_key_db, &lmdb_key, value, "jmt_unique_key_table")?;
+                    warn!(target: LOG_TARGET, "Inserted unique key {} for version {}", value_key.1 .0.to_hex(), value_key.0);
                 },
             };
         }

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_tree_writer.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_tree_writer.rs
@@ -20,8 +20,6 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::collections::HashMap;
-
 use jmt::storage::{Node, TreeWriter};
 use lmdb_zero::WriteTransaction;
 use log::{info, warn};
@@ -179,7 +177,7 @@ mod test {
         let (_sk, commitment) = RistrettoPublicKey::random_keypair(&mut OsRng);
         let smt_key = KeyHash(commitment.as_bytes().try_into().expect("Key hash is always 32 bytes"));
         let value = b"test_value".to_vec();
-        let (root, updates) = jmt.put_value_set(vec![(smt_key, Some(value.clone()))], 0).unwrap();
+        let (_root, updates) = jmt.put_value_set(vec![(smt_key, Some(value.clone()))], 0).unwrap();
         tree_writer.write_node_batch(&updates.node_batch).unwrap();
 
         txn.commit().unwrap();

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_tree_writer.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_tree_writer.rs
@@ -108,7 +108,6 @@ impl TreeWriter for LmdbTreeWriter<'_> {
                 lmdb_fetch_matching_after(&self.txn, &self.unique_key_db, &value_key.1 .0)?;
             let mut existing_history = vec![];
             for (key, x) in existing_values {
-                dbg!(&key);
                 let version = u64::from_be_bytes(key[32..].try_into().unwrap());
                 existing_history.push((version, x));
             }

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_tree_writer.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_tree_writer.rs
@@ -23,17 +23,11 @@
 use jmt::storage::{Node, TreeWriter};
 use lmdb_zero::WriteTransaction;
 use log::{info, warn};
-use tari_common_types::types::FixedHash;
 use tari_storage::lmdb_store::DatabaseRef;
 use tari_utilities::hex::Hex;
 
 use super::lmdb::lmdb_insert;
-use crate::chain_storage::lmdb_db::lmdb::{
-    lmdb_delete,
-    lmdb_delete_keys_starting_with,
-    lmdb_fetch_matching_after,
-    lmdb_get_prefix_cursor,
-};
+use crate::chain_storage::lmdb_db::lmdb::{lmdb_delete, lmdb_delete_keys_starting_with, lmdb_fetch_matching_after};
 pub const LOG_TARGET: &str = "c::cs::lmdb_db::lmdb_tree_writer";
 
 pub(crate) struct LmdbTreeWriter<'a> {
@@ -124,9 +118,10 @@ impl TreeWriter for LmdbTreeWriter<'_> {
                     lmdb_key.extend_from_slice(value_key.1 .0.as_slice());
                     lmdb_key.extend_from_slice(&value_key.0.to_be_bytes());
                     lmdb_insert(self.txn, &self.unique_key_db, &lmdb_key, value, "jmt_unique_key_table")?;
-                    warn!(target: LOG_TARGET, "Deleted unique key {} effective from version {}", value_key.1 .0.to_hex(), value_key.0);
+                    // warn!(target: LOG_TARGET, "Deleted unique key {} effective from version {}", value_key.1
+                    // .0.to_hex(), value_key.0);
                 },
-                (Some(_v), Some(x)) => {
+                (Some(_v), Some(_x)) => {
                     warn!(target: LOG_TARGET, "Found existing unique key {} for version {}", value_key.1 .0.to_hex(), value_key.0);
                     return Err(anyhow::anyhow!("Duplicate value key found in batch"));
                 },
@@ -135,12 +130,13 @@ impl TreeWriter for LmdbTreeWriter<'_> {
                 // Technically this is allowed
                 // return Err(anyhow::anyhow!("Duplicate value key found in batch"));
                 // },
-                (Some(v), None) => {
+                (Some(_v), None) => {
                     let mut lmdb_key: Vec<u8> = vec![];
                     lmdb_key.extend_from_slice(value_key.1 .0.as_slice());
                     lmdb_key.extend_from_slice(&value_key.0.to_be_bytes());
                     lmdb_insert(self.txn, &self.unique_key_db, &lmdb_key, value, "jmt_unique_key_table")?;
-                    warn!(target: LOG_TARGET, "Inserted unique key {} for version {}", value_key.1 .0.to_hex(), value_key.0);
+                    // warn!(target: LOG_TARGET, "Inserted unique key {} for version {}", value_key.1 .0.to_hex(),
+                    // value_key.0);
                 },
             };
         }

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_tree_writer.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_tree_writer.rs
@@ -101,12 +101,15 @@ impl TreeWriter for LmdbTreeWriter<'_> {
                     )?;
                 },
                 None => {
+                    xxx remove genesis check 
+                    
                     let version = value_key.0;
                     if version != 0 {
                         // No need to delete for the first version, zero conf spends are only allowed in first version.
                         lmdb_delete(&self.txn, &self.unique_key_db, &value_key.1 .0, "jmt_unique_key_table")?;
                     }
                 },
+                
             };
         }
         info!(target: LOG_TARGET, "Wrote JMT batch of {} nodes and {} values", node_batch.nodes().len(), node_batch.values().len());
@@ -116,15 +119,16 @@ impl TreeWriter for LmdbTreeWriter<'_> {
 
 #[cfg(test)]
 mod test {
+    use jmt::{JellyfishMerkleTree, KeyHash};
+    use rand::rngs::OsRng;
+    use tari_crypto::{keys::PublicKey, ristretto::RistrettoPublicKey};
+    use tari_utilities::ByteArray;
+
     use super::*;
     use crate::{
         chain_storage::{BlockchainBackend, SmtHasher},
         test_helpers::blockchain::TempDatabase,
     };
-    use jmt::{JellyfishMerkleTree, KeyHash};
-    use rand::rngs::OsRng;
-    use tari_crypto::{keys::PublicKey, ristretto::RistrettoPublicKey};
-    use tari_utilities::ByteArray;
 
     #[test]
     fn test_jmt_does_not_accept_duplicates() {
@@ -219,7 +223,7 @@ mod test {
         let smt_key2 = KeyHash(commitment.as_bytes().try_into().expect("Key hash is always 32 bytes"));
         let jmt = JellyfishMerkleTree::<_, SmtHasher>::new(&reader);
 
-        let (_root1, update2) = jmt.put_value_set(vec![(smt_key2, Some(value))], 1).unwrap();
+        let (root1, update2) = jmt.put_value_set(vec![(smt_key2, Some(value.clone()))], 1).unwrap();
         tree_writer.write_node_batch(&update2.node_batch).unwrap();
         txn.commit().unwrap();
 
@@ -233,5 +237,17 @@ mod test {
         let root2 = jmt.get_root_hash(0).unwrap();
 
         assert_eq!(root, root2);
+
+        // Test that you can add it back again.
+        let txn = db.db().create_write_txn();
+        let tree_writer = db.db().create_lmdb_tree_writer(&txn);
+        let reader = db.db().create_smt_reader().unwrap();
+
+        let jmt = JellyfishMerkleTree::<_, SmtHasher>::new(&reader);
+        let (root1_v2, update2) = jmt.put_value_set(vec![(smt_key2, Some(value))], 1).unwrap();
+        tree_writer.write_node_batch(&update2.node_batch).unwrap();
+        txn.commit().unwrap();
+
+        assert_eq!(root1, root1_v2);
     }
 }

--- a/base_layer/core/src/chain_storage/mod.rs
+++ b/base_layer/core/src/chain_storage/mod.rs
@@ -39,8 +39,15 @@ use serde::{Deserialize, Serialize};
 
 mod blockchain_database;
 pub use blockchain_database::{
-    calculate_mmr_roots, calculate_validator_node_mr, fetch_header, fetch_headers,
-    fetch_target_difficulty_for_next_block, BlockchainDatabase, BlockchainDatabaseConfig, MmrRoots, Validators,
+    calculate_mmr_roots,
+    calculate_validator_node_mr,
+    fetch_header,
+    fetch_headers,
+    fetch_target_difficulty_for_next_block,
+    BlockchainDatabase,
+    BlockchainDatabaseConfig,
+    MmrRoots,
+    Validators,
 };
 mod blockchain_backend;
 pub use blockchain_backend::BlockchainBackend;
@@ -57,7 +64,8 @@ mod reorg;
 pub use reorg::Reorg;
 mod lmdb_db;
 pub use lmdb_db::{
-    create_lmdb_database, create_recovery_lmdb_database,
+    create_lmdb_database,
+    create_recovery_lmdb_database,
     lmdb_tree_reader::{LmdbTreeReader, OwnedLmdbTreeReader},
     LMDBDatabase,
 };

--- a/base_layer/core/src/chain_storage/mod.rs
+++ b/base_layer/core/src/chain_storage/mod.rs
@@ -39,15 +39,8 @@ use serde::{Deserialize, Serialize};
 
 mod blockchain_database;
 pub use blockchain_database::{
-    calculate_mmr_roots,
-    calculate_validator_node_mr,
-    fetch_header,
-    fetch_headers,
-    fetch_target_difficulty_for_next_block,
-    BlockchainDatabase,
-    BlockchainDatabaseConfig,
-    MmrRoots,
-    Validators,
+    calculate_mmr_roots, calculate_validator_node_mr, fetch_header, fetch_headers,
+    fetch_target_difficulty_for_next_block, BlockchainDatabase, BlockchainDatabaseConfig, MmrRoots, Validators,
 };
 mod blockchain_backend;
 pub use blockchain_backend::BlockchainBackend;
@@ -64,8 +57,7 @@ mod reorg;
 pub use reorg::Reorg;
 mod lmdb_db;
 pub use lmdb_db::{
-    create_lmdb_database,
-    create_recovery_lmdb_database,
+    create_lmdb_database, create_recovery_lmdb_database,
     lmdb_tree_reader::{LmdbTreeReader, OwnedLmdbTreeReader},
     LMDBDatabase,
 };
@@ -81,7 +73,6 @@ use tari_common_types::types::HashOutput;
 mod template_registation;
 pub use template_registation::TemplateRegistrationEntry;
 mod smt_hasher;
-#[cfg(test)]
 pub use smt_hasher::SmtHasher;
 
 #[derive(Debug, Serialize, Deserialize, Default, Clone, PartialEq, Eq)]

--- a/base_layer/core/src/consensus/consensus_constants.rs
+++ b/base_layer/core/src/consensus/consensus_constants.rs
@@ -37,7 +37,11 @@ use crate::{
     transactions::{
         tari_amount::{uT, MicroMinotari},
         transaction_components::{
-            OutputFeaturesVersion, OutputType, RangeProofType, TransactionInputVersion, TransactionKernelVersion,
+            OutputFeaturesVersion,
+            OutputType,
+            RangeProofType,
+            TransactionInputVersion,
+            TransactionKernelVersion,
             TransactionOutputVersion,
         },
         weight::TransactionWeight,
@@ -365,22 +369,16 @@ impl ConsensusConstants {
     pub fn localnet() -> Vec<Self> {
         let difficulty_block_window = 90;
         let mut algos = HashMap::new();
-        algos.insert(
-            PowAlgorithm::Sha3x,
-            PowAlgorithmConstants {
-                min_difficulty: Difficulty::min(),
-                max_difficulty: Difficulty::min(),
-                target_time: 240,
-            },
-        );
-        algos.insert(
-            PowAlgorithm::RandomX,
-            PowAlgorithmConstants {
-                min_difficulty: Difficulty::min(),
-                max_difficulty: Difficulty::min(),
-                target_time: 240,
-            },
-        );
+        algos.insert(PowAlgorithm::Sha3x, PowAlgorithmConstants {
+            min_difficulty: Difficulty::min(),
+            max_difficulty: Difficulty::min(),
+            target_time: 240,
+        });
+        algos.insert(PowAlgorithm::RandomX, PowAlgorithmConstants {
+            min_difficulty: Difficulty::min(),
+            max_difficulty: Difficulty::min(),
+            target_time: 240,
+        });
         let (input_version_range, output_version_range, kernel_version_range) = version_zero();
         let consensus_constants = vec![ConsensusConstants {
             effective_from_height: 0,
@@ -430,24 +428,18 @@ impl ConsensusConstants {
         let future_time_limit = target_time * difficulty_block_window / 20;
 
         let mut algos = HashMap::new();
-        algos.insert(
-            PowAlgorithm::Sha3x,
-            PowAlgorithmConstants {
-                // (target_time x 200_000/3) ... for easy testing
-                min_difficulty: Difficulty::from_u64(sha3x_target_time * 67_000).expect("valid difficulty"),
-                max_difficulty: Difficulty::max(),
-                target_time: sha3x_target_time,
-            },
-        );
-        algos.insert(
-            PowAlgorithm::RandomX,
-            PowAlgorithmConstants {
-                // (target_time x 300/3)     ... for easy testing
-                min_difficulty: Difficulty::from_u64(randomx_target_time * 100).expect("valid difficulty"),
-                max_difficulty: Difficulty::max(),
-                target_time: randomx_target_time,
-            },
-        );
+        algos.insert(PowAlgorithm::Sha3x, PowAlgorithmConstants {
+            // (target_time x 200_000/3) ... for easy testing
+            min_difficulty: Difficulty::from_u64(sha3x_target_time * 67_000).expect("valid difficulty"),
+            max_difficulty: Difficulty::max(),
+            target_time: sha3x_target_time,
+        });
+        algos.insert(PowAlgorithm::RandomX, PowAlgorithmConstants {
+            // (target_time x 300/3)     ... for easy testing
+            min_difficulty: Difficulty::from_u64(randomx_target_time * 100).expect("valid difficulty"),
+            max_difficulty: Difficulty::max(),
+            target_time: randomx_target_time,
+        });
         let (input_version_range, output_version_range, kernel_version_range) = version_zero();
         let consensus_constants = vec![ConsensusConstants {
             effective_from_height: 0,
@@ -498,22 +490,16 @@ impl ConsensusConstants {
     /// * Coinbase lock height - 12 hours = 360 blocks
     pub fn esmeralda() -> Vec<Self> {
         let mut algos = HashMap::new();
-        algos.insert(
-            PowAlgorithm::Sha3x,
-            PowAlgorithmConstants {
-                min_difficulty: Difficulty::from_u64(60_000_000).expect("valid difficulty"),
-                max_difficulty: Difficulty::max(),
-                target_time: 60,
-            },
-        );
-        algos.insert(
-            PowAlgorithm::RandomX,
-            PowAlgorithmConstants {
-                min_difficulty: Difficulty::from_u64(60_000).expect("valid difficulty"),
-                max_difficulty: Difficulty::max(),
-                target_time: 60,
-            },
-        );
+        algos.insert(PowAlgorithm::Sha3x, PowAlgorithmConstants {
+            min_difficulty: Difficulty::from_u64(60_000_000).expect("valid difficulty"),
+            max_difficulty: Difficulty::max(),
+            target_time: 60,
+        });
+        algos.insert(PowAlgorithm::RandomX, PowAlgorithmConstants {
+            min_difficulty: Difficulty::from_u64(60_000).expect("valid difficulty"),
+            max_difficulty: Difficulty::max(),
+            target_time: 60,
+        });
         let (input_version_range, output_version_range, kernel_version_range) = version_zero();
         let consensus_constants1 = ConsensusConstants {
             effective_from_height: 0,
@@ -561,22 +547,16 @@ impl ConsensusConstants {
     /// * Coinbase lock height - 12 hours = 360 blocks
     pub fn stagenet() -> Vec<Self> {
         let mut algos = HashMap::new();
-        algos.insert(
-            PowAlgorithm::Sha3x,
-            PowAlgorithmConstants {
-                min_difficulty: Difficulty::from_u64(450_000_000_000).expect("valid difficulty"),
-                max_difficulty: Difficulty::max(),
-                target_time: 240,
-            },
-        );
-        algos.insert(
-            PowAlgorithm::RandomX,
-            PowAlgorithmConstants {
-                min_difficulty: Difficulty::from_u64(1_200_000).expect("valid difficulty"),
-                max_difficulty: Difficulty::max(),
-                target_time: 240,
-            },
-        );
+        algos.insert(PowAlgorithm::Sha3x, PowAlgorithmConstants {
+            min_difficulty: Difficulty::from_u64(450_000_000_000).expect("valid difficulty"),
+            max_difficulty: Difficulty::max(),
+            target_time: 240,
+        });
+        algos.insert(PowAlgorithm::RandomX, PowAlgorithmConstants {
+            min_difficulty: Difficulty::from_u64(1_200_000).expect("valid difficulty"),
+            max_difficulty: Difficulty::max(),
+            target_time: 240,
+        });
         let (input_version_range, output_version_range, kernel_version_range) = version_zero();
         let consensus_constants = vec![ConsensusConstants {
             effective_from_height: 0,
@@ -617,22 +597,16 @@ impl ConsensusConstants {
 
     pub fn nextnet() -> Vec<Self> {
         let mut algos = HashMap::new();
-        algos.insert(
-            PowAlgorithm::Sha3x,
-            PowAlgorithmConstants {
-                min_difficulty: Difficulty::from_u64(150_000_000_000).expect("valid difficulty"),
-                max_difficulty: Difficulty::max(),
-                target_time: 240,
-            },
-        );
-        algos.insert(
-            PowAlgorithm::RandomX,
-            PowAlgorithmConstants {
-                min_difficulty: Difficulty::from_u64(1_200_000).expect("valid difficulty"),
-                max_difficulty: Difficulty::max(),
-                target_time: 240,
-            },
-        );
+        algos.insert(PowAlgorithm::Sha3x, PowAlgorithmConstants {
+            min_difficulty: Difficulty::from_u64(150_000_000_000).expect("valid difficulty"),
+            max_difficulty: Difficulty::max(),
+            target_time: 240,
+        });
+        algos.insert(PowAlgorithm::RandomX, PowAlgorithmConstants {
+            min_difficulty: Difficulty::from_u64(1_200_000).expect("valid difficulty"),
+            max_difficulty: Difficulty::max(),
+            target_time: 240,
+        });
         let (input_version_range, output_version_range, kernel_version_range) = version_zero();
         let con_1 = ConsensusConstants {
             effective_from_height: 0,
@@ -680,22 +654,16 @@ impl ConsensusConstants {
     pub fn mainnet() -> Vec<Self> {
         let difficulty_block_window = 90;
         let mut algos = HashMap::new();
-        algos.insert(
-            PowAlgorithm::Sha3x,
-            PowAlgorithmConstants {
-                min_difficulty: Difficulty::from_u64(450_000_000_000).expect("valid difficulty"),
-                max_difficulty: Difficulty::max(),
-                target_time: 240,
-            },
-        );
-        algos.insert(
-            PowAlgorithm::RandomX,
-            PowAlgorithmConstants {
-                min_difficulty: Difficulty::from_u64(1_200_000).expect("valid difficulty"),
-                max_difficulty: Difficulty::max(),
-                target_time: 240,
-            },
-        );
+        algos.insert(PowAlgorithm::Sha3x, PowAlgorithmConstants {
+            min_difficulty: Difficulty::from_u64(450_000_000_000).expect("valid difficulty"),
+            max_difficulty: Difficulty::max(),
+            target_time: 240,
+        });
+        algos.insert(PowAlgorithm::RandomX, PowAlgorithmConstants {
+            min_difficulty: Difficulty::from_u64(1_200_000).expect("valid difficulty"),
+            max_difficulty: Difficulty::max(),
+            target_time: 240,
+        });
         let (input_version_range, output_version_range, kernel_version_range) = version_zero();
         let consensus_constants = vec![ConsensusConstants {
             effective_from_height: 0,
@@ -741,15 +709,14 @@ impl ConsensusConstants {
     const fn current_permitted_range_proof_types() -> [(OutputType, &'static [RangeProofType]); 5] {
         [
             (OutputType::Standard, &[RangeProofType::BulletProofPlus]),
-            (
-                OutputType::Coinbase,
-                &[RangeProofType::BulletProofPlus, RangeProofType::RevealedValue],
-            ),
+            (OutputType::Coinbase, &[
+                RangeProofType::BulletProofPlus,
+                RangeProofType::RevealedValue,
+            ]),
             (OutputType::Burn, &[RangeProofType::BulletProofPlus]),
-            (
-                OutputType::ValidatorNodeRegistration,
-                &[RangeProofType::BulletProofPlus],
-            ),
+            (OutputType::ValidatorNodeRegistration, &[
+                RangeProofType::BulletProofPlus,
+            ]),
             (OutputType::CodeTemplateRegistration, &[RangeProofType::BulletProofPlus]),
         ]
     }

--- a/base_layer/core/src/consensus/consensus_constants.rs
+++ b/base_layer/core/src/consensus/consensus_constants.rs
@@ -37,11 +37,7 @@ use crate::{
     transactions::{
         tari_amount::{uT, MicroMinotari},
         transaction_components::{
-            OutputFeaturesVersion,
-            OutputType,
-            RangeProofType,
-            TransactionInputVersion,
-            TransactionKernelVersion,
+            OutputFeaturesVersion, OutputType, RangeProofType, TransactionInputVersion, TransactionKernelVersion,
             TransactionOutputVersion,
         },
         weight::TransactionWeight,
@@ -245,6 +241,13 @@ impl ConsensusConstants {
         self.proof_of_work.len() as u64
     }
 
+    // Should only be used in tests
+    pub fn set_pow_target_block_interval(&mut self, pow_algo: PowAlgorithm, target_time: u64) {
+        if let Some(v) = self.proof_of_work.get_mut(&pow_algo) {
+            v.target_time = target_time;
+        }
+    }
+
     /// The target time used by the difficulty adjustment algorithms, their target time is the target block interval /
     /// algo block percentage
     pub fn pow_target_block_interval(&self, pow_algo: PowAlgorithm) -> u64 {
@@ -362,16 +365,22 @@ impl ConsensusConstants {
     pub fn localnet() -> Vec<Self> {
         let difficulty_block_window = 90;
         let mut algos = HashMap::new();
-        algos.insert(PowAlgorithm::Sha3x, PowAlgorithmConstants {
-            min_difficulty: Difficulty::min(),
-            max_difficulty: Difficulty::min(),
-            target_time: 240,
-        });
-        algos.insert(PowAlgorithm::RandomX, PowAlgorithmConstants {
-            min_difficulty: Difficulty::min(),
-            max_difficulty: Difficulty::min(),
-            target_time: 240,
-        });
+        algos.insert(
+            PowAlgorithm::Sha3x,
+            PowAlgorithmConstants {
+                min_difficulty: Difficulty::min(),
+                max_difficulty: Difficulty::min(),
+                target_time: 240,
+            },
+        );
+        algos.insert(
+            PowAlgorithm::RandomX,
+            PowAlgorithmConstants {
+                min_difficulty: Difficulty::min(),
+                max_difficulty: Difficulty::min(),
+                target_time: 240,
+            },
+        );
         let (input_version_range, output_version_range, kernel_version_range) = version_zero();
         let consensus_constants = vec![ConsensusConstants {
             effective_from_height: 0,
@@ -421,18 +430,24 @@ impl ConsensusConstants {
         let future_time_limit = target_time * difficulty_block_window / 20;
 
         let mut algos = HashMap::new();
-        algos.insert(PowAlgorithm::Sha3x, PowAlgorithmConstants {
-            // (target_time x 200_000/3) ... for easy testing
-            min_difficulty: Difficulty::from_u64(sha3x_target_time * 67_000).expect("valid difficulty"),
-            max_difficulty: Difficulty::max(),
-            target_time: sha3x_target_time,
-        });
-        algos.insert(PowAlgorithm::RandomX, PowAlgorithmConstants {
-            // (target_time x 300/3)     ... for easy testing
-            min_difficulty: Difficulty::from_u64(randomx_target_time * 100).expect("valid difficulty"),
-            max_difficulty: Difficulty::max(),
-            target_time: randomx_target_time,
-        });
+        algos.insert(
+            PowAlgorithm::Sha3x,
+            PowAlgorithmConstants {
+                // (target_time x 200_000/3) ... for easy testing
+                min_difficulty: Difficulty::from_u64(sha3x_target_time * 67_000).expect("valid difficulty"),
+                max_difficulty: Difficulty::max(),
+                target_time: sha3x_target_time,
+            },
+        );
+        algos.insert(
+            PowAlgorithm::RandomX,
+            PowAlgorithmConstants {
+                // (target_time x 300/3)     ... for easy testing
+                min_difficulty: Difficulty::from_u64(randomx_target_time * 100).expect("valid difficulty"),
+                max_difficulty: Difficulty::max(),
+                target_time: randomx_target_time,
+            },
+        );
         let (input_version_range, output_version_range, kernel_version_range) = version_zero();
         let consensus_constants = vec![ConsensusConstants {
             effective_from_height: 0,
@@ -483,16 +498,22 @@ impl ConsensusConstants {
     /// * Coinbase lock height - 12 hours = 360 blocks
     pub fn esmeralda() -> Vec<Self> {
         let mut algos = HashMap::new();
-        algos.insert(PowAlgorithm::Sha3x, PowAlgorithmConstants {
-            min_difficulty: Difficulty::from_u64(60_000_000).expect("valid difficulty"),
-            max_difficulty: Difficulty::max(),
-            target_time: 60,
-        });
-        algos.insert(PowAlgorithm::RandomX, PowAlgorithmConstants {
-            min_difficulty: Difficulty::from_u64(60_000).expect("valid difficulty"),
-            max_difficulty: Difficulty::max(),
-            target_time: 60,
-        });
+        algos.insert(
+            PowAlgorithm::Sha3x,
+            PowAlgorithmConstants {
+                min_difficulty: Difficulty::from_u64(60_000_000).expect("valid difficulty"),
+                max_difficulty: Difficulty::max(),
+                target_time: 60,
+            },
+        );
+        algos.insert(
+            PowAlgorithm::RandomX,
+            PowAlgorithmConstants {
+                min_difficulty: Difficulty::from_u64(60_000).expect("valid difficulty"),
+                max_difficulty: Difficulty::max(),
+                target_time: 60,
+            },
+        );
         let (input_version_range, output_version_range, kernel_version_range) = version_zero();
         let consensus_constants1 = ConsensusConstants {
             effective_from_height: 0,
@@ -540,16 +561,22 @@ impl ConsensusConstants {
     /// * Coinbase lock height - 12 hours = 360 blocks
     pub fn stagenet() -> Vec<Self> {
         let mut algos = HashMap::new();
-        algos.insert(PowAlgorithm::Sha3x, PowAlgorithmConstants {
-            min_difficulty: Difficulty::from_u64(450_000_000_000).expect("valid difficulty"),
-            max_difficulty: Difficulty::max(),
-            target_time: 240,
-        });
-        algos.insert(PowAlgorithm::RandomX, PowAlgorithmConstants {
-            min_difficulty: Difficulty::from_u64(1_200_000).expect("valid difficulty"),
-            max_difficulty: Difficulty::max(),
-            target_time: 240,
-        });
+        algos.insert(
+            PowAlgorithm::Sha3x,
+            PowAlgorithmConstants {
+                min_difficulty: Difficulty::from_u64(450_000_000_000).expect("valid difficulty"),
+                max_difficulty: Difficulty::max(),
+                target_time: 240,
+            },
+        );
+        algos.insert(
+            PowAlgorithm::RandomX,
+            PowAlgorithmConstants {
+                min_difficulty: Difficulty::from_u64(1_200_000).expect("valid difficulty"),
+                max_difficulty: Difficulty::max(),
+                target_time: 240,
+            },
+        );
         let (input_version_range, output_version_range, kernel_version_range) = version_zero();
         let consensus_constants = vec![ConsensusConstants {
             effective_from_height: 0,
@@ -590,16 +617,22 @@ impl ConsensusConstants {
 
     pub fn nextnet() -> Vec<Self> {
         let mut algos = HashMap::new();
-        algos.insert(PowAlgorithm::Sha3x, PowAlgorithmConstants {
-            min_difficulty: Difficulty::from_u64(150_000_000_000).expect("valid difficulty"),
-            max_difficulty: Difficulty::max(),
-            target_time: 240,
-        });
-        algos.insert(PowAlgorithm::RandomX, PowAlgorithmConstants {
-            min_difficulty: Difficulty::from_u64(1_200_000).expect("valid difficulty"),
-            max_difficulty: Difficulty::max(),
-            target_time: 240,
-        });
+        algos.insert(
+            PowAlgorithm::Sha3x,
+            PowAlgorithmConstants {
+                min_difficulty: Difficulty::from_u64(150_000_000_000).expect("valid difficulty"),
+                max_difficulty: Difficulty::max(),
+                target_time: 240,
+            },
+        );
+        algos.insert(
+            PowAlgorithm::RandomX,
+            PowAlgorithmConstants {
+                min_difficulty: Difficulty::from_u64(1_200_000).expect("valid difficulty"),
+                max_difficulty: Difficulty::max(),
+                target_time: 240,
+            },
+        );
         let (input_version_range, output_version_range, kernel_version_range) = version_zero();
         let con_1 = ConsensusConstants {
             effective_from_height: 0,
@@ -647,16 +680,22 @@ impl ConsensusConstants {
     pub fn mainnet() -> Vec<Self> {
         let difficulty_block_window = 90;
         let mut algos = HashMap::new();
-        algos.insert(PowAlgorithm::Sha3x, PowAlgorithmConstants {
-            min_difficulty: Difficulty::from_u64(450_000_000_000).expect("valid difficulty"),
-            max_difficulty: Difficulty::max(),
-            target_time: 240,
-        });
-        algos.insert(PowAlgorithm::RandomX, PowAlgorithmConstants {
-            min_difficulty: Difficulty::from_u64(1_200_000).expect("valid difficulty"),
-            max_difficulty: Difficulty::max(),
-            target_time: 240,
-        });
+        algos.insert(
+            PowAlgorithm::Sha3x,
+            PowAlgorithmConstants {
+                min_difficulty: Difficulty::from_u64(450_000_000_000).expect("valid difficulty"),
+                max_difficulty: Difficulty::max(),
+                target_time: 240,
+            },
+        );
+        algos.insert(
+            PowAlgorithm::RandomX,
+            PowAlgorithmConstants {
+                min_difficulty: Difficulty::from_u64(1_200_000).expect("valid difficulty"),
+                max_difficulty: Difficulty::max(),
+                target_time: 240,
+            },
+        );
         let (input_version_range, output_version_range, kernel_version_range) = version_zero();
         let consensus_constants = vec![ConsensusConstants {
             effective_from_height: 0,
@@ -702,14 +741,15 @@ impl ConsensusConstants {
     const fn current_permitted_range_proof_types() -> [(OutputType, &'static [RangeProofType]); 5] {
         [
             (OutputType::Standard, &[RangeProofType::BulletProofPlus]),
-            (OutputType::Coinbase, &[
-                RangeProofType::BulletProofPlus,
-                RangeProofType::RevealedValue,
-            ]),
+            (
+                OutputType::Coinbase,
+                &[RangeProofType::BulletProofPlus, RangeProofType::RevealedValue],
+            ),
             (OutputType::Burn, &[RangeProofType::BulletProofPlus]),
-            (OutputType::ValidatorNodeRegistration, &[
-                RangeProofType::BulletProofPlus,
-            ]),
+            (
+                OutputType::ValidatorNodeRegistration,
+                &[RangeProofType::BulletProofPlus],
+            ),
             (OutputType::CodeTemplateRegistration, &[RangeProofType::BulletProofPlus]),
         ]
     }

--- a/base_layer/core/src/test_helpers/blockchain.rs
+++ b/base_layer/core/src/test_helpers/blockchain.rs
@@ -26,12 +26,19 @@ use std::{
     path::{Path, PathBuf},
     sync::Arc,
 };
+use tari_utilities::ByteArray;
 
+use jmt::{
+    mock::MockTreeStore,
+    restore::JellyfishMerkleRestore,
+    storage::{TreeReader, TreeUpdateBatch, TreeWriter},
+    JellyfishMerkleTree, KeyHash,
+};
 use tari_common::configuration::Network;
 use tari_common_types::{
     chain_metadata::ChainMetadata,
     tari_address::TariAddress,
-    types::{BadBlock, CompressedCommitment, CompressedPublicKey, HashOutput, Signature},
+    types::{BadBlock, CompressedCommitment, CompressedPublicKey, FixedHash, HashOutput, Signature},
 };
 use tari_storage::lmdb_store::LMDBConfig;
 use tari_test_utils::paths::create_temporary_data_path;
@@ -40,25 +47,9 @@ use super::{create_block, mine_to_difficulty};
 use crate::{
     blocks::{Block, BlockAccumulatedData, BlockHeader, BlockHeaderAccumulatedData, ChainBlock, ChainHeader},
     chain_storage::{
-        create_lmdb_database,
-        BlockAddResult,
-        BlockchainBackend,
-        BlockchainDatabase,
-        BlockchainDatabaseConfig,
-        ChainStorageError,
-        DbBasicStats,
-        DbKey,
-        DbTotalSizeStats,
-        DbTransaction,
-        DbValue,
-        HorizonData,
-        InputMinedInfo,
-        LMDBDatabase,
-        MmrTree,
-        OutputMinedInfo,
-        OwnedLmdbTreeReader,
-        Reorg,
-        TemplateRegistrationEntry,
+        create_lmdb_database, BlockAddResult, BlockchainBackend, BlockchainDatabase, BlockchainDatabaseConfig,
+        ChainStorageError, DbBasicStats, DbKey, DbTotalSizeStats, DbTransaction, DbValue, HorizonData, InputMinedInfo,
+        LMDBDatabase, MmrTree, OutputMinedInfo, OwnedLmdbTreeReader, Reorg, SmtHasher, TemplateRegistrationEntry,
         Validators,
     },
     consensus::{chain_strength_comparer::ChainStrengthComparerBuilder, ConsensusConstantsBuilder, ConsensusManager},
@@ -66,11 +57,7 @@ use crate::{
     test_helpers::{block_spec::BlockSpecs, create_consensus_rules, default_coinbase_entities, BlockSpec},
     transactions::{
         transaction_components::{
-            RangeProofType,
-            TransactionInput,
-            TransactionKernel,
-            TransactionOutput,
-            WalletOutput,
+            RangeProofType, TransactionInput, TransactionKernel, TransactionOutput, WalletOutput,
         },
         transaction_key_manager::{create_memory_db_key_manager, MemoryDbKeyManager, TariKeyId},
         CryptoFactories,
@@ -438,19 +425,57 @@ pub async fn create_chained_blocks<T: Into<BlockSpecs>, TDB: BlockchainBackend>(
     genesis_block: Arc<ChainBlock>,
 ) -> (Vec<String>, HashMap<String, Arc<ChainBlock>>) {
     let mut block_hashes = HashMap::new();
+    let gb_height = genesis_block.header().height;
     block_hashes.insert("GB".to_string(), genesis_block);
     let rules = ConsensusManager::builder(Network::LocalNet).build().unwrap();
     let km = create_memory_db_key_manager().unwrap();
     let blocks: BlockSpecs = blocks.into();
     let mut block_names = Vec::with_capacity(blocks.len());
     let (script_key_id, wallet_payment_address) = default_coinbase_entities(&km).await;
+    let mock_store = MockTreeStore::new(true);
+    // let smt_reader = db.create_smt_reader().unwrap();
+    // let restore = JellyfishMerkleRestore::<SmtHasher>::new(
+    //     mock_store,
+    //     genesis_block.header().height,
+    //     genesis_block.header().output_mr,
+    // )
+    // .unwrap();
+    let jmt = JellyfishMerkleTree::<_, SmtHasher>::new(&mock_store);
+
+    for h in 0..=gb_height {
+        let mut batch = vec![];
+        let h_block = db.fetch_block(h, false).unwrap();
+
+        for output in h_block.block().body.outputs() {
+            if !output.is_burned() {
+                let smt_key = KeyHash(output.commitment.as_bytes().try_into().expect("commitment is 32 bytes"));
+                let smt_value = output.smt_hash(h_block.block().header.height);
+                batch.push((smt_key, Some(smt_value.to_vec())));
+            }
+        }
+        for input in h_block.block().body.inputs() {
+            let smt_key = KeyHash(
+                input
+                    .commitment()
+                    .unwrap()
+                    .as_bytes()
+                    .try_into()
+                    .expect("Commitment is 32 bytes"),
+            );
+            batch.push((smt_key, None));
+        }
+        let (root, updates) = jmt.put_value_set(batch, h).unwrap();
+        mock_store.write_node_batch(&updates.node_batch).unwrap();
+        assert_eq!(root.0.as_slice(), h_block.block().header.output_mr.as_slice());
+    }
+
     for block_spec in blocks {
         let prev_block = block_hashes
             .get(block_spec.parent)
             .unwrap_or_else(|| panic!("Could not find block {}", block_spec.parent));
         let name = block_spec.name;
         let difficulty = block_spec.difficulty;
-        let (block, _) = create_block(
+        let (mut block, _) = create_block(
             db,
             &rules,
             prev_block.block(),
@@ -461,6 +486,10 @@ pub async fn create_chained_blocks<T: Into<BlockSpecs>, TDB: BlockchainBackend>(
             None,
         )
         .await;
+        let updates = update_block_and_smt(&mut block, &jmt);
+
+        mock_store.write_node_batch(&updates.node_batch).unwrap();
+
         let block = mine_block(block, prev_block.accumulated_data(), difficulty);
         block_names.push(name.to_string());
         block_hashes.insert(name.to_string(), block);
@@ -514,6 +543,37 @@ pub async fn create_orphan_chain<T: Into<BlockSpecs>>(
     db.write(txn).unwrap();
 
     (names, chain)
+}
+
+pub fn update_block_and_smt<T: TreeReader>(
+    block: &mut Block,
+    jmt: &JellyfishMerkleTree<T, SmtHasher>,
+) -> TreeUpdateBatch {
+    // let jmt = JellyfishMerkleTree::<_, SmtHasher>::new(smt_reader);
+    let mut batch = vec![];
+    for output in block.body.outputs() {
+        if !output.is_burned() {
+            let smt_key = KeyHash(output.commitment.as_bytes().try_into().expect("commitment is 32 bytes"));
+            let smt_value = output.smt_hash(block.header.height);
+
+            batch.push((smt_key, Some(smt_value.to_vec())));
+        }
+    }
+    for input in block.body.inputs() {
+        let smt_key = KeyHash(
+            input
+                .commitment()
+                .unwrap()
+                .as_bytes()
+                .try_into()
+                .expect("Commitment is 32 bytes"),
+        );
+        batch.push((smt_key, None));
+    }
+    let (root, updates) = jmt.put_value_set(batch, block.header.height).unwrap();
+    // let root = FixedHash::try_from(smt.hash().as_slice()).unwrap();
+    block.header.output_mr = FixedHash::try_from(root.0.as_slice()).unwrap();
+    updates
 }
 
 pub struct TestBlockchain {

--- a/base_layer/core/src/test_helpers/blockchain.rs
+++ b/base_layer/core/src/test_helpers/blockchain.rs
@@ -29,7 +29,6 @@ use std::{
 
 use jmt::{
     mock::MockTreeStore,
-    restore::JellyfishMerkleRestore,
     storage::{TreeReader, TreeUpdateBatch, TreeWriter},
     JellyfishMerkleTree,
     KeyHash,

--- a/base_layer/core/src/test_helpers/blockchain.rs
+++ b/base_layer/core/src/test_helpers/blockchain.rs
@@ -26,13 +26,13 @@ use std::{
     path::{Path, PathBuf},
     sync::Arc,
 };
-use tari_utilities::ByteArray;
 
 use jmt::{
     mock::MockTreeStore,
     restore::JellyfishMerkleRestore,
     storage::{TreeReader, TreeUpdateBatch, TreeWriter},
-    JellyfishMerkleTree, KeyHash,
+    JellyfishMerkleTree,
+    KeyHash,
 };
 use tari_common::configuration::Network;
 use tari_common_types::{
@@ -42,14 +42,32 @@ use tari_common_types::{
 };
 use tari_storage::lmdb_store::LMDBConfig;
 use tari_test_utils::paths::create_temporary_data_path;
+use tari_utilities::ByteArray;
 
 use super::{create_block, mine_to_difficulty};
 use crate::{
     blocks::{Block, BlockAccumulatedData, BlockHeader, BlockHeaderAccumulatedData, ChainBlock, ChainHeader},
     chain_storage::{
-        create_lmdb_database, BlockAddResult, BlockchainBackend, BlockchainDatabase, BlockchainDatabaseConfig,
-        ChainStorageError, DbBasicStats, DbKey, DbTotalSizeStats, DbTransaction, DbValue, HorizonData, InputMinedInfo,
-        LMDBDatabase, MmrTree, OutputMinedInfo, OwnedLmdbTreeReader, Reorg, SmtHasher, TemplateRegistrationEntry,
+        create_lmdb_database,
+        BlockAddResult,
+        BlockchainBackend,
+        BlockchainDatabase,
+        BlockchainDatabaseConfig,
+        ChainStorageError,
+        DbBasicStats,
+        DbKey,
+        DbTotalSizeStats,
+        DbTransaction,
+        DbValue,
+        HorizonData,
+        InputMinedInfo,
+        LMDBDatabase,
+        MmrTree,
+        OutputMinedInfo,
+        OwnedLmdbTreeReader,
+        Reorg,
+        SmtHasher,
+        TemplateRegistrationEntry,
         Validators,
     },
     consensus::{chain_strength_comparer::ChainStrengthComparerBuilder, ConsensusConstantsBuilder, ConsensusManager},
@@ -57,7 +75,11 @@ use crate::{
     test_helpers::{block_spec::BlockSpecs, create_consensus_rules, default_coinbase_entities, BlockSpec},
     transactions::{
         transaction_components::{
-            RangeProofType, TransactionInput, TransactionKernel, TransactionOutput, WalletOutput,
+            RangeProofType,
+            TransactionInput,
+            TransactionKernel,
+            TransactionOutput,
+            WalletOutput,
         },
         transaction_key_manager::{create_memory_db_key_manager, MemoryDbKeyManager, TariKeyId},
         CryptoFactories,

--- a/base_layer/core/src/test_helpers/mod.rs
+++ b/base_layer/core/src/test_helpers/mod.rs
@@ -146,7 +146,7 @@ pub async fn create_block<TDB: BlockchainBackend>(
         .timestamp
         .checked_add(EpochTime::from(spec.block_time))
         .unwrap();
-    // let mut block = apply_mmr_to_block(db, block);
+    let mut block = apply_mmr_to_block(db, block);
 
     block.header.output_smt_size = prev_block.header.output_smt_size + block.body.outputs().len() as u64;
     block.header.kernel_mmr_size = prev_block.header.kernel_mmr_size + block.body.kernels().len() as u64;
@@ -154,17 +154,25 @@ pub async fn create_block<TDB: BlockchainBackend>(
     (block, coinbase_wallet_output)
 }
 
-// pub fn apply_mmr_to_block<TDB: BlockchainBackend>(db: &BlockchainDatabase<TDB>, block: Block) -> Block {
-//     let (mut block, mmr_roots) = db.calculate_mmr_roots(block).unwrap();
-//     block.header.input_mr = mmr_roots.input_mr;
-//     block.header.output_mr = mmr_roots.output_mr;
-//     block.header.output_smt_size = mmr_roots.output_smt_size;
-//     block.header.kernel_mr = mmr_roots.kernel_mr;
-//     block.header.kernel_mmr_size = mmr_roots.kernel_mmr_size;
-//     block.header.validator_node_mr = mmr_roots.validator_node_mr;
-//     block.header.validator_node_size = mmr_roots.validator_node_size;
-//     block
-// }
+pub fn apply_mmr_to_block<TDB: BlockchainBackend>(db: &BlockchainDatabase<TDB>, block: Block) -> Block {
+    let res = block.clone();
+    let (mut block, mmr_roots) = match db.calculate_mmr_roots(block) {
+        Ok(mmr_roots) => mmr_roots,
+        Err(e) => {
+            // Sometimes the block is not at the tip, so we can't calculate the MMR roots.
+            // Tests should set the mmr elsewhere.
+            return res;
+        },
+    };
+    //     block.header.input_mr = mmr_roots.input_mr;
+    block.header.output_mr = mmr_roots.output_mr;
+    //     block.header.output_smt_size = mmr_roots.output_smt_size;
+    //     block.header.kernel_mr = mmr_roots.kernel_mr;
+    //     block.header.kernel_mmr_size = mmr_roots.kernel_mmr_size;
+    //     block.header.validator_node_mr = mmr_roots.validator_node_mr;
+    //     block.header.validator_node_size = mmr_roots.validator_node_size;
+    block
+}
 
 pub fn mine_to_difficulty(mut block: Block, difficulty: Difficulty) -> Result<Block, String> {
     // When starting from the same nonce, in tests it becomes common to mine the same block more than once without the

--- a/base_layer/core/src/test_helpers/mod.rs
+++ b/base_layer/core/src/test_helpers/mod.rs
@@ -158,7 +158,7 @@ pub fn apply_mmr_to_block<TDB: BlockchainBackend>(db: &BlockchainDatabase<TDB>, 
     let res = block.clone();
     let (mut block, mmr_roots) = match db.calculate_mmr_roots(block) {
         Ok(mmr_roots) => mmr_roots,
-        Err(e) => {
+        Err(_) => {
             // Sometimes the block is not at the tip, so we can't calculate the MMR roots.
             // Tests should set the mmr elsewhere.
             return res;

--- a/base_layer/core/src/test_helpers/mod.rs
+++ b/base_layer/core/src/test_helpers/mod.rs
@@ -146,7 +146,7 @@ pub async fn create_block<TDB: BlockchainBackend>(
         .timestamp
         .checked_add(EpochTime::from(spec.block_time))
         .unwrap();
-    let mut block = apply_mmr_to_block(db, block);
+    // let mut block = apply_mmr_to_block(db, block);
 
     block.header.output_smt_size = prev_block.header.output_smt_size + block.body.outputs().len() as u64;
     block.header.kernel_mmr_size = prev_block.header.kernel_mmr_size + block.body.kernels().len() as u64;
@@ -154,17 +154,17 @@ pub async fn create_block<TDB: BlockchainBackend>(
     (block, coinbase_wallet_output)
 }
 
-pub fn apply_mmr_to_block<TDB: BlockchainBackend>(db: &BlockchainDatabase<TDB>, block: Block) -> Block {
-    let (mut block, mmr_roots) = db.calculate_mmr_roots(block).unwrap();
-    block.header.input_mr = mmr_roots.input_mr;
-    block.header.output_mr = mmr_roots.output_mr;
-    block.header.output_smt_size = mmr_roots.output_smt_size;
-    block.header.kernel_mr = mmr_roots.kernel_mr;
-    block.header.kernel_mmr_size = mmr_roots.kernel_mmr_size;
-    block.header.validator_node_mr = mmr_roots.validator_node_mr;
-    block.header.validator_node_size = mmr_roots.validator_node_size;
-    block
-}
+// pub fn apply_mmr_to_block<TDB: BlockchainBackend>(db: &BlockchainDatabase<TDB>, block: Block) -> Block {
+//     let (mut block, mmr_roots) = db.calculate_mmr_roots(block).unwrap();
+//     block.header.input_mr = mmr_roots.input_mr;
+//     block.header.output_mr = mmr_roots.output_mr;
+//     block.header.output_smt_size = mmr_roots.output_smt_size;
+//     block.header.kernel_mr = mmr_roots.kernel_mr;
+//     block.header.kernel_mmr_size = mmr_roots.kernel_mmr_size;
+//     block.header.validator_node_mr = mmr_roots.validator_node_mr;
+//     block.header.validator_node_size = mmr_roots.validator_node_size;
+//     block
+// }
 
 pub fn mine_to_difficulty(mut block: Block, difficulty: Difficulty) -> Result<Block, String> {
     // When starting from the same nonce, in tests it becomes common to mine the same block more than once without the

--- a/base_layer/core/src/validation/test.rs
+++ b/base_layer/core/src/validation/test.rs
@@ -20,16 +20,17 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use jmt::{mock::MockTreeStore, JellyfishMerkleTree, KeyHash};
 use std::{cmp, sync::Arc};
-
 use tari_common::configuration::Network;
 use tari_common_types::types::{CompressedCommitment, UncompressedCommitment};
 use tari_script::TariScript;
 use tari_test_utils::unpack_enum;
+use tari_utilities::ByteArray;
 
 use crate::{
     blocks::{BlockHeader, BlockHeaderAccumulatedData, ChainBlock, ChainHeader},
-    chain_storage::{BlockchainBackend, BlockchainDatabase, ChainStorageError, DbTransaction},
+    chain_storage::{BlockchainBackend, BlockchainDatabase, ChainStorageError, DbTransaction, SmtHasher},
     consensus::{ConsensusConstantsBuilder, ConsensusManager, ConsensusManagerBuilder},
     covenants::Covenant,
     proof_of_work::AchievedTargetDifficulty,
@@ -118,9 +119,10 @@ mod header_validators {
         let err = validator
             .validate(&*db.db_read_access().unwrap(), &header, genesis.header(), &[], None)
             .unwrap_err();
-        assert!(matches!(err, ValidationError::InvalidBlockchainVersion {
-            version: u16::MAX
-        }));
+        assert!(matches!(
+            err,
+            ValidationError::InvalidBlockchainVersion { version: u16::MAX }
+        ));
     }
 
     #[tokio::test]
@@ -158,10 +160,10 @@ mod header_validators {
                 None,
             )
             .unwrap_err();
-        assert!(matches!(err, ValidationError::IncorrectNumberOfTimestampsProvided {
-            actual: 5,
-            expected: 4
-        }));
+        assert!(matches!(
+            err,
+            ValidationError::IncorrectNumberOfTimestampsProvided { actual: 5, expected: 4 }
+        ));
     }
 }
 
@@ -200,16 +202,39 @@ async fn chain_balance_validation() {
     let mut utxo_sum = UncompressedCommitment::default();
     let mut kernel_sum = UncompressedCommitment::default();
     let burned_sum = UncompressedCommitment::default();
+    let mock_store = MockTreeStore::new(true);
+    let smt = JellyfishMerkleTree::<_, SmtHasher>::new(&mock_store);
+    let mut batch = vec![];
     for output in gen_block.body.outputs() {
         utxo_sum = &output.commitment.to_commitment().unwrap() + &utxo_sum;
+        let smt_key = KeyHash(output.commitment.as_bytes().try_into().expect("commitment is 32 bytes"));
+        let smt_value = output.smt_hash(0);
+
+        batch.push((smt_key, Some(smt_value.to_vec())));
     }
     for input in gen_block.body.inputs() {
         utxo_sum = &utxo_sum - &input.commitment().unwrap().to_commitment().unwrap();
+        let smt_key = KeyHash(
+            input
+                .commitment()
+                .unwrap()
+                .as_bytes()
+                .try_into()
+                .expect("Commitment is 32 bytes"),
+        );
+        batch.push((smt_key, None));
     }
     for kernel in gen_block.body.kernels() {
         kernel_sum = &kernel.excess.to_commitment().unwrap() + &kernel_sum;
     }
-    let genesis = ChainBlock::try_construct(Arc::new(gen_block), genesis.accumulated_data().clone()).unwrap();
+    let root = smt.put_value_set(batch, 0).unwrap();
+
+    gen_block.header.output_mr = root.0 .0.try_into().expect("Output MMR root is 32 bytes");
+    let mut accum = genesis.accumulated_data().clone();
+    accum.hash = gen_block.header.hash();
+
+    let genesis = ChainBlock::try_construct(Arc::new(gen_block), accum).unwrap();
+
     let total_pre_mine = pre_mine_value + consensus_manager.consensus_constants(0).pre_mine_value();
     let constants = ConsensusConstantsBuilder::new(Network::LocalNet)
         .with_consensus_constants(consensus_manager.consensus_constants(0).clone())

--- a/base_layer/core/src/validation/test.rs
+++ b/base_layer/core/src/validation/test.rs
@@ -20,8 +20,9 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use jmt::{mock::MockTreeStore, JellyfishMerkleTree, KeyHash};
 use std::{cmp, sync::Arc};
+
+use jmt::{mock::MockTreeStore, JellyfishMerkleTree, KeyHash};
 use tari_common::configuration::Network;
 use tari_common_types::types::{CompressedCommitment, UncompressedCommitment};
 use tari_script::TariScript;
@@ -119,10 +120,9 @@ mod header_validators {
         let err = validator
             .validate(&*db.db_read_access().unwrap(), &header, genesis.header(), &[], None)
             .unwrap_err();
-        assert!(matches!(
-            err,
-            ValidationError::InvalidBlockchainVersion { version: u16::MAX }
-        ));
+        assert!(matches!(err, ValidationError::InvalidBlockchainVersion {
+            version: u16::MAX
+        }));
     }
 
     #[tokio::test]
@@ -160,10 +160,10 @@ mod header_validators {
                 None,
             )
             .unwrap_err();
-        assert!(matches!(
-            err,
-            ValidationError::IncorrectNumberOfTimestampsProvided { actual: 5, expected: 4 }
-        ));
+        assert!(matches!(err, ValidationError::IncorrectNumberOfTimestampsProvided {
+            actual: 5,
+            expected: 4
+        }));
     }
 }
 

--- a/base_layer/core/tests/helpers/block_builders.rs
+++ b/base_layer/core/tests/helpers/block_builders.rs
@@ -37,12 +37,22 @@ use tari_core::{
         tari_amount::MicroMinotari,
         test_helpers::{create_wallet_output_with_data, spend_utxos, TestParams, TransactionSchema},
         transaction_components::{
-            CoinBaseExtra, KernelBuilder, KernelFeatures, OutputFeatures, RangeProofType, Transaction,
-            TransactionKernel, TransactionKernelVersion, TransactionOutput, WalletOutput,
+            CoinBaseExtra,
+            KernelBuilder,
+            KernelFeatures,
+            OutputFeatures,
+            RangeProofType,
+            Transaction,
+            TransactionKernel,
+            TransactionKernelVersion,
+            TransactionOutput,
+            WalletOutput,
         },
         transaction_key_manager::{MemoryDbKeyManager, TransactionKeyManagerInterface, TxoStage},
     },
-    KernelMmr, OutputSmt, PrunedOutputMmr,
+    KernelMmr,
+    OutputSmt,
+    PrunedOutputMmr,
 };
 use tari_mmr::{
     pruned_hashset::PrunedHashSet,
@@ -192,18 +202,15 @@ pub async fn create_genesis_block_with_coinbase_value(
     find_header_with_achieved_difficulty(&mut block.header, Difficulty::from_u64(1).unwrap());
     let hash = block.hash();
     (
-        ChainBlock::try_construct(
-            block.into(),
-            BlockHeaderAccumulatedData {
-                hash,
-                total_kernel_offset: Default::default(),
-                achieved_difficulty: Difficulty::min(),
-                total_accumulated_difficulty: 1.into(),
-                accumulated_randomx_difficulty: AccumulatedDifficulty::min(),
-                accumulated_sha3x_difficulty: AccumulatedDifficulty::min(),
-                target_difficulty: Difficulty::min(),
-            },
-        )
+        ChainBlock::try_construct(block.into(), BlockHeaderAccumulatedData {
+            hash,
+            total_kernel_offset: Default::default(),
+            achieved_difficulty: Difficulty::min(),
+            total_accumulated_difficulty: 1.into(),
+            accumulated_randomx_difficulty: AccumulatedDifficulty::min(),
+            accumulated_sha3x_difficulty: AccumulatedDifficulty::min(),
+            target_difficulty: Difficulty::min(),
+        })
         .unwrap(),
         output,
     )
@@ -236,18 +243,15 @@ pub async fn create_genesis_block_with_utxos(
     find_header_with_achieved_difficulty(&mut block.header, Difficulty::from_u64(1).unwrap());
     let hash = block.hash();
     (
-        ChainBlock::try_construct(
-            block.into(),
-            BlockHeaderAccumulatedData {
-                hash,
-                total_kernel_offset: Default::default(),
-                achieved_difficulty: Difficulty::min(),
-                total_accumulated_difficulty: 1.into(),
-                accumulated_randomx_difficulty: AccumulatedDifficulty::min(),
-                accumulated_sha3x_difficulty: AccumulatedDifficulty::min(),
-                target_difficulty: Difficulty::min(),
-            },
-        )
+        ChainBlock::try_construct(block.into(), BlockHeaderAccumulatedData {
+            hash,
+            total_kernel_offset: Default::default(),
+            achieved_difficulty: Difficulty::min(),
+            total_accumulated_difficulty: 1.into(),
+            accumulated_randomx_difficulty: AccumulatedDifficulty::min(),
+            accumulated_sha3x_difficulty: AccumulatedDifficulty::min(),
+            target_difficulty: Difficulty::min(),
+        })
         .unwrap(),
         outputs,
     )

--- a/base_layer/core/tests/helpers/block_builders.rs
+++ b/base_layer/core/tests/helpers/block_builders.rs
@@ -21,6 +21,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 use std::{convert::TryFrom, sync::Arc};
 
+use jmt::{mock::MockTreeStore, JellyfishMerkleTree, KeyHash};
 use rand::{rngs::OsRng, RngCore};
 use tari_common_types::{
     key_branches::TransactionKeyManagerBranch,
@@ -28,7 +29,7 @@ use tari_common_types::{
 };
 use tari_core::{
     blocks::{Block, BlockHeader, BlockHeaderAccumulatedData, ChainBlock, ChainHeader, NewBlockTemplate},
-    chain_storage::{BlockAddResult, BlockchainBackend, BlockchainDatabase, ChainStorageError},
+    chain_storage::{BlockAddResult, BlockchainBackend, BlockchainDatabase, ChainStorageError, SmtHasher},
     consensus::{emission::Emission, ConsensusConstants, ConsensusManager},
     kernel_mr_hash_from_mmr,
     proof_of_work::{sha3x_difficulty, AccumulatedDifficulty, AchievedTargetDifficulty, Difficulty},
@@ -36,22 +37,12 @@ use tari_core::{
         tari_amount::MicroMinotari,
         test_helpers::{create_wallet_output_with_data, spend_utxos, TestParams, TransactionSchema},
         transaction_components::{
-            CoinBaseExtra,
-            KernelBuilder,
-            KernelFeatures,
-            OutputFeatures,
-            RangeProofType,
-            Transaction,
-            TransactionKernel,
-            TransactionKernelVersion,
-            TransactionOutput,
-            WalletOutput,
+            CoinBaseExtra, KernelBuilder, KernelFeatures, OutputFeatures, RangeProofType, Transaction,
+            TransactionKernel, TransactionKernelVersion, TransactionOutput, WalletOutput,
         },
         transaction_key_manager::{MemoryDbKeyManager, TransactionKeyManagerInterface, TxoStage},
     },
-    KernelMmr,
-    OutputSmt,
-    PrunedOutputMmr,
+    KernelMmr, OutputSmt, PrunedOutputMmr,
 };
 use tari_mmr::{
     pruned_hashset::PrunedHashSet,
@@ -169,17 +160,23 @@ fn update_genesis_block_mmr_roots(template: NewBlockTemplate) -> Result<Block, C
     let mut header = BlockHeader::from(header);
     let kernel_mmr = KernelMmr::new(kernel_hashes);
     header.kernel_mr = kernel_mr_hash_from_mmr(&kernel_mmr)?;
-    let mut mmr = OutputSmt::new();
+    let mock_store = MockTreeStore::new(true);
+    let jmt = JellyfishMerkleTree::<_, SmtHasher>::new(&mock_store);
     let mut output_mr = PrunedOutputMmr::new(PrunedHashSet::default());
+    let mut batch = vec![];
     for output in body.outputs() {
         output_mr.push(output.hash().to_vec()).unwrap();
-        let smt_key = NodeKey::try_from(output.commitment.as_bytes())?;
-        let smt_node = ValueHash::try_from(output.smt_hash(header.height).as_slice())?;
-        mmr.insert(smt_key, smt_node).unwrap();
+        if !output.is_burned() {
+            let smt_key = KeyHash(output.commitment.as_bytes().try_into().expect("commitment is 32 bytes"));
+            let smt_value = output.smt_hash(header.height);
+
+            batch.push((smt_key, Some(smt_value.to_vec())));
+        }
     }
     header.output_smt_size = body.outputs().len() as u64;
 
-    header.output_mr = FixedHash::try_from(mmr.hash().as_slice()).unwrap();
+    let (root, _) = jmt.put_value_set(batch, 0).unwrap();
+    header.output_mr = FixedHash::try_from(root.0.as_slice()).unwrap();
     header.block_output_mr = FixedHash::try_from(output_mr.get_merkle_root().unwrap()).unwrap();
     Ok(Block { header, body })
 }
@@ -195,15 +192,18 @@ pub async fn create_genesis_block_with_coinbase_value(
     find_header_with_achieved_difficulty(&mut block.header, Difficulty::from_u64(1).unwrap());
     let hash = block.hash();
     (
-        ChainBlock::try_construct(block.into(), BlockHeaderAccumulatedData {
-            hash,
-            total_kernel_offset: Default::default(),
-            achieved_difficulty: Difficulty::min(),
-            total_accumulated_difficulty: 1.into(),
-            accumulated_randomx_difficulty: AccumulatedDifficulty::min(),
-            accumulated_sha3x_difficulty: AccumulatedDifficulty::min(),
-            target_difficulty: Difficulty::min(),
-        })
+        ChainBlock::try_construct(
+            block.into(),
+            BlockHeaderAccumulatedData {
+                hash,
+                total_kernel_offset: Default::default(),
+                achieved_difficulty: Difficulty::min(),
+                total_accumulated_difficulty: 1.into(),
+                accumulated_randomx_difficulty: AccumulatedDifficulty::min(),
+                accumulated_sha3x_difficulty: AccumulatedDifficulty::min(),
+                target_difficulty: Difficulty::min(),
+            },
+        )
         .unwrap(),
         output,
     )
@@ -236,15 +236,18 @@ pub async fn create_genesis_block_with_utxos(
     find_header_with_achieved_difficulty(&mut block.header, Difficulty::from_u64(1).unwrap());
     let hash = block.hash();
     (
-        ChainBlock::try_construct(block.into(), BlockHeaderAccumulatedData {
-            hash,
-            total_kernel_offset: Default::default(),
-            achieved_difficulty: Difficulty::min(),
-            total_accumulated_difficulty: 1.into(),
-            accumulated_randomx_difficulty: AccumulatedDifficulty::min(),
-            accumulated_sha3x_difficulty: AccumulatedDifficulty::min(),
-            target_difficulty: Difficulty::min(),
-        })
+        ChainBlock::try_construct(
+            block.into(),
+            BlockHeaderAccumulatedData {
+                hash,
+                total_kernel_offset: Default::default(),
+                achieved_difficulty: Difficulty::min(),
+                total_accumulated_difficulty: 1.into(),
+                accumulated_randomx_difficulty: AccumulatedDifficulty::min(),
+                accumulated_sha3x_difficulty: AccumulatedDifficulty::min(),
+                target_difficulty: Difficulty::min(),
+            },
+        )
         .unwrap(),
         outputs,
     )

--- a/base_layer/core/tests/helpers/block_builders.rs
+++ b/base_layer/core/tests/helpers/block_builders.rs
@@ -51,13 +51,9 @@ use tari_core::{
         transaction_key_manager::{MemoryDbKeyManager, TransactionKeyManagerInterface, TxoStage},
     },
     KernelMmr,
-    OutputSmt,
     PrunedOutputMmr,
 };
-use tari_mmr::{
-    pruned_hashset::PrunedHashSet,
-    sparse_merkle_tree::{NodeKey, ValueHash},
-};
+use tari_mmr::pruned_hashset::PrunedHashSet;
 use tari_script::script;
 use tari_utilities::ByteArray;
 


### PR DESCRIPTION
Restrict JMT from allowing multiple values.

This creates a new database table so will need a reset

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced unique key management for Jellyfish Merkle Tree (JMT) storage, ensuring consistent handling of unique keys during insertions and deletions.
  - Added a new LMDB database to support unique key data for JMT.
  - Expanded test helpers and blockchain tests to integrate and validate JMT state tracking and root consistency.
  - Added a method to adjust proof-of-work target block intervals for testing purposes.

- **Bug Fixes**
  - Improved error handling in test helpers to prevent panics when MMR root calculation fails.

- **Tests**
  - Added comprehensive tests for JMT integration, duplicate key handling, and tree state reversion.

- **Chores**
  - Enabled the "mocks" feature for the JMT dependency to support enhanced testing.
  - Cleaned up unused code and improved code formatting in several modules.

- **Documentation**
  - Updated inline comments to clarify test-only methods and error handling rationale.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->