### PR TITLE
chore: deprecate interactive send

### DIFF
--- a/applications/minotari_app_grpc/proto/wallet.proto
+++ b/applications/minotari_app_grpc/proto/wallet.proto
@@ -1107,9 +1107,9 @@ message PaymentRecipient {
   uint64 fee_per_gram = 3;
   enum PaymentType {
     // Default Mimblewimble-style transaction.
-    STANDARD_MIMBLEWIMBLE = 0;
+    STANDARD_MIMBLEWIMBLE = 0 [deprecated = true] ;
     // One-sided transaction (receiver not required to participate).
-    ONE_SIDED = 1;
+    ONE_SIDED = 1 [deprecated = true] ;
     // One-sided stealth address (adds privacy by hiding destination).
     ONE_SIDED_TO_STEALTH_ADDRESS = 2;
   }


### PR DESCRIPTION
Description
---
Add depricate warning for grpc interactive send

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Deprecations**
  - Marked two payment types as deprecated in the payment recipient options. Existing integrations using these types should plan for future updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->