### PR TITLE
feat: add spendable supply grpc query

### DIFF
--- a/applications/minotari_app_grpc/proto/base_node.proto
+++ b/applications/minotari_app_grpc/proto/base_node.proto
@@ -225,8 +225,9 @@ message NetworkDifficultyResponse {
 
 // A generic single value response for a specific height
 message ValueAtHeightResponse {
-    uint64 value= 1;
-    uint64 height = 2;
+    uint64 circulating_supply = 1;
+    uint64 spendable_supply = 2;
+    uint64 height = 3;
 }
 
 // A generic uint value

--- a/applications/minotari_console_wallet/src/automation/commands.rs
+++ b/applications/minotari_console_wallet/src/automation/commands.rs
@@ -839,7 +839,7 @@ pub async fn command_runner(
                 let output_hashes: Vec<HashOutput> = pre_mine_outputs.iter().map(|v| v.hash()).collect();
                 let unspent_outputs = transaction_service.fetch_unspent_outputs(output_hashes).await?;
 
-                let pre_mine_items = match get_pre_mine_items(Network::get_current_or_user_setting_or_default()).await {
+                let pre_mine_items = match get_pre_mine_items(Network::get_current_or_user_setting_or_default()) {
                     Ok(items) => items,
                     Err(e) => {
                         eprintln!("\nError: {}\n", e);
@@ -1278,7 +1278,7 @@ pub async fn command_runner(
                 // Encumber outputs
                 let mut outputs_for_parties = Vec::with_capacity(party_info_per_index.len());
                 let mut outputs_for_self = Vec::with_capacity(party_info_per_index.len());
-                let pre_mine_items = match get_pre_mine_items(Network::get_current_or_user_setting_or_default()).await {
+                let pre_mine_items = match get_pre_mine_items(Network::get_current_or_user_setting_or_default()) {
                     Ok(items) => items,
                     Err(e) => {
                         eprintln!("\nError: {}\n", e);

--- a/applications/minotari_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/minotari_node/src/grpc/base_node_grpc_server.rs
@@ -1796,6 +1796,7 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
         Ok(Response::new(rx))
     }
 
+    // Get current blocks for list of block heights - if the request is empty the tip block is returned
     async fn get_blocks(
         &self,
         request: Request<tari_rpc::GetBlocksRequest>,
@@ -1810,10 +1811,10 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
 
         let mut heights = request.heights;
         if heights.is_empty() {
-            return Err(obscure_error_if_true(
-                report_error_flag,
-                Status::invalid_argument("heights cannot be empty"),
-            ));
+            let mut handler = self.node_service.clone();
+            if let Ok(tip) = handler.get_metadata().await {
+                heights.push(tip.best_block_height());
+            }
         }
 
         heights.truncate(GET_BLOCKS_MAX_HEIGHTS);
@@ -2204,6 +2205,7 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
         Ok(Response::new(resp))
     }
 
+    // Get tokens in circulations for list of block heights - if the request is empty the tip block height is used
     async fn get_tokens_in_circulation(
         &self,
         request: Request<tari_rpc::GetBlocksRequest>,
@@ -2213,6 +2215,12 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
         trace!(target: LOG_TARGET, "Incoming GRPC request for GetTokensInCirculation",);
         let request = request.into_inner();
         let mut heights = request.heights;
+        if heights.is_empty() {
+            let mut handler = self.node_service.clone();
+            if let Ok(tip) = handler.get_metadata().await {
+                heights.push(tip.best_block_height());
+            }
+        }
         heights = heights
             .drain(..cmp::min(heights.len(), GET_TOKENS_IN_CIRCULATION_MAX_HEIGHTS))
             .collect();
@@ -2231,24 +2239,46 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
                 .drain(..cmp::min(heights.len(), GET_TOKENS_IN_CIRCULATION_PAGE_SIZE))
                 .collect();
             while !page.is_empty() {
-                let values: Vec<tari_rpc::ValueAtHeightResponse> = page
+                let values = page
                     .clone()
                     .into_iter()
-                    .map(|height| tari_rpc::ValueAtHeightResponse {
-                        height,
-                        value: consensus_manager.emission_schedule().supply_at_block(height).into(),
+                    .map(|height| {
+                        let circulating_supply = consensus_manager.emission_schedule().supply_at_block(height).into();
+                        let spendable_supply = consensus_manager.block_rewards_spendable_at_height(height)?.into();
+
+                        Ok(tari_rpc::ValueAtHeightResponse {
+                            height,
+                            circulating_supply,
+                            spendable_supply,
+                        })
                     })
-                    .collect();
-                let result_size = values.len();
-                for value in values {
-                    if tx.send(Ok(value)).await.is_err() {
+                    .collect::<Result<Vec<tari_rpc::ValueAtHeightResponse>, String>>();
+                let result_size = match values {
+                    Ok(values) => {
+                        let values_len = values.len();
+                        for value in values {
+                            if tx.send(Ok(value)).await.is_err() {
+                                warn!(
+                                    target: LOG_TARGET,
+                                    "[get_tokens_in_circulation] Request was cancelled while sending a response"
+                                );
+                                return;
+                            }
+                        }
+                        values_len
+                    },
+                    Err(e) => {
                         warn!(
                             target: LOG_TARGET,
-                            "[get_tokens_in_circulation] Request was cancelled while sending a response"
+                            "Error communicating with local base node: {:?}", e,
                         );
+                        let _ignore = tx.send(Err(obscure_error_if_true(
+                            report_error_flag,
+                            Status::internal(format!("Error communicating with local base node: {}", e)),
+                        )));
                         return;
-                    }
-                }
+                    },
+                };
                 if result_size < GET_TOKENS_IN_CIRCULATION_PAGE_SIZE {
                     break;
                 }

--- a/base_layer/core/src/blocks/pre_mine/mod.rs
+++ b/base_layer/core/src/blocks/pre_mine/mod.rs
@@ -167,6 +167,16 @@ fn get_expected_payout_grace_period_blocks(network: Network) -> u64 {
     }
 }
 
+/// Get the total spendable pre-mine amount in circulation at the specified height
+pub fn pre_mine_spendable_at_height(height: u64, network: Network) -> Result<MicroMinotari, String> {
+    let pre_mine_items = get_pre_mine_items(network)?;
+    Ok(pre_mine_items
+        .iter()
+        .filter(|v| v.original_maturity <= height)
+        .map(|v| v.value)
+        .sum())
+}
+
 /// Get the tokenomics unlock schedule as per the specification - see `https://tari.substack.com/p/tari-tokenomics`
 pub fn get_tokenomics_pre_mine_unlock_schedule(network: Network) -> UnlockSchedule {
     UnlockSchedule {
@@ -735,7 +745,7 @@ pub fn create_pre_mine_output_values(schedule: UnlockSchedule) -> Result<Vec<Pre
 }
 
 /// Get the pre-mine items according to the pre-mine specification
-pub async fn get_pre_mine_items(network: Network) -> Result<Vec<PreMineItem>, String> {
+pub fn get_pre_mine_items(network: Network) -> Result<Vec<PreMineItem>, String> {
     let schedule = get_tokenomics_pre_mine_unlock_schedule(network);
     create_pre_mine_output_values(schedule)
 }
@@ -793,6 +803,7 @@ pub fn verify_script_keys_for_index(
 }
 
 /// Create pre-mine genesis block info with the given pre-mine items and party public keys
+#[allow(clippy::too_many_lines)]
 pub async fn create_pre_mine_genesis_block_info(
     pre_mine_items: &[PreMineItem],
     threshold_spend_keys: &[Vec<CompressedPublicKey>],
@@ -809,27 +820,37 @@ pub async fn create_pre_mine_genesis_block_info(
         let signature_threshold = get_signature_threshold(public_keys.len())?;
         let mut total_script_key = UncompressedPublicKey::default();
         for key in public_keys {
-            total_script_key = total_script_key + key.to_public_key().unwrap();
+            total_script_key = total_script_key + key.to_public_key().map_err(|e| e.to_string())?;
         }
-        let key_manager = create_memory_db_key_manager().unwrap();
-        let view_key =
-            public_key_to_output_encryption_key(&CompressedPublicKey::new_from_pk(total_script_key)).unwrap();
-        let view_key_id = key_manager.import_key(view_key.clone()).await.unwrap();
-        let address_len = u8::try_from(public_keys.len()).unwrap();
+        let key_manager = create_memory_db_key_manager().map_err(|e| e.to_string())?;
+        let view_key = public_key_to_output_encryption_key(&CompressedPublicKey::new_from_pk(total_script_key))
+            .map_err(|e| e.to_string())?;
+        let view_key_id = key_manager
+            .import_key(view_key.clone())
+            .await
+            .map_err(|e| e.to_string())?;
+        let address_len = u8::try_from(public_keys.len()).map_err(|e| e.to_string())?;
 
-        let (commitment_mask, script_key) = key_manager.get_next_commitment_mask_and_script_key().await.unwrap();
-        total_private_key = total_private_key + &key_manager.get_private_key(&commitment_mask.key_id).await.unwrap();
+        let (commitment_mask, script_key) = key_manager
+            .get_next_commitment_mask_and_script_key()
+            .await
+            .map_err(|e| e.to_string())?;
+        total_private_key = total_private_key +
+            &key_manager
+                .get_private_key(&commitment_mask.key_id)
+                .await
+                .map_err(|e| e.to_string())?;
         let commitment = key_manager
             .get_commitment(&commitment_mask.key_id, &item.value.into())
             .await
-            .unwrap();
+            .map_err(|e| e.to_string())?;
         let mut commitment_bytes = [0u8; 32];
         commitment_bytes.clone_from_slice(commitment.as_bytes());
 
         let sender_offset = key_manager
             .get_next_key(TransactionKeyManagerBranch::SenderOffset.get_branch_key())
             .await
-            .unwrap();
+            .map_err(|e| e.to_string())?;
         let mut public_keys = public_keys.clone();
         public_keys.shuffle(&mut thread_rng());
         let script = script!(
@@ -852,7 +873,7 @@ pub async fn create_pre_mine_genesis_block_info(
             .with_script(script)
             .encrypt_data_for_recovery(&key_manager, Some(&view_key_id), PaymentId::U256(i.into()))
             .await
-            .unwrap()
+            .map_err(|e| e.to_string())?
             .with_input_data(ExecutionStack::default())
             .with_version(TransactionOutputVersion::get_current_version())
             .with_sender_offset_public_key(sender_offset.pub_key)
@@ -860,11 +881,16 @@ pub async fn create_pre_mine_genesis_block_info(
             .with_minimum_value_promise(item.value)
             .sign_as_sender_and_receiver(&key_manager, &sender_offset.key_id)
             .await
-            .unwrap()
+            .map_err(|e| e.to_string())?
             .try_build(&key_manager)
             .await
-            .unwrap();
-        outputs.push(output.to_transaction_output(&key_manager).await.unwrap());
+            .map_err(|e| e.to_string())?;
+        outputs.push(
+            output
+                .to_transaction_output(&key_manager)
+                .await
+                .map_err(|e| e.to_string())?,
+        );
     }
     // lets create a single kernel for all the outputs
     let r = PrivateKey::random(&mut OsRng);
@@ -876,7 +902,7 @@ pub async fn create_pre_mine_genesis_block_info(
         &total_public_key,
         &tx_meta,
     );
-    let signature = UncompressedSignature::sign_raw_uniform(&total_private_key, r, &e).unwrap();
+    let signature = UncompressedSignature::sign_raw_uniform(&total_private_key, r, &e).map_err(|e| e.to_string())?;
     let compressed_signature = Signature::new_from_schnorr(signature);
     let excess = CompressedCommitment::from_compressed_key(total_public_key);
     let kernel = TransactionKernel::new_current_version(
@@ -904,9 +930,11 @@ mod test {
             create_pre_mine_genesis_block_info,
             create_pre_mine_output_values,
             get_expected_payout_grace_period_blocks,
+            get_pre_mine_items,
             get_pre_mine_value,
             get_signature_threshold,
             get_tokenomics_pre_mine_unlock_schedule,
+            pre_mine_spendable_at_height,
             verify_script_keys_for_index,
             Apportionment,
             CustomRelease,
@@ -916,7 +944,7 @@ mod test {
             ReleaseStrategy,
             BLOCKS_PER_DAY,
         },
-        consensus::consensus_constants::MAINNET_PRE_MINE_VALUE,
+        consensus::{consensus_constants::MAINNET_PRE_MINE_VALUE, emission::Emission, ConsensusManager},
         transactions::{
             tari_amount::{MicroMinotari, Minotari},
             transaction_components::{TransactionKernel, TransactionOutput},
@@ -1437,5 +1465,160 @@ mod test {
         assert_eq!(get_signature_threshold(18).unwrap(), 10);
         assert_eq!(get_signature_threshold(19).unwrap(), 10);
         assert_eq!(get_signature_threshold(20).unwrap(), 11);
+    }
+
+    #[test]
+    #[allow(clippy::too_many_lines)]
+    fn test_total_spendable_supply_at_height() {
+        // Initial maturity schedule up to 3 weeks ( | height | (maturity) |):
+        // | 0 -> 5040 - 1 | (720) |
+        //                 | 5040 -> 10080 - 1 | (540) |
+        //                                     | 10080 -> 15120 - 1 | (360) |
+        //                                                          | 15120 -> | (180) |
+
+        let network = Network::MainNet;
+        let consensus_manager = ConsensusManager::builder(network)
+            .build()
+            .map_err(|e| e.to_string())
+            .unwrap();
+        let emission_schedule = consensus_manager.emission_schedule();
+        let pre_mine_items = get_pre_mine_items(network).unwrap();
+        let maturity_tranches = consensus_manager.get_maturity_tranches();
+
+        for (height, value) in [
+            // Within 1st tranche
+            (0, 756000002000000),
+            (maturity_tranches[0].maturity / 2, 756000002000000),
+            // Within 2nd tranche
+            (maturity_tranches[1].effective_from_height, 816162165168137),
+            (
+                maturity_tranches[1].effective_from_height + maturity_tranches[0].maturity / 2,
+                821165374278621,
+            ),
+            (
+                maturity_tranches[1].effective_from_height + maturity_tranches[0].maturity,
+                828667219912912,
+            ),
+            // Within 3rd tranche
+            (maturity_tranches[2].effective_from_height, 888553971940358),
+            (
+                maturity_tranches[2].effective_from_height + maturity_tranches[1].maturity / 2,
+                892289348766953,
+            ),
+            (
+                maturity_tranches[2].effective_from_height + maturity_tranches[1].maturity,
+                898513007030503,
+            ),
+            // Within 4th tranche
+            (maturity_tranches[3].effective_from_height, 960614382886959),
+            (
+                maturity_tranches[3].effective_from_height + maturity_tranches[2].maturity / 2,
+                963093332298424,
+            ),
+            (
+                maturity_tranches[3].effective_from_height + maturity_tranches[2].maturity,
+                968050054592502,
+            ),
+            // Within pre-mine maturity range 1
+            (180 * BLOCKS_PER_DAY, 2573982676047120),
+            (180 * BLOCKS_PER_DAY + 2 * 31 * BLOCKS_PER_DAY, 3341352003000927),
+            (180 * BLOCKS_PER_DAY + 5 * 31 * BLOCKS_PER_DAY, 4453332200422863),
+            // Within pre-mine maturity range 2
+            (365 * BLOCKS_PER_DAY, 4925001471171519),
+            (365 * BLOCKS_PER_DAY + 2 * 31 * BLOCKS_PER_DAY, 5870144522232540),
+            (365 * BLOCKS_PER_DAY + 5 * 31 * BLOCKS_PER_DAY, 7253103292383049),
+        ] {
+            let rewards_at_height = emission_schedule
+                .supply_at_block(height)
+                .saturating_sub(MAINNET_PRE_MINE_VALUE);
+
+            let matured_rewards_at_height = consensus_manager.block_rewards_spendable_at_height(height).unwrap();
+
+            if height > 0 {
+                assert!(rewards_at_height > matured_rewards_at_height);
+            }
+
+            let pre_mine_spendable_supply = pre_mine_spendable_at_height(height, network).unwrap();
+
+            assert_eq!(
+                pre_mine_spendable_supply,
+                pre_mine_items
+                    .iter()
+                    .filter(|v| v.original_maturity <= height)
+                    .map(|v| v.value)
+                    .sum()
+            );
+
+            let total_spendable_supply = matured_rewards_at_height + pre_mine_spendable_supply;
+            assert_eq!(total_spendable_supply, MicroMinotari(value));
+        }
+
+        // Verify that the spendable supply is monotonically increasing at tranche boundaries
+        for tranche in [
+            maturity_tranches[1].clone(),
+            maturity_tranches[2].clone(),
+            maturity_tranches[3].clone(),
+        ] {
+            assert!(
+                consensus_manager
+                    .block_rewards_spendable_at_height(tranche.effective_from_height + tranche.maturity - 2,)
+                    .unwrap() <
+                    consensus_manager
+                        .block_rewards_spendable_at_height(tranche.effective_from_height + tranche.maturity - 1,)
+                        .unwrap()
+            );
+
+            assert!(
+                consensus_manager
+                    .block_rewards_spendable_at_height(tranche.effective_from_height + tranche.maturity - 1,)
+                    .unwrap() <
+                    consensus_manager
+                        .block_rewards_spendable_at_height(tranche.effective_from_height + tranche.maturity,)
+                        .unwrap()
+            );
+
+            assert!(
+                consensus_manager
+                    .block_rewards_spendable_at_height(tranche.effective_from_height + tranche.maturity,)
+                    .unwrap() <
+                    consensus_manager
+                        .block_rewards_spendable_at_height(tranche.effective_from_height + tranche.maturity + 1,)
+                        .unwrap()
+            );
+
+            assert!(
+                consensus_manager
+                    .block_rewards_spendable_at_height(tranche.effective_from_height + tranche.maturity + 1,)
+                    .unwrap() <
+                    consensus_manager
+                        .block_rewards_spendable_at_height(tranche.effective_from_height + tranche.maturity + 2,)
+                        .unwrap()
+            );
+        }
+
+        // Verify that the simple calculation of spendable supply does not match the actual spendable supply at tranche
+        // boundaries
+        let simple_calc = emission_schedule
+            .supply_at_block(maturity_tranches[1].effective_from_height - 1)
+            .saturating_sub(MAINNET_PRE_MINE_VALUE);
+        assert_eq!(
+            simple_calc,
+            consensus_manager
+                .block_rewards_spendable_at_height(
+                    maturity_tranches[1].effective_from_height - 1 + maturity_tranches[0].maturity,
+                )
+                .unwrap()
+        );
+        let simple_calc = emission_schedule
+            .supply_at_block(maturity_tranches[1].effective_from_height)
+            .saturating_sub(MAINNET_PRE_MINE_VALUE);
+        assert!(
+            simple_calc >
+                consensus_manager
+                    .block_rewards_spendable_at_height(
+                        maturity_tranches[1].effective_from_height + maturity_tranches[1].maturity,
+                    )
+                    .unwrap()
+        );
     }
 }

--- a/base_layer/core/src/consensus/consensus_manager.rs
+++ b/base_layer/core/src/consensus/consensus_manager.rs
@@ -34,6 +34,7 @@ use crate::{
 };
 use crate::{
     consensus::{
+        consensus_constants::MAINNET_PRE_MINE_VALUE,
         emission::{Emission, EmissionSchedule},
         ConsensusConstants,
         NetworkConsensus,
@@ -41,6 +42,13 @@ use crate::{
     proof_of_work::DifficultyAdjustmentError,
     transactions::{tari_amount::MicroMinotari, transaction_components::TransactionKernel},
 };
+
+/// A simple struct to hold the maturity and effective height
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+pub struct MaturityTranche {
+    pub maturity: u64,
+    pub effective_from_height: u64,
+}
 
 #[derive(Debug, Error)]
 #[allow(clippy::large_enum_variant)]
@@ -110,6 +118,11 @@ impl ConsensusManager {
         constants
     }
 
+    /// Get the vector of consensus constants applicable for all heights
+    pub fn consensus_constants_vec(&self) -> &[ConsensusConstants] {
+        &self.inner.consensus_constants
+    }
+
     /// Create a new TargetDifficulty for the given proof of work using constants that are effective from the given
     /// height
     #[cfg(feature = "base_node")]
@@ -160,6 +173,56 @@ impl ConsensusManager {
     /// This is the currently configured chain network.
     pub fn network(&self) -> NetworkConsensus {
         self.inner.network
+    }
+
+    /// Get the maturity tranches from the consensus manager
+    pub fn get_maturity_tranches(&self) -> Vec<MaturityTranche> {
+        self.consensus_constants_vec()
+            .iter()
+            .map(|c| MaturityTranche {
+                maturity: c.coinbase_min_maturity(),
+                effective_from_height: c.effective_from_height(),
+            })
+            .collect::<Vec<_>>()
+    }
+
+    /// Get the total spendable block rewards circulation at the specified height (excluding pre-mine)
+    pub fn block_rewards_spendable_at_height(&self, height: u64) -> Result<MicroMinotari, String> {
+        // Example initial maturity schedule up to 3 weeks ( | height | (maturity) |):
+        // | 0 -> 5040 - 1 | (720) |
+        //                 | 5040 -> 10080 - 1 | (540) |
+        //                                     | 10080 -> 15120 - 1 | (360) |
+        //                                                          | 15120 -> | (180) |
+
+        let maturity_tranches = self.get_maturity_tranches();
+
+        let last_effective_tranche = maturity_tranches
+            .iter()
+            .filter(|v| v.effective_from_height <= height)
+            .max_by_key(|v| v.effective_from_height)
+            .ok_or_else(|| format!("Last effective maturity tranche for height {} not found", height))?;
+        let last_effective_index = maturity_tranches
+            .iter()
+            .position(|v| v == last_effective_tranche)
+            .ok_or_else(|| format!("Last effective maturity tranche index for height {} not found", height))?;
+        let previous_effective_tranch = maturity_tranches[last_effective_index.saturating_sub(1)].clone();
+
+        // We have to adjust the matured rewards at height to account for the effective from height of the last
+        // effective tranche
+        let emission_schedule = self.emission_schedule();
+        let matured_rewards_at_height = if last_effective_tranche.maturity < previous_effective_tranch.maturity &&
+            height < last_effective_tranche.effective_from_height + previous_effective_tranch.maturity
+        {
+            emission_schedule
+                .supply_at_block(height.saturating_sub(previous_effective_tranch.maturity))
+                .saturating_sub(MAINNET_PRE_MINE_VALUE)
+        } else {
+            emission_schedule
+                .supply_at_block(height.saturating_sub(last_effective_tranche.maturity))
+                .saturating_sub(MAINNET_PRE_MINE_VALUE)
+        };
+
+        Ok(matured_rewards_at_height)
     }
 }
 


### PR DESCRIPTION
Description
---
- Added a grpc query to return the spendable as well as the circulating token supply for a list of heights. An empty list will result in the tip block height being used.
- Improved the get blocks grpc query to accept an empty list, in which case the tip block will be returned.

Motivation and Context
---
Exchanges need this functionality.

How Has This Been Tested?
---
- New unit test to test the integrity of the spendable supply calculation.
- System-level tests to test the grpc query.

What process can a PR reviewer use to test or verify this change?
---
- Code review
- System-level tests

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [ ] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [X] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
BREAKING CHANGE: The `ValueAtHeightResponse` in `base_node.proto` changed to allow for spendable token supply alongside circulating supply.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added separate reporting of circulating supply and spendable supply at specific blockchain heights in supply queries.
  - Introduced calculation and reporting of spendable block rewards and pre-mine supply at given heights.
- **Bug Fixes**
  - Improved error handling in token supply and block retrieval, with clearer error messages and fallback to the current tip block height when no height is specified.
- **Tests**
  - Added tests to verify correctness of spendable supply calculations at various block heights.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->