### PR TITLE
fix: dont start second utxo scanner for recovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4543,7 +4543,6 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
- "url",
  "zeroize",
 ]
 

--- a/base_layer/wallet/src/utxo_scanner_service/uxto_scanner_service_builder.rs
+++ b/base_layer/wallet/src/utxo_scanner_service/uxto_scanner_service_builder.rs
@@ -63,8 +63,6 @@ impl Debug for UtxoScannerMode {
 pub struct UtxoScannerServiceBuilder<TWalletClientFactory> {
     retry_limit: usize,
     mode: Option<UtxoScannerMode>,
-    one_sided_message: String,
-    recovery_message: String,
     client_factory: Option<TWalletClientFactory>,
     scanning_interval: u64,
 }
@@ -74,8 +72,6 @@ impl<T> Default for UtxoScannerServiceBuilder<T> {
         Self {
             retry_limit: 0,
             mode: None,
-            one_sided_message: "Detected one-sided payment on blockchain".to_string(),
-            recovery_message: "Output found on blockchain during Wallet Recovery".to_string(),
             client_factory: None,
             scanning_interval: 60, // Default scanning interval in seconds
         }
@@ -92,16 +88,6 @@ impl<T: HttpClientFactory + Clone + Send + Sync + 'static> UtxoScannerServiceBui
 
     pub fn with_mode(&mut self, mode: UtxoScannerMode) -> &mut Self {
         self.mode = Some(mode);
-        self
-    }
-
-    pub fn with_one_sided_message(&mut self, message: String) -> &mut Self {
-        self.one_sided_message = message;
-        self
-    }
-
-    pub fn with_recovery_message(&mut self, message: String) -> &mut Self {
-        self.recovery_message = message;
         self
     }
 

--- a/base_layer/wallet/tests/utxo_scanner/mod.rs
+++ b/base_layer/wallet/tests/utxo_scanner/mod.rs
@@ -102,8 +102,6 @@ async fn setup(
     key_manager: MemoryDbKeyManager,
     mode: UtxoScannerMode,
     previous_db: Option<WalletDatabase<WalletSqliteDatabase>>,
-    recovery_message: Option<String>,
-    one_sided_message: Option<String>,
 ) -> UtxoScannerTestInterface {
     let shutdown = Shutdown::new();
 
@@ -168,14 +166,6 @@ async fn setup(
         UtxoScannerService::<WalletSqliteDatabase, MemoryDbKeyManager, MockHttpClientFactory>::builder();
 
     scanner_service_builder.with_retry_limit(1).with_mode(mode);
-
-    if let Some(message) = one_sided_message {
-        scanner_service_builder.with_one_sided_message(message);
-    }
-
-    if let Some(message) = recovery_message {
-        scanner_service_builder.with_recovery_message(message);
-    }
 
     let view_key = key_manager.get_view_key().await.unwrap();
     let tari_address = TariAddress::new_dual_address_with_default_features(
@@ -284,7 +274,7 @@ async fn generate_block_headers_and_utxos(
 async fn test_utxo_scanner_recovery() {
     // env_logger::builder().filter_level(log::LevelFilter::Trace).init();  //  > ./target/output.log 2>&1
     let key_manager = create_memory_db_key_manager().unwrap();
-    let mut test_interface = setup(key_manager.clone(), UtxoScannerMode::Recovery, None, None, None).await;
+    let mut test_interface = setup(key_manager.clone(), UtxoScannerMode::Recovery, None).await;
 
     let cipher_seed = CipherSeed::new();
     // get birthday duration, in seconds, from unix epoch
@@ -379,7 +369,7 @@ async fn test_utxo_scanner_recovery() {
 #[allow(clippy::too_many_lines)]
 async fn test_utxo_scanner_recovery_with_restart() {
     let key_manager = create_memory_db_key_manager().unwrap();
-    let mut test_interface = setup(key_manager.clone(), UtxoScannerMode::Recovery, None, None, None).await;
+    let mut test_interface = setup(key_manager.clone(), UtxoScannerMode::Recovery, None).await;
 
     let cipher_seed = CipherSeed::new();
     // get birthday duration, in seconds, from unix epoch
@@ -480,8 +470,6 @@ async fn test_utxo_scanner_recovery_with_restart() {
         key_manager.clone(),
         UtxoScannerMode::Recovery,
         Some(test_interface.wallet_db),
-        Some("recovery".to_string()),
-        None,
     )
     .await;
     test_interface2
@@ -528,7 +516,7 @@ async fn test_utxo_scanner_recovery_with_restart() {
 #[allow(clippy::too_many_lines)]
 async fn test_utxo_scanner_recovery_with_restart_and_reorg() {
     let key_manager = create_memory_db_key_manager().unwrap();
-    let mut test_interface = setup(key_manager.clone(), UtxoScannerMode::Recovery, None, None, None).await;
+    let mut test_interface = setup(key_manager.clone(), UtxoScannerMode::Recovery, None).await;
 
     let cipher_seed = CipherSeed::new();
     // get birthday duration, in seconds, from unix epoch
@@ -625,8 +613,6 @@ async fn test_utxo_scanner_recovery_with_restart_and_reorg() {
         key_manager.clone(),
         UtxoScannerMode::Recovery,
         Some(test_interface.wallet_db),
-        None,
-        None,
     )
     .await;
     test_interface2
@@ -712,7 +698,7 @@ async fn test_utxo_scanner_recovery_with_restart_and_reorg() {
 #[allow(clippy::too_many_lines)]
 async fn test_utxo_scanner_scanned_block_cache_clearing() {
     let key_manager = create_memory_db_key_manager().unwrap();
-    let mut test_interface = setup(key_manager.clone(), UtxoScannerMode::Recovery, None, None, None).await;
+    let mut test_interface = setup(key_manager.clone(), UtxoScannerMode::Recovery, None).await;
 
     for h in 0u64..800u64 {
         // let num_outputs = if h % 2 == 1 { Some(1) } else { None };
@@ -850,14 +836,7 @@ async fn test_utxo_scanner_scanned_block_cache_clearing() {
 async fn test_utxo_scanner_one_sided_payments() {
     // env_logger::builder().filter_level(log::LevelFilter::Trace).init();  //  > ./target/output.log 2>&1
     let key_manager = create_memory_db_key_manager().unwrap();
-    let mut test_interface = setup(
-        key_manager.clone(),
-        UtxoScannerMode::Scanning,
-        None,
-        None,
-        Some("one-sided non-default".to_string()),
-    )
-    .await;
+    let mut test_interface = setup(key_manager.clone(), UtxoScannerMode::Scanning, None).await;
 
     let cipher_seed = CipherSeed::new();
     // get birthday duration, in seconds, from unix epoch
@@ -1041,7 +1020,7 @@ async fn test_utxo_scanner_one_sided_payments() {
 #[tokio::test]
 async fn test_birthday_timestamp_over_chain() {
     let key_manager = create_memory_db_key_manager().unwrap();
-    let test_interface = setup(key_manager, UtxoScannerMode::Recovery, None, None, None).await;
+    let test_interface = setup(key_manager, UtxoScannerMode::Recovery, None).await;
 
     let cipher_seed = CipherSeed::new();
     // get birthday duration, in seconds, from unix epoch

--- a/base_layer/wallet_ffi/Cargo.toml
+++ b/base_layer/wallet_ffi/Cargo.toml
@@ -43,7 +43,6 @@ num-traits = "0.2.15"
 itertools = "0.10.3"
 zeroize = "1"
 serde_json = "1.0"
-url = { version = "2.5.4", features = ["default", "serde"] }
 
 [target.'cfg(target_os="android")'.dependencies]
 openssl = { version = "0.10.72", features = ["vendored"] }

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -10768,7 +10768,10 @@ mod test {
     use std::{ffi::c_void, str::from_utf8, sync::Mutex};
 
     use minotari_wallet::{
-        storage::sqlite_utilities::run_migration_and_create_sqlite_connection,
+        storage::{
+            sqlite_db::wallet::WalletSqliteDatabase,
+            sqlite_utilities::run_migration_and_create_sqlite_connection,
+        },
         transaction_service::handle::TransactionSendStatus,
     };
     use once_cell::sync::Lazy;
@@ -11532,7 +11535,7 @@ mod test {
                 OutputType::from_byte(output_type as u8).unwrap()
             );
             assert_eq!((*output_features).maturity, maturity);
-            assert!((*output_features).coinbase_extra.is_empty());
+            assert!((&(*output_features).coinbase_extra).is_empty());
 
             output_features_destroy(output_features);
             byte_vector_destroy(metadata);

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -81,7 +81,6 @@ use log4rs::{
 };
 use minotari_wallet::{
     base_node_service::config::BaseNodeServiceConfig,
-    client::http_client_factory::{DefaultHttpClientFactory, HttpClientFactory},
     connectivity_service::WalletConnectivityInterface,
     error::{WalletError, WalletStorageError},
     output_manager_service::{
@@ -95,7 +94,6 @@ use minotari_wallet::{
     },
     storage::{
         database::WalletDatabase,
-        sqlite_db::wallet::WalletSqliteDatabase,
         sqlite_utilities::{get_last_network, get_last_version, initialize_sqlite_database_backends},
     },
     transaction_service::{
@@ -106,11 +104,10 @@ use minotari_wallet::{
             models::{CompletedTransaction, InboundTransaction, OutboundTransaction},
         },
     },
-    utxo_scanner_service::{service::UtxoScannerService, RECOVERY_KEY},
+    utxo_scanner_service::RECOVERY_KEY,
     wallet::{derive_comms_secret_key, read_or_create_master_seed, WalletMessageSigningDomain},
     Wallet,
     WalletConfig,
-    WalletKeyManager,
     WalletSqlite,
 };
 use num_traits::FromPrimitive;
@@ -192,7 +189,6 @@ use tari_utilities::{
     SafePassword,
 };
 use tokio::runtime::Runtime;
-use url::Url;
 use zeroize::Zeroize;
 
 use crate::{
@@ -281,7 +277,7 @@ pub struct TariSeedWords(SeedWords);
 pub struct TariPublicKeys(Vec<TariPublicKey>);
 
 pub struct TariWallet {
-    wallet: WalletSqlite,
+    pub wallet: WalletSqlite,
     runtime: Runtime,
     shutdown: Shutdown,
     context: Context,
@@ -10064,7 +10060,6 @@ pub unsafe extern "C" fn wallet_is_recovery_in_progress(wallet: *mut TariWallet,
 ///
 /// ## Arguments
 /// `wallet` - The TariWallet pointer.
-/// `base_node_public_keys` - An optional TariPublicKeys pointer of the Base Nodes the recovery process must use
 /// `recovery_progress_callback` - The callback function pointer that will be used to asynchronously communicate
 /// progress to the client. The first argument of the callback is an event enum encoded as a u8 as follows:
 /// ```
@@ -10102,9 +10097,6 @@ pub unsafe extern "C" fn wallet_is_recovery_in_progress(wallet: *mut TariWallet,
 ///     - If a unrecoverable error occurs the `RecoveryFailed` event will be returned and the client will need to start
 ///       a new process.
 ///
-/// `recovered_output_message` - A string that will be used as the message for any recovered outputs. If Null the
-/// default     message will be used
-///
 /// `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
 /// as an out parameter.
 ///
@@ -10118,9 +10110,7 @@ pub unsafe extern "C" fn wallet_is_recovery_in_progress(wallet: *mut TariWallet,
 #[no_mangle]
 pub unsafe extern "C" fn wallet_start_recovery(
     wallet: *mut TariWallet,
-    http_base_node: *const c_char,
     recovery_progress_callback: unsafe extern "C" fn(context: *mut c_void, u8, u64, u64),
-    recovered_output_message: *const c_char,
     error_out: *mut c_int,
 ) -> bool {
     if error_out.is_null() {
@@ -10133,68 +10123,11 @@ pub unsafe extern "C" fn wallet_start_recovery(
         return false;
     }
 
-    let runtime = match Runtime::new() {
-        Ok(r) => r,
-        Err(e) => {
-            *error_out = LibWalletError::from(InterfaceError::TokioError(e.to_string())).code;
-            return false;
-        },
-    };
-    let shutdown_signal = (*wallet).shutdown.to_signal();
-    let mut recovery_task_builder =
-        UtxoScannerService::<WalletSqliteDatabase, WalletKeyManager, DefaultHttpClientFactory>::builder();
-
-    if !recovered_output_message.is_null() {
-        let message_str = match CStr::from_ptr(recovered_output_message).to_str() {
-            Ok(v) => v.to_owned(),
-            _ => {
-                *error_out =
-                    LibWalletError::from(InterfaceError::PointerError("recovered_output_message".to_string())).code;
-                return false;
-            },
-        };
-        recovery_task_builder.with_recovery_message(message_str);
-    }
-    let http_url = if http_base_node.is_null() {
-        *error_out = LibWalletError::from(InterfaceError::NullError("http_base_node".to_string())).code;
-        return false;
-    } else {
-        match CStr::from_ptr(http_base_node).to_str() {
-            Ok(v) => match Url::parse(v) {
-                Ok(url) => url,
-                Err(e) => {
-                    *error_out =
-                        LibWalletError::from(InterfaceError::InvalidArgument(format!("Url is not valid: {}", e))).code;
-                    return false;
-                },
-            },
-            _ => {
-                *error_out = LibWalletError::from(InterfaceError::PointerError("http_base_node".to_string())).code;
-                return false;
-            },
-        }
-    };
-    let mut recovery_task = match runtime.block_on(async {
-        recovery_task_builder
-            .with_client_factory(DefaultHttpClientFactory::new(http_url))
-            .with_retry_limit(10)
-            .build_with_wallet(&(*wallet).wallet, shutdown_signal)
-            .await
-    }) {
-        Ok(v) => v,
-        Err(e) => {
-            *error_out = LibWalletError::from(WalletError::ServiceInitializationError(e)).code;
-            return false;
-        },
-    };
-
-    let event_stream = recovery_task.get_event_receiver();
-    let recovery_join_handle = (*wallet).runtime.spawn(recovery_task.run());
+    let event_stream = (*wallet).wallet.utxo_scanner_service.clone().get_event_receiver();
 
     // Spawn a task to monitor the recovery process events and call the callback appropriately
     (*wallet).runtime.spawn(recovery_event_monitoring(
         event_stream,
-        recovery_join_handle,
         recovery_progress_callback,
         (*wallet).context,
     ));

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -11535,7 +11535,7 @@ mod test {
                 OutputType::from_byte(output_type as u8).unwrap()
             );
             assert_eq!((*output_features).maturity, maturity);
-            assert!((&(*output_features).coinbase_extra).is_empty());
+            assert!((*output_features).coinbase_extra);
 
             output_features_destroy(output_features);
             byte_vector_destroy(metadata);

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -11535,7 +11535,7 @@ mod test {
                 OutputType::from_byte(output_type as u8).unwrap()
             );
             assert_eq!((*output_features).maturity, maturity);
-            assert!((*output_features).coinbase_extra);
+            assert!((*output_features).coinbase_extra.is_empty());
 
             output_features_destroy(output_features);
             byte_vector_destroy(metadata);

--- a/base_layer/wallet_ffi/src/tasks.rs
+++ b/base_layer/wallet_ffi/src/tasks.rs
@@ -23,9 +23,9 @@
 use std::ffi::c_void;
 
 use log::*;
-use minotari_wallet::{error::WalletError, utxo_scanner_service::handle::UtxoScannerEvent};
+use minotari_wallet::utxo_scanner_service::handle::UtxoScannerEvent;
 use tari_utilities::hex::Hex;
-use tokio::{sync::broadcast, task::JoinHandle};
+use tokio::sync::broadcast;
 
 use crate::callback_handler::Context;
 
@@ -45,7 +45,6 @@ enum RecoveryEvent {
 #[allow(clippy::too_many_lines)]
 pub async fn recovery_event_monitoring(
     mut event_stream: broadcast::Receiver<UtxoScannerEvent>,
-    recovery_join_handle: JoinHandle<Result<(), WalletError>>,
     recovery_progress_callback: unsafe extern "C" fn(context: *mut c_void, u8, u64, u64),
     context: Context,
 ) {
@@ -157,22 +156,5 @@ pub async fn recovery_event_monitoring(
                 warn!(target: LOG_TARGET, "{}", e);
             },
         }
-    }
-
-    let recovery_result = recovery_join_handle.await;
-    match recovery_result {
-        Ok(Ok(_)) => {},
-        Ok(Err(e)) => {
-            unsafe {
-                (recovery_progress_callback)(context.0, RecoveryEvent::RecoveryFailed as u8, 0u64, 1u64);
-            }
-            error!(target: LOG_TARGET, "Recovery error: {:?}", e);
-        },
-        Err(e) => {
-            unsafe {
-                (recovery_progress_callback)(context.0, RecoveryEvent::RecoveryFailed as u8, 1u64, 0u64);
-            }
-            error!(target: LOG_TARGET, "Recovery error: {}", e);
-        },
     }
 }

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -4411,7 +4411,6 @@ bool wallet_is_recovery_in_progress(struct TariWallet *wallet,
  *
  * ## Arguments
  * `wallet` - The TariWallet pointer.
- * `base_node_public_keys` - An optional TariPublicKeys pointer of the Base Nodes the recovery process must use
  * `recovery_progress_callback` - The callback function pointer that will be used to asynchronously communicate
  * progress to the client. The first argument of the callback is an event enum encoded as a u8 as follows:
  * ```
@@ -4449,9 +4448,6 @@ bool wallet_is_recovery_in_progress(struct TariWallet *wallet,
  *     - If a unrecoverable error occurs the `RecoveryFailed` event will be returned and the client will need to start
  *       a new process.
  *
- * `recovered_output_message` - A string that will be used as the message for any recovered outputs. If Null the
- * default     message will be used
- *
  * `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
  * as an out parameter.
  *
@@ -4464,12 +4460,10 @@ bool wallet_is_recovery_in_progress(struct TariWallet *wallet,
  * None
  */
 bool wallet_start_recovery(struct TariWallet *wallet,
-                           const char *http_base_node,
                            void (*recovery_progress_callback)(void *context,
                                                               uint8_t,
                                                               uint64_t,
                                                               uint64_t),
-                           const char *recovered_output_message,
                            int *error_out);
 
 /**

--- a/docs/guide/ffi_overview.md
+++ b/docs/guide/ffi_overview.md
@@ -360,7 +360,6 @@ uint64_t wallet_start_txo_validation(
 ```c
 bool wallet_start_recovery(
     TariWallet* wallet,
-    TariPublicKey* base_node_public_key,
     void (*callback_recovery_progress)(uint8_t, uint64_t, uint64_t),
     int* error_out
 );

--- a/integration_tests/src/ffi/ffi_import.rs
+++ b/integration_tests/src/ffi/ffi_import.rs
@@ -611,9 +611,7 @@ extern "C" {
     pub fn wallet_is_recovery_in_progress(wallet: *mut TariWallet, error_out: *mut c_int) -> bool;
     pub fn wallet_start_recovery(
         wallet: *mut TariWallet,
-        base_node_public_keys: *mut TariPublicKeys,
         recovery_progress_callback: unsafe extern "C" fn(context: *mut c_void, u8, u64, u64),
-        recovered_output_message: *const c_char,
         error_out: *mut c_int,
     ) -> bool;
     pub fn wallet_set_one_sided_payment_message(


### PR DESCRIPTION
Description
---
Dont start a new utxo scanning service, simply listen to its feedback. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Simplified the wallet recovery process to use the existing UTXO scanner service for monitoring progress.
* **Refactor**
  * Streamlined the recovery workflow by removing redundant parameters and tasks, resulting in a cleaner and more efficient recovery operation.
  * Removed unused message settings from the UTXO scanner configuration.
* **Chores**
  * Updated function signatures and field visibility for improved integration and maintainability.
  * Cleaned up related test setups and documentation to reflect the simplified recovery interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->