### PR TITLE
fix: remove long timeout in interactive_tx till tx is persisted into db

### DIFF
--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -841,7 +841,6 @@ impl wallet_server::Wallet for WalletGrpcServer {
                         .get_wallet_one_sided_address()
                         .await
                         .map_err(|e| Status::internal(format!("{:?}", e)))?;
-                    // The transaction is only persisted after it has been sent via comms, so we need to wait
                     let wallet_tx = timeout(Duration::from_millis(100), async {
                         loop {
                             let tx = self

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -24,6 +24,7 @@ use std::{
     convert::{TryFrom, TryInto},
     str::FromStr,
     sync::Arc,
+    time::Duration,
 };
 
 use futures::{
@@ -140,7 +141,7 @@ use tari_utilities::{hex::Hex, ByteArray};
 use tokio::{
     sync::{broadcast, Mutex},
     task,
-    time::{sleep, timeout, Duration},
+    time::{sleep, timeout},
 };
 use tonic::{Request, Response, Status};
 
@@ -841,7 +842,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
                         .await
                         .map_err(|e| Status::internal(format!("{:?}", e)))?;
                     // The transaction is only persisted after it has been sent via comms, so we need to wait
-                    let wallet_tx = timeout(Duration::from_secs(30), async {
+                    let wallet_tx = timeout(Duration::from_millis(100), async {
                         loop {
                             let tx = self
                                 .get_transaction_service()

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -852,7 +852,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
                             if let Ok(Some(tx)) = tx {
                                 break tx;
                             }
-                            sleep(Duration::from_millis(100)).await;
+                            sleep(Duration::from_millis(10)).await;
                         }
                     })
                     .await

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_send_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_send_protocol.rs
@@ -316,6 +316,28 @@ where
             store_and_forward_send_result: false,
             transaction_status: TransactionStatus::Queued,
         };
+        // Add pending outbound transaction if it does not exist
+        if !self
+            .resources
+            .db
+            .transaction_exists(tx_id)
+            .map_err(|e| TransactionServiceProtocolError::new(self.id, TransactionServiceError::from(e)))?
+        {
+            let fee = sender_protocol
+                .get_fee_amount()
+                .map_err(|e| TransactionServiceProtocolError::new(self.id, TransactionServiceError::from(e)))?;
+            outbound_tx.fee = fee;
+            outbound_tx.status = initial_send.transaction_status;
+            self.resources
+                .db
+                .add_pending_outbound_transaction(outbound_tx.tx_id, outbound_tx.clone())
+                .map_err(|e| TransactionServiceProtocolError::new(self.id, TransactionServiceError::from(e)))?;
+            if let Err(e) = check_transaction_size(&outbound_tx, self.id) {
+                self.cancel_oversized_transaction().await?;
+                return Err(e);
+            }
+        }
+
         if let Err(e) = check_transaction_size(&outbound_tx, self.id) {
             info!(
                 target: LOG_TARGET,
@@ -342,28 +364,6 @@ where
                 .map_err(|e| TransactionServiceProtocolError::new(self.id, TransactionServiceError::from(e)))?;
         }
 
-        // Add pending outbound transaction if it does not exist
-        if !self
-            .resources
-            .db
-            .transaction_exists(tx_id)
-            .map_err(|e| TransactionServiceProtocolError::new(self.id, TransactionServiceError::from(e)))?
-        {
-            let fee = sender_protocol
-                .get_fee_amount()
-                .map_err(|e| TransactionServiceProtocolError::new(self.id, TransactionServiceError::from(e)))?;
-            outbound_tx.fee = fee;
-            outbound_tx.status = initial_send.transaction_status;
-            outbound_tx.direct_send_success = true;
-            self.resources
-                .db
-                .add_pending_outbound_transaction(outbound_tx.tx_id, outbound_tx.clone())
-                .map_err(|e| TransactionServiceProtocolError::new(self.id, TransactionServiceError::from(e)))?;
-            if let Err(e) = check_transaction_size(&outbound_tx, self.id) {
-                self.cancel_oversized_transaction().await?;
-                return Err(e);
-            }
-        }
         if initial_send.transaction_status == TransactionStatus::Pending {
             self.resources
                 .db

--- a/integration_tests/tests/features/WalletTransactions.feature
+++ b/integration_tests/tests/features/WalletTransactions.feature
@@ -180,6 +180,20 @@ Feature: Wallet Transactions
     Then all nodes are at height 17
     Then I wait for wallet WALLET_C to have at least 400000 uT
 
+  @critical
+  Scenario: Wallet sends many interactive transactions to another wallet
+    Given I have a seed node NODE
+    When I have wallet WALLET_A connected to all seed nodes
+    When I have wallet WALLET_B connected to all seed nodes
+    When I have mining node MINER connected to base node NODE and wallet WALLET_A
+    When mining node MINER mines 50 blocks
+    Then all nodes are at height 50
+    Then I wait for wallet WALLET_A to have at least 10000000000 uT
+    When I send 40 interactive transactions of 1000000 uT from wallet WALLET_A to wallet WALLET_B at fee 100
+    When mining node MINER mines 5 blocks
+    Then all nodes are at height 55
+
+
   Scenario: Wallet should display all transactions made
     Given I have a seed node NODE
     When I have wallet WALLET_A connected to all seed nodes

--- a/integration_tests/tests/steps/wallet_steps.rs
+++ b/integration_tests/tests/steps/wallet_steps.rs
@@ -1083,6 +1083,138 @@ async fn send_interactive_amount_from_wallet_to_wallet_at_fee(
     ));
 }
 
+#[then(expr = "I send {} interactive transactions of {int} uT from wallet {word} to wallet {word} at fee {int}")]
+#[when(expr = "I send {} interactive transactions of {int} uT from wallet {word} to wallet {word} at fee {int}")]
+#[allow(clippy::too_many_lines)]
+async fn send_many_interactive_amount_from_wallet_to_wallet_at_fee(
+    world: &mut TariWorld,
+    number_of_transactions: u64,
+    amount: u64,
+    sender: String,
+    receiver: String,
+    fee_per_gram: u64,
+) {
+    let mut sender_wallet_client = create_wallet_client(world, sender.clone()).await.unwrap();
+    let sender_wallet_address = world.get_wallet_address(&sender).await.unwrap();
+    let receiver_wallet_address = world.get_wallet_address(&receiver).await.unwrap();
+
+    let payment_recipient = PaymentRecipient {
+        address: receiver_wallet_address.clone(),
+        amount,
+        fee_per_gram,
+        payment_type: 0, // mimblewimble transaction
+        raw_payment_id: PaymentId::open_from_string(
+            &format!(
+                "Transfer amount {} from {} to {} as fee {}",
+                amount,
+                sender.as_str(),
+                receiver.as_str(),
+                fee_per_gram
+            ),
+            TxType::PaymentToOther,
+        )
+        .to_bytes(),
+        user_payment_id: None,
+    };
+    let transfer_req = TransferRequest {
+        recipients: vec![payment_recipient],
+    };
+    let mut tx_ids = Vec::with_capacity(usize::try_from(number_of_transactions).unwrap());
+    for i in 0..number_of_transactions {
+        cucumber_steps_log(format!(
+            "Sending transaction {} of {} with amount {} from {} to {} at fee {}",
+            i + 1,
+            number_of_transactions,
+            amount,
+            sender,
+            receiver,
+            fee_per_gram
+        ));
+        let tx_res = sender_wallet_client
+            .transfer(transfer_req.clone())
+            .await
+            .unwrap()
+            .into_inner();
+        let tx_res = tx_res.results;
+        cucumber_steps_log(format!("Transaction results: {:?}", tx_res));
+
+        assert_eq!(tx_res.len(), 1usize);
+
+        let tx_res = tx_res.first().unwrap();
+        cucumber_steps_log(format!("Transaction 1 result: {:?}", tx_res));
+        assert!(
+            tx_res.is_success,
+            "Transaction with amount {} from wallet {} to {} at fee {} failed",
+            amount,
+            sender.as_str(),
+            receiver.as_str(),
+            fee_per_gram
+        );
+        tx_ids.push(tx_res.transaction_id);
+    }
+
+    for tx_id in &tx_ids {
+        let tx_info_req = GetTransactionInfoRequest {
+            transaction_ids: vec![*tx_id],
+        };
+
+        let num_retries = 300; // 30s total wait with 100ms intervals
+        for i in 0..num_retries {
+            let tx_info_res = sender_wallet_client
+                .get_transaction_info(tx_info_req.clone())
+                .await
+                .unwrap()
+                .into_inner();
+            let tx_info = tx_info_res.transactions.first().unwrap();
+
+            // TransactionStatus::TRANSACTION_STATUS_BROADCAST == 1_i32
+            if tx_info.status == 1_i32 {
+                cucumber_steps_log(format!(
+                    "Wait for transaction from {} to {} with amount {} at fee {} (DONE) to be broadcast",
+                    sender.clone(),
+                    receiver.clone(),
+                    amount,
+                    fee_per_gram
+                ));
+                break;
+            } else if i % 5 == 0 {
+                cucumber_steps_log(format!(
+                    "Wait for transaction from {} to {} with amount {} at fee {} to be broadcast",
+                    sender.clone(),
+                    receiver.clone(),
+                    amount,
+                    fee_per_gram
+                ));
+            } else {
+                // Nothing here
+            }
+
+            if i == num_retries - 1 {
+                panic!(
+                    "Transaction from {} to {} with amount {} at fee {} failed to be broadcast",
+                    sender.clone(),
+                    receiver.clone(),
+                    amount,
+                    fee_per_gram
+                )
+            }
+
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    }
+
+    // Insert tx_id's to the corresponding world mapping
+    world
+        .wallet_tx_ids
+        .insert(sender_wallet_address.clone(), tx_ids.clone());
+    world.wallet_tx_ids.insert(receiver_wallet_address.clone(), tx_ids);
+
+    cucumber_steps_log(format!(
+        "{} consecutive interactive transactions with amount {} from {} to {} at fee {} succeeded",
+        number_of_transactions, amount, sender, receiver, fee_per_gram
+    ));
+}
+
 #[then(expr = "wallet {word} detects at least {int} coinbase transactions as CoinbaseConfirmed")]
 async fn wallet_detects_at_least_coinbase_transactions(world: &mut TariWorld, wallet_name: String, coinbases: u64) {
     let mut client = create_wallet_client(world, wallet_name.clone()).await.unwrap();


### PR DESCRIPTION
Description
---
fixes: #7251 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved transaction handling to ensure pending outbound transactions are added at the correct stage and with accurate status and fee information.
  - Adjusted transaction size checks to cancel oversized transactions earlier in the process.
  - Reduced the timeout when waiting for transaction persistence, resulting in faster feedback during transfers.
- **Tests**
  - Added a new test scenario to validate handling of multiple consecutive interactive transactions between wallets.
  - Introduced a test step to support sending multiple interactive transactions with specified fees in sequence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->