### PR TITLE
feat: improve listening error propagation

### DIFF
--- a/base_layer/core/src/base_node/state_machine_service/states/listening.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/listening.rs
@@ -30,6 +30,7 @@ use std::{
 use log::*;
 use serde::{Deserialize, Serialize};
 use tari_common_types::chain_metadata::ChainMetadata;
+use tari_comms::peer_manager::PeerManagerError;
 use tari_utilities::epoch_time::EpochTime;
 use tokio::sync::broadcast;
 
@@ -189,8 +190,20 @@ impl Listening {
                             continue;
                         },
                         Ok(false) => {},
-                        Err(e) => {
-                            return FatalError(format!("Error checking if peer is banned: {}", e));
+                        Err(e) => match e {
+                            PeerManagerError::DataInconsistency(_) |
+                            PeerManagerError::DatabaseError(_) |
+                            PeerManagerError::MigrationError(_) => {
+                                return FatalError(format!("Error checking if peer is banned: {}", e));
+                            },
+                            _ => {
+                                warn!(
+                                    target: LOG_TARGET,
+                                    "Ignoring chain metadata from peer {} due to error: {}",
+                                    peer_metadata.node_id(), e
+                                );
+                                continue;
+                            },
                         },
                     }
 


### PR DESCRIPTION
Description
---
Improved listening service error propagation if the peer manager returns errors while checking if the peer is banned.  This eliminates an unnecessary panic when a peer is not found in the peer database.

Motivation and Context
---
All peer manager errors at this stage should not be treated as fatal errors.

How Has This Been Tested?
---
System-level testing

What process can a PR reviewer use to test or verify this change?
---
Code review.

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling when checking if a peer is banned, ensuring non-critical errors do not interrupt normal operations and are logged as warnings instead. Critical errors will still result in a fatal error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->