### PR TITLE
chore(ci): split out amd64 and arm64 docker builds into native runners

### DIFF
--- a/.github/workflows/build_dockers.yml
+++ b/.github/workflows/build_dockers.yml
@@ -11,8 +11,8 @@ name: Build docker images
       - 'build-all-*'
       - 'build-dockers-*'
   schedule:
-    - cron: '05 00 * * 0-5'  # Daily build, 5min past midnight, Sunday to Friday
-    - cron: '23 01 * * 0-5'  # MainNet Debug - Daily build at 01h23, Sunday to Friday
+    - cron: '05 00 * * 0-5'  # Nightly build, 5min past midnight, Sunday to Friday
+    - cron: '23 01 * * 0-5'  # MainNet Debug - Nightly build at 01h23, Sunday to Friday
   workflow_dispatch:
     inputs:
       version:
@@ -127,17 +127,17 @@ jobs:
               echo "tari_network=esme" >> $GITHUB_OUTPUT
               echo "build_items=minotari_all" >> $GITHUB_OUTPUT
             else
-              echo "Daily Build - limited amd64 - esme"
+              echo "Nightly Build - limited amd64 - esme"
               echo "platforms=linux/amd64" >> $GITHUB_OUTPUT
-              #echo "tag_alias=latest-daily" >> $GITHUB_OUTPUT
+              #echo "tag_alias=latest-nightly" >> $GITHUB_OUTPUT
               echo "tari_network=esme" >> $GITHUB_OUTPUT
               echo "build_items=minotari_all" >> $GITHUB_OUTPUT
             fi
             echo "Schedule: ${SCHEDULE} - $(date)"
             if [[ "${SCHEDULE}" == "23 01 * * 0-5" ]]; then
-              echo "Daily CI Build - limited amd64 - mainNet - minotari_node"
+              echo "Nightly CI Build - limited amd64 - mainNet - minotari_node"
               echo "platforms=linux/amd64" >> $GITHUB_OUTPUT
-              echo "tag_alias=latest-ci-node" >> $GITHUB_OUTPUT
+              echo "tag_alias=nightly-ci-node" >> $GITHUB_OUTPUT
               echo "tari_network=mainnet" >> $GITHUB_OUTPUT
               echo "build_items=minotari_node" >> $GITHUB_OUTPUT
             fi

--- a/.github/workflows/build_dockers.yml
+++ b/.github/workflows/build_dockers.yml
@@ -11,26 +11,34 @@ name: Build docker images
       - 'build-all-*'
       - 'build-dockers-*'
   schedule:
-    - cron: '05 00 * * *'
+    - cron: '05 00 * * 0-5'  # Daily build, 5min past midnight, Sunday to Friday
+    - cron: '23 01 * * 0-5'  # MainNet Debug - Daily build at 01h23, Sunday to Friday
   workflow_dispatch:
     inputs:
-#      toolchain:
-#        type: string
-#        description: 'Rust toolchain'
       version:
         type: string
-        description: 'override image tag/version'
+        description: 'override minotari image tag/version'
       tag_alias:
+        default: latest-adhoc
         type: string
-        description: 'image tag alias'
+        description: 'minotari image tag alias'
       platforms:
         default: linux/amd64
-        description: 'docker platform(s)'
+        description: 'docker target build platform(s)'
         type: choice
         options:
           - linux/amd64
           - linux/arm64
           - linux/arm64, linux/amd64
+      tari_network:
+        default: esmeralda
+        description: 'target testNet'
+        type: choice
+        options:
+          - esmeralda
+          - nextnet
+          - mainnet
+          - igor
       build_items:
         default: minotari_all
         description: 'image(s) to build'
@@ -59,18 +67,21 @@ permissions:
   contents: read
 
 jobs:
-  builds_envs_setup:
+  base_builds_envs_setup:
     runs-on: ubuntu-latest
     outputs:
       toolchain: ${{ steps.envs_setup.outputs.toolchain }}
       platforms: ${{ steps.envs_setup.outputs.platforms }}
       version: ${{ steps.envs_setup.outputs.version }}
       tag_alias: ${{ steps.envs_setup.outputs.tag_alias }}
+      tari_network: ${{ steps.envs_setup.outputs.tari_network }}
       build_items: ${{ steps.envs_setup.outputs.build_items }}
 
     steps:
       - name: envs setup
         id: envs_setup
+        env:
+          SCHEDULE: ${{ github.event.schedule }}
         shell: bash
         run: |
           echo "Workflow triggered by ${{ github.actor }} for ${{ github.event_name }}"
@@ -82,7 +93,8 @@ jobs:
           echo "toolchain=${TOOLCHAIN:-${{ env.toolchain_default }}}" >> $GITHUB_OUTPUT
           if [[ "${{ github.ref }}" =~ ^refs/tags/v* ]] && [ "${{ github.event_name }}" != "workflow_dispatch" ] ; then
             echo "Tagged Build - Build everything"
-            VERSION="${{ github.ref_name }}_$(date -u '+%Y%m%d')_${VSHA_SHORT}"
+            #VERSION="${{ github.ref_name }}_$(date -u '+%Y%m%d')_${VSHA_SHORT}"
+            VERSION="${{ github.ref_name }}"
             echo "Version used - ${VERSION}"
             echo "platforms=linux/arm64, linux/amd64" >> $GITHUB_OUTPUT
             echo "version=${VERSION}" >> $GITHUB_OUTPUT
@@ -92,43 +104,56 @@ jobs:
           if [[ "${{ github.ref }}" =~ ^refs/heads/build-dockers-* ]] || [[ "${{ github.ref }}" =~ ^refs/heads/build-all-* ]] ; then
             echo "Branch Build - limited dual arch"
             echo "platforms=linux/arm64, linux/amd64" >> $GITHUB_OUTPUT
-            echo "tag_alias=latest-testing" >> $GITHUB_OUTPUT
+            #echo "tag_alias=latest-adhoc" >> $GITHUB_OUTPUT
+            echo "tari_network=esme" >> $GITHUB_OUTPUT
             #echo "build_items=xmrig" >> $GITHUB_OUTPUT
             #echo "build_items=3rdparty" >> $GITHUB_OUTPUT
