### PR TITLE
ci: nightly builds for mainnet and nextnet

### DIFF
--- a/.github/workflows/build_dockers.yml
+++ b/.github/workflows/build_dockers.yml
@@ -10,8 +10,6 @@ name: Build docker images
     branches:
       - 'build-all-*'
       - 'build-dockers-*'
-  schedule:
-    - cron: '05 00 * * *'
   workflow_dispatch:
     inputs:
 #      toolchain:
@@ -104,19 +102,6 @@ jobs:
             echo "version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
             echo "tag_alias=${{ github.event.inputs.tag_alias }}" >> $GITHUB_OUTPUT
             echo "build_items=${{ github.event.inputs.build_items }}" >> $GITHUB_OUTPUT
-          fi
-          if [ "${{ github.event_name }}" == "schedule" ] ; then
-            if [[ $(date +%u) -eq 7 ]] ; then
-              echo "Weekly Build - limited dual arch"
-              echo "platforms=linux/arm64, linux/amd64" >> $GITHUB_OUTPUT
-              echo "tag_alias=latest-weekly" >> $GITHUB_OUTPUT
-              echo "build_items=minotari_all" >> $GITHUB_OUTPUT
-            else
-              echo "Daily Build - limited"
-              echo "platforms=linux/amd64" >> $GITHUB_OUTPUT
-              echo "tag_alias=latest-daily" >> $GITHUB_OUTPUT
-              echo "build_items=minotari_all" >> $GITHUB_OUTPUT
-            fi
           fi
 
   builds_run:

--- a/.github/workflows/build_dockers_workflow.yml
+++ b/.github/workflows/build_dockers_workflow.yml
@@ -35,6 +35,18 @@ name: Build docker images - workflow_call/on-demand
         type: string
         # linux/arm64, linux/amd64
         default: linux/amd64
+      tari_network:
+        type: string
+        description: 'Tari network (mainnet, nextnet, etc.)'
+        default: ''
+      tari_target_network:
+        type: string
+        description: 'Tari target network for TARI_TARGET_NETWORK env var'
+        default: ''
+      tari_network_dir:
+        type: string
+        description: 'Tari network directory'
+        default: ''
 
 env:
   DAYS_to_EXPIRE: 30
@@ -114,6 +126,18 @@ jobs:
           echo "TARI_NETWORK=${TARI_NETWORK}" >> $GITHUB_ENV
           echo ${TARI_TARGET_NETWORK}
           echo "TARI_TARGET_NETWORK=${TARI_TARGET_NETWORK}" >> $GITHUB_ENV
+
+      - name: Set network environment variables from inputs
+        if: ${{ inputs.tari_target_network != '' }}
+        shell: bash
+        run: |
+          echo "Setting network environment variables from workflow inputs"
+          echo "TARI_NETWORK=${{ inputs.tari_network }}" >> $GITHUB_ENV
+          echo "TARI_TARGET_NETWORK=${{ inputs.tari_target_network }}" >> $GITHUB_ENV
+          echo "TARI_NETWORK_DIR=${{ inputs.tari_network_dir }}" >> $GITHUB_ENV
+          echo "Network: ${{ inputs.tari_network }}"
+          echo "Target Network: ${{ inputs.tari_target_network }}"
+          echo "Network Dir: ${{ inputs.tari_network_dir }}"
 
       - name: Setup expiration for none releases
         if: ${{ ! startsWith(github.ref, 'refs/tags/v') }}

