### PR TITLE
fix: payment id tari address usage

### DIFF
--- a/base_layer/common_types/src/tari_address/dual_address.rs
+++ b/base_layer/common_types/src/tari_address/dual_address.rs
@@ -583,4 +583,68 @@ mod test {
             payment_id.as_slice()
         );
     }
+
+    #[test]
+    fn valid_max_payment_id() {
+        // Generate random public key
+        let mut rng = rand::thread_rng();
+        let view_key = CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut rng));
+        let spend_key = CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut rng));
+        let payment_id = vec![1u8; MAX_ENCRYPTED_DATA_SIZE + 1];
+
+        // Generate an emoji ID from the public key and ensure we recover it
+        let _emoji_id_from_public_key = DualAddress::new(
+            view_key.clone(),
+            spend_key.clone(),
+            Network::Esmeralda,
+            TariAddressFeatures::default(),
+            Some(payment_id.clone()),
+        )
+        .unwrap_err();
+        let spend_key = CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut rng));
+
+        let payment_id = vec![1u8; MAX_ENCRYPTED_DATA_SIZE];
+
+        // Generate an emoji ID from the public key and ensure we recover it
+        let emoji_id_from_public_key = DualAddress::new(
+            view_key.clone(),
+            spend_key.clone(),
+            Network::Esmeralda,
+            TariAddressFeatures::default(),
+            Some(payment_id.clone()),
+        )
+        .unwrap();
+
+        assert_eq!(emoji_id_from_public_key.public_spend_key(), &spend_key);
+        assert_eq!(
+            emoji_id_from_public_key.payment_id_user_data.as_bytes(),
+            payment_id.as_slice()
+        );
+
+        // Check the size of the corresponding emoji string
+        let emoji_string = emoji_id_from_public_key.to_emoji_string();
+        assert_eq!(emoji_string.chars().count(), TARI_ADDRESS_INTERNAL_DUAL_SIZE + 256);
+
+        let features = emoji_id_from_public_key.features();
+        assert_eq!(features, TariAddressFeatures(7));
+        // Generate an emoji ID from the emoji string and ensure we recover it
+        let emoji_id_from_emoji_string = DualAddress::from_emoji_string(&emoji_string).unwrap();
+        assert_eq!(emoji_id_from_emoji_string.to_emoji_string(), emoji_string);
+
+        // Return to the original public keys for good measure
+        assert_eq!(emoji_id_from_emoji_string.public_spend_key(), &spend_key);
+        assert_eq!(
+            emoji_id_from_emoji_string.payment_id_user_data.as_bytes(),
+            payment_id.as_slice()
+        );
+        let bas58 = emoji_id_from_emoji_string.to_base58();
+        if bas58.len() > INTERNAL_DUAL_BASE58_MAX_SIZE {
+            dbg!(bas58.len());
+            panic!("Base58 is too long");
+        }
+        if bas58.len() < INTERNAL_DUAL_BASE58_MIN_SIZE {
+            dbg!(bas58.len());
+            panic!("Base58 is too short");
+        }
+    }
 }

--- a/base_layer/common_types/src/tari_address/dual_address.rs
+++ b/base_layer/common_types/src/tari_address/dual_address.rs
@@ -601,8 +601,6 @@ mod test {
             Some(payment_id.clone()),
         )
         .unwrap_err();
-        let spend_key = CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut rng));
-
         let payment_id = vec![1u8; MAX_ENCRYPTED_DATA_SIZE];
 
         // Generate an emoji ID from the public key and ensure we recover it

