### PR TITLE
fix: minotari_merge_mining_proxy returns Tari block hash even if submit_to_origin is disabled

### DIFF
--- a/applications/minotari_merge_mining_proxy/src/proxy/inner.rs
+++ b/applications/minotari_merge_mining_proxy/src/proxy/inner.rs
@@ -270,32 +270,21 @@ impl InnerService {
 
                 match resp {
                     Ok(resp) => {
-                        if self.config.submit_to_origin {
-                            json_resp = json_rpc::success_response(
-                                request["id"].as_i64(),
-                                json!({ "status": "OK", "untrusted": !self.initial_sync_achieved.load(Ordering::SeqCst) }),
-                            );
-                            let resp = resp.into_inner();
-                            json_resp = crate::proxy::utils::append_aux_chain_data(
-                                json_resp,
-                                json!({"id": TARI_CHAIN_ID, "block_hash": resp.block_hash.to_hex()}),
-                            );
-                            debug!(
-                                target: LOG_TARGET,
-                                "Submitted block #{} to Minotari node in {:.0?} (SubmitBlock)",
-                                height,
-                                start.elapsed()
-                            );
-                        } else {
-                            // self-select related, do not change.
-                            json_resp = json_rpc::default_block_accept_response(request["id"].as_i64());
-                            trace!(
-                                target: LOG_TARGET,
-                                "pool merged mining proxy_submit_to_origin({}) json_resp: {}",
-                                self.config.submit_to_origin,
-                                json_resp
-                            );
-                        }
+                        json_resp = json_rpc::success_response(
+                            request["id"].as_i64(),
+                            json!({ "status": "OK", "untrusted": !self.initial_sync_achieved.load(Ordering::SeqCst) }),
+                        );
+                        let resp = resp.into_inner();
+                        json_resp = crate::proxy::utils::append_aux_chain_data(
+                            json_resp,
+                            json!({"id": TARI_CHAIN_ID, "block_hash": resp.block_hash.to_hex()}),
+                        );
+                        debug!(
+                            target: LOG_TARGET,
+                            "Submitted block #{} to Minotari node in {:.0?} (SubmitBlock)",
+                            height,
+                            start.elapsed()
+                        );
                         self.block_templates.remove_final_block_template(&hash).await;
                     },
                     Err(err) => {


### PR DESCRIPTION
Fix for issue https://github.com/tari-project/tari/issues/7031. For XMR/XTM merge pool it is convenient to submit XTM and XMR blocks separately (with submit_to_origin disabled). However we still need XTM block hash in that case.

Description
---
Makes merge_mining_proxy block submit response consistent, do not depend on submit_to_origin flag and always include Tari block hash (if submit was successful).

Motivation and Context
---
Fixes issue https://github.com/tari-project/tari/issues/7031.

How Has This Been Tested?
---
source ./buildtools/multinet_envs.sh mainnet; cargo build --release; cargo check --release
Also running this for month in MoneroOcean pool mining setup.

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Standardized the block submission response to always include auxiliary chain data, regardless of configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->