-            #echo "build_items=minotari_all" >> $GITHUB_OUTPUT
-            echo "build_items=all" >> $GITHUB_OUTPUT
+            echo "build_items=minotari_all" >> $GITHUB_OUTPUT
           fi
           if [ "${{ github.event_name }}" == "workflow_dispatch" ] ; then
             echo "Manual Build - selective"
             echo "platforms=${{ github.event.inputs.platforms }}" >> $GITHUB_OUTPUT
             echo "version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
             echo "tag_alias=${{ github.event.inputs.tag_alias }}" >> $GITHUB_OUTPUT
+            echo "tari_network=${{ github.event.inputs.tari_network }}" >> $GITHUB_OUTPUT
             echo "build_items=${{ github.event.inputs.build_items }}" >> $GITHUB_OUTPUT
           fi
           if [ "${{ github.event_name }}" == "schedule" ] ; then
+            echo "Scheduled builds"
             if [[ $(date +%u) -eq 7 ]] ; then
-              echo "Weekly Build - limited dual arch"
+              echo "Weekly Build - limited dual arch - esme"
               echo "platforms=linux/arm64, linux/amd64" >> $GITHUB_OUTPUT
               echo "tag_alias=latest-weekly" >> $GITHUB_OUTPUT
+              echo "tari_network=esme" >> $GITHUB_OUTPUT
               echo "build_items=minotari_all" >> $GITHUB_OUTPUT
             else
-              echo "Daily Build - limited"
+              echo "Daily Build - limited amd64 - esme"
               echo "platforms=linux/amd64" >> $GITHUB_OUTPUT
-              echo "tag_alias=latest-daily" >> $GITHUB_OUTPUT
+              #echo "tag_alias=latest-daily" >> $GITHUB_OUTPUT
+              echo "tari_network=esme" >> $GITHUB_OUTPUT
               echo "build_items=minotari_all" >> $GITHUB_OUTPUT
+            fi
+            echo "Schedule: ${SCHEDULE} - $(date)"
+            if [[ "${SCHEDULE}" == "23 01 * * 0-5" ]]; then
+              echo "Daily CI Build - limited amd64 - mainNet - minotari_node"
+              echo "platforms=linux/amd64" >> $GITHUB_OUTPUT
+              echo "tag_alias=latest-ci-node" >> $GITHUB_OUTPUT
+              echo "tari_network=mainnet" >> $GITHUB_OUTPUT
+              echo "build_items=minotari_node" >> $GITHUB_OUTPUT
             fi
           fi
 
   builds_run:
-    needs: builds_envs_setup
+    needs: base_builds_envs_setup
     permissions:
       contents: read
       packages: write
     uses: ./.github/workflows/build_dockers_workflow.yml
     secrets: inherit
     with:
-      toolchain: ${{ needs.builds_envs_setup.outputs.toolchain }}
-      platforms: ${{ needs.builds_envs_setup.outputs.platforms }}
-      version: ${{ needs.builds_envs_setup.outputs.version }}
-      tag_alias: ${{ needs.builds_envs_setup.outputs.tag_alias }}
-      build_items: ${{ needs.builds_envs_setup.outputs.build_items }}
+      toolchain: ${{ needs.base_builds_envs_setup.outputs.toolchain }}
+      platforms: ${{ needs.base_builds_envs_setup.outputs.platforms }}
+      version: ${{ needs.base_builds_envs_setup.outputs.version }}
+      tag_alias: ${{ needs.base_builds_envs_setup.outputs.tag_alias }}
+      tari_network: ${{ needs.base_builds_envs_setup.outputs.tari_network }}
+      build_items: ${{ needs.base_builds_envs_setup.outputs.build_items }}

--- a/.github/workflows/build_dockers.yml
+++ b/.github/workflows/build_dockers.yml
@@ -29,7 +29,7 @@ name: Build docker images
         options:
           - linux/amd64
           - linux/arm64
-          - linux/arm64, linux/amd64
+          - linux/arm64,linux/amd64
       tari_network:
         default: esmeralda
         description: 'target testNet'
@@ -105,7 +105,7 @@ jobs:
             echo "Branch Build - limited dual arch"
             echo "platforms=linux/arm64, linux/amd64" >> $GITHUB_OUTPUT
             #echo "tag_alias=latest-adhoc" >> $GITHUB_OUTPUT
-            echo "tari_network=esme" >> $GITHUB_OUTPUT
+            echo "tari_network=esmeralda" >> $GITHUB_OUTPUT
             #echo "build_items=xmrig" >> $GITHUB_OUTPUT
             #echo "build_items=3rdparty" >> $GITHUB_OUTPUT
             echo "build_items=minotari_all" >> $GITHUB_OUTPUT
@@ -121,16 +121,16 @@ jobs:
           if [ "${{ github.event_name }}" == "schedule" ] ; then
             echo "Scheduled builds"
             if [[ $(date +%u) -eq 7 ]] ; then
-              echo "Weekly Build - limited dual arch - esme"
+              echo "Weekly Build - limited dual arch - esmeralda"
               echo "platforms=linux/arm64, linux/amd64" >> $GITHUB_OUTPUT
               echo "tag_alias=latest-weekly" >> $GITHUB_OUTPUT
-              echo "tari_network=esme" >> $GITHUB_OUTPUT
+              echo "tari_network=esmeralda" >> $GITHUB_OUTPUT
               echo "build_items=minotari_all" >> $GITHUB_OUTPUT
             else
-              echo "Nightly Build - limited amd64 - esme"
+              echo "Nightly Build - limited amd64 - esmeralda"
               echo "platforms=linux/amd64" >> $GITHUB_OUTPUT
               #echo "tag_alias=latest-nightly" >> $GITHUB_OUTPUT
-              echo "tari_network=esme" >> $GITHUB_OUTPUT
+              echo "tari_network=esmeralda" >> $GITHUB_OUTPUT
               echo "build_items=minotari_all" >> $GITHUB_OUTPUT
             fi
             echo "Schedule: ${SCHEDULE} - $(date)"

--- a/.github/workflows/build_dockers.yml
+++ b/.github/workflows/build_dockers.yml
@@ -96,15 +96,15 @@ jobs:
             #VERSION="${{ github.ref_name }}_$(date -u '+%Y%m%d')_${VSHA_SHORT}"
             VERSION="${{ github.ref_name }}"
             echo "Version used - ${VERSION}"