--- a/base_layer/common_types/src/tari_address/mod.rs
+++ b/base_layer/common_types/src/tari_address/mod.rs
@@ -44,7 +44,7 @@ use crate::{
 pub const TARI_ADDRESS_INTERNAL_DUAL_SIZE: usize = 67; // number of bytes used for the internal representation
 pub const TARI_ADDRESS_INTERNAL_SINGLE_SIZE: usize = 35; // number of bytes used for the internal representation
 const INTERNAL_DUAL_BASE58_MIN_SIZE: usize = 89; // number of bytes used for the internal representation
-const INTERNAL_DUAL_BASE58_MAX_SIZE: usize = 441; // number of bytes used for the internal representation
+const INTERNAL_DUAL_BASE58_MAX_SIZE: usize = 443; // number of bytes used for the internal representation
 const INTERNAL_SINGLE_MIN_BASE58_SIZE: usize = 45; // number of bytes used for the internal representation
 const INTERNAL_SINGLE_MAX_BASE58_SIZE: usize = 48; // number of bytes used for the internal representation
 const MAX_ENCRYPTED_DATA_SIZE: usize = 256; // max size of the payment_id_ bytes
@@ -128,6 +128,8 @@ pub enum TariAddressError {
     CreationError(String),
     #[error("Too large payment_id")]
     PaymentIdTooLarge,
+    #[error("Payment_id not supported on single addresses")]
+    PaymentIdNotSupported,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -251,7 +253,7 @@ impl TariAddress {
                 address.add_payment_id(data)?;
                 Ok(TariAddress::Dual(address))
             },
-            TariAddress::Single(_) => Err(TariAddressError::PaymentIdTooLarge),
+            TariAddress::Single(_) => Err(TariAddressError::PaymentIdNotSupported),
         }
     }
 

--- a/base_layer/common_types/src/tari_address/mod.rs
+++ b/base_layer/common_types/src/tari_address/mod.rs
@@ -44,7 +44,7 @@ use crate::{
 pub const TARI_ADDRESS_INTERNAL_DUAL_SIZE: usize = 67; // number of bytes used for the internal representation
 pub const TARI_ADDRESS_INTERNAL_SINGLE_SIZE: usize = 35; // number of bytes used for the internal representation
 const INTERNAL_DUAL_BASE58_MIN_SIZE: usize = 89; // number of bytes used for the internal representation
-const INTERNAL_DUAL_BASE58_MAX_SIZE: usize = 91; // number of bytes used for the internal representation
+const INTERNAL_DUAL_BASE58_MAX_SIZE: usize = 441; // number of bytes used for the internal representation
 const INTERNAL_SINGLE_MIN_BASE58_SIZE: usize = 45; // number of bytes used for the internal representation
 const INTERNAL_SINGLE_MAX_BASE58_SIZE: usize = 48; // number of bytes used for the internal representation
 const MAX_ENCRYPTED_DATA_SIZE: usize = 256; // max size of the payment_id_ bytes
@@ -159,13 +159,9 @@ impl TariAddress {
         spend_key: CompressedPublicKey,
         network: Network,
         features: TariAddressFeatures,
-        payment_id_user_data: Option<Vec<u8>>,
     ) -> Result<TariAddress, TariAddressError> {
         Ok(TariAddress::Single(Box::new(SingleAddress::new(
-            spend_key,
-            network,
-            features,
-            payment_id_user_data,
+            spend_key, network, features,
         )?)))
     }
 
@@ -223,7 +219,6 @@ impl TariAddress {
                 one.public_spend_key().clone(),
                 one.network(),
                 one.features().combine_features(two.features()),
-                None,
             ),
         }
     }
