### PR TITLE
feat: expose user payment id

### DIFF
--- a/applications/minotari_app_grpc/proto/wallet.proto
+++ b/applications/minotari_app_grpc/proto/wallet.proto
@@ -1065,6 +1065,8 @@ message PaymentRecipient {
   }
   // The type of payment to perform.
   PaymentType payment_type = 5;
+  // Reserve the old payment_id tag to prevent future reuse.
+  reserved 6;
   // Optional encrypted payment ID for reference (max 256 bytes).
   UserPaymentId user_payment_id = 7;
 }

--- a/applications/minotari_app_grpc/proto/wallet.proto
+++ b/applications/minotari_app_grpc/proto/wallet.proto
@@ -1065,9 +1065,9 @@ message PaymentRecipient {
   }
   // The type of payment to perform.
   PaymentType payment_type = 5;
-  // Reserve the old payment_id tag to prevent future reuse.
-  reserved 6;
-  // Optional encrypted payment ID for reference (max 256 bytes).
+  // raw payment id
+  bytes raw_payment_id = 6;
+  // Optional user encrypted payment ID for reference (max 256 bytes).
   UserPaymentId user_payment_id = 7;
 }
 

--- a/applications/minotari_app_grpc/proto/wallet.proto
+++ b/applications/minotari_app_grpc/proto/wallet.proto
@@ -1066,7 +1066,7 @@ message PaymentRecipient {
   // The type of payment to perform.
   PaymentType payment_type = 5;
   // Optional encrypted payment ID for reference (max 256 bytes).
-  bytes payment_id = 6;
+  UserPaymentId user_payment_id = 7;
 }
 
 message TransferResponse {
@@ -1136,8 +1136,9 @@ message TransactionInfo {
   bool is_cancelled = 8;
   bytes excess_sig = 9;
   uint64 timestamp = 10;
-  bytes payment_id = 12;
+  bytes raw_payment_id = 12;
   uint64 mined_in_block_height = 13;
+  bytes user_payment_id = 14;
 }
 
 enum TransactionDirection {

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -670,6 +670,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
         }))
     }
 
+    #[allow(clippy::too_many_lines)]
     async fn transfer(&self, request: Request<TransferRequest>) -> Result<Response<TransferResponse>, Status> {
         let message = request.into_inner();
         let recipients = message
@@ -686,14 +687,17 @@ impl wallet_server::Wallet for WalletGrpcServer {
                     dest.fee_per_gram,
                     dest.payment_type,
                     dest.user_payment_id,
+                    dest.raw_payment_id,
                 ))
             })
             .collect::<Result<Vec<_>, _>>()
             .map_err(Status::invalid_argument)?;
 
         let mut transfers = Vec::new();
