### PR TITLE
perf: dont update confirmations of tx every single time

### DIFF
--- a/base_layer/wallet/src/transaction_service/protocols/check_faux_transaction_status.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/check_faux_transaction_status.rs
@@ -161,59 +161,55 @@ pub async fn check_detected_transactions<TBackend: 'static + TransactionBackend>
         let previously_confirmed = tx.status.is_confirmed();
         let must_be_confirmed =
             tip_height.saturating_sub(mined_height) >= TransactionServiceConfig::default().num_confirmations_required;
-        let num_confirmations = tip_height.saturating_sub(mined_height);
 
-        let log_msg = format!(
-            "Updating faux transaction: TxId({}), mined_height({}), must_be_confirmed({}), num_confirmations({}), \
-             output_status({}), is_valid({})",
-            tx.tx_id, mined_height, must_be_confirmed, num_confirmations, output_status, is_valid
-        );
-        if num_confirmations <= 5 {
-            debug!(target: LOG_TARGET, "{}", log_msg);
-        } else {
-            trace!(target: LOG_TARGET, "{}", log_msg);
-        }
-
-        let result = db.set_transaction_mined_height(
-            tx.tx_id,
-            mined_height,
-            mined_in_block,
-            tx.mined_timestamp
-                .map_or(0, |mined_timestamp| mined_timestamp.timestamp() as u64),
-            num_confirmations,
-            must_be_confirmed,
-            &tx.status,
-        );
-        if let Err(e) = result {
-            error!(
-                target: LOG_TARGET,
-                "Error setting faux transaction to mined confirmed: {}", e
+        if !(previously_confirmed && must_be_confirmed) {
+            let log_msg = format!(
+                "Updating faux transaction: TxId({}), mined_height({}), must_be_confirmed({}), output_status({}), \
+                 is_valid({})",
+                tx.tx_id, mined_height, must_be_confirmed, output_status, is_valid
             );
-        } else {
-            // Only send an event if the transaction was not previously confirmed OR was previously confirmed and is
-            // now not confirmed (i.e. confirmation changed)
-            if !(previously_confirmed && must_be_confirmed) {
-                let transaction_event = if must_be_confirmed {
-                    TransactionEvent::DetectedTransactionConfirmed {
-                        tx_id: tx.tx_id,
-                        is_valid,
-                    }
-                } else {
-                    TransactionEvent::DetectedTransactionUnconfirmed {
-                        tx_id: tx.tx_id,
-                        num_confirmations: 0,
-                        is_valid,
-                    }
-                };
-                let _size = event_publisher.send(Arc::new(transaction_event)).map_err(|e| {
-                    trace!(
-                        target: LOG_TARGET,
-                        "Error sending event, usually because there are no subscribers: {:?}",
-                        e
-                    );
-                    e
-                });
+            if must_be_confirmed {
+                debug!(target: LOG_TARGET, "{}", log_msg);
+            } else {
+                trace!(target: LOG_TARGET, "{}", log_msg);
             }
+
+            let result = db.set_transaction_mined_height(
+                tx.tx_id,
+                mined_height,
+                mined_in_block,
+                tx.mined_timestamp
+                    .map_or(0, |mined_timestamp| mined_timestamp.timestamp() as u64),
+                must_be_confirmed,
+                &tx.status,
+            );
+            if let Err(e) = result {
+                error!(
+                    target: LOG_TARGET,
+                    "Error setting faux transaction to mined confirmed: {}", e
+                );
+                continue;
+            }
+            let transaction_event = if must_be_confirmed {
+                TransactionEvent::DetectedTransactionConfirmed {
+                    tx_id: tx.tx_id,
+                    is_valid,
+                }
+            } else {
+                TransactionEvent::DetectedTransactionUnconfirmed {
+                    tx_id: tx.tx_id,
+                    num_confirmations: 0,
+                    is_valid,
+                }
+            };
+            let _size = event_publisher.send(Arc::new(transaction_event)).map_err(|e| {
+                trace!(
+                    target: LOG_TARGET,
+                    "Error sending event, usually because there are no subscribers: {:?}",
+                    e
+                );
+                e
+            });
         }
     }
     if state_changed {

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_validation_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_validation_protocol.rs
@@ -383,7 +383,6 @@ where
                 mined_height,
                 *mined_in_block,
                 mined_timestamp,
-                num_confirmations,
                 num_confirmations >= self.config.num_confirmations_required,
                 status,
             )

--- a/base_layer/wallet/src/transaction_service/storage/database.rs
+++ b/base_layer/wallet/src/transaction_service/storage/database.rs
@@ -133,7 +133,6 @@ pub trait TransactionBackend: Send + Sync + Clone {
         mined_height: u64,
         mined_in_block: BlockHash,
         mined_timestamp: u64,
-        num_confirmations: u64,
         must_be_confirmed: bool,
         status: &TransactionStatus,
     ) -> Result<(), TransactionStorageError>;
@@ -819,7 +818,6 @@ where T: TransactionBackend + 'static
         mined_height: u64,
         mined_in_block: BlockHash,
         mined_timestamp: u64,
-        num_confirmations: u64,
         must_be_confirmed: bool,
         status: &TransactionStatus,
     ) -> Result<(), TransactionStorageError> {
@@ -828,7 +826,6 @@ where T: TransactionBackend + 'static
             mined_height,
             mined_in_block,
             mined_timestamp,
-            num_confirmations,
             must_be_confirmed,
             status,
         )

--- a/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
@@ -830,7 +830,6 @@ impl TransactionBackend for TransactionServiceSqliteDatabase {
         mined_height: u64,
         mined_in_block: BlockHash,
         mined_timestamp: u64,
-        num_confirmations: u64,
         must_be_confirmed: bool,
         status: &TransactionStatus,
     ) -> Result<(), TransactionStorageError> {
@@ -845,7 +844,6 @@ impl TransactionBackend for TransactionServiceSqliteDatabase {
 
         match CompletedTransactionSql::update_mined_height(
             tx_id,
-            num_confirmations,
             status,
             mined_height,
             mined_in_block,
@@ -2090,7 +2088,6 @@ impl CompletedTransactionSql {
 
     pub fn update_mined_height(
         tx_id: TxId,
-        num_confirmations: u64,
         status: TransactionStatus,
         mined_height: u64,
         mined_in_block: BlockHash,
@@ -2110,18 +2107,16 @@ impl CompletedTransactionSql {
         })?;
         trace!(
             target: LOG_TARGET,
-            "update_mined_height: tx_id '{}', status '{:?}', confirmations '{}', mined height '{}', \
+            "update_mined_height: tx_id '{}', status '{:?}', mined height '{}', \
             mined timestamp '{}', mined block hash '{}'",
             tx_id,
             status,
-            num_confirmations,
             mined_height,
             timestamp,
             mined_in_block.to_hex(),
         );
         diesel::update(completed_transactions::table.filter(completed_transactions::tx_id.eq(tx_id.as_u64() as i64)))
             .set(UpdateCompletedTransactionSql {
-                confirmations: Some(Some(num_confirmations as i64)),
                 status: Some(status as i32),
                 mined_height: Some(Some(mined_height as i64)),
                 mined_in_block: Some(Some(mined_in_block.to_vec())),

--- a/base_layer/wallet/tests/transaction_service_tests/storage.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/storage.rs
@@ -398,7 +398,6 @@ pub async fn test_db_backend<T: TransactionBackend + 'static>(backend: T) {
         10,
         FixedHash::zero(),
         0,
-        5,
         true,
         &completed_txs[0].status,
     )


### PR DESCRIPTION
Description
---
We keep writing to the confirmation colomn of the transaction table, and that value never gets read. 
Only update the tx if needed. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined transaction confirmation logic by removing explicit confirmation count handling.
  * Updated transaction storage methods to no longer track or require the number of confirmations.
  * Simplified logging and event publishing related to transaction confirmations.

* **Tests**
  * Adjusted tests to align with the updated transaction storage method signatures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->