@@ -231,7 +226,13 @@ impl TariAddress {
     /// Gets the bytes size of the Tari Address
     pub fn get_size(&self) -> usize {
         match self {
-            TariAddress::Dual(_) => TARI_ADDRESS_INTERNAL_DUAL_SIZE,
+            TariAddress::Dual(v) => {
+                if v.features().contains(TariAddressFeatures::PAYMENT_ID) {
+                    v.to_vec().len()
+                } else {
+                    TARI_ADDRESS_INTERNAL_DUAL_SIZE
+                }
+            },
             TariAddress::Single(_) => TARI_ADDRESS_INTERNAL_SINGLE_SIZE,
         }
     }
@@ -239,7 +240,7 @@ impl TariAddress {
     pub fn get_payment_id_bytes(&self) -> Vec<u8> {
         match self {
             TariAddress::Dual(v) => v.get_payment_id_bytes(),
-            TariAddress::Single(v) => v.get_payment_id_bytes(),
+            TariAddress::Single(_) => vec![],
         }
     }
 
@@ -250,11 +251,7 @@ impl TariAddress {
                 address.add_payment_id(data)?;
                 Ok(TariAddress::Dual(address))
             },
-            TariAddress::Single(v) => {
-                let mut address = v.clone();
-                address.add_payment_id(data)?;
-                Ok(TariAddress::Single(address))
-            },
+            TariAddress::Single(_) => Err(TariAddressError::PaymentIdTooLarge),
         }
     }
 
