### PR TITLE
chore(ci): windows binary audit fix and more code-signing verification

### DIFF
--- a/.github/workflows/build_binaries.json
+++ b/.github/workflows/build_binaries.json
@@ -9,10 +9,10 @@
   },
   {
     "name": "linux-arm64",
-    "runs-on": "ubuntu-latest",
+    "runs-on": "ubuntu-22.04-arm",
     "rust": "stable",
     "target": "aarch64-unknown-linux-gnu",
-    "cross": true,
+    "cross": false,
     "flags": "--features libtor --workspace --exclude minotari_mining_helper_ffi --exclude tari_integration_tests",
     "build_metric": true
   },

--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -314,7 +314,9 @@ jobs:
           echo "cross flag: ${{ matrix.builds.cross }}"
 
       - name: Debug environment variables - Windows
-        if: startsWith(runner.os,'Windows')
+        # Debug
+        if: ${{ false }}
+        # if: startsWith(runner.os,'Windows')
         run: printenv
 
       - name: Build release binaries
@@ -544,6 +546,14 @@ jobs:
           description: ${{ env.TS_DESCRIPTION }}
           description-url: ${{ env.TS_URL }}
 
+      - name: Verify Windows signing for archive pack
+        if: ${{ ( startsWith(runner.os,'Windows') ) && ( env.AZURE_TENANT_ID != '' ) }}
+        env:
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+        shell: powershell
+        run: |
+          .\buildtools\check_signatures.ps1 -ScanDir ".\${{ env.TS_DIST }}"
+
       - name: Build the Windows installer
         if: startsWith(runner.os,'Windows')
         shell: cmd
@@ -578,45 +588,7 @@ jobs:
         shell: powershell
         working-directory: ${{ github.workspace }}/buildtools/Output
         run: |
-          # Get the Program Files (x86) directory dynamically
-          $programFilesX86 = [System.Environment]::GetFolderPath("ProgramFilesX86")
-          $sdkBasePath = Join-Path $programFilesX86 "Windows Kits"
-
-          # Check if Windows Kits exists
-          if (-Not (Test-Path $sdkBasePath)) {
-            Write-Error "Windows Kits folder not found at $sdkBasePath!"
-            exit 1
-          }
-
-          Write-Output "Searching for signtool.exe in: $sdkBasePath"
-
-          # Search for signtool.exe within Windows Kits fold with x64 in the path
-          $signtoolPath = Get-ChildItem -Path $sdkBasePath -Recurse -Filter signtool.exe -ErrorAction SilentlyContinue |
-                          Where-Object { $_.FullName -match '\\x64\\' } |
-                          Select-Object -ExpandProperty FullName -First 1
-
-          if (-not $signtoolPath) {
-            Write-Error "signtool.exe not found in Windows Kits folder!"
-            exit 1
-          }
-
-          Write-Output "Found signtool.exe at: $signtoolPath"
-
-          $Signature = Get-AuthenticodeSignature "${{ env.TS_FILENAME }}-${{ env.TARI_VERSION }}-${{ env.VSHA_SHORT }}-${{ matrix.builds.name }}-installer.exe"
-
-          # Display results
-          Write-Host "File: ${{ env.TS_FILENAME }}-${{ env.TARI_VERSION }}-${{ env.VSHA_SHORT }}-${{ matrix.builds.name }}-installer.exe"
-          Write-Host "  - Status: $($Signature.Status)"
-          Write-Host "  - Status Message: $($Signature.StatusMessage)"
-          Write-Host "  - Signer: $($Signature.SignerCertificate.Subject)"
-          Write-Host "  - Issuer: $($Signature.SignerCertificate.Issuer)"
-          Write-Host "---------------------------------------------"
-
-          & $signtoolPath verify /pa "${{ env.TS_FILENAME }}-${{ env.TARI_VERSION }}-${{ env.VSHA_SHORT }}-${{ matrix.builds.name }}-installer.exe"
-          if ($LASTEXITCODE -ne 0) {
-            Write-Error "!! Signature verification failed for ${{ env.TS_FILENAME }}-${{ env.TARI_VERSION }}-${{ env.VSHA_SHORT }}-${{ matrix.builds.name }}-installer.exe !!"
-            exit 1
-          }
+          ..\check_signatures.ps1 -ScanDir "."
 
       - name: Windows installer Compute archive checksum
         if: startsWith(runner.os,'Windows')
@@ -641,8 +613,9 @@ jobs:
         if: ${{ ( ! matrix.builds.cross ) }}
         continue-on-error: true
         shell: bash
