### PR TITLE
fix: imported transaction directions

### DIFF
--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -3830,29 +3830,23 @@ where
         {
             (
                 match tx_type {
-                    TxType::PaymentToOther | TxType::Burn => TransactionDirection::Outbound,
-                    TxType::PaymentToSelf |
-                    TxType::CoinSplit |
-                    TxType::CoinJoin |
-                    TxType::ValidatorNodeRegistration |
+                    TxType::PaymentToOther |
+                    TxType::Burn |
                     TxType::CodeTemplateRegistration |
+                    TxType::ValidatorNodeRegistration |
+                    TxType::CoinSplit |
+                    TxType::PaymentToSelf => TransactionDirection::Outbound,
+                    TxType::CoinJoin |
                     TxType::ClaimAtomicSwap |
                     TxType::HtlcAtomicSwapRefund |
                     TxType::ImportedUtxoNoneRewindable |
                     TxType::Coinbase => TransactionDirection::Inbound,
                 },
                 amount,
-                match tx_type {
-                    TxType::PaymentToOther | TxType::ImportedUtxoNoneRewindable => recipient_address.clone(),
-                    TxType::Burn => TariAddress::default(),
-                    TxType::PaymentToSelf |
-                    TxType::CoinSplit |
-                    TxType::CoinJoin |
-                    TxType::ValidatorNodeRegistration |
-                    TxType::CodeTemplateRegistration |
-                    TxType::ClaimAtomicSwap |
-                    TxType::HtlcAtomicSwapRefund |
-                    TxType::Coinbase => self.resources.one_sided_tari_address.clone(),
+                if tx_type == TxType::Burn {
+                    TariAddress::default()
+                } else {
+                    recipient_address.clone()
                 },
             )
         } else {


### PR DESCRIPTION
Description
---
Fix imported transactions. 

Doing a spend to self will result in two inbound transactions for the same amount, they need to be one out and 1 in

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved accuracy in determining transaction direction and destination address for various transaction types, ensuring correct categorization and display in transaction histories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->