@@ -337,7 +334,10 @@ impl TariAddress {
     /// Construct Tari Address from bytes
     pub fn from_bytes(bytes: &[u8]) -> Result<TariAddress, TariAddressError>
     where Self: Sized {
-        if !(bytes.len() == TARI_ADDRESS_INTERNAL_SINGLE_SIZE || bytes.len() == TARI_ADDRESS_INTERNAL_DUAL_SIZE) {
+        if !(bytes.len() == TARI_ADDRESS_INTERNAL_SINGLE_SIZE ||
+            (bytes.len() >= TARI_ADDRESS_INTERNAL_DUAL_SIZE &&
+                bytes.len() <= (TARI_ADDRESS_INTERNAL_DUAL_SIZE + MAX_ENCRYPTED_DATA_SIZE)))
+        {
             return Err(TariAddressError::InvalidSize);
         }
         if bytes.len() == TARI_ADDRESS_INTERNAL_SINGLE_SIZE {
@@ -356,12 +356,14 @@ impl TariAddress {
     }
 
     /// Construct Tari Address from hex
-    pub fn from_base58(hex_str: &str) -> Result<TariAddress, TariAddressError> {
-        if hex_str.len() < INTERNAL_SINGLE_MIN_BASE58_SIZE {
+    pub fn from_base58(bas58_str: &str) -> Result<TariAddress, TariAddressError> {
+        if bas58_str.len() < INTERNAL_SINGLE_MIN_BASE58_SIZE {
             return Err(TariAddressError::InvalidSize);
         }
 
-        let (first, rest) = hex_str.split_at_checked(2).ok_or(TariAddressError::InvalidCharacter)?;
+        let (first, rest) = bas58_str
+            .split_at_checked(2)
+            .ok_or(TariAddressError::InvalidCharacter)?;
         let (network, features) = first.split_at_checked(1).ok_or(TariAddressError::InvalidCharacter)?;
         let mut result = bs58::decode(network)
             .into_vec()
@@ -374,6 +376,7 @@ impl TariAddress {
             .map_err(|_| TariAddressError::CannotRecoverPublicKey)?;
         result.append(&mut features);
         result.append(&mut rest);
+
         Self::from_bytes(result.as_slice())
     }
 
@@ -534,7 +537,6 @@ mod test {
             public_key.clone(),
             Network::Esmeralda,
             TariAddressFeatures::create_interactive_only(),
-            None,
         )
         .unwrap();
         assert_eq!(emoji_id_from_public_key.public_spend_key(), &public_key);
@@ -561,7 +563,6 @@ mod test {
             public_key.clone(),
             Network::Esmeralda,
             TariAddressFeatures::create_one_sided_only(),
-            None,
         )
         .unwrap();
         assert_eq!(emoji_id_from_public_key.public_spend_key(), &public_key);
@@ -732,7 +733,6 @@ mod test {
             public_key.clone(),
             Network::Esmeralda,
             TariAddressFeatures::create_interactive_only(),
-            None,
         )
         .unwrap();
 
@@ -778,7 +778,6 @@ mod test {
             public_key.clone(),
             Network::Esmeralda,
             TariAddressFeatures::create_one_sided_only(),
-            None,
         )
         .unwrap();
 

--- a/base_layer/common_types/src/tari_address/single_address.rs
+++ b/base_layer/common_types/src/tari_address/single_address.rs
@@ -35,7 +35,6 @@ use crate::{
         TariAddressFeatures,
         INTERNAL_SINGLE_MAX_BASE58_SIZE,
         INTERNAL_SINGLE_MIN_BASE58_SIZE,
-        MAX_ENCRYPTED_DATA_SIZE,
         TARI_ADDRESS_INTERNAL_SINGLE_SIZE,
     },
     types::CompressedPublicKey,
@@ -74,9 +73,7 @@ impl SingleAddress {
     pub fn emoji_to_bytes(emoji: &str) -> Result<Vec<u8>, TariAddressError> {
         // The string must be the correct size, including the checksum
         let length = emoji.chars().count();
-        if !(TARI_ADDRESS_INTERNAL_SINGLE_SIZE..=TARI_ADDRESS_INTERNAL_SINGLE_SIZE + MAX_ENCRYPTED_DATA_SIZE)
-            .contains(&length)
-        {
+        if length != TARI_ADDRESS_INTERNAL_SINGLE_SIZE {
             return Err(TariAddressError::InvalidSize);
         }
 
@@ -124,7 +121,7 @@ impl SingleAddress {
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, TariAddressError>
     where Self: Sized {
         let length = bytes.len();
-        if !(TARI_ADDRESS_INTERNAL_SINGLE_SIZE..=TARI_ADDRESS_INTERNAL_SINGLE_SIZE).contains(&length) {
+        if length != TARI_ADDRESS_INTERNAL_SINGLE_SIZE {
             return Err(TariAddressError::InvalidSize);
         }
         if validate_checksum(bytes).is_err() {

--- a/base_layer/common_types/src/tari_address/single_address.rs
+++ b/base_layer/common_types/src/tari_address/single_address.rs
@@ -25,7 +25,6 @@ use std::convert::TryFrom;
 use serde::{Deserialize, Serialize};
 use tari_common::configuration::Network;
 use tari_crypto::tari_utilities::ByteArray;
-use tari_max_size::MaxSizeBytes;
 use tari_utilities::hex::{from_hex, Hex};
 
 use crate::{
@@ -47,7 +46,6 @@ pub struct SingleAddress {
     network: Network,
     features: TariAddressFeatures,
     public_spend_key: CompressedPublicKey,
-    payment_id_user_data: MaxSizeBytes<MAX_ENCRYPTED_DATA_SIZE>,
 }
 
 impl SingleAddress {
@@ -56,24 +54,11 @@ impl SingleAddress {
         spend_key: CompressedPublicKey,
         network: Network,
         features: TariAddressFeatures,
-        payment_id_user_data: Option<Vec<u8>>,
     ) -> Result<SingleAddress, TariAddressError> {
-        let mut features = features;
-        let payment_id_user_data = match payment_id_user_data {
-            Some(data) => {
-                if data.len() > MAX_ENCRYPTED_DATA_SIZE {
-                    return Err(TariAddressError::PaymentIdTooLarge);
-                }
-                features.set(TariAddressFeatures::PAYMENT_ID, true);
-                MaxSizeBytes::from_bytes_truncate(data)
-            },
-            None => MaxSizeBytes::empty(),
-        };
         Ok(Self {
             network,
             features,
             public_spend_key: spend_key,
-            payment_id_user_data,
         })
     }
 
@@ -82,16 +67,7 @@ impl SingleAddress {
         spend_key: CompressedPublicKey,
         network: Network,
     ) -> Result<SingleAddress, TariAddressError> {
-        Self::new(spend_key, network, TariAddressFeatures::create_interactive_only(), None)
-    }
-
-    pub fn add_payment_id(&mut self, data: Vec<u8>) -> Result<(), TariAddressError> {
-        if data.len() > MAX_ENCRYPTED_DATA_SIZE {
-            return Err(TariAddressError::PaymentIdTooLarge);
-        }
-        self.features.set(TariAddressFeatures::PAYMENT_ID, true);
-        self.payment_id_user_data = MaxSizeBytes::from_bytes_truncate(data);
-        Ok(())
+        Self::new(spend_key, network, TariAddressFeatures::create_interactive_only())
     }
 
     /// helper function to convert emojis to u8
@@ -122,10 +98,6 @@ impl SingleAddress {
         Self::from_bytes(&bytes)
     }
 
-    pub fn get_payment_id_bytes(&self) -> Vec<u8> {
-        self.payment_id_user_data.as_ref().to_vec()
-    }
-
     /// Gets the network from the Tari Address
     pub fn network(&self) -> Network {
         self.network
@@ -152,9 +124,7 @@ impl SingleAddress {
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, TariAddressError>
     where Self: Sized {
         let length = bytes.len();
-        if !(TARI_ADDRESS_INTERNAL_SINGLE_SIZE..=TARI_ADDRESS_INTERNAL_SINGLE_SIZE + MAX_ENCRYPTED_DATA_SIZE)
-            .contains(&length)
-        {
+        if !(TARI_ADDRESS_INTERNAL_SINGLE_SIZE..=TARI_ADDRESS_INTERNAL_SINGLE_SIZE).contains(&length) {
             return Err(TariAddressError::InvalidSize);
         }
         if validate_checksum(bytes).is_err() {
@@ -164,26 +134,22 @@ impl SingleAddress {
         let features = TariAddressFeatures::from_bits(bytes[1]).ok_or(TariAddressError::InvalidFeatures)?;
         let public_spend_key = CompressedPublicKey::from_canonical_bytes(&bytes[2..34])
             .map_err(|_| TariAddressError::CannotRecoverPublicKey)?;
-        let payment_id_user_data = MaxSizeBytes::from_bytes_truncate(&bytes[34..length - 1]);
         Ok(Self {
             network,
             features,
             public_spend_key,
-            payment_id_user_data,
         })
     }
 
     /// Convert Tari Address to bytes
     pub fn to_vec(&self) -> Vec<u8> {
-        let length = TARI_ADDRESS_INTERNAL_SINGLE_SIZE + self.payment_id_user_data.len();
-        let mut buf = vec![0; length];
+        let mut buf = [0u8; TARI_ADDRESS_INTERNAL_SINGLE_SIZE];
         buf[0] = self.network.as_byte();
         buf[1] = self.features.0;
         buf[2..34].copy_from_slice(self.public_spend_key.as_bytes());
-        buf[34..(length - 1)].copy_from_slice(self.payment_id_user_data.as_bytes());
-        let checksum = compute_checksum(&buf[0..(length - 1)]);
-        buf[length - 1] = checksum;
-        buf
+        let checksum = compute_checksum(&buf[0..34]);
+        buf[34] = checksum;
+        buf.to_vec()
     }
 
     /// Construct Tari Address from Base58
@@ -273,7 +239,6 @@ mod test {
             public_key.clone(),
             Network::Esmeralda,
             TariAddressFeatures::create_interactive_only(),
-            None,
         )
         .unwrap();
         assert_eq!(emoji_id_from_public_key.public_spend_key(), &public_key);
@@ -299,7 +264,6 @@ mod test {
             public_key.clone(),
             Network::Esmeralda,
             TariAddressFeatures::create_one_sided_only(),
-            None,
         )
         .unwrap();
         assert_eq!(emoji_id_from_public_key.public_spend_key(), &public_key);
@@ -362,7 +326,6 @@ mod test {
             public_key.clone(),
             Network::Esmeralda,
             TariAddressFeatures::create_interactive_only(),
-            None,
         )
         .unwrap();
 
@@ -399,7 +362,6 @@ mod test {
             public_key.clone(),
             Network::Esmeralda,
             TariAddressFeatures::create_one_sided_only(),
-            None,
         )
         .unwrap();
 
@@ -497,44 +459,5 @@ mod test {
         let checksum = compute_checksum(&bytes[0..34]);
         bytes[34] = checksum;
         assert_eq!(SingleAddress::from_bytes(&bytes), Err(TariAddressError::InvalidNetwork));
-    }
-
-    #[test]
-    fn valid_payment_id() {
-        // Generate random public key
-        let mut rng = rand::thread_rng();
-        let spend_key = CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut rng));
-
-        // Generate an emoji ID from the public key and ensure we recover it
-        let payment_id = vec![1u8, 2, 3, 4, 5, 6, 7, 8];
-        let emoji_id_from_public_key = SingleAddress::new(
-            spend_key.clone(),
-            Network::Esmeralda,
-            TariAddressFeatures::default(),
-            Some(payment_id.clone()),
-        )
-        .unwrap();
-        assert_eq!(emoji_id_from_public_key.public_spend_key(), &spend_key);
-        assert_eq!(
-            emoji_id_from_public_key.payment_id_user_data.as_bytes(),
-            payment_id.as_slice()
-        );
-
-        // Check the size of the corresponding emoji string
-        let emoji_string = emoji_id_from_public_key.to_emoji_string();
-        assert_eq!(emoji_string.chars().count(), TARI_ADDRESS_INTERNAL_SINGLE_SIZE + 8);
-
-        let features = emoji_id_from_public_key.features();
-        assert_eq!(features, TariAddressFeatures(7));
-        // Generate an emoji ID from the emoji string and ensure we recover it
-        let emoji_id_from_emoji_string = SingleAddress::from_emoji_string(&emoji_string).unwrap();
-        assert_eq!(emoji_id_from_emoji_string.to_emoji_string(), emoji_string);
-
-        // Return to the original public keys for good measure
-        assert_eq!(emoji_id_from_emoji_string.public_spend_key(), &spend_key);
-        assert_eq!(
-            emoji_id_from_emoji_string.payment_id_user_data.as_bytes(),
-            payment_id.as_slice()
-        );
     }
 }

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_send_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_send_protocol.rs
@@ -235,8 +235,8 @@ where
             Ok(sp) => {
                 let _result = service_reply_channel
                     .send(Ok(TransactionServiceResponse::TransactionSent(self.id)))
-                    .inspect_err(|_| {
-                        warn!(target: LOG_TARGET, "Failed to send service reply");
+                    .inspect_err(|e| {
+                        warn!(target: LOG_TARGET, "Failed to send service reply: {:?}", e);
                     });
                 Ok(sp)
             },
@@ -244,8 +244,8 @@ where
                 let error_string = e.to_string();
                 let _size = service_reply_channel
                     .send(Err(TransactionServiceError::from(e)))
-                    .inspect_err(|_| {
-                        warn!(target: LOG_TARGET, "Failed to send service reply");
+                    .inspect_err(|e| {
+                        warn!(target: LOG_TARGET, "Failed to send service reply: {:?}", e);
                     });
                 Err(TransactionServiceProtocolError::new(
                     self.id,

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -3036,7 +3036,6 @@ where
                     source_pubkey,
                     self.resources.interactive_tari_address.network(),
                     TariAddressFeatures::INTERACTIVE,
-                    None,
                 )?
             };
             let (tx_finalized_sender, tx_finalized_receiver) = mpsc::channel(100);


### PR DESCRIPTION
Description
---
Fixes use of tari address with payment id inside

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error logging in transaction preparation, providing more detailed error information when sending service replies fails.

- **Refactor**
  - Removed support for payment IDs in single addresses, simplifying address handling and serialization.
  - Updated address size limits and validation logic for dual addresses, allowing for larger internal representations and more flexible size handling.
  - Cleaned up code to remove unnecessary arguments and streamline address creation across the wallet and address modules.

- **Tests**
  - Added comprehensive tests for dual addresses to ensure correct handling of maximum payment ID sizes and address conversions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->