### PR TITLE
feat: add block hash to grpc method

### DIFF
--- a/.license.ignore
+++ b/.license.ignore
@@ -2,6 +2,7 @@
 ./applications/minotari_node/assets/tari_logo.rs
 ./applications/minotari_node/osx-pkg/entitlements.xml
 ./base_layer/contacts/src/schema.rs
+./base_layer/core/src/blocks/gen_block/Tari.Manifesto
 ./base_layer/core/src/transactions/transaction_key_manager/schema.rs
 ./base_layer/key_manager/src/schema.rs
 ./base_layer/wallet/src/schema.rs

--- a/applications/minotari_app_grpc/proto/wallet.proto
+++ b/applications/minotari_app_grpc/proto/wallet.proto
@@ -316,7 +316,7 @@ service Wallet {
   // Streams completed transactions for a given user payment ID.
   //
   // The `GetCompletedTransactions` call retrieves all completed wallet transactions,
-  // optionally filtered by a specific `payment_id`. The response is streamed back to the client
+  // optionally filtered by a specific `payment_id` and/or block hash. The response is streamed back to the client
   // one transaction at a time, with each transaction including details such as status, direction,
   // amount, fees, and associated metadata.
   //
@@ -332,6 +332,14 @@ service Wallet {
   //   - **Restrictions**:
   //     - Exactly **one format must be set**. Providing more than one or none results in an error.
   //     - If no `payment_id` is provided, all completed transactions will be returned.
+  //
+  // - `block_hash` (optional):
+  //   - **Type**: `string`
+  //   - **Description**: A specific block hash to filter transactions by.
+  //   - **Accepted Formats**
+  //     - Hexadecimal string representing the block hash.
+  //   - **Restrictions**:
+  //     - If provided, the transactions will be filtered to only those included in the specified block.
   //
   // ### Example JavaScript gRPC client usage:
   //

--- a/applications/minotari_app_grpc/proto/wallet.proto
+++ b/applications/minotari_app_grpc/proto/wallet.proto
@@ -49,6 +49,7 @@ service Wallet {
   // ```
 
   rpc GetVersion (GetVersionRequest) returns (GetVersionResponse);
+
   // Returns the current operational state of the wallet.
   //
   // This RPC provides an overview of the wallet's internal status, including:
@@ -84,6 +85,7 @@ service Wallet {
   // }
   // ```
   rpc GetState (GetStateRequest) returns (GetStateResponse);
+
   // This RPC returns a lightweight response indicating whether the wallet is connected to the network, attempting to connect, or currently offline. This is useful for UIs or clients to determine if network interactions like transactions or syncs are possible.
   //
   // Example usage (JavaScript):
@@ -99,8 +101,10 @@ service Wallet {
   // }
   // ```
   rpc CheckConnectivity(GetConnectivityRequest) returns (CheckConnectivityResponse);
+
   // Check for new updates
   rpc CheckForUpdates (Empty) returns (SoftwareUpdate);
+
   // The `Identify` RPC call returns the identity information of the wallet node.
   // This includes:
   // - **Public Key**: The wallet’s cryptographic public key.
@@ -129,6 +133,7 @@ service Wallet {
   // }
   // ```
   rpc Identify (GetIdentityRequest) returns (GetIdentityResponse);
+
   // This RPC returns two types of wallet addresses: interactive and one-sided addresses.
   // It provides these addresses in byte format as part of the response.
   // - **Interactive Address**: This is a type of address used for interaction and communication with the wallet.
@@ -153,6 +158,7 @@ service Wallet {
   // }
   // ```
   rpc GetAddress (Empty) returns (GetAddressResponse);
+
   // This RPC returns addresses generated for a specific payment ID. It provides both the interactive 
   // and one-sided addresses for the given payment ID, along with their respective representations in 
   // base58 and emoji formats.
@@ -188,6 +194,7 @@ service Wallet {
   //```
   //
   rpc GetPaymentIdAddress (GetPaymentIdAddressRequest) returns (GetCompleteAddressResponse);
+
   // This RPC call that retrieves the current wallet's interactive and one-sided addresses in multiple formats and returns them in a structured response.
   // The response includes:
   // - Raw binary
@@ -216,6 +223,7 @@ service Wallet {
   // }
   // ```
   rpc GetCompleteAddress (Empty) returns (GetCompleteAddressResponse);
+
   // This call supports standard interactive transactions (Mimblewimble),
   // one-sided transactions, and one-sided-to-stealth-address transactions.
   // Each recipient must include a valid Tari address, amount, fee, and payment type.
@@ -304,6 +312,7 @@ service Wallet {
   // }
   // ```
   rpc GetTransactionInfo (GetTransactionInfoRequest) returns (GetTransactionInfoResponse);
+
   // Streams completed transactions for a given user payment ID.
   //
   // The `GetCompletedTransactions` call retrieves all completed wallet transactions,
@@ -361,6 +370,7 @@ service Wallet {
   // }
   // ```
   rpc GetCompletedTransactions (GetCompletedTransactionsRequest) returns (stream GetCompletedTransactionsResponse);
+
   // Returns the wallet balance details.
   //
   // The `GetBalance` call retrieves the current balance status of the wallet,
@@ -406,6 +416,7 @@ service Wallet {
   // }
   // ```
   rpc GetBalance (GetBalanceRequest) returns (GetBalanceResponse);
+
   // Returns the total value of unspent outputs in the wallet.
   //
   // The `GetUnspentAmounts` call retrieves the sum of all unspent output amounts
@@ -435,6 +446,7 @@ service Wallet {
   // }
   // ```
   rpc GetUnspentAmounts (Empty) returns (GetUnspentAmountsResponse);
+
   // Creates a transaction that splits funds into multiple smaller outputs.
   //
   // The `CoinSplit` call initiates a transaction that divides wallet funds into several equal-sized outputs.
@@ -492,6 +504,7 @@ service Wallet {
   // }
   // ```
   rpc CoinSplit (CoinSplitRequest) returns (CoinSplitResponse);
+
   // Imports UTXOs into the wallet as spendable outputs.
   //
   // The `ImportUtxos` call allows you to manually insert one or more previously received UTXOs
@@ -535,6 +548,7 @@ service Wallet {
   // }
   // ```
   rpc ImportUtxos (ImportUtxosRequest) returns (ImportUtxosResponse);
+
   // Returns the wallet's current network connectivity status.
   //
   // The `GetNetworkStatus` call provides a snapshot of the wallet’s connection to the Tari network,
@@ -583,6 +597,7 @@ service Wallet {
   //   - This status means the wallet is unable to communicate with the network and cannot perform any network-related operations.
   //
   rpc GetNetworkStatus(Empty) returns (NetworkStatusResponse);
+
   // Returns a list of peers currently connected to the wallet.
   //
   // The `ListConnectedPeers` call retrieves information about peers that the wallet is currently
@@ -647,6 +662,7 @@ service Wallet {
   // }
   // ```
   rpc ListConnectedPeers(Empty) returns (ListConnectedPeersResponse);
+
   // Cancels a specific transaction by its ID.
   //
   // The `CancelTransaction` call allows a transaction to be cancelled by its unique transaction ID (TxId).
@@ -683,10 +699,13 @@ service Wallet {
   // }
   // ```
   rpc CancelTransaction (CancelTransactionRequest) returns (CancelTransactionResponse);
+
   // Will trigger a complete revalidation of all wallet outputs.
   rpc RevalidateAllTransactions (RevalidateRequest) returns (RevalidateResponse);
+
   // Will trigger a validation of all wallet outputs.
   rpc ValidateAllTransactions (ValidateRequest) returns (ValidateResponse);
+
   // Sends a XTR SHA Atomic Swap transaction.
   //
   // The `SendShaAtomicSwapTransaction` call is used to initiate an Atomic Swap 
@@ -731,6 +750,7 @@ service Wallet {
   //   "failure_message": ""
   // }
   rpc SendShaAtomicSwapTransaction(SendShaAtomicSwapRequest) returns (SendShaAtomicSwapResponse);
+
   // Creates a burn transaction for burning a specified amount of Tari currency.
   //
   // The `CreateBurnTransaction` call facilitates burning a certain amount of Tari
@@ -778,6 +798,7 @@ service Wallet {
   //   "reciprocal_claim_public_key": "0xreciprocalpublickey"
   // }
   rpc CreateBurnTransaction(CreateBurnTransactionRequest) returns (CreateBurnTransactionResponse);
+
   // Claims a SHA Atomic Swap transaction using a pre-image and output hash.
   //
   // The `ClaimShaAtomicSwapTransaction` call allows the user to unlock and claim funds from
@@ -822,6 +843,7 @@ service Wallet {
   //   }
   // }
   rpc ClaimShaAtomicSwapTransaction(ClaimShaAtomicSwapRequest) returns (ClaimShaAtomicSwapResponse);
+
   // Claims an HTLC refund transaction after the timelock period has passed.
   //
   // The `ClaimHtlcRefundTransaction` call enables the original sender of a Hash Time-Locked Contract (HTLC)
@@ -862,8 +884,10 @@ service Wallet {
   //   }
   // }
   rpc ClaimHtlcRefundTransaction(ClaimHtlcRefundRequest) returns (ClaimHtlcRefundResponse);
+
   // Creates a transaction with a template registration output
   rpc CreateTemplateRegistration(CreateTemplateRegistrationRequest) returns (CreateTemplateRegistrationResponse);
+
   // The SetBaseNode call configures the base node peer for the wallet.
   //
   // This RPC sets the public key and network address of the base node peer that the wallet should communicate with.
@@ -898,6 +922,7 @@ service Wallet {
   // {}
   // ```
   rpc SetBaseNode(SetBaseNodeRequest) returns (SetBaseNodeResponse);
+
   // Streams real-time wallet transaction events to the client.
   //
   // The `StreamTransactionEvents` RPC provides a continuous stream of transaction events as they occur within the wallet.
@@ -1141,6 +1166,11 @@ enum TransactionStatus {
 
 message GetCompletedTransactionsRequest {
   UserPaymentId payment_id = 1;
+  BlockHashHex block_hash = 2;
+}
+
+message BlockHashHex {
+  string hash = 1;
 }
 
 message GetCompletedTransactionsResponse {

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -930,9 +930,18 @@ impl wallet_server::Wallet for WalletGrpcServer {
         } else {
             None
         };
+        let block_hash = if let Some(hash) = message.block_hash {
+            Some(
+                BlockHash::from_hex(&hash.hash)
+                    .map_err(|_| Status::internal("Output hash is malformed".to_string()))?,
+            )
+        } else {
+            None
+        };
+
         let mut transaction_service = self.get_transaction_service();
         let transactions = transaction_service
-            .get_completed_transactions(payment_id)
+            .get_completed_transactions(payment_id, block_hash)
             .await
             .map_err(|err| Status::not_found(format!("No completed transactions found: {:?}", err)))?;
         debug!(

--- a/applications/minotari_console_wallet/src/ui/state/app_state.rs
+++ b/applications/minotari_console_wallet/src/ui/state/app_state.rs
@@ -751,7 +751,12 @@ impl AppStateInner {
             .collect::<Result<Vec<_>, _>>()?;
 
         let mut completed_transactions: Vec<CompletedTransaction> = Vec::new();
-        completed_transactions.extend(self.wallet.transaction_service.get_completed_transactions(None).await?);
+        completed_transactions.extend(
+            self.wallet
+                .transaction_service
+                .get_completed_transactions(None, None)
+                .await?,
+        );
 
         completed_transactions.extend(
             self.wallet

--- a/base_layer/wallet/src/transaction_service/handle.rs
+++ b/base_layer/wallet/src/transaction_service/handle.rs
@@ -79,7 +79,10 @@ use crate::{
 pub enum TransactionServiceRequest {
     GetPendingInboundTransactions,
     GetPendingOutboundTransactions,
-    GetCompletedTransactions(Option<Vec<u8>>),
+    GetCompletedTransactions {
+        payment_id: Option<Vec<u8>>,
+        block_hash: Option<FixedHash>,
+    },
     GetCancelledPendingInboundTransactions,
     GetCancelledPendingOutboundTransactions,
     GetCancelledCompletedTransactions,
@@ -208,7 +211,7 @@ impl fmt::Display for TransactionServiceRequest {
         match self {
             Self::GetPendingInboundTransactions => write!(f, "GetPendingInboundTransactions"),
             Self::GetPendingOutboundTransactions => write!(f, "GetPendingOutboundTransactions"),
-            Self::GetCompletedTransactions(_) => write!(f, "GetCompletedTransactions"),
+            Self::GetCompletedTransactions { .. } => write!(f, "GetCompletedTransactions"),
             Self::ImportTransaction(tx) => write!(f, "ImportTransaction: {:?}", tx),
             Self::GetCancelledPendingInboundTransactions => write!(f, "GetCancelledPendingInboundTransactions"),
             Self::GetCancelledPendingOutboundTransactions => write!(f, "GetCancelledPendingOutboundTransactions"),
@@ -963,10 +966,11 @@ impl TransactionServiceHandle {
     pub async fn get_completed_transactions(
         &mut self,
         payment_id: Option<Vec<u8>>,
+        block_hash: Option<FixedHash>,
     ) -> Result<Vec<CompletedTransaction>, TransactionServiceError> {
         match self
             .handle
-            .call(TransactionServiceRequest::GetCompletedTransactions(payment_id))
+            .call(TransactionServiceRequest::GetCompletedTransactions { payment_id, block_hash })
             .await??
         {
             TransactionServiceResponse::CompletedTransactions(c) => Ok(c),

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -891,9 +891,11 @@ where
                 TransactionServiceResponse::PendingOutboundTransactions(self.db.get_pending_outbound_transactions()?),
             ),
 
-            TransactionServiceRequest::GetCompletedTransactions(payment_id) => Ok(
-                TransactionServiceResponse::CompletedTransactions(self.db.get_completed_transactions(payment_id)?),
-            ),
+            TransactionServiceRequest::GetCompletedTransactions { payment_id, block_hash } => {
+                Ok(TransactionServiceResponse::CompletedTransactions(
+                    self.db.get_completed_transactions(payment_id, block_hash)?,
+                ))
+            },
             TransactionServiceRequest::GetCancelledPendingInboundTransactions => {
                 Ok(TransactionServiceResponse::PendingInboundTransactions(
                     self.db.get_cancelled_pending_inbound_transactions()?,

--- a/base_layer/wallet/src/transaction_service/storage/database.rs
+++ b/base_layer/wallet/src/transaction_service/storage/database.rs
@@ -31,7 +31,7 @@ use log::*;
 use tari_common_types::{
     tari_address::TariAddress,
     transaction::{TransactionDirection, TransactionStatus, TxId},
-    types::{BlockHash, PrivateKey},
+    types::{BlockHash, FixedHash, PrivateKey},
 };
 use tari_core::transactions::{
     tari_amount::MicroMinotari,
@@ -156,9 +156,10 @@ pub trait TransactionBackend: Send + Sync + Clone {
         height: u64,
     ) -> Result<Vec<CompletedTransaction>, TransactionStorageError>;
 
-    fn find_completed_transactions_for_payment_id(
+    fn find_completed_transactions_filter_payment_id_block_hash(
         &self,
-        payment_id: Vec<u8>,
+        payment_id: Option<Vec<u8>>,
+        block_hash: Option<FixedHash>,
     ) -> Result<Vec<CompletedTransaction>, TransactionStorageError>;
 }
 
@@ -482,11 +483,14 @@ where T: TransactionBackend + 'static
         Ok(t)
     }
 
-    pub fn get_completed_transactions_by_payment_id(
+    pub fn get_completed_transactions_filter_payment_id_block_hash(
         &self,
-        payment_id: Vec<u8>,
+        payment_id: Option<Vec<u8>>,
+        block_hash: Option<FixedHash>,
     ) -> Result<Vec<CompletedTransaction>, TransactionStorageError> {
-        let t = self.db.find_completed_transactions_for_payment_id(payment_id)?;
+        let t = self
+            .db
+            .find_completed_transactions_filter_payment_id_block_hash(payment_id, block_hash)?;
         Ok(t)
     }
 
@@ -599,12 +603,13 @@ where T: TransactionBackend + 'static
     pub fn get_completed_transactions(
         &self,
         payment_id: Option<Vec<u8>>,
+        block_hash: Option<FixedHash>,
     ) -> Result<Vec<CompletedTransaction>, TransactionStorageError> {
-        self.get_completed_transactions_by_cancelled(payment_id, false)
+        self.get_completed_transactions_by_cancelled(payment_id, false, block_hash)
     }
 
     pub fn get_cancelled_completed_transactions(&self) -> Result<Vec<CompletedTransaction>, TransactionStorageError> {
-        self.get_completed_transactions_by_cancelled(None, true)
+        self.get_completed_transactions_by_cancelled(None, true, None)
     }
 
     pub fn get_any_transaction(&self, tx_id: TxId) -> Result<Option<WalletTransaction>, TransactionStorageError> {
@@ -630,15 +635,15 @@ where T: TransactionBackend + 'static
         &self,
         payment_id: Option<Vec<u8>>,
         cancelled: bool,
+        block_hash: Option<FixedHash>,
     ) -> Result<Vec<CompletedTransaction>, TransactionStorageError> {
         let key = if cancelled {
             DbKey::CancelledCompletedTransactions
         } else {
             DbKey::CompletedTransactions
         };
-        match payment_id {
-            Some(payment_id) => self.db.find_completed_transactions_for_payment_id(payment_id),
-            None => {
+        match (payment_id.is_none(), block_hash.is_none()) {
+            (true, true) => {
                 let t = match self.db.fetch(&key) {
                     Ok(None) => log_error(
                         key,
@@ -652,6 +657,9 @@ where T: TransactionBackend + 'static
                 }?;
                 Ok(t)
             },
+            (_, _) => self
+                .db
+                .find_completed_transactions_filter_payment_id_block_hash(payment_id, block_hash),
         }
     }
 

--- a/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
@@ -1057,7 +1057,7 @@ impl TransactionBackend for TransactionServiceSqliteDatabase {
         let cipher = acquire_read_lock!(self.cipher);
 
         let mut query = completed_transactions::table.into_boxed();
-if let Some(id) = payment_id{
+        if let Some(id) = payment_id {
             query = query.filter(completed_transactions::user_payment_id.eq(id));
         }
         if let Some(hash) = block_hash {

--- a/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
@@ -40,7 +40,7 @@ use tari_common_types::{
         TransactionStatus,
         TxId,
     },
-    types::{BlockHash, CompressedPublicKey, PrivateKey, Signature},
+    types::{BlockHash, CompressedPublicKey, FixedHash, PrivateKey, Signature},
 };
 use tari_core::transactions::{tari_amount::MicroMinotari, transaction_components::encrypted_data::PaymentId};
 use tari_utilities::{hex::Hex, ByteArray, Hidden};
@@ -1048,14 +1048,30 @@ impl TransactionBackend for TransactionServiceSqliteDatabase {
         Ok(coinbases)
     }
 
-    fn find_completed_transactions_for_payment_id(
+    fn find_completed_transactions_filter_payment_id_block_hash(
         &self,
-        payment_id: Vec<u8>,
+        payment_id: Option<Vec<u8>>,
+        block_hash: Option<FixedHash>,
     ) -> Result<Vec<CompletedTransaction>, TransactionStorageError> {
         let mut conn = self.database_connection.get_pooled_connection()?;
         let cipher = acquire_read_lock!(self.cipher);
-        completed_transactions::table
-            .filter(completed_transactions::user_payment_id.eq(payment_id))
+
+        let mut query = completed_transactions::table.into_boxed();
+        match (payment_id, block_hash) {
+            (Some(id), Some(hash)) => {
+                query = query.filter(completed_transactions::user_payment_id.eq(id));
+                query = query.filter(completed_transactions::mined_in_block.eq(hash.to_vec()));
+            },
+            (Some(id), None) => {
+                query = query.filter(completed_transactions::user_payment_id.eq(id));
+            },
+            (None, Some(hash)) => {
+                query = query.filter(completed_transactions::mined_in_block.eq(hash.to_vec()));
+            },
+            (None, None) => (),
+        }
+
+        query
             .load::<CompletedTransactionSql>(&mut conn)?
             .into_iter()
             .map(|ct: CompletedTransactionSql| {

--- a/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
@@ -1057,18 +1057,11 @@ impl TransactionBackend for TransactionServiceSqliteDatabase {
         let cipher = acquire_read_lock!(self.cipher);
 
         let mut query = completed_transactions::table.into_boxed();
-        match (payment_id, block_hash) {
-            (Some(id), Some(hash)) => {
-                query = query.filter(completed_transactions::user_payment_id.eq(id));
-                query = query.filter(completed_transactions::mined_in_block.eq(hash.to_vec()));
-            },
-            (Some(id), None) => {
-                query = query.filter(completed_transactions::user_payment_id.eq(id));
-            },
-            (None, Some(hash)) => {
-                query = query.filter(completed_transactions::mined_in_block.eq(hash.to_vec()));
-            },
-            (None, None) => (),
+if let Some(id) = payment_id{
+            query = query.filter(completed_transactions::user_payment_id.eq(id));
+        }
+        if let Some(hash) = block_hash {
+            query = query.filter(completed_transactions::mined_in_block.eq(hash.to_vec()));
         }
 
         query

--- a/base_layer/wallet/tests/transaction_service_tests/service.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/service.rs
@@ -2304,7 +2304,7 @@ async fn manage_multiple_transactions() {
         )
         .await
         .unwrap();
-    let alice_completed_tx = alice_ts.get_completed_transactions(None).await.unwrap();
+    let alice_completed_tx = alice_ts.get_completed_transactions(None, None).await.unwrap();
     assert_eq!(alice_completed_tx.len(), 0);
     log::trace!("A to C 1 TxID: {}", tx_id_a_to_c_1);
 
@@ -2409,16 +2409,16 @@ async fn manage_multiple_transactions() {
     assert_eq!(finalized, 1);
 
     let alice_pending_outbound = alice_ts.get_pending_outbound_transactions().await.unwrap();
-    let alice_completed_tx = alice_ts.get_completed_transactions(None).await.unwrap();
+    let alice_completed_tx = alice_ts.get_completed_transactions(None, None).await.unwrap();
     assert_eq!(alice_pending_outbound.len(), 0);
     assert_eq!(alice_completed_tx.len(), 4, "Not enough transactions for Alice");
     let bob_pending_outbound = bob_ts.get_pending_outbound_transactions().await.unwrap();
-    let bob_completed_tx = bob_ts.get_completed_transactions(None).await.unwrap();
+    let bob_completed_tx = bob_ts.get_completed_transactions(None, None).await.unwrap();
     assert_eq!(bob_pending_outbound.len(), 0);
     assert_eq!(bob_completed_tx.len(), 3, "Not enough transactions for Bob");
 
     let carol_pending_inbound = carol_ts.get_pending_inbound_transactions().await.unwrap();
-    let carol_completed_tx = carol_ts.get_completed_transactions(None).await.unwrap();
+    let carol_completed_tx = carol_ts.get_completed_transactions(None, None).await.unwrap();
     assert_eq!(carol_pending_inbound.len(), 0);
     assert_eq!(carol_completed_tx.len(), 1);
 
@@ -5588,7 +5588,7 @@ async fn transaction_service_tx_broadcast() {
 
     let alice_completed_txs = alice_ts_interface
         .transaction_service_handle
-        .get_completed_transactions(None)
+        .get_completed_transactions(None, None)
         .await
         .unwrap();
     let alice_completed_tx1 = alice_completed_txs
@@ -5696,7 +5696,7 @@ async fn transaction_service_tx_broadcast() {
 
     let alice_completed_txs = alice_ts_interface
         .transaction_service_handle
-        .get_completed_transactions(None)
+        .get_completed_transactions(None, None)
         .await
         .unwrap();
     let alice_completed_tx2 = alice_completed_txs
@@ -6332,7 +6332,7 @@ async fn test_completed_transactions_ordering() {
 
     let alice_completed_transactions = alice_ts_interface
         .transaction_service_handle
-        .get_completed_transactions(None)
+        .get_completed_transactions(None, None)
         .await
         .unwrap();
 

--- a/base_layer/wallet/tests/transaction_service_tests/storage.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/storage.rs
@@ -358,7 +358,7 @@ pub async fn test_db_backend<T: TransactionBackend + 'static>(backend: T) {
         .unwrap();
     }
 
-    let retrieved_completed_txs = db.get_completed_transactions(None).unwrap();
+    let retrieved_completed_txs = db.get_completed_transactions(None, None).unwrap();
     assert_eq!(retrieved_completed_txs.len(), 2 * messages.len());
 
     for i in 0..messages.len() {
@@ -416,7 +416,7 @@ pub async fn test_db_backend<T: TransactionBackend + 'static>(backend: T) {
         panic!("Should have found completed tx");
     }
 
-    let completed_txs = db.get_completed_transactions(None).unwrap();
+    let completed_txs = db.get_completed_transactions(None, None).unwrap();
     let num_completed_txs = completed_txs.len();
     assert_eq!(db.get_cancelled_completed_transactions().unwrap().len(), 0);
 
@@ -424,7 +424,7 @@ pub async fn test_db_backend<T: TransactionBackend + 'static>(backend: T) {
     assert!(db.get_cancelled_completed_transaction(cancelled_tx_id).is_err());
     db.reject_completed_transaction(cancelled_tx_id, TxCancellationReason::Unknown)
         .unwrap();
-    let completed_txs = db.get_completed_transactions(None).unwrap();
+    let completed_txs = db.get_completed_transactions(None, None).unwrap();
     assert_eq!(completed_txs.len(), num_completed_txs - 1);
 
     db.get_cancelled_completed_transaction(cancelled_tx_id)

--- a/base_layer/wallet/tests/transaction_service_tests/transaction_protocols.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/transaction_protocols.rs
@@ -855,7 +855,7 @@ async fn tx_validation_protocol_tx_becomes_mined_unconfirmed_then_confirmed() {
     let result = join_handle.await.unwrap();
     assert!(result.is_ok());
 
-    let completed_txs = resources.db.get_completed_transactions(None).unwrap();
+    let completed_txs = resources.db.get_completed_transactions(None, None).unwrap();
 
     assert_eq!(
         completed_txs
@@ -890,7 +890,7 @@ async fn tx_validation_protocol_tx_becomes_mined_unconfirmed_then_confirmed() {
     let result = join_handle.await.unwrap();
     assert!(result.is_ok());
 
-    let completed_txs = resources.db.get_completed_transactions(None).unwrap();
+    let completed_txs = resources.db.get_completed_transactions(None, None).unwrap();
 
     assert_eq!(
         completed_txs
@@ -943,7 +943,7 @@ async fn tx_validation_protocol_tx_becomes_mined_unconfirmed_then_confirmed() {
     let result = join_handle.await.unwrap();
     assert!(result.is_ok());
 
-    let completed_txs = resources.db.get_completed_transactions(None).unwrap();
+    let completed_txs = resources.db.get_completed_transactions(None, None).unwrap();
 
     assert_eq!(
         completed_txs
@@ -1036,7 +1036,7 @@ async fn tx_revalidation() {
     let result = join_handle.await.unwrap();
     assert!(result.is_ok());
 
-    let completed_txs = resources.db.get_completed_transactions(None).unwrap();
+    let completed_txs = resources.db.get_completed_transactions(None, None).unwrap();
 
     assert_eq!(
         completed_txs
@@ -1081,7 +1081,7 @@ async fn tx_revalidation() {
         .db
         .mark_all_non_coinbases_transactions_as_unvalidated()
         .unwrap();
-    let completed_txs = resources.db.get_completed_transactions(None).unwrap();
+    let completed_txs = resources.db.get_completed_transactions(None, None).unwrap();
     let completed_tx_2 = completed_txs
         .iter()
         .find(|c_tx| c_tx.tx_id == TxId::from(2u64))
@@ -1102,7 +1102,7 @@ async fn tx_revalidation() {
     let result = join_handle.await.unwrap();
     assert!(result.is_ok());
 
-    let completed_txs = resources.db.get_completed_transactions(None).unwrap();
+    let completed_txs = resources.db.get_completed_transactions(None, None).unwrap();
     // data should now be updated and changed
     let completed_tx_2 = completed_txs
         .iter()
@@ -1272,7 +1272,7 @@ async fn tx_validation_protocol_reorg() {
     let result = join_handle.await.unwrap();
     assert!(result.is_ok());
 
-    let completed_txs = resources.db.get_completed_transactions(None).unwrap();
+    let completed_txs = resources.db.get_completed_transactions(None, None).unwrap();
     let mut unconfirmed_count = 0;
     let mut confirmed_count = 0;
     for tx in completed_txs {
@@ -1389,7 +1389,7 @@ async fn tx_validation_protocol_reorg() {
 
     assert_eq!(rpc_service_state.take_get_header_by_height_calls().len(), 0);
 
-    let completed_txs = resources.db.get_completed_transactions(None).unwrap();
+    let completed_txs = resources.db.get_completed_transactions(None, None).unwrap();
     // Tx 1
     assert!(completed_txs
         .iter()

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -8293,9 +8293,12 @@ pub unsafe extern "C" fn wallet_get_completed_transactions(
         return ptr::null_mut();
     }
 
-    let completed_transactions = (*wallet)
-        .runtime
-        .block_on((*wallet).wallet.transaction_service.get_completed_transactions(None));
+    let completed_transactions = (*wallet).runtime.block_on(
+        (*wallet)
+            .wallet
+            .transaction_service
+            .get_completed_transactions(None, None),
+    );
     match completed_transactions {
         Ok(completed_transactions) => {
             // The frontend specification calls for completed transactions that have not yet been mined to be
@@ -8361,10 +8364,12 @@ pub unsafe extern "C" fn wallet_get_pending_inbound_transactions(
                 pending.push(tx.clone());
             }
 
-            if let Ok(completed_txs) = (*wallet)
-                .runtime
-                .block_on((*wallet).wallet.transaction_service.get_completed_transactions(None))
-            {
+            if let Ok(completed_txs) = (*wallet).runtime.block_on(
+                (*wallet)
+                    .wallet
+                    .transaction_service
+                    .get_completed_transactions(None, None),
+            ) {
                 // The frontend specification calls for completed transactions that have not yet been mined to be
                 // classified as Pending Transactions. In order to support this logic without impacting the practical
                 // definitions and storage of a MimbleWimble CompletedTransaction we will add those transaction to the
@@ -8431,10 +8436,12 @@ pub unsafe extern "C" fn wallet_get_pending_outbound_transactions(
             for tx in &pending_transactions {
                 pending.push(tx.clone());
             }
-            if let Ok(completed_txs) = (*wallet)
-                .runtime
-                .block_on((*wallet).wallet.transaction_service.get_completed_transactions(None))
-            {
+            if let Ok(completed_txs) = (*wallet).runtime.block_on(
+                (*wallet)
+                    .wallet
+                    .transaction_service
+                    .get_completed_transactions(None, None),
+            ) {
                 // The frontend specification calls for completed transactions that have not yet been mined to be
                 // classified as Pending Transactions. In order to support this logic without impacting the practical
                 // definitions and storage of a MimbleWimble CompletedTransaction we will add those transaction to the
@@ -8586,9 +8593,12 @@ pub unsafe extern "C" fn wallet_get_completed_transaction_by_id(
         return ptr::null_mut();
     }
 
-    let completed_transactions = (*wallet)
-        .runtime
-        .block_on((*wallet).wallet.transaction_service.get_completed_transactions(None));
+    let completed_transactions = (*wallet).runtime.block_on(
+        (*wallet)
+            .wallet
+            .transaction_service
+            .get_completed_transactions(None, None),
+    );
 
     match completed_transactions {
         Ok(completed_transactions) => {
@@ -8647,9 +8657,12 @@ pub unsafe extern "C" fn wallet_get_pending_inbound_transaction_by_id(
         .runtime
         .block_on((*wallet).wallet.transaction_service.get_pending_inbound_transactions());
 
-    let completed_transactions = (*wallet)
-        .runtime
-        .block_on((*wallet).wallet.transaction_service.get_completed_transactions(None));
+    let completed_transactions = (*wallet).runtime.block_on(
+        (*wallet)
+            .wallet
+            .transaction_service
+            .get_completed_transactions(None, None),
+    );
 
     match completed_transactions {
         Ok(completed_transactions) => {
@@ -8720,9 +8733,12 @@ pub unsafe extern "C" fn wallet_get_pending_outbound_transaction_by_id(
         .runtime
         .block_on((*wallet).wallet.transaction_service.get_pending_outbound_transactions());
 
-    let completed_transactions = (*wallet)
-        .runtime
-        .block_on((*wallet).wallet.transaction_service.get_completed_transactions(None));
+    let completed_transactions = (*wallet).runtime.block_on(
+        (*wallet)
+            .wallet
+            .transaction_service
+            .get_completed_transactions(None, None),
+    );
 
     match completed_transactions {
         Ok(completed_transactions) => {

--- a/integration_tests/tests/steps/wallet_steps.rs
+++ b/integration_tests/tests/steps/wallet_steps.rs
@@ -159,7 +159,10 @@ async fn wallet_detects_all_txs_as_mined_status(world: &mut TariWorld, wallet_na
     let mut client = create_wallet_client(world, wallet_name.clone()).await.unwrap();
 
     let mut completed_tx_stream = client
-        .get_completed_transactions(GetCompletedTransactionsRequest { payment_id: None })
+        .get_completed_transactions(GetCompletedTransactionsRequest {
+            payment_id: None,
+            block_hash: None,
+        })
         .await
         .unwrap()
         .into_inner();
@@ -493,7 +496,10 @@ async fn list_all_txs_for_wallet(world: &mut TariWorld, transaction_type: String
     }
     let mut client = create_wallet_client(world, wallet.clone()).await.unwrap();
 
-    let request = GetCompletedTransactionsRequest { payment_id: None };
+    let request = GetCompletedTransactionsRequest {
+        payment_id: None,
+        block_hash: None,
+    };
     let mut completed_txs = client.get_completed_transactions(request).await.unwrap().into_inner();
 
     while let Some(tx) = completed_txs.next().await {
@@ -542,7 +548,10 @@ async fn wallet_has_at_least_num_txs(world: &mut TariWorld, wallet: String, num_
 
     for _ in 0..num_retries {
         let mut txs = client
-            .get_completed_transactions(grpc::GetCompletedTransactionsRequest { payment_id: None })
+            .get_completed_transactions(grpc::GetCompletedTransactionsRequest {
+                payment_id: None,
+                block_hash: None,
+            })
             .await
             .unwrap()
             .into_inner();
@@ -959,7 +968,10 @@ async fn send_amount_from_wallet_to_wallet_at_fee(
 async fn wallet_detects_at_least_coinbase_transactions(world: &mut TariWorld, wallet_name: String, coinbases: u64) {
     let mut client = create_wallet_client(world, wallet_name.clone()).await.unwrap();
     let mut completed_tx_res = client
-        .get_completed_transactions(GetCompletedTransactionsRequest { payment_id: None })
+        .get_completed_transactions(GetCompletedTransactionsRequest {
+            payment_id: None,
+            block_hash: None,
+        })
         .await
         .unwrap()
         .into_inner();
@@ -1015,7 +1027,10 @@ async fn wallet_detects_at_least_coinbase_unconfirmed_transactions(
 ) {
     let mut client = create_wallet_client(world, wallet_name.clone()).await.unwrap();
     let mut completed_tx_res = client
-        .get_completed_transactions(GetCompletedTransactionsRequest { payment_id: None })
+        .get_completed_transactions(GetCompletedTransactionsRequest {
+            payment_id: None,
+            block_hash: None,
+        })
         .await
         .unwrap()
         .into_inner();
@@ -1230,7 +1245,10 @@ async fn wallets_should_have_at_least_num_spendable_coinbase_outs(
 
         'inner: for _ in 0..num_retries {
             let mut stream = client
-                .get_completed_transactions(GetCompletedTransactionsRequest { payment_id: None })
+                .get_completed_transactions(GetCompletedTransactionsRequest {
+                    payment_id: None,
+                    block_hash: None,
+                })
                 .await
                 .unwrap()
                 .into_inner();
@@ -2642,7 +2660,10 @@ async fn restart_wallet(world: &mut TariWorld, wallet: String) {
 async fn check_if_wallet_has_num_transactions(world: &mut TariWorld, wallet: String, num_txs: u64) {
     let mut client = create_wallet_client(world, wallet.clone()).await.unwrap();
     let mut get_completed_txs_res = client
-        .get_completed_transactions(GetCompletedTransactionsRequest { payment_id: None })
+        .get_completed_transactions(GetCompletedTransactionsRequest {
+            payment_id: None,
+            block_hash: None,
+        })
         .await
         .unwrap()
         .into_inner();
@@ -2793,7 +2814,10 @@ async fn multi_send_txs_from_wallet(
 async fn check_if_last_imported_txs_are_invalid_in_wallet(world: &mut TariWorld, wallet: String) {
     let mut client = create_wallet_client(world, wallet.clone()).await.unwrap();
     let mut get_completed_txs_res = client
-        .get_completed_transactions(GetCompletedTransactionsRequest { payment_id: None })
+        .get_completed_transactions(GetCompletedTransactionsRequest {
+            payment_id: None,
+            block_hash: None,
+        })
         .await
         .unwrap()
         .into_inner();
@@ -2816,7 +2840,10 @@ async fn check_if_last_imported_txs_are_invalid_in_wallet(world: &mut TariWorld,
 async fn check_if_last_imported_txs_are_valid_in_wallet(world: &mut TariWorld, wallet: String) {
     let mut client = create_wallet_client(world, wallet.clone()).await.unwrap();
     let mut get_completed_txs_res = client
-        .get_completed_transactions(GetCompletedTransactionsRequest { payment_id: None })
+        .get_completed_transactions(GetCompletedTransactionsRequest {
+            payment_id: None,
+            block_hash: None,
+        })
         .await
         .unwrap()
         .into_inner();


### PR DESCRIPTION
Description
---
Added optional block hash to grpc method GetCompletedTransactionsRequest


Motivation and Context
---
Some clients maw want to filter completed transactions by block hash.

How Has This Been Tested?
---
System-level testing running thre grpc call.

What process can a PR reviewer use to test or verify this change?
---
Code review
System-level testing 

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for filtering completed wallet transactions by block hash alongside payment ID.

- **Tests**
  - Updated test cases and integration tests to accommodate the new block hash filter parameter when retrieving completed transactions.

- **Chores**
  - Enhanced internal request structures, gRPC service, and database queries to support filtering by block hash.

No changes to user interface or existing transaction retrieval behavior unless the new filter is applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->