### PR TITLE
fix!: update target time

### DIFF
--- a/base_layer/core/src/chain_storage/target_difficulties.rs
+++ b/base_layer/core/src/chain_storage/target_difficulties.rs
@@ -59,10 +59,10 @@ impl TargetDifficulties {
             if let std::collections::hash_map::Entry::Vacant(e) = self.algos.entry(algo) {
                 let target_difficulty_window = consensus_rules.new_target_difficulty(algo, height)?;
                 e.insert(target_difficulty_window);
+            } else if let Some(target_diff) = self.algos.get_mut(&algo) {
+                target_diff.update_target_time(consensus_constants.pow_target_block_interval(algo))?
             } else {
-                if let Some(target_diff) = self.algos.get_mut(&algo) {
-                    target_diff.update_target_time(consensus_constants.pow_target_block_interval(algo))?
-                }
+                // clippy, this else should never be hit
             }
         }
         Ok(())

--- a/base_layer/core/src/chain_storage/target_difficulties.rs
+++ b/base_layer/core/src/chain_storage/target_difficulties.rs
@@ -47,9 +47,8 @@ impl TargetDifficulties {
     }
 
     pub fn update_algos(&mut self, consensus_rules: &ConsensusManager, height: u64) -> Result<(), String> {
-        let permitted_algos = consensus_rules
-            .consensus_constants(height)
-            .current_permitted_pow_algos();
+        let consensus_constants = consensus_rules.consensus_constants(height);
+        let permitted_algos = consensus_constants.current_permitted_pow_algos();
         let current_keys: Vec<PowAlgorithm> = self.algos.keys().copied().collect();
         for algo in current_keys {
             if !permitted_algos.contains(&algo) {
@@ -60,6 +59,10 @@ impl TargetDifficulties {
             if let std::collections::hash_map::Entry::Vacant(e) = self.algos.entry(algo) {
                 let target_difficulty_window = consensus_rules.new_target_difficulty(algo, height)?;
                 e.insert(target_difficulty_window);
+            } else {
+                if let Some(target_diff) = self.algos.get_mut(&algo) {
+                    target_diff.update_target_time(consensus_constants.pow_target_block_interval(algo))?
+                }
             }
         }
         Ok(())

--- a/base_layer/core/src/proof_of_work/lwma_diff.rs
+++ b/base_layer/core/src/proof_of_work/lwma_diff.rs
@@ -176,6 +176,26 @@ impl LinearWeightedMovingAverage {
         }
         self.target_difficulties.push_back((timestamp, target_difficulty));
     }
+
+    pub fn update_target_time(&mut self, target_time: u64) -> Result<(), String> {
+        if target_time == 0 {
+            return Err(
+                "LinearWeightedMovingAverage::update_target_time(...) expected `target_time` to be greater than 0, \
+                 but 0 was given"
+                    .into(),
+            );
+        }
+        if target_time.checked_mul(LWMA_MAX_BLOCK_TIME_RATIO).is_none() {
+            return Err(format!(
+                "LinearWeightedMovingAverage::update_target_time(...) expected `target_time` to be at least {} times \
+                 smaller than `u64::MAX`",
+                LWMA_MAX_BLOCK_TIME_RATIO,
+            ));
+        }
+        self.target_time = u128::from(target_time);
+        self.max_block_time = target_time * LWMA_MAX_BLOCK_TIME_RATIO;
+        Ok(())
+    }
 }
 
 impl DifficultyAdjustment for LinearWeightedMovingAverage {

--- a/base_layer/core/src/proof_of_work/target_difficulty_window.rs
+++ b/base_layer/core/src/proof_of_work/target_difficulty_window.rs
@@ -76,6 +76,10 @@ impl TargetDifficultyWindow {
         let difficulty = self.lwma.get_difficulty().unwrap_or(min);
         cmp::max(min, cmp::min(max, difficulty))
     }
+
+    pub fn update_target_time(&mut self, target_time: u64) -> Result<(), String> {
+        self.lwma.update_target_time(target_time)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Description
---
This updates the target time inside the lwma if the consensus constants change
During sync, the consensus constants need to be updated on the block height that is currently correct. 
The difficulties for Sha3x and RxM need to be calculated using a target time of 240 secs up to block 14_999, but on block 15_000 they need to ber calculated using a target time of 360. The previous difficulties are still correctly calculated, as they are still targeting a time of 240. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to update the target block interval for supported algorithms dynamically.
  - Improved validation and error handling when updating target block times.

- **Bug Fixes**
  - Ensured algorithms that are no longer permitted are correctly removed from the active set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->