-        for (hex_address, address, amount, fee_per_gram, payment_type, user_payment_id) in recipients {
-            let payment_id = if let Some(user_pay_id) = user_payment_id {
+        for (hex_address, address, amount, fee_per_gram, payment_type, user_payment_id, raw_payment_id) in recipients {
+            let payment_id = if !raw_payment_id.is_empty() {
+                PaymentId::from_bytes(&raw_payment_id)
+            } else if let Some(user_pay_id) = user_payment_id {
                 let bytes = match (
                     user_pay_id.u256.is_empty(),
                     user_pay_id.utf8_string.is_empty(),

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -710,7 +710,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
                 };
                 PaymentId::Open {
                     user_data: bytes,
-                    tx_type: TxType::ClaimAtomicSwap,
+                    tx_type: TxType::PaymentToOther,
                 }
             } else {
                 PaymentId::Empty

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -489,7 +489,9 @@ impl wallet_server::Wallet for WalletGrpcServer {
             .ok_or_else(|| Status::internal("Request is malformed".to_string()))?;
         let address = TariAddress::from_str(&message.address)
             .map_err(|_| Status::internal("Destination address is malformed".to_string()))?;
-        let payment_id = if let Some(user_pay_id) = message.user_payment_id {
+        let payment_id = if !message.raw_payment_id.is_empty() {
+            PaymentId::from_bytes(&message.raw_payment_id)
+        } else if let Some(user_pay_id) = message.user_payment_id {
             let bytes = match (
                 user_pay_id.u256.is_empty(),
                 user_pay_id.utf8_string.is_empty(),

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -489,7 +489,28 @@ impl wallet_server::Wallet for WalletGrpcServer {
             .ok_or_else(|| Status::internal("Request is malformed".to_string()))?;
         let address = TariAddress::from_str(&message.address)
             .map_err(|_| Status::internal("Destination address is malformed".to_string()))?;
-
+        let payment_id = if let Some(user_pay_id) = message.user_payment_id {
+            let bytes = match (
+                user_pay_id.u256.is_empty(),
+                user_pay_id.utf8_string.is_empty(),
+                user_pay_id.user_bytes.is_empty(),
+            ) {
+                (false, true, true) => user_pay_id.u256,
+                (true, false, true) => user_pay_id.utf8_string.as_bytes().to_vec(),
+                (true, true, false) => user_pay_id.user_bytes,
+                _ => {
+                    return Err(Status::invalid_argument(
+                        "user_payment_id must be one of u256, utf8_string or user_bytes".to_string(),
+                    ));
+                },
+            };
+            PaymentId::Open {
+                user_data: bytes,
+                tx_type: TxType::ClaimAtomicSwap,
+            }
+        } else {
+            PaymentId::Empty
+        };
         let mut transaction_service = self.get_transaction_service();
         let response = match transaction_service
             .send_sha_atomic_swap_transaction(
@@ -497,7 +518,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
                 message.amount.into(),
                 UtxoSelectionCriteria::default(),
                 message.fee_per_gram.into(),
-                PaymentId::from_bytes(&message.payment_id),
+                payment_id,
             )
             .await
         {
@@ -664,15 +685,36 @@ impl wallet_server::Wallet for WalletGrpcServer {
                     dest.amount,
                     dest.fee_per_gram,
                     dest.payment_type,
-                    dest.payment_id,
+                    dest.user_payment_id,
                 ))
             })
             .collect::<Result<Vec<_>, _>>()
             .map_err(Status::invalid_argument)?;
 
         let mut transfers = Vec::new();
-        for (hex_address, address, amount, fee_per_gram, payment_type, payment_id) in recipients {
-            let payment_id = PaymentId::from_bytes(&payment_id);
+        for (hex_address, address, amount, fee_per_gram, payment_type, user_payment_id) in recipients {
+            let payment_id = if let Some(user_pay_id) = user_payment_id {
+                let bytes = match (
+                    user_pay_id.u256.is_empty(),
+                    user_pay_id.utf8_string.is_empty(),
+                    user_pay_id.user_bytes.is_empty(),
+                ) {
+                    (false, true, true) => user_pay_id.u256,
+                    (true, false, true) => user_pay_id.utf8_string.as_bytes().to_vec(),
+                    (true, true, false) => user_pay_id.user_bytes,
+                    _ => {
+                        return Err(Status::invalid_argument(
+                            "user_payment_id must be one of u256, utf8_string or user_bytes".to_string(),
+                        ));
+                    },
+                };
+                PaymentId::Open {
+                    user_data: bytes,
+                    tx_type: TxType::ClaimAtomicSwap,
+                }
+            } else {
+                PaymentId::Empty
+            };
             let mut transaction_service = self.get_transaction_service();
             transfers.push(async move {
                 (
@@ -971,7 +1013,8 @@ impl wallet_server::Wallet for WalletGrpcServer {
                             .unwrap_or(&Signature::default())
                             .get_signature()
                             .to_vec(),
-                        payment_id: txn.payment_id.to_bytes(),
+                        raw_payment_id: txn.payment_id.to_bytes(),
+                        user_payment_id: txn.payment_id.user_data_as_bytes(),
                         mined_in_block_height: txn.mined_height.unwrap_or(0),
                     }),
                 };
@@ -1321,7 +1364,8 @@ fn convert_wallet_transaction_into_transaction_info(
             fee: 0,
             excess_sig: Default::default(),
             timestamp: tx.timestamp.timestamp() as u64,
-            payment_id: tx.payment_id.to_bytes(),
+            raw_payment_id: tx.payment_id.to_bytes(),
+            user_payment_id: tx.payment_id.user_data_as_bytes(),
             mined_in_block_height: 0,
         },
         PendingOutbound(tx) => TransactionInfo {
@@ -1335,7 +1379,8 @@ fn convert_wallet_transaction_into_transaction_info(
             fee: tx.fee.into(),
             excess_sig: Default::default(),
             timestamp: tx.timestamp.timestamp() as u64,
-            payment_id: tx.payment_id.to_bytes(),
+            raw_payment_id: tx.payment_id.to_bytes(),
+            user_payment_id: tx.payment_id.user_data_as_bytes(),
             mined_in_block_height: 0,
         },
         Completed(tx) => TransactionInfo {
@@ -1353,7 +1398,8 @@ fn convert_wallet_transaction_into_transaction_info(
                 .first_kernel_excess_sig()
                 .map(|s| s.get_signature().to_vec())
                 .unwrap_or_default(),
-            payment_id: tx.payment_id.to_bytes(),
+            raw_payment_id: tx.payment_id.to_bytes(),
+            user_payment_id: tx.payment_id.user_data_as_bytes(),
             mined_in_block_height: tx.mined_height.unwrap_or(0),
         },
     }

--- a/base_layer/contacts/src/contacts_service/storage/sqlite_db.rs
+++ b/base_layer/contacts/src/contacts_service/storage/sqlite_db.rs
@@ -169,8 +169,13 @@ where TContactServiceDbConnection: PooledDbConnection<Error = SqliteStorageError
                         let stored_contact = ContactSql::find_by_node_id(&c.node_id.to_vec(), &mut conn)?;
                         let stored_address = TariAddress::from_bytes(stored_contact.address.as_slice())
                             .map_err(|_| ContactsServiceStorageError::ConversionError)?;
-                        let new_address = TariAddress::combine_addresses(&stored_address, &k)
+                        let mut new_address = TariAddress::combine_addresses(&stored_address, &k)
                             .map_err(|_| ContactsServiceStorageError::ConversionError)?;
+                        if !k.get_payment_id_user_data_bytes().is_empty() {
+                            new_address = new_address
+                                .with_payment_id_user_data(k.get_payment_id_user_data_bytes())
+                                .map_err(|_| ContactsServiceStorageError::ConversionError)?;
+                        }
                         ContactSql::set_address_of_node_id(&c.node_id.to_vec(), &new_address.to_vec(), &mut conn)?;
                     }
                 },

--- a/base_layer/wallet/src/base_node_service/service.rs
+++ b/base_layer/wallet/src/base_node_service/service.rs
@@ -146,7 +146,7 @@ where T: WalletBackend + 'static
         &mut self,
         request: BaseNodeServiceRequest,
     ) -> Result<BaseNodeServiceResponse, BaseNodeServiceError> {
-        debug!(
+        trace!(
             target: LOG_TARGET,
             "Handling Wallet Base Node Service Request: {:?}", request
         );

--- a/base_layer/wallet/src/connectivity_service/service.rs
+++ b/base_layer/wallet/src/connectivity_service/service.rs
@@ -206,7 +206,7 @@ impl WalletConnectivityService {
         match self.pools.get(&node_id) {
             Some(pools) => match pools.base_node_wallet_rpc_client.get().await {
                 Ok(client) => {
-                    debug!(target: LOG_TARGET, "Obtained pool RPC 'wallet' connection to base node '{}'", node_id);
+                    trace!(target: LOG_TARGET, "Obtained pool RPC 'wallet' connection to base node '{}'", node_id);
                     let _result = reply.send(client);
                 },
                 Err(e) => {
@@ -247,7 +247,7 @@ impl WalletConnectivityService {
         match self.pools.get(&node_id) {
             Some(pools) => match pools.base_node_sync_rpc_client.get().await {
                 Ok(client) => {
-                    debug!(target: LOG_TARGET, "Obtained pool RPC 'sync' connection to base node '{}'", node_id);
+                    trace!(target: LOG_TARGET, "Obtained pool RPC 'sync' connection to base node '{}'", node_id);
                     let _result = reply.send(client);
                 },
                 Err(e) => {

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -1142,6 +1142,7 @@ where
         >,
         reply_channel: oneshot::Sender<Result<TransactionServiceResponse, TransactionServiceError>>,
     ) -> Result<(), TransactionServiceError> {
+        debug!(target: LOG_TARGET, "Sending transaction to {} with {}", destination, amount);
         let tx_id = TxId::new_random();
         if let Err(e) = self.verify_send(&destination, TariAddressFeatures::create_interactive_only()) {
             let err = match e {
@@ -1158,6 +1159,11 @@ where
                 warn!(target: LOG_TARGET, "Failed to send service reply");
             });
             return Err(e);
+        }
+        // let override the payment_id if the address says we should
+        if destination.features().contains(TariAddressFeatures::PAYMENT_ID) {
+            debug!(target: LOG_TARGET, "Address contains memo, overriding memo {} with {:?}", payment_id, destination.get_payment_id_user_data_bytes());
+            payment_id = PaymentId::open(destination.get_payment_id_user_data_bytes(), TxType::PaymentToOther);
         }
         // If we're paying ourselves, let's complete and submit the transaction immediately
         if &self
@@ -1218,10 +1224,6 @@ where
                 });
 
             return Ok(());
-        }
-        // let override the payment_id if the address says we should
-        if destination.features().contains(TariAddressFeatures::PAYMENT_ID) {
-            payment_id = PaymentId::open(destination.get_payment_id_user_data_bytes(), TxType::PaymentToOther);
         }
         let (tx_reply_sender, tx_reply_receiver) = mpsc::channel(100);
         let (cancellation_sender, cancellation_receiver) = oneshot::channel();
@@ -1773,9 +1775,11 @@ where
         recipient_script: Option<TariScript>,
         mut payment_id: PaymentId,
     ) -> Result<TxId, TransactionServiceError> {
+        debug!(target: LOG_TARGET, "Sending one sided transaction to {} with {}", dest_address, amount);
         let tx_id = TxId::new_random();
         // let override the payment_id if the address says we should
         if dest_address.features().contains(TariAddressFeatures::PAYMENT_ID) {
+            debug!(target: LOG_TARGET, "Address contains memo, overriding memo {} with {:?}", payment_id, dest_address.get_payment_id_user_data_bytes());
             payment_id = PaymentId::open(dest_address.get_payment_id_user_data_bytes(), TxType::PaymentToOther);
         }
         let payment_id = match payment_id.clone() {

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -4742,12 +4742,12 @@ pub unsafe extern "C" fn completed_transaction_user_get_payment_id(
     }
     *error_out = 0;
 
-    let payment_id = (*transaction).payment_id.clone();
     let mut result = CString::new("").expect("Blank CString will not fail.");
     if transaction.is_null() {
         *error_out = LibWalletError::from(InterfaceError::NullError("transaction".to_string())).code;
         return result.into_raw();
     }
+    let payment_id = (*transaction).payment_id.clone();
     match CString::new(payment_id.user_data_as_string()) {
         Ok(v) => result = v,
         Err(e) => {
@@ -4782,11 +4782,11 @@ pub unsafe extern "C" fn completed_transaction_user_get_payment_id_as_bytes(
     }
     *error_out = 0;
 
-    let payment_id = (*transaction).payment_id.clone();
     if transaction.is_null() {
         *error_out = LibWalletError::from(InterfaceError::NullError("transaction".to_string())).code;
         return ptr::null_mut();
     }
+    let payment_id = (*transaction).payment_id.clone();
     let mut bytes = ByteVector(Vec::new());
     bytes.0 = payment_id.user_data_as_bytes();
 
@@ -4817,11 +4817,11 @@ pub unsafe extern "C" fn completed_transaction_get_payment_id_as_bytes(
     }
     *error_out = 0;
 
-    let payment_id = (*transaction).payment_id.clone();
     if transaction.is_null() {
         *error_out = LibWalletError::from(InterfaceError::NullError("transaction".to_string())).code;
         return ptr::null_mut();
     }
+    let payment_id = (*transaction).payment_id.clone();
     let mut bytes = ByteVector(Vec::new());
     bytes.0 = payment_id.to_bytes();
 
@@ -5270,13 +5270,13 @@ pub unsafe extern "C" fn pending_outbound_transaction_get_payment_id(
     }
     *error_out = 0;
 
-    let payment_id = (*transaction).payment_id.clone();
     let mut result = CString::new("").expect("Blank CString will not fail.");
     if transaction.is_null() {
         *error_out = LibWalletError::from(InterfaceError::NullError("transaction".to_string())).code;
         return result.into_raw();
     }
 
+    let payment_id = (*transaction).payment_id.clone();
     match CString::new(payment_id.user_data_as_string()) {
         Ok(v) => result = v,
         Err(e) => {
@@ -5311,11 +5311,11 @@ pub unsafe extern "C" fn pending_outbound_transaction_user_get_payment_id_as_byt
     }
     *error_out = 0;
 
-    let payment_id = (*transaction).payment_id.clone();
     if transaction.is_null() {
         *error_out = LibWalletError::from(InterfaceError::NullError("transaction".to_string())).code;
         return ptr::null_mut();
     }
+    let payment_id = (*transaction).payment_id.clone();
     let mut bytes = ByteVector(Vec::new());
     bytes.0 = payment_id.user_data_as_bytes();
 
@@ -5346,11 +5346,11 @@ pub unsafe extern "C" fn pending_outbound_transaction_get_payment_id_as_bytes(
     }
     *error_out = 0;
 
-    let payment_id = (*transaction).payment_id.clone();
     if transaction.is_null() {
         *error_out = LibWalletError::from(InterfaceError::NullError("transaction".to_string())).code;
         return ptr::null_mut();
     }
+    let payment_id = (*transaction).payment_id.clone();
     let mut bytes = ByteVector(Vec::new());
     bytes.0 = payment_id.to_bytes();
 
@@ -5558,12 +5558,12 @@ pub unsafe extern "C" fn pending_inbound_transaction_get_payment_id(
     }
     *error_out = 0;
 
-    let payment_id = (*transaction).payment_id.clone();
     let mut result = CString::new("").expect("Blank CString will not fail.");
     if transaction.is_null() {
         *error_out = LibWalletError::from(InterfaceError::NullError("transaction".to_string())).code;
         return result.into_raw();
     }
+    let payment_id = (*transaction).payment_id.clone();
 
     match CString::new(payment_id.user_data_as_string()) {
         Ok(v) => result = v,
@@ -5599,11 +5599,11 @@ pub unsafe extern "C" fn pending_inbound_transaction_user_get_payment_id_as_byte
     }
     *error_out = 0;
 
-    let payment_id = (*transaction).payment_id.clone();
     if transaction.is_null() {
         *error_out = LibWalletError::from(InterfaceError::NullError("transaction".to_string())).code;
         return ptr::null_mut();
     }
+    let payment_id = (*transaction).payment_id.clone();
     let mut bytes = ByteVector(Vec::new());
     bytes.0 = payment_id.user_data_as_bytes();
 
@@ -5634,11 +5634,11 @@ pub unsafe extern "C" fn pending_inbound_transaction_get_payment_id_as_bytes(
     }
     *error_out = 0;
 
-    let payment_id = (*transaction).payment_id.clone();
     if transaction.is_null() {
         *error_out = LibWalletError::from(InterfaceError::NullError("transaction".to_string())).code;
         return ptr::null_mut();
     }
+    let payment_id = (*transaction).payment_id.clone();
     let mut bytes = ByteVector(Vec::new());
     bytes.0 = payment_id.to_bytes();
 

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -1507,7 +1507,10 @@ pub unsafe extern "C" fn tari_address_create_with_payment_id_bytes(
         return ptr::null_mut();
     }
     *error_out = 0;
-
+    if address.is_null() {
+        *error_out = LibWalletError::from(InterfaceError::NullError("address".to_string())).code;
+        return ptr::null_mut();
+    }
     if bytes.is_null() {
         *error_out = LibWalletError::from(InterfaceError::NullError("bytes".to_string())).code;
         return ptr::null_mut();
@@ -1548,6 +1551,16 @@ pub unsafe extern "C" fn tari_address_create_with_payment_id_utf8(
         return ptr::null_mut();
     }
     *error_out = 0;
+
+    if address.is_null() {
+        *error_out = LibWalletError::from(InterfaceError::NullError("address".to_string())).code;
+        return ptr::null_mut();
+    }
+
+    if utf8string.is_null() {
+        *error_out = LibWalletError::from(InterfaceError::NullError("utf8string".to_string())).code;
+        return ptr::null_mut();
+    }
 
     let utf8_str = match CStr::from_ptr(utf8string).to_str() {
         Ok(v) => v.to_owned(),

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -4719,7 +4719,7 @@ pub unsafe extern "C" fn completed_transaction_get_mined_in_block(
     CString::into_raw(result)
 }
 
-/// Gets the payment ID of a TariCompletedTransaction
+/// Gets the user payment ID of a TariCompletedTransaction in string format
 ///
 /// ## Arguments
 /// `transaction` - The pointer to a TariCompletedTransaction
@@ -4733,7 +4733,7 @@ pub unsafe extern "C" fn completed_transaction_get_mined_in_block(
 /// # Safety
 /// The ```string_destroy``` method must be called when finished with string coming from rust to prevent a memory leak
 #[no_mangle]
-pub unsafe extern "C" fn completed_transaction_get_payment_id(
+pub unsafe extern "C" fn completed_transaction_user_get_payment_id(
     transaction: *mut TariCompletedTransaction,
     error_out: *mut c_int,
 ) -> *mut c_char {
@@ -4750,12 +4750,82 @@ pub unsafe extern "C" fn completed_transaction_get_payment_id(
     }
     match CString::new(payment_id.user_data_as_string()) {
         Ok(v) => result = v,
-        _ => {
-            *error_out = LibWalletError::from(InterfaceError::PointerError("payment id".to_string())).code;
+        Err(e) => {
+            *error_out = LibWalletError::from(InterfaceError::InternalError(e.to_string())).code;
         },
     }
 
     result.into_raw()
+}
+
+/// Gets the user payment ID of a TariCompletedTransaction as bytes
+///
+/// ## Arguments
+/// `transaction` - The pointer to a TariCompletedTransaction
+/// `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
+/// as an out parameter. Returns a null pointer if any pointer argument is null.
+///
+/// ## Returns
+/// `*mut ByteVector` - Pointer to the created ByteVector. Note that it will be ptr::null_mut()
+/// if the byte_array pointer was null or if the elements in the byte_vector don't match
+/// element_count when it is created
+///
+/// # Safety
+/// The ```byte_vector_destroy``` function must be called when finished with a ByteVector to prevent a memory leak
+#[no_mangle]
+pub unsafe extern "C" fn completed_transaction_user_get_payment_id_as_bytes(
+    transaction: *mut TariCompletedTransaction,
+    error_out: *mut c_int,
+) -> *mut ByteVector {
+    if error_out.is_null() {
+        return ptr::null_mut();
+    }
+    *error_out = 0;
+
+    let payment_id = (*transaction).payment_id.clone();
+    if transaction.is_null() {
+        *error_out = LibWalletError::from(InterfaceError::NullError("transaction".to_string())).code;
+        return ptr::null_mut();
+    }
+    let mut bytes = ByteVector(Vec::new());
+    bytes.0 = payment_id.user_data_as_bytes();
+
+    Box::into_raw(Box::new(bytes))
+}
+
+/// Gets the payment ID of a TariCompletedTransaction as bytes
+///
+/// ## Arguments
+/// `transaction` - The pointer to a TariCompletedTransaction
+/// `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
+/// as an out parameter. Returns a null pointer if any pointer argument is null.
+///
+/// ## Returns
+/// `*mut ByteVector` - Pointer to the created ByteVector. Note that it will be ptr::null_mut()
+/// if the byte_array pointer was null or if the elements in the byte_vector don't match
+/// element_count when it is created
+///
+/// # Safety
+/// The ```byte_vector_destroy``` function must be called when finished with a ByteVector to prevent a memory leak
+#[no_mangle]
+pub unsafe extern "C" fn completed_transaction_get_payment_id_as_bytes(
+    transaction: *mut TariCompletedTransaction,
+    error_out: *mut c_int,
+) -> *mut ByteVector {
+    if error_out.is_null() {
+        return ptr::null_mut();
+    }
+    *error_out = 0;
+
+    let payment_id = (*transaction).payment_id.clone();
+    if transaction.is_null() {
+        *error_out = LibWalletError::from(InterfaceError::NullError("transaction".to_string())).code;
+        return ptr::null_mut();
+    }
+    let mut bytes = ByteVector(Vec::new());
+    bytes.0 = payment_id.to_bytes();
+
+    Box::into_raw(Box::new(bytes))
 }
 
 /// Extract the transaction type from a TariCompletedTransaction
@@ -5209,12 +5279,82 @@ pub unsafe extern "C" fn pending_outbound_transaction_get_payment_id(
 
     match CString::new(payment_id.user_data_as_string()) {
         Ok(v) => result = v,
-        _ => {
-            *error_out = LibWalletError::from(InterfaceError::PointerError("message".to_string())).code;
+        Err(e) => {
+            *error_out = LibWalletError::from(InterfaceError::InternalError(e.to_string())).code;
         },
     }
 
     result.into_raw()
+}
+
+/// Gets the user payment ID of a TariPendingOutboundTransaction as bytes
+///
+/// ## Arguments
+/// `transaction` - The pointer to a TariPendingOutboundTransaction
+/// `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
+/// as an out parameter. Returns a null pointer if any pointer argument is null.
+///
+/// ## Returns
+/// `*mut ByteVector` - Pointer to the created ByteVector. Note that it will be ptr::null_mut()
+/// if the byte_array pointer was null or if the elements in the byte_vector don't match
+/// element_count when it is created
+///
+/// # Safety
+/// The ```byte_vector_destroy``` function must be called when finished with a ByteVector to prevent a memory leak
+#[no_mangle]
+pub unsafe extern "C" fn pending_outbound_transaction_user_get_payment_id_as_bytes(
+    transaction: *mut TariPendingOutboundTransaction,
+    error_out: *mut c_int,
+) -> *mut ByteVector {
+    if error_out.is_null() {
+        return ptr::null_mut();
+    }
+    *error_out = 0;
+
+    let payment_id = (*transaction).payment_id.clone();
+    if transaction.is_null() {
+        *error_out = LibWalletError::from(InterfaceError::NullError("transaction".to_string())).code;
+        return ptr::null_mut();
+    }
+    let mut bytes = ByteVector(Vec::new());
+    bytes.0 = payment_id.user_data_as_bytes();
+
+    Box::into_raw(Box::new(bytes))
+}
+
+/// Gets the payment ID of a TariPendingOutboundTransaction as bytes
+///
+/// ## Arguments
+/// `transaction` - The pointer to a TariPendingOutboundTransaction
+/// `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
+/// as an out parameter. Returns a null pointer if any pointer argument is null.
+///
+/// ## Returns
+/// `*mut ByteVector` - Pointer to the created ByteVector. Note that it will be ptr::null_mut()
+/// if the byte_array pointer was null or if the elements in the byte_vector don't match
+/// element_count when it is created
+///
+/// # Safety
+/// The ```byte_vector_destroy``` function must be called when finished with a ByteVector to prevent a memory leak
+#[no_mangle]
+pub unsafe extern "C" fn pending_outbound_transaction_get_payment_id_as_bytes(
+    transaction: *mut TariPendingOutboundTransaction,
+    error_out: *mut c_int,
+) -> *mut ByteVector {
+    if error_out.is_null() {
+        return ptr::null_mut();
+    }
+    *error_out = 0;
+
+    let payment_id = (*transaction).payment_id.clone();
+    if transaction.is_null() {
+        *error_out = LibWalletError::from(InterfaceError::NullError("transaction".to_string())).code;
+        return ptr::null_mut();
+    }
+    let mut bytes = ByteVector(Vec::new());
+    bytes.0 = payment_id.to_bytes();
+
+    Box::into_raw(Box::new(bytes))
 }
 
 /// Gets the status of a TariPendingOutboundTransaction
@@ -5427,12 +5567,82 @@ pub unsafe extern "C" fn pending_inbound_transaction_get_payment_id(
 
     match CString::new(payment_id.user_data_as_string()) {
         Ok(v) => result = v,
-        _ => {
-            *error_out = LibWalletError::from(InterfaceError::PointerError("message".to_string())).code;
+        Err(e) => {
+            *error_out = LibWalletError::from(InterfaceError::InternalError(e.to_string())).code;
         },
     }
 
     result.into_raw()
+}
+
+/// Gets the user payment ID of a TariPendingInboundTransaction as bytes
+///
+/// ## Arguments
+/// `transaction` - The pointer to a TariPendingInboundTransaction
+/// `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
+/// as an out parameter. Returns a null pointer if any pointer argument is null.
+///
+/// ## Returns
+/// `*mut ByteVector` - Pointer to the created ByteVector. Note that it will be ptr::null_mut()
+/// if the byte_array pointer was null or if the elements in the byte_vector don't match
+/// element_count when it is created
+///
+/// # Safety
+/// The ```byte_vector_destroy``` function must be called when finished with a ByteVector to prevent a memory leak
+#[no_mangle]
+pub unsafe extern "C" fn pending_inbound_transaction_user_get_payment_id_as_bytes(
+    transaction: *mut TariPendingInboundTransaction,
+    error_out: *mut c_int,
+) -> *mut ByteVector {
+    if error_out.is_null() {
+        return ptr::null_mut();
+    }
+    *error_out = 0;
+
+    let payment_id = (*transaction).payment_id.clone();
+    if transaction.is_null() {
+        *error_out = LibWalletError::from(InterfaceError::NullError("transaction".to_string())).code;
+        return ptr::null_mut();
+    }
+    let mut bytes = ByteVector(Vec::new());
+    bytes.0 = payment_id.user_data_as_bytes();
+
+    Box::into_raw(Box::new(bytes))
+}
+
+/// Gets the payment ID of a TariPendingInboundTransaction as bytes
+///
+/// ## Arguments
+/// `transaction` - The pointer to a TariPendingInboundTransaction
+/// `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
+/// as an out parameter. Returns a null pointer if any pointer argument is null.
+///
+/// ## Returns
+/// `*mut ByteVector` - Pointer to the created ByteVector. Note that it will be ptr::null_mut()
+/// if the byte_array pointer was null or if the elements in the byte_vector don't match
+/// element_count when it is created
+///
+/// # Safety
+/// The ```byte_vector_destroy``` function must be called when finished with a ByteVector to prevent a memory leak
+#[no_mangle]
+pub unsafe extern "C" fn pending_inbound_transaction_get_payment_id_as_bytes(
+    transaction: *mut TariPendingInboundTransaction,
+    error_out: *mut c_int,
+) -> *mut ByteVector {
+    if error_out.is_null() {
+        return ptr::null_mut();
+    }
+    *error_out = 0;
+
+    let payment_id = (*transaction).payment_id.clone();
+    if transaction.is_null() {
+        *error_out = LibWalletError::from(InterfaceError::NullError("transaction".to_string())).code;
+        return ptr::null_mut();
+    }
+    let mut bytes = ByteVector(Vec::new());
+    bytes.0 = payment_id.to_bytes();
+
+    Box::into_raw(Box::new(bytes))
 }
 
 /// Gets the status of a TariPendingInboundTransaction

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -355,7 +355,7 @@ impl From<DbWalletOutput> for TariUtxo {
             raw_payment_id: CString::new(format!("{}", x.payment_id))
                 .expect("failed to obtain string from a payment id")
                 .into_raw(),
-            user_payment_id: CString::new(format!("{}", x.payment_id.user_data_as_string()))
+            user_payment_id: CString::new(x.payment_id.user_data_as_string())
                 .expect("failed to obtain string from a payment id")
                 .into_raw(),
             mined_in_block: CString::new(x.mined_in_block.unwrap_or_default().to_hex())
@@ -1458,7 +1458,8 @@ pub unsafe extern "C" fn public_key_from_hex(key: *const c_char, error_out: *mut
 /// if there was an error with the contents of bytes
 ///
 /// # Safety
-/// The ```public_key_destroy``` function must be called when finished with a TariWalletAddress to prevent a memory leak
+/// The ```tari_address_destroy``` function must be called when finished with a TariWalletAddress to prevent a memory
+/// leak
 #[no_mangle]
 pub unsafe extern "C" fn tari_address_create(bytes: *mut ByteVector, error_out: *mut c_int) -> *mut TariWalletAddress {
     if error_out.is_null() {
@@ -1473,6 +1474,92 @@ pub unsafe extern "C" fn tari_address_create(bytes: *mut ByteVector, error_out: 
     let v = (*bytes).0.clone();
     let address = TariWalletAddress::from_bytes(&v);
     match address {
+        Ok(address) => Box::into_raw(Box::new(address)),
+        Err(e) => {
+            *error_out = LibWalletError::from(e).code;
+            ptr::null_mut()
+        },
+    }
+}
+
+/// Creates a new TariWalletAddress from an existing TariWalletAddress adding a payment id in the form a ByteVector
+///
+/// ## Arguments
+/// `address` - The pointer to a TariWalletAddress
+/// `bytes` - The pointer to a ByteVector
+/// `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
+/// as an out parameter. Returns a null pointer if any pointer argument is null.
+///
+/// ## Returns
+/// `TariWalletAddress` - Returns a public key. Note that it will be ptr::null_mut() if bytes is null or
+/// if there was an error with the contents of bytes
+///
+/// # Safety
+/// The ```tari_address_destroy``` function must be called when finished with a TariWalletAddress to prevent a memory
+/// leak
+#[no_mangle]
+pub unsafe extern "C" fn tari_address_create_with_payment_id_bytes(
+    address: *mut TariWalletAddress,
+    bytes: *mut ByteVector,
+    error_out: *mut c_int,
+) -> *mut TariWalletAddress {
+    if error_out.is_null() {
+        return ptr::null_mut();
+    }
+    *error_out = 0;
+
+    if bytes.is_null() {
+        *error_out = LibWalletError::from(InterfaceError::NullError("bytes".to_string())).code;
+        return ptr::null_mut();
+    }
+    let v = (*bytes).0.clone();
+    let new_address = (*address).with_payment_id_user_data(v);
+    match new_address {
+        Ok(address) => Box::into_raw(Box::new(address)),
+        Err(e) => {
+            *error_out = LibWalletError::from(e).code;
+            ptr::null_mut()
+        },
+    }
+}
+
+/// Creates a new TariWalletAddress from an existing TariWalletAddress adding a payment id in the form a utf8 string
+///
+/// ## Arguments
+/// `address` - The pointer to a TariWalletAddress
+/// `utf8string` - The pointer to a char array which is base58 encoded
+/// `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
+/// as an out parameter. Returns a null pointer if any pointer argument is null.
+///
+/// ## Returns
+/// `TariWalletAddress` - Returns a public key. Note that it will be ptr::null_mut() if bytes is null or
+/// if there was an error with the contents of bytes
+///
+/// # Safety
+/// The ```tari_address_destroy``` function must be called when finished with a TariWalletAddress to prevent a memory
+/// leak
+#[no_mangle]
+pub unsafe extern "C" fn tari_address_create_with_payment_id_utf8(
+    address: *mut TariWalletAddress,
+    utf8string: *const c_char,
+    error_out: *mut c_int,
+) -> *mut TariWalletAddress {
+    if error_out.is_null() {
+        return ptr::null_mut();
+    }
+    *error_out = 0;
+
+    let utf8_str = match CStr::from_ptr(utf8string).to_str() {
+        Ok(v) => v.to_owned(),
+        _ => {
+            *error_out = LibWalletError::from(InterfaceError::PointerError("utf8 string".to_string())).code;
+            return ptr::null_mut();
+        },
+    };
+
+    let v = utf8_str.as_bytes().to_vec();
+    let new_address = (*address).with_payment_id_user_data(v);
+    match new_address {
         Ok(address) => Box::into_raw(Box::new(address)),
         Err(e) => {
             *error_out = LibWalletError::from(e).code;
@@ -1533,7 +1620,7 @@ pub unsafe extern "C" fn tari_address_get_bytes(
 /// Creates a TariWalletAddress from a char array
 ///
 /// ## Arguments
-/// `address` - The pointer to a char array which is hex encoded
+/// `address` - The pointer to a char array which is base58 encoded
 /// `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
 /// as an out parameter. Returns a null pointer if any pointer argument is null.
 ///
@@ -12137,10 +12224,10 @@ mod test {
                     CStr::from_ptr(utxo.coinbase_extra).to_str().unwrap()
                 );
                 string_destroy(coinbase_extra);
-                let payment_id = tari_utxo_get_payment_id(utxo, error_ptr);
+                let payment_id = tari_utxo_get_raw_payment_id(utxo, error_ptr);
                 assert_eq!(
                     CStr::from_ptr(payment_id).to_str().unwrap(),
-                    CStr::from_ptr(utxo.payment_id).to_str().unwrap()
+                    CStr::from_ptr(utxo.raw_payment_id).to_str().unwrap()
                 );
                 string_destroy(payment_id);
                 let mined_in_block = tari_utxo_get_mined_in_block(utxo, error_ptr);
@@ -12743,7 +12830,7 @@ mod test {
             );
             let utxos: &[TariUtxo] = slice::from_raw_parts_mut((*outputs).ptr as *mut TariUtxo, (*outputs).len);
             for (utxo, utxo_from_db) in utxos.iter().zip(utxos_from_db.iter()) {
-                let payment_id_c_str: &str = CStr::from_ptr(utxo.payment_id).to_str().unwrap();
+                let payment_id_c_str: &str = CStr::from_ptr(utxo.raw_payment_id).to_str().unwrap();
                 assert_eq!(
                     OutputStatus::try_from(i32::from(utxo.status)).unwrap(),
                     OutputStatus::EncumberedToBeReceived
@@ -13022,7 +13109,7 @@ mod test {
             );
             let utxos: &[TariUtxo] = slice::from_raw_parts_mut((*outputs).ptr as *mut TariUtxo, (*outputs).len);
             for (utxo, utxo_from_db) in utxos.iter().zip(utxos_from_db.iter()) {
-                let payment_id_c_str: &str = CStr::from_ptr(utxo.payment_id).to_str().unwrap();
+                let payment_id_c_str: &str = CStr::from_ptr(utxo.raw_payment_id).to_str().unwrap();
                 assert_eq!(
                     OutputStatus::try_from(i32::from(utxo.status)).unwrap(),
                     OutputStatus::EncumberedToBeReceived

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -895,7 +895,12 @@ pub unsafe extern "C" fn tari_utxo_get_raw_payment_id(utxo: *const TariUtxo, err
     let result = CString::new("").expect("Blank CString will not fail.");
     if utxo.is_null() {
         *error_out = LibWalletError::from(InterfaceError::NullError("utxo".to_string())).code;
-        return ptr::null_mut();
+        return result.into_raw();
+    }
+
+    if (*utxo).raw_payment_id.is_null() {
+        *error_out = LibWalletError::from(InterfaceError::NullError("raw_payment_id".to_string())).code;
+        return CString::into_raw(result);
     }
 
     let payment_id_str = match CStr::from_ptr((*utxo).raw_payment_id).to_str() {

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -318,7 +318,8 @@ pub struct TariUtxo {
     pub lock_height: u64,
     pub status: u8,
     pub coinbase_extra: *const c_char,
-    pub payment_id: *const c_char,
+    pub raw_payment_id: *const c_char,
+    pub user_payment_id: *const c_char,
     pub mined_in_block: *const c_char,
 }
 
@@ -351,7 +352,10 @@ impl From<DbWalletOutput> for TariUtxo {
             coinbase_extra: CString::new(x.wallet_output.features.coinbase_extra.to_hex())
                 .expect("failed to obtain hex from a commitment")
                 .into_raw(),
-            payment_id: CString::new(format!("{}", x.payment_id))
+            raw_payment_id: CString::new(format!("{}", x.payment_id))
+                .expect("failed to obtain string from a payment id")
+                .into_raw(),
+            user_payment_id: CString::new(format!("{}", x.payment_id.user_data_as_string()))
                 .expect("failed to obtain string from a payment id")
                 .into_raw(),
             mined_in_block: CString::new(x.mined_in_block.unwrap_or_default().to_hex())
@@ -868,7 +872,7 @@ pub unsafe extern "C" fn tari_utxo_get_coinbase_extra(utxo: *const TariUtxo, err
     CString::into_raw(result)
 }
 
-/// Get the payment id from a TariUtxo
+/// Get the raw payment id from a TariUtxo
 ///
 /// ## Arguments
 /// `utxo` - The pointer to a TariUtxo.
@@ -882,7 +886,7 @@ pub unsafe extern "C" fn tari_utxo_get_coinbase_extra(utxo: *const TariUtxo, err
 /// # Safety
 /// The ```string_destroy``` method must be called when finished with a string from rust to prevent a memory leak
 #[no_mangle]
-pub unsafe extern "C" fn tari_utxo_get_payment_id(utxo: *const TariUtxo, error_out: *mut c_int) -> *mut c_char {
+pub unsafe extern "C" fn tari_utxo_get_raw_payment_id(utxo: *const TariUtxo, error_out: *mut c_int) -> *mut c_char {
     if error_out.is_null() {
         return ptr::null_mut();
     }
@@ -894,7 +898,44 @@ pub unsafe extern "C" fn tari_utxo_get_payment_id(utxo: *const TariUtxo, error_o
         return ptr::null_mut();
     }
 
-    let payment_id_str = match CStr::from_ptr((*utxo).payment_id).to_str() {
+    let payment_id_str = match CStr::from_ptr((*utxo).raw_payment_id).to_str() {
+        Ok(s) => s,
+        Err(_) => {
+            *error_out = LibWalletError::from(InterfaceError::PointerError("payment_id".to_string())).code;
+            return CString::into_raw(result);
+        },
+    };
+    let result = CString::new(payment_id_str).expect("Commitment will not fail.");
+    CString::into_raw(result)
+}
+
+/// Get the user payment id from a TariUtxo
+///
+/// ## Arguments
+/// `utxo` - The pointer to a TariUtxo.
+/// `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
+/// as an out parameter. Returns a null pointer if any pointer argument is null.
+///
+/// ## Returns
+/// `*mut c_char` - Returns a pointer to a char array (that contains the payment id). Note that it returns empty if
+/// there was an error
+///
+/// # Safety
+/// The ```string_destroy``` method must be called when finished with a string from rust to prevent a memory leak
+#[no_mangle]
+pub unsafe extern "C" fn tari_utxo_get_user_payment_id(utxo: *const TariUtxo, error_out: *mut c_int) -> *mut c_char {
+    if error_out.is_null() {
+        return ptr::null_mut();
+    }
+    *error_out = 0;
+
+    let result = CString::new("").expect("Blank CString will not fail.");
+    if utxo.is_null() {
+        *error_out = LibWalletError::from(InterfaceError::NullError("utxo".to_string())).code;
+        return ptr::null_mut();
+    }
+
+    let payment_id_str = match CStr::from_ptr((*utxo).user_payment_id).to_str() {
         Ok(s) => s,
         Err(_) => {
             *error_out = LibWalletError::from(InterfaceError::PointerError("payment_id".to_string())).code;

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -4833,7 +4833,7 @@ pub unsafe extern "C" fn completed_transaction_get_mined_in_block(
 /// # Safety
 /// The ```string_destroy``` method must be called when finished with string coming from rust to prevent a memory leak
 #[no_mangle]
-pub unsafe extern "C" fn completed_transaction_user_get_payment_id(
+pub unsafe extern "C" fn completed_transaction_get_user_payment_id(
     transaction: *mut TariCompletedTransaction,
     error_out: *mut c_int,
 ) -> *mut c_char {
@@ -4873,7 +4873,7 @@ pub unsafe extern "C" fn completed_transaction_user_get_payment_id(
 /// # Safety
 /// The ```byte_vector_destroy``` function must be called when finished with a ByteVector to prevent a memory leak
 #[no_mangle]
-pub unsafe extern "C" fn completed_transaction_user_get_payment_id_as_bytes(
+pub unsafe extern "C" fn completed_transaction_get_user_payment_id_as_bytes(
     transaction: *mut TariCompletedTransaction,
     error_out: *mut c_int,
 ) -> *mut ByteVector {
@@ -5402,7 +5402,7 @@ pub unsafe extern "C" fn pending_outbound_transaction_get_payment_id(
 /// # Safety
 /// The ```byte_vector_destroy``` function must be called when finished with a ByteVector to prevent a memory leak
 #[no_mangle]
-pub unsafe extern "C" fn pending_outbound_transaction_user_get_payment_id_as_bytes(
+pub unsafe extern "C" fn pending_outbound_transaction_get_user_payment_id_as_bytes(
     transaction: *mut TariPendingOutboundTransaction,
     error_out: *mut c_int,
 ) -> *mut ByteVector {
@@ -5690,7 +5690,7 @@ pub unsafe extern "C" fn pending_inbound_transaction_get_payment_id(
 /// # Safety
 /// The ```byte_vector_destroy``` function must be called when finished with a ByteVector to prevent a memory leak
 #[no_mangle]
-pub unsafe extern "C" fn pending_inbound_transaction_user_get_payment_id_as_bytes(
+pub unsafe extern "C" fn pending_inbound_transaction_get_user_payment_id_as_bytes(
     transaction: *mut TariPendingInboundTransaction,
     error_out: *mut c_int,
 ) -> *mut ByteVector {

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -173,7 +173,8 @@ struct TariUtxo {
   uint64_t lock_height;
   uint8_t status;
   const char *coinbase_extra;
-  const char *payment_id;
+  const char *raw_payment_id;
+  const char *user_payment_id;
   const char *mined_in_block;
 };
 
@@ -453,7 +454,7 @@ char *tari_utxo_get_coinbase_extra(const struct TariUtxo *utxo,
                                    int *error_out);
 
 /**
- * Get the payment id from a TariUtxo
+ * Get the raw payment id from a TariUtxo
  *
  * ## Arguments
  * `utxo` - The pointer to a TariUtxo.
@@ -467,8 +468,26 @@ char *tari_utxo_get_coinbase_extra(const struct TariUtxo *utxo,
  * # Safety
  * The ```string_destroy``` method must be called when finished with a string from rust to prevent a memory leak
  */
-char *tari_utxo_get_payment_id(const struct TariUtxo *utxo,
-                               int *error_out);
+char *tari_utxo_get_raw_payment_id(const struct TariUtxo *utxo,
+                                   int *error_out);
+
+/**
+ * Get the user payment id from a TariUtxo
+ *
+ * ## Arguments
+ * `utxo` - The pointer to a TariUtxo.
+ * `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
+ * as an out parameter. Returns a null pointer if any pointer argument is null.
+ *
+ * ## Returns
+ * `*mut c_char` - Returns a pointer to a char array (that contains the payment id). Note that it returns empty if
+ * there was an error
+ *
+ * # Safety
+ * The ```string_destroy``` method must be called when finished with a string from rust to prevent a memory leak
+ */
+char *tari_utxo_get_user_payment_id(const struct TariUtxo *utxo,
+                                    int *error_out);
 
 /**
  * Get the mined in block hash from a TariUtxo

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -784,10 +784,53 @@ TariPublicKey *public_key_from_hex(const char *key,
  * if there was an error with the contents of bytes
  *
  * # Safety
- * The ```public_key_destroy``` function must be called when finished with a TariWalletAddress to prevent a memory leak
+ * The ```tari_address_destroy``` function must be called when finished with a TariWalletAddress to prevent a memory
+ * leak
  */
 TariWalletAddress *tari_address_create(struct ByteVector *bytes,
                                        int *error_out);
+
+/**
+ * Creates a new TariWalletAddress from an existing TariWalletAddress adding a payment id in the form a ByteVector
+ *
+ * ## Arguments
+ * `address` - The pointer to a TariWalletAddress
+ * `bytes` - The pointer to a ByteVector
+ * `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
+ * as an out parameter. Returns a null pointer if any pointer argument is null.
+ *
+ * ## Returns
+ * `TariWalletAddress` - Returns a public key. Note that it will be ptr::null_mut() if bytes is null or
+ * if there was an error with the contents of bytes
+ *
+ * # Safety
+ * The ```tari_address_destroy``` function must be called when finished with a TariWalletAddress to prevent a memory
+ * leak
+ */
+TariWalletAddress *tari_address_create_with_payment_id_bytes(TariWalletAddress *address,
+                                                             struct ByteVector *bytes,
+                                                             int *error_out);
+
+/**
+ * Creates a new TariWalletAddress from an existing TariWalletAddress adding a payment id in the form a utf8 string
+ *
+ * ## Arguments
+ * `address` - The pointer to a TariWalletAddress
+ * `utf8string` - The pointer to a char array which is base58 encoded
+ * `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
+ * as an out parameter. Returns a null pointer if any pointer argument is null.
+ *
+ * ## Returns
+ * `TariWalletAddress` - Returns a public key. Note that it will be ptr::null_mut() if bytes is null or
+ * if there was an error with the contents of bytes
+ *
+ * # Safety
+ * The ```tari_address_destroy``` function must be called when finished with a TariWalletAddress to prevent a memory
+ * leak
+ */
+TariWalletAddress *tari_address_create_with_payment_id_utf8(TariWalletAddress *address,
+                                                            const char *utf8string,
+                                                            int *error_out);
 
 /**
  * Frees memory for a TariWalletAddress
@@ -824,7 +867,7 @@ struct ByteVector *tari_address_get_bytes(TariWalletAddress *address,
  * Creates a TariWalletAddress from a char array
  *
  * ## Arguments
- * `address` - The pointer to a char array which is hex encoded
+ * `address` - The pointer to a char array which is base58 encoded
  * `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
  * as an out parameter. Returns a null pointer if any pointer argument is null.
  *

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -2423,7 +2423,7 @@ char *completed_transaction_get_mined_in_block(TariCompletedTransaction *transac
  * # Safety
  * The ```string_destroy``` method must be called when finished with string coming from rust to prevent a memory leak
  */
-char *completed_transaction_user_get_payment_id(TariCompletedTransaction *transaction,
+char *completed_transaction_get_user_payment_id(TariCompletedTransaction *transaction,
                                                 int *error_out);
 
 /**
@@ -2442,7 +2442,7 @@ char *completed_transaction_user_get_payment_id(TariCompletedTransaction *transa
  * # Safety
  * The ```byte_vector_destroy``` function must be called when finished with a ByteVector to prevent a memory leak
  */
-struct ByteVector *completed_transaction_user_get_payment_id_as_bytes(TariCompletedTransaction *transaction,
+struct ByteVector *completed_transaction_get_user_payment_id_as_bytes(TariCompletedTransaction *transaction,
                                                                       int *error_out);
 
 /**
@@ -2726,7 +2726,7 @@ const char *pending_outbound_transaction_get_payment_id(TariPendingOutboundTrans
  * # Safety
  * The ```byte_vector_destroy``` function must be called when finished with a ByteVector to prevent a memory leak
  */
-struct ByteVector *pending_outbound_transaction_user_get_payment_id_as_bytes(TariPendingOutboundTransaction *transaction,
+struct ByteVector *pending_outbound_transaction_get_user_payment_id_as_bytes(TariPendingOutboundTransaction *transaction,
                                                                              int *error_out);
 
 /**
@@ -2895,7 +2895,7 @@ const char *pending_inbound_transaction_get_payment_id(TariPendingInboundTransac
  * # Safety
  * The ```byte_vector_destroy``` function must be called when finished with a ByteVector to prevent a memory leak
  */
-struct ByteVector *pending_inbound_transaction_user_get_payment_id_as_bytes(TariPendingInboundTransaction *transaction,
+struct ByteVector *pending_inbound_transaction_get_user_payment_id_as_bytes(TariPendingInboundTransaction *transaction,
                                                                             int *error_out);
 
 /**

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -2366,7 +2366,7 @@ char *completed_transaction_get_mined_in_block(TariCompletedTransaction *transac
                                                int *error_out);
 
 /**
- * Gets the payment ID of a TariCompletedTransaction
+ * Gets the user payment ID of a TariCompletedTransaction in string format
  *
  * ## Arguments
  * `transaction` - The pointer to a TariCompletedTransaction
@@ -2380,8 +2380,46 @@ char *completed_transaction_get_mined_in_block(TariCompletedTransaction *transac
  * # Safety
  * The ```string_destroy``` method must be called when finished with string coming from rust to prevent a memory leak
  */
-char *completed_transaction_get_payment_id(TariCompletedTransaction *transaction,
-                                           int *error_out);
+char *completed_transaction_user_get_payment_id(TariCompletedTransaction *transaction,
+                                                int *error_out);
+
+/**
+ * Gets the user payment ID of a TariCompletedTransaction as bytes
+ *
+ * ## Arguments
+ * `transaction` - The pointer to a TariCompletedTransaction
+ * `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
+ * as an out parameter. Returns a null pointer if any pointer argument is null.
+ *
+ * ## Returns
+ * `*mut ByteVector` - Pointer to the created ByteVector. Note that it will be ptr::null_mut()
+ * if the byte_array pointer was null or if the elements in the byte_vector don't match
+ * element_count when it is created
+ *
+ * # Safety
+ * The ```byte_vector_destroy``` function must be called when finished with a ByteVector to prevent a memory leak
+ */
+struct ByteVector *completed_transaction_user_get_payment_id_as_bytes(TariCompletedTransaction *transaction,
+                                                                      int *error_out);
+
+/**
+ * Gets the payment ID of a TariCompletedTransaction as bytes
+ *
+ * ## Arguments
+ * `transaction` - The pointer to a TariCompletedTransaction
+ * `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
+ * as an out parameter. Returns a null pointer if any pointer argument is null.
+ *
+ * ## Returns
+ * `*mut ByteVector` - Pointer to the created ByteVector. Note that it will be ptr::null_mut()
+ * if the byte_array pointer was null or if the elements in the byte_vector don't match
+ * element_count when it is created
+ *
+ * # Safety
+ * The ```byte_vector_destroy``` function must be called when finished with a ByteVector to prevent a memory leak
+ */
+struct ByteVector *completed_transaction_get_payment_id_as_bytes(TariCompletedTransaction *transaction,
+                                                                 int *error_out);
 
 /**
  * Extract the transaction type from a TariCompletedTransaction
@@ -2630,6 +2668,44 @@ const char *pending_outbound_transaction_get_payment_id(TariPendingOutboundTrans
                                                         int *error_out);
 
 /**
+ * Gets the user payment ID of a TariPendingOutboundTransaction as bytes
+ *
+ * ## Arguments
+ * `transaction` - The pointer to a TariPendingOutboundTransaction
+ * `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
+ * as an out parameter. Returns a null pointer if any pointer argument is null.
+ *
+ * ## Returns
+ * `*mut ByteVector` - Pointer to the created ByteVector. Note that it will be ptr::null_mut()
+ * if the byte_array pointer was null or if the elements in the byte_vector don't match
+ * element_count when it is created
+ *
+ * # Safety
+ * The ```byte_vector_destroy``` function must be called when finished with a ByteVector to prevent a memory leak
+ */
+struct ByteVector *pending_outbound_transaction_user_get_payment_id_as_bytes(TariPendingOutboundTransaction *transaction,
+                                                                             int *error_out);
+
+/**
+ * Gets the payment ID of a TariPendingOutboundTransaction as bytes
+ *
+ * ## Arguments
+ * `transaction` - The pointer to a TariPendingOutboundTransaction
+ * `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
+ * as an out parameter. Returns a null pointer if any pointer argument is null.
+ *
+ * ## Returns
+ * `*mut ByteVector` - Pointer to the created ByteVector. Note that it will be ptr::null_mut()
+ * if the byte_array pointer was null or if the elements in the byte_vector don't match
+ * element_count when it is created
+ *
+ * # Safety
+ * The ```byte_vector_destroy``` function must be called when finished with a ByteVector to prevent a memory leak
+ */
+struct ByteVector *pending_outbound_transaction_get_payment_id_as_bytes(TariPendingOutboundTransaction *transaction,
+                                                                        int *error_out);
+
+/**
  * Gets the status of a TariPendingOutboundTransaction
  *
  * ## Arguments
@@ -2759,6 +2835,44 @@ unsigned long long pending_inbound_transaction_get_timestamp(TariPendingInboundT
  */
 const char *pending_inbound_transaction_get_payment_id(TariPendingInboundTransaction *transaction,
                                                        int *error_out);
+
+/**
+ * Gets the user payment ID of a TariPendingInboundTransaction as bytes
+ *
+ * ## Arguments
+ * `transaction` - The pointer to a TariPendingInboundTransaction
+ * `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
+ * as an out parameter. Returns a null pointer if any pointer argument is null.
+ *
+ * ## Returns
+ * `*mut ByteVector` - Pointer to the created ByteVector. Note that it will be ptr::null_mut()
+ * if the byte_array pointer was null or if the elements in the byte_vector don't match
+ * element_count when it is created
+ *
+ * # Safety
+ * The ```byte_vector_destroy``` function must be called when finished with a ByteVector to prevent a memory leak
+ */
+struct ByteVector *pending_inbound_transaction_user_get_payment_id_as_bytes(TariPendingInboundTransaction *transaction,
+                                                                            int *error_out);
+
+/**
+ * Gets the payment ID of a TariPendingInboundTransaction as bytes
+ *
+ * ## Arguments
+ * `transaction` - The pointer to a TariPendingInboundTransaction
+ * `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
+ * as an out parameter. Returns a null pointer if any pointer argument is null.
+ *
+ * ## Returns
+ * `*mut ByteVector` - Pointer to the created ByteVector. Note that it will be ptr::null_mut()
+ * if the byte_array pointer was null or if the elements in the byte_vector don't match
+ * element_count when it is created
+ *
+ * # Safety
+ * The ```byte_vector_destroy``` function must be called when finished with a ByteVector to prevent a memory leak
+ */
+struct ByteVector *pending_inbound_transaction_get_payment_id_as_bytes(TariPendingInboundTransaction *transaction,
+                                                                       int *error_out);
 
 /**
  * Gets the status of a TariPendingInboundTransaction

--- a/integration_tests/src/ffi/completed_transaction.rs
+++ b/integration_tests/src/ffi/completed_transaction.rs
@@ -136,7 +136,7 @@ impl CompletedTransaction {
         let ptr;
         let mut error = 0;
         unsafe {
-            ptr = ffi_import::completed_transaction_get_payment_id(self.ptr, &mut error);
+            ptr = ffi_import::completed_transaction_get_user_payment_id(self.ptr, &mut error);
             if error > 0 {
                 println!("completed_transaction_get_payment_id error {}", error);
                 panic!("completed_transaction_get_payment_id error");

--- a/integration_tests/src/ffi/ffi_import.rs
+++ b/integration_tests/src/ffi/ffi_import.rs
@@ -304,7 +304,7 @@ extern "C" {
         transaction: *mut TariCompletedTransaction,
         error_out: *mut c_int,
     ) -> *mut c_char;
-    pub fn completed_transaction_get_payment_id(
+    pub fn completed_transaction_get_user_payment_id(
         transaction: *mut TariCompletedTransaction,
         error_out: *mut c_int,
     ) -> *mut c_char;

--- a/integration_tests/tests/steps/wallet_steps.rs
+++ b/integration_tests/tests/steps/wallet_steps.rs
@@ -717,7 +717,7 @@ async fn send_amount_from_source_wallet_to_dest_wallet_without_broadcast(
         amount,
         fee_per_gram: fee,
         payment_type: 0, // normal mimblewimble payment type
-        payment_id: PaymentId::open_from_string(
+        raw_payment_id: PaymentId::open_from_string(
             &format!(
                 "transfer amount {} from {} to {}",
                 amount,
@@ -727,6 +727,7 @@ async fn send_amount_from_source_wallet_to_dest_wallet_without_broadcast(
             TxType::PaymentToOther,
         )
         .to_bytes(),
+        user_payment_id: None,
     };
     let transfer_req = TransferRequest {
         recipients: vec![payment_recipient],
@@ -781,7 +782,7 @@ async fn send_one_sided_transaction_from_source_wallet_to_dest_wallt(
         amount,
         fee_per_gram: fee,
         payment_type: 1, // one sided transaction
-        payment_id: PaymentId::open_from_string(
+        raw_payment_id: PaymentId::open_from_string(
             &format!(
                 "One sided transfer amount {} from {} to {}",
                 amount,
@@ -791,6 +792,7 @@ async fn send_one_sided_transaction_from_source_wallet_to_dest_wallt(
             TxType::PaymentToOther,
         )
         .to_bytes(),
+        user_payment_id: None,
     };
     let transfer_req = TransferRequest {
         recipients: vec![payment_recipient],
@@ -883,7 +885,7 @@ async fn send_amount_from_wallet_to_wallet_at_fee(
         amount,
         fee_per_gram,
         payment_type: 0, // mimblewimble transaction
-        payment_id: PaymentId::open_from_string(
+        raw_payment_id: PaymentId::open_from_string(
             &format!(
                 "Transfer amount {} from {} to {} as fee {}",
                 amount,
@@ -894,6 +896,7 @@ async fn send_amount_from_wallet_to_wallet_at_fee(
             TxType::PaymentToOther,
         )
         .to_bytes(),
+        user_payment_id: None,
     };
     let transfer_req = TransferRequest {
         recipients: vec![payment_recipient],
@@ -1329,7 +1332,7 @@ async fn send_num_transactions_to_wallets_at_fee(
             amount,
             fee_per_gram,
             payment_type: 0, // standard mimblewimble transaction
-            payment_id: PaymentId::open_from_string(
+            raw_payment_id: PaymentId::open_from_string(
                 &format!(
                     "transfer amount {} from {} to {}",
                     amount,
@@ -1339,6 +1342,7 @@ async fn send_num_transactions_to_wallets_at_fee(
                 TxType::PaymentToOther,
             )
             .to_bytes(),
+            user_payment_id: None,
         };
         let transfer_req = TransferRequest {
             recipients: vec![payment_recipient],
@@ -1474,7 +1478,7 @@ async fn transfer_tari_from_wallet_to_receiver(world: &mut TariWorld, amount: u6
         amount: amount * 1_000_000_u64, // 1T = 1_000_000uT
         fee_per_gram: 10,               // as in the js cucumber tests
         payment_type: 0,                // normal mimblewimble payment type
-        payment_id: PaymentId::open_from_string(
+        raw_payment_id: PaymentId::open_from_string(
             &format!(
                 "transfer amount {} from {} to {}",
                 amount,
@@ -1484,6 +1488,7 @@ async fn transfer_tari_from_wallet_to_receiver(world: &mut TariWorld, amount: u6
             TxType::PaymentToOther,
         )
         .to_bytes(),
+        user_payment_id: None,
     };
     let transfer_req = TransferRequest {
         recipients: vec![payment_recipient],
@@ -1673,7 +1678,7 @@ async fn transfer_from_wallet_to_two_recipients_at_fee(
         amount,
         fee_per_gram,
         payment_type: 0, // normal mimblewimble payment type
-        payment_id: PaymentId::open_from_string(
+        raw_payment_id: PaymentId::open_from_string(
             &format!(
                 "transfer amount {} from {} to {}",
                 amount,
@@ -1683,6 +1688,7 @@ async fn transfer_from_wallet_to_two_recipients_at_fee(
             TxType::PaymentToOther,
         )
         .to_bytes(),
+        user_payment_id: None,
     };
 
     let payment_recipient2 = PaymentRecipient {
@@ -1690,7 +1696,7 @@ async fn transfer_from_wallet_to_two_recipients_at_fee(
         amount,
         fee_per_gram,
         payment_type: 0, // normal mimblewimble payment type
-        payment_id: PaymentId::open_from_string(
+        raw_payment_id: PaymentId::open_from_string(
             &format!(
                 "transfer amount {} from {} to {}",
                 amount,
@@ -1700,6 +1706,7 @@ async fn transfer_from_wallet_to_two_recipients_at_fee(
             TxType::PaymentToOther,
         )
         .to_bytes(),
+        user_payment_id: None,
     };
     let transfer_req = TransferRequest {
         recipients: vec![payment_recipient1, payment_recipient2],
@@ -1810,11 +1817,12 @@ async fn transfer_tari_to_self(world: &mut TariWorld, amount: u64, sender: Strin
         amount,
         fee_per_gram,
         payment_type: 0, // normal mimblewimble payment type
-        payment_id: PaymentId::open_from_string(
+        raw_payment_id: PaymentId::open_from_string(
             &format!("transfer amount {} from {} to self", amount, sender.as_str()),
             TxType::PaymentToSelf,
         )
         .to_bytes(),
+        user_payment_id: None,
     };
     let transfer_req = TransferRequest {
         recipients: vec![payment_recipient],
@@ -1893,7 +1901,7 @@ async fn htlc_transaction(world: &mut TariWorld, amount: u64, sender: String, re
         amount,
         fee_per_gram,
         payment_type: 0, // normal mimblewimble transaction
-        payment_id: PaymentId::open_from_string(
+        raw_payment_id: PaymentId::open_from_string(
             &format!(
                 "Atomic Swap from {} to {} with amount {} at fee {}",
                 sender.as_str(),
@@ -1904,6 +1912,7 @@ async fn htlc_transaction(world: &mut TariWorld, amount: u64, sender: String, re
             TxType::PaymentToOther,
         )
         .to_bytes(),
+        user_payment_id: None,
     };
 
     let atomic_swap_request = SendShaAtomicSwapRequest {
@@ -2187,7 +2196,7 @@ async fn send_one_sided_stealth_transaction(
         amount,
         fee_per_gram,
         payment_type: 2, // one sided stealth transaction
-        payment_id: PaymentId::open_from_string(
+        raw_payment_id: PaymentId::open_from_string(
             &format!(
                 "One sided stealth transfer amount {} from {} to {}",
                 amount,
@@ -2197,6 +2206,7 @@ async fn send_one_sided_stealth_transaction(
             TxType::PaymentToOther,
         )
         .to_bytes(),
+        user_payment_id: None,
     };
     let transfer_req = TransferRequest {
         recipients: vec![payment_recipient],
@@ -2726,7 +2736,7 @@ async fn multi_send_txs_from_wallet(
             amount,
             fee_per_gram,
             payment_type: 0, // mimblewimble transaction
-            payment_id: PaymentId::open_from_string(
+            raw_payment_id: PaymentId::open_from_string(
                 &format!(
                     "I send multi-transfers with amount {} from {} to {} with fee per gram {}",
                     amount,
@@ -2737,6 +2747,7 @@ async fn multi_send_txs_from_wallet(
                 TxType::PaymentToOther,
             )
             .to_bytes(),
+            user_payment_id: None,
         };
 
         let transfer_req = TransferRequest {


### PR DESCRIPTION
Description
---
Currently, the wallet adds extra data to the payment id field to enable it to track its own transactions on the blockchain.
This however leads to weird results when trying to display the raw user payment id. This ensures that all grpc and ffi calls either straight up just provides the user provided payment id, or explicitly states which one it is, and provide both. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for both raw and user payment IDs in wallet transactions and UTXOs, enabling clearer distinction and more flexible handling of payment identifiers.
  - Introduced new functions to retrieve raw and user payment IDs from UTXOs and transactions via FFI, including byte-level accessors.
  - Added functions to create wallet addresses with payment IDs from bytes or UTF-8 strings.
- **Bug Fixes**
  - Enhanced validation and processing of user payment IDs in wallet operations to ensure accurate handling.
- **Style**
  - Adjusted logging levels for wallet service events from debug to trace for improved log clarity.
  - Added debug logs in transaction sending functions to improve traceability.
- **Enhancements**
  - Updated contact address handling to incorporate user payment ID data when updating stored addresses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->