### PR TITLE
Wallet GRPC port comment fix from 18142 to 18143

### DIFF
--- a/common/config/presets/d_console_wallet.toml
+++ b/common/config/presets/d_console_wallet.toml
@@ -55,7 +55,7 @@
 # Set to true to enable grpc. (default = false)
 #grpc_enabled = false
 # The socket to expose for the gRPC base node server (default = "http://127.0.0.1:18143")
-#grpc_address = "/ip4/127.0.0.1/tcp/18142"
+#grpc_address = "/ip4/127.0.0.1/tcp/18143"
 # gRPC authentication method (default = "none")
 #grpc_authentication = { username = "admin", password = "xxxx" }
 


### PR DESCRIPTION
Description
---
Fixes wallet GRPC port from 18142 to 18143 in the comment.

Motivation and Context
---
Useful for sed like replacements.

How Has This Been Tested?
---
Comment change should not break anything.

What process can a PR reviewer use to test or verify this change?
---
Check that it is commented line.

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the documentation for the default gRPC base node server port in the wallet configuration to reflect the correct default port (18143).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->