-            echo "platforms=linux/arm64, linux/amd64" >> $GITHUB_OUTPUT
+            echo "platforms=linux/arm64,linux/amd64" >> $GITHUB_OUTPUT
             echo "version=${VERSION}" >> $GITHUB_OUTPUT
             echo "tag_alias=latest" >> $GITHUB_OUTPUT
             echo "build_items=all" >> $GITHUB_OUTPUT
           fi
           if [[ "${{ github.ref }}" =~ ^refs/heads/build-dockers-* ]] || [[ "${{ github.ref }}" =~ ^refs/heads/build-all-* ]] ; then
             echo "Branch Build - limited dual arch"
-            echo "platforms=linux/arm64, linux/amd64" >> $GITHUB_OUTPUT
-            #echo "tag_alias=latest-adhoc" >> $GITHUB_OUTPUT
+            echo "platforms=linux/arm64,linux/amd64" >> $GITHUB_OUTPUT
+            echo "tag_alias=latest-adhoc" >> $GITHUB_OUTPUT
             echo "tari_network=esmeralda" >> $GITHUB_OUTPUT
             #echo "build_items=xmrig" >> $GITHUB_OUTPUT
             #echo "build_items=3rdparty" >> $GITHUB_OUTPUT
@@ -122,14 +122,14 @@ jobs:
             echo "Scheduled builds"
             if [[ $(date +%u) -eq 7 ]] ; then
               echo "Weekly Build - limited dual arch - esmeralda"
-              echo "platforms=linux/arm64, linux/amd64" >> $GITHUB_OUTPUT
+              echo "platforms=linux/arm64,linux/amd64" >> $GITHUB_OUTPUT
               echo "tag_alias=latest-weekly" >> $GITHUB_OUTPUT
               echo "tari_network=esmeralda" >> $GITHUB_OUTPUT
               echo "build_items=minotari_all" >> $GITHUB_OUTPUT
             else
               echo "Nightly Build - limited amd64 - esmeralda"
               echo "platforms=linux/amd64" >> $GITHUB_OUTPUT
-              #echo "tag_alias=latest-nightly" >> $GITHUB_OUTPUT
+              echo "tag_alias=latest-nightly" >> $GITHUB_OUTPUT
               echo "tari_network=esmeralda" >> $GITHUB_OUTPUT
               echo "build_items=minotari_all" >> $GITHUB_OUTPUT
             fi

--- a/.github/workflows/build_dockers_workflow.yml
+++ b/.github/workflows/build_dockers_workflow.yml
@@ -15,18 +15,18 @@ name: Build docker images - workflow_call/on-demand
         type: string
         description: 'Rust toolchain'
         default: stable
-      arch:
-        type: string
-        default: x86-64
       features:
         type: string
         default: 'safe,libtor,metrics'
       version:
         type: string
-        description: 'build tag/version'
+        description: 'build minotari tag/version'
       tag_alias:
         type: string
-        description: 'build tag alias'
+        description: 'build minotari tag alias'
+      tari_network:
+        type: string
+        description: 'target testNet'
       build_items:
         type: string
         default: minotari_sha3_miner
@@ -35,6 +35,7 @@ name: Build docker images - workflow_call/on-demand
         type: string
         # linux/arm64, linux/amd64
         default: linux/amd64
+        description: 'docker target build platform(s)'
 
 env:
   DAYS_to_EXPIRE: 30
@@ -43,88 +44,23 @@ permissions:
   contents: read
 
 jobs:
-  envs_setup:
+  builds_envs_setup:
     runs-on: ubuntu-latest
     outputs:
-      matrix: ${{ steps.set_matrix.outputs.matrix }}
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      TARI_NETWORK: ${{ steps.set-tari-network.outputs.TARI_NETWORK }}
+      TARI_TARGET_NETWORK: ${{ steps.set-tari-network.outputs.TARI_TARGET_NETWORK }}
 
     steps:
       - name: checkout tari
         uses: actions/checkout@v4
 
       - name: Set Matrix
-        id: set_matrix
+        id: set-matrix
         shell: bash
         run: |
+          # set -xuo pipefail
           build_items=${{ inputs.build_items }}
-          echo "Building with ${build_items}."
-          if [ -z "${build_items}" ] || [ "${build_items}" = "minotari_all" ] ; then
-            echo "Build all Minotari images"
-            matrix_selection=$( jq -s -c '.[]' ./buildtools/docker_rig/tarisuite.json )
-          elif [ "${build_items:0:9}" = "minotari_" ] ; then
-            echo "Build only selected minotari images - ${build_items}"
-            matrix_selection=$( jq --arg jsonVar "${build_items}" -r '[. []
-              | select(."image_name"==$jsonVar)]' ./buildtools/docker_rig/tarisuite.json )
-          elif [ "${build_items}" = "all" ] ; then
-            echo "Build all images"
-            matrix_selection=$( jq -c '. += input' ./buildtools/docker_rig/tarisuite.json ./buildtools/docker_rig/3rdparty.json )
-          elif [ "${build_items:0:8}" = "3rdparty" ] ; then
-            echo "Build only 3rdparty images - ${build_items}"
-            matrix_selection=$( jq -s -c '.[]' ./buildtools/docker_rig/3rdparty.json )
-          else
-            echo "Build only selected 3rdparty images - ${build_items}"
-            matrix_selection=$( jq --arg jsonVar "${build_items}" -r '[. []
-              | select(."image_name"==$jsonVar)]' ./buildtools/docker_rig/3rdparty.json )
-          #  "!! Broken selection? !!"
-          #  exit 1
-          fi
-
-          # ToDo: Add error checking
-
-          # Setup the json build matrix
-          matrix=$(echo ${matrix_selection} | jq -s -c '{"builds": .[]}')
-
-          echo $matrix
-          echo $matrix | jq .
-          echo "matrix=${matrix}" >> $GITHUB_OUTPUT
-
-  docker_build:
-    name: Docker building ${{ matrix.builds.image_name }}
-    needs: envs_setup
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(needs.envs_setup.outputs.matrix) }}
-
-    permissions:
-      contents: read
-      packages: write
-
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: checkout tari
-        uses: actions/checkout@v4
-
-      - name: Declare TestNet for tags
-        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-        shell: bash
-        run: |
-          source ./buildtools/multinet_envs.sh ${{github.ref_name}}
-          echo ${TARI_NETWORK}
-          echo "TARI_NETWORK=${TARI_NETWORK}" >> $GITHUB_ENV
-          echo ${TARI_TARGET_NETWORK}
-          echo "TARI_TARGET_NETWORK=${TARI_TARGET_NETWORK}" >> $GITHUB_ENV
-
-      - name: Setup expiration for none releases
-        if: ${{ ! startsWith(github.ref, 'refs/tags/v') }}
-        shell: bash
-        run: |
-          echo "EXPIRATION=${{ env.DAYS_to_EXPIRE }}d" >> $GITHUB_ENV
-
-      - name: environment setup
-        shell: bash
-        run: |
-          IMAGE_NAME=${{ matrix.builds.image_name }}
           if [ -z "${{ inputs.version }}" ] ; then
             echo "Get tari version"
             TARI_SOURCE_ROOT="./"
