### PR TITLE
fix: base node panic

### DIFF
--- a/applications/minotari_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/minotari_node/src/grpc/base_node_grpc_server.rs
@@ -426,7 +426,7 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
                         obscure_error_if_true(report_error_flag, Status::internal(e.to_string()))
                     })?;
                 let target_time = constants.pow_target_block_interval(PowAlgorithm::Sha3x);
-                let estimated_hash_rate = target_difficulty.as_u64().checked_sub(target_time).unwrap_or(0);
+                let estimated_hash_rate = target_difficulty.as_u64().saturating_sub(target_time);
                 self.data_cache
                     .set_sha3x_estimated_hash_rate(estimated_hash_rate, *metadata.best_block_hash())
                     .await;
@@ -452,7 +452,7 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
                         obscure_error_if_true(report_error_flag, Status::internal(e.to_string()))
                     })?;
                 let target_time = constants.pow_target_block_interval(PowAlgorithm::RandomXM);
-                let estimated_hash_rate = target_difficulty.as_u64().checked_sub(target_time).unwrap_or(0);
+                let estimated_hash_rate = target_difficulty.as_u64().saturating_sub(target_time);
                 self.data_cache
                     .set_monero_randomx_estimated_hash_rate(estimated_hash_rate, *metadata.best_block_hash())
                     .await;
@@ -479,7 +479,7 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
                         obscure_error_if_true(report_error_flag, Status::internal(e.to_string()))
                     })?;
                 let target_time = constants.pow_target_block_interval(PowAlgorithm::RandomXT);
-                let estimated_hash_rate = target_difficulty.as_u64().checked_sub(target_time).unwrap_or(0);
+                let estimated_hash_rate = target_difficulty.as_u64().saturating_sub(target_time);
                 self.data_cache
                     .set_tari_randomx_estimated_hash_rate(estimated_hash_rate, *metadata.best_block_hash())
                     .await;

--- a/applications/minotari_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/minotari_node/src/grpc/base_node_grpc_server.rs
@@ -426,7 +426,7 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
                         obscure_error_if_true(report_error_flag, Status::internal(e.to_string()))
                     })?;
                 let target_time = constants.pow_target_block_interval(PowAlgorithm::Sha3x);
-                let estimated_hash_rate = target_difficulty.as_u64() / target_time;
+                let estimated_hash_rate = target_difficulty.as_u64().checked_sub(target_time).unwrap_or(0);
                 self.data_cache
                     .set_sha3x_estimated_hash_rate(estimated_hash_rate, *metadata.best_block_hash())
                     .await;
@@ -452,7 +452,7 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
                         obscure_error_if_true(report_error_flag, Status::internal(e.to_string()))
                     })?;
                 let target_time = constants.pow_target_block_interval(PowAlgorithm::RandomXM);
-                let estimated_hash_rate = target_difficulty.as_u64() / target_time;
+                let estimated_hash_rate = target_difficulty.as_u64().checked_sub(target_time).unwrap_or(0);
                 self.data_cache
                     .set_monero_randomx_estimated_hash_rate(estimated_hash_rate, *metadata.best_block_hash())
                     .await;
@@ -479,7 +479,7 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
                         obscure_error_if_true(report_error_flag, Status::internal(e.to_string()))
                     })?;
                 let target_time = constants.pow_target_block_interval(PowAlgorithm::RandomXT);
-                let estimated_hash_rate = target_difficulty.as_u64() / target_time;
+                let estimated_hash_rate = target_difficulty.as_u64().checked_sub(target_time).unwrap_or(0);
                 self.data_cache
                     .set_tari_randomx_estimated_hash_rate(estimated_hash_rate, *metadata.best_block_hash())
                     .await;

--- a/base_layer/core/src/blocks/pre_mine/mod.rs
+++ b/base_layer/core/src/blocks/pre_mine/mod.rs
@@ -1473,8 +1473,8 @@ mod test {
         // Initial maturity schedule up to 3 weeks ( | height | (maturity) |):
         // | 0 -> 5040 - 1 | (720) |
         //                 | 5040 -> 10080 - 1 | (540) |
-        //                                     | 10080 -> 15120 - 1 | (360) |
-        //                                                          | 15120 -> | (180) |
+        //                                     | 10080 -> 15000 - 1 | (360) |
+        //                                                          | 15000 -> | (180) |
 
         let network = Network::MainNet;
         let consensus_manager = ConsensusManager::builder(network)
@@ -1510,14 +1510,14 @@ mod test {
                 898513007030503,
             ),
             // Within 4th tranche
-            (maturity_tranches[3].effective_from_height, 960614382886959),
+            (maturity_tranches[3].effective_from_height, 958961532039375),
             (
                 maturity_tranches[3].effective_from_height + maturity_tranches[2].maturity / 2,
-                963093332298424,
+                961440742937559,
             ),
             (
                 maturity_tranches[3].effective_from_height + maturity_tranches[2].maturity,
-                968050054592502,
+                966397988109264,
             ),
             // Within pre-mine maturity range 1
             (180 * BLOCKS_PER_DAY, 2573982676047120),

--- a/base_layer/core/src/consensus/consensus_constants.rs
+++ b/base_layer/core/src/consensus/consensus_constants.rs
@@ -696,7 +696,6 @@ impl ConsensusConstants {
         consensus_constants
     }
 
-    // These values are mainly place holder till the final decision has been made about their values.
     pub fn mainnet() -> Vec<Self> {
         let difficulty_block_window = 90;
         let mut algos = HashMap::new();
@@ -759,17 +758,17 @@ impl ConsensusConstants {
         algos.insert(PowAlgorithm::Sha3x, PowAlgorithmConstants {
             min_difficulty: Difficulty::from_u64(150_000_000_000).expect("valid difficulty"),
             max_difficulty: Difficulty::max(),
-            target_time: 360,
+            target_time: 240,
         });
         algos.insert(PowAlgorithm::RandomXM, PowAlgorithmConstants {
             min_difficulty: Difficulty::from_u64(1_200_000).expect("valid difficulty"),
             max_difficulty: Difficulty::max(),
-            target_time: 360,
+            target_time: 480,
         });
         algos.insert(PowAlgorithm::RandomXT, PowAlgorithmConstants {
             min_difficulty: Difficulty::from_u64(1_200_000).expect("valid difficulty"),
             max_difficulty: Difficulty::max(),
-            target_time: 360,
+            target_time: 480,
         });
         con_4.blockchain_version = 1;
         con_4.valid_blockchain_version_range = 1..=1;


### PR DESCRIPTION
Description
---
Fix potential panic in base node

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the calculation method for estimated hash rates of different proof-of-work algorithms, ensuring more accurate and reliable network state reporting.

- **Chores**
  - Updated mainnet configuration to adjust the expected block target times for multiple proof-of-work algorithms.
  - Refined pre-mine token maturity schedules and spendable supply expectations in tests to reflect updated block boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->