### PR TITLE
fix: don't ban peers for invalid peer data

### DIFF
--- a/base_layer/core/src/base_node/state_machine_service/states/listening.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/listening.rs
@@ -224,14 +224,12 @@ impl Listening {
                 info!(target: LOG_TARGET, "[BN SM LISTENING] Bootstrap not complete - setting UI to show bootstrap phase 0/{}", shared.config.blockchain_sync_config.num_initial_sync_rounds_seed_bootstrap());
             };
 
-        info!(target: LOG_TARGET, "here");
             // Ensure other fields are also current
             current_listening_info.synced = self.is_synced;
             current_listening_info.initial_delay_connected_count = self.initial_delay_count;
             shared.set_state_info(StateInfo::Listening(current_listening_info));
         }
 
-        info!(target: LOG_TARGET, "here");
 
         let mut chain_metadata_events = shared.metadata_event_stream.resubscribe();
         let mut dht_events = shared.dht_event_stream.resubscribe();
@@ -239,11 +237,9 @@ impl Listening {
         let mut initial_sync_counter = 0; // This seems to track number of peers heard from for initial sync decision.
         let mut ahead_of_peers_counter = 0;
         let mut initial_sync_peer_list = Vec::new();
-        info!(target: LOG_TARGET, "here");
         loop {
             tokio::select! {
                 result = chain_metadata_events.recv() => {
-        info!(target: LOG_TARGET, "here");
                     match result {
                         Ok(metadata_event_arc) => {
                             let metadata_event = metadata_event_arc.deref();
@@ -378,7 +374,6 @@ impl Listening {
                     }
                 },
                 result = dht_events.recv() => {
-        info!(target: LOG_TARGET, "here");
                     match result {
                         Ok(dht_event_arc) => {
                             let dht_event = dht_event_arc.deref();

--- a/base_layer/core/src/base_node/state_machine_service/states/listening.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/listening.rs
@@ -230,7 +230,6 @@ impl Listening {
             shared.set_state_info(StateInfo::Listening(current_listening_info));
         }
 
-
         let mut chain_metadata_events = shared.metadata_event_stream.resubscribe();
         let mut dht_events = shared.dht_event_stream.resubscribe();
         let mut time_since_better_block = None;

--- a/base_layer/core/src/base_node/state_machine_service/states/listening.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/listening.rs
@@ -224,11 +224,14 @@ impl Listening {
                 info!(target: LOG_TARGET, "[BN SM LISTENING] Bootstrap not complete - setting UI to show bootstrap phase 0/{}", shared.config.blockchain_sync_config.num_initial_sync_rounds_seed_bootstrap());
             };
 
+        info!(target: LOG_TARGET, "here");
             // Ensure other fields are also current
             current_listening_info.synced = self.is_synced;
             current_listening_info.initial_delay_connected_count = self.initial_delay_count;
             shared.set_state_info(StateInfo::Listening(current_listening_info));
         }
+
+        info!(target: LOG_TARGET, "here");
 
         let mut chain_metadata_events = shared.metadata_event_stream.resubscribe();
         let mut dht_events = shared.dht_event_stream.resubscribe();
@@ -236,9 +239,11 @@ impl Listening {
         let mut initial_sync_counter = 0; // This seems to track number of peers heard from for initial sync decision.
         let mut ahead_of_peers_counter = 0;
         let mut initial_sync_peer_list = Vec::new();
+        info!(target: LOG_TARGET, "here");
         loop {
             tokio::select! {
                 result = chain_metadata_events.recv() => {
+        info!(target: LOG_TARGET, "here");
                     match result {
                         Ok(metadata_event_arc) => {
                             let metadata_event = metadata_event_arc.deref();
@@ -373,6 +378,7 @@ impl Listening {
                     }
                 },
                 result = dht_events.recv() => {
+        info!(target: LOG_TARGET, "here");
                     match result {
                         Ok(dht_event_arc) => {
                             let dht_event = dht_event_arc.deref();

--- a/comms/dht/src/network_discovery/discovering.rs
+++ b/comms/dht/src/network_discovery/discovering.rs
@@ -266,7 +266,6 @@ impl Discovering {
                 match &err {
                     NetworkDiscoveryError::EmptyPeerMessageReceived |
                     NetworkDiscoveryError::InvalidPeerDataReceived(_) |
-                    NetworkDiscoveryError::PeerValidationError(_) |
                     NetworkDiscoveryError::DuplicatePeerReceived |
                     NetworkDiscoveryError::TooManyPeersReceived => {
                         self.ban_peer(peer, OffenceSeverity::High, &err).await;
@@ -283,6 +282,7 @@ impl Discovering {
                     NetworkDiscoveryError::PeerManagerError(_) |
                     NetworkDiscoveryError::RpcError(_) |
                     NetworkDiscoveryError::ConnectivityError(_) |
+                    NetworkDiscoveryError::PeerValidationError(_) |
                     NetworkDiscoveryError::JoinError(_) => {},
                 }
                 Err(err)

--- a/comms/dht/src/network_discovery/on_connect.rs
+++ b/comms/dht/src/network_discovery/on_connect.rs
@@ -150,11 +150,22 @@ impl OnConnect {
         let mut num_added = 0;
         while let Some(resp) = peer_stream.next().await {
             match resp {
-                Ok(resp) => match resp.peer.and_then(|peer| peer.try_into().ok()) {
+                Ok(resp) => match resp.peer.and_then(|peer| UnvalidatedPeerInfo::try_from(peer).ok()) {
                     Some(peer) => {
-                        if self.validate_and_add_peer(peer).await? {
-                            num_added += 1;
+                        let pub_key = peer.public_key.clone();
+                        match self.validate_and_add_peer(peer).await {
+                            Ok(new_peer) => {
+                                if new_peer {
+                                    debug!(target: LOG_TARGET, "Added new peer `{}` from `{}`", &pub_key, sync_peer);
+                                    num_added += 1;
+                                } 
+                            }
+                            Err(e) => {
+                                debug!(target: LOG_TARGET, "Failed to validate peer `{}` from `{}`: {}", pub_key, sync_peer, e);
+                            }
                         }
+                            // num_added += 1;
+                        // }
                     },
                     None => {
                         debug!(target: LOG_TARGET, "Invalid response from peer `{}`", sync_peer);

--- a/comms/dht/src/network_discovery/on_connect.rs
+++ b/comms/dht/src/network_discovery/on_connect.rs
@@ -158,14 +158,12 @@ impl OnConnect {
                                 if new_peer {
                                     debug!(target: LOG_TARGET, "Added new peer `{}` from `{}`", &pub_key, sync_peer);
                                     num_added += 1;
-                                } 
-                            }
+                                }
+                            },
                             Err(e) => {
                                 debug!(target: LOG_TARGET, "Failed to validate peer `{}` from `{}`: {}", pub_key, sync_peer, e);
-                            }
+                            },
                         }
-                            // num_added += 1;
-                        // }
                     },
                     None => {
                         debug!(target: LOG_TARGET, "Invalid response from peer `{}`", sync_peer);

--- a/comms/dht/src/network_discovery/seed_strap.rs
+++ b/comms/dht/src/network_discovery/seed_strap.rs
@@ -25,14 +25,14 @@ use std::{cmp, collections::HashSet, convert::TryInto, time::Duration};
 use futures::StreamExt;
 use log::*;
 use rand::seq::IteratorRandom;
-use tari_comms::{peer_manager::NodeId, peer_validator::PeerValidatorError, Minimized, PeerConnection};
+use tari_comms::{peer_manager::NodeId, Minimized, PeerConnection};
 
 use crate::{
     network_discovery::{
         error::NetworkDiscoveryError,
         state_machine::{DhtNetworkDiscoveryRoundInfo, DiscoveryPhase, NetworkDiscoveryContext, StateEvent},
     },
-    peer_validator::{DhtPeerValidatorError, PeerValidator},
+    peer_validator::PeerValidator,
     proto::rpc::GetPeersRequest,
     rpc::{DhtClient, UnvalidatedPeerInfo},
     DhtConfig,
@@ -280,7 +280,7 @@ impl SeedStrap {
 
             let mut new_peers_this_seed = 0;
             let mut duplicates_this_seed = 0;
-            let mut ban_this_seed_peer = false;
+            let ban_this_seed_peer = false;
 
             let peers_count = peers_from_seed.len();
             debug!(

--- a/comms/dht/src/network_discovery/seed_strap.rs
+++ b/comms/dht/src/network_discovery/seed_strap.rs
@@ -388,22 +388,22 @@ impl SeedStrap {
                             },
                         }
                     },
-                    Err(DhtPeerValidatorError::ValidatorError(PeerValidatorError::InvalidPeerSignature { .. })) |
-                    Err(DhtPeerValidatorError::ValidatorError(PeerValidatorError::PeerIdentityNoAddresses {
-                        ..
-                    })) => {
-                        warn!(
-                            target: LOG_TARGET,
-                            "SeedStrap: (From Seed '{}', Peer Candidate {}/{}): Ban-worthy invalid peer data for peer {} received from seed peer '{}'. Will ban seed peer and stop processing its list.",
-                            seed_peer_node_id_str,
-                            peer_idx_loop + 1,
-                            peers_count,
-                            candidate_node_id,
-                            seed_peer_node_id_str,
-                        );
-                        ban_this_seed_peer = true;
-                        break;
-                    },
+                    // Err(DhtPeerValidatorError::ValidatorError(PeerValidatorError::InvalidPeerSignature { .. })) |
+                    // Err(DhtPeerValidatorError::ValidatorError(PeerValidatorError::PeerIdentityNoAddresses {
+                    //     ..
+                    // })) => {
+                    //     warn!(
+                    //         target: LOG_TARGET,
+                    //         "SeedStrap: (From Seed '{}', Peer Candidate {}/{}): Ban-worthy invalid peer data for peer {} received from seed peer '{}'. Will ban seed peer and stop processing its list.",
+                    //         seed_peer_node_id_str,
+                    //         peer_idx_loop + 1,
+                    //         peers_count,
+                    //         candidate_node_id,
+                    //         seed_peer_node_id_str,
+                    //     );
+                    //     ban_this_seed_peer = true;
+                    //     break;
+                    // },
                     Err(e) => {
                         warn!(
                             target: LOG_TARGET,

--- a/comms/dht/src/network_discovery/seed_strap.rs
+++ b/comms/dht/src/network_discovery/seed_strap.rs
@@ -388,22 +388,6 @@ impl SeedStrap {
                             },
                         }
                     },
-                    // Err(DhtPeerValidatorError::ValidatorError(PeerValidatorError::InvalidPeerSignature { .. })) |
-                    // Err(DhtPeerValidatorError::ValidatorError(PeerValidatorError::PeerIdentityNoAddresses {
-                    //     ..
-                    // })) => {
-                    //     warn!(
-                    //         target: LOG_TARGET,
-                    //         "SeedStrap: (From Seed '{}', Peer Candidate {}/{}): Ban-worthy invalid peer data for peer {} received from seed peer '{}'. Will ban seed peer and stop processing its list.",
-                    //         seed_peer_node_id_str,
-                    //         peer_idx_loop + 1,
-                    //         peers_count,
-                    //         candidate_node_id,
-                    //         seed_peer_node_id_str,
-                    //     );
-                    //     ban_this_seed_peer = true;
-                    //     break;
-                    // },
                     Err(e) => {
                         warn!(
                             target: LOG_TARGET,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved peer validation handling to prevent unnecessary banning or disconnection of peers due to certain validation errors.
  - Adjusted error processing so that validation failures no longer interrupt peer synchronization or discovery processes.
  - Updated logging to provide clearer information when invalid peer data is encountered without penalizing peers for specific validation issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->