### PR TITLE
test: add maximum grpc block cucumber test

### DIFF
--- a/base_layer/core/src/consensus/consensus_constants.rs
+++ b/base_layer/core/src/consensus/consensus_constants.rs
@@ -165,6 +165,8 @@ pub const MAINNET_PRE_MINE_VALUE: MicroMinotari = MicroMinotari((21_000_000_000 
 // The target time used by the difficulty adjustment algorithms, their target time is the target block interval * PoW
 // algorithm count
 impl ConsensusConstants {
+    const MAINNET_MAX_WEIGHT_V1: u64 = 90_000;
+
     /// The height at which these constants become effective
     pub fn effective_from_height(&self) -> u64 {
         self.effective_from_height
@@ -391,7 +393,7 @@ impl ConsensusConstants {
             valid_blockchain_version_range: 0..=0,
             future_time_limit: 540,
             difficulty_block_window,
-            max_block_transaction_weight: 19500,
+            max_block_transaction_weight: ConsensusConstants::MAINNET_MAX_WEIGHT_V1,
             max_block_coinbase_count: 1000,
             median_timestamp_count: 11,
             emission_initial: 18_462_816_327 * uT,
@@ -717,7 +719,7 @@ impl ConsensusConstants {
             valid_blockchain_version_range: 0..=0,
             future_time_limit: 540,
             difficulty_block_window,
-            max_block_transaction_weight: 90_000,
+            max_block_transaction_weight: ConsensusConstants::MAINNET_MAX_WEIGHT_V1,
             max_block_coinbase_count: 1000,
             median_timestamp_count: 11,
             emission_initial: INITIAL_EMISSION,

--- a/integration_tests/tests/features/BlockTemplate.feature
+++ b/integration_tests/tests/features/BlockTemplate.feature
@@ -14,5 +14,92 @@ Scenario: Verify UTXO and kernel MMR size in header
     Scenario: Verify gprc can create block with more than 1 coinbase
         Given I have a seed node SEED_A
         When I have 1 base nodes connected to all seed nodes
-        Then generate a block with 2 coinbases from node SEED_A
-        Then generate a block with 2 coinbases as a single request from node SEED_A
+        Then generate a block BLOCK_02 with 2 coinbases from node SEED_A
+        Then generate a block BLOCK_02 with 2 coinbases as a single request from node SEED_A
+
+    @critical
+    Scenario: Verify grpc can create full block with maximum number of coinbases
+        Given I have 1 seed nodes
+        When I have a base node NODE_01 connected to all seed nodes
+        When I have wallet WALLET_DEFAULT connected to all seed nodes
+        When I have wallet WALLET_01 connected to all seed nodes
+        When I have wallet WALLET_02 connected to all seed nodes
+        When I have wallet WALLET_03 connected to all seed nodes
+        When I have wallet WALLET_04 connected to all seed nodes
+        When I have wallet WALLET_05 connected to all seed nodes
+        When I have wallet WALLET_06 connected to all seed nodes
+        When I have wallet WALLET_07 connected to all seed nodes
+        When I have wallet WALLET_08 connected to all seed nodes
+        When I have wallet WALLET_09 connected to all seed nodes
+        When I have wallet WALLET_10 connected to all seed nodes
+        When I have wallet WALLET_11 connected to all seed nodes
+        When I have wallet WALLET_12 connected to all seed nodes
+        When I have mining node MINER connected to base node NODE_01 and wallet WALLET_DEFAULT
+        When mining node MINER mines 1 blocks
+        Then all nodes are at height 1
+
+        Then I generate a block BLOCK_02 with 1000 coinbases from node NODE_01 for wallet WALLET_01
+        Then all nodes are at height 2
+        Then I generate a block BLOCK_03 with 1000 coinbases from node NODE_01 for wallet WALLET_02
+        Then all nodes are at height 3
+        Then I generate a block BLOCK_04 with 1000 coinbases from node NODE_01 for wallet WALLET_03
+        Then all nodes are at height 4
+        Then I generate a block BLOCK_05 with 1000 coinbases from node NODE_01 for wallet WALLET_04
+        Then all nodes are at height 5
+        Then I generate a block BLOCK_06 with 1000 coinbases from node NODE_01 for wallet WALLET_05
+        Then all nodes are at height 6
+        Then I generate a block BLOCK_07 with 1000 coinbases from node NODE_01 for wallet WALLET_06
+        Then all nodes are at height 7
+        Then I generate a block BLOCK_08 with 1000 coinbases from node NODE_01 for wallet WALLET_07
+        Then all nodes are at height 8
+        Then I generate a block BLOCK_09 with 1000 coinbases from node NODE_01 for wallet WALLET_08
+        Then all nodes are at height 9
+        Then I generate a block BLOCK_10 with 1000 coinbases from node NODE_01 for wallet WALLET_09
+        Then all nodes are at height 10
+        Then I generate a block BLOCK_11 with 1000 coinbases from node NODE_01 for wallet WALLET_10
+        Then all nodes are at height 11
+        Then I generate a block BLOCK_12 with 1000 coinbases from node NODE_01 for wallet WALLET_11
+        Then all nodes are at height 12
+        Then I generate a block BLOCK_13 with 1000 coinbases from node NODE_01 for wallet WALLET_12
+        Then all nodes are at height 13
+
+        When mining node MINER mines 1 blocks
+        Then all nodes are at height 14
+        When mining node MINER mines 1 blocks
+        Then all nodes are at height 15
+        When mining node MINER mines 1 blocks
+        Then all nodes are at height 16
+        When mining node MINER mines 1 blocks
+        Then all nodes are at height 17
+
+        When I wait for wallet WALLET_01 to have at least 18462050000 uT
+        When I wait for wallet WALLET_02 to have at least 18462050000 uT
+        When I wait for wallet WALLET_03 to have at least 18462050000 uT
+        When I wait for wallet WALLET_04 to have at least 18462050000 uT
+        When I wait for wallet WALLET_05 to have at least 18462050000 uT
+        When I wait for wallet WALLET_06 to have at least 18462050000 uT
+        When I wait for wallet WALLET_07 to have at least 18462050000 uT
+        When I wait for wallet WALLET_08 to have at least 18462050000 uT
+        When I wait for wallet WALLET_09 to have at least 18462050000 uT
+        When I wait for wallet WALLET_10 to have at least 18462050000 uT
+        When I wait for wallet WALLET_11 to have at least 18462050000 uT
+        When I wait for wallet WALLET_12 to have at least 18462050000 uT
+
+        Then I send 18462000000 uT from wallet WALLET_01 to wallet WALLET_DEFAULT at fee 1
+        Then I send 18462000000 uT from wallet WALLET_02 to wallet WALLET_DEFAULT at fee 1
+        Then I send 18462000000 uT from wallet WALLET_03 to wallet WALLET_DEFAULT at fee 1
+        Then I send 18462000000 uT from wallet WALLET_04 to wallet WALLET_DEFAULT at fee 1
+        Then I send 18462000000 uT from wallet WALLET_05 to wallet WALLET_DEFAULT at fee 1
+        Then I send 18462000000 uT from wallet WALLET_06 to wallet WALLET_DEFAULT at fee 1
+        Then I send 18462000000 uT from wallet WALLET_07 to wallet WALLET_DEFAULT at fee 1
+        Then I send 18462000000 uT from wallet WALLET_08 to wallet WALLET_DEFAULT at fee 1
+        Then I send 18462000000 uT from wallet WALLET_09 to wallet WALLET_DEFAULT at fee 1
+        Then I send 18462000000 uT from wallet WALLET_10 to wallet WALLET_DEFAULT at fee 1
+        Then I send 18462000000 uT from wallet WALLET_11 to wallet WALLET_DEFAULT at fee 1
+        Then I send 18462000000 uT from wallet WALLET_12 to wallet WALLET_DEFAULT at fee 1
+
+        # Mempool now has 12 transactions, each with 1000 coinbases as inputs, so we can create a big block
+        Then I generate a block BLOCK_18 with 1000 coinbases from node NODE_01 for wallet WALLET_DEFAULT
+        Then all nodes are at height 18
+
+        Then block BLOCK_18 has serialized size at least 7000000 bytes

--- a/integration_tests/tests/steps/node_steps.rs
+++ b/integration_tests/tests/steps/node_steps.rs
@@ -42,7 +42,11 @@ use minotari_app_grpc::tari_rpc::{
 use minotari_node::BaseNodeConfig;
 use minotari_wallet_grpc_client::grpc::{Empty, GetIdentityRequest};
 use tari_common_types::tari_address::TariAddress;
-use tari_core::{blocks::Block, transactions::aggregated_body::AggregateBody};
+use tari_core::{
+    blocks::Block,
+    borsh::SerializedSize,
+    transactions::{aggregated_body::AggregateBody, weight::TransactionWeight},
+};
 use tari_integration_tests::{
     base_node_process::{spawn_base_node, spawn_base_node_with_config},
     get_peer_addresses,
@@ -731,6 +735,110 @@ async fn no_meddling_with_data(world: &mut TariWorld, node: String) {
             e.message()
         ),
     }
+}
+
+#[then(expr = "I generate a block {word} with {int} coinbases from node {word} for wallet {word}")]
+async fn generate_block_with_many_coinbases(
+    world: &mut TariWorld,
+    block_name: String,
+    number_of_coinbases: u64,
+    node_name: String,
+    wallet_name: String,
+) {
+    let mut client = world.get_node_client(&node_name).await.unwrap();
+    let wallet_address = world.get_wallet_address(&wallet_name).await.unwrap();
+
+    let template_req = NewBlockTemplateRequest {
+        algo: Some(PowAlgo {
+            pow_algo: PowAlgos::Sha3x.into(),
+        }),
+        max_weight: 0,
+    };
+    let template_response = client.get_new_block_template(template_req).await.unwrap().into_inner();
+    let miner_data = template_response.miner_data.unwrap();
+
+    let mut coinbases = Vec::with_capacity(usize::try_from(number_of_coinbases).unwrap());
+    let mut value = 0;
+    for i in 0..number_of_coinbases {
+        let share_value = if i == number_of_coinbases - 1 {
+            miner_data.reward - value
+        } else {
+            miner_data.reward / number_of_coinbases
+        };
+        coinbases.push(NewBlockCoinbase {
+            address: wallet_address.clone(),
+            value: share_value,
+            stealth_payment: true,
+            revealed_value_proof: true,
+            coinbase_extra: Vec::new(),
+        });
+        value += share_value;
+    }
+
+    let template_req = GetNewBlockTemplateWithCoinbasesRequest {
+        algo: Some(PowAlgo {
+            pow_algo: PowAlgos::Sha3x.into(),
+        }),
+        max_weight: 0,
+        coinbases,
+    };
+
+    let template_response = client
+        .get_new_block_template_with_coinbases(template_req)
+        .await
+        .unwrap()
+        .into_inner();
+    let new_block = template_response.block.clone().unwrap();
+
+    let block = Block::try_from(template_response.block.unwrap()).unwrap();
+    let coinbase_outputs = block
+        .body
+        .outputs()
+        .iter()
+        .filter(|o| o.is_coinbase())
+        .cloned()
+        .collect::<Vec<_>>();
+    let outputs = block
+        .body
+        .outputs()
+        .iter()
+        .filter(|o| !o.is_coinbase())
+        .cloned()
+        .collect::<Vec<_>>();
+    let block_size = block.get_serialized_size().unwrap();
+
+    println!(
+        "Custom block: {}, size: {} bytes, coinbases: {}, kernels: {}, outputs: {}, inputs: {}, weight: {}",
+        block.header.height,
+        block_size,
+        coinbase_outputs.len(),
+        block.body.kernels().len(),
+        outputs.len(),
+        block.body.inputs().len(),
+        block.body.calculate_weight(&TransactionWeight::latest()).unwrap(),
+    );
+
+    assert_eq!(coinbase_outputs.len() as u64, number_of_coinbases);
+
+    match client.submit_block(new_block).await {
+        Ok(_) => (),
+        Err(e) => panic!("The block should have been valid, {}", e),
+    }
+
+    world.blocks.insert(block_name, block);
+}
+
+#[then(expr = "block {word} has serialized size at least {int} bytes")]
+async fn block_has_serialized_size_greater_than(world: &mut TariWorld, block: String, size: u64) {
+    let block = world.blocks.get(&block).unwrap();
+    assert!(
+        u64::try_from(block.get_serialized_size().unwrap()).unwrap() >= size,
+        "Block {} with weight {} has serialized size of {} which is not at least {}",
+        block.header.height,
+        block.body.calculate_weight(&TransactionWeight::latest()).unwrap(),
+        block.get_serialized_size().unwrap(),
+        size,
+    );
 }
 
 #[then(expr = "generate a block with 2 coinbases from node {word}")]


### PR DESCRIPTION
Description
---
Added a cucumber integration test to verify that a maximum block can be created via grpc and mined. For this, the maximum block weight of localnet has been adjusted to match that of mainnet.

Motivation and Context
---
A user reported that their client could not get a template via grpc method `GetNewBlockTemplateWithCoinbases` due to `Received message larger than max (4199623 vs. 4194304)`,

How Has This Been Tested?
---
New cucumber test added:
- `Scenario: Verify grpc can create full block with maximum number of coinbases`

```
Transaction with amount 18462000000 from WALLET_12 to WALLET_DEFAULT at fee 1 succeeded
Custom block: 18, size: 7167912 bytes, coinbases: 1000, kernels: 12, outputs: 22, inputs: 11000, weight: 89518
```

What process can a PR reviewer use to test or verify this change?
---
- Code review
- `cargo +nightly-2024-07-07 test --release --test cucumber -- --name "Verify grpc can create full block with maximum number of coinbases"`

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added integration tests to verify block creation with a large number of coinbase outputs and to ensure support for large block sizes.
- **Chores**
  - Centralized the maximum block transaction weight value for improved consistency across network configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->