### PR TITLE
feat: display seed info with list-connections command

### DIFF
--- a/applications/minotari_node/src/commands/command/list_connections.rs
+++ b/applications/minotari_node/src/commands/command/list_connections.rs
@@ -51,6 +51,7 @@ impl CommandContext {
             "Direction",
             "Age",
             "User Agent",
+            "Seed",
             "Info",
         ]);
         let peer_manager = self.comms.peer_manager();
@@ -80,6 +81,7 @@ impl CommandContext {
                 .and_then(|v| bincode::deserialize::<PeerMetadata>(v).ok())
                 .map(|metadata| format!("height: {}", metadata.metadata.best_block_height()));
 
+            let is_seed = peer.is_seed();
             let ua = peer.user_agent;
             let rpc_sessions = self
                 .rpc_server
@@ -99,6 +101,7 @@ impl CommandContext {
                         ua.as_ref()
                     }
                 },
+                if is_seed { "SEED" } else { "    " },
                 format!(
                     "{}hnd: {}, ss: {}, rpc: {}",
                     chain_height.map(|s| format!("{}, ", s)).unwrap_or_default(),


### PR DESCRIPTION
Description
---
Add display seed with `list-connections` in the base node console.

Motivation and Context
---
Display more insightful connection information.

How Has This Been Tested?
---
System-level testing.

What process can a PR reviewer use to test or verify this change?
---
Code review.

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Seed" column to the connections table in the list connections output, indicating which peers are seed nodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->