### PR TITLE
feat: add payref to grpc outputs

### DIFF
--- a/applications/minotari_app_grpc/src/conversions/aggregate_body.rs
+++ b/applications/minotari_app_grpc/src/conversions/aggregate_body.rs
@@ -22,28 +22,28 @@
 
 use std::convert::TryFrom;
 
+use tari_common_types::types::BlockHash;
 use tari_core::transactions::aggregated_body::AggregateBody;
 use tari_utilities::convert::try_convert_all;
 
-use crate::tari_rpc as grpc;
+use crate::{conversions::transaction_output::grpc_output_with_payref, tari_rpc as grpc};
 
-impl TryFrom<AggregateBody> for grpc::AggregateBody {
-    type Error = String;
-
-    fn try_from(source: AggregateBody) -> Result<Self, Self::Error> {
-        let (inputs, outputs, kernels) = source.dissolve();
-        Ok(Self {
-            inputs: inputs
-                .into_iter()
-                .map(grpc::TransactionInput::try_from)
-                .collect::<Result<Vec<_>, _>>()?,
-            outputs: outputs
-                .into_iter()
-                .map(grpc::TransactionOutput::try_from)
-                .collect::<Result<Vec<grpc::TransactionOutput>, Self::Error>>()?,
-            kernels: kernels.into_iter().map(grpc::TransactionKernel::from).collect(),
-        })
-    }
+pub fn grpc_aggregate_body_with_payrefs(
+    block: AggregateBody,
+    block_hash: Option<BlockHash>,
+) -> Result<grpc::AggregateBody, String> {
+    let (inputs, outputs, kernels) = block.clone().dissolve();
+    Ok(grpc::AggregateBody {
+        inputs: inputs
+            .into_iter()
+            .map(grpc::TransactionInput::try_from)
+            .collect::<Result<Vec<_>, _>>()?,
+        outputs: outputs
+            .into_iter()
+            .map(|o| grpc_output_with_payref(o, block_hash))
+            .collect::<Result<Vec<_>, _>>()?,
+        kernels: kernels.into_iter().map(grpc::TransactionKernel::from).collect(),
+    })
 }
 
 impl TryFrom<grpc::AggregateBody> for AggregateBody {

--- a/applications/minotari_app_grpc/src/conversions/block.rs
+++ b/applications/minotari_app_grpc/src/conversions/block.rs
@@ -24,14 +24,14 @@ use std::convert::{TryFrom, TryInto};
 
 use tari_core::blocks::Block;
 
-use crate::tari_rpc as grpc;
+use crate::{conversions::aggregate_body::grpc_aggregate_body_with_payrefs, tari_rpc as grpc};
 
 impl TryFrom<tari_core::blocks::Block> for grpc::Block {
     type Error = String;
 
     fn try_from(block: Block) -> Result<Self, Self::Error> {
         Ok(Self {
-            body: Some(block.body.try_into()?),
+            body: Some(grpc_aggregate_body_with_payrefs(block.body, Some(block.header.hash()))?),
             header: Some(block.header.into()),
         })
     }

--- a/applications/minotari_app_grpc/src/conversions/block.rs
+++ b/applications/minotari_app_grpc/src/conversions/block.rs
@@ -30,9 +30,11 @@ impl TryFrom<tari_core::blocks::Block> for grpc::Block {
     type Error = String;
 
     fn try_from(block: Block) -> Result<Self, Self::Error> {
+        let Block { header, body } = block;
+        let body = grpc_aggregate_body_with_payrefs(body, Some(header.hash()))?;
         Ok(Self {
-            body: Some(grpc_aggregate_body_with_payrefs(block.body, Some(block.header.hash()))?),
-            header: Some(block.header.into()),
+            body: Some(body),
+            header: Some(header.into()),
         })
     }
 }

--- a/applications/minotari_app_grpc/src/conversions/new_block_template.rs
+++ b/applications/minotari_app_grpc/src/conversions/new_block_template.rs
@@ -29,7 +29,7 @@ use tari_core::{
 };
 use tari_utilities::ByteArray;
 
-use crate::tari_rpc as grpc;
+use crate::{conversions::transaction_output::grpc_output_with_payref, tari_rpc as grpc};
 
 impl TryFrom<NewBlockTemplate> for grpc::NewBlockTemplate {
     type Error = String;
@@ -58,7 +58,7 @@ impl TryFrom<NewBlockTemplate> for grpc::NewBlockTemplate {
                     .body
                     .outputs()
                     .iter()
-                    .map(|output| grpc::TransactionOutput::try_from(output.clone()))
+                    .map(|output| grpc_output_with_payref(output.clone(), None))
                     .collect::<Result<Vec<_>, _>>()?,
                 kernels: block
                     .body

--- a/applications/minotari_app_grpc/src/conversions/transaction.rs
+++ b/applications/minotari_app_grpc/src/conversions/transaction.rs
@@ -30,7 +30,7 @@ use tari_core::transactions::transaction_components::Transaction;
 use tari_crypto::ristretto::RistrettoSecretKey;
 use tari_utilities::ByteArray;
 
-use crate::tari_rpc as grpc;
+use crate::{conversions::aggregate_body::grpc_aggregate_body_with_payrefs, tari_rpc as grpc};
 
 impl TryFrom<Transaction> for grpc::Transaction {
     type Error = String;
@@ -38,7 +38,7 @@ impl TryFrom<Transaction> for grpc::Transaction {
     fn try_from(source: Transaction) -> Result<Self, Self::Error> {
         Ok(Self {
             offset: Vec::from(source.offset.as_bytes()),
-            body: Some(source.body.try_into()?),
+            body: Some(grpc_aggregate_body_with_payrefs(source.body, None)?),
             script_offset: Vec::from(source.script_offset.as_bytes()),
         })
     }
@@ -52,7 +52,7 @@ impl TryFrom<Arc<Transaction>> for grpc::Transaction {
             Ok(tx) => tx.try_into(),
             Err(tx) => Ok(Self {
                 offset: Vec::from(tx.offset.as_bytes()),
-                body: Some(tx.body.clone().try_into()?),
+                body: Some(grpc_aggregate_body_with_payrefs(tx.body.clone(), None)?),
                 script_offset: Vec::from(tx.script_offset.as_bytes()),
             }),
         }

--- a/applications/minotari_app_grpc/src/conversions/transaction_output.rs
+++ b/applications/minotari_app_grpc/src/conversions/transaction_output.rs
@@ -23,7 +23,10 @@
 use std::convert::{TryFrom, TryInto};
 
 use borsh::{BorshDeserialize, BorshSerialize};
-use tari_common_types::types::{BulletRangeProof, CompressedCommitment, CompressedPublicKey, RangeProof};
+use tari_common_types::{
+    payment_reference::generate_payment_reference,
+    types::{BlockHash, BulletRangeProof, CompressedCommitment, CompressedPublicKey, RangeProof},
+};
 use tari_core::transactions::{
     tari_amount::MicroMinotari,
     transaction_components::{EncryptedData, TransactionOutput, TransactionOutputVersion},
@@ -83,39 +86,42 @@ impl TryFrom<grpc::TransactionOutput> for TransactionOutput {
     }
 }
 
-impl TryFrom<TransactionOutput> for grpc::TransactionOutput {
-    type Error = String;
-
-    fn try_from(output: TransactionOutput) -> Result<Self, Self::Error> {
-        let hash = output.hash().to_vec();
-        let mut covenant = Vec::new();
-        BorshSerialize::serialize(&output.covenant, &mut covenant).map_err(|err| err.to_string())?;
-        let range_proof = output.proof.map(|proof| grpc::RangeProof {
-            proof_bytes: proof.to_vec(),
-        });
-        Ok(grpc::TransactionOutput {
-            hash,
-            features: Some(output.features.into()),
-            commitment: Vec::from(output.commitment.as_bytes()),
-            range_proof,
-            script: output.script.to_bytes(),
-            sender_offset_public_key: output.sender_offset_public_key.as_bytes().to_vec(),
-            metadata_signature: Some(grpc::ComAndPubSignature {
-                ephemeral_commitment: Vec::from(output.metadata_signature.ephemeral_commitment().as_bytes()),
-                ephemeral_pubkey: Vec::from(output.metadata_signature.ephemeral_pubkey().as_bytes()),
-                u_a: Vec::from(output.metadata_signature.u_a().as_bytes()),
-                u_x: Vec::from(output.metadata_signature.u_x().as_bytes()),
-                u_y: Vec::from(output.metadata_signature.u_y().as_bytes()),
-            }),
-            covenant,
-            version: output.version as u32,
-            encrypted_data: output.encrypted_data.to_byte_vec(),
-            minimum_value_promise: output.minimum_value_promise.into(),
-            // Payment reference will be populated when the output is included in a block
-            // and the block hash is available
-            payment_reference: vec![],
-        })
-    }
+pub fn grpc_output_with_payref(
+    output: TransactionOutput,
+    block_hash: Option<BlockHash>,
+) -> Result<grpc::TransactionOutput, String> {
+    let output_hash = output.hash();
+    let mut covenant = Vec::new();
+    BorshSerialize::serialize(&output.covenant, &mut covenant).map_err(|err| err.to_string())?;
+    let range_proof = output.proof.map(|proof| grpc::RangeProof {
+        proof_bytes: proof.to_vec(),
+    });
+    Ok(grpc::TransactionOutput {
+        hash: output_hash.to_vec(),
+        features: Some(output.features.into()),
+        commitment: Vec::from(output.commitment.as_bytes()),
+        range_proof,
+        script: output.script.to_bytes(),
+        sender_offset_public_key: output.sender_offset_public_key.as_bytes().to_vec(),
+        metadata_signature: Some(grpc::ComAndPubSignature {
+            ephemeral_commitment: Vec::from(output.metadata_signature.ephemeral_commitment().as_bytes()),
+            ephemeral_pubkey: Vec::from(output.metadata_signature.ephemeral_pubkey().as_bytes()),
+            u_a: Vec::from(output.metadata_signature.u_a().as_bytes()),
+            u_x: Vec::from(output.metadata_signature.u_x().as_bytes()),
+            u_y: Vec::from(output.metadata_signature.u_y().as_bytes()),
+        }),
+        covenant,
+        version: output.version as u32,
+        encrypted_data: output.encrypted_data.to_byte_vec(),
+        minimum_value_promise: output.minimum_value_promise.into(),
+        // Payment reference will be populated when the output is included in a block
+        // and the block hash is available
+        payment_reference: if let Some(hash) = block_hash {
+            generate_payment_reference(&hash, &output_hash).to_vec()
+        } else {
+            vec![]
+        },
+    })
 }
 
 impl From<RangeProof> for GrpcRangeProof {

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -1232,7 +1232,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
         let mut transactions: Vec<TransactionInfo> = Vec::new();
         for txn in completed_transactions
             .into_iter()
-            .filter(|tx| req.status_bitflag == 0 || (req.status_bitflag & (1 << (tx.status.clone() as u32))) != 0)
+            .filter(|tx| req.status_bitflag == 0 || (req.status_bitflag & (1 << (tx.status as u32))) != 0)
             .skip(offset)
             .take(limit)
         {

--- a/applications/minotari_miner/src/run_miner.rs
+++ b/applications/minotari_miner/src/run_miner.rs
@@ -25,6 +25,7 @@ use futures::stream::StreamExt;
 use log::*;
 use minotari_app_grpc::{
     authentication::ClientAuthenticationInterceptor,
+    conversions::transaction_output::grpc_output_with_payref,
     tari_rpc::{
         base_node_client::BaseNodeClient,
         pow_algo::PowAlgos,
@@ -34,7 +35,6 @@ use minotari_app_grpc::{
         PowAlgo,
         SubmitBlockRequest,
         SubmitBlockResponse,
-        TransactionOutput as GrpcTransactionOutput,
     },
 };
 use minotari_app_utilities::parse_miner_input::{
@@ -461,7 +461,8 @@ async fn get_new_block_base_node(
         .body
         .as_mut()
         .ok_or_else(|| err_empty("new_block_template.body"))?;
-    let grpc_output = GrpcTransactionOutput::try_from(coinbase_output.clone()).map_err(MinerError::Conversion)?;
+    let grpc_output =
+        grpc_output_with_payref(coinbase_output.clone(), None).map_err(|e| MinerError::Conversion(e.to_string()))?;
 
     body.outputs.push(grpc_output);
     body.kernels.push(coinbase_kernel.into());

--- a/applications/minotari_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/minotari_node/src/grpc/base_node_grpc_server.rs
@@ -31,6 +31,7 @@ use either::Either;
 use futures::{channel::mpsc, SinkExt};
 use log::*;
 use minotari_app_grpc::{
+    conversions::transaction_output::grpc_output_with_payref,
     tari_rpc,
     tari_rpc::{CalcType, Sorting},
 };
@@ -2170,7 +2171,7 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
                 Ok(data) => data,
             };
             for output in outputs {
-                match output.try_into() {
+                match grpc_output_with_payref(output, None) {
                     Ok(output) => {
                         let resp = tari_rpc::FetchMatchingUtxosResponse { output: Some(output) };
                         if tx.send(Ok(resp)).await.is_err() {
@@ -2896,7 +2897,14 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
                 let sidechain_outputs = utxos
                     .into_iter()
                     .filter(|u| u.features.output_type.is_sidechain_type())
-                    .map(TryInto::try_into)
+                    .map(|o| {
+                        grpc_output_with_payref(o, None).inspect_err(|e| {
+                            let _ignore = tx.send(Err(obscure_error_if_true(
+                                report_error_flag,
+                                Status::internal(e.to_string()),
+                            )));
+                        })
+                    })
                     .collect::<Result<Vec<_>, _>>();
 
                 match sidechain_outputs {

--- a/applications/minotari_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/minotari_node/src/grpc/base_node_grpc_server.rs
@@ -2897,9 +2897,7 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
                 let sidechain_outputs = utxos
                     .into_iter()
                     .filter(|u| u.features.output_type.is_sidechain_type())
-                    .map(|o| {
-                        grpc_output_with_payref(o, Some(header_hash))
-                    })
+                    .map(|o| grpc_output_with_payref(o, Some(header_hash)))
                     .collect::<Result<Vec<_>, _>>();
 
                 match sidechain_outputs {

--- a/applications/minotari_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/minotari_node/src/grpc/base_node_grpc_server.rs
@@ -2898,12 +2898,7 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
                     .into_iter()
                     .filter(|u| u.features.output_type.is_sidechain_type())
                     .map(|o| {
-                        grpc_output_with_payref(o, None).inspect_err(|e| {
-                            let _ignore = tx.send(Err(obscure_error_if_true(
-                                report_error_flag,
-                                Status::internal(e.to_string()),
-                            )));
-                        })
+                        grpc_output_with_payref(o, Some(header_hash))
                     })
                     .collect::<Result<Vec<_>, _>>();
 

--- a/base_layer/core/src/base_node/comms_interface/comms_request.rs
+++ b/base_layer/core/src/base_node/comms_interface/comms_request.rs
@@ -144,7 +144,7 @@ impl Display for NodeCommsRequest {
                 write!(f, "FetchOutputByPayRef ({})", payref.to_hex())
             },
             CheckOutputSpentStatus(output_hash) => {
-                write!(f, "CheckOutputSpentStatus ({})", output_hash.to_hex())
+                write!(f, "CheckOutputSpentStatus ({})", output_hash)
             },
         }
     }

--- a/integration_tests/src/miner.rs
+++ b/integration_tests/src/miner.rs
@@ -20,15 +20,11 @@
 //   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{convert::TryFrom, time::Duration};
+use std::time::Duration;
 
-use minotari_app_grpc::tari_rpc::{
-    pow_algo::PowAlgos,
-    Block,
-    NewBlockTemplate,
-    NewBlockTemplateRequest,
-    PowAlgo,
-    TransactionOutput as GrpcTransactionOutput,
+use minotari_app_grpc::{
+    conversions::transaction_output::grpc_output_with_payref,
+    tari_rpc::{pow_algo::PowAlgos, Block, NewBlockTemplate, NewBlockTemplateRequest, PowAlgo},
 };
 use minotari_app_utilities::common_cli_args::CommonCliArgs;
 use minotari_miner::{run_miner, Cli};
@@ -312,7 +308,7 @@ async fn create_block_template_with_coinbase(
     .unwrap();
     let body = block_template.body.as_mut().unwrap();
 
-    let grpc_output = GrpcTransactionOutput::try_from(coinbase_output).unwrap();
+    let grpc_output = grpc_output_with_payref(coinbase_output, None).unwrap();
     body.outputs.push(grpc_output);
     body.kernels.push(coinbase_kernel.into());
 


### PR DESCRIPTION
Description
---
Added payref hash to grpc outputs when a block is queried from the base node.

Motivation and Context
---
This functionality ws not wirted in.

How Has This Been Tested?
---
System-level testing

What process can a PR reviewer use to test or verify this change?
---
Code review
System-level testing

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced transaction output conversions to support payment references in gRPC responses, improving output traceability.

- **Refactor**
  - Unified and streamlined transaction output conversion logic across multiple modules for consistency.
  - Minor code simplifications and import cleanups for better maintainability.

- **Style**
  - Adjusted formatting for output hash display in node communication requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->