### PR TITLE
chore(ci): bump randomx-rs to resolve windows-x64 build issues

### DIFF
--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -279,7 +279,7 @@ jobs:
         if: ${{ ( ! startsWith(github.ref, 'refs/tags/v') ) && ( ! matrix.builds.cross ) && ( env.CARGO_CACHE ) }}
         uses: Swatinem/rust-cache@v2
         with:
-          key: ${{ matrix.builds.target }}
+          key: ${{ matrix.builds.runs-on }}-${{ matrix.builds.target }}-${{ matrix.builds.name }}
 
       - name: Install and setup cargo cross
         if: ${{ matrix.builds.cross }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1005,6 +1005,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5908,11 +5917,12 @@ dependencies = [
 
 [[package]]
 name = "randomx-rs"
-version = "1.3.2"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09c347596479c4796192e68aec20e62e31655b57753586f2b1ec320b779ef14c"
+checksum = "deaa87bef86369a9bbe6165b78343886dfb42bdb282339a4198f1b6230363e0f"
 dependencies = [
  "bitflags 1.3.2",
+ "cmake",
  "libc",
  "thiserror 1.0.69",
 ]

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -78,7 +78,7 @@ num-format = "0.4.0"
 once_cell = "1.8.0"
 prost = "0.13.3"
 rand = "0.8"
-randomx-rs = { version = "1.3", optional = true }
+randomx-rs = { version = "1.4", optional = true }
 serde = { version = "1.0.106", features = ["derive"] }
 serde_json = "1.0"
 serde_repr = "0.1.8"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -427,6 +427,10 @@ criteria = "safe-to-deploy"
 version = "4.5.0"
 criteria = "safe-to-deploy"
 
+[[exemptions.cmake]]
+version = "0.1.54"
+criteria = "safe-to-deploy"
+
 [[exemptions.colorchoice]]
 version = "1.0.3"
 criteria = "safe-to-deploy"
@@ -1720,7 +1724,7 @@ version = "0.9.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.randomx-rs]]
-version = "1.3.2"
+version = "1.4.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.rcgen]]


### PR DESCRIPTION
Description
bump randomx-rs to resolve windows-x64 build issues

Motivation and Context
Fix windows-x64 build

How Has This Been Tested?
Builds in local fork


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved caching logic in the build process to better distinguish between different runner environments and build variants.
  - Updated dependency version for enhanced stability.
  - Added new package exemption and updated existing exemption criteria for deployment safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->