### PR TITLE
feat: block seed words extraction from view only wallets

### DIFF
--- a/applications/minotari_console_wallet/src/init/mod.rs
+++ b/applications/minotari_console_wallet/src/init/mod.rs
@@ -485,6 +485,12 @@ pub async fn init_wallet(
     );
 
     if let Some(file_name) = seed_words_file_name {
+        if wallet.db.get_wallet_type()? != Some(WalletType::DerivedKeys) {
+            return Err(ExitError::new(
+                ExitCode::WalletError,
+                "Cannot export seed words from a Hardware/View_only wallet",
+            ));
+        }
         let seed_words = wallet.get_seed_words(&MnemonicLanguage::English)?.join(" ");
         let _result = fs::write(file_name, seed_words.reveal()).map_err(|e| {
             ExitError::new(


### PR DESCRIPTION
Description
---

Block the extraction of seed words from wallets that don't have access to the correct seed words, which is view only wallets and hardware enabled wallets. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Exporting seed words is now restricted to supported wallet types only. Users with Hardware or View-only wallets will no longer be able to export seed words, and will receive an appropriate error message if they attempt to do so.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->