### PR TITLE
feat!: vm calc height

### DIFF
--- a/applications/minotari_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/minotari_node/src/grpc/base_node_grpc_server.rs
@@ -999,7 +999,8 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
                 new_template
                     .header
                     .height
-                    .saturating_sub(new_template.header.height % 2000),
+                    .saturating_sub(new_template.header.height % 2048)
+                    .saturating_sub(64),
             )
             .await
             .map_err(|_| {
@@ -1292,7 +1293,13 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
             PowAlgorithm::RandomXM => new_block.header.merge_mining_hash().to_vec(),
         };
         let vm_key = *handler
-            .get_header(new_block.header.height.saturating_sub(new_block.header.height % 2000))
+            .get_header(
+                new_block
+                    .header
+                    .height
+                    .saturating_sub(new_block.header.height % 2048)
+                    .saturating_sub(64),
+            )
             .await
             .map_err(|_| {
                 obscure_error_if_true(
@@ -1565,7 +1572,8 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
                 new_template
                     .header
                     .height
-                    .saturating_sub(new_template.header.height % 2000),
+                    .saturating_sub(new_template.header.height % 2048)
+                    .saturating_sub(64),
             )
             .await
             .map_err(|_| {

--- a/applications/minotari_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/minotari_node/src/grpc/base_node_grpc_server.rs
@@ -76,6 +76,7 @@ use tari_core::{
         },
         transaction_key_manager::{create_memory_db_key_manager, TariKeyId, TransactionKeyManagerInterface, TxoStage},
     },
+    validation::tari_rx_vm_key_height,
 };
 use tari_p2p::{auto_update::SoftwareUpdaterHandle, services::liveness::LivenessHandle};
 use tari_utilities::{hex::Hex, message_format::MessageFormat, ByteArray};
@@ -93,7 +94,6 @@ use crate::{
     grpc_method::GrpcMethod,
     BaseNodeConfig,
 };
-
 const LOG_TARGET: &str = "minotari::base_node::grpc";
 const GET_TOKENS_IN_CIRCULATION_MAX_HEIGHTS: usize = 1_000_000;
 const GET_TOKENS_IN_CIRCULATION_PAGE_SIZE: usize = 1_000;
@@ -995,13 +995,7 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
             algo: Some(tari_rpc::PowAlgo { pow_algo: pow }),
         };
         let vm_key = *handler
-            .get_header(
-                new_template
-                    .header
-                    .height
-                    .saturating_sub(new_template.header.height % 2048)
-                    .saturating_sub(64),
-            )
+            .get_header(tari_rx_vm_key_height(new_template.header.height))
             .await
             .map_err(|_| {
                 obscure_error_if_true(
@@ -1293,13 +1287,7 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
             PowAlgorithm::RandomXM => new_block.header.merge_mining_hash().to_vec(),
         };
         let vm_key = *handler
-            .get_header(
-                new_block
-                    .header
-                    .height
-                    .saturating_sub(new_block.header.height % 2048)
-                    .saturating_sub(64),
-            )
+            .get_header(tari_rx_vm_key_height(new_block.header.height))
             .await
             .map_err(|_| {
                 obscure_error_if_true(
@@ -1568,13 +1556,7 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
             algo: Some(tari_rpc::PowAlgo { pow_algo: pow }),
         };
         let vm_key = *handler
-            .get_header(
-                new_template
-                    .header
-                    .height
-                    .saturating_sub(new_template.header.height % 2048)
-                    .saturating_sub(64),
-            )
+            .get_header(tari_rx_vm_key_height(new_template.header.height))
             .await
             .map_err(|_| {
                 obscure_error_if_true(

--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -56,7 +56,7 @@ use crate::{
         PowError,
     },
     transactions::aggregated_body::AggregateBody,
-    validation::{helpers, ValidationError},
+    validation::{helpers, tari_rx_vm_key_height, ValidationError},
 };
 
 const LOG_TARGET: &str = "c::bn::comms_interface::inbound_handler";
@@ -574,12 +574,7 @@ where B: BlockchainBackend + 'static
             PowAlgorithm::RandomXT => {
                 let vm_key = *self
                     .blockchain_db
-                    .fetch_chain_header(
-                        header
-                            .height()
-                            .saturating_sub(header.height() % 2048)
-                            .saturating_sub(64),
-                    )
+                    .fetch_chain_header(tari_rx_vm_key_height(header.height()))
                     .await?
                     .hash();
                 tari_randomx_difficulty(&new_block.header, &self.randomx_factory, &vm_key)?

--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -574,7 +574,12 @@ where B: BlockchainBackend + 'static
             PowAlgorithm::RandomXT => {
                 let vm_key = *self
                     .blockchain_db
-                    .fetch_chain_header(header.height().saturating_sub(header.height() % 2000))
+                    .fetch_chain_header(
+                        header
+                            .height()
+                            .saturating_sub(header.height() % 2048)
+                            .saturating_sub(64),
+                    )
                     .await?
                     .hash();
                 tari_randomx_difficulty(&new_block.header, &self.randomx_factory, &vm_key)?

--- a/base_layer/core/src/validation/difficulty_calculator.rs
+++ b/base_layer/core/src/validation/difficulty_calculator.rs
@@ -53,12 +53,7 @@ impl DifficultyCalculator {
         );
         let gen_hash = *self.rules.get_genesis_block().hash();
         let vm_key = *db
-            .fetch_chain_header_by_height(
-                block_header
-                    .height
-                    .saturating_sub(block_header.height % 2048)
-                    .saturating_sub(64),
-            )?
+            .fetch_chain_header_by_height(tari_rx_vm_key_height(block_header.height))?
             .hash();
         let achieved_target = check_target_difficulty(
             block_header,
@@ -70,5 +65,56 @@ impl DifficultyCalculator {
         )?;
 
         Ok(achieved_target)
+    }
+}
+
+pub fn tari_rx_vm_key_height(height: u64) -> u64 {
+    // The VM key is calculated from the block at height - (height % 2048) - 64
+    // This is to ensure that the VM key is not too far in the past
+    // and that it is not too close to the current block
+    height.saturating_sub(height % 2048).saturating_sub(64)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_tari_vm_key_calc() {
+        let height = 0;
+        let expected = 0;
+        assert_eq!(tari_rx_vm_key_height(height), expected);
+
+        let height = 1000;
+        let expected = 0;
+        assert_eq!(tari_rx_vm_key_height(height), expected);
+
+        let height = 2047;
+        let expected = 0;
+        assert_eq!(tari_rx_vm_key_height(height), expected);
+
+        let height = 2048;
+        let expected = 1984;
+        assert_eq!(tari_rx_vm_key_height(height), expected);
+
+        let height = 3048;
+        let expected = 1984;
+        assert_eq!(tari_rx_vm_key_height(height), expected);
+
+        let height = 4000;
+        let expected = 1984;
+        assert_eq!(tari_rx_vm_key_height(height), expected);
+
+        let height = 4095;
+        let expected = 1984;
+        assert_eq!(tari_rx_vm_key_height(height), expected);
+
+        let height = 4096;
+        let expected = 4032;
+        assert_eq!(tari_rx_vm_key_height(height), expected);
+
+        let height = 4097;
+        let expected = 4032;
+        assert_eq!(tari_rx_vm_key_height(height), expected);
     }
 }

--- a/base_layer/core/src/validation/difficulty_calculator.rs
+++ b/base_layer/core/src/validation/difficulty_calculator.rs
@@ -28,6 +28,9 @@ use crate::{
     validation::{helpers::check_target_difficulty, ValidationError},
 };
 
+const TARI_RX_VM_KEY_BLOCK_SWAP: u64 = 2048;
+const TARI_RX_VM_KEY_REORG_SAFETY_NUMBER: u64 = 64;
+
 #[derive(Clone)]
 pub struct DifficultyCalculator {
     pub rules: ConsensusManager,
@@ -72,7 +75,9 @@ pub fn tari_rx_vm_key_height(height: u64) -> u64 {
     // The VM key is calculated from the block at height - (height % 2048) - 64
     // This is to ensure that the VM key is not too far in the past
     // and that it is not too close to the current block
-    height.saturating_sub(height % 2048).saturating_sub(64)
+    height
+        .saturating_sub(height % TARI_RX_VM_KEY_BLOCK_SWAP)
+        .saturating_sub(TARI_RX_VM_KEY_REORG_SAFETY_NUMBER)
 }
 
 #[cfg(test)]

--- a/base_layer/core/src/validation/difficulty_calculator.rs
+++ b/base_layer/core/src/validation/difficulty_calculator.rs
@@ -72,12 +72,11 @@ impl DifficultyCalculator {
 }
 
 pub fn tari_rx_vm_key_height(height: u64) -> u64 {
-    // The VM key is calculated from the block at height - (height % 2048) - 64
-    // This is to ensure that the VM key is not too far in the past
-    // and that it is not too close to the current block
-    height
-        .saturating_sub(height % TARI_RX_VM_KEY_BLOCK_SWAP)
-        .saturating_sub(TARI_RX_VM_KEY_REORG_SAFETY_NUMBER)
+    if height <= TARI_RX_VM_KEY_BLOCK_SWAP + TARI_RX_VM_KEY_REORG_SAFETY_NUMBER {
+        0
+    } else {
+        (height - TARI_RX_VM_KEY_REORG_SAFETY_NUMBER - 1) & !(TARI_RX_VM_KEY_BLOCK_SWAP - 1)
+    }
 }
 
 #[cfg(test)]
@@ -99,27 +98,27 @@ mod test {
         assert_eq!(tari_rx_vm_key_height(height), expected);
 
         let height = 2048;
-        let expected = 1984;
+        let expected = 0;
         assert_eq!(tari_rx_vm_key_height(height), expected);
 
         let height = 3048;
-        let expected = 1984;
+        let expected = 2048;
         assert_eq!(tari_rx_vm_key_height(height), expected);
 
         let height = 4000;
-        let expected = 1984;
+        let expected = 2048;
         assert_eq!(tari_rx_vm_key_height(height), expected);
 
-        let height = 4095;
-        let expected = 1984;
+        let height = 4159;
+        let expected = 2048;
         assert_eq!(tari_rx_vm_key_height(height), expected);
 
-        let height = 4096;
-        let expected = 4032;
+        let height = 4160;
+        let expected = 2048;
         assert_eq!(tari_rx_vm_key_height(height), expected);
 
-        let height = 4097;
-        let expected = 4032;
+        let height = 4161;
+        let expected = 4096;
         assert_eq!(tari_rx_vm_key_height(height), expected);
     }
 }

--- a/base_layer/core/src/validation/difficulty_calculator.rs
+++ b/base_layer/core/src/validation/difficulty_calculator.rs
@@ -53,7 +53,12 @@ impl DifficultyCalculator {
         );
         let gen_hash = *self.rules.get_genesis_block().hash();
         let vm_key = *db
-            .fetch_chain_header_by_height(block_header.height.saturating_sub(block_header.height % 2000))?
+            .fetch_chain_header_by_height(
+                block_header
+                    .height
+                    .saturating_sub(block_header.height % 2048)
+                    .saturating_sub(64),
+            )?
             .hash();
         let achieved_target = check_target_difficulty(
             block_header,

--- a/base_layer/core/src/validation/header/header_full_validator.rs
+++ b/base_layer/core/src/validation/header/header_full_validator.rs
@@ -80,7 +80,7 @@ impl<B: BlockchainBackend> HeaderChainLinkedValidator<B> for HeaderFullValidator
         check_timestamp_ftl(header, &self.rules)?;
         check_pow_data(header)?;
         let vm_key = *db
-            .fetch_chain_header_by_height(header.height.saturating_sub(header.height % 2000))?
+            .fetch_chain_header_by_height(header.height.saturating_sub(header.height % 2048).saturating_sub(64))?
             .hash();
 
         let achieved_target = if let Some(target) = target_difficulty {

--- a/base_layer/core/src/validation/header/header_full_validator.rs
+++ b/base_layer/core/src/validation/header/header_full_validator.rs
@@ -33,6 +33,7 @@ use crate::{
     proof_of_work::{AchievedTargetDifficulty, Difficulty, PowAlgorithm, PowError},
     validation::{
         helpers::{check_header_timestamp_greater_than_median, check_target_difficulty},
+        tari_rx_vm_key_height,
         DifficultyCalculator,
         HeaderChainLinkedValidator,
         ValidationError,
@@ -80,7 +81,7 @@ impl<B: BlockchainBackend> HeaderChainLinkedValidator<B> for HeaderFullValidator
         check_timestamp_ftl(header, &self.rules)?;
         check_pow_data(header)?;
         let vm_key = *db
-            .fetch_chain_header_by_height(header.height.saturating_sub(header.height % 2048).saturating_sub(64))?
+            .fetch_chain_header_by_height(tari_rx_vm_key_height(header.height))?
             .hash();
 
         let achieved_target = if let Some(target) = target_difficulty {


### PR DESCRIPTION
Description
---
Changes the vm key header hash height to be more reorg resilient and keep the same height as monero, 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved the calculation method for selecting the reference block height used in proof-of-work and difficulty validation, enhancing consistency by introducing a new helper function with updated alignment logic.
- **Bug Fixes**
  - Enhanced block header retrieval accuracy during difficulty checks to ensure more reliable validation outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->