### PR TITLE
chore(wallet): allow read only wallet to receive keys args as envs

### DIFF
--- a/applications/minotari_console_wallet/src/cli.rs
+++ b/applications/minotari_console_wallet/src/cli.rs
@@ -95,9 +95,9 @@ pub struct Cli {
     #[clap(long, alias = "profile")]
     pub profile_with_tokio_console: bool,
     // For read only wallets
-    #[clap(long)]
+    #[clap(long, env = "VIEW_PRIVATE_KEY")]
     pub view_private_key: Option<String>,
-    #[clap(long)]
+    #[clap(long, env = "SPEND_KEY")]
     pub spend_key: Option<String>,
     #[clap(long)]
     pub birthday: Option<u16>,

--- a/applications/minotari_console_wallet/src/cli.rs
+++ b/applications/minotari_console_wallet/src/cli.rs
@@ -95,9 +95,9 @@ pub struct Cli {
     #[clap(long, alias = "profile")]
     pub profile_with_tokio_console: bool,
     // For read only wallets
-    #[clap(long, env = "MINOTARI_WALLET_VIEW_PRIVATE_KEY")]
+    #[clap(long, env = "MINOTARI_WALLET_VIEW_PRIVATE_KEY", hide_env_values = true)]
     pub view_private_key: Option<String>,
-    #[clap(long, env = "MINOTARI_WALLET_SPEND_KEY")]
+    #[clap(long, env = "MINOTARI_WALLET_SPEND_KEY", hide_env_values = true)]
     pub spend_key: Option<String>,
     #[clap(long)]
     pub birthday: Option<u16>,

--- a/applications/minotari_console_wallet/src/cli.rs
+++ b/applications/minotari_console_wallet/src/cli.rs
@@ -95,9 +95,9 @@ pub struct Cli {
     #[clap(long, alias = "profile")]
     pub profile_with_tokio_console: bool,
     // For read only wallets
-    #[clap(long, env = "VIEW_PRIVATE_KEY")]
+    #[clap(long, env = "MINOTARI_WALLET_VIEW_PRIVATE_KEY")]
     pub view_private_key: Option<String>,
-    #[clap(long, env = "SPEND_KEY")]
+    #[clap(long, env = "MINOTARI_WALLET_SPEND_KEY")]
     pub spend_key: Option<String>,
     #[clap(long)]
     pub birthday: Option<u16>,


### PR DESCRIPTION
Description
---
Allow `view_private_key` and `spend_key` CLI args for minotari_console_wallet to be received as envs.

Motivation and Context
---
Some users complained about these value being visible in logs. This is not security issue but just to make it more obvious since `view_private_key` sounds like something that shouldn't be visible as plain text.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for setting the view private key and spend key via environment variables, in addition to existing command-line options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->