### PR TITLE
fix: get_all_completed_transactions limit issues

### DIFF
--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -1324,7 +1324,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
         let mut transaction_service = self.get_transaction_service();
 
         let mut completed_transactions = transaction_service
-            .get_completed_transactions(None, None, None, req.limit)
+            .get_completed_transactions(None, None, None, 0)
             .await
             .map_err(|err| {
                 Status::not_found(format!(
@@ -1334,7 +1334,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
             })?;
         completed_transactions.extend(
             transaction_service
-                .get_cancelled_completed_transactions(req.limit)
+                .get_cancelled_completed_transactions(0)
                 .await
                 .map_err(|err| {
                     Status::not_found(format!(


### PR DESCRIPTION
Description
---
Limit filter was applied twice:
1. when fetching completed and cancelled transactions, we use limit for both
2 We apply offset and limit filter on merged records, which means: offset 20, limit 20. returns 0 records

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where completed and cancelled transactions were not fully retrieved due to an unintended limit. All relevant transactions are now fetched as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->