### PR TITLE
fix: mismatched tms db state

### DIFF
--- a/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
@@ -1829,6 +1829,18 @@ impl CompletedTransactionSql {
             .load::<CompletedTransactionSql>(conn)?)
     }
 
+    /// Fetches completed transactions that have a mismatched mined status.
+    /// 
+    /// This method finds transactions that have been marked as confirmed or unconfirmed
+    /// but are missing their mined height information, indicating a mismatch between
+    /// the transaction status and mining data.
+    ///
+    /// # Arguments
+    /// * `cancelled` - Whether to fetch cancelled (true) or non-cancelled (false) transactions
+    /// * `conn` - Database connection
+    ///
+    /// # Returns
+    /// Vector of transactions with mismatched mined status
     pub fn fetch_transactions_with_mismatched_mined_status(
         cancelled: bool,
         conn: &mut SqliteConnection,
@@ -1843,7 +1855,7 @@ impl CompletedTransactionSql {
         Ok(query
             .filter(
                 completed_transactions::status
-                    // Filter out imported or scanned transactions
+                    // Include transactions with confirmed/unconfirmed statuses that may have mismatched mined data
                     .eq(TransactionStatus::Imported as i32)
                     .or(completed_transactions::status.eq(TransactionStatus::OneSidedUnconfirmed as i32))
                     .or(completed_transactions::status.eq(TransactionStatus::OneSidedConfirmed as i32))

--- a/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
@@ -1045,6 +1045,15 @@ impl TransactionBackend for TransactionServiceSqliteDatabase {
         })
         .collect::<Result<Vec<CompletedTransaction>, TransactionStorageError>>()?;
         coinbases.append(&mut one_sided);
+
+        let mut mismatched_tx =
+            CompletedTransactionSql::fetch_transactions_with_mismatched_mined_status(false, &mut conn)?
+                .into_iter()
+                .map(|ct: CompletedTransactionSql| {
+                    CompletedTransaction::try_from(ct, &cipher).map_err(TransactionStorageError::from)
+                })
+                .collect::<Result<Vec<CompletedTransaction>, TransactionStorageError>>()?;
+        coinbases.append(&mut mismatched_tx);
         Ok(coinbases)
     }
 
@@ -1817,6 +1826,31 @@ impl CompletedTransactionSql {
         Ok(query
             .filter(completed_transactions::status.eq(status as i32))
             .filter(completed_transactions::mined_height.ge(block_height))
+            .load::<CompletedTransactionSql>(conn)?)
+    }
+
+    pub fn fetch_transactions_with_mismatched_mined_status(
+        cancelled: bool,
+        conn: &mut SqliteConnection,
+    ) -> Result<Vec<CompletedTransactionSql>, TransactionStorageError> {
+        let mut query = completed_transactions::table.into_boxed();
+        query = if cancelled {
+            query.filter(completed_transactions::cancelled.is_not_null())
+        } else {
+            query.filter(completed_transactions::cancelled.is_null())
+        };
+
+        Ok(query
+            .filter(
+                completed_transactions::status
+                    // Filter out imported or scanned transactions
+                    .eq(TransactionStatus::Imported as i32)
+                    .or(completed_transactions::status.eq(TransactionStatus::OneSidedUnconfirmed as i32))
+                    .or(completed_transactions::status.eq(TransactionStatus::OneSidedConfirmed as i32))
+                    .or(completed_transactions::status.eq(TransactionStatus::CoinbaseUnconfirmed as i32))
+                    .or(completed_transactions::status.eq(TransactionStatus::CoinbaseConfirmed as i32)),
+            )
+            .filter(completed_transactions::mined_height.eq::<Option<i64>>(None))
             .load::<CompletedTransactionSql>(conn)?)
     }
 

--- a/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
@@ -1830,7 +1830,7 @@ impl CompletedTransactionSql {
     }
 
     /// Fetches completed transactions that have a mismatched mined status.
-    /// 
+    ///
     /// This method finds transactions that have been marked as confirmed or unconfirmed
     /// but are missing their mined height information, indicating a mismatch between
     /// the transaction status and mining data.


### PR DESCRIPTION
Description
---
Somehow the TMS db for completed transactions loses its mined height, but keeps its mined_confirmed status. The outputs are correctly marked with mined_heights in the OMS. 
This tries to correct the fields and update them 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection and retrieval of transactions with mismatched mined status, ensuring more accurate reporting of unconfirmed transactions in the wallet.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->