### PR TITLE
chore: new release v4.9.0-pre.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4138,7 +4138,7 @@ dependencies = [
 
 [[package]]
 name = "minotari_app_grpc"
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 dependencies = [
  "argon2 0.4.1",
  "base64 0.13.1",
@@ -4168,7 +4168,7 @@ dependencies = [
 
 [[package]]
 name = "minotari_app_utilities"
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 dependencies = [
  "clap 3.2.25",
  "dialoguer 0.10.4",
@@ -4190,7 +4190,7 @@ dependencies = [
 
 [[package]]
 name = "minotari_console_wallet"
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 dependencies = [
  "blake2",
  "chrono",
@@ -4247,14 +4247,14 @@ dependencies = [
 
 [[package]]
 name = "minotari_ledger_wallet_common"
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 dependencies = [
  "bs58 0.5.1",
 ]
 
 [[package]]
 name = "minotari_ledger_wallet_comms"
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 dependencies = [
  "borsh",
  "dialoguer 0.11.0",
@@ -4275,7 +4275,7 @@ dependencies = [
 
 [[package]]
 name = "minotari_merge_mining_proxy"
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4319,7 +4319,7 @@ dependencies = [
 
 [[package]]
 name = "minotari_miner"
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 dependencies = [
  "base64 0.13.1",
  "borsh",
@@ -4354,7 +4354,7 @@ dependencies = [
 
 [[package]]
 name = "minotari_mining_helper_ffi"
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 dependencies = [
  "borsh",
  "cbindgen",
@@ -4373,7 +4373,7 @@ dependencies = [
 
 [[package]]
 name = "minotari_node"
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4425,7 +4425,7 @@ dependencies = [
 
 [[package]]
 name = "minotari_node_grpc_client"
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 dependencies = [
  "minotari_app_grpc",
  "tokio",
@@ -4433,7 +4433,7 @@ dependencies = [
 
 [[package]]
 name = "minotari_node_wallet_client"
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4450,7 +4450,7 @@ dependencies = [
 
 [[package]]
 name = "minotari_wallet"
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 dependencies = [
  "anyhow",
  "argon2 0.4.1",
@@ -4506,7 +4506,7 @@ dependencies = [
 
 [[package]]
 name = "minotari_wallet_ffi"
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 dependencies = [
  "borsh",
  "cbindgen",
@@ -7422,7 +7422,7 @@ dependencies = [
 
 [[package]]
 name = "tari_common"
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 dependencies = [
  "anyhow",
  "cargo_toml",
@@ -7448,7 +7448,7 @@ dependencies = [
 
 [[package]]
 name = "tari_common_sqlite"
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -7464,7 +7464,7 @@ dependencies = [
 
 [[package]]
 name = "tari_common_types"
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 dependencies = [
  "base64 0.21.7",
  "bitflags 2.6.0",
@@ -7492,7 +7492,7 @@ dependencies = [
 
 [[package]]
 name = "tari_comms"
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7543,7 +7543,7 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_dht"
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",
@@ -7585,7 +7585,7 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_rpc_macros"
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 dependencies = [
  "futures 0.3.31",
  "proc-macro2",
@@ -7600,7 +7600,7 @@ dependencies = [
 
 [[package]]
 name = "tari_contacts"
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 dependencies = [
  "chrono",
  "diesel",
@@ -7634,7 +7634,7 @@ dependencies = [
 
 [[package]]
 name = "tari_core"
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7741,11 +7741,11 @@ dependencies = [
 
 [[package]]
 name = "tari_features"
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 
 [[package]]
 name = "tari_hashing"
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 dependencies = [
  "blake2",
  "borsh",
@@ -7800,7 +7800,7 @@ dependencies = [
 
 [[package]]
 name = "tari_jellyfish"
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 dependencies = [
  "borsh",
  "digest 0.10.7",
@@ -7813,7 +7813,7 @@ dependencies = [
 
 [[package]]
 name = "tari_key_manager"
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 dependencies = [
  "argon2 0.4.1",
  "async-trait",
@@ -7848,7 +7848,7 @@ dependencies = [
 
 [[package]]
 name = "tari_libtor"
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 dependencies = [
  "derivative",
  "libtor",
@@ -7861,7 +7861,7 @@ dependencies = [
 
 [[package]]
 name = "tari_max_size"
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 dependencies = [
  "borsh",
  "serde",
@@ -7871,7 +7871,7 @@ dependencies = [
 
 [[package]]
 name = "tari_metrics"
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -7886,7 +7886,7 @@ dependencies = [
 
 [[package]]
 name = "tari_mmr"
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 dependencies = [
  "bincode",
  "blake2",
@@ -7904,7 +7904,7 @@ dependencies = [
 
 [[package]]
 name = "tari_p2p"
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 dependencies = [
  "anyhow",
  "clap 3.2.25",
@@ -7937,7 +7937,7 @@ dependencies = [
 
 [[package]]
 name = "tari_script"
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 dependencies = [
  "blake2",
  "borsh",
@@ -7955,7 +7955,7 @@ dependencies = [
 
 [[package]]
 name = "tari_service_framework"
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7972,7 +7972,7 @@ dependencies = [
 
 [[package]]
 name = "tari_shutdown"
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 dependencies = [
  "futures 0.3.31",
  "tokio",
@@ -7980,7 +7980,7 @@ dependencies = [
 
 [[package]]
 name = "tari_sidechain"
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 dependencies = [
  "borsh",
  "hex",
@@ -7997,7 +7997,7 @@ dependencies = [
 
 [[package]]
 name = "tari_storage"
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 dependencies = [
  "bincode",
  "lmdb-zero",
@@ -8010,7 +8010,7 @@ dependencies = [
 
 [[package]]
 name = "tari_test_utils"
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 dependencies = [
  "futures 0.3.31",
  "futures-test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 edition = "2021"
 authors = ["The Tari Development Community"]
 repository = "https://github.com/tari-project/tari"

--- a/applications/minotari_ledger_wallet/comms/Cargo.toml
+++ b/applications/minotari_ledger_wallet/comms/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "minotari_ledger_wallet_comms"
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 authors = ["The Tari Development Community"]
 license = "BSD-3-Clause"
 edition = "2021"

--- a/applications/minotari_ledger_wallet/wallet/Cargo.lock
+++ b/applications/minotari_ledger_wallet/wallet/Cargo.lock
@@ -530,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "minotari_ledger_wallet"
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 dependencies = [
  "blake2",
  "borsh",
@@ -547,7 +547,7 @@ dependencies = [
 
 [[package]]
 name = "minotari_ledger_wallet_common"
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 dependencies = [
  "bs58",
 ]

--- a/applications/minotari_ledger_wallet/wallet/Cargo.toml
+++ b/applications/minotari_ledger_wallet/wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "minotari_ledger_wallet"
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 authors = ["The Tari Development Community"]
 license = "BSD-3-Clause"
 edition = "2021"

--- a/applications/minotari_miner/Cargo.toml
+++ b/applications/minotari_miner/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "The tari miner implementation"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 edition = "2018"
 
 [dependencies]

--- a/clients/ffi_client/package-lock.json
+++ b/clients/ffi_client/package-lock.json
@@ -18,11 +18,11 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
-            "ms": "4.9.0-pre.0"
+            "ms": "4.9.0-pre.1"
           }
         },
         "ms": {
-          "version": "4.9.0-pre.0",
+          "version": "4.9.0-pre.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
@@ -180,11 +180,11 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
-            "ms": "4.9.0-pre.0"
+            "ms": "4.9.0-pre.1"
           }
         },
         "ms": {
-          "version": "4.9.0-pre.0",
+          "version": "4.9.0-pre.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }

--- a/clients/rust/base_node_wallet_client/Cargo.toml
+++ b/clients/rust/base_node_wallet_client/Cargo.toml
@@ -9,7 +9,6 @@ license.workspace = true
 [dependencies]
 tari_core = { workspace = true, default-features = false, features = [
     "transactions",
-    "base_node",
 ] }
 tari_utilities = { workspace = true }
 tari_shutdown = { workspace = true }

--- a/comms/rpc_macros/Cargo.toml
+++ b/comms/rpc_macros/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 edition = "2018"
 
 [lib]

--- a/infrastructure/test_utils/Cargo.toml
+++ b/infrastructure/test_utils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_test_utils"
 description = "Utility functions used in Tari test functions"
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 authors = ["The Tari Development Community"]
 edition = "2018"
 license = "BSD-3-Clause"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tari",
-  "version": "4.9.0-pre.0",
+  "version": "4.9.0-pre.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {}

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -1585,63 +1585,63 @@ version = "0.8.8"
 criteria = "safe-to-deploy"
 
 [[exemptions.minotari_app_grpc]]
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.minotari_app_grpc]]
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.minotari_app_utilities]]
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.minotari_app_utilities]]
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.minotari_console_wallet]]
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.minotari_console_wallet]]
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.minotari_merge_mining_proxy]]
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.minotari_merge_mining_proxy]]
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.minotari_miner]]
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.minotari_mining_helper_ffi]]
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.minotari_mining_helper_ffi]]
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.minotari_wallet]]
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.minotari_wallet]]
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.minotari_wallet_ffi]]
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.minotari_wallet_ffi]]
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.mintex]]
@@ -2725,63 +2725,63 @@ version = "0.4.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.tari_common]]
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.tari_common]]
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.tari_common_sqlite]]
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.tari_common_sqlite]]
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.tari_common_types]]
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.tari_common_types]]
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.tari_comms]]
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.tari_comms]]
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.tari_comms_dht]]
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.tari_comms_dht]]
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.tari_comms_rpc_macros]]
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.tari_contacts]]
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.tari_contacts]]
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.tari_core]]
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.tari_core]]
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.tari_crypto]]
@@ -2789,95 +2789,95 @@ version = "0.22.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.tari_features]]
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.tari_features]]
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.tari_hashing]]
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.tari_hashing]]
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.tari_key_manager]]
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.tari_key_manager]]
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.tari_libtor]]
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.tari_libtor]]
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.tari_metrics]]
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.tari_metrics]]
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.tari_mmr]]
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.tari_mmr]]
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.tari_p2p]]
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.tari_p2p]]
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.tari_script]]
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.tari_script]]
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.tari_service_framework]]
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.tari_service_framework]]
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.tari_shutdown]]
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.tari_shutdown]]
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.tari_storage]]
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.tari_storage]]
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.tari_test_utils]]
-version = "4.9.0-pre.0"
+version = "4.9.0-pre.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.tari_utilities]]


### PR DESCRIPTION
Description
---
new release emse fixing ffi builds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version numbers from "4.9.0-pre.0" to "4.9.0-pre.1" across multiple packages and configuration files.
  * Updated exemption entries in configuration to reflect the new version.
* **Refactor**
  * Removed the "base_node" feature from a dependency in the wallet client configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->