### PR TITLE
test: add ffi cucumber wallet balance test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7495,6 +7495,7 @@ dependencies = [
  "tari_comms_dht",
  "tari_core",
  "tari_crypto",
+ "tari_key_manager",
  "tari_p2p",
  "tari_script",
  "tari_shutdown",

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -830,7 +830,10 @@ impl wallet_server::Wallet for WalletGrpcServer {
                         .get_any_transaction(tx_id)
                         .await
                         .map_err(|e| Status::internal(format!("{:?}", e)))?
-                        .ok_or_else(|| Status::not_found("Transaction not found".to_string()))?;
+                        .ok_or_else(|| {
+                            error!(target: LOG_TARGET, "Transaction {} not found", tx_id);
+                            Status::not_found(format!("Transaction {} not found", tx_id))
+                        })?;
                     let final_tx = convert_wallet_transaction_into_transaction_info(
                         wallet_tx,
                         &wallet_address,

--- a/applications/minotari_console_wallet/src/lib.rs
+++ b/applications/minotari_console_wallet/src/lib.rs
@@ -40,6 +40,7 @@ pub use cli::{
     CoinSplitArgs,
     DiscoverPeerArgs,
     ExportUtxosArgs,
+    ExportViewKeyAndSpendKeyArgs,
     MakeItRainArgs,
     SendMinotariArgs,
     SetBaseNodeArgs,

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -17,6 +17,7 @@ tari_common_sqlite = { path = "../common_sqlite" }
 tari_common_types = { path = "../base_layer/common_types" }
 tari_comms = { path = "../comms/core" }
 tari_comms_dht = { path = "../comms/dht" }
+tari_key_manager = { path = "../base_layer/key_manager" }
 minotari_console_wallet = { path = "../applications/minotari_console_wallet", features = ["grpc"] }
 tari_core = { path = "../base_layer/core" }
 minotari_merge_mining_proxy = { path = "../applications/minotari_merge_mining_proxy" }

--- a/integration_tests/src/ffi/ffi_import.rs
+++ b/integration_tests/src/ffi/ffi_import.rs
@@ -201,7 +201,12 @@ extern "C" {
     ) -> *mut TariSeedWords;
     pub fn seed_words_get_length(seed_words: *const TariSeedWords, error_out: *mut c_int) -> c_uint;
     pub fn seed_words_get_at(seed_words: *mut TariSeedWords, position: c_uint, error_out: *mut c_int) -> *mut c_char;
-    pub fn seed_words_push_word(seed_words: *mut TariSeedWords, word: *const c_char, error_out: *mut c_int) -> c_uchar;
+    pub fn seed_words_push_word(
+        seed_words: *mut TariSeedWords,
+        word: *const c_char,
+        passphrase: *const c_char,
+        error_out: *mut c_int,
+    ) -> c_uchar;
     pub fn seed_words_destroy(seed_words: *mut TariSeedWords);
     pub fn contact_create(
         alias: *const c_char,
@@ -412,7 +417,7 @@ extern "C" {
         context: *mut c_void,
         config: *mut TariCommsConfig,
         log_path: *const c_char,
-        log_level: c_int,
+        log_verbosity: c_int,
         num_rolling_log_files: c_uint,
         size_per_log_file_bytes: c_uint,
         passphrase: *const c_char,
@@ -422,6 +427,7 @@ extern "C" {
         dns_seeds_str: *const c_char,
         dns_seed_name_servers_str: *const c_char,
         use_dns_sec: bool,
+
         callback_received_transaction: unsafe extern "C" fn(context: *mut c_void, *mut TariPendingInboundTransaction),
         callback_received_transaction_reply: unsafe extern "C" fn(context: *mut c_void, *mut TariCompletedTransaction),
         callback_received_finalized_transaction: unsafe extern "C" fn(
@@ -461,7 +467,7 @@ extern "C" {
         callback_saf_messages_received: unsafe extern "C" fn(context: *mut c_void),
         callback_connectivity_status: unsafe extern "C" fn(context: *mut c_void, u64),
         callback_wallet_scanned_height: unsafe extern "C" fn(context: *mut c_void, u64),
-        callback_base_node_state_updated: unsafe extern "C" fn(context: *mut c_void, *mut TariBaseNodeState),
+        callback_base_node_state: unsafe extern "C" fn(context: *mut c_void, *mut TariBaseNodeState),
         recovery_in_progress: *mut bool,
         error_out: *mut c_int,
     ) -> *mut TariWallet;

--- a/integration_tests/src/ffi/seed_words.rs
+++ b/integration_tests/src/ffi/seed_words.rs
@@ -20,14 +20,15 @@
 //   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{ffi::CString, ptr::null_mut};
+use std::{ffi::CString, ptr, ptr::null_mut};
 
-use libc::c_void;
+use libc::{c_char, c_void};
 
 use super::{ffi_import, FFIString};
+use crate::ffi::ffi_import::TariSeedWords;
 
 pub struct SeedWords {
-    ptr: *mut c_void,
+    ptr: *mut TariSeedWords,
 }
 
 impl Drop for SeedWords {
@@ -38,7 +39,7 @@ impl Drop for SeedWords {
 }
 
 impl SeedWords {
-    pub fn create() -> Self {
+    pub fn create_empty_seed_words() -> Self {
         let ptr;
         unsafe {
             ptr = ffi_import::seed_words_create();
@@ -96,7 +97,9 @@ impl SeedWords {
         let mut error = 0;
         let result;
         unsafe {
-            result = ffi_import::seed_words_push_word(self.ptr, CString::new(word).unwrap().into_raw(), &mut error);
+            let w = CString::new(word).unwrap();
+            let w_str: *const c_char = CString::into_raw(w) as *const c_char;
+            result = ffi_import::seed_words_push_word(self.ptr, w_str, ptr::null(), &mut error);
             if error > 0 {
                 println!("seed_words_push_word error {}", error);
                 panic!("seed_words_push_word error");

--- a/integration_tests/src/wallet_ffi.rs
+++ b/integration_tests/src/wallet_ffi.rs
@@ -233,18 +233,3 @@ pub fn create_seed_words(words: Vec<&str>) -> ffi::SeedWords {
     seed_words
 }
 
-// pub fn create_seed_words(words: Vec<&str>) -> ffi::SeedWords {
-//     let mut error = 0;
-//     let error_ptr = &mut error as *mut c_int;
-//     let seed_words = ffi::SeedWords::create_empty_seed_words();
-//
-//     for word in words {
-//         let word = CString::new(word).unwrap();
-//         let word_str: *const c_char = CString::into_raw(word) as *const c_char;
-//         unsafe {
-//             seed_words_push_word(seed_words.get_ptr(), word_str, ptr::null(), error_ptr),
-//         }
-//     }
-//
-//     seed_words
-// }

--- a/integration_tests/src/wallet_ffi.rs
+++ b/integration_tests/src/wallet_ffi.rs
@@ -226,9 +226,25 @@ pub fn create_contact(alias: String, address: String) -> ffi::Contact {
 }
 
 pub fn create_seed_words(words: Vec<&str>) -> ffi::SeedWords {
-    let seed_words = ffi::SeedWords::create();
+    let seed_words = ffi::SeedWords::create_empty_seed_words();
     for word in words {
         seed_words.push_word(word.to_string());
     }
     seed_words
 }
+
+// pub fn create_seed_words(words: Vec<&str>) -> ffi::SeedWords {
+//     let mut error = 0;
+//     let error_ptr = &mut error as *mut c_int;
+//     let seed_words = ffi::SeedWords::create_empty_seed_words();
+//
+//     for word in words {
+//         let word = CString::new(word).unwrap();
+//         let word_str: *const c_char = CString::into_raw(word) as *const c_char;
+//         unsafe {
+//             seed_words_push_word(seed_words.get_ptr(), word_str, ptr::null(), error_ptr),
+//         }
+//     }
+//
+//     seed_words
+// }

--- a/integration_tests/src/wallet_ffi.rs
+++ b/integration_tests/src/wallet_ffi.rs
@@ -232,4 +232,3 @@ pub fn create_seed_words(words: Vec<&str>) -> ffi::SeedWords {
     }
     seed_words
 }
-

--- a/integration_tests/src/wallet_process.rs
+++ b/integration_tests/src/wallet_process.rs
@@ -49,6 +49,8 @@ pub struct WalletProcess {
     pub name: String,
     pub port: u64,
     pub temp_dir_path: PathBuf,
+    pub base_node_name: Option<String>,
+    pub peer_seeds: Vec<String>,
 }
 
 impl Drop for WalletProcess {
@@ -99,7 +101,7 @@ pub async fn spawn_wallet(
             .base_node_monitor_max_refresh_interval = Duration::from_secs(5);
     };
 
-    let base_node = base_node_name.map(|name| {
+    let base_node = base_node_name.clone().map(|name| {
         let pubkey = world.base_nodes.get(&name).unwrap().identity.public_key().clone();
         let port = world.base_nodes.get(&name).unwrap().port;
         let set_base_node_request = SetBaseNodeRequest {
@@ -192,7 +194,9 @@ pub async fn spawn_wallet(
         port,
         grpc_port,
         temp_dir_path: temp_dir,
+        base_node_name,
         kill_signal: shutdown,
+        peer_seeds,
     });
 
     tokio::time::sleep(Duration::from_secs(5)).await;

--- a/integration_tests/src/world.rs
+++ b/integration_tests/src/world.rs
@@ -28,6 +28,7 @@ use std::{
 
 use cucumber::gherkin::{Feature, Scenario};
 use indexmap::IndexMap;
+use minotari_app_grpc::tari_rpc::GetBalanceResponse;
 use rand::rngs::OsRng;
 use serde_json::Value;
 use tari_common::configuration::Network;
@@ -86,6 +87,7 @@ pub struct TariWorld {
     pub miners: IndexMap<String, MinerProcess>,
     pub ffi_wallets: IndexMap<String, WalletFFI>,
     pub wallets: IndexMap<String, WalletProcess>,
+    pub balance: IndexMap<String, GetBalanceResponse>,
     pub merge_mining_proxies: IndexMap<String, MergeMiningProxyProcess>,
     pub transactions: IndexMap<String, Transaction>,
     pub wallet_addresses: IndexMap<String, String>, // values are strings representing tari addresses
@@ -128,6 +130,7 @@ impl Default for TariWorld {
             miners: Default::default(),
             ffi_wallets: Default::default(),
             wallets: Default::default(),
+            balance: Default::default(),
             merge_mining_proxies: Default::default(),
             transactions: Default::default(),
             wallet_addresses: Default::default(),

--- a/integration_tests/src/world.rs
+++ b/integration_tests/src/world.rs
@@ -88,6 +88,7 @@ pub struct TariWorld {
     pub ffi_wallets: IndexMap<String, WalletFFI>,
     pub wallets: IndexMap<String, WalletProcess>,
     pub balance: IndexMap<String, GetBalanceResponse>,
+    pub view_and_spend_keys: IndexMap<String, PathBuf>,
     pub merge_mining_proxies: IndexMap<String, MergeMiningProxyProcess>,
     pub transactions: IndexMap<String, Transaction>,
     pub wallet_addresses: IndexMap<String, String>, // values are strings representing tari addresses
@@ -131,6 +132,7 @@ impl Default for TariWorld {
             ffi_wallets: Default::default(),
             wallets: Default::default(),
             balance: Default::default(),
+            view_and_spend_keys: Default::default(),
             merge_mining_proxies: Default::default(),
             transactions: Default::default(),
             wallet_addresses: Default::default(),

--- a/integration_tests/tests/features/BlockTemplate.feature
+++ b/integration_tests/tests/features/BlockTemplate.feature
@@ -85,18 +85,18 @@ Scenario: Verify UTXO and kernel MMR size in header
         When I wait for wallet WALLET_11 to have at least 18462050000 uT
         When I wait for wallet WALLET_12 to have at least 18462050000 uT
 
-        Then I send 18462000000 uT from wallet WALLET_01 to wallet WALLET_DEFAULT at fee 1
-        Then I send 18462000000 uT from wallet WALLET_02 to wallet WALLET_DEFAULT at fee 1
-        Then I send 18462000000 uT from wallet WALLET_03 to wallet WALLET_DEFAULT at fee 1
-        Then I send 18462000000 uT from wallet WALLET_04 to wallet WALLET_DEFAULT at fee 1
-        Then I send 18462000000 uT from wallet WALLET_05 to wallet WALLET_DEFAULT at fee 1
-        Then I send 18462000000 uT from wallet WALLET_06 to wallet WALLET_DEFAULT at fee 1
-        Then I send 18462000000 uT from wallet WALLET_07 to wallet WALLET_DEFAULT at fee 1
-        Then I send 18462000000 uT from wallet WALLET_08 to wallet WALLET_DEFAULT at fee 1
-        Then I send 18462000000 uT from wallet WALLET_09 to wallet WALLET_DEFAULT at fee 1
-        Then I send 18462000000 uT from wallet WALLET_10 to wallet WALLET_DEFAULT at fee 1
-        Then I send 18462000000 uT from wallet WALLET_11 to wallet WALLET_DEFAULT at fee 1
-        Then I send 18462000000 uT from wallet WALLET_12 to wallet WALLET_DEFAULT at fee 1
+        Then I send a one-sided transaction of 18462000000 uT from wallet WALLET_01 to wallet WALLET_DEFAULT at fee 1
+        Then I send a one-sided transaction of 18462000000 uT from wallet WALLET_02 to wallet WALLET_DEFAULT at fee 1
+        Then I send a one-sided transaction of 18462000000 uT from wallet WALLET_03 to wallet WALLET_DEFAULT at fee 1
+        Then I send a one-sided transaction of 18462000000 uT from wallet WALLET_04 to wallet WALLET_DEFAULT at fee 1
+        Then I send a one-sided transaction of 18462000000 uT from wallet WALLET_05 to wallet WALLET_DEFAULT at fee 1
+        Then I send a one-sided transaction of 18462000000 uT from wallet WALLET_06 to wallet WALLET_DEFAULT at fee 1
+        Then I send a one-sided transaction of 18462000000 uT from wallet WALLET_07 to wallet WALLET_DEFAULT at fee 1
+        Then I send a one-sided transaction of 18462000000 uT from wallet WALLET_08 to wallet WALLET_DEFAULT at fee 1
+        Then I send a one-sided transaction of 18462000000 uT from wallet WALLET_09 to wallet WALLET_DEFAULT at fee 1
+        Then I send a one-sided transaction of 18462000000 uT from wallet WALLET_10 to wallet WALLET_DEFAULT at fee 1
+        Then I send a one-sided transaction of 18462000000 uT from wallet WALLET_11 to wallet WALLET_DEFAULT at fee 1
+        Then I send a one-sided transaction of 18462000000 uT from wallet WALLET_12 to wallet WALLET_DEFAULT at fee 1
 
         # Mempool now has 12 transactions, each with 1000 coinbases as inputs, so we can create a big block
         Then I generate a block BLOCK_18 with 1000 coinbases from node NODE_01 for wallet WALLET_DEFAULT

--- a/integration_tests/tests/features/StressTest.feature
+++ b/integration_tests/tests/features/StressTest.feature
@@ -23,7 +23,7 @@ Feature: Stress Test
         # When mining node MINER mines <NumCoinsplitsNeeded> blocks
         # Then all nodes are on the same chain tip
         # Then wallet WALLET_A detects all transactions as Mined_or_OneSidedConfirmed
-        # When I send <NumTransactions> transactions of 1111 uT each from wallet WALLET_A to wallet WALLET_B at fee_per_gram 4
+        # When I send <NumTransactions> one-sided transactions of 1111 uT each from wallet WALLET_A to wallet WALLET_B at fee_per_gram 4
         # # Mine enough blocks for the first block of transactions to be confirmed.
         # When mining node MINER mines 4 blocks
         # Then all nodes are on the same chain tip
@@ -72,7 +72,7 @@ Feature: Stress Test
 
         # Then all nodes are on the same chain tip
         # Then wallet WALLET_A detects all transactions as Mined_or_OneSidedConfirmed
-        # When I send 2000 transactions of 1111 uT each from wallet WALLET_A to wallet WALLET_B at fee_per_gram 4
+        # When I send 2000 one-sided transactions of 1111 uT each from wallet WALLET_A to wallet WALLET_B at fee_per_gram 4
         # # Mine enough blocks for the first block of transactions to be confirmed.
         # When mining node MINER mines 4 blocks
         # Then all nodes are on the same chain tip

--- a/integration_tests/tests/features/TransactionInfo.feature
+++ b/integration_tests/tests/features/TransactionInfo.feature
@@ -17,7 +17,7 @@ Scenario: Get Transaction Info
     Then all nodes are at height 4
     Then I list all COINBASE transactions for wallet WALLET_A
     When I wait for wallet WALLET_A to have at least 1002000 uT
-    When I send 1000000 uT from wallet WALLET_A to wallet WALLET_B at fee 20
+    When I send a one-sided transaction of 1000000 uT from wallet WALLET_A to wallet WALLET_B at fee 20
     Then wallet WALLET_A detects all transactions are at least Pending
     Then wallet WALLET_B detects all transactions are at least Pending
     Then wallet WALLET_A detects all transactions are at least Completed

--- a/integration_tests/tests/features/WalletFFI.feature
+++ b/integration_tests/tests/features/WalletFFI.feature
@@ -26,42 +26,41 @@ Feature: Wallet FFI
         Given I have a seed node SEED
         When I have a base node BASE connected to all seed nodes
 
-        When I have wallet WALLET1 connected to base node BASE
-        When I have mining node MINER1 connected to base node BASE and wallet WALLET1
+        When I have wallet OTHER_WALLET connected to base node BASE
+        When I have mining node OTHER_MINER connected to base node BASE and wallet OTHER_WALLET
 
-        When I have wallet WALLET2 connected to base node BASE
-        When I have mining node MINER2 connected to base node BASE and wallet WALLET2
+        When I have wallet MY_WALLET connected to base node BASE
+        When I have mining node MY_MINER connected to base node BASE and wallet MY_WALLET
 
-        Then I export wallet WALLET2 view and spend keys as VIEW_SPEND_KEYS
-        Then I create view wallet VIEW_WALLET2 from view and spend keys VIEW_SPEND_KEYS on node BASE
+        Then I export wallet MY_WALLET view and spend keys as VIEW_SPEND_KEYS
+        Then I create view wallet VIEW_MY_WALLET from view and spend keys VIEW_SPEND_KEYS on node BASE
 
-        When mining node MINER1 mines 12 blocks
-        Then I wait for wallet WALLET1 to have at least 166164000000 uT
-        Then I send a one-sided stealth transaction of 10000123 uT from wallet WALLET1 to wallet WALLET2 at fee 1
-        Then I send a one-sided stealth transaction of 10000123 uT from wallet WALLET1 to wallet WALLET2 at fee 1
+        Then I recover wallet MY_WALLET into wallet MY_WALLET2 from seed words on node BASE
 
-        When mining node MINER2 mines 12 blocks
-        Then I send a one-sided stealth transaction of 10000123 uT from wallet WALLET1 to wallet WALLET2 at fee 1
-        Then I send a one-sided stealth transaction of 10000123 uT from wallet WALLET1 to wallet WALLET2 at fee 1
+        Then I recover wallet MY_WALLET into ffi wallet FFI_WALLET from seed words on node BASE
 
-        When mining node MINER1 mines 1 blocks
+        When mining node OTHER_MINER mines 12 blocks
+        When I wait for wallet OTHER_WALLET to have scanned to height 12
+        Then I send a one-sided stealth transaction of 10000123 uT from wallet OTHER_WALLET to wallet MY_WALLET at fee 1
 
-        Then I send a one-sided stealth transaction of 10000123 uT from wallet WALLET1 to wallet WALLET2 at fee 1
-        Then I send a one-sided stealth transaction of 10000123 uT from wallet WALLET1 to wallet WALLET2 at fee 1
-        Then I wait for wallet WALLET2 to have at least 184640500000 uT
-        Then I remember wallet WALLET2 balance BALANCE
+        When mining node MY_MINER mines 12 blocks
+        When I wait for wallet MY_WALLET to have scanned to height 24
+        Then I send a one-sided stealth transaction of 10000123 uT from wallet OTHER_WALLET to wallet MY_WALLET at fee 1
+        Then I send a one-sided stealth transaction of 10000123 uT from wallet MY_WALLET to wallet OTHER_WALLET at fee 1
 
-        Then I wait for wallet VIEW_WALLET2 to have at least 184640500000 uT
-        Then wallet VIEW_WALLET2 balance is BALANCE
+        When mining node OTHER_MINER mines 1 blocks
+        When I wait for wallet MY_WALLET to have scanned to height 25
+        Then I wait for wallet MY_WALLET to have less than 166164000000 uT
+        Then I remember wallet MY_WALLET balance BALANCE_STATE_ON_BLOCKCHAIN
 
-        Then I recover wallet WALLET2 into ffi wallet FFI_WALLET from seed words on node BASE
-        And I wait for ffi wallet FFI_WALLET to have at least 184640500000 uT
-        Then ffi wallet FFI_WALLET balance is BALANCE
+        When I wait for wallet MY_WALLET2 to have scanned to height 25
+        Then wallet MY_WALLET2 balance is BALANCE_STATE_ON_BLOCKCHAIN
+
+        Then ffi wallet FFI_WALLET balance is BALANCE_STATE_ON_BLOCKCHAIN
         And I stop ffi wallet FFI_WALLET
 
-        Then I recover wallet WALLET2 into wallet WALLET3 from seed words on node BASE
-        Then I wait for wallet WALLET3 to have at least 184640500000 uT
-        Then wallet WALLET3 balance is BALANCE
+        When I wait for wallet VIEW_MY_WALLET to have scanned to height 25
+        Then wallet VIEW_MY_WALLET balance is BALANCE_STATE_ON_BLOCKCHAIN
 
     @critical
     Scenario: As a client I want to retrieve the mnemonic word list for a given language

--- a/integration_tests/tests/features/WalletFFI.feature
+++ b/integration_tests/tests/features/WalletFFI.feature
@@ -10,6 +10,7 @@ Feature: Wallet FFI
         And I want to get emoji id of ffi wallet FFI_WALLET
         And I stop ffi wallet FFI_WALLET
 
+    @critical
     Scenario: As a client I want to be able to restore my ffi wallet from seed words
         Given I have a base node BASE
         When I have wallet SPECTATOR connected to base node BASE
@@ -18,6 +19,30 @@ Feature: Wallet FFI
         Then I wait for wallet SPECTATOR to have at least 1000000 uT
         Then I recover wallet SPECTATOR into ffi wallet FFI_WALLET from seed words on node BASE
         And I wait for ffi wallet FFI_WALLET to have at least 1000000 uT
+        And I stop ffi wallet FFI_WALLET
+
+    @critical
+    Scenario: As a client I want to be able to check my balance from restored wallets
+        Given I have a seed node SEED
+        When I have a base node BASE connected to all seed nodes
+
+        When I have wallet WALLET1 connected to base node BASE
+        When I have mining node MINER1 connected to base node BASE and wallet WALLET1
+
+        When I have wallet WALLET2 connected to base node BASE
+        When I have mining node MINER2 connected to base node BASE and wallet WALLET2
+
+        When mining node MINER2 mines 12 blocks
+        Then all nodes are at height 12
+        Then all nodes are at height 12
+        When mining node MINER1 mines 1 blocks
+        Then all nodes are at height 13
+        Then I wait for wallet WALLET2 to have at least 184620500000 uT
+        Then I remember wallet WALLET2 balance BALANCE
+
+        Then I recover wallet WALLET2 into ffi wallet FFI_WALLET from seed words on node BASE
+        And I wait for ffi wallet FFI_WALLET to have at least 184620500000 uT
+        Then ffi wallet FFI_WALLET balance is BALANCE
         And I stop ffi wallet FFI_WALLET
 
     @critical

--- a/integration_tests/tests/features/WalletFFI.feature
+++ b/integration_tests/tests/features/WalletFFI.feature
@@ -32,18 +32,36 @@ Feature: Wallet FFI
         When I have wallet WALLET2 connected to base node BASE
         When I have mining node MINER2 connected to base node BASE and wallet WALLET2
 
+        Then I export wallet WALLET2 view and spend keys as VIEW_SPEND_KEYS
+        Then I create view wallet VIEW_WALLET2 from view and spend keys VIEW_SPEND_KEYS on node BASE
+
+        When mining node MINER1 mines 12 blocks
+        Then I wait for wallet WALLET1 to have at least 166164000000 uT
+        Then I send a one-sided stealth transaction of 10000123 uT from wallet WALLET1 to wallet WALLET2 at fee 1
+        Then I send a one-sided stealth transaction of 10000123 uT from wallet WALLET1 to wallet WALLET2 at fee 1
+
         When mining node MINER2 mines 12 blocks
-        Then all nodes are at height 12
-        Then all nodes are at height 12
+        Then I send a one-sided stealth transaction of 10000123 uT from wallet WALLET1 to wallet WALLET2 at fee 1
+        Then I send a one-sided stealth transaction of 10000123 uT from wallet WALLET1 to wallet WALLET2 at fee 1
+
         When mining node MINER1 mines 1 blocks
-        Then all nodes are at height 13
-        Then I wait for wallet WALLET2 to have at least 184620500000 uT
+
+        Then I send a one-sided stealth transaction of 10000123 uT from wallet WALLET1 to wallet WALLET2 at fee 1
+        Then I send a one-sided stealth transaction of 10000123 uT from wallet WALLET1 to wallet WALLET2 at fee 1
+        Then I wait for wallet WALLET2 to have at least 184640500000 uT
         Then I remember wallet WALLET2 balance BALANCE
 
+        Then I wait for wallet VIEW_WALLET2 to have at least 184640500000 uT
+        Then wallet VIEW_WALLET2 balance is BALANCE
+
         Then I recover wallet WALLET2 into ffi wallet FFI_WALLET from seed words on node BASE
-        And I wait for ffi wallet FFI_WALLET to have at least 184620500000 uT
+        And I wait for ffi wallet FFI_WALLET to have at least 184640500000 uT
         Then ffi wallet FFI_WALLET balance is BALANCE
         And I stop ffi wallet FFI_WALLET
+
+        Then I recover wallet WALLET2 into wallet WALLET3 from seed words on node BASE
+        Then I wait for wallet WALLET3 to have at least 184640500000 uT
+        Then wallet WALLET3 balance is BALANCE
 
     @critical
     Scenario: As a client I want to retrieve the mnemonic word list for a given language
@@ -71,7 +89,7 @@ Feature: Wallet FFI
         When I have mining node MINER connected to base node BASE and wallet SENDER
         When mining node MINER mines 10 blocks
         Then I wait for wallet SENDER to have at least 1000000 uT
-        And I send 2000000 uT without waiting for broadcast from wallet SENDER to wallet FFI_WALLET at fee 20
+        And I send 2000000 uT one-sided without waiting for broadcast from wallet SENDER to wallet FFI_WALLET at fee 20
         Then ffi wallet FFI_WALLET detects AT_LEAST 1 ffi transactions to be TRANSACTION_STATUS_BROADCAST
         And wallet SENDER detects all transactions are at least Broadcast
         When mining node MINER mines 10 blocks
@@ -111,8 +129,8 @@ Feature: Wallet FFI
         And mining node MINER2 mines 5 blocks
         Then I wait for wallet WALLET1 to have at least 100000000 uT
         And I wait for wallet WALLET2 to have at least 100000000 uT
-        When I send 100000000 uT without waiting for broadcast from wallet WALLET1 to wallet FFI_WALLET at fee 20
-        And I send 100000000 uT without waiting for broadcast from wallet WALLET2 to wallet FFI_WALLET at fee 20
+        When I send 100000000 uT one-sided without waiting for broadcast from wallet WALLET1 to wallet FFI_WALLET at fee 20
+        And I send 100000000 uT one-sided without waiting for broadcast from wallet WALLET2 to wallet FFI_WALLET at fee 20
         # If the FFI wallet can send the transactions, P2P connectivity has been established
         Then I wait for ffi wallet FFI_WALLET to have at least 2 contacts to be Online
         And I stop ffi wallet FFI_WALLET
@@ -130,7 +148,7 @@ Feature: Wallet FFI
         When mining node MINER mines 10 blocks
         Then all nodes are at height 10
         Then I wait for wallet SENDER to have at least 2000000 uT
-        And I send 2000000 uT from wallet SENDER to wallet FFI_WALLET at fee 20
+        And I send a one-sided stealth transaction of 2000000 uT from wallet SENDER to wallet FFI_WALLET at fee 20
         Then ffi wallet FFI_WALLET detects AT_LEAST 1 ffi transactions to be TRANSACTION_STATUS_BROADCAST
         When mining node MINER mines 10 blocks
         Then all nodes are at height 20
@@ -169,7 +187,7 @@ Feature: Wallet FFI
         When mining node MINER mines 10 blocks
         Then all nodes are at height 10
         Then I wait for wallet SENDER to have at least 129239250000 uT
-        And I send 1000000 uT from wallet SENDER to wallet FFI_WALLET at fee 5
+        And I send a one-sided stealth transaction of 1000000 uT from wallet SENDER to wallet FFI_WALLET at fee 5
         Then wallet SENDER has at least 1 transactions that are all TRANSACTION_STATUS_BROADCAST and not cancelled
         Then ffi wallet FFI_WALLET detects AT_LEAST 1 ffi transactions to be TRANSACTION_STATUS_BROADCAST
         When mining node MINER mines 10 blocks
@@ -179,13 +197,13 @@ Feature: Wallet FFI
 
         # We have established comms, so now we can go offline and receive a transaction while offline
         And I stop ffi wallet FFI_WALLET
-        And I send 1000000 uT without waiting for broadcast from wallet SENDER to wallet FFI_WALLET at fee 20
+        And I send 1000000 uT one-sided without waiting for broadcast from wallet SENDER to wallet FFI_WALLET at fee 20
 
         # Let's restart the wallet and see if it can receive the offline transaction
         And I restart ffi wallet FFI_WALLET connected to base node BASE1
         When I add contact with alias ALIAS2 and address of SENDER to ffi wallet FFI_WALLET
         # BROKEN
-        And I send 1000000 uT from wallet SENDER to wallet FFI_WALLET at fee 5
+        And I send a one-sided stealth transaction of 1000000 uT from wallet SENDER to wallet FFI_WALLET at fee 5
         Then ffi wallet FFI_WALLET detects AT_LEAST 1 ffi transactions to be TRANSACTION_STATUS_BROADCAST
         When mining node MINER mines 2 blocks
         Then all nodes are at height 22
@@ -213,8 +231,8 @@ Feature: Wallet FFI
         When mining node MINER mines 10 blocks
         Then all nodes are at height 10
         Then I wait for wallet SENDER to have at least 129239250000 uT
-        And I send 2400000 uT from wallet SENDER to wallet FFI_WALLET at fee 5
-        And I send 2400000 uT from wallet SENDER to wallet FFI_WALLET at fee 5
+        And I send a one-sided stealth transaction of 2400000 uT from wallet SENDER to wallet FFI_WALLET at fee 5
+        And I send a one-sided stealth transaction of 2400000 uT from wallet SENDER to wallet FFI_WALLET at fee 5
         Then wallet SENDER has at least 2 transactions that are all TRANSACTION_STATUS_BROADCAST and not cancelled
         Then ffi wallet FFI_WALLET detects AT_LEAST 2 ffi transactions to be TRANSACTION_STATUS_BROADCAST
         When mining node MINER mines 10 blocks
@@ -243,11 +261,11 @@ Feature: Wallet FFI
         When I have mining node MINER connected to base node BASE1 and wallet SENDER
         When mining node MINER mines 10 blocks
         Then I wait for wallet SENDER to have at least 5000000 uT
-        Then I send a one-sided transaction of 1000000 uT from SENDER to FFI_RECEIVER at fee 20
+        Then I send a one-sided transaction of 1000000 uT from wallet SENDER to wallet FFI_RECEIVER at fee 20
         When mining node MINER mines 2 blocks
         Then all nodes are at height 12
         Then ffi wallet FFI_RECEIVER detects AT_LEAST 1 ffi transactions to be TRANSACTION_STATUS_ONE_SIDED_UNCONFIRMED
-        And I send 1000000 uT from wallet SENDER to wallet FFI_RECEIVER at fee 20
+        And I send a one-sided stealth transaction of 1000000 uT from wallet SENDER to wallet FFI_RECEIVER at fee 20
         Then ffi wallet FFI_RECEIVER detects AT_LEAST 1 ffi transactions to be TRANSACTION_STATUS_BROADCAST
         When mining node MINER mines 5 blocks
         Then all nodes are at height 17
@@ -263,11 +281,11 @@ Feature: Wallet FFI
         Then I wait for wallet WALLET_A to have at least 10000000 uT
         And I have a ffi wallet FFI_WALLET connected to base node BASE
         And The fee per gram stats for FFI_WALLET are 1, 1, 1
-        And I send 1000000 uT from wallet WALLET_A to wallet WALLET_B at fee 20
+        And I send a one-sided stealth transaction of 1000000 uT from wallet WALLET_A to wallet WALLET_B at fee 20
         And The fee per gram stats for FFI_WALLET are 20, 20, 20
-        And I send 1000000 uT from wallet WALLET_A to wallet WALLET_B at fee 40
+        And I send a one-sided stealth transaction of 1000000 uT from wallet WALLET_A to wallet WALLET_B at fee 40
         And The fee per gram stats for FFI_WALLET are 20, 30, 40
-        And I send 1000000 uT from wallet WALLET_A to wallet WALLET_B at fee 60
+        And I send a one-sided stealth transaction of 1000000 uT from wallet WALLET_A to wallet WALLET_B at fee 60
         And The fee per gram stats for FFI_WALLET are 20, 40, 60
         When mining node MINER mines 1 blocks
         And The fee per gram stats for FFI_WALLET are 1, 1, 1

--- a/integration_tests/tests/features/WalletMonitoring.feature
+++ b/integration_tests/tests/features/WalletMonitoring.feature
@@ -68,7 +68,7 @@ Feature: Wallet Monitoring
     # Then node NODE_A1 is at height 10
     # Then wallet WALLET_A1 detects exactly 7 coinbase transactions as CoinbaseConfirmed
     #     # Use 7 of the 10 coinbase UTXOs in transactions (others require 3 confirmations)
-    # And I multi-send 7 transactions of 1000000 uT from wallet WALLET_A1 to wallet WALLET_A2 at fee 100
+    # And I multi-send 7 one-sided transactions of 1000000 uT from wallet WALLET_A1 to wallet WALLET_A2 at fee 100
     # When mining node MINING_A mines 10 blocks with min difficulty 20 and max difficulty 9999999999
     # Then node SEED_A is at height 20
     # Then node NODE_A1 is at height 20
@@ -90,7 +90,7 @@ Feature: Wallet Monitoring
     # Then node NODE_B1 is at height 10
     # Then wallet WALLET_B1 detects exactly 7 coinbase transactions as CoinbaseConfirmed
     #     # Use 7 of the 10 coinbase UTXOs in transactions (others require 3 confirmations)
-    # And I multi-send 7 transactions of 1000000 uT from wallet WALLET_B1 to wallet WALLET_B2 at fee 100
+    # And I multi-send 7 one-sided transactions of 1000000 uT from wallet WALLET_B1 to wallet WALLET_B2 at fee 100
     # When mining node MINING_B mines 10 blocks with min difficulty 1 and max difficulty 2
     # Then node SEED_B is at height 20
     # Then node NODE_B1 is at height 20

--- a/integration_tests/tests/features/WalletQuery.feature
+++ b/integration_tests/tests/features/WalletQuery.feature
@@ -21,7 +21,7 @@ Feature: Wallet Querying
     When I have wallet WALLET_A with 10T connected to base node NODE
     When I have wallet WALLET_B connected to base node NODE
     When I wait 5 seconds
-    When I transfer 5T from WALLET_A to WALLET_B
+    When I transfer 5T one-sided from WALLET_A to WALLET_B
     When I mine 5 blocks on NODE
     Then all wallets detect all transactions as Mined_or_OneSidedConfirmed
 

--- a/integration_tests/tests/features/WalletRecovery.feature
+++ b/integration_tests/tests/features/WalletRecovery.feature
@@ -15,7 +15,7 @@ Feature: Wallet Recovery
         When I mine 5 blocks on NODE
       #   When I wait for wallet WALLET_A to have at least 55000000000 uT
         Then all nodes are at height 15
-      #   And I send 200000 uT from wallet WALLET_A to wallet WALLET_B at fee 25
+      #   And I send a one-sided transaction of 200000 uT from wallet WALLET_A to wallet WALLET_B at fee 25
       When I have mining node MINER_B connected to base node NODE and wallet WALLET_B
       When mining node MINER_B mines 2 blocks
         When I mine 5 blocks on NODE
@@ -24,7 +24,7 @@ Feature: Wallet Recovery
       #   When I recover wallet WALLET_B into wallet WALLET_C connected to all seed nodes
       #   When I wait for wallet WALLET_C to have at least 10000200000 uT
       When I have wallet WALLET_D connected to all seed nodes
-      #   And I send 100000 uT from wallet WALLET_C to wallet WALLET_D at fee 25
+      #   And I send a one-sided transaction of 100000 uT from wallet WALLET_C to wallet WALLET_D at fee 25
         When I mine 5 blocks on NODE
         Then all nodes are at height 27
       #   Then I wait for wallet WALLET_D to have at least 100000 uT
@@ -62,20 +62,20 @@ Feature: Wallet Recovery
         Then all nodes are at height 10
       #   And I stop wallet WALLET_B
       #   # Send 2 one-sided payments to WALLET_B so it can spend them in two cases
-      #   Then I send a one-sided transaction of 1000000 uT from WALLET_A to WALLET_B at fee 20
-      #   Then I send a one-sided transaction of 1000000 uT from WALLET_A to WALLET_B at fee 20
+      #   Then I send a one-sided transaction of 1000000 uT from wallet WALLET_A to wallet WALLET_B at fee 20
+      #   Then I send a one-sided transaction of 1000000 uT from wallet WALLET_A to wallet WALLET_B at fee 20
       When mining node MINER mines 5 blocks
         Then all nodes are at height 15
       #   When I recover wallet WALLET_B into wallet WALLET_C connected to all seed nodes
       #   # BREAKS HERE
       #   Then I wait for wallet WALLET_C to have at least 2000000 uT
       #   # Send one of the recovered outputs back to Wallet A as a one-sided transactions
-      #   Then I send a one-sided transaction of 900000 uT from WALLET_C to WALLET_A at fee 20
+      #   Then I send a one-sided transaction of 900000 uT from wallet WALLET_C to wallet WALLET_A at fee 20
       When mining node MINER mines 5 blocks
         Then all nodes are at height 20
       #   Then I wait for wallet WALLET_C to have less than 1100000 uT
       #   # Send the remaining recovered UTXO to self in standard MW transaction
-      #   Then I send 1000000 uT from wallet WALLET_C to wallet WALLET_C at fee 20
+      #   Then I send a one-sided transaction of 1000000 uT from wallet WALLET_C to wallet WALLET_C at fee 20
       #   Then I wait for wallet WALLET_C to have less than 100000 uT
       When mining node MINER mines 5 blocks
         Then all nodes are at height 25

--- a/integration_tests/tests/features/WalletRoutingMechanism.feature
+++ b/integration_tests/tests/features/WalletRoutingMechanism.feature
@@ -52,7 +52,7 @@ Feature: Wallet Routing Mechanism
       When I have mining node MINE connected to base node BASE and wallet SENDER
       #   And mining node MINE mines 5 blocks
       #   Then I wait for wallet SENDER to have at least 1000000 uT
-      #   And I send 1000000 uT from wallet SENDER to wallet RECEIVER at fee 100
+      #   And I send a one-sided transaction of 1000000 uT from wallet SENDER to wallet RECEIVER at fee 100
   #
   #
   # 10 minutes of waiting...

--- a/integration_tests/tests/features/WalletTransactions.feature
+++ b/integration_tests/tests/features/WalletTransactions.feature
@@ -16,19 +16,19 @@ Feature: Wallet Transactions
     Then all nodes are at height 15
     When I wait 5 seconds
     When I wait for wallet WALLET_A to have at least 55000000000 uT
-    Then I send a one-sided transaction of 1000000 uT from WALLET_A to WALLET_B at fee 100
-    Then I send a one-sided transaction of 1000000 uT from WALLET_A to WALLET_B at fee 100
+    Then I send a one-sided transaction of 1000000 uT from wallet WALLET_A to wallet WALLET_B at fee 100
+    Then I send a one-sided transaction of 1000000 uT from wallet WALLET_A to wallet WALLET_B at fee 100
     When mining node MINER mines 5 blocks
     Then all nodes are at height 20
     Then I wait for wallet WALLET_B to have at least 2000000 uT
     # Spend one of the recovered UTXOs to self in a standard MW transaction
-    Then I send 900000 uT from wallet WALLET_B to wallet WALLET_B at fee 20
+    Then I send an interactive transaction of 900000 uT from wallet WALLET_B to wallet WALLET_B at fee 20
     Then I wait for wallet WALLET_B to have less than 1100000 uT
     When mining node MINER mines 5 blocks
     Then all nodes are at height 25
     Then I wait for wallet WALLET_B to have at least 1900000 uT
     # Make a one-sided payment to a new wallet that is big enough to ensure the second recovered output is spent
-    Then I send a one-sided transaction of 1500000 uT from WALLET_B to WALLET_C at fee 20
+    Then I send a one-sided transaction of 1500000 uT from wallet WALLET_B to wallet WALLET_C at fee 20
     Then I wait for wallet WALLET_B to have less than 1000000 uT
     When mining node MINER mines 5 blocks
     Then all nodes are at height 30
@@ -46,19 +46,19 @@ Feature: Wallet Transactions
     When mining node MINER mines 15 blocks
     Then all nodes are at height 15
     When I wait for wallet WALLET_A to have at least 55000000000 uT
-    Then I send a one-sided stealth transaction of 1000000 uT from WALLET_A to WALLET_B at fee 100
-    Then I send a one-sided stealth transaction of 1000000 uT from WALLET_A to WALLET_B at fee 100
+    Then I send a one-sided stealth transaction of 1000000 uT from wallet WALLET_A to wallet WALLET_B at fee 100
+    Then I send a one-sided stealth transaction of 1000000 uT from wallet WALLET_A to wallet WALLET_B at fee 100
     When mining node MINER mines 5 blocks
     Then all nodes are at height 20
     Then I wait for wallet WALLET_B to have at least 2000000 uT
     # Spend one of the recovered UTXOs to self in a standard MW transaction
-    Then I send 900000 uT from wallet WALLET_B to wallet WALLET_B at fee 20
+    Then I send an interactive transaction of 900000 uT from wallet WALLET_B to wallet WALLET_B at fee 20
     Then I wait for wallet WALLET_B to have less than 2100000 uT
     When mining node MINER mines 5 blocks
     Then all nodes are at height 25
     Then I wait for wallet WALLET_B to have at least 1900000 uT
     # Make a one-sided payment to a new wallet that is big enough to ensure the second recovered output is spent
-    Then I send a one-sided stealth transaction of 1500000 uT from WALLET_B to WALLET_C at fee 20
+    Then I send a one-sided stealth transaction of 1500000 uT from wallet WALLET_B to wallet WALLET_C at fee 20
     Then I wait for wallet WALLET_B to have less than 1000000 uT
     When mining node MINER mines 5 blocks
     Then all nodes are at height 30
@@ -74,7 +74,7 @@ Feature: Wallet Transactions
     When mining node MINER mines 5 blocks
     Then all nodes are at height 5
     Then I wait for wallet WALLET_A to have at least 10000000000 uT
-    When I send 1000000 uT from wallet WALLET_A to wallet WALLET_B at fee 100
+    When I send a one-sided transaction of 1000000 uT from wallet WALLET_A to wallet WALLET_B at fee 100
     When mining node MINER mines 5 blocks
     Then all nodes are at height 10
     Then I wait for wallet WALLET_B to have at least 1000000 uT
@@ -109,11 +109,11 @@ Feature: Wallet Transactions
     When mining node MINER mines 5 blocks
     Then all nodes are at height 5
     Then I wait for wallet WALLET_A to have at least 10000000000 uT
-    When I send 1000000 uT from wallet WALLET_A to wallet WALLET_B at fee 100
+    When I send a one-sided transaction of 1000000 uT from wallet WALLET_A to wallet WALLET_B at fee 100
     When mining node MINER mines 5 blocks
     Then all nodes are at height 10
     Then I wait for wallet WALLET_B to have at least 1000000 uT
-    When I send 900000 uT from wallet WALLET_B to wallet WALLET_A at fee 100
+    When I send a one-sided transaction of 900000 uT from wallet WALLET_B to wallet WALLET_A at fee 100
     When mining node MINER mines 5 blocks
     Then all nodes are at height 15
     When I wait for wallet WALLET_B to have at least 50000 uT
@@ -136,7 +136,7 @@ Feature: Wallet Transactions
     When I have mining node BM connected to base node B and wallet WB
     When mining node BM mines 4 blocks with min difficulty 1 and max difficulty 50
     Then I wait for wallet WB to have at least 1000000 uT
-    When I send 1000000 uT from wallet WB to wallet WALLET_RECEIVE_TX at fee 100
+    When I send a one-sided transaction of 1000000 uT from wallet WB to wallet WALLET_RECEIVE_TX at fee 100
     Then mining node BM mines 4 blocks with min difficulty 50 and max difficulty 100
     When node B is at height 8
     Then I wait for wallet WALLET_RECEIVE_TX to have at least 1000000 uT
@@ -177,7 +177,7 @@ Feature: Wallet Transactions
     When mining node MINER mines 5 blocks
     Then all nodes are at height 5
     Then I wait for wallet WALLET_A to have at least 10000000000 uT
-    When I send 1000000 uT from wallet WALLET_A to wallet WALLET_B at fee 100
+    When I send a one-sided transaction of 1000000 uT from wallet WALLET_A to wallet WALLET_B at fee 100
     When mining node MINER mines 6 blocks
     Then all nodes are at height 11
     Then I wait for wallet WALLET_B to have at least 1000000 uT
@@ -185,7 +185,7 @@ Feature: Wallet Transactions
     When I wait 15 seconds
     Then I import WALLET_B unspent outputs as pre_mine outputs to WALLET_C
     Then I wait for wallet WALLET_C to have at least 1000000 uT
-    When I send 500000 uT from wallet WALLET_C to wallet WALLET_A at fee 100
+    When I send a one-sided transaction of 500000 uT from wallet WALLET_C to wallet WALLET_A at fee 100
     When mining node MINER mines 6 blocks
     Then all nodes are at height 17
     Then I wait for wallet WALLET_C to have at least 400000 uT
@@ -199,11 +199,11 @@ Feature: Wallet Transactions
     When mining node MINER mines 10 blocks
     Then all nodes are at height 10
     Then I wait for wallet WALLET_A to have at least 10000000000 uT
-    When I send 100000 uT from wallet WALLET_A to wallet WALLET_B at fee 100
-    When I send 100000 uT from wallet WALLET_A to wallet WALLET_B at fee 100
-    When I send 100000 uT from wallet WALLET_A to wallet WALLET_B at fee 100
-    When I send 100000 uT from wallet WALLET_A to wallet WALLET_B at fee 100
-    When I send 100000 uT from wallet WALLET_A to wallet WALLET_B at fee 100
+    When I send a one-sided transaction of 100000 uT from wallet WALLET_A to wallet WALLET_B at fee 100
+    When I send a one-sided transaction of 100000 uT from wallet WALLET_A to wallet WALLET_B at fee 100
+    When I send a one-sided transaction of 100000 uT from wallet WALLET_A to wallet WALLET_B at fee 100
+    When I send a one-sided transaction of 100000 uT from wallet WALLET_A to wallet WALLET_B at fee 100
+    When I send a one-sided transaction of 100000 uT from wallet WALLET_A to wallet WALLET_B at fee 100
     When mining node MINER mines 5 blocks
     Then all nodes are at height 15
     Then I wait for wallet WALLET_B to have at least 500000 uT
@@ -230,7 +230,7 @@ Feature: Wallet Transactions
   #   Then wallet WALLET_A1 detects at least 7 coinbase transactions as CoinbaseConfirmed
   #   Then node SEED_A is at height 10
   #   Then node NODE_A1 is at height 10
-  #   When I multi-send 7 transactions of 1000000 uT from wallet WALLET_A1 to wallet WALLET_A2 at fee 100
+  #   When I multi-send 7 one-sided transactions of 1000000 uT from wallet WALLET_A1 to wallet WALLET_A2 at fee 100
   #   #
   #   # Chain 2:
   #   #   Collects 7 coinbases into one wallet, send 7 transactions
@@ -248,7 +248,7 @@ Feature: Wallet Transactions
   #   Then wallet WALLET_B1 detects at least 7 coinbase transactions as CoinbaseConfirmed
   #   Then node SEED_B is at height 12
   #   Then node NODE_B1 is at height 12
-  #   When I multi-send 7 transactions of 1000000 uT from wallet WALLET_B1 to wallet WALLET_B2 at fee 100
+  #   When I multi-send 7 one-sided transactions of 1000000 uT from wallet WALLET_B1 to wallet WALLET_B2 at fee 100
   #   #
   #   # Connect Chain 1 and 2 in stages
   #   #    # New node connects to weaker chain, receives all broadcast (not mined) transactions into mempool
@@ -276,7 +276,7 @@ Feature: Wallet Transactions
     Then I stop wallet WALLET_B
     Then I stop node SEED
     When I wait 10 seconds
-    Then I send 100000000 uT without waiting for broadcast from wallet WALLET_A to wallet WALLET_B at fee 20
+    Then I send 100000000 uT one-sided without waiting for broadcast from wallet WALLET_A to wallet WALLET_B at fee 20
     When I wait 10 seconds
     When I start base node SEED
     When I have a base node NODE_A connected to seed SEED
@@ -310,7 +310,7 @@ Feature: Wallet Transactions
   #   Then wallet WALLET_A1 detects at least 1 coinbase transactions as CoinbaseConfirmed
   #   Then node SEED_A is at height 4
   #   Then node NODE_A1 is at height 4
-  #   When I multi-send 1 transactions of 10000 uT from wallet WALLET_A1 to wallet WALLET_A2 at fee 20
+  #   When I multi-send 1 one-sided transactions of 10000 uT from wallet WALLET_A1 to wallet WALLET_A2 at fee 20
   #   #
   #   # Chain 2:
   #   #   Collects 7 coinbases into one wallet, send 7 transactions
@@ -328,7 +328,7 @@ Feature: Wallet Transactions
   #   Then wallet WALLET_B1 detects at least 2 coinbase transactions as CoinbaseConfirmed
   #   Then node SEED_B is at height 5
   #   Then node NODE_B1 is at height 5
-  #   When I multi-send 2 transactions of 10000 uT from wallet WALLET_B1 to wallet WALLET_B2 at fee 20
+  #   When I multi-send 2 one-sided transactions of 10000 uT from wallet WALLET_B1 to wallet WALLET_B2 at fee 20
   #   #
   #   # Connect Chain 1 and 2 in stages
   #   #    # New node connects to weaker chain, receives all broadcast (not mined) transactions into mempool
@@ -355,12 +355,12 @@ Feature: Wallet Transactions
   #   Then all nodes are at height 5
   #   Then I wait for wallet WALLET_A to have at least 10000000000 uT
   #   When I have non-default wallet WALLET_SENDER connected to all seed nodes using StoreAndForwardOnly
-  #   When I send 100000000 uT from wallet WALLET_A to wallet WALLET_SENDER at fee 100
+  #   When I send a one-sided transaction of 100000000 uT from wallet WALLET_A to wallet WALLET_SENDER at fee 100
   #   When mining node MINER mines 5 blocks
   #   Then all nodes are at height 10
   #   Then I wait for wallet WALLET_SENDER to have at least 100000000 uT
   #   Then I stop wallet WALLET_RECV
-  #   When I send 1000000 uT without waiting for broadcast from wallet WALLET_SENDER to wallet WALLET_RECV at fee 100
+  #   When I send 1000000 uT one-sided without waiting for broadcast from wallet WALLET_SENDER to wallet WALLET_RECV at fee 100
   #   When wallet WALLET_SENDER detects last transaction is Pending
   #   Then I stop wallet WALLET_SENDER
   #   When I wait 15 seconds
@@ -401,7 +401,7 @@ Feature: Wallet Transactions
   #   Then I wait for wallet WALLET_SENDER to have at least 10000000000 uT
   #   Then I stop wallet WALLET_RECV
   #   When I wait 15 seconds
-  #   When I send 1000000 uT without waiting for broadcast from wallet WALLET_SENDER to wallet WALLET_RECV at fee 100
+  #   When I send 1000000 uT one-sided without waiting for broadcast from wallet WALLET_SENDER to wallet WALLET_RECV at fee 100
   #   When I wait 15 seconds
   #   Then I cancel last transaction in wallet WALLET_SENDER
   #   Then I restart wallet WALLET_RECV

--- a/integration_tests/tests/features/WalletTransfer.feature
+++ b/integration_tests/tests/features/WalletTransfer.feature
@@ -14,7 +14,7 @@ Feature: Wallet Transfer
     When I have wallet WALLET_A with 10T connected to base node NODE_A
     When I have wallet WALLET_B connected to base node NODE_B
     When I wait 5 seconds
-    When I transfer 5T from WALLET_A to WALLET_B
+    When I transfer 5T one-sided from WALLET_A to WALLET_B
     When I mine 4 blocks on SEED_A
     Then wallet WALLET_A has 5T
     When I wait 5 seconds
@@ -37,7 +37,7 @@ Feature: Wallet Transfer
     When mining node MINER mines 5 blocks
     Then all nodes are at height 10
     Then I wait for wallet WALLET_A to have at least 10000000000 uT
-    When I transfer 50000 uT from WALLET_A to WALLET_B and WALLET_C at fee 20
+    When I transfer 50000 uT one-sided from WALLET_A to WALLET_B and WALLET_C at fee 20
     When mining node MINER mines 10 blocks
     Then all nodes are at height 20
     Then all wallets detect all transactions as Mined_or_OneSidedConfirmed

--- a/integration_tests/tests/steps/mod.rs
+++ b/integration_tests/tests/steps/mod.rs
@@ -20,7 +20,7 @@
 //   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::time::Duration;
+use std::{fs::OpenOptions, io::Write, path::PathBuf, time::Duration};
 
 use cucumber::{then, when};
 use tari_integration_tests::TariWorld;
@@ -53,4 +53,10 @@ async fn receive_an_error(world: &mut TariWorld, error: String) {
 
     // assert!(world.errors.len() > 1);
     // assert!(world.errors.pop_front().unwrap().contains(&error))
+}
+
+pub fn cucumber_steps_log<S: AsRef<str>>(log_message: S) {
+    let log_file = PathBuf::from("./log/steps.log");
+    let mut file = OpenOptions::new().create(true).append(true).open(log_file).unwrap();
+    writeln!(file, "{}", log_message.as_ref()).unwrap();
 }

--- a/integration_tests/tests/steps/mod.rs
+++ b/integration_tests/tests/steps/mod.rs
@@ -20,8 +20,14 @@
 //   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{fs::OpenOptions, io::Write, path::PathBuf, time::Duration};
+use std::{
+    fs::OpenOptions,
+    io::{BufRead, Write},
+    path::PathBuf,
+    time::Duration,
+};
 
+use chrono::Local;
 use cucumber::{then, when};
 use tari_integration_tests::TariWorld;
 
@@ -58,5 +64,26 @@ async fn receive_an_error(world: &mut TariWorld, error: String) {
 pub fn cucumber_steps_log<S: AsRef<str>>(log_message: S) {
     let log_file = PathBuf::from("./log/steps.log");
     let mut file = OpenOptions::new().create(true).append(true).open(log_file).unwrap();
-    writeln!(file, "{}", log_message.as_ref()).unwrap();
+    let timestamp = Local::now().format("%Y-%m-%d %H:%M:%S").to_string();
+    writeln!(file, "[{}] {}", timestamp, log_message.as_ref()).unwrap();
+}
+
+pub fn get_saved_seed_words(world: &mut TariWorld, wallet_name: &str) -> Vec<String> {
+    let source_wallet = world
+        .get_wallet(&wallet_name)
+        .unwrap_or_else(|e| panic!("Wallet process '{}' does not exist in world: {}", wallet_name, e));
+    let seed_words_path = source_wallet.temp_dir_path.clone().join("seed_words.txt");
+    let seed_words_file = std::fs::File::open(&seed_words_path)
+        .unwrap_or_else(|e| panic!("Failed to open seed words file at {:?}: {}", seed_words_path, e));
+    let reader = std::io::BufReader::new(seed_words_file);
+    let line = reader
+        .lines()
+        .next()
+        .unwrap_or_else(|| panic!("Seed words file at {:?} is empty", seed_words_path))
+        .unwrap_or_else(|e| panic!("Failed to read seed words from file: {}", e));
+    line.split_whitespace()
+        .collect::<Vec<_>>()
+        .into_iter()
+        .map(|v| v.to_string())
+        .collect::<Vec<_>>()
 }

--- a/integration_tests/tests/steps/wallet_cli_steps.rs
+++ b/integration_tests/tests/steps/wallet_cli_steps.rs
@@ -20,7 +20,7 @@
 //   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{convert::TryFrom, path::PathBuf, str::FromStr, time::Duration};
+use std::{convert::TryFrom, io::BufRead, path::PathBuf, str::FromStr, time::Duration};
 
 use cucumber::{then, when};
 use minotari_app_grpc::tari_rpc::Empty;
@@ -31,6 +31,7 @@ use minotari_console_wallet::{
     CoinSplitArgs,
     DiscoverPeerArgs,
     ExportUtxosArgs,
+    ExportViewKeyAndSpendKeyArgs,
     MakeItRainArgs,
     SendMinotariArgs,
     SetBaseNodeArgs,
@@ -43,6 +44,7 @@ use tari_integration_tests::{
     wallet_process::{create_wallet_client, get_default_cli, spawn_wallet},
     TariWorld,
 };
+use tari_key_manager::SeedWords;
 use tari_utilities::hex::Hex;
 
 #[then(expr = "I change base node of {word} to {word} via command line")]
@@ -349,4 +351,130 @@ async fn whois(world: &mut TariWorld, node: String, wallet: String) {
     let base_node = world.wallet_connected_to_base_node.get(&wallet).unwrap();
     let seed_nodes = world.base_nodes.get(&node).unwrap().seed_nodes.clone();
     spawn_wallet(world, wallet, Some(base_node.clone()), seed_nodes, None, Some(cli)).await;
+}
+
+#[then(expr = "I recover wallet {word} into wallet {word} from seed words on node {word}")]
+async fn recover_wallet_via_cli(
+    world: &mut TariWorld,
+    source_wallet_name: String,
+    target_wallet_name: String,
+    node: String,
+) {
+    if let Some(wallet_ps) = world.wallets.get_mut(&target_wallet_name) {
+        wallet_ps.kill();
+        tokio::time::sleep(Duration::from_secs(5)).await;
+    }
+
+    let source_wallet = world.get_wallet(&source_wallet_name).unwrap();
+    let seed_words_path = source_wallet.temp_dir_path.clone().join("seed_words.txt");
+    let seed_words_file = std::fs::File::open(seed_words_path).unwrap();
+    let reader = std::io::BufReader::new(seed_words_file);
+    let line = reader.lines().next().unwrap().unwrap();
+    let saved_seed_words = line
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .into_iter()
+        .map(|v| v.to_string())
+        .collect::<Vec<_>>();
+
+    let mut cli = get_default_cli();
+
+    let mut node_client = world.get_node_client(&node).await.unwrap();
+    let node_identity = node_client.identify(Empty {}).await.unwrap().into_inner();
+
+    let args = SetBaseNodeArgs {
+        public_key: UniPublicKey::from_str(node_identity.public_key.to_hex().as_str()).unwrap(),
+        address: Multiaddr::from_str(node_identity.public_addresses[0].as_str()).unwrap(),
+    };
+    cli.command2 = Some(CliCommands::SetCustomBaseNode(args));
+
+    cli.recovery = true;
+    let mut seed_words = SeedWords::new(vec![]);
+    for word in &saved_seed_words {
+        seed_words.push(word.to_string());
+    }
+    cli.seed_words = Some(seed_words);
+
+    let seed_nodes = world.base_nodes.get(&node).unwrap().seed_nodes.clone();
+    spawn_wallet(
+        world,
+        target_wallet_name,
+        Some(node.clone()),
+        seed_nodes,
+        None,
+        Some(cli),
+    )
+    .await;
+}
+
+#[then(expr = "I export wallet {word} view and spend keys as {word}")]
+async fn export_wallet_view_and_spend_keys_via_cli(
+    world: &mut TariWorld,
+    wallet_name: String,
+    view_and_spend_key: String,
+) {
+    let wallet_ps = if let Some(wallet_ps) = world.wallets.get_mut(&wallet_name) {
+        wallet_ps.kill();
+        tokio::time::sleep(Duration::from_secs(5)).await;
+        wallet_ps.clone()
+    } else {
+        panic!("Wallet '{}' not found", wallet_name);
+    };
+
+    let mut cli = get_default_cli();
+
+    let output_file = wallet_ps.temp_dir_path.clone().join("view_and_spend_key.txt");
+    let args = ExportViewKeyAndSpendKeyArgs {
+        output_file: Some(output_file.clone()),
+    };
+    cli.command2 = Some(CliCommands::ExportViewKeyAndSpendKey(args));
+
+    world.view_and_spend_keys.insert(view_and_spend_key, output_file);
+
+    spawn_wallet(
+        world,
+        wallet_name,
+        wallet_ps.base_node_name.clone(),
+        wallet_ps.peer_seeds.clone(),
+        None,
+        Some(cli),
+    )
+    .await;
+}
+
+#[then(expr = "I create view wallet {word} from view and spend keys {word} on node {word}")]
+async fn recover_wallet_from_view_and_spend_keys_via_cli(
+    world: &mut TariWorld,
+    wallet_name: String,
+    view_and_spend_key: String,
+    node: String,
+) {
+    if let Some(wallet_ps) = world.wallets.get_mut(&wallet_name) {
+        wallet_ps.kill();
+        tokio::time::sleep(Duration::from_secs(5)).await;
+        world.wallets.remove(&wallet_name);
+    }
+
+    // Extract view_key and spend_key from the file with format:
+    // {"view_key":"c593a5d131d46ece6d08c39693b1260aeb502d25c0e898358e6fc1b2b19fe404","public_view_key":"
+    // 5ade435cc6947ac2979c0ea2f3d6a1f64d0c35b1995d48a60e2720c283dd3e38","spend_key":"
+    // 9e9c7d4eedb70a1e31bfaad1ad38ffc7340a4b61120e6c911afcd702219c1764","birthday":1252}
+    let keys_file = world.view_and_spend_keys.get(&view_and_spend_key);
+    let keys_file = if let Some(file) = keys_file {
+        file
+    } else {
+        panic!("View and spend keys file not found for '{}'", view_and_spend_key);
+    };
+    let keys_content = std::fs::read_to_string(keys_file).unwrap();
+    let keys_json: serde_json::Value = serde_json::from_str(&keys_content).unwrap();
+    let view_key = keys_json["view_key"].as_str().unwrap();
+    let spend_key = keys_json["spend_key"].as_str().unwrap();
+
+    let mut cli = get_default_cli();
+
+    cli.view_private_key = Some(view_key.to_string());
+    cli.spend_key = Some(spend_key.to_string());
+
+    let seed_nodes = world.base_nodes.get(&node).unwrap().seed_nodes.clone();
+    spawn_wallet(world, wallet_name, Some(node.clone()), seed_nodes, None, Some(cli)).await;
 }

--- a/integration_tests/tests/steps/wallet_cli_steps.rs
+++ b/integration_tests/tests/steps/wallet_cli_steps.rs
@@ -20,7 +20,7 @@
 //   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{convert::TryFrom, io::BufRead, path::PathBuf, str::FromStr, time::Duration};
+use std::{convert::TryFrom, path::PathBuf, str::FromStr, time::Duration};
 
 use cucumber::{then, when};
 use minotari_app_grpc::tari_rpc::Empty;
@@ -46,6 +46,8 @@ use tari_integration_tests::{
 };
 use tari_key_manager::SeedWords;
 use tari_utilities::hex::Hex;
+
+use crate::steps::get_saved_seed_words;
 
 #[then(expr = "I change base node of {word} to {word} via command line")]
 async fn change_base_node_of_wallet_via_cli(world: &mut TariWorld, wallet: String, node: String) {
@@ -365,18 +367,6 @@ async fn recover_wallet_via_cli(
         tokio::time::sleep(Duration::from_secs(5)).await;
     }
 
-    let source_wallet = world.get_wallet(&source_wallet_name).unwrap();
-    let seed_words_path = source_wallet.temp_dir_path.clone().join("seed_words.txt");
-    let seed_words_file = std::fs::File::open(seed_words_path).unwrap();
-    let reader = std::io::BufReader::new(seed_words_file);
-    let line = reader.lines().next().unwrap().unwrap();
-    let saved_seed_words = line
-        .split_whitespace()
-        .collect::<Vec<_>>()
-        .into_iter()
-        .map(|v| v.to_string())
-        .collect::<Vec<_>>();
-
     let mut cli = get_default_cli();
 
     let mut node_client = world.get_node_client(&node).await.unwrap();
@@ -389,6 +379,7 @@ async fn recover_wallet_via_cli(
     cli.command2 = Some(CliCommands::SetCustomBaseNode(args));
 
     cli.recovery = true;
+    let saved_seed_words = get_saved_seed_words(world, &source_wallet_name);
     let mut seed_words = SeedWords::new(vec![]);
     for word in &saved_seed_words {
         seed_words.push(word.to_string());
@@ -465,10 +456,15 @@ async fn recover_wallet_from_view_and_spend_keys_via_cli(
     } else {
         panic!("View and spend keys file not found for '{}'", view_and_spend_key);
     };
-    let keys_content = std::fs::read_to_string(keys_file).unwrap();
-    let keys_json: serde_json::Value = serde_json::from_str(&keys_content).unwrap();
-    let view_key = keys_json["view_key"].as_str().unwrap();
-    let spend_key = keys_json["spend_key"].as_str().unwrap();
+    let keys_content = std::fs::read_to_string(keys_file).unwrap_or_else(|e| panic!("Failed to read keys file: {}", e));
+    let keys_json: serde_json::Value =
+        serde_json::from_str(&keys_content).unwrap_or_else(|e| panic!("Failed to parse keys JSON: {}", e));
+    let view_key = keys_json["view_key"]
+        .as_str()
+        .unwrap_or_else(|| panic!("Missing 'view_key' in keys file"));
+    let spend_key = keys_json["spend_key"]
+        .as_str()
+        .unwrap_or_else(|| panic!("Missing 'spend_key' in keys file"));
 
     let mut cli = get_default_cli();
 

--- a/integration_tests/tests/steps/wallet_ffi_steps.rs
+++ b/integration_tests/tests/steps/wallet_ffi_steps.rs
@@ -23,6 +23,7 @@
 use std::{convert::TryFrom, io::BufRead, ptr::null, time::Duration};
 
 use cucumber::{given, then, when};
+use minotari_app_grpc::tari_rpc::GetBalanceResponse;
 use tari_common_types::tari_address::TariAddress;
 use tari_core::transactions::transaction_components::encrypted_data::{PaymentId, TxType};
 use tari_integration_tests::{
@@ -145,6 +146,24 @@ async fn ffi_wait_for_balance(world: &mut TariWorld, wallet: String, balance: u6
         ffi_balance.get_available(),
         ffi_balance.get_pending_incoming(),
         ffi_balance.get_time_locked()
+    );
+}
+
+#[then(expr = "ffi wallet {word} balance is {word}")]
+async fn ffi_has_balance(world: &mut TariWorld, wallet: String, balance_key: String) {
+    let ffi_wallet = world.get_ffi_wallet(&wallet).unwrap();
+    let ffi_balance = ffi_wallet.get_balance();
+    let ffi_wallet_balance = GetBalanceResponse {
+        available_balance: ffi_balance.get_available(),
+        pending_incoming_balance: ffi_balance.get_pending_incoming(),
+        timelocked_balance: ffi_balance.get_time_locked(),
+        pending_outgoing_balance: ffi_balance.get_pending_outgoing(),
+    };
+    let balance = world.balance.get(&balance_key).unwrap();
+    assert_eq!(
+        balance, &ffi_wallet_balance,
+        "Wallet {}:{} doesn't have the correct balance: expected {:?} current {:?}",
+        ffi_wallet.name, ffi_wallet.port, balance, ffi_wallet_balance
     );
 }
 
@@ -533,7 +552,7 @@ async fn ffi_recover_wallet(world: &mut TariWorld, wallet_name: String, ffi_wall
     let seed_words_file = std::fs::File::open(seed_words_path).unwrap();
     let reader = std::io::BufReader::new(seed_words_file);
     let line = reader.lines().next().unwrap().unwrap();
-    let words = line.split_whitespace().collect();
+    let words = line.split_whitespace().collect::<Vec<&str>>();
     let seed_words = create_seed_words(words);
 
     spawn_wallet_ffi(world, ffi_wallet_name.clone(), seed_words.get_ptr());

--- a/integration_tests/tests/steps/wallet_ffi_steps.rs
+++ b/integration_tests/tests/steps/wallet_ffi_steps.rs
@@ -20,7 +20,7 @@
 //   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{convert::TryFrom, io::BufRead, ptr::null, time::Duration};
+use std::{convert::TryFrom, ptr::null, time::Duration};
 
 use cucumber::{given, then, when};
 use minotari_app_grpc::tari_rpc::GetBalanceResponse;
@@ -31,6 +31,8 @@ use tari_integration_tests::{
     TariWorld,
 };
 use tari_utilities::hex::Hex;
+
+use crate::steps::{cucumber_steps_log, get_saved_seed_words};
 
 #[when(expr = "I have a ffi wallet {word} connected to base node {word}")]
 #[then(expr = "I have a ffi wallet {word} connected to base node {word}")]
@@ -68,7 +70,7 @@ async fn ffi_set_base_node(world: &mut TariWorld, base_node: String, wallet: Str
 async fn ffi_get_public_key(world: &mut TariWorld, wallet: String) {
     let wallet = world.get_ffi_wallet(&wallet).unwrap();
     let public_key = wallet.identify();
-    println!("public_key {}", public_key);
+    cucumber_steps_log(format!("wallet: {}, public_key: {}", wallet.name, public_key));
 }
 
 #[then(expr = "I want to get emoji id of ffi wallet {word}")]
@@ -87,19 +89,18 @@ async fn ffi_get_emoji_id(world: &mut TariWorld, wallet: String) {
 async fn ffi_stop_wallet(world: &mut TariWorld, wallet: String) {
     let address = world.get_wallet_address(&wallet).await.unwrap();
     let ffi_wallet = world.ffi_wallets.get_mut(&wallet).unwrap();
-    println!("Adding wallet {}", wallet);
+    cucumber_steps_log(format!("Adding wallet {}", wallet));
     world.wallet_addresses.insert(wallet, address);
     ffi_wallet.destroy();
 }
 
 #[then(expr = "I retrieve the mnemonic word list for {word}")]
 async fn ffi_retrieve_mnemonic_words(_world: &mut TariWorld, language: String) {
-    println!("Mnemonic words for language {}:", language);
+    cucumber_steps_log(format!("Mnemonic words for language {}:", language));
     let words = get_mnemonic_word_list_for_language(language);
     for i in 0..words.get_length() {
-        print!("{} ", words.get_at(u32::try_from(i).unwrap()).as_string());
+        cucumber_steps_log(format!("{} ", words.get_at(u32::try_from(i).unwrap()).as_string()));
     }
-    println!();
     assert_eq!(words.get_length(), 2048);
 }
 
@@ -121,25 +122,29 @@ async fn ffi_wait_wallet_to_connect(world: &mut TariWorld, wallet: String, node:
 }
 
 #[then(expr = "I wait for ffi wallet {word} to have at least {int} uT")]
-async fn ffi_wait_for_balance(world: &mut TariWorld, wallet: String, balance: u64) {
+#[when(expr = "I wait for ffi wallet {word} to have at least {int} uT")]
+async fn ffi_wait_for_balance(world: &mut TariWorld, wallet: String, amount: u64) {
     let ffi_wallet = world.get_ffi_wallet(&wallet).unwrap();
     let mut ffi_balance = ffi_wallet.get_balance();
     let mut cnt = 0;
-    while ffi_balance.get_available() < balance && cnt < 10 {
-        println!(
-            "wallet {}, port {}, balance: available {} incoming {} time locked {}",
-            ffi_wallet.name,
-            ffi_wallet.port,
-            ffi_balance.get_available(),
-            ffi_balance.get_pending_incoming(),
-            ffi_balance.get_time_locked()
-        );
+    while ffi_balance.get_available() < amount && cnt < 10 {
+        if cnt % 3 == 0 {
+            cucumber_steps_log(format!(
+                "wallet {}, port {}, needs available {}, has balance: available {} incoming {} time locked {}",
+                ffi_wallet.name,
+                ffi_wallet.port,
+                amount,
+                ffi_balance.get_available(),
+                ffi_balance.get_pending_incoming(),
+                ffi_balance.get_time_locked()
+            ));
+        }
         tokio::time::sleep(Duration::from_secs(3)).await;
         ffi_balance = ffi_wallet.get_balance();
         cnt += 1;
     }
     assert!(
-        ffi_balance.get_available() >= balance,
+        ffi_balance.get_available() >= amount,
         "Wallet {}:{} doesn't have enough available funds: available {} incoming {} time locked {}",
         ffi_wallet.name,
         ffi_wallet.port,
@@ -152,16 +157,37 @@ async fn ffi_wait_for_balance(world: &mut TariWorld, wallet: String, balance: u6
 #[then(expr = "ffi wallet {word} balance is {word}")]
 async fn ffi_has_balance(world: &mut TariWorld, wallet: String, balance_key: String) {
     let ffi_wallet = world.get_ffi_wallet(&wallet).unwrap();
-    let ffi_balance = ffi_wallet.get_balance();
-    let ffi_wallet_balance = GetBalanceResponse {
-        available_balance: ffi_balance.get_available(),
-        pending_incoming_balance: ffi_balance.get_pending_incoming(),
-        timelocked_balance: ffi_balance.get_time_locked(),
-        pending_outgoing_balance: ffi_balance.get_pending_outgoing(),
-    };
     let balance = world.balance.get(&balance_key).unwrap();
-    assert_eq!(
-        balance, &ffi_wallet_balance,
+    let num_retries = 15;
+    let mut ffi_wallet_balance = GetBalanceResponse::default();
+
+    for i in 0..num_retries {
+        ffi_wallet.start_transaction_validation();
+        let ffi_balance = ffi_wallet.get_balance();
+        ffi_wallet_balance = GetBalanceResponse {
+            available_balance: ffi_balance.get_available(),
+            pending_incoming_balance: ffi_balance.get_pending_incoming(),
+            timelocked_balance: ffi_balance.get_time_locked(),
+            pending_outgoing_balance: ffi_balance.get_pending_outgoing(),
+        };
+        if &ffi_wallet_balance == balance {
+            cucumber_steps_log(format!(
+                "Wallet {}:{} waiting for balance to be {:?} (DONE), current {:?}",
+                ffi_wallet.name, ffi_wallet.port, balance, ffi_wallet_balance
+            ));
+            return;
+        } else if i % 3 == 0 {
+            cucumber_steps_log(format!(
+                "Wallet {}:{} waiting for balance to be {:?}, current {:?}",
+                ffi_wallet.name, ffi_wallet.port, balance, ffi_wallet_balance
+            ))
+        } else {
+            // Nothing here
+        }
+
+        tokio::time::sleep(Duration::from_secs(2)).await;
+    }
+    panic!(
         "Wallet {}:{} doesn't have the correct balance: expected {:?} current {:?}",
         ffi_wallet.name, ffi_wallet.port, balance, ffi_wallet_balance
     );
@@ -288,6 +314,7 @@ async fn ffi_check_number_of_outbound_transactions(world: &mut TariWorld, wallet
 }
 
 #[then(expr = "I wait for ffi wallet {word} to have at least {int} contacts to be {word}")]
+#[when(expr = "I wait for ffi wallet {word} to have at least {int} contacts to be {word}")]
 async fn ffi_check_contacts(world: &mut TariWorld, wallet: String, cnt: u64, status: String) {
     assert!(
         ["Online", "Offline", "NeverSeen"].contains(&status.as_str()),
@@ -295,14 +322,20 @@ async fn ffi_check_contacts(world: &mut TariWorld, wallet: String, cnt: u64, sta
         status
     );
     let ffi_wallet = world.get_ffi_wallet(&wallet).unwrap();
-    println!(
+    cucumber_steps_log(format!(
         "Waiting for {} to have at least {} contacts with status '{}'",
         wallet, cnt, status
-    );
+    ));
     let mut found_cnt = 0;
 
     let liveness_data = ffi_wallet.get_liveness_data();
-    for _ in 0..120 {
+    for i in 0..120 {
+        if i % 5 == 0 {
+            cucumber_steps_log(format!(
+                "Waiting for {} to have at least {} contacts with status '{}', current count: {}",
+                wallet, cnt, status, found_cnt
+            ));
+        }
         found_cnt = 0;
         for (_alias, data) in liveness_data.lock().unwrap().iter() {
             if data.get_online_status() == status {
@@ -330,13 +363,21 @@ async fn ffi_view_transaction_kernels_for_completed(world: &mut TariWorld, walle
     for i in 0..completed_transactions.get_length() {
         let completed_transaction = completed_transactions.get_at(i);
         let kernel = completed_transaction.get_transaction_kernel();
-        println!("Transaction kernel info :");
+        cucumber_steps_log(format!("Wallet {}, Transaction kernel info :", wallet));
         assert!(!kernel.get_excess_hex().is_empty());
-        println!("Excess {}", kernel.get_excess_hex());
+        cucumber_steps_log(format!("Wallet {}, Excess {}", wallet, kernel.get_excess_hex()));
         assert!(!kernel.get_excess_public_nonce_hex().is_empty());
-        println!("Nonce {}", kernel.get_excess_public_nonce_hex());
+        cucumber_steps_log(format!(
+            "Wallet {}, Nonce {}",
+            wallet,
+            kernel.get_excess_public_nonce_hex()
+        ));
         assert!(!kernel.get_excess_signature_hex().is_empty());
-        println!("Signature {}", kernel.get_excess_signature_hex());
+        cucumber_steps_log(format!(
+            "Wallet {}, Signature {}",
+            wallet,
+            kernel.get_excess_signature_hex()
+        ));
         let address = completed_transaction.get_destination_tari_address();
         assert!(TariAddress::from_hex(&address.address().get_as_hex()).is_ok());
         let address = completed_transaction.get_source_tari_address();
@@ -486,12 +527,18 @@ async fn ffi_detects_transaction(
         "TRANSACTION_STATUS_ONE_SIDED_CONFIRMED"
     ]
     .contains(&status.as_str()));
-    println!(
+    cucumber_steps_log(format!(
         "Waiting for {} to have detected {} {} {} transaction(s)",
         wallet, comparison, count, status
-    );
+    ));
     let mut found_count = 0;
-    for _ in 0..120 {
+    for i in 0..120 {
+        if i % 5 == 0 {
+            cucumber_steps_log(format!(
+                "Waiting for {} to have detected {} {} {} transaction(s), current count: {}",
+                wallet, comparison, count, status, found_count
+            ));
+        }
         found_count = match status.as_str() {
             "TRANSACTION_STATUS_BROADCAST" => ffi_wallet.get_counters().get_transaction_broadcast(),
             "TRANSACTION_STATUS_MINED_UNCONFIRMED" => ffi_wallet.get_counters().get_transaction_mined_unconfirmed(),
@@ -513,7 +560,7 @@ async fn ffi_detects_transaction(
         }
         tokio::time::sleep(Duration::from_secs(5)).await;
     }
-    println!("Counters {:?}", ffi_wallet.get_counters());
+    cucumber_steps_log(format!("Counters {:?}", ffi_wallet.get_counters()));
     match comparison.as_str() {
         "AT_LEAST" => assert!(
             found_count >= count,
@@ -532,10 +579,19 @@ async fn ffi_detects_transaction(
 #[then(expr = "I wait for ffi wallet {word} to receive {int} mined")]
 async fn ffi_wait_for_received_mined(world: &mut TariWorld, wallet: String, count: u64) {
     let ffi_wallet = world.get_ffi_wallet(&wallet).unwrap();
-    println!("Waiting for {} to receive {} transaction(s) mined", wallet, count);
+    cucumber_steps_log(format!(
+        "Waiting for {} to receive {} transaction(s) mined",
+        wallet, count
+    ));
 
     let mut found_cnt = 0;
-    for _ in 0..120 {
+    for i in 0..120 {
+        if i % 5 == 0 {
+            cucumber_steps_log(format!(
+                "Waiting for {} to receive {} transaction(s) mined, current count: {}",
+                wallet, count, found_cnt
+            ));
+        }
         found_cnt = ffi_wallet.get_counters().get_transaction_mined();
         if found_cnt >= count {
             break;
@@ -547,13 +603,9 @@ async fn ffi_wait_for_received_mined(world: &mut TariWorld, wallet: String, coun
 
 #[then(expr = "I recover wallet {word} into ffi wallet {word} from seed words on node {word}")]
 async fn ffi_recover_wallet(world: &mut TariWorld, wallet_name: String, ffi_wallet_name: String, base_node: String) {
-    let wallet = world.get_wallet(&wallet_name).unwrap();
-    let seed_words_path = wallet.temp_dir_path.clone().join("seed_words.txt");
-    let seed_words_file = std::fs::File::open(seed_words_path).unwrap();
-    let reader = std::io::BufReader::new(seed_words_file);
-    let line = reader.lines().next().unwrap().unwrap();
-    let words = line.split_whitespace().collect::<Vec<&str>>();
-    let seed_words = create_seed_words(words);
+    let saved_seed_words = get_saved_seed_words(world, &wallet_name);
+    let saved_seed_words = saved_seed_words.iter().map(|word| word.as_str()).collect();
+    let seed_words = create_seed_words(saved_seed_words);
 
     spawn_wallet_ffi(world, ffi_wallet_name.clone(), seed_words.get_ptr());
 
@@ -583,10 +635,10 @@ async fn ffi_fee_per_gram_stats(world: &mut TariWorld, wallet: String, min: u64,
     let fee_per_gram_stats = ffi_wallet.get_fee_per_gram_stats(5);
     for i in 0..fee_per_gram_stats.get_length() {
         let fee_per_gram_stat = fee_per_gram_stats.get_at(i);
-        println!("order {}", fee_per_gram_stat.get_order());
-        println!("min {}", fee_per_gram_stat.get_min_fee_per_gram());
-        println!("avg {}", fee_per_gram_stat.get_avg_fee_per_gram());
-        println!("max {}", fee_per_gram_stat.get_max_fee_per_gram());
+        cucumber_steps_log(format!("{}: order {}", wallet, fee_per_gram_stat.get_order()));
+        cucumber_steps_log(format!("{}: min {}", wallet, fee_per_gram_stat.get_min_fee_per_gram()));
+        cucumber_steps_log(format!("{}: avg {}", wallet, fee_per_gram_stat.get_avg_fee_per_gram()));
+        cucumber_steps_log(format!("{}: max {}", wallet, fee_per_gram_stat.get_max_fee_per_gram()));
         assert_eq!(fee_per_gram_stat.get_min_fee_per_gram(), min);
         assert_eq!(fee_per_gram_stat.get_avg_fee_per_gram(), avg);
         assert_eq!(fee_per_gram_stat.get_max_fee_per_gram(), max);

--- a/integration_tests/tests/steps/wallet_steps.rs
+++ b/integration_tests/tests/steps/wallet_steps.rs
@@ -132,6 +132,27 @@ async fn wait_for_wallet_to_have_micro_tari(world: &mut TariWorld, wallet: Strin
     );
 }
 
+#[when(expr = "I remember wallet {word} balance {word}")]
+#[then(expr = "I remember wallet {word} balance {word}")]
+async fn remember_wallet_balance(world: &mut TariWorld, wallet: String, balance_key: String) {
+    let wallet_ps = world.wallets.get(&wallet).unwrap();
+
+    let mut client = wallet_ps.get_grpc_client().await.unwrap();
+    println!("remember_wallet_balance - 0");
+
+    let _result = client.validate_all_transactions(ValidateRequest {}).await;
+    println!("remember_wallet_balance - 1");
+    let balance = client
+        .get_balance(GetBalanceRequest { payment_id: None })
+        .await
+        .unwrap()
+        .into_inner();
+    println!("remember_wallet_balance - 2: {:?}", balance);
+    world.balance.insert(balance_key, balance);
+    // world.balance.insert(balance_key, GetBalanceResponse::default());
+    println!("remember_wallet_balance - 3");
+}
+
 #[when(expr = "I have wallet {word} connected to base node {word}")]
 async fn wallet_connected_to_base_node(world: &mut TariWorld, wallet: String, base_node: String) {
     let bn = world.base_nodes.get(&base_node).unwrap();

--- a/integration_tests/tests/steps/wallet_steps.rs
+++ b/integration_tests/tests/steps/wallet_steps.rs
@@ -39,7 +39,7 @@ use grpc::{
     TransferRequest,
     ValidateRequest,
 };
-use minotari_app_grpc::tari_rpc::{self as grpc, TransactionStatus};
+use minotari_app_grpc::tari_rpc::{self as grpc, GetBalanceResponse, GetStateRequest, TransactionStatus};
 use minotari_console_wallet::{CliCommands, ExportUtxosArgs};
 use minotari_wallet::transaction_service::config::TransactionRoutingMechanism;
 use tari_common_types::types::{ComAndPubSignature, CompressedPublicKey, PrivateKey, RangeProof};
@@ -115,19 +115,30 @@ async fn wait_for_wallet_to_have_micro_tari(world: &mut TariWorld, wallet: Strin
     let num_retries = 100;
 
     let mut client = wallet_ps.get_grpc_client().await.unwrap();
-    let mut curr_amount = 0;
+    let mut available_balance = 0;
 
-    for _ in 0..=num_retries {
+    for i in 0..=num_retries {
         let _result = client.validate_all_transactions(ValidateRequest {}).await;
-        curr_amount = client
+        let balance = client
             .get_balance(GetBalanceRequest { payment_id: None })
             .await
             .unwrap()
-            .into_inner()
-            .available_balance;
+            .into_inner();
+        available_balance = balance.available_balance;
 
-        if curr_amount >= amount {
+        if available_balance >= amount {
+            cucumber_steps_log(format!(
+                "Wallet {} needs at least available {} uT (DONE), has {:?}",
+                wallet, amount, balance
+            ));
             return;
+        } else if i % 5 == 0 {
+            cucumber_steps_log(format!(
+                "Wallet {} needs at least available {} uT, has {:?}",
+                wallet, amount, balance
+            ));
+        } else {
+            // Nothing here
         }
 
         tokio::time::sleep(Duration::from_secs(5)).await;
@@ -136,7 +147,7 @@ async fn wait_for_wallet_to_have_micro_tari(world: &mut TariWorld, wallet: Strin
     // failed to get wallet right amount, so we panic
     panic!(
         "wallet {} failed to get balance of at least amount {}, current amount is {}",
-        wallet, amount, curr_amount
+        wallet, amount, available_balance
     );
 }
 
@@ -146,19 +157,18 @@ async fn remember_wallet_balance(world: &mut TariWorld, wallet: String, balance_
     let wallet_ps = world.wallets.get(&wallet).unwrap();
 
     let mut client = wallet_ps.get_grpc_client().await.unwrap();
-    println!("remember_wallet_balance - 0");
 
     let _result = client.validate_all_transactions(ValidateRequest {}).await;
-    println!("remember_wallet_balance - 1");
     let balance = client
         .get_balance(GetBalanceRequest { payment_id: None })
         .await
         .unwrap()
         .into_inner();
-    println!("remember_wallet_balance - 2: {:?}", balance);
+    cucumber_steps_log(format!(
+        "Wallet: {}, balance key: {}, balance: {:?}",
+        wallet, balance_key, balance
+    ));
     world.balance.insert(balance_key, balance);
-    // world.balance.insert(balance_key, GetBalanceResponse::default());
-    println!("remember_wallet_balance - 3");
 }
 
 #[when(expr = "I have wallet {word} connected to base node {word}")]
@@ -203,7 +213,7 @@ async fn wallet_detects_all_txs_as_mined_status(world: &mut TariWorld, wallet_na
         let tx_info = tx_info.unwrap();
         let tx_id = tx_info.transaction.unwrap().tx_id;
 
-        println!("waiting for tx with tx_id = {} to be {}", tx_id, status);
+        cucumber_steps_log(format!("waiting for tx with tx_id = {} to be {}", tx_id, status));
         for retry in 0..=num_retries {
             let request = GetTransactionInfoRequest {
                 transaction_ids: vec![tx_id],
@@ -307,7 +317,7 @@ async fn wallet_detects_all_txs_are_at_least_in_some_status(
     let num_retries = 100;
 
     for tx_id in tx_ids {
-        println!("waiting for tx with tx_id = {} to be pending", tx_id);
+        cucumber_steps_log(format!("waiting for tx with tx_id = {} to be pending", tx_id));
         for retry in 0..=num_retries {
             let request = GetTransactionInfoRequest {
                 transaction_ids: vec![*tx_id],
@@ -388,7 +398,7 @@ async fn wallet_detects_all_txs_as_broadcast(world: &mut TariWorld, wallet_name:
     let num_retries = 100;
 
     for tx_id in tx_ids {
-        println!("waiting for tx with tx_id = {} to be mined_confirmed", tx_id);
+        cucumber_steps_log(format!("waiting for tx with tx_id = {} to be mined_confirmed", tx_id));
         for retry in 0..=num_retries {
             let request = GetTransactionInfoRequest {
                 transaction_ids: vec![*tx_id],
@@ -405,19 +415,19 @@ async fn wallet_detects_all_txs_as_broadcast(world: &mut TariWorld, wallet_name:
             }
             match tx_info.status() {
                 grpc::TransactionStatus::Broadcast => {
-                    println!(
+                    cucumber_steps_log(format!(
                         "Transaction with tx_id = {} has been detected as mined_confirmed by wallet {}",
                         tx_id,
                         wallet_name.as_str()
-                    );
+                    ));
                     return;
                 },
                 _ => {
-                    println!(
+                    cucumber_steps_log(format!(
                         "Transaction with tx_id = {} has been detected with status = {:?}",
                         tx_id,
                         tx_info.status()
-                    );
+                    ));
                     tokio::time::sleep(Duration::from_secs(5)).await;
                     continue;
                 },
@@ -440,7 +450,7 @@ async fn wallet_detects_last_tx_as_pending(world: &mut TariWorld, wallet: String
     let tx_id = tx_ids.last().unwrap(); // get last transaction
     let num_retries = 100;
 
-    println!("waiting for tx with tx_id = {} to be pending", tx_id);
+    cucumber_steps_log(format!("waiting for tx with tx_id = {} to be pending", tx_id));
     for retry in 0..=num_retries {
         let request = GetTransactionInfoRequest {
             transaction_ids: vec![*tx_id],
@@ -457,11 +467,11 @@ async fn wallet_detects_last_tx_as_pending(world: &mut TariWorld, wallet: String
         }
         match tx_info.status() {
             grpc::TransactionStatus::Pending => {
-                println!(
+                cucumber_steps_log(format!(
                     "Transaction with tx_id = {} has been detected as pending by wallet {}",
                     tx_id,
                     wallet.as_str()
-                );
+                ));
                 return;
             },
             _ => {
@@ -486,7 +496,7 @@ async fn wallet_detects_last_tx_as_cancelled(world: &mut TariWorld, wallet: Stri
     let tx_id = tx_ids.last().unwrap(); // get last transaction
     let num_retries = 100;
 
-    println!("waiting for tx with tx_id = {} to be Cancelled", tx_id);
+    cucumber_steps_log(format!("waiting for tx with tx_id = {} to be Cancelled", tx_id));
     for retry in 0..=num_retries {
         let request = GetTransactionInfoRequest {
             transaction_ids: vec![*tx_id],
@@ -504,7 +514,11 @@ async fn wallet_detects_last_tx_as_cancelled(world: &mut TariWorld, wallet: Stri
         }
         match tx_info.status() {
             grpc::TransactionStatus::Rejected => {
-                println!("Transaction with tx_id = {} has status {:?}", tx_id, tx_info.status());
+                cucumber_steps_log(format!(
+                    "Transaction with tx_id = {} has status {:?}",
+                    tx_id,
+                    tx_info.status()
+                ));
                 return;
             },
             _ => {
@@ -542,11 +556,10 @@ async fn list_all_txs_for_wallet(world: &mut TariWorld, transaction_type: String
         if transaction_type == "COINBASE" && !is_coinbase || transaction_type == "NORMAL" && is_coinbase {
             continue;
         }
-        println!("\n");
-        println!(
+        cucumber_steps_log(format!(
             "TxId: {}, Status: {}, IsCancelled: {}, {}",
             tx_info.tx_id, tx_info.status, tx_info.is_cancelled, transaction_type
-        );
+        ));
     }
 }
 
@@ -659,23 +672,33 @@ async fn create_tx_custom_lock(
     world.transactions.insert(transaction, tx);
 }
 
+#[then(expr = "I wait for wallet {word} to have less than {int} uT")]
 #[when(expr = "I wait for wallet {word} to have less than {int} uT")]
 async fn wait_for_wallet_to_have_less_than_micro_tari(world: &mut TariWorld, wallet: String, amount: u64) {
     let mut client = create_wallet_client(world, wallet.clone()).await.unwrap();
-    println!("Waiting for wallet {} to have less than {} uT", wallet, amount);
+    cucumber_steps_log(format!("Waiting for wallet {} to have less than {} uT", wallet, amount));
 
     let num_retries = 100;
-    let request = GetBalanceRequest { payment_id: None };
-
-    for _ in 0..num_retries {
-        let balance_res = client.get_balance(request.clone()).await.unwrap().into_inner();
-        let current_balance = balance_res.available_balance;
-        if current_balance < amount {
-            println!(
-                "Wallet {} now has less than {}, with current balance {}",
-                wallet, amount, current_balance
-            );
+    for i in 0..num_retries {
+        let _result = client.validate_all_transactions(ValidateRequest {}).await;
+        let balance_res = client
+            .get_balance(GetBalanceRequest { payment_id: None })
+            .await
+            .unwrap()
+            .into_inner();
+        if balance_res.available_balance < amount {
+            cucumber_steps_log(format!(
+                "Wallet {} needs less than available {} uT (DONE), has {:?}",
+                wallet, amount, balance_res
+            ));
             return;
+        } else if i % 5 == 0 {
+            cucumber_steps_log(format!(
+                "Wallet {} needs less than available {} uT, has {:?}",
+                wallet, amount, balance_res
+            ));
+        } else {
+            // Nothing here
         }
         tokio::time::sleep(Duration::from_secs(5)).await;
     }
@@ -683,6 +706,42 @@ async fn wait_for_wallet_to_have_less_than_micro_tari(world: &mut TariWorld, wal
     panic!(
         "Wallet {} didn't get less than {} after num_retries {}",
         wallet, amount, num_retries
+    );
+}
+
+#[then(expr = "I wait for wallet {word} to have scanned to height {int}")]
+#[when(expr = "I wait for wallet {word} to have scanned to height {int}")]
+async fn wait_for_wallet_to_have_scanned_to_height(world: &mut TariWorld, wallet: String, height: u64) {
+    let mut client = create_wallet_client(world, wallet.clone()).await.unwrap();
+    cucumber_steps_log(format!(
+        "Waiting for wallet {} to have scanned to height {}",
+        wallet, height
+    ));
+
+    let num_retries = 15;
+    for i in 0..num_retries {
+        let _result = client.validate_all_transactions(ValidateRequest {}).await;
+        let state_res = client.get_state(GetStateRequest {}).await.unwrap().into_inner();
+        if state_res.scanned_height == height {
+            cucumber_steps_log(format!(
+                "Wallet {} needs to scan to height {} (DONE), current {:?}",
+                wallet, height, state_res
+            ));
+            return;
+        } else if i % 3 == 0 {
+            cucumber_steps_log(format!(
+                "Wallet {} needs to scan to height {}, current {:?}",
+                wallet, height, state_res
+            ));
+        } else {
+            // Nothing here
+        }
+        tokio::time::sleep(Duration::from_secs(5)).await;
+    }
+
+    panic!(
+        "Wallet {} didn't scan to height {} after num_retries {}",
+        wallet, height, num_retries
     );
 }
 
@@ -791,10 +850,10 @@ async fn send_amount_from_source_wallet_to_dest_wallet_without_broadcast(
 
     dest_tx_ids.push(tx_id);
 
-    println!(
+    cucumber_steps_log(format!(
         "Transfer amount {} from {} to {} at fee {} succeeded",
         amount, source_wallet, dest_wallet, fee
-    );
+    ));
 }
 
 #[then(expr = "I send a one-sided transaction of {int} uT from wallet {word} to wallet {word} at fee {int}")]
@@ -845,7 +904,7 @@ async fn send_one_sided_transaction_from_source_wallet_to_dest_wallt(
         fee
     );
 
-    // we wait for transaction to be broadcasted
+    // we wait for transaction to be broadcast
     let tx_id = tx_res.transaction_id;
     let num_retries = 100;
     let tx_info_req = GetTransactionInfoRequest {
@@ -862,19 +921,29 @@ async fn send_one_sided_transaction_from_source_wallet_to_dest_wallt(
 
         // TransactionStatus::TRANSACTION_STATUS_BROADCAST == 1_i32
         if tx_info.status == 1_i32 {
-            println!(
-                "One sided transaction from {} to {} with amount {} at fee {} has been broadcasted",
+            cucumber_steps_log(format!(
+                "Wait for one sided transaction from {} to {} (DONE) with amount {} at fee {} to be broadcast",
                 source_wallet.clone(),
                 dest_wallet.clone(),
                 amount,
                 fee
-            );
+            ));
             break;
+        } else if i % 5 == 0 {
+            cucumber_steps_log(format!(
+                "Wait for one sided transaction from {} to {} with amount {} at fee {} to be broadcast",
+                source_wallet.clone(),
+                dest_wallet.clone(),
+                amount,
+                fee
+            ));
+        } else {
+            // Nothing here
         }
 
         if i == num_retries - 1 {
             panic!(
-                "One sided transaction from {} to {} with amount {} at fee {} failed to be broadcasted",
+                "One sided transaction from {} to {} with amount {} at fee {} failed to be broadcast",
                 source_wallet.clone(),
                 dest_wallet.clone(),
                 amount,
@@ -894,10 +963,10 @@ async fn send_one_sided_transaction_from_source_wallet_to_dest_wallt(
 
     dest_tx_ids.push(tx_id);
 
-    println!(
+    cucumber_steps_log(format!(
         "One sided transaction with amount {} from {} to {} at fee {} succeeded",
         amount, source_wallet, dest_wallet, fee
-    );
+    ));
 }
 
 #[then(expr = "I send an interactive transaction of {int} uT from wallet {word} to wallet {word} at fee {int}")]
@@ -912,7 +981,6 @@ async fn send_interactive_amount_from_wallet_to_wallet_at_fee(
     let mut sender_wallet_client = create_wallet_client(world, sender.clone()).await.unwrap();
     let sender_wallet_address = world.get_wallet_address(&sender).await.unwrap();
     let receiver_wallet_address = world.get_wallet_address(&receiver).await.unwrap();
-    cucumber_steps_log(" - here 1");
 
     let payment_recipient = PaymentRecipient {
         address: receiver_wallet_address.clone(),
@@ -935,9 +1003,7 @@ async fn send_interactive_amount_from_wallet_to_wallet_at_fee(
     let transfer_req = TransferRequest {
         recipients: vec![payment_recipient],
     };
-    cucumber_steps_log(" - here 2");
     let tx_res = sender_wallet_client.transfer(transfer_req).await.unwrap().into_inner();
-    cucumber_steps_log(" - here 3");
     let tx_res = tx_res.results;
     cucumber_steps_log(format!("Transaction results: {:?}", tx_res));
 
@@ -970,19 +1036,29 @@ async fn send_interactive_amount_from_wallet_to_wallet_at_fee(
 
         // TransactionStatus::TRANSACTION_STATUS_BROADCAST == 1_i32
         if tx_info.status == 1_i32 {
-            println!(
-                "Transaction from {} to {} with amount {} at fee {} has been broadcasted",
+            cucumber_steps_log(format!(
+                "Wait for transaction from {} to {} with amount {} at fee {} (DONE) to be broadcast",
                 sender.clone(),
                 receiver.clone(),
                 amount,
                 fee_per_gram
-            );
+            ));
             break;
+        } else if i % 5 == 0 {
+            cucumber_steps_log(format!(
+                "Wait for transaction from {} to {} with amount {} at fee {} to be broadcast",
+                sender.clone(),
+                receiver.clone(),
+                amount,
+                fee_per_gram
+            ));
+        } else {
+            // Nothing here
         }
 
         if i == num_retries - 1 {
             panic!(
-                "Transaction from {} to {} with amount {} at fee {} failed to be broadcasted",
+                "Transaction from {} to {} with amount {} at fee {} failed to be broadcast",
                 sender.clone(),
                 receiver.clone(),
                 amount,
@@ -1002,10 +1078,10 @@ async fn send_interactive_amount_from_wallet_to_wallet_at_fee(
 
     receiver_tx_ids.push(tx_id);
 
-    println!(
+    cucumber_steps_log(format!(
         "Transaction with amount {} from {} to {} at fee {} succeeded",
         amount, sender, receiver, fee_per_gram
-    );
+    ));
 }
 
 #[then(expr = "wallet {word} detects at least {int} coinbase transactions as CoinbaseConfirmed")]
@@ -1025,7 +1101,7 @@ async fn wallet_detects_at_least_coinbase_transactions(world: &mut TariWorld, wa
     let mut total_mined_confirmed_coinbases = 0;
 
     'outer: for _ in 0..num_retries {
-        println!("Detecting coinbase confirmed transactions");
+        cucumber_steps_log(format!("{}: Detecting coinbase confirmed transactions", wallet_name));
         'inner: while let Some(tx_info) = completed_tx_res.next().await {
             let tx_id = tx_info.unwrap().transaction.unwrap().tx_id;
             let request = GetTransactionInfoRequest {
@@ -1052,10 +1128,10 @@ async fn wallet_detects_at_least_coinbase_transactions(world: &mut TariWorld, wa
     }
 
     if total_mined_confirmed_coinbases >= coinbases {
-        println!(
+        cucumber_steps_log(format!(
             "Wallet {} detected at least {} coinbase transactions as CoinbaseConfirmed",
             &wallet_name, coinbases
-        );
+        ));
     } else {
         panic!(
             "Wallet {} failed to detect at least {} coinbase transactions as CoinbaseConfirmed",
@@ -1085,7 +1161,7 @@ async fn wallet_detects_at_least_coinbase_unconfirmed_transactions(
     let mut total_mined_unconfirmed_coinbases = 0;
 
     'outer: for _ in 0..num_retries {
-        println!("Detecting coinbase unconfirmed transactions");
+        cucumber_steps_log(format!("{}, Detecting coinbase unconfirmed transactions", wallet_name));
         'inner: while let Some(tx_info) = completed_tx_res.next().await {
             let tx_id = tx_info.unwrap().transaction.unwrap().tx_id;
             let request = GetTransactionInfoRequest {
@@ -1112,10 +1188,10 @@ async fn wallet_detects_at_least_coinbase_unconfirmed_transactions(
     }
 
     if total_mined_unconfirmed_coinbases >= coinbases {
-        println!(
+        cucumber_steps_log(format!(
             "Wallet {} detected at least {} coinbase transactions as CoinbaseConfirmed",
             &wallet_name, coinbases
-        );
+        ));
     } else {
         panic!(
             "Wallet {} failed to detect at least {} coinbase transactions as CoinbaseConfirmed",
@@ -1134,7 +1210,7 @@ async fn wallet_detects_exactly_coinbase_transactions(world: &mut TariWorld, wal
     let mut total_mined_confirmed_coinbases = 0;
 
     'outer: for _ in 0..num_retries {
-        println!("Detecting coinbase confirmed transactions");
+        cucumber_steps_log("Detecting coinbase confirmed transactions");
         'inner: for tx_id in tx_ids {
             let request = GetTransactionInfoRequest {
                 transaction_ids: vec![*tx_id],
@@ -1157,10 +1233,10 @@ async fn wallet_detects_exactly_coinbase_transactions(world: &mut TariWorld, wal
     }
 
     if total_mined_confirmed_coinbases == coinbases {
-        println!(
+        cucumber_steps_log(format!(
             "Wallet {} detected exactly {} coinbase transactions as CoinbaseConfirmed",
             &wallet_name, coinbases
-        );
+        ));
     } else {
         panic!(
             "Wallet {} failed to detect exactly {} coinbase transactions as CoinbaseConfirmed",
@@ -1172,7 +1248,7 @@ async fn wallet_detects_exactly_coinbase_transactions(world: &mut TariWorld, wal
 #[then(expr = "I stop all wallets")]
 async fn stop_all_wallets(world: &mut TariWorld) {
     for (wallet, wallet_ps) in &mut world.wallets {
-        println!("Stopping wallet {}", wallet);
+        cucumber_steps_log(format!("Stopping wallet {}", wallet));
 
         wallet_ps.kill();
     }
@@ -1192,7 +1268,7 @@ async fn stop_wallet(world: &mut TariWorld, wallet: String) {
         .to_hex();
     let wallet_ps = world.wallets.get_mut(&wallet).unwrap();
     world.wallet_addresses.insert(wallet.clone(), wallet_address);
-    println!("Stopping wallet {}", wallet.as_str());
+    cucumber_steps_log(format!("Stopping wallet {}", wallet.as_str()));
     wallet_ps.kill();
 }
 
@@ -1218,7 +1294,7 @@ async fn all_wallets_detect_all_txs_as_mined_confirmed(world: &mut TariWorld) {
         let wallet_tx_ids = world.wallet_tx_ids.get(&wallet_address);
 
         let wallet_tx_ids = if wallet_tx_ids.is_none() {
-            println!("Wallet {} has no available transactions", &wallet);
+            cucumber_steps_log(format!("Wallet {} has no available transactions", &wallet));
             vec![]
         } else {
             let wallet_tx_ids = wallet_tx_ids.unwrap();
@@ -1241,10 +1317,10 @@ async fn all_wallets_detect_all_txs_as_mined_confirmed(world: &mut TariWorld) {
                 if tx_status == TransactionStatus::MinedConfirmed as i32 ||
                     tx_status == TransactionStatus::OneSidedConfirmed as i32
                 {
-                    println!(
+                    cucumber_steps_log(format!(
                         "Wallet {} has detected transaction with id {} as Mined_or_OneSidedConfirmed",
                         &wallet, tx_id
-                    );
+                    ));
                     break 'inner;
                 }
 
@@ -1303,34 +1379,34 @@ async fn wallets_should_have_at_least_num_spendable_coinbase_outs(
                 let tx_info = completed_tx.unwrap().transaction.unwrap();
                 if tx_info.status == grpc::TransactionStatus::CoinbaseUnconfirmed as i32 {
                     unspendable_coinbase_count += 1;
-                    println!(
+                    cucumber_steps_log(format!(
                         "Found coinbase transaction with id {} for wallet '{}' as 'CoinbaseUnconfirmed'",
                         tx_info.tx_id, &wallet
-                    );
+                    ));
                 }
                 if tx_info.status == grpc::TransactionStatus::CoinbaseNotInBlockChain as i32 {
                     unspendable_coinbase_count += 1;
-                    println!(
+                    cucumber_steps_log(format!(
                         "Found coinbase transaction with id {} for wallet '{}' as 'CoinbaseNotInBlockChain'",
                         tx_info.tx_id, &wallet
-                    );
+                    ));
                 }
                 if tx_info.status == grpc::TransactionStatus::CoinbaseConfirmed as i32 {
                     spendable_coinbase_count += 1;
-                    println!(
+                    cucumber_steps_log(format!(
                         "Found coinbase transaction with id {} for wallet '{}' as 'CoinbaseConfirmed'",
                         tx_info.tx_id, &wallet
-                    );
+                    ));
                 }
             }
 
             if spendable_coinbase_count >= amount_of_coinbases {
-                println!(
+                cucumber_steps_log(format!(
                     "Wallet '{}' has found at least {} spendable coinbases within a total of {} coinbase transactions",
                     &wallet,
                     amount_of_coinbases,
                     spendable_coinbase_count + unspendable_coinbase_count
-                );
+                ));
                 break 'inner;
             }
 
@@ -1338,9 +1414,9 @@ async fn wallets_should_have_at_least_num_spendable_coinbase_outs(
         }
 
         if comparison == at_least && spendable_coinbase_count >= amount_of_coinbases {
-            println!("Wallet {} has found at least {}", &wallet, amount_of_coinbases);
+            cucumber_steps_log(format!("Wallet {} has found at least {}", &wallet, amount_of_coinbases));
         } else if comparison == exactly && spendable_coinbase_count == amount_of_coinbases {
-            println!("Wallet {} has found exactly {}", &wallet, amount_of_coinbases);
+            cucumber_steps_log(format!("Wallet {} has found exactly {}", &wallet, amount_of_coinbases));
         } else {
             panic!(
                 "Wallet {} hasn't found {} {} spendable outputs, instead got {}",
@@ -1412,20 +1488,20 @@ async fn send_num_one_sided_transactions_to_wallets_at_fee(
     }
 
     let num_retries = 100;
-    println!(
-        "Waiting for transactions from wallet {} to wallet {} to be broadcasted",
+    cucumber_steps_log(format!(
+        "Waiting for transactions from wallet {} to wallet {} to be broadcast",
         &sender_wallet, &receiver_wallet
-    );
+    ));
 
     for tx_id in tx_ids {
-        println!("Waiting for transaction with id {} to be broadcasted", tx_id);
+        cucumber_steps_log(format!("Waiting for transaction with id {} to be broadcast", tx_id));
         let request = GetTransactionInfoRequest {
             transaction_ids: vec![tx_id],
         };
 
         let mut is_broadcast = false;
 
-        'inner: for _ in 0..num_retries {
+        'inner: for i in 0..num_retries {
             let txs_info = sender_wallet_client
                 .get_transaction_info(request.clone())
                 .await
@@ -1434,12 +1510,19 @@ async fn send_num_one_sided_transactions_to_wallets_at_fee(
             let txs_info = txs_info.transactions.first().unwrap();
 
             if txs_info.status == 1 {
-                println!(
-                    "Transaction from wallet {} to wallet {} with id {} has been broadcasted to the network",
+                cucumber_steps_log(format!(
+                    "Wait for Transaction from wallet {} to wallet {} (DONE) with id {} broadcast to the network",
                     &sender_wallet, &receiver_wallet, tx_id
-                );
+                ));
                 is_broadcast = true;
                 break 'inner;
+            } else if i % 5 == 0 {
+                cucumber_steps_log(format!(
+                    "Wait for Transaction from wallet {} to wallet {} with id {} broadcast to the network",
+                    &sender_wallet, &receiver_wallet, tx_id
+                ));
+            } else {
+                // Nothing here
             }
             tokio::time::sleep(Duration::from_secs(5)).await;
         }
@@ -1458,14 +1541,17 @@ async fn wait_for_wallet_to_have_num_connections(world: &mut TariWorld, wallet: 
     let mut wallet_client = create_wallet_client(world, wallet.clone()).await.unwrap();
     let num_retries = 100;
 
-    println!("Waiting for wallet {} to have {} connections", &wallet, connections);
+    cucumber_steps_log(format!(
+        "Waiting for wallet {} to have {} connections",
+        &wallet, connections
+    ));
     let mut actual_connections = 0_u32;
 
     for _ in 0..num_retries {
         let network_status_res = wallet_client.get_network_status(Empty {}).await.unwrap().into_inner();
         actual_connections = network_status_res.num_node_connections;
         if u64::from(actual_connections) >= connections {
-            println!("Wallet {} has at least {} connections", &wallet, connections);
+            cucumber_steps_log(format!("Wallet {} has at least {} connections", &wallet, connections));
             break;
         }
         tokio::time::sleep(Duration::from_secs(5)).await;
@@ -1481,7 +1567,10 @@ async fn wait_for_wallet_to_have_specific_connectivity(world: &mut TariWorld, wa
     let mut wallet_client = create_wallet_client(world, wallet.clone()).await.unwrap();
     let num_retries = 100;
 
-    println!("Waiting for wallet {} to have connectivity {}", &wallet, &connectivity);
+    cucumber_steps_log(format!(
+        "Waiting for wallet {} to have connectivity {}",
+        &wallet, &connectivity
+    ));
     let connectivity = connectivity.to_uppercase();
 
     let connectivity_index = match connectivity.as_str() {
@@ -1496,7 +1585,7 @@ async fn wait_for_wallet_to_have_specific_connectivity(world: &mut TariWorld, wa
         let network_status_res = wallet_client.get_network_status(Empty {}).await.unwrap().into_inner();
         let connectivity_status = network_status_res.status;
         if connectivity_status == connectivity_index {
-            println!("Wallet {} has {} connectivity", &wallet, &connectivity);
+            cucumber_steps_log(format!("Wallet {} has {} connectivity", &wallet, &connectivity));
             return;
         }
         tokio::time::sleep(Duration::from_secs(5)).await;
@@ -1549,7 +1638,7 @@ async fn transfer_tari_from_wallet_to_receiver(world: &mut TariWorld, amount: u6
         10
     );
 
-    // we wait for transaction to be broadcasted
+    // we wait for transaction to be broadcast
     let tx_id = tx_res.transaction_id;
     let num_retries = 100;
     let tx_info_req = GetTransactionInfoRequest {
@@ -1566,19 +1655,29 @@ async fn transfer_tari_from_wallet_to_receiver(world: &mut TariWorld, amount: u6
 
         // TransactionStatus::TRANSACTION_STATUS_BROADCAST == 1_i32
         if tx_info.status == 1_i32 {
-            println!(
-                "Transaction from {} to {} with amount {} at fee {} has been broadcasted",
+            cucumber_steps_log(format!(
+                "Wait for Transaction from {} to {} with amount {} at fee {} (DONE) to be broadcast",
                 sender.clone(),
                 receiver.clone(),
                 amount,
                 10
-            );
+            ));
             break;
+        } else if i % 5 == 0 {
+            cucumber_steps_log(format!(
+                "Wait for Transaction from {} to {} with amount {} at fee {} to be broadcast",
+                sender.clone(),
+                receiver.clone(),
+                amount,
+                10
+            ));
+        } else {
+            // Nothing here
         }
 
         if i == num_retries {
             panic!(
-                "Transaction from {} to {} with amount {} at fee {} failed to be broadcasted",
+                "Transaction from {} to {} with amount {} at fee {} failed to be broadcast",
                 sender.clone(),
                 receiver.clone(),
                 amount,
@@ -1598,10 +1697,10 @@ async fn transfer_tari_from_wallet_to_receiver(world: &mut TariWorld, amount: u6
 
     dest_tx_ids.push(tx_id);
 
-    println!(
+    cucumber_steps_log(format!(
         "Transfer amount {} from {} to {} at fee {} succeeded",
         amount, sender, receiver, 10
-    );
+    ));
 }
 
 #[when(expr = "wallet {word} has {int}T")]
@@ -1622,7 +1721,7 @@ async fn wallet_has_tari(world: &mut TariWorld, wallet: String, amount: u64) {
 
         available_balance = balance_res.available_balance;
         if available_balance >= amount * 1_000_000 {
-            println!("Wallet {} has at least {}T", wallet.as_str(), amount);
+            cucumber_steps_log(format!("Wallet {} has at least {}T", wallet.as_str(), amount));
             return;
         }
 
@@ -1643,11 +1742,11 @@ async fn wallet_with_tari_connected_to_base_node(
     base_node: String,
 ) {
     let peer_seeds = world.base_nodes.get(&base_node).unwrap().seed_nodes.clone();
-    println!(
+    cucumber_steps_log(format!(
         "Start a new wallet {} connected to base node {}",
         wallet.as_str(),
         base_node.as_str()
-    );
+    ));
     world
         .wallet_connected_to_base_node
         .insert(wallet.clone(), base_node.clone());
@@ -1668,10 +1767,10 @@ async fn wallet_with_tari_connected_to_base_node(
         // uT
     }
 
-    println!("Creating miner...");
+    cucumber_steps_log("Creating miner...");
     create_miner(world, "temp_miner".to_string(), base_node.clone(), wallet.clone()).await;
 
-    println!("Mining {} blocks", num_blocks + CONFIRMATION_PERIOD);
+    cucumber_steps_log(format!("Mining {} blocks", num_blocks + CONFIRMATION_PERIOD));
     let miner = world.miners.get(&"temp_miner".to_string()).unwrap();
     miner
         .mine(world, Some(num_blocks + CONFIRMATION_PERIOD), None, None)
@@ -1689,7 +1788,7 @@ async fn wallet_with_tari_connected_to_base_node(
             .into_inner();
 
         if balance_res.available_balance >= amount * 1_000_000 {
-            println!("Wallet {} has at least {}T", wallet.as_str(), amount);
+            cucumber_steps_log(format!("Wallet {} has at least {}T", wallet.as_str(), amount));
             return;
         }
 
@@ -1777,7 +1876,7 @@ async fn transfer_one_sided_from_wallet_to_two_recipients_at_fee(
         fee_per_gram
     );
 
-    // we wait for transaction to be broadcasted
+    // we wait for transaction to be broadcast
     let tx_id1 = tx_res1.transaction_id;
     let tx_id2 = tx_res2.transaction_id;
 
@@ -1795,30 +1894,41 @@ async fn transfer_one_sided_from_wallet_to_two_recipients_at_fee(
         let tx_info1 = tx_info_res.transactions.first().unwrap();
         let tx_info2 = tx_info_res.transactions.last().unwrap();
 
-        println!(
+        cucumber_steps_log(format!(
             "Tx_info for first recipient {} is {}, for tx_id = {}",
             receiver1, tx_info1.status, tx_id1
-        );
-        println!(
+        ));
+        cucumber_steps_log(format!(
             "Tx_info for second recipient {} is {}, for tx_id = {}",
             receiver2, tx_info2.status, tx_id2
-        );
+        ));
         // TransactionStatus::TRANSACTION_STATUS_BROADCAST == 1_i32
         if tx_info1.status == 1_i32 && tx_info2.status == 1_i32 {
-            println!(
-                "Transaction from {} to {} and {} with amount {} at fee {} has been broadcasted",
+            cucumber_steps_log(format!(
+                "Transaction from {} to {} and {} with amount {} at fee {} (DONE) to be broadcast",
                 sender.as_str(),
                 receiver1.as_str(),
                 receiver2.as_str(),
                 amount,
                 fee_per_gram
-            );
+            ));
             break;
+        } else if i % 5 == 0 {
+            cucumber_steps_log(format!(
+                "Transaction from {} to {} and {} with amount {} at fee {} to be broadcast",
+                sender.as_str(),
+                receiver1.as_str(),
+                receiver2.as_str(),
+                amount,
+                fee_per_gram
+            ));
+        } else {
+            // Nothing here
         }
 
         if i == num_retries {
             panic!(
-                "Transaction from {} to {} and {} with amount {} at fee {} failed to be broadcasted",
+                "Transaction from {} to {} and {} with amount {} at fee {} failed to be broadcast",
                 sender.as_str(),
                 receiver1.as_str(),
                 receiver2.as_str(),
@@ -1842,10 +1952,10 @@ async fn transfer_one_sided_from_wallet_to_two_recipients_at_fee(
     let receiver2_tx_ids = world.wallet_tx_ids.entry(receiver2_address.clone()).or_default();
     receiver2_tx_ids.push(tx_id2);
 
-    println!(
+    cucumber_steps_log(format!(
         "Transfer amount {} from {} to {} and {} at fee {} succeeded",
         amount, sender, receiver1, receiver2, fee_per_gram
-    );
+    ));
 }
 
 #[when(expr = "I transfer {int} uT to self from wallet {word} at fee {int}")]
@@ -1882,7 +1992,7 @@ async fn transfer_tari_to_self(world: &mut TariWorld, amount: u64, sender: Strin
         fee_per_gram
     );
 
-    // we wait for transaction to be broadcasted
+    // we wait for transaction to be broadcast
     let tx_id = tx_res.transaction_id;
     let num_retries = 100;
     let tx_info_req = GetTransactionInfoRequest {
@@ -1899,18 +2009,27 @@ async fn transfer_tari_to_self(world: &mut TariWorld, amount: u64, sender: Strin
 
         // TransactionStatus::TRANSACTION_STATUS_BROADCAST == 1_i32
         if tx_info.status == 1_i32 {
-            println!(
-                "Transaction to self from {} with amount {} at fee {} has been broadcasted",
+            cucumber_steps_log(format!(
+                "Wait for Transaction to self from {} with amount {} at fee {} (DONE) to be broadcast",
                 sender.clone(),
                 amount,
                 fee_per_gram
-            );
+            ));
             break;
+        } else if i % 5 == 0 {
+            cucumber_steps_log(format!(
+                "Wait for Transaction to self from {} with amount {} at fee {} to be broadcast",
+                sender.clone(),
+                amount,
+                fee_per_gram
+            ));
+        } else {
+            // Nothing here
         }
 
         if i == num_retries {
             panic!(
-                "Transaction to self from {} with amount {} at fee {} failed to be broadcasted",
+                "Transaction to self from {} with amount {} at fee {} failed to be broadcast",
                 sender.clone(),
                 amount,
                 fee_per_gram
@@ -1925,10 +2044,10 @@ async fn transfer_tari_to_self(world: &mut TariWorld, amount: u64, sender: Strin
 
     sender_tx_ids.push(tx_id);
 
-    println!(
+    cucumber_steps_log(format!(
         "Transfer amount {} to self from {} at fee {} succeeded",
         amount, sender, fee_per_gram
-    );
+    ));
 }
 
 #[when(expr = "I broadcast HTLC transaction with {int} uT from wallet {word} to wallet {word} at fee {int}")]
@@ -1974,7 +2093,7 @@ async fn htlc_transaction(world: &mut TariWorld, amount: u64, sender: String, re
         fee_per_gram
     );
 
-    // we wait for transaction to be broadcasted
+    // we wait for transaction to be broadcast
     let tx_id = sha_atomic_swap_tx_res.transaction_id;
     let num_retries = 100;
     let tx_info_req = GetTransactionInfoRequest {
@@ -1991,19 +2110,29 @@ async fn htlc_transaction(world: &mut TariWorld, amount: u64, sender: String, re
 
         // TransactionStatus::TRANSACTION_STATUS_BROADCAST == 1_i32
         if tx_info.status == 1_i32 {
-            println!(
-                "Atomic swap transaction from {} to {} with amount {} at fee {} has been broadcasted",
+            cucumber_steps_log(format!(
+                "Wait for Atomic swap transaction from {} to {} (DONE) with amount {} at fee {} to be broadcast",
                 sender.as_str(),
                 receiver.as_str(),
                 amount,
                 fee_per_gram
-            );
+            ));
             break;
+        } else if i % 5 == 0 {
+            cucumber_steps_log(format!(
+                "Wait for Atomic swap transaction from {} to {} with amount {} at fee {} to be broadcast",
+                sender.as_str(),
+                receiver.as_str(),
+                amount,
+                fee_per_gram
+            ));
+        } else {
+            // Nothing here
         }
 
         if i == num_retries {
             panic!(
-                "Atomic swap transaction from {} to {} with amount {} at fee {} failed to be broadcasted",
+                "Atomic swap transaction from {} to {} with amount {} at fee {} failed to be broadcast",
                 sender.as_str(),
                 receiver.as_str(),
                 amount,
@@ -2025,10 +2154,10 @@ async fn htlc_transaction(world: &mut TariWorld, amount: u64, sender: String, re
     world.output_hash = Some(sha_atomic_swap_tx_res.output_hash);
     world.pre_image = Some(sha_atomic_swap_tx_res.pre_image);
 
-    println!(
+    cucumber_steps_log(format!(
         "Atomic swap transfer amount {} from {} to {} at fee {} succeeded",
         amount, sender, receiver, fee_per_gram
-    );
+    ));
 }
 
 #[when(expr = "I claim an HTLC refund transaction with wallet {word} at fee {int}")]
@@ -2055,7 +2184,7 @@ async fn claim_htlc_refund_transaction_with_wallet_at_fee(world: &mut TariWorld,
         fee_per_gram
     );
 
-    // we wait for transaction to be broadcasted
+    // we wait for transaction to be broadcast
     let tx_id = claim_htlc_refund_res.results.unwrap().transaction_id;
     let num_retries = 100;
     let tx_info_req = GetTransactionInfoRequest {
@@ -2072,17 +2201,25 @@ async fn claim_htlc_refund_transaction_with_wallet_at_fee(world: &mut TariWorld,
 
         // TransactionStatus::TRANSACTION_STATUS_BROADCAST == 1_i32
         if tx_info.status == 1_i32 {
-            println!(
-                "Claim HTLC refund transaction with wallet {} at fee {} has been broadcasted",
+            cucumber_steps_log(format!(
+                "Wait for Claim HTLC refund transaction with wallet {} (DONE) at fee {} to be broadcast",
                 wallet.as_str(),
                 fee_per_gram
-            );
+            ));
             break;
+        } else if i % 5 == 0 {
+            cucumber_steps_log(format!(
+                "Wait for Claim HTLC refund transaction with wallet {} at fee {} to be broadcast",
+                wallet.as_str(),
+                fee_per_gram
+            ));
+        } else {
+            // Nothing here
         }
 
         if i == num_retries {
             panic!(
-                "Claim HTLC refund transaction with wallet {} at fee {} failed to be broadcasted",
+                "Claim HTLC refund transaction with wallet {} at fee {} failed to be broadcast",
                 wallet.as_str(),
                 fee_per_gram
             )
@@ -2095,10 +2232,10 @@ async fn claim_htlc_refund_transaction_with_wallet_at_fee(world: &mut TariWorld,
     let wallet_tx_ids = world.wallet_tx_ids.entry(wallet_address.clone()).or_default();
     wallet_tx_ids.push(tx_id);
 
-    println!(
+    cucumber_steps_log(format!(
         "Claim HTLC refund transaction with wallet {} at fee {} succeeded",
         wallet, fee_per_gram
-    );
+    ));
 }
 
 #[when(expr = "I claim an HTLC transaction with wallet {word} at fee {int}")]
@@ -2127,7 +2264,7 @@ async fn wallet_claims_htlc_transaction_at_fee(world: &mut TariWorld, wallet: St
         fee_per_gram
     );
 
-    // we wait for transaction to be broadcasted
+    // we wait for transaction to be broadcast
     let tx_id = claim_htlc_res.results.unwrap().transaction_id;
     let num_retries = 100;
     let tx_info_req = GetTransactionInfoRequest {
@@ -2144,17 +2281,25 @@ async fn wallet_claims_htlc_transaction_at_fee(world: &mut TariWorld, wallet: St
 
         // TransactionStatus::TRANSACTION_STATUS_BROADCAST == 1_i32
         if tx_info.status == 1_i32 {
-            println!(
-                "Claim HTLC transaction with wallet {} at fee {} has been broadcasted",
+            cucumber_steps_log(format!(
+                "Wait for Claim HTLC transaction with wallet {} (DONE) at fee {} to be broadcast",
                 wallet.as_str(),
                 fee_per_gram
-            );
+            ));
             break;
+        } else if i % 5 == 0 {
+            cucumber_steps_log(format!(
+                "Wait for Claim HTLC transaction with wallet {} at fee {} to be broadcast",
+                wallet.as_str(),
+                fee_per_gram
+            ));
+        } else {
+            // Nothing here
         }
 
         if i == num_retries {
             panic!(
-                "Claim HTLC transaction with wallet {} at fee {} failed to be broadcasted",
+                "Claim HTLC transaction with wallet {} at fee {} failed to be broadcast",
                 wallet.as_str(),
                 fee_per_gram
             )
@@ -2167,43 +2312,10 @@ async fn wallet_claims_htlc_transaction_at_fee(world: &mut TariWorld, wallet: St
     let wallet_tx_ids = world.wallet_tx_ids.entry(wallet_address.clone()).or_default();
     wallet_tx_ids.push(tx_id);
 
-    println!(
+    cucumber_steps_log(format!(
         "Claim HTLC transaction with wallet {} at fee {} succeeded",
         wallet, fee_per_gram
-    );
-}
-
-#[then(expr = "I wait for wallet {word} to have less than {int} uT")]
-async fn wait_for_wallet_to_have_less_than_amount(world: &mut TariWorld, wallet: String, amount: u64) {
-    let wallet_ps = world.wallets.get(&wallet).unwrap();
-    let num_retries = 100;
-
-    let mut client = wallet_ps.get_grpc_client().await.unwrap();
-    let mut curr_amount = u64::MAX;
-
-    for _ in 0..=num_retries {
-        let _result = client.validate_all_transactions(ValidateRequest {}).await;
-        curr_amount = client
-            .get_balance(GetBalanceRequest { payment_id: None })
-            .await
-            .unwrap()
-            .into_inner()
-            .available_balance;
-
-        if curr_amount < amount {
-            return;
-        }
-
-        tokio::time::sleep(Duration::from_secs(5)).await;
-    }
-
-    // failed to get wallet right amount, so we panic
-    panic!(
-        "wallet {} failed to get less balance than amount {}, current amount is {}",
-        wallet.as_str(),
-        amount,
-        curr_amount
-    );
+    ));
 }
 
 #[then(expr = "I send a one-sided stealth transaction of {int} uT from wallet {word} to wallet {word} at fee {int}")]
@@ -2267,7 +2379,7 @@ async fn send_one_sided_stealth_transaction(
         fee_per_gram
     );
 
-    // we wait for transaction to be broadcasted
+    // we wait for transaction to be broadcast
     let tx_id = tx_res.transaction_id;
     let num_retries = 100;
     let tx_info_req = GetTransactionInfoRequest {
@@ -2284,19 +2396,29 @@ async fn send_one_sided_stealth_transaction(
 
         // TransactionStatus::TRANSACTION_STATUS_BROADCAST == 1_i32
         if tx_info.status == 1_i32 {
-            println!(
-                "One sided stealth transaction from {} to {} with amount {} at fee {} has been broadcasted",
+            cucumber_steps_log(format!(
+                "Wait for one sided stealth transaction from {} to {} (DONE) with amount {} at fee {} to be broadcast",
                 sender.clone(),
                 receiver.clone(),
                 amount,
                 fee_per_gram
-            );
+            ));
             break;
+        } else if i % 5 == 0 {
+            cucumber_steps_log(format!(
+                "Wait for one sided stealth transaction from {} to {} with amount {} at fee {} to be broadcast",
+                sender.clone(),
+                receiver.clone(),
+                amount,
+                fee_per_gram
+            ));
+        } else {
+            // Nothing here
         }
 
         if i == num_retries - 1 {
             panic!(
-                "One sided stealth transaction from {} to {} with amount {} at fee {} failed to be broadcasted",
+                "One sided stealth transaction from {} to {} with amount {} at fee {} failed to be broadcast",
                 sender.clone(),
                 receiver.clone(),
                 amount,
@@ -2316,10 +2438,10 @@ async fn send_one_sided_stealth_transaction(
 
     receiver_tx_ids.push(tx_id);
 
-    println!(
+    cucumber_steps_log(format!(
         "One sided stealth transaction with amount {} from {} to {} at fee {} succeeded",
         amount, sender, receiver, fee_per_gram
-    );
+    ));
 }
 
 #[then(expr = "I import {word} unspent outputs to {word}")]
@@ -2830,19 +2952,19 @@ async fn multi_send_txs_from_wallet(
 
             // TransactionStatus::TRANSACTION_STATUS_BROADCAST == 1_i32
             if tx_info.status == 1_i32 {
-                println!(
-                    "Multi-transaction from {} to {} with amount {} at fee {} has been broadcasted",
+                cucumber_steps_log(format!(
+                    "Wait for Multi-transaction from {} to {} with amount {} at fee {} has been broadcast",
                     sender.clone(),
                     receiver.clone(),
                     amount,
                     fee_per_gram
-                );
+                ));
                 break;
             }
 
             if i == num_retries - 1 {
                 panic!(
-                    "Multi-transaction from {} to {} with amount {} at fee {} failed to be broadcasted",
+                    "Multi-transaction from {} to {} with amount {} at fee {} failed to be broadcast",
                     sender.clone(),
                     receiver.clone(),
                     amount,
@@ -2862,10 +2984,10 @@ async fn multi_send_txs_from_wallet(
 
         receiver_tx_ids.push(tx_id);
 
-        println!(
+        cucumber_steps_log(format!(
             "Multi-transaction with amount {} from {} to {} at fee {} succeeded",
             amount, sender, receiver, fee_per_gram
-        );
+        ));
     }
 }
 
@@ -2989,16 +3111,37 @@ async fn burn_transaction(world: &mut TariWorld, amount: u64, wallet: String, fe
 
 #[then(expr = "wallet {word} balance is {word}")]
 async fn wallet_has_balance(world: &mut TariWorld, wallet_name: String, balance_key: String) {
-    let mut wallet_client = world.get_wallet_client(&wallet_name).await.unwrap();
-    let wallet_balance = wallet_client
-        .get_balance(GetBalanceRequest { payment_id: None })
-        .await
-        .unwrap()
-        .into_inner();
+    let mut client = world.get_wallet_client(&wallet_name).await.unwrap();
     let balance = world.balance.get(&balance_key).unwrap();
-    assert_eq!(
-        balance, &wallet_balance,
+
+    let balance_res = GetBalanceResponse::default();
+    let num_retries = 15;
+    for i in 0..num_retries {
+        let _result = client.validate_all_transactions(ValidateRequest {}).await;
+        let balance_res = client
+            .get_balance(GetBalanceRequest { payment_id: None })
+            .await
+            .unwrap()
+            .into_inner();
+        if &balance_res == balance {
+            cucumber_steps_log(format!(
+                "Wallet {} needs balance {:?} (DONE), has {:?}",
+                wallet_name, balance, balance_res
+            ));
+            return;
+        } else if i % 3 == 0 {
+            cucumber_steps_log(format!(
+                "Wallet {} needs balance {:?}, has {:?}",
+                wallet_name, balance, balance_res
+            ));
+        } else {
+            // Nothing here
+        }
+        tokio::time::sleep(Duration::from_secs(2)).await;
+    }
+
+    panic!(
         "Wallet {} doesn't have the correct balance: expected {:?} current {:?}",
-        wallet_name, balance, wallet_balance
+        wallet_name, balance, balance_res
     );
 }

--- a/integration_tests/tests/steps/wallet_steps.rs
+++ b/integration_tests/tests/steps/wallet_steps.rs
@@ -72,7 +72,15 @@ use tari_integration_tests::{
 use tari_script::{ExecutionStack, TariScript};
 use tari_utilities::hex::Hex;
 
-use crate::steps::{mining_steps::create_miner, CONFIRMATION_PERIOD, HALF_SECOND, TWO_MINUTES_WITH_HALF_SECOND_SLEEP};
+use crate::steps::{
+    cucumber_steps_log,
+    mining_steps::create_miner,
+    CONFIRMATION_PERIOD,
+    HALF_SECOND,
+    TWO_MINUTES_WITH_HALF_SECOND_SLEEP,
+};
+
+pub const LOG_TARGET: &str = "cucumber::wallet_steps";
 
 #[given(expr = "a wallet {word} connected to base node {word}")]
 async fn start_wallet(world: &mut TariWorld, wallet_name: String, node_name: String) {
@@ -719,8 +727,12 @@ async fn non_default_wallets_connected_to_all_seed_nodes(world: &mut TariWorld, 
     }
 }
 
-#[when(expr = "I send {int} uT without waiting for broadcast from wallet {word} to wallet {word} at fee {int}")]
-#[then(expr = "I send {int} uT without waiting for broadcast from wallet {word} to wallet {word} at fee {int}")]
+#[when(
+    expr = "I send {int} uT one-sided without waiting for broadcast from wallet {word} to wallet {word} at fee {int}"
+)]
+#[then(
+    expr = "I send {int} uT one-sided without waiting for broadcast from wallet {word} to wallet {word} at fee {int}"
+)]
 async fn send_amount_from_source_wallet_to_dest_wallet_without_broadcast(
     world: &mut TariWorld,
     amount: u64,
@@ -737,7 +749,7 @@ async fn send_amount_from_source_wallet_to_dest_wallet_without_broadcast(
         address: dest_wallet_address.clone(),
         amount,
         fee_per_gram: fee,
-        payment_type: 0, // normal mimblewimble payment type
+        payment_type: 1, // one sided transaction
         raw_payment_id: PaymentId::open_from_string(
             &format!(
                 "transfer amount {} from {} to {}",
@@ -785,7 +797,7 @@ async fn send_amount_from_source_wallet_to_dest_wallet_without_broadcast(
     );
 }
 
-#[then(expr = "I send a one-sided transaction of {int} uT from {word} to {word} at fee {int}")]
+#[then(expr = "I send a one-sided transaction of {int} uT from wallet {word} to wallet {word} at fee {int}")]
 async fn send_one_sided_transaction_from_source_wallet_to_dest_wallt(
     world: &mut TariWorld,
     amount: u64,
@@ -888,9 +900,9 @@ async fn send_one_sided_transaction_from_source_wallet_to_dest_wallt(
     );
 }
 
-#[then(expr = "I send {int} uT from wallet {word} to wallet {word} at fee {int}")]
-#[when(expr = "I send {int} uT from wallet {word} to wallet {word} at fee {int}")]
-async fn send_amount_from_wallet_to_wallet_at_fee(
+#[then(expr = "I send an interactive transaction of {int} uT from wallet {word} to wallet {word} at fee {int}")]
+#[when(expr = "I send an interactive transaction of {int} uT from wallet {word} to wallet {word} at fee {int}")]
+async fn send_interactive_amount_from_wallet_to_wallet_at_fee(
     world: &mut TariWorld,
     amount: u64,
     sender: String,
@@ -900,6 +912,7 @@ async fn send_amount_from_wallet_to_wallet_at_fee(
     let mut sender_wallet_client = create_wallet_client(world, sender.clone()).await.unwrap();
     let sender_wallet_address = world.get_wallet_address(&sender).await.unwrap();
     let receiver_wallet_address = world.get_wallet_address(&receiver).await.unwrap();
+    cucumber_steps_log(" - here 1");
 
     let payment_recipient = PaymentRecipient {
         address: receiver_wallet_address.clone(),
@@ -922,12 +935,16 @@ async fn send_amount_from_wallet_to_wallet_at_fee(
     let transfer_req = TransferRequest {
         recipients: vec![payment_recipient],
     };
+    cucumber_steps_log(" - here 2");
     let tx_res = sender_wallet_client.transfer(transfer_req).await.unwrap().into_inner();
+    cucumber_steps_log(" - here 3");
     let tx_res = tx_res.results;
+    cucumber_steps_log(format!("Transaction results: {:?}", tx_res));
 
     assert_eq!(tx_res.len(), 1usize);
 
     let tx_res = tx_res.first().unwrap();
+    cucumber_steps_log(format!("Transaction 1 result: {:?}", tx_res));
     assert!(
         tx_res.is_success,
         "Transaction with amount {} from wallet {} to {} at fee {} failed",
@@ -1333,8 +1350,11 @@ async fn wallets_should_have_at_least_num_spendable_coinbase_outs(
     }
 }
 
-#[when(expr = "I send {int} transactions of {int} uT each from wallet {word} to wallet {word} at fee_per_gram {int}")]
-async fn send_num_transactions_to_wallets_at_fee(
+#[when(
+    expr = "I send {int} one-sided transactions of {int} uT each from wallet {word} to wallet {word} at fee_per_gram \
+            {int}"
+)]
+async fn send_num_one_sided_transactions_to_wallets_at_fee(
     world: &mut TariWorld,
     num_txs: u64,
     amount: u64,
@@ -1352,7 +1372,7 @@ async fn send_num_transactions_to_wallets_at_fee(
             address: receiver_wallet_address.clone(),
             amount,
             fee_per_gram,
-            payment_type: 0, // standard mimblewimble transaction
+            payment_type: 1, // one sided transaction
             raw_payment_id: PaymentId::open_from_string(
                 &format!(
                     "transfer amount {} from {} to {}",
@@ -1488,7 +1508,7 @@ async fn wait_for_wallet_to_have_specific_connectivity(world: &mut TariWorld, wa
     );
 }
 
-#[when(expr = "I transfer {int}T from {word} to {word}")]
+#[when(expr = "I transfer {int}T one-sided from {word} to {word}")]
 async fn transfer_tari_from_wallet_to_receiver(world: &mut TariWorld, amount: u64, sender: String, receiver: String) {
     let mut sender_wallet_client = create_wallet_client(world, sender.clone()).await.unwrap();
     let sender_wallet_address = world.get_wallet_address(&sender).await.unwrap();
@@ -1498,7 +1518,7 @@ async fn transfer_tari_from_wallet_to_receiver(world: &mut TariWorld, amount: u6
         address: receiver_wallet_address.clone(),
         amount: amount * 1_000_000_u64, // 1T = 1_000_000uT
         fee_per_gram: 10,               // as in the js cucumber tests
-        payment_type: 0,                // normal mimblewimble payment type
+        payment_type: 1,                // one sided transaction
         raw_payment_id: PaymentId::open_from_string(
             &format!(
                 "transfer amount {} from {} to {}",
@@ -1679,9 +1699,9 @@ async fn wallet_with_tari_connected_to_base_node(
     panic!("Wallet {} failed to have at least {}T", wallet, amount);
 }
 
-#[when(expr = "I transfer {int} uT from {word} to {word} and {word} at fee {int}")]
+#[when(expr = "I transfer {int} uT one-sided from {word} to {word} and {word} at fee {int}")]
 #[allow(clippy::too_many_lines)]
-async fn transfer_from_wallet_to_two_recipients_at_fee(
+async fn transfer_one_sided_from_wallet_to_two_recipients_at_fee(
     world: &mut TariWorld,
     amount: u64,
     sender: String,
@@ -1698,7 +1718,7 @@ async fn transfer_from_wallet_to_two_recipients_at_fee(
         address: receiver1_address.clone(),
         amount,
         fee_per_gram,
-        payment_type: 0, // normal mimblewimble payment type
+        payment_type: 1, // one sided transaction
         raw_payment_id: PaymentId::open_from_string(
             &format!(
                 "transfer amount {} from {} to {}",
@@ -1716,7 +1736,7 @@ async fn transfer_from_wallet_to_two_recipients_at_fee(
         address: receiver2_address.clone(),
         amount,
         fee_per_gram,
-        payment_type: 0, // normal mimblewimble payment type
+        payment_type: 1, // one sided transaction
         raw_payment_id: PaymentId::open_from_string(
             &format!(
                 "transfer amount {} from {} to {}",
@@ -2186,7 +2206,7 @@ async fn wait_for_wallet_to_have_less_than_amount(world: &mut TariWorld, wallet:
     );
 }
 
-#[then(expr = "I send a one-sided stealth transaction of {int} uT from {word} to {word} at fee {int}")]
+#[then(expr = "I send a one-sided stealth transaction of {int} uT from wallet {word} to wallet {word} at fee {int}")]
 async fn send_one_sided_stealth_transaction(
     world: &mut TariWorld,
     amount: u64,
@@ -2722,7 +2742,7 @@ async fn check_if_wallet_has_num_transactions(world: &mut TariWorld, wallet: Str
     );
 }
 
-#[when(expr = "I multi-send {int} transactions of {int} uT from wallet {word} to wallet {word} at fee {int}")]
+#[when(expr = "I multi-send {int} one-sided transactions of {int} uT from wallet {word} to wallet {word} at fee {int}")]
 async fn multi_send_txs_from_wallet(
     world: &mut TariWorld,
     num_txs: u64,
@@ -2756,7 +2776,7 @@ async fn multi_send_txs_from_wallet(
             address: receiver_wallet_address.clone(),
             amount,
             fee_per_gram,
-            payment_type: 0, // mimblewimble transaction
+            payment_type: 1, // one sided transaction
             raw_payment_id: PaymentId::open_from_string(
                 &format!(
                     "I send multi-transfers with amount {} from {} to {} with fee per gram {}",
@@ -2965,4 +2985,20 @@ async fn burn_transaction(world: &mut TariWorld, amount: u64, wallet: String, fe
          (TRANSACTION_STATUS_UNCONFIRMED), or 6 (TRANSACTION_STATUS_CONFIRMED)",
         last_status
     )
+}
+
+#[then(expr = "wallet {word} balance is {word}")]
+async fn wallet_has_balance(world: &mut TariWorld, wallet_name: String, balance_key: String) {
+    let mut wallet_client = world.get_wallet_client(&wallet_name).await.unwrap();
+    let wallet_balance = wallet_client
+        .get_balance(GetBalanceRequest { payment_id: None })
+        .await
+        .unwrap()
+        .into_inner();
+    let balance = world.balance.get(&balance_key).unwrap();
+    assert_eq!(
+        balance, &wallet_balance,
+        "Wallet {} doesn't have the correct balance: expected {:?} current {:?}",
+        wallet_name, balance, wallet_balance
+    );
 }


### PR DESCRIPTION
Description
---
- Added cucumber test to verify wallet balance with recovery into FFI wallet.
- Fixed broken `As a client I want to be able to restore my ffi wallet from seed words` cucumber test.

Motivation and Context
---
Trying to solve various balance query inconsistencies.

How Has This Been Tested?
---
Cucumber test: `As a client I want to be able to check my balance from restored wallets`

What process can a PR reviewer use to test or verify this change?
---
Code review

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to restore FFI wallets from seed words and verify balances in integration tests.
  - Introduced support for storing and checking wallet balances within the test environment.
  - Enhanced wallet CLI test steps to support wallet recovery from seed words and view/spend key export/import.
  - Added detailed logging for transaction errors in the wallet gRPC server.
  - Extended wallet process and world state with new fields for base node association, peer seeds, balances, and keys.

- **Bug Fixes**
  - Improved type handling when collecting seed words during wallet recovery.

- **Tests**
  - Added critical scenarios to test wallet restoration and balance checking for FFI wallets.
  - Introduced new test steps for remembering and verifying wallet balances.
  - Updated test scenarios and steps to explicitly specify one-sided and interactive transaction types for clarity.
  - Added logging support for cucumber test steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->