### PR TITLE
feat: auto zero value coinbase reward calculation

### DIFF
--- a/applications/minotari_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/minotari_node/src/grpc/base_node_grpc_server.rs
@@ -1128,7 +1128,7 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
         if coinbases.len() == 1 && coinbases[0].value == 0 {
             coinbases[0].value = 1;
         }
-        
+
         let mut total_shares = 0u128;
         for coinbase in &coinbases {
             total_shares += u128::from(coinbase.value);
@@ -1390,7 +1390,7 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
         if coinbases.len() == 1 && coinbases[0].value == 0 {
             coinbases[0].value = reward.as_u64();
         }
-       
+
         let mut amount = 0u64;
         for coinbase in &coinbases {
             amount += coinbase.value;

--- a/applications/minotari_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/minotari_node/src/grpc/base_node_grpc_server.rs
@@ -1126,7 +1126,7 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
 
         // assume full coinbase reward in case of single coinbase with zero value
         if coinbases.len() == 1 && coinbases[0].value == 0 {
-            coinbases[0].value = reward as u64;
+            coinbases[0].value = 1;
         }
         
         let mut total_shares = 0u128;

--- a/applications/minotari_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/minotari_node/src/grpc/base_node_grpc_server.rs
@@ -1123,6 +1123,12 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
                 })?
                 .as_u64(),
         );
+
+        // assume full coinbase reward in case of single coinbase with zero value
+        if coinbases.len() == 1 && coinbases[0].value == 0 {
+            coinbases[0].value = reward as u64;
+        }
+        
         let mut total_shares = 0u128;
         for coinbase in &coinbases {
             total_shares += u128::from(coinbase.value);
@@ -1355,7 +1361,7 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
                     Status::invalid_argument(format!("Malformed block template provided: {}", s)),
                 )
             })?;
-        let coinbases: Vec<tari_rpc::NewBlockCoinbase> = request.coinbases;
+        let mut coinbases: Vec<tari_rpc::NewBlockCoinbase> = request.coinbases;
         if coinbases.len() as u64 >
             self.consensus_rules
                 .consensus_constants(block_template.header.height)
@@ -1379,6 +1385,12 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
                     Status::internal("Could not calculate the amount of fees in the block".to_string()),
                 )
             })?;
