### PR TITLE
fix(tari-pulse): dns for mainner checkpoints

### DIFF
--- a/base_layer/core/src/base_node/tari_pulse_service/mod.rs
+++ b/base_layer/core/src/base_node/tari_pulse_service/mod.rs
@@ -75,7 +75,7 @@ impl Default for TariPulseConfig {
 fn get_network_dns_name(network: Network) -> &'static str {
     match network {
         Network::NextNet => "checkpoints-nextnet.tari.com.",
-        Network::MainNet => "checkpoints-mainnet.tari.com.",
+        Network::MainNet => "checkpoints.tari.com.",
         Network::Esmeralda => "checkpoints-esmeralda.tari.com.",
         Network::StageNet => "checkpoints-stagenet.tari.com.",
         Network::Igor => "checkpoints-igor.tari.com.",


### PR DESCRIPTION
Description
---
Fix invalid DNS address for tari pulse checkpoints on the mainnet.

Motivation and Context
---
Previous value was placeholder but now there is actual DNS for mainnet but on different address then expected.

How Has This Been Tested?
---
run `dig` command to fetch checkpoints:
`dig -t txt checkpoints.tari.com +dnssec @1.1.1.1`
which gaves this response:
```
;; ANSWER SECTION:
checkpoints.tari.com.	3600	IN	TXT	"2689:fd9ff7a4b6ba80ca88f1c04f9eccc37ebfc86833440d25a82753fa0847b4768f"
checkpoints.tari.com.	3600	IN	TXT	"2723:1914d1e47cba910020a814ac55613601e6502abedc41bb02e5299757d37b675a"
checkpoints.tari.com.	3600	IN	TXT	"2751:edbf2987dbcd6488ca6dc6e9a01cc3cf1cc034902fcc27d768371ca03ca9d01b"
checkpoints.tari.com.	3600	IN	TXT	"2789:3a964367c6d27a59f30df79dc57c3abd6f5802ad04e43720d9bf40431238f056"
checkpoints.tari.com.	3600	IN	TXT	"2819:926b4e2ce6ed4a8a33abbfc94174e48dc6afb1cf819b28fb746874db91dabce1"
checkpoints.tari.com.	3600	IN	RRSIG	TXT 13 3 3600 20250506094113 20250504074113 34505 tari.com. 2zFWcDigRalTBvLBzuid2qwHInGYRmSn0rkOc10g8ikpHbYCsM0/kpA2 ZXdjQ1u17I51nEqnanRfawMvGEoxWA==
```

What process can a PR reviewer use to test or verify this change?
---
Same as above.


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
