### PR TITLE
feat: limit txs searches

### DIFF
--- a/applications/minotari_console_wallet/src/automation/commands.rs
+++ b/applications/minotari_console_wallet/src/automation/commands.rs
@@ -2793,7 +2793,10 @@ pub async fn command_runner(
             ListTx => {
                 debug!(target: LOG_TARGET, "payref_debug: List all transactions command starting execution");
 
-                match transaction_service.get_completed_transactions(None, None, None).await {
+                match transaction_service
+                    .get_completed_transactions(None, None, None, 0)
+                    .await
+                {
                     Ok(txs) => {
                         debug!(target: LOG_TARGET, "ListTxs command got {} transactions", txs.len());
 

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -1100,7 +1100,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
 
         let mut transaction_service = self.get_transaction_service();
         let transactions = transaction_service
-            .get_completed_transactions(payment_id, block_hash, block_height)
+            .get_completed_transactions(payment_id, block_hash, block_height, 0)
             .await
             .map_err(|err| Status::not_found(format!("No completed transactions found: {:?}", err)))?;
         debug!(
@@ -1206,6 +1206,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
         request: Request<GetAllCompletedTransactionsRequest>,
     ) -> Result<Response<GetAllCompletedTransactionsResponse>, Status> {
         let start = std::time::Instant::now();
+        let req = request.into_inner();
         trace!(
             target: LOG_TARGET,
             "GetAllCompletedTransactions: Incoming GRPC request"
@@ -1213,7 +1214,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
         let mut transaction_service = self.get_transaction_service();
 
         let mut completed_transactions = transaction_service
-            .get_completed_transactions(None, None, None)
+            .get_completed_transactions(None, None, None, req.limit)
             .await
             .map_err(|err| {
                 Status::not_found(format!(
@@ -1223,7 +1224,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
             })?;
         completed_transactions.extend(
             transaction_service
-                .get_cancelled_completed_transactions()
+                .get_cancelled_completed_transactions(req.limit)
                 .await
                 .map_err(|err| {
                     Status::not_found(format!(
@@ -1239,7 +1240,6 @@ impl wallet_server::Wallet for WalletGrpcServer {
                 .expect("Should be able to compare timestamps")
         });
 
-        let req = request.into_inner();
         let offset = usize::try_from(req.offset).unwrap_or(0);
         let limit = if req.limit > 0 {
             usize::try_from(req.limit).unwrap_or(usize::MAX)
@@ -1331,7 +1331,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
 
         let mut transaction_service = self.get_transaction_service();
         let transactions = transaction_service
-            .get_completed_transactions(None, None, Some(block_height))
+            .get_completed_transactions(None, None, Some(block_height), 0)
             .await
             .map_err(|err| {
                 Status::not_found(format!(

--- a/applications/minotari_console_wallet/src/ui/state/app_state.rs
+++ b/applications/minotari_console_wallet/src/ui/state/app_state.rs
@@ -754,14 +754,14 @@ impl AppStateInner {
         completed_transactions.extend(
             self.wallet
                 .transaction_service
-                .get_completed_transactions(None, None, None)
+                .get_completed_transactions(None, None, None, 100)
                 .await?,
         );
 
         completed_transactions.extend(
             self.wallet
                 .transaction_service
-                .get_cancelled_completed_transactions()
+                .get_cancelled_completed_transactions(100)
                 .await?,
         );
         completed_transactions.sort_by(|a, b| {

--- a/applications/minotari_console_wallet/src/ui/state/app_state.rs
+++ b/applications/minotari_console_wallet/src/ui/state/app_state.rs
@@ -754,7 +754,7 @@ impl AppStateInner {
         completed_transactions.extend(
             self.wallet
                 .transaction_service
-                .get_completed_transactions(None, None, None, 100)
+                .get_completed_transactions(None, None, None, 500)
                 .await?,
         );
 

--- a/base_layer/wallet/src/transaction_service/handle.rs
+++ b/base_layer/wallet/src/transaction_service/handle.rs
@@ -83,6 +83,7 @@ pub enum TransactionServiceRequest {
         payment_id: Option<Vec<u8>>,
         block_hash: Option<FixedHash>,
         block_height: Option<u64>,
+        max_limit: u64,
     },
     GetCompletedTransactionsByAddresses {
         source_address: Option<TariAddress>,
@@ -90,7 +91,7 @@ pub enum TransactionServiceRequest {
     },
     GetCancelledPendingInboundTransactions,
     GetCancelledPendingOutboundTransactions,
-    GetCancelledCompletedTransactions,
+    GetCancelledCompletedTransactions(u64),
     GetCompletedTransaction(TxId),
     GetAnyTransaction(TxId),
     ImportTransaction(WalletTransaction),
@@ -226,7 +227,7 @@ impl fmt::Display for TransactionServiceRequest {
             Self::ImportTransaction(tx) => write!(f, "ImportTransaction: {:?}", tx),
             Self::GetCancelledPendingInboundTransactions => write!(f, "GetCancelledPendingInboundTransactions"),
             Self::GetCancelledPendingOutboundTransactions => write!(f, "GetCancelledPendingOutboundTransactions"),
-            Self::GetCancelledCompletedTransactions => write!(f, "GetCancelledCompletedTransactions"),
+            Self::GetCancelledCompletedTransactions(_) => write!(f, "GetCancelledCompletedTransactions"),
             Self::GetCompletedTransaction(t) => write!(f, "GetCompletedTransaction({})", t),
             Self::ScrapeWallet {
                 destination,
@@ -1007,6 +1008,7 @@ impl TransactionServiceHandle {
         payment_id: Option<Vec<u8>>,
         block_hash: Option<FixedHash>,
         block_height: Option<u64>,
+        max_limit: u64,
     ) -> Result<Vec<CompletedTransaction>, TransactionServiceError> {
         match self
             .handle
@@ -1014,6 +1016,7 @@ impl TransactionServiceHandle {
                 payment_id,
                 block_hash,
                 block_height,
+                max_limit,
             })
             .await??
         {
@@ -1042,10 +1045,11 @@ impl TransactionServiceHandle {
 
     pub async fn get_cancelled_completed_transactions(
         &mut self,
+        max_limit: u64,
     ) -> Result<Vec<CompletedTransaction>, TransactionServiceError> {
         match self
             .handle
-            .call(TransactionServiceRequest::GetCancelledCompletedTransactions)
+            .call(TransactionServiceRequest::GetCancelledCompletedTransactions(max_limit))
             .await??
         {
             TransactionServiceResponse::CompletedTransactions(c) => Ok(c),

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -898,9 +898,10 @@ where
                 payment_id,
                 block_hash,
                 block_height,
+                max_limit,
             } => Ok(TransactionServiceResponse::CompletedTransactions(
                 self.db
-                    .get_completed_transactions(payment_id, block_hash, block_height)?,
+                    .get_completed_transactions(payment_id, block_hash, block_height, max_limit)?,
             )),
             TransactionServiceRequest::GetCompletedTransactionsByAddresses {
                 source_address,
@@ -919,9 +920,11 @@ where
                     self.db.get_cancelled_pending_outbound_transactions()?,
                 ))
             },
-            TransactionServiceRequest::GetCancelledCompletedTransactions => Ok(
-                TransactionServiceResponse::CompletedTransactions(self.db.get_cancelled_completed_transactions()?),
-            ),
+            TransactionServiceRequest::GetCancelledCompletedTransactions(max_limit) => {
+                Ok(TransactionServiceResponse::CompletedTransactions(
+                    self.db.get_cancelled_completed_transactions(max_limit)?,
+                ))
+            },
             TransactionServiceRequest::GetCompletedTransaction(tx_id) => Ok(
                 TransactionServiceResponse::CompletedTransaction(Box::new(self.db.get_completed_transaction(tx_id)?)),
             ),
@@ -1028,7 +1031,7 @@ where
                 match self.get_transaction_with_payref(payref)? {
                     Some(tx) => Ok(TransactionServiceResponse::CompletedTransaction(Box::new(tx))),
                     None => Err(TransactionServiceError::TransactionStorageError(
-                        TransactionStorageError::ValueNotFound(DbKey::CompletedTransactions),
+                        TransactionStorageError::ValueNotFound(DbKey::CompletedTransactions(1)),
                     ))?,
                 }
             },

--- a/base_layer/wallet/src/transaction_service/storage/database.rs
+++ b/base_layer/wallet/src/transaction_service/storage/database.rs
@@ -162,6 +162,7 @@ pub trait TransactionBackend: Send + Sync + Clone {
         payment_id: Option<Vec<u8>>,
         block_hash: Option<FixedHash>,
         block_height: Option<u64>,
+        max_limit: u64,
     ) -> Result<Vec<CompletedTransaction>, TransactionStorageError>;
     fn find_completed_transactions_filter_addresses(
         &self,
@@ -181,10 +182,10 @@ pub enum DbKey {
     CompletedTransaction(TxId),
     PendingOutboundTransactions,
     PendingInboundTransactions,
-    CompletedTransactions,
+    CompletedTransactions(u64),
     CancelledPendingOutboundTransactions,
     CancelledPendingInboundTransactions,
-    CancelledCompletedTransactions,
+    CancelledCompletedTransactions(u64),
     CancelledPendingOutboundTransaction(TxId),
     CancelledPendingInboundTransaction(TxId),
     AnyTransaction(TxId),
@@ -221,7 +222,7 @@ impl fmt::Debug for DbKey {
             PendingInboundTransactions => {
                 write!(f, "PendingInboundTransactions")
             },
-            CompletedTransactions => {
+            CompletedTransactions(_) => {
                 write!(f, "CompletedTransactions ")
             },
             CancelledPendingOutboundTransactions => {
@@ -230,7 +231,7 @@ impl fmt::Debug for DbKey {
             CancelledPendingInboundTransactions => {
                 write!(f, "CancelledPendingInboundTransactions")
             },
-            CancelledCompletedTransactions => {
+            CancelledCompletedTransactions(_) => {
                 write!(f, "CancelledCompletedTransactions")
             },
             CancelledPendingOutboundTransaction(tx_id) => {
@@ -499,10 +500,14 @@ where T: TransactionBackend + 'static
         payment_id: Option<Vec<u8>>,
         block_hash: Option<FixedHash>,
         block_height: Option<u64>,
+        max_limit: u64,
     ) -> Result<Vec<CompletedTransaction>, TransactionStorageError> {
-        let t =
-            self.db
-                .find_completed_transactions_filter_payment_id_block_hash(payment_id, block_hash, block_height)?;
+        let t = self.db.find_completed_transactions_filter_payment_id_block_hash(
+            payment_id,
+            block_hash,
+            block_height,
+            max_limit,
+        )?;
         Ok(t)
     }
 
@@ -617,8 +622,9 @@ where T: TransactionBackend + 'static
         payment_id: Option<Vec<u8>>,
         block_hash: Option<FixedHash>,
         block_height: Option<u64>,
+        max_limit: u64,
     ) -> Result<Vec<CompletedTransaction>, TransactionStorageError> {
-        self.get_completed_transactions_by_cancelled(payment_id, false, block_hash, block_height)
+        self.get_completed_transactions_by_cancelled(payment_id, false, block_hash, block_height, max_limit)
     }
 
     pub fn get_completed_transactions_by_addresses(
@@ -630,8 +636,11 @@ where T: TransactionBackend + 'static
             .find_completed_transactions_filter_addresses(source_address, destination_address)
     }
 
-    pub fn get_cancelled_completed_transactions(&self) -> Result<Vec<CompletedTransaction>, TransactionStorageError> {
-        self.get_completed_transactions_by_cancelled(None, true, None, None)
+    pub fn get_cancelled_completed_transactions(
+        &self,
+        max_limit: u64,
+    ) -> Result<Vec<CompletedTransaction>, TransactionStorageError> {
+        self.get_completed_transactions_by_cancelled(None, true, None, None, max_limit)
     }
 
     pub fn get_any_transaction(&self, tx_id: TxId) -> Result<Option<WalletTransaction>, TransactionStorageError> {
@@ -659,11 +668,12 @@ where T: TransactionBackend + 'static
         cancelled: bool,
         block_hash: Option<FixedHash>,
         block_height: Option<u64>,
+        max_limit: u64,
     ) -> Result<Vec<CompletedTransaction>, TransactionStorageError> {
         let key = if cancelled {
-            DbKey::CancelledCompletedTransactions
+            DbKey::CancelledCompletedTransactions(max_limit)
         } else {
-            DbKey::CompletedTransactions
+            DbKey::CompletedTransactions(max_limit)
         };
         match (payment_id.is_none(), block_hash.is_none(), block_height.is_none()) {
             (true, true, true) => {
@@ -680,10 +690,12 @@ where T: TransactionBackend + 'static
                 }?;
                 Ok(t)
             },
-            (_, _, _) => {
-                self.db
-                    .find_completed_transactions_filter_payment_id_block_hash(payment_id, block_hash, block_height)
-            },
+            (_, _, _) => self.db.find_completed_transactions_filter_payment_id_block_hash(
+                payment_id,
+                block_hash,
+                block_height,
+                max_limit,
+            ),
         }
     }
 
@@ -843,10 +855,10 @@ impl Display for DbKey {
             DbKey::CompletedTransaction(_) => f.write_str("Completed Transaction"),
             DbKey::PendingOutboundTransactions => f.write_str("All Pending Outbound Transactions"),
             DbKey::PendingInboundTransactions => f.write_str("All Pending Inbound Transactions"),
-            DbKey::CompletedTransactions => f.write_str("All Complete Transactions"),
+            DbKey::CompletedTransactions(_) => f.write_str("All Complete Transactions"),
             DbKey::CancelledPendingOutboundTransactions => f.write_str("All Cancelled Pending Inbound Transactions"),
             DbKey::CancelledPendingInboundTransactions => f.write_str("All Cancelled Pending Outbound Transactions"),
-            DbKey::CancelledCompletedTransactions => f.write_str("All Cancelled Complete Transactions"),
+            DbKey::CancelledCompletedTransactions(_) => f.write_str("All Cancelled Complete Transactions"),
             DbKey::CancelledPendingOutboundTransaction(_) => f.write_str("Cancelled Pending Outbound Transaction"),
             DbKey::CancelledPendingInboundTransaction(_) => f.write_str("Cancelled Pending Inbound Transaction"),
             DbKey::AnyTransaction(_) => f.write_str("Any Transaction"),

--- a/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
@@ -2896,7 +2896,7 @@ mod test {
             .commit(&mut conn)
             .unwrap();
 
-        let completed_txs = CompletedTransactionSql::index_by_cancelled(&mut conn, false).unwrap();
+        let completed_txs = CompletedTransactionSql::index_by_cancelled(&mut conn, false, 0).unwrap();
         assert_eq!(completed_txs.len(), 2);
 
         let returned_completed_tx = CompletedTransaction::try_from(
@@ -3283,7 +3283,7 @@ mod test {
 
         assert!(db2.fetch(&DbKey::PendingInboundTransactions).is_ok());
         assert!(db2.fetch(&DbKey::PendingOutboundTransactions).is_ok());
-        assert!(db2.fetch(&DbKey::CompletedTransactions).is_ok());
+        assert!(db2.fetch(&DbKey::CompletedTransactions(0)).is_ok());
 
         let mut key = [0u8; size_of::<Key>()];
         OsRng.fill_bytes(&mut key);
@@ -3293,7 +3293,7 @@ mod test {
         let db3 = TransactionServiceSqliteDatabase::new(connection, new_cipher);
         assert!(db3.fetch(&DbKey::PendingInboundTransactions).is_err());
         assert!(db3.fetch(&DbKey::PendingOutboundTransactions).is_err());
-        assert!(db3.fetch(&DbKey::CompletedTransactions).is_err());
+        assert!(db3.fetch(&DbKey::CompletedTransactions(0)).is_err());
     }
 
     #[test]

--- a/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
@@ -177,10 +177,10 @@ impl TransactionServiceSqliteDatabase {
             },
             DbKey::PendingOutboundTransactions => Err(TransactionStorageError::OperationNotSupported),
             DbKey::PendingInboundTransactions => Err(TransactionStorageError::OperationNotSupported),
-            DbKey::CompletedTransactions => Err(TransactionStorageError::OperationNotSupported),
+            DbKey::CompletedTransactions(_) => Err(TransactionStorageError::OperationNotSupported),
             DbKey::CancelledPendingOutboundTransactions => Err(TransactionStorageError::OperationNotSupported),
             DbKey::CancelledPendingInboundTransactions => Err(TransactionStorageError::OperationNotSupported),
-            DbKey::CancelledCompletedTransactions => Err(TransactionStorageError::OperationNotSupported),
+            DbKey::CancelledCompletedTransactions(_) => Err(TransactionStorageError::OperationNotSupported),
             DbKey::CancelledPendingOutboundTransaction(k) => {
                 conn.transaction::<_, _, _>(|conn| match OutboundTransactionSql::find_by_cancelled(k, true, conn) {
                     Ok(v) => {
@@ -294,9 +294,9 @@ impl TransactionBackend for TransactionServiceSqliteDatabase {
 
                 Some(DbValue::PendingInboundTransactions(result))
             },
-            DbKey::CompletedTransactions => {
+            DbKey::CompletedTransactions(max_limit) => {
                 let mut result = Vec::new();
-                for c in CompletedTransactionSql::index_by_cancelled(&mut conn, false)? {
+                for c in CompletedTransactionSql::index_by_cancelled(&mut conn, false, *max_limit)? {
                     result.push(CompletedTransaction::try_from((c).clone(), &cipher)?);
                 }
 
@@ -318,9 +318,9 @@ impl TransactionBackend for TransactionServiceSqliteDatabase {
 
                 Some(DbValue::PendingInboundTransactions(result))
             },
-            DbKey::CancelledCompletedTransactions => {
+            DbKey::CancelledCompletedTransactions(max_limit) => {
                 let mut result = Vec::new();
-                for c in CompletedTransactionSql::index_by_cancelled(&mut conn, true)? {
+                for c in CompletedTransactionSql::index_by_cancelled(&mut conn, true, *max_limit)? {
                     result.push(CompletedTransaction::try_from((c).clone(), &cipher)?);
                 }
 
@@ -374,10 +374,10 @@ impl TransactionBackend for TransactionServiceSqliteDatabase {
             DbKey::CompletedTransaction(k) => CompletedTransactionSql::find(*k, &mut conn).is_ok(),
             DbKey::PendingOutboundTransactions => false,
             DbKey::PendingInboundTransactions => false,
-            DbKey::CompletedTransactions => false,
+            DbKey::CompletedTransactions(_) => false,
             DbKey::CancelledPendingOutboundTransactions => false,
             DbKey::CancelledPendingInboundTransactions => false,
-            DbKey::CancelledCompletedTransactions => false,
+            DbKey::CancelledCompletedTransactions(_) => false,
             DbKey::CancelledPendingOutboundTransaction(k) => {
                 OutboundTransactionSql::find_by_cancelled(*k, true, &mut conn).is_ok()
             },
@@ -1144,7 +1144,9 @@ impl TransactionBackend for TransactionServiceSqliteDatabase {
         payment_id: Option<Vec<u8>>,
         block_hash: Option<FixedHash>,
         block_height: Option<u64>,
+        max_limit: u64,
     ) -> Result<Vec<CompletedTransaction>, TransactionStorageError> {
+        let limit = if max_limit == 0 { i64::MAX } else { max_limit as i64 };
         let mut conn = self.database_connection.get_pooled_connection()?;
         let cipher = acquire_read_lock!(self.cipher);
 
@@ -1160,6 +1162,7 @@ impl TransactionBackend for TransactionServiceSqliteDatabase {
         }
 
         query
+            .limit(limit)
             .load::<CompletedTransactionSql>(&mut conn)?
             .into_iter()
             .map(|ct: CompletedTransactionSql| {
@@ -1866,7 +1869,9 @@ impl CompletedTransactionSql {
     pub fn index_by_cancelled(
         conn: &mut SqliteConnection,
         cancelled: bool,
+        max_limit: u64,
     ) -> Result<Vec<CompletedTransactionSql>, TransactionStorageError> {
+        let max_limit_i64 = if max_limit == 0 { i64::MAX } else { max_limit as i64 };
         let mut query = completed_transactions::table.into_boxed();
 
         query = if cancelled {
@@ -1877,6 +1882,7 @@ impl CompletedTransactionSql {
 
         Ok(query
             .order_by(completed_transactions::mined_timestamp.desc())
+            .limit(max_limit_i64)
             .load::<CompletedTransactionSql>(conn)?)
     }
 

--- a/base_layer/wallet/tests/transaction_service_tests/service.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/service.rs
@@ -2283,7 +2283,7 @@ async fn manage_multiple_transactions() {
         )
         .await
         .unwrap();
-    let alice_completed_tx = alice_ts.get_completed_transactions(None, None, None).await.unwrap();
+    let alice_completed_tx = alice_ts.get_completed_transactions(None, None, None, 0).await.unwrap();
     assert_eq!(alice_completed_tx.len(), 0);
     log::trace!("A to C 1 TxID: {}", tx_id_a_to_c_1);
 
@@ -2388,16 +2388,16 @@ async fn manage_multiple_transactions() {
     assert_eq!(finalized, 1);
 
     let alice_pending_outbound = alice_ts.get_pending_outbound_transactions().await.unwrap();
-    let alice_completed_tx = alice_ts.get_completed_transactions(None, None, None).await.unwrap();
+    let alice_completed_tx = alice_ts.get_completed_transactions(None, None, None, 0).await.unwrap();
     assert_eq!(alice_pending_outbound.len(), 0);
     assert_eq!(alice_completed_tx.len(), 4, "Not enough transactions for Alice");
     let bob_pending_outbound = bob_ts.get_pending_outbound_transactions().await.unwrap();
-    let bob_completed_tx = bob_ts.get_completed_transactions(None, None, None).await.unwrap();
+    let bob_completed_tx = bob_ts.get_completed_transactions(None, None, None, 0).await.unwrap();
     assert_eq!(bob_pending_outbound.len(), 0);
     assert_eq!(bob_completed_tx.len(), 3, "Not enough transactions for Bob");
 
     let carol_pending_inbound = carol_ts.get_pending_inbound_transactions().await.unwrap();
-    let carol_completed_tx = carol_ts.get_completed_transactions(None, None, None).await.unwrap();
+    let carol_completed_tx = carol_ts.get_completed_transactions(None, None, None, 0).await.unwrap();
     assert_eq!(carol_pending_inbound.len(), 0);
     assert_eq!(carol_completed_tx.len(), 1);
 
@@ -5578,7 +5578,7 @@ async fn transaction_service_tx_broadcast() {
 
     let alice_completed_txs = alice_ts_interface
         .transaction_service_handle
-        .get_completed_transactions(None, None, None)
+        .get_completed_transactions(None, None, None, 0)
         .await
         .unwrap();
     let alice_completed_tx1 = alice_completed_txs
@@ -5686,7 +5686,7 @@ async fn transaction_service_tx_broadcast() {
 
     let alice_completed_txs = alice_ts_interface
         .transaction_service_handle
-        .get_completed_transactions(None, None, None)
+        .get_completed_transactions(None, None, None, 0)
         .await
         .unwrap();
     let alice_completed_tx2 = alice_completed_txs
@@ -6360,7 +6360,7 @@ async fn test_completed_transactions_ordering() {
 
     let alice_completed_transactions = alice_ts_interface
         .transaction_service_handle
-        .get_completed_transactions(None, None, None)
+        .get_completed_transactions(None, None, None, 0)
         .await
         .unwrap();
 

--- a/base_layer/wallet/tests/transaction_service_tests/storage.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/storage.rs
@@ -363,7 +363,7 @@ pub async fn test_db_backend<T: TransactionBackend + 'static>(backend: T) {
         .unwrap();
     }
 
-    let retrieved_completed_txs = db.get_completed_transactions(None, None, None).unwrap();
+    let retrieved_completed_txs = db.get_completed_transactions(None, None, None, 0).unwrap();
     assert_eq!(retrieved_completed_txs.len(), 2 * messages.len());
 
     for i in 0..messages.len() {
@@ -421,21 +421,21 @@ pub async fn test_db_backend<T: TransactionBackend + 'static>(backend: T) {
         panic!("Should have found completed tx");
     }
 
-    let completed_txs = db.get_completed_transactions(None, None, None).unwrap();
+    let completed_txs = db.get_completed_transactions(None, None, None, 0).unwrap();
     let num_completed_txs = completed_txs.len();
-    assert_eq!(db.get_cancelled_completed_transactions().unwrap().len(), 0);
+    assert_eq!(db.get_cancelled_completed_transactions(0).unwrap().len(), 0);
 
     let cancelled_tx_id = completed_txs[1].tx_id;
     assert!(db.get_cancelled_completed_transaction(cancelled_tx_id).is_err());
     db.reject_completed_transaction(cancelled_tx_id, TxCancellationReason::Unknown)
         .unwrap();
-    let completed_txs = db.get_completed_transactions(None, None, None).unwrap();
+    let completed_txs = db.get_completed_transactions(None, None, None, 0).unwrap();
     assert_eq!(completed_txs.len(), num_completed_txs - 1);
 
     db.get_cancelled_completed_transaction(cancelled_tx_id)
         .expect("Should find cancelled transaction");
 
-    let cancelled_txs = db.get_cancelled_completed_transactions().unwrap();
+    let cancelled_txs = db.get_cancelled_completed_transactions(0).unwrap();
     assert_eq!(cancelled_txs.len(), 1);
     assert!(cancelled_txs.iter().any(|c_tx| c_tx.tx_id == cancelled_tx_id));
 

--- a/base_layer/wallet/tests/transaction_service_tests/transaction_protocols.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/transaction_protocols.rs
@@ -856,7 +856,7 @@ async fn tx_validation_protocol_tx_becomes_mined_unconfirmed_then_confirmed() {
     let result = join_handle.await.unwrap();
     assert!(result.is_ok());
 
-    let completed_txs = resources.db.get_completed_transactions(None, None, None).unwrap();
+    let completed_txs = resources.db.get_completed_transactions(None, None, None, 0).unwrap();
 
     assert_eq!(
         completed_txs
@@ -892,7 +892,7 @@ async fn tx_validation_protocol_tx_becomes_mined_unconfirmed_then_confirmed() {
     let result = join_handle.await.unwrap();
     assert!(result.is_ok());
 
-    let completed_txs = resources.db.get_completed_transactions(None, None, None).unwrap();
+    let completed_txs = resources.db.get_completed_transactions(None, None, None, 0).unwrap();
 
     assert_eq!(
         completed_txs
@@ -946,7 +946,7 @@ async fn tx_validation_protocol_tx_becomes_mined_unconfirmed_then_confirmed() {
     let result = join_handle.await.unwrap();
     assert!(result.is_ok());
 
-    let completed_txs = resources.db.get_completed_transactions(None, None, None).unwrap();
+    let completed_txs = resources.db.get_completed_transactions(None, None, None, 0).unwrap();
 
     assert_eq!(
         completed_txs
@@ -1040,7 +1040,7 @@ async fn tx_revalidation() {
     let result = join_handle.await.unwrap();
     assert!(result.is_ok());
 
-    let completed_txs = resources.db.get_completed_transactions(None, None, None).unwrap();
+    let completed_txs = resources.db.get_completed_transactions(None, None, None, 0).unwrap();
 
     assert_eq!(
         completed_txs
@@ -1085,7 +1085,7 @@ async fn tx_revalidation() {
         .db
         .mark_all_non_coinbases_transactions_as_unvalidated()
         .unwrap();
-    let completed_txs = resources.db.get_completed_transactions(None, None, None).unwrap();
+    let completed_txs = resources.db.get_completed_transactions(None, None, None, 0).unwrap();
     let completed_tx_2 = completed_txs
         .iter()
         .find(|c_tx| c_tx.tx_id == TxId::from(2u64))
@@ -1107,7 +1107,7 @@ async fn tx_revalidation() {
     let result = join_handle.await.unwrap();
     assert!(result.is_ok());
 
-    let completed_txs = resources.db.get_completed_transactions(None, None, None).unwrap();
+    let completed_txs = resources.db.get_completed_transactions(None, None, None, 0).unwrap();
     // data should now be updated and changed
     let completed_tx_2 = completed_txs
         .iter()
@@ -1278,7 +1278,7 @@ async fn tx_validation_protocol_reorg() {
     let result = join_handle.await.unwrap();
     assert!(result.is_ok());
 
-    let completed_txs = resources.db.get_completed_transactions(None, None, None).unwrap();
+    let completed_txs = resources.db.get_completed_transactions(None, None, None, 0).unwrap();
     let mut unconfirmed_count = 0;
     let mut confirmed_count = 0;
     for tx in completed_txs {
@@ -1396,7 +1396,7 @@ async fn tx_validation_protocol_reorg() {
 
     assert_eq!(rpc_service_state.take_get_header_by_height_calls().len(), 0);
 
-    let completed_txs = resources.db.get_completed_transactions(None, None, None).unwrap();
+    let completed_txs = resources.db.get_completed_transactions(None, None, None, 0).unwrap();
     // Tx 1
     assert!(completed_txs
         .iter()

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -102,7 +102,7 @@ use minotari_wallet::{
         error::TransactionServiceError,
         storage::{
             database::TransactionDatabase,
-            models::{CompletedTransaction, InboundTransaction, OutboundTransaction, WalletTransaction},
+            models::{CompletedTransaction, InboundTransaction, OutboundTransaction},
         },
     },
     utxo_scanner_service::{service::UtxoScannerService, RECOVERY_KEY},
@@ -9299,25 +9299,78 @@ pub unsafe extern "C" fn wallet_get_cancelled_transaction_by_id(
         return ptr::null_mut();
     }
 
-    let transaction = match (*wallet)
-        .runtime
-        .block_on((*wallet).wallet.transaction_service.get_any_transaction(transaction_id))
-    {
-        Ok(tx) => tx,
+    let mut transaction = None;
+
+    let completed_transactions = match (*wallet).runtime.block_on(
+        (*wallet)
+            .wallet
+            .transaction_service
+            .get_cancelled_completed_transactions(0),
+    ) {
+        Ok(txs) => txs,
         Err(e) => {
             *error_out = LibWalletError::from(WalletError::TransactionServiceError(e)).code;
             return ptr::null_mut();
         },
     };
 
+    if let Some(tx) = completed_transactions.iter().find(|tx| tx.tx_id == transaction_id) {
+        transaction = Some(tx.clone());
+    } else {
+        let outbound_transactions = match (*wallet).runtime.block_on(
+            (*wallet)
+                .wallet
+                .transaction_service
+                .get_cancelled_pending_outbound_transactions(),
+        ) {
+            Ok(txs) => txs,
+            Err(e) => {
+                *error_out = LibWalletError::from(WalletError::TransactionServiceError(e)).code;
+                return ptr::null_mut();
+            },
+        };
+        let runtime = match Runtime::new() {
+            Ok(r) => r,
+            Err(e) => {
+                *error_out = LibWalletError::from(InterfaceError::TokioError(e.to_string())).code;
+                return ptr::null_mut();
+            },
+        };
+        let address = match runtime.block_on(async { (*wallet).wallet.get_wallet_interactive_address().await }) {
+            Ok(address) => address,
+            Err(e) => {
+                *error_out = LibWalletError::from(e).code;
+                return ptr::null_mut();
+            },
+        };
+        if let Some(tx) = outbound_transactions.iter().find(|tx| tx.tx_id == transaction_id) {
+            let mut outbound_tx = CompletedTransaction::from_outbound(tx.clone(), Vec::new());
+            outbound_tx.source_address = address;
+            transaction = Some(outbound_tx);
+        } else {
+            let inbound_transactions = match (*wallet).runtime.block_on(
+                (*wallet)
+                    .wallet
+                    .transaction_service
+                    .get_cancelled_pending_inbound_transactions(),
+            ) {
+                Ok(txs) => txs,
+                Err(e) => {
+                    *error_out = LibWalletError::from(WalletError::TransactionServiceError(e)).code;
+                    return ptr::null_mut();
+                },
+            };
+            if let Some(tx) = inbound_transactions.iter().find(|tx| tx.tx_id == transaction_id) {
+                let mut inbound_tx = CompletedTransaction::from(tx.clone());
+                inbound_tx.destination_address = address;
+                transaction = Some(inbound_tx);
+            }
+        }
+    }
+
     match transaction {
         Some(tx) => {
-            let completed_tx = match tx {
-                WalletTransaction::Completed(ct) => ct,
-                WalletTransaction::PendingInbound(inbound) => CompletedTransaction::from(inbound),
-                WalletTransaction::PendingOutbound(out) => CompletedTransaction::from_outbound(out, Vec::new()),
-            };
-            return Box::into_raw(Box::new(completed_tx));
+            return Box::into_raw(Box::new(tx.clone()));
         },
         None => {
             *error_out = LibWalletError::from(WalletError::TransactionServiceError(

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -102,7 +102,7 @@ use minotari_wallet::{
         error::TransactionServiceError,
         storage::{
             database::TransactionDatabase,
-            models::{CompletedTransaction, InboundTransaction, OutboundTransaction},
+            models::{CompletedTransaction, InboundTransaction, OutboundTransaction, WalletTransaction},
         },
     },
     utxo_scanner_service::{service::UtxoScannerService, RECOVERY_KEY},
@@ -8735,6 +8735,7 @@ pub unsafe extern "C" fn wallet_get_contacts(wallet: *mut TariWallet, error_out:
 ///
 /// ## Arguments
 /// `wallet` - The TariWallet pointer
+/// `max_search_limit` - The maximum number of transactions to return, if 0 then all transactions will be returned
 /// `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
 /// as an out parameter. Returns a null pointer if any pointer argument is null.
 ///
@@ -8748,6 +8749,7 @@ pub unsafe extern "C" fn wallet_get_contacts(wallet: *mut TariWallet, error_out:
 #[no_mangle]
 pub unsafe extern "C" fn wallet_get_completed_transactions(
     wallet: *mut TariWallet,
+    max_search_limit: c_ulonglong,
     error_out: *mut c_int,
 ) -> *mut TariCompletedTransactions {
     if error_out.is_null() {
@@ -8761,12 +8763,15 @@ pub unsafe extern "C" fn wallet_get_completed_transactions(
         return ptr::null_mut();
     }
 
-    let completed_transactions = (*wallet).runtime.block_on(
+    let completed_transactions =
         (*wallet)
-            .wallet
-            .transaction_service
-            .get_completed_transactions(None, None, None),
-    );
+            .runtime
+            .block_on((*wallet).wallet.transaction_service.get_completed_transactions(
+                None,
+                None,
+                None,
+                max_search_limit,
+            ));
     match completed_transactions {
         Ok(completed_transactions) => {
             // The frontend specification calls for completed transactions that have not yet been mined to be
@@ -8796,6 +8801,7 @@ pub unsafe extern "C" fn wallet_get_completed_transactions(
 ///
 /// ## Arguments
 /// `wallet` - The TariWallet pointer
+/// `max_search_limit` - The maximum number of transactions to return, if 0 then all transactions will be returned
 /// `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
 /// as an out parameter. Returns a null pointer if any pointer argument is null.
 ///
@@ -8810,6 +8816,7 @@ pub unsafe extern "C" fn wallet_get_completed_transactions(
 pub unsafe extern "C" fn wallet_get_pending_inbound_transactions(
     wallet: *mut TariWallet,
     error_out: *mut c_int,
+    max_search_limit: c_ulonglong,
 ) -> *mut TariPendingInboundTransactions {
     if error_out.is_null() {
         return ptr::null_mut();
@@ -8832,12 +8839,16 @@ pub unsafe extern "C" fn wallet_get_pending_inbound_transactions(
                 pending.push(tx.clone());
             }
 
-            if let Ok(completed_txs) = (*wallet).runtime.block_on(
+            if let Ok(completed_txs) =
                 (*wallet)
-                    .wallet
-                    .transaction_service
-                    .get_completed_transactions(None, None, None),
-            ) {
+                    .runtime
+                    .block_on((*wallet).wallet.transaction_service.get_completed_transactions(
+                        None,
+                        None,
+                        None,
+                        max_search_limit,
+                    ))
+            {
                 // The frontend specification calls for completed transactions that have not yet been mined to be
                 // classified as Pending Transactions. In order to support this logic without impacting the practical
                 // definitions and storage of a MimbleWimble CompletedTransaction we will add those transaction to the
@@ -8870,6 +8881,7 @@ pub unsafe extern "C" fn wallet_get_pending_inbound_transactions(
 ///
 /// ## Arguments
 /// `wallet` - The TariWallet pointer
+/// `max_search_limit` - The maximum number of transactions to return, if 0 then all transactions will be returned
 /// `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
 /// as an out parameter. Returns a null pointer if any pointer argument is null.
 ///
@@ -8883,6 +8895,7 @@ pub unsafe extern "C" fn wallet_get_pending_inbound_transactions(
 #[no_mangle]
 pub unsafe extern "C" fn wallet_get_pending_outbound_transactions(
     wallet: *mut TariWallet,
+    max_search_limit: c_ulonglong,
     error_out: *mut c_int,
 ) -> *mut TariPendingOutboundTransactions {
     if error_out.is_null() {
@@ -8904,12 +8917,16 @@ pub unsafe extern "C" fn wallet_get_pending_outbound_transactions(
             for tx in &pending_transactions {
                 pending.push(tx.clone());
             }
-            if let Ok(completed_txs) = (*wallet).runtime.block_on(
+            if let Ok(completed_txs) =
                 (*wallet)
-                    .wallet
-                    .transaction_service
-                    .get_completed_transactions(None, None, None),
-            ) {
+                    .runtime
+                    .block_on((*wallet).wallet.transaction_service.get_completed_transactions(
+                        None,
+                        None,
+                        None,
+                        max_search_limit,
+                    ))
+            {
                 // The frontend specification calls for completed transactions that have not yet been mined to be
                 // classified as Pending Transactions. In order to support this logic without impacting the practical
                 // definitions and storage of a MimbleWimble CompletedTransaction we will add those transaction to the
@@ -8936,6 +8953,7 @@ pub unsafe extern "C" fn wallet_get_pending_outbound_transactions(
 ///
 /// ## Arguments
 /// `wallet` - The TariWallet pointer
+/// `max_search_limit` - The maximum number of transactions to return, if 0 then all transactions will be returned
 /// `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
 /// as an out parameter. Returns a null pointer if any pointer argument is null.
 ///
@@ -8949,6 +8967,7 @@ pub unsafe extern "C" fn wallet_get_pending_outbound_transactions(
 #[no_mangle]
 pub unsafe extern "C" fn wallet_get_cancelled_transactions(
     wallet: *mut TariWallet,
+    max_search_limit: c_ulonglong,
     error_out: *mut c_int,
 ) -> *mut TariCompletedTransactions {
     if error_out.is_null() {
@@ -8965,7 +8984,7 @@ pub unsafe extern "C" fn wallet_get_cancelled_transactions(
         (*wallet)
             .wallet
             .transaction_service
-            .get_cancelled_completed_transactions(),
+            .get_cancelled_completed_transactions(max_search_limit),
     ) {
         Ok(txs) => txs,
         Err(e) => {
@@ -9035,6 +9054,7 @@ pub unsafe extern "C" fn wallet_get_cancelled_transactions(
 /// ## Arguments
 /// `wallet` - The TariWallet pointer
 /// `transaction_id` - The TransactionId
+/// `max_search_limit` - The maximum number of transactions to return, if 0 then all transactions will be returned
 /// `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
 /// as an out parameter. Returns a null pointer if any pointer argument is null.
 ///
@@ -9049,6 +9069,7 @@ pub unsafe extern "C" fn wallet_get_cancelled_transactions(
 pub unsafe extern "C" fn wallet_get_completed_transaction_by_id(
     wallet: *mut TariWallet,
     transaction_id: c_ulonglong,
+    max_search_limit: c_ulonglong,
     error_out: *mut c_int,
 ) -> *mut TariCompletedTransaction {
     if error_out.is_null() {
@@ -9061,12 +9082,15 @@ pub unsafe extern "C" fn wallet_get_completed_transaction_by_id(
         return ptr::null_mut();
     }
 
-    let completed_transactions = (*wallet).runtime.block_on(
+    let completed_transactions =
         (*wallet)
-            .wallet
-            .transaction_service
-            .get_completed_transactions(None, None, None),
-    );
+            .runtime
+            .block_on((*wallet).wallet.transaction_service.get_completed_transactions(
+                None,
+                None,
+                None,
+                max_search_limit,
+            ));
 
     match completed_transactions {
         Ok(completed_transactions) => {
@@ -9094,6 +9118,7 @@ pub unsafe extern "C" fn wallet_get_completed_transaction_by_id(
 /// ## Arguments
 /// `wallet` - The TariWallet pointer
 /// `transaction_id` - The TransactionId
+/// `max_search_limit` - The maximum number of transactions to return, if 0 then all transactions will be returned
 /// `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
 /// as an out parameter. Returns a null pointer if any pointer argument is null.
 ///
@@ -9108,6 +9133,7 @@ pub unsafe extern "C" fn wallet_get_completed_transaction_by_id(
 pub unsafe extern "C" fn wallet_get_pending_inbound_transaction_by_id(
     wallet: *mut TariWallet,
     transaction_id: c_ulonglong,
+    max_search_limit: c_ulonglong,
     error_out: *mut c_int,
 ) -> *mut TariPendingInboundTransaction {
     if error_out.is_null() {
@@ -9125,12 +9151,15 @@ pub unsafe extern "C" fn wallet_get_pending_inbound_transaction_by_id(
         .runtime
         .block_on((*wallet).wallet.transaction_service.get_pending_inbound_transactions());
 
-    let completed_transactions = (*wallet).runtime.block_on(
+    let completed_transactions =
         (*wallet)
-            .wallet
-            .transaction_service
-            .get_completed_transactions(None, None, None),
-    );
+            .runtime
+            .block_on((*wallet).wallet.transaction_service.get_completed_transactions(
+                None,
+                None,
+                None,
+                max_search_limit,
+            ));
 
     match completed_transactions {
         Ok(completed_transactions) => {
@@ -9170,6 +9199,7 @@ pub unsafe extern "C" fn wallet_get_pending_inbound_transaction_by_id(
 /// ## Arguments
 /// `wallet` - The TariWallet pointer
 /// `transaction_id` - The TransactionId
+/// `max_search_limit` - The maximum number of transactions to return, if 0 then all transactions will be returned
 /// `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
 /// as an out parameter. Returns a null pointer if any pointer argument is null.
 ///
@@ -9184,6 +9214,7 @@ pub unsafe extern "C" fn wallet_get_pending_inbound_transaction_by_id(
 pub unsafe extern "C" fn wallet_get_pending_outbound_transaction_by_id(
     wallet: *mut TariWallet,
     transaction_id: c_ulonglong,
+    max_search_limit: c_ulonglong,
     error_out: *mut c_int,
 ) -> *mut TariPendingOutboundTransaction {
     if error_out.is_null() {
@@ -9201,12 +9232,15 @@ pub unsafe extern "C" fn wallet_get_pending_outbound_transaction_by_id(
         .runtime
         .block_on((*wallet).wallet.transaction_service.get_pending_outbound_transactions());
 
-    let completed_transactions = (*wallet).runtime.block_on(
+    let completed_transactions =
         (*wallet)
-            .wallet
-            .transaction_service
-            .get_completed_transactions(None, None, None),
-    );
+            .runtime
+            .block_on((*wallet).wallet.transaction_service.get_completed_transactions(
+                None,
+                None,
+                None,
+                max_search_limit,
+            ));
 
     match completed_transactions {
         Ok(completed_transactions) => {
@@ -9274,78 +9308,27 @@ pub unsafe extern "C" fn wallet_get_cancelled_transaction_by_id(
         return ptr::null_mut();
     }
 
-    let mut transaction = None;
-
-    let completed_transactions = match (*wallet).runtime.block_on(
+    let transaction = match (*wallet).runtime.block_on(
         (*wallet)
             .wallet
             .transaction_service
-            .get_cancelled_completed_transactions(),
+            .get_any_transaction(transaction_id.into()),
     ) {
-        Ok(txs) => txs,
+        Ok(tx) => tx,
         Err(e) => {
             *error_out = LibWalletError::from(WalletError::TransactionServiceError(e)).code;
             return ptr::null_mut();
         },
     };
 
-    if let Some(tx) = completed_transactions.iter().find(|tx| tx.tx_id == transaction_id) {
-        transaction = Some(tx.clone());
-    } else {
-        let outbound_transactions = match (*wallet).runtime.block_on(
-            (*wallet)
-                .wallet
-                .transaction_service
-                .get_cancelled_pending_outbound_transactions(),
-        ) {
-            Ok(txs) => txs,
-            Err(e) => {
-                *error_out = LibWalletError::from(WalletError::TransactionServiceError(e)).code;
-                return ptr::null_mut();
-            },
-        };
-        let runtime = match Runtime::new() {
-            Ok(r) => r,
-            Err(e) => {
-                *error_out = LibWalletError::from(InterfaceError::TokioError(e.to_string())).code;
-                return ptr::null_mut();
-            },
-        };
-        let address = match runtime.block_on(async { (*wallet).wallet.get_wallet_interactive_address().await }) {
-            Ok(address) => address,
-            Err(e) => {
-                *error_out = LibWalletError::from(e).code;
-                return ptr::null_mut();
-            },
-        };
-        if let Some(tx) = outbound_transactions.iter().find(|tx| tx.tx_id == transaction_id) {
-            let mut outbound_tx = CompletedTransaction::from_outbound(tx.clone(), Vec::new());
-            outbound_tx.source_address = address;
-            transaction = Some(outbound_tx);
-        } else {
-            let inbound_transactions = match (*wallet).runtime.block_on(
-                (*wallet)
-                    .wallet
-                    .transaction_service
-                    .get_cancelled_pending_inbound_transactions(),
-            ) {
-                Ok(txs) => txs,
-                Err(e) => {
-                    *error_out = LibWalletError::from(WalletError::TransactionServiceError(e)).code;
-                    return ptr::null_mut();
-                },
-            };
-            if let Some(tx) = inbound_transactions.iter().find(|tx| tx.tx_id == transaction_id) {
-                let mut inbound_tx = CompletedTransaction::from(tx.clone());
-                inbound_tx.destination_address = address;
-                transaction = Some(inbound_tx);
-            }
-        }
-    }
-
     match transaction {
         Some(tx) => {
-            return Box::into_raw(Box::new(tx.clone()));
+            let completed_tx = match tx {
+                WalletTransaction::Completed(ct) => ct,
+                WalletTransaction::PendingInbound(inbound) => CompletedTransaction::from(inbound),
+                WalletTransaction::PendingOutbound(out) => CompletedTransaction::from_outbound(out, Vec::new()),
+            };
+            return Box::into_raw(Box::new(completed_tx));
         },
         None => {
             *error_out = LibWalletError::from(WalletError::TransactionServiceError(

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -8815,8 +8815,8 @@ pub unsafe extern "C" fn wallet_get_completed_transactions(
 #[no_mangle]
 pub unsafe extern "C" fn wallet_get_pending_inbound_transactions(
     wallet: *mut TariWallet,
-    error_out: *mut c_int,
     max_search_limit: c_ulonglong,
+    error_out: *mut c_int,
 ) -> *mut TariPendingInboundTransactions {
     if error_out.is_null() {
         return ptr::null_mut();
@@ -9054,7 +9054,6 @@ pub unsafe extern "C" fn wallet_get_cancelled_transactions(
 /// ## Arguments
 /// `wallet` - The TariWallet pointer
 /// `transaction_id` - The TransactionId
-/// `max_search_limit` - The maximum number of transactions to return, if 0 then all transactions will be returned
 /// `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
 /// as an out parameter. Returns a null pointer if any pointer argument is null.
 ///
@@ -9069,7 +9068,6 @@ pub unsafe extern "C" fn wallet_get_cancelled_transactions(
 pub unsafe extern "C" fn wallet_get_completed_transaction_by_id(
     wallet: *mut TariWallet,
     transaction_id: c_ulonglong,
-    max_search_limit: c_ulonglong,
     error_out: *mut c_int,
 ) -> *mut TariCompletedTransaction {
     if error_out.is_null() {
@@ -9082,34 +9080,27 @@ pub unsafe extern "C" fn wallet_get_completed_transaction_by_id(
         return ptr::null_mut();
     }
 
-    let completed_transactions =
+    let completed_transactions = (*wallet).runtime.block_on(
         (*wallet)
-            .runtime
-            .block_on((*wallet).wallet.transaction_service.get_completed_transactions(
-                None,
-                None,
-                None,
-                max_search_limit,
-            ));
+            .wallet
+            .transaction_service
+            .get_completed_transaction(transaction_id.into()),
+    );
 
     match completed_transactions {
-        Ok(completed_transactions) => {
-            if let Some(tx) = completed_transactions
-                .iter()
-                .find(|tx| tx.tx_id == TxId::from(transaction_id))
+        Ok(completed_transaction) => {
+            if completed_transaction.status != TransactionStatus::Completed &&
+                completed_transaction.status != TransactionStatus::Broadcast
             {
-                if tx.status != TransactionStatus::Completed && tx.status != TransactionStatus::Broadcast {
-                    let completed = tx.clone();
-                    return Box::into_raw(Box::new(completed));
-                }
+                let completed = completed_transaction.clone();
+                return Box::into_raw(Box::new(completed));
             }
-            *error_out = 108;
         },
         Err(e) => {
             *error_out = LibWalletError::from(WalletError::TransactionServiceError(e)).code;
         },
     }
-
+    *error_out = 108;
     ptr::null_mut()
 }
 
@@ -9308,12 +9299,10 @@ pub unsafe extern "C" fn wallet_get_cancelled_transaction_by_id(
         return ptr::null_mut();
     }
 
-    let transaction = match (*wallet).runtime.block_on(
-        (*wallet)
-            .wallet
-            .transaction_service
-            .get_any_transaction(transaction_id.into()),
-    ) {
+    let transaction = match (*wallet)
+        .runtime
+        .block_on((*wallet).wallet.transaction_service.get_any_transaction(transaction_id))
+    {
         Ok(tx) => tx,
         Err(e) => {
             *error_out = LibWalletError::from(WalletError::TransactionServiceError(e)).code;


### PR DESCRIPTION
Description
---
adds the option to limit transaction searches and not read the entire completed transactions database. 
Limits the console wallet to only view the latest 500 txs. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to limit the number of completed and cancelled transactions returned in wallet queries and API calls, improving performance and usability for large transaction histories.
  - Introduced support for specifying a maximum number of transactions to retrieve when using wallet FFI functions.

- **Refactor**
  - Simplified and optimized the retrieval of cancelled transactions by ID for external integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->