### PR TITLE
feat: overrride coinbase payment_id if included in wallet payment address

### DIFF
--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -272,7 +272,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
             .await
             .map_err(|e| Status::internal(format!("{:?}", e)))?;
         let interactive_address = interactive_address
-            .create_payment_id_address(message.payment_id.clone())
+            .with_payment_id_user_data(message.payment_id.clone())
             .map_err(|e| Status::internal(format!("{:?}", e)))?;
         let one_sided_address = self
             .wallet
@@ -280,7 +280,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
             .await
             .map_err(|e| Status::internal(format!("{:?}", e)))?;
         let one_sided_address = one_sided_address
-            .create_payment_id_address(message.payment_id)
+            .with_payment_id_user_data(message.payment_id)
             .map_err(|e| Status::internal(format!("{:?}", e)))?;
         Ok(Response::new(GetCompleteAddressResponse {
             interactive_address: interactive_address.to_vec(),

--- a/applications/minotari_merge_mining_proxy/src/block_template_manager.rs
+++ b/applications/minotari_merge_mining_proxy/src/block_template_manager.rs
@@ -33,7 +33,12 @@ use tari_core::{
     proof_of_work::{monero_rx, monero_rx::FixedByteArray, Difficulty},
     transactions::{
         generate_coinbase,
-        transaction_components::{encrypted_data::PaymentId, CoinBaseExtra, TransactionKernel, TransactionOutput},
+        transaction_components::{
+            encrypted_data::{PaymentId, TxType},
+            CoinBaseExtra,
+            TransactionKernel,
+            TransactionOutput,
+        },
         transaction_key_manager::{create_memory_db_key_manager, MemoryDbKeyManager},
     },
     AuxChainHashes,
@@ -246,7 +251,10 @@ impl BlockTemplateManager<'_> {
             true,
             self.consensus_manager.consensus_constants(tari_height),
             self.config.range_proof_type,
-            PaymentId::Empty,
+            PaymentId::Open {
+                user_data: vec![],
+                tx_type: TxType::Coinbase,
+            },
         )
         .await?;
         Ok((coinbase_output, coinbase_kernel))

--- a/applications/minotari_miner/src/run_miner.rs
+++ b/applications/minotari_miner/src/run_miner.rs
@@ -59,7 +59,10 @@ use tari_core::{
     transactions::{
         generate_coinbase,
         tari_amount::MicroMinotari,
-        transaction_components::{encrypted_data::PaymentId, CoinBaseExtra},
+        transaction_components::{
+            encrypted_data::{PaymentId, TxType},
+            CoinBaseExtra,
+        },
         transaction_key_manager::{create_memory_db_key_manager, MemoryDbKeyManager},
     },
 };
@@ -440,7 +443,10 @@ async fn get_new_block_base_node(
         true,
         consensus_manager.consensus_constants(height),
         config.range_proof_type,
-        PaymentId::Empty,
+        PaymentId::Open {
+            user_data: vec![],
+            tx_type: TxType::Coinbase,
+        },
     )
     .await
     .map_err(|e| MinerError::CoinbaseError(e.to_string()))?;

--- a/applications/minotari_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/minotari_node/src/grpc/base_node_grpc_server.rs
@@ -66,7 +66,7 @@ use tari_core::{
     transactions::{
         generate_coinbase_with_wallet_output,
         transaction_components::{
-            encrypted_data::PaymentId,
+            encrypted_data::{PaymentId, TxType},
             CoinBaseExtra,
             KernelBuilder,
             RangeProofType,
@@ -1094,7 +1094,10 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
                 coinbase.stealth_payment,
                 self.consensus_rules.consensus_constants(height),
                 range_proof_type,
-                PaymentId::Empty,
+                PaymentId::Open {
+                    user_data: vec![],
+                    tx_type: TxType::Coinbase,
+                },
             )
             .await
             .map_err(|e| obscure_error_if_true(report_error_flag, Status::internal(e.to_string())))?;
@@ -1312,7 +1315,10 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
                 coinbase.stealth_payment,
                 self.consensus_rules.consensus_constants(height),
                 range_proof_type,
-                PaymentId::Empty,
+                PaymentId::Open {
+                    user_data: vec![],
+                    tx_type: TxType::Coinbase,
+                },
             )
             .await
             .map_err(|e| obscure_error_if_true(report_error_flag, Status::internal(e.to_string())))?;

--- a/base_layer/common_types/src/tari_address/dual_address.rs
+++ b/base_layer/common_types/src/tari_address/dual_address.rs
@@ -89,7 +89,7 @@ impl DualAddress {
         Self::new(view_key, spend_key, network, TariAddressFeatures::default(), None)
     }
 
-    pub fn add_payment_id(&mut self, data: Vec<u8>) -> Result<(), TariAddressError> {
+    pub fn add_payment_id_user_data(&mut self, data: Vec<u8>) -> Result<(), TariAddressError> {
         if data.len() > MAX_ENCRYPTED_DATA_SIZE {
             return Err(TariAddressError::PaymentIdTooLarge);
         }
@@ -126,7 +126,7 @@ impl DualAddress {
         Self::from_bytes(&bytes)
     }
 
-    pub fn get_payment_id_bytes(&self) -> Vec<u8> {
+    pub fn get_payment_id_user_data_bytes(&self) -> Vec<u8> {
         self.payment_id_user_data.as_ref().to_vec()
     }
 

--- a/base_layer/common_types/src/tari_address/mod.rs
+++ b/base_layer/common_types/src/tari_address/mod.rs
@@ -239,18 +239,18 @@ impl TariAddress {
         }
     }
 
-    pub fn get_payment_id_bytes(&self) -> Vec<u8> {
+    pub fn get_payment_id_user_data_bytes(&self) -> Vec<u8> {
         match self {
-            TariAddress::Dual(v) => v.get_payment_id_bytes(),
+            TariAddress::Dual(v) => v.get_payment_id_user_data_bytes(),
             TariAddress::Single(_) => vec![],
         }
     }
 
-    pub fn create_payment_id_address(&self, data: Vec<u8>) -> Result<Self, TariAddressError> {
+    pub fn with_payment_id_user_data(&self, data: Vec<u8>) -> Result<Self, TariAddressError> {
         match self {
             TariAddress::Dual(v) => {
                 let mut address = v.clone();
-                address.add_payment_id(data)?;
+                address.add_payment_id_user_data(data)?;
                 Ok(TariAddress::Dual(address))
             },
             TariAddress::Single(_) => Err(TariAddressError::PaymentIdNotSupported),

--- a/base_layer/core/src/test_helpers/mod.rs
+++ b/base_layer/core/src/test_helpers/mod.rs
@@ -47,7 +47,13 @@ use crate::{
     transactions::{
         generate_coinbase_with_wallet_output,
         tari_amount::MicroMinotari,
-        transaction_components::{encrypted_data::PaymentId, CoinBaseExtra, RangeProofType, Transaction, WalletOutput},
+        transaction_components::{
+            encrypted_data::{PaymentId, TxType},
+            CoinBaseExtra,
+            RangeProofType,
+            Transaction,
+            WalletOutput,
+        },
         transaction_key_manager::{MemoryDbKeyManager, TariKeyId, TransactionKeyManagerInterface},
     },
 };
@@ -124,7 +130,10 @@ pub async fn create_block<TDB: BlockchainBackend>(
         false,
         rules.consensus_constants(header.height),
         range_proof_type.unwrap_or(RangeProofType::BulletProofPlus),
-        PaymentId::Empty,
+        PaymentId::Open {
+            user_data: vec![],
+            tx_type: TxType::Coinbase,
+        },
     )
     .await
     .unwrap();

--- a/base_layer/core/src/transactions/coinbase_builder.rs
+++ b/base_layer/core/src/transactions/coinbase_builder.rs
@@ -41,7 +41,7 @@ use crate::{
     transactions::{
         tari_amount::{uT, MicroMinotari},
         transaction_components::{
-            encrypted_data::PaymentId,
+            encrypted_data::{PaymentId, TxType},
             CoinBaseExtra,
             KernelBuilder,
             KernelFeatures,
@@ -449,6 +449,16 @@ pub async fn generate_coinbase_with_wallet_output(
             "Invalid address, address must be one-sided enabled".to_string(),
         ));
     }
+    // Override payment id if the wallet address contains a pyment id
+    let payment_id = if wallet_payment_address.get_payment_id_user_data_bytes().is_empty() {
+        payment_id
+    } else {
+        PaymentId::Open {
+            user_data: wallet_payment_address.get_payment_id_user_data_bytes(),
+            tx_type: TxType::Coinbase,
+        }
+    };
+
     let sender_offset = key_manager
         .get_next_key(TransactionKeyManagerBranch::SenderOffset.get_branch_key())
         .await?;
@@ -509,9 +519,11 @@ mod test {
     use tari_common_types::{
         key_branches::TransactionKeyManagerBranch,
         tari_address::TariAddress,
-        types::{CompressedCommitment, CompressedPublicKey, Signature},
+        types::{CompressedCommitment, CompressedPublicKey, PrivateKey, Signature},
     };
     use tari_comms::types::CompressedSignature;
+    use tari_crypto::keys::SecretKey;
+    use tari_utilities::ByteArray;
 
     use crate::{
         consensus::{emission::Emission, ConsensusManager, ConsensusManagerBuilder},
@@ -779,15 +791,26 @@ mod test {
     }
     use tari_script::push_pubkey_script;
 
-    use crate::transactions::{
-        aggregated_body::AggregateBody,
-        transaction_components::{encrypted_data::PaymentId, KernelBuilder, RangeProofType, TransactionKernelVersion},
-        transaction_key_manager::{
-            create_memory_db_key_manager,
-            MemoryDbKeyManager,
-            TariKeyId,
-            TransactionKeyManagerInterface,
-            TxoStage,
+    use crate::{
+        test_helpers::create_consensus_constants,
+        transactions::{
+            aggregated_body::AggregateBody,
+            generate_coinbase_with_wallet_output,
+            tari_amount::MicroMinotari,
+            transaction_components::{
+                encrypted_data::{PaymentId, TxType},
+                CoinBaseExtra,
+                KernelBuilder,
+                RangeProofType,
+                TransactionKernelVersion,
+            },
+            transaction_key_manager::{
+                create_memory_db_key_manager,
+                MemoryDbKeyManager,
+                TariKeyId,
+                TransactionKeyManagerInterface,
+                TxoStage,
+            },
         },
     };
 
@@ -1207,5 +1230,56 @@ mod test {
             1,
         )
         .unwrap_err();
+    }
+
+    #[tokio::test]
+    async fn test_generate_coinbase_with_payment_id_from_address() {
+        let key_manager = create_memory_db_key_manager().unwrap();
+        let wallet_private_spend_key = PrivateKey::random(&mut rand::rngs::OsRng);
+        let wallet_private_view_key = PrivateKey::random(&mut rand::rngs::OsRng);
+
+        let script_key_id = key_manager.import_key(wallet_private_spend_key.clone()).await.unwrap();
+        let payment_id_user_data = b"This is my payment id";
+        let wallet_payment_address =
+            tari_common_types::tari_address::TariAddress::new_dual_address_with_default_features(
+                tari_common_types::types::CompressedPublicKey::from_secret_key(&wallet_private_view_key),
+                tari_common_types::types::CompressedPublicKey::from_secret_key(&wallet_private_spend_key),
+                Network::LocalNet,
+            )
+            .unwrap()
+            .with_payment_id_user_data(payment_id_user_data.to_vec())
+            .unwrap();
+        assert_eq!(
+            PaymentId::stringify_bytes(&wallet_payment_address.get_payment_id_user_data_bytes()),
+            PaymentId::stringify_bytes(payment_id_user_data)
+        );
+
+        let reward = MicroMinotari::from(1000);
+        let header_height = 1;
+        let range_proof_type = RangeProofType::RevealedValue;
+
+        let (_, _, _, coinbase_wallet_output) = generate_coinbase_with_wallet_output(
+            MicroMinotari::from(0),
+            reward,
+            header_height,
+            &CoinBaseExtra::default(),
+            &key_manager,
+            &script_key_id,
+            &wallet_payment_address,
+            false,
+            &create_consensus_constants(header_height),
+            range_proof_type,
+            PaymentId::Open {
+                user_data: vec![],
+                tx_type: TxType::Coinbase,
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            coinbase_wallet_output.payment_id.user_data_as_string(),
+            PaymentId::stringify_bytes(payment_id_user_data)
+        );
     }
 }

--- a/base_layer/core/src/transactions/coinbase_builder.rs
+++ b/base_layer/core/src/transactions/coinbase_builder.rs
@@ -449,7 +449,7 @@ pub async fn generate_coinbase_with_wallet_output(
             "Invalid address, address must be one-sided enabled".to_string(),
         ));
     }
-    // Override payment id if the wallet address contains a pyment id
+    // Override payment id if the wallet address contains a payment id
     let payment_id = if wallet_payment_address.get_payment_id_user_data_bytes().is_empty() {
         payment_id
     } else {

--- a/base_layer/core/src/transactions/transaction_components/encrypted_data.rs
+++ b/base_layer/core/src/transactions/transaction_components/encrypted_data.rs
@@ -93,6 +93,7 @@ pub enum TxType {
     HtlcAtomicSwapRefund = 0b0111,
     CodeTemplateRegistration = 0b1000,
     ImportedUtxoNoneRewindable = 0b1001,
+    Coinbase = 0b1011,
 }
 
 impl TxType {
@@ -112,6 +113,7 @@ impl TxType {
             0b0111 => TxType::HtlcAtomicSwapRefund,
             0b1000 => TxType::CodeTemplateRegistration,
             0b1001 => TxType::ImportedUtxoNoneRewindable,
+            0b1011 => TxType::Coinbase,
             _ => TxType::default(),
         }
     }
@@ -128,6 +130,7 @@ impl TxType {
             TxType::HtlcAtomicSwapRefund => 0b0111,
             TxType::CodeTemplateRegistration => 0b1000,
             TxType::ImportedUtxoNoneRewindable => 0b1001,
+            TxType::Coinbase => 0b1011,
         }
     }
 
@@ -149,6 +152,7 @@ impl Display for TxType {
             TxType::HtlcAtomicSwapRefund => write!(f, "HtlcAtomicSwapRefund"),
             TxType::CodeTemplateRegistration => write!(f, "CodeTemplateRegistration"),
             TxType::ImportedUtxoNoneRewindable => write!(f, "ImportedUtxoNoneRewindable"),
+            TxType::Coinbase => write!(f, "Coinbase"),
         }
     }
 }
@@ -1098,7 +1102,7 @@ mod test {
             ),
             PaymentId::Open {
                 user_data: vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-                tx_type: TxType::default(),
+                tx_type: TxType::Coinbase,
             },
             PaymentId::Open {
                 user_data: vec![1; 254],
@@ -1220,6 +1224,7 @@ mod test {
             TxType::HtlcAtomicSwapRefund,
             TxType::CodeTemplateRegistration,
             TxType::ImportedUtxoNoneRewindable,
+            TxType::Coinbase,
         ] {
             let payment_id = PaymentId::Open {
                 tx_type: tx_type.clone(),
@@ -1364,14 +1369,14 @@ mod test {
             sender_one_sided: true,
             amount: MicroMinotari::from(u64::MAX),
             fee: MicroMinotari::from(4_294_967_295 + 100), // 4294.967395 T
-            tx_type: TxType::Burn,
+            tx_type: TxType::Coinbase,
             user_data: "Hello World!!! 11-22-33".as_bytes().to_vec(),
         };
         // - It can be displayed as is ...
         assert_eq!(
             payment_id_3.to_string(),
             "recipient_address(f425UWsDp714RiN53c1G6ek57rfFnotB5NCMyrn4iDgbR8i2sXVHa4xSsedd66o9KmkRgErQnyDdCaAdNLzcKrj7eUb), \
-            sender_one_sided(true), amount(18446744073709.551615 T), fee(4294.967395 T), type(Burn), data(Hello World!!! 11-22-33)"
+            sender_one_sided(true), amount(18446744073709.551615 T), fee(4294.967395 T), type(Coinbase), data(Hello World!!! 11-22-33)"
         );
         // ... but it cannot be serialized and deserialized as is - overflowed metadata will be zeroed.
         let payment_id_3_bytes = payment_id_3.to_bytes();
@@ -1379,7 +1384,7 @@ mod test {
         assert_eq!(
             payment_id_3_from_bytes.to_string(),
             "recipient_address(f425UWsDp714RiN53c1G6ek57rfFnotB5NCMyrn4iDgbR8i2sXVHa4xSsedd66o9KmkRgErQnyDdCaAdNLzcKrj7eUb), \
-            sender_one_sided(true), amount(18446744073709.551615 T), fee(0 µT), type(Burn), data(Hello World!!! 11-22-33)"
+            sender_one_sided(true), amount(18446744073709.551615 T), fee(0 µT), type(Coinbase), data(Hello World!!! 11-22-33)"
         );
     }
 

--- a/base_layer/tari_mining_helper_ffi/src/lib.rs
+++ b/base_layer/tari_mining_helper_ffi/src/lib.rs
@@ -42,7 +42,11 @@ use tari_core::{
     proof_of_work::sha3x_difficulty,
     transactions::{
         generate_coinbase,
-        transaction_components::{encrypted_data::PaymentId, CoinBaseExtra, RangeProofType},
+        transaction_components::{
+            encrypted_data::{PaymentId, TxType},
+            CoinBaseExtra,
+            RangeProofType,
+        },
         transaction_key_manager::create_memory_db_key_manager,
     },
 };
@@ -400,7 +404,10 @@ pub unsafe extern "C" fn inject_coinbase(
             stealth_payment,
             consensus_manager.consensus_constants(height),
             range_proof_type,
-            PaymentId::Empty,
+            PaymentId::Open {
+                user_data: vec![],
+                tx_type: TxType::Coinbase,
+            },
         )
         .await
     }) {

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -1206,7 +1206,7 @@ where
         }
         // let override the payment_id if the address says we should
         if destination.features().contains(TariAddressFeatures::PAYMENT_ID) {
-            payment_id = PaymentId::open(destination.get_payment_id_bytes(), TxType::PaymentToOther);
+            payment_id = PaymentId::open(destination.get_payment_id_user_data_bytes(), TxType::PaymentToOther);
         }
         let (tx_reply_sender, tx_reply_receiver) = mpsc::channel(100);
         let (cancellation_sender, cancellation_receiver) = oneshot::channel();
@@ -1761,7 +1761,7 @@ where
         let tx_id = TxId::new_random();
         // let override the payment_id if the address says we should
         if dest_address.features().contains(TariAddressFeatures::PAYMENT_ID) {
-            payment_id = PaymentId::open(dest_address.get_payment_id_bytes(), TxType::PaymentToOther);
+            payment_id = PaymentId::open(dest_address.get_payment_id_user_data_bytes(), TxType::PaymentToOther);
         }
         let payment_id = match payment_id.clone() {
             PaymentId::Open { .. } | PaymentId::Empty => PaymentId::add_sender_address(
@@ -3205,7 +3205,8 @@ where
                                             TxType::ValidatorNodeRegistration |
                                             TxType::CodeTemplateRegistration |
                                             TxType::ClaimAtomicSwap |
-                                            TxType::HtlcAtomicSwapRefund => {
+                                            TxType::HtlcAtomicSwapRefund |
+                                            TxType::Coinbase => {
                                                 source_address = Some(own_address.clone());
                                                 destination_address = Some(own_address.clone());
                                             },
@@ -3705,7 +3706,8 @@ where
                     TxType::CodeTemplateRegistration |
                     TxType::ClaimAtomicSwap |
                     TxType::HtlcAtomicSwapRefund |
-                    TxType::ImportedUtxoNoneRewindable => TransactionDirection::Inbound,
+                    TxType::ImportedUtxoNoneRewindable |
+                    TxType::Coinbase => TransactionDirection::Inbound,
                 },
                 amount,
                 match tx_type {
@@ -3717,7 +3719,8 @@ where
                     TxType::ValidatorNodeRegistration |
                     TxType::CodeTemplateRegistration |
                     TxType::ClaimAtomicSwap |
-                    TxType::HtlcAtomicSwapRefund => self.resources.one_sided_tari_address.clone(),
+                    TxType::HtlcAtomicSwapRefund |
+                    TxType::Coinbase => self.resources.one_sided_tari_address.clone(),
                 },
             )
         } else {

--- a/integration_tests/src/miner.rs
+++ b/integration_tests/src/miner.rs
@@ -41,7 +41,12 @@ use tari_core::{
     transactions::{
         generate_coinbase_with_wallet_output,
         tari_amount::MicroMinotari,
-        transaction_components::{encrypted_data::PaymentId, CoinBaseExtra, RangeProofType, WalletOutput},
+        transaction_components::{
+            encrypted_data::{PaymentId, TxType},
+            CoinBaseExtra,
+            RangeProofType,
+            WalletOutput,
+        },
         transaction_key_manager::{MemoryDbKeyManager, TariKeyId},
     },
 };
@@ -296,7 +301,10 @@ async fn create_block_template_with_coinbase(
         stealth_payment,
         consensus_manager.consensus_constants(height),
         RangeProofType::BulletProofPlus,
-        PaymentId::Empty,
+        PaymentId::Open {
+            user_data: vec![],
+            tx_type: TxType::Coinbase,
+        },
     )
     .await
     .unwrap();


### PR DESCRIPTION

Description
---
Added coinbase payment_id to the coinbase from the wallet payment address if it exists.

Motivation and Context
---
This functionality can be used by pool operators.

How Has This Been Tested?
---
Added new unit test - `test_generate_coinbase_with_payment_id_from_address`

What process can a PR reviewer use to test or verify this change?
---
Code review

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for a new "Coinbase" transaction type.
  - Enhanced coinbase transaction creation to embed payment ID user data directly from wallet addresses.

- **Bug Fixes**
  - Improved extraction and handling of payment ID user data from addresses when sending transactions.
  - Extended transaction handling logic to treat "Coinbase" transactions consistently with other special types.

- **Tests**
  - Added test verifying coinbase creation with embedded payment ID user data.

- **Refactor**
  - Renamed several address and payment ID methods for improved clarity and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->