### PR TITLE
fix(network-discovery): add back idle event handling

### DIFF
--- a/comms/dht/src/network_discovery/ready.rs
+++ b/comms/dht/src/network_discovery/ready.rs
@@ -160,9 +160,10 @@ impl DiscoveryReady {
                 num_peers, min_desired_peers
             );
 
-            let excluded_peers = self.context.all_attempted_peers.read().await.clone();
-            let peers_for_discovery =
-                select_peers_for_discovery_round(&self.context, None, &excluded_peers, self.config()).await?;
+            let peers_for_discovery = {
+                let excluded_peers = self.context.all_attempted_peers.read().await;
+                select_peers_for_discovery_round(&self.context, None, &excluded_peers, self.config()).await?
+            };
 
             if peers_for_discovery.is_empty() {
                 debug!(

--- a/comms/dht/src/network_discovery/state_machine.rs
+++ b/comms/dht/src/network_discovery/state_machine.rs
@@ -375,6 +375,7 @@ impl DhtNetworkDiscovery {
                 State::Discovering(Discovering::new(params, self.context.clone()))
             },
             (State::Ready(_), StateEvent::OnConnectMode) => State::OnConnect(OnConnect::new(self.context.clone())),
+            (State::Ready(_), StateEvent::Idle) => State::Waiting(config.idle_period.into()),
             (State::OnConnect(_), StateEvent::Ready) => State::Ready(DiscoveryReady::new(self.context.clone())),
             (_, StateEvent::Shutdown) => State::Shutdown,
             (_state, StateEvent::Errored(err)) => {


### PR DESCRIPTION
Description
---
fix(network-discovery): add back idle event handling

Motivation and Context
---
network discovery was spinning at full speed because the Idle event transition was removed. Network logs would rotate < 1s.

```
[comms::dht::network_discovery::ready] [Thread:123190302967360] DEBUG NetworkDiscovery::Ready: Peer list contains 759 entries. Current discovery rounds in this cycle: 0.
[comms::dht::network_discovery::ready] [Thread:123190302967360] DEBUG First active round (current_num_rounds = 0) and num_peers (759) >= min_desired_peers (16). Forcing DHT discovery.
 [comms::dht::network_discovery::ready] [Thread:123190302967360] DEBUG Selecting 5 random peers for discovery (last round info available: false, new peers in last round: false).
[comms::dht::network_discovery::ready] [Thread:123190302967360] DEBUG No suitable peers found for the forced DHT discovery round (current_num_rounds = 0 path). Transitioning to Idle.
 [comms::dht::network_discovery] [Thread:123190302967360] DEBUG Transition triggered from current state `Ready` by event `Idle`
comms::dht::network_discovery] [Thread:123190302967360] DEBUG No state transition for event `Idle`. The current state is `Ready`

...instant rinse and repeat...
```

This PR adds the idle state transition back. Note that idle will idle for 30 minutes so should only transition when all work is done and we have downloaded sufficient peers. 

How Has This Been Tested?
---
Manually - console wallet with empty peer db

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
