### PR TITLE
fix: exclude coinbases from fee calc

### DIFF
--- a/applications/minotari_node/src/grpc/blocks.rs
+++ b/applications/minotari_node/src/grpc/blocks.rs
@@ -77,6 +77,7 @@ pub fn block_fees(block: &HistoricalBlock) -> u64 {
     let body = &block.block().body;
     body.kernels()
         .iter()
+        .filter(|k| !k.is_coinbase())
         .map(|k| k.fee.into())
         .collect::<Vec<u64>>()
         .iter()


### PR DESCRIPTION
Description
---
dont include the coinbase in the fee calcs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected block fee calculations to exclude coinbase transactions, ensuring only non-coinbase fees are included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->