### PR TITLE
feat: add concurrency when contacting seed peers while performing seed strap

### DIFF
--- a/base_layer/core/src/consensus/consensus_manager.rs
+++ b/base_layer/core/src/consensus/consensus_manager.rs
@@ -20,7 +20,9 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{convert::TryFrom, sync::Arc};
+#[cfg(feature = "base_node")]
+use std::convert::TryFrom;
+use std::sync::Arc;
 
 use tari_common::configuration::Network;
 use thiserror::Error;

--- a/comms/dht/Cargo.toml
+++ b/comms/dht/Cargo.toml
@@ -32,6 +32,7 @@ diesel = { version = "2.2.10", features = [
 diesel_migrations = "2.2.0"
 digest = "0.10"
 futures = "^0.3.1"
+futures-util = "^0.3.1"
 log = "0.4.8"
 prost = "0.13.3"
 rand = "0.8"
@@ -54,7 +55,6 @@ tari_test_utils = { workspace = true }
 
 env_logger = "0.10"
 futures-test = { version = "0.3.5" }
-futures-util = "^0.3.1"
 lmdb-zero = "0.4.4"
 once_cell = "1.8.0"
 tempfile = "3.1.0"

--- a/comms/dht/src/network_discovery/discovering.rs
+++ b/comms/dht/src/network_discovery/discovering.rs
@@ -85,8 +85,6 @@ impl Discovering {
 
         // Set discovery phase and rounds information
         self.stats.phase = DiscoveryPhase::General;
-        self.stats.round_number = Some(self.context.num_rounds());
-        self.stats.total_rounds = None; // No fixed total for general discovery
 
         Ok(())
     }

--- a/comms/dht/src/network_discovery/on_connect.rs
+++ b/comms/dht/src/network_discovery/on_connect.rs
@@ -187,8 +187,6 @@ impl OnConnect {
                     num_succeeded: num_added,
                     sync_peers: vec![conn.peer_node_id().clone()],
                     phase: DiscoveryPhase::General, // This is regular peer connection, not seed bootstrap
-                    round_number: None,             // Not tracking specific rounds for on_connect mode
-                    total_rounds: None,             // Not tracking total rounds for on_connect mode
                 }));
         }
 

--- a/comms/dht/src/network_discovery/seed_strap.rs
+++ b/comms/dht/src/network_discovery/seed_strap.rs
@@ -24,7 +24,7 @@ use std::{cmp, collections::HashSet, convert::TryInto, time::Duration};
 
 use futures::{future, StreamExt};
 use log::*;