@@ -137,36 +73,91 @@ jobs:
           else
             VERSION=${{ inputs.version }}
           fi
-          echo "Setting ${VERSION} as docker tag"
-          echo "VERSION=${VERSION}" >> $GITHUB_ENV
-          if [ ! -z "${{ inputs.tag_alias }}" ] ; then
-            if [ -z "${{ env.TARI_NETWORK }}" ] ; then
-              echo "Setup tag_alias"
-              echo "TAG_ALIAS=${{ secrets.DOCKER_PROVIDER }}/${{ secrets.DOCKER_REPO }}/${{ matrix.builds.image_name }}:${{ inputs.tag_alias }}" >> $GITHUB_ENV
-            else
-              echo "Setup tag_alias with network"
-              echo "TAG_ALIAS=${{ secrets.DOCKER_PROVIDER }}/${{ secrets.DOCKER_REPO }}/${{ matrix.builds.image_name }}:${{ inputs.tag_alias }}-${{ env.TARI_NETWORK }}" >> $GITHUB_ENV
-            fi
+
+          cd buildtools/docker_rig
+          source ./build-matrix.sh "${{ inputs.build_items }}" "${VERSION}" "${{ inputs.platforms }}"
+
+          echo $matrix
+          echo $matrix | jq .
+          echo "matrix=${matrix}" >> $GITHUB_OUTPUT
+
+      - name: Declare TestNet for tags/branches
+        id: set-tari-network
+        shell: bash
+        run: |
+          if [ "$GITHUB_EVENT_NAME" != "workflow_dispatch" ] && [ -z "${{ inputs.tari_network }}" ]; then
+            # Case: A version tag push (e.g., v1.0.0), not manually triggered
+            echo "Using $GITHUB_REF_NAME for multinet_envs.sh"
+            source ./buildtools/multinet_envs.sh "$GITHUB_REF_NAME"
+          else
+            # Case: Manually triggered workflow, or non-tag
+            echo "Using ${{ inputs.tari_network }} for multinet_envs.sh"
+            source ./buildtools/multinet_envs.sh "${{ inputs.tari_network }}"
           fi
+          echo "${TARI_NETWORK}"
+          echo "TARI_NETWORK=${TARI_NETWORK}" >> $GITHUB_OUTPUT
+          echo "${TARI_TARGET_NETWORK}"
+          echo "TARI_TARGET_NETWORK=${TARI_TARGET_NETWORK}" >> $GITHUB_OUTPUT
+
+  docker_builds:
+    name: Docker ${{ matrix.builds.arch }} ${{ matrix.builds.image_name }} build
+    needs: builds_envs_setup
+
+    continue-on-error: true
+
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.builds_envs_setup.outputs.matrix) }}
+
+    permissions:
+      contents: read
+      packages: write
+
+    runs-on: ${{ matrix.builds.runner }}
+
+    env:
+      TARI_NETWORK: ${{ needs.builds_envs_setup.outputs.TARI_NETWORK }}
+      TARI_TARGET_NETWORK: ${{ needs.builds_envs_setup.outputs.TARI_TARGET_NETWORK }}
+
+    steps:
+      - name: checkout tari
+        uses: actions/checkout@v4
+
+      - name: Setup expiration for none releases
+        shell: bash
+        run: |
+          if [[ "${{ github.ref }}" =~ ^refs\/tags\/v[0-9]+\.[0-9]+\.[0-9]+.*$ ]]; then
+            echo "No Expire for release"
+          else
+            echo "Expires in ${{ env.DAYS_to_EXPIRE }} days"
+            echo "EXPIRATION=${{ env.DAYS_to_EXPIRE }}d" >> $GITHUB_ENV
+          fi
+
+      - name: environment setup
+        shell: bash
+        run: |
+          IMAGE_NAME=${{ matrix.builds.image_name }}
           if [ "${IMAGE_NAME:0:9}" = "minotari_" ] ; then
             echo "Minotari builds"
-            echo "DOCKERFILE=tarilabs" >> $GITHUB_ENV
             echo "APP_NAME=${{ matrix.builds.app_name }}" >> $GITHUB_ENV
             echo "APP_EXEC=${{ matrix.builds.app_exec }}" >> $GITHUB_ENV
+
+            if [ ! -z "${{ inputs.tag_alias }}" ] ; then
+              echo "Setup tag_alias with network"
+              echo "TAG_ALIASQ=${{ secrets.DOCKER_PROVIDER }}/${{ secrets.DOCKER_REPO }}/${{ matrix.builds.image_name }}:${{ inputs.tag_alias }}-${{ env.TARI_NETWORK }}-${{ matrix.builds.arch }}" >> $GITHUB_ENV
+              echo "TAG_ALIASG=ghcr.io/${{ github.repository_owner }}/${{ matrix.builds.image_name }}:${{ inputs.tag_alias }}-${{ env.TARI_NETWORK }}-${{ matrix.builds.arch }}" >> $GITHUB_ENV
+            fi
+            echo "DSuffix=-${{ env.TARI_NETWORK }}-${{ matrix.builds.arch }}" >> $GITHUB_ENV
           else
             echo "3rd Party builds - ${IMAGE_NAME}"
