### PR TITLE
fix!: payref migration and indexes, add grpc query via output hash

### DIFF
--- a/applications/minotari_app_grpc/proto/base_node.proto
+++ b/applications/minotari_app_grpc/proto/base_node.proto
@@ -600,7 +600,7 @@ message PaymentReferenceResponse {
     bytes block_hash = 3;
     // Timestamp when the output was mined
     uint64 mined_timestamp = 4;
-    // Output commitment (32 bytes) - will be empty if output was spent as we do not track this for spent outputs
+    // Output commitment (32 bytes)
     bytes commitment = 5;
     // Whether this output has been spent
     bool is_spent = 6;

--- a/applications/minotari_app_grpc/proto/base_node.proto
+++ b/applications/minotari_app_grpc/proto/base_node.proto
@@ -598,7 +598,7 @@ message PaymentReferenceResponse {
     uint64 block_height = 2;
     // Block hash where the output was mined
     bytes block_hash = 3;
-    // Timestamp when the output was mined - will be 0 for spent outputs as it is not applicable
+    // Timestamp when the output was mined
     uint64 mined_timestamp = 4;
     // Output commitment (32 bytes) - will be empty if output was spent as we do not track this for spent outputs
     bytes commitment = 5;

--- a/applications/minotari_app_grpc/proto/base_node.proto
+++ b/applications/minotari_app_grpc/proto/base_node.proto
@@ -594,23 +594,23 @@ message SearchPaymentReferencesRequest {
 message PaymentReferenceResponse {
     // The payment reference that was found
     string payment_reference_hex = 1;
-    // Block height where the output was mined - will be 0 for spent outputs
+    // Block height where the output was mined - will be 0 for spent outputs as it is not applicable
     uint64 block_height = 2;
-    // Block hash where the output was mined - will be empty for spent outputs
+    // Block hash where the output was mined - will be empty for spent outputs as it is not applicable
     bytes block_hash = 3;
-    // Timestamp when the output was mined - will be 0 for spent outputs
+    // Timestamp when the output was mined - will be 0 for spent outputs as it is not applicable
     uint64 mined_timestamp = 4;
-    // Output commitment (32 bytes) - will be empty if output was spent
+    // Output commitment (32 bytes) - will be empty if output was spent as we do not track this for spent outputs
     bytes commitment = 5;
     // Whether this output has been spent
     bool is_spent = 6;
-    // Height where output was spent - will be 0 for unspent outputs
+    // Height where output was spent - will be 0 for unspent outputs as it is not applicable
     uint64 spent_height = 7;
     // Block hash where output was spent - will be empty for unspent outputs
     bytes spent_block_hash = 8;
-    // Minimum value promise - will be 0 for spent outputs
+    // Minimum value promise - will be 0 for spent outputs as we do not track this for spent outputs
     uint64 min_value_promise = 9;
-    // Timestamp when the output was spent - will be 0 for unspent outputs
+    // Timestamp when the output was spent - will be 0 for unspent outputs as it is not applicable
     uint64 spent_timestamp = 10;
     // Output hash of the output
     bytes output_hash = 11;

--- a/applications/minotari_app_grpc/proto/base_node.proto
+++ b/applications/minotari_app_grpc/proto/base_node.proto
@@ -594,7 +594,7 @@ message SearchPaymentReferencesRequest {
 message PaymentReferenceResponse {
     // The payment reference that was found
     string payment_reference_hex = 1;
-    // Block height where the output was mined - will be 0 for spent outputs as it is not applicable
+    // Block height where the output was mined
     uint64 block_height = 2;
     // Block hash where the output was mined - will be empty for spent outputs as it is not applicable
     bytes block_hash = 3;

--- a/applications/minotari_app_grpc/proto/base_node.proto
+++ b/applications/minotari_app_grpc/proto/base_node.proto
@@ -596,7 +596,7 @@ message PaymentReferenceResponse {
     string payment_reference_hex = 1;
     // Block height where the output was mined
     uint64 block_height = 2;
-    // Block hash where the output was mined - will be empty for spent outputs as it is not applicable
+    // Block hash where the output was mined
     bytes block_hash = 3;
     // Timestamp when the output was mined - will be 0 for spent outputs as it is not applicable
     uint64 mined_timestamp = 4;

--- a/applications/minotari_app_grpc/proto/base_node.proto
+++ b/applications/minotari_app_grpc/proto/base_node.proto
@@ -608,7 +608,7 @@ message PaymentReferenceResponse {
     uint64 spent_height = 7;
     // Block hash where output was spent - will be empty for unspent outputs
     bytes spent_block_hash = 8;
-    // Minimum value promise - will be 0 for spent outputs as we do not track this for spent outputs
+    // Minimum value promise
     uint64 min_value_promise = 9;
     // Timestamp when the output was spent - will be 0 for unspent outputs as it is not applicable
     uint64 spent_timestamp = 10;

--- a/applications/minotari_app_grpc/proto/base_node.proto
+++ b/applications/minotari_app_grpc/proto/base_node.proto
@@ -102,6 +102,9 @@ service BaseNode {
     rpc GetNetworkState(GetNetworkStateRequest) returns (GetNetworkStateResponse);
     // PayRef (Payment Reference) lookup for block explorers and external services
     rpc SearchPaymentReferences(SearchPaymentReferencesRequest) returns (stream PaymentReferenceResponse);
+    // PayRef (Payment Reference) lookup for block explorers and external services via output hash
+    rpc SearchPaymentReferencesViaOutputHash(FetchMatchingUtxosRequest) returns (stream PaymentReferenceResponse);
+
 }
 
 message GetAssetMetadataRequest {
@@ -591,20 +594,22 @@ message SearchPaymentReferencesRequest {
 message PaymentReferenceResponse {
     // The payment reference that was found
     string payment_reference_hex = 1;
-    // Block height where the output was mined
+    // Block height where the output was mined - will be 0 for spent outputs
     uint64 block_height = 2;
-    // Block hash where the output was mined
+    // Block hash where the output was mined - will be empty for spent outputs
     bytes block_hash = 3;
-    // Timestamp when the output was mined
+    // Timestamp when the output was mined - will be 0 for spent outputs
     uint64 mined_timestamp = 4;
-    // Output commitment (32 bytes)
+    // Output commitment (32 bytes) - will be empty if output was spent
     bytes commitment = 5;
     // Whether this output has been spent
     bool is_spent = 6;
-    // Height where output was spent (if spent)
+    // Height where output was spent - will be 0 for unspent outputs
     uint64 spent_height = 7;
-    // Block hash where output was spent (if spent)
+    // Block hash where output was spent - will be empty for unspent outputs
     bytes spent_block_hash = 8;
-    // Transaction output amount will be 0 for non set a
+    // Minimum value promise - will be 0 for spent outputs
     uint64 min_value_promise = 9;
+    // Timestamp when the output was spent - will be 0 for unspent outputs
+    uint64 spent_timestamp = 10;
 }

--- a/applications/minotari_app_grpc/proto/base_node.proto
+++ b/applications/minotari_app_grpc/proto/base_node.proto
@@ -612,4 +612,6 @@ message PaymentReferenceResponse {
     uint64 min_value_promise = 9;
     // Timestamp when the output was spent - will be 0 for unspent outputs
     uint64 spent_timestamp = 10;
+    // Output hash of the output
+    bytes output_hash = 11;
 }

--- a/applications/minotari_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/minotari_node/src/grpc/base_node_grpc_server.rs
@@ -3058,7 +3058,7 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
 
         trace!(
             target: LOG_TARGET,
-            "Sending FindMatchingUtxos response stream to client"
+            "Sending SearchPaymentReferencesViaOutputHash response stream to client"
         );
         Ok(Response::new(rx))
     }

--- a/applications/minotari_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/minotari_node/src/grpc/base_node_grpc_server.rs
@@ -38,6 +38,7 @@ use minotari_app_grpc::{
 use minotari_app_utilities::consts;
 use tari_common_types::{
     key_branches::TransactionKeyManagerBranch,
+    payment_reference::generate_payment_reference,
     tari_address::TariAddress,
     types::{
         CompressedCommitment,
@@ -59,7 +60,7 @@ use tari_core::{
         StateMachineHandle,
     },
     blocks::{Block, BlockHeader, NewBlockTemplate},
-    chain_storage::ChainStorageError,
+    chain_storage::{ChainStorageError, MinedInfo},
     consensus::{ConsensusManager, NetworkConsensus},
     iterators::NonOverlappingIntegerPairIter,
     mempool::{service::LocalMempoolService, TxStorageResponse},
@@ -236,6 +237,8 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
     type ListHeadersStream = mpsc::Receiver<Result<tari_rpc::BlockHeaderResponse, Status>>;
     type SearchKernelsStream = mpsc::Receiver<Result<tari_rpc::HistoricalBlock, Status>>;
     type SearchPaymentReferencesStream = mpsc::Receiver<Result<tari_rpc::PaymentReferenceResponse, Status>>;
+    type SearchPaymentReferencesViaOutputHashStream =
+        mpsc::Receiver<Result<tari_rpc::PaymentReferenceResponse, Status>>;
     type SearchUtxosStream = mpsc::Receiver<Result<tari_rpc::HistoricalBlock, Status>>;
 
     #[allow(clippy::too_many_lines)]
@@ -2951,6 +2954,116 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
         Ok(Response::new(rx))
     }
 
+    #[allow(clippy::too_many_lines)]
+    async fn search_payment_references_via_output_hash(
+        &self,
+        request: Request<tari_rpc::FetchMatchingUtxosRequest>,
+    ) -> Result<Response<Self::SearchPaymentReferencesStream>, Status> {
+        self.check_method_enabled(GrpcMethod::SearchPaymentReferencesViaOutputHash)?;
+        let report_error_flag = self.report_error_flag();
+        trace!(target: LOG_TARGET, "Incoming GRPC request for SearchPaymentReferencesViaOutputHash");
+        let request = request.into_inner();
+
+        let hashes = request
+            .hashes
+            .into_iter()
+            .map(|s| s.try_into())
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| {
+                obscure_error_if_true(
+                    report_error_flag,
+                    Status::invalid_argument(format!("Invalid hashes provided '{}'", e)),
+                )
+            })?;
+
+        let mut node_service = self.node_service.clone();
+
+        let (mut tx, rx) = mpsc::channel(GET_BLOCKS_PAGE_SIZE);
+        task::spawn(async move {
+            for output_hash in &hashes {
+                match node_service.fetch_mined_info_by_output_hash(output_hash).await {
+                    Ok(MinedInfo {
+                        output: Some(output_info),
+                        ..
+                    }) => {
+                        let response = tari_rpc::PaymentReferenceResponse {
+                            payment_reference_hex: generate_payment_reference(
+                                &output_info.header_hash,
+                                &output_info.output.hash(),
+                            )
+                            .to_hex(),
+                            block_height: output_info.mined_height,
+                            block_hash: output_info.header_hash.to_vec(),
+                            mined_timestamp: output_info.mined_timestamp,
+                            commitment: output_info.output.commitment.to_vec(),
+                            is_spent: false,
+                            spent_height: 0,
+                            spent_block_hash: vec![],
+                            min_value_promise: output_info.output.minimum_value_promise.as_u64(),
+                            spent_timestamp: 0,
+                        };
+
+                        if tx.send(Ok(response)).await.is_err() {
+                            return;
+                        }
+                    },
+                    Ok(MinedInfo {
+                        input: Some(input_info),
+                        ..
+                    }) => match node_service.fetch_payref_by_output_hash(output_hash).await {
+                        Ok(Some(payref)) => {
+                            let response = tari_rpc::PaymentReferenceResponse {
+                                payment_reference_hex: payref.to_hex(),
+                                block_height: 0,
+                                block_hash: vec![],
+                                mined_timestamp: 0,
+                                commitment: vec![],
+                                is_spent: true,
+                                spent_height: input_info.spent_height,
+                                spent_block_hash: input_info.header_hash.to_vec(),
+                                min_value_promise: 0,
+                                spent_timestamp: input_info.spent_timestamp,
+                            };
+
+                            if tx.send(Ok(response)).await.is_err() {
+                                return;
+                            }
+                        },
+                        Ok(None) => {},
+                        Err(err) => {
+                            let _ignore = tx.send(Err(obscure_error_if_true(
+                                report_error_flag,
+                                Status::internal(format!("Error communicating with local base node: {}", err)),
+                            )));
+                            return;
+                        },
+                    },
+                    Ok(_) => {
+                        // mined info not found - no error, just no results for this output hash
+                        continue;
+                    },
+                    Err(e) => {
+                        warn!(target: LOG_TARGET, "Error looking up mined info via output hash {}: {}", output_hash, e);
+                        let error = obscure_error_if_true(
+                            report_error_flag,
+                            Status::internal(format!("Mined info via output hash  lookup error: {}", e)),
+                        );
+                        if tx.send(Err(error)).await.is_err() {
+                            break;
+                        }
+                    },
+                }
+            }
+        });
+
+        trace!(
+            target: LOG_TARGET,
+            "Sending FindMatchingUtxos response stream to client"
+        );
+        Ok(Response::new(rx))
+    }
+
+    #[allow(clippy::too_many_lines)]
     async fn search_payment_references(
         &self,
         request: Request<tari_rpc::SearchPaymentReferencesRequest>,
@@ -3016,36 +3129,50 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
                 payrefs.push(payref_fixed_hash);
             }
             for payref in payrefs {
-                match node_service.fetch_output_by_payref(&payref).await {
-                    Ok(Some(output_info)) => {
-                        // Check if output is spent
-                        let output_hash = output_info.output.hash();
-                        let (is_spent, spent_height, spent_block_hash) = match node_service
-                            .check_output_spent_status(output_hash)
-                            .await
-                        {
-                            Ok(Some(input_info)) => (true, input_info.spent_height, input_info.header_hash.to_vec()),
-                            Ok(None) => (false, 0, vec![]),
-                            Err(_) => (false, 0, vec![]), // Default to not spent on error
-                        };
-
+                match node_service.fetch_mined_info_by_payref(&payref).await {
+                    Ok(MinedInfo {
+                        output: Some(output_info),
+                        ..
+                    }) => {
                         let response = tari_rpc::PaymentReferenceResponse {
                             payment_reference_hex: payref.to_hex(),
                             block_height: output_info.mined_height,
                             block_hash: output_info.header_hash.to_vec(),
                             mined_timestamp: output_info.mined_timestamp,
                             commitment: output_info.output.commitment.to_vec(),
-                            is_spent,
-                            spent_height,
-                            spent_block_hash,
+                            is_spent: false,
+                            spent_height: 0,
+                            spent_block_hash: vec![],
                             min_value_promise: output_info.output.minimum_value_promise.as_u64(),
+                            spent_timestamp: 0,
                         };
 
                         if tx.send(Ok(response)).await.is_err() {
                             return;
                         }
                     },
-                    Ok(None) => {
+                    Ok(MinedInfo {
+                        input: Some(input_info),
+                        ..
+                    }) => {
+                        let response = tari_rpc::PaymentReferenceResponse {
+                            payment_reference_hex: payref.to_hex(),
+                            block_height: 0,
+                            block_hash: vec![],
+                            mined_timestamp: 0,
+                            commitment: vec![],
+                            is_spent: true,
+                            spent_height: input_info.spent_height,
+                            spent_block_hash: input_info.header_hash.to_vec(),
+                            min_value_promise: 0,
+                            spent_timestamp: input_info.spent_timestamp,
+                        };
+
+                        if tx.send(Ok(response)).await.is_err() {
+                            return;
+                        }
+                    },
+                    Ok(_) => {
                         // PayRef not found - no error, just no results for this PayRef
                         continue;
                     },

--- a/applications/minotari_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/minotari_node/src/grpc/base_node_grpc_server.rs
@@ -60,7 +60,7 @@ use tari_core::{
         StateMachineHandle,
     },
     blocks::{Block, BlockHeader, NewBlockTemplate},
-    chain_storage::{ChainStorageError, MinedInfo},
+    chain_storage::ChainStorageError,
     consensus::{ConsensusManager, NetworkConsensus},
     iterators::NonOverlappingIntegerPairIter,
     mempool::{service::LocalMempoolService, TxStorageResponse},
@@ -2961,8 +2961,12 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
     ) -> Result<Response<Self::SearchPaymentReferencesStream>, Status> {
         self.check_method_enabled(GrpcMethod::SearchPaymentReferencesViaOutputHash)?;
         let report_error_flag = self.report_error_flag();
-        trace!(target: LOG_TARGET, "Incoming GRPC request for SearchPaymentReferencesViaOutputHash");
         let request = request.into_inner();
+        trace!(
+            target: LOG_TARGET,
+            "Incoming GRPC request for SearchPaymentReferencesViaOutputHash: {} hashes",
+            request.hashes.len()
+        );
 
         let hashes = request
             .hashes
@@ -2981,66 +2985,40 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
         let (mut tx, rx) = mpsc::channel(GET_BLOCKS_PAGE_SIZE);
         task::spawn(async move {
             for output_hash in &hashes {
+                let mut response = tari_rpc::PaymentReferenceResponse::default();
                 match node_service.fetch_mined_info_by_output_hash(output_hash).await {
-                    Ok(MinedInfo {
-                        output: Some(output_info),
-                        ..
-                    }) => {
-                        let response = tari_rpc::PaymentReferenceResponse {
-                            payment_reference_hex: generate_payment_reference(
-                                &output_info.header_hash,
-                                &output_info.output.hash(),
-                            )
-                            .to_hex(),
-                            block_height: output_info.mined_height,
-                            block_hash: output_info.header_hash.to_vec(),
-                            mined_timestamp: output_info.mined_timestamp,
-                            commitment: output_info.output.commitment.to_vec(),
-                            is_spent: false,
-                            spent_height: 0,
-                            spent_block_hash: vec![],
-                            min_value_promise: output_info.output.minimum_value_promise.as_u64(),
-                            spent_timestamp: 0,
-                        };
-
-                        if tx.send(Ok(response)).await.is_err() {
-                            return;
+                    Ok(mined_info) => {
+                        let has_output = mined_info.output.is_some();
+                        let has_input = mined_info.input.is_some();
+                        if let Some(output_info) = mined_info.output {
+                            response.payment_reference_hex =
+                                generate_payment_reference(&output_info.header_hash, output_hash).to_hex();
+                            response.block_height = output_info.mined_height;
+                            response.block_hash = output_info.header_hash.to_vec();
+                            response.mined_timestamp = output_info.mined_timestamp;
+                            response.commitment = output_info.output.commitment.to_vec();
+                            response.min_value_promise = output_info.output.minimum_value_promise.as_u64();
+                            response.output_hash = output_info.output.hash().to_vec();
                         }
-                    },
-                    Ok(MinedInfo {
-                        input: Some(input_info),
-                        ..
-                    }) => match node_service.fetch_payref_by_output_hash(output_hash).await {
-                        Ok(Some(payref)) => {
-                            let response = tari_rpc::PaymentReferenceResponse {
-                                payment_reference_hex: payref.to_hex(),
-                                block_height: 0,
-                                block_hash: vec![],
-                                mined_timestamp: 0,
-                                commitment: vec![],
-                                is_spent: true,
-                                spent_height: input_info.spent_height,
-                                spent_block_hash: input_info.header_hash.to_vec(),
-                                min_value_promise: 0,
-                                spent_timestamp: input_info.spent_timestamp,
-                            };
-
+                        if let Some(input_info) = mined_info.input {
+                            response.is_spent = true;
+                            response.spent_height = input_info.spent_height;
+                            response.spent_block_hash = input_info.header_hash.to_vec();
+                            response.spent_timestamp = input_info.spent_timestamp;
+                            if response.output_hash.is_empty() {
+                                response.output_hash = input_info.input.output_hash().to_vec();
+                            }
+                        }
+                        if has_output || has_input {
+                            trace!(
+                                target: LOG_TARGET,
+                                "GRPC request SearchPaymentReferencesViaOutputHash for {} found",
+                                output_hash
+                            );
                             if tx.send(Ok(response)).await.is_err() {
                                 return;
                             }
-                        },
-                        Ok(None) => {},
-                        Err(err) => {
-                            let _ignore = tx.send(Err(obscure_error_if_true(
-                                report_error_flag,
-                                Status::internal(format!("Error communicating with local base node: {}", err)),
-                            )));
-                            return;
-                        },
-                    },
-                    Ok(_) => {
-                        // mined info not found - no error, just no results for this output hash
-                        continue;
+                        }
                     },
                     Err(e) => {
                         warn!(target: LOG_TARGET, "Error looking up mined info via output hash {}: {}", output_hash, e);
@@ -3129,52 +3107,35 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
                 payrefs.push(payref_fixed_hash);
             }
             for payref in payrefs {
+                let mut response = tari_rpc::PaymentReferenceResponse::default();
                 match node_service.fetch_mined_info_by_payref(&payref).await {
-                    Ok(MinedInfo {
-                        output: Some(output_info),
-                        ..
-                    }) => {
-                        let response = tari_rpc::PaymentReferenceResponse {
-                            payment_reference_hex: payref.to_hex(),
-                            block_height: output_info.mined_height,
-                            block_hash: output_info.header_hash.to_vec(),
-                            mined_timestamp: output_info.mined_timestamp,
-                            commitment: output_info.output.commitment.to_vec(),
-                            is_spent: false,
-                            spent_height: 0,
-                            spent_block_hash: vec![],
-                            min_value_promise: output_info.output.minimum_value_promise.as_u64(),
-                            spent_timestamp: 0,
-                        };
-
-                        if tx.send(Ok(response)).await.is_err() {
-                            return;
+                    Ok(mined_info) => {
+                        let has_output = mined_info.output.is_some();
+                        let has_input = mined_info.input.is_some();
+                        if let Some(output_info) = mined_info.output {
+                            response.payment_reference_hex = payref.to_hex();
+                            response.block_height = output_info.mined_height;
+                            response.block_hash = output_info.header_hash.to_vec();
+                            response.mined_timestamp = output_info.mined_timestamp;
+                            response.commitment = output_info.output.commitment.to_vec();
+                            response.min_value_promise = output_info.output.minimum_value_promise.as_u64();
+                            response.output_hash = output_info.output.hash().to_vec();
                         }
-                    },
-                    Ok(MinedInfo {
-                        input: Some(input_info),
-                        ..
-                    }) => {
-                        let response = tari_rpc::PaymentReferenceResponse {
-                            payment_reference_hex: payref.to_hex(),
-                            block_height: 0,
-                            block_hash: vec![],
-                            mined_timestamp: 0,
-                            commitment: vec![],
-                            is_spent: true,
-                            spent_height: input_info.spent_height,
-                            spent_block_hash: input_info.header_hash.to_vec(),
-                            min_value_promise: 0,
-                            spent_timestamp: input_info.spent_timestamp,
-                        };
-
-                        if tx.send(Ok(response)).await.is_err() {
-                            return;
+                        if let Some(input_info) = mined_info.input {
+                            response.is_spent = true;
+                            response.spent_height = input_info.spent_height;
+                            response.spent_block_hash = input_info.header_hash.to_vec();
+                            response.spent_timestamp = input_info.spent_timestamp;
+                            if response.output_hash.is_empty() {
+                                response.output_hash = input_info.input.output_hash().to_vec();
+                            }
                         }
-                    },
-                    Ok(_) => {
-                        // PayRef not found - no error, just no results for this PayRef
-                        continue;
+                        if has_output || has_input {
+                            trace!(target: LOG_TARGET, "GRPC request SearchPaymentReferences for {} found", payref);
+                            if tx.send(Ok(response)).await.is_err() {
+                                return;
+                            }
+                        }
                     },
                     Err(e) => {
                         warn!(target: LOG_TARGET, "Error looking up PayRef {}: {}", payref, e);

--- a/applications/minotari_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/minotari_node/src/grpc/base_node_grpc_server.rs
@@ -2958,7 +2958,7 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
     async fn search_payment_references_via_output_hash(
         &self,
         request: Request<tari_rpc::FetchMatchingUtxosRequest>,
-    ) -> Result<Response<Self::SearchPaymentReferencesStream>, Status> {
+    ) -> Result<Response<Self::SearchPaymentReferencesViaOutputHashStream>, Status> {
         self.check_method_enabled(GrpcMethod::SearchPaymentReferencesViaOutputHash)?;
         let report_error_flag = self.report_error_flag();
         let request = request.into_inner();

--- a/applications/minotari_node/src/grpc/readiness_grpc_server.rs
+++ b/applications/minotari_node/src/grpc/readiness_grpc_server.rs
@@ -93,6 +93,8 @@ impl tari_rpc::base_node_server::BaseNode for ReadinessGrpcServer {
     type ListHeadersStream = mpsc::Receiver<Result<tari_rpc::BlockHeaderResponse, Status>>;
     type SearchKernelsStream = mpsc::Receiver<Result<tari_rpc::HistoricalBlock, Status>>;
     type SearchPaymentReferencesStream = mpsc::Receiver<Result<tari_rpc::PaymentReferenceResponse, Status>>;
+    type SearchPaymentReferencesViaOutputHashStream =
+        mpsc::Receiver<Result<tari_rpc::PaymentReferenceResponse, Status>>;
     type SearchUtxosStream = mpsc::Receiver<Result<tari_rpc::HistoricalBlock, Status>>;
 
     async fn get_network_state(
@@ -365,6 +367,13 @@ impl tari_rpc::base_node_server::BaseNode for ReadinessGrpcServer {
     async fn search_payment_references(
         &self,
         _request: Request<tari_rpc::SearchPaymentReferencesRequest>,
+    ) -> Result<Response<Self::SearchPaymentReferencesStream>, Status> {
+        return Err(self.get_not_available_status());
+    }
+
+    async fn search_payment_references_via_output_hash(
+        &self,
+        _request: Request<tari_rpc::FetchMatchingUtxosRequest>,
     ) -> Result<Response<Self::SearchPaymentReferencesStream>, Status> {
         return Err(self.get_not_available_status());
     }

--- a/applications/minotari_node/src/grpc_method.rs
+++ b/applications/minotari_node/src/grpc_method.rs
@@ -66,11 +66,12 @@ pub enum GrpcMethod {
     GetTemplateRegistrations,
     GetSideChainUtxos,
     SearchPaymentReferences,
+    SearchPaymentReferencesViaOutputHash,
 }
 
 impl GrpcMethod {
     /// All the GRPC methods as a fixed array
-    pub const ALL_VARIANTS: [GrpcMethod; 37] = [
+    pub const ALL_VARIANTS: [GrpcMethod; 38] = [
         GrpcMethod::ListHeaders,
         GrpcMethod::GetHeaderByHash,
         GrpcMethod::GetBlocks,
@@ -108,11 +109,12 @@ impl GrpcMethod {
         GrpcMethod::GetTemplateRegistrations,
         GrpcMethod::GetSideChainUtxos,
         GrpcMethod::SearchPaymentReferences,
+        GrpcMethod::SearchPaymentReferencesViaOutputHash,
     ];
 }
 
 impl IntoIterator for GrpcMethod {
-    type IntoIter = std::array::IntoIter<GrpcMethod, 37>;
+    type IntoIter = std::array::IntoIter<GrpcMethod, 38>;
     type Item = GrpcMethod;
 
     fn into_iter(self) -> Self::IntoIter {
@@ -164,6 +166,7 @@ impl FromStr for GrpcMethod {
             "get_template_registrations" => Ok(GrpcMethod::GetTemplateRegistrations),
             "get_side_chain_utxos" => Ok(GrpcMethod::GetSideChainUtxos),
             "search_payment_references" => Ok(GrpcMethod::SearchPaymentReferences),
+            "search_payment_references_via_output_hash" => Ok(GrpcMethod::SearchPaymentReferencesViaOutputHash),
             _ => Err(format!("'{}' not supported", s)),
         }
     }
@@ -261,6 +264,7 @@ mod tests {
                 GrpcMethod::GetTemplateRegistrations => count += 1,
                 GrpcMethod::GetSideChainUtxos => count += 1,
                 GrpcMethod::SearchPaymentReferences => count += 1,
+                GrpcMethod::SearchPaymentReferencesViaOutputHash => count += 1,
             }
         }
         assert_eq!(count, GrpcMethod::ALL_VARIANTS.len());

--- a/base_layer/core/src/base_node/comms_interface/comms_request.rs
+++ b/base_layer/core/src/base_node/comms_interface/comms_request.rs
@@ -84,7 +84,10 @@ pub enum NodeCommsRequest {
     FetchUnspentUtxosInBlock {
         block_hash: BlockHash,
     },
-    FetchOutputByPayRef(FixedHash),
+    FetchMinedInfoByPayRef(FixedHash),
+    FetchMinedInfoByOutputHash(HashOutput),
+    FetchPayRefByOutputHash(HashOutput),
+    FetchOutputMinedInfo(HashOutput),
     CheckOutputSpentStatus(HashOutput),
 }
 
@@ -140,8 +143,17 @@ impl Display for NodeCommsRequest {
             FetchUnspentUtxosInBlock { block_hash } => {
                 write!(f, "FetchUnspentUtxosInBlock ({})", block_hash)
             },
-            FetchOutputByPayRef(payref) => {
-                write!(f, "FetchOutputByPayRef ({})", payref.to_hex())
+            FetchMinedInfoByPayRef(payref) => {
+                write!(f, "FetchMinedInfoByPayRef ({})", payref)
+            },
+            FetchMinedInfoByOutputHash(payref) => {
+                write!(f, "FetchMinedInfoByOutputHash ({})", payref)
+            },
+            FetchPayRefByOutputHash(payref) => {
+                write!(f, "FetchPayRefByOutputHash ({})", payref)
+            },
+            FetchOutputMinedInfo(output_hash) => {
+                write!(f, "FetchOutputMinedInfo ({})", output_hash)
             },
             CheckOutputSpentStatus(output_hash) => {
                 write!(f, "CheckOutputSpentStatus ({})", output_hash)

--- a/base_layer/core/src/base_node/comms_interface/comms_request.rs
+++ b/base_layer/core/src/base_node/comms_interface/comms_request.rs
@@ -86,7 +86,6 @@ pub enum NodeCommsRequest {
     },
     FetchMinedInfoByPayRef(FixedHash),
     FetchMinedInfoByOutputHash(HashOutput),
-    FetchPayRefByOutputHash(HashOutput),
     FetchOutputMinedInfo(HashOutput),
     CheckOutputSpentStatus(HashOutput),
 }
@@ -148,9 +147,6 @@ impl Display for NodeCommsRequest {
             },
             FetchMinedInfoByOutputHash(payref) => {
                 write!(f, "FetchMinedInfoByOutputHash ({})", payref)
-            },
-            FetchPayRefByOutputHash(payref) => {
-                write!(f, "FetchPayRefByOutputHash ({})", payref)
             },
             FetchOutputMinedInfo(output_hash) => {
                 write!(f, "FetchOutputMinedInfo ({})", output_hash)

--- a/base_layer/core/src/base_node/comms_interface/comms_response.rs
+++ b/base_layer/core/src/base_node/comms_interface/comms_response.rs
@@ -27,12 +27,12 @@ use std::{
 
 use tari_common_types::{
     chain_metadata::ChainMetadata,
-    types::{CompressedPublicKey, HashOutput, PrivateKey},
+    types::{CompressedPublicKey, FixedHash, HashOutput, PrivateKey},
 };
 
 use crate::{
     blocks::{Block, ChainHeader, HistoricalBlock, NewBlockTemplate},
-    chain_storage::{InputMinedInfo, OutputMinedInfo, TemplateRegistrationEntry},
+    chain_storage::{InputMinedInfo, MinedInfo, OutputMinedInfo, TemplateRegistrationEntry},
     proof_of_work::Difficulty,
     transactions::transaction_components::{Transaction, TransactionKernel, TransactionOutput},
 };
@@ -62,7 +62,9 @@ pub enum NodeCommsResponse {
     GetShardKeyResponse(Option<[u8; 32]>),
     FetchTemplateRegistrationsResponse(Vec<TemplateRegistrationEntry>),
     OutputMinedInfo(Option<OutputMinedInfo>),
+    MinedInfo(MinedInfo),
     InputMinedInfo(Option<InputMinedInfo>),
+    PayRef(Option<FixedHash>),
 }
 
 impl Display for NodeCommsResponse {
@@ -101,7 +103,9 @@ impl Display for NodeCommsResponse {
             GetShardKeyResponse(_) => write!(f, "GetShardKeyResponse"),
             FetchTemplateRegistrationsResponse(_) => write!(f, "FetchTemplateRegistrationsResponse"),
             OutputMinedInfo(_) => write!(f, "OutputMinedInfo"),
+            MinedInfo(_) => write!(f, "MinedInfo"),
             InputMinedInfo(_) => write!(f, "InputMinedInfo"),
+            PayRef(_) => write!(f, "PayRef"),
         }
     }
 }

--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -454,8 +454,20 @@ where B: BlockchainBackend + 'static
                 let utxos = self.blockchain_db.fetch_outputs_in_block(block_hash).await?;
                 Ok(NodeCommsResponse::TransactionOutputs(utxos))
             },
-            NodeCommsRequest::FetchOutputByPayRef(payref) => {
-                let output_info = self.blockchain_db.fetch_output_by_payref(payref).await?;
+            NodeCommsRequest::FetchMinedInfoByPayRef(payref) => {
+                let output_info = self.blockchain_db.fetch_mined_info_by_payref(payref).await?;
+                Ok(NodeCommsResponse::MinedInfo(output_info))
+            },
+            NodeCommsRequest::FetchMinedInfoByOutputHash(output_hash) => {
+                let output_info = self.blockchain_db.fetch_mined_info_by_output_hash(output_hash).await?;
+                Ok(NodeCommsResponse::MinedInfo(output_info))
+            },
+            NodeCommsRequest::FetchPayRefByOutputHash(output_hash) => {
+                let payref = self.blockchain_db.fetch_payref_by_output_hash(output_hash).await?;
+                Ok(NodeCommsResponse::PayRef(payref))
+            },
+            NodeCommsRequest::FetchOutputMinedInfo(output_hash) => {
+                let output_info = self.blockchain_db.fetch_output(output_hash).await?;
                 Ok(NodeCommsResponse::OutputMinedInfo(output_info))
             },
             NodeCommsRequest::CheckOutputSpentStatus(output_hash) => {

--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -462,10 +462,6 @@ where B: BlockchainBackend + 'static
                 let output_info = self.blockchain_db.fetch_mined_info_by_output_hash(output_hash).await?;
                 Ok(NodeCommsResponse::MinedInfo(output_info))
             },
-            NodeCommsRequest::FetchPayRefByOutputHash(output_hash) => {
-                let payref = self.blockchain_db.fetch_payref_by_output_hash(output_hash).await?;
-                Ok(NodeCommsResponse::PayRef(payref))
-            },
             NodeCommsRequest::FetchOutputMinedInfo(output_hash) => {
                 let output_info = self.blockchain_db.fetch_output(output_hash).await?;
                 Ok(NodeCommsResponse::OutputMinedInfo(output_info))

--- a/base_layer/core/src/base_node/comms_interface/local_interface.rs
+++ b/base_layer/core/src/base_node/comms_interface/local_interface.rs
@@ -376,25 +376,10 @@ impl LocalNodeCommsInterface {
     ) -> Result<MinedInfo, CommsInterfaceError> {
         match self
             .request_sender
-            .call(NodeCommsRequest::FetchMinedInfoByPayRef(*output_hash))
+            .call(NodeCommsRequest::FetchMinedInfoByOutputHash(*output_hash))
             .await??
         {
             NodeCommsResponse::MinedInfo(mined_info) => Ok(mined_info),
-            _ => Err(CommsInterfaceError::UnexpectedApiResponse),
-        }
-    }
-
-    /// Fetch PayRef (Payment Reference) by output hash
-    pub async fn fetch_payref_by_output_hash(
-        &mut self,
-        output_hash: &HashOutput,
-    ) -> Result<Option<FixedHash>, CommsInterfaceError> {
-        match self
-            .request_sender
-            .call(NodeCommsRequest::FetchPayRefByOutputHash(*output_hash))
-            .await??
-        {
-            NodeCommsResponse::PayRef(payref) => Ok(payref),
             _ => Err(CommsInterfaceError::UnexpectedApiResponse),
         }
     }

--- a/base_layer/core/src/base_node/comms_interface/local_interface.rs
+++ b/base_layer/core/src/base_node/comms_interface/local_interface.rs
@@ -369,7 +369,7 @@ impl LocalNodeCommsInterface {
         }
     }
 
-    /// Fetch mined info by PayRef (Payment Reference)
+    /// Fetch mined info by output hash
     pub async fn fetch_mined_info_by_output_hash(
         &mut self,
         output_hash: &HashOutput,
@@ -384,7 +384,7 @@ impl LocalNodeCommsInterface {
         }
     }
 
-    /// Fetch mined info by PayRef (Payment Reference)
+    /// Fetch PayRef (Payment Reference) by output hash
     pub async fn fetch_payref_by_output_hash(
         &mut self,
         output_hash: &HashOutput,

--- a/base_layer/core/src/base_node/comms_interface/local_interface.rs
+++ b/base_layer/core/src/base_node/comms_interface/local_interface.rs
@@ -38,7 +38,7 @@ use crate::{
         NodeCommsResponse,
     },
     blocks::{Block, ChainHeader, HistoricalBlock, NewBlockTemplate},
-    chain_storage::{InputMinedInfo, OutputMinedInfo, TemplateRegistrationEntry},
+    chain_storage::{InputMinedInfo, MinedInfo, OutputMinedInfo, TemplateRegistrationEntry},
     proof_of_work::{Difficulty, PowAlgorithm},
     transactions::transaction_components::{TransactionKernel, TransactionOutput},
 };
@@ -357,14 +357,56 @@ impl LocalNodeCommsInterface {
         }
     }
 
-    /// Fetch output by PayRef (Payment Reference)
-    pub async fn fetch_output_by_payref(
+    /// Fetch mined info by PayRef (Payment Reference)
+    pub async fn fetch_mined_info_by_payref(&mut self, payref: &FixedHash) -> Result<MinedInfo, CommsInterfaceError> {
+        match self
+            .request_sender
+            .call(NodeCommsRequest::FetchMinedInfoByPayRef(*payref))
+            .await??
+        {
+            NodeCommsResponse::MinedInfo(mined_info) => Ok(mined_info),
+            _ => Err(CommsInterfaceError::UnexpectedApiResponse),
+        }
+    }
+
+    /// Fetch mined info by PayRef (Payment Reference)
+    pub async fn fetch_mined_info_by_output_hash(
         &mut self,
-        payref: &FixedHash,
+        output_hash: &HashOutput,
+    ) -> Result<MinedInfo, CommsInterfaceError> {
+        match self
+            .request_sender
+            .call(NodeCommsRequest::FetchMinedInfoByPayRef(*output_hash))
+            .await??
+        {
+            NodeCommsResponse::MinedInfo(mined_info) => Ok(mined_info),
+            _ => Err(CommsInterfaceError::UnexpectedApiResponse),
+        }
+    }
+
+    /// Fetch mined info by PayRef (Payment Reference)
+    pub async fn fetch_payref_by_output_hash(
+        &mut self,
+        output_hash: &HashOutput,
+    ) -> Result<Option<FixedHash>, CommsInterfaceError> {
+        match self
+            .request_sender
+            .call(NodeCommsRequest::FetchPayRefByOutputHash(*output_hash))
+            .await??
+        {
+            NodeCommsResponse::PayRef(payref) => Ok(payref),
+            _ => Err(CommsInterfaceError::UnexpectedApiResponse),
+        }
+    }
+
+    /// Fetch output mined info by output hash
+    pub async fn fetch_output_mined_info(
+        &mut self,
+        output_hash: &HashOutput,
     ) -> Result<Option<OutputMinedInfo>, CommsInterfaceError> {
         match self
             .request_sender
-            .call(NodeCommsRequest::FetchOutputByPayRef(*payref))
+            .call(NodeCommsRequest::FetchOutputMinedInfo(*output_hash))
             .await??
         {
             NodeCommsResponse::OutputMinedInfo(output_info) => Ok(output_info),

--- a/base_layer/core/src/chain_storage/async_db.rs
+++ b/base_layer/core/src/chain_storage/async_db.rs
@@ -30,7 +30,7 @@ use tari_common_types::{
 };
 use tari_utilities::epoch_time::EpochTime;
 
-use super::TemplateRegistrationEntry;
+use super::{MinedInfo, TemplateRegistrationEntry};
 use crate::{
     blocks::{
         Block,
@@ -276,7 +276,11 @@ impl<B: BlockchainBackend + 'static> AsyncBlockchainDb<B> {
 
     make_async_fn!(swap_to_highest_pow_chain() -> (), "swap to highest proof-of-work chain");
 
-    make_async_fn!(fetch_output_by_payref(payref: FixedHash) -> Option<OutputMinedInfo>, "fetch_output_by_payref");
+    make_async_fn!(fetch_mined_info_by_payref(payref: FixedHash) -> MinedInfo, "fetch_mined_info_by_payref");
+
+    make_async_fn!(fetch_mined_info_by_output_hash(output_hash: HashOutput) -> MinedInfo, "fetch_mined_info_by_output_hash");
+
+    make_async_fn!(fetch_payref_by_output_hash(output_hash: HashOutput) -> Option<FixedHash>, "fetch_payref_by_output_hash");
 }
 
 impl<B: BlockchainBackend + 'static> From<BlockchainDatabase<B>> for AsyncBlockchainDb<B> {

--- a/base_layer/core/src/chain_storage/async_db.rs
+++ b/base_layer/core/src/chain_storage/async_db.rs
@@ -279,8 +279,6 @@ impl<B: BlockchainBackend + 'static> AsyncBlockchainDb<B> {
     make_async_fn!(fetch_mined_info_by_payref(payref: FixedHash) -> MinedInfo, "fetch_mined_info_by_payref");
 
     make_async_fn!(fetch_mined_info_by_output_hash(output_hash: HashOutput) -> MinedInfo, "fetch_mined_info_by_output_hash");
-
-    make_async_fn!(fetch_payref_by_output_hash(output_hash: HashOutput) -> Option<FixedHash>, "fetch_payref_by_output_hash");
 }
 
 impl<B: BlockchainBackend + 'static> From<BlockchainDatabase<B>> for AsyncBlockchainDb<B> {

--- a/base_layer/core/src/chain_storage/blockchain_backend.rs
+++ b/base_layer/core/src/chain_storage/blockchain_backend.rs
@@ -96,10 +96,10 @@ pub trait BlockchainBackend: Send + Sync {
         spend_status_at_header: Option<&HashOutput>,
     ) -> Result<Vec<(TransactionOutput, bool)>, ChainStorageError>;
 
-    /// Fetch a specific output. Returns the output
+    /// Returns optional output mined info for the given output hash
     fn fetch_output(&self, output_hash: &HashOutput) -> Result<Option<OutputMinedInfo>, ChainStorageError>;
 
-    /// Fetch a specific input. Returns the input
+    /// Returns optional input mined info for the given output hash
     fn fetch_input(&self, output_hash: &HashOutput) -> Result<Option<InputMinedInfo>, ChainStorageError>;
 
     /// Returns the unspent TransactionOutput output that matches the given commitment if it exists in the current UTXO

--- a/base_layer/core/src/chain_storage/blockchain_backend.rs
+++ b/base_layer/core/src/chain_storage/blockchain_backend.rs
@@ -6,7 +6,7 @@ use tari_common_types::{
     types::{BadBlock, CompressedCommitment, CompressedPublicKey, FixedHash, HashOutput, Signature},
 };
 
-use super::{lmdb_db::lmdb_tree_reader::OwnedLmdbTreeReader, TemplateRegistrationEntry};
+use super::{lmdb_db::lmdb_tree_reader::OwnedLmdbTreeReader, MinedInfo, TemplateRegistrationEntry};
 use crate::{
     blocks::{Block, BlockAccumulatedData, BlockHeader, BlockHeaderAccumulatedData, ChainBlock, ChainHeader},
     chain_storage::{
@@ -109,9 +109,14 @@ pub trait BlockchainBackend: Send + Sync {
         commitment: &CompressedCommitment,
     ) -> Result<Option<HashOutput>, ChainStorageError>;
 
-    /// Fetch output by PayRef (Payment Reference)
-    /// Returns the OutputMinedInfo if found, None if PayRef doesn't exist
-    fn fetch_output_by_payref(&self, payref: &FixedHash) -> Result<Option<OutputMinedInfo>, ChainStorageError>;
+    /// Fetch mined info by PayRef (Payment Reference)
+    fn fetch_mined_info_by_payref(&self, payref: &FixedHash) -> Result<MinedInfo, ChainStorageError>;
+
+    /// Fetch mined info by output hash
+    fn fetch_mined_info_by_output_hash(&self, output_hash: &HashOutput) -> Result<MinedInfo, ChainStorageError>;
+
+    /// Fetch PayRef (Payment Reference) by output hash
+    fn fetch_payref_by_output_hash(&self, output_hash: &HashOutput) -> Result<Option<FixedHash>, ChainStorageError>;
 
     /// Fetch all outputs in a block
     fn fetch_outputs_in_block(&self, header_hash: &HashOutput) -> Result<Vec<TransactionOutput>, ChainStorageError>;

--- a/base_layer/core/src/chain_storage/blockchain_backend.rs
+++ b/base_layer/core/src/chain_storage/blockchain_backend.rs
@@ -115,9 +115,6 @@ pub trait BlockchainBackend: Send + Sync {
     /// Fetch mined info by output hash
     fn fetch_mined_info_by_output_hash(&self, output_hash: &HashOutput) -> Result<MinedInfo, ChainStorageError>;
 
-    /// Fetch PayRef (Payment Reference) by output hash
-    fn fetch_payref_by_output_hash(&self, output_hash: &HashOutput) -> Result<Option<FixedHash>, ChainStorageError>;
-
     /// Fetch all outputs in a block
     fn fetch_outputs_in_block(&self, header_hash: &HashOutput) -> Result<Vec<TransactionOutput>, ChainStorageError>;
 

--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -59,7 +59,7 @@ use tari_hashing::TransactionHashDomain;
 use tari_mmr::pruned_hashset::PrunedHashSet;
 use tari_utilities::{epoch_time::EpochTime, hex::Hex, ByteArray};
 
-use super::{smt_hasher::SmtHasher, TemplateRegistrationEntry};
+use super::{smt_hasher::SmtHasher, MinedInfo, TemplateRegistrationEntry};
 use crate::{
     block_output_mr_hash_from_pruned_mmr,
     blocks::{
@@ -454,10 +454,22 @@ where B: BlockchainBackend
         db.fetch_input(&output_hash)
     }
 
-    /// Returns a copy of the output mined info by payment reference
-    pub fn fetch_output_by_payref(&self, payref: FixedHash) -> Result<Option<OutputMinedInfo>, ChainStorageError> {
+    /// Returns a copy of the mined info by payment reference
+    pub fn fetch_mined_info_by_payref(&self, payref: FixedHash) -> Result<MinedInfo, ChainStorageError> {
         let db = self.db_read_access()?;
-        db.fetch_output_by_payref(&payref)
+        db.fetch_mined_info_by_payref(&payref)
+    }
+
+    /// Returns a copy of the mined info by payment reference
+    pub fn fetch_mined_info_by_output_hash(&self, output_hash: HashOutput) -> Result<MinedInfo, ChainStorageError> {
+        let db = self.db_read_access()?;
+        db.fetch_mined_info_by_output_hash(&output_hash)
+    }
+
+    /// Returns a copy of the mined info by payment reference
+    pub fn fetch_payref_by_output_hash(&self, output_hash: HashOutput) -> Result<Option<FixedHash>, ChainStorageError> {
+        let db = self.db_read_access()?;
+        db.fetch_payref_by_output_hash(&output_hash)
     }
 
     pub fn fetch_unspent_output_hash_by_commitment(

--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -460,13 +460,13 @@ where B: BlockchainBackend
         db.fetch_mined_info_by_payref(&payref)
     }
 
-    /// Returns a copy of the mined info by payment reference
+    /// Returns a copy of the mined info by output hash
     pub fn fetch_mined_info_by_output_hash(&self, output_hash: HashOutput) -> Result<MinedInfo, ChainStorageError> {
         let db = self.db_read_access()?;
         db.fetch_mined_info_by_output_hash(&output_hash)
     }
 
-    /// Returns a copy of the mined info by payment reference
+    /// Returns a copy of the payment reference by output hash
     pub fn fetch_payref_by_output_hash(&self, output_hash: HashOutput) -> Result<Option<FixedHash>, ChainStorageError> {
         let db = self.db_read_access()?;
         db.fetch_payref_by_output_hash(&output_hash)

--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -448,19 +448,19 @@ where B: BlockchainBackend
         db.fetch_output(&output_hash)
     }
 
-    /// Returns a copy of the current input mined info
+    /// Returns optional input mined info for the given output hash
     pub fn fetch_input(&self, output_hash: HashOutput) -> Result<Option<InputMinedInfo>, ChainStorageError> {
         let db = self.db_read_access()?;
         db.fetch_input(&output_hash)
     }
 
-    /// Returns a copy of the mined info by payment reference
+    /// Returns the mined info for the given payment reference
     pub fn fetch_mined_info_by_payref(&self, payref: FixedHash) -> Result<MinedInfo, ChainStorageError> {
         let db = self.db_read_access()?;
         db.fetch_mined_info_by_payref(&payref)
     }
 
-    /// Returns a copy of the mined info by output hash
+    /// Returns the mined info for the given output hash
     pub fn fetch_mined_info_by_output_hash(&self, output_hash: HashOutput) -> Result<MinedInfo, ChainStorageError> {
         let db = self.db_read_access()?;
         db.fetch_mined_info_by_output_hash(&output_hash)

--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -466,12 +466,6 @@ where B: BlockchainBackend
         db.fetch_mined_info_by_output_hash(&output_hash)
     }
 
-    /// Returns a copy of the payment reference by output hash
-    pub fn fetch_payref_by_output_hash(&self, output_hash: HashOutput) -> Result<Option<FixedHash>, ChainStorageError> {
-        let db = self.db_read_access()?;
-        db.fetch_payref_by_output_hash(&output_hash)
-    }
-
     pub fn fetch_unspent_output_hash_by_commitment(
         &self,
         commitment: CompressedCommitment,

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb.rs
@@ -142,6 +142,7 @@ where
 {
     let val_buf = serialize(val, size_hint)?;
     let start = Instant::now();
+    // put::Flags::empty(): This will replace the value if it exists, or insert a new value if it does not.
     let res = txn.access().put(db, key, &val_buf, put::Flags::empty()).map_err(|e| {
         if let lmdb_zero::Error::Code(code) = &e {
             if *code == lmdb_zero::error::MAP_FULL {

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb.rs
@@ -37,7 +37,7 @@ use lmdb_zero::{
 };
 use log::*;
 use serde::{de::DeserializeOwned, Serialize};
-use tari_storage::lmdb_store::BYTES_PER_MB;
+use tari_storage::lmdb_store::{LMDBConfig, LMDBStore, BYTES_PER_MB};
 use tari_utilities::hex::to_hex;
 
 use crate::chain_storage::{
@@ -142,18 +142,29 @@ where
 {
     let val_buf = serialize(val, size_hint)?;
     let start = Instant::now();
-    let res = txn.access().put(db, key, &val_buf, put::Flags::empty()).map_err(|e| {
-        if let lmdb_zero::Error::Code(code) = &e {
-            if *code == lmdb_zero::error::MAP_FULL {
-                return ChainStorageError::DbResizeRequired(Some(val_buf.len()));
-            }
+    let max_resizes = 1;
+    for i in 0..max_resizes {
+        match txn.access().put(db, key, &val_buf, put::Flags::empty()) {
+            Ok(_) => {},
+            Err(Error::Code(error::MAP_FULL)) => {
+                info!(
+                    target: LOG_TARGET,
+                    "Database resize required (resized {} time(s) in this transaction)",
+                    i + 1
+                );
+                unsafe {
+                    LMDBStore::resize(db.env(), &LMDBConfig::default(), None)?;
+                }
+            },
+            Err(e) => {
+                error!(
+                    target: LOG_TARGET,
+                    "Could not replace value in lmdb transaction: {:?}", e
+                );
+                return Err(ChainStorageError::AccessError(e.to_string()));
+            },
         }
-        error!(
-            target: LOG_TARGET,
-            "Could not replace value in lmdb transaction: {:?}", e
-        );
-        ChainStorageError::AccessError(e.to_string())
-    });
+    }
     if val_buf.len() >= BYTES_PER_MB {
         let write_time = start.elapsed();
         trace!(
@@ -162,7 +173,7 @@ where
             write_time
         );
     }
-    res
+    Ok(())
 }
 
 /// Deletes the given key. An error is returned if the key does not exist

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb.rs
@@ -37,7 +37,7 @@ use lmdb_zero::{
 };
 use log::*;
 use serde::{de::DeserializeOwned, Serialize};
-use tari_storage::lmdb_store::{LMDBConfig, LMDBStore, BYTES_PER_MB};
+use tari_storage::lmdb_store::BYTES_PER_MB;
 use tari_utilities::hex::to_hex;
 
 use crate::chain_storage::{
@@ -142,29 +142,18 @@ where
 {
     let val_buf = serialize(val, size_hint)?;
     let start = Instant::now();
-    let max_resizes = 1;
-    for i in 0..max_resizes {
-        match txn.access().put(db, key, &val_buf, put::Flags::empty()) {
-            Ok(_) => {},
-            Err(Error::Code(error::MAP_FULL)) => {
-                info!(
-                    target: LOG_TARGET,
-                    "Database resize required (resized {} time(s) in this transaction)",
-                    i + 1
-                );
-                unsafe {
-                    LMDBStore::resize(db.env(), &LMDBConfig::default(), None)?;
-                }
-            },
-            Err(e) => {
-                error!(
-                    target: LOG_TARGET,
-                    "Could not replace value in lmdb transaction: {:?}", e
-                );
-                return Err(ChainStorageError::AccessError(e.to_string()));
-            },
+    let res = txn.access().put(db, key, &val_buf, put::Flags::empty()).map_err(|e| {
+        if let lmdb_zero::Error::Code(code) = &e {
+            if *code == lmdb_zero::error::MAP_FULL {
+                return ChainStorageError::DbResizeRequired(Some(val_buf.len()));
+            }
         }
-    }
+        error!(
+            target: LOG_TARGET,
+            "Could not replace value in lmdb transaction: {:?}", e
+        );
+        ChainStorageError::AccessError(e.to_string())
+    });
     if val_buf.len() >= BYTES_PER_MB {
         let write_time = start.elapsed();
         trace!(
@@ -173,7 +162,7 @@ where
             write_time
         );
     }
-    Ok(())
+    res
 }
 
 /// Deletes the given key. An error is returned if the key does not exist

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -115,6 +115,7 @@ use crate::{
         DbSize,
         HorizonData,
         InputMinedInfo,
+        MinedInfo,
         MmrTree,
         Reorg,
         TemplateRegistrationEntry,
@@ -157,6 +158,7 @@ const LMDB_DB_UTXO_COMMITMENT_INDEX: &str = "utxo_commitment_index";
 const LMDB_DB_UNIQUE_ID_INDEX: &str = "unique_id_index";
 const LMDB_DB_CONTRACT_ID_INDEX: &str = "contract_index";
 const LMDB_DB_PAYREF_TO_OUTPUT_INDEX: &str = "payref_to_output_index";
+const LMDB_DB_OUTPUT_TO_PAYREF_INDEX: &str = "output_to_payref_index";
 const LMDB_DB_ORPHANS: &str = "orphans";
 const LMDB_DB_MONERO_SEED_HEIGHT: &str = "monero_seed_height";
 const LMDB_DB_MONERO_SEED_HEIGHT_INDEX: &str = "monero_seed_height_index";
@@ -211,6 +213,7 @@ pub fn create_lmdb_database<P: AsRef<Path>>(
         .add_database(LMDB_DB_UNIQUE_ID_INDEX, flags)
         .add_database(LMDB_DB_CONTRACT_ID_INDEX, flags)
         .add_database(LMDB_DB_PAYREF_TO_OUTPUT_INDEX, flags)
+        .add_database(LMDB_DB_OUTPUT_TO_PAYREF_INDEX, flags)
         .add_database(LMDB_DB_DELETED_TXO_HASH_TO_HEADER_INDEX, flags)
         .add_database(LMDB_DB_ORPHANS, flags)
         .add_database(LMDB_DB_ORPHAN_HEADER_ACCUMULATED_DATA, flags)
@@ -269,6 +272,8 @@ pub struct LMDBDatabase {
     contract_index: DatabaseRef,
     /// Maps payment_reference[32] -> output_hash[32] for fast PayRef lookup
     payref_to_output_index: DatabaseRef,
+    /// Maps output_hash[32]  -> payment_reference[32]for fast PayRef lookup
+    output_to_payref_index: DatabaseRef,
     /// Maps output hash-> <block_hash, input_hash>
     deleted_txo_hash_to_header_index: DatabaseRef,
     /// Maps block_hash -> Block
@@ -326,6 +331,7 @@ impl LMDBDatabase {
             unique_id_index: get_database(store, LMDB_DB_UNIQUE_ID_INDEX)?,
             contract_index: get_database(store, LMDB_DB_CONTRACT_ID_INDEX)?,
             payref_to_output_index: get_database(store, LMDB_DB_PAYREF_TO_OUTPUT_INDEX)?,
+            output_to_payref_index: get_database(store, LMDB_DB_OUTPUT_TO_PAYREF_INDEX)?,
             deleted_txo_hash_to_header_index: get_database(store, LMDB_DB_DELETED_TXO_HASH_TO_HEADER_INDEX)?,
             orphans_db: get_database(store, LMDB_DB_ORPHANS)?,
             orphan_header_accumulated_data_db: get_database(store, LMDB_DB_ORPHAN_HEADER_ACCUMULATED_DATA)?,
@@ -541,7 +547,7 @@ impl LMDBDatabase {
         Ok(())
     }
 
-    fn all_dbs(&self) -> [(&'static str, &DatabaseRef); 32] {
+    fn all_dbs(&self) -> [(&'static str, &DatabaseRef); 33] {
         [
             (LMDB_DB_METADATA, &self.metadata_db),
             (LMDB_DB_HEADERS, &self.headers_db),
@@ -559,6 +565,7 @@ impl LMDBDatabase {
             (LMDB_DB_CONTRACT_ID_INDEX, &self.contract_index),
             (LMDB_DB_UNIQUE_ID_INDEX, &self.unique_id_index),
             (LMDB_DB_PAYREF_TO_OUTPUT_INDEX, &self.payref_to_output_index),
+            (LMDB_DB_OUTPUT_TO_PAYREF_INDEX, &self.output_to_payref_index),
             (
                 LMDB_DB_DELETED_TXO_HASH_TO_HEADER_INDEX,
                 &self.deleted_txo_hash_to_header_index,
@@ -608,13 +615,7 @@ impl LMDBDatabase {
 
         // Generate PayRef and add to index
         let payref = Self::generate_payment_reference_for_output(header_hash, &output_hash);
-        lmdb_insert(
-            txn,
-            &self.payref_to_output_index,
-            payref.as_slice(),
-            &output_hash,
-            "payref_to_output_index",
-        )?;
+        self.insert_payref_index(txn, &payref, &output_hash)?;
 
         lmdb_insert(
             txn,
@@ -635,6 +636,34 @@ impl LMDBDatabase {
                 mined_timestamp: header_timestamp,
             },
             LMDB_DB_UTXOS,
+        )?;
+
+        Ok(())
+    }
+
+    /// Inserts both payref -> output_hash and output_hash -> payref into LMDB
+    fn insert_payref_index(
+        &self,
+        txn: &WriteTransaction<'_>,
+        payref: &FixedHash,
+        output_hash: &HashOutput,
+    ) -> Result<(), ChainStorageError> {
+        // Forward mapping: payref -> output_hash
+        lmdb_insert(
+            txn,
+            &self.payref_to_output_index,
+            payref.as_slice(),
+            output_hash,
+            "payref_to_output_index",
+        )?;
+
+        // Reverse mapping: output_hash -> payref
+        lmdb_insert(
+            txn,
+            &self.output_to_payref_index,
+            output_hash.as_slice(),
+            payref,
+            "output_to_payref_index",
         )?;
 
         Ok(())
@@ -772,34 +801,6 @@ impl LMDBDatabase {
             },
             "inputs_db",
         )?;
-
-        // Remove PayRef index when output is spent
-        // We need to find where this output was mined to calculate its PayRef
-        if let Ok(Some(output_info)) = self.fetch_output_in_txn(txn, output_hash.as_slice()) {
-            // Generate the PayRef using the same method as in generate_payment_reference
-            let payref_bytes = Self::generate_payment_reference_for_output(&output_info.header_hash, &output_hash);
-
-            // Delete the PayRef index entry
-            match lmdb_delete(
-                txn,
-                &self.payref_to_output_index,
-                payref_bytes.as_slice(),
-                "payref_to_output_index",
-            ) {
-                Ok(()) => {
-                    debug!(target: LOG_TARGET, "Successfully deleted PayRef for output {}", output_hash.to_hex());
-                },
-                Err(ChainStorageError::ValueNotFound { .. }) => {
-                    // PayRef not found - this is acceptable as it might not have been created in older versions
-                    debug!(target: LOG_TARGET, "PayRef not found for output {} - likely from older version", output_hash.to_hex());
-                },
-                Err(e) => {
-                    // Actual database error - must fail the transaction
-                    error!(target: LOG_TARGET, "Failed to delete PayRef for output {}: {}", output_hash.to_hex(), e);
-                    return Err(e);
-                },
-            }
-        }
 
         Ok(())
     }
@@ -1102,12 +1103,7 @@ impl LMDBDatabase {
             if should_cleanup_payref {
                 let payref_bytes = Self::generate_payment_reference_for_output(block_hash, &output_hash);
                 // Delete the PayRef index entry with proper error handling
-                match lmdb_delete(
-                    txn,
-                    &self.payref_to_output_index,
-                    payref_bytes.as_slice(),
-                    "payref_to_output_index",
-                ) {
+                match self.delete_payref_index(txn, &payref_bytes, &output_hash) {
                     Ok(()) => {
                         debug!(target: LOG_TARGET, "Deleted PayRef during reorg for output {}", output_hash.to_hex())
                     },
@@ -1182,13 +1178,7 @@ impl LMDBDatabase {
 
             let payref =
                 Self::generate_payment_reference_for_output(&utxo_mined_info.header_hash, &input.output_hash());
-            lmdb_insert(
-                txn,
-                &self.payref_to_output_index,
-                payref.as_slice(),
-                &output_hash,
-                "payref_to_output_index",
-            )?;
+            self.insert_payref_index(txn, &payref, &output_hash)?;
 
             trace!(target: LOG_TARGET, "Input moved to UTXO set: {}", input);
             lmdb_insert(
@@ -1199,6 +1189,32 @@ impl LMDBDatabase {
                 "utxo_commitment_index",
             )?;
         }
+        Ok(())
+    }
+
+    /// Deletes both payref -> output_hash and output_hash -> payref from LMDB
+    fn delete_payref_index(
+        &self,
+        txn: &WriteTransaction<'_>,
+        payref: &FixedHash,
+        output_hash: &HashOutput,
+    ) -> Result<(), ChainStorageError> {
+        // Delete forward mapping
+        lmdb_delete(
+            txn,
+            &self.payref_to_output_index,
+            payref.as_slice(),
+            "payref_to_output_index",
+        )?;
+
+        // Delete reverse mapping
+        lmdb_delete(
+            txn,
+            &self.output_to_payref_index,
+            output_hash.as_slice(),
+            "output_to_payref_index",
+        )?;
+
         Ok(())
     }
 
@@ -1907,20 +1923,54 @@ impl LMDBDatabase {
         }
     }
 
-    /// Fetch output by PayRef (Payment Reference)
-    /// Returns the OutputMinedInfo if found, None if not found
-    fn fetch_output_by_payref_in_txn(
+    // Fetch mined info by PayRef (Payment Reference)
+    fn fetch_mined_info_by_payref_in_txn(
         &self,
         txn: &ConstTransaction<'_>,
         payref: &FixedHash,
-    ) -> Result<Option<OutputMinedInfo>, ChainStorageError> {
+    ) -> Result<MinedInfo, ChainStorageError> {
         // Look up output hash by PayRef
         if let Some(output_hash) = lmdb_get::<_, HashOutput>(txn, &self.payref_to_output_index, payref.as_slice())? {
-            // Use existing fetch_output_in_txn method to get the full output info
-            self.fetch_output_in_txn(txn, output_hash.as_slice())
+            self.fetch_mined_info_by_output_hash_in_txn(txn, &output_hash)
         } else {
-            Ok(None)
+            Ok(MinedInfo {
+                input: None,
+                output: None,
+            })
         }
+    }
+
+    // Fetch mined info by PayRef (Payment Reference)
+    fn fetch_mined_info_by_output_hash_in_txn(
+        &self,
+        txn: &ConstTransaction<'_>,
+        output_hash: &HashOutput,
+    ) -> Result<MinedInfo, ChainStorageError> {
+        if let Ok(Some(mined_info)) = self.fetch_output_in_txn(txn, output_hash.as_slice()) {
+            Ok(MinedInfo {
+                input: None,
+                output: Some(mined_info),
+            })
+        } else if let Ok(Some(mined_info)) = self.fetch_input_in_txn(txn, output_hash.as_slice()) {
+            Ok(MinedInfo {
+                input: Some(mined_info),
+                output: None,
+            })
+        } else {
+            Ok(MinedInfo {
+                input: None,
+                output: None,
+            })
+        }
+    }
+
+    // Fetch mined info by PayRef (Payment Reference)
+    fn fetch_payref_by_output_hash_in_txn(
+        &self,
+        txn: &ConstTransaction<'_>,
+        output_hash: &HashOutput,
+    ) -> Result<Option<FixedHash>, ChainStorageError> {
+        lmdb_get::<_, FixedHash>(txn, &self.output_to_payref_index, output_hash.as_slice())
     }
 
     fn get_consensus_constants(&self, height: u64) -> &ConsensusConstants {
@@ -2368,9 +2418,19 @@ impl BlockchainBackend for LMDBDatabase {
         lmdb_get::<_, HashOutput>(&txn, &self.utxo_commitment_index, commitment.as_bytes())
     }
 
-    fn fetch_output_by_payref(&self, payref: &FixedHash) -> Result<Option<OutputMinedInfo>, ChainStorageError> {
+    fn fetch_mined_info_by_payref(&self, payref: &FixedHash) -> Result<MinedInfo, ChainStorageError> {
         let txn = self.read_transaction()?;
-        self.fetch_output_by_payref_in_txn(&txn, payref)
+        self.fetch_mined_info_by_payref_in_txn(&txn, payref)
+    }
+
+    fn fetch_mined_info_by_output_hash(&self, output_hash: &HashOutput) -> Result<MinedInfo, ChainStorageError> {
+        let txn = self.read_transaction()?;
+        self.fetch_mined_info_by_output_hash_in_txn(&txn, output_hash)
+    }
+
+    fn fetch_payref_by_output_hash(&self, output_hash: &HashOutput) -> Result<Option<FixedHash>, ChainStorageError> {
+        let txn = self.read_transaction()?;
+        self.fetch_payref_by_output_hash_in_txn(&txn, output_hash)
     }
 
     fn fetch_outputs_in_block(&self, header_hash: &HashOutput) -> Result<Vec<TransactionOutput>, ChainStorageError> {
@@ -2989,7 +3049,7 @@ impl fmt::Display for MetadataValue {
 
 #[allow(clippy::too_many_lines)]
 fn run_migrations(db: &mut LMDBDatabase) -> Result<(), ChainStorageError> {
-    const MIGRATION_VERSION: u64 = 3;
+    const MIGRATION_VERSION: u64 = 5;
     let txn = db.read_transaction()?;
     let k = MetadataKey::MigrationVersion;
     let val = lmdb_get::<_, MetadataValue>(&txn, &db.metadata_db, &k.as_u32())?;
@@ -3003,8 +3063,12 @@ fn run_migrations(db: &mut LMDBDatabase) -> Result<(), ChainStorageError> {
     );
     drop(txn);
 
-    for migrate_from_version in last_migrated_version..=MIGRATION_VERSION {
-        // Add migrations here
+    // This is to fix the previous payref migration error as `last_migrated_version` was incremented beyond
+    // `MIGRATION_VERSION`
+    let mut payref_index_done = false;
+
+    for migrate_from_version in last_migrated_version..MIGRATION_VERSION {
+        // MIGRATION: Accumulated difficulty migration after the 3rd mining algorithm was introduced
         if migrate_from_version == 0 {
             let txn = db.read_transaction()?;
 
@@ -3117,6 +3181,8 @@ fn run_migrations(db: &mut LMDBDatabase) -> Result<(), ChainStorageError> {
             }
             txn.commit()?;
         }
+
+        // MIGRATION: Accumulated difficulty migration - blockchain rewind to last known good accumulated difficulty
         if migrate_from_version == 1 {
             let known_good_difficulties = get_correct_accumulated_difficulty();
             if known_good_difficulties.is_empty() {
@@ -3150,9 +3216,11 @@ fn run_migrations(db: &mut LMDBDatabase) -> Result<(), ChainStorageError> {
             // lets rewind to last known good accumulated difficulty so the db can be correctly calculated again
             rewind_to_height(db, last_correct_height)?;
         }
-        if migrate_from_version == 2 {
-            // Verify database consistency before starting migration
-            info!(target: LOG_TARGET, "Starting PayRef migration");
+
+        // MIGRATION: Add payref index, rebuild payref index to recover deleted payrefs, add reverse payref index
+        if (migrate_from_version == 2 || migrate_from_version == 3 || migrate_from_version == 4) && !payref_index_done {
+            info!(target: LOG_TARGET, "Starting PayRef migration with reverse lookup");
+            let add_reverse_lookup = true;
 
             let read_txn = db.read_transaction()?;
             let chain_height = match fetch_chain_height(&read_txn, &db.metadata_db) {
@@ -3160,23 +3228,28 @@ fn run_migrations(db: &mut LMDBDatabase) -> Result<(), ChainStorageError> {
                 Err(_) => {
                     // No chain data, skip PayRef rebuild
                     drop(read_txn);
-                    continue;
+                    return Ok(());
                 },
             };
             drop(read_txn);
-            // we need to clear the payref index first as they might now bw wrong
+
+            // Clear the payref index first as they might now be wrong
             {
                 let txn = db.write_transaction()?;
                 lmdb_clear(&txn, &db.payref_to_output_index)?;
                 txn.commit()?;
                 info!(target: LOG_TARGET, "Cleared PayRef index");
             }
+
             for height in 0..=chain_height {
-                process_payref_for_height(db, height)?;
+                process_payref_for_height(db, height, add_reverse_lookup)?;
             }
-            info!(target: LOG_TARGET, "PayRef index rebuild completed");
+
+            payref_index_done = true;
+            info!(target: LOG_TARGET, "PayRef index rebuild with reverse lookup completed");
         }
-        // lets update the migration version
+
+        // Lets update the migration version
         {
             let txn = db.write_transaction()?;
             info!(target: LOG_TARGET, "Migrated database to version {}", MIGRATION_VERSION);
@@ -3184,7 +3257,7 @@ fn run_migrations(db: &mut LMDBDatabase) -> Result<(), ChainStorageError> {
                 &txn,
                 &db.metadata_db,
                 &k.as_u32(),
-                &MetadataValue::MigrationVersion(migrate_from_version + 1),
+                &MetadataValue::MigrationVersion(max(migrate_from_version + 1, MIGRATION_VERSION)),
                 None,
             )?;
             txn.commit()?;
@@ -3286,7 +3359,11 @@ fn get_correct_accumulated_difficulty() -> Vec<(u64, U512)> {
 }
 
 /// Process a batch of blocks for PayRef migration with error handling
-fn process_payref_for_height(db: &LMDBDatabase, height: u64) -> Result<(), ChainStorageError> {
+fn process_payref_for_height(
+    db: &LMDBDatabase,
+    height: u64,
+    add_reverse_lookup: bool,
+) -> Result<(), ChainStorageError> {
     info!(target: LOG_TARGET, "Processing PayRef migration for  {}", height);
     let read_txn = db.read_transaction()?;
     let read_header: Option<BlockHeader> = lmdb_get(&read_txn, &db.headers_db, &height)?;
@@ -3321,6 +3398,15 @@ fn process_payref_for_height(db: &LMDBDatabase, height: u64) -> Result<(), Chain
             &output_hash,
             None,
         )?;
+        if add_reverse_lookup {
+            lmdb_insert(
+                &write_txn,
+                &db.output_to_payref_index,
+                output_hash.as_slice(),
+                &payref,
+                "output_to_payref_index",
+            )?;
+        }
     }
     write_txn.commit()?;
     // Commit the batch

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -36,7 +36,6 @@ use lmdb_zero::{open, ConstTransaction, Database, Environment, ReadTransaction, 
 use log::*;
 use primitive_types::{U256, U512};
 use serde::{Deserialize, Serialize};
-use tari_common::configuration::Network;
 use tari_common_types::{
     chain_metadata::ChainMetadata,
     epoch::VnEpoch,
@@ -67,7 +66,6 @@ use super::{
 };
 use crate::{
     blocks::{
-        genesis_block::get_genesis_block,
         Block,
         BlockAccumulatedData,
         BlockHeader,
@@ -611,7 +609,13 @@ impl LMDBDatabase {
 
         // Generate PayRef and add to index
         let payref = Self::generate_payment_reference_for_output(header_hash, &output_hash);
-        lmdb_replace(txn, &self.payref_to_output_index, payref.as_slice(), &output_hash, None)?;
+        lmdb_insert(
+            txn,
+            &self.payref_to_output_index,
+            payref.as_slice(),
+            &output_hash,
+            "payref_to_output_index",
+        )?;
 
         lmdb_insert(
             txn,
@@ -1053,15 +1057,14 @@ impl LMDBDatabase {
         debug!(target: LOG_TARGET, "Deleted {} input(s)...", inputs.len());
 
         for (_, utxo) in &output_rows {
-            trace!(target: LOG_TARGET, "Deleting UTXO `{}`", to_hex(utxo.hash.as_slice()));
+            let output_hash = utxo.hash;
+            trace!(target: LOG_TARGET, "Deleting UTXO `{}`", output_hash);
             lmdb_delete(
                 txn,
                 &self.txos_hash_to_index_db,
                 utxo.hash.as_slice(),
                 "txos_hash_to_index_db",
             )?;
-
-            let output_hash = utxo.output.hash();
 
             // Clean up PayRef index for this output during reorg
             // Only clean PayRef if output was actually created (not spent in same block, not burned)
@@ -1090,15 +1093,19 @@ impl LMDBDatabase {
                 }
             }
 
-            // if an output was already spent in the block, it was never created as unspent, so dont delete it as it
+            // If an output was already spent in the block, it was never created as unspent, so don't delete it as it
             // does not exist here
             if inputs.iter().any(|(_, r)| r.input.output_hash() == output_hash) {
+                trace!(target: LOG_TARGET, "Not deleting UTXO `{}` - immediate spend", output_hash);
                 continue;
             }
-            // if an output was burned, it was never created as an unspent utxo
+            // If an output was burned, it was never created as an unspent utxo
             if utxo.output.is_burned() {
+                trace!(target: LOG_TARGET, "Not deleting UTXO `{}` - burned", output_hash);
                 continue;
             }
+
+            // Delete the output from the UTXO commitment index
             lmdb_delete(
                 txn,
                 &self.utxo_commitment_index,
@@ -1147,20 +1154,16 @@ impl LMDBDatabase {
                 utxo_mined_info.output.metadata_signature,
                 rp_hash,
                 utxo_mined_info.output.minimum_value_promise,
-            ); // Generate PayRef and add to index.
+            );
 
-            let payref =
-                Self::generate_payment_reference_for_output(&utxo_mined_info.header_hash, &input.output_hash());
-            lmdb_replace(txn, &self.payref_to_output_index, payref.as_slice(), &output_hash, None)?;
-
-            trace!(target: LOG_TARGET, "Input moved to UTXO set: {}", input);
             lmdb_insert(
                 txn,
                 &self.utxo_commitment_index,
                 input.commitment()?.as_bytes(),
-                &input.output_hash(),
+                &output_hash,
                 "utxo_commitment_index",
             )?;
+            trace!(target: LOG_TARGET, "Input moved to UTXO set: {}", input);
         }
         Ok(())
     }
@@ -3113,7 +3116,8 @@ fn run_migrations(db: &mut LMDBDatabase) -> Result<(), ChainStorageError> {
             txn.commit()?;
         }
 
-        // MIGRATION: Accumulated difficulty migration - blockchain rewind to last known good accumulated difficulty
+        // MIGRATION: Total accumulated difficulty migration - blockchain rewind to last known good accumulated
+        // difficulty
         if migrate_from_version == 1 {
             let known_good_difficulties = get_correct_accumulated_difficulty();
             if known_good_difficulties.is_empty() {
@@ -3160,24 +3164,24 @@ fn run_migrations(db: &mut LMDBDatabase) -> Result<(), ChainStorageError> {
             rewind_to_height(db, last_correct_height)?;
         }
 
-        // MIGRATION: Add payref index, rebuild payref index to recover deleted payrefs, add reverse payref index
+        // MIGRATION: Add payref index, rebuild payref index to recover deleted payrefs
         // Note: For previously running base nodes `last_migrated_version` was incremented beyond `MIGRATION_VERSION` up
         //       to `migrate_from_version == 4`. This migration also fix the error introduced with the original payref
         //       migration where it was only added for outputs in the unspent set, resulting in missing payrefs.
         if (migrate_from_version == 2 || migrate_from_version == 3 || migrate_from_version == 4) && !payref_index_done {
             info!(target: LOG_TARGET, "[MIGRATIONS] v{}: Starting PayRef migration", migrate_from_version);
 
+            // Verify database consistency before starting migration
             let read_txn = db.read_transaction()?;
-            let chain_height = fetch_chain_height(&read_txn, &db.metadata_db).unwrap_or(0);
+            let chain_height = match fetch_chain_height(&read_txn, &db.metadata_db) {
+                Ok(v) => v,
+                Err(_) => {
+                    // No chain data, skip PayRef rebuild
+                    drop(read_txn);
+                    continue;
+                },
+            };
             drop(read_txn);
-
-            // Clear the payref index first as they might now be wrong
-            {
-                let txn = db.write_transaction()?;
-                lmdb_clear(&txn, &db.payref_to_output_index)?;
-                txn.commit()?;
-                info!(target: LOG_TARGET, "[MIGRATIONS] v{}: Cleared PayRef index", migrate_from_version);
-            }
 
             for height in 0..=chain_height {
                 if height % 100 == 0 {
@@ -3305,72 +3309,40 @@ fn get_correct_accumulated_difficulty() -> Vec<(u64, U512)> {
     vec![]
 }
 
-/// Process a batch of blocks for PayRef migration with error handling
+/// Process a batch of blocks for PayRef migration
 fn process_payref_for_height(db: &LMDBDatabase, height: u64) -> Result<(), ChainStorageError> {
     debug!(target: LOG_TARGET, "Processing PayRef migration for {}", height);
 
-    let (block_hash, output_row_data) = if height == 0 {
-        let genesis_block = get_genesis_block(Network::get_current_or_user_setting_or_default());
-        let header_hash = genesis_block.header().hash();
-        let mined_timestamp = genesis_block.header().timestamp.as_u64();
-        let outputs = genesis_block
-            .block()
-            .body
-            .outputs()
-            .iter()
-            .map(|o| TransactionOutputRowData {
-                output: o.clone(),
-                header_hash,
-                hash: o.hash(),
-                mined_height: 0,
-                mined_timestamp,
-            })
-            .collect::<Vec<_>>();
-        (header_hash, outputs)
-    } else {
-        let read_txn = db.read_transaction()?;
-        let read_header: Option<BlockHeader> = lmdb_get(&read_txn, &db.headers_db, &height)?;
-        let header = read_header.ok_or_else(|| ChainStorageError::ValueNotFound {
-            entity: "BlockHeader",
-            field: "height",
-            value: height.to_string(),
-        })?;
-        let header_hash = header.hash();
-        let query_results: Vec<(Vec<u8>, TransactionOutputRowData)> =
-            lmdb_fetch_matching_after(&read_txn, &db.utxos_db, header_hash.as_slice())?;
-        let outputs = query_results
-            .iter()
-            .map(|(_, o)| TransactionOutputRowData {
-                output: o.output.clone(),
-                header_hash: o.header_hash,
-                hash: o.hash,
-                mined_height: o.mined_height,
-                mined_timestamp: o.mined_timestamp,
-            })
-            .collect::<Vec<_>>();
-        (header_hash, outputs)
-    };
-
     // Get all outputs for this block
-    let mut payrefs = Vec::new();
-    for output in output_row_data {
-        let payref = LMDBDatabase::generate_payment_reference_for_output(&block_hash, &output.hash);
-        payrefs.push((payref, output.hash));
-    }
+    let read_txn = db.read_transaction()?;
+    let read_header: Option<BlockHeader> = lmdb_get(&read_txn, &db.headers_db, &height)?;
+    let header = read_header.ok_or_else(|| ChainStorageError::ValueNotFound {
+        entity: "BlockHeader",
+        field: "height",
+        value: height.to_string(),
+    })?;
+    let block_hash = header.hash();
+    let query_results: Vec<(Vec<u8>, TransactionOutputRowData)> =
+        lmdb_fetch_matching_after(&read_txn, &db.utxos_db, block_hash.as_slice())?;
+    drop(read_txn);
+
+    // Add payrefs, replacing any existing ones
     let write_txn = db.write_transaction()?;
-    for (payref, output_hash) in payrefs {
+    for (_, output_data) in query_results {
+        let payref = LMDBDatabase::generate_payment_reference_for_output(&block_hash, &output_data.hash);
         trace!(target: LOG_TARGET,
             "Processing payref {} and output hash {} for height {}",
-            payref, output_hash, height
+            payref, output_data.hash, height
         );
         lmdb_replace(
             &write_txn,
             &db.payref_to_output_index,
             payref.as_slice(),
-            &output_hash,
+            &output_data.hash,
             None,
         )?;
     }
+
     // Commit the batch
     write_txn.commit()?;
 

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -649,22 +649,24 @@ impl LMDBDatabase {
         output_hash: &HashOutput,
     ) -> Result<(), ChainStorageError> {
         // Forward mapping: payref -> output_hash
-        lmdb_insert(
-            txn,
-            &self.payref_to_output_index,
-            payref.as_slice(),
-            output_hash,
-            "payref_to_output_index",
-        )?;
+        // lmdb_insert(
+        //     txn,
+        //     &self.payref_to_output_index,
+        //     payref.as_slice(),
+        //     output_hash,
+        //     "payref_to_output_index",
+        // )?;
+        lmdb_replace(txn, &self.payref_to_output_index, payref.as_slice(), &output_hash, None)?;
 
         // Reverse mapping: output_hash -> payref
-        lmdb_insert(
-            txn,
-            &self.output_to_payref_index,
-            output_hash.as_slice(),
-            payref,
-            "output_to_payref_index",
-        )?;
+        // lmdb_insert(
+        //     txn,
+        //     &self.output_to_payref_index,
+        //     output_hash.as_slice(),
+        //     payref,
+        //     "output_to_payref_index",
+        // )?;
+        lmdb_replace(txn, &self.output_to_payref_index, output_hash.as_slice(), payref, None)?;
 
         Ok(())
     }
@@ -1192,7 +1194,7 @@ impl LMDBDatabase {
         Ok(())
     }
 
-    /// Deletes both payref -> output_hash and output_hash -> payref from LMDB
+    // Deletes both payref -> output_hash and output_hash -> payref from LMDB
     fn delete_payref_index(
         &self,
         txn: &WriteTransaction<'_>,
@@ -1200,20 +1202,24 @@ impl LMDBDatabase {
         output_hash: &HashOutput,
     ) -> Result<(), ChainStorageError> {
         // Delete forward mapping
-        lmdb_delete(
+        let res1 = lmdb_delete(
             txn,
             &self.payref_to_output_index,
             payref.as_slice(),
             "payref_to_output_index",
-        )?;
+        );
 
         // Delete reverse mapping
-        lmdb_delete(
+        let res2 = lmdb_delete(
             txn,
             &self.output_to_payref_index,
             output_hash.as_slice(),
             "output_to_payref_index",
-        )?;
+        );
+
+        // Return error if either delete fails
+        res1?;
+        res2?;
 
         Ok(())
     }
@@ -3220,7 +3226,6 @@ fn run_migrations(db: &mut LMDBDatabase) -> Result<(), ChainStorageError> {
         // MIGRATION: Add payref index, rebuild payref index to recover deleted payrefs, add reverse payref index
         if (migrate_from_version == 2 || migrate_from_version == 3 || migrate_from_version == 4) && !payref_index_done {
             info!(target: LOG_TARGET, "Starting PayRef migration with reverse lookup");
-            let add_reverse_lookup = true;
 
             let read_txn = db.read_transaction()?;
             let chain_height = match fetch_chain_height(&read_txn, &db.metadata_db) {
@@ -3237,12 +3242,13 @@ fn run_migrations(db: &mut LMDBDatabase) -> Result<(), ChainStorageError> {
             {
                 let txn = db.write_transaction()?;
                 lmdb_clear(&txn, &db.payref_to_output_index)?;
+                lmdb_clear(&txn, &db.output_to_payref_index)?;
                 txn.commit()?;
                 info!(target: LOG_TARGET, "Cleared PayRef index");
             }
 
             for height in 0..=chain_height {
-                process_payref_for_height(db, height, add_reverse_lookup)?;
+                process_payref_for_height(db, height)?;
             }
 
             payref_index_done = true;
@@ -3359,11 +3365,7 @@ fn get_correct_accumulated_difficulty() -> Vec<(u64, U512)> {
 }
 
 /// Process a batch of blocks for PayRef migration with error handling
-fn process_payref_for_height(
-    db: &LMDBDatabase,
-    height: u64,
-    add_reverse_lookup: bool,
-) -> Result<(), ChainStorageError> {
+fn process_payref_for_height(db: &LMDBDatabase, height: u64) -> Result<(), ChainStorageError> {
     info!(target: LOG_TARGET, "Processing PayRef migration for  {}", height);
     let read_txn = db.read_transaction()?;
     let read_header: Option<BlockHeader> = lmdb_get(&read_txn, &db.headers_db, &height)?;
@@ -3391,6 +3393,10 @@ fn process_payref_for_height(
     drop(read_txn);
     let write_txn = db.write_transaction()?;
     for (payref, output_hash) in payrefs {
+        trace!(target: LOG_TARGET,
+            "Processing payref {} and output hash {} for height {}",
+            payref, output_hash, height
+        );
         lmdb_replace(
             &write_txn,
             &db.payref_to_output_index,
@@ -3398,15 +3404,13 @@ fn process_payref_for_height(
             &output_hash,
             None,
         )?;
-        if add_reverse_lookup {
-            lmdb_insert(
-                &write_txn,
-                &db.output_to_payref_index,
-                output_hash.as_slice(),
-                &payref,
-                "output_to_payref_index",
-            )?;
-        }
+        lmdb_replace(
+            &write_txn,
+            &db.output_to_payref_index,
+            output_hash.as_slice(),
+            &payref,
+            None,
+        )?;
     }
     write_txn.commit()?;
     // Commit the batch

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -3180,6 +3180,11 @@ fn run_migrations(db: &mut LMDBDatabase) -> Result<(), ChainStorageError> {
             }
 
             for height in 0..=chain_height {
+                if height % 100 == 0 {
+                    unsafe {
+                        LMDBStore::resize_if_required(&db.env, &db.env_config, None)?;
+                    }
+                }
                 process_payref_for_height(db, height)?;
             }
 

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -1058,40 +1058,20 @@ impl LMDBDatabase {
 
         for (_, utxo) in &output_rows {
             let output_hash = utxo.hash;
-            trace!(target: LOG_TARGET, "Deleting UTXO `{}`", output_hash);
+            let payref = Self::generate_payment_reference_for_output(block_hash, &output_hash);
+            trace!(target: LOG_TARGET, "Deleting UTXO `{}` with payref `{}`", output_hash, payref);
             lmdb_delete(
                 txn,
                 &self.txos_hash_to_index_db,
                 utxo.hash.as_slice(),
                 "txos_hash_to_index_db",
             )?;
-
-            // Clean up PayRef index for this output during reorg
-            // Only clean PayRef if output was actually created (not spent in same block, not burned)
-            let should_cleanup_payref =
-                !inputs.iter().any(|(_, r)| r.input.output_hash() == output_hash) && !utxo.output.is_burned();
-
-            if should_cleanup_payref {
-                let payref_bytes = Self::generate_payment_reference_for_output(block_hash, &output_hash);
-                // Delete the PayRef index entry with proper error handling
-                match lmdb_delete(
-                    txn,
-                    &self.payref_to_output_index,
-                    payref_bytes.as_slice(),
-                    "payref_to_output_index",
-                ) {
-                    Ok(()) => {
-                        debug!(target: LOG_TARGET, "Deleted PayRef during reorg for output {}", output_hash.to_hex())
-                    },
-                    Err(ChainStorageError::ValueNotFound { .. }) => {
-                        // Expected case for outputs that didn't have PayRefs
-                    },
-                    Err(e) => {
-                        error!(target: LOG_TARGET, "Failed to delete PayRef during reorg for output {}: {}", output_hash.to_hex(), e);
-                        return Err(e);
-                    },
-                }
-            }
+            lmdb_delete(
+                txn,
+                &self.payref_to_output_index,
+                payref.as_slice(),
+                "payref_to_output_index",
+            )?;
 
             // If an output was already spent in the block, it was never created as unspent, so don't delete it as it
             // does not exist here
@@ -2999,6 +2979,10 @@ fn run_migrations(db: &mut LMDBDatabase) -> Result<(), ChainStorageError> {
     let mut payref_index_done = false;
 
     for migrate_from_version in last_migrated_version..MIGRATION_VERSION {
+        unsafe {
+            LMDBStore::resize_if_required(&db.env, &db.env_config, None)?;
+        }
+
         // MIGRATION: Accumulated difficulty migration after the 3rd mining algorithm was introduced
         if migrate_from_version == 0 {
             let txn = db.read_transaction()?;
@@ -3184,7 +3168,16 @@ fn run_migrations(db: &mut LMDBDatabase) -> Result<(), ChainStorageError> {
             drop(read_txn);
 
             for height in 0..=chain_height {
-                if height % 100 == 0 {
+                // The average size added to the db per block for payrefs for the first 16,500 blocks was approximately
+                // 4,209 bytes as measured on a mainnet node and for the next 17,500 blocks approximately 7,550 bytes.
+                // The highest measured value is much less than the theoretical maximum of
+                // `(1000 coinbases + 900 outputs) * 2 * 32 bytes per output = 242,200 bytes per block`. The
+                // default db maspize increase is 128MB when we have less than 64MB free space left, so we should be
+                // checking how long it will take to fill up 64MB. Taking the biggest measured value we end up with
+                // approximately 8888 blocks to consume 64MB wirth of payref data. Theoretically, we can fill up 64MB
+                // with 277 block's worth of payrefs. To test if the db needs resizing every 1000 blocks is deemed
+                // practical and safe.
+                if height % 1000 == 0 {
                     unsafe {
                         LMDBStore::resize_if_required(&db.env, &db.env_config, None)?;
                     }

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -160,7 +160,6 @@ const LMDB_DB_UTXO_COMMITMENT_INDEX: &str = "utxo_commitment_index";
 const LMDB_DB_UNIQUE_ID_INDEX: &str = "unique_id_index";
 const LMDB_DB_CONTRACT_ID_INDEX: &str = "contract_index";
 const LMDB_DB_PAYREF_TO_OUTPUT_INDEX: &str = "payref_to_output_index";
-const LMDB_DB_OUTPUT_TO_PAYREF_INDEX: &str = "output_to_payref_index";
 const LMDB_DB_ORPHANS: &str = "orphans";
 const LMDB_DB_MONERO_SEED_HEIGHT: &str = "monero_seed_height";
 const LMDB_DB_MONERO_SEED_HEIGHT_INDEX: &str = "monero_seed_height_index";
@@ -215,7 +214,6 @@ pub fn create_lmdb_database<P: AsRef<Path>>(
         .add_database(LMDB_DB_UNIQUE_ID_INDEX, flags)
         .add_database(LMDB_DB_CONTRACT_ID_INDEX, flags)
         .add_database(LMDB_DB_PAYREF_TO_OUTPUT_INDEX, flags)
-        .add_database(LMDB_DB_OUTPUT_TO_PAYREF_INDEX, flags)
         .add_database(LMDB_DB_DELETED_TXO_HASH_TO_HEADER_INDEX, flags)
         .add_database(LMDB_DB_ORPHANS, flags)
         .add_database(LMDB_DB_ORPHAN_HEADER_ACCUMULATED_DATA, flags)
@@ -274,8 +272,6 @@ pub struct LMDBDatabase {
     contract_index: DatabaseRef,
     /// Maps payment_reference[32] -> output_hash[32] for fast PayRef lookup
     payref_to_output_index: DatabaseRef,
-    /// Maps output_hash[32]  -> payment_reference[32]for fast PayRef lookup
-    output_to_payref_index: DatabaseRef,
     /// Maps output hash-> <block_hash, input_hash>
     deleted_txo_hash_to_header_index: DatabaseRef,
     /// Maps block_hash -> Block
@@ -333,7 +329,6 @@ impl LMDBDatabase {
             unique_id_index: get_database(store, LMDB_DB_UNIQUE_ID_INDEX)?,
             contract_index: get_database(store, LMDB_DB_CONTRACT_ID_INDEX)?,
             payref_to_output_index: get_database(store, LMDB_DB_PAYREF_TO_OUTPUT_INDEX)?,
-            output_to_payref_index: get_database(store, LMDB_DB_OUTPUT_TO_PAYREF_INDEX)?,
             deleted_txo_hash_to_header_index: get_database(store, LMDB_DB_DELETED_TXO_HASH_TO_HEADER_INDEX)?,
             orphans_db: get_database(store, LMDB_DB_ORPHANS)?,
             orphan_header_accumulated_data_db: get_database(store, LMDB_DB_ORPHAN_HEADER_ACCUMULATED_DATA)?,
@@ -549,7 +544,7 @@ impl LMDBDatabase {
         Ok(())
     }
 
-    fn all_dbs(&self) -> [(&'static str, &DatabaseRef); 33] {
+    fn all_dbs(&self) -> [(&'static str, &DatabaseRef); 32] {
         [
             (LMDB_DB_METADATA, &self.metadata_db),
             (LMDB_DB_HEADERS, &self.headers_db),
@@ -567,7 +562,6 @@ impl LMDBDatabase {
             (LMDB_DB_CONTRACT_ID_INDEX, &self.contract_index),
             (LMDB_DB_UNIQUE_ID_INDEX, &self.unique_id_index),
             (LMDB_DB_PAYREF_TO_OUTPUT_INDEX, &self.payref_to_output_index),
-            (LMDB_DB_OUTPUT_TO_PAYREF_INDEX, &self.output_to_payref_index),
             (
                 LMDB_DB_DELETED_TXO_HASH_TO_HEADER_INDEX,
                 &self.deleted_txo_hash_to_header_index,
@@ -617,7 +611,7 @@ impl LMDBDatabase {
 
         // Generate PayRef and add to index
         let payref = Self::generate_payment_reference_for_output(header_hash, &output_hash);
-        self.insert_payref_index(txn, &payref, &output_hash)?;
+        lmdb_replace(txn, &self.payref_to_output_index, payref.as_slice(), &output_hash, None)?;
 
         lmdb_insert(
             txn,
@@ -639,36 +633,6 @@ impl LMDBDatabase {
             },
             LMDB_DB_UTXOS,
         )?;
-
-        Ok(())
-    }
-
-    /// Inserts both payref -> output_hash and output_hash -> payref into LMDB
-    fn insert_payref_index(
-        &self,
-        txn: &WriteTransaction<'_>,
-        payref: &FixedHash,
-        output_hash: &HashOutput,
-    ) -> Result<(), ChainStorageError> {
-        // Forward mapping: payref -> output_hash
-        // lmdb_insert(
-        //     txn,
-        //     &self.payref_to_output_index,
-        //     payref.as_slice(),
-        //     output_hash,
-        //     "payref_to_output_index",
-        // )?;
-        lmdb_replace(txn, &self.payref_to_output_index, payref.as_slice(), &output_hash, None)?;
-
-        // Reverse mapping: output_hash -> payref
-        // lmdb_insert(
-        //     txn,
-        //     &self.output_to_payref_index,
-        //     output_hash.as_slice(),
-        //     payref,
-        //     "output_to_payref_index",
-        // )?;
-        lmdb_replace(txn, &self.output_to_payref_index, output_hash.as_slice(), payref, None)?;
 
         Ok(())
     }
@@ -1107,7 +1071,12 @@ impl LMDBDatabase {
             if should_cleanup_payref {
                 let payref_bytes = Self::generate_payment_reference_for_output(block_hash, &output_hash);
                 // Delete the PayRef index entry with proper error handling
-                match self.delete_payref_index(txn, &payref_bytes, &output_hash) {
+                match lmdb_delete(
+                    txn,
+                    &self.payref_to_output_index,
+                    payref_bytes.as_slice(),
+                    "payref_to_output_index",
+                ) {
                     Ok(()) => {
                         debug!(target: LOG_TARGET, "Deleted PayRef during reorg for output {}", output_hash.to_hex())
                     },
@@ -1182,7 +1151,7 @@ impl LMDBDatabase {
 
             let payref =
                 Self::generate_payment_reference_for_output(&utxo_mined_info.header_hash, &input.output_hash());
-            self.insert_payref_index(txn, &payref, &output_hash)?;
+            lmdb_replace(txn, &self.payref_to_output_index, payref.as_slice(), &output_hash, None)?;
 
             trace!(target: LOG_TARGET, "Input moved to UTXO set: {}", input);
             lmdb_insert(
@@ -1193,36 +1162,6 @@ impl LMDBDatabase {
                 "utxo_commitment_index",
             )?;
         }
-        Ok(())
-    }
-
-    // Deletes both payref -> output_hash and output_hash -> payref from LMDB
-    fn delete_payref_index(
-        &self,
-        txn: &WriteTransaction<'_>,
-        payref: &FixedHash,
-        output_hash: &HashOutput,
-    ) -> Result<(), ChainStorageError> {
-        // Delete forward mapping
-        let res1 = lmdb_delete(
-            txn,
-            &self.payref_to_output_index,
-            payref.as_slice(),
-            "payref_to_output_index",
-        );
-
-        // Delete reverse mapping
-        let res2 = lmdb_delete(
-            txn,
-            &self.output_to_payref_index,
-            output_hash.as_slice(),
-            "output_to_payref_index",
-        );
-
-        // Return error if either delete fails
-        res1?;
-        res2?;
-
         Ok(())
     }
 
@@ -1954,31 +1893,18 @@ impl LMDBDatabase {
         txn: &ConstTransaction<'_>,
         output_hash: &HashOutput,
     ) -> Result<MinedInfo, ChainStorageError> {
-        if let Ok(Some(mined_info)) = self.fetch_output_in_txn(txn, output_hash.as_slice()) {
-            Ok(MinedInfo {
-                input: None,
-                output: Some(mined_info),
-            })
-        } else if let Ok(Some(mined_info)) = self.fetch_input_in_txn(txn, output_hash.as_slice()) {
-            Ok(MinedInfo {
-                input: Some(mined_info),
-                output: None,
-            })
-        } else {
-            Ok(MinedInfo {
-                input: None,
-                output: None,
-            })
+        let mut mined_info = MinedInfo {
+            input: None,
+            output: None,
+        };
+        if let Ok(Some(output_mined_info)) = self.fetch_output_in_txn(txn, output_hash.as_slice()) {
+            mined_info.output = Some(output_mined_info);
         }
-    }
+        if let Ok(Some(input_mined_info)) = self.fetch_input_in_txn(txn, output_hash.as_slice()) {
+            mined_info.input = Some(input_mined_info);
+        }
 
-    // Fetch mined info by PayRef (Payment Reference)
-    fn fetch_payref_by_output_hash_in_txn(
-        &self,
-        txn: &ConstTransaction<'_>,
-        output_hash: &HashOutput,
-    ) -> Result<Option<FixedHash>, ChainStorageError> {
-        lmdb_get::<_, FixedHash>(txn, &self.output_to_payref_index, output_hash.as_slice())
+        Ok(mined_info)
     }
 
     fn get_consensus_constants(&self, height: u64) -> &ConsensusConstants {
@@ -2434,11 +2360,6 @@ impl BlockchainBackend for LMDBDatabase {
     fn fetch_mined_info_by_output_hash(&self, output_hash: &HashOutput) -> Result<MinedInfo, ChainStorageError> {
         let txn = self.read_transaction()?;
         self.fetch_mined_info_by_output_hash_in_txn(&txn, output_hash)
-    }
-
-    fn fetch_payref_by_output_hash(&self, output_hash: &HashOutput) -> Result<Option<FixedHash>, ChainStorageError> {
-        let txn = self.read_transaction()?;
-        self.fetch_payref_by_output_hash_in_txn(&txn, output_hash)
     }
 
     fn fetch_outputs_in_block(&self, header_hash: &HashOutput) -> Result<Vec<TransactionOutput>, ChainStorageError> {
@@ -3254,7 +3175,6 @@ fn run_migrations(db: &mut LMDBDatabase) -> Result<(), ChainStorageError> {
             {
                 let txn = db.write_transaction()?;
                 lmdb_clear(&txn, &db.payref_to_output_index)?;
-                lmdb_clear(&txn, &db.output_to_payref_index)?;
                 txn.commit()?;
                 info!(target: LOG_TARGET, "[MIGRATIONS] v{}: Cleared PayRef index", migrate_from_version);
             }
@@ -3443,13 +3363,6 @@ fn process_payref_for_height(db: &LMDBDatabase, height: u64) -> Result<(), Chain
             &db.payref_to_output_index,
             payref.as_slice(),
             &output_hash,
-            None,
-        )?;
-        lmdb_replace(
-            &write_txn,
-            &db.output_to_payref_index,
-            output_hash.as_slice(),
-            &payref,
             None,
         )?;
     }

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -36,6 +36,7 @@ use lmdb_zero::{open, ConstTransaction, Database, Environment, ReadTransaction, 
 use log::*;
 use primitive_types::{U256, U512};
 use serde::{Deserialize, Serialize};
+use tari_common::configuration::Network;
 use tari_common_types::{
     chain_metadata::ChainMetadata,
     epoch::VnEpoch,
@@ -66,6 +67,7 @@ use super::{
 };
 use crate::{
     blocks::{
+        genesis_block::get_genesis_block,
         Block,
         BlockAccumulatedData,
         BlockHeader,
@@ -3065,12 +3067,11 @@ fn run_migrations(db: &mut LMDBDatabase) -> Result<(), ChainStorageError> {
     };
     info!(
         target: LOG_TARGET,
-        "Blockchain database is at v{} (required version: {})", last_migrated_version, MIGRATION_VERSION
+        "[MIGRATIONS] Blockchain database is at v{} (required version: {})",
+        last_migrated_version, MIGRATION_VERSION
     );
     drop(txn);
 
-    // This is to fix the previous payref migration error as `last_migrated_version` was incremented beyond
-    // `MIGRATION_VERSION`
     let mut payref_index_done = false;
 
     for migrate_from_version in last_migrated_version..MIGRATION_VERSION {
@@ -3111,7 +3112,8 @@ fn run_migrations(db: &mut LMDBDatabase) -> Result<(), ChainStorageError> {
                 txn.commit()?;
                 info!(
                     target: LOG_TARGET,
-                    "Replaced tip accumulated data ",
+                    "[MIGRATIONS] v{}: Replaced tip accumulated data ",
+                    migrate_from_version
                 );
             }
             let txn = db.write_transaction()?;
@@ -3147,7 +3149,8 @@ fn run_migrations(db: &mut LMDBDatabase) -> Result<(), ChainStorageError> {
             let txn = db.write_transaction()?;
             info!(
                 target: LOG_TARGET,
-                "Replaced accumulated data for blocks",
+                "[MIGRATIONS] v{}: Replaced accumulated data for blocks",
+                migrate_from_version
             );
             let orphan_headers_accum_data: Vec<(Vec<u8>, V0BLockHeaderAccumulatedData)> =
                 lmdb_all(&txn, &db.orphan_header_accumulated_data_db)?;
@@ -3174,7 +3177,8 @@ fn run_migrations(db: &mut LMDBDatabase) -> Result<(), ChainStorageError> {
             let txn = db.write_transaction()?;
             info!(
                 target: LOG_TARGET,
-                "Replaced accumulated data for orphan blocks",
+                "[MIGRATIONS] v{}: Replaced accumulated data for orphan blocks",
+                migrate_from_version
             );
             let orphan_chain_tips: Vec<(Vec<u8>, OldChainTipData)> = lmdb_all(&txn, &db.orphan_chain_tips_db)?;
 
@@ -3192,7 +3196,11 @@ fn run_migrations(db: &mut LMDBDatabase) -> Result<(), ChainStorageError> {
         if migrate_from_version == 1 {
             let known_good_difficulties = get_correct_accumulated_difficulty();
             if known_good_difficulties.is_empty() {
-                info!(target: LOG_TARGET, "No migration to perform for version network");
+                info!(
+                    target: LOG_TARGET,
+                    "[MIGRATIONS] v{}: No migration to perform for version network",
+                    migrate_from_version
+                );
                 continue;
             }
             let mut last_correct_height = 0;
@@ -3204,19 +3212,27 @@ fn run_migrations(db: &mut LMDBDatabase) -> Result<(), ChainStorageError> {
                     if accum_data.total_accumulated_difficulty == correct_difficulty {
                         info!(
                             target: LOG_TARGET,
-                            "Block height {} already has correct accumulated difficulty",
-                            height
+                            "[MIGRATIONS] v{}: Block height {} already has correct accumulated difficulty",
+                            migrate_from_version, height
                         );
                         last_correct_height = height;
                     }
                 } else {
-                    info!(target: LOG_TARGET, "No accumulated difficulty found for block height {}", height);
+                    info!(
+                        target: LOG_TARGET,
+                        "[MIGRATIONS] v{}: No accumulated difficulty found for block height {}",
+                        migrate_from_version, height
+                    );
                     break;
                 }
             }
             if last_correct_height == 0 {
                 // this will happen only happen if the db is below the fork height of the RxT fork
-                info!(target: LOG_TARGET, "No migration to perform for version network");
+                info!(
+                    target: LOG_TARGET,
+                    "[MIGRATIONS] v{}: No migration to perform for version network",
+                    migrate_from_version
+                );
                 continue;
             }
             // lets rewind to last known good accumulated difficulty so the db can be correctly calculated again
@@ -3224,18 +3240,14 @@ fn run_migrations(db: &mut LMDBDatabase) -> Result<(), ChainStorageError> {
         }
 
         // MIGRATION: Add payref index, rebuild payref index to recover deleted payrefs, add reverse payref index
+        // Note: For previously running base nodes `last_migrated_version` was incremented beyond `MIGRATION_VERSION` up
+        //       to `migrate_from_version == 4`. This migration also fix the error introduced with the original payref
+        //       migration where it was only added for outputs in the unspent set, resulting in missing payrefs.
         if (migrate_from_version == 2 || migrate_from_version == 3 || migrate_from_version == 4) && !payref_index_done {
-            info!(target: LOG_TARGET, "Starting PayRef migration with reverse lookup");
+            info!(target: LOG_TARGET, "[MIGRATIONS] v{}: Starting PayRef migration", migrate_from_version);
 
             let read_txn = db.read_transaction()?;
-            let chain_height = match fetch_chain_height(&read_txn, &db.metadata_db) {
-                Ok(v) => v,
-                Err(_) => {
-                    // No chain data, skip PayRef rebuild
-                    drop(read_txn);
-                    return Ok(());
-                },
-            };
+            let chain_height = fetch_chain_height(&read_txn, &db.metadata_db).unwrap_or(0);
             drop(read_txn);
 
             // Clear the payref index first as they might now be wrong
@@ -3244,7 +3256,7 @@ fn run_migrations(db: &mut LMDBDatabase) -> Result<(), ChainStorageError> {
                 lmdb_clear(&txn, &db.payref_to_output_index)?;
                 lmdb_clear(&txn, &db.output_to_payref_index)?;
                 txn.commit()?;
-                info!(target: LOG_TARGET, "Cleared PayRef index");
+                info!(target: LOG_TARGET, "[MIGRATIONS] v{}: Cleared PayRef index", migrate_from_version);
             }
 
             for height in 0..=chain_height {
@@ -3252,18 +3264,22 @@ fn run_migrations(db: &mut LMDBDatabase) -> Result<(), ChainStorageError> {
             }
 
             payref_index_done = true;
-            info!(target: LOG_TARGET, "PayRef index rebuild with reverse lookup completed");
+            info!(target: LOG_TARGET, "[MIGRATIONS] v{}: PayRef index rebuild completed", migrate_from_version);
         }
 
         // Lets update the migration version
         {
+            let migrated_to_version = migrate_from_version + 1;
             let txn = db.write_transaction()?;
-            info!(target: LOG_TARGET, "Migrated database to version {}", MIGRATION_VERSION);
+            info!(
+                target: LOG_TARGET, "[MIGRATIONS] Migrated database from version {} to version {}",
+                migrate_from_version, migrated_to_version
+            );
             lmdb_replace(
                 &txn,
                 &db.metadata_db,
                 &k.as_u32(),
-                &MetadataValue::MigrationVersion(max(migrate_from_version + 1, MIGRATION_VERSION)),
+                &MetadataValue::MigrationVersion(migrated_to_version),
                 None,
             )?;
             txn.commit()?;
@@ -3366,31 +3382,56 @@ fn get_correct_accumulated_difficulty() -> Vec<(u64, U512)> {
 
 /// Process a batch of blocks for PayRef migration with error handling
 fn process_payref_for_height(db: &LMDBDatabase, height: u64) -> Result<(), ChainStorageError> {
-    info!(target: LOG_TARGET, "Processing PayRef migration for  {}", height);
-    let read_txn = db.read_transaction()?;
-    let read_header: Option<BlockHeader> = lmdb_get(&read_txn, &db.headers_db, &height)?;
-    let header = read_header.ok_or_else(|| ChainStorageError::ValueNotFound {
-        entity: "BlockHeader",
-        field: "height",
-        value: height.to_string(),
-    })?;
-    let block_hash = header.hash();
+    debug!(target: LOG_TARGET, "Processing PayRef migration for {}", height);
+
+    let (block_hash, output_row_data) = if height == 0 {
+        let genesis_block = get_genesis_block(Network::get_current_or_user_setting_or_default());
+        let header_hash = genesis_block.header().hash();
+        let mined_timestamp = genesis_block.header().timestamp.as_u64();
+        let outputs = genesis_block
+            .block()
+            .body
+            .outputs()
+            .iter()
+            .map(|o| TransactionOutputRowData {
+                output: o.clone(),
+                header_hash,
+                hash: o.hash(),
+                mined_height: 0,
+                mined_timestamp,
+            })
+            .collect::<Vec<_>>();
+        (header_hash, outputs)
+    } else {
+        let read_txn = db.read_transaction()?;
+        let read_header: Option<BlockHeader> = lmdb_get(&read_txn, &db.headers_db, &height)?;
+        let header = read_header.ok_or_else(|| ChainStorageError::ValueNotFound {
+            entity: "BlockHeader",
+            field: "height",
+            value: height.to_string(),
+        })?;
+        let header_hash = header.hash();
+        let query_results: Vec<(Vec<u8>, TransactionOutputRowData)> =
+            lmdb_fetch_matching_after(&read_txn, &db.utxos_db, header_hash.as_slice())?;
+        let outputs = query_results
+            .iter()
+            .map(|(_, o)| TransactionOutputRowData {
+                output: o.output.clone(),
+                header_hash: o.header_hash,
+                hash: o.hash,
+                mined_height: o.mined_height,
+                mined_timestamp: o.mined_timestamp,
+            })
+            .collect::<Vec<_>>();
+        (header_hash, outputs)
+    };
+
     // Get all outputs for this block
-    let outputs: Vec<(Vec<u8>, TransactionOutputRowData)> =
-        lmdb_fetch_matching_after(&read_txn, &db.utxos_db, block_hash.as_slice())?;
     let mut payrefs = Vec::new();
-    for (_, output_data) in outputs {
-        let exist = lmdb_exists(
-            &read_txn,
-            &db.utxo_commitment_index,
-            output_data.output.commitment().as_bytes(),
-        )?;
-        if exist {
-            let payref = LMDBDatabase::generate_payment_reference_for_output(&block_hash, &output_data.hash);
-            payrefs.push((payref, output_data.hash));
-        }
+    for output in output_row_data {
+        let payref = LMDBDatabase::generate_payment_reference_for_output(&block_hash, &output.hash);
+        payrefs.push((payref, output.hash));
     }
-    drop(read_txn);
     let write_txn = db.write_transaction()?;
     for (payref, output_hash) in payrefs {
         trace!(target: LOG_TARGET,
@@ -3412,8 +3453,8 @@ fn process_payref_for_height(db: &LMDBDatabase, height: u64) -> Result<(), Chain
             None,
         )?;
     }
-    write_txn.commit()?;
     // Commit the batch
+    write_txn.commit()?;
 
     Ok(())
 }

--- a/base_layer/core/src/chain_storage/utxo_mined_info.rs
+++ b/base_layer/core/src/chain_storage/utxo_mined_info.rs
@@ -40,3 +40,9 @@ pub struct InputMinedInfo {
     pub header_hash: BlockHash,
     pub spent_timestamp: u64,
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MinedInfo {
+    pub input: Option<InputMinedInfo>,
+    pub output: Option<OutputMinedInfo>,
+}

--- a/base_layer/core/src/test_helpers/blockchain.rs
+++ b/base_layer/core/src/test_helpers/blockchain.rs
@@ -323,10 +323,6 @@ impl BlockchainBackend for TempDatabase {
         self.db.as_ref().unwrap().fetch_mined_info_by_output_hash(output_hash)
     }
 
-    fn fetch_payref_by_output_hash(&self, output_hash: &HashOutput) -> Result<Option<FixedHash>, ChainStorageError> {
-        self.db.as_ref().unwrap().fetch_payref_by_output_hash(output_hash)
-    }
-
     fn fetch_outputs_in_block(&self, header_hash: &HashOutput) -> Result<Vec<TransactionOutput>, ChainStorageError> {
         self.db.as_ref().unwrap().fetch_outputs_in_block(header_hash)
     }

--- a/base_layer/core/src/test_helpers/blockchain.rs
+++ b/base_layer/core/src/test_helpers/blockchain.rs
@@ -61,6 +61,7 @@ use crate::{
         HorizonData,
         InputMinedInfo,
         LMDBDatabase,
+        MinedInfo,
         MmrTree,
         OutputMinedInfo,
         OwnedLmdbTreeReader,
@@ -314,8 +315,16 @@ impl BlockchainBackend for TempDatabase {
             .fetch_unspent_output_hash_by_commitment(commitment)
     }
 
-    fn fetch_output_by_payref(&self, payref: &FixedHash) -> Result<Option<OutputMinedInfo>, ChainStorageError> {
-        self.db.as_ref().unwrap().fetch_output_by_payref(payref)
+    fn fetch_mined_info_by_payref(&self, payref: &FixedHash) -> Result<MinedInfo, ChainStorageError> {
+        self.db.as_ref().unwrap().fetch_mined_info_by_payref(payref)
+    }
+
+    fn fetch_mined_info_by_output_hash(&self, output_hash: &HashOutput) -> Result<MinedInfo, ChainStorageError> {
+        self.db.as_ref().unwrap().fetch_mined_info_by_output_hash(output_hash)
+    }
+
+    fn fetch_payref_by_output_hash(&self, output_hash: &HashOutput) -> Result<Option<FixedHash>, ChainStorageError> {
+        self.db.as_ref().unwrap().fetch_payref_by_output_hash(output_hash)
     }
 
     fn fetch_outputs_in_block(&self, header_hash: &HashOutput) -> Result<Vec<TransactionOutput>, ChainStorageError> {

--- a/base_layer/core/tests/chain_storage_tests/chain_storage.rs
+++ b/base_layer/core/tests/chain_storage_tests/chain_storage.rs
@@ -203,7 +203,7 @@ fn test_checkpoints() {
 #[test]
 #[allow(clippy::identity_op)]
 fn test_rewind_to_height() {
-    let _ = env_logger::builder().is_test(true).try_init();
+    // let _ = env_logger::builder().is_test(true).try_init();
     let network = Network::LocalNet;
     let (mut db, mut blocks, mut outputs, consensus_manager) = create_new_blockchain(network);
 

--- a/base_layer/core/tests/tests/block_sync.rs
+++ b/base_layer/core/tests/tests/block_sync.rs
@@ -29,8 +29,7 @@ use crate::helpers::{
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_block_sync_happy_path() {
-    // env_logger::builder().filter_level(log::LevelFilter::Debug).init();
-    // env_logger::init(); // Set `$env:RUST_LOG = "trace"`  //  > ./target/output.log 2>&1
+    // env_logger::builder().filter_level(log::LevelFilter::Trace).init();  //  > ./target/output.log 2>&1
 
     // Create the network with Alice node and Bob node
     let (mut state_machines, mut peer_nodes, initial_block, consensus_manager, key_manager, initial_coinbase) =

--- a/base_layer/core/tests/tests/block_validation.rs
+++ b/base_layer/core/tests/tests/block_validation.rs
@@ -262,7 +262,7 @@ fn add_bad_monero_data(tblock: &mut Block, seed_key: &str) {
 
 #[tokio::test]
 async fn inputs_are_not_malleable() {
-    let _ = env_logger::try_init();
+    // let _ = env_logger::builder().filter_level(log::LevelFilter::Trace).init(); //  > ./target/output.log 2>&1
     let mut blockchain = TestBlockchain::with_genesis("GB").await;
     let blocks = blockchain.builder();
 

--- a/common/config/presets/c_base_node_b_mining_allow_methods.toml
+++ b/common/config/presets/c_base_node_b_mining_allow_methods.toml
@@ -52,4 +52,5 @@ grpc_server_allow_methods = [
     "get_template_registrations",
     "get_side_chain_utxos",
     "search_payment_references",
+    "search_payment_references_via_output_hash",
 ]

--- a/common/config/presets/c_base_node_b_non_mining_allow_methods.toml
+++ b/common/config/presets/c_base_node_b_non_mining_allow_methods.toml
@@ -52,4 +52,5 @@ grpc_server_allow_methods = [
     #"get_template_registrations",
     #"get_side_chain_utxos",
     #"search_payment_references",
+    #"search_payment_references_via_output_hash",
 ]

--- a/comms/dht/src/connectivity/test.rs
+++ b/comms/dht/src/connectivity/test.rs
@@ -142,7 +142,7 @@ async fn initialize() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn added_neighbours() {
-    // env_logger::init(); // Set `$env:RUST_LOG = "trace"` // Pipe to `> .\target\output.txt 2>&1`
+    // env_logger::init(); // Set `$env:RUST_LOG = "trace"` // Pipe to `> .\target\output.log 2>&1`
     let node_identity = make_node_identity();
     let mut node_identities =
         ordered_node_identities_by_distance(node_identity.node_id(), 6, PeerFeatures::COMMUNICATION_NODE);

--- a/infrastructure/storage/src/lmdb_store/store.rs
+++ b/infrastructure/storage/src/lmdb_store/store.rs
@@ -438,7 +438,7 @@ impl LMDBStore {
                 size_used_bytes / BYTES_PER_MB,
                 size_left_bytes / BYTES_PER_MB
             );
-            Self::resize(env, config, Some(increase_threshold_by.unwrap_or_default()))?;
+            Self::resize(env, config, increase_threshold_by)?;
         }
         Ok(())
     }

--- a/integration_tests/tests/features/WalletTransactions.feature
+++ b/integration_tests/tests/features/WalletTransactions.feature
@@ -185,7 +185,7 @@ Feature: Wallet Transactions
     Given I have a seed node NODE
     When I have wallet WALLET_A connected to all seed nodes
     When I have wallet WALLET_B connected to all seed nodes
-    When I have mining node MINER connected to base node NODE and wallet WALLET_A
+    When I have SHA3X mining node MINER connected to base node NODE and wallet WALLET_A
     When mining node MINER mines 50 blocks
     Then all nodes are at height 50
     Then I wait for wallet WALLET_A to have at least 10000000000 uT


### PR DESCRIPTION
Description
---
- Added gRPC method to retrieve output information via output hash
- Updated the gRPC payref search to return spent and unspent output information
- Added migration to rebuild payref indexes due to missing payrefs (_added periodic call to `LMDBStore::resize_if_required`_)
- Fixed error in lmdb migration counter where it recorded a higher version done than what it should

Fixes #7263 

Motivation and Context
---
- Payref information was deleted when the outputs were spent.
- With migrations, payref information was only created for the current output set, not all outputs.
- Payref lookups for spent outputs were not possible.
- Output and payref information was not possible via output hash.

How Has This Been Tested?
---
- New lmdb migration tested at the system level for fresh and existing base nodes.
- New gRPC method system-level testing [_tested with block explorer upgrade_].
- General system-level testing.

Fresh base node with a restart afterwards
```rust
2025-06-27 09:09:24.013840800 [c::cs::lmdb_db::lmdb_db] INFO  [MIGRATIONS] Blockchain database is at v0 (required version: 5)
2025-06-27 09:09:24.013873800 [c::cs::lmdb_db::lmdb_db] INFO  [MIGRATIONS] v1: No accumulated difficulty found for block height 14999
2025-06-27 09:09:24.013877800 [c::cs::lmdb_db::lmdb_db] INFO  [MIGRATIONS] v1: No migration to perform for version network
2025-06-27 09:09:24.013883100 [c::cs::lmdb_db::lmdb_db] INFO  [MIGRATIONS] v2: Starting PayRef migration
2025-06-27 09:09:24.013899700 [c::cs::lmdb_db::lmdb_db] INFO  [MIGRATIONS] v2: Cleared PayRef index
2025-06-27 09:09:24.038671500 [c::cs::lmdb_db::lmdb_db] INFO  [MIGRATIONS] v2: PayRef index rebuild completed
2025-06-27 09:09:24.038693200 [c::cs::lmdb_db::lmdb_db] INFO  [MIGRATIONS] Migrated database from version 2 to version 3
2025-06-27 09:09:24.039646900 [c::cs::lmdb_db::lmdb_db] INFO  [MIGRATIONS] Migrated database from version 3 to version 4
2025-06-27 09:09:24.040506700 [c::cs::lmdb_db::lmdb_db] INFO  [MIGRATIONS] Migrated database from version 4 to version 5
2025-06-27 09:10:24.526178200 [c::cs::lmdb_db::lmdb_db] INFO  [MIGRATIONS] Blockchain database is at v5 (required version: 5)
```

What process can a PR reviewer use to test or verify this change?
---
- Code review.
- System-level testing.

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [ ] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [X] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
BREAKING CHANGE: 
- A new base node gRPC method `SearchPaymentReferencesViaOutputHash` was added that returns a stream of `PaymentReferenceResponse`.
- The gRPC `PaymentReferenceResponse` was also updated to return the spent timestamp and output hash additionally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a new gRPC method to search payment references by output hash, providing detailed mined and spent information for outputs.
  * Expanded response data to include spent timestamps and output hashes for enhanced transaction tracing.

* **Refactor**
  * Unified and extended backend logic for fetching mined information by payment reference or output hash.
  * Improved migration and index handling for payment references to ensure data consistency, including genesis block coverage.

* **Documentation**
  * Clarified field comments and updated configuration files to reflect new gRPC capabilities.

* **Style**
  * Updated test and code comments for clarity and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->