### PR TITLE
fix: seed peers being disconnected while seedstrap is in progress

### DIFF
--- a/base_layer/core/src/base_node/tari_pulse_service/mod.rs
+++ b/base_layer/core/src/base_node/tari_pulse_service/mod.rs
@@ -332,7 +332,7 @@ async fn check_health(
     let results = Arc::new(RwLock::new(Vec::new()));
     let peers = node_comms.get_seeds().await.unwrap_or_else(|_| vec![]);
     let mut handles = vec![];
-    for peer in peers {
+    for peer in &peers {
         let result_clone = results.clone();
         let mut result = LivenessCheckResult {
             peer: peer.node_id.clone(),
@@ -343,7 +343,6 @@ async fn check_health(
         let mut discovery = node_discovery.clone();
         let mut liveness_events = liveness_handle.get_event_stream();
         let mut liveness = liveness_handle.clone();
-        let mut comms = node_comms.clone();
         handles.push(task::spawn(async move {
             let start = Instant::now();
             if discovery
@@ -372,15 +371,20 @@ async fn check_health(
                     }
                 }
             }
-            if let Ok(Some(mut conn)) = comms.get_connection(result.peer.clone()).await {
-                if let Err(err) = conn.disconnect(Minimized::No).await {
-                    warn!(target: LOG_TARGET, "Failed to disconnect peer {} ({})", result.peer, err);
-                }
-            }
             (*result_clone).write().await.push(result);
         }));
     }
     futures::future::join_all(handles).await;
     let inner_result = (*(*results).read().await).clone();
     notify_comms_health.send(inner_result).expect("Channel should be open");
+
+    // Only disconnect seed connections that were created as a result of the health check when the health check is
+    // complete and out of scope, or any seed connections that are not in use anymore.
+    for peer in &peers {
+        if let Ok(Some(mut conn)) = node_comms.get_connection(peer.node_id.clone()).await {
+            if let Err(err) = conn.disconnect_if_unused(Minimized::No, "Health check").await {
+                warn!(target: LOG_TARGET, "Failed to disconnect peer {} ({})", peer.node_id, err);
+            }
+        }
+    }
 }

--- a/base_layer/p2p/src/services/liveness/service.rs
+++ b/base_layer/p2p/src/services/liveness/service.rs
@@ -387,7 +387,10 @@ where
                     target: LOG_TARGET,
                     "Disconnecting peer {} that failed {} rounds of pings", node_id, max_allowed_ping_failures
                 );