-            if [ -f "./buildtools/docker_rig/${IMAGE_NAME}.Dockerfile" ] ; then
-              echo "DOCKERFILE=${IMAGE_NAME}" >> $GITHUB_ENV
-              SUBTAG=$(awk -v search="^ARG ${IMAGE_NAME^^}?_VERSION=" -F '=' '$0 ~ search \
-                { gsub(/["]/, "", $2); printf("%s",$2) }' \
-                "./buildtools/docker_rig/${IMAGE_NAME}.Dockerfile")
-              echo "Docker subtag - ${SUBTAG}"
-              echo "VERSION=${SUBTAG}_${VERSION}" >> $GITHUB_ENV
-              echo "DOCKER_SUBTAG=--build-arg ${IMAGE_NAME^^}_VERSION=${SUBTAG}" >> $GITHUB_ENV
-            else
-              "!! ${IMAGE_NAME}.Dockerfile file not found !!"
-              exit 1
-            fi
+            echo "DOCKER_SUBTAG=${{ matrix.builds.build_args }}" >> $GITHUB_ENV
+            echo "DSuffix=-${{ matrix.builds.arch }}" >> $GITHUB_ENV
+          fi
+          # What about riscv?
+          if [[ "${{ matrix.builds.arch }}" == "amd64" ]]; then
+            echo "cargo_arch=x86-64" >> $GITHUB_ENV
+          else
+            echo "cargo_arch=aarch64" >> $GITHUB_ENV
           fi
 
       - name: Set up QEMU for Docker
@@ -180,18 +171,31 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            #name/${{ matrix.builds.image_name }}
+            # name/${{ matrix.builds.image_name }}
             ghcr.io/${{ github.repository_owner }}/${{ matrix.builds.image_name }}
+            ${{ secrets.DOCKER_PROVIDER }}/${{ secrets.DOCKER_REPO }}/${{ matrix.builds.image_name }}
           tags: |