+
+        // assume full coinbase reward in case of single coinbase with zero value
+        if coinbases.len() == 1 && coinbases[0].value == 0 {
+            coinbases[0].value = reward.as_u64();
+        }
+       
         let mut amount = 0u64;
         for coinbase in &coinbases {
             amount += coinbase.value;

--- a/integration_tests/tests/features/BlockTemplate.feature
+++ b/integration_tests/tests/features/BlockTemplate.feature
@@ -18,6 +18,13 @@ Scenario: Verify UTXO and kernel MMR size in header
         Then generate a block BLOCK_02 with 2 coinbases as a single request from node SEED_A
 
     @critical
+    Scenario: Verify gprc can create block with zero value coinbase
+        Given I have a seed node SEED_A
+        When I have 1 base nodes connected to all seed nodes
+        Then generate a block BLOCK_02 with zero value coinbase from node SEED_A
+        Then generate a block BLOCK_02 with zero value coinbase as a single request from node SEED_A
+
+    @critical
     Scenario: Verify grpc can create full block with maximum number of coinbases
         Given I have 1 seed nodes
         When I have a base node NODE_01 connected to all seed nodes

--- a/integration_tests/tests/steps/node_steps.rs
+++ b/integration_tests/tests/steps/node_steps.rs
@@ -1077,8 +1077,6 @@ async fn generate_block_with_zero_coinbase(world: &mut TariWorld, node: String) 
     let template_response = client.get_new_block_template(template_req).await.unwrap().into_inner();
 
     let block_template = template_response.new_block_template.clone().unwrap();
-    let miner_data = template_response.miner_data.unwrap();
-    let amount = miner_data.reward + miner_data.total_fees;
     let request = GetNewBlockWithCoinbasesRequest {
         new_template: Some(block_template),
         coinbases: vec![

--- a/integration_tests/tests/steps/node_steps.rs
+++ b/integration_tests/tests/steps/node_steps.rs
@@ -1019,19 +1019,17 @@ async fn generate_block_as_single_request_with_zero_coinbase(world: &mut TariWor
             pow_algo: PowAlgos::Sha3x.into(),
         }),
         max_weight: 0,
-        coinbases: vec![
-            NewBlockCoinbase {
-                address: TariAddress::from_base58(
-                    "f4L8GRWsXqz26DM3qAGErLtVknYzmTe2fYP2yKFn4biFXYJMP61W9MeD726QJ7ytWhRGyewTZzTzjZ7tEPskDptwRub",
-                )
-                .unwrap()
-                .to_base58(),
-                value: 0,
-                stealth_payment: false,
-                revealed_value_proof: true,
-                coinbase_extra: Vec::new(),
-            }
-        ],
+        coinbases: vec![NewBlockCoinbase {
+            address: TariAddress::from_base58(
+                "f4L8GRWsXqz26DM3qAGErLtVknYzmTe2fYP2yKFn4biFXYJMP61W9MeD726QJ7ytWhRGyewTZzTzjZ7tEPskDptwRub",
+            )
+            .unwrap()
+            .to_base58(),
+            value: 0,
+            stealth_payment: false,
+            revealed_value_proof: true,
+            coinbase_extra: Vec::new(),
+        }],
     };
     let new_block = client
         .get_new_block_template_with_coinbases(template_req)
@@ -1059,8 +1057,10 @@ async fn generate_block_as_single_request_with_zero_coinbase(world: &mut TariWor
 
     // Verify that the zero coinbase was automatically set to the full block reward
     let coinbase_output = body.outputs().iter().find(|o| o.is_coinbase()).unwrap();
-    assert!(coinbase_output.minimum_value_promise.as_u64() > 0, 
-        "Zero coinbase should have been automatically set to block reward");
+    assert!(
+        coinbase_output.minimum_value_promise.as_u64() > 0,
+        "Zero coinbase should have been automatically set to block reward"
+    );
 
     match client.submit_block(new_block).await {
         Ok(_) => (),
@@ -1084,19 +1084,17 @@ async fn generate_block_with_zero_coinbase(world: &mut TariWorld, node: String) 
     let block_template = template_response.new_block_template.clone().unwrap();
     let request = GetNewBlockWithCoinbasesRequest {
         new_template: Some(block_template),
-        coinbases: vec![
-            NewBlockCoinbase {
-                address: TariAddress::from_base58(
-                    "f4L8GRWsXqz26DM3qAGErLtVknYzmTe2fYP2yKFn4biFXYJMP61W9MeD726QJ7ytWhRGyewTZzTzjZ7tEPskDptwRub",
-                )
-                .unwrap()
-                .to_base58(),
-                value: 0,
-                stealth_payment: false,
-                revealed_value_proof: true,
-                coinbase_extra: Vec::new(),
-            }
-        ],
+        coinbases: vec![NewBlockCoinbase {
+            address: TariAddress::from_base58(
+                "f4L8GRWsXqz26DM3qAGErLtVknYzmTe2fYP2yKFn4biFXYJMP61W9MeD726QJ7ytWhRGyewTZzTzjZ7tEPskDptwRub",
+            )
+            .unwrap()
+            .to_base58(),
+            value: 0,
+            stealth_payment: false,
+            revealed_value_proof: true,
+            coinbase_extra: Vec::new(),
+        }],
     };
 
     let new_block = client.get_new_block_with_coinbases(request).await.unwrap().into_inner();
@@ -1120,8 +1118,10 @@ async fn generate_block_with_zero_coinbase(world: &mut TariWorld, node: String) 
 
     // Verify that the zero coinbase was automatically set to the full block reward
     let coinbase_output = body.outputs().iter().find(|o| o.is_coinbase()).unwrap();
-    assert!(coinbase_output.minimum_value_promise.as_u64() > 0, 
-        "Zero coinbase should have been automatically set to block reward");
+    assert!(
+        coinbase_output.minimum_value_promise.as_u64() > 0,
+        "Zero coinbase should have been automatically set to block reward"
+    );
 
     match client.submit_block(new_block).await {
         Ok(_) => (),

--- a/integration_tests/tests/steps/node_steps.rs
+++ b/integration_tests/tests/steps/node_steps.rs
@@ -1057,6 +1057,11 @@ async fn generate_block_as_single_request_with_zero_coinbase(world: &mut TariWor
     assert_eq!(coinbase_kernel_count, 1);
     assert_eq!(coinbase_utxo_count, 1);
 
+    // Verify that the zero coinbase was automatically set to the full block reward
+    let coinbase_output = body.outputs().iter().find(|o| o.is_coinbase()).unwrap();
+    assert!(coinbase_output.minimum_value_promise.as_u64() > 0, 
+        "Zero coinbase should have been automatically set to block reward");
+
     match client.submit_block(new_block).await {
         Ok(_) => (),
         Err(e) => panic!("The block should have been valid, {}", e),
@@ -1112,6 +1117,11 @@ async fn generate_block_with_zero_coinbase(world: &mut TariWorld, node: String) 
     }
     assert_eq!(coinbase_kernel_count, 1);
     assert_eq!(coinbase_utxo_count, 1);
+
+    // Verify that the zero coinbase was automatically set to the full block reward
+    let coinbase_output = body.outputs().iter().find(|o| o.is_coinbase()).unwrap();
+    assert!(coinbase_output.minimum_value_promise.as_u64() > 0, 
+        "Zero coinbase should have been automatically set to block reward");
 
     match client.submit_block(new_block).await {
         Ok(_) => (),

--- a/integration_tests/tests/steps/node_steps.rs
+++ b/integration_tests/tests/steps/node_steps.rs
@@ -1010,6 +1010,117 @@ async fn generate_block_with_2_as_single_request_coinbases(world: &mut TariWorld
     }
 }
 
+#[then(expr = "generate a block with zero value coinbase as a single request from node {word}")]
+async fn generate_block_as_single_request_with_zero_coinbase(world: &mut TariWorld, node: String) {
+    let mut client = world.get_node_client(&node).await.unwrap();
+
+    let template_req = GetNewBlockTemplateWithCoinbasesRequest {
+        algo: Some(PowAlgo {
+            pow_algo: PowAlgos::Sha3x.into(),
+        }),
+        max_weight: 0,
+        coinbases: vec![
+            NewBlockCoinbase {
+                address: TariAddress::from_base58(
+                    "f4L8GRWsXqz26DM3qAGErLtVknYzmTe2fYP2yKFn4biFXYJMP61W9MeD726QJ7ytWhRGyewTZzTzjZ7tEPskDptwRub",
+                )
+                .unwrap()
+                .to_base58(),
+                value: 0,
+                stealth_payment: false,
+                revealed_value_proof: true,
+                coinbase_extra: Vec::new(),
+            }
+        ],
+    };
+    let new_block = client
+        .get_new_block_template_with_coinbases(template_req)
+        .await
+        .unwrap()
+        .into_inner();
+
+    let new_block = new_block.block.unwrap();
+    let mut coinbase_kernel_count = 0;
+    let mut coinbase_utxo_count = 0;
+    let body: AggregateBody = new_block.body.clone().unwrap().try_into().unwrap();
+    for kernel in body.kernels() {
+        if kernel.is_coinbase() {
+            coinbase_kernel_count += 1;
+        }
+    }
+    println!("{}", body);
+    for utxo in body.outputs() {
+        if utxo.is_coinbase() {
+            coinbase_utxo_count += 1;
+        }
+    }
+    assert_eq!(coinbase_kernel_count, 1);
+    assert_eq!(coinbase_utxo_count, 1);
+
+    match client.submit_block(new_block).await {
+        Ok(_) => (),
+        Err(e) => panic!("The block should have been valid, {}", e),
+    }
+}
+
+#[then(expr = "generate a block with zero value coinbase from node {word}")]
+async fn generate_block_with_zero_coinbase(world: &mut TariWorld, node: String) {
+    let mut client = world.get_node_client(&node).await.unwrap();
+
+    let template_req = NewBlockTemplateRequest {
+        algo: Some(PowAlgo {
+            pow_algo: PowAlgos::Sha3x.into(),
+        }),
+        max_weight: 0,
+    };
+
+    let template_response = client.get_new_block_template(template_req).await.unwrap().into_inner();
+
+    let block_template = template_response.new_block_template.clone().unwrap();
+    let miner_data = template_response.miner_data.unwrap();
+    let amount = miner_data.reward + miner_data.total_fees;
+    let request = GetNewBlockWithCoinbasesRequest {
+        new_template: Some(block_template),
+        coinbases: vec![
+            NewBlockCoinbase {
+                address: TariAddress::from_base58(
+                    "f4L8GRWsXqz26DM3qAGErLtVknYzmTe2fYP2yKFn4biFXYJMP61W9MeD726QJ7ytWhRGyewTZzTzjZ7tEPskDptwRub",
+                )
+                .unwrap()
+                .to_base58(),
+                value: 0,
+                stealth_payment: false,
+                revealed_value_proof: true,
+                coinbase_extra: Vec::new(),
+            }
+        ],
+    };
+
+    let new_block = client.get_new_block_with_coinbases(request).await.unwrap().into_inner();
+
+    let new_block = new_block.block.unwrap();
+    let mut coinbase_kernel_count = 0;
+    let mut coinbase_utxo_count = 0;
+    let body: AggregateBody = new_block.body.clone().unwrap().try_into().unwrap();
+    for kernel in body.kernels() {
+        if kernel.is_coinbase() {
+            coinbase_kernel_count += 1;
+        }
+    }
+    for utxo in body.outputs() {
+        if utxo.is_coinbase() {
+            coinbase_utxo_count += 1;
+        }
+    }
+    assert_eq!(coinbase_kernel_count, 1);
+    assert_eq!(coinbase_utxo_count, 1);
+
+    match client.submit_block(new_block).await {
+        Ok(_) => (),
+        Err(e) => panic!("The block should have been valid, {}", e),
+    }
+}
+
 #[when(expr = "I have a lagging delayed node {word} connected to node {word} with \
                blocks_behind_before_considered_lagging {int}")]
 async fn lagging_delayed_node(world: &mut TariWorld, delayed_node: String, node: String, delay: u64) {


### PR DESCRIPTION
Description
---
This adds way to auto use correct (max) coinbase value in case you pass single coinbase with zero value.

Motivation and Context
---
This is hard to guess correct coinbase value to pass its check in GetNewBlockWithCoinbases and GetNewBlockTemplateWithCoinbases GRPC methods.

How Has This Been Tested?
---
Tested as part of RandomX-T pool implementation. Will add new integration tests to this PR but I was not able to run them locally since I can't find seed node setup environment.

What process can a PR reviewer use to test or verify this change?
---
Run new integration scenario: Verify gprc can create block with zero value coinbase

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of blocks with a single zero-value coinbase, ensuring it is assigned a minimal or full block reward as appropriate.
- **Tests**
  - Added integration tests to verify processing and submission of blocks containing a single zero-value coinbase output.
  - Introduced a test scenario validating block creation with a zero-value coinbase via the gRPC interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->