### PR TITLE
fix: scanned height tracking

### DIFF
--- a/applications/minotari_console_wallet/src/automation/commands.rs
+++ b/applications/minotari_console_wallet/src/automation/commands.rs
@@ -2175,8 +2175,15 @@ pub async fn command_runner(
                             UtxoScannerEvent::Progress {
                                 current_height,
                                 tip_height,
+                                latency,
+                                ..
                             } => {
-                                println!("Progress: {}/{}", current_height, tip_height);
+                                println!(
+                                    "Progress: {}/{} (Latency: {}ms)",
+                                    current_height,
+                                    tip_height,
+                                    latency.as_millis()
+                                );
                                 if current_height >= args.sync_to_height && args.sync_to_height > 0 {
                                     break;
                                 }

--- a/applications/minotari_console_wallet/src/grpc/wallet_debouncer.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_debouncer.rs
@@ -62,6 +62,7 @@ impl WalletDebouncer {
         transaction_service: TransactionServiceHandle,
         utxo_scanner_handle: UtxoScannerHandle,
         shutdown_signal: ShutdownSignal,
+        scanned_height: u64,
     ) -> Self {
         Self {
             balance: Arc::new(Mutex::new(Balance {
@@ -71,7 +72,7 @@ impl WalletDebouncer {
                 time_locked_balance: None,
             })),
             refresh_needed: Arc::new(Mutex::new(true)),
-            scanned_height: Arc::new(Mutex::new(0)),
+            scanned_height: Arc::new(Mutex::new(scanned_height)),
             output_manager_service,
             transaction_service,
             utxo_scanner_handle,

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -190,11 +190,17 @@ pub struct WalletGrpcServer {
 impl WalletGrpcServer {
     #[allow(dead_code)]
     pub fn new(wallet: WalletSqlite) -> Result<Self, ConsensusBuilderError> {
+        let scanned_height = wallet
+            .db
+            .get_last_scanned_height()
+            .unwrap_or_default()
+            .unwrap_or_default();
         let debouncer = WalletDebouncer::new(
             wallet.output_manager_service.clone(),
             wallet.transaction_service.clone(),
             wallet.utxo_scanner_service.clone(),
             wallet.comms.shutdown_signal(),
+            scanned_height,
         );
         let rules = ConsensusManager::builder(wallet.network.as_network()).build()?;
         Ok(Self {

--- a/applications/minotari_console_wallet/src/recovery.rs
+++ b/applications/minotari_console_wallet/src/recovery.rs
@@ -107,6 +107,7 @@ pub async fn wallet_recovery(wallet: &WalletSqlite, retry_limit: usize) -> Resul
             Ok(UtxoScannerEvent::Progress {
                 current_height,
                 tip_height,
+                ..
             }) => {
                 // its going to fail if the tip height is 0, meaning if you scanned up to 0, you are done
                 let percentage_progress = (current_height * 100).checked_div(tip_height).unwrap_or(100);

--- a/applications/minotari_console_wallet/src/ui/components/base_node.rs
+++ b/applications/minotari_console_wallet/src/ui/components/base_node.rs
@@ -46,9 +46,39 @@ impl<B: Backend> Component<B> for BaseNode {
     fn draw(&mut self, f: &mut Frame<B>, area: Rect, app_state: &AppState)
     where B: Backend {
         let title = Spans::from(vec![Span::styled(
-            " Base Node Status  -  ",
+            " Base Node Status  -     ",
             Style::default().fg(Color::White),
         )]);
+
+        let scanned_height = app_state.get_wallet_scanned_height();
+        let tip_height = app_state.get_wallet_tip_height();
+        let mut chain_info = vec![
+            Span::styled("Chain Tip:", Style::default().fg(Color::Magenta)),
+            Span::raw(" "),
+            Span::styled(
+                format!("#{}({})", tip_height, scanned_height),
+                Style::default().fg(Color::Green),
+            ),
+            Span::raw("   "),
+        ];
+
+        let latency = app_state.get_base_node_latency().unwrap_or_default().as_millis();
+        let latency_color = match latency {
+            0 => Color::Gray, // offline? default duration is 0
+            1..=800 => Color::Green,
+            801..=1200 => Color::Yellow,
+            _ => Color::Red,
+        };
+
+        let mut latency_span = vec![
+            Span::styled("Latency", Style::default().fg(Color::White)),
+            Span::raw(" "),
+            Span::styled(latency.to_string(), Style::default().fg(latency_color)),
+            Span::styled(" ms", Style::default().fg(Color::DarkGray)),
+        ];
+        chain_info.append(&mut latency_span);
+
+        let chain_info = Spans::from(chain_info);
 
         let base_node_id = Spans::from(vec![
             Span::styled(" Connected Base Node ID: ", Style::default().fg(Color::Magenta)),
@@ -77,6 +107,9 @@ impl<B: Backend> Component<B> for BaseNode {
 
         let paragraph = Paragraph::new(title).block(Block::default());
         f.render_widget(paragraph, columns[0]);
+        let paragraph = Paragraph::new(chain_info).block(Block::default());
+        f.render_widget(paragraph, columns[1]);
+
         let paragraph = Paragraph::new(base_node_id).block(Block::default());
         f.render_widget(paragraph, columns[2]);
 

--- a/applications/minotari_console_wallet/src/ui/state/app_state.rs
+++ b/applications/minotari_console_wallet/src/ui/state/app_state.rs
@@ -389,7 +389,19 @@ impl AppState {
     }
 
     pub fn get_http_node_url(&self) -> String {
-        self.wallet_config.http_client_url.clone()
+        self.cached_data.wallet_current_connected_node.clone()
+    }
+
+    pub fn get_wallet_scanned_height(&self) -> u64 {
+        self.cached_data.wallet_scanned_height
+    }
+
+    pub fn get_base_node_latency(&self) -> Option<Duration> {
+        self.cached_data.base_node_latency
+    }
+
+    pub fn get_wallet_tip_height(&self) -> u64 {
+        self.cached_data.wallet_tip_height
     }
 
     pub fn get_identity(&self) -> &MyIdentity {
@@ -534,8 +546,15 @@ pub struct AppStateInner {
 
 impl AppStateInner {
     pub fn new(wallet_identity: &WalletIdentity, wallet: WalletSqlite) -> Self {
-        let data = AppStateData::new(wallet_identity);
+        let mut data = AppStateData::new(wallet_identity);
+        let last_scanned_height = wallet
+            .db
+            .get_last_scanned_height()
+            .unwrap_or_default()
+            .unwrap_or_default();
 
+        data.wallet_tip_height = last_scanned_height;
+        data.wallet_scanned_height = last_scanned_height;
         AppStateInner {
             updated: false,
             data,
@@ -931,8 +950,16 @@ impl AppStateInner {
         Ok(())
     }
 
-    pub async fn trigger_wallet_scanned_height_update(&mut self, height: u64) -> Result<(), UiError> {
+    pub async fn trigger_wallet_scanned_height_update(&mut self, height: u64, tip_height: u64) -> Result<(), UiError> {
         self.data.wallet_scanned_height = height;
+        self.data.wallet_tip_height = tip_height;
+        self.updated = true;
+        Ok(())
+    }
+
+    pub async fn trigger_wallet_latency_node_update(&mut self, latency: Duration, name: String) -> Result<(), UiError> {
+        self.data.base_node_latency = Some(latency);
+        self.data.wallet_current_connected_node = name;
         self.updated = true;
         Ok(())
     }
@@ -1084,6 +1111,9 @@ struct AppStateData {
     notifications: Vec<(DateTime<Local>, String)>,
     new_notification_count: u32,
     wallet_scanned_height: u64,
+    wallet_tip_height: u64,
+    wallet_current_connected_node: String,
+    base_node_latency: Option<Duration>,
 }
 
 #[derive(Clone)]
@@ -1137,6 +1167,9 @@ impl AppStateData {
             notifications: Vec::new(),
             new_notification_count: 0,
             wallet_scanned_height: 0,
+            wallet_tip_height: 0,
+            wallet_current_connected_node: "".to_string(),
+            base_node_latency: None,
         }
     }
 }

--- a/applications/minotari_console_wallet/src/ui/state/wallet_event_monitor.rs
+++ b/applications/minotari_console_wallet/src/ui/state/wallet_event_monitor.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use log::*;
 use minotari_wallet::{
@@ -180,15 +180,19 @@ impl WalletEventMonitor {
                         Ok(event) => {
                             match event {
                                 UtxoScannerEvent::Progress {
-                                    current_height,..
+                                    current_height,tip_height, latency, current_node
                                 }=> {
-                                    self.trigger_wallet_scanned_height_update(current_height).await;
+                                    self.trigger_wallet_scanned_height_update(current_height, tip_height).await;
+                                self.trigger_wallet_latency_node_update(latency, current_node).await;
                                 }
                                 UtxoScannerEvent::Completed {
                                     final_height,
+                                latency, current_node,
                                     ..
                                 }=> {
-                                    self.trigger_wallet_scanned_height_update(final_height).await;
+                                    self.trigger_wallet_scanned_height_update(final_height,final_height).await;
+
+                                self.trigger_wallet_latency_node_update(latency, current_node).await;
                                     if self.should_we_trigger_tx_update_for_payref().await{
                                         self.trigger_full_tx_state_refresh().await;
                                     }
@@ -293,10 +297,18 @@ impl WalletEventMonitor {
         }
     }
 
-    async fn trigger_wallet_scanned_height_update(&mut self, height: u64) {
+    async fn trigger_wallet_scanned_height_update(&mut self, height: u64, tip_height: u64) {
         let mut inner = self.app_state_inner.write().await;
 
-        if let Err(e) = inner.trigger_wallet_scanned_height_update(height).await {
+        if let Err(e) = inner.trigger_wallet_scanned_height_update(height, tip_height).await {
+            warn!(target: LOG_TARGET, "Error refresh app_state: {}", e);
+        }
+    }
+
+    async fn trigger_wallet_latency_node_update(&mut self, latency: Duration, name: String) {
+        let mut inner = self.app_state_inner.write().await;
+
+        if let Err(e) = inner.trigger_wallet_latency_node_update(latency, name).await {
             warn!(target: LOG_TARGET, "Error refresh app_state: {}", e);
         }
     }

--- a/applications/minotari_console_wallet/src/ui/state/wallet_event_monitor.rs
+++ b/applications/minotari_console_wallet/src/ui/state/wallet_event_monitor.rs
@@ -183,7 +183,7 @@ impl WalletEventMonitor {
                                     current_height,tip_height, latency, current_node
                                 }=> {
                                     self.trigger_wallet_scanned_height_update(current_height, tip_height).await;
-                                self.trigger_wallet_latency_node_update(latency, current_node).await;
+                                    self.trigger_wallet_latency_node_update(latency, current_node).await;
                                 }
                                 UtxoScannerEvent::Completed {
                                     final_height,
@@ -191,8 +191,7 @@ impl WalletEventMonitor {
                                     ..
                                 }=> {
                                     self.trigger_wallet_scanned_height_update(final_height,final_height).await;
-
-                                self.trigger_wallet_latency_node_update(latency, current_node).await;
+                                    self.trigger_wallet_latency_node_update(latency, current_node).await;
                                     if self.should_we_trigger_tx_update_for_payref().await{
                                         self.trigger_full_tx_state_refresh().await;
                                     }

--- a/applications/minotari_console_wallet/src/wallet_modes.rs
+++ b/applications/minotari_console_wallet/src/wallet_modes.rs
@@ -331,7 +331,7 @@ pub fn recovery_mode(
         const CUCUMBER_TEST_MARKER_A: &str = "Minotari Console Wallet running... (Recovery mode started)";
         println!("{}", CUCUMBER_TEST_MARKER_A);
 
-        let url = Url::parse(wallet_config.http_client_url.as_ref())
+        let url = Url::parse(wallet_config.http_server_url.as_ref())
             .map_err(|e| ExitError::new(ExitCode::ConfigError, format!("Invalid HTTP client URL: {}", e)))?;
         match handle.block_on(wallet_recovery(&wallet, wallet_config.recovery_retry_limit)) {
             Ok(_) => println!("Wallet recovered!"),

--- a/base_layer/wallet/src/base_node_service/monitor.rs
+++ b/base_layer/wallet/src/base_node_service/monitor.rs
@@ -111,7 +111,7 @@ where TWalletConnectivity: WalletConnectivityInterface
                         .metadata
                         .ok_or_else(|| BaseNodeMonitorError::InvalidBaseNodeResponse("Tip info no metadata".to_string()))?;
 
-                    let latency = match client.get_last_request_latency() {
+                    let latency = match client.get_last_request_latency().await {
                         Some(latency) => latency,
                         None => {
                             continue;

--- a/base_layer/wallet/src/client/http_client_factory.rs
+++ b/base_layer/wallet/src/client/http_client_factory.rs
@@ -26,21 +26,22 @@ use url::Url;
 pub trait HttpClientFactory: Clone + Send + Sync + 'static {
     type Client: BaseNodeWalletClient;
     fn create_http_client(&self) -> Self::Client;
-    fn new(node_url: Url) -> Self;
+    fn new(node_url: Url, seed_url: Url) -> Self;
 }
 #[derive(Clone)]
 pub struct DefaultHttpClientFactory {
     node_url: Url,
+    seed_url: Url,
 }
 
 impl HttpClientFactory for DefaultHttpClientFactory {
     type Client = minotari_node_wallet_client::http::Client;
 
-    fn new(node_url: Url) -> Self {
-        Self { node_url }
+    fn new(node_url: Url, seed_url: Url) -> Self {
+        Self { node_url, seed_url }
     }
 
     fn create_http_client(&self) -> Self::Client {
-        minotari_node_wallet_client::http::Client::new(self.node_url.clone())
+        minotari_node_wallet_client::http::Client::new(self.node_url.clone(), self.seed_url.clone())
     }
 }

--- a/base_layer/wallet/src/config.rs
+++ b/base_layer/wallet/src/config.rs
@@ -29,7 +29,12 @@ use std::{
 use serde::{Deserialize, Serialize};
 use strum::EnumString;
 use tari_common::{
-    configuration::{bootstrap::wallet_http_service_default_port, serializers, Network, StringList},
+    configuration::{
+        bootstrap::{wallet_get_default_seed_https_address, wallet_http_service_default_port},
+        serializers,
+        Network,
+        StringList,
+    },
     SubConfigPath,
 };
 use tari_common_types::grpc_authentication::GrpcAuthentication;
@@ -125,7 +130,9 @@ pub struct WalletConfig {
     /// How many days do we need to start scanning before our actual birthday
     pub birthday_offset: u16,
     /// The URL of the HTTP client to use for base node requests
-    pub http_client_url: String,
+    pub http_server_url: String,
+    /// The fallback url address to use if the base node at http_server_url does not respond
+    pub fallback_http_server_url: String,
     /// the scanning interval for the utxo scanner service
     pub scanning_interval: u64,
 }
@@ -138,7 +145,10 @@ impl Default for WalletConfig {
             ..Default::default()
         };
         let port = wallet_http_service_default_port(Network::get_current());
-        let http_client_url = Url::parse(format!("http://127.0.0.1:{port}").as_str())
+        let http_server_url = Url::parse(format!("http://127.0.0.1:{port}").as_str())
+            .expect("This should be a valid URL")
+            .to_string();
+        let fallback_http_server_url = Url::parse(wallet_get_default_seed_https_address(Network::get_current()))
             .expect("This should be a valid URL")
             .to_string();
         Self {
@@ -172,7 +182,8 @@ impl Default for WalletConfig {
             identity_file: None,
             balance_enquiry_cooldown_period: Duration::from_secs(5),
             birthday_offset: 2,
-            http_client_url,
+            http_server_url,
+            fallback_http_server_url,
             scanning_interval: 60,
         }
     }

--- a/base_layer/wallet/src/connectivity_service/initializer.rs
+++ b/base_layer/wallet/src/connectivity_service/initializer.rs
@@ -36,15 +36,15 @@ use crate::client::http_client_factory::HttpClientFactory;
 
 pub struct WalletConnectivityInitializer<TClientFactory: HttpClientFactory> {
     http_node_url: Url,
-    https_seed_url: Url,
+    http_seed_url: Url,
     phantom: std::marker::PhantomData<TClientFactory>,
 }
 
 impl<T: HttpClientFactory> WalletConnectivityInitializer<T> {
-    pub fn new(http_node_url: Url, https_seed_url: Url) -> Self {
+    pub fn new(http_node_url: Url, http_seed_url: Url) -> Self {
         Self {
             http_node_url,
-            https_seed_url,
+            http_seed_url,
             phantom: std::marker::PhantomData,
         }
     }
@@ -53,7 +53,7 @@ impl<T: HttpClientFactory> WalletConnectivityInitializer<T> {
 #[async_trait]
 impl<T: HttpClientFactory> ServiceInitializer for WalletConnectivityInitializer<T> {
     async fn initialize(&mut self, context: ServiceInitializerContext) -> Result<(), ServiceInitializationError> {
-        let factory = T::new(self.http_node_url.clone(), self.https_seed_url.clone());
+        let factory = T::new(self.http_node_url.clone(), self.http_seed_url.clone());
         context.register_handle(WalletConnectivityHandle::new(factory));
 
         Ok(())

--- a/base_layer/wallet/src/connectivity_service/initializer.rs
+++ b/base_layer/wallet/src/connectivity_service/initializer.rs
@@ -36,13 +36,15 @@ use crate::client::http_client_factory::HttpClientFactory;
 
 pub struct WalletConnectivityInitializer<TClientFactory: HttpClientFactory> {
     http_node_url: Url,
+    https_seed_url: Url,
     phantom: std::marker::PhantomData<TClientFactory>,
 }
 
 impl<T: HttpClientFactory> WalletConnectivityInitializer<T> {
-    pub fn new(http_node_url: Url) -> Self {
+    pub fn new(http_node_url: Url, https_seed_url: Url) -> Self {
         Self {
             http_node_url,
+            https_seed_url,
             phantom: std::marker::PhantomData,
         }
     }
@@ -51,7 +53,7 @@ impl<T: HttpClientFactory> WalletConnectivityInitializer<T> {
 #[async_trait]
 impl<T: HttpClientFactory> ServiceInitializer for WalletConnectivityInitializer<T> {
     async fn initialize(&mut self, context: ServiceInitializerContext) -> Result<(), ServiceInitializationError> {
-        let factory = T::new(self.http_node_url.clone());
+        let factory = T::new(self.http_node_url.clone(), self.https_seed_url.clone());
         context.register_handle(WalletConnectivityHandle::new(factory));
 
         Ok(())

--- a/base_layer/wallet/src/utxo_scanner_service/handle.rs
+++ b/base_layer/wallet/src/utxo_scanner_service/handle.rs
@@ -47,6 +47,8 @@ pub enum UtxoScannerEvent {
     Progress {
         current_height: u64,
         tip_height: u64,
+        latency: Duration,
+        current_node: String,
     },
     /// Completed Recovery (Number scanned, Num of Recovered outputs, Value of recovered outputs, Time taken)
     Completed {
@@ -54,6 +56,8 @@ pub enum UtxoScannerEvent {
         num_recovered: u64,
         value_recovered: MicroMinotari,
         time_taken: Duration,
+        latency: Duration,
+        current_node: String,
     },
     /// Scanning process has failed and scanning process has exited
     ScanningFailed,

--- a/base_layer/wallet/src/utxo_scanner_service/initializer.rs
+++ b/base_layer/wallet/src/utxo_scanner_service/initializer.rs
@@ -51,6 +51,7 @@ pub struct UtxoScannerServiceInitializer<T, TKeyManagerInterface> {
     network: Network,
     birthday_offset: u16,
     http_node_url: Url,
+    http_fallback_url: Url,
     scanning_interval: u64,
     phantom: PhantomData<TKeyManagerInterface>,
 }
@@ -63,6 +64,7 @@ where T: WalletBackend + 'static
         network: Network,
         birthday_offset: u16,
         http_node_url: Url,
+        http_fallback_url: Url,
         scanning_interval: u64,
     ) -> Self {
         Self {
@@ -71,6 +73,7 @@ where T: WalletBackend + 'static
             phantom: PhantomData,
             birthday_offset,
             http_node_url,
+            http_fallback_url,
             scanning_interval,
         }
     }
@@ -102,6 +105,7 @@ where
         let network = self.network;
         let birthday_offset = self.birthday_offset;
         let node_url = self.http_node_url.clone();
+        let fallback_http_server_url = self.http_fallback_url.clone();
         let scanning_interval = self.scanning_interval;
 
         context.spawn_when_ready(move |handles| async move {
@@ -127,7 +131,7 @@ where
             .expect("Could not create one-sided Tari address");
 
             let scanning_service = UtxoScannerService::<T, TKeyManagerInterface, _>::builder()
-                .with_client_factory(DefaultHttpClientFactory::new(node_url))
+                .with_client_factory(DefaultHttpClientFactory::new(node_url, fallback_http_server_url))
                 .with_retry_limit(2)
                 .with_mode(UtxoScannerMode::Scanning)
                 .with_scanning_interval(scanning_interval)

--- a/base_layer/wallet/src/utxo_scanner_service/utxo_scanner_task.rs
+++ b/base_layer/wallet/src/utxo_scanner_service/utxo_scanner_task.rs
@@ -74,6 +74,8 @@ struct SyncResult {
     scanned_blocks: u64,
     value_recovered: MicroMinotari,
     elapsed: Duration,
+    latency: Duration,
+    node: String,
 }
 
 pub struct UtxoScannerTask<
@@ -106,17 +108,9 @@ where
                 return Ok(());
             }
             match self.attempt_sync().await {
-                Ok(SyncResult {
-                    final_height,
-                    num_recovered,
-                    scanned_blocks,
-                    value_recovered,
-                    elapsed,
-                }) => {
-                    debug!(target: LOG_TARGET, "Scanned to height #{}", final_height);
-                    self.finalize(num_recovered, value_recovered, final_height, elapsed)
-                        .await?;
-                    if scanned_blocks > SAFETY_HEIGHT_MARGIN {
+                Ok(sync_result) => {
+                    debug!(target: LOG_TARGET, "Scanned to height #{}", sync_result.final_height);
+                    if sync_result.scanned_blocks > SAFETY_HEIGHT_MARGIN {
                         // if the TMS validates the transactions before the OMS does, it can invalidate some
                         // transactions, so we need to reset them to ensure we can revalidate them
                         let _result = self
@@ -125,6 +119,8 @@ where
                             .revalidate_rejected_transactions()
                             .await;
                     }
+                    self.finalize(sync_result).await?;
+
                     return Ok(());
                 },
                 Err(e) => {
@@ -145,27 +141,33 @@ where
         }
     }
 
-    async fn finalize(
-        &mut self,
-        num_recovered: u64,
-        value_recovered: MicroMinotari,
-        final_height: u64,
-        elapsed: Duration,
-    ) -> Result<(), anyhow::Error> {
+    async fn finalize(&mut self, sync_result: SyncResult) -> Result<(), anyhow::Error> {
         // this is a best effort, if this fails, its very likely that it's already busy with a validation. We have
         // updated the scanned, so we need to update txns
         let _result = self.resources.output_manager_service.validate_txos().await;
         let _result = self.resources.transaction_service.validate_transactions().await;
-
+        let SyncResult {
+            final_height,
+            num_recovered,
+            value_recovered,
+            elapsed,
+            latency,
+            node: current_node,
+            scanned_blocks: _,
+        } = sync_result;
         self.publish_event(UtxoScannerEvent::Progress {
             current_height: final_height,
             tip_height: final_height,
+            current_node: current_node.clone(),
+            latency,
         });
         self.publish_event(UtxoScannerEvent::Completed {
             final_height,
             num_recovered,
             value_recovered,
             time_taken: elapsed,
+            latency,
+            current_node,
         });
         debug!(
             target: LOG_TARGET,
@@ -253,12 +255,19 @@ where
                         last_scanned_block.height,
                         timer.elapsed()
                     );
+                    let latency = wallet_service_client
+                        .get_last_request_latency()
+                        .await
+                        .unwrap_or_default();
+                    let node = wallet_service_client.get_address();
                     return Ok(SyncResult {
                         final_height: last_scanned_block.height,
                         num_recovered: total_num_recovered,
                         value_recovered: total_value_recovered,
                         scanned_blocks,
                         elapsed: timer.elapsed(),
+                        latency,
+                        node,
                     });
                 }
             }
@@ -500,9 +509,14 @@ where
                                 target: LOG_TARGET,
                                 "Scanned up to block {} with a current tip_height of {}", current_height, tip_height
                             );
+
+                            let latency = client.get_last_request_latency().await.unwrap_or_default();
+                            let node = client.get_address();
                             self.publish_event(UtxoScannerEvent::Progress {
                                 current_height,
                                 tip_height,
+                                current_node: node,
+                                latency,
                             });
                         }
                     }

--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -261,16 +261,22 @@ where
             .add_initializer(BaseNodeServiceInitializer::<THttpClientFactory>::new())
             .add_initializer(WalletConnectivityInitializer::<DefaultHttpClientFactory>::new(
                 config
-                    .http_client_url
+                    .http_server_url
                     .parse()
-                    .map_err(|e| WalletError::InvalidHttpNodeUrl(format!("URL is invalid:{}", e)))?,
+                    .map_err(|e| WalletError::InvalidHttpNodeUrl(format!("base node URL is invalid:{}", e)))?,
+                config
+                    .fallback_http_server_url
+                    .parse()
+                    .map_err(|e| WalletError::InvalidHttpNodeUrl(format!("fallback seed URL is invalid:{}", e)))?,
             ))
             .add_initializer(UtxoScannerServiceInitializer::<T, TKeyManagerInterface>::new(
                 wallet_database.clone(),
                 config.network,
                 config.birthday_offset,
-                Url::parse(&config.http_client_url)
-                    .map_err(|e| WalletError::InvalidHttpNodeUrl(format!("URL is invalid:{}", e)))?,
+                Url::parse(&config.http_server_url)
+                    .map_err(|e| WalletError::InvalidHttpNodeUrl(format!("base node URL is invalid:{}", e)))?,
+                Url::parse(&config.fallback_http_server_url)
+                    .map_err(|e| WalletError::InvalidHttpNodeUrl(format!("fallback seed URL is invalid:{}", e)))?,
                 config.scanning_interval,
             ));
 

--- a/base_layer/wallet/tests/support/base_node_http_service_mock.rs
+++ b/base_layer/wallet/tests/support/base_node_http_service_mock.rs
@@ -104,7 +104,7 @@ impl BaseNodeWalletClient for HttpBaseNodeMock {
         todo!()
     }
 
-    fn get_last_request_latency(&self) -> Option<Duration> {
+    async fn get_last_request_latency(&self) -> Option<Duration> {
         todo!()
     }
 
@@ -291,7 +291,7 @@ impl Default for MockHttpClientFactory {
 impl HttpClientFactory for MockHttpClientFactory {
     type Client = HttpBaseNodeMock;
 
-    fn new(_node_url: Url) -> Self {
+    fn new(_node_url: Url, _seed_url: Url) -> Self {
         Self::default()
     }
 

--- a/base_layer/wallet/tests/transaction_service_tests/service.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/service.rs
@@ -278,11 +278,13 @@ async fn setup_transaction_service<P: AsRef<Path>>(
         .add_initializer(BaseNodeServiceInitializer::<MockHttpClientFactory>::new())
         .add_initializer(WalletConnectivityInitializer::<MockHttpClientFactory>::new(
             "http://localhost:9001".parse().unwrap(),
+            "http://localhost:9001".parse().unwrap(),
         ))
         .add_initializer(UtxoScannerServiceInitializer::<_, MemoryDbKeyManager>::new(
             db,
             Network::LocalNet,
             14,
+            http_node_url.clone(),
             http_node_url,
             1,
         ))

--- a/base_layer/wallet_ffi/src/callback_handler_tests.rs
+++ b/base_layer/wallet_ffi/src/callback_handler_tests.rs
@@ -888,6 +888,8 @@ mod test {
             .send(UtxoScannerEvent::Progress {
                 current_height: 500,
                 tip_height: 600,
+                latency: Duration::from_millis(100),
+                current_node: "".to_string(),
             })
             .unwrap();
 
@@ -898,6 +900,8 @@ mod test {
                 num_recovered: 0,
                 value_recovered: 0.into(),
                 time_taken: Duration::from_secs(0),
+                latency: Duration::from_millis(100),
+                current_node: "".to_string(),
             })
             .unwrap();
 

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -7062,7 +7062,7 @@ pub unsafe extern "C" fn wallet_create(
         },
         base_node_service_config: BaseNodeServiceConfig { ..Default::default() },
         network,
-        http_client_url: http_base_node,
+        http_server_url: http_base_node,
         ..Default::default()
     };
 

--- a/base_layer/wallet_ffi/src/tasks.rs
+++ b/base_layer/wallet_ffi/src/tasks.rs
@@ -94,6 +94,7 @@ pub async fn recovery_event_monitoring(
             Ok(UtxoScannerEvent::Progress {
                 current_height: current,
                 tip_height: total,
+                ..
             }) => {
                 unsafe {
                     (recovery_progress_callback)(context.0, RecoveryEvent::Progress as u8, current, total);
@@ -105,6 +106,7 @@ pub async fn recovery_event_monitoring(
                 time_taken: elapsed,
                 num_recovered,
                 value_recovered,
+                ..
             }) => {
                 let rate = (final_height as f32) * 1000f32 / (elapsed.as_millis() as f32);
                 info!(

--- a/clients/rust/base_node_wallet_client/src/client/http.rs
+++ b/clients/rust/base_node_wallet_client/src/client/http.rs
@@ -1,6 +1,6 @@
 // Copyright 2025 The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
-use std::{sync::RwLock, time::Instant};
+use std::time::Instant;
 
 use anyhow::anyhow;
 use async_trait::async_trait;
@@ -22,7 +22,7 @@ use tari_core::{
 };
 use tari_shutdown::ShutdownSignal;
 use tari_utilities::hex::Hex;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, RwLock};
 use url::Url;
 
 use crate::{BaseNodeWalletClient, JsonRpcResponse};
@@ -31,17 +31,21 @@ const LOG_TARGET: &str = "tari::wallet::client::http";
 
 /// HTTP client for the Base Node wallet service.
 pub struct Client {
-    api_address: Url,
+    local_api_address: Url,
+    default_seed_address: Url,
     http_client: reqwest::Client,
     last_latency: RwLock<Option<(std::time::Duration, Instant)>>,
+    use_local_api_address: RwLock<Option<bool>>,
 }
 
 impl Client {
-    pub fn new(api_address: Url) -> Self {
+    pub fn new(local_api_address: Url, default_seed_address: Url) -> Self {
         Self {
-            api_address,
+            local_api_address,
+            default_seed_address,
             http_client: reqwest::Client::new(),
             last_latency: RwLock::new(None),
+            use_local_api_address: RwLock::new(None),
         }
     }
 }
@@ -49,42 +53,81 @@ impl Client {
 impl Clone for Client {
     fn clone(&self) -> Self {
         Self {
-            api_address: self.api_address.clone(),
+            local_api_address: self.local_api_address.clone(),
+            default_seed_address: self.default_seed_address.clone(),
             http_client: self.http_client.clone(),
             last_latency: RwLock::new(None),
+            use_local_api_address: RwLock::new(None),
         }
     }
 }
 impl Client {
-    fn set_last_latency(&self, duration: std::time::Duration) {
-        let mut last_latency = self.last_latency.write().expect("rwlock poisoned");
+    async fn set_last_latency(&self, duration: std::time::Duration) {
+        let mut last_latency = self.last_latency.write().await;
         *last_latency = Some((duration, Instant::now()));
+    }
+
+    /// returns the Url of the https server to use
+    async fn http_server_address(&self) -> Result<&Url, anyhow::Error> {
+        if let Some(use_local) = self.use_local_api_address.read().await.as_ref() {
+            if *use_local {
+                return Ok(&self.local_api_address);
+            } else {
+                return Ok(&self.default_seed_address);
+            }
+        }
+        debug!(target: LOG_TARGET, "There is no last connected server set, trying local API address: {}", self.local_api_address);
+        // Try to reach the local API address
+        let res = match self
+            .http_client
+            .get(self.local_api_address.join("/get_tip_info")?)
+            .send()
+            .await
+        {
+            Ok(response) => response,
+            Err(e) => {
+                debug!(target: LOG_TARGET, "Failed to reach local API address {}: {}", self.local_api_address, e);
+                *self.use_local_api_address.write().await = Some(false);
+                return Ok(&self.default_seed_address);
+            },
+        };
+        if res.status().is_client_error() || res.status().is_server_error() {
+            debug!(target: LOG_TARGET, "Local API address {} is not reachable, falling back to default seed address: {}", self.local_api_address, self.default_seed_address);
+            // we cant use the local, use the default seed address
+            *self.use_local_api_address.write().await = Some(false);
+            Ok(&self.default_seed_address)
+        } else {
+            debug!(target: LOG_TARGET, "Using local API address: {}", self.local_api_address);
+            // if we can reach the local api, then use it
+            *self.use_local_api_address.write().await = Some(true);
+            Ok(&self.local_api_address)
+        }
     }
 }
 
 #[async_trait]
 impl BaseNodeWalletClient for Client {
     fn get_address(&self) -> String {
-        self.api_address.to_string()
+        self.local_api_address.to_string()
     }
 
     fn is_online(&self) -> bool {
         self.last_latency
-            .read()
-            .expect("rwlock poisoned")
+            .blocking_read()
             .map(|latency| latency.1.elapsed() < std::time::Duration::from_secs(60))
             .unwrap_or(false)
     }
 
     async fn get_tip_info(&self) -> Result<TipInfoResponse, anyhow::Error> {
-        debug!(target: LOG_TARGET, "Requesting tip info from Base Node wallet service at {}", self.api_address);
+        let server_address = self.http_server_address().await?;
+        debug!(target: LOG_TARGET, "Requesting tip info from Base Node wallet service at {}", server_address);
         let timer = Instant::now();
         let res = self
             .http_client
-            .get(self.api_address.join("/get_tip_info")?)
+            .get(server_address.join("/get_tip_info")?)
             .send()
             .await?;
-        self.set_last_latency(timer.elapsed());
+        self.set_last_latency(timer.elapsed()).await;
 
         if res.status().is_client_error() || res.status().is_server_error() {
             let status = res.status();
@@ -101,14 +144,15 @@ impl BaseNodeWalletClient for Client {
     }
 
     async fn get_header_by_height(&self, height: u64) -> Result<Option<BlockHeader>, anyhow::Error> {
-        debug!(target: LOG_TARGET, "Requesting block header at height {} from Base Node wallet service at {}", height, self.api_address);
-        let mut target_url = self.api_address.join("/get_header_by_height")?;
+        let server_address = self.http_server_address().await?;
+        debug!(target: LOG_TARGET, "Requesting block header at height {} from Base Node wallet service at {}", height, server_address);
+        let mut target_url = server_address.join("/get_header_by_height")?;
         target_url.set_query(Some(format!("height={}", height).as_str()));
         let timer = Instant::now();
         let res = self.http_client.get(target_url).send().await?;
-        self.set_last_latency(timer.elapsed());
+        self.set_last_latency(timer.elapsed()).await;
         if res.status() == StatusCode::NOT_FOUND {
-            debug!(target: LOG_TARGET, "No block header found at height {} from Base Node wallet service at {}", height, self.api_address);
+            debug!(target: LOG_TARGET, "No block header found at height {} from Base Node wallet service at {}", height, server_address);
             return Ok(None);
         }
         if res.status().is_client_error() || res.status().is_server_error() {
@@ -136,12 +180,13 @@ impl BaseNodeWalletClient for Client {
     }
 
     async fn get_height_at_time(&self, epoch_time: u64) -> Result<u64, anyhow::Error> {
-        debug!(target: LOG_TARGET, "Requesting block height at epoch time {} from Base Node wallet service at {}", epoch_time, self.api_address);
-        let mut target_url = self.api_address.join("/get_height_at_time")?;
+        let server_address = self.http_server_address().await?;
+        debug!(target: LOG_TARGET, "Requesting block height at epoch time {} from Base Node wallet service at {}", epoch_time, server_address);
+        let mut target_url = server_address.join("/get_height_at_time")?;
         target_url.set_query(Some(format!("time={}", epoch_time).as_str()));
         let timer = Instant::now();
         let res = self.http_client.get(target_url).send().await?;
-        self.set_last_latency(timer.elapsed());
+        self.set_last_latency(timer.elapsed()).await;
         if res.status().is_client_error() || res.status().is_server_error() {
             let status = res.status();
             let body = res.text().await.unwrap_or_else(|_| "No response body".to_string());
@@ -157,8 +202,9 @@ impl BaseNodeWalletClient for Client {
     }
 
     async fn get_utxos_by_block(&self, header_hash: Vec<u8>) -> Result<models::GetUtxosByBlockResponse, anyhow::Error> {
-        debug!(target: LOG_TARGET, "Requesting UTXOs for block with header hash {} from Base Node wallet service at {}", header_hash.to_hex(), self.api_address);
-        let mut target_url = self.api_address.join("/get_utxos_by_block")?;
+        let server_address = self.http_server_address().await?;
+        debug!(target: LOG_TARGET, "Requesting UTXOs for block with header hash {} from Base Node wallet service at {}", header_hash.to_hex(), server_address);
+        let mut target_url = server_address.join("/get_utxos_by_block")?;
         target_url.set_query(Some(&format!("header_hash={}", header_hash.to_hex())));
         let timer = Instant::now();
         let res = self
@@ -167,7 +213,7 @@ impl BaseNodeWalletClient for Client {
             .json(&models::GetUtxosByBlockRequest { header_hash })
             .send()
             .await?;
-        self.set_last_latency(timer.elapsed());
+        self.set_last_latency(timer.elapsed()).await;
         if res.status().is_client_error() || res.status().is_server_error() {
             let status = res.status();
             let body = res.text().await.unwrap_or_else(|_| "No response body".to_string());
@@ -188,7 +234,7 @@ impl BaseNodeWalletClient for Client {
         shutdown: ShutdownSignal,
     ) -> Result<mpsc::Receiver<Result<SyncUtxosByBlockResponse, anyhow::Error>>, anyhow::Error> {
         debug!(target: LOG_TARGET, "Starting UTXO sync from {} to {}", start_header_hash.to_hex(), end_header_hash.to_hex());
-        let mut target_url = self.api_address.join("/sync_utxos_by_block")?;
+        let mut target_url = self.http_server_address().await?.join("/sync_utxos_by_block")?;
         let (resp_tx, resp_rx) = mpsc::channel(1000);
         let start_header_hash_hex = start_header_hash.to_hex();
         let end_header_hash_hex = end_header_hash.to_hex();
@@ -244,23 +290,21 @@ impl BaseNodeWalletClient for Client {
         Ok(resp_rx)
     }
 
-    fn get_last_request_latency(&self) -> Option<std::time::Duration> {
-        self.last_latency
-            .read()
-            .expect("rwlock poisoned")
-            .map(|(duration, _)| duration)
+    async fn get_last_request_latency(&self) -> Option<std::time::Duration> {
+        self.last_latency.read().await.map(|(duration, _)| duration)
     }
 
     async fn get_utxos_mined_info(&self, hashes: Vec<Vec<u8>>) -> Result<GetUtxosMinedInfoResponse, anyhow::Error> {
-        debug!(target: LOG_TARGET, "Requesting matching UTXOs for hashes {:?} from Base Node wallet service at {}", hashes, self.api_address);
-        let mut target_url = self.api_address.join("/get_utxos_mined_info")?;
+        let server_address = self.http_server_address().await?;
+        debug!(target: LOG_TARGET, "Requesting matching UTXOs for hashes {:?} from Base Node wallet service at {}", hashes, server_address);
+        let mut target_url = server_address.join("/get_utxos_mined_info")?;
         target_url.set_query(Some(&format!(
             "hashes={}",
             hashes.iter().map(|h| h.to_hex()).collect::<Vec<_>>().join(",")
         )));
         let timer = Instant::now();
         let res = self.http_client.get(target_url).send().await?;
-        self.set_last_latency(timer.elapsed());
+        self.set_last_latency(timer.elapsed()).await;
         if res.status().is_client_error() || res.status().is_server_error() {
             let status = res.status();
             let body = res.text().await.unwrap_or_else(|_| "No response body".to_string());
@@ -271,7 +315,7 @@ impl BaseNodeWalletClient for Client {
                 body
             ));
         }
-        info!(target: LOG_TARGET, "Received UTXOs mined info for hashes {:?} from Base Node wallet service at {}", hashes, self.api_address);
+        info!(target: LOG_TARGET, "Received UTXOs mined info for hashes {:?} from Base Node wallet service at {}", hashes, server_address);
 
         let res_text = res.text().await?;
         debug!(target: LOG_TARGET, "Response text: {}", res_text);
@@ -285,8 +329,9 @@ impl BaseNodeWalletClient for Client {
         hashes: Vec<Vec<u8>>,
         must_include_header: Vec<u8>,
     ) -> Result<GetUtxosDeletedInfoResponse, anyhow::Error> {
+        let server_address = self.http_server_address().await?;
         debug!(target: LOG_TARGET, "Requesting deleted UTXOs for hashes {:?}, must include:{:?} from Base Node wallet", hashes, &must_include_header);
-        let mut target_url = self.api_address.join("/get_utxos_deleted_info")?;
+        let mut target_url = server_address.join("/get_utxos_deleted_info")?;
         target_url.set_query(Some(&format!(
             "hashes={}&must_include_header={}",
             hashes.iter().map(|h| h.to_hex()).collect::<Vec<_>>().join(","),
@@ -294,7 +339,7 @@ impl BaseNodeWalletClient for Client {
         )));
         let timer = Instant::now();
         let res = self.http_client.get(target_url).send().await?;
-        self.set_last_latency(timer.elapsed());
+        self.set_last_latency(timer.elapsed()).await;
         if res.status().is_client_error() || res.status().is_server_error() {
             let status = res.status();
             let body = res.text().await.unwrap_or_else(|_| "No response body".to_string());
@@ -305,7 +350,7 @@ impl BaseNodeWalletClient for Client {
                 body
             ));
         }
-        info!(target: LOG_TARGET, "Received deleted UTXOs for hashes {:?} from Base Node wallet service at {}", hashes, self.api_address);
+        info!(target: LOG_TARGET, "Received deleted UTXOs for hashes {:?} from Base Node wallet service at {}", hashes, server_address);
         let res_text = res.text().await?;
         debug!(target: LOG_TARGET, "Response text: {}", res_text);
         let json = serde_json::from_str::<GetUtxosDeletedInfoResponse>(&res_text)
@@ -314,12 +359,13 @@ impl BaseNodeWalletClient for Client {
     }
 
     async fn fetch_utxo(&self, utxo: Vec<u8>) -> Result<Option<TransactionOutput>, anyhow::Error> {
-        debug!(target: LOG_TARGET, "Requesting UTXO with hash {} from Base Node wallet service at {}", utxo.to_hex(), self.api_address);
-        let mut target_url = self.api_address.join("/fetch_utxo")?;
+        let server_address = self.http_server_address().await?;
+        debug!(target: LOG_TARGET, "Requesting UTXO with hash {} from Base Node wallet service at {}", utxo.to_hex(), server_address);
+        let mut target_url = server_address.join("/fetch_utxo")?;
         target_url.set_query(Some(&format!("utxo={}", utxo.to_hex())));
         let timer = Instant::now();
         let res = self.http_client.get(target_url).send().await?;
-        self.set_last_latency(timer.elapsed());
+        self.set_last_latency(timer.elapsed()).await;
         if res.status().is_client_error() || res.status().is_server_error() {
             let status = res.status();
             let body = res.text().await.unwrap_or_else(|_| "No response body".to_string());
@@ -337,8 +383,9 @@ impl BaseNodeWalletClient for Client {
         &self,
         transaction: tari_core::transactions::transaction_components::Transaction,
     ) -> Result<TxSubmissionResponse, anyhow::Error> {
-        debug!(target: LOG_TARGET, "Submitting transaction to Base Node wallet service at {}", self.api_address);
-        let target_url = self.api_address.join("/json_rpc")?;
+        let server_address = self.http_server_address().await?;
+        debug!(target: LOG_TARGET, "Submitting transaction to Base Node wallet service at {}", server_address);
+        let target_url = server_address.join("/json_rpc")?;
         let request_body = serde_json::json!({
             "jsonrpc": "2.0",
             "id": "1",
@@ -359,7 +406,7 @@ impl BaseNodeWalletClient for Client {
                 body
             ));
         }
-        info!(target: LOG_TARGET, "Transaction submitted successfully to Base Node wallet service at {}", self.api_address);
+        info!(target: LOG_TARGET, "Transaction submitted successfully to Base Node wallet service at {}", server_address);
         let response = res.json::<JsonRpcResponse<TxSubmissionResponse>>().await?;
         match response.result {
             Some(result) => {
@@ -379,8 +426,9 @@ impl BaseNodeWalletClient for Client {
         excess_sig_nonce: Vec<u8>,
         excess_sig_sig: Vec<u8>,
     ) -> Result<TxQueryResponse, anyhow::Error> {
+        let server_address = self.http_server_address().await?;
         debug!(target: LOG_TARGET, "Querying transaction with excess signature nonce {} and signature {}", excess_sig_nonce.to_hex(), excess_sig_sig.to_hex());
-        let mut target_url = self.api_address.join("/transactions")?;
+        let mut target_url = server_address.join("/transactions")?;
         target_url.set_query(Some(&format!(
             "excess_sig_nonce={}&excess_sig_sig={}",
             excess_sig_nonce.to_hex(),
@@ -388,7 +436,7 @@ impl BaseNodeWalletClient for Client {
         )));
         let timer = Instant::now();
         let res = self.http_client.get(target_url).send().await?;
-        self.set_last_latency(timer.elapsed());
+        self.set_last_latency(timer.elapsed()).await;
         if res.status().is_client_error() || res.status().is_server_error() {
             let status = res.status();
             let body = res.text().await.unwrap_or_else(|_| "No response body".to_string());

--- a/clients/rust/base_node_wallet_client/src/client/mod.rs
+++ b/clients/rust/base_node_wallet_client/src/client/mod.rs
@@ -40,7 +40,7 @@ pub trait BaseNodeWalletClient: Send + Sync + Clone + 'static {
         shutdown: ShutdownSignal,
     ) -> Result<mpsc::Receiver<Result<SyncUtxosByBlockResponse, Error>>, Error>;
 
-    fn get_last_request_latency(&self) -> Option<std::time::Duration>;
+    async fn get_last_request_latency(&self) -> Option<std::time::Duration>;
 
     async fn get_utxos_mined_info(&self, hashes: Vec<Vec<u8>>) -> Result<GetUtxosMinedInfoResponse, Error>;
 

--- a/common/config/presets/b_peer_seeds.toml
+++ b/common/config/presets/b_peer_seeds.toml
@@ -51,12 +51,12 @@ dns_seeds = ["seeds.stagenet.tari.com"]
 dns_seeds = ["seeds.esmeralda.tari.com"]
 # Custom specified peer seed nodes (Default: peer_seeds = [])
 peer_seeds = [
-    "8a24a7fb8ff2f1183c02ac52d488a13cc1104f970cc9a6fb3dd5f17ea1d85212::/ip6/2a05:d018:1b3d:f00:eb56:6954:8531:3582/tcp/18189",
-    "8a24a7fb8ff2f1183c02ac52d488a13cc1104f970cc9a6fb3dd5f17ea1d85212::/onion3/4a5vimdolvhhn6v55vjvoxgvfehqh7zwpdhi6touut3cvxtkg6a5jqqd:18141",
-    "84f96417df602c11fbe34871b89b542925cafeca1aa7d97e263c425502c27165::/ip6/2a05:d018:1b3d:f00:93e2:188:105d:e5f1/tcp/18189",
-    "84f96417df602c11fbe34871b89b542925cafeca1aa7d97e263c425502c27165::/onion3/vzzzo4e5vjhoz3u35cz5wkijfxahwxwt723af2b4lcd6wuxvlpg5awid:18141",
-    "8a24a7fb8ff2f1183c02ac52d488a13cc1104f970cc9a6fb3dd5f17ea1d85212::/ip4/3.248.103.200/tcp/18189",
-    "84f96417df602c11fbe34871b89b542925cafeca1aa7d97e263c425502c27165::/ip4/52.30.9.0/tcp/18189",
+    "1e08628960f75b7e324f010b2ee609a9e28097e9101f4d769d474a38b6ee2d76::/ip4/51.83.102.25/tcp/18189",
+    "1e08628960f75b7e324f010b2ee609a9e28097e9101f4d769d474a38b6ee2d76::/ip6/2001:41d0:303:a619::1/tcp/18189",
+    "1e08628960f75b7e324f010b2ee609a9e28097e9101f4d769d474a38b6ee2d76::/onion3/tadnxyokalnqjtvu6mlhxndcq4v2tlolotpvrflscdmi7lcautao3had:18141",
+    "4cdfb70e0b38b60c6a3573b2870e32bc3d846419c606ea379f43650b80f38409::/ip4/51.83.4.85/tcp/18189",
+    "4cdfb70e0b38b60c6a3573b2870e32bc3d846419c606ea379f43650b80f38409::/ip6/2001:41d0:303:9a55::1/tcp/18189",
+    "4cdfb70e0b38b60c6a3573b2870e32bc3d846419c606ea379f43650b80f38409::/onion3/mhfptgpcj6htjkr5zwurom32wvt7x76ovqzn2ttnwo2bnku6baeaaiyd:18141",
 ]
 
 [igor.p2p.seeds]

--- a/common/config/presets/c_base_node_c.toml
+++ b/common/config/presets/c_base_node_c.toml
@@ -172,9 +172,6 @@ listener_self_liveness_check_interval = 15
 # with a new session. If false, the RPC server will reject the new session and preserve the older session.
 # (default value = true).
 #pub cull_oldest_peer_rpc_connection_on_full = true
-# Listening address of the base node wallet query service.
-# Default: 0.0.0.0:9000
-# base_node_http_wallet_query_service_listen_address = "0.0.0.0:9000"
 
 [base_node.p2p.transport]
 # -------------- Transport configuration --------------
@@ -342,5 +339,5 @@ excluded_dial_addresses = []
 # `external_address` is optional, but if not set, then wallet wont be able to call our endpoint.
 # This address must be accessible by the wallet (on a global scale over the internet).
 [base_node.http_wallet_query_service]
-port = 9000
-external_address = "http://127.0.0.1:9000"
+#port = 9000
+#external_address = "http://127.0.0.1:9000"

--- a/common/config/presets/d_console_wallet.toml
+++ b/common/config/presets/d_console_wallet.toml
@@ -102,6 +102,10 @@
 #birthday_offset = 2
 #The scanning interval in secs to poll the base node for new blocks
 #scanning_interval = 60
+# The URL of the HTTP client to use for base node service requests
+#http_server_url="http://127.0.0.1:9000"
+# The fallback url address to use if the base node at http_server_url does not respond
+#fallback_http_server_url = "https://rpc.esmeralda.tari.com"
 
 [wallet.transactions]
 # This is the timeout period that will be used for base node broadcast monitoring tasks (default = 30)

--- a/common/src/configuration/bootstrap.rs
+++ b/common/src/configuration/bootstrap.rs
@@ -132,6 +132,17 @@ pub fn wallet_http_service_default_port(network: Network) -> u16 {
     }
 }
 
+pub fn wallet_get_default_seed_https_address(network: Network) -> &'static str {
+    match network {
+        Network::MainNet => "https://rpc.tari.com",
+        Network::StageNet => "https://rpc.stagenet.tari.com",
+        Network::NextNet => "https://rpc.nextnet.tari.com",
+        Network::LocalNet => "https://rpc.localnet.tari.com",
+        Network::Igor => "https://rpc.igor.tari.com",
+        Network::Esmeralda => "https://rpc.esmeralda.tari.com",
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;


### PR DESCRIPTION
Description
---
This should fix the display of the console wallet to again show properly the scanned height and track the latency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for primary and fallback HTTP server URLs for wallet connectivity and UTXO scanning, automatically switching to a fallback if the primary server is unavailable.
  * Wallet UI now displays chain tip, scanned height, and base node latency with improved formatting and color coding.
  * Wallet state tracks and exposes synchronization heights and node latency for enhanced status reporting.

* **Improvements**
  * Wallet synchronizer and event monitor now provide detailed progress updates, including latency and connected node information.
  * Enhanced configuration options for specifying base node service endpoints.
  * Updated peer seed lists and configuration presets for improved network connectivity.
  * Base node wallet client dynamically selects between local API and default seed server based on connectivity.

* **Bug Fixes**
  * Improved handling of additional event fields for future compatibility.

* **Documentation**
  * Updated configuration files to reflect new HTTP server URL options and network seed addresses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->