### PR TITLE
chore: ci disable win arm64 build

### DIFF
--- a/.github/workflows/build_binaries.json
+++ b/.github/workflows/build_binaries.json
@@ -44,7 +44,7 @@
   },
   {
     "name": "windows-x64",
-    "runs-on": "windows-2019",
+    "runs-on": "windows-2022",
     "rust": "stable",
     "target": "x86_64-pc-windows-msvc",
     "cross": false,

--- a/.github/workflows/build_binaries.json
+++ b/.github/workflows/build_binaries.json
@@ -60,7 +60,7 @@
     "features": "safe",
     "target_bins": "minotari_node, minotari_console_wallet, minotari_merge_mining_proxy, minotari_miner",
     "flags": "--workspace --exclude tari_libtor",
-    "build_enabled": true,
+    "build_enabled": false,
     "best_effort": true
   }
 ]


### PR DESCRIPTION
Description
---
The build is not working atm, and its just eating resources to build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Disabled the build process for the Windows ARM64 platform in the workflow configuration.
  - Updated the Windows build environment to a newer version for improved performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->