### PR TITLE
fix: unban peers when their ban expires

### DIFF
--- a/comms/core/src/peer_manager/storage/database.rs
+++ b/comms/core/src/peer_manager/storage/database.rs
@@ -798,12 +798,20 @@ impl PeerDatabaseSql {
             let affected = diesel::update(peers::table.filter(peers::node_id.eq(node_id.to_string())))
                 .set((
                     peers::banned_until.eq(banned_until),
-                    peers::banned_reason.eq(banned_reason),
+                    peers::banned_reason.eq(banned_reason.clone()),
                 ))
                 .execute(conn)?;
             if affected > 0 {
                 Ok(Some(node_id.clone()))
             } else {
+                // Insert a node id to ban. This allows us to ban a peer that does not exist in the database.
+                diesel::insert_into(peers::table)
+                    .values((
+                        peers::node_id.eq(node_id.to_string()),
+                        peers::banned_until.eq(banned_until),
+                        peers::banned_reason.eq(banned_reason),
+                    ))
+                    .execute(conn)?;
                 Ok(None)
             }
         })
@@ -1121,7 +1129,7 @@ impl PeerDatabaseSql {
         // Perform a join query to fetch peers and their addresses
         let results = peers::table
             .inner_join(multi_addresses::table.on(multi_addresses::peer_id.eq(peers::peer_id)))
-            .filter(peers::banned_until.is_null())
+            .filter(peers::banned_until.is_null().or(peers::banned_until.lt(chrono::Utc::now().naive_utc())))
             .filter(peers::deleted_at.is_null())
             .load::<(NewPeerSql, NewMultiaddrWithStatsSql)>(&mut conn)?;
 
@@ -1198,7 +1206,9 @@ impl PeerDatabaseSql {
         // Perform a join query to fetch peers and their addresses
         let results = peers::table
             .inner_join(multi_addresses::table.on(multi_addresses::peer_id.eq(peers::peer_id)))
-            .filter(peers::banned_until.is_not_null())
+            .filter(peers::banned_until.is_not_null().and(
+                peers::banned_until.gt(chrono::Utc::now().naive_utc()),
+            ))
             .load::<(NewPeerSql, NewMultiaddrWithStatsSql)>(&mut conn)?;
 
         PeerDatabaseSql::peers_from_join_query(results)
@@ -1257,7 +1267,7 @@ impl PeerDatabaseSql {
                     .eq(peers::peer_id)
                     .and(multi_addresses::last_failed_reason.is_null())),
             )
-            .filter(peers::banned_until.is_null())
+            .filter(peers::banned_until.is_null().or(peers::banned_until.lt(chrono::Utc::now().naive_utc())))
             .filter(peers::deleted_at.is_null())
             .distinct()
             .into_boxed();
@@ -1349,7 +1359,7 @@ impl PeerDatabaseSql {
         // Step 1: Retrieve relevant node_ids
         let mut query = peers::table
             .inner_join(multi_addresses::table.on(multi_addresses::peer_id.eq(peers::peer_id)))
-            .filter(peers::banned_until.is_null())
+            .filter(peers::banned_until.is_null().or(peers::banned_until.lt(chrono::Utc::now().naive_utc())))
             .filter(peers::deleted_at.is_null())
             .filter(peers::node_id.ne_all(excluded_node_ids_hex))
             .distinct()
@@ -1673,7 +1683,7 @@ impl PeerDatabaseSql {
             let node_ids: Vec<String> = peers::table
                 .inner_join(multi_addresses::table.on(multi_addresses::peer_id.eq(peers::peer_id)))
                 .filter(peers::deleted_at.is_null())
-                .filter(peers::banned_until.is_null().or(peers::banned_until.lt(now.nullable())))
+                .filter(peers::banned_until.is_null().or(peers::banned_until.lt(chrono::Utc::now().naive_utc())))
                 .filter(diesel::dsl::sql::<diesel::sql_types::Bool>(&format!(
                     "features & {} != 0",
                     PeerFeatures::COMMUNICATION_NODE.to_i32()

--- a/comms/core/src/peer_manager/storage/database.rs
+++ b/comms/core/src/peer_manager/storage/database.rs
@@ -26,7 +26,6 @@ use bytes::Bytes;
 use chrono::{NaiveDateTime, TimeDelta};
 use diesel::{
     self,
-    dsl::now,
     prelude::*,
     r2d2::{ConnectionManager, PooledConnection},
     ExpressionMethods,

--- a/comms/core/src/peer_manager/storage/database.rs
+++ b/comms/core/src/peer_manager/storage/database.rs
@@ -805,13 +805,13 @@ impl PeerDatabaseSql {
                 Ok(Some(node_id.clone()))
             } else {
                 // Insert a node id to ban. This allows us to ban a peer that does not exist in the database.
-                diesel::insert_into(peers::table)
-                    .values((
-                        peers::node_id.eq(node_id.to_string()),
-                        peers::banned_until.eq(banned_until),
-                        peers::banned_reason.eq(banned_reason),
-                    ))
-                    .execute(conn)?;
+                // diesel::insert_into(peers::table)
+                //     .values((
+                //         peers::node_id.eq(node_id.to_string()),
+                //         peers::banned_until.eq(banned_until),
+                //         peers::banned_reason.eq(banned_reason),
+                //     ))
+                //     .execute(conn)?;
                 Ok(None)
             }
         })
@@ -1129,7 +1129,11 @@ impl PeerDatabaseSql {
         // Perform a join query to fetch peers and their addresses
         let results = peers::table
             .inner_join(multi_addresses::table.on(multi_addresses::peer_id.eq(peers::peer_id)))
-            .filter(peers::banned_until.is_null().or(peers::banned_until.lt(chrono::Utc::now().naive_utc())))
+            .filter(
+                peers::banned_until
+                    .is_null()
+                    .or(peers::banned_until.lt(chrono::Utc::now().naive_utc())),
+            )
             .filter(peers::deleted_at.is_null())
             .load::<(NewPeerSql, NewMultiaddrWithStatsSql)>(&mut conn)?;
 
@@ -1206,9 +1210,11 @@ impl PeerDatabaseSql {
         // Perform a join query to fetch peers and their addresses
         let results = peers::table
             .inner_join(multi_addresses::table.on(multi_addresses::peer_id.eq(peers::peer_id)))
-            .filter(peers::banned_until.is_not_null().and(
-                peers::banned_until.gt(chrono::Utc::now().naive_utc()),
-            ))
+            .filter(
+                peers::banned_until
+                    .is_not_null()
+                    .and(peers::banned_until.gt(chrono::Utc::now().naive_utc())),
+            )
             .load::<(NewPeerSql, NewMultiaddrWithStatsSql)>(&mut conn)?;
 
         PeerDatabaseSql::peers_from_join_query(results)
@@ -1267,7 +1273,11 @@ impl PeerDatabaseSql {
                     .eq(peers::peer_id)
                     .and(multi_addresses::last_failed_reason.is_null())),
             )
-            .filter(peers::banned_until.is_null().or(peers::banned_until.lt(chrono::Utc::now().naive_utc())))
+            .filter(
+                peers::banned_until
+                    .is_null()
+                    .or(peers::banned_until.lt(chrono::Utc::now().naive_utc())),
+            )
             .filter(peers::deleted_at.is_null())
             .distinct()
             .into_boxed();
@@ -1359,7 +1369,11 @@ impl PeerDatabaseSql {
         // Step 1: Retrieve relevant node_ids
         let mut query = peers::table
             .inner_join(multi_addresses::table.on(multi_addresses::peer_id.eq(peers::peer_id)))
-            .filter(peers::banned_until.is_null().or(peers::banned_until.lt(chrono::Utc::now().naive_utc())))
+            .filter(
+                peers::banned_until
+                    .is_null()
+                    .or(peers::banned_until.lt(chrono::Utc::now().naive_utc())),
+            )
             .filter(peers::deleted_at.is_null())
             .filter(peers::node_id.ne_all(excluded_node_ids_hex))
             .distinct()
@@ -1683,7 +1697,11 @@ impl PeerDatabaseSql {
             let node_ids: Vec<String> = peers::table
                 .inner_join(multi_addresses::table.on(multi_addresses::peer_id.eq(peers::peer_id)))
                 .filter(peers::deleted_at.is_null())
-                .filter(peers::banned_until.is_null().or(peers::banned_until.lt(chrono::Utc::now().naive_utc())))
+                .filter(
+                    peers::banned_until
+                        .is_null()
+                        .or(peers::banned_until.lt(chrono::Utc::now().naive_utc())),
+                )
                 .filter(diesel::dsl::sql::<diesel::sql_types::Bool>(&format!(
                     "features & {} != 0",
                     PeerFeatures::COMMUNICATION_NODE.to_i32()

--- a/comms/core/src/protocol/messaging/inbound.rs
+++ b/comms/core/src/protocol/messaging/inbound.rs
@@ -33,7 +33,7 @@ use tokio::{
 #[cfg(feature = "metrics")]
 use super::metrics;
 use super::{MessagingEvent, MessagingProtocol};
-use crate::{message::InboundMessage, peer_manager, PeerConnection};
+use crate::{message::InboundMessage, PeerConnection};
 
 const LOG_TARGET: &str = "comms::protocol::messaging::inbound";
 

--- a/comms/core/src/protocol/messaging/inbound.rs
+++ b/comms/core/src/protocol/messaging/inbound.rs
@@ -66,7 +66,7 @@ impl InboundMessaging {
     pub async fn run<S>(mut self, socket: S)
     where S: AsyncRead + AsyncWrite + Unpin {
         let peer = self.connection.peer_node_id();
-        
+
         #[cfg(feature = "metrics")]
         metrics::num_sessions().inc();
         debug!(
@@ -74,7 +74,6 @@ impl InboundMessaging {
             "Starting inbound messaging protocol for peer '{}'",
             peer.short_str()
         );
-
 
         let stream = MessagingProtocol::framed(socket);
         let stream = stream.take_until(self.connection.on_disconnect());

--- a/comms/core/src/protocol/messaging/inbound.rs
+++ b/comms/core/src/protocol/messaging/inbound.rs
@@ -33,7 +33,7 @@ use tokio::{
 #[cfg(feature = "metrics")]
 use super::metrics;
 use super::{MessagingEvent, MessagingProtocol};
-use crate::{message::InboundMessage, PeerConnection};
+use crate::{message::InboundMessage, peer_manager, PeerConnection};
 
 const LOG_TARGET: &str = "comms::protocol::messaging::inbound";
 
@@ -66,6 +66,7 @@ impl InboundMessaging {
     pub async fn run<S>(mut self, socket: S)
     where S: AsyncRead + AsyncWrite + Unpin {
         let peer = self.connection.peer_node_id();
+        
         #[cfg(feature = "metrics")]
         metrics::num_sessions().inc();
         debug!(
@@ -73,6 +74,7 @@ impl InboundMessaging {
             "Starting inbound messaging protocol for peer '{}'",
             peer.short_str()
         );
+
 
         let stream = MessagingProtocol::framed(socket);
         let stream = stream.take_until(self.connection.on_disconnect());

--- a/comms/dht/src/inbound/deserialize.rs
+++ b/comms/dht/src/inbound/deserialize.rs
@@ -85,34 +85,42 @@ where
             match DhtEnvelope::decode(&mut body) {
                 Ok(dht_envelope) => {
                     let mut res = Ok(());
-                    if let Some(source_peer) = peer_manager
-                        .find_by_node_id(&source_peer)
-                        .await? {
+                    if let Some(source_peer) = peer_manager.find_by_node_id(&source_peer).await? {
                         // .or_not_found(&source_peer)
                         // .map(Arc::new)?;
 
-                    let inbound_msg =
-                        DhtInboundMessage::new(tag, dht_envelope.header.try_into()?, Arc::new(source_peer), dht_envelope.body);
-                    trace!(
-                        target: LOG_TARGET,
-                        "Deserialization succeeded. Passing message {} onto next service (Trace: {})",
-                        tag,
-                        inbound_msg.dht_header.message_tag
-                    );
+                        let inbound_msg = DhtInboundMessage::new(
+                            tag,
+                            dht_envelope.header.try_into()?,
+                            Arc::new(source_peer),
+                            dht_envelope.body,
+                        );
+                        trace!(
+                            target: LOG_TARGET,
+                            "Deserialization succeeded. Passing message {} onto next service (Trace: {})",
+                            tag,
+                            inbound_msg.dht_header.message_tag
+                        );
 
-                    let next_service = next_service.ready_oneshot().await?;
-                   res = next_service.oneshot(inbound_msg).await;
-                } else {
-                    warn!(
-                        target: LOG_TARGET,
-                        "Received message from unknown peer '{}'. Message tag: {}",
-                        source_peer,
-                        tag
-                    );
-                    peer_manager.ban_peer_by_node_id(&source_peer, Duration::from_secs(60*5), "Received message from unknown peer".to_string()).await?;
-                    res = Err(anyhow::anyhow!("Received message from unknown peer '{}'", source_peer));
-                }
-                res 
+                        let next_service = next_service.ready_oneshot().await?;
+                        res = next_service.oneshot(inbound_msg).await;
+                    } else {
+                        warn!(
+                            target: LOG_TARGET,
+                            "Received message from unknown peer '{}'. Message tag: {}",
+                            source_peer,
+                            tag
+                        );
+                        peer_manager
+                            .ban_peer_by_node_id(
+                                &source_peer,
+                                Duration::from_secs(60 * 5),
+                                "Received message from unknown peer".to_string(),
+                            )
+                            .await?;
+                        res = Err(anyhow::anyhow!("Received message from unknown peer '{}'", source_peer));
+                    }
+                    res
                 },
                 Err(err) => {
                     error!(target: LOG_TARGET, "DHT deserialization failed: {}", err);

--- a/comms/dht/src/inbound/deserialize.rs
+++ b/comms/dht/src/inbound/deserialize.rs
@@ -25,7 +25,7 @@ use std::{convert::TryInto, sync::Arc, task::Poll, time::Duration};
 use futures::{future::BoxFuture, task::Context};
 use log::*;
 use prost::Message;
-use tari_comms::{message::InboundMessage, pipeline::PipelineError, OrNotFound, PeerManager};
+use tari_comms::{message::InboundMessage, pipeline::PipelineError, PeerManager};
 use tower::{layer::Layer, Service, ServiceExt};
 
 use crate::{inbound::DhtInboundMessage, proto::envelope::DhtEnvelope};
@@ -84,7 +84,7 @@ where
 
             match DhtEnvelope::decode(&mut body) {
                 Ok(dht_envelope) => {
-                    let mut res = Ok(());
+                    let res ;
                     if let Some(source_peer) = peer_manager.find_by_node_id(&source_peer).await? {
                         // .or_not_found(&source_peer)
                         // .map(Arc::new)?;

--- a/comms/dht/src/inbound/deserialize.rs
+++ b/comms/dht/src/inbound/deserialize.rs
@@ -84,7 +84,7 @@ where
 
             match DhtEnvelope::decode(&mut body) {
                 Ok(dht_envelope) => {
-                    let res ;
+                    let res;
                     if let Some(source_peer) = peer_manager.find_by_node_id(&source_peer).await? {
                         // .or_not_found(&source_peer)
                         // .map(Arc::new)?;

--- a/comms/dht/src/inbound/deserialize.rs
+++ b/comms/dht/src/inbound/deserialize.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{convert::TryInto, sync::Arc, task::Poll};
+use std::{convert::TryInto, sync::Arc, task::Poll, time::Duration};
 
 use futures::{future::BoxFuture, task::Context};
 use log::*;
@@ -84,14 +84,15 @@ where
 
             match DhtEnvelope::decode(&mut body) {
                 Ok(dht_envelope) => {
-                    let source_peer = peer_manager
+                    let mut res = Ok(());
+                    if let Some(source_peer) = peer_manager
                         .find_by_node_id(&source_peer)
-                        .await
-                        .or_not_found(&source_peer)
-                        .map(Arc::new)?;
+                        .await? {
+                        // .or_not_found(&source_peer)
+                        // .map(Arc::new)?;
 
                     let inbound_msg =
-                        DhtInboundMessage::new(tag, dht_envelope.header.try_into()?, source_peer, dht_envelope.body);
+                        DhtInboundMessage::new(tag, dht_envelope.header.try_into()?, Arc::new(source_peer), dht_envelope.body);
                     trace!(
                         target: LOG_TARGET,
                         "Deserialization succeeded. Passing message {} onto next service (Trace: {})",
@@ -100,7 +101,18 @@ where
                     );
 
                     let next_service = next_service.ready_oneshot().await?;
-                    next_service.oneshot(inbound_msg).await
+                   res = next_service.oneshot(inbound_msg).await;
+                } else {
+                    warn!(
+                        target: LOG_TARGET,
+                        "Received message from unknown peer '{}'. Message tag: {}",
+                        source_peer,
+                        tag
+                    );
+                    peer_manager.ban_peer_by_node_id(&source_peer, Duration::from_secs(60*5), "Received message from unknown peer".to_string()).await?;
+                    res = Err(anyhow::anyhow!("Received message from unknown peer '{}'", source_peer));
+                }
+                res 
                 },
                 Err(err) => {
                     error!(target: LOG_TARGET, "DHT deserialization failed: {}", err);


### PR DESCRIPTION
Fixes a bug where peers never get released from their ban

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved handling of unknown peers by automatically banning them for a short period when they attempt to communicate.
- **Bug Fixes**
	- Enhanced filtering to ensure only currently banned peers are excluded from queries, preventing expired bans from affecting peer selection.
- **Chores**
	- Improved logging and code structure for better maintainability and clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->