### PR TITLE
Feat (doc): amended gRPC documentation to discuss Emoji ID

### DIFF
--- a/docs/src/API_GRPC_Explanation.md
+++ b/docs/src/API_GRPC_Explanation.md
@@ -92,7 +92,7 @@ Please note that fees will be applicable for every bit used in the `payment_id`.
 After serialization, the complete byte array is encoded using **Base58**, resulting in a human-readable Tari address.
 
 Please note that Tari supports three address formats for representation of the address:
-- Hexidecimal
+- Hexadecimal
 - Base58
 - Emoji ID
 
@@ -105,7 +105,7 @@ The **Emoji ID** is the preferred encoding for Tari addresses. Emoji ID has a nu
 
 The EmojiID is derived deterministically from a public view key as a 33-byte address, with the first 32-characters representing the address and the 33rd character a checksum of the address calculated from `DammSumm`. The checksum can be used to confirm the address validity and other variables/feature requirements (such as whether the address is for the correct network.) Conversion between these forms is supported, with automatic checksum validation. The public key is recoverable from the Emoji ID.
 
-You can find more information about the Emoji ID implementation here: https://github.com/tari-project/tari/blob/development/base_layer/common_types/src/emoji.rs
+You can find more information about the Emoji ID implementation here: [emoji.rs implementation](https://github.com/tari-project/tari/blob/development/base_layer/common_types/src/emoji.rs)
 
 The `GetAddress` gRPC call can retrieve the wallet's Emoji ID address.
 

--- a/docs/src/API_GRPC_Explanation.md
+++ b/docs/src/API_GRPC_Explanation.md
@@ -51,7 +51,10 @@ message GetBalanceResponse {
 ```
 
 ### Tari Address Structure (with Optional Payment ID)
+
 Tari addresses are an address scheme used by Tari. Each address includes the necessary information for identifying the network, verifying integrity, and optionally embedding an **encrypted payment identifier**. The [RFC-0155 TariAddress](https://rfc.tari.com/RFC-0155_TariAddress) can be reviewed for more information.
+
+> We strongly recommend the use of Emoji ID as the preferred format. This is discussed in more detail in the [encoding](#encoding) section below.
 
 #### Binary Structure
 
@@ -63,6 +66,10 @@ Tari addresses are an address scheme used by Tari. Each address includes the nec
 | 34–65  | Public Spend Key | Required to authorize spending from the wallet.                           |
 | 66–N   | Payment ID       | *(Optional)* Encrypted tag embedded for tracking the purpose of payment. |
 | N+1    | Checksum         | Calculated using the [Damm algorithm](https://en.wikipedia.org/wiki/Damm_algorithm). |
+
+#### Emoji ID
+
+
 
 #### Payment ID Feature (Optional)
 
@@ -87,6 +94,25 @@ Please note that fees will be applicable for every bit used in the `payment_id`.
 
 #### Encoding
 After serialization, the complete byte array is encoded using **Base58**, resulting in a human-readable Tari address.
+
+Please note that Tari supports three address formats for representation of the address:
+- Hexidecimal
+- Base58
+- Emoji ID
+
+**EmojiID**
+
+The **Emoji ID** is the preferred format for Tari. Emoji ID has a number of benefits for users:
+- The address is shorter, and provides for more easily-identifiable characters, thus eliminating identification errors (0 vs O, 1 vs l)
+- The alphabet used for Emoji ID is larger than hexidecimal or Base58, resulting in shorter character sequences for encoding
+- The use of a checksum can verify if the address is correct and for the correct network.
+
+The EmojiID is derived deterministically from a public view key as a 33-byte address, with the first 32-characters representing the address and the 33rd character 
+
+
+
+
+
 
 ### Understanding Code Generation from `.proto` Files
 The `.proto` file, such as [`wallet.proto`][wallet-proto], acts as a **shared contract** that defines all available services, methods, and message structures for the Minotari Wallet's gRPC API. However, it is not executable code by itself.

--- a/docs/src/API_GRPC_Explanation.md
+++ b/docs/src/API_GRPC_Explanation.md
@@ -67,10 +67,6 @@ Tari addresses are an address scheme used by Tari. Each address includes the nec
 | 66–N   | Payment ID       | *(Optional)* Encrypted tag embedded for tracking the purpose of payment. |
 | N+1    | Checksum         | Calculated using the [Damm algorithm](https://en.wikipedia.org/wiki/Damm_algorithm). |
 
-#### Emoji ID
-
-
-
 #### Payment ID Feature (Optional)
 
 The optional Payment ID feature allows an exchange, merchant or other service to append a payment ID to the address in a manner that preserves privacy while still allowing the service to track payments, withdrawals and other activity against a particular user. This is done by requesting an address from the existing wallet via the gRPC method `GetPaymentIdAddress`, described later in the document.
@@ -102,17 +98,36 @@ Please note that Tari supports three address formats for representation of the a
 
 **EmojiID**
 
-The **Emoji ID** is the preferred format for Tari. Emoji ID has a number of benefits for users:
+The **Emoji ID** is the preferred encoding for Tari addresses. Emoji ID has a number of benefits for users:
 - The address is shorter, and provides for more easily-identifiable characters, thus eliminating identification errors (0 vs O, 1 vs l)
 - The alphabet used for Emoji ID is larger than hexidecimal or Base58, resulting in shorter character sequences for encoding
 - The use of a checksum can verify if the address is correct and for the correct network.
 
-The EmojiID is derived deterministically from a public view key as a 33-byte address, with the first 32-characters representing the address and the 33rd character 
+The EmojiID is derived deterministically from a public view key as a 33-byte address, with the first 32-characters representing the address and the 33rd character a checksum of the address calculated from `DammSumm`. The checksum can be used to confirm the address validity and other variables/feature requirements (such as whether the address is for the correct network.) Conversion between these forms is supported, with automatic checksum validation. The public key is recoverable from the Emoji ID.
 
+You can find more information about the Emoji ID implementation here: https://github.com/tari-project/tari/blob/development/base_layer/common_types/src/emoji.rs
 
+The `GetAddress` gRPC call can retrieve the wallet's Emoji ID address.
 
+The 256 emojis used are shown below:
 
-
+| 🐢 | 📟 | 🌈 | 🌊 | 🎯 | 🐋 | 🌙 | 🤔 | 🌕 | ⭐ | 🎋 | 🌰 | 🌴 | 🌵 | 🌲 | 🌸 |
+|-----|-----|-----|-----|-----|-----|-----|-----|-----|-----|-----|-----|-----|-----|-----|-----|
+| 🌹 | 🌻 | 🌽 | 🍀 | 🍁 | 🍄 | 🥑 | 🍆 | 🍇 | 🍈 | 🍉 | 🍊 | 🍋 | 🍌 | 🍍 | 🍎 |
+| 🍐 | 🍑 | 🍒 | 🍓 | 🍔 | 🍕 | 🍗 | 🍚 | 🍞 | 🍟 | 🥝 | 🍣 | 🍦 | 🍩 | 🍪 | 🍫 |
+| 🍬 | 🍭 | 🍯 | 🥐 | 🍳 | 🥄 | 🍵 | 🍶 | 🍷 | 🍸 | 🍾 | 🍺 | 🍼 | 🎀 | 🎁 | 🎂 |
+| 🎃 | 🤖 | 🎈 | 🎉 | 🎒 | 🎓 | 🎠 | 🎡 | 🎢 | 🎣 | 🎤 | 🎥 | 🎧 | 🎨 | 🎩 | 🎪 |
+| 🎬 | 🎭 | 🎮 | 🎰 | 🎱 | 🎲 | 🎳 | 🎵 | 🎷 | 🎸 | 🎹 | 🎺 | 🎻 | 🎼 | 🎽 | 🎾 |
+| 🎿 | 🏀 | 🏁 | 🏆 | 🏈 | ⚽ | 🏠 | 🏥 | 🏦 | 🏭 | 🏰 | 🐀 | 🐉 | 🐊 | 🐌 | 🐍 |
+| 🦁 | 🐐 | 🐑 | 🐔 | 🙈 | 🐗 | 🐘 | 🐙 | 🐚 | 🐛 | 🐜 | 🐝 | 🐞 | 🦋 | 🐣 | 🐨 |
+| 🦀 | 🐪 | 🐬 | 🐭 | 🐮 | 🐯 | 🐰 | 🦆 | 🦂 | 🐴 | 🐵 | 🐶 | 🐷 | 🐸 | 🐺 | 🐻 |
+| 🐼 | 🐽 | 🐾 | 👀 | 👅 | 👑 | 👒 | 🧢 | 💅 | 👕 | 👖 | 👗 | 👘 | 👙 | 💃 | 👛 |
+| 👞 | 👟 | 👠 | 🥊 | 👢 | 👣 | 🤡 | 👻 | 👽 | 👾 | 🤠 | 👃 | 💄 | 💈 | 💉 | 💊 |
+| 💋 | 👂 | 💍 | 💎 | 💐 | 💔 | 🔒 | 🧩 | 💡 | 💣 | 💤 | 💦 | 💨 | 💩 | ➕ | 💯 |
+| 💰 | 💳 | 💵 | 💺 | 💻 | 💼 | 📈 | 📜 | 📌 | 📎 | 📖 | 📿 | 📡 | ⏰ | 📱 | 📷 |
+| 🔋 | 🔌 | 🚰 | 🔑 | 🔔 | 🔥 | 🔦 | 🔧 | 🔨 | 🔩 | 🔪 | 🔫 | 🔬 | 🔭 | 🔮 | 🔱 |
+| 🗽 | 😂 | 😇 | 😈 | 🤑 | 😍 | 😎 | 😱 | 😷 | 🤢 | 👍 | 👶 | 🚀 | 🚁 | 🚂 | 🚚 |
+| 🚑 | 🚒 | 🚓 | 🛵 | 🚗 | 🚜 | 🚢 | 🚦 | 🚧 | 🚨 | 🚪 | 🚫 | 🚲 | 🚽 | 🚿 | 🧲 |
 
 ### Understanding Code Generation from `.proto` Files
 The `.proto` file, such as [`wallet.proto`][wallet-proto], acts as a **shared contract** that defines all available services, methods, and message structures for the Minotari Wallet's gRPC API. However, it is not executable code by itself.
@@ -340,6 +355,39 @@ const userPaymentId = {
 }
 ```
 
+### Get Address 
+This RPC returns addresses generated for a specific payment ID. It provides both the interactive and one-sided addresses for the given payment ID, along with their respective representations in base58 and emoji formats.
+
+ Example usage (JavaScript):
+
+ ```javascript
+ // Prepare the payment ID for the request
+ const paymentId = Buffer.from('your_payment_id_here', 'hex');
+ const request = { payment_id: paymentId };
+
+ // Call the GetPaymentIdAddress RPC method
+ client.GetPaymentIdAddress(request, (error, response) => {
+   if (error) {
+     console.error('Error:', error);
+   } else {
+     console.log('Payment ID Address Response:', response);
+   }
+ });
+ ```
+
+ **Sample JSON Response:**
+
+ ```json
+{
+  "interactive_address": "0411aabbccddeeff00112233445566778899aabbccddeeff0011223344556677",
+  "one_sided_address": "02ff8899aabbccddeeff00112233445566778899aabbccddeeff001122334455",
+  "interactive_address_base58": "14HVCEeZC2RGE4SDn3yG.....6xouGvS5SXwEvXKwK3zLz2rgReh",
+  "one_sided_address_base58": "12HVCEeZC2RGE4SDn3yGwqz.....obB1a6xouGvS5SXwEvXKwK3zLz2rgReL",
+  "interactive_address_emoji": "🐢🌊💤🔌🚑🐛🏦⚽🍓🐭🚁🎢🔪🥐👛🍞.....🍐🍟💵🎉🍯🎁🎾🎼💻💄🍳🍐🤔🥝🍫👅🚀🐬🎭",
+  "one_sided_address_emoji": "🐢📟💤🔌🚑🐛🏦⚽🍓🐭🚁🎢🔪🥐👛🍞📜.....🍐🍟💵🎉🍯🎁🎾🎼💻💄🍳🍐🤔🥝🍫👅🚀🐬🎭"
+}
+```
+
 ### Get Payment ID Address
 The `GetPaymentIdAddress` gRPC method returns an address appended with a payment ID, derived from an existing address. The payment ID is an optional, additional piece of metadata (like an invoice number or customer reference).
 
@@ -349,8 +397,8 @@ The `GetPaymentIdAddress` gRPC method returns an address appended with a payment
 ```javascript
 const crypto = require('crypto');
 
-// Generate a 32-byte random payment_id
-const paymentId = crypto.randomBytes(32); // This will be a Buffer
+ Generate a 32-byte random payment_id
+const paymentId = crypto.randomBytes(32);  This will be a Buffer
 
 client.GetPaymentIdAddress({ payment_id: paymentId }, (error, response) => {
   if (error) {


### PR DESCRIPTION
Description
---

Added content related to EmojiID and to stress that it is the preferred encoding/display format for Tari addresses. Have also included the RPC documentation for GetAddress so they can retrieve it.

Motivation and Context
---

How Has This Been Tested?
---

What process can a PR reviewer use to test or verify this change?
---

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded documentation on Tari address encoding formats, with detailed information about the Emoji ID format, its benefits, derivation, checksum, and emoji alphabet.
  - Updated address structure section to recommend Emoji ID and clarify support for Hexadecimal, Base58, and Emoji ID formats.
  - Added a new section describing the "Get Address" RPC method, including usage examples and sample responses.
  - Minor correction to a code comment for generating a random payment ID.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->