### PR TITLE
feat: add block height to query

### DIFF
--- a/applications/minotari_app_grpc/proto/wallet.proto
+++ b/applications/minotari_app_grpc/proto/wallet.proto
@@ -341,6 +341,13 @@ service Wallet {
   //   - **Restrictions**:
   //     - If provided, the transactions will be filtered to only those included in the specified block.
   //
+  // - `block_height` (optional):
+  //   - **Type**: `uint64`
+  //   - **Description**: A specific block height to filter transactions by.
+  //   - **Restrictions**:
+  //     - If provided, the transactions will be filtered to only those included in the specified height.
+
+  //
   // ### Example JavaScript gRPC client usage:
   //
   // ```javascript
@@ -1175,6 +1182,7 @@ enum TransactionStatus {
 message GetCompletedTransactionsRequest {
   UserPaymentId payment_id = 1;
   BlockHashHex block_hash = 2;
+  BlockHeight block_height = 3;
 }
 
 message BlockHashHex {

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -938,10 +938,11 @@ impl wallet_server::Wallet for WalletGrpcServer {
         } else {
             None
         };
+        let block_height = message.block_height.map(|height| height.block_height);
 
         let mut transaction_service = self.get_transaction_service();
         let transactions = transaction_service
-            .get_completed_transactions(payment_id, block_hash)
+            .get_completed_transactions(payment_id, block_hash, block_height)
             .await
             .map_err(|err| Status::not_found(format!("No completed transactions found: {:?}", err)))?;
         debug!(

--- a/applications/minotari_console_wallet/src/ui/state/app_state.rs
+++ b/applications/minotari_console_wallet/src/ui/state/app_state.rs
@@ -754,7 +754,7 @@ impl AppStateInner {
         completed_transactions.extend(
             self.wallet
                 .transaction_service
-                .get_completed_transactions(None, None)
+                .get_completed_transactions(None, None, None)
                 .await?,
         );
 

--- a/base_layer/wallet/src/transaction_service/handle.rs
+++ b/base_layer/wallet/src/transaction_service/handle.rs
@@ -82,6 +82,7 @@ pub enum TransactionServiceRequest {
     GetCompletedTransactions {
         payment_id: Option<Vec<u8>>,
         block_hash: Option<FixedHash>,
+        block_height: Option<u64>,
     },
     GetCancelledPendingInboundTransactions,
     GetCancelledPendingOutboundTransactions,
@@ -967,10 +968,15 @@ impl TransactionServiceHandle {
         &mut self,
         payment_id: Option<Vec<u8>>,
         block_hash: Option<FixedHash>,
+        block_height: Option<u64>,
     ) -> Result<Vec<CompletedTransaction>, TransactionServiceError> {
         match self
             .handle
-            .call(TransactionServiceRequest::GetCompletedTransactions { payment_id, block_hash })
+            .call(TransactionServiceRequest::GetCompletedTransactions {
+                payment_id,
+                block_hash,
+                block_height,
+            })
             .await??
         {
             TransactionServiceResponse::CompletedTransactions(c) => Ok(c),

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -891,11 +891,14 @@ where
                 TransactionServiceResponse::PendingOutboundTransactions(self.db.get_pending_outbound_transactions()?),
             ),
 
-            TransactionServiceRequest::GetCompletedTransactions { payment_id, block_hash } => {
-                Ok(TransactionServiceResponse::CompletedTransactions(
-                    self.db.get_completed_transactions(payment_id, block_hash)?,
-                ))
-            },
+            TransactionServiceRequest::GetCompletedTransactions {
+                payment_id,
+                block_hash,
+                block_height,
+            } => Ok(TransactionServiceResponse::CompletedTransactions(
+                self.db
+                    .get_completed_transactions(payment_id, block_hash, block_height)?,
+            )),
             TransactionServiceRequest::GetCancelledPendingInboundTransactions => {
                 Ok(TransactionServiceResponse::PendingInboundTransactions(
                     self.db.get_cancelled_pending_inbound_transactions()?,

--- a/base_layer/wallet/src/transaction_service/storage/database.rs
+++ b/base_layer/wallet/src/transaction_service/storage/database.rs
@@ -160,6 +160,7 @@ pub trait TransactionBackend: Send + Sync + Clone {
         &self,
         payment_id: Option<Vec<u8>>,
         block_hash: Option<FixedHash>,
+        block_height: Option<u64>,
     ) -> Result<Vec<CompletedTransaction>, TransactionStorageError>;
 }
 
@@ -487,10 +488,11 @@ where T: TransactionBackend + 'static
         &self,
         payment_id: Option<Vec<u8>>,
         block_hash: Option<FixedHash>,
+        block_height: Option<u64>,
     ) -> Result<Vec<CompletedTransaction>, TransactionStorageError> {
-        let t = self
-            .db
-            .find_completed_transactions_filter_payment_id_block_hash(payment_id, block_hash)?;
+        let t =
+            self.db
+                .find_completed_transactions_filter_payment_id_block_hash(payment_id, block_hash, block_height)?;
         Ok(t)
     }
 
@@ -604,12 +606,13 @@ where T: TransactionBackend + 'static
         &self,
         payment_id: Option<Vec<u8>>,
         block_hash: Option<FixedHash>,
+        block_height: Option<u64>,
     ) -> Result<Vec<CompletedTransaction>, TransactionStorageError> {
-        self.get_completed_transactions_by_cancelled(payment_id, false, block_hash)
+        self.get_completed_transactions_by_cancelled(payment_id, false, block_hash, block_height)
     }
 
     pub fn get_cancelled_completed_transactions(&self) -> Result<Vec<CompletedTransaction>, TransactionStorageError> {
-        self.get_completed_transactions_by_cancelled(None, true, None)
+        self.get_completed_transactions_by_cancelled(None, true, None, None)
     }
 
     pub fn get_any_transaction(&self, tx_id: TxId) -> Result<Option<WalletTransaction>, TransactionStorageError> {
@@ -636,14 +639,15 @@ where T: TransactionBackend + 'static
         payment_id: Option<Vec<u8>>,
         cancelled: bool,
         block_hash: Option<FixedHash>,
+        block_height: Option<u64>,
     ) -> Result<Vec<CompletedTransaction>, TransactionStorageError> {
         let key = if cancelled {
             DbKey::CancelledCompletedTransactions
         } else {
             DbKey::CompletedTransactions
         };
-        match (payment_id.is_none(), block_hash.is_none()) {
-            (true, true) => {
+        match (payment_id.is_none(), block_hash.is_none(), block_height.is_none()) {
+            (true, true, true) => {
                 let t = match self.db.fetch(&key) {
                     Ok(None) => log_error(
                         key,
@@ -657,9 +661,10 @@ where T: TransactionBackend + 'static
                 }?;
                 Ok(t)
             },
-            (_, _) => self
-                .db
-                .find_completed_transactions_filter_payment_id_block_hash(payment_id, block_hash),
+            (_, _, _) => {
+                self.db
+                    .find_completed_transactions_filter_payment_id_block_hash(payment_id, block_hash, block_height)
+            },
         }
     }
 

--- a/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
@@ -1052,6 +1052,7 @@ impl TransactionBackend for TransactionServiceSqliteDatabase {
         &self,
         payment_id: Option<Vec<u8>>,
         block_hash: Option<FixedHash>,
+        block_height: Option<u64>,
     ) -> Result<Vec<CompletedTransaction>, TransactionStorageError> {
         let mut conn = self.database_connection.get_pooled_connection()?;
         let cipher = acquire_read_lock!(self.cipher);
@@ -1062,6 +1063,9 @@ impl TransactionBackend for TransactionServiceSqliteDatabase {
         }
         if let Some(hash) = block_hash {
             query = query.filter(completed_transactions::mined_in_block.eq(hash.to_vec()));
+        }
+        if let Some(height) = block_height {
+            query = query.filter(completed_transactions::mined_height.eq(height as i64));
         }
 
         query

--- a/base_layer/wallet/tests/transaction_service_tests/service.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/service.rs
@@ -2304,7 +2304,7 @@ async fn manage_multiple_transactions() {
         )
         .await
         .unwrap();
-    let alice_completed_tx = alice_ts.get_completed_transactions(None, None).await.unwrap();
+    let alice_completed_tx = alice_ts.get_completed_transactions(None, None, None).await.unwrap();
     assert_eq!(alice_completed_tx.len(), 0);
     log::trace!("A to C 1 TxID: {}", tx_id_a_to_c_1);
 
@@ -2409,16 +2409,16 @@ async fn manage_multiple_transactions() {
     assert_eq!(finalized, 1);
 
     let alice_pending_outbound = alice_ts.get_pending_outbound_transactions().await.unwrap();
-    let alice_completed_tx = alice_ts.get_completed_transactions(None, None).await.unwrap();
+    let alice_completed_tx = alice_ts.get_completed_transactions(None, None, None).await.unwrap();
     assert_eq!(alice_pending_outbound.len(), 0);
     assert_eq!(alice_completed_tx.len(), 4, "Not enough transactions for Alice");
     let bob_pending_outbound = bob_ts.get_pending_outbound_transactions().await.unwrap();
-    let bob_completed_tx = bob_ts.get_completed_transactions(None, None).await.unwrap();
+    let bob_completed_tx = bob_ts.get_completed_transactions(None, None, None).await.unwrap();
     assert_eq!(bob_pending_outbound.len(), 0);
     assert_eq!(bob_completed_tx.len(), 3, "Not enough transactions for Bob");
 
     let carol_pending_inbound = carol_ts.get_pending_inbound_transactions().await.unwrap();
-    let carol_completed_tx = carol_ts.get_completed_transactions(None, None).await.unwrap();
+    let carol_completed_tx = carol_ts.get_completed_transactions(None, None, None).await.unwrap();
     assert_eq!(carol_pending_inbound.len(), 0);
     assert_eq!(carol_completed_tx.len(), 1);
 
@@ -5588,7 +5588,7 @@ async fn transaction_service_tx_broadcast() {
 
     let alice_completed_txs = alice_ts_interface
         .transaction_service_handle
-        .get_completed_transactions(None, None)
+        .get_completed_transactions(None, None, None)
         .await
         .unwrap();
     let alice_completed_tx1 = alice_completed_txs
@@ -5696,7 +5696,7 @@ async fn transaction_service_tx_broadcast() {
 
     let alice_completed_txs = alice_ts_interface
         .transaction_service_handle
-        .get_completed_transactions(None, None)
+        .get_completed_transactions(None, None, None)
         .await
         .unwrap();
     let alice_completed_tx2 = alice_completed_txs
@@ -6332,7 +6332,7 @@ async fn test_completed_transactions_ordering() {
 
     let alice_completed_transactions = alice_ts_interface
         .transaction_service_handle
-        .get_completed_transactions(None, None)
+        .get_completed_transactions(None, None, None)
         .await
         .unwrap();
 

--- a/base_layer/wallet/tests/transaction_service_tests/storage.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/storage.rs
@@ -358,7 +358,7 @@ pub async fn test_db_backend<T: TransactionBackend + 'static>(backend: T) {
         .unwrap();
     }
 
-    let retrieved_completed_txs = db.get_completed_transactions(None, None).unwrap();
+    let retrieved_completed_txs = db.get_completed_transactions(None, None, None).unwrap();
     assert_eq!(retrieved_completed_txs.len(), 2 * messages.len());
 
     for i in 0..messages.len() {
@@ -416,7 +416,7 @@ pub async fn test_db_backend<T: TransactionBackend + 'static>(backend: T) {
         panic!("Should have found completed tx");
     }
 
-    let completed_txs = db.get_completed_transactions(None, None).unwrap();
+    let completed_txs = db.get_completed_transactions(None, None, None).unwrap();
     let num_completed_txs = completed_txs.len();
     assert_eq!(db.get_cancelled_completed_transactions().unwrap().len(), 0);
 
@@ -424,7 +424,7 @@ pub async fn test_db_backend<T: TransactionBackend + 'static>(backend: T) {
     assert!(db.get_cancelled_completed_transaction(cancelled_tx_id).is_err());
     db.reject_completed_transaction(cancelled_tx_id, TxCancellationReason::Unknown)
         .unwrap();
-    let completed_txs = db.get_completed_transactions(None, None).unwrap();
+    let completed_txs = db.get_completed_transactions(None, None, None).unwrap();
     assert_eq!(completed_txs.len(), num_completed_txs - 1);
 
     db.get_cancelled_completed_transaction(cancelled_tx_id)

--- a/base_layer/wallet/tests/transaction_service_tests/transaction_protocols.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/transaction_protocols.rs
@@ -855,7 +855,7 @@ async fn tx_validation_protocol_tx_becomes_mined_unconfirmed_then_confirmed() {
     let result = join_handle.await.unwrap();
     assert!(result.is_ok());
 
-    let completed_txs = resources.db.get_completed_transactions(None, None).unwrap();
+    let completed_txs = resources.db.get_completed_transactions(None, None, None).unwrap();
 
     assert_eq!(
         completed_txs
@@ -890,7 +890,7 @@ async fn tx_validation_protocol_tx_becomes_mined_unconfirmed_then_confirmed() {
     let result = join_handle.await.unwrap();
     assert!(result.is_ok());
 
-    let completed_txs = resources.db.get_completed_transactions(None, None).unwrap();
+    let completed_txs = resources.db.get_completed_transactions(None, None, None).unwrap();
 
     assert_eq!(
         completed_txs
@@ -943,7 +943,7 @@ async fn tx_validation_protocol_tx_becomes_mined_unconfirmed_then_confirmed() {
     let result = join_handle.await.unwrap();
     assert!(result.is_ok());
 
-    let completed_txs = resources.db.get_completed_transactions(None, None).unwrap();
+    let completed_txs = resources.db.get_completed_transactions(None, None, None).unwrap();
 
     assert_eq!(
         completed_txs
@@ -1036,7 +1036,7 @@ async fn tx_revalidation() {
     let result = join_handle.await.unwrap();
     assert!(result.is_ok());
 
-    let completed_txs = resources.db.get_completed_transactions(None, None).unwrap();
+    let completed_txs = resources.db.get_completed_transactions(None, None, None).unwrap();
 
     assert_eq!(
         completed_txs
@@ -1081,7 +1081,7 @@ async fn tx_revalidation() {
         .db
         .mark_all_non_coinbases_transactions_as_unvalidated()
         .unwrap();
-    let completed_txs = resources.db.get_completed_transactions(None, None).unwrap();
+    let completed_txs = resources.db.get_completed_transactions(None, None, None).unwrap();
     let completed_tx_2 = completed_txs
         .iter()
         .find(|c_tx| c_tx.tx_id == TxId::from(2u64))
@@ -1102,7 +1102,7 @@ async fn tx_revalidation() {
     let result = join_handle.await.unwrap();
     assert!(result.is_ok());
 
-    let completed_txs = resources.db.get_completed_transactions(None, None).unwrap();
+    let completed_txs = resources.db.get_completed_transactions(None, None, None).unwrap();
     // data should now be updated and changed
     let completed_tx_2 = completed_txs
         .iter()
@@ -1272,7 +1272,7 @@ async fn tx_validation_protocol_reorg() {
     let result = join_handle.await.unwrap();
     assert!(result.is_ok());
 
-    let completed_txs = resources.db.get_completed_transactions(None, None).unwrap();
+    let completed_txs = resources.db.get_completed_transactions(None, None, None).unwrap();
     let mut unconfirmed_count = 0;
     let mut confirmed_count = 0;
     for tx in completed_txs {
@@ -1389,7 +1389,7 @@ async fn tx_validation_protocol_reorg() {
 
     assert_eq!(rpc_service_state.take_get_header_by_height_calls().len(), 0);
 
-    let completed_txs = resources.db.get_completed_transactions(None, None).unwrap();
+    let completed_txs = resources.db.get_completed_transactions(None, None, None).unwrap();
     // Tx 1
     assert!(completed_txs
         .iter()

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -8297,7 +8297,7 @@ pub unsafe extern "C" fn wallet_get_completed_transactions(
         (*wallet)
             .wallet
             .transaction_service
-            .get_completed_transactions(None, None),
+            .get_completed_transactions(None, None, None),
     );
     match completed_transactions {
         Ok(completed_transactions) => {
@@ -8368,7 +8368,7 @@ pub unsafe extern "C" fn wallet_get_pending_inbound_transactions(
                 (*wallet)
                     .wallet
                     .transaction_service
-                    .get_completed_transactions(None, None),
+                    .get_completed_transactions(None, None, None),
             ) {
                 // The frontend specification calls for completed transactions that have not yet been mined to be
                 // classified as Pending Transactions. In order to support this logic without impacting the practical
@@ -8440,7 +8440,7 @@ pub unsafe extern "C" fn wallet_get_pending_outbound_transactions(
                 (*wallet)
                     .wallet
                     .transaction_service
-                    .get_completed_transactions(None, None),
+                    .get_completed_transactions(None, None, None),
             ) {
                 // The frontend specification calls for completed transactions that have not yet been mined to be
                 // classified as Pending Transactions. In order to support this logic without impacting the practical
@@ -8597,7 +8597,7 @@ pub unsafe extern "C" fn wallet_get_completed_transaction_by_id(
         (*wallet)
             .wallet
             .transaction_service
-            .get_completed_transactions(None, None),
+            .get_completed_transactions(None, None, None),
     );
 
     match completed_transactions {
@@ -8661,7 +8661,7 @@ pub unsafe extern "C" fn wallet_get_pending_inbound_transaction_by_id(
         (*wallet)
             .wallet
             .transaction_service
-            .get_completed_transactions(None, None),
+            .get_completed_transactions(None, None, None),
     );
 
     match completed_transactions {
@@ -8737,7 +8737,7 @@ pub unsafe extern "C" fn wallet_get_pending_outbound_transaction_by_id(
         (*wallet)
             .wallet
             .transaction_service
-            .get_completed_transactions(None, None),
+            .get_completed_transactions(None, None, None),
     );
 
     match completed_transactions {

--- a/integration_tests/tests/steps/wallet_steps.rs
+++ b/integration_tests/tests/steps/wallet_steps.rs
@@ -162,6 +162,7 @@ async fn wallet_detects_all_txs_as_mined_status(world: &mut TariWorld, wallet_na
         .get_completed_transactions(GetCompletedTransactionsRequest {
             payment_id: None,
             block_hash: None,
+            block_height: None,
         })
         .await
         .unwrap()
@@ -499,6 +500,7 @@ async fn list_all_txs_for_wallet(world: &mut TariWorld, transaction_type: String
     let request = GetCompletedTransactionsRequest {
         payment_id: None,
         block_hash: None,
+        block_height: None,
     };
     let mut completed_txs = client.get_completed_transactions(request).await.unwrap().into_inner();
 
@@ -551,6 +553,7 @@ async fn wallet_has_at_least_num_txs(world: &mut TariWorld, wallet: String, num_
             .get_completed_transactions(grpc::GetCompletedTransactionsRequest {
                 payment_id: None,
                 block_hash: None,
+                block_height: None,
             })
             .await
             .unwrap()
@@ -971,6 +974,7 @@ async fn wallet_detects_at_least_coinbase_transactions(world: &mut TariWorld, wa
         .get_completed_transactions(GetCompletedTransactionsRequest {
             payment_id: None,
             block_hash: None,
+            block_height: None,
         })
         .await
         .unwrap()
@@ -1030,6 +1034,7 @@ async fn wallet_detects_at_least_coinbase_unconfirmed_transactions(
         .get_completed_transactions(GetCompletedTransactionsRequest {
             payment_id: None,
             block_hash: None,
+            block_height: None,
         })
         .await
         .unwrap()
@@ -1248,6 +1253,7 @@ async fn wallets_should_have_at_least_num_spendable_coinbase_outs(
                 .get_completed_transactions(GetCompletedTransactionsRequest {
                     payment_id: None,
                     block_hash: None,
+                    block_height: None,
                 })
                 .await
                 .unwrap()
@@ -2663,6 +2669,7 @@ async fn check_if_wallet_has_num_transactions(world: &mut TariWorld, wallet: Str
         .get_completed_transactions(GetCompletedTransactionsRequest {
             payment_id: None,
             block_hash: None,
+            block_height: None,
         })
         .await
         .unwrap()
@@ -2817,6 +2824,7 @@ async fn check_if_last_imported_txs_are_invalid_in_wallet(world: &mut TariWorld,
         .get_completed_transactions(GetCompletedTransactionsRequest {
             payment_id: None,
             block_hash: None,
+            block_height: None,
         })
         .await
         .unwrap()
@@ -2843,6 +2851,7 @@ async fn check_if_last_imported_txs_are_valid_in_wallet(world: &mut TariWorld, w
         .get_completed_transactions(GetCompletedTransactionsRequest {
             payment_id: None,
             block_hash: None,
+            block_height: None,
         })
         .await
         .unwrap()


### PR DESCRIPTION
Description
---
Added block height to the grpc query to get completed transactions.

Motivation and Context
---
Some clients need to query transactions in a block by height.

How Has This Been Tested?
---
System-level testing [**TBD**]

What process can a PR reviewer use to test or verify this change?
---
Code review
System-level testing

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for filtering completed transactions by block height in wallet queries and APIs.

- **Bug Fixes**
  - Updated all relevant interfaces and test cases to ensure compatibility with the new block height filter option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->