### PR TITLE
feat: get_all_completed_transactions bitflag status filtering

### DIFF
--- a/applications/minotari_app_grpc/proto/wallet.proto
+++ b/applications/minotari_app_grpc/proto/wallet.proto
@@ -1426,6 +1426,7 @@ message ImportTransactionsResponse {
 message GetAllCompletedTransactionsRequest {
   uint64 offset = 1;
   uint64 limit = 2;
+  uint32 status_bitflag = 3;
 }
 
 message GetAllCompletedTransactionsResponse {

--- a/applications/minotari_app_grpc/proto/wallet.proto
+++ b/applications/minotari_app_grpc/proto/wallet.proto
@@ -1424,9 +1424,9 @@ message ImportTransactionsResponse {
 }
 
 message GetAllCompletedTransactionsRequest {
-  uint32 offset = 1;
-  uint32 limit = 2;
-  uint32 status_bitflag = 3;
+  uint64 offset = 1;
+  uint64 limit = 2;
+  uint64 status_bitflag = 3;
 }
 
 message GetAllCompletedTransactionsResponse {

--- a/applications/minotari_app_grpc/proto/wallet.proto
+++ b/applications/minotari_app_grpc/proto/wallet.proto
@@ -1424,8 +1424,8 @@ message ImportTransactionsResponse {
 }
 
 message GetAllCompletedTransactionsRequest {
-  uint64 offset = 1;
-  uint64 limit = 2;
+  uint32 offset = 1;
+  uint32 limit = 2;
   uint32 status_bitflag = 3;
 }
 

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -1202,6 +1202,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
         };
         let transactions = completed_transactions
             .into_iter()
+            .filter(|tx| req.status_bitflag == 0 || (req.status_bitflag & (1 << (tx.status.clone() as u32))) != 0)
             .skip(offset)
             .take(limit)
             .map(|txn| {


### PR DESCRIPTION
Description
---
* return all txs when 0 bitflag passes
* return filtered txs by passed bitflag

Motivation and Context
---

How Has This Been Tested?
---
locally, using nodejs client:
```{
  transactions: [
    {
      input_commitments: [],
      output_commitments: [Array],
      tx_id: '486069054555219532',
      source_address: <Buffer 00 01 e4 07 de be 8a 2b 22 25 3b 58 e5 b5 06 61 2c de fa bf 54 1a b2 c9 4a f0 32 f5 81 21 fb 9e 38 03 36 f8 71 b4 cc c3 22 ba 79 7e d0 78 1c ef 03 2e ... 17 more bytes>,
      dest_address: <Buffer 00 01 c2 d6 4e 45 6c 1b 85 4e ed be ed 6c 47 b0 da 70 e9 a0 dd f7 7f 5e 42 f9 b4 b4 0d 2c 1d eb cf 33 3a bd b9 35 e5 2d 35 6a 3c 72 01 64 c6 b6 40 af ... 17 more bytes>,
      status: 'TRANSACTION_STATUS_ONE_SIDED_CONFIRMED',
      direction: 'TRANSACTION_DIRECTION_INBOUND',
      amount: '20000',
      fee: '0',
      is_cancelled: false,
      excess_sig: <Buffer 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00>,
      timestamp: '1748606772',
      raw_payment_id: <Buffer 03 20 4e 00 00 00 00 00 00 00 00 00 05 80 00 01 e4 07 de be 8a 2b 22 25 3b 58 e5 b5 06 61 2c de fa bf 54 1a b2 c9 4a f0 32 f5 81 21 fb 9e 38 03 36 f8 ... 35 more bytes>,
      mined_in_block_height: '17813',
      user_payment_id: <Buffer 4c 61 6c 61>
    },
    {
      input_commitments: [],
      output_commitments: [Array],
      tx_id: '8663099122238597301',
      source_address: <Buffer 00 01 e4 07 de be 8a 2b 22 25 3b 58 e5 b5 06 61 2c de fa bf 54 1a b2 c9 4a f0 32 f5 81 21 fb 9e 38 03 36 f8 71 b4 cc c3 22 ba 79 7e d0 78 1c ef 03 2e ... 17 more bytes>,
      dest_address: <Buffer 00 01 c2 d6 4e 45 6c 1b 85 4e ed be ed 6c 47 b0 da 70 e9 a0 dd f7 7f 5e 42 f9 b4 b4 0d 2c 1d eb cf 33 3a bd b9 35 e5 2d 35 6a 3c 72 01 64 c6 b6 40 af ... 17 more bytes>,
      status: 'TRANSACTION_STATUS_ONE_SIDED_CONFIRMED',
      direction: 'TRANSACTION_DIRECTION_INBOUND',
      amount: '20000',
      fee: '0',
      is_cancelled: false,
      excess_sig: <Buffer 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00>,
      timestamp: '1748605941',
      raw_payment_id: <Buffer 03 20 4e 00 00 00 00 00 00 00 00 00 05 80 00 01 e4 07 de be 8a 2b 22 25 3b 58 e5 b5 06 61 2c de fa bf 54 1a b2 c9 4a f0 32 f5 81 21 fb 9e 38 03 36 f8 ... 34 more bytes>,
      mined_in_block_height: '17808',
      user_payment_id: <Buffer 54 23 32>
    },
    ...
```


What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for filtering completed transactions by status using a bitflag when retrieving all completed transactions via gRPC. This allows users to more precisely select which transaction statuses to view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->