-use rand::{prelude::SliceRandom, seq::IteratorRandom};
+use rand::prelude::SliceRandom;
 use tari_comms::{
     peer_manager::{NodeId, Peer},
     Minimized,
@@ -69,8 +69,6 @@ impl SeedStrap {
             num_succeeded: 0,
             sync_peers: Vec::new(),
             phase: DiscoveryPhase::SeedStrap,
-            round_number: None, // Will be updated in discover_peers_via_seeds
-            total_rounds: None, // Will be updated in discover_peers_via_seeds
         };
 
         match self.discover_peers_via_seeds(&mut round_info).await {
@@ -160,28 +158,10 @@ impl SeedStrap {
             self.context.config.network_discovery.max_seed_peer_sync_count,
         );
 
-        // Update round info with total rounds (Ensure at least 1, even if num_seeds_to_try is 0 to avoid div by zero
-        // display)
-        round_info.total_rounds = Some(num_seeds_to_try.max(1));
-
-        let selected_seed_peers_for_sync = {
-            // Create the RNG and use it immediately within this scope
-            let mut rng = rand::thread_rng();
-            seed_peers_available.iter().choose_multiple(&mut rng, num_seeds_to_try)
-        };
-
-        round_info.sync_peers = selected_seed_peers_for_sync.iter().map(|p| p.node_id.clone()).collect();
-        debug!(
-            target: LOG_TARGET,
-            "SeedStrap: Preparing to sync from up to {} seed peers. Selected peer IDs for this round: {:?}",
-            num_seeds_to_try,
-            round_info.sync_peers
-        );
-
         let mut seed_peers = seed_peers_available.clone();
         seed_peers.shuffle(&mut rand::thread_rng());
         let mut seed_peers_iter = seed_peers.iter();
-        let mut permitted_concurrent = self.context.config.network_discovery.max_seed_peer_sync_count;
+        let mut permitted_concurrent = num_seeds_to_try;
         let mut remaining_seed_peers = seed_peers.len();
 
         let mut exit_loop = false;
@@ -192,11 +172,20 @@ impl SeedStrap {
             .peer_validator_config
             .max_permitted_peer_addresses_per_claim;
         while !exit_loop && permitted_concurrent > 0 {
-            // Get concurrent number of seed peers to try from seed_peers_iter
+            // Select the permitted concurrent number of seed peers to try
             let candidates: Vec<Peer> = seed_peers_iter.by_ref().take(permitted_concurrent).cloned().collect();
+            let num_seeds_this_round = candidates.len();
+            round_info.sync_peers = candidates.iter().map(|p| p.node_id.clone()).collect();
             if candidates.is_empty() {
                 debug!(target: LOG_TARGET, "SeedStrap: No more seed peer candidates available to try.");
                 break;
+            } else {
+                debug!(
+                    target: LOG_TARGET,
+                    "SeedStrap: Preparing to sync from up to {} seed peers. Selected peer IDs for this round: {:?}",
+                    num_seeds_this_round,
+                    round_info.sync_peers,
+                );
             }
             remaining_seed_peers = remaining_seed_peers.saturating_sub(candidates.len());
 
@@ -204,8 +193,6 @@ impl SeedStrap {
             let mut join_handles = Vec::new();
             for (idx, seed_peer_candidate) in candidates.into_iter().enumerate() {
                 attempted_seed_contacts += 1;
-                // Update round info with current round number
-                round_info.round_number = Some(idx + 1); // 1-based round numbers
 
                 let seed_node_ids_set_clone = seed_node_ids_set.clone();
                 let context_clone = self.context.clone();
@@ -214,7 +201,7 @@ impl SeedStrap {
                     get_peers(
                         context_clone,
                         seed_peer_candidate,
-                        num_seeds_to_try,
+                        num_seeds_this_round,
                         idx,
                         &seed_node_ids_set_clone,
                         max_peers_to_sync_per_round,
@@ -250,7 +237,7 @@ impl SeedStrap {
 
             // Exit condition
             if remaining_seed_peers == 0 ||
-                self.early_exit_conditions_met(total_peers_added_this_round, successful_seed_contacts, round_info)
+                self.early_exit_conditions_met(total_peers_added_this_round, successful_seed_contacts)
             {
                 exit_loop = true;
             }
@@ -298,12 +285,7 @@ impl SeedStrap {
         Ok(total_peers_added_this_round)
     }
 
-    fn early_exit_conditions_met(
-        &self,
-        total_peers_added_this_round: usize,
-        successful_seed_contacts: usize,
-        round_info: &mut DhtNetworkDiscoveryRoundInfo,
-    ) -> bool {
+    fn early_exit_conditions_met(&self, total_peers_added_this_round: usize, successful_seed_contacts: usize) -> bool {
         // EARLY EXIT CONDITION: if min_desired_peers AND max_peers_to_sync_per_round are met
         // after at least one successful contact.
         if successful_seed_contacts > 0 && // Ensure we've actually talked to at least one seed successfully
@@ -320,10 +302,7 @@ impl SeedStrap {
                 self.context.config.network_discovery.max_peers_to_sync_per_round,
                 successful_seed_contacts
             );
-            // If we early exit because we found enough peers, make the round_number reflect completion
-            // of the seed strap phase.
-            round_info.round_number = round_info.total_rounds;
-            return true; // Exit the loop over seed peers
+            return true;
         }
 
         // Additional early exit conditions:
@@ -357,9 +336,6 @@ impl SeedStrap {
                 successful_seed_contacts,
                 self.context.config.network_discovery.min_successful_seed_contacts_for_early_exit
             );
-            // If we early exit because we found enough peers, make the round_number reflect completion
-            // of the seed strap phase.
-            round_info.round_number = round_info.total_rounds;
             return true;
         }
 
@@ -376,7 +352,7 @@ impl SeedStrap {
 async fn get_peers(
     context: NetworkDiscoveryContext,
     seed_peer_candidate: Peer,
-    num_seeds_to_try: usize,
+    num_seeds_this_round: usize,
     idx: usize,
     seed_node_ids_set: &HashSet<NodeId>,
     max_peers_to_sync_per_round: u32,
@@ -388,9 +364,9 @@ async fn get_peers(
     if context.node_identity.node_id() == &seed_peer_candidate.node_id {
         info!(
             target: LOG_TARGET,
-            "SeedStrap: Iteration {}/{}: Skipping self as seed peer candidate (node_id: {}).",
+            "SeedStrap: Attempt {}/{}: Skipping self as seed peer candidate (node_id: {}).",
             idx + 1,
-            num_seeds_to_try,
+            num_seeds_this_round,
             seed_peer_node_id_str
         );
         return (vec![], 0, 0);
@@ -398,74 +374,95 @@ async fn get_peers(
 
     debug!(
         target: LOG_TARGET,
-        "SeedStrap: Iteration {}/{}: Attempting to connect to seed peer '{}' to get their peer list",
+        "SeedStrap: Attempt {}/{}: Attempting to connect to seed peer '{}' to get their peer list",
         idx + 1,
-        num_seeds_to_try,
+        num_seeds_this_round,
         seed_peer_node_id_str
     );
 
-    let mut conn = match context
-        .connectivity
-        .dial_peer(seed_peer_candidate.node_id.clone())
+    const NUM_RETRIES: usize = 3;
+    let mut peers_from_seed = vec![];
+    for attempt in 1..=NUM_RETRIES {
+        let mut conn = match context
+            .connectivity
+            .dial_peer(seed_peer_candidate.node_id.clone())
+            .await
+        {
+            Ok(c) => c,
+            Err(e) => {
+                warn!(
+                    target: LOG_TARGET,
+                    "SeedStrap: Attempt {}/{}: Failed to dial seed peer '{}': {}.",
+                    idx + 1,
+                    num_seeds_this_round,
+                    seed_peer_node_id_str,
+                    e
+                );
+                return (vec![], 0, 0);
+            },
+        };
+
+        debug!(
+            target: LOG_TARGET,
+            "SeedStrap: Connected to seed peer '{}'. Requesting peer list.",
+            seed_peer_node_id_str
+        );
+
+        match fetch_peers_from_connection(
+            &mut conn,
+            max_peers_to_sync_per_round,
+            max_permitted_peer_claims,
+            max_permitted_peer_addresses_per_claim,
+        )
         .await
-    {
-        Ok(c) => c,
-        Err(e) => {
-            warn!(
-                target: LOG_TARGET,
-                "SeedStrap: Iteration {}/{}: Failed to dial seed peer '{}': {}. Continuing to next seed candidate.",
-                idx + 1,
-                num_seeds_to_try,
-                seed_peer_node_id_str,
-                e
-            );
-            return (vec![], 0, 0);
-        },
-    };
-
-    debug!(
-        target: LOG_TARGET,
-        "SeedStrap: Connected to seed peer '{}'. Requesting peer list.",
-        seed_peer_node_id_str
-    );
-
-    let peers_from_seed = match fetch_peers_from_connection(
-        &mut conn,
-        max_peers_to_sync_per_round,
-        max_permitted_peer_claims,
-        max_permitted_peer_addresses_per_claim,
-    )
-    .await
-    {
-        Ok(peers) => peers,
-        Err(e) => {
-            warn!(
-                target: LOG_TARGET,
-                "SeedStrap: Iteration {}/{}: Failed to fetch peers from seed peer '{}': {}. Disconnecting and continuing.",
-                idx + 1,
-                num_seeds_to_try,
-                seed_peer_node_id_str,
-                e
-            );
-            // Attempt to disconnect, log if it fails but continue
-            if let Err(disc_err) = conn.disconnect(Minimized::Yes).await {
-                warn!(target: LOG_TARGET, "SeedStrap: Also failed to disconnect from seed peer '{}' after fetch failure: {}", seed_peer_node_id_str, disc_err);
-            }
-            return (vec![], 0, 0);
-        },
-    };
+        {
+            Ok(peers) => {
+                if peers.is_empty() && !conn.is_connected() && attempt < NUM_RETRIES {
+                    debug!(
+                        target: LOG_TARGET,
+                        "SeedStrap: Connection to seed peer '{}' lost. Retry {} of {}.",
+                        seed_peer_node_id_str, attempt, NUM_RETRIES,
+                    );
+                    continue;
+                }
+                if let Err(e) = conn.disconnect(Minimized::Yes).await {
+                    warn!(target: LOG_TARGET, "SeedStrap: Failed to disconnect from seed peer '{}': {}", seed_peer_node_id_str, e);
+                } else {
+                    debug!(target: LOG_TARGET, "SeedStrap: Successfully disconnected from seed peer '{}'", seed_peer_node_id_str);
+                }
+                peers_from_seed = peers;
+                break;
+            },
+            Err(e) => {
+                warn!(
+                    target: LOG_TARGET,
+                    "SeedStrap: Attempt {}/{}: Failed to fetch peers from seed peer '{}': {}. Disconnecting and continuing.",
+                    idx + 1,
+                    num_seeds_this_round,
+                    seed_peer_node_id_str,
+                    e
+                );
+                // Attempt to disconnect, log if it fails but continue
+                if let Err(disc_err) = conn.disconnect(Minimized::Yes).await {
+                    warn!(
+                        target: LOG_TARGET,
+                        "SeedStrap: Also failed to disconnect from seed peer '{}' after fetch failure: {}",
+                        seed_peer_node_id_str, disc_err
+                    );
+                }
+                return (vec![], 0, 0);
+            },
+        };
+    }
 
     if peers_from_seed.is_empty() {
         info!(
             target: LOG_TARGET,
-            "SeedStrap: Iteration {}/{}: Seed peer '{}' returned an empty peer list. Disconnecting.",
+            "SeedStrap: Attempt {}/{}: Seed peer '{}' returned an empty peer list. Disconnecting.",
             idx + 1,
-            num_seeds_to_try,
+            num_seeds_this_round,
             seed_peer_node_id_str
         );
-        if let Err(e) = conn.disconnect(Minimized::Yes).await {
-            warn!(target: LOG_TARGET, "SeedStrap: Failed to disconnect from seed peer '{}' after receiving empty list: {}", seed_peer_node_id_str, e);
-        }
         return (vec![], 0, 0);
     }
 
@@ -476,21 +473,15 @@ async fn get_peers(
         seed_peer_node_id_str
     );
 
-    if let Err(e) = conn.disconnect(Minimized::Yes).await {
-        warn!(target: LOG_TARGET, "SeedStrap: Failed to disconnect from seed peer '{}': {}", seed_peer_node_id_str, e);
-    } else {
-        debug!(target: LOG_TARGET, "SeedStrap: Successfully disconnected from seed peer '{}'", seed_peer_node_id_str);
-    }
-
     let mut new_peers_this_seed = 0;
     let mut duplicates_this_seed = 0;
 
     let peers_count = peers_from_seed.len();
     debug!(
         target: LOG_TARGET,
-        "SeedStrap: Iteration {}/{}: Beginning to process {} peers from seed peer '{}'",
+        "SeedStrap: Attempt {}/{}: Beginning to process {} peers from seed peer '{}'",
         idx + 1,
-        num_seeds_to_try,
+        num_seeds_this_round,
         peers_count,
         seed_peer_node_id_str
     );
@@ -608,10 +599,10 @@ async fn get_peers(
 
     info!(
         target: LOG_TARGET,
-        "SeedStrap: Iteration {}/{}: Finished processing peers from seed '{}'. New peers from this seed: {}. \
+        "SeedStrap: Attempt {}/{}: Finished processing peers from seed '{}'. New peers from this seed: {}. \
         Duplicates from this seed: {}.",
         idx + 1,
-        num_seeds_to_try,
+        num_seeds_this_round,
         seed_peer_node_id_str,
         new_peers_this_seed,
         duplicates_this_seed
@@ -733,7 +724,8 @@ where
             Err(_) => {
                 warn!(
                     target: LOG_TARGET,
-                    "SeedStrap: Timeout after {:.2?} waiting for next peer from stream for seed '{}'. Breaking from peer stream collection.",
+                    "SeedStrap: Timeout after {:.2?} waiting for next peer from stream for seed '{}'. Breaking from \
+                    peer stream collection.",
                     STREAM_ITEM_TIMEOUT,
                     seed_node_id_str
                 );
@@ -759,7 +751,8 @@ where
                         } else {
                             debug!(
                                 target: LOG_TARGET,
-                                "SeedStrap: Stream item #{} from seed '{}' contains an empty (None) GetPeersResponse.peer field.",
+                                "SeedStrap: Stream item #{} from seed '{}' contains an empty (None) \
+                                GetPeersResponse.peer field.",
                                 stream_items_processed_total,
                                 seed_node_id_str
                             );
@@ -776,7 +769,8 @@ where
                         );
                         debug!(
                             target: LOG_TARGET,
-                            "SeedStrap: Exiting collect_peer_stream for seed '{}' early due to RPC stream error. Peers collected so far: {}. Total items processed from stream: {}.",
+                            "SeedStrap: Exiting collect_peer_stream for seed '{}' early due to RPC stream error. Peers \
+                            collected so far: {}. Total items processed from stream: {}.",
                             seed_node_id_str,
                             peers_from_seed.len(),
                             stream_items_processed_total
@@ -786,7 +780,8 @@ where
                     None => {
                         debug!(
                             target: LOG_TARGET,
-                            "SeedStrap: Peer stream ended for seed '{}'. Processed {} items in total, {} of which contained peers.",
+                            "SeedStrap: Peer stream ended for seed '{}'. Processed {} items in total, {} of which \
+                            contained peers.",
                             seed_node_id_str,
                             stream_items_processed_total,
                             stream_items_with_peers

--- a/comms/dht/src/network_discovery/seed_strap.rs
+++ b/comms/dht/src/network_discovery/seed_strap.rs
@@ -22,10 +22,14 @@
 
 use std::{cmp, collections::HashSet, convert::TryInto, time::Duration};
 
-use futures::StreamExt;
+use futures::{future, StreamExt};
 use log::*;
-use rand::seq::IteratorRandom;
-use tari_comms::{peer_manager::NodeId, Minimized, PeerConnection};
+use rand::{prelude::SliceRandom, seq::IteratorRandom};
+use tari_comms::{
+    peer_manager::{NodeId, Peer},
+    Minimized,
+    PeerConnection,
+};
 
 use crate::{
     network_discovery::{
@@ -33,7 +37,7 @@ use crate::{
         state_machine::{DhtNetworkDiscoveryRoundInfo, DiscoveryPhase, NetworkDiscoveryContext, StateEvent},
     },
     peer_validator::PeerValidator,
-    proto::rpc::GetPeersRequest,
+    proto::rpc::{GetPeersRequest, PeerInfo},
     rpc::{DhtClient, UnvalidatedPeerInfo},
     DhtConfig,
 };
@@ -46,7 +50,7 @@ const STREAM_ITEM_TIMEOUT: Duration = Duration::from_secs(10);
 
 const LOG_TARGET: &str = "comms::dht::network_discovery::seed_strap";
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(super) struct SeedStrap {
     context: NetworkDiscoveryContext,
 }
@@ -156,15 +160,14 @@ impl SeedStrap {
             self.context.config.network_discovery.max_seed_peer_sync_count,
         );
 
-        // Update round info with total rounds
-        round_info.total_rounds = Some(num_seeds_to_try.max(1)); // Ensure at least 1, even if num_seeds_to_try is 0 to avoid div by zero display
+        // Update round info with total rounds (Ensure at least 1, even if num_seeds_to_try is 0 to avoid div by zero
+        // display)
+        round_info.total_rounds = Some(num_seeds_to_try.max(1));
 
         let selected_seed_peers_for_sync = {
             // Create the RNG and use it immediately within this scope
             let mut rng = rand::thread_rng();
-            seed_peers_available
-                .into_iter()
-                .choose_multiple(&mut rng, num_seeds_to_try)
+            seed_peers_available.iter().choose_multiple(&mut rng, num_seeds_to_try)
         };
 
         round_info.sync_peers = selected_seed_peers_for_sync.iter().map(|p| p.node_id.clone()).collect();
@@ -175,343 +178,67 @@ impl SeedStrap {
             round_info.sync_peers
         );
 
-        let validator = PeerValidator::new(&self.context.config);
+        let mut seed_peers = seed_peers_available.clone();
+        seed_peers.shuffle(&mut rand::thread_rng());
+        let mut seed_peers_iter = seed_peers.iter();
+        let mut permitted_concurrent = self.context.config.network_discovery.max_seed_peer_sync_count;
+        let mut remaining_seed_peers = seed_peers.len();
 
-        for (idx, seed_peer_candidate) in selected_seed_peers_for_sync.into_iter().enumerate() {
-            attempted_seed_contacts += 1;
-            // Update round info with current round number
-            round_info.round_number = Some(idx + 1); // 1-based round numbers
-            let seed_peer_node_id_str = seed_peer_candidate.node_id.to_string();
-
-            if self.context.node_identity.node_id() == &seed_peer_candidate.node_id {
-                info!(
-                    target: LOG_TARGET,
-                    "SeedStrap: Iteration {}/{}: Skipping self as seed peer candidate (node_id: {}).",
-                    idx + 1,
-                    num_seeds_to_try,
-                    seed_peer_node_id_str
-                );
-                continue;
-            }
-
-            debug!(
-                target: LOG_TARGET,
-                "SeedStrap: Iteration {}/{}: Attempting to connect to seed peer '{}' to get their peer list",
-                idx + 1,
-                num_seeds_to_try,
-                seed_peer_node_id_str
-            );
-
-            let mut conn = match self
-                .context
-                .connectivity
-                .dial_peer(seed_peer_candidate.node_id.clone())
-                .await
-            {
-                Ok(c) => c,
-                Err(e) => {
-                    warn!(
-                        target: LOG_TARGET,
-                        "SeedStrap: Iteration {}/{}: Failed to dial seed peer '{}': {}. Continuing to next seed candidate.",
-                        idx + 1,
-                        num_seeds_to_try,
-                        seed_peer_node_id_str,
-                        e
-                    );
-                    continue;
-                },
-            };
-
-            debug!(
-                target: LOG_TARGET,
-                "SeedStrap: Connected to seed peer '{}'. Requesting peer list.",
-                seed_peer_node_id_str
-            );
-
-            let peers_from_seed = match self.fetch_peers_from_connection(&mut conn).await {
-                Ok(peers) => peers,
-                Err(e) => {
-                    warn!(
-                        target: LOG_TARGET,
-                        "SeedStrap: Iteration {}/{}: Failed to fetch peers from seed peer '{}': {}. Disconnecting and continuing.",
-                        idx + 1,
-                        num_seeds_to_try,
-                        seed_peer_node_id_str,
-                        e
-                    );
-                    // Attempt to disconnect, log if it fails but continue
-                    if let Err(disc_err) = conn.disconnect(Minimized::Yes).await {
-                        warn!(target: LOG_TARGET, "SeedStrap: Also failed to disconnect from seed peer '{}' after fetch failure: {}", seed_peer_node_id_str, disc_err);
-                    }
-                    continue;
-                },
-            };
-
-            if peers_from_seed.is_empty() {
-                info!(
-                    target: LOG_TARGET,
-                    "SeedStrap: Iteration {}/{}: Seed peer '{}' returned an empty peer list. Disconnecting.",
-                    idx + 1,
-                    num_seeds_to_try,
-                    seed_peer_node_id_str
-                );
-                if let Err(e) = conn.disconnect(Minimized::Yes).await {
-                    warn!(target: LOG_TARGET, "SeedStrap: Failed to disconnect from seed peer '{}' after receiving empty list: {}", seed_peer_node_id_str, e);
-                }
-                continue;
-            }
-
-            // This seed successfully provided peers
-            round_info.num_succeeded += 1;
-            successful_seed_contacts += 1;
-
-            debug!(
-                target: LOG_TARGET,
-                "SeedStrap: Successfully fetched {} peer entries from seed peer '{}'. Disconnecting before processing.",
-                peers_from_seed.len(),
-                seed_peer_node_id_str
-            );
-
-            if let Err(e) = conn.disconnect(Minimized::Yes).await {
-                warn!(target: LOG_TARGET, "SeedStrap: Failed to disconnect from seed peer '{}': {}", seed_peer_node_id_str, e);
-            } else {
-                debug!(target: LOG_TARGET, "SeedStrap: Successfully disconnected from seed peer '{}'", seed_peer_node_id_str);
-            }
-
-            let mut new_peers_this_seed = 0;
-            let mut duplicates_this_seed = 0;
-            let ban_this_seed_peer = false;
-
-            let peers_count = peers_from_seed.len();
-            debug!(
-                target: LOG_TARGET,
-                "SeedStrap: Iteration {}/{}: Beginning to process {} peers from seed peer '{}'",
-                idx + 1,
-                num_seeds_to_try,
-                peers_count,
-                seed_peer_node_id_str
-            );
-
-            for (peer_idx_loop, peer_info_proto) in peers_from_seed.into_iter().enumerate() {
-                let new_peer_candidate: UnvalidatedPeerInfo = match peer_info_proto.try_into() {
-                    Ok(p) => p,
-                    Err(e) => {
-                        warn!(
-                            target: LOG_TARGET,
-                            "SeedStrap: (From Seed '{}', Peer Candidate {}/{}): Invalid peer data received, skipping: {}",
-                            seed_peer_node_id_str,
-                            peer_idx_loop + 1,
-                            peers_count,
-                            e
-                        );
-                        continue; // Skip this invalid entry
-                    },
-                };
-
-                let candidate_node_id = NodeId::from_public_key(&new_peer_candidate.public_key);
-                trace!(
-                    target: LOG_TARGET,
-                    "SeedStrap: (From Seed '{}', Peer Candidate {}/{}): Processing candidate NodeId = {}",
-                    seed_peer_node_id_str,
-                    peer_idx_loop + 1,
-                    peers_count,
-                    candidate_node_id
-                );
-
-                if new_peer_candidate.public_key == *self.context.node_identity.public_key() {
-                    trace!(target: LOG_TARGET, "SeedStrap: (From Seed '{}', Peer Candidate {}/{}): Skipping self.", seed_peer_node_id_str, peer_idx_loop+1, peers_count);
-                    continue;
-                }
-
-                if seed_node_ids_set.contains(&candidate_node_id) {
-                    trace!(
-                        target: LOG_TARGET,
-                        "SeedStrap: (From Seed '{}', Peer Candidate {}/{}): Skipping known seed peer {}.",
-                        seed_peer_node_id_str,
-                        peer_idx_loop + 1,
-                        peers_count,
-                        candidate_node_id
-                    );
-                    continue;
-                }
-
-                let maybe_existing_peer = match self
-                    .context
-                    .peer_manager
-                    .find_by_public_key(&new_peer_candidate.public_key)
-                    .await
-                {
-                    Ok(peer) => peer,
-                    Err(e) => {
-                        warn!(
-                            target: LOG_TARGET,
-                            "SeedStrap: (Seed '{}', Peer Candidate {}/{}): Error searching for existing peer candidate {} by public key: {}. Skipping.",
-                            seed_peer_node_id_str, peer_idx_loop + 1, peers_count, candidate_node_id, e
-                        );
-                        continue;
-                    },
-                };
-
-                let is_new_peer = maybe_existing_peer.is_none();
-
-                match validator.validate_peer(new_peer_candidate, maybe_existing_peer) {
-                    Ok(valid_peer) => {
-                        debug!(
-                            target: LOG_TARGET,
-                            "SeedStrap: (From Seed '{}', Peer Candidate {}/{}): Peer {} from seed '{}' is valid. New: {}. Adding to peer manager.",
-                            seed_peer_node_id_str,
-                            peer_idx_loop + 1,
-                            peers_count,
-                            valid_peer.node_id,
-                            seed_peer_node_id_str,
-                            is_new_peer
-                        );
-
-                        match self.context.peer_manager.add_or_update_peer(valid_peer).await {
-                            Ok(_) => {
-                                if is_new_peer {
-                                    new_peers_this_seed += 1;
-                                } else {
-                                    duplicates_this_seed += 1;
-                                }
-                            },
-                            Err(e) => {
-                                warn!(
-                                    target: LOG_TARGET,
-                                    "SeedStrap: (From Seed '{}', Peer Candidate {}/{}): Failed to add validated peer {}: {}",
-                                    seed_peer_node_id_str,
-                                    peer_idx_loop + 1,
-                                    peers_count,
-                                    candidate_node_id,
-                                    e
-                                );
-                            },
-                        }
-                    },
-                    Err(e) => {
-                        warn!(
-                            target: LOG_TARGET,
-                            "SeedStrap: (From Seed '{}', Peer Candidate {}/{}): Invalid peer data for {} received from seed peer '{}': {}",
-                            seed_peer_node_id_str,
-                            peer_idx_loop + 1,
-                            peers_count,
-                            candidate_node_id,
-                            seed_peer_node_id_str,
-                            e
-                        );
-                    },
-                }
-            }
-
-            if ban_this_seed_peer {
-                warn!(
-                    target: LOG_TARGET,
-                    "SeedStrap: Banning seed peer '{}' for providing invalid peer data.",
-                    seed_peer_node_id_str
-                );
-
-                // First disconnect to free the connection slot
-                if let Err(e) = conn.disconnect(Minimized::Yes).await {
-                    warn!(
-                        target: LOG_TARGET,
-                        "SeedStrap: Failed to disconnect from seed peer '{}' before banning: {}",
-                        seed_peer_node_id_str,
-                        e
-                    );
-                }
-
-                // Then ban the peer
-                match self
-                    .context
-                    .connectivity
-                    .ban_peer_until(
-                        seed_peer_candidate.node_id.clone(),
-                        self.config().ban_duration_short,
-                        "Sent invalid peer data during seed bootstrap".to_string(),
-                    )
-                    .await
-                {
-                    Ok(_) => {
-                        debug!(target: LOG_TARGET, "SeedStrap: Successfully banned seed peer '{}'", seed_peer_node_id_str)
-                    },
-                    Err(e) => {
-                        warn!(target: LOG_TARGET, "SeedStrap: Failed to ban seed peer '{}': {}", seed_peer_node_id_str, e)
-                    },
-                }
-
-                // If we banned the seed, we don't count it as a successful sync
-                if round_info.num_succeeded > 0 {
-                    round_info.num_succeeded -= 1;
-                }
-                successful_seed_contacts = successful_seed_contacts.saturating_sub(1);
-            }
-
-            info!(
-                target: LOG_TARGET,
-                "SeedStrap: Iteration {}/{}: Finished processing peers from seed '{}'. New peers from this seed: {}. Duplicates from this seed: {}.",
-                idx + 1,
-                num_seeds_to_try,
-                seed_peer_node_id_str,
-                new_peers_this_seed,
-                duplicates_this_seed
-            );
-            total_peers_added_this_round += new_peers_this_seed;
-            total_duplicates_this_round += duplicates_this_seed;
-
-            // EARLY EXIT CONDITION: if min_desired_peers AND max_peers_to_sync_per_round are met
-            // after at least one successful contact.
-            if successful_seed_contacts > 0 && // Ensure we've actually talked to at least one seed successfully
-               total_peers_added_this_round >= self.context.config.network_discovery.min_desired_peers &&
-               total_peers_added_this_round >= self.context.config.network_discovery.max_peers_to_sync_per_round.try_into().unwrap_or(usize::MAX)
-            {
-                info!(
-                    target: LOG_TARGET,
-                    "SeedStrap: Early exit: Found sufficient peers. Total new peers ({}) >= min_desired_peers ({}) AND >= max_peers_to_sync_per_round ({}). Exiting seed node loop after {} successful sync(s). Signaling round as complete.",
-                    total_peers_added_this_round,
-                    self.context.config.network_discovery.min_desired_peers,
-                    self.context.config.network_discovery.max_peers_to_sync_per_round,
-                    successful_seed_contacts
-                );
-                // If we early exit because we found enough peers, make the round_number reflect completion
-                // of the seed strap phase.
-                round_info.round_number = round_info.total_rounds;
-                break; // Exit the loop over seed peers
-            }
-
-            // Additional early exit conditions:
-            // 1. The soft limit for total peers needed must be enabled (> 0).
-            // 2. The total number of peers added in this round must meet or exceed this soft limit.
-            // 3. The number of successfully contacted seed peers must meet or exceed the configured minimum.
-            let soft_peer_limit_enabled = self
-                .context
-                .config
-                .network_discovery
-                .seed_peer_min_initial_sync_peers_needed >
-                0;
-            let enough_total_peers_added = total_peers_added_this_round >=
-                self.context
-                    .config
-                    .network_discovery
-                    .seed_peer_min_initial_sync_peers_needed;
-            let enough_successful_seed_contacts = successful_seed_contacts >=
-                self.context
-                    .config
-                    .network_discovery
-                    .min_successful_seed_contacts_for_early_exit;
-
-            if soft_peer_limit_enabled && enough_total_peers_added && enough_successful_seed_contacts {
-                info!(
-                    target: LOG_TARGET,
-                    "SeedStrap: Original early exit conditions met. Total peers added ({}) >= needed ({}). Successful seed contacts ({}) >= min ({}). Exiting seed node loop.",
-                    total_peers_added_this_round,
-                    self.context.config.network_discovery.seed_peer_min_initial_sync_peers_needed,
-                    successful_seed_contacts,
-                    self.context.config.network_discovery.min_successful_seed_contacts_for_early_exit
-                );
-                // If we early exit because we found enough peers, make the round_number reflect completion
-                // of the seed strap phase.
-                round_info.round_number = round_info.total_rounds;
+        let mut exit_loop = false;
+        while !exit_loop && permitted_concurrent > 0 {
+            // Get concurrent number of seed peers to try from seed_peers_iter
+            let candidates: Vec<Peer> = seed_peers_iter.by_ref().take(permitted_concurrent).cloned().collect();
+            if candidates.is_empty() {
+                debug!(target: LOG_TARGET, "SeedStrap: No more seed peer candidates available to try.");
                 break;
+            }
+            remaining_seed_peers = remaining_seed_peers.saturating_sub(candidates.len());
+
+            // Get peers from seeds concurrently
+            let mut join_handles = Vec::new();
+            for (idx, seed_peer_candidate) in candidates.into_iter().enumerate() {
+                attempted_seed_contacts += 1;
+                // Update round info with current round number
+                round_info.round_number = Some(idx + 1); // 1-based round numbers
+
+                let seed_node_ids_set_clone = seed_node_ids_set.clone();
+                let mut self_clone = self.clone();
+
+                let handle = tokio::task::spawn(async move {
+                    self_clone
+                        .get_peers(seed_peer_candidate, num_seeds_to_try, idx, &seed_node_ids_set_clone)
+                        .await
+                });
+
+                join_handles.push(handle);
+            }
+            let results = future::join_all(join_handles).await;
+
+            permitted_concurrent = 0;
+            for result in results {
+                let Ok((peers_from_seed, new_peers_this_seed, duplicates_this_seed)) = result else {
+                    warn!(target: LOG_TARGET, "SeedStrap: get_peers task panicked or was cancelled");
+                    permitted_concurrent += 1;
+                    continue;
+                };
+
+                // This seed successfully provided peers
+                if peers_from_seed.is_empty() {
+                    permitted_concurrent += 1;
+                } else {
+                    round_info.num_succeeded += 1;
+                    successful_seed_contacts += 1;
+                }
+
+                total_peers_added_this_round += new_peers_this_seed;
+                total_duplicates_this_round += duplicates_this_seed;
+            }
+
+            // Exit condition
+            if remaining_seed_peers == 0 ||
+                self.early_exit_conditions_met(total_peers_added_this_round, successful_seed_contacts, round_info)
+            {
+                exit_loop = true;
             }
         }
 
@@ -519,7 +246,8 @@ impl SeedStrap {
 
         info!(
             target: LOG_TARGET,
-            "SeedStrap: discover_peers_via_seeds finished. Attempted to contact: {}/{}. Successfully synced from: {}. Total new peers added in this round: {}. Total duplicates processed in this round: {}.",
+            "SeedStrap: discover_peers_via_seeds finished. Attempted to contact: {}/{}. Successfully synced from: {}. \
+            Total new peers added in this round: {}. Total duplicates processed in this round: {}.",
             attempted_seed_contacts,
             num_seeds_to_try,
             round_info.num_succeeded,
@@ -554,6 +282,314 @@ impl SeedStrap {
         );
 
         Ok(total_peers_added_this_round)
+    }
+
+    fn early_exit_conditions_met(
+        &self,
+        total_peers_added_this_round: usize,
+        successful_seed_contacts: usize,
+        round_info: &mut DhtNetworkDiscoveryRoundInfo,
+    ) -> bool {
+        // EARLY EXIT CONDITION: if min_desired_peers AND max_peers_to_sync_per_round are met
+        // after at least one successful contact.
+        if successful_seed_contacts > 0 && // Ensure we've actually talked to at least one seed successfully
+            total_peers_added_this_round >= self.context.config.network_discovery.min_desired_peers &&
+            total_peers_added_this_round >= self.context.config.network_discovery.max_peers_to_sync_per_round.try_into().unwrap_or(usize::MAX)
+        {
+            info!(
+                target: LOG_TARGET,
+                "SeedStrap: Early exit: Found sufficient peers. Total new peers ({}) >= min_desired_peers ({}) \
+                AND >= max_peers_to_sync_per_round ({}). Exiting seed node loop after {} successful sync(s). \
+                Signaling round as complete.",
+                total_peers_added_this_round,
+                self.context.config.network_discovery.min_desired_peers,
+                self.context.config.network_discovery.max_peers_to_sync_per_round,
+                successful_seed_contacts
+            );
+            // If we early exit because we found enough peers, make the round_number reflect completion
+            // of the seed strap phase.
+            round_info.round_number = round_info.total_rounds;
+            return true; // Exit the loop over seed peers
+        }
+
+        // Additional early exit conditions:
+        // 1. The soft limit for total peers needed must be enabled (> 0).
+        // 2. The total number of peers added in this round must meet or exceed this soft limit.
+        // 3. The number of successfully contacted seed peers must meet or exceed the configured minimum.
+        let soft_peer_limit_enabled = self
+            .context
+            .config
+            .network_discovery
+            .seed_peer_min_initial_sync_peers_needed >
+            0;
+        let enough_total_peers_added = total_peers_added_this_round >=
+            self.context
+                .config
+                .network_discovery
+                .seed_peer_min_initial_sync_peers_needed;
+        let enough_successful_seed_contacts = successful_seed_contacts >=
+            self.context
+                .config
+                .network_discovery
+                .min_successful_seed_contacts_for_early_exit;
+
+        if soft_peer_limit_enabled && enough_total_peers_added && enough_successful_seed_contacts {
+            info!(
+                target: LOG_TARGET,
+                "SeedStrap: Original early exit conditions met. Total peers added ({}) >= needed ({}). Successful \
+                seed contacts ({}) >= min ({}). Exiting seed node loop.",
+                total_peers_added_this_round,
+                self.context.config.network_discovery.seed_peer_min_initial_sync_peers_needed,
+                successful_seed_contacts,
+                self.context.config.network_discovery.min_successful_seed_contacts_for_early_exit
+            );
+            // If we early exit because we found enough peers, make the round_number reflect completion
+            // of the seed strap phase.
+            round_info.round_number = round_info.total_rounds;
+            return true;
+        }
+
+        false
+    }
+
+    #[allow(clippy::too_many_lines)]
+    async fn get_peers(
+        &mut self,
+        seed_peer_candidate: Peer,
+        num_seeds_to_try: usize,
+        idx: usize,
+        seed_node_ids_set: &HashSet<NodeId>,
+    ) -> (Vec<PeerInfo>, usize, usize) {
+        let seed_peer_node_id_str = seed_peer_candidate.node_id.to_string();
+
+        if self.context.node_identity.node_id() == &seed_peer_candidate.node_id {
+            info!(
+                target: LOG_TARGET,
+                "SeedStrap: Iteration {}/{}: Skipping self as seed peer candidate (node_id: {}).",
+                idx + 1,
+                num_seeds_to_try,
+                seed_peer_node_id_str
+            );
+            return (vec![], 0, 0);
+        }
+
+        debug!(
+            target: LOG_TARGET,
+            "SeedStrap: Iteration {}/{}: Attempting to connect to seed peer '{}' to get their peer list",
+            idx + 1,
+            num_seeds_to_try,
+            seed_peer_node_id_str
+        );
+
+        let mut conn = match self
+            .context
+            .connectivity
+            .dial_peer(seed_peer_candidate.node_id.clone())
+            .await
+        {
+            Ok(c) => c,
+            Err(e) => {
+                warn!(
+                    target: LOG_TARGET,
+                    "SeedStrap: Iteration {}/{}: Failed to dial seed peer '{}': {}. Continuing to next seed candidate.",
+                    idx + 1,
+                    num_seeds_to_try,
+                    seed_peer_node_id_str,
+                    e
+                );
+                return (vec![], 0, 0);
+            },
+        };
+
+        debug!(
+            target: LOG_TARGET,
+            "SeedStrap: Connected to seed peer '{}'. Requesting peer list.",
+            seed_peer_node_id_str
+        );
+
+        let peers_from_seed = match self.fetch_peers_from_connection(&mut conn).await {
+            Ok(peers) => peers,
+            Err(e) => {
+                warn!(
+                    target: LOG_TARGET,
+                    "SeedStrap: Iteration {}/{}: Failed to fetch peers from seed peer '{}': {}. Disconnecting and continuing.",
+                    idx + 1,
+                    num_seeds_to_try,
+                    seed_peer_node_id_str,
+                    e
+                );
+                // Attempt to disconnect, log if it fails but continue
+                if let Err(disc_err) = conn.disconnect(Minimized::Yes).await {
+                    warn!(target: LOG_TARGET, "SeedStrap: Also failed to disconnect from seed peer '{}' after fetch failure: {}", seed_peer_node_id_str, disc_err);
+                }
+                return (vec![], 0, 0);
+            },
+        };
+
+        if peers_from_seed.is_empty() {
+            info!(
+                target: LOG_TARGET,
+                "SeedStrap: Iteration {}/{}: Seed peer '{}' returned an empty peer list. Disconnecting.",
+                idx + 1,
+                num_seeds_to_try,
+                seed_peer_node_id_str
+            );
+            if let Err(e) = conn.disconnect(Minimized::Yes).await {
+                warn!(target: LOG_TARGET, "SeedStrap: Failed to disconnect from seed peer '{}' after receiving empty list: {}", seed_peer_node_id_str, e);
+            }
+            return (vec![], 0, 0);
+        }
+
+        debug!(
+            target: LOG_TARGET,
+            "SeedStrap: Successfully fetched {} peer entries from seed peer '{}'. Disconnecting before processing.",
+            peers_from_seed.len(),
+            seed_peer_node_id_str
+        );
+
+        if let Err(e) = conn.disconnect(Minimized::Yes).await {
+            warn!(target: LOG_TARGET, "SeedStrap: Failed to disconnect from seed peer '{}': {}", seed_peer_node_id_str, e);
+        } else {
+            debug!(target: LOG_TARGET, "SeedStrap: Successfully disconnected from seed peer '{}'", seed_peer_node_id_str);
+        }
+
+        let mut new_peers_this_seed = 0;
+        let mut duplicates_this_seed = 0;
+
+        let peers_count = peers_from_seed.len();
+        debug!(
+            target: LOG_TARGET,
+            "SeedStrap: Iteration {}/{}: Beginning to process {} peers from seed peer '{}'",
+            idx + 1,
+            num_seeds_to_try,
+            peers_count,
+            seed_peer_node_id_str
+        );
+
+        for (peer_idx_loop, peer_info_proto) in peers_from_seed.iter().enumerate() {
+            let new_peer_candidate: UnvalidatedPeerInfo = match peer_info_proto.clone().try_into() {
+                Ok(p) => p,
+                Err(e) => {
+                    warn!(
+                        target: LOG_TARGET,
+                        "SeedStrap: (From Seed '{}', Peer Candidate {}/{}): Invalid peer data received, skipping: {}",
+                        seed_peer_node_id_str,
+                        peer_idx_loop + 1,
+                        peers_count,
+                        e
+                    );
+                    continue; // Skip this invalid entry
+                },
+            };
+
+            let candidate_node_id = NodeId::from_public_key(&new_peer_candidate.public_key);
+            trace!(
+                target: LOG_TARGET,
+                "SeedStrap: (From Seed '{}', Peer Candidate {}/{}): Processing candidate NodeId = {}",
+                seed_peer_node_id_str,
+                peer_idx_loop + 1,
+                peers_count,
+                candidate_node_id
+            );
+
+            if new_peer_candidate.public_key == *self.context.node_identity.public_key() {
+                trace!(target: LOG_TARGET, "SeedStrap: (From Seed '{}', Peer Candidate {}/{}): Skipping self.", seed_peer_node_id_str, peer_idx_loop+1, peers_count);
+                continue;
+            }
+
+            if seed_node_ids_set.contains(&candidate_node_id) {
+                trace!(
+                    target: LOG_TARGET,
+                    "SeedStrap: (From Seed '{}', Peer Candidate {}/{}): Skipping known seed peer {}.",
+                    seed_peer_node_id_str,
+                    peer_idx_loop + 1,
+                    peers_count,
+                    candidate_node_id
+                );
+                continue;
+            }
+
+            let maybe_existing_peer = match self
+                .context
+                .peer_manager
+                .find_by_public_key(&new_peer_candidate.public_key)
+                .await
+            {
+                Ok(peer) => peer,
+                Err(e) => {
+                    warn!(
+                        target: LOG_TARGET,
+                        "SeedStrap: (Seed '{}', Peer Candidate {}/{}): Error searching for existing peer candidate {} by public key: {}. Skipping.",
+                        seed_peer_node_id_str, peer_idx_loop + 1, peers_count, candidate_node_id, e
+                    );
+                    continue;
+                },
+            };
+
+            let is_new_peer = maybe_existing_peer.is_none();
+
+            let validator = PeerValidator::new(&self.context.config);
+            match validator.validate_peer(new_peer_candidate, maybe_existing_peer) {
+                Ok(valid_peer) => {
+                    debug!(
+                        target: LOG_TARGET,
+                        "SeedStrap: (From Seed '{}', Peer Candidate {}/{}): Peer {} from seed '{}' is valid. New: {}. Adding to peer manager.",
+                        seed_peer_node_id_str,
+                        peer_idx_loop + 1,
+                        peers_count,
+                        valid_peer.node_id,
+                        seed_peer_node_id_str,
+                        is_new_peer
+                    );
+
+                    match self.context.peer_manager.add_or_update_peer(valid_peer).await {
+                        Ok(_) => {
+                            if is_new_peer {
+                                new_peers_this_seed += 1;
+                            } else {
+                                duplicates_this_seed += 1;
+                            }
+                        },
+                        Err(e) => {
+                            warn!(
+                                target: LOG_TARGET,
+                                "SeedStrap: (From Seed '{}', Peer Candidate {}/{}): Failed to add validated peer {}: {}",
+                                seed_peer_node_id_str,
+                                peer_idx_loop + 1,
+                                peers_count,
+                                candidate_node_id,
+                                e
+                            );
+                        },
+                    }
+                },
+                Err(e) => {
+                    warn!(
+                        target: LOG_TARGET,
+                        "SeedStrap: (From Seed '{}', Peer Candidate {}/{}): Invalid peer data for {} received from seed peer '{}': {}",
+                        seed_peer_node_id_str,
+                        peer_idx_loop + 1,
+                        peers_count,
+                        candidate_node_id,
+                        seed_peer_node_id_str,
+                        e
+                    );
+                },
+            }
+        }
+
+        info!(
+            target: LOG_TARGET,
+            "SeedStrap: Iteration {}/{}: Finished processing peers from seed '{}'. New peers from this seed: {}. \
+            Duplicates from this seed: {}.",
+            idx + 1,
+            num_seeds_to_try,
+            seed_peer_node_id_str,
+            new_peers_this_seed,
+            duplicates_this_seed
+        );
+
+        (peers_from_seed, new_peers_this_seed, duplicates_this_seed)
     }
 
     async fn fetch_peers_from_connection(

--- a/comms/dht/src/network_discovery/seed_strap.rs
+++ b/comms/dht/src/network_discovery/seed_strap.rs
@@ -50,7 +50,7 @@ const STREAM_ITEM_TIMEOUT: Duration = Duration::from_secs(10);
 
 const LOG_TARGET: &str = "comms::dht::network_discovery::seed_strap";
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(super) struct SeedStrap {
     context: NetworkDiscoveryContext,
 }
@@ -185,6 +185,12 @@ impl SeedStrap {
         let mut remaining_seed_peers = seed_peers.len();
 
         let mut exit_loop = false;
+        let max_peers_to_sync_per_round = self.config().network_discovery.max_peers_to_sync_per_round;
+        let max_permitted_peer_claims = self.config().max_permitted_peer_claims;
+        let max_permitted_peer_addresses_per_claim = self
+            .config()
+            .peer_validator_config
+            .max_permitted_peer_addresses_per_claim;
         while !exit_loop && permitted_concurrent > 0 {
             // Get concurrent number of seed peers to try from seed_peers_iter
             let candidates: Vec<Peer> = seed_peers_iter.by_ref().take(permitted_concurrent).cloned().collect();
@@ -202,12 +208,20 @@ impl SeedStrap {
                 round_info.round_number = Some(idx + 1); // 1-based round numbers
 
                 let seed_node_ids_set_clone = seed_node_ids_set.clone();
-                let mut self_clone = self.clone();
+                let context_clone = self.context.clone();
 
                 let handle = tokio::task::spawn(async move {
-                    self_clone
-                        .get_peers(seed_peer_candidate, num_seeds_to_try, idx, &seed_node_ids_set_clone)
-                        .await
+                    get_peers(
+                        context_clone,
+                        seed_peer_candidate,
+                        num_seeds_to_try,
+                        idx,
+                        &seed_node_ids_set_clone,
+                        max_peers_to_sync_per_round,
+                        max_permitted_peer_claims,
+                        max_permitted_peer_addresses_per_claim,
+                    )
+                    .await
                 });
 
                 join_handles.push(handle);
@@ -352,445 +366,446 @@ impl SeedStrap {
         false
     }
 
-    #[allow(clippy::too_many_lines)]
-    async fn get_peers(
-        &mut self,
-        seed_peer_candidate: Peer,
-        num_seeds_to_try: usize,
-        idx: usize,
-        seed_node_ids_set: &HashSet<NodeId>,
-    ) -> (Vec<PeerInfo>, usize, usize) {
-        let seed_peer_node_id_str = seed_peer_candidate.node_id.to_string();
+    #[inline]
+    fn config(&self) -> &DhtConfig {
+        &self.context.config
+    }
+}
 
-        if self.context.node_identity.node_id() == &seed_peer_candidate.node_id {
-            info!(
-                target: LOG_TARGET,
-                "SeedStrap: Iteration {}/{}: Skipping self as seed peer candidate (node_id: {}).",
-                idx + 1,
-                num_seeds_to_try,
-                seed_peer_node_id_str
-            );
-            return (vec![], 0, 0);
-        }
+#[allow(clippy::too_many_lines)]
+async fn get_peers(
+    context: NetworkDiscoveryContext,
+    seed_peer_candidate: Peer,
+    num_seeds_to_try: usize,
+    idx: usize,
+    seed_node_ids_set: &HashSet<NodeId>,
+    max_peers_to_sync_per_round: u32,
+    max_permitted_peer_claims: usize,
+    max_permitted_peer_addresses_per_claim: usize,
+) -> (Vec<PeerInfo>, usize, usize) {
+    let seed_peer_node_id_str = seed_peer_candidate.node_id.to_string();
 
-        debug!(
+    if context.node_identity.node_id() == &seed_peer_candidate.node_id {
+        info!(
             target: LOG_TARGET,
-            "SeedStrap: Iteration {}/{}: Attempting to connect to seed peer '{}' to get their peer list",
+            "SeedStrap: Iteration {}/{}: Skipping self as seed peer candidate (node_id: {}).",
             idx + 1,
             num_seeds_to_try,
             seed_peer_node_id_str
         );
+        return (vec![], 0, 0);
+    }
 
-        let mut conn = match self
-            .context
-            .connectivity
-            .dial_peer(seed_peer_candidate.node_id.clone())
-            .await
-        {
-            Ok(c) => c,
-            Err(e) => {
-                warn!(
-                    target: LOG_TARGET,
-                    "SeedStrap: Iteration {}/{}: Failed to dial seed peer '{}': {}. Continuing to next seed candidate.",
-                    idx + 1,
-                    num_seeds_to_try,
-                    seed_peer_node_id_str,
-                    e
-                );
-                return (vec![], 0, 0);
-            },
-        };
+    debug!(
+        target: LOG_TARGET,
+        "SeedStrap: Iteration {}/{}: Attempting to connect to seed peer '{}' to get their peer list",
+        idx + 1,
+        num_seeds_to_try,
+        seed_peer_node_id_str
+    );
 
-        debug!(
-            target: LOG_TARGET,
-            "SeedStrap: Connected to seed peer '{}'. Requesting peer list.",
-            seed_peer_node_id_str
-        );
-
-        let peers_from_seed = match self.fetch_peers_from_connection(&mut conn).await {
-            Ok(peers) => peers,
-            Err(e) => {
-                warn!(
-                    target: LOG_TARGET,
-                    "SeedStrap: Iteration {}/{}: Failed to fetch peers from seed peer '{}': {}. Disconnecting and continuing.",
-                    idx + 1,
-                    num_seeds_to_try,
-                    seed_peer_node_id_str,
-                    e
-                );
-                // Attempt to disconnect, log if it fails but continue
-                if let Err(disc_err) = conn.disconnect(Minimized::Yes).await {
-                    warn!(target: LOG_TARGET, "SeedStrap: Also failed to disconnect from seed peer '{}' after fetch failure: {}", seed_peer_node_id_str, disc_err);
-                }
-                return (vec![], 0, 0);
-            },
-        };
-
-        if peers_from_seed.is_empty() {
-            info!(
+    let mut conn = match context
+        .connectivity
+        .dial_peer(seed_peer_candidate.node_id.clone())
+        .await
+    {
+        Ok(c) => c,
+        Err(e) => {
+            warn!(
                 target: LOG_TARGET,
-                "SeedStrap: Iteration {}/{}: Seed peer '{}' returned an empty peer list. Disconnecting.",
+                "SeedStrap: Iteration {}/{}: Failed to dial seed peer '{}': {}. Continuing to next seed candidate.",
                 idx + 1,
                 num_seeds_to_try,
-                seed_peer_node_id_str
+                seed_peer_node_id_str,
+                e
             );
-            if let Err(e) = conn.disconnect(Minimized::Yes).await {
-                warn!(target: LOG_TARGET, "SeedStrap: Failed to disconnect from seed peer '{}' after receiving empty list: {}", seed_peer_node_id_str, e);
+            return (vec![], 0, 0);
+        },
+    };
+
+    debug!(
+        target: LOG_TARGET,
+        "SeedStrap: Connected to seed peer '{}'. Requesting peer list.",
+        seed_peer_node_id_str
+    );
+
+    let peers_from_seed = match fetch_peers_from_connection(
+        &mut conn,
+        max_peers_to_sync_per_round,
+        max_permitted_peer_claims,
+        max_permitted_peer_addresses_per_claim,
+    )
+    .await
+    {
+        Ok(peers) => peers,
+        Err(e) => {
+            warn!(
+                target: LOG_TARGET,
+                "SeedStrap: Iteration {}/{}: Failed to fetch peers from seed peer '{}': {}. Disconnecting and continuing.",
+                idx + 1,
+                num_seeds_to_try,
+                seed_peer_node_id_str,
+                e
+            );
+            // Attempt to disconnect, log if it fails but continue
+            if let Err(disc_err) = conn.disconnect(Minimized::Yes).await {
+                warn!(target: LOG_TARGET, "SeedStrap: Also failed to disconnect from seed peer '{}' after fetch failure: {}", seed_peer_node_id_str, disc_err);
             }
             return (vec![], 0, 0);
-        }
+        },
+    };
 
-        debug!(
+    if peers_from_seed.is_empty() {
+        info!(
             target: LOG_TARGET,
-            "SeedStrap: Successfully fetched {} peer entries from seed peer '{}'. Disconnecting before processing.",
-            peers_from_seed.len(),
-            seed_peer_node_id_str
-        );
-
-        if let Err(e) = conn.disconnect(Minimized::Yes).await {
-            warn!(target: LOG_TARGET, "SeedStrap: Failed to disconnect from seed peer '{}': {}", seed_peer_node_id_str, e);
-        } else {
-            debug!(target: LOG_TARGET, "SeedStrap: Successfully disconnected from seed peer '{}'", seed_peer_node_id_str);
-        }
-
-        let mut new_peers_this_seed = 0;
-        let mut duplicates_this_seed = 0;
-
-        let peers_count = peers_from_seed.len();
-        debug!(
-            target: LOG_TARGET,
-            "SeedStrap: Iteration {}/{}: Beginning to process {} peers from seed peer '{}'",
+            "SeedStrap: Iteration {}/{}: Seed peer '{}' returned an empty peer list. Disconnecting.",
             idx + 1,
             num_seeds_to_try,
-            peers_count,
             seed_peer_node_id_str
         );
+        if let Err(e) = conn.disconnect(Minimized::Yes).await {
+            warn!(target: LOG_TARGET, "SeedStrap: Failed to disconnect from seed peer '{}' after receiving empty list: {}", seed_peer_node_id_str, e);
+        }
+        return (vec![], 0, 0);
+    }
 
-        for (peer_idx_loop, peer_info_proto) in peers_from_seed.iter().enumerate() {
-            let new_peer_candidate: UnvalidatedPeerInfo = match peer_info_proto.clone().try_into() {
-                Ok(p) => p,
-                Err(e) => {
-                    warn!(
-                        target: LOG_TARGET,
-                        "SeedStrap: (From Seed '{}', Peer Candidate {}/{}): Invalid peer data received, skipping: {}",
-                        seed_peer_node_id_str,
-                        peer_idx_loop + 1,
-                        peers_count,
-                        e
-                    );
-                    continue; // Skip this invalid entry
-                },
-            };
+    debug!(
+        target: LOG_TARGET,
+        "SeedStrap: Successfully fetched {} peer entries from seed peer '{}'. Disconnecting before processing.",
+        peers_from_seed.len(),
+        seed_peer_node_id_str
+    );
 
-            let candidate_node_id = NodeId::from_public_key(&new_peer_candidate.public_key);
+    if let Err(e) = conn.disconnect(Minimized::Yes).await {
+        warn!(target: LOG_TARGET, "SeedStrap: Failed to disconnect from seed peer '{}': {}", seed_peer_node_id_str, e);
+    } else {
+        debug!(target: LOG_TARGET, "SeedStrap: Successfully disconnected from seed peer '{}'", seed_peer_node_id_str);
+    }
+
+    let mut new_peers_this_seed = 0;
+    let mut duplicates_this_seed = 0;
+
+    let peers_count = peers_from_seed.len();
+    debug!(
+        target: LOG_TARGET,
+        "SeedStrap: Iteration {}/{}: Beginning to process {} peers from seed peer '{}'",
+        idx + 1,
+        num_seeds_to_try,
+        peers_count,
+        seed_peer_node_id_str
+    );
+
+    for (peer_idx_loop, peer_info_proto) in peers_from_seed.iter().enumerate() {
+        let new_peer_candidate: UnvalidatedPeerInfo = match peer_info_proto.clone().try_into() {
+            Ok(p) => p,
+            Err(e) => {
+                warn!(
+                    target: LOG_TARGET,
+                    "SeedStrap: (From Seed '{}', Peer Candidate {}/{}): Invalid peer data received, skipping: {}",
+                    seed_peer_node_id_str,
+                    peer_idx_loop + 1,
+                    peers_count,
+                    e
+                );
+                continue; // Skip this invalid entry
+            },
+        };
+
+        let candidate_node_id = NodeId::from_public_key(&new_peer_candidate.public_key);
+        trace!(
+            target: LOG_TARGET,
+            "SeedStrap: (From Seed '{}', Peer Candidate {}/{}): Processing candidate NodeId = {}",
+            seed_peer_node_id_str,
+            peer_idx_loop + 1,
+            peers_count,
+            candidate_node_id
+        );
+
+        if new_peer_candidate.public_key == *context.node_identity.public_key() {
+            trace!(target: LOG_TARGET, "SeedStrap: (From Seed '{}', Peer Candidate {}/{}): Skipping self.", seed_peer_node_id_str, peer_idx_loop+1, peers_count);
+            continue;
+        }
+
+        if seed_node_ids_set.contains(&candidate_node_id) {
             trace!(
                 target: LOG_TARGET,
-                "SeedStrap: (From Seed '{}', Peer Candidate {}/{}): Processing candidate NodeId = {}",
+                "SeedStrap: (From Seed '{}', Peer Candidate {}/{}): Skipping known seed peer {}.",
                 seed_peer_node_id_str,
                 peer_idx_loop + 1,
                 peers_count,
                 candidate_node_id
             );
+            continue;
+        }
 
-            if new_peer_candidate.public_key == *self.context.node_identity.public_key() {
-                trace!(target: LOG_TARGET, "SeedStrap: (From Seed '{}', Peer Candidate {}/{}): Skipping self.", seed_peer_node_id_str, peer_idx_loop+1, peers_count);
-                continue;
-            }
-
-            if seed_node_ids_set.contains(&candidate_node_id) {
-                trace!(
+        let maybe_existing_peer = match context
+            .peer_manager
+            .find_by_public_key(&new_peer_candidate.public_key)
+            .await
+        {
+            Ok(peer) => peer,
+            Err(e) => {
+                warn!(
                     target: LOG_TARGET,
-                    "SeedStrap: (From Seed '{}', Peer Candidate {}/{}): Skipping known seed peer {}.",
+                    "SeedStrap: (Seed '{}', Peer Candidate {}/{}): Error searching for existing peer candidate {} by public key: {}. Skipping.",
+                    seed_peer_node_id_str, peer_idx_loop + 1, peers_count, candidate_node_id, e
+                );
+                continue;
+            },
+        };
+
+        let is_new_peer = maybe_existing_peer.is_none();
+
+        let validator = PeerValidator::new(&context.config);
+        match validator.validate_peer(new_peer_candidate, maybe_existing_peer) {
+            Ok(valid_peer) => {
+                debug!(
+                    target: LOG_TARGET,
+                    "SeedStrap: (From Seed '{}', Peer Candidate {}/{}): Peer {} from seed '{}' is valid. New: {}. Adding to peer manager.",
                     seed_peer_node_id_str,
                     peer_idx_loop + 1,
                     peers_count,
-                    candidate_node_id
+                    valid_peer.node_id,
+                    seed_peer_node_id_str,
+                    is_new_peer
                 );
-                continue;
-            }
 
-            let maybe_existing_peer = match self
-                .context
-                .peer_manager
-                .find_by_public_key(&new_peer_candidate.public_key)
-                .await
-            {
-                Ok(peer) => peer,
-                Err(e) => {
-                    warn!(
-                        target: LOG_TARGET,
-                        "SeedStrap: (Seed '{}', Peer Candidate {}/{}): Error searching for existing peer candidate {} by public key: {}. Skipping.",
-                        seed_peer_node_id_str, peer_idx_loop + 1, peers_count, candidate_node_id, e
-                    );
-                    continue;
-                },
-            };
-
-            let is_new_peer = maybe_existing_peer.is_none();
-
-            let validator = PeerValidator::new(&self.context.config);
-            match validator.validate_peer(new_peer_candidate, maybe_existing_peer) {
-                Ok(valid_peer) => {
-                    debug!(
-                        target: LOG_TARGET,
-                        "SeedStrap: (From Seed '{}', Peer Candidate {}/{}): Peer {} from seed '{}' is valid. New: {}. Adding to peer manager.",
-                        seed_peer_node_id_str,
-                        peer_idx_loop + 1,
-                        peers_count,
-                        valid_peer.node_id,
-                        seed_peer_node_id_str,
-                        is_new_peer
-                    );
-
-                    match self.context.peer_manager.add_or_update_peer(valid_peer).await {
-                        Ok(_) => {
-                            if is_new_peer {
-                                new_peers_this_seed += 1;
-                            } else {
-                                duplicates_this_seed += 1;
-                            }
-                        },
-                        Err(e) => {
-                            warn!(
-                                target: LOG_TARGET,
-                                "SeedStrap: (From Seed '{}', Peer Candidate {}/{}): Failed to add validated peer {}: {}",
-                                seed_peer_node_id_str,
-                                peer_idx_loop + 1,
-                                peers_count,
-                                candidate_node_id,
-                                e
-                            );
-                        },
-                    }
-                },
-                Err(e) => {
-                    warn!(
-                        target: LOG_TARGET,
-                        "SeedStrap: (From Seed '{}', Peer Candidate {}/{}): Invalid peer data for {} received from seed peer '{}': {}",
-                        seed_peer_node_id_str,
-                        peer_idx_loop + 1,
-                        peers_count,
-                        candidate_node_id,
-                        seed_peer_node_id_str,
-                        e
-                    );
-                },
-            }
+                match context.peer_manager.add_or_update_peer(valid_peer).await {
+                    Ok(_) => {
+                        if is_new_peer {
+                            new_peers_this_seed += 1;
+                        } else {
+                            duplicates_this_seed += 1;
+                        }
+                    },
+                    Err(e) => {
+                        warn!(
+                            target: LOG_TARGET,
+                            "SeedStrap: (From Seed '{}', Peer Candidate {}/{}): Failed to add validated peer {}: {}",
+                            seed_peer_node_id_str,
+                            peer_idx_loop + 1,
+                            peers_count,
+                            candidate_node_id,
+                            e
+                        );
+                    },
+                }
+            },
+            Err(e) => {
+                warn!(
+                    target: LOG_TARGET,
+                    "SeedStrap: (From Seed '{}', Peer Candidate {}/{}): Invalid peer data for {} received from seed peer '{}': {}",
+                    seed_peer_node_id_str,
+                    peer_idx_loop + 1,
+                    peers_count,
+                    candidate_node_id,
+                    seed_peer_node_id_str,
+                    e
+                );
+            },
         }
-
-        info!(
-            target: LOG_TARGET,
-            "SeedStrap: Iteration {}/{}: Finished processing peers from seed '{}'. New peers from this seed: {}. \
-            Duplicates from this seed: {}.",
-            idx + 1,
-            num_seeds_to_try,
-            seed_peer_node_id_str,
-            new_peers_this_seed,
-            duplicates_this_seed
-        );
-
-        (peers_from_seed, new_peers_this_seed, duplicates_this_seed)
     }
 
-    async fn fetch_peers_from_connection(
-        &self,
-        conn: &mut PeerConnection,
-    ) -> Result<Vec<crate::proto::rpc::PeerInfo>, NetworkDiscoveryError> {
-        debug!(
-            target: LOG_TARGET,
-            "SeedStrap: Beginning RPC client connection to seed peer '{}'",
-            conn.peer_node_id()
-        );
+    info!(
+        target: LOG_TARGET,
+        "SeedStrap: Iteration {}/{}: Finished processing peers from seed '{}'. New peers from this seed: {}. \
+        Duplicates from this seed: {}.",
+        idx + 1,
+        num_seeds_to_try,
+        seed_peer_node_id_str,
+        new_peers_this_seed,
+        duplicates_this_seed
+    );
 
-        let mut client = match conn.connect_rpc::<DhtClient>().await {
-            Ok(client) => {
-                debug!(
-                    target: LOG_TARGET,
-                    "SeedStrap: Successfully connected RPC client to seed peer '{}'",
-                    conn.peer_node_id()
-                );
-                client
-            },
-            Err(e) => {
-                error!(
-                    target: LOG_TARGET,
-                    "SeedStrap: Failed to connect RPC client to seed peer {}: {}",
-                    conn.peer_node_id(),
-                    e
-                );
-                return Err(e.into());
-            },
-        };
+    (peers_from_seed, new_peers_this_seed, duplicates_this_seed)
+}
 
-        let base = cmp::min(
-            self.config().network_discovery.max_peers_to_sync_per_round,
-            DHT_RPC_MAX_PEERS_PER_REQUEST,
-        );
-        // Ask for at most half the configured value but never zero
-        let num_peers_to_request = (base / 2).max(1);
+async fn fetch_peers_from_connection(
+    conn: &mut PeerConnection,
+    max_peers_to_sync_per_round: u32,
+    max_permitted_peer_claims: usize,
+    max_permitted_peer_addresses_per_claim: usize,
+) -> Result<Vec<crate::proto::rpc::PeerInfo>, NetworkDiscoveryError> {
+    debug!(
+        target: LOG_TARGET,
+        "SeedStrap: Beginning RPC client connection to seed peer '{}'",
+        conn.peer_node_id()
+    );
 
-        let req = GetPeersRequest {
-            n: num_peers_to_request,
-            include_clients: false,
-            max_claims: self.config().max_permitted_peer_claims.try_into().unwrap_or(u32::MAX),
-            max_addresses_per_claim: self
-                .config()
-                .peer_validator_config
-                .max_permitted_peer_addresses_per_claim
-                .try_into()
-                .unwrap_or(u32::MAX),
-        };
-
-        debug!(
-            target: LOG_TARGET,
-            "SeedStrap: Calling get_peers RPC to request {} peers from seed '{}'",
-            num_peers_to_request,
-            conn.peer_node_id()
-        );
-
-        let mut peer_stream = match client.get_peers(req).await {
-            Ok(stream) => {
-                debug!(
-                    target: LOG_TARGET,
-                    "SeedStrap: Successfully initiated get_peers stream from seed peer '{}'",
-                    conn.peer_node_id()
-                );
-                stream
-            },
-            Err(e) => {
-                error!(
-                    target: LOG_TARGET,
-                    "SeedStrap: Failed to initiate get_peers stream from seed peer '{}': {}. This seed peer will be skipped.",
-                    conn.peer_node_id(),
-                    e
-                );
-                return Err(e.into());
-            },
-        };
-
-        let seed_node_id_str = conn.peer_node_id().to_string(); // Used for logging
-        let peers_from_seed = self.collect_peer_stream(&seed_node_id_str, &mut peer_stream).await?;
-
-        debug!(
-            target: LOG_TARGET,
-            "SeedStrap: fetch_peers_from_connection for seed '{}' is returning {} peer entries.",
-            conn.peer_node_id(),
-            peers_from_seed.len()
-        );
-        Ok(peers_from_seed)
-    }
-
-    async fn collect_peer_stream<S>(
-        &self,
-        seed_node_id_str: &str,
-        peer_stream: &mut S,
-    ) -> Result<Vec<crate::proto::rpc::PeerInfo>, NetworkDiscoveryError>
-    where
-        S: StreamExt<Item = Result<crate::proto::rpc::GetPeersResponse, tari_comms::protocol::rpc::RpcStatus>> + Unpin,
-    {
-        let mut peers_from_seed = Vec::new();
-        let mut stream_items_processed_total = 0; // Total items received from stream
-        let mut stream_items_with_peers = 0; // Items that actually contained peer data
-
-        debug!(
-            target: LOG_TARGET,
-            "SeedStrap: Beginning to collect peer stream items from seed '{}'", seed_node_id_str
-        );
-
-        loop {
+    let mut client = match conn.connect_rpc::<DhtClient>().await {
+        Ok(client) => {
             debug!(
                 target: LOG_TARGET,
-                "SeedStrap: Attempting to get next peer from stream for seed '{}'. Processed {} items so far ({} with peers).",
-                seed_node_id_str,
-                stream_items_processed_total,
-                stream_items_with_peers
+                "SeedStrap: Successfully connected RPC client to seed peer '{}'",
+                conn.peer_node_id()
             );
+            client
+        },
+        Err(e) => {
+            error!(
+                target: LOG_TARGET,
+                "SeedStrap: Failed to connect RPC client to seed peer {}: {}",
+                conn.peer_node_id(),
+                e
+            );
+            return Err(e.into());
+        },
+    };
 
-            // Add timeout to prevent hanging indefinitely on a stalled stream
-            match tokio::time::timeout(STREAM_ITEM_TIMEOUT, peer_stream.next()).await {
-                // Timeout occurred while waiting for the next item
-                Err(_) => {
-                    warn!(
-                        target: LOG_TARGET,
-                        "SeedStrap: Timeout after {:.2?} waiting for next peer from stream for seed '{}'. Breaking from peer stream collection.",
-                        STREAM_ITEM_TIMEOUT,
-                        seed_node_id_str
-                    );
-                    // Treat as if the stream ended, but it was due to a timeout
-                    // This allows the outer loop to try another seed peer
-                    break;
-                },
-                // Got an item from the stream (or stream ended)
-                Ok(item_result) => {
-                    match item_result {
-                        Some(Ok(crate::proto::rpc::GetPeersResponse { peer })) => {
-                            stream_items_processed_total += 1;
-                            if let Some(peer_info_proto) = peer {
-                                debug!(
-                                    target: LOG_TARGET,
-                                    "SeedStrap: Stream item #{} (peer item #{}) from seed '{}' contains a peer",
-                                    stream_items_processed_total,
-                                    stream_items_with_peers + 1, // +1 because this one is a peer
-                                    seed_node_id_str
-                                );
-                                peers_from_seed.push(peer_info_proto);
-                                stream_items_with_peers += 1;
-                            } else {
-                                debug!(
-                                    target: LOG_TARGET,
-                                    "SeedStrap: Stream item #{} from seed '{}' contains an empty (None) GetPeersResponse.peer field.",
-                                    stream_items_processed_total,
-                                    seed_node_id_str
-                                );
-                            }
-                        },
-                        Some(Err(e)) => {
-                            stream_items_processed_total += 1;
-                            warn!(
-                                target: LOG_TARGET,
-                                "SeedStrap: Error in stream item #{} from seed '{}': {}. Breaking from peer stream collection.",
-                                stream_items_processed_total,
-                                seed_node_id_str,
-                                e
-                            );
-                            debug!(
-                                target: LOG_TARGET,
-                                "SeedStrap: Exiting collect_peer_stream for seed '{}' early due to RPC stream error. Peers collected so far: {}. Total items processed from stream: {}.",
-                                seed_node_id_str,
-                                peers_from_seed.len(),
-                                stream_items_processed_total
-                            );
-                            return Err(e.into());
-                        },
-                        None => {
-                            debug!(
-                                target: LOG_TARGET,
-                                "SeedStrap: Peer stream ended for seed '{}'. Processed {} items in total, {} of which contained peers.",
-                                seed_node_id_str,
-                                stream_items_processed_total,
-                                stream_items_with_peers
-                            );
-                            break; // Stream ended gracefully
-                        },
-                    }
-                },
-            }
-        }
+    let base = cmp::min(max_peers_to_sync_per_round, DHT_RPC_MAX_PEERS_PER_REQUEST);
+    // Ask for at most half the configured value but never zero
+    let num_peers_to_request = (base / 2).max(1);
 
-        info!(
+    let req = GetPeersRequest {
+        n: num_peers_to_request,
+        include_clients: false,
+        max_claims: max_permitted_peer_claims.try_into().unwrap_or(u32::MAX),
+        max_addresses_per_claim: max_permitted_peer_addresses_per_claim.try_into().unwrap_or(u32::MAX),
+    };
+
+    debug!(
+        target: LOG_TARGET,
+        "SeedStrap: Calling get_peers RPC to request {} peers from seed '{}'",
+        num_peers_to_request,
+        conn.peer_node_id()
+    );
+
+    let mut peer_stream = match client.get_peers(req).await {
+        Ok(stream) => {
+            debug!(
+                target: LOG_TARGET,
+                "SeedStrap: Successfully initiated get_peers stream from seed peer '{}'",
+                conn.peer_node_id()
+            );
+            stream
+        },
+        Err(e) => {
+            error!(
+                target: LOG_TARGET,
+                "SeedStrap: Failed to initiate get_peers stream from seed peer '{}': {}. This seed peer will be skipped.",
+                conn.peer_node_id(),
+                e
+            );
+            return Err(e.into());
+        },
+    };
+
+    let seed_node_id_str = conn.peer_node_id().to_string(); // Used for logging
+    let peers_from_seed = collect_peer_stream(&seed_node_id_str, &mut peer_stream).await?;
+
+    debug!(
+        target: LOG_TARGET,
+        "SeedStrap: fetch_peers_from_connection for seed '{}' is returning {} peer entries.",
+        conn.peer_node_id(),
+        peers_from_seed.len()
+    );
+    Ok(peers_from_seed)
+}
+
+async fn collect_peer_stream<S>(
+    seed_node_id_str: &str,
+    peer_stream: &mut S,
+) -> Result<Vec<crate::proto::rpc::PeerInfo>, NetworkDiscoveryError>
+where
+    S: StreamExt<Item = Result<crate::proto::rpc::GetPeersResponse, tari_comms::protocol::rpc::RpcStatus>> + Unpin,
+{
+    let mut peers_from_seed = Vec::new();
+    let mut stream_items_processed_total = 0; // Total items received from stream
+    let mut stream_items_with_peers = 0; // Items that actually contained peer data
+
+    debug!(
+        target: LOG_TARGET,
+        "SeedStrap: Beginning to collect peer stream items from seed '{}'", seed_node_id_str
+    );
+
+    loop {
+        debug!(
             target: LOG_TARGET,
-            "SeedStrap: Received {} total peer entries from seed peer '{}' (in {} stream items, {} containing actual peers).",
-            peers_from_seed.len(),
+            "SeedStrap: Attempting to get next peer from stream for seed '{}'. Processed {} items so far ({} with peers).",
             seed_node_id_str,
             stream_items_processed_total,
-            stream_items_with_peers,
+            stream_items_with_peers
         );
 
-        Ok(peers_from_seed)
+        // Add timeout to prevent hanging indefinitely on a stalled stream
+        match tokio::time::timeout(STREAM_ITEM_TIMEOUT, peer_stream.next()).await {
+            // Timeout occurred while waiting for the next item
+            Err(_) => {
+                warn!(
+                    target: LOG_TARGET,
+                    "SeedStrap: Timeout after {:.2?} waiting for next peer from stream for seed '{}'. Breaking from peer stream collection.",
+                    STREAM_ITEM_TIMEOUT,
+                    seed_node_id_str
+                );
+                // Treat as if the stream ended, but it was due to a timeout
+                // This allows the outer loop to try another seed peer
+                break;
+            },
+            // Got an item from the stream (or stream ended)
+            Ok(item_result) => {
+                match item_result {
+                    Some(Ok(crate::proto::rpc::GetPeersResponse { peer })) => {
+                        stream_items_processed_total += 1;
+                        if let Some(peer_info_proto) = peer {
+                            debug!(
+                                target: LOG_TARGET,
+                                "SeedStrap: Stream item #{} (peer item #{}) from seed '{}' contains a peer",
+                                stream_items_processed_total,
+                                stream_items_with_peers + 1, // +1 because this one is a peer
+                                seed_node_id_str
+                            );
+                            peers_from_seed.push(peer_info_proto);
+                            stream_items_with_peers += 1;
+                        } else {
+                            debug!(
+                                target: LOG_TARGET,
+                                "SeedStrap: Stream item #{} from seed '{}' contains an empty (None) GetPeersResponse.peer field.",
+                                stream_items_processed_total,
+                                seed_node_id_str
+                            );
+                        }
+                    },
+                    Some(Err(e)) => {
+                        stream_items_processed_total += 1;
+                        warn!(
+                            target: LOG_TARGET,
+                            "SeedStrap: Error in stream item #{} from seed '{}': {}. Breaking from peer stream collection.",
+                            stream_items_processed_total,
+                            seed_node_id_str,
+                            e
+                        );
+                        debug!(
+                            target: LOG_TARGET,
+                            "SeedStrap: Exiting collect_peer_stream for seed '{}' early due to RPC stream error. Peers collected so far: {}. Total items processed from stream: {}.",
+                            seed_node_id_str,
+                            peers_from_seed.len(),
+                            stream_items_processed_total
+                        );
+                        return Err(e.into());
+                    },
+                    None => {
+                        debug!(
+                            target: LOG_TARGET,
+                            "SeedStrap: Peer stream ended for seed '{}'. Processed {} items in total, {} of which contained peers.",
+                            seed_node_id_str,
+                            stream_items_processed_total,
+                            stream_items_with_peers
+                        );
+                        break; // Stream ended gracefully
+                    },
+                }
+            },
+        }
     }
 
-    #[inline]
-    fn config(&self) -> &DhtConfig {
-        &self.context.config
-    }
+    info!(
+        target: LOG_TARGET,
+        "SeedStrap: Received {} total peer entries from seed peer '{}' (in {} stream items, {} containing actual peers).",
+        peers_from_seed.len(),
+        seed_node_id_str,
+        stream_items_processed_total,
+        stream_items_with_peers,
+    );
+
+    Ok(peers_from_seed)
 }

--- a/comms/dht/src/network_discovery/seed_strap.rs
+++ b/comms/dht/src/network_discovery/seed_strap.rs
@@ -22,7 +22,8 @@
 
 use std::{cmp, collections::HashSet, convert::TryInto, time::Duration};
 
-use futures::{future, StreamExt};
+use futures::StreamExt;
+use futures_util::stream::FuturesUnordered;
 use log::*;
 use rand::prelude::SliceRandom;
 use tari_comms::{
@@ -161,85 +162,90 @@ impl SeedStrap {
         let mut seed_peers = seed_peers_available.clone();
         seed_peers.shuffle(&mut rand::thread_rng());
         let mut seed_peers_iter = seed_peers.iter();
-        let mut permitted_concurrent = num_seeds_to_try;
-        let mut remaining_seed_peers = seed_peers.len();
 
-        let mut exit_loop = false;
         let max_peers_to_sync_per_round = self.config().network_discovery.max_peers_to_sync_per_round;
         let max_permitted_peer_claims = self.config().max_permitted_peer_claims;
         let max_permitted_peer_addresses_per_claim = self
             .config()
             .peer_validator_config
             .max_permitted_peer_addresses_per_claim;
-        while !exit_loop && permitted_concurrent > 0 {
-            // Select the permitted concurrent number of seed peers to try
-            let candidates: Vec<Peer> = seed_peers_iter.by_ref().take(permitted_concurrent).cloned().collect();
-            let num_seeds_this_round = candidates.len();
-            round_info.sync_peers = candidates.iter().map(|p| p.node_id.clone()).collect();
-            if candidates.is_empty() {
-                debug!(target: LOG_TARGET, "SeedStrap: No more seed peer candidates available to try.");
-                break;
-            } else {
-                debug!(
-                    target: LOG_TARGET,
-                    "SeedStrap: Preparing to sync from up to {} seed peers. Selected peer IDs for this round: {:?}",
+
+        // Select the permitted concurrent number of seed peers to try
+        let candidates: Vec<Peer> = seed_peers_iter.by_ref().take(num_seeds_to_try).cloned().collect();
+        let num_seeds_this_round = candidates.len();
+        round_info.sync_peers = candidates.iter().map(|p| p.node_id.clone()).collect();
+        debug!(
+            target: LOG_TARGET,
+            "SeedStrap: Preparing to sync from up to {} seed peers. Selected peer IDs for this round: {:?}",
+            num_seeds_this_round,
+            round_info.sync_peers,
+        );
+
+        // Get peers from seeds concurrently
+        let mut task_stream = FuturesUnordered::new();
+        for (idx, seed_peer_candidate) in candidates.into_iter().enumerate() {
+            attempted_seed_contacts += 1;
+            let seed_node_ids_set_clone = seed_node_ids_set.clone();
+            let context_clone = self.context.clone();
+            let handle = tokio::task::spawn(async move {
+                get_peers(
+                    context_clone,
+                    seed_peer_candidate,
                     num_seeds_this_round,
-                    round_info.sync_peers,
-                );
-            }
-            remaining_seed_peers = remaining_seed_peers.saturating_sub(candidates.len());
+                    idx,
+                    &seed_node_ids_set_clone,
+                    max_peers_to_sync_per_round,
+                    max_permitted_peer_claims,
+                    max_permitted_peer_addresses_per_claim,
+                )
+                .await
+            });
+            task_stream.push(handle);
+        }
 
-            // Get peers from seeds concurrently
-            let mut join_handles = Vec::new();
-            for (idx, seed_peer_candidate) in candidates.into_iter().enumerate() {
-                attempted_seed_contacts += 1;
+        while let Some(result) = task_stream.next().await {
+            let (peers_from_seed, new_peers_this_seed, duplicates_this_seed, spawn_another_task) = match result {
+                Ok((peers, n_new, n_dup)) => (peers, n_new, n_dup, false),
+                Err(e) => {
+                    debug!(target: LOG_TARGET, "SeedStrap: get_peers task unsuccessful, starting a new one: {}", e);
+                    (Vec::new(), 0, 0, true)
+                },
+            };
 
-                let seed_node_ids_set_clone = seed_node_ids_set.clone();
-                let context_clone = self.context.clone();
-
-                let handle = tokio::task::spawn(async move {
-                    get_peers(
-                        context_clone,
-                        seed_peer_candidate,
-                        num_seeds_this_round,
-                        idx,
-                        &seed_node_ids_set_clone,
-                        max_peers_to_sync_per_round,
-                        max_permitted_peer_claims,
-                        max_permitted_peer_addresses_per_claim,
-                    )
-                    .await
-                });
-
-                join_handles.push(handle);
-            }
-            let results = future::join_all(join_handles).await;
-
-            permitted_concurrent = 0;
-            for result in results {
-                let Ok((peers_from_seed, new_peers_this_seed, duplicates_this_seed)) = result else {
-                    warn!(target: LOG_TARGET, "SeedStrap: get_peers task panicked or was cancelled");
-                    permitted_concurrent += 1;
-                    continue;
-                };
-
-                // This seed successfully provided peers
-                if peers_from_seed.is_empty() {
-                    permitted_concurrent += 1;
-                } else {
-                    round_info.num_succeeded += 1;
-                    successful_seed_contacts += 1;
+            if spawn_another_task || peers_from_seed.is_empty() {
+                // Add a new task to the stream if the previous one failed
+                if let Some(seed_peer_candidate) = seed_peers_iter.next().cloned() {
+                    attempted_seed_contacts += 1;
+                    let seed_node_ids_set_clone = seed_node_ids_set.clone();
+                    let context_clone = self.context.clone();
+                    let handle = tokio::task::spawn(async move {
+                        get_peers(
+                            context_clone,
+                            seed_peer_candidate,
+                            num_seeds_this_round,
+                            1,
+                            &seed_node_ids_set_clone,
+                            max_peers_to_sync_per_round,
+                            max_permitted_peer_claims,
+                            max_permitted_peer_addresses_per_claim,
+                        )
+                        .await
+                    });
+                    task_stream.push(handle);
                 }
-
-                total_peers_added_this_round += new_peers_this_seed;
-                total_duplicates_this_round += duplicates_this_seed;
+                continue;
+            } else {
+                // This seed successfully provided peers
+                round_info.num_succeeded += 1;
+                successful_seed_contacts += 1;
             }
+
+            total_peers_added_this_round += new_peers_this_seed;
+            total_duplicates_this_round += duplicates_this_seed;
 
             // Exit condition
-            if remaining_seed_peers == 0 ||
-                self.early_exit_conditions_met(total_peers_added_this_round, successful_seed_contacts)
-            {
-                exit_loop = true;
+            if self.early_exit_conditions_met(total_peers_added_this_round, successful_seed_contacts) {
+                break;
             }
         }
 
@@ -404,8 +410,8 @@ async fn get_peers(
 
         debug!(
             target: LOG_TARGET,
-            "SeedStrap: Connected to seed peer '{}'. Requesting peer list.",
-            seed_peer_node_id_str
+            "SeedStrap: Connected to seed peer '{}'. Requesting peer list. Try {} of {}.",
+            seed_peer_node_id_str, attempt, NUM_RETRIES,
         );
 
         match fetch_peers_from_connection(
@@ -420,8 +426,8 @@ async fn get_peers(
                 if peers.is_empty() && !conn.is_connected() && attempt < NUM_RETRIES {
                     debug!(
                         target: LOG_TARGET,
-                        "SeedStrap: Connection to seed peer '{}' lost. Retry {} of {}.",
-                        seed_peer_node_id_str, attempt, NUM_RETRIES,
+                        "SeedStrap: Connection to seed peer '{}' lost on try {}. Will retry.",
+                        seed_peer_node_id_str, attempt,
                     );
                     continue;
                 }

--- a/comms/dht/src/network_discovery/state_machine.rs
+++ b/comms/dht/src/network_discovery/state_machine.rs
@@ -513,8 +513,6 @@ pub struct DhtNetworkDiscoveryRoundInfo {
     pub sync_peers: Vec<NodeId>,
     // New fields:
     pub phase: DiscoveryPhase,
-    pub round_number: Option<usize>, // Current round/iteration number if applicable
-    pub total_rounds: Option<usize>, // Total rounds/iterations planned for this phase, if applicable
 }
 
 impl DhtNetworkDiscoveryRoundInfo {


### PR DESCRIPTION
Description
---
Added concurrency when contacting seed nodes during seed strap operations.

Fixes #7181.

Motivation and Context
---
Seed trap mode and startup can be improved.

How Has This Been Tested?
---
System-level testing [**TBD**]

What process can a PR reviewer use to test or verify this change?
---
Code review
System-level testing 

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved peer discovery performance by processing seed peers concurrently, resulting in faster network discovery.
  * Enhanced modularity and clarity of the peer fetching and validation process.
  * Improved logging for better visibility during peer discovery operations.
  * Removed round tracking fields from network discovery status to simplify peer discovery state management.
  * Promoted a key utility dependency to support core network discovery features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->