### PR TITLE
fix(sidechain): minor API improvements

### DIFF
--- a/base_layer/sidechain/src/commit_proof.rs
+++ b/base_layer/sidechain/src/commit_proof.rs
@@ -1,6 +1,8 @@
 // Copyright 2024 The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
 
+use std::fmt::Display;
+
 use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 use tari_common_types::{
@@ -230,6 +232,17 @@ impl QuorumCertificate {
             .finalize()
             .into()
     }
+
+    pub fn calculate_id(&self, epoch: u64) -> FixedHash {
+        layer2::quorum_certificate_hasher()
+            .chain(&epoch)
+            .chain(&self.header_hash)
+            .chain(&self.parent_id)
+            .chain(&self.signatures)
+            .chain(&self.decision)
+            .finalize()
+            .into()
+    }
 }
 
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
@@ -237,6 +250,54 @@ pub enum QuorumDecision {
     Accept,
     Reject,
 }
+
+impl QuorumDecision {
+    pub fn is_accept(&self) -> bool {
+        matches!(self, QuorumDecision::Accept)
+    }
+
+    pub fn is_reject(&self) -> bool {
+        matches!(self, QuorumDecision::Reject)
+    }
+}
+
+impl QuorumDecision {
+    pub fn as_u8(&self) -> u8 {
+        match self {
+            QuorumDecision::Accept => 0,
+            QuorumDecision::Reject => 1,
+        }
+    }
+
+    pub fn from_u8(v: u8) -> Option<Self> {
+        match v {
+            0 => Some(QuorumDecision::Accept),
+            1 => Some(QuorumDecision::Reject),
+            _ => None,
+        }
+    }
+}
+
+impl TryFrom<u8> for QuorumDecision {
+    type Error = InvalidQuorumDecisionByteError;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        Self::from_u8(value).ok_or(InvalidQuorumDecisionByteError(value))
+    }
+}
+
+impl Display for QuorumDecision {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            QuorumDecision::Accept => write!(f, "Accept"),
+            QuorumDecision::Reject => write!(f, "Reject"),
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("Invalid quorum decision byte: {0}")]
+pub struct InvalidQuorumDecisionByteError(u8);
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, BorshSerialize, BorshDeserialize)]
 pub struct ValidatorQcSignature {

--- a/hashing/src/borsh_hasher.rs
+++ b/hashing/src/borsh_hasher.rs
@@ -59,12 +59,12 @@ impl<D: Digest + Default, M: DomainSeparation> DomainSeparatedBorshHasher<M, D> 
     }
 
     /// Update the hasher using the Borsh encoding of the input, which is assumed to be canonical.
-    pub fn update_consensus_encode<T: BorshSerialize>(&mut self, data: &T) {
+    pub fn update_consensus_encode<T: BorshSerialize + ?Sized>(&mut self, data: &T) {
         BorshSerialize::serialize(data, &mut self.writer)
             .expect("Incorrect implementation of BorshSerialize encountered. Implementations MUST be infallible.");
     }
 
-    pub fn chain<T: BorshSerialize>(mut self, data: &T) -> Self {
+    pub fn chain<T: BorshSerialize + ?Sized>(mut self, data: &T) -> Self {
         self.update_consensus_encode(data);
         self
     }


### PR DESCRIPTION
Description
---
Minor API improvements/fixes to facilitate usage with the L2

Motivation and Context
---
Changes required for https://github.com/tari-project/tari-dan/pull/1413 to compile.

- The QuorumDecision type to be used from the tari_sidechain crate instead of a duplicate type in both repos.
- `+ ?Sized` should have already been added to the hasher since it is more permissive, specifically used to allow hashing of slices (`&[T]` did not work previously,  `&Vec<T>` required)
- Allows the QC id to be calculated from the QuorumCertificate sidechain type

How Has This Been Tested?
---
N/A

What process can a PR reviewer use to test or verify this change?
---
N/A
<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced decision handling with new utility methods and string representations for quorum decisions.
  - Improved error messaging for invalid decision inputs.

- **Refactor**
  - Expanded support for serialization methods to accept a wider range of data types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->