### PR TITLE
feat: modify soft disconnect criteria

### DIFF
--- a/base_layer/core/src/base_node/tari_pulse_service/mod.rs
+++ b/base_layer/core/src/base_node/tari_pulse_service/mod.rs
@@ -332,6 +332,7 @@ async fn check_health(
     let results = Arc::new(RwLock::new(Vec::new()));
     let peers = node_comms.get_seeds().await.unwrap_or_else(|_| vec![]);
     let mut handles = vec![];
+    trace!(target: LOG_TARGET, "check_health started contacting {} seed peers", peers.len());
     for peer in &peers {
         let result_clone = results.clone();
         let mut result = LivenessCheckResult {
@@ -383,4 +384,5 @@ async fn check_health(
     futures::future::join_all(handles).await;
     let inner_result = (*(*results).read().await).clone();
     notify_comms_health.send(inner_result).expect("Channel should be open");
+    trace!(target: LOG_TARGET, "check_health ended");
 }

--- a/base_layer/core/src/base_node/tari_pulse_service/mod.rs
+++ b/base_layer/core/src/base_node/tari_pulse_service/mod.rs
@@ -382,7 +382,7 @@ async fn check_health(
     // complete and out of scope, or any seed connections that are not in use anymore.
     for peer in &peers {
         if let Ok(Some(mut conn)) = node_comms.get_connection(peer.node_id.clone()).await {
-            if let Err(err) = conn.disconnect_if_unused(Minimized::No, "Health check").await {
+            if let Err(err) = conn.disconnect_if_unused(Minimized::No, 0, 2, "Health check").await {
                 warn!(target: LOG_TARGET, "Failed to disconnect peer {} ({})", peer.node_id, err);
             }
         }

--- a/base_layer/core/src/base_node/tari_pulse_service/mod.rs
+++ b/base_layer/core/src/base_node/tari_pulse_service/mod.rs
@@ -343,6 +343,7 @@ async fn check_health(
         let mut discovery = node_discovery.clone();
         let mut liveness_events = liveness_handle.get_event_stream();
         let mut liveness = liveness_handle.clone();
+        let mut comms = node_comms.clone();
         handles.push(task::spawn(async move {
             let start = Instant::now();
             if discovery
@@ -371,20 +372,15 @@ async fn check_health(
                     }
                 }
             }
+            if let Ok(Some(mut conn)) = comms.get_connection(result.peer.clone()).await {
+                if let Err(err) = conn.disconnect_if_unused(Minimized::No, 0, 2, "Health check").await {
+                    warn!(target: LOG_TARGET, "Failed to disconnect peer {} ({})", result.peer, err);
+                }
+            }
             (*result_clone).write().await.push(result);
         }));
     }
     futures::future::join_all(handles).await;
     let inner_result = (*(*results).read().await).clone();
     notify_comms_health.send(inner_result).expect("Channel should be open");
-
-    // Only disconnect seed connections that were created as a result of the health check when the health check is
-    // complete and out of scope, or any seed connections that are not in use anymore.
-    for peer in &peers {
-        if let Ok(Some(mut conn)) = node_comms.get_connection(peer.node_id.clone()).await {
-            if let Err(err) = conn.disconnect_if_unused(Minimized::No, 0, 2, "Health check").await {
-                warn!(target: LOG_TARGET, "Failed to disconnect peer {} ({})", peer.node_id, err);
-            }
-        }
-    }
 }

--- a/comms/core/src/connection_manager/peer_connection.rs
+++ b/comms/core/src/connection_manager/peer_connection.rs
@@ -35,7 +35,7 @@ use log::*;
 use multiaddr::Multiaddr;
 use tari_shutdown::oneshot_trigger::OneshotTrigger;
 use tokio::{
-    sync::{mpsc, oneshot},
+    sync::{mpsc, oneshot, Mutex},
     time,
 };
 use tokio_stream::StreamExt;
@@ -144,8 +144,8 @@ pub struct PeerConnection {
     substream_counter: AtomicRefCounter,
     handle_counter: Arc<()>,
     drop_notifier: OneshotTrigger<NodeId>,
-    number_of_rpc_clients: Arc<AtomicUsize>,
     force_disconnect_rpc_clients_when_clone_drops: Arc<AtomicBool>,
+    rpc_session_states: Vec<Arc<Mutex<bool>>>,
 }
 
 impl PeerConnection {
@@ -169,8 +169,8 @@ impl PeerConnection {
             substream_counter,
             handle_counter: Arc::new(()),
             drop_notifier: OneshotTrigger::<NodeId>::new(),
-            number_of_rpc_clients: Arc::new(AtomicUsize::new(0)),
             force_disconnect_rpc_clients_when_clone_drops: Arc::new(Default::default()),
+            rpc_session_states: Vec::new(),
         }
     }
 
@@ -276,14 +276,16 @@ impl PeerConnection {
             self.peer_node_id
         );
         let framed = self.open_framed_substream(&protocol, RPC_MAX_FRAME_SIZE).await?;
+        let rpc_session_state = Arc::new(Mutex::new(true));
 
         let rpc_client = builder
             .with_protocol_id(protocol)
             .with_node_id(self.peer_node_id.clone())
             .with_terminate_signal(self.drop_notifier.to_signal())
+            .with_session_state(rpc_session_state.clone())
             .connect(framed)
             .await?;
-        self.number_of_rpc_clients.fetch_add(1, Ordering::Relaxed);
+        self.rpc_session_states.push(rpc_session_state.clone());
 
         Ok(rpc_client)
     }
@@ -302,6 +304,17 @@ impl PeerConnection {
         RpcClientPool::new(self.clone(), max_sessions, client_config)
     }
 
+    async fn count_rpc_sessions(&self) -> usize {
+        let futures = self
+            .rpc_session_states
+            .iter()
+            .map(|state| async move { *state.lock().await })
+            .collect::<Vec<_>>();
+
+        let results = futures::future::join_all(futures).await;
+        results.into_iter().filter(|&b| b).count()
+    }
+
     /// Immediately disconnects the peer connection. This can only fail if the peer connection worker
     /// is shut down (and the peer is already disconnected)
     pub async fn disconnect(&mut self, minimized: Minimized, requester: &str) -> Result<(), PeerConnectionError> {
@@ -310,7 +323,7 @@ impl PeerConnection {
             "Hard disconnect - requester: '{}', peer: `{}`, RPC clients: {}, substreams {}",
             requester,
             self.peer_node_id,
-            self.number_of_rpc_clients.load(Ordering::Relaxed),
+            self.count_rpc_sessions().await,
             self.substream_count()
         );
         let (reply_tx, reply_rx) = oneshot::channel();
@@ -344,7 +357,7 @@ impl PeerConnection {
         expected_substreams: usize,
         requester: &str,
     ) -> Result<(), PeerConnectionError> {
-        let number_of_rpc_clients = self.number_of_rpc_clients.load(Ordering::Relaxed);
+        let number_of_rpc_clients = self.count_rpc_sessions().await;
         let substream_count = self.substream_count();
         if number_of_rpc_clients > expected_rpc || substream_count > expected_substreams {
             trace!(
@@ -403,8 +416,8 @@ impl Drop for PeerConnection {
             self.force_disconnect_rpc_clients_when_clone_drops
                 .load(Ordering::Relaxed)
         {
-            let number_of_rpc_clients = self.number_of_rpc_clients.load(Ordering::Relaxed);
-            if number_of_rpc_clients > 0 {
+            let number_of_rpc_clients = self.rpc_session_states.len();
+            if self.rpc_session_states.len() > 0 {
                 self.drop_notifier.broadcast(self.peer_node_id.clone());
                 trace!(
                     target: LOG_TARGET,

--- a/comms/core/src/connection_manager/peer_connection.rs
+++ b/comms/core/src/connection_manager/peer_connection.rs
@@ -340,11 +340,13 @@ impl PeerConnection {
     pub async fn disconnect_if_unused(
         &mut self,
         minimized: Minimized,
+        expected_rpc: usize,
+        expected_substreams: usize,
         requester: &str,
     ) -> Result<(), PeerConnectionError> {
         let number_of_rpc_clients = self.number_of_rpc_clients.load(Ordering::Relaxed);
         let substream_count = self.substream_count();
-        if number_of_rpc_clients >= 1 || substream_count >= 1 {
+        if number_of_rpc_clients > expected_rpc || substream_count > expected_substreams {
             trace!(
                 target: LOG_TARGET,
                 "Soft disconnect - requester: '{}', peer: `{}`, RPC clients: {}, substreams {}, NOT disconnecting",

--- a/comms/core/src/connection_manager/peer_connection.rs
+++ b/comms/core/src/connection_manager/peer_connection.rs
@@ -35,7 +35,7 @@ use log::*;
 use multiaddr::Multiaddr;
 use tari_shutdown::oneshot_trigger::OneshotTrigger;
 use tokio::{
-    sync::{mpsc, oneshot, Mutex},
+    sync::{mpsc, oneshot},
     time,
 };
 use tokio_stream::StreamExt;
@@ -145,7 +145,7 @@ pub struct PeerConnection {
     handle_counter: Arc<()>,
     drop_notifier: OneshotTrigger<NodeId>,
     force_disconnect_rpc_clients_when_clone_drops: Arc<AtomicBool>,
-    rpc_session_states: Vec<Arc<Mutex<bool>>>,
+    rpc_session_states: Vec<Arc<AtomicBool>>,
 }
 
 impl PeerConnection {
@@ -276,7 +276,7 @@ impl PeerConnection {
             self.peer_node_id
         );
         let framed = self.open_framed_substream(&protocol, RPC_MAX_FRAME_SIZE).await?;
-        let rpc_session_state = Arc::new(Mutex::new(true));
+        let rpc_session_state = Arc::new(AtomicBool::new(true));
 
         let rpc_client = builder
             .with_protocol_id(protocol)
@@ -304,15 +304,11 @@ impl PeerConnection {
         RpcClientPool::new(self.clone(), max_sessions, client_config)
     }
 
-    async fn count_rpc_sessions(&self) -> usize {
-        let futures = self
-            .rpc_session_states
+    fn rpc_session_count(&self) -> usize {
+        self.rpc_session_states
             .iter()
-            .map(|state| async move { *state.lock().await })
-            .collect::<Vec<_>>();
-
-        let results = futures::future::join_all(futures).await;
-        results.into_iter().filter(|&b| b).count()
+            .filter(|s| s.load(Ordering::Relaxed))
+            .count()
     }
 
     /// Immediately disconnects the peer connection. This can only fail if the peer connection worker
@@ -323,7 +319,7 @@ impl PeerConnection {
             "Hard disconnect - requester: '{}', peer: `{}`, RPC clients: {}, substreams {}",
             requester,
             self.peer_node_id,
-            self.count_rpc_sessions().await,
+            self.rpc_session_count(),
             self.substream_count()
         );
         let (reply_tx, reply_rx) = oneshot::channel();
@@ -357,7 +353,7 @@ impl PeerConnection {
         expected_substreams: usize,
         requester: &str,
     ) -> Result<(), PeerConnectionError> {
-        let number_of_rpc_clients = self.count_rpc_sessions().await;
+        let number_of_rpc_clients = self.rpc_session_count();
         let substream_count = self.substream_count();
         if number_of_rpc_clients > expected_rpc || substream_count > expected_substreams {
             trace!(
@@ -416,13 +412,12 @@ impl Drop for PeerConnection {
             self.force_disconnect_rpc_clients_when_clone_drops
                 .load(Ordering::Relaxed)
         {
-            let number_of_rpc_clients = self.rpc_session_states.len();
-            if self.rpc_session_states.len() > 0 {
+            let number_of_rpc_clients = self.rpc_session_count();
+            if number_of_rpc_clients > 0 {
                 self.drop_notifier.broadcast(self.peer_node_id.clone());
                 trace!(
                     target: LOG_TARGET,
-                    "PeerConnection `{}` drop called, open sub-streams: {}, notified {} potential RPC clients to drop \
-                    connection",
+                    "PeerConnection `{}` drop called, open sub-streams: {}, notified {} RPC clients to drop connection",
                     self.peer_node_id.clone(), self.substream_count(), number_of_rpc_clients,
                 );
             } else {
@@ -440,13 +435,15 @@ impl fmt::Display for PeerConnection {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(
             f,
-            "Id: {}, Node ID: {}, Direction: {}, Peer Address: {}, Age: {:.0?}, #Substreams: {}, #Refs: {}",
+            "Id: {}, Node ID: {}, Direction: {}, Peer Address: {}, Age: {:.0?}, #Substreams: {}, #RPC sessions: {}, \
+             #Refs: {}",
             self.id,
             self.peer_node_id.short_str(),
             self.direction,
             self.address,
             self.age(),
             self.substream_count(),
+            self.rpc_session_count(),
             self.handle_count()
         )
     }

--- a/comms/core/src/connectivity/manager.rs
+++ b/comms/core/src/connectivity/manager.rs
@@ -1311,7 +1311,7 @@ async fn disconnect_if_unused_with_timeout(
 ) -> Result<(), PeerConnectionError> {
     match tokio::time::timeout(
         PEER_DISCONNECT_TIMEOUT,
-        connection.disconnect_if_unused(minimized, requester),
+        connection.disconnect_if_unused(minimized, 0, 0, requester),
     )
     .await
     {

--- a/comms/core/src/protocol/rpc/client/mod.rs
+++ b/comms/core/src/protocol/rpc/client/mod.rs
@@ -102,6 +102,7 @@ impl RpcClient {
         framed: CanonicalFraming<TSubstream>,
         protocol_name: ProtocolId,
         terminate_signal: Option<OneshotSignal<NodeId>>,
+        session_state: Option<Arc<Mutex<bool>>>,
     ) -> Result<Self, RpcError>
     where
         TSubstream: AsyncRead + AsyncWrite + Unpin + Send + StreamId + 'static,
@@ -129,6 +130,7 @@ impl RpcClient {
                 protocol_name,
                 shutdown_signal,
                 terminate_signal,
+                session_state,
             )
             .run()
             .instrument(span)
@@ -212,6 +214,7 @@ pub struct RpcClientBuilder<TClient> {
     protocol_id: Option<ProtocolId>,
     node_id: Option<NodeId>,
     terminate_signal: Option<OneshotSignal<NodeId>>,
+    session_state: Option<Arc<Mutex<bool>>>,
     _client: PhantomData<TClient>,
 }
 
@@ -222,6 +225,7 @@ impl<TClient> Default for RpcClientBuilder<TClient> {
             protocol_id: None,
             node_id: None,
             terminate_signal: None,
+            session_state: None,
             _client: PhantomData,
         }
     }
@@ -278,6 +282,12 @@ impl<TClient> RpcClientBuilder<TClient> {
         self.terminate_signal = Some(terminate_signal);
         self
     }
+
+    /// Set a bool that can be set to false when this client terminates
+    pub fn with_session_state(mut self, session_state: Arc<Mutex<bool>>) -> Self {
+        self.session_state = Some(session_state);
+        self
+    }
 }
 
 impl<TClient> RpcClientBuilder<TClient>
@@ -295,6 +305,7 @@ where TClient: From<RpcClient> + NamedProtocolService
                 .cloned()
                 .unwrap_or_else(|| ProtocolId::from_static(TClient::PROTOCOL_NAME)),
             self.terminate_signal,
+            self.session_state,
         )
         .await
         .map(Into::into)
@@ -418,6 +429,7 @@ struct RpcClientWorker<TSubstream> {
     protocol_id: ProtocolId,
     shutdown_signal: ShutdownSignal,
     terminate_signal: Option<OneshotSignal<NodeId>>,
+    session_state: Option<Arc<Mutex<bool>>>,
 }
 
 impl<TSubstream> RpcClientWorker<TSubstream>
@@ -433,6 +445,7 @@ where TSubstream: AsyncRead + AsyncWrite + Unpin + Send + StreamId
         protocol_id: ProtocolId,
         shutdown_signal: ShutdownSignal,
         terminate_signal: Option<OneshotSignal<NodeId>>,
+        session_state: Option<Arc<Mutex<bool>>>,
     ) -> Self {
         Self {
             config,
@@ -445,6 +458,7 @@ where TSubstream: AsyncRead + AsyncWrite + Unpin + Send + StreamId
             protocol_id,
             shutdown_signal,
             terminate_signal,
+            session_state,
         }
     }
 
@@ -456,6 +470,7 @@ where TSubstream: AsyncRead + AsyncWrite + Unpin + Send + StreamId
         self.framed.stream_id()
     }
 
+    #[allow(clippy::too_many_lines)]
     async fn run(mut self) {
         debug!(
             target: LOG_TARGET,
@@ -543,6 +558,12 @@ where TSubstream: AsyncRead + AsyncWrite + Unpin + Send + StreamId
         }
         #[cfg(feature = "metrics")]
         metrics::num_sessions(&self.protocol_id).dec();
+
+        let lock = self.session_state.as_ref().map(|s| s.lock());
+        if let Some(session_state) = lock {
+            let mut state = session_state.await;
+            *state = false;
+        }
 
         if let Err(err) = self.framed.close().await {
             debug!(

--- a/comms/core/src/protocol/rpc/client/mod.rs
+++ b/comms/core/src/protocol/rpc/client/mod.rs
@@ -34,7 +34,10 @@ use std::{
     fmt,
     future::Future,
     marker::PhantomData,
-    sync::Arc,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
     time::{Duration, Instant},
 };
 
@@ -102,7 +105,7 @@ impl RpcClient {
         framed: CanonicalFraming<TSubstream>,
         protocol_name: ProtocolId,
         terminate_signal: Option<OneshotSignal<NodeId>>,
-        session_state: Option<Arc<Mutex<bool>>>,
+        session_state: Option<Arc<AtomicBool>>,
     ) -> Result<Self, RpcError>
     where
         TSubstream: AsyncRead + AsyncWrite + Unpin + Send + StreamId + 'static,
@@ -214,7 +217,7 @@ pub struct RpcClientBuilder<TClient> {
     protocol_id: Option<ProtocolId>,
     node_id: Option<NodeId>,
     terminate_signal: Option<OneshotSignal<NodeId>>,
-    session_state: Option<Arc<Mutex<bool>>>,
+    session_state: Option<Arc<AtomicBool>>,
     _client: PhantomData<TClient>,
 }
 
@@ -284,7 +287,7 @@ impl<TClient> RpcClientBuilder<TClient> {
     }
 
     /// Set a bool that can be set to false when this client terminates
-    pub fn with_session_state(mut self, session_state: Arc<Mutex<bool>>) -> Self {
+    pub fn with_session_state(mut self, session_state: Arc<AtomicBool>) -> Self {
         self.session_state = Some(session_state);
         self
     }
@@ -429,7 +432,7 @@ struct RpcClientWorker<TSubstream> {
     protocol_id: ProtocolId,
     shutdown_signal: ShutdownSignal,
     terminate_signal: Option<OneshotSignal<NodeId>>,
-    session_state: Option<Arc<Mutex<bool>>>,
+    session_state: Option<Arc<AtomicBool>>,
 }
 
 impl<TSubstream> RpcClientWorker<TSubstream>
@@ -445,7 +448,7 @@ where TSubstream: AsyncRead + AsyncWrite + Unpin + Send + StreamId
         protocol_id: ProtocolId,
         shutdown_signal: ShutdownSignal,
         terminate_signal: Option<OneshotSignal<NodeId>>,
-        session_state: Option<Arc<Mutex<bool>>>,
+        session_state: Option<Arc<AtomicBool>>,
     ) -> Self {
         Self {
             config,
@@ -559,10 +562,8 @@ where TSubstream: AsyncRead + AsyncWrite + Unpin + Send + StreamId
         #[cfg(feature = "metrics")]
         metrics::num_sessions(&self.protocol_id).dec();
 
-        let lock = self.session_state.as_ref().map(|s| s.lock());
-        if let Some(session_state) = lock {
-            let mut state = session_state.await;
-            *state = false;
+        if let Some(session_state) = self.session_state.as_ref() {
+            session_state.store(false, Ordering::Relaxed);
         }
 
         if let Err(err) = self.framed.close().await {

--- a/comms/core/src/protocol/rpc/client/mod.rs
+++ b/comms/core/src/protocol/rpc/client/mod.rs
@@ -105,7 +105,7 @@ impl RpcClient {
         framed: CanonicalFraming<TSubstream>,
         protocol_name: ProtocolId,
         terminate_signal: Option<OneshotSignal<NodeId>>,
-        session_state: Option<Arc<AtomicBool>>,
+        session_state: Arc<AtomicBool>,
     ) -> Result<Self, RpcError>
     where
         TSubstream: AsyncRead + AsyncWrite + Unpin + Send + StreamId + 'static,
@@ -308,7 +308,7 @@ where TClient: From<RpcClient> + NamedProtocolService
                 .cloned()
                 .unwrap_or_else(|| ProtocolId::from_static(TClient::PROTOCOL_NAME)),
             self.terminate_signal,
-            self.session_state,
+            self.session_state.unwrap_or_default(),
         )
         .await
         .map(Into::into)
@@ -432,7 +432,7 @@ struct RpcClientWorker<TSubstream> {
     protocol_id: ProtocolId,
     shutdown_signal: ShutdownSignal,
     terminate_signal: Option<OneshotSignal<NodeId>>,
-    session_state: Option<Arc<AtomicBool>>,
+    session_state: Arc<AtomicBool>,
 }
 
 impl<TSubstream> RpcClientWorker<TSubstream>
@@ -448,7 +448,7 @@ where TSubstream: AsyncRead + AsyncWrite + Unpin + Send + StreamId
         protocol_id: ProtocolId,
         shutdown_signal: ShutdownSignal,
         terminate_signal: Option<OneshotSignal<NodeId>>,
-        session_state: Option<Arc<AtomicBool>>,
+        session_state: Arc<AtomicBool>,
     ) -> Self {
         Self {
             config,
@@ -562,9 +562,8 @@ where TSubstream: AsyncRead + AsyncWrite + Unpin + Send + StreamId
         #[cfg(feature = "metrics")]
         metrics::num_sessions(&self.protocol_id).dec();
 
-        if let Some(session_state) = self.session_state.as_ref() {
-            session_state.store(false, Ordering::Relaxed);
-        }
+        let session_state = self.session_state.as_ref();
+        session_state.store(false, Ordering::Relaxed);
 
         if let Err(err) = self.framed.close().await {
             debug!(

--- a/comms/core/src/protocol/rpc/client/mod.rs
+++ b/comms/core/src/protocol/rpc/client/mod.rs
@@ -308,7 +308,7 @@ where TClient: From<RpcClient> + NamedProtocolService
                 .cloned()
                 .unwrap_or_else(|| ProtocolId::from_static(TClient::PROTOCOL_NAME)),
             self.terminate_signal,
-            self.session_state.unwrap_or_default(),
+            self.session_state.unwrap_or(Arc::new(AtomicBool::new(true))),
         )
         .await
         .map(Into::into)

--- a/comms/core/src/protocol/rpc/test/greeting_service.rs
+++ b/comms/core/src/protocol/rpc/test/greeting_service.rs
@@ -406,7 +406,7 @@ impl GreetingClient {
             framed,
             Self::PROTOCOL_NAME.into(),
             Default::default(),
-            Some(Arc::new(AtomicBool::new(true))),
+            Arc::new(AtomicBool::new(true)),
         )
         .await?;
         Ok(Self { inner })

--- a/comms/core/src/protocol/rpc/test/greeting_service.rs
+++ b/comms/core/src/protocol/rpc/test/greeting_service.rs
@@ -32,7 +32,7 @@ use std::{
 
 use tari_utilities::hex::Hex;
 use tokio::{
-    sync::{mpsc, RwLock},
+    sync::{mpsc, Mutex, RwLock},
     task,
     time,
 };
@@ -406,6 +406,7 @@ impl GreetingClient {
             framed,
             Self::PROTOCOL_NAME.into(),
             Default::default(),
+            Some(Arc::new(Mutex::new(true))),
         )
         .await?;
         Ok(Self { inner })

--- a/comms/core/src/protocol/rpc/test/greeting_service.rs
+++ b/comms/core/src/protocol/rpc/test/greeting_service.rs
@@ -24,7 +24,7 @@ use std::{
     cmp,
     convert::TryFrom,
     sync::{
-        atomic::{AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
         Arc,
     },
     time::Duration,
@@ -32,7 +32,7 @@ use std::{
 
 use tari_utilities::hex::Hex;
 use tokio::{
-    sync::{mpsc, Mutex, RwLock},
+    sync::{mpsc, RwLock},
     task,
     time,
 };
@@ -406,7 +406,7 @@ impl GreetingClient {
             framed,
             Self::PROTOCOL_NAME.into(),
             Default::default(),
-            Some(Arc::new(Mutex::new(true))),
+            Some(Arc::new(AtomicBool::new(true))),
         )
         .await?;
         Ok(Self { inner })

--- a/comms/rpc_macros/src/generator.rs
+++ b/comms/rpc_macros/src/generator.rs
@@ -198,7 +198,9 @@ impl RpcCodeGenerator {
             pub async fn connect<TSubstream>(framed: #dep_mod::CanonicalFraming<TSubstream>) -> Result<Self, #dep_mod::RpcError>
               where TSubstream: #dep_mod::AsyncRead + #dep_mod::AsyncWrite + Unpin + Send + #dep_mod::StreamId + 'static {
                 use #dep_mod::NamedProtocolService;
-                let inner = #dep_mod::RpcClient::connect(Default::default(), Default::default(), framed, Self::PROTOCOL_NAME.into(), None).await?;
+                let inner = #dep_mod::RpcClient::connect(
+                    Default::default(), Default::default(), framed, Self::PROTOCOL_NAME.into(), None, None
+                ).await?;
                 Ok(Self { inner })
             }
 

--- a/comms/rpc_macros/src/generator.rs
+++ b/comms/rpc_macros/src/generator.rs
@@ -198,8 +198,9 @@ impl RpcCodeGenerator {
             pub async fn connect<TSubstream>(framed: #dep_mod::CanonicalFraming<TSubstream>) -> Result<Self, #dep_mod::RpcError>
               where TSubstream: #dep_mod::AsyncRead + #dep_mod::AsyncWrite + Unpin + Send + #dep_mod::StreamId + 'static {
                 use #dep_mod::NamedProtocolService;
+                use std::sync::{atomic::AtomicBool, Arc};
                 let inner = #dep_mod::RpcClient::connect(
-                    Default::default(), Default::default(), framed, Self::PROTOCOL_NAME.into(), None, None
+                    Default::default(), Default::default(), framed, Self::PROTOCOL_NAME.into(), None, Arc::new(AtomicBool::new(true))
                 ).await?;
                 Ok(Self { inner })
             }


### PR DESCRIPTION
Description
---
We can be more efficient with soft disconnects when we compare against expected RPC sessions and substream counts. This PR adds finer discernment when doing soft peer disconnects.

Motivation and Context
---
The health check opens 2 substreams and 0 PRC sessions - that should result in a disconnect if those are the only opened resources.

How Has This Been Tested?
---
System-level testing
```rust
2025-07-11 13:52:26.703289300 [comms::connection_manager::peer_connection] TRACE Hard disconnect - requester: 'Health check', peer: `d7c289e9e3c8377705ce599a96`, RPC clients: 0, substreams 2
2025-07-11 13:52:26.705658100 [comms::connection_manager::peer_connection] TRACE Soft disconnect - requester: 'Health check', peer: `0984896e74022c442c1034852c`, RPC clients: 1, substreams 3, NOT disconnecting
2025-07-11 13:52:26.705735900 [comms::connection_manager::peer_connection] TRACE Hard disconnect - requester: 'Health check', peer: `d025bc9e4bd423a9b304c491b8`, RPC clients: 0, substreams 2
2025-07-11 13:52:26.707647400 [comms::connection_manager::peer_connection] TRACE Hard disconnect - requester: 'Health check', peer: `51af08aff11f7129b4681d9950`, RPC clients: 0, substreams 2
```

What process can a PR reviewer use to test or verify this change?
---
Code review

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Refactor**
  * Enhanced connection management with more precise tracking and control of active RPC sessions.
  * Improved disconnection logic to better handle unused connections based on configurable thresholds.
  * Updated client session handling to reflect session state changes upon termination, improving connection lifecycle accuracy.
  * Added detailed trace logging for health checks to improve monitoring of peer connectivity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->