### PR TITLE
chore: don't check TLS certs for monerod proxying

### DIFF
--- a/applications/minotari_merge_mining_proxy/src/run_merge_miner.rs
+++ b/applications/minotari_merge_mining_proxy/src/run_merge_miner.rs
@@ -109,6 +109,7 @@ pub async fn start_merge_miner(cli: Cli) -> Result<(), anyhow::Error> {
     info!(target: LOG_TARGET, "Configuration: {:?}", config);
     let agent = concat!("minotari_mm_proxy/", env!("CARGO_PKG_VERSION"));
     let client = reqwest::Client::builder()
+        .danger_accept_invalid_certs(true)
         .connect_timeout(Duration::from_secs(5))
         .timeout(Duration::from_secs(10))
         .user_agent(agent)


### PR DESCRIPTION
Description
---

We don't need to check TLS certs for the proxying, it's not relevant.

Motivation and Context
---

We only use TLS to stop anyone snooping on our remote node to monerod traffic in merge mine proxy. However, we need to be able to DNS black-holing, and have IP addresses as a fallback, but in that event we can't expect a valid TLS certificate for an IP address.

How Has This Been Tested?
---

On a box with known DNS issues

What process can a PR reviewer use to test or verify this change?
---

Test it against the monerod remote node IPs directly.

Breaking Changes
---

- [x] None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the application to allow connections using invalid TLS certificates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->