### PR TITLE
feat: add gprc methods to get fees

### DIFF
--- a/applications/minotari_app_grpc/proto/wallet.proto
+++ b/applications/minotari_app_grpc/proto/wallet.proto
@@ -1134,6 +1134,10 @@ service Wallet {
   // }
   // ```
   rpc GetPaymentByReference(GetPaymentByReferenceRequest) returns (GetPaymentByReferenceResponse);
+
+  rpc GetFeeEstimate(GetFeeEstimateRequest) returns (GetFeeEstimateResponse);
+
+  rpc GetFeePerGramStats(GetFeePerGramStatsRequest) returns (GetFeePerGramStatsResponse);
 }
 
 
@@ -1483,7 +1487,8 @@ message TransactionEvent {
   string status = 5;
   string direction = 6;
   uint64 amount = 7;
-  bytes payment_id = 9;
+  bytes raw_payment_id = 9;
+  bytes user_payment_id = 10;
 }
 
 message TransactionEventResponse {
@@ -1579,4 +1584,36 @@ enum PaymentDirection {
   PAYMENT_DIRECTION_INBOUND = 1;
   // Payment sent from this wallet
   PAYMENT_DIRECTION_OUTBOUND = 2;
+}
+
+message GetFeeEstimateRequest {
+  // The amount to send in microTari (1 T = 1_000_000 µT).
+  uint64 amount = 1;
+  // fee per gram to use for the estimate
+  uint64 fee_per_gram = 2;
+  // number of outputs to create in the transaction
+  uint64 output_count = 3;
+}
+
+message GetFeeEstimateResponse {
+  // Estimated fee for the transaction in microTari
+  uint64 estimated_fee = 1;
+}
+
+message GetFeePerGramStatsRequest {
+  // Optional: The number of recent blocks to consider for fee statistics.
+  uint64 block_count = 1;
+}
+
+message GetFeePerGramStatsResponse {
+  repeated FeePerGramStat fee_per_gram_stats = 1;
+}
+
+message FeePerGramStat {
+  // The average fee per gram over the specified number of blocks.
+  uint64 average_fee_per_gram = 1;
+  // The minimum fee per gram observed in the recent blocks.
+  uint64 min_fee_per_gram = 2;
+  // The maximum fee per gram observed in the recent blocks.
+  uint64 max_fee_per_gram = 3;
 }

--- a/applications/minotari_console_wallet/src/grpc/mod.rs
+++ b/applications/minotari_console_wallet/src/grpc/mod.rs
@@ -40,8 +40,8 @@ pub fn convert_to_transaction_event(event: String, source: TransactionWrapper) -
             status: outbound.status.to_string(),
             direction: "outbound".to_string(),
             amount: outbound.amount.as_u64(),
-            raw_payment_id: vec![],
-            user_payment_id: vec![],
+            raw_payment_id: outbound.payment_id.to_bytes(),
+            user_payment_id: outbound.payment_id.user_data_as_bytes(),
         },
         TransactionWrapper::Inbound(inbound) => TransactionEvent {
             event,
@@ -51,8 +51,8 @@ pub fn convert_to_transaction_event(event: String, source: TransactionWrapper) -
             status: inbound.status.to_string(),
             direction: "inbound".to_string(),
             amount: inbound.amount.as_u64(),
-            raw_payment_id: vec![],
-            user_payment_id: vec![],
+            raw_payment_id: inbound.payment_id.to_bytes(),
+            user_payment_id: inbound.payment_id.user_data_as_bytes(),
         },
     }
 }

--- a/applications/minotari_console_wallet/src/grpc/mod.rs
+++ b/applications/minotari_console_wallet/src/grpc/mod.rs
@@ -29,7 +29,8 @@ pub fn convert_to_transaction_event(event: String, source: TransactionWrapper) -
             status: completed.status.to_string(),
             direction: completed.direction.to_string(),
             amount: completed.amount.as_u64(),
-            payment_id: completed.payment_id.to_bytes(),
+            raw_payment_id: completed.payment_id.to_bytes(),
+            user_payment_id: completed.payment_id.user_data_as_bytes(),
         },
         TransactionWrapper::Outbound(outbound) => TransactionEvent {
             event,
@@ -39,7 +40,8 @@ pub fn convert_to_transaction_event(event: String, source: TransactionWrapper) -
             status: outbound.status.to_string(),
             direction: "outbound".to_string(),
             amount: outbound.amount.as_u64(),
-            payment_id: vec![],
+            raw_payment_id: vec![],
+            user_payment_id: vec![],
         },
         TransactionWrapper::Inbound(inbound) => TransactionEvent {
             event,
@@ -49,7 +51,8 @@ pub fn convert_to_transaction_event(event: String, source: TransactionWrapper) -
             status: inbound.status.to_string(),
             direction: "inbound".to_string(),
             amount: inbound.amount.as_u64(),
-            payment_id: vec![],
+            raw_payment_id: vec![],
+            user_payment_id: vec![],
         },
     }
 }

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -1892,7 +1892,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
                 amount.into(),
                 selection_criteria,
                 fee_per_gram.into(),
