### PR TITLE
fix: fix scanner service when connectivity offline

### DIFF
--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -1232,7 +1232,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
         let mut transactions: Vec<TransactionInfo> = Vec::new();
         for txn in completed_transactions
             .into_iter()
-            .filter(|tx| req.status_bitflag == 0 || (req.status_bitflag & (1 << (tx.status.clone() as u32))) != 0)
+            .filter(|tx| req.status_bitflag == 0 || (req.status_bitflag & (1 << (tx.status as u32))) != 0)
             .skip(offset)
             .take(limit)
         {

--- a/base_layer/wallet/src/utxo_scanner_service/service.rs
+++ b/base_layer/wallet/src/utxo_scanner_service/service.rs
@@ -145,35 +145,19 @@ where
         loop {
             let mut local_shutdown = Shutdown::new();
 
-            // No use to try scanning when we do not have a base node connection, typically at startup
-            if !self.is_base_node_connected() {
-                local_shutdown.trigger();
+            if self
+                .resources
+                .comms_connectivity
+                .get_connectivity_status()
+                .await?
+                .is_offline()
+            {
                 debug!(
                     target: LOG_TARGET,
-                    "{:?}: Base node is not connected - waiting for base node connection.",
+                    "{:?}: Comms connectivity is offline - waiting for connectivity.",
                     self.mode
                 );
-                tokio::select! {
-                    _ = main_shutdown.wait() => {
-                        info!(
-                            target: LOG_TARGET,
-                            "{:?}: UTXO scanning service shutting down because it received the shutdown signal",
-                            self.mode
-                        );
-                        return Ok(());
-                    }
-                    _ = self.resources.current_base_node_watcher.changed() => {
-                        debug!(
-                            target: LOG_TARGET,
-                            "{:?}: Base node change detected waiting for initial connection.",
-                            self.mode
-                        );
-                        let selected_peer =  self.resources.current_base_node_watcher.borrow().as_ref().cloned();
-                        if let Some(peer) = selected_peer {
-                            self.peer_seeds = vec![peer.get_current_peer().public_key];
-                        }
-                    },
-                }
+                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
                 continue;
             }
 
@@ -304,15 +288,6 @@ where
             // Nothing here
         }
         should_trigger_scanning
-    }
-
-    fn is_base_node_connected(&self) -> bool {
-        self.resources
-            .current_base_node_watcher
-            .borrow()
-            .as_ref()
-            .cloned()
-            .is_some()
     }
 }
 

