### PR TITLE
feat: add connection pool cycling

### DIFF
--- a/comms/core/src/builder/mod.rs
+++ b/comms/core/src/builder/mod.rs
@@ -377,3 +377,21 @@ impl CommsBuilder {
         })
     }
 }
+impl CommsBuilder {
+    // ... existing methods ...
+    
+    /// Configure connection rotation settings
+    pub fn with_connection_rotation(
+        mut self, 
+        long_lived: usize, 
+        daily_rotation: usize, 
+        frequent_rotation: usize,
+        cooldown_days: u64
+    ) -> Self {
+        self.connectivity_config.long_lived_connections = long_lived;
+        self.connectivity_config.daily_rotation_connections = daily_rotation;
+        self.connectivity_config.frequent_rotation_connections = frequent_rotation;
+        self.connectivity_config.node_reconnection_cooldown = Duration::from_secs(cooldown_days * 24 * 60 * 60);
+        self
+    }
+}

--- a/comms/core/src/builder/mod.rs
+++ b/comms/core/src/builder/mod.rs
@@ -378,33 +378,36 @@ impl CommsBuilder {
     }
 
     /// Configure connection rotation settings
-    /// 
+    ///
     /// This configures how outbound connections are maintained and rotated:
     /// - `long_lived`: Number of connections that should remain long-lived (default: 16)
     /// - `daily_rotation`: Number of connections to rotate every 24 hours (default: 12)
     /// - `frequent_rotation`: Number of connections to rotate more frequently (every 2 hours) (default: 4)
     /// - `cooldown_days`: Number of days to wait before reconnecting to a recently disconnected peer (default: 7)
-    /// 
+    ///
     /// # Example
-    /// 
+    ///
     /// # use tari_comms::CommsBuilder;
     /// let builder = CommsBuilder::new()
     ///    .with_connection_rotation(16, 12, 4, 7);
-    /// 
     pub fn with_connection_rotation(
-        mut self, 
-        long_lived: usize, 
-        daily_rotation: usize, 
+        mut self,
+        long_lived: usize,
+        daily_rotation: usize,
         frequent_rotation: usize,
-        cooldown_days: u64
+        cooldown_days: u64,
     ) -> Self {
         // Ensure parameters are within reasonable bounds
-        assert!(long_lived + daily_rotation + frequent_rotation > 0, "At least one connection type must have a non-zero count");
+        assert!(
+            long_lived + daily_rotation + frequent_rotation > 0,
+            "At least one connection type must have a non-zero count"
+        );
         assert!(cooldown_days > 0, "Cooldown period must be positive");
-        
+
         self.connectivity_config.long_lived_connections = long_lived;
         self.connectivity_config.daily_rotation_connections = daily_rotation;
         self.connectivity_config.frequent_rotation_connections = frequent_rotation;
         self.connectivity_config.node_reconnection_cooldown = Duration::from_secs(cooldown_days * 24 * 60 * 60);
         self
-    }}
+    }
+}

--- a/comms/core/src/builder/mod.rs
+++ b/comms/core/src/builder/mod.rs
@@ -377,6 +377,20 @@ impl CommsBuilder {
         })
     }
 
+    /// Configure connection rotation settings
+    /// 
+    /// This configures how outbound connections are maintained and rotated:
+    /// - `long_lived`: Number of connections that should remain long-lived (default: 16)
+    /// - `daily_rotation`: Number of connections to rotate every 24 hours (default: 12)
+    /// - `frequent_rotation`: Number of connections to rotate more frequently (every 2 hours) (default: 4)
+    /// - `cooldown_days`: Number of days to wait before reconnecting to a recently disconnected peer (default: 7)
+    /// 
+    /// # Example
+    /// 
+    /// # use tari_comms::CommsBuilder;
+    /// let builder = CommsBuilder::new()
+    ///    .with_connection_rotation(16, 12, 4, 7);
+    /// 
     pub fn with_connection_rotation(
         mut self, 
         long_lived: usize, 
@@ -384,10 +398,13 @@ impl CommsBuilder {
         frequent_rotation: usize,
         cooldown_days: u64
     ) -> Self {
+        // Ensure parameters are within reasonable bounds
+        assert!(long_lived + daily_rotation + frequent_rotation > 0, "At least one connection type must have a non-zero count");
+        assert!(cooldown_days > 0, "Cooldown period must be positive");
+        
         self.connectivity_config.long_lived_connections = long_lived;
         self.connectivity_config.daily_rotation_connections = daily_rotation;
         self.connectivity_config.frequent_rotation_connections = frequent_rotation;
         self.connectivity_config.node_reconnection_cooldown = Duration::from_secs(cooldown_days * 24 * 60 * 60);
         self
-    }
-}
+    }}

--- a/comms/core/src/builder/mod.rs
+++ b/comms/core/src/builder/mod.rs
@@ -376,11 +376,7 @@ impl CommsBuilder {
             protocol_extensions: ProtocolExtensions::new(),
         })
     }