-            type=raw,value=latest-${{ env.TARI_NETWORK }},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=schedule
             type=ref,event=tag
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
+            type=ref,event=branch,enable=${{ startsWith(matrix.builds.image_name, 'minotari_') }}
+            type=ref,event=pr,enable=${{ startsWith(matrix.builds.image_name, 'minotari_') }}
+            type=semver,pattern={{version}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
             type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
             type=sha
           labels: |
+            maintainer=${{ github.actor }}
             quay.expires-after=${{ env.EXPIRATION }}
+            org.opencontainers.image.vendor=TariLabs
+            org.opencontainers.image.title=${{ matrix.builds.image_name }}
+            org.opencontainers.image.description=Tari docker image ${{ matrix.builds.image_name }} for ${{ matrix.builds.arch }}
+            org.opencontainers.image.url=https://github.com/${{ github.repository }}
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.version=${{ matrix.builds.version }}
+          flavor: |
+            # latest=${{ startsWith(github.ref, 'refs/tags/v') }}
+            latest=false
+            suffix=${{ env.DSuffix }}
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -212,15 +216,15 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: ./buildtools/docker_rig/${{ env.DOCKERFILE }}.Dockerfile
-          platforms: ${{ inputs.platforms }}
+          file: ./buildtools/docker_rig/${{ matrix.builds.dockerfile }}
+          platforms: ${{ matrix.builds.platform }}
           push: true
           provenance: false
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
-            VERSION=${{ env.VERSION }}
-            ARCH=${{ inputs.arch }}
+            VERSION=${{ matrix.builds.version }}
+            ARCH=${{ env.cargo_arch }}
             FEATURES=${{ inputs.features }}
             APP_NAME=${{ matrix.builds.app_name }}
             APP_EXEC=${{ matrix.builds.app_exec }}
@@ -228,10 +232,121 @@ jobs:
             TARI_TARGET_NETWORK=${{ env.TARI_TARGET_NETWORK }}
             ${{ env.DOCKER_SUBTAG }}
           tags: |
+            ${{ secrets.DOCKER_PROVIDER }}/${{ secrets.DOCKER_REPO }}/${{ matrix.builds.image_name }}:${{ matrix.builds.version }}${{ env.DSuffix }}
+            ghcr.io/${{ github.repository_owner }}/${{ matrix.builds.image_name }}:${{ matrix.builds.version }}${{ env.DSuffix }}
             ${{ steps.meta.outputs.tags }}
-            ${{ secrets.DOCKER_PROVIDER }}/${{ secrets.DOCKER_REPO }}/${{ matrix.builds.image_name }}:${{ env.VERSION }}
-            ${{ env.TAG_ALIAS }}
+            ${{ env.TAG_ALIASQ }}
+            ${{ env.TAG_ALIASD }}
           labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
 
       - name: Image digest
-        run: echo ${{ steps.docker_build.outputs.digest }}
+        run: |
+          echo "Docker Digest - ${{ steps.docker_build.outputs.digest }}"
+          echo "Docker Image - ${{ matrix.builds.image_name }}:${{ matrix.builds.version }}${{ env.DSuffix }}"
+
+  multi-arch-create-manifest:
+    needs: [ builds_envs_setup, docker_builds ]
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Log in to Registries
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+          echo "${{ secrets.DOCKER_PASSWORD }}" | docker login ${{ secrets.DOCKER_PROVIDER }} -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+
+      - name: Pre for multi-arch image merge
+        env:
+          BMATRIX: ${{ needs.builds_envs_setup.outputs.matrix }}
+          TARI_NETWORK: ${{ needs.builds_envs_setup.outputs.TARI_NETWORK }}
+        run: |
+          # set -xuo pipefail
+          echo '${{ env.BMATRIX }}' | jq -r
+
+          # Get all multi-arch image_names (have both amd64 and arm64), with version
+          mapfile -t multiarch_images < <(
+            echo '${{ env.BMATRIX }}' | jq -r '
+              .builds
+                | group_by(.image_name)
+                | map(select((map(.arch) | index("amd64")) and (map(.arch) | index("arm64"))))
+                | map({image_name: .[0].image_name, version: .[0].version})
+                | unique
+                | map("\(.image_name):\(.version)")
+                | .[]
+              '
+            )
+
+          if [ ${#multiarch_images[@]} -eq 0 ]; then
+            echo "No multi-arch Docker images found."
+            mapfile -t all_images < <(jq -r '.builds[].image_name' build-bmatrix.json  | sort -u)
+            for img in "${all_images[@]}"; do
+              if [[ ! " ${multiarch_images[*]} " =~ " ${img} " ]]; then
+                echo "Image '$img' has only one architecture built."
+              fi
+            done
+          else
+            echo "Found ${#multiarch_images[@]} multi-arch Docker images."
+            echo "${multiarch_images[*]}"
+            for DENTRY in "${multiarch_images[@]}"; do
+              DNAME="${DENTRY%%:*}"
+              DVERSION="${DENTRY##*:}"
+              if [ "${DNAME:0:9}" = "minotari_" ] ; then
+                DSUFFIX=-${{ env.TARI_NETWORK }}
+              else
+                DSUFFIX=
+              fi
+              echo "Multi-arch ${DNAME} processing ..."
+              for DREGISTRY in ghcr.io quay.io; do
+                if [[ "${DREGISTRY}" == "ghcr.io" ]]; then
+                  REPO="${{ github.repository_owner }}"
+                else
+                  REPO="${{ secrets.DOCKER_REPO }}"
+                fi
+
+                echo "Registry run - ${DREGISTRY}"
+                echo "Creating multi-arch image for ${REPO}/${DNAME} for ${DVERSION}${DSUFFIX}"
+                docker manifest create \
+                  ${DREGISTRY}/${REPO}/${DNAME}:${DVERSION}${DSUFFIX} \
+                    --amend ${DREGISTRY}/${REPO}/${DNAME}:${DVERSION}${DSUFFIX}-amd64 \
+                    --amend ${DREGISTRY}/${REPO}/${DNAME}:${DVERSION}${DSUFFIX}-arm64
+
+                echo "Inspect multi-arch image for ${REPO}/${DNAME}"
+                docker manifest inspect ${DREGISTRY}/${REPO}/${DNAME}:${DVERSION}${DSUFFIX} > manifest.json
+                cat manifest.json
+                echo "Pushing multi-arch image for ${REPO}/${DNAME}"
+                docker manifest push ${DREGISTRY}/${REPO}/${DNAME}:${DVERSION}${DSUFFIX} || true
+
+                if [[ "${{ inputs.tag_alias }}" =~ ^latest-.*$ ]]; then
+                  echo "Latest Alis Multi-Arch tag - ${{ inputs.tag_alias }}"
+                  docker manifest create \
+                    ${DREGISTRY}/${REPO}/${DNAME}:${{ inputs.tag_alias }}${DSUFFIX} \
+                      --amend ${DREGISTRY}/${REPO}/${DNAME}:${DVERSION}${DSUFFIX}-amd64 \
+                      --amend ${DREGISTRY}/${REPO}/${DNAME}:${DVERSION}${DSUFFIX}-arm64
+                  docker manifest push ${DREGISTRY}/${REPO}/${DNAME}:${{ inputs.tag_alias }}${DSUFFIX} || true
+                fi
+
+                if [[ "${GITHUB_REF}" =~ ^refs\/tags\/v[0-9]+\.[0-9]+\.[0-9]+.*$ ]]; then
+                  echo "Release Multi-Arch Tag - ${GITHUB_REF_NAME} for ${GITHUB_REF}"
+                  docker manifest create \
+                    ${DREGISTRY}/${REPO}/${DNAME}:${GITHUB_REF_NAME} \
+                      --amend ${DREGISTRY}/${REPO}/${DNAME}:${DVERSION}${DSUFFIX}-amd64 \
+                      --amend ${DREGISTRY}/${REPO}/${DNAME}:${DVERSION}${DSUFFIX}-arm64
+                  docker manifest push ${DREGISTRY}/${REPO}/${DNAME}:${GITHUB_REF_NAME} || true
+                fi
+
+                if [[ "$GITHUB_REF_TYPE" == "tag" && "$GITHUB_REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+.*$ ]]; then
+                  echo "Latest Release Multi-Arch tag - $GITHUB_REF_NAME for $GITHUB_REF"
+                  docker manifest create \
+                    ${DREGISTRY}/${REPO}/${DNAME}:latest-${DSUFFIX} \
+                      --amend ${DREGISTRY}/${REPO}/${DNAME}:${DVERSION}${DSUFFIX}-amd64 \
+                      --amend ${DREGISTRY}/${REPO}/${DNAME}:${DVERSION}${DSUFFIX}-arm64
+                  #docker manifest annotate ${DREGISTRY}/${REPO}/${DNAME}:latest${DSUFFIX} --file manifest.json
+                  docker manifest push ${DREGISTRY}/${REPO}/${DNAME}:latest${DSUFFIX} || true
+                fi
+              done
+            done
+          fi

--- a/.github/workflows/build_dockers_workflow.yml
+++ b/.github/workflows/build_dockers_workflow.yml
@@ -282,12 +282,13 @@ jobs:
 
           if [ ${#multiarch_images[@]} -eq 0 ]; then
             echo "No multi-arch Docker images found."
-            mapfile -t all_images < <(jq -r '.builds[].image_name' build-bmatrix.json  | sort -u)
-            for img in "${all_images[@]}"; do
-              if [[ ! " ${multiarch_images[*]} " =~ " ${img} " ]]; then
-                echo "Image '$img' has only one architecture built."
-              fi
-            done
+            mapfile -t all_images < <(
+              echo '${{ env.BMATRIX }}' | jq -r '.builds[].image_name' | sort -u)
+                for img in "${all_images[@]}"; do
+                  if [[ ! " ${multiarch_images[*]} " =~ " ${img} " ]]; then
+                    echo "Image '$img' has only one architecture built."
+                  fi
+                done
           else
             echo "Found ${#multiarch_images[@]} multi-arch Docker images."
             echo "${multiarch_images[*]}"

--- a/.github/workflows/build_dockers_workflow.yml
+++ b/.github/workflows/build_dockers_workflow.yml
@@ -33,7 +33,7 @@ name: Build docker images - workflow_call/on-demand
         description: 'build images'
       platforms:
         type: string
-        # linux/arm64, linux/amd64
+        # linux/arm64,linux/amd64
         default: linux/amd64
         description: 'docker target build platform(s)'
 
@@ -77,8 +77,8 @@ jobs:
           cd buildtools/docker_rig
           source ./build-matrix.sh "${{ inputs.build_items }}" "${VERSION}" "${{ inputs.platforms }}"
 
-          echo $matrix
-          echo $matrix | jq .
+          echo "${matrix}"
+          echo "${matrix}" | jq .
           echo "matrix=${matrix}" >> $GITHUB_OUTPUT
 
       - name: Declare TestNet for tags/branches
@@ -340,9 +340,9 @@ jobs:
                 fi
 
                 if [[ "$GITHUB_REF_TYPE" == "tag" && "$GITHUB_REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+.*$ ]]; then
-                  echo "Latest Release Multi-Arch tag - $GITHUB_REF_NAME for $GITHUB_REF"
+                  echo "Latest Release Multi-Arch tag - $GITHUB_REF_NAME for $GITHUB_REF using ${DVERSION}${DSUFFIX}"
                   docker manifest create \
-                    ${DREGISTRY}/${REPO}/${DNAME}:latest-${DSUFFIX} \
+                    ${DREGISTRY}/${REPO}/${DNAME}:latest${DSUFFIX} \
                       --amend ${DREGISTRY}/${REPO}/${DNAME}:${DVERSION}${DSUFFIX}-amd64 \
                       --amend ${DREGISTRY}/${REPO}/${DNAME}:${DVERSION}${DSUFFIX}-arm64
                   #docker manifest annotate ${DREGISTRY}/${REPO}/${DNAME}:latest${DSUFFIX} --file manifest.json

--- a/.github/workflows/build_dockers_workflow.yml
+++ b/.github/workflows/build_dockers_workflow.yml
@@ -236,7 +236,7 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/${{ matrix.builds.image_name }}:${{ matrix.builds.version }}${{ env.DSuffix }}
             ${{ steps.meta.outputs.tags }}
             ${{ env.TAG_ALIASQ }}
-            ${{ env.TAG_ALIASD }}
+            ${{ env.TAG_ALIASG }}
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}
 

--- a/buildtools/docker_rig/build-matrix.sh
+++ b/buildtools/docker_rig/build-matrix.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 #
-# prep json build matrix from envs
+# prep json build matrix from args
 #
 # ./build-matrix.sh all "4.4.1" "linux/amd64,linux/arm64"
 # ./build-matrix.sh minotari_sha3_miner "4.4.1" "linux/arm64"
 # ./build-matrix.sh tor "4.4.1" "linux/arm64"
+#
 
-#set -xuo pipefail
+set -euxo pipefail
 
 build_items=${1:-minotari_all}
 echo "Building with ${build_items}."
@@ -19,7 +20,7 @@ elif [ "${build_items:0:9}" = "minotari_" ] ; then
     | select(."image_name"==$jsonVar)]' tarisuite.json )
 elif [ "${build_items}" = "all" ] ; then
   echo "Build all images"
-  matrix_selection=$( jq -c '. += input' tarisuite.json 3rdparty.json )
+  matrix_selection=$(jq -s -c '.[0] + .[1]' tarisuite.json 3rdparty.json)
 elif [ "${build_items:0:8}" = "3rdparty" ] ; then
   echo "Build only 3rdparty images - ${build_items}"
   matrix_selection=$( jq -s -c '.[]' 3rdparty.json )
@@ -35,12 +36,12 @@ MINOTARI_VERSION="${2:-dev}"  # e.g., pass in tag as first arg
 # Start jSon string
 matrix_details="["
 
-echo "${matrix_selection}" | jq -c '.'
+#echo "${matrix_selection}" | jq -c '.'
 while read -r item; do
 
   image_name=$(jq -r '.image_name' <<< "${item}")
-  echo "Image: ${image_name}"
-  echo "JSon Object: $(jq -r '.' <<< "${item}")"
+  #echo "Image: ${image_name}"
+  #echo "JSon Object: $(jq -r '.' <<< "${item}")"
 
   # Determine version
   if [[ "${image_name}" == minotari_* ]]; then
@@ -60,7 +61,7 @@ while read -r item; do
     continue
   fi
 
-  echo "${version}, ${dockerfile}, ${build_arg}"
+  #echo "${version}, ${dockerfile}, ${build_arg}"
 
   # Extend the original JSON object with new fields
   enriched=$(jq -c \
@@ -86,7 +87,7 @@ else
   matrix_details+="]"
 fi
 
-#echo $matrix_details
+#echo "${matrix_details}"
 #echo "${matrix_details}" | jq .
 
 build_platforms=${3:-"linux/arm64, linux/amd64"}
@@ -113,7 +114,7 @@ matrix_platforms=$(jq --argjson platforms "$platforms_json" '
   ]
 ' <<< "${matrix_details}")
 
-matrix=$(echo ${matrix_platforms} | jq -s -c '{"builds": .[]}')
+matrix=$(echo "${matrix_platforms}" | jq -s -c '{"builds": .[]}')
 
-echo $matrix
-echo $matrix | jq .
+echo "${matrix}"
+echo "${matrix}" | jq .

--- a/buildtools/docker_rig/build-matrix.sh
+++ b/buildtools/docker_rig/build-matrix.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+#
+# prep json build matrix from envs
+#
+# ./build-matrix.sh all "4.4.1" "linux/amd64,linux/arm64"
+# ./build-matrix.sh minotari_sha3_miner "4.4.1" "linux/arm64"
+# ./build-matrix.sh tor "4.4.1" "linux/arm64"
+
+#set -xuo pipefail
+
+build_items=${1:-minotari_all}
+echo "Building with ${build_items}."
+if [ -z "${build_items}" ] || [ "${build_items}" = "minotari_all" ] ; then
+  echo "Build all Minotari images"
+  matrix_selection=$( jq -s -c '.[]' tarisuite.json )
+elif [ "${build_items:0:9}" = "minotari_" ] ; then
+  echo "Build only selected minotari images - ${build_items}"
+  matrix_selection=$( jq --arg jsonVar "${build_items}" -r '[. []
+    | select(."image_name"==$jsonVar)]' tarisuite.json )
+elif [ "${build_items}" = "all" ] ; then
+  echo "Build all images"
+  matrix_selection=$( jq -c '. += input' tarisuite.json 3rdparty.json )
+elif [ "${build_items:0:8}" = "3rdparty" ] ; then
+  echo "Build only 3rdparty images - ${build_items}"
+  matrix_selection=$( jq -s -c '.[]' 3rdparty.json )
+else
+  echo "Build only selected 3rdparty images - ${build_items}"
+  matrix_selection=$( jq --arg jsonVar "${build_items}" -r '[. []
+    | select(."image_name"==$jsonVar)]' 3rdparty.json )
+fi
+
+# Choose version prefix for minotari builds
+MINOTARI_VERSION="${2:-dev}"  # e.g., pass in tag as first arg
+
+# Start jSon string
+matrix_details="["
+
+echo "${matrix_selection}" | jq -c '.'
+while read -r item; do
+
+  image_name=$(jq -r '.image_name' <<< "${item}")
+  echo "Image: ${image_name}"
+  echo "JSon Object: $(jq -r '.' <<< "${item}")"
+
+  # Determine version
+  if [[ "${image_name}" == minotari_* ]]; then
+    version="${MINOTARI_VERSION}"
+    dockerfile="tarilabs.Dockerfile"
+    build_arg=""
+  elif [[ -f "${image_name}.Dockerfile" ]]; then
+    uppername=$(echo "${image_name}" | tr '[:lower:]' '[:upper:]')
+    version=$(awk -v search="^ARG ${uppername}_VERSION=" \
+      -F '=' '$0 ~ search \
+        { gsub(/["]/, "", $2); print $2 }' "${image_name}.Dockerfile")
+    #version+="-${MINOTARI_VERSION}"
+    dockerfile="${image_name}.Dockerfile"
+    build_arg="${uppername}_VERSION=${version}"
+  else
+    echo "No Dockerfile for ${image_name}, skipping..."
+    continue
+  fi
+
+  echo "${version}, ${dockerfile}, ${build_arg}"
+
+  # Extend the original JSON object with new fields
+  enriched=$(jq -c \
+    --arg version "$version" \
+    --arg dockerfile "$dockerfile" \
+    --arg build_args "$build_arg" \
+    '. + {
+      version: $version,
+      dockerfile: $dockerfile,
+      build_args: $build_args
+    }' <<< "${item}")
+
+  matrix_details+="$enriched,"
+done < <(jq -c '.[]' <<< "${matrix_selection}")
+
+if [[ "${matrix_details}" == "[" ]]; then
+  matrix_details="[]"  # no entries were added
+  echo "!! Broken selection? !!"
+  exit 1
+else
+  # Trim trailing comma and close string
+  matrix_details="${matrix_details%,}"
+  matrix_details+="]"
+fi
+
+#echo $matrix_details
+#echo "${matrix_details}" | jq .
+
+build_platforms=${3:-"linux/arm64, linux/amd64"}
+mapfile -t platform_list < <(echo "${build_platforms}" | tr ',' '\n'| awk '{$1=$1; print}')
+# Convert platform list to JSON array
+platforms_json=$(jq -n --argjson p "$(printf '%s\n' "${platform_list[@]}" | jq -R . | jq -s .)" '$p')
+matrix_platforms=$(jq --argjson platforms "$platforms_json" '
+  [
+    .[] as $b |
+    $platforms[] as $p |
+    $b + {
+      platform: $p,
+      runner: (
+        if $p | test("arm64") then "ubuntu-24.04-arm"
+        else "ubuntu-latest"
+        end
+      ),
+      arch: (
+        if $p | test("arm64") then "arm64"
+        else "amd64"
+        end
+      )
+    }
+  ]
+' <<< "${matrix_details}")
+
+matrix=$(echo ${matrix_platforms} | jq -s -c '{"builds": .[]}')
+
+echo $matrix
+echo $matrix | jq .

--- a/buildtools/docker_rig/tor.Dockerfile
+++ b/buildtools/docker_rig/tor.Dockerfile
@@ -1,6 +1,6 @@
 # Package build
 
-ARG ALPINE_VERSION=3.21
+ARG ALPINE_VERSION=3.22
 
 FROM alpine:$ALPINE_VERSION
 
@@ -9,7 +9,7 @@ ARG BUILDPLATFORM
 ARG VERSION=1.0.1
 
 # https://pkgs.alpinelinux.org/packages?name=tor&branch=v3.18&repo=community&arch=&maintainer=
-ARG TOR_VERSION=0.4.8.14-r0
+ARG TOR_VERSION=0.4.8.16-r0
 
 # Install tor with a minimum version
 RUN apk add --no-cache grep curl tor>$TOR_VERSION

--- a/buildtools/docker_rig/tor.Dockerfile
+++ b/buildtools/docker_rig/tor.Dockerfile
@@ -12,7 +12,7 @@ ARG VERSION=1.0.1
 ARG TOR_VERSION=0.4.8.16-r0
 
 # Install tor with a minimum version
-RUN apk add --no-cache grep curl "tor>${TOR_VERSION}"
+RUN apk add --no-cache grep curl tor>${TOR_VERSION}
 
 ENV dockerfile_version=$VERSION
 ENV dockerfile_build_arch=$BUILDPLATFORM

--- a/buildtools/docker_rig/tor.Dockerfile
+++ b/buildtools/docker_rig/tor.Dockerfile
@@ -12,7 +12,7 @@ ARG VERSION=1.0.1
 ARG TOR_VERSION=0.4.8.16-r0
 
 # Install tor with a minimum version
-RUN apk add --no-cache grep curl tor>$TOR_VERSION
+RUN apk add --no-cache grep curl "tor>${TOR_VERSION}"
 
 ENV dockerfile_version=$VERSION
 ENV dockerfile_build_arch=$BUILDPLATFORM


### PR DESCRIPTION
Description
 - Split out docker builds for amd64/arm64 into native runners to address https://github.com/tari-project/tari/issues/7142 in GitHub CI
 - New step to merge both builds into a multi-arch single label
 - Add extra docker labels and with testNet build target included
 - Match as many of the labels between both docker registries
 - Extend ad-hoc CI builds, to include testNets
 - Add mainNet CI target nightly build of node

Motivation and Context
 - Splitting out the docker builds for amd64/arm64 into native runners to address https://github.com/tari-project/tari/issues/7142, because the docker cross-compile has broken. Using the native runners for building the local platforms should be faster, less likely to break and if it does, we can better debug what broken, verse the current state where dual-build platforms has all logging intermixed between both building platforms.
 - Merge both platforms back into one label, try not to break any systems use current labeling
 - Extra labels make it easier to target images
 - Make sure that labels on docker registries are as close as possible
 - Enabled targeted CI ad-hoc builds from GitHub
 - Enable an extra nightly build for mainNet node for testing in CI 

How Has This Been Tested?
Built in local fork and tested via images from fork registries


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for network selection when manually triggering Docker builds, enabling builds for different networks.
  - Introduced a new scheduled nightly build for MainNet with specific build parameters.
  - Implemented multi-architecture Docker manifest creation and publishing for built images.
  - Added a new build matrix generation script to streamline Docker image builds across platforms.

- **Improvements**
  - Enhanced build workflows with refined versioning, tagging, and environment setup logic.
  - Upgraded Tor package and Alpine Linux base version in Docker image for improved security and stability.

- **Chores**
  - Modularized and reorganized build scripts for better maintainability and flexibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->