### PR TITLE
feat: prioritize pending txs in find_completed_transactions..

### DIFF
--- a/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
@@ -1093,6 +1093,12 @@ impl TransactionBackend for TransactionServiceSqliteDatabase {
             query = query.filter(completed_transactions::mined_height.eq(height as i64));
         }
 
+        // Add ordering to prioritize mined_height = 0, then descending mined_height
+        query = query.order((
+            completed_transactions::mined_height.eq(0).desc(),
+            completed_transactions::mined_height.desc(),
+        ));
+
         query
             .load::<CompletedTransactionSql>(&mut conn)?
             .into_iter()


### PR DESCRIPTION
Description
---
Records with `mined_height = 0` are at the top, followed by other records sorted in descending order of `mined_height`:

**Example:**
For the following `mined_height` values in the database:
```
[531, 0, 24, 0, 9213, 8321, 0, 9122, 5]
```
The query will return:
```
[0, 0, 0, 9213, 9122, 8321, 531, 24, 5]
```

Motivation and Context
---

How Has This Been Tested?
---

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