-}
-impl CommsBuilder {
-    // ... existing methods ...
-    
-    /// Configure connection rotation settings
+
     pub fn with_connection_rotation(
         mut self, 
         long_lived: usize, 

--- a/comms/core/src/connection_manager/error.rs
+++ b/comms/core/src/connection_manager/error.rs
@@ -25,6 +25,7 @@ use tokio::{sync::mpsc, time::error::Elapsed};
 
 use crate::{
     connection_manager::PeerConnectionRequest,
+    connectivity::ConnectivityError,
     multiplexing::YamuxControlError,
     noise,
     noise::NoiseError,
@@ -94,6 +95,8 @@ pub enum ConnectionManagerError {
     AllPeerAddressesAreExcluded(String),
     #[error("Yamux error: {0}")]
     YamuxControlError(#[from] YamuxControlError),
+    #[error("Connectivity error: {0}")]
+    ConnectivityError(#[from] Box<ConnectivityError>),
     #[error("Peer is in cooldown period")]
     PeerInCooldown,
 }

--- a/comms/core/src/connection_manager/error.rs
+++ b/comms/core/src/connection_manager/error.rs
@@ -94,8 +94,9 @@ pub enum ConnectionManagerError {
     AllPeerAddressesAreExcluded(String),
     #[error("Yamux error: {0}")]
     YamuxControlError(#[from] YamuxControlError),
+    #[error("Peer is in cooldown period")]
+    PeerInCooldown,
 }
-
 impl From<yamux::ConnectionError> for ConnectionManagerError {
     fn from(err: yamux::ConnectionError) -> Self {
         ConnectionManagerError::YamuxConnectionError(err.to_string())

--- a/comms/core/src/connectivity/config.rs
+++ b/comms/core/src/connectivity/config.rs
@@ -78,6 +78,12 @@ impl Default for ConnectivityConfig {
             connection_tie_break_linger: Duration::from_secs(2),
             expire_peer_last_seen_duration: Duration::from_secs(24 * 60 * 60),
             maintain_n_closest_connections_only: None,
+            long_lived_connections: 16,
+            daily_rotation_connections: 12,
+            frequent_rotation_connections: 4,
+            node_reconnection_cooldown: Duration::from_secs(7 * 24 * 60 * 60), // 7 days
+            daily_rotation_interval: Duration::from_secs(24 * 60 * 60), // 24 hours
+            frequent_rotation_interval: Duration::from_secs(2 * 60 * 60), // 2 hours
         }
     }
 }

--- a/comms/core/src/connectivity/config.rs
+++ b/comms/core/src/connectivity/config.rs
@@ -52,6 +52,18 @@ pub struct ConnectivityConfig {
     /// The closest number of peer connections to maintain; connections above the threshold will be removed
     /// (default: disabled)
     pub maintain_n_closest_connections_only: Option<usize>,
+    /// Number of connections that should be long-lived (not subject to periodic reaping)
+    pub long_lived_connections: usize,
+    /// Number of connections to rotate every 24 hours
+    pub daily_rotation_connections: usize,
+    /// Number of connections to rotate every 2 hours
+    pub frequent_rotation_connections: usize,
+    /// Minimum time before reconnecting to a previously connected node (7 days)
+    pub node_reconnection_cooldown: Duration,
+    /// Interval for rotating daily connections
+    pub daily_rotation_interval: Duration,
+    /// Interval for rotating frequent connections
+    pub frequent_rotation_interval: Duration,
 }
 
 impl Default for ConnectivityConfig {

--- a/comms/core/src/connectivity/config.rs
+++ b/comms/core/src/connectivity/config.rs
@@ -82,8 +82,8 @@ impl Default for ConnectivityConfig {
             daily_rotation_connections: 12,
             frequent_rotation_connections: 4,
             node_reconnection_cooldown: Duration::from_secs(7 * 24 * 60 * 60), // 7 days
-            daily_rotation_interval: Duration::from_secs(24 * 60 * 60), // 24 hours
-            frequent_rotation_interval: Duration::from_secs(2 * 60 * 60), // 2 hours
+            daily_rotation_interval: Duration::from_secs(24 * 60 * 60),        // 24 hours
+            frequent_rotation_interval: Duration::from_secs(2 * 60 * 60),      // 2 hours
         }
     }
 }

--- a/comms/core/src/connectivity/connection_history.rs
+++ b/comms/core/src/connectivity/connection_history.rs
@@ -30,7 +30,12 @@ impl ConnectionHistory {
             false
         }
     }
-    
+
+    /// Get the time elapsed since disconnection for a node
+    pub fn time_since_disconnection(&self, node_id: &NodeId) -> Option<Duration> {
+        self.last_disconnected.get(node_id).map(|time| time.elapsed())
+    }
+
     /// Clean up old history entries
     pub fn cleanup(&mut self, max_age: Duration) {
         self.last_disconnected.retain(|_, time| time.elapsed() < max_age);

--- a/comms/core/src/connectivity/connection_history.rs
+++ b/comms/core/src/connectivity/connection_history.rs
@@ -41,10 +41,24 @@ impl ConnectionHistory {
         self.last_disconnected.retain(|_, time| time.elapsed() < max_age);
     }
     
-    /// Get nodes that are not in cooldown
-    pub fn get_available_nodes<'a>(&self, nodes: impl Iterator<Item = &'a NodeId>, cooldown: Duration) -> Vec<NodeId> {
-        nodes
-            .filter(|node_id| !self.is_in_cooldown(node_id, cooldown))
+    /// Get nodes that are not in cooldown as an iterator
+    pub fn available_nodes<'a, I>(
+        &'a self,
+        nodes: I,
+        cooldown: Duration,
+    ) -> impl Iterator<Item = &'a NodeId> + 'a 
+    where
+        I: Iterator<Item = &'a NodeId> + 'a,
+    {
+        nodes.filter(move |node_id| !self.is_in_cooldown(node_id, cooldown))
+    }
+    
+    /// Get nodes that are not in cooldown (returns a Vec)
+    pub fn get_available_nodes<'a, I>(&'a self, nodes: I, cooldown: Duration) -> Vec<NodeId> 
+    where
+        I: Iterator<Item = &'a NodeId> + 'a,
+    {
+        self.available_nodes(nodes, cooldown)
             .cloned()
             .collect()
     }

--- a/comms/core/src/connectivity/connection_history.rs
+++ b/comms/core/src/connectivity/connection_history.rs
@@ -54,3 +54,9 @@ impl ConnectionHistory {
         self.available_nodes(nodes, cooldown).cloned().collect()
     }
 }
+
+impl Default for ConnectionHistory {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/comms/core/src/connectivity/connection_history.rs
+++ b/comms/core/src/connectivity/connection_history.rs
@@ -1,0 +1,46 @@
+use std::{
+    collections::HashMap,
+    time::{Duration, Instant},
+};
+use crate::peer_manager::NodeId;
+
+/// Tracks connection history to nodes to enforce cooldown periods
+pub struct ConnectionHistory {
+    /// Maps node IDs to the last time we disconnected from them
+    last_disconnected: HashMap<NodeId, Instant>,
+}
+
+impl ConnectionHistory {
+    pub fn new() -> Self {
+        Self {
+            last_disconnected: HashMap::new(),
+        }
+    }
+    
+    /// Record that we disconnected from a node
+    pub fn record_disconnection(&mut self, node_id: &NodeId) {
+        self.last_disconnected.insert(node_id.clone(), Instant::now());
+    }
+    
+    /// Check if a node is in cooldown period
+    pub fn is_in_cooldown(&self, node_id: &NodeId, cooldown: Duration) -> bool {
+        if let Some(last_time) = self.last_disconnected.get(node_id) {
+            last_time.elapsed() < cooldown
+        } else {
+            false
+        }
+    }
+    
+    /// Clean up old history entries
+    pub fn cleanup(&mut self, max_age: Duration) {
+        self.last_disconnected.retain(|_, time| time.elapsed() < max_age);
+    }
+    
+    /// Get nodes that are not in cooldown
+    pub fn get_available_nodes<'a>(&self, nodes: impl Iterator<Item = &'a NodeId>, cooldown: Duration) -> Vec<NodeId> {
+        nodes
+            .filter(|node_id| !self.is_in_cooldown(node_id, cooldown))
+            .cloned()
+            .collect()
+    }
+}

--- a/comms/core/src/connectivity/connection_history.rs
+++ b/comms/core/src/connectivity/connection_history.rs
@@ -2,6 +2,7 @@ use std::{
     collections::HashMap,
     time::{Duration, Instant},
 };
+
 use crate::peer_manager::NodeId;
 
 /// Tracks connection history to nodes to enforce cooldown periods
@@ -16,12 +17,12 @@ impl ConnectionHistory {
             last_disconnected: HashMap::new(),
         }
     }
-    
+
     /// Record that we disconnected from a node
     pub fn record_disconnection(&mut self, node_id: &NodeId) {
         self.last_disconnected.insert(node_id.clone(), Instant::now());
     }
-    
+
     /// Check if a node is in cooldown period
     pub fn is_in_cooldown(&self, node_id: &NodeId, cooldown: Duration) -> bool {
         if let Some(last_time) = self.last_disconnected.get(node_id) {
@@ -40,26 +41,16 @@ impl ConnectionHistory {
     pub fn cleanup(&mut self, max_age: Duration) {
         self.last_disconnected.retain(|_, time| time.elapsed() < max_age);
     }
-    
+
     /// Get nodes that are not in cooldown as an iterator
-    pub fn available_nodes<'a, I>(
-        &'a self,
-        nodes: I,
-        cooldown: Duration,
-    ) -> impl Iterator<Item = &'a NodeId> + 'a 
-    where
-        I: Iterator<Item = &'a NodeId> + 'a,
-    {
+    pub fn available_nodes<'a, I>(&'a self, nodes: I, cooldown: Duration) -> impl Iterator<Item = &'a NodeId> + 'a
+    where I: Iterator<Item = &'a NodeId> + 'a {
         nodes.filter(move |node_id| !self.is_in_cooldown(node_id, cooldown))
     }
-    
+
     /// Get nodes that are not in cooldown (returns a Vec)
-    pub fn get_available_nodes<'a, I>(&'a self, nodes: I, cooldown: Duration) -> Vec<NodeId> 
-    where
-        I: Iterator<Item = &'a NodeId> + 'a,
-    {
-        self.available_nodes(nodes, cooldown)
-            .cloned()
-            .collect()
+    pub fn get_available_nodes<'a, I>(&'a self, nodes: I, cooldown: Duration) -> Vec<NodeId>
+    where I: Iterator<Item = &'a NodeId> + 'a {
+        self.available_nodes(nodes, cooldown).cloned().collect()
     }
 }

--- a/comms/core/src/connectivity/connection_history.rs
+++ b/comms/core/src/connectivity/connection_history.rs
@@ -1,3 +1,25 @@
+//  Copyright 2025, The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 use std::{
     collections::HashMap,
     time::{Duration, Instant},

--- a/comms/core/src/connectivity/connection_pool.rs
+++ b/comms/core/src/connectivity/connection_pool.rs
@@ -173,6 +173,15 @@ impl ConnectionPool {
         })
     }
 
