### PR TITLE
fix: stop allowing too many connections

### DIFF
--- a/comms/dht/src/config.rs
+++ b/comms/dht/src/config.rs
@@ -168,7 +168,7 @@ impl Default for DhtConfig {
             protocol_version: DhtProtocolVersion::latest(),
             num_neighbouring_nodes: 6,
             num_random_nodes: 6,
-            minimize_connections: false,
+            minimize_connections: true,
             propagation_factor: 20,
             broadcast_factor: 8,
             outbound_buffer_size: 20,


### PR DESCRIPTION
Description
---

We have an outbound connection limiter. We should probably actually use it.

Motivation and Context
---

This has been plaguing the network by overloading nodes with open inbound ports.

How Has This Been Tested?
---

I mean...it's trivial to test.

What process can a PR reviewer use to test or verify this change?
---

Compile and run. Observe that outbound connections doesn't exceed 32. Celebrate.

Breaking Changes
---

- [x] None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the default configuration to enable connection minimization by default, which may affect how excess network connections are managed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->