### PR TITLE
feat!: add proportional block weights

### DIFF
--- a/base_layer/core/src/transactions/transaction_components/mod.rs
+++ b/base_layer/core/src/transactions/transaction_components/mod.rs
@@ -67,8 +67,12 @@ mod side_chain;
 mod transaction;
 mod transaction_builder;
 mod transaction_input;
+#[cfg(test)]
+pub use transaction_input::{MAX_INPUT_SIZE_AVERAGE_STACK, MAX_INPUT_SIZE_LARGE_STACK};
 mod transaction_input_version;
 mod transaction_kernel;
+#[cfg(test)]
+pub use transaction_kernel::MAX_KERNEL_SIZE;
 mod transaction_kernel_version;
 pub mod transaction_output;
 mod transaction_output_version;

--- a/base_layer/core/src/transactions/transaction_components/transaction_input.rs
+++ b/base_layer/core/src/transactions/transaction_components/transaction_input.rs
@@ -61,6 +61,11 @@ use crate::{
     },
 };
 
+#[cfg(test)]
+pub const MAX_INPUT_SIZE_LARGE_STACK: usize = 435; // 422 (max size from unit test) + 13 (margin)
+#[cfg(test)]
+pub const MAX_INPUT_SIZE_AVERAGE_STACK: usize = 355; // 347 (max size from unit test) + 8 (margin)
+
 /// A transaction input.
 ///
 /// Primarily a reference to an output being spent by the transaction.
@@ -625,5 +630,72 @@ impl SpentOutput {
             rangeproof_hash: rp_hash,
             minimum_value_promise: output.minimum_value_promise,
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::convert::TryInto;
+
+    use tari_common_types::types::ComAndPubSignature;
+    use tari_crypto::ristretto::RistrettoComAndPubSig;
+    use tari_script::ExecutionStack;
+    use tari_utilities::{
+        hex::{from_hex, Hex},
+        message_format::MessageFormat,
+    };
+
+    use crate::{
+        borsh::SerializedSize,
+        transactions::transaction_components::{
+            transaction_input::{MAX_INPUT_SIZE_AVERAGE_STACK, MAX_INPUT_SIZE_LARGE_STACK},
+            SpentOutput,
+            TransactionInput,
+        },
+    };
+
+    #[test]
+    fn verify_max_size_const() {
+        let hash = vec![0u8; 32].try_into().unwrap();
+        let spent_output = SpentOutput::OutputHash(hash);
+
+        const SERDE_ENCODED_BYTES: &str = "ce0000000000000006fdf9fc345d2cdd8aff624a55f824c7c9ce3cc9\
+        72e011b4e750e417a90ecc5da50456c0fa32558d6edc0916baa26b48e745de834571534ca253ea82435f08ebbc\
+        7c0556c0fa32558d6edc0916baa26b48e745de834571534ca253ea82435f08ebbc7c6db1023d5c46d78a97da8eb\
+        6c5a37e00d5f2fee182dcb38c1b6c65e90a43c10906fdf9fc345d2cdd8aff624a55f824c7c9ce3cc972e011b4e7\
+        50e417a90ecc5da501d2040000000000000356c0fa32558d6edc0916baa26b48e745de834571534ca253ea82435\
+        f08ebbc7c";
+        let stack = ExecutionStack::from_binary(&from_hex(SERDE_ENCODED_BYTES).unwrap()).unwrap();
+
+        let tx_input = TransactionInput::new_current_version(
+            spent_output,
+            stack,
+            ComAndPubSignature::new_from_capk_signature(RistrettoComAndPubSig::default()),
+        );
+
+        let tx_input_size = tx_input.get_serialized_size().unwrap();
+
+        // tx_input_size: 422
+        // println!("tx_input_size: {}", tx_input_size);
+
+        assert!(MAX_INPUT_SIZE_LARGE_STACK >= tx_input_size);
+
+        let s = "06fdf9fc345d2cdd8aff624a55f824c7c9ce3cc972e011b4e750e417a90ecc5da50500f7c695528c858cde76dab3076908e0122\
+        8b6dbdd5f671bed1b03b89e170c316db1023d5c46d78a97da8eb6c5a37e00d5f2fee182dcb38c1b6c65e90a43c1090456c0fa32558d6edc0916baa2\
+        6b48e745de834571534ca253ea82435f08ebbc7c";
+        let stack = ExecutionStack::from_hex(s).unwrap();
+
+        let tx_input = TransactionInput::new_current_version(
+            SpentOutput::OutputHash(hash),
+            stack,
+            ComAndPubSignature::new_from_capk_signature(RistrettoComAndPubSig::default()),
+        );
+
+        let tx_input_size = tx_input.get_serialized_size().unwrap();
+
+        // tx_input_size: 347
+        // println!("tx_input_size: {}", tx_input_size);
+
+        assert!(MAX_INPUT_SIZE_AVERAGE_STACK >= tx_input_size);
     }
 }

