### PR TITLE
feat!: improve grpc token supply

### DIFF
--- a/applications/minotari_app_grpc/proto/base_node.proto
+++ b/applications/minotari_app_grpc/proto/base_node.proto
@@ -237,13 +237,24 @@ message NetworkDifficultyResponse {
 
 // A generic single value response for a specific height
 message ValueAtHeightResponse {
-    // uint64 circulating_supply = 1;    // No longer used
+    // This is the total circulating token supply up to date ('mined_rewards + spendable_pre_mine').
+    uint64 circulating_supply = 1;
     // uint64 spendable_supply = 2;      // No longer used
+    // This is the block height the values are valid for.
     uint64 height = 3;
+    // This is the total mined rewards up to date, including time locked coinbase rewards that is not spendable.
     uint64 mined_rewards = 4;
+    // This is the total spendable minded rewards up to date, which excludes all coinbase rewards that is
+    // still time locked.
     uint64 spendable_rewards = 5;
+    // This is the total spendable pre-mine tokens released up to date, i.e. not time-locked anymore.
     uint64 spendable_pre_mine = 6;
+    // This is the total spendable token supply up to date ('spendable_rewards + spendable_pre_mine').
     uint64 total_spendable = 7;
+    // This is the total pre-mine tokens in the genesis block, time-locked and not time-locked.
+    uint64 total_pre_mine = 8;
+    // This is the total pre-mine tokens that are still time-locked up to date (`total_pre_mine - spendable_pre_mine`).
+    uint64 time_locked_pre_mine = 9;
 }
 
 // A generic uint value

--- a/applications/minotari_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/minotari_node/src/grpc/base_node_grpc_server.rs
@@ -2368,17 +2368,23 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
                     .clone()
                     .into_iter()
                     .map(|height| {
+                        let circulating_supply = consensus_manager.total_tokens_circulating_at_height(height)?.into();
                         let mined_rewards = consensus_manager.block_rewards_mined_at_height(height)?.into();
                         let spendable_rewards = consensus_manager.block_rewards_spendable_at_height(height)?.into();
                         let spendable_pre_mine = consensus_manager.pre_mine_spendable_at_height(height)?.into();
                         let total_spendable = consensus_manager.total_tokens_spendable_at_height(height)?.into();
+                        let total_pre_mine = consensus_manager.total_pre_mine_in_genesis_block().into();
+                        let time_locked_pre_mine = consensus_manager.time_locked_pre_mine(height)?.into();
 
                         Ok(tari_rpc::ValueAtHeightResponse {
+                            circulating_supply,
                             height,
                             mined_rewards,
                             spendable_rewards,
                             spendable_pre_mine,
                             total_spendable,
+                            total_pre_mine,
+                            time_locked_pre_mine,
                         })
                     })
                     .collect::<Result<Vec<tari_rpc::ValueAtHeightResponse>, String>>();

--- a/base_layer/core/src/consensus/consensus_manager.rs
+++ b/base_layer/core/src/consensus/consensus_manager.rs
@@ -196,10 +196,31 @@ impl ConsensusManager {
             .ok_or_else(|| "total_tokens_spendable_at_height overflowed u128".to_string())
     }
 
+    /// Get the total circulating block rewards and spendable pre-mine at the specified height
+    #[cfg(feature = "base_node")]
+    pub fn total_tokens_circulating_at_height(&self, height: u64) -> Result<MicroMinotari, String> {
+        let mined_rewards = self.block_rewards_mined_at_height(height)?;
+        let spendable_pre_mine = self.pre_mine_spendable_at_height(height)?;
+        mined_rewards
+            .checked_add(spendable_pre_mine)
+            .ok_or_else(|| "total_circulating_tokens_at_height overflowed u128".to_string())
+    }
+
     /// Get the total spendable pre-mine at the specified height
     #[cfg(feature = "base_node")]
     pub fn pre_mine_spendable_at_height(&self, height: u64) -> Result<MicroMinotari, String> {
         pre_mine_spendable_at_height(height, self.network().as_network())
+    }
+
+    /// Get the total spendable pre-mine at the specified height
+    pub fn total_pre_mine_in_genesis_block(&self) -> MicroMinotari {
+        self.consensus_constants(0).pre_mine_value()
+    }
+
+    /// Get the total pre-mine that is still time-locked at the specified height
+    #[cfg(feature = "base_node")]
+    pub fn time_locked_pre_mine(&self, height: u64) -> Result<MicroMinotari, String> {
+        Ok(self.total_pre_mine_in_genesis_block() - self.pre_mine_spendable_at_height(height)?)
     }
 
     /// Get the total mined block rewards at the specified height (excluding pre-mine)
@@ -364,7 +385,7 @@ mod test {
     use std::str::FromStr;
 
     use super::*;
-    use crate::blocks::pre_mine::BLOCKS_PER_DAY;
+    use crate::{blocks::pre_mine::BLOCKS_PER_DAY, consensus::consensus_constants::MAINNET_PRE_MINE_VALUE};
 
     #[test]
     fn test_supply_at_block() {
@@ -428,15 +449,26 @@ mod test {
                 MicroMinotari::from_str("7716495870.271662 T"), // total
             ),
         ] {
+            let mined = mined.unwrap();
+            let spendable = spendable.unwrap();
+            let pre_mine = pre_mine.unwrap();
+            let total = total.unwrap();
+
             let mined_rewards = consensus_manager.block_rewards_mined_at_height(height).unwrap();
             let spendable_rewards = consensus_manager.block_rewards_spendable_at_height(height).unwrap();
             let total_spendable = consensus_manager.total_tokens_spendable_at_height(height).unwrap();
             let pre_mine_spendable = consensus_manager.pre_mine_spendable_at_height(height).unwrap();
+            let circulating_supply = consensus_manager.total_tokens_circulating_at_height(height).unwrap();
+            let total_pre_mine = consensus_manager.total_pre_mine_in_genesis_block();
+            let time_locked_pre_mine = consensus_manager.time_locked_pre_mine(height).unwrap();
 
-            assert_eq!(mined_rewards, mined.unwrap());
-            assert_eq!(spendable_rewards, spendable.unwrap());
-            assert_eq!(pre_mine_spendable, pre_mine.unwrap());
-            assert_eq!(total_spendable, total.unwrap());
+            assert_eq!(mined_rewards, mined);
+            assert_eq!(spendable_rewards, spendable);
+            assert_eq!(pre_mine_spendable, pre_mine);
+            assert_eq!(total_spendable, total);
+            assert_eq!(circulating_supply, mined + pre_mine);
+            assert_eq!(total_pre_mine, MAINNET_PRE_MINE_VALUE);
+            assert_eq!(time_locked_pre_mine, MAINNET_PRE_MINE_VALUE - pre_mine);
         }
     }
 }


