### PR TITLE
feat!: make tari randomx pow compatible with xmrig

### DIFF
--- a/base_layer/core/src/blocks/block_header.rs
+++ b/base_layer/core/src/blocks/block_header.rs
@@ -78,8 +78,6 @@ pub enum BlockHeaderValidationError {
     OldSeedHash,
     #[error("Monero blocks must have a nonce of 0")]
     InvalidNonce,
-    #[error("Nonce to high, Tari RandomX must have a 32 bit nonce")]
-    NonceTooHigh,
     #[error("Incorrect height: Expected {expected} but got {actual}")]
     InvalidHeight { expected: u64, actual: u64 },
     #[error("Incorrect previous hash: Expected {expected} but got {actual}")]

--- a/base_layer/core/src/blocks/block_header.rs
+++ b/base_layer/core/src/blocks/block_header.rs
@@ -78,6 +78,8 @@ pub enum BlockHeaderValidationError {
     OldSeedHash,
     #[error("Monero blocks must have a nonce of 0")]
     InvalidNonce,
+    #[error("Nonce to high, Tari RandomX must have a 32 bit nonce")]
+    NonceTooHigh,
     #[error("Incorrect height: Expected {expected} but got {actual}")]
     InvalidHeight { expected: u64, actual: u64 },
     #[error("Incorrect previous hash: Expected {expected} but got {actual}")]

--- a/base_layer/core/src/proof_of_work/error.rs
+++ b/base_layer/core/src/proof_of_work/error.rs
@@ -55,6 +55,7 @@ impl PowError {
             err @ PowError::InvalidProofOfWork |
             err @ PowError::AchievedDifficultyBelowMin |
             err @ PowError::Sha3HeaderNonEmptyPowBytes |
+            err @ PowError::RandomxTPowDataTooLong |
             err @ PowError::AchievedDifficultyTooLow { .. } |
             err @ PowError::InvalidTargetDifficulty { .. } => Some(BanReason {
                 reason: err.to_string(),

--- a/base_layer/core/src/proof_of_work/error.rs
+++ b/base_layer/core/src/proof_of_work/error.rs
@@ -38,6 +38,8 @@ pub enum PowError {
     AchievedDifficultyBelowMin,
     #[error("Proof of work data must be empty for Sha3 blocks")]
     Sha3HeaderNonEmptyPowBytes,
+    #[error("Proof of work data is too long. Max allowed is 32 bytes")]
+    RandomxTPowDataTooLong,
     #[error("Target difficulty {target} not achieved. Achieved difficulty: {achieved}")]
     AchievedDifficultyTooLow { target: Difficulty, achieved: Difficulty },
     #[error("Invalid target difficulty (expected: {expected}, got: {got})")]

--- a/base_layer/core/src/proof_of_work/monero_rx/helpers.rs
+++ b/base_layer/core/src/proof_of_work/monero_rx/helpers.rs
@@ -433,7 +433,7 @@ mod test {
     };
 
     use super::*;
-    use crate::proof_of_work::{PowAlgorithm, PowData, ProofOfWork};
+    use crate::proof_of_work::{difficulty, PowAlgorithm, PowData, ProofOfWork};
 
     // This tests checks the hash of monero-rs
     #[test]
@@ -1288,6 +1288,45 @@ mod test {
             "f68fbc8cc85bde856cd1323e9f8e6f024483038d728835de2f8c014ff6260000"
         );
         assert_eq!(difficulty.as_u64(), 430603);
+    }
+
+    #[test]
+    fn test_tari_randomx_difficulty() {
+        let randomx_factory = RandomXFactory::new(1);
+        let vm_key = from_hex("920647f8f10b8b484649adf83599c5b86bba137e7eb22e95dd8739d98528f677").unwrap();
+
+        let vm = randomx_factory.create(vm_key.as_slice(), None, None).unwrap();
+
+        let mut blob = 0u8.to_le_bytes().to_vec();
+
+        blob.extend_from_slice(&[0u8; 1]);
+        // timestamp
+        blob.extend_from_slice(&[0u8; 5]);
+        let mut mining_hash: Vec<u8> =
+            Hex::from_hex("7d0b4f7dfcae9fbf72114f5b17d84691c7ba5061bb1cfb414964eceaf56d0157").unwrap();
+        blob.extend_from_slice(&mining_hash.as_slice());
+        let mut prep_mining_blob = blob.clone();
+        prep_mining_blob.extend_from_slice(&[0u8; 4]);
+        // Add pow
+        let pow = ProofOfWork {
+            pow_algo: PowAlgorithm::RandomXT,
+            pow_data: PowData::try_from(vec![0u8; 32]).unwrap(),
+        };
+        prep_mining_blob.extend_from_slice(&pow.to_bytes());
+
+        assert_eq!(
+            hex::encode(&prep_mining_blob),
+            "000000000000007d0b4f7dfcae9fbf72114f5b17d84691c7ba5061bb1cfb414964eceaf56d015700000000020000000000000000000000000000000000000000000000000000000000000000"
+        );
+
+        blob.extend_from_slice(hex::decode("00000b00").unwrap().as_slice());
+        blob.extend_from_slice(&pow.to_bytes().as_slice());
+        let difficulty = get_random_x_difficulty(&blob, &vm).unwrap();
+        assert_eq!(
+            hex::encode(&difficulty.1),
+            "79cebc2e374e8d545017149bd05f25b04530984927bd6703f8cc2d216b0bca04"
+        );
+        assert_eq!(difficulty.0.as_u64(), 53);
     }
 
     #[test]

--- a/base_layer/core/src/proof_of_work/monero_rx/helpers.rs
+++ b/base_layer/core/src/proof_of_work/monero_rx/helpers.rs
@@ -79,18 +79,18 @@ pub fn tari_randomx_difficulty(
     // xmrig assumes the nonce is at offset 39.
 
     // The format is:
-    // | 1 byte | 1 byte | 5 bytes | 32 bytes | 4 bytes | 1 byte | 32 bytes|
-    // | major version | minor version | timestamp | mining_hash | nonce | pow_algo | pow_data, excluding algo, padded to 32 bytes |
+    // | 1 byte | 1 byte | 1 bytes | 32 bytes | 8 bytes | 1 byte | 32 bytes|
+    // | major version | minor version | timestamp | mining_hash | nonce (big endian) | pow_algo | pow_data, excluding algo, padded to 32 bytes |
     //
     // Major version: 0
     // Minor version: 0
     // Timestamp: 0
 
-    let mut blob = vec![0u8; 7];
+    let mut blob = vec![0u8; 3];
     blob.extend_from_slice(header.mining_hash().as_slice());
     // Note, only the first 4 bytes of the nonce are used (u32)
     let nonce = header.nonce.to_be_bytes();
-    blob.extend_from_slice(&nonce[4..8]);
+    blob.extend_from_slice(&nonce);
     // The pow_algo is the first byte of the pow field when serialized to bytes
     let mut pow_bytes = header.pow.to_bytes();
     if pow_bytes.len() < 33 {
@@ -205,8 +205,8 @@ fn check_aux_chains(
             .chain_update((109_u8).to_le_bytes())
             .finalize(),
     )
-    .low_u32() %
-        u32::from(merkle_tree_params.number_of_chains());
+    .low_u32()
+        % u32::from(merkle_tree_params.number_of_chains());
     let (merkle_root, pos) = monero_data
         .aux_chain_merkle_proof
         .calculate_root_with_pos(&t_hash, merkle_tree_params.number_of_chains());
@@ -249,7 +249,9 @@ pub fn extract_aux_merkle_root_from_block(monero: &monero::Block) -> Result<Opti
 
 /// Deserializes the given hex-encoded string into a Monero block
 pub fn deserialize_monero_block_from_hex<T>(data: T) -> Result<monero::Block, MergeMineError>
-where T: AsRef<[u8]> {
+where
+    T: AsRef<[u8]>,
+{
     let bytes = hex::decode(data).map_err(|_| HexError::HexConversionError {})?;
     let obj = consensus::deserialize::<monero::Block>(&bytes)
         .map_err(|e| MergeMineError::ValidationError(format!("blocktemplate blob invalid: {}", e)))?;
@@ -420,12 +422,7 @@ mod test {
         blockdata::transaction::TxOutTarget,
         consensus::deserialize,
         util::ringct::{RctSig, RctSigBase, RctType},
-        Hash,
-        PublicKey,
-        Transaction,
-        TransactionPrefix,
-        TxIn,
-        TxOut,
+        Hash, PublicKey, Transaction, TransactionPrefix, TxIn, TxOut,
     };
     use tari_common::configuration::Network;
     use tari_test_utils::unpack_enum;

--- a/base_layer/core/src/proof_of_work/monero_rx/helpers.rs
+++ b/base_layer/core/src/proof_of_work/monero_rx/helpers.rs
@@ -75,9 +75,28 @@ pub fn tari_randomx_difficulty(
     vm_key: &FixedHash,
 ) -> Result<Difficulty, MergeMineError> {
     let vm = randomx_factory.create(vm_key.as_slice(), None, None)?;
-    let mut blob = header.nonce.to_le_bytes().to_vec();
+    // This is done to make a blob that xmrig can process.
+    // xmrig assumes the nonce is at offset 39.
+
+    // The format is:
+    // | 1 byte | 1 byte | 5 bytes | 32 bytes | 4 bytes | 1 byte | 32 bytes|
+    // | major version | minor version | timestamp | mining_hash | nonce | pow_algo | pow_data, excluding algo, padded to 32 bytes |
+    //
+    // Major version: 0
+    // Minor version: 0
+    // Timestamp: 0
+
+    let mut blob = vec![0u8; 7];
     blob.extend_from_slice(header.mining_hash().as_slice());
-    blob.extend_from_slice(&header.pow.to_bytes());
+    // Note, only the first 4 bytes of the nonce are used (u32)
+    let nonce = header.nonce.to_le_bytes();
+    blob.extend_from_slice(&nonce[0..4]);
+    // The pow_algo is the first byte of the pow field when serialized to bytes
+    let mut pow_bytes = header.pow.to_bytes();
+    if pow_bytes.len() < 33 {
+        pow_bytes.resize(33, 0)
+    }
+    blob.extend_from_slice(&pow_bytes[0..33]);
     get_random_x_difficulty(&blob, &vm).map(|(diff, _)| diff)
 }
 

--- a/base_layer/core/src/proof_of_work/monero_rx/helpers.rs
+++ b/base_layer/core/src/proof_of_work/monero_rx/helpers.rs
@@ -89,8 +89,8 @@ pub fn tari_randomx_difficulty(
     let mut blob = vec![0u8; 7];
     blob.extend_from_slice(header.mining_hash().as_slice());
     // Note, only the first 4 bytes of the nonce are used (u32)
-    let nonce = header.nonce.to_le_bytes();
-    blob.extend_from_slice(&nonce[0..4]);
+    let nonce = header.nonce.to_be_bytes();
+    blob.extend_from_slice(&nonce[4..8]);
     // The pow_algo is the first byte of the pow field when serialized to bytes
     let mut pow_bytes = header.pow.to_bytes();
     if pow_bytes.len() < 33 {

--- a/base_layer/core/src/proof_of_work/monero_rx/helpers.rs
+++ b/base_layer/core/src/proof_of_work/monero_rx/helpers.rs
@@ -436,10 +436,7 @@ mod test {
     };
 
     use super::*;
-    use crate::{
-        proof_of_work::{difficulty, PowAlgorithm, PowData, ProofOfWork},
-        validation::block_body,
-    };
+    use crate::proof_of_work::{PowAlgorithm, PowData, ProofOfWork};
 
     // This tests checks the hash of monero-rs
     #[test]
@@ -1308,9 +1305,9 @@ mod test {
         blob.extend_from_slice(&[0u8; 1]);
         // timestamp
         blob.extend_from_slice(&[0u8; 1]);
-        let mut mining_hash: Vec<u8> =
+        let mining_hash: Vec<u8> =
             Hex::from_hex("0ef6ed2c9c04830a899d388fbc5ec250acdb7b4b70fa2422c3d6e802c348d2c9").unwrap();
-        blob.extend_from_slice(&mining_hash.as_slice());
+        blob.extend_from_slice(mining_hash.as_slice());
         blob.extend_from_slice(&[0u8; 4]);
         let mut prep_mining_blob = blob.clone();
         prep_mining_blob.extend_from_slice(&[0u8; 4]);
@@ -1330,7 +1327,7 @@ mod test {
         // let nonce = 1u64;
 
         blob.extend_from_slice(hex::decode("00800700").unwrap().as_slice());
-        blob.extend_from_slice(&pow.to_bytes().as_slice());
+        blob.extend_from_slice(pow.to_bytes().as_slice());
         let difficulty = get_random_x_difficulty(&blob, &vm).unwrap();
         assert_eq!(
             hex::encode(&difficulty.1),
@@ -1339,7 +1336,7 @@ mod test {
         assert_eq!(difficulty.0.as_u64(), 15);
 
         // Now construct a block header and see if it matches
-        let mut block_header = BlockHeader {
+        let block_header = BlockHeader {
             version: 1,
             height: 123,
             prev_hash: FixedHash::try_from_slice(

--- a/base_layer/core/src/proof_of_work/monero_rx/helpers.rs
+++ b/base_layer/core/src/proof_of_work/monero_rx/helpers.rs
@@ -205,8 +205,8 @@ fn check_aux_chains(
             .chain_update((109_u8).to_le_bytes())
             .finalize(),
     )
-    .low_u32()
-        % u32::from(merkle_tree_params.number_of_chains());
+    .low_u32() %
+        u32::from(merkle_tree_params.number_of_chains());
     let (merkle_root, pos) = monero_data
         .aux_chain_merkle_proof
         .calculate_root_with_pos(&t_hash, merkle_tree_params.number_of_chains());
@@ -249,9 +249,7 @@ pub fn extract_aux_merkle_root_from_block(monero: &monero::Block) -> Result<Opti
 
 /// Deserializes the given hex-encoded string into a Monero block
 pub fn deserialize_monero_block_from_hex<T>(data: T) -> Result<monero::Block, MergeMineError>
-where
-    T: AsRef<[u8]>,
-{
+where T: AsRef<[u8]> {
     let bytes = hex::decode(data).map_err(|_| HexError::HexConversionError {})?;
     let obj = consensus::deserialize::<monero::Block>(&bytes)
         .map_err(|e| MergeMineError::ValidationError(format!("blocktemplate blob invalid: {}", e)))?;
@@ -417,12 +415,17 @@ pub fn create_block_hashing_blob(
 mod test {
     use std::convert::{TryFrom, TryInto};
 
-    use borsh::BorshSerialize;
+    use borsh::{BorshDeserialize, BorshSerialize};
     use monero::{
         blockdata::transaction::TxOutTarget,
         consensus::deserialize,
         util::ringct::{RctSig, RctSigBase, RctType},
-        Hash, PublicKey, Transaction, TransactionPrefix, TxIn, TxOut,
+        Hash,
+        PublicKey,
+        Transaction,
+        TransactionPrefix,
+        TxIn,
+        TxOut,
     };
     use tari_common::configuration::Network;
     use tari_test_utils::unpack_enum;
@@ -433,7 +436,10 @@ mod test {
     };
 
     use super::*;
-    use crate::proof_of_work::{difficulty, PowAlgorithm, PowData, ProofOfWork};
+    use crate::{
+        proof_of_work::{difficulty, PowAlgorithm, PowData, ProofOfWork},
+        validation::block_body,
+    };
 
     // This tests checks the hash of monero-rs
     #[test]
@@ -1301,10 +1307,11 @@ mod test {
 
         blob.extend_from_slice(&[0u8; 1]);
         // timestamp
-        blob.extend_from_slice(&[0u8; 5]);
+        blob.extend_from_slice(&[0u8; 1]);
         let mut mining_hash: Vec<u8> =
-            Hex::from_hex("7d0b4f7dfcae9fbf72114f5b17d84691c7ba5061bb1cfb414964eceaf56d0157").unwrap();
+            Hex::from_hex("0ef6ed2c9c04830a899d388fbc5ec250acdb7b4b70fa2422c3d6e802c348d2c9").unwrap();
         blob.extend_from_slice(&mining_hash.as_slice());
+        blob.extend_from_slice(&[0u8; 4]);
         let mut prep_mining_blob = blob.clone();
         prep_mining_blob.extend_from_slice(&[0u8; 4]);
         // Add pow
@@ -1316,17 +1323,54 @@ mod test {
 
         assert_eq!(
             hex::encode(&prep_mining_blob),
-            "000000000000007d0b4f7dfcae9fbf72114f5b17d84691c7ba5061bb1cfb414964eceaf56d015700000000020000000000000000000000000000000000000000000000000000000000000000"
+            "0000000ef6ed2c9c04830a899d388fbc5ec250acdb7b4b70fa2422c3d6e802c348d2c90000000000000000020000000000000000000000000000000000000000000000000000000000000000"
         );
 
-        blob.extend_from_slice(hex::decode("00000b00").unwrap().as_slice());
+        let nonce = 8390400u64;
+        // let nonce = 1u64;
+
+        blob.extend_from_slice(hex::decode("00800700").unwrap().as_slice());
         blob.extend_from_slice(&pow.to_bytes().as_slice());
         let difficulty = get_random_x_difficulty(&blob, &vm).unwrap();
         assert_eq!(
             hex::encode(&difficulty.1),
-            "79cebc2e374e8d545017149bd05f25b04530984927bd6703f8cc2d216b0bca04"
+            "3b5af219f2491561cfd3b11d1ee9cc9fba81112f58042ce2f9c8541b2d44a410"
         );
-        assert_eq!(difficulty.0.as_u64(), 53);
+        assert_eq!(difficulty.0.as_u64(), 15);
+
+        // Now construct a block header and see if it matches
+        let mut block_header = BlockHeader {
+            version: 1,
+            height: 123,
+            prev_hash: FixedHash::try_from_slice(
+                hex::decode("7d0b4f7dfcae9fbf72114f5b17d84691c7ba5061bb1cfb414964eceaf56d0157")
+                    .unwrap()
+                    .as_slice(),
+            )
+            .unwrap(),
+            timestamp: 11222333.into(),
+            output_mr: FixedHash::zero(),
+            block_output_mr: FixedHash::zero(),
+            output_smt_size: 0,
+            kernel_mr: FixedHash::zero(),
+            kernel_mmr_size: 0,
+            input_mr: FixedHash::zero(),
+            total_kernel_offset: Default::default(),
+            total_script_offset: Default::default(),
+            nonce,
+            pow,
+            validator_node_mr: FixedHash::zero(),
+            validator_node_size: 0,
+        };
+
+        let mining_hash = block_header.mining_hash();
+        assert_eq!(
+            mining_hash.to_hex(),
+            "0ef6ed2c9c04830a899d388fbc5ec250acdb7b4b70fa2422c3d6e802c348d2c9"
+        );
+
+        let diff = tari_randomx_difficulty(&block_header, &randomx_factory, &vm_key.try_into().unwrap()).unwrap();
+        assert_eq!(diff.as_u64(), 15);
     }
 
     #[test]

--- a/base_layer/core/src/validation/header/header_full_validator.rs
+++ b/base_layer/core/src/validation/header/header_full_validator.rs
@@ -33,7 +33,9 @@ use crate::{
     proof_of_work::{AchievedTargetDifficulty, Difficulty, PowAlgorithm, PowError},
     validation::{
         helpers::{check_header_timestamp_greater_than_median, check_target_difficulty},
-        DifficultyCalculator, HeaderChainLinkedValidator, ValidationError,
+        DifficultyCalculator,
+        HeaderChainLinkedValidator,
+        ValidationError,
     },
 };
 pub const LOG_TARGET: &str = "c::val::header_full_validator";

--- a/base_layer/core/src/validation/header/header_full_validator.rs
+++ b/base_layer/core/src/validation/header/header_full_validator.rs
@@ -79,6 +79,7 @@ impl<B: BlockchainBackend> HeaderChainLinkedValidator<B> for HeaderFullValidator
 
         check_timestamp_ftl(header, &self.rules)?;
         check_pow_data(header)?;
+        check_nonce(header)?;
         let vm_key = *db
             .fetch_chain_header_by_height(header.height.saturating_sub(header.height % 2000))?
             .hash();
@@ -126,6 +127,27 @@ fn sanity_check_timestamp_count(
     Ok(())
 }
 
+fn check_nonce(header: &BlockHeader) -> Result<(), ValidationError> {
+    match header.pow.pow_algo {
+        PowAlgorithm::RandomXM => {
+            if header.nonce != 0 {
+                return Err(ValidationError::BlockHeaderError(
+                    BlockHeaderValidationError::InvalidNonce,
+                ));
+            }
+        },
+        PowAlgorithm::RandomXT => {
+            // xmrig only allows 32 bit nonces
+            if header.nonce > u32::MAX.into() {
+                return Err(ValidationError::BlockHeaderError(
+                    BlockHeaderValidationError::NonceTooHigh,
+                ));
+            }
+        },
+        PowAlgorithm::Sha3x => {},
+    }
+    Ok(())
+}
 fn check_height(header: &BlockHeader, prev_header: &BlockHeader) -> Result<(), ValidationError> {
     if header.height != prev_header.height + 1 {
         return Err(ValidationError::BlockHeaderError(
@@ -201,7 +223,13 @@ fn check_pow_data(block_header: &BlockHeader) -> Result<(), ValidationError> {
             }
             Ok(())
         },
-        Sha3x | RandomXT => {
+        RandomXT => {
+            if block_header.pow.pow_data.len() > 32 {
+                return Err(PowError::RandomxTPowDataTooLong.into());
+            }
+            Ok(())
+        },
+        Sha3x => {
             if !block_header.pow.pow_data.is_empty() {
                 return Err(PowError::Sha3HeaderNonEmptyPowBytes.into());
             }

--- a/base_layer/core/src/validation/header/header_full_validator.rs
+++ b/base_layer/core/src/validation/header/header_full_validator.rs
@@ -33,9 +33,7 @@ use crate::{
     proof_of_work::{AchievedTargetDifficulty, Difficulty, PowAlgorithm, PowError},
     validation::{
         helpers::{check_header_timestamp_greater_than_median, check_target_difficulty},
-        DifficultyCalculator,
-        HeaderChainLinkedValidator,
-        ValidationError,
+        DifficultyCalculator, HeaderChainLinkedValidator, ValidationError,
     },
 };
 pub const LOG_TARGET: &str = "c::val::header_full_validator";
@@ -79,7 +77,6 @@ impl<B: BlockchainBackend> HeaderChainLinkedValidator<B> for HeaderFullValidator
 
         check_timestamp_ftl(header, &self.rules)?;
         check_pow_data(header)?;
-        check_nonce(header)?;
         let vm_key = *db
             .fetch_chain_header_by_height(header.height.saturating_sub(header.height % 2000))?
             .hash();
@@ -127,27 +124,6 @@ fn sanity_check_timestamp_count(
     Ok(())
 }
 
-fn check_nonce(header: &BlockHeader) -> Result<(), ValidationError> {
-    match header.pow.pow_algo {
-        PowAlgorithm::RandomXM => {
-            if header.nonce != 0 {
-                return Err(ValidationError::BlockHeaderError(
-                    BlockHeaderValidationError::InvalidNonce,
-                ));
-            }
-        },
-        PowAlgorithm::RandomXT => {
-            // xmrig only allows 32 bit nonces
-            if header.nonce > u32::MAX.into() {
-                return Err(ValidationError::BlockHeaderError(
-                    BlockHeaderValidationError::NonceTooHigh,
-                ));
-            }
-        },
-        PowAlgorithm::Sha3x => {},
-    }
-    Ok(())
-}
 fn check_height(header: &BlockHeader, prev_header: &BlockHeader) -> Result<(), ValidationError> {
     if header.height != prev_header.height + 1 {
         return Err(ValidationError::BlockHeaderError(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for proof-of-work data by enforcing a maximum length of 32 bytes for RandomXT PoW data and ensuring Sha3x PoW data is empty.
  - Enhanced error reporting with a new error message when RandomXT PoW data exceeds the allowed length.

- **Refactor**
  - Updated the construction of input data for RandomX difficulty calculation to match xmrig miner compatibility, including new formatting and padding rules.

- **Tests**
  - Added comprehensive tests to verify RandomX difficulty calculation and data formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->