-                1, // We assume 1 input for simplicity
+                1, // We assume 1 kernel for simplicity
                 output_count,
             )
             .await

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -48,6 +48,7 @@ use minotari_app_grpc::tari_rpc::{
     CreateBurnTransactionResponse,
     CreateTemplateRegistrationRequest,
     CreateTemplateRegistrationResponse,
+    FeePerGramStat,
     GetAddressResponse,
     GetAllCompletedTransactionsRequest,
     GetAllCompletedTransactionsResponse,
@@ -59,6 +60,10 @@ use minotari_app_grpc::tari_rpc::{
     GetCompletedTransactionsRequest,
     GetCompletedTransactionsResponse,
     GetConnectivityRequest,
+    GetFeeEstimateRequest,
+    GetFeeEstimateResponse,
+    GetFeePerGramStatsRequest,
+    GetFeePerGramStatsResponse,
     GetIdentityRequest,
     GetIdentityResponse,
     GetPaymentByReferenceRequest,
@@ -1864,6 +1869,70 @@ impl wallet_server::Wallet for WalletGrpcServer {
             },
         }
     }
+
+    async fn get_fee_estimate(
+        &self,
+        request: Request<GetFeeEstimateRequest>,
+    ) -> Result<Response<GetFeeEstimateResponse>, Status> {
+        let message = request.into_inner();
+        debug!(
+            target: LOG_TARGET,
+            "get_fee_estimation: Incoming GRPC request with fee_per_gram: {}",
+            message.fee_per_gram
+        );
+
+        let mut oms = self.get_output_manager_service();
+        let fee_per_gram = message.fee_per_gram;
+        let amount = message.amount;
+        let output_count = usize::try_from(message.output_count)
+            .map_err(|_| Status::internal("Count not convert u64 to usize".to_string()))?;
+        let selection_criteria = UtxoSelectionCriteria::default();
+        let fee = oms
+            .fee_estimate(
+                amount.into(),
+                selection_criteria,
+                fee_per_gram.into(),
+                1, // We assume 1 input for simplicity
+                output_count,
+            )
+            .await
+            .map_err(|e| Status::internal(e.to_string()))?;
+
+        Ok(Response::new(GetFeeEstimateResponse {
+            estimated_fee: fee.as_u64(),
+        }))
+    }
+
+    async fn get_fee_per_gram_stats(
+        &self,
+        request: Request<GetFeePerGramStatsRequest>,
+    ) -> Result<Response<GetFeePerGramStatsResponse>, Status> {
+        let message = request.into_inner();
+        debug!(
+            target: LOG_TARGET,
+            "get_fee_per_gram_stats: Incoming GRPC request with count: {}",
+            message.block_count
+        );
+        let block_count = usize::try_from(message.block_count)
+            .map_err(|_| Status::internal("Count not convert u64 to usize".to_string()))?;
+
+        let mut transaction_service = self.get_transaction_service();
+        let stats = transaction_service
+            .get_fee_per_gram_stats_per_block(block_count)
+            .await
+            .map_err(|e| Status::internal(e.to_string()))?;
+        let mut fee_stats = Vec::new();
+        for stat in stats.stats {
+            fee_stats.push(FeePerGramStat {
+                average_fee_per_gram: stat.avg_fee_per_gram.as_u64(),
+                min_fee_per_gram: stat.min_fee_per_gram.as_u64(),
+                max_fee_per_gram: stat.max_fee_per_gram.as_u64(),
+            });
+        }
+        Ok(Response::new(GetFeePerGramStatsResponse {
+            fee_per_gram_stats: fee_stats,
+        }))
+    }
 }
 
 async fn handle_completed_tx(
@@ -1913,7 +1982,8 @@ fn simple_event(event: &str) -> TransactionEvent {
         status: event.to_string(),
         direction: event.to_string(),
         amount: 0,
-        payment_id: vec![],
+        raw_payment_id: vec![],
+        user_payment_id: vec![],
     }
 }
 


### PR DESCRIPTION
Description
---
Add grpc methods to get fee estimates for tx and mempool
Add user_payment_id to the transaction events

Fixes: #7093 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to estimate transaction fees based on amount, fee per gram, and output count.
  - Introduced a new feature to retrieve fee per gram statistics over recent blocks, including average, minimum, and maximum values.

- **Enhancements**
  - Improved transaction event details by distinguishing between raw and user-specific payment identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->