-                match conn.disconnect(Minimized::No).await {
+                match conn
+                    .disconnect(Minimized::No, "LivenessService disconnect failed peers")
+                    .await
+                {
                     Ok(_) => {
                         node_ids.push(node_id.clone());
                     },

--- a/base_layer/p2p/src/services/monitor_peers/service.rs
+++ b/base_layer/p2p/src/services/monitor_peers/service.rs
@@ -311,7 +311,11 @@ async fn update_stats_and_cull_unresponsive_connections(
                 peer.peer_node_id(),
                 stats.iter().map(|s|(s.loop_count, s.connected, s.responsive)).collect::<Vec<_>>(),
             );
-            if let Err(e) = peer.clone().disconnect(Minimized::No).await {
+            if let Err(e) = peer
+                .clone()
+                .disconnect(Minimized::No, "Monitor peers disconnect unresponsive")
+                .await
+            {
                 warn!(
                     target: LOG_TARGET,
                     "Error while attempting to disconnect peer {}: {}", peer.peer_node_id(), e

--- a/comms/core/src/connection_manager/peer_connection.rs
+++ b/comms/core/src/connection_manager/peer_connection.rs
@@ -120,7 +120,12 @@ pub enum PeerConnectionRequest {
         reply_tx: oneshot::Sender<Result<NegotiatedSubstream<Substream>, PeerConnectionError>>,
     },
     /// Disconnect all substreams and close the transport connection
-    Disconnect(bool, oneshot::Sender<Result<(), PeerConnectionError>>, Minimized),
+    Disconnect(
+        bool,
+        oneshot::Sender<Result<(), PeerConnectionError>>,
+        Minimized,
+        String,
+    ),
 }
 
 /// ID type for peer connections
@@ -299,11 +304,24 @@ impl PeerConnection {
 
     /// Immediately disconnects the peer connection. This can only fail if the peer connection worker
     /// is shut down (and the peer is already disconnected)
-    pub async fn disconnect(&mut self, minimized: Minimized) -> Result<(), PeerConnectionError> {
+    pub async fn disconnect(&mut self, minimized: Minimized, requester: &str) -> Result<(), PeerConnectionError> {
+        trace!(
+            target: LOG_TARGET,
+            "Hard disconnect - requester: '{}', peer: `{}`, RPC clients: {}, substreams {}",
+            requester,
+            self.peer_node_id,
+            self.number_of_rpc_clients.load(Ordering::Relaxed),
+            self.substream_count()
+        );
         let (reply_tx, reply_rx) = oneshot::channel();
         let _unused = self
             .request_tx
-            .send(PeerConnectionRequest::Disconnect(false, reply_tx, minimized))
+            .send(PeerConnectionRequest::Disconnect(
+                false,
+                reply_tx,
+                minimized,
+                requester.to_string(),
+            ))
             .await
             .inspect_err(|e| {
                 info!(
@@ -318,11 +336,43 @@ impl PeerConnection {
             .map_err(|_| PeerConnectionError::InternalReplyCancelled)?
     }
 
-    pub(crate) async fn disconnect_silent(&mut self, minimized: Minimized) -> Result<(), PeerConnectionError> {
+    /// Request to disconnect the peer connection if unused by other services.
+    pub async fn disconnect_if_unused(
+        &mut self,
+        minimized: Minimized,
+        requester: &str,
+    ) -> Result<(), PeerConnectionError> {
+        let number_of_rpc_clients = self.number_of_rpc_clients.load(Ordering::Relaxed);
+        let substream_count = self.substream_count();
+        if number_of_rpc_clients >= 1 || substream_count >= 1 {
+            trace!(
+                target: LOG_TARGET,
+                "Soft disconnect - requester: '{}', peer: `{}`, RPC clients: {}, substreams {}, NOT disconnecting",
+                requester,
+                self.peer_node_id,
+                number_of_rpc_clients,
+                self.substream_count()
+            );
+            Ok(())
+        } else {
+            self.disconnect(minimized, requester).await
+        }
+    }
+
+    pub(crate) async fn disconnect_silent(
+        &mut self,
+        minimized: Minimized,
+        requester: &str,
+    ) -> Result<(), PeerConnectionError> {
         let (reply_tx, reply_rx) = oneshot::channel();
         let _unused = self
             .request_tx
-            .send(PeerConnectionRequest::Disconnect(true, reply_tx, minimized))
+            .send(PeerConnectionRequest::Disconnect(
+                true,
+                reply_tx,
+                minimized,
+                requester.to_string(),
+            ))
             .await
             .inspect_err(|e| {
                 info!(
@@ -462,7 +512,7 @@ impl PeerConnectionActor {
             }
         }
 
-        if let Err(err) = self.disconnect(false, Minimized::No).await {
+        if let Err(err) = self.disconnect(false, Minimized::No, "PeerConnectionActor exit").await {
             warn!(
                 target: LOG_TARGET,
                 "[{}] Failed to politely close connection to peer '{}' because '{}'",
@@ -487,16 +537,17 @@ impl PeerConnectionActor {
                     "Reply oneshot closed when sending reply",
                 );
             },
-            Disconnect(silent, reply_tx, minimized) => {
+            Disconnect(silent, reply_tx, minimized, requester) => {
                 debug!(
                     target: LOG_TARGET,
-                    "[{}] Disconnect{}requested for {} connection to peer '{}'",
+                    "[{}] Disconnect{}requested for {} connection to peer '{}', requester: '{}'",
                     self,
                     if silent { " (silent) " } else { " " },
                     self.direction,
-                    self.peer_node_id.short_str()
+                    self.peer_node_id.short_str(),
+                    requester,
                 );
-                let _result = reply_tx.send(self.disconnect(silent, minimized).await);
+                let _result = reply_tx.send(self.disconnect(silent, minimized, &requester).await);
             },
         }
     }
@@ -592,7 +643,12 @@ impl PeerConnectionActor {
     /// # Arguments
     ///
     /// silent - true to suppress the PeerDisconnected event, false to publish the event
-    async fn disconnect(&mut self, silent: bool, minimized: Minimized) -> Result<(), PeerConnectionError> {
+    async fn disconnect(
+        &mut self,
+        silent: bool,
+        minimized: Minimized,
+        requester: &str,
+    ) -> Result<(), PeerConnectionError> {
         self.request_rx.close();
 
         // Only emit closed event once
@@ -618,7 +674,11 @@ impl PeerConnectionActor {
             ))
             .await;
         }
-        trace!(target: LOG_TARGET, "(Peer = {}) Connection closed", self.peer_node_id.short_str());
+        trace!(
+            target: LOG_TARGET,
+            "(Peer = {}) Connection closed, requester: '{}'",
+            self.peer_node_id.short_str(), requester
+        );
 
         Ok(())
     }

--- a/comms/core/src/connection_manager/tests/listener_dialer.rs
+++ b/comms/core/src/connection_manager/tests/listener_dialer.rs
@@ -182,7 +182,7 @@ async fn smoke() {
     assert_eq!(buf, *b"HELLO");
 
     // Disconnect conn1
-    conn1.disconnect(Minimized::No).await.unwrap();
+    conn1.disconnect(Minimized::No, "unit test").await.unwrap();
     // conn2.disconnect(Minimized::No).await.unwrap();
 
     shutdown.trigger();

--- a/comms/core/src/connectivity/manager.rs
+++ b/comms/core/src/connectivity/manager.rs
@@ -425,7 +425,14 @@ impl ConnectivityManagerActor {
                 if !conn.is_connected() {
                     continue;
                 }
-                match disconnect_silent_with_timeout(conn, Minimized::No, None).await {
+                match disconnect_silent_with_timeout(
+                    conn,
+                    Minimized::No,
+                    None,
+                    "ConnectivityManagerActor disconnect all",
+                )
+                .await
+                {
                     Ok(_) => {
                         node_ids.push(conn.peer_node_id().clone());
                     },
@@ -546,7 +553,14 @@ impl ConnectivityManagerActor {
                 conn.peer_node_id(),
                 threshold
             );
-            match disconnect_with_timeout(conn, Minimized::Yes, Some(task_id)).await {
+            match disconnect_if_unused_with_timeout(
+                conn,
+                Minimized::Yes,
+                Some(task_id),
+                "ConnectivityManagerActor maintain closest",
+            )
+            .await
+            {
                 Ok(_) => {
                     self.pool.remove(conn.peer_node_id());
                 },
@@ -598,7 +612,14 @@ impl ConnectivityManagerActor {
                 conn.peer_node_id().short_str(),
                 conn.handle_count()
             );
-            match disconnect_with_timeout(conn, Minimized::Yes, Some(task_id)).await {
+            match disconnect_with_timeout(
+                conn,
+                Minimized::Yes,
+                Some(task_id),
+                "ConnectivityManagerActor reap inactive",
+            )
+            .await
+            {
                 Ok(_) => {
                     nodes_to_remove.push(conn.peer_node_id().clone());
                 },
@@ -828,7 +849,13 @@ impl ConnectivityManagerActor {
                         msg
                     );
                     let mut conn = conn.clone();
-                    disconnect_with_timeout(&mut conn, Minimized::No, None).await?;
+                    disconnect_with_timeout(
+                        &mut conn,
+                        Minimized::No,
+                        None,
+                        "ConnectivityManagerActor peer connect failed",
+                    )
+                    .await?;
                 }
                 (node_id, ConnectionStatus::Failed, None)
             },
@@ -952,7 +979,13 @@ impl ConnectivityManagerActor {
                         existing_conn.direction(),
                     );
 
-                    let _result = disconnect_silent_with_timeout(existing_conn, Minimized::Yes, None).await;
+                    let _result = disconnect_silent_with_timeout(
+                        existing_conn,
+                        Minimized::Yes,
+                        None,
+                        "ConnectivityManagerActor tie break",
+                    )
+                    .await;
                     self.pool.remove(existing_conn.peer_node_id());
                     TieBreak::UseNew
                 } else {
@@ -968,7 +1001,13 @@ impl ConnectivityManagerActor {
                         existing_conn.direction(),
                     );
 
-                    let _result = disconnect_silent_with_timeout(&mut new_conn.clone(), Minimized::Yes, None).await;
+                    let _result = disconnect_silent_with_timeout(
+                        &mut new_conn.clone(),
+                        Minimized::Yes,
+                        None,
+                        "ConnectivityManagerActor tie break",
+                    )
+                    .await;
                     TieBreak::KeepExisting
                 }
             },
@@ -1146,7 +1185,7 @@ impl ConnectivityManagerActor {
         self.publish_event(ConnectivityEvent::PeerBanned(node_id.clone()));
 
         if let Some(conn) = self.pool.get_connection_mut(node_id) {
-            disconnect_with_timeout(conn, Minimized::Yes, None).await?;
+            disconnect_with_timeout(conn, Minimized::Yes, None, "ConnectivityManagerActor ban peer").await?;
             let status = self.pool.get_connection_status(node_id);
             debug!(
                 target: LOG_TARGET,
@@ -1248,8 +1287,34 @@ async fn disconnect_with_timeout(
     connection: &mut PeerConnection,
     minimized: Minimized,
     task_id: Option<u64>,
+    requester: &str,
 ) -> Result<(), PeerConnectionError> {
-    match tokio::time::timeout(PEER_DISCONNECT_TIMEOUT, connection.disconnect(minimized)).await {
+    match tokio::time::timeout(PEER_DISCONNECT_TIMEOUT, connection.disconnect(minimized, requester)).await {
+        Ok(res) => res,
+        Err(_) => {
+            warn!(
+                target: LOG_TARGET,
+                "Timeout disconnecting peer ({:?}) '{}'",
+                task_id,
+                connection.peer_node_id().short_str(),
+            );
+            Err(PeerConnectionError::DisconnectTimeout)
+        },
+    }
+}
+
+async fn disconnect_if_unused_with_timeout(
+    connection: &mut PeerConnection,
+    minimized: Minimized,
+    task_id: Option<u64>,
+    requester: &str,
+) -> Result<(), PeerConnectionError> {
+    match tokio::time::timeout(
+        PEER_DISCONNECT_TIMEOUT,
+        connection.disconnect_if_unused(minimized, requester),
+    )
+    .await
+    {
         Ok(res) => res,
         Err(_) => {
             warn!(
@@ -1267,8 +1332,14 @@ async fn disconnect_silent_with_timeout(
     connection: &mut PeerConnection,
     minimized: Minimized,
     task_id: Option<u64>,
+    requester: &str,
 ) -> Result<(), PeerConnectionError> {
-    match tokio::time::timeout(PEER_DISCONNECT_TIMEOUT, connection.disconnect_silent(minimized)).await {
+    match tokio::time::timeout(
+        PEER_DISCONNECT_TIMEOUT,
+        connection.disconnect_silent(minimized, requester),
+    )
+    .await
+    {
         Ok(res) => res,
         Err(_) => {
             warn!(

--- a/comms/core/src/connectivity/test.rs
+++ b/comms/core/src/connectivity/test.rs
@@ -421,7 +421,7 @@ async fn pool_management() {
         if conn != important_connection {
             assert_eq!(conn.handle_count(), 2);
             // The peer connection mock does not "automatically" publish event to connectivity manager
-            conn.disconnect(Minimized::No).await.unwrap();
+            conn.disconnect(Minimized::No, "unit test").await.unwrap();
             cm_mock_state.publish_event(ConnectionManagerEvent::PeerDisconnected(
                 conn.id(),
                 conn.peer_node_id().clone(),
@@ -442,7 +442,10 @@ async fn pool_management() {
     let conns = connectivity.get_active_connections().await.unwrap();
 
     assert_eq!(conns.len(), 1);
-    important_connection.disconnect(Minimized::No).await.unwrap();
+    important_connection
+        .disconnect(Minimized::No, "unit test")
+        .await
+        .unwrap();
     cm_mock_state.publish_event(ConnectionManagerEvent::PeerDisconnected(
         important_connection.id(),
         important_connection.peer_node_id().clone(),

--- a/comms/core/src/protocol/rpc/client/tests.rs
+++ b/comms/core/src/protocol/rpc/client/tests.rs
@@ -171,7 +171,7 @@ mod lazy_pool {
         let (mut peer_conn, _, _shutdown) = setup(2).await;
         let mut pool = LazyPool::<GreetingClient>::new(peer_conn.clone(), 2, Default::default());
         let mut _conn1 = pool.get_least_used_or_connect().await.unwrap();
-        peer_conn.disconnect(Minimized::No).await.unwrap();
+        peer_conn.disconnect(Minimized::No, "unit test").await.unwrap();
         let err = pool.get_least_used_or_connect().await.unwrap_err();
         unpack_enum!(RpcClientPoolError::PeerConnectionDropped { .. } = err);
     }

--- a/comms/core/src/test_utils/mocks/peer_connection.rs
+++ b/comms/core/src/test_utils/mocks/peer_connection.rs
@@ -220,7 +220,7 @@ impl PeerConnectionMock {
                     reply_tx.send(Err(err)).unwrap();
                 },
             },
-            Disconnect(_, reply_tx, _minimized) => {
+            Disconnect(_, reply_tx, _minimized, _requester) => {
                 self.receiver.close();
                 reply_tx.send(self.state.disconnect().await).unwrap();
             },

--- a/comms/core/tests/tests/rpc.rs
+++ b/comms/core/tests/tests/rpc.rs
@@ -317,7 +317,7 @@ async fn rpc_server_drop_sessions_when_peer_is_disconnected() {
     }
 
     // RPC connections are closed when the peer is disconnected
-    conn1_2.disconnect(Minimized::No).await.unwrap();
+    conn1_2.disconnect(Minimized::No, "unit tests").await.unwrap();
 
     // Verify the RPC connections are closed
     async_assert_eventually!(

--- a/comms/dht/src/network_discovery/seed_strap.rs
+++ b/comms/dht/src/network_discovery/seed_strap.rs
@@ -431,7 +431,7 @@ async fn get_peers(
                     );
                     continue;
                 }
-                if let Err(e) = conn.disconnect(Minimized::Yes).await {
+                if let Err(e) = conn.disconnect(Minimized::Yes, "SeedStrap disconnect seed on Ok").await {
                     warn!(target: LOG_TARGET, "SeedStrap: Failed to disconnect from seed peer '{}': {}", seed_peer_node_id_str, e);
                 } else {
                     debug!(target: LOG_TARGET, "SeedStrap: Successfully disconnected from seed peer '{}'", seed_peer_node_id_str);
@@ -449,7 +449,10 @@ async fn get_peers(
                     e
                 );
                 // Attempt to disconnect, log if it fails but continue
-                if let Err(disc_err) = conn.disconnect(Minimized::Yes).await {
+                if let Err(disc_err) = conn
+                    .disconnect(Minimized::Yes, "SeedStrap disconnect seed on Error")
+                    .await
+                {
                     warn!(
                         target: LOG_TARGET,
                         "SeedStrap: Also failed to disconnect from seed peer '{}' after fetch failure: {}",


### PR DESCRIPTION
Description
---
- Fixed seedstrap seeds disconnecting during the seedstrap phase. This was caused by the health service, which obtained connections to all seed peers and disconnected them while seedstrap was busy. This was fixed by adding a soft disconnect alongside the hard disconnect in `peer_connection.rs::PeerConnection`, so that a parallel spawned process can politely request connections to be broken if they are not in use. 
- Also added better logging information for peer disconnects, in that the requester is also logged.

Motivation and Context
---
Seed peer connections are being dropped while still busy streaming peer info via RPC during seedstrap.

How Has This Been Tested?
---
System-level testing

Seedstrap can now finish within 3s if there are no seed peer connection issues:
```rust
[comms::dht::network_discovery::seed_strap] INFO  SeedStrap: Original early exit conditions met. Total peers added (455) >= needed (15). Successful seed contacts (5) >= min (5). Exiting seed node loop.
[comms::dht::network_discovery::seed_strap] INFO  SeedStrap: discover_peers_via_seeds finished. Attempted to contact: 5/5. Successfully synced from: 5. Total new peers added in this round: 455. Total duplicates processed in this round: 38.
[comms::dht::network_discovery::seed_strap] INFO  SeedStrap: Peer DB counts after seed bootstrap completion: Total peers in DB = 468, Non-seed peers in DB = 455
[comms::dht::network_discovery::seed_strap] INFO  SeedStrap: Added 455 (new) peers via seed nodes (5 successful seed node contacts).
[comms::dht::network_discovery::seed_strap] DEBUG SeedStrap: Round info at completion - new_peers: 455, duplicate_peers: 38, succeeded: 5, sync_peers_contacted: 5
[comms::dht::network_discovery] DEBUG Transition triggered from current state `SeedStrap` by event `DiscoveryComplete(Synced 5/5, num_new_peers = 455, num_duplicate_peers = 38)`
[comms::dht::network_discovery] INFO  [DHT EVENT PUBLISH] Successfully published DhtEvent::NetworkDiscoveryPeersAdded to 3 receiver(s)
[comms::dht::network_discovery] INFO  [DHT BOOTSTRAP] Bootstrap completed via SeedStrap in 2.397606s
```
Previously when the connections were being closed:
```rust
[comms::dht::network_discovery::seed_strap] WARN  SeedStrap: Timeout after 10.00s waiting for next peer from stream for seed 'd4b68aa41844d331149939e1da'. Breaking from peer stream collection.
[comms::dht::network_discovery::seed_strap] WARN  SeedStrap: Timeout after 10.00s waiting for next peer from stream for seed 'd7c289e9e3c8377705ce599a96'. Breaking from peer stream collection.
[comms::dht::network_discovery::seed_strap] WARN  SeedStrap: Timeout after 10.00s waiting for next peer from stream for seed '01dc53343af8e28b86892e1c0d'. Breaking from peer stream collection.
[comms::dht::network_discovery::seed_strap] WARN  SeedStrap: Timeout after 10.00s waiting for next peer from stream for seed '515391f40a2cf72ca362589ccb'. Breaking from peer stream collection.
[comms::dht::network_discovery::seed_strap] WARN  SeedStrap: Timeout after 10.00s waiting for next peer from stream for seed '6b959c029a0bbd3299b96efd78'. Breaking from peer stream collection.

...    

[comms::dht::network_discovery::seed_strap] INFO  SeedStrap: Original early exit conditions met. Total peers added (441) >= needed (15). Successful seed contacts (5) >= min (5). Exiting seed node loop.
[comms::dht::network_discovery::seed_strap] INFO  SeedStrap: discover_peers_via_seeds finished. Attempted to contact: 5/5. Successfully synced from: 5. Total new peers added in this round: 441. Total duplicates processed in this round: 48.
[comms::dht::network_discovery::seed_strap] INFO  SeedStrap: Peer DB counts after seed bootstrap completion: Total peers in DB = 453, Non-seed peers in DB = 440
[comms::dht::network_discovery::seed_strap] INFO  SeedStrap: Added 441 (new) peers via seed nodes (5 successful seed node contacts).
[comms::dht::network_discovery::seed_strap] DEBUG SeedStrap: Round info at completion - new_peers: 441, duplicate_peers: 48, succeeded: 5, sync_peers_contacted: 5
[comms::dht::network_discovery] DEBUG Transition triggered from current state `SeedStrap` by event `DiscoveryComplete(Synced 5/5, num_new_peers = 441, num_duplicate_peers = 48)`
[comms::dht::network_discovery] INFO  [DHT EVENT PUBLISH] Successfully published DhtEvent::NetworkDiscoveryPeersAdded to 3 receiver(s)
[comms::dht::network_discovery] INFO  [DHT BOOTSTRAP] Bootstrap completed via SeedStrap in 12.1362851s
```

What process can a PR reviewer use to test or verify this change?
---
Code review
System-level testing 

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved peer connection management by introducing a reason/context parameter for all disconnect operations, enhancing traceability and logging.
  * Added conditional disconnect functionality to only disconnect unused peer connections after health checks.

* **Bug Fixes**
  * Ensured that peer disconnections now occur after all health check tasks complete, preventing premature disconnects.

* **Tests**
  * Updated tests to support the new disconnect method signature with reason/context parameters.

* **Refactor**
  * Enhanced logging throughout the peer connection lifecycle to include requester context for better diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->