### PR TITLE
feat: move comms channels to unbounded

### DIFF
--- a/base_layer/p2p/src/initialization.rs
+++ b/base_layer/p2p/src/initialization.rs
@@ -186,7 +186,7 @@ pub async fn initialize_local_test_comms<P: AsRef<Path>>(
     add_seed_peers(&comms.peer_manager(), &comms.node_identity(), seed_peers).await?;
 
     // Create outbound channel
-    let (outbound_tx, outbound_rx) = mpsc::channel(10);
+    let (outbound_tx, outbound_rx) = mpsc::unbounded_channel();
 
     let dht = Dht::builder()
         .local_test()
@@ -350,7 +350,7 @@ async fn configure_comms_and_dht(
     let node_identity = comms.node_identity();
     let shutdown_signal = comms.shutdown_signal();
     // Create outbound channel
-    let (outbound_tx, outbound_rx) = mpsc::channel(config.dht.outbound_buffer_size);
+    let (outbound_tx, outbound_rx) = mpsc::unbounded_channel();
 
     let mut dht = Dht::builder();
     dht.with_config(config.dht.clone()).with_outbound_sender(outbound_tx);

--- a/base_layer/p2p/src/services/liveness/service.rs
+++ b/base_layer/p2p/src/services/liveness/service.rs
@@ -477,7 +477,7 @@ mod test {
         mock.spawn();
 
         // Setup a CommsOutbound service handle which is not connected to the actual CommsOutbound service
-        let (outbound_tx, _) = mpsc::channel(10);
+        let (outbound_tx, _) = mpsc::unbounded_channel();
         let outbound_messaging = OutboundMessageRequester::new(outbound_tx);
 
         // Setup liveness service
@@ -514,7 +514,7 @@ mod test {
         let (connectivity, mock) = create_connectivity_mock();
         mock.spawn();
         // Setup a CommsOutbound service handle which is not connected to the actual CommsOutbound service
-        let (outbound_tx, mut outbound_rx) = mpsc::channel(10);
+        let (outbound_tx, mut outbound_rx) = mpsc::unbounded_channel();
         let outbound_messaging = OutboundMessageRequester::new(outbound_tx);
 
         // Setup liveness service
@@ -594,7 +594,7 @@ mod test {
         let (connectivity, mock) = create_connectivity_mock();
         mock.spawn();
         // Setup a CommsOutbound service handle which is not connected to the actual CommsOutbound service
-        let (outbound_tx, mut outbound_rx) = mpsc::channel(10);
+        let (outbound_tx, mut outbound_rx) = mpsc::unbounded_channel();
         let outbound_messaging = OutboundMessageRequester::new(outbound_tx);
 
         let metadata = Metadata::new();
@@ -631,7 +631,7 @@ mod test {
 
         let (connectivity, mock) = create_connectivity_mock();
         mock.spawn();
-        let (outbound_tx, _) = mpsc::channel(10);
+        let (outbound_tx, _) = mpsc::unbounded_channel();
         let outbound_messaging = OutboundMessageRequester::new(outbound_tx);
 
         let mut metadata = Metadata::new();

--- a/base_layer/wallet/tests/transaction_service_tests/service.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/service.rs
@@ -341,7 +341,7 @@ async fn setup_transaction_service_no_comms(
     let (oms_request_sender, oms_request_receiver) = reply_channel::unbounded();
 
     let (output_manager_service_event_publisher, _) = broadcast::channel(200);
-    let (outbound_message_requester, mock_outbound_service) = create_outbound_service_mock(100);
+    let (outbound_message_requester, mock_outbound_service) = create_outbound_service_mock();
 
     let (ts_request_sender, ts_request_receiver) = reply_channel::unbounded();
     let (event_publisher, _) = channel(100);

--- a/base_layer/wallet/tests/transaction_service_tests/transaction_protocols.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/transaction_protocols.rs
@@ -152,7 +152,7 @@ pub async fn setup() -> (
     let output_manager_service_handle = OutputManagerHandle::new(oms_request_sender, oms_event_publisher);
     let core_key_manager_service_handle = create_memory_db_key_manager().unwrap();
 
-    let (outbound_message_requester, mock_outbound_service) = create_outbound_service_mock(100);
+    let (outbound_message_requester, mock_outbound_service) = create_outbound_service_mock();
     let outbound_mock_state = mock_outbound_service.get_state();
     task::spawn(mock_outbound_service.run());
 

--- a/common/config/presets/c_base_node_c.toml
+++ b/common/config/presets/c_base_node_c.toml
@@ -226,7 +226,7 @@ listener_self_liveness_check_interval = 15
 # The `DbConnectionUrl` for the Dht database. Default: In-memory database
 database_url = "data/base_node/dht.db"
 # The size of the buffer (channel) which holds pending outbound message requests. Default: 20
-#outbound_buffer_size = 20
+#outbound_buffer_size = 200
 # The maximum number of peer nodes that a message has to be closer to, to be considered a neighbour. Default: 8
 #num_neighbouring_nodes = 6
 # Number of random peers to include. Default: 4

--- a/common/config/presets/c_base_node_c.toml
+++ b/common/config/presets/c_base_node_c.toml
@@ -225,8 +225,6 @@ listener_self_liveness_check_interval = 15
 [base_node.p2p.dht]
 # The `DbConnectionUrl` for the Dht database. Default: In-memory database
 database_url = "data/base_node/dht.db"
-# The size of the buffer (channel) which holds pending outbound message requests. Default: 20
-#outbound_buffer_size = 200
 # The maximum number of peer nodes that a message has to be closer to, to be considered a neighbour. Default: 8
 #num_neighbouring_nodes = 6
 # Number of random peers to include. Default: 4

--- a/common/config/presets/d_console_wallet.toml
+++ b/common/config/presets/d_console_wallet.toml
@@ -267,7 +267,7 @@ event_channel_size = 3500
 # The `DbConnectionUrl` for the Dht database. Default: In-memory database
 database_url = "data/wallet/dht.db"
 # The size of the buffer (channel) which holds pending outbound message requests. Default: 20
-#outbound_buffer_size = 20
+#outbound_buffer_size = 200
 # The maximum number of peer nodes that a message has to be closer to, to be considered a neighbour. Default: 8
 num_neighbouring_nodes = 5
 # Number of random peers to include. Default: 4

--- a/common/config/presets/d_console_wallet.toml
+++ b/common/config/presets/d_console_wallet.toml
@@ -266,8 +266,6 @@ event_channel_size = 3500
 [wallet.p2p.dht]
 # The `DbConnectionUrl` for the Dht database. Default: In-memory database
 database_url = "data/wallet/dht.db"
-# The size of the buffer (channel) which holds pending outbound message requests. Default: 20
-#outbound_buffer_size = 200
 # The maximum number of peer nodes that a message has to be closer to, to be considered a neighbour. Default: 8
 num_neighbouring_nodes = 5
 # Number of random peers to include. Default: 4

--- a/comms/core/examples/stress/node.rs
+++ b/comms/core/examples/stress/node.rs
@@ -62,7 +62,7 @@ pub async fn create(
         CommsNode,
         mpsc::Receiver<ProtocolNotification<Substream>>,
         mpsc::Receiver<InboundMessage>,
-        mpsc::Sender<OutboundMessage>,
+        mpsc::UnboundedSender<OutboundMessage>,
     ),
     Error,
 > {
@@ -107,7 +107,7 @@ pub async fn create(
         .disable_connection_reaping();
 
     let (inbound_tx, inbound_rx) = mpsc::channel(100);
-    let (outbound_tx, outbound_rx) = mpsc::channel(100);
+    let (outbound_tx, outbound_rx) = mpsc::unbounded_channel();
     let (event_tx, _) = broadcast::channel(1);
 
     let comms_node = if is_tcp {

--- a/comms/core/examples/stress/service.rs
+++ b/comms/core/examples/stress/service.rs
@@ -56,7 +56,7 @@ pub fn start_service(
     comms_node: CommsNode,
     protocol_notif: mpsc::Receiver<ProtocolNotification<Substream>>,
     inbound_rx: mpsc::Receiver<InboundMessage>,
-    outbound_tx: mpsc::Sender<OutboundMessage>,
+    outbound_tx: mpsc::UnboundedSender<OutboundMessage>,
     shutdown: Shutdown,
 ) -> (JoinHandle<Result<(), Error>>, mpsc::Sender<StressTestServiceRequest>) {
     let node_identity = comms_node.node_identity();
@@ -151,7 +151,7 @@ struct StressTestService {
     protocol_notif: mpsc::Receiver<ProtocolNotification<Substream>>,
 
     inbound_rx: Arc<RwLock<mpsc::Receiver<InboundMessage>>>,
-    outbound_tx: mpsc::Sender<OutboundMessage>,
+    outbound_tx: mpsc::UnboundedSender<OutboundMessage>,
 
     shutdown: Shutdown,
 }
@@ -162,7 +162,7 @@ impl StressTestService {
         comms_node: CommsNode,
         protocol_notif: mpsc::Receiver<ProtocolNotification<Substream>>,
         inbound_rx: mpsc::Receiver<InboundMessage>,
-        outbound_tx: mpsc::Sender<OutboundMessage>,
+        outbound_tx: mpsc::UnboundedSender<OutboundMessage>,
         shutdown: Shutdown,
     ) -> Self {
         Self {
@@ -264,7 +264,7 @@ async fn start_initiator_protocol(
     protocol: StressProtocol,
 
     inbound_rx: Arc<RwLock<mpsc::Receiver<InboundMessage>>>,
-    outbound_tx: mpsc::Sender<OutboundMessage>,
+    outbound_tx: mpsc::UnboundedSender<OutboundMessage>,
 ) -> Result<(), Error> {
     println!("Negotiating {:?} protocol...", protocol);
     let start = Instant::now();
@@ -347,7 +347,7 @@ async fn start_responder_protocol(
     mut substream: Substream,
 
     inbound_rx: Arc<RwLock<mpsc::Receiver<InboundMessage>>>,
-    outbound_tx: mpsc::Sender<OutboundMessage>,
+    outbound_tx: mpsc::UnboundedSender<OutboundMessage>,
 ) -> Result<(), Error> {
     let mut buf = [0u8; 9];
     substream.read_exact(&mut buf).await?;
@@ -442,7 +442,7 @@ async fn messaging_flood(
     peer: NodeId,
     protocol: StressProtocol,
     inbound_rx: Arc<RwLock<mpsc::Receiver<InboundMessage>>>,
-    outbound_tx: mpsc::Sender<OutboundMessage>,
+    outbound_tx: mpsc::UnboundedSender<OutboundMessage>,
 ) -> Result<(), Error> {
     let start = Instant::now();
     let mut counter = 1u32;
@@ -459,11 +459,9 @@ async fn messaging_flood(
             OutboundMessage::new(peer.clone(), generate_message(counter, protocol.message_size as usize))
         })
         .take(protocol.num_messages as usize);
-        utils::mpsc::send_all(&outbound_tx, iter).await?;
+        utils::mpsc::send_all_unbounded(&outbound_tx, iter)?;
         time::sleep(Duration::from_secs(5)).await;
-        outbound_tx
-            .send(OutboundMessage::new(peer.clone(), Bytes::from_static(&[0u8; 4])))
-            .await?;
+        outbound_tx.send(OutboundMessage::new(peer.clone(), Bytes::from_static(&[0u8; 4])))?;
         Result::<_, Error>::Ok(())
     });
 

--- a/comms/core/examples/tor.rs
+++ b/comms/core/examples/tor.rs
@@ -115,12 +115,10 @@ async fn run() -> Result<(), Error> {
         .await?;
 
     // This kicks things off
-    outbound_tx1
-        .send(OutboundMessage::new(
-            comms_node2.node_identity().node_id().clone(),
-            Bytes::from_static(b"START"),
-        ))
-        .await?;
+    outbound_tx1.send(OutboundMessage::new(
+        comms_node2.node_identity().node_id().clone(),
+        Bytes::from_static(b"START"),
+    ))?;
 
     let executor = runtime::Handle::current();
 
@@ -153,7 +151,14 @@ async fn setup_node_with_tor<P: Into<tor::PortMapping>>(
     database_path: &Path,
     port_mapping: P,
     tor_identity: Option<tor::TorIdentity>,
-) -> Result<(CommsNode, mpsc::Receiver<InboundMessage>, mpsc::Sender<OutboundMessage>), Error> {
+) -> Result<
+    (
+        CommsNode,
+        mpsc::UnboundedReceiver<InboundMessage>,
+        mpsc::UnboundedSender<OutboundMessage>,
+    ),
+    Error,
+> {
     let datastore = LMDBBuilder::new()
         .set_path(database_path.to_str().unwrap())
         .set_env_config(LMDBConfig::default())
@@ -164,8 +169,8 @@ async fn setup_node_with_tor<P: Into<tor::PortMapping>>(
     let peer_database = datastore.get_handle("peerdb").unwrap();
     let peer_database = LMDBWrapper::new(Arc::new(peer_database));
 
-    let (inbound_tx, inbound_rx) = mpsc::channel(10);
-    let (outbound_tx, outbound_rx) = mpsc::channel(10);
+    let (inbound_tx, inbound_rx) = mpsc::unbounded_channel();
+    let (outbound_tx, outbound_rx) = mpsc::unbounded_channel();
 
     let mut hs_builder = tor::HiddenServiceBuilder::new()
         .with_port_mapping(port_mapping)
@@ -218,8 +223,8 @@ async fn setup_node_with_tor<P: Into<tor::PortMapping>>(
 
 async fn start_ping_ponger(
     dest_node_id: NodeId,
-    mut inbound_rx: mpsc::Receiver<InboundMessage>,
-    outbound_tx: mpsc::Sender<OutboundMessage>,
+    mut inbound_rx: mpsc::UnboundedReceiver<InboundMessage>,
+    outbound_tx: mpsc::UnboundedSender<OutboundMessage>,
 ) -> Result<usize, Error> {
     let mut inflight_pings = HashMap::new();
     let mut counter = 0;
@@ -236,7 +241,7 @@ async fn start_ping_ponger(
                 let id = thread_rng().next_u64();
                 inflight_pings.insert(id, Utc::now().naive_utc());
                 let msg = make_msg(&dest_node_id, &format!("PING {}", id));
-                outbound_tx.send(msg).await?;
+                outbound_tx.send(msg)?;
             },
             Some("PING") => {
                 let id = msg_parts.next().ok_or_else(|| anyhow!("Received PING without id"))?;
@@ -244,7 +249,7 @@ async fn start_ping_ponger(
                 let msg_str = format!("PONG {}", id);
                 let msg = make_msg(&dest_node_id, &msg_str);
 
-                outbound_tx.send(msg).await?;
+                outbound_tx.send(msg)?;
             },
 
             Some("PONG") => {
@@ -261,7 +266,7 @@ async fn start_ping_ponger(
                 let new_id = thread_rng().next_u64();
                 inflight_pings.insert(new_id, Utc::now().naive_utc());
                 let msg = make_msg(&dest_node_id, &format!("PING {}", new_id));
-                outbound_tx.send(msg).await?;
+                outbound_tx.send(msg)?;
             },
             msg => {
                 return Err(anyhow!("Received invalid message '{:?}'", msg));

--- a/comms/core/src/builder/tests.rs
+++ b/comms/core/src/builder/tests.rs
@@ -62,7 +62,7 @@ async fn spawn_node(
 ) -> (
     CommsNode,
     mpsc::Receiver<InboundMessage>,
-    mpsc::Sender<OutboundMessage>,
+    mpsc::UnboundedSender<OutboundMessage>,
     MessagingEventSender,
 ) {
     let addr = format!("/memory/{}", memsocket::acquire_next_memsocket_port())
@@ -72,7 +72,7 @@ async fn spawn_node(
     node_identity.add_public_address(addr.clone());
 
     let (inbound_tx, inbound_rx) = mpsc::channel(10);
-    let (outbound_tx, outbound_rx) = mpsc::channel(10);
+    let (outbound_tx, outbound_rx) = mpsc::unbounded_channel();
 
     let comms_node = CommsBuilder::new()
         // These calls are just to get rid of unused function warnings.
@@ -249,7 +249,7 @@ async fn peer_to_peer_messaging() {
             format!("#{:0>3} - comms messaging is so hot right now!", i).into(),
             reply_tx.into(),
         );
-        outbound_tx1.send(outbound_msg).await.unwrap();
+        outbound_tx1.send(outbound_msg).unwrap();
     }
 
     let messages1_to_2 = collect_recv!(inbound_rx2, take = NUM_MSGS, timeout = Duration::from_secs(10));
@@ -269,7 +269,7 @@ async fn peer_to_peer_messaging() {
             node_identity1.node_id().clone(),
             format!("#{:0>3} - comms messaging is so hot right now!", i).into(),
         );
-        outbound_tx2.send(outbound_msg).await.unwrap();
+        outbound_tx2.send(outbound_msg).unwrap();
     }
 
     let messages2_to_1 = collect_recv!(inbound_rx1, take = NUM_MSGS, timeout = Duration::from_secs(10));
@@ -357,7 +357,7 @@ async fn peer_to_peer_messaging_simultaneous() {
                 node_identity2.node_id().clone(),
                 format!("#{:0>3} - comms messaging is so hot right now!", i).into(),
             );
-            outbound_tx1.send(outbound_msg).await.unwrap();
+            outbound_tx1.send(outbound_msg).unwrap();
         }
     });
 
@@ -367,7 +367,7 @@ async fn peer_to_peer_messaging_simultaneous() {
                 node_identity1.node_id().clone(),
                 format!("#{:0>3} - comms messaging is so hot right now!", i).into(),
             );
-            outbound_tx2.send(outbound_msg).await.unwrap();
+            outbound_tx2.send(outbound_msg).unwrap();
         }
     });
 

--- a/comms/core/src/pipeline/builder.rs
+++ b/comms/core/src/pipeline/builder.rs
@@ -39,7 +39,7 @@ pub struct Builder<TInSvc, TOutSvc, TOutReq> {
     max_concurrent_inbound_tasks: usize,
     max_concurrent_outbound_tasks: Option<usize>,
     inbound: Option<TInSvc>,
-    outbound_rx: Option<mpsc::Receiver<TOutReq>>,
+    outbound_rx: Option<mpsc::UnboundedReceiver<TOutReq>>,
     outbound_pipeline_factory: Option<Box<dyn FnOnce(OutboundMessageSinkService) -> TOutSvc>>,
 }
 
@@ -66,7 +66,11 @@ impl<TInSvc, TOutSvc, TOutReq> Builder<TInSvc, TOutSvc, TOutReq> {
         self
     }
 
-    pub fn with_outbound_pipeline<F, S, R>(self, receiver: mpsc::Receiver<R>, factory: F) -> Builder<TInSvc, S, R>
+    pub fn with_outbound_pipeline<F, S, R>(
+        self,
+        receiver: mpsc::UnboundedReceiver<R>,
+        factory: F,
+    ) -> Builder<TInSvc, S, R>
     where
         // Factory function takes in a SinkService and returns a new composed service
         F: FnOnce(OutboundMessageSinkService) -> S + 'static,
@@ -145,7 +149,7 @@ where
 /// Configuration for the outbound pipeline.
 pub struct OutboundPipelineConfig<TInItem, TPipeline> {
     /// Messages read from this stream are passed to the pipeline
-    pub in_receiver: mpsc::Receiver<TInItem>,
+    pub in_receiver: mpsc::UnboundedReceiver<TInItem>,
     /// Receiver of `OutboundMessage`s coming from the pipeline
     pub out_receiver: Option<mpsc::UnboundedReceiver<OutboundMessage>>,
     /// The pipeline (`tower::Service`) to run for each in_stream message
@@ -167,30 +171,4 @@ pub enum PipelineBuilderError {
     InboundNotProvided,
     #[error("Outbound pipeline was not provided")]
     OutboundPipelineNotProvided,
-}
-
-#[cfg(test)]
-mod test {
-    use std::convert::identity;
-
-    use futures::future;
-    use tower::service_fn;
-
-    use super::*;
-
-    #[test]
-    fn minimal_usage() {
-        // Called when a message is sent on the given channel.
-        let (_, rx) = mpsc::channel::<OutboundMessage>(1);
-
-        let config = Builder::new()
-            .max_concurrent_inbound_tasks(50)
-            // Forward all messages on rx_out to the provided SinkService
-            .with_outbound_pipeline(rx, identity)
-            // Discard all inbound messages
-            .with_inbound_pipeline(service_fn(|_| future::ready(Result::<_, ()>::Ok(()))))
-            .build();
-
-        assert_eq!(config.max_concurrent_inbound_tasks, 50);
-    }
 }

--- a/comms/core/src/pipeline/outbound.rs
+++ b/comms/core/src/pipeline/outbound.rs
@@ -129,12 +129,11 @@ mod test {
     #[tokio::test]
     async fn run() {
         const NUM_ITEMS: usize = 10;
-        let (tx, mut in_receiver) = mpsc::channel(NUM_ITEMS);
-        utils::mpsc::send_all(
+        let (tx, mut in_receiver) = mpsc::unbounded_channel();
+        utils::mpsc::send_all_unbounded(
             &tx,
             (0..NUM_ITEMS).map(|i| OutboundMessage::new(Default::default(), Bytes::copy_from_slice(&i.to_be_bytes()))),
         )
-        .await
         .unwrap();
         in_receiver.close();
 

--- a/comms/core/src/utils/mpsc.rs
+++ b/comms/core/src/utils/mpsc.rs
@@ -31,3 +31,13 @@ pub async fn send_all<T, I: IntoIterator<Item = T>>(
     }
     Ok(())
 }
+
+pub fn send_all_unbounded<T, I: IntoIterator<Item = T>>(
+    sender: &mpsc::UnboundedSender<T>,
+    iter: I,
+) -> Result<(), mpsc::error::SendError<T>> {
+    for item in iter {
+        sender.send(item)?;
+    }
+    Ok(())
+}

--- a/comms/dht/examples/memory_net/utilities.rs
+++ b/comms/dht/examples/memory_net/utilities.rs
@@ -716,7 +716,7 @@ async fn setup_comms_dht(
     shutdown_signal: ShutdownSignal,
 ) -> (CommsNode, Dht, MessagingEventSender) {
     // Create inbound and outbound channels
-    let (outbound_tx, outbound_rx) = mpsc::channel(10);
+    let (outbound_tx, outbound_rx) = mpsc::unbounded_channel();
 
     let comms = CommsBuilder::new()
         .allow_test_addresses()

--- a/comms/dht/examples/propagation/node.rs
+++ b/comms/dht/examples/propagation/node.rs
@@ -94,7 +94,7 @@ pub async fn create<P: AsRef<Path>>(
         .disable_connection_reaping();
 
     let (inbound_tx, inbound_rx) = mpsc::channel(1);
-    let (outbound_tx, outbound_rx) = mpsc::channel(1);
+    let (outbound_tx, outbound_rx) = mpsc::unbounded_channel();
     let (event_tx, _) = broadcast::channel(1);
 
     let mut hs_builder = tor::HiddenServiceBuilder::new()

--- a/comms/dht/src/actor.rs
+++ b/comms/dht/src/actor.rs
@@ -175,25 +175,24 @@ impl Display for DhtRequest {
 /// DHT actor requester
 #[derive(Clone)]
 pub struct DhtRequester {
-    sender: mpsc::Sender<DhtRequest>,
+    sender: mpsc::UnboundedSender<DhtRequest>,
 }
 
 impl DhtRequester {
-    pub(crate) fn new(sender: mpsc::Sender<DhtRequest>) -> Self {
+    pub(crate) fn new(sender: mpsc::UnboundedSender<DhtRequest>) -> Self {
         Self { sender }
     }
 
     /// Send a Join message to the network
     pub async fn send_join(&mut self) -> Result<(), DhtActorError> {
-        self.sender.send(DhtRequest::SendJoin).await.map_err(Into::into)
+        self.sender.send(DhtRequest::SendJoin).map_err(Into::into)
     }
 
     /// Select peers by [BroadcastStrategy](crate::broadcast_strategy::BroadcastStrategy]
     pub async fn select_peers(&mut self, broadcast_strategy: BroadcastStrategy) -> Result<Vec<NodeId>, DhtActorError> {
         let (reply_tx, reply_rx) = oneshot::channel();
         self.sender
-            .send(DhtRequest::SelectPeers(broadcast_strategy, reply_tx))
-            .await?;
+            .send(DhtRequest::SelectPeers(broadcast_strategy, reply_tx))?;
         reply_rx.await.map_err(|_| DhtActorError::ReplyCanceled)
     }
 
@@ -204,13 +203,11 @@ impl DhtRequester {
         received_from: CommsPublicKey,
     ) -> Result<u32, DhtActorError> {
         let (reply_tx, reply_rx) = oneshot::channel();
-        self.sender
-            .send(DhtRequest::MsgHashCacheInsert {
-                message_hash,
-                received_from,
-                reply_tx,
-            })
-            .await?;
+        self.sender.send(DhtRequest::MsgHashCacheInsert {
+            message_hash,
+            received_from,
+            reply_tx,
+        })?;
 
         reply_rx.await.map_err(|_| DhtActorError::ReplyCanceled)
     }
@@ -219,8 +216,7 @@ impl DhtRequester {
     pub async fn get_message_cache_hit_count(&mut self, message_hash: Vec<u8>) -> Result<u32, DhtActorError> {
         let (reply_tx, reply_rx) = oneshot::channel();
         self.sender
-            .send(DhtRequest::GetMsgHashHitCount(message_hash, reply_tx))
-            .await?;
+            .send(DhtRequest::GetMsgHashHitCount(message_hash, reply_tx))?;
 
         reply_rx.await.map_err(|_| DhtActorError::ReplyCanceled)
     }
@@ -228,7 +224,7 @@ impl DhtRequester {
     /// Returns the deserialized metadata value for the given key
     pub async fn get_metadata<T: MessageFormat>(&mut self, key: DhtMetadataKey) -> Result<Option<T>, DhtActorError> {
         let (reply_tx, reply_rx) = oneshot::channel();
-        self.sender.send(DhtRequest::GetMetadata(key, reply_tx)).await?;
+        self.sender.send(DhtRequest::GetMetadata(key, reply_tx))?;
         match reply_rx.await.map_err(|_| DhtActorError::ReplyCanceled)?? {
             Some(bytes) => T::from_binary(&bytes)
                 .map(Some)
@@ -241,7 +237,7 @@ impl DhtRequester {
     pub async fn set_metadata<T: MessageFormat>(&mut self, key: DhtMetadataKey, value: T) -> Result<(), DhtActorError> {
         let (reply_tx, reply_rx) = oneshot::channel();
         let bytes = value.to_binary().map_err(DhtActorError::FailedToSerializeValue)?;
-        self.sender.send(DhtRequest::SetMetadata(key, bytes, reply_tx)).await?;
+        self.sender.send(DhtRequest::SetMetadata(key, bytes, reply_tx))?;
         reply_rx.await.map_err(|_| DhtActorError::ReplyCanceled)?
     }
 
@@ -249,12 +245,10 @@ impl DhtRequester {
     /// connection to the peer will be returned.
     pub async fn dial_or_discover_peer(&mut self, public_key: CommsPublicKey) -> Result<PeerConnection, DhtActorError> {
         let (reply_tx, reply_rx) = oneshot::channel();
-        self.sender
-            .send(DhtRequest::DialDiscoverPeer {
-                public_key,
-                reply: reply_tx,
-            })
-            .await?;
+        self.sender.send(DhtRequest::DialDiscoverPeer {
+            public_key,
+            reply: reply_tx,
+        })?;
         reply_rx.await.map_err(|_| DhtActorError::ReplyCanceled)?
     }
 
@@ -266,7 +260,6 @@ impl DhtRequester {
                 severity,
                 reason: reason.to_string(),
             })
-            .await
             .is_err()
         {
             debug!(target: LOG_TARGET, "DhtActor is shut down and no longer responding to requests. This is expected during shutdown.");
@@ -284,7 +277,7 @@ pub struct DhtActor {
     config: Arc<DhtConfig>,
     discovery: DhtDiscoveryRequester,
     shutdown_signal: ShutdownSignal,
-    request_rx: mpsc::Receiver<DhtRequest>,
+    request_rx: mpsc::UnboundedReceiver<DhtRequest>,
     msg_hash_dedup_cache: DedupCacheDatabase,
 }
 
@@ -297,7 +290,7 @@ impl DhtActor {
         peer_manager: Arc<PeerManager>,
         connectivity: ConnectivityRequester,
         outbound_requester: OutboundMessageRequester,
-        request_rx: mpsc::Receiver<DhtRequest>,
+        request_rx: mpsc::UnboundedReceiver<DhtRequest>,
         discovery: DhtDiscoveryRequester,
         shutdown_signal: ShutdownSignal,
     ) -> Self {
@@ -991,10 +984,10 @@ mod test {
     async fn send_join_request() {
         let node_identity = make_node_identity();
         let peer_manager = build_peer_manager();
-        let (out_tx, mut out_rx) = mpsc::channel(1);
+        let (out_tx, mut out_rx) = mpsc::unbounded_channel();
         let (connectivity_manager, mock) = create_connectivity_mock();
         mock.spawn();
-        let (actor_tx, actor_rx) = mpsc::channel(1);
+        let (actor_tx, actor_rx) = mpsc::unbounded_channel();
         let mut requester = DhtRequester::new(actor_tx);
         let outbound_requester = OutboundMessageRequester::new(out_tx);
         let (discovery, _) = create_dht_discovery_mock(Duration::from_secs(10));
@@ -1033,11 +1026,11 @@ mod test {
         ) {
             let node_identity = make_node_identity();
             let peer_manager = build_peer_manager();
-            let (out_tx, _) = mpsc::channel(1);
+            let (out_tx, _) = mpsc::unbounded_channel();
             let (connectivity_manager, mock) = create_connectivity_mock();
             let connectivity_mock = mock.get_shared_state();
             mock.spawn();
-            let (actor_tx, actor_rx) = mpsc::channel(1);
+            let (actor_tx, actor_rx) = mpsc::unbounded_channel();
             let requester = DhtRequester::new(actor_tx);
             let outbound_requester = OutboundMessageRequester::new(out_tx);
             let (discovery, mock) = create_dht_discovery_mock(Duration::from_secs(10));
@@ -1112,8 +1105,8 @@ mod test {
         let peer_manager = build_peer_manager();
         let (connectivity_manager, mock) = create_connectivity_mock();
         mock.spawn();
-        let (out_tx, _) = mpsc::channel(1);
-        let (actor_tx, actor_rx) = mpsc::channel(1);
+        let (out_tx, _) = mpsc::unbounded_channel();
+        let (actor_tx, actor_rx) = mpsc::unbounded_channel();
         let mut requester = DhtRequester::new(actor_tx);
         let (discovery, _) = create_dht_discovery_mock(Duration::from_secs(10));
         let outbound_requester = OutboundMessageRequester::new(out_tx);
@@ -1156,8 +1149,8 @@ mod test {
         let peer_manager = build_peer_manager();
         let (connectivity_manager, mock) = create_connectivity_mock();
         mock.spawn();
-        let (out_tx, _) = mpsc::channel(1);
-        let (actor_tx, actor_rx) = mpsc::channel(1);
+        let (out_tx, _) = mpsc::unbounded_channel();
+        let (actor_tx, actor_rx) = mpsc::unbounded_channel();
         let mut requester = DhtRequester::new(actor_tx);
         let outbound_requester = OutboundMessageRequester::new(out_tx);
         let (discovery, _) = create_dht_discovery_mock(Duration::from_secs(10));
@@ -1258,8 +1251,8 @@ mod test {
 
         peer_manager.add_peer(make_node_identity().to_peer()).await.unwrap();
 
-        let (out_tx, _) = mpsc::channel(1);
-        let (actor_tx, actor_rx) = mpsc::channel(1);
+        let (out_tx, _) = mpsc::unbounded_channel();
+        let (actor_tx, actor_rx) = mpsc::unbounded_channel();
         let mut requester = DhtRequester::new(actor_tx);
         let outbound_requester = OutboundMessageRequester::new(out_tx);
         let shutdown = Shutdown::new();
@@ -1356,8 +1349,8 @@ mod test {
     async fn get_and_set_metadata() {
         let node_identity = make_node_identity();
         let peer_manager = build_peer_manager();
-        let (out_tx, _out_rx) = mpsc::channel(1);
-        let (actor_tx, actor_rx) = mpsc::channel(1);
+        let (out_tx, _out_rx) = mpsc::unbounded_channel();
+        let (actor_tx, actor_rx) = mpsc::unbounded_channel();
         let (connectivity_manager, mock) = create_connectivity_mock();
         mock.spawn();
         let mut requester = DhtRequester::new(actor_tx);

--- a/comms/dht/src/builder.rs
+++ b/comms/dht/src/builder.rs
@@ -43,7 +43,7 @@ use crate::{dht::DhtInitializationError, outbound::DhtOutboundRequest, version::
 #[derive(Debug, Clone, Default)]
 pub struct DhtBuilder {
     config: DhtConfig,
-    outbound_tx: Option<mpsc::Sender<DhtOutboundRequest>>,
+    outbound_tx: Option<mpsc::UnboundedSender<DhtOutboundRequest>>,
 }
 
 impl DhtBuilder {
@@ -76,7 +76,7 @@ impl DhtBuilder {
     }
 
     /// Sets the mpsc sender that is hooked up to the outbound messaging pipeline.
-    pub fn with_outbound_sender(&mut self, outbound_tx: mpsc::Sender<DhtOutboundRequest>) -> &mut Self {
+    pub fn with_outbound_sender(&mut self, outbound_tx: mpsc::UnboundedSender<DhtOutboundRequest>) -> &mut Self {
         self.outbound_tx = Some(outbound_tx);
         self
     }

--- a/comms/dht/src/config.rs
+++ b/comms/dht/src/config.rs
@@ -171,7 +171,7 @@ impl Default for DhtConfig {
             minimize_connections: false,
             propagation_factor: 20,
             broadcast_factor: 8,
-            outbound_buffer_size: 20,
+            outbound_buffer_size: 200,
             dedup_cache_capacity: 2_500,
             dedup_cache_trim_interval: Duration::from_secs(5 * 60),
             dedup_allowed_message_occurrences: 1,

--- a/comms/dht/src/config.rs
+++ b/comms/dht/src/config.rs
@@ -36,9 +36,6 @@ pub struct DhtConfig {
     pub protocol_version: DhtProtocolVersion,
     /// The `DbConnectionUrl` for the Dht database. Default: In-memory database
     pub database_url: DbConnectionUrl,
-    /// The size of the buffer (channel) which holds pending outbound message requests.
-    /// Default: 20
-    pub outbound_buffer_size: usize,
     /// The maximum number of peer nodes that a message has to be closer to, to be considered a neighbour
     /// Default: 8
     pub num_neighbouring_nodes: usize,
@@ -171,7 +168,6 @@ impl Default for DhtConfig {
             minimize_connections: false,
             propagation_factor: 20,
             broadcast_factor: 8,
-            outbound_buffer_size: 200,
             dedup_cache_capacity: 2_500,
             dedup_cache_trim_interval: Duration::from_secs(5 * 60),
             dedup_allowed_message_occurrences: 1,

--- a/comms/dht/src/connectivity/test.rs
+++ b/comms/dht/src/connectivity/test.rs
@@ -66,7 +66,7 @@ async fn setup(
     let (connectivity, mock) = create_connectivity_mock();
     let connectivity_state = mock.get_shared_state();
     mock.spawn();
-    let (dht_requester, mock) = create_dht_actor_mock(1);
+    let (dht_requester, mock) = create_dht_actor_mock();
     let dht_state = mock.get_shared_state();
     mock.spawn();
     let (event_publisher, _) = broadcast::channel(1);

--- a/comms/dht/src/dedup/mod.rs
+++ b/comms/dht/src/dedup/mod.rs
@@ -186,7 +186,7 @@ mod test {
         let rt = Runtime::new().unwrap();
         let spy = service_spy();
 
-        let (dht_requester, mock) = create_dht_actor_mock(1);
+        let (dht_requester, mock) = create_dht_actor_mock();
         let mock_state = mock.get_shared_state();
         mock_state.set_number_of_message_hits(1);
         rt.spawn(mock.run());

--- a/comms/dht/src/dht.rs
+++ b/comms/dht/src/dht.rs
@@ -61,7 +61,6 @@ use crate::{
 
 const LOG_TARGET: &str = "comms::dht";
 
-const DHT_ACTOR_CHANNEL_SIZE: usize = 100;
 const DHT_DISCOVERY_CHANNEL_SIZE: usize = 100;
 const DHT_EVENT_BROADCAST_CHANNEL_SIZE: usize = 100;
 
@@ -86,9 +85,9 @@ pub struct Dht {
     /// Dht configuration
     config: Arc<DhtConfig>,
     /// Used to create a OutboundMessageRequester.
-    outbound_tx: mpsc::Sender<DhtOutboundRequest>,
+    outbound_tx: mpsc::UnboundedSender<DhtOutboundRequest>,
     /// Sender for DHT requests
-    dht_sender: mpsc::Sender<DhtRequest>,
+    dht_sender: mpsc::UnboundedSender<DhtRequest>,
     /// Sender for DHT discovery requests
     discovery_sender: mpsc::Sender<DhtDiscoveryRequest>,
     /// Connectivity actor requester
@@ -104,11 +103,11 @@ impl Dht {
         config: DhtConfig,
         node_identity: Arc<NodeIdentity>,
         peer_manager: Arc<PeerManager>,
-        outbound_tx: mpsc::Sender<DhtOutboundRequest>,
+        outbound_tx: mpsc::UnboundedSender<DhtOutboundRequest>,
         connectivity: ConnectivityRequester,
         shutdown_signal: ShutdownSignal,
     ) -> Result<Self, DhtInitializationError> {
-        let (dht_sender, dht_receiver) = mpsc::channel(DHT_ACTOR_CHANNEL_SIZE);
+        let (dht_sender, dht_receiver) = mpsc::unbounded_channel();
         let (discovery_sender, discovery_receiver) = mpsc::channel(DHT_DISCOVERY_CHANNEL_SIZE);
         let (event_publisher, _) = broadcast::channel(DHT_EVENT_BROADCAST_CHANNEL_SIZE);
 
@@ -152,7 +151,7 @@ impl Dht {
     fn actor(
         &self,
         conn: DbConnection,
-        request_receiver: mpsc::Receiver<DhtRequest>,
+        request_receiver: mpsc::UnboundedReceiver<DhtRequest>,
         shutdown_signal: ShutdownSignal,
     ) -> DhtActor {
         DhtActor::new(
@@ -421,7 +420,7 @@ mod test {
         peer_manager.add_peer(node_identity.to_peer()).await.unwrap();
 
         // Dummy out channel, we are not testing outbound here.
-        let (out_tx, _) = mpsc::channel(10);
+        let (out_tx, _) = mpsc::unbounded_channel();
 
         let shutdown = Shutdown::new();
         let dht = Dht::builder()
@@ -474,7 +473,7 @@ mod test {
         peer_manager.add_peer(node_identity.to_peer()).await.unwrap();
 
         // Dummy out channel, we are not testing outbound here.
-        let (out_tx, _) = mpsc::channel(10);
+        let (out_tx, _) = mpsc::unbounded_channel();
 
         let shutdown = Shutdown::new();
         let dht = Dht::builder()
@@ -528,7 +527,7 @@ mod test {
         peer_manager.add_peer(node_identity.to_peer()).await.unwrap();
 
         let (connectivity, _) = create_connectivity_mock();
-        let (oms_requester, oms_mock) = create_outbound_service_mock(1);
+        let (oms_requester, oms_mock) = create_outbound_service_mock();
 
         // Send all outbound requests to the mock
         let dht = Dht::builder()

--- a/comms/dht/src/discovery/service.rs
+++ b/comms/dht/src/discovery/service.rs
@@ -393,7 +393,7 @@ mod test {
     async fn send_discovery() {
         let node_identity = make_node_identity();
         let peer_manager = build_peer_manager();
-        let (outbound_requester, outbound_mock) = create_outbound_service_mock(10);
+        let (outbound_requester, outbound_mock) = create_outbound_service_mock();
         let oms_mock_state = outbound_mock.get_state();
         task::spawn(outbound_mock.run());
 
@@ -401,7 +401,7 @@ mod test {
         // Requester which timeout instantly
         let mut requester = DhtDiscoveryRequester::new(sender, Duration::from_millis(1));
         let shutdown = Shutdown::new();
-        let (dht, _mock) = create_dht_actor_mock(1);
+        let (dht, _mock) = create_dht_actor_mock();
 
         DhtDiscoveryService::new(
             Default::default(),

--- a/comms/dht/src/inbound/forward.rs
+++ b/comms/dht/src/inbound/forward.rs
@@ -283,8 +283,8 @@ mod test {
     #[tokio::test]
     async fn decryption_succeeded() {
         let spy = service_spy();
-        let (oms_tx, _) = mpsc::channel(1);
-        let (dht, _mock) = create_dht_actor_mock(1);
+        let (oms_tx, _) = mpsc::unbounded_channel();
+        let (dht, _mock) = create_dht_actor_mock();
         let oms = OutboundMessageRequester::new(oms_tx);
         let mut service = ForwardLayer::new(dht, oms, true).layer(spy.to_service::<PipelineError>());
 
@@ -303,9 +303,9 @@ mod test {
     #[tokio::test]
     async fn decryption_failed() {
         let spy = service_spy();
-        let (oms_requester, oms_mock) = create_outbound_service_mock(1);
+        let (oms_requester, oms_mock) = create_outbound_service_mock();
         let oms_mock_state = oms_mock.get_state();
-        let (dht, _mock) = create_dht_actor_mock(1);
+        let (dht, _mock) = create_dht_actor_mock();
         task::spawn(oms_mock.run());
 
         let mut service = ForwardLayer::new(dht, oms_requester, true).layer(spy.to_service::<PipelineError>());

--- a/comms/dht/src/outbound/broadcast.rs
+++ b/comms/dht/src/outbound/broadcast.rs
@@ -616,7 +616,7 @@ mod test {
             PeerFeatures::COMMUNICATION_NODE,
         ));
 
-        let (dht_requester, dht_mock) = create_dht_actor_mock(10);
+        let (dht_requester, dht_mock) = create_dht_actor_mock();
         let (dht_discover_requester, _) = create_dht_discovery_mock(Duration::from_secs(10));
 
         let mock_state = dht_mock.get_shared_state();
@@ -664,7 +664,7 @@ mod test {
             "/ip4/127.0.0.1/tcp/9000".parse().unwrap(),
             PeerFeatures::COMMUNICATION_NODE,
         );
-        let (dht_requester, dht_mock) = create_dht_actor_mock(10);
+        let (dht_requester, dht_mock) = create_dht_actor_mock();
         task::spawn(dht_mock.run());
         let (dht_discover_requester, _) = create_dht_discovery_mock(Duration::from_secs(10));
         let spy = service_spy();
@@ -706,7 +706,7 @@ mod test {
             "/ip4/127.0.0.1/tcp/9000".parse().unwrap(),
             PeerFeatures::COMMUNICATION_NODE,
         );
-        let (dht_requester, dht_mock) = create_dht_actor_mock(10);
+        let (dht_requester, dht_mock) = create_dht_actor_mock();
         task::spawn(dht_mock.run());
         let (dht_discover_requester, discovery_mock) = create_dht_discovery_mock(Duration::from_secs(10));
         let dht_discovery_state = discovery_mock.get_shared_state();

--- a/comms/dht/src/outbound/mock.rs
+++ b/comms/dht/src/outbound/mock.rs
@@ -54,8 +54,8 @@ const LOG_TARGET: &str = "mock::outbound_requester";
 /// Creates a mock outbound request "handler" for testing purposes.
 ///
 /// Each time a request is expected, handle_next should be called.
-pub fn create_outbound_service_mock(size: usize) -> (OutboundMessageRequester, OutboundServiceMock) {
-    let (tx, rx) = mpsc::channel(size);
+pub fn create_outbound_service_mock() -> (OutboundMessageRequester, OutboundServiceMock) {
+    let (tx, rx) = mpsc::unbounded_channel();
     (OutboundMessageRequester::new(tx), OutboundServiceMock::new(rx))
 }
 
@@ -172,12 +172,12 @@ impl Default for OutboundServiceMockState {
 }
 
 pub struct OutboundServiceMock {
-    receiver: mpsc::Receiver<DhtOutboundRequest>,
+    receiver: mpsc::UnboundedReceiver<DhtOutboundRequest>,
     mock_state: OutboundServiceMockState,
 }
 
 impl OutboundServiceMock {
-    pub fn new(receiver: mpsc::Receiver<DhtOutboundRequest>) -> Self {
+    pub fn new(receiver: mpsc::UnboundedReceiver<DhtOutboundRequest>) -> Self {
         Self {
             receiver,
             mock_state: OutboundServiceMockState::new(),

--- a/comms/dht/src/outbound/requester.rs
+++ b/comms/dht/src/outbound/requester.rs
@@ -42,11 +42,11 @@ const LOG_TARGET: &str = "comms::dht::requests::outbound";
 
 #[derive(Clone)]
 pub struct OutboundMessageRequester {
-    sender: mpsc::Sender<DhtOutboundRequest>,
+    sender: mpsc::UnboundedSender<DhtOutboundRequest>,
 }
 
 impl OutboundMessageRequester {
-    pub fn new(sender: mpsc::Sender<DhtOutboundRequest>) -> Self {
+    pub fn new(sender: mpsc::UnboundedSender<DhtOutboundRequest>) -> Self {
         Self { sender }
     }
 
@@ -336,8 +336,7 @@ impl OutboundMessageRequester {
     ) -> Result<SendMessageResponse, DhtOutboundError> {
         let (reply_tx, reply_rx) = oneshot::channel();
         self.sender
-            .send(DhtOutboundRequest::SendMessage(Box::new(params), body, reply_tx))
-            .await?;
+            .send(DhtOutboundRequest::SendMessage(Box::new(params), body, reply_tx))?;
 
         reply_rx
             .await
@@ -352,13 +351,12 @@ impl OutboundMessageRequester {
     ) -> Result<(), DhtOutboundError> {
         let (reply_tx, _) = oneshot::channel();
         self.sender
-            .send(DhtOutboundRequest::SendMessage(Box::new(params), body, reply_tx))
-            .await?;
+            .send(DhtOutboundRequest::SendMessage(Box::new(params), body, reply_tx))?;
         Ok(())
     }
 
     #[cfg(test)]
-    pub fn get_mpsc_sender(&self) -> mpsc::Sender<DhtOutboundRequest> {
+    pub fn get_mpsc_sender(&self) -> mpsc::UnboundedSender<DhtOutboundRequest> {
         self.sender.clone()
     }
 }

--- a/comms/dht/src/test_utils/dht_actor_mock.rs
+++ b/comms/dht/src/test_utils/dht_actor_mock.rs
@@ -39,8 +39,8 @@ use crate::{
     storage::DhtMetadataKey,
 };
 
-pub fn create_dht_actor_mock(buf_size: usize) -> (DhtRequester, DhtActorMock) {
-    let (tx, rx) = mpsc::channel(buf_size);
+pub fn create_dht_actor_mock() -> (DhtRequester, DhtActorMock) {
+    let (tx, rx) = mpsc::unbounded_channel();
     (DhtRequester::new(tx), DhtActorMock::new(rx))
 }
 
@@ -77,12 +77,12 @@ impl DhtMockState {
 }
 
 pub struct DhtActorMock {
-    receiver: mpsc::Receiver<DhtRequest>,
+    receiver: mpsc::UnboundedReceiver<DhtRequest>,
     state: DhtMockState,
 }
 
 impl DhtActorMock {
-    pub fn new(receiver: mpsc::Receiver<DhtRequest>) -> Self {
+    pub fn new(receiver: mpsc::UnboundedReceiver<DhtRequest>) -> Self {
         Self {
             receiver,
             state: DhtMockState::default(),

--- a/comms/dht/tests/harness.rs
+++ b/comms/dht/tests/harness.rs
@@ -156,7 +156,7 @@ pub async fn setup_comms_dht(
     shutdown_signal: ShutdownSignal,
 ) -> (CommsNode, Dht, MessagingEventSender) {
     // Create inbound and outbound channels
-    let (outbound_tx, outbound_rx) = mpsc::channel(10);
+    let (outbound_tx, outbound_rx) = mpsc::unbounded_channel();
 
     let comms = CommsBuilder::new()
         .allow_test_addresses()


### PR DESCRIPTION
Description
---
Change comms channels to unbounded 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Converted all outbound and DHT communication channels from bounded to unbounded, enabling unlimited message buffering across nodes, wallet, and test environments.
  - Updated public interfaces and test utilities to use unbounded channels for outbound messaging.
  - Simplified test and mock setup by removing explicit buffer size parameters.
  - Removed obsolete test code related to bounded channels.

- **Bug Fixes**
  - Removed unnecessary awaits on message sends, improving message handling consistency with unbounded channels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->