### PR DESCRIPTION
Description
---
Improved the gRPC token supply request in that `circulating_supply`, `total_pre_mine` and `time_locked_pre_mine` are also added to the return values:
- `circulating_supply = mined_rewards + spendable_pre_mine`
- `total_pre_mine = ` total pre-mine tokens in the genesis block as per consensus constants, time-locked and not time-locked
- `time_locked_pre_mine = total_pre_mine - spendable_pre_mine`

Motivation and Context
---
Some pertinent information about token supply was missing from the query (`total_pre_mine ` and `time_locked_pre_mine`), or left to the user to deduce from the provided values (`circulating_supply`).

How Has This Been Tested?
---
- Expanded the related unit test.
- System-level testing with gRPC client

What process can a PR reviewer use to test or verify this change?
---
- Code review
- System-level testing

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [ ] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [X] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
BREAKING CHANGE: New return parameters are added to the `GetTokensInCirculation` gRPC method - all existing parameters remain unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded blockchain supply metrics with detailed breakdowns, including circulating supply, mined rewards, spendable and time-locked pre-mine, and total pre-mine values at any block height.
  - Enhanced API responses to provide clearer and more granular information about token distribution and availability.

- **Documentation**
  - Improved field descriptions for supply and reward metrics to aid user understanding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->