--- a/.github/workflows/nightly_docker_builds.yml
+++ b/.github/workflows/nightly_docker_builds.yml
@@ -1,0 +1,125 @@
+---
+name: Nightly Docker Builds
+
+"on":
+  schedule:
+    - cron: "05 00 * * *"
+  workflow_dispatch:
+    inputs:
+      platforms:
+        default: linux/amd64
+        description: "docker platform(s)"
+        type: choice
+        options:
+          - linux/amd64
+          - linux/arm64
+          - linux/arm64, linux/amd64
+      build_items:
+        default: minotari_all
+        description: "image(s) to build"
+        type: choice
+        options:
+          - all
+          - minotari_all
+          - minotari_node
+          - minotari_console_wallet
+          - minotari_merge_mining_proxy
+          - minotari_sha3_miner
+          - 3rdparty_all
+
+env:
+  toolchain_default: stable
+
+concurrency:
+  group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  nightly_builds_envs_setup:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      toolchain: ${{ steps.envs_setup.outputs.toolchain }}
+      platforms: ${{ steps.envs_setup.outputs.platforms }}
+      tag_alias: ${{ steps.envs_setup.outputs.tag_alias }}
+      build_items: ${{ steps.envs_setup.outputs.build_items }}
+
+    steps:
+      - name: envs setup
+        id: envs_setup
+        shell: bash
+        run: |
+          echo "Nightly workflow triggered by ${{ github.actor }} for ${{ github.event_name }}"
+          echo "SHA - ${GITHUB_SHA}"
+          VSHA_SHORT=$(echo ${GITHUB_SHA::7})
+          echo "SHA short - ${VSHA_SHORT}"
+          echo "VSHA_SHORT=${VSHA_SHORT}" >> $GITHUB_ENV
+          TOOLCHAIN=${{ github.event.inputs.toolchain }}
+          echo "toolchain=${TOOLCHAIN:-${{ env.toolchain_default }}}" >> $GITHUB_OUTPUT
+
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ] ; then
+            echo "Manual Nightly Build - selective"
+            echo "platforms=${{ github.event.inputs.platforms }}" >> $GITHUB_OUTPUT
+            echo "build_items=${{ github.event.inputs.build_items }}" >> $GITHUB_OUTPUT
+          else
+            echo "Scheduled Nightly Build"
+            if [[ $(date +%u) -eq 7 ]] ; then
+              echo "Weekly Build - limited dual arch"
+              echo "platforms=linux/arm64, linux/amd64" >> $GITHUB_OUTPUT
+              echo "tag_alias=latest-weekly" >> $GITHUB_OUTPUT
+              echo "build_items=minotari_all" >> $GITHUB_OUTPUT
+            else
+              echo "Daily Build - limited"
+              echo "platforms=linux/amd64" >> $GITHUB_OUTPUT
+              echo "tag_alias=latest-daily" >> $GITHUB_OUTPUT
+              echo "build_items=minotari_all" >> $GITHUB_OUTPUT
+            fi
+          fi
+
+      - name: set matrix
+        id: set-matrix
+        shell: bash
+        run: |
+          # Create matrix for both mainnet and nextnet builds
+          matrix='{
+            "network": [
+              {
+                "name": "mainnet",
+                "tari_target_network": "mainnet",
+                "tari_network": "mainnet",
+                "tari_network_dir": "mainnet"
+              },
+              {
+                "name": "nextnet", 
+                "tari_target_network": "nextnet",
+                "tari_network": "nextnet",
+                "tari_network_dir": "nextnet"
+              }
+            ]
+          }'
+          echo "matrix=${matrix}" >> $GITHUB_OUTPUT
+          echo "Matrix configuration:"
+          echo $matrix | jq .
+
+  nightly_builds_run:
+    needs: nightly_builds_envs_setup
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.nightly_builds_envs_setup.outputs.matrix) }}
+    uses: ./.github/workflows/build_dockers_workflow.yml
+    secrets: inherit
+    with:
+      toolchain: ${{ needs.nightly_builds_envs_setup.outputs.toolchain }}
+      platforms: ${{ needs.nightly_builds_envs_setup.outputs.platforms }}
+      version: nightly_${{ matrix.network.name }}_${{ github.run_number }}_${{ github.sha }}
+      tag_alias: ${{ needs.nightly_builds_envs_setup.outputs.tag_alias }}-${{ matrix.network.name }}
+      build_items: ${{ needs.nightly_builds_envs_setup.outputs.build_items }}
+      tari_network: ${{ matrix.network.tari_network }}
+      tari_target_network: ${{ matrix.network.tari_target_network }}
+      tari_network_dir: ${{ matrix.network.tari_network_dir }}


### PR DESCRIPTION
This pull request introduces significant updates to the GitHub Actions workflows for building Docker images. The changes include the removal of scheduled builds from the `build_dockers.yml` workflow, the addition of new input parameters for network configurations in the `build_dockers_workflow.yml`, and the creation of a dedicated nightly Docker build workflow (`nightly_docker_builds.yml`). These updates aim to streamline the build process and enhance configurability for nightly builds.

### Removal of scheduled builds from `build_dockers.yml`:
* Removed the cron-based scheduled builds and associated logic for daily and weekly builds from the `build_dockers.yml` workflow. This workflow now exclusively supports manual dispatch builds. [[1]](diffhunk://#diff-185e07a1a359a8e6fec4d5e6fee4c16872ff9cc484089b3677a54b1c5c6f29aeL13-L14) [[2]](diffhunk://#diff-185e07a1a359a8e6fec4d5e6fee4c16872ff9cc484089b3677a54b1c5c6f29aeL108-L120)

### Enhancements in `build_dockers_workflow.yml`:
* Added new input parameters (`tari_network`, `tari_target_network`, and `tari_network_dir`) to allow specifying Tari network configurations during workflow execution.
* Introduced logic to set environment variables based on the new inputs, enabling dynamic configuration of network-related settings.

### Creation of `nightly_docker_builds.yml`:
* Added a new workflow dedicated to nightly Docker builds, triggered either by a schedule or manually. This workflow supports selective builds with configurable platforms and build items.
* Implemented matrix-based builds for both `mainnet` and `nextnet` networks, enabling parallel builds with distinct configurations for each network.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new workflow to automate nightly Docker image builds, supporting both scheduled and manual triggers with configurable options.
- **Chores**
  - Removed automatic scheduled builds from the main Docker build workflow; it now only triggers on pushes and manual runs.
  - Added new input parameters for network configuration in the Docker build workflow for greater flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->