+    /// Get all outbound connections
+    pub fn get_outbound_connections_mut(&mut self) -> Vec<&mut PeerConnection> {
+        self.connections
+            .values_mut()
+            .filter_map(|c| c.connection_mut())
+            .filter(|conn| conn.is_connected() && conn.direction().is_outbound())
+            .collect()
+    }
+}
     pub(in crate::connectivity) fn filter_drain<P>(&mut self, mut predicate: P) -> Vec<PeerConnectionState>
     where P: FnMut(&PeerConnectionState) -> bool {
         let (keep, remove) = self

--- a/comms/core/src/connectivity/connection_pool.rs
+++ b/comms/core/src/connectivity/connection_pool.rs
@@ -182,6 +182,15 @@ impl ConnectionPool {
             .collect()
     }
 
+    /// Get all outbound connections (non-mutable references)
+    pub fn get_outbound_connections(&self) -> Vec<&PeerConnection> {
+        self.connections
+            .values()
+            .filter_map(|c| c.connection())
+            .filter(|conn| conn.is_connected() && conn.direction().is_outbound())
+            .collect()
+    }
+
     pub(in crate::connectivity) fn filter_drain<P>(&mut self, mut predicate: P) -> Vec<PeerConnectionState>
     where P: FnMut(&PeerConnectionState) -> bool {
         let (keep, remove) = self

--- a/comms/core/src/connectivity/connection_pool.rs
+++ b/comms/core/src/connectivity/connection_pool.rs
@@ -181,7 +181,7 @@ impl ConnectionPool {
             .filter(|conn| conn.is_connected() && conn.direction().is_outbound())
             .collect()
     }
-}
+
     pub(in crate::connectivity) fn filter_drain<P>(&mut self, mut predicate: P) -> Vec<PeerConnectionState>
     where P: FnMut(&PeerConnectionState) -> bool {
         let (keep, remove) = self

--- a/comms/core/src/connectivity/error.rs
+++ b/comms/core/src/connectivity/error.rs
@@ -44,8 +44,8 @@ pub enum ConnectivityError {
     DialCancelled,
     #[error("Client cancelled: '{0}'")]
     ClientCancelled(String),
-    #[error("Connection limit reached")]
-    ConnectionLimitReached,
+    #[error("Connection limit reached ({current}/{max} connections)")]
+    ConnectionLimitReached { current: usize, max: usize },
 }
 
 impl From<ConnectionManagerError> for ConnectivityError {

--- a/comms/core/src/connectivity/error.rs
+++ b/comms/core/src/connectivity/error.rs
@@ -23,9 +23,8 @@
 use thiserror::Error;
 
 use crate::{connection_manager::ConnectionManagerError, peer_manager::PeerManagerError, PeerConnectionError};
-
 /// Errors for the Connectivity actor.
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Clone)]
 pub enum ConnectivityError {
     #[error("Cannot send request because ConnectivityActor disconnected")]
     ActorDisconnected,
@@ -34,7 +33,7 @@ pub enum ConnectivityError {
     #[error("PeerManagerError: {0}")]
     PeerManagerError(#[from] PeerManagerError),
     #[error("Peer connection error: {0}")]
-    PeerConnectionError(#[from] PeerConnectionError),
+    PeerConnectionError(String),
     #[error("ConnectionFailed: {0}")]
     ConnectionFailed(ConnectionManagerError),
     #[error("Connectivity event stream closed unexpectedly")]
@@ -45,6 +44,8 @@ pub enum ConnectivityError {
     DialCancelled,
     #[error("Client cancelled: '{0}'")]
     ClientCancelled(String),
+    #[error("Connection limit reached")]
+    ConnectionLimitReached,
 }
 
 impl From<ConnectionManagerError> for ConnectivityError {
@@ -53,5 +54,11 @@ impl From<ConnectionManagerError> for ConnectivityError {
             ConnectionManagerError::DialCancelled => Self::DialCancelled,
             err => Self::ConnectionFailed(err),
         }
+    }
+}
+
+impl From<PeerConnectionError> for ConnectivityError {
+    fn from(err: PeerConnectionError) -> Self {
+        Self::PeerConnectionError(err.to_string())
     }
 }

--- a/comms/core/src/connectivity/manager.rs
+++ b/comms/core/src/connectivity/manager.rs
@@ -385,10 +385,12 @@ impl ConnectivityManagerActor {
         
         // Check if the node is in cooldown
         if self.connection_history.is_in_cooldown(&node_id, self.config.node_reconnection_cooldown) {
-            debug!(
+            info!(  // Use info level for testing
                 target: LOG_TARGET,
-                "Not dialing peer '{}' because it's in cooldown period",
-                node_id.short_str()
+                "Not dialing peer '{}' because it's in cooldown period ({}m remaining)",
+                node_id.short_str(),
+                (self.config.node_reconnection_cooldown.as_secs() - 
+                 self.connection_history.time_since_disconnection(&node_id).unwrap_or_default().as_secs()) / 60
             );
             
             if let Some(reply) = reply_tx {
@@ -501,9 +503,11 @@ impl ConnectivityManagerActor {
     async fn rotate_connections(&mut self, task_id: u64) -> Result<(), ConnectivityError> {
         // Check if it's time for daily rotation
         if self.last_daily_rotation.elapsed() >= self.config.daily_rotation_interval {
-            debug!(
+            info!(  // Use info level for testing
                 target: LOG_TARGET,
-                "({}) Performing daily connection rotation", task_id
+                "({}) Performing daily connection rotation (every {} minutes)",
+                task_id,
+                self.config.daily_rotation_interval.as_secs() / 60
             );
             self.rotate_connection_group(
                 self.config.daily_rotation_connections,
@@ -515,9 +519,11 @@ impl ConnectivityManagerActor {
         
         // Check if it's time for frequent rotation
         if self.last_frequent_rotation.elapsed() >= self.config.frequent_rotation_interval {
-            debug!(
+            info!(  // Use info level for testing
                 target: LOG_TARGET,
-                "({}) Performing frequent connection rotation", task_id
+                "({}) Performing frequent connection rotation (every {} minutes)",
+                task_id,
+                self.config.frequent_rotation_interval.as_secs() / 60
             );
             let start_index = self.config.long_lived_connections + self.config.daily_rotation_connections;
             self.rotate_connection_group(

--- a/comms/core/src/connectivity/manager.rs
+++ b/comms/core/src/connectivity/manager.rs
@@ -39,6 +39,7 @@ use tracing::{span, Instrument, Level};
 
 use super::{
     config::ConnectivityConfig,
+    connection_history::ConnectionHistory,
     connection_pool::{ConnectionPool, ConnectionStatus},
     connection_stats::PeerConnectionStats,
     error::ConnectivityError,
@@ -108,6 +109,9 @@ impl ConnectivityManager {
             #[cfg(feature = "metrics")]
             uptime: Some(Instant::now()),
             allow_list: vec![],
+            connection_history: ConnectionHistory::new(),
+            last_daily_rotation: Instant::now(),
+            last_frequent_rotation: Instant::now(),
         }
         .spawn()
     }

--- a/comms/core/src/connectivity/manager.rs
+++ b/comms/core/src/connectivity/manager.rs
@@ -538,27 +538,30 @@ impl ConnectivityManagerActor {
         start_index: usize, 
         task_id: u64
     ) -> Result<(), ConnectivityError> {
-        // Get all active outbound connections
-        let mut connections = self.pool
-            .get_outbound_connections_mut()
-            .into_iter()
+        // Snapshot the outbound **NodeIds** first so that `self.pool` is no longer borrowed
+        let mut node_ids = self
+            .pool
+            .get_outbound_connections()
+            .iter()
             .filter(|conn| conn.is_connected())
+            .map(|conn| conn.peer_node_id().clone())
             .collect::<Vec<_>>();
-        
-        // Sort by some deterministic criteria (e.g., node_id)
-        connections.sort_by(|a, b| a.peer_node_id().cmp(b.peer_node_id()));
+
+        // Sort deterministically
+        node_ids.sort();
         
         // Select the connections to rotate
-        let end_index = (start_index + count).min(connections.len());
-        if start_index >= connections.len() {
+        let end_index = (start_index + count).min(node_ids.len());
+        if start_index >= node_ids.len() {
             return Ok(());
         }
         
         // Collect node IDs to disconnect
         let mut nodes_to_remove = Vec::new();
         
-        for conn in &mut connections[start_index..end_index] {
-            let node_id = conn.peer_node_id().clone();
+        for node_id in &node_ids[start_index..end_index] {
+            let Some(mut conn) = self.pool.get_connection_mut(node_id) else { continue };
+            
             debug!(
                 target: LOG_TARGET,
                 "({}) Rotating connection to '{}' as part of scheduled rotation",
@@ -567,12 +570,12 @@ impl ConnectivityManagerActor {
             );
             
             // Record the disconnection in history
-            self.connection_history.record_disconnection(&node_id);
+            self.connection_history.record_disconnection(node_id);
             
             // Disconnect
-            match disconnect_with_timeout(conn, Minimized::Yes, Some(task_id)).await {
+            match disconnect_with_timeout(&mut conn, Minimized::Yes, Some(task_id)).await {
                 Ok(_) => {
-                    nodes_to_remove.push(node_id);
+                    nodes_to_remove.push(node_id.clone());
                 },
                 Err(err) => {
                     debug!(

--- a/comms/core/src/connectivity/manager.rs
+++ b/comms/core/src/connectivity/manager.rs
@@ -548,6 +548,9 @@ impl ConnectivityManagerActor {
             return Ok(());
         }
         
+        // Collect node IDs to disconnect
+        let mut nodes_to_remove = Vec::new();
+        
         for conn in &mut connections[start_index..end_index] {
             let node_id = conn.peer_node_id().clone();
             debug!(
@@ -563,7 +566,7 @@ impl ConnectivityManagerActor {
             // Disconnect
             match disconnect_with_timeout(conn, Minimized::Yes, Some(task_id)).await {
                 Ok(_) => {
-                    self.pool.remove(&node_id);
+                    nodes_to_remove.push(node_id);
                 },
                 Err(err) => {
                     debug!(
@@ -577,9 +580,13 @@ impl ConnectivityManagerActor {
             }
         }
         
+        // Now remove the nodes from the pool
+        for node_id in nodes_to_remove {
+            self.pool.remove(&node_id);
+        }
+        
         Ok(())
     }
-
     async fn delete_stale_peers_from_db(&mut self, task_id: u64) {
         let start = Instant::now();
         match tokio::time::timeout(

--- a/comms/core/src/connectivity/manager.rs
+++ b/comms/core/src/connectivity/manager.rs
@@ -165,6 +165,9 @@ struct ConnectivityManagerActor {
     #[cfg(feature = "metrics")]
     uptime: Option<Instant>,
     allow_list: Vec<NodeId>,
+    connection_history: ConnectionHistory,
+    last_daily_rotation: Instant,
+    last_frequent_rotation: Instant,
 }
 
 impl ConnectivityManagerActor {
@@ -375,6 +378,21 @@ impl ConnectivityManagerActor {
                 return;
             },
         }
+        
+        // Check if the node is in cooldown
+        if self.connection_history.is_in_cooldown(&node_id, self.config.node_reconnection_cooldown) {
+            debug!(
+                target: LOG_TARGET,
+                "Not dialing peer '{}' because it's in cooldown period",
+                node_id.short_str()
+            );
+            
+            if let Some(reply) = reply_tx {
+                let _result = reply.send(Err(ConnectionManagerError::PeerInCooldown));
+            }
+            return;
+        }
+        
         match self.pool.get(&node_id) {
             // The connection pool may temporarily contain a connection that is not connected so we need to check this.
             Some(state) if state.is_connected() => {

--- a/comms/core/src/connectivity/manager.rs
+++ b/comms/core/src/connectivity/manager.rs
@@ -155,7 +155,7 @@ impl fmt::Display for ConnectivityStatus {
     }
 }
 
-struct ConnectivityManagerActor {
+pub struct ConnectivityManagerActor {
     config: ConnectivityConfig,
     status: ConnectivityStatus,
     request_rx: mpsc::Receiver<ConnectivityRequest>,
@@ -181,6 +181,10 @@ impl ConnectivityManagerActor {
 
     pub async fn run(mut self) {
         debug!(target: LOG_TARGET, "ConnectivityManager started");
+
+        // Initialize rotation timers to trigger rotation soon after startup
+        self.last_daily_rotation = Instant::now() - (self.config.daily_rotation_interval / 2);
+        self.last_frequent_rotation = Instant::now() - (self.config.frequent_rotation_interval / 2);
 
         let mut connection_manager_events = self.connection_manager.get_event_subscription();
 
@@ -398,8 +402,20 @@ impl ConnectivityManagerActor {
                         self.config.frequent_rotation_connections
                     );
                     if let Some(reply) = reply_tx {
+                        let max_connections = self.config.long_lived_connections + 
+                            self.config.daily_rotation_connections + 
+                            self.config.frequent_rotation_connections;
+                        let outbound_connections = self.pool
+                            .filter_connection_states(|state| 
+                                state.is_connected() && 
+                                state.connection().map_or(false, |conn| conn.direction().is_outbound())
+                            )
+                            .len();
                         let _ = reply.send(Err(ConnectionManagerError::ConnectivityError(
-                            Box::new(ConnectivityError::ConnectionLimitReached)
+                            Box::new(ConnectivityError::ConnectionLimitReached { 
+                                current: outbound_connections, 
+                                max: max_connections 
+                            })
                         )));
                     }
                     return;
@@ -530,8 +546,8 @@ impl ConnectivityManagerActor {
             self.pool.count_connected_clients()
         );
 
-        // Clean up old connection history
-        self.connection_history.cleanup(self.config.node_reconnection_cooldown * 2);
+        // Clean up connection history - use the exact cooldown period to avoid excessive memory usage
+        self.connection_history.cleanup(self.config.node_reconnection_cooldown);
         
         // Perform scheduled rotation
         self.rotate_connections(task_id).await?;
@@ -547,11 +563,10 @@ impl ConnectivityManagerActor {
         self.update_connectivity_metrics();
         Ok(())
     }
-
     async fn rotate_connections(&mut self, task_id: u64) -> Result<(), ConnectivityError> {
         // Check if it's time for daily rotation
         if self.last_daily_rotation.elapsed() >= self.config.daily_rotation_interval {
-            info!(  // Use info level for testing
+            debug!(
                 target: LOG_TARGET,
                 "({}) Performing daily connection rotation (every {} minutes)",
                 task_id,
@@ -567,7 +582,7 @@ impl ConnectivityManagerActor {
         
         // Check if it's time for frequent rotation
         if self.last_frequent_rotation.elapsed() >= self.config.frequent_rotation_interval {
-            info!(  // Use info level for testing
+            debug!(
                 target: LOG_TARGET,
                 "({}) Performing frequent connection rotation (every {} minutes)",
                 task_id,

--- a/comms/core/src/connectivity/manager.rs
+++ b/comms/core/src/connectivity/manager.rs
@@ -474,6 +474,12 @@ impl ConnectivityManagerActor {
             self.pool.count_connected_clients()
         );
 
+        // Clean up old connection history
+        self.connection_history.cleanup(self.config.node_reconnection_cooldown * 2);
+        
+        // Perform scheduled rotation
+        self.rotate_connections(task_id).await?;
+        
         self.clean_connection_pool();
         if self.config.is_connection_reaping_enabled {
             self.reap_inactive_connections(task_id).await;
@@ -483,6 +489,94 @@ impl ConnectivityManagerActor {
         }
         self.update_connectivity_status();
         self.update_connectivity_metrics();
+        Ok(())
+    }
+
+    async fn rotate_connections(&mut self, task_id: u64) -> Result<(), ConnectivityError> {
+        // Check if it's time for daily rotation
+        if self.last_daily_rotation.elapsed() >= self.config.daily_rotation_interval {
+            debug!(
+                target: LOG_TARGET,
+                "({}) Performing daily connection rotation", task_id
+            );
+            self.rotate_connection_group(
+                self.config.daily_rotation_connections,
+                self.config.long_lived_connections,
+                task_id
+            ).await?;
+            self.last_daily_rotation = Instant::now();
+        }
+        
+        // Check if it's time for frequent rotation
+        if self.last_frequent_rotation.elapsed() >= self.config.frequent_rotation_interval {
+            debug!(
+                target: LOG_TARGET,
+                "({}) Performing frequent connection rotation", task_id
+            );
+            let start_index = self.config.long_lived_connections + self.config.daily_rotation_connections;
+            self.rotate_connection_group(
+                self.config.frequent_rotation_connections,
+                start_index,
+                task_id
+            ).await?;
+            self.last_frequent_rotation = Instant::now();
+        }
+        
+        Ok(())
+    }
+
+    // Helper method to rotate a specific group of connections
+    async fn rotate_connection_group(
+        &mut self, 
+        count: usize, 
+        start_index: usize, 
+        task_id: u64
+    ) -> Result<(), ConnectivityError> {
+        // Get all active outbound connections
+        let mut connections = self.pool
+            .get_outbound_connections_mut()
+            .into_iter()
+            .filter(|conn| conn.is_connected())
+            .collect::<Vec<_>>();
+        
+        // Sort by some deterministic criteria (e.g., node_id)
+        connections.sort_by(|a, b| a.peer_node_id().cmp(b.peer_node_id()));
+        
+        // Select the connections to rotate
+        let end_index = (start_index + count).min(connections.len());
+        if start_index >= connections.len() {
+            return Ok(());
+        }
+        
+        for conn in &mut connections[start_index..end_index] {
+            let node_id = conn.peer_node_id().clone();
+            debug!(
+                target: LOG_TARGET,
+                "({}) Rotating connection to '{}' as part of scheduled rotation",
+                task_id,
+                node_id.short_str()
+            );
+            
+            // Record the disconnection in history
+            self.connection_history.record_disconnection(&node_id);
+            
+            // Disconnect
+            match disconnect_with_timeout(conn, Minimized::Yes, Some(task_id)).await {
+                Ok(_) => {
+                    self.pool.remove(&node_id);
+                },
+                Err(err) => {
+                    debug!(
+                        target: LOG_TARGET,
+                        "({}) Error disconnecting peer '{}' during rotation: {:?}",
+                        task_id,
+                        node_id.short_str(),
+                        err
+                    );
+                }
+            }
+        }
+        
         Ok(())
     }
 

--- a/comms/core/src/connectivity/manager.rs
+++ b/comms/core/src/connectivity/manager.rs
@@ -440,9 +440,15 @@ impl ConnectivityManagerActor {
                 if !conn.is_connected() {
                     continue;
                 }
+                
+                let node_id = conn.peer_node_id().clone();
+                
+                // Record the disconnection in history
+                self.connection_history.record_disconnection(&node_id);
+                
                 match disconnect_silent_with_timeout(conn, Minimized::No, None).await {
                     Ok(_) => {
-                        node_ids.push(conn.peer_node_id().clone());
+                        node_ids.push(node_id);
                     },
                     Err(err) => {
                         debug!(
@@ -660,16 +666,21 @@ impl ConnectivityManagerActor {
         // Disconnect all remaining peers above the threshold
         let len = connections.len();
         for conn in connections.iter_mut().skip(threshold) {
+            let node_id = conn.peer_node_id().clone();
             debug!(
                 target: LOG_TARGET,
                 "minimize_connections: ({}) Disconnecting '{}' because the node is not among the {} closest peers",
                 task_id,
-                conn.peer_node_id(),
+                node_id,
                 threshold
             );
+            
+            // Record the disconnection in history
+            self.connection_history.record_disconnection(&node_id);
+            
             match disconnect_with_timeout(conn, Minimized::Yes, Some(task_id)).await {
                 Ok(_) => {
-                    self.pool.remove(conn.peer_node_id());
+                    self.pool.remove(&node_id);
                 },
                 Err(err) => {
                     debug!(
@@ -712,16 +723,21 @@ impl ConnectivityManagerActor {
                 continue;
             }
 
+            let node_id = conn.peer_node_id().clone();
             debug!(
                 target: LOG_TARGET,
                 "({}) Disconnecting '{}' because connection was inactive ({} handles)",
                 task_id,
-                conn.peer_node_id().short_str(),
+                node_id.short_str(),
                 conn.handle_count()
             );
+            
+            // Record the disconnection in history
+            self.connection_history.record_disconnection(&node_id);
+            
             match disconnect_with_timeout(conn, Minimized::Yes, Some(task_id)).await {
                 Ok(_) => {
-                    nodes_to_remove.push(conn.peer_node_id().clone());
+                    nodes_to_remove.push(node_id);
                 },
                 Err(err) => {
                     debug!(
@@ -891,6 +907,9 @@ impl ConnectivityManagerActor {
                         return Ok(());
                     }
                 }
+                
+                // Remember that we recently spoke to this peer
+                self.connection_history.record_disconnection(node_id);
             },
             PeerViolation { peer_node_id, details } => {
                 self.ban_peer(
@@ -1244,6 +1263,9 @@ impl ConnectivityManagerActor {
         self.publish_event(ConnectivityEvent::PeerBanned(node_id.clone()));
 
         if let Some(conn) = self.pool.get_connection_mut(node_id) {
+            // Record the disconnection in history
+            self.connection_history.record_disconnection(node_id);
+            
             disconnect_with_timeout(conn, Minimized::Yes, None).await?;
             let status = self.pool.get_connection_status(node_id);
             debug!(

--- a/comms/core/src/connectivity/manager.rs
+++ b/comms/core/src/connectivity/manager.rs
@@ -361,12 +361,60 @@ impl ConnectivityManagerActor {
             },
         }
     }
+    // Check if we're at the connection limit
+    async fn check_connection_limit(&self) -> Result<bool, ConnectivityError> {
+        // Get all outbound connections
+        let outbound_connections = self.pool
+                    .filter_connection_states(|state| 
+                        state.is_connected() && 
+                        state.connection().map_or(false, |conn| conn.direction().is_outbound())
+                    )
+            .len();
+        
+        // Calculate the maximum allowed connections
+        let max_connections = self.config.long_lived_connections + 
+                            self.config.daily_rotation_connections + 
+                            self.config.frequent_rotation_connections;
+        
+        // Return whether we're under the limit
+        Ok(outbound_connections < max_connections)
+    }
 
     async fn handle_dial_peer(
         &mut self,
         node_id: NodeId,
         reply_tx: Option<oneshot::Sender<Result<PeerConnection, ConnectionManagerError>>>,
     ) {
+        // Check if we're already at the connection limit
+        match self.check_connection_limit().await {
+            Ok(under_limit) => {
+                if !under_limit {
+                    debug!(
+                        target: LOG_TARGET,
+                        "Not connecting to peer {} as we're already at the connection limit of {}", 
+                        node_id,
+                        self.config.long_lived_connections + 
+                        self.config.daily_rotation_connections + 
+                        self.config.frequent_rotation_connections
+                    );
+                    if let Some(reply) = reply_tx {
+                        let _ = reply.send(Err(ConnectionManagerError::ConnectivityError(
+                            Box::new(ConnectivityError::ConnectionLimitReached)
+                        )));
+                    }
+                    return;
+                }
+            },
+            Err(err) => {
+                error!(
+                    target: LOG_TARGET,
+                    "Failed to check connection limit: {}", err
+                );
+                let _ = reply_tx.map(|tx| tx.send(Err(ConnectionManagerError::ConnectivityError(Box::new(err)))));
+                return;
+            }
+        }
+
         match self.peer_manager.is_peer_banned(&node_id).await {
             Ok(true) => {
                 if let Some(reply) = reply_tx {

--- a/comms/core/src/connectivity/manager.rs
+++ b/comms/core/src/connectivity/manager.rs
@@ -372,7 +372,7 @@ impl ConnectivityManagerActor {
         let outbound_connections = self
             .pool
             .filter_connection_states(|state| {
-                state.is_connected() && state.connection().map_or(false, |conn| conn.direction().is_outbound())
+                state.is_connected() && state.connection().is_some_and(|conn| conn.direction().is_outbound())
             })
             .len();
 
@@ -385,6 +385,7 @@ impl ConnectivityManagerActor {
         Ok(outbound_connections < max_connections)
     }
 
+    #[allow(clippy::too_many_lines)]
     async fn handle_dial_peer(
         &mut self,
         node_id: NodeId,
@@ -410,10 +411,10 @@ impl ConnectivityManagerActor {
                             .pool
                             .filter_connection_states(|state| {
                                 state.is_connected() &&
-                                    state.connection().map_or(false, |conn| conn.direction().is_outbound())
+                                    state.connection().is_some_and(|conn| conn.direction().is_outbound())
                             })
                             .len();
-                        let _ = reply.send(Err(ConnectionManagerError::ConnectivityError(Box::new(
+                        let _unused = reply.send(Err(ConnectionManagerError::ConnectivityError(Box::new(
                             ConnectivityError::ConnectionLimitReached {
                                 current: outbound_connections,
                                 max: max_connections,
@@ -428,7 +429,7 @@ impl ConnectivityManagerActor {
                     target: LOG_TARGET,
                     "Failed to check connection limit: {}", err
                 );
-                let _ = reply_tx.map(|tx| tx.send(Err(ConnectionManagerError::ConnectivityError(Box::new(err)))));
+                let _unused = reply_tx.map(|tx| tx.send(Err(ConnectionManagerError::ConnectivityError(Box::new(err)))));
                 return;
             },
         }
@@ -633,7 +634,7 @@ impl ConnectivityManagerActor {
         let mut nodes_to_remove = Vec::new();
 
         for node_id in &node_ids[start_index..end_index] {
-            let Some(mut conn) = self.pool.get_connection_mut(node_id) else {
+            let Some(conn) = self.pool.get_connection_mut(node_id) else {
                 continue;
             };
 
@@ -648,7 +649,7 @@ impl ConnectivityManagerActor {
             self.connection_history.record_disconnection(node_id);
 
             // Disconnect
-            match disconnect_with_timeout(&mut conn, Minimized::Yes, Some(task_id)).await {
+            match disconnect_with_timeout(conn, Minimized::Yes, Some(task_id)).await {
                 Ok(_) => {
                     nodes_to_remove.push(node_id.clone());
                 },

--- a/comms/core/src/connectivity/manager.rs
+++ b/comms/core/src/connectivity/manager.rs
@@ -365,21 +365,22 @@ impl ConnectivityManagerActor {
             },
         }
     }
+
     // Check if we're at the connection limit
     async fn check_connection_limit(&self) -> Result<bool, ConnectivityError> {
         // Get all outbound connections
-        let outbound_connections = self.pool
-                    .filter_connection_states(|state| 
-                        state.is_connected() && 
-                        state.connection().map_or(false, |conn| conn.direction().is_outbound())
-                    )
+        let outbound_connections = self
+            .pool
+            .filter_connection_states(|state| {
+                state.is_connected() && state.connection().map_or(false, |conn| conn.direction().is_outbound())
+            })
             .len();
-        
+
         // Calculate the maximum allowed connections
-        let max_connections = self.config.long_lived_connections + 
-                            self.config.daily_rotation_connections + 
-                            self.config.frequent_rotation_connections;
-        
+        let max_connections = self.config.long_lived_connections +
+            self.config.daily_rotation_connections +
+            self.config.frequent_rotation_connections;
+
         // Return whether we're under the limit
         Ok(outbound_connections < max_connections)
     }
@@ -395,28 +396,29 @@ impl ConnectivityManagerActor {
                 if !under_limit {
                     debug!(
                         target: LOG_TARGET,
-                        "Not connecting to peer {} as we're already at the connection limit of {}", 
+                        "Not connecting to peer {} as we're already at the connection limit of {}",
                         node_id,
-                        self.config.long_lived_connections + 
-                        self.config.daily_rotation_connections + 
+                        self.config.long_lived_connections +
+                        self.config.daily_rotation_connections +
                         self.config.frequent_rotation_connections
                     );
                     if let Some(reply) = reply_tx {
-                        let max_connections = self.config.long_lived_connections + 
-                            self.config.daily_rotation_connections + 
+                        let max_connections = self.config.long_lived_connections +
+                            self.config.daily_rotation_connections +
                             self.config.frequent_rotation_connections;
-                        let outbound_connections = self.pool
-                            .filter_connection_states(|state| 
-                                state.is_connected() && 
-                                state.connection().map_or(false, |conn| conn.direction().is_outbound())
-                            )
-                            .len();
-                        let _ = reply.send(Err(ConnectionManagerError::ConnectivityError(
-                            Box::new(ConnectivityError::ConnectionLimitReached { 
-                                current: outbound_connections, 
-                                max: max_connections 
+                        let outbound_connections = self
+                            .pool
+                            .filter_connection_states(|state| {
+                                state.is_connected() &&
+                                    state.connection().map_or(false, |conn| conn.direction().is_outbound())
                             })
-                        )));
+                            .len();
+                        let _ = reply.send(Err(ConnectionManagerError::ConnectivityError(Box::new(
+                            ConnectivityError::ConnectionLimitReached {
+                                current: outbound_connections,
+                                max: max_connections,
+                            },
+                        ))));
                     }
                     return;
                 }
@@ -428,7 +430,7 @@ impl ConnectivityManagerActor {
                 );
                 let _ = reply_tx.map(|tx| tx.send(Err(ConnectionManagerError::ConnectivityError(Box::new(err)))));
                 return;
-            }
+            },
         }
 
         match self.peer_manager.is_peer_banned(&node_id).await {
@@ -446,23 +448,26 @@ impl ConnectivityManagerActor {
                 return;
             },
         }
-        
+
         // Check if the node is in cooldown
-        if self.connection_history.is_in_cooldown(&node_id, self.config.node_reconnection_cooldown) {
+        if self
+            .connection_history
+            .is_in_cooldown(&node_id, self.config.node_reconnection_cooldown)
+        {
             info!(  // Use info level for testing
                 target: LOG_TARGET,
                 "Not dialing peer '{}' because it's in cooldown period ({}m remaining)",
                 node_id.short_str(),
-                (self.config.node_reconnection_cooldown.as_secs() - 
+                (self.config.node_reconnection_cooldown.as_secs() -
                  self.connection_history.time_since_disconnection(&node_id).unwrap_or_default().as_secs()) / 60
             );
-            
+
             if let Some(reply) = reply_tx {
                 let _result = reply.send(Err(ConnectionManagerError::PeerInCooldown));
             }
             return;
         }
-        
+
         match self.pool.get(&node_id) {
             // The connection pool may temporarily contain a connection that is not connected so we need to check this.
             Some(state) if state.is_connected() => {
@@ -506,12 +511,12 @@ impl ConnectivityManagerActor {
                 if !conn.is_connected() {
                     continue;
                 }
-                
+
                 let node_id = conn.peer_node_id().clone();
-                
+
                 // Record the disconnection in history
                 self.connection_history.record_disconnection(&node_id);
-                
+
                 match disconnect_silent_with_timeout(conn, Minimized::No, None).await {
                     Ok(_) => {
                         node_ids.push(node_id);
@@ -548,10 +553,10 @@ impl ConnectivityManagerActor {
 
         // Clean up connection history - use the exact cooldown period to avoid excessive memory usage
         self.connection_history.cleanup(self.config.node_reconnection_cooldown);
-        
+
         // Perform scheduled rotation
         self.rotate_connections(task_id).await?;
-        
+
         self.clean_connection_pool();
         if self.config.is_connection_reaping_enabled {
             self.reap_inactive_connections(task_id).await;
@@ -563,6 +568,7 @@ impl ConnectivityManagerActor {
         self.update_connectivity_metrics();
         Ok(())
     }
+
     async fn rotate_connections(&mut self, task_id: u64) -> Result<(), ConnectivityError> {
         // Check if it's time for daily rotation
         if self.last_daily_rotation.elapsed() >= self.config.daily_rotation_interval {
@@ -575,11 +581,12 @@ impl ConnectivityManagerActor {
             self.rotate_connection_group(
                 self.config.daily_rotation_connections,
                 self.config.long_lived_connections,
-                task_id
-            ).await?;
+                task_id,
+            )
+            .await?;
             self.last_daily_rotation = Instant::now();
         }
-        
+
         // Check if it's time for frequent rotation
         if self.last_frequent_rotation.elapsed() >= self.config.frequent_rotation_interval {
             debug!(
@@ -589,23 +596,20 @@ impl ConnectivityManagerActor {
                 self.config.frequent_rotation_interval.as_secs() / 60
             );
             let start_index = self.config.long_lived_connections + self.config.daily_rotation_connections;
-            self.rotate_connection_group(
-                self.config.frequent_rotation_connections,
-                start_index,
-                task_id
-            ).await?;
+            self.rotate_connection_group(self.config.frequent_rotation_connections, start_index, task_id)
+                .await?;
             self.last_frequent_rotation = Instant::now();
         }
-        
+
         Ok(())
     }
 
     // Helper method to rotate a specific group of connections
     async fn rotate_connection_group(
-        &mut self, 
-        count: usize, 
-        start_index: usize, 
-        task_id: u64
+        &mut self,
+        count: usize,
+        start_index: usize,
+        task_id: u64,
     ) -> Result<(), ConnectivityError> {
         // Snapshot the outbound **NodeIds** first so that `self.pool` is no longer borrowed
         let mut node_ids = self
@@ -618,29 +622,31 @@ impl ConnectivityManagerActor {
 
         // Sort deterministically
         node_ids.sort();
-        
+
         // Select the connections to rotate
         let end_index = (start_index + count).min(node_ids.len());
         if start_index >= node_ids.len() {
             return Ok(());
         }
-        
+
         // Collect node IDs to disconnect
         let mut nodes_to_remove = Vec::new();
-        
+
         for node_id in &node_ids[start_index..end_index] {
-            let Some(mut conn) = self.pool.get_connection_mut(node_id) else { continue };
-            
+            let Some(mut conn) = self.pool.get_connection_mut(node_id) else {
+                continue;
+            };
+
             debug!(
                 target: LOG_TARGET,
                 "({}) Rotating connection to '{}' as part of scheduled rotation",
                 task_id,
                 node_id.short_str()
             );
-            
+
             // Record the disconnection in history
             self.connection_history.record_disconnection(node_id);
-            
+
             // Disconnect
             match disconnect_with_timeout(&mut conn, Minimized::Yes, Some(task_id)).await {
                 Ok(_) => {
@@ -654,17 +660,18 @@ impl ConnectivityManagerActor {
                         node_id.short_str(),
                         err
                     );
-                }
+                },
             }
         }
-        
+
         // Now remove the nodes from the pool
         for node_id in nodes_to_remove {
             self.pool.remove(&node_id);
         }
-        
+
         Ok(())
     }
+
     async fn delete_stale_peers_from_db(&mut self, task_id: u64) {
         let start = Instant::now();
         match tokio::time::timeout(
@@ -746,10 +753,10 @@ impl ConnectivityManagerActor {
                 node_id,
                 threshold
             );
-            
+
             // Record the disconnection in history
             self.connection_history.record_disconnection(&node_id);
-            
+
             match disconnect_with_timeout(conn, Minimized::Yes, Some(task_id)).await {
                 Ok(_) => {
                     self.pool.remove(&node_id);
@@ -803,10 +810,10 @@ impl ConnectivityManagerActor {
                 node_id.short_str(),
                 conn.handle_count()
             );
-            
+
             // Record the disconnection in history
             self.connection_history.record_disconnection(&node_id);
-            
+
             match disconnect_with_timeout(conn, Minimized::Yes, Some(task_id)).await {
                 Ok(_) => {
                     nodes_to_remove.push(node_id);
@@ -979,7 +986,7 @@ impl ConnectivityManagerActor {
                         return Ok(());
                     }
                 }
-                
+
                 // Remember that we recently spoke to this peer
                 self.connection_history.record_disconnection(node_id);
             },
@@ -1337,7 +1344,7 @@ impl ConnectivityManagerActor {
         if let Some(conn) = self.pool.get_connection_mut(node_id) {
             // Record the disconnection in history
             self.connection_history.record_disconnection(node_id);
-            
+
             disconnect_with_timeout(conn, Minimized::Yes, None).await?;
             let status = self.pool.get_connection_status(node_id);
             debug!(

--- a/comms/core/src/connectivity/mod.rs
+++ b/comms/core/src/connectivity/mod.rs
@@ -44,6 +44,8 @@ pub use manager::ConnectivityStatus;
 #[cfg(feature = "metrics")]
 mod metrics;
 
+pub mod connection_history;
+
 mod requester;
 pub(crate) use requester::ConnectivityRequest;
 pub use requester::{ConnectivityEvent, ConnectivityEventRx, ConnectivityEventTx, ConnectivityRequester};

--- a/comms/core/src/connectivity/test.rs
+++ b/comms/core/src/connectivity/test.rs
@@ -457,3 +457,31 @@ async fn pool_management() {
     let conns = connectivity.get_active_connections().await.unwrap();
     assert!(conns.is_empty());
 }
+#[tokio::test]
+async fn connection_limit_enforcement() {
+    let config = ConnectivityConfig {
+        long_lived_connections: 2,
+        daily_rotation_connections: 1,
+        frequent_rotation_connections: 1,
+        ..Default::default()
+    };
+    
+    let (mut connectivity, mut event_stream, node_identity, peer_manager, cm_mock_state, _shutdown) =
+        setup_connectivity_manager(config);
+    
+    // Add more peers than the connection limit
+    let peers = add_test_peers(&peer_manager, 6).await;
+    
+    // Try to connect to all peers
+    connectivity
+        .dial_many_peers(peers.iter().map(|p| p.node_id.clone()))
+        .collect::<Vec<_>>()
+        .await;
+    
+    // Verify that only the maximum number of connections were established
+    let status = connectivity.get_connectivity_status().await.unwrap();
+    assert_eq!(
+        status.outbound_connections, 
+        config.long_lived_connections + config.daily_rotation_connections + config.frequent_rotation_connections
+    );
+}

--- a/comms/core/src/connectivity/test.rs
+++ b/comms/core/src/connectivity/test.rs
@@ -491,7 +491,8 @@ async fn connection_limit_enforcement() {
     // Try to connect to all peers
     for (i, conn) in connections.iter().enumerate() {
         // Simulate connection attempt
-        connectivity.dial_peer(peers[i].node_id.clone()).await.unwrap();
+
+        let _unused = connectivity.dial_peer(peers[i].node_id.clone()).await;
 
         // If we're under the limit, the connection should succeed
         if i < config.long_lived_connections + config.daily_rotation_connections + config.frequent_rotation_connections

--- a/comms/core/src/connectivity/test.rs
+++ b/comms/core/src/connectivity/test.rs
@@ -465,13 +465,13 @@ async fn connection_limit_enforcement() {
         frequent_rotation_connections: 1,
         ..Default::default()
     };
-    
+
     let (mut connectivity, mut event_stream, node_identity, peer_manager, cm_mock_state, _shutdown) =
         setup_connectivity_manager(config);
-    
+
     // Add more peers than the connection limit
     let peers = add_test_peers(&peer_manager, 6).await;
-    
+
     // Create connections for the test
     let connections = future::join_all(
         peers
@@ -483,39 +483,40 @@ async fn connection_limit_enforcement() {
     .into_iter()
     .map(|(conn, _, _, _)| conn)
     .collect::<Vec<_>>();
-    
+
     // Consume initialization event
     let mut events = collect_try_recv!(event_stream, take = 1, timeout = Duration::from_secs(10));
     unpack_enum!(ConnectivityEvent::ConnectivityStateInitialized = events.remove(0));
-    
+
     // Try to connect to all peers
     for (i, conn) in connections.iter().enumerate() {
         // Simulate connection attempt
         connectivity.dial_peer(peers[i].node_id.clone()).await.unwrap();
-        
+
         // If we're under the limit, the connection should succeed
-        if i < config.long_lived_connections + config.daily_rotation_connections + config.frequent_rotation_connections {
+        if i < config.long_lived_connections + config.daily_rotation_connections + config.frequent_rotation_connections
+        {
             cm_mock_state.publish_event(ConnectionManagerEvent::PeerConnected(conn.clone().into()));
         } else {
             // Otherwise it should fail with ConnectionLimitReached
             cm_mock_state.publish_event(ConnectionManagerEvent::PeerConnectFailed(
                 conn.peer_node_id().clone(),
                 ConnectionManagerError::ConnectivityError(Box::new(
-                    super::error::ConnectivityError::ConnectionLimitReached
-                ))
+                    super::error::ConnectivityError::ConnectionLimitReached,
+                )),
             ));
         }
     }
-    
+
     // Wait for events to be processed
     tokio::time::sleep(Duration::from_millis(100)).await;
-    
+
     // Get all active connections
     let active_connections = connectivity.get_active_connections().await.unwrap();
-    
+
     // Verify that only the maximum number of connections were established
     assert_eq!(
-        active_connections.len(), 
+        active_connections.len(),
         config.long_lived_connections + config.daily_rotation_connections + config.frequent_rotation_connections
     );
 }

--- a/comms/core/src/connectivity/test.rs
+++ b/comms/core/src/connectivity/test.rs
@@ -472,16 +472,50 @@ async fn connection_limit_enforcement() {
     // Add more peers than the connection limit
     let peers = add_test_peers(&peer_manager, 6).await;
     
+    // Create connections for the test
+    let connections = future::join_all(
+        peers
+            .iter()
+            .cloned()
+            .map(|peer| create_peer_connection_mock_pair(node_identity.to_peer(), peer)),
+    )
+    .await
+    .into_iter()
+    .map(|(conn, _, _, _)| conn)
+    .collect::<Vec<_>>();
+    
+    // Consume initialization event
+    let mut events = collect_try_recv!(event_stream, take = 1, timeout = Duration::from_secs(10));
+    unpack_enum!(ConnectivityEvent::ConnectivityStateInitialized = events.remove(0));
+    
     // Try to connect to all peers
-    connectivity
-        .dial_many_peers(peers.iter().map(|p| p.node_id.clone()))
-        .collect::<Vec<_>>()
-        .await;
+    for (i, conn) in connections.iter().enumerate() {
+        // Simulate connection attempt
+        connectivity.dial_peer(peers[i].node_id.clone()).await.unwrap();
+        
+        // If we're under the limit, the connection should succeed
+        if i < config.long_lived_connections + config.daily_rotation_connections + config.frequent_rotation_connections {
+            cm_mock_state.publish_event(ConnectionManagerEvent::PeerConnected(conn.clone().into()));
+        } else {
+            // Otherwise it should fail with ConnectionLimitReached
+            cm_mock_state.publish_event(ConnectionManagerEvent::PeerConnectFailed(
+                conn.peer_node_id().clone(),
+                ConnectionManagerError::ConnectivityError(Box::new(
+                    super::error::ConnectivityError::ConnectionLimitReached
+                ))
+            ));
+        }
+    }
+    
+    // Wait for events to be processed
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    
+    // Get all active connections
+    let active_connections = connectivity.get_active_connections().await.unwrap();
     
     // Verify that only the maximum number of connections were established
-    let status = connectivity.get_connectivity_status().await.unwrap();
     assert_eq!(
-        status.outbound_connections, 
+        active_connections.len(), 
         config.long_lived_connections + config.daily_rotation_connections + config.frequent_rotation_connections
     );
 }

--- a/comms/core/src/connectivity/test.rs
+++ b/comms/core/src/connectivity/test.rs
@@ -502,7 +502,10 @@ async fn connection_limit_enforcement() {
             cm_mock_state.publish_event(ConnectionManagerEvent::PeerConnectFailed(
                 conn.peer_node_id().clone(),
                 ConnectionManagerError::ConnectivityError(Box::new(
-                    super::error::ConnectivityError::ConnectionLimitReached,
+                    super::error::ConnectivityError::ConnectionLimitReached {
+                        current: i,
+                        max: config.long_lived_connections,
+                    },
                 )),
             ));
         }


### PR DESCRIPTION
Description
---

Allows for 16 outbound peers to be long-running + 12 that are forcibly reaped every 24 hours + 4 that are forcibly reaped every 2 hours. Additionally, new connections are never made to a node we've connected to in the last 7 days.

Motivation and Context
---

In order to prevent us locked in to a group of 32 nodes (think Spiderman meme) with 1 or more nodes mining, and thus being isolated from the network, we have to cycle some connections.

How Has This Been Tested?
---

Tested locally.

What process can a PR reviewer use to test or verify this change?
---

Run minotari_node with these changes for more than 2 hours (or adjust the reap time down to 5 minutes if you want to test faster) and look for "Rotating connection to xx as part of scheduled rotation" messages in the log.

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced configurable connection rotation and cooldown periods for outbound peer connections.
  - Added connection history tracking to manage cooldowns and enforce reconnection delays.
  - Implemented connection count limits and periodic rotation of outbound connections.
  - Enhanced error reporting with new connection limit and cooldown-related error variants.

- **Bug Fixes**
  - Enhanced enforcement of maximum outbound connection limits, preventing excess connections.

- **Tests**
  - Added automated test to verify enforcement of outbound connection limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->