### PR TITLE
fix(sidechain): minor updates for PR tari-dan#1437

### DIFF
--- a/applications/minotari_app_grpc/src/conversions/sidechain_feature.rs
+++ b/applications/minotari_app_grpc/src/conversions/sidechain_feature.rs
@@ -483,8 +483,7 @@ impl TryFrom<grpc::SidechainBlockHeader> for SidechainBlockHeader {
             signature: value
                 .signature
                 .ok_or("SidechainBlockHeader signature not provided")?
-                .try_into()
-                .map_err(|_| "Invalid signature")?,
+                .try_into()?,
             metadata_hash: value.metadata_hash.try_into().map_err(|_| "Invalid metadata hash")?,
         })
     }

--- a/applications/minotari_app_grpc/src/conversions/sidechain_feature.rs
+++ b/applications/minotari_app_grpc/src/conversions/sidechain_feature.rs
@@ -517,7 +517,7 @@ impl TryFrom<grpc::CommitProofElement> for CommitProofElement {
             grpc::commit_proof_element::ProofElement::QuorumCertificate(qc) => {
                 Ok(CommitProofElement::QuorumCertificate(qc.try_into()?))
             },
-            grpc::commit_proof_element::ProofElement::DummyChain(chain) => Ok(CommitProofElement::DummyChain(
+            grpc::commit_proof_element::ProofElement::DummyChain(chain) => Ok(CommitProofElement::ChainLinks(
                 chain
                     .chain_links
                     .into_iter()
@@ -534,7 +534,7 @@ impl From<&CommitProofElement> for grpc::CommitProofElement {
             CommitProofElement::QuorumCertificate(qc) => Self {
                 proof_element: Some(grpc::commit_proof_element::ProofElement::QuorumCertificate(qc.into())),
             },
-            CommitProofElement::DummyChain(chain) => Self {
+            CommitProofElement::ChainLinks(chain) => Self {
                 proof_element: Some(grpc::commit_proof_element::ProofElement::DummyChain(grpc::DummyChain {
                     chain_links: chain.iter().map(Into::into).collect(),
                 })),

--- a/base_layer/core/src/proto/sidechain_feature.rs
+++ b/base_layer/core/src/proto/sidechain_feature.rs
@@ -471,8 +471,7 @@ impl TryFrom<proto::types::SidechainBlockHeader> for SidechainBlockHeader {
             signature: value
                 .signature
                 .ok_or("SidechainBlockHeader signature not provided")?
-                .try_into()
-                .map_err(|_| "Invalid signature")?,
+                .try_into()?,
             metadata_hash: value.metadata_hash.try_into().map_err(|_| "Invalid metadata hash")?,
         })
     }

--- a/base_layer/core/src/proto/sidechain_feature.rs
+++ b/base_layer/core/src/proto/sidechain_feature.rs
@@ -505,7 +505,7 @@ impl TryFrom<proto::types::CommitProofElement> for CommitProofElement {
             proto::types::commit_proof_element::ProofElement::QuorumCertificate(qc) => {
                 Ok(CommitProofElement::QuorumCertificate(qc.try_into()?))
             },
-            proto::types::commit_proof_element::ProofElement::DummyChain(chain) => Ok(CommitProofElement::DummyChain(
+            proto::types::commit_proof_element::ProofElement::DummyChain(chain) => Ok(CommitProofElement::ChainLinks(
                 chain
                     .chain_links
                     .into_iter()
@@ -524,7 +524,7 @@ impl From<&CommitProofElement> for proto::types::CommitProofElement {
                     qc.into(),
                 )),
             },
-            CommitProofElement::DummyChain(chain) => Self {
+            CommitProofElement::ChainLinks(chain) => Self {
                 proof_element: Some(proto::types::commit_proof_element::ProofElement::DummyChain(
                     proto::types::DummyChain {
                         chain_links: chain.iter().map(Into::into).collect(),

--- a/base_layer/sidechain/src/commit_proof.rs
+++ b/base_layer/sidechain/src/commit_proof.rs
@@ -232,17 +232,6 @@ impl QuorumCertificate {
             .finalize()
             .into()
     }
-
-    pub fn calculate_id(&self, epoch: u64) -> FixedHash {
-        layer2::quorum_certificate_hasher()
-            .chain(&epoch)
-            .chain(&self.header_hash)
-            .chain(&self.parent_id)
-            .chain(&self.signatures)
-            .chain(&self.decision)
-            .finalize()
-            .into()
-    }
 }
 
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
@@ -316,10 +305,9 @@ impl ValidatorQcSignature {
             return false;
         };
 
-        let message = layer2::vote_signature_hasher()
-            .chain(block_id)
-            .chain(&decision)
-            .finalize();
+        let fields = ProposalCertificateSignatureFields { block_id, decision };
+
+        let message = layer2::proposal_vote_signature_hasher().chain(&fields).finalize();
         signature.verify(&public_key, message)
     }
 
@@ -330,6 +318,12 @@ impl ValidatorQcSignature {
     pub fn signature(&self) -> &ValidatorBlockSignature {
         &self.signature
     }
+}
+
+#[derive(Debug, BorshSerialize)]
+pub struct ProposalCertificateSignatureFields<'a> {
+    pub block_id: &'a FixedHash,
+    pub decision: QuorumDecision,
 }
 
 #[derive(Debug, BorshSerialize)]

--- a/base_layer/sidechain/src/commit_proof.rs
+++ b/base_layer/sidechain/src/commit_proof.rs
@@ -150,7 +150,7 @@ impl SidechainBlockCommitProof {
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, BorshSerialize, BorshDeserialize)]
 pub enum CommitProofElement {
     QuorumCertificate(QuorumCertificate),
-    DummyChain(Vec<ChainLink>),
+    ChainLinks(Vec<ChainLink>),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, BorshSerialize, BorshDeserialize)]

--- a/base_layer/sidechain/src/validations.rs
+++ b/base_layer/sidechain/src/validations.rs
@@ -189,7 +189,7 @@ fn validate_qc(
 
         if !sig.verify(&block_id, quorum_decision) {
             return Err(SidechainProofValidationError::InvalidProof {
-                details: "Invalid signature".to_string(),
+                details: format!("Invalid signature for QC for block ID {block_id}",),
             });
         }
     }

--- a/base_layer/sidechain/src/validations.rs
+++ b/base_layer/sidechain/src/validations.rs
@@ -89,7 +89,7 @@ pub fn check_proof_elements(
                             ),
                         });
                     }
-                    expected = block_id;
+                    expected = link.parent_id;
                     last_parent = Some(&link.parent_id);
                 }
             },

--- a/base_layer/sidechain/src/validations.rs
+++ b/base_layer/sidechain/src/validations.rs
@@ -57,7 +57,7 @@ pub fn check_proof_elements(
                 last_parent = Some(&qc.parent_id);
                 last_justify = Some(justifies);
             },
-            CommitProofElement::DummyChain(chain) => {
+            CommitProofElement::ChainLinks(chain) => {
                 if proven_3_chain != 3 {
                     return Err(SidechainProofValidationError::InvalidProof {
                         details: format!(
@@ -136,7 +136,7 @@ pub fn check_proof_elements_num_qcs(
     if num_qcs < expected_len {
         return Err(SidechainProofValidationError::InvalidProof {
             details: format!(
-                "Expected at least {} proof elements, but got {}",
+                "Expected at least {} QC proof elements, but got {}",
                 expected_len,
                 proof_elems.len()
             ),

--- a/hashing/src/layer2.rs
+++ b/hashing/src/layer2.rs
@@ -23,7 +23,7 @@ pub fn tari_hasher32<M: DomainSeparation>(label: &'static str) -> TariDomainHash
     TariDomainHasher::<M, U32>::new_with_label(label)
 }
 
-fn tari_consensus_hasher(label: &'static str) -> TariConsensusHasher {
+pub fn tari_consensus_hasher(label: &'static str) -> TariConsensusHasher {
     TariConsensusHasher::new_with_label(label)
 }
 
@@ -43,12 +43,12 @@ pub fn command_hasher() -> TariConsensusHasher {
     tari_consensus_hasher("Command")
 }
 
-pub fn quorum_certificate_hasher() -> TariConsensusHasher {
-    tari_consensus_hasher("QuorumCertificate")
+pub fn proposal_vote_signature_hasher() -> TariConsensusHasher {
+    tari_consensus_hasher("VoteSignature")
 }
 
-pub fn vote_signature_hasher() -> TariConsensusHasher {
-    tari_consensus_hasher("VoteSignature")
+pub fn timeout_vote_signature_hasher() -> TariConsensusHasher {
+    tari_consensus_hasher("TimeoutVoteSignature")
 }
 
 pub type ValidatorNodeBmtHasherBlake2b = DomainSeparatedHasher<Blake2b<U32>, ValidatorNodeMerkleHashDomain>;


### PR DESCRIPTION
Description
---
Make `tari_consensus_hasher` public
Define QC signature fields
Remove QC ID calculation (not needed on L1)
Fix bug in chain link verification

Motivation and Context
---
https://github.com/tari-project/tari-dan/pull/1437

How Has This Been Tested?
---

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new functions for proposal and timeout vote signature hashing.
	- Improved error messages for quorum certificate signature verification, now including specific block IDs.

- **Refactor**
	- Updated signature verification logic for quorum certificates, changing how messages are constructed and hashed.
	- Simplified error handling by allowing original errors to propagate instead of mapping to generic messages.

- **Removals**
	- Removed the method for calculating quorum certificate IDs.
	- Removed legacy hasher functions related to quorum certificates and vote signatures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->