--- a/base_layer/core/src/transactions/transaction_components/transaction_kernel.rs
+++ b/base_layer/core/src/transactions/transaction_components/transaction_kernel.rs
@@ -46,6 +46,9 @@ use crate::{
     },
 };
 
+#[cfg(test)]
+pub const MAX_KERNEL_SIZE: usize = 132; // 127 (max size from unit test) + 5 (margin)
+
 /// The transaction kernel tracks the excess for a given transaction. For an explanation of what the excess is, and
 /// why it is necessary, refer to the
 /// [Mimblewimble TLU post](https://tlu.tarilabs.com/protocols/mimblewimble-1/sources/PITCHME.link.html?highlight=mimblewimble#mimblewimble).
@@ -270,5 +273,40 @@ impl PartialOrd for TransactionKernel {
 impl Ord for TransactionKernel {
     fn cmp(&self, other: &Self) -> Ordering {
         self.excess_sig.cmp(&other.excess_sig)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use tari_common_types::types::{CompressedCommitment, CompressedPublicKey, PrivateKey, Signature};
+    use tari_utilities::hex::Hex;
+
+    use crate::{
+        borsh::SerializedSize,
+        transactions::transaction_components::{transaction_kernel::MAX_KERNEL_SIZE, KernelBuilder},
+    };
+
+    #[test]
+    fn verify_max_size_const() {
+        let s = PrivateKey::from_hex("6c6eebc5a9c02e1f3c16a69ba4331f9f63d0718401dea10adc4f9d3b879a2c09").unwrap();
+        let r =
+            CompressedPublicKey::from_hex("28e8efe4e5576aac931d358d0f6ace43c55fa9d4186d1d259d1436caa876d43b").unwrap();
+        let sig = Signature::new(r, s);
+        let excess =
+            CompressedCommitment::from_hex("9017be5092b85856ce71061cadeb20c2d1fabdf664c4b3f082bf44cf5065e650").unwrap();
+        let tx_kernel = KernelBuilder::new()
+            .with_signature(sig)
+            .with_fee(100.into())
+            .with_excess(&excess)
+            .with_lock_height(500)
+            .build()
+            .unwrap();
+
+        let tx_kernel_size = tx_kernel.get_serialized_size().unwrap();
+
+        // tx_kernel_size: 127
+        // println!("tx_kernel_size: {}", tx_kernel_size);
+
+        assert!(MAX_KERNEL_SIZE >= tx_kernel_size);
     }
 }

--- a/base_layer/core/src/transactions/transaction_components/transaction_output.rs
+++ b/base_layer/core/src/transactions/transaction_components/transaction_output.rs
@@ -74,6 +74,15 @@ use crate::{
     },
 };
 
+#[cfg(test)]
+pub const MAX_OUTPUT_SIZE_NO_FEATURES: usize = 1000; // 983 (max size from unit test) + 17 (margin)
+#[cfg(test)]
+const VALIDATOR_NODE_FEATURES_SIZE: usize = 125;
+#[cfg(test)]
+const COINBASE_FEATURES_SIZE: usize = 56;
+#[cfg(test)]
+const NORMAL_OUTPUT_FEATURES_SIZE: usize = 56;
+
 /// Output for a transaction, defining the new ownership of coins that are being transferred. The commitment is a
 /// blinded/masked value for the output while the range proof guarantees the commitment includes a positive value
 /// without overflow and the ownership of the private key.
@@ -600,14 +609,33 @@ pub(crate) fn batch_verify_range_proofs(
 
 #[cfg(test)]
 mod test {
-    use super::{batch_verify_range_proofs, TransactionOutput};
-    use crate::transactions::{
-        tari_amount::MicroMinotari,
-        test_helpers::{TestParams, UtxoTestParams},
-        transaction_components::{OutputFeatures, RangeProofType},
-        transaction_key_manager::{create_memory_db_key_manager, MemoryDbKeyManager, TransactionKeyManagerInterface},
-        CryptoFactories,
+    use chacha20poly1305::aead::OsRng;
+    use tari_utilities::hex::Hex;
+    use tari_common_types::types::CompressedPublicKey;
+    use tari_script::{push_pubkey_script, ExecutionStack};
+    use super::{
+        batch_verify_range_proofs,
+        TransactionOutput,
+        COINBASE_FEATURES_SIZE,
+        MAX_OUTPUT_SIZE_NO_FEATURES,
+        NORMAL_OUTPUT_FEATURES_SIZE,
+        VALIDATOR_NODE_FEATURES_SIZE,
     };
+    use crate::{
+        borsh::SerializedSize,
+        transactions::{
+            tari_amount::MicroMinotari,
+            test_helpers::{TestParams, UtxoTestParams},
+            transaction_components::{OutputFeatures, OutputType, RangeProofType, ValidatorNodeSignature},
+            transaction_key_manager::{
+                create_memory_db_key_manager,
+                MemoryDbKeyManager,
+                TransactionKeyManagerInterface,
+            },
+            CryptoFactories,
+        },
+    };
+    use crate::transactions::transaction_components::encrypted_data::PaymentId;
 
     #[tokio::test]
     async fn it_builds_correctly() {
@@ -631,6 +659,60 @@ mod test {
         assert!(tx_output.verify_metadata_signature().is_ok());
         let (_, recovered_value, _) = key_manager.try_output_key_recovery(&tx_output, None).await.unwrap();
         assert_eq!(recovered_value, value);
+    }
+
+    #[tokio::test]
+    async fn verify_max_size_const() {
+        // tx_output_size:                     983
+        // coinbase_output_size:               660
+        //
+        // tx_output_features_size:             56
+        // coinbase_output_features_size:       56
+        // validator_node_features_size:       125
+        //
+        // tx_output_size_no_features:         927
+        // coinbase_output_size_no_features:   604
+
+        let key_manager = create_memory_db_key_manager().unwrap();
+        let test_params = TestParams::new(&key_manager).await;
+
+        let value = MicroMinotari(10);
+        let minimum_value_promise = MicroMinotari(10);
+        let (tx_output, coinbase_output) =
+            create_output_with_max_size(&test_params, value, minimum_value_promise, &key_manager)
+                .await
+                .unwrap();
+
+        let tx_output_size = tx_output.get_serialized_size().unwrap();
+        let tx_output_features_size = tx_output.get_features_and_scripts_size().unwrap();
+        let tx_output_size_no_features = tx_output_size - tx_output_features_size;
+        let coinbase_output_size = coinbase_output.get_serialized_size().unwrap();
+        let coinbase_output_features_size = tx_output.get_features_and_scripts_size().unwrap();
+        let coinbase_output_size_no_features = coinbase_output_size - coinbase_output_features_size;
+
+        let (sk, public_key) = CompressedPublicKey::random_keypair(&mut OsRng);
+        let signature = ValidatorNodeSignature::sign(&sk, &[]);
+        let validator_node_features =
+            OutputFeatures::for_validator_node_registration(public_key.clone(), signature.signature().clone());
+        let validator_node_features_size = validator_node_features.get_serialized_size().unwrap();
+
+        let test = true;
+        if test {
+            assert!(MAX_OUTPUT_SIZE_NO_FEATURES >= tx_output_size_no_features);
+            assert!(MAX_OUTPUT_SIZE_NO_FEATURES >= coinbase_output_size_no_features);
+            assert_eq!(VALIDATOR_NODE_FEATURES_SIZE, validator_node_features_size);
+            assert_eq!(NORMAL_OUTPUT_FEATURES_SIZE, tx_output_features_size);
+            assert_eq!(COINBASE_FEATURES_SIZE, coinbase_output_features_size);
+        } else {
+            println!("tx_output_size: {}", tx_output_size);
+            println!("coinbase_output_size: {}", coinbase_output_size);
+            println!("tx_output_features_size: {}", tx_output_features_size);
+            println!("coinbase_output_features_size: {}", coinbase_output_features_size);
+            println!("tx_output_size_no_features: {}", tx_output_size_no_features);
+            println!("coinbase_output_size_no_features: {}", coinbase_output_size_no_features);
+            println!("validator_node_features_size: {}", validator_node_features_size);
+        }
+
     }
 
     #[tokio::test]
@@ -825,6 +907,70 @@ mod test {
             .to_transaction_output(key_manager)
             .await
             .map_err(|e| e.to_string())
+    }
+    async fn create_output_with_max_size(
+        test_params: &TestParams,
+        value: MicroMinotari,
+        minimum_value_promise: MicroMinotari,
+        key_manager: &MemoryDbKeyManager,
+    ) -> Result<(TransactionOutput, TransactionOutput), String> {
+        // Create the first output with `RangeProofType::BulletProofPlus` and `OutputType::Standard`
+        let s = "06fdf9fc345d2cdd8aff624a55f824c7c9ce3cc972e011b4e750e417a90ecc5da50500f7c695528c858cde76dab3076908e0122\
+        8b6dbdd5f671bed1b03b89e170c316db1023d5c46d78a97da8eb6c5a37e00d5f2fee182dcb38c1b6c65e90a43c1090456c0fa32558d6edc0916baa2\
+        6b48e745de834571534ca253ea82435f08ebbc7c";
+        let stack = ExecutionStack::from_hex(s).unwrap();
+        let normal_output = test_params
+            .create_output(
+                UtxoTestParams {
+                    value,
+                    minimum_value_promise,
+                    features: OutputFeatures {
+                        range_proof_type: RangeProofType::BulletProofPlus,
+                        output_type: OutputType::Standard,
+                        coinbase_extra: vec![].try_into().unwrap(),
+                        sidechain_feature: None,
+                        ..Default::default()
+                    },
+                    payment_id: PaymentId::Open { user_data: vec![1, 2, 3], tx_type: Default::default() },
+                    script: push_pubkey_script(&Default::default()),
+                    input_data: Some(stack),
+                    ..Default::default()
+                },
+                key_manager,
+            )
+            .await?
+            .to_transaction_output(key_manager)
+            .await
+            .map_err(|e| e.to_string())?;
+
+        // Create the second output with `RangeProofType::RevealedValue` and `OutputType::Coinbase`
+        let coinbase_output = test_params
+            .create_output(
+                UtxoTestParams {
+                    value,
+                    minimum_value_promise,
+                    features: OutputFeatures {
+                        range_proof_type: RangeProofType::RevealedValue,
+                        output_type: OutputType::Coinbase,
+                        coinbase_extra: vec![0u8; normal_output.features.coinbase_extra.max_size()]
+                            .try_into()
+                            .unwrap(),
+                        sidechain_feature: None,
+                        ..Default::default()
+                    },
+                    payment_id: PaymentId::Open { user_data: vec![1, 2, 3], tx_type: Default::default() },
+                    script: push_pubkey_script(&Default::default()),
+                    input_data: None,
+                    ..Default::default()
+                },
+                key_manager,
+            )
+            .await?
+            .to_transaction_output(key_manager)
+            .await
+            .map_err(|e| e.to_string())?;
+
+        Ok((normal_output, coinbase_output))
     }
 
     async fn create_invalid_output(

--- a/base_layer/core/src/transactions/weight.rs
+++ b/base_layer/core/src/transactions/weight.rs
@@ -39,11 +39,11 @@ pub struct WeightParams {
 impl WeightParams {
     pub const fn v1() -> Self {
         Self {
-            kernel_weight: 10,
-            input_weight: 8,
-            output_weight: 53,
+            kernel_weight: 5,
+            input_weight: 18,
+            output_weight: 43,
             // SAFETY: the value isn't 0. NonZeroU64::new(x).expect(...) is not const so cannot be used in const fn
-            features_and_scripts_bytes_per_gram: unsafe { NonZeroU64::new_unchecked(16) },
+            features_and_scripts_bytes_per_gram: unsafe { NonZeroU64::new_unchecked(23) },
         }
     }
 }
@@ -151,7 +151,18 @@ impl From<WeightParams> for TransactionWeight {
 
 #[cfg(test)]
 mod test {
+    use tari_common::configuration::Network;
+
     use super::*;
+    use crate::{
+        consensus::ConsensusManager,
+        transactions::transaction_components::{
+            transaction_output::{MAX_OUTPUT_SIZE_NO_FEATURES},
+            MAX_INPUT_SIZE_AVERAGE_STACK,
+            MAX_INPUT_SIZE_LARGE_STACK,
+            MAX_KERNEL_SIZE,
+        },
+    };
 
     #[test]
     fn round_up_features_and_scripts_size() {
@@ -177,5 +188,138 @@ mod test {
         let weighting = TransactionWeight::latest();
         let body = AggregateBody::empty();
         assert_eq!(weighting.calculate_body(&body).unwrap(), 0);
+    }
+
+    // The purpose of this test is to ensure that the weight params are proportional to the size of the individual
+    // components that makes up a transaction and ultimately the block size.
+    #[test]
+    fn weight_params_sanity_chack() {
+        let weighting = TransactionWeight::latest();
+        let weight_params = weighting.0;
+        let esmeralda_max_weight = ConsensusManager::builder(Network::Esmeralda)
+            .build()
+            .unwrap()
+            .consensus_constants(0)
+            .max_block_transaction_weight();
+        let nextnet_max_weight = ConsensusManager::builder(Network::NextNet)
+            .build()
+            .unwrap()
+            .consensus_constants(0)
+            .max_block_transaction_weight();
+        let mainnet_max_weight = ConsensusManager::builder(Network::MainNet)
+            .build()
+            .unwrap()
+            .consensus_constants(0)
+            .max_block_transaction_weight();
+
+        let output_ratio_bytes_per_gram = MAX_OUTPUT_SIZE_NO_FEATURES as f64 / weight_params.output_weight as f64;
+        let input_ratio_bytes_per_gram = MAX_INPUT_SIZE_AVERAGE_STACK as f64 / weight_params.input_weight as f64;
+        let kernel_ratio_bytes_per_gram = MAX_KERNEL_SIZE as f64 / weight_params.kernel_weight as f64;
+        let features_ratio_bytes_per_gram = weight_params.features_and_scripts_bytes_per_gram.get() as f64;
+        let average_ratio_bytes_per_gram = (output_ratio_bytes_per_gram +
+            input_ratio_bytes_per_gram +
+            kernel_ratio_bytes_per_gram +
+            features_ratio_bytes_per_gram) /
+            4.0;
+
+        let adjusted_weight_params = WeightParams {
+            kernel_weight: (MAX_KERNEL_SIZE as f64 / average_ratio_bytes_per_gram) as u64,
+            input_weight: (MAX_INPUT_SIZE_LARGE_STACK as f64 / average_ratio_bytes_per_gram) as u64,
+            output_weight: (MAX_OUTPUT_SIZE_NO_FEATURES as f64 / average_ratio_bytes_per_gram) as u64,
+            features_and_scripts_bytes_per_gram: unsafe {
+                NonZeroU64::new_unchecked(average_ratio_bytes_per_gram as u64)
+            },
+        };
+
+        let adjusted_weighting = TransactionWeight(adjusted_weight_params);
+
+        // Test case - block on esmeralda that could not be propagated via grpc:
+        //  - weight 127770,
+        //  - input(s): 6541,
+        //  - output(s): 1126,
+        //  - kernel(s): 563,
+        //  - byte size: 5316326
+        //  - average feature byte size: 144
+        let inputs = 6541;
+        let outputs = 1126;
+        let kernels = 563;
+        let average_feature_size = 144;
+
+        let inputs_reduced = 4645;
+        let outputs_reduced = 800;
+        let kernels_reduced = 400;
+
+        let size_1 = kernels * MAX_KERNEL_SIZE +
+            inputs * MAX_INPUT_SIZE_AVERAGE_STACK +
+            outputs * MAX_OUTPUT_SIZE_NO_FEATURES +
+            outputs * average_feature_size;
+        let size_2 = kernels * MAX_KERNEL_SIZE +
+            inputs * MAX_INPUT_SIZE_LARGE_STACK +
+            outputs * MAX_OUTPUT_SIZE_NO_FEATURES +
+            outputs * average_feature_size;
+        let weight = weighting.calculate(kernels, inputs, outputs, outputs * average_feature_size);
+        let adjusted_weight = adjusted_weighting.calculate(kernels, inputs, outputs, outputs * average_feature_size);
+        let reduced_weight = adjusted_weighting.calculate(kernels_reduced, inputs_reduced, outputs_reduced, outputs * average_feature_size);
+
+        // output_ratio_bytes_per_gram:   23.26
+        // input_ratio_bytes_per_gram:    19.72
+        // kernel_ratio_bytes_per_gram:   26.40
+        // features_ratio_bytes_per_gram: 23.00
+        // average_ratio_bytes_per_gram:  23.09
+        // weight_params:                 WeightParams { kernel_weight: 5, input_weight: 18, output_weight: 43,
+        //                                               features_and_scripts_bytes_per_gram: 23 }
+        // adjusted_weight_params:        WeightParams { kernel_weight: 5, input_weight: 18, output_weight: 43,
+        //                                               features_and_scripts_bytes_per_gram: 23 }
+        // average_feature_size:          144
+        // weight:          176020, size_1: 3684515, size_2: 4207795
+        // adjusted_weight: 176020, size_1: 3684515, size_2: 4207795
+        // reduced_weight: 127059, size_1: 3684515, size_2: 4207795
+
+        let test = true;
+        if test {
+            // We allow some margins away from the size proportionate weights, but not much as this will skew the block size
+            assert!(
+                (weight_params.input_weight.saturating_sub(1)..
+                    weight_params.input_weight + 1).contains(&adjusted_weight_params.input_weight)
+            );
+            assert!(
+                (weight_params.output_weight.saturating_sub(1)..
+                    weight_params.output_weight + 1).contains(&adjusted_weight_params.output_weight)
+            );
+            assert!(
+                (weight_params.kernel_weight.saturating_sub(1)..
+                    weight_params.kernel_weight + 1).contains(&adjusted_weight_params.kernel_weight)
+            );
+            assert!(
+                (weight_params
+                    .features_and_scripts_bytes_per_gram
+                    .get()
+                    .saturating_sub(1)..
+                    weight_params.features_and_scripts_bytes_per_gram.get() +
+                        1).contains(&adjusted_weight_params.features_and_scripts_bytes_per_gram.get())
+            );
+            assert!((weight.saturating_sub(100)..weight + 100).contains(&adjusted_weight));
+            assert!(reduced_weight < esmeralda_max_weight);
+            assert!(reduced_weight < nextnet_max_weight);
+            assert!(reduced_weight < mainnet_max_weight);
+        } else {
+            println!("output_ratio_bytes_per_gram:   {:.2}", output_ratio_bytes_per_gram);
+            println!("input_ratio_bytes_per_gram:    {:.2}", input_ratio_bytes_per_gram);
+            println!("kernel_ratio_bytes_per_gram:   {:.2}", kernel_ratio_bytes_per_gram);
+            println!("features_ratio_bytes_per_gram: {:.2}", features_ratio_bytes_per_gram);
+            println!("average_ratio_bytes_per_gram:  {:.2}", average_ratio_bytes_per_gram);
+            println!("weight_params:                 {:?}", weight_params);
+            println!("adjusted_weight_params:        {:?}", adjusted_weight_params);
+            println!("average_feature_size:          {}", average_feature_size);
+            println!("weight:          {}, size_1: {}, size_2: {}", weight, size_1, size_2);
+            println!(
+                "adjusted_weight: {}, size_1: {}, size_2: {}",
+                adjusted_weight, size_1, size_2
+            );
+            println!(
+                "reduced_weight:  {}, size_1: {}, size_2: {}",
+                reduced_weight, size_1, size_2
+            );
+        }
     }
 }


### PR DESCRIPTION
Description
---
Added block weights to components proportional to their average number of bytes when stored in the blockchain.

Motivation and Context
---
The issue here is that we have 2MB for coinbases and 4MB for payload data; this block template had a single coinbase but exceeded the intended payload size due to weight proportions not reflective of actual transaction component byte size.
```
        // Test case - block on esmeralda that could not be propagated via grpc:
        //  - weight 127770,
        //  - input(s): 6541,
        //  - output(s): 1126,
        //  - kernel(s): 563,
        //  - byte size: 5316326
        //  - average feature byte size: 144
```

How Has This Been Tested?
---
Added new unit tests to verify weight proportions.

What process can a PR reviewer use to test or verify this change?
---
Code review

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
BREAKING CHANGE: Weight calculations will be different, affecting fee calculations and maximum blockchain payload size.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Introduced new constants and comprehensive tests to verify maximum serialized sizes for transaction inputs, outputs, and kernels.
  - Added a test to validate proportionality and correctness of transaction weight parameters against component size limits.

- **Refactor**
  - Adjusted transaction weight parameters for inputs, outputs, kernels, and features to better align with observed size characteristics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->