-        working-directory: ${{ env.MTS_SOURCE }}
+        # working-directory: ${{ env.MTS_SOURCE }} - breaks on Windows
         run: |
+          cd "${{ env.MTS_SOURCE }}"
           echo "Audit binaries ..."
           cargo audit bin *minotari*${{ env.TS_EXT }}
 

--- a/buildtools/check_signatures.ps1
+++ b/buildtools/check_signatures.ps1
@@ -1,0 +1,106 @@
+param(
+    [string[]]$Files,
+    [string]$ScanDir
+)
+
+Write-Host "=== Signature Check Script Starting ==="
+
+# Show usage if no input provided
+if (-not $Files -and -not $ScanDir) {
+    Write-Warning @"
+No input files or scan directory provided.
+
+Usage examples:
+
+  # Check specific files
+  .\check_signatures.ps1 -Files "C:\path\to\file1.exe","C:\path\to\file2.exe"
+
+  # Or scan a directory recursively for all .exe files
+  .\check_signatures.ps1 -ScanDir "C:\path\to\build\folder"
+
+Environment vars in CI:
+  - TS_FILES: Space-separated list of EXE paths
+  - MTS_SOURCE: Folder to scan for EXEs
+
+"@
+    exit 1
+}
+
+# Locate signtool.exe
+$programFilesX86 = [System.Environment]::GetFolderPath("ProgramFilesX86")
+$sdkBasePath = Join-Path $programFilesX86 "Windows Kits"
+
+if (-Not (Test-Path $sdkBasePath)) {
+    Write-Error "Windows Kits folder not found at $sdkBasePath!"
+    exit 1
+}
+
+Write-Output "Searching for signtool.exe in: $sdkBasePath"
+
+$signtoolPath = Get-ChildItem -Path $sdkBasePath -Recurse -Filter signtool.exe -ErrorAction SilentlyContinue |
+                Where-Object { $_.FullName -match '\\x64\\' } |
+                Select-Object -ExpandProperty FullName -First 1
+
+if (-not $signtoolPath) {
+    Write-Error "signtool.exe not found in Windows Kits folder!"
+    exit 1
+}
+
+Write-Output "Found signtool.exe at: $signtoolPath"
+Write-Host ""
+
+# Resolve EXE files
+$exeFiles = @()
+
+if ($Files) {
+    Write-Host "Using provided TS_FILES list"
+    $exeFiles = $Files
+} elseif ($ScanDir) {
+    Write-Host "Scanning for .exe files in: $ScanDir"
+    $exeFiles = Get-ChildItem -Path $ScanDir -Recurse -Filter *.exe | Select-Object -ExpandProperty FullName
+} else {
+    Write-Error "No input files or scan directory provided"
+    exit 1
+}
+
+if (-not $exeFiles) {
+    Write-Error "No .exe files found"
+    exit 1
+}
+
+# Check each file
+$failures = 0
+foreach ($file in $exeFiles) {
+    Write-Host "Checking: $file"
+
+    if (!(Test-Path $file)) {
+        Write-Warning "File does not exist: $file"
+        $failures++
+        continue
+    }
+
+    # Check with Get-AuthenticodeSignature
+    $sig = Get-AuthenticodeSignature $file
+    if ($sig.Status -ne 'Valid') {
+        Write-Warning "Authenticode check failed: $($sig.Status)"
+        $failures++
+    } else {
+        Write-Host "Authenticode signature valid: $($sig.SignerCertificate.Subject)"
+    }
+
+    # Check with signtool
+    & "$signtoolPath" verify /pa "$file"
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warning "signtool verify failed for: $file"
+        $failures++
+    } else {
+        Write-Host "signtool verify passed"
+    }
+}
+
+if ($failures -gt 0) {
+    Write-Error "Signature check failed for $failures file(s)"
+    exit $failures
+}
+
+Write-Host "All files passed signature checks"


### PR DESCRIPTION
Description
Windows binary audit fix
move code-signing verification into common powerShell
add per Windows exe verify before Windows installer build
Move linux-arm64 from cross-rs compile to native runner on Ubuntu 22.04

Motivation and Context
Make sure that audit is included for Windows binaries
Verify Windows exes before build Windows installer 
Fix linux-arm64 builds

How Has This Been Tested?
Builds and works as expected in CI workflows


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a script to verify digital signatures of Windows executable files, enhancing security checks in the release process.

- **Chores**
  - Updated build configuration for Linux ARM64 to use a specific runner environment and disable cross-compilation.
  - Improved CI workflow for Windows by simplifying and centralizing signature verification steps and adjusting audit step execution for better compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->