--- a/base_layer/wallet/src/utxo_scanner_service/service.rs
+++ b/base_layer/wallet/src/utxo_scanner_service/service.rs
@@ -145,20 +145,22 @@ where
         loop {
             let mut local_shutdown = Shutdown::new();
 
-            if self
-                .resources
-                .comms_connectivity
-                .get_connectivity_status()
-                .await?
-                .is_offline()
-            {
-                debug!(
-                    target: LOG_TARGET,
-                    "{:?}: Comms connectivity is offline - waiting for connectivity.",
-                    self.mode
-                );
-                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-                continue;
+            match self.resources.comms_connectivity.get_connectivity_status().await {
+                Ok(status) if status.is_offline() => {
+                    debug!(target: LOG_TARGET,
+                     "{:?}: Comms connectivity is offline - waiting for connectivity.",
+                     self.mode);
+                    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                    continue;
+                },
+                Err(e) => {
+                    warn!(target: LOG_TARGET,
+                        "{:?}: Failed to query connectivity status: {} – retrying in 5 s",
+                        self.mode, e);
+                    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                    continue;
+                },
+                _ => {},
             }
 
             // If we have a base node connection, we can spawn a task to scanning UTXOs

--- a/base_layer/wallet/src/utxo_scanner_service/utxo_scanner_task.rs
+++ b/base_layer/wallet/src/utxo_scanner_service/utxo_scanner_task.rs
@@ -90,14 +90,14 @@ where
 {
     pub async fn run(mut self) -> Result<(), UtxoScannerError> {
         if self.mode == UtxoScannerMode::Recovery {
-            self.set_recovery_mode().await?;
+            self.set_recovery_mode()?;
         }
 
         loop {
             if self.shutdown_signal.is_triggered() {
                 return Ok(());
             }
-            if self.check_recovery_mode().await? && self.mode != UtxoScannerMode::Recovery {
+            if self.check_recovery_mode()? && self.mode != UtxoScannerMode::Recovery {
                 warn!(
                     target: LOG_TARGET,
                     "{:?}: Scanning round aborted as a Recovery is in progress", self.mode
@@ -178,7 +178,7 @@ where
 
         if self.mode == UtxoScannerMode::Recovery {
             // Presence of scanning keys are used to determine if a wallet is busy with recovery or not.
-            self.clear_recovery_mode().await?;
+            self.clear_recovery_mode()?;
         }
         Ok(())
     }
@@ -289,7 +289,7 @@ where
             };
 
             if self.shutdown_signal.is_triggered() ||
-                self.check_recovery_mode().await? && self.mode != UtxoScannerMode::Recovery
+                self.check_recovery_mode()? && self.mode != UtxoScannerMode::Recovery
             {
                 if !self.shutdown_signal.is_triggered() {
                     warn!(
@@ -700,14 +700,14 @@ where
         Ok((num_recovered, total_amount))
     }
 
-    async fn set_recovery_mode(&self) -> Result<(), UtxoScannerError> {
+    fn set_recovery_mode(&self) -> Result<(), UtxoScannerError> {
         self.resources
             .db
             .set_client_key_value(RECOVERY_KEY.to_owned(), Utc::now().to_string())?;
         Ok(())
     }
 
-    pub async fn check_recovery_mode(&self) -> Result<bool, UtxoScannerError> {
+    pub fn check_recovery_mode(&self) -> Result<bool, UtxoScannerError> {
         self.resources
             .db
             .get_client_key_from_str::<String>(RECOVERY_KEY.to_owned())
@@ -715,7 +715,7 @@ where
             .map_err(UtxoScannerError::from) // in case if `get_client_key_from_str` returns not exactly that type
     }
 
-    async fn clear_recovery_mode(&self) -> Result<(), UtxoScannerError> {
+    fn clear_recovery_mode(&self) -> Result<(), UtxoScannerError> {
         let _ = self.resources.db.clear_client_value(RECOVERY_KEY.to_owned())?;
         Ok(())
     }

--- a/base_layer/wallet/tests/utxo_scanner/mod.rs
+++ b/base_layer/wallet/tests/utxo_scanner/mod.rs
@@ -49,6 +49,7 @@ use rand::{rngs::OsRng, RngCore};
 use tari_common::configuration::Network;
 use tari_common_types::{chain_metadata, tari_address::TariAddress, types::BlockHash};
 use tari_comms::{
+    connectivity::ConnectivityStatus,
     peer_manager::PeerFeatures,
     protocol::rpc::{mock::MockRpcServer, NamedProtocolService},
     test_utils::{
@@ -138,6 +139,9 @@ async fn setup(
     comms_connectivity_mock_state
         .add_active_connection(rpc_server_connection)
         .await;
+    comms_connectivity_mock_state
+        .set_connectivity_status(ConnectivityStatus::Online(1))
+        .await;
     task::spawn(connectivity_mock.run());
 
     let wallet_connectivity_mock = create_wallet_connectivity_mock();
@@ -205,7 +209,7 @@ async fn setup(
         .build_with_resources::<WalletSqliteDatabase, WalletConnectivityMock, MemoryDbKeyManager>(
             wallet_db.clone(),
             comms_connectivity,
-            wallet_connectivity_mock,
+            wallet_connectivity_mock.clone(),
             oms_handle,
             ts_handle,
             tari_address,
@@ -300,7 +304,7 @@ async fn generate_block_headers_and_utxos(
 
 #[tokio::test]
 async fn test_utxo_scanner_recovery() {
-    // env_logger::init(); // Set `$env:RUST_LOG = "trace"`
+    // env_logger::builder().filter_level(log::LevelFilter::Trace).init();  //  > ./target/output.log 2>&1
     let key_manager = create_memory_db_key_manager().unwrap();
     let mut test_interface = setup(key_manager.clone(), UtxoScannerMode::Recovery, None, None, None).await;
 
@@ -857,6 +861,7 @@ async fn test_utxo_scanner_scanned_block_cache_clearing() {
 #[tokio::test]
 #[allow(clippy::too_many_lines)]
 async fn test_utxo_scanner_one_sided_payments() {
+    // env_logger::builder().filter_level(log::LevelFilter::Trace).init();  //  > ./target/output.log 2>&1
     let key_manager = create_memory_db_key_manager().unwrap();
     let mut test_interface = setup(
         key_manager.clone(),


### PR DESCRIPTION
Description
---
Fixed the scanner service when connectivity is offline - the connectivity status will now be queried to start scanning, instead of relying on a based node change to initiate the process. The logical error was introduced in a recent PR.

Motivation and Context
---
Unit test `async fn test_utxo_scanner_one_sided_payments()` failed due to logic implementation error.

How Has This Been Tested?
---
Unit test `async fn test_utxo_scanner_one_sided_payments()` pass.

What process can a PR reviewer use to test or verify this change?
---
Code review.

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved internal logic for connectivity checks and status handling in the UTXO scanning service.
  - Converted certain recovery mode methods from asynchronous to synchronous for more efficient execution.
  - Simplified transaction status filtering logic for better performance.

- **Tests**
  - Enhanced test setup and logging for better debugging and reliability.

No changes to user-facing features or functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->