### PR TITLE
feat: message signing exposed via gRPC

### DIFF
--- a/applications/minotari_app_grpc/proto/wallet.proto
+++ b/applications/minotari_app_grpc/proto/wallet.proto
@@ -993,6 +993,52 @@ service Wallet {
   // Creates a transaction with a template registration output
   rpc CreateTemplateRegistration(CreateTemplateRegistrationRequest) returns (CreateTemplateRegistrationResponse);
   
+  // Signs a message using the wallet's node identity private key.
+  //
+  // The `SignMessage` call creates a Schnorr signature over a message using the wallet's node identity private key.
+  // This signature can be used to prove ownership of the wallet or authenticate messages.
+  // The signature is returned as separate components (signature and public nonce) for verification.
+  //
+  // ### Request Parameters:
+  //
+  // - `message` (required):
+  //   - **Type**: `bytes`
+  //   - **Description**: The message to be signed (arbitrary bytes).
+  //   - **Restrictions**: Can be any byte sequence.
+  //
+  // ### Response Fields:
+  //
+  // - **signature**: The Schnorr signature as hex-encoded bytes.
+  // - **public_nonce**: The public nonce component of the signature as hex-encoded bytes.
+  //
+  // ### Example JavaScript gRPC client usage:
+  //
+  // ```javascript
+  // const request = {
+  //   message: Buffer.from("Hello Tari!", "utf-8")
+  // };
+  // client.signMessage(request, (err, response) => {
+  //   if (err) console.error(err);
+  //   else console.log("Signature:", response.signature, "Nonce:", response.public_nonce);
+  // });
+  // ```
+  //
+  // ### Sample JSON Response:
+  //
+  // ```json
+  // {
+  //   "signature": "a1b2c3d4e5f6...",
+  //   "public_nonce": "f6e5d4c3b2a1..."
+  // }
+  // ```
+  //
+  // ### Security Notes:
+  //
+  // - This signs with the wallet's node identity private key.
+  // - The signature can be verified using the wallet's public key.
+  // - Use this for authentication and ownership proofs only.
+  rpc SignMessage (SignMessageRequest) returns (SignMessageResponse);
+
   // Streams real-time wallet transaction events to the client.
   //
   // The `StreamTransactionEvents` RPC provides a continuous stream of transaction events as they occur within the wallet.
@@ -1645,4 +1691,18 @@ message FeePerGramStat {
   uint64 min_fee_per_gram = 2;
   // The maximum fee per gram observed in the recent blocks.
   uint64 max_fee_per_gram = 3;
+}
+
+// Request message for SignMessage RPC
+message SignMessageRequest {
+  // The message to be signed (arbitrary bytes)
+  bytes message = 1;
+}
+
+// Response message for SignMessage RPC
+message SignMessageResponse {
+  // The Schnorr signature as hex-encoded string
+  string signature = 1;
+  // The public nonce component as hex-encoded string
+  string public_nonce = 2;
 }

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -93,6 +93,8 @@ use minotari_app_grpc::tari_rpc::{
     RevalidateResponse,
     SendShaAtomicSwapRequest,
     SendShaAtomicSwapResponse,
+    SignMessageRequest,
+    SignMessageResponse,
     SubmitValidatorEvictionProofRequest,
     SubmitValidatorEvictionProofResponse,
     SubmitValidatorNodeExitRequest,
@@ -124,8 +126,10 @@ use tari_common_types::{
     payment_reference::generate_payment_reference,
     tari_address::TariAddress,
     transaction::TxId,
-    types::{BlockHash, CompressedPublicKey, PrivateKey, Signature},
+    types::{BlockHash, CompressedPublicKey, PrivateKey, Signature, SignatureWithDomain},
 };
+use tari_crypto::hash_domain;
+use rand::rngs::OsRng;
 use tari_comms::{types::CommsPublicKey, CommsNode};
 use tari_core::{
     consensus::{ConsensusBuilderError, ConsensusConstants, ConsensusManager},
@@ -154,6 +158,13 @@ use crate::{
 };
 
 const LOG_TARGET: &str = "wallet::ui::grpc";
+
+// Domain separator for signing arbitrary messages with a wallet secret key
+hash_domain!(
+    WalletMessageSigningDomain,
+    "com.tari.base_layer.wallet.message_signing",
+    1
+);
 
 async fn send_transaction_event(
     transaction_event: TransactionEvent,
@@ -2106,6 +2117,37 @@ impl wallet_server::Wallet for WalletGrpcServer {
         }];
         Ok(Response::new(GetFeePerGramStatsResponse {
             fee_per_gram_stats: fee_stats,
+        }))
+    }
+
+    async fn sign_message(
+        &self,
+        request: Request<SignMessageRequest>,
+    ) -> Result<Response<SignMessageResponse>, Status> {
+        let message = request.into_inner();
+        debug!(
+            target: LOG_TARGET,
+            "sign_message: Incoming GRPC request with message length: {}",
+            message.message.len()
+        );
+
+        let secret = self.wallet.comms.node_identity().secret_key().clone();
+        let message_str = String::from_utf8(message.message)
+            .map_err(|_| Status::invalid_argument("Message must be valid UTF-8"))?;
+
+        let signature = SignatureWithDomain::<WalletMessageSigningDomain>::sign(
+            &secret,
+            message_str.as_bytes(),
+            &mut OsRng,
+        )
+        .map_err(|e| Status::internal(format!("Failed to sign message: {}", e)))?;
+
+        let hex_sig = signature.get_signature().to_hex();
+        let hex_nonce = signature.get_public_nonce().to_hex();
+
+        Ok(Response::new(SignMessageResponse {
+            signature: hex_sig,
+            public_nonce: hex_nonce,
         }))
     }
 }

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -122,14 +122,13 @@ use minotari_wallet::{
     },
     WalletSqlite,
 };
+use rand::rngs::OsRng;
 use tari_common_types::{
     payment_reference::generate_payment_reference,
     tari_address::TariAddress,
     transaction::TxId,
     types::{BlockHash, CompressedPublicKey, PrivateKey, Signature, SignatureWithDomain},
 };
-use tari_crypto::hash_domain;
-use rand::rngs::OsRng;
 use tari_comms::{types::CommsPublicKey, CommsNode};
 use tari_core::{
     consensus::{ConsensusBuilderError, ConsensusConstants, ConsensusManager},
@@ -144,6 +143,7 @@ use tari_core::{
         transaction_protocol::recipient::RecipientState,
     },
 };
+use tari_crypto::hash_domain;
 use tari_utilities::{hex::Hex, ByteArray};
 use tokio::{
     sync::{broadcast, Mutex},
@@ -2132,15 +2132,12 @@ impl wallet_server::Wallet for WalletGrpcServer {
         );
 
         let secret = self.wallet.comms.node_identity().secret_key().clone();
-        let message_str = String::from_utf8(message.message)
-            .map_err(|_| Status::invalid_argument("Message must be valid UTF-8"))?;
+        let message_str =
+            String::from_utf8(message.message).map_err(|_| Status::invalid_argument("Message must be valid UTF-8"))?;
 
-        let signature = SignatureWithDomain::<WalletMessageSigningDomain>::sign(
-            &secret,
-            message_str.as_bytes(),
-            &mut OsRng,
-        )
-        .map_err(|e| Status::internal(format!("Failed to sign message: {}", e)))?;
+        let signature =
+            SignatureWithDomain::<WalletMessageSigningDomain>::sign(&secret, message_str.as_bytes(), &mut OsRng)
+                .map_err(|e| Status::internal(format!("Failed to sign message: {}", e)))?;
 
         let hex_sig = signature.get_signature().to_hex();
         let hex_nonce = signature.get_public_nonce().to_hex();


### PR DESCRIPTION
Description
---
Add gRPC SignMessage method to complement existing FFI wallet message signing functionality.

This PR adds the `SignMessage` gRPC method to the Tari wallet API, providing message signing capabilities through the gRPC interface. This complements the existing FFI `wallet_sign_message` function by offering the same cryptographic functionality through a different API interface.

**Key Components Added:**
- `SignMessage` RPC method definition in `wallet.proto`
- Complete gRPC service implementation in `wallet_grpc_server.rs`
- Comprehensive documentation with JavaScript examples and security notes
- Consistent signature format with existing FFI implementation

Both implementations use the wallet's node identity private key with the same domain separation (`WalletMessageSigningDomain`) to ensure signature compatibility.

Motivation and Context
---
This feature enables gRPC clients to authenticate messages and prove wallet ownership through cryptographic signatures. The Tari wallet already supports message signing through FFI bindings, but gRPC clients needed equivalent functionality.

The SignMessage method creates domain-separated Schnorr signatures using the wallet's node identity private key, returning both the signature and public nonce as hex-encoded strings for easy verification.

How Has This Been Tested?
---
- [x] Code compiles without errors
- [x] gRPC protobuf definitions generate successfully
- [x] Implementation follows existing gRPC patterns in the codebase
- [x] Signature format matches FFI implementation
- [x] Error handling properly maps to gRPC status codes
- [ ] Integration tests (recommended for future work)

What process can a PR reviewer use to test or verify this change?
---
1. **Build verification**: Run `cargo build --release --all-features` to ensure compilation
2. **gRPC generation**: Verify protobuf compilation in `applications/minotari_app_grpc/build.rs`
3. **Method signature**: Check that `sign_message` method appears in the generated Wallet trait
4. **Manual testing**: Start a wallet with gRPC enabled and call the SignMessage method
5. **Consistency check**: Compare signature output with FFI `wallet_sign_message` for same input
6. **Documentation review**: Verify proto documentation includes security notes and examples

**Files to review:**
- `applications/minotari_app_grpc/proto/wallet.proto` - RPC definition and documentation
- `applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs` - Implementation

Breaking Changes
---
- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to sign arbitrary messages using the wallet's private key via a new gRPC method.
  * Users can now obtain Schnorr signatures and public nonces for authentication purposes through the wallet service.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->