### PR TITLE
chore(ci): don't stop testNets ci on failure for other testNets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,9 @@ jobs:
     permissions:
       checks: write
       pull-requests: write
+    continue-on-error: true
     strategy:
+      fail-fast: false
       matrix:
         tari_target_network: [
           { target: "testnet", network: "esmeralda" },


### PR DESCRIPTION
Description
don't stop testNets ci on failure for other testNets

Motivation and Context
Continue to run CI, if other testNet CI fails


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow configuration to ensure all test variations run to completion, even if some fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->