### PR TITLE
feat: import transactions via grpc

### DIFF
--- a/applications/minotari_app_grpc/proto/wallet.proto
+++ b/applications/minotari_app_grpc/proto/wallet.proto
@@ -997,6 +997,8 @@ service Wallet {
   rpc StreamTransactionEvents(TransactionEventRequest) returns (stream TransactionEventResponse);
 
   rpc RegisterValidatorNode(RegisterValidatorNodeRequest) returns (RegisterValidatorNodeResponse);
+
+  rpc ImportTransactions(ImportTransactionsRequest) returns (ImportTransactionsResponse);
 }
 
 
@@ -1354,4 +1356,12 @@ message RegisterValidatorNodeResponse {
   uint64 transaction_id = 1;
   bool is_success = 2;
   string failure_message = 3;
+}
+
+message ImportTransactionsRequest {
+  string file_path = 1;
+}
+
+message ImportTransactionsResponse {
+    repeated uint64 tx_ids = 1;
 }

--- a/applications/minotari_app_grpc/proto/wallet.proto
+++ b/applications/minotari_app_grpc/proto/wallet.proto
@@ -159,8 +159,8 @@ service Wallet {
   // ```
   rpc GetAddress (Empty) returns (GetAddressResponse);
 
-  // This RPC returns addresses generated for a specific payment ID. It provides both the interactive 
-  // and one-sided addresses for the given payment ID, along with their respective representations in 
+  // This RPC returns addresses generated for a specific payment ID. It provides both the interactive
+  // and one-sided addresses for the given payment ID, along with their respective representations in
   // base58 and emoji formats.
   //
   // Example usage (JavaScript):
@@ -200,7 +200,7 @@ service Wallet {
   // - Raw binary
   // - Base58-encoded (human-readable)
   // - Emoji-encoded (for fun and friendliness)
-  // 
+  //
   // Example usage (JavaScript with gRPC):
   //
   // ```js
@@ -262,7 +262,7 @@ service Wallet {
   // }
   // ```
   rpc Transfer (TransferRequest)  returns (TransferResponse);
-  
+
   // Returns the transaction details for the given transaction IDs.
   //
   // The GetTransactionInfo RPC retrieves detailed information about specific transactions based on their IDs.
@@ -270,10 +270,10 @@ service Wallet {
   //
   // ### Request Parameters:
   //
-  // - `transaction_ids` (required):  
-  //   - **Type**: `repeated uint64`  
-  //   - **Description**: A list of transaction IDs to query.  
-  //   - **Restrictions**:  
+  // - `transaction_ids` (required):
+  //   - **Type**: `repeated uint64`
+  //   - **Description**: A list of transaction IDs to query.
+  //   - **Restrictions**:
   //     - Must contain at least one ID.
   //     - All IDs must be valid unsigned 64-bit integers.
   //     - Duplicates will be ignored; only the first occurrence is processed.
@@ -440,7 +440,7 @@ service Wallet {
   //
   // ### Request Parameters:
   //
-  // - *(none)*  
+  // - *(none)*
   //   - This method uses an empty request body (`google.protobuf.Empty`).
   //   - No filters or arguments are required.
   //
@@ -470,29 +470,29 @@ service Wallet {
   //
   // ### Request Parameters:
   //
-  // - `amount_per_split` (required):  
-  //   - **Type**: `uint64`  
-  //   - **Description**: The value of each individual output in the split.  
+  // - `amount_per_split` (required):
+  //   - **Type**: `uint64`
+  //   - **Description**: The value of each individual output in the split.
   //   - **Restrictions**: Must be greater than zero.
   //
-  // - `split_count` (required):  
-  //   - **Type**: `uint64`  
-  //   - **Description**: The number of outputs to create.  
+  // - `split_count` (required):
+  //   - **Type**: `uint64`
+  //   - **Description**: The number of outputs to create.
   //   - **Restrictions**: Must be greater than zero and within practical system limits.
   //
-  // - `fee_per_gram` (required):  
-  //   - **Type**: `uint64`  
-  //   - **Description**: The transaction fee rate (per gram of weight).  
+  // - `fee_per_gram` (required):
+  //   - **Type**: `uint64`
+  //   - **Description**: The transaction fee rate (per gram of weight).
   //   - **Restrictions**: Should be set high enough to ensure confirmation.
   //
-  // - `lock_height` (optional):  
-  //   - **Type**: `uint64`  
-  //   - **Description**: The earliest block height at which the transaction becomes valid.  
+  // - `lock_height` (optional):
+  //   - **Type**: `uint64`
+  //   - **Description**: The earliest block height at which the transaction becomes valid.
   //   - **Restrictions**: Defaults to 0 if not specified.
   //
-  // - `payment_id` (optional):  
-  //   - **Type**: `bytes`  
-  //   - **Description**: A user-defined identifier for tracking or referencing the transaction.  
+  // - `payment_id` (optional):
+  //   - **Type**: `bytes`
+  //   - **Description**: A user-defined identifier for tracking or referencing the transaction.
   //   - **Restrictions**: Optional; can be left empty.
   //
   // ### Example JavaScript gRPC client usage:
@@ -528,17 +528,17 @@ service Wallet {
   //
   // ### Request Parameters:
   //
-  // - `outputs` (required):  
-  //   - **Type**: `repeated UnblindedOutput`  
-  //   - **Description**: A list of unblinded outputs to import into the wallet.  
-  //   - **Restrictions**:  
+  // - `outputs` (required):
+  //   - **Type**: `repeated UnblindedOutput`
+  //   - **Description**: A list of unblinded outputs to import into the wallet.
+  //   - **Restrictions**:
   //     - Each output must be valid and convertible to an internal UTXO format.
   //     - The list must contain at least one item.
   //
-  // - `payment_id` (optional):  
-  //   - **Type**: `bytes`  
-  //   - **Description**: An optional user-defined identifier to associate with the imported outputs.  
-  //   - **Restrictions**:  
+  // - `payment_id` (optional):
+  //   - **Type**: `bytes`
+  //   - **Description**: An optional user-defined identifier to associate with the imported outputs.
+  //   - **Restrictions**:
   //     - Can be left empty if not needed.
   //     - Must be a valid byte string if provided.
   //
@@ -572,7 +572,7 @@ service Wallet {
   //
   // ### Request Parameters:
   //
-  // - *(none)*  
+  // - *(none)*
   //   - This method uses an empty request body (`google.protobuf.Empty`).
   //   - No filters or arguments are required.
   //
@@ -599,16 +599,16 @@ service Wallet {
   //
   // The `status` field indicates the current network connectivity of the wallet. Possible values are:
   //
-  // - `ONLINE`:  
-  //   - The wallet is fully connected to the network and functioning normally.  
+  // - `ONLINE`:
+  //   - The wallet is fully connected to the network and functioning normally.
   //   - The node has enough active peer connections to operate efficiently.
   //
-  // - `DEGRADED`:  
-  //   - The wallet is connected to some peers but not enough to maintain full functionality.  
+  // - `DEGRADED`:
+  //   - The wallet is connected to some peers but not enough to maintain full functionality.
   //   - This could indicate issues with network connectivity, such as intermittent disconnections or insufficient peers, leading to reduced performance or reliability.
   //
-  // - `OFFLINE`:  
-  //   - The wallet is not connected to any peers.  
+  // - `OFFLINE`:
+  //   - The wallet is not connected to any peers.
   //   - This status means the wallet is unable to communicate with the network and cannot perform any network-related operations.
   //
   rpc GetNetworkStatus(Empty) returns (NetworkStatusResponse);
@@ -621,7 +621,7 @@ service Wallet {
   //
   // ### Request Parameters:
   //
-  // - *(none)*  
+  // - *(none)*
   //   - This method uses an empty request body (`google.protobuf.Empty`).
   //   - No filters or arguments are required.
   //
@@ -681,7 +681,7 @@ service Wallet {
   // Cancels a specific transaction by its ID.
   //
   // The `CancelTransaction` call allows a transaction to be cancelled by its unique transaction ID (TxId).
-  // If the cancellation is successful, the response will indicate success. Otherwise, the response will 
+  // If the cancellation is successful, the response will indicate success. Otherwise, the response will
   // contain a failure message with the reason for the failure.
   //
   // ### Request Parameters:
@@ -723,13 +723,13 @@ service Wallet {
 
   // Sends a XTR SHA Atomic Swap transaction.
   //
-  // The `SendShaAtomicSwapTransaction` call is used to initiate an Atomic Swap 
-  // transaction using SHA. It allows the sender to send a payment to the recipient 
+  // The `SendShaAtomicSwapTransaction` call is used to initiate an Atomic Swap
+  // transaction using SHA. It allows the sender to send a payment to the recipient
   // in exchange for an atomic swap, with SHA used as the secret for the swap.
   // The method accepts the recipient's information and initiates the transaction.
   //
   // ### Request Parameters:
-  // - **recipient** (required): A PaymentRecipient object containing the recipient's address, 
+  // - **recipient** (required): A PaymentRecipient object containing the recipient's address,
   //   the amount to be swapped, the fee per gram, and the payment ID to identify the transaction.
   //
   // ### Response Fields:
@@ -1359,7 +1359,7 @@ message RegisterValidatorNodeResponse {
 }
 
 message ImportTransactionsRequest {
-  string file_path = 1;
+  string txs = 1;
 }
 
 message ImportTransactionsResponse {

--- a/applications/minotari_console_wallet/src/automation/commands.rs
+++ b/applications/minotari_console_wallet/src/automation/commands.rs
@@ -2062,6 +2062,7 @@ pub async fn command_runner(
                             target: LOG_TARGET,
                             "send-one-sided-to-stealth-address concluded with tx_id {}", tx_id
                         );
+                        println!("Transaction ID: {}", tx_id);
                         tx_ids.push(tx_id);
                     },
                     Err(e) => eprintln!("SendOneSidedToStealthAddress error! {}", e),

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -1259,16 +1259,11 @@ impl wallet_server::Wallet for WalletGrpcServer {
         request: Request<ImportTransactionsRequest>,
     ) -> Result<Response<ImportTransactionsResponse>, Status> {
         let request = request.into_inner();
-        let file_contents = std::fs::read_to_string(request.file_path)
-            .map_err(|_| Status::invalid_argument("File path is malformed!"))?;
-        let mut txs: Vec<WalletTransaction> = Vec::new();
-        for line in file_contents.lines() {
-            serde_json::from_str(line)
-                .map(|tx| txs.push(tx))
-                .map_err(|_| Status::invalid_argument("File path is malformed!"))?;
-        }
-        let mut transaction_service = self.get_transaction_service();
+        let txs: Vec<WalletTransaction> = serde_json::from_str(&request.txs)
+            .map_err(|_| Status::invalid_argument("Could not parse transactions. Use valid JSON format."))?;
+        info!(target: LOG_TARGET, "Importing {:?} transactions", txs.len());
 
+        let mut transaction_service = self.get_transaction_service();
         let mut tx_ids = Vec::new();
         for tx in txs {
             match transaction_service.import_transaction(tx).await {

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -1205,7 +1205,6 @@ impl wallet_server::Wallet for WalletGrpcServer {
         request: Request<ImportTransactionsRequest>,
     ) -> Result<Response<ImportTransactionsResponse>, Status> {
         let request = request.into_inner();
-        // Extract file contents
         let file_contents = std::fs::read_to_string(request.file_path).map_err(|_| Status::invalid_argument("File path is malformed!"))?;
         let mut txs: Vec<WalletTransaction> = Vec::new();
         for line in file_contents.lines() {

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -1273,7 +1273,6 @@ impl wallet_server::Wallet for WalletGrpcServer {
         for tx in txs {
             match transaction_service.import_transaction(tx).await {
                 Ok(id) => {
-                    println!("Imported tx: {}", id);
                     tx_ids.push(id.into());
                 },
                 Err(e) => eprintln!("Could not import tx {}", e),

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -33,59 +33,7 @@ use futures::{
 };
 use log::*;
 use minotari_app_grpc::tari_rpc::{
-    self,
-    payment_recipient::PaymentType,
-    wallet_server,
-    CheckConnectivityResponse,
-    ClaimHtlcRefundRequest,
-    ClaimHtlcRefundResponse,
-    ClaimShaAtomicSwapRequest,
-    ClaimShaAtomicSwapResponse,
-    CoinSplitRequest,
-    CoinSplitResponse,
-    CommitmentSignature,
-    CreateBurnTransactionRequest,
-    CreateBurnTransactionResponse,
-    CreateTemplateRegistrationRequest,
-    CreateTemplateRegistrationResponse,
-    GetAddressResponse,
-    GetBalanceRequest,
-    GetBalanceResponse,
-    GetCompleteAddressResponse,
-    GetCompletedTransactionsRequest,
-    GetCompletedTransactionsResponse,
-    GetConnectivityRequest,
-    GetIdentityRequest,
-    GetIdentityResponse,
-    GetPaymentIdAddressRequest,
-    GetStateRequest,
-    GetStateResponse,
-    GetTransactionInfoRequest,
-    GetTransactionInfoResponse,
-    GetUnspentAmountsResponse,
-    GetVersionRequest,
-    GetVersionResponse,
-    ImportUtxosRequest,
-    ImportUtxosResponse,
-    RegisterValidatorNodeRequest,
-    RegisterValidatorNodeResponse,
-    RevalidateRequest,
-    RevalidateResponse,
-    SendShaAtomicSwapRequest,
-    SendShaAtomicSwapResponse,
-    SetBaseNodeRequest,
-    SetBaseNodeResponse,
-    TransactionDirection,
-    TransactionEvent,
-    TransactionEventRequest,
-    TransactionEventResponse,
-    TransactionInfo,
-    TransactionStatus,
-    TransferRequest,
-    TransferResponse,
-    TransferResult,
-    ValidateRequest,
-    ValidateResponse,
+    self, payment_recipient::PaymentType, wallet_server, CheckConnectivityResponse, ClaimHtlcRefundRequest, ClaimHtlcRefundResponse, ClaimShaAtomicSwapRequest, ClaimShaAtomicSwapResponse, CoinSplitRequest, CoinSplitResponse, CommitmentSignature, CreateBurnTransactionRequest, CreateBurnTransactionResponse, CreateTemplateRegistrationRequest, CreateTemplateRegistrationResponse, GetAddressResponse, GetBalanceRequest, GetBalanceResponse, GetCompleteAddressResponse, GetCompletedTransactionsRequest, GetCompletedTransactionsResponse, GetConnectivityRequest, GetIdentityRequest, GetIdentityResponse, GetPaymentIdAddressRequest, GetStateRequest, GetStateResponse, GetTransactionInfoRequest, GetTransactionInfoResponse, GetUnspentAmountsResponse, GetVersionRequest, GetVersionResponse, ImportTransactionsRequest, ImportTransactionsResponse, ImportUtxosRequest, ImportUtxosResponse, RegisterValidatorNodeRequest, RegisterValidatorNodeResponse, RevalidateRequest, RevalidateResponse, SendShaAtomicSwapRequest, SendShaAtomicSwapResponse, SetBaseNodeRequest, SetBaseNodeResponse, TransactionDirection, TransactionEvent, TransactionEventRequest, TransactionEventResponse, TransactionInfo, TransactionStatus, TransferRequest, TransferResponse, TransferResult, ValidateRequest, ValidateResponse
 };
 use minotari_wallet::{
     connectivity_service::WalletConnectivityInterface,
@@ -1250,6 +1198,37 @@ impl wallet_server::Wallet for WalletGrpcServer {
             },
         };
         Ok(Response::new(response))
+    }
+
+    async fn import_transactions(
+        &self,
+        request: Request<ImportTransactionsRequest>,
+    ) -> Result<Response<ImportTransactionsResponse>, Status> {
+        let request = request.into_inner();
+        // Extract file contents
+        let file_contents = std::fs::read_to_string(request.file_path).map_err(|_| Status::invalid_argument("File path is malformed!"))?;
+        let mut txs: Vec<WalletTransaction> = Vec::new();
+        for line in file_contents.lines() {
+            serde_json::from_str(line)
+                .map(|tx| txs.push(tx))
+                .map_err(|_| Status::invalid_argument("File path is malformed!"))?;
+        }
+        let mut transaction_service = self.get_transaction_service();
+
+        info!(target: LOG_TARGET, "====AAA Txs to import: {:?}", txs);
+        let mut tx_ids = Vec::new();
+        for tx in txs {
+            match transaction_service.import_transaction(tx).await {
+                Ok(id) => {
+                    info!(target: LOG_TARGET, "====BBB Single imported transaction: {:?}", id);
+                    println!("imported tx: {}", id);
+                    tx_ids.push(id.into());
+                },
+                Err(e) => eprintln!("Could not import tx {}", e),
+            };
+        }
+        info!(target: LOG_TARGET, "====CCCCC All Imported transactions: {:?}", tx_ids);
+        Ok(Response::new(ImportTransactionsResponse { tx_ids }))
     }
 }
 

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -1215,19 +1215,16 @@ impl wallet_server::Wallet for WalletGrpcServer {
         }
         let mut transaction_service = self.get_transaction_service();
 
-        info!(target: LOG_TARGET, "====AAA Txs to import: {:?}", txs);
         let mut tx_ids = Vec::new();
         for tx in txs {
             match transaction_service.import_transaction(tx).await {
                 Ok(id) => {
-                    info!(target: LOG_TARGET, "====BBB Single imported transaction: {:?}", id);
-                    println!("imported tx: {}", id);
+                    println!("Imported tx: {}", id);
                     tx_ids.push(id.into());
                 },
                 Err(e) => eprintln!("Could not import tx {}", e),
             };
         }
-        info!(target: LOG_TARGET, "====CCCCC All Imported transactions: {:?}", tx_ids);
         Ok(Response::new(ImportTransactionsResponse { tx_ids }))
     }
 }

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -33,7 +33,61 @@ use futures::{
 };
 use log::*;
 use minotari_app_grpc::tari_rpc::{
-    self, payment_recipient::PaymentType, wallet_server, CheckConnectivityResponse, ClaimHtlcRefundRequest, ClaimHtlcRefundResponse, ClaimShaAtomicSwapRequest, ClaimShaAtomicSwapResponse, CoinSplitRequest, CoinSplitResponse, CommitmentSignature, CreateBurnTransactionRequest, CreateBurnTransactionResponse, CreateTemplateRegistrationRequest, CreateTemplateRegistrationResponse, GetAddressResponse, GetBalanceRequest, GetBalanceResponse, GetCompleteAddressResponse, GetCompletedTransactionsRequest, GetCompletedTransactionsResponse, GetConnectivityRequest, GetIdentityRequest, GetIdentityResponse, GetPaymentIdAddressRequest, GetStateRequest, GetStateResponse, GetTransactionInfoRequest, GetTransactionInfoResponse, GetUnspentAmountsResponse, GetVersionRequest, GetVersionResponse, ImportTransactionsRequest, ImportTransactionsResponse, ImportUtxosRequest, ImportUtxosResponse, RegisterValidatorNodeRequest, RegisterValidatorNodeResponse, RevalidateRequest, RevalidateResponse, SendShaAtomicSwapRequest, SendShaAtomicSwapResponse, SetBaseNodeRequest, SetBaseNodeResponse, TransactionDirection, TransactionEvent, TransactionEventRequest, TransactionEventResponse, TransactionInfo, TransactionStatus, TransferRequest, TransferResponse, TransferResult, ValidateRequest, ValidateResponse
+    self,
+    payment_recipient::PaymentType,
+    wallet_server,
+    CheckConnectivityResponse,
+    ClaimHtlcRefundRequest,
+    ClaimHtlcRefundResponse,
+    ClaimShaAtomicSwapRequest,
+    ClaimShaAtomicSwapResponse,
+    CoinSplitRequest,
+    CoinSplitResponse,
+    CommitmentSignature,
+    CreateBurnTransactionRequest,
+    CreateBurnTransactionResponse,
+    CreateTemplateRegistrationRequest,
+    CreateTemplateRegistrationResponse,
+    GetAddressResponse,
+    GetBalanceRequest,
+    GetBalanceResponse,
+    GetCompleteAddressResponse,
+    GetCompletedTransactionsRequest,
+    GetCompletedTransactionsResponse,
+    GetConnectivityRequest,
+    GetIdentityRequest,
+    GetIdentityResponse,
+    GetPaymentIdAddressRequest,
+    GetStateRequest,
+    GetStateResponse,
+    GetTransactionInfoRequest,
+    GetTransactionInfoResponse,
+    GetUnspentAmountsResponse,
+    GetVersionRequest,
+    GetVersionResponse,
+    ImportTransactionsRequest,
+    ImportTransactionsResponse,
+    ImportUtxosRequest,
+    ImportUtxosResponse,
+    RegisterValidatorNodeRequest,
+    RegisterValidatorNodeResponse,
+    RevalidateRequest,
+    RevalidateResponse,
+    SendShaAtomicSwapRequest,
+    SendShaAtomicSwapResponse,
+    SetBaseNodeRequest,
+    SetBaseNodeResponse,
+    TransactionDirection,
+    TransactionEvent,
+    TransactionEventRequest,
+    TransactionEventResponse,
+    TransactionInfo,
+    TransactionStatus,
+    TransferRequest,
+    TransferResponse,
+    TransferResult,
+    ValidateRequest,
+    ValidateResponse,
 };
 use minotari_wallet::{
     connectivity_service::WalletConnectivityInterface,
@@ -1205,7 +1259,8 @@ impl wallet_server::Wallet for WalletGrpcServer {
         request: Request<ImportTransactionsRequest>,
     ) -> Result<Response<ImportTransactionsResponse>, Status> {
         let request = request.into_inner();
-        let file_contents = std::fs::read_to_string(request.file_path).map_err(|_| Status::invalid_argument("File path is malformed!"))?;
+        let file_contents = std::fs::read_to_string(request.file_path)
+            .map_err(|_| Status::invalid_argument("File path is malformed!"))?;
         let mut txs: Vec<WalletTransaction> = Vec::new();
         for line in file_contents.lines() {
             serde_json::from_str(line)

--- a/applications/minotari_console_wallet/src/ui/state/wallet_event_monitor.rs
+++ b/applications/minotari_console_wallet/src/ui/state/wallet_event_monitor.rs
@@ -168,6 +168,13 @@ impl WalletEventMonitor {
                                     self.trigger_full_tx_state_refresh().await;
                                     self.trigger_balance_refresh();
                                 },
+                                TransactionEvent::TransactionImported(tx_id) => {
+                                    self.trigger_tx_state_refresh(tx_id).await;
+                                    self.trigger_balance_refresh();
+                                    self.add_notification(
+                                        format!("Transaction Imported - TxId: {}", tx_id)
+                                    ).await;
+                                },
                                 // Only the above variants trigger state refresh
                                 _ => (),
                             }

--- a/base_layer/wallet/src/transaction_service/handle.rs
+++ b/base_layer/wallet/src/transaction_service/handle.rs
@@ -490,6 +490,7 @@ pub enum TransactionEvent {
         num_confirmations: u64,
         is_valid: bool,
     },
+    TransactionImported(TxId),
     TransactionValidationStateChanged(OperationId),
     TransactionValidationCompleted(OperationId),
     TransactionValidationFailed(OperationId, u64),
@@ -550,6 +551,9 @@ impl fmt::Display for TransactionEvent {
                     "TransactionMinedUnconfirmed for {tx_id} with num confirmations: {num_confirmations}. is_valid: \
                      {is_valid}",
                 )
+            },
+            TransactionEvent::TransactionImported(tx) => {
+                write!(f, "TransactionImported for {tx}")
             },
             TransactionEvent::Error(error) => {
                 write!(f, "Error:{error}")

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -946,6 +946,9 @@ where
                         tx_id
                     },
                 };
+                let _size = self
+                    .event_publisher
+                    .send(Arc::new(TransactionEvent::TransactionImported(tx_id)));
                 Ok(TransactionServiceResponse::TransactionImported(tx_id))
             },
             TransactionServiceRequest::ImportUtxoWithStatus {


### PR DESCRIPTION
Description
---
In Tari Universe we want to import tx when view wallet instance is running. It's only possible via grpc due to exclusive file lock.

* also print out tx_id when send-one-sided completed to export the tx easily

Motivation and Context
---

How Has This Been Tested?
---
https://drive.google.com/file/d/1iV-cLxqvnTBX0QSs6lAzqg55Zn5aGOu2/view

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added the ability to import transactions into the wallet via a new gRPC method.
  - Transaction IDs of sent one-sided transactions to stealth addresses are now displayed in the console.
  - Users receive notifications